### PR TITLE
Additional test case for ValidateHistogram

### DIFF
--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -4836,6 +4836,16 @@ func TestHistogramValidation(t *testing.T) {
 		"valid histogram": {
 			h: tsdbutil.GenerateTestHistograms(1)[0],
 		},
+		"valid histogram that has its Count (4) higher than the actual total of buckets (2 + 1)": {
+			// This case is possible if NaN values (which do not fall into any bucket) are observed.
+			h: &histogram.Histogram{
+				ZeroCount:       2,
+				Count:           4,
+				Sum:             math.NaN(),
+				PositiveSpans:   []histogram.Span{{Offset: 0, Length: 1}},
+				PositiveBuckets: []int64{1},
+			},
+		},
 		"rejects histogram that has too few negative buckets": {
 			h: &histogram.Histogram{
 				NegativeSpans:   []histogram.Span{{Offset: 0, Length: 1}},


### PR DESCRIPTION
`ValidateHistogram` did not have any direct unit test covering edge case discussed in https://github.com/prometheus/prometheus/pull/12739#issuecomment-1735911917.
This PR adds such test case. Besides additional test coverage, it would serve as documenting this aspect of validation logic (which was not immediately obvious, at least for me).