### PR TITLE
Add more rules for flaky TestAsyncRuleEvaluation

### DIFF
--- a/rules/fixtures/rules_multiple_independent_many.yaml
+++ b/rules/fixtures/rules_multiple_independent_many.yaml
@@ -1,0 +1,27 @@
+groups:
+  - name: independents_one
+    rules:
+      - record: job:http_requests:rate1m
+        expr: sum by (job)(rate(http_requests_total[1m]))
+      - record: job:http_requests:rate5m
+        expr: sum by (job)(rate(http_requests_total[5m]))
+      - record: job:http_requests:rate15m
+        expr: sum by (job)(rate(http_requests_total[15m]))
+      - record: job:http_requests:rate30m
+        expr: sum by (job)(rate(http_requests_total[30m]))
+      - record: job:http_requests:rate1h
+        expr: sum by (job)(rate(http_requests_total[1h]))
+      - record: job:http_requests:rate2h
+        expr: sum by (job)(rate(http_requests_total[2h]))
+      - record: job:http_requests:rate4h
+        expr: sum by (job)(rate(http_requests_total[4h]))
+      - record: job:http_requests:rate8h
+        expr: sum by (job)(rate(http_requests_total[8h]))
+      - record: job:http_requests:rate16h
+        expr: sum by (job)(rate(http_requests_total[16h]))
+      - record: job:http_requests:rate32h
+        expr: sum by (job)(rate(http_requests_total[32h]))
+      - record: job:http_requests:rate64h
+        expr: sum by (job)(rate(http_requests_total[64h]))
+      - record: job:http_requests:rate128h
+        expr: sum by (job)(rate(http_requests_total[128h]))

--- a/rules/fixtures/rules_multiple_many.yaml
+++ b/rules/fixtures/rules_multiple_many.yaml
@@ -1,0 +1,30 @@
+groups:
+  - name: test
+    rules:
+      # independents
+      - record: job:http_requests:rate1m
+        expr: sum by (job)(rate(http_requests_total[1m]))
+      - record: job:http_requests:rate5m
+        expr: sum by (job)(rate(http_requests_total[5m]))
+      - record: job:http_requests:rate15m
+        expr: sum by (job)(rate(http_requests_total[15m]))
+      - record: job:http_requests:rate30m
+        expr: sum by (job)(rate(http_requests_total[30m]))
+      - record: job:http_requests:rate1h
+        expr: sum by (job)(rate(http_requests_total[1h]))
+      - record: job:http_requests:rate2h
+        expr: sum by (job)(rate(http_requests_total[2h]))
+      - record: job:http_requests:rate4h
+        expr: sum by (job)(rate(http_requests_total[4h]))
+      - record: job:http_requests:rate8h
+        expr: sum by (job)(rate(http_requests_total[8h]))
+      - record: job:http_requests:rate16h
+        expr: sum by (job)(rate(http_requests_total[16h]))
+      - record: job:http_requests:rate32h
+        expr: sum by (job)(rate(http_requests_total[32h]))
+
+      # dependents
+      - record: job:http_requests:rate15m
+        expr: sum by (job)(rate(http_requests_total[15m]))
+      - record: TooManyRequests
+        expr: job:http_requests:rate15m > 100

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -1900,7 +1900,7 @@ func TestAsyncRuleEvaluation(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		ruleCount := 4
+		ruleCount := 12
 		opts := optsFactory(storage, &maxInflight, &inflightQueries, 0)
 
 		// Configure concurrency settings.
@@ -1909,7 +1909,7 @@ func TestAsyncRuleEvaluation(t *testing.T) {
 		opts.RuleConcurrencyController = nil
 		ruleManager := NewManager(opts)
 
-		groups, errs := ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, []string{"fixtures/rules_multiple.yaml"}...)
+		groups, errs := ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, []string{"fixtures/rules_multiple_many.yaml"}...)
 		require.Empty(t, errs)
 		require.Len(t, groups, 1)
 
@@ -1936,7 +1936,7 @@ func TestAsyncRuleEvaluation(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		ruleCount := 6
+		ruleCount := 12
 		opts := optsFactory(storage, &maxInflight, &inflightQueries, 0)
 
 		// Configure concurrency settings.
@@ -1945,7 +1945,7 @@ func TestAsyncRuleEvaluation(t *testing.T) {
 		opts.RuleConcurrencyController = nil
 		ruleManager := NewManager(opts)
 
-		groups, errs := ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, []string{"fixtures/rules_multiple_independent.yaml"}...)
+		groups, errs := ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, []string{"fixtures/rules_multiple_independent_many.yaml"}...)
 		require.Empty(t, errs)
 		require.Len(t, groups, 1)
 


### PR DESCRIPTION
Hypothesis for flakiness: the concurrency does not get to "kick in" with just 6 rules, and so if we increase the number of rules to evaluate, the time savings due to concurrency will get more marked. 