### PR TITLE
Labels: reduce allocations when creating from TSDB WAL

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -617,6 +617,12 @@ func (b *ScratchBuilder) Add(name, value string) {
 	b.add = append(b.add, Label{Name: name, Value: value})
 }
 
+// Add a name/value pair, using []byte instead of string.
+// Intended for '-tags stringlabels'; this version purely so the old way still compiles.
+func (b *ScratchBuilder) UnsafeAddBytes(name, value []byte) {
+	b.add = append(b.add, Label{Name: string(name), Value: string(value)})
+}
+
 // Sort the labels added so far by name.
 func (b *ScratchBuilder) Sort() {
 	slices.SortFunc(b.add, func(a, b Label) int { return strings.Compare(a.Name, b.Name) })

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -618,7 +618,8 @@ func (b *ScratchBuilder) Add(name, value string) {
 }
 
 // Add a name/value pair, using []byte instead of string.
-// Intended for '-tags stringlabels'; this version purely so the old way still compiles.
+// The '-tags stringlabels' version of this function is unsafe, hence the name.
+// This version is safe - it copies the strings immediately - but we keep the same name so everything compiles.
 func (b *ScratchBuilder) UnsafeAddBytes(name, value []byte) {
 	b.add = append(b.add, Label{Name: string(name), Value: string(value)})
 }

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -829,6 +829,12 @@ func (b *ScratchBuilder) Add(name, value string) {
 	b.add = append(b.add, Label{Name: name, Value: value})
 }
 
+// Add a name/value pair, using []byte instead of string to reduce memory allocations.
+// The values must remain live until Labels() is called.
+func (b *ScratchBuilder) UnsafeAddBytes(name, value []byte) {
+	b.add = append(b.add, Label{Name: yoloString(name), Value: yoloString(value)})
+}
+
 // Sort the labels added so far by name.
 func (b *ScratchBuilder) Sort() {
 	slices.SortFunc(b.add, func(a, b Label) int { return strings.Compare(a.Name, b.Name) })

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -279,13 +279,12 @@ func (d *Decoder) Metadata(rec []byte, metadata []RefMetadata) ([]RefMetadata, e
 
 // DecodeLabels decodes one set of labels from buf.
 func (d *Decoder) DecodeLabels(dec *encoding.Decbuf) labels.Labels {
-	// TODO: reconsider if this function could be pushed down into labels.Labels to be more efficient.
 	d.builder.Reset()
 	nLabels := dec.Uvarint()
 	for i := 0; i < nLabels; i++ {
-		lName := dec.UvarintStr()
-		lValue := dec.UvarintStr()
-		d.builder.Add(lName, lValue)
+		lName := dec.UvarintBytes()
+		lValue := dec.UvarintBytes()
+		d.builder.UnsafeAddBytes(lName, lValue)
 	}
 	return d.builder.Labels()
 }


### PR DESCRIPTION
This is used when reading the WAL; by passing references into the buffer we can avoid copying strings under `-tags stringlabels`.  It's even better with #12304.

I had to bump the number of iterations to get stable results on this benchmark:
```
% go test -tags stringlabels -benchtime 100x -run xxx -bench LoadWLs/samplesPerSeries=50,exemplarsPerSeries=0 -benchmem ./tsdb
```

Before:
```
               100         272656568 ns/op        218812154 B/op   2202642 allocs/op
```

After:
```
               100         269984012 ns/op        206498400 B/op   1203049 allocs/op
```