### PR TITLE
Change discovery manager syncCh to buffered channel

### DIFF
--- a/discovery/legacymanager/manager.go
+++ b/discovery/legacymanager/manager.go
@@ -48,7 +48,7 @@ func NewManager(ctx context.Context, logger log.Logger, registerer prometheus.Re
 	}
 	mgr := &Manager{
 		logger:         logger,
-		syncCh:         make(chan map[string][]*targetgroup.Group),
+		syncCh:         make(chan map[string][]*targetgroup.Group, 1),
 		targets:        make(map[poolKey]map[string]*targetgroup.Group),
 		discoverCancel: []context.CancelFunc{},
 		ctx:            ctx,

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -87,7 +87,7 @@ func NewManager(ctx context.Context, logger log.Logger, registerer prometheus.Re
 	}
 	mgr := &Manager{
 		logger:      logger,
-		syncCh:      make(chan map[string][]*targetgroup.Group),
+		syncCh:      make(chan map[string][]*targetgroup.Group, 1),
 		targets:     make(map[poolKey]map[string]*targetgroup.Group),
 		ctx:         ctx,
 		updatert:    5 * time.Second,


### PR DESCRIPTION
This is intended to improve the behavior of Alertmanager service discovery when the notifier is under high load. In normal conditions, buffering this channel doesn't make much of a difference as both the discovery manager and the receiver have plenty of chances to write/read the channel. When the receiver is under heavy load, the buffered channel guarantees it will see the results of a recent discovery manager iteration. I don't think this has any unforeseen impacts. I've opened #13676 with details of the problem I'm trying to fix.

Fixes #13676