### PR TITLE
Improving "Sparse postings" intersection

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -619,17 +619,19 @@ func (it *intersectPostings) At() storage.SeriesRef {
 
 func (it *intersectPostings) doNext() bool {
 	for {
-		foundNext := true
+		allEqual := true
 		for _, p := range it.arr {
 			if !p.Seek(it.cur) {
 				return false
 			}
 			if p.At() > it.cur {
 				it.cur = p.At()
-				foundNext = false
+				allEqual = false
 			}
 		}
-		if foundNext {
+
+		// if all p.At() are all equal, we found an intersection.
+		if allEqual {
 			return true
 		}
 	}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -620,14 +620,18 @@ func (it *intersectPostings) At() storage.SeriesRef {
 func (it *intersectPostings) doNext() bool {
 Loop:
 	for {
+		cont := false
 		for _, p := range it.arr {
 			if !p.Seek(it.cur) {
 				return false
 			}
 			if p.At() > it.cur {
 				it.cur = p.At()
-				continue Loop
+				cont = true
 			}
+		}
+		if cont {
+			continue Loop
 		}
 		return true
 	}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -618,22 +618,20 @@ func (it *intersectPostings) At() storage.SeriesRef {
 }
 
 func (it *intersectPostings) doNext() bool {
-Loop:
 	for {
-		cont := false
+		foundNext := true
 		for _, p := range it.arr {
 			if !p.Seek(it.cur) {
 				return false
 			}
 			if p.At() > it.cur {
 				it.cur = p.At()
-				cont = true
+				foundNext = false
 			}
 		}
-		if cont {
-			continue Loop
+		if foundNext {
+			return true
 		}
-		return true
 	}
 }
 

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -47,6 +47,7 @@ func BenchmarkQuerier(b *testing.B) {
 	}
 
 	for n := 0; n < 10; n++ {
+		addSeries(labels.FromStrings("a", strconv.Itoa(n)+postingsBenchSuffix))
 		for i := 0; i < 100000; i++ {
 			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", strconv.Itoa(n)+postingsBenchSuffix, "j", "foo"))
 			// Have some series that won't be matched, to properly test inverted matches.
@@ -101,7 +102,9 @@ func BenchmarkQuerier(b *testing.B) {
 func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	ctx := context.Background()
 
+	a1 := labels.MustNewMatcher(labels.MatchEqual, "a", "1"+postingsBenchSuffix)
 	n1 := labels.MustNewMatcher(labels.MatchEqual, "n", "1"+postingsBenchSuffix)
+	n0_1 := labels.MustNewMatcher(labels.MatchEqual, "n", "0_1"+postingsBenchSuffix)
 	nX := labels.MustNewMatcher(labels.MatchEqual, "n", "X"+postingsBenchSuffix)
 
 	jFoo := labels.MustNewMatcher(labels.MatchEqual, "j", "foo")
@@ -137,6 +140,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 		{`j="foo",n="1"`, []*labels.Matcher{jFoo, n1}},
 		{`n="1",j!="foo"`, []*labels.Matcher{n1, jNotFoo}},
 		{`n="1",i!="2"`, []*labels.Matcher{n1, iNot2}},
+		{`n="0_1",j="foo,a="1"`, []*labels.Matcher{n0_1, jFoo, a1}},
 		{`n="X",j!="foo"`, []*labels.Matcher{nX, jNotFoo}},
 		{`i=~"1[0-9]",j=~"foo|bar"`, []*labels.Matcher{iCharSet, jFooBar}},
 		{`j=~"foo|bar"`, []*labels.Matcher{jFooBar}},
@@ -176,8 +180,12 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := PostingsForMatchers(ctx, ir, c.matchers...)
+				p, err := PostingsForMatchers(ctx, ir, c.matchers...)
 				require.NoError(b, err)
+				// Iterate over the postings
+				for p.Next() {
+					// Do nothing
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Lets take the given example:

P1: [2, 5, 9, 18, 21]
P2: [3, 7, 14, 19, 21]
P3: [1, 21]

Currently, we would only advance through P1 and P2 until discovering an intersection and then checking P3. In essence, the traversal order was: 2, 3, 5, 7, 9, 14, 18, 19, 21 (intersection found).

With the proposed change, P3 is also examined even if P1 and P2 haven't found an intersection yet. This adjustment allows for the possibility of skipping some iterations.

Post-change, the traversal order becomes: 2, 3, 21 (3 iterations instead of 9).

To validate the improvement, benchmarks were adjusted to simulate this scenario. Additionally, calling next on the resulting postings demonstrates the benefits. In this extreme case, a significant 97% reduction in time is observed.

```

goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
                                                          │   /tmp/old    │              /tmp/new              │
                                                          │    sec/op     │   sec/op     vs base               │
Querier/Block/PostingsForMatchers/n="0_1",j="foo,a="1"-32   15815.1µ ± 7%   431.4µ ± 3%  -97.27% (p=0.002 n=6)

                                                          │  /tmp/old  │           /tmp/new            │
                                                          │    B/op    │    B/op     vs base           │
Querier/Block/PostingsForMatchers/n="0_1",j="foo,a="1"-32   336.0 ± 0%   336.0 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal

                                                          │  /tmp/old  │           /tmp/new            │
                                                          │ allocs/op  │ allocs/op   vs base           │
Querier/Block/PostingsForMatchers/n="0_1",j="foo,a="1"-32   13.00 ± 0%   13.00 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal
```

Ideally we could  sort the `arr []Postings` by size before iterating but, unfortunately,  the postings interface does not allow us to retrieve the underlining size.