### PR TITLE
Avoid creating new slices for labels values on postings for matchers

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -331,18 +331,20 @@ func postingsForMatcher(ctx context.Context, ix IndexReader, m *labels.Matcher) 
 		return nil, err
 	}
 
-	var res []string
+	i := 0
 	for _, val := range vals {
 		if m.Matches(val) {
-			res = append(res, val)
+			vals[i] = val
+			i++
 		}
 	}
 
-	if len(res) == 0 {
+	vals = vals[0:i]
+	if len(vals) == 0 {
 		return index.EmptyPostings(), nil
 	}
 
-	return ix.Postings(ctx, m.Name, res...)
+	return ix.Postings(ctx, m.Name, vals...)
 }
 
 // inversePostingsForMatcher returns the postings for the series with the label name set but not matching the matcher.

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -331,20 +331,18 @@ func postingsForMatcher(ctx context.Context, ix IndexReader, m *labels.Matcher) 
 		return nil, err
 	}
 
-	i := 0
+	res := vals[:0]
 	for _, val := range vals {
 		if m.Matches(val) {
-			vals[i] = val
-			i++
+			res = append(res, val)
 		}
 	}
 
-	vals = vals[0:i]
-	if len(vals) == 0 {
+	if len(res) == 0 {
 		return index.EmptyPostings(), nil
 	}
 
-	return ix.Postings(ctx, m.Name, vals...)
+	return ix.Postings(ctx, m.Name, res...)
 }
 
 // inversePostingsForMatcher returns the postings for the series with the label name set but not matching the matcher.
@@ -370,7 +368,7 @@ func inversePostingsForMatcher(ctx context.Context, ix IndexReader, m *labels.Ma
 		return nil, err
 	}
 
-	var res []string
+	res := vals[:0]
 	// If the inverse match is ="", we just want all the values.
 	if m.Type == labels.MatchEqual && m.Value == "" {
 		res = vals


### PR DESCRIPTION
Avoid creating new string slices when running queries with regex that match lots of postings.

We can see in some cases that this method is allocating quite a bit of memory and causing GC to use quite a bit CPU.

Benchmark result for the regex cases that match lots of postings (the main difference is in the total bytes allocated per operation):

```
~/go/bin/benchstat /tmp/old /tmp/new                                                                                                              

goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
                                              │  /tmp/old   │             /tmp/new              │
                                              │   sec/op    │   sec/op     vs base              │
Querier/Head/PostingsForMatchers/i=~"1.*"-32   7.939m ± 1%   7.146m ± 1%  -9.99% (p=0.002 n=6)
Querier/Block/PostingsForMatchers/i=~"1.*"-32   6.375m ± 1%   5.973m ± 3%  -6.30% (p=0.002 n=6)

                                              │   /tmp/old   │              /tmp/new               │
                                              │     B/op     │     B/op      vs base               │
Querier/Head/PostingsForMatchers/i=~"1.*"-32   3.357Mi ± 0%   2.722Mi ± 0%  -18.92% (p=0.002 n=6)
Querier/Block/PostingsForMatchers/i=~"1.*"-32   3.357Mi ± 0%   2.722Mi ± 0%  -18.92% (p=0.002 n=6)

                                              │  /tmp/old   │             /tmp/new              │
                                              │  allocs/op  │  allocs/op   vs base              │
Querier/Head/PostingsForMatchers/i=~"1.*"-32   11.13k ± 0%   11.12k ± 0%  -0.16% (p=0.002 n=6)
Querier/Block/PostingsForMatchers/i=~"1.*"-32   11.13k ± 0%   11.12k ± 0%  -0.16% (p=0.002 n=6)
```