### PR TITLE
Do not keep the AlertingRule.activeMtx lock while running the query to restore an alert activeAt

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -93,15 +93,8 @@ type Alert struct {
 
 func (a *Alert) deepCopy() *Alert {
 	anew := *a
-
-	if a.Labels != nil {
-		anew.Labels = a.Labels.Copy()
-	}
-
-	if a.Annotations != nil {
-		anew.Annotations = a.Annotations.Copy()
-	}
-
+	anew.Labels = a.Labels.Copy()
+	anew.Annotations = a.Annotations.Copy()
 	return &anew
 }
 

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -684,7 +684,7 @@ func TestSendAlertsDontAffectActiveAlerts(t *testing.T) {
 	// Set an active alert.
 	lbls := labels.FromStrings("a1", "1")
 	h := lbls.Hash()
-	al := &Alert{State: StateFiring, Labels: lbls, ActiveAt: time.Now()}
+	al := &Alert{State: StateFiring, Labels: lbls, Annotations: labels.EmptyLabels(), ActiveAt: time.Now()}
 	rule.active[h] = al
 
 	expr, err := parser.ParseExpr("foo")


### PR DESCRIPTION
In Mimir we're chasing  since few months an infrequent (big) slowdown in the API used to list the active rules. It happens sometimes in the Mimir ruler, typically at startup, and we haven't found the cause. Till today.

### What's happening?

- The Mimir ruler `/api/v1/rules` API endpoint, among other things, calls `AlertingRule.ActiveAlerts()` to get the active alerts of an alerting rule
- `AlertingRule.ActiveAlerts()` takes the `AlertingRule.activeMtx` lock before iterating on active alerts and make a copy of the list
- The `AlertingRule.activeMtx` is also taken by `AlertingRule.ForEachActiveAlert()`
- The `AlertingRule.ForEachActiveAlert()` is called by `Group.RestoreForState()` to restore the `activeAt` timestamp of an active alert (in Mimir this could happen at a Mimir ruler startup or after a resharing)
- The `Group.RestoreForState()` runs the query(s) to fetch the state while the `AlertingRule.activeMtx` lock is held, because `AlertingRule.ForEachActiveAlert()` correctly keeps the lock for the entire iteration
- Typically, the query to restore the state is fast, but if there's any issue (e.g. networking issue, slowdown in the read path, etc...) the lock is held for long enough to slow down significantly the `/api/v1/rules` API endpoint

### What I'm proposing in this PR

In this PR I propose to run the query to restore each alert state **without** holding the lock. To do it I changed the logic into 3 steps:

1. With lock: Get the list of active alerts to restore
2. Without lock: Run the queries to get the desired activeAt
3. With lock: Update the active alerts' activeAt

### Suggestions to review the PR

- The [1st commit](https://github.com/prometheus/prometheus/pull/13049/commits/6969a09aebf3b01c257961dc1bd25ed140235b43) is a refactoring. Logic shouldn't have changed. Review it with "hide whitespace changes"
- The [2nd commit](https://github.com/prometheus/prometheus/pull/13049/commits/a7dc5e57aa08f7fe9e1eebefff18cd4f48ed4b00) is the actual logic change.
