### PR TITLE
otlptranslator/update-copy.sh: Fix sed command lines

### DIFF
--- a/storage/remote/otlptranslator/update-copy.sh
+++ b/storage/remote/otlptranslator/update-copy.sh
@@ -18,5 +18,5 @@ rm -rf ./prometheus/*_test.go
 
 rm -rf ./tmp
 
-sed -i '' 's#github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus#github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheus#g' ./prometheusremotewrite/*.go
-sed -i '' '1s#^#// DO NOT EDIT. COPIED AS-IS. SEE ../README.md\n\n#g' ./prometheusremotewrite/*.go ./prometheus/*.go
+sed -i 's#github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus#github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheus#g' ./prometheusremotewrite/*.go
+sed -i '1s#^#// DO NOT EDIT. COPIED AS-IS. SEE ../README.md\n\n#g' ./prometheusremotewrite/*.go ./prometheus/*.go

--- a/storage/remote/otlptranslator/update-copy.sh
+++ b/storage/remote/otlptranslator/update-copy.sh
@@ -18,5 +18,10 @@ rm -rf ./prometheus/*_test.go
 
 rm -rf ./tmp
 
-sed -i 's#github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus#github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheus#g' ./prometheusremotewrite/*.go
-sed -i '1s#^#// DO NOT EDIT. COPIED AS-IS. SEE ../README.md\n\n#g' ./prometheusremotewrite/*.go ./prometheus/*.go
+case $(sed --help 2>&1) in
+  *GNU*) set sed -i;;
+  *)     set sed -i '';;
+esac
+
+"$@" -e 's#github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus#github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheus#g' ./prometheusremotewrite/*.go
+"$@" -e '1s#^#// DO NOT EDIT. COPIED AS-IS. SEE ../README.md\n\n#g' ./prometheusremotewrite/*.go ./prometheus/*.go


### PR DESCRIPTION
I realized that the `sed` command lines in `storage/remote/otlptranslator/update-copy.sh` are non-standard, at least they won't work with GNU sed. The reason being the initial empty argument (`''`), which might be for the OSX version of sed?

I propose we remove the initial empty argument, to make this script work with GNU sed. I tested my changes locally, and they work (i.e. the copied files don't change versus main).