### PR TITLE
List Prometheus v3 coordinators in MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,3 +30,13 @@ size of this repository, the natural changes in focus of maintainers over time,
 and nuances of where particular features live, this list will always be
 incomplete and out of date. However the listed maintainer(s) should be able to
 direct a PR/question to the right person.
+
+v3 release coordinators:
+* Alex Greenbank (<alex.greenbank@grafana.com> / @alexgreenbank)
+* Carrie Edwards (<carrie.edwards@grafana.com> / @carrieedwards)
+* Fiona Liao (<fiona.liao@grafana.com> / @fionaliao)
+* Jan Fajerski (<github@fajerski.name> / @jan--f)
+* Jesús Vázquez (<jesus.vazquez@grafana.com> / @jesusvazquez)
+* Nico Pazos (<nicolas.pazos-mendez@grafana.com> / @npazosmendez)
+* Owen Williams (<owen.williams@grafana.com> / @ywwg)
+* Tom Braack (<me@shorez.de> / @sh0rez)


### PR DESCRIPTION
The Prometheus v3 coordinators are full members of the Prometheus GH org, a status that our governance specifies for maintainers. As discussed, it appears best to formalize maintainership by listing the coordinators in the MAINTAINERS.md file of prometheus/prometheus.
 
@alexgreenbank @carrieedwards @fionaliao  @jan--f @npazosmendez @ywwg @sh0rez could you all please check if your names are written correctly and if I have picked your preferred email address? (I took email addresses that I found on your commits).

@npazosmendez for you, I couldn't find an email address you use on GH commits. Could you please let me know what email address I should use to list you here?