### PR TITLE
TSDB block index writer: reduce memory used by symbol cache

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -107,8 +107,8 @@ func newCRC32() hash.Hash32 {
 
 type symbolCacheEntry struct {
 	index          uint32
-	lastValue      string
 	lastValueIndex uint32
+	lastValue      string
 }
 
 // Writer implements the IndexWriter interface for the standard
@@ -457,8 +457,8 @@ func (w *Writer) AddSeries(ref storage.SeriesRef, lset labels.Labels, chunks ...
 			}
 			w.symbolCache[l.Name] = symbolCacheEntry{
 				index:          nameIndex,
-				lastValue:      l.Value,
 				lastValueIndex: valueIndex,
+				lastValue:      l.Value,
 			}
 		}
 		w.buf2.PutUvarint32(valueIndex)


### PR DESCRIPTION
the benchmark is:

```
BenchmarkSymbolCacheEntry_WithAlignment-4      	 5377081	       224.4 ns/op	     121 B/op	       0 allocs/op
BenchmarkSymbolCacheEntry_WithoutAlignment-4   	 6005053	       224.1 ns/op	     137 B/op	       0 allocs/op
```

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
