### PR TITLE
BUGFIX: Mark the rule's restoration process as completed always

### DIFF
--- a/rules/group.go
+++ b/rules/group.go
@@ -672,6 +672,7 @@ func (g *Group) RestoreForState(ts time.Time) {
 				"stage", "Select",
 				"err", err,
 			)
+			alertRule.SetRestored(true)
 			continue
 		}
 
@@ -684,6 +685,7 @@ func (g *Group) RestoreForState(ts time.Time) {
 		// No results for this alert rule.
 		if len(seriesByLabels) == 0 {
 			level.Debug(g.logger).Log("msg", "Failed to find a series to restore the 'for' state", labels.AlertName, alertRule.Name())
+			alertRule.SetRestored(true)
 			continue
 		}
 

--- a/rules/group.go
+++ b/rules/group.go
@@ -672,6 +672,8 @@ func (g *Group) RestoreForState(ts time.Time) {
 				"stage", "Select",
 				"err", err,
 			)
+			// Even if we failed to query the `ALERT_FOR_STATE` series, we currently have no way to retry the restore process.
+			// So the best we can do is mark the rule as restored and let it eventually fire.
 			alertRule.SetRestored(true)
 			continue
 		}
@@ -684,7 +686,7 @@ func (g *Group) RestoreForState(ts time.Time) {
 
 		// No results for this alert rule.
 		if len(seriesByLabels) == 0 {
-			level.Debug(g.logger).Log("msg", "Failed to find a series to restore the 'for' state", labels.AlertName, alertRule.Name())
+			level.Debug(g.logger).Log("msg", "No series found to restore the 'for' state of the alert rule", labels.AlertName, alertRule.Name())
 			alertRule.SetRestored(true)
 			continue
 		}

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -482,6 +482,9 @@ func TestForStateRestore(t *testing.T) {
 				return labels.Compare(got[i].Labels, got[j].Labels) < 0
 			})
 
+			// In all cases, we expect the restoration process to have completed.
+			require.Truef(t, newRule.Restored(), "expected the rule restoration proccess to have completed")
+
 			// Checking if we have restored it correctly.
 			switch {
 			case tt.noRestore:

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -483,7 +483,7 @@ func TestForStateRestore(t *testing.T) {
 			})
 
 			// In all cases, we expect the restoration process to have completed.
-			require.Truef(t, newRule.Restored(), "expected the rule restoration proccess to have completed")
+			require.Truef(t, newRule.Restored(), "expected the rule restoration process to have completed")
 
 			// Checking if we have restored it correctly.
 			switch {


### PR DESCRIPTION
In https://github.com/prometheus/prometheus/pull/13980 I introduced a change to reduce the number of queries executed when we restore alert statuses.

With this, the querying semantics changed as we now need to go through all series before we enter the alert restoration loop and I missed the fact that exiting early when there are no rules to restore would lead to an incomplete restoration.

An alert being restored is used as a proxy for "we're now ready to write `ALERTS/ALERTS_FOR_SERIES` metrics" so as a result we weren't writing the series if we didn't restore anything the first time around

PD: I have not updated the changelog as technically this is still unreleased.