### PR TITLE
WBL loading: don't send empty buffers over chan

### DIFF
--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -886,7 +886,6 @@ func (wp *wblSubsetProcessor) reuseBuf() []record.RefSample {
 
 // processWBLSamples adds the samples it receives to the head and passes
 // the buffer received to an output channel for reuse.
-// Samples before the minValidTime timestamp are discarded.
 func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (unknownRefs uint64) {
 	defer close(wp.output)
 

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -749,7 +749,9 @@ func (h *Head) loadWBL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 					m = len(samples)
 				}
 				for i := 0; i < concurrency; i++ {
-					shards[i] = processors[i].reuseBuf()
+					if shards[i] == nil {
+						shards[i] = processors[i].reuseBuf()
+					}
 				}
 				for _, sam := range samples[:m] {
 					if r, ok := multiRef[sam.Ref]; ok {
@@ -759,7 +761,10 @@ func (h *Head) loadWBL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.
 					shards[mod] = append(shards[mod], sam)
 				}
 				for i := 0; i < concurrency; i++ {
-					processors[i].input <- shards[i]
+					if len(shards[i]) > 0 {
+						processors[i].input <- shards[i]
+						shards[i] = nil
+					}
 				}
 				samples = samples[m:]
 			}


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Based on https://github.com/prometheus/prometheus/pull/11319 in WAL loading:

If some shards did not get any samples mapped, the buffer will be empty so sending it over the chan to processWBLSamples() is a waste of time.

This resolves point #2 in [this comment](https://github.com/prometheus/prometheus/issues/11329#issuecomment-1702815572).

Thanks @fionaliao for the pairing session.
