### PR TITLE
Build: remove -a from build to speed up rebuilds

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -18,7 +18,6 @@ build:
         windows:
             - builtinassets
             - stringlabels
-    flags: -a
     ldflags: |
         -X github.com/prometheus/common/version.Version={{.Version}}
         -X github.com/prometheus/common/version.Revision={{.Revision}}


### PR DESCRIPTION
I think this is a hold-over from when Go was less careful about separating architectures.

`make build` is about 3 minutes with this option and 1 minute without, on my desktop computer.
