### PR TITLE
Allow to filter out running VMs on Azure SD

### DIFF
--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -51,6 +52,12 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 		HardwareProfile: &armcompute.HardwareProfile{
 			VMSize: &vmSize,
 		},
+		InstanceView: &armcompute.VirtualMachineInstanceView{
+			Statuses: []*armcompute.InstanceViewStatus{
+				{DisplayStatus: to.Ptr("VM running")},
+				{DisplayStatus: to.Ptr("Provisioning succeeded")},
+			},
+		},
 	}
 
 	testVM := armcompute.VirtualMachine{
@@ -72,6 +79,7 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 		Tags:              map[string]*string{},
 		NetworkInterfaces: []string{},
 		Size:              size,
+		RunningStatus:     "yes",
 	}
 
 	actualVM := mapFromVM(testVM)
@@ -107,6 +115,12 @@ func TestMapFromVMWithTags(t *testing.T) {
 		HardwareProfile: &armcompute.HardwareProfile{
 			VMSize: &vmSize,
 		},
+		InstanceView: &armcompute.VirtualMachineInstanceView{
+			Statuses: []*armcompute.InstanceViewStatus{
+				{DisplayStatus: to.Ptr("VM deallocated")},
+				{DisplayStatus: to.Ptr("Provisioning succeeded")},
+			},
+		},
 	}
 
 	testVM := armcompute.VirtualMachine{
@@ -128,6 +142,7 @@ func TestMapFromVMWithTags(t *testing.T) {
 		Tags:              tags,
 		NetworkInterfaces: []string{},
 		Size:              size,
+		RunningStatus:     "no",
 	}
 
 	actualVM := mapFromVM(testVM)
@@ -161,6 +176,12 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 		HardwareProfile: &armcompute.HardwareProfile{
 			VMSize: &vmSize,
 		},
+		InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+			Statuses: []*armcompute.InstanceViewStatus{
+				{DisplayStatus: to.Ptr("VM deallocated")},
+				{DisplayStatus: to.Ptr("Provisioning succeeded")},
+			},
+		},
 	}
 
 	testVM := armcompute.VirtualMachineScaleSetVM{
@@ -186,6 +207,7 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 		ScaleSet:          scaleSet,
 		InstanceID:        instanceID,
 		Size:              size,
+		RunningStatus:     "no",
 	}
 
 	actualVM := mapFromVMScaleSetVM(testVM, scaleSet)
@@ -222,6 +244,12 @@ func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
 		HardwareProfile: &armcompute.HardwareProfile{
 			VMSize: &vmSize,
 		},
+		InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+			Statuses: []*armcompute.InstanceViewStatus{
+				{DisplayStatus: to.Ptr("VM running")},
+				{DisplayStatus: to.Ptr("Provisioning succeeded")},
+			},
+		},
 	}
 
 	testVM := armcompute.VirtualMachineScaleSetVM{
@@ -247,6 +275,7 @@ func TestMapFromVMScaleSetVMWithTags(t *testing.T) {
 		ScaleSet:          scaleSet,
 		InstanceID:        instanceID,
 		Size:              size,
+		RunningStatus:     "yes",
 	}
 
 	actualVM := mapFromVMScaleSetVM(testVM, scaleSet)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -550,6 +550,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_azure_machine_tag_<tagname>`: each tag value of the machine
 * `__meta_azure_machine_scale_set`: the name of the scale set which the vm is part of (this value is only set if you are using a [scale set](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/))
 * `__meta_azure_machine_size`: the machine size
+* `__meta_azure_machine_running`: the VM running status "yes" or "no"
 * `__meta_azure_subscription_id`: the subscription ID
 * `__meta_azure_tenant_id`: the tenant ID
 


### PR DESCRIPTION
Azure SD doesn't provide a way to filter out running VM/VMSS instances.
There is no reason to discover stopped/deallocated instances for scraping.

This PR fixes #4340
There was 4-year old PR  https://github.com/prometheus/prometheus/pull/5569 in attempt to fix this but it was before Azure SD update, with extra API calls etc.

This PR is simple and up-to-date, adds a label `__meta_azure_machine_running` with possible values `yes` or `no` when one of the instance view statuses is `VM running`. No extra calls.

Thanks,
Roman
