### PR TITLE
promtool: Set test group interval default to evaluation interval

### DIFF
--- a/cmd/promtool/testdata/no-test-group-interval.yml
+++ b/cmd/promtool/testdata/no-test-group-interval.yml
@@ -1,0 +1,15 @@
+tests:
+  - input_series:
+      - series: test
+        values: 0 1
+    promql_expr_test:
+      - expr: test
+        eval_time: 59s
+        exp_samples:
+          - value: 0
+            labels: test
+      - expr: test
+        eval_time: 1m
+        exp_samples:
+          - value: 1
+            labels: test

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -96,6 +96,9 @@ func ruleUnitTest(filename string, queryOpts promql.LazyLoaderOpts) []error {
 	// Testing.
 	var errs []error
 	for _, t := range unitTestInp.Tests {
+		if t.Interval == 0 {
+			t.Interval = unitTestInp.EvaluationInterval
+		}
 		ers := t.test(evalInterval, groupOrderMap, queryOpts, unitTestInp.RuleFiles...)
 		if ers != nil {
 			errs = append(errs, ers...)

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -112,6 +112,16 @@ func TestRulesUnitTest(t *testing.T) {
 			},
 			want: 0,
 		},
+		{
+			name: "No test group interval",
+			args: args{
+				files: []string{"./testdata/no-test-group-interval.yml"},
+			},
+			queryOpts: promql.LazyLoaderOpts{
+				EnableNegativeOffset: true,
+			},
+			want: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/configuration/unit_testing_rules.md
+++ b/docs/configuration/unit_testing_rules.md
@@ -39,7 +39,7 @@ tests:
 
 ``` yaml
 # Series data
-interval: <duration>
+[ interval: <duration> | default = evaluation_interval ]
 input_series:
   [ - <series> ]
 


### PR DESCRIPTION
The `interval` field for `test_group` is marked as required by the documentation, but the application neither enforces this requirement nor sets a default, leading to a default of 0 and unexpected behavior in some cases. In issue #12871 the idea was proposed to instead make the field optional and set `evaluation_interval` as a default if no interval is specified. This may break some existing tests, though these would likewise break if the application started considering an unspecified interval as an error.

Fixes #12871 
