### PR TITLE
promql: include more details in error message when creating test query fails or an unexpected series is returned

### DIFF
--- a/promql/test.go
+++ b/promql/test.go
@@ -516,7 +516,7 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 		for _, s := range val {
 			hash := s.Metric.Hash()
 			if _, ok := ev.metrics[hash]; !ok {
-				return fmt.Errorf("unexpected metric %s in result", s.Metric)
+				return fmt.Errorf("unexpected metric %s in result, has %s", s.Metric, formatSeriesResult(s))
 			}
 			seen[hash] = true
 			exp := ev.expected[hash]
@@ -581,7 +581,11 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 		for pos, v := range val {
 			fp := v.Metric.Hash()
 			if _, ok := ev.metrics[fp]; !ok {
-				return fmt.Errorf("unexpected metric %s in result", v.Metric)
+				if v.H != nil {
+					return fmt.Errorf("unexpected metric %s in result, has value %v", v.Metric, v.H)
+				}
+
+				return fmt.Errorf("unexpected metric %s in result, has value %v", v.Metric, v.F)
 			}
 			exp := ev.expected[fp]
 			if ev.ordered && exp.pos != pos+1 {

--- a/promql/test.go
+++ b/promql/test.go
@@ -767,7 +767,7 @@ func (t *test) execEval(cmd *evalCmd, engine QueryEngine) error {
 func (t *test) execRangeEval(cmd *evalCmd, engine QueryEngine) error {
 	q, err := engine.NewRangeQuery(t.context, t.storage, nil, cmd.expr, cmd.start, cmd.end, cmd.step)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating range query for %q (line %d): %w", cmd.expr, cmd.line, err)
 	}
 	res := q.Exec(t.context)
 	if res.Err != nil {
@@ -798,7 +798,7 @@ func (t *test) execInstantEval(cmd *evalCmd, engine QueryEngine) error {
 	for _, iq := range queries {
 		q, err := engine.NewInstantQuery(t.context, t.storage, nil, iq.expr, iq.evalTime)
 		if err != nil {
-			return err
+			return fmt.Errorf("error creating instant query for %q (line %d): %w", cmd.expr, cmd.line, err)
 		}
 		defer q.Close()
 		res := q.Exec(t.context)
@@ -820,7 +820,7 @@ func (t *test) execInstantEval(cmd *evalCmd, engine QueryEngine) error {
 		// by checking against the middle step.
 		q, err = engine.NewRangeQuery(t.context, t.storage, nil, iq.expr, iq.evalTime.Add(-time.Minute), iq.evalTime.Add(time.Minute), time.Minute)
 		if err != nil {
-			return err
+			return fmt.Errorf("error creating range query for %q (line %d): %w", cmd.expr, cmd.line, err)
 		}
 		rangeRes := q.Exec(t.context)
 		if rangeRes.Err != nil {

--- a/promql/test_test.go
+++ b/promql/test_test.go
@@ -224,12 +224,21 @@ eval instant at 0 testmetric
 `,
 			expectedError: `error in eval testmetric (line 5): expected float value 2.000000 for {__name__="testmetric"} but got histogram {{}}`,
 		},
-		"instant query, but result has an unexpected series": {
+		"instant query, but result has an unexpected series with a float value": {
 			input: testData + `
 eval instant at 5m sum by (group) (http_requests)
 	{group="production"} 30
 `,
-			expectedError: `error in eval sum by (group) (http_requests) (line 8): unexpected metric {group="canary"} in result`,
+			expectedError: `error in eval sum by (group) (http_requests) (line 8): unexpected metric {group="canary"} in result, has value 70`,
+		},
+		"instant query, but result has an unexpected series with a histogram value": {
+			input: `
+load 5m
+	testmetric {{}}
+
+eval instant at 5m testmetric
+`,
+			expectedError: `error in eval testmetric (line 5): unexpected metric {__name__="testmetric"} in result, has value {count:0, sum:0}`,
 		},
 		"instant query, but result is missing a series": {
 			input: testData + `
@@ -279,7 +288,7 @@ eval_ordered instant at 50m sort(http_requests)
 	http_requests{group="production", instance="1", job="api-server"} 200
 	http_requests{group="canary", instance="0", job="api-server"} 300
 `,
-			expectedError: `error in eval sort(http_requests) (line 8): unexpected metric {__name__="http_requests", group="canary", instance="1", job="api-server"} in result`,
+			expectedError: `error in eval sort(http_requests) (line 8): unexpected metric {__name__="http_requests", group="canary", instance="1", job="api-server"} in result, has value 400`,
 		},
 		"instant query with invalid timestamp": {
 			input:         `eval instant at abc123 vector(0)`,
@@ -350,7 +359,7 @@ eval range from 0 to 10m step 5m sum by (group) (http_requests)
 eval range from 0 to 10m step 5m sum by (group) (http_requests)
 	{group="production"} 0 30 60
 `,
-			expectedError: `error in eval sum by (group) (http_requests) (line 8): unexpected metric {group="canary"} in result`,
+			expectedError: `error in eval sum by (group) (http_requests) (line 8): unexpected metric {group="canary"} in result, has 3 float points [0 @[0] 70 @[300000] 140 @[600000]] and 0 histogram points []`,
 		},
 		"range query, but result is missing a series": {
 			input: testData + `


### PR DESCRIPTION
This makes it easier to debug test failures.