### PR TITLE
ci(lint): enable nolintlint and remove redundant comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - gofumpt
     - goimports
     - misspell
+    - nolintlint
     - predeclared
     - revive
     - unconvert

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 // The main package for the Prometheus server executable.
-// nolint:revive // Many unsued function arguments in this file by design.
 package main
 
 import (

--- a/cmd/promtool/backfill_test.go
+++ b/cmd/promtool/backfill_test.go
@@ -44,7 +44,7 @@ func sortSamples(samples []backfillSample) {
 	})
 }
 
-func queryAllSeries(t testing.TB, q storage.Querier, expectedMinTime, expectedMaxTime int64) []backfillSample { // nolint:revive
+func queryAllSeries(t testing.TB, q storage.Querier, expectedMinTime, expectedMaxTime int64) []backfillSample {
 	ss := q.Select(context.Background(), false, nil, labels.MustNewMatcher(labels.MatchRegexp, "", ".*"))
 	samples := []backfillSample{}
 	for ss.Next() {

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -411,7 +411,6 @@ func checkExperimental(f bool) {
 	}
 }
 
-// nolint:revive
 var lintError = fmt.Errorf("lint error")
 
 type lintConfig struct {

--- a/cmd/promtool/rules_test.go
+++ b/cmd/promtool/rules_test.go
@@ -35,7 +35,7 @@ type mockQueryRangeAPI struct {
 	samples model.Matrix
 }
 
-func (mockAPI mockQueryRangeAPI) QueryRange(_ context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) { // nolint:revive
+func (mockAPI mockQueryRangeAPI) QueryRange(_ context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
 	return mockAPI.samples, v1.Warnings{}, nil
 }
 

--- a/discovery/kubernetes/endpoints.go
+++ b/discovery/kubernetes/endpoints.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:revive // Many legitimately empty blocks in this file.
 package kubernetes
 
 import (

--- a/discovery/kubernetes/endpointslice.go
+++ b/discovery/kubernetes/endpointslice.go
@@ -190,7 +190,7 @@ func (e *EndpointSlice) Run(ctx context.Context, ch chan<- []*targetgroup.Group)
 	}
 
 	go func() {
-		for e.process(ctx, ch) { // nolint:revive
+		for e.process(ctx, ch) {
 		}
 	}()
 

--- a/discovery/kubernetes/ingress.go
+++ b/discovery/kubernetes/ingress.go
@@ -88,7 +88,7 @@ func (i *Ingress) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	}
 
 	go func() {
-		for i.process(ctx, ch) { // nolint:revive
+		for i.process(ctx, ch) {
 		}
 	}()
 

--- a/discovery/kubernetes/node.go
+++ b/discovery/kubernetes/node.go
@@ -96,7 +96,7 @@ func (n *Node) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	}
 
 	go func() {
-		for n.process(ctx, ch) { // nolint:revive
+		for n.process(ctx, ch) {
 		}
 	}()
 

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -131,7 +131,7 @@ func (p *Pod) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	}
 
 	go func() {
-		for p.process(ctx, ch) { // nolint:revive
+		for p.process(ctx, ch) {
 		}
 	}()
 

--- a/discovery/kubernetes/service.go
+++ b/discovery/kubernetes/service.go
@@ -91,7 +91,7 @@ func (s *Service) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	}
 
 	go func() {
-		for s.process(ctx, ch) { // nolint:revive
+		for s.process(ctx, ch) {
 		}
 	}()
 

--- a/discovery/zookeeper/zookeeper.go
+++ b/discovery/zookeeper/zookeeper.go
@@ -193,7 +193,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 		}
 		for _, pathUpdate := range d.pathUpdates {
 			// Drain event channel in case the treecache leaks goroutines otherwise.
-			for range pathUpdate { // nolint:revive
+			for range pathUpdate {
 			}
 		}
 		d.conn.Close()

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2016,7 +2016,7 @@ func (ev *evaluator) matrixIterSlice(
 		//   (b) the number of samples is relatively small.
 		// so a linear search will be as fast as a binary search.
 		var drop int
-		for drop = 0; floats[drop].T < mint; drop++ { // nolint:revive
+		for drop = 0; floats[drop].T < mint; drop++ {
 		}
 		ev.currentSamples -= drop
 		copy(floats, floats[drop:])
@@ -2038,7 +2038,7 @@ func (ev *evaluator) matrixIterSlice(
 		//   (b) the number of samples is relatively small.
 		// so a linear search will be as fast as a binary search.
 		var drop int
-		for drop = 0; histograms[drop].T < mint; drop++ { // nolint:revive
+		for drop = 0; histograms[drop].T < mint; drop++ {
 		}
 		ev.currentSamples -= drop
 		copy(histograms, histograms[drop:])

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1656,7 +1656,6 @@ func TestRecoverEvaluatorRuntime(t *testing.T) {
 
 	// Cause a runtime panic.
 	var a []int
-	//nolint:govet
 	a[123] = 1
 }
 

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:revive // Many unsued function arguments in this file by design.
 package promql
 
 import (

--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -55,7 +55,6 @@ type Statement interface {
 	Node
 
 	// PromQLStmt ensures that no other type accidentally implements the interface
-	// nolint:unused
 	PromQLStmt()
 }
 

--- a/promql/parser/lex.go
+++ b/promql/parser/lex.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:revive // Many legitimately empty blocks in this file.
 package parser
 
 import (

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -72,7 +72,6 @@ func WithFunctions(functions map[string]*Function) Opt {
 }
 
 // NewParser returns a new parser.
-// nolint:revive
 func NewParser(input string, opts ...Opt) *parser {
 	p := parserPool.Get().(*parser)
 
@@ -660,9 +659,9 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 		// This is made a function instead of a variable, so it is lazily evaluated on demand.
 		opRange := func() (r posrange.PositionRange) {
 			// Remove whitespace at the beginning and end of the range.
-			for r.Start = n.LHS.PositionRange().End; isSpace(rune(p.lex.input[r.Start])); r.Start++ { // nolint:revive
+			for r.Start = n.LHS.PositionRange().End; isSpace(rune(p.lex.input[r.Start])); r.Start++ {
 			}
-			for r.End = n.RHS.PositionRange().Start - 1; isSpace(rune(p.lex.input[r.End])); r.End-- { // nolint:revive
+			for r.End = n.RHS.PositionRange().Start - 1; isSpace(rune(p.lex.input[r.End])); r.End-- {
 			}
 			return
 		}

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -4036,7 +4036,6 @@ func TestRecoverParserRuntime(t *testing.T) {
 	defer p.recover(&err)
 	// Cause a runtime panic.
 	var a []int
-	//nolint:govet
 	a[123] = 1
 }
 

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -145,9 +145,7 @@ func (t *Target) SetMetadataStore(s MetricMetadataStore) {
 func (t *Target) hash() uint64 {
 	h := fnv.New64a()
 
-	//nolint: errcheck
 	h.Write([]byte(fmt.Sprintf("%016d", t.labels.Hash())))
-	//nolint: errcheck
 	h.Write([]byte(t.URL().String()))
 
 	return h.Sum64()

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -211,7 +211,7 @@ func BenchmarkBufferedSeriesIterator(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	for it.Next() != chunkenc.ValNone { // nolint:revive
+	for it.Next() != chunkenc.ValNone {
 		// Scan everything.
 	}
 	require.NoError(b, it.Err())

--- a/storage/memoized_iterator_test.go
+++ b/storage/memoized_iterator_test.go
@@ -112,7 +112,7 @@ func BenchmarkMemoizedSeriesIterator(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	for it.Next() != chunkenc.ValNone { // nolint:revive
+	for it.Next() != chunkenc.ValNone {
 		// Scan everything.
 	}
 	require.NoError(b, it.Err())

--- a/storage/remote/azuread/azuread.go
+++ b/storage/remote/azuread/azuread.go
@@ -47,7 +47,7 @@ type ManagedIdentityConfig struct {
 }
 
 // AzureADConfig is used to store the config values.
-type AzureADConfig struct { // nolint:revive
+type AzureADConfig struct {
 	// ManagedIdentity is the managed identity that is being used to authenticate.
 	ManagedIdentity *ManagedIdentityConfig `yaml:"managed_identity,omitempty"`
 

--- a/template/template.go
+++ b/template/template.go
@@ -181,7 +181,7 @@ func NewTemplateExpander(
 				return html_template.HTML(text)
 			},
 			"match":     regexp.MatchString,
-			"title":     strings.Title, // nolint:staticcheck
+			"title":     strings.Title, //nolint:staticcheck
 			"toUpper":   strings.ToUpper,
 			"toLower":   strings.ToLower,
 			"graphLink": strutil.GraphLinkForExpression,

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -103,7 +103,7 @@ func (c *FloatHistogramChunk) Appender() (Appender, error) {
 	// To get an appender, we must know the state it would have if we had
 	// appended all existing data from scratch. We iterate through the end
 	// and populate via the iterator's state.
-	for it.Next() == ValFloatHistogram { // nolint:revive
+	for it.Next() == ValFloatHistogram {
 	}
 	if err := it.Err(); err != nil {
 		return nil, err

--- a/tsdb/chunkenc/float_histogram_test.go
+++ b/tsdb/chunkenc/float_histogram_test.go
@@ -157,7 +157,7 @@ func TestFloatHistogramChunkSameBuckets(t *testing.T) {
 
 	// 3. Now recycle an iterator that was never used to access anything.
 	itX := c.Iterator(nil)
-	for itX.Next() == ValFloatHistogram { // nolint:revive
+	for itX.Next() == ValFloatHistogram {
 		// Just iterate through without accessing anything.
 	}
 	it3 := c.iterator(itX)

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -114,7 +114,7 @@ func (c *HistogramChunk) Appender() (Appender, error) {
 	// To get an appender, we must know the state it would have if we had
 	// appended all existing data from scratch. We iterate through the end
 	// and populate via the iterator's state.
-	for it.Next() == ValHistogram { // nolint:revive
+	for it.Next() == ValHistogram {
 	}
 	if err := it.Err(); err != nil {
 		return nil, err

--- a/tsdb/chunkenc/histogram_test.go
+++ b/tsdb/chunkenc/histogram_test.go
@@ -162,7 +162,7 @@ func TestHistogramChunkSameBuckets(t *testing.T) {
 
 	// 3. Now recycle an iterator that was never used to access anything.
 	itX := c.Iterator(nil)
-	for itX.Next() == ValHistogram { // nolint:revive
+	for itX.Next() == ValHistogram {
 		// Just iterate through without accessing anything.
 	}
 	it3 := c.iterator(itX)

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -99,7 +99,7 @@ func (c *XORChunk) Appender() (Appender, error) {
 	// To get an appender we must know the state it would have if we had
 	// appended all existing data from scratch.
 	// We iterate through the end and populate via the iterator's state.
-	for it.Next() != ValNone { // nolint:revive
+	for it.Next() != ValNone {
 	}
 	if err := it.Err(); err != nil {
 		return nil, err

--- a/tsdb/errors/errors.go
+++ b/tsdb/errors/errors.go
@@ -25,7 +25,7 @@ import (
 type multiError []error
 
 // NewMulti returns multiError with provided errors added if not nil.
-func NewMulti(errs ...error) multiError { // nolint:revive
+func NewMulti(errs ...error) multiError {
 	m := multiError{}
 	m.Add(errs...)
 	return m

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:revive // Many legitimately empty blocks in this file.
 package tsdb
 
 import (

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:revive // Many legitimately empty blocks in this file.
 package tsdb
 
 import (

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:revive // Many unused function arguments in this file by design.
 package tsdb
 
 import (

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -267,7 +267,7 @@ func BenchmarkQuerierSelect(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					ss := q.Select(context.Background(), sorted, nil, matcher)
-					for ss.Next() { // nolint:revive
+					for ss.Next() {
 					}
 					require.NoError(b, ss.Err())
 				}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:revive // Many unsued function arguments in this file by design.
 package tsdb
 
 import (

--- a/tsdb/wal.go
+++ b/tsdb/wal.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:revive // Many unsued function arguments in this file by design.
 package tsdb
 
 import (

--- a/tsdb/wlog/reader_test.go
+++ b/tsdb/wlog/reader_test.go
@@ -541,7 +541,7 @@ func TestReaderData(t *testing.T) {
 			require.NoError(t, err)
 
 			reader := fn(sr)
-			for reader.Next() { // nolint:revive
+			for reader.Next() {
 			}
 			require.NoError(t, reader.Err())
 

--- a/tsdb/wlog/wlog.go
+++ b/tsdb/wlog/wlog.go
@@ -971,7 +971,6 @@ type segmentBufReader struct {
 	off  int // Offset of read data into current segment.
 }
 
-// nolint:revive // TODO: Consider exporting segmentBufReader
 func NewSegmentBufReader(segs ...*Segment) *segmentBufReader {
 	if len(segs) == 0 {
 		return &segmentBufReader{}
@@ -983,7 +982,6 @@ func NewSegmentBufReader(segs ...*Segment) *segmentBufReader {
 	}
 }
 
-// nolint:revive
 func NewSegmentBufReaderWithOffset(offset int, segs ...*Segment) (sbr *segmentBufReader, err error) {
 	if offset == 0 || len(segs) == 0 {
 		return NewSegmentBufReader(segs...), nil

--- a/tsdb/wlog/wlog_test.go
+++ b/tsdb/wlog/wlog_test.go
@@ -164,7 +164,7 @@ func TestWALRepair_ReadingError(t *testing.T) {
 				sr := NewSegmentBufReader(s)
 				require.NoError(t, err)
 				r := NewReader(sr)
-				for r.Next() { // nolint:revive
+				for r.Next() {
 				}
 
 				// Close the segment so we don't break things on Windows.

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -91,7 +91,6 @@ func (a Annotations) AsStrings(query string, maxAnnos int) []string {
 	return arr
 }
 
-//nolint:revive // Ignore ST1012
 var (
 	// Currently there are only 2 types, warnings and info.
 	// For now, info are visually identical with warnings as we have not updated

--- a/util/treecache/treecache.go
+++ b/util/treecache/treecache.go
@@ -116,7 +116,7 @@ func (tc *ZookeeperTreeCache) Stop() {
 	tc.stop <- struct{}{}
 	go func() {
 		// Drain tc.head.events so that go routines can make progress and exit.
-		for range tc.head.events { // nolint:revive
+		for range tc.head.events {
 		}
 	}()
 	go func() {

--- a/util/zeropool/pool_test.go
+++ b/util/zeropool/pool_test.go
@@ -149,13 +149,13 @@ func BenchmarkSyncPoolNewPointer(b *testing.B) {
 
 	// Warmup
 	item := pool.Get().(*[]byte)
-	pool.Put(item) //nolint:staticcheck // This allocates.
+	pool.Put(item)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		item := pool.Get().(*[]byte)
 		buf := *item
-		pool.Put(&buf) //nolint:staticcheck  // New pointer.
+		pool.Put(&buf)
 	}
 }
 

--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:revive // Many unsued function arguments in this file by design.
 package v1
 
 import (


### PR DESCRIPTION
This PR enables `nolintlint` linter to check `//nolint` comments. Also, removes redundant `//nolint:` directives.