### PR TITLE
Publish v2.51.0-rc.1+dedupelabels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,28 +47,6 @@ jobs:
       - run: make build
       - run: make test GO_ONLY=1
 
-  test_ui:
-    name: UI tests
-    runs-on: ubuntu-latest
-    # Whenever the Go version is updated here, .promu.yml
-    # should also be updated.
-    container:
-      image: quay.io/prometheus/golang-builder:1.22-base
-
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: prometheus/promci@3cb0c3871f223bd5ce1226995bd52ffb314798b6 # v0.1.0
-      - uses: ./.github/promci/actions/setup_environment
-        with:
-          enable_go: false
-          enable_npm: true
-      - run: make assets-tarball
-      - run: make ui-lint
-      - run: make ui-test
-      - uses: ./.github/promci/actions/save_artifacts
-        with:
-          directory: .tarballs
-
   test_windows:
     name: Go tests on Windows
     runs-on: windows-latest
@@ -171,7 +149,7 @@ jobs:
   publish_main:
     name: Publish main branch artifacts
     runs-on: ubuntu-latest
-    needs: [test_ui, test_go, test_windows, golangci, codeql, build_all]
+    needs: [test_go, test_windows, golangci, codeql, build_all]
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -185,7 +163,7 @@ jobs:
   publish_release:
     name: Publish release artefacts
     runs-on: ubuntu-latest
-    needs: [test_ui, test_go, test_windows, golangci, codeql, build_all]
+    needs: [test_go, test_windows, golangci, codeql, build_all]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.')
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -197,39 +175,3 @@ jobs:
           quay_io_login: ${{ secrets.quay_io_login }}
           quay_io_password: ${{ secrets.quay_io_password }}
           github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}
-  publish_ui_release:
-    name: Publish UI on npm Registry
-    runs-on: ubuntu-latest
-    needs: [test_ui, codeql]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: prometheus/promci@3cb0c3871f223bd5ce1226995bd52ffb314798b6 # v0.1.0
-      - name: Install nodejs
-        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
-        with:
-          node-version-file: "web/ui/.nvmrc"
-          registry-url: "https://registry.npmjs.org"
-      - uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Check libraries version
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.')
-        run: ./scripts/ui_release.sh --check-package "$(echo ${{ github.ref_name }}|sed s/v2/v0/)"
-      - name: build
-        run: make assets
-      - name: Copy files before publishing libs
-        run: ./scripts/ui_release.sh --copy
-      - name: Publish dry-run libraries
-        if: "!(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))"
-        run: ./scripts/ui_release.sh --publish dry-run
-      - name: Publish libraries
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.')
-        run: ./scripts/ui_release.sh --publish
-        env:
-          # The setup-node action writes an .npmrc file with this env variable
-          # as the placeholder for the auth token
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.promu.yml
+++ b/.promu.yml
@@ -14,10 +14,10 @@ build:
         all:
             - netgo
             - builtinassets
-            - stringlabels
+            - dedupelabels
         windows:
             - builtinassets
-            - stringlabels
+            - dedupelabels
     ldflags: |
         -X github.com/prometheus/common/version.Version={{.Version}}
         -X github.com/prometheus/common/version.Revision={{.Revision}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.51.0-rc.1+dedupelabels / 2024-03-14
+
+Special release candidate build that incorporates performance improvements using
+the `dedupelabels` Go tag. The new labels data structure deduplicates label names
+and values via symbol or intern tables, reducing memory usage.
+
 ## 2.51.0-rc.0 / 2024-03-07
 
 This version is built with Go 1.22.1.

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.51.0-rc.0
+2.51.0-rc.0+dedupelabels


### PR DESCRIPTION
This is a parallel release that will push its own docker tags so users can try the experimental memory reduction.

Modeled after #12148 
