### PR TITLE
Do WBL mmap marker replay concurrently

### DIFF
--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -762,7 +762,7 @@ func (h *Head) loadWBL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 				}
 				for i := 0; i < concurrency; i++ {
 					if len(shards[i]) > 0 {
-						processors[i].input <- shards[i]
+						processors[i].input <- wblSubsetProcessorInputItem{samples: shards[i]}
 						shards[i] = nil
 					}
 				}
@@ -790,23 +790,7 @@ func (h *Head) loadWBL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 					continue
 				}
 				idx := uint64(ms.ref) % uint64(concurrency)
-				// It is possible that some old sample is being processed in processWALSamples that
-				// could cause race below. So we wait for the goroutine to empty input the buffer and finish
-				// processing all old samples after emptying the buffer.
-				processors[idx].waitUntilIdle()
-				// Lock the subset so we can modify the series object
-				processors[idx].mx.Lock()
-
-				// All samples till now have been m-mapped. Hence clear out the headChunk.
-				// In case some samples slipped through and went into m-map chunks because of changed
-				// chunk size parameters, we are not taking care of that here.
-				// TODO(codesome): see if there is a way to avoid duplicate m-map chunks if
-				// the size of ooo chunk was reduced between restart.
-				if ms.ooo != nil {
-					ms.ooo.oooHeadChunk = nil
-				}
-
-				processors[idx].mx.Unlock()
+				processors[idx].input <- wblSubsetProcessorInputItem{mmappedSeries: ms}
 			}
 		default:
 			panic(fmt.Errorf("unexpected decodedCh type: %T", d))
@@ -858,14 +842,18 @@ func isErrLoadOOOWal(err error) bool {
 }
 
 type wblSubsetProcessor struct {
-	mx     sync.Mutex // Take this lock while modifying series in the subset.
-	input  chan []record.RefSample
+	input  chan wblSubsetProcessorInputItem
 	output chan []record.RefSample
+}
+
+type wblSubsetProcessorInputItem struct {
+	mmappedSeries *memSeries
+	samples       []record.RefSample
 }
 
 func (wp *wblSubsetProcessor) setup() {
 	wp.output = make(chan []record.RefSample, 300)
-	wp.input = make(chan []record.RefSample, 300)
+	wp.input = make(chan wblSubsetProcessorInputItem, 300)
 }
 
 func (wp *wblSubsetProcessor) closeAndDrain() {
@@ -892,9 +880,17 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (unknownRefs uint64) {
 	oooCapMax := h.opts.OutOfOrderCapMax.Load()
 	// We don't check for minValidTime for ooo samples.
 	mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)
-	for samples := range wp.input {
-		wp.mx.Lock()
-		for _, s := range samples {
+	for in := range wp.input {
+		if in.mmappedSeries != nil && in.mmappedSeries.ooo != nil {
+			// All samples till now have been m-mapped. Hence clear out the headChunk.
+			// In case some samples slipped through and went into m-map chunks because of changed
+			// chunk size parameters, we are not taking care of that here.
+			// TODO(codesome): see if there is a way to avoid duplicate m-map chunks if
+			// the size of ooo chunk was reduced between restart.
+			in.mmappedSeries.ooo.oooHeadChunk = nil
+			continue
+		}
+		for _, s := range in.samples {
 			ms := h.series.getByID(s.Ref)
 			if ms == nil {
 				unknownRefs++
@@ -914,28 +910,12 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (unknownRefs uint64) {
 				}
 			}
 		}
-		wp.mx.Unlock()
 
 	}
 
 	h.updateMinOOOMaxOOOTime(mint, maxt)
 
 	return unknownRefs
-}
-
-func (wp *wblSubsetProcessor) waitUntilIdle() {
-	select {
-	case <-wp.output: // Allow output side to drain to avoid deadlock.
-	default:
-	}
-	wp.input <- []record.RefSample{}
-	for len(wp.input) != 0 {
-		time.Sleep(10 * time.Microsecond)
-		select {
-		case <-wp.output: // Allow output side to drain to avoid deadlock.
-		default:
-		}
-	}
 }
 
 const (

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -910,7 +910,10 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (unknownRefs uint64) {
 				}
 			}
 		}
-
+		select {
+		case wp.output <- in.samples:
+		default:
+		}
 	}
 
 	h.updateMinOOOMaxOOOTime(mint, maxt)


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Part of https://github.com/prometheus/prometheus/issues/11329. 

This PR makes `processWALSamples()` and `processWBLSamples()` more similar by making the WBL mmap marker replay concurrent, removing need for the wblSubsetProcessor's `waitUntilIdle()` function. This is similar to a change that was done to the WAL in https://github.com/prometheus/prometheus/pull/10973.

Also I noticed that the wblSubsetProcessor wasn't returning sample slices to the output channel for reuse, fixed that in https://github.com/prometheus/prometheus/pull/12801/commits/4771e714b25ffff18e8a38a7756fc085f3e5fbd9.

To test the concurrent mmap marker replay, I extended the WAL replay benchmark with WBL replay as well - test cases can now specify a percentage of series that should have OOO samples. The first samples (by sample timestamp) are chosen as OOO samples and are written after the in-order samples.

The results are below, and it _seems_ like the changes show a slight speed improvement for the WBL for these artificial test cases. However, some test cases that don't have any OOO samples (`oooSeriesPct =0`) are also faster with the changes, which is confusing since I haven't made any changes to the WAL so wouldn't expect any differences.

However, I think the main benefit of the change is that it makes the WAL and WBL code more similar, so it'll be easier to refactor and deduplicate. As long as the new behaviour isn't making anything slower it's still a net positive.

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
```

```
$ benchstat bb1e641a5.txt be995d267.txt
name                                                                                                                                                          old time/op  new time/op  delta
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16         608ms ± 9%   627ms ± 5%     ~     (p=0.310 n=5+5)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16        674ms ± 3%   657ms ± 4%     ~     (p=0.222 n=5+5)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16        691ms ± 4%   659ms ± 4%   -4.58%  (p=0.016 n=5+5)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16       817ms ± 5%   751ms ± 6%   -8.07%  (p=0.016 n=5+5)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16         660ms ± 3%   631ms ± 5%     ~     (p=0.095 n=5+5)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16         724ms ± 4%   688ms ± 2%   -4.89%  (p=0.032 n=5+5)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16         289ms ± 2%   258ms ± 6%  -10.91%  (p=0.008 n=5+5)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16         307ms ± 3%   269ms ± 4%  -12.18%  (p=0.008 n=5+5)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16         317ms ± 7%   277ms ± 9%  -12.74%  (p=0.008 n=5+5)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16        381ms ± 4%   354ms ± 5%   -6.98%  (p=0.016 n=5+5)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16     2.60s ± 5%   2.28s ± 5%  -12.10%  (p=0.008 n=5+5)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16     2.70s ± 2%   2.37s ± 3%  -12.20%  (p=0.008 n=5+5)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16     2.73s ± 1%   2.49s ± 2%   -9.06%  (p=0.008 n=5+5)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-16    3.36s ± 5%   3.01s ± 3%  -10.49%  (p=0.008 n=5+5)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-16        1.15s ± 9%   0.87s ± 3%  -23.92%  (p=0.008 n=5+5)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-16        1.18s ± 7%   0.92s ± 6%  -21.43%  (p=0.008 n=5+5)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-16        1.18s ± 8%   0.97s ± 6%  -17.31%  (p=0.008 n=5+5)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-16       1.22s ± 1%   0.97s ± 4%  -20.68%  (p=0.008 n=5+5)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-16         875ms ± 4%   812ms ± 8%     ~     (p=0.056 n=5+5)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-16         889ms ± 5%   807ms ± 4%   -9.30%  (p=0.008 n=5+5)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-16         879ms ± 1%   815ms ± 0%   -7.34%  (p=0.016 n=5+4)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-16        988ms ± 9%   886ms ± 7%  -10.39%  (p=0.016 n=5+5)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-16    11.8s ± 2%   12.1s ±54%     ~     (p=0.151 n=5+5)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-16    12.1s ± 2%   10.5s ± 2%  -13.19%  (p=0.008 n=5+5)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-16    12.1s ± 4%   10.4s ± 2%  -14.22%  (p=0.008 n=5+5)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-16   12.8s ± 2%   10.9s ± 2%  -14.92%  (p=0.008 n=5+5)
```
