### PR TITLE
Convert classic histograms to nhcb in scrape

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -617,6 +617,8 @@ type ScrapeConfig struct {
 	ScrapeProtocols []ScrapeProtocol `yaml:"scrape_protocols,omitempty"`
 	// Whether to scrape a classic histogram that is also exposed as a native histogram.
 	ScrapeClassicHistograms bool `yaml:"scrape_classic_histograms,omitempty"`
+	// Whether to convert a scraped classic histogram into a native histogram with custom buckets.
+	ConvertClassicHistograms bool `yaml:"convert_classic_histograms,omitempty"`
 	// The HTTP resource path on which to fetch metrics from targets.
 	MetricsPath string `yaml:"metrics_path,omitempty"`
 	// The URL scheme with which to fetch metrics from targets.

--- a/model/textparse/nhcbparse.go
+++ b/model/textparse/nhcbparse.go
@@ -45,8 +45,6 @@ type NhcbParser struct {
 	lset         labels.Labels
 	metricString string
 
-	buf []byte
-
 	// Collates values from the classic histogram series to build
 	// the converted histogram later.
 	lsetNhcb labels.Labels
@@ -61,7 +59,6 @@ func NewNhcbParser(p Parser, keepClassicHistograms bool) Parser {
 	return &NhcbParser{
 		parser:                p,
 		keepClassicHistograms: keepClassicHistograms,
-		buf:                   make([]byte, 0, 1024),
 		tempNhcb:              convertnhcb.NewTempHistogram(),
 	}
 }
@@ -189,7 +186,8 @@ func (p *NhcbParser) processNhcb(th convertnhcb.TempHistogram) bool {
 		p.h = nil
 		p.fh = fh
 	}
-	p.bytes = p.lsetNhcb.Bytes(p.buf)
+	buf := make([]byte, 0, 1024)
+	p.bytes = p.lsetNhcb.Bytes(buf)
 	p.lset = p.lsetNhcb
 	p.metricString = p.lsetNhcb.String()
 	p.tempNhcb = convertnhcb.NewTempHistogram()

--- a/model/textparse/nhcbparse.go
+++ b/model/textparse/nhcbparse.go
@@ -1,0 +1,188 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textparse
+
+import (
+	"errors"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/util/convertnhcb"
+)
+
+type NhcbParser struct {
+	parser                Parser
+	keepClassicHistograms bool
+
+	bytes []byte
+	ts    *int64
+	value float64
+	h     *histogram.Histogram
+	fh    *histogram.FloatHistogram
+
+	lset         labels.Labels
+	metricString string
+
+	buf []byte
+
+	nhcbLabels  map[uint64]labels.Labels
+	nhcbBuilder map[uint64]convertnhcb.TempHistogram
+}
+
+func NewNhcbParser(p Parser, keepClassicHistograms bool) Parser {
+	return &NhcbParser{
+		parser:                p,
+		keepClassicHistograms: keepClassicHistograms,
+		buf:                   make([]byte, 0, 1024),
+		nhcbLabels:            make(map[uint64]labels.Labels),
+		nhcbBuilder:           make(map[uint64]convertnhcb.TempHistogram),
+	}
+}
+
+func (p *NhcbParser) Series() ([]byte, *int64, float64) {
+	return p.bytes, p.ts, p.value
+}
+
+func (p *NhcbParser) Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram) {
+	return p.bytes, p.ts, p.h, p.fh
+}
+
+func (p *NhcbParser) Help() ([]byte, []byte) {
+	return p.parser.Help()
+}
+
+func (p *NhcbParser) Type() ([]byte, model.MetricType) {
+	return p.parser.Type()
+}
+
+func (p *NhcbParser) Unit() ([]byte, []byte) {
+	return p.parser.Unit()
+}
+
+func (p *NhcbParser) Comment() []byte {
+	return p.parser.Comment()
+}
+
+func (p *NhcbParser) Metric(l *labels.Labels) string {
+	*l = p.lset
+	return p.metricString
+}
+
+func (p *NhcbParser) Exemplar(ex *exemplar.Exemplar) bool {
+	return p.parser.Exemplar(ex)
+}
+
+func (p *NhcbParser) CreatedTimestamp() *int64 {
+	return p.parser.CreatedTimestamp()
+}
+
+func (p *NhcbParser) Next() (Entry, error) {
+	et, err := p.parser.Next()
+	if errors.Is(err, io.EOF) {
+		if len(p.nhcbBuilder) > 0 {
+			p.processNhcb()
+			return EntryHistogram, nil
+		}
+		return EntryInvalid, err
+	}
+	switch et {
+	case EntrySeries:
+		p.bytes, p.ts, p.value = p.parser.Series()
+		p.metricString = p.parser.Metric(&p.lset)
+		if isNhcb := p.handleClassicHistogramSeries(p.lset); isNhcb && !p.keepClassicHistograms {
+			return p.Next()
+		}
+	case EntryHistogram:
+		p.bytes, p.ts, p.h, p.fh = p.parser.Histogram()
+		p.metricString = p.parser.Metric(&p.lset)
+	}
+	return et, err
+}
+
+func (p *NhcbParser) handleClassicHistogramSeries(lset labels.Labels) bool {
+	mName := lset.Get(labels.MetricName)
+	switch {
+	case strings.HasSuffix(mName, "_bucket") && lset.Has(labels.BucketLabel):
+		le, err := strconv.ParseFloat(lset.Get(labels.BucketLabel), 64)
+		if err == nil && !math.IsNaN(le) {
+			processClassicHistogramSeries(lset, "_bucket", p.nhcbLabels, p.nhcbBuilder, func(hist *convertnhcb.TempHistogram) {
+				hist.BucketCounts[le] = p.value
+			})
+			return true
+		}
+	case strings.HasSuffix(mName, "_count"):
+		processClassicHistogramSeries(lset, "_count", p.nhcbLabels, p.nhcbBuilder, func(hist *convertnhcb.TempHistogram) {
+			hist.Count = p.value
+		})
+		return true
+	case strings.HasSuffix(mName, "_sum"):
+		processClassicHistogramSeries(lset, "_sum", p.nhcbLabels, p.nhcbBuilder, func(hist *convertnhcb.TempHistogram) {
+			hist.Sum = p.value
+		})
+		return true
+	}
+	return false
+}
+
+func processClassicHistogramSeries(lset labels.Labels, suffix string, nhcbLabels map[uint64]labels.Labels, nhcbBuilder map[uint64]convertnhcb.TempHistogram, updateHist func(*convertnhcb.TempHistogram)) {
+	m2 := convertnhcb.GetHistogramMetricBase(lset, suffix)
+	m2hash := m2.Hash()
+	nhcbLabels[m2hash] = m2
+	th, exists := nhcbBuilder[m2hash]
+	if !exists {
+		th = convertnhcb.NewTempHistogram()
+	}
+	updateHist(&th)
+	nhcbBuilder[m2hash] = th
+}
+
+func (p *NhcbParser) processNhcb() {
+	for hash, th := range p.nhcbBuilder {
+		lset, ok := p.nhcbLabels[hash]
+		if !ok {
+			continue
+		}
+		ub := make([]float64, 0, len(th.BucketCounts))
+		for b := range th.BucketCounts {
+			ub = append(ub, b)
+		}
+		upperBounds, hBase := convertnhcb.ProcessUpperBoundsAndCreateBaseHistogram(ub, false)
+		fhBase := hBase.ToFloat(nil)
+		h, fh := convertnhcb.ConvertHistogramWrapper(th, upperBounds, hBase, fhBase)
+		if h != nil {
+			if err := h.Validate(); err != nil {
+				panic("histogram validation failed")
+			}
+			p.h = h
+			p.fh = nil
+		} else if fh != nil {
+			if err := fh.Validate(); err != nil {
+				panic("histogram validation failed")
+			}
+			p.h = nil
+			p.fh = fh
+		}
+		p.bytes = lset.Bytes(p.buf)
+		p.lset = lset
+		p.metricString = lset.String()
+	}
+	p.nhcbBuilder = map[uint64]convertnhcb.TempHistogram{}
+}

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/almost"
+	"github.com/prometheus/prometheus/util/convertnhcb"
 	"github.com/prometheus/prometheus/util/teststorage"
 	"github.com/prometheus/prometheus/util/testutil"
 )
@@ -460,43 +461,22 @@ func (cmd *loadCmd) append(a storage.Appender) error {
 	return nil
 }
 
-func getHistogramMetricBase(m labels.Labels, suffix string) (labels.Labels, uint64) {
-	mName := m.Get(labels.MetricName)
-	baseM := labels.NewBuilder(m).
-		Set(labels.MetricName, strings.TrimSuffix(mName, suffix)).
-		Del(labels.BucketLabel).
-		Labels()
-	hash := baseM.Hash()
-	return baseM, hash
-}
-
 type tempHistogramWrapper struct {
 	metric        labels.Labels
 	upperBounds   []float64
-	histogramByTs map[int64]tempHistogram
+	histogramByTs map[int64]convertnhcb.TempHistogram
 }
 
 func newTempHistogramWrapper() tempHistogramWrapper {
 	return tempHistogramWrapper{
 		upperBounds:   []float64{},
-		histogramByTs: map[int64]tempHistogram{},
+		histogramByTs: map[int64]convertnhcb.TempHistogram{},
 	}
 }
 
-type tempHistogram struct {
-	bucketCounts map[float64]float64
-	count        float64
-	sum          float64
-}
-
-func newTempHistogram() tempHistogram {
-	return tempHistogram{
-		bucketCounts: map[float64]float64{},
-	}
-}
-
-func processClassicHistogramSeries(m labels.Labels, suffix string, histogramMap map[uint64]tempHistogramWrapper, smpls []promql.Sample, updateHistogramWrapper func(*tempHistogramWrapper), updateHistogram func(*tempHistogram, float64)) {
-	m2, m2hash := getHistogramMetricBase(m, suffix)
+func processClassicHistogramSeries(m labels.Labels, suffix string, histogramMap map[uint64]tempHistogramWrapper, smpls []promql.Sample, updateHistogramWrapper func(*tempHistogramWrapper), updateHistogram func(*convertnhcb.TempHistogram, float64)) {
+	m2 := convertnhcb.GetHistogramMetricBase(m, suffix)
+	m2hash := m2.Hash()
 	histogramWrapper, exists := histogramMap[m2hash]
 	if !exists {
 		histogramWrapper = newTempHistogramWrapper()
@@ -511,40 +491,12 @@ func processClassicHistogramSeries(m labels.Labels, suffix string, histogramMap 
 		}
 		histogram, exists := histogramWrapper.histogramByTs[s.T]
 		if !exists {
-			histogram = newTempHistogram()
+			histogram = convertnhcb.NewTempHistogram()
 		}
 		updateHistogram(&histogram, s.F)
 		histogramWrapper.histogramByTs[s.T] = histogram
 	}
 	histogramMap[m2hash] = histogramWrapper
-}
-
-func processUpperBoundsAndCreateBaseHistogram(upperBounds0 []float64) ([]float64, *histogram.FloatHistogram) {
-	sort.Float64s(upperBounds0)
-	upperBounds := make([]float64, 0, len(upperBounds0))
-	prevLE := math.Inf(-1)
-	for _, le := range upperBounds0 {
-		if le != prevLE { // deduplicate
-			upperBounds = append(upperBounds, le)
-			prevLE = le
-		}
-	}
-	var customBounds []float64
-	if upperBounds[len(upperBounds)-1] == math.Inf(1) {
-		customBounds = upperBounds[:len(upperBounds)-1]
-	} else {
-		customBounds = upperBounds
-	}
-	return upperBounds, &histogram.FloatHistogram{
-		Count:  0,
-		Sum:    0,
-		Schema: histogram.CustomBucketsSchema,
-		PositiveSpans: []histogram.Span{
-			{Offset: 0, Length: uint32(len(upperBounds))},
-		},
-		PositiveBuckets: make([]float64, len(upperBounds)),
-		CustomValues:    customBounds,
-	}
 }
 
 // If classic histograms are defined, convert them into native histograms with custom
@@ -565,16 +517,16 @@ func (cmd *loadCmd) appendCustomHistogram(a storage.Appender) error {
 			}
 			processClassicHistogramSeries(m, "_bucket", histogramMap, smpls, func(histogramWrapper *tempHistogramWrapper) {
 				histogramWrapper.upperBounds = append(histogramWrapper.upperBounds, le)
-			}, func(histogram *tempHistogram, f float64) {
-				histogram.bucketCounts[le] = f
+			}, func(histogram *convertnhcb.TempHistogram, f float64) {
+				histogram.BucketCounts[le] = f
 			})
 		case strings.HasSuffix(mName, "_count"):
-			processClassicHistogramSeries(m, "_count", histogramMap, smpls, nil, func(histogram *tempHistogram, f float64) {
-				histogram.count = f
+			processClassicHistogramSeries(m, "_count", histogramMap, smpls, nil, func(histogram *convertnhcb.TempHistogram, f float64) {
+				histogram.Count = f
 			})
 		case strings.HasSuffix(mName, "_sum"):
-			processClassicHistogramSeries(m, "_sum", histogramMap, smpls, nil, func(histogram *tempHistogram, f float64) {
-				histogram.sum = f
+			processClassicHistogramSeries(m, "_sum", histogramMap, smpls, nil, func(histogram *convertnhcb.TempHistogram, f float64) {
+				histogram.Sum = f
 			})
 		}
 	}
@@ -582,30 +534,14 @@ func (cmd *loadCmd) appendCustomHistogram(a storage.Appender) error {
 	// Convert the collated classic histogram data into native histograms
 	// with custom bounds and append them to the storage.
 	for _, histogramWrapper := range histogramMap {
-		upperBounds, fhBase := processUpperBoundsAndCreateBaseHistogram(histogramWrapper.upperBounds)
+		upperBounds, fhBase := convertnhcb.ProcessUpperBoundsAndCreateBaseHistogram(histogramWrapper.upperBounds)
 		samples := make([]promql.Sample, 0, len(histogramWrapper.histogramByTs))
 		for t, histogram := range histogramWrapper.histogramByTs {
-			fh := fhBase.Copy()
-			var prevCount, total float64
-			for i, le := range upperBounds {
-				currCount, exists := histogram.bucketCounts[le]
-				if !exists {
-					currCount = 0
-				}
-				count := currCount - prevCount
-				fh.PositiveBuckets[i] = count
-				total += count
-				prevCount = currCount
-			}
-			fh.Sum = histogram.sum
-			if histogram.count != 0 {
-				total = histogram.count
-			}
-			fh.Count = total
-			s := promql.Sample{T: t, H: fh.Compact(0)}
-			if err := s.H.Validate(); err != nil {
+			fh := convertnhcb.ConvertHistogramWrapper(histogram, upperBounds, fhBase)
+			if err := fh.Validate(); err != nil {
 				return err
 			}
+			s := promql.Sample{T: t, H: fh}
 			samples = append(samples, s)
 		}
 		sort.Slice(samples, func(i, j int) bool { return samples[i].T < samples[j].T })

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1473,7 +1473,7 @@ type appendErrors struct {
 func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string, ts time.Time) (total, added, seriesAdded int, err error) {
 	p, err := textparse.New(b, contentType, sl.scrapeClassicHistograms, sl.symbolTable)
 	if sl.convertClassicHistograms {
-		p = textparse.NewNhcbParser(p, sl.scrapeClassicHistograms)
+		p = textparse.NewNHCBParser(p, sl.scrapeClassicHistograms)
 	}
 	if err != nil {
 		level.Debug(sl.l).Log(

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -3379,11 +3379,10 @@ func TestConvertClassicHistograms(t *testing.T) {
 # TYPE %s counter
 %s{address="0.0.0.0",port="5001"} %d
 `, name, name, name, value)
-		} else {
-			return fmt.Sprintf(`
+		}
+		return fmt.Sprintf(`
 %s %d
 `, name, value)
-		}
 	}
 	genTestHistText := func(name string, withMetadata bool) string {
 		data := map[string]interface{}{

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -3464,6 +3464,12 @@ test_histogram_count{address="0.0.0.0",port="5001"} 1
 	series = q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", "test_histogram"))
 	count := 0
 	for series.Next() {
+		i := series.At().Iterator(nil)
+		for i.Next() == chunkenc.ValHistogram {
+			_, h := i.AtHistogram(nil)
+			require.Equal(t, uint64(1), h.Count)
+			require.Equal(t, 10.0, h.Sum)
+		}
 		count++
 	}
 	require.Equal(t, 1, count, "number of series not as expected")

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -3760,27 +3760,27 @@ metric: <
 		} {
 			var expectedClassicHistCount, expectedNativeHistCount int
 			var expectCustomBuckets bool
-			switch {
-			case tc.scrapeClassicHistograms && tc.convertClassicHistograms:
-				expectedClassicHistCount = 1
-				expectedNativeHistCount = 1
-				expectCustomBuckets = true
-			case !tc.scrapeClassicHistograms && tc.convertClassicHistograms:
-				expectedClassicHistCount = 0
-				expectedNativeHistCount = 1
-				expectCustomBuckets = true
-			case tc.scrapeClassicHistograms && !tc.convertClassicHistograms:
-				expectedClassicHistCount = 1
-				expectedNativeHistCount = 0
-			case !tc.scrapeClassicHistograms && !tc.convertClassicHistograms:
-				expectedClassicHistCount = 1 // since these are sent without native histograms
-				expectedNativeHistCount = 0
-			}
 			if metricsText.hasExponential {
 				expectedNativeHistCount = 1
 				expectCustomBuckets = false
-			} else {
-				expectCustomBuckets = true
+				expectedClassicHistCount = 0
+				if metricsText.hasClassic && tc.scrapeClassicHistograms {
+					expectedClassicHistCount = 1
+				}
+			} else if metricsText.hasClassic {
+				switch {
+				case tc.scrapeClassicHistograms && tc.convertClassicHistograms:
+					expectedClassicHistCount = 1
+					expectedNativeHistCount = 1
+					expectCustomBuckets = true
+				case !tc.scrapeClassicHistograms && tc.convertClassicHistograms:
+					expectedClassicHistCount = 0
+					expectedNativeHistCount = 1
+					expectCustomBuckets = true
+				case !tc.convertClassicHistograms:
+					expectedClassicHistCount = 1
+					expectedNativeHistCount = 0
+				}
 			}
 
 			t.Run(fmt.Sprintf("%s with %s", name, metricsTextName), func(t *testing.T) {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -3377,7 +3377,7 @@ func TestConvertClassicHistograms(t *testing.T) {
 			return fmt.Sprintf(`
 # HELP %s some help text
 # TYPE %s counter
-%s %d
+%s{address="0.0.0.0",port="5001"} %d
 `, name, name, name, value)
 		} else {
 			return fmt.Sprintf(`
@@ -3420,6 +3420,14 @@ name: "%s"
 help: "some help text"
 type: COUNTER
 metric: <
+	label: <
+		name: "address"
+		value: "0.0.0.0"
+	>
+	label: <
+		name: "port"
+		value: "5001"
+	>
 	counter: <
 		value: %d
 	>
@@ -3519,30 +3527,57 @@ metric: <
 		"text": {
 			text: []string{
 				genTestCounterText("test_metric_1", 1, true),
+				genTestCounterText("test_metric_1_count", 1, true),
+				genTestCounterText("test_metric_1_sum", 1, true),
+				genTestCounterText("test_metric_1_bucket", 1, true),
 				genTestHistText("test_histogram_1", true),
 				genTestCounterText("test_metric_2", 1, true),
+				genTestCounterText("test_metric_2_count", 1, true),
+				genTestCounterText("test_metric_2_sum", 1, true),
+				genTestCounterText("test_metric_2_bucket", 1, true),
 				genTestHistText("test_histogram_2", true),
 				genTestCounterText("test_metric_3", 1, true),
+				genTestCounterText("test_metric_3_count", 1, true),
+				genTestCounterText("test_metric_3_sum", 1, true),
+				genTestCounterText("test_metric_3_bucket", 1, true),
 				genTestHistText("test_histogram_3", true),
 			},
 		},
-		"text, no metadata, in different order": {
+		"text, in different order": {
 			text: []string{
-				genTestCounterText("test_metric_1", 1, false),
-				genTestHistText("test_histogram_1", false),
-				genTestCounterText("test_metric_2", 1, false),
-				genTestHistText("test_histogram_2", false),
-				genTestHistText("test_histogram_3", false),
-				genTestCounterText("test_metric_3", 1, false),
+				genTestCounterText("test_metric_1", 1, true),
+				genTestCounterText("test_metric_1_count", 1, true),
+				genTestCounterText("test_metric_1_sum", 1, true),
+				genTestCounterText("test_metric_1_bucket", 1, true),
+				genTestHistText("test_histogram_1", true),
+				genTestCounterText("test_metric_2", 1, true),
+				genTestCounterText("test_metric_2_count", 1, true),
+				genTestCounterText("test_metric_2_sum", 1, true),
+				genTestCounterText("test_metric_2_bucket", 1, true),
+				genTestHistText("test_histogram_2", true),
+				genTestHistText("test_histogram_3", true),
+				genTestCounterText("test_metric_3", 1, true),
+				genTestCounterText("test_metric_3_count", 1, true),
+				genTestCounterText("test_metric_3_sum", 1, true),
+				genTestCounterText("test_metric_3_bucket", 1, true),
 			},
 		},
 		"protobuf": {
 			text: []string{
 				genTestCounterProto("test_metric_1", 1),
+				genTestCounterProto("test_metric_1_count", 1),
+				genTestCounterProto("test_metric_1_sum", 1),
+				genTestCounterProto("test_metric_1_bucket", 1),
 				genTestHistProto("test_histogram_1", true, false),
 				genTestCounterProto("test_metric_2", 1),
+				genTestCounterProto("test_metric_2_count", 1),
+				genTestCounterProto("test_metric_2_sum", 1),
+				genTestCounterProto("test_metric_2_bucket", 1),
 				genTestHistProto("test_histogram_2", true, false),
 				genTestCounterProto("test_metric_3", 1),
+				genTestCounterProto("test_metric_3_count", 1),
+				genTestCounterProto("test_metric_3_sum", 1),
+				genTestCounterProto("test_metric_3_bucket", 1),
 				genTestHistProto("test_histogram_3", true, false),
 			},
 			contentType: "application/vnd.google.protobuf",
@@ -3551,20 +3586,38 @@ metric: <
 			text: []string{
 				genTestHistProto("test_histogram_1", true, false),
 				genTestCounterProto("test_metric_1", 1),
+				genTestCounterProto("test_metric_1_count", 1),
+				genTestCounterProto("test_metric_1_sum", 1),
+				genTestCounterProto("test_metric_1_bucket", 1),
 				genTestHistProto("test_histogram_2", true, false),
 				genTestCounterProto("test_metric_2", 1),
+				genTestCounterProto("test_metric_2_count", 1),
+				genTestCounterProto("test_metric_2_sum", 1),
+				genTestCounterProto("test_metric_2_bucket", 1),
 				genTestHistProto("test_histogram_3", true, false),
 				genTestCounterProto("test_metric_3", 1),
+				genTestCounterProto("test_metric_3_count", 1),
+				genTestCounterProto("test_metric_3_sum", 1),
+				genTestCounterProto("test_metric_3_bucket", 1),
 			},
 			contentType: "application/vnd.google.protobuf",
 		},
 		"protobuf, with native exponential histogram": {
 			text: []string{
 				genTestCounterProto("test_metric_1", 1),
+				genTestCounterProto("test_metric_1_count", 1),
+				genTestCounterProto("test_metric_1_sum", 1),
+				genTestCounterProto("test_metric_1_bucket", 1),
 				genTestHistProto("test_histogram_1", true, true),
 				genTestCounterProto("test_metric_2", 1),
+				genTestCounterProto("test_metric_2_count", 1),
+				genTestCounterProto("test_metric_2_sum", 1),
+				genTestCounterProto("test_metric_2_bucket", 1),
 				genTestHistProto("test_histogram_2", true, true),
 				genTestCounterProto("test_metric_3", 1),
+				genTestCounterProto("test_metric_3_count", 1),
+				genTestCounterProto("test_metric_3_sum", 1),
+				genTestCounterProto("test_metric_3_bucket", 1),
 				genTestHistProto("test_histogram_3", true, true),
 			},
 			contentType:    "application/vnd.google.protobuf",
@@ -3767,11 +3820,20 @@ metric: <
 					series = q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", fmt.Sprintf("test_metric_%d", i)))
 					checkFloatSeries(series, 1, 1.)
 
-					series = q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", fmt.Sprintf("test_histogram_%d_sum", i)))
-					checkFloatSeries(series, tc.expectedClassicHistCount, 10.)
+					series = q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", fmt.Sprintf("test_metric_%d_count", i)))
+					checkFloatSeries(series, 1, 1.)
+
+					series = q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", fmt.Sprintf("test_metric_%d_sum", i)))
+					checkFloatSeries(series, 1, 1.)
+
+					series = q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", fmt.Sprintf("test_metric_%d_bucket", i)))
+					checkFloatSeries(series, 1, 1.)
 
 					series = q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", fmt.Sprintf("test_histogram_%d_count", i)))
 					checkFloatSeries(series, tc.expectedClassicHistCount, 1.)
+
+					series = q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", fmt.Sprintf("test_histogram_%d_sum", i)))
+					checkFloatSeries(series, tc.expectedClassicHistCount, 10.)
 
 					series = q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", fmt.Sprintf("test_histogram_%d_bucket", i)))
 					checkBucketValues(tc.expectedClassicHistCount, metricsText.contentType, series)

--- a/util/convertnhcb/convertnhcb.go
+++ b/util/convertnhcb/convertnhcb.go
@@ -164,7 +164,8 @@ func GetHistogramMetricBase(m labels.Labels, suffix string) labels.Labels {
 		Labels()
 }
 
-func GetHistogramMetricBaseName(s string) string {
+func GetHistogramMetricBaseName(m labels.Labels) string {
+	s := m.Get(labels.MetricName)
 	for _, rep := range histogramNameSuffixReplacements {
 		s = rep.pattern.ReplaceAllString(s, rep.repl)
 	}

--- a/util/convertnhcb/convertnhcb.go
+++ b/util/convertnhcb/convertnhcb.go
@@ -164,8 +164,7 @@ func GetHistogramMetricBase(m labels.Labels, suffix string) labels.Labels {
 		Labels()
 }
 
-func GetHistogramMetricBaseName(m labels.Labels) string {
-	s := m.Get(labels.MetricName)
+func GetHistogramMetricBaseName(s string) string {
 	for _, rep := range histogramNameSuffixReplacements {
 		s = rep.pattern.ReplaceAllString(s, rep.repl)
 	}

--- a/util/convertnhcb/convertnhcb.go
+++ b/util/convertnhcb/convertnhcb.go
@@ -19,9 +19,29 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/grafana/regexp"
+
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 )
+
+var histogramNameSuffixReplacements = []struct {
+	pattern *regexp.Regexp
+	repl    string
+}{
+	{
+		pattern: regexp.MustCompile(`_bucket$`),
+		repl:    "",
+	},
+	{
+		pattern: regexp.MustCompile(`_sum$`),
+		repl:    "",
+	},
+	{
+		pattern: regexp.MustCompile(`_count$`),
+		repl:    "",
+	},
+}
 
 type TempHistogram struct {
 	BucketCounts map[float64]float64
@@ -142,4 +162,11 @@ func GetHistogramMetricBase(m labels.Labels, suffix string) labels.Labels {
 		Set(labels.MetricName, strings.TrimSuffix(mName, suffix)).
 		Del(labels.BucketLabel).
 		Labels()
+}
+
+func GetHistogramMetricBaseName(s string) string {
+	for _, rep := range histogramNameSuffixReplacements {
+		s = rep.pattern.ReplaceAllString(s, rep.repl)
+	}
+	return s
 }

--- a/util/convertnhcb/convertnhcb.go
+++ b/util/convertnhcb/convertnhcb.go
@@ -14,6 +14,7 @@
 package convertnhcb
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"strings"
@@ -26,6 +27,7 @@ type TempHistogram struct {
 	BucketCounts map[float64]float64
 	Count        float64
 	Sum          float64
+	HasFloat     bool
 }
 
 func NewTempHistogram() TempHistogram {
@@ -34,15 +36,32 @@ func NewTempHistogram() TempHistogram {
 	}
 }
 
-func ProcessUpperBoundsAndCreateBaseHistogram(upperBounds0 []float64) ([]float64, *histogram.FloatHistogram) {
-	sort.Float64s(upperBounds0)
-	upperBounds := make([]float64, 0, len(upperBounds0))
-	prevLE := math.Inf(-1)
-	for _, le := range upperBounds0 {
-		if le != prevLE { // deduplicate
-			upperBounds = append(upperBounds, le)
-			prevLE = le
+func (h TempHistogram) getIntBucketCounts() (map[float64]int64, error) {
+	bucketCounts := map[float64]int64{}
+	for le, count := range h.BucketCounts {
+		intCount := int64(math.Round(count))
+		if float64(intCount) != count {
+			return nil, fmt.Errorf("bucket count %f for le %g is not an integer", count, le)
 		}
+		bucketCounts[le] = intCount
+	}
+	return bucketCounts, nil
+}
+
+func ProcessUpperBoundsAndCreateBaseHistogram(upperBounds0 []float64, needsDedup bool) ([]float64, *histogram.Histogram) {
+	sort.Float64s(upperBounds0)
+	var upperBounds []float64
+	if needsDedup {
+		upperBounds = make([]float64, 0, len(upperBounds0))
+		prevLE := math.Inf(-1)
+		for _, le := range upperBounds0 {
+			if le != prevLE {
+				upperBounds = append(upperBounds, le)
+				prevLE = le
+			}
+		}
+	} else {
+		upperBounds = upperBounds0
 	}
 	var customBounds []float64
 	if upperBounds[len(upperBounds)-1] == math.Inf(1) {
@@ -50,23 +69,57 @@ func ProcessUpperBoundsAndCreateBaseHistogram(upperBounds0 []float64) ([]float64
 	} else {
 		customBounds = upperBounds
 	}
-	return upperBounds, &histogram.FloatHistogram{
+	return upperBounds, &histogram.Histogram{
 		Count:  0,
 		Sum:    0,
 		Schema: histogram.CustomBucketsSchema,
 		PositiveSpans: []histogram.Span{
 			{Offset: 0, Length: uint32(len(upperBounds))},
 		},
-		PositiveBuckets: make([]float64, len(upperBounds)),
+		PositiveBuckets: make([]int64, len(upperBounds)),
 		CustomValues:    customBounds,
 	}
 }
 
-func ConvertHistogramWrapper(hist TempHistogram, upperBounds []float64, fhBase *histogram.FloatHistogram) *histogram.FloatHistogram {
+func ConvertHistogramWrapper(histogram TempHistogram, upperBounds []float64, hBase *histogram.Histogram, fhBase *histogram.FloatHistogram) (*histogram.Histogram, *histogram.FloatHistogram) {
+	intBucketCounts, err := histogram.getIntBucketCounts()
+	if err != nil {
+		return nil, convertFloatHistogramWrapper(histogram, upperBounds, histogram.BucketCounts, fhBase)
+	}
+	return convertIntHistogramWrapper(histogram, upperBounds, intBucketCounts, hBase), nil
+}
+
+func convertIntHistogramWrapper(histogram TempHistogram, upperBounds []float64, bucketCounts map[float64]int64, hBase *histogram.Histogram) *histogram.Histogram {
+	h := hBase.Copy()
+	absBucketCounts := make([]int64, len(h.PositiveBuckets))
+	var prevCount, total int64
+	for i, le := range upperBounds {
+		currCount, exists := bucketCounts[le]
+		if !exists {
+			currCount = 0
+		}
+		count := currCount - prevCount
+		absBucketCounts[i] = count
+		total += count
+		prevCount = currCount
+	}
+	h.PositiveBuckets[0] = absBucketCounts[0]
+	for i := 1; i < len(h.PositiveBuckets); i++ {
+		h.PositiveBuckets[i] = absBucketCounts[i] - absBucketCounts[i-1]
+	}
+	h.Sum = histogram.Sum
+	if histogram.Count != 0 {
+		total = int64(histogram.Count)
+	}
+	h.Count = uint64(total)
+	return h.Compact(0)
+}
+
+func convertFloatHistogramWrapper(histogram TempHistogram, upperBounds []float64, bucketCounts map[float64]float64, fhBase *histogram.FloatHistogram) *histogram.FloatHistogram {
 	fh := fhBase.Copy()
 	var prevCount, total float64
 	for i, le := range upperBounds {
-		currCount, exists := hist.BucketCounts[le]
+		currCount, exists := bucketCounts[le]
 		if !exists {
 			currCount = 0
 		}
@@ -75,9 +128,9 @@ func ConvertHistogramWrapper(hist TempHistogram, upperBounds []float64, fhBase *
 		total += count
 		prevCount = currCount
 	}
-	fh.Sum = hist.Sum
-	if hist.Count != 0 {
-		total = hist.Count
+	fh.Sum = histogram.Sum
+	if histogram.Count != 0 {
+		total = histogram.Count
 	}
 	fh.Count = total
 	return fh.Compact(0)

--- a/util/convertnhcb/convertnhcb.go
+++ b/util/convertnhcb/convertnhcb.go
@@ -1,0 +1,92 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convertnhcb
+
+import (
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type TempHistogram struct {
+	BucketCounts map[float64]float64
+	Count        float64
+	Sum          float64
+}
+
+func NewTempHistogram() TempHistogram {
+	return TempHistogram{
+		BucketCounts: map[float64]float64{},
+	}
+}
+
+func ProcessUpperBoundsAndCreateBaseHistogram(upperBounds0 []float64) ([]float64, *histogram.FloatHistogram) {
+	sort.Float64s(upperBounds0)
+	upperBounds := make([]float64, 0, len(upperBounds0))
+	prevLE := math.Inf(-1)
+	for _, le := range upperBounds0 {
+		if le != prevLE { // deduplicate
+			upperBounds = append(upperBounds, le)
+			prevLE = le
+		}
+	}
+	var customBounds []float64
+	if upperBounds[len(upperBounds)-1] == math.Inf(1) {
+		customBounds = upperBounds[:len(upperBounds)-1]
+	} else {
+		customBounds = upperBounds
+	}
+	return upperBounds, &histogram.FloatHistogram{
+		Count:  0,
+		Sum:    0,
+		Schema: histogram.CustomBucketsSchema,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: uint32(len(upperBounds))},
+		},
+		PositiveBuckets: make([]float64, len(upperBounds)),
+		CustomValues:    customBounds,
+	}
+}
+
+func ConvertHistogramWrapper(hist TempHistogram, upperBounds []float64, fhBase *histogram.FloatHistogram) *histogram.FloatHistogram {
+	fh := fhBase.Copy()
+	var prevCount, total float64
+	for i, le := range upperBounds {
+		currCount, exists := hist.BucketCounts[le]
+		if !exists {
+			currCount = 0
+		}
+		count := currCount - prevCount
+		fh.PositiveBuckets[i] = count
+		total += count
+		prevCount = currCount
+	}
+	fh.Sum = hist.Sum
+	if hist.Count != 0 {
+		total = hist.Count
+	}
+	fh.Count = total
+	return fh.Compact(0)
+}
+
+func GetHistogramMetricBase(m labels.Labels, suffix string) labels.Labels {
+	mName := m.Get(labels.MetricName)
+	return labels.NewBuilder(m).
+		Set(labels.MetricName, strings.TrimSuffix(mName, suffix)).
+		Del(labels.BucketLabel).
+		Labels()
+}


### PR DESCRIPTION
Partially addresses https://github.com/prometheus/prometheus/issues/13529 and https://github.com/prometheus/prometheus/issues/13532

Assumes that metadata is present as it depends on that to detect classic histogram series for conversion.

Status: Pretty much done except for the exemplar support.