### PR TITLE
tsdb/index: Fix number of series in TestReader_PostingsForLabelMatchingHonorsContextCancel

### DIFF
--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -615,7 +615,7 @@ func TestChunksTimeOrdering(t *testing.T) {
 func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	const seriesCount = 1000
 	var input indexWriterSeriesSlice
-	for i := 1; i < seriesCount; i++ {
+	for i := 1; i <= seriesCount; i++ {
 		input = append(input, &indexWriterSeries{
 			labels: labels.FromStrings("__name__", fmt.Sprintf("%4d", i)),
 			chunks: []chunks.Meta{


### PR DESCRIPTION
Fix number of series in `TestReader_PostingsForLabelMatchingHonorsContextCancel`, as due to a refactoring mistake they become 999 instead of 1000. 

I made the [mistake](https://github.com/prometheus/prometheus/pull/14071/files#diff-ec282c4a395e89aab93c5f8ad0931878c9f17625ef1e87c0d1b1523e7379949aR618) when refactoring in https://github.com/prometheus/prometheus/pull/14071. As you can tell from that diff, the operator `<=` became `<`. It makes no practical difference, but is logically off :)