### PR TITLE
reuse header chunk with sync.pool

### DIFF
--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -353,9 +353,12 @@ func FromData(e Encoding, d []byte) (Chunk, error) {
 }
 
 // NewEmptyChunk returns an empty chunk for the given encoding.
-func NewEmptyChunk(e Encoding) (Chunk, error) {
+func NewEmptyChunk(e Encoding, withPool ...bool) (Chunk, error) {
 	switch e {
 	case EncXOR:
+		if len(withPool) > 0 {
+			return GetXORChunk(), nil
+		}
 		return NewXORChunk(), nil
 	case EncHistogram:
 		return NewHistogramChunk(), nil

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -1118,7 +1118,14 @@ func (cb *chunkBuffer) get(ref ChunkDiskMapperRef) chunkenc.Chunk {
 func (cb *chunkBuffer) clear() {
 	for i := 0; i < inBufferShards; i++ {
 		cb.inBufferChunksMtxs[i].Lock()
+		oldChunks := cb.inBufferChunks[i]
 		cb.inBufferChunks[i] = make(map[ChunkDiskMapperRef]chunkenc.Chunk)
 		cb.inBufferChunksMtxs[i].Unlock()
+
+		for _, c := range oldChunks {
+			if xc, ok := c.(*chunkenc.XORChunk); ok {
+				chunkenc.PutXORChunk(xc)
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
