### PR TITLE
[TEST] Rules: Sleep 15ms to fit Windows behaviour better

### DIFF
--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -2043,7 +2043,7 @@ func TestBoundedRuleEvalConcurrency(t *testing.T) {
 	require.EqualValues(t, maxInflight.Load(), int32(maxConcurrency)+int32(groupCount))
 }
 
-const artificialDelay = 10 * time.Millisecond
+const artificialDelay = 15 * time.Millisecond
 
 func optsFactory(storage storage.Storage, maxInflight, inflightQueries *atomic.Int32, maxConcurrent int64) *ManagerOptions {
 	var inflightMu sync.Mutex


### PR DESCRIPTION
On Windows, Go will sleep 15ms if you ask for less.  `TestAsyncRuleEvaluation` compares actual delay to the nominal time, so using 15ms should work better on Windows, and be hardly noticeable elsewhere.

Attempting to fix #13547 
