### PR TITLE
Fix chunks iterator bug when tombstone covers a whole chunk

### DIFF
--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3663,5 +3663,4 @@ func TestQueryWithOneChunkCompletelyDeleted(t *testing.T) {
 	}
 	require.NoError(t, css.Err())
 	require.Equal(t, 1, seriesCount)
-
 }

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3587,3 +3587,81 @@ func TestQueryWithDeletedHistograms(t *testing.T) {
 		})
 	}
 }
+
+func TestQueryWithOneChunkCompletelyDeleted(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t, nil, nil)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	db.EnableNativeHistograms()
+	appender := db.Appender(context.Background())
+
+	var (
+		err       error
+		seriesRef storage.SeriesRef
+	)
+	lbs := labels.FromStrings("__name__", "test")
+
+	// Create an int histogram chunk with samples between 0 - 20 and 30 - 40.
+	for i := 0; i < 20; i++ {
+		h := tsdbutil.GenerateTestHistogram(1)
+		seriesRef, err = appender.AppendHistogram(seriesRef, lbs, int64(i), h, nil)
+		require.NoError(t, err)
+	}
+	for i := 30; i < 40; i++ {
+		h := tsdbutil.GenerateTestHistogram(1)
+		seriesRef, err = appender.AppendHistogram(seriesRef, lbs, int64(i), h, nil)
+		require.NoError(t, err)
+	}
+
+	// Append some float histograms - float histograms are a different encoding
+	// type from int histograms so a new chunk is created.
+	for i := 60; i < 100; i++ {
+		fh := tsdbutil.GenerateTestFloatHistogram(1)
+		seriesRef, err = appender.AppendHistogram(seriesRef, lbs, int64(i), nil, fh)
+		require.NoError(t, err)
+	}
+
+	err = appender.Commit()
+	require.NoError(t, err)
+
+	matcher, err := labels.NewMatcher(labels.MatchEqual, "__name__", "test")
+	require.NoError(t, err)
+
+	// Delete all samples from the int histogram chunk. The deletion intervals
+	// doesn't cover the entire histogram chunk, but does cover all the samples
+	// in the chunk. This case was previously not handled properly.
+	err = db.Delete(ctx, 0, 20, matcher)
+	require.NoError(t, err)
+	err = db.Delete(ctx, 30, 40, matcher)
+	require.NoError(t, err)
+
+	chunkQuerier, err := db.ChunkQuerier(0, 100)
+	require.NoError(t, err)
+
+	css := chunkQuerier.Select(context.Background(), false, nil, matcher)
+
+	seriesCount := 0
+	for css.Next() {
+		seriesCount++
+		series := css.At()
+
+		sampleCount := 0
+		it := series.Iterator(nil)
+		for it.Next() {
+			chk := it.At()
+			cit := chk.Chunk.Iterator(nil)
+			for vt := cit.Next(); vt != chunkenc.ValNone; vt = cit.Next() {
+				require.Equal(t, vt, chunkenc.ValFloatHistogram, "Only float histograms expected, other sample types should have been deleted.")
+				sampleCount++
+			}
+		}
+		require.NoError(t, it.Err())
+		require.Equal(t, 40, sampleCount)
+	}
+	require.NoError(t, css.Err())
+	require.Equal(t, 1, seriesCount)
+
+}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -1038,6 +1038,24 @@ func TestPopulateWithTombSeriesIterators(t *testing.T) {
 			},
 			expectedMinMaxTimes: []minMaxTimes{{1, 3}, {9, 9}},
 		},
+		{
+			name: "two chunks with first chunk deleted",
+			samples: [][]chunks.Sample{
+				{sample{1, 2, nil, nil}, sample{2, 3, nil, nil}, sample{3, 5, nil, nil}, sample{6, 1, nil, nil}},
+				{sample{7, 89, nil, nil}, sample{9, 8, nil, nil}},
+			},
+			intervals: tombstones.Intervals{{Mint: 1, Maxt: 6}},
+
+			expected: []chunks.Sample{
+				sample{7, 89, nil, nil}, sample{9, 8, nil, nil},
+			},
+			expectedChks: []chunks.Meta{
+				assureChunkFromSamples(t, []chunks.Sample{
+					sample{7, 89, nil, nil}, sample{9, 8, nil, nil},
+				}),
+			},
+			expectedMinMaxTimes: []minMaxTimes{{7, 9}},
+		},
 		// Deletion with seek.
 		{
 			name: "two chunks with trimmed first and last samples from edge chunks, seek from middle of first chunk",


### PR DESCRIPTION
As mentioned in https://github.com/prometheus/prometheus/pull/13123#issuecomment-1825952514, there is a bug with the populateWithDelChunkSeriesIterator. If currDelIter doesn't return any samples for a meta, then we don't read the samples from the remaining metas for the series iterator. Fixing this by continuously looping over the metas if the current one doesn't generate any chunks.

Tests are added in https://github.com/prometheus/prometheus/commit/b2c8111ac35b1f2985dc75db0cc9797272c09135 (you can checkout this commit and see it fail because no chunks are returned), and fix is done in https://github.com/prometheus/prometheus/commit/f67e5a3499ce0d85b6c77966dcde65615e42dfaf. https://github.com/prometheus/prometheus/commit/16f561cf8efd46327d333b79732780fbcaf8a90c adds a test case that could actually happen in practice - when all samples in a chunk are deleted, but the tombstones don't cover the entire chunk range.
