### PR TITLE
Dedupelabels: improve observability and memory consumption

### DIFF
--- a/model/labels/labels_dedupelabels.go
+++ b/model/labels/labels_dedupelabels.go
@@ -105,25 +105,27 @@ func (t *nameTable) ToName(num int) string {
 	return t.byNum[num]
 }
 
+// "Varint" in this file is non-standard: we encode small numbers (up to 32767) in 2 bytes,
+// because we expect most Prometheus to have more than 127 unique strings.
+// And we don't encode numbers larger than 4 bytes because we don't expect more than 536,870,912 unique strings.
 func decodeVarint(data string, index int) (int, int) {
-	// Fast-path for common case of a single byte, value 0..127.
-	b := data[index]
+	b := int(data[index]) + int(data[index+1])<<8
+	index += 2
+	if b < 0x8000 {
+		return b, index
+	}
+
+	value := int(b & 0x7FFF)
+	b = int(data[index])
 	index++
 	if b < 0x80 {
-		return int(b), index
+		return value | (b << 15), index
 	}
-	value := int(b & 0x7F)
-	for shift := uint(7); ; shift += 7 {
-		// Just panic if we go of the end of data, since all Labels strings are constructed internally and
-		// malformed data indicates a bug, or memory corruption.
-		b := data[index]
-		index++
-		value |= int(b&0x7F) << shift
-		if b < 0x80 {
-			break
-		}
-	}
-	return value, index
+
+	value |= (b & 0x7f) << 15
+	b = int(data[index])
+	index++
+	return value | (b << 22), index
 }
 
 func decodeString(t *nameTable, data string, index int) (string, int) {
@@ -646,29 +648,24 @@ func marshalNumbersToSizedBuffer(nums []int, data []byte) int {
 
 func sizeVarint(x uint64) (n int) {
 	// Most common case first
-	if x < 1<<7 {
-		return 1
+	if x < 1<<15 {
+		return 2
 	}
-	if x >= 1<<56 {
-		return 9
+	if x < 1<<22 {
+		return 3
 	}
-	if x >= 1<<28 {
-		x >>= 28
-		n = 4
+	if x >= 1<<29 {
+		panic("Number too large to represent")
 	}
-	if x >= 1<<14 {
-		x >>= 14
-		n += 2
-	}
-	if x >= 1<<7 {
-		n++
-	}
-	return n + 1
+	return 4
 }
 
 func encodeVarintSlow(data []byte, offset int, v uint64) int {
 	offset -= sizeVarint(v)
 	base := offset
+	data[offset] = uint8(v)
+	v >>= 8
+	offset++
 	for v >= 1<<7 {
 		data[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
@@ -678,11 +675,12 @@ func encodeVarintSlow(data []byte, offset int, v uint64) int {
 	return base
 }
 
-// Special code for the common case that a value is less than 128
+// Special code for the common case that a value is less than 32768
 func encodeVarint(data []byte, offset, v int) int {
-	if v < 1<<7 {
-		offset--
+	if v < 1<<15 {
+		offset -= 2
 		data[offset] = uint8(v)
+		data[offset+1] = uint8(v >> 8)
 		return offset
 	}
 	return encodeVarintSlow(data, offset, uint64(v))

--- a/model/labels/labels_dedupelabels_test.go
+++ b/model/labels/labels_dedupelabels_test.go
@@ -1,0 +1,50 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dedupelabels
+
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVarint(t *testing.T) {
+	cases := []struct {
+		v        int
+		expected []byte
+	}{
+		{0, []byte{0, 0}},
+		{1, []byte{1, 0}},
+		{2, []byte{2, 0}},
+		{0x7FFF, []byte{0xFF, 0x7F}},
+		{0x8000, []byte{0x00, 0x80, 0x01}},
+		{0x8001, []byte{0x01, 0x80, 0x01}},
+		{0x3FFFFF, []byte{0xFF, 0xFF, 0x7F}},
+		{0x400000, []byte{0x00, 0x80, 0x80, 0x01}},
+		{0x400001, []byte{0x01, 0x80, 0x80, 0x01}},
+		{0x1FFFFFFF, []byte{0xFF, 0xFF, 0xFF, 0x7F}},
+	}
+	var buf [16]byte
+	for _, c := range cases {
+		n := encodeVarint(buf[:], len(buf), c.v)
+		require.Equal(t, len(c.expected), len(buf)-n)
+		require.Equal(t, c.expected, buf[n:])
+		got, m := decodeVarint(string(buf[:]), n)
+		require.Equal(t, c.v, got)
+		require.Equal(t, len(buf), m)
+	}
+	require.Panics(t, func() { encodeVarint(buf[:], len(buf), 1<<29) })
+}

--- a/scrape/metrics.go
+++ b/scrape/metrics.go
@@ -33,6 +33,7 @@ type scrapeMetrics struct {
 	targetScrapePoolExceededTargetLimit prometheus.Counter
 	targetScrapePoolTargetLimit         *prometheus.GaugeVec
 	targetScrapePoolTargetsAdded        *prometheus.GaugeVec
+	targetScrapePoolSymbolTableItems    *prometheus.GaugeVec
 	targetSyncIntervalLength            *prometheus.SummaryVec
 	targetSyncFailed                    *prometheus.CounterVec
 
@@ -125,6 +126,13 @@ func newScrapeMetrics(reg prometheus.Registerer) (*scrapeMetrics, error) {
 		prometheus.GaugeOpts{
 			Name: "prometheus_target_scrape_pool_targets",
 			Help: "Current number of targets in this scrape pool.",
+		},
+		[]string{"scrape_job"},
+	)
+	sm.targetScrapePoolSymbolTableItems = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prometheus_target_scrape_pool_symboltable_items",
+			Help: "Current number of symbols in table for this scrape pool.",
 		},
 		[]string{"scrape_job"},
 	)
@@ -233,6 +241,7 @@ func newScrapeMetrics(reg prometheus.Registerer) (*scrapeMetrics, error) {
 		sm.targetScrapePoolExceededTargetLimit,
 		sm.targetScrapePoolTargetLimit,
 		sm.targetScrapePoolTargetsAdded,
+		sm.targetScrapePoolSymbolTableItems,
 		sm.targetSyncFailed,
 		// Used by targetScraper.
 		sm.targetScrapeExceededBodySizeLimit,

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -376,22 +376,10 @@ func (sp *scrapePool) checkSymbolTable() {
 			level.Info(sp.logger).Log("msg", "Recreating symbol table", "job", sp.config.JobName, "initialLength", sp.initialSymbolTableLen, "length", sp.symbolTable.Len())
 			sp.symbolTable = labels.NewSymbolTable()
 			sp.initialSymbolTableLen = 0
-			sp.dropAllCaches()
+			sp.restartLoops(false) // To drop all caches.
+			level.Info(sp.logger).Log("msg", "Finished restarting loops", "job", sp.config.JobName)
 		}
 		sp.lastSymbolTableCheck = time.Now()
-	}
-}
-
-// Must be called with sp.mtx held.
-func (sp *scrapePool) dropAllCaches() {
-	for _, loop := range sp.loops {
-		cache := loop.getCache()
-		if cache == nil {
-			continue
-		}
-		for s := range cache.series {
-			delete(cache.series, s)
-		}
 	}
 }
 

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -245,6 +245,7 @@ func (sp *scrapePool) stop() {
 		sp.metrics.targetScrapePoolSyncsCounter.DeleteLabelValues(sp.config.JobName)
 		sp.metrics.targetScrapePoolTargetLimit.DeleteLabelValues(sp.config.JobName)
 		sp.metrics.targetScrapePoolTargetsAdded.DeleteLabelValues(sp.config.JobName)
+		sp.metrics.targetScrapePoolSymbolTableItems.DeleteLabelValues(sp.config.JobName)
 		sp.metrics.targetSyncIntervalLength.DeleteLabelValues(sp.config.JobName)
 		sp.metrics.targetSyncFailed.DeleteLabelValues(sp.config.JobName)
 	}
@@ -407,6 +408,7 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 			}
 		}
 	}
+	sp.metrics.targetScrapePoolSymbolTableItems.WithLabelValues(sp.config.JobName).Set(float64(sp.symbolTable.Len()))
 	sp.targetMtx.Unlock()
 	sp.sync(all)
 

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -369,6 +369,7 @@ func (sp *scrapePool) checkSymbolTable() {
 		if sp.initialSymbolTableLen == 0 {
 			sp.initialSymbolTableLen = sp.symbolTable.Len()
 		} else if sp.symbolTable.Len() > 2*sp.initialSymbolTableLen {
+			level.Info(sp.logger).Log("msg", "Recreating symbol table", "job", sp.config.JobName, "initialLength", sp.initialSymbolTableLen, "length", sp.symbolTable.Len())
 			sp.symbolTable = labels.NewSymbolTable()
 			sp.initialSymbolTableLen = 0
 		}

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1361,6 +1361,11 @@ func (db *DB) compactHead(head *RangeHead) error {
 	if err = db.head.truncateMemory(head.BlockMaxTime()); err != nil {
 		return fmt.Errorf("head memory truncate: %w", err)
 	}
+
+	level.Info(db.logger).Log("msg", "RebuildSymbolTable starting")
+	st := db.head.RebuildSymbolTable()
+	level.Info(db.logger).Log("msg", "RebuildSymbolTable finished", "addr", fmt.Sprintf("%p", st), "size", st.Len())
+
 	return nil
 }
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2347,5 +2347,9 @@ func (h *Head) RebuildSymbolTable() *labels.SymbolTable {
 
 		h.series.locks[i].Unlock()
 	}
+
+	if e, ok := h.exemplars.(interface{ ResetSymbolTable(*labels.SymbolTable) }); ok {
+		e.ResetSymbolTable(st)
+	}
 	return st
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2332,12 +2332,16 @@ func (h *Head) RebuildSymbolTable() *labels.SymbolTable {
 		h.series.locks[i].Lock()
 
 		for _, s := range h.series.hashes[i].unique {
+			s.Lock()
 			s.lset = rebuildLabels(s.lset)
+			s.Unlock()
 		}
 
 		for _, all := range h.series.hashes[i].conflicts {
 			for _, s := range all {
+				s.Lock()
 				s.lset = rebuildLabels(s.lset)
+				s.Unlock()
 			}
 		}
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2028,8 +2028,7 @@ func (s sample) Type() chunkenc.ValueType {
 // memSeries is the in-memory representation of a series. None of its methods
 // are goroutine safe and it is the caller's responsibility to lock it.
 type memSeries struct {
-	sync.Mutex
-
+	// Members up to the Mutex are not changed after construction, so can be accessed without a lock.
 	ref  chunks.HeadSeriesRef
 	lset labels.Labels
 	meta *metadata.Metadata
@@ -2037,6 +2036,10 @@ type memSeries struct {
 	// Series labels hash to use for sharding purposes. The value is always 0 when sharding has not
 	// been explicitly enabled in TSDB.
 	shardHash uint64
+
+	sync.Mutex
+
+	// Everything after here should only be accessed with the lock.
 
 	// Immutable chunks on disk that have not yet gone into a block, in order of ascending time stamps.
 	// When compaction runs, chunks get moved into a block and all pointers are shifted like so:

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -561,7 +561,7 @@ func (a *headAppender) AppendExemplar(ref storage.SeriesRef, lset labels.Labels,
 	// Ensure no empty labels have gotten through.
 	e.Labels = e.Labels.WithoutEmpty()
 
-	err := a.head.exemplars.ValidateExemplar(s.lset, e)
+	err := a.head.exemplars.ValidateExemplar(s.labels(), e)
 	if err != nil {
 		if errors.Is(err, storage.ErrDuplicateExemplar) || errors.Is(err, storage.ErrExemplarsDisabled) {
 			// Duplicate, don't return an error but don't accept the exemplar.
@@ -715,7 +715,7 @@ func (a *headAppender) GetRef(lset labels.Labels, hash uint64) (storage.SeriesRe
 		return 0, labels.EmptyLabels()
 	}
 	// returned labels must be suitable to pass to Append()
-	return storage.SeriesRef(s.ref), s.lset
+	return storage.SeriesRef(s.ref), s.labels()
 }
 
 // log writes all headAppender's data to the WAL.
@@ -823,7 +823,7 @@ func (a *headAppender) Commit() (err error) {
 			continue
 		}
 		// We don't instrument exemplar appends here, all is instrumented by storage.
-		if err := a.head.exemplars.AddExemplar(s.lset, e.exemplar); err != nil {
+		if err := a.head.exemplars.AddExemplar(s.labels(), e.exemplar); err != nil {
 			if errors.Is(err, storage.ErrOutOfOrderExemplar) {
 				continue
 			}

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -138,7 +138,7 @@ func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {
 	}
 
 	slices.SortFunc(series, func(a, b *memSeries) int {
-		return labels.Compare(a.lset, b.lset)
+		return labels.Compare(a.labels(), b.labels())
 	})
 
 	// Convert back to list.
@@ -185,7 +185,7 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchB
 		h.head.metrics.seriesNotFound.Inc()
 		return storage.ErrNotFound
 	}
-	builder.Assign(s.lset)
+	builder.Assign(s.labels())
 
 	if chks == nil {
 		return nil
@@ -255,7 +255,7 @@ func (h *headIndexReader) LabelValueFor(_ context.Context, id storage.SeriesRef,
 		return "", storage.ErrNotFound
 	}
 
-	value := memSeries.lset.Get(label)
+	value := memSeries.labels().Get(label)
 	if value == "" {
 		return "", storage.ErrNotFound
 	}
@@ -275,7 +275,7 @@ func (h *headIndexReader) LabelNamesFor(ctx context.Context, ids ...storage.Seri
 		if memSeries == nil {
 			return nil, storage.ErrNotFound
 		}
-		memSeries.lset.Range(func(lbl labels.Label) {
+		memSeries.labels().Range(func(lbl labels.Label) {
 			namesMap[lbl.Name] = struct{}{}
 		})
 	}

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -126,7 +126,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 			}
 			// At the moment the only possible error here is out of order exemplars, which we shouldn't see when
 			// replaying the WAL, so lets just log the error if it's not that type.
-			err = h.exemplars.AddExemplar(ms.lset, exemplar.Exemplar{Ts: e.T, Value: e.V, Labels: e.Labels})
+			err = h.exemplars.AddExemplar(ms.labels(), exemplar.Exemplar{Ts: e.T, Value: e.V, Labels: e.Labels})
 			if err != nil && errors.Is(err, storage.ErrOutOfOrderExemplar) {
 				level.Warn(h.logger).Log("msg", "Unexpected error when replaying WAL on exemplar record", "err", err)
 			}
@@ -448,7 +448,7 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 			) {
 				level.Debug(h.logger).Log(
 					"msg", "M-mapped chunks overlap on a duplicate series record",
-					"series", mSeries.lset.String(),
+					"series", mSeries.labels().String(),
 					"oldref", mSeries.ref,
 					"oldmint", mSeries.mmappedChunks[0].minTime,
 					"oldmaxt", mSeries.mmappedChunks[len(mSeries.mmappedChunks)-1].maxTime,
@@ -932,7 +932,7 @@ func (s *memSeries) encodeToSnapshotRecord(b []byte) []byte {
 
 	buf.PutByte(chunkSnapshotRecordTypeSeries)
 	buf.PutBE64(uint64(s.ref))
-	record.EncodeLabels(&buf, s.lset)
+	record.EncodeLabels(&buf, s.labels())
 	buf.PutBE64int64(0) // Backwards-compatibility; was chunkRange but now unused.
 
 	s.Lock()
@@ -1486,7 +1486,7 @@ Outer:
 					continue
 				}
 
-				if err := h.exemplars.AddExemplar(ms.lset, exemplar.Exemplar{
+				if err := h.exemplars.AddExemplar(ms.labels(), exemplar.Exemplar{
 					Labels: e.Labels,
 					Value:  e.V,
 					Ts:     e.T,

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -67,7 +67,7 @@ func (oh *OOOHeadIndexReader) series(ref storage.SeriesRef, builder *labels.Scra
 		oh.head.metrics.seriesNotFound.Inc()
 		return storage.ErrNotFound
 	}
-	builder.Assign(s.lset)
+	builder.Assign(s.labels())
 
 	if chks == nil {
 		return nil


### PR DESCRIPTION
This PR targets `release-2.51+dedupelabels` branch, because the changes are most relevant there.  It's marked as draft, since we probably don't want to merge that branch into main.

I added a metric `prometheus_target_scrape_pool_symboltable_items` to observe the symbol-table per scrape job being resized, and a log message too.

This made it clear it the code only resized on change of scraping config, so I changed that to resync every time targets are synced.  I think this is max every 5 minutes.  Also drop the scraping series cache when resizing symbol table, suggested at https://github.com/prometheus/prometheus/pull/12304#issuecomment-2032147063.

In TSDB, throw away all labels for series in the Head and rebuild them with a fresh symbol-table, on each compaction (by default every 2 hours). Log begin/end for timing, plus some stats. We need to add locks around every use of `memSeries.lset` which were previously assumed to be immutable.

In my test with 3M series, this rebuild takes about 8 seconds.  Perhaps I will re-code it to run on multiple threads.
