### PR TITLE
Restore more efficient version of NewPossibleNonCounterInfo annotation

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -1558,6 +1559,18 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 				}
 			}
 			ev.samplesStats.UpdatePeak(ev.currentSamples)
+
+			if e.Func.Name == "rate" || e.Func.Name == "increase" {
+				samples := inMatrix[0]
+				metricName := samples.Metric.Get(labels.MetricName)
+				if metricName != "" && len(samples.Floats) > 0 &&
+					!strings.HasSuffix(metricName, "_total") &&
+					!strings.HasSuffix(metricName, "_sum") &&
+					!strings.HasSuffix(metricName, "_count") &&
+					!strings.HasSuffix(metricName, "_bucket") {
+					warnings.Add(annotations.NewPossibleNonCounterInfo(metricName, e.Args[0].PositionRange()))
+				}
+			}
 		}
 		ev.samplesStats.UpdatePeak(ev.currentSamples)
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1364,22 +1364,13 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 			}, e.Expr)
 		}
 
-		var warnings annotations.Annotations
-		if e.Op == parser.QUANTILE && e.Param != nil {
-			q, _ := strconv.ParseFloat(e.Param.String(), 64)
-			if math.IsNaN(q) || q < 0 || q > 1 {
-				warnings.Add(annotations.NewInvalidQuantileWarning(q, e.Param.PositionRange()))
-			}
-		}
-
-		vec, annos := ev.rangeEval(initSeries, func(v []parser.Value, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+		return ev.rangeEval(initSeries, func(v []parser.Value, sh [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
 			var param float64
 			if e.Param != nil {
 				param = v[0].(Vector)[0].F
 			}
 			return ev.aggregation(e, sortedGrouping, param, v[1].(Vector), sh[1], enh)
 		}, e.Param, e.Expr)
-		return vec, warnings.Merge(annos)
 
 	case *parser.Call:
 		call := FunctionCalls[e.Func.Name]
@@ -2887,6 +2878,9 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, grouping []string, par
 			continue // Bypass default append.
 
 		case parser.QUANTILE:
+			if math.IsNaN(q) || q < 0 || q > 1 {
+				annos.Add(annotations.NewInvalidQuantileWarning(q, e.Param.PositionRange()))
+			}
 			aggr.floatValue = quantile(q, aggr.heap)
 
 		case parser.SUM:

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1374,9 +1374,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 
 	case *parser.Call:
 		call := FunctionCalls[e.Func.Name]
-		var warnings annotations.Annotations
-		switch e.Func.Name {
-		case "timestamp":
+		if e.Func.Name == "timestamp" {
 			// Matrix evaluation always returns the evaluation time,
 			// so this function needs special handling when given
 			// a vector selector.
@@ -1387,20 +1385,13 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 			if ok {
 				return ev.rangeEvalTimestampFunctionOverVectorSelector(vs, call, e)
 			}
-		case "histogram_quantile", "quantile_over_time":
-			unwrapParenExpr(&e.Args[0])
-			arg := unwrapStepInvariantExpr(e.Args[0])
-			unwrapParenExpr(&arg)
-			q, _ := strconv.ParseFloat(arg.String(), 64)
-			if math.IsNaN(q) || q < 0 || q > 1 {
-				warnings.Add(annotations.NewInvalidQuantileWarning(q, arg.PositionRange()))
-			}
 		}
 
 		// Check if the function has a matrix argument.
 		var (
 			matrixArgIndex int
 			matrixArg      bool
+			warnings       annotations.Annotations
 		)
 		for i := range e.Args {
 			unwrapParenExpr(&e.Args[i])

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -633,16 +633,11 @@ func funcQuantileOverTime(vals []parser.Value, args parser.Expressions, enh *Eva
 		return enh.Out, nil
 	}
 
-	var annos annotations.Annotations
-	if math.IsNaN(q) || q < 0 || q > 1 {
-		annos.Add(annotations.NewInvalidQuantileWarning(q, args[0].PositionRange()))
-	}
-
 	values := make(vectorByValueHeap, 0, len(el.Floats))
 	for _, f := range el.Floats {
 		values = append(values, Sample{F: f.F})
 	}
-	return append(enh.Out, Sample{F: quantile(q, values)}), annos
+	return append(enh.Out, Sample{F: quantile(q, values)}), nil
 }
 
 // === stddev_over_time(Matrix parser.ValueTypeMatrix) (Vector, Annotations) ===
@@ -1097,10 +1092,6 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 	q := vals[0].(Vector)[0].F
 	inVec := vals[1].(Vector)
 	var annos annotations.Annotations
-
-	if math.IsNaN(q) || q < 0 || q > 1 {
-		annos.Add(annotations.NewInvalidQuantileWarning(q, args[0].PositionRange()))
-	}
 
 	if enh.signatureToMetricWithBuckets == nil {
 		enh.signatureToMetricWithBuckets = map[string]*metricWithBuckets{}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -633,11 +633,16 @@ func funcQuantileOverTime(vals []parser.Value, args parser.Expressions, enh *Eva
 		return enh.Out, nil
 	}
 
+	var annos annotations.Annotations
+	if math.IsNaN(q) || q < 0 || q > 1 {
+		annos.Add(annotations.NewInvalidQuantileWarning(q, args[0].PositionRange()))
+	}
+
 	values := make(vectorByValueHeap, 0, len(el.Floats))
 	for _, f := range el.Floats {
 		values = append(values, Sample{F: f.F})
 	}
-	return append(enh.Out, Sample{F: quantile(q, values)}), nil
+	return append(enh.Out, Sample{F: quantile(q, values)}), annos
 }
 
 // === stddev_over_time(Matrix parser.ValueTypeMatrix) (Vector, Annotations) ===
@@ -1092,6 +1097,10 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 	q := vals[0].(Vector)[0].F
 	inVec := vals[1].(Vector)
 	var annos annotations.Annotations
+
+	if math.IsNaN(q) || q < 0 || q > 1 {
+		annos.Add(annotations.NewInvalidQuantileWarning(q, args[0].PositionRange()))
+	}
 
 	if enh.signatureToMetricWithBuckets == nil {
 		enh.signatureToMetricWithBuckets = map[string]*metricWithBuckets{}


### PR DESCRIPTION
Follow up to https://github.com/prometheus/prometheus/pull/13012
- Put back NewPossibleNonCounterInfo and run it only once per series instead of at every step
- ~Run NewInvalidQuantileWarning only once per query instead of at every step~

Benchmark for overhead for rate queries (before is run on [a branch on main that reverts the commits that added and modified annotations](https://github.com/zenador/prometheus/tree/temp-benchmark-remove-annotations), and after is run on this branch):
```
                                                  │ BenchmarkRangeQuery_before.txt │    BenchmarkRangeQuery_after.txt    │
                                                  │             sec/op             │    sec/op     vs base               │
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-16                     9.345m ± 18%   10.076m ± 3%  +7.83% (p=0.029 n=10)

                                                  │ BenchmarkRangeQuery_before.txt │    BenchmarkRangeQuery_after.txt    │
                                                  │              B/op              │     B/op      vs base               │
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-16                     367.6Ki ± 0%   402.6Ki ± 1%  +9.54% (p=0.000 n=10)

                                                  │ BenchmarkRangeQuery_before.txt │    BenchmarkRangeQuery_after.txt    │
                                                  │           allocs/op            │  allocs/op   vs base                │
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-16                      5.256k ± 0%   5.859k ± 0%  +11.47% (p=0.000 n=10)
```