### PR TITLE
Disallowing configure AM with the v1 api

### DIFF
--- a/cmd/promtool/testdata/config_with_service_discovery_files.yml
+++ b/cmd/promtool/testdata/config_with_service_discovery_files.yml
@@ -6,7 +6,7 @@ scrape_configs:
 alerting:
   alertmanagers:
     - scheme: http
-      api_version: v1
+      api_version: v2
       file_sd_configs:
         - files:
             - nonexistent_file.yml

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1041,11 +1040,6 @@ func (c *AlertmanagerConfig) UnmarshalYAML(unmarshal func(interface{}) error) er
 
 	if httpClientConfigAuthEnabled && c.SigV4Config != nil {
 		return fmt.Errorf("at most one of basic_auth, authorization, oauth2, & sigv4 must be configured")
-	}
-
-	// Disallow config using AM V1 API.
-	if !slices.Contains(SupportedAlertmanagerAPIVersions, c.APIVersion) {
-		return fmt.Errorf("invalid Alertmanager API version '%v', expected one of '%v'", c.APIVersion, SupportedAlertmanagerAPIVersions)
 	}
 
 	// Check for users putting URLs in target groups.

--- a/config/config.go
+++ b/config/config.go
@@ -958,7 +958,7 @@ func (a AlertmanagerConfigs) ToMap() map[string]*AlertmanagerConfig {
 
 // AlertmanagerAPIVersion represents a version of the
 // github.com/prometheus/alertmanager/api, e.g. 'v1' or 'v2'.
-// V1 is current deprecated and no longer supported.
+// 'v1' is no longer supported.
 type AlertmanagerAPIVersion string
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1501,8 +1501,8 @@ var expectedConf = &Config{
 }
 
 func TestYAMLNotLongerSupportedAMApi(t *testing.T) {
-	_, err := LoadFile("testdata/config_with_deprecated_am_api_config.yml", false, false, log.NewNopLogger())
-	require.Error(t, err, "parsing YAML file testdata/config_with_deprecated_am_api_config.yml: expected Alertmanager api version to be one of [v2] but got v1")
+	_, err := LoadFile("testdata/config_with_no_longer_supported_am_api_config.yml", false, false, promslog.NewNopLogger())
+	require.Error(t, err)
 }
 
 func TestYAMLRoundtrip(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1501,7 +1501,7 @@ var expectedConf = &Config{
 }
 
 func TestYAMLNotLongerSupportedAMApi(t *testing.T) {
-	_, err := LoadFile("testdata/config_with_no_longer_supported_am_api_config.yml", false, false, promslog.NewNopLogger())
+	_, err := LoadFile("testdata/config_with_no_longer_supported_am_api_config.yml", false, promslog.NewNopLogger())
 	require.Error(t, err)
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1500,7 +1500,7 @@ var expectedConf = &Config{
 	},
 }
 
-func TestYAMLDeprecatedAMApi(t *testing.T) {
+func TestYAMLNotLongerSupportedAMApi(t *testing.T) {
 	_, err := LoadFile("testdata/config_with_deprecated_am_api_config.yml", false, false, log.NewNopLogger())
 	require.Error(t, err, "parsing YAML file testdata/config_with_deprecated_am_api_config.yml: expected Alertmanager api version to be one of [v2] but got v1")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1500,6 +1500,11 @@ var expectedConf = &Config{
 	},
 }
 
+func TestYAMLDeprecatedAMApi(t *testing.T) {
+	_, err := LoadFile("testdata/config_with_deprecated_am_api_config.yml", false, false, log.NewNopLogger())
+	require.Error(t, err, "parsing YAML file testdata/config_with_deprecated_am_api_config.yml: expected Alertmanager api version to be one of [v2] but got v1")
+}
+
 func TestYAMLRoundtrip(t *testing.T) {
 	want, err := LoadFile("testdata/roundtrip.good.yml", false, false, promslog.NewNopLogger())
 	require.NoError(t, err)

--- a/config/testdata/config_with_deprecated_am_api_config.yml
+++ b/config/testdata/config_with_deprecated_am_api_config.yml
@@ -1,0 +1,7 @@
+alerting:
+  alertmanagers:
+    - scheme: http
+      api_version: v1
+      file_sd_configs:
+        - files:
+            - nonexistent_file.yml

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -542,7 +542,7 @@ func (n *Manager) sendAll(alerts ...*Alert) bool {
 
 	begin := time.Now()
 
-	// v2Payload represent 'alerts' marshaled for Alertmanager API v2.
+	// cachedPayload represent 'alerts' marshaled for Alertmanager API v2.
 	// Marshaling happens below. Reference here is for caching between
 	// for loop iterations.
 	var cachedPayload []byte

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -50,27 +50,27 @@ func TestPostPath(t *testing.T) {
 	}{
 		{
 			in:  "",
-			out: "/api/v1/alerts",
+			out: "/api/v2/alerts",
 		},
 		{
 			in:  "/",
-			out: "/api/v1/alerts",
+			out: "/api/v2/alerts",
 		},
 		{
 			in:  "/prefix",
-			out: "/prefix/api/v1/alerts",
+			out: "/prefix/api/v2/alerts",
 		},
 		{
 			in:  "/prefix//",
-			out: "/prefix/api/v1/alerts",
+			out: "/prefix/api/v2/alerts",
 		},
 		{
 			in:  "prefix//",
-			out: "/prefix/api/v1/alerts",
+			out: "/prefix/api/v2/alerts",
 		},
 	}
 	for _, c := range cases {
-		require.Equal(t, c.out, postPath(c.in, config.AlertmanagerAPIVersionV1))
+		require.Equal(t, c.out, postPath(c.in, config.AlertmanagerAPIVersionV2))
 	}
 }
 


### PR DESCRIPTION
AM V1 API is deprecated and removed.

* https://github.com/prometheus/alertmanager/pull/2970

This PR is just not allowing to configure AM with the V1 api anymore.