### PR TITLE
storage/remote: document why two benchmarks are skipped

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -924,7 +924,7 @@ func BenchmarkSampleSend(b *testing.B) {
 func BenchmarkStartup(b *testing.B) {
 	dir := os.Getenv("WALDIR")
 	if dir == "" {
-		return
+		b.Skip("WALDIR env var not set")
 	}
 
 	// Find the second largest segment; we will replay up to this.

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -204,6 +204,7 @@ func TestCommitErr(t *testing.T) {
 }
 
 func BenchmarkRemoteWriteOOOSamples(b *testing.B) {
+	b.Skip("Not a valid benchmark (does not count to b.N)")
 	dir := b.TempDir()
 
 	opts := tsdb.DefaultOptions()


### PR DESCRIPTION
One was silently doing nothing; one was doing something but the work didn't go up linearly with iteration count.

