### PR TITLE
Scrape: Use clean host header in request

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -736,6 +736,10 @@ func (s *targetScraper) scrape(ctx context.Context) (*http.Response, error) {
 		req.Header.Set("User-Agent", UserAgent)
 		req.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", strconv.FormatFloat(s.timeout.Seconds(), 'f', -1, 64))
 
+		// Add the Host header without the port
+		hostname := strings.Split(req.URL.Host, ":")[0]
+		req.Header.Set("Host", hostname)
+
 		s.req = req
 	}
 


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Found when used GCP application LB, the scrape command didn't get to the right host while simple curl does.
Found that the difference between curl and the request is the Host header that apparently used by the application LB for find the matching host.
