### PR TITLE
Notifier: fix deadlock when zero alerts

### DIFF
--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -471,6 +471,10 @@ func (n *Manager) sendAll(alerts ...*Alert) bool {
 		numSuccess atomic.Uint64
 	)
 	for _, ams := range amSets {
+		if len(ams.ams) == 0 {
+			continue
+		}
+
 		var (
 			payload  []byte
 			err      error
@@ -482,6 +486,7 @@ func (n *Manager) sendAll(alerts ...*Alert) bool {
 		if len(ams.cfg.AlertRelabelConfigs) > 0 {
 			amAlerts = relabelAlerts(ams.cfg.AlertRelabelConfigs, labels.Labels{}, alerts)
 			if len(amAlerts) == 0 {
+				ams.mtx.RUnlock()
 				continue
 			}
 			// We can't use the cached values from previous iteration.


### PR DESCRIPTION
When all alerts were dropped after alert relabeling, the `sendAll()` function didn't release the lock properly which created a deadlock with the Alertmanager target discovery.

In addition, the commit detects early when there are no Alertmanager endpoint to notify to avoid unnecessary work.

@bboreham I've found the bug while playing with the feature. Since it is a 2.51 addition, I made the PR against `release-2.51` branch.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
