### PR TITLE
Fix head stats and hooks when replaying a corrupted snapshot

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1963,7 +1963,7 @@ func (s *stripeSeries) iter(f func(int, uint64, *memSeries, map[chunks.HeadSerie
 	for i := 0; i < s.size; i++ {
 		seriesSet := make(map[chunks.HeadSeriesRef]labels.Labels, seriesSetFromPrevStripe)
 		s.locks[i].Lock()
-		// Iterate conflicts first so seriesHashmap.del doesn't move them to the `unique` field,
+		// Iterate conflicts first so f doesn't move them to the `unique` field,
 		// after deleting `unique`.
 		for hash, all := range s.hashes[i].conflicts {
 			for _, series := range all {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -4007,7 +4007,7 @@ func TestSnapshotError(t *testing.T) {
 	require.NoError(t, err)
 	f, err := os.OpenFile(path.Join(snapDir, files[0].Name()), os.O_RDWR, 0)
 	require.NoError(t, err)
-	// create snapshot backup to be restored on future test cases
+	// Create snapshot backup to be restored on future test cases.
 	snapshotBackup, err := io.ReadAll(f)
 	require.NoError(t, err)
 	_, err = f.WriteAt([]byte{0b11111111}, 18)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -4007,7 +4007,8 @@ func TestSnapshotError(t *testing.T) {
 	require.NoError(t, err)
 	f, err := os.OpenFile(path.Join(snapDir, files[0].Name()), os.O_RDWR, 0)
 	require.NoError(t, err)
-	_, err = f.WriteAt([]byte{0b11111111}, 18)
+	// lets corrupt middle of the snapshot, so we can replay some entries
+	_, err = f.WriteAt([]byte{0b11111111}, 300)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
@@ -4015,6 +4016,9 @@ func TestSnapshotError(t *testing.T) {
 	w, err := wlog.NewSize(nil, nil, head.wal.Dir(), 32768, wlog.CompressionNone)
 	require.NoError(t, err)
 	// Testing https://github.com/prometheus/prometheus/issues/9437 with the registry.
+	c := &countSeriesLifecycleCallback{}
+	opts := head.opts
+	opts.SeriesCallback = c
 	head, err = NewHead(prometheus.NewRegistry(), nil, w, nil, head.opts, nil)
 	require.NoError(t, err)
 	require.NoError(t, head.Init(math.MinInt64))
@@ -4022,6 +4026,12 @@ func TestSnapshotError(t *testing.T) {
 	// There should be no series in the memory after snapshot error since WAL was removed.
 	require.Equal(t, 1.0, prom_testutil.ToFloat64(head.metrics.snapshotReplayErrorTotal))
 	require.Nil(t, head.series.getByHash(lbls.Hash(), lbls))
+	require.Equal(t, uint64(0), head.NumSeries())
+
+	// Since the snapshot could replay certain series, we continue invoking the create hooks.
+	// In such instances, we need to ensure that we also trigger the delete hooks when resetting the memory.
+	require.Equal(t, int64(2), c.created.Load())
+	require.Equal(t, int64(2), c.deleted.Load())
 	tm, err = head.tombstones.Get(1)
 	require.NoError(t, err)
 	require.Empty(t, tm)
@@ -5828,4 +5838,15 @@ func TestHeadCompactableDoesNotCompactEmptyHead(t *testing.T) {
 	}()
 
 	require.False(t, head.compactable())
+}
+
+type countSeriesLifecycleCallback struct {
+	created atomic.Int64
+	deleted atomic.Int64
+}
+
+func (c *countSeriesLifecycleCallback) PreCreation(labels.Labels) error { return nil }
+func (c *countSeriesLifecycleCallback) PostCreation(labels.Labels)      { c.created.Inc() }
+func (c *countSeriesLifecycleCallback) PostDeletion(s map[chunks.HeadSeriesRef]labels.Labels) {
+	c.deleted.Add(int64(len(s)))
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -4031,7 +4031,7 @@ func TestSnapshotError(t *testing.T) {
 	require.Empty(t, tm)
 	require.NoError(t, head.Close())
 
-	// test corruption in the middle of the snapshot
+	// Test corruption in the middle of the snapshot.
 	f, err = os.OpenFile(path.Join(snapDir, files[0].Name()), os.O_RDWR, 0)
 	require.NoError(t, err)
 	_, err = f.WriteAt(snapshotBackup, 0)


### PR DESCRIPTION
When loading a snapshot and encountering a corrupted chunk, we discard previously loaded series from the snapshot and resort to replaying the wall. In such cases, we were not resetting the number of series in the head, leading to double counting them.

Additionally, we did not invoke the PostDeletion hook when resetting the memory - this needs to be called as the PostCreation was called for the series which we were able to replay from the snapshot but were subsequently discarded.