### PR TITLE
docs: textparse.Parser return type mismatch

### DIFF
--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -71,8 +71,8 @@ type Parser interface {
 	// if the scrape protocol or metric type does not support created timestamps.
 	CreatedTimestamp() *int64
 
-	// Next advances the parser to the next sample. It returns false if no
-	// more samples were read or an error occurred.
+	// Next advances the parser to the next sample.
+	// It returns (EntryInvalid, io.EOF) if no samples were read.
 	Next() (Entry, error)
 }
 

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -239,8 +239,8 @@ func (p *OpenMetricsParser) parseError(exp string, got token) error {
 	return fmt.Errorf("%s, got %q (%q) while parsing: %q", exp, p.l.b[p.l.start:e], got, p.l.b[p.start:e])
 }
 
-// Next advances the parser to the next sample. It returns false if no
-// more samples were read or an error occurred.
+// Next advances the parser to the next sample.
+// It returns (EntryInvalid, io.EOF) if no samples were read.
 func (p *OpenMetricsParser) Next() (Entry, error) {
 	var err error
 

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -280,8 +280,8 @@ func (p *PromParser) parseError(exp string, got token) error {
 	return fmt.Errorf("%s, got %q (%q) while parsing: %q", exp, p.l.b[p.l.start:e], got, p.l.b[p.start:e])
 }
 
-// Next advances the parser to the next sample. It returns false if no
-// more samples were read or an error occurred.
+// Next advances the parser to the next sample.
+// It returns (EntryInvalid, io.EOF) if no samples were read.
 func (p *PromParser) Next() (Entry, error) {
 	var err error
 


### PR DESCRIPTION
The docs suggest the Next method returns a bool, but that's not the case (`Entry` is an int).

```
	// Next advances the parser to the next sample. It returns false if no
	// more samples were read or an error occurred.
	Next() (Entry, error)
```

The docs were first added in d80a3de235b5f1349591420c55925d82ca49204e in 2017. Back then the signature was indeed `func (p *Parser) Next() bool`. But then it got refactored in 76a4a46cb0b78ab5b25f099693e9ddd23860a38d and the signature changed with it, yet docs stayed the same - and eventually made their way into the `Parser` interface.

However, the Protobuf parser does have the right wording: 5de2df752f39de05c6ab53a9ec93f797027da0b9

```
// Next advances the parser to the next "sample" (emulating the behavior of a
// text format parser). It returns (EntryInvalid, io.EOF) if no samples were
// read.
```

Changing all other implementations (and the interface itself) to match this doc.