### PR TITLE
`MemPostings.Delete()`: reduce locking/unlocking

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -324,7 +324,8 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}) {
 		// This way we only need to Lock once later.
 		for i := 0; i < len(vals); {
 			found := false
-			for _, id := range p.m[n][vals[i]] {
+			refs := p.m[n][vals[i]]
+			for _, id := range refs {
 				if _, ok := deleted[id]; ok {
 					i++
 					found = true

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -317,18 +317,21 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}) {
 		// For each posting we first analyse whether the postings list is affected by the deletes.
 		// If no, we remove the label value from the vals list.
 		// This way we only need to Lock once later.
-	values:
 		for i := 0; i < len(vals); {
-			l := vals[i]
-			for _, id := range p.m[n][l] {
+			found := false
+			for _, id := range p.m[n][vals[i]] {
 				if _, ok := deleted[id]; ok {
 					i++
-					continue values
+					found = true
+					break
 				}
 			}
-			// This label value doesn't contain deleted ids, so no need to process it later.
-			// We we continue with the next one, which is the last one in the list.
-			vals[i], vals = vals[len(vals)-1], vals[:len(vals)-1]
+
+			if !found {
+				// This label value doesn't contain deleted ids, so no need to process it later.
+				// We we continue with the next one, which is the last one in the list.
+				vals[i], vals = vals[len(vals)-1], vals[:len(vals)-1]
+			}
 		}
 
 		// If no label values have deleted ids, just continue.

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1002,6 +1002,8 @@ func TestMemPostings_Delete(t *testing.T) {
 	require.Empty(t, expanded, "expected empty postings, got %v", expanded)
 }
 
+// BenchmarkMemPostings_Delete is quite heavy, so consider running it with
+// -benchtime=10x or similar to get more stable and comparable results.
 func BenchmarkMemPostings_Delete(b *testing.B) {
 	internedItoa := map[int]string{}
 	var mtx sync.RWMutex

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/grafana/regexp"
@@ -999,6 +1000,100 @@ func TestMemPostings_Delete(t *testing.T) {
 	expanded, err = ExpandPostings(deleted)
 	require.NoError(t, err)
 	require.Empty(t, expanded, "expected empty postings, got %v", expanded)
+}
+
+func BenchmarkMemPostings_Delete(b *testing.B) {
+	internedItoa := map[int]string{}
+	var mtx sync.RWMutex
+	itoa := func(i int) string {
+		mtx.RLock()
+		s, ok := internedItoa[i]
+		mtx.RUnlock()
+		if ok {
+			return s
+		}
+		mtx.Lock()
+		s = strconv.Itoa(i)
+		internedItoa[i] = s
+		mtx.Unlock()
+		return s
+	}
+
+	const total = 1e6
+	prepare := func() *MemPostings {
+		var ref storage.SeriesRef
+		next := func() storage.SeriesRef {
+			ref++
+			return ref
+		}
+
+		p := NewMemPostings()
+		nameValues := make([]string, 0, 100)
+		for i := 0; i < total; i++ {
+			nameValues = nameValues[:0]
+
+			// A thousand labels like lbl_x_of_1000, each with total/1000 values
+			thousand := "lbl_" + itoa(i%1000) + "_of_1000"
+			nameValues = append(nameValues, thousand, itoa(i/1000))
+			// A hundred labels like lbl_x_of_100, each with total/100 values.
+			hundred := "lbl_" + itoa(i%100) + "_of_100"
+			nameValues = append(nameValues, hundred, itoa(i/100))
+
+			if i < 100 {
+				ten := "lbl_" + itoa(i%10) + "_of_10"
+				nameValues = append(nameValues, ten, itoa(i%10))
+			}
+
+			p.Add(next(), labels.FromStrings(append(nameValues, "first", "a", "second", "a", "third", "a")...))
+		}
+		return p
+	}
+
+	for _, refs := range []int{1, 100, 10_000} {
+		b.Run(fmt.Sprintf("refs=%d", refs), func(b *testing.B) {
+			for _, reads := range []int{0, 1, 10} {
+				b.Run(fmt.Sprintf("readers=%d", reads), func(b *testing.B) {
+					if b.N > total/refs {
+						// Just to make sure that benchmark still makes sense.
+						panic("benchmark not prepared")
+					}
+
+					p := prepare()
+					stop := make(chan struct{})
+					wg := sync.WaitGroup{}
+					for i := 0; i < reads; i++ {
+						wg.Add(1)
+						go func(i int) {
+							lbl := "lbl_" + itoa(i) + "_of_100"
+							defer wg.Done()
+							for {
+								select {
+								case <-stop:
+									return
+								default:
+									// Get a random value of this label.
+									p.Get(lbl, itoa(rand.Intn(10000))).Next()
+								}
+							}
+						}(i)
+					}
+					b.Cleanup(func() {
+						close(stop)
+						wg.Wait()
+					})
+
+					b.ResetTimer()
+					for n := 0; n < b.N; n++ {
+						deleted := map[storage.SeriesRef]struct{}{}
+						for i := 0; i < refs; i++ {
+							deleted[storage.SeriesRef(n*refs+i)] = struct{}{}
+						}
+						p.Delete(deleted)
+					}
+				})
+			}
+		})
+	}
 }
 
 func TestFindIntersectingPostings(t *testing.T) {


### PR DESCRIPTION
(The description has been updated since I created this PR)

`MemPostings.Delete` is called from Head.gc(), i.e. it gets the IDs of the series that have churned.

With current implementation, it tried to acquire the `Lock()` for each label/value combination: this can be quite expensive for tenants who have lots of those combinations.

This changes the implementation to call `Lock` only once per each label name (not value), and only if it is affected by the series churn.

I'm also adding a benchmark, which I ran with `-benchtime=10x`: it's quite difficult to get meaningful result here as each time the operation called, the benchmarked entity is being changed. 

The benchmark runs some read operations which would make the `Lock()` operation wait, which is the scenario that I'm trying to mitigate, as in a downstream project we've seen some profiles waiting continuously on this `Lock()` call.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb/index
                                            │     main     │                 new                 │
                                            │    sec/op    │    sec/op     vs base               │
MemPostings_Delete/refs=1/readers=0-12         141.2m ± 5%   157.2m ±  1%  +11.29% (p=0.002 n=6)
MemPostings_Delete/refs=1/readers=1-12        1152.1m ± 1%   205.7m ±  5%  -82.14% (p=0.002 n=6)
MemPostings_Delete/refs=1/readers=10-12        10.424 ± 3%    1.149 ± 45%  -88.98% (p=0.002 n=6)
MemPostings_Delete/refs=100/readers=0-12       173.8m ± 5%   202.2m ± 13%  +16.36% (p=0.004 n=6)
MemPostings_Delete/refs=100/readers=1-12      1203.4m ± 1%   226.8m ±  5%  -81.15% (p=0.002 n=6)
MemPostings_Delete/refs=100/readers=10-12      10.791 ± 2%    1.164 ± 49%  -89.21% (p=0.002 n=6)
MemPostings_Delete/refs=10000/readers=0-12     198.3m ± 7%   176.3m ±  2%  -11.08% (p=0.002 n=6)
MemPostings_Delete/refs=10000/readers=1-12    1246.2m ± 2%   241.1m ±  4%  -80.66% (p=0.002 n=6)
MemPostings_Delete/refs=10000/readers=10-12    10.571 ± 3%    1.122 ± 49%  -89.39% (p=0.002 n=6)
geomean                                         1.292        357.2m        -72.34%
```

I haven't found the reason for such a high variance in some of the new implementation's results.

I only ran memory benchmarks with `readers=0`, and the results are very similar:
```
                                           │   main_mem    │                new_mem                │
                                           │     B/op      │     B/op       vs base                │
MemPostings_Delete/refs=1/readers=0-12       28.17Mi ± ∞ ¹   27.65Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
MemPostings_Delete/refs=100/readers=0-12     31.22Mi ± ∞ ¹   30.70Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
MemPostings_Delete/refs=10000/readers=0-12   30.37Mi ± ∞ ¹   29.84Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                      29.89Mi         29.37Mi        -1.74%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                           │   main_mem   │                new_mem                │
                                           │  allocs/op   │  allocs/op    vs base                 │
MemPostings_Delete/refs=1/readers=0-12       36.000 ± ∞ ¹    8.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
MemPostings_Delete/refs=100/readers=0-12      248.0 ± ∞ ¹    221.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
MemPostings_Delete/refs=10000/readers=0-12   20.18k ± ∞ ¹   20.15k ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                       564.7          329.0        -41.74%
```