### PR TITLE
Remove `NewPossibleNonCounterInfo` and minimise creating empty annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [ENHANCEMENT] Promtool: Add support for specifying series matchers in the TSDB analyze command. #12842
 * [ENHANCEMENT] PromQL: Prevent Prometheus from overallocating memory on subquery with large amount of steps. #12734
 * [ENHANCEMENT] PromQL: Add warning when monotonicity is forced in the input to histogram_quantile. #12931
+* [ENHANCEMENT] PromQL: Reduce inefficiency introduced by warnings/annotations, and temporarily remove NewPossibleNonCounterInfo. #13012
 * [ENHANCEMENT] Scraping: Optimize sample appending by reducing garbage. #12939
 * [ENHANCEMENT] Storage: Reduce memory allocations in queries that merge series sets. #12938
 * [ENHANCEMENT] UI: Show group interval in rules display. #12943

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+* [ENHANCEMENT] PromQL: Reduce inefficiency introduced by warnings/annotations, and temporarily remove NewPossibleNonCounterInfo. #13012
+
 ## 2.48.0-rc.0 / 2023-10-10
 
 * [CHANGE] Remote-write: respect Retry-After header on 5xx errors. #12677
@@ -15,7 +19,6 @@
 * [ENHANCEMENT] Promtool: Add support for specifying series matchers in the TSDB analyze command. #12842
 * [ENHANCEMENT] PromQL: Prevent Prometheus from overallocating memory on subquery with large amount of steps. #12734
 * [ENHANCEMENT] PromQL: Add warning when monotonicity is forced in the input to histogram_quantile. #12931
-* [ENHANCEMENT] PromQL: Reduce inefficiency introduced by warnings/annotations, and temporarily remove NewPossibleNonCounterInfo. #13012
 * [ENHANCEMENT] Scraping: Optimize sample appending by reducing garbage. #12939
 * [ENHANCEMENT] Storage: Reduce memory allocations in queries that merge series sets. #12938
 * [ENHANCEMENT] UI: Show group interval in rules display. #12943

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2535,7 +2535,7 @@ type groupedAggregation struct {
 func (ev *evaluator) aggregation(e *parser.AggregateExpr, grouping []string, param interface{}, vec Vector, seriesHelper []EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
 	op := e.Op
 	without := e.Without
-	annos := annotations.Annotations{}
+	var annos annotations.Annotations
 	result := map[uint64]*groupedAggregation{}
 	orderedResult := []*groupedAggregation{}
 	var k int64

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -77,7 +77,7 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 		resultHistogram    *histogram.FloatHistogram
 		firstT, lastT      int64
 		numSamplesMinusOne int
-		annos              = annotations.Annotations{}
+		annos              annotations.Annotations
 	)
 
 	// We need either at least two Histograms and no Floats, or at least two
@@ -86,14 +86,6 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 	metricName := samples.Metric.Get(labels.MetricName)
 	if len(samples.Histograms) > 0 && len(samples.Floats) > 0 {
 		return enh.Out, annos.Add(annotations.NewMixedFloatsHistogramsWarning(metricName, args[0].PositionRange()))
-	}
-
-	if isCounter && metricName != "" && len(samples.Floats) > 0 &&
-		!strings.HasSuffix(metricName, "_total") &&
-		!strings.HasSuffix(metricName, "_sum") &&
-		!strings.HasSuffix(metricName, "_count") &&
-		!strings.HasSuffix(metricName, "_bucket") {
-		annos.Add(annotations.NewPossibleNonCounterInfo(metricName, args[0].PositionRange()))
 	}
 
 	switch {
@@ -642,7 +634,7 @@ func funcQuantileOverTime(vals []parser.Value, args parser.Expressions, enh *Eva
 		return enh.Out, nil
 	}
 
-	annos := annotations.Annotations{}
+	var annos annotations.Annotations
 	if math.IsNaN(q) || q < 0 || q > 1 {
 		annos.Add(annotations.NewInvalidQuantileWarning(q, args[0].PositionRange()))
 	}
@@ -1105,7 +1097,7 @@ func funcHistogramFraction(vals []parser.Value, args parser.Expressions, enh *Ev
 func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
 	q := vals[0].(Vector)[0].F
 	inVec := vals[1].(Vector)
-	annos := annotations.Annotations{}
+	var annos annotations.Annotations
 
 	if math.IsNaN(q) || q < 0 || q > 1 {
 		annos.Add(annotations.NewInvalidQuantileWarning(q, args[0].PositionRange()))

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1933,7 +1933,8 @@ func TestQuerierWithBoundaryChunks(t *testing.T) {
 	// The requested interval covers 2 blocks, so the querier's label values for blockID should give us 2 values, one from each block.
 	b, ws, err := q.LabelValues(ctx, "blockID")
 	require.NoError(t, err)
-	require.Equal(t, annotations.Annotations{}, ws)
+	var nilAnnotations annotations.Annotations
+	require.Equal(t, nilAnnotations, ws)
 	require.Equal(t, []string{"1", "2"}, b)
 }
 

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -50,6 +50,9 @@ func (a *Annotations) Add(err error) Annotations {
 // the first in-place, and returns the merged first Annotation for convenience.
 func (a *Annotations) Merge(aa Annotations) Annotations {
 	if *a == nil {
+		if aa == nil {
+			return nil
+		}
 		*a = Annotations{}
 	}
 	for key, val := range aa {


### PR DESCRIPTION
Follow up to https://github.com/prometheus/prometheus/pull/12959 as a quick fix to temporarily remove `NewPossibleNonCounterInfo` and avoid creating empty annotations unnecessarily.

Followed up with https://github.com/prometheus/prometheus/pull/13022 to put `NewPossibleNonCounterInfo` back without running it every step, and apply a similar treatment for other warnings which don't look at the data like `NewInvalidQuantileWarning`.

According to benchmarks, this should restore most of the efficiency:
Before is run on [a branch on main that reverts the commits that added and modified annotations](https://github.com/zenador/prometheus/tree/temp-benchmark-remove-annotations), and after is run on [a branch on main with this commit applied](https://github.com/zenador/prometheus/tree/remove-NewPossibleNonCounterInfo).
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                                                  │ BenchmarkRangeQuery_before.txt │   BenchmarkRangeQuery_after.txt    │
                                                  │             sec/op             │   sec/op     vs base               │
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-16                      9.176m ± 4%   9.645m ± 1%  +5.11% (p=0.002 n=10)

                                                  │ BenchmarkRangeQuery_before.txt │ BenchmarkRangeQuery_after.txt  │
                                                  │              B/op              │     B/op      vs base          │
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-16                     367.6Ki ± 0%   367.6Ki ± 0%  ~ (p=0.353 n=10)

                                                  │ BenchmarkRangeQuery_before.txt │   BenchmarkRangeQuery_after.txt    │
                                                  │           allocs/op            │  allocs/op   vs base               │
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-16                      5.256k ± 0%   5.257k ± 0%  +0.02% (p=0.000 n=10)
```