### PR TITLE
configuration: Implement IsZero for relabel.Regex to remove default regex

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -111,6 +111,15 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return c.Validate()
 }
 
+// MarshalYAML implements the yaml.Marshaler interface.
+func (c Config) MarshalYAML() (interface{}, error) {
+	// Omit the regex if it is the default regex as it was not provided in the first place.
+	if c.Regex == DefaultRelabelConfig.Regex {
+		c.Regex.Regexp = nil
+	}
+	return c, nil
+}
+
 func (c *Config) Validate() error {
 	if c.Action == "" {
 		return fmt.Errorf("relabel action cannot be empty")

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -111,15 +111,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return c.Validate()
 }
 
-// MarshalYAML implements the yaml.Marshaler interface.
-func (c Config) MarshalYAML() (interface{}, error) {
-	// Omit the regex if it is the default regex as it was not provided in the first place.
-	if c.Regex == DefaultRelabelConfig.Regex {
-		c.Regex.Regexp = nil
-	}
-	return c, nil
-}
-
 func (c *Config) Validate() error {
 	if c.Action == "" {
 		return fmt.Errorf("relabel action cannot be empty")
@@ -212,6 +203,11 @@ func (re Regexp) MarshalYAML() (interface{}, error) {
 		return re.String(), nil
 	}
 	return nil, nil
+}
+
+// IsZero implements the yaml.IsZeroer interface.
+func (re Regexp) IsZero() bool {
+	return re.Regexp == DefaultRelabelConfig.Regex.Regexp
 }
 
 // String returns the original string used to compile the regular expression.

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -851,3 +851,42 @@ func BenchmarkRelabel(b *testing.B) {
 		})
 	}
 }
+
+func TestConfig_UnmarshalThenMarshal(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputYaml string
+	}{
+		{
+			name: "Values provided",
+			inputYaml: `source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+separator: ;
+regex: \\d+
+target_label: __meta_kubernetes_pod_container_port_number
+replacement: $1
+action: replace
+`,
+		},
+		{
+			name: "No regex provided",
+			inputYaml: `source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+separator: ;
+target_label: __meta_kubernetes_pod_container_port_number
+replacement: $1
+action: keepequal
+`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			unmarshalled := Config{}
+			err := yaml.Unmarshal([]byte(test.inputYaml), &unmarshalled)
+			require.NoError(t, err)
+
+			marshalled, err := yaml.Marshal(&unmarshalled)
+			require.NoError(t, err)
+
+			require.Equal(t, test.inputYaml, string(marshalled))
+		})
+	}
+}

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -876,6 +876,16 @@ replacement: $1
 action: keepequal
 `,
 		},
+		{
+			name: "Default regex provided",
+			inputYaml: `source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+separator: ;
+regex: (.*)
+target_label: __meta_kubernetes_pod_container_port_number
+replacement: $1
+action: replace
+`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #12534

Currently, when unmarshalling some relabel config from YAML, if the regex field is not provided we set this to be equal to the default value. If we then want to marshal this config back in to YAML, it will generate the YAML with the regex field set equal to the default YAML value, meaning that unmarshalling and then marshalling again doesn't give the same output as the original input. For the `keepequal` and `dropequal` actions we expect that no `regex` field is set and therefore an error is returned if we try to unmarshal, then marshal and again unmarshal one of these actions, because the `regex` field will be set on the marshal step. By implementing the MarshalYAML function and ensuring the `regex` field is not set if it was not provided originally, we fix this bug.