### PR TITLE
ui: fix handling of scalar and string in isHeatmapData

### DIFF
--- a/web/ui/react-app/src/pages/graph/DataTable.test.tsx
+++ b/web/ui/react-app/src/pages/graph/DataTable.test.tsx
@@ -338,7 +338,7 @@ describe('DataTable', () => {
     const dataTableProps: DataTableProps = {
       data: {
         resultType: 'string',
-        result: 'string',
+        result: [1572098246.599, 'test'],
       },
       useLocalTime: false,
     };
@@ -346,7 +346,7 @@ describe('DataTable', () => {
     it('renders a string row', () => {
       const table = dataTable.find(Table);
       const rows = table.find('tr');
-      expect(rows.text()).toEqual('stringt');
+      expect(rows.text()).toEqual('stringtest');
     });
   });
 });

--- a/web/ui/react-app/src/pages/graph/DataTable.tsx
+++ b/web/ui/react-app/src/pages/graph/DataTable.tsx
@@ -24,7 +24,7 @@ export interface DataTableProps {
       }
     | {
         resultType: 'string';
-        result: string;
+        result: SampleValue;
       };
   useLocalTime: boolean;
 }

--- a/web/ui/react-app/src/pages/graph/GraphHeatmapHelpers.test.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHeatmapHelpers.test.ts
@@ -1,0 +1,27 @@
+import { isHeatmapData } from './GraphHeatmapHelpers';
+
+describe('GraphHeatmapHelpers', () => {
+  it('isHeatmapData should return false for a vector', () => {
+    const data = {
+      resultType: 'vector',
+      result: [
+        {
+          metric: {
+            __name__: 'my_gauge',
+            job: 'target',
+          },
+          value: [1703091180.683, '6'],
+        },
+      ],
+    };
+    expect(isHeatmapData(data)).toBe(false);
+  });
+
+  it('isHeatmapData should return false for scalar resultType', () => {
+    const data = {
+      resultType: 'scalar',
+      result: [1703091180.125, '1703091180.125'],
+    };
+    expect(isHeatmapData(data)).toBe(false);
+  });
+});

--- a/web/ui/react-app/src/pages/graph/GraphHeatmapHelpers.test.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHeatmapHelpers.test.ts
@@ -1,8 +1,23 @@
+import { DataTableProps } from './DataTable';
 import { isHeatmapData } from './GraphHeatmapHelpers';
 
 describe('GraphHeatmapHelpers', () => {
-  it('isHeatmapData should return false for a vector', () => {
-    const data = {
+  it('isHeatmapData should return false for scalar and string resultType', () => {
+    let data = {
+      resultType: 'scalar',
+      result: [1703091180.125, '1703091180.125'],
+    } as DataTableProps['data'];
+    expect(isHeatmapData(data)).toBe(false);
+
+    data = {
+      resultType: 'string',
+      result: [1704305680.332, '2504'],
+    } as DataTableProps['data'];
+    expect(isHeatmapData(data)).toBe(false);
+  });
+
+  it('isHeatmapData should return false for a vector and matrix if length < 2', () => {
+    let data = {
       resultType: 'vector',
       result: [
         {
@@ -13,15 +28,39 @@ describe('GraphHeatmapHelpers', () => {
           value: [1703091180.683, '6'],
         },
       ],
-    };
+    } as DataTableProps['data'];
+    expect(isHeatmapData(data)).toBe(false);
+
+    data = {
+      resultType: 'matrix',
+      result: [
+        {
+          metric: {},
+          values: [[1703091180.683, '6']],
+        },
+      ],
+    } as DataTableProps['data'];
     expect(isHeatmapData(data)).toBe(false);
   });
 
-  it('isHeatmapData should return false for scalar resultType', () => {
+  it('isHeatmapData should return true for valid heatmap data', () => {
     const data = {
-      resultType: 'scalar',
-      result: [1703091180.125, '1703091180.125'],
-    };
-    expect(isHeatmapData(data)).toBe(false);
+      resultType: 'matrix',
+      result: [
+        {
+          metric: {
+            le: '100',
+          },
+          values: [[1703091180.683, '6']],
+        },
+        {
+          metric: {
+            le: '1000',
+          },
+          values: [[1703091190.683, '6.1']],
+        },
+      ],
+    } as DataTableProps['data'];
+    expect(isHeatmapData(data)).toBe(true);
   });
 });

--- a/web/ui/react-app/src/pages/graph/GraphHeatmapHelpers.ts
+++ b/web/ui/react-app/src/pages/graph/GraphHeatmapHelpers.ts
@@ -1,10 +1,12 @@
+import { DataTableProps } from './DataTable';
 import { GraphProps, GraphSeries } from './Graph';
 
-export function isHeatmapData(data: GraphProps['data']) {
-  if (!data?.result?.length || data?.result?.length < 2) {
+export function isHeatmapData(data: DataTableProps['data']) {
+  if (data?.resultType === 'scalar' || data?.resultType === 'string' || !data?.result?.length || data?.result?.length < 2) {
     return false;
   }
-  const result = data.result;
+  // Type assertion to prevent TS2349 error.
+  const result = data.result as GraphProps['data']['result'];
   const firstLabels = Object.keys(result[0].metric).filter((label) => label !== 'le');
   return result.every(({ metric }) => {
     const labels = Object.keys(metric).filter((label) => label !== 'le');


### PR DESCRIPTION
**Description:**
This PR fixes an edge case when handling scalar and string data in the `isHeatmapData` function.

Incidentally, another minor issue on the type of `DataTableProps['data']` (specifically for resultType == 'string') was discovered and fixed (picture attached below). 

Fixes #13292.

---

From here, it can be seen that for resultType == 'string', the type of `result` is not a string, but rather `SampleValue` (which is `[number, string]`)

<img width="869" alt="Screen Shot 2024-01-04 at 02 17 45" src="https://github.com/prometheus/prometheus/assets/69668484/bb8c5acd-7c89-4dd6-ad8f-39744e55db02">
