### PR TITLE
Check context every 128 labels instead of 100

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -53,7 +53,7 @@ const (
 	seriesByteAlign = 16
 
 	// checkContextEveryNIterations is used in some tight loops to check if the context is done.
-	checkContextEveryNIterations = 100
+	checkContextEveryNIterations = 128
 )
 
 type indexWriterSeries struct {

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -22,8 +22,10 @@ import (
 	"math/rand"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -1280,6 +1282,58 @@ func BenchmarkListPostings(b *testing.B) {
 				}
 				require.NotZero(b, sum)
 			}
+		})
+	}
+}
+
+func slowRegexpString() string {
+	nums := map[int]struct{}{}
+	for i := 10_000; i < 20_000; i++ {
+		if i%3 == 0 {
+			nums[i] = struct{}{}
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(".*(9999")
+	for i := range nums {
+		sb.WriteString("|")
+		sb.WriteString(strconv.Itoa(i))
+	}
+	sb.WriteString(").*")
+	return sb.String()
+}
+
+func BenchmarkMemPostings_PostingsForLabelMatching(b *testing.B) {
+	fast := regexp.MustCompile("^(100|200)$")
+	slowRegexp := "^" + slowRegexpString() + "$"
+	b.Logf("Slow regexp length = %d", len(slowRegexp))
+	slow := regexp.MustCompile(slowRegexp)
+
+	for _, labelValueCount := range []int{1_000, 10_000, 100_000} {
+		b.Run(fmt.Sprintf("labels=%d", labelValueCount), func(b *testing.B) {
+			mp := NewMemPostings()
+			for i := 0; i < labelValueCount; i++ {
+				mp.Add(storage.SeriesRef(i), labels.FromStrings("label", strconv.Itoa(i)))
+			}
+
+			fp, err := ExpandPostings(mp.PostingsForLabelMatching(context.Background(), "label", fast.MatchString))
+			require.NoError(b, err)
+			b.Logf("Fast matcher matches %d series", len(fp))
+			b.Run("matcher=fast", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					mp.PostingsForLabelMatching(context.Background(), "label", fast.MatchString).Next()
+				}
+			})
+
+			sp, err := ExpandPostings(mp.PostingsForLabelMatching(context.Background(), "label", slow.MatchString))
+			require.NoError(b, err)
+			b.Logf("Slow matcher matches %d series", len(sp))
+			b.Run("matcher=slow", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					mp.PostingsForLabelMatching(context.Background(), "label", slow.MatchString).Next()
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
Follow up on https://github.com/prometheus/prometheus/pull/14096

As promised, I bring a benchmark, which shows a very small improvement if context is checked every 128 iterations of label instead of every 100.

It's much easier for a computer to check modulo 128 than modulo 100. This is a very small 0-2% improvement but I'd say this is one of the hottest paths of the app so this is still relevant.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb/index
                                                                   │    main     │                128                 │
                                                                   │   sec/op    │   sec/op     vs base               │
MemPostings_PostingsForLabelMatching/labels=1000/matcher=fast-12     38.36µ ± 1%   38.01µ ± 1%  -0.91% (p=0.003 n=10)
MemPostings_PostingsForLabelMatching/labels=1000/matcher=slow-12     12.65µ ± 1%   12.40µ ± 1%  -2.01% (p=0.000 n=10)
MemPostings_PostingsForLabelMatching/labels=10000/matcher=fast-12    402.8µ ± 2%   395.1µ ± 1%  -1.91% (p=0.000 n=10)
MemPostings_PostingsForLabelMatching/labels=10000/matcher=slow-12    250.1m ± 3%   249.9m ± 0%       ~ (p=0.089 n=10)
MemPostings_PostingsForLabelMatching/labels=100000/matcher=fast-12   3.952m ± 1%   3.930m ± 0%  -0.57% (p=0.000 n=10)
MemPostings_PostingsForLabelMatching/labels=100000/matcher=slow-12    3.283 ± 0%    3.292 ± 1%       ~ (p=0.190 n=10)
geomean                                                              2.931m        2.906m       -0.87%
```
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
