### PR TITLE
fix inconsistent histogram chunk iterators

### DIFF
--- a/promql/value.go
+++ b/promql/value.go
@@ -468,8 +468,12 @@ func (ssi *storageSeriesIterator) AtHistogram(*histogram.Histogram) (int64, *his
 	panic(errors.New("storageSeriesIterator: AtHistogram not supported"))
 }
 
-func (ssi *storageSeriesIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
-	return ssi.currT, ssi.currH
+func (ssi *storageSeriesIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+	if fh == nil {
+		return ssi.currT, ssi.currH.Copy()
+	}
+	ssi.currH.CopyTo(fh)
+	return ssi.currT, fh
 }
 
 func (ssi *storageSeriesIterator) AtT() int64 {

--- a/promql/value_test.go
+++ b/promql/value_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/testutil"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 )
 
@@ -118,5 +119,5 @@ func TestStorageSeriesIterator_CopiesHistograms(t *testing.T) {
 		Histograms: []HPoint{{T: 0, H: h}},
 	}
 	it := newStorageSeriesIterator(series)
-	tsdbutil.VerifyChunkIteratorCopiesFloatHistograms(t, h, it)
+	require.NoError(t, testutil.VerifyChunkIteratorCopiesFloatHistograms(h, it))
 }

--- a/promql/value_test.go
+++ b/promql/value_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 )
 
 func TestVector_ContainsSameLabelset(t *testing.T) {
@@ -107,4 +108,15 @@ func TestMatrix_ContainsSameLabelset(t *testing.T) {
 			require.Equal(t, tc.expected, tc.matrix.ContainsSameLabelset())
 		})
 	}
+}
+
+func TestStorageSeriesIterator_CopiesHistograms(t *testing.T) {
+	h := tsdbutil.GenerateTestFloatHistogram(0)
+	series := Series{
+		Metric:     labels.FromStrings("__name__", "test"),
+		Floats:     nil,
+		Histograms: []HPoint{{T: 0, H: h}},
+	}
+	it := newStorageSeriesIterator(series)
+	tsdbutil.VerifyChunkIteratorCopiesFloatHistograms(t, h, it)
 }

--- a/storage/series.go
+++ b/storage/series.go
@@ -123,14 +123,22 @@ func (it *listSeriesIterator) At() (int64, float64) {
 	return s.T(), s.F()
 }
 
-func (it *listSeriesIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
+func (it *listSeriesIterator) AtHistogram(h *histogram.Histogram) (int64, *histogram.Histogram) {
 	s := it.samples.Get(it.idx)
-	return s.T(), s.H()
+	if h == nil {
+		return s.T(), s.H().Copy()
+	}
+	s.H().CopyTo(h)
+	return s.T(), h
 }
 
-func (it *listSeriesIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+func (it *listSeriesIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
 	s := it.samples.Get(it.idx)
-	return s.T(), s.FH()
+	if fh == nil {
+		return s.T(), s.FH().Copy()
+	}
+	s.FH().CopyTo(fh)
+	return s.T(), fh
 }
 
 func (it *listSeriesIterator) AtT() int64 {

--- a/storage/series_test.go
+++ b/storage/series_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/testutil"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 )
 
@@ -132,8 +133,8 @@ func TestListSeriesIteratorCopiesHistograms(t *testing.T) {
 		hSample{0, h},
 		fhSample{1, fh},
 	})
-	tsdbutil.VerifyChunkIteratorCopiesHistograms(t, h, it)
-	tsdbutil.VerifyChunkIteratorCopiesFloatHistograms(t, fh, it)
+	require.NoError(t, testutil.VerifyChunkIteratorCopiesHistograms(h, it))
+	require.NoError(t, testutil.VerifyChunkIteratorCopiesFloatHistograms(fh, it))
 }
 
 type histogramTest struct {

--- a/storage/series_test.go
+++ b/storage/series_test.go
@@ -128,12 +128,17 @@ func TestChunkSeriesSetToSeriesSet(t *testing.T) {
 
 func TestListSeriesIteratorCopiesHistograms(t *testing.T) {
 	h := tsdbutil.GenerateTestHistogram(0)
-	fh := tsdbutil.GenerateTestFloatHistogram(1)
 	it := NewListSeriesIterator(samples{
 		hSample{0, h},
-		fhSample{1, fh},
 	})
 	require.NoError(t, testutil.VerifyChunkIteratorCopiesHistograms(h, it))
+}
+
+func TestListSeriesIteratorCopiesFloatHistograms(t *testing.T) {
+	fh := tsdbutil.GenerateTestFloatHistogram(0)
+	it := NewListSeriesIterator(samples{
+		fhSample{1, fh},
+	})
 	require.NoError(t, testutil.VerifyChunkIteratorCopiesFloatHistograms(fh, it))
 }
 

--- a/storage/series_test.go
+++ b/storage/series_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 )
 
 func TestListSeriesIterator(t *testing.T) {
@@ -122,6 +123,17 @@ func TestChunkSeriesSetToSeriesSet(t *testing.T) {
 			j++
 		}
 	}
+}
+
+func TestListSeriesIteratorCopiesHistograms(t *testing.T) {
+	h := tsdbutil.GenerateTestHistogram(0)
+	fh := tsdbutil.GenerateTestFloatHistogram(1)
+	it := NewListSeriesIterator(samples{
+		hSample{0, h},
+		fhSample{1, fh},
+	})
+	tsdbutil.VerifyChunkIteratorCopiesHistograms(t, h, it)
+	tsdbutil.VerifyChunkIteratorCopiesFloatHistograms(t, fh, it)
 }
 
 type histogramTest struct {

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -131,18 +131,18 @@ type Iterator interface {
 	// At returns the current timestamp/value pair if the value is a float.
 	// Before the iterator has advanced, the behaviour is unspecified.
 	At() (int64, float64)
-	// AtHistogram returns the current timestamp/value pair if the value is a
+	// AtHistogram returns a copy(!) of the current timestamp/value pair if the value is a
 	// histogram with integer counts. Before the iterator has advanced, the behaviour
 	// is unspecified.
-	// The method accepts an optional Histogram object which will be
+	// The method accepts an optional Histogram object which may be
 	// reused when not nil. Otherwise, a new Histogram object will be allocated.
 	AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram)
-	// AtFloatHistogram returns the current timestamp/value pair if the
+	// AtFloatHistogram returns a copy(!) of the current timestamp/value pair if the
 	// value is a histogram with floating-point counts. It also works if the
 	// value is a histogram with integer counts, in which case a
 	// FloatHistogram copy of the histogram is returned. Before the iterator
 	// has advanced, the behaviour is unspecified.
-	// The method accepts an optional FloatHistogram object which will be
+	// The method accepts an optional FloatHistogram object which may be
 	// reused when not nil. Otherwise, a new FloatHistogram object will be allocated.
 	AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram)
 	// AtT returns the current timestamp.

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -776,11 +776,11 @@ func (it *mockSampleIterator) At() (int64, float64) {
 }
 
 func (it *mockSampleIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
-	return it.s[it.idx].T(), it.s[it.idx].H()
+	return it.s[it.idx].T(), it.s[it.idx].H().Copy()
 }
 
 func (it *mockSampleIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
-	return it.s[it.idx].T(), it.s[it.idx].FH()
+	return it.s[it.idx].T(), it.s[it.idx].FH().Copy()
 }
 
 func (it *mockSampleIterator) AtT() int64 {

--- a/tsdb/testutil/histogram.go
+++ b/tsdb/testutil/histogram.go
@@ -21,6 +21,7 @@ import (
 )
 
 // Test helper to ensure that the iterator copies histograms when iterating.
+// The helper will call it.Next() and check if the next value is a histogram.
 func VerifyChunkIteratorCopiesHistograms(h *histogram.Histogram, it chunkenc.Iterator) error {
 	originalCount := h.Count
 	if it.Next() != chunkenc.ValHistogram {
@@ -46,6 +47,7 @@ func VerifyChunkIteratorCopiesHistograms(h *histogram.Histogram, it chunkenc.Ite
 }
 
 // Test helper to ensure that the iterator copies float histograms when iterating.
+// The helper will call it.Next() and check if the next value is a float histogram.
 func VerifyChunkIteratorCopiesFloatHistograms(fh *histogram.FloatHistogram, it chunkenc.Iterator) error {
 	originalCount := fh.Count
 	if it.Next() != chunkenc.ValFloatHistogram {

--- a/tsdb/testutil/histogram.go
+++ b/tsdb/testutil/histogram.go
@@ -1,0 +1,71 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+// Test helper to ensure that the iterator copies histograms when iterating.
+func VerifyChunkIteratorCopiesHistograms(h *histogram.Histogram, it chunkenc.Iterator) error {
+	originalCount := h.Count
+	if it.Next() != chunkenc.ValHistogram {
+		return fmt.Errorf("expected histogram value type")
+	}
+	// Get a copy.
+	_, hCopy := it.AtHistogram(nil)
+	// Copy into a new histogram.
+	hCopy2 := &histogram.Histogram{}
+	_, hCopy2 = it.AtHistogram(hCopy2)
+
+	// Change the original
+	h.Count = originalCount + 1
+
+	// Ensure that the copy is not affected.
+	if hCopy.Count != originalCount {
+		return fmt.Errorf("copied histogram count should not change when original is modified")
+	}
+	if hCopy2.Count != originalCount {
+		return fmt.Errorf("copied to histogram count should not change when original is modified")
+	}
+	return nil
+}
+
+// Test helper to ensure that the iterator copies float histograms when iterating.
+func VerifyChunkIteratorCopiesFloatHistograms(fh *histogram.FloatHistogram, it chunkenc.Iterator) error {
+	originalCount := fh.Count
+	if it.Next() != chunkenc.ValFloatHistogram {
+		return fmt.Errorf("expected float histogram value type")
+	}
+	// Get a copy.
+	_, hCopy := it.AtFloatHistogram(nil)
+	// Copy into a new histogram.
+	hCopy2 := &histogram.FloatHistogram{}
+	_, hCopy2 = it.AtFloatHistogram(hCopy2)
+
+	// Change the original
+	fh.Count = originalCount + 1
+
+	// Ensure that the copy is not affected.
+	if hCopy.Count != originalCount {
+		return fmt.Errorf("copied histogram count should not change when original is modified")
+	}
+	if hCopy2.Count != originalCount {
+		return fmt.Errorf("copied to histogram count should not change when original is modified")
+	}
+	return nil
+}

--- a/tsdb/tsdbutil/histogram.go
+++ b/tsdb/tsdbutil/histogram.go
@@ -15,12 +15,8 @@ package tsdbutil
 
 import (
 	"math"
-	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/histogram"
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
 func GenerateTestHistograms(n int) (r []*histogram.Histogram) {
@@ -141,40 +137,4 @@ func SetFloatHistogramNotCounterReset(h *histogram.FloatHistogram) *histogram.Fl
 func SetFloatHistogramCounterReset(h *histogram.FloatHistogram) *histogram.FloatHistogram {
 	h.CounterResetHint = histogram.CounterReset
 	return h
-}
-
-// Ensure that the iterator copies histograms when iterating.
-func VerifyChunkIteratorCopiesHistograms(t *testing.T, h *histogram.Histogram, it chunkenc.Iterator) {
-	originalCount := h.Count
-	require.Equal(t, chunkenc.ValHistogram, it.Next())
-	// Get a copy.
-	_, hCopy := it.AtHistogram(nil)
-	// Copy into a new histogram.
-	hCopy2 := &histogram.Histogram{}
-	_, hCopy2 = it.AtHistogram(hCopy2)
-
-	// Change the original
-	h.Count = originalCount + 1
-
-	// Ensure that the copy is not affected.
-	require.Equal(t, originalCount, hCopy.Count, "Copied histogram count should not change when original is modified")
-	require.Equal(t, originalCount, hCopy2.Count, "Copied to histogram count should not change when original is modified")
-}
-
-// Ensure that the iterator copies float histograms when iterating.
-func VerifyChunkIteratorCopiesFloatHistograms(t *testing.T, fh *histogram.FloatHistogram, it chunkenc.Iterator) {
-	originalCount := fh.Count
-	require.Equal(t, chunkenc.ValFloatHistogram, it.Next())
-	// Get a copy.
-	_, hCopy := it.AtFloatHistogram(nil)
-	// Copy into a new histogram.
-	hCopy2 := &histogram.FloatHistogram{}
-	_, hCopy2 = it.AtFloatHistogram(hCopy2)
-
-	// Change the original
-	fh.Count = originalCount + 1
-
-	// Ensure that the copy is not affected.
-	require.Equal(t, originalCount, hCopy.Count, "Copied histogram count should not change when original is modified")
-	require.Equal(t, originalCount, hCopy2.Count, "Copied to histogram count should not change when original is modified")
 }

--- a/tsdb/tsdbutil/histogram.go
+++ b/tsdb/tsdbutil/histogram.go
@@ -15,8 +15,12 @@ package tsdbutil
 
 import (
 	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
 func GenerateTestHistograms(n int) (r []*histogram.Histogram) {
@@ -137,4 +141,40 @@ func SetFloatHistogramNotCounterReset(h *histogram.FloatHistogram) *histogram.Fl
 func SetFloatHistogramCounterReset(h *histogram.FloatHistogram) *histogram.FloatHistogram {
 	h.CounterResetHint = histogram.CounterReset
 	return h
+}
+
+// Ensure that the iterator copies histograms when iterating.
+func VerifyChunkIteratorCopiesHistograms(t *testing.T, h *histogram.Histogram, it chunkenc.Iterator) {
+	originalCount := h.Count
+	require.Equal(t, chunkenc.ValHistogram, it.Next())
+	// Get a copy.
+	_, hCopy := it.AtHistogram(nil)
+	// Copy into a new histogram.
+	hCopy2 := &histogram.Histogram{}
+	_, hCopy2 = it.AtHistogram(hCopy2)
+
+	// Change the original
+	h.Count = originalCount + 1
+
+	// Ensure that the copy is not affected.
+	require.Equal(t, originalCount, hCopy.Count, "Copied histogram count should not change when original is modified")
+	require.Equal(t, originalCount, hCopy2.Count, "Copied to histogram count should not change when original is modified")
+}
+
+// Ensure that the iterator copies float histograms when iterating.
+func VerifyChunkIteratorCopiesFloatHistograms(t *testing.T, fh *histogram.FloatHistogram, it chunkenc.Iterator) {
+	originalCount := fh.Count
+	require.Equal(t, chunkenc.ValFloatHistogram, it.Next())
+	// Get a copy.
+	_, hCopy := it.AtFloatHistogram(nil)
+	// Copy into a new histogram.
+	hCopy2 := &histogram.FloatHistogram{}
+	_, hCopy2 = it.AtFloatHistogram(hCopy2)
+
+	// Change the original
+	fh.Count = originalCount + 1
+
+	// Ensure that the copy is not affected.
+	require.Equal(t, originalCount, hCopy.Count, "Copied histogram count should not change when original is modified")
+	require.Equal(t, originalCount, hCopy2.Count, "Copied to histogram count should not change when original is modified")
 }


### PR DESCRIPTION
tsdb: fix inconsistent histogram chunk iterators

The PromQL engine has an implicit requirement that chunk iterators return copies of native histograms. For example [here](https://github.com/prometheus/prometheus/blob/4408f898bc592b570aa0a173c228e4fe2f284474/promql/engine.go#L2203).

Some iterators do not follow this, so this PR updates the interface definition to be more explicit and fixes some iterators.

Caught when `go test -race` failed on [TestInstantQuerySplittingCorrectness](https://github.com/grafana/mimir/blob/8d24be9d6c5dec105f579488732247facdfdc595/pkg/frontend/querymiddleware/split_by_instant_interval_test.go#L28) in Mimir. Here we are seeding multiple engines with the same series, so reading through [storageSeriesIterator](https://github.com/prometheus/prometheus/blob/4408f898bc592b570aa0a173c228e4fe2f284474/promql/value.go#L471-L473) put the histogram pointers into two separate pools for reuse [here](https://github.com/prometheus/prometheus/blob/4408f898bc592b570aa0a173c228e4fe2f284474/promql/engine.go#L2203).