### PR TITLE
fix: restore ability to match __name__ multiple times in selector

### DIFF
--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -791,20 +791,7 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 			// Skip the check for non-empty matchers because an explicit
 			// metric name is a non-empty matcher.
 			break
-		} else {
-			// We also have to make sure a metric name was not set twice inside the
-			// braces.
-			foundMetricName := ""
-			for _, m := range n.LabelMatchers {
-				if m != nil && m.Name == labels.MetricName {
-					if foundMetricName != "" {
-						p.addParseErrf(n.PositionRange(), "metric name must not be set twice: %q or %q", foundMetricName, m.Value)
-					}
-					foundMetricName = m.Value
-				}
-			}
 		}
-
 		// A Vector selector must contain at least one non-empty matcher to prevent
 		// implicit selection of all metrics (e.g. by a typo).
 		notEmpty := false


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/13596 
Add tests to cover this case.
