### PR TITLE
FloatHistogram.Add/Sub: handle any schema change

### DIFF
--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -1242,7 +1242,7 @@ func TestFloatHistogramAdd(t *testing.T) {
 				Sum:             1.234,
 				PositiveSpans:   []Span{{0, 2}, {3, 3}},
 				PositiveBuckets: []float64{5, 4, 2, 3, 6},
-				NegativeSpans:   []Span{{-9, 2}, {3, 2}},
+				NegativeSpans:   []Span{{-6, 2}, {1, 2}},
 				NegativeBuckets: []float64{1, 1, 4, 4},
 			},
 			&FloatHistogram{
@@ -1262,7 +1262,7 @@ func TestFloatHistogramAdd(t *testing.T) {
 				Sum:             3.579,
 				PositiveSpans:   []Span{{-2, 2}, {0, 5}, {0, 3}},
 				PositiveBuckets: []float64{1, 0, 5, 4, 3, 4, 7, 2, 3, 6},
-				NegativeSpans:   []Span{{-9, 2}, {3, 2}, {5, 2}, {3, 2}},
+				NegativeSpans:   []Span{{-6, 2}, {1, 2}, {4, 2}, {3, 2}},
 				NegativeBuckets: []float64{1, 1, 4, 4, 3, 1, 5, 6},
 			},
 		},
@@ -1573,14 +1573,31 @@ func TestFloatHistogramAdd(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			in2Copy := c.in2.Copy()
-			require.Equal(t, c.expected, c.in1.Add(c.in2))
-			// Has it also happened in-place?
-			require.Equal(t, c.expected, c.in1)
-			// Check that the argument was not mutated.
-			require.Equal(t, in2Copy, c.in2)
+			testHistogramAdd(t, c.in1, c.in2, c.expected)
+			testHistogramAdd(t, c.in2, c.in1, c.expected)
 		})
 	}
+}
+
+func testHistogramAdd(t *testing.T, a, b, expected *FloatHistogram) {
+	var (
+		aCopy        = a.Copy()
+		bCopy        = b.Copy()
+		expectedCopy = expected.Copy()
+	)
+
+	res := aCopy.Add(bCopy)
+
+	res.Compact(0)
+	expectedCopy.Compact(0)
+
+	require.Equal(t, expectedCopy, res)
+
+	// Has it also happened in-place?
+	require.Equal(t, expectedCopy, aCopy)
+
+	// Check that the argument was not mutated.
+	require.Equal(t, b, bCopy)
 }
 
 func TestFloatHistogramSub(t *testing.T) {
@@ -1662,14 +1679,33 @@ func TestFloatHistogramSub(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			in2Copy := c.in2.Copy()
-			require.Equal(t, c.expected, c.in1.Sub(c.in2))
-			// Has it also happened in-place?
-			require.Equal(t, c.expected, c.in1)
-			// Check that the argument was not mutated.
-			require.Equal(t, in2Copy, c.in2)
+			testFloatHistogramSub(t, c.in1, c.in2, c.expected)
+
+			expectedNegative := c.expected.Copy().Mul(-1)
+			testFloatHistogramSub(t, c.in2, c.in1, expectedNegative)
 		})
 	}
+}
+
+func testFloatHistogramSub(t *testing.T, a, b, expected *FloatHistogram) {
+	var (
+		aCopy        = a.Copy()
+		bCopy        = b.Copy()
+		expectedCopy = expected.Copy()
+	)
+
+	res := aCopy.Sub(bCopy)
+
+	res.Compact(0)
+	expectedCopy.Compact(0)
+
+	require.Equal(t, expectedCopy, res)
+
+	// Has it also happened in-place?
+	require.Equal(t, expectedCopy, aCopy)
+
+	// Check that the argument was not mutated.
+	require.Equal(t, b, bCopy)
 }
 
 func TestFloatHistogramCopyToSchema(t *testing.T) {


### PR DESCRIPTION
Previously, `FloatHistogram.Add`/`Sub` would panic if `other` argument was a histogram with lower resolution than receiver. With this change, histograms with any schema can be added/subtracted, by reducing the resolution of receiving histogram to match the `other` argument if needed.

Couldn't think of any downsides/cases when this would be wrong. Chances are I am missing something. But, assuming we can land this change, there will be some nice ripple effects all over the query engine, simplifying histogram function code and removing additional operations/copies (but that's a separate PR), for example here:
https://github.com/prometheus/prometheus/blob/97f9ad9d317f1e227359d31de11f87fbc849e3f5/promql/functions.go#L535-L543

I have modified the existing unit tests to exercise both `Add` and `Sub` symmetrically, i.e.:
```
a + b = expected; b + a = expected
a - b = expected; b - a = -expected
```