### PR TITLE
PromQL: Allow operators between range vector selectors and scalars

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2086,11 +2086,11 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		case lt == parser.ValueTypeMatrix && rt == parser.ValueTypeScalar:
 			var allAnnos annotations.Annotations
 
-			valLHS, anons := ev.eval(ctx, e.LHS)
-			allAnnos.Merge(anons)
+			valLHS, annons := ev.eval(ctx, e.LHS)
+			allAnnos.Merge(annons)
 
-			valRHS, anons := ev.eval(ctx, e.RHS)
-			allAnnos.Merge(anons)
+			valRHS, annons := ev.eval(ctx, e.RHS)
+			allAnnos.Merge(annons)
 
 			valMatrix := valLHS.(Matrix)
 			valScalar := Scalar{V: valRHS.(Matrix)[0].Floats[0].F}
@@ -2105,11 +2105,11 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		case lt == parser.ValueTypeScalar && rt == parser.ValueTypeMatrix:
 			var allAnnos annotations.Annotations
 
-			valLHS, anons := ev.eval(ctx, e.LHS)
-			allAnnos.Merge(anons)
+			valLHS, annons := ev.eval(ctx, e.LHS)
+			allAnnos.Merge(annons)
 
-			valRHS, anons := ev.eval(ctx, e.RHS)
-			allAnnos.Merge(anons)
+			valRHS, annons := ev.eval(ctx, e.RHS)
+			allAnnos.Merge(annons)
 
 			valMatrix := valRHS.(Matrix)
 			valScalar := Scalar{V: valLHS.(Matrix)[0].Floats[0].F}

--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -252,9 +252,17 @@ func (e *StringLiteral) Type() ValueType  { return ValueTypeString }
 func (e *UnaryExpr) Type() ValueType      { return e.Expr.Type() }
 func (e *VectorSelector) Type() ValueType { return ValueTypeVector }
 func (e *BinaryExpr) Type() ValueType {
-	if e.LHS.Type() == ValueTypeScalar && e.RHS.Type() == ValueTypeScalar {
+	lt, rt := e.LHS.Type(), e.RHS.Type()
+	if lt == ValueTypeScalar && rt == ValueTypeScalar {
 		return ValueTypeScalar
 	}
+
+	// Operator between range vector selector and scalar.
+	if lt == ValueTypeMatrix || rt == ValueTypeMatrix {
+		return ValueTypeMatrix
+	}
+
+	// Operator between instant vector selector and scalar.
 	return ValueTypeVector
 }
 func (e *StepInvariantExpr) Type() ValueType { return e.Expr.Type() }

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -769,11 +769,15 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 		if !n.Op.IsOperator() {
 			p.addParseErrf(n.PositionRange(), "binary expression does not support operator %q", n.Op)
 		}
-		if lt != ValueTypeScalar && lt != ValueTypeVector {
-			p.addParseErrf(n.LHS.PositionRange(), "binary expression must contain only scalar and instant vector types")
+		if lt != ValueTypeScalar && lt != ValueTypeVector && lt != ValueTypeMatrix {
+			p.addParseErrf(n.LHS.PositionRange(), "binary expression must contain only scalar, instant vector types and matrix vector types")
 		}
-		if rt != ValueTypeScalar && rt != ValueTypeVector {
-			p.addParseErrf(n.RHS.PositionRange(), "binary expression must contain only scalar and instant vector types")
+		if rt != ValueTypeScalar && rt != ValueTypeVector && rt != ValueTypeMatrix {
+			p.addParseErrf(n.RHS.PositionRange(), "binary expression must contain only scalar, instant vector types and matrix vector types")
+		}
+
+		if (lt == ValueTypeVector && rt == ValueTypeMatrix) || (rt == ValueTypeVector && lt == ValueTypeMatrix) || (lt == ValueTypeMatrix && rt == ValueTypeMatrix) {
+			p.addParseErrf(n.RHS.PositionRange(), "binary expression must contain only scalar, instant vector types and matrix vector types")
 		}
 
 		switch {

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -770,14 +770,14 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 			p.addParseErrf(n.PositionRange(), "binary expression does not support operator %q", n.Op)
 		}
 		if lt != ValueTypeScalar && lt != ValueTypeVector && lt != ValueTypeMatrix {
-			p.addParseErrf(n.LHS.PositionRange(), "binary expression must contain only scalar, instant vector types and matrix vector types")
+			p.addParseErrf(n.LHS.PositionRange(), "binary expression must contain only scalar, instant vector, and range vector types")
 		}
 		if rt != ValueTypeScalar && rt != ValueTypeVector && rt != ValueTypeMatrix {
-			p.addParseErrf(n.RHS.PositionRange(), "binary expression must contain only scalar, instant vector types and matrix vector types")
+			p.addParseErrf(n.RHS.PositionRange(), "binary expression must contain only scalar, instant vector, and range vector types")
 		}
 
-		if (lt == ValueTypeVector && rt == ValueTypeMatrix) || (rt == ValueTypeVector && lt == ValueTypeMatrix) || (lt == ValueTypeMatrix && rt == ValueTypeMatrix) {
-			p.addParseErrf(n.RHS.PositionRange(), "binary expression must contain only scalar, instant vector types and matrix vector types")
+		if (lt == ValueTypeVector && rt == ValueTypeMatrix) || (lt == ValueTypeMatrix && rt == ValueTypeVector) || (lt == ValueTypeMatrix && rt == ValueTypeMatrix) {
+			p.addParseErrf(n.RHS.PositionRange(), "binary expression involving a range vector requires a scalar type as the other operand")
 		}
 
 		switch {

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -560,6 +560,21 @@ var testExpr = []struct {
 		errMsg: "set operator \"and\" not allowed in binary scalar expression",
 	},
 	{
+		input:  `test[5m] + test[5m]`,
+		fail:   true,
+		errMsg: `binary expression must contain only scalar, instant vector types and matrix vector types`,
+	},
+	{
+		input:  `test[5m] + test`,
+		fail:   true,
+		errMsg: `binary expression must contain only scalar, instant vector types and matrix vector types`,
+	},
+	{
+		input:  `test + test[5m]`,
+		fail:   true,
+		errMsg: `binary expression must contain only scalar, instant vector types and matrix vector types`,
+	},
+	{
 		input:  "1 == 1",
 		fail:   true,
 		errMsg: "1:3: parse error: comparisons between scalars must use BOOL modifier",
@@ -2221,6 +2236,32 @@ var testExpr = []struct {
 		},
 	},
 	{
+		input: `foo[3ms] @ 2.345 + 1`,
+		expected: &BinaryExpr{
+			Op: ADD,
+			LHS: &MatrixSelector{
+				VectorSelector: &VectorSelector{
+					Name:      "foo",
+					Timestamp: makeInt64Pointer(2345),
+					LabelMatchers: []*labels.Matcher{
+						MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+					},
+					PosRange: posrange.PositionRange{
+						Start: 0,
+						End:   3,
+					},
+				},
+				Range:  3 * time.Millisecond,
+				EndPos: 16,
+			},
+			RHS: &NumberLiteral{
+				Val:      1,
+				PosRange: posrange.PositionRange{Start: 19, End: 20},
+			},
+			VectorMatching: nil,
+		},
+	},
+	{
 		input: `foo[4s180ms] @ 2.345`,
 		expected: &MatrixSelector{
 			VectorSelector: &VectorSelector{
@@ -3073,6 +3114,64 @@ var testExpr = []struct {
 				},
 			},
 			VectorMatching: &VectorMatching{},
+		},
+	},
+	{
+		input: "a[5m] + 1",
+		expected: &BinaryExpr{
+			Op: ADD,
+			LHS: &MatrixSelector{
+				VectorSelector: &VectorSelector{
+					Name: "a",
+					LabelMatchers: []*labels.Matcher{
+						MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "a"),
+					},
+					PosRange: posrange.PositionRange{
+						Start: 0,
+						End:   1,
+					},
+				},
+				Range:  5 * time.Minute,
+				EndPos: 5,
+			},
+			RHS: &NumberLiteral{
+				Val:      1,
+				PosRange: posrange.PositionRange{Start: 8, End: 9},
+			},
+			VectorMatching: nil,
+		},
+	},
+	{
+		input: "a[5m] > 0 > 1",
+		expected: &BinaryExpr{
+			Op: GTR,
+			LHS: &BinaryExpr{
+				Op: GTR,
+				LHS: &MatrixSelector{
+					VectorSelector: &VectorSelector{
+						Name: "a",
+						LabelMatchers: []*labels.Matcher{
+							MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "a"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   1,
+						},
+					},
+					Range:  5 * time.Minute,
+					EndPos: 5,
+				},
+				RHS: &NumberLiteral{
+					Val:      0,
+					PosRange: posrange.PositionRange{Start: 8, End: 9},
+				},
+				VectorMatching: nil,
+			},
+			RHS: &NumberLiteral{
+				Val:      1,
+				PosRange: posrange.PositionRange{Start: 12, End: 13},
+			},
+			VectorMatching: nil,
 		},
 	},
 	// String quoting and escape sequence interpretation tests.

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -562,17 +562,17 @@ var testExpr = []struct {
 	{
 		input:  `test[5m] + test[5m]`,
 		fail:   true,
-		errMsg: `binary expression must contain only scalar, instant vector types and matrix vector types`,
+		errMsg: `binary expression involving a range vector requires a scalar type as the other operand`,
 	},
 	{
 		input:  `test[5m] + test`,
 		fail:   true,
-		errMsg: `binary expression must contain only scalar, instant vector types and matrix vector types`,
+		errMsg: `binary expression involving a range vector requires a scalar type as the other operand`,
 	},
 	{
 		input:  `test + test[5m]`,
 		fail:   true,
-		errMsg: `binary expression must contain only scalar, instant vector types and matrix vector types`,
+		errMsg: `binary expression involving a range vector requires a scalar type as the other operand`,
 	},
 	{
 		input:  "1 == 1",

--- a/promql/parser/prettier_test.go
+++ b/promql/parser/prettier_test.go
@@ -131,6 +131,20 @@ func TestBinaryExprPretty(t *testing.T) {
 			out: `a + b`,
 		},
 		{
+			in:  `a[5m]+1`,
+			out: `a[5m] + 1`,
+		},
+		{
+			in: `a[5m]+1+2+3>4`,
+			out: `      a[5m] + 1
+    +
+      2
+  +
+    3
+>
+  4`,
+		},
+		{
 			in: `a == bool 1`,
 			out: `  a
 == bool

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -181,10 +181,19 @@ eval instant at 50m rate(calculate_rate_window_total[50m])
 eval instant at 50m rate(calculate_rate_window_total[50m] + 0)
 	{} 0.26666666666666666
 
+eval instant at 50m rate(0 + calculate_rate_window_total[50m])
+	{} 0.26666666666666666
+
 eval instant at 50m rate(calculate_rate_window_total[50m] + 0 - 0)
 	{} 0.26666666666666666
 
+eval instant at 50m rate(0 - 0 + calculate_rate_window_total[50m] + 0 - 0)
+	{} 0.26666666666666666
+
 eval instant at 50m rate(calculate_rate_window_total[50m] + 0 - 0 + 1 > 0)
+	{} 0.26666666666666666
+
+eval instant at 50m rate(0 < calculate_rate_window_total[50m] + 0 - 0 + 1 > 0)
 	{} 0.26666666666666666
 
 eval instant at 50m rate(calculate_rate_offset_total[10m] offset 5m)

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -178,6 +178,15 @@ load 5m
 eval instant at 50m rate(calculate_rate_window_total[50m])
 	{} 0.26666666666666666
 
+eval instant at 50m rate(calculate_rate_window_total[50m] + 0)
+	{} 0.26666666666666666
+
+eval instant at 50m rate(calculate_rate_window_total[50m] + 0 - 0)
+	{} 0.26666666666666666
+
+eval instant at 50m rate(calculate_rate_window_total[50m] + 0 - 0 + 1 > 0)
+	{} 0.26666666666666666
+
 eval instant at 50m rate(calculate_rate_offset_total[10m] offset 5m)
 	{x="a"} 0.03333333333333333
 	{x="b"} 0.06666666666666667


### PR DESCRIPTION
Allow operators between range vector selectors and scalars. Specifically,

- Arithmetic binary operators
  - \+ (addition)
  - \- (subtraction)
  - \* (multiplication)
  - / (division)
  - % (modulo)
  - ^ (power/exponentiation)

- Comparison binary operators
  - == (equal)
  - != (not-equal)
  - \> (greater-than)
  - < (less-than)
  - \>= (greater-or-equal)
  - <= (less-or-equal)


Examples:
- `avg_over_time(probe_duration_seconds[10m] > 0 < 10)`
- `rate(my_metric[5m] != 0)`

closes https://github.com/prometheus/prometheus/issues/10399

(This PR does not update the UI)

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
