### PR TITLE
Add min time to histogram chunks

### DIFF
--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -935,7 +935,8 @@ func TestCompaction_populateBlock(t *testing.T) {
 			},
 		},
 		{
-			title:          "Populate from mixed type series and expect sample inside the interval only", // regression test for populateWithDelChunkSeriesIterator failing to set minTime on chunks
+			// Regression test for populateWithDelChunkSeriesIterator failing to set minTime on chunks.
+			title:          "Populate from mixed type series and expect sample inside the interval only.",
 			compactMinTime: 1,
 			compactMaxTime: 11,
 			inputSeriesSamples: [][]seriesSamples{

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/tsdb/wlog"
 )
 
@@ -933,6 +934,31 @@ func TestCompaction_populateBlock(t *testing.T) {
 				},
 			},
 		},
+		{
+			title:          "Populate from mixed type series and expect sample inside the interval only", // regression test for populateWithDelChunkSeriesIterator failing to set minTime on chunks
+			compactMinTime: 1,
+			compactMaxTime: 11,
+			inputSeriesSamples: [][]seriesSamples{
+				{
+					{
+						lset: map[string]string{"a": "1"},
+						chunks: [][]sample{
+							{{t: 0, h: tsdbutil.GenerateTestHistogram(0)}, {t: 1, h: tsdbutil.GenerateTestHistogram(1)}},
+							{{t: 10, f: 1}, {t: 11, f: 2}},
+						},
+					},
+				},
+			},
+			expSeriesSamples: []seriesSamples{
+				{
+					lset: map[string]string{"a": "1"},
+					chunks: [][]sample{
+						{{t: 1, h: tsdbutil.GenerateTestHistogram(1)}},
+						{{t: 10, f: 1}},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			blocks := make([]BlockReader, 0, len(tc.inputSeriesSamples))
@@ -974,12 +1000,23 @@ func TestCompaction_populateBlock(t *testing.T) {
 						firstTs int64 = math.MaxInt64
 						s       sample
 					)
-					for iter.Next() == chunkenc.ValFloat {
-						s.t, s.f = iter.At()
+					for vt := iter.Next(); vt != chunkenc.ValNone; vt = iter.Next() {
+						switch vt {
+						case chunkenc.ValFloat:
+							s.t, s.f = iter.At()
+							samples = append(samples, s)
+						case chunkenc.ValHistogram:
+							s.t, s.h = iter.AtHistogram()
+							samples = append(samples, s)
+						case chunkenc.ValFloatHistogram:
+							s.t, s.fh = iter.AtFloatHistogram()
+							samples = append(samples, s)
+						default:
+							require.Fail(t, "unexpected value type")
+						}
 						if firstTs == math.MaxInt64 {
 							firstTs = s.t
 						}
-						samples = append(samples, s)
 					}
 
 					// Check if chunk has correct min, max times.

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -855,13 +855,18 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 		if app, err = newChunk.Appender(); err != nil {
 			break
 		}
-
-		for vt := valueType; vt != chunkenc.ValNone; vt = p.currDelIter.Next() {
+		var h *histogram.Histogram
+		t, h = p.currDelIter.AtHistogram()
+		p.curr.MinTime = t
+		_, _, app, err = app.AppendHistogram(nil, t, h, true)
+		if err != nil {
+			break
+		}
+		for vt := p.currDelIter.Next(); vt != chunkenc.ValNone; vt = p.currDelIter.Next() {
 			if vt != chunkenc.ValHistogram {
 				err = fmt.Errorf("found value type %v in histogram chunk", vt)
 				break
 			}
-			var h *histogram.Histogram
 			t, h = p.currDelIter.AtHistogram()
 			_, _, app, err = app.AppendHistogram(nil, t, h, true)
 			if err != nil {
@@ -890,13 +895,18 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 		if app, err = newChunk.Appender(); err != nil {
 			break
 		}
-
-		for vt := valueType; vt != chunkenc.ValNone; vt = p.currDelIter.Next() {
+		var h *histogram.FloatHistogram
+		t, h = p.currDelIter.AtFloatHistogram()
+		p.curr.MinTime = t
+		_, _, app, err = app.AppendFloatHistogram(nil, t, h, true)
+		if err != nil {
+			break
+		}
+		for vt := p.currDelIter.Next(); vt != chunkenc.ValNone; vt = p.currDelIter.Next() {
 			if vt != chunkenc.ValFloatHistogram {
 				err = fmt.Errorf("found value type %v in histogram chunk", vt)
 				break
 			}
-			var h *histogram.FloatHistogram
 			t, h = p.currDelIter.AtFloatHistogram()
 			_, _, app, err = app.AppendFloatHistogram(nil, t, h, true)
 			if err != nil {

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -840,6 +840,7 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 		}
 		return false
 	}
+	p.curr.MinTime = p.currDelIter.AtT()
 
 	// Re-encode the chunk if iterator is provider. This means that it has
 	// some samples to be deleted or chunk is opened.
@@ -855,18 +856,12 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 		if app, err = newChunk.Appender(); err != nil {
 			break
 		}
-		var h *histogram.Histogram
-		t, h = p.currDelIter.AtHistogram()
-		p.curr.MinTime = t
-		_, _, app, err = app.AppendHistogram(nil, t, h, true)
-		if err != nil {
-			break
-		}
-		for vt := p.currDelIter.Next(); vt != chunkenc.ValNone; vt = p.currDelIter.Next() {
+		for vt := valueType; vt != chunkenc.ValNone; vt = p.currDelIter.Next() {
 			if vt != chunkenc.ValHistogram {
 				err = fmt.Errorf("found value type %v in histogram chunk", vt)
 				break
 			}
+			var h *histogram.Histogram
 			t, h = p.currDelIter.AtHistogram()
 			_, _, app, err = app.AppendHistogram(nil, t, h, true)
 			if err != nil {
@@ -878,15 +873,12 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 		if app, err = newChunk.Appender(); err != nil {
 			break
 		}
-		var v float64
-		t, v = p.currDelIter.At()
-		p.curr.MinTime = t
-		app.Append(t, v)
-		for vt := p.currDelIter.Next(); vt != chunkenc.ValNone; vt = p.currDelIter.Next() {
+		for vt := valueType; vt != chunkenc.ValNone; vt = p.currDelIter.Next() {
 			if vt != chunkenc.ValFloat {
 				err = fmt.Errorf("found value type %v in float chunk", vt)
 				break
 			}
+			var v float64
 			t, v = p.currDelIter.At()
 			app.Append(t, v)
 		}
@@ -895,18 +887,12 @@ func (p *populateWithDelChunkSeriesIterator) Next() bool {
 		if app, err = newChunk.Appender(); err != nil {
 			break
 		}
-		var h *histogram.FloatHistogram
-		t, h = p.currDelIter.AtFloatHistogram()
-		p.curr.MinTime = t
-		_, _, app, err = app.AppendFloatHistogram(nil, t, h, true)
-		if err != nil {
-			break
-		}
-		for vt := p.currDelIter.Next(); vt != chunkenc.ValNone; vt = p.currDelIter.Next() {
+		for vt := valueType; vt != chunkenc.ValNone; vt = p.currDelIter.Next() {
 			if vt != chunkenc.ValFloatHistogram {
 				err = fmt.Errorf("found value type %v in histogram chunk", vt)
 				break
 			}
+			var h *histogram.FloatHistogram
 			t, h = p.currDelIter.AtFloatHistogram()
 			_, _, app, err = app.AppendFloatHistogram(nil, t, h, true)
 			if err != nil {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -133,12 +133,35 @@ func createIdxChkReaders(t *testing.T, tc []seriesSamples) (IndexReader, ChunkRe
 				Ref:     chunkRef,
 			})
 
-			chunk := chunkenc.NewXORChunk()
-			app, _ := chunk.Appender()
-			for _, smpl := range chk {
-				app.Append(smpl.t, smpl.f)
+			switch {
+			case chk[0].fh != nil:
+				chunk := chunkenc.NewFloatHistogramChunk()
+				app, _ := chunk.Appender()
+				for _, smpl := range chk {
+					require.NotNil(t, smpl.fh, "chunk can only contain one type of sample")
+					_, _, _, err := app.AppendFloatHistogram(nil, smpl.t, smpl.fh, true)
+					require.NoError(t, err, "chunk should be appendable")
+				}
+				chkReader[chunkRef] = chunk
+			case chk[0].h != nil:
+				chunk := chunkenc.NewHistogramChunk()
+				app, _ := chunk.Appender()
+				for _, smpl := range chk {
+					require.NotNil(t, smpl.h, "chunk can only contain one type of sample")
+					_, _, _, err := app.AppendHistogram(nil, smpl.t, smpl.h, true)
+					require.NoError(t, err, "chunk should be appendable")
+				}
+				chkReader[chunkRef] = chunk
+			default:
+				chunk := chunkenc.NewXORChunk()
+				app, _ := chunk.Appender()
+				for _, smpl := range chk {
+					require.Nil(t, smpl.h, "chunk can only contain one type of sample")
+					require.Nil(t, smpl.fh, "chunk can only contain one type of sample")
+					app.Append(smpl.t, smpl.f)
+				}
+				chkReader[chunkRef] = chunk
 			}
-			chkReader[chunkRef] = chunk
 			chunkRef++
 		}
 		ls := labels.FromMap(s.lset)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1160,65 +1160,218 @@ func rmChunkRefs(chks []chunks.Meta) {
 
 // Regression for: https://github.com/prometheus/tsdb/pull/97
 func TestPopulateWithDelSeriesIterator_DoubleSeek(t *testing.T) {
-	f, chkMetas := createFakeReaderAndNotPopulatedChunks(
-		[]chunks.Sample{},
-		[]chunks.Sample{sample{1, 1, nil, nil}, sample{2, 2, nil, nil}, sample{3, 3, nil, nil}},
-		[]chunks.Sample{sample{4, 4, nil, nil}, sample{5, 5, nil, nil}},
-	)
-
-	it := &populateWithDelSeriesIterator{}
-	it.reset(ulid.ULID{}, f, chkMetas, nil)
-	require.Equal(t, chunkenc.ValFloat, it.Seek(1))
-	require.Equal(t, chunkenc.ValFloat, it.Seek(2))
-	require.Equal(t, chunkenc.ValFloat, it.Seek(2))
-	ts, v := it.At()
-	require.Equal(t, int64(2), ts)
-	require.Equal(t, float64(2), v)
+	t.Run("float", func(t *testing.T) {
+		valType := chunkenc.ValFloat
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{},
+			[]chunks.Sample{sample{1, 1, nil, nil}, sample{2, 2, nil, nil}, sample{3, 3, nil, nil}},
+			[]chunks.Sample{sample{4, 4, nil, nil}, sample{5, 5, nil, nil}},
+		)
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, nil)
+		require.Equal(t, valType, it.Seek(1))
+		require.Equal(t, valType, it.Seek(2))
+		require.Equal(t, valType, it.Seek(2))
+		ts, v := it.At()
+		require.Equal(t, int64(2), ts)
+		require.Equal(t, float64(2), v)
+		require.Equal(t, int64(0), chkMetas[0].MinTime)
+		require.Equal(t, int64(1), chkMetas[1].MinTime)
+		require.Equal(t, int64(4), chkMetas[2].MinTime)
+	})
+	t.Run("histogram", func(t *testing.T) {
+		valType := chunkenc.ValHistogram
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{},
+			[]chunks.Sample{sample{1, 0, tsdbutil.GenerateTestHistogram(1), nil}, sample{2, 0, tsdbutil.GenerateTestHistogram(2), nil}, sample{3, 0, tsdbutil.GenerateTestHistogram(3), nil}},
+			[]chunks.Sample{sample{4, 0, tsdbutil.GenerateTestHistogram(4), nil}, sample{5, 0, tsdbutil.GenerateTestHistogram(5), nil}},
+		)
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, nil)
+		require.Equal(t, valType, it.Seek(1))
+		require.Equal(t, valType, it.Seek(2))
+		require.Equal(t, valType, it.Seek(2))
+		ts, h := it.AtHistogram()
+		require.Equal(t, int64(2), ts)
+		h.CounterResetHint = histogram.UnknownCounterReset
+		require.Equal(t, tsdbutil.GenerateTestHistogram(2), h)
+		require.Equal(t, int64(0), chkMetas[0].MinTime)
+		require.Equal(t, int64(1), chkMetas[1].MinTime)
+		require.Equal(t, int64(4), chkMetas[2].MinTime)
+	})
+	t.Run("float histogram", func(t *testing.T) {
+		valType := chunkenc.ValFloatHistogram
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{},
+			[]chunks.Sample{sample{1, 0, nil, tsdbutil.GenerateTestFloatHistogram(1)}, sample{2, 0, nil, tsdbutil.GenerateTestFloatHistogram(2)}, sample{3, 0, nil, tsdbutil.GenerateTestFloatHistogram(3)}},
+			[]chunks.Sample{sample{4, 0, nil, tsdbutil.GenerateTestFloatHistogram(4)}, sample{5, 0, nil, tsdbutil.GenerateTestFloatHistogram(5)}},
+		)
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, nil)
+		require.Equal(t, valType, it.Seek(1))
+		require.Equal(t, valType, it.Seek(2))
+		require.Equal(t, valType, it.Seek(2))
+		ts, h := it.AtFloatHistogram()
+		require.Equal(t, int64(2), ts)
+		h.CounterResetHint = histogram.UnknownCounterReset
+		require.Equal(t, tsdbutil.GenerateTestFloatHistogram(2), h)
+		require.Equal(t, int64(0), chkMetas[0].MinTime)
+		require.Equal(t, int64(1), chkMetas[1].MinTime)
+		require.Equal(t, int64(4), chkMetas[2].MinTime)
+	})
 }
 
 // Regression when seeked chunks were still found via binary search and we always
 // skipped to the end when seeking a value in the current chunk.
 func TestPopulateWithDelSeriesIterator_SeekInCurrentChunk(t *testing.T) {
-	f, chkMetas := createFakeReaderAndNotPopulatedChunks(
-		[]chunks.Sample{},
-		[]chunks.Sample{sample{1, 2, nil, nil}, sample{3, 4, nil, nil}, sample{5, 6, nil, nil}, sample{7, 8, nil, nil}},
-		[]chunks.Sample{},
-	)
+	t.Run("float", func(t *testing.T) {
+		valType := chunkenc.ValFloat
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{},
+			[]chunks.Sample{sample{1, 2, nil, nil}, sample{3, 4, nil, nil}, sample{5, 6, nil, nil}, sample{7, 8, nil, nil}},
+			[]chunks.Sample{},
+		)
 
-	it := &populateWithDelSeriesIterator{}
-	it.reset(ulid.ULID{}, f, chkMetas, nil)
-	require.Equal(t, chunkenc.ValFloat, it.Next())
-	ts, v := it.At()
-	require.Equal(t, int64(1), ts)
-	require.Equal(t, float64(2), v)
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, nil)
+		require.Equal(t, valType, it.Next())
+		ts, v := it.At()
+		require.Equal(t, int64(1), ts)
+		require.Equal(t, float64(2), v)
 
-	require.Equal(t, chunkenc.ValFloat, it.Seek(4))
-	ts, v = it.At()
-	require.Equal(t, int64(5), ts)
-	require.Equal(t, float64(6), v)
+		require.Equal(t, valType, it.Seek(4))
+		ts, v = it.At()
+		require.Equal(t, int64(5), ts)
+		require.Equal(t, float64(6), v)
+
+		require.Equal(t, int64(0), chkMetas[0].MinTime)
+		require.Equal(t, int64(1), chkMetas[1].MinTime)
+		require.Equal(t, int64(0), chkMetas[2].MinTime)
+	})
+	t.Run("histogram", func(t *testing.T) {
+		valType := chunkenc.ValHistogram
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{},
+			[]chunks.Sample{sample{1, 0, tsdbutil.GenerateTestHistogram(2), nil}, sample{3, 0, tsdbutil.GenerateTestHistogram(4), nil}, sample{5, 0, tsdbutil.GenerateTestHistogram(6), nil}, sample{7, 0, tsdbutil.GenerateTestHistogram(8), nil}},
+			[]chunks.Sample{},
+		)
+
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, nil)
+		require.Equal(t, valType, it.Next())
+		ts, h := it.AtHistogram()
+		require.Equal(t, int64(1), ts)
+		require.Equal(t, tsdbutil.GenerateTestHistogram(2), h)
+
+		require.Equal(t, valType, it.Seek(4))
+		ts, h = it.AtHistogram()
+		require.Equal(t, int64(5), ts)
+		h.CounterResetHint = histogram.UnknownCounterReset
+		require.Equal(t, tsdbutil.GenerateTestHistogram(6), h)
+
+		require.Equal(t, int64(0), chkMetas[0].MinTime)
+		require.Equal(t, int64(1), chkMetas[1].MinTime)
+		require.Equal(t, int64(0), chkMetas[2].MinTime)
+	})
+	t.Run("float histogram", func(t *testing.T) {
+		valType := chunkenc.ValFloatHistogram
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{},
+			[]chunks.Sample{sample{1, 0, nil, tsdbutil.GenerateTestFloatHistogram(2)}, sample{3, 0, nil, tsdbutil.GenerateTestFloatHistogram(4)}, sample{5, 0, nil, tsdbutil.GenerateTestFloatHistogram(6)}, sample{7, 0, nil, tsdbutil.GenerateTestFloatHistogram(8)}},
+			[]chunks.Sample{},
+		)
+
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, nil)
+		require.Equal(t, valType, it.Next())
+		ts, h := it.AtFloatHistogram()
+		require.Equal(t, int64(1), ts)
+		require.Equal(t, tsdbutil.GenerateTestFloatHistogram(2), h)
+
+		require.Equal(t, valType, it.Seek(4))
+		ts, h = it.AtFloatHistogram()
+		require.Equal(t, int64(5), ts)
+		h.CounterResetHint = histogram.UnknownCounterReset
+		require.Equal(t, tsdbutil.GenerateTestFloatHistogram(6), h)
+
+		require.Equal(t, int64(0), chkMetas[0].MinTime)
+		require.Equal(t, int64(1), chkMetas[1].MinTime)
+		require.Equal(t, int64(0), chkMetas[2].MinTime)
+	})
 }
 
 func TestPopulateWithDelSeriesIterator_SeekWithMinTime(t *testing.T) {
-	f, chkMetas := createFakeReaderAndNotPopulatedChunks(
-		[]chunks.Sample{sample{1, 6, nil, nil}, sample{5, 6, nil, nil}, sample{6, 8, nil, nil}},
-	)
+	t.Run("float", func(t *testing.T) {
+		valType := chunkenc.ValFloat
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{sample{1, 6, nil, nil}, sample{5, 6, nil, nil}, sample{6, 8, nil, nil}},
+		)
 
-	it := &populateWithDelSeriesIterator{}
-	it.reset(ulid.ULID{}, f, chkMetas, nil)
-	require.Equal(t, chunkenc.ValNone, it.Seek(7))
-	require.Equal(t, chunkenc.ValFloat, it.Seek(3))
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, nil)
+		require.Equal(t, chunkenc.ValNone, it.Seek(7))
+		require.Equal(t, valType, it.Seek(3))
+		require.Equal(t, int64(1), chkMetas[0].MinTime)
+	})
+	t.Run("histogram", func(t *testing.T) {
+		valType := chunkenc.ValHistogram
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{sample{1, 0, tsdbutil.GenerateTestHistogram(6), nil}, sample{5, 0, tsdbutil.GenerateTestHistogram(6), nil}, sample{6, 0, tsdbutil.GenerateTestHistogram(8), nil}},
+		)
+
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, nil)
+		require.Equal(t, chunkenc.ValNone, it.Seek(7))
+		require.Equal(t, valType, it.Seek(3))
+		require.Equal(t, int64(1), chkMetas[0].MinTime)
+	})
+	t.Run("float histogram", func(t *testing.T) {
+		valType := chunkenc.ValFloatHistogram
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{sample{1, 0, nil, tsdbutil.GenerateTestFloatHistogram(6)}, sample{5, 0, nil, tsdbutil.GenerateTestFloatHistogram(6)}, sample{6, 0, nil, tsdbutil.GenerateTestFloatHistogram(8)}},
+		)
+
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, nil)
+		require.Equal(t, chunkenc.ValNone, it.Seek(7))
+		require.Equal(t, valType, it.Seek(3))
+		require.Equal(t, int64(1), chkMetas[0].MinTime)
+	})
 }
 
 // Regression when calling Next() with a time bounded to fit within two samples.
 // Seek gets called and advances beyond the max time, which was just accepted as a valid sample.
 func TestPopulateWithDelSeriesIterator_NextWithMinTime(t *testing.T) {
-	f, chkMetas := createFakeReaderAndNotPopulatedChunks(
-		[]chunks.Sample{sample{1, 6, nil, nil}, sample{5, 6, nil, nil}, sample{7, 8, nil, nil}},
-	)
+	t.Run("float", func(t *testing.T) {
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{sample{1, 6, nil, nil}, sample{5, 6, nil, nil}, sample{7, 8, nil, nil}},
+		)
 
-	it := &populateWithDelSeriesIterator{}
-	it.reset(ulid.ULID{}, f, chkMetas, tombstones.Intervals{{Mint: math.MinInt64, Maxt: 2}}.Add(tombstones.Interval{Mint: 4, Maxt: math.MaxInt64}))
-	require.Equal(t, chunkenc.ValNone, it.Next())
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, tombstones.Intervals{{Mint: math.MinInt64, Maxt: 2}}.Add(tombstones.Interval{Mint: 4, Maxt: math.MaxInt64}))
+		require.Equal(t, chunkenc.ValNone, it.Next())
+		require.Equal(t, int64(1), chkMetas[0].MinTime)
+	})
+	t.Run("histogram", func(t *testing.T) {
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{sample{1, 0, tsdbutil.GenerateTestHistogram(6), nil}, sample{5, 0, tsdbutil.GenerateTestHistogram(6), nil}, sample{7, 0, tsdbutil.GenerateTestHistogram(8), nil}},
+		)
+
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, tombstones.Intervals{{Mint: math.MinInt64, Maxt: 2}}.Add(tombstones.Interval{Mint: 4, Maxt: math.MaxInt64}))
+		require.Equal(t, chunkenc.ValNone, it.Next())
+		require.Equal(t, int64(1), chkMetas[0].MinTime)
+	})
+	t.Run("float histogram", func(t *testing.T) {
+		f, chkMetas := createFakeReaderAndNotPopulatedChunks(
+			[]chunks.Sample{sample{1, 0, nil, tsdbutil.GenerateTestFloatHistogram(6)}, sample{5, 0, nil, tsdbutil.GenerateTestFloatHistogram(6)}, sample{7, 0, nil, tsdbutil.GenerateTestFloatHistogram(8)}},
+		)
+
+		it := &populateWithDelSeriesIterator{}
+		it.reset(ulid.ULID{}, f, chkMetas, tombstones.Intervals{{Mint: math.MinInt64, Maxt: 2}}.Add(tombstones.Interval{Mint: 4, Maxt: math.MaxInt64}))
+		require.Equal(t, chunkenc.ValNone, it.Next())
+		require.Equal(t, int64(1), chkMetas[0].MinTime)
+	})
 }
 
 // Test the cost of merging series sets for different number of merged sets and their size.

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -950,7 +950,30 @@ func TestPopulateWithTombSeriesIterators(t *testing.T) {
 			expectedMinMaxTimes: []minMaxTimes{{1, 6}},
 		},
 		{
-			name: "one histogram chunk intersect with deletion interval",
+			name: "one histogram chunk intersect with earlier deletion interval",
+			chks: [][]chunks.Sample{
+				{
+					sample{1, 0, tsdbutil.GenerateTestHistogram(1), nil},
+					sample{2, 0, tsdbutil.GenerateTestHistogram(2), nil},
+					sample{3, 0, tsdbutil.GenerateTestHistogram(3), nil},
+					sample{6, 0, tsdbutil.GenerateTestHistogram(6), nil},
+				},
+			},
+			intervals: tombstones.Intervals{{Mint: 1, Maxt: 2}},
+			expected: []chunks.Sample{
+				sample{3, 0, tsdbutil.SetHistogramNotCounterReset(tsdbutil.GenerateTestHistogram(3)), nil},
+				sample{6, 0, tsdbutil.SetHistogramNotCounterReset(tsdbutil.GenerateTestHistogram(6)), nil},
+			},
+			expectedChks: []chunks.Meta{
+				assureChunkFromSamples(t, []chunks.Sample{
+					sample{3, 0, tsdbutil.SetHistogramNotCounterReset(tsdbutil.GenerateTestHistogram(3)), nil},
+					sample{6, 0, tsdbutil.SetHistogramNotCounterReset(tsdbutil.GenerateTestHistogram(6)), nil},
+				}),
+			},
+			expectedMinMaxTimes: []minMaxTimes{{3, 6}},
+		},
+		{
+			name: "one histogram chunk intersect with later deletion interval",
 			chks: [][]chunks.Sample{
 				{
 					sample{1, 0, tsdbutil.GenerateTestHistogram(1), nil},
@@ -1001,7 +1024,30 @@ func TestPopulateWithTombSeriesIterators(t *testing.T) {
 			expectedMinMaxTimes: []minMaxTimes{{1, 6}},
 		},
 		{
-			name: "one float histogram chunk intersect with deletion interval",
+			name: "one float histogram chunk intersect with earlier deletion interval",
+			chks: [][]chunks.Sample{
+				{
+					sample{1, 0, nil, tsdbutil.GenerateTestFloatHistogram(1)},
+					sample{2, 0, nil, tsdbutil.GenerateTestFloatHistogram(2)},
+					sample{3, 0, nil, tsdbutil.GenerateTestFloatHistogram(3)},
+					sample{6, 0, nil, tsdbutil.GenerateTestFloatHistogram(6)},
+				},
+			},
+			intervals: tombstones.Intervals{{Mint: 1, Maxt: 2}},
+			expected: []chunks.Sample{
+				sample{3, 0, nil, tsdbutil.SetFloatHistogramNotCounterReset(tsdbutil.GenerateTestFloatHistogram(3))},
+				sample{6, 0, nil, tsdbutil.SetFloatHistogramNotCounterReset(tsdbutil.GenerateTestFloatHistogram(6))},
+			},
+			expectedChks: []chunks.Meta{
+				assureChunkFromSamples(t, []chunks.Sample{
+					sample{3, 0, nil, tsdbutil.SetFloatHistogramNotCounterReset(tsdbutil.GenerateTestFloatHistogram(3))},
+					sample{6, 0, nil, tsdbutil.SetFloatHistogramNotCounterReset(tsdbutil.GenerateTestFloatHistogram(6))},
+				}),
+			},
+			expectedMinMaxTimes: []minMaxTimes{{3, 6}},
+		},
+		{
+			name: "one float histogram chunk intersect with later deletion interval",
 			chks: [][]chunks.Sample{
 				{
 					sample{1, 0, nil, tsdbutil.GenerateTestFloatHistogram(1)},
@@ -1052,7 +1098,30 @@ func TestPopulateWithTombSeriesIterators(t *testing.T) {
 			expectedMinMaxTimes: []minMaxTimes{{1, 6}},
 		},
 		{
-			name: "one gauge histogram chunk intersect with deletion interval",
+			name: "one gauge histogram chunk intersect with earlier deletion interval",
+			chks: [][]chunks.Sample{
+				{
+					sample{1, 0, tsdbutil.GenerateTestGaugeHistogram(1), nil},
+					sample{2, 0, tsdbutil.GenerateTestGaugeHistogram(2), nil},
+					sample{3, 0, tsdbutil.GenerateTestGaugeHistogram(3), nil},
+					sample{6, 0, tsdbutil.GenerateTestGaugeHistogram(6), nil},
+				},
+			},
+			intervals: tombstones.Intervals{{Mint: 1, Maxt: 2}},
+			expected: []chunks.Sample{
+				sample{3, 0, tsdbutil.GenerateTestGaugeHistogram(3), nil},
+				sample{6, 0, tsdbutil.GenerateTestGaugeHistogram(6), nil},
+			},
+			expectedChks: []chunks.Meta{
+				assureChunkFromSamples(t, []chunks.Sample{
+					sample{3, 0, tsdbutil.GenerateTestGaugeHistogram(3), nil},
+					sample{6, 0, tsdbutil.GenerateTestGaugeHistogram(6), nil},
+				}),
+			},
+			expectedMinMaxTimes: []minMaxTimes{{3, 6}},
+		},
+		{
+			name: "one gauge histogram chunk intersect with later deletion interval",
 			chks: [][]chunks.Sample{
 				{
 					sample{1, 0, tsdbutil.GenerateTestGaugeHistogram(1), nil},
@@ -1103,7 +1172,30 @@ func TestPopulateWithTombSeriesIterators(t *testing.T) {
 			expectedMinMaxTimes: []minMaxTimes{{1, 6}},
 		},
 		{
-			name: "one gauge float histogram chunk intersect with deletion interval",
+			name: "one gauge float histogram chunk intersect with earlier deletion interval",
+			chks: [][]chunks.Sample{
+				{
+					sample{1, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(1)},
+					sample{2, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(2)},
+					sample{3, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(3)},
+					sample{6, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(6)},
+				},
+			},
+			intervals: tombstones.Intervals{{Mint: 1, Maxt: 2}},
+			expected: []chunks.Sample{
+				sample{3, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(3)},
+				sample{6, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(6)},
+			},
+			expectedChks: []chunks.Meta{
+				assureChunkFromSamples(t, []chunks.Sample{
+					sample{3, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(3)},
+					sample{6, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(6)},
+				}),
+			},
+			expectedMinMaxTimes: []minMaxTimes{{3, 6}},
+		},
+		{
+			name: "one gauge float histogram chunk intersect with later deletion interval",
 			chks: [][]chunks.Sample{
 				{
 					sample{1, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(1)},
@@ -1221,6 +1313,38 @@ func TestPopulateWithTombSeriesIterators(t *testing.T) {
 				}),
 			},
 			expectedMinMaxTimes: []minMaxTimes{{7, 7}, {12, 13}, {203, 203}},
+		},
+		{
+			name: "three full mixed chunks overlapping",
+			chks: [][]chunks.Sample{
+				{
+					sample{7, 0, tsdbutil.GenerateTestGaugeHistogram(89), nil},
+					sample{12, 0, tsdbutil.GenerateTestGaugeHistogram(8), nil},
+				},
+				{sample{11, 2, nil, nil}, sample{12, 3, nil, nil}, sample{13, 5, nil, nil}, sample{16, 1, nil, nil}},
+				{
+					sample{10, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(22)},
+					sample{203, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(3493)},
+				},
+			},
+
+			expected: []chunks.Sample{
+				sample{7, 0, tsdbutil.GenerateTestGaugeHistogram(89), nil}, sample{12, 0, tsdbutil.GenerateTestGaugeHistogram(8), nil}, sample{11, 2, nil, nil}, sample{12, 3, nil, nil}, sample{13, 5, nil, nil}, sample{16, 1, nil, nil}, sample{10, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(22)}, sample{203, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(3493)},
+			},
+			expectedChks: []chunks.Meta{
+				assureChunkFromSamples(t, []chunks.Sample{
+					sample{7, 0, tsdbutil.GenerateTestGaugeHistogram(89), nil},
+					sample{12, 0, tsdbutil.GenerateTestGaugeHistogram(8), nil},
+				}),
+				assureChunkFromSamples(t, []chunks.Sample{
+					sample{11, 2, nil, nil}, sample{12, 3, nil, nil}, sample{13, 5, nil, nil}, sample{16, 1, nil, nil},
+				}),
+				assureChunkFromSamples(t, []chunks.Sample{
+					sample{10, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(22)},
+					sample{203, 0, nil, tsdbutil.GenerateTestGaugeFloatHistogram(3493)},
+				}),
+			},
+			expectedMinMaxTimes: []minMaxTimes{{7, 12}, {11, 16}, {10, 203}},
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
This fixes root cause of compactor failures with many chunks non-completely outside the block time range.

You can test `TestPopulateWithTombSeriesIterators` before and after the latest commit to verify that it fails before and passes after.

The new `expectedMinMaxTimes` in the unit tests may not be necessary as they can be inferred from `expectedChks`. Not sure if we want to include it just as an actual check though (in case the inference from `expectedChks` can be buggy somehow).

So the bug that this fixes is that previously, when the deletion interval removes the earlier part of a integer/float gauge/counter histogram chunk, the minTime is not updated. For example, when the true time range of the chunk is 200-300, it may be recorded as 100-300. (Previously we only tested the removal of the later part and maxTime, which already works.) You don't need to have mixed types of chunks in a block.