### PR TITLE
Bugfix: quote label name in matchers when needed

### DIFF
--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -78,7 +78,20 @@ func MustNewMatcher(mt MatchType, name, val string) *Matcher {
 }
 
 func (m *Matcher) String() string {
-	return fmt.Sprintf("%s%s%q", m.Name, m.Type, m.Value)
+	if !m.shouldQuoteName() {
+		return fmt.Sprintf("%s%s%q", m.Name, m.Type, m.Value)
+	}
+	return fmt.Sprintf("%q%s%q", m.Name, m.Type, m.Value)
+}
+
+func (m *Matcher) shouldQuoteName() bool {
+	for i, c := range m.Name {
+		if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (i > 0 && c >= '0' && c <= '9') {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // Matches returns whether the matcher matches the given string value.

--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -14,7 +14,8 @@
 package labels
 
 import (
-	"fmt"
+	"strconv"
+	"unsafe"
 )
 
 // MatchType is an enum for label matching types.
@@ -78,10 +79,20 @@ func MustNewMatcher(mt MatchType, name, val string) *Matcher {
 }
 
 func (m *Matcher) String() string {
-	if !m.shouldQuoteName() {
-		return fmt.Sprintf("%s%s%q", m.Name, m.Type, m.Value)
+	const quote = 1
+	const matcher = 2
+	// As we're not on go1.22 yet and we don't have the new fancy AvailableBuffer method on strings.Builder,
+	// we'll use a plain byte slice and then do the unsafe conversion to string just like strings.Builder does.
+	// We pre-allocate pessimistically for quoting the label name, and optimistically for not having to escape any quotes.
+	b := make([]byte, 0, quote+len(m.Name)+quote+matcher+quote+len(m.Value)+quote)
+	if m.shouldQuoteName() {
+		b = strconv.AppendQuote(b, m.Name)
+	} else {
+		b = append(b, m.Name...)
 	}
-	return fmt.Sprintf("%q%s%q", m.Name, m.Type, m.Value)
+	b = append(b, m.Type.String()...)
+	b = strconv.AppendQuote(b, m.Value)
+	return *((*string)(unsafe.Pointer(&b)))
 }
 
 func (m *Matcher) shouldQuoteName() bool {

--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -15,6 +15,7 @@ package labels
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -224,4 +225,129 @@ func BenchmarkNewMatcher(b *testing.B) {
 			NewMatcher(MatchRegexp, "foo", "bar")
 		}
 	})
+}
+
+func BenchmarkMatcher_String(b *testing.B) {
+	type benchCase struct {
+		name     string
+		matchers []*Matcher
+	}
+	cases := []benchCase{
+		{
+			name: "short name equal",
+			matchers: []*Matcher{
+				MustNewMatcher(MatchEqual, "foo", "bar"),
+				MustNewMatcher(MatchEqual, "bar", "baz"),
+				MustNewMatcher(MatchEqual, "abc", "def"),
+				MustNewMatcher(MatchEqual, "ghi", "klm"),
+				MustNewMatcher(MatchEqual, "nop", "qrs"),
+			},
+		},
+		{
+			name: "short quoted name not equal",
+			matchers: []*Matcher{
+				MustNewMatcher(MatchEqual, "f.o", "bar"),
+				MustNewMatcher(MatchEqual, "b.r", "baz"),
+				MustNewMatcher(MatchEqual, "a.c", "def"),
+				MustNewMatcher(MatchEqual, "g.i", "klm"),
+				MustNewMatcher(MatchEqual, "n.p", "qrs"),
+			},
+		},
+		{
+			name: "short quoted name with quotes not equal",
+			matchers: []*Matcher{
+				MustNewMatcher(MatchEqual, `"foo"`, "bar"),
+				MustNewMatcher(MatchEqual, `"foo"`, "baz"),
+				MustNewMatcher(MatchEqual, `"foo"`, "def"),
+				MustNewMatcher(MatchEqual, `"foo"`, "klm"),
+				MustNewMatcher(MatchEqual, `"foo"`, "qrs"),
+			},
+		},
+		{
+			name: "short name value with quotes equal",
+			matchers: []*Matcher{
+				MustNewMatcher(MatchEqual, "foo", `"bar"`),
+				MustNewMatcher(MatchEqual, "bar", `"baz"`),
+				MustNewMatcher(MatchEqual, "abc", `"def"`),
+				MustNewMatcher(MatchEqual, "ghi", `"klm"`),
+				MustNewMatcher(MatchEqual, "nop", `"qrs"`),
+			},
+		},
+		{
+			name: "short name and long value regexp",
+			matchers: []*Matcher{
+				MustNewMatcher(MatchRegexp, "foo", "five_six_seven_eight_nine_ten_one_two_three_four"),
+				MustNewMatcher(MatchRegexp, "bar", "one_two_three_four_five_six_seven_eight_nine_ten"),
+				MustNewMatcher(MatchRegexp, "abc", "two_three_four_five_six_seven_eight_nine_ten_one"),
+				MustNewMatcher(MatchRegexp, "ghi", "three_four_five_six_seven_eight_nine_ten_one_two"),
+				MustNewMatcher(MatchRegexp, "nop", "four_five_six_seven_eight_nine_ten_one_two_three"),
+			},
+		},
+		{
+			name: "short name and long value with quotes equal",
+			matchers: []*Matcher{
+				MustNewMatcher(MatchEqual, "foo", `five_six_seven_eight_nine_ten_"one"_two_three_four`),
+				MustNewMatcher(MatchEqual, "bar", `one_two_three_four_five_six_"seven"_eight_nine_ten`),
+				MustNewMatcher(MatchEqual, "abc", `two_three_four_five_six_seven_"eight"_nine_ten_one`),
+				MustNewMatcher(MatchEqual, "ghi", `three_four_five_six_seven_eight_"nine"_ten_one_two`),
+				MustNewMatcher(MatchEqual, "nop", `four_five_six_seven_eight_nine_"ten"_one_two_three`),
+			},
+		},
+		{
+			name: "long name regexp",
+			matchers: []*Matcher{
+				MustNewMatcher(MatchRegexp, "one_two_three_four_five_six_seven_eight_nine_ten", "val"),
+				MustNewMatcher(MatchRegexp, "two_three_four_five_six_seven_eight_nine_ten_one", "val"),
+				MustNewMatcher(MatchRegexp, "three_four_five_six_seven_eight_nine_ten_one_two", "val"),
+				MustNewMatcher(MatchRegexp, "four_five_six_seven_eight_nine_ten_one_two_three", "val"),
+				MustNewMatcher(MatchRegexp, "five_six_seven_eight_nine_ten_one_two_three_four", "val"),
+			},
+		},
+		{
+			name: "long quoted name regexp",
+			matchers: []*Matcher{
+				MustNewMatcher(MatchRegexp, "one.two.three.four.five.six.seven.eight.nine.ten", "val"),
+				MustNewMatcher(MatchRegexp, "two.three.four.five.six.seven.eight.nine.ten.one", "val"),
+				MustNewMatcher(MatchRegexp, "three.four.five.six.seven.eight.nine.ten.one.two", "val"),
+				MustNewMatcher(MatchRegexp, "four.five.six.seven.eight.nine.ten.one.two.three", "val"),
+				MustNewMatcher(MatchRegexp, "five.six.seven.eight.nine.ten.one.two.three.four", "val"),
+			},
+		},
+		{
+			name: "long name and long value regexp",
+			matchers: []*Matcher{
+				MustNewMatcher(MatchRegexp, "one_two_three_four_five_six_seven_eight_nine_ten", "five_six_seven_eight_nine_ten_one_two_three_four"),
+				MustNewMatcher(MatchRegexp, "two_three_four_five_six_seven_eight_nine_ten_one", "one_two_three_four_five_six_seven_eight_nine_ten"),
+				MustNewMatcher(MatchRegexp, "three_four_five_six_seven_eight_nine_ten_one_two", "two_three_four_five_six_seven_eight_nine_ten_one"),
+				MustNewMatcher(MatchRegexp, "four_five_six_seven_eight_nine_ten_one_two_three", "three_four_five_six_seven_eight_nine_ten_one_two"),
+				MustNewMatcher(MatchRegexp, "five_six_seven_eight_nine_ten_one_two_three_four", "four_five_six_seven_eight_nine_ten_one_two_three"),
+			},
+		},
+		{
+			name: "long quoted name and long value regexp",
+			matchers: []*Matcher{
+				MustNewMatcher(MatchRegexp, "one.two.three.four.five.six.seven.eight.nine.ten", "five.six.seven.eight.nine.ten.one.two.three.four"),
+				MustNewMatcher(MatchRegexp, "two.three.four.five.six.seven.eight.nine.ten.one", "one.two.three.four.five.six.seven.eight.nine.ten"),
+				MustNewMatcher(MatchRegexp, "three.four.five.six.seven.eight.nine.ten.one.two", "two.three.four.five.six.seven.eight.nine.ten.one"),
+				MustNewMatcher(MatchRegexp, "four.five.six.seven.eight.nine.ten.one.two.three", "three.four.five.six.seven.eight.nine.ten.one.two"),
+				MustNewMatcher(MatchRegexp, "five.six.seven.eight.nine.ten.one.two.three.four", "four.five.six.seven.eight.nine.ten.one.two.three"),
+			},
+		},
+	}
+
+	var mixed []*Matcher
+	for _, bc := range cases {
+		mixed = append(mixed, bc.matchers...)
+	}
+	rand.Shuffle(len(mixed), func(i, j int) { mixed[i], mixed[j] = mixed[j], mixed[i] })
+	cases = append(cases, benchCase{name: "mixed", matchers: mixed})
+
+	for _, bc := range cases {
+		b.Run(bc.name, func(b *testing.B) {
+			for i := 0; i <= b.N; i++ {
+				m := bc.matchers[i%len(bc.matchers)]
+				_ = m.String()
+			}
+		})
+	}
 }

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -138,6 +138,16 @@ func TestExprString(t *testing.T) {
 		{
 			in: `{__name__="",a="x"}`,
 		},
+		{
+			in: `{"a.b"="c"}`,
+		},
+		{
+			in: `{"0"="1"}`,
+		},
+		{
+			in:  `{"_0"="1"}`,
+			out: `{_0="1"}`,
+		},
 	}
 
 	for _, test := range inputs {


### PR DESCRIPTION
Yet another issue I discovered fuzzying.

`{"0"="0"}` is now a valid parseable vector selector, but `parser.VectorSelector.String()` of that is `{0="0"}`, which is not.

This fixes the `Matcher.String()` method to quote the name _when needed_.

Obviously, _when needed_ came at a cost, so I also optimized `Match.String()` getting rid of the _expensive_ `fmt.Sprintf()` and making the net cost of the method cheaper in most cases.

(Updated benchmarks)
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
                                                              │   main_mem    │             buffer_mem              │
                                                              │    sec/op     │   sec/op     vs base                │
Matcher_String/short_name_equal-12                              123.30n ± 10%   41.86n ± 0%  -66.05% (p=0.000 n=10)
Matcher_String/short_quoted_name_not_equal-12                   131.10n ± 14%   54.25n ± 0%  -58.62% (p=0.000 n=10)
Matcher_String/short_quoted_name_with_quotes_not_equal-12       125.10n ± 12%   60.01n ± 1%  -52.03% (p=0.000 n=10)
Matcher_String/short_name_value_with_quotes_equal-12            134.30n ± 16%   47.78n ± 1%  -64.42% (p=0.000 n=10)
Matcher_String/short_name_and_long_value_regexp-12               301.6n ± 14%   213.7n ± 1%  -29.16% (p=0.000 n=10)
Matcher_String/short_name_and_long_value_with_quotes_equal-12    323.0n ± 17%   226.9n ± 1%  -29.74% (p=0.000 n=10)
Matcher_String/long_name_regexp-12                              134.65n ± 10%   82.34n ± 1%  -38.85% (p=0.000 n=10)
Matcher_String/long_quoted_name_regexp-12                        132.0n ± 14%   232.4n ± 0%  +76.06% (p=0.000 n=10)
Matcher_String/long_name_and_long_value_regexp-12                316.3n ± 13%   263.4n ± 3%  -16.71% (p=0.000 n=10)
Matcher_String/long_quoted_name_and_long_value_regexp-12         309.5n ± 12%   412.7n ± 3%  +33.35% (p=0.000 n=10)
Matcher_String/mixed-12                                          212.9n ± 11%   172.5n ± 1%  -19.00% (p=0.000 n=10)
geomean                                                          187.0n         124.7n       -33.33%

                                                              │  main_mem  │             buffer_mem             │
                                                              │    B/op    │    B/op     vs base                │
Matcher_String/short_name_equal-12                              48.00 ± 0%   16.00 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/short_quoted_name_not_equal-12                   48.00 ± 0%   16.00 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/short_quoted_name_with_quotes_not_equal-12       48.00 ± 0%   16.00 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/short_name_value_with_quotes_equal-12            48.00 ± 0%   16.00 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/short_name_and_long_value_regexp-12              96.00 ± 0%   64.00 ± 0%  -33.33% (p=0.000 n=10)
Matcher_String/short_name_and_long_value_with_quotes_equal-12   96.00 ± 0%   64.00 ± 0%  -33.33% (p=0.000 n=10)
Matcher_String/long_name_regexp-12                              96.00 ± 0%   64.00 ± 0%  -33.33% (p=0.000 n=10)
Matcher_String/long_quoted_name_regexp-12                       96.00 ± 0%   64.00 ± 0%  -33.33% (p=0.000 n=10)
Matcher_String/long_name_and_long_value_regexp-12               144.0 ± 0%   112.0 ± 0%  -22.22% (p=0.000 n=10)
Matcher_String/long_quoted_name_and_long_value_regexp-12        144.0 ± 0%   112.0 ± 0%  -22.22% (p=0.000 n=10)
Matcher_String/mixed-12                                         86.00 ± 0%   54.00 ± 0%  -37.21% (p=0.000 n=10)
geomean                                                         79.52        42.14       -47.00%

                                                              │  main_mem  │             buffer_mem             │
                                                              │ allocs/op  │ allocs/op   vs base                │
Matcher_String/short_name_equal-12                              3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/short_quoted_name_not_equal-12                   3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/short_quoted_name_with_quotes_not_equal-12       3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/short_name_value_with_quotes_equal-12            3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/short_name_and_long_value_regexp-12              3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/short_name_and_long_value_with_quotes_equal-12   3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/long_name_regexp-12                              3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/long_quoted_name_regexp-12                       3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/long_name_and_long_value_regexp-12               3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/long_quoted_name_and_long_value_regexp-12        3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
Matcher_String/mixed-12                                         3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
geomean                                                         3.000        1.000       -66.67%
```