### PR TITLE
Fix AllPostings added twice

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -253,12 +253,9 @@ func PostingsForMatchers(ctx context.Context, ix IndexReader, ms ...*labels.Matc
 		}
 		switch {
 		case m.Name == "" && m.Value == "":
-			k, v := index.AllPostingsKey()
-			allPostings, err := ix.Postings(ctx, k, v)
-			if err != nil {
-				return nil, err
-			}
-			its = append(its, allPostings)
+			// We already handled the case at the top of the function,
+			// and it is unexpected to get all postings again here.
+			return nil, errors.New("unexpected all postings")
 		case m.Type == labels.MatchRegexp && m.Value == ".*":
 			// .* regexp matches any string: do nothing.
 		case m.Type == labels.MatchNotRegexp && m.Value == ".*":

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -193,6 +193,11 @@ func selectChunkSeriesSet(ctx context.Context, sortSeries bool, hints *storage.S
 // PostingsForMatchers assembles a single postings iterator against the index reader
 // based on the given matchers. The resulting postings are not ordered by series.
 func PostingsForMatchers(ctx context.Context, ix IndexReader, ms ...*labels.Matcher) (index.Postings, error) {
+	if len(ms) == 1 && ms[0].Name == "" && ms[0].Value == "" {
+		k, v := index.AllPostingsKey()
+		return ix.Postings(ctx, k, v)
+	}
+
 	var its, notIts []index.Postings
 	// See which label must be non-empty.
 	// Optimization for case like {l=~".", l!="1"}.

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -252,7 +252,7 @@ func PostingsForMatchers(ctx context.Context, ix IndexReader, ms ...*labels.Matc
 			return nil, ctx.Err()
 		}
 		switch {
-		case m.Name == "" && m.Value == "": // Special-case for AllPostings, used in tests at least.
+		case m.Name == "" && m.Value == "":
 			k, v := index.AllPostingsKey()
 			allPostings, err := ix.Postings(ctx, k, v)
 			if err != nil {


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

In `PostingsForMatchers`, if both label name and value are set to empty string, AllPostings are added. However, with the `hasSubtractingMatchers` logic above, AllPostings is already added so in this case it is added twice and merge.

```
	if hasSubtractingMatchers && !hasIntersectingMatchers {
		// If there's nothing to subtract from, add in everything and remove the notIts later.
		// We prefer to get AllPostings so that the base of subtraction (i.e. allPostings)
		// doesn't include series that may be added to the index reader during this function call.
		k, v := index.AllPostingsKey()
		allPostings, err := ix.Postings(ctx, k, v)
		if err != nil {
			return nil, err
		}
		its = append(its, allPostings)
	}
```