### PR TITLE
UTF-8: updates UI parser to support UTF-8 characters

### DIFF
--- a/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
@@ -300,6 +300,12 @@ describe('analyzeCompletion test', () => {
       expectedContext: [{ kind: ContextKind.LabelName, metricName: '' }],
     },
     {
+      title: 'continue to autocomplete quoted labelName associated to a metric',
+      expr: '{"metric_"}',
+      pos: 10, // cursor is between the bracket after the string metric_
+      expectedContext: [{ kind: ContextKind.MetricName, metricName: 'metric_' }],
+    },
+    {
       title: 'autocomplete the labelValue with metricName + labelName',
       expr: 'metric_name{labelName=""}',
       pos: 23, // cursor is between the quotes
@@ -337,6 +343,30 @@ describe('analyzeCompletion test', () => {
               name: 'labelName',
               type: Neq,
               value: '',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      title: 'autocomplete the labelValue with metricName + quoted labelName',
+      expr: 'metric_name{labelName="labelValue", "labelName"!=""}',
+      pos: 50, // cursor is between the quotes
+      expectedContext: [
+        {
+          kind: ContextKind.LabelValue,
+          metricName: 'metric_name',
+          labelName: 'labelName',
+          matchers: [
+            {
+              name: 'labelName',
+              type: Neq,
+              value: '',
+            },
+            {
+              name: 'labelName',
+              type: EqlSingle,
+              value: 'labelValue',
             },
           ],
         },
@@ -426,6 +456,12 @@ describe('analyzeCompletion test', () => {
       expr: 'metric_name{labelName!}',
       pos: 22, // cursor is after '!'
       expectedContext: [{ kind: ContextKind.MatchOp }],
+    },
+    {
+      title: 'autocomplete matchOp 3',
+      expr: 'metric_name{"labelName"!}',
+      pos: 24, // cursor is after '!'
+      expectedContext: [{ kind: ContextKind.BinOp }],
     },
     {
       title: 'autocomplete duration with offset',

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
@@ -252,6 +252,12 @@ describe('analyzeCompletion test', () => {
       expectedContext: [{ kind: ContextKind.LabelName }],
     },
     {
+      title: 'continue to autocomplete QuotedLabelName in aggregate modifier',
+      expr: 'sum by ("myL")',
+      pos: 12, // cursor is between the bracket after the string myL
+      expectedContext: [{ kind: ContextKind.LabelName }],
+    },
+    {
       title: 'autocomplete labelName in a list',
       expr: 'sum by (myLabel1,)',
       pos: 17, // cursor is between the bracket after the string myLab
@@ -261,6 +267,12 @@ describe('analyzeCompletion test', () => {
       title: 'autocomplete labelName in a list 2',
       expr: 'sum by (myLabel1, myLab)',
       pos: 23, // cursor is between the bracket after the string myLab
+      expectedContext: [{ kind: ContextKind.LabelName }],
+    },
+    {
+      title: 'autocomplete labelName in a list 2',
+      expr: 'sum by ("myLabel1", "myLab")',
+      pos: 27, // cursor is between the bracket after the string myLab
       expectedContext: [{ kind: ContextKind.LabelName }],
     },
     {

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -380,7 +380,12 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
       result.push({ kind: ContextKind.LabelName, metricName: getMetricNameInVectorSelector(node, state) });
       break;
     case QuotedLabelName:
-      if (node.parent?.type.id === LabelMatchers) {
+      if (node.parent?.type.id === GroupingLabels) {
+        // In this case we are in the given situation:
+        //      sum by ("myL")
+        // So we have to continue to autocomplete any kind of labelName
+        result.push({ kind: ContextKind.LabelName });
+      } else if (node.parent?.type.id === LabelMatchers) {
         // In that case we are in the given situation:
         //       {""} or {"metric_"}
         // since this is for the QuotedMetricName we need to continue to autocomplete for the metric names

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -379,19 +379,6 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
       // so we have or to autocomplete any kind of labelName or to autocomplete only the labelName associated to the metric
       result.push({ kind: ContextKind.LabelName, metricName: getMetricNameInVectorSelector(node, state) });
       break;
-    case QuotedLabelName:
-      if (node.parent?.type.id === GroupingLabels) {
-        // In this case we are in the given situation:
-        //      sum by ("myL")
-        // So we have to continue to autocomplete any kind of labelName
-        result.push({ kind: ContextKind.LabelName });
-      } else if (node.parent?.type.id === LabelMatchers) {
-        // In that case we are in the given situation:
-        //       {""} or {"metric_"}
-        // since this is for the QuotedMetricName we need to continue to autocomplete for the metric names
-        result.push({ kind: ContextKind.MetricName, metricName: state.sliceDoc(node.from, node.to).slice(1, -1) });
-      }
-      break;
     case LabelName:
       if (node.parent?.type.id === GroupingLabels) {
         // In this case we are in the given situation:
@@ -435,6 +422,16 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
           labelName: labelName,
           matchers: labelMatchers,
         });
+      } else if (node.parent?.parent?.type.id === GroupingLabels) {
+        // In this case we are in the given situation:
+        //      sum by ("myL")
+        // So we have to continue to autocomplete any kind of labelName
+        result.push({ kind: ContextKind.LabelName });
+      } else if (node.parent?.parent?.type.id === LabelMatchers) {
+        // In that case we are in the given situation:
+        //       {""} or {"metric_"}
+        // since this is for the QuotedMetricName we need to continue to autocomplete for the metric names
+        result.push({ kind: ContextKind.MetricName, metricName: state.sliceDoc(node.from, node.to).slice(1, -1) });
       }
       break;
     case NumberLiteral:

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -52,7 +52,7 @@ import {
   SubqueryExpr,
   Unless,
   VectorSelector,
-  LegacyLabelMatcher,
+  UnquotedLabelMatcher,
 } from '@prometheus-io/lezer-promql';
 import { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import { EditorState } from '@codemirror/state';
@@ -182,7 +182,7 @@ export function computeStartCompletePosition(node: SyntaxNode, pos: number): num
   let start = node.from;
   if (node.type.id === LabelMatchers || node.type.id === GroupingLabels) {
     start = computeStartCompleteLabelPositionInLabelMatcherOrInGroupingLabel(node, pos);
-  } else if (node.type.id === FunctionCallBody || (node.type.id === StringLiteral && node.parent?.type.id === LegacyLabelMatcher)) {
+  } else if (node.type.id === FunctionCallBody || (node.type.id === StringLiteral && node.parent?.type.id === UnquotedLabelMatcher)) {
     // When the cursor is between bracket, quote, we need to increment the starting position to avoid to consider the open bracket/ first string.
     start++;
   } else if (
@@ -213,7 +213,7 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
         result.push({ kind: ContextKind.Duration });
         break;
       }
-      if (node.parent?.type.id === LegacyLabelMatcher) {
+      if (node.parent?.type.id === UnquotedLabelMatcher) {
         // In this case the current token is not itself a valid match op yet:
         //      metric_name{labelName!}
         result.push({ kind: ContextKind.MatchOp });
@@ -381,7 +381,7 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
         //      sum by (myL)
         // So we have to continue to autocomplete any kind of labelName
         result.push({ kind: ContextKind.LabelName });
-      } else if (node.parent?.type.id === LegacyLabelMatcher) {
+      } else if (node.parent?.type.id === UnquotedLabelMatcher) {
         // In that case we are in the given situation:
         //       metric_name{myL} or {myL}
         // so we have or to continue to autocomplete any kind of labelName or
@@ -390,7 +390,7 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
       }
       break;
     case StringLiteral:
-      if (node.parent?.type.id === LegacyLabelMatcher) {
+      if (node.parent?.type.id === UnquotedLabelMatcher) {
         // In this case we are in the given situation:
         //      metric_name{labelName=""}
         // So we can autocomplete the labelValue

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -52,6 +52,7 @@ import {
   SubqueryExpr,
   Unless,
   VectorSelector,
+  LegacyLabelMatcher,
 } from '@prometheus-io/lezer-promql';
 import { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import { EditorState } from '@codemirror/state';
@@ -181,7 +182,7 @@ export function computeStartCompletePosition(node: SyntaxNode, pos: number): num
   let start = node.from;
   if (node.type.id === LabelMatchers || node.type.id === GroupingLabels) {
     start = computeStartCompleteLabelPositionInLabelMatcherOrInGroupingLabel(node, pos);
-  } else if (node.type.id === FunctionCallBody || (node.type.id === StringLiteral && node.parent?.type.id === LabelMatcher)) {
+  } else if (node.type.id === FunctionCallBody || (node.type.id === StringLiteral && node.parent?.type.id === LegacyLabelMatcher)) {
     // When the cursor is between bracket, quote, we need to increment the starting position to avoid to consider the open bracket/ first string.
     start++;
   } else if (
@@ -212,7 +213,7 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
         result.push({ kind: ContextKind.Duration });
         break;
       }
-      if (node.parent?.type.id === LabelMatcher) {
+      if (node.parent?.type.id === LegacyLabelMatcher) {
         // In this case the current token is not itself a valid match op yet:
         //      metric_name{labelName!}
         result.push({ kind: ContextKind.MatchOp });
@@ -380,7 +381,7 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
         //      sum by (myL)
         // So we have to continue to autocomplete any kind of labelName
         result.push({ kind: ContextKind.LabelName });
-      } else if (node.parent?.type.id === LabelMatcher) {
+      } else if (node.parent?.type.id === LegacyLabelMatcher) {
         // In that case we are in the given situation:
         //       metric_name{myL} or {myL}
         // so we have or to continue to autocomplete any kind of labelName or
@@ -389,7 +390,7 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
       }
       break;
     case StringLiteral:
-      if (node.parent?.type.id === LabelMatcher) {
+      if (node.parent?.type.id === LegacyLabelMatcher) {
         // In this case we are in the given situation:
         //      metric_name{labelName=""}
         // So we can autocomplete the labelValue

--- a/web/ui/module/codemirror-promql/src/parser/matcher.ts
+++ b/web/ui/module/codemirror-promql/src/parser/matcher.ts
@@ -20,10 +20,10 @@ import {
   Neq,
   NeqRegex,
   StringLiteral,
-  LegacyLabelMatcher,
-  NewLabelMatcher,
+  UnquotedLabelMatcher,
+  QuotedLabelMatcher,
   MetricNameLabelMatcher,
-  NewLabelName,
+  QuotedLabelName,
 } from '@prometheus-io/lezer-promql';
 import { EditorState } from '@codemirror/state';
 import { Matcher } from '../types';
@@ -36,14 +36,14 @@ function createMatcher(labelMatcher: SyntaxNode, state: EditorState): Matcher {
     return matcher;
   }
   switch (cursor.type.id) {
-    case NewLabelMatcher:
+    case QuotedLabelMatcher:
       if (!cursor.next()) {
         // weird case, that would mean the labelMatcher doesn't have any child.
         return matcher;
       }
       do {
         switch (cursor.type.id) {
-          case NewLabelName:
+          case QuotedLabelName:
             matcher.name = state.sliceDoc(cursor.from, cursor.to).slice(1, -1);
             break;
           case MatchOp:
@@ -58,7 +58,7 @@ function createMatcher(labelMatcher: SyntaxNode, state: EditorState): Matcher {
         }
       } while (cursor.nextSibling());
       break;
-    case LegacyLabelMatcher:
+    case UnquotedLabelMatcher:
       if (!cursor.next()) {
         // weird case, that would mean the labelMatcher doesn't have any child.
         return matcher;

--- a/web/ui/module/codemirror-promql/src/parser/matcher.ts
+++ b/web/ui/module/codemirror-promql/src/parser/matcher.ts
@@ -22,7 +22,6 @@ import {
   StringLiteral,
   UnquotedLabelMatcher,
   QuotedLabelMatcher,
-  MetricNameLabelMatcher,
   QuotedLabelName,
 } from '@prometheus-io/lezer-promql';
 import { EditorState } from '@codemirror/state';
@@ -31,10 +30,6 @@ import { Matcher } from '../types';
 function createMatcher(labelMatcher: SyntaxNode, state: EditorState): Matcher {
   const matcher = new Matcher(0, '', '');
   const cursor = labelMatcher.cursor();
-  if (!cursor.next()) {
-    // weird case, that would mean the labelMatcher doesn't have any child.
-    return matcher;
-  }
   switch (cursor.type.id) {
     case QuotedLabelMatcher:
       if (!cursor.next()) {
@@ -80,7 +75,7 @@ function createMatcher(labelMatcher: SyntaxNode, state: EditorState): Matcher {
         }
       } while (cursor.nextSibling());
       break;
-    case MetricNameLabelMatcher:
+    case QuotedLabelName:
       matcher.name = '__name__';
       matcher.value = state.sliceDoc(cursor.from, cursor.to).slice(1, -1);
       matcher.type = EqlSingle;

--- a/web/ui/module/codemirror-promql/src/parser/matcher.ts
+++ b/web/ui/module/codemirror-promql/src/parser/matcher.ts
@@ -38,7 +38,7 @@ function createMatcher(labelMatcher: SyntaxNode, state: EditorState): Matcher {
   switch (cursor.type.id) {
     case QuotedLabelMatcher:
       if (!cursor.next()) {
-        // weird case, that would mean the labelMatcher doesn't have any child.
+        // weird case, that would mean the QuotedLabelMatcher doesn't have any child.
         return matcher;
       }
       do {
@@ -60,7 +60,7 @@ function createMatcher(labelMatcher: SyntaxNode, state: EditorState): Matcher {
       break;
     case UnquotedLabelMatcher:
       if (!cursor.next()) {
-        // weird case, that would mean the labelMatcher doesn't have any child.
+        // weird case, that would mean the UnquotedLabelMatcher doesn't have any child.
         return matcher;
       }
       do {

--- a/web/ui/module/codemirror-promql/src/parser/parser.test.ts
+++ b/web/ui/module/codemirror-promql/src/parser/parser.test.ts
@@ -943,6 +943,16 @@ describe('promql operations', () => {
         },
       ],
     },
+    {
+      expr: `{'foo\`metric':'bar'}`, // eslint-disable-line
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{`foo\"metric`=`bar`}', // eslint-disable-line
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
   ];
   testCases.forEach((value) => {
     const state = createEditorState(value.expr);

--- a/web/ui/module/codemirror-promql/src/parser/parser.test.ts
+++ b/web/ui/module/codemirror-promql/src/parser/parser.test.ts
@@ -825,6 +825,124 @@ describe('promql operations', () => {
       expectedValueType: ValueType.vector,
       expectedDiag: [],
     },
+    {
+      expr: '{"foo"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      // with metric name in the middle
+      expr: '{a="b","foo",c~="d"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"foo", a="bc"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"colon:in:the:middle"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"dot.in.the.middle"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"😀 in metric name"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      // quotes with escape
+      expr: '{"this is \"foo\" metric"}', // eslint-disable-line
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"foo","colon:in:the:middle"="val"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"foo","dot.in.the.middle"="val"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: '{"foo","😀 in label name"="val"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      // quotes with escape
+      expr: '{"foo","this is \"bar\" label"="val"}', // eslint-disable-line
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: 'foo{"bar"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          message: 'metric name must not be set twice: foo or bar',
+          severity: 'error',
+          to: 10,
+        },
+      ],
+    },
+    {
+      expr: '{"foo", __name__="bar"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          message: 'metric name must not be set twice: foo or bar',
+          severity: 'error',
+          to: 23,
+        },
+      ],
+    },
+    {
+      expr: '{"foo", "__name__"="bar"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          message: 'metric name must not be set twice: foo or bar',
+          severity: 'error',
+          to: 25,
+        },
+      ],
+    },
+    {
+      expr: '{"__name__"="foo", __name__="bar"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          message: 'metric name must not be set twice: foo or bar',
+          severity: 'error',
+          to: 34,
+        },
+      ],
+    },
+    {
+      expr: '{"foo", "bar"}',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          to: 14,
+          message: 'metric name must not be set twice: foo or bar',
+          severity: 'error',
+        },
+      ],
+    },
   ];
   testCases.forEach((value) => {
     const state = createEditorState(value.expr);

--- a/web/ui/module/codemirror-promql/src/parser/parser.test.ts
+++ b/web/ui/module/codemirror-promql/src/parser/parser.test.ts
@@ -205,12 +205,22 @@ describe('promql operations', () => {
       expectedDiag: [] as Diagnostic[],
     },
     {
+      expr: 'foo and on(test,"blub") bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
       expr: 'foo and on() bar',
       expectedValueType: ValueType.vector,
       expectedDiag: [] as Diagnostic[],
     },
     {
       expr: 'foo and ignoring(test,blub) bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
+      expr: 'foo and ignoring(test,"blub") bar',
       expectedValueType: ValueType.vector,
       expectedDiag: [] as Diagnostic[],
     },
@@ -226,6 +236,11 @@ describe('promql operations', () => {
     },
     {
       expr: 'foo / on(test,blub) group_left(bar) bar',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [] as Diagnostic[],
+    },
+    {
+      expr: 'foo / on(test,blub) group_left("bar") bar',
       expectedValueType: ValueType.vector,
       expectedDiag: [] as Diagnostic[],
     },

--- a/web/ui/module/codemirror-promql/src/parser/parser.ts
+++ b/web/ui/module/codemirror-promql/src/parser/parser.ts
@@ -301,6 +301,14 @@ export class Parser {
       // adding the metric name as a Matcher to avoid a false positive for this kind of expression:
       // foo{bare=''}
       labelMatchers.push(new Matcher(EqlSingle, '__name__', vectorSelectorName));
+    } else {
+      // In this case when metric name is not set outside the braces
+      // It is checking whether metric name is set twice like in :
+      // {__name__:"foo", "foo"}, {"foo", "bar"}
+      const labelMatchersMetricName = labelMatchers.filter((lm) => lm.name === '__name__');
+      if (labelMatchersMetricName.length > 1) {
+        this.addDiagnostic(node, `metric name must not be set twice: ${labelMatchersMetricName[0].value} or ${labelMatchersMetricName[1].value}`);
+      }
     }
 
     // A Vector selector must contain at least one non-empty matcher to prevent

--- a/web/ui/module/codemirror-promql/src/parser/parser.ts
+++ b/web/ui/module/codemirror-promql/src/parser/parser.ts
@@ -27,7 +27,6 @@ import {
   Gte,
   Gtr,
   Identifier,
-  LabelMatcher,
   LabelMatchers,
   Lss,
   Lte,
@@ -36,11 +35,14 @@ import {
   Or,
   ParenExpr,
   Quantile,
+  QuotedLabelMatcher,
+  QuotedLabelName,
   StepInvariantExpr,
   SubqueryExpr,
   Topk,
   UnaryExpr,
   Unless,
+  UnquotedLabelMatcher,
   VectorSelector,
 } from '@prometheus-io/lezer-promql';
 import { containsAtLeastOneChild } from './path-finder';
@@ -282,7 +284,11 @@ export class Parser {
 
   private checkVectorSelector(node: SyntaxNode): void {
     const matchList = node.getChild(LabelMatchers);
-    const labelMatchers = buildLabelMatchers(matchList ? matchList.getChildren(LabelMatcher) : [], this.state);
+    const labelMatcherOpts = [QuotedLabelName, QuotedLabelMatcher, UnquotedLabelMatcher];
+    let labelMatchers: Matcher[] = [];
+    for (const labelMatcherOpt of labelMatcherOpts) {
+      labelMatchers = labelMatchers.concat(buildLabelMatchers(matchList ? matchList.getChildren(labelMatcherOpt) : [], this.state));
+    }
     let vectorSelectorName = '';
     // VectorSelector ( Identifier )
     // https://github.com/promlabs/lezer-promql/blob/71e2f9fa5ae6f5c5547d5738966cd2512e6b99a8/src/promql.grammar#L200

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -289,7 +289,11 @@ NumberLiteral  {
   }
   Identifier { (std.asciiLetter | "_" | ":") (std.asciiLetter | std.digit | "_" | ":" )*}
   LabelName { (std.asciiLetter | "_") (std.asciiLetter | std.digit | "_")* }
-  QuotedLabelName { '"' (![\\\n"] | "\\" _)* '"' }
+  QuotedLabelName {
+    '"' (![\\\n"] | "\\" _)* '"' |
+    "'" (![\\\n'] | "\\" _)* "'" |
+    "`" ![`]* "`"
+  }
 
   // Operator
   Sub { "-" }

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -97,7 +97,7 @@ binModifiers {
 }
 
 GroupingLabels {
-  "(" (LabelName ("," LabelName)* ","?)? ")"
+  "(" ((LabelName | QuotedLabelName) ("," (LabelName | QuotedLabelName))* ","?)? ")"
 }
 
 FunctionCall {

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -220,7 +220,7 @@ VectorSelector {
 }
 
 LabelMatchers {
-  "{" (LabelMatcher ("," LabelMatcher)* ","?)? "}"
+  "{" ((UnquotedLabelMatcher | QuotedLabelMatcher | QuotedLabelName)("," (UnquotedLabelMatcher | QuotedLabelMatcher | QuotedLabelName))* ","?)? "}"
 }
 
 MatchOp {
@@ -230,22 +230,12 @@ MatchOp {
   NeqRegex
 }
 
-LabelMatcher {
-  UnquotedLabelMatcher |
-  QuotedLabelMatcher |
-  MetricNameLabelMatcher
-}
-
 UnquotedLabelMatcher {
     LabelName MatchOp StringLiteral
 }
 
 QuotedLabelMatcher {
     QuotedLabelName MatchOp StringLiteral
-}
-
-MetricNameLabelMatcher {
-    QuotedLabelName
 }
 
 StepInvariantExpr {

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -231,21 +231,21 @@ MatchOp {
 }
 
 LabelMatcher {
-  LegacyLabelMatcher |
-  NewLabelMatcher |
+  UnquotedLabelMatcher |
+  QuotedLabelMatcher |
   MetricNameLabelMatcher
 }
 
-LegacyLabelMatcher {
+UnquotedLabelMatcher {
     LabelName MatchOp StringLiteral
 }
 
-NewLabelMatcher {
-    NewLabelName MatchOp StringLiteral
+QuotedLabelMatcher {
+    QuotedLabelName MatchOp StringLiteral
 }
 
 MetricNameLabelMatcher {
-    NewLabelName
+    QuotedLabelName
 }
 
 StepInvariantExpr {
@@ -289,7 +289,7 @@ NumberLiteral  {
   }
   Identifier { (std.asciiLetter | "_" | ":") (std.asciiLetter | std.digit | "_" | ":" )*}
   LabelName { (std.asciiLetter | "_") (std.asciiLetter | std.digit | "_")* }
-  NewLabelName { '"' (![\\\n"] | "\\" _)* '"' }
+  QuotedLabelName { '"' (![\\\n"] | "\\" _)* '"' }
 
   // Operator
   Sub { "-" }

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -238,6 +238,10 @@ QuotedLabelMatcher {
     QuotedLabelName MatchOp StringLiteral
 }
 
+QuotedLabelName {
+    StringLiteral
+}
+
 StepInvariantExpr {
   expr At ( NumberLiteral | AtModifierPreprocessors "(" ")" )
 }
@@ -279,11 +283,6 @@ NumberLiteral  {
   }
   Identifier { (std.asciiLetter | "_" | ":") (std.asciiLetter | std.digit | "_" | ":" )*}
   LabelName { (std.asciiLetter | "_") (std.asciiLetter | std.digit | "_")* }
-  QuotedLabelName {
-    '"' (![\\\n"] | "\\" _)* '"' |
-    "'" (![\\\n'] | "\\" _)* "'" |
-    "`" ![`]* "`"
-  }
 
   // Operator
   Sub { "-" }

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -231,7 +231,21 @@ MatchOp {
 }
 
 LabelMatcher {
-  LabelName MatchOp StringLiteral
+  LegacyLabelMatcher |
+  NewLabelMatcher |
+  MetricNameLabelMatcher
+}
+
+LegacyLabelMatcher {
+    LabelName MatchOp StringLiteral
+}
+
+NewLabelMatcher {
+    NewLabelName MatchOp StringLiteral
+}
+
+MetricNameLabelMatcher {
+    NewLabelName
 }
 
 StepInvariantExpr {
@@ -275,6 +289,7 @@ NumberLiteral  {
   }
   Identifier { (std.asciiLetter | "_" | ":") (std.asciiLetter | std.digit | "_" | ":" )*}
   LabelName { (std.asciiLetter | "_") (std.asciiLetter | std.digit | "_")* }
+  NewLabelName { '"' (![\\\n"] | "\\" _)* '"' }
 
   // Operator
   Sub { "-" }

--- a/web/ui/module/lezer-promql/test/expression.txt
+++ b/web/ui/module/lezer-promql/test/expression.txt
@@ -227,24 +227,32 @@ PromQL(
       Identifier,
       LabelMatchers(
         LabelMatcher(
-          LabelName,
-          MatchOp(EqlSingle),
-          StringLiteral
+          LegacyLabelMatcher(
+            LabelName,
+            MatchOp(EqlSingle),
+            StringLiteral
+          )
         ),
         LabelMatcher(
-          LabelName,
-          MatchOp(Neq),
-          StringLiteral
+          LegacyLabelMatcher(
+            LabelName,
+            MatchOp(Neq),
+            StringLiteral
+          )
         ),
         LabelMatcher(
-          LabelName,
-          MatchOp(EqlRegex),
-          StringLiteral
+          LegacyLabelMatcher(
+            LabelName,
+            MatchOp(EqlRegex),
+            StringLiteral
+          )
         ),
         LabelMatcher(
-          LabelName,
-          MatchOp(NeqRegex),
-          StringLiteral
+          LegacyLabelMatcher(
+            LabelName,
+            MatchOp(NeqRegex),
+            StringLiteral
+          )
         )
       )
     )
@@ -571,14 +579,14 @@ PromQL(NumberLiteral)
 NaN{foo="bar"}
 
 ==>
-PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
+PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LegacyLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral))))))
 
 # Trying to illegally use Inf as a metric name.
 
 Inf{foo="bar"}
 
 ==>
-PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
+PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LegacyLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral))))))
 
 # Negative offset
 
@@ -614,3 +622,24 @@ MetricName(Identifier)
 
 ==>
 PromQL(BinaryExpr(NumberLiteral,Add,BinaryExpr(VectorSelector(Identifier),Atan2,VectorSelector(Identifier))))
+
+# Testing quoted metric name
+
+{"metric_name"}
+
+==>
+PromQL(VectorSelector(LabelMatchers(LabelMatcher(MetricNameLabelMatcher(NewLabelName)))))
+
+# Testing quoted label name
+
+{"foo"="bar"}
+
+==>
+PromQL(VectorSelector(LabelMatchers(LabelMatcher(NewLabelMatcher(NewLabelName, MatchOp(EqlSingle), StringLiteral)))))
+
+# Testing quoted metric name and label name
+
+{"metric_name", "foo"="bar"}
+
+==>
+PromQL(VectorSelector(LabelMatchers(LabelMatcher(MetricNameLabelMatcher(NewLabelName)), LabelMatcher(NewLabelMatcher(NewLabelName, MatchOp(EqlSingle), StringLiteral)))))

--- a/web/ui/module/lezer-promql/test/expression.txt
+++ b/web/ui/module/lezer-promql/test/expression.txt
@@ -112,6 +112,54 @@ PromQL(
     )
 )
 
+# Quoted label name in grouping labels
+
+sum by("job", mode) (test_metric) / on("job") group_left sum by("job")(test_metric)
+
+==>
+
+PromQL(
+    BinaryExpr(
+        AggregateExpr(
+          AggregateOp(Sum),
+          AggregateModifier(
+            By,
+            GroupingLabels(
+                QuotedLabelName,
+                LabelName
+            )
+          ),
+          FunctionCallBody(
+                VectorSelector(
+                  Identifier
+                )
+          )
+      ),
+      Div,
+        MatchingModifierClause(
+          On,
+          GroupingLabels(
+              QuotedLabelName
+          )
+          GroupLeft
+        ),
+        AggregateExpr(
+          AggregateOp(Sum),
+          AggregateModifier(
+            By,
+            GroupingLabels(
+                QuotedLabelName
+            )
+          ),
+          FunctionCallBody(
+                VectorSelector(
+                  Identifier
+                )
+          )
+        )
+    )
+)
+
 # Case insensitivity for aggregations and binop modifiers.
 
 SuM BY(testlabel1) (testmetric1) / IGNOring(testlabel2) AVG withOUT(testlabel3) (testmetric2)

--- a/web/ui/module/lezer-promql/test/expression.txt
+++ b/web/ui/module/lezer-promql/test/expression.txt
@@ -227,28 +227,28 @@ PromQL(
       Identifier,
       LabelMatchers(
         LabelMatcher(
-          LegacyLabelMatcher(
+          UnquotedLabelMatcher(
             LabelName,
             MatchOp(EqlSingle),
             StringLiteral
           )
         ),
         LabelMatcher(
-          LegacyLabelMatcher(
+          UnquotedLabelMatcher(
             LabelName,
             MatchOp(Neq),
             StringLiteral
           )
         ),
         LabelMatcher(
-          LegacyLabelMatcher(
+          UnquotedLabelMatcher(
             LabelName,
             MatchOp(EqlRegex),
             StringLiteral
           )
         ),
         LabelMatcher(
-          LegacyLabelMatcher(
+          UnquotedLabelMatcher(
             LabelName,
             MatchOp(NeqRegex),
             StringLiteral
@@ -579,14 +579,14 @@ PromQL(NumberLiteral)
 NaN{foo="bar"}
 
 ==>
-PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LegacyLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral))))))
+PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(UnquotedLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral))))))
 
 # Trying to illegally use Inf as a metric name.
 
 Inf{foo="bar"}
 
 ==>
-PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LegacyLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral))))))
+PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(UnquotedLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral))))))
 
 # Negative offset
 
@@ -628,18 +628,18 @@ PromQL(BinaryExpr(NumberLiteral,Add,BinaryExpr(VectorSelector(Identifier),Atan2,
 {"metric_name"}
 
 ==>
-PromQL(VectorSelector(LabelMatchers(LabelMatcher(MetricNameLabelMatcher(NewLabelName)))))
+PromQL(VectorSelector(LabelMatchers(LabelMatcher(MetricNameLabelMatcher(QuotedLabelName)))))
 
 # Testing quoted label name
 
 {"foo"="bar"}
 
 ==>
-PromQL(VectorSelector(LabelMatchers(LabelMatcher(NewLabelMatcher(NewLabelName, MatchOp(EqlSingle), StringLiteral)))))
+PromQL(VectorSelector(LabelMatchers(LabelMatcher(QuotedLabelMatcher(QuotedLabelName, MatchOp(EqlSingle), StringLiteral)))))
 
 # Testing quoted metric name and label name
 
 {"metric_name", "foo"="bar"}
 
 ==>
-PromQL(VectorSelector(LabelMatchers(LabelMatcher(MetricNameLabelMatcher(NewLabelName)), LabelMatcher(NewLabelMatcher(NewLabelName, MatchOp(EqlSingle), StringLiteral)))))
+PromQL(VectorSelector(LabelMatchers(LabelMatcher(MetricNameLabelMatcher(QuotedLabelName)), LabelMatcher(QuotedLabelMatcher(QuotedLabelName, MatchOp(EqlSingle), StringLiteral)))))

--- a/web/ui/module/lezer-promql/test/expression.txt
+++ b/web/ui/module/lezer-promql/test/expression.txt
@@ -125,7 +125,7 @@ PromQL(
           AggregateModifier(
             By,
             GroupingLabels(
-                QuotedLabelName,
+                QuotedLabelName(StringLiteral),
                 LabelName
             )
           ),
@@ -139,7 +139,7 @@ PromQL(
         MatchingModifierClause(
           On,
           GroupingLabels(
-              QuotedLabelName
+              QuotedLabelName(StringLiteral)
           )
           GroupLeft
         ),
@@ -148,7 +148,7 @@ PromQL(
           AggregateModifier(
             By,
             GroupingLabels(
-                QuotedLabelName
+                QuotedLabelName(StringLiteral)
             )
           ),
           FunctionCallBody(
@@ -668,18 +668,18 @@ PromQL(BinaryExpr(NumberLiteral,Add,BinaryExpr(VectorSelector(Identifier),Atan2,
 {"metric_name"}
 
 ==>
-PromQL(VectorSelector(LabelMatchers(QuotedLabelName)))
+PromQL(VectorSelector(LabelMatchers(QuotedLabelName(StringLiteral))))
 
 # Testing quoted label name
 
 {"foo"="bar"}
 
 ==>
-PromQL(VectorSelector(LabelMatchers(QuotedLabelMatcher(QuotedLabelName, MatchOp(EqlSingle), StringLiteral))))
+PromQL(VectorSelector(LabelMatchers(QuotedLabelMatcher(QuotedLabelName(StringLiteral), MatchOp(EqlSingle), StringLiteral))))
 
 # Testing quoted metric name and label name
 
 {"metric_name", "foo"="bar"}
 
 ==>
-PromQL(VectorSelector(LabelMatchers(QuotedLabelName, QuotedLabelMatcher(QuotedLabelName, MatchOp(EqlSingle), StringLiteral))))
+PromQL(VectorSelector(LabelMatchers(QuotedLabelName(StringLiteral), QuotedLabelMatcher(QuotedLabelName(StringLiteral), MatchOp(EqlSingle), StringLiteral))))

--- a/web/ui/module/lezer-promql/test/expression.txt
+++ b/web/ui/module/lezer-promql/test/expression.txt
@@ -226,33 +226,25 @@ PromQL(
     VectorSelector(
       Identifier,
       LabelMatchers(
-        LabelMatcher(
-          UnquotedLabelMatcher(
+        UnquotedLabelMatcher(
             LabelName,
             MatchOp(EqlSingle),
             StringLiteral
-          )
         ),
-        LabelMatcher(
-          UnquotedLabelMatcher(
+        UnquotedLabelMatcher(
             LabelName,
             MatchOp(Neq),
             StringLiteral
-          )
         ),
-        LabelMatcher(
-          UnquotedLabelMatcher(
+        UnquotedLabelMatcher(
             LabelName,
             MatchOp(EqlRegex),
             StringLiteral
-          )
         ),
-        LabelMatcher(
-          UnquotedLabelMatcher(
+        UnquotedLabelMatcher(
             LabelName,
             MatchOp(NeqRegex),
             StringLiteral
-          )
         )
       )
     )
@@ -579,14 +571,14 @@ PromQL(NumberLiteral)
 NaN{foo="bar"}
 
 ==>
-PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(UnquotedLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral))))))
+PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(UnquotedLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
 
 # Trying to illegally use Inf as a metric name.
 
 Inf{foo="bar"}
 
 ==>
-PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(UnquotedLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral))))))
+PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(UnquotedLabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
 
 # Negative offset
 
@@ -628,18 +620,18 @@ PromQL(BinaryExpr(NumberLiteral,Add,BinaryExpr(VectorSelector(Identifier),Atan2,
 {"metric_name"}
 
 ==>
-PromQL(VectorSelector(LabelMatchers(LabelMatcher(MetricNameLabelMatcher(QuotedLabelName)))))
+PromQL(VectorSelector(LabelMatchers(QuotedLabelName)))
 
 # Testing quoted label name
 
 {"foo"="bar"}
 
 ==>
-PromQL(VectorSelector(LabelMatchers(LabelMatcher(QuotedLabelMatcher(QuotedLabelName, MatchOp(EqlSingle), StringLiteral)))))
+PromQL(VectorSelector(LabelMatchers(QuotedLabelMatcher(QuotedLabelName, MatchOp(EqlSingle), StringLiteral))))
 
 # Testing quoted metric name and label name
 
 {"metric_name", "foo"="bar"}
 
 ==>
-PromQL(VectorSelector(LabelMatchers(LabelMatcher(MetricNameLabelMatcher(QuotedLabelName)), LabelMatcher(QuotedLabelMatcher(QuotedLabelName, MatchOp(EqlSingle), StringLiteral)))))
+PromQL(VectorSelector(LabelMatchers(QuotedLabelName, QuotedLabelMatcher(QuotedLabelName, MatchOp(EqlSingle), StringLiteral))))


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
fixes- #13564 

In this PR three children added to `LabelMatcher` in `promql.grammar` which are namely-
- `LegacyLabelMatcher` which is the old label matcher.
-  `NewLabelMatcher` which is the label matcher with new syntax.
-  `MetricNameLabelMatcher` which is a matcher for metric name inside quotes.