### PR TITLE
bug: Fix quality value in accept header

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -675,7 +675,7 @@ func acceptHeader(sps []config.ScrapeProtocol) string {
 		weight--
 	}
 	// Default match anything.
-	vals = append(vals, fmt.Sprintf("*/*;q=%d", weight))
+	vals = append(vals, fmt.Sprintf("*/*;q=0.%d", weight))
 	return strings.Join(vals, ",")
 }
 


### PR DESCRIPTION
Fixed #13268 - Now 'q' value will be strictly within the range of 0 to 1.

