### PR TITLE
scrape: make TargetsActive function run concurrently

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -290,8 +290,9 @@ func (m *Manager) TargetsActive() map[string][]*Target {
 		// Running in parallel limits the blocking time of scrapePool to scrape
 		// interval when there's an update from SD.
 		go func(tset string, sp *scrapePool) {
+			poolTargets := sp.ActiveTargets()
 			mtx.Lock()
-			targets[tset] = sp.ActiveTargets()
+			targets[tset] = poolTargets
 			mtx.Unlock()
 			wg.Done()
 		}(tset, sp)


### PR DESCRIPTION
Instead of serializing everything, allow fetches of data to proceed in parallel and lock only when we need to modify the shared map which is collecting results.

I think this may have been the original idea of #5740, to let other work proceed while some pools were locked for `Sync()`.
However I still don't follow the comment about "limits the blocking time of scrapePool".

This PR is in competition with #13167.  See which one you like best!
