### PR TITLE
tsdb/index/postings: fix missing lock unlock

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -419,6 +419,7 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	count := 1
 	for _, v := range vals {
 		if count%checkContextEveryNIterations == 0 && ctx.Err() != nil {
+			p.mtx.RUnlock()
 			return ErrPostings(ctx.Err())
 		}
 		count++


### PR DESCRIPTION
Followup to #14096

Unfortunately the previous PR introduced this bug by not releasing the lock before returning.
