### PR TITLE
Make predict_linear @ safe

### DIFF
--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -230,11 +230,11 @@ eval instant at 50m predict_linear(testcounter_reset_middle[100m] @ 3000, 3600)
 
 # intercept at t = 600+3600 = 4200
 eval instant at 10m predict_linear(testcounter_reset_middle[100m] @ 3000, 3600)
-	{} 51.36363636363637
+	{} 76.81818181818181
 
 # intercept at t = 4200+3600 = 7800
 eval instant at 70m predict_linear(testcounter_reset_middle[100m] @ 3000, 3600)
-	{} 89.54545454545455
+	{} 76.81818181818181
 
 # With http_requests, there is a sample value exactly at the end of
 # the range, and it has exactly the predicted value, so predict_linear


### PR DESCRIPTION
As discussed in the linked issue, currently `predict_linear`'s result is dependent on the evaluation timestamp. When used with `@` modifier, the input data to the function reduces on each successive timestamp and this causes the linear regression calculation to return increasingly nonsensical results. This patch makes `predict_linear` use the `@` modifier timestamp in these cases so that the result remains the same irrespective of the query evaluation time. 

closes https://github.com/prometheus/prometheus/issues/11708


<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
