### PR TITLE
MemPostings: Use dolthub SwissMap for label values/postings map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,8 @@ require (
 	k8s.io/klog/v2 v2.120.1
 )
 
+require github.com/dolthub/swiss v0.2.1
+
 require (
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
@@ -113,6 +115,7 @@ require (
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/dolthub/maphash v0.1.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/fatih/color v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,10 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ=
+github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
+github.com/dolthub/swiss v0.2.1 h1:gs2osYs5SJkAaH5/ggVJqXQxRXtWshF6uE0lgR/Y3Gw=
+github.com/dolthub/swiss v0.2.1/go.mod h1:8AhKZZ1HK7g18j7v7k6c5cYIGEZJcPn0ARsai8cUrh0=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/bboreham/go-loser"
+	"github.com/dolthub/swiss"
 	"golang.org/x/exp/slices"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -55,14 +56,14 @@ var ensureOrderBatchPool = sync.Pool{
 // unordered batch fills on startup.
 type MemPostings struct {
 	mtx     sync.RWMutex
-	m       map[string]map[string][]storage.SeriesRef
+	m       map[string]*swiss.Map[string, []storage.SeriesRef]
 	ordered bool
 }
 
 // NewMemPostings returns a memPostings that's ready for reads and writes.
 func NewMemPostings() *MemPostings {
 	return &MemPostings{
-		m:       make(map[string]map[string][]storage.SeriesRef, 512),
+		m:       make(map[string]*swiss.Map[string, []storage.SeriesRef], 512),
 		ordered: true,
 	}
 }
@@ -71,7 +72,7 @@ func NewMemPostings() *MemPostings {
 // until EnsureOrder() was called once.
 func NewUnorderedMemPostings() *MemPostings {
 	return &MemPostings{
-		m:       make(map[string]map[string][]storage.SeriesRef, 512),
+		m:       make(map[string]*swiss.Map[string, []storage.SeriesRef], 512),
 		ordered: false,
 	}
 }
@@ -84,9 +85,10 @@ func (p *MemPostings) Symbols() StringIter {
 	symbols := make(map[string]struct{}, 512)
 	for n, e := range p.m {
 		symbols[n] = struct{}{}
-		for v := range e {
+		e.Iter(func(v string, _ []storage.SeriesRef) bool {
 			symbols[v] = struct{}{}
-		}
+			return false
+		})
 	}
 	p.mtx.RUnlock()
 
@@ -105,9 +107,10 @@ func (p *MemPostings) SortedKeys() []labels.Label {
 	keys := make([]labels.Label, 0, len(p.m))
 
 	for n, e := range p.m {
-		for v := range e {
+		e.Iter(func(v string, _ []storage.SeriesRef) bool {
 			keys = append(keys, labels.Label{Name: n, Value: v})
-		}
+			return false
+		})
 	}
 	p.mtx.RUnlock()
 
@@ -146,10 +149,16 @@ func (p *MemPostings) LabelValues(_ context.Context, name string) []string {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	values := make([]string, 0, len(p.m[name]))
-	for v := range p.m[name] {
-		values = append(values, v)
+	e := p.m[name]
+	if e == nil || e.Count() == 0 {
+		return nil
 	}
+
+	values := make([]string, 0, e.Count())
+	e.Iter(func(v string, _ []storage.SeriesRef) bool {
+		values = append(values, v)
+		return false
+	})
 	return values
 }
 
@@ -182,17 +191,18 @@ func (p *MemPostings) Stats(label string, limit int) *PostingsStats {
 		if n == "" {
 			continue
 		}
-		labels.push(Stat{Name: n, Count: uint64(len(e))})
-		numLabelPairs += len(e)
+		labels.push(Stat{Name: n, Count: uint64(e.Count())})
+		numLabelPairs += e.Count()
 		size = 0
-		for name, values := range e {
+		e.Iter(func(name string, values []storage.SeriesRef) bool {
 			if n == label {
 				metrics.push(Stat{Name: name, Count: uint64(len(values))})
 			}
 			seriesCnt := uint64(len(values))
 			labelValuePairs.push(Stat{Name: n + "=" + name, Count: seriesCnt})
 			size += uint64(len(name)) * seriesCnt
-		}
+			return false
+		})
 		labelValueLength.push(Stat{Name: n, Count: size})
 	}
 
@@ -213,7 +223,7 @@ func (p *MemPostings) Get(name, value string) Postings {
 	p.mtx.RLock()
 	l := p.m[name]
 	if l != nil {
-		lp = l[value]
+		lp, _ = l.Get(value)
 	}
 	p.mtx.RUnlock()
 
@@ -266,14 +276,16 @@ func (p *MemPostings) EnsureOrder(numberOfConcurrentProcesses int) {
 
 	nextJob := ensureOrderBatchPool.Get().(*[][]storage.SeriesRef)
 	for _, e := range p.m {
-		for _, l := range e {
+		e.Iter(func(_ string, l []storage.SeriesRef) bool {
 			*nextJob = append(*nextJob, l)
 
 			if len(*nextJob) >= ensureOrderBatchSize {
 				workc <- nextJob
 				nextJob = ensureOrderBatchPool.Get().(*[][]storage.SeriesRef)
 			}
-		}
+
+			return false
+		})
 	}
 
 	// If the last job was partially filled, we need to push it to workers too.
@@ -302,9 +314,10 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}) {
 	for _, n := range keys {
 		p.mtx.RLock()
 		vals = vals[:0]
-		for v := range p.m[n] {
+		p.m[n].Iter(func(v string, _ []storage.SeriesRef) bool {
 			vals = append(vals, v)
-		}
+			return false
+		})
 		p.mtx.RUnlock()
 
 		// For each posting we first analyse whether the postings list is affected by the deletes.
@@ -314,7 +327,8 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}) {
 			p.mtx.Lock()
 
 			found := false
-			for _, id := range p.m[n][l] {
+			srs, _ := p.m[n].Get(l)
+			for _, id := range srs {
 				if _, ok := deleted[id]; ok {
 					found = true
 					break
@@ -324,22 +338,22 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}) {
 				p.mtx.Unlock()
 				continue
 			}
-			repl := make([]storage.SeriesRef, 0, len(p.m[n][l]))
+			repl := make([]storage.SeriesRef, 0, len(srs))
 
-			for _, id := range p.m[n][l] {
+			for _, id := range srs {
 				if _, ok := deleted[id]; !ok {
 					repl = append(repl, id)
 				}
 			}
 			if len(repl) > 0 {
-				p.m[n][l] = repl
+				p.m[n].Put(l, repl)
 			} else {
-				delete(p.m[n], l)
+				p.m[n].Delete(l)
 			}
 			p.mtx.Unlock()
 		}
 		p.mtx.Lock()
-		if len(p.m[n]) == 0 {
+		if p.m[n].Count() == 0 {
 			delete(p.m, n)
 		}
 		p.mtx.Unlock()
@@ -352,10 +366,15 @@ func (p *MemPostings) Iter(f func(labels.Label, Postings) error) error {
 	defer p.mtx.RUnlock()
 
 	for n, e := range p.m {
-		for v, p := range e {
-			if err := f(labels.Label{Name: n, Value: v}, newListPostings(p...)); err != nil {
-				return err
+		var err error
+		e.Iter(func(v string, p []storage.SeriesRef) bool {
+			if err = f(labels.Label{Name: n, Value: v}, newListPostings(p...)); err != nil {
+				return true
 			}
+			return false
+		})
+		if err != nil {
+			return err
 		}
 	}
 	return nil
@@ -376,11 +395,12 @@ func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
 func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
 	nm, ok := p.m[l.Name]
 	if !ok {
-		nm = map[string][]storage.SeriesRef{}
+		nm = swiss.NewMap[string, []storage.SeriesRef](0)
 		p.m[l.Name] = nm
 	}
-	list := append(nm[l.Value], id)
-	nm[l.Value] = list
+	list, _ := nm.Get(l.Value)
+	list = append(list, id)
+	nm.Put(l.Value, list)
 
 	if !p.ordered {
 		return

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/dolthub/swiss"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -32,17 +33,18 @@ import (
 
 func TestMemPostings_addFor(t *testing.T) {
 	p := NewMemPostings()
-	p.m[allPostingsKey.Name] = map[string][]storage.SeriesRef{}
-	p.m[allPostingsKey.Name][allPostingsKey.Value] = []storage.SeriesRef{1, 2, 3, 4, 6, 7, 8}
+	p.m[allPostingsKey.Name] = swiss.NewMap[string, []storage.SeriesRef](0)
+	p.m[allPostingsKey.Name].Put(allPostingsKey.Value, []storage.SeriesRef{1, 2, 3, 4, 6, 7, 8})
 
 	p.addFor(5, allPostingsKey)
 
-	require.Equal(t, []storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8}, p.m[allPostingsKey.Name][allPostingsKey.Value])
+	srs, _ := p.m[allPostingsKey.Name].Get(allPostingsKey.Value)
+	require.Equal(t, []storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8}, srs)
 }
 
 func TestMemPostings_ensureOrder(t *testing.T) {
 	p := NewUnorderedMemPostings()
-	p.m["a"] = map[string][]storage.SeriesRef{}
+	p.m["a"] = swiss.NewMap[string, []storage.SeriesRef](0)
 
 	for i := 0; i < 100; i++ {
 		l := make([]storage.SeriesRef, 100)
@@ -51,18 +53,19 @@ func TestMemPostings_ensureOrder(t *testing.T) {
 		}
 		v := fmt.Sprintf("%d", i)
 
-		p.m["a"][v] = l
+		p.m["a"].Put(v, l)
 	}
 
 	p.EnsureOrder(0)
 
 	for _, e := range p.m {
-		for _, l := range e {
+		e.Iter(func(_ string, l []storage.SeriesRef) bool {
 			ok := sort.SliceIsSorted(l, func(i, j int) bool {
 				return l[i] < l[j]
 			})
 			require.True(t, ok, "postings list %v is not sorted", l)
-		}
+			return false
+		})
 	}
 }
 
@@ -96,7 +99,7 @@ func BenchmarkMemPostings_ensureOrder(b *testing.B) {
 			// Generate postings.
 			for l := 0; l < testData.numLabels; l++ {
 				labelName := strconv.Itoa(l)
-				p.m[labelName] = map[string][]storage.SeriesRef{}
+				p.m[labelName] = swiss.NewMap[string, []storage.SeriesRef](0)
 
 				for v := 0; v < testData.numValuesPerLabel; v++ {
 					refs := make([]storage.SeriesRef, testData.numRefsPerValue)
@@ -105,7 +108,7 @@ func BenchmarkMemPostings_ensureOrder(b *testing.B) {
 					}
 
 					labelValue := strconv.Itoa(v)
-					p.m[labelName][labelValue] = refs
+					p.m[labelName].Put(labelValue, refs)
 				}
 			}
 


### PR DESCRIPTION
Test of [dolthub SwissMap](https://github.com/dolthub/swiss) instead of standard `map` in `tsdb/index.MemPostings`, for performance. Requested by @bboreham for prombench-ing, so we can see if there's any real difference.

Confer corresponding [PR](https://github.com/prometheus/prometheus/pull/13646) for CockroachDB implementation.