### PR TITLE
ui: Pass unexpected boot errors to StartingContent component

### DIFF
--- a/web/ui/react-app/src/components/withStartingIndicator.test.tsx
+++ b/web/ui/react-app/src/components/withStartingIndicator.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { WALReplayData } from '../types/types';
 import { StartingContent } from './withStartingIndicator';
-import { Progress } from 'reactstrap';
+import { Alert, Progress } from 'reactstrap';
 
 describe('Starting', () => {
   describe('progress bar', () => {
@@ -51,6 +51,18 @@ describe('Starting', () => {
       const progress = starting.find(Progress);
       expect(progress.prop('value')).toBe(21);
       expect(progress.prop('color')).toBe('success');
+    });
+
+    it('shows unexpected error', () => {
+      const status: WALReplayData = {
+        min: 0,
+        max: 20,
+        current: 0,
+      };
+
+      const starting = shallow(<StartingContent status={status} isUnexpected={true} />);
+      const alert = starting.find(Alert);
+      expect(alert.prop('color')).toBe('danger');
     });
   });
 });

--- a/web/ui/react-app/src/components/withStartingIndicator.tsx
+++ b/web/ui/react-app/src/components/withStartingIndicator.tsx
@@ -51,7 +51,7 @@ export const withStartingIndicator =
     const { ready, walReplayStatus, isUnexpected } = useFetchReadyInterval(pathPrefix);
     const staticReady = useReady();
 
-    if (staticReady || ready || isUnexpected) {
+    if (staticReady || ready) {
       return <Page {...(rest as T)} />;
     }
 


### PR DESCRIPTION
When an unexpected error occurred during the boot sequence, it was rendering an empty page instead of the progress page with an alert stating something went during during initialization.

