### PR TITLE
Hide position info for warnings when position is unknown

### DIFF
--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -116,6 +116,9 @@ type annoErr struct {
 }
 
 func (e annoErr) Error() string {
+	if e.Query == "" {
+		return e.Err.Error()
+	}
 	return fmt.Sprintf("%s (%s)", e.Err, e.PositionRange.StartPosInput(e.Query, 0))
 }
 


### PR DESCRIPTION
e.g. when empty query string is passed in