### PR TITLE
Proposal to opmize "or" regex on the FastRegexMatcher

### DIFF
--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2550,10 +2550,24 @@ func BenchmarkSetMatcher(b *testing.B) {
 		},
 		{
 			numBlocks:                   1,
+			numSeries:                   1,
+			numSamplesPerSeriesPerBlock: 10,
+			cardinality:                 100,
+			pattern:                     "1|2|3|4|5|(6.*|7.*)|8|9|10",
+		},
+		{
+			numBlocks:                   1,
 			numSeries:                   15,
 			numSamplesPerSeriesPerBlock: 10,
 			cardinality:                 100,
 			pattern:                     "1|2|3|4|5|6|7|8|9|10",
+		},
+		{
+			numBlocks:                   1,
+			numSeries:                   15,
+			numSamplesPerSeriesPerBlock: 10,
+			cardinality:                 100,
+			pattern:                     "1|2|3|4|5|6.*|7|8|9|10",
 		},
 		{
 			numBlocks:                   1,
@@ -2605,6 +2619,34 @@ func BenchmarkSetMatcher(b *testing.B) {
 			numSamplesPerSeriesPerBlock: 10,
 			cardinality:                 1000000,
 			pattern:                     "1|2|3|4|5|6|7|8|9|10",
+		},
+		{
+			numBlocks:                   1,
+			numSeries:                   100000,
+			numSamplesPerSeriesPerBlock: 10,
+			cardinality:                 100000,
+			pattern:                     "1|2|3|4|5|(6.*|7)|8|9|10",
+		},
+		{
+			numBlocks:                   1,
+			numSeries:                   500000,
+			numSamplesPerSeriesPerBlock: 10,
+			cardinality:                 500000,
+			pattern:                     "1|2|3|4|5|6.*|7|8|9|10",
+		},
+		{
+			numBlocks:                   10,
+			numSeries:                   500000,
+			numSamplesPerSeriesPerBlock: 10,
+			cardinality:                 500000,
+			pattern:                     "1|2|3|4|5|6.*|7|8|9|10",
+		},
+		{
+			numBlocks:                   1,
+			numSeries:                   1000000,
+			numSamplesPerSeriesPerBlock: 10,
+			cardinality:                 1000000,
+			pattern:                     "1|2|3|4|5|6.*|7|8|9|10",
 		},
 	}
 
@@ -2948,6 +2990,43 @@ func TestPostingsForMatchers(t *testing.T) {
 		{
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", "2|2\\.5")},
 			exp: []labels.Labels{
+				labels.FromStrings("n", "2"),
+				labels.FromStrings("n", "2.5"),
+			},
+		},
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", "2|2.5")},
+			exp: []labels.Labels{
+				labels.FromStrings("n", "2"),
+				labels.FromStrings("n", "2.5"),
+			},
+		},
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", "1|2.*")},
+			exp: []labels.Labels{
+				labels.FromStrings("n", "1"),
+				labels.FromStrings("n", "1", "i", "a"),
+				labels.FromStrings("n", "1", "i", "b"),
+				labels.FromStrings("n", "2"),
+				labels.FromStrings("n", "2.5"),
+			},
+		},
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", "1|(2.*)")},
+			exp: []labels.Labels{
+				labels.FromStrings("n", "1"),
+				labels.FromStrings("n", "1", "i", "a"),
+				labels.FromStrings("n", "1", "i", "b"),
+				labels.FromStrings("n", "2"),
+				labels.FromStrings("n", "2.5"),
+			},
+		},
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", "1|(2|2.5)")},
+			exp: []labels.Labels{
+				labels.FromStrings("n", "1"),
+				labels.FromStrings("n", "1", "i", "a"),
+				labels.FromStrings("n", "1", "i", "b"),
 				labels.FromStrings("n", "2"),
 				labels.FromStrings("n", "2.5"),
 			},


### PR DESCRIPTION
This PR is just to open a discussion if this change can make sense - there are lots of code that I copied around just to illustrate the idea. We can improve the code if we decide to go forward with this.

FastRegexMatcher already have an optimization to short circuit the regex parse and evaluation for literals. This change is just extending this optimization to regex like `(a|b|c)` or even regex like (`a|b.*|c)` -> in this case we add `a` and `c` as literals and we only parse  evaluate `b.*`.

This change not only beneficial for hybrid regex like `a|b.*|c` but also for the already optimized  regex like `(a|b|c)`. For the latter types of regex we have an optimization on the `PostingForMatchers` that [short circuit the Regex Matcher](https://github.com/prometheus/prometheus/blob/4d6bb2e0e44b4d9b4f06c7c44bf2263416f64879/tsdb/querier.go#L387-L404) and, instead of getting the labels values and running the regex on them, it instead only get the postings for the values `a`, `b` and `c`. Said that, the regex `(a|b|c)` is still parsed and compiled when creating the `FastRegexMatcher` - and we can sometimes a substantial CPU usage compiling those queries that will not be ever used(bear in mind that those regex can become quite big because of grafana dashboards)


Here is the benchmark results (60%+ improvements in some cases):

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz
                                                                                             │   /tmp/old    │              /tmp/new               │
                                                                                             │    sec/op     │    sec/op     vs base               │
SetMatcher/nSeries=1,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6|7|8|9|10"-32                9.285µ ± ∞ ¹   3.867µ ± ∞ ¹  -58.35% (p=0.008 n=5)
SetMatcher/nSeries=1,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6.*|7|8|9|10"-32             11.773µ ± ∞ ¹   9.081µ ± ∞ ¹  -22.87% (p=0.008 n=5)
SetMatcher/nSeries=15,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6|7|8|9|10"-32               9.285µ ± ∞ ¹   3.844µ ± ∞ ¹  -58.60% (p=0.008 n=5)
SetMatcher/nSeries=15,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6.*|7|8|9|10"-32            11.751µ ± ∞ ¹   9.036µ ± ∞ ¹  -23.10% (p=0.008 n=5)
SetMatcher/nSeries=15,nBlocks=1,cardinality=100,pattern="1|2|3"-32                              5.968µ ± ∞ ¹   2.129µ ± ∞ ¹  -64.33% (p=0.008 n=5)
SetMatcher/nSeries=1000,nBlocks=20,cardinality=100,pattern="1|2|3"-32                           23.46µ ± ∞ ¹   19.72µ ± ∞ ¹  -15.93% (p=0.008 n=5)
SetMatcher/nSeries=1000,nBlocks=20,cardinality=100,pattern="1|2|3|4|5|6|7|8|9|10"-32            41.62µ ± ∞ ¹   36.63µ ± ∞ ¹  -12.00% (p=0.008 n=5)
SetMatcher/nSeries=100000,nBlocks=1,cardinality=100000,pattern="1|2|3|4|5|6|7|8|9|10"-32        9.166µ ± ∞ ¹   3.831µ ± ∞ ¹  -58.20% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=1,cardinality=500000,pattern="1|2|3|4|5|6|7|8|9|10"-32        9.154µ ± ∞ ¹   3.827µ ± ∞ ¹  -58.19% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=10,cardinality=500000,pattern="1|2|3|4|5|6|7|8|9|10"-32       24.06µ ± ∞ ¹   18.93µ ± ∞ ¹  -21.34% (p=0.008 n=5)
SetMatcher/nSeries=1000000,nBlocks=1,cardinality=1000000,pattern="1|2|3|4|5|6|7|8|9|10"-32      8.979µ ± ∞ ¹   3.758µ ± ∞ ¹  -58.15% (p=0.008 n=5)
SetMatcher/nSeries=100000,nBlocks=1,cardinality=100000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32     11.417µ ± ∞ ¹   8.858µ ± ∞ ¹  -22.41% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=1,cardinality=500000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32     11.361µ ± ∞ ¹   8.678µ ± ∞ ¹  -23.62% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=10,cardinality=500000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32     21.81µ ± ∞ ¹   13.16µ ± ∞ ¹  -39.65% (p=0.008 n=5)
SetMatcher/nSeries=1000000,nBlocks=1,cardinality=1000000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32   11.193µ ± ∞ ¹   8.684µ ± ∞ ¹  -22.42% (p=0.008 n=5)
geomean                                                                                         12.79µ         7.627µ        -40.35%
¹ need >= 6 samples for confidence interval at level 0.95

                                                                                             │    /tmp/old    │               /tmp/new               │
                                                                                             │      B/op      │     B/op       vs base               │
SetMatcher/nSeries=1,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6|7|8|9|10"-32                4.867Ki ± ∞ ¹   1.792Ki ± ∞ ¹  -63.18% (p=0.008 n=5)
SetMatcher/nSeries=1,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6.*|7|8|9|10"-32              7.312Ki ± ∞ ¹   5.172Ki ± ∞ ¹  -29.27% (p=0.008 n=5)
SetMatcher/nSeries=15,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6|7|8|9|10"-32               4.867Ki ± ∞ ¹   1.792Ki ± ∞ ¹  -63.18% (p=0.008 n=5)
SetMatcher/nSeries=15,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6.*|7|8|9|10"-32             7.312Ki ± ∞ ¹   5.172Ki ± ∞ ¹  -29.27% (p=0.008 n=5)
SetMatcher/nSeries=15,nBlocks=1,cardinality=100,pattern="1|2|3"-32                               3640.0 ± ∞ ¹     888.0 ± ∞ ¹  -75.60% (p=0.008 n=5)
SetMatcher/nSeries=1000,nBlocks=20,cardinality=100,pattern="1|2|3"-32                           13.43Ki ± ∞ ¹   10.73Ki ± ∞ ¹  -20.07% (p=0.008 n=5)
SetMatcher/nSeries=1000,nBlocks=20,cardinality=100,pattern="1|2|3|4|5|6|7|8|9|10"-32            25.57Ki ± ∞ ¹   22.50Ki ± ∞ ¹  -12.03% (p=0.008 n=5)
SetMatcher/nSeries=100000,nBlocks=1,cardinality=100000,pattern="1|2|3|4|5|6|7|8|9|10"-32        4.867Ki ± ∞ ¹   1.792Ki ± ∞ ¹  -63.18% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=1,cardinality=500000,pattern="1|2|3|4|5|6|7|8|9|10"-32        4.867Ki ± ∞ ¹   1.792Ki ± ∞ ¹  -63.18% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=10,cardinality=500000,pattern="1|2|3|4|5|6|7|8|9|10"-32       14.79Ki ± ∞ ¹   11.71Ki ± ∞ ¹  -20.79% (p=0.008 n=5)
SetMatcher/nSeries=1000000,nBlocks=1,cardinality=1000000,pattern="1|2|3|4|5|6|7|8|9|10"-32      4.867Ki ± ∞ ¹   1.792Ki ± ∞ ¹  -63.18% (p=0.008 n=5)
SetMatcher/nSeries=100000,nBlocks=1,cardinality=100000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32      7.312Ki ± ∞ ¹   5.172Ki ± ∞ ¹  -29.27% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=1,cardinality=500000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32      7.312Ki ± ∞ ¹   5.172Ki ± ∞ ¹  -29.27% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=10,cardinality=500000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32    13.297Ki ± ∞ ¹   8.062Ki ± ∞ ¹  -39.37% (p=0.008 n=5)
SetMatcher/nSeries=1000000,nBlocks=1,cardinality=1000000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32    7.312Ki ± ∞ ¹   5.172Ki ± ∞ ¹  -29.27% (p=0.008 n=5)
geomean                                                                                         7.513Ki         4.062Ki        -45.93%
¹ need >= 6 samples for confidence interval at level 0.95

                                                                                             │   /tmp/old   │              /tmp/new              │
                                                                                             │  allocs/op   │  allocs/op   vs base               │
SetMatcher/nSeries=1,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6|7|8|9|10"-32                83.00 ± ∞ ¹   47.00 ± ∞ ¹  -43.37% (p=0.008 n=5)
SetMatcher/nSeries=1,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6.*|7|8|9|10"-32             101.00 ± ∞ ¹   83.00 ± ∞ ¹  -17.82% (p=0.008 n=5)
SetMatcher/nSeries=15,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6|7|8|9|10"-32               83.00 ± ∞ ¹   47.00 ± ∞ ¹  -43.37% (p=0.008 n=5)
SetMatcher/nSeries=15,nBlocks=1,cardinality=100,pattern="1|2|3|4|5|6.*|7|8|9|10"-32            101.00 ± ∞ ¹   83.00 ± ∞ ¹  -17.82% (p=0.008 n=5)
SetMatcher/nSeries=15,nBlocks=1,cardinality=100,pattern="1|2|3"-32                              60.00 ± ∞ ¹   23.00 ± ∞ ¹  -61.67% (p=0.008 n=5)
SetMatcher/nSeries=1000,nBlocks=20,cardinality=100,pattern="1|2|3"-32                           313.0 ± ∞ ¹   276.0 ± ∞ ¹  -11.82% (p=0.008 n=5)
SetMatcher/nSeries=1000,nBlocks=20,cardinality=100,pattern="1|2|3|4|5|6|7|8|9|10"-32            640.0 ± ∞ ¹   604.0 ± ∞ ¹   -5.63% (p=0.008 n=5)
SetMatcher/nSeries=100000,nBlocks=1,cardinality=100000,pattern="1|2|3|4|5|6|7|8|9|10"-32        83.00 ± ∞ ¹   47.00 ± ∞ ¹  -43.37% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=1,cardinality=500000,pattern="1|2|3|4|5|6|7|8|9|10"-32        83.00 ± ∞ ¹   47.00 ± ∞ ¹  -43.37% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=10,cardinality=500000,pattern="1|2|3|4|5|6|7|8|9|10"-32       350.0 ± ∞ ¹   314.0 ± ∞ ¹  -10.29% (p=0.008 n=5)
SetMatcher/nSeries=1000000,nBlocks=1,cardinality=1000000,pattern="1|2|3|4|5|6|7|8|9|10"-32      83.00 ± ∞ ¹   47.00 ± ∞ ¹  -43.37% (p=0.008 n=5)
SetMatcher/nSeries=100000,nBlocks=1,cardinality=100000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32     101.00 ± ∞ ¹   83.00 ± ∞ ¹  -17.82% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=1,cardinality=500000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32     101.00 ± ∞ ¹   83.00 ± ∞ ¹  -17.82% (p=0.008 n=5)
SetMatcher/nSeries=500000,nBlocks=10,cardinality=500000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32     278.0 ± ∞ ¹   125.0 ± ∞ ¹  -55.04% (p=0.008 n=5)
SetMatcher/nSeries=1000000,nBlocks=1,cardinality=1000000,pattern="1|2|3|4|5|6.*|7|8|9|10"-32   101.00 ± ∞ ¹   83.00 ± ∞ ¹  -17.82% (p=0.008 n=5)
geomean                                                                                         129.5         87.54        -32.41%
¹ need >= 6 samples for confidence interval at level 0.95
```

