### PR TITLE
Expose --storage.tsdb.retention.time in metric prometheus_tsdb_retention_limit_seconds

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -248,6 +248,7 @@ type dbMetrics struct {
 	tombCleanTimer       prometheus.Histogram
 	blocksBytes          prometheus.Gauge
 	maxBytes             prometheus.Gauge
+	retentionDuration    prometheus.Gauge
 }
 
 func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
@@ -325,7 +326,10 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 		Name: "prometheus_tsdb_size_retentions_total",
 		Help: "The number of times that blocks were deleted because the maximum number of bytes was exceeded.",
 	})
-
+	m.retentionDuration = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_retention_seconds",
+		Help: "How long to retain samples in storage.",
+	})
 	if r != nil {
 		r.MustRegister(
 			m.loadedBlocks,
@@ -341,6 +345,7 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 			m.tombCleanTimer,
 			m.blocksBytes,
 			m.maxBytes,
+			m.retentionDuration,
 		)
 	}
 	return m
@@ -870,6 +875,7 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		maxBytes = 0
 	}
 	db.metrics.maxBytes.Set(float64(maxBytes))
+	db.metrics.retentionDuration.Set((time.Duration(opts.RetentionDuration) * time.Millisecond).Seconds())
 
 	if err := db.reload(); err != nil {
 		return nil, err

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -322,14 +322,15 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 		Name: "prometheus_tsdb_retention_limit_bytes",
 		Help: "Max number of bytes to be retained in the tsdb blocks, configured 0 means disabled",
 	})
+	m.retentionDuration = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_retention_limit_seconds",
+		Help: "How long to retain samples in storage.",
+	})
 	m.sizeRetentionCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_size_retentions_total",
 		Help: "The number of times that blocks were deleted because the maximum number of bytes was exceeded.",
 	})
-	m.retentionDuration = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_retention_seconds",
-		Help: "How long to retain samples in storage.",
-	})
+
 	if r != nil {
 		r.MustRegister(
 			m.loadedBlocks,

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1494,6 +1494,19 @@ func TestTimeRetention(t *testing.T) {
 	require.Equal(t, expBlocks[len(expBlocks)-1].MaxTime, actBlocks[len(actBlocks)-1].meta.MaxTime)
 }
 
+func TestRetentionDurationMetric(t *testing.T) {
+	db := openTestDB(t, &Options{
+		RetentionDuration: 1000,
+	}, []int64{100})
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	expRetentionDuration := 1.0
+	actRetentionDuration := prom_testutil.ToFloat64(db.metrics.retentionDuration)
+	require.Equal(t, expRetentionDuration, actRetentionDuration, "metric retention duration mismatch")
+}
+
 func TestSizeRetention(t *testing.T) {
 	opts := DefaultOptions()
 	opts.OutOfOrderTimeWindow = 100


### PR DESCRIPTION
This PR exposes the config option `--storage.tsdb.retention.time` as a metric.

It's assumed that tsdb.Option is an int64 representing time in milliseconds, based on its definition found here:
https://github.com/prometheus/prometheus/blob/624b973ebf4d0d7ed863b5538d7940c9c66c5cd0/cmd/prometheus/main.go#L1572

Related Issue: https://github.com/prometheus/prometheus/issues/12925