### PR TITLE
fix(model/relabel): string comparison of relabel's regexes

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -131,7 +131,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	if c.Action == DropEqual || c.Action == KeepEqual {
-		if c.Regex != DefaultRelabelConfig.Regex ||
+		if c.Regex.String() != DefaultRelabelConfig.Regex.String() ||
 			c.Modulus != DefaultRelabelConfig.Modulus ||
 			c.Separator != DefaultRelabelConfig.Separator ||
 			c.Replacement != DefaultRelabelConfig.Replacement {


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes #12534 

Comparing `Regex` struct object might not always be correct, string comparison would ensure correctness.