### PR TITLE
feat: Implement Created Timestamp ingestion for agent mode

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -49,7 +49,8 @@ var (
 	// NOTE(bwplotka): This can be both an instrumentation failure or commonly expected
 	// behaviour, and we currently don't have a way to determine this. As a result
 	// it's recommended to ignore this error for now.
-	ErrOutOfOrderCT = fmt.Errorf("created timestamp out of order, ignoring")
+	ErrOutOfOrderCT      = fmt.Errorf("created timestamp out of order, ignoring")
+	ErrCTNewerThanSample = fmt.Errorf("CT is newer or the same as sample's timestamp, ignoring")
 )
 
 // SeriesRef is a generic series reference. In prometheus it is either a

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -963,9 +963,53 @@ func (a *appender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Met
 	return 0, nil
 }
 
-func (a *appender) AppendCTZeroSample(storage.SeriesRef, labels.Labels, int64, int64) (storage.SeriesRef, error) {
-	// TODO(bwplotka): Wire metadata in the Agent's appender.
-	return 0, nil
+// AppendCTZeroSample appends synthetic zero sample for ct timestamp. It returns
+// error when sample can't be appended. See
+// storage.CreatedTimestampAppender.AppendCTZeroSample for further documentation.
+func (a *appender) AppendCTZeroSample(ref storage.SeriesRef, l labels.Labels, t, ct int64) (storage.SeriesRef, error) {
+	if ct >= t {
+		return 0, storage.ErrCTNewerThanSample
+	}
+
+	series := a.series.GetByID(chunks.HeadSeriesRef(ref))
+	if series == nil {
+		l = l.WithoutEmpty()
+		if l.IsEmpty() {
+			return 0, fmt.Errorf("empty labelset: %w", tsdb.ErrInvalidSample)
+		}
+
+		if lbl, dup := l.HasDuplicateLabelNames(); dup {
+			return 0, fmt.Errorf(`label name "%s" is not unique: %w`, lbl, tsdb.ErrInvalidSample)
+		}
+
+		var created bool
+		series, created = a.getOrCreate(l)
+		if created {
+			a.pendingSeries = append(a.pendingSeries, record.RefSeries{
+				Ref:    series.ref,
+				Labels: l,
+			})
+
+			a.metrics.numActiveSeries.Inc()
+		}
+	}
+	series.Lock()
+	defer series.Unlock()
+
+	if ct <= series.lastTs {
+		return storage.SeriesRef(series.ref), storage.ErrOutOfOrderCT
+	}
+
+	// NOTE: always modify pendingSamples and sampleSeries together.
+	a.pendingSamples = append(a.pendingSamples, record.RefSample{
+		Ref: series.ref,
+		T:   ct,
+		V:   0,
+	})
+	a.sampleSeries = append(a.sampleSeries, series)
+
+	a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
+	return storage.SeriesRef(series.ref), nil
 }
 
 // Commit submits the collected samples and purges the batch.

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -394,7 +394,7 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 // storage.CreatedTimestampAppender.AppendCTZeroSample for further documentation.
 func (a *headAppender) AppendCTZeroSample(ref storage.SeriesRef, lset labels.Labels, t, ct int64) (storage.SeriesRef, error) {
 	if ct >= t {
-		return 0, fmt.Errorf("CT is newer or the same as sample's timestamp, ignoring")
+		return 0, storage.ErrCTNewerThanSample
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))


### PR DESCRIPTION
Continuing the work from https://github.com/prometheus/proposals/blob/main/proposals/2023-06-13_created-timestamp.md, this PR implements the created timestamp ingestion for Prometheus in agent mode.

The logic is quite similar to what was done with the head appender in https://github.com/prometheus/prometheus/pull/12733, but there's a small difference: the appender's lastTimestamp is only updated during the Commit() phase[[1](https://github.com/prometheus/prometheus/blob/a67266207377f8294dcd4bd3043ecfe6dac4a086/tsdb/agent/db.go#L1040-L1042)], while in the regular head appender it is updated during the append phase[[1](https://github.com/prometheus/prometheus/blob/a67266207377f8294dcd4bd3043ecfe6dac4a086/tsdb/head_append.go#L425-L427)][[2](https://github.com/prometheus/prometheus/blob/a67266207377f8294dcd4bd3043ecfe6dac4a086/tsdb/head_append.go#L379-L381)]. This means that Agent mode depends on Commit() always being called after ingesting a single sample from a particular series, and I'm not sure if this is guaranteed at the moment.

If we still compare this PR to https://github.com/prometheus/prometheus/pull/12733, we can also see a difference in tests. A regular TSDB can be queried, and [that's how we test ingested samples in the original PR](https://github.com/prometheus/prometheus/blob/a67266207377f8294dcd4bd3043ecfe6dac4a086/tsdb/head_test.go#L5806-L5819). Agent mode doesn't implement the Querier interface, and therefore we can't query ingested samples to verify if they exist as expected. The only way I found was to measure the ingested samples counter 😬 