### PR TITLE
Increase the depndabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       go.opentelemetry.io:
         patterns:
           - "go.opentelemetry.io/*"
+    open-pull-requests-limit: 20
   - package-ecosystem: "gomod"
     directory: "/documentation/examples/remote_storage"
     schedule:
@@ -19,6 +20,7 @@ updates:
     directory: "/web/ui"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 20
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
The default limit of 5 is a bit small given the number of dependencies we have for Go and JS. Increase to 20 to allow more updates to be pushed.
