### PR TITLE
Remove duplicated ms.mmMaxTime check in processWALSamples

### DIFF
--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -589,9 +589,6 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if s.T <= ms.mmMaxTime {
 				continue
 			}
-			if s.T <= ms.mmMaxTime {
-				continue
-			}
 			if _, chunkCreated := ms.append(s.T, s.V, 0, appendChunkOpts); chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Small code cleanup, the `s.T <= ms.mmMaxTime` check is repeated.

It looks like it was introduced in accident in: https://github.com/prometheus/prometheus/commit/e934d0f01158a1d55fa0ebb035346b195fcc1260#diff-e55e448a1ce649167194e1ced19ab2009f422ad678011e333414b8de8e62d311 (large commit merging main branch into spare-histograms one).
