### PR TITLE
Prometheus support parse exemplars from native histogram

### DIFF
--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -306,8 +306,8 @@ func (p *ProtobufParser) Metric(l *labels.Labels) string {
 
 // Exemplar writes the exemplar of the current sample into the passed
 // exemplar. It returns if an exemplar exists or not. In case of a native
-// histogram, the exemplars in native histogram will be returned.
-// If this field is empty, the legacy bucket section is still used for exemplars.
+// histogram, the exemplars in the native histogram will be returned.
+// If this field is empty, the classic bucket section is still used for exemplars.
 // To ingest all exemplars, call the Exemplar method repeatedly until it returns false.
 func (p *ProtobufParser) Exemplar(ex *exemplar.Exemplar) bool {
 	if p.exemplarReturned && p.state == EntrySeries {

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -56,7 +56,7 @@ type ProtobufParser struct {
 	fieldPos    int
 	fieldsDone  bool // true if no more fields of a Summary or (legacy) Histogram to be processed.
 	redoClassic bool // true after parsing a native histogram if we need to parse it again as a classic histogram.
-	// exemplarPos is the position within exemplars slice of native exemplars.
+	// exemplarPos is the position within the exemplars slice of a native histogram.
 	exemplarPos int
 
 	// exemplarReturned is set to true each time an exemplar has been

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -596,6 +596,94 @@ metric: <
 >
 
 `,
+		`name: "test_histogram_with_native_histogram_exemplars"
+help: "A histogram with native histogram exemplars."
+type: HISTOGRAM
+metric: <
+  histogram: <
+    sample_count: 175
+    sample_sum: 0.0008280461746287094
+    bucket: <
+      cumulative_count: 2
+      upper_bound: -0.0004899999999999998
+    >
+    bucket: <
+      cumulative_count: 4
+      upper_bound: -0.0003899999999999998
+      exemplar: <
+	    label: <
+	      name: "dummyID"
+	      value: "59727"
+	    >
+	    value: -0.00039
+	    timestamp: <
+	      seconds: 1625851155
+	      nanos: 146848499
+	    >
+      >
+    >
+    bucket: <
+      cumulative_count: 16
+      upper_bound: -0.0002899999999999998
+      exemplar: <
+	    label: <
+	      name: "dummyID"
+	      value: "5617"
+	    >
+	    value: -0.00029
+      >
+    >
+    schema: 3
+    zero_threshold: 2.938735877055719e-39
+    zero_count: 2
+    negative_span: <
+      offset: -162
+      length: 1
+    >
+    negative_span: <
+      offset: 23
+      length: 4
+    >
+    negative_delta: 1
+    negative_delta: 3
+    negative_delta: -2
+    negative_delta: -1
+    negative_delta: 1
+    positive_span: <
+      offset: -161
+      length: 1
+    >
+    positive_span: <
+      offset: 8
+      length: 3
+    >
+    positive_delta: 1
+    positive_delta: 2
+    positive_delta: -1
+    positive_delta: -1
+	exemplars: <
+	  label: <
+	    name: "dummyID"
+	    value: "59780"
+	  >
+	  value: -0.00039
+	  timestamp: <
+	    seconds: 1625851155
+	    nanos: 146848499
+	  >
+	>
+	exemplars: <
+	  label: <
+	    name: "dummyID"
+	    value: "5617"
+	  >
+	  value: -0.00029
+	>
+  >
+  timestamp_ms: 1234568
+>
+
+`,
 	}
 
 	varintBuf := make([]byte, binary.MaxVarintLen32)
@@ -1139,6 +1227,41 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_gaugehistogram_with_createdtimestamp",
 					),
+				},
+				{
+					m:    "test_histogram_with_native_histogram_exemplars",
+					help: "A histogram with native histogram exemplars.",
+				},
+				{
+					m:   "test_histogram_with_native_histogram_exemplars",
+					typ: model.MetricTypeHistogram,
+				},
+				{
+					m: "test_histogram_with_native_histogram_exemplars",
+					t: 1234568,
+					shs: &histogram.Histogram{
+						Count:         175,
+						ZeroCount:     2,
+						Sum:           0.0008280461746287094,
+						ZeroThreshold: 2.938735877055719e-39,
+						Schema:        3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []int64{1, 2, -1, -1},
+						NegativeBuckets: []int64{1, 3, -2, -1, 1},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59780"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+					},
 				},
 			},
 		},
@@ -1956,6 +2079,99 @@ func TestProtobufParse(t *testing.T) {
 					},
 					lset: labels.FromStrings(
 						"__name__", "test_gaugehistogram_with_createdtimestamp",
+					),
+				},
+				{ // 94
+					m:    "test_histogram_with_native_histogram_exemplars",
+					help: "A histogram with native histogram exemplars.",
+				},
+				{ // 95
+					m:   "test_histogram_with_native_histogram_exemplars",
+					typ: model.MetricTypeHistogram,
+				},
+				{ // 96
+					m: "test_histogram_with_native_histogram_exemplars",
+					t: 1234568,
+					shs: &histogram.Histogram{
+						Count:         175,
+						ZeroCount:     2,
+						Sum:           0.0008280461746287094,
+						ZeroThreshold: 2.938735877055719e-39,
+						Schema:        3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []int64{1, 2, -1, -1},
+						NegativeBuckets: []int64{1, 3, -2, -1, 1},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59780"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+					},
+				},
+				{ // 97
+					m: "test_histogram_with_native_histogram_exemplars_count",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars_count",
+					),
+				},
+				{ // 98
+					m: "test_histogram_with_native_histogram_exemplars_sum",
+					t: 1234568,
+					v: 0.0008280461746287094,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars_sum",
+					),
+				},
+				{ // 99
+					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff-0.0004899999999999998",
+					t: 1234568,
+					v: 2,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars_bucket",
+						"le", "-0.0004899999999999998",
+					),
+				},
+				{ // 100
+					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff-0.0003899999999999998",
+					t: 1234568,
+					v: 4,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars_bucket",
+						"le", "-0.0003899999999999998",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+					},
+				},
+				{ // 101
+					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff-0.0002899999999999998",
+					t: 1234568,
+					v: 16,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars_bucket",
+						"le", "-0.0002899999999999998",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
+					},
+				},
+				{ // 102
+					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff+Inf",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars_bucket",
+						"le", "+Inf",
 					),
 				},
 			},

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -661,24 +661,35 @@ metric: <
     positive_delta: 2
     positive_delta: -1
     positive_delta: -1
-	exemplars: <
-	  label: <
-	    name: "dummyID"
-	    value: "59780"
-	  >
-	  value: -0.00039
-	  timestamp: <
-	    seconds: 1625851155
-	    nanos: 146848499
-	  >
-	>
-	exemplars: <
-	  label: <
-	    name: "dummyID"
-	    value: "5617"
-	  >
-	  value: -0.00029
-	>
+    exemplars: <
+      label: <
+        name: "dummyID"
+        value: "59780"
+      >
+      value: -0.00039
+      timestamp: <
+        seconds: 1625851155
+        nanos: 146848499
+      >
+    >
+    exemplars: <
+      label: <
+        name: "dummyID"
+        value: "5617"
+      >
+      value: -0.00029
+    >
+    exemplars: <
+      label: <
+        name: "dummyID"
+        value: "59772"
+      >
+      value: -0.00052
+      timestamp: <
+        seconds: 1625851160
+        nanos: 156848499
+      >
+    >
   >
   timestamp_ms: 1234568
 >
@@ -1261,6 +1272,7 @@ func TestProtobufParse(t *testing.T) {
 					),
 					e: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59780"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+						{Labels: labels.FromStrings("dummyID", "59772"), Value: -0.00052, HasTs: true, Ts: 1625851160156},
 					},
 				},
 			},
@@ -2114,6 +2126,7 @@ func TestProtobufParse(t *testing.T) {
 					),
 					e: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59780"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+						{Labels: labels.FromStrings("dummyID", "59772"), Value: -0.00052, HasTs: true, Ts: 1625851160156},
 					},
 				},
 				{ // 97


### PR DESCRIPTION
following
https://github.com/prometheus/prometheus/pull/13449#pullrequestreview-1844632501

Prometheus support parse exemplars from native histogram.

For now, prometheus will parse the exemplar from the `exemplars` field of the data if the field is not empty, otherwise it will parse like before, which is parsing the exemplar from the `bucket` field. 