### PR TITLE
docs: clarify backup requirements for storage

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -61,8 +61,12 @@ A Prometheus server's data directory looks something like this:
 Note that a limitation of local storage is that it is not clustered or
 replicated. Thus, it is not arbitrarily scalable or durable in the face of
 drive or node outages and should be managed like any other single node
-database. The use of RAID is suggested for storage availability, and
-[snapshots](querying/api.md#snapshot) are recommended for backups. With proper
+database. 
+
+The use of RAID is suggested for storage availability, and
+[snapshots](querying/api.md#snapshot) are recommended for backups. Backups 
+made without snapshots run the risk of losing data that was recorded sync 
+the last WAL sync, which typically happens every two hours. With proper
 architecture, it is possible to retain years of data in local storage.
 
 Alternatively, external storage may be used via the

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -64,7 +64,7 @@ drive or node outages and should be managed like any other single node
 database. 
 
 [Snapshots](querying/api.md#snapshot) are recommended for backups. Backups 
-made without snapshots run the risk of losing data that was recorded sync 
+made without snapshots run the risk of losing data that was recorded since 
 the last WAL sync, which typically happens every two hours. With proper
 architecture, it is possible to retain years of data in local storage.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -63,8 +63,7 @@ replicated. Thus, it is not arbitrarily scalable or durable in the face of
 drive or node outages and should be managed like any other single node
 database. 
 
-The use of RAID is suggested for storage availability, and
-[snapshots](querying/api.md#snapshot) are recommended for backups. Backups 
+[Snapshots](querying/api.md#snapshot) are recommended for backups. Backups 
 made without snapshots run the risk of losing data that was recorded sync 
 the last WAL sync, which typically happens every two hours. With proper
 architecture, it is possible to retain years of data in local storage.


### PR DESCRIPTION
After reading this (again) recently, I was under the impression that our backup strategy ("just throw Bacula at it") was just not good enough and that our backups were inconsistent. I filed [an issue internally][41627] about this because of that concern.

But reading a conversation with @SuperQ on IRC, I came under the impression that only the WAL files would be lost. This is an attempt at documenting this more clearly.

[41627]: https://gitlab.torproject.org/tpo/tpa/team/-/issues/41627
