### PR TITLE
[BUGFIX] tsdb/wlog.Checkpoint: Fix counting of histogram samples in stats.

### DIFF
--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -224,8 +224,8 @@ func Checkpoint(logger log.Logger, w *WL, from, to int, keep func(id chunks.Head
 			if len(repl) > 0 {
 				buf = enc.HistogramSamples(repl, buf)
 			}
-			stats.TotalSamples += len(samples)
-			stats.DroppedSamples += len(samples) - len(repl)
+			stats.TotalSamples += len(histogramSamples)
+			stats.DroppedSamples += len(histogramSamples) - len(repl)
 
 		case record.Tombstones:
 			tstones, err = dec.Tombstones(rec, tstones)


### PR DESCRIPTION
I realized that histogram samples are wrongly counted in `tsdb/wlog.Checkpoint`, in that float samples are counted against `stats.TotalSamples` and `stats.DroppedSamples` respectively instead.

This PR rectifies the bug, and augments `TestCheckpoint` to verify that `stats.TotalSamples` and `stats.DroppedSamples` are correctly updated.

That said, I don't think any callers of `Checkpoint` use the `stats` return value. Should it be dropped?