### PR TITLE
[ENHANCEMENT] TSDB: Log more statistics during startup

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -822,7 +822,7 @@ func (h *Head) Init(minValidTime int64) error {
 		"checkpoint_replay_duration", checkpointReplayDuration.String(),
 		"wal_replay_duration", walReplayDuration.String(),
 		"wbl_replay_duration", wblReplayDuration.String(),
-		"chunk_snapshot_replay_duration", chunkSnapshotLoadDuration.String(),
+		"chunk_snapshot_load_duration", chunkSnapshotLoadDuration.String(),
 		"mmap_chunk_replay_duration", mmapChunkReplayDuration.String(),
 		"total_replay_duration", totalReplayDuration.String(),
 	)


### PR DESCRIPTION
…l replay duration

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

It would be useful to log chunk snapshot load duration and mmap chunk replay duration together with `total_replay_duration` log line so that it is easier to understand the WAL replay duration breakdown.

Previously the two fields are also logged but in separate log lines, which is hard to search and correlate with a specific WAL replay run.