### PR TITLE
OTLP: Use PrometheusConverter directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [CHANGE] TSDB: Fix the predicate checking for blocks which are beyond the retention period to include the ones right at the retention boundary. #9633
 * [ENHANCEMENT] Rules: Add `rule_group_last_restore_duration_seconds` to measure the time it takes to restore a rule group. #13974
+* [ENHANCEMENT] OTLP: Improve remote write format translation performance by using label set hashes for metric identifiers instead of string based ones. #14006 #13991
 
 ## 2.51.2 / 2024-04-09
 

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper.go
@@ -219,7 +219,7 @@ func isValidAggregationTemporality(metric pmetric.Metric) bool {
 	return false
 }
 
-func (c *prometheusConverter) addHistogramDataPoints(dataPoints pmetric.HistogramDataPointSlice,
+func (c *PrometheusConverter) addHistogramDataPoints(dataPoints pmetric.HistogramDataPointSlice,
 	resource pcommon.Resource, settings Settings, baseName string) {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
@@ -395,7 +395,7 @@ func mostRecentTimestampInMetric(metric pmetric.Metric) pcommon.Timestamp {
 	return ts
 }
 
-func (c *prometheusConverter) addSummaryDataPoints(dataPoints pmetric.SummaryDataPointSlice, resource pcommon.Resource,
+func (c *PrometheusConverter) addSummaryDataPoints(dataPoints pmetric.SummaryDataPointSlice, resource pcommon.Resource,
 	settings Settings, baseName string) {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
@@ -468,7 +468,7 @@ func createLabels(name string, baseLabels []prompb.Label, extras ...string) []pr
 
 // getOrCreateTimeSeries returns the time series corresponding to the label set if existent, and false.
 // Otherwise it creates a new one and returns that, and true.
-func (c *prometheusConverter) getOrCreateTimeSeries(lbls []prompb.Label) (*prompb.TimeSeries, bool) {
+func (c *PrometheusConverter) getOrCreateTimeSeries(lbls []prompb.Label) (*prompb.TimeSeries, bool) {
 	h := timeSeriesSignature(lbls)
 	ts := c.unique[h]
 	if ts != nil {
@@ -504,7 +504,7 @@ func (c *prometheusConverter) getOrCreateTimeSeries(lbls []prompb.Label) (*promp
 // addTimeSeriesIfNeeded adds a corresponding time series if it doesn't already exist.
 // If the time series doesn't already exist, it gets added with startTimestamp for its value and timestamp for its timestamp,
 // both converted to milliseconds.
-func (c *prometheusConverter) addTimeSeriesIfNeeded(lbls []prompb.Label, startTimestamp pcommon.Timestamp, timestamp pcommon.Timestamp) {
+func (c *PrometheusConverter) addTimeSeriesIfNeeded(lbls []prompb.Label, startTimestamp pcommon.Timestamp, timestamp pcommon.Timestamp) {
 	ts, created := c.getOrCreateTimeSeries(lbls)
 	if created {
 		ts.Samples = []prompb.Sample{
@@ -518,7 +518,7 @@ func (c *prometheusConverter) addTimeSeriesIfNeeded(lbls []prompb.Label, startTi
 }
 
 // addResourceTargetInfo converts the resource to the target info metric.
-func addResourceTargetInfo(resource pcommon.Resource, settings Settings, timestamp pcommon.Timestamp, converter *prometheusConverter) {
+func addResourceTargetInfo(resource pcommon.Resource, settings Settings, timestamp pcommon.Timestamp, converter *PrometheusConverter) {
 	if settings.DisableTargetInfo || timestamp == 0 {
 		return
 	}

--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
@@ -30,7 +30,7 @@ import (
 
 const defaultZeroThreshold = 1e-128
 
-func (c *prometheusConverter) addExponentialHistogramDataPoints(dataPoints pmetric.ExponentialHistogramDataPointSlice,
+func (c *PrometheusConverter) addExponentialHistogramDataPoints(dataPoints pmetric.ExponentialHistogramDataPointSlice,
 	resource pcommon.Resource, settings Settings, baseName string) error {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -39,34 +38,21 @@ type Settings struct {
 	SendMetadata        bool
 }
 
-// FromMetrics converts pmetric.Metrics to Prometheus remote write format.
-func FromMetrics(md pmetric.Metrics, settings Settings) (map[string]*prompb.TimeSeries, error) {
-	c := newPrometheusConverter()
-	errs := c.fromMetrics(md, settings)
-	tss := c.timeSeries()
-	out := make(map[string]*prompb.TimeSeries, len(tss))
-	for i := range tss {
-		out[strconv.Itoa(i)] = &tss[i]
-	}
-
-	return out, errs
-}
-
-// prometheusConverter converts from OTel write format to Prometheus write format.
-type prometheusConverter struct {
+// PrometheusConverter converts from OTel write format to Prometheus write format.
+type PrometheusConverter struct {
 	unique    map[uint64]*prompb.TimeSeries
 	conflicts map[uint64][]*prompb.TimeSeries
 }
 
-func newPrometheusConverter() *prometheusConverter {
-	return &prometheusConverter{
+func NewPrometheusConverter() *PrometheusConverter {
+	return &PrometheusConverter{
 		unique:    map[uint64]*prompb.TimeSeries{},
 		conflicts: map[uint64][]*prompb.TimeSeries{},
 	}
 }
 
-// fromMetrics converts pmetric.Metrics to Prometheus remote write format.
-func (c *prometheusConverter) fromMetrics(md pmetric.Metrics, settings Settings) (errs error) {
+// FromMetrics converts pmetric.Metrics to Prometheus remote write format.
+func (c *PrometheusConverter) FromMetrics(md pmetric.Metrics, settings Settings) (errs error) {
 	resourceMetricsSlice := md.ResourceMetrics()
 	for i := 0; i < resourceMetricsSlice.Len(); i++ {
 		resourceMetrics := resourceMetricsSlice.At(i)
@@ -144,8 +130,8 @@ func (c *prometheusConverter) fromMetrics(md pmetric.Metrics, settings Settings)
 	return
 }
 
-// timeSeries returns a slice of the prompb.TimeSeries that were converted from OTel format.
-func (c *prometheusConverter) timeSeries() []prompb.TimeSeries {
+// TimeSeries returns a slice of the prompb.TimeSeries that were converted from OTel format.
+func (c *PrometheusConverter) TimeSeries() []prompb.TimeSeries {
 	conflicts := 0
 	for _, ts := range c.conflicts {
 		conflicts += len(ts)
@@ -177,7 +163,7 @@ func isSameMetric(ts *prompb.TimeSeries, lbls []prompb.Label) bool {
 
 // addExemplars adds exemplars for the dataPoint. For each exemplar, if it can find a bucket bound corresponding to its value,
 // the exemplar is added to the bucket bound's time series, provided that the time series' has samples.
-func (c *prometheusConverter) addExemplars(dataPoint pmetric.HistogramDataPoint, bucketBounds []bucketBoundsData) {
+func (c *PrometheusConverter) addExemplars(dataPoint pmetric.HistogramDataPoint, bucketBounds []bucketBoundsData) {
 	if len(bucketBounds) == 0 {
 		return
 	}
@@ -202,7 +188,7 @@ func (c *prometheusConverter) addExemplars(dataPoint pmetric.HistogramDataPoint,
 // If there is no corresponding TimeSeries already, it's created.
 // The corresponding TimeSeries is returned.
 // If either lbls is nil/empty or sample is nil, nothing is done.
-func (c *prometheusConverter) addSample(sample *prompb.Sample, lbls []prompb.Label) *prompb.TimeSeries {
+func (c *PrometheusConverter) addSample(sample *prompb.Sample, lbls []prompb.Label) *prompb.TimeSeries {
 	if sample == nil || len(lbls) == 0 {
 		// This shouldn't happen
 		return nil

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -1,0 +1,134 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Provenance-includes-location: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/95e8f8fdc2a9dc87230406c9a3cf02be4fd68bea/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: Copyright The OpenTelemetry Authors.
+
+package prometheusremotewrite
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+)
+
+func BenchmarkPrometheusConverter_FromMetrics(b *testing.B) {
+	for _, resourceAttributeCount := range []int{0, 5, 50} {
+		b.Run(fmt.Sprintf("resource attribute count: %v", resourceAttributeCount), func(b *testing.B) {
+			for _, histogramCount := range []int{0, 1000} {
+				b.Run(fmt.Sprintf("histogram count: %v", histogramCount), func(b *testing.B) {
+					nonHistogramCounts := []int{0, 1000}
+
+					if resourceAttributeCount == 0 && histogramCount == 0 {
+						// Don't bother running a scenario where we'll generate no series.
+						nonHistogramCounts = []int{1000}
+					}
+
+					for _, nonHistogramCount := range nonHistogramCounts {
+						b.Run(fmt.Sprintf("non-histogram count: %v", nonHistogramCount), func(b *testing.B) {
+							for _, labelsPerMetric := range []int{2, 20} {
+								b.Run(fmt.Sprintf("labels per metric: %v", labelsPerMetric), func(b *testing.B) {
+									for _, exemplarsPerSeries := range []int{0, 5, 10} {
+										b.Run(fmt.Sprintf("exemplars per series: %v", exemplarsPerSeries), func(b *testing.B) {
+											payload := createExportRequest(resourceAttributeCount, histogramCount, nonHistogramCount, labelsPerMetric, exemplarsPerSeries)
+
+											for i := 0; i < b.N; i++ {
+												converter := NewPrometheusConverter()
+												require.NoError(b, converter.FromMetrics(payload.Metrics(), Settings{}))
+												require.NotNil(b, converter.TimeSeries())
+											}
+										})
+									}
+								})
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func createExportRequest(resourceAttributeCount int, histogramCount int, nonHistogramCount int, labelsPerMetric int, exemplarsPerSeries int) pmetricotlp.ExportRequest {
+	request := pmetricotlp.NewExportRequest()
+
+	rm := request.Metrics().ResourceMetrics().AppendEmpty()
+	generateAttributes(rm.Resource().Attributes(), "resource", resourceAttributeCount)
+
+	metrics := rm.ScopeMetrics().AppendEmpty().Metrics()
+	ts := pcommon.NewTimestampFromTime(time.Now())
+
+	for i := 1; i <= histogramCount; i++ {
+		m := metrics.AppendEmpty()
+		m.SetEmptyHistogram()
+		m.SetName(fmt.Sprintf("histogram-%v", i))
+		m.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		h := m.Histogram().DataPoints().AppendEmpty()
+		h.SetTimestamp(ts)
+
+		// Set 50 samples, 10 each with values 0.5, 1, 2, 4, and 8
+		h.SetCount(50)
+		h.SetSum(155)
+		h.BucketCounts().FromRaw([]uint64{10, 10, 10, 10, 10, 0})
+		h.ExplicitBounds().FromRaw([]float64{.5, 1, 2, 4, 8, 16}) // Bucket boundaries include the upper limit (ie. each sample is on the upper limit of its bucket)
+
+		generateAttributes(h.Attributes(), "series", labelsPerMetric)
+		generateExemplars(h.Exemplars(), exemplarsPerSeries, ts)
+	}
+
+	for i := 1; i <= nonHistogramCount; i++ {
+		m := metrics.AppendEmpty()
+		m.SetEmptySum()
+		m.SetName(fmt.Sprintf("sum-%v", i))
+		m.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		point := m.Sum().DataPoints().AppendEmpty()
+		point.SetTimestamp(ts)
+		point.SetDoubleValue(1.23)
+		generateAttributes(point.Attributes(), "series", labelsPerMetric)
+		generateExemplars(point.Exemplars(), exemplarsPerSeries, ts)
+	}
+
+	for i := 1; i <= nonHistogramCount; i++ {
+		m := metrics.AppendEmpty()
+		m.SetEmptyGauge()
+		m.SetName(fmt.Sprintf("gauge-%v", i))
+		point := m.Gauge().DataPoints().AppendEmpty()
+		point.SetTimestamp(ts)
+		point.SetDoubleValue(1.23)
+		generateAttributes(point.Attributes(), "series", labelsPerMetric)
+		generateExemplars(point.Exemplars(), exemplarsPerSeries, ts)
+	}
+
+	return request
+}
+
+func generateAttributes(m pcommon.Map, prefix string, count int) {
+	for i := 1; i <= count; i++ {
+		m.PutStr(fmt.Sprintf("%v-name-%v", prefix, i), fmt.Sprintf("value-%v", i))
+	}
+}
+
+func generateExemplars(exemplars pmetric.ExemplarSlice, count int, ts pcommon.Timestamp) {
+	for i := 1; i <= count; i++ {
+		e := exemplars.AppendEmpty()
+		e.SetTimestamp(ts)
+		e.SetDoubleValue(2.22)
+		e.SetSpanID(pcommon.SpanID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08})
+		e.SetTraceID(pcommon.TraceID{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f})
+	}
+}

--- a/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
@@ -27,7 +27,7 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 )
 
-func (c *prometheusConverter) addGaugeNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
+func (c *PrometheusConverter) addGaugeNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
 	resource pcommon.Resource, settings Settings, name string) {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
@@ -57,7 +57,7 @@ func (c *prometheusConverter) addGaugeNumberDataPoints(dataPoints pmetric.Number
 	}
 }
 
-func (c *prometheusConverter) addSumNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
+func (c *PrometheusConverter) addSumNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
 	resource pcommon.Resource, metric pmetric.Metric, settings Settings, name string) {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)


### PR DESCRIPTION
Optimize by using `prometheusremotewrite.PrometheusConverter` directly in the OTLP endpoint handler, instead of going via the wrapping `prometheusremotewrite.FromMetrics` function. Follow-up to #13991.

Also add benchmark for `PrometheusConverter.FromMetrics`.

#### Benchmarks

<details>
<summary>Benchmark stats vs main branch</summary>

```console
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite
                                                                                                                                           │ frommetrics.txt │ prometheusconverter-frommetrics.txt │
                                                                                                                                           │     sec/op      │    sec/op     vs base               │
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12            1.802m ±  4%   1.672m ±  3%   -7.21% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12            3.195m ±  3%   3.074m ±  1%   -3.79% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12           4.305m ±  2%   4.152m ± 10%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12           10.56m ±  1%   10.55m ±  2%        ~ (p=0.818 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12           12.17m ±  3%   12.13m ±  1%        ~ (p=0.589 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12          13.38m ±  3%   13.19m ±  1%        ~ (p=0.093 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12            5.859m ±  1%   5.398m ±  2%   -7.86% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12            7.857m ±  4%   7.623m ± 11%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12           9.181m ± 12%   8.843m ±  1%   -3.68% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12           18.33m ±  1%   18.12m ±  4%        ~ (p=0.394 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12           20.30m ±  1%   19.90m ±  1%   -1.96% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12          21.75m ±  2%   21.90m ±  3%        ~ (p=0.485 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12         7.368m ±  3%   6.865m ±  3%   -6.83% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12         10.34m ±  6%   10.26m ±  3%        ~ (p=0.394 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12        13.08m ±  2%   12.88m ±  1%   -1.55% (p=0.015 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12        29.72m ±  3%   29.21m ±  4%   -1.73% (p=0.026 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12        32.54m ±  1%   32.48m ±  3%        ~ (p=0.818 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12       35.45m ±  4%   34.95m ±  8%        ~ (p=0.699 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12               341.0n ±  0%   299.5n ±  1%  -12.18% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12               342.6n ±  1%   301.8n ±  1%  -11.91% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12              342.8n ±  3%   299.9n ±  6%  -12.53% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12              343.4n ±  3%   297.2n ±  2%  -13.45% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12              344.5n ±  4%   302.1n ±  5%  -12.31% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12             349.0n ±  4%   299.9n ±  1%  -14.07% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12            1.873m ±  2%   1.705m ±  1%   -8.98% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12            3.231m ±  5%   3.094m ±  2%   -4.25% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12           4.331m ±  7%   4.201m ±  6%   -2.99% (p=0.041 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12           10.84m ±  6%   10.59m ±  7%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12           12.25m ±  6%   12.39m ±  3%        ~ (p=0.818 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12          13.28m ±  0%   13.29m ±  2%        ~ (p=1.000 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12            6.042m ±  5%   5.409m ±  2%  -10.47% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12            7.824m ±  1%   7.418m ± 10%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12           9.432m ± 12%   8.988m ± 18%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12           20.09m ± 12%   18.80m ±  5%   -6.42% (p=0.026 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12           22.13m ±  6%   20.25m ±  3%   -8.49% (p=0.004 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12          23.64m ±  4%   21.90m ±  8%   -7.36% (p=0.015 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12         7.860m ±  3%   6.827m ±  2%  -13.15% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12        10.512m ±  5%   9.817m ±  1%   -6.61% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12        13.66m ±  6%   12.79m ±  6%   -6.37% (p=0.009 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12        29.11m ±  4%   28.72m ±  8%        ~ (p=0.240 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12        32.58m ±  3%   31.80m ±  2%   -2.39% (p=0.041 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12       35.14m ±  4%   34.43m ±  1%   -2.02% (p=0.026 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12              341.5n ±  1%   300.2n ±  1%  -12.08% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12              339.0n ±  2%   300.2n ±  1%  -11.43% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12             341.5n ±  1%   300.8n ±  6%  -11.95% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12             342.8n ±  2%   299.2n ±  1%  -12.69% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12             343.1n ± 18%   300.2n ±  1%  -12.48% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12            342.6n ±  1%   302.1n ±  4%  -11.84% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12           1.925m ±  3%   1.835m ±  4%   -4.66% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12           3.283m ±  5%   3.304m ±  7%        ~ (p=0.937 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12          4.385m ±  5%   4.367m ± 10%        ~ (p=0.818 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12          10.83m ±  1%   10.99m ±  5%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12          12.35m ±  3%   12.16m ±  2%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12         13.71m ± 16%   13.33m ±  1%   -2.83% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12           5.990m ±  3%   5.463m ±  1%   -8.80% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12           8.023m ±  5%   7.482m ±  1%   -6.75% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12          9.542m ±  7%   8.779m ±  3%   -7.99% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12          19.22m ±  6%   18.11m ±  2%   -5.81% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12          21.80m ± 15%   20.04m ±  6%   -8.09% (p=0.009 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12         24.08m ± 12%   21.36m ±  9%  -11.28% (p=0.026 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12        7.682m ± 32%   6.980m ±  3%   -9.14% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12        10.69m ±  3%   10.26m ±  5%   -3.96% (p=0.026 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12       13.89m ± 10%   13.41m ±  4%        ~ (p=0.310 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12       29.62m ±  2%   28.89m ±  1%   -2.45% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12       34.73m ± 10%   32.56m ±  2%   -6.25% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12      36.32m ±  7%   36.00m ±  4%        ~ (p=0.310 n=6)
geomean                                                                                                                                         1.689m         1.593m         -5.70%

                                                                                                                                           │ frommetrics.txt │   prometheusconverter-frommetrics.txt    │
                                                                                                                                           │      B/op       │     B/op      vs base                    │
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12            1.499Mi ± 0%   1.383Mi ± 0%    -7.75% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12            3.611Mi ± 0%   3.495Mi ± 0%    -3.22% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12           5.730Mi ± 0%   5.612Mi ± 0%    -2.04% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12           7.022Mi ± 0%   6.905Mi ± 0%    -1.66% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12           9.161Mi ± 0%   9.042Mi ± 0%    -1.30% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12          11.30Mi ± 0%   11.19Mi ± 0%    -1.01% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12            6.825Mi ± 0%   6.354Mi ± 0%    -6.90% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12            9.695Mi ± 0%   9.223Mi ± 0%    -4.86% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12           12.67Mi ± 0%   12.20Mi ± 0%    -3.73% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12           20.52Mi ± 0%   20.05Mi ± 0%    -2.30% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12           23.41Mi ± 0%   22.93Mi ± 0%    -2.02% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12          26.39Mi ± 0%   25.92Mi ± 0%    -1.79% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12         8.062Mi ± 0%   7.574Mi ± 0%    -6.05% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12         13.06Mi ± 0%   12.57Mi ± 0%    -3.73% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12        18.18Mi ± 0%   17.69Mi ± 0%    -2.69% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12        27.42Mi ± 0%   26.93Mi ± 0%    -1.79% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12        32.50Mi ± 0%   32.02Mi ± 0%    -1.50% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12       37.72Mi ± 0%   37.24Mi ± 0%    -1.27% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                 48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                 48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12                48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12               48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12            1.499Mi ± 0%   1.383Mi ± 0%    -7.75% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12            3.612Mi ± 0%   3.496Mi ± 0%    -3.22% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12           5.730Mi ± 0%   5.613Mi ± 0%    -2.04% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12           7.024Mi ± 0%   6.906Mi ± 0%    -1.68% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12           9.161Mi ± 0%   9.044Mi ± 0%    -1.27% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12          11.30Mi ± 0%   11.19Mi ± 0%    -1.03% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12            6.826Mi ± 0%   6.355Mi ± 0%    -6.90% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12            9.695Mi ± 0%   9.224Mi ± 0%    -4.86% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12           12.67Mi ± 0%   12.20Mi ± 0%    -3.73% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12           20.52Mi ± 0%   20.05Mi ± 0%    -2.31% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12           23.41Mi ± 0%   22.94Mi ± 0%    -2.03% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12          26.40Mi ± 0%   25.93Mi ± 0%    -1.80% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12         8.063Mi ± 0%   7.574Mi ± 0%    -6.06% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12         13.06Mi ± 0%   12.57Mi ± 0%    -3.75% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12        18.19Mi ± 0%   17.69Mi ± 0%    -2.71% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12        27.41Mi ± 0%   26.93Mi ± 0%    -1.78% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12        32.50Mi ± 0%   32.01Mi ± 0%    -1.53% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12       37.73Mi ± 0%   37.23Mi ± 0%    -1.33% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12               48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12               48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12               48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12              48.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12           1.506Mi ± 0%   1.390Mi ± 0%    -7.71% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12           3.619Mi ± 0%   3.503Mi ± 0%    -3.21% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12          5.737Mi ± 0%   5.621Mi ± 0%    -2.02% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12          7.030Mi ± 0%   6.916Mi ± 0%    -1.62% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12          9.168Mi ± 0%   9.052Mi ± 0%    -1.27% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12         11.31Mi ± 0%   11.20Mi ± 0%    -1.04% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12           6.832Mi ± 0%   6.361Mi ± 0%    -6.90% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12           9.702Mi ± 0%   9.230Mi ± 0%    -4.86% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12          12.67Mi ± 0%   12.20Mi ± 0%    -3.73% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12          20.53Mi ± 0%   20.05Mi ± 0%    -2.32% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12          23.42Mi ± 0%   22.94Mi ± 0%    -2.03% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12         26.41Mi ± 0%   25.93Mi ± 0%    -1.83% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12        8.069Mi ± 0%   7.581Mi ± 0%    -6.05% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12        13.07Mi ± 0%   12.58Mi ± 0%    -3.74% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12       18.19Mi ± 0%   17.70Mi ± 0%    -2.70% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12       27.43Mi ± 0%   26.93Mi ± 0%    -1.82% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12       32.54Mi ± 0%   32.02Mi ± 0%    -1.60% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12      37.74Mi ± 0%   37.25Mi ± 0%    -1.31% (p=0.002 n=6)
geomean                                                                                                                                         1.212Mi                      ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                                                                                                                                           │ frommetrics.txt │   prometheusconverter-frommetrics.txt   │
                                                                                                                                           │    allocs/op    │  allocs/op   vs base                    │
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12             20.02k ± 0%   18.11k ± 0%    -9.52% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12             52.11k ± 0%   50.20k ± 0%    -3.66% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12            82.20k ± 0%   80.29k ± 0%    -2.33% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12            60.09k ± 0%   58.19k ± 0%    -3.17% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12            92.54k ± 0%   90.61k ± 0%    -2.10% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12           122.8k ± 0%   121.0k ± 0%    -1.53% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12             72.21k ± 0%   63.30k ± 0%   -12.34% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12            108.30k ± 0%   99.40k ± 0%    -8.22% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12            139.4k ± 0%   130.5k ± 0%    -6.40% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12            92.78k ± 0%   83.88k ± 0%    -9.59% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12            129.1k ± 0%   120.1k ± 0%    -6.96% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12           160.3k ± 0%   151.4k ± 0%    -5.56% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12          92.53k ± 0%   81.56k ± 0%   -11.85% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12          160.9k ± 0%   150.0k ± 0%    -6.80% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12         222.3k ± 0%   211.3k ± 0%    -4.93% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12         157.2k ± 0%   146.1k ± 0%    -7.02% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12         226.4k ± 0%   215.5k ± 0%    -4.83% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12        288.7k ± 0%   278.0k ± 0%    -3.74% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                 1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                 1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12                1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12               1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12             20.03k ± 0%   18.12k ± 0%    -9.53% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12             52.12k ± 0%   50.21k ± 0%    -3.66% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12            82.21k ± 0%   80.30k ± 0%    -2.33% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12            60.15k ± 0%   58.21k ± 0%    -3.23% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12            92.56k ± 0%   90.65k ± 0%    -2.07% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12           122.9k ± 0%   121.0k ± 0%    -1.56% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12             72.22k ± 0%   63.31k ± 0%   -12.34% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12            108.31k ± 0%   99.40k ± 0%    -8.23% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12            139.4k ± 0%   130.5k ± 0%    -6.40% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12            92.89k ± 0%   83.90k ± 0%    -9.67% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12            129.2k ± 0%   120.3k ± 0%    -6.94% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12           160.5k ± 0%   151.5k ± 0%    -5.59% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12          92.56k ± 0%   81.56k ± 0%   -11.89% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12          160.9k ± 0%   149.9k ± 0%    -6.83% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12         222.3k ± 0%   211.3k ± 0%    -4.95% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12         156.9k ± 0%   145.9k ± 0%    -6.97% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12         226.4k ± 0%   215.2k ± 0%    -4.93% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12        289.1k ± 0%   277.8k ± 0%    -3.89% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12               1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12               1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12               1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12              1.000 ± 0%    0.000 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12            20.07k ± 0%   18.17k ± 0%    -9.49% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12            52.17k ± 0%   50.26k ± 0%    -3.65% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12           82.26k ± 0%   80.36k ± 0%    -2.31% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12           60.19k ± 0%   58.34k ± 0%    -3.08% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12           92.61k ± 0%   90.70k ± 0%    -2.07% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12          123.0k ± 0%   121.1k ± 0%    -1.58% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12            72.27k ± 0%   63.36k ± 0%   -12.33% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12           108.37k ± 0%   99.45k ± 0%    -8.23% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12           139.5k ± 0%   130.5k ± 0%    -6.40% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12           92.93k ± 0%   83.89k ± 0%    -9.73% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12           129.3k ± 1%   120.2k ± 0%    -6.98% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12          160.6k ± 0%   151.5k ± 0%    -5.67% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12         92.59k ± 0%   81.62k ± 0%   -11.85% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12         161.0k ± 0%   150.0k ± 0%    -6.81% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12        222.4k ± 0%   211.4k ± 0%    -4.94% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12        157.3k ± 0%   146.0k ± 0%    -7.19% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12        227.3k ± 0%   215.5k ± 0%    -5.16% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12       289.1k ± 0%   278.0k ± 0%    -3.84% (p=0.002 n=6)
geomean                                                                                                                                          13.16k                     ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```
</details>

<details>
<summary>Benchmark stats vs string based metric identifiers</summary>

```console
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite
                                                                                                                                           │ old-frommetrics.txt │ prometheusconverter-frommetrics.txt │
                                                                                                                                           │       sec/op        │    sec/op     vs base               │
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12                 1.886m ± 6%   1.672m ±  3%  -11.32% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12                 3.332m ± 8%   3.074m ±  1%   -7.74% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12                4.399m ± 2%   4.152m ± 10%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12                11.56m ± 1%   10.55m ±  2%   -8.77% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12                12.95m ± 0%   12.13m ±  1%   -6.35% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12               14.07m ± 1%   13.19m ±  1%   -6.28% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                 6.057m ± 1%   5.398m ±  2%  -10.87% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                 8.399m ± 1%   7.623m ± 11%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12               10.077m ± 1%   8.843m ±  1%  -12.24% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                20.02m ± 0%   18.12m ±  4%   -9.46% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                22.47m ± 1%   19.90m ±  1%  -11.45% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12               24.31m ± 1%   21.90m ±  3%   -9.92% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12              7.489m ± 3%   6.865m ±  3%   -8.33% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12              11.04m ± 3%   10.26m ±  3%   -7.10% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12             13.59m ± 6%   12.88m ±  1%   -5.21% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12             30.99m ± 6%   29.21m ±  4%   -5.77% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12             34.67m ± 2%   32.48m ±  3%   -6.33% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12            37.45m ± 2%   34.95m ±  8%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                   1515.0n ± 2%   299.5n ±  1%  -80.23% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                   1512.0n ± 0%   301.8n ±  1%  -80.04% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12                  1517.0n ± 2%   299.9n ±  6%  -80.23% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                  1514.5n ± 1%   297.2n ±  2%  -80.37% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                  1514.5n ± 2%   302.1n ±  5%  -80.05% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12                 1522.0n ± 3%   299.9n ±  1%  -80.30% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12                 1.926m ± 1%   1.705m ±  1%  -11.46% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12                 3.363m ± 1%   3.094m ±  2%   -8.01% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12                4.443m ± 1%   4.201m ±  6%   -5.44% (p=0.004 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12                11.69m ± 1%   10.59m ±  7%   -9.42% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12                13.09m ± 3%   12.39m ±  3%   -5.34% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12               14.11m ± 0%   13.29m ±  2%   -5.79% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                 6.083m ± 1%   5.409m ±  2%  -11.07% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                 8.398m ± 8%   7.418m ± 10%  -11.67% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12               10.106m ± 1%   8.988m ± 18%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                19.98m ± 1%   18.80m ±  5%   -5.90% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                22.38m ± 1%   20.25m ±  3%   -9.52% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12               24.24m ± 1%   21.90m ±  8%   -9.66% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12              7.539m ± 0%   6.827m ±  2%   -9.45% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12             10.887m ± 0%   9.817m ±  1%   -9.82% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12             13.59m ± 4%   12.79m ±  6%   -5.89% (p=0.004 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12             30.53m ± 3%   28.72m ±  8%   -5.92% (p=0.041 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12             34.32m ± 0%   31.80m ±  2%   -7.32% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12            37.13m ± 0%   34.43m ±  1%   -7.28% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                 13379.0n ± 0%   300.2n ±  1%  -97.76% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                 13363.5n ± 0%   300.2n ±  1%  -97.75% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12                13332.5n ± 0%   300.8n ±  6%  -97.74% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                13312.0n ± 1%   299.2n ±  1%  -97.75% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                13327.0n ± 0%   300.2n ±  1%  -97.75% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12               13323.5n ± 0%   302.1n ±  4%  -97.73% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12                2.033m ± 0%   1.835m ±  4%   -9.76% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12                3.506m ± 0%   3.304m ±  7%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12               4.542m ± 1%   4.367m ± 10%        ~ (p=0.065 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12               11.70m ± 0%   10.99m ±  5%   -6.03% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12               13.02m ± 1%   12.16m ±  2%   -6.60% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12              14.11m ± 0%   13.33m ±  1%   -5.59% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                6.110m ± 0%   5.463m ±  1%  -10.60% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                8.386m ± 0%   7.482m ±  1%  -10.79% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12              10.046m ± 5%   8.779m ±  3%  -12.62% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12               19.40m ± 1%   18.11m ±  2%   -6.66% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12               22.34m ± 1%   20.04m ±  6%  -10.30% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12              24.06m ± 1%   21.36m ±  9%  -11.20% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12             7.550m ± 1%   6.980m ±  3%   -7.55% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12             11.00m ± 0%   10.26m ±  5%   -6.72% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12            13.76m ± 2%   13.41m ±  4%        ~ (p=0.093 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12            30.81m ± 1%   28.89m ±  1%   -6.22% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12            34.63m ± 2%   32.56m ±  2%   -5.97% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12           37.46m ± 2%   36.00m ±  4%   -3.90% (p=0.002 n=6)
geomean                                                                                                                                              2.790m        1.593m        -42.91%

                                                                                                                                           │ old-frommetrics.txt │   prometheusconverter-frommetrics.txt    │
                                                                                                                                           │        B/op         │     B/op      vs base                    │
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12                1.583Mi ± 0%   1.383Mi ± 0%   -12.68% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12                3.696Mi ± 0%   3.495Mi ± 0%    -5.44% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12               5.814Mi ± 0%   5.612Mi ± 0%    -3.47% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12              10.392Mi ± 0%   6.905Mi ± 0%   -33.56% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12              12.532Mi ± 0%   9.042Mi ± 0%   -27.85% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12              14.68Mi ± 0%   11.19Mi ± 0%   -23.77% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                6.583Mi ± 0%   6.354Mi ± 0%    -3.47% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                9.453Mi ± 0%   9.223Mi ± 0%    -2.43% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12               12.43Mi ± 0%   12.20Mi ± 0%    -1.88% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12               25.09Mi ± 0%   20.05Mi ± 0%   -20.09% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12               27.98Mi ± 0%   22.93Mi ± 0%   -18.04% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12              30.97Mi ± 0%   25.92Mi ± 0%   -16.30% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12             7.946Mi ± 0%   7.574Mi ± 0%    -4.69% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12             12.95Mi ± 0%   12.57Mi ± 0%    -2.89% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12            18.07Mi ± 0%   17.69Mi ± 0%    -2.09% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12            35.40Mi ± 0%   26.93Mi ± 0%   -23.92% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12            40.51Mi ± 0%   32.02Mi ± 0%   -20.96% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12           45.72Mi ± 0%   37.24Mi ± 0%   -18.56% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                   1.613Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                   1.613Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12                  1.613Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                  1.613Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                  1.613Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12                 1.613Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12                1.585Mi ± 0%   1.383Mi ± 0%   -12.72% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12                3.698Mi ± 0%   3.496Mi ± 0%    -5.47% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12               5.816Mi ± 0%   5.613Mi ± 0%    -3.48% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12              10.395Mi ± 0%   6.906Mi ± 0%   -33.56% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12              12.533Mi ± 0%   9.044Mi ± 0%   -27.84% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12              14.68Mi ± 0%   11.19Mi ± 0%   -23.78% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                6.584Mi ± 0%   6.355Mi ± 0%    -3.48% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                9.454Mi ± 0%   9.224Mi ± 0%    -2.44% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12               12.43Mi ± 0%   12.20Mi ± 0%    -1.90% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12               25.09Mi ± 0%   20.05Mi ± 0%   -20.09% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12               27.98Mi ± 0%   22.94Mi ± 0%   -18.02% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12              30.97Mi ± 0%   25.93Mi ± 0%   -16.29% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12             7.947Mi ± 0%   7.574Mi ± 0%    -4.70% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12             12.95Mi ± 0%   12.57Mi ± 0%    -2.91% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12            18.07Mi ± 0%   17.69Mi ± 0%    -2.09% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12            35.40Mi ± 0%   26.93Mi ± 0%   -23.94% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12            40.51Mi ± 0%   32.01Mi ± 0%   -20.99% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12           45.72Mi ± 0%   37.23Mi ± 0%   -18.58% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                  14.20Ki ± 0%    0.00Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                  14.20Ki ± 0%    0.00Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12                 14.20Ki ± 0%    0.00Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                 14.20Ki ± 0%    0.00Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                 14.20Ki ± 0%    0.00Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12                14.20Ki ± 0%    0.00Ki ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12               1.597Mi ± 0%   1.390Mi ± 0%   -12.98% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12               3.710Mi ± 0%   3.503Mi ± 0%    -5.59% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12              5.829Mi ± 0%   5.621Mi ± 0%    -3.57% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12             10.408Mi ± 0%   6.916Mi ± 0%   -33.55% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12             12.546Mi ± 0%   9.052Mi ± 0%   -27.85% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12             14.69Mi ± 0%   11.20Mi ± 0%   -23.79% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12               6.596Mi ± 0%   6.361Mi ± 0%    -3.57% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12               9.467Mi ± 0%   9.230Mi ± 0%    -2.50% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12              12.44Mi ± 0%   12.20Mi ± 0%    -1.91% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12              25.10Mi ± 0%   20.05Mi ± 0%   -20.10% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12              27.99Mi ± 0%   22.94Mi ± 0%   -18.05% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12             30.98Mi ± 0%   25.93Mi ± 0%   -16.31% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12            7.960Mi ± 0%   7.581Mi ± 0%    -4.76% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12            12.96Mi ± 0%   12.58Mi ± 0%    -2.94% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12           18.08Mi ± 0%   17.70Mi ± 0%    -2.12% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12           35.41Mi ± 0%   26.93Mi ± 0%   -23.95% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12           40.52Mi ± 0%   32.02Mi ± 0%   -20.98% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12          45.74Mi ± 0%   37.25Mi ± 0%   -18.56% (p=0.002 n=6)
geomean                                                                                                                                             3.099Mi                      ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                                                                                                                                           │ old-frommetrics.txt │   prometheusconverter-frommetrics.txt   │
                                                                                                                                           │      allocs/op      │  allocs/op   vs base                    │
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12                 22.13k ± 0%   18.11k ± 0%   -18.17% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12                 54.22k ± 0%   50.20k ± 0%    -7.42% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12                84.32k ± 0%   80.29k ± 0%    -4.78% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12                62.36k ± 0%   58.19k ± 0%    -6.70% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12                94.79k ± 0%   90.61k ± 0%    -4.41% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12               125.1k ± 0%   121.0k ± 0%    -3.33% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                 73.38k ± 0%   63.30k ± 0%   -13.74% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                109.49k ± 0%   99.40k ± 0%    -9.22% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12                140.6k ± 0%   130.5k ± 0%    -7.21% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                94.07k ± 0%   83.88k ± 0%   -10.84% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                130.5k ± 0%   120.1k ± 0%    -7.92% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12               161.7k ± 0%   151.4k ± 0%    -6.38% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12              95.67k ± 0%   81.56k ± 0%   -14.75% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12              164.1k ± 0%   150.0k ± 0%    -8.61% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12             225.5k ± 0%   211.3k ± 0%    -6.28% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12             160.4k ± 0%   146.1k ± 0%    -8.90% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12             230.3k ± 0%   215.5k ± 0%    -6.45% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_0/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12            292.5k ± 0%   278.0k ± 0%    -4.98% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                     17.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                     17.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12                    17.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                    17.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                    17.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12                   17.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12                 22.14k ± 0%   18.12k ± 0%   -18.18% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12                 54.24k ± 0%   50.21k ± 0%    -7.44% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12                84.33k ± 0%   80.30k ± 0%    -4.78% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12                62.42k ± 0%   58.21k ± 0%    -6.74% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12                94.82k ± 0%   90.65k ± 0%    -4.41% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12               125.2k ± 0%   121.0k ± 0%    -3.33% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                 73.40k ± 0%   63.31k ± 0%   -13.74% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                109.50k ± 0%   99.40k ± 0%    -9.22% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12                140.6k ± 0%   130.5k ± 0%    -7.22% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                94.09k ± 0%   83.90k ± 0%   -10.82% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                130.5k ± 0%   120.3k ± 0%    -7.84% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12               161.7k ± 0%   151.5k ± 0%    -6.32% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12              95.69k ± 0%   81.56k ± 0%   -14.76% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12              164.1k ± 0%   149.9k ± 0%    -8.63% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12             225.5k ± 0%   211.3k ± 0%    -6.27% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12             160.4k ± 0%   145.9k ± 0%    -9.02% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12             230.3k ± 0%   215.2k ± 0%    -6.56% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_5/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12            292.5k ± 0%   277.8k ± 0%    -5.04% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                    64.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12                    64.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12                   64.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12                   64.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12                   64.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12                  64.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12                22.20k ± 0%   18.17k ± 0%   -18.14% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12                54.29k ± 0%   50.26k ± 0%    -7.42% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12               84.39k ± 0%   80.36k ± 0%    -4.77% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12               62.47k ± 0%   58.34k ± 0%    -6.61% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12               94.88k ± 0%   90.70k ± 0%    -4.40% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_0/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12              125.2k ± 0%   121.1k ± 0%    -3.32% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_0-12                73.45k ± 0%   63.36k ± 0%   -13.74% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_5-12               109.55k ± 0%   99.45k ± 0%    -9.22% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_2/exemplars_per_series:_10-12               140.6k ± 0%   130.5k ± 0%    -7.19% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_0-12               94.08k ± 0%   83.89k ± 0%   -10.83% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_5-12               130.5k ± 0%   120.2k ± 0%    -7.88% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_0/labels_per_metric:_20/exemplars_per_series:_10-12              161.8k ± 0%   151.5k ± 0%    -6.38% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_0-12             95.73k ± 0%   81.62k ± 0%   -14.74% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_5-12             164.1k ± 0%   150.0k ± 0%    -8.61% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_2/exemplars_per_series:_10-12            225.5k ± 0%   211.4k ± 0%    -6.27% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_0-12            160.6k ± 0%   146.0k ± 0%    -9.07% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_5-12            230.4k ± 0%   215.5k ± 0%    -6.46% (p=0.002 n=6)
FromMetrics/resource_attribute_count:_50/histogram_count:_1000/non-histogram_count:_1000/labels_per_metric:_20/exemplars_per_series:_10-12           292.6k ± 0%   278.0k ± 0%    -4.98% (p=0.002 n=6)
geomean                                                                                                                                              25.34k                     ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```

</details>