### PR TITLE
build(deps): bump lru-cache from 7.18.3 to 11.0.1 in /web/ui

### DIFF
--- a/web/ui/module/codemirror-promql/package.json
+++ b/web/ui/module/codemirror-promql/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/prometheus/prometheus/blob/main/web/ui/module/codemirror-promql/README.md",
   "dependencies": {
     "@prometheus-io/lezer-promql": "0.300.0-beta.0",
-    "lru-cache": "^7.18.3"
+    "lru-cache": "^11.0.1"
   },
   "devDependencies": {
     "@codemirror/autocomplete": "^6.17.0",

--- a/web/ui/module/codemirror-promql/src/client/prometheus.ts
+++ b/web/ui/module/codemirror-promql/src/client/prometheus.ts
@@ -14,7 +14,7 @@
 import { FetchFn } from './index';
 import { Matcher } from '../types';
 import { labelMatchersToString } from '../parser';
-import LRUCache from 'lru-cache';
+import { LRUCache } from 'lru-cache';
 
 export interface MetricMetadata {
   type: string;
@@ -292,7 +292,10 @@ class Cache {
   private flags: Record<string, string>;
 
   constructor(config?: CacheConfig) {
-    const maxAge: LRUCache.LimitedByTTL = { ttl: config && config.maxAge ? config.maxAge : 5 * 60 * 1000 };
+    const maxAge = {
+      ttl: config && config.maxAge ? config.maxAge : 5 * 60 * 1000,
+      ttlAutopurge: false,
+    };
     this.completeAssociation = new LRUCache<string, Map<string, Set<string>>>(maxAge);
     this.metricMetadata = {};
     this.labelValues = new LRUCache<string, string[]>(maxAge);

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -163,7 +163,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@prometheus-io/lezer-promql": "0.300.0-beta.0",
-        "lru-cache": "^7.18.3"
+        "lru-cache": "^11.0.1"
       },
       "devDependencies": {
         "@codemirror/autocomplete": "^6.17.0",
@@ -7050,12 +7050,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
+      "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
       "engines": {
-        "node": ">=12"
+        "node": "20 || >=22"
       }
     },
     "node_modules/lz-string": {


### PR DESCRIPTION
- Bumps [lru-cache](https://github.com/isaacs/node-lru-cache) from from 7.18.3 to 10.0.1.
  - replace ` LRUCache ` import -> `{ LRUCache }`, see [changelog](https://github.com/isaacs/node-lru-cache/blob/main/CHANGELOG.md#900)
  - help  dependabot #14916
  - follow-up #12768 

- labels 
  - https://github.com/prometheus/prometheus/labels/dependencies
  - https://github.com/prometheus/prometheus/labels/javascript
  - https://github.com/prometheus/prometheus/labels/component%2Fui