### PR TITLE
[Azure] Fixes `error: parameter virtualMachineScaleSetName cannot be empty`

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -413,26 +413,20 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 					} else {
 						networkInterface, err = client.getVMScaleSetVMNetworkInterfaceByID(ctx, nicID, vm.ScaleSet, vm.InstanceID)
 					}
+					
 					if err != nil {
 						if errors.Is(err, errorNotFound) {
 							level.Warn(d.logger).Log("msg", "Network interface does not exist", "name", nicID, "err", err)
 						} else {
 							ch <- target{labelSet: nil, err: err}
 						}
-						d.addToCache(nicID, networkInterface)
-					} else {
-						networkInterface, err = client.getVMScaleSetVMNetworkInterfaceByID(ctx, nicID, vm.ScaleSet, vm.InstanceID)
-						if err != nil {
-							if errors.Is(err, errorNotFound) {
-								level.Warn(d.logger).Log("msg", "Network interface does not exist", "name", nicID, "err", err)
-							} else {
-								ch <- target{labelSet: nil, err: err}
-							}
-							// Get out of this routine because we cannot continue without a network interface.
-							return
-						}
-						d.addToCache(nicID, networkInterface)
+						
+						// Get out of this routine because we cannot continue without a network interface.
+						return
 					}
+
+					// Continue processing with the network interface
+					d.addToCache(nicID, networkInterface)
 				}
 
 				if networkInterface.Properties == nil {

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -413,14 +413,14 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 					} else {
 						networkInterface, err = client.getVMScaleSetVMNetworkInterfaceByID(ctx, nicID, vm.ScaleSet, vm.InstanceID)
 					}
-					
+
 					if err != nil {
 						if errors.Is(err, errorNotFound) {
 							level.Warn(d.logger).Log("msg", "Network interface does not exist", "name", nicID, "err", err)
 						} else {
 							ch <- target{labelSet: nil, err: err}
 						}
-						
+
 						// Get out of this routine because we cannot continue without a network interface.
 						return
 					}


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/13643

## Problem
<img width="622" alt="Cuplikan layar 2024-03-04 184059" src="https://github.com/prometheus/prometheus/assets/86778470/159984eb-94af-44ad-aca7-4c39bdfa4dae">

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
