### PR TITLE
Enhanced visibility for `promtool test rules` with JSON colored formatting

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -77,8 +77,10 @@ const (
 	checkReadiness           = "/-/ready"
 )
 
-var lintOptions = []string{lintOptionAll, lintOptionDuplicateRules, lintOptionNone}
-var diffFlag bool
+var (
+	lintOptions = []string{lintOptionAll, lintOptionDuplicateRules, lintOptionNone}
+	diffFlag    bool
+)
 
 func main() {
 	var (

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -78,6 +78,7 @@ const (
 )
 
 var lintOptions = []string{lintOptionAll, lintOptionDuplicateRules, lintOptionNone}
+var diffFlag bool
 
 func main() {
 	var (
@@ -204,6 +205,7 @@ func main() {
 		"test-rule-file",
 		"The unit test file.",
 	).Required().ExistingFiles()
+	testRulesDiff := testRulesCmd.Flag("diff", "Print colored differential output between expected & received output").Default("false").Bool()
 
 	defaultDBPath := "data/"
 	tsdbCmd := app.Command("tsdb", "Run tsdb commands.")
@@ -363,6 +365,7 @@ func main() {
 		os.Exit(QueryLabels(serverURL, httpRoundTripper, *queryLabelsMatch, *queryLabelsName, *queryLabelsBegin, *queryLabelsEnd, p))
 
 	case testRulesCmd.FullCommand():
+		diffFlag = *testRulesDiff
 		os.Exit(RulesUnitTest(
 			promql.LazyLoaderOpts{
 				EnableAtModifier:     true,

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -204,7 +204,7 @@ func main() {
 		"test-rule-file",
 		"The unit test file.",
 	).Required().ExistingFiles()
-	testRulesDiff := testRulesCmd.Flag("diff", "Print colored differential output between expected & received output").Default("false").Bool()
+	testRulesDiff := testRulesCmd.Flag("diff", "Print colored differential output between expected & received output.").Default("false").Bool()
 
 	defaultDBPath := "data/"
 	tsdbCmd := app.Command("tsdb", "Run tsdb commands.")

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -77,10 +77,7 @@ const (
 	checkReadiness           = "/-/ready"
 )
 
-var (
-	lintOptions = []string{lintOptionAll, lintOptionDuplicateRules, lintOptionNone}
-	diffFlag    bool
-)
+var lintOptions = []string{lintOptionAll, lintOptionDuplicateRules, lintOptionNone}
 
 func main() {
 	var (
@@ -367,13 +364,13 @@ func main() {
 		os.Exit(QueryLabels(serverURL, httpRoundTripper, *queryLabelsMatch, *queryLabelsName, *queryLabelsBegin, *queryLabelsEnd, p))
 
 	case testRulesCmd.FullCommand():
-		diffFlag = *testRulesDiff
 		os.Exit(RulesUnitTest(
 			promql.LazyLoaderOpts{
 				EnableAtModifier:     true,
 				EnableNegativeOffset: true,
 			},
 			*testRulesRun,
+			*testRulesDiff,
 			*testRulesFiles...),
 		)
 

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -204,7 +204,7 @@ func main() {
 		"test-rule-file",
 		"The unit test file.",
 	).Required().ExistingFiles()
-	testRulesDiff := testRulesCmd.Flag("diff", "Print colored differential output between expected & received output.").Default("false").Bool()
+	testRulesDiff := testRulesCmd.Flag("diff", "[Experimental] Print colored differential output between expected & received output.").Default("false").Bool()
 
 	defaultDBPath := "data/"
 	tsdbCmd := app.Command("tsdb", "Run tsdb commands.")

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -366,14 +366,12 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 						diffOpts := jsondiff.DefaultConsoleOptions()
 						expAlertsJSON, err := json.Marshal(expAlerts)
 						if err != nil {
-							// errs = append(errs, fmt.Errorf("alertName: %s\nError converting expAlert to JSON: %v", tg.TestGroupName, expAlerts.String()))
 							errs = append(errs, fmt.Errorf("error marshaling expected %s alert: [%s]", tg.TestGroupName, err.Error()))
 							continue
 						}
 
 						gotAlertsJSON, err := json.Marshal(gotAlerts)
 						if err != nil {
-							// errs = append(errs, fmt.Errorf("alertName: %s\nError converting gotAlert to JSON: %v", tg.TestGroupName, gotAlerts.String()))
 							errs = append(errs, fmt.Errorf("error marshaling received %s alert: [%s]", tg.TestGroupName, err.Error()))
 							continue
 						}

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -125,7 +125,7 @@ func TestRulesUnitTest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := RulesUnitTest(tt.queryOpts, nil, tt.args.files...); got != tt.want {
+			if got := RulesUnitTest(tt.queryOpts, nil, false, tt.args.files...); got != tt.want {
 				t.Errorf("RulesUnitTest() = %v, want %v", got, tt.want)
 			}
 		})
@@ -178,7 +178,7 @@ func TestRulesUnitTestRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := RulesUnitTest(tt.queryOpts, tt.args.run, tt.args.files...); got != tt.want {
+			if got := RulesUnitTest(tt.queryOpts, tt.args.run, false, tt.args.files...); got != tt.want {
 				t.Errorf("RulesUnitTest() = %v, want %v", got, tt.want)
 			}
 		})

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -431,9 +431,10 @@ Unit tests for rules.
 
 ###### Flags
 
-| Flag | Description |
-| --- | --- |
-| <code class="text-nowrap">--run</code> | If set, will only run test groups whose names match the regular expression. Can be specified multiple times. |
+| Flag | Description | Default |
+| --- | --- | --- |
+| <code class="text-nowrap">--run</code> | If set, will only run test groups whose names match the regular expression. Can be specified multiple times. |  |
+| <code class="text-nowrap">--diff</code> | Print colored differential output between expected & received output | `false` |
 
 
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -434,7 +434,7 @@ Unit tests for rules.
 | Flag | Description | Default |
 | --- | --- | --- |
 | <code class="text-nowrap">--run</code> | If set, will only run test groups whose names match the regular expression. Can be specified multiple times. |  |
-| <code class="text-nowrap">--diff</code> | Print colored differential output between expected & received output. | `false` |
+| <code class="text-nowrap">--diff</code> | [Experimental] Print colored differential output between expected & received output. | `false` |
 
 
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -434,7 +434,7 @@ Unit tests for rules.
 | Flag | Description | Default |
 | --- | --- | --- |
 | <code class="text-nowrap">--run</code> | If set, will only run test groups whose names match the regular expression. Can be specified multiple times. |  |
-| <code class="text-nowrap">--diff</code> | Print colored differential output between expected & received output | `false` |
+| <code class="text-nowrap">--diff</code> | Print colored differential output between expected & received output. | `false` |
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,8 @@ require (
 	k8s.io/klog/v2 v2.110.1
 )
 
+require github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
+
 require (
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/miekg/dns v1.1.57
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
+	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 	github.com/oklog/run v1.1.0
 	github.com/oklog/ulid v1.3.1
 	github.com/ovh/go-ovh v1.4.3
@@ -89,8 +90,6 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.110.1
 )
-
-require github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 
 require (
 	cloud.google.com/go/compute v1.23.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -577,6 +577,8 @@ github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1 h1:dOYG7LS/WK00RWZc8XGgcUTlTxpp3mKhdR2Q9z9HbXM=
+github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=

--- a/tsdb/tsdbutil/dir_locker_testutil.go
+++ b/tsdb/tsdbutil/dir_locker_testutil.go
@@ -61,7 +61,7 @@ func TestDirLockerUsage(t *testing.T, open func(t *testing.T, data string, creat
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%+v", c), func(t *testing.T) {
 			tmpdir := t.TempDir()
-
+			
 			// Test preconditions (file already exists + lockfile option)
 			if c.fileAlreadyExists {
 				tmpLocker, err := NewDirLocker(tmpdir, "tsdb", log.NewNopLogger(), nil)

--- a/tsdb/tsdbutil/dir_locker_testutil.go
+++ b/tsdb/tsdbutil/dir_locker_testutil.go
@@ -61,7 +61,7 @@ func TestDirLockerUsage(t *testing.T, open func(t *testing.T, data string, creat
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%+v", c), func(t *testing.T) {
 			tmpdir := t.TempDir()
-			
+
 			// Test preconditions (file already exists + lockfile option)
 			if c.fileAlreadyExists {
 				tmpLocker, err := NewDirLocker(tmpdir, "tsdb", log.NewNopLogger(), nil)


### PR DESCRIPTION
## Problem statement

`promtool` executes prometheus test cases. In case of discrepancy between test cases, it shows output of expected (exp) value & received (got) values.

A failed test case output looks something like below snippet. Identifying the exact differential output between `exp` & `got` values is equivalent to finding a needle in haystack, especially when there are multiple failed test cases.

```
Unit Testing:  loki.all.rules.test.yml_global
  FAILED:
    alertname: LokiRingUnhealthy, time: 40m,
        exp:[
            0:
              Labels:{alertname="LokiRingUnhealthy", app="loki-service", cancel_if_apiserver_down="true", cancel_if_cluster_status_creating="true", cancel_if_cluster_status_deleting="true", cancel_if_cluster_status_updating="true", cancel_if_outside_working_hours="true", cancel_if_scrape_timeout="true", container="service", name="service", namespace="loki", pod="loki-service-676b8c897b-rq29", severity="page", topic="observability"}
              Annotations:{description="Loki pod loki-service-676b8c897b-rq298 (namespace loki) sees 1 unhealthy ring members"}
            ],
        got:[
            0:
              Labels:{alertname="LokiRingUnhealthy", area="services", cancel_if_apiserver_down="true", cancel_if_cluster_status_creating="true", cancel_if_cluster_status_deleting="true", cancel_if_cluster_status_updating="true", cancel_if_outside_working_hours="true", cancel_if_scrape_timeout="true", container="service", name="service", namespace="loki", pod="loki-service-676b8c897b-rq298", severity="page", topic="observability"}
              Annotations:{description="Loki pod loki-service-676b8c897b-rq298 (namespace loki) sees 1 unhealthy ring members"}
            ]
```

## Proposal

This PR aims to fix this issue by developing enhanced readability with JSON colored formatting.

### Current workflow

<img width="1721" alt="image" src="https://github.com/prometheus/prometheus/assets/22347290/ca13bac9-f7af-4530-a492-15ab50f167fa">

### Proposed workflow

This PR introduces `--diff` flag.

```bash
./promtool test rules loki.all.rules.test.yml_global --diff
```

<img width="1722" alt="image" src="https://github.com/prometheus/prometheus/assets/22347290/e44c1112-a132-441e-87d6-b57d88f81609">


### Reproduction steps

```bash
git clone https://github.com/rewanthtammana/prometheus -b promtool-test-rules
cd prometheus/cmd/promtool
# Download sample files for tests
wget https://gist.githubusercontent.com/rewanthtammana/d4315690bc80012cc01b1ff4dc88a80f/raw/19bfe81c7b8b6737d9a30a781aafb273717222ed/loki.all.rules.test.yml_global
wget https://gist.githubusercontent.com/rewanthtammana/564cf6493ca546f2cffc1fa5f80cc576/raw/948546cba1dedffa4f04f51552e83d228b4fe574/loki.all.rules.yml
# Download packages & run promtool
go get -v ./...
go build -o promtool .
./promtool test rules loki.all.rules.test.yml_global --diff
```

## Conclusion

This new workflow enables end user to easily visualize, debug & understand more about the failed test cases.

Closes https://github.com/prometheus/prometheus/issues/7568
