### PR TITLE
fix(scaleway-sd): use public IPs if no private IP present

### DIFF
--- a/discovery/scaleway/instance.go
+++ b/discovery/scaleway/instance.go
@@ -177,20 +177,21 @@ func (d *instanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 		addr := ""
 		if server.IPv6 != nil {
 			labels[instancePublicIPv6Label] = model.LabelValue(server.IPv6.Address.String())
-			addr = net.JoinHostPort(server.IPv6.Address.String(), strconv.FormatUint(uint64(d.port), 10))
+			addr = server.IPv6.Address.String()
 		}
 
 		if server.PublicIP != nil {
 			labels[instancePublicIPv4Label] = model.LabelValue(server.PublicIP.Address.String())
-			addr = net.JoinHostPort(server.PublicIP.Address.String(), strconv.FormatUint(uint64(d.port), 10))
+			addr = server.PublicIP.Address.String()
 		}
 
 		if server.PrivateIP != nil {
 			labels[instancePrivateIPv4Label] = model.LabelValue(*server.PrivateIP)
-			addr = net.JoinHostPort(*server.PrivateIP, strconv.FormatUint(uint64(d.port), 10))
+			addr = *server.PrivateIP
 		}
 
 		if addr != "" {
+			addr := net.JoinHostPort(addr, strconv.FormatUint(uint64(d.port), 10))
 			labels[model.AddressLabel] = model.LabelValue(addr)
 			targets = append(targets, labels)
 		}

--- a/discovery/scaleway/instance.go
+++ b/discovery/scaleway/instance.go
@@ -174,25 +174,23 @@ func (d *instanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 			labels[instanceTagsLabel] = model.LabelValue(tags)
 		}
 
-		var addrs []string
+		addr := ""
 		if server.IPv6 != nil {
 			labels[instancePublicIPv6Label] = model.LabelValue(server.IPv6.Address.String())
-			addrs = append(addrs, server.IPv6.Address.String())
+			addr = net.JoinHostPort(server.IPv6.Address.String(), strconv.FormatUint(uint64(d.port), 10))
 		}
 
 		if server.PublicIP != nil {
 			labels[instancePublicIPv4Label] = model.LabelValue(server.PublicIP.Address.String())
-			addrs = append(addrs, server.PublicIP.Address.String())
+			addr = net.JoinHostPort(server.PublicIP.Address.String(), strconv.FormatUint(uint64(d.port), 10))
 		}
 
 		if server.PrivateIP != nil {
 			labels[instancePrivateIPv4Label] = model.LabelValue(*server.PrivateIP)
-			addrs = append(addrs, *server.PrivateIP)
+			addr = net.JoinHostPort(*server.PrivateIP, strconv.FormatUint(uint64(d.port), 10))
 		}
 
-		if len(addrs) > 0 {
-			port := strconv.FormatUint(uint64(d.port), 10)
-			addr := net.JoinHostPort(addrs[len(addrs)-1], port)
+		if addr != "" {
 			labels[model.AddressLabel] = model.LabelValue(addr)
 			targets = append(targets, labels)
 		}

--- a/discovery/scaleway/instance.go
+++ b/discovery/scaleway/instance.go
@@ -174,23 +174,25 @@ func (d *instanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 			labels[instanceTagsLabel] = model.LabelValue(tags)
 		}
 
-		addr := ""
+		var addrs []string
 		if server.IPv6 != nil {
 			labels[instancePublicIPv6Label] = model.LabelValue(server.IPv6.Address.String())
-			addr = net.JoinHostPort(server.IPv6.Address.String(), strconv.FormatUint(uint64(d.port), 10))
+			addrs = append(addrs, server.IPv6.Address.String())
 		}
 
 		if server.PublicIP != nil {
 			labels[instancePublicIPv4Label] = model.LabelValue(server.PublicIP.Address.String())
-			addr = net.JoinHostPort(server.PublicIP.Address.String(), strconv.FormatUint(uint64(d.port), 10))
+			addrs = append(addrs, server.PublicIP.Address.String())
 		}
 
 		if server.PrivateIP != nil {
 			labels[instancePrivateIPv4Label] = model.LabelValue(*server.PrivateIP)
-			addr = net.JoinHostPort(*server.PrivateIP, strconv.FormatUint(uint64(d.port), 10))
+			addrs = append(addrs, *server.PrivateIP)
 		}
 
-		if addr != "" {
+		if len(addrs) > 0 {
+			port := strconv.FormatUint(uint64(d.port), 10)
+			addr := net.JoinHostPort(addrs[len(addrs)-1], port)
 			labels[model.AddressLabel] = model.LabelValue(addr)
 			targets = append(targets, labels)
 		}

--- a/discovery/scaleway/instance.go
+++ b/discovery/scaleway/instance.go
@@ -174,20 +174,24 @@ func (d *instanceDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, 
 			labels[instanceTagsLabel] = model.LabelValue(tags)
 		}
 
+		addr := ""
 		if server.IPv6 != nil {
 			labels[instancePublicIPv6Label] = model.LabelValue(server.IPv6.Address.String())
+			addr = net.JoinHostPort(server.IPv6.Address.String(), strconv.FormatUint(uint64(d.port), 10))
 		}
 
 		if server.PublicIP != nil {
 			labels[instancePublicIPv4Label] = model.LabelValue(server.PublicIP.Address.String())
+			addr = net.JoinHostPort(server.PublicIP.Address.String(), strconv.FormatUint(uint64(d.port), 10))
 		}
 
 		if server.PrivateIP != nil {
 			labels[instancePrivateIPv4Label] = model.LabelValue(*server.PrivateIP)
+			addr = net.JoinHostPort(*server.PrivateIP, strconv.FormatUint(uint64(d.port), 10))
+		}
 
-			addr := net.JoinHostPort(*server.PrivateIP, strconv.FormatUint(uint64(d.port), 10))
+		if addr != "" {
 			labels[model.AddressLabel] = model.LabelValue(addr)
-
 			targets = append(targets, labels)
 		}
 	}

--- a/discovery/scaleway/instance_test.go
+++ b/discovery/scaleway/instance_test.go
@@ -60,7 +60,7 @@ api_url: %s
 	tg := tgs[0]
 	require.NotNil(t, tg)
 	require.NotNil(t, tg.Targets)
-	require.Len(t, tg.Targets, 2)
+	require.Len(t, tg.Targets, 3)
 
 	for i, lbls := range []model.LabelSet{
 		{
@@ -109,6 +109,28 @@ api_url: %s
 			"__meta_scaleway_instance_status":                 "running",
 			"__meta_scaleway_instance_type":                   "DEV1-S",
 			"__meta_scaleway_instance_zone":                   "fr-par-1",
+		},
+		{
+			"__address__":                                     "51.158.183.115:80",
+			"__meta_scaleway_instance_boot_type":              "local",
+			"__meta_scaleway_instance_hostname":               "routed-dualstack",
+			"__meta_scaleway_instance_id":                     "4904366a-7e26-4b65-b97b-6392c761247a",
+			"__meta_scaleway_instance_image_arch":             "x86_64",
+			"__meta_scaleway_instance_image_id":               "3e0a5b84-1d69-4993-8fa4-0d7df52d5160",
+			"__meta_scaleway_instance_image_name":             "Ubuntu 22.04 Jammy Jellyfish",
+			"__meta_scaleway_instance_location_cluster_id":    "19",
+			"__meta_scaleway_instance_location_hypervisor_id": "1201",
+			"__meta_scaleway_instance_location_node_id":       "24",
+			"__meta_scaleway_instance_name":                   "routed-dualstack",
+			"__meta_scaleway_instance_organization_id":        "20b3d507-96ac-454c-a795-bc731b46b12f",
+			"__meta_scaleway_instance_project_id":             "20b3d507-96ac-454c-a795-bc731b46b12f",
+			"__meta_scaleway_instance_public_ipv4":            "51.158.183.115",
+			"__meta_scaleway_instance_region":                 "nl-ams",
+			"__meta_scaleway_instance_security_group_id":      "984414da-9fc2-49c0-a925-fed6266fe092",
+			"__meta_scaleway_instance_security_group_name":    "Default security group",
+			"__meta_scaleway_instance_status":                 "running",
+			"__meta_scaleway_instance_type":                   "DEV1-S",
+			"__meta_scaleway_instance_zone":                   "nl-ams-1",
 		},
 	} {
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {

--- a/discovery/scaleway/testdata/instance.json
+++ b/discovery/scaleway/testdata/instance.json
@@ -216,6 +216,146 @@
       "placement_group": null,
       "private_nics": [],
       "zone": "fr-par-1"
+    },
+    {
+      "id": "4904366a-7e26-4b65-b97b-6392c761247a",
+      "name": "routed-dualstack",
+      "arch": "x86_64",
+      "commercial_type": "DEV1-S",
+      "boot_type": "local",
+      "organization": "20b3d507-96ac-454c-a795-bc731b46b12f",
+      "project": "20b3d507-96ac-454c-a795-bc731b46b12f",
+      "hostname": "routed-dualstack",
+      "image": {
+        "id": "3e0a5b84-1d69-4993-8fa4-0d7df52d5160",
+        "name": "Ubuntu 22.04 Jammy Jellyfish",
+        "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+        "project": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+        "root_volume": {
+          "id": "13d945b9-5e78-4f9d-8ac4-c4bc2fa7c31a",
+          "name": "Ubuntu 22.04 Jammy Jellyfish",
+          "volume_type": "unified",
+          "size": 10000000000
+        },
+        "extra_volumes": {},
+        "public": true,
+        "arch": "x86_64",
+        "creation_date": "2024-02-22T15:52:56.037007+00:00",
+        "modification_date": "2024-02-22T15:52:56.037007+00:00",
+        "default_bootscript": null,
+        "from_server": null,
+        "state": "available",
+        "tags": [],
+        "zone": "nl-ams-1"
+      },
+      "volumes": {
+        "0": {
+          "boot": false,
+          "id": "fe85c817-e67e-4e24-8f13-bde3e9f42620",
+          "name": "Ubuntu 22.04 Jammy Jellyfish",
+          "volume_type": "l_ssd",
+          "export_uri": null,
+          "organization": "20b3d507-96ac-454c-a795-bc731b46b12f",
+          "project": "20b3d507-96ac-454c-a795-bc731b46b12f",
+          "server": {
+            "id": "4904366a-7e26-4b65-b97b-6392c761247a",
+            "name": "routed-dualstack"
+          },
+          "size": 20000000000,
+          "state": "available",
+          "creation_date": "2024-04-19T14:50:14.019739+00:00",
+          "modification_date": "2024-04-19T14:50:14.019739+00:00",
+          "tags": [],
+          "zone": "nl-ams-1"
+        }
+      },
+      "tags": [],
+      "state": "running",
+      "protected": false,
+      "state_detail": "booted",
+      "public_ip": {
+        "id": "53f8f861-7a11-4b16-a4bc-fb8f4b4a11d0",
+        "address": "51.158.183.115",
+        "dynamic": false,
+        "gateway": "62.210.0.1",
+        "netmask": "32",
+        "family": "inet",
+        "provisioning_mode": "dhcp",
+        "tags": [],
+        "state": "attached",
+        "ipam_id": "ec3499ff-a664-49b7-818a-9fe4b95aee5e"
+      },
+      "public_ips": [
+        {
+          "id": "53f8f861-7a11-4b16-a4bc-fb8f4b4a11d0",
+          "address": "51.158.183.115",
+          "dynamic": false,
+          "gateway": "62.210.0.1",
+          "netmask": "32",
+          "family": "inet",
+          "provisioning_mode": "dhcp",
+          "tags": [],
+          "state": "attached",
+          "ipam_id": "ec3499ff-a664-49b7-818a-9fe4b95aee5e"
+        },
+        {
+          "id": "f52a8c81-0875-4aee-b96e-eccfc6bec367",
+          "address": "2001:bc8:1640:1568:dc00:ff:fe21:91b",
+          "dynamic": false,
+          "gateway": "fe80::dc00:ff:fe21:91c",
+          "netmask": "64",
+          "family": "inet6",
+          "provisioning_mode": "slaac",
+          "tags": [],
+          "state": "attached",
+          "ipam_id": "40d1e6ea-e932-42f9-8acb-55398bec7ad6"
+        }
+      ],
+      "mac_address": "de:00:00:21:09:1b",
+      "routed_ip_enabled": true,
+      "ipv6": null,
+      "extra_networks": [],
+      "dynamic_ip_required": false,
+      "enable_ipv6": false,
+      "private_ip": null,
+      "creation_date": "2024-04-19T14:50:14.019739+00:00",
+      "modification_date": "2024-04-19T14:52:21.181670+00:00",
+      "bootscript": {
+        "id": "5a520dda-96d6-4ed2-acd1-1d526b6859fe",
+        "public": true,
+        "title": "x86_64 mainline 4.4.182 rev1",
+        "architecture": "x86_64",
+        "organization": "11111111-1111-4111-8111-111111111111",
+        "project": "11111111-1111-4111-8111-111111111111",
+        "kernel": "http://10.196.2.9/kernel/x86_64-mainline-lts-4.4-4.4.182-rev1/vmlinuz-4.4.182",
+        "dtb": "",
+        "initrd": "http://10.196.2.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
+        "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16",
+        "default": true,
+        "zone": "nl-ams-1"
+      },
+      "security_group": {
+        "id": "984414da-9fc2-49c0-a925-fed6266fe092",
+        "name": "Default security group"
+      },
+      "location": {
+        "zone_id": "ams1",
+        "platform_id": "23",
+        "cluster_id": "19",
+        "hypervisor_id": "1201",
+        "node_id": "24"
+      },
+      "maintenances": [],
+      "allowed_actions": [
+        "poweroff",
+        "terminate",
+        "reboot",
+        "stop_in_place",
+        "backup"
+      ],
+      "placement_group": null,
+      "private_nics": [],
+      "zone": "nl-ams-1"
     }
   ]
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2949,9 +2949,10 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_scaleway_instance_type`: commercial type of the server
 * `__meta_scaleway_instance_zone`: the zone of the server (ex: `fr-par-1`, complete list [here](https://developers.scaleway.com/en/products/instance/api/#introduction))
 
-This role uses the private IPv4 address by default. This can be
+This role uses the first address it finds in the following order: private IPv4, public IPv4, public IPv6. This can be
 changed with relabeling, as demonstrated in [the Prometheus scaleway-sd
 configuration file](/documentation/examples/prometheus-scaleway.yml).
+Should an instance have no address before relabeling, it will not be added to the target list and you will not be able to relabel it.
 
 #### Baremetal role
 


### PR DESCRIPTION
In the Scaleway service discovery, use the instance's public IP if no private IP is available.


Fixes #13940 

@bboreham 
