### PR TITLE
Native Histograms: automatically reduce resolution rather than fail scrape

### DIFF
--- a/scrape/target.go
+++ b/scrape/target.go
@@ -367,20 +367,18 @@ type bucketLimitAppender struct {
 func (app *bucketLimitAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	if h != nil {
 		for len(h.PositiveBuckets)+len(h.NegativeBuckets) > app.limit {
-			lastCount := len(h.PositiveBuckets) + len(h.NegativeBuckets)
-			h = h.ReduceResolution(h.Schema - 1)
-			if len(h.PositiveBuckets)+len(h.NegativeBuckets) == lastCount {
+			if h.Schema == -4 {
 				return 0, errBucketLimit
 			}
+			h = h.ReduceResolution(h.Schema - 1)
 		}
 	}
 	if fh != nil {
 		for len(fh.PositiveBuckets)+len(fh.NegativeBuckets) > app.limit {
-			lastCount := len(fh.PositiveBuckets) + len(fh.NegativeBuckets)
-			fh = fh.ReduceResolution(fh.Schema - 1)
-			if len(fh.PositiveBuckets)+len(fh.NegativeBuckets) == lastCount {
+			if fh.Schema == -4 {
 				return 0, errBucketLimit
 			}
+			fh = fh.ReduceResolution(fh.Schema - 1)
 		}
 	}
 	ref, err := app.Appender.AppendHistogram(ref, lset, t, h, fh)

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -367,18 +367,18 @@ type bucketLimitAppender struct {
 func (app *bucketLimitAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	if h != nil {
 		for len(h.PositiveBuckets)+len(h.NegativeBuckets) > app.limit {
-			lastSum := len(h.PositiveBuckets) + len(h.NegativeBuckets)
+			lastCount := len(h.PositiveBuckets) + len(h.NegativeBuckets)
 			h = h.ReduceResolution(h.Schema - 1)
-			if len(h.PositiveBuckets)+len(h.NegativeBuckets) == lastSum {
+			if len(h.PositiveBuckets)+len(h.NegativeBuckets) == lastCount {
 				return 0, errBucketLimit
 			}
 		}
 	}
 	if fh != nil {
 		for len(fh.PositiveBuckets)+len(fh.NegativeBuckets) > app.limit {
-			lastSum := len(fh.PositiveBuckets) + len(fh.NegativeBuckets)
+			lastCount := len(fh.PositiveBuckets) + len(fh.NegativeBuckets)
 			fh = fh.ReduceResolution(fh.Schema - 1)
-			if len(fh.PositiveBuckets)+len(fh.NegativeBuckets) == lastSum {
+			if len(fh.PositiveBuckets)+len(fh.NegativeBuckets) == lastCount {
 				return 0, errBucketLimit
 			}
 		}

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -366,13 +366,21 @@ type bucketLimitAppender struct {
 
 func (app *bucketLimitAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	if h != nil {
-		if len(h.PositiveBuckets)+len(h.NegativeBuckets) > app.limit {
-			return 0, errBucketLimit
+		for len(h.PositiveBuckets)+len(h.NegativeBuckets) > app.limit {
+			lastSum := len(h.PositiveBuckets) + len(h.NegativeBuckets)
+			h = h.ReduceResolution(h.Schema - 1)
+			if len(h.PositiveBuckets)+len(h.NegativeBuckets) == lastSum {
+				return 0, errBucketLimit
+			}
 		}
 	}
 	if fh != nil {
-		if len(fh.PositiveBuckets)+len(fh.NegativeBuckets) > app.limit {
-			return 0, errBucketLimit
+		for len(fh.PositiveBuckets)+len(fh.NegativeBuckets) > app.limit {
+			lastSum := len(fh.PositiveBuckets) + len(fh.NegativeBuckets)
+			fh = fh.ReduceResolution(fh.Schema - 1)
+			if len(fh.PositiveBuckets)+len(fh.NegativeBuckets) == lastSum {
+				return 0, errBucketLimit
+			}
 		}
 	}
 	ref, err := app.Appender.AppendHistogram(ref, lset, t, h, fh)

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -519,6 +519,11 @@ func TestBucketLimitAppender(t *testing.T) {
 		},
 		{
 			h:           example,
+			limit:       4,
+			expectError: false,
+		},
+		{
+			h:           example,
 			limit:       10,
 			expectError: false,
 		},

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -507,6 +507,19 @@ func TestBucketLimitAppender(t *testing.T) {
 		NegativeBuckets: []int64{3, 0, 0},
 	}
 
+	bigGap := histogram.Histogram{
+		Schema:        0,
+		Count:         21,
+		Sum:           33,
+		ZeroThreshold: 0.001,
+		ZeroCount:     3,
+		PositiveSpans: []histogram.Span{
+			{Offset: 1, Length: 1}, // in (1, 2]
+			{Offset: 2, Length: 1}, // in (8, 16]
+		},
+		PositiveBuckets: []int64{1, 0}, // 1, 1
+	}
+
 	cases := []struct {
 		h                 histogram.Histogram
 		limit             int
@@ -532,6 +545,13 @@ func TestBucketLimitAppender(t *testing.T) {
 			expectError:       false,
 			expectBucketCount: 6,
 			expectSchema:      0,
+		},
+		{
+			h:                 bigGap,
+			limit:             1,
+			expectError:       false,
+			expectBucketCount: 1,
+			expectSchema:      -2,
 		},
 	}
 


### PR DESCRIPTION
related #12864

when `native_histogram_bucket_limit` is hitted, reduce the resolution until it is beyond the limit.
