### PR TITLE
Speed up MemPostings.addFor()

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -379,22 +379,21 @@ func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
 		nm = map[string][]storage.SeriesRef{}
 		p.m[l.Name] = nm
 	}
-	list := append(nm[l.Value], id)
-	nm[l.Value] = list
 
+	// If ordering is disabled then simply append our id.
 	if !p.ordered {
+		nm[l.Value] = append(nm[l.Value], id)
 		return
 	}
+
 	// There is no guarantee that no higher ID was inserted before as they may
 	// be generated independently before adding them to postings.
-	// We repair order violations on insert. The invariant is that the first n-1
-	// items in the list are already sorted.
-	for i := len(list) - 1; i >= 1; i-- {
-		if list[i] >= list[i-1] {
-			break
-		}
-		list[i], list[i-1] = list[i-1], list[i]
-	}
+	// We repair order violations on insert.
+	// Find the slot we need to insert our id into, grow the slice and insert our id.
+	index, _ := slices.BinarySearch(nm[l.Value], id)
+	nm[l.Value] = append(nm[l.Value], storage.SeriesRef(0))
+	copy(nm[l.Value][index+1:], nm[l.Value][index:])
+	nm[l.Value][index] = id
 }
 
 func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string, match func(string) bool) Postings {


### PR DESCRIPTION
MemPosting.Add() can be very slow because of the requirement to ensure ordering of SeriesRef values.
Speed it up by sort on insert instead of appending and the sorting - this way we scan the slice for the correct place in the slice to insert into.
I've used the code from https://stackoverflow.com/questions/42746972/insert-to-a-sorted-slice to insert into a sorted slice.

The problem with this code being slow is that all time series must be added to MemPostings when they are first scraped.
If MemPostings.Add() is slow then this will block first scrape of each time series because there is a single mutex that guards writes.
This can cause missing scraped data for a lot of time series when you restart Prometheus and all time series are initially added.
What saves us is that if you restart Prometheus it will replay WAL, which will have most of the scraped time series in it,
so while WAL is being replayed MemPostings is being populated and the slowness only makes WAL replay slow, it doesn't affect scrapes.
This makes this problem invisible to most users unless they nuke the data directory and then restart Prometheus.

Another trigger is having a lot of common labels on time series, if theres'a label/value pair set on all time series then all these
time series references will have to be added to a single slice on MemPostings, which will trigger a lot of re-sortings on each Add().

Benchmark results:

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb/index
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
                  │  main.txt   │               new.txt               │
                  │   sec/op    │   sec/op     vs base                │
MemPostings_Add-8   91.49m ± 2%   15.41m ± 0%  -83.15% (p=0.000 n=20)

                  │   main.txt   │            new.txt             │
                  │     B/op     │     B/op      vs base          │
MemPostings_Add-8   288.1Ki ± 0%   288.1Ki ± 0%  ~ (p=0.560 n=20)

                  │  main.txt  │            new.txt             │
                  │ allocs/op  │ allocs/op   vs base            │
MemPostings_Add-8   98.00 ± 0%   98.00 ± 0%  ~ (p=1.000 n=20) ¹
¹ all samples are equal
```