### PR TITLE
CI: Use default behavior of update-container-description-action

### DIFF
--- a/.github/workflows/container_description.yml
+++ b/.github/workflows/container_description.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - "README.md"
+      - "README-containers.md"
       - ".github/workflows/container_description.yml"
     branches: [ main, master ]
 
@@ -29,7 +30,6 @@ jobs:
           destination_container_repo: ${{ env.DOCKER_REPO_NAME }}
           provider: dockerhub
           short_description: ${{ env.DOCKER_REPO_NAME }}
-          readme_file: 'README.md'
 
   PushQuayIoReadme:
     runs-on: ubuntu-latest
@@ -49,4 +49,3 @@ jobs:
         with:
           destination_container_repo: ${{ env.DOCKER_REPO_NAME }}
           provider: quay
-          readme_file: 'README.md'


### PR DESCRIPTION
Previously, we always used README.md as the readme to push as container description. By not explicitly specifying this file name, we use the default behavior of the action, which is to push README-containers.md if it exist, and push README.md otherwise.

In short, nothing will directly change with this commit, but now repositories can provide a README-containers.md if they want to push a different README as the container description.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
