### PR TITLE
CI: run main tests with --tags=stringlabels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,8 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: prometheus/promci@3cb0c3871f223bd5ce1226995bd52ffb314798b6 # v0.1.0
       - uses: ./.github/promci/actions/setup_environment
-      - run: make GO_ONLY=1 SKIP_GOLANGCI_LINT=1
-      - run: go test ./tsdb/ -test.tsdb-isolation=false
-      - run: go test --tags=stringlabels ./...
+      - run: make GOOPTS=--tags=stringlabels GO_ONLY=1 SKIP_GOLANGCI_LINT=1
+      - run: go test --tags=stringlabels ./tsdb/ -test.tsdb-isolation=false
       - run: go test --tags=dedupelabels ./...
       - run: GOARCH=386 go test ./cmd/prometheus
       - run: make -C documentation/examples/remote_storage


### PR DESCRIPTION
This is what we use for builds, so do the main testing (with -race) under that flag.

Drop non-stringlabels tests from current Go version; previous Go version still runs them.

