### PR TITLE
enhance promtool tsdb analyze command

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -738,16 +738,21 @@ func displayHistogram(dataType string, datas []int, total int) {
 	start, end, step := generateBucket(datas[0], datas[len(datas)-1])
 	sum := 0
 	buckets := make([]int, (end-start)/step+1)
+	maxCount := 0
 	for _, c := range datas {
 		sum += c
 		buckets[(c-start)/step]++
+		if buckets[(c-start)/step] > maxCount {
+			maxCount = buckets[(c-start)/step]
+		}
 	}
 	avg := sum / len(datas)
 	fmt.Printf("%s (min/max/avg): %d/%d/%d\n", dataType, datas[0], datas[len(datas)-1], avg)
 	maxLen := strconv.Itoa(len(fmt.Sprintf("%d", end)))
+	maxCountLen := strconv.Itoa(len(fmt.Sprintf("%d", maxCount)))
 	for bucket, count := range buckets {
 		percentage := 100.0 * count / total
-		fmt.Printf("[%"+maxLen+"d, %"+maxLen+"d]: %d %s\n", bucket*step+start+1, (bucket+1)*step+start, count, strings.Repeat("#", percentage))
+		fmt.Printf("[%"+maxLen+"d, %"+maxLen+"d]: %"+maxCountLen+"d %s\n", bucket*step+start+1, (bucket+1)*step+start, count, strings.Repeat("#", percentage))
 	}
 	fmt.Println()
 }

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -638,25 +638,16 @@ func analyzeCompaction(ctx context.Context, block tsdb.BlockReader, indexr tsdb.
 	}
 
 	fmt.Printf("\nCompaction analysis:\n")
-	fmt.Println("Fullness: Amount of samples in float chunks")
-	displayHistogram("sample count per float chunk", floatChunkSamplesCount, totalChunks)
 	fmt.Println()
+	displayHistogram("samples per float chunk", floatChunkSamplesCount, totalChunks)
 
-	fmt.Println("Size of float chunks")
 	displayHistogram("bytes per float chunk", floatChunkSize, totalChunks)
-	fmt.Println()
 
-	fmt.Println("Fullness: Amount of samples in histogram chunks")
-	displayHistogram("sample count per histogram chunk", histogramChunkSamplesCount, totalChunks)
-	fmt.Println()
+	displayHistogram("samples per histogram chunk", histogramChunkSamplesCount, totalChunks)
 
-	fmt.Println("Size of histogram chunks")
 	displayHistogram("bytes per histogram chunk", histogramChunkSize, totalChunks)
-	fmt.Println()
 
-	fmt.Println("Amount of buckets of histogram chunks")
 	displayHistogram("buckets per histogram chunk", histogramChunkBucketsCount, totalChunks)
-	fmt.Println()
 	return nil
 }
 
@@ -747,7 +738,7 @@ func displayHistogram(dataType string, datas []int, total int) {
 		}
 	}
 	avg := sum / len(datas)
-	fmt.Printf("%s (min/max/avg): %d/%d/%d\n", dataType, datas[0], datas[len(datas)-1], avg)
+	fmt.Printf("%s (min/avg/max): %d/%d/%d\n", dataType, datas[0], avg, datas[len(datas)-1])
 	maxLen := strconv.Itoa(len(fmt.Sprintf("%d", end)))
 	maxCountLen := strconv.Itoa(len(fmt.Sprintf("%d", maxCount)))
 	for bucket, count := range buckets {

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -739,11 +739,12 @@ func displayHistogram(dataType string, datas []int, total int) {
 	}
 	avg := sum / len(datas)
 	fmt.Printf("%s (min/avg/max): %d/%d/%d\n", dataType, datas[0], avg, datas[len(datas)-1])
-	maxLen := strconv.Itoa(len(fmt.Sprintf("%d", end)))
+	maxLeftLen := strconv.Itoa(len(fmt.Sprintf("%d", end)))
+	maxRightLen := strconv.Itoa(len(fmt.Sprintf("%d", end+step)))
 	maxCountLen := strconv.Itoa(len(fmt.Sprintf("%d", maxCount)))
 	for bucket, count := range buckets {
 		percentage := 100.0 * count / total
-		fmt.Printf("[%"+maxLen+"d, %"+maxLen+"d]: %"+maxCountLen+"d %s\n", bucket*step+start+1, (bucket+1)*step+start, count, strings.Repeat("#", percentage))
+		fmt.Printf("[%"+maxLeftLen+"d, %"+maxRightLen+"d]: %"+maxCountLen+"d %s\n", bucket*step+start+1, (bucket+1)*step+start, count, strings.Repeat("#", percentage))
 	}
 	fmt.Println()
 }

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -579,10 +579,6 @@ func analyzeCompaction(ctx context.Context, block tsdb.BlockReader, indexr tsdb.
 		err = tsdb_errors.NewMulti(err, chunkr.Close()).Err()
 	}()
 
-	// 构造一个有序数组，数组第一个元素，最后一个元素分别是最大，最小值，然后均分创建 10 个元素的数据，分别统计每个数组内的值
-	// const maxSamplesPerChunk = 120
-	// nBuckets := 10
-	// histogram := make([]int, nBuckets)
 	totalChunks := 0
 	floatChunkSamplesCount := make([]int, 0)
 	floatChunkSize := make([]int, 0)
@@ -748,13 +744,10 @@ func displayHistogram(dataType string, datas []int, total int) {
 	}
 	avg := sum / len(datas)
 	fmt.Printf("%s (min/max/avg): %d/%d/%d\n", dataType, datas[0], datas[len(datas)-1], avg)
+	maxLen := strconv.Itoa(len(fmt.Sprintf("%d", end)))
 	for bucket, count := range buckets {
 		percentage := 100.0 * count / total
-		fmt.Printf("[%d, %d]: %d ", bucket*step+start+1, (bucket+1)*step+start, count)
-		for j := 0; j < percentage; j++ {
-			fmt.Printf("#")
-		}
-		fmt.Println()
+		fmt.Printf("[%"+maxLen+"d, %"+maxLen+"d]: %d %s\n", bucket*step+start+1, (bucket+1)*step+start, count, strings.Repeat("#", percentage))
 	}
 	fmt.Println()
 }

--- a/cmd/promtool/tsdb_test.go
+++ b/cmd/promtool/tsdb_test.go
@@ -16,7 +16,7 @@ package main
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateBucket(t *testing.T) {
@@ -36,8 +36,8 @@ func TestGenerateBucket(t *testing.T) {
 	for _, tc := range tcs {
 		start, end, step := generateBucket(tc.min, tc.max)
 
-		assert.Equal(t, tc.start, start)
-		assert.Equal(t, tc.end, end)
-		assert.Equal(t, tc.step, step)
+		require.Equal(t, tc.start, start)
+		require.Equal(t, tc.end, end)
+		require.Equal(t, tc.step, step)
 	}
 }

--- a/cmd/promtool/tsdb_test.go
+++ b/cmd/promtool/tsdb_test.go
@@ -1,0 +1,43 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateBucket(t *testing.T) {
+	tcs := []struct {
+		min, max         int
+		start, end, step int
+	}{
+		{
+			min:   101,
+			max:   141,
+			start: 100,
+			end:   150,
+			step:  10,
+		},
+	}
+
+	for _, tc := range tcs {
+		start, end, step := generateBucket(tc.min, tc.max)
+
+		assert.Equal(t, tc.start, start)
+		assert.Equal(t, tc.end, end)
+		assert.Equal(t, tc.step, step)
+	}
+}


### PR DESCRIPTION
related #12146

This is first commit to try to enhance the tsdb analyze for native histgram.  Toke the advise from @beorn7 

> So maybe have separate histograms for float chunks and histogram chunks, and each of them should have a histogram for sample count, chunk size in bytes, and for histogram number of buckets in the chunk (maybe even "represented buckets" vs. "populated buckets").

_Originally posted by @beorn7 in https://github.com/prometheus/prometheus/issues/12146#issuecomment-1699105207_
            
I first try to 
- separate the histogram for float and histogram chunks, and display about the sample count and total bytes 
- display the result according to the absolute value, since the max chunk number is not const

here is the format now

```
Compaction analysis:
Fullness: Amount of samples in float chunks
chunk sample num min: 101
chunk sample num max: 141
    100: ########
    110:
    120: ################
    130:
    140: ################
    150:

Size of float chunks
chunk size min: 121
chunk size max: 1183
      0: ######################################
   1000: ##
   2000:

Fullness: Amount of samples in histogram chunks
chunk sample num min: 101
chunk sample num max: 141
    100: ###########
    110:
    120: #######################
    130:
    140: #######################
    150:

Size of histogram chunks
chunk size min: 2362
chunk size max: 3257
   2300: #####
   2400: #####
   2500:
   2600: ############
   2700: ##########
   2800:
   2900:
   3000:
   3100: ##################
   3200: #####
   3300:
```


