### PR TITLE
rules: allow using alternative PromQL engines for rule evaluation

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -115,6 +115,13 @@ func (e ErrStorage) Error() string {
 	return e.Err.Error()
 }
 
+// QueryEngine defines the interface for the *promql.Engine, so it can be replaced, wrapped or mocked.
+type QueryEngine interface {
+	SetQueryLogger(l QueryLogger)
+	NewInstantQuery(ctx context.Context, q storage.Queryable, opts QueryOpts, qs string, ts time.Time) (Query, error)
+	NewRangeQuery(ctx context.Context, q storage.Queryable, opts QueryOpts, qs string, start, end time.Time, interval time.Duration) (Query, error)
+}
+
 // QueryLogger is an interface that can be used to log all the queries logged
 // by the engine.
 type QueryLogger interface {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -117,7 +117,6 @@ func (e ErrStorage) Error() string {
 
 // QueryEngine defines the interface for the *promql.Engine, so it can be replaced, wrapped or mocked.
 type QueryEngine interface {
-	SetQueryLogger(l QueryLogger)
 	NewInstantQuery(ctx context.Context, q storage.Queryable, opts QueryOpts, qs string, ts time.Time) (Query, error)
 	NewRangeQuery(ctx context.Context, q storage.Queryable, opts QueryOpts, qs string, start, end time.Time, interval time.Duration) (Query, error)
 }

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -43,7 +43,7 @@ type QueryFunc func(ctx context.Context, q string, t time.Time) (promql.Vector, 
 // EngineQueryFunc returns a new query function that executes instant queries against
 // the given engine.
 // It converts scalar into vector results.
-func EngineQueryFunc(engine *promql.Engine, q storage.Queryable) QueryFunc {
+func EngineQueryFunc(engine promql.QueryEngine, q storage.Queryable) QueryFunc {
 	return func(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
 		q, err := engine.NewInstantQuery(ctx, q, nil, qs, t)
 		if err != nil {

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -177,13 +177,6 @@ type TSDBAdminStats interface {
 	WALReplayStatus() (tsdb.WALReplayStatus, error)
 }
 
-// QueryEngine defines the interface for the *promql.Engine, so it can be replaced, wrapped or mocked.
-type QueryEngine interface {
-	SetQueryLogger(l promql.QueryLogger)
-	NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error)
-	NewRangeQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error)
-}
-
 type QueryOpts interface {
 	EnablePerStepStats() bool
 	LookbackDelta() time.Duration
@@ -193,7 +186,7 @@ type QueryOpts interface {
 // them using the provided storage and query engine.
 type API struct {
 	Queryable         storage.SampleAndChunkQueryable
-	QueryEngine       QueryEngine
+	QueryEngine       promql.QueryEngine
 	ExemplarQueryable storage.ExemplarQueryable
 
 	scrapePoolsRetriever  func(context.Context) ScrapePoolsRetriever
@@ -226,7 +219,7 @@ type API struct {
 
 // NewAPI returns an initialized API type.
 func NewAPI(
-	qe QueryEngine,
+	qe promql.QueryEngine,
 	q storage.SampleAndChunkQueryable,
 	ap storage.Appendable,
 	eq storage.ExemplarQueryable,

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -3884,8 +3884,6 @@ type fakeEngine struct {
 	query fakeQuery
 }
 
-func (e *fakeEngine) SetQueryLogger(promql.QueryLogger) {}
-
 func (e *fakeEngine) NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
 	return &e.query, nil
 }


### PR DESCRIPTION
This PR makes it possible to use alternative PromQL query engines for rule evaluation in projects like Mimir or Thanos, similar to the changes introduced in https://github.com/prometheus/prometheus/pull/10050 and https://github.com/prometheus/prometheus/pull/12516.

I've moved the `QueryEngine` interface introduced in https://github.com/prometheus/prometheus/pull/10050 to the `promql` package and changed the `web/api/v1` and `rules` packages to use it. Another option would be to introduce a `QueryEngine` interface specifically for the `rules` package that just contains `NewInstantQuery()`, as that's the only method used in the `rules` package - open to feedback on which approach is preferable.