### PR TITLE
Fix hist std dev var negative

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3499,6 +3499,38 @@ func TestNativeHistogram_HistogramStdDevVar(t *testing.T) {
 			stdVar: 1544.8582535368798, // actual variance: 1738.4082
 		},
 		{
+			name: "-100000, -10000, -1000, -888, -888, -100, -50, -9, -8, -3",
+			h: &histogram.Histogram{
+				Count:     10,
+				ZeroCount: 0,
+				Sum:       -112946,
+				Schema:    0,
+				NegativeSpans: []histogram.Span{
+					{Offset: 2, Length: 3},
+					{Offset: 1, Length: 2},
+					{Offset: 2, Length: 1},
+					{Offset: 3, Length: 1},
+					{Offset: 2, Length: 1},
+				},
+				NegativeBuckets: []int64{1, 0, 0, 0, 0, 2, -2, 0},
+			},
+			stdVar: 1240930974.5260057, // actual variance: 882690990
+		},
+		{
+			name: "-10 x10",
+			h: &histogram.Histogram{
+				Count:     10,
+				ZeroCount: 0,
+				Sum:       -100,
+				Schema:    0,
+				NegativeSpans: []histogram.Span{
+					{Offset: 4, Length: 1},
+				},
+				NegativeBuckets: []int64{10},
+			},
+			stdVar: 454.2741699796952, // actual variance: 0
+		},
+		{
 			name: "-50, -8, 0, 3, 8, 9, 100, NaN",
 			h: &histogram.Histogram{
 				Count:     8,

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3496,7 +3496,7 @@ func TestNativeHistogram_HistogramStdDevVar(t *testing.T) {
 				},
 				NegativeBuckets: []int64{1, 0},
 			},
-			stdVar: 1544.8582535368798, // actual variance: 1738.4082
+			stdVar: 1844.4651144196398, // actual variance: 1738.4082
 		},
 		{
 			name: "-100000, -10000, -1000, -888, -888, -100, -50, -9, -8, -3",
@@ -3514,7 +3514,7 @@ func TestNativeHistogram_HistogramStdDevVar(t *testing.T) {
 				},
 				NegativeBuckets: []int64{1, 0, 0, 0, 0, 2, -2, 0},
 			},
-			stdVar: 1240930974.5260057, // actual variance: 882690990
+			stdVar: 759352122.1939945, // actual variance: 882690990
 		},
 		{
 			name: "-10 x10",
@@ -3528,7 +3528,7 @@ func TestNativeHistogram_HistogramStdDevVar(t *testing.T) {
 				},
 				NegativeBuckets: []int64{10},
 			},
-			stdVar: 454.2741699796952, // actual variance: 0
+			stdVar: 1.725830020304794, // actual variance: 0
 		},
 		{
 			name: "-50, -8, 0, 3, 8, 9, 100, NaN",

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1111,6 +1111,9 @@ func funcHistogramStdDev(vals []parser.Value, args parser.Expressions, enh *Eval
 		it := sample.H.AllBucketIterator()
 		for it.Next() {
 			bucket := it.At()
+			if bucket.Count == 0 {
+				continue
+			}
 			var val float64
 			if bucket.Lower <= 0 && 0 <= bucket.Upper {
 				val = 0
@@ -1147,6 +1150,9 @@ func funcHistogramStdVar(vals []parser.Value, args parser.Expressions, enh *Eval
 		it := sample.H.AllBucketIterator()
 		for it.Next() {
 			bucket := it.At()
+			if bucket.Count == 0 {
+				continue
+			}
 			var val float64
 			if bucket.Lower <= 0 && 0 <= bucket.Upper {
 				val = 0

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1116,6 +1116,9 @@ func funcHistogramStdDev(vals []parser.Value, args parser.Expressions, enh *Eval
 				val = 0
 			} else {
 				val = math.Sqrt(bucket.Upper * bucket.Lower)
+				if bucket.Upper < 0 {
+					val = -val
+				}
 			}
 			delta := val - mean
 			variance, cVariance = kahanSumInc(bucket.Count*delta*delta, variance, cVariance)
@@ -1149,6 +1152,9 @@ func funcHistogramStdVar(vals []parser.Value, args parser.Expressions, enh *Eval
 				val = 0
 			} else {
 				val = math.Sqrt(bucket.Upper * bucket.Lower)
+				if bucket.Upper < 0 {
+					val = -val
+				}
 			}
 			delta := val - mean
 			variance, cVariance = kahanSumInc(bucket.Count*delta*delta, variance, cVariance)


### PR DESCRIPTION
The current behaviour of `histogram_stddev` and `histogram_stdvar` has 2 problems:
1. They don't handle buckets with negative values for both upper and lower bounds properly.
2. They don't handle empty buckets with an infinite bound properly.

For problem 1, the first commit adds unit tests addressing the issue with the values that make it pass. The second commit fixes this problem and updates the expected values in the unit tests to the new values to make it pass, and we can see the new standard variances for the histogram are much closer to the actual population standard variances for the raw numbers as stated in the comments.

As for problem 2, it's not really an issue with the current exponential histograms as we don't have such buckets. But with custom buckets such an issue will easily crop up, so we need this fix in the third commit, and we can see that there is no need to update any tests as they all still pass, meaning the behaviour for exponential histograms should still be the same. (Note that with the new custom buckets, if there are any counts in a bucket with infinite bounds, we won't be able to get a meaningful result, so those who want to use these functions must ensure they define enough custom bounds to cover all observations, e.g. if there are no negative observations they need to start with the 0 bound so the first bucket with counts will have a lower bound of 0 instead of negative infinity, and they need to define their expected max value as the last custom bound so they won't need to use the last bucket with an upper bound of infinity.)