### PR TITLE
native histograms: only reduce resolution for exponential histograms

### DIFF
--- a/scrape/target.go
+++ b/scrape/target.go
@@ -365,7 +365,7 @@ type bucketLimitAppender struct {
 
 func (app *bucketLimitAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	if h != nil {
-		if len(h.PositiveBuckets)+len(h.NegativeBuckets) > app.limit && h.Schema > histogram.ExponentialSchemaMax {
+		if len(h.PositiveBuckets)+len(h.NegativeBuckets) > app.limit && !histogram.IsExponentialSchema(h.Schema) {
 			return 0, errBucketLimit
 		}
 		for len(h.PositiveBuckets)+len(h.NegativeBuckets) > app.limit {
@@ -376,7 +376,7 @@ func (app *bucketLimitAppender) AppendHistogram(ref storage.SeriesRef, lset labe
 		}
 	}
 	if fh != nil {
-		if len(fh.PositiveBuckets)+len(fh.NegativeBuckets) > app.limit && fh.Schema > histogram.ExponentialSchemaMax {
+		if len(fh.PositiveBuckets)+len(fh.NegativeBuckets) > app.limit && !histogram.IsExponentialSchema(fh.Schema) {
 			return 0, errBucketLimit
 		}
 		for len(fh.PositiveBuckets)+len(fh.NegativeBuckets) > app.limit {

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -378,6 +378,8 @@ func (app *bucketLimitAppender) AppendHistogram(ref storage.SeriesRef, lset labe
 		}
 	}
 	if fh != nil {
+		// Return with an early error if the histogram has too many buckets and the
+		// schema is not exponential, in which case we can't reduce the resolution.
 		if len(fh.PositiveBuckets)+len(fh.NegativeBuckets) > app.limit && !histogram.IsExponentialSchema(fh.Schema) {
 			return 0, errBucketLimit
 		}

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -365,6 +365,8 @@ type bucketLimitAppender struct {
 
 func (app *bucketLimitAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	if h != nil {
+		// Return with an early error if the histogram has too many buckets and the
+		// schema is not exponential, in which case we can't reduce the resolution.
 		if len(h.PositiveBuckets)+len(h.NegativeBuckets) > app.limit && !histogram.IsExponentialSchema(h.Schema) {
 			return 0, errBucketLimit
 		}


### PR DESCRIPTION
Currently we can only reduce the resolution of exponential native histograms, so checking the schema for that is slightly more precise than checking against max schema.
