### PR TITLE
tsdb.BeyondTimeRetention: Fix comment and test at retention duration

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1608,7 +1608,7 @@ func BeyondTimeRetention(db *DB, blocks []*Block) (deletable map[ulid.ULID]struc
 
 	deletable = make(map[ulid.ULID]struct{})
 	for i, block := range blocks {
-		// The difference between the first block and this block is larger than
+		// The difference between the first block and this block is greater than or equal to
 		// the retention period so any blocks after that are added as deletable.
 		if i > 0 && blocks[0].Meta().MaxTime-block.Meta().MaxTime >= db.opts.RetentionDuration {
 			for _, b := range blocks[i:] {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -689,10 +689,10 @@ func TestDB_BeyondTimeRetention(t *testing.T) {
 		require.NoError(t, db.Close())
 	}()
 
-	// We have 4 blocks, 3 of which are beyond the retention duration.
+	// We have 4 blocks, 3 of which are beyond or at the retention duration.
 	metas := []BlockMeta{
 		{MinTime: 300, MaxTime: 500},
-		{MinTime: 200, MaxTime: 300},
+		{MinTime: 200, MaxTime: 400},
 		{MinTime: 100, MaxTime: 200},
 		{MinTime: 0, MaxTime: 100},
 	}


### PR DESCRIPTION
I noticed that the comment in `tsdb.BeyondTimeRetention` regarding which blocks to delete is out of date since #9633. I'm proposing to make it reflect that blocks with max time difference, versus the first block, greater than _or equal to_ the retention duration are deleted.

I also propose to make the test `TestTimeRetention` contain also a test case for when a block is exactly at the retention duration (which is what #9633 changes). Currently that particular case is untested. On suggestion from @machine424, remove `TestDB_BeyondTimeRetention` since it overlaps with `TestTimeRetention`.

cc @darshanime 