### PR TITLE
CI: don't run race-detector on tests with previous Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - run: make build
-      - run: make test GO_ONLY=1
+      # Don't run NPM build; don't run race-detector.
+      - run: make test GO_ONLY=1 test-flags=""
 
   test_ui:
     name: UI tests


### PR DESCRIPTION
The purpose of running with a previous Go version is to spot usage of new language features; we don't need to intensively look for bugs.
