### PR TITLE
Add warnings for histogramRate applied with isCounter not matching counter/gauge histogram

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -469,8 +469,8 @@ func (h *FloatHistogram) DetectReset(previous *FloatHistogram) bool {
 	// is a counter reset or not.
 	// We do the same if the CounterResetHint is GaugeType, which should not happen, but PromQL still
 	// allows the user to apply functions to gauge histograms that are only meant for counter histograms.
-	// In this case, we treat the gauge histograms as a counter histograms
-	// (and we plan to return a warning about it to the user).
+	// In this case, we treat the gauge histograms as counter histograms and return a warning about it to
+	// the user. (This only happens with histogramRate as this function isn't really used outside of that.)
 	if h.Count < previous.Count {
 		return true
 	}

--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -469,8 +469,8 @@ func (h *FloatHistogram) DetectReset(previous *FloatHistogram) bool {
 	// is a counter reset or not.
 	// We do the same if the CounterResetHint is GaugeType, which should not happen, but PromQL still
 	// allows the user to apply functions to gauge histograms that are only meant for counter histograms.
-	// In this case, we treat the gauge histograms as counter histograms and return a warning about it to
-	// the user. (This only happens with histogramRate as this function isn't really used outside of that.)
+	// In this case, we treat the gauge histograms as counter histograms. A warning should be returned
+	// to the user in this case.
 	if h.Count < previous.Count {
 		return true
 	}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -202,7 +202,7 @@ func histogramRate(points []HPoint, isCounter bool, metricName string, pos posra
 			continue
 		}
 		if curr.CounterResetHint == histogram.GaugeType {
-			annos.Add(annotations.NewCounterHistogramRateOnGaugeHistogramWarning(metricName, pos))
+			annos.Add(annotations.NewNativeHistogramNotCounterWarning(metricName, pos))
 		}
 		if curr.Schema < minSchema {
 			minSchema = curr.Schema
@@ -222,7 +222,7 @@ func histogramRate(points []HPoint, isCounter bool, metricName string, pos posra
 			prev = curr
 		}
 	} else if points[0].H.CounterResetHint != histogram.GaugeType || points[len(points)-1].H.CounterResetHint != histogram.GaugeType {
-		annos.Add(annotations.NewGaugeHistogramRateOnCounterHistogramWarning(metricName, pos))
+		annos.Add(annotations.NewNativeHistogramNotGaugeWarning(metricName, pos))
 	}
 
 	h.CounterResetHint = histogram.GaugeType

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -103,10 +103,12 @@ var (
 	PromQLInfo    = errors.New("PromQL info")
 	PromQLWarning = errors.New("PromQL warning")
 
-	InvalidQuantileWarning              = fmt.Errorf("%w: quantile value should be between 0 and 1", PromQLWarning)
-	BadBucketLabelWarning               = fmt.Errorf("%w: bucket label %q is missing or has a malformed value", PromQLWarning, model.BucketLabel)
-	MixedFloatsHistogramsWarning        = fmt.Errorf("%w: encountered a mix of histograms and floats for metric name", PromQLWarning)
-	MixedClassicNativeHistogramsWarning = fmt.Errorf("%w: vector contains a mix of classic and native histograms for metric name", PromQLWarning)
+	InvalidQuantileWarning                      = fmt.Errorf("%w: quantile value should be between 0 and 1", PromQLWarning)
+	BadBucketLabelWarning                       = fmt.Errorf("%w: bucket label %q is missing or has a malformed value", PromQLWarning, model.BucketLabel)
+	MixedFloatsHistogramsWarning                = fmt.Errorf("%w: encountered a mix of histograms and floats for metric name", PromQLWarning)
+	MixedClassicNativeHistogramsWarning         = fmt.Errorf("%w: vector contains a mix of classic and native histograms for metric name", PromQLWarning)
+	CounterHistogramRateOnGaugeHistogramWarning = fmt.Errorf("%w: the counter version of histogramRate is applied on a gauge histogram", PromQLWarning)
+	GaugeHistogramRateOnCounterHistogramWarning = fmt.Errorf("%w: the gauge version of histogramRate is applied on a counter histogram", PromQLWarning)
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
@@ -163,6 +165,24 @@ func NewMixedClassicNativeHistogramsWarning(metricName string, pos posrange.Posi
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q", MixedClassicNativeHistogramsWarning, metricName),
+	}
+}
+
+// NewCounterHistogramRateOnGaugeHistogramWarning is used when histogramRate is called
+// with isCounter set to true on a gauge histogram.
+func NewCounterHistogramRateOnGaugeHistogramWarning(metricName string, pos posrange.PositionRange) error {
+	return annoErr{
+		PositionRange: pos,
+		Err:           fmt.Errorf("%w %q", CounterHistogramRateOnGaugeHistogramWarning, metricName),
+	}
+}
+
+// NewGaugeHistogramRateOnCounterHistogramWarning is used when histogramRate is called
+// with isCounter set to false on a counter histogram.
+func NewGaugeHistogramRateOnCounterHistogramWarning(metricName string, pos posrange.PositionRange) error {
+	return annoErr{
+		PositionRange: pos,
+		Err:           fmt.Errorf("%w %q", GaugeHistogramRateOnCounterHistogramWarning, metricName),
 	}
 }
 

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -103,12 +103,12 @@ var (
 	PromQLInfo    = errors.New("PromQL info")
 	PromQLWarning = errors.New("PromQL warning")
 
-	InvalidQuantileWarning                      = fmt.Errorf("%w: quantile value should be between 0 and 1", PromQLWarning)
-	BadBucketLabelWarning                       = fmt.Errorf("%w: bucket label %q is missing or has a malformed value", PromQLWarning, model.BucketLabel)
-	MixedFloatsHistogramsWarning                = fmt.Errorf("%w: encountered a mix of histograms and floats for metric name", PromQLWarning)
-	MixedClassicNativeHistogramsWarning         = fmt.Errorf("%w: vector contains a mix of classic and native histograms for metric name", PromQLWarning)
-	CounterHistogramRateOnGaugeHistogramWarning = fmt.Errorf("%w: the counter version of histogramRate is applied on a gauge histogram", PromQLWarning)
-	GaugeHistogramRateOnCounterHistogramWarning = fmt.Errorf("%w: the gauge version of histogramRate is applied on a counter histogram", PromQLWarning)
+	InvalidQuantileWarning              = fmt.Errorf("%w: quantile value should be between 0 and 1", PromQLWarning)
+	BadBucketLabelWarning               = fmt.Errorf("%w: bucket label %q is missing or has a malformed value", PromQLWarning, model.BucketLabel)
+	MixedFloatsHistogramsWarning        = fmt.Errorf("%w: encountered a mix of histograms and floats for metric name", PromQLWarning)
+	MixedClassicNativeHistogramsWarning = fmt.Errorf("%w: vector contains a mix of classic and native histograms for metric name", PromQLWarning)
+	NativeHistogramNotCounterWarning    = fmt.Errorf("%w: this native histogram metric is not a counter:", PromQLWarning)
+	NativeHistogramNotGaugeWarning      = fmt.Errorf("%w: this native histogram metric is not a gauge:", PromQLWarning)
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
@@ -168,21 +168,21 @@ func NewMixedClassicNativeHistogramsWarning(metricName string, pos posrange.Posi
 	}
 }
 
-// NewCounterHistogramRateOnGaugeHistogramWarning is used when histogramRate is called
+// NewNativeHistogramNotCounterWarning is used when histogramRate is called
 // with isCounter set to true on a gauge histogram.
-func NewCounterHistogramRateOnGaugeHistogramWarning(metricName string, pos posrange.PositionRange) error {
+func NewNativeHistogramNotCounterWarning(metricName string, pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
-		Err:           fmt.Errorf("%w %q", CounterHistogramRateOnGaugeHistogramWarning, metricName),
+		Err:           fmt.Errorf("%w %q", NativeHistogramNotCounterWarning, metricName),
 	}
 }
 
-// NewGaugeHistogramRateOnCounterHistogramWarning is used when histogramRate is called
+// NewNativeHistogramNotGaugeWarning is used when histogramRate is called
 // with isCounter set to false on a counter histogram.
-func NewGaugeHistogramRateOnCounterHistogramWarning(metricName string, pos posrange.PositionRange) error {
+func NewNativeHistogramNotGaugeWarning(metricName string, pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
-		Err:           fmt.Errorf("%w %q", GaugeHistogramRateOnCounterHistogramWarning, metricName),
+		Err:           fmt.Errorf("%w %q", NativeHistogramNotGaugeWarning, metricName),
 	}
 }
 


### PR DESCRIPTION
Addresses https://github.com/prometheus/prometheus/issues/13345

Adds a warning without modifying current behaviour (doesn't exit early and return empty data).

@beorn7 DetectReset is only used in histogramRate and in the function `resets`. Since the latter function is directly detecting resets, do you think we need a warning if it's applied to a gauge histogram?