### PR TITLE
TSDB: Don't rely on integer overflow in head compaction check

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1966,6 +1966,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		// Should be set to init values if no WAL or blocks exist so far.
 		require.Equal(t, int64(math.MaxInt64), db.head.MinTime())
 		require.Equal(t, int64(math.MinInt64), db.head.MaxTime())
+		require.False(t, db.head.initialized())
 
 		// First added sample initializes the writable range.
 		ctx := context.Background()
@@ -1975,6 +1976,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 
 		require.Equal(t, int64(1000), db.head.MinTime())
 		require.Equal(t, int64(1000), db.head.MaxTime())
+		require.True(t, db.head.initialized())
 	})
 	t.Run("wal-only", func(t *testing.T) {
 		dir := t.TempDir()
@@ -2003,6 +2005,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 
 		require.Equal(t, int64(5000), db.head.MinTime())
 		require.Equal(t, int64(15000), db.head.MaxTime())
+		require.True(t, db.head.initialized())
 	})
 	t.Run("existing-block", func(t *testing.T) {
 		dir := t.TempDir()
@@ -2015,6 +2018,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 
 		require.Equal(t, int64(2000), db.head.MinTime())
 		require.Equal(t, int64(2000), db.head.MaxTime())
+		require.True(t, db.head.initialized())
 	})
 	t.Run("existing-block-and-wal", func(t *testing.T) {
 		dir := t.TempDir()
@@ -2047,6 +2051,7 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 
 		require.Equal(t, int64(6000), db.head.MinTime())
 		require.Equal(t, int64(15000), db.head.MaxTime())
+		require.True(t, db.head.initialized())
 		// Check that old series has been GCed.
 		require.Equal(t, 1.0, prom_testutil.ToFloat64(db.head.metrics.series))
 	})

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1074,7 +1074,7 @@ func (h *Head) SetMinValidTime(minValidTime int64) {
 
 // Truncate removes old data before mint from the head and WAL.
 func (h *Head) Truncate(mint int64) (err error) {
-	initialized := h.isInitialized()
+	initialized := h.initialized()
 	if err := h.truncateMemory(mint); err != nil {
 		return err
 	}
@@ -1100,7 +1100,7 @@ func (h *Head) truncateMemory(mint int64) (err error) {
 		}
 	}()
 
-	initialized := h.isInitialized()
+	initialized := h.initialized()
 
 	if h.MinTime() >= mint && initialized {
 		return nil
@@ -1615,16 +1615,16 @@ func (h *Head) MaxOOOTime() int64 {
 	return h.maxOOOTime.Load()
 }
 
-// isInitialized returns true if the head has a MinTime and MaxTime set, false otherwise.
-func (h *Head) isInitialized() bool {
-	return h.MinTime() != math.MaxInt64 && h.MaxTime() != math.MinInt64
+// initialized returns true if the head has a MinTime set, false otherwise.
+func (h *Head) initialized() bool {
+	return h.MinTime() != math.MaxInt64
 }
 
 // compactable returns whether the head has a compactable range.
 // The head has a compactable range when the head time range is 1.5 times the chunk range.
 // The 0.5 acts as a buffer of the appendable window.
 func (h *Head) compactable() bool {
-	if !h.isInitialized() {
+	if !h.initialized() {
 		return false
 	}
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1074,11 +1074,11 @@ func (h *Head) SetMinValidTime(minValidTime int64) {
 
 // Truncate removes old data before mint from the head and WAL.
 func (h *Head) Truncate(mint int64) (err error) {
-	initialize := h.MinTime() == math.MaxInt64
+	uninitialized := h.isUninitialized()
 	if err := h.truncateMemory(mint); err != nil {
 		return err
 	}
-	if initialize {
+	if uninitialized {
 		return nil
 	}
 	return h.truncateWAL(mint)
@@ -1100,9 +1100,9 @@ func (h *Head) truncateMemory(mint int64) (err error) {
 		}
 	}()
 
-	initialize := h.MinTime() == math.MaxInt64
+	uninitialized := h.isUninitialized()
 
-	if h.MinTime() >= mint && !initialize {
+	if h.MinTime() >= mint && !uninitialized {
 		return nil
 	}
 
@@ -1113,7 +1113,7 @@ func (h *Head) truncateMemory(mint int64) (err error) {
 	defer h.memTruncationInProcess.Store(false)
 
 	// We wait for pending queries to end that overlap with this truncation.
-	if !initialize {
+	if !uninitialized {
 		h.WaitForPendingReadersInTimeRange(h.MinTime(), mint)
 	}
 
@@ -1127,7 +1127,7 @@ func (h *Head) truncateMemory(mint int64) (err error) {
 
 	// This was an initial call to Truncate after loading blocks on startup.
 	// We haven't read back the WAL yet, so do not attempt to truncate it.
-	if initialize {
+	if uninitialized {
 		return nil
 	}
 
@@ -1615,10 +1615,19 @@ func (h *Head) MaxOOOTime() int64 {
 	return h.maxOOOTime.Load()
 }
 
+// isUninitialized returns true if the head does not yet have a MinTime or MaxTime set, false otherwise.
+func (h *Head) isUninitialized() bool {
+	return h.MinTime() == math.MaxInt64 || h.MaxTime() == math.MinInt64
+}
+
 // compactable returns whether the head has a compactable range.
 // The head has a compactable range when the head time range is 1.5 times the chunk range.
 // The 0.5 acts as a buffer of the appendable window.
 func (h *Head) compactable() bool {
+	if h.isUninitialized() {
+		return false
+	}
+
 	return h.MaxTime()-h.MinTime() > h.chunkRange.Load()/2*3
 }
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -138,7 +138,7 @@ func (h *Head) Appender(_ context.Context) storage.Appender {
 
 	// The head cache might not have a starting point yet. The init appender
 	// picks up the first appended timestamp as the base.
-	if h.MinTime() == math.MaxInt64 {
+	if h.isUninitialized() {
 		return &initAppender{
 			head: h,
 		}
@@ -191,7 +191,7 @@ func (h *Head) appendableMinValidTime() int64 {
 // AppendableMinValidTime returns the minimum valid time for samples to be appended to the Head.
 // Returns false if Head hasn't been initialized yet and the minimum time isn't known yet.
 func (h *Head) AppendableMinValidTime() (int64, bool) {
-	if h.MinTime() == math.MaxInt64 {
+	if h.isUninitialized() {
 		return 0, false
 	}
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -138,7 +138,7 @@ func (h *Head) Appender(_ context.Context) storage.Appender {
 
 	// The head cache might not have a starting point yet. The init appender
 	// picks up the first appended timestamp as the base.
-	if h.isUninitialized() {
+	if !h.isInitialized() {
 		return &initAppender{
 			head: h,
 		}
@@ -191,7 +191,7 @@ func (h *Head) appendableMinValidTime() int64 {
 // AppendableMinValidTime returns the minimum valid time for samples to be appended to the Head.
 // Returns false if Head hasn't been initialized yet and the minimum time isn't known yet.
 func (h *Head) AppendableMinValidTime() (int64, bool) {
-	if h.isUninitialized() {
+	if !h.isInitialized() {
 		return 0, false
 	}
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -138,7 +138,7 @@ func (h *Head) Appender(_ context.Context) storage.Appender {
 
 	// The head cache might not have a starting point yet. The init appender
 	// picks up the first appended timestamp as the base.
-	if !h.isInitialized() {
+	if !h.initialized() {
 		return &initAppender{
 			head: h,
 		}
@@ -191,7 +191,7 @@ func (h *Head) appendableMinValidTime() int64 {
 // AppendableMinValidTime returns the minimum valid time for samples to be appended to the Head.
 // Returns false if Head hasn't been initialized yet and the minimum time isn't known yet.
 func (h *Head) AppendableMinValidTime() (int64, bool) {
-	if !h.isInitialized() {
+	if !h.initialized() {
 		return 0, false
 	}
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3066,22 +3066,6 @@ func TestHeadExemplars(t *testing.T) {
 	require.NoError(t, head.Close())
 }
 
-func TestHeadMinMaxTimeNotSet(t *testing.T) {
-	head, _ := newTestHead(t, 1000, wlog.CompressionNone, false)
-	defer func() {
-		require.NoError(t, head.Close())
-	}()
-
-	require.False(t, head.isInitialized())
-
-	app := head.Appender(context.Background())
-	_, err := app.Append(0, labels.FromStrings("a", "b"), 100, 100)
-	require.NoError(t, err)
-	require.NoError(t, app.Commit())
-
-	require.True(t, head.isInitialized())
-}
-
 func BenchmarkHeadLabelValuesWithMatchers(b *testing.B) {
 	chunkRange := int64(2000)
 	head, _ := newTestHead(b, chunkRange, wlog.CompressionNone, false)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3066,6 +3066,22 @@ func TestHeadExemplars(t *testing.T) {
 	require.NoError(t, head.Close())
 }
 
+func TestHeadMinMaxTimeNotSet(t *testing.T) {
+	head, _ := newTestHead(t, 1000, wlog.CompressionNone, false)
+	defer func() {
+		require.NoError(t, head.Close())
+	}()
+
+	require.True(t, head.isUninitialized())
+
+	app := head.Appender(context.Background())
+	_, err := app.Append(0, labels.FromStrings("a", "b"), 100, 100)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	require.False(t, head.isUninitialized())
+}
+
 func BenchmarkHeadLabelValuesWithMatchers(b *testing.B) {
 	chunkRange := int64(2000)
 	head, _ := newTestHead(b, chunkRange, wlog.CompressionNone, false)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -5820,11 +5820,11 @@ func TestHeadAppender_AppendCTZeroSample(t *testing.T) {
 	}
 }
 
-func TestHeadCompactableDoesNotRequireOverflow(t *testing.T) {
-	// Set a chunk range of 1 to ensure that Head.compactable() doesn't require
-	// the default min (math.MaxInt64) and max (math.MinInt64) timestamps for the
-	// head before any samples are added to overflow to return correct results.
-	// See https://github.com/prometheus/prometheus/pull/13755
+func TestHeadCompactableDoesNotCompactEmptyHead(t *testing.T) {
+	// Use a chunk range of 1 here so that if we attempted to determine if the head
+	// was compactable using default values for min and max times, `Head.compactable()`
+	// would return true which is incorrect. This test verifies that we short-circuit
+	// the check when the head has not yet had any samples added.
 	head, _ := newTestHead(t, 1, wlog.CompressionNone, false)
 	defer func() {
 		require.NoError(t, head.Close())

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -5819,3 +5819,16 @@ func TestHeadAppender_AppendCTZeroSample(t *testing.T) {
 		require.Equal(t, chunkenc.ValNone, it.Next())
 	}
 }
+
+func TestHeadCompactableDoesNotRequireOverflow(t *testing.T) {
+	// Set a chunk range of 1 to ensure that Head.compactable() doesn't require
+	// the default min (math.MaxInt64) and max (math.MinInt64) timestamps for the
+	// head before any samples are added to overflow to return correct results.
+	// See https://github.com/prometheus/prometheus/pull/13755
+	head, _ := newTestHead(t, 1, wlog.CompressionNone, false)
+	defer func() {
+		require.NoError(t, head.Close())
+	}()
+
+	require.False(t, head.compactable())
+}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3072,14 +3072,14 @@ func TestHeadMinMaxTimeNotSet(t *testing.T) {
 		require.NoError(t, head.Close())
 	}()
 
-	require.True(t, head.isUninitialized())
+	require.False(t, head.isInitialized())
 
 	app := head.Appender(context.Background())
 	_, err := app.Append(0, labels.FromStrings("a", "b"), 100, 100)
 	require.NoError(t, err)
 	require.NoError(t, app.Commit())
 
-	require.False(t, head.isUninitialized())
+	require.True(t, head.isInitialized())
 }
 
 func BenchmarkHeadLabelValuesWithMatchers(b *testing.B) {


### PR DESCRIPTION
Don't rely on integer overflow for correct behavior in the `Head.compactable()` check.

Previously, the logic for determining if the head should be compacted relied on the default values for min and max time and integer overflow when they were checked in `Head.compactable()`. The check in `Head.compactable()` effectively did `math.MinInt64 - math.MaxInt64` which overflowed and wrapped to `1`. Since `1` is less than `1.5` times the chunk range, compaction did not happen. This was the correct behavior but relying on overflow wrapping is surprising.

This change adds a method for checking if the min time for the head is unset and uses it to short-circuit compaction in that case. It also replaces several explicit checks for the default value to determine if the head has not yet had any samples added.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
