### PR TITLE
SD: Support unregistering discovery manager metrics

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -169,6 +169,13 @@ func (m *Manager) Providers() []*Provider {
 	return m.providers
 }
 
+// UnregisterMetrics unregisters manager metrics. It does not unregister
+// service discovery or refresh metrics, whose lifecycle is managed independent
+// of the discovery Manager.
+func (m *Manager) UnregisterMetrics() {
+	m.metrics.Unregister(m.registerer)
+}
+
 // Run starts the background processing.
 func (m *Manager) Run() error {
 	go m.sender()

--- a/discovery/metrics.go
+++ b/discovery/metrics.go
@@ -99,3 +99,12 @@ func NewManagerMetrics(registerer prometheus.Registerer, sdManagerName string) (
 
 	return m, nil
 }
+
+// Unregister unregisters all metrics.
+func (m *Metrics) Unregister(registerer prometheus.Registerer) {
+	registerer.Unregister(m.FailedConfigs)
+	registerer.Unregister(m.DiscoveredTargets)
+	registerer.Unregister(m.ReceivedUpdates)
+	registerer.Unregister(m.DelayedUpdates)
+	registerer.Unregister(m.SentUpdates)
+}


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/13892

This adds `discovery.Manager.UnregisterMetrics()`, which allows discovery manager metrics to be unregistered.  This makes it possible for a process to shut down and restart discovery managers.

@ptodev