### PR TITLE
repository: proposal - Add workflow to process stale issues and PRs

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,0 +1,34 @@
+# based on https://github.com/open-telemetry/opentelemetry-lambda/blob/main/.github/workflows/close-stale.yaml
+# The idea of this workflow is to close issues that are no longer relevant
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    # for fairness create notifications 12h apart
+    - cron: "42 3,15 * * 1-5" # Run at an arbitrary time on weekdays.
+
+permissions:
+  issues: write
+  pull-requests: write
+env:
+  DAYS_BEFORE_STALE: 365
+  DAYS_BEFORE_CLOSE: 60
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue was marked stale. It will be closed in ${{ env.DAYS_BEFORE_CLOSE }} if it continues without additional activity.'
+          close-issue-message: 'Closed as inactive. Feel free to reopen if this issue is still relevant.'
+
+          stale-pr-message: 'This PR was marked stale. It will be closed in ${{ env.DAYS_BEFORE_CLOSE }} days if it continues without additional activity.'
+          close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
+
+          days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-close: ${{ env.DAYS_BEFORE_STALE }}
+          # This label has to be manually applied
+          exempt-issue-labels: 'Never Stale'
+          # We want the backlog to be processed slowly so that we don't overload people with notifications
+          operations-per-run: 10


### PR DESCRIPTION
This PR contains a proposal to improve the quality of life of maintainers and of the community by reducing the number of open issues and PRs that are no longer relevant.

It contains a github workflow based on the [stale](https://github.com/actions/stale) github action that will run on weekdays at 3 AM and 3PM UTC. When it runs it will automatically mark PRs and issues that did not receive any activity in the last year as stale: the `Stale` label is applied and an informative comment is posted.

This will give a chance to people involved in the issue/PR to reply, likely with new information, which will will remove the label.

However, If there is no reply within 60 days, that means that the issue/PR is no longer relevant, and therefore they should be closed. At this point people can still reopen the the issue/PR or create new ones.