### PR TITLE
[TESTS] Truncate some long test names, for readability

### DIFF
--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -100,7 +100,7 @@ func TestFastRegexMatcher_MatchString(t *testing.T) {
 		r := r
 		for _, v := range testValues {
 			v := v
-			t.Run(r+` on "`+v+`"`, func(t *testing.T) {
+			t.Run(readable(r)+` on "`+readable(v)+`"`, func(t *testing.T) {
 				t.Parallel()
 				m, err := NewFastRegexMatcher(r)
 				require.NoError(t, err)
@@ -109,6 +109,14 @@ func TestFastRegexMatcher_MatchString(t *testing.T) {
 			})
 		}
 	}
+}
+
+func readable(s string) string {
+	const maxReadableStringLen = 40
+	if len(s) < maxReadableStringLen {
+		return s
+	}
+	return s[:maxReadableStringLen] + "..."
 }
 
 func TestOptimizeConcatRegex(t *testing.T) {

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -3696,9 +3696,17 @@ func makeInt64Pointer(val int64) *int64 {
 	return valp
 }
 
+func readable(s string) string {
+	const maxReadableStringLen = 40
+	if len(s) < maxReadableStringLen {
+		return s
+	}
+	return s[:maxReadableStringLen] + "..."
+}
+
 func TestParseExpressions(t *testing.T) {
 	for _, test := range testExpr {
-		t.Run(test.input, func(t *testing.T) {
+		t.Run(readable(test.input), func(t *testing.T) {
 			expr, err := ParseExpr(test.input)
 
 			// Unexpected errors are always caused by a bug.


### PR DESCRIPTION
The strings produced by these tests can run to thousands of characters, which makes test logs difficult to read.

Example where I had this difficulty: https://github.com/prometheus/prometheus/actions/runs/8462518935/job/23378929811?pr=13847

I have copy-pasted the `readable` function rather than trying to make it reusable, as I suspect it might be tuned differently for different tests.

