### PR TITLE
Adding multi-stage Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ The `make docker` target is designed for use in our CI system.
 You can build a docker image locally with the following commands:
 
 ```bash
-make promu
-promu crossbuild -p linux/amd64
 make npm_licenses
 make common-docker-amd64
 ```


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/7509 
Adding a multi-stage dockerfile to build ui assets in one stage & copying the required binaries to the next stage. 
Build logs for linux-amd64:
```
Step 25/25 : CMD        [ "--config.file=/etc/prometheus/prometheus.yml",              "--storage.tsdb.path=/prometheus",              "--web.console.libraries=/usr/share/prometheus/console_libraries",              "--web.console.templates=/usr/share/prometheus/consoles" ]
 ---> Running in fd2c27a973dc
Removing intermediate container fd2c27a973dc
 ---> b3b7d2d0acc5
Successfully built b3b7d2d0acc5
Successfully tagged prom/prometheus-linux-amd64:hackfest-docker
```
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
