### PR TITLE
Show group interval in Rules display

### DIFF
--- a/web/ui/react-app/src/pages/rules/RulesContent.tsx
+++ b/web/ui/react-app/src/pages/rules/RulesContent.tsx
@@ -13,6 +13,7 @@ interface RulesContentProps {
 interface RuleGroup {
   name: string;
   file: string;
+  interval: number;
   rules: Rule[];
   evaluationTime: string;
   lastEvaluation: string;
@@ -58,12 +59,15 @@ export const RulesContent: FC<RulesContentProps> = ({ response }) => {
             <Table bordered key={i}>
               <thead>
                 <tr>
-                  <td colSpan={3}>
+                  <td>
                     <a href={'#' + g.name}>
                       <h4 id={g.name} className="text-break">
                         {g.name}
                       </h4>
                     </a>
+                  </td>
+                  <td colSpan={2}>
+                    <h4>Interval: {g.interval}s</h4>
                   </td>
                   <td>
                     <h4>{formatRelative(g.lastEvaluation, now())}</h4>

--- a/web/ui/react-app/src/pages/rules/RulesContent.tsx
+++ b/web/ui/react-app/src/pages/rules/RulesContent.tsx
@@ -13,7 +13,7 @@ interface RulesContentProps {
 interface RuleGroup {
   name: string;
   file: string;
-  interval: number;
+  interval: string;
   rules: Rule[];
   evaluationTime: string;
   lastEvaluation: string;
@@ -67,7 +67,7 @@ export const RulesContent: FC<RulesContentProps> = ({ response }) => {
                     </a>
                   </td>
                   <td colSpan={2}>
-                    <h4>Interval: {g.interval}s</h4>
+                    <h4>Interval: {humanizeDuration(parseFloat(g.interval) * 1000)}</h4>
                   </td>
                   <td>
                     <h4>{formatRelative(g.lastEvaluation, now())}</h4>


### PR DESCRIPTION
Before:
<img width="1503" alt="image" src="https://github.com/prometheus/prometheus/assets/373762/03e47339-585b-4cd7-9d0b-39804be1477e">

After: 
<img width="1503" alt="image" src="https://github.com/prometheus/prometheus/assets/373762/df9d5026-3aea-4440-a9db-e8dfa89366ff">

If an interval is not set, it will inherit the global `evaluation_interval` value.