### PR TITLE
fix:default value of storage.tsdb.retention.time flag

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -344,7 +344,7 @@ func main() {
 		SetValue(&oldFlagRetentionDuration)
 
 	serverOnlyFlag(a, "storage.tsdb.retention.time", "How long to retain samples in storage. When this flag is set it overrides \"storage.tsdb.retention\". If neither this flag nor \"storage.tsdb.retention\" nor \"storage.tsdb.retention.size\" is set, the retention time defaults to "+defaultRetentionString+". Units Supported: y, w, d, h, m, s, ms.").
-		SetValue(&newFlagRetentionDuration)
+		Default("15d").SetValue(&newFlagRetentionDuration)
 
 	serverOnlyFlag(a, "storage.tsdb.retention.size", "Maximum number of bytes that can be stored for blocks. A unit is required, supported units: B, KB, MB, GB, TB, PB, EB. Ex: \"512MB\". Based on powers-of-2, so 1KB is 1024B.").
 		BytesVar(&cfg.tsdb.MaxBytes)


### PR DESCRIPTION
#13967 

The default value for flag `--storage.tsdb.retention.time` as mentioned in the docs is **15d**. 
But when user doesn't provide the flag in the cmd line then, `/flags` page show the value set to be **0s**.

![image](https://github.com/prometheus/prometheus/assets/94526347/850393bc-1a52-47ff-a955-cf865fad17f8)

Now providing the Default value to the flag `--storage.tsdb.retention.time` i.e. **15d**. Fixes this issue 
![image(1)](https://github.com/prometheus/prometheus/assets/94526347/3d99acc3-fc93-4cde-aac5-9cfa2c1f7b88)


