### PR TITLE
add context cancellation check at get series result iteration

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -883,7 +883,7 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 
 	for set.Next() {
 		if err := ctx.Err(); err != nil {
-			return apiFuncResult{nil, contextErr(err), warnings, closer}
+			return apiFuncResult{nil, returnAPIError(err), warnings, closer}
 		}
 		metrics = append(metrics, set.At().Labels())
 
@@ -897,17 +897,6 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 	}
 
 	return apiFuncResult{metrics, nil, warnings, closer}
-}
-
-func contextErr(err error) *apiError {
-	switch {
-	case errors.Is(err, context.Canceled):
-		return &apiError{errorCanceled, err}
-	case errors.Is(err, context.DeadlineExceeded):
-		return &apiError{errorTimeout, err}
-	default:
-		return &apiError{errorExec, err}
-	}
 }
 
 func (api *API) dropSeries(_ *http.Request) apiFuncResult {

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -883,7 +883,7 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 
 	for set.Next() {
 		if err := ctx.Err(); err != nil {
-			return apiFuncResult{nil, contextErr(err), nil, nil}
+			return apiFuncResult{nil, contextErr(err), warnings, closer}
 		}
 		metrics = append(metrics, set.At().Labels())
 

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -3568,6 +3568,9 @@ func TestReturnAPIError(t *testing.T) {
 		}, {
 			err:      errors.New("exec error"),
 			expected: errorExec,
+		}, {
+			err:      context.Canceled,
+			expected: errorCanceled,
 		},
 	}
 


### PR DESCRIPTION
For series api when the response is big, we found out that it still will be iterating over the result SeriesSet even if query already timed out and context was cancelled.

This PR will add context check while iterating on the SeriesSet. There was similar context check changes [here](https://github.com/prometheus/prometheus/pull/13437) 