### PR TITLE
Parse created timestamps from OpenMetrics-Text format

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -226,7 +226,7 @@ func (c *flagConfig) setFeatureListOptions(logger log.Logger) error {
 				// Change relevant global variables. Hacky, but it's hard to pass a new option or default to unmarshallers.
 				config.DefaultConfig.GlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols
 				config.DefaultGlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols
-				level.Info(logger).Log("msg", "Experimental created timestamp zero ingestion enabled. Changed default scrape_protocols to prefer PrometheusProto format.", "global.scrape_protocols", fmt.Sprintf("%v", config.DefaultGlobalConfig.ScrapeProtocols))
+				level.Info(logger).Log("msg", "Experimental created timestamp zero ingestion enabled. Changed default scrape_protocols to prefer PrometheusProto format since it has better performance.", "global.scrape_protocols", fmt.Sprintf("%v", config.DefaultGlobalConfig.ScrapeProtocols))
 			case "":
 				continue
 			case "promql-at-modifier", "promql-negative-offset":

--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -85,7 +85,7 @@ func New(b []byte, contentType string, parseClassicHistograms bool, st *labels.S
 		return NewPromParser(b, st), nil
 	}
 
-	mediaType, _, err := mime.ParseMediaType(contentType)
+	mediaType, err := ParseMediaType(contentType)
 	if err != nil {
 		return NewPromParser(b, st), err
 	}
@@ -97,6 +97,11 @@ func New(b []byte, contentType string, parseClassicHistograms bool, st *labels.S
 	default:
 		return NewPromParser(b, st), nil
 	}
+}
+
+func ParseMediaType(contentType string) (string, error) {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	return mediaType, err
 }
 
 // Entry represents the type of a parsed entry.

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -64,7 +64,10 @@ _metric_starting_with_underscore 1
 testmetric{_label_starting_with_underscore="foo"} 1
 testmetric{label="\"bar\""} 1
 # TYPE foo counter
-foo_total 17.0 1520879607.789 # {id="counter-test"} 5`
+foo_total 17.0 1520879607.789 # {id="counter-test"} 5
+foo_created 1000
+foo_total{a="b"} 17.0 1520879607.789 # {id="counter-test"} 5
+foo_created{a="b"} 1000`
 
 	input += "\n# HELP metric foo\x00bar"
 	input += "\nnull_byte_metric{a=\"abc\x00\"} 1"
@@ -225,6 +228,14 @@ foo_total 17.0 1520879607.789 # {id="counter-test"} 5`
 			lset: labels.FromStrings("__name__", "foo_total"),
 			t:    int64p(1520879607789),
 			e:    &exemplar.Exemplar{Labels: labels.FromStrings("id", "counter-test"), Value: 5},
+			ct:   1000,
+		}, {
+			m:    "foo_total{a=\"b\"}",
+			v:    17,
+			lset: labels.FromStrings("__name__", "foo_total", "a", "b"),
+			t:    int64p(1520879607789),
+			e:    &exemplar.Exemplar{Labels: labels.FromStrings("id", "counter-test"), Value: 5},
+			ct:   1000,
 		}, {
 			m:    "metric",
 			help: "foo\x00bar",

--- a/model/textparse/promparse_test.go
+++ b/model/textparse/promparse_test.go
@@ -41,6 +41,7 @@ type expectedParse struct {
 	unit    string
 	comment string
 	e       *exemplar.Exemplar
+	ct      int64
 }
 
 func TestPromParse(t *testing.T) {
@@ -212,11 +213,19 @@ func checkParseResults(t *testing.T, p Parser, exp []expectedParse) {
 
 			var e exemplar.Exemplar
 			found := p.Exemplar(&e)
+			var ct *int64
+			if exp[i].ct != 0 {
+				p.Next()
+				ct = p.CreatedTimestamp()
+			}
 			if exp[i].e == nil {
 				require.False(t, found)
 			} else {
 				require.True(t, found)
 				testutil.RequireEqual(t, *exp[i].e, e)
+			}
+			if exp[i].ct != 0 {
+				require.Equal(t, exp[i].ct, *ct)
 			}
 
 		case EntryType:


### PR DESCRIPTION
Fix #12980

The already existing feature-flag 'created-timestamp-zero-ingestion' is extended to also cover OpenMetrics-Text format.
Once enabled, _created lines, that before were treated as a whole new timeseries, will be appended as a synthetic zero to the timeseries they are related to.