### PR TITLE
histograms: support expansion of native histogram values in templating

### DIFF
--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -18,7 +18,7 @@ The primary data structure for dealing with time series data is the sample, defi
 ```go
 type sample struct {
         Labels map[string]string
-        Value  float64
+        Value  interface{}
 }
 ```
 
@@ -44,7 +44,7 @@ If functions are used in a pipeline, the pipeline value is passed as the last ar
 | query         | query string  | []sample | Queries the database, does not support returning range vectors.  |
 | first         | []sample      | sample   | Equivalent to `index a 0`  |
 | label         | label, sample | string   | Equivalent to `index sample.Labels label`  |
-| value         | sample        | float64  | Equivalent to `sample.Value`  |
+| value         | sample        | interface{}  | Equivalent to `sample.Value`  |
 | sortByLabel   | label, []samples | []sample | Sorts the samples by the given label. Is stable.  |
 
 `first`, `label` and `value` are intended to make query results easily usable in pipelines.

--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -27,6 +27,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/template"
 )
@@ -256,7 +257,7 @@ func testTemplateParsing(rl *RuleNode) (errs []error) {
 	}
 
 	// Trying to parse templates.
-	tmplData := template.AlertTemplateData(map[string]string{}, map[string]string{}, "", 0)
+	tmplData := template.AlertTemplateData(map[string]string{}, map[string]string{}, "", promql.Sample{})
 	defs := []string{
 		"{{$labels := .Labels}}",
 		"{{$externalLabels := .ExternalLabels}}",

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -364,7 +364,7 @@ func (r *AlertingRule) Eval(ctx context.Context, ts time.Time, query QueryFunc, 
 		// Provide the alert information to the template.
 		l := smpl.Metric.Map()
 
-		tmplData := template.AlertTemplateData(l, r.externalLabels, r.externalURL, smpl.F)
+		tmplData := template.AlertTemplateData(l, r.externalLabels, r.externalURL, smpl)
 		// Inject some convenience variables that are easier to remember for users
 		// who are not used to Go's templating system.
 		defs := []string{

--- a/template/template.go
+++ b/template/template.go
@@ -355,18 +355,24 @@ func NewTemplateExpander(
 }
 
 // AlertTemplateData returns the interface to be used in expanding the template.
-func AlertTemplateData(labels, externalLabels map[string]string, externalURL string, value float64) interface{} {
-	return struct {
+func AlertTemplateData(labels, externalLabels map[string]string, externalURL string, smpl promql.Sample) interface{} {
+	res := struct {
 		Labels         map[string]string
 		ExternalLabels map[string]string
 		ExternalURL    string
-		Value          float64
+		Value          interface{}
 	}{
 		Labels:         labels,
 		ExternalLabels: externalLabels,
 		ExternalURL:    externalURL,
-		Value:          value,
+		Value:          smpl.F,
 	}
+
+	if smpl.H != nil {
+		res.Value = smpl.H
+	}
+
+	return res
 }
 
 // Funcs adds the functions in fm to the Expander's function map.

--- a/template/template.go
+++ b/template/template.go
@@ -57,7 +57,7 @@ func init() {
 // A version of vector that's easier to use from templates.
 type sample struct {
 	Labels map[string]string
-	Value  float64
+	Value  interface{}
 }
 type queryResult []*sample
 
@@ -95,6 +95,9 @@ func query(ctx context.Context, q string, ts time.Time, queryFn QueryFunc) (quer
 		s := sample{
 			Value:  v.F,
 			Labels: v.Metric.Map(),
+		}
+		if v.H != nil {
+			s.Value = v.H
 		}
 		result[n] = &s
 	}
@@ -160,7 +163,7 @@ func NewTemplateExpander(
 			"label": func(label string, s *sample) string {
 				return s.Labels[label]
 			},
-			"value": func(s *sample) float64 {
+			"value": func(s *sample) interface{} {
 				return s.Value
 			},
 			"strvalue": func(s *sample) string {


### PR DESCRIPTION
Partial [#11910](https://github.com/prometheus/prometheus/issues/11910)

The most fundamental change comes from updating the definition of `template.sample` and associated template functions. Notably, the return type of the `value` function changes to `interface{}`. `interface{}` is required so that native histograms are included in addition to floats. Similarly, the `Value` field in alert template data is now of type `interface{}` instead of `float64`.

TODO:

- [x] Add support in alert templates
- [x] Add support in console templates
- [x] Fix failing tests. "Signed off by" needs to be added.
- [ ] Optional: update the histogram representation. The first iteration was a pure text representation.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
