### PR TITLE
remote write 2.0 - add flag to override remote write header value (for rollout/rollback)

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -158,7 +158,9 @@ type flagConfig struct {
 	enablePerStepStats         bool
 	enableAutoGOMAXPROCS       bool
 	// todo: how to use the enable feature flag properly + use the remote format enum type
-	rwFormat                 int
+	rwFormat int
+	// Allow the header value sent to clients to be overridden during rollout/rollback
+	rwFormatHeaderAdvertise  string
 	enableAutoGOMEMLIMIT     bool
 	enableConcurrentRuleEval bool
 
@@ -456,6 +458,9 @@ func main() {
 
 	a.Flag("remote-write-format", "remote write proto format to use, valid options: 0 (1.0), 1 (reduced format), 3 (min64 format)").
 		Default("0").IntVar(&cfg.rwFormat)
+
+	a.Flag("remote-write-header-advertise-overide", "remote write header to send back for rollout/rollback phases").
+		Default("").StringVar(&cfg.rwFormatHeaderAdvertise)
 
 	promlogflag.AddFlags(a, &cfg.promlogConfig)
 

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -56,6 +56,7 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--query.max-samples</code> | Maximum number of samples a single query can load into memory. Note that queries will fail if they try to load more samples than this into memory, so this also limits the number of samples a query can return. Use with server mode only. | `50000000` |
 | <code class="text-nowrap">--enable-feature</code> | Comma separated feature names to enable. Valid options: agent, auto-gomemlimit, exemplar-storage, expand-external-labels, memory-snapshot-on-shutdown, promql-at-modifier, promql-negative-offset, promql-per-step-stats, promql-experimental-functions, remote-write-receiver (DEPRECATED), extra-scrape-metrics, new-service-discovery-manager, auto-gomaxprocs, no-default-scrape-port, native-histograms, otlp-write-receiver, metadata-wal-records. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details. |  |
 | <code class="text-nowrap">--remote-write-format</code> | remote write proto format to use, valid options: 0 (1.0), 1 (reduced format), 3 (min64 format) | `0` |
+| <code class="text-nowrap">--remote-write-header-advertise-overide</code> | remote write header to send back for rollout/rollback phases |  |
 | <code class="text-nowrap">--log.level</code> | Only log messages with the given severity or above. One of: [debug, info, warn, error] | `info` |
 | <code class="text-nowrap">--log.format</code> | Output format of log messages. One of: [logfmt, json] | `logfmt` |
 

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -255,6 +255,7 @@ func NewAPI(
 	statsRenderer StatsRenderer,
 	rwEnabled bool,
 	rwFormat config.RemoteWriteFormat,
+	rwFormatHeaderAdvertise string,
 	otlpEnabled bool,
 ) *API {
 	a := &API{
@@ -309,8 +310,8 @@ func NewAPI(
 		// 1. (During) support new protocols but don't advertise
 		// <wait a suitable period for all sending clients to be aware that receiving servers no longer support 2.0>
 		// 2. (After) no flags set
-		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, rwFormat)
-		a.remoteWriteHeadHandler = remote.NewWriteHeadHandler(logger, registerer, rwFormat)
+		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, rwFormat, rwFormatHeaderAdvertise)
+		a.remoteWriteHeadHandler = remote.NewWriteHeadHandler(logger, registerer, rwFormat, rwFormatHeaderAdvertise)
 	}
 	if otlpEnabled {
 		a.otlpWriteHandler = remote.NewOTLPWriteHandler(logger, ap)

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -339,27 +339,37 @@ var sampleFlagMap = map[string]string{
 
 func TestHeadEndpoint(t *testing.T) {
 	for _, tc := range []struct {
-		name                string
-		rwFormat            config.RemoteWriteFormat
-		expectedStatusCode  int
-		expectedHeaderValue string
+		name                    string
+		rwFormat                config.RemoteWriteFormat
+		rwFormatHeaderAdvertise string
+		expectedStatusCode      int
+		expectedHeaderValue     string
 	}{
 		{
-			name:                "HEAD Version 1",
-			rwFormat:            remote.Version1,
-			expectedStatusCode:  http.StatusOK,
-			expectedHeaderValue: "0.1.0",
+			name:                    "HEAD Version 1",
+			rwFormat:                remote.Version1,
+			rwFormatHeaderAdvertise: "",
+			expectedStatusCode:      http.StatusOK,
+			expectedHeaderValue:     "0.1.0",
 		},
 		{
-			name:                "HEAD Version 2",
-			rwFormat:            remote.Version2,
-			expectedStatusCode:  http.StatusOK,
-			expectedHeaderValue: "2.0;snappy,0.1.0",
+			name:                    "HEAD Version 2",
+			rwFormat:                remote.Version2,
+			rwFormatHeaderAdvertise: "",
+			expectedStatusCode:      http.StatusOK,
+			expectedHeaderValue:     "2.0;snappy,0.1.0",
+		},
+		{
+			name:                    "HEAD Version 2",
+			rwFormat:                remote.Version2,
+			rwFormatHeaderAdvertise: "0.1.0",
+			expectedStatusCode:      http.StatusOK,
+			expectedHeaderValue:     "0.1.0",
 		},
 	} {
 		r := route.New()
 		api := &API{
-			remoteWriteHeadHandler: remote.NewWriteHeadHandler(log.NewNopLogger(), nil, tc.rwFormat),
+			remoteWriteHeadHandler: remote.NewWriteHeadHandler(log.NewNopLogger(), nil, tc.rwFormat, tc.rwFormatHeaderAdvertise),
 			ready:                  func(f http.HandlerFunc) http.HandlerFunc { return f },
 		}
 		api.Register(r)

--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -137,6 +137,7 @@ func createPrometheusAPI(q storage.SampleAndChunkQueryable) *route.Router {
 		nil,
 		false,
 		remote.Version1,
+		"",
 		false, // Disable experimental reduce remote write proto support.
 	)
 

--- a/web/web.go
+++ b/web/web.go
@@ -262,7 +262,8 @@ type Options struct {
 	IsAgent                    bool
 	AppName                    string
 	// TODO(cstyan): should this change to a list of tuples, maybe via the content negotiation PR?
-	RemoteWriteFormat config.RemoteWriteFormat
+	RemoteWriteFormat                config.RemoteWriteFormat
+	RemoteWriteFormatHeaderAdvertise string
 
 	Gatherer   prometheus.Gatherer
 	Registerer prometheus.Registerer
@@ -353,6 +354,7 @@ func New(logger log.Logger, o *Options) *Handler {
 		nil,
 		o.EnableRemoteWriteReceiver,
 		o.RemoteWriteFormat,
+		o.RemoteWriteFormatHeaderAdvertise,
 		o.EnableOTLPWriteReceiver,
 	)
 


### PR DESCRIPTION
Prototype for a flag to allow the Remote Write header `X-Prometheus-Remote-Write-Version` to be overridden with a specified value to aid rollout/rollback situations.

For example, say you are rolling out Remote Write 2.x amongst many servers behind a load balancer, you don't want any one to respond to a request saying it can support "2.0;snappy" and then the subsequent 2.0 request is sent to a server that has not yet been upgraded.

The plan would be:
* 1. Existing servers that don't support Remote Write 2.0
* 2. Rollout servers running with `--remote-write-format 1` and `--remote-write-header-advertise-override "0.1.0"`
* 3. When all servers behind the load balancer have been upgraded you can restart individual servers and remove the `--remote-write-advertise-override` flag.

Between steps 1 and 2 no servers will announce they support Remote Write 2.0.
Between steps 2 and 3 all servers will support Remote Write 2.0 even if they do not announce it.

The flag would also be required if servers are upgraded to support a new compression/encoding, e.g. if `2.0;gzip` were added.

* 1. Existing servers all supporting base Remote Write 2.0 (e.g. `2.0;snappy,0.1.0`)
* 2. Upgrade servers with `gzip` support but run with `--remote-write-header-advertise-override "2.0;snappy,0.1.0"`
* 3. When all servers behind the load balancer have been upgraded to the version that supports `gzip` you can restart individual servers and remove the `--remote-write-advertise-override` flag.

At the end all servers will then return `2.0;gzip,2.0;snappy,0.1.0` (assuming that is the preferred order).

Still to do:
- [ ] Add some more tests on the `write_handler_test.go` side