### PR TITLE
Execute compact if head num series is greater than 0 after one chunk …

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1605,8 +1605,9 @@ func (h *Head) MaxOOOTime() int64 {
 // compactable returns whether the head has a compactable range.
 // The head has a compactable range when the head time range is 1.5 times the chunk range.
 // The 0.5 acts as a buffer of the appendable window.
+// The head is also compactable when the head is not empty and the max time is older than the chunk range.
 func (h *Head) compactable() bool {
-	return h.MaxTime()-h.MinTime() > h.chunkRange.Load()/2*3
+	return h.MaxTime()-h.MinTime() > h.chunkRange.Load()/2*3 || (h.MaxTime() < time.Now().UnixMilli()-h.chunkRange.Load() && h.numSeries.Load() > 0)
 }
 
 // Close flushes the WAL and closes the head.


### PR DESCRIPTION
avoid compact not firing due to maxTime and minTime equality after stopping writing


This is how I stopped using thanos,prometheus, and started using mimir. 

When I stopped prometheus for one month, I observed that the prometheus memory usage was still very high. Through monitoring, I saw that the reason was that there was no timed trigger compaction, so the memory kept the data for the first two hours of stopping writing. Is this not in line with expectations? In some scenarios, such as thanos sidecar, tsdb blocks to s3 will be transmitted every two hours to de-emphasize historical data...