### PR TITLE
Add json tags to Metadata struct

### DIFF
--- a/model/metadata/metadata.go
+++ b/model/metadata/metadata.go
@@ -17,7 +17,7 @@ import "github.com/prometheus/common/model"
 
 // Metadata stores a series' metadata information.
 type Metadata struct {
-	Type model.MetricType
-	Unit string
-	Help string
+	Type model.MetricType `json:"type"`
+	Unit string           `json:"unit"`
+	Help string           `json:"help"`
 }

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1056,6 +1056,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 		response              interface{}
 		responseLen           int
 		responseMetadataTotal int
+		responseAsJSON        string
 		errType               errorType
 		sorter                func(interface{})
 		metadata              []targetMetadata
@@ -2853,6 +2854,11 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 							test.zeroFunc(res.data)
 						}
 						assertAPIResponse(t, res.data, test.response)
+						if test.responseAsJSON != "" {
+							s, err := json.Marshal(res.data)
+							require.NoError(t, err)
+							require.Equal(t, test.responseAsJSON, string(s))
+						}
 					}
 				})
 			}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1832,8 +1832,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 					},
 				},
 			},
-			responseLen:    2,
-			responseAsJSON: `{"go_threads": [{"type":"gauge","unit":"","help":"Number of OS threads created"}], "prometheus_engine_query_duration_seconds": [{"type":"summary","unit":"","help":"Query Timings."}]}`,
+			responseLen: 2,
 		},
 		// With a limit for the number of metadata per metric.
 		{
@@ -1872,7 +1871,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 					{Type: model.MetricTypeSummary, Help: "A summary of the GC invocation durations."},
 				},
 			},
-			responseAsJSON: `{"go_gc_duration_seconds":[{"type":"summary", "unit":"", "help":"A summary of the GC invocation durations."}],"go_threads": [{"type":"gauge", "unit":"", "help":"Number of OS threads created"}]}`,
+			responseAsJSON: `{"go_gc_duration_seconds":[{"help":"A summary of the GC invocation durations.","type":"summary","unit":""}],"go_threads": [{"type":"gauge","unit":"","help":"Number of OS threads created"}]}`,
 		},
 		// With a limit for the number of metadata per metric and per metric.
 		{
@@ -1996,6 +1995,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 					{Type: model.MetricTypeGauge, Help: "Number of OS threads that were created."},
 				},
 			},
+			responseAsJSON: `{"go_threads": [{"type":"gauge","unit":"","help":"Number of OS threads created"},{"type":"gauge","unit":"","help":"Number of OS threads that were created."}]}`,
 			sorter: func(m interface{}) {
 				v := m.(map[string][]metadata.Metadata)["go_threads"]
 

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1872,7 +1872,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 					{Type: model.MetricTypeSummary, Help: "A summary of the GC invocation durations."},
 				},
 			},
-			responseAsJSON: `{"go_threads": [{"type":"gauge", unit:"", "help":"Number of OS threads created"}],"go_gc_duration_seconds":[{"type":"summary", unit:"", "help":"A summary of the GC invocation durations."}]}`,
+			responseAsJSON: `{"go_gc_duration_seconds":[{"type":"summary", "unit":"", "help":"A summary of the GC invocation durations."}],"go_threads": [{"type":"gauge", "unit":"", "help":"Number of OS threads created"}]}`,
 		},
 		// With a limit for the number of metadata per metric and per metric.
 		{


### PR DESCRIPTION
Before Prometheus `v2.50.0` when we query `/api/v1/metadata` endpoint we receive data like the below:
```
{
  "total_http_requests": [
    {
      "type": "counter",
      "help": "Amount of HTTP requests",
      "unit": ""
    }
  ]
}
```

But with `v2.50.0` it changed to the following:
```
{
  "total_http_requests": [
    {
      "Type": "counter",
      "Help": "Amount of HTTP requests",
      "Unit": ""
    }
  ]
}
```

The change was introduced accidentally in this PR https://github.com/prometheus/prometheus/pull/13176
This PR fixes this inconsistency and adds unit tests related to this topic.