### PR TITLE
RuleQueryOffset: Add omitempty for the global configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -399,7 +399,7 @@ type GlobalConfig struct {
 	// How frequently to evaluate rules by default.
 	EvaluationInterval model.Duration `yaml:"evaluation_interval,omitempty"`
 	// Offset the rule evaluation timestamp of this particular group by the specified duration into the past to ensure the underlying metrics have been received.
-	RuleQueryOffset model.Duration `yaml:"rule_query_offset"`
+	RuleQueryOffset model.Duration `yaml:"rule_query_offset,omitempty"`
 	// File to which PromQL queries are logged.
 	QueryLogFile string `yaml:"query_log_file,omitempty"`
 	// The labels to add to any timeseries that this Prometheus instance scrapes.


### PR DESCRIPTION
A small oversight of when I introduced https://github.com/prometheus/prometheus/pull/14061, I could add a test to cover it but it seems like an overkill given other similar attributes don't have it either. Let me know if you think it's worth it.