### PR TITLE
fix non counter warning on series without metric name

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -88,7 +88,7 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 		return enh.Out, annos.Add(annotations.NewMixedFloatsHistogramsWarning(metricName, args[0].PositionRange()))
 	}
 
-	if isCounter && !strings.HasSuffix(metricName, "_total") && !strings.HasSuffix(metricName, "_sum") && !strings.HasSuffix(metricName, "_count") {
+	if isCounter && len(metricName) > 0 && !strings.HasSuffix(metricName, "_total") && !strings.HasSuffix(metricName, "_sum") && !strings.HasSuffix(metricName, "_count") {
 		annos.Add(annotations.NewPossibleNonCounterInfo(metricName, args[0].PositionRange()))
 	}
 


### PR DESCRIPTION
When I run a nested subquery like this `rate(sum by (series) http_requests_total[5m:1m])`, I got a warning of possible non counter.

It looks like the check doesn't consider the case where metric name label is aggregated away.