### PR TITLE
Only skip invalid wal record

### DIFF
--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -38,9 +38,11 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--storage.tsdb.retention.time</code> | How long to retain samples in storage. If neither this flag nor "storage.tsdb.retention.size" is set, the retention time defaults to 15d. Units Supported: y, w, d, h, m, s, ms. Use with server mode only. |  |
 | <code class="text-nowrap">--storage.tsdb.retention.size</code> | Maximum number of bytes that can be stored for blocks. A unit is required, supported units: B, KB, MB, GB, TB, PB, EB. Ex: "512MB". Based on powers-of-2, so 1KB is 1024B. Use with server mode only. |  |
 | <code class="text-nowrap">--storage.tsdb.no-lockfile</code> | Do not create lockfile in data directory. Use with server mode only. | `false` |
+| <code class="text-nowrap">--storage.tsdb.ignore-wal-reading-corruption</code> | Ignore WAL corruption while reading it, if true this will skip all corruption records of WAL and truncate it as normal. Use with server mode only. | `false` |
 | <code class="text-nowrap">--storage.tsdb.head-chunks-write-queue-size</code> | Size of the queue through which head chunks are written to the disk to be m-mapped, 0 disables the queue completely. Experimental. Use with server mode only. | `0` |
 | <code class="text-nowrap">--storage.agent.path</code> | Base path for metrics storage. Use with agent mode only. | `data-agent/` |
 | <code class="text-nowrap">--storage.agent.wal-compression</code> | Compress the agent WAL. Use with agent mode only. | `true` |
+| <code class="text-nowrap">--storage.agent.ignore-wal-replay-corruption</code> | Ignore WAL corruption while reading it, if true this will skip all corruption records of WAL and truncate it as normal. Use with agent mode only. | `false` |
 | <code class="text-nowrap">--storage.agent.retention.min-time</code> | Minimum age samples may be before being considered for deletion when the WAL is truncated Use with agent mode only. |  |
 | <code class="text-nowrap">--storage.agent.retention.max-time</code> | Maximum age samples may be before being forcibly deleted when the WAL is truncated Use with agent mode only. |  |
 | <code class="text-nowrap">--storage.agent.no-lockfile</code> | Do not create lockfile in data directory. Use with agent mode only. | `false` |

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -92,6 +92,7 @@ func DefaultOptions() *Options {
 		CompactionDelayMaxPercent:   DefaultCompactionDelayMaxPercent,
 		CompactionDelay:             time.Duration(0),
 		PostingsDecoderFactory:      DefaultPostingsDecoderFactory,
+		IgnoreWALReadingCorruption:  DefaultIgnoreWALReadingCorruption,
 	}
 }
 
@@ -224,6 +225,9 @@ type Options struct {
 	// PostingsDecoderFactory allows users to customize postings decoders based on BlockMeta.
 	// By default, DefaultPostingsDecoderFactory will be used to create raw posting decoder.
 	PostingsDecoderFactory PostingsDecoderFactory
+
+	// IgnoreWALReadingCorruption is a flag to ignore WAL corruption during replay.
+	IgnoreWALReadingCorruption bool
 }
 
 type NewCompactorFunc func(ctx context.Context, r prometheus.Registerer, l *slog.Logger, ranges []int64, pool chunkenc.Pool, opts *Options) (Compactor, error)
@@ -976,6 +980,9 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 	if opts.IsolationDisabled {
 		// We only override this flag if isolation is disabled at DB level. We use the default otherwise.
 		headOpts.IsolationDisabled = opts.IsolationDisabled
+	}
+	if opts.IgnoreWALReadingCorruption {
+		headOpts.IgnoreWALReadingCorruption = opts.IgnoreWALReadingCorruption
 	}
 	db.head, err = NewHead(r, l, wal, wbl, headOpts, stats.Head)
 	if err != nil {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1606,7 +1606,7 @@ func TestSizeRetention(t *testing.T) {
 	// Create a WAL checkpoint, and compare sizes.
 	first, last, err := wlog.Segments(db.Head().wal.Dir())
 	require.NoError(t, err)
-	_, err = wlog.Checkpoint(promslog.NewNopLogger(), db.Head().wal, first, last-1, func(x chunks.HeadSeriesRef) bool { return false }, 0)
+	_, err = wlog.Checkpoint(promslog.NewNopLogger(), db.Head().wal, first, last-1, func(x chunks.HeadSeriesRef) bool { return false }, 0, false)
 	require.NoError(t, err)
 	blockSize = int64(prom_testutil.ToFloat64(db.metrics.blocksBytes)) // Use the actual internal metrics.
 	walSize, err = db.Head().wal.Size()
@@ -4595,7 +4595,7 @@ func TestMetadataCheckpointingOnlyKeepsLatestEntry(t *testing.T) {
 	keep := func(id chunks.HeadSeriesRef) bool {
 		return id != 3
 	}
-	_, err = wlog.Checkpoint(promslog.NewNopLogger(), w, first, last-1, keep, 0)
+	_, err = wlog.Checkpoint(promslog.NewNopLogger(), w, first, last-1, keep, 0, false)
 	require.NoError(t, err)
 
 	// Confirm there's been a checkpoint.

--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -92,7 +92,7 @@ const checkpointPrefix = "checkpoint."
 // segmented format as the original WAL itself.
 // This makes it easy to read it through the WAL package and concatenate
 // it with the original WAL.
-func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.HeadSeriesRef) bool, mint int64) (*CheckpointStats, error) {
+func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.HeadSeriesRef) bool, mint int64, ignoreCorruption bool) (*CheckpointStats, error) {
 	stats := &CheckpointStats{}
 	var sgmReader io.ReadCloser
 
@@ -162,6 +162,9 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 
 		latestMetadataMap = make(map[chunks.HeadSeriesRef]record.RefMetadata)
 	)
+	if ignoreCorruption {
+		r.SetIgnoreCorruption()
+	}
 	for r.Next() {
 		series, samples, histogramSamples, floatHistogramSamples, tstones, exemplars, metadata = series[:0], samples[:0], histogramSamples[:0], floatHistogramSamples[:0], tstones[:0], exemplars[:0], metadata[:0]
 

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -247,7 +247,7 @@ func TestCheckpoint(t *testing.T) {
 
 			stats, err := Checkpoint(promslog.NewNopLogger(), w, 100, 106, func(x chunks.HeadSeriesRef) bool {
 				return x%2 == 0
-			}, last/2)
+			}, last/2, false)
 			require.NoError(t, err)
 			require.NoError(t, w.Truncate(107))
 			require.NoError(t, DeleteCheckpoints(w.Dir(), 106))
@@ -355,7 +355,7 @@ func TestCheckpointNoTmpFolderAfterError(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	// Run the checkpoint and since the wlog contains corrupt data this should return an error.
-	_, err = Checkpoint(promslog.NewNopLogger(), w, 0, 1, nil, 0)
+	_, err = Checkpoint(promslog.NewNopLogger(), w, 0, 1, nil, 0, false)
 	require.Error(t, err)
 
 	// Walk the wlog dir to make sure there are no tmp folder left behind after the error.

--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -375,7 +375,7 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 				}
 			}
 
-			Checkpoint(promslog.NewNopLogger(), w, 0, 1, func(x chunks.HeadSeriesRef) bool { return true }, 0)
+			Checkpoint(promslog.NewNopLogger(), w, 0, 1, func(x chunks.HeadSeriesRef) bool { return true }, 0, false)
 			w.Truncate(1)
 
 			// Write more records after checkpointing.
@@ -466,7 +466,7 @@ func TestReadCheckpoint(t *testing.T) {
 			}
 			_, err = w.NextSegmentSync()
 			require.NoError(t, err)
-			_, err = Checkpoint(promslog.NewNopLogger(), w, 30, 31, func(x chunks.HeadSeriesRef) bool { return true }, 0)
+			_, err = Checkpoint(promslog.NewNopLogger(), w, 30, 31, func(x chunks.HeadSeriesRef) bool { return true }, 0, false)
 			require.NoError(t, err)
 			require.NoError(t, w.Truncate(32))
 
@@ -629,7 +629,7 @@ func TestCheckpointSeriesReset(t *testing.T) {
 				return wt.checkNumSeries() == seriesCount
 			}, 10*time.Second, 1*time.Second)
 
-			_, err = Checkpoint(promslog.NewNopLogger(), w, 2, 4, func(x chunks.HeadSeriesRef) bool { return true }, 0)
+			_, err = Checkpoint(promslog.NewNopLogger(), w, 2, 4, func(x chunks.HeadSeriesRef) bool { return true }, 0, false)
 			require.NoError(t, err)
 
 			err = w.Truncate(5)

--- a/tsdb/wlog/wlog_test.go
+++ b/tsdb/wlog/wlog_test.go
@@ -40,9 +40,10 @@ func TestMain(m *testing.M) {
 // when reading a record.
 func TestWALRepair_ReadingError(t *testing.T) {
 	for name, test := range map[string]struct {
-		corrSgm    int              // Which segment to corrupt.
-		corrFunc   func(f *os.File) // Func that applies the corruption.
-		intactRecs int              // Total expected records left after the repair.
+		corrSgm        int              // Which segment to corrupt.
+		corrFunc       func(f *os.File) // Func that applies the corruption.
+		intactRecs     int              // Total expected records left after the repair.
+		intactRecIndex []int            // Index of the intact record.
 	}{
 		"torn_last_record": {
 			2,
@@ -53,6 +54,7 @@ func TestWALRepair_ReadingError(t *testing.T) {
 				require.NoError(t, err)
 			},
 			8,
+			[]int{0, 1, 2, 3, 4, 5, 6, 7},
 		},
 		// Ensures that the page buffer is big enough to fit
 		// an entire page size without panicking.
@@ -66,6 +68,7 @@ func TestWALRepair_ReadingError(t *testing.T) {
 				require.NoError(t, err)
 			},
 			4,
+			[]int{0, 1, 2, 3},
 		},
 		"bad_fragment_sequence": {
 			1,
@@ -76,6 +79,7 @@ func TestWALRepair_ReadingError(t *testing.T) {
 				require.NoError(t, err)
 			},
 			4,
+			[]int{0, 1, 2, 3},
 		},
 		"bad_fragment_flag": {
 			1,
@@ -86,6 +90,7 @@ func TestWALRepair_ReadingError(t *testing.T) {
 				require.NoError(t, err)
 			},
 			4,
+			[]int{0, 1, 2, 3},
 		},
 		"bad_checksum": {
 			1,
@@ -96,6 +101,7 @@ func TestWALRepair_ReadingError(t *testing.T) {
 				require.NoError(t, err)
 			},
 			4,
+			[]int{0, 1, 2, 3},
 		},
 		"bad_length": {
 			1,
@@ -106,6 +112,7 @@ func TestWALRepair_ReadingError(t *testing.T) {
 				require.NoError(t, err)
 			},
 			4,
+			[]int{0, 1, 2, 3},
 		},
 		"bad_content": {
 			1,
@@ -116,6 +123,29 @@ func TestWALRepair_ReadingError(t *testing.T) {
 				require.NoError(t, err)
 			},
 			4,
+			[]int{0, 1, 2, 3},
+		},
+		"unexpected_middle": {
+			1,
+			func(f *os.File) {
+				_, err := f.Seek(pageSize, 0)
+				require.NoError(t, err)
+				_, err = f.Write([]byte{byte(recMiddle)})
+				require.NoError(t, err)
+			},
+			4,
+			[]int{0, 1, 2, 3},
+		},
+		"unexpected_full_after_first": {
+			1,
+			func(f *os.File) {
+				_, err := f.Seek(pageSize, 0)
+				require.NoError(t, err)
+				_, err = f.Write([]byte{byte(recFirst)})
+				require.NoError(t, err)
+			},
+			4,
+			[]int{0, 1, 2, 3},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -191,15 +221,213 @@ func TestWALRepair_ReadingError(t *testing.T) {
 			}
 			require.NoError(t, r.Err())
 			require.Len(t, result, test.intactRecs, "Wrong number of intact records")
+			require.Len(t, test.intactRecIndex, len(result), "Wrong number of intact records")
 
 			for i, r := range result {
-				require.True(t, bytes.Equal(records[i], r), "record %d diverges: want %x, got %x", i, records[i][:10], r[:10])
+				if !bytes.Equal(records[test.intactRecIndex[i]], r) {
+					t.Fatalf("record %d diverges: want %x, got %x", i, records[i][:10], r[:10])
+				}
 			}
 
 			// Make sure there is a new 0 size Segment after the corrupted Segment.
 			_, last, err = Segments(w.Dir())
 			require.NoError(t, err)
 			require.Equal(t, test.corrSgm+1, last)
+			fi, err := os.Stat(SegmentName(dir, last))
+			require.NoError(t, err)
+			require.Equal(t, int64(0), fi.Size())
+		})
+	}
+}
+
+// TestWALIgnoreCorruption ensures that if ignoreCorruption is set, reading will continue on remain valid records.
+func TestWALIgnoreCorruption(t *testing.T) {
+	for name, test := range map[string]struct {
+		corrSgm        int              // Which segment to corrupt.
+		corrFunc       func(f *os.File) // Func that applies the corruption.
+		intactRecs     int              // Total expected records left after the repair.
+		intactRecIndex []int            // Index of the intact record.
+	}{
+		"bad_fragment_sequence": {
+			1,
+			func(f *os.File) {
+				_, err := f.Seek(pageSize, 0)
+				require.NoError(t, err)
+				_, err = f.Write([]byte{byte(recLast)})
+				require.NoError(t, err)
+			},
+			8,
+			[]int{0, 1, 2, 3, 5, 6, 7, 8},
+		},
+		"bad_fragment_flag": {
+			1,
+			func(f *os.File) {
+				_, err := f.Seek(pageSize, 0)
+				require.NoError(t, err)
+				_, err = f.Write([]byte{123})
+				require.NoError(t, err)
+			},
+			8,
+			[]int{0, 1, 2, 3, 5, 6, 7, 8},
+		},
+		"bad_checksum": {
+			1,
+			func(f *os.File) {
+				_, err := f.Seek(pageSize+4, 0)
+				require.NoError(t, err)
+				_, err = f.Write([]byte{0})
+				require.NoError(t, err)
+			},
+			4,
+			[]int{0, 1, 2, 3},
+		},
+		"bad_length": {
+			1,
+			func(f *os.File) {
+				_, err := f.Seek(pageSize+2, 0)
+				require.NoError(t, err)
+				_, err = f.Write([]byte{0})
+				require.NoError(t, err)
+			},
+			4,
+			[]int{0, 1, 2, 3},
+		},
+		"bad_content": {
+			1,
+			func(f *os.File) {
+				_, err := f.Seek(pageSize+100, 0)
+				require.NoError(t, err)
+				_, err = f.Write([]byte("beef"))
+				require.NoError(t, err)
+			},
+			4,
+			[]int{0, 1, 2, 3},
+		},
+		"unexpected_middle": {
+			1,
+			func(f *os.File) {
+				_, err := f.Seek(pageSize, 0)
+				require.NoError(t, err)
+				_, err = f.Write([]byte{byte(recMiddle)})
+				require.NoError(t, err)
+			},
+			8,
+			[]int{0, 1, 2, 3, 5, 6, 7, 8},
+		},
+		"unexpected_full_after_first": {
+			1,
+			func(f *os.File) {
+				_, err := f.Seek(pageSize, 0)
+				require.NoError(t, err)
+				_, err = f.Write([]byte{byte(recFirst)})
+				require.NoError(t, err)
+			},
+			7,
+			[]int{0, 1, 2, 3, 6, 7, 8},
+		},
+		"multi_corruption_in_one_seg": {
+			1,
+			func(f *os.File) {
+				_, err := f.Seek(0, 0)
+				require.NoError(t, err)
+				_, err = f.Write([]byte{byte(recLast)})
+				require.NoError(t, err)
+
+				_, err = f.Seek(pageSize, 0)
+				require.NoError(t, err)
+				_, err = f.Write([]byte{byte(recMiddle)})
+				require.NoError(t, err)
+			},
+			7,
+			[]int{0, 1, 2, 5, 6, 7, 8},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create 3 segments with 3 records each and
+			// then corrupt given records in a given segment.
+			// As a result we expect a repaired WAL with given intact records.
+			segSize := 3 * pageSize
+			w, err := NewSize(nil, nil, dir, segSize, CompressionNone)
+			require.NoError(t, err)
+
+			var records [][]byte
+
+			for i := 1; i <= 9; i++ {
+				b := make([]byte, pageSize-recordHeaderSize)
+				b[0] = byte(i)
+				records = append(records, b)
+				require.NoError(t, w.Log(b))
+			}
+			first, last, err := Segments(w.Dir())
+			require.NoError(t, err)
+			require.Equal(t, 3, 1+last-first, "wlog creation didn't result in expected number of segments")
+
+			require.NoError(t, w.Close())
+
+			f, err := os.OpenFile(SegmentName(dir, test.corrSgm), os.O_RDWR, 0o666)
+			require.NoError(t, err)
+
+			test.corrFunc(f)
+
+			require.NoError(t, f.Close())
+
+			w, err = NewSize(nil, nil, dir, segSize, CompressionNone)
+			require.NoError(t, err)
+			defer w.Close()
+
+			first, last, err = Segments(w.Dir())
+			require.NoError(t, err)
+
+			for i := first; i <= last; i++ {
+				s, err := OpenReadSegment(SegmentName(w.Dir(), i))
+				require.NoError(t, err)
+
+				sr := NewSegmentBufReader(s)
+				require.NoError(t, err)
+				r := NewReader(sr)
+				r.SetIgnoreCorruption() // Ignore corruption.
+				for r.Next() {
+				}
+
+				// Close the segment so we don't break things on Windows.
+				s.Close()
+
+				// No corruption in this segment.
+				if r.Err() == nil {
+					continue
+				}
+				require.NoError(t, w.Repair(r.Err()))
+				break
+			}
+
+			sr, err := NewSegmentsReader(dir)
+			require.NoError(t, err)
+			defer sr.Close()
+			r := NewReader(sr)
+			r.SetIgnoreCorruption() // Ignore corruption.
+
+			var result [][]byte
+			for r.Next() {
+				var b []byte
+				result = append(result, append(b, r.Record()...))
+			}
+			require.NoError(t, r.Err())
+			require.Len(t, result, test.intactRecs, "Wrong number of intact records")
+			require.Len(t, result, len(test.intactRecIndex), "Wrong number of intact records")
+
+			for i, r := range result {
+				if !bytes.Equal(records[test.intactRecIndex[i]], r) {
+					t.Logf("expected record %d: %x\n", i, records[test.intactRecIndex[i]][:10])
+					t.Logf("record %d: %x\n", i, r[:10])
+					t.Fatalf("record %d diverges: want %x, got %x", i, records[i][:10], r[:10])
+				}
+			}
+
+			// Make sure last is a new 0 size Segment, if there are valid records after the corruption, last may not equal corruptSgm+1.
+			_, last, err = Segments(w.Dir())
+			require.NoError(t, err)
 			fi, err := os.Stat(SegmentName(dir, last))
 			require.NoError(t, err)
 			require.Equal(t, int64(0), fi.Size())


### PR DESCRIPTION
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
Try to fix https://github.com/prometheus/prometheus/issues/13152
If there is an abnormal record in wal, prometheus will fail to truncate wal and abort this truncate job, and number of wals will grow endlessly and never be cleaned, so prometheus will consume disk space on this situation.
In this pr, if we encounter an abnormal record when reading wal, we skip this record an clean buf if any and won't block wal truncation
