### PR TITLE
scraping: hoist labels variable to save garbage

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1525,6 +1525,7 @@ func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string,
 		appErrs         = appendErrors{}
 		sampleLimitErr  error
 		bucketLimitErr  error
+		lset            labels.Labels     // escapes to heap so hoisted out of loop
 		e               exemplar.Exemplar // escapes to heap so hoisted out of loop
 		meta            metadata.Metadata
 		metadataChanged bool
@@ -1622,7 +1623,6 @@ loop:
 		ce, ok := sl.cache.get(met)
 		var (
 			ref  storage.SeriesRef
-			lset labels.Labels
 			hash uint64
 		)
 


### PR DESCRIPTION
`lset` escapes to heap due to being passed through the text-parser interface, so we can reduce garbage by hoisting it out of the loop so only one allocation is done for every series in a scrape.

Very similar to https://github.com/prometheus/prometheus/pull/9299/commits/21c0cc3bd6cb03c694a48e36f0b76e13009cb15f

Benchmark:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/scrape
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                   │ before.txt  │             after.txt             │
                   │   sec/op    │   sec/op     vs base              │
ScrapeLoopAppend-4   139.0µ ± 5%   131.2µ ± 3%  -5.61% (p=0.002 n=6)

                   │  before.txt  │             after.txt              │
                   │     B/op     │     B/op      vs base              │
ScrapeLoopAppend-4   20.41Ki ± 6%   18.50Ki ± 3%  -9.37% (p=0.002 n=6)

                   │  before.txt  │             after.txt             │
                   │  allocs/op   │ allocs/op   vs base               │
ScrapeLoopAppend-4   108.000 ± 0%   9.000 ± 0%  -91.67% (p=0.002 n=6)
```