### PR TITLE
PUPPETDB SD: Validate HTTP config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1826,6 +1826,10 @@ var expectedErrors = []struct {
 		errMsg:   "URL scheme must be 'http' or 'https'",
 	},
 	{
+		filename: "puppetdb_token_file.bad.yml",
+		errMsg:   "at most one of bearer_token & bearer_token_file must be configured",
+	},
+	{
 		filename: "hetzner_role.bad.yml",
 		errMsg:   "unknown role",
 	},

--- a/config/testdata/puppetdb_token_file.bad.yml
+++ b/config/testdata/puppetdb_token_file.bad.yml
@@ -1,0 +1,7 @@
+scrape_configs:
+- job_name: puppetdb
+  puppetdb_sd_configs:
+  - url: http://puppet
+    query: 'resources { type = "Package" and title = "httpd" }'
+    bearer_token: foo
+    bearer_token_file: foo

--- a/discovery/puppetdb/puppetdb.go
+++ b/discovery/puppetdb/puppetdb.go
@@ -115,7 +115,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if c.Query == "" {
 		return fmt.Errorf("query missing")
 	}
-	return nil
+	return c.HTTPClientConfig.Validate()
 }
 
 // Discovery provides service discovery functionality based


### PR DESCRIPTION
Related-to #12810

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
