### PR TITLE
Scraping: improve memory handling of scrape buffers

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -58,7 +58,7 @@ func NewManager(o *Options, logger log.Logger, app storage.Appendable, registere
 		graceShut:     make(chan struct{}),
 		triggerReload: make(chan struct{}, 1),
 		metrics:       sm,
-		buffers:       pool.New(1e3, 100e6, 3),
+		buffers:       pool.New(8e3, 6e6, 3),
 	}
 
 	m.metrics.setTargetMetadataCacheGatherer(m)

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -58,7 +58,7 @@ func NewManager(o *Options, logger log.Logger, app storage.Appendable, registere
 		graceShut:     make(chan struct{}),
 		triggerReload: make(chan struct{}, 1),
 		metrics:       sm,
-		buffers:       pool.New(1e3, 100e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) }),
+		buffers:       pool.New(1e3, 100e6, 3),
 	}
 
 	m.metrics.setTargetMetadataCacheGatherer(m)

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1108,7 +1108,7 @@ func newScrapeLoop(ctx context.Context,
 		l = log.NewNopLogger()
 	}
 	if buffers == nil {
-		buffers = pool.New(1e3, 1e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
+		buffers = pool.New(1e3, 1e6, 3)
 	}
 	if cache == nil {
 		cache = newScrapeCache(metrics)
@@ -1281,7 +1281,7 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 	scrapeCtx, cancel := context.WithTimeout(sl.parentCtx, sl.timeout)
 	resp, scrapeErr = sl.scraper.scrape(scrapeCtx)
 	if scrapeErr == nil {
-		b = sl.buffers.Get(sl.lastScrapeSize).([]byte)
+		b = sl.buffers.Get(sl.lastScrapeSize)
 		defer sl.buffers.Put(b)
 		buf = bytes.NewBuffer(b)
 		contentType, scrapeErr = sl.scraper.readResponse(scrapeCtx, resp, buf)

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2968,7 +2968,7 @@ func TestReuseCacheRace(t *testing.T) {
 			ScrapeInterval: model.Duration(5 * time.Second),
 			MetricsPath:    "/metrics",
 		}
-		buffers = pool.New(1e3, 100e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
+		buffers = pool.New(1e3, 100e6, 3)
 		sp, _   = newScrapePool(cfg, app, 0, nil, buffers, &Options{}, newTestScrapeMetrics(t))
 		t1      = &Target{
 			discoveredLabels: labels.FromStrings("labelNew", "nameNew"),

--- a/util/pool/pool.go
+++ b/util/pool/pool.go
@@ -91,6 +91,7 @@ func (p *Pool) Get(sz int) []byte {
 			return b
 		}
 	}
+	sz += (sz / 16) // Add a little extra for expansion.
 	return make([]byte, 0, sz)
 }
 

--- a/util/pool/pool_test.go
+++ b/util/pool/pool_test.go
@@ -37,6 +37,10 @@ func TestPool(t *testing.T) {
 			size:        10,
 			expectedCap: 10,
 		},
+		{
+			size:        9,
+			expectedCap: 10,
+		},
 	}
 	for _, c := range cases {
 		ret := testPool.Get(c.size)

--- a/util/pool/pool_test.go
+++ b/util/pool/pool_test.go
@@ -19,12 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeFunc(size int) interface{} {
-	return make([]int, 0, size)
-}
-
 func TestPool(t *testing.T) {
-	testPool := New(1, 8, 2, makeFunc)
+	testPool := New(1, 8, 2)
 	cases := []struct {
 		size        int
 		expectedCap int
@@ -44,7 +40,7 @@ func TestPool(t *testing.T) {
 	}
 	for _, c := range cases {
 		ret := testPool.Get(c.size)
-		require.Equal(t, c.expectedCap, cap(ret.([]int)))
+		require.Equal(t, c.expectedCap, cap(ret))
 		testPool.Put(ret)
 	}
 }


### PR DESCRIPTION
Context here is that I am analyzing Prometheus scraping a range of targets which return from a few KB to tens of megabytes (kube-state-metrics), and a large number of buffers retained in the scape pool, roughly matching those sizes.

Improvements here are stylistic:
* `util.Pool` returns `[]byte` instead of `interface{}`.  This essentially reverts #3835: since this pool is only used in one place making it generic just complicates things.

And for efficiency:
* Add a pool for slice headers, similar to `zeropool`, saves 1 allocation of 24 bytes on every Put to the pool.  Just one for all the buckets.
* Fewer pool buckets. Previously we had sizes in bytes: 1000, 3000, 9e3, 27e3, 81e3, 243e3, 729e3, 2.2e6, 6.6e6, 1.97e6, 59e6.
Now they are 8000, 24000, 72e3, 216e3, 648e3, 1.9e6, 5.8e6 and "outsize".  So it takes less time to find the right bucket, and less space is wasted from rounding up to the maximum size of the bucket.
* We now pool objects bigger than the largest bucket, in an "outsize" pool.  This is a slice not a `sync.Pool` since those maintain a separate free-list for each CPU core.  Cleaning it out on each garbage-collection cycle is a little complicated.

In my ~8GB Prometheus this gives a ~300MB reduction.  It doesn't show up so much in the benchmarks.

<details><summary>Benchmarks</summary>
<p>
<pre>
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/scrape
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                                               │    before    │               after               │
                                               │    sec/op    │   sec/op     vs base              │
ScrapeAndReport/#00-4                            188.6µ ± 30%   191.9µ ± 8%       ~ (p=0.818 n=6)
ScrapeAndReport/application/openmetrics-text-4   191.6µ ± 13%   186.5µ ± 4%       ~ (p=0.240 n=6)
geomean                                          190.1µ         189.2µ       -0.48%

                                               │    before     │                after                │
                                               │     B/op      │     B/op       vs base              │
ScrapeAndReport/#00-4                            36.19Ki ± 94%   36.14Ki ± 19%       ~ (p=0.065 n=6)
ScrapeAndReport/application/openmetrics-text-4   37.24Ki ±  0%   37.19Ki ±  0%  -0.12% (p=0.004 n=6)
geomean                                          36.71Ki         36.66Ki        -0.12%

                                               │   before    │               after               │
                                               │  allocs/op  │  allocs/op   vs base              │
ScrapeAndReport/#00-4                            844.0 ± 95%   842.0 ± 20%  -0.24% (p=0.015 n=6)
ScrapeAndReport/application/openmetrics-text-4   858.0 ±  0%   856.0 ±  0%  -0.23% (p=0.002 n=6)
geomean                                          851.0         849.0        -0.24%
<pre>
</p>
</details> 