### PR TITLE
[PRW-2.0] New config surface allowing content-type and encoding preferences for both sending and receiving.

### DIFF
--- a/config/config_remote_write.go
+++ b/config/config_remote_write.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// TODO(bwplotka): Consider an util for "preference enums" as it's similar code for rw compression, proto type and scrape protocol.
+
+// RemoteWriteProtoType represents the supported protobuf types for the remote write.
+type RemoteWriteProtoType string
+
+// Validate returns error if the given protobuf type is not supported.
+func (s RemoteWriteProtoType) Validate() error {
+	if _, ok := RemoteWriteContentTypeHeaders[s]; !ok {
+		return fmt.Errorf("unknown remote write protobuf type %v, supported: %v",
+			s, func() (ret []string) {
+				for k := range RemoteWriteContentTypeHeaders {
+					ret = append(ret, string(k))
+				}
+				sort.Strings(ret)
+				return ret
+			}())
+	}
+	return nil
+}
+
+type RemoteWriteProtoTypes []RemoteWriteProtoType
+
+func (t RemoteWriteProtoTypes) Strings() []string {
+	ret := make([]string, 0, len(t))
+	for _, typ := range t {
+		ret = append(ret, string(typ))
+	}
+	return ret
+}
+
+func (t RemoteWriteProtoTypes) String() string {
+	return strings.Join(t.Strings(), ",")
+}
+
+// ServerAcceptHeaderValue returns server Accept header value for
+// given list of proto types as per RFC 9110 https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1-14
+func (t RemoteWriteProtoTypes) ServerAcceptHeaderValue() string {
+	// TODO(bwplotka): Consider implementing an optional quality factor.
+	ret := make([]string, 0, len(t))
+	for _, typ := range t {
+		ret = append(ret, RemoteWriteContentTypeHeaders[typ])
+	}
+	return strings.Join(ret, ",")
+}
+
+var (
+	RemoteWriteProtoTypeV1        RemoteWriteProtoType = "v1.WriteRequest"
+	RemoteWriteProtoTypeV2        RemoteWriteProtoType = "v2.WriteRequest"
+	RemoteWriteContentTypeHeaders                      = map[RemoteWriteProtoType]string{
+		RemoteWriteProtoTypeV1: "application/x-protobuf", // Also application/x-protobuf; proto=prometheus.WriteRequest but simplified for compatibility with 1.x spec.
+		RemoteWriteProtoTypeV2: "application/x-protobuf;proto=io.prometheus.remote.write.v2.WriteRequest",
+	}
+
+	// DefaultRemoteWriteProtoTypes is the set of remote write protobuf types that will be
+	// preferred by the remote write client.
+	DefaultRemoteWriteProtoTypes = RemoteWriteProtoTypes{
+		RemoteWriteProtoTypeV1,
+		RemoteWriteProtoTypeV2,
+	}
+)
+
+// validateRemoteWriteProtoTypes return errors if we see problems with rw protobuf types in
+// the Prometheus configuration.
+func validateRemoteWriteProtoTypes(ts []RemoteWriteProtoType) error {
+	if len(ts) == 0 {
+		return errors.New("protobuf_types cannot be empty")
+	}
+	dups := map[string]struct{}{}
+	for _, t := range ts {
+		if _, ok := dups[strings.ToLower(string(t))]; ok {
+			return fmt.Errorf("duplicated protobuf types in protobuf_types, got %v", ts)
+		}
+		if err := t.Validate(); err != nil {
+			return fmt.Errorf("protobuf_types: %w", err)
+		}
+		dups[strings.ToLower(string(t))] = struct{}{}
+	}
+	return nil
+}
+
+// RemoteWriteCompression represents the supported compressions for the remote write.
+type RemoteWriteCompression string
+
+// Validate returns error if the given protobuf type is not supported.
+func (s RemoteWriteCompression) Validate() error {
+	if _, ok := RemoteWriteContentEncodingHeaders[s]; !ok {
+		return fmt.Errorf("unknown remote write protobuf type %v, supported: %v",
+			s, func() (ret []string) {
+				for k := range RemoteWriteContentEncodingHeaders {
+					ret = append(ret, string(k))
+				}
+				sort.Strings(ret)
+				return ret
+			}())
+	}
+	return nil
+}
+
+type RemoteWriteCompressions []RemoteWriteCompression
+
+func (cs RemoteWriteCompressions) Strings() []string {
+	ret := make([]string, 0, len(cs))
+	for _, c := range cs {
+		ret = append(ret, string(c))
+	}
+	return ret
+}
+
+func (cs RemoteWriteCompressions) String() string {
+	return strings.Join(cs.Strings(), ",")
+}
+
+// ServerAcceptEncodingHeaderValue returns server Accept-Encoding header value for
+// given list of compressions as per RFC 9110 https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-encoding
+func (cs RemoteWriteCompressions) ServerAcceptEncodingHeaderValue() string {
+	// TODO(bwplotka): Consider implementing an optional quality factor.
+	ret := make([]string, 0, len(cs))
+	for _, typ := range cs {
+		ret = append(ret, RemoteWriteContentEncodingHeaders[typ])
+	}
+	return strings.Join(ret, ",")
+}
+
+// validateRemoteWriteCompressions return errors if we see problems with rw compressions in
+// the Prometheus configuration.
+func validateRemoteWriteCompressions(cs []RemoteWriteCompression) error {
+	if len(cs) == 0 {
+		return errors.New("compressions cannot be empty")
+	}
+	dups := map[string]struct{}{}
+	for _, c := range cs {
+		if _, ok := dups[strings.ToLower(string(c))]; ok {
+			return fmt.Errorf("duplicated compression in compressions, got %v", cs)
+		}
+		if err := c.Validate(); err != nil {
+			return fmt.Errorf("compressions: %w", err)
+		}
+		dups[strings.ToLower(string(c))] = struct{}{}
+	}
+	return nil
+}
+
+var (
+	RemoteWriteCompressionSnappy RemoteWriteCompression = "snappy"
+
+	RemoteWriteContentEncodingHeaders = map[RemoteWriteCompression]string{
+		RemoteWriteCompressionSnappy: "snappy",
+	}
+
+	DefaultRemoteWriteCompressions = RemoteWriteCompressions{
+		RemoteWriteCompressionSnappy,
+	}
+)

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -210,10 +210,9 @@ type API struct {
 	isAgent       bool
 	statsRenderer StatsRenderer
 
-	remoteWriteHeadHandler http.Handler
-	remoteWriteHandler     http.Handler
-	remoteReadHandler      http.Handler
-	otlpWriteHandler       http.Handler
+	remoteWriteHandler http.Handler
+	remoteReadHandler  http.Handler
+	otlpWriteHandler   http.Handler
 
 	codecs []Codec
 }
@@ -247,7 +246,8 @@ func NewAPI(
 	registerer prometheus.Registerer,
 	statsRenderer StatsRenderer,
 	rwEnabled bool,
-	rwFormat config.RemoteWriteFormat,
+	rwProtoTypes []config.RemoteWriteProtoType,
+	rwCompressions []config.RemoteWriteCompression,
 	otlpEnabled bool,
 ) *API {
 	a := &API{
@@ -290,20 +290,7 @@ func NewAPI(
 	}
 
 	if rwEnabled {
-		// TODO(alexg) - Two phase rwFormat rollout needs to create handlers with flag for advertising.
-		// For rollout we do two phases:
-		// 0. (Before) no flags set
-		// 1. (During) support new protocols but don't advertise
-		// <wait until all servers have rolled out and now support RW2.0>
-		// 2. (After) support new protocols and advertise
-		//
-		// For rollback the two phases are:
-		// 0. (Before) support new protocols and advertise
-		// 1. (During) support new protocols but don't advertise
-		// <wait a suitable period for all sending clients to be aware that receiving servers no longer support 2.0>
-		// 2. (After) no flags set
-		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, rwFormat)
-		a.remoteWriteHeadHandler = remote.NewWriteHeadHandler(logger, registerer, rwFormat)
+		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, rwProtoTypes, rwCompressions)
 	}
 	if otlpEnabled {
 		a.otlpWriteHandler = remote.NewOTLPWriteHandler(logger, ap)
@@ -400,7 +387,6 @@ func (api *API) Register(r *route.Router) {
 	r.Get("/status/walreplay", api.serveWALReplayStatus)
 	r.Post("/read", api.ready(api.remoteRead))
 	r.Post("/write", api.ready(api.remoteWrite))
-	r.Head("/write", api.remoteWriteHead)
 	r.Post("/otlp/v1/metrics", api.ready(api.otlpWrite))
 
 	r.Get("/alerts", wrapAgent(api.alerts))
@@ -1658,14 +1644,6 @@ func (api *API) remoteRead(w http.ResponseWriter, r *http.Request) {
 		api.remoteReadHandler.ServeHTTP(w, r)
 	} else {
 		http.Error(w, "not found", http.StatusNotFound)
-	}
-}
-
-func (api *API) remoteWriteHead(w http.ResponseWriter, r *http.Request) {
-	if api.remoteWriteHeadHandler != nil {
-		api.remoteWriteHeadHandler.ServeHTTP(w, r)
-	} else {
-		http.Error(w, "remote write receiver needs to be enabled with --web.enable-remote-write-receiver", http.StatusNotFound)
 	}
 }
 

--- a/web/web.go
+++ b/web/web.go
@@ -244,28 +244,28 @@ type Options struct {
 	Version               *PrometheusVersion
 	Flags                 map[string]string
 
-	ListenAddress              string
-	CORSOrigin                 *regexp.Regexp
-	ReadTimeout                time.Duration
-	MaxConnections             int
-	ExternalURL                *url.URL
-	RoutePrefix                string
-	UseLocalAssets             bool
-	UserAssetsPath             string
-	ConsoleTemplatesPath       string
-	ConsoleLibrariesPath       string
-	EnableLifecycle            bool
-	EnableAdminAPI             bool
-	PageTitle                  string
-	RemoteReadSampleLimit      int
-	RemoteReadConcurrencyLimit int
-	RemoteReadBytesInFrame     int
-	EnableRemoteWriteReceiver  bool
-	EnableOTLPWriteReceiver    bool
-	IsAgent                    bool
-	AppName                    string
-	// TODO(cstyan): should this change to a list of tuples, maybe via the content negotiation PR?
-	RemoteWriteFormat config.RemoteWriteFormat
+	ListenAddress                   string
+	CORSOrigin                      *regexp.Regexp
+	ReadTimeout                     time.Duration
+	MaxConnections                  int
+	ExternalURL                     *url.URL
+	RoutePrefix                     string
+	UseLocalAssets                  bool
+	UserAssetsPath                  string
+	ConsoleTemplatesPath            string
+	ConsoleLibrariesPath            string
+	EnableLifecycle                 bool
+	EnableAdminAPI                  bool
+	PageTitle                       string
+	RemoteReadSampleLimit           int
+	RemoteReadConcurrencyLimit      int
+	RemoteReadBytesInFrame          int
+	EnableRemoteWriteReceiver       bool
+	RemoteWriteReceiverProtoTypes   []config.RemoteWriteProtoType
+	RemoteWriteReceiverCompressions []config.RemoteWriteCompression
+	EnableOTLPWriteReceiver         bool
+	IsAgent                         bool
+	AppName                         string
 
 	Gatherer   prometheus.Gatherer
 	Registerer prometheus.Registerer
@@ -355,7 +355,8 @@ func New(logger log.Logger, o *Options) *Handler {
 		o.Registerer,
 		nil,
 		o.EnableRemoteWriteReceiver,
-		o.RemoteWriteFormat,
+		o.RemoteWriteReceiverProtoTypes,
+		o.RemoteWriteReceiverCompressions,
 		o.EnableOTLPWriteReceiver,
 	)
 


### PR DESCRIPTION
TODO(bwplotka): 
* [ ] Agree if we want what's proposed in the new negotiation proposal https://docs.google.com/document/d/16ivhfAaaezNpB1OVs3p83-_ZZK-8uRgktqtcpYT2Sjc/edit
* [ ] Fix the sender part
* [ ] Consider util for "preference enum" flags
* [ ] Finish the receive part.
* [ ] Fix tests