### PR TITLE
[ENHANCEMENT] PromQL: Re-structure aggregations for clarity and performance

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3081,12 +3081,12 @@ func addToSeries(ss *Series, ts int64, f float64, h *histogram.FloatHistogram, n
 			ss.Floats = getFPointSlice(numSteps)
 		}
 		ss.Floats = append(ss.Floats, FPoint{T: ts, F: f})
-	} else {
-		if ss.Histograms == nil {
-			ss.Histograms = getHPointSlice(numSteps)
-		}
-		ss.Histograms = append(ss.Histograms, HPoint{T: ts, H: h})
+		return
 	}
+	if ss.Histograms == nil {
+		ss.Histograms = getHPointSlice(numSteps)
+	}
+	ss.Histograms = append(ss.Histograms, HPoint{T: ts, H: h})
 }
 
 func (ev *evaluator) nextValues(ts int64, series *Series) (f float64, h *histogram.FloatHistogram, b bool) {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1257,17 +1257,7 @@ func (ev *evaluator) rangeEval(prepSeries func(labels.Labels, *EvalSeriesHelper)
 			} else {
 				ss = seriesAndTimestamp{Series{Metric: sample.Metric}, ts}
 			}
-			if sample.H == nil {
-				if ss.Floats == nil {
-					ss.Floats = getFPointSlice(numSteps)
-				}
-				ss.Floats = append(ss.Floats, FPoint{T: ts, F: sample.F})
-			} else {
-				if ss.Histograms == nil {
-					ss.Histograms = getHPointSlice(numSteps)
-				}
-				ss.Histograms = append(ss.Histograms, HPoint{T: ts, H: sample.H})
-			}
+			addToSeries(&ss.Series, enh.Ts, sample.F, sample.H, numSteps)
 			seriess[h] = ss
 		}
 	}
@@ -2938,17 +2928,7 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 			if !ok {
 				ss = Series{Metric: lbls}
 			}
-			if h == nil {
-				if ss.Floats == nil {
-					ss.Floats = getFPointSlice(numSteps)
-				}
-				ss.Floats = append(ss.Floats, FPoint{T: enh.Ts, F: f})
-			} else {
-				if ss.Histograms == nil {
-					ss.Histograms = getHPointSlice(numSteps)
-				}
-				ss.Histograms = append(ss.Histograms, HPoint{T: enh.Ts, H: h})
-			}
+			addToSeries(&ss, enh.Ts, f, h, numSteps)
 			seriess[hash] = ss
 		}
 	}
@@ -3062,6 +3042,20 @@ func (ev *evaluator) aggregationCountValues(e *parser.AggregateExpr, grouping []
 		})
 	}
 	return enh.Out, nil
+}
+
+func addToSeries(ss *Series, ts int64, f float64, h *histogram.FloatHistogram, numSteps int) {
+	if h == nil {
+		if ss.Floats == nil {
+			ss.Floats = getFPointSlice(numSteps)
+		}
+		ss.Floats = append(ss.Floats, FPoint{T: ts, F: f})
+	} else {
+		if ss.Histograms == nil {
+			ss.Histograms = getHPointSlice(numSteps)
+		}
+		ss.Histograms = append(ss.Histograms, HPoint{T: ts, H: h})
+	}
 }
 
 // groupingKey builds and returns the grouping key for the given metric and

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2686,9 +2686,6 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, grouping []string, par
 				newAgg.groupCount = 0
 			}
 
-			result[groupingKey] = newAgg
-			orderedResult = append(orderedResult, newAgg)
-
 			inputVecLen := int64(len(vec))
 			resultSize := k
 			switch {
@@ -2699,22 +2696,25 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, grouping []string, par
 			}
 			switch op {
 			case parser.STDVAR, parser.STDDEV:
-				result[groupingKey].floatValue = 0
+				newAgg.floatValue = 0
 			case parser.TOPK, parser.QUANTILE:
-				result[groupingKey].heap = make(vectorByValueHeap, 1, resultSize)
-				result[groupingKey].heap[0] = Sample{
+				newAgg.heap = make(vectorByValueHeap, 1, resultSize)
+				newAgg.heap[0] = Sample{
 					F:      s.F,
 					Metric: s.Metric,
 				}
 			case parser.BOTTOMK:
-				result[groupingKey].reverseHeap = make(vectorByReverseValueHeap, 1, resultSize)
-				result[groupingKey].reverseHeap[0] = Sample{
+				newAgg.reverseHeap = make(vectorByReverseValueHeap, 1, resultSize)
+				newAgg.reverseHeap[0] = Sample{
 					F:      s.F,
 					Metric: s.Metric,
 				}
 			case parser.GROUP:
-				result[groupingKey].floatValue = 1
+				newAgg.floatValue = 1
 			}
+
+			result[groupingKey] = newAgg
+			orderedResult = append(orderedResult, newAgg)
 			continue
 		}
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -966,7 +966,7 @@ load 10s
 		{
 			Query:        "sum by (b) (max_over_time(metricWith3SampleEvery10Seconds[60s] @ 30))",
 			Start:        time.Unix(201, 0),
-			PeakSamples:  8,
+			PeakSamples:  7,
 			TotalSamples: 12, // @ modifier force the evaluation to at 30 seconds - So it brings 4 datapoints (0, 10, 20, 30 seconds) * 3 series
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 12,


### PR DESCRIPTION
I found it very hard to follow the twists and turns of the `aggregation()` function.

This PR splits it into three implementations divided by how they output:
* `aggregation` for sum, avg, count, stdvar, stddev and quantile, produces one output series for each group specified in the expression, with just the labels from `by(...)`.
* `aggregationK`, for topk and bottomk, in contrast produces output that has the same labels as the input, but just `k` of them per group.
* `aggregationCountValues` outputs as many series per group as there are values in the input.

The main `aggregation` function no longer looks up each input and output series in a map on every timestamp; instead the lookup is done once per input series and a slice mapping input to output indexes is used subsequently.

One test had to change: because we no longer generate an intermediate vector of input samples the peak-sample count has gone down.

`aggregation()` was 325 lines before and 190 lines now.

~There are a lot of commits in this PR, and some of them say "WIP"; I have some hopes of cleaning them up, but could also squash the lot.~

Benchmarks, first steps=100 then steps=1000:
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/promql
                                                                              │ before100.txt │            after100.txt             │
                                                                              │    sec/op     │    sec/op     vs base               │
RangeQuery/expr=a_hundred,steps=100-8                                            481.3µ ±  2%   496.0µ ±  8%   +3.05% (p=0.026 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                  1.042m ±  9%   1.026m ±  5%        ~ (p=0.699 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                561.2m ±  3%   573.0m ± 13%        ~ (p=0.240 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                               99.79m ±  2%   98.44m ±  4%        ~ (p=0.394 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                  77.21m ±  3%   76.13m ±  1%   -1.39% (p=0.041 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                      45.20m ±  2%   44.95m ±  1%        ~ (p=0.394 n=6)
RangeQuery/expr=-a_hundred,steps=100-8                                           491.7µ ± 16%   494.3µ ±  6%        ~ (p=0.310 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                3.064m ±  3%   3.055m ±  4%        ~ (p=0.937 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8               1.620m ±  4%   1.602m ±  1%        ~ (p=0.394 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                1.944m ± 11%   1.934m ±  0%        ~ (p=0.485 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8            1.624m ±  6%   1.602m ±  1%        ~ (p=0.180 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                549.4µ ±  5%   545.8µ ±  1%        ~ (p=0.589 n=6)
RangeQuery/expr=abs(a_hundred),steps=100-8                                       949.5µ ±  3%   955.9µ ±  0%        ~ (p=0.394 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8    515.4µ ±  1%   515.6µ ±  0%        ~ (p=1.000 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8           508.2µ ±  2%   498.3µ ±  1%        ~ (p=0.065 n=6)
RangeQuery/expr=sum(a_hundred),steps=100-8                                       609.5µ ±  8%   513.7µ ±  0%  -15.71% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                           7.147m ±  3%   5.529m ±  4%  -22.64% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                          9.090m ±  4%   5.628m ±  1%  -38.09% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                                9.519m ±  3%   5.603m ±  1%  -41.13% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                               7.252m ±  6%   5.521m ±  1%  -23.87% (p=0.002 n=6)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                     135.7m ±  1%   134.3m ±  1%   -1.00% (p=0.009 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=100-8                                   636.0µ ±  1%   536.1µ ±  1%  -15.71% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=100-8                                   845.1µ ±  0%   737.0µ ±  1%  -12.79% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8            4.033m ±  0%   4.038m ±  2%        ~ (p=0.937 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                 1.152m ±  0%   1.048m ±  9%   -9.08% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8         21.47m ±  1%   21.22m ±  1%   -1.19% (p=0.004 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8                  958.0µ ±  1%   947.0µ ±  1%   -1.15% (p=0.026 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=100-8                                 965.9µ ±  1%   969.5µ ± 10%        ~ (p=0.310 n=6)
geomean                                                                          3.513m         3.249m         -7.51%

                                                                              │ before100.txt │            after100.txt             │
                                                                              │     B/op      │     B/op      vs base               │
RangeQuery/expr=a_hundred,steps=100-8                                            75.05Ki ± 0%   75.06Ki ± 0%        ~ (p=0.675 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                  100.6Ki ± 0%   100.6Ki ± 0%        ~ (p=0.394 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                3.489Mi ± 0%   3.487Mi ± 0%        ~ (p=0.242 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                               3.044Mi ± 2%   3.004Mi ± 0%   -1.30% (p=0.041 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                  3.041Mi ± 2%   3.024Mi ± 1%        ~ (p=0.589 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                      3.180Mi ± 1%   3.181Mi ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=-a_hundred,steps=100-8                                           78.64Ki ± 0%   78.64Ki ± 0%        ~ (p=0.859 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                288.3Ki ± 0%   284.8Ki ± 0%   -1.21% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8               680.3Ki ± 0%   678.0Ki ± 0%   -0.34% (p=0.002 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                1.195Mi ± 0%   1.192Mi ± 0%   -0.21% (p=0.002 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8            680.5Ki ± 0%   677.8Ki ± 0%   -0.40% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                127.7Ki ± 0%   125.9Ki ± 0%   -1.38% (p=0.002 n=6)
RangeQuery/expr=abs(a_hundred),steps=100-8                                       123.2Ki ± 0%   123.2Ki ± 0%        ~ (p=0.394 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8    92.46Ki ± 0%   92.45Ki ± 0%   -0.01% (p=0.039 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8           83.82Ki ± 0%   83.83Ki ± 0%        ~ (p=0.368 n=6)
RangeQuery/expr=sum(a_hundred),steps=100-8                                      136.75Ki ± 0%   83.41Ki ± 0%  -39.01% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                          1400.7Ki ± 0%   868.7Ki ± 0%  -37.98% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                         3862.0Ki ± 0%   901.8Ki ± 0%  -76.65% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                               3862.2Ki ± 0%   901.9Ki ± 0%  -76.65% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                              1400.6Ki ± 0%   868.8Ki ± 0%  -37.97% (p=0.002 n=6)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                     97.76Mi ± 0%   85.49Mi ± 0%  -12.55% (p=0.002 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=100-8                                   142.5Ki ± 0%   121.5Ki ± 0%  -14.71% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=100-8                                   181.4Ki ± 0%   141.5Ki ± 0%  -22.00% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8            333.9Ki ± 0%   330.5Ki ± 0%   -1.02% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                 163.0Ki ± 0%   109.2Ki ± 0%  -32.97% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8         1.453Mi ± 0%   1.453Mi ± 0%        ~ (p=0.589 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8                  170.0Ki ± 0%   168.2Ki ± 0%   -1.05% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=100-8                                 583.9Ki ± 0%   583.9Ki ± 0%        ~ (p=0.589 n=6)
geomean                                                                          564.4Ki        465.8Ki       -17.47%

                                                                              │ before100.txt │             after100.txt             │
                                                                              │   allocs/op   │  allocs/op   vs base                 │
RangeQuery/expr=a_hundred,steps=100-8                                             1.199k ± 0%   1.199k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=rate(a_hundred[1m]),steps=100-8                                   1.644k ± 0%   1.644k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=100-8                 37.09k ± 0%   37.08k ± 0%        ~ (p=0.242 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=100-8                                36.99k ± 0%   36.99k ± 0%        ~ (p=0.061 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=100-8                                   37.39k ± 0%   37.39k ± 0%        ~ (p=0.240 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=100-8                       37.08k ± 0%   37.08k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=-a_hundred,steps=100-8                                            1.217k ± 0%   1.217k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=a_hundred_-_b_hundred,steps=100-8                                 2.996k ± 0%   2.997k ± 0%        ~ (p=0.182 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=100-8                2.989k ± 0%   2.989k ± 0%        ~ (p=0.545 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=100-8                 3.149k ± 0%   3.149k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=100-8             2.989k ± 0%   2.989k ± 0%        ~ (p=0.545 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=100-8                 1.568k ± 0%   1.568k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=abs(a_hundred),steps=100-8                                        1.334k ± 0%   1.334k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=100-8     1.740k ± 0%   1.740k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=100-8            1.505k ± 0%   1.505k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=sum(a_hundred),steps=100-8                                        1.640k ± 0%   1.225k ± 0%  -25.30% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-8                            15.15k ± 0%   12.12k ± 0%  -20.02% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-8                           34.17k ± 0%   12.22k ± 0%  -64.23% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-8                                 34.17k ± 0%   12.22k ± 0%  -64.23% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-8                                15.15k ± 0%   12.12k ± 0%  -20.02% (p=0.002 n=6)
RangeQuery/expr=count_values('value',_h_hundred),steps=100-8                      574.3k ± 0%   573.0k ± 0%   -0.22% (p=0.002 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=100-8                                    1.763k ± 0%   1.546k ± 0%  -12.31% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=100-8                                    2.369k ± 0%   1.748k ± 0%  -26.21% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=100-8             3.881k ± 0%   3.881k ± 0%        ~ (p=0.455 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-8                  2.188k ± 0%   1.673k ± 0%  -23.54% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=100-8          17.80k ± 0%   17.80k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=100-8                   1.601k ± 0%   1.601k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=timestamp(a_hundred),steps=100-8                                  1.935k ± 0%   1.935k ± 0%        ~ (p=1.000 n=6) ¹
geomean                                                                           5.631k        4.969k       -11.75%
¹ all samples are equal

goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/promql
                                                                               │ before1000.txt │            after1000.txt            │
                                                                               │     sec/op     │    sec/op     vs base               │
RangeQuery/expr=a_hundred,steps=1000-8                                              2.673m ± 1%   2.672m ±  1%        ~ (p=0.699 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-8                                    7.397m ± 0%   7.266m ±  6%        ~ (p=0.065 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-8                   5.239 ± 4%    5.308 ±  0%        ~ (p=0.394 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-8                                 762.8m ± 1%   760.0m ±  0%   -0.36% (p=0.041 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-8                                    541.1m ± 1%   548.0m ±  4%   +1.27% (p=0.026 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-8                        239.6m ± 2%   241.6m ±  1%        ~ (p=0.132 n=6)
RangeQuery/expr=-a_hundred,steps=1000-8                                             2.723m ± 0%   2.724m ±  0%        ~ (p=0.589 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                                  25.55m ± 1%   25.67m ±  1%        ~ (p=0.093 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8                 12.25m ± 7%   12.30m ±  0%        ~ (p=0.394 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8                  15.47m ± 1%   15.48m ±  0%        ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8              12.32m ± 1%   12.33m ±  0%        ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-8                  3.296m ± 0%   3.276m ±  8%        ~ (p=0.394 n=6)
RangeQuery/expr=abs(a_hundred),steps=1000-8                                         7.080m ± 5%   7.152m ±  0%        ~ (p=0.065 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8      2.704m ± 0%   2.702m ±  0%        ~ (p=0.485 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8             2.684m ± 0%   2.686m ±  0%        ~ (p=0.180 n=6)
RangeQuery/expr=sum(a_hundred),steps=1000-8                                         3.982m ± 4%   3.041m ±  4%  -23.62% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-8                             52.36m ± 2%   35.08m ±  0%  -32.99% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-8                            74.45m ± 3%   36.03m ±  1%  -51.60% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-8                                  75.09m ± 1%   35.83m ±  9%  -52.28% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-8                                 52.73m ± 1%   34.79m ±  1%  -34.01% (p=0.002 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-8                                     4.145m ± 0%   3.188m ±  1%  -23.08% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=1000-8                                     6.181m ± 1%   5.147m ±  0%  -16.72% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-8              34.72m ± 2%   34.24m ±  1%   -1.36% (p=0.004 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-8                   8.715m ± 0%   8.808m ± 13%        ~ (p=0.394 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-8           182.2m ± 1%   181.7m ±  4%        ~ (p=0.818 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8                    7.233m ± 1%   7.110m ±  0%   -1.70% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1000-8                                   7.125m ± 2%   7.178m ±  0%        ~ (p=0.394 n=6)
geomean                                                                             21.72m        19.46m        -10.40%

                                                                               │ before1000.txt │            after1000.txt            │
                                                                               │      B/op      │     B/op      vs base               │
RangeQuery/expr=a_hundred,steps=1000-8                                             353.0Ki ± 0%   353.0Ki ± 0%        ~ (p=0.699 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-8                                   345.8Ki ± 0%   345.8Ki ± 0%        ~ (p=0.394 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-8                 3.709Mi ± 1%   3.709Mi ± 1%        ~ (p=1.000 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-8                                3.354Mi ± 3%   3.467Mi ± 7%        ~ (p=0.082 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-8                                   3.375Mi ± 3%   3.374Mi ± 3%        ~ (p=0.853 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-8                       4.796Mi ± 0%   4.845Mi ± 1%        ~ (p=0.288 n=6)
RangeQuery/expr=-a_hundred,steps=1000-8                                            356.5Ki ± 0%   356.5Ki ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                                 887.2Ki ± 0%   883.5Ki ± 0%   -0.42% (p=0.002 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8                5.396Mi ± 0%   5.395Mi ± 0%   -0.03% (p=0.026 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8                 10.62Mi ± 0%   10.61Mi ± 0%   -0.05% (p=0.009 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8             5.397Mi ± 0%   5.394Mi ± 0%   -0.05% (p=0.041 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-8                 447.8Ki ± 0%   446.0Ki ± 0%   -0.40% (p=0.002 n=6)
RangeQuery/expr=abs(a_hundred),steps=1000-8                                        422.4Ki ± 0%   422.4Ki ± 0%        ~ (p=0.894 n=6)
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8     370.4Ki ± 0%   370.4Ki ± 0%        ~ (p=0.240 n=6)
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8            361.8Ki ± 0%   361.8Ki ± 0%        ~ (p=0.589 n=6)
RangeQuery/expr=sum(a_hundred),steps=1000-8                                        562.5Ki ± 0%   361.3Ki ± 0%  -35.77% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-8                            6.214Mi ± 0%   3.819Mi ± 0%  -38.54% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-8                          29.886Mi ± 0%   3.850Mi ± 0%  -87.12% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-8                                29.886Mi ± 0%   3.851Mi ± 0%  -87.12% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-8                                6.213Mi ± 0%   3.819Mi ± 0%  -38.53% (p=0.002 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-8                                    610.3Ki ± 0%   554.4Ki ± 0%   -9.16% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=1000-8                                    994.1Ki ± 0%   750.4Ki ± 0%  -24.52% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-8             867.7Ki ± 0%   864.8Ki ± 0%   -0.33% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-8                  559.5Ki ± 0%   354.4Ki ± 0%  -36.66% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-8          4.465Mi ± 0%   4.465Mi ± 1%        ~ (p=0.974 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8                   494.8Ki ± 0%   493.0Ki ± 0%   -0.36% (p=0.002 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1000-8                                  4.394Mi ± 0%   4.394Mi ± 0%        ~ (p=0.132 n=6)
geomean                                                                            1.724Mi        1.364Mi       -20.88%

                                                                               │ before1000.txt │            after1000.txt             │
                                                                               │   allocs/op    │  allocs/op   vs base                 │
RangeQuery/expr=a_hundred,steps=1000-8                                              5.206k ± 0%   5.206k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=rate(a_hundred[1m]),steps=1000-8                                    5.164k ± 0%   5.164k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=holt_winters(a_hundred[1d],_0.3,_0.3),steps=1000-8                  40.51k ± 0%   40.51k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=changes(a_hundred[1d]),steps=1000-8                                 40.42k ± 0%   40.42k ± 0%        ~ (p=0.082 n=6)
RangeQuery/expr=rate(a_hundred[1d]),steps=1000-8                                    40.82k ± 0%   40.82k ± 0%        ~ (p=0.946 n=6)
RangeQuery/expr=absent_over_time(a_hundred[1d]),steps=1000-8                        40.50k ± 0%   40.50k ± 0%        ~ (p=0.076 n=6)
RangeQuery/expr=-a_hundred,steps=1000-8                                             5.224k ± 0%   5.224k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_-_b_hundred,steps=1000-8                                  12.81k ± 0%   12.81k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l=~'.*[0-4]$'},steps=1000-8                 16.92k ± 0%   16.92k ± 0%        ~ (p=0.260 n=6)
RangeQuery/expr=a_hundred_or_b_hundred{l=~'.*[0-4]$'},steps=1000-8                  18.50k ± 0%   18.50k ± 0%        ~ (p=0.794 n=6)
RangeQuery/expr=a_hundred_unless_b_hundred{l=~'.*[0-4]$'},steps=1000-8              16.92k ± 0%   16.92k ± 0%        ~ (p=0.857 n=6)
RangeQuery/expr=a_hundred_and_b_hundred{l='notfound'},steps=1000-8                  7.375k ± 0%   7.375k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=abs(a_hundred),steps=1000-8                                         6.241k ± 0%   6.241k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=label_replace(a_hundred,_'l2',_'$1',_'l',_'(.*)'),steps=1000-8      5.748k ± 0%   5.748k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=label_join(a_hundred,_'l2',_'-',_'l',_'l'),steps=1000-8             5.512k ± 0%   5.512k ± 0%        ~ (p=1.000 n=6) ¹
RangeQuery/expr=sum(a_hundred),steps=1000-8                                         9.248k ± 0%   5.232k ± 0%  -43.43% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-8                             86.16k ± 0%   56.07k ± 0%  -34.92% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-8                           274.62k ± 0%   56.18k ± 0%  -79.54% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-8                                 274.62k ± 0%   56.18k ± 0%  -79.54% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-8                                 86.17k ± 0%   56.07k ± 0%  -34.93% (p=0.002 n=6)
RangeQuery/expr=topk(1,_a_hundred),steps=1000-8                                    10.271k ± 0%   8.253k ± 0%  -19.65% (p=0.002 n=6)
RangeQuery/expr=topk(5,_a_hundred),steps=1000-8                                     16.28k ± 0%   10.26k ± 0%  -36.99% (p=0.002 n=6)
RangeQuery/expr=rate(a_hundred[1m])_+_rate(b_hundred[1m]),steps=1000-8              12.72k ± 0%   12.72k ± 0%        ~ (p=0.182 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-8                  10.208k ± 0%   5.192k ± 0%  -49.13% (p=0.002 n=6)
RangeQuery/expr=histogram_quantile(0.9,_rate(h_hundred[5m])),steps=1000-8           63.56k ± 0%   63.56k ± 0%        ~ (p=0.680 n=6)
RangeQuery/expr=a_hundred_+_on(l)_group_right_a_one,steps=1000-8                    7.453k ± 0%   7.453k ± 0%        ~ (p=1.000 n=6)
RangeQuery/expr=timestamp(a_hundred),steps=1000-8                                   8.648k ± 0%   8.648k ± 0%        ~ (p=0.273 n=6)
geomean                                                                             18.54k        14.87k       -19.80%
¹ all samples are equal
```