### PR TITLE
Fix linting errors

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -650,7 +650,7 @@ func (client *azureClient) getNetworkInterfaceByID(ctx context.Context, networkI
 	return &resp.Interface, nil
 }
 
-// addToCache will add the network interface information for the specified nicID
+// addToCache will add the network interface information for the specified nicID.
 func (d *Discovery) addToCache(nicID string, netInt *armnetwork.Interface) {
 	random := rand.Int63n(int64(time.Duration(d.cfg.RefreshInterval * 3).Seconds()))
 	rs := time.Duration(random) * time.Second
@@ -659,8 +659,8 @@ func (d *Discovery) addToCache(nicID string, netInt *armnetwork.Interface) {
 	level.Debug(d.logger).Log("msg", "Adding nic", "nic", nicID, "time", exptime.Seconds())
 }
 
-// getFromCache will get the network Interface for the specified nicID
-// If the cache is disabled nothing will happen
+// getFromCache will get the network Interface for the specified nicID.
+// If the cache is disabled nothing will happen.
 func (d *Discovery) getFromCache(nicID string) (*armnetwork.Interface, bool) {
 	net, found := d.cache.Get(nicID)
 	return net, found

--- a/template/template.go
+++ b/template/template.go
@@ -181,7 +181,7 @@ func NewTemplateExpander(
 				return html_template.HTML(text)
 			},
 			"match":     regexp.MatchString,
-			"title":     strings.Title, //nolint:staticcheck
+			"title":     strings.Title,
 			"toUpper":   strings.ToUpper,
 			"toLower":   strings.ToLower,
 			"graphLink": strutil.GraphLinkForExpression,


### PR DESCRIPTION
The golangci-lint check is failing in other PRs because of `Comment should end in a period (godot)` errors in azure.go and an unused `nolint:staticcheck` in template.go.

E.g. https://github.com/prometheus/prometheus/actions/runs/6948069651?pr=13169, https://github.com/prometheus/prometheus/actions/runs/6955823651?pr=13123