### PR TITLE
notifier: fix drop alertmanager on apply config step

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -264,6 +264,14 @@ func (n *Manager) ApplyConfig(conf *config.Config) error {
 			return err
 		}
 
+		// If alertmanagers already exists, don't skip it, in reload step will be refreshed new targets.
+		oldAmSets, ok := n.alertmanagers[k]
+		if ok {
+			oldAmSets.mtx.RLock()
+			ams.ams = oldAmSets.ams
+			oldAmSets.mtx.RUnlock()
+		}
+
 		amSets[k] = ams
 	}
 


### PR DESCRIPTION
When the config is applied, set of alertmanagers are recreated with an empty list of URLs (`ams []alertmanager` [init alertmanagerSet](https://github.com/prometheus/prometheus/blob/main/notifier/notifier.go#L655)). Before reload will happen, `sendAll` will skip the notification batch, because alertmnager list is empty ( [skip for](https://github.com/prometheus/prometheus/blob/main/notifier/notifier.go#L522) ). I think it is necessary to save the list of alertmanagers when applying the config, since it will be updated at the next reload step. 

A test case is added to demonstrate issue above.

Fixes https://github.com/prometheus/prometheus/issues/13064

In our cases, we observe that metric prometheus_notifications_dropped_total increases and heartbeat notifications in alertmanager are skipped, this fix repare this.