### PR TITLE
tsdb: check for context cancel before regex matching postings

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -51,6 +51,9 @@ const (
 	indexFilename = "index"
 
 	seriesByteAlign = 16
+
+	// checkContextEveryNIterations is used in some tight loops to check if the context is done.
+	checkContextEveryNIterations = 100
 )
 
 type indexWriterSeries struct {
@@ -1799,7 +1802,7 @@ func (r *Reader) postingsForLabelMatchingV1(ctx context.Context, name string, ma
 	var its []Postings
 	count := 1
 	for val, offset := range e {
-		if count%100 == 0 && ctx.Err() != nil {
+		if count%checkContextEveryNIterations == 0 && ctx.Err() != nil {
 			return ErrPostings(ctx.Err())
 		}
 		count++

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1797,7 +1797,12 @@ func (r *Reader) postingsForLabelMatchingV1(ctx context.Context, name string, ma
 	}
 
 	var its []Postings
+	count := 1
 	for val, offset := range e {
+		if count%100 == 0 && ctx.Err() != nil {
+			return ErrPostings(ctx.Err())
+		}
+		count++
 		if !match(val) {
 			continue
 		}

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -726,12 +726,13 @@ func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	idx, err := NewWriter(context.Background(), filepath.Join(dir, "index"))
 	require.NoError(t, err)
 
-	for i := 1; i <= 1000; i++ {
+	seriesCount := 1000
+	for i := 1; i <= seriesCount; i++ {
 		require.NoError(t, idx.AddSymbol(fmt.Sprintf("%4d", i)))
 	}
 	require.NoError(t, idx.AddSymbol("__name__"))
 
-	for i := 1; i <= 1000; i++ {
+	for i := 1; i <= seriesCount; i++ {
 		require.NoError(t, idx.AddSeries(storage.SeriesRef(i), labels.FromStrings("__name__", fmt.Sprintf("%4d", i)),
 			chunks.Meta{Ref: 1, MinTime: 0, MaxTime: 10},
 		))
@@ -743,7 +744,7 @@ func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	require.NoError(t, err)
 	defer ir.Close()
 
-	failAfter := uint64(500)
+	failAfter := uint64(seriesCount / 2) // Fail after processing half of the series.
 	ctx := &testutil.MockContextErrAfter{FailAfter: failAfter}
 	p := ir.PostingsForLabelMatching(ctx, "__name__", func(string) bool {
 		return true

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -750,17 +750,3 @@ func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	require.Error(t, p.Err())
 	require.GreaterOrEqual(t, ctx.Count(), uint64(500))
 }
-
-type MockContextErrCall struct {
-	context.Context
-	count     int
-	failAfter int
-}
-
-func (c *MockContextErrCall) Err() error {
-	c.count++
-	if c.count > c.failAfter {
-		return context.Canceled
-	}
-	return c.Context.Err()
-}

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -743,10 +743,11 @@ func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	require.NoError(t, err)
 	defer ir.Close()
 
-	ctx := &testutil.MockContextErrAfter{FailAfter: 500}
+	failAfter := uint64(500)
+	ctx := &testutil.MockContextErrAfter{FailAfter: failAfter}
 	p := ir.PostingsForLabelMatching(ctx, "__name__", func(string) bool {
 		return true
 	})
 	require.Error(t, p.Err())
-	require.Equal(t, uint64(501), ctx.Count())
+	require.Equal(t, failAfter, ctx.Count())
 }

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -748,5 +748,5 @@ func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 		return true
 	})
 	require.Error(t, p.Err())
-	require.GreaterOrEqual(t, ctx.Count(), uint64(500))
+	require.Equal(t, uint64(501), ctx.Count())
 }

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -743,7 +743,7 @@ func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	require.NoError(t, err)
 	defer ir.Close()
 
-	ctx := &testutil.MockContextErrAfter{Context: context.Background(), FailAfter: 500}
+	ctx := &testutil.MockContextErrAfter{FailAfter: 500}
 	p := ir.PostingsForLabelMatching(ctx, "__name__", func(string) bool {
 		return true
 	})

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -418,7 +418,7 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	var its []Postings
 	count := 1
 	for _, v := range vals {
-		if count%100 == 0 && ctx.Err() != nil {
+		if count%checkContextEveryNIterations == 0 && ctx.Err() != nil {
 			return ErrPostings(ctx.Err())
 		}
 		count++

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -416,7 +416,12 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	}
 
 	var its []Postings
+	count := 1
 	for _, v := range vals {
+		if count%100 == 0 && ctx.Err() != nil {
+			return ErrPostings(ctx.Err())
+		}
+		count++
 		if match(v) {
 			its = append(its, NewListPostings(e[v]))
 		}

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1286,12 +1286,12 @@ func BenchmarkListPostings(b *testing.B) {
 
 func TestMemPostings_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	memP := NewMemPostings()
-
-	for i := 1; i <= 10000; i++ {
+	seriesCount := 10 * checkContextEveryNIterations
+	for i := 1; i <= seriesCount; i++ {
 		memP.Add(storage.SeriesRef(i), labels.FromStrings("__name__", fmt.Sprintf("%4d", i)))
 	}
 
-	failAfter := uint64(50)
+	failAfter := uint64(seriesCount / 2 / checkContextEveryNIterations)
 	ctx := &testutil.MockContextErrAfter{FailAfter: failAfter}
 	p := memP.PostingsForLabelMatching(ctx, "__name__", func(string) bool {
 		return true

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1291,7 +1291,7 @@ func TestMemPostings_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 		memP.Add(storage.SeriesRef(i), labels.FromStrings("__name__", fmt.Sprintf("%4d", i)))
 	}
 
-	ctx := &testutil.MockContextErrAfter{Context: context.Background(), FailAfter: 50}
+	ctx := &testutil.MockContextErrAfter{FailAfter: 50}
 	p := memP.PostingsForLabelMatching(ctx, "__name__", func(string) bool {
 		return true
 	})

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1291,10 +1291,11 @@ func TestMemPostings_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 		memP.Add(storage.SeriesRef(i), labels.FromStrings("__name__", fmt.Sprintf("%4d", i)))
 	}
 
-	ctx := &testutil.MockContextErrAfter{FailAfter: 50}
+	failAfter := uint64(50)
+	ctx := &testutil.MockContextErrAfter{FailAfter: failAfter}
 	p := memP.PostingsForLabelMatching(ctx, "__name__", func(string) bool {
 		return true
 	})
 	require.Error(t, p.Err())
-	require.Equal(t, uint64(52), ctx.Count())
+	require.Equal(t, failAfter+1, ctx.Count()) // Plus one for the Err() call that puts the error in the result.
 }

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1296,5 +1296,5 @@ func TestMemPostings_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 		return true
 	})
 	require.Error(t, p.Err())
-	require.GreaterOrEqual(t, ctx.Count(), uint64(50))
+	require.Equal(t, uint64(52), ctx.Count())
 }

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -33,6 +33,9 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 )
 
+// checkContextEveryNIterations is used in some tight loops to check if the context is done.
+const checkContextEveryNIterations = 100
+
 type blockBaseQuerier struct {
 	blockID    ulid.ULID
 	index      IndexReader
@@ -360,7 +363,7 @@ func inversePostingsForMatcher(ctx context.Context, ix IndexReader, m *labels.Ma
 	} else {
 		count := 1
 		for _, val := range vals {
-			if count%100 == 0 && ctx.Err() != nil {
+			if count%checkContextEveryNIterations == 0 && ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
 			count++
@@ -394,7 +397,7 @@ func labelValuesWithMatchers(ctx context.Context, r IndexReader, name string, ma
 		filteredValues := allValues[:0]
 		count := 1
 		for _, v := range allValues {
-			if count%100 == 0 && ctx.Err() != nil {
+			if count%checkContextEveryNIterations == 0 && ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
 			count++

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -358,7 +358,12 @@ func inversePostingsForMatcher(ctx context.Context, ix IndexReader, m *labels.Ma
 	if m.Type == labels.MatchEqual && m.Value == "" {
 		res = vals
 	} else {
+		count := 1
 		for _, val := range vals {
+			if count%100 == 0 && ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			count++
 			if !m.Matches(val) {
 				res = append(res, val)
 			}
@@ -387,7 +392,12 @@ func labelValuesWithMatchers(ctx context.Context, r IndexReader, name string, ma
 		// re-use the allValues slice to avoid allocations
 		// this is safe because the iteration is always ahead of the append
 		filteredValues := allValues[:0]
+		count := 1
 		for _, v := range allValues {
+			if count%100 == 0 && ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			count++
 			if m.Matches(v) {
 				filteredValues = append(filteredValues, v)
 			}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3647,7 +3647,7 @@ func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	_, err := labelValuesWithMatchers(ctx, ir, "__name__", labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
 
 	require.Error(t, err)
-	require.GreaterOrEqual(t, ctx.Count(), uint64(5))
+	require.Equal(t, uint64(7), ctx.Count())
 }
 
 func TestReader_InversePostingsForMatcherHonorsContextCancel(t *testing.T) {
@@ -3657,7 +3657,7 @@ func TestReader_InversePostingsForMatcherHonorsContextCancel(t *testing.T) {
 	_, err := inversePostingsForMatcher(ctx, ir, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
 
 	require.Error(t, err)
-	require.GreaterOrEqual(t, ctx.Count(), uint64(5))
+	require.Equal(t, uint64(7), ctx.Count())
 }
 
 type mockReaderOfLabels struct{}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3643,7 +3643,7 @@ func TestQueryWithOneChunkCompletelyDeleted(t *testing.T) {
 func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	ir := mockReaderOfLabels{}
 
-	ctx := &testutil.MockContextErrAfter{Context: context.Background(), FailAfter: 5}
+	ctx := &testutil.MockContextErrAfter{FailAfter: 5}
 	_, err := labelValuesWithMatchers(ctx, ir, "__name__", labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
 
 	require.Error(t, err)
@@ -3653,7 +3653,7 @@ func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 func TestReader_InversePostingsForMatcherHonorsContextCancel(t *testing.T) {
 	ir := mockReaderOfLabels{}
 
-	ctx := &testutil.MockContextErrAfter{Context: context.Background(), FailAfter: 5}
+	ctx := &testutil.MockContextErrAfter{FailAfter: 5}
 	_, err := inversePostingsForMatcher(ctx, ir, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
 
 	require.Error(t, err)

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/util/annotations"
+	"github.com/prometheus/prometheus/util/testutil"
 )
 
 // TODO(bwplotka): Replace those mocks with remote.concreteSeriesSet.
@@ -3637,4 +3638,74 @@ func TestQueryWithOneChunkCompletelyDeleted(t *testing.T) {
 	}
 	require.NoError(t, css.Err())
 	require.Equal(t, 1, seriesCount)
+}
+
+func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
+	ir := mockReaderOfLabels{}
+
+	ctx := &testutil.MockContextErrAfter{Context: context.Background(), FailAfter: 5}
+	_, err := labelValuesWithMatchers(ctx, ir, "__name__", labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
+
+	require.Error(t, err)
+	require.GreaterOrEqual(t, ctx.Count(), uint64(5))
+}
+
+func TestReader_InversePostingsForMatcherHonorsContextCancel(t *testing.T) {
+	ir := mockReaderOfLabels{}
+
+	ctx := &testutil.MockContextErrAfter{Context: context.Background(), FailAfter: 5}
+	_, err := inversePostingsForMatcher(ctx, ir, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
+
+	require.Error(t, err)
+	require.GreaterOrEqual(t, ctx.Count(), uint64(5))
+}
+
+type mockReaderOfLabels struct{}
+
+func (m mockReaderOfLabels) LabelValues(context.Context, string, ...*labels.Matcher) ([]string, error) {
+	return make([]string, 1000), nil
+}
+
+func (m mockReaderOfLabels) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {
+	panic("LabelValueFor called")
+}
+
+func (m mockReaderOfLabels) SortedLabelValues(context.Context, string, ...*labels.Matcher) ([]string, error) {
+	panic("SortedLabelValues called")
+}
+
+func (m mockReaderOfLabels) Close() error {
+	return nil
+}
+
+func (m mockReaderOfLabels) LabelNames(context.Context, ...*labels.Matcher) ([]string, error) {
+	panic("LabelNames called")
+}
+
+func (m mockReaderOfLabels) LabelNamesFor(context.Context, ...storage.SeriesRef) ([]string, error) {
+	panic("LabelNamesFor called")
+}
+
+func (m mockReaderOfLabels) PostingsForLabelMatching(context.Context, string, func(string) bool) index.Postings {
+	panic("PostingsForLabelMatching called")
+}
+
+func (m mockReaderOfLabels) Postings(context.Context, string, ...string) (index.Postings, error) {
+	panic("Postings called")
+}
+
+func (m mockReaderOfLabels) ShardedPostings(index.Postings, uint64, uint64) index.Postings {
+	panic("Postings called")
+}
+
+func (m mockReaderOfLabels) SortedPostings(index.Postings) index.Postings {
+	panic("SortedPostings called")
+}
+
+func (m mockReaderOfLabels) Series(storage.SeriesRef, *labels.ScratchBuilder, *[]chunks.Meta) error {
+	panic("Series called")
+}
+
+func (m mockReaderOfLabels) Symbols() index.StringIter {
+	panic("Series called")
 }

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3643,21 +3643,23 @@ func TestQueryWithOneChunkCompletelyDeleted(t *testing.T) {
 func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	ir := mockReaderOfLabels{}
 
-	ctx := &testutil.MockContextErrAfter{FailAfter: 5}
-	_, err := labelValuesWithMatchers(ctx, ir, "__name__", labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
+	failAfter := uint64(5)
+	ctx := &testutil.MockContextErrAfter{FailAfter: failAfter}
+	_, err := labelValuesWithMatchers(ctx, ir, "__name__", labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".+"))
 
 	require.Error(t, err)
-	require.Equal(t, uint64(7), ctx.Count())
+	require.Equal(t, failAfter+1, ctx.Count()) // Plus one for the Err() call that puts the error in the result.
 }
 
 func TestReader_InversePostingsForMatcherHonorsContextCancel(t *testing.T) {
 	ir := mockReaderOfLabels{}
 
-	ctx := &testutil.MockContextErrAfter{FailAfter: 5}
+	failAfter := uint64(5)
+	ctx := &testutil.MockContextErrAfter{FailAfter: failAfter}
 	_, err := inversePostingsForMatcher(ctx, ir, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
 
 	require.Error(t, err)
-	require.Equal(t, uint64(7), ctx.Count())
+	require.Equal(t, failAfter+1, ctx.Count()) // Plus one for the Err() call that puts the error in the result.
 }
 
 type mockReaderOfLabels struct{}

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3643,7 +3643,7 @@ func TestQueryWithOneChunkCompletelyDeleted(t *testing.T) {
 func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	ir := mockReaderOfLabels{}
 
-	failAfter := uint64(5)
+	failAfter := uint64(mockReaderOfLabelsSeriesCount / 2 / checkContextEveryNIterations)
 	ctx := &testutil.MockContextErrAfter{FailAfter: failAfter}
 	_, err := labelValuesWithMatchers(ctx, ir, "__name__", labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".+"))
 
@@ -3654,7 +3654,7 @@ func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 func TestReader_InversePostingsForMatcherHonorsContextCancel(t *testing.T) {
 	ir := mockReaderOfLabels{}
 
-	failAfter := uint64(5)
+	failAfter := uint64(mockReaderOfLabelsSeriesCount / 2 / checkContextEveryNIterations)
 	ctx := &testutil.MockContextErrAfter{FailAfter: failAfter}
 	_, err := inversePostingsForMatcher(ctx, ir, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"))
 
@@ -3664,8 +3664,10 @@ func TestReader_InversePostingsForMatcherHonorsContextCancel(t *testing.T) {
 
 type mockReaderOfLabels struct{}
 
+const mockReaderOfLabelsSeriesCount = checkContextEveryNIterations * 10
+
 func (m mockReaderOfLabels) LabelValues(context.Context, string, ...*labels.Matcher) ([]string, error) {
-	return make([]string, 1000), nil
+	return make([]string, mockReaderOfLabelsSeriesCount), nil
 }
 
 func (m mockReaderOfLabels) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {

--- a/util/testutil/context.go
+++ b/util/testutil/context.go
@@ -49,7 +49,7 @@ func (c *MockContext) Value(interface{}) interface{} {
 // MockContextErrAfter is a MockContext that will return an error after a certain
 // number of calls to Err().
 type MockContextErrAfter struct {
-	context.Context
+	MockContext
 	count     atomic.Uint64
 	FailAfter uint64
 }
@@ -59,7 +59,7 @@ func (c *MockContextErrAfter) Err() error {
 	if c.count.Load() > c.FailAfter {
 		return context.Canceled
 	}
-	return c.Context.Err()
+	return c.MockContext.Err()
 }
 
 func (c *MockContextErrAfter) Count() uint64 {

--- a/util/testutil/context.go
+++ b/util/testutil/context.go
@@ -56,7 +56,7 @@ type MockContextErrAfter struct {
 
 func (c *MockContextErrAfter) Err() error {
 	c.count.Inc()
-	if c.count.Load() > c.FailAfter {
+	if c.count.Load() >= c.FailAfter {
 		return context.Canceled
 	}
 	return c.MockContext.Err()

--- a/util/testutil/context.go
+++ b/util/testutil/context.go
@@ -15,8 +15,9 @@ package testutil
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
+
+	"go.uber.org/atomic"
 )
 
 // A MockContext provides a simple stub implementation of a Context.
@@ -49,18 +50,18 @@ func (c *MockContext) Value(interface{}) interface{} {
 // number of calls to Err().
 type MockContextErrAfter struct {
 	context.Context
-	count     uint64
+	count     atomic.Uint64
 	FailAfter uint64
 }
 
 func (c *MockContextErrAfter) Err() error {
-	atomic.AddUint64(&c.count, 1)
-	if atomic.LoadUint64(&c.count) > c.FailAfter {
+	c.count.Inc()
+	if c.count.Load() > c.FailAfter {
 		return context.Canceled
 	}
 	return c.Context.Err()
 }
 
 func (c *MockContextErrAfter) Count() uint64 {
-	return atomic.LoadUint64(&c.count)
+	return c.count.Load()
 }


### PR DESCRIPTION
Regex matching can be heavy if the regex takes a lot of cycles to evaluate and we can get stuck evaluating postings for a long time without this fix.

This PR adds a missing unit test for checking that the index reader honors context cancel when doing `r.traversePostingOffsets` iteration.