### PR TITLE
[REFACTOR] Scraping: rename variables for clarity

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -350,12 +350,12 @@ func (sp *scrapePool) restartLoops(reuseCache bool) {
 		}
 
 		t := sp.activeTargets[fp]
-		interval, timeout, err := t.intervalAndTimeout(interval, timeout)
+		targetInterval, targetTimeout, err := t.intervalAndTimeout(interval, timeout)
 		var (
 			s = &targetScraper{
 				Target:               t,
 				client:               sp.client,
-				timeout:              timeout,
+				timeout:              targetTimeout,
 				bodySizeLimit:        bodySizeLimit,
 				acceptHeader:         acceptHeader(sp.config.ScrapeProtocols, validationScheme),
 				acceptEncodingHeader: acceptEncodingHeader(enableCompression),
@@ -373,8 +373,8 @@ func (sp *scrapePool) restartLoops(reuseCache bool) {
 				trackTimestampsStaleness: trackTimestampsStaleness,
 				mrc:                      mrc,
 				cache:                    cache,
-				interval:                 interval,
-				timeout:                  timeout,
+				interval:                 targetInterval,
+				timeout:                  targetTimeout,
 				validationScheme:         validationScheme,
 				fallbackScrapeProtocol:   fallbackScrapeProtocol,
 			})


### PR DESCRIPTION
I thought this was a bug, but it was just hard-to-read code.
Instead of shadowing the outer variables `interval` and `timeout` with new local variables in each loop iteration, use different names.

Also add a test to check it is working as intended.  Needed to extend `newTestScrapeMetrics` to get at the Registry.
~`gatherLabels` function could go upstream to `client_golang`.~

