### PR TITLE
Don't run container readme publishing workflow on forks

### DIFF
--- a/.github/workflows/container_description.yml
+++ b/.github/workflows/container_description.yml
@@ -14,7 +14,7 @@ jobs:
   PushDockerHubReadme:
     runs-on: ubuntu-latest
     name: Push README to Docker Hub
-    if: github.repository == 'prometheus/prometheus'
+    if: github.repository_owner == 'prometheus' || github.repository_owner == 'prometheus-community' # Don't run this workflow on forks.
     steps:
       - name: git checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -34,7 +34,7 @@ jobs:
   PushQuayIoReadme:
     runs-on: ubuntu-latest
     name: Push README to quay.io
-    if: github.repository == 'prometheus/prometheus'
+    if: github.repository_owner == 'prometheus' || github.repository_owner == 'prometheus-community' # Don't run this workflow on forks.
     steps:
       - name: git checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/container_description.yml
+++ b/.github/workflows/container_description.yml
@@ -14,6 +14,7 @@ jobs:
   PushDockerHubReadme:
     runs-on: ubuntu-latest
     name: Push README to Docker Hub
+    if: github.repository == 'prometheus/prometheus'
     steps:
       - name: git checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -33,6 +34,7 @@ jobs:
   PushQuayIoReadme:
     runs-on: ubuntu-latest
     name: Push README to quay.io
+    if: github.repository == 'prometheus/prometheus'
     steps:
       - name: git checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
https://github.com/prometheus/prometheus/pull/13752 introduced a workflow to automatically publish the readme to Docker Hub and Quay.io.

However, the workflow is configured to run on all repositories, including forks. This is not necessary and will fail for forks as it requires access to secrets only available in the `prometheus/prometheus` repo.