### PR TITLE
Makefile: add .PHONY plugins/plugins.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ tarball: npm_licenses common-tarball
 .PHONY: docker
 docker: npm_licenses common-docker
 
+.PHONY: plugins/plugins.go
 plugins/plugins.go: plugins.yml plugins/generate.go
 	@echo ">> creating plugins list"
 	$(GO) generate -tags plugins ./plugins


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
fix make plugins comand error

The plugins command executes the plugins/plugins. go command, and the plugins/plugins. go file is a real file, which leads to errors

![image](https://github.com/prometheus/prometheus/assets/55082705/ecb4ae3f-c80a-4137-8e8f-29790d881073)
