### PR TITLE
scrape.Manager: Remove initial scrape delay

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -148,15 +148,15 @@ func (m *Manager) reloader() {
 
 	for {
 		select {
+		case <-m.triggerReload:
+			m.reload()
+		case <-m.graceShut:
+			return
+		}
+		select {
 		case <-m.graceShut:
 			return
 		case <-ticker.C:
-			select {
-			case <-m.triggerReload:
-				m.reload()
-			case <-m.graceShut:
-				return
-			}
 		}
 	}
 }

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -87,8 +87,9 @@ type Options struct {
 	// Optional HTTP client options to use when scraping.
 	HTTPClientOptions []config_util.HTTPClientOption
 
-	// private option for testability.
+	// private options for testability.
 	skipOffsetting bool
+	skipReloader   bool
 }
 
 // Manager maintains a set of scrape pools and manages start/stop cycles
@@ -114,7 +115,9 @@ type Manager struct {
 // Run receives and saves target set updates and triggers the scraping loops reloading.
 // Reloading happens in the background so that it doesn't block receiving targets updates.
 func (m *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) error {
-	go m.reloader()
+	if !m.opts.skipReloader {
+		go m.reloader()
+	}
 	for {
 		select {
 		case ts := <-tsets:

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -572,7 +572,7 @@ scrape_configs:
 }
 
 func TestManagerTargetsUpdates(t *testing.T) {
-	opts := Options{}
+	opts := Options{skipReloader: true}
 	testRegistry := prometheus.NewRegistry()
 	m, err := NewManager(&opts, nil, nil, testRegistry)
 	require.NoError(t, err)


### PR DESCRIPTION
This simple change ensures that the initial scrape can be started without the 5 second delay. A nice side-effect is that tests in that package now complete 15 seconds faster.

Background: I'm working on a small [CLI tool](https://github.com/lovromazgon/impromptu) that embeds Prometheus and allows you to scrape and visualize metrics ad-hoc. The UX suffers because of the initial 5 second delay.