### PR TITLE
promtool: Buffer piped unit test rule input to a tempfile

### DIFF
--- a/docs/configuration/unit_testing_rules.md
+++ b/docs/configuration/unit_testing_rules.md
@@ -265,3 +265,29 @@ groups:
         summary: "Instance {{ $labels.instance }} down"
         description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes."
 ```
+
+### Unit testing rules from other sources
+
+Since Prometheus 2.52 it is possible to use a special file such as `/dev/stdin`
+in `rule_files`. This can be used to test rules which originate from templating
+systems or are otherwise not present as raw rules in files.
+
+For example in test.yaml:
+
+```
+rule_files:
+  - /dev/stdin
+
+tests:
+[...]
+```
+
+Then run:
+
+```
+$ yq .spec rules-k8s-manifest.yaml | ./promtool test rules tesr.yaml
+```
+
+(Where yq is the [yq YAML processor tool](https://mikefarah.gitbook.io/yq) and
+rules-k8s-manifest.yaml is a file of rules formatted as a PrometheusRule CRD
+for [prometheus-operator](https://prometheus-operator.dev/)).


### PR DESCRIPTION
Fixes #13785.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
