### PR TITLE
Reset alert `ActiveAt` and `FiredAt` when it becomes firing from prev…

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -447,6 +447,11 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 				continue
 			}
 		} else {
+			// Reset `ActiveAt` and `FiredAt` when alert becomes firing from previous `Stabilizing`.
+			if a.State == StateFiring && !a.KeepFiringSince.IsZero() {
+				a.ActiveAt = ts
+				a.FiredAt = ts
+			}
 			// The alert is firing, reset keepFiringSince.
 			a.KeepFiringSince = time.Time{}
 		}


### PR DESCRIPTION
…ious `Stabilizing`
We use `keep_firing_for` to stabilize and prevent confusing resolved messages from being propagated through Alertmanager. But If the alert become firing again from this `keep_firing`, I think we should update:
1. the `ActiveAt` which generate the timestamp in `ALERTS_FOR_STATE`, otherwise it could cause wrong results when restoring rules. But the `ALERTS_FOR_STATE` during the `keep_firing` stage also effect the restore results, I'm not sure whether to remove `ALERTS_FOR_STATE` totally when `keep_firing`.
2. `FiredAt` which propagate to alertmanager, although that won't change the stamp inside alertmanager's memory because it always [store the earliest starting time](https://github.com/prometheus/alertmanager/blob/7cdecbf6ee97951d3ba1430fae6598a1fe9defe1/types/types.go#L357). And alertmanager won't resend firing notification to users.

The `ActiveAt` could equal to `FiredAt` in this situation even if rule have non-zero `for`.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
