### PR TITLE
prometheusremotewrite: Move TimeSeries method to timeseries.go

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -38,7 +38,7 @@ type Settings struct {
 	SendMetadata        bool
 }
 
-// PrometheusConverter converts from OTel write format to Prometheus write format.
+// PrometheusConverter converts from OTel write format to Prometheus remote write format.
 type PrometheusConverter struct {
 	unique    map[uint64]*prompb.TimeSeries
 	conflicts map[uint64][]*prompb.TimeSeries
@@ -128,25 +128,6 @@ func (c *PrometheusConverter) FromMetrics(md pmetric.Metrics, settings Settings)
 	}
 
 	return
-}
-
-// TimeSeries returns a slice of the prompb.TimeSeries that were converted from OTel format.
-func (c *PrometheusConverter) TimeSeries() []prompb.TimeSeries {
-	conflicts := 0
-	for _, ts := range c.conflicts {
-		conflicts += len(ts)
-	}
-	allTS := make([]prompb.TimeSeries, 0, len(c.unique)+conflicts)
-	for _, ts := range c.unique {
-		allTS = append(allTS, *ts)
-	}
-	for _, cTS := range c.conflicts {
-		for _, ts := range cTS {
-			allTS = append(allTS, *ts)
-		}
-	}
-
-	return allTS
 }
 
 func isSameMetric(ts *prompb.TimeSeries, lbls []prompb.Label) bool {

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -64,7 +64,7 @@ func BenchmarkPrometheusConverter_FromMetrics(b *testing.B) {
 	}
 }
 
-func createExportRequest(resourceAttributeCount int, histogramCount int, nonHistogramCount int, labelsPerMetric int, exemplarsPerSeries int) pmetricotlp.ExportRequest {
+func createExportRequest(resourceAttributeCount, histogramCount, nonHistogramCount, labelsPerMetric, exemplarsPerSeries int) pmetricotlp.ExportRequest {
 	request := pmetricotlp.NewExportRequest()
 
 	rm := request.Metrics().ResourceMetrics().AppendEmpty()

--- a/storage/remote/otlptranslator/prometheusremotewrite/timeseries.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/timeseries.go
@@ -1,0 +1,41 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Provenance-includes-location:
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/95e8f8fdc2a9dc87230406c9a3cf02be4fd68bea/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: Copyright The OpenTelemetry Authors.
+
+package prometheusremotewrite
+
+import (
+	"github.com/prometheus/prometheus/prompb"
+)
+
+// TimeSeries returns a slice of the prompb.TimeSeries that were converted from OTel format.
+func (c *PrometheusConverter) TimeSeries() []prompb.TimeSeries {
+	conflicts := 0
+	for _, ts := range c.conflicts {
+		conflicts += len(ts)
+	}
+	allTS := make([]prompb.TimeSeries, 0, len(c.unique)+conflicts)
+	for _, ts := range c.unique {
+		allTS = append(allTS, *ts)
+	}
+	for _, cTS := range c.conflicts {
+		for _, ts := range cTS {
+			allTS = append(allTS, *ts)
+		}
+	}
+
+	return allTS
+}


### PR DESCRIPTION
To facilitate generating OTel translation code for other Prometheus compatible backends (e.g. Grafana Mimir/Thanos/Cortex), modify the `prometheusremotewrite` sources slightly so that the `PrometheusConverter.TimeSeries` method is in a file called timeseries.go. The rationale is to allow other backends to define their own implementation of this method.

The change has no practical effect, it's just code reorganizing.

At the same time taking the opportunity to format metrics_to_prw_test.go via `gofumpt -extra` (`golangci-lint` complained about this locally).