### PR TITLE
util/runtime: Ignore nolintlint failure on OSX

### DIFF
--- a/util/runtime/statfs_default.go
+++ b/util/runtime/statfs_default.go
@@ -71,7 +71,8 @@ func Statfs(path string) string {
 
 	var fs syscall.Statfs_t
 	err := syscall.Statfs(path, &fs)
-	//nolint:unconvert // This ensure Type format on all Platforms
+	// nolintlint might cry out depending on the architecture (e.g. ARM64), so ignore it
+	//nolint:unconvert,nolintlint // This ensures Type format on all Platforms
 	localType := int64(fs.Type)
 	if err != nil {
 		return strconv.FormatInt(localType, 16)

--- a/util/runtime/statfs_default.go
+++ b/util/runtime/statfs_default.go
@@ -71,8 +71,8 @@ func Statfs(path string) string {
 
 	var fs syscall.Statfs_t
 	err := syscall.Statfs(path, &fs)
-	// nolintlint might cry out depending on the architecture (e.g. ARM64), so ignore it
-	//nolint:unconvert,nolintlint // This ensures Type format on all Platforms
+	// nolintlint might cry out depending on the architecture (e.g. ARM64), so ignore it.
+	//nolint:unconvert,nolintlint // This ensures Type format on all Platforms.
 	localType := int64(fs.Type)
 	if err != nil {
 		return strconv.FormatInt(localType, 16)


### PR DESCRIPTION
Make the "nolintlint" linter ignore the fact that an "unconvert" linter directive, in the `util/runtime` package, is ignored on OSX. Without this, golangci-lint fails as follows on OSX:
```console
✗ make common-lint
>> running golangci-lint
go list -e -compiled -test=true -export=false -deps=true -find=false -tags= -- ./... > /dev/null
/Users/arve/go/bin/golangci-lint run --timeout 4m ./...
util/runtime/statfs_default.go:74:2: directive `//nolint:unconvert // This ensure Type format on all Platforms` is unused for linter "unconvert" (nolintlint)
	//nolint:unconvert // This ensure Type format on all Platforms
	^
make: *** [common-lint] Error 1
```

Also making a minor language improvement on the same line.