### PR TITLE
Move v2.51 release date up

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,7 +55,7 @@ Release cadence of first pre-releases being cut is 6 weeks.
 | v2.48          | 2023-10-04                                 | Levi Harrison (GitHub: @LeviHarrison)       |
 | v2.49          | 2023-12-05                                 | Bartek Plotka (GitHub: @bwplotka)           |
 | v2.50          | 2024-01-16                                 | Augustin Husson (GitHub: @nexucis)          |
-| v2.51          | 2024-04-01                                 | Bryan Boreham (GitHub: @bboreham)           |
+| v2.51          | 2024-03-07                                 | Bryan Boreham (GitHub: @bboreham)           |
 
 If you are interested in volunteering please create a pull request against the [prometheus/prometheus](https://github.com/prometheus/prometheus) repository and propose yourself for the release series of your choice.
 


### PR DESCRIPTION
The previous release was forked on 25th Jan, so we should aim about 6 weeks after that.
