### PR TITLE
Fix issue where queries can fail or omit OOO samples if OOO head compaction occurs between creating a querier and reading chunks

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1243,7 +1243,7 @@ func (db *DB) compactOOOHead(ctx context.Context) error {
 
 	lastWBLFile, minOOOMmapRef := oooHead.LastWBLFile(), oooHead.LastMmapRef()
 	if lastWBLFile != 0 || minOOOMmapRef != 0 {
-		if err := db.head.truncateOOO(lastWBLFile, minOOOMmapRef); err != nil {
+		if err := db.head.truncateOOO(lastWBLFile, minOOOMmapRef, oooHead.MinTime(), oooHead.MaxTime()); err != nil {
 			return errors.Wrap(err, "truncate ooo wbl")
 		}
 	}

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1937,12 +1937,10 @@ func (db *DB) Querier(mint, maxt int64) (_ storage.Querier, err error) {
 
 	for _, b := range blocks {
 		q, err := NewBlockQuerier(b, mint, maxt)
-		if err == nil {
-			blockQueriers = append(blockQueriers, q)
-			continue
+		if err != nil {
+			return nil, errors.Wrapf(err, "open querier for block %s", b)
 		}
-
-		return nil, errors.Wrapf(err, "open querier for block %s", b)
+		blockQueriers = append(blockQueriers, q)
 	}
 
 	return storage.NewMergeQuerier(blockQueriers, nil, storage.ChainedSeriesMerge), nil
@@ -2016,12 +2014,10 @@ func (db *DB) blockChunkQuerierForRange(mint, maxt int64) (_ []storage.ChunkQuer
 
 	for _, b := range blocks {
 		q, err := NewBlockChunkQuerier(b, mint, maxt)
-		if err == nil {
-			blockQueriers = append(blockQueriers, q)
-			continue
+		if err != nil {
+			return nil, errors.Wrapf(err, "open querier for block %s", b)
 		}
-
-		return nil, errors.Wrapf(err, "open querier for block %s", b)
+		blockQueriers = append(blockQueriers, q)
 	}
 
 	return blockQueriers, nil

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1947,6 +1947,9 @@ func (db *DB) Querier(mint, maxt int64) (_ storage.Querier, err error) {
 		var err error
 		outOfOrderHeadQuerier, err := NewBlockQuerier(rh, mint, maxt)
 		if err != nil {
+			// If NewBlockQuerier() failed, make sure to clean up the pending read created by NewOOORangeHead.
+			rh.isoState.Close()
+
 			return nil, errors.Wrapf(err, "open block querier for ooo head %s", rh)
 		}
 

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3653,6 +3653,170 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier(t *test
 	querier, err := db.ChunkQuerier(0, math.MaxInt64)
 	require.NoError(t, err)
 
+	// Start OOO head compaction.
+	compactionComplete := atomic.NewBool(false)
+	go func() {
+		defer compactionComplete.Store(true)
+
+		require.NoError(t, db.CompactOOOHead(ctx))
+		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
+	}()
+
+	// Give CompactOOOHead time to start work.
+	// If it does not wait for the querier to be closed, then the query will return incorrect results or fail.
+	time.Sleep(time.Second)
+	require.False(t, compactionComplete.Load(), "compaction completed before reading chunks or closing querier")
+
+	// Query back the series.
+	hints := &storage.SelectHints{Start: 0, End: math.MaxInt64, Step: interval}
+	seriesSet := querier.Select(ctx, true, hints, labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "test_metric"))
+
+	// Collect the iterator for the series.
+	var iterators []chunks.Iterator
+	for seriesSet.Next() {
+		iterators = append(iterators, seriesSet.At().Iterator(nil))
+	}
+	require.NoError(t, seriesSet.Err())
+	require.Len(t, iterators, 1)
+	iterator := iterators[0]
+
+	// Check that we can still successfully read all samples.
+	samplesRead := 0
+	for iterator.Next() {
+		samplesRead += iterator.At().Chunk.NumSamples()
+	}
+
+	require.NoError(t, iterator.Err())
+	require.Equal(t, samplesWritten, samplesRead)
+
+	require.False(t, compactionComplete.Load(), "compaction completed before closing querier")
+	require.NoError(t, querier.Close())
+	require.Eventually(t, compactionComplete.Load, time.Second, 10*time.Millisecond, "compaction should complete after querier was closed")
+}
+
+func TestQuerierShouldNotFailIfOOOCompactionOccursAfterSelecting(t *testing.T) {
+	opts := DefaultOptions()
+	opts.OutOfOrderTimeWindow = 3 * DefaultBlockDuration
+	db := openTestDB(t, opts, nil)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	// Disable compactions so we can control it.
+	db.DisableCompactions()
+
+	metric := labels.FromStrings(labels.MetricName, "test_metric")
+	ctx := context.Background()
+	interval := int64(15 * time.Second / time.Millisecond)
+	ts := int64(0)
+	samplesWritten := 0
+
+	// Capture the first timestamp - this will be the timestamp of the OOO sample we'll append below.
+	oooTS := ts
+	ts += interval
+
+	// Push samples after the OOO sample we'll write below.
+	for ; ts < 10*interval; ts += interval {
+		app := db.Appender(ctx)
+		_, err := app.Append(0, metric, ts, float64(ts))
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+		samplesWritten++
+	}
+
+	// Push a single OOO sample.
+	app := db.Appender(ctx)
+	_, err := app.Append(0, metric, oooTS, float64(ts))
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+	samplesWritten++
+
+	// Get a querier.
+	querier, err := db.ChunkQuerier(0, math.MaxInt64)
+	require.NoError(t, err)
+
+	// Query back the series.
+	hints := &storage.SelectHints{Start: 0, End: math.MaxInt64, Step: interval}
+	seriesSet := querier.Select(ctx, true, hints, labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "test_metric"))
+
+	// Start OOO head compaction.
+	compactionComplete := atomic.NewBool(false)
+	go func() {
+		defer compactionComplete.Store(true)
+
+		require.NoError(t, db.CompactOOOHead(ctx))
+		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
+	}()
+
+	// Give CompactOOOHead time to start work.
+	// If it does not wait for the querier to be closed, then the query will return incorrect results or fail.
+	time.Sleep(time.Second)
+	require.False(t, compactionComplete.Load(), "compaction completed before reading chunks or closing querier")
+
+	// Collect the iterator for the series.
+	var iterators []chunks.Iterator
+	for seriesSet.Next() {
+		iterators = append(iterators, seriesSet.At().Iterator(nil))
+	}
+	require.NoError(t, seriesSet.Err())
+	require.Len(t, iterators, 1)
+	iterator := iterators[0]
+
+	// Check that we can still successfully read all samples.
+	samplesRead := 0
+	for iterator.Next() {
+		samplesRead += iterator.At().Chunk.NumSamples()
+	}
+
+	require.NoError(t, iterator.Err())
+	require.Equal(t, samplesWritten, samplesRead)
+
+	require.False(t, compactionComplete.Load(), "compaction completed before closing querier")
+	require.NoError(t, querier.Close())
+	require.Eventually(t, compactionComplete.Load, time.Second, 10*time.Millisecond, "compaction should complete after querier was closed")
+}
+
+func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingIterators(t *testing.T) {
+	opts := DefaultOptions()
+	opts.OutOfOrderTimeWindow = 3 * DefaultBlockDuration
+	db := openTestDB(t, opts, nil)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	// Disable compactions so we can control it.
+	db.DisableCompactions()
+
+	metric := labels.FromStrings(labels.MetricName, "test_metric")
+	ctx := context.Background()
+	interval := int64(15 * time.Second / time.Millisecond)
+	ts := int64(0)
+	samplesWritten := 0
+
+	// Capture the first timestamp - this will be the timestamp of the OOO sample we'll append below.
+	oooTS := ts
+	ts += interval
+
+	// Push samples after the OOO sample we'll write below.
+	for ; ts < 10*interval; ts += interval {
+		app := db.Appender(ctx)
+		_, err := app.Append(0, metric, ts, float64(ts))
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+		samplesWritten++
+	}
+
+	// Push a single OOO sample.
+	app := db.Appender(ctx)
+	_, err := app.Append(0, metric, oooTS, float64(ts))
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+	samplesWritten++
+
+	// Get a querier.
+	querier, err := db.ChunkQuerier(0, math.MaxInt64)
+	require.NoError(t, err)
+
 	// Query back the series.
 	hints := &storage.SelectHints{Start: 0, End: math.MaxInt64, Step: interval}
 	seriesSet := querier.Select(ctx, true, hints, labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "test_metric"))

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -5014,7 +5014,7 @@ func TestHeadMinOOOTimeUpdate(t *testing.T) {
 	require.Equal(t, 295*time.Minute.Milliseconds(), h.MinOOOTime())
 
 	// Allowed window for OOO is >=290, which is before the earliest ooo sample 295, so it gets set to the lower value.
-	require.NoError(t, h.truncateOOO(0, 1, 295, 295))
+	require.NoError(t, h.truncateOOO(0, 1))
 	require.Equal(t, 290*time.Minute.Milliseconds(), h.MinOOOTime())
 
 	appendSample(310) // In-order sample.
@@ -5023,7 +5023,7 @@ func TestHeadMinOOOTimeUpdate(t *testing.T) {
 
 	// Now the OOO sample 295 was not gc'ed yet. And allowed window for OOO is now >=300.
 	// So the lowest among them, 295, is set as minOOOTime.
-	require.NoError(t, h.truncateOOO(0, 2, 305, 305))
+	require.NoError(t, h.truncateOOO(0, 2))
 	require.Equal(t, 295*time.Minute.Milliseconds(), h.MinOOOTime())
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -5014,7 +5014,7 @@ func TestHeadMinOOOTimeUpdate(t *testing.T) {
 	require.Equal(t, 295*time.Minute.Milliseconds(), h.MinOOOTime())
 
 	// Allowed window for OOO is >=290, which is before the earliest ooo sample 295, so it gets set to the lower value.
-	require.NoError(t, h.truncateOOO(0, 1))
+	require.NoError(t, h.truncateOOO(0, 1, 295, 295))
 	require.Equal(t, 290*time.Minute.Milliseconds(), h.MinOOOTime())
 
 	appendSample(310) // In-order sample.
@@ -5023,7 +5023,7 @@ func TestHeadMinOOOTimeUpdate(t *testing.T) {
 
 	// Now the OOO sample 295 was not gc'ed yet. And allowed window for OOO is now >=300.
 	// So the lowest among them, 295, is set as minOOOTime.
-	require.NoError(t, h.truncateOOO(0, 2))
+	require.NoError(t, h.truncateOOO(0, 2, 305, 305))
 	require.Equal(t, 295*time.Minute.Milliseconds(), h.MinOOOTime())
 }
 

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -128,7 +128,8 @@ func (oh *OOORangeHead) Index() (IndexReader, error) {
 }
 
 func (oh *OOORangeHead) Chunks() (ChunkReader, error) {
-	return NewOOOHeadChunkReader(oh.head, oh.mint, oh.maxt), nil
+	isoState := oh.head.oooIso.State(oh.mint, oh.maxt)
+	return NewOOOHeadChunkReader(oh.head, oh.mint, oh.maxt, isoState), nil
 }
 
 func (oh *OOORangeHead) Tombstones() (tombstones.Reader, error) {

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -20,6 +20,7 @@ import (
 	"github.com/oklog/ulid"
 
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 )
 
@@ -113,23 +114,27 @@ type OOORangeHead struct {
 	// the timerange of the query and having preexisting pointers to the first
 	// and last timestamp help with that.
 	mint, maxt int64
+
+	isoState *oooIsolationState
 }
 
-func NewOOORangeHead(head *Head, mint, maxt int64) *OOORangeHead {
+func NewOOORangeHead(head *Head, mint, maxt int64, minRef chunks.ChunkDiskMapperRef) *OOORangeHead {
+	isoState := head.oooIso.TrackReadAfter(minRef)
+
 	return &OOORangeHead{
-		head: head,
-		mint: mint,
-		maxt: maxt,
+		head:     head,
+		mint:     mint,
+		maxt:     maxt,
+		isoState: isoState,
 	}
 }
 
 func (oh *OOORangeHead) Index() (IndexReader, error) {
-	return NewOOOHeadIndexReader(oh.head, oh.mint, oh.maxt), nil
+	return NewOOOHeadIndexReader(oh.head, oh.mint, oh.maxt, oh.isoState.minRef), nil
 }
 
 func (oh *OOORangeHead) Chunks() (ChunkReader, error) {
-	isoState := oh.head.oooIso.State(oh.mint, oh.maxt)
-	return NewOOOHeadChunkReader(oh.head, oh.mint, oh.maxt, isoState), nil
+	return NewOOOHeadChunkReader(oh.head, oh.mint, oh.maxt, oh.isoState), nil
 }
 
 func (oh *OOORangeHead) Tombstones() (tombstones.Reader, error) {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -38,26 +38,29 @@ var _ IndexReader = &OOOHeadIndexReader{}
 // decided to do this to avoid code duplication.
 // The only methods that change are the ones about getting Series and Postings.
 type OOOHeadIndexReader struct {
-	*headIndexReader // A reference to the headIndexReader so we can reuse as many interface implementation as possible.
+	*headIndexReader     // A reference to the headIndexReader so we can reuse as many interface implementation as possible.
+	lastForbiddenMmapRef chunks.ChunkDiskMapperRef
 }
 
-func NewOOOHeadIndexReader(head *Head, mint, maxt int64) *OOOHeadIndexReader {
+func NewOOOHeadIndexReader(head *Head, mint, maxt int64, lastForbiddenMmapRef chunks.ChunkDiskMapperRef) *OOOHeadIndexReader {
 	hr := &headIndexReader{
 		head: head,
 		mint: mint,
 		maxt: maxt,
 	}
-	return &OOOHeadIndexReader{hr}
+	return &OOOHeadIndexReader{hr, lastForbiddenMmapRef}
 }
 
 func (oh *OOOHeadIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
-	return oh.series(ref, builder, chks, 0)
+	return oh.series(ref, builder, chks, oh.lastForbiddenMmapRef, 0)
 }
 
-// The passed lastMmapRef tells upto what max m-map chunk that we can consider.
-// If it is 0, it means all chunks need to be considered.
-// If it is non-0, then the oooHeadChunk must not be considered.
-func (oh *OOOHeadIndexReader) series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta, lastMmapRef chunks.ChunkDiskMapperRef) error {
+// lastForbiddenMmapRef gives the last mmap chunk that may be being garbage collected and so
+// any chunk at or before this ref will not be considered. 0 disables this check.
+//
+// lastMmapRef tells upto what max m-map chunk that we can consider. If it is non-0, then
+// the oooHeadChunk will not be considered.
+func (oh *OOOHeadIndexReader) series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta, lastForbiddenMmapRef, maxMmapRef chunks.ChunkDiskMapperRef) error {
 	s := oh.head.series.getByID(chunks.HeadSeriesRef(ref))
 
 	if s == nil {
@@ -112,14 +115,14 @@ func (oh *OOOHeadIndexReader) series(ref storage.SeriesRef, builder *labels.Scra
 	// so we can set the correct markers.
 	if s.ooo.oooHeadChunk != nil {
 		c := s.ooo.oooHeadChunk
-		if c.OverlapsClosedInterval(oh.mint, oh.maxt) && lastMmapRef == 0 {
+		if c.OverlapsClosedInterval(oh.mint, oh.maxt) && maxMmapRef == 0 {
 			ref := chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.oooHeadChunkID(len(s.ooo.oooMmappedChunks))))
 			addChunk(c.minTime, c.maxTime, ref)
 		}
 	}
 	for i := len(s.ooo.oooMmappedChunks) - 1; i >= 0; i-- {
 		c := s.ooo.oooMmappedChunks[i]
-		if c.OverlapsClosedInterval(oh.mint, oh.maxt) && (lastMmapRef == 0 || lastMmapRef.GreaterThanOrEqualTo(c.ref)) {
+		if c.OverlapsClosedInterval(oh.mint, oh.maxt) && (maxMmapRef == 0 || maxMmapRef.GreaterThanOrEqualTo(c.ref)) && (lastForbiddenMmapRef == 0 || c.ref.GreaterThan(lastForbiddenMmapRef)) {
 			ref := chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.oooHeadChunkID(i)))
 			addChunk(c.minTime, c.maxTime, ref)
 		}
@@ -232,10 +235,10 @@ func (oh *OOOHeadIndexReader) Postings(ctx context.Context, name string, values 
 type OOOHeadChunkReader struct {
 	head       *Head
 	mint, maxt int64
-	isoState   *isolationState
+	isoState   *oooIsolationState
 }
 
-func NewOOOHeadChunkReader(head *Head, mint, maxt int64, isoState *isolationState) *OOOHeadChunkReader {
+func NewOOOHeadChunkReader(head *Head, mint, maxt int64, isoState *oooIsolationState) *OOOHeadChunkReader {
 	return &OOOHeadChunkReader{
 		head:     head,
 		mint:     mint,
@@ -311,7 +314,7 @@ func NewOOOCompactionHead(ctx context.Context, head *Head) (*OOOCompactionHead, 
 		ch.lastWBLFile = lastWBLFile
 	}
 
-	ch.oooIR = NewOOOHeadIndexReader(head, math.MinInt64, math.MaxInt64)
+	ch.oooIR = NewOOOHeadIndexReader(head, math.MinInt64, math.MaxInt64, 0)
 	n, v := index.AllPostingsKey()
 
 	// TODO: verify this gets only ooo samples.
@@ -396,7 +399,7 @@ func (ch *OOOCompactionHead) Meta() BlockMeta {
 // Only the method of BlockReader interface are valid for the cloned OOOCompactionHead.
 func (ch *OOOCompactionHead) CloneForTimeRange(mint, maxt int64) *OOOCompactionHead {
 	return &OOOCompactionHead{
-		oooIR:       NewOOOHeadIndexReader(ch.oooIR.head, mint, maxt),
+		oooIR:       NewOOOHeadIndexReader(ch.oooIR.head, mint, maxt, 0),
 		lastMmapRef: ch.lastMmapRef,
 		postings:    ch.postings,
 		chunkRange:  ch.chunkRange,
@@ -438,7 +441,7 @@ func (ir *OOOCompactionHeadIndexReader) SortedPostings(p index.Postings) index.P
 }
 
 func (ir *OOOCompactionHeadIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
-	return ir.ch.oooIR.series(ref, builder, chks, ir.ch.lastMmapRef)
+	return ir.ch.oooIR.series(ref, builder, chks, 0, ir.ch.lastMmapRef)
 }
 
 func (ir *OOOCompactionHeadIndexReader) SortedLabelValues(_ context.Context, name string, matchers ...*labels.Matcher) ([]string, error) {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -232,13 +232,15 @@ func (oh *OOOHeadIndexReader) Postings(ctx context.Context, name string, values 
 type OOOHeadChunkReader struct {
 	head       *Head
 	mint, maxt int64
+	isoState   *isolationState
 }
 
-func NewOOOHeadChunkReader(head *Head, mint, maxt int64) *OOOHeadChunkReader {
+func NewOOOHeadChunkReader(head *Head, mint, maxt int64, isoState *isolationState) *OOOHeadChunkReader {
 	return &OOOHeadChunkReader{
-		head: head,
-		mint: mint,
-		maxt: maxt,
+		head:     head,
+		mint:     mint,
+		maxt:     maxt,
+		isoState: isoState,
 	}
 }
 
@@ -272,6 +274,9 @@ func (cr OOOHeadChunkReader) Chunk(meta chunks.Meta) (chunkenc.Chunk, error) {
 }
 
 func (cr OOOHeadChunkReader) Close() error {
+	if cr.isoState != nil {
+		cr.isoState.Close()
+	}
 	return nil
 }
 
@@ -365,7 +370,7 @@ func (ch *OOOCompactionHead) Index() (IndexReader, error) {
 }
 
 func (ch *OOOCompactionHead) Chunks() (ChunkReader, error) {
-	return NewOOOHeadChunkReader(ch.oooIR.head, ch.oooIR.mint, ch.oooIR.maxt), nil
+	return NewOOOHeadChunkReader(ch.oooIR.head, ch.oooIR.mint, ch.oooIR.maxt, nil), nil
 }
 
 func (ch *OOOCompactionHead) Tombstones() (tombstones.Reader, error) {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -58,7 +58,7 @@ func (oh *OOOHeadIndexReader) Series(ref storage.SeriesRef, builder *labels.Scra
 // lastForbiddenMmapRef gives the last mmap chunk that may be being garbage collected and so
 // any chunk at or before this ref will not be considered. 0 disables this check.
 //
-// lastMmapRef tells upto what max m-map chunk that we can consider. If it is non-0, then
+// maxMmapRef tells upto what max m-map chunk that we can consider. If it is non-0, then
 // the oooHeadChunk will not be considered.
 func (oh *OOOHeadIndexReader) series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta, lastForbiddenMmapRef, maxMmapRef chunks.ChunkDiskMapperRef) error {
 	s := oh.head.series.getByID(chunks.HeadSeriesRef(ref))

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -484,7 +484,8 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 	t.Run("Getting a non existing chunk fails with not found error", func(t *testing.T) {
 		db := newTestDBWithOpts(t, opts)
 
-		cr := NewOOOHeadChunkReader(db.head, 0, 1000)
+		cr := NewOOOHeadChunkReader(db.head, 0, 1000, db.head.oooIso.State(0, 1000))
+		defer cr.Close()
 		c, err := cr.Chunk(chunks.Meta{
 			Ref: 0x1000000, Chunk: chunkenc.Chunk(nil), MinTime: 100, MaxTime: 300,
 		})
@@ -849,7 +850,8 @@ func TestOOOHeadChunkReader_Chunk(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, len(tc.expChunksSamples), len(chks))
 
-			cr := NewOOOHeadChunkReader(db.head, tc.queryMinT, tc.queryMaxT)
+			cr := NewOOOHeadChunkReader(db.head, tc.queryMinT, tc.queryMaxT, db.head.oooIso.State(tc.queryMinT, tc.queryMaxT))
+			defer cr.Close()
 			for i := 0; i < len(chks); i++ {
 				c, err := cr.Chunk(chks[i])
 				require.NoError(t, err)
@@ -1020,7 +1022,8 @@ func TestOOOHeadChunkReader_Chunk_ConsistentQueryResponseDespiteOfHeadExpanding(
 			}
 			require.NoError(t, app.Commit())
 
-			cr := NewOOOHeadChunkReader(db.head, tc.queryMinT, tc.queryMaxT)
+			cr := NewOOOHeadChunkReader(db.head, tc.queryMinT, tc.queryMaxT, db.head.oooIso.State(tc.queryMinT, tc.queryMaxT))
+			defer cr.Close()
 			for i := 0; i < len(chks); i++ {
 				c, err := cr.Chunk(chks[i])
 				require.NoError(t, err)

--- a/tsdb/ooo_isolation.go
+++ b/tsdb/ooo_isolation.go
@@ -1,0 +1,79 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"container/list"
+	"sync"
+
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+type oooIsolation struct {
+	mtx       sync.RWMutex
+	openReads *list.List
+}
+
+type oooIsolationState struct {
+	i *oooIsolation
+	e *list.Element
+
+	minRef chunks.ChunkDiskMapperRef
+}
+
+func newOOOIsolation() *oooIsolation {
+	return &oooIsolation{
+		openReads: list.New(),
+	}
+}
+
+// HasOpenReadsAtOrBefore returns true if this oooIsolation is aware of any reads that use
+// chunks with reference at or before ref.
+func (i *oooIsolation) HasOpenReadsAtOrBefore(ref chunks.ChunkDiskMapperRef) bool {
+	i.mtx.RLock()
+	defer i.mtx.RUnlock()
+
+	for e := i.openReads.Front(); e != nil; e = e.Next() {
+		s := e.Value.(*oooIsolationState)
+
+		if ref.GreaterThan(s.minRef) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TrackReadAfter records a read that uses chunks with reference after minRef.
+//
+// The caller must ensure that the returned oooIsolationState is eventually closed when
+// the read is complete.
+func (i *oooIsolation) TrackReadAfter(minRef chunks.ChunkDiskMapperRef) *oooIsolationState {
+	s := &oooIsolationState{
+		i:      i,
+		minRef: minRef,
+	}
+
+	i.mtx.Lock()
+	s.e = i.openReads.PushBack(s)
+	i.mtx.Unlock()
+
+	return s
+}
+
+func (s oooIsolationState) Close() {
+	s.i.mtx.Lock()
+	s.i.openReads.Remove(s.e)
+	s.i.mtx.Unlock()
+}

--- a/tsdb/ooo_isolation_test.go
+++ b/tsdb/ooo_isolation_test.go
@@ -1,0 +1,54 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOOOIsolation(t *testing.T) {
+	i := newOOOIsolation()
+
+	// Empty state shouldn't have any open reads.
+	require.False(t, i.HasOpenReadsAtOrBefore(0))
+	require.False(t, i.HasOpenReadsAtOrBefore(1))
+	require.False(t, i.HasOpenReadsAtOrBefore(2))
+	require.False(t, i.HasOpenReadsAtOrBefore(3))
+
+	// Add a read.
+	read1 := i.TrackReadAfter(1)
+	require.False(t, i.HasOpenReadsAtOrBefore(0))
+	require.False(t, i.HasOpenReadsAtOrBefore(1))
+	require.True(t, i.HasOpenReadsAtOrBefore(2))
+
+	// Add another overlapping read.
+	read2 := i.TrackReadAfter(0)
+	require.False(t, i.HasOpenReadsAtOrBefore(0))
+	require.True(t, i.HasOpenReadsAtOrBefore(1))
+	require.True(t, i.HasOpenReadsAtOrBefore(2))
+
+	// Close the second read, should now only report open reads for the first read's ref.
+	read2.Close()
+	require.False(t, i.HasOpenReadsAtOrBefore(0))
+	require.False(t, i.HasOpenReadsAtOrBefore(1))
+	require.True(t, i.HasOpenReadsAtOrBefore(2))
+
+	// Closing the first read should indicate no further open reads.
+	read1.Close()
+	require.False(t, i.HasOpenReadsAtOrBefore(0))
+	require.False(t, i.HasOpenReadsAtOrBefore(1))
+	require.False(t, i.HasOpenReadsAtOrBefore(2))
+}

--- a/tsdb/ooo_isolation_test.go
+++ b/tsdb/ooo_isolation_test.go
@@ -46,6 +46,12 @@ func TestOOOIsolation(t *testing.T) {
 	require.False(t, i.HasOpenReadsAtOrBefore(1))
 	require.True(t, i.HasOpenReadsAtOrBefore(2))
 
+	// Close the second read again: this should do nothing and ensures we can safely call Close() multiple times.
+	read2.Close()
+	require.False(t, i.HasOpenReadsAtOrBefore(0))
+	require.False(t, i.HasOpenReadsAtOrBefore(1))
+	require.True(t, i.HasOpenReadsAtOrBefore(2))
+
 	// Closing the first read should indicate no further open reads.
 	read1.Close()
 	require.False(t, i.HasOpenReadsAtOrBefore(0))

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2803,7 +2803,7 @@ func BenchmarkQueries(b *testing.B) {
 
 					qHead, err := NewBlockQuerier(NewRangeHead(head, 1, nSamples), 1, nSamples)
 					require.NoError(b, err)
-					qOOOHead, err := NewBlockQuerier(NewOOORangeHead(head, 1, nSamples), 1, nSamples)
+					qOOOHead, err := NewBlockQuerier(NewOOORangeHead(head, 1, nSamples, 0), 1, nSamples)
 					require.NoError(b, err)
 
 					queryTypes = append(queryTypes, qt{


### PR DESCRIPTION
This PR fixes two related issues:
* queries can fail with an `cannot populate chunk XXX from block 2ZBXFNYVVFDXFPGSB1CHFNYQTZ: not found` error if OOO head compaction occurs while the query is being evaluated
* queries can omit data from the OOO head if OOO head compaction occurs while the query is being evaluated

### `cannot populate chunk XXX from block 2ZBXFNYVVFDXFPGSB1CHFNYQTZ: not found` error

This issue occurs if events happen in this sequence:

1. Call `DB.ChunksQuerier()`, which returns a querier `q`
2. Call `q.Select()`, which returns a series set `ss`
3. Retrieve an iterator `it` for a series with samples in the OOO head block (ie. call `ss.At().Iterator(...)`)
4. Run OOO head compaction
5. Use `it` to read the chunks for the series

Eventually, `it.Next()` will return `false`, and `it.Err()` will report a `cannot populate chunk XXX from block 2ZBXFNYVVFDXFPGSB1CHFNYQTZ: not found` error.

`2ZBXFNYVVFDXFPGSB1CHFNYQTZ` is the ULID of the OOO head block, defined [here](https://github.com/prometheus/prometheus/blob/ab2a7bb74fa32f9199e3b9d4a19c000c304a37e9/tsdb/ooo_head.go#L140).

This happens because the garbage collection that occurs during OOO head compaction does not wait for pending reads to complete, and so the iterator created in step 3 has a reference to a chunk that is removed during compaction and can't be read in step 5.

### Omitting data

This issue occurs if events happen in this sequence:

1. Call `DB.ChunksQuerier()`, which returns a querier `q`
2. Call `q.Select()`, which returns a series set `ss`
3. Run OOO head compaction
4. Retrieve an iterator `it` for a series with samples that were in the OOO head before compaction (ie. call `ss.At().Iterator(...)`)
5. Use `it` to read the chunks for the series, none of which will include the samples that were in the OOO head before compaction

It also happens if steps 2 and 3 happen in the reverse order (ie. head compaction happens before the call to `q.Select()`).

In this case, the data that was in the OOO head before compaction is omitted, and no error is returned, so query results are incorrect.

This happens because the list of blocks on disk is captured in step 1, but by the time we get to step 4, which evaluates the list of chunks for the series, the chunk that was in the OOO head has been written to disk and garbage collected from the head, so it isn't returned from either source (disk or head).

### Root cause

I believe the reason for this is that OOO compaction doesn't check for pending reads that overlap with the chunks to be garbage collected, unlike what is done for in-order head compaction [here](https://github.com/prometheus/prometheus/blob/ab2a7bb74fa32f9199e3b9d4a19c000c304a37e9/tsdb/head.go#L1093). 

Under normal circumstances (ie. when `DB.Compact()` is used), OOO head compaction only occurs after in-order head compaction. Because of this, most of the time, this issue won't happen in practice because the time range of a query that includes OOO samples will also include time range of the in-order head and therefore be protected by the pending read check done before compacting the in-order head, or be protected by another query running at the same time that includes the in-order head. However, queries that are only for the time range of blocks on disk and OOO head samples (ie. do not overlap with the time range of the in-order head) would be susceptible to this issue.

---

I'd suggest reviewing each commit individually, the key commits are:
* https://github.com/prometheus/prometheus/commit/8898a5624d93144d53753d5d6099d84d963d01ae and https://github.com/prometheus/prometheus/commit/07c443f273f0f1cb4133d05cc6185f4ee0933b18 add tests that demonstrates the issue
* https://github.com/prometheus/prometheus/commit/cc238228c091030fa229f85232fe5e8e43818b7d adds a naive solution that uses the query range and chunk time range to block OOO garbage collection running while queries touching chunks that will be GCed are in progress, but this runs the risk of never allowing garbage collection to proceed
* https://github.com/prometheus/prometheus/commit/e3d12ed468954a3ef4165085d661656f9d19351c improves on the previous commit by using the last compacted OOO chunk reference instead to block garbage collection

I'd suggest reviewing this carefully: while this fix makes the test pass, I suspect there are some edge cases I haven't considered.