### PR TITLE
[ENHANCEMENT] PromQL: use Kahan summation for sum()

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2730,7 +2730,7 @@ type groupedAggregation struct {
 	hasHistogram   bool // Has at least 1 histogram sample aggregated.
 	floatValue     float64
 	histogramValue *histogram.FloatHistogram
-	floatMean      float64
+	floatMean      float64 // Mean, or "compensating value" for Kahan summation.
 	groupCount     int
 	heap           vectorByValueHeap
 }
@@ -2758,11 +2758,13 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 			*group = groupedAggregation{
 				seen:       true,
 				floatValue: f,
-				floatMean:  f,
 				groupCount: 1,
 			}
 			switch op {
-			case parser.SUM, parser.AVG:
+			case parser.AVG:
+				group.floatMean = f
+				fallthrough
+			case parser.SUM:
 				if h == nil {
 					group.hasFloat = true
 				} else {
@@ -2770,6 +2772,7 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 					group.hasHistogram = true
 				}
 			case parser.STDVAR, parser.STDDEV:
+				group.floatMean = f
 				group.floatValue = 0
 			case parser.QUANTILE:
 				group.heap = make(vectorByValueHeap, 1)
@@ -2792,7 +2795,7 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 				// point in copying the histogram in that case.
 			} else {
 				group.hasFloat = true
-				group.floatValue += f
+				group.floatValue, group.floatMean = kahanSumInc(f, group.floatValue, group.floatMean)
 			}
 
 		case parser.AVG:
@@ -2903,6 +2906,8 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 			}
 			if aggr.hasHistogram {
 				aggr.histogramValue.Compact(0)
+			} else {
+				aggr.floatValue += aggr.floatMean // Add Kahan summation compensating term.
 			}
 		default:
 			// For other aggregations, we already have the right value.

--- a/promql/promqltest/testdata/aggregators.test
+++ b/promql/promqltest/testdata/aggregators.test
@@ -503,6 +503,18 @@ eval instant at 1m avg(data{test="-big"})
 eval instant at 1m avg(data{test="bigzero"})
 	{} 0
 
+# Test summing extreme values.
+clear
+
+load 10s
+	data{test="ten",point="a"} 2
+	data{test="ten",point="b"} 8
+	data{test="ten",point="c"} 1e+100
+	data{test="ten",point="d"} -1e100
+
+eval instant at 1m sum(data{test="ten"})
+	{} 10
+
 clear
 
 # Test that aggregations are deterministic.


### PR DESCRIPTION
This can give a more precise result, by keeping a separate running compensation value to accumulate small errors.
See https://en.wikipedia.org/wiki/Kahan_summation_algorithm

Possible improvement for #14052 (I won't call it a fix).

I'm re-using `floatMean` which is otherwise unused for `sum()`; it would be clearer to add a new field but would cost 8 bytes per output value.

Benchmarks show a bigger slow-down than I expected.
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
cpu: Intel(R) Core(TM) i7-14700K
                                                                                                          │ before.txt  │             after.txt             │
                                                                                                          │   sec/op    │   sec/op     vs base              │
RangeQuery/expr=sum(a_hundred),steps=1-28                                                                   142.2µ ± 1%   144.2µ ± 0%  +1.41% (p=0.009 n=6)
RangeQuery/expr=sum(a_hundred),steps=100-28                                                                 447.5µ ± 2%   460.3µ ± 1%  +2.85% (p=0.002 n=6)
RangeQuery/expr=sum(a_hundred),steps=1000-28                                                                2.670m ± 2%   2.760m ± 1%  +3.37% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1-28                                                       1.637m ± 2%   1.653m ± 1%       ~ (p=0.240 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=100-28                                                     5.081m ± 2%   5.352m ± 1%  +5.33% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(h_hundred),steps=1000-28                                                    33.30m ± 2%   35.05m ± 0%  +5.25% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1-28                                                      1.676m ± 2%   1.691m ± 1%  +0.89% (p=0.026 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=100-28                                                    5.315m ± 2%   5.503m ± 1%  +3.54% (p=0.002 n=6)
RangeQuery/expr=sum_without_(le)(h_hundred),steps=1000-28                                                   35.13m ± 1%   36.76m ± 1%  +4.62% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1-28                                                            1.654m ± 1%   1.685m ± 1%  +1.84% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=100-28                                                          5.349m ± 2%   5.476m ± 0%  +2.39% (p=0.002 n=6)
RangeQuery/expr=sum_by_(l)(h_hundred),steps=1000-28                                                         34.97m ± 1%   36.87m ± 1%  +5.44% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1-28                                                           1.618m ± 1%   1.647m ± 0%  +1.79% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=100-28                                                         5.154m ± 1%   5.379m ± 1%  +4.35% (p=0.002 n=6)
RangeQuery/expr=sum_by_(le)(h_hundred),steps=1000-28                                                        33.34m ± 2%   35.18m ± 1%  +5.51% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1-28                                             174.5µ ± 1%   176.0µ ± 1%       ~ (p=0.065 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=100-28                                           897.6µ ± 1%   911.0µ ± 1%  +1.49% (p=0.015 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m])),steps=1000-28                                          6.615m ± 1%   6.690m ± 0%  +1.14% (p=0.002 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1-28      361.2µ ± 1%   360.3µ ± 1%       ~ (p=0.699 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=100-28    1.848m ± 1%   1.859m ± 1%       ~ (p=0.132 n=6)
RangeQuery/expr=sum_without_(l)(rate(a_hundred[1m]))_/_sum_without_(l)(rate(b_hundred[1m])),steps=1000-28   13.46m ± 1%   13.61m ± 1%  +1.14% (p=0.041 n=6)
geomean                                                                                                     3.017m        3.095m       +2.58%
```