### PR TITLE
PromQL: reduce garbage in range-query evaluation

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1172,9 +1172,7 @@ func (ev *evaluator) rangeEval(prepSeries func(labels.Labels, *EvalSeriesHelper)
 			bufHelpers[i] = make([]EvalSeriesHelper, len(matrixes[i]))
 
 			for si, series := range matrixes[i] {
-				h := seriesHelpers[i][si]
-				prepSeries(series.Metric, &h)
-				seriesHelpers[i][si] = h
+				prepSeries(series.Metric, &seriesHelpers[i][si])
 			}
 		}
 	}


### PR DESCRIPTION
The temporary variable `h` was allocated on the heap, and it is unnecessary.

It's not huge for performance but every little helps.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/promql
                                                 │   before    │               after               │
                                                 │   sec/op    │   sec/op     vs base              │
RangeQuery/expr=sum_by_(l)(h_one),steps=1-8        26.93µ ± 3%   26.82µ ± 1%       ~ (p=0.132 n=6)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-8        204.7µ ± 1%   202.0µ ± 0%  -1.30% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-8    1.965m ± 0%   1.939m ± 1%  -1.34% (p=0.026 n=6)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-8       32.30µ ± 1%   32.25µ ± 0%       ~ (p=0.240 n=6)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-8       207.1µ ± 0%   204.9µ ± 0%  -1.07% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-8   1.912m ± 1%   1.888m ± 1%  -1.23% (p=0.026 n=6)
geomean                                            227.5µ        225.4µ       -0.92%

                                                 │    before     │                after                │
                                                 │     B/op      │     B/op       vs base              │
RangeQuery/expr=sum_by_(l)(h_one),steps=1-8         16.65Ki ± 0%    16.40Ki ± 0%  -1.54% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-8         117.0Ki ± 0%    114.4Ki ± 0%  -2.21% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-8     1.063Mi ± 0%    1.038Mi ± 0%  -2.39% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-8        21.68Ki ± 0%    21.42Ki ± 0%  -1.19% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-8        117.4Ki ± 0%    114.9Ki ± 0%  -2.19% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-8   1040.4Ki ± 0%   1014.8Ki ± 0%  -2.46% (p=0.002 n=6)
geomean                                             133.3Ki         130.7Ki       -2.00%

                                                 │   before    │               after                │
                                                 │  allocs/op  │  allocs/op   vs base               │
RangeQuery/expr=sum_by_(l)(h_one),steps=1-8         248.0 ± 0%    237.0 ± 0%   -4.44% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_ten),steps=1-8        1090.0 ± 0%    980.0 ± 0%  -10.09% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-8    9.397k ± 0%   8.297k ± 0%  -11.71% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_one),steps=1-8        298.0 ± 0%    287.0 ± 0%   -3.69% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_ten),steps=1-8       1094.0 ± 0%    984.0 ± 0%  -10.05% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-8   9.020k ± 0%   7.920k ± 0%  -12.20% (p=0.002 n=6)
geomean                                            1.398k        1.276k        -8.76%
```