### PR TITLE
update help string for flag 'web.cors.origin' and escape pipe character when writing the docs flag table

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -303,7 +303,7 @@ func main() {
 	a.Flag("web.page-title", "Document title of Prometheus instance.").
 		Default("Prometheus Time Series Collection and Processing Server").StringVar(&cfg.web.PageTitle)
 
-	a.Flag("web.cors.origin", `Regex for CORS origin. It is fully anchored. Example: 'https?://(domain1|domain2)\.com'`).
+	a.Flag("web.cors.origin", "Regex for CORS origin. It is fully anchored. Example: `https?://(domain1|domain2)\\.com`").
 		Default(".*").StringVar(&cfg.corsRegexString)
 
 	serverOnlyFlag(a, "storage.tsdb.path", "Base path for metrics storage.").

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -28,7 +28,7 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--web.console.templates</code> | Path to the console template directory, available at /consoles. | `consoles` |
 | <code class="text-nowrap">--web.console.libraries</code> | Path to the console library directory. | `console_libraries` |
 | <code class="text-nowrap">--web.page-title</code> | Document title of Prometheus instance. | `Prometheus Time Series Collection and Processing Server` |
-| <code class="text-nowrap">--web.cors.origin</code> | Regex for CORS origin. It is fully anchored. Example: 'https?://(domain1|domain2)\.com' | `.*` |
+| <code class="text-nowrap">--web.cors.origin</code> | Regex for CORS origin. It is fully anchored. Example: `https?://(domain1\|domain2)\.com` | `.*` |
 | <code class="text-nowrap">--storage.tsdb.path</code> | Base path for metrics storage. Use with server mode only. | `data/` |
 | <code class="text-nowrap">--storage.tsdb.retention</code> | [DEPRECATED] How long to retain samples in storage. This flag has been deprecated, use "storage.tsdb.retention.time" instead. Use with server mode only. |  |
 | <code class="text-nowrap">--storage.tsdb.retention.time</code> | How long to retain samples in storage. When this flag is set it overrides "storage.tsdb.retention". If neither this flag nor "storage.tsdb.retention" nor "storage.tsdb.retention.size" is set, the retention time defaults to 15d. Units Supported: y, w, d, h, m, s, ms. Use with server mode only. |  |

--- a/util/documentcli/documentcli.go
+++ b/util/documentcli/documentcli.go
@@ -75,7 +75,7 @@ func createFlagRow(flag *kingpin.FlagModel) []string {
 		name = fmt.Sprintf(`<code class="text-nowrap">-%c</code>, <code class="text-nowrap">--%s</code>`, flag.Short, flag.Name)
 	}
 
-	return []string{name, flag.Help, defaultVal}
+	return []string{name, strings.ReplaceAll(flag.Help, "|", `\|`), defaultVal}
 }
 
 func writeFlagTable(writer io.Writer, level int, fgm *kingpin.FlagGroupModel) error {


### PR DESCRIPTION
This allows for help strings / examples to contain pipe characters and not break the markdown table that is generated by documentcli.go.

As a result, the example in the output of `prometheus --help` changes from single quotes to backticks:

```
# before
$ go run ./cmd/prometheus/ --help
      ...
      --web.cors.origin=".*"     Regex for CORS origin. It is fully anchored. Example: 'https?://(domain1|domain2)\.com'
      
# after
$ go run ./cmd/prometheus/ --help
      ...
      --web.cors.origin=".*"     Regex for CORS origin. It is fully anchored. Example: `https?://(domain1|domain2)\.com`
```

Fixes #13309

@metalmatze 