### PR TITLE
Histogram performance: optimize floatBucketIterator

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -434,25 +434,25 @@ func (h *FloatHistogram) DetectReset(previous *FloatHistogram) bool {
 	}
 	currIt := h.floatBucketIterator(true, h.ZeroThreshold, h.Schema)
 	prevIt := previous.floatBucketIterator(true, h.ZeroThreshold, h.Schema)
-	if detectReset(currIt, prevIt) {
+	if detectReset(&currIt, &prevIt) {
 		return true
 	}
 	currIt = h.floatBucketIterator(false, h.ZeroThreshold, h.Schema)
 	prevIt = previous.floatBucketIterator(false, h.ZeroThreshold, h.Schema)
-	return detectReset(currIt, prevIt)
+	return detectReset(&currIt, &prevIt)
 }
 
-func detectReset(currIt, prevIt BucketIterator[float64]) bool {
+func detectReset(currIt, prevIt *floatBucketIterator) bool {
 	if !prevIt.Next() {
 		return false // If no buckets in previous histogram, nothing can be reset.
 	}
-	prevBucket := prevIt.At()
+	prevBucket := prevIt.strippedAt()
 	if !currIt.Next() {
 		// No bucket in current, but at least one in previous
 		// histogram. Check if any of those are non-zero, in which case
 		// this is a reset.
 		for {
-			if prevBucket.Count != 0 {
+			if prevBucket.count != 0 {
 				return true
 			}
 			if !prevIt.Next() {
@@ -460,10 +460,10 @@ func detectReset(currIt, prevIt BucketIterator[float64]) bool {
 			}
 		}
 	}
-	currBucket := currIt.At()
+	currBucket := currIt.strippedAt()
 	for {
 		// Forward currIt until we find the bucket corresponding to prevBucket.
-		for currBucket.Index < prevBucket.Index {
+		for currBucket.index < prevBucket.index {
 			if !currIt.Next() {
 				// Reached end of currIt early, therefore
 				// previous histogram has a bucket that the
@@ -471,7 +471,7 @@ func detectReset(currIt, prevIt BucketIterator[float64]) bool {
 				// remaining buckets in the previous histogram
 				// are unpopulated, this is a reset.
 				for {
-					if prevBucket.Count != 0 {
+					if prevBucket.count != 0 {
 						return true
 					}
 					if !prevIt.Next() {
@@ -479,18 +479,18 @@ func detectReset(currIt, prevIt BucketIterator[float64]) bool {
 					}
 				}
 			}
-			currBucket = currIt.At()
+			currBucket = currIt.strippedAt()
 		}
-		if currBucket.Index > prevBucket.Index {
+		if currBucket.index > prevBucket.index {
 			// Previous histogram has a bucket the current one does
 			// not have. If it's populated, it's a reset.
-			if prevBucket.Count != 0 {
+			if prevBucket.count != 0 {
 				return true
 			}
 		} else {
 			// We have reached corresponding buckets in both iterators.
 			// We can finally compare the counts.
-			if currBucket.Count < prevBucket.Count {
+			if currBucket.count < prevBucket.count {
 				return true
 			}
 		}
@@ -498,35 +498,39 @@ func detectReset(currIt, prevIt BucketIterator[float64]) bool {
 			// Reached end of prevIt without finding offending buckets.
 			return false
 		}
-		prevBucket = prevIt.At()
+		prevBucket = prevIt.strippedAt()
 	}
 }
 
 // PositiveBucketIterator returns a BucketIterator to iterate over all positive
 // buckets in ascending order (starting next to the zero bucket and going up).
 func (h *FloatHistogram) PositiveBucketIterator() BucketIterator[float64] {
-	return h.floatBucketIterator(true, 0, h.Schema)
+	it := h.floatBucketIterator(true, 0, h.Schema)
+	return &it
 }
 
 // NegativeBucketIterator returns a BucketIterator to iterate over all negative
 // buckets in descending order (starting next to the zero bucket and going
 // down).
 func (h *FloatHistogram) NegativeBucketIterator() BucketIterator[float64] {
-	return h.floatBucketIterator(false, 0, h.Schema)
+	it := h.floatBucketIterator(false, 0, h.Schema)
+	return &it
 }
 
 // PositiveReverseBucketIterator returns a BucketIterator to iterate over all
 // positive buckets in descending order (starting at the highest bucket and
 // going down towards the zero bucket).
 func (h *FloatHistogram) PositiveReverseBucketIterator() BucketIterator[float64] {
-	return newReverseFloatBucketIterator(h.PositiveSpans, h.PositiveBuckets, h.Schema, true)
+	it := newReverseFloatBucketIterator(h.PositiveSpans, h.PositiveBuckets, h.Schema, true)
+	return &it
 }
 
 // NegativeReverseBucketIterator returns a BucketIterator to iterate over all
 // negative buckets in ascending order (starting at the lowest bucket and going
 // up towards the zero bucket).
 func (h *FloatHistogram) NegativeReverseBucketIterator() BucketIterator[float64] {
-	return newReverseFloatBucketIterator(h.NegativeSpans, h.NegativeBuckets, h.Schema, false)
+	it := newReverseFloatBucketIterator(h.NegativeSpans, h.NegativeBuckets, h.Schema, false)
+	return &it
 }
 
 // AllBucketIterator returns a BucketIterator to iterate over all negative,
@@ -683,11 +687,11 @@ func (h *FloatHistogram) reconcileZeroBuckets(other *FloatHistogram) float64 {
 // targetSchema prior to iterating (without mutating FloatHistogram).
 func (h *FloatHistogram) floatBucketIterator(
 	positive bool, absoluteStartValue float64, targetSchema int32,
-) *floatBucketIterator {
+) floatBucketIterator {
 	if targetSchema > h.Schema {
 		panic(fmt.Errorf("cannot merge from schema %d to %d", h.Schema, targetSchema))
 	}
-	i := &floatBucketIterator{
+	i := floatBucketIterator{
 		baseBucketIterator: baseBucketIterator[float64, float64]{
 			schema:   h.Schema,
 			positive: positive,
@@ -708,8 +712,8 @@ func (h *FloatHistogram) floatBucketIterator(
 // reverseFloatbucketiterator is a low-level constructor for reverse bucket iterators.
 func newReverseFloatBucketIterator(
 	spans []Span, buckets []float64, schema int32, positive bool,
-) *reverseFloatBucketIterator {
-	r := &reverseFloatBucketIterator{
+) reverseFloatBucketIterator {
+	r := reverseFloatBucketIterator{
 		baseBucketIterator: baseBucketIterator[float64, float64]{
 			schema:   schema,
 			spans:    spans,

--- a/model/histogram/generic.go
+++ b/model/histogram/generic.go
@@ -53,6 +53,13 @@ type Bucket[BC BucketCount] struct {
 	Index int32
 }
 
+// strippedBucket is Bucket without bound values (which are expensive to calculate
+// and not used in certain use cases).
+type strippedBucket[BC BucketCount] struct {
+	count BC
+	index int32
+}
+
 // String returns a string representation of a Bucket, using the usual
 // mathematical notation of '['/']' for inclusive bounds and '('/')' for
 // non-inclusive bounds.
@@ -105,8 +112,7 @@ func (b baseBucketIterator[BC, IBC]) At() Bucket[BC] {
 	return b.at(b.schema)
 }
 
-// at is an internal version of the exported At to enable using a different
-// schema.
+// at is an internal version of the exported At to enable using a different schema.
 func (b baseBucketIterator[BC, IBC]) at(schema int32) Bucket[BC] {
 	bucket := Bucket[BC]{
 		Count: BC(b.currCount),
@@ -122,6 +128,14 @@ func (b baseBucketIterator[BC, IBC]) at(schema int32) Bucket[BC] {
 	bucket.LowerInclusive = bucket.Lower < 0
 	bucket.UpperInclusive = bucket.Upper > 0
 	return bucket
+}
+
+// strippedAt returns current strippedBucket (which lacks bucket bounds but is cheaper to compute).
+func (b baseBucketIterator[BC, IBC]) strippedAt() strippedBucket[BC] {
+	return strippedBucket[BC]{
+		count: BC(b.currCount),
+		index: b.currIdx,
+	}
 }
 
 // compactBuckets is a generic function used by both Histogram.Compact and

--- a/model/histogram/histogram.go
+++ b/model/histogram/histogram.go
@@ -148,13 +148,15 @@ func (h *Histogram) ZeroBucket() Bucket[uint64] {
 // PositiveBucketIterator returns a BucketIterator to iterate over all positive
 // buckets in ascending order (starting next to the zero bucket and going up).
 func (h *Histogram) PositiveBucketIterator() BucketIterator[uint64] {
-	return newRegularBucketIterator(h.PositiveSpans, h.PositiveBuckets, h.Schema, true)
+	it := newRegularBucketIterator(h.PositiveSpans, h.PositiveBuckets, h.Schema, true)
+	return &it
 }
 
 // NegativeBucketIterator returns a BucketIterator to iterate over all negative
 // buckets in descending order (starting next to the zero bucket and going down).
 func (h *Histogram) NegativeBucketIterator() BucketIterator[uint64] {
-	return newRegularBucketIterator(h.NegativeSpans, h.NegativeBuckets, h.Schema, false)
+	it := newRegularBucketIterator(h.NegativeSpans, h.NegativeBuckets, h.Schema, false)
+	return &it
 }
 
 // CumulativeBucketIterator returns a BucketIterator to iterate over a
@@ -325,14 +327,14 @@ type regularBucketIterator struct {
 	baseBucketIterator[uint64, int64]
 }
 
-func newRegularBucketIterator(spans []Span, buckets []int64, schema int32, positive bool) *regularBucketIterator {
+func newRegularBucketIterator(spans []Span, buckets []int64, schema int32, positive bool) regularBucketIterator {
 	i := baseBucketIterator[uint64, int64]{
 		schema:   schema,
 		spans:    spans,
 		buckets:  buckets,
 		positive: positive,
 	}
-	return &regularBucketIterator{i}
+	return regularBucketIterator{i}
 }
 
 func (r *regularBucketIterator) Next() bool {


### PR DESCRIPTION
There are two optimizations in this PR:
1. Introduce `strippedBucket` struct/`strippedAt` method on `floatBucketIterator` which allows to skip bound calculations (which are relatively expensive `getBound` calls) in use cases where bound values are not needed (such as `DetectReset`).
2. Avoid allocating `floatBucketIterator` object on heap.

For this change, I have adapted benchmark code from https://github.com/prometheus/prometheus/pull/12711/commits/4787c879bce2b44a8a5634d94f1c8b847dc07875. Benchmark results below.

Before the change:
```
go test -bench=BenchmarkFloatHistogramDetectReset -count=5             
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/histogram
BenchmarkFloatHistogramDetectReset-10    	 9413133	       126.1 ns/op	     256 B/op	       2 allocs/op
BenchmarkFloatHistogramDetectReset-10    	 9557922	       124.6 ns/op	     256 B/op	       2 allocs/op
BenchmarkFloatHistogramDetectReset-10    	 9350709	       128.9 ns/op	     256 B/op	       2 allocs/op
BenchmarkFloatHistogramDetectReset-10    	 9439388	       128.7 ns/op	     256 B/op	       2 allocs/op
BenchmarkFloatHistogramDetectReset-10    	 9173514	       127.0 ns/op	     256 B/op	       2 allocs/op
```

Avoiding `getBound` calls (~35% improvement):
```
BenchmarkFloatHistogramDetectReset-10    	14278440	        81.12 ns/op	     256 B/op	       2 allocs/op
BenchmarkFloatHistogramDetectReset-10    	13361082	        82.16 ns/op	     256 B/op	       2 allocs/op
BenchmarkFloatHistogramDetectReset-10    	15049930	        80.98 ns/op	     256 B/op	       2 allocs/op
BenchmarkFloatHistogramDetectReset-10    	14484721	        83.29 ns/op	     256 B/op	       2 allocs/op
BenchmarkFloatHistogramDetectReset-10    	14899450	        83.53 ns/op	     256 B/op	       2 allocs/op
```

Additionally, avoiding iterator allocations (~2.5x total improvement, allocs down from 2 to 0):
```
BenchmarkFloatHistogramDetectReset-10    	24134176	        49.68 ns/op	       0 B/op	       0 allocs/op
BenchmarkFloatHistogramDetectReset-10    	23310399	        49.72 ns/op	       0 B/op	       0 allocs/op
BenchmarkFloatHistogramDetectReset-10    	24175940	        49.61 ns/op	       0 B/op	       0 allocs/op
BenchmarkFloatHistogramDetectReset-10    	23970396	        49.60 ns/op	       0 B/op	       0 allocs/op
BenchmarkFloatHistogramDetectReset-10    	23984430	        49.62 ns/op	       0 B/op	       0 allocs/op
```

As a followup to this PR, I am planning to eliminate (or reduce) `getBound` calls from `floatBucketIterator.Next()` as well, which would have even broader impact in terms of use cases affected. At a quick glance, this seems to be possible because of the properties of this function (especially in case of `absoluteStartValue == 0`, which appears to be the case in query engine).