### PR TITLE
tsdb: add details to duplicate sample error

### DIFF
--- a/storage/errors.go
+++ b/storage/errors.go
@@ -1,0 +1,48 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import "fmt"
+
+type errDuplicateSampleForTimestamp struct {
+	timestamp int64
+	existing  float64
+	newValue  float64
+}
+
+func NewDuplicateFloatErr(t int64, existing, newValue float64) error {
+	return errDuplicateSampleForTimestamp{
+		timestamp: t,
+		existing:  existing,
+		newValue:  newValue,
+	}
+}
+
+func (e errDuplicateSampleForTimestamp) Error() string {
+	if e.timestamp == 0 {
+		return "duplicate sample for timestamp"
+	}
+	return fmt.Sprintf("duplicate sample for timestamp %d: existing %g, new value %g", e.timestamp, e.existing, e.newValue)
+}
+
+// Every errDuplicateSampleForTimestamp compares equal to the global ErrDuplicateSampleForTimestamp.
+func (e errDuplicateSampleForTimestamp) Is(t error) bool {
+	if t == ErrDuplicateSampleForTimestamp {
+		return true
+	}
+	if v, ok := t.(errDuplicateSampleForTimestamp); ok {
+		return e == v
+	}
+	return false
+}

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -33,7 +33,7 @@ func (e errDuplicateSampleForTimestamp) Error() string {
 	if e.timestamp == 0 {
 		return "duplicate sample for timestamp"
 	}
-	return fmt.Sprintf("duplicate sample for timestamp %d: existing %g, new value %g", e.timestamp, e.existing, e.newValue)
+	return fmt.Sprintf("duplicate sample for timestamp %d; overrides not allowed: existing %g, new value %g", e.timestamp, e.existing, e.newValue)
 }
 
 // Every errDuplicateSampleForTimestamp compares equal to the global ErrDuplicateSampleForTimestamp.

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -37,7 +37,7 @@ var (
 	// ErrTooOldSample is when out of order support is enabled but the sample is outside the time window allowed.
 	ErrTooOldSample = errors.New("too old sample")
 	// ErrDuplicateSampleForTimestamp is when the sample has same timestamp but different value.
-	ErrDuplicateSampleForTimestamp = errors.New("duplicate sample for timestamp")
+	ErrDuplicateSampleForTimestamp = errDuplicateSampleForTimestamp{}
 	ErrOutOfOrderExemplar          = errors.New("out of order exemplar")
 	ErrDuplicateExemplar           = errors.New("duplicate exemplar")
 	ErrExemplarLabelLength         = fmt.Errorf("label length for exemplar exceeds maximum of %d UTF-8 characters", exemplar.ExemplarMaxLabelSetLength)

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -504,7 +504,7 @@ func TestAmendHistogramDatapointCausesError(t *testing.T) {
 	_, err = app.Append(0, labels.FromStrings("a", "b"), 0, 0)
 	require.NoError(t, err)
 	_, err = app.Append(0, labels.FromStrings("a", "b"), 0, 1)
-	require.Equal(t, storage.ErrDuplicateSampleForTimestamp, err)
+	require.ErrorIs(t, err, storage.ErrDuplicateSampleForTimestamp)
 	require.NoError(t, app.Rollback())
 
 	h := histogram.Histogram{
@@ -580,7 +580,7 @@ func TestNonDuplicateNaNDatapointsCausesAmendError(t *testing.T) {
 
 	app = db.Appender(ctx)
 	_, err = app.Append(0, labels.FromStrings("a", "b"), 0, math.Float64frombits(0x7ff0000000000002))
-	require.Equal(t, storage.ErrDuplicateSampleForTimestamp, err)
+	require.ErrorIs(t, err, storage.ErrDuplicateSampleForTimestamp)
 }
 
 func TestEmptyLabelsetCausesError(t *testing.T) {

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -468,7 +468,7 @@ func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime, oooTi
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
 			if math.Float64bits(s.lastValue) != math.Float64bits(v) {
-				return false, 0, storage.ErrDuplicateSampleForTimestamp
+				return false, 0, storage.NewDuplicateFloatErr(t, s.lastValue, v)
 			}
 			// Sample is identical (ts + value) with most current (highest ts) sample in sampleBuf.
 			return false, 0, nil


### PR DESCRIPTION
Now the error will include the timestamp and the existing and new values. When you are trying to track down the source of this error, it can be useful to see that the values are close, or alternating, or something else.

Since the existing ErrDuplicateSampleForTimestamp is used for floats and native histograms, and I didn't want to have to figure out how to print a histogram, I did the details only for floats.  `Is()` is implemented to mask this change from people who don't know about it (as long as they call `Errors.Is`).

Posting for opinion - interested to see what people think.
