### PR TITLE
api: Serialize discovered and target labels into JSON directly

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -903,7 +903,7 @@ type ScrapePoolsDiscovery struct {
 // DroppedTarget has the information for one target that was dropped during relabelling.
 type DroppedTarget struct {
 	// Labels before any processing.
-	DiscoveredLabels map[string]string `json:"discoveredLabels"`
+	DiscoveredLabels labels.Labels `json:"discoveredLabels"`
 }
 
 // TargetDiscovery has all the active targets.

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -879,9 +879,9 @@ func (api *API) dropSeries(_ *http.Request) apiFuncResult {
 // Target has the information for one target.
 type Target struct {
 	// Labels before any processing.
-	DiscoveredLabels map[string]string `json:"discoveredLabels"`
+	DiscoveredLabels labels.Labels `json:"discoveredLabels"`
 	// Any labels that are added to this target and its metrics.
-	Labels map[string]string `json:"labels"`
+	Labels labels.Labels `json:"labels"`
 
 	ScrapePool string `json:"scrapePool"`
 	ScrapeURL  string `json:"scrapeUrl"`
@@ -1024,8 +1024,8 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 				globalURL, err := getGlobalURL(target.URL(), api.globalURLOptions)
 
 				res.ActiveTargets = append(res.ActiveTargets, &Target{
-					DiscoveredLabels: target.DiscoveredLabels().Map(),
-					Labels:           target.Labels().Map(),
+					DiscoveredLabels: target.DiscoveredLabels().Labels(),
+					Labels:           target.Labels().Labels(),
 					ScrapePool:       key,
 					ScrapeURL:        target.URL().String(),
 					GlobalURL:        globalURL.String(),
@@ -1063,7 +1063,7 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 			}
 			for _, target := range targetsDropped[key] {
 				res.DroppedTargets = append(res.DroppedTargets, &DroppedTarget{
-					DiscoveredLabels: target.DiscoveredLabels().Map(),
+					DiscoveredLabels: target.DiscoveredLabels().Labels(),
 				})
 			}
 		}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1024,8 +1024,8 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 				globalURL, err := getGlobalURL(target.URL(), api.globalURLOptions)
 
 				res.ActiveTargets = append(res.ActiveTargets, &Target{
-					DiscoveredLabels: target.DiscoveredLabels().Labels(),
-					Labels:           target.Labels().Labels(),
+					DiscoveredLabels: target.DiscoveredLabels(),
+					Labels:           target.Labels(),
 					ScrapePool:       key,
 					ScrapeURL:        target.URL().String(),
 					GlobalURL:        globalURL.String(),
@@ -1063,7 +1063,7 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 			}
 			for _, target := range targetsDropped[key] {
 				res.DroppedTargets = append(res.DroppedTargets, &DroppedTarget{
-					DiscoveredLabels: target.DiscoveredLabels().Labels(),
+					DiscoveredLabels: target.DiscoveredLabels(),
 				})
 			}
 		}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -903,7 +903,7 @@ type ScrapePoolsDiscovery struct {
 // DroppedTarget has the information for one target that was dropped during relabelling.
 type DroppedTarget struct {
 	// Labels before any processing.
-	DiscoveredLabels labels.Labels `json:"discoveredLabels"`
+	DiscoveredLabels map[string]string `json:"discoveredLabels"`
 }
 
 // TargetDiscovery has all the active targets.
@@ -1063,7 +1063,7 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 			}
 			for _, target := range targetsDropped[key] {
 				res.DroppedTargets = append(res.DroppedTargets, &DroppedTarget{
-					DiscoveredLabels: target.DiscoveredLabels(),
+					DiscoveredLabels: target.DiscoveredLabels().Map(),
 				})
 			}
 		}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1412,7 +1412,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 				ActiveTargets: []*Target{
 					{
 						DiscoveredLabels:   labels.FromStrings(),
-						Labels:             labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "blackbox"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
 						GlobalURL:          "http://localhost:9115/probe?target=example.com",
@@ -1425,7 +1425,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 					},
 					{
 						DiscoveredLabels:   labels.FromStrings(),
-						Labels:             labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "blackbox"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",
@@ -1461,7 +1461,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 				ActiveTargets: []*Target{
 					{
 						DiscoveredLabels:   labels.FromStrings(),
-						Labels:             labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "blackbox"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
 						GlobalURL:          "http://localhost:9115/probe?target=example.com",
@@ -1474,7 +1474,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 					},
 					{
 						DiscoveredLabels:   labels.FromStrings(),
-						Labels:             labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "blackbox"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",
@@ -1510,7 +1510,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 				ActiveTargets: []*Target{
 					{
 						DiscoveredLabels:   labels.FromStrings(),
-						Labels:             labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "blackbox"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
 						GlobalURL:          "http://localhost:9115/probe?target=example.com",
@@ -1523,7 +1523,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 					},
 					{
 						DiscoveredLabels:   labels.FromStrings(),
-						Labels:             labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "blackbox"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1411,7 +1411,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						DiscoveredLabels:   labels.FromStrings(),
 						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1424,7 +1424,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						DiscoveredLabels:   labels.FromStrings(),
 						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
@@ -1460,7 +1460,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						DiscoveredLabels:   labels.FromStrings(),
 						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1473,7 +1473,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						DiscoveredLabels:   labels.FromStrings(),
 						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
@@ -1509,7 +1509,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						DiscoveredLabels:   labels.FromStrings(),
 						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1522,7 +1522,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						DiscoveredLabels:   labels.FromStrings(),
 						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1439,14 +1439,14 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 				},
 				DroppedTargets: []*DroppedTarget{
 					{
-						DiscoveredLabels: labels.FromStrings(
-							"__address__", "http://dropped.example.com:9115",
-							"__metrics_path__", "/probe",
-							"__scheme__", "http",
-							"job", "blackbox",
-							"__scrape_interval__", "30s",
-							"__scrape_timeout__", "15s",
-						),
+						DiscoveredLabels: map[string]string{
+							"__address__":         "http://dropped.example.com:9115",
+							"__metrics_path__":    "/probe",
+							"__scheme__":          "http",
+							"job":                 "blackbox",
+							"__scrape_interval__": "30s",
+							"__scrape_timeout__":  "15s",
+						},
 					},
 				},
 				DroppedTargetCounts: map[string]int{"blackbox": 1},
@@ -1488,14 +1488,14 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 				},
 				DroppedTargets: []*DroppedTarget{
 					{
-						DiscoveredLabels: labels.FromStrings(
-							"__address__", "http://dropped.example.com:9115",
-							"__metrics_path__", "/probe",
-							"__scheme__", "http",
-							"job", "blackbox",
-							"__scrape_interval__", "30s",
-							"__scrape_timeout__", "15s",
-						),
+						DiscoveredLabels: map[string]string{
+							"__address__":         "http://dropped.example.com:9115",
+							"__metrics_path__":    "/probe",
+							"__scheme__":          "http",
+							"job":                 "blackbox",
+							"__scrape_interval__": "30s",
+							"__scrape_timeout__":  "15s",
+						},
 					},
 				},
 				DroppedTargetCounts: map[string]int{"blackbox": 1},
@@ -1547,14 +1547,14 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 				ActiveTargets: []*Target{},
 				DroppedTargets: []*DroppedTarget{
 					{
-						DiscoveredLabels: labels.FromStrings(
-							"__address__", "http://dropped.example.com:9115",
-							"__metrics_path__", "/probe",
-							"__scheme__", "http",
-							"job", "blackbox",
-							"__scrape_interval__", "30s",
-							"__scrape_timeout__", "15s",
-						),
+						DiscoveredLabels: map[string]string{
+							"__address__":         "http://dropped.example.com:9115",
+							"__metrics_path__":    "/probe",
+							"__scheme__":          "http",
+							"job":                 "blackbox",
+							"__scrape_interval__": "30s",
+							"__scrape_timeout__":  "15s",
+						},
 					},
 				},
 				DroppedTargetCounts: map[string]int{"blackbox": 1},

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1411,7 +1411,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.Labels{},
+						DiscoveredLabels: labels.Labels,
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1424,7 +1424,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.Labels{},
+						DiscoveredLabels: labels.Labels,
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
@@ -1460,7 +1460,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.Labels{},
+						DiscoveredLabels: labels.Labels,
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1473,7 +1473,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.Labels{},
+						DiscoveredLabels: labels.Labels,
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
@@ -1509,7 +1509,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.Labels{},
+						DiscoveredLabels: labels.Labels,
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1522,7 +1522,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.Labels{},
+						DiscoveredLabels: labels.Labels,
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1547,14 +1547,14 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 				ActiveTargets: []*Target{},
 				DroppedTargets: []*DroppedTarget{
 					{
-						DiscoveredLabels: map[string]string{
-							"__address__":         "http://dropped.example.com:9115",
-							"__metrics_path__":    "/probe",
-							"__scheme__":          "http",
-							"job":                 "blackbox",
-							"__scrape_interval__": "30s",
-							"__scrape_timeout__":  "15s",
-						},
+						DiscoveredLabels: labels.FromStrings(
+							"__address__", "http://dropped.example.com:9115",
+							"__metrics_path__", "/probe",
+							"__scheme__", "http",
+							"job", "blackbox",
+							"__scrape_interval__", "30s",
+							"__scrape_timeout__", "15s",
+						),
 					},
 				},
 				DroppedTargetCounts: map[string]int{"blackbox": 1},

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1522,7 +1522,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.FromStrings()s,
+						DiscoveredLabels: labels.FromStrings(),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1439,14 +1439,14 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 				},
 				DroppedTargets: []*DroppedTarget{
 					{
-						DiscoveredLabels: map[string]string{
-							"__address__":         "http://dropped.example.com:9115",
-							"__metrics_path__":    "/probe",
-							"__scheme__":          "http",
-							"job":                 "blackbox",
-							"__scrape_interval__": "30s",
-							"__scrape_timeout__":  "15s",
-						},
+						DiscoveredLabels: labels.FromStrings(
+							"__address__", "http://dropped.example.com:9115",
+							"__metrics_path__", "/probe",
+							"__scheme__", "http",
+							"job", "blackbox",
+							"__scrape_interval__", "30s",
+							"__scrape_timeout__", "15s",
+						),
 					},
 				},
 				DroppedTargetCounts: map[string]int{"blackbox": 1},
@@ -1488,14 +1488,14 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 				},
 				DroppedTargets: []*DroppedTarget{
 					{
-						DiscoveredLabels: map[string]string{
-							"__address__":         "http://dropped.example.com:9115",
-							"__metrics_path__":    "/probe",
-							"__scheme__":          "http",
-							"job":                 "blackbox",
-							"__scrape_interval__": "30s",
-							"__scrape_timeout__":  "15s",
-						},
+						DiscoveredLabels: labels.FromStrings(
+							"__address__", "http://dropped.example.com:9115",
+							"__metrics_path__", "/probe",
+							"__scheme__", "http",
+							"job", "blackbox",
+							"__scrape_interval__", "30s",
+							"__scrape_timeout__", "15s",
+						),
 					},
 				},
 				DroppedTargetCounts: map[string]int{"blackbox": 1},

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1411,8 +1411,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.FromStrings("job","test"),
-						Labels: labels.FromStrings("job","test"),
+						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
 						GlobalURL:          "http://localhost:9115/probe?target=example.com",
@@ -1424,8 +1424,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.FromStrings("job","test"),
-						Labels: labels.FromStrings("job","test"),
+						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",
@@ -1460,8 +1460,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.FromStrings("job","test"),
-						Labels: labels.FromStrings("job","test"),
+						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
 						GlobalURL:          "http://localhost:9115/probe?target=example.com",
@@ -1473,8 +1473,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.FromStrings("job","test"),
-						Labels: labels.FromStrings("job","test"),
+						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",
@@ -1509,8 +1509,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.FromStrings("job","test"),
-						Labels: labels.FromStrings("job","test"),
+						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
 						GlobalURL:          "http://localhost:9115/probe?target=example.com",
@@ -1522,8 +1522,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.FromStrings("job","test"),
-						Labels: labels.FromStrings("job","test"),
+						DiscoveredLabels:   labels.FromStrings("job", "test"),
+						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1411,10 +1411,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: map[string]string{},
-						Labels: map[string]string{
-							"job": "blackbox",
-						},
+						DiscoveredLabels: labels.Labels{},
+						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
 						GlobalURL:          "http://localhost:9115/probe?target=example.com",
@@ -1426,10 +1424,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: map[string]string{},
-						Labels: map[string]string{
-							"job": "test",
-						},
+						DiscoveredLabels: labels.Labels{},
+						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",
@@ -1464,10 +1460,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: map[string]string{},
-						Labels: map[string]string{
-							"job": "blackbox",
-						},
+						DiscoveredLabels: labels.Labels{},
+						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
 						GlobalURL:          "http://localhost:9115/probe?target=example.com",
@@ -1479,10 +1473,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: map[string]string{},
-						Labels: map[string]string{
-							"job": "test",
-						},
+						DiscoveredLabels: labels.Labels{},
+						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",
@@ -1517,10 +1509,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: map[string]string{},
-						Labels: map[string]string{
-							"job": "blackbox",
-						},
+						DiscoveredLabels: labels.Labels{},
+						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
 						GlobalURL:          "http://localhost:9115/probe?target=example.com",
@@ -1532,10 +1522,8 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: map[string]string{},
-						Labels: map[string]string{
-							"job": "test",
-						},
+						DiscoveredLabels: labels.Labels{},
+						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1411,7 +1411,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.FromStrings(),
+						DiscoveredLabels: labels.FromStrings("job","test"),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1424,7 +1424,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.FromStrings(),
+						DiscoveredLabels: labels.FromStrings("job","test"),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
@@ -1460,7 +1460,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.FromStrings(),
+						DiscoveredLabels: labels.FromStrings("job","test"),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1473,7 +1473,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.FromStrings(),
+						DiscoveredLabels: labels.FromStrings("job","test"),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
@@ -1509,7 +1509,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.FromStrings(),
+						DiscoveredLabels: labels.FromStrings("job","test"),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1522,7 +1522,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.FromStrings(),
+						DiscoveredLabels: labels.FromStrings("job","test"),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1411,7 +1411,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.Labels,
+						DiscoveredLabels: labels.FromStrings(),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1424,7 +1424,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.Labels,
+						DiscoveredLabels: labels.FromStrings(),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
@@ -1460,7 +1460,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.Labels,
+						DiscoveredLabels: labels.FromStrings(),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1473,7 +1473,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.Labels,
+						DiscoveredLabels: labels.FromStrings(),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
@@ -1509,7 +1509,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels: labels.Labels,
+						DiscoveredLabels: labels.FromStrings(),
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1522,7 +1522,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels: labels.Labels,
+						DiscoveredLabels: labels.FromStrings()s,
 						Labels: labels.FromStrings("job","test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1425,7 +1425,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 					},
 					{
 						DiscoveredLabels:   labels.FromStrings(),
-						Labels:             labels.FromStrings("job", "blackbox"),
+						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",
@@ -1474,7 +1474,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 					},
 					{
 						DiscoveredLabels:   labels.FromStrings(),
-						Labels:             labels.FromStrings("job", "blackbox"),
+						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",
@@ -1523,7 +1523,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 					},
 					{
 						DiscoveredLabels:   labels.FromStrings(),
-						Labels:             labels.FromStrings("job", "blackbox"),
+						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
 						GlobalURL:          "http://example.com:8080/metrics",


### PR DESCRIPTION
Converted maps into labels.Labels to avoid a lot of copying of data which leads to very high memory consumption while opening the /service-discovery endpoint in the Prometheus UI

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
