### PR TITLE
storage/remote: apply custom headers before sigv4 transport

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -141,22 +141,22 @@ func NewWriteClient(name string, conf *ClientConfig) (WriteClient, error) {
 	}
 	t := httpClient.Transport
 
+	if len(conf.Headers) > 0 {
+		t = newInjectHeadersRoundTripper(conf.Headers, t)
+	}
+
 	if conf.SigV4Config != nil {
-		t, err = sigv4.NewSigV4RoundTripper(conf.SigV4Config, httpClient.Transport)
+		t, err = sigv4.NewSigV4RoundTripper(conf.SigV4Config, t)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if conf.AzureADConfig != nil {
-		t, err = azuread.NewAzureADRoundTripper(conf.AzureADConfig, httpClient.Transport)
+		t, err = azuread.NewAzureADRoundTripper(conf.AzureADConfig, t)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if len(conf.Headers) > 0 {
-		t = newInjectHeadersRoundTripper(conf.Headers, t)
 	}
 
 	httpClient.Transport = otelhttp.NewTransport(t)


### PR DESCRIPTION
We've seen problems writing to Amazon Managed Prometheus when other headers are applied to the remote-write endpoint. Errors like `The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method.`. Tracked it down to this code, where the request is being signed **before** the custom headers are applied. 

With this change, the headers should be set before the signatures happen, and be included in the hash.