### PR TITLE
tsdb: use cheaper Mutex on series

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1484,9 +1484,9 @@ func (h *Head) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Match
 			continue
 		}
 
-		series.RLock()
+		series.Lock()
 		t0, t1 := series.minTime(), series.maxTime()
-		series.RUnlock()
+		series.Unlock()
 		if t0 == math.MinInt64 || t1 == math.MinInt64 {
 			continue
 		}
@@ -2016,7 +2016,7 @@ func (s sample) Type() chunkenc.ValueType {
 // memSeries is the in-memory representation of a series. None of its methods
 // are goroutine safe and it is the caller's responsibility to lock it.
 type memSeries struct {
-	sync.RWMutex
+	sync.Mutex
 
 	ref  chunks.HeadSeriesRef
 	lset labels.Labels

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -684,9 +684,9 @@ func (a *headAppender) UpdateMetadata(ref storage.SeriesRef, lset labels.Labels,
 		return 0, fmt.Errorf("unknown series when trying to add metadata with HeadSeriesRef: %d and labels: %s", ref, lset)
 	}
 
-	s.RLock()
+	s.Lock()
 	hasNewMetadata := s.meta == nil || *s.meta != meta
-	s.RUnlock()
+	s.Unlock()
 
 	if hasNewMetadata {
 		a.metadata = append(a.metadata, record.RefMetadata{


### PR DESCRIPTION
Mutex is 8 bytes; RWMutex is 24 bytes and much more complicated. Since `RLock` is only used in two places, `UpdateMetadata` and `Delete`, neither of which are hotspots, we should use the cheaper one.
