### PR TITLE
fix(scrape/manager): reload manager's internals with new function

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -267,9 +267,14 @@ func (m *Manager) ApplyConfigAndOptions(cfg *config.Config, opts *Options) error
 	m.mtxScrape.Lock()
 	var managerOptionsAreChanged bool
 	if m.opts != nil {
-		managerOptionsAreChanged = m.opts.ExtraMetrics == opts.ExtraMetrics || m.opts.EnableProtobufNegotiation == opts.EnableProtobufNegotiation
+		managerOptionsAreChanged = m.opts.ExtraMetrics != opts.ExtraMetrics ||
+			m.opts.NoDefaultPort != opts.ExtraMetrics ||
+			m.opts.PassMetadataInContext != opts.PassMetadataInContext ||
+			m.opts.EnableMetadataStorage != opts.EnableMetadataStorage
 		m.opts.ExtraMetrics = opts.ExtraMetrics
-		m.opts.EnableProtobufNegotiation = opts.EnableProtobufNegotiation
+		m.opts.NoDefaultPort = opts.NoDefaultPort
+		m.opts.PassMetadataInContext = opts.PassMetadataInContext
+		m.opts.EnableMetadataStorage = opts.EnableMetadataStorage
 	}
 	m.mtxScrape.Unlock()
 
@@ -300,7 +305,7 @@ func (m *Manager) applyNewSetting(cfg *config.Config, managerOptionsAreChanged b
 		return err
 	}
 
-	// Cleanup and reload pool if the configuration has changed.
+	// Cleanup and reload pool if the scrape configuration or manager's option has changed.
 	var failed bool
 	for name, sp := range m.scrapePools {
 		switch cfg, ok := m.scrapeConfigs[name]; {

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -265,9 +265,12 @@ func (m *Manager) updateTsets(tsets map[string][]*targetgroup.Group) {
 // ApplyConfigAndOption loads up scrape options for scrape managers.
 func (m *Manager) ApplyConfigAndOptions(cfg *config.Config, opts *Options) error {
 	m.mtxScrape.Lock()
-	managerOptionsAreChanged := m.opts.ExtraMetrics == opts.ExtraMetrics || m.opts.EnableProtobufNegotiation == opts.EnableProtobufNegotiation
-	m.opts.ExtraMetrics = opts.ExtraMetrics
-	m.opts.EnableProtobufNegotiation = opts.EnableProtobufNegotiation
+	var managerOptionsAreChanged bool
+	if m.opts != nil {
+		managerOptionsAreChanged = m.opts.ExtraMetrics == opts.ExtraMetrics || m.opts.EnableProtobufNegotiation == opts.EnableProtobufNegotiation
+		m.opts.ExtraMetrics = opts.ExtraMetrics
+		m.opts.EnableProtobufNegotiation = opts.EnableProtobufNegotiation
+	}
 	m.mtxScrape.Unlock()
 
 	return m.applyNewSetting(cfg, managerOptionsAreChanged)

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -592,23 +592,21 @@ scrape_configs:
 		}
 	}
 
-	// Apply new options for manager
+	// Apply old scrape configs but new manager's options
 	scrapeManager.ApplyConfigAndOptions(
 		cfg,
 		&Options{
-			EnableProtobufNegotiation: true,
-			ExtraMetrics:              true,
+			ExtraMetrics:          true,
+			NoDefaultPort:         true,
+			PassMetadataInContext: true,
+			EnableMetadataStorage: true,
 		},
 	)
 
-	// Wait for manager's reloader goroutine to recreate scrape pool
-	// By default, the reloader waits for
-	require.Eventually(t, func() bool {
-		if sp, ok := scrapeManager.scrapePools["job1"]; ok {
-			return sp.enableProtobufNegotiation
-		}
-		return false
-	}, 20*time.Second, 1*time.Second)
+	require.True(t, scrapeManager.opts.ExtraMetrics)
+	require.True(t, scrapeManager.opts.NoDefaultPort)
+	require.True(t, scrapeManager.opts.PassMetadataInContext)
+	require.True(t, scrapeManager.opts.EnableMetadataStorage)
 }
 
 func TestManagerTargetsUpdates(t *testing.T) {


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Add a new function, `ApplyConfigAndOptions`, to allow external parties to reload scrape managers.