### PR TITLE
Improve sensitivity of TestQuerierIndexQueriesRace

### DIFF
--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2225,6 +2225,7 @@ func TestQuerierIndexQueriesRace(t *testing.T) {
 	for _, c := range testCases {
 		c := c
 		t.Run(fmt.Sprintf("%v", c.matchers), func(t *testing.T) {
+			t.Parallel()
 			db := openTestDB(t, DefaultOptions(), nil)
 			h := db.Head()
 			t.Cleanup(func() {
@@ -2244,6 +2245,9 @@ func TestQuerierIndexQueriesRace(t *testing.T) {
 				values, _, err := q.LabelValues(ctx, "seq", c.matchers...)
 				require.NoError(t, err)
 				require.Emptyf(t, values, `label values for label "seq" should be empty`)
+
+				// Sleep to give the appends some change to run.
+				time.Sleep(time.Millisecond)
 			}
 		})
 	}
@@ -2260,6 +2264,7 @@ func appendSeries(t *testing.T, ctx context.Context, wg *sync.WaitGroup, h *Head
 		require.NoError(t, err)
 
 		// Throttle down the appends to keep the test somewhat nimble.
+		// Otherwise, we end up appending thousands or millions of samples.
 		time.Sleep(time.Millisecond)
 	}
 }


### PR DESCRIPTION
This is a follow-up from this comment by @bboreham https://github.com/prometheus/prometheus/issues/12867#issuecomment-1728264193

Currently, the two goroutines race against each other and it's possible that the main test goroutine finishes way earlier than appendSeries has had a chance to run at all.

I tested this change by breaking the code that https://github.com/prometheus/prometheus/pull/12558 fixed and running the race test 100 times. Without the additional `time.Sleep` the test failed 11 times. With the sleep it failed 65 out of the 100 runs. Which is still not ideal, but it's a step forward.


Run without changes:
```
▶ go test ./... -run=TestQuerierIndexQueriesRace -count=100 | grep 'FAIL: TestQuerierIndexQueriesRace/' | wc -l
11
```

Run with changes

```
▶ go test ./... -run=TestQuerierIndexQueriesRace -count=100 | grep 'FAIL: TestQuerierIndexQueriesRace/' | wc -l
65
```

<details><summary>Changes necessary to make the test fail again</summary>
<p>


```diff
diff --git a/tsdb/querier.go b/tsdb/querier.go
index 2c2ae849a..aae034aa8 100644
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
-	"golang.org/x/exp/slices"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -279,9 +278,9 @@ func PostingsForMatchers(ctx context.Context, ix IndexReader, ms ...*labels.Matc
 	// there is no chance that the set we subtract from
 	// contains postings of series that didn't exist when
 	// we constructed the set we subtract by.
-	slices.SortStableFunc(ms, func(i, j *labels.Matcher) bool {
-		return !isSubtractingMatcher(i) && isSubtractingMatcher(j)
-	})
+	//slices.SortStableFunc(ms, func(i, j *labels.Matcher) bool {
+	//	return !isSubtractingMatcher(i) && isSubtractingMatcher(j)
+	//})
 
 	for _, m := range ms {
 		if ctx.Err() != nil {
```



</p>
</details> 

#### Note to reviewers

The tests now take at least 1 second to run each. That's two tests, so I made them run in `Parallel()` to reduce the impact.