### PR TITLE
discovery/kubernetes: fix selectors validation for role pod

### DIFF
--- a/config/testdata/kubernetes_selectors_pod.good.yml
+++ b/config/testdata/kubernetes_selectors_pod.good.yml
@@ -7,7 +7,9 @@ scrape_configs:
             label: "foo=bar"
             field: "metadata.status=Running"
       - role: pod
+        attach_metadata:
+          node: true
         selectors:
-          - role: "pod"
-            label: "foo in (bar,baz)"
+          - role: "node"
+            label: "foo=bar"
             field: "metadata.status=Running"

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -222,6 +222,10 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				break
 			}
 		}
+		// The pod role supports node selectors when configured with `attach_metadata: {node: true}`.
+		if !allowed && selector.Role == RoleNode && c.Role == RolePod && c.AttachMetadata.Node {
+			allowed = true
+		}
 
 		if !allowed {
 			return fmt.Errorf("%s role supports only %s selectors", c.Role, strings.Join(allowedSelectors[c.Role], ", "))


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

According to the [doc](https://prometheus.io/docs/prometheus/latest/configuration/configuration/)
> The pod role supports node selectors when configured with `attach_metadata: {node: true}`. 

and the code
https://github.com/prometheus/prometheus/blob/bfbb13cf369da4cd1b29ee52c396c902723febfb/discovery/kubernetes/kubernetes.go#L583-L588 
`node` selector can be used for `role: pod`