### PR TITLE
Fix buffer corruption issue of last_over_time with native histograms

### DIFF
--- a/promql/testdata/native_histograms.test
+++ b/promql/testdata/native_histograms.test
@@ -224,3 +224,15 @@ eval instant at 5m histogram_fraction(0, 4, balanced_histogram)
 # the first populated bucket after the span of empty buckets.
 eval instant at 5m histogram_quantile(0.5, balanced_histogram)
 	{} 0.5
+
+
+# Add histogram to test sum(last_over_time) regression
+load 5m
+    incr_sum_histogram{number="1"} {{schema:0 sum:0 count:0 buckets:[1]}}+{{schema:0 sum:1 count:1 buckets:[1]}}x10
+    incr_sum_histogram{number="2"} {{schema:0 sum:0 count:0 buckets:[1]}}+{{schema:0 sum:2 count:1 buckets:[1]}}x10
+
+eval instant at 50m histogram_sum(sum(incr_sum_histogram))
+    {} 30
+
+eval instant at 50m histogram_sum(sum(last_over_time(incr_sum_histogram[5m])))
+    {} 30


### PR DESCRIPTION
The test defined by
```
# Add histogram to test sum(last_over_time) regression
load 5m
    incr_sum_histogram{number="1"} {{schema:0 sum:0 count:0 buckets:[1]}}+{{schema:0 sum:1 count:1 buckets:[1]}}x10
    incr_sum_histogram{number="2"} {{schema:0 sum:0 count:0 buckets:[1]}}+{{schema:0 sum:2 count:1 buckets:[1]}}x10

eval instant at 50m histogram_sum(sum(incr_sum_histogram))
    {} 30

eval instant at 50m histogram_sum(sum(last_over_time(incr_sum_histogram[5m])))
    {} 30
```

Should pass, but results in 
```
error in eval histogram_sum(sum(last_over_time(incr_sum_histogram[1m]))) (line 237): expected 30 for {} but got 40
```

Works before #13340 