### PR TITLE
storage/remote: speed up StoreSeries by re-using labels.Builder

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -1013,7 +1013,8 @@ func BenchmarkStartup(b *testing.B) {
 }
 
 func TestProcessExternalLabels(t *testing.T) {
-	for _, tc := range []struct {
+	b := labels.NewBuilder(labels.EmptyLabels())
+	for i, tc := range []struct {
 		labels         labels.Labels
 		externalLabels []labels.Label
 		expected       labels.Labels
@@ -1074,7 +1075,9 @@ func TestProcessExternalLabels(t *testing.T) {
 			expected:       labels.FromStrings("a", "b", "c", "d", "e", "f"),
 		},
 	} {
-		require.Equal(t, tc.expected, processExternalLabels(tc.labels, tc.externalLabels))
+		b.Reset(tc.labels)
+		processExternalLabels(b, tc.externalLabels)
+		require.Equal(t, tc.expected, b.Labels(), "test %d", i)
 	}
 }
 


### PR DESCRIPTION
Relabeling can take a pre-populated `Builder` instead of making a new
 one every time. This is much more efficient.

Added a benchmark to demonstrate:

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/storage/remote
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                                     │  before.txt  │              after.txt              │
                                     │    sec/op    │    sec/op     vs base               │
StoreSeries/plain-4                    1.569m ±  8%   1.270m ±  5%  -19.06% (p=0.002 n=6)
StoreSeries/externalLabels-4           3.288m ±  2%   2.497m ±  8%  -24.07% (p=0.002 n=6)
StoreSeries/relabel-4                  3.252m ± 17%   3.107m ± 10%        ~ (p=0.065 n=6)
StoreSeries/externalLabels+relabel-4   5.122m ±  3%   3.414m ±  6%  -33.34% (p=0.002 n=6)
geomean                                3.045m         2.408m        -20.90%

                                     │  before.txt  │              after.txt              │
                                     │     B/op     │     B/op      vs base               │
StoreSeries/plain-4                    598.8Ki ± 0%   364.7Ki ± 0%  -39.10% (p=0.002 n=6)
StoreSeries/externalLabels-4           1.867Mi ± 0%   1.089Mi ± 0%  -41.68% (p=0.002 n=6)
StoreSeries/relabel-4                  1.348Mi ± 0%   1.119Mi ± 0%  -16.96% (p=0.002 n=6)
StoreSeries/externalLabels+relabel-4   2.630Mi ± 0%   1.119Mi ± 0%  -57.44% (p=0.002 n=6)
geomean                                1.403Mi        854.9Ki       -40.48%

                                     │ before.txt  │             after.txt              │
                                     │  allocs/op  │  allocs/op   vs base               │
StoreSeries/plain-4                    3.659k ± 0%   1.662k ± 0%  -54.58% (p=0.002 n=6)
StoreSeries/externalLabels-4           5.660k ± 0%   2.662k ± 0%  -52.97% (p=0.002 n=6)
StoreSeries/relabel-4                  7.661k ± 0%   5.663k ± 0%  -26.07% (p=0.002 n=6)
StoreSeries/externalLabels+relabel-4   9.664k ± 0%   5.663k ± 0%  -41.40% (p=0.002 n=6)
geomean                                6.257k        3.451k       -44.84%
```
Also simplify `processExternalLabels` taking advantage of `Builder.Get` added recently.

Switching `processExternalLabels` from `ScratchBuilder` to `Builder` makes the code slower for the no-build-tags implementation of `labels.Labels`, which I can fix, but I figured I would wait to see if anyone is affected by this.  Prometheus and Grafana Agent are both using `-tags stringlabels`.
