### PR TITLE
PromQL: ignore small errors for bucketQuantile

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -329,8 +329,9 @@ Buckets of classic histograms are cumulative. Therefore, the following should al
 - A lack of observations between the upper limits of two consecutive buckets results in equal counts
 in those two buckets.
 
-However, floating point precision issues or invalid data might violate these assumptions. In that
-case, `histogram_quantile` would be unable to return meaningful results. To mitigate the issue,
+However, floating point precision issues (e.g. small discrepancies introduced by computing of buckets
+with `sum(rate(...))`) or invalid data might violate these assumptions. In that case,
+`histogram_quantile` would be unable to return meaningful results. To mitigate the issue,
 `histogram_quantile` assumes that tiny relative differences between consecutive buckets are happening
 because of floating point precision errors and ignores them. (The threshold to ignore a difference
 between two buckets is a trillionth (1e-12) of the sum of both buckets.) Furthermore, if there are

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -323,6 +323,19 @@ a histogram.
 You can use `histogram_quantile(1, v instant-vector)` to get the estimated maximum value stored in
 a histogram.
 
+You may see this informational annotation: `input to histogram_quantile needed to be fixed for
+monotonicity`. Monotonicity (strictly non-decreasing values) of bucket counts in classic histograms
+is necessary for `histogram_quantile` to yield accurate results. In most cases when nothing has gone
+wrong, the bucket counts are monotonic. But when this assumption is violated in cases of missing or
+corrupt data, we fix the bucket counts to make them monotonic, but this means the query results might
+be inaccurate, because the data was problematic in the first place and also because we have modified
+the counts.
+
+Note that another reason the bucket counts might be non-monotonic is due to floating point precision
+errors, but we correct numerically insignificant differences between consecutive buckets silently,
+so you will only see the above warning if there are huge decreases in the bucket counts which are not
+likely to be due to float imprecision.
+
 ## `histogram_stddev()` and `histogram_stdvar()`
 
 _Both functions only act on native histograms, which are an experimental

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3699,7 +3699,7 @@ func TestNativeHistogram_HistogramQuantile(t *testing.T) {
 
 						require.Len(t, vector, 1)
 						require.Nil(t, vector[0].H)
-						require.True(t, almostEqual(sc.value, vector[0].F))
+						require.True(t, almostEqual(sc.value, vector[0].F, defaultEpsilon))
 					})
 				}
 				idx++

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1163,7 +1163,7 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 
 	for _, mb := range enh.signatureToMetricWithBuckets {
 		if len(mb.buckets) > 0 {
-			res, forcedMonotonicity := bucketQuantile(q, mb.buckets)
+			res, forcedMonotonicity, _ := bucketQuantile(q, mb.buckets)
 			enh.Out = append(enh.Out, Sample{
 				Metric: mb.metric,
 				F:      res,

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1163,13 +1163,16 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 
 	for _, mb := range enh.signatureToMetricWithBuckets {
 		if len(mb.buckets) > 0 {
-			res, forcedMonotonicity, _ := bucketQuantile(q, mb.buckets)
+			res, forcedMonotonicity, fixedPrecision := bucketQuantile(q, mb.buckets)
 			enh.Out = append(enh.Out, Sample{
 				Metric: mb.metric,
 				F:      res,
 			})
 			if forcedMonotonicity {
 				annos.Add(annotations.NewHistogramQuantileForcedMonotonicityInfo(mb.metric.Get(labels.MetricName), args[1].PositionRange()))
+			}
+			if fixedPrecision {
+				annos.Add(annotations.NewHistogramQuantileFixedPrecisionInfo(args[1].PositionRange()))
 			}
 		}
 	}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1163,16 +1163,13 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 
 	for _, mb := range enh.signatureToMetricWithBuckets {
 		if len(mb.buckets) > 0 {
-			res, forcedMonotonicity, fixedPrecision := bucketQuantile(q, mb.buckets)
+			res, forcedMonotonicity, _ := bucketQuantile(q, mb.buckets)
 			enh.Out = append(enh.Out, Sample{
 				Metric: mb.metric,
 				F:      res,
 			})
 			if forcedMonotonicity {
 				annos.Add(annotations.NewHistogramQuantileForcedMonotonicityInfo(mb.metric.Get(labels.MetricName), args[1].PositionRange()))
-			}
-			if fixedPrecision {
-				annos.Add(annotations.NewHistogramQuantileFixedPrecisionInfo(args[1].PositionRange()))
 			}
 		}
 	}

--- a/promql/quantile.go
+++ b/promql/quantile.go
@@ -391,12 +391,11 @@ func ensureMonotonicAndIgnoreSmallDeltas(buckets buckets, tolerance float64) (bo
 	prev := buckets[0].count
 	for i := 1; i < len(buckets); i++ {
 		curr := buckets[i].count // Assumed always positive.
-		delta := math.Abs(curr - prev)
-		if delta == 0 {
+		if curr == prev {
 			// No correction needed if the counts are identical between buckets.
 			continue
 		}
-		if (delta / curr) <= tolerance {
+		if almostEqual(prev, curr, tolerance) {
 			// Silently correct numerically insignificant differences from floating
 			// point precision errors, regardless of direction.
 			// Do not update the 'prev' value as we are ignoring the difference.

--- a/promql/quantile.go
+++ b/promql/quantile.go
@@ -23,6 +23,9 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
+// smallDeltaTolerance is the threshold for relative deltas between classic
+// histogram buckets that will be ignored by the histogram_quantile function
+// because they are most likely artifacts of floating point precision issues.
 // Testing on 2 sets of real data with bugs arising from small deltas,
 // the safe ranges were from:
 // - 1e-05 to 1e-15
@@ -377,7 +380,7 @@ func coalesceBuckets(buckets buckets) buckets {
 // bucket with the φ-quantile count, so breaking the monotonicity
 // guarantee causes bucketQuantile() to return undefined (nonsense) results.
 //
-// As a somewhat hacky solution, we first silently correct any numerically
+// As a somewhat hacky solution, we first silently ignore any numerically
 // insignificant (relative delta below the requested tolerance and likely to
 // be from floating point precision errors) differences between successive
 // buckets regardless of the direction. Then we calculate the "envelope" of

--- a/promql/quantile_test.go
+++ b/promql/quantile_test.go
@@ -1,0 +1,361 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
+	eps := 1e-12
+
+	t.Run("simple - monotonic", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 10,
+					count:      10,
+				}, {
+					upperBound: 15,
+					count:      15,
+				}, {
+					upperBound: 20,
+					count:      15,
+				}, {
+					upperBound: 30,
+					count:      15,
+				}, {
+					upperBound: math.Inf(1),
+					count:      15,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 15., res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 14.85, res)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 13.5, res)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 7.5, res)
+	})
+
+	t.Run("simple - non-monotonic middle", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 10,
+					count:      10,
+				}, {
+					upperBound: 15,
+					count:      15,
+				}, {
+					upperBound: 20,
+					count:      15.00000000001, // Simulate the case there's a small imprecision in float64.
+				}, {
+					upperBound: 30,
+					count:      15,
+				}, {
+					upperBound: math.Inf(1),
+					count:      15,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 15., res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 14.85, res)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 13.5, res)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 7.5, res)
+	})
+
+	t.Run("real example - monotonic", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 1,
+					count:      6454661.3014166197,
+				}, {
+					upperBound: 5,
+					count:      8339611.2001912938,
+				}, {
+					upperBound: 10,
+					count:      14118319.2444762159,
+				}, {
+					upperBound: 25,
+					count:      14130031.5272856522,
+				}, {
+					upperBound: 50,
+					count:      46001270.3030008152,
+				}, {
+					upperBound: 64,
+					count:      46008473.8585563600,
+				}, {
+					upperBound: 80,
+					count:      46008473.8585563600,
+				}, {
+					upperBound: 100,
+					count:      46008473.8585563600,
+				}, {
+					upperBound: 250,
+					count:      46008473.8585563600,
+				}, {
+					upperBound: 1000,
+					count:      46008473.8585563600,
+				}, {
+					upperBound: math.Inf(1),
+					count:      46008473.8585563600,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 64., res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 49.64475715376406, res, eps)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 46.39671690938454, res, eps)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 31.96098248992002, res, eps)
+	})
+
+	t.Run("real example - non-monotonic", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 1,
+					count:      6454661.3014166225,
+				}, {
+					upperBound: 5,
+					count:      8339611.2001912957,
+				}, {
+					upperBound: 10,
+					count:      14118319.2444762159,
+				}, {
+					upperBound: 25,
+					count:      14130031.5272856504,
+				}, {
+					upperBound: 50,
+					count:      46001270.3030008227,
+				}, {
+					upperBound: 64,
+					count:      46008473.8585563824,
+				}, {
+					upperBound: 80,
+					count:      46008473.8585563898,
+				}, {
+					upperBound: 100,
+					count:      46008473.8585563824,
+				}, {
+					upperBound: 250,
+					count:      46008473.8585563824,
+				}, {
+					upperBound: 1000,
+					count:      46008473.8585563898,
+				}, {
+					upperBound: math.Inf(1),
+					count:      46008473.8585563824,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 64., res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 49.64475715376406, res, eps)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 46.39671690938454, res, eps)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 31.96098248992002, res, eps)
+	})
+
+	t.Run("real example 2 - monotonic", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 0.005,
+					count:      9.6,
+				}, {
+					upperBound: 0.01,
+					count:      9.688888889,
+				}, {
+					upperBound: 0.025,
+					count:      9.755555556,
+				}, {
+					upperBound: 0.05,
+					count:      9.844444444,
+				}, {
+					upperBound: 0.1,
+					count:      9.888888889,
+				}, {
+					upperBound: 0.25,
+					count:      9.888888889,
+				}, {
+					upperBound: 0.5,
+					count:      9.888888889,
+				}, {
+					upperBound: 1,
+					count:      9.888888889,
+				}, {
+					upperBound: 2.5,
+					count:      9.888888889,
+				}, {
+					upperBound: 5,
+					count:      9.888888889,
+				}, {
+					upperBound: 10,
+					count:      9.888888889,
+				}, {
+					upperBound: 25,
+					count:      9.888888889,
+				}, {
+					upperBound: 50,
+					count:      9.888888889,
+				}, {
+					upperBound: 100,
+					count:      9.888888889,
+				}, {
+					upperBound: math.Inf(1),
+					count:      9.888888889,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.False(t, forced)
+		assert.Equal(t, 0.1, res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 0.03468750000281261, res, eps)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 0.00463541666671875, res, eps)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.False(t, forced)
+		assert.InEpsilon(t, 0.0025752314815104174, res, eps)
+	})
+
+	t.Run("real example 2 - non-monotonic", func(t *testing.T) {
+		// The buckets can be modified in-place so return each time a new one.
+		getInput := func() buckets {
+			return buckets{
+				{
+					upperBound: 0.005,
+					count:      9.6,
+				}, {
+					upperBound: 0.01,
+					count:      9.688888889,
+				}, {
+					upperBound: 0.025,
+					count:      9.755555556,
+				}, {
+					upperBound: 0.05,
+					count:      9.844444444,
+				}, {
+					upperBound: 0.1,
+					count:      9.888888889,
+				}, {
+					upperBound: 0.25,
+					count:      9.888888889,
+				}, {
+					upperBound: 0.5,
+					count:      9.888888889,
+				}, {
+					upperBound: 1,
+					count:      9.888888889,
+				}, {
+					upperBound: 2.5,
+					count:      9.888888889,
+				}, {
+					upperBound: 5,
+					count:      9.888888889,
+				}, {
+					upperBound: 10,
+					count:      9.888888889001, // Simulate the case there's a small imprecision in float64.
+				}, {
+					upperBound: 25,
+					count:      9.888888889,
+				}, {
+					upperBound: 50,
+					count:      9.888888888999, // Simulate the case there's a small imprecision in float64.
+				}, {
+					upperBound: 100,
+					count:      9.888888889,
+				}, {
+					upperBound: math.Inf(1),
+					count:      9.888888889,
+				},
+			}
+		}
+
+		res, forced := bucketQuantile(1, getInput())
+		assert.True(t, forced)
+		assert.Equal(t, 0.1, res)
+
+		res, forced = bucketQuantile(0.99, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 0.03468750000281261, res, eps)
+
+		res, forced = bucketQuantile(0.9, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 0.00463541666671875, res, eps)
+
+		res, forced = bucketQuantile(0.5, getInput())
+		assert.True(t, forced)
+		assert.InEpsilon(t, 0.0025752314815104174, res, eps)
+	})
+}

--- a/promql/quantile_test.go
+++ b/promql/quantile_test.go
@@ -26,6 +26,7 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 	for name, tc := range map[string]struct {
 		getInput       func() buckets // The buckets can be modified in-place so return a new one each time.
 		expectedForced bool
+		expectedFixed  bool
 		expectedValues map[float64]float64
 	}{
 		"simple - monotonic": {
@@ -50,6 +51,7 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 				}
 			},
 			expectedForced: false,
+			expectedFixed:  false,
 			expectedValues: map[float64]float64{
 				1:    15.,
 				0.99: 14.85,
@@ -78,7 +80,8 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 					},
 				}
 			},
-			expectedForced: true,
+			expectedForced: false,
+			expectedFixed:  true,
 			expectedValues: map[float64]float64{
 				1:    15.,
 				0.99: 14.85,
@@ -126,6 +129,7 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 				}
 			},
 			expectedForced: false,
+			expectedFixed:  false,
 			expectedValues: map[float64]float64{
 				1:    64.,
 				0.99: 49.64475715376406,
@@ -172,7 +176,8 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 					},
 				}
 			},
-			expectedForced: true,
+			expectedForced: false,
+			expectedFixed:  true,
 			expectedValues: map[float64]float64{
 				1:    64.,
 				0.99: 49.64475715376406,
@@ -232,6 +237,7 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 				}
 			},
 			expectedForced: false,
+			expectedFixed:  false,
 			expectedValues: map[float64]float64{
 				1:    0.1,
 				0.99: 0.03468750000281261,
@@ -290,7 +296,8 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 					},
 				}
 			},
-			expectedForced: true,
+			expectedForced: false,
+			expectedFixed:  true,
 			expectedValues: map[float64]float64{
 				1:    0.1,
 				0.99: 0.03468750000281261,
@@ -301,8 +308,9 @@ func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			for q, v := range tc.expectedValues {
-				res, forced := bucketQuantile(q, tc.getInput())
+				res, forced, fixed := bucketQuantile(q, tc.getInput())
 				require.Equal(t, tc.expectedForced, forced)
+				require.Equal(t, tc.expectedFixed, fixed)
 				require.InEpsilon(t, v, res, eps)
 			}
 		})

--- a/promql/quantile_test.go
+++ b/promql/quantile_test.go
@@ -17,345 +17,294 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBucketQuantile_ForcedMonotonicity(t *testing.T) {
 	eps := 1e-12
 
-	t.Run("simple - monotonic", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 10,
-					count:      10,
-				}, {
-					upperBound: 15,
-					count:      15,
-				}, {
-					upperBound: 20,
-					count:      15,
-				}, {
-					upperBound: 30,
-					count:      15,
-				}, {
-					upperBound: math.Inf(1),
-					count:      15,
-				},
+	for name, tc := range map[string]struct {
+		getInput       func() buckets // The buckets can be modified in-place so return a new one each time.
+		expectedForced bool
+		expectedValues map[float64]float64
+	}{
+		"simple - monotonic": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 10,
+						count:      10,
+					}, {
+						upperBound: 15,
+						count:      15,
+					}, {
+						upperBound: 20,
+						count:      15,
+					}, {
+						upperBound: 30,
+						count:      15,
+					}, {
+						upperBound: math.Inf(1),
+						count:      15,
+					},
+				}
+			},
+			expectedForced: false,
+			expectedValues: map[float64]float64{
+				1:    15.,
+				0.99: 14.85,
+				0.9:  13.5,
+				0.5:  7.5,
+			},
+		},
+		"simple - non-monotonic middle": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 10,
+						count:      10,
+					}, {
+						upperBound: 15,
+						count:      15,
+					}, {
+						upperBound: 20,
+						count:      15.00000000001, // Simulate the case there's a small imprecision in float64.
+					}, {
+						upperBound: 30,
+						count:      15,
+					}, {
+						upperBound: math.Inf(1),
+						count:      15,
+					},
+				}
+			},
+			expectedForced: true,
+			expectedValues: map[float64]float64{
+				1:    15.,
+				0.99: 14.85,
+				0.9:  13.5,
+				0.5:  7.5,
+			},
+		},
+		"real example - monotonic": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 1,
+						count:      6454661.3014166197,
+					}, {
+						upperBound: 5,
+						count:      8339611.2001912938,
+					}, {
+						upperBound: 10,
+						count:      14118319.2444762159,
+					}, {
+						upperBound: 25,
+						count:      14130031.5272856522,
+					}, {
+						upperBound: 50,
+						count:      46001270.3030008152,
+					}, {
+						upperBound: 64,
+						count:      46008473.8585563600,
+					}, {
+						upperBound: 80,
+						count:      46008473.8585563600,
+					}, {
+						upperBound: 100,
+						count:      46008473.8585563600,
+					}, {
+						upperBound: 250,
+						count:      46008473.8585563600,
+					}, {
+						upperBound: 1000,
+						count:      46008473.8585563600,
+					}, {
+						upperBound: math.Inf(1),
+						count:      46008473.8585563600,
+					},
+				}
+			},
+			expectedForced: false,
+			expectedValues: map[float64]float64{
+				1:    64.,
+				0.99: 49.64475715376406,
+				0.9:  46.39671690938454,
+				0.5:  31.96098248992002,
+			},
+		},
+		"real example - non-monotonic": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 1,
+						count:      6454661.3014166225,
+					}, {
+						upperBound: 5,
+						count:      8339611.2001912957,
+					}, {
+						upperBound: 10,
+						count:      14118319.2444762159,
+					}, {
+						upperBound: 25,
+						count:      14130031.5272856504,
+					}, {
+						upperBound: 50,
+						count:      46001270.3030008227,
+					}, {
+						upperBound: 64,
+						count:      46008473.8585563824,
+					}, {
+						upperBound: 80,
+						count:      46008473.8585563898,
+					}, {
+						upperBound: 100,
+						count:      46008473.8585563824,
+					}, {
+						upperBound: 250,
+						count:      46008473.8585563824,
+					}, {
+						upperBound: 1000,
+						count:      46008473.8585563898,
+					}, {
+						upperBound: math.Inf(1),
+						count:      46008473.8585563824,
+					},
+				}
+			},
+			expectedForced: true,
+			expectedValues: map[float64]float64{
+				1:    64.,
+				0.99: 49.64475715376406,
+				0.9:  46.39671690938454,
+				0.5:  31.96098248992002,
+			},
+		},
+		"real example 2 - monotonic": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 0.005,
+						count:      9.6,
+					}, {
+						upperBound: 0.01,
+						count:      9.688888889,
+					}, {
+						upperBound: 0.025,
+						count:      9.755555556,
+					}, {
+						upperBound: 0.05,
+						count:      9.844444444,
+					}, {
+						upperBound: 0.1,
+						count:      9.888888889,
+					}, {
+						upperBound: 0.25,
+						count:      9.888888889,
+					}, {
+						upperBound: 0.5,
+						count:      9.888888889,
+					}, {
+						upperBound: 1,
+						count:      9.888888889,
+					}, {
+						upperBound: 2.5,
+						count:      9.888888889,
+					}, {
+						upperBound: 5,
+						count:      9.888888889,
+					}, {
+						upperBound: 10,
+						count:      9.888888889,
+					}, {
+						upperBound: 25,
+						count:      9.888888889,
+					}, {
+						upperBound: 50,
+						count:      9.888888889,
+					}, {
+						upperBound: 100,
+						count:      9.888888889,
+					}, {
+						upperBound: math.Inf(1),
+						count:      9.888888889,
+					},
+				}
+			},
+			expectedForced: false,
+			expectedValues: map[float64]float64{
+				1:    0.1,
+				0.99: 0.03468750000281261,
+				0.9:  0.00463541666671875,
+				0.5:  0.0025752314815104174,
+			},
+		},
+		"real example 2 - non-monotonic": {
+			getInput: func() buckets {
+				return buckets{
+					{
+						upperBound: 0.005,
+						count:      9.6,
+					}, {
+						upperBound: 0.01,
+						count:      9.688888889,
+					}, {
+						upperBound: 0.025,
+						count:      9.755555556,
+					}, {
+						upperBound: 0.05,
+						count:      9.844444444,
+					}, {
+						upperBound: 0.1,
+						count:      9.888888889,
+					}, {
+						upperBound: 0.25,
+						count:      9.888888889,
+					}, {
+						upperBound: 0.5,
+						count:      9.888888889,
+					}, {
+						upperBound: 1,
+						count:      9.888888889,
+					}, {
+						upperBound: 2.5,
+						count:      9.888888889,
+					}, {
+						upperBound: 5,
+						count:      9.888888889,
+					}, {
+						upperBound: 10,
+						count:      9.888888889001, // Simulate the case there's a small imprecision in float64.
+					}, {
+						upperBound: 25,
+						count:      9.888888889,
+					}, {
+						upperBound: 50,
+						count:      9.888888888999, // Simulate the case there's a small imprecision in float64.
+					}, {
+						upperBound: 100,
+						count:      9.888888889,
+					}, {
+						upperBound: math.Inf(1),
+						count:      9.888888889,
+					},
+				}
+			},
+			expectedForced: true,
+			expectedValues: map[float64]float64{
+				1:    0.1,
+				0.99: 0.03468750000281261,
+				0.9:  0.00463541666671875,
+				0.5:  0.0025752314815104174,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for q, v := range tc.expectedValues {
+				res, forced := bucketQuantile(q, tc.getInput())
+				require.Equal(t, tc.expectedForced, forced)
+				require.InEpsilon(t, v, res, eps)
 			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 15., res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 14.85, res)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 13.5, res)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 7.5, res)
-	})
-
-	t.Run("simple - non-monotonic middle", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 10,
-					count:      10,
-				}, {
-					upperBound: 15,
-					count:      15,
-				}, {
-					upperBound: 20,
-					count:      15.00000000001, // Simulate the case there's a small imprecision in float64.
-				}, {
-					upperBound: 30,
-					count:      15,
-				}, {
-					upperBound: math.Inf(1),
-					count:      15,
-				},
-			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 15., res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 14.85, res)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 13.5, res)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 7.5, res)
-	})
-
-	t.Run("real example - monotonic", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 1,
-					count:      6454661.3014166197,
-				}, {
-					upperBound: 5,
-					count:      8339611.2001912938,
-				}, {
-					upperBound: 10,
-					count:      14118319.2444762159,
-				}, {
-					upperBound: 25,
-					count:      14130031.5272856522,
-				}, {
-					upperBound: 50,
-					count:      46001270.3030008152,
-				}, {
-					upperBound: 64,
-					count:      46008473.8585563600,
-				}, {
-					upperBound: 80,
-					count:      46008473.8585563600,
-				}, {
-					upperBound: 100,
-					count:      46008473.8585563600,
-				}, {
-					upperBound: 250,
-					count:      46008473.8585563600,
-				}, {
-					upperBound: 1000,
-					count:      46008473.8585563600,
-				}, {
-					upperBound: math.Inf(1),
-					count:      46008473.8585563600,
-				},
-			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 64., res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 49.64475715376406, res, eps)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 46.39671690938454, res, eps)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 31.96098248992002, res, eps)
-	})
-
-	t.Run("real example - non-monotonic", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 1,
-					count:      6454661.3014166225,
-				}, {
-					upperBound: 5,
-					count:      8339611.2001912957,
-				}, {
-					upperBound: 10,
-					count:      14118319.2444762159,
-				}, {
-					upperBound: 25,
-					count:      14130031.5272856504,
-				}, {
-					upperBound: 50,
-					count:      46001270.3030008227,
-				}, {
-					upperBound: 64,
-					count:      46008473.8585563824,
-				}, {
-					upperBound: 80,
-					count:      46008473.8585563898,
-				}, {
-					upperBound: 100,
-					count:      46008473.8585563824,
-				}, {
-					upperBound: 250,
-					count:      46008473.8585563824,
-				}, {
-					upperBound: 1000,
-					count:      46008473.8585563898,
-				}, {
-					upperBound: math.Inf(1),
-					count:      46008473.8585563824,
-				},
-			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 64., res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 49.64475715376406, res, eps)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 46.39671690938454, res, eps)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 31.96098248992002, res, eps)
-	})
-
-	t.Run("real example 2 - monotonic", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 0.005,
-					count:      9.6,
-				}, {
-					upperBound: 0.01,
-					count:      9.688888889,
-				}, {
-					upperBound: 0.025,
-					count:      9.755555556,
-				}, {
-					upperBound: 0.05,
-					count:      9.844444444,
-				}, {
-					upperBound: 0.1,
-					count:      9.888888889,
-				}, {
-					upperBound: 0.25,
-					count:      9.888888889,
-				}, {
-					upperBound: 0.5,
-					count:      9.888888889,
-				}, {
-					upperBound: 1,
-					count:      9.888888889,
-				}, {
-					upperBound: 2.5,
-					count:      9.888888889,
-				}, {
-					upperBound: 5,
-					count:      9.888888889,
-				}, {
-					upperBound: 10,
-					count:      9.888888889,
-				}, {
-					upperBound: 25,
-					count:      9.888888889,
-				}, {
-					upperBound: 50,
-					count:      9.888888889,
-				}, {
-					upperBound: 100,
-					count:      9.888888889,
-				}, {
-					upperBound: math.Inf(1),
-					count:      9.888888889,
-				},
-			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.False(t, forced)
-		assert.Equal(t, 0.1, res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 0.03468750000281261, res, eps)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 0.00463541666671875, res, eps)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.False(t, forced)
-		assert.InEpsilon(t, 0.0025752314815104174, res, eps)
-	})
-
-	t.Run("real example 2 - non-monotonic", func(t *testing.T) {
-		// The buckets can be modified in-place so return each time a new one.
-		getInput := func() buckets {
-			return buckets{
-				{
-					upperBound: 0.005,
-					count:      9.6,
-				}, {
-					upperBound: 0.01,
-					count:      9.688888889,
-				}, {
-					upperBound: 0.025,
-					count:      9.755555556,
-				}, {
-					upperBound: 0.05,
-					count:      9.844444444,
-				}, {
-					upperBound: 0.1,
-					count:      9.888888889,
-				}, {
-					upperBound: 0.25,
-					count:      9.888888889,
-				}, {
-					upperBound: 0.5,
-					count:      9.888888889,
-				}, {
-					upperBound: 1,
-					count:      9.888888889,
-				}, {
-					upperBound: 2.5,
-					count:      9.888888889,
-				}, {
-					upperBound: 5,
-					count:      9.888888889,
-				}, {
-					upperBound: 10,
-					count:      9.888888889001, // Simulate the case there's a small imprecision in float64.
-				}, {
-					upperBound: 25,
-					count:      9.888888889,
-				}, {
-					upperBound: 50,
-					count:      9.888888888999, // Simulate the case there's a small imprecision in float64.
-				}, {
-					upperBound: 100,
-					count:      9.888888889,
-				}, {
-					upperBound: math.Inf(1),
-					count:      9.888888889,
-				},
-			}
-		}
-
-		res, forced := bucketQuantile(1, getInput())
-		assert.True(t, forced)
-		assert.Equal(t, 0.1, res)
-
-		res, forced = bucketQuantile(0.99, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 0.03468750000281261, res, eps)
-
-		res, forced = bucketQuantile(0.9, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 0.00463541666671875, res, eps)
-
-		res, forced = bucketQuantile(0.5, getInput())
-		assert.True(t, forced)
-		assert.InEpsilon(t, 0.0025752314815104174, res, eps)
-	})
+		})
+	}
 }

--- a/promql/test.go
+++ b/promql/test.go
@@ -49,7 +49,7 @@ var (
 )
 
 const (
-	epsilon = 0.000001 // Relative error allowed for sample values.
+	defaultEpsilon = 0.000001 // Relative error allowed for sample values.
 )
 
 var testStartTime = time.Unix(0, 0).UTC()
@@ -440,7 +440,7 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 			if (expH == nil) != (v.H == nil) || (expH != nil && !expH.Equals(v.H)) {
 				return fmt.Errorf("expected %v for %s but got %s", HistogramTestExpression(expH), v.Metric, HistogramTestExpression(v.H))
 			}
-			if !almostEqual(exp0.Value, v.F) {
+			if !almostEqual(exp0.Value, v.F, defaultEpsilon) {
 				return fmt.Errorf("expected %v for %s but got %v", exp0.Value, v.Metric, v.F)
 			}
 
@@ -464,7 +464,7 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 		if exp0.Histogram != nil {
 			return fmt.Errorf("expected Histogram %v but got scalar %s", exp0.Histogram.TestExpression(), val.String())
 		}
-		if !almostEqual(exp0.Value, val.V) {
+		if !almostEqual(exp0.Value, val.V, defaultEpsilon) {
 			return fmt.Errorf("expected Scalar %v but got %v", val.V, exp0.Value)
 		}
 
@@ -665,7 +665,7 @@ func (t *test) clear() {
 
 // samplesAlmostEqual returns true if the two sample lines only differ by a
 // small relative error in their sample value.
-func almostEqual(a, b float64) bool {
+func almostEqual(a, b, epsilon float64) bool {
 	// NaN has no equality but for testing we still want to know whether both values
 	// are NaN.
 	if math.IsNaN(a) && math.IsNaN(b) {
@@ -677,12 +677,13 @@ func almostEqual(a, b float64) bool {
 		return true
 	}
 
+	absSum := math.Abs(a) + math.Abs(b)
 	diff := math.Abs(a - b)
 
-	if a == 0 || b == 0 || diff < minNormal {
+	if a == 0 || b == 0 || absSum < minNormal {
 		return diff < epsilon*minNormal
 	}
-	return diff/(math.Abs(a)+math.Abs(b)) < epsilon
+	return diff/math.Min(absSum, math.MaxFloat64) < epsilon
 }
 
 func parseNumber(s string) (float64, error) {

--- a/promql/test.go
+++ b/promql/test.go
@@ -663,8 +663,8 @@ func (t *test) clear() {
 	t.context, t.cancelCtx = context.WithCancel(context.Background())
 }
 
-// samplesAlmostEqual returns true if the two sample lines only differ by a
-// small relative error in their sample value.
+// almostEqual returns true if a and b differ by less than their sum
+// multiplied by epsilon.
 func almostEqual(a, b, epsilon float64) bool {
 	// NaN has no equality but for testing we still want to know whether both values
 	// are NaN.

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -108,7 +108,7 @@ var (
 	MixedClassicNativeHistogramsWarning = fmt.Errorf("%w: vector contains a mix of classic and native histograms for metric name", PromQLWarning)
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
-	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (and may give inaccurate results) for metric name", PromQLInfo)
+	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
 )
 
 type annoErr struct {

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -109,6 +109,7 @@ var (
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
+	HistogramQuantileFixedPrecisionInfo     = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for floating point imprecision (and may give inaccurate results)", PromQLInfo)
 )
 
 type annoErr struct {
@@ -180,5 +181,15 @@ func NewHistogramQuantileForcedMonotonicityInfo(metricName string, pos posrange.
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q", HistogramQuantileForcedMonotonicityInfo, metricName),
+	}
+}
+
+// NewHistogramQuantileFixedPrecisionInfo is used when the input (classic histograms) to
+// histogram_quantile was fixed to ignore small differences in bucket counts which are assumed
+// to be due to floating point imprecision accumulated from query sharding in Mimir.
+func NewHistogramQuantileFixedPrecisionInfo(pos posrange.PositionRange) annoErr {
+	return annoErr{
+		PositionRange: pos,
+		Err:           HistogramQuantileFixedPrecisionInfo,
 	}
 }

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -109,7 +109,6 @@ var (
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
-	HistogramQuantileFixedPrecisionInfo     = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for floating point imprecision (and may give inaccurate results)", PromQLInfo)
 )
 
 type annoErr struct {
@@ -181,15 +180,5 @@ func NewHistogramQuantileForcedMonotonicityInfo(metricName string, pos posrange.
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q", HistogramQuantileForcedMonotonicityInfo, metricName),
-	}
-}
-
-// NewHistogramQuantileFixedPrecisionInfo is used when the input (classic histograms) to
-// histogram_quantile was fixed to ignore small differences in bucket counts which are assumed
-// to be due to floating point imprecision accumulated from query sharding in Mimir.
-func NewHistogramQuantileFixedPrecisionInfo(pos posrange.PositionRange) annoErr {
-	return annoErr{
-		PositionRange: pos,
-		Err:           HistogramQuantileFixedPrecisionInfo,
 	}
 }


### PR DESCRIPTION
This PR fixes the wrong results from `histogram_quantile` that happens due to floating point precision errors in the bucket counts of classic histograms, and also gets rid of the monotonicity warnings which may confuse end-users.

The fix: ignoring numerically insignificant (ratio of delta to current value below a certain tolerance) changes in counts between classic histogram buckets before running bucketQuantile.

The currently set tolerance is 1e-12. Testing on real data with this bug locally, on the first set of data the safe range was from 1e-05 to 1e-15, the second set was from 1e-06 to 1e-15. Anything to the left of that would cause non-query-sharded data to be corrected for precision errors (unnecessary and we should avoid this), and anything to the right of that would cause query-sharded data to not be corrected (so the problem won't be fixed). (Query sharding triggers these float precision errors in Mimir).

You can try the new unit tests before and after the fix to verify that it fails before and passes afterwards.