### PR TITLE
codemirror-promql: Add request header to client

### DIFF
--- a/web/ui/module/codemirror-promql/README.md
+++ b/web/ui/module/codemirror-promql/README.md
@@ -161,6 +161,15 @@ You can change it to use the HTTP method `GET` if you prefer.
 const promQL = new PromQLExtension().setComplete({remote: {httpMethod: 'GET'}})
 ```
 
+###### HTTP request headers
+
+If you need to send specific HTTP headers along with the requests to Prometheus, you can adjust that as follows:
+
+```typescript
+const customHeaders = new Headers({'header-name': 'test-value'});
+const promql = new PromQLExtension().setComplete({remote: {requestHeaders: customHeaders}})
+```
+
 ###### Override the API Prefix
 
 The default Prometheus Client, when building the query to get data from Prometheus, is using an API prefix which is by

--- a/web/ui/module/codemirror-promql/src/client/prometheus.ts
+++ b/web/ui/module/codemirror-promql/src/client/prometheus.ts
@@ -58,6 +58,7 @@ export interface PrometheusConfig {
   cache?: CacheConfig;
   httpMethod?: 'POST' | 'GET';
   apiPrefix?: string;
+  requestHeaders?: Headers;
 }
 
 interface APIResponse<T> {
@@ -84,6 +85,7 @@ export class HTTPPrometheusClient implements PrometheusClient {
   // For some reason, just assigning via "= fetch" here does not end up executing fetch correctly
   // when calling it, thus the indirection via another function wrapper.
   private readonly fetchFn: FetchFn = (input: RequestInfo, init?: RequestInit): Promise<Response> => fetch(input, init);
+  private requestHeaders: Headers = new Headers();
 
   constructor(config: PrometheusConfig) {
     this.url = config.url ? config.url : '';
@@ -99,6 +101,9 @@ export class HTTPPrometheusClient implements PrometheusClient {
     }
     if (config.apiPrefix) {
       this.apiPrefix = config.apiPrefix;
+    }
+    if (config.requestHeaders) {
+      this.requestHeaders = config.requestHeaders;
     }
   }
 
@@ -221,6 +226,11 @@ export class HTTPPrometheusClient implements PrometheusClient {
   }
 
   private fetchAPI<T>(resource: string, init?: RequestInit): Promise<T> {
+    if (init) {
+      init.headers = this.requestHeaders;
+    } else {
+      init = { headers: this.requestHeaders };
+    }
     return this.fetchFn(this.url + resource, init)
       .then((res) => {
         if (!res.ok && ![badRequest, unprocessableEntity, serviceUnavailable].includes(res.status)) {


### PR DESCRIPTION
With this commit we make it possible to adjust the request headers sent to Prometheus by the codemirror-promql extension. This enables customizing the headers sent, without re-implementing the Prometheus client completely.

This can be useful if using a different PromQL compatible backend, such as Thanos, where setting headers for tenancy purposes is needed.

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
