### PR TITLE
azure_sd: fix missing public IP addresses

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
@@ -638,7 +639,7 @@ func (client *azureClient) getNetworkInterfaceByID(ctx context.Context, networkI
 		return nil, fmt.Errorf("could not parse network interface ID: %w", err)
 	}
 
-	resp, err := client.nic.Get(ctx, r.ResourceGroupName, r.Name, nil)
+	resp, err := client.nic.Get(ctx, r.ResourceGroupName, r.Name, &armnetwork.InterfacesClientGetOptions{Expand: to.Ptr("IPConfigurations/PublicIPAddress")})
 	if err != nil {
 		var responseError *azcore.ResponseError
 		if errors.As(err, &responseError) && responseError.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
Fixes #5588, #9293

# How I fixed this

This issue is not caused by any Azure SDK bugs. It is by design that the Azure get network interface API does not automatically resolve its child resources. There are two potential solutions to address this problem.

1. Retrieve all public IP address resources and programmatically match them up with each virtual machines. This approach generate a lot of additional RPCs, which is not ideal.
2. Use the `$expand` query parameter to resolve the public IP addresses within the same RPC, offering a more efficient solution.

Relevant Azure API documentation:

1. [Network Interfaces - Get - REST API (Azure Virtual Networks) | Microsoft Learn](https://learn.microsoft.com/en-us/rest/api/virtualnetwork/network-interfaces/get?view=rest-virtualnetwork-2023-05-01&tabs=HTTP)
2. [Use query parameters to customize responses - Microsoft Graph | Microsoft Learn](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http#expand-parameter)

# Testing

Unfortunately `azure_sd` lacks comprehensive automated testing. I am aware of the ongoing discussions and plans to revamp the module, aiming to minimize the amount of RPCs. I am keen to contribute to enhancing this module in upcoming developments.

Regarding the current fix, I have conducted some manual testing to validate the following.

1. `azure_sd` is not resolving public IP addresses without the fix

2. The `$expand` parameter resolves public IP addresses of Azure virtual machines
![image](https://github.com/prometheus/prometheus/assets/7066141/6cbd1e20-ad08-4b80-b89a-2089f2477e24)

3. The `$expand` parameter does no harms to virtual machines without public IP addresses
![image](https://github.com/prometheus/prometheus/assets/7066141/432c1030-9a0b-4e67-9f18-3172273e61d8)

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->