### PR TITLE
fix bug that would cause us to endlessly fall behind

### DIFF
--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -262,10 +262,8 @@ func (w *Watcher) loop() {
 // Run the watcher, which will tail the WAL until the quit channel is closed
 // or an error case is hit.
 func (w *Watcher) Run() error {
-	_, lastSegment, err := w.firstAndLast()
-	if err != nil {
-		return fmt.Errorf("wal.Segments: %w", err)
-	}
+	var lastSegment int
+	var err error
 
 	// We want to ensure this is false across iterations since
 	// Run will be called again if there was a failure to read the WAL.
@@ -291,18 +289,18 @@ func (w *Watcher) Run() error {
 		return err
 	}
 
-	tail := false
-
 	level.Debug(w.logger).Log("msg", "Tailing WAL", "lastCheckpoint", lastCheckpoint, "checkpointIndex", checkpointIndex, "currentSegment", currentSegment, "lastSegment", lastSegment)
 	for !isClosed(w.quit) {
 		w.currentSegmentMetric.Set(float64(currentSegment))
 		level.Debug(w.logger).Log("msg", "Processing segment", "currentSegment", currentSegment)
 
-		// Reset the value of lastSegment, this is to avoid having to wait too long for between reads if we're reading a
-		// segment that is not the most recent segment after startup. Ignore error here since if there was a problem it would
-		// have been surfaced earlier.
-		_, lastSegment, _ := w.firstAndLast()
-		tail = currentSegment >= lastSegment
+		// Reset the value of lastSegment each iteration, this is to avoid having to wait too long for
+		// between reads if we're reading a segment that is not the most recent segment after startup.
+		_, lastSegment, err = w.firstAndLast()
+		if err != nil {
+			return fmt.Errorf("wal.Segments: %w", err)
+		}
+		tail := currentSegment >= lastSegment
 
 		// On start, after reading the existing WAL for series records, we have a pointer to what is the latest segment.
 		// On subsequent calls to this function, currentSegment will have been incremented and we should open that segment.

--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -484,7 +484,6 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 
 		// we haven't read due to a notification in quite some time, try reading anyways
 		case <-readTicker.C:
-			fmt.Println("reading because of ticker")
 			level.Debug(w.logger).Log("msg", "Watcher is reading the WAL due to timeout, haven't received any write notifications recently", "timeout", readTimeout)
 			err := w.readAndHandleError(reader, segmentNum, tail, size)
 			if err != nil {
@@ -494,8 +493,6 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 			readTicker.Reset(readTimeout)
 
 		case <-w.readNotify:
-			fmt.Println("reading because of notify")
-
 			err := w.readAndHandleError(reader, segmentNum, tail, size)
 			if err != nil {
 				return err

--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -60,17 +60,19 @@ type writeToMock struct {
 	seriesSegmentIndexes    map[chunks.HeadSeriesRef]int
 
 	// delay reads with a short sleep
-	delay bool
+	delay time.Duration
 }
 
 func (wtm *writeToMock) Append(s []record.RefSample) bool {
-	time.Sleep(10 * time.Millisecond)
+	if wtm.delay > 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
 	wtm.samplesAppended += len(s)
 	return true
 }
 
 func (wtm *writeToMock) AppendExemplars(e []record.RefExemplar) bool {
-	if wtm.delay {
+	if wtm.delay > 0 {
 		time.Sleep(10 * time.Millisecond)
 	}
 	wtm.exemplarsAppended += len(e)
@@ -78,7 +80,7 @@ func (wtm *writeToMock) AppendExemplars(e []record.RefExemplar) bool {
 }
 
 func (wtm *writeToMock) AppendHistograms(h []record.RefHistogramSample) bool {
-	if wtm.delay {
+	if wtm.delay > 0 {
 		time.Sleep(10 * time.Millisecond)
 	}
 	wtm.histogramsAppended += len(h)
@@ -86,7 +88,7 @@ func (wtm *writeToMock) AppendHistograms(h []record.RefHistogramSample) bool {
 }
 
 func (wtm *writeToMock) AppendFloatHistograms(fh []record.RefFloatHistogramSample) bool {
-	if wtm.delay {
+	if wtm.delay > 0 {
 		time.Sleep(10 * time.Millisecond)
 	}
 	wtm.floatHistogramsAppended += len(fh)
@@ -94,7 +96,7 @@ func (wtm *writeToMock) AppendFloatHistograms(fh []record.RefFloatHistogramSampl
 }
 
 func (wtm *writeToMock) StoreSeries(series []record.RefSeries, index int) {
-	if wtm.delay {
+	if wtm.delay > 0 {
 		time.Sleep(10 * time.Millisecond)
 	}
 	wtm.UpdateSeriesSegment(series, index)
@@ -129,7 +131,7 @@ func (wtm *writeToMock) checkNumSeries() int {
 func newWriteToMock(delay bool) *writeToMock {
 	return &writeToMock{
 		seriesSegmentIndexes: make(map[chunks.HeadSeriesRef]int),
-		delay:                delay,
+		delay:                10 * time.Millisecond,
 	}
 }
 

--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -714,8 +714,8 @@ func TestRun_AvoidNotifyWhenBehind(t *testing.T) {
 	const seriesCount = 20
 	const samplesCount = 300
 
-	// This test may take slightly more than 1s to finish in cloud CI.
-	readTimeout := 2 * time.Second
+	// This test can take longer than intended to finish in cloud CI.
+	readTimeout := 10 * time.Second
 
 	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
 		t.Run(string(compress), func(t *testing.T) {

--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -65,7 +65,7 @@ type writeToMock struct {
 
 func (wtm *writeToMock) Append(s []record.RefSample) bool {
 	if wtm.delay > 0 {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(wtm.delay)
 	}
 	wtm.samplesAppended += len(s)
 	return true
@@ -73,7 +73,7 @@ func (wtm *writeToMock) Append(s []record.RefSample) bool {
 
 func (wtm *writeToMock) AppendExemplars(e []record.RefExemplar) bool {
 	if wtm.delay > 0 {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(wtm.delay)
 	}
 	wtm.exemplarsAppended += len(e)
 	return true
@@ -81,7 +81,7 @@ func (wtm *writeToMock) AppendExemplars(e []record.RefExemplar) bool {
 
 func (wtm *writeToMock) AppendHistograms(h []record.RefHistogramSample) bool {
 	if wtm.delay > 0 {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(wtm.delay)
 	}
 	wtm.histogramsAppended += len(h)
 	return true
@@ -89,7 +89,7 @@ func (wtm *writeToMock) AppendHistograms(h []record.RefHistogramSample) bool {
 
 func (wtm *writeToMock) AppendFloatHistograms(fh []record.RefFloatHistogramSample) bool {
 	if wtm.delay > 0 {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(wtm.delay)
 	}
 	wtm.floatHistogramsAppended += len(fh)
 	return true
@@ -97,7 +97,7 @@ func (wtm *writeToMock) AppendFloatHistograms(fh []record.RefFloatHistogramSampl
 
 func (wtm *writeToMock) StoreSeries(series []record.RefSeries, index int) {
 	if wtm.delay > 0 {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(wtm.delay)
 	}
 	wtm.UpdateSeriesSegment(series, index)
 }
@@ -128,10 +128,10 @@ func (wtm *writeToMock) checkNumSeries() int {
 	return len(wtm.seriesSegmentIndexes)
 }
 
-func newWriteToMock(delay bool) *writeToMock {
+func newWriteToMock(delay time.Duration) *writeToMock {
 	return &writeToMock{
 		seriesSegmentIndexes: make(map[chunks.HeadSeriesRef]int),
-		delay:                10 * time.Millisecond,
+		delay:                delay,
 	}
 }
 
@@ -228,7 +228,7 @@ func TestTailSamples(t *testing.T) {
 			first, last, err := Segments(w.Dir())
 			require.NoError(t, err)
 
-			wt := newWriteToMock(false)
+			wt := newWriteToMock(0)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, true, true)
 			watcher.SetStartTime(now)
 
@@ -313,7 +313,7 @@ func TestReadToEndNoCheckpoint(t *testing.T) {
 			_, _, err = Segments(w.Dir())
 			require.NoError(t, err)
 
-			wt := newWriteToMock(false)
+			wt := newWriteToMock(0)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			go watcher.Start()
 
@@ -402,7 +402,7 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 			_, _, err = Segments(w.Dir())
 			require.NoError(t, err)
 			readTimeout = time.Second
-			wt := newWriteToMock(false)
+			wt := newWriteToMock(0)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			go watcher.Start()
 
@@ -473,7 +473,7 @@ func TestReadCheckpoint(t *testing.T) {
 			_, _, err = Segments(w.Dir())
 			require.NoError(t, err)
 
-			wt := newWriteToMock(false)
+			wt := newWriteToMock(0)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			go watcher.Start()
 
@@ -542,7 +542,7 @@ func TestReadCheckpointMultipleSegments(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			wt := newWriteToMock(false)
+			wt := newWriteToMock(0)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			watcher.MaxSegment = -1
 
@@ -615,7 +615,7 @@ func TestCheckpointSeriesReset(t *testing.T) {
 			require.NoError(t, err)
 
 			readTimeout = time.Second
-			wt := newWriteToMock(false)
+			wt := newWriteToMock(0)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			watcher.MaxSegment = -1
 			go watcher.Start()
@@ -694,7 +694,7 @@ func TestRun_StartupTime(t *testing.T) {
 			}
 			require.NoError(t, w.Close())
 
-			wt := newWriteToMock(false)
+			wt := newWriteToMock(0)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			watcher.MaxSegment = segments
 
@@ -783,7 +783,7 @@ func TestRun_AvoidNotifyWhenBehind(t *testing.T) {
 				}
 			}()
 
-			wt := newWriteToMock(true)
+			wt := newWriteToMock(time.Millisecond)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			watcher.MaxSegment = segments
 

--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -58,29 +58,45 @@ type writeToMock struct {
 	floatHistogramsAppended int
 	seriesLock              sync.Mutex
 	seriesSegmentIndexes    map[chunks.HeadSeriesRef]int
+
+	// delay reads with a short sleep
+	delay bool
 }
 
 func (wtm *writeToMock) Append(s []record.RefSample) bool {
+	time.Sleep(10 * time.Millisecond)
 	wtm.samplesAppended += len(s)
 	return true
 }
 
 func (wtm *writeToMock) AppendExemplars(e []record.RefExemplar) bool {
+	if wtm.delay {
+		time.Sleep(10 * time.Millisecond)
+	}
 	wtm.exemplarsAppended += len(e)
 	return true
 }
 
 func (wtm *writeToMock) AppendHistograms(h []record.RefHistogramSample) bool {
+	if wtm.delay {
+		time.Sleep(10 * time.Millisecond)
+	}
 	wtm.histogramsAppended += len(h)
 	return true
 }
 
 func (wtm *writeToMock) AppendFloatHistograms(fh []record.RefFloatHistogramSample) bool {
+	if wtm.delay {
+		time.Sleep(10 * time.Millisecond)
+	}
 	wtm.floatHistogramsAppended += len(fh)
 	return true
 }
 
 func (wtm *writeToMock) StoreSeries(series []record.RefSeries, index int) {
+	if wtm.delay {
+		time.Sleep(10 * time.Millisecond)
+	}
 	wtm.UpdateSeriesSegment(series, index)
 }
 
@@ -110,9 +126,10 @@ func (wtm *writeToMock) checkNumSeries() int {
 	return len(wtm.seriesSegmentIndexes)
 }
 
-func newWriteToMock() *writeToMock {
+func newWriteToMock(delay bool) *writeToMock {
 	return &writeToMock{
 		seriesSegmentIndexes: make(map[chunks.HeadSeriesRef]int),
+		delay:                delay,
 	}
 }
 
@@ -209,7 +226,7 @@ func TestTailSamples(t *testing.T) {
 			first, last, err := Segments(w.Dir())
 			require.NoError(t, err)
 
-			wt := newWriteToMock()
+			wt := newWriteToMock(false)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, true, true)
 			watcher.SetStartTime(now)
 
@@ -294,7 +311,7 @@ func TestReadToEndNoCheckpoint(t *testing.T) {
 			_, _, err = Segments(w.Dir())
 			require.NoError(t, err)
 
-			wt := newWriteToMock()
+			wt := newWriteToMock(false)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			go watcher.Start()
 
@@ -383,7 +400,7 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 			_, _, err = Segments(w.Dir())
 			require.NoError(t, err)
 			readTimeout = time.Second
-			wt := newWriteToMock()
+			wt := newWriteToMock(false)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			go watcher.Start()
 
@@ -454,7 +471,7 @@ func TestReadCheckpoint(t *testing.T) {
 			_, _, err = Segments(w.Dir())
 			require.NoError(t, err)
 
-			wt := newWriteToMock()
+			wt := newWriteToMock(false)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			go watcher.Start()
 
@@ -523,7 +540,7 @@ func TestReadCheckpointMultipleSegments(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			wt := newWriteToMock()
+			wt := newWriteToMock(false)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			watcher.MaxSegment = -1
 
@@ -596,7 +613,7 @@ func TestCheckpointSeriesReset(t *testing.T) {
 			require.NoError(t, err)
 
 			readTimeout = time.Second
-			wt := newWriteToMock()
+			wt := newWriteToMock(false)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			watcher.MaxSegment = -1
 			go watcher.Start()
@@ -675,7 +692,7 @@ func TestRun_StartupTime(t *testing.T) {
 			}
 			require.NoError(t, w.Close())
 
-			wt := newWriteToMock()
+			wt := newWriteToMock(false)
 			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
 			watcher.MaxSegment = segments
 
@@ -685,6 +702,92 @@ func TestRun_StartupTime(t *testing.T) {
 			err = watcher.Run()
 			require.Less(t, time.Since(startTime), readTimeout)
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestRun_AvoidNotifyWhenBehind(t *testing.T) {
+	const pageSize = 32 * 1024
+	const segments = 10
+	const seriesCount = 20
+	const samplesCount = 300
+
+	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
+		t.Run(string(compress), func(t *testing.T) {
+			dir := t.TempDir()
+
+			wdir := path.Join(dir, "wal")
+			err := os.Mkdir(wdir, 0o777)
+			require.NoError(t, err)
+
+			enc := record.Encoder{}
+			w, err := NewSize(nil, nil, wdir, pageSize, compress)
+			require.NoError(t, err)
+			var wg sync.WaitGroup
+			for i := 0; i < 1; i++ {
+				for j := 0; j < seriesCount; j++ {
+					ref := j + (i * 100)
+					series := enc.Series([]record.RefSeries{
+						{
+							Ref:    chunks.HeadSeriesRef(ref),
+							Labels: labels.FromStrings("__name__", fmt.Sprintf("metric_%d", i)),
+						},
+					}, nil)
+					require.NoError(t, w.Log(series))
+
+					for k := 0; k < samplesCount; k++ {
+						inner := rand.Intn(ref + 1)
+						sample := enc.Samples([]record.RefSample{
+							{
+								Ref: chunks.HeadSeriesRef(inner),
+								T:   int64(i),
+								V:   float64(i),
+							},
+						}, nil)
+						require.NoError(t, w.Log(sample))
+					}
+				}
+			}
+			go func() {
+				wg.Add(1)
+				defer wg.Done()
+				for i := 1; i < segments; i++ {
+					for j := 0; j < seriesCount; j++ {
+						ref := j + (i * 100)
+						series := enc.Series([]record.RefSeries{
+							{
+								Ref:    chunks.HeadSeriesRef(ref),
+								Labels: labels.FromStrings("__name__", fmt.Sprintf("metric_%d", i)),
+							},
+						}, nil)
+						require.NoError(t, w.Log(series))
+
+						for k := 0; k < samplesCount; k++ {
+							inner := rand.Intn(ref + 1)
+							sample := enc.Samples([]record.RefSample{
+								{
+									Ref: chunks.HeadSeriesRef(inner),
+									T:   int64(i),
+									V:   float64(i),
+								},
+							}, nil)
+							require.NoError(t, w.Log(sample))
+						}
+					}
+				}
+			}()
+
+			wt := newWriteToMock(true)
+			watcher := NewWatcher(wMetrics, nil, nil, "", wt, dir, false, false)
+			watcher.MaxSegment = segments
+
+			watcher.setMetrics()
+			startTime := time.Now()
+			err = watcher.Run()
+			wg.Wait()
+			require.Less(t, time.Since(startTime), readTimeout)
+			require.NoError(t, err)
+			require.NoError(t, w.Close())
 		})
 	}
 }


### PR DESCRIPTION
This should fix https://github.com/prometheus/prometheus/issues/13471 

The `notify` read implementation, which was in effort to reduce CPU consumption especially in lower scrape throughput deployments, had a bug that meant that if remote write had fallen behind and was reading from a WAL segment that was not the segment which was currently being written to we would only read as a result of the fallback timer which is every 15s. This meant that if remote write had fallen behind it would only continue to fall further behind. 

With this PR we're updating the value of `lastSegment` each time we iterate over the loop and open the `currentSegment` to be the segment ID that is currently being written to. In short, if segment `10` is being written to but the watcher is currently reading from segment `9`, we won't wait for the notify ticker before actually doing the read.

The test I'm adding here took more than 2 minutes to finish and fails, and passes in just over 1s with the change from this pr.


Before
```
go test -run TestRun_AvoidNotifyWhenBehind -v
=== RUN   TestRun_AvoidNotifyWhenBehind
=== RUN   TestRun_AvoidNotifyWhenBehind/none
    watcher_test.go:788:
        	Error Trace:	/home/callum/go/src/github.com/prometheus/prometheus/tsdb/wlog/watcher_test.go:788
        	Error:      	"47.042147543s" is not less than "15s"
        	Test:       	TestRun_AvoidNotifyWhenBehind/none
=== RUN   TestRun_AvoidNotifyWhenBehind/snappy
    watcher_test.go:788:
        	Error Trace:	/home/callum/go/src/github.com/prometheus/prometheus/tsdb/wlog/watcher_test.go:788
        	Error:      	"1m8.25411025s" is not less than "15s"
        	Test:       	TestRun_AvoidNotifyWhenBehind/snappy
=== RUN   TestRun_AvoidNotifyWhenBehind/zstd
    watcher_test.go:788:
        	Error Trace:	/home/callum/go/src/github.com/prometheus/prometheus/tsdb/wlog/watcher_test.go:788
        	Error:      	"52.939656246s" is not less than "15s"
        	Test:       	TestRun_AvoidNotifyWhenBehind/zstd
--- FAIL: TestRun_AvoidNotifyWhenBehind (168.29s)
    --- FAIL: TestRun_AvoidNotifyWhenBehind/none (47.05s)
    --- FAIL: TestRun_AvoidNotifyWhenBehind/snappy (68.26s)
    --- FAIL: TestRun_AvoidNotifyWhenBehind/zstd (52.97s)
FAIL
exit status 1
FAIL	github.com/prometheus/prometheus/tsdb/wlog	168.291s
```

After
```
go test -run TestRun_AvoidNotifyWhenBehind -v
=== RUN   TestRun_AvoidNotifyWhenBehind
=== RUN   TestRun_AvoidNotifyWhenBehind/none
=== RUN   TestRun_AvoidNotifyWhenBehind/snappy
=== RUN   TestRun_AvoidNotifyWhenBehind/zstd
--- PASS: TestRun_AvoidNotifyWhenBehind (1.24s)
    --- PASS: TestRun_AvoidNotifyWhenBehind/none (0.38s)
    --- PASS: TestRun_AvoidNotifyWhenBehind/snappy (0.45s)
    --- PASS: TestRun_AvoidNotifyWhenBehind/zstd (0.41s)
PASS
ok  	github.com/prometheus/prometheus/tsdb/wlog	1.249s
```