### PR TITLE
Support specifying series matchers to analyze tsdb

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -218,6 +218,7 @@ func main() {
 	analyzeBlockID := tsdbAnalyzeCmd.Arg("block id", "Block to analyze (default is the last block).").String()
 	analyzeLimit := tsdbAnalyzeCmd.Flag("limit", "How many items to show in each list.").Default("20").Int()
 	analyzeRunExtended := tsdbAnalyzeCmd.Flag("extended", "Run extended analysis.").Bool()
+	analyzeMatchers := tsdbAnalyzeCmd.Flag("match", "Series selector to analyze. Only 1 set of matchers is supported now.").String()
 
 	tsdbListCmd := tsdbCmd.Command("list", "List tsdb blocks.")
 	listHumanReadable := tsdbListCmd.Flag("human-readable", "Print human readable values.").Short('r').Bool()
@@ -372,7 +373,7 @@ func main() {
 		os.Exit(checkErr(benchmarkWrite(*benchWriteOutPath, *benchSamplesFile, *benchWriteNumMetrics, *benchWriteNumScrapes)))
 
 	case tsdbAnalyzeCmd.FullCommand():
-		os.Exit(checkErr(analyzeBlock(ctx, *analyzePath, *analyzeBlockID, *analyzeLimit, *analyzeRunExtended)))
+		os.Exit(checkErr(analyzeBlock(ctx, *analyzePath, *analyzeBlockID, *analyzeLimit, *analyzeRunExtended, *analyzeMatchers)))
 
 	case tsdbListCmd.FullCommand():
 		os.Exit(checkErr(listBlocks(*listPath, *listHumanReadable)))

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -488,6 +488,7 @@ Analyze churn, label pair cardinality and compaction efficiency.
 | --- | --- | --- |
 | <code class="text-nowrap">--limit</code> | How many items to show in each list. | `20` |
 | <code class="text-nowrap">--extended</code> | Run extended analysis. |  |
+| <code class="text-nowrap">--match</code> | Series selector to analyze. Only 1 set of matchers is supported now. |  |
 
 
 


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Add `match` flag to specify matchers to analyze specific series.
Example usage below. Only series that matched `up{job="thanos"}` will be queried.
```
promtool tsdb analyze data 01H8QNNSR7SHY0W001YB29WTBZ --match='up{job="thanos"}'

Block ID: 01H8QNNSR7SHY0W001YB29WTBZ
Duration: 1h59m59.314s
Total Series: 60
Matcher: up{job="thanos"}
Label names: 3
Matched series: 1
Postings (unique label pairs): 3
Postings entries (total label pairs): 3

Label pairs most involved in churning:
0 job=thanos
0 __name__=up
0 instance=localhost:10906

Label names most involved in churning:
0 __name__
0 instance
0 job

Most common label pairs:
1 __name__=up
1 instance=localhost:10906
1 job=thanos

Label names with highest cumulative label value length:
15 instance
6 job
2 __name__

Highest cardinality labels:
1 __name__
1 instance
1 job

Highest cardinality metric names:
1 up
```
