### PR TITLE
kuma_sd: Extend Kuma SD configuration to allow users to specify ClientId

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -568,6 +568,7 @@ var expectedConf = &Config{
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&xds.KumaSDConfig{
 					Server:           "http://kuma-control-plane.kuma-system.svc:5676",
+					ClientId:         "main-prometheus",
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 					RefreshInterval:  model.Duration(15 * time.Second),
 					FetchTimeout:     model.Duration(2 * time.Minute),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -568,7 +568,7 @@ var expectedConf = &Config{
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&xds.KumaSDConfig{
 					Server:           "http://kuma-control-plane.kuma-system.svc:5676",
-					ClientId:         "main-prometheus",
+					ClientID:         "main-prometheus",
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 					RefreshInterval:  model.Duration(15 * time.Second),
 					FetchTimeout:     model.Duration(2 * time.Minute),

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -221,7 +221,7 @@ scrape_configs:
 
     kuma_sd_configs:
       - server: http://kuma-control-plane.kuma-system.svc:5676
-        clientId: main-prometheus
+        client_id: main-prometheus
 
   - job_name: service-marathon
     marathon_sd_configs:

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -221,6 +221,7 @@ scrape_configs:
 
     kuma_sd_configs:
       - server: http://kuma-control-plane.kuma-system.svc:5676
+        clientId: main-prometheus
 
   - job_name: service-marathon
     marathon_sd_configs:

--- a/config/testdata/roundtrip.good.yml
+++ b/config/testdata/roundtrip.good.yml
@@ -108,7 +108,7 @@ scrape_configs:
 
     kuma_sd_configs:
       - server: http://kuma-control-plane.kuma-system.svc:5676
-        clientId: main-prometheus
+        client_id: main-prometheus
 
     marathon_sd_configs:
       - servers:

--- a/config/testdata/roundtrip.good.yml
+++ b/config/testdata/roundtrip.good.yml
@@ -108,6 +108,7 @@ scrape_configs:
 
     kuma_sd_configs:
       - server: http://kuma-control-plane.kuma-system.svc:5676
+        clientId: main-prometheus
 
     marathon_sd_configs:
       - servers:

--- a/discovery/xds/kuma.go
+++ b/discovery/xds/kuma.go
@@ -178,10 +178,11 @@ func kumaMadsV1ResourceParser(resources []*anypb.Any, typeURL string) ([]model.L
 
 func NewKumaHTTPDiscovery(conf *KumaSDConfig, logger log.Logger) (discovery.Discoverer, error) {
 	// Default to "prometheus" if hostname is unavailable.
-	clientID, err := osutil.GetFQDN()
-	if err != nil {
-		level.Debug(logger).Log("msg", "error getting FQDN", "err", err)
-		clientID = "prometheus"
+	var clientID string
+	if conf.ClientId == "" {
+		clientID = defaultClientId(logger)
+	} else {
+		clientID = conf.ClientId
 	}
 
 	clientConfig := &HTTPResourceClientConfig{
@@ -214,4 +215,13 @@ func NewKumaHTTPDiscovery(conf *KumaSDConfig, logger log.Logger) (discovery.Disc
 	}
 
 	return d, nil
+}
+
+func defaultClientId(logger log.Logger) string {
+	clientID, err := osutil.GetFQDN()
+	if err != nil {
+		level.Debug(logger).Log("msg", "error getting FQDN", "err", err)
+		clientID = "prometheus"
+	}
+	return clientID
 }

--- a/discovery/xds/kuma.go
+++ b/discovery/xds/kuma.go
@@ -178,11 +178,14 @@ func kumaMadsV1ResourceParser(resources []*anypb.Any, typeURL string) ([]model.L
 
 func NewKumaHTTPDiscovery(conf *KumaSDConfig, logger log.Logger) (discovery.Discoverer, error) {
 	// Default to "prometheus" if hostname is unavailable.
-	var clientID string
-	if conf.ClientID == "" {
-		clientID = defaultClientID(logger)
-	} else {
-		clientID = conf.ClientID
+	clientID := conf.ClientID
+	if clientID == "" {
+		var err error
+		clientID, err = osutil.GetFQDN()
+		if err != nil {
+			level.Debug(logger).Log("msg", "error getting FQDN", "err", err)
+			clientID = "prometheus"
+		}
 	}
 
 	clientConfig := &HTTPResourceClientConfig{
@@ -215,13 +218,4 @@ func NewKumaHTTPDiscovery(conf *KumaSDConfig, logger log.Logger) (discovery.Disc
 	}
 
 	return d, nil
-}
-
-func defaultClientID(logger log.Logger) string {
-	clientID, err := osutil.GetFQDN()
-	if err != nil {
-		level.Debug(logger).Log("msg", "error getting FQDN", "err", err)
-		clientID = "prometheus"
-	}
-	return clientID
 }

--- a/discovery/xds/kuma.go
+++ b/discovery/xds/kuma.go
@@ -179,10 +179,10 @@ func kumaMadsV1ResourceParser(resources []*anypb.Any, typeURL string) ([]model.L
 func NewKumaHTTPDiscovery(conf *KumaSDConfig, logger log.Logger) (discovery.Discoverer, error) {
 	// Default to "prometheus" if hostname is unavailable.
 	var clientID string
-	if conf.ClientId == "" {
-		clientID = defaultClientId(logger)
+	if conf.ClientID == "" {
+		clientID = defaultClientID(logger)
 	} else {
-		clientID = conf.ClientId
+		clientID = conf.ClientID
 	}
 
 	clientConfig := &HTTPResourceClientConfig{
@@ -217,7 +217,7 @@ func NewKumaHTTPDiscovery(conf *KumaSDConfig, logger log.Logger) (discovery.Disc
 	return d, nil
 }
 
-func defaultClientId(logger log.Logger) string {
+func defaultClientID(logger log.Logger) string {
 	clientID, err := osutil.GetFQDN()
 	if err != nil {
 		level.Debug(logger).Log("msg", "error getting FQDN", "err", err)

--- a/discovery/xds/kuma_test.go
+++ b/discovery/xds/kuma_test.go
@@ -204,7 +204,7 @@ func TestNewKumaHTTPDiscovery(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, kumaConf.Server, resClient.Server())
 	require.Equal(t, KumaMadsV1ResourceTypeURL, resClient.ResourceTypeURL())
-	require.NotEmpty(t, resClient.ID())
+	require.Equal(t, kumaConf.ClientId, resClient.ID())
 	require.Equal(t, KumaMadsV1ResourceType, resClient.config.ResourceType)
 }
 

--- a/discovery/xds/kuma_test.go
+++ b/discovery/xds/kuma_test.go
@@ -204,7 +204,7 @@ func TestNewKumaHTTPDiscovery(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, kumaConf.Server, resClient.Server())
 	require.Equal(t, KumaMadsV1ResourceTypeURL, resClient.ResourceTypeURL())
-	require.Equal(t, kumaConf.ClientId, resClient.ID())
+	require.Equal(t, kumaConf.ClientID, resClient.ID())
 	require.Equal(t, KumaMadsV1ResourceType, resClient.config.ResourceType)
 }
 

--- a/discovery/xds/xds.go
+++ b/discovery/xds/xds.go
@@ -55,6 +55,7 @@ type SDConfig struct {
 	RefreshInterval  model.Duration          `yaml:"refresh_interval,omitempty"`
 	FetchTimeout     model.Duration          `yaml:"fetch_timeout,omitempty"`
 	Server           string                  `yaml:"server,omitempty"`
+	ClientId         string                  `yaml:"clientId,omitempty"`
 }
 
 // mustRegisterMessage registers the provided message type in the typeRegistry, and panics

--- a/discovery/xds/xds.go
+++ b/discovery/xds/xds.go
@@ -55,7 +55,7 @@ type SDConfig struct {
 	RefreshInterval  model.Duration          `yaml:"refresh_interval,omitempty"`
 	FetchTimeout     model.Duration          `yaml:"fetch_timeout,omitempty"`
 	Server           string                  `yaml:"server,omitempty"`
-	ClientId         string                  `yaml:"clientId,omitempty"`
+	ClientID         string                  `yaml:"client_id,omitempty"`
 }
 
 // mustRegisterMessage registers the provided message type in the typeRegistry, and panics

--- a/discovery/xds/xds_test.go
+++ b/discovery/xds/xds_test.go
@@ -36,7 +36,7 @@ var (
 	sdConf = SDConfig{
 		Server:          "http://127.0.0.1",
 		RefreshInterval: model.Duration(10 * time.Second),
-		ClientId:        "test-id",
+		ClientID:        "test-id",
 	}
 
 	testFetchFailuresCount = prometheus.NewCounter(

--- a/discovery/xds/xds_test.go
+++ b/discovery/xds/xds_test.go
@@ -36,6 +36,7 @@ var (
 	sdConf = SDConfig{
 		Server:          "http://127.0.0.1",
 		RefreshInterval: model.Duration(10 * time.Second),
+		ClientId:        "test-id",
 	}
 
 	testFetchFailuresCount = prometheus.NewCounter(

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2231,9 +2231,9 @@ See below for the configuration options for Kuma MonitoringAssignment discovery:
 server: <string>
 
 # Client id is used by Kuma Control Plane to compute Monitoring Assignment for specific Prometheus backend. 
-# This is useful when migrating between multiple Prometheus backends, or having separate backend for each Mesh
+# This is useful when migrating between multiple Prometheus backends, or having separate backend for each Mesh.
 # When not specified, system hostname/fqdn will be used if available, if not `prometheus` will be used.
-client_id: <string>
+[ client_id: <string> ]
 
 # The time to wait between polling update requests.
 [ refresh_interval: <duration> | default = 30s ]

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2230,6 +2230,11 @@ See below for the configuration options for Kuma MonitoringAssignment discovery:
 # Address of the Kuma Control Plane's MADS xDS server.
 server: <string>
 
+# Client id is used by Kuma Control Plane to compute Monitoring Assignment for specific Prometheus backend. 
+# This is useful when migrating between multiple Prometheus backends, or having separate backend for each Mesh
+# When not specified, system hostname/fqdn will be used if available, if not `prometheus` will be used.
+clientId: <string>
+
 # The time to wait between polling update requests.
 [ refresh_interval: <duration> | default = 30s ]
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2233,7 +2233,7 @@ server: <string>
 # Client id is used by Kuma Control Plane to compute Monitoring Assignment for specific Prometheus backend. 
 # This is useful when migrating between multiple Prometheus backends, or having separate backend for each Mesh
 # When not specified, system hostname/fqdn will be used if available, if not `prometheus` will be used.
-clientId: <string>
+client_id: <string>
 
 # The time to wait between polling update requests.
 [ refresh_interval: <duration> | default = 30s ]


### PR DESCRIPTION
In Kuma we are changing how we deal with observability and especially metrics. We are adding change to MADS service that is used in Kuma SD in Prometheus. The change is described in this [design document](https://github.com/kumahq/kuma/blob/f684b25b903a99e2a64edec99bd7516ee0ae076f/docs/madr/decisions/035-mesh-metric-policy.md?plain=1#L106).  

This change will allow users to specify ClientId used in Kuma SD, thanks to this Kuma users will be allowed to use different Prometheus backends per Mesh, or easily migrate between multiple Prometheus backends.