### PR TITLE
tsdb: zero out Labels and memSeries pointers in pool

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -281,7 +281,7 @@ func (h *Head) getSeriesBuffer() []*memSeries {
 }
 
 func (h *Head) putSeriesBuffer(b []*memSeries) {
-	for i := range b { // Zero out to avoid retaining data
+	for i := range b { // Zero out to avoid retaining data.
 		b[i] = nil
 	}
 	h.seriesPool.Put(b[:0])

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -229,6 +229,9 @@ func (h *Head) putExemplarBuffer(b []exemplarWithSeriesRef) {
 	if b == nil {
 		return
 	}
+	for i := range b { // Zero out to avoid retaining label data
+		b[i].exemplar.Labels = labels.EmptyLabels()
+	}
 
 	h.exemplarsPool.Put(b[:0])
 }
@@ -278,6 +281,9 @@ func (h *Head) getSeriesBuffer() []*memSeries {
 }
 
 func (h *Head) putSeriesBuffer(b []*memSeries) {
+	for i := range b { // Zero out to avoid retaining data
+		b[i] = nil
+	}
 	h.seriesPool.Put(b[:0])
 }
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -229,7 +229,7 @@ func (h *Head) putExemplarBuffer(b []exemplarWithSeriesRef) {
 	if b == nil {
 		return
 	}
-	for i := range b { // Zero out to avoid retaining label data
+	for i := range b { // Zero out to avoid retaining label data.
 		b[i].exemplar.Labels = labels.EmptyLabels()
 	}
 


### PR DESCRIPTION
So that the garbage-collector doesn't see this memory as still in use.

To explain a little further, the block of memory in the pool will be seen as a zero-length slice when used, but it might have previously contained 10,000 series.  Unless we zero out those pointers, or re-use that block for a new scrape of length 10,000, they will all continue to be seen as valid references by the garbage-collector.

This is more noticeable when using `-tags dedupelabels`, but still relevant before.
