### PR TITLE
Use only one scrapeMetrics object per test

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -792,8 +792,9 @@ func TestScrapeLoopRun(t *testing.T) {
 		signal = make(chan struct{}, 1)
 		errc   = make(chan error)
 
-		scraper = &testScraper{}
-		app     = func(ctx context.Context) storage.Appender { return &nopAppender{} }
+		scraper       = &testScraper{}
+		app           = func(ctx context.Context) storage.Appender { return &nopAppender{} }
+		scrapeMetrics = newTestScrapeMetrics(t)
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -817,7 +818,7 @@ func TestScrapeLoopRun(t *testing.T) {
 		false,
 		nil,
 		false,
-		newTestScrapeMetrics(t),
+		scrapeMetrics,
 	)
 
 	// The loop must terminate during the initial offset if the context
@@ -876,7 +877,7 @@ func TestScrapeLoopRun(t *testing.T) {
 		false,
 		nil,
 		false,
-		newTestScrapeMetrics(t),
+		scrapeMetrics,
 	)
 
 	go func() {
@@ -974,9 +975,10 @@ func TestScrapeLoopForcedErr(t *testing.T) {
 
 func TestScrapeLoopMetadata(t *testing.T) {
 	var (
-		signal  = make(chan struct{})
-		scraper = &testScraper{}
-		cache   = newScrapeCache(newTestScrapeMetrics(t))
+		signal        = make(chan struct{})
+		scraper       = &testScraper{}
+		scrapeMetrics = newTestScrapeMetrics(t)
+		cache         = newScrapeCache(scrapeMetrics)
 	)
 	defer close(signal)
 
@@ -1001,7 +1003,7 @@ func TestScrapeLoopMetadata(t *testing.T) {
 		false,
 		nil,
 		false,
-		newTestScrapeMetrics(t),
+		scrapeMetrics,
 	)
 	defer cancel()
 


### PR DESCRIPTION
This is a minor change to get the tests' behaviour more in line with the behaviour of production code.

PR #12958 introduced a `scrapeMetrics` struct which is instantiated when a `scrapeManager` is created. The same instance of `scrapeMetrics` is then reused in the various components of the `scrape` package such as `scrapeManager` and `scrapeLoop`. 

As suggested in [this comment](https://github.com/prometheus/prometheus/commit/5752050b42195d87d7dd0760f7ec3b088f115cd3#r131276453) by @bboreham, it is more correct for the scrape loop and scrape cache to use the same `scrapeMetrics` in tests.

