### PR TITLE
otlptranslator: Upgrade to v0.95.0

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
@@ -13,11 +13,9 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-
-	prometheustranslator "github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheus"
 )
 
-// addSingleSumNumberDataPoint converts the Gauge metric data point to a
+// addSingleGaugeNumberDataPoint converts the Gauge metric data point to a
 // Prometheus time series with samples and labels. The result is stored in the
 // series map.
 func addSingleGaugeNumberDataPoint(
@@ -26,13 +24,14 @@ func addSingleGaugeNumberDataPoint(
 	metric pmetric.Metric,
 	settings Settings,
 	series map[string]*prompb.TimeSeries,
+	name string,
 ) {
-	name := prometheustranslator.BuildCompliantName(metric, settings.Namespace, settings.AddMetricSuffixes)
 	labels := createAttributes(
 		resource,
 		pt.Attributes(),
 		settings.ExternalLabels,
-		model.MetricNameLabel, name,
+		model.MetricNameLabel,
+		name,
 	)
 	sample := &prompb.Sample{
 		// convert ns to ms
@@ -59,8 +58,8 @@ func addSingleSumNumberDataPoint(
 	metric pmetric.Metric,
 	settings Settings,
 	series map[string]*prompb.TimeSeries,
+	name string,
 ) {
-	name := prometheustranslator.BuildCompliantName(metric, settings.Namespace, settings.AddMetricSuffixes)
 	labels := createAttributes(
 		resource,
 		pt.Attributes(),
@@ -82,7 +81,7 @@ func addSingleSumNumberDataPoint(
 	}
 	sig := addSample(series, sample, labels, metric.Type().String())
 
-	if ts, ok := series[sig]; sig != "" && ok {
+	if ts := series[sig]; sig != "" && ts != nil {
 		exemplars := getPromExemplars[pmetric.NumberDataPoint](pt)
 		ts.Exemplars = append(ts.Exemplars, exemplars...)
 	}
@@ -90,15 +89,18 @@ func addSingleSumNumberDataPoint(
 	// add _created time series if needed
 	if settings.ExportCreatedMetric && metric.Sum().IsMonotonic() {
 		startTimestamp := pt.StartTimestamp()
-		if startTimestamp != 0 {
-			createdLabels := createAttributes(
-				resource,
-				pt.Attributes(),
-				settings.ExternalLabels,
-				nameStr,
-				name+createdSuffix,
-			)
-			addCreatedTimeSeriesIfNeeded(series, createdLabels, startTimestamp, metric.Type().String())
+		if startTimestamp == 0 {
+			return
 		}
+
+		createdLabels := make([]prompb.Label, len(labels))
+		copy(createdLabels, labels)
+		for i, l := range createdLabels {
+			if l.Name == model.MetricNameLabel {
+				createdLabels[i].Value = name + createdSuffix
+				break
+			}
+		}
+		addCreatedTimeSeriesIfNeeded(series, createdLabels, startTimestamp, pt.Timestamp(), metric.Type().String())
 	}
 }

--- a/storage/remote/otlptranslator/prometheusremotewrite/otlp_to_openmetrics_metadata.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/otlp_to_openmetrics_metadata.go
@@ -1,0 +1,66 @@
+// DO NOT EDIT. COPIED AS-IS. SEE ../README.md
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheusremotewrite // import "github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite"
+
+import (
+	"github.com/prometheus/prometheus/prompb"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	prometheustranslator "github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheus"
+)
+
+func otelMetricTypeToPromMetricType(otelMetric pmetric.Metric) prompb.MetricMetadata_MetricType {
+	switch otelMetric.Type() {
+	case pmetric.MetricTypeGauge:
+		return prompb.MetricMetadata_GAUGE
+	case pmetric.MetricTypeSum:
+		metricType := prompb.MetricMetadata_GAUGE
+		if otelMetric.Sum().IsMonotonic() {
+			metricType = prompb.MetricMetadata_COUNTER
+		}
+		return metricType
+	case pmetric.MetricTypeHistogram:
+		return prompb.MetricMetadata_HISTOGRAM
+	case pmetric.MetricTypeSummary:
+		return prompb.MetricMetadata_SUMMARY
+	case pmetric.MetricTypeExponentialHistogram:
+		return prompb.MetricMetadata_HISTOGRAM
+	}
+	return prompb.MetricMetadata_UNKNOWN
+}
+
+func OtelMetricsToMetadata(md pmetric.Metrics, addMetricSuffixes bool) []*prompb.MetricMetadata {
+	resourceMetricsSlice := md.ResourceMetrics()
+
+	metadataLength := 0
+	for i := 0; i < resourceMetricsSlice.Len(); i++ {
+		scopeMetricsSlice := resourceMetricsSlice.At(i).ScopeMetrics()
+		for j := 0; j < scopeMetricsSlice.Len(); j++ {
+			metadataLength += scopeMetricsSlice.At(j).Metrics().Len()
+		}
+	}
+
+	var metadata = make([]*prompb.MetricMetadata, 0, metadataLength)
+	for i := 0; i < resourceMetricsSlice.Len(); i++ {
+		resourceMetrics := resourceMetricsSlice.At(i)
+		scopeMetricsSlice := resourceMetrics.ScopeMetrics()
+
+		for j := 0; j < scopeMetricsSlice.Len(); j++ {
+			scopeMetrics := scopeMetricsSlice.At(j)
+			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
+				metric := scopeMetrics.Metrics().At(k)
+				entry := prompb.MetricMetadata{
+					Type:             otelMetricTypeToPromMetricType(metric),
+					MetricFamilyName: prometheustranslator.BuildCompliantName(metric, "", addMetricSuffixes),
+					Help:             metric.Description(),
+				}
+				metadata = append(metadata, &entry)
+			}
+		}
+	}
+
+	return metadata
+}

--- a/storage/remote/otlptranslator/update-copy.sh
+++ b/storage/remote/otlptranslator/update-copy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xe
 
-OTEL_VERSION=v0.88.0
+OTEL_VERSION=v0.95.0
 
 git clone https://github.com/open-telemetry/opentelemetry-collector-contrib ./tmp
 cd ./tmp


### PR DESCRIPTION
Upgrade storage/remote/otlptranslator to v0.95.0 of upstream. This brings in changes from a couple of PRs I've made upstream, that brought performance improvements (benchmark stats in the linked PRs):

* https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/29686
* https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30749