### PR TITLE
scrape: add metric for dropped targets

### DIFF
--- a/scrape/metrics.go
+++ b/scrape/metrics.go
@@ -34,6 +34,7 @@ type scrapeMetrics struct {
 	targetScrapePoolExceededTargetLimit prometheus.Counter
 	targetScrapePoolTargetLimit         *prometheus.GaugeVec
 	targetScrapePoolTargetsAdded        *prometheus.GaugeVec
+	targetScrapePoolTargetsDropped      *prometheus.GaugeVec
 	targetScrapePoolSymbolTableItems    *prometheus.GaugeVec
 	targetSyncIntervalLength            *prometheus.SummaryVec
 	targetSyncFailed                    *prometheus.CounterVec
@@ -127,6 +128,13 @@ func newScrapeMetrics(reg prometheus.Registerer) (*scrapeMetrics, error) {
 		prometheus.GaugeOpts{
 			Name: "prometheus_target_scrape_pool_targets",
 			Help: "Current number of targets in this scrape pool.",
+		},
+		[]string{"scrape_job"},
+	)
+	sm.targetScrapePoolTargetsDropped = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prometheus_target_scrape_pool_targets_dropped",
+			Help: "Current number of targets dropped from this scrape pool.",
 		},
 		[]string{"scrape_job"},
 	)
@@ -242,6 +250,7 @@ func newScrapeMetrics(reg prometheus.Registerer) (*scrapeMetrics, error) {
 		sm.targetScrapePoolExceededTargetLimit,
 		sm.targetScrapePoolTargetLimit,
 		sm.targetScrapePoolTargetsAdded,
+		sm.targetScrapePoolTargetsDropped,
 		sm.targetScrapePoolSymbolTableItems,
 		sm.targetSyncFailed,
 		// Used by targetScraper.
@@ -283,6 +292,7 @@ func (sm *scrapeMetrics) Unregister() {
 	sm.reg.Unregister(sm.targetScrapePoolExceededTargetLimit)
 	sm.reg.Unregister(sm.targetScrapePoolTargetLimit)
 	sm.reg.Unregister(sm.targetScrapePoolTargetsAdded)
+	sm.reg.Unregister(sm.targetScrapePoolTargetsDropped)
 	sm.reg.Unregister(sm.targetScrapePoolSymbolTableItems)
 	sm.reg.Unregister(sm.targetSyncFailed)
 	sm.reg.Unregister(sm.targetScrapeExceededBodySizeLimit)

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -274,6 +274,7 @@ func (sp *scrapePool) stop() {
 		sp.metrics.targetScrapePoolSyncsCounter.DeleteLabelValues(sp.config.JobName)
 		sp.metrics.targetScrapePoolTargetLimit.DeleteLabelValues(sp.config.JobName)
 		sp.metrics.targetScrapePoolTargetsAdded.DeleteLabelValues(sp.config.JobName)
+		sp.metrics.targetScrapePoolTargetsDropped.DeleteLabelValues(sp.config.JobName)
 		sp.metrics.targetScrapePoolSymbolTableItems.DeleteLabelValues(sp.config.JobName)
 		sp.metrics.targetSyncIntervalLength.DeleteLabelValues(sp.config.JobName)
 		sp.metrics.targetSyncFailed.DeleteLabelValues(sp.config.JobName)
@@ -455,6 +456,7 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 	}
 	sp.metrics.targetScrapePoolSymbolTableItems.WithLabelValues(sp.config.JobName).Set(float64(sp.symbolTable.Len()))
 	sp.targetMtx.Unlock()
+	sp.metrics.targetScrapePoolTargetsDropped.WithLabelValues(sp.config.JobName).Set(float64(sp.droppedTargetsCount))
 	sp.sync(all)
 	sp.checkSymbolTable()
 


### PR DESCRIPTION
Adds a `prometheus_target_scrape_pool_targets_dropped` metric to track the number of targets dropped from the current scrape pool.

Fixes: #12767.
***
```
┌[rexagod@nebuchadnezzar] [/dev/ttys008]
└[~]> curl -fs '0.0.0.0:9090/api/v1/targets' | jq '.data.droppedTargets | length'
1
┌[rexagod@nebuchadnezzar] [/dev/ttys008]
└[~]> curl -fs '0.0.0.0:9090/metrics' | grep 'prometheus_target_scrape_pool_targets_dropped'
# HELP prometheus_target_scrape_pool_targets_dropped Current number of targets dropped from this scrape pool.
# TYPE prometheus_target_scrape_pool_targets_dropped gauge
prometheus_target_scrape_pool_targets_dropped{scrape_job="prometheus"} 1
```