### PR TITLE
MemPostings: Use CockroachDB Swiss Map for label values/postings map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,8 @@ require (
 	k8s.io/klog/v2 v2.120.1
 )
 
+require github.com/cockroachdb/swiss v0.0.0-20240218003604-fa7bdb1c8c21
+
 require (
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/xds/go v0.0.0-20231109132714-523115ebc101 h1:7To3pQ+pZo0i3dsWEbinPNFs5gPSBOsJtx3wTT94VBY=
 github.com/cncf/xds/go v0.0.0-20231109132714-523115ebc101/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/cockroachdb/swiss v0.0.0-20240218003604-fa7bdb1c8c21 h1:cBVkE9C0tBqXvpRk6CzYecmiOEj+7r9JLxEJcM65TEA=
+github.com/cockroachdb/swiss v0.0.0-20240218003604-fa7bdb1c8c21/go.mod h1:kvAEHbo4OwYBZpQIKRqjj2hxpFj8WhgtzDg8ZtrhaIc=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/cgroups/v3 v3.0.3 h1:S5ByHZ/h9PMe5IOQoN7E+nMc2UcLEM/V48DGDJ9kip0=
 github.com/containerd/cgroups/v3 v3.0.3/go.mod h1:8HBe7V3aWGLFPd/k03swSIsGjZhHI2WzJmticMgVuz0=

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/cockroachdb/swiss"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -32,17 +33,18 @@ import (
 
 func TestMemPostings_addFor(t *testing.T) {
 	p := NewMemPostings()
-	p.m[allPostingsKey.Name] = map[string][]storage.SeriesRef{}
-	p.m[allPostingsKey.Name][allPostingsKey.Value] = []storage.SeriesRef{1, 2, 3, 4, 6, 7, 8}
+	p.m[allPostingsKey.Name] = swiss.New[string, []storage.SeriesRef](0)
+	p.m[allPostingsKey.Name].Put(allPostingsKey.Value, []storage.SeriesRef{1, 2, 3, 4, 6, 7, 8})
 
 	p.addFor(5, allPostingsKey)
 
-	require.Equal(t, []storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8}, p.m[allPostingsKey.Name][allPostingsKey.Value])
+	srs, _ := p.m[allPostingsKey.Name].Get(allPostingsKey.Value)
+	require.Equal(t, []storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8}, srs)
 }
 
 func TestMemPostings_ensureOrder(t *testing.T) {
 	p := NewUnorderedMemPostings()
-	p.m["a"] = map[string][]storage.SeriesRef{}
+	p.m["a"] = swiss.New[string, []storage.SeriesRef](0)
 
 	for i := 0; i < 100; i++ {
 		l := make([]storage.SeriesRef, 100)
@@ -51,18 +53,19 @@ func TestMemPostings_ensureOrder(t *testing.T) {
 		}
 		v := fmt.Sprintf("%d", i)
 
-		p.m["a"][v] = l
+		p.m["a"].Put(v, l)
 	}
 
 	p.EnsureOrder(0)
 
 	for _, e := range p.m {
-		for _, l := range e {
+		e.All(func(_ string, l []storage.SeriesRef) bool {
 			ok := sort.SliceIsSorted(l, func(i, j int) bool {
 				return l[i] < l[j]
 			})
 			require.True(t, ok, "postings list %v is not sorted", l)
-		}
+			return true
+		})
 	}
 }
 
@@ -96,7 +99,7 @@ func BenchmarkMemPostings_ensureOrder(b *testing.B) {
 			// Generate postings.
 			for l := 0; l < testData.numLabels; l++ {
 				labelName := strconv.Itoa(l)
-				p.m[labelName] = map[string][]storage.SeriesRef{}
+				p.m[labelName] = swiss.New[string, []storage.SeriesRef](0)
 
 				for v := 0; v < testData.numValuesPerLabel; v++ {
 					refs := make([]storage.SeriesRef, testData.numRefsPerValue)
@@ -105,7 +108,7 @@ func BenchmarkMemPostings_ensureOrder(b *testing.B) {
 					}
 
 					labelValue := strconv.Itoa(v)
-					p.m[labelName][labelValue] = refs
+					p.m[labelName].Put(labelValue, refs)
 				}
 			}
 


### PR DESCRIPTION
Test of [CockroachDB Swiss Map](https://github.com/cockroachdb/swiss) instead of standard `map` in `tsdb/index.MemPostings`, for performance. Requested by @bboreham for prombench-ing, so we can see if there's any real difference.

Confer corresponding [PR](https://github.com/prometheus/prometheus/pull/13644) for dolthub implementation.