### PR TITLE
`MemPostings.PostingsForLabelMatching()`: don't hold the mutex while matching

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -403,9 +403,6 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	// which can be slow (seconds) if the match function is a huge regex.
 	// Holding this lock prevents new series from being added (slows down the write path)
 	// and blocks the compaction process.
-	//
-	// Also, benchmarking shows that first copying the values into a slice and then matching over that is
-	// faster than matching over the map keys directly, at least on AMD64.
 	vals := p.labelValues(name)
 	for i, count := 0, 1; i < len(vals); count++ {
 		if count%checkContextEveryNIterations == 0 && ctx.Err() != nil {

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -428,7 +428,7 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	}
 
 	// Now `vals` only contains the values that matched, get their postings.
-	var its []Postings
+	its := make([]Postings, 0, len(vals))
 	p.mtx.RLock()
 	e := p.m[name]
 	for _, v := range vals {

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1338,6 +1338,28 @@ func BenchmarkMemPostings_PostingsForLabelMatching(b *testing.B) {
 	}
 }
 
+func TestMemPostings_PostingsForLabelMatching(t *testing.T) {
+	mp := NewMemPostings()
+	mp.Add(1, labels.FromStrings("foo", "1"))
+	mp.Add(2, labels.FromStrings("foo", "2"))
+	mp.Add(3, labels.FromStrings("foo", "3"))
+	mp.Add(4, labels.FromStrings("foo", "4"))
+
+	isEven := func(v string) bool {
+		iv, err := strconv.Atoi(v)
+		if err != nil {
+			panic(err)
+		}
+		return iv%2 == 0
+	}
+
+	p := mp.PostingsForLabelMatching(context.Background(), "foo", isEven)
+	require.NoError(t, p.Err())
+	refs, err := ExpandPostings(p)
+	require.NoError(t, err)
+	require.Equal(t, []storage.SeriesRef{2, 4}, refs)
+}
+
 func TestMemPostings_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	memP := NewMemPostings()
 	seriesCount := 10 * checkContextEveryNIterations


### PR DESCRIPTION
This changes the `MemPostings.PostingsForLabelMatching` implementation to stop holding the read mutex while matching the label values.

We've seen that this method can be slow when the matcher is expensive, that's why we even added a context expiration check.

However, there are critical process that might be waiting on this mutex: writes (adding new series) and compaction (deleting the garbage-collected ones), so we should avoid holding it for a long period of time.

Given that we've copied the values to a slice anyway, there's no need to hold the lock while matching.

Related to https://github.com/prometheus/prometheus/pull/13286