### PR TITLE
storage: skip merging when no remote storage configured

### DIFF
--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -89,7 +89,9 @@ func (f *fanout) Querier(mint, maxt int64) (Querier, error) {
 			}
 			return nil, errs.Err()
 		}
-		secondaries = append(secondaries, querier)
+		if _, ok := querier.(noopQuerier); !ok {
+			secondaries = append(secondaries, querier)
+		}
 	}
 	return NewMergeQuerier([]Querier{primary}, secondaries, ChainedSeriesMerge), nil
 }

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -46,6 +46,9 @@ type mergeGenericQuerier struct {
 //
 // In case of overlaps between the data given by primaries' and secondaries' Selects, merge function will be used.
 func NewMergeQuerier(primaries, secondaries []Querier, mergeFn VerticalSeriesMergeFunc) Querier {
+	if len(primaries)+len(secondaries) == 0 {
+		return NoopQuerier()
+	}
 	queriers := make([]genericQuerier, 0, len(primaries)+len(secondaries))
 	for _, q := range primaries {
 		if _, ok := q.(noopQuerier); !ok && q != nil {


### PR DESCRIPTION
Prometheus is hard-coded to use a fanout storage between TSDB and a remote storage which by default is empty.
This change detects the empty storage and skips merging between result sets, which would make `Select()` sort results.

Bottom line: we skip a sort unless there really is some remote storage configured.
