### PR TITLE
labels: optimize String method

### DIFF
--- a/model/labels/labels_common.go
+++ b/model/labels/labels_common.go
@@ -39,7 +39,8 @@ type Label struct {
 }
 
 func (ls Labels) String() string {
-	var b bytes.Buffer
+	var bytea [1024]byte // On stack to avoid memory allocation while building the output.
+	b := bytes.NewBuffer(bytea[:0])
 
 	b.WriteByte('{')
 	i := 0
@@ -50,7 +51,7 @@ func (ls Labels) String() string {
 		}
 		b.WriteString(l.Name)
 		b.WriteByte('=')
-		b.WriteString(strconv.Quote(l.Value))
+		b.Write(strconv.AppendQuote(b.AvailableBuffer(), l.Value))
 		i++
 	})
 	b.WriteByte('}')

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -43,6 +43,13 @@ func TestLabels_String(t *testing.T) {
 	}
 }
 
+func BenchmarkString(b *testing.B) {
+	ls := New(benchmarkLabels...)
+	for i := 0; i < b.N; i++ {
+		_ = ls.String()
+	}
+}
+
 func TestLabels_MatchLabels(t *testing.T) {
 	labels := FromStrings(
 		"__name__", "ALERTS",

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -785,24 +785,25 @@ func BenchmarkLabels_Hash(b *testing.B) {
 	}
 }
 
+var benchmarkLabels = []Label{
+	{"job", "node"},
+	{"instance", "123.123.1.211:9090"},
+	{"path", "/api/v1/namespaces/<namespace>/deployments/<name>"},
+	{"method", "GET"},
+	{"namespace", "system"},
+	{"status", "500"},
+	{"prometheus", "prometheus-core-1"},
+	{"datacenter", "eu-west-1"},
+	{"pod_name", "abcdef-99999-defee"},
+}
+
 func BenchmarkBuilder(b *testing.B) {
-	m := []Label{
-		{"job", "node"},
-		{"instance", "123.123.1.211:9090"},
-		{"path", "/api/v1/namespaces/<namespace>/deployments/<name>"},
-		{"method", "GET"},
-		{"namespace", "system"},
-		{"status", "500"},
-		{"prometheus", "prometheus-core-1"},
-		{"datacenter", "eu-west-1"},
-		{"pod_name", "abcdef-99999-defee"},
-	}
 
 	var l Labels
 	builder := NewBuilder(EmptyLabels())
 	for i := 0; i < b.N; i++ {
 		builder.Reset(EmptyLabels())
-		for _, l := range m {
+		for _, l := range benchmarkLabels {
 			builder.Set(l.Name, l.Value)
 		}
 		l = builder.Labels()
@@ -811,18 +812,7 @@ func BenchmarkBuilder(b *testing.B) {
 }
 
 func BenchmarkLabels_Copy(b *testing.B) {
-	m := map[string]string{
-		"job":        "node",
-		"instance":   "123.123.1.211:9090",
-		"path":       "/api/v1/namespaces/<namespace>/deployments/<name>",
-		"method":     "GET",
-		"namespace":  "system",
-		"status":     "500",
-		"prometheus": "prometheus-core-1",
-		"datacenter": "eu-west-1",
-		"pod_name":   "abcdef-99999-defee",
-	}
-	l := FromMap(m)
+	l := New(benchmarkLabels...)
 
 	for i := 0; i < b.N; i++ {
 		l = l.Copy()

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -805,7 +805,6 @@ var benchmarkLabels = []Label{
 }
 
 func BenchmarkBuilder(b *testing.B) {
-
 	var l Labels
 	builder := NewBuilder(EmptyLabels())
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Applying a pattern I learned about recently - `Write(AppendQuote(AvailableBuffer` does not allocate or copy when the buffer has sufficient space.

Use a stack buffer to reduce memory allocations.

Also some refactoring to add a benchmark without adding lines of code.

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Intel(R) Core(TM) i7-14700K
         │  before.txt   │             after.txt              │
         │    sec/op     │   sec/op     vs base               │
String-4   1039.0n ± 29%   691.5n ± 7%  -33.45% (p=0.002 n=6)

         │ before.txt │             after.txt             │
         │    B/op    │    B/op     vs base               │
String-4   992.0 ± 0%   240.0 ± 0%  -75.81% (p=0.002 n=6)

         │ before.txt  │             after.txt             │
         │  allocs/op  │ allocs/op   vs base               │
String-4   16.000 ± 0%   1.000 ± 0%  -93.75% (p=0.002 n=6)
```
