### PR TITLE
http client config: Allow overwriting Host Header

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -182,6 +182,9 @@ type injectHeadersRoundTripper struct {
 func (t *injectHeadersRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	for key, value := range t.headers {
 		req.Header.Set(key, value)
+		if key == "Host" {
+			req.Host = value
+		}
 	}
 	return t.RoundTripper.RoundTrip(req)
 }


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->


This PR allow to overwrite the HTTP Host header via `headers`


```yaml
remote_write:
- name: remote
  url: https://20.0.0.1/api/v1/write
  headers:
    Host: prometheus.example.com
  tls_config:
    server_name: prometheus.example.com # this already works
```
