### PR TITLE
Fix error on ingesting out-of-order exemplars

### DIFF
--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -336,7 +336,7 @@ func (p *ProtobufParser) Exemplar(ex *exemplar.Exemplar) bool {
 			}
 		}
 		// If the last exemplar for native histograms has no timestamp, ignore it.
-		if !isClassic && (exProto == nil || exProto.GetTimestamp() == nil) {
+		if !isClassic && exProto.GetTimestamp() == nil {
 			return false
 		}
 	default:

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -729,7 +729,6 @@ func TestProtobufParse(t *testing.T) {
 					),
 					e: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
 				{
@@ -766,7 +765,6 @@ func TestProtobufParse(t *testing.T) {
 					),
 					e: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
 				{
@@ -802,7 +800,6 @@ func TestProtobufParse(t *testing.T) {
 					),
 					e: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
 				{
@@ -839,7 +836,6 @@ func TestProtobufParse(t *testing.T) {
 					),
 					e: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
 				{
@@ -1233,7 +1229,6 @@ func TestProtobufParse(t *testing.T) {
 					),
 					e: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
 				{ // 12
@@ -1328,7 +1323,6 @@ func TestProtobufParse(t *testing.T) {
 					),
 					e: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
 				{ // 21
@@ -1422,7 +1416,6 @@ func TestProtobufParse(t *testing.T) {
 					),
 					e: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
 				{ // 30
@@ -1517,7 +1510,6 @@ func TestProtobufParse(t *testing.T) {
 					),
 					e: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
-						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
 				{ // 39

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1594,7 +1594,10 @@ loop:
 			if exemplars[i].Ts != exemplars[j].Ts {
 				return exemplars[i].Ts < exemplars[j].Ts
 			}
-			return exemplars[i].Value < exemplars[j].Value
+			if exemplars[i].Value != exemplars[j].Value {
+				return exemplars[i].Value < exemplars[j].Value
+			}
+			return exemplars[i].Labels.Hash() < exemplars[j].Labels.Hash()
 		})
 		outOfOrderExemplars := 0
 		for _, e := range exemplars {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1581,7 +1581,10 @@ loop:
 			e = exemplar.Exemplar{} // Reset for next time round loop.
 		}
 		sort.Slice(exemplars, func(i, j int) bool {
-			return exemplars[i].Ts < exemplars[j].Ts
+			if exemplars[i].Ts != exemplars[j].Ts {
+				return exemplars[i].Ts < exemplars[j].Ts
+			}
+			return exemplars[i].Value < exemplars[j].Value
 		})
 		outOfOrderExemplars := 0
 		for _, e := range exemplars {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1589,10 +1589,10 @@ loop:
 		outOfOrderExemplars := 0
 		for _, e := range exemplars {
 			_, exemplarErr := app.AppendExemplar(ref, lset, e)
-			switch exemplarErr {
-			case nil:
+			switch {
+			case exemplarErr == nil:
 				// do nothing
-			case storage.ErrOutOfOrderExemplar:
+			case errors.Is(exemplarErr, storage.ErrOutOfOrderExemplar):
 				outOfOrderExemplars++
 			default:
 				// Since exemplar storage is still experimental, we don't fail the scrape on ingestion errors.

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2104,7 +2104,7 @@ metric_total{n="2"} 2 # {t="2"} 2.0 20000
 			},
 		},
 		{
-			title: "Native histogram with two exemplars",
+			title: "Native histogram with three exemplars",
 			scrapeText: `name: "test_histogram"
 help: "Test histogram with many buckets removed to keep it manageable in size."
 type: HISTOGRAM
@@ -2140,6 +2140,21 @@ metric: <
           value: "5617"
         >
         value: -0.00029
+      >
+    >
+    bucket: <
+      cumulative_count: 32
+      upper_bound: -0.0001899999999999998
+      exemplar: <
+        label: <
+          name: "dummyID"
+          value: "58215"
+        >
+        value: -0.00019
+        timestamp: <
+          seconds: 1625851055
+          nanos: 146848599
+        >
       >
     >
     schema: 3
@@ -2197,12 +2212,13 @@ metric: <
 				},
 			}},
 			exemplars: []exemplar.Exemplar{
-				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
+				// Native histogram exemplars are arranged by timestamp, and those with missing timestamps are dropped.
+				{Labels: labels.FromStrings("dummyID", "58215"), Value: -0.00019, Ts: 1625851055146, HasTs: true},
 				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
 			},
 		},
 		{
-			title: "Native histogram with two exemplars scraped as classic histogram",
+			title: "Native histogram with three exemplars scraped as classic histogram",
 			scrapeText: `name: "test_histogram"
 help: "Test histogram with many buckets removed to keep it manageable in size."
 type: HISTOGRAM
@@ -2238,6 +2254,21 @@ metric: <
           value: "5617"
         >
         value: -0.00029
+      >
+    >
+    bucket: <
+      cumulative_count: 32
+      upper_bound: -0.0001899999999999998
+      exemplar: <
+        label: <
+          name: "dummyID"
+          value: "58215"
+        >
+        value: -0.00019
+        timestamp: <
+          seconds: 1625851055
+          nanos: 146848599
+        >
       >
     >
     schema: 3
@@ -2281,6 +2312,7 @@ metric: <
 				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0004899999999999998"), t: 1234568, f: 2},
 				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0003899999999999998"), t: 1234568, f: 4},
 				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0002899999999999998"), t: 1234568, f: 16},
+				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "-0.0001899999999999998"), t: 1234568, f: 32},
 				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "+Inf"), t: 1234568, f: 175},
 			},
 			histograms: []histogramSample{{
@@ -2305,11 +2337,14 @@ metric: <
 			}},
 			exemplars: []exemplar.Exemplar{
 				// Native histogram one is arranged by timestamp.
-				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
+				// Exemplars with missing timestamps are dropped for native histograms.
+				{Labels: labels.FromStrings("dummyID", "58215"), Value: -0.00019, Ts: 1625851055146, HasTs: true},
 				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
 				// Classic histogram one is in order of appearance.
+				// Exemplars with missing timestamps are supported for classic histograms.
 				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
 				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
+				{Labels: labels.FromStrings("dummyID", "58215"), Value: -0.00019, Ts: 1625851055146, HasTs: true},
 			},
 		},
 	}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2304,10 +2304,10 @@ metric: <
 				},
 			}},
 			exemplars: []exemplar.Exemplar{
-				// native histogram one is arranged by timestamp
+				// Native histogram one is arranged by timestamp.
 				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
 				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
-				// classic histogram one is in order of appearance
+				// Classic histogram one is in order of appearance.
 				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
 				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
 			},

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2197,8 +2197,8 @@ metric: <
 				},
 			}},
 			exemplars: []exemplar.Exemplar{
-				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
 				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
+				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
 			},
 		},
 		{
@@ -2304,8 +2304,10 @@ metric: <
 				},
 			}},
 			exemplars: []exemplar.Exemplar{
-				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
+				// native histogram one is arranged by timestamp
 				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
+				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
+				// classic histogram one is in order of appearance
 				{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, Ts: 1625851155146, HasTs: true},
 				{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, Ts: 1234568, HasTs: false},
 			},

--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -249,7 +249,7 @@ func (ce *CircularExemplarStorage) validateExemplar(key []byte, e exemplar.Exemp
 		return storage.ErrDuplicateExemplar
 	}
 
-	if e.Ts <= ce.exemplars[idx.newest].exemplar.Ts {
+	if e.Ts < ce.exemplars[idx.newest].exemplar.Ts || (e.Ts == ce.exemplars[idx.newest].exemplar.Ts && e.Value < ce.exemplars[idx.newest].exemplar.Value) {
 		if appended {
 			ce.metrics.outOfOrderExemplars.Inc()
 		}

--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -250,29 +250,10 @@ func (ce *CircularExemplarStorage) validateExemplar(key []byte, e exemplar.Exemp
 	}
 
 	if e.Ts <= ce.exemplars[idx.newest].exemplar.Ts {
-		// Check for duplicates in the stored exemplars for this series.
-		// NB these are expected, and appending them is a no-op.
-		// This is separate from the earlier check because the earlier one is
-		// expected to be triggered more often and we don't want to go through
-		// the exemplars for this series unnecessarily.
-		// This triggers even when the timestamp is equal to the newest exemplar
-		// in case there are multiple exemplars with the same timestamp like for
-		// native histograms. However this means that we may repeat the comparison
-		// for the newest exemplar.
-		for i := idx.oldest; i != noExemplar; i = ce.exemplars[i].next {
-			if ce.exemplars[i].exemplar.Equals(e) {
-				return storage.ErrDuplicateExemplar
-			}
+		if appended {
+			ce.metrics.outOfOrderExemplars.Inc()
 		}
-		// Only treat it as out of order if the timestamp is earlier. If the
-		// timestamps are equal but it is not a duplicate of the stored exemplars,
-		// we don't treat it as an error.
-		if e.Ts < ce.exemplars[idx.newest].exemplar.Ts {
-			if appended {
-				ce.metrics.outOfOrderExemplars.Inc()
-			}
-			return storage.ErrOutOfOrderExemplar
-		}
+		return storage.ErrOutOfOrderExemplar
 	}
 	return nil
 }

--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -245,11 +245,23 @@ func (ce *CircularExemplarStorage) validateExemplar(key []byte, e exemplar.Exemp
 
 	// Check for duplicate vs last stored exemplar for this series.
 	// NB these are expected, and appending them is a no-op.
+	// For floats and classic histograms, there is only 1 exemplar per series,
+	// so this is sufficient. For native histograms with multiple exemplars per series,
+	// we have another check below.
 	newestExemplar := ce.exemplars[idx.newest].exemplar
 	if newestExemplar.Equals(e) {
 		return storage.ErrDuplicateExemplar
 	}
 
+	// Since during the scrape the exemplars are sorted first by timestamp, then value, then labels,
+	// if any of these conditions are true, we know that the exemplar is either a duplicate
+	// of a previous one (but not the most recent one as that is checked above) or out of order.
+	// We now allow exemplars with duplicate timestamps as long as they have different values and/or labels
+	// since that can happen for different buckets of a native histogram.
+	// We do not distinguish between duplicates and out of order as iterating through the exemplars
+	// to check for that would be expensive (versus just comparing with the most recent one) especially
+	// since this is run under a lock, and not worth it as we just need to return an error so we do not
+	// append the exemplar.
 	if e.Ts < newestExemplar.Ts ||
 		(e.Ts == newestExemplar.Ts && e.Value < newestExemplar.Value) ||
 		(e.Ts == newestExemplar.Ts && e.Value == newestExemplar.Value && e.Labels.Hash() < newestExemplar.Labels.Hash()) {

--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -245,11 +245,14 @@ func (ce *CircularExemplarStorage) validateExemplar(key []byte, e exemplar.Exemp
 
 	// Check for duplicate vs last stored exemplar for this series.
 	// NB these are expected, and appending them is a no-op.
-	if ce.exemplars[idx.newest].exemplar.Equals(e) {
+	newestExemplar := ce.exemplars[idx.newest].exemplar
+	if newestExemplar.Equals(e) {
 		return storage.ErrDuplicateExemplar
 	}
 
-	if e.Ts < ce.exemplars[idx.newest].exemplar.Ts || (e.Ts == ce.exemplars[idx.newest].exemplar.Ts && e.Value < ce.exemplars[idx.newest].exemplar.Value) {
+	if e.Ts < newestExemplar.Ts ||
+		(e.Ts == newestExemplar.Ts && e.Value < newestExemplar.Value) ||
+		(e.Ts == newestExemplar.Ts && e.Value == newestExemplar.Value && e.Labels.Hash() < newestExemplar.Labels.Hash()) {
 		if appended {
 			ce.metrics.outOfOrderExemplars.Inc()
 		}


### PR DESCRIPTION
Addresses https://github.com/prometheus/prometheus/issues/12971.

This gets rid of the error, however the implementation does not seem efficient.

Implemented the solution as per @beorn7 ['s suggestion](https://github.com/prometheus/prometheus/issues/12971#issuecomment-1766502119), which solves part of the problem, but we still run into the error.

Testing locally and looking at debug logs, it seems this is the flow when scrape_classic_histograms is enabled:
- Exemplars for native histograms are added (can have multiple at once which may not be in ascending timestamp order, seems to follow the order below - OOO errors caused by this are fixed with the above solution, but see below for the other problem)
- Exemplars for classic histogram buckets are added, one by one per bucket, in order of ascending buckets (which may not be in ascending timestamp order. these are the same exemplars as above but they do not clash as they belong to different series)

And then this repeats with each scrape of the histogram, but sometimes, the same exemplar for a bucket sent previously may be re-sent again with new exemplars for other buckets. This doesn't seem to be a problem for classic histograms as they are separated by buckets, so when a repeat is sent, it is compared with the most recently sent exemplar and found to be a duplicate instead of OOO. However, since native histogram exemplars are all thrown together, when a repeat is sent, it is not enough to only compare with the most recently sent exemplar. So we have to look through all the exemplars to properly detect duplicates, which seems a bit heavy.

How do you think we should fix this? Should we modify the code to indicate if the exemplar is for a native histogram and only run through all the exemplars for that case, or perhaps just skip that check if it's a native histogram and assume it's a duplicate if the timestamp is earlier or the same?