### PR TITLE
promql: faster range-query of label_replace and label_join

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"go.opentelemetry.io/otel"
@@ -1080,8 +1079,6 @@ type EvalNodeHelper struct {
 	Dmn map[uint64]labels.Labels
 	// funcHistogramQuantile for classic histograms.
 	signatureToMetricWithBuckets map[string]*metricWithBuckets
-	// label_replace.
-	regex *regexp.Regexp
 
 	lb           *labels.Builder
 	lblBuf       []byte

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1409,6 +1409,15 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 				break
 			}
 		}
+
+		// Special handling for functions that work on series not samples.
+		switch e.Func.Name {
+		case "label_replace":
+			return ev.evalLabelReplace(e.Args)
+		case "label_join":
+			return ev.evalLabelJoin(e.Args)
+		}
+
 		if !matrixArg {
 			// Does not have a matrix argument.
 			return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1321,59 +1321,47 @@ func funcChanges(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelp
 	return append(enh.Out, Sample{F: float64(changes)}), nil
 }
 
-// === label_replace(Vector parser.ValueTypeVector, dst_label, replacement, src_labelname, regex parser.ValueTypeString) (Vector, Annotations) ===
-func funcLabelReplace(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+// label_replace function operates only on series; does not look at timestamps or values.
+func (ev *evaluator) evalLabelReplace(args parser.Expressions) (parser.Value, annotations.Annotations) {
 	var (
-		vector   = vals[0].(Vector)
 		dst      = stringFromArg(args[1])
 		repl     = stringFromArg(args[2])
 		src      = stringFromArg(args[3])
 		regexStr = stringFromArg(args[4])
 	)
 
-	if enh.regex == nil {
-		var err error
-		enh.regex, err = regexp.Compile("^(?:" + regexStr + ")$")
-		if err != nil {
-			panic(fmt.Errorf("invalid regular expression in label_replace(): %s", regexStr))
-		}
-		if !model.LabelNameRE.MatchString(dst) {
-			panic(fmt.Errorf("invalid destination label name in label_replace(): %s", dst))
-		}
-		enh.Dmn = make(map[uint64]labels.Labels, len(enh.Out))
+	regex, err := regexp.Compile("^(?:" + regexStr + ")$")
+	if err != nil {
+		panic(fmt.Errorf("invalid regular expression in label_replace(): %s", regexStr))
+	}
+	if !model.LabelNameRE.MatchString(dst) {
+		panic(fmt.Errorf("invalid destination label name in label_replace(): %s", dst))
 	}
 
-	for _, el := range vector {
-		h := el.Metric.Hash()
-		var outMetric labels.Labels
-		if l, ok := enh.Dmn[h]; ok {
-			outMetric = l
-		} else {
-			srcVal := el.Metric.Get(src)
-			indexes := enh.regex.FindStringSubmatchIndex(srcVal)
-			if indexes == nil {
-				// If there is no match, no replacement should take place.
-				outMetric = el.Metric
-				enh.Dmn[h] = outMetric
-			} else {
-				res := enh.regex.ExpandString([]byte{}, repl, srcVal, indexes)
+	val, ws := ev.eval(args[0])
+	matrix := val.(Matrix)
+	lb := labels.NewBuilder(labels.EmptyLabels())
 
-				lb := labels.NewBuilder(el.Metric).Del(dst)
-				if len(res) > 0 {
-					lb.Set(dst, string(res))
-				}
-				outMetric = lb.Labels()
-				enh.Dmn[h] = outMetric
-			}
+	for i, el := range matrix {
+		srcVal := el.Metric.Get(src)
+		indexes := regex.FindStringSubmatchIndex(srcVal)
+		if indexes != nil { // Only replace when regexp matches.
+			res := regex.ExpandString([]byte{}, repl, srcVal, indexes)
+			lb.Reset(el.Metric)
+			lb.Set(dst, string(res))
+			matrix[i].Metric = lb.Labels()
 		}
-
-		enh.Out = append(enh.Out, Sample{
-			Metric: outMetric,
-			F:      el.F,
-			H:      el.H,
-		})
 	}
-	return enh.Out, nil
+	if matrix.ContainsSameLabelset() {
+		ev.errorf("vector cannot contain metrics with the same labelset")
+	}
+
+	return matrix, ws
+}
+
+// === label_replace(Vector parser.ValueTypeVector, dst_label, replacement, src_labelname, regex parser.ValueTypeString) (Vector, Annotations) ===
+func funcLabelReplace(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+	panic("funcLabelReplace wrong implementation called")
 }
 
 // === Vector(s Scalar) (Vector, Annotations) ===
@@ -1385,19 +1373,13 @@ func funcVector(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelpe
 		}), nil
 }
 
-// === label_join(vector model.ValVector, dest_labelname, separator, src_labelname...) (Vector, Annotations) ===
-func funcLabelJoin(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+// label_join function operates only on series; does not look at timestamps or values.
+func (ev *evaluator) evalLabelJoin(args parser.Expressions) (parser.Value, annotations.Annotations) {
 	var (
-		vector    = vals[0].(Vector)
 		dst       = stringFromArg(args[1])
 		sep       = stringFromArg(args[2])
 		srcLabels = make([]string, len(args)-3)
 	)
-
-	if enh.Dmn == nil {
-		enh.Dmn = make(map[uint64]labels.Labels, len(enh.Out))
-	}
-
 	for i := 3; i < len(args); i++ {
 		src := stringFromArg(args[i])
 		if !model.LabelName(src).IsValid() {
@@ -1406,42 +1388,27 @@ func funcLabelJoin(vals []parser.Value, args parser.Expressions, enh *EvalNodeHe
 		srcLabels[i-3] = src
 	}
 
-	if !model.LabelName(dst).IsValid() {
-		panic(fmt.Errorf("invalid destination label name in label_join(): %s", dst))
-	}
-
+	val, ws := ev.eval(args[0])
+	matrix := val.(Matrix)
 	srcVals := make([]string, len(srcLabels))
-	for _, el := range vector {
-		h := el.Metric.Hash()
-		var outMetric labels.Labels
-		if l, ok := enh.Dmn[h]; ok {
-			outMetric = l
-		} else {
+	lb := labels.NewBuilder(labels.EmptyLabels())
 
-			for i, src := range srcLabels {
-				srcVals[i] = el.Metric.Get(src)
-			}
-
-			lb := labels.NewBuilder(el.Metric)
-
-			strval := strings.Join(srcVals, sep)
-			if strval == "" {
-				lb.Del(dst)
-			} else {
-				lb.Set(dst, strval)
-			}
-
-			outMetric = lb.Labels()
-			enh.Dmn[h] = outMetric
+	for i, el := range matrix {
+		for i, src := range srcLabels {
+			srcVals[i] = el.Metric.Get(src)
 		}
-
-		enh.Out = append(enh.Out, Sample{
-			Metric: outMetric,
-			F:      el.F,
-			H:      el.H,
-		})
+		strval := strings.Join(srcVals, sep)
+		lb.Reset(el.Metric)
+		lb.Set(dst, strval)
+		matrix[i].Metric = lb.Labels()
 	}
-	return enh.Out, nil
+
+	return matrix, ws
+}
+
+// === label_join(vector model.ValVector, dest_labelname, separator, src_labelname...) (Vector, Annotations) ===
+func funcLabelJoin(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+	panic("funcLabelReplace wrong implementation called")
 }
 
 // Common code for date related functions.


### PR DESCRIPTION
These functions act on the labels only, so don't need to go step by step over the samples in a range query.

I'm not entirely happy about the `switch` that calls the new version, but it is in line with some previous changes.
I think the whole of `eval` and `evalRange` should be refactored to make it easier to understand.

I left the previous entry-points in place with a `panic`, to make it obvious if someone is calling them in a way I didnt know about.

<details><summary>Benchmarks</summary>
<p>

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/promql
                                                                               │  before.txt  │             after.txt              │
                                                                               │    sec/op    │   sec/op     vs base               │
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-8           14.32µ ± 0%   13.43µ ± 1%   -6.28% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-8         35.54µ ± 0%   16.67µ ± 1%  -53.10% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8       214.67µ ± 1%   39.39µ ± 1%  -81.65% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-8           35.11µ ± 1%   30.48µ ± 0%  -13.18% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-8        131.30µ ± 0%   61.87µ ± 1%  -52.88% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8        937.1µ ± 1%   285.1µ ± 1%  -69.57% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-8       249.0µ ± 0%   206.7µ ± 2%  -16.98% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8    1169.6µ ± 3%   513.7µ ± 0%  -56.07% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8    8.847m ± 1%   2.715m ± 0%  -69.31% (p=0.002 n=6)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-8                  12.21µ ± 1%   11.21µ ± 1%   -8.14% (p=0.002 n=6)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-8                38.33µ ± 1%   14.41µ ± 1%  -62.41% (p=0.002 n=6)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-8              263.34µ ± 1%   37.25µ ± 1%  -85.86% (p=0.002 n=6)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-8                  31.94µ ± 1%   26.95µ ± 1%  -15.60% (p=0.002 n=6)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-8               140.45µ ± 0%   58.11µ ± 2%  -58.63% (p=0.002 n=6)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-8              1060.0µ ± 1%   279.9µ ± 1%  -73.60% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-8              235.2µ ± 1%   188.4µ ± 1%  -19.89% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8           1236.9µ ± 1%   498.1µ ± 1%  -59.73% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8           9.784m ± 1%   2.696m ± 1%  -72.45% (p=0.002 n=6)
geomean                                                                           224.1µ        99.49µ       -55.60%

                                                                               │  before.txt   │              after.txt              │
                                                                               │     B/op      │     B/op      vs base               │
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-8           13.41Ki ± 0%   12.11Ki ± 0%   -9.69% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-8         25.48Ki ± 0%   12.57Ki ± 0%  -50.67% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8       135.62Ki ± 0%   17.16Ki ± 0%  -87.35% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-8           23.31Ki ± 0%   16.41Ki ± 0%  -29.59% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-8         38.26Ki ± 0%   19.75Ki ± 0%  -48.38% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8       173.86Ki ± 0%   49.82Ki ± 0%  -71.35% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-8      142.74Ki ± 0%   61.16Ki ± 0%  -57.15% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8    185.66Ki ± 0%   92.45Ki ± 0%  -50.21% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8    569.3Ki ± 0%   370.4Ki ± 0%  -34.94% (p=0.002 n=6)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-8                 10.602Ki ± 0%   9.240Ki ± 0%  -12.84% (p=0.002 n=6)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-8               28.860Ki ± 0%   9.695Ki ± 0%  -66.41% (p=0.002 n=6)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-8              195.28Ki ± 0%   14.29Ki ± 0%  -92.68% (p=0.002 n=6)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-8                  20.25Ki ± 0%   13.13Ki ± 0%  -35.17% (p=0.002 n=6)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-8                41.39Ki ± 0%   16.46Ki ± 0%  -60.23% (p=0.002 n=6)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-8              233.24Ki ± 0%   46.52Ki ± 0%  -80.06% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-8             137.22Ki ± 0%   52.47Ki ± 0%  -61.76% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8           186.31Ki ± 0%   83.82Ki ± 0%  -55.01% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8           626.1Ki ± 0%   361.7Ki ± 0%  -42.23% (p=0.002 n=6)
geomean                                                                           80.52Ki        32.68Ki       -59.42%

                                                                               │  before.txt  │             after.txt              │
                                                                               │  allocs/op   │  allocs/op   vs base               │
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1-8            281.0 ± 0%    260.0 ± 0%   -7.47% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=100-8          782.0 ± 0%    266.0 ± 0%  -65.98% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_one,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8        5326.0 ± 0%    310.0 ± 0%  -94.18% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1-8            387.0 ± 0%    347.0 ± 0%  -10.34% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=100-8          933.0 ± 0%    398.0 ± 0%  -57.34% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_ten,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8        5846.0 ± 0%    811.0 ± 0%  -86.13% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1-8       1.478k ± 0%   1.251k ± 0%  -15.36% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8     2.462k ± 0%   1.740k ± 0%  -29.33% (p=0.002 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8   10.970k ± 0%   5.748k ± 0%  -47.60% (p=0.002 n=6)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1-8                   240.0 ± 0%    217.0 ± 0%   -9.58% (p=0.002 n=6)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=100-8                 939.0 ± 0%    223.0 ± 0%  -76.25% (p=0.002 n=6)
RangeQuery/expr=label_join(a_one,_'l2',_'-',_'l',_'l'),steps=1000-8               7283.0 ± 0%    267.0 ± 0%  -96.33% (p=0.002 n=6)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1-8                   336.0 ± 0%    293.0 ± 0%  -12.80% (p=0.002 n=6)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=100-8                1080.0 ± 0%    344.0 ± 0%  -68.15% (p=0.002 n=6)
RangeQuery/expr=label_join(a_ten,_'l2',_'-',_'l',_'l'),steps=1000-8               7793.0 ± 0%    757.0 ± 0%  -90.29% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1-8              1.247k ± 0%   1.016k ± 0%  -18.52% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8            2.429k ± 0%   1.505k ± 0%  -38.04% (p=0.002 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8          12.736k ± 0%   5.512k ± 0%  -56.72% (p=0.002 n=6)
geomean                                                                           1.722k         630.7       -63.36%
```

</p>
</details> 