### PR TITLE
Labels: Add DropMetricName function, used in PromQL

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -342,6 +342,19 @@ func (ls Labels) Validate(f func(l Label) error) error {
 	return nil
 }
 
+// DropMetricName returns Labels with "__name__" removed.
+func (ls Labels) DropMetricName() Labels {
+	for i, l := range ls {
+		if l.Name == MetricName {
+			if i == 0 { // Make common case fast with no allocations.
+				return ls[1:]
+			}
+			return append(ls[:i], ls[i+1:]...)
+		}
+	}
+	return ls
+}
+
 // InternStrings calls intern on every string value inside ls, replacing them with what it returns.
 func (ls *Labels) InternStrings(intern func(string) string) {
 	for i, l := range *ls {

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -429,6 +429,27 @@ func (ls Labels) Validate(f func(l Label) error) error {
 	return nil
 }
 
+// DropMetricName returns Labels with "__name__" removed.
+func (ls Labels) DropMetricName() Labels {
+	for i := 0; i < len(ls.data); {
+		lName, i2 := decodeString(ls.data, i)
+		size, i2 := decodeSize(ls.data, i2)
+		i2 += size
+		if lName == MetricName {
+			if i == 0 { // Make common case fast with no allocations.
+				ls.data = ls.data[i2:]
+			} else {
+				ls.data = ls.data[:i] + ls.data[i2:]
+			}
+			break
+		} else if lName[0] > MetricName[0] { // Stop looking if we've gone past.
+			break
+		}
+		i = i2
+	}
+	return ls
+}
+
 // InternStrings calls intern on every string value inside ls, replacing them with what it returns.
 func (ls *Labels) InternStrings(intern func(string) string) {
 	ls.data = intern(ls.data)

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -447,6 +447,12 @@ func TestLabels_Get(t *testing.T) {
 	require.Equal(t, "222", FromStrings("aaaa", "111", "bbb", "222").Get("bbb"))
 }
 
+func TestLabels_DropMetricName(t *testing.T) {
+	require.True(t, Equal(FromStrings("aaa", "111", "bbb", "222"), FromStrings("aaa", "111", "bbb", "222").DropMetricName()))
+	require.True(t, Equal(FromStrings("aaa", "111"), FromStrings(MetricName, "myname", "aaa", "111").DropMetricName()))
+	require.True(t, Equal(FromStrings("__aaa__", "111", "bbb", "222"), FromStrings("__aaa__", "111", MetricName, "myname", "bbb", "222").DropMetricName()))
+}
+
 // BenchmarkLabels_Get was written to check whether a binary search can improve the performance vs the linear search implementation
 // The results have shown that binary search would only be better when searching last labels in scenarios with more than 10 labels.
 // In the following list, `old` is the linear search while `new` is the binary search implementation (without calling sort.Search, which performs even worse here)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1073,7 +1073,7 @@ type EvalNodeHelper struct {
 	Out Vector
 
 	// Caches.
-	// DropMetricName and label_*.
+	// label_*.
 	Dmn map[uint64]labels.Labels
 	// funcHistogramQuantile for classic histograms.
 	signatureToMetricWithBuckets map[string]*metricWithBuckets
@@ -1096,21 +1096,6 @@ func (enh *EvalNodeHelper) resetBuilder(lbls labels.Labels) {
 	} else {
 		enh.lb.Reset(lbls)
 	}
-}
-
-// DropMetricName is a cached version of DropMetricName.
-func (enh *EvalNodeHelper) DropMetricName(l labels.Labels) labels.Labels {
-	if enh.Dmn == nil {
-		enh.Dmn = make(map[uint64]labels.Labels, len(enh.Out))
-	}
-	h := l.Hash()
-	ret, ok := enh.Dmn[h]
-	if ok {
-		return ret
-	}
-	ret = dropMetricName(l)
-	enh.Dmn[h] = ret
-	return ret
 }
 
 // rangeEval evaluates the given expressions, and then for each step calls
@@ -1489,7 +1474,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 			// vector functions, the only change needed is to drop the
 			// metric name in the output.
 			if e.Func.Name != "last_over_time" {
-				metric = dropMetricName(metric)
+				metric = metric.DropMetricName()
 			}
 			ss := Series{
 				Metric: metric,
@@ -1621,7 +1606,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 		mat := val.(Matrix)
 		if e.Op == parser.SUB {
 			for i := range mat {
-				mat[i].Metric = dropMetricName(mat[i].Metric)
+				mat[i].Metric = mat[i].Metric.DropMetricName()
 				for j := range mat[i].Floats {
 					mat[i].Floats[j].F = -mat[i].Floats[j].F
 				}
@@ -2341,7 +2326,7 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 		}
 		metric := resultMetric(ls.Metric, rs.Metric, op, matching, enh)
 		if returnBool {
-			metric = enh.DropMetricName(metric)
+			metric = metric.DropMetricName()
 		}
 		insertedSigs, exists := matchedSigs[sig]
 		if matching.Card == parser.CardOneToOne {
@@ -2463,16 +2448,12 @@ func (ev *evaluator) VectorscalarBinop(op parser.ItemType, lhs Vector, rhs Scala
 			lhsSample.F = float
 			lhsSample.H = histogram
 			if shouldDropMetricName(op) || returnBool {
-				lhsSample.Metric = enh.DropMetricName(lhsSample.Metric)
+				lhsSample.Metric = lhsSample.Metric.DropMetricName()
 			}
 			enh.Out = append(enh.Out, lhsSample)
 		}
 	}
 	return enh.Out
-}
-
-func dropMetricName(l labels.Labels) labels.Labels {
-	return labels.NewBuilder(l).Del(labels.MetricName).Labels()
 }
 
 // scalarBinop evaluates a binary operation between two Scalars.

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -445,7 +445,7 @@ func funcClamp(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 	}
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(el.Metric),
+			Metric: el.Metric.DropMetricName(),
 			F:      math.Max(min, math.Min(max, el.F)),
 		})
 	}
@@ -458,7 +458,7 @@ func funcClampMax(vals []parser.Value, args parser.Expressions, enh *EvalNodeHel
 	max := vals[1].(Vector)[0].F
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(el.Metric),
+			Metric: el.Metric.DropMetricName(),
 			F:      math.Min(max, el.F),
 		})
 	}
@@ -471,7 +471,7 @@ func funcClampMin(vals []parser.Value, args parser.Expressions, enh *EvalNodeHel
 	min := vals[1].(Vector)[0].F
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(el.Metric),
+			Metric: el.Metric.DropMetricName(),
 			F:      math.Max(min, el.F),
 		})
 	}
@@ -493,7 +493,7 @@ func funcRound(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 	for _, el := range vec {
 		f := math.Floor(el.F*toNearestInverse+0.5) / toNearestInverse
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(el.Metric),
+			Metric: el.Metric.DropMetricName(),
 			F:      f,
 		})
 	}
@@ -797,7 +797,7 @@ func simpleFunc(vals []parser.Value, enh *EvalNodeHelper, f func(float64) float6
 	for _, el := range vals[0].(Vector) {
 		if el.H == nil { // Process only float samples.
 			enh.Out = append(enh.Out, Sample{
-				Metric: enh.DropMetricName(el.Metric),
+				Metric: el.Metric.DropMetricName(),
 				F:      f(el.F),
 			})
 		}
@@ -943,7 +943,7 @@ func funcTimestamp(vals []parser.Value, args parser.Expressions, enh *EvalNodeHe
 	vec := vals[0].(Vector)
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(el.Metric),
+			Metric: el.Metric.DropMetricName(),
 			F:      float64(el.T) / 1000,
 		})
 	}
@@ -1057,7 +1057,7 @@ func funcHistogramCount(vals []parser.Value, args parser.Expressions, enh *EvalN
 			continue
 		}
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(sample.Metric),
+			Metric: sample.Metric.DropMetricName(),
 			F:      sample.H.Count,
 		})
 	}
@@ -1074,7 +1074,7 @@ func funcHistogramSum(vals []parser.Value, args parser.Expressions, enh *EvalNod
 			continue
 		}
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(sample.Metric),
+			Metric: sample.Metric.DropMetricName(),
 			F:      sample.H.Sum,
 		})
 	}
@@ -1107,7 +1107,7 @@ func funcHistogramStdDev(vals []parser.Value, args parser.Expressions, enh *Eval
 		variance += cVariance
 		variance /= sample.H.Count
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(sample.Metric),
+			Metric: sample.Metric.DropMetricName(),
 			F:      math.Sqrt(variance),
 		})
 	}
@@ -1140,7 +1140,7 @@ func funcHistogramStdVar(vals []parser.Value, args parser.Expressions, enh *Eval
 		variance += cVariance
 		variance /= sample.H.Count
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(sample.Metric),
+			Metric: sample.Metric.DropMetricName(),
 			F:      variance,
 		})
 	}
@@ -1159,7 +1159,7 @@ func funcHistogramFraction(vals []parser.Value, args parser.Expressions, enh *Ev
 			continue
 		}
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(sample.Metric),
+			Metric: sample.Metric.DropMetricName(),
 			F:      histogramFraction(lower, upper, sample.H),
 		})
 	}
@@ -1230,7 +1230,7 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 		}
 
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(sample.Metric),
+			Metric: sample.Metric.DropMetricName(),
 			F:      histogramQuantile(q, sample.H),
 		})
 	}
@@ -1440,7 +1440,7 @@ func dateWrapper(vals []parser.Value, enh *EvalNodeHelper, f func(time.Time) flo
 	for _, el := range vals[0].(Vector) {
 		t := time.Unix(int64(el.F), 0).UTC()
 		enh.Out = append(enh.Out, Sample{
-			Metric: enh.DropMetricName(el.Metric),
+			Metric: el.Metric.DropMetricName(),
 			F:      f(t),
 		})
 	}


### PR DESCRIPTION
This function is called very frequently when executing PromQL functions, and we can do it much more efficiently inside Labels.

In the common case that `__name__` comes first in the labels, we simply re-point to start at the next label, which is nearly free.

`DropMetricName` is now so cheap I removed the cache - benchmarks show everything still goes faster.

<details><summary>Benchmarks</summary>
<p>

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/promql
                                                                              │  before.txt  │             after.txt              │
                                                                              │    sec/op    │   sec/op     vs base               │
RangeQuery/expr=a_hundred,steps=100-8                                            487.7µ ± 0%   487.2µ ± 1%        ~ (p=1.000 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                  1.028m ± 1%   1.027m ± 2%        ~ (p=0.937 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                562.0m ± 1%   548.8m ± 3%   -2.35% (p=0.041 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                               97.80m ± 1%   97.49m ± 1%        ~ (p=0.699 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                  75.48m ± 1%   75.43m ± 2%        ~ (p=0.937 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                      44.87m ± 0%   45.07m ± 2%        ~ (p=0.485 n=6)
RangeQuery/expr=-a_hundred,steps=100-8                                           502.1µ ± 0%   495.1µ ± 0%   -1.39% (p=0.002 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                3.045m ± 2%   3.062m ± 1%        ~ (p=0.394 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8               1.588m ± 1%   1.593m ± 0%        ~ (p=0.240 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                1.923m ± 1%   1.935m ± 0%        ~ (p=0.065 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8            1.593m ± 3%   1.598m ± 1%        ~ (p=0.394 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                548.9µ ± 3%   552.6µ ± 1%        ~ (p=0.132 n=6)
RangeQuery/expr=abs(a_hundred),steps=100-8                                      1139.3µ ± 0%   949.8µ ± 1%  -16.63% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8    1.170m ± 0%   1.174m ± 0%        ~ (p=0.589 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8           1.207m ± 1%   1.209m ± 1%        ~ (p=0.485 n=6)
RangeQuery/expr=sum(a_hundred),steps=100-8                                       612.6µ ± 0%   615.9µ ± 1%   +0.54% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                           7.065m ± 6%   7.073m ± 1%        ~ (p=0.937 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                          9.132m ± 2%   9.150m ± 1%        ~ (p=0.937 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                                9.268m ± 5%   9.273m ± 0%        ~ (p=0.699 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                               7.036m ± 1%   7.086m ± 1%   +0.70% (p=0.041 n=6)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                     131.7m ± 0%   131.5m ± 1%        ~ (p=0.589 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=100-8                                   630.2µ ± 1%   634.4µ ± 0%   +0.66% (p=0.041 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=100-8                                   848.5µ ± 1%   844.9µ ± 1%        ~ (p=0.589 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8            4.031m ± 1%   4.017m ± 0%   -0.34% (p=0.015 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                 1.161m ± 0%   1.148m ± 1%   -1.09% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8         21.30m ± 1%   21.11m ± 2%        ~ (p=0.093 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8                  972.8µ ± 4%   962.8µ ± 0%        ~ (p=0.180 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=100-8                                1169.4µ ± 1%   960.6µ ± 1%  -17.86% (p=0.002 n=6)
geomean                                                                          3.759m        3.705m        -1.43%

                                                                              │  before.txt   │              after.txt              │
                                                                              │     B/op      │     B/op      vs base               │
RangeQuery/expr=a_hundred,steps=100-8                                            75.04Ki ± 0%   75.04Ki ± 0%        ~ (p=0.701 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                  126.1Ki ± 0%   100.3Ki ± 0%  -20.46% (p=0.002 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                3.514Mi ± 0%   3.487Mi ± 0%   -0.77% (p=0.002 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                               3.069Mi ± 1%   3.024Mi ± 1%        ~ (p=0.065 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                  3.050Mi ± 1%   3.041Mi ± 1%        ~ (p=0.699 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                      3.215Mi ± 1%   3.189Mi ± 1%   -0.79% (p=0.002 n=6)
RangeQuery/expr=-a_hundred,steps=100-8                                          104.43Ki ± 0%   78.62Ki ± 0%  -24.71% (p=0.002 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                288.3Ki ± 0%   288.3Ki ± 0%        ~ (p=0.485 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8               680.3Ki ± 0%   680.2Ki ± 0%        ~ (p=0.394 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                1.195Mi ± 0%   1.195Mi ± 0%        ~ (p=0.310 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8            680.3Ki ± 0%   680.3Ki ± 0%        ~ (p=0.853 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                127.6Ki ± 0%   127.6Ki ± 0%        ~ (p=0.851 n=6)
RangeQuery/expr=abs(a_hundred),steps=100-8                                       164.7Ki ± 0%   123.2Ki ± 0%  -25.20% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8    185.6Ki ± 0%   185.6Ki ± 0%        ~ (p=0.394 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8           186.3Ki ± 0%   186.3Ki ± 0%        ~ (p=0.937 n=6)
RangeQuery/expr=sum(a_hundred),steps=100-8                                       136.8Ki ± 0%   136.7Ki ± 0%        ~ (p=0.814 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                           1.368Mi ± 0%   1.368Mi ± 0%        ~ (p=0.818 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                          3.772Mi ± 0%   3.772Mi ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                                3.772Mi ± 0%   3.772Mi ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                               1.368Mi ± 0%   1.368Mi ± 0%        ~ (p=0.937 n=6)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                     97.78Mi ± 0%   97.78Mi ± 0%        ~ (p=0.937 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=100-8                                   142.5Ki ± 0%   142.5Ki ± 0%        ~ (p=0.165 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=100-8                                   181.4Ki ± 0%   181.4Ki ± 0%        ~ (p=0.418 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8            385.1Ki ± 0%   333.5Ki ± 0%  -13.42% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                 188.5Ki ± 0%   162.7Ki ± 0%  -13.69% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8         1.739Mi ± 0%   1.452Mi ± 0%  -16.47% (p=0.002 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8                  170.0Ki ± 0%   170.0Ki ± 0%        ~ (p=0.937 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=100-8                                 625.4Ki ± 0%   583.8Ki ± 0%   -6.64% (p=0.002 n=6)
geomean                                                                          625.2Ki        595.2Ki        -4.80%

                                                                              │ before.txt  │              after.txt               │
                                                                              │  allocs/op  │  allocs/op   vs base                 │
RangeQuery/expr=a_hundred,steps=100-8                                           1.199k ± 0%   1.199k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                 1.944k ± 0%   1.644k ± 0%  -15.43% (p=0.002 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8               37.39k ± 0%   37.08k ± 0%   -0.81% (p=0.002 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                              37.29k ± 0%   36.99k ± 0%   -0.81% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                 37.69k ± 0%   37.39k ± 0%   -0.79% (p=0.002 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                     37.38k ± 0%   37.08k ± 0%   -0.80% (p=0.002 n=6)
RangeQuery/expr=-a_hundred,steps=100-8                                          1.517k ± 0%   1.217k ± 0%  -19.78% (p=0.002 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                               2.997k ± 0%   2.997k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8              2.989k ± 0%   2.989k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8               3.149k ± 0%   3.149k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8           2.989k ± 0%   2.989k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8               1.568k ± 0%   1.568k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=abs(a_hundred),steps=100-8                                      1.644k ± 0%   1.334k ± 0%  -18.86% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8   2.462k ± 0%   2.462k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8          2.429k ± 0%   2.429k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=sum(a_hundred),steps=100-8                                      1.640k ± 0%   1.640k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                          15.15k ± 0%   15.15k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                         34.17k ± 0%   34.17k ± 0%        ~ (p=0.446 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                               34.17k ± 0%   34.17k ± 0%        ~ (p=0.994 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                              15.15k ± 0%   15.15k ± 0%        ~ (p=0.455 n=6)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                    574.3k ± 0%   574.3k ± 0%        ~ (p=0.502 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=100-8                                  1.763k ± 0%   1.763k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=topk(5,_a_hundred),steps=100-8                                  2.369k ± 0%   2.369k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8           4.481k ± 0%   3.881k ± 0%  -13.40% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                2.488k ± 0%   2.188k ± 0%  -12.06% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8        21.11k ± 0%   17.80k ± 0%  -15.64% (p=0.002 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8                 1.601k ± 0%   1.601k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=timestamp(a_hundred),steps=100-8                                2.245k ± 0%   1.935k ± 0%  -13.81% (p=0.002 n=6)
geomean                                                                         6.058k        5.800k        -4.26%
¹ all samples are equal
```

</p>
</details> 

Originally written as part of #12304.
