### PR TITLE
optimize regex matching for empty label values in posting match

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -354,8 +354,10 @@ func inversePostingsForMatcher(ctx context.Context, ix IndexReader, m *labels.Ma
 	}
 
 	res := vals[:0]
-	// If the inverse match is ="", we just want all the values.
-	if m.Type == labels.MatchEqual && m.Value == "" {
+	// Only = and =~ cases are left.
+	// If the inverse match is ="" or =~"", we just want all the values.
+	// https://github.com/prometheus/prometheus/blob/main/model/labels/regexp.go#L680
+	if m.Value == "" {
 		res = vals
 	} else {
 		for _, val := range vals {


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Now `=~""` is optimized into empty string matcher https://github.com/prometheus/prometheus/blob/main/model/labels/regexp.go#L680, which matches empty string only.

Then we can skip matching because all label values should be non empty string.
