### PR TITLE
remove  obsolete build tag

### DIFF
--- a/cmd/prometheus/main_unix_test.go
+++ b/cmd/prometheus/main_unix_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 //
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/config/config_default_test.go
+++ b/config/config_default_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package config
 

--- a/plugins/generate.go
+++ b/plugins/generate.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build plugins
-// +build plugins
 
 package main
 

--- a/promql/fuzz.go
+++ b/promql/fuzz.go
@@ -13,7 +13,6 @@
 
 // Only build when go-fuzz is in use
 //go:build gofuzz
-// +build gofuzz
 
 package promql
 

--- a/promql/fuzz_test.go
+++ b/promql/fuzz_test.go
@@ -13,7 +13,6 @@
 
 // Only build when go-fuzz is in use
 //go:build gofuzz
-// +build gofuzz
 
 package promql
 

--- a/scripts/tools.go
+++ b/scripts/tools.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build tools
-// +build tools
 
 // Package tools tracks dependencies for tools that are required to generate the protobuf code.
 // See https://github.com/golang/go/issues/25922

--- a/tsdb/chunks/head_chunks_other.go
+++ b/tsdb/chunks/head_chunks_other.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package chunks
 

--- a/tsdb/fileutil/dir_unix.go
+++ b/tsdb/fileutil/dir_unix.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package fileutil
 

--- a/tsdb/fileutil/dir_windows.go
+++ b/tsdb/fileutil/dir_windows.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package fileutil
 

--- a/tsdb/fileutil/flock_js.go
+++ b/tsdb/fileutil/flock_js.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build js
-// +build js
 
 package fileutil
 

--- a/tsdb/fileutil/flock_solaris.go
+++ b/tsdb/fileutil/flock_solaris.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build solaris
-// +build solaris
 
 package fileutil
 

--- a/tsdb/fileutil/flock_unix.go
+++ b/tsdb/fileutil/flock_unix.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
 
 package fileutil
 

--- a/tsdb/fileutil/mmap_386.go
+++ b/tsdb/fileutil/mmap_386.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package fileutil
 

--- a/tsdb/fileutil/mmap_amd64.go
+++ b/tsdb/fileutil/mmap_amd64.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package fileutil
 

--- a/tsdb/fileutil/mmap_arm64.go
+++ b/tsdb/fileutil/mmap_arm64.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package fileutil
 

--- a/tsdb/fileutil/mmap_js.go
+++ b/tsdb/fileutil/mmap_js.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build js
-// +build js
 
 package fileutil
 

--- a/tsdb/fileutil/mmap_unix.go
+++ b/tsdb/fileutil/mmap_unix.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows && !plan9 && !js
-// +build !windows,!plan9,!js
 
 package fileutil
 

--- a/tsdb/fileutil/preallocate_other.go
+++ b/tsdb/fileutil/preallocate_other.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !linux && !darwin
-// +build !linux,!darwin
 
 package fileutil
 

--- a/tsdb/fileutil/sync.go
+++ b/tsdb/fileutil/sync.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !linux && !darwin
-// +build !linux,!darwin
 
 package fileutil
 

--- a/tsdb/fileutil/sync_darwin.go
+++ b/tsdb/fileutil/sync_darwin.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build darwin
-// +build darwin
 
 package fileutil
 

--- a/tsdb/fileutil/sync_linux.go
+++ b/tsdb/fileutil/sync_linux.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build linux
-// +build linux
 
 package fileutil
 

--- a/tsdb/goversion/goversion.go
+++ b/tsdb/goversion/goversion.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build go1.12
-// +build go1.12
 
 // Package goversion enforces the go version supported by the tsdb module.
 package goversion

--- a/tsdb/wal_test.go
+++ b/tsdb/wal_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package tsdb
 

--- a/util/runtime/limits_default.go
+++ b/util/runtime/limits_default.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package runtime
 

--- a/util/runtime/limits_windows.go
+++ b/util/runtime/limits_windows.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package runtime
 

--- a/util/runtime/statfs.go
+++ b/util/runtime/statfs.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build openbsd || windows || netbsd || solaris
-// +build openbsd windows netbsd solaris
 
 package runtime
 

--- a/util/runtime/statfs_default.go
+++ b/util/runtime/statfs_default.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows && !openbsd && !netbsd && !solaris && !386
-// +build !windows,!openbsd,!netbsd,!solaris,!386
 
 package runtime
 

--- a/util/runtime/statfs_linux_386.go
+++ b/util/runtime/statfs_linux_386.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build linux && 386
-// +build linux,386
 
 package runtime
 

--- a/util/runtime/statfs_uint32.go
+++ b/util/runtime/statfs_uint32.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build (386 && darwin) || (386 && freebsd)
-// +build 386,darwin 386,freebsd
 
 package runtime
 

--- a/util/runtime/uname_default.go
+++ b/util/runtime/uname_default.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !linux
-// +build !linux
 
 package runtime
 

--- a/util/runtime/vmlimits_default.go
+++ b/util/runtime/vmlimits_default.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !windows && !openbsd
-// +build !windows,!openbsd
 
 package runtime
 

--- a/util/runtime/vmlimits_openbsd.go
+++ b/util/runtime/vmlimits_openbsd.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build openbsd
-// +build openbsd
 
 package runtime
 

--- a/web/ui/assets_embed.go
+++ b/web/ui/assets_embed.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build builtinassets
-// +build builtinassets
 
 package ui
 

--- a/web/ui/ui.go
+++ b/web/ui/ui.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !builtinassets
-// +build !builtinassets
 
 package ui
 


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
`//go:build` has been introduced in  `go 1.18` and  the obsolete `// +build` lines  has been  removed  in modules declaring `go 1.18 or later` in their go.mod files.
i dont  think  it is  nessasary  that  prometheus support the  obsolete build tags(at 1.17 or lower)