### PR TITLE
[ENHANCEMENT] TSDB: Improve calculation of space used by labels

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"slices"
 	"strings"
+	"unsafe"
 
 	"github.com/cespare/xxhash/v2"
 )
@@ -487,4 +488,9 @@ func (b *ScratchBuilder) Labels() Labels {
 // Callers must ensure that there are no other references to ls, or any strings fetched from it.
 func (b *ScratchBuilder) Overwrite(ls *Labels) {
 	*ls = append((*ls)[:0], b.add...)
+}
+
+// SizeOfLabels returns the approximate space required for n copies of a label.
+func SizeOfLabels(value string, n uint64) uint64 {
+	return (uint64(len(value)) + uint64(unsafe.Sizeof(value))) * n
 }

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -491,6 +491,6 @@ func (b *ScratchBuilder) Overwrite(ls *Labels) {
 }
 
 // SizeOfLabels returns the approximate space required for n copies of a label.
-func SizeOfLabels(value string, n uint64) uint64 {
-	return (uint64(len(value)) + uint64(unsafe.Sizeof(value))) * n
+func SizeOfLabels(name, value string, n uint64) uint64 {
+	return (uint64(len(name)) + uint64(unsafe.Sizeof(name)) + uint64(len(value)) + uint64(unsafe.Sizeof(value))) * n
 }

--- a/model/labels/labels_dedupelabels.go
+++ b/model/labels/labels_dedupelabels.go
@@ -815,3 +815,8 @@ func (b *ScratchBuilder) Overwrite(ls *Labels) {
 	ls.syms = b.syms.nameTable
 	ls.data = yoloString(b.overwriteBuffer)
 }
+
+// SizeOfLabels returns the approximate space required for n copies of a label.
+func SizeOfLabels(value string, n uint64) uint64 {
+	return uint64(len(value)) + n*2 // Assuming most symbol-table entries are 2 bytes long.
+}

--- a/model/labels/labels_dedupelabels.go
+++ b/model/labels/labels_dedupelabels.go
@@ -817,6 +817,6 @@ func (b *ScratchBuilder) Overwrite(ls *Labels) {
 }
 
 // SizeOfLabels returns the approximate space required for n copies of a label.
-func SizeOfLabels(value string, n uint64) uint64 {
-	return uint64(len(value)) + n*2 // Assuming most symbol-table entries are 2 bytes long.
+func SizeOfLabels(name, value string, n uint64) uint64 {
+	return uint64(len(name)+len(value)) + n*4 // Assuming most symbol-table entries are 2 bytes long.
 }

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -693,6 +693,6 @@ func (b *ScratchBuilder) SetSymbolTable(_ *SymbolTable) {
 }
 
 // SizeOfLabels returns the approximate space required for n copies of a label.
-func SizeOfLabels(value string, n uint64) uint64 {
-	return uint64(len(value)+sizeVarint(uint64(len(value)))) * n
+func SizeOfLabels(name, value string, n uint64) uint64 {
+	return uint64(len(name)+sizeVarint(uint64(len(name)))+len(value)+sizeVarint(uint64(len(value)))) * n
 }

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -694,5 +694,5 @@ func (b *ScratchBuilder) SetSymbolTable(_ *SymbolTable) {
 
 // SizeOfLabels returns the approximate space required for n copies of a label.
 func SizeOfLabels(name, value string, n uint64) uint64 {
-	return uint64(len(name)+sizeVarint(uint64(len(name)))+len(value)+sizeVarint(uint64(len(value)))) * n
+	return uint64(labelSize(&Label{Name: name, Value: value})) * n
 }

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -691,3 +691,8 @@ func NewScratchBuilderWithSymbolTable(_ *SymbolTable, n int) ScratchBuilder {
 func (b *ScratchBuilder) SetSymbolTable(_ *SymbolTable) {
 	// no-op
 }
+
+// SizeOfLabels returns the approximate space required for n copies of a label.
+func SizeOfLabels(value string, n uint64) uint64 {
+	return uint64(len(value)+sizeVarint(uint64(len(value)))) * n
+}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1048,7 +1048,7 @@ func (h *Head) PostingsCardinalityStats(statsByLabelName string, limit int) *ind
 		return h.cardinalityCache
 	}
 	h.cardinalityCacheKey = cacheKey
-	h.cardinalityCache = h.postings.Stats(statsByLabelName, limit)
+	h.cardinalityCache = h.postings.Stats(statsByLabelName, limit, labels.SizeOfLabels)
 	h.lastPostingsStatsCall = time.Duration(time.Now().Unix()) * time.Second
 
 	return h.cardinalityCache

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -164,7 +164,8 @@ type PostingsStats struct {
 }
 
 // Stats calculates the cardinality statistics from postings.
-func (p *MemPostings) Stats(label string, limit int) *PostingsStats {
+// Caller can pass in a function which computes the space required for n series with a given label.
+func (p *MemPostings) Stats(label string, limit int, bytes func(string, uint64) uint64) *PostingsStats {
 	var size uint64
 	p.mtx.RLock()
 
@@ -192,7 +193,7 @@ func (p *MemPostings) Stats(label string, limit int) *PostingsStats {
 			}
 			seriesCnt := uint64(len(values))
 			labelValuePairs.push(Stat{Name: n + "=" + name, Count: seriesCnt})
-			size += uint64(len(name)) * seriesCnt
+			size += bytes(name, seriesCnt)
 		}
 		labelValueLength.push(Stat{Name: n, Count: size})
 	}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -165,7 +165,7 @@ type PostingsStats struct {
 
 // Stats calculates the cardinality statistics from postings.
 // Caller can pass in a function which computes the space required for n series with a given label.
-func (p *MemPostings) Stats(label string, limit int, bytes func(string, uint64) uint64) *PostingsStats {
+func (p *MemPostings) Stats(label string, limit int, labelSizeFunc func(string, string, uint64) uint64) *PostingsStats {
 	var size uint64
 	p.mtx.RLock()
 
@@ -193,7 +193,7 @@ func (p *MemPostings) Stats(label string, limit int, bytes func(string, uint64) 
 			}
 			seriesCnt := uint64(len(values))
 			labelValuePairs.push(Stat{Name: n + "=" + name, Count: seriesCnt})
-			size += bytes(name, seriesCnt)
+			size += labelSizeFunc(n, name, seriesCnt)
 		}
 		labelValueLength.push(Stat{Name: n, Count: size})
 	}

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -939,7 +939,7 @@ func BenchmarkPostings_Stats(b *testing.B) {
 	}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		p.Stats("__name__", 10)
+		p.Stats("__name__", 10, labels.SizeOfLabels)
 	}
 }
 
@@ -954,7 +954,7 @@ func TestMemPostingsStats(t *testing.T) {
 	p.Add(2, labels.FromStrings("label", "value1"))
 
 	// call the Stats method to calculate the cardinality statistics
-	stats := p.Stats("label", 10)
+	stats := p.Stats("label", 10, func(s string, n uint64) uint64 { return uint64(len(s)) * n })
 
 	// assert that the expected statistics were calculated
 	require.Equal(t, uint64(2), stats.CardinalityMetricsStats[0].Count)

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -954,7 +954,7 @@ func TestMemPostingsStats(t *testing.T) {
 	p.Add(2, labels.FromStrings("label", "value1"))
 
 	// call the Stats method to calculate the cardinality statistics
-	stats := p.Stats("label", 10, func(s string, n uint64) uint64 { return uint64(len(s)) * n })
+	stats := p.Stats("label", 10, func(name, value string, n uint64) uint64 { return uint64(len(name)+len(value)) * n })
 
 	// assert that the expected statistics were calculated
 	require.Equal(t, uint64(2), stats.CardinalityMetricsStats[0].Count)
@@ -963,7 +963,7 @@ func TestMemPostingsStats(t *testing.T) {
 	require.Equal(t, uint64(3), stats.CardinalityLabelStats[0].Count)
 	require.Equal(t, "label", stats.CardinalityLabelStats[0].Name)
 
-	require.Equal(t, uint64(24), stats.LabelValueStats[0].Count)
+	require.Equal(t, uint64(44), stats.LabelValueStats[0].Count)
 	require.Equal(t, "label", stats.LabelValueStats[0].Name)
 
 	require.Equal(t, uint64(2), stats.LabelValuePairsStats[0].Count)

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -954,6 +954,7 @@ func TestMemPostingsStats(t *testing.T) {
 	p.Add(2, labels.FromStrings("label", "value1"))
 
 	// call the Stats method to calculate the cardinality statistics
+	// passing a fake calculation so we get the same result regardless of compilation -tags.
 	stats := p.Stats("label", 10, func(name, value string, n uint64) uint64 { return uint64(len(name)+len(value)) * n })
 
 	// assert that the expected statistics were calculated


### PR DESCRIPTION
The labels for each series in the Head take up some some space in the Postings index, but far more space in the `memSeries` structure.

Instead of having the Postings index calculate this overhead, which is a layering violation, have the caller pass in a function to do it.

Provide three implementations of this function for the three Labels versions.
