### PR TITLE
promql: extend test scripting language to support range queries

### DIFF
--- a/promql/test.go
+++ b/promql/test.go
@@ -564,7 +564,7 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 
 		}
 
-		for hash, _ := range ev.expected {
+		for hash := range ev.expected {
 			if !seen[hash] {
 				return fmt.Errorf("expected metric %s not found", ev.metrics[hash])
 			}

--- a/promql/test.go
+++ b/promql/test.go
@@ -757,9 +757,9 @@ func (t *test) exec(tc testCommand, engine QueryEngine) error {
 func (t *test) execEval(cmd *evalCmd, engine QueryEngine) error {
 	if cmd.isRange {
 		return t.execRangeEval(cmd, engine)
-	} else {
-		return t.execInstantEval(cmd, engine)
 	}
+
+	return t.execInstantEval(cmd, engine)
 }
 
 func (t *test) execRangeEval(cmd *evalCmd, engine QueryEngine) error {

--- a/promql/test.go
+++ b/promql/test.go
@@ -535,18 +535,18 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 			}
 
 			if len(expectedFloats) != len(s.Floats) || len(expectedHistograms) != len(s.Histograms) {
-				return fmt.Errorf("expected %v float points and %v histogram points for %s, but got %v float points %v and %v histogram points %v", len(expectedFloats), len(expectedHistograms), ev.metrics[hash], len(s.Floats), s.Floats, len(s.Histograms), s.Histograms)
+				return fmt.Errorf("expected %v float points and %v histogram points for %s, but got %s", len(expectedFloats), len(expectedHistograms), ev.metrics[hash], formatSeriesResult(s))
 			}
 
 			for i, expected := range expectedFloats {
 				actual := s.Floats[i]
 
 				if expected.T != actual.T {
-					return fmt.Errorf("expected float value at index %v for %s to have timestamp %v, but it had timestamp %v in result with %v float points %v and %v histogram points %v", i, ev.metrics[hash], expected.T, actual.T, len(s.Floats), s.Floats, len(s.Histograms), s.Histograms)
+					return fmt.Errorf("expected float value at index %v for %s to have timestamp %v, but it had timestamp %v (result has %s)", i, ev.metrics[hash], expected.T, actual.T, formatSeriesResult(s))
 				}
 
 				if !almostEqual(actual.F, expected.F, defaultEpsilon) {
-					return fmt.Errorf("expected float value at index %v (t=%v) for %s to be %v, but got %v in result with %v float points %v and %v histogram points %v", i, actual.T, ev.metrics[hash], expected.F, actual.F, len(s.Floats), s.Floats, len(s.Histograms), s.Histograms)
+					return fmt.Errorf("expected float value at index %v (t=%v) for %s to be %v, but got %v (result has %s)", i, actual.T, ev.metrics[hash], expected.F, actual.F, formatSeriesResult(s))
 				}
 			}
 
@@ -554,11 +554,11 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 				actual := s.Histograms[i]
 
 				if expected.T != actual.T {
-					return fmt.Errorf("expected histogram value at index %v for %s to have timestamp %v, but it had timestamp %v in result with %v float points %v and %v histogram points %v", i, ev.metrics[hash], expected.T, actual.T, len(s.Floats), s.Floats, len(s.Histograms), s.Histograms)
+					return fmt.Errorf("expected histogram value at index %v for %s to have timestamp %v, but it had timestamp %v (result has %s)", i, ev.metrics[hash], expected.T, actual.T, formatSeriesResult(s))
 				}
 
 				if !actual.H.Equals(expected.H) {
-					return fmt.Errorf("expected histogram value at index %v (t=%v) for %s to be %v, but got %v in result with %v float points %v and %v histogram points %v", i, actual.T, ev.metrics[hash], expected.H, actual.H, len(s.Floats), s.Floats, len(s.Histograms), s.Histograms)
+					return fmt.Errorf("expected histogram value at index %v (t=%v) for %s to be %v, but got %v (result has %s)", i, actual.T, ev.metrics[hash], expected.H, actual.H, formatSeriesResult(s))
 				}
 			}
 
@@ -630,20 +630,19 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 	return nil
 }
 
-func formatFloatAndHistogramPoints(floats []FPoint, histograms []HPoint) string {
-	if len(histograms) == 0 && len(floats) == 0 {
-		return "[]"
+func formatSeriesResult(s Series) string {
+	floatPlural := "s"
+	histogramPlural := "s"
+
+	if len(s.Floats) == 1 {
+		floatPlural = ""
 	}
 
-	if len(histograms) != 0 && len(floats) != 0 {
-		return fmt.Sprintf("floats: %v, histograms: %v", floats, histograms)
+	if len(s.Histograms) == 1 {
+		histogramPlural = ""
 	}
 
-	if len(histograms) != 0 {
-		return fmt.Sprintf("%v", histograms)
-	}
-
-	return fmt.Sprintf("%v", floats)
+	return fmt.Sprintf("%v float point%s %v and %v histogram point%s %v", len(s.Floats), floatPlural, s.Floats, len(s.Histograms), histogramPlural, s.Histograms)
 }
 
 // HistogramTestExpression returns TestExpression() for the given histogram or "" if the histogram is nil.

--- a/promql/test.go
+++ b/promql/test.go
@@ -72,7 +72,7 @@ func LoadedStorage(t testutil.T, input string) *teststorage.TestStorage {
 }
 
 // RunBuiltinTests runs an acceptance test suite against the provided engine.
-func RunBuiltinTests(t *testing.T, engine engineQuerier) {
+func RunBuiltinTests(t *testing.T, engine QueryEngine) {
 	t.Cleanup(func() { parser.EnableExperimentalFunctions = false })
 	parser.EnableExperimentalFunctions = true
 
@@ -89,11 +89,11 @@ func RunBuiltinTests(t *testing.T, engine engineQuerier) {
 }
 
 // RunTest parses and runs the test against the provided engine.
-func RunTest(t testutil.T, input string, engine engineQuerier) {
+func RunTest(t testutil.T, input string, engine QueryEngine) {
 	require.NoError(t, runTest(t, input, engine))
 }
 
-func runTest(t testutil.T, input string, engine engineQuerier) error {
+func runTest(t testutil.T, input string, engine QueryEngine) error {
 	test, err := newTest(t, input)
 	if err != nil {
 		return err
@@ -146,11 +146,6 @@ func newTest(t testutil.T, input string) (*test, error) {
 
 //go:embed testdata
 var testsFs embed.FS
-
-type engineQuerier interface {
-	NewRangeQuery(ctx context.Context, q storage.Queryable, opts QueryOpts, qs string, start, end time.Time, interval time.Duration) (Query, error)
-	NewInstantQuery(ctx context.Context, q storage.Queryable, opts QueryOpts, qs string, ts time.Time) (Query, error)
-}
 
 func raise(line int, format string, v ...interface{}) error {
 	return &parser.ParseErr{
@@ -571,7 +566,7 @@ func atModifierTestCases(exprStr string, evalTime time.Time) ([]atModifierTestCa
 }
 
 // exec processes a single step of the test.
-func (t *test) exec(tc testCommand, engine engineQuerier) error {
+func (t *test) exec(tc testCommand, engine QueryEngine) error {
 	switch cmd := tc.(type) {
 	case *clearCmd:
 		t.clear()

--- a/promql/test.go
+++ b/promql/test.go
@@ -587,7 +587,13 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 			}
 			exp0 := exp.vals[0]
 			expH := exp0.Histogram
-			if (expH == nil) != (v.H == nil) || (expH != nil && !expH.Equals(v.H)) {
+			if expH == nil && v.H != nil {
+				return fmt.Errorf("expected float value %v for %s but got histogram %s", exp0, v.Metric, HistogramTestExpression(v.H))
+			}
+			if expH != nil && v.H == nil {
+				return fmt.Errorf("expected histogram %s for %s but got float value %v", HistogramTestExpression(expH), v.Metric, v.F)
+			}
+			if expH != nil && !expH.Equals(v.H) {
 				return fmt.Errorf("expected %v for %s but got %s", HistogramTestExpression(expH), v.Metric, HistogramTestExpression(v.H))
 			}
 			if !almostEqual(exp0.Value, v.F, defaultEpsilon) {

--- a/promql/test.go
+++ b/promql/test.go
@@ -90,8 +90,14 @@ func RunBuiltinTests(t *testing.T, engine engineQuerier) {
 
 // RunTest parses and runs the test against the provided engine.
 func RunTest(t testutil.T, input string, engine engineQuerier) {
+	require.NoError(t, runTest(t, input, engine))
+}
+
+func runTest(t testutil.T, input string, engine engineQuerier) error {
 	test, err := newTest(t, input)
-	require.NoError(t, err)
+	if err != nil {
+		return err
+	}
 
 	defer func() {
 		if test.storage != nil {
@@ -103,10 +109,14 @@ func RunTest(t testutil.T, input string, engine engineQuerier) {
 	}()
 
 	for _, cmd := range test.cmds {
-		// TODO(fabxc): aggregate command errors, yield diffs for result
-		// comparison errors.
-		require.NoError(t, test.exec(cmd, engine))
+		if err := test.exec(cmd, engine); err != nil {
+			// TODO(fabxc): aggregate command errors, yield diffs for result
+			// comparison errors.
+			return err
+		}
 	}
+
+	return nil
 }
 
 // test is a sequence of read and write commands that are run

--- a/promql/test.go
+++ b/promql/test.go
@@ -564,13 +564,9 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 
 		}
 
-		for hash, expVals := range ev.expected {
+		for hash, _ := range ev.expected {
 			if !seen[hash] {
-				fmt.Println("matrix result", len(val), ev.expr)
-				for _, ss := range val {
-					fmt.Println("    ", ss.Metric, ss.Floats)
-				}
-				return fmt.Errorf("expected metric %s with %v not found", ev.metrics[hash], expVals)
+				return fmt.Errorf("expected metric %s not found", ev.metrics[hash])
 			}
 		}
 

--- a/promql/test.go
+++ b/promql/test.go
@@ -278,6 +278,8 @@ func (t *test) parseEval(lines []string, i int) (int, *evalCmd, error) {
 
 	switch mod {
 	case "ordered":
+		// Ordered results are not supported for range queries, but the regex for range query commands does not allow
+		// asserting an ordered result, so we don't need to do any error checking here.
 		cmd.ordered = true
 	case "fail":
 		cmd.fail = true

--- a/promql/test_test.go
+++ b/promql/test_test.go
@@ -359,7 +359,7 @@ eval range from 0 to 10m step 5m sum by (group) (http_requests)
 	{group="canary"} 0 70 140
 	{group="test"} 0 100 200
 `,
-			expectedError: `error in eval sum by (group) (http_requests) (line 8): expected metric {group="test"} with 3: [0.000000 100.000000 200.000000] not found`,
+			expectedError: `error in eval sum by (group) (http_requests) (line 8): expected metric {group="test"} not found`,
 		},
 		"range query expected to fail, and query fails": {
 			input: `

--- a/promql/test_test.go
+++ b/promql/test_test.go
@@ -295,7 +295,7 @@ eval range from 0 to 10m step 5m sum by (group) (http_requests)
 	{group="production"} 0 30 60
 	{group="canary"} 0 80 140
 `,
-			expectedError: `error in eval sum by (group) (http_requests) (line 8): expected float value at index 1 (t=300000) for {group="canary"} to be 80, but got 70 in result with 3 float points [0 @[0] 70 @[300000] 140 @[600000]] and 0 histogram points []`,
+			expectedError: `error in eval sum by (group) (http_requests) (line 8): expected float value at index 1 (t=300000) for {group="canary"} to be 80, but got 70 (result has 3 float points [0 @[0] 70 @[300000] 140 @[600000]] and 0 histogram points [])`,
 		},
 		"range query with expected histogram values": {
 			input: `
@@ -314,7 +314,7 @@ load 5m
 eval range from 0 to 10m step 5m testmetric
 	testmetric {{schema:-1 sum:4 count:1 buckets:[1] offset:1}} {{schema:-1 sum:7 count:1 buckets:[1] offset:1}} {{schema:-1 sum:8 count:1 buckets:[1] offset:1}}
 `,
-			expectedError: `error in eval testmetric (line 5): expected histogram value at index 1 (t=300000) for {__name__="testmetric"} to be {count:1, sum:7, (1,4]:1}, but got {count:1, sum:5, (1,4]:1} in result with 0 float points [] and 3 histogram points [{count:1, sum:4, (1,4]:1} @[0] {count:1, sum:5, (1,4]:1} @[300000] {count:1, sum:6, (1,4]:1} @[600000]]`,
+			expectedError: `error in eval testmetric (line 5): expected histogram value at index 1 (t=300000) for {__name__="testmetric"} to be {count:1, sum:7, (1,4]:1}, but got {count:1, sum:5, (1,4]:1} (result has 0 float points [] and 3 histogram points [{count:1, sum:4, (1,4]:1} @[0] {count:1, sum:5, (1,4]:1} @[300000] {count:1, sum:6, (1,4]:1} @[600000]])`,
 		},
 		"range query with too many points for query time range": {
 			input: testData + `
@@ -332,7 +332,7 @@ load 5m
 eval range from 0 to 6m step 6m testmetric
 	testmetric 5 10
 `,
-			expectedError: `error in eval testmetric (line 5): expected 2 float points and 0 histogram points for {__name__="testmetric"}, but got 1 float points [5 @[0]] and 0 histogram points []`,
+			expectedError: `error in eval testmetric (line 5): expected 2 float points and 0 histogram points for {__name__="testmetric"}, but got 1 float point [5 @[0]] and 0 histogram points []`,
 		},
 		"range query with extra point in result": {
 			input: testData + `
@@ -432,7 +432,7 @@ load 5m
 eval range from 0 to 5m step 5m testmetric
 	testmetric {{}} 3
 `,
-			expectedError: `error in eval testmetric (line 5): expected float value at index 0 for {__name__="testmetric"} to have timestamp 300000, but it had timestamp 0 in result with 1 float points [3 @[0]] and 1 histogram points [{count:0, sum:0} @[300000]]`,
+			expectedError: `error in eval testmetric (line 5): expected float value at index 0 for {__name__="testmetric"} to have timestamp 300000, but it had timestamp 0 (result has 1 float point [3 @[0]] and 1 histogram point [{count:0, sum:0} @[300000]])`,
 		},
 	}
 

--- a/promql/test_test.go
+++ b/promql/test_test.go
@@ -281,7 +281,10 @@ eval_ordered instant at 50m sort(http_requests)
 `,
 			expectedError: `error in eval sort(http_requests) (line 8): unexpected metric {__name__="http_requests", group="canary", instance="1", job="api-server"} in result`,
 		},
-
+		"instant query with invalid timestamp": {
+			input:         `eval instant at abc123 vector(0)`,
+			expectedError: `error in eval vector(0) (line 1): invalid timestamp definition "abc123": not a valid duration string: "abc123"`,
+		},
 		"range query with expected result": {
 			input: testData + `
 eval range from 0 to 10m step 5m sum by (group) (http_requests)


### PR DESCRIPTION
This PR extends the PromQL test scripting language to support range queries in addition to the existing support for instant queries.

It also:
* adds tests for the language, including for instant queries
* improves the error messages returned in some cases (eg. when an invalid duration value is given as timestamp for an instant query, it'll now include more context about which eval command is problematic)

This was previously discussed on the CNCF Slack [here](https://cloud-native.slack.com/archives/C01AUBA4PFE/p1710480869547059).