### PR TITLE
[ENHANCEMENT] Optimize regexps with multiple prefixes

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -787,13 +787,16 @@ func (m *equalMultiStringSliceMatcher) Matches(s string) bool {
 	return false
 }
 
-// equalMultiStringMapMatcher matches a string exactly against a map of valid values.
+// equalMultiStringMapMatcher matches a string exactly against a map of valid values
+// or against a set of prefix matchers.
 type equalMultiStringMapMatcher struct {
 	// values contains values to match a string against. If the matching is case insensitive,
 	// the values here must be lowercase.
-	values   map[string]struct{}
+	values map[string]struct{}
+	// prefixes maps strings, all of length minPrefixLen, to sets of matchers to check the rest of the string.
+	// If the matching is case insensitive, prefixes are all lowercase.
 	prefixes map[string][]*literalPrefixStringMatcher
-
+	// minPrefixLen can be zero, meaning there are no prefix matchers.
 	minPrefixLen  int
 	caseSensitive bool
 }
@@ -807,6 +810,9 @@ func (m *equalMultiStringMapMatcher) add(s string) {
 }
 
 func (m *equalMultiStringMapMatcher) addPrefix(p *literalPrefixStringMatcher) {
+	if m.minPrefixLen == 0 {
+		panic("addPrefix called when no prefix length defined")
+	}
 	s := p.prefix[:m.minPrefixLen]
 	if !m.caseSensitive {
 		s = strings.ToLower(s)

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -940,7 +940,7 @@ func (m trueMatcher) Matches(_ string) bool {
 
 // optimizeEqualOrPrefixStringMatchers optimize a specific case where all matchers are made by an
 // alternation (orStringMatcher) of strings checked for equality (equalStringMatcher) or
-// with a literal prefix (literalPrefixStringMatcher).
+// with a literal prefix (literalPrefixSensitiveStringMatcher or literalPrefixInsensitiveStringMatcher).
 //
 // In this specific case, when we have many strings to match against we can use a map instead
 // of iterating over the list of strings.
@@ -988,7 +988,7 @@ func optimizeEqualOrPrefixStringMatchers(input StringMatcher, threshold int) Str
 		return input
 	}
 
-	// If the number of values found is less than the threshold, then we should skip the optimization.
+	// If the number of values and prefixes found is less than the threshold, then we should skip the optimization.
 	if (numValues + numPrefixes) < threshold {
 		return input
 	}
@@ -1012,10 +1012,10 @@ func optimizeEqualOrPrefixStringMatchers(input StringMatcher, threshold int) Str
 }
 
 // findEqualOrPrefixStringMatchers analyze the input StringMatcher and calls the equalMatcherCallback for each
-// equalStringMatcher found, and prefixMatcherCallback for each literalPrefixStringMatcher found.
+// equalStringMatcher found, and prefixMatcherCallback for each literalPrefixSensitiveStringMatcher and literalPrefixInsensitiveStringMatcher found.
 //
 // Returns true if and only if the input StringMatcher is *only* composed by an alternation of equalStringMatcher and/or
-// literalPrefixStringMatcher. Returns false if prefixMatcherCallback is nil and a literalPrefixStringMatcher is encountered.
+// literal prefix matcher. Returns false if prefixMatcherCallback is nil and a literal prefix matcher is encountered.
 func findEqualOrPrefixStringMatchers(input StringMatcher, equalMatcherCallback func(matcher *equalStringMatcher) bool, prefixMatcherCallback func(prefix string, prefixCaseSensitive bool, matcher StringMatcher) bool) bool {
 	orInput, ok := input.(orStringMatcher)
 	if !ok {

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -29,7 +29,7 @@ const (
 	maxSetMatches = 256
 
 	// The minimum number of alternate values a regex should have to trigger
-	// the optimization done by optimizeEqualStringMatchers() and so use a map
+	// the optimization done by optimizeEqualOrPrefixStringMatchers() and so use a map
 	// to match values instead of iterating over a list. This value has
 	// been computed running BenchmarkOptimizeEqualStringMatchers.
 	minEqualMultiStringMatcherMapThreshold = 16
@@ -413,7 +413,7 @@ func stringMatcherFromRegexp(re *syntax.Regexp) StringMatcher {
 	clearBeginEndText(re)
 
 	m := stringMatcherFromRegexpInternal(re)
-	m = optimizeEqualStringMatchers(m, minEqualMultiStringMatcherMapThreshold)
+	m = optimizeEqualOrPrefixStringMatchers(m, minEqualMultiStringMatcherMapThreshold)
 
 	return m
 }
@@ -762,7 +762,7 @@ func (m *equalMultiStringSliceMatcher) add(s string) {
 	m.values = append(m.values, s)
 }
 
-func (m *equalMultiStringSliceMatcher) addPrefix(p *literalPrefixStringMatcher) {
+func (m *equalMultiStringSliceMatcher) addPrefix(_ *literalPrefixStringMatcher) {
 	panic("not implemented")
 }
 
@@ -813,6 +813,13 @@ func (m *equalMultiStringMapMatcher) addPrefix(p *literalPrefixStringMatcher) {
 	if m.minPrefixLen == 0 {
 		panic("addPrefix called when no prefix length defined")
 	}
+	if len(p.prefix) < m.minPrefixLen {
+		panic("addPrefix called with a too short prefix")
+	}
+	if m.caseSensitive != p.prefixCaseSensitive {
+		panic("addPrefix called with a prefix whose case sensitivity is different than the expected one")
+	}
+
 	s := p.prefix[:m.minPrefixLen]
 	if !m.caseSensitive {
 		s = strings.ToLower(s)
@@ -931,11 +938,13 @@ func (m trueMatcher) Matches(_ string) bool {
 	return true
 }
 
-// optimizeEqualStringMatchers optimize a specific case where all matchers are made by an
-// alternation (orStringMatcher) of strings checked for equality (equalStringMatcher). In
-// this specific case, when we have many strings to match against we can use a map instead
+// optimizeEqualOrPrefixStringMatchers optimize a specific case where all matchers are made by an
+// alternation (orStringMatcher) of strings checked for equality (equalStringMatcher) or
+// with a literal prefix (literalPrefixStringMatcher).
+//
+// In this specific case, when we have many strings to match against we can use a map instead
 // of iterating over the list of strings.
-func optimizeEqualStringMatchers(input StringMatcher, threshold int) StringMatcher {
+func optimizeEqualOrPrefixStringMatchers(input StringMatcher, threshold int) StringMatcher {
 	var (
 		caseSensitive    bool
 		caseSensitiveSet bool
@@ -946,7 +955,7 @@ func optimizeEqualStringMatchers(input StringMatcher, threshold int) StringMatch
 
 	// Analyse the input StringMatcher to count the number of occurrences
 	// and ensure all of them have the same case sensitivity.
-	analyseCallback := func(matcher *equalStringMatcher) bool {
+	analyseEqualMatcherCallback := func(matcher *equalStringMatcher) bool {
 		// Ensure we don't have mixed case sensitivity.
 		if caseSensitiveSet && caseSensitive != matcher.caseSensitive {
 			return false
@@ -958,7 +967,8 @@ func optimizeEqualStringMatchers(input StringMatcher, threshold int) StringMatch
 		numValues++
 		return true
 	}
-	prefixCallback := func(matcher *literalPrefixStringMatcher) bool {
+
+	analysePrefixMatcherCallback := func(matcher *literalPrefixStringMatcher) bool {
 		// Ensure we don't have mixed case sensitivity.
 		if caseSensitiveSet && caseSensitive != matcher.prefixCaseSensitive {
 			return false
@@ -974,7 +984,7 @@ func optimizeEqualStringMatchers(input StringMatcher, threshold int) StringMatch
 		return true
 	}
 
-	if !findEqualStringMatchers(input, analyseCallback, prefixCallback) {
+	if !findEqualOrPrefixStringMatchers(input, analyseEqualMatcherCallback, analysePrefixMatcherCallback) {
 		return input
 	}
 
@@ -990,7 +1000,7 @@ func optimizeEqualStringMatchers(input StringMatcher, threshold int) StringMatch
 
 	// Ignore the return value because we already iterated over the input StringMatcher
 	// and it was all good.
-	findEqualStringMatchers(input, func(matcher *equalStringMatcher) bool {
+	findEqualOrPrefixStringMatchers(input, func(matcher *equalStringMatcher) bool {
 		multiMatcher.add(matcher.s)
 		return true
 	}, func(matcher *literalPrefixStringMatcher) bool {
@@ -1001,10 +1011,12 @@ func optimizeEqualStringMatchers(input StringMatcher, threshold int) StringMatch
 	return multiMatcher
 }
 
-// findEqualStringMatchers analyze the input StringMatcher and calls the callback for each
-// equalStringMatcher found. Returns true if and only if the input StringMatcher is *only*
-// composed by an alternation of equalStringMatcher.
-func findEqualStringMatchers(input StringMatcher, callback func(matcher *equalStringMatcher) bool, prefixCallback func(matcher *literalPrefixStringMatcher) bool) bool {
+// findEqualOrPrefixStringMatchers analyze the input StringMatcher and calls the equalMatcherCallback for each
+// equalStringMatcher found, and prefixMatcherCallback for each literalPrefixStringMatcher found.
+//
+// Returns true if and only if the input StringMatcher is *only* composed by an alternation of equalStringMatcher and/or
+// literalPrefixStringMatcher. Returns false if prefixMatcherCallback is nil and a literalPrefixStringMatcher is encountered.
+func findEqualOrPrefixStringMatchers(input StringMatcher, equalMatcherCallback func(matcher *equalStringMatcher) bool, prefixMatcherCallback func(matcher *literalPrefixStringMatcher) bool) bool {
 	orInput, ok := input.(orStringMatcher)
 	if !ok {
 		return false
@@ -1013,22 +1025,22 @@ func findEqualStringMatchers(input StringMatcher, callback func(matcher *equalSt
 	for _, m := range orInput {
 		switch casted := m.(type) {
 		case orStringMatcher:
-			if !findEqualStringMatchers(m, callback, prefixCallback) {
+			if !findEqualOrPrefixStringMatchers(m, equalMatcherCallback, prefixMatcherCallback) {
 				return false
 			}
 
 		case *equalStringMatcher:
-			if !callback(casted) {
+			if !equalMatcherCallback(casted) {
 				return false
 			}
 
 		case *literalPrefixStringMatcher:
-			if prefixCallback == nil || !prefixCallback(casted) {
+			if prefixMatcherCallback == nil || !prefixMatcherCallback(casted) {
 				return false
 			}
 
 		default:
-			// It's not an equal string matcher, so we have to stop searching
+			// It's not an equal or prefix string matcher, so we have to stop searching
 			// cause this optimization can't be applied.
 			return false
 		}

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -14,7 +14,6 @@
 package labels
 
 import (
-	"math"
 	"slices"
 	"strings"
 	"unicode"
@@ -950,7 +949,7 @@ func optimizeEqualOrPrefixStringMatchers(input StringMatcher, threshold int) Str
 		caseSensitiveSet bool
 		numValues        int
 		numPrefixes      int
-		minPrefixLength  = math.MaxInt
+		minPrefixLength  int
 	)
 
 	// Analyse the input StringMatcher to count the number of occurrences
@@ -976,7 +975,7 @@ func optimizeEqualOrPrefixStringMatchers(input StringMatcher, threshold int) Str
 			caseSensitive = prefixCaseSensitive
 			caseSensitiveSet = true
 		}
-		if len(prefix) < minPrefixLength {
+		if numPrefixes == 0 || len(prefix) < minPrefixLength {
 			minPrefixLength = len(prefix)
 		}
 

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -811,7 +811,7 @@ func TestNewEqualMultiStringMatcher(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values))
+			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), 0, 0)
 			for _, v := range testData.values {
 				matcher.add(v)
 			}
@@ -864,7 +864,7 @@ func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values))
+			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), 0, 0)
 			for _, v := range testData.values {
 				matcher.add(v)
 			}
@@ -890,7 +890,7 @@ func TestFindEqualStringMatchers(t *testing.T) {
 		ok = findEqualStringMatchers(input, func(matcher *equalStringMatcher) bool {
 			matches = append(matches, match{matcher.s, matcher.caseSensitive})
 			return true
-		})
+		}, nil)
 		return
 	}
 
@@ -1204,10 +1204,16 @@ func visitStringMatcher(matcher StringMatcher, callback func(matcher StringMatch
 		}
 
 	// No nested matchers for the following ones.
+	case *equalMultiStringMapMatcher:
+		for _, prefixes := range casted.prefixes {
+			for _, matcher := range prefixes {
+				visitStringMatcher(matcher, callback)
+			}
+		}
+
 	case emptyStringMatcher:
 	case *equalStringMatcher:
 	case *equalMultiStringSliceMatcher:
-	case *equalMultiStringMapMatcher:
 	case anyStringWithoutNewlineMatcher:
 	case *anyNonEmptyStringMatcher:
 	case trueMatcher:

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -71,6 +71,8 @@ var (
 		// A long case insensitive alternation.
 		"(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKMimS|IecrXtPa|seTckYqt|NxnyHkgB|fIDlOgKb|UhlWIygH|OtNoJxHG|cUTkFVIV|mTgFIHjr|jQkoIDtE|PPMKxRXl|AwMfwVkQ|CQyMrTQJ|BzrqxVSi|nTpcWuhF|PertdywG|ZZDgCtXN|WWdDPyyE|uVtNQsKk|BdeCHvPZ|wshRnFlH|aOUIitIp|RxZeCdXT|CFZMslCj|AVBZRDxl|IzIGCnhw|ythYuWiz|oztXVXhl|VbLkwqQx|qvaUgyVC|VawUjPWC|ecloYJuj|boCLTdSU|uPrKeAZx|hrMWLWBq|JOnUNHRM|rYnujkPq|dDEdZhIj|DRrfvugG|yEGfDxVV|YMYdJWuP|PHUQZNWM|AmKNrLis|zTxndVfn|FPsHoJnc|EIulZTua|KlAPhdzg|ScHJJCLt|NtTfMzME|eMCwuFdo|SEpJVJbR|cdhXZeCx|sAVtBwRh|kVFEVcMI|jzJrxraA|tGLHTell|NNWoeSaw|DcOKSetX|UXZAJyka|THpMphDP|rizheevl|kDCBRidd|pCZZRqyu|pSygkitl|SwZGkAaW|wILOrfNX|QkwVOerj|kHOMxPDr|EwOVycJv|AJvtzQFS|yEOjKYYB|LizIINLL|JBRSsfcG|YPiUqqNl|IsdEbvee|MjEpGcBm|OxXZVgEQ|xClXGuxa|UzRCGFEb|buJbvfvA|IPZQxRet|oFYShsMc|oBHffuHO|bzzKrcBR|KAjzrGCl|IPUsAVls|OGMUMbIU|gyDccHuR|bjlalnDd|ZLWjeMna|fdsuIlxQ|dVXtiomV|XxedTjNg|XWMHlNoA|nnyqArQX|opfkWGhb|wYtnhdYb))",
 		"(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BBBBBBBBBBBBBBBBBBBBBBBB|cccccccccccccccccccccccC|ſſſſſſſſſſſſſſſſſſſſſſſſS|SSSSSSSSSSSSSSSSSSSSSSSSſ))",
+		// A short case insensitive alternation where each entry ends with ".*".
+		"(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuSoAl.*))",
 		// A long case insensitive alternation where each entry ends with ".*".
 		"(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuSoAl.*|qbvKMimS.*|IecrXtPa.*|seTckYqt.*|NxnyHkgB.*|fIDlOgKb.*|UhlWIygH.*|OtNoJxHG.*|cUTkFVIV.*|mTgFIHjr.*|jQkoIDtE.*|PPMKxRXl.*|AwMfwVkQ.*|CQyMrTQJ.*|BzrqxVSi.*|nTpcWuhF.*|PertdywG.*|ZZDgCtXN.*|WWdDPyyE.*|uVtNQsKk.*|BdeCHvPZ.*|wshRnFlH.*|aOUIitIp.*|RxZeCdXT.*|CFZMslCj.*|AVBZRDxl.*|IzIGCnhw.*|ythYuWiz.*|oztXVXhl.*|VbLkwqQx.*|qvaUgyVC.*|VawUjPWC.*|ecloYJuj.*|boCLTdSU.*|uPrKeAZx.*|hrMWLWBq.*|JOnUNHRM.*|rYnujkPq.*|dDEdZhIj.*|DRrfvugG.*|yEGfDxVV.*|YMYdJWuP.*|PHUQZNWM.*|AmKNrLis.*|zTxndVfn.*|FPsHoJnc.*|EIulZTua.*|KlAPhdzg.*|ScHJJCLt.*|NtTfMzME.*|eMCwuFdo.*|SEpJVJbR.*|cdhXZeCx.*|sAVtBwRh.*|kVFEVcMI.*|jzJrxraA.*|tGLHTell.*|NNWoeSaw.*|DcOKSetX.*|UXZAJyka.*|THpMphDP.*|rizheevl.*|kDCBRidd.*|pCZZRqyu.*|pSygkitl.*|SwZGkAaW.*|wILOrfNX.*|QkwVOerj.*|kHOMxPDr.*|EwOVycJv.*|AJvtzQFS.*|yEOjKYYB.*|LizIINLL.*|JBRSsfcG.*|YPiUqqNl.*|IsdEbvee.*|MjEpGcBm.*|OxXZVgEQ.*|xClXGuxa.*|UzRCGFEb.*|buJbvfvA.*|IPZQxRet.*|oFYShsMc.*|oBHffuHO.*|bzzKrcBR.*|KAjzrGCl.*|IPUsAVls.*|OGMUMbIU.*|gyDccHuR.*|bjlalnDd.*|ZLWjeMna.*|fdsuIlxQ.*|dVXtiomV.*|XxedTjNg.*|XWMHlNoA.*|nnyqArQX.*|opfkWGhb.*|wYtnhdYb.*))",
 		// A long case insensitive alternation where each entry starts with ".*".
@@ -686,7 +688,15 @@ func randStrings(randGenerator *rand.Rand, many, length int) []string {
 	return out
 }
 
-func TestOptimizeEqualStringMatchers(t *testing.T) {
+func randStringsWithSuffix(randGenerator *rand.Rand, many, length int, suffix string) []string {
+	out := randStrings(randGenerator, many, length)
+	for i := range out {
+		out[i] += suffix
+	}
+	return out
+}
+
+func TestOptimizeEqualOrPrefixStringMatchers(t *testing.T) {
 	tests := map[string]struct {
 		input                 StringMatcher
 		expectedValues        []string
@@ -767,7 +777,7 @@ func TestOptimizeEqualStringMatchers(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			actualMatcher := optimizeEqualStringMatchers(testData.input, 0)
+			actualMatcher := optimizeEqualOrPrefixStringMatchers(testData.input, 0)
 
 			if testData.expectedValues == nil {
 				require.IsType(t, testData.input, actualMatcher)
@@ -782,10 +792,12 @@ func TestOptimizeEqualStringMatchers(t *testing.T) {
 
 func TestNewEqualMultiStringMatcher(t *testing.T) {
 	tests := map[string]struct {
-		values             []string
-		caseSensitive      bool
-		expectedValuesMap  map[string]struct{}
-		expectedValuesList []string
+		values              []string
+		prefixes            []*literalPrefixStringMatcher
+		caseSensitive       bool
+		expectedValuesMap   map[string]struct{}
+		expectedPrefixesMap map[string][]*literalPrefixStringMatcher
+		expectedValuesList  []string
 	}{
 		"few case sensitive values": {
 			values:             []string{"a", "B"},
@@ -797,27 +809,47 @@ func TestNewEqualMultiStringMatcher(t *testing.T) {
 			caseSensitive:      false,
 			expectedValuesList: []string{"a", "B"},
 		},
+		"few case sensitive values and prefixes": {
+			values:              []string{"a"},
+			prefixes:            []*literalPrefixStringMatcher{{prefix: "B", prefixCaseSensitive: true, right: anyStringWithoutNewlineMatcher{}}},
+			caseSensitive:       true,
+			expectedValuesMap:   map[string]struct{}{"a": {}},
+			expectedPrefixesMap: map[string][]*literalPrefixStringMatcher{"B": {{prefix: "B", prefixCaseSensitive: true, right: anyStringWithoutNewlineMatcher{}}}},
+		},
 		"many case sensitive values": {
-			values:            []string{"a", "B", "c", "D", "e", "F", "g", "H", "i", "L", "m", "N", "o", "P", "q", "r"},
-			caseSensitive:     true,
-			expectedValuesMap: map[string]struct{}{"a": {}, "B": {}, "c": {}, "D": {}, "e": {}, "F": {}, "g": {}, "H": {}, "i": {}, "L": {}, "m": {}, "N": {}, "o": {}, "P": {}, "q": {}, "r": {}},
+			values:              []string{"a", "B", "c", "D", "e", "F", "g", "H", "i", "L", "m", "N", "o", "P", "q", "r"},
+			caseSensitive:       true,
+			expectedValuesMap:   map[string]struct{}{"a": {}, "B": {}, "c": {}, "D": {}, "e": {}, "F": {}, "g": {}, "H": {}, "i": {}, "L": {}, "m": {}, "N": {}, "o": {}, "P": {}, "q": {}, "r": {}},
+			expectedPrefixesMap: map[string][]*literalPrefixStringMatcher{},
 		},
 		"many case insensitive values": {
-			values:            []string{"a", "B", "c", "D", "e", "F", "g", "H", "i", "L", "m", "N", "o", "P", "q", "r"},
-			caseSensitive:     false,
-			expectedValuesMap: map[string]struct{}{"a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {}, "g": {}, "h": {}, "i": {}, "l": {}, "m": {}, "n": {}, "o": {}, "p": {}, "q": {}, "r": {}},
+			values:              []string{"a", "B", "c", "D", "e", "F", "g", "H", "i", "L", "m", "N", "o", "P", "q", "r"},
+			caseSensitive:       false,
+			expectedValuesMap:   map[string]struct{}{"a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {}, "g": {}, "h": {}, "i": {}, "l": {}, "m": {}, "n": {}, "o": {}, "p": {}, "q": {}, "r": {}},
+			expectedPrefixesMap: map[string][]*literalPrefixStringMatcher{},
 		},
 	}
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), 0, 0)
+			// To keep this test simple, we always assume a min prefix length of 1.
+			minPrefixLength := 0
+			if len(testData.prefixes) > 0 {
+				minPrefixLength = 1
+			}
+
+			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), len(testData.prefixes), minPrefixLength)
 			for _, v := range testData.values {
 				matcher.add(v)
 			}
-			if testData.expectedValuesMap != nil {
+			for _, p := range testData.prefixes {
+				matcher.addPrefix(p)
+			}
+
+			if testData.expectedValuesMap != nil || testData.expectedPrefixesMap != nil {
 				require.IsType(t, &equalMultiStringMapMatcher{}, matcher)
 				require.Equal(t, testData.expectedValuesMap, matcher.(*equalMultiStringMapMatcher).values)
+				require.Equal(t, testData.expectedPrefixesMap, matcher.(*equalMultiStringMapMatcher).prefixes)
 				require.Equal(t, testData.caseSensitive, matcher.(*equalMultiStringMapMatcher).caseSensitive)
 			}
 			if testData.expectedValuesList != nil {
@@ -829,9 +861,34 @@ func TestNewEqualMultiStringMatcher(t *testing.T) {
 	}
 }
 
+func TestEqualMultiStringMapMatcher_addPrefix(t *testing.T) {
+	t.Run("should panic if the matcher is case sensitive but the prefix is not case sensitive", func(t *testing.T) {
+		matcher := newEqualMultiStringMatcher(true, 0, 1, 1)
+
+		require.Panics(t, func() {
+			matcher.addPrefix(&literalPrefixStringMatcher{
+				prefix:              "a",
+				prefixCaseSensitive: false,
+			})
+		})
+	})
+
+	t.Run("should panic if the matcher is not case sensitive but the prefix is case sensitive", func(t *testing.T) {
+		matcher := newEqualMultiStringMatcher(false, 0, 1, 1)
+
+		require.Panics(t, func() {
+			matcher.addPrefix(&literalPrefixStringMatcher{
+				prefix:              "a",
+				prefixCaseSensitive: true,
+			})
+		})
+	})
+}
+
 func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 	tests := map[string]struct {
 		values             []string
+		prefixes           []*literalPrefixStringMatcher
 		caseSensitive      bool
 		expectedMatches    []string
 		expectedNotMatches []string
@@ -848,6 +905,24 @@ func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 			expectedMatches:    []string{"a", "A", "b", "B"},
 			expectedNotMatches: []string{"c", "C"},
 		},
+		"few case sensitive prefixes": {
+			prefixes: []*literalPrefixStringMatcher{
+				{prefix: "a", prefixCaseSensitive: true, right: anyStringWithoutNewlineMatcher{}},
+				{prefix: "B", prefixCaseSensitive: true, right: anyStringWithoutNewlineMatcher{}},
+			},
+			caseSensitive:      true,
+			expectedMatches:    []string{"a", "aX", "B", "BX"},
+			expectedNotMatches: []string{"A", "b"},
+		},
+		"few case insensitive prefixes": {
+			prefixes: []*literalPrefixStringMatcher{
+				{prefix: "a", prefixCaseSensitive: false, right: anyStringWithoutNewlineMatcher{}},
+				{prefix: "B", prefixCaseSensitive: false, right: anyStringWithoutNewlineMatcher{}},
+			},
+			caseSensitive:      false,
+			expectedMatches:    []string{"a", "aX", "A", "AX", "b", "bX", "B", "BX"},
+			expectedNotMatches: []string{"c", "cX", "C", "CX"},
+		},
 		"many case sensitive values": {
 			values:             []string{"a", "B", "c", "D", "e", "F", "g", "H", "i", "L", "m", "N", "o", "P", "q", "r"},
 			caseSensitive:      true,
@@ -860,13 +935,29 @@ func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 			expectedMatches:    []string{"a", "A", "b", "B"},
 			expectedNotMatches: []string{"x", "X"},
 		},
+		"mixed values and prefixes": {
+			values:             []string{"a"},
+			prefixes:           []*literalPrefixStringMatcher{{prefix: "B", prefixCaseSensitive: true, right: anyStringWithoutNewlineMatcher{}}},
+			caseSensitive:      true,
+			expectedMatches:    []string{"a", "B", "BX"},
+			expectedNotMatches: []string{"aX", "A", "b", "bX"},
+		},
 	}
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), 0, 0)
+			// To keep this test simple, we always assume a min prefix length of 1.
+			minPrefixLength := 0
+			if len(testData.prefixes) > 0 {
+				minPrefixLength = 1
+			}
+
+			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), len(testData.prefixes), minPrefixLength)
 			for _, v := range testData.values {
 				matcher.add(v)
+			}
+			for _, p := range testData.prefixes {
+				matcher.addPrefix(p)
 			}
 
 			for _, v := range testData.expectedMatches {
@@ -879,29 +970,33 @@ func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 	}
 }
 
-func TestFindEqualStringMatchers(t *testing.T) {
+func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	type match struct {
 		s             string
 		caseSensitive bool
 	}
 
-	// Utility to call findEqualStringMatchers() and collect all callback invocations.
-	findEqualStringMatchersAndCollectMatches := func(input StringMatcher) (matches []match, ok bool) {
-		ok = findEqualStringMatchers(input, func(matcher *equalStringMatcher) bool {
+	// Utility to call findEqualOrPrefixStringMatchers() and collect all callback invocations.
+	findEqualOrPrefixStringMatchersAndCollectMatches := func(input StringMatcher) (matches []match, ok bool) {
+		ok = findEqualOrPrefixStringMatchers(input, func(matcher *equalStringMatcher) bool {
 			matches = append(matches, match{matcher.s, matcher.caseSensitive})
 			return true
-		}, nil)
+		}, func(matcher *literalPrefixStringMatcher) bool {
+			matches = append(matches, match{matcher.prefix, matcher.prefixCaseSensitive})
+			return true
+		})
+
 		return
 	}
 
 	t.Run("empty matcher", func(t *testing.T) {
-		actualMatches, actualOk := findEqualStringMatchersAndCollectMatches(emptyStringMatcher{})
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(emptyStringMatcher{})
 		require.False(t, actualOk)
 		require.Empty(t, actualMatches)
 	})
 
 	t.Run("concat of literal matchers (case sensitive)", func(t *testing.T) {
-		actualMatches, actualOk := findEqualStringMatchersAndCollectMatches(
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&equalStringMatcher{s: "test-1", caseSensitive: true},
 				&equalStringMatcher{s: "test-2", caseSensitive: true},
@@ -913,7 +1008,7 @@ func TestFindEqualStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal matchers (case insensitive)", func(t *testing.T) {
-		actualMatches, actualOk := findEqualStringMatchersAndCollectMatches(
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&equalStringMatcher{s: "test-1", caseSensitive: false},
 				&equalStringMatcher{s: "test-2", caseSensitive: false},
@@ -925,7 +1020,7 @@ func TestFindEqualStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal matchers (mixed case)", func(t *testing.T) {
-		actualMatches, actualOk := findEqualStringMatchersAndCollectMatches(
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&equalStringMatcher{s: "test-1", caseSensitive: false},
 				&equalStringMatcher{s: "test-2", caseSensitive: true},
@@ -935,11 +1030,59 @@ func TestFindEqualStringMatchers(t *testing.T) {
 		require.True(t, actualOk)
 		require.Equal(t, []match{{"test-1", false}, {"test-2", true}}, actualMatches)
 	})
+
+	t.Run("concat of literal prefix matchers (case sensitive)", func(t *testing.T) {
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
+			orStringMatcher{
+				&literalPrefixStringMatcher{prefix: "test-1", prefixCaseSensitive: true},
+				&literalPrefixStringMatcher{prefix: "test-2", prefixCaseSensitive: true},
+			},
+		)
+
+		require.True(t, actualOk)
+		require.Equal(t, []match{{"test-1", true}, {"test-2", true}}, actualMatches)
+	})
+
+	t.Run("concat of literal prefix matchers (case insensitive)", func(t *testing.T) {
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
+			orStringMatcher{
+				&literalPrefixStringMatcher{prefix: "test-1", prefixCaseSensitive: false},
+				&literalPrefixStringMatcher{prefix: "test-2", prefixCaseSensitive: false},
+			},
+		)
+
+		require.True(t, actualOk)
+		require.Equal(t, []match{{"test-1", false}, {"test-2", false}}, actualMatches)
+	})
+
+	t.Run("concat of literal prefix matchers (mixed case)", func(t *testing.T) {
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
+			orStringMatcher{
+				&literalPrefixStringMatcher{prefix: "test-1", prefixCaseSensitive: false},
+				&literalPrefixStringMatcher{prefix: "test-2", prefixCaseSensitive: true},
+			},
+		)
+
+		require.True(t, actualOk)
+		require.Equal(t, []match{{"test-1", false}, {"test-2", true}}, actualMatches)
+	})
+
+	t.Run("concat of literal string and prefix matchers (case sensitive)", func(t *testing.T) {
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
+			orStringMatcher{
+				&equalStringMatcher{s: "test-1", caseSensitive: true},
+				&literalPrefixStringMatcher{prefix: "test-2", prefixCaseSensitive: true},
+			},
+		)
+
+		require.True(t, actualOk)
+		require.Equal(t, []match{{"test-1", true}, {"test-2", true}}, actualMatches)
+	})
 }
 
 // This benchmark is used to find a good threshold to use to apply the optimization
-// done by optimizeEqualStringMatchers().
-func BenchmarkOptimizeEqualStringMatchers(b *testing.B) {
+// done by optimizeEqualOrPrefixStringMatchers().
+func BenchmarkOptimizeEqualOrPrefixStringMatchers(b *testing.B) {
 	randGenerator := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	// Generate variable lengths random texts to match against.
@@ -949,42 +1092,51 @@ func BenchmarkOptimizeEqualStringMatchers(b *testing.B) {
 
 	for numAlternations := 2; numAlternations <= 256; numAlternations *= 2 {
 		for _, caseSensitive := range []bool{true, false} {
-			b.Run(fmt.Sprintf("alternations: %d case sensitive: %t", numAlternations, caseSensitive), func(b *testing.B) {
-				// Generate a regex with the expected number of alternations.
-				re := strings.Join(randStrings(randGenerator, numAlternations, 10), "|")
-				if !caseSensitive {
-					re = "(?i:(" + re + "))"
-				}
-
-				parsed, err := syntax.Parse(re, syntax.Perl)
-				require.NoError(b, err)
-
-				unoptimized := stringMatcherFromRegexpInternal(parsed)
-				require.IsType(b, orStringMatcher{}, unoptimized)
-
-				optimized := optimizeEqualStringMatchers(unoptimized, 0)
-				if numAlternations < minEqualMultiStringMatcherMapThreshold {
-					require.IsType(b, &equalMultiStringSliceMatcher{}, optimized)
-				} else {
-					require.IsType(b, &equalMultiStringMapMatcher{}, optimized)
-				}
-
-				b.Run("without optimizeEqualStringMatchers()", func(b *testing.B) {
-					for n := 0; n < b.N; n++ {
-						for _, t := range texts {
-							unoptimized.Matches(t)
-						}
+			for _, prefixMatcher := range []bool{true, false} {
+				b.Run(fmt.Sprintf("alternations: %d case sensitive: %t prefix matcher: %t", numAlternations, caseSensitive, prefixMatcher), func(b *testing.B) {
+					// If the test should run on prefix matchers, we add a wildcard matcher as suffix (prefix will be a literal).
+					suffix := ""
+					if prefixMatcher {
+						suffix = ".*"
 					}
-				})
 
-				b.Run("with optimizeEqualStringMatchers()", func(b *testing.B) {
-					for n := 0; n < b.N; n++ {
-						for _, t := range texts {
-							optimized.Matches(t)
-						}
+					// Generate a regex with the expected number of alternations.
+					re := strings.Join(randStringsWithSuffix(randGenerator, numAlternations, 10, suffix), "|")
+					if !caseSensitive {
+						re = "(?i:(" + re + "))"
 					}
+					b.Logf("regexp: %s", re)
+
+					parsed, err := syntax.Parse(re, syntax.Perl)
+					require.NoError(b, err)
+
+					unoptimized := stringMatcherFromRegexpInternal(parsed)
+					require.IsType(b, orStringMatcher{}, unoptimized)
+
+					optimized := optimizeEqualOrPrefixStringMatchers(unoptimized, 0)
+					if numAlternations < minEqualMultiStringMatcherMapThreshold && !prefixMatcher {
+						require.IsType(b, &equalMultiStringSliceMatcher{}, optimized)
+					} else {
+						require.IsType(b, &equalMultiStringMapMatcher{}, optimized)
+					}
+
+					b.Run("without optimizeEqualOrPrefixStringMatchers()", func(b *testing.B) {
+						for n := 0; n < b.N; n++ {
+							for _, t := range texts {
+								unoptimized.Matches(t)
+							}
+						}
+					})
+
+					b.Run("with optimizeEqualOrPrefixStringMatchers()", func(b *testing.B) {
+						for n := 0; n < b.N; n++ {
+							for _, t := range texts {
+								optimized.Matches(t)
+							}
+						}
+					})
 				})
-			})
+			}
 		}
 	}
 }


### PR DESCRIPTION
For example `foo.*|bar.*|baz.*`. Instead of checking each one in turn, we build a map of prefixes, then check the smaller set that could match the string supplied.

Benchmarks (updated 2024-07-02):
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
                                                       │  before.txt  │              after.txt               │
                                                       │    sec/op    │    sec/op      vs base               │
FastRegexMatcher/#00-8                                   44.89n ±  4%   43.62n ±   1%   -2.82% (p=0.002 n=6)
FastRegexMatcher/foo-8                                   51.32n ±  3%   51.75n ±   5%        ~ (p=0.193 n=6)
FastRegexMatcher/^foo-8                                  46.49n ±  1%   47.13n ±   2%        ~ (p=0.093 n=6)
FastRegexMatcher/(foo|bar)-8                             55.58n ±  2%   56.74n ±   1%        ~ (p=0.065 n=6)
FastRegexMatcher/foo.*-8                                 94.66n ±  4%   94.98n ±   1%        ~ (p=0.221 n=6)
FastRegexMatcher/.*foo-8                                 113.0n ±  3%   114.1n ±   1%        ~ (p=0.333 n=6)
FastRegexMatcher/^.*foo$-8                               112.3n ±  1%   114.8n ±   5%   +2.23% (p=0.002 n=6)
FastRegexMatcher/^.+foo$-8                               112.6n ±  0%   114.2n ±   0%   +1.51% (p=0.002 n=6)
FastRegexMatcher/.?-8                                    68.52n ±  5%   68.44n ±   1%        ~ (p=1.000 n=6)
FastRegexMatcher/.*-8                                    79.41n ± 10%   80.76n ±   3%        ~ (p=0.394 n=6)
FastRegexMatcher/.+-8                                    82.43n ±  5%   83.16n ±   1%        ~ (p=0.180 n=6)
FastRegexMatcher/foo.+-8                                 93.81n ±  1%   95.14n ±   1%   +1.42% (p=0.004 n=6)
FastRegexMatcher/.+foo-8                                 114.0n ±  4%   114.4n ±   4%        ~ (p=0.420 n=6)
FastRegexMatcher/foo_.+-8                                80.70n ±  2%   81.91n ±   1%   +1.49% (p=0.015 n=6)
FastRegexMatcher/foo_.*-8                                81.61n ±  3%   82.73n ±   3%        ~ (p=0.071 n=6)
FastRegexMatcher/.*foo.*-8                               192.7n ±  2%   199.5n ±   1%   +3.56% (p=0.002 n=6)
FastRegexMatcher/.+foo.+-8                               200.6n ±  2%   204.4n ±   2%        ~ (p=0.084 n=6)
FastRegexMatcher/(?s:.*)-8                               42.90n ±  2%   44.48n ±   1%   +3.68% (p=0.002 n=6)
FastRegexMatcher/(?s:.+)-8                               51.12n ±  5%   52.06n ±   2%        ~ (p=0.065 n=6)
FastRegexMatcher/(?s:^.*foo$)-8                          109.6n ±  0%   109.3n ±   1%        ~ (p=0.372 n=6)
FastRegexMatcher/(?i:foo)-8                              70.81n ±  2%   70.38n ±   2%        ~ (p=0.394 n=6)
FastRegexMatcher/(?i:(foo|bar))-8                        157.2n ±  3%   156.6n ±   6%        ~ (p=0.937 n=6)
FastRegexMatcher/(?i:(foo1|foo2|bar))-8                  283.8n ±  3%   285.7n ±   0%        ~ (p=0.394 n=6)
FastRegexMatcher/^(?i:foo|oo)|(bar)$-8                   710.2n ±  5%   722.5n ±   6%   +1.73% (p=0.041 n=6)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-8      798.0n ±  7%   800.5n ±   4%        ~ (p=0.818 n=6)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-8           485.9n ±  2%   490.7n ±   1%   +0.99% (p=0.002 n=6)
FastRegexMatcher/^$-8                                    42.68n ±  3%   43.17n ±   1%        ~ (p=0.065 n=6)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-8       186.8n ±  4%   187.2n ±   1%        ~ (p=0.190 n=6)
FastRegexMatcher/10\.0\.(1|2)\.+-8                       81.48n ±  1%   81.94n ±   3%        ~ (p=0.240 n=6)
FastRegexMatcher/10\.0\.(1|2).+-8                        80.74n ±  1%   82.16n ±   3%   +1.76% (p=0.002 n=6)
FastRegexMatcher/((fo(bar))|.+foo)-8                     204.9n ±  2%   205.8n ±   2%        ~ (p=0.732 n=6)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-8      203.5n ± 15%   215.4n ±   9%        ~ (p=0.093 n=6)
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-8      204.2n ±  5%   213.8n ±   8%        ~ (p=0.180 n=6)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-8      794.8n ±  3%   803.5n ±   3%        ~ (p=0.240 n=6)
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-8      356.9n ±  2%   357.9n ±   1%        ~ (p=1.000 n=6)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-8      7.481µ ±  1%   7.575µ ±   1%   +1.26% (p=0.004 n=6)
FastRegexMatcher/fo.?-8                                  93.49n ±  2%   95.07n ± 141%   +1.68% (p=0.024 n=6)
FastRegexMatcher/foo.?-8                                 94.03n ±  4%   94.62n ±   3%        ~ (p=0.310 n=6)
FastRegexMatcher/f.?o-8                                  81.32n ±  2%   80.81n ±   2%        ~ (p=0.937 n=6)
FastRegexMatcher/.*foo.?-8                               201.9n ±  2%   200.9n ±   0%   -0.45% (p=0.011 n=6)
FastRegexMatcher/.?foo.+-8                               192.2n ±  3%   189.9n ±   0%   -1.22% (p=0.002 n=6)
FastRegexMatcher/foo.?|bar-8                             147.5n ±  6%   156.1n ±   6%        ~ (p=0.106 n=6)
FastRegexMatcher/ſſs-8                                   51.20n ±  2%   51.90n ±   3%        ~ (p=0.132 n=6)
FastRegexMatcher/.*-.*-.*-.*-.*-8                        195.6n ±  2%   193.6n ±   2%        ~ (p=0.333 n=6)
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-8              194.8n ±  1%   199.1n ±   4%   +2.21% (p=0.004 n=6)
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-8      4.642µ ±  2%   4.616µ ±   1%        ~ (p=0.394 n=6)
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-8      3.750µ ±  0%   3.802µ ±   2%   +1.40% (p=0.004 n=6)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-8   5.638µ ±  1%   1.040µ ±   1%  -81.55% (p=0.002 n=6)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-8      257.6n ±  1%   261.5n ±   3%   +1.49% (p=0.002 n=6)
geomean                                                  172.4n         168.4n          -2.32%
```