### PR TITLE
fix slice copy in 1.20

### DIFF
--- a/model/histogram/generic_test.go
+++ b/model/histogram/generic_test.go
@@ -17,9 +17,8 @@ import (
 	"math"
 	"testing"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 )
 
 func TestGetBound(t *testing.T) {

--- a/model/histogram/generic_test.go
+++ b/model/histogram/generic_test.go
@@ -15,7 +15,6 @@ package histogram
 
 import (
 	"math"
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -141,7 +140,10 @@ func TestReduceResolutionHistogram(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		spansCopy, bucketsCopy := slices.Clone(tc.spans), slices.Clone(tc.buckets)
+		spansCopy := make([]Span, len(tc.spans))
+		bucketsCopy := make([]int64, len(tc.buckets))
+		copy(spansCopy, tc.spans)
+		copy(bucketsCopy, tc.buckets)
 		spans, buckets := reduceResolution(tc.spans, tc.buckets, tc.schema, tc.targetSchema, true, false)
 		require.Equal(t, tc.expectedSpans, spans)
 		require.Equal(t, tc.expectedBuckets, buckets)
@@ -189,7 +191,10 @@ func TestReduceResolutionFloatHistogram(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		spansCopy, bucketsCopy := slices.Clone(tc.spans), slices.Clone(tc.buckets)
+		spansCopy := make([]Span, len(tc.spans))
+		bucketsCopy := make([]float64, len(tc.buckets))
+		copy(spansCopy, tc.spans)
+		copy(bucketsCopy, tc.buckets)
 		spans, buckets := reduceResolution(tc.spans, tc.buckets, tc.schema, tc.targetSchema, false, false)
 		require.Equal(t, tc.expectedSpans, spans)
 		require.Equal(t, tc.expectedBuckets, buckets)

--- a/model/histogram/generic_test.go
+++ b/model/histogram/generic_test.go
@@ -17,6 +17,8 @@ import (
 	"math"
 	"testing"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -140,10 +142,7 @@ func TestReduceResolutionHistogram(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		spansCopy := make([]Span, len(tc.spans))
-		bucketsCopy := make([]int64, len(tc.buckets))
-		copy(spansCopy, tc.spans)
-		copy(bucketsCopy, tc.buckets)
+		spansCopy, bucketsCopy := slices.Clone(tc.spans), slices.Clone(tc.buckets)
 		spans, buckets := reduceResolution(tc.spans, tc.buckets, tc.schema, tc.targetSchema, true, false)
 		require.Equal(t, tc.expectedSpans, spans)
 		require.Equal(t, tc.expectedBuckets, buckets)
@@ -191,10 +190,7 @@ func TestReduceResolutionFloatHistogram(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		spansCopy := make([]Span, len(tc.spans))
-		bucketsCopy := make([]float64, len(tc.buckets))
-		copy(spansCopy, tc.spans)
-		copy(bucketsCopy, tc.buckets)
+		spansCopy, bucketsCopy := slices.Clone(tc.spans), slices.Clone(tc.buckets)
 		spans, buckets := reduceResolution(tc.spans, tc.buckets, tc.schema, tc.targetSchema, false, false)
 		require.Equal(t, tc.expectedSpans, spans)
 		require.Equal(t, tc.expectedBuckets, buckets)


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
the Slices package is  added  in Go 1.21. so  `Compilation failed` is  caused by  importing  package slices  in 1.20