### PR TITLE
Explicit schema check in [Float]Histogram.ReduceResolution

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -1110,6 +1110,10 @@ func floatBucketsMatch(b1, b2 []float64) bool {
 // ReduceResolution reduces the float histogram's spans, buckets into target schema.
 // The target schema must be smaller than the current float histogram's schema.
 func (h *FloatHistogram) ReduceResolution(targetSchema int32) *FloatHistogram {
+	if targetSchema >= h.Schema {
+		panic(fmt.Errorf("cannot reduce resolution from schema %d to %d", h.Schema, targetSchema))
+	}
+
 	h.PositiveSpans, h.PositiveBuckets = reduceResolution(h.PositiveSpans, h.PositiveBuckets, h.Schema, targetSchema, false)
 	h.NegativeSpans, h.NegativeBuckets = reduceResolution(h.NegativeSpans, h.NegativeBuckets, h.Schema, targetSchema, false)
 	h.Schema = targetSchema

--- a/model/histogram/histogram.go
+++ b/model/histogram/histogram.go
@@ -497,6 +497,10 @@ func (c *cumulativeBucketIterator) At() Bucket[uint64] {
 // ReduceResolution reduces the histogram's spans, buckets into target schema.
 // The target schema must be smaller than the current histogram's schema.
 func (h *Histogram) ReduceResolution(targetSchema int32) *Histogram {
+	if targetSchema >= h.Schema {
+		panic(fmt.Errorf("cannot reduce resolution from schema %d to %d", h.Schema, targetSchema))
+	}
+
 	h.PositiveSpans, h.PositiveBuckets = reduceResolution(
 		h.PositiveSpans, h.PositiveBuckets, h.Schema, targetSchema, true,
 	)


### PR DESCRIPTION
`[Float]Histogram.ReduceResolution` methods have this requirement on their inputs:
```
// The target schema must be smaller than the current float histogram's schema.
```
but it was not enforced explicitly, resulting in low level panic in case of non-complying input:
```
	panic: runtime error: negative shift amount

github.com/prometheus/prometheus/model/histogram.targetIdx(...)
/prometheus/model/histogram/float_histogram.go:965
github.com/prometheus/prometheus/model/histogram.reduceResolution[...]({0x140000ae168, 0x3, 0x14000056e48}, {0x140000bc1b0?, 0x6, 0x14000056de8}, 0x0?, 0x1, 0x0)
/prometheus/model/histogram/generic.go:625 +0x738
github.com/prometheus/prometheus/model/histogram.(*FloatHistogram).ReduceResolution(0x14000118000, 0x1)
/prometheus/model/histogram/float_histogram.go:1113 +0x54
github.com/prometheus/prometheus/model/histogram.TestFloatHistogramReduceResolution(0x0?)
/prometheus/model/histogram/float_histogram_test.go:2484 +0x3ec
```
This PR adds an explicit check so that a higher level panic is now being thrown instead:
```
panic: cannot reduce resolution from schema 1 to 2
```

Note that `FloatHistogram.Add/Sub` also have similar requirements, which used to be enforced indirectly via `FloatHistogram.floatBucketIterator`:
https://github.com/prometheus/prometheus/blob/965e603fa792bca0900ac76eb45ae84c81af1cdf/model/histogram/float_histogram.go#L738-L740
but then those checks got lost with [this change](https://github.com/prometheus/prometheus/pull/12711/files).

`Add` and `Sub` will now always check for a valid schema change via their use of `ReduceResolution`.

Also note that there are more issues with `Add` and `Sub`, I am planning to address them in separate PR(s) soon.
