### PR TITLE
Storage: reduce memory allocations when merging series sets

### DIFF
--- a/storage/merge.go
+++ b/storage/merge.go
@@ -347,7 +347,7 @@ func (c *genericMergeSeriesSet) Next() bool {
 		}
 
 		// Now, pop items of the heap that have equal label sets.
-		c.currentSets = nil
+		c.currentSets = c.currentSets[:0]
 		c.currentLabels = c.heap[0].At().Labels()
 		for len(c.heap) > 0 && labels.Equal(c.currentLabels, c.heap[0].At().Labels()) {
 			set := heap.Pop(&c.heap).(genericSeriesSet)


### PR DESCRIPTION
Instead of setting to nil and allocating a new slice every time the merge is advanced, re-use the previous slice.
This is safe because the `currentSets` member is only used inside member functions, and explicitly copied in `At()`, the only place it leaves the struct.

This is not a huge volume of memory since the slice is usually 16 bytes, but it's an easy win.

Benchmarks:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/storage
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                             │ before.txt  │             after.txt              │
                             │   sec/op    │    sec/op     vs base              │
NoMergeSeriesSet_100_100-4     910.1µ ± 3%   901.5µ ±  2%       ~ (p=0.699 n=6)
MergeSeriesSet/1_100_100-4     908.5µ ± 1%   895.3µ ± 11%       ~ (p=0.132 n=6)
MergeSeriesSet/10_100_100-4    77.79m ± 2%   76.70m ±  3%       ~ (p=0.240 n=6)
MergeSeriesSet/100_100_100-4    1.372 ± 4%    1.362 ±  2%       ~ (p=0.132 n=6)
geomean                        17.24m        17.04m        -1.15%

                             │   before.txt   │               after.txt               │
                             │      B/op      │     B/op      vs base                 │
NoMergeSeriesSet_100_100-4        482.0 ± 15%     486.5 ± 8%        ~ (p=0.937 n=6)
MergeSeriesSet/1_100_100-4        112.0 ±  0%     112.0 ± 0%        ~ (p=1.000 n=6) ¹
MergeSeriesSet/10_100_100-4    135.70Ki ±  0%   87.74Ki ± 0%  -35.34% (p=0.002 n=6)
MergeSeriesSet/100_100_100-4   1168.0Ki ±  0%   773.6Ki ± 0%  -33.77% (p=0.002 n=6)
geomean                         9.504Ki         7.706Ki       -18.92%
¹ all samples are equal

                             │  before.txt  │               after.txt               │
                             │  allocs/op   │  allocs/op    vs base                 │
NoMergeSeriesSet_100_100-4      10.00 ± 10%    10.00 ± 10%        ~ (p=1.000 n=6)
MergeSeriesSet/1_100_100-4      7.000 ±  0%    7.000 ±  0%        ~ (p=1.000 n=6) ¹
MergeSeriesSet/10_100_100-4    1432.0 ±  0%    937.0 ±  0%  -34.57% (p=0.002 n=6)
MergeSeriesSet/100_100_100-4   2.319k ±  0%   1.527k ±  0%  -34.15% (p=0.002 n=6)
geomean                         123.5          100.0        -18.98%
¹ all samples are equal
```