### PR TITLE
change origin schema in `ReduceResolution` method of histogram and float histogram

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -1112,6 +1112,6 @@ func floatBucketsMatch(b1, b2 []float64) bool {
 func (h *FloatHistogram) ReduceResolution(targetSchema int32) *FloatHistogram {
 	h.PositiveSpans, h.PositiveBuckets = reduceResolution(h.PositiveSpans, h.PositiveBuckets, h.Schema, targetSchema, false)
 	h.NegativeSpans, h.NegativeBuckets = reduceResolution(h.NegativeSpans, h.NegativeBuckets, h.Schema, targetSchema, false)
-
+	h.Schema = targetSchema
 	return h
 }

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -2445,9 +2445,8 @@ func createRandomSpans(rng *rand.Rand, spanNum int32) ([]Span, []float64) {
 
 func TestFloatHistogramReduceResolution(t *testing.T) {
 	tcs := map[string]struct {
-		origin       *FloatHistogram
-		targetSchema int32
-		target       *FloatHistogram
+		origin *FloatHistogram
+		target *FloatHistogram
 	}{
 		"valid float histogram": {
 			origin: &FloatHistogram{
@@ -2465,7 +2464,6 @@ func TestFloatHistogramReduceResolution(t *testing.T) {
 				},
 				NegativeBuckets: []float64{1, 3, 1, 2, 1, 1},
 			},
-			targetSchema: -1,
 			target: &FloatHistogram{
 				Schema: -1,
 				PositiveSpans: []Span{
@@ -2483,7 +2481,7 @@ func TestFloatHistogramReduceResolution(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		target := tc.origin.ReduceResolution(tc.targetSchema)
+		target := tc.origin.ReduceResolution(tc.target.Schema)
 		require.Equal(t, tc.target, target)
 	}
 }

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -2442,3 +2442,48 @@ func createRandomSpans(rng *rand.Rand, spanNum int32) ([]Span, []float64) {
 	}
 	return Spans, Buckets
 }
+
+func TestFloatHistogramReduceResolution(t *testing.T) {
+	tcs := map[string]struct {
+		origin       *FloatHistogram
+		targetSchema int32
+		target       *FloatHistogram
+	}{
+		"valid float histogram": {
+			origin: &FloatHistogram{
+				Schema: 0,
+				PositiveSpans: []Span{
+					{Offset: 0, Length: 4},
+					{Offset: 0, Length: 0},
+					{Offset: 3, Length: 2},
+				},
+				PositiveBuckets: []float64{1, 3, 1, 2, 1, 1},
+				NegativeSpans: []Span{
+					{Offset: 0, Length: 4},
+					{Offset: 0, Length: 0},
+					{Offset: 3, Length: 2},
+				},
+				NegativeBuckets: []float64{1, 3, 1, 2, 1, 1},
+			},
+			targetSchema: -1,
+			target: &FloatHistogram{
+				Schema: -1,
+				PositiveSpans: []Span{
+					{Offset: 0, Length: 3},
+					{Offset: 1, Length: 1},
+				},
+				PositiveBuckets: []float64{1, 4, 2, 2},
+				NegativeSpans: []Span{
+					{Offset: 0, Length: 3},
+					{Offset: 1, Length: 1},
+				},
+				NegativeBuckets: []float64{1, 4, 2, 2},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		target := tc.origin.ReduceResolution(tc.targetSchema)
+		require.Equal(t, tc.target, target)
+	}
+}

--- a/model/histogram/histogram.go
+++ b/model/histogram/histogram.go
@@ -503,5 +503,6 @@ func (h *Histogram) ReduceResolution(targetSchema int32) *Histogram {
 	h.NegativeSpans, h.NegativeBuckets = reduceResolution(
 		h.NegativeSpans, h.NegativeBuckets, h.Schema, targetSchema, true,
 	)
+	h.Schema = targetSchema
 	return h
 }

--- a/model/histogram/histogram_test.go
+++ b/model/histogram/histogram_test.go
@@ -970,9 +970,8 @@ func BenchmarkHistogramValidation(b *testing.B) {
 
 func TestHistogramReduceResolution(t *testing.T) {
 	tcs := map[string]struct {
-		origin       *Histogram
-		targetSchema int32
-		target       *Histogram
+		origin *Histogram
+		target *Histogram
 	}{
 		"valid histogram": {
 			origin: &Histogram{
@@ -990,7 +989,6 @@ func TestHistogramReduceResolution(t *testing.T) {
 				},
 				NegativeBuckets: []int64{1, 2, -2, 1, -1, 0},
 			},
-			targetSchema: -1,
 			target: &Histogram{
 				Schema: -1,
 				PositiveSpans: []Span{
@@ -1008,7 +1006,7 @@ func TestHistogramReduceResolution(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		target := tc.origin.ReduceResolution(tc.targetSchema)
+		target := tc.origin.ReduceResolution(tc.target.Schema)
 		require.Equal(t, tc.target, target)
 	}
 }

--- a/model/histogram/histogram_test.go
+++ b/model/histogram/histogram_test.go
@@ -967,3 +967,48 @@ func BenchmarkHistogramValidation(b *testing.B) {
 		require.NoError(b, h.Validate())
 	}
 }
+
+func TestHistogramReduceResolution(t *testing.T) {
+	tcs := map[string]struct {
+		origin       *Histogram
+		targetSchema int32
+		target       *Histogram
+	}{
+		"valid histogram": {
+			origin: &Histogram{
+				Schema: 0,
+				PositiveSpans: []Span{
+					{Offset: 0, Length: 4},
+					{Offset: 0, Length: 0},
+					{Offset: 3, Length: 2},
+				},
+				PositiveBuckets: []int64{1, 2, -2, 1, -1, 0},
+				NegativeSpans: []Span{
+					{Offset: 0, Length: 4},
+					{Offset: 0, Length: 0},
+					{Offset: 3, Length: 2},
+				},
+				NegativeBuckets: []int64{1, 2, -2, 1, -1, 0},
+			},
+			targetSchema: -1,
+			target: &Histogram{
+				Schema: -1,
+				PositiveSpans: []Span{
+					{Offset: 0, Length: 3},
+					{Offset: 1, Length: 1},
+				},
+				PositiveBuckets: []int64{1, 3, -2, 0},
+				NegativeSpans: []Span{
+					{Offset: 0, Length: 3},
+					{Offset: 1, Length: 1},
+				},
+				NegativeBuckets: []int64{1, 3, -2, 0},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		target := tc.origin.ReduceResolution(tc.targetSchema)
+		require.Equal(t, tc.target, target)
+	}
+}


### PR DESCRIPTION
              @fatsheep9146 / @beorn7 shouldn't there be `h.Schema = targetSchema`? While the comment only speaks about spans and buckets, name and the API of this method would make me expect that the whole histogram gets reduced as such.
Same question applies to the integer histogram below.

_Originally posted by @linasm in https://github.com/prometheus/prometheus/pull/13001#discussion_r1387548416_
            
fix the bug found by @linasm in #13111 13001