### PR TITLE
UYUNI SD: Validate HTTP config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1894,6 +1894,10 @@ var expectedErrors = []struct {
 		errMsg:   "Uyuni SD configuration requires server host",
 	},
 	{
+		filename: "uyuni_token_file.bad.yml",
+		errMsg:   "at most one of bearer_token & bearer_token_file must be configured",
+	},
+	{
 		filename: "ionos_datacenter.bad.yml",
 		errMsg:   "datacenter id can't be empty",
 	},

--- a/config/testdata/uyuni_token_file.bad.yml
+++ b/config/testdata/uyuni_token_file.bad.yml
@@ -1,0 +1,8 @@
+scrape_configs:
+  - job_name: uyuni
+    uyuni_sd_configs:
+      - server: "server"
+        username: "username"
+        password: "password"
+        bearer_token: foo
+        bearer_token_file: foo

--- a/discovery/uyuni/uyuni.go
+++ b/discovery/uyuni/uyuni.go
@@ -146,7 +146,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if c.Password == "" {
 		return errors.New("Uyuni SD configuration requires a password")
 	}
-	return nil
+	return c.HTTPClientConfig.Validate()
 }
 
 func login(rpcclient *xmlrpc.Client, user, pass string, duration int) (string, error) {


### PR DESCRIPTION
Related-to #12810

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
