### PR TITLE
tsdb/db: change log level

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1514,7 +1514,7 @@ func (db *DB) reloadBlocks() (err error) {
 		blockMetas = append(blockMetas, b.Meta())
 	}
 	if overlaps := OverlappingBlocks(blockMetas); len(overlaps) > 0 {
-		level.Warn(db.logger).Log("msg", "Overlapping blocks found during reloadBlocks", "detail", overlaps.String())
+		level.Debug(db.logger).Log("msg", "Overlapping blocks found during reloadBlocks", "detail", overlaps.String())
 	}
 
 	// Append blocks to old, deletable blocks, so we can close them.


### PR DESCRIPTION
In Thanos/Mimir/etc. it is possible to have OOO support enabled without vertical compaction. This leads to constant messages during reloadBlocks. As a user, this is what I wanted and I know that this is happening, it's not a problem. Reduce the log level to avoid this spam.
