### PR TITLE
WIP: Add LabelQuerier.LabelValuesStream method

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -227,6 +227,10 @@ func (*errQuerier) LabelValues(context.Context, string, ...*labels.Matcher) ([]s
 	return nil, nil, nil
 }
 
+func (*errQuerier) LabelValuesStream(string, ...*labels.Matcher) storage.LabelValues {
+	return nil
+}
+
 func (*errQuerier) LabelNames(context.Context, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, nil
 }

--- a/storage/fanout_test.go
+++ b/storage/fanout_test.go
@@ -240,6 +240,10 @@ func (errQuerier) LabelValues(context.Context, string, ...*labels.Matcher) ([]st
 	return nil, nil, errors.New("label values error")
 }
 
+func (errQuerier) LabelValuesStream(string, ...*labels.Matcher) storage.LabelValues {
+	return storage.ErrLabelValues(errors.New("label values stream error"))
+}
+
 func (errQuerier) LabelNames(context.Context, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, errors.New("label names error")
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -126,6 +126,10 @@ func (q *MockQuerier) LabelValues(context.Context, string, ...*labels.Matcher) (
 	return nil, nil, nil
 }
 
+func (q *MockQuerier) LabelValuesStream(string, ...*labels.Matcher) LabelValues {
+	return nil
+}
+
 func (q *MockQuerier) LabelNames(context.Context, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, nil
 }
@@ -162,6 +166,12 @@ type LabelQuerier interface {
 	// If matchers are specified the returned result set is reduced
 	// to label values of metrics matching the matchers.
 	LabelValues(ctx context.Context, name string, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error)
+
+	// LabelValuesStream returns an iterator over all potential values for a label name.
+	// It is not safe to use the strings beyond the lifetime of the querier.
+	// If matchers are specified the returned result set is reduced
+	// to label values of metrics matching the matchers.
+	LabelValuesStream(name string, matchers ...*labels.Matcher) LabelValues
 
 	// LabelNames returns all the unique label names present in the block in sorted order.
 	// If matchers are specified the returned result set is reduced
@@ -469,4 +479,18 @@ type ChunkIterable interface {
 	// Iterator returns an iterator that iterates over potentially overlapping
 	// chunks of the series, sorted by min time.
 	Iterator(chunks.Iterator) chunks.Iterator
+}
+
+// LabelValues is an iterator over label values.
+type LabelValues interface {
+	// Next tries to advance the iterator and returns true if it could, false otherwise.
+	Next() bool
+	// At returns the current label value.
+	At() string
+	// Err is the error that iteration eventually failed with.
+	// When an error occurs, the iterator cannot continue.
+	Err() error
+	// Warnings is a collection of warnings that have occurred during iteration.
+	// Warnings could be non-empty even if iteration has not failed with an error.
+	Warnings() annotations.Annotations
 }

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -35,6 +35,10 @@ func (noopQuerier) LabelValues(context.Context, string, ...*labels.Matcher) ([]s
 	return nil, nil, nil
 }
 
+func (noopQuerier) LabelValuesStream(string, ...*labels.Matcher) LabelValues {
+	return nil
+}
+
 func (noopQuerier) LabelNames(context.Context, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, nil
 }
@@ -56,6 +60,10 @@ func (noopChunkQuerier) Select(context.Context, bool, *SelectHints, ...*labels.M
 
 func (noopChunkQuerier) LabelValues(context.Context, string, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, nil
+}
+
+func (noopChunkQuerier) LabelValuesStream(string, ...*labels.Matcher) LabelValues {
+	return nil
 }
 
 func (noopChunkQuerier) LabelNames(context.Context, ...*labels.Matcher) ([]string, annotations.Annotations, error) {

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -209,10 +209,16 @@ func (q querier) addExternalLabels(ms []*labels.Matcher) ([]*labels.Matcher, []s
 	return ms, names
 }
 
-// LabelValues implements storage.Querier and is a noop.
+// LabelValues implements storage.LabelQuerier and is a noop.
 func (q *querier) LabelValues(context.Context, string, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	// TODO: Implement: https://github.com/prometheus/prometheus/issues/3351
 	return nil, nil, errors.New("not implemented")
+}
+
+// LabelValuesStream implements storage.LabelQuerier and is a noop.
+func (q *querier) LabelValuesStream(string, ...*labels.Matcher) storage.LabelValues {
+	// TODO: Implement: https://github.com/prometheus/prometheus/issues/3351
+	return storage.ErrLabelValues(errors.New("not implemented"))
 }
 
 // LabelNames implements storage.Querier and is a noop.

--- a/tsdb/db_bench_test.go
+++ b/tsdb/db_bench_test.go
@@ -1,0 +1,178 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func BenchmarkQuerier_LabelValuesStream(b *testing.B) {
+	db := openTestDB(b, nil, []int64{1000})
+	b.Cleanup(func() {
+		require.NoError(b, db.Close())
+	})
+
+	app := db.head.Appender(context.Background())
+	// var seriesEntries []storage.Series
+	addSeries := func(l labels.Labels) {
+		app.Append(0, l, 0, 0)
+		// seriesEntries = append(seriesEntries, storage.NewListSeries(l, tsdbutil.GenerateSamples(1, 1)))
+	}
+
+	for n := 0; n < 10; n++ {
+		for i := 0; i < 100000; i++ {
+			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", strconv.Itoa(n)+postingsBenchSuffix, "j", "foo", "i_times_n", strconv.Itoa(i*n)))
+			// Have some series that won't be matched, to properly test inverted matchers.
+			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", strconv.Itoa(n)+postingsBenchSuffix, "j", "bar"))
+			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", "0_"+strconv.Itoa(n)+postingsBenchSuffix, "j", "bar"))
+			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", "1_"+strconv.Itoa(n)+postingsBenchSuffix, "j", "bar"))
+			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", "2_"+strconv.Itoa(n)+postingsBenchSuffix, "j", "foo"))
+		}
+	}
+	require.NoError(b, app.Commit())
+	// createBlock(b, db.Dir(), seriesEntries)
+	require.NoError(b, db.reloadBlocks())
+
+	querier, err := db.Querier(0, 1)
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, querier.Close()) })
+
+	i1 := labels.MustNewMatcher(labels.MatchEqual, "i", "1")
+	iStar := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.*$")
+	jNotFoo := labels.MustNewMatcher(labels.MatchNotEqual, "j", "foo")
+	jXXXYYY := labels.MustNewMatcher(labels.MatchRegexp, "j", "XXX|YYY")
+	jXplus := labels.MustNewMatcher(labels.MatchRegexp, "j", "X.+")
+	n1 := labels.MustNewMatcher(labels.MatchEqual, "n", "1"+postingsBenchSuffix)
+	nX := labels.MustNewMatcher(labels.MatchNotEqual, "n", "X"+postingsBenchSuffix)
+	nPlus := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")
+	primesTimes := labels.MustNewMatcher(labels.MatchEqual, "i_times_n", "533701") // = 76243*7, ie. multiplication of primes. It will match single i*n combination.
+	nonPrimesTimes := labels.MustNewMatcher(labels.MatchEqual, "i_times_n", "20")  // 1*20, 2*10, 4*5, 5*4
+	times12 := labels.MustNewMatcher(labels.MatchRegexp, "i_times_n", "12.*")
+
+	cases := []struct {
+		name      string
+		labelName string
+		matchers  []*labels.Matcher
+	}{
+		{`i with i="1"`, "i", []*labels.Matcher{i1}},
+		// i has 100k values.
+		{`i with n="1"`, "i", []*labels.Matcher{n1}},
+		{`i with n="^.+$"`, "i", []*labels.Matcher{nPlus}},
+		{`i with n="1",j!="foo"`, "i", []*labels.Matcher{n1, jNotFoo}},
+		{`i with n="1",j=~"X.+"`, "i", []*labels.Matcher{n1, jXplus}},
+		{`i with n="1",j=~"XXX|YYY"`, "i", []*labels.Matcher{n1, jXXXYYY}},
+		{`i with n="X",j!="foo"`, "i", []*labels.Matcher{nX, jNotFoo}},
+		{`i with n="1",i=~"^.*$",j!="foo"`, "i", []*labels.Matcher{n1, iStar, jNotFoo}},
+		{`i with i_times_n=533701`, "i", []*labels.Matcher{primesTimes}},
+		{`i with i_times_n=20`, "i", []*labels.Matcher{nonPrimesTimes}},
+		{`i with i_times_n=~"12.*""`, "i", []*labels.Matcher{times12}},
+		// n has 10 values.
+		{`n with j!="foo"`, "n", []*labels.Matcher{jNotFoo}},
+		{`n with i="1"`, "n", []*labels.Matcher{i1}},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				it := querier.LabelValuesStream(c.labelName, c.matchers...)
+				for it.Next() {
+				}
+				require.NoError(b, it.Err())
+				require.Empty(b, it.Warnings())
+			}
+		})
+	}
+}
+
+func BenchmarkQuerier_LabelValues(b *testing.B) {
+	db := openTestDB(b, nil, []int64{1000})
+	b.Cleanup(func() {
+		require.NoError(b, db.Close())
+	})
+
+	ctx := context.Background()
+
+	app := db.head.Appender(ctx)
+	// var seriesEntries []storage.Series
+	addSeries := func(l labels.Labels) {
+		app.Append(0, l, 0, 0)
+		// seriesEntries = append(seriesEntries, storage.NewListSeries(l, tsdbutil.GenerateSamples(1, 1)))
+	}
+
+	for n := 0; n < 10; n++ {
+		for i := 0; i < 100000; i++ {
+			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", strconv.Itoa(n)+postingsBenchSuffix, "j", "foo", "i_times_n", strconv.Itoa(i*n)))
+			// Have some series that won't be matched, to properly test inverted matchers.
+			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", strconv.Itoa(n)+postingsBenchSuffix, "j", "bar"))
+			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", "0_"+strconv.Itoa(n)+postingsBenchSuffix, "j", "bar"))
+			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", "1_"+strconv.Itoa(n)+postingsBenchSuffix, "j", "bar"))
+			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", "2_"+strconv.Itoa(n)+postingsBenchSuffix, "j", "foo"))
+		}
+	}
+	require.NoError(b, app.Commit())
+	// createBlock(b, db.Dir(), seriesEntries)
+	require.NoError(b, db.reloadBlocks())
+
+	querier, err := db.Querier(0, 1)
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, querier.Close()) })
+
+	i1 := labels.MustNewMatcher(labels.MatchEqual, "i", "1")
+	iStar := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.*$")
+	jNotFoo := labels.MustNewMatcher(labels.MatchNotEqual, "j", "foo")
+	jXXXYYY := labels.MustNewMatcher(labels.MatchRegexp, "j", "XXX|YYY")
+	jXplus := labels.MustNewMatcher(labels.MatchRegexp, "j", "X.+")
+	n1 := labels.MustNewMatcher(labels.MatchEqual, "n", "1"+postingsBenchSuffix)
+	nX := labels.MustNewMatcher(labels.MatchNotEqual, "n", "X"+postingsBenchSuffix)
+	nPlus := labels.MustNewMatcher(labels.MatchRegexp, "i", "^.+$")
+	primesTimes := labels.MustNewMatcher(labels.MatchEqual, "i_times_n", "533701") // = 76243*7, ie. multiplication of primes. It will match single i*n combination.
+	nonPrimesTimes := labels.MustNewMatcher(labels.MatchEqual, "i_times_n", "20")  // 1*20, 2*10, 4*5, 5*4
+	times12 := labels.MustNewMatcher(labels.MatchRegexp, "i_times_n", "12.*")
+
+	cases := []struct {
+		name      string
+		labelName string
+		matchers  []*labels.Matcher
+	}{
+		{`i with i="1"`, "i", []*labels.Matcher{i1}},
+		// i has 100k values.
+		{`i with n="1"`, "i", []*labels.Matcher{n1}},
+		{`i with n="^.+$"`, "i", []*labels.Matcher{nPlus}},
+		{`i with n="1",j!="foo"`, "i", []*labels.Matcher{n1, jNotFoo}},
+		{`i with n="1",j=~"X.+"`, "i", []*labels.Matcher{n1, jXplus}},
+		{`i with n="1",j=~"XXX|YYY"`, "i", []*labels.Matcher{n1, jXXXYYY}},
+		{`i with n="X",j!="foo"`, "i", []*labels.Matcher{nX, jNotFoo}},
+		{`i with n="1",i=~"^.*$",j!="foo"`, "i", []*labels.Matcher{n1, iStar, jNotFoo}},
+		{`i with i_times_n=533701`, "i", []*labels.Matcher{primesTimes}},
+		{`i with i_times_n=20`, "i", []*labels.Matcher{nonPrimesTimes}},
+		{`i with i_times_n=~"12.*""`, "i", []*labels.Matcher{times12}},
+		// n has 10 values.
+		{`n with j!="foo"`, "n", []*labels.Matcher{jNotFoo}},
+		{`n with i="1"`, "n", []*labels.Matcher{i1}},
+	}
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, warnings, err := querier.LabelValues(ctx, c.labelName, c.matchers...)
+				require.NoError(b, err)
+				require.Empty(b, warnings)
+			}
+		})
+	}
+}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -6981,6 +6981,100 @@ Outer:
 	require.NoError(t, writerErr)
 }
 
+func TestQuerier_LabelValuesStream(t *testing.T) {
+	db := openTestDB(t, nil, nil)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	var seriesEntries []storage.Series
+	// Add a block of 70 series with timestamp 1
+	for i := 0; i < 70; i++ {
+		seriesEntries = append(seriesEntries, storage.NewListSeries(labels.FromStrings(
+			"tens", fmt.Sprintf("value%d", i/10),
+			"unique", fmt.Sprintf("value%d", i),
+		), chunks.GenerateSamples(1, 1)))
+	}
+	createBlock(t, db.Dir(), seriesEntries)
+
+	// Add a block of 50 series with timestamp 2
+	// Since "tens" start at 50, two of the label values ("value5", "value6") will overlap with the
+	// previous block
+	seriesEntries = seriesEntries[:0]
+	for i := 50; i < 100; i++ {
+		seriesEntries = append(seriesEntries, storage.NewListSeries(labels.FromStrings(
+			"tens", fmt.Sprintf("value%d", i/10),
+			"unique", fmt.Sprintf("value%d", i),
+		), chunks.GenerateSamples(2, 1)))
+	}
+	createBlock(t, db.Dir(), seriesEntries)
+
+	require.NoError(t, db.reloadBlocks())
+
+	querier, err := db.Querier(1, 2)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, querier.Close()) })
+
+	t.Run("without matchers", func(t *testing.T) {
+		it := querier.LabelValuesStream("tens")
+		var values []string
+		for it.Next() {
+			values = append(values, it.At())
+		}
+		require.NoError(t, it.Err())
+
+		require.Equal(t, []string{
+			"value0", "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
+		}, values)
+	})
+
+	t.Run("with matchers", func(t *testing.T) {
+		testCases := []struct {
+			name      string
+			label     string
+			matchers  []*labels.Matcher
+			expLabels []string
+		}{
+			{
+				name:  "matching on requested label",
+				label: "tens",
+				matchers: []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, "tens", "value1"),
+				},
+				expLabels: []string{"value1"},
+			},
+			{
+				name:  "unsuccessful matching on requested label",
+				label: "tens",
+				matchers: []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, "tens", "value10"),
+				},
+				expLabels: nil,
+			},
+			{
+				name:  "matching on other label",
+				label: "tens",
+				matchers: []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, "unique", "value51"),
+				},
+				expLabels: []string{"value5"},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				it := querier.LabelValuesStream(tc.label, tc.matchers...)
+				var values []string
+				for it.Next() {
+					values = append(values, it.At())
+				}
+				require.NoError(t, it.Err())
+
+				require.Equal(t, tc.expLabels, values)
+			})
+		}
+	})
+}
+
 func requireEqualOOOSamples(t *testing.T, expectedSamples int, db *DB) {
 	require.Equal(t, float64(expectedSamples),
 		prom_testutil.ToFloat64(db.head.metrics.outOfOrderSamplesAppended.WithLabelValues(sampleMetricTypeFloat)),

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -87,6 +87,30 @@ func (h *headIndexReader) LabelValues(ctx context.Context, name string, matchers
 	return labelValuesWithMatchers(ctx, h, name, matchers...)
 }
 
+// LabelValuesStream returns an iterator over label values present in
+// the head for the specific label name that are within the time range
+// mint to maxt.
+// If matchers are specified the returned result set is reduced
+// to label values of metrics matching the matchers.
+func (h *headIndexReader) LabelValuesStream(name string, matchers ...*labels.Matcher) storage.LabelValues {
+	if h.maxt < h.head.MinTime() || h.mint > h.head.MaxTime() {
+		return nil
+	}
+
+	ownMatchers := 0
+	for _, m := range matchers {
+		if m.Name == name {
+			ownMatchers++
+		}
+	}
+	if ownMatchers == len(matchers) {
+		return h.head.postings.LabelValuesStream(name, matchers...)
+	}
+
+	// There are matchers on other label names than the requested one, so will need to intersect matching series
+	return labelValuesForMatchersStream(h, name, matchers)
+}
+
 // LabelNames returns all the unique label names present in the head
 // that are within the time range mint to maxt.
 func (h *headIndexReader) LabelNames(ctx context.Context, matchers ...*labels.Matcher) ([]string, error) {
@@ -151,6 +175,10 @@ func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {
 		ep = append(ep, storage.SeriesRef(p.ref))
 	}
 	return index.NewListPostings(ep)
+}
+
+func (h *headIndexReader) LabelValuesIntersectingPostings(name string, postings index.Postings) storage.LabelValues {
+	return h.head.postings.LabelValuesIntersectingPostings(name, postings)
 }
 
 // ShardedPostings implements IndexReader. This function returns an failing postings list if sharding

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2840,6 +2840,82 @@ func TestHeadLabelValuesWithMatchers(t *testing.T) {
 	}
 }
 
+func TestHeadLabelValuesStream_WithMatchers(t *testing.T) {
+	head, _ := newTestHead(t, 1000, wlog.CompressionNone, false)
+	t.Cleanup(func() { require.NoError(t, head.Close()) })
+
+	app := head.Appender(context.Background())
+	for i := 0; i < 100; i++ {
+		_, err := app.Append(0, labels.FromStrings(
+			"tens", fmt.Sprintf("value%d", i/10),
+			"unique", fmt.Sprintf("value%d", i),
+		), 100, 0)
+		require.NoError(t, err)
+	}
+	require.NoError(t, app.Commit())
+
+	indexReader := head.indexRange(0, 200)
+	t.Cleanup(func() {
+		require.NoError(t, indexReader.Close())
+	})
+
+	var uniqueWithout30s []string
+	for i := 0; i < 100; i++ {
+		if i/10 != 3 {
+			uniqueWithout30s = append(uniqueWithout30s, fmt.Sprintf("value%d", i))
+		}
+	}
+	sort.Strings(uniqueWithout30s)
+	testCases := []struct {
+		name           string
+		labelName      string
+		matchers       []*labels.Matcher
+		expectedValues []string
+	}{
+		{
+			name:           "get tens based on unique ID",
+			labelName:      "tens",
+			matchers:       []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "unique", "value35")},
+			expectedValues: []string{"value3"},
+		}, {
+			name:           "get unique IDs based on a ten",
+			labelName:      "unique",
+			matchers:       []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "tens", "value1")},
+			expectedValues: []string{"value10", "value11", "value12", "value13", "value14", "value15", "value16", "value17", "value18", "value19"},
+		}, {
+			name:           "get tens by pattern matching on unique ID",
+			labelName:      "tens",
+			matchers:       []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "unique", "value[5-7]5")},
+			expectedValues: []string{"value5", "value6", "value7"},
+		}, {
+			name:           "get tens by matching for presence of unique label",
+			labelName:      "tens",
+			matchers:       []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "unique", "")},
+			expectedValues: []string{"value0", "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9"},
+		}, {
+			name:      "get unique IDs based on tens not being equal to a certain value, while not empty",
+			labelName: "unique",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchNotEqual, "tens", "value3"),
+				labels.MustNewMatcher(labels.MatchNotEqual, "tens", ""),
+			},
+			expectedValues: uniqueWithout30s,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			it := indexReader.LabelValuesStream(tt.labelName, tt.matchers...)
+			var values []string
+			for it.Next() {
+				values = append(values, it.At())
+			}
+			require.NoError(t, it.Err())
+			require.Empty(t, it.Warnings())
+			require.Equal(t, tt.expectedValues, values)
+		})
+	}
+}
+
 func TestHeadLabelNamesWithMatchers(t *testing.T) {
 	head, _ := newTestHead(t, 1000, wlog.CompressionNone, false)
 	defer func() {

--- a/tsdb/index/labelvalues.go
+++ b/tsdb/index/labelvalues.go
@@ -1,0 +1,364 @@
+// Copyright 2023 The Prometheus Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/pkg/errors"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/encoding"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+type labelValuesV2 struct {
+	name      string
+	cur       string
+	dec       encoding.Decbuf
+	matchers  []*labels.Matcher
+	skip      int
+	lastVal   string
+	exhausted bool
+	err       error
+}
+
+// newLabelValuesV2 returns an iterator over label values in a v2 index.
+func (r *Reader) newLabelValuesV2(name string, matchers []*labels.Matcher) storage.LabelValues {
+	p := r.postings[name]
+
+	d := encoding.NewDecbufAt(r.b, int(r.toc.PostingsTable), nil)
+	d.Skip(p[0].off)
+	// These are always the same number of bytes, and it's faster to skip than to parse
+	skip := d.Len()
+	// Key count
+	d.Uvarint()
+	// Label name
+	d.UvarintBytes()
+	skip -= d.Len()
+
+	return &labelValuesV2{
+		name:     name,
+		matchers: matchers,
+		dec:      d,
+		lastVal:  p[len(p)-1].value,
+		skip:     skip,
+	}
+}
+
+func (l *labelValuesV2) Next() bool {
+	if l.err != nil || l.exhausted {
+		return false
+	}
+
+	// Pick the first matching label value
+	for l.dec.Err() == nil {
+		// Label value
+		val := yoloString(l.dec.UvarintBytes())
+		isMatch := true
+		for _, m := range l.matchers {
+			if m.Name != l.name {
+				// This should not happen
+				continue
+			}
+
+			if !m.Matches(val) {
+				isMatch = false
+				break
+			}
+		}
+
+		if isMatch {
+			l.cur = val
+		}
+		if val == l.lastVal {
+			l.exhausted = true
+			return isMatch
+		}
+
+		// Offset
+		l.dec.Uvarint64()
+		// Skip forward to next entry
+		l.dec.Skip(l.skip)
+
+		if isMatch {
+			break
+		}
+	}
+	if l.dec.Err() != nil {
+		// An error occurred decoding
+		l.err = errors.Wrap(l.dec.Err(), "get postings offset entry")
+		return false
+	}
+
+	return true
+}
+
+func (l *labelValuesV2) At() string {
+	return l.cur
+}
+
+func (l *labelValuesV2) Err() error {
+	return l.err
+}
+
+func (l *labelValuesV2) Warnings() annotations.Annotations {
+	return nil
+}
+
+type labelValuesV1 struct {
+	it       *reflect.MapIter
+	matchers []*labels.Matcher
+	name     string
+}
+
+func (l *labelValuesV1) Next() bool {
+loop:
+	for l.it.Next() {
+		for _, m := range l.matchers {
+			if m.Name != l.name {
+				// This should not happen
+				continue
+			}
+
+			if !m.Matches(l.At()) {
+				continue loop
+			}
+		}
+
+		// This entry satisfies all matchers
+		return true
+	}
+
+	return false
+}
+
+func (l *labelValuesV1) At() string {
+	return yoloString(l.it.Value().Bytes())
+}
+
+func (*labelValuesV1) Err() error {
+	return nil
+}
+
+func (*labelValuesV1) Warnings() annotations.Annotations {
+	return nil
+}
+
+func (r *Reader) LabelValuesIntersectingPostings(name string, postings Postings) storage.LabelValues {
+	if r.version == FormatV1 {
+		/* TODO
+		e := r.postingsV1[name]
+		if len(e) == 0 {
+			return NewEmptyWrapPostingsWithLabelValue()
+		}
+
+		var res []PostingsWithLabelValues
+		for val, off := range e {
+			// Read from the postings table.
+			d := encoding.NewDecbufAt(r.b, int(off), castagnoliTable)
+			_, p, err := r.dec.Postings(d.Get())
+			if err != nil {
+				return NewErrWrapPostingsWithLabelValue(errors.Wrap(err, "decode postings"))
+			}
+			res = append(res, NewWrapPostingsWithLabelValue(p, val))
+		}
+		return newMergedPostingsWithLabelValues(res)
+		*/
+		return storage.EmptyLabelValues()
+	}
+
+	e := r.postings[name]
+	if len(e) == 0 {
+		return storage.EmptyLabelValues()
+	}
+
+	d := encoding.NewDecbufAt(r.b, int(r.toc.PostingsTable), nil)
+	// Skip to start
+	d.Skip(e[0].off)
+	lastVal := e[len(e)-1].value
+
+	return &intersectLabelValues{
+		d:        &d,
+		b:        r.b,
+		dec:      r.dec,
+		lastVal:  lastVal,
+		postings: postings,
+	}
+}
+
+type intersectLabelValues struct {
+	d           *encoding.Decbuf
+	b           ByteSlice
+	dec         *Decoder
+	postings    Postings
+	curPostings bigEndianPostings
+	lastVal     string
+	skip        int
+	cur         string
+	exhausted   bool
+	err         error
+}
+
+func (it *intersectLabelValues) Next() bool {
+	if it.exhausted {
+		return false
+	}
+
+	for !it.exhausted && it.d.Err() == nil {
+		if it.skip == 0 {
+			// These are always the same number of bytes,
+			// and it's faster to skip than to parse.
+			it.skip = it.d.Len()
+			// Key count
+			it.d.Uvarint()
+			// Label name
+			it.d.UvarintBytes()
+			it.skip -= it.d.Len()
+		} else {
+			it.d.Skip(it.skip)
+		}
+
+		// Label value
+		v := yoloString(it.d.UvarintBytes())
+
+		postingsOff := it.d.Uvarint64()
+		// Read from the postings table
+		d2 := encoding.NewDecbufAt(it.b, int(postingsOff), castagnoliTable)
+		_, err := it.dec.PostingsInPlace(d2.Get(), &it.curPostings)
+		if err != nil {
+			it.err = errors.Wrap(err, "decode postings")
+			return false
+		}
+
+		it.exhausted = v == it.lastVal
+
+		it.postings.Reset()
+		if checkIntersection(&it.curPostings, it.postings) {
+			it.cur = v
+			return true
+		}
+	}
+	if it.d.Err() != nil {
+		it.err = errors.Wrap(it.d.Err(), "get postings offset entry")
+	}
+
+	return false
+}
+
+func (it *intersectLabelValues) At() string {
+	return it.cur
+}
+
+func (it *intersectLabelValues) Err() error {
+	return it.err
+}
+
+func (it *intersectLabelValues) Warnings() annotations.Annotations {
+	return nil
+}
+
+// ListLabelValues is an iterator over a slice of label values.
+type ListLabelValues struct {
+	cur    string
+	values []string
+}
+
+func NewListLabelValues(values []string) *ListLabelValues {
+	return &ListLabelValues{
+		values: values,
+	}
+}
+
+func (l *ListLabelValues) Next() bool {
+	if len(l.values) == 0 {
+		return false
+	}
+
+	l.cur = l.values[0]
+	l.values = l.values[1:]
+	return true
+}
+
+func (l *ListLabelValues) At() string {
+	return l.cur
+}
+
+func (*ListLabelValues) Err() error {
+	return nil
+}
+
+func (*ListLabelValues) Warnings() annotations.Annotations {
+	return nil
+}
+
+func (p *MemPostings) LabelValuesIntersectingPostings(name string, postings Postings) storage.LabelValues {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	e := p.m[name]
+	if len(e) == 0 {
+		return storage.EmptyLabelValues()
+	}
+
+	// With thread safety in mind and due to random key ordering in map, we have to construct the array in memory
+	vals := make([]string, 0, len(e))
+	for val, srs := range e {
+		p.curPostings.list = srs
+		p.curPostings.Reset()
+		postings.Reset()
+
+		if checkIntersection(&p.curPostings, postings) {
+			vals = append(vals, val)
+		}
+	}
+
+	sort.Strings(vals)
+	return NewListLabelValues(vals)
+}
+
+// checkIntersection returns whether p1 and p2 have at least one series in common.
+func checkIntersection(p1, p2 Postings) bool {
+	if !p1.Next() || !p2.Next() {
+		return false
+	}
+
+	cur := p1.At()
+	if p2.At() > cur {
+		cur = p2.At()
+	}
+
+	for {
+		if !p1.Seek(cur) {
+			break
+		}
+		if p1.At() > cur {
+			cur = p1.At()
+		}
+		if !p2.Seek(cur) {
+			break
+		}
+		if p2.At() > cur {
+			cur = p2.At()
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -54,9 +54,10 @@ var ensureOrderBatchPool = sync.Pool{
 // EnsureOrder() must be called once before any reads are done. This allows for quick
 // unordered batch fills on startup.
 type MemPostings struct {
-	mtx     sync.RWMutex
-	m       map[string]map[string][]storage.SeriesRef
-	ordered bool
+	mtx         sync.RWMutex
+	m           map[string]map[string][]storage.SeriesRef
+	ordered     bool
+	curPostings ListPostings
 }
 
 // NewMemPostings returns a memPostings that's ready for reads and writes.
@@ -151,6 +152,29 @@ func (p *MemPostings) LabelValues(_ context.Context, name string) []string {
 		values = append(values, v)
 	}
 	return values
+}
+
+// LabelValuesStream returns an iterator over label values for the given name.
+func (p *MemPostings) LabelValuesStream(name string, matchers ...*labels.Matcher) storage.LabelValues {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	values := make([]string, 0, len(p.m[name]))
+loop:
+	for v := range p.m[name] {
+		for _, m := range matchers {
+			if m.Name != name {
+				// This should not happen
+				continue
+			}
+
+			if !m.Matches(v) {
+				continue loop
+			}
+		}
+		values = append(values, v)
+	}
+	return NewListLabelValues(values)
 }
 
 // PostingsStats contains cardinality based statistics for postings.
@@ -449,6 +473,9 @@ type Postings interface {
 
 	// Err returns the last error of the iterator.
 	Err() error
+
+	// Reset the iterator to its initial state.
+	Reset()
 }
 
 // errPostings is an empty iterator that always errors.
@@ -460,6 +487,7 @@ func (e errPostings) Next() bool                  { return false }
 func (e errPostings) Seek(storage.SeriesRef) bool { return false }
 func (e errPostings) At() storage.SeriesRef       { return 0 }
 func (e errPostings) Err() error                  { return e.err }
+func (e errPostings) Reset()                      {}
 
 var emptyPostings = errPostings{}
 
@@ -555,8 +583,15 @@ func (it *intersectPostings) Err() error {
 	return nil
 }
 
+func (it *intersectPostings) Reset() {
+	for _, p := range it.arr {
+		p.Reset()
+	}
+	it.cur = 0
+}
+
 // Merge returns a new iterator over the union of the input iterators.
-func Merge(_ context.Context, its ...Postings) Postings {
+func Merge(ctx context.Context, its ...Postings) Postings {
 	if len(its) == 0 {
 		return EmptyPostings()
 	}
@@ -571,16 +606,52 @@ func Merge(_ context.Context, its ...Postings) Postings {
 	return p
 }
 
-type mergedPostings struct {
-	p   []Postings
-	h   *loser.Tree[storage.SeriesRef, Postings]
-	cur storage.SeriesRef
+type postingsHeap []Postings
+
+func (h postingsHeap) Len() int           { return len(h) }
+func (h postingsHeap) Less(i, j int) bool { return h[i].At() < h[j].At() }
+func (h *postingsHeap) Swap(i, j int)     { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
+
+func (h *postingsHeap) Push(x interface{}) {
+	*h = append(*h, x.(Postings))
 }
 
-func newMergedPostings(p []Postings) (m *mergedPostings, nonEmpty bool) {
-	const maxVal = storage.SeriesRef(math.MaxUint64) // This value must be higher than all real values used in the tree.
-	lt := loser.New(p, maxVal)
-	return &mergedPostings{p: p, h: lt}, true
+func (h *postingsHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+type mergedPostings struct {
+	h           postingsHeap
+	hCopy       postingsHeap
+	initialized bool
+	cur         storage.SeriesRef
+	err         error
+}
+
+func newMergedPostings(ctx context.Context, p []Postings) (m *mergedPostings, nonEmpty bool) {
+	ph := make(postingsHeap, 0, len(p))
+
+	for _, it := range p {
+		// NOTE: mergedPostings struct requires the user to issue an initial Next.
+		switch {
+		case ctx.Err() != nil:
+			return &mergedPostings{err: ctx.Err()}, true
+		case it.Next():
+			ph = append(ph, it)
+		case it.Err() != nil:
+			return &mergedPostings{err: it.Err()}, true
+		}
+	}
+
+	if len(ph) == 0 {
+		return nil, false
+	}
+
+	return &mergedPostings{h: ph, hCopy: ph}, true
 }
 
 func (it *mergedPostings) Next() bool {
@@ -614,12 +685,22 @@ func (it mergedPostings) At() storage.SeriesRef {
 }
 
 func (it mergedPostings) Err() error {
-	for _, p := range it.p {
-		if err := p.Err(); err != nil {
-			return err
+	return it.err
+}
+
+func (it *mergedPostings) Reset() {
+	// Reset the heap and its iterators
+	it.h = it.hCopy
+	for _, p := range it.h {
+		p.Reset()
+		// All iterators are expected to be initialized
+		if !p.Next() {
+			panic("couldn't issue initial Postings.Next()")
 		}
 	}
-	return nil
+	it.initialized = false
+	it.cur = 0
+	it.err = nil
 }
 
 // Without returns a new postings list that contains all elements from the full list that
@@ -707,10 +788,17 @@ func (rp *removedPostings) Err() error {
 	return rp.remove.Err()
 }
 
+func (rp *removedPostings) Reset() {
+	rp.full.Reset()
+	rp.remove.Reset()
+	rp.cur = 0
+	rp.initialized = false
+}
+
 // ListPostings implements the Postings interface over a plain list.
 type ListPostings struct {
 	list []storage.SeriesRef
-	cur  storage.SeriesRef
+	pos  int
 }
 
 func NewListPostings(list []storage.SeriesRef) Postings {
@@ -718,39 +806,52 @@ func NewListPostings(list []storage.SeriesRef) Postings {
 }
 
 func newListPostings(list ...storage.SeriesRef) *ListPostings {
-	return &ListPostings{list: list}
+	return &ListPostings{
+		list: list,
+		pos:  -1,
+	}
 }
 
 func (it *ListPostings) At() storage.SeriesRef {
-	return it.cur
+	if it.pos < 0 {
+		return 0
+	}
+
+	if it.pos >= len(it.list) {
+		// Not entirely sure why postingsWithIndexHeap needs to keep exhausted iterators around
+		return 0
+	}
+
+	return it.list[it.pos]
 }
 
 func (it *ListPostings) Next() bool {
-	if len(it.list) > 0 {
-		it.cur = it.list[0]
-		it.list = it.list[1:]
-		return true
+	if it.pos >= len(it.list)-1 {
+		return false
 	}
-	it.cur = 0
-	return false
+
+	it.pos++
+	return true
 }
 
 func (it *ListPostings) Seek(x storage.SeriesRef) bool {
 	// If the current value satisfies, then return.
-	if it.cur >= x {
+	if it.pos >= 0 && it.list[it.pos] >= x {
 		return true
 	}
-	if len(it.list) == 0 {
-		return false
+
+	start := it.pos
+	if start < 0 {
+		start = 0
 	}
 
 	// Do binary search between current position and end.
-	i := sort.Search(len(it.list), func(i int) bool {
-		return it.list[i] >= x
+	l := it.list[start:]
+	i := sort.Search(len(l), func(i int) bool {
+		return l[i] >= x
 	})
-	if i < len(it.list) {
-		it.cur = it.list[i]
-		it.list = it.list[i+1:]
+	if i < len(l) {
+		it.pos = start + i
 		return true
 	}
 	it.list = nil
@@ -761,15 +862,23 @@ func (it *ListPostings) Err() error {
 	return nil
 }
 
+func (it *ListPostings) Reset() {
+	it.pos = -1
+}
+
 // bigEndianPostings implements the Postings interface over a byte stream of
 // big endian numbers.
 type bigEndianPostings struct {
 	list []byte
+	i    int
 	cur  uint32
 }
 
 func newBigEndianPostings(list []byte) *bigEndianPostings {
-	return &bigEndianPostings{list: list}
+	return &bigEndianPostings{
+		list: list,
+		i:    -4,
+	}
 }
 
 func (it *bigEndianPostings) At() storage.SeriesRef {
@@ -777,12 +886,14 @@ func (it *bigEndianPostings) At() storage.SeriesRef {
 }
 
 func (it *bigEndianPostings) Next() bool {
-	if len(it.list) >= 4 {
-		it.cur = binary.BigEndian.Uint32(it.list)
-		it.list = it.list[4:]
-		return true
+	if it.i >= len(it.list)-4 {
+		it.i = len(it.list)
+		return false
 	}
-	return false
+
+	it.i += 4
+	it.cur = binary.BigEndian.Uint32(it.list[it.i:])
+	return true
 }
 
 func (it *bigEndianPostings) Seek(x storage.SeriesRef) bool {
@@ -790,23 +901,34 @@ func (it *bigEndianPostings) Seek(x storage.SeriesRef) bool {
 		return true
 	}
 
-	num := len(it.list) / 4
+	start := it.i
+	if start < 0 {
+		start = 0
+	}
+
+	l := it.list[start:]
+	num := len(l) / 4
 	// Do binary search between current position and end.
 	i := sort.Search(num, func(i int) bool {
-		return binary.BigEndian.Uint32(it.list[i*4:]) >= uint32(x)
+		return binary.BigEndian.Uint32(l[i*4:]) >= uint32(x)
 	})
 	if i < num {
 		j := i * 4
-		it.cur = binary.BigEndian.Uint32(it.list[j:])
-		it.list = it.list[j+4:]
+		it.cur = binary.BigEndian.Uint32(l[j:])
+		it.i = start + j
 		return true
 	}
-	it.list = nil
+
 	return false
 }
 
 func (it *bigEndianPostings) Err() error {
 	return nil
+}
+
+func (it *bigEndianPostings) Reset() {
+	it.i = -4
+	it.cur = 0
 }
 
 // FindIntersectingPostings checks the intersection of p and candidates[i] for each i in candidates,

--- a/tsdb/labelvalues.go
+++ b/tsdb/labelvalues.go
@@ -1,0 +1,116 @@
+// Copyright 2023 The Prometheus Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/index"
+)
+
+func labelValuesForMatchersStream(r IndexReader, name string, matchers []*labels.Matcher) storage.LabelValues {
+	// See which labels must be non-empty.
+	// Optimization for case like {l=~".", l!="1"}.
+	labelMustBeSet := make(map[string]bool, len(matchers))
+	for _, m := range matchers {
+		if !m.Matches("") {
+			labelMustBeSet[m.Name] = true
+		}
+	}
+
+	ctx := context.TODO()
+
+	var its, notIts []index.Postings
+	for _, m := range matchers {
+		switch {
+		case labelMustBeSet[m.Name]:
+			// If this matcher must be non-empty, we can be smarter.
+			matchesEmpty := m.Matches("")
+			isNot := m.Type == labels.MatchNotEqual || m.Type == labels.MatchNotRegexp
+			switch {
+			case isNot && matchesEmpty: // l!="foo"
+				// If the label can't be empty and is a Not and the inner matcher
+				// doesn't match empty, then subtract it out at the end.
+				inverse, err := m.Inverse()
+				if err != nil {
+					return storage.ErrLabelValues(err)
+				}
+
+				it, err := postingsForMatcher(ctx, r, inverse)
+				if err != nil {
+					return storage.ErrLabelValues(err)
+				}
+				notIts = append(notIts, it)
+			case isNot && !matchesEmpty: // l!=""
+				// If the label can't be empty and is a Not, but the inner matcher can
+				// be empty we need to use inversePostingsForMatcher.
+				inverse, err := m.Inverse()
+				if err != nil {
+					return storage.ErrLabelValues(err)
+				}
+
+				it, err := inversePostingsForMatcher(ctx, r, inverse)
+				if err != nil {
+					return storage.ErrLabelValues(err)
+				}
+				if index.IsEmptyPostingsType(it) {
+					return storage.EmptyLabelValues()
+				}
+				its = append(its, it)
+			default: // l="a"
+				// Non-Not matcher, use normal postingsForMatcher.
+				it, err := postingsForMatcher(ctx, r, m)
+				if err != nil {
+					return storage.ErrLabelValues(err)
+				}
+				if index.IsEmptyPostingsType(it) {
+					return storage.EmptyLabelValues()
+				}
+				its = append(its, it)
+			}
+		default: // l=""
+			// If a matcher for a labelname selects an empty value, it selects all
+			// the series which don't have the label name set too. See:
+			// https://github.com/prometheus/prometheus/issues/3575 and
+			// https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555
+			it, err := inversePostingsForMatcher(ctx, r, m)
+			if err != nil {
+				return storage.ErrLabelValues(err)
+			}
+			notIts = append(notIts, it)
+		}
+	}
+
+	if len(its) == 0 && len(notIts) > 0 {
+		k, v := index.AllPostingsKey()
+		allPostings, err := r.Postings(ctx, k, v)
+		if err != nil {
+			return storage.ErrLabelValues(err)
+		}
+		its = append(its, allPostings)
+	}
+
+	pit := index.Intersect(its...)
+	for _, n := range notIts {
+		pit = index.Without(pit, n)
+	}
+	if pit.Err() != nil {
+		return storage.ErrLabelValues(pit.Err())
+	}
+
+	return r.LabelValuesIntersectingPostings(name, pit)
+}

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -79,6 +79,10 @@ func (q *blockBaseQuerier) LabelValues(ctx context.Context, name string, matcher
 	return res, nil, err
 }
 
+func (q *blockBaseQuerier) LabelValuesStream(name string, matchers ...*labels.Matcher) storage.LabelValues {
+	return q.index.LabelValuesStream(name, matchers...)
+}
+
 func (q *blockBaseQuerier) LabelNames(ctx context.Context, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	res, err := q.index.LabelNames(ctx, matchers...)
 	return res, nil, err
@@ -289,7 +293,7 @@ func PostingsForMatchers(ctx context.Context, ix IndexReader, ms ...*labels.Matc
 				its = append(its, it)
 			}
 		default: // l=""
-			// If the matchers for a labelname selects an empty value, it selects all
+			// If a matcher for a labelname selects an empty value, it selects all
 			// the series which don't have the label name set too. See:
 			// https://github.com/prometheus/prometheus/issues/3575 and
 			// https://github.com/prometheus/prometheus/pull/3578#issuecomment-351653555

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2287,6 +2287,11 @@ func (m mockIndex) LabelValues(_ context.Context, name string, matchers ...*labe
 	return values, nil
 }
 
+func (m mockIndex) LabelValuesStream(name string, matchers ...*labels.Matcher) storage.LabelValues {
+	// TODO
+	return storage.EmptyLabelValues()
+}
+
 func (m mockIndex) LabelValueFor(_ context.Context, id storage.SeriesRef, label string) (string, error) {
 	return m.series[id].l.Get(label), nil
 }
@@ -2324,6 +2329,10 @@ func (m mockIndex) SortedPostings(p index.Postings) index.Postings {
 		return labels.Compare(m.series[ep[i]].l, m.series[ep[j]].l) < 0
 	})
 	return index.NewListPostings(ep)
+}
+
+func (mockIndex) LabelValuesIntersectingPostings(string, index.Postings) storage.LabelValues {
+	panic("not implemented")
 }
 
 func (m mockIndex) PostingsForLabelMatching(ctx context.Context, name string, match func(string) bool) index.Postings {
@@ -3220,6 +3229,11 @@ func (m mockMatcherIndex) LabelValues(context.Context, string, ...*labels.Matche
 	return []string{}, errors.New("label values called")
 }
 
+// LabelValuesStream will return a failing label values iterator.
+func (m mockMatcherIndex) LabelValuesStream(string, ...*labels.Matcher) storage.LabelValues {
+	return storage.ErrLabelValues(errors.New("label values stream called"))
+}
+
 func (m mockMatcherIndex) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {
 	return "", errors.New("label value for called")
 }
@@ -3242,6 +3256,10 @@ func (m mockMatcherIndex) ShardedPostings(ps index.Postings, shardIndex, shardCo
 
 func (m mockMatcherIndex) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
 	return nil
+}
+
+func (m mockMatcherIndex) LabelValuesIntersectingPostings(name string, p index.Postings) storage.LabelValues {
+	return storage.EmptyLabelValues()
 }
 
 func (m mockMatcherIndex) LabelNames(context.Context, ...*labels.Matcher) ([]string, error) {

--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -174,6 +174,10 @@ func (t errorTestQuerier) LabelValues(context.Context, string, ...*labels.Matche
 	return nil, nil, t.err
 }
 
+func (t errorTestQuerier) LabelValuesStream(string, ...*labels.Matcher) storage.LabelValues {
+	return storage.ErrLabelValues(t.err)
+}
+
 func (t errorTestQuerier) LabelNames(context.Context, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, t.err
 }


### PR DESCRIPTION
Add method `storage.LabelQuerier.LabelValuesStream` that returns an iterator over corresponding label values, instead of a slice.

Work in progress!

TODO:
- [ ] Benchmark
- [ ] Instead of making a sorted values slice, consider copying the postings matching the matchers, before intersecting them with each label value’s posting list, allowing iterating over values in alphabetical order (thanks, @dimitarvdimitrov)
- [ ] Extend test cases to cover relevant corners