### PR TITLE
Change metric label for Puppet SD from 'http' to 'puppetdb'

### DIFF
--- a/discovery/puppetdb/puppetdb.go
+++ b/discovery/puppetdb/puppetdb.go
@@ -171,7 +171,7 @@ func NewDiscovery(conf *SDConfig, logger log.Logger, metrics discovery.Discovere
 	d.Discovery = refresh.NewDiscovery(
 		refresh.Options{
 			Logger:              logger,
-			Mech:                "http",
+			Mech:                "puppetdb",
 			Interval:            time.Duration(conf.RefreshInterval),
 			RefreshF:            d.refresh,
 			MetricsInstantiator: m.refreshMetrics,


### PR DESCRIPTION
I believe the metrics for the Puppet SD are not being recorded correctly. They seem to overlap with the metrics of HTTP SD, because Puppet SD uses the same `http` label.

Puppet SD has been using `http` since #8883, the pull request which originally added the Puppetdb SD.