### PR TITLE
Update `go get buf.build` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ We are publishing our Remote Write protobuf independently at
 You can use that as a library:
 
 ```shell
-go get go.buf.build/protocolbuffers/go/prometheus/prometheus
+go get buf.build/gen/go/prometheus/prometheus/protocolbuffers/go@latest
 ```
 
 This is experimental.


### PR DESCRIPTION
The old import path stopped working. 

```
go get go.buf.build/protocolbuffers/go/prometheus/prometheus
go: unrecognized import path "go.buf.build/protocolbuffers/go/prometheus/prometheus": https fetch: Get "https://go.buf.build/protocolbuffers/go/prometheus/prometheus?go-get=1": dial tcp: lookup go.buf.build on 192.168.2.1:53: no such host
```

We should instead tell users to use the new import paths:
```
go get buf.build/gen/go/prometheus/prometheus/protocolbuffers/go@latest
```
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
