### PR TITLE
Rules: Sync access to `done` channel in rules.Group type

### DIFF
--- a/rules/group.go
+++ b/rules/group.go
@@ -60,6 +60,9 @@ type Group struct {
 
 	shouldRestore bool
 
+	isDoneChClosed bool
+	doneChMtx      sync.Mutex
+
 	markStale   bool
 	done        chan struct{}
 	terminated  chan struct{}
@@ -264,7 +267,13 @@ func (g *Group) run(ctx context.Context) {
 }
 
 func (g *Group) stop() {
-	close(g.done)
+	g.doneChMtx.Lock()
+	if !g.isDoneChClosed {
+		g.isDoneChClosed = true
+		close(g.done)
+	}
+	g.doneChMtx.Unlock()
+
 	<-g.terminated
 }
 


### PR DESCRIPTION
Fixes: #14146 

The behaviour in #14146 is expected when you try to close a channel from different goroutines that aren't synchronized between them. For example, `manager.Update()` launches goroutines that calls to `rules.Group.stop()` without synchronization between them [here](https://github.com/prometheus/prometheus/blob/main/rules/manager.go#L225) and [here](https://github.com/prometheus/prometheus/blob/main/rules/manager.go#L242). Also, the `manager.Stop()` method also calls `rules.Group.stop()` without sync [here](https://github.com/prometheus/prometheus/blob/main/rules/manager.go#L181)

I have managed to reproduce the issue with a test to produce the race condition, but the test is unreliable when shutting down.

Happy to talk about a way to reproduce this behaviour in a test reliably. I haven't included the test that reproduces this issue because it's a bit "hacky" and can't be finished gracefully. But I think that small code in this PR solves the issue.