### PR TITLE
scrape: consistent function names for metadata

### DIFF
--- a/scrape/metrics.go
+++ b/scrape/metrics.go
@@ -286,8 +286,8 @@ func (mc *MetadataMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	for tset, targets := range mc.TargetsGatherer.TargetsActive() {
 		var size, length int
 		for _, t := range targets {
-			size += t.MetadataSize()
-			length += t.MetadataLength()
+			size += t.SizeMetadata()
+			length += t.LengthMetadata()
 		}
 
 		ch <- prometheus.MustNewConstMetric(

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -92,7 +92,7 @@ type MetricMetadata struct {
 	Unit   string
 }
 
-func (t *Target) MetadataList() []MetricMetadata {
+func (t *Target) ListMetadata() []MetricMetadata {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
 
@@ -102,7 +102,7 @@ func (t *Target) MetadataList() []MetricMetadata {
 	return t.metadata.ListMetadata()
 }
 
-func (t *Target) MetadataSize() int {
+func (t *Target) SizeMetadata() int {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
 
@@ -113,7 +113,7 @@ func (t *Target) MetadataSize() int {
 	return t.metadata.SizeMetadata()
 }
 
-func (t *Target) MetadataLength() int {
+func (t *Target) LengthMetadata() int {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
 
@@ -124,8 +124,8 @@ func (t *Target) MetadataLength() int {
 	return t.metadata.LengthMetadata()
 }
 
-// Metadata returns type and help metadata for the given metric.
-func (t *Target) Metadata(metric string) (MetricMetadata, bool) {
+// GetMetadata returns type and help metadata for the given metric.
+func (t *Target) GetMetadata(metric string) (MetricMetadata, bool) {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
 

--- a/storage/remote/metadata_watcher.go
+++ b/storage/remote/metadata_watcher.go
@@ -136,7 +136,7 @@ func (mw *MetadataWatcher) collect() {
 	metadata := []scrape.MetricMetadata{}
 	for _, tset := range mw.manager.TargetsActive() {
 		for _, target := range tset {
-			for _, entry := range target.MetadataList() {
+			for _, entry := range target.ListMetadata() {
 				if _, ok := metadataSet[entry]; !ok {
 					metadata = append(metadata, entry)
 					metadataSet[entry] = struct{}{}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1114,7 +1114,7 @@ func (api *API) targetMetadata(r *http.Request) apiFuncResult {
 			}
 			// If no metric is specified, get the full list for the target.
 			if metric == "" {
-				for _, md := range t.MetadataList() {
+				for _, md := range t.ListMetadata() {
 					res = append(res, metricMetadata{
 						Target: t.Labels(),
 						Metric: md.Metric,
@@ -1126,7 +1126,7 @@ func (api *API) targetMetadata(r *http.Request) apiFuncResult {
 				continue
 			}
 			// Get metadata for the specified metric.
-			if md, ok := t.Metadata(metric); ok {
+			if md, ok := t.GetMetadata(metric); ok {
 				res = append(res, metricMetadata{
 					Target: t.Labels(),
 					Type:   md.Type,
@@ -1249,7 +1249,7 @@ func (api *API) metricMetadata(r *http.Request) apiFuncResult {
 	for _, tt := range api.targetRetriever(r.Context()).TargetsActive() {
 		for _, t := range tt {
 			if metric == "" {
-				for _, mm := range t.MetadataList() {
+				for _, mm := range t.ListMetadata() {
 					m := metadata{Type: mm.Type, Help: mm.Help, Unit: mm.Unit}
 					ms, ok := metrics[mm.Metric]
 
@@ -1266,7 +1266,7 @@ func (api *API) metricMetadata(r *http.Request) apiFuncResult {
 				continue
 			}
 
-			if md, ok := t.Metadata(metric); ok {
+			if md, ok := t.GetMetadata(metric); ok {
 				m := metadata{Type: md.Type, Help: md.Help, Unit: md.Unit}
 				ms, ok := metrics[md.Metric]
 


### PR DESCRIPTION
This was doing my head in - `MetadataList` vs `ListMetadata`, etc. 

I standardised on the ones which are in an interface.
