### PR TITLE
Azure SD: Update predicate check if VM is active

### DIFF
--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -35,6 +35,7 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 	vmType := "type"
 	location := "westeurope"
 	computerName := "computer_name"
+	status := "PowerState/Foo"
 	networkProfile := armcompute.NetworkProfile{
 		NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
 	}
@@ -50,6 +51,9 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 		NetworkProfile: &networkProfile,
 		HardwareProfile: &armcompute.HardwareProfile{
 			VMSize: &vmSize,
+		},
+		InstanceView: &armcompute.VirtualMachineInstanceView{
+			Statuses: []*armcompute.InstanceViewStatus{{Code: &status}},
 		},
 	}
 
@@ -72,6 +76,7 @@ func TestMapFromVMWithEmptyTags(t *testing.T) {
 		Tags:              map[string]*string{},
 		NetworkInterfaces: []string{},
 		Size:              size,
+		PowerStateCode:    "PowerState/Foo",
 	}
 
 	actualVM := mapFromVM(testVM)
@@ -145,6 +150,7 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 	instanceID := "123"
 	location := "westeurope"
 	computerName := "computer_name"
+	status := "PowerState/Foo"
 	networkProfile := armcompute.NetworkProfile{
 		NetworkInterfaces: []*armcompute.NetworkInterfaceReference{},
 	}
@@ -160,6 +166,9 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 		NetworkProfile: &networkProfile,
 		HardwareProfile: &armcompute.HardwareProfile{
 			VMSize: &vmSize,
+		},
+		InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+			Statuses: []*armcompute.InstanceViewStatus{{Code: &status}},
 		},
 	}
 
@@ -186,6 +195,7 @@ func TestMapFromVMScaleSetVMWithEmptyTags(t *testing.T) {
 		ScaleSet:          scaleSet,
 		InstanceID:        instanceID,
 		Size:              size,
+		PowerStateCode:    "PowerState/Foo",
 	}
 
 	actualVM := mapFromVMScaleSetVM(testVM, scaleSet)


### PR DESCRIPTION
As per https://github.com/Azure/azure-sdk-for-go/issues/2838, we can use the `InstanceViewStatus` to view the power status. This was attempted in https://github.com/prometheus/prometheus/pull/4908, but was later [reverted](https://github.com/prometheus/prometheus/pull/4980) due to nil deference. 

Also updated the current logic to check `MacAddress == nil` as discussed in https://github.com/prometheus/prometheus/issues/4340

related to https://github.com/prometheus/prometheus/pull/5569
closes https://github.com/prometheus/prometheus/issues/4340

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
