### PR TITLE
Do not compare relabel.Regexp as a plain struct

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -142,7 +142,7 @@ func (c *Config) Validate() error {
 	}
 
 	if c.Action == DropEqual || c.Action == KeepEqual {
-		if c.Regex != DefaultRelabelConfig.Regex ||
+		if !c.Regex.Equal(DefaultRelabelConfig.Regex) ||
 			c.Modulus != DefaultRelabelConfig.Modulus ||
 			c.Separator != DefaultRelabelConfig.Separator ||
 			c.Replacement != DefaultRelabelConfig.Replacement {
@@ -211,6 +211,15 @@ func (re Regexp) String() string {
 	str := re.Regexp.String()
 	// Trim the anchor `^(?:` prefix and `)$` suffix.
 	return str[4 : len(str)-2]
+}
+
+// Equal returns whether re and other have the same original string used to compile
+// the regular expression.
+func (re Regexp) Equal(other Regexp) bool {
+	if re.Regexp == nil || other.Regexp == nil {
+		return re.Regexp == nil && other.Regexp == nil
+	}
+	return re.Regexp.String() == other.Regexp.String()
 }
 
 // Process returns a relabeled version of the given label set. The relabel configurations

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -655,6 +655,40 @@ func TestRelabelValidate(t *testing.T) {
 			},
 			expected: `"-${3}" is invalid 'target_label' for replace action`,
 		},
+		{
+			config: Config{
+				SourceLabels: model.LabelNames{"a"},
+				Separator:    DefaultRelabelConfig.Separator,
+				Regex:        DefaultRelabelConfig.Regex,
+				Modulus:      DefaultRelabelConfig.Modulus,
+				TargetLabel:  "b",
+				Replacement:  DefaultRelabelConfig.Replacement,
+				Action:       KeepEqual,
+			},
+		},
+		{
+			config: Config{
+				SourceLabels: model.LabelNames{"a"},
+				Separator:    DefaultRelabelConfig.Separator,
+				Regex:        MustNewRegexp(DefaultRelabelConfig.Regex.String()),
+				Modulus:      DefaultRelabelConfig.Modulus,
+				TargetLabel:  "b",
+				Replacement:  DefaultRelabelConfig.Replacement,
+				Action:       KeepEqual,
+			},
+		},
+		{
+			config: Config{
+				SourceLabels: model.LabelNames{"a"},
+				Separator:    DefaultRelabelConfig.Separator,
+				Regex:        MustNewRegexp("non-default"),
+				Modulus:      DefaultRelabelConfig.Modulus,
+				TargetLabel:  "b",
+				Replacement:  DefaultRelabelConfig.Replacement,
+				Action:       KeepEqual,
+			},
+			expected: "keepequal action requires only 'source_labels' and `target_label`, and no other fields",
+		},
 	}
 	for i, test := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/12534

`(*relabel.Config).Validate` method compares Regexp like a plain struct against the default config
```go
if c.Regex != DefaultRelabelConfig.Regex
```
having that Regexp is defined as
```go
type Regexp struct {
	*regexp.Regexp
}
```
this expression returns `true` then and only then underlying pointers are also the same which is possible only when a config is instanced by `DefaultRelabelConfig.Regex`

that means we are not able to validate Config created by other ways
for instance via `Marshal + Unmarshal` as shown below

```go
package main

import (
	"github.com/prometheus/prometheus/model/relabel"
	"gopkg.in/yaml.v2"
)

const config = `
action: keepequal
source_labels: [a]
target_label: b
`

func main() {
	var static relabel.Config
	err := yaml.UnmarshalStrict([]byte(config), &static)
	if err != nil {
		panic(err)
	}

	data, err := yaml.Marshal(static)
	if err != nil {
		panic(err)
	}

	var c relabel.Config
	err = yaml.UnmarshalStrict(data, &c)
	if err != nil {
		panic(err) // keepequal action requires only 'source_labels' and `target_label`, and no other fields
	}
}
```