### PR TITLE
[ENHANCEMENT] TSDB: Allow to stop waiting for pending queries

### DIFF
--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -2090,7 +2090,7 @@ func TestDelayedCompaction(t *testing.T) {
 			require.NotZero(t, getDelayStart())
 
 			// Trigger a manual compaction.
-			require.NoError(t, db.CompactHead(NewRangeHead(db.Head(), 0, 50.0)))
+			require.NoError(t, db.CompactHead(t.Context(), NewRangeHead(db.Head(), 0, 50.0)))
 			require.Equal(t, 4.0, compactorRanCount(db))
 
 			// Re-trigger an auto compaction.

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1463,7 +1463,7 @@ func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
 			for _, m := range blocks {
 				createBlock(t, db.Dir(), genSeries(1, 1, m.MinTime, m.MaxTime))
 			}
-			require.NoError(t, db.reload())
+			require.NoError(t, db.reload(t.Context()))
 			require.Len(t, db.Blocks(), len(blocks), "unexpected block count after a reloadBlocks")
 
 			return len(blocks)

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1227,7 +1227,7 @@ func (db *DB) run(ctx context.Context) {
 					}
 
 					if !nextCompactionIsSoon {
-						if err := db.CompactStaleHead(); err != nil {
+						if err := db.CompactStaleHead(ctx); err != nil {
 							db.logger.Error("immediate stale series compaction failed", "err", err)
 						}
 					}
@@ -1478,9 +1478,11 @@ func (db *DB) Compact(ctx context.Context) (returnErr error) {
 		// ensures that maxt is more than chunkRange/2 back from now, and
 		// head.appendableMinValidTime() ensures that no new appends can start within the compaction range.
 		// We do need to wait for any overlapping appenders that started previously to finish.
-		db.head.WaitForAppendersOverlapping(rh.MaxTime())
+		if err := db.head.WaitForAppendersOverlapping(ctx, rh.MaxTime()); err != nil {
+			return err
+		}
 
-		if err := db.compactHead(rh); err != nil {
+		if err := db.compactHead(ctx, rh); err != nil {
 			return fmt.Errorf("compact head: %w", err)
 		}
 		// Consider only successful compactions for WAL truncation.
@@ -1513,11 +1515,11 @@ func (db *DB) Compact(ctx context.Context) (returnErr error) {
 }
 
 // CompactHead compacts the given RangeHead.
-func (db *DB) CompactHead(head *RangeHead) error {
+func (db *DB) CompactHead(ctx context.Context, head *RangeHead) error {
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
 
-	if err := db.compactHead(head); err != nil {
+	if err := db.compactHead(ctx, head); err != nil {
 		return fmt.Errorf("compact head: %w", err)
 	}
 
@@ -1583,7 +1585,7 @@ func (db *DB) compactOOOHead(ctx context.Context) error {
 			db.mtx.Unlock()
 		}
 
-		if err := db.head.truncateOOO(lastWBLFile, minOOOMmapRef); err != nil {
+		if err := db.head.truncateOOO(ctx, lastWBLFile, minOOOMmapRef); err != nil {
 			return fmt.Errorf("truncate ooo wbl: %w", err)
 		}
 	}
@@ -1640,7 +1642,7 @@ func (db *DB) compactOOO(dest string, oooHead *OOOCompactionHead) (_ []ulid.ULID
 
 // compactHead compacts the given RangeHead.
 // The db.cmtx should be held before calling this method.
-func (db *DB) compactHead(head *RangeHead) error {
+func (db *DB) compactHead(ctx context.Context, head *RangeHead) error {
 	db.lastHeadCompactionTime = time.Now()
 
 	uids, err := db.compactor.Write(db.dir, head, head.MinTime(), head.BlockMaxTime(), nil)
@@ -1659,7 +1661,7 @@ func (db *DB) compactHead(head *RangeHead) error {
 		}
 		return errors.Join(errs...)
 	}
-	if err = db.head.truncateMemory(head.BlockMaxTime()); err != nil {
+	if err = db.head.truncateMemory(ctx, head.BlockMaxTime()); err != nil {
 		return fmt.Errorf("head memory truncate: %w", err)
 	}
 
@@ -1668,7 +1670,7 @@ func (db *DB) compactHead(head *RangeHead) error {
 	return nil
 }
 
-func (db *DB) CompactStaleHead() (err error) {
+func (db *DB) CompactStaleHead(ctx context.Context) (err error) {
 	db.cmtx.Lock()
 	defer func() {
 		db.cmtx.Unlock()
@@ -1712,7 +1714,7 @@ func (db *DB) CompactStaleHead() (err error) {
 		}
 	}
 
-	if err := db.head.truncateStaleSeries(staleSeriesRefs, maxt); err != nil {
+	if err := db.head.truncateStaleSeries(ctx, staleSeriesRefs, maxt); err != nil {
 		return fmt.Errorf("head truncate: %w", err)
 	}
 	db.head.RebuildSymbolTable(db.logger)

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1110,7 +1110,7 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 
 	// Calling db.reload() calls db.reloadBlocks() which requires cmtx to be locked.
 	db.cmtx.Lock()
-	if err := db.reload(); err != nil {
+	if err := db.reload(context.Background()); err != nil {
 		db.cmtx.Unlock()
 		return nil, err
 	}
@@ -1784,7 +1784,7 @@ func getBlock(allBlocks []*Block, id ulid.ULID) (*Block, bool) {
 
 // reload reloads blocks and truncates the head and its WAL.
 // The db.cmtx mutex should be held before calling this method.
-func (db *DB) reload() error {
+func (db *DB) reload(ctx context.Context) error {
 	if err := db.reloadBlocks(); err != nil {
 		return fmt.Errorf("reloadBlocks: %w", err)
 	}
@@ -1792,7 +1792,7 @@ func (db *DB) reload() error {
 	if !ok {
 		return nil
 	}
-	if err := db.head.Truncate(maxt); err != nil {
+	if err := db.head.Truncate(ctx, maxt); err != nil {
 		return fmt.Errorf("head truncate: %w", err)
 	}
 	return nil

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -2318,7 +2318,7 @@ func TestCompactHead_AppendV2(t *testing.T) {
 	require.NoError(t, app.Commit())
 
 	// Compact the Head to create a new block.
-	require.NoError(t, db.CompactHead(NewRangeHead(db.Head(), 0, int64(maxt)-1)))
+	require.NoError(t, db.CompactHead(ctx, NewRangeHead(db.Head(), 0, int64(maxt)-1)))
 	require.NoError(t, db.Close())
 
 	// Delete everything but the new block and
@@ -2363,7 +2363,7 @@ func TestCompactHeadWithDeletion_AppendV2(t *testing.T) {
 	require.NoError(t, err)
 
 	// This recreates the bug.
-	require.NoError(t, db.CompactHead(NewRangeHead(db.Head(), 0, 100)))
+	require.NoError(t, db.CompactHead(ctx, NewRangeHead(db.Head(), 0, 100)))
 	require.NoError(t, db.Close())
 }
 
@@ -3940,7 +3940,7 @@ func testOOOCompactionAppenderV2(t *testing.T, scenario sampleTypeScenario, addE
 
 	// Compact the in-order head and expect another block.
 	// Since this is a forced compaction, this block is not aligned with 2h.
-	err = db.CompactHead(NewRangeHead(db.head, 250*time.Minute.Milliseconds(), 350*time.Minute.Milliseconds()))
+	err = db.CompactHead(ctx, NewRangeHead(db.head, 250*time.Minute.Milliseconds(), 350*time.Minute.Milliseconds()))
 	require.NoError(t, err)
 	require.Len(t, db.Blocks(), 4) // [0, 120), [120, 240), [240, 360), [250, 351)
 	verifySamples(db.Blocks()[3], 250, highest)
@@ -6079,7 +6079,7 @@ func TestOOOHistogramCompactionWithCounterResets_AppendV2(t *testing.T) {
 
 		// Compact the in-order head and expect another block.
 		// Since this is a forced compaction, this block is not aligned with 2h.
-		err = db.CompactHead(NewRangeHead(db.head, 500*time.Minute.Milliseconds(), 550*time.Minute.Milliseconds()))
+		err = db.CompactHead(t.Context(), NewRangeHead(db.head, 500*time.Minute.Milliseconds(), 550*time.Minute.Milliseconds()))
 		require.NoError(t, err)
 		require.Len(t, db.Blocks(), 6)
 		verifyBlockSamples(db.Blocks()[5], 520, 520)
@@ -6182,7 +6182,7 @@ func TestInterleavedInOrderAndOOOHistogramCompactionWithCounterResets_AppendV2(t
 
 		// Compact the in-order head and expect another block.
 		// Since this is a forced compaction, this block is not aligned with 2h.
-		err := db.CompactHead(NewRangeHead(db.head, 0, 3))
+		err := db.CompactHead(ctx, NewRangeHead(db.head, 0, 3))
 		require.NoError(t, err)
 		require.Len(t, db.Blocks(), 2)
 
@@ -6333,7 +6333,7 @@ func testOOOCompactionFailureAppendV2(t *testing.T, scenario sampleTypeScenario)
 
 	// Compact the in-order head and expect another block.
 	// Since this is a forced compaction, this block is not aligned with 2h.
-	err = db.CompactHead(NewRangeHead(db.head, 250*time.Minute.Milliseconds(), 350*time.Minute.Milliseconds()))
+	err = db.CompactHead(ctx, NewRangeHead(db.head, 250*time.Minute.Milliseconds(), 350*time.Minute.Milliseconds()))
 	require.NoError(t, err)
 	require.Len(t, db.Blocks(), 4) // [0, 120), [120, 240), [240, 360), [250, 351)
 	verifySamples(db.Blocks()[3], 250, 350)
@@ -7530,7 +7530,7 @@ func TestCompactHeadWithSTStorage_AppendV2(t *testing.T) {
 	}
 	require.NoError(t, app.Commit())
 
-	require.NoError(t, db.CompactHead(NewRangeHead(db.Head(), int64(mint), int64(maxt)-1)))
+	require.NoError(t, db.CompactHead(ctx, NewRangeHead(db.Head(), int64(mint), int64(maxt)-1)))
 	require.Len(t, db.Blocks(), 1)
 	b := db.Blocks()[0]
 

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3184,7 +3184,7 @@ func TestCompactHead(t *testing.T) {
 	require.NoError(t, app.Commit())
 
 	// Compact the Head to create a new block.
-	require.NoError(t, db.CompactHead(NewRangeHead(db.Head(), 0, int64(maxt)-1)))
+	require.NoError(t, db.CompactHead(ctx, NewRangeHead(db.Head(), 0, int64(maxt)-1)))
 	require.NoError(t, db.Close())
 
 	// Delete everything but the new block and
@@ -3229,7 +3229,7 @@ func TestCompactHeadWithDeletion(t *testing.T) {
 	require.NoError(t, err)
 
 	// This recreates the bug.
-	require.NoError(t, db.CompactHead(NewRangeHead(db.Head(), 0, 100)))
+	require.NoError(t, db.CompactHead(ctx, NewRangeHead(db.Head(), 0, 100)))
 }
 
 func deleteNonBlocks(dbDir string) error {
@@ -5211,7 +5211,7 @@ func testOOOCompaction(t *testing.T, scenario sampleTypeScenario, addExtraSample
 
 	// Compact the in-order head and expect another block.
 	// Since this is a forced compaction, this block is not aligned with 2h.
-	err = db.CompactHead(NewRangeHead(db.head, 250*time.Minute.Milliseconds(), 350*time.Minute.Milliseconds()))
+	err = db.CompactHead(ctx, NewRangeHead(db.head, 250*time.Minute.Milliseconds(), 350*time.Minute.Milliseconds()))
 	require.NoError(t, err)
 	require.Len(t, db.Blocks(), 4) // [0, 120), [120, 240), [240, 360), [250, 351)
 	verifySamples(db.Blocks()[3], 250, highest)
@@ -7350,7 +7350,7 @@ func TestOOOHistogramCompactionWithCounterResets(t *testing.T) {
 
 		// Compact the in-order head and expect another block.
 		// Since this is a forced compaction, this block is not aligned with 2h.
-		err = db.CompactHead(NewRangeHead(db.head, 500*time.Minute.Milliseconds(), 550*time.Minute.Milliseconds()))
+		err = db.CompactHead(ctx, NewRangeHead(db.head, 500*time.Minute.Milliseconds(), 550*time.Minute.Milliseconds()))
 		require.NoError(t, err)
 		require.Len(t, db.Blocks(), 6)
 		verifyBlockSamples(db.Blocks()[5], 520, 520)
@@ -7453,7 +7453,7 @@ func TestInterleavedInOrderAndOOOHistogramCompactionWithCounterResets(t *testing
 
 		// Compact the in-order head and expect another block.
 		// Since this is a forced compaction, this block is not aligned with 2h.
-		require.NoError(t, db.CompactHead(NewRangeHead(db.head, 0, 3)))
+		require.NoError(t, db.CompactHead(ctx, NewRangeHead(db.head, 0, 3)))
 		require.Len(t, db.Blocks(), 2)
 
 		// Blocks created out of normal and OOO head now. But not merged.
@@ -7612,7 +7612,7 @@ func testOOOCompactionFailure(t *testing.T, scenario sampleTypeScenario) {
 
 	// Compact the in-order head and expect another block.
 	// Since this is a forced compaction, this block is not aligned with 2h.
-	err = db.CompactHead(NewRangeHead(db.head, 250*time.Minute.Milliseconds(), 350*time.Minute.Milliseconds()))
+	err = db.CompactHead(ctx, NewRangeHead(db.head, 250*time.Minute.Milliseconds(), 350*time.Minute.Milliseconds()))
 	require.NoError(t, err)
 	require.Len(t, db.Blocks(), 4) // [0, 120), [120, 240), [240, 360), [250, 351)
 	verifySamples(db.Blocks()[3], 250, 350)
@@ -9493,7 +9493,7 @@ func TestStaleSeriesCompaction(t *testing.T) {
 	addNormalSamples(1100, staleSeriesCrossingBoundary, staleHistCrossingBoundary, staleFHistCrossingBoundary)
 	addStaleSamples(1200, staleSeriesCrossingBoundary, staleHistCrossingBoundary, staleFHistCrossingBoundary)
 
-	require.NoError(t, db.CompactStaleHead())
+	require.NoError(t, db.CompactStaleHead(t.Context()))
 
 	require.Equal(t, uint64(3*numSeriesPerCategory), db.Head().NumSeries())
 	require.Equal(t, uint64(0), db.Head().NumStaleSeries())
@@ -9647,7 +9647,7 @@ func TestStaleSeriesCompactionWithZeroSeries(t *testing.T) {
 	require.Equal(t, uint64(0), db.Head().NumStaleSeries())
 
 	// CompactStaleHead should handle zero series gracefully (no panic, no error).
-	require.NoError(t, db.CompactStaleHead())
+	require.NoError(t, db.CompactStaleHead(t.Context()))
 
 	// Should still have no blocks since there was nothing to compact.
 	require.Empty(t, db.Blocks())

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3232,6 +3232,75 @@ func TestCompactHeadWithDeletion(t *testing.T) {
 	require.NoError(t, db.CompactHead(ctx, NewRangeHead(db.Head(), 0, 100)))
 }
 
+// TestCompactCancellation verifies that Compact returns when its context is
+// canceled while it is waiting for in-flight appenders that overlap the
+// compaction range to finish.
+func TestCompactCancellation(t *testing.T) {
+	t.Parallel()
+
+	blockRange := int64(1000)
+	opts := &Options{
+		RetentionDuration: blockRange * 1000,
+		NoLockfile:        true,
+		MinBlockDuration:  blockRange,
+		MaxBlockDuration:  blockRange,
+	}
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+
+	lbls := labels.FromStrings("foo", "bar")
+
+	// Initialise the head with a sample at t=0 so that subsequent appenders
+	// take the regular path and register with isolation.
+	app := db.Appender(context.Background())
+	_, err := app.Append(0, lbls, 0, 0)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	// Open another appender and keep it open. Its isolation minTime is
+	// captured at creation (currently 0) and will overlap the compaction
+	// range even after the head grows past it, forcing Compact() to wait.
+	pending := db.Appender(context.Background())
+	defer func() { require.NoError(t, pending.Rollback()) }()
+
+	// Extend MaxTime past 1.5 * blockRange so the head becomes compactable.
+	app = db.Appender(context.Background())
+	_, err = app.Append(0, lbls, 2*blockRange, 0)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	require.True(t, db.head.compactable(), "head should be compactable")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- db.Compact(ctx)
+	}()
+
+	// Confirm Compact is blocked waiting for `pending` rather than returning
+	// on its own, then cancel and check that it observes the cancellation.
+	select {
+	case err := <-errCh:
+		t.Fatalf("Compact returned before cancel: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Compact did not return after context cancellation")
+	}
+
+	// No block was created.
+	require.Empty(t, db.Blocks())
+	// Cancellation is explicitly excluded from the failure counter.
+	require.Equal(t, 0.0, prom_testutil.ToFloat64(db.metrics.compactionsFailed))
+}
+
 func deleteNonBlocks(dbDir string) error {
 	dirs, err := os.ReadDir(dbDir)
 	if err != nil {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -8761,7 +8761,7 @@ func TestQueryHistogramFromBlocksWithCompaction(t *testing.T) {
 		}
 
 		require.Empty(t, db.Blocks())
-		require.NoError(t, db.reload())
+		require.NoError(t, db.reload(context.Background()))
 		require.Len(t, db.Blocks(), len(blockSeries))
 
 		q, err := db.Querier(math.MinInt64, math.MaxInt64)
@@ -8778,7 +8778,7 @@ func TestQueryHistogramFromBlocksWithCompaction(t *testing.T) {
 		ids, err := db.compactor.Compact(db.Dir(), blockDirs, blocks)
 		require.NoError(t, err)
 		require.Len(t, ids, 1)
-		require.NoError(t, db.reload())
+		require.NoError(t, db.reload(t.Context()))
 		require.Len(t, db.Blocks(), 1)
 
 		q, err = db.Querier(math.MinInt64, math.MaxInt64)
@@ -9509,7 +9509,7 @@ func TestStaleSeriesCompaction(t *testing.T) {
 	require.Truef(t, m.Compaction.FromStaleSeries(), "stale series info not found in block meta")
 
 	// To make sure that Head is not truncated based on stale series block.
-	require.NoError(t, db.reload())
+	require.NoError(t, db.reload(t.Context()))
 
 	nonFirstH := h.Copy()
 	nonFirstH.CounterResetHint = histogram.NotCounterReset

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1191,9 +1191,9 @@ func (h *Head) SetMinValidTime(minValidTime int64) {
 }
 
 // Truncate removes old data before mint from the head and WAL.
-func (h *Head) Truncate(mint int64) (err error) {
+func (h *Head) Truncate(ctx context.Context, mint int64) (err error) {
 	initialized := h.initialized()
-	if err := h.truncateMemory(context.Background(), mint); err != nil {
+	if err := h.truncateMemory(ctx, mint); err != nil {
 		return err
 	}
 	if !initialized {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1193,7 +1193,7 @@ func (h *Head) SetMinValidTime(minValidTime int64) {
 // Truncate removes old data before mint from the head and WAL.
 func (h *Head) Truncate(mint int64) (err error) {
 	initialized := h.initialized()
-	if err := h.truncateMemory(mint); err != nil {
+	if err := h.truncateMemory(context.Background(), mint); err != nil {
 		return err
 	}
 	if !initialized {
@@ -1208,7 +1208,7 @@ func (h *Head) OverlapsClosedInterval(mint, maxt int64) bool {
 }
 
 // truncateMemory removes old data before mint from the head.
-func (h *Head) truncateMemory(mint int64) (err error) {
+func (h *Head) truncateMemory(ctx context.Context, mint int64) (err error) {
 	h.chunkSnapshotMtx.Lock()
 	defer h.chunkSnapshotMtx.Unlock()
 
@@ -1236,7 +1236,9 @@ func (h *Head) truncateMemory(mint int64) (err error) {
 
 	// We wait for pending queries to end that overlap with this truncation.
 	if initialized {
-		h.WaitForPendingReadersInTimeRange(h.MinTime(), mint)
+		if err := h.WaitForPendingReadersInTimeRange(ctx, h.MinTime(), mint); err != nil {
+			return err
+		}
 	}
 
 	h.minTime.Store(mint)
@@ -1258,7 +1260,7 @@ func (h *Head) truncateMemory(mint int64) (err error) {
 }
 
 // truncateStaleSeries removes the provided series as long as they are still stale.
-func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64) error {
+func (h *Head) truncateStaleSeries(ctx context.Context, seriesRefs []storage.SeriesRef, maxt int64) error {
 	h.chunkSnapshotMtx.Lock()
 	defer h.chunkSnapshotMtx.Unlock()
 
@@ -1266,7 +1268,9 @@ func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64) e
 		return nil
 	}
 
-	h.WaitForPendingReadersInTimeRange(h.MinTime(), maxt)
+	if err := h.WaitForPendingReadersInTimeRange(ctx, h.MinTime(), maxt); err != nil {
+		return err
+	}
 
 	deleted := h.gcStaleSeries(seriesRefs, maxt)
 
@@ -1290,7 +1294,7 @@ func (h *Head) truncateStaleSeries(seriesRefs []storage.SeriesRef, maxt int64) e
 // WaitForPendingReadersInTimeRange waits for queries overlapping with given range to finish querying.
 // The query timeout limits the max wait time of this function implicitly.
 // The mint is inclusive and maxt is the truncation time hence exclusive.
-func (h *Head) WaitForPendingReadersInTimeRange(mint, maxt int64) {
+func (h *Head) WaitForPendingReadersInTimeRange(ctx context.Context, mint, maxt int64) error {
 	maxt-- // Making it inclusive before checking overlaps.
 	overlaps := func() bool {
 		o := false
@@ -1305,23 +1309,35 @@ func (h *Head) WaitForPendingReadersInTimeRange(mint, maxt int64) {
 		return o
 	}
 	for overlaps() {
+		if err := ctx.Err(); err != nil {
+			return context.Cause(ctx)
+		}
 		time.Sleep(500 * time.Millisecond)
 	}
+	return nil
 }
 
 // WaitForPendingReadersForOOOChunksAtOrBefore is like WaitForPendingReadersInTimeRange, except it waits for
 // queries touching OOO chunks less than or equal to chunk to finish querying.
-func (h *Head) WaitForPendingReadersForOOOChunksAtOrBefore(chunk chunks.ChunkDiskMapperRef) {
+func (h *Head) WaitForPendingReadersForOOOChunksAtOrBefore(ctx context.Context, chunk chunks.ChunkDiskMapperRef) error {
 	for h.oooIso.HasOpenReadsAtOrBefore(chunk) {
+		if err := ctx.Err(); err != nil {
+			return context.Cause(ctx)
+		}
 		time.Sleep(500 * time.Millisecond)
 	}
+	return nil
 }
 
 // WaitForAppendersOverlapping waits for appends overlapping maxt to finish.
-func (h *Head) WaitForAppendersOverlapping(maxt int64) {
+func (h *Head) WaitForAppendersOverlapping(ctx context.Context, maxt int64) error {
 	for maxt >= h.iso.lowestAppendTime() {
+		if err := ctx.Err(); err != nil {
+			return context.Cause(ctx)
+		}
 		time.Sleep(500 * time.Millisecond)
 	}
+	return nil
 }
 
 // IsQuerierCollidingWithTruncation returns if the current querier needs to be closed and if a new querier
@@ -1484,10 +1500,12 @@ func (h *Head) truncateWAL(mint int64) error {
 //
 // The caller is responsible for ensuring that no further queriers will be created that reference chunks less
 // than or equal to newMinOOOMmapRef before calling truncateOOO.
-func (h *Head) truncateOOO(lastWBLFile int, newMinOOOMmapRef chunks.ChunkDiskMapperRef) error {
+func (h *Head) truncateOOO(ctx context.Context, lastWBLFile int, newMinOOOMmapRef chunks.ChunkDiskMapperRef) error {
 	curMinOOOMmapRef := chunks.ChunkDiskMapperRef(h.minOOOMmapRef.Load())
 	if newMinOOOMmapRef.GreaterThan(curMinOOOMmapRef) {
-		h.WaitForPendingReadersForOOOChunksAtOrBefore(newMinOOOMmapRef)
+		if err := h.WaitForPendingReadersForOOOChunksAtOrBefore(ctx, newMinOOOMmapRef); err != nil {
+			return err
+		}
 		h.minOOOMmapRef.Store(uint64(newMinOOOMmapRef))
 
 		if err := h.truncateSeriesAndChunkDiskMapper("truncateOOO"); err != nil {

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -82,7 +82,7 @@ func TestHeadAppenderV2_WALMultiRef(t *testing.T) {
 	require.NoError(t, app.Commit())
 	require.Equal(t, 2.0, prom_testutil.ToFloat64(head.metrics.chunksCreated))
 
-	require.NoError(t, head.Truncate(1600))
+	require.NoError(t, head.Truncate(t.Context(), 1600))
 
 	app = head.AppenderV2(context.Background())
 	ref2, err := app.Append(0, labels.FromStrings("foo", "bar"), 0, 1700, 3, nil, nil, storage.AOptions{})
@@ -430,7 +430,7 @@ func TestHeadAppenderV2_DeleteSamplesAndSeriesStillInWALAfterCheckpoint(t *testi
 		require.NoError(t, app.Commit())
 	}
 	require.NoError(t, hb.Delete(context.Background(), 0, int64(numSamples), labels.MustNewMatcher(labels.MatchEqual, "a", "b")))
-	require.NoError(t, hb.Truncate(1))
+	require.NoError(t, hb.Truncate(t.Context(), 1))
 	require.NoError(t, hb.Close())
 
 	// Confirm there's been a checkpoint.
@@ -633,7 +633,7 @@ func TestHeadAppenderV2_UncommittedSamplesNotLostOnTruncate(t *testing.T) {
 	_, err := app.Append(0, lset, 0, 2100, 1, nil, nil, storage.AOptions{})
 	require.NoError(t, err)
 
-	require.NoError(t, h.Truncate(2000))
+	require.NoError(t, h.Truncate(t.Context(), 2000))
 	require.NotNil(t, h.series.getByHash(lset.Hash(), lset), "series should not have been garbage collected")
 
 	require.NoError(t, app.Commit())
@@ -663,7 +663,7 @@ func TestHeadAppenderV2_TestRemoveSeriesAfterRollbackAndTruncate(t *testing.T) {
 	_, err := app.Append(0, lset, 0, 2100, 1, nil, nil, storage.AOptions{})
 	require.NoError(t, err)
 
-	require.NoError(t, h.Truncate(2000))
+	require.NoError(t, h.Truncate(t.Context(), 2000))
 	require.NotNil(t, h.series.getByHash(lset.Hash(), lset), "series should not have been garbage collected")
 
 	require.NoError(t, app.Rollback())
@@ -677,7 +677,7 @@ func TestHeadAppenderV2_TestRemoveSeriesAfterRollbackAndTruncate(t *testing.T) {
 	require.NoError(t, q.Close())
 
 	// Truncate again, this time the series should be deleted
-	require.NoError(t, h.Truncate(2050))
+	require.NoError(t, h.Truncate(t.Context(), 2050))
 	require.Equal(t, (*memSeries)(nil), h.series.getByHash(lset.Hash(), lset))
 }
 
@@ -753,13 +753,13 @@ func TestHeadAppenderV2_NewWalSegmentOnTruncate(t *testing.T) {
 	require.Equal(t, 0, last)
 
 	add(1)
-	require.NoError(t, h.Truncate(1))
+	require.NoError(t, h.Truncate(t.Context(), 1))
 	_, last, err = wlog.Segments(wal.Dir())
 	require.NoError(t, err)
 	require.Equal(t, 1, last)
 
 	add(2)
-	require.NoError(t, h.Truncate(2))
+	require.NoError(t, h.Truncate(t.Context(), 2))
 	_, last, err = wlog.Segments(wal.Dir())
 	require.NoError(t, err)
 	require.Equal(t, 2, last)
@@ -1266,19 +1266,19 @@ func TestHeadAppenderV2_MinTimeAfterTruncation(t *testing.T) {
 
 	// Truncating outside the appendable window and actual mint being outside
 	// appendable window should leave mint at the actual mint.
-	require.NoError(t, head.Truncate(3500))
+	require.NoError(t, head.Truncate(t.Context(), 3500))
 	require.Equal(t, int64(4000), head.MinTime())
 	require.Equal(t, int64(4000), head.minValidTime.Load())
 
 	// After truncation outside the appendable window if the actual min time
 	// is in the appendable window then we should leave mint at the start of appendable window.
-	require.NoError(t, head.Truncate(5000))
+	require.NoError(t, head.Truncate(t.Context(), 5000))
 	require.Equal(t, head.appendableMinValidTime(), head.MinTime())
 	require.Equal(t, head.appendableMinValidTime(), head.minValidTime.Load())
 
 	// If the truncation time is inside the appendable window, then the min time
 	// should be the truncation time.
-	require.NoError(t, head.Truncate(7500))
+	require.NoError(t, head.Truncate(t.Context(), 7500))
 	require.Equal(t, int64(7500), head.MinTime())
 	require.Equal(t, int64(7500), head.minValidTime.Load())
 
@@ -4760,7 +4760,7 @@ func TestHeadAppenderV2_NumStaleSeries(t *testing.T) {
 
 	// Test garbage collection behavior - stale series should be decremented when GC'd.
 	// Force a garbage collection by truncating old data.
-	require.NoError(t, head.Truncate(300))
+	require.NoError(t, head.Truncate(t.Context(), 300))
 
 	// After truncation, run GC to collect old chunks/series.
 	head.gc()

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -1447,7 +1447,7 @@ func TestWaitForPendingReadersInTimeRange_AppenderV2(t *testing.T) {
 				synctest.Test(t, func(t *testing.T) {
 					var waitOver atomic.Bool
 					go func() {
-						db.head.WaitForPendingReadersInTimeRange(truncMint, truncMaxt)
+						db.head.WaitForPendingReadersInTimeRange(t.Context(), truncMint, truncMaxt)
 						waitOver.Store(true)
 					}()
 
@@ -3442,7 +3442,7 @@ func testHeadMinOOOTimeUpdateAppenderV2(t *testing.T, scenario sampleTypeScenari
 	require.Equal(t, 295*time.Minute.Milliseconds(), h.MinOOOTime())
 
 	// Allowed window for OOO is >=290, which is before the earliest ooo sample 295, so it gets set to the lower value.
-	require.NoError(t, h.truncateOOO(0, 1))
+	require.NoError(t, h.truncateOOO(t.Context(), 0, 1))
 	require.Equal(t, 290*time.Minute.Milliseconds(), h.MinOOOTime())
 
 	appendSample(310) // In-order sample.
@@ -3451,7 +3451,7 @@ func testHeadMinOOOTimeUpdateAppenderV2(t *testing.T, scenario sampleTypeScenari
 
 	// Now the OOO sample 295 was not gc'ed yet. And allowed window for OOO is now >=300.
 	// So the lowest among them, 295, is set as minOOOTime.
-	require.NoError(t, h.truncateOOO(0, 2))
+	require.NoError(t, h.truncateOOO(t.Context(), 0, 2))
 	require.Equal(t, 295*time.Minute.Milliseconds(), h.MinOOOTime())
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -937,7 +937,7 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 
 	// Truncate stale series: removes ref1 from the head and writes a
 	// [MinInt64, MaxInt64] tombstone record to the WAL.
-	require.NoError(t, head.truncateStaleSeries([]storage.SeriesRef{ref1}, 3500))
+	require.NoError(t, head.truncateStaleSeries(t.Context(), []storage.SeriesRef{ref1}, 3500))
 
 	// Append a single sample with the same labels to create ref2.
 	// Ref2 has 0 m-mapped chunks, fewer than ref1's 3.
@@ -4080,7 +4080,7 @@ func TestWaitForPendingReadersInTimeRange(t *testing.T) {
 				synctest.Test(t, func(t *testing.T) {
 					var waitOver atomic.Bool
 					go func() {
-						db.head.WaitForPendingReadersInTimeRange(truncMint, truncMaxt)
+						db.head.WaitForPendingReadersInTimeRange(t.Context(), truncMint, truncMaxt)
 						waitOver.Store(true)
 					}()
 
@@ -6261,7 +6261,7 @@ func testHeadMinOOOTimeUpdate(t *testing.T, scenario sampleTypeScenario) {
 	require.Equal(t, 295*time.Minute.Milliseconds(), h.MinOOOTime())
 
 	// Allowed window for OOO is >=290, which is before the earliest ooo sample 295, so it gets set to the lower value.
-	require.NoError(t, h.truncateOOO(0, 1))
+	require.NoError(t, h.truncateOOO(t.Context(), 0, 1))
 	require.Equal(t, 290*time.Minute.Milliseconds(), h.MinOOOTime())
 
 	appendSample(310) // In-order sample.
@@ -6270,7 +6270,7 @@ func testHeadMinOOOTimeUpdate(t *testing.T, scenario sampleTypeScenario) {
 
 	// Now the OOO sample 295 was not gc'ed yet. And allowed window for OOO is now >=300.
 	// So the lowest among them, 295, is set as minOOOTime.
-	require.NoError(t, h.truncateOOO(0, 2))
+	require.NoError(t, h.truncateOOO(t.Context(), 0, 2))
 	require.Equal(t, 295*time.Minute.Milliseconds(), h.MinOOOTime())
 }
 
@@ -7993,7 +7993,7 @@ func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
 		require.NotNil(t, ms)
 		staleRefs = append(staleRefs, storage.SeriesRef(ms.ref))
 	}
-	require.NoError(t, head.truncateStaleSeries(staleRefs, 300))
+	require.NoError(t, head.truncateStaleSeries(t.Context(), staleRefs, 300))
 	require.Equal(t, uint64(0), head.NumStaleSeries())
 	require.Equal(t, uint64(0), head.NumSeries())
 
@@ -8600,7 +8600,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		readyBefore := mmapReadyCounter()
 
 		// Use truncateStaleSeries which calls gcStaleSeries internally.
-		require.NoError(t, h.truncateStaleSeries(
+		require.NoError(t, h.truncateStaleSeries(t.Context(),
 			[]storage.SeriesRef{storage.SeriesRef(sB.ref)}, ts,
 		))
 		requireCounterConsistent("after truncateStaleSeries")

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -855,7 +855,7 @@ func TestHead_WALMultiRef(t *testing.T) {
 	require.NoError(t, app.Commit())
 	require.Equal(t, 2.0, prom_testutil.ToFloat64(head.metrics.chunksCreated))
 
-	require.NoError(t, head.Truncate(1600))
+	require.NoError(t, head.Truncate(context.Background(), 1600))
 
 	app = head.Appender(context.Background())
 	ref2, err := app.Append(0, labels.FromStrings("foo", "bar"), 1700, 3)
@@ -1443,7 +1443,7 @@ func BenchmarkHead_Truncate(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; b.Loop(); i++ {
-				require.NoError(b, h.Truncate(1000*int64(i)))
+				require.NoError(b, h.Truncate(b.Context(), 1000*int64(i)))
 				// Make sure the benchmark is meaningful and it's actually truncating the expected amount of series.
 				require.Equal(b, total-churn*i, int(h.NumSeries()))
 			}
@@ -1480,9 +1480,9 @@ func TestHead_Truncate(t *testing.T) {
 	s4.mmappedChunks = []*mmappedChunk{}
 
 	// Truncation need not be aligned.
-	require.NoError(t, h.Truncate(1))
+	require.NoError(t, h.Truncate(context.Background(), 1))
 
-	require.NoError(t, h.Truncate(2000))
+	require.NoError(t, h.Truncate(context.Background(), 2000))
 
 	require.Equal(t, []*mmappedChunk{
 		{minTime: 2000, maxTime: 2999},
@@ -1983,7 +1983,7 @@ func TestDeletedSamplesAndSeriesStillInWALAfterCheckpoint(t *testing.T) {
 		require.NoError(t, app.Commit())
 	}
 	require.NoError(t, hb.Delete(context.Background(), 0, int64(numSamples), labels.MustNewMatcher(labels.MatchEqual, "a", "b")))
-	require.NoError(t, hb.Truncate(1))
+	require.NoError(t, hb.Truncate(context.Background(), 1))
 	require.NoError(t, hb.Close())
 
 	// Confirm there's been a checkpoint.
@@ -2559,7 +2559,7 @@ func TestGCChunkAccess(t *testing.T) {
 	_, _, err = cr.ChunkOrIterable(chnks[1])
 	require.NoError(t, err)
 
-	require.NoError(t, h.Truncate(1500)) // Remove a chunk.
+	require.NoError(t, h.Truncate(context.Background(), 1500)) // Remove a chunk.
 
 	_, _, err = cr.ChunkOrIterable(chnks[0])
 	require.Equal(t, storage.ErrNotFound, err)
@@ -2615,7 +2615,7 @@ func TestGCSeriesAccess(t *testing.T) {
 	_, _, err = cr.ChunkOrIterable(chunks[1])
 	require.NoError(t, err)
 
-	require.NoError(t, h.Truncate(2000)) // Remove the series.
+	require.NoError(t, h.Truncate(context.Background(), 2000)) // Remove the series.
 
 	require.Equal(t, (*memSeries)(nil), h.series.getByID(1))
 
@@ -2635,7 +2635,7 @@ func TestUncommittedSamplesNotLostOnTruncate(t *testing.T) {
 	_, err := app.Append(0, lset, 2100, 1)
 	require.NoError(t, err)
 
-	require.NoError(t, h.Truncate(2000))
+	require.NoError(t, h.Truncate(context.Background(), 2000))
 	require.NotNil(t, h.series.getByHash(lset.Hash(), lset), "series should not have been garbage collected")
 
 	require.NoError(t, app.Commit())
@@ -2662,7 +2662,7 @@ func TestRemoveSeriesAfterRollbackAndTruncate(t *testing.T) {
 	_, err := app.Append(0, lset, 2100, 1)
 	require.NoError(t, err)
 
-	require.NoError(t, h.Truncate(2000))
+	require.NoError(t, h.Truncate(context.Background(), 2000))
 	require.NotNil(t, h.series.getByHash(lset.Hash(), lset), "series should not have been garbage collected")
 
 	require.NoError(t, app.Rollback())
@@ -2676,7 +2676,7 @@ func TestRemoveSeriesAfterRollbackAndTruncate(t *testing.T) {
 	require.NoError(t, q.Close())
 
 	// Truncate again, this time the series should be deleted
-	require.NoError(t, h.Truncate(2050))
+	require.NoError(t, h.Truncate(context.Background(), 2050))
 	require.Equal(t, (*memSeries)(nil), h.series.getByHash(lset.Hash(), lset))
 }
 
@@ -2992,13 +2992,13 @@ func TestNewWalSegmentOnTruncate(t *testing.T) {
 	require.Equal(t, 0, last)
 
 	add(1)
-	require.NoError(t, h.Truncate(1))
+	require.NoError(t, h.Truncate(context.Background(), 1))
 	_, last, err = wlog.Segments(wal.Dir())
 	require.NoError(t, err)
 	require.Equal(t, 1, last)
 
 	add(2)
-	require.NoError(t, h.Truncate(2))
+	require.NoError(t, h.Truncate(context.Background(), 2))
 	_, last, err = wlog.Segments(wal.Dir())
 	require.NoError(t, err)
 	require.Equal(t, 2, last)
@@ -3746,19 +3746,19 @@ func TestHeadMintAfterTruncation(t *testing.T) {
 
 	// Truncating outside the appendable window and actual mint being outside
 	// appendable window should leave mint at the actual mint.
-	require.NoError(t, head.Truncate(3500))
+	require.NoError(t, head.Truncate(context.Background(), 3500))
 	require.Equal(t, int64(4000), head.MinTime())
 	require.Equal(t, int64(4000), head.minValidTime.Load())
 
 	// After truncation outside the appendable window if the actual min time
 	// is in the appendable window then we should leave mint at the start of appendable window.
-	require.NoError(t, head.Truncate(5000))
+	require.NoError(t, head.Truncate(context.Background(), 5000))
 	require.Equal(t, head.appendableMinValidTime(), head.MinTime())
 	require.Equal(t, head.appendableMinValidTime(), head.minValidTime.Load())
 
 	// If the truncation time is inside the appendable window, then the min time
 	// should be the truncation time.
-	require.NoError(t, head.Truncate(7500))
+	require.NoError(t, head.Truncate(context.Background(), 7500))
 	require.Equal(t, int64(7500), head.MinTime())
 	require.Equal(t, int64(7500), head.minValidTime.Load())
 }
@@ -6781,7 +6781,7 @@ func TestHeadCompactionWhileAppendAndCommitExemplar(t *testing.T) {
 	app = h.Appender(context.Background())
 	_, err = app.AppendExemplar(ref, lbls, exemplar.Exemplar{Value: 1, Ts: 20})
 	require.NoError(t, err)
-	h.Truncate(10)
+	h.Truncate(context.Background(), 10)
 	app.Commit()
 }
 
@@ -7480,7 +7480,7 @@ func TestHead_NumStaleSeries(t *testing.T) {
 
 	// Test garbage collection behavior - stale series should be decremented when GC'd.
 	// Force a garbage collection by truncating old data.
-	require.NoError(t, head.Truncate(300))
+	require.NoError(t, head.Truncate(t.Context(), 300))
 
 	// After truncation, run GC to collect old chunks/series.
 	head.gc()


### PR DESCRIPTION
If queries take a very long time to finish, perhaps because something has gone wrong, we would prefer operations like `Compact()` to be interruptible so we can shut down cleanly.

```release-notes
[BUGFIX] TSDB: Cancel a compaction in progress if Prometheus is shut down.
```
