### PR TITLE
Scraping tests: refactor scrapeLoop creation

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -640,22 +640,22 @@ func TestScrapePoolScrapeLoopsStarted(t *testing.T) {
 	}
 }
 
-func TestScrapeLoopStopBeforeRun(t *testing.T) {
-	scraper := &testScraper{}
-
-	sl := newScrapeLoop(context.Background(),
+func newBasicScrapeLoop(t testing.TB, ctx context.Context, scraper scraper, app func(ctx context.Context) storage.Appender, interval time.Duration) *scrapeLoop {
+	return newScrapeLoop(ctx,
 		scraper,
 		nil, nil,
 		nopMutator,
 		nopMutator,
-		nil, nil, 0,
+		app,
+		nil,
+		0,
 		true,
 		false,
 		true,
 		0, 0,
 		nil,
-		1,
-		0,
+		interval,
+		time.Hour,
 		false,
 		false,
 		false,
@@ -663,6 +663,11 @@ func TestScrapeLoopStopBeforeRun(t *testing.T) {
 		false,
 		newTestScrapeMetrics(t),
 	)
+}
+
+func TestScrapeLoopStopBeforeRun(t *testing.T) {
+	scraper := &testScraper{}
+	sl := newBasicScrapeLoop(t, context.Background(), scraper, nil, 1)
 
 	// The scrape pool synchronizes on stopping scrape loops. However, new scrape
 	// loops are started asynchronously. Thus it's possible, that a loop is stopped
@@ -717,28 +722,7 @@ func TestScrapeLoopStop(t *testing.T) {
 		app      = func(ctx context.Context) storage.Appender { return appender }
 	)
 
-	sl := newScrapeLoop(context.Background(),
-		scraper,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		app,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		10*time.Millisecond,
-		time.Hour,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), scraper, app, 10*time.Millisecond)
 
 	// Terminate loop after 2 scrapes.
 	numScrapes := 0
@@ -857,28 +841,8 @@ func TestScrapeLoopRun(t *testing.T) {
 	}
 
 	ctx, cancel = context.WithCancel(context.Background())
-	sl = newScrapeLoop(ctx,
-		scraper,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		app,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		time.Second,
-		100*time.Millisecond,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		scrapeMetrics,
-	)
+	sl = newBasicScrapeLoop(t, ctx, scraper, app, time.Second)
+	sl.timeout = 100 * time.Millisecond
 
 	go func() {
 		sl.run(errc)
@@ -920,28 +884,7 @@ func TestScrapeLoopForcedErr(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		scraper,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		app,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		time.Second,
-		time.Hour,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, scraper, app, time.Second)
 
 	forcedErr := fmt.Errorf("forced err")
 	sl.setForcedError(forcedErr)
@@ -1044,28 +987,7 @@ func simpleTestScrapeLoop(t testing.TB) (context.Context, *scrapeLoop) {
 	t.Cleanup(func() { s.Close() })
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		&testScraper{},
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		s.Appender,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, &testScraper{}, s.Appender, 0)
 	t.Cleanup(func() { cancel() })
 
 	return ctx, sl
@@ -1106,30 +1028,10 @@ func TestScrapeLoopFailWithInvalidLabelsAfterRelabel(t *testing.T) {
 		Separator:   ";",
 		Replacement: "$1",
 	}}
-	sl := newScrapeLoop(ctx,
-		&testScraper{},
-		nil, nil,
-		func(l labels.Labels) labels.Labels {
-			return mutateSampleLabels(l, target, true, relabelConfig)
-		},
-		nopMutator,
-		s.Appender,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, &testScraper{}, s.Appender, 0)
+	sl.sampleMutator = func(l labels.Labels) labels.Labels {
+		return mutateSampleLabels(l, target, true, relabelConfig)
+	}
 
 	slApp := sl.appender(ctx)
 	total, added, seriesAdded, err := sl.append(slApp, []byte("test_metric 1\n"), "", time.Time{})
@@ -1190,28 +1092,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrape(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		scraper,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		app,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		10*time.Millisecond,
-		time.Hour,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, scraper, app, 10*time.Millisecond)
 	// Succeed once, several failures, then stop.
 	numScrapes := 0
 
@@ -1257,28 +1138,7 @@ func TestScrapeLoopRunCreatesStaleMarkersOnParseFailure(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		scraper,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		app,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		10*time.Millisecond,
-		time.Hour,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, scraper, app, 10*time.Millisecond)
 
 	// Succeed once, several failures, then stop.
 	scraper.scrapeFunc = func(ctx context.Context, w io.Writer) error {
@@ -1327,28 +1187,7 @@ func TestScrapeLoopCache(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		scraper,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		app,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		10*time.Millisecond,
-		time.Hour,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, scraper, app, 10*time.Millisecond)
 
 	numScrapes := 0
 
@@ -1414,28 +1253,7 @@ func TestScrapeLoopCacheMemoryExhaustionProtection(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		scraper,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		app,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		10*time.Millisecond,
-		time.Hour,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, scraper, app, 10*time.Millisecond)
 
 	numScrapes := 0
 
@@ -1529,31 +1347,13 @@ func TestScrapeLoopAppend(t *testing.T) {
 			labels: labels.FromStrings(test.discoveryLabels...),
 		}
 
-		sl := newScrapeLoop(context.Background(),
-			nil, nil, nil,
-			func(l labels.Labels) labels.Labels {
-				return mutateSampleLabels(l, discoveryLabels, test.honorLabels, nil)
-			},
-			func(l labels.Labels) labels.Labels {
-				return mutateReportSampleLabels(l, discoveryLabels)
-			},
-			func(ctx context.Context) storage.Appender { return app },
-			nil,
-			0,
-			true,
-			false,
-			true,
-			0, 0,
-			nil,
-			0,
-			0,
-			false,
-			false,
-			false,
-			nil,
-			false,
-			newTestScrapeMetrics(t),
-		)
+		sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
+		sl.sampleMutator = func(l labels.Labels) labels.Labels {
+			return mutateSampleLabels(l, discoveryLabels, test.honorLabels, nil)
+		}
+		sl.reportSampleMutator = func(l labels.Labels) labels.Labels {
+			return mutateReportSampleLabels(l, discoveryLabels)
+		}
 
 		now := time.Now()
 
@@ -1635,14 +1435,10 @@ func TestScrapeLoopAppendForConflictingPrefixedLabels(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			app := &collectResultAppender{}
-			sl := newScrapeLoop(context.Background(), nil, nil, nil,
-				func(l labels.Labels) labels.Labels {
-					return mutateSampleLabels(l, &Target{labels: labels.FromStrings(tc.targetLabels...)}, false, nil)
-				},
-				nil,
-				func(ctx context.Context) storage.Appender { return app },
-				nil, 0, true, false, true, 0, 0, nil, 0, 0, false, false, false, nil, false, newTestScrapeMetrics(t),
-			)
+			sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
+			sl.sampleMutator = func(l labels.Labels) labels.Labels {
+				return mutateSampleLabels(l, &Target{labels: labels.FromStrings(tc.targetLabels...)}, false, nil)
+			}
 			slApp := sl.appender(context.Background())
 			_, _, _, err := sl.append(slApp, []byte(tc.exposedLabels), "", time.Date(2000, 1, 1, 1, 0, 0, 0, time.UTC))
 			require.NoError(t, err)
@@ -1663,28 +1459,7 @@ func TestScrapeLoopAppendForConflictingPrefixedLabels(t *testing.T) {
 func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 	// collectResultAppender's AddFast always returns ErrNotFound if we don't give it a next.
 	app := &collectResultAppender{}
-
-	sl := newScrapeLoop(context.Background(),
-		nil, nil, nil,
-		nopMutator,
-		nopMutator,
-		func(ctx context.Context) storage.Appender { return app },
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
 
 	fakeRef := storage.SeriesRef(1)
 	expValue := float64(1)
@@ -1721,32 +1496,14 @@ func TestScrapeLoopAppendSampleLimit(t *testing.T) {
 	resApp := &collectResultAppender{}
 	app := &limitAppender{Appender: resApp, limit: 1}
 
-	sl := newScrapeLoop(context.Background(),
-		nil, nil, nil,
-		func(l labels.Labels) labels.Labels {
-			if l.Has("deleteme") {
-				return labels.EmptyLabels()
-			}
-			return l
-		},
-		nopMutator,
-		func(ctx context.Context) storage.Appender { return app },
-		nil,
-		0,
-		true,
-		false,
-		true,
-		app.limit, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
+	sl.sampleMutator = func(l labels.Labels) labels.Labels {
+		if l.Has("deleteme") {
+			return labels.EmptyLabels()
+		}
+		return l
+	}
+	sl.sampleLimit = app.limit
 
 	// Get the value of the Counter before performing the append.
 	beforeMetric := dto.Metric{}
@@ -1802,32 +1559,14 @@ func TestScrapeLoop_HistogramBucketLimit(t *testing.T) {
 	resApp := &collectResultAppender{}
 	app := &bucketLimitAppender{Appender: resApp, limit: 2}
 
-	sl := newScrapeLoop(context.Background(),
-		nil, nil, nil,
-		func(l labels.Labels) labels.Labels {
-			if l.Has("deleteme") {
-				return labels.EmptyLabels()
-			}
-			return l
-		},
-		nopMutator,
-		func(ctx context.Context) storage.Appender { return app },
-		nil,
-		0,
-		true,
-		false,
-		true,
-		app.limit, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
+	sl.sampleMutator = func(l labels.Labels) labels.Labels {
+		if l.Has("deleteme") {
+			return labels.EmptyLabels()
+		}
+		return l
+	}
+	sl.sampleLimit = app.limit
 
 	metric := dto.Metric{}
 	err := sl.metrics.targetScrapeNativeHistogramBucketLimit.Write(&metric)
@@ -1908,28 +1647,7 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 	defer s.Close()
 
 	capp := &collectResultAppender{}
-
-	sl := newScrapeLoop(context.Background(),
-		nil, nil, nil,
-		nopMutator,
-		nopMutator,
-		func(ctx context.Context) storage.Appender { capp.next = s.Appender(ctx); return capp },
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return capp }, 0)
 
 	now := time.Now()
 	slApp := sl.appender(context.Background())
@@ -1961,27 +1679,7 @@ func TestScrapeLoop_ChangingMetricString(t *testing.T) {
 func TestScrapeLoopAppendStaleness(t *testing.T) {
 	app := &collectResultAppender{}
 
-	sl := newScrapeLoop(context.Background(),
-		nil, nil, nil,
-		nopMutator,
-		nopMutator,
-		func(ctx context.Context) storage.Appender { return app },
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
 
 	now := time.Now()
 	slApp := sl.appender(context.Background())
@@ -2016,28 +1714,7 @@ func TestScrapeLoopAppendStaleness(t *testing.T) {
 
 func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 	app := &collectResultAppender{}
-	sl := newScrapeLoop(context.Background(),
-		nil, nil, nil,
-		nopMutator,
-		nopMutator,
-		func(ctx context.Context) storage.Appender { return app },
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
-
+	sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
 	now := time.Now()
 	slApp := sl.appender(context.Background())
 	_, _, _, err := sl.append(slApp, []byte("metric_a 1 1000\n"), "", now)
@@ -2061,27 +1738,8 @@ func TestScrapeLoopAppendNoStalenessIfTimestamp(t *testing.T) {
 
 func TestScrapeLoopAppendStalenessIfTrackTimestampStaleness(t *testing.T) {
 	app := &collectResultAppender{}
-	sl := newScrapeLoop(context.Background(),
-		nil, nil, nil,
-		nopMutator,
-		nopMutator,
-		func(ctx context.Context) storage.Appender { return app },
-		nil,
-		0,
-		true,
-		true,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
+	sl.trackTimestampsStaleness = true
 
 	now := time.Now()
 	slApp := sl.appender(context.Background())
@@ -2430,31 +2088,14 @@ metric: <
 				labels: labels.FromStrings(test.discoveryLabels...),
 			}
 
-			sl := newScrapeLoop(context.Background(),
-				nil, nil, nil,
-				func(l labels.Labels) labels.Labels {
-					return mutateSampleLabels(l, discoveryLabels, false, nil)
-				},
-				func(l labels.Labels) labels.Labels {
-					return mutateReportSampleLabels(l, discoveryLabels)
-				},
-				func(ctx context.Context) storage.Appender { return app },
-				nil,
-				0,
-				true,
-				false,
-				true,
-				0, 0,
-				nil,
-				0,
-				0,
-				test.scrapeClassicHistograms,
-				false,
-				false,
-				nil,
-				false,
-				newTestScrapeMetrics(t),
-			)
+			sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
+			sl.sampleMutator = func(l labels.Labels) labels.Labels {
+				return mutateSampleLabels(l, discoveryLabels, false, nil)
+			}
+			sl.reportSampleMutator = func(l labels.Labels) labels.Labels {
+				return mutateReportSampleLabels(l, discoveryLabels)
+			}
+			sl.scrapeClassicHistograms = test.scrapeClassicHistograms
 
 			now := time.Now()
 
@@ -2521,31 +2162,13 @@ func TestScrapeLoopAppendExemplarSeries(t *testing.T) {
 
 	app := &collectResultAppender{}
 
-	sl := newScrapeLoop(context.Background(),
-		nil, nil, nil,
-		func(l labels.Labels) labels.Labels {
-			return mutateSampleLabels(l, discoveryLabels, false, nil)
-		},
-		func(l labels.Labels) labels.Labels {
-			return mutateReportSampleLabels(l, discoveryLabels)
-		},
-		func(ctx context.Context) storage.Appender { return app },
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
+	sl.sampleMutator = func(l labels.Labels) labels.Labels {
+		return mutateSampleLabels(l, discoveryLabels, false, nil)
+	}
+	sl.reportSampleMutator = func(l labels.Labels) labels.Labels {
+		return mutateReportSampleLabels(l, discoveryLabels)
+	}
 
 	now := time.Now()
 
@@ -2580,28 +2203,7 @@ func TestScrapeLoopRunReportsTargetDownOnScrapeError(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		scraper,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		app,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		10*time.Millisecond,
-		time.Hour,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, scraper, app, 10*time.Millisecond)
 
 	scraper.scrapeFunc = func(ctx context.Context, w io.Writer) error {
 		cancel()
@@ -2620,28 +2222,7 @@ func TestScrapeLoopRunReportsTargetDownOnInvalidUTF8(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		scraper,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		app,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		10*time.Millisecond,
-		time.Hour,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, scraper, app, 10*time.Millisecond)
 
 	scraper.scrapeFunc = func(ctx context.Context, w io.Writer) error {
 		cancel()
@@ -2672,29 +2253,7 @@ func (app *errorAppender) Append(ref storage.SeriesRef, lset labels.Labels, t in
 
 func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T) {
 	app := &errorAppender{}
-
-	sl := newScrapeLoop(context.Background(),
-		nil,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		func(ctx context.Context) storage.Appender { return app },
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
 
 	now := time.Unix(1, 0)
 	slApp := sl.appender(context.Background())
@@ -2717,32 +2276,14 @@ func TestScrapeLoopAppendGracefullyIfAmendOrOutOfOrderOrOutOfBounds(t *testing.T
 
 func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
 	app := &collectResultAppender{}
-	sl := newScrapeLoop(context.Background(),
-		nil,
-		nil, nil,
-		nopMutator,
-		nopMutator,
+	sl := newBasicScrapeLoop(t, context.Background(), nil,
 		func(ctx context.Context) storage.Appender {
 			return &timeLimitAppender{
 				Appender: app,
 				maxTime:  timestamp.FromTime(time.Now().Add(10 * time.Minute)),
 			}
 		},
-		nil,
 		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
 	)
 
 	now := time.Now().Add(20 * time.Minute)
@@ -3014,29 +2555,8 @@ func TestScrapeLoop_RespectTimestamps(t *testing.T) {
 	defer s.Close()
 
 	app := s.Appender(context.Background())
-
 	capp := &collectResultAppender{next: app}
-
-	sl := newScrapeLoop(context.Background(),
-		nil, nil, nil,
-		nopMutator,
-		nopMutator,
-		func(ctx context.Context) storage.Appender { return capp },
-		nil, 0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return capp }, 0)
 
 	now := time.Now()
 	slApp := sl.appender(context.Background())
@@ -3062,26 +2582,8 @@ func TestScrapeLoop_DiscardTimestamps(t *testing.T) {
 
 	capp := &collectResultAppender{next: app}
 
-	sl := newScrapeLoop(context.Background(),
-		nil, nil, nil,
-		nopMutator,
-		nopMutator,
-		func(ctx context.Context) storage.Appender { return capp },
-		nil, 0,
-		false,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return capp }, 0)
+	sl.honorTimestamps = false
 
 	now := time.Now()
 	slApp := sl.appender(context.Background())
@@ -3104,28 +2606,7 @@ func TestScrapeLoopDiscardDuplicateLabels(t *testing.T) {
 	defer s.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		&testScraper{},
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		s.Appender,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, &testScraper{}, s.Appender, 0)
 	defer cancel()
 
 	// We add a good and a bad metric to check that both are discarded.
@@ -3161,33 +2642,13 @@ func TestScrapeLoopDiscardUnnamedMetrics(t *testing.T) {
 	app := s.Appender(context.Background())
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(context.Background(),
-		&testScraper{},
-		nil, nil,
-		func(l labels.Labels) labels.Labels {
-			if l.Has("drop") {
-				return labels.FromStrings("no", "name") // This label set will trigger an error.
-			}
-			return l
-		},
-		nopMutator,
-		func(ctx context.Context) storage.Appender { return app },
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, context.Background(), &testScraper{}, func(ctx context.Context) storage.Appender { return app }, 0)
+	sl.sampleMutator = func(l labels.Labels) labels.Labels {
+		if l.Has("drop") {
+			return labels.FromStrings("no", "name") // This label set will trigger an error.
+		}
+		return l
+	}
 	defer cancel()
 
 	slApp := sl.appender(context.Background())
@@ -3433,28 +2894,7 @@ func TestScrapeAddFast(t *testing.T) {
 	defer s.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		&testScraper{},
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		s.Appender,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		0,
-		0,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, &testScraper{}, s.Appender, 0)
 	defer cancel()
 
 	slApp := sl.appender(ctx)
@@ -3523,28 +2963,7 @@ func TestScrapeReportSingleAppender(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		scraper,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		s.Appender,
-		nil,
-		0,
-		true,
-		false,
-		true,
-		0, 0,
-		nil,
-		10*time.Millisecond,
-		time.Hour,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, scraper, s.Appender, 10*time.Millisecond)
 
 	numScrapes := 0
 
@@ -3726,31 +3145,14 @@ func TestScrapeLoopLabelLimit(t *testing.T) {
 			labels: labels.FromStrings(test.discoveryLabels...),
 		}
 
-		sl := newScrapeLoop(context.Background(),
-			nil, nil, nil,
-			func(l labels.Labels) labels.Labels {
-				return mutateSampleLabels(l, discoveryLabels, false, nil)
-			},
-			func(l labels.Labels) labels.Labels {
-				return mutateReportSampleLabels(l, discoveryLabels)
-			},
-			func(ctx context.Context) storage.Appender { return app },
-			nil,
-			0,
-			true,
-			false,
-			true,
-			0, 0,
-			&test.labelLimits,
-			0,
-			0,
-			false,
-			false,
-			false,
-			nil,
-			false,
-			newTestScrapeMetrics(t),
-		)
+		sl := newBasicScrapeLoop(t, context.Background(), nil, func(ctx context.Context) storage.Appender { return app }, 0)
+		sl.sampleMutator = func(l labels.Labels) labels.Labels {
+			return mutateSampleLabels(l, discoveryLabels, false, nil)
+		}
+		sl.reportSampleMutator = func(l labels.Labels) labels.Labels {
+			return mutateReportSampleLabels(l, discoveryLabels)
+		}
+		sl.labelLimits = &test.labelLimits
 
 		slApp := sl.appender(context.Background())
 		_, _, _, err := sl.append(slApp, []byte(test.scrapeLabels), "", time.Now())
@@ -3936,28 +3338,8 @@ func TestScrapeLoopRunCreatesStaleMarkersOnFailedScrapeForTimestampedMetrics(t *
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	sl := newScrapeLoop(ctx,
-		scraper,
-		nil, nil,
-		nopMutator,
-		nopMutator,
-		app,
-		nil,
-		0,
-		true,
-		true,
-		true,
-		0, 0,
-		nil,
-		10*time.Millisecond,
-		time.Hour,
-		false,
-		false,
-		false,
-		nil,
-		false,
-		newTestScrapeMetrics(t),
-	)
+	sl := newBasicScrapeLoop(t, ctx, scraper, app, 10*time.Millisecond)
+	sl.trackTimestampsStaleness = true
 	// Succeed once, several failures, then stop.
 	numScrapes := 0
 


### PR DESCRIPTION
Pull boilerplate code into a function. Where appropriate we set some config on the returned object.
This removes 600 lines of repetitive code, and makes it easier to make further changes to scrapeLoop.

This was originally part of #12993.

