### PR TITLE
doc: clarify `rate` values are averaged

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -532,7 +532,7 @@ resets due to target restarts) are automatically adjusted for. Also, the
 calculation extrapolates to the ends of the time range, allowing for missed
 scrapes or imperfect alignment of scrape cycles with the range's time period.
 
-The following example expression returns the per-second rate of HTTP requests as measured
+The following example expression returns the per-second rate of HTTP requests averaged
 over the last 5 minutes, per time series in the range vector:
 
 ```

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -532,7 +532,7 @@ resets due to target restarts) are automatically adjusted for. Also, the
 calculation extrapolates to the ends of the time range, allowing for missed
 scrapes or imperfect alignment of scrape cycles with the range's time period.
 
-The following example expression returns the per-second rate of HTTP requests averaged
+The following example expression returns the per-second average rate of HTTP requests
 over the last 5 minutes, per time series in the range vector:
 
 ```


### PR DESCRIPTION
In the previous formulation, it wasn't clear to me what `[5m]` was doing, now it should be more clear that it's the window used to calculate the average.