### PR TITLE
Improve contains check done by FastRegexMatcher

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -42,7 +42,7 @@ type FastRegexMatcher struct {
 	stringMatcher StringMatcher
 	prefix        string
 	suffix        string
-	contains      string
+	contains      []string
 
 	// matchString is the "compiled" function to run by MatchString().
 	matchString func(string) bool
@@ -87,7 +87,7 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 // compileMatchStringFunction returns the function to run by MatchString().
 func (m *FastRegexMatcher) compileMatchStringFunction() func(string) bool {
 	// If the only optimization available is the string matcher, then we can just run it.
-	if len(m.setMatches) == 0 && m.prefix == "" && m.suffix == "" && m.contains == "" && m.stringMatcher != nil {
+	if len(m.setMatches) == 0 && m.prefix == "" && m.suffix == "" && len(m.contains) == 0 && m.stringMatcher != nil {
 		return m.stringMatcher.Matches
 	}
 
@@ -106,7 +106,7 @@ func (m *FastRegexMatcher) compileMatchStringFunction() func(string) bool {
 		if m.suffix != "" && !strings.HasSuffix(s, m.suffix) {
 			return false
 		}
-		if m.contains != "" && !strings.Contains(s, m.contains) {
+		if len(m.contains) > 0 && !containsInOrder(s, m.contains) {
 			return false
 		}
 		if m.stringMatcher != nil {
@@ -119,7 +119,7 @@ func (m *FastRegexMatcher) compileMatchStringFunction() func(string) bool {
 // IsOptimized returns true if any fast-path optimization is applied to the
 // regex matcher.
 func (m *FastRegexMatcher) IsOptimized() bool {
-	return len(m.setMatches) > 0 || m.stringMatcher != nil || m.prefix != "" || m.suffix != "" || m.contains != ""
+	return len(m.setMatches) > 0 || m.stringMatcher != nil || m.prefix != "" || m.suffix != "" || len(m.contains) > 0
 }
 
 // findSetMatches extract equality matches from a regexp.
@@ -361,8 +361,9 @@ func optimizeAlternatingLiterals(s string) (StringMatcher, []string) {
 
 // optimizeConcatRegex returns literal prefix/suffix text that can be safely
 // checked against the label value before running the regexp matcher.
-func optimizeConcatRegex(r *syntax.Regexp) (prefix, suffix, contains string) {
+func optimizeConcatRegex(r *syntax.Regexp) (prefix, suffix string, contains []string) {
 	sub := r.Sub
+	clearCapture(sub...)
 
 	// We can safely remove begin and end text matchers respectively
 	// at the beginning and end of the regexp.
@@ -387,13 +388,12 @@ func optimizeConcatRegex(r *syntax.Regexp) (prefix, suffix, contains string) {
 		suffix = string(sub[last].Rune)
 	}
 
-	// If contains any literal which is not a prefix/suffix, we keep the
-	// 1st one. We do not keep the whole list of literals to simplify the
-	// fast path.
+	// If contains any literal which is not a prefix/suffix, we keep track of
+	// all the ones which are case sensitive.
 	for i := 1; i < len(sub)-1; i++ {
+		// TODO if it's case insensitive we should return an contains list or is it safe to keep searching for case sensitive ones?
 		if sub[i].Op == syntax.OpLiteral && (sub[i].Flags&syntax.FoldCase) == 0 {
-			contains = string(sub[i].Rune)
-			break
+			contains = append(contains, string(sub[i].Rune))
 		}
 	}
 
@@ -939,4 +939,19 @@ func hasPrefixCaseInsensitive(s, prefix string) bool {
 
 func hasSuffixCaseInsensitive(s, suffix string) bool {
 	return len(s) >= len(suffix) && strings.EqualFold(s[len(s)-len(suffix):], suffix)
+}
+
+func containsInOrder(s string, contains []string) bool {
+	offset := 0
+
+	for _, substr := range contains {
+		at := strings.Index(s[offset:], substr)
+		if at == -1 {
+			return false
+		}
+
+		offset += at + len(substr)
+	}
+
+	return true
 }

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -389,9 +389,8 @@ func optimizeConcatRegex(r *syntax.Regexp) (prefix, suffix string, contains []st
 	}
 
 	// If contains any literal which is not a prefix/suffix, we keep track of
-	// all the ones which are case sensitive.
+	// all the ones which are case-sensitive.
 	for i := 1; i < len(sub)-1; i++ {
-		// TODO if it's case insensitive we should return an contains list or is it safe to keep searching for case sensitive ones?
 		if sub[i].Op == syntax.OpLiteral && (sub[i].Flags&syntax.FoldCase) == 0 {
 			contains = append(contains, string(sub[i].Rune))
 		}

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -941,6 +941,15 @@ func hasSuffixCaseInsensitive(s, suffix string) bool {
 }
 
 func containsInOrder(s string, contains []string) bool {
+	// Optimization for the case we only have to look for 1 substring.
+	if len(contains) == 1 {
+		return strings.Contains(s, contains[0])
+	}
+
+	return containsInOrderMulti(s, contains)
+}
+
+func containsInOrderMulti(s string, contains []string) bool {
 	offset := 0
 
 	for _, substr := range contains {

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -84,11 +84,12 @@ var (
 		// Concat of literals and wildcards.
 		".*-.*-.*-.*-.*",
 		"(.+)-(.+)-(.+)-(.+)-(.+)",
-		"((.*))-((.*))-((.*))-((.*))-((.*))",
+		"((.*))(?i:f)((.*))o((.*))o((.*))",
+		"((.*))f((.*))(?i:o)((.*))o((.*))",
 	}
 	values = []string{
 		"foo", " foo bar", "bar", "buzz\nbar", "bar foo", "bfoo", "\n", "\nfoo", "foo\n", "hello foo world", "hello foo\n world", "",
-		"FOO", "Foo", "OO", "Oo", "\nfoo\n", strings.Repeat("f", 20), "prometheus", "prometheus_api_v1", "prometheus_api_v1_foo",
+		"FOO", "Foo", "fOo", "foO", "OO", "Oo", "\nfoo\n", strings.Repeat("f", 20), "prometheus", "prometheus_api_v1", "prometheus_api_v1_foo",
 		"10.0.1.20", "10.0.2.10", "10.0.3.30", "10.0.4.40",
 		"foofoo0", "foofoo", "😀foo0",
 


### PR DESCRIPTION
I recently saw a production regexp pattern like `(.+)-(.+)-(.+)-(.+)-(.+)`. Currently, this pattern is loosely optimised in the `FastRegexMatcher`: we only check if the input string contains 1 occurence of `-` (in any position) and, if yes, we run the full regexp engine, while if it doesn't we skip the regexp engine.

A simple way to further optimise it is to check for all literals in the pattern instead of just the first one, which is what I'm proposing in this PR.

#### Benchmark

The benchmark shows some performance change to few patterns that are not expected to change. I've re-run the benchmarks multiple times and they're consistent, which I don't fully understand. I thought it was the change to `compileMatchStringFunction()` so I've commented the change there (essentially skipping the "contains" check), but I still get such difference with `main`.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
                                                     │  before.txt   │              after.txt              │
                                                     │    sec/op     │    sec/op     vs base               │
FastRegexMatcher/#00-11                                 40.86n ±  3%   35.52n ±  1%  -13.07% (p=0.002 n=6)
FastRegexMatcher/foo-11                                 41.51n ± 21%   36.10n ±  0%  -13.04% (p=0.050 n=6)
FastRegexMatcher/^foo-11                                33.90n ±  1%   33.62n ±  1%        ~ (p=0.065 n=6)
FastRegexMatcher/(foo|bar)-11                           47.43n ±  1%   46.74n ±  2%   -1.45% (p=0.041 n=6)
FastRegexMatcher/foo.*-11                               84.12n ±  2%   80.83n ±  4%   -3.92% (p=0.009 n=6)
FastRegexMatcher/.*foo-11                               96.67n ±  3%   96.01n ±  4%        ~ (p=0.699 n=6)
FastRegexMatcher/^.*foo$-11                             98.48n ±  2%   95.20n ±  0%   -3.34% (p=0.002 n=6)
FastRegexMatcher/^.+foo$-11                             98.22n ±  2%   97.08n ±  3%        ~ (p=0.818 n=6)
FastRegexMatcher/.?-11                                  55.68n ±  0%   55.63n ±  0%   -0.09% (p=0.002 n=6)
FastRegexMatcher/.*-11                                  66.39n ±  4%   65.73n ±  6%        ~ (p=0.485 n=6)
FastRegexMatcher/.+-11                                  72.13n ±  4%   70.46n ±  5%        ~ (p=0.394 n=6)
FastRegexMatcher/foo.+-11                               84.08n ±  1%   84.39n ±  2%        ~ (p=1.000 n=6)
FastRegexMatcher/.+foo-11                               97.27n ±  3%   97.39n ±  3%        ~ (p=0.937 n=6)
FastRegexMatcher/foo_.+-11                              70.28n ±  1%   70.11n ±  1%        ~ (p=0.485 n=6)
FastRegexMatcher/foo_.*-11                              71.00n ±  4%   69.97n ±  2%   -1.45% (p=0.026 n=6)
FastRegexMatcher/.*foo.*-11                             175.1n ±  1%   173.2n ±  5%        ~ (p=0.143 n=6)
FastRegexMatcher/.+foo.+-11                             185.0n ±  1%   184.2n ±  2%        ~ (p=0.411 n=6)
FastRegexMatcher/(?s:.*)-11                             35.58n ±  1%   34.82n ±  1%   -2.14% (p=0.002 n=6)
FastRegexMatcher/(?s:.+)-11                             34.48n ±  0%   34.78n ±  1%   +0.87% (p=0.004 n=6)
FastRegexMatcher/(?s:^.*foo$)-11                        96.44n ±  1%   95.79n ±  2%        ~ (p=1.000 n=6)
FastRegexMatcher/(?i:foo)-11                            63.73n ±  1%   63.69n ±  0%        ~ (p=0.327 n=6)
FastRegexMatcher/(?i:(foo|bar))-11                      145.4n ±  1%   145.6n ±  2%        ~ (p=0.219 n=6)
FastRegexMatcher/(?i:(foo1|foo2|bar))-11                239.5n ±  1%   240.2n ±  1%        ~ (p=0.310 n=6)
FastRegexMatcher/^(?i:foo|oo)|(bar)$-11                 642.6n ±  0%   635.7n ±  0%   -1.07% (p=0.002 n=6)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-11    1.352µ ±  1%   1.470µ ±  1%   +8.73% (p=0.002 n=6)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-11         432.1n ±  1%   443.3n ±  1%   +2.58% (p=0.002 n=6)
FastRegexMatcher/^$-11                                  35.62n ±  0%   34.79n ±  3%   -2.32% (p=0.039 n=6)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-11     162.5n ±  2%   162.4n ±  3%        ~ (p=0.671 n=6)
FastRegexMatcher/10\.0\.(1|2)\.+-11                     70.96n ±  0%   70.96n ±  0%        ~ (p=1.000 n=6)
FastRegexMatcher/10\.0\.(1|2).+-11                      70.97n ±  0%   71.01n ±  2%        ~ (p=0.448 n=6)
FastRegexMatcher/((fo(bar))|.+foo)-11                   181.8n ±  0%   181.7n ±  0%        ~ (p=0.210 n=6)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-11    186.9n ±  6%   179.3n ± 11%        ~ (p=0.240 n=6)
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-11    180.4n ± 29%   189.7n ±  5%        ~ (p=0.394 n=6)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-11    1.371µ ±  1%   1.473µ ±  1%   +7.48% (p=0.002 n=6)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-11    5.176µ ±  0%   5.179µ ±  1%   +0.06% (p=0.017 n=6)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-11    6.163µ ±  0%   6.151µ ±  0%   -0.19% (p=0.009 n=6)
FastRegexMatcher/fo.?-11                                84.01n ±  0%   85.22n ±  0%   +1.45% (p=0.002 n=6)
FastRegexMatcher/foo.?-11                               83.43n ±  0%   85.21n ±  1%   +2.14% (p=0.002 n=6)
FastRegexMatcher/f.?o-11                                71.54n ±  0%   71.56n ±  1%        ~ (p=0.855 n=6)
FastRegexMatcher/.*foo.?-11                             183.6n ±  0%   185.9n ±  3%        ~ (p=0.067 n=6)
FastRegexMatcher/.?foo.+-11                             173.7n ±  1%   176.1n ±  5%   +1.41% (p=0.009 n=6)
FastRegexMatcher/foo.?|bar-11                           127.0n ±  0%   126.8n ±  1%        ~ (p=0.288 n=6)
FastRegexMatcher/.*-.*-.*-.*-.*-11                     4631.0n ±  2%   178.7n ±  1%  -96.14% (p=0.002 n=6)
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-11           5704.0n ±  0%   179.8n ±  1%  -96.85% (p=0.002 n=6)
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-11    8.558µ ±  0%   4.012µ ±  1%  -53.12% (p=0.002 n=6)
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-11    5.493µ ±  0%   3.264µ ±  1%  -40.59% (p=0.002 n=6)
geomean                                                 183.9n         153.7n        -16.41%
```

(I omitted memory benchmark results because there's no diff)