### PR TITLE
Add container_description.yml to force sync list

### DIFF
--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -144,7 +144,7 @@ process_repo() {
     if [[ -z "${target_file}" ]]; then
       echo "${target_filename} doesn't exist in ${org_repo}"
       case "${source_file}" in
-        CODE_OF_CONDUCT.md | SECURITY.md)
+        CODE_OF_CONDUCT.md | SECURITY.md | .github/workflows/container_description.yml)
           echo "${source_file} missing in ${org_repo}, force updating."
           needs_update+=("${source_file}")
           ;;


### PR DESCRIPTION
Since we skip repos that don't have a Dockerfile, we can force sync the `.github/workflows/container_description.yml` config.
