### PR TITLE
Enable previously disabled revive (lint) rules and fix up code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,8 +81,39 @@ linters-settings:
   gofumpt:
     extra-rules: true
   revive:
+    # By default, revive will enable only the linting rules that are named in the configuration file.
+    # So, it's needed to explicitly set in configuration all required rules.
+    # The following configuration enables all the rules from the defaults.toml
+    # https://github.com/mgechev/revive/blob/master/defaults.toml
     rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
-      - name: unused-parameter
-        severity: warning
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
+      - name: blank-imports
+      - name: context-as-argument
+        arguments:
+          # allow functions with test or bench signatures
+          - allowTypesBefore: "*testing.T,testing.TB"
+      - name: context-keys-type
+      - name: dot-imports
+      # A lot of false positives: incorrectly identifies channel draining as "empty code block".
+      # See https://github.com/mgechev/revive/issues/386
+      - name: empty-block
         disabled: true
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+        disabled: true
+      - name: var-declaration
+      - name: var-naming

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -411,7 +411,7 @@ func checkExperimental(f bool) {
 	}
 }
 
-var lintError = fmt.Errorf("lint error")
+var errLint = fmt.Errorf("lint error")
 
 type lintConfig struct {
 	all            bool
@@ -763,7 +763,7 @@ func checkRulesFromStdin(ls lintConfig) (bool, bool) {
 		fmt.Fprintln(os.Stderr, "  FAILED:")
 		for _, e := range errs {
 			fmt.Fprintln(os.Stderr, e.Error())
-			hasErrors = hasErrors || !errors.Is(e, lintError)
+			hasErrors = hasErrors || !errors.Is(e, errLint)
 		}
 		if hasErrors {
 			return failed, hasErrors
@@ -776,7 +776,7 @@ func checkRulesFromStdin(ls lintConfig) (bool, bool) {
 		}
 		failed = true
 		for _, err := range errs {
-			hasErrors = hasErrors || !errors.Is(err, lintError)
+			hasErrors = hasErrors || !errors.Is(err, errLint)
 		}
 	} else {
 		fmt.Printf("  SUCCESS: %d rules found\n", n)
@@ -797,7 +797,7 @@ func checkRules(files []string, ls lintConfig) (bool, bool) {
 			fmt.Fprintln(os.Stderr, "  FAILED:")
 			for _, e := range errs {
 				fmt.Fprintln(os.Stderr, e.Error())
-				hasErrors = hasErrors || !errors.Is(e, lintError)
+				hasErrors = hasErrors || !errors.Is(e, errLint)
 			}
 			if hasErrors {
 				continue
@@ -810,7 +810,7 @@ func checkRules(files []string, ls lintConfig) (bool, bool) {
 			}
 			failed = true
 			for _, err := range errs {
-				hasErrors = hasErrors || !errors.Is(err, lintError)
+				hasErrors = hasErrors || !errors.Is(err, errLint)
 			}
 		} else {
 			fmt.Printf("  SUCCESS: %d rules found\n", n)
@@ -837,7 +837,7 @@ func checkRuleGroups(rgs *rulefmt.RuleGroups, lintSettings lintConfig) (int, []e
 				})
 			}
 			errMessage += "Might cause inconsistency while recording expressions"
-			return 0, []error{fmt.Errorf("%w %s", lintError, errMessage)}
+			return 0, []error{fmt.Errorf("%w %s", errLint, errMessage)}
 		}
 	}
 

--- a/discovery/openstack/instance.go
+++ b/discovery/openstack/instance.go
@@ -145,16 +145,16 @@ func (i *InstanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 				openstackLabelUserID:         model.LabelValue(s.UserID),
 			}
 
-			flavorId, ok := s.Flavor["id"].(string)
+			flavorID, ok := s.Flavor["id"].(string)
 			if !ok {
 				level.Warn(i.logger).Log("msg", "Invalid type for flavor id, expected string")
 				continue
 			}
-			labels[openstackLabelInstanceFlavor] = model.LabelValue(flavorId)
+			labels[openstackLabelInstanceFlavor] = model.LabelValue(flavorID)
 
-			imageId, ok := s.Image["id"].(string)
+			imageID, ok := s.Image["id"].(string)
 			if ok {
-				labels[openstackLabelInstanceImage] = model.LabelValue(imageId)
+				labels[openstackLabelInstanceImage] = model.LabelValue(imageID)
 			}
 
 			for k, v := range s.Metadata {

--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -331,12 +331,12 @@ func (h *FloatHistogram) Equals(h2 *FloatHistogram) bool {
 // Size returns the total size of the FloatHistogram, which includes the size of the pointer
 // to FloatHistogram, all its fields, and all elements contained in slices.
 // NOTE: this is only valid for 64 bit architectures.
-func (fh *FloatHistogram) Size() int {
+func (h *FloatHistogram) Size() int {
 	// Size of each slice separately.
-	posSpanSize := len(fh.PositiveSpans) * 8     // 8 bytes (int32 + uint32).
-	negSpanSize := len(fh.NegativeSpans) * 8     // 8 bytes (int32 + uint32).
-	posBucketSize := len(fh.PositiveBuckets) * 8 // 8 bytes (float64).
-	negBucketSize := len(fh.NegativeBuckets) * 8 // 8 bytes (float64).
+	posSpanSize := len(h.PositiveSpans) * 8     // 8 bytes (int32 + uint32).
+	negSpanSize := len(h.NegativeSpans) * 8     // 8 bytes (int32 + uint32).
+	posBucketSize := len(h.PositiveBuckets) * 8 // 8 bytes (float64).
+	negBucketSize := len(h.NegativeBuckets) * 8 // 8 bytes (float64).
 
 	// Total size of the struct.
 
@@ -978,8 +978,8 @@ func addBuckets(
 	spansB []Span, bucketsB []float64,
 ) ([]Span, []float64) {
 	var (
-		iSpan              int = -1
-		iBucket            int = -1
+		iSpan              = -1
+		iBucket            = -1
 		iInSpan            int32
 		indexA             int32
 		indexB             int32
@@ -1012,17 +1012,16 @@ func addBuckets(
 						spansA[0].Length++
 						spansA[0].Offset--
 						goto nextLoop
-					} else {
-						spansA = append(spansA, Span{})
-						copy(spansA[1:], spansA)
-						spansA[0] = Span{Offset: indexB, Length: 1}
-						if len(spansA) > 1 {
-							// Convert the absolute offset in the formerly
-							// first span to a relative offset.
-							spansA[1].Offset -= indexB + 1
-						}
-						goto nextLoop
 					}
+					spansA = append(spansA, Span{})
+					copy(spansA[1:], spansA)
+					spansA[0] = Span{Offset: indexB, Length: 1}
+					if len(spansA) > 1 {
+						// Convert the absolute offset in the formerly
+						// first span to a relative offset.
+						spansA[1].Offset -= indexB + 1
+					}
+					goto nextLoop
 				} else if spansA[0].Offset == indexB {
 					// Just add to first bucket.
 					bucketsA[0] += bucketB
@@ -1040,48 +1039,47 @@ func addBuckets(
 					iInSpan += deltaIndex
 					bucketsA[iBucket] += bucketB
 					break
-				} else {
-					deltaIndex -= remainingInSpan
-					iBucket += int(remainingInSpan)
-					iSpan++
-					if iSpan == len(spansA) || deltaIndex < spansA[iSpan].Offset {
-						// Bucket is in gap behind previous span (or there are no further spans).
-						bucketsA = append(bucketsA, 0)
-						copy(bucketsA[iBucket+1:], bucketsA[iBucket:])
-						bucketsA[iBucket] = bucketB
-						switch {
-						case deltaIndex == 0:
-							// Directly after previous span, extend previous span.
-							if iSpan < len(spansA) {
-								spansA[iSpan].Offset--
-							}
-							iSpan--
-							iInSpan = int32(spansA[iSpan].Length)
-							spansA[iSpan].Length++
-							goto nextLoop
-						case iSpan < len(spansA) && deltaIndex == spansA[iSpan].Offset-1:
-							// Directly before next span, extend next span.
-							iInSpan = 0
+				}
+				deltaIndex -= remainingInSpan
+				iBucket += int(remainingInSpan)
+				iSpan++
+				if iSpan == len(spansA) || deltaIndex < spansA[iSpan].Offset {
+					// Bucket is in gap behind previous span (or there are no further spans).
+					bucketsA = append(bucketsA, 0)
+					copy(bucketsA[iBucket+1:], bucketsA[iBucket:])
+					bucketsA[iBucket] = bucketB
+					switch {
+					case deltaIndex == 0:
+						// Directly after previous span, extend previous span.
+						if iSpan < len(spansA) {
 							spansA[iSpan].Offset--
-							spansA[iSpan].Length++
-							goto nextLoop
-						default:
-							// No next span, or next span is not directly adjacent to new bucket.
-							// Add new span.
-							iInSpan = 0
-							if iSpan < len(spansA) {
-								spansA[iSpan].Offset -= deltaIndex + 1
-							}
-							spansA = append(spansA, Span{})
-							copy(spansA[iSpan+1:], spansA[iSpan:])
-							spansA[iSpan] = Span{Length: 1, Offset: deltaIndex}
-							goto nextLoop
 						}
-					} else {
-						// Try start of next span.
-						deltaIndex -= spansA[iSpan].Offset
+						iSpan--
+						iInSpan = int32(spansA[iSpan].Length)
+						spansA[iSpan].Length++
+						goto nextLoop
+					case iSpan < len(spansA) && deltaIndex == spansA[iSpan].Offset-1:
+						// Directly before next span, extend next span.
 						iInSpan = 0
+						spansA[iSpan].Offset--
+						spansA[iSpan].Length++
+						goto nextLoop
+					default:
+						// No next span, or next span is not directly adjacent to new bucket.
+						// Add new span.
+						iInSpan = 0
+						if iSpan < len(spansA) {
+							spansA[iSpan].Offset -= deltaIndex + 1
+						}
+						spansA = append(spansA, Span{})
+						copy(spansA[iSpan+1:], spansA[iSpan:])
+						spansA[iSpan] = Span{Length: 1, Offset: deltaIndex}
+						goto nextLoop
 					}
+				} else {
+					// Try start of next span.
+					deltaIndex -= spansA[iSpan].Offset
+					iInSpan = 0
 				}
 			}
 

--- a/promql/parser/lex.go
+++ b/promql/parser/lex.go
@@ -566,9 +566,8 @@ Loop:
 				if l.peek() == ':' {
 					l.emit(desc)
 					return lexHistogram
-				} else {
-					l.errorf("missing `:` for histogram descriptor")
 				}
+				l.errorf("missing `:` for histogram descriptor")
 			} else {
 				l.errorf("bad histogram descriptor found: %q", word)
 			}

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -72,7 +72,7 @@ func WithFunctions(functions map[string]*Function) Opt {
 }
 
 // NewParser returns a new parser.
-func NewParser(input string, opts ...Opt) *parser {
+func NewParser(input string, opts ...Opt) *parser { //nolint:revive // unexported-return.
 	p := parserPool.Get().(*parser)
 
 	p.functions = Functions

--- a/storage/remote/azuread/azuread.go
+++ b/storage/remote/azuread/azuread.go
@@ -62,7 +62,7 @@ type OAuthConfig struct {
 }
 
 // AzureADConfig is used to store the config values.
-type AzureADConfig struct {
+type AzureADConfig struct { //nolint:revive // exported.
 	// ManagedIdentity is the managed identity that is being used to authenticate.
 	ManagedIdentity *ManagedIdentityConfig `yaml:"managed_identity,omitempty"`
 

--- a/storage/remote/azuread/azuread_test.go
+++ b/storage/remote/azuread/azuread_test.go
@@ -283,7 +283,7 @@ func (s *TokenProviderTestSuite) TestNewTokenProvider() {
 			s.Assert().NotNil(actualTokenProvider.getAccessToken(context.Background()))
 
 			s.mockCredential.AssertNumberOfCalls(s.T(), "GetToken", 2*mockGetTokenCallCounter)
-			mockGetTokenCallCounter += 1
+			mockGetTokenCallCounter++
 			accessToken, err := actualTokenProvider.getAccessToken(context.Background())
 			s.Assert().Nil(err)
 			s.Assert().NotEqual(accessToken, testTokenString)

--- a/storage/remote/otlptranslator/prometheus/normalize_label.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_label.go
@@ -25,7 +25,6 @@ var dropSanitizationGate = featuregate.GlobalRegistry().MustRegister(
 //
 // Exception is made for double-underscores which are allowed
 func NormalizeLabel(label string) string {
-
 	// Trivial case
 	if len(label) == 0 {
 		return label

--- a/tsdb/errors/errors.go
+++ b/tsdb/errors/errors.go
@@ -25,7 +25,7 @@ import (
 type multiError []error
 
 // NewMulti returns multiError with provided errors added if not nil.
-func NewMulti(errs ...error) multiError {
+func NewMulti(errs ...error) multiError { //nolint:revive // unexported-return.
 	m := multiError{}
 	m.Add(errs...)
 	return m

--- a/tsdb/wlog/wlog.go
+++ b/tsdb/wlog/wlog.go
@@ -970,7 +970,7 @@ type segmentBufReader struct {
 	off  int // Offset of read data into current segment.
 }
 
-func NewSegmentBufReader(segs ...*Segment) *segmentBufReader {
+func NewSegmentBufReader(segs ...*Segment) io.ReadCloser {
 	if len(segs) == 0 {
 		return &segmentBufReader{}
 	}
@@ -981,15 +981,16 @@ func NewSegmentBufReader(segs ...*Segment) *segmentBufReader {
 	}
 }
 
-func NewSegmentBufReaderWithOffset(offset int, segs ...*Segment) (sbr *segmentBufReader, err error) {
+func NewSegmentBufReaderWithOffset(offset int, segs ...*Segment) (io.ReadCloser, error) {
 	if offset == 0 || len(segs) == 0 {
 		return NewSegmentBufReader(segs...), nil
 	}
 
-	sbr = &segmentBufReader{
+	sbr := &segmentBufReader{
 		buf:  bufio.NewReaderSize(segs[0], 16*pageSize),
 		segs: segs,
 	}
+	var err error
 	if offset > 0 {
 		_, err = sbr.buf.Discard(offset)
 	}

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -94,6 +94,7 @@ func (a Annotations) AsStrings(query string, maxAnnos int) []string {
 	return arr
 }
 
+//nolint:revive // error-naming.
 var (
 	// Currently there are only 2 types, warnings and info.
 	// For now, info are visually identical with warnings as we have not updated
@@ -130,7 +131,7 @@ func (e annoErr) Unwrap() error {
 
 // NewInvalidQuantileWarning is used when the user specifies an invalid quantile
 // value, i.e. a float that is outside the range [0, 1] or NaN.
-func NewInvalidQuantileWarning(q float64, pos posrange.PositionRange) annoErr {
+func NewInvalidQuantileWarning(q float64, pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w, got %g", InvalidQuantileWarning, q),
@@ -139,7 +140,7 @@ func NewInvalidQuantileWarning(q float64, pos posrange.PositionRange) annoErr {
 
 // NewBadBucketLabelWarning is used when there is an error parsing the bucket label
 // of a classic histogram.
-func NewBadBucketLabelWarning(metricName, label string, pos posrange.PositionRange) annoErr {
+func NewBadBucketLabelWarning(metricName, label string, pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w of %q for metric name %q", BadBucketLabelWarning, label, metricName),
@@ -149,7 +150,7 @@ func NewBadBucketLabelWarning(metricName, label string, pos posrange.PositionRan
 // NewMixedFloatsHistogramsWarning is used when the queried series includes both
 // float samples and histogram samples for functions that do not support mixed
 // samples.
-func NewMixedFloatsHistogramsWarning(metricName string, pos posrange.PositionRange) annoErr {
+func NewMixedFloatsHistogramsWarning(metricName string, pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q", MixedFloatsHistogramsWarning, metricName),
@@ -158,7 +159,7 @@ func NewMixedFloatsHistogramsWarning(metricName string, pos posrange.PositionRan
 
 // NewMixedClassicNativeHistogramsWarning is used when the queried series includes
 // both classic and native histograms.
-func NewMixedClassicNativeHistogramsWarning(metricName string, pos posrange.PositionRange) annoErr {
+func NewMixedClassicNativeHistogramsWarning(metricName string, pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q", MixedClassicNativeHistogramsWarning, metricName),
@@ -167,7 +168,7 @@ func NewMixedClassicNativeHistogramsWarning(metricName string, pos posrange.Posi
 
 // NewPossibleNonCounterInfo is used when a named counter metric with only float samples does not
 // have the suffixes _total, _sum, _count, or _bucket.
-func NewPossibleNonCounterInfo(metricName string, pos posrange.PositionRange) annoErr {
+func NewPossibleNonCounterInfo(metricName string, pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q", PossibleNonCounterInfo, metricName),
@@ -176,7 +177,7 @@ func NewPossibleNonCounterInfo(metricName string, pos posrange.PositionRange) an
 
 // NewHistogramQuantileForcedMonotonicityInfo is used when the input (classic histograms) to
 // histogram_quantile needs to be forced to be monotonic.
-func NewHistogramQuantileForcedMonotonicityInfo(metricName string, pos posrange.PositionRange) annoErr {
+func NewHistogramQuantileForcedMonotonicityInfo(metricName string, pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q", HistogramQuantileForcedMonotonicityInfo, metricName),


### PR DESCRIPTION
This PR enables `revive` linter default rules that were implicitly disabled in #12197. Also, the PR fixes `revive` lint issues.

## Explanation

By design, if no particular configuration is provided, `revive` will behave as `golint` does, i.e. all `golint` rules are enabled (see this [default.toml](https://github.com/mgechev/revive/blob/master/defaults.toml)). But when a configuration is provided, only rules in the configuration are enabled (see [revive's doc)](https://github.com/mgechev/revive/tree/master#configuration). That's why, when PR #12197 disables `unused-parameter` in the configuration, it actually disables the whole default ruleset.

Thanks to @bboreham for pointing out revive's configuration issue [here](https://github.com/prometheus/prometheus/pull/12926#issuecomment-1787538416) 

## Additional Logs

Below is the full list of `revive` issues that were disabled or fixed:

```
❯ golangci-lint run
cmd/promtool/main.go:414:5: error-naming: error var lintError should have name of the form errFoo (revive)
var lintError = fmt.Errorf("lint error")
    ^
discovery/openstack/instance.go:148:4: var-naming: var flavorId should be flavorID (revive)
                        flavorId, ok := s.Flavor["id"].(string)
                        ^
discovery/openstack/instance.go:155:4: var-naming: var imageId should be imageID (revive)
                        imageId, ok := s.Image["id"].(string)
                        ^
discovery/zookeeper/zookeeper.go:196:4: empty-block: this block is empty, you can remove it (revive)
                        for range pathUpdate {
                        }
model/histogram/float_histogram.go:344:1: receiver-naming: receiver name fh should be consistent with previous receiver name h for FloatHistogram (revive)
func (fh *FloatHistogram) Size() int {
        // Size of each slice separately.
        posSpanSize := len(fh.PositiveSpans) * 8     // 8 bytes (int32 + uint32).
        negSpanSize := len(fh.NegativeSpans) * 8     // 8 bytes (int32 + uint32).
        posBucketSize := len(fh.PositiveBuckets) * 8 // 8 bytes (float64).
        negBucketSize := len(fh.NegativeBuckets) * 8 // 8 bytes (float64).

        // Total size of the struct.

        // fh is 8 bytes.
        // fh.CounterResetHint is 4 bytes (1 byte bool + 3 bytes padding).
        // fh.Schema is 4 bytes.
        // fh.ZeroThreshold is 8 bytes.
        // fh.ZeroCount is 8 bytes.
        // fh.Count is 8 bytes.
        // fh.Sum is 8 bytes.
        // fh.PositiveSpans is 24 bytes.
        // fh.NegativeSpans is 24 bytes.
        // fh.PositiveBuckets is 24 bytes.
        // fh.NegativeBuckets is 24 bytes.
        structSize := 144

        return structSize + posSpanSize + negSpanSize + posBucketSize + negBucketSize
}
model/histogram/float_histogram.go:1021:22: var-declaration: should omit type int from declaration of var iSpan; it will be inferred from the right-hand side (revive)
                iSpan              int = -1
                                   ^
model/histogram/float_histogram.go:1022:22: var-declaration: should omit type int from declaration of var iBucket; it will be inferred from the right-hand side (revive)
                iBucket            int = -1
                                   ^
model/histogram/float_histogram.go:1055:13: superfluous-else: if block ends with a goto statement, so drop this else and outdent its block (revive)
                                        } else {
                                                spansA = append(spansA, Span{})
                                                copy(spansA[1:], spansA)
                                                spansA[0] = Span{Offset: indexB, Length: 1}
                                                if len(spansA) > 1 {
                                                        // Convert the absolute offset in the formerly
                                                        // first span to a relative offset.
                                                        spansA[1].Offset -= indexB + 1
                                                }
                                                goto nextLoop
                                        }
model/histogram/float_histogram.go:1083:12: superfluous-else: if block ends with a break statement, so drop this else and outdent its block (revive)
                                } else {
                                        deltaIndex -= remainingInSpan
                                        iBucket += int(remainingInSpan)
                                        iSpan++
                                        if iSpan == len(spansA) || deltaIndex < spansA[iSpan].Offset {
                                                // Bucket is in gap behind previous span (or there are no further spans).
                                                bucketsA = append(bucketsA, 0)
                                                copy(bucketsA[iBucket+1:], bucketsA[iBucket:])
                                                bucketsA[iBucket] = bucketB
                                                switch {
                                                case deltaIndex == 0:
                                                        // Directly after previous span, extend previous span.
                                                        if iSpan < len(spansA) {
                                                                spansA[iSpan].Offset--
                                                        }
                                                        iSpan--
                                                        iInSpan = int32(spansA[iSpan].Length)
                                                        spansA[iSpan].Length++
                                                        goto nextLoop
                                                case iSpan < len(spansA) && deltaIndex == spansA[iSpan].Offset-1:
                                                        // Directly before next span, extend next span.
                                                        iInSpan = 0
                                                        spansA[iSpan].Offset--
                                                        spansA[iSpan].Length++
                                                        goto nextLoop
                                                default:
                                                        // No next span, or next span is not directly adjacent to new bucket.
                                                        // Add new span.
                                                        iInSpan = 0
                                                        if iSpan < len(spansA) {
                                                                spansA[iSpan].Offset -= deltaIndex + 1
                                                        }
                                                        spansA = append(spansA, Span{})
                                                        copy(spansA[iSpan+1:], spansA[iSpan:])
                                                        spansA[iSpan] = Span{Length: 1, Offset: deltaIndex}
                                                        goto nextLoop
                                                }
                                        } else {
                                                // Try start of next span.
                                                deltaIndex -= spansA[iSpan].Offset
                                                iInSpan = 0
                                        }
                                }
promql/engine.go:2028:47: empty-block: this block is empty, you can remove it (revive)
                for drop = 0; floats[drop].T < mint; drop++ {
                }
promql/engine.go:2050:51: empty-block: this block is empty, you can remove it (revive)
                for drop = 0; histograms[drop].T < mint; drop++ {
                }
promql/parser/lex.go:569:12: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
                                } else {
                                        l.errorf("missing `:` for histogram descriptor")
                                }
promql/parser/parse.go:75:43: unexported-return: exported func NewParser returns unexported type *parser.parser, which can be annoying to use (revive)
func NewParser(input string, opts ...Opt) *parser {
                                          ^
promql/parser/parse.go:662:92: empty-block: this block is empty, you can remove it (revive)
                        for r.Start = n.LHS.PositionRange().End; isSpace(rune(p.lex.input[r.Start])); r.Start++ {
                        }
promql/parser/parse.go:664:92: empty-block: this block is empty, you can remove it (revive)
                        for r.End = n.RHS.PositionRange().Start - 1; isSpace(rune(p.lex.input[r.End])); r.End-- {
                        }
storage/buffer_test.go:262:36: empty-block: this block is empty, you can remove it (revive)
        for it.Next() != chunkenc.ValNone {
                // Scan everything.
        }
storage/memoized_iterator_test.go:115:36: empty-block: this block is empty, you can remove it (revive)
        for it.Next() != chunkenc.ValNone {
                // Scan everything.
        }
storage/remote/azuread/azuread.go:65:6: exported: type name will be used as azuread.AzureADConfig by other packages, and that stutters; consider calling this Config (revive)
type AzureADConfig struct {
     ^
storage/remote/azuread/azuread_test.go:286:4: increment-decrement: should replace mockGetTokenCallCounter += 1 with mockGetTokenCallCounter++ (revive)
                        mockGetTokenCallCounter += 1
                        ^
storage/remote/otlptranslator/prometheus/normalize_label.go:18:6: exported: func name will be used as normalize.NormalizeLabel by other packages, and that stutters; consider calling this Label (revive)
func NormalizeLabel(label string) string {
     ^
tsdb/chunkenc/float_histogram.go:106:37: empty-block: this block is empty, you can remove it (revive)
        for it.Next() == ValFloatHistogram {
        }
tsdb/chunkenc/float_histogram_test.go:160:38: empty-block: this block is empty, you can remove it (revive)
        for itX.Next() == ValFloatHistogram {
                // Just iterate through without accessing anything.
        }
tsdb/chunkenc/histogram.go:117:32: empty-block: this block is empty, you can remove it (revive)
        for it.Next() == ValHistogram {
        }
tsdb/chunkenc/histogram_test.go:165:33: empty-block: this block is empty, you can remove it (revive)
        for itX.Next() == ValHistogram {
                // Just iterate through without accessing anything.
        }
tsdb/chunkenc/xor.go:102:27: empty-block: this block is empty, you can remove it (revive)
        for it.Next() != ValNone {
        }
tsdb/errors/errors.go:28:30: unexported-return: exported func NewMulti returns unexported type errors.multiError, which can be annoying to use (revive)
func NewMulti(errs ...error) multiError {
                             ^
tsdb/head_wal.go:407:3: empty-block: this block is empty, you can remove it (revive)
                for range decoded {
                }
tsdb/head_wal.go:531:2: empty-block: this block is empty, you can remove it (revive)
        for range wp.output {
        }
tsdb/head_wal.go:533:2: empty-block: this block is empty, you can remove it (revive)
        for range wp.histogramsOutput {
        }
tsdb/head_wal.go:852:2: empty-block: this block is empty, you can remove it (revive)
        for range wp.output {
        }
tsdb/head_wal.go:1367:5: empty-block: this block is empty, you can remove it (revive)
                                for range rc {
                                }
tsdb/querier_test.go:2251:33: context-as-argument: context.Context should be the first parameter of a function (revive)
func appendSeries(t *testing.T, ctx context.Context, wg *sync.WaitGroup, h *Head) {
                                ^
tsdb/wlog/wlog.go:975:44: unexported-return: exported func NewSegmentBufReader returns unexported type *wlog.segmentBufReader, which can be annoying to use (revive)
func NewSegmentBufReader(segs ...*Segment) *segmentBufReader {
                                           ^
tsdb/wlog/wlog.go:986:71: unexported-return: exported func NewSegmentBufReaderWithOffset returns unexported type *wlog.segmentBufReader, which can be annoying to use (revive)
func NewSegmentBufReaderWithOffset(offset int, segs ...*Segment) (sbr *segmentBufReader, err error) {
                                                                      ^
util/annotations/annotations.go:102:2: error-naming: error var PromQLInfo should have name of the form ErrFoo (revive)
        PromQLInfo    = errors.New("PromQL info")
        ^
util/annotations/annotations.go:103:2: error-naming: error var PromQLWarning should have name of the form ErrFoo (revive)
        PromQLWarning = errors.New("PromQL warning")
        ^
util/annotations/annotations.go:105:2: error-naming: error var InvalidQuantileWarning should have name of the form ErrFoo (revive)
        InvalidQuantileWarning              = fmt.Errorf("%w: quantile value should be between 0 and 1", PromQLWarning)
        ^
util/annotations/annotations.go:106:2: error-naming: error var BadBucketLabelWarning should have name of the form ErrFoo (revive)
        BadBucketLabelWarning               = fmt.Errorf("%w: bucket label %q is missing or has a malformed value", PromQLWarning, model.BucketLabel)
        ^
util/annotations/annotations.go:107:2: error-naming: error var MixedFloatsHistogramsWarning should have name of the form ErrFoo (revive)
        MixedFloatsHistogramsWarning        = fmt.Errorf("%w: encountered a mix of histograms and floats for metric name", PromQLWarning)
        ^
util/annotations/annotations.go:108:2: error-naming: error var MixedClassicNativeHistogramsWarning should have name of the form ErrFoo (revive)
        MixedClassicNativeHistogramsWarning = fmt.Errorf("%w: vector contains a mix of classic and native histograms for metric name", PromQLWarning)
        ^
util/annotations/annotations.go:110:55: error-strings: error strings should not be capitalized or end with punctuation or a newline (revive)
        PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
                                                             ^
util/annotations/annotations.go:111:2: error-naming: error var HistogramQuantileForcedMonotonicityInfo should have name of the form ErrFoo (revive)
        HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (and may give inaccurate results) for metric name", PromQLInfo)
        ^
util/annotations/annotations.go:133:71: unexported-return: exported func NewInvalidQuantileWarning returns unexported type annotations.annoErr, which can be annoying to use (revive)
func NewInvalidQuantileWarning(q float64, pos posrange.PositionRange) annoErr {
                                                                      ^
util/annotations/annotations.go:142:85: unexported-return: exported func NewBadBucketLabelWarning returns unexported type annotations.annoErr, which can be annoying to use (revive)
func NewBadBucketLabelWarning(metricName, label string, pos posrange.PositionRange) annoErr {
                                                                                    ^
util/annotations/annotations.go:152:85: unexported-return: exported func NewMixedFloatsHistogramsWarning returns unexported type annotations.annoErr, which can be annoying to use (revive)
func NewMixedFloatsHistogramsWarning(metricName string, pos posrange.PositionRange) annoErr {
                                                                                    ^
util/annotations/annotations.go:161:92: unexported-return: exported func NewMixedClassicNativeHistogramsWarning returns unexported type annotations.annoErr, which can be annoying to use (revive)
func NewMixedClassicNativeHistogramsWarning(metricName string, pos posrange.PositionRange) annoErr {
                                                                                           ^
util/annotations/annotations.go:170:79: unexported-return: exported func NewPossibleNonCounterInfo returns unexported type annotations.annoErr, which can be annoying to use (revive)
func NewPossibleNonCounterInfo(metricName string, pos posrange.PositionRange) annoErr {
                                                                              ^
util/annotations/annotations.go:179:96: unexported-return: exported func NewHistogramQuantileForcedMonotonicityInfo returns unexported type annotations.annoErr, which can be annoying to use (revive)
func NewHistogramQuantileForcedMonotonicityInfo(metricName string, pos posrange.PositionRange) annoErr {
                                                                                               ^
util/treecache/treecache.go:119:3: empty-block: this block is empty, you can remove it (revive)
                for range tc.head.events {
                }
```