### PR TITLE
tsdb: make transaction isolation data structures smaller

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2011,7 +2011,7 @@ func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, isolationDisabled
 		nextAt: math.MinInt64,
 	}
 	if !isolationDisabled {
-		s.txs = newTxRing(4)
+		s.txs = newTxRing(0)
 	}
 	return s
 }

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -724,7 +724,7 @@ func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *
 
 		// Removing the extra transactionIDs that are relevant for samples that
 		// come after this chunk, from the total transactionIDs.
-		appendIDsToConsider := s.txs.txIDCount - (totalSamples - (previousSamples + numSamples))
+		appendIDsToConsider := int(s.txs.txIDCount) - (totalSamples - (previousSamples + numSamples))
 
 		// Iterate over the appendIDs, find the first one that the isolation state says not
 		// to return.

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -2550,7 +2550,7 @@ func TestIsolationAppendIDZeroIsNoop(t *testing.T) {
 
 	ok, _ := s.append(0, 0, 0, cOpts)
 	require.True(t, ok, "Series append failed.")
-	require.Equal(t, 0, s.txs.txIDCount, "Series should not have an appendID after append with appendID=0.")
+	require.Equal(t, 0, int(s.txs.txIDCount), "Series should not have an appendID after append with appendID=0.")
 }
 
 func TestHeadSeriesChunkRace(t *testing.T) {

--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -253,7 +253,11 @@ func newTxRing(capacity int) *txRing {
 func (txr *txRing) add(appendID uint64) {
 	if int(txr.txIDCount) == len(txr.txIDs) {
 		// Ring buffer is full, expand by doubling.
-		newRing := make([]uint64, txr.txIDCount*2)
+		newLen := txr.txIDCount * 2
+		if newLen == 0 {
+			newLen = 4
+		}
+		newRing := make([]uint64, newLen)
 		idx := copy(newRing, txr.txIDs[txr.txIDFirst:])
 		copy(newRing[idx:], txr.txIDs[:txr.txIDFirst])
 		txr.txIDs = newRing
@@ -265,6 +269,9 @@ func (txr *txRing) add(appendID uint64) {
 }
 
 func (txr *txRing) cleanupAppendIDsBelow(bound uint64) {
+	if len(txr.txIDs) == 0 {
+		return
+	}
 	pos := int(txr.txIDFirst)
 
 	for txr.txIDCount > 0 {

--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -240,8 +240,8 @@ func (i *isolation) closeAppend(appendID uint64) {
 // The transactionID ring buffer.
 type txRing struct {
 	txIDs     []uint64
-	txIDFirst int // Position of the first id in the ring.
-	txIDCount int // How many ids in the ring.
+	txIDFirst uint32 // Position of the first id in the ring.
+	txIDCount uint32 // How many ids in the ring.
 }
 
 func newTxRing(capacity int) *txRing {
@@ -251,7 +251,7 @@ func newTxRing(capacity int) *txRing {
 }
 
 func (txr *txRing) add(appendID uint64) {
-	if txr.txIDCount == len(txr.txIDs) {
+	if int(txr.txIDCount) == len(txr.txIDs) {
 		// Ring buffer is full, expand by doubling.
 		newRing := make([]uint64, txr.txIDCount*2)
 		idx := copy(newRing, txr.txIDs[txr.txIDFirst:])
@@ -260,12 +260,12 @@ func (txr *txRing) add(appendID uint64) {
 		txr.txIDFirst = 0
 	}
 
-	txr.txIDs[(txr.txIDFirst+txr.txIDCount)%len(txr.txIDs)] = appendID
+	txr.txIDs[int(txr.txIDFirst+txr.txIDCount)%len(txr.txIDs)] = appendID
 	txr.txIDCount++
 }
 
 func (txr *txRing) cleanupAppendIDsBelow(bound uint64) {
-	pos := txr.txIDFirst
+	pos := int(txr.txIDFirst)
 
 	for txr.txIDCount > 0 {
 		if txr.txIDs[pos] < bound {
@@ -281,7 +281,7 @@ func (txr *txRing) cleanupAppendIDsBelow(bound uint64) {
 		}
 	}
 
-	txr.txIDFirst %= len(txr.txIDs)
+	txr.txIDFirst %= uint32(len(txr.txIDs))
 }
 
 func (txr *txRing) iterator() *txRingIterator {
@@ -296,7 +296,7 @@ func (txr *txRing) iterator() *txRingIterator {
 type txRingIterator struct {
 	ids []uint64
 
-	pos int
+	pos uint32
 }
 
 func (it *txRingIterator) At() uint64 {
@@ -305,7 +305,7 @@ func (it *txRingIterator) At() uint64 {
 
 func (it *txRingIterator) Next() {
 	it.pos++
-	if it.pos == len(it.ids) {
+	if int(it.pos) == len(it.ids) {
 		it.pos = 0
 	}
 }


### PR DESCRIPTION
First change is to use smaller integers - 4 billion active transactions ought to be enough for anyone.
This saves 16 bytes per head series.

Second change is to create the slice on demand: when Prometheus restarts it creates every series read in from the WAL, but many of those series will be finished, and never receive any more samples. 
This saves 32 bytes per stale head series.

I profiled the benchmark with one iteration to get detailed figures:
```
go test -run xxx -benchtime 1x -bench CreateSeries -memprofile mem.pprof -memprofilerate 1 ./tsdb
```

Before:
```
ROUTINE ======================== github.com/prometheus/prometheus/tsdb.newTxRing in /home/vagrant/src/github.com/prometheus/prometheus/tsdb/isolation.go
       80B        80B (flat, cum) 0.0018% of Total
         .          .    247:func newTxRing(capacity int) *txRing {
       48B        48B    248:   return &txRing{
       32B        32B    249:           txIDs: make([]uint64, capacity),
         .          .    250:   }
         .          .    251:}
```

After:
```
ROUTINE ======================== github.com/prometheus/prometheus/tsdb.newTxRing in /home/vagrant/src/github.com/prometheus/prometheus/tsdb/isolation.go
       32B        32B (flat, cum) 0.00071% of Total
         .          .    247:func newTxRing(capacity int) *txRing {
       32B        32B    248:   return &txRing{
         .          .    249:           txIDs: make([]uint64, capacity),
         .          .    250:   }
         .          .    251:}
```