### PR TITLE
headIndexReader.LabelNamesFor: skip not found series

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -277,7 +277,9 @@ func (h *headIndexReader) LabelNamesFor(ctx context.Context, ids ...storage.Seri
 		}
 		memSeries := h.head.series.getByID(chunks.HeadSeriesRef(id))
 		if memSeries == nil {
-			return nil, storage.ErrNotFound
+			// Series not found, this happens during compaction,
+			// when series was garbage collected after the caller got the series IDs.
+			continue
 		}
 		memSeries.lset.Range(func(lbl labels.Label) {
 			namesMap[lbl.Name] = struct{}{}


### PR DESCRIPTION
It's quite common during the compaction cycle to hold series IDs for series that aren't in the TSDB head anymore.

We shouldn't fail if that happens, as the caller has no way to figure out which one of the IDs doesn't exist.

Fixes https://github.com/prometheus/prometheus/issues/14278
