### PR TITLE
labels: make InternStrings a no-op for stringlabels version

### DIFF
--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -450,14 +450,12 @@ func (ls Labels) DropMetricName() Labels {
 	return ls
 }
 
-// InternStrings calls intern on every string value inside ls, replacing them with what it returns.
+// InternStrings is a no-op because it would only save when the whole set of labels is identical.
 func (ls *Labels) InternStrings(intern func(string) string) {
-	ls.data = intern(ls.data)
 }
 
-// ReleaseStrings calls release on every string value inside ls.
+// ReleaseStrings is a no-op for the same reason as InternStrings.
 func (ls Labels) ReleaseStrings(release func(string)) {
-	release(ls.data)
 }
 
 // Labels returns the labels from the builder.


### PR DESCRIPTION
The current implementation of `InternStrings` will only save memory when the whole set of labels is identical to one already seen, and this cannot happen in the one place it is called from in Prometheus, remote-write, which already detects identical series.

Using `BenchmarkStoreSeries` from #13491:

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/storage/remote
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                                     │  before.txt  │             after2.txt              │
                                     │    sec/op    │    sec/op     vs base               │
StoreSeries/plain-4                    1.569m ±  8%   1.035m ±  3%  -34.07% (p=0.002 n=6)
StoreSeries/externalLabels-4           3.288m ±  2%   2.978m ± 15%        ~ (p=0.093 n=6)
StoreSeries/relabel-4                  3.252m ± 17%   2.628m ±  8%  -19.18% (p=0.002 n=6)
StoreSeries/externalLabels+relabel-4   5.122m ±  3%   4.826m ± 10%        ~ (p=0.132 n=6)
geomean                                3.045m         2.500m        -17.88%

                                     │  before.txt  │             after2.txt              │
                                     │     B/op     │     B/op      vs base               │
StoreSeries/plain-4                    598.8Ki ± 0%   458.4Ki ± 0%  -23.44% (p=0.002 n=6)
StoreSeries/externalLabels-4           1.867Mi ± 0%   1.730Mi ± 0%   -7.35% (p=0.002 n=6)
StoreSeries/relabel-4                  1.348Mi ± 0%   1.211Mi ± 0%  -10.17% (p=0.002 n=6)
StoreSeries/externalLabels+relabel-4   2.630Mi ± 0%   2.493Mi ± 0%   -5.22% (p=0.002 n=6)
geomean                                1.403Mi        1.237Mi       -11.84%

                                     │ before.txt  │             after2.txt             │
                                     │  allocs/op  │  allocs/op   vs base               │
StoreSeries/plain-4                    3.659k ± 0%   2.631k ± 0%  -28.10% (p=0.002 n=6)
StoreSeries/externalLabels-4           5.660k ± 0%   4.632k ± 0%  -18.16% (p=0.002 n=6)
StoreSeries/relabel-4                  7.661k ± 0%   6.633k ± 0%  -13.42% (p=0.002 n=6)
StoreSeries/externalLabels+relabel-4   9.664k ± 0%   8.635k ± 0%  -10.64% (p=0.002 n=6)
geomean                                6.257k        5.140k       -17.86%
```
