### PR TITLE
Adding small test update for temp dir using t.TempDir

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -47,9 +47,10 @@ func TestMain(m *testing.M) {
 func TestQueryConcurrency(t *testing.T) {
 	maxConcurrency := 10
 
-	dir, err := os.MkdirTemp("", "test_concurrency")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(dir))
+	})
 	queryTracker := NewActiveQueryTracker(dir, maxConcurrency, nil)
 	t.Cleanup(queryTracker.Close)
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -48,9 +47,6 @@ func TestQueryConcurrency(t *testing.T) {
 	maxConcurrency := 10
 
 	dir := t.TempDir()
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(dir))
-	})
 	queryTracker := NewActiveQueryTracker(dir, maxConcurrency, nil)
 	t.Cleanup(queryTracker.Close)
 

--- a/tsdb/tsdbutil/dir_locker_testutil.go
+++ b/tsdb/tsdbutil/dir_locker_testutil.go
@@ -60,8 +60,7 @@ func TestDirLockerUsage(t *testing.T, open func(t *testing.T, data string, creat
 
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%+v", c), func(t *testing.T) {
-			tmpdir, err := os.MkdirTemp("", "test")
-			require.NoError(t, err)
+			tmpdir := t.TempDir()
 			t.Cleanup(func() {
 				require.NoError(t, os.RemoveAll(tmpdir))
 			})
@@ -82,7 +81,7 @@ func TestDirLockerUsage(t *testing.T, open func(t *testing.T, data string, creat
 
 			// Check that the lockfile is always deleted
 			if !c.lockFileDisabled {
-				_, err = os.Stat(locker.path)
+				_, err := os.Stat(locker.path)
 				require.True(t, os.IsNotExist(err), "lockfile was not deleted")
 			}
 		})

--- a/tsdb/tsdbutil/dir_locker_testutil.go
+++ b/tsdb/tsdbutil/dir_locker_testutil.go
@@ -61,10 +61,7 @@ func TestDirLockerUsage(t *testing.T, open func(t *testing.T, data string, creat
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%+v", c), func(t *testing.T) {
 			tmpdir := t.TempDir()
-			t.Cleanup(func() {
-				require.NoError(t, os.RemoveAll(tmpdir))
-			})
-
+			
 			// Test preconditions (file already exists + lockfile option)
 			if c.fileAlreadyExists {
 				tmpLocker, err := NewDirLocker(tmpdir, "tsdb", log.NewNopLogger(), nil)


### PR DESCRIPTION
This is a little fix update for this issue: 
https://github.com/prometheus/prometheus/issues/9594

Use case. Why is this important? 
Error handling is implicit.
Cleanup is implicit.