### PR TITLE
Sync golangci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           args: --verbose
+          # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
           version: v1.55.2
   fuzzing:
     uses: ./.github/workflows/fuzzing.yml

--- a/scripts/golangci-lint.yml
+++ b/scripts/golangci-lint.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.54.2
+          version: v1.55.2


### PR DESCRIPTION
Update `scripts/golangci-lint.yml` golangci-lint version to match main workflow.
* Add note to keep things in sync.
