### PR TITLE
Fix last_over_time for native histograms

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -603,7 +603,7 @@ func funcLastOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNod
 	}
 	return append(enh.Out, Sample{
 		Metric: el.Metric,
-		H:      h.H,
+		H:      h.H.Copy(),
 	}), nil
 }
 

--- a/promql/testdata/native_histograms.test
+++ b/promql/testdata/native_histograms.test
@@ -224,3 +224,14 @@ eval instant at 5m histogram_fraction(0, 4, balanced_histogram)
 # the first populated bucket after the span of empty buckets.
 eval instant at 5m histogram_quantile(0.5, balanced_histogram)
 	{} 0.5
+
+# Add histogram to test sum(last_over_time) regression
+load 5m
+    incr_sum_histogram{number="1"} {{schema:0 sum:0 count:0 buckets:[1]}}+{{schema:0 sum:1 count:1 buckets:[1]}}x10
+    incr_sum_histogram{number="2"} {{schema:0 sum:0 count:0 buckets:[1]}}+{{schema:0 sum:2 count:1 buckets:[1]}}x10
+
+eval instant at 50m histogram_sum(sum(incr_sum_histogram))
+    {} 30
+
+eval instant at 50m histogram_sum(sum(last_over_time(incr_sum_histogram[5m])))
+    {} 30


### PR DESCRIPTION
The last_over_time retains a histogram sample without making a copy. This sample is now coming from the buffered iterator used for windowing functions, and can be reused for reading subsequent samples as the iterator progresses.

I would propose copying the sample in the last_over_time function, similar to how it is done for rate, sum_over_time and others.

Closes https://github.com/prometheus/prometheus/pull/13470.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
