### PR TITLE
Improvements to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,8 @@
 <!--
+    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"
+
+    If your PR is to fix an issue, put "Fixes #issue-number" in the description.
+
     Don't forget!
 
     - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.
@@ -6,8 +10,6 @@
     - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
 
     - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
-
-    - No tests are needed for internal implementation changes.
 
     - Performance improvements would need a benchmark test to prove it.
 


### PR DESCRIPTION
I like a bit more of a hint what the PR is supposed to achieve.

Also, I took out a suggestion not to write tests.  We can decide case-by-case if it's ok not to add a test; no need to encourage it.

BTW I like the description of good commit messages here: https://go.dev/doc/contribute#first_line, but didn't want to put all that in the template.