### PR TITLE
fix: broken link on github mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center" style="border-bottom: none">
-    <a href="//prometheus.io" target="_blank"><img alt="Prometheus" src="/documentation/images/prometheus-logo.svg"></a><br>Prometheus
+    <a href="https://prometheus.io" target="_blank"><img alt="Prometheus" src="/documentation/images/prometheus-logo.svg"></a><br>Prometheus
 </h1>
 
-<p align="center">Visit <a href="//prometheus.io" target="_blank">prometheus.io</a> for the full documentation,
+<p align="center">Visit <a href="https://prometheus.io" target="_blank">prometheus.io</a> for the full documentation,
 examples and guides.</p>
 
 <div align="center">


### PR DESCRIPTION
Fixes the 2 broken links to [prometheus.io](https://prometheus.io/) in the readme when accessed through github mobile

Please have a look @metalmatze 

Fixes #14281