### PR TITLE
Fix issue where `chainSampleIterator` can obscure errors

### DIFF
--- a/storage/merge.go
+++ b/storage/merge.go
@@ -502,9 +502,9 @@ func (c *chainSampleIterator) Seek(t int64) chunkenc.ValueType {
 				// If any iterator is reporting an error, abort.
 				return chunkenc.ValNone
 			}
-		} else {
-			heap.Push(&c.h, iter)
+			continue
 		}
+		heap.Push(&c.h, iter)
 	}
 	if len(c.h) > 0 {
 		c.curr = heap.Pop(&c.h).(chunkenc.Iterator)
@@ -599,7 +599,9 @@ func (c *chainSampleIterator) Next() chunkenc.ValueType {
 			if c.curr.Err() != nil {
 				// Abort if we've hit an error.
 				return chunkenc.ValNone
-			} else if len(c.h) == 0 {
+			}
+
+			if len(c.h) == 0 {
 				// No iterator left to iterate.
 				c.curr = nil
 				return chunkenc.ValNone

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -497,7 +497,12 @@ func (c *chainSampleIterator) Seek(t int64) chunkenc.ValueType {
 	c.consecutive = false
 	c.h = samplesIteratorHeap{}
 	for _, iter := range c.iterators {
-		if iter.Seek(t) != chunkenc.ValNone {
+		if iter.Seek(t) == chunkenc.ValNone {
+			if iter.Err() != nil {
+				// If any iterator is reporting an error, abort.
+				return chunkenc.ValNone
+			}
+		} else {
 			heap.Push(&c.h, iter)
 		}
 	}
@@ -571,7 +576,13 @@ func (c *chainSampleIterator) Next() chunkenc.ValueType {
 		// So, we don't call Next() on it here.
 		c.curr = c.iterators[0]
 		for _, iter := range c.iterators[1:] {
-			if iter.Next() != chunkenc.ValNone {
+			if iter.Next() == chunkenc.ValNone {
+				if iter.Err() != nil {
+					// If any iterator is reporting an error, abort.
+					// If c.iterators[0] is reporting an error, we'll handle that below.
+					return chunkenc.ValNone
+				}
+			} else {
 				heap.Push(&c.h, iter)
 			}
 		}
@@ -583,7 +594,17 @@ func (c *chainSampleIterator) Next() chunkenc.ValueType {
 
 	for {
 		currValueType = c.curr.Next()
-		if currValueType != chunkenc.ValNone {
+
+		if currValueType == chunkenc.ValNone {
+			if c.curr.Err() != nil {
+				// Abort if we've hit an error.
+				return chunkenc.ValNone
+			} else if len(c.h) == 0 {
+				// No iterator left to iterate.
+				c.curr = nil
+				return chunkenc.ValNone
+			}
+		} else {
 			currT = c.curr.AtT()
 			if currT == c.lastT {
 				// Ignoring sample for the same timestamp.
@@ -603,10 +624,6 @@ func (c *chainSampleIterator) Next() chunkenc.ValueType {
 			}
 			// Current iterator does not hold the smallest timestamp.
 			heap.Push(&c.h, c.curr)
-		} else if len(c.h) == 0 {
-			// No iterator left to iterate.
-			c.curr = nil
-			return chunkenc.ValNone
 		}
 
 		c.curr = heap.Pop(&c.h).(chunkenc.Iterator)


### PR DESCRIPTION
If any iterator in a `chainSampleIterator` has a sample after the desired timestamp when `Seek()` is called, `Seek()` will not return `ValNone`. 

If some iterators have failed (ie. calling `innerIterator.Err()` returns a non-`nil` value) and others have not, this behaviour may hide errors from those iterators: callers of `Seek()` will not receive `ValNone` and therefore won't know to check `chainSampleIterator.Err()`.

`Next()` is susceptible to a similar issue if `Next()` is not called until the stream is completely exhausted. 

This PR upstreams the change from https://github.com/grafana/mimir-prometheus/pull/540, which has already been tested in Mimir.