### PR TITLE
ui: fix for deep linking in stacked graphs

### DIFF
--- a/web/ui/react-app/src/pages/graph/Panel.tsx
+++ b/web/ui/react-app/src/pages/graph/Panel.tsx
@@ -194,7 +194,8 @@ class Panel extends Component<PanelProps, PanelState> {
       }
 
       const isHeatmap = isHeatmapData(query.data);
-      if (!isHeatmap) {
+      const isHeatmapDisplayMode = this.props.options.displayMode === GraphDisplayMode.Heatmap;
+      if (!isHeatmap && isHeatmapDisplayMode) {
         this.setOptions({ displayMode: GraphDisplayMode.Lines });
       }
 


### PR DESCRIPTION
This PR resolves the issue described in #13445, specifically the problem of stacked graphs not maintaining their deep linked state in Prometheus.