### PR TITLE
Check for duplicated series on a scrape

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2975,7 +2975,7 @@ func TestReuseCacheRace(t *testing.T) {
 func TestCheckAddError(t *testing.T) {
 	var appErrs appendErrors
 	sl := scrapeLoop{l: log.NewNopLogger(), metrics: newTestScrapeMetrics(t)}
-	sl.checkAddError(nil, nil, nil, storage.ErrOutOfOrderSample, nil, nil, &appErrs)
+	sl.checkAddError(nil, storage.ErrOutOfOrderSample, nil, nil, &appErrs)
 	require.Equal(t, 1, appErrs.numOutOfOrder)
 }
 

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1068,6 +1068,7 @@ func makeTestMetrics(n int) []byte {
 		fmt.Fprintf(&sb, "# HELP metric_a help text\n")
 		fmt.Fprintf(&sb, "metric_a{foo=\"%d\",bar=\"%d\"} 1\n", i, i*100)
 	}
+	fmt.Fprintf(&sb, "# EOF\n")
 	return sb.Bytes()
 }
 

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2636,6 +2636,9 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 	_, _, _, err := sl.append(slApp, []byte("test_metric{le=\"500\"} 1\ntest_metric{le=\"600\",le=\"700\"} 1\n"), "", time.Time{})
 	require.Error(t, err)
 	require.NoError(t, slApp.Rollback())
+	// We need to cycle staleness cache maps after a manual rollback. Otherwise they will have old entries in them,
+	// which would cause ErrDuplicateSampleForTimestamp errors on the next append.
+	sl.cache.iterDone(true)
 
 	q, err := s.Querier(time.Time{}.UnixNano(), 0)
 	require.NoError(t, err)


### PR DESCRIPTION
When Prometheus scrapes a target and it sees the same time series repeated multiple times it currently silently ignores that. This change adds a test for that and fixes the scrape loop so that:
1. Only first sample for each unique time series is appended
2. Duplicated samples increment the prometheus_target_scrapes_sample_duplicate_timestamp_total metric

This allows one to identify such scrape jobs and targets.

Benchmark results:

```
name                            old time/op    new time/op    delta
ScrapeLoopAppend-8                71.5µs ± 1%    82.7µs ± 7%  +15.66%  (p=0.000 n=8+9)
ScrapeLoopAppendOM-8              63.4µs ± 1%    70.0µs ± 6%  +10.43%  (p=0.000 n=10+10)
TargetsFromGroup/1_targets-8      14.5µs ± 3%    14.7µs ± 1%   +1.21%  (p=0.016 n=9+10)
TargetsFromGroup/10_targets-8      150µs ± 1%     152µs ± 1%   +1.39%  (p=0.001 n=10+10)
TargetsFromGroup/100_targets-8    1.47ms ± 1%    1.48ms ± 1%   +0.65%  (p=0.006 n=9+10)

name                            old alloc/op   new alloc/op   delta
ScrapeLoopAppend-8                20.3kB ± 1%    24.6kB ± 4%  +20.92%  (p=0.000 n=10+10)
ScrapeLoopAppendOM-8              21.0kB ± 1%    23.5kB ± 2%  +11.62%  (p=0.000 n=9+10)
TargetsFromGroup/1_targets-8      2.43kB ± 0%    2.43kB ± 0%     ~     (p=0.299 n=9+10)
TargetsFromGroup/10_targets-8     24.3kB ± 0%    24.3kB ± 0%     ~     (p=0.725 n=10+10)
TargetsFromGroup/100_targets-8     243kB ± 0%     243kB ± 0%     ~     (p=0.579 n=10+10)

name                            old allocs/op  new allocs/op  delta
ScrapeLoopAppend-8                   108 ± 0%       112 ± 0%   +3.70%  (p=0.000 n=10+10)
ScrapeLoopAppendOM-8                 110 ± 0%       114 ± 0%   +3.64%  (p=0.000 n=10+10)
TargetsFromGroup/1_targets-8        40.0 ± 0%      40.0 ± 0%     ~     (all equal)
TargetsFromGroup/10_targets-8        400 ± 0%       400 ± 0%     ~     (all equal)
TargetsFromGroup/100_targets-8     4.00k ± 0%     4.00k ± 0%     ~     (all equal)
```

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
