### PR TITLE
Add User Defined Functions to PromQL

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -652,6 +652,12 @@ func main() {
 			EnablePerStepStats:   cfg.enablePerStepStats,
 		}
 
+		for _, udfCfg := range cfgFile.UDFConfigs {
+			if err := promql.AddUDFfromConfig(udfCfg); err != nil {
+				level.Error(logger).Log("msg", "Failed to register UDF", "err", err)
+				os.Exit(1)
+			}
+		}
 		queryEngine = promql.NewEngine(opts)
 
 		ruleManager = rules.NewManager(&rules.ManagerOptions{

--- a/config/config.go
+++ b/config/config.go
@@ -1115,13 +1115,21 @@ func ValidateUDFInputTypes(inputTypes []parser.ValueType) error {
 	if len(inputTypes) == 0 {
 		return errors.New("must have at least 1 input type for UDF")
 	}
-	if inputTypes[0] != parser.ValueTypeMatrix && inputTypes[0] != parser.ValueTypeVector {
-		return fmt.Errorf("first input argument for UDF must be matrix or vector, but got %s", inputTypes[0])
-	}
-	for _, t := range inputTypes[1:] {
-		if t != parser.ValueTypeScalar && t != parser.ValueTypeString {
-			return fmt.Errorf("additional input arguments for UDF must be scalar or string, but got %s", t)
+	switch inputTypes[0] {
+	case parser.ValueTypeMatrix:
+		for _, t := range inputTypes[1:] {
+			if t != parser.ValueTypeScalar {
+				return fmt.Errorf("additional input arguments for matrix-based UDF must be scalar, but got %s", t)
+			}
 		}
+	case parser.ValueTypeVector:
+		for _, t := range inputTypes[1:] {
+			if t != parser.ValueTypeScalar && t != parser.ValueTypeString {
+				return fmt.Errorf("additional input arguments for vector-based UDF must be scalar or string, but got %s", t)
+			}
+		}
+	default:
+		return fmt.Errorf("first input argument for UDF must be matrix or vector, but got %s", inputTypes[0])
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
+	github.com/d5/tengo/v2 v2.16.1 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/aws/aws-sdk-go v1.44.317
 	github.com/cespare/xxhash/v2 v2.2.0
+	github.com/d5/tengo/v2 v2.16.1
 	github.com/dennwc/varint v1.0.0
 	github.com/digitalocean/godo v1.99.0
 	github.com/docker/docker v24.0.4+incompatible
@@ -92,7 +93,6 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.0.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/d5/tengo/v2 v2.16.1 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/d5/tengo/v2 v2.16.1 h1:/N6dqiGu9toqANInZEOQMM8I06icdZnmb+81DG/lZdw=
+github.com/d5/tengo/v2 v2.16.1/go.mod h1:XRGjEs5I9jYIKTxly6HCF8oiiilk5E/RYXOZ5b0DZC8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -24,7 +24,6 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -1388,12 +1387,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 		}, e.Param, e.Expr)
 
 	case *parser.Call:
-		call, ok := FunctionCalls[e.Func.Name]
-		if !ok && strings.HasPrefix(e.Func.Name, "udf_") {
-			call = genFunctionCall(e.Func.Name)
-			FunctionCalls[e.Func.Name] = call
-		}
-
+		call := FunctionCalls[e.Func.Name]
 		if e.Func.Name == "timestamp" {
 			// Matrix evaluation always returns the evaluation time,
 			// so this function needs special handling when given

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -1387,7 +1388,12 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 		}, e.Param, e.Expr)
 
 	case *parser.Call:
-		call := FunctionCalls[e.Func.Name]
+		call, ok := FunctionCalls[e.Func.Name]
+		if !ok && strings.HasPrefix(e.Func.Name, "udf_") {
+			call = genFunctionCall(e.Func.Name)
+			FunctionCalls[e.Func.Name] = call
+		}
+
 		if e.Func.Name == "timestamp" {
 			// Matrix evaluation always returns the evaluation time,
 			// so this function needs special handling when given

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -396,6 +396,17 @@ var Functions = map[string]*Function{
 	},
 }
 
+func AddFunction(name string) {
+	if _, ok := Functions[name]; ok {
+		return
+	}
+	Functions[name] = &Function{
+		Name:       name,
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+	}
+}
+
 // getFunction returns a predefined Function object for the given name.
 func getFunction(name string, functions map[string]*Function) (*Function, bool) {
 	function, ok := functions[name]

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -396,13 +396,13 @@ var Functions = map[string]*Function{
 	},
 }
 
-func AddFunction(name string) {
+func AddFunction(name string, inputTypes []ValueType) {
 	if _, ok := Functions[name]; ok {
 		return
 	}
 	Functions[name] = &Function{
 		Name:       name,
-		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ArgTypes:   inputTypes,
 		ReturnType: ValueTypeVector,
 	}
 }

--- a/promql/udfs.go
+++ b/promql/udfs.go
@@ -208,6 +208,7 @@ func init() {
 		}
 		funcMap[name] = c
 		parser.AddFunction(name)
+		FunctionCalls[name] = genFunctionCall(name)
 	}
 	for _, name := range []string{"mad_over_time", "std_dev_over_time"} {
 		parser.AddFunction(name)

--- a/promql/udfs.go
+++ b/promql/udfs.go
@@ -1,0 +1,314 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"math"
+
+	"github.com/d5/tengo/v2"
+	"github.com/d5/tengo/v2/stdlib"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+var (
+	utilSrc = `
+		rand := import("rand")
+
+		_quicksort := func(arr, left, right, less) {
+			if right <= left {
+				return
+			}
+			i := left
+		
+			for j := left; j < right; j++ {
+				if less(arr[j], arr[right]) {
+					if i != j {
+						tmp := arr[i]
+						arr[i] = arr[j]
+						arr[j] = tmp
+					}
+					i++
+				}
+			}
+		
+			if i != right {
+				tmp := arr[i]
+				arr[i] = arr[right]
+				arr[right] = tmp
+			}
+		
+			_quicksort(arr, left, i-1, less)
+			_quicksort(arr, i+1, right, less)
+		}
+		
+		// sorts in place. https://github.com/d5/tengo/pull/416
+		quicksort := func(arr, less) {
+			_quicksort(arr, 0, len(arr)-1, less)
+		}
+
+		median_simple := func(seq) {
+			n := len(seq)
+			if n == 0 {
+				return error("cannot calculate median of empty array")
+			}
+			quicksort(seq, func(i, j) {
+				return i < j
+			})
+			if n % 2 == 0 {
+				return (seq[n/2-1] + seq[n/2]) / 2
+			} else {
+				return seq[n/2]
+			}
+		}
+
+		_quickselect := func(l, k, pivot_fn) {
+			if len(l) == 1 {
+				if k != 0 {
+					return error("invalid k for 1-element list")
+				}
+				return l[0]
+			}
+
+			pivot := pivot_fn(l)
+
+			lows := []
+			highs := []
+			pivot_length := 0
+			for x in l {
+				if x < pivot {
+					lows = append(lows, x)
+				} else if x > pivot {
+					highs = append(highs, x)
+				} else {
+					pivot_length++
+				}
+			}
+			low_length := len(lows)
+
+			if k < low_length {
+				return _quickselect(lows, k, pivot_fn)
+			} else if k < (low_length + pivot_length) {
+				return pivot
+			} else {
+				return _quickselect(highs, k - low_length - pivot_length, pivot_fn)
+			}
+		}
+
+		_quickselect_median := func(l, pivot_fn) {
+			length := len(l)
+			half_length := length / 2
+			if length % 2 == 1 {
+				return _quickselect(l, half_length, pivot_fn)
+			} else {
+				return 0.5 * (_quickselect(l, half_length - 1, pivot_fn) + _quickselect(l, half_length, pivot_fn))
+			}
+		}
+
+		random_choice := func(seq) {
+			return seq[rand.intn(len(seq))]
+		}
+
+		// https://rcoh.me/posts/linear-time-median-finding/
+		median := func(seq) {
+			return _quickselect_median(seq, random_choice)
+		}
+
+		export {
+			quicksort: quicksort,
+			median: median
+		}
+	`
+	srcMap = map[string]string{
+		"udf_mad_over_time": `
+			// fmt := import("fmt")
+			math := import("math")
+			util := import("util")
+
+			mad := func(seq) {
+				median := util.median(seq)
+				if is_error(median) {
+					return median
+				}
+				deltas := []
+				for x in seq {
+					deltas = append(deltas, math.abs(x-median))
+				}
+				// fmt.println(deltas)
+				return util.median(deltas)
+			}
+
+			output := mad(input)
+		`,
+		"udf_std_dev_simple_over_time": `
+			math := import("math")
+
+			std := func(seq) {
+				n := len(seq)
+				if n == 0 {
+					return error("cannot calculate mean of empty array")
+				}
+				sum := 0
+				for x in seq {
+					sum += x
+				}
+				mean := sum / n
+				variance := 0
+				for x in seq {
+					variance += math.pow(x-mean, 2)
+				}
+				variance /= n
+				return math.sqrt(variance)
+			}
+
+			output := std(input)
+		`,
+		"udf_std_dev_over_time": `
+			math := import("math")
+
+			std := func(seq) {
+				count := 0
+				mean := 0
+				aux := 0
+				for x in seq {
+					count++
+					delta := x - mean
+					mean += delta/count
+					aux += delta*(x-mean)
+				}
+				if count == 0 {
+					return error("cannot calculate mean of empty array")
+				}
+				return math.sqrt(aux / count)
+			}
+
+			output := std(input)
+		`,
+	}
+	funcMap = make(map[string]*tengo.Compiled, len(srcMap))
+)
+
+func init() {
+	for name, src := range srcMap {
+		c, err := compileSrc(src)
+		if err != nil {
+			panic(err)
+		}
+		funcMap[name] = c
+		parser.AddFunction(name)
+	}
+	for _, name := range []string{"mad_over_time", "std_dev_over_time"} {
+		parser.AddFunction(name)
+	}
+	FunctionCalls["mad_over_time"] = funcMadOverTime
+	FunctionCalls["std_dev_over_time"] = funcStdDevOverTime
+}
+
+func compileSrc(src string) (*tengo.Compiled, error) {
+	s := tengo.NewScript([]byte(src))
+	mods := stdlib.GetModuleMap("math", "rand") //, "fmt")
+	// mods := stdlib.GetModuleMap(stdlib.AllModuleNames()...)
+	mods.AddSourceModule("util", []byte(utilSrc))
+	s.SetImports(mods)
+	s.Add("input", []interface{}{})
+	return s.Compile()
+}
+
+func runCustomFunc(funcName string, input []FPoint) (float64, error) {
+	inputInterface := make([]interface{}, len(input))
+	for i, f := range input {
+		inputInterface[i] = f.F
+	}
+	c := funcMap[funcName].Clone()
+	if err := c.Set("input", inputInterface); err != nil {
+		return 0, err
+	}
+	if err := c.Run(); err != nil {
+		return 0, err
+	}
+	output := c.Get("output")
+	if err := output.Error(); err != nil {
+		return 0, err
+	}
+	return output.Float(), nil
+}
+
+func genFunctionCall(funcName string) FunctionCall {
+	return func(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+		if len(vals[0].(Matrix)[0].Floats) == 0 {
+			// TODO(beorn7): The passed values only contain
+			// histograms. This ignores histograms for now. If
+			// there are only histograms, we have to return without adding
+			// anything to enh.Out.
+			return enh.Out, nil
+		}
+		return aggrOverTime(vals, enh, func(s Series) float64 {
+			res, err := runCustomFunc(funcName, s.Floats)
+			if err != nil {
+				return 0
+			}
+			return res
+		}), nil
+	}
+}
+
+// below is just for benchmark comparison, should be removed before PR is merged
+
+// duplicate of funcStddevOverTime that doesn't use kahan sum so it is comparable to funcUdfStdDevOverTime
+// === std_dev_over_time(Matrix parser.ValueTypeMatrix) (Vector, Annotations) ===
+func funcStdDevOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+	if len(vals[0].(Matrix)[0].Floats) == 0 {
+		// TODO(beorn7): The passed values only contain
+		// histograms. std_dev_over_time ignores histograms for now. If
+		// there are only histograms, we have to return without adding
+		// anything to enh.Out.
+		return enh.Out, nil
+	}
+	return aggrOverTime(vals, enh, func(s Series) float64 {
+		var count float64
+		var mean float64
+		var aux float64
+		for _, f := range s.Floats {
+			count++
+			delta := f.F - mean
+			mean += delta / count
+			aux += delta * (f.F - mean)
+		}
+		return math.Sqrt(aux / count)
+	}), nil
+}
+
+// === mad_over_time(Matrix parser.ValueTypeMatrix) (Vector, Annotations) ===
+func funcMadOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+	if len(vals[0].(Matrix)[0].Floats) == 0 {
+		// TODO(beorn7): The passed values only contain
+		// histograms. mad_over_time ignores histograms for now. If
+		// there are only histograms, we have to return without adding
+		// anything to enh.Out.
+		return enh.Out, nil
+	}
+	return aggrOverTime(vals, enh, func(s Series) float64 {
+		values := make(vectorByValueHeap, 0, len(s.Floats))
+		for _, f := range s.Floats {
+			values = append(values, Sample{F: f.F})
+		}
+		median := quantile(0.5, values)
+		values = make(vectorByValueHeap, 0, len(s.Floats))
+		for _, f := range s.Floats {
+			values = append(values, Sample{F: math.Abs(f.F - median)})
+		}
+		return quantile(0.5, values)
+	}), nil
+}

--- a/promql/udfs.go
+++ b/promql/udfs.go
@@ -251,7 +251,9 @@ func compileSrc(src string, modules []string, useUtil bool, inputTypes []parser.
 	s.SetImports(mods)
 	for i := range inputTypes {
 		var interfaceType interface{}
-		s.Add(makeInputName(i), interfaceType)
+		if err := s.Add(makeInputName(i), interfaceType); err != nil {
+			return nil, err
+		}
 	}
 	return s.Compile()
 }

--- a/promql/udfs.go
+++ b/promql/udfs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/d5/tengo/v2"
 	"github.com/d5/tengo/v2/stdlib"
 
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/util/annotations"
 )
@@ -212,6 +213,10 @@ func init() {
 	}
 	FunctionCalls["mad_over_time"] = funcMadOverTime
 	FunctionCalls["std_dev_over_time"] = funcStdDevOverTime
+}
+
+func AddUDFfromConfig(cfg *config.UDFConfig) error {
+	return addUDF("udf_"+cfg.Name, cfg.Src, cfg.Modules, cfg.UseUtil)
 }
 
 func addUDF(name, src string, modules []string, useUtil bool) error {

--- a/promql/udfs_test.go
+++ b/promql/udfs_test.go
@@ -1,0 +1,182 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/util/teststorage"
+)
+
+func TestMadOverTime(t *testing.T) {
+	cases := []struct {
+		series      []int
+		expectedRes float64
+	}{
+		{
+			series:      []int{4, 6, 2, 1, 999, 1, 2},
+			expectedRes: 1,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			engine := newTestEngine()
+			storage := teststorage.New(t)
+			t.Cleanup(func() { storage.Close() })
+
+			seriesName := "float_series"
+
+			ts := int64(0)
+			app := storage.Appender(context.Background())
+			lbls := labels.FromStrings("__name__", seriesName)
+			var err error
+			for _, num := range c.series {
+				_, err = app.Append(0, lbls, ts, float64(num))
+				require.NoError(t, err)
+				ts += int64(1 * time.Minute / time.Millisecond)
+			}
+			require.NoError(t, app.Commit())
+
+			queryAndCheck := func(queryString string, exp Vector) {
+				qry, err := engine.NewInstantQuery(context.Background(), storage, nil, queryString, timestamp.Time(ts))
+				require.NoError(t, err)
+
+				res := qry.Exec(context.Background())
+				require.NoError(t, res.Err)
+
+				vector, err := res.Vector()
+				require.NoError(t, err)
+
+				require.Equal(t, exp, vector)
+			}
+
+			queryString := fmt.Sprintf(`mad_over_time(%s[%dm])`, seriesName, len(c.series))
+			queryAndCheck(queryString, []Sample{{T: ts, F: c.expectedRes, Metric: labels.EmptyLabels()}})
+
+			queryString = fmt.Sprintf(`udf_mad_over_time(%s[%dm])`, seriesName, len(c.series))
+			queryAndCheck(queryString, []Sample{{T: ts, F: c.expectedRes, Metric: labels.EmptyLabels()}})
+		})
+	}
+}
+
+func compareAggsOverTime(t *testing.T, aggName string) {
+	for i := 0; i < 10; i++ {
+		t.Run(fmt.Sprintf("iteration %d", i), func(t *testing.T) {
+			engine := newTestEngine()
+			storage := teststorage.New(t)
+			t.Cleanup(func() { storage.Close() })
+
+			seriesName := "float_series"
+
+			ts := int64(0)
+			app := storage.Appender(context.Background())
+			lbls := labels.FromStrings("__name__", seriesName)
+			n := 100
+			var err error
+			for j := 0; j < n; j++ {
+				num := rand.Float64() * 1000
+				_, err = app.Append(0, lbls, ts, num)
+				require.NoError(t, err)
+				ts += int64(1 * time.Minute / time.Millisecond)
+			}
+			require.NoError(t, app.Commit())
+
+			queryAndCheck := func(queryString, queryString2 string) {
+				qry, err := engine.NewInstantQuery(context.Background(), storage, nil, queryString, timestamp.Time(ts))
+				require.NoError(t, err)
+
+				res := qry.Exec(context.Background())
+				require.NoError(t, res.Err)
+
+				vector, err := res.Vector()
+				require.NoError(t, err)
+
+				qry, err = engine.NewInstantQuery(context.Background(), storage, nil, queryString2, timestamp.Time(ts))
+				require.NoError(t, err)
+
+				res = qry.Exec(context.Background())
+				require.NoError(t, res.Err)
+
+				vector2, err := res.Vector()
+				require.NoError(t, err)
+
+				require.Equal(t, vector[0].F, vector2[0].F)
+				// require.InEpsilon(t, vector[0].F, vector2[0].F, 1e-12)
+			}
+
+			queryString := fmt.Sprintf(`%s_over_time(%s[%dm])`, aggName, seriesName, n)
+			queryString2 := fmt.Sprintf(`udf_%s_over_time(%s[%dm])`, aggName, seriesName, n)
+			queryAndCheck(queryString, queryString2)
+		})
+	}
+}
+
+func TestMadOverTimeComparison(t *testing.T) {
+	compareAggsOverTime(t, "mad")
+}
+
+func TestStdDevOverTimeComparison(t *testing.T) {
+	compareAggsOverTime(t, "std_dev")
+}
+
+func benchmarkAggOverTime(b *testing.B, aggName string) {
+	engine := newTestEngine()
+	storage := teststorage.New(b)
+	b.Cleanup(func() { storage.Close() })
+
+	seriesName := "float_series"
+
+	ts := int64(0)
+	app := storage.Appender(context.Background())
+	lbls := labels.FromStrings("__name__", seriesName)
+	n := 100
+	var err error
+	for j := 0; j < n; j++ {
+		num := rand.Float64() * 1000
+		_, err = app.Append(0, lbls, ts, num)
+		require.NoError(b, err)
+		ts += int64(1 * time.Minute / time.Millisecond)
+	}
+	require.NoError(b, app.Commit())
+
+	query := func(queryString string) {
+		qry, _ := engine.NewInstantQuery(context.Background(), storage, nil, queryString, timestamp.Time(ts))
+		res := qry.Exec(context.Background())
+		res.Vector()
+	}
+
+	queryString := fmt.Sprintf(`%s_over_time(%s[%dm])`, aggName, seriesName, n)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		query(queryString)
+	}
+}
+
+func BenchmarkMadOverTime(b *testing.B) {
+	benchmarkAggOverTime(b, "mad")
+}
+
+func BenchmarkStdDevOverTime(b *testing.B) {
+	benchmarkAggOverTime(b, "std_dev")
+}

--- a/promql/udfs_test.go
+++ b/promql/udfs_test.go
@@ -16,16 +16,144 @@ package promql
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/prometheus/prometheus/util/teststorage"
 )
+
+var srcMap = map[string]string{
+	"udf_mad_over_time": `
+		// fmt := import("fmt")
+		math := import("math")
+		util := import("util")
+
+		mad := func(seq) {
+			median := util.median(seq)
+			if is_error(median) {
+				return median
+			}
+			deltas := []
+			for x in seq {
+				deltas = append(deltas, math.abs(x-median))
+			}
+			// fmt.println(deltas)
+			return util.median(deltas)
+		}
+
+		output := mad(input0)
+	`,
+	// "udf_std_dev_simple_over_time": `
+	// 	math := import("math")
+
+	// 	std := func(seq) {
+	// 		n := len(seq)
+	// 		if n == 0 {
+	// 			return error("cannot calculate mean of empty array")
+	// 		}
+	// 		sum := 0
+	// 		for x in seq {
+	// 			sum += x
+	// 		}
+	// 		mean := sum / n
+	// 		variance := 0
+	// 		for x in seq {
+	// 			variance += math.pow(x-mean, 2)
+	// 		}
+	// 		variance /= n
+	// 		return math.sqrt(variance)
+	// 	}
+
+	// 	output := std(input0)
+	// `,
+	"udf_std_dev_over_time": `
+		math := import("math")
+
+		std := func(seq) {
+			count := 0
+			mean := 0
+			aux := 0
+			for x in seq {
+				count++
+				delta := x - mean
+				mean += delta/count
+				aux += delta*(x-mean)
+			}
+			if count == 0 {
+				return error("cannot calculate mean of empty array")
+			}
+			return math.sqrt(aux / count)
+		}
+
+		output := std(input0)
+	`,
+}
+
+func init() {
+	for name, src := range srcMap {
+		inputTypes := []parser.ValueType{parser.ValueTypeMatrix}
+		if err := config.ValidateUDFInputTypes(inputTypes); err != nil {
+			panic(err)
+		}
+		err := addUDF(name, src, []string{"math", "rand"}, true, inputTypes)
+		if err != nil {
+			panic(err)
+		}
+	}
+	for _, name := range []string{"mad_over_time", "std_dev_over_time"} {
+		parser.AddFunction(name, []parser.ValueType{parser.ValueTypeMatrix})
+	}
+	FunctionCalls["mad_over_time"] = funcMadOverTime
+	FunctionCalls["std_dev_over_time"] = funcStdDevOverTime
+}
+
+// duplicate of funcStddevOverTime that doesn't use kahan sum so it is comparable to funcUdfStdDevOverTime
+// === std_dev_over_time(Matrix parser.ValueTypeMatrix) (Vector, Annotations) ===
+func funcStdDevOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+	if len(vals[0].(Matrix)[0].Floats) == 0 {
+		return enh.Out, nil
+	}
+	return aggrOverTime(vals, enh, func(s Series) float64 {
+		var count float64
+		var mean float64
+		var aux float64
+		for _, f := range s.Floats {
+			count++
+			delta := f.F - mean
+			mean += delta / count
+			aux += delta * (f.F - mean)
+		}
+		return math.Sqrt(aux / count)
+	}), nil
+}
+
+// === mad_over_time(Matrix parser.ValueTypeMatrix) (Vector, Annotations) ===
+func funcMadOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+	if len(vals[0].(Matrix)[0].Floats) == 0 {
+		return enh.Out, nil
+	}
+	return aggrOverTime(vals, enh, func(s Series) float64 {
+		values := make(vectorByValueHeap, 0, len(s.Floats))
+		for _, f := range s.Floats {
+			values = append(values, Sample{F: f.F})
+		}
+		median := quantile(0.5, values)
+		values = make(vectorByValueHeap, 0, len(s.Floats))
+		for _, f := range s.Floats {
+			values = append(values, Sample{F: math.Abs(f.F - median)})
+		}
+		return quantile(0.5, values)
+	}), nil
+}
 
 func TestMadOverTime(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
This PR adds User Defined Functions (UDFs) to PromQL.

Why use UDFs?
- Users have asked for functions that we are reluctant to include, e.g. [mad_over_time](https://github.com/prometheus/prometheus/issues/5514) (Median absolute deviation, similar to standard deviation but ignores outliers)
- Similar products like VictoriaMetrics have implemented these functions or something similar
- It'd be good to give users the flexibility to define their own functions, without having to make the case for it being needed and waiting for it to be added to Prometheus, and so they can use their preferred variety (e.g. there are different kinds of MAD functions)
- We would not need to support a lot of additional functions, and we would not have a lot of rarely-used functions to confuse users

Limitations of the current implementation:
- Slower than native functions (see below benchmarks)
- Adds a dependency on a new library (which is not updated that often)
- Allowing scripting may add security risks
- Uses a lesser known scripting language, but one that is simple and based on go ([Tengo](https://github.com/d5/tengo))
- UDFs won't appear in query autocomplete
- UDFs are shared across the whole instance, not separated by tenant
- Cannot aggregate multiple series
- Input and output types are limited, but they cover most of the functions that we currently have
- Does not support native histograms yet, but this is theoretically possible to add though I haven't tested it

Example YML (add to main Prometheus config):
```
udfs:
  - name: mad_over_time
    input_types:
      - matrix
    modules:
      - math
    util: true
    src: |
      math := import("math")
      util := import("util")

      mad := func(seq) {
        median := util.median(seq)
        if is_error(median) {
          return error("cannot compute median")
        }
        deltas := []
        for x in seq {
          deltas = append(deltas, math.abs(x-median))
        }
        return util.median(deltas)
      }

      output := mad(input0)
```

Benchmark results (before is native function, after is UDF):
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                  │ BenchmarkStdDevOverTime_before.txt │  BenchmarkStdDevOverTime_after.txt   │
                  │               sec/op               │   sec/op     vs base                 │
StdDevOverTime-16                          16.22µ ± 1%   52.71µ ± 3%  +224.97% (p=0.000 n=10)

                  │ BenchmarkStdDevOverTime_before.txt │   BenchmarkStdDevOverTime_after.txt    │
                  │                B/op                │     B/op       vs base                 │
StdDevOverTime-16                         10.32Ki ± 0%   109.33Ki ± 0%  +959.63% (p=0.000 n=10)

                  │ BenchmarkStdDevOverTime_before.txt │  BenchmarkStdDevOverTime_after.txt   │
                  │             allocs/op              │  allocs/op   vs base                 │
StdDevOverTime-16                           145.0 ± 0%   1056.0 ± 0%  +628.28% (p=0.000 n=10)

goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
               │ BenchmarkMadOverTime_before.txt │     BenchmarkMadOverTime_after.txt     │
               │             sec/op              │    sec/op     vs base                  │
MadOverTime-16                       26.15µ ± 3%   288.25µ ± 4%  +1002.11% (p=0.000 n=10)

               │ BenchmarkMadOverTime_before.txt │     BenchmarkMadOverTime_after.txt      │
               │              B/op               │     B/op       vs base                  │
MadOverTime-16                      19.87Ki ± 0%   245.13Ki ± 0%  +1133.71% (p=0.000 n=10)

               │ BenchmarkMadOverTime_before.txt │    BenchmarkMadOverTime_after.txt     │
               │            allocs/op            │  allocs/op   vs base                  │
MadOverTime-16                        149.0 ± 0%   4052.0 ± 0%  +2619.46% (p=0.000 n=10)
```
BenchmarkStdDevOverTime is a better comparison as the native function and UDF are implemented in very similar ways. For BenchmarkMadOverTime, the implementations are very different, and there is room to optimise the UDF performance by using more efficient methods to calculate the median.