### PR TITLE
MemPostings: Use DoltHub SwissMap for label values/postings map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/dennwc/varint v1.0.0
 	github.com/digitalocean/godo v1.122.0
 	github.com/docker/docker v27.2.0+incompatible
+	github.com/dolthub/swiss v0.2.1
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/envoyproxy/go-control-plane v0.13.0
 	github.com/envoyproxy/protoc-gen-validate v1.1.0
@@ -114,6 +115,7 @@ require (
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/dolthub/maphash v0.1.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,10 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ=
+github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
+github.com/dolthub/swiss v0.2.1 h1:gs2osYs5SJkAaH5/ggVJqXQxRXtWshF6uE0lgR/Y3Gw=
+github.com/dolthub/swiss v0.2.1/go.mod h1:8AhKZZ1HK7g18j7v7k6c5cYIGEZJcPn0ARsai8cUrh0=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/bboreham/go-loser"
+	"github.com/dolthub/swiss"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -55,14 +56,14 @@ var ensureOrderBatchPool = sync.Pool{
 // unordered batch fills on startup.
 type MemPostings struct {
 	mtx     sync.RWMutex
-	m       map[string]map[string][]storage.SeriesRef
+	m       map[string]*swiss.Map[string, []storage.SeriesRef]
 	ordered bool
 }
 
 // NewMemPostings returns a memPostings that's ready for reads and writes.
 func NewMemPostings() *MemPostings {
 	return &MemPostings{
-		m:       make(map[string]map[string][]storage.SeriesRef, 512),
+		m:       make(map[string]*swiss.Map[string, []storage.SeriesRef], 512),
 		ordered: true,
 	}
 }
@@ -71,7 +72,7 @@ func NewMemPostings() *MemPostings {
 // until EnsureOrder() was called once.
 func NewUnorderedMemPostings() *MemPostings {
 	return &MemPostings{
-		m:       make(map[string]map[string][]storage.SeriesRef, 512),
+		m:       make(map[string]*swiss.Map[string, []storage.SeriesRef], 512),
 		ordered: false,
 	}
 }
@@ -84,9 +85,10 @@ func (p *MemPostings) Symbols() StringIter {
 	symbols := make(map[string]struct{}, 512)
 	for n, e := range p.m {
 		symbols[n] = struct{}{}
-		for v := range e {
+		e.Iter(func(v string, _ []storage.SeriesRef) bool {
 			symbols[v] = struct{}{}
-		}
+			return false
+		})
 	}
 	p.mtx.RUnlock()
 
@@ -105,9 +107,10 @@ func (p *MemPostings) SortedKeys() []labels.Label {
 	keys := make([]labels.Label, 0, len(p.m))
 
 	for n, e := range p.m {
-		for v := range e {
+		e.Iter(func(v string, _ []storage.SeriesRef) bool {
 			keys = append(keys, labels.Label{Name: n, Value: v})
-		}
+			return false
+		})
 	}
 	p.mtx.RUnlock()
 
@@ -146,10 +149,16 @@ func (p *MemPostings) LabelValues(_ context.Context, name string) []string {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	values := make([]string, 0, len(p.m[name]))
-	for v := range p.m[name] {
-		values = append(values, v)
+	e := p.m[name]
+	if e == nil || e.Count() == 0 {
+		return nil
 	}
+
+	values := make([]string, 0, e.Count())
+	e.Iter(func(v string, _ []storage.SeriesRef) bool {
+		values = append(values, v)
+		return false
+	})
 	return values
 }
 
@@ -182,17 +191,18 @@ func (p *MemPostings) Stats(label string, limit int) *PostingsStats {
 		if n == "" {
 			continue
 		}
-		labels.push(Stat{Name: n, Count: uint64(len(e))})
-		numLabelPairs += len(e)
+		labels.push(Stat{Name: n, Count: uint64(e.Count())})
+		numLabelPairs += e.Count()
 		size = 0
-		for name, values := range e {
+		e.Iter(func(name string, values []storage.SeriesRef) bool {
 			if n == label {
 				metrics.push(Stat{Name: name, Count: uint64(len(values))})
 			}
 			seriesCnt := uint64(len(values))
 			labelValuePairs.push(Stat{Name: n + "=" + name, Count: seriesCnt})
 			size += uint64(len(name)) * seriesCnt
-		}
+			return false
+		})
 		labelValueLength.push(Stat{Name: n, Count: size})
 	}
 
@@ -213,7 +223,7 @@ func (p *MemPostings) Get(name, value string) Postings {
 	p.mtx.RLock()
 	l := p.m[name]
 	if l != nil {
-		lp = l[value]
+		lp, _ = l.Get(value)
 	}
 	p.mtx.RUnlock()
 
@@ -266,14 +276,16 @@ func (p *MemPostings) EnsureOrder(numberOfConcurrentProcesses int) {
 
 	nextJob := ensureOrderBatchPool.Get().(*[][]storage.SeriesRef)
 	for _, e := range p.m {
-		for _, l := range e {
+		e.Iter(func(_ string, l []storage.SeriesRef) bool {
 			*nextJob = append(*nextJob, l)
 
 			if len(*nextJob) >= ensureOrderBatchSize {
 				workc <- nextJob
 				nextJob = ensureOrderBatchPool.Get().(*[][]storage.SeriesRef)
 			}
-		}
+
+			return false
+		})
 	}
 
 	// If the last job was partially filled, we need to push it to workers too.
@@ -294,7 +306,11 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 	defer p.mtx.Unlock()
 
 	process := func(l labels.Label) {
-		orig := p.m[l.Name][l.Value]
+		nm := p.m[l.Name]
+		var orig []storage.SeriesRef
+		if nm != nil {
+			orig, _ = nm.Get(l.Value)
+		}
 		repl := make([]storage.SeriesRef, 0, len(orig))
 		for _, id := range orig {
 			if _, ok := deleted[id]; !ok {
@@ -302,11 +318,13 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 			}
 		}
 		if len(repl) > 0 {
-			p.m[l.Name][l.Value] = repl
+			nm.Put(l.Value, repl)
 		} else {
-			delete(p.m[l.Name], l.Value)
+			if nm != nil {
+				nm.Delete(l.Value)
+			}
 			// Delete the key if we removed all values.
-			if len(p.m[l.Name]) == 0 {
+			if nm == nil || nm.Count() == 0 {
 				delete(p.m, l.Name)
 			}
 		}
@@ -324,10 +342,13 @@ func (p *MemPostings) Iter(f func(labels.Label, Postings) error) error {
 	defer p.mtx.RUnlock()
 
 	for n, e := range p.m {
-		for v, p := range e {
-			if err := f(labels.Label{Name: n, Value: v}, newListPostings(p...)); err != nil {
-				return err
-			}
+		var err error
+		e.Iter(func(v string, p []storage.SeriesRef) bool {
+			err = f(labels.Label{Name: n, Value: v}, newListPostings(p...))
+			return err != nil
+		})
+		if err != nil {
+			return err
 		}
 	}
 	return nil
@@ -348,11 +369,12 @@ func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
 func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
 	nm, ok := p.m[l.Name]
 	if !ok {
-		nm = map[string][]storage.SeriesRef{}
+		nm = swiss.NewMap[string, []storage.SeriesRef](0)
 		p.m[l.Name] = nm
 	}
-	list := append(nm[l.Value], id)
-	nm[l.Value] = list
+	list, _ := nm.Get(l.Value)
+	list = append(list, id)
+	nm.Put(l.Value, list)
 
 	if !p.ordered {
 		return
@@ -401,7 +423,7 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	p.mtx.RLock()
 	e := p.m[name]
 	for _, v := range vals {
-		if refs, ok := e[v]; ok {
+		if refs, ok := e.Get(v); ok {
 			// Some of the values may have been garbage-collected in the meantime this is fine, we'll just skip them.
 			// If we didn't let the mutex go, we'd have these postings here, but they would be pointing nowhere
 			// because there would be a `MemPostings.Delete()` call waiting for the lock to delete these labels,
@@ -422,16 +444,17 @@ func (p *MemPostings) labelValues(name string) []string {
 	defer p.mtx.RUnlock()
 
 	e := p.m[name]
-	if len(e) == 0 {
+	if e == nil || e.Count() == 0 {
 		return nil
 	}
 
-	vals := make([]string, 0, len(e))
-	for v, srs := range e {
+	vals := make([]string, 0, e.Count())
+	e.Iter(func(v string, srs []storage.SeriesRef) bool {
 		if len(srs) > 0 {
 			vals = append(vals, v)
 		}
-	}
+		return false
+	})
 
 	return vals
 }


### PR DESCRIPTION
Use [DoltHub SwissMap](https://github.com/dolthub/swiss) instead of standard `map` in `tsdb/index.MemPostings`' table of series refs per label value, for performance.

#### Context

I've considered both the DoltHub and CockroachDB SwissMap implementations in the past, and found then that the former benchmarked better. Also, when @bboreham ran [prombench on DoltHub](https://github.com/prometheus/prometheus/pull/13644), no material difference could be observed, whereas [prombench for CockroachDB](https://github.com/prometheus/prometheus/pull/13646) at least appeared worse.

#### Benchmark results

<details>
<summary>PostingsForMatchers benchmark stats</summary>

```console
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
                                                                     │ postings-head-main.txt │      postings-head-dolthub.txt      │
                                                                     │         sec/op         │    sec/op     vs base               │
Querier/Head/PostingsForMatchers/n="1"-12                                        259.9n ±  3%   262.0n ±  2%        ~ (p=0.065 n=6)
Querier/Head/PostingsForMatchers/n="X"-12                                        257.6n ±  0%   259.8n ±  1%        ~ (p=0.058 n=6)
Querier/Head/PostingsForMatchers/n="1",j="foo"-12                                392.7n ±  0%   408.5n ±  1%   +4.02% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="X",j="foo"-12                                269.9n ±  1%   271.0n ±  1%        ~ (p=0.102 n=6)
Querier/Head/PostingsForMatchers/j="foo",n="1"-12                                393.4n ±  0%   406.4n ±  1%   +3.30% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",j!="foo"-12                               388.4n ±  1%   405.4n ±  1%   +4.39% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!="2"-12                                 398.6n ±  1%   409.2n ±  1%   +2.65% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="X",j!="foo"-12                               271.7n ±  0%   270.7n ±  2%        ~ (p=1.000 n=6)
Querier/Head/PostingsForMatchers/i=~"1[0-9]",j=~"foo|bar"-12                     779.1n ±  0%   845.8n ±  1%   +8.57% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/j=~"foo|bar"-12                                 419.9n ±  1%   437.6n ±  1%   +4.21% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/j=~"XXX|YYY"-12                                 361.8n ±  1%   363.9n ±  1%        ~ (p=0.065 n=6)
Querier/Head/PostingsForMatchers/j=~"X.+"-12                                     327.7n ±  0%   303.1n ±  1%   -7.49% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i=~"(1|2|3|4|5|6|20|55)"-12                     651.3n ±  0%   697.6n ±  2%   +7.11% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i!~"(1|2|3|4|5|6|20|55)"-12                     713.9n ±  2%   767.2n ±  3%   +7.48% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i=~"X|Y|Z"-12                                   424.7n ±  0%   425.5n ±  1%        ~ (p=0.937 n=6)
Querier/Head/PostingsForMatchers/i!~"X|Y|Z"-12                                   476.0n ±  1%   493.0n ±  0%   +3.57% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i=~".*"-12                                      2.826m ±  1%   2.540m ±  2%  -10.12% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i=~"1.*"-12                                     3.858m ±  2%   3.495m ±  1%   -9.41% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i=~".*1"-12                                     2.453m ±  1%   2.178m ±  2%  -11.24% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i=~".+"-12                                      14.72m ±  2%   13.77m ±  2%   -6.50% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i=~".+",j=~"X.+"-12                             14.66m ±  1%   13.96m ±  2%   -4.81% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i=~""-12                                        14.63m ±  1%   12.74m ±  1%  -12.96% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/i!=""-12                                        14.16m ±  2%   12.15m ±  1%  -14.21% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i=~".*",j="foo"-12                        2.844m ±  1%   2.516m ± 21%        ~ (p=0.065 n=6)
Querier/Head/PostingsForMatchers/n="X",i=~".*",j="foo"-12                        299.2n ±  1%   299.6n ±  0%        ~ (p=0.738 n=6)
Querier/Head/PostingsForMatchers/n="1",i=~".*",i!="2",j="foo"-12                 2.858m ±  0%   2.558m ±  2%  -10.47% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!=""-12                                  14.28m ±  1%   12.27m ±  1%  -14.05% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!="",j="foo"-12                          14.22m ±  1%   12.25m ±  1%  -13.81% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!="",j=~"X.+"-12                         14.15m ±  1%   12.14m ±  1%  -14.22% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!="",j=~"XXX|YYY"-12                     14.17m ±  1%   12.13m ±  1%  -14.38% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i=~"X|Y|Z",j="foo"-12                     573.3n ±  0%   582.6n ±  1%   +1.62% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i!~"X|Y|Z",j="foo"-12                     677.9n ±  1%   701.0n ±  1%   +3.39% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i=~".+",j="foo"-12                        14.73m ±  1%   13.81m ±  1%   -6.25% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i=~"1.+",j="foo"-12                       3.855m ± 14%   3.445m ±  1%  -10.65% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i=~".*1.*",j="foo"-12                     10.84m ± 11%   10.59m ± 16%        ~ (p=0.589 n=6)
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!="2",j="foo"-12                 14.89m ±  2%   14.48m ±  6%        ~ (p=0.240 n=6)
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!~"2.*",j="foo"-12               19.40m ±  3%   18.20m ±  1%   -6.18% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!~".*2.*",j="foo"-12             26.23m ±  3%   24.22m ±  1%   -7.64% (p=0.002 n=6)
Querier/Head/PostingsForMatchers/n="X",i=~".+",i!~".*2.*",j="foo"-12             345.9n ±  1%   347.0n ±  2%        ~ (p=0.145 n=6)
geomean                                                                          53.81µ         51.77µ         -3.79%

                                                                     │ postings-head-main.txt │      postings-head-dolthub.txt       │
                                                                     │          B/op          │     B/op      vs base                │
Querier/Head/PostingsForMatchers/n="1"-12                                          64.00 ± 0%     64.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="X"-12                                          48.00 ± 0%     48.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",j="foo"-12                                  176.0 ± 0%     176.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="X",j="foo"-12                                  48.00 ± 0%     48.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/j="foo",n="1"-12                                  176.0 ± 0%     176.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",j!="foo"-12                                 176.0 ± 0%     176.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!="2"-12                                   176.0 ± 0%     176.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="X",j!="foo"-12                                 48.00 ± 0%     48.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~"1[0-9]",j=~"foo|bar"-12                       512.0 ± 0%     512.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/j=~"foo|bar"-12                                   352.0 ± 0%     352.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/j=~"XXX|YYY"-12                                   128.0 ± 0%     128.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/j=~"X.+"-12                                       80.00 ± 0%     80.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~"(1|2|3|4|5|6|20|55)"-12                       416.0 ± 0%     416.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i!~"(1|2|3|4|5|6|20|55)"-12                       480.0 ± 0%     480.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~"X|Y|Z"-12                                     176.0 ± 0%     176.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i!~"X|Y|Z"-12                                     240.0 ± 0%     240.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~".*"-12                                      1.531Mi ± 0%   1.531Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~"1.*"-12                                     2.722Mi ± 0%   2.722Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~".*1"-12                                     1.531Mi ± 0%   1.531Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~".+"-12                                      12.22Mi ± 0%   12.22Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~".+",j=~"X.+"-12                             12.22Mi ± 0%   12.22Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~""-12                                        12.22Mi ± 0%   12.22Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i!=""-12                                        12.22Mi ± 0%   12.22Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".*",j="foo"-12                        1.531Mi ± 0%   1.531Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="X",i=~".*",j="foo"-12                          48.00 ± 0%     48.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".*",i!="2",j="foo"-12                 1.532Mi ± 0%   1.532Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!=""-12                                  12.22Mi ± 0%   12.22Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!="",j="foo"-12                          12.22Mi ± 0%   12.22Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!="",j=~"X.+"-12                         12.22Mi ± 0%   12.22Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!="",j=~"XXX|YYY"-12                     12.22Mi ± 0%   12.22Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~"X|Y|Z",j="foo"-12                       240.0 ± 0%     240.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!~"X|Y|Z",j="foo"-12                       352.0 ± 0%     352.0 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".+",j="foo"-12                        12.22Mi ± 0%   12.22Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~"1.+",j="foo"-12                       2.722Mi ± 0%   2.722Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".*1.*",j="foo"-12                     5.906Mi ± 0%   5.906Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!="2",j="foo"-12                 12.22Mi ± 0%   12.22Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!~"2.*",j="foo"-12               14.95Mi ± 0%   14.95Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!~".*2.*",j="foo"-12             18.14Mi ± 0%   18.14Mi ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="X",i=~".+",i!~".*2.*",j="foo"-12               48.00 ± 0%     48.00 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                                          27.27Ki        27.27Ki       +0.00%
¹ all samples are equal

                                                                     │ postings-head-main.txt │      postings-head-dolthub.txt      │
                                                                     │       allocs/op        │  allocs/op   vs base                │
Querier/Head/PostingsForMatchers/n="1"-12                                          3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="X"-12                                          3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",j="foo"-12                                  7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="X",j="foo"-12                                  3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/j="foo",n="1"-12                                  7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",j!="foo"-12                                 7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!="2"-12                                   7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="X",j!="foo"-12                                 3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~"1[0-9]",j=~"foo|bar"-12                       14.00 ± 0%    14.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/j=~"foo|bar"-12                                   8.000 ± 0%    8.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/j=~"XXX|YYY"-12                                   6.000 ± 0%    6.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/j=~"X.+"-12                                       4.000 ± 0%    4.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~"(1|2|3|4|5|6|20|55)"-12                       12.00 ± 0%    12.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i!~"(1|2|3|4|5|6|20|55)"-12                       15.00 ± 0%    15.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~"X|Y|Z"-12                                     7.000 ± 0%    7.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i!~"X|Y|Z"-12                                     10.00 ± 0%    10.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~".*"-12                                        6.000 ± 0%    6.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~"1.*"-12                                      11.12k ± 0%   11.12k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~".*1"-12                                       4.000 ± 0%    4.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~".+"-12                                       100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~".+",j=~"X.+"-12                              100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i=~""-12                                         100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/i!=""-12                                         100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".*",j="foo"-12                          10.00 ± 0%    10.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="X",i=~".*",j="foo"-12                          3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".*",i!="2",j="foo"-12                   14.00 ± 0%    14.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!=""-12                                   100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!="",j="foo"-12                           100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!="",j=~"X.+"-12                          100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!="",j=~"XXX|YYY"-12                      100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~"X|Y|Z",j="foo"-12                       10.00 ± 0%    10.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i!~"X|Y|Z",j="foo"-12                       14.00 ± 0%    14.00 ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".+",j="foo"-12                         100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~"1.+",j="foo"-12                        11.12k ± 0%   11.12k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".*1.*",j="foo"-12                      40.97k ± 0%   40.97k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!="2",j="foo"-12                  100.0k ± 0%   100.0k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!~"2.*",j="foo"-12                111.2k ± 0%   111.2k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="1",i=~".+",i!~".*2.*",j="foo"-12              141.1k ± 0%   141.1k ± 0%       ~ (p=1.000 n=6) ¹
Querier/Head/PostingsForMatchers/n="X",i=~".+",i!~".*2.*",j="foo"-12               3.000 ± 0%    3.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                                            233.3         233.3       +0.00%
¹ all samples are equal
```
</details>