### PR TITLE
API: Add tests for query timeout parameter

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -436,7 +436,7 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 			return invalidParamError(err, "timeout")
 		}
 
-		ctx, cancel = context.WithTimeout(ctx, timeout)
+		ctx, cancel = context.WithDeadline(ctx, api.now().Add(timeout))
 		defer cancel()
 	}
 


### PR DESCRIPTION
Add web/api/v1 unit tests that verify that the `timeout` parameter of the `query` endpoint gets translated into a context deadline, which gets passed on to the Prometheus query.

Fixes #12836.