### PR TITLE
Reuse float histogram objects

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2114,12 +2114,7 @@ loop:
 				if floats == nil {
 					floats = getFPointSlice(16)
 				}
-				if n := len(floats); n < cap(floats) {
-					floats = floats[:n+1]
-					floats[n].T, floats[n].F = t, f
-				} else {
-					floats = append(floats, FPoint{T: t, F: f})
-				}
+				floats = append(floats, FPoint{T: t, F: f})
 			}
 		}
 	}

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -310,6 +310,8 @@ func (r *sampleRing) iterator() *SampleRingIterator {
 	return &r.it
 }
 
+// SampleRingIterator is returned by BufferedSeriesIterator.Buffer() and can be
+// used to iterate samples buffered in the lookback window.
 type SampleRingIterator struct {
 	r  *sampleRing
 	i  int
@@ -356,14 +358,6 @@ func (it *SampleRingIterator) Next() chunkenc.ValueType {
 		it.f = s.F()
 		return chunkenc.ValFloat
 	}
-}
-
-func (it *SampleRingIterator) Seek(int64) chunkenc.ValueType {
-	return chunkenc.ValNone
-}
-
-func (it *SampleRingIterator) Err() error {
-	return nil
 }
 
 func (it *SampleRingIterator) At() (int64, float64) {

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -74,7 +74,7 @@ func (b *BufferedSeriesIterator) PeekBack(n int) (sample chunks.Sample, ok bool)
 
 // Buffer returns an iterator over the buffered data. Invalidates previously
 // returned iterators.
-func (b *BufferedSeriesIterator) Buffer() chunkenc.Iterator {
+func (b *BufferedSeriesIterator) Buffer() *sampleRingIterator {
 	return b.buf.iterator()
 }
 
@@ -304,7 +304,7 @@ func (r *sampleRing) reset() {
 }
 
 // Returns the current iterator. Invalidates previously returned iterators.
-func (r *sampleRing) iterator() chunkenc.Iterator {
+func (r *sampleRing) iterator() *sampleRingIterator {
 	r.it.r = r
 	r.it.i = -1
 	return &r.it
@@ -374,9 +374,9 @@ func (it *sampleRingIterator) AtHistogram() (int64, *histogram.Histogram) {
 	return it.t, it.h
 }
 
-func (it *sampleRingIterator) AtFloatHistogram() (int64, *histogram.FloatHistogram) {
+func (it *sampleRingIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
 	if it.fh == nil {
-		return it.t, it.h.ToFloat(nil)
+		return it.t, it.h.ToFloat(fh)
 	}
 	return it.t, it.fh
 }

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -360,14 +360,20 @@ func (it *SampleRingIterator) Next() chunkenc.ValueType {
 	}
 }
 
+// At returns the current float element of the iterator.
 func (it *SampleRingIterator) At() (int64, float64) {
 	return it.t, it.f
 }
 
+// AtHistogram returns the current histogram element of the iterator.
 func (it *SampleRingIterator) AtHistogram() (int64, *histogram.Histogram) {
 	return it.t, it.h
 }
 
+// AtFloatHistogram returns the current histogram element of the iterator. If the
+// current sample is an integer histogram, it will be converted to a float histogram.
+// An optional histogram.FloatHistogram can be provided to avoid allocating a new
+// object for the conversion.
 func (it *SampleRingIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
 	if it.fh == nil {
 		return it.t, it.h.ToFloat(fh)

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -74,7 +74,7 @@ func (b *BufferedSeriesIterator) PeekBack(n int) (sample chunks.Sample, ok bool)
 
 // Buffer returns an iterator over the buffered data. Invalidates previously
 // returned iterators.
-func (b *BufferedSeriesIterator) Buffer() *sampleRingIterator {
+func (b *BufferedSeriesIterator) Buffer() *SampleRingIterator {
 	return b.buf.iterator()
 }
 
@@ -252,7 +252,7 @@ type sampleRing struct {
 	f int // Position of first element in ring buffer.
 	l int // Number of elements in buffer.
 
-	it sampleRingIterator
+	it SampleRingIterator
 }
 
 type bufType int
@@ -304,13 +304,13 @@ func (r *sampleRing) reset() {
 }
 
 // Returns the current iterator. Invalidates previously returned iterators.
-func (r *sampleRing) iterator() *sampleRingIterator {
+func (r *sampleRing) iterator() *SampleRingIterator {
 	r.it.r = r
 	r.it.i = -1
 	return &r.it
 }
 
-type sampleRingIterator struct {
+type SampleRingIterator struct {
 	r  *sampleRing
 	i  int
 	t  int64
@@ -319,7 +319,7 @@ type sampleRingIterator struct {
 	fh *histogram.FloatHistogram
 }
 
-func (it *sampleRingIterator) Next() chunkenc.ValueType {
+func (it *SampleRingIterator) Next() chunkenc.ValueType {
 	it.i++
 	if it.i >= it.r.l {
 		return chunkenc.ValNone
@@ -358,30 +358,30 @@ func (it *sampleRingIterator) Next() chunkenc.ValueType {
 	}
 }
 
-func (it *sampleRingIterator) Seek(int64) chunkenc.ValueType {
+func (it *SampleRingIterator) Seek(int64) chunkenc.ValueType {
 	return chunkenc.ValNone
 }
 
-func (it *sampleRingIterator) Err() error {
+func (it *SampleRingIterator) Err() error {
 	return nil
 }
 
-func (it *sampleRingIterator) At() (int64, float64) {
+func (it *SampleRingIterator) At() (int64, float64) {
 	return it.t, it.f
 }
 
-func (it *sampleRingIterator) AtHistogram() (int64, *histogram.Histogram) {
+func (it *SampleRingIterator) AtHistogram() (int64, *histogram.Histogram) {
 	return it.t, it.h
 }
 
-func (it *sampleRingIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+func (it *SampleRingIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
 	if it.fh == nil {
 		return it.t, it.h.ToFloat(fh)
 	}
 	return it.t, it.fh
 }
 
-func (it *sampleRingIterator) AtT() int64 {
+func (it *SampleRingIterator) AtT() int64 {
 	return it.t
 }
 

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -243,11 +243,11 @@ func TestBufferedSeriesIteratorMixedHistograms(t *testing.T) {
 	buf := it.Buffer()
 
 	require.Equal(t, chunkenc.ValFloatHistogram, buf.Next())
-	_, fh := buf.AtFloatHistogram()
+	_, fh := buf.AtFloatHistogram(nil)
 	require.Equal(t, histograms[0].ToFloat(nil), fh)
 
 	require.Equal(t, chunkenc.ValHistogram, buf.Next())
-	_, fh = buf.AtFloatHistogram()
+	_, fh = buf.AtFloatHistogram(nil)
 	require.Equal(t, histograms[1].ToFloat(nil), fh)
 }
 


### PR DESCRIPTION
This commit builds upon https://github.com/prometheus/prometheus/pull/13215, and reduces memory for querying native histogram by reusing existing HPoint instances.

Benchmarks show ~23% improvement in performance and ~45% reduction in memory usage. Queries without `rate` are not affected yet. To make improvements there we will need to change the iterator interface and I will do that in a follow up PR.

```
benchstat main.out new.out                                                                    
name                         old time/op    new time/op    delta
NativeHistograms/sum-8          521ms ± 2%     522ms ± 3%     ~     (p=1.000 n=5+5)
NativeHistograms/sum_rate-8     1.11s ± 3%     0.85s ± 8%  -23.15%  (p=0.008 n=5+5)

name                         old alloc/op   new alloc/op   delta
NativeHistograms/sum-8          415MB ± 0%     414MB ± 0%     ~     (p=0.548 n=5+5)
NativeHistograms/sum_rate-8    1.16GB ± 0%    0.64GB ± 0%  -44.94%  (p=0.008 n=5+5)

name                         old allocs/op  new allocs/op  delta
NativeHistograms/sum-8          5.16M ± 0%     5.16M ± 0%     ~     (p=0.841 n=5+5)
NativeHistograms/sum_rate-8     21.1M ± 0%     10.3M ± 0%  -51.26%  (p=0.008 n=5+5)
```
