### PR TITLE
remote write: simplify readability of timeseries filtering by using the slices package

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -1741,10 +1742,12 @@ func buildTimeSeries(timeSeries []prompb.TimeSeries, filter func(prompb.TimeSeri
 	var lowest int64
 	var droppedSamples, droppedExemplars, droppedHistograms int
 
-	keepIdx := 0
+	//keepIdx := 0
 	lowest = math.MaxInt64
-	for i, ts := range timeSeries {
+	//for i, ts := range timeSeries {
+	timeSeries = slices.DeleteFunc(timeSeries, func(ts prompb.TimeSeries) bool {
 		if filter != nil && filter(ts) {
+			//fmt.Println("deleteing")
 			if len(ts.Samples) > 0 {
 				droppedSamples++
 			}
@@ -1754,7 +1757,7 @@ func buildTimeSeries(timeSeries []prompb.TimeSeries, filter func(prompb.TimeSeri
 			if len(ts.Histograms) > 0 {
 				droppedHistograms++
 			}
-			continue
+			return true
 		}
 
 		// At the moment we only ever append a TimeSeries with a single sample or exemplar in it.
@@ -1778,13 +1781,14 @@ func buildTimeSeries(timeSeries []prompb.TimeSeries, filter func(prompb.TimeSeri
 		if len(ts.Histograms) > 0 && ts.Histograms[0].Timestamp < lowest {
 			lowest = ts.Histograms[0].Timestamp
 		}
-
+		return false
 		// Move the current element to the write position and increment the write pointer
-		timeSeries[keepIdx] = timeSeries[i]
-		keepIdx++
-	}
+		//timeSeries[keepIdx] = timeSeries[i]
+		//keepIdx++
+	})
 
-	timeSeries = timeSeries[:keepIdx]
+	//timeSeries = timeSeries[:keepIdx]
+	//fmt.Println("timeseries: ", timeSeries)
 	return highest, lowest, timeSeries, droppedSamples, droppedExemplars, droppedHistograms
 }
 


### PR DESCRIPTION
Hopefully this will help us fix #13979 or reproduce it in a test more easily. It's been noted a few times in https://github.com/prometheus/prometheus/pull/14078 that the readability or modification of the underlying `pendingData` slice is difficult and potentially the cause of the data corruption.

cc @FUSAKLA @david-vavra

Without this change
```
perflock go test -run=XXX -bench=BenchmarkBuildTimeSeries -benchmem -timeout=99999s
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/storage/remote
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkBuildTimeSeries-32    	     529	   2305662 ns/op	 2652227 B/op	   39749 allocs/op
PASS
ok  	github.com/prometheus/prometheus/storage/remote	1.460s
```

With this change
```
perflock go test -run=XXX -bench=BenchmarkBuildTimeSeries -benchmem -timeout=99999s
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/storage/remote
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkBuildTimeSeries-32    	     523	   2355820 ns/op	 2652200 B/op	   39749 allocs/op
PASS
ok  	github.com/prometheus/prometheus/storage/remote	1.475s
```