### PR TITLE
Log out of order when writing a block

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -575,6 +575,7 @@ func (c *LeveledCompactor) Write(dest string, b BlockReader, mint, maxt int64, p
 		"maxt", meta.MaxTime,
 		"ulid", meta.ULID,
 		"duration", time.Since(start),
+		"ooo", meta.Compaction.FromOutOfOrder(),
 	)
 	return uid, nil
 }


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

When analyzing prometheus logs, it would be helpful to distinguish when a block that's created is from the out of order head or not. Currently there is an indication when OOO compaction runs ([code](https://github.com/prometheus/prometheus/blob/31491eb37c556a81b071ec25a7452114e0714e82/tsdb/db.go#L1332-L1335)), but this doesn't include the mint and maxt for each block. Having this information all together is useful, for example, when analyzing how blocks came to be created for different time ranges.

This PR adds an "ooo" meta field (other naming welcome) to the block creation logging, so that it's possible to easily find OOO blocks for certain min and max times.
