### PR TITLE
adding rule name label to assign new metrics name based on actual name

### DIFF
--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -156,6 +156,7 @@ type Rule struct {
 type RuleNode struct {
 	Record        yaml.Node         `yaml:"record,omitempty"`
 	Alert         yaml.Node         `yaml:"alert,omitempty"`
+	NameLabel     yaml.Node         `yaml:"name_label,omitempty"`
 	Expr          yaml.Node         `yaml:"expr"`
 	For           model.Duration    `yaml:"for,omitempty"`
 	KeepFiringFor model.Duration    `yaml:"keep_firing_for,omitempty"`

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -1166,6 +1166,7 @@ func (m *Manager) LoadGroups(
 				}
 				rules = append(rules, NewRecordingRule(
 					r.Record.Value,
+					r.NameLabel.Value,
 					expr,
 					labels.FromMap(r.Labels),
 				))

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -533,7 +533,7 @@ func TestStaleness(t *testing.T) {
 
 	expr, err := parser.ParseExpr("a + 1")
 	require.NoError(t, err)
-	rule := NewRecordingRule("a_plus_one", expr, labels.Labels{})
+	rule := NewRecordingRule("a_plus_one", "", expr, labels.Labels{})
 	group := NewGroup(GroupOptions{
 		Name:          "default",
 		Interval:      time.Second,
@@ -608,11 +608,11 @@ func TestCopyState(t *testing.T) {
 	oldGroup := &Group{
 		rules: []Rule{
 			NewAlertingRule("alert", nil, 0, 0, labels.EmptyLabels(), labels.EmptyLabels(), labels.EmptyLabels(), "", true, nil),
-			NewRecordingRule("rule1", nil, labels.EmptyLabels()),
-			NewRecordingRule("rule2", nil, labels.EmptyLabels()),
-			NewRecordingRule("rule3", nil, labels.FromStrings("l1", "v1")),
-			NewRecordingRule("rule3", nil, labels.FromStrings("l1", "v2")),
-			NewRecordingRule("rule3", nil, labels.FromStrings("l1", "v3")),
+			NewRecordingRule("rule1", "", nil, labels.EmptyLabels()),
+			NewRecordingRule("rule2", "", nil, labels.EmptyLabels()),
+			NewRecordingRule("rule3", "", nil, labels.FromStrings("l1", "v1")),
+			NewRecordingRule("rule3", "", nil, labels.FromStrings("l1", "v2")),
+			NewRecordingRule("rule3", "", nil, labels.FromStrings("l1", "v3")),
 			NewAlertingRule("alert2", nil, 0, 0, labels.FromStrings("l2", "v1"), labels.EmptyLabels(), labels.EmptyLabels(), "", true, nil),
 		},
 		seriesInPreviousEval: []map[string]labels.Labels{
@@ -629,14 +629,14 @@ func TestCopyState(t *testing.T) {
 	oldGroup.rules[0].(*AlertingRule).active[42] = nil
 	newGroup := &Group{
 		rules: []Rule{
-			NewRecordingRule("rule3", nil, labels.FromStrings("l1", "v0")),
-			NewRecordingRule("rule3", nil, labels.FromStrings("l1", "v1")),
-			NewRecordingRule("rule3", nil, labels.FromStrings("l1", "v2")),
+			NewRecordingRule("rule3", "", nil, labels.FromStrings("l1", "v0")),
+			NewRecordingRule("rule3", "", nil, labels.FromStrings("l1", "v1")),
+			NewRecordingRule("rule3", "", nil, labels.FromStrings("l1", "v2")),
 			NewAlertingRule("alert", nil, 0, 0, labels.EmptyLabels(), labels.EmptyLabels(), labels.EmptyLabels(), "", true, nil),
-			NewRecordingRule("rule1", nil, labels.EmptyLabels()),
+			NewRecordingRule("rule1", "", nil, labels.EmptyLabels()),
 			NewAlertingRule("alert2", nil, 0, 0, labels.FromStrings("l2", "v0"), labels.EmptyLabels(), labels.EmptyLabels(), "", true, nil),
 			NewAlertingRule("alert2", nil, 0, 0, labels.FromStrings("l2", "v1"), labels.EmptyLabels(), labels.EmptyLabels(), "", true, nil),
-			NewRecordingRule("rule4", nil, labels.EmptyLabels()),
+			NewRecordingRule("rule4", "", nil, labels.EmptyLabels()),
 		},
 		seriesInPreviousEval: make([]map[string]labels.Labels, 8),
 	}
@@ -664,7 +664,7 @@ func TestDeletedRuleMarkedStale(t *testing.T) {
 	defer st.Close()
 	oldGroup := &Group{
 		rules: []Rule{
-			NewRecordingRule("rule1", nil, labels.FromStrings("l1", "v1")),
+			NewRecordingRule("rule1", "", nil, labels.FromStrings("l1", "v1")),
 		},
 		seriesInPreviousEval: []map[string]labels.Labels{
 			{"r1": labels.FromStrings("l1", "v1")},
@@ -1140,7 +1140,7 @@ func TestGroupHasAlertingRules(t *testing.T) {
 				name: "HasAlertingRule",
 				rules: []Rule{
 					NewAlertingRule("alert", nil, 0, 0, labels.EmptyLabels(), labels.EmptyLabels(), labels.EmptyLabels(), "", true, nil),
-					NewRecordingRule("record", nil, labels.EmptyLabels()),
+					NewRecordingRule("record", "", nil, labels.EmptyLabels()),
 				},
 			},
 			want: true,
@@ -1156,7 +1156,7 @@ func TestGroupHasAlertingRules(t *testing.T) {
 			group: &Group{
 				name: "HasOnlyRecordingRule",
 				rules: []Rule{
-					NewRecordingRule("record", nil, labels.EmptyLabels()),
+					NewRecordingRule("record", "", nil, labels.EmptyLabels()),
 				},
 			},
 			want: false,
@@ -1189,7 +1189,7 @@ func TestRuleHealthUpdates(t *testing.T) {
 
 	expr, err := parser.ParseExpr("a + 1")
 	require.NoError(t, err)
-	rule := NewRecordingRule("a_plus_one", expr, labels.Labels{})
+	rule := NewRecordingRule("a_plus_one", "", expr, labels.Labels{})
 	group := NewGroup(GroupOptions{
 		Name:          "default",
 		Interval:      time.Second,
@@ -1369,7 +1369,7 @@ func TestNativeHistogramsInRecordingRules(t *testing.T) {
 
 	expr, err := parser.ParseExpr("sum(histogram_metric)")
 	require.NoError(t, err)
-	rule := NewRecordingRule("sum:histogram_metric", expr, labels.Labels{})
+	rule := NewRecordingRule("sum:histogram_metric", "", expr, labels.Labels{})
 
 	group := NewGroup(GroupOptions{
 		Name:          "default",

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1332,6 +1332,7 @@ type AlertingRule struct {
 
 type RecordingRule struct {
 	Name           string           `json:"name"`
+	NameLabel      string           `json:"nameLabel,omitempty"`
 	Query          string           `json:"query"`
 	Labels         labels.Labels    `json:"labels,omitempty"`
 	Health         rules.RuleHealth `json:"health"`
@@ -1432,6 +1433,7 @@ func (api *API) rules(r *http.Request) apiFuncResult {
 				}
 				enrichedRule = RecordingRule{
 					Name:           rule.Name(),
+					NameLabel:      rule.NameLabel(),
 					Query:          rule.Query().String(),
 					Labels:         rule.Labels(),
 					Health:         rule.Health(),

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -283,7 +283,7 @@ func (m rulesRetrieverMock) RuleGroups() []*rules.Group {
 	if err != nil {
 		m.testing.Fatalf("unable to parse alert expression: %s", err)
 	}
-	recordingRule := rules.NewRecordingRule("recording-rule-1", recordingExpr, labels.Labels{})
+	recordingRule := rules.NewRecordingRule("recording-rule-1", "", recordingExpr, labels.Labels{})
 	r = append(r, recordingRule)
 
 	group := rules.NewGroup(rules.GroupOptions{

--- a/web/ui/react-app/src/pages/rules/RulesContent.tsx
+++ b/web/ui/react-app/src/pages/rules/RulesContent.tsx
@@ -91,6 +91,11 @@ export const RulesContent: FC<RulesContentProps> = ({ response }) => {
                           <GraphExpressionLink title="record" text={r.name} expr={r.name} />
                         )}
                         <GraphExpressionLink title="expr" text={r.query} expr={r.query} />
+                        {r.nameLabel && (
+                          <div>
+                            <strong>nameLabel:</strong> {r.nameLabel}
+                          </div>
+                        )}
                         {r.duration > 0 && (
                           <div>
                             <strong>for:</strong> {formatDuration(r.duration * 1000)}

--- a/web/ui/react-app/src/types/types.ts
+++ b/web/ui/react-app/src/types/types.ts
@@ -33,6 +33,7 @@ export type Rule = {
   lastError?: string;
   lastEvaluation: string;
   name: string;
+  nameLabel: string;
   query: string;
   state: RuleState;
   type: string;


### PR DESCRIPTION
Hi Team,

I am new to Prometheus, Please guide me if I am doing it wrongly or if is there any other way to solve my scenario.

Currently, the Recording Rule name is a constant value, e.g.: `job:test_rule`. If we want to run the same expression for n metrics then we have to write n new rules. And in production, if new metrics are added then we have to update the rules file for new metrics.
We wanted to run the same rule for multiple metrics without any changes for new additions/deletions of metrics.

**Proposed Solution**

To achieve the above scenario we can add a custom label name in `rule.name` which will get replaced for each resultant metrics name.
`$ cat prometheus.rules.yml
groups:
  - name: recording_rules
    rules:
      - record: job:__custom_name__
        name_label: __custom_name__
        expr: sum without(instance)(label_replace({job!="", __custom_name__=""}, "__custom_name__", "$1", "__name__", "(.*)"))
`

This will make each resultant metric will get the original name value of the metrics.

Please let me know your thoughts on this.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
