### PR TITLE
Refactor rules seriesInPreviousEval

### DIFF
--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -109,6 +109,21 @@ func (ls Labels) Bytes(buf []byte) []byte {
 	return buf
 }
 
+func FromBytes(buf []byte) (*Labels, error) {
+	series := &Labels{}
+	err := series.FromBytes(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return series, nil
+}
+
+func (ls *Labels) FromBytes(buf []byte) error {
+	ls.data = string(buf)
+	return nil
+}
+
 // MarshalJSON implements json.Marshaler.
 func (ls Labels) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ls.Map())

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -561,6 +561,14 @@ func TestLabels_BytesWithoutLabels(t *testing.T) {
 	require.Equal(t, FromStrings("aaa", "111").Bytes(nil), FromStrings(MetricName, "333", "aaa", "111", "bbb", "222").BytesWithoutLabels(nil, MetricName, "bbb"))
 }
 
+func TestLabels_LabelsFromBytes(t *testing.T) {
+	ls1 := FromStrings("aaa", "111", "bbb", "222")
+	bt := ls1.Bytes(nil)
+	ls2 := Labels{}
+	ls2.FromBytes(bt)
+	require.Equal(t, bt, ls2.Bytes(nil))
+}
+
 func TestBuilder(t *testing.T) {
 	for i, tcase := range []struct {
 		base Labels

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -103,18 +103,19 @@ type NotifyFunc func(ctx context.Context, expr string, alerts ...*Alert)
 
 // ManagerOptions bundles options for the Manager.
 type ManagerOptions struct {
-	ExternalURL     *url.URL
-	QueryFunc       QueryFunc
-	NotifyFunc      NotifyFunc
-	Context         context.Context
-	Appendable      storage.Appendable
-	Queryable       storage.Queryable
-	Logger          log.Logger
-	Registerer      prometheus.Registerer
-	OutageTolerance time.Duration
-	ForGracePeriod  time.Duration
-	ResendDelay     time.Duration
-	GroupLoader     GroupLoader
+	ExternalURL            *url.URL
+	QueryFunc              QueryFunc
+	NotifyFunc             NotifyFunc
+	Context                context.Context
+	Appendable             storage.Appendable
+	Queryable              storage.Queryable
+	Logger                 log.Logger
+	Registerer             prometheus.Registerer
+	OutageTolerance        time.Duration
+	ForGracePeriod         time.Duration
+	ResendDelay            time.Duration
+	GroupLoader            GroupLoader
+	StaleSeriesRepoFactory StaleSeriesRepoFactory
 
 	Metrics *Metrics
 }

--- a/rules/stale.go
+++ b/rules/stale.go
@@ -1,0 +1,104 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type StaleSeriesRepo interface {
+	Clear()
+	InitCurrent(length int)
+	AddToCurrent(ls labels.Labels)
+	ForEachStale(ruleId int, fn func(lset labels.Labels))
+	MoveCurrentToPrevious(ruleId int)
+	GetNumberOfRules() int
+	GetAll(ruleId int) []labels.Labels
+	CopyFrom(ruleId int, other StaleSeriesRepo, otherRuleId int)
+}
+
+type StaleSeriesRepoFactory func(numberOfRules int) StaleSeriesRepo
+
+func DefaultStaleSeriesRepoFactory(numberOfRules int) StaleSeriesRepo {
+	return NewDefaultStaleSeriesRepo(numberOfRules)
+}
+
+type DefaultStaleSeriesRepo struct {
+	seriesReturned       map[string]bool
+	seriesInPreviousEval []map[string]bool
+	numberOfRules        int
+}
+
+func NewDefaultStaleSeriesRepo(numberOfRules int) *DefaultStaleSeriesRepo {
+	return &DefaultStaleSeriesRepo{
+		seriesInPreviousEval: make([]map[string]bool, numberOfRules),
+		numberOfRules:        numberOfRules,
+	}
+}
+
+func (r *DefaultStaleSeriesRepo) InitCurrent(length int) {
+	r.seriesReturned = make(map[string]bool, length)
+}
+
+func (r *DefaultStaleSeriesRepo) AddToCurrent(ls labels.Labels) {
+	buf := [1024]byte{}
+	r.seriesReturned[string(ls.Bytes(buf[:]))] = true
+}
+
+func (r *DefaultStaleSeriesRepo) Clear() {
+	r.seriesInPreviousEval = nil
+	r.seriesReturned = nil
+}
+
+func (r *DefaultStaleSeriesRepo) ForEachStale(ruleId int, fn func(lset labels.Labels)) {
+	for metric := range r.seriesInPreviousEval[ruleId] {
+		if _, ok := r.seriesReturned[metric]; !ok {
+			lset, err := labels.FromBytes([]byte(metric))
+			if err == nil {
+				fn(*lset)
+			}
+		}
+	}
+}
+
+func (r *DefaultStaleSeriesRepo) GetAll(ruleId int) []labels.Labels {
+	ls := make([]labels.Labels, 0, len(r.seriesInPreviousEval[ruleId]))
+	for metric := range r.seriesInPreviousEval[ruleId] {
+		lset, err := labels.FromBytes([]byte(metric))
+		if err == nil {
+			ls = append(ls, *lset)
+		}
+	}
+	return ls
+}
+
+func (r *DefaultStaleSeriesRepo) MoveCurrentToPrevious(ruleId int) {
+	r.seriesInPreviousEval[ruleId] = r.seriesReturned
+	r.seriesReturned = nil
+}
+
+func (r *DefaultStaleSeriesRepo) KeyCount(ruleId int) int {
+	if r.seriesInPreviousEval[ruleId] == nil {
+		return 0
+	}
+	return len(r.seriesInPreviousEval[ruleId])
+}
+
+func (r *DefaultStaleSeriesRepo) CopyFrom(ruleId int, other StaleSeriesRepo, otherRuleId int) {
+	r.seriesInPreviousEval[ruleId] = other.(*DefaultStaleSeriesRepo).seriesInPreviousEval[otherRuleId]
+}
+
+func (r *DefaultStaleSeriesRepo) GetNumberOfRules() int {
+	return r.numberOfRules
+}

--- a/rules/stale_test.go
+++ b/rules/stale_test.go
@@ -1,0 +1,45 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestMemoryStaleRepo(t *testing.T) {
+	seriesMemoryRepository := NewDefaultStaleSeriesRepo(7)
+	seriesMemoryRepository.InitCurrent(2)
+	seriesMemoryRepository.AddToCurrent(labels.FromStrings("l1", "v1"))
+	seriesMemoryRepository.AddToCurrent(labels.FromStrings("l2", "v2"))
+	seriesMemoryRepository.MoveCurrentToPrevious(0)
+
+	lbls := seriesMemoryRepository.GetAll(0)
+	require.Equal(t, 2, len(lbls))
+	require.Contains(t, lbls, labels.FromStrings("l1", "v1"))
+	require.Contains(t, lbls, labels.FromStrings("l2", "v2"))
+
+	seriesMemoryRepository.InitCurrent(1)
+	seriesMemoryRepository.AddToCurrent(labels.FromStrings("l2", "v2"))
+
+	c := 0
+	seriesMemoryRepository.ForEachStale(0, func(lset labels.Labels) {
+		require.Equal(t, labels.FromStrings("l1", "v1"), lset)
+		c++
+	})
+	require.Equal(t, 1, c)
+}


### PR DESCRIPTION
This PR refactors the handling of stale marks in rules.

Currently, time-series of every rule’s iteration are stored in a seriesInPreviousEval, an array of map[string]labels.Labels, which is a direct member of the rule. The map' keys are string made from the labels’ bytes - a data duplication. These labelsets of the series are stored not only during the rule group evaluation, but also between iterations (this is needed so they can later be compared with the current iteration, and any stale series can be marked as such). This makes seriesInPreviousEval a large consumer of heap space.

This PR refactors all the handling of the stale marks to a separate interface and implementation. The default implementation uses map[string]bool (Affectively a hash set). The labels can be reconstructed from the string when needed (for that FromBytes method was added to labels type).

A nonstandard implementation of that interface can be configured in ManagerOptions. This opens the options to offload the time-series to disk, which is possibly only relevant to systems running high load of rules (such as cortex ruler).
