### PR TITLE
Fix regression: Returning "null" for empty matrix results in some cases.

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1298,7 +1298,7 @@ func (ev *evaluator) rangeEvalAgg(aggExpr *parser.AggregateExpr, sortedGrouping 
 	buf := make([]byte, 0, 1024)
 	groupToResultIndex := make(map[uint64]int)
 	seriesToResult := make([]int, len(inputMatrix))
-	var result Matrix
+	result := Matrix{}
 
 	groupCount := 0
 	for si, series := range inputMatrix {
@@ -1331,7 +1331,7 @@ func (ev *evaluator) rangeEvalAgg(aggExpr *parser.AggregateExpr, sortedGrouping 
 			k = len(inputMatrix)
 		}
 		if k < 1 {
-			return nil, warnings
+			return Matrix{}, warnings
 		}
 		seriess = make(map[uint64]Series, len(inputMatrix)) // Output series by series hash.
 	case parser.QUANTILE:
@@ -2983,7 +2983,7 @@ func (ev *evaluator) aggregationK(e *parser.AggregateExpr, k int, inputMatrix Ma
 
 	// Construct the result from the aggregated groups.
 	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
-	var mat Matrix
+	mat := Matrix{}
 	if ev.endTimestamp == ev.startTimestamp {
 		mat = make(Matrix, 0, len(groups))
 	}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1171,6 +1171,21 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 				},
 			},
 		},
+		// Test empty matrix result
+		{
+			endpoint: api.queryRange,
+			query: url.Values{
+				"query": []string{"bottomk(2, notExists)"},
+				"start": []string{"0"},
+				"end":   []string{"2"},
+				"step":  []string{"1"},
+			},
+			response: &QueryData{
+				ResultType: parser.ValueTypeMatrix,
+				Result:     promql.Matrix{},
+			},
+			responseAsJSON: `{"resultType":"matrix","result":[]}`,
+		},
 		// Missing query params in range queries.
 		{
 			endpoint: api.queryRange,


### PR DESCRIPTION
Seems like https://github.com/prometheus/prometheus/commit/2f03acbafc08dd83cc8a5c3d94b2f071bb34f809 introduced a regression where we before returned `[]` form empty results and we are returning`null` on the serialized response:

To reproduce we can run a simple range query with bottomK and a metric that does no exists (ex: `bottomk(2, doNotExists)`: 
Before:

```
{"resultType":"matrix","result":[]}
```

After the change:

```
{"resultType":"matrix","result":null}
```

This is problematic as the prometheus client cannot deserialize this result (screenshot attached). we found the issue when updating prometheus on cortex and the fuzzy tests started to fail. 

https://github.com/cortexproject/cortex/actions/runs/8826947786/job/24233899882

![Screenshot 2024-04-25 at 11 57 24 AM](https://github.com/prometheus/prometheus/assets/4027760/dbdadfeb-c21f-4bff-be2a-665957709e7d)

Im not sure if this is the right fix but im creating the issue anyway to highlight the issue.


cc @bboreham 
