### PR TITLE
Tune default GOGC

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -154,7 +154,7 @@ var (
 
 	DefaultRuntimeConfig = RuntimeConfig{
 		// Go runtime tuning.
-		GoGC: 50,
+		GoGC: 75,
 	}
 
 	// DefaultScrapeConfig is the default scrape configuration.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -125,7 +125,7 @@ runtime:
   # Configure the Go garbage collector GOGC parameter
   # See: https://tip.golang.org/doc/gc-guide#GOGC
   # Lowering this number increases CPU usage.
-  [ gogc: <int> | default = 50 ]
+  [ gogc: <int> | default = 75 ]
 
 # Rule files specifies a list of globs. Rules and alerts are read from
 # all matching files.


### PR DESCRIPTION
Adjust the default GOGC value to 75. This is less of a memory savings,
but has less impact on CPU use.