### PR TITLE
tsdb: register metrics after Head is initialized

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -258,7 +258,6 @@ func NewHead(r prometheus.Registerer, l log.Logger, wal, wbl *wlog.WL, opts *Hea
 	if err := h.resetInMemoryState(); err != nil {
 		return nil, err
 	}
-	h.metrics = newHeadMetrics(h, r)
 
 	if opts.ChunkPool == nil {
 		opts.ChunkPool = chunkenc.NewPool()
@@ -278,6 +277,7 @@ func NewHead(r prometheus.Registerer, l log.Logger, wal, wbl *wlog.WL, opts *Hea
 	if err != nil {
 		return nil, err
 	}
+	h.metrics = newHeadMetrics(h, r)
 
 	return h, nil
 }


### PR DESCRIPTION
This avoids situations where metrics are scraped before the data they are trying to look at is initialized.

My belief this can happen comes from this stack trace:

```
panic({0x2e16700?, 0x59266d0?})
    /usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/prometheus/prometheus/tsdb/chunks.(*ChunkDiskMapper).Size(...)
    /app/tsdb/chunks/head_chunks.go:1036
github.com/prometheus/prometheus/tsdb.newHeadMetrics.func6()
    /app/tsdb/head.go:535 +0x2a
github.com/prometheus/client_golang/prometheus.(*valueFunc).Write(0xc00076b680, 0xc00198a6c0?)
    /go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/value.go:94 +0x22
github.com/prometheus/client_golang/prometheus.processMetric({0x3e04f38, 0xc00076b680}, 0x0?, 0x0?, 0x0)
    /go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/registry.go:632 +0x84
github.com/prometheus/client_golang/prometheus.(*Registry).Gather(0x59670e0)
    /go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/registry.go:501 +0x819
github.com/prometheus/client_golang/prometheus.(*noTransactionGatherer).Gather(0x0?)
    /go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/registry.go:1073 +0x1b
github.com/prometheus/client_golang/prometheus/promhttp.HandlerForTransactional.func1({0x7fd07fd2ea00, 0xc00057a9b0}, 0xc0009a8800)
    /go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/promhttp/http.go:140 +0x2b0
net/http.HandlerFunc.ServeHTTP(0x3df7c80?, {0x7fd07fd2ea00?, 0xc00057a9b0?}, 0xc000e7e450?)
    /usr/local/go/src/net/http/server.go:2136 +0x29
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentMetricHandler.InstrumentHandlerInFlight.func1({0x7fd07fd2ea00, 0xc00057a9b0}, 0x7fd07fd2ea00?)
    /go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/promhttp/instrument_server.go:60 +0xcb
```