### PR TITLE
Reuse golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,23 +135,7 @@ jobs:
           thread: ${{ matrix.thread }}
   golangci:
     name: golangci-lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Install Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-        with:
-          cache: false
-          go-version: 1.21.x
-      - name: Install snmp_exporter/generator dependencies
-        run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
-        if: github.repository == 'prometheus/snmp_exporter'
-      - name: Lint
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
-        with:
-          args: --verbose
-          version: v1.55.2
+    uses: ./.github/workflows/golangci-lint.yml
   fuzzing:
     uses: ./.github/workflows/fuzzing.yml
     if: github.event_name == 'pull_request'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,33 @@
+name: golangci-lint
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        default: '.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: install Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          cache: false
+          go-version: 1.21.x
+      - name: Install snmp_exporter/generator dependencies
+        run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
+        if: github.repository == 'prometheus/snmp_exporter'
+      - name: Lint
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        with:
+          args: --verbose
+          version: v1.55.2
+          working-directory: ${{ inputs.working-directory }}

--- a/scripts/golangci-lint.yml
+++ b/scripts/golangci-lint.yml
@@ -15,18 +15,4 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: install Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-        with:
-          go-version: 1.21.x
-      - name: Install snmp_exporter/generator dependencies
-        run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
-        if: github.repository == 'prometheus/snmp_exporter'
-      - name: Lint
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
-        with:
-          version: v1.54.2
+    uses: prometheus/prometheus/.github/workflows/golangci-lint.yml@main


### PR DESCRIPTION
This creates a reusable workflow that can be called with different parameters. 
Right now the golangci-lint can only be called for the root go.mod. With the use of working-directory it will then be possible to handle multimodules projects.

In addition there won’t be a need to create a merge request to update golangci-lint version on every project using this workflow. 

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>