### PR TITLE
promtool: Fix panic on extended tsdb analyze

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -838,6 +838,10 @@ func backfillOpenMetrics(path, outputDir string, humanReadable, quiet bool, maxB
 }
 
 func displayHistogram(dataType string, datas []int, total int) {
+	if len(datas) == 0 {
+		fmt.Printf("%s: N/A\n\n", dataType)
+		return
+	}
 	slices.Sort(datas)
 	start, end, step := generateBucket(datas[0], datas[len(datas)-1])
 	sum := 0


### PR DESCRIPTION
Currently, running `promtool tsdb analyze` with the `--extended` flag will cause an `index out of range` error if running it against a block that does not have any native histogram chunks.

This change ensures that promtool won't try to display data that doesn't exist.

**Before:**
```console
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.displayHistogram({0x35e1d4e, 0x1b}, {0xc001106818, 0x0, 0x0?}, 0x2d789dfe)
        /app/cmd/promtool/tsdb.go:843 +0x7b4
main.analyzeCompaction({0x3dfa870?, 0x59fcb80?}, {0x3dfdc80, 0xc000b969a0}, {0x3e0d680, 0xc00057b890}, {0x0?, 0x0?, 0x4?})
        /app/cmd/promtool/tsdb.go:702 +0x535
main.analyzeBlock({0x3dfa870, 0x59fcb80}, {0x7ffc357d0881?, 0x35a3b03?}, {0x7ffc357d0895?, 0xc0001ae7c8?}, 0x14, 0x1, {0x0, 0x0})
        /app/cmd/promtool/tsdb.go:607 +0x1b9b
main.main()
        /app/cmd/promtool/main.go:393 +0xba8a
```

**After:**
```console
bytes per float chunk (min/avg/max): 17/147/1016
[   1,  100]: 580469725 ############################################################################
[ 101,  200]:  25665765 ###
[ 201,  300]:  30682023 ####
[ 301,  400]:  28268299 ###
[ 401,  500]:  25762230 ###
[ 501,  600]:   6929461
[ 601,  700]:  22255472 ##
[ 701,  800]:  37438529 ####
[ 801,  900]:   3749296
[ 901, 1000]:   1654054
[1001, 1100]:      4632
[1101, 1200]:         0

samples per histogram chunk: N/A

bytes per histogram chunk: N/A

buckets per histogram chunk: N/A
```