### PR TITLE
tsdb/index: extend index.Postings interface with MaxLen()

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1788,7 +1788,7 @@ func (dec *Decoder) Postings(b []byte) (int, Postings, error) {
 	if len(l) != 4*n {
 		return 0, nil, fmt.Errorf("unexpected postings length, should be %d bytes for %d postings, got %d bytes", 4*n, n, len(l))
 	}
-	return n, newBigEndianPostings(l), nil
+	return n, newBigEndianPostings(l, n), nil
 }
 
 // LabelNamesOffsetsFor decodes the offsets of the name symbols for a given series.

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -736,7 +736,7 @@ func TestBigEndian(t *testing.T) {
 	}
 
 	t.Run("Iteration", func(t *testing.T) {
-		bep := newBigEndianPostings(beLst)
+		bep := newBigEndianPostings(beLst, num)
 		for i := 0; i < num; i++ {
 			require.True(t, bep.Next())
 			require.Equal(t, storage.SeriesRef(ls[i]), bep.At())
@@ -784,7 +784,7 @@ func TestBigEndian(t *testing.T) {
 			},
 		}
 
-		bep := newBigEndianPostings(beLst)
+		bep := newBigEndianPostings(beLst, num)
 
 		for _, v := range table {
 			require.Equal(t, v.found, bep.Seek(storage.SeriesRef(v.seek)))


### PR DESCRIPTION
Calculating postings intersection faster entails intersecting a smaller list with a bigger list and choosing a different algorithm depending on the difference in sizes. Modern fast intersection algorithms are focused on either reducing the number of comparisons and/or making the comparisons faster with SIMD instructions. See
https://arxiv.org/pdf/1401.6399.pdf this paper.

I propose adding MaxLen() method to the Postings interface so that it would be possible to select a different algorithm depending on the size of the lists.
