### PR TITLE
[ENHANCEMENT] TSDB: Faster exemplars

### DIFF
--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -482,8 +482,11 @@ func BenchmarkResizeExemplars(b *testing.B) {
 				require.NoError(b, err)
 				es := exs.(*CircularExemplarStorage)
 
+				var l labels.Labels
 				for i := 0; i < int(float64(tc.startSize)*float64(1.5)); i++ {
-					l := labels.FromStrings("service", strconv.Itoa(i))
+					if i%100 == 0 {
+						l = labels.FromStrings("service", strconv.Itoa(i))
+					}
 
 					err = es.AddExemplar(l, exemplar.Exemplar{Value: float64(i), Ts: int64(i)})
 					if err != nil {

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -415,27 +415,29 @@ func BenchmarkAddExemplar(b *testing.B) {
 	// before adding.
 	exLabels := labels.FromStrings("trace_id", "89620921")
 
-	for _, n := range []int{10000, 100000, 1000000} {
-		b.Run(strconv.Itoa(n), func(b *testing.B) {
-			for j := 0; j < b.N; j++ {
-				b.StopTimer()
-				exs, err := NewCircularExemplarStorage(int64(n), eMetrics)
-				require.NoError(b, err)
-				es := exs.(*CircularExemplarStorage)
-				var l labels.Labels
-				b.StartTimer()
+	for _, capacity := range []int{1000, 10000, 100000} {
+		for _, n := range []int{10000, 100000, 1000000} {
+			b.Run(fmt.Sprintf("%d/%d", n, capacity), func(b *testing.B) {
+				for j := 0; j < b.N; j++ {
+					b.StopTimer()
+					exs, err := NewCircularExemplarStorage(int64(capacity), eMetrics)
+					require.NoError(b, err)
+					es := exs.(*CircularExemplarStorage)
+					var l labels.Labels
+					b.StartTimer()
 
-				for i := 0; i < n; i++ {
-					if i%100 == 0 {
-						l = labels.FromStrings("service", strconv.Itoa(i))
-					}
-					err = es.AddExemplar(l, exemplar.Exemplar{Value: float64(i), Ts: int64(i), Labels: exLabels})
-					if err != nil {
-						require.NoError(b, err)
+					for i := 0; i < n; i++ {
+						if i%100 == 0 {
+							l = labels.FromStrings("service", strconv.Itoa(i))
+						}
+						err = es.AddExemplar(l, exemplar.Exemplar{Value: float64(i), Ts: int64(i), Labels: exLabels})
+						if err != nil {
+							require.NoError(b, err)
+						}
 					}
 				}
-			}
-		})
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
Mostly to change from a slice of pointers to a slice of exemplar entries.
Since the data structure is a circular buffer, every entry will be in-use anyway, except at startup before the buffer fills for the first time.

Also: 
 * Reduce map lookups on exemplar index 
 * Re-use buffer in `Resize()`, saves having to zero it every time.
 * Save map lookup on validation.

Couple of changes to the benchmarks, to make them more realistic. One exemplar per series is not a typical workload. 
`BenchmarkResizeExemplars` shows 4x more memory, because the memory before resize is not counted by the benchmark.

Benchmarks:
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
                                           │  before.txt   │             after.txt              │
                                           │    sec/op     │   sec/op     vs base               │
AddExemplar/10000/1000-8                     1317.5µ ±  2%   749.0µ ± 1%  -43.15% (p=0.002 n=6)
AddExemplar/100000/1000-8                    13.076m ±  1%   7.412m ± 2%  -43.32% (p=0.002 n=6)
AddExemplar/1000000/1000-8                   129.91m ±  0%   73.86m ± 2%  -43.15% (p=0.002 n=6)
AddExemplar/10000/10000-8                    1189.6µ ±  1%   707.9µ ± 2%  -40.50% (p=0.002 n=6)
AddExemplar/100000/10000-8                   13.000m ±  0%   7.449m ± 1%  -42.70% (p=0.002 n=6)
AddExemplar/1000000/10000-8                  132.26m ±  1%   75.30m ± 1%  -43.06% (p=0.002 n=6)
AddExemplar/10000/100000-8                   1201.4µ ±  1%   703.0µ ± 2%  -41.49% (p=0.002 n=6)
AddExemplar/100000/100000-8                  11.699m ±  0%   6.849m ± 2%  -41.45% (p=0.002 n=6)
AddExemplar/1000000/100000-8                 131.36m ±  0%   75.10m ± 2%  -42.83% (p=0.002 n=6)
ResizeExemplars/grow-100000-to-200000-8       2.858m ±  1%   2.152m ± 3%  -24.70% (p=0.002 n=6)
ResizeExemplars/shrink-100000-to-50000-8     1407.2µ ±  1%   795.8µ ± 2%  -43.45% (p=0.002 n=6)
ResizeExemplars/grow-1000000-to-2000000-8     33.62m ± 10%   21.65m ± 1%  -35.59% (p=0.002 n=6)
ResizeExemplars/shrink-1000000-to-500000-8   13.785m ±  1%   7.575m ± 0%  -45.05% (p=0.002 n=6)
geomean                                       10.36m         6.110m       -41.00%

                                           │   before.txt   │               after.txt               │
                                           │      B/op      │     B/op       vs base                │
AddExemplar/10000/1000-8                      72.235Ki ± 0%    9.734Ki ± 0%   -86.52% (p=0.002 n=6)
AddExemplar/100000/1000-8                     161.30Ki ± 0%    98.80Ki ± 0%   -38.75% (p=0.002 n=6)
AddExemplar/1000000/1000-8                    1075.4Ki ± 0%   1012.9Ki ± 0%    -5.81% (p=0.002 n=6)
AddExemplar/10000/10000-8                    634.743Ki ± 0%    9.740Ki ± 0%   -98.47% (p=0.002 n=6)
AddExemplar/100000/10000-8                    723.80Ki ± 0%    98.80Ki ± 0%   -86.35% (p=0.002 n=6)
AddExemplar/1000000/10000-8                   1637.9Ki ± 0%   1012.9Ki ± 0%   -38.16% (p=0.002 n=6)
AddExemplar/10000/100000-8                   634.741Ki ± 0%    9.734Ki ± 0%   -98.47% (p=0.002 n=6)
AddExemplar/100000/100000-8                  6348.85Ki ± 0%    98.80Ki ± 0%   -98.44% (p=0.002 n=6)
AddExemplar/1000000/100000-8                  7262.9Ki ± 0%   1012.9Ki ± 0%   -86.05% (p=0.002 n=6)
ResizeExemplars/grow-100000-to-200000-8        1.984Mi ± 0%   11.140Mi ± 0%  +461.49% (p=0.002 n=6)
ResizeExemplars/shrink-100000-to-50000-8       511.9Ki ± 0%   2855.9Ki ± 0%  +457.92% (p=0.002 n=6)
ResizeExemplars/grow-1000000-to-2000000-8      22.32Mi ± 0%   113.87Mi ± 0%  +410.07% (p=0.002 n=6)
ResizeExemplars/shrink-1000000-to-500000-8     5.623Mi ± 0%   28.506Mi ± 0%  +406.93% (p=0.002 n=6)
geomean                                        1.291Mi         493.3Ki        -62.69%

                                           │  before.txt   │              after.txt               │
                                           │   allocs/op   │  allocs/op   vs base                 │
AddExemplar/10000/1000-8                       1499.0 ± 0%    499.0 ± 0%  -66.71% (p=0.002 n=6)
AddExemplar/100000/1000-8                      5.999k ± 0%   4.999k ± 0%  -16.67% (p=0.002 n=6)
AddExemplar/1000000/1000-8                     51.00k ± 0%   50.00k ± 0%   -1.96% (p=0.002 n=6)
AddExemplar/10000/10000-8                     10499.0 ± 0%    499.0 ± 0%  -95.25% (p=0.002 n=6)
AddExemplar/100000/10000-8                    14.999k ± 0%   4.999k ± 0%  -66.67% (p=0.002 n=6)
AddExemplar/1000000/10000-8                    60.00k ± 0%   50.00k ± 0%  -16.67% (p=0.002 n=6)
AddExemplar/10000/100000-8                    10499.0 ± 0%    499.0 ± 0%  -95.25% (p=0.002 n=6)
AddExemplar/100000/100000-8                  104.999k ± 0%   4.999k ± 0%  -95.24% (p=0.002 n=6)
AddExemplar/1000000/100000-8                  150.00k ± 0%   50.00k ± 0%  -66.67% (p=0.002 n=6)
ResizeExemplars/grow-100000-to-200000-8        1.004k ± 0%   1.004k ± 0%        ~ (p=1.000 n=6) ¹
ResizeExemplars/shrink-100000-to-50000-8        504.0 ± 0%    504.0 ± 0%        ~ (p=1.000 n=6) ¹
ResizeExemplars/grow-1000000-to-2000000-8      10.00k ± 0%   10.00k ± 0%        ~ (p=1.000 n=6) ¹
ResizeExemplars/shrink-1000000-to-500000-8     5.004k ± 0%   5.004k ± 0%        ~ (p=1.000 n=6) ¹
geomean                                        10.47k        3.905k       -62.70%
¹ all samples are equal
```