### PR TITLE
[BUGFIX] Scraping: Tolerance should be max 1% of interval

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1218,10 +1218,8 @@ mainLoop:
 		// and .Add on time.Time behave differently (see time package docs).
 		scrapeTime := time.Now().Round(0)
 		if AlignScrapeTimestamps {
-			tolerance := ScrapeTimestampTolerance
-			if maxTolerance := sl.interval / 100; tolerance < maxTolerance {
-				tolerance = maxTolerance
-			}
+			// Tolerance is clamped to maximum 1% of the scrape interval.
+			tolerance := min(sl.interval/100, ScrapeTimestampTolerance)
 			// For some reason, a tick might have been skipped, in which case we
 			// would call alignedScrapeTime.Add(interval) multiple times.
 			for scrapeTime.Sub(alignedScrapeTime) >= sl.interval {


### PR DESCRIPTION
Previous code set it at minimum 1%, which was not intended.

Fixes #13730
