### PR TITLE
Proposal to improve FPointSlice and HPointSlice allocation.

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -34,6 +34,10 @@ func setupRangeQueryTestData(stor *teststorage.TestStorage, _ *Engine, interval,
 	ctx := context.Background()
 
 	metrics := []labels.Labels{}
+	// Generating test series: a_X, b_X, and h_X, where X can take values of one, ten, or hundred,
+	// representing the number of series each metric name contains.
+	// Metric a_X and b_X are simple metrics where h_X is a histogram.
+	// These metrics will have data for all test time range
 	metrics = append(metrics, labels.FromStrings("__name__", "a_one"))
 	metrics = append(metrics, labels.FromStrings("__name__", "b_one"))
 	for j := 0; j < 10; j++ {
@@ -67,6 +71,9 @@ func setupRangeQueryTestData(stor *teststorage.TestStorage, _ *Engine, interval,
 			ref, _ := a.Append(refs[i], metric, ts, float64(s)+float64(i)/float64(len(metrics)))
 			refs[i] = ref
 		}
+		// Generating a sparse time series named "sparse" with multiple label values for the label "l".
+		// Each label value of "l" will contain data only for a subset of the test time range, resulting in sparse series.
+		// The "sparse" series differ from the previous series as the latter contain data for the entire test time range.
 		metric := labels.FromStrings("__name__", "sparse", "l", strconv.Itoa(s/(numIntervals/50)))
 		_, err := a.Append(0, metric, ts, float64(s)/float64(len(metrics)))
 		if err != nil {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1858,6 +1858,8 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 	panic(fmt.Errorf("unhandled expression of type: %T", expr))
 }
 
+// reuseOrGetFPointSlices reuses the space from previous slice to create new slice if the former has lots of room.
+// The previous slices capacity is adjusted so when it is re-used from the pool it doesn't overflow into the new one.
 func reuseOrGetHPointSlices(prevSS *Series, numSteps int) (r []HPoint) {
 	if prevSS != nil && cap(prevSS.Histograms)-2*len(prevSS.Histograms) > 0 {
 		r = prevSS.Histograms[len(prevSS.Histograms):]
@@ -1868,6 +1870,8 @@ func reuseOrGetHPointSlices(prevSS *Series, numSteps int) (r []HPoint) {
 	return getHPointSlice(numSteps)
 }
 
+// reuseOrGetFPointSlices reuses the space from previous slice to create new slice if the former has lots of room.
+// The previous slices capacity is adjusted so when it is re-used from the pool it doesn't overflow into the new one.
 func reuseOrGetFPointSlices(prevSS *Series, numSteps int) (r []FPoint) {
 	if prevSS != nil && cap(prevSS.Floats)-2*len(prevSS.Floats) > 0 {
 		r = prevSS.Floats[len(prevSS.Floats):]


### PR DESCRIPTION
This is a follow up/continuation of https://github.com/prometheus/prometheus/pull/12734

The previous PR improved but did not fix the problem. We can still have sparse series that the engine end up allocating points to all possible steps weather or not the series has samples to all steps.

 This PR is proposing to reuse the pointslice from the previous series if the slice was underutilized - if the remaining capacity is greater than the current length (ex: slice used on the previous series has capacity of 1000 but only 80 is used - In this case, we split the slice in 2 slices of 80 for the previous series and 920 for the current series)  **This will assure the capacity of the slices will never have more than 2 times the configured `maxSamples`**
 
I created a new metric on the benchmark - `QueryInMemoryBytes` - to illustrate the improvements - it compares the capacity of all slices in the result (in bytes).

The allocations dos not really change as the slices are coming from the pool but the total size of the pool should be reflected on the `QueryInMemoryBytes` metric.

```
Every 2.0s: go/bin/benchstat /tmp/old /tmp/new                                                                                                                                                                                                        Tue Jan 23 20:48:50 2024

goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
cpu: Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
                                                │   /tmp/old   │              /tmp/new              │
                                                │    sec/op    │    sec/op     vs base              │
RangeQuery/expr=rate(sparse[1m]),steps=10000-16   12.23m ± ∞ ¹   12.28m ± ∞ ¹  +0.45% (p=0.032 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

                                                │      /tmp/old      │                 /tmp/new           	   │
                                                │ QueryInMemoryBytes │ QueryInMemoryBytes  vs base          	 │
RangeQuery/expr=rate(sparse[1m]),steps=10000-16        2240.0k ± ∞ ¹         178.3k ± ∞ ¹  -92.04% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

                                                │   /tmp/old    │            /tmp/new            │
                                                │     B/op	│     B/op	 vs base         │
RangeQuery/expr=rate(sparse[1m]),steps=10000-16   55.85Ki ± ∞ ¹   54.98Ki ± ∞ ¹  ~ (p=0.548 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

                                                │  /tmp/old   │            /tmp/new            │
                                                │  allocs/op  │	 allocs/op   vs base           │
RangeQuery/expr=rate(sparse[1m]),steps=10000-16   821.0 ± ∞ ¹   821.0 ± ∞ ¹  ~ (p=1.000 n=5) ²
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
``` 
