### PR TITLE
[BUGFIX] Promtool: Improve error reporting; avoid using testify for user rule tests

### DIFF
--- a/promql/test_test.go
+++ b/promql/test_test.go
@@ -110,7 +110,7 @@ func TestLazyLoader_WithSamplesTill(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		suite, err := NewLazyLoader(t, c.loadString, LazyLoaderOpts{})
+		suite, err := NewLazyLoader(c.loadString, LazyLoaderOpts{})
 		require.NoError(t, err)
 		defer suite.Close()
 


### PR DESCRIPTION
Using testify outside of unit tests results in panics rather than a useful error for the user.

Fixes #13703

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
