### PR TITLE
scripts/genproto.sh: Support OSX sed

### DIFF
--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -43,11 +43,11 @@ for dir in ${DIRS}; do
 		protoc --gogofast_out=Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,paths=source_relative:. -I=. \
             -I="${GOGOPROTO_PATH}" \
             ./io/prometheus/client/*.proto
-		sed -i.bak -E 's/import _ \"github.com\/gogo\/protobuf\/gogoproto\"//g' -- *.pb.go
-		sed -i.bak -E 's/import _ \"google\/protobuf\"//g' -- *.pb.go
-		sed -i.bak -E 's/\t_ \"google\/protobuf\"//g' -- *.pb.go
-		sed -i.bak -E 's/golang\/protobuf\/descriptor/gogo\/protobuf\/protoc-gen-gogo\/descriptor/g' -- *.go
-		sed -i.bak -E 's/golang\/protobuf/gogo\/protobuf/g' -- *.go
+		sed -i.bak -E 's/import _ \"github.com\/gogo\/protobuf\/gogoproto\"//g' *.pb.go
+		sed -i.bak -E 's/import _ \"google\/protobuf\"//g' *.pb.go
+		sed -i.bak -E 's/\t_ \"google\/protobuf\"//g' *.pb.go
+		sed -i.bak -E 's/golang\/protobuf\/descriptor/gogo\/protobuf\/protoc-gen-gogo\/descriptor/g' *.go
+		sed -i.bak -E 's/golang\/protobuf/gogo\/protobuf/g' *.go
 		rm -f -- *.bak
 		goimports -w ./*.go ./io/prometheus/client/*.go
 	popd


### PR DESCRIPTION
scripts/genproto.sh seems to assume GNU sed, as it uses `--` to separate arguments from flags, which OSX sed doesn't understand:

```console
✗ make proto
>> generating code from proto files
generating code
~/Projects/prometheus/prometheus/prompb ~/Projects/prometheus/prometheus
sed: --: No such file or directory
make: *** [proto] Error 1
```

AFAICT, there's no practical need to explicitly separate sed flags and arguments in this script, so I propose we drop `--`. I've tested this change on OSX (don't have access to Linux currently), and it works. I did also test with GNU sed on OSX, which works just as well as OSX sed with this version of the script.