### PR TITLE
scrape: simplify TargetsActive function

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -279,24 +279,10 @@ func (m *Manager) TargetsActive() map[string][]*Target {
 	m.mtxScrape.Lock()
 	defer m.mtxScrape.Unlock()
 
-	var (
-		wg  sync.WaitGroup
-		mtx sync.Mutex
-	)
-
 	targets := make(map[string][]*Target, len(m.scrapePools))
-	wg.Add(len(m.scrapePools))
 	for tset, sp := range m.scrapePools {
-		// Running in parallel limits the blocking time of scrapePool to scrape
-		// interval when there's an update from SD.
-		go func(tset string, sp *scrapePool) {
-			mtx.Lock()
-			targets[tset] = sp.ActiveTargets()
-			mtx.Unlock()
-			wg.Done()
-		}(tset, sp)
+		targets[tset] = sp.ActiveTargets()
 	}
-	wg.Wait()
 	return targets
 }
 


### PR DESCRIPTION
Since everything was serialized on a single mutex, it's exactly the same if we process targets in sequence without starting goroutines.

This is basically reverting #5740.

This PR is in competition with #13168 .  See which one you like best!
