### PR TITLE
Add support for Host header

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -580,6 +580,8 @@ type ScrapeConfig struct {
 	MetricsPath string `yaml:"metrics_path,omitempty"`
 	// The URL scheme with which to fetch metrics from targets.
 	Scheme string `yaml:"scheme,omitempty"`
+	// Host header to use in requests
+	HostHeader string `yaml:"host_header,omitempty"`
 	// An uncompressed response body larger than this many bytes will cause the
 	// scrape to fail. 0 means no limit.
 	BodySizeLimit units.Base2Bytes `yaml:"body_size_limit,omitempty"`

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -225,6 +225,9 @@ job_name: <job_name>
 # Configures the protocol scheme used for requests.
 [ scheme: <scheme> | default = http ]
 
+# Host header for requests. By default, the target address is used.
+[ host_header: <string>]
+
 # Optional HTTP URL parameters.
 params:
   [ <string>: [<string>, ...] ]

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2632,6 +2632,61 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 	runTest(acceptHeader(config.DefaultNativeHistogramScrapeProtocols))
 }
 
+func TestTargetScraperScrapeHostHeader(t *testing.T) {
+	const (
+		expectedHostHeader = "somehost.dev"
+	)
+
+	var needHostHeader bool
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if needHostHeader {
+				host := r.Host
+				if host != expectedHostHeader {
+					t.Errorf("Expected Host header value %q, got %q", host, expectedHostHeader)
+				}
+			}
+
+			w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+			w.Write([]byte("metric_a 1\nmetric_b 2\n"))
+		}),
+	)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		panic(err)
+	}
+
+	runTest := func() {
+		ts := &targetScraper{
+			Target: &Target{
+				labels: labels.FromStrings(
+					model.SchemeLabel, serverURL.Scheme,
+					model.AddressLabel, serverURL.Host,
+				),
+			},
+			client: http.DefaultClient,
+		}
+		var buf bytes.Buffer
+		if needHostHeader {
+			ts.hostHeader = expectedHostHeader
+		}
+
+		resp, err := ts.scrape(context.Background())
+		require.NoError(t, err)
+		contentType, err := ts.readResponse(context.Background(), resp, &buf)
+		require.NoError(t, err)
+		require.Equal(t, "text/plain; version=0.0.4", contentType)
+		require.Equal(t, "metric_a 1\nmetric_b 2\n", buf.String())
+	}
+
+	runTest()
+	needHostHeader = true
+	runTest()
+}
+
 func TestTargetScrapeScrapeCancel(t *testing.T) {
 	block := make(chan struct{})
 

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -395,6 +395,8 @@ func PopulateLabels(lb *labels.Builder, cfg *config.ScrapeConfig, noDefaultPort 
 		{Name: model.ScrapeTimeoutLabel, Value: cfg.ScrapeTimeout.String()},
 		{Name: model.MetricsPathLabel, Value: cfg.MetricsPath},
 		{Name: model.SchemeLabel, Value: cfg.Scheme},
+		// TODO: introduce proper const in model
+		{Name: "__host_header__", Value: cfg.HostHeader},
 	}
 
 	for _, l := range scrapeLabels {


### PR DESCRIPTION
This adds support for adding optional host headers to `scrape_config`s. The additional `host_header` configuration parameter is optional, and if omitted, the host header is not changed, i.e. set to the target addess/port, so backwards compatible. If set, it overrides the host header for all targets of the job for which this `host_header` field is set.

Example job:
```yaml
  - job_name: test-job
    sample_limit:     0
    honor_timestamps: true
    scrape_interval:  60s
    scrape_timeout:   5s
    metrics_path:     /metrics
    scheme:           http
    enable_http2:     true
    follow_redirects: true
    host_header: service.example.com
    static_configs:
      - targets:
          - 10.10.10.10
        labels:
          some: label
```
