### PR TITLE
CI: Actually enable the default fallback behavior of docker-pushrm

### DIFF
--- a/.github/workflows/container_description.yml
+++ b/.github/workflows/container_description.yml
@@ -30,6 +30,9 @@ jobs:
           destination_container_repo: ${{ env.DOCKER_REPO_NAME }}
           provider: dockerhub
           short_description: ${{ env.DOCKER_REPO_NAME }}
+          # Empty string results in README-containers.md being pushed if it
+          # exists. Otherwise, README.md is pushed.
+          readme_file: ''
 
   PushQuayIoReadme:
     runs-on: ubuntu-latest
@@ -49,3 +52,6 @@ jobs:
         with:
           destination_container_repo: ${{ env.DOCKER_REPO_NAME }}
           provider: quay
+          # Empty string results in README-containers.md being pushed if it
+          # exists. Otherwise, README.md is pushed.
+          readme_file: ''


### PR DESCRIPTION
The Github action explicitly sets `README.md` as the default file to push, see
https://github.com/christian-korneck/update-container-description-action/blob/master/action.yml#L17

This disables the fallback to `README-containers.md`, as implemented in the actual tool that the Github action uses, i.e. https://github.com/christian-korneck/docker-pushrm

However, by setting the file name explicitly to an empty string, we can trigger the default fallback behavior of dockre-pushrm after all.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
