### PR TITLE
Extended index reader

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -117,7 +117,15 @@ func (q *blockQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 	disableTrimming := false
 	sharded := hints != nil && hints.ShardCount > 0
 
-	p, err := PostingsForMatchers(ctx, q.index, ms...)
+	var p index.Postings
+	var err error
+
+	if i, ok := q.index.(ExtendedIndexReader); ok {
+		p, err = i.PostingsForMatchers(ctx, ms...)
+	} else {
+		p, err = PostingsForMatchers(ctx, q.index, ms...)
+	}
+
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}
@@ -166,7 +174,16 @@ func (q *blockChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *
 		maxt = hints.End
 		disableTrimming = hints.DisableTrimming
 	}
-	p, err := PostingsForMatchers(ctx, q.index, ms...)
+
+	var p index.Postings
+	var err error
+
+	if i, ok := q.index.(ExtendedIndexReader); ok {
+		p, err = i.PostingsForMatchers(ctx, ms...)
+	} else {
+		p, err = PostingsForMatchers(ctx, q.index, ms...)
+	}
+
 	if err != nil {
 		return storage.ErrChunkSeriesSet(err)
 	}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2432,7 +2432,7 @@ type mockExtendedIndex struct {
 func newMockExtendedIndex(err error) mockExtendedIndex {
 	return mockExtendedIndex{
 		mockIndex: newMockIndex(),
-		err: err,
+		err:       err,
 	}
 }
 


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR is adding a hook in index reader, such that we could return an index reader with custom PostingsForMatchers function. One great example is to have index reader with ability to cache postings for matchers.

Unit tests have been added.