### PR TITLE
file sd: only glob on actual patterns

### DIFF
--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -209,12 +209,16 @@ func NewDiscovery(conf *SDConfig, logger log.Logger) *Discovery {
 func (d *Discovery) listFiles() []string {
 	var paths []string
 	for _, p := range d.paths {
-		files, err := filepath.Glob(p)
-		if err != nil {
-			level.Error(d.logger).Log("msg", "Error expanding glob", "glob", p, "err", err)
-			continue
+		if strings.ContainsAny(p, "^?*[") {
+			files, err := filepath.Glob(p)
+			if err != nil {
+				level.Error(d.logger).Log("msg", "Error expanding glob", "glob", p, "err", err)
+				continue
+			}
+			paths = append(paths, files...)
+		} else {
+			paths = append(paths, p)
 		}
-		paths = append(paths, files...)
 	}
 	return paths
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1578,8 +1578,9 @@ files:
 [ refresh_interval: <duration> | default = 5m ]
 ```
 
-Where `<filename_pattern>` may be a path ending in `.json`, `.yml` or `.yaml`. The last path segment
-may contain a single `*` that matches any character sequence, e.g. `my/path/tg_*.json`.
+Where `<filename_pattern>` may be a path ending in `.json`, `.yml` or `.yaml`.
+If the pattern contains any of `?`, `*`, `^` or `[`, it will be treated as a
+glob and expanded.
 
 ### `<gce_sd_config>`
 


### PR DESCRIPTION
The previous implementation can be confusing. It will glob even regular file paths, which means passing in a non-existing filepath will not result in an error. This is counter-intuitive, as examplified in #12356. As a result of this change, the following can be seen in logs:

```
ts=2023-09-23T17:53:57.332Z caller=file.go:352 level=error component="discovery manager scrape" discovery=file config=testFile msg="Error reading file" path=banana.yml err="open banana.yml: no such file or directory"
```

And the file SD error count is also incremented now as a consequence. I've also documented this behaviour, as I believe the documentation wasn't necessarily clear on the fact that pattern would be globbed.
Fixes #12356.