### PR TITLE
Add support for defining series and alert limits individually in rule groups

### DIFF
--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -128,6 +128,20 @@ func (g *RuleGroups) Validate(node ruleGroups) (errs []error) {
 				})
 			}
 		}
+
+		if g.AlertLimit > 0 && g.Limit != 0 && g.Limit < g.AlertLimit {
+			errs = append(
+				errs,
+				fmt.Errorf("%d:%d: alert_limit must not be greater than the total limit", node.Groups[j].Line, node.Groups[j].Column),
+			)
+		}
+
+		if g.SeriesLimit > 0 && g.Limit != 0 && g.Limit < g.SeriesLimit {
+			errs = append(
+				errs,
+				fmt.Errorf("%d:%d: series_limit must not be greater than the total limit", node.Groups[j].Line, node.Groups[j].Column),
+			)
+		}
 	}
 
 	return errs
@@ -135,10 +149,12 @@ func (g *RuleGroups) Validate(node ruleGroups) (errs []error) {
 
 // RuleGroup is a list of sequentially evaluated recording and alerting rules.
 type RuleGroup struct {
-	Name     string         `yaml:"name"`
-	Interval model.Duration `yaml:"interval,omitempty"`
-	Limit    int            `yaml:"limit,omitempty"`
-	Rules    []RuleNode     `yaml:"rules"`
+	Name        string         `yaml:"name"`
+	Interval    model.Duration `yaml:"interval,omitempty"`
+	Limit       int            `yaml:"limit,omitempty"`
+	SeriesLimit int            `yaml:"series_limit,omitempty"`
+	AlertLimit  int            `yaml:"alert_limit,omitempty"`
+	Rules       []RuleNode     `yaml:"rules"`
 }
 
 // Rule describes an alerting or recording rule.

--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -81,6 +81,14 @@ func TestParseFileFailure(t *testing.T) {
 			filename: "record_and_keep_firing_for.bad.yaml",
 			errMsg:   "invalid field 'keep_firing_for' in recording rule",
 		},
+		{
+			filename: "invalid_alerts_limit.yaml",
+			errMsg:   "alert_limit must not be greater than the total limit",
+		},
+		{
+			filename: "invalid_series_limit.yaml",
+			errMsg:   "series_limit must not be greater than the total limit",
+		},
 	}
 
 	for _, c := range table {
@@ -159,6 +167,32 @@ groups:
       description: "{{$labels.quantile * 100}}"
 `,
 			shouldPass: false,
+		},
+		{
+			// limit is undefined but alert_limit is set
+			ruleString: `
+groups:
+- name: example
+  rules:
+    - alert: InstanceDown
+      expr: up == 0
+      for: 5m
+  alert_limit: 100
+      `,
+			shouldPass: true,
+		},
+		{
+			// limit is undefined but series_limit is set
+			ruleString: `
+groups:
+- name: example
+  rules:
+    - alert: InstanceDown
+      expr: up == 0
+      for: 5m
+  series_limit: 100
+      `,
+			shouldPass: true,
 		},
 	}
 

--- a/model/rulefmt/testdata/invalid_alerts_limit.yaml
+++ b/model/rulefmt/testdata/invalid_alerts_limit.yaml
@@ -1,0 +1,8 @@
+groups:
+- name: example
+  rules:
+  - alert: InstanceDown
+    expr: up == 0
+    for: 5m
+  limit: 10
+  alert_limit: 100

--- a/model/rulefmt/testdata/invalid_series_limit.yaml
+++ b/model/rulefmt/testdata/invalid_series_limit.yaml
@@ -1,0 +1,8 @@
+groups:
+- name: example
+  rules:
+    - alert: InstanceDown
+      expr: up == 0
+      for: 5m
+  limit: 10
+  series_limit: 100

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -333,6 +333,8 @@ func (m *Manager) LoadGroups(
 				File:              fn,
 				Interval:          itv,
 				Limit:             rg.Limit,
+				SeriesLimit:       rg.SeriesLimit,
+				AlertLimit:        rg.AlertLimit,
 				Rules:             rules,
 				ShouldRestore:     shouldRestore,
 				Opts:              m.opts,


### PR DESCRIPTION
This PR attempts to define rule group parameters for series and alert limits so that individual limits can be applied to recording and alerting rules respectively. 

Alert managers typically suffer when too many alerts are emitted. Rule groups can have a mix of both recording and alerting rules and it is beneficial to end users to be able to define each limit separately. 

This PR takes the global limit as-is if neither is defined. If either alert or series limits are defined, then they are honored first.

Ex:

```
groups:
- name: example
  rules:
  - alert: InstanceDown
    expr: count(prometheus_http_requests_total) by (handler) > 0
    for: 1m
    labels:
      severity: page
    annotations:
      summary: "Instance {{ $labels.instance }} down"
      description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes."
  alert_limit: 1
```