### PR TITLE
Scraping: use slices.sort for exemplars

### DIFF
--- a/model/exemplar/exemplar.go
+++ b/model/exemplar/exemplar.go
@@ -48,3 +48,18 @@ func (e Exemplar) Equals(e2 Exemplar) bool {
 
 	return e.Value == e2.Value
 }
+
+// Sort first by timestamp, then value, then labels.
+func Compare(a, b Exemplar) int {
+	if a.Ts < b.Ts {
+		return -1
+	} else if a.Ts > b.Ts {
+		return 1
+	}
+	if a.Value < b.Value {
+		return -1
+	} else if a.Value > b.Value {
+		return 1
+	}
+	return labels.Compare(a.Labels, b.Labels)
+}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"net/http"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1610,17 +1609,8 @@ loop:
 			exemplars = append(exemplars, e)
 			e = exemplar.Exemplar{} // Reset for next time round loop.
 		}
-		sort.Slice(exemplars, func(i, j int) bool {
-			// Sort first by timestamp, then value, then labels so the checking
-			// for duplicates / out of order is more efficient during validation.
-			if exemplars[i].Ts != exemplars[j].Ts {
-				return exemplars[i].Ts < exemplars[j].Ts
-			}
-			if exemplars[i].Value != exemplars[j].Value {
-				return exemplars[i].Value < exemplars[j].Value
-			}
-			return exemplars[i].Labels.Hash() < exemplars[j].Labels.Hash()
-		})
+		// Sort so that checking for duplicates / out of order is more efficient during validation.
+		slices.SortFunc(exemplars, exemplar.Compare)
 		outOfOrderExemplars := 0
 		for _, e := range exemplars {
 			_, exemplarErr := app.AppendExemplar(ref, lset, e)


### PR DESCRIPTION
The sort implementation using Go generics is used everywhere else in Prometheus.

This code was added very recently in #13201.  I took the opportunity to move one of the lengthy parts out to the `exemplars` package, and to just compare labels since `Hash` is unncessary.

