### PR TITLE
[PRW-2.0] (part 2) Removed automatic negotiation, updates for the latest spec semantics in remote pkg

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1747,6 +1747,7 @@ func rwProtoMsgFlagValue(msgs *[]config.RemoteWriteProtoMsg) kingpin.Value {
 	return &rwProtoMsgFlagParser{msgs: msgs}
 }
 
+// IsCumulative is used by kingpin to tell if it's an array or not.
 func (p *rwProtoMsgFlagParser) IsCumulative() bool {
 	return true
 }

--- a/cmd/promtool/metrics.go
+++ b/cmd/promtool/metrics.go
@@ -116,7 +116,7 @@ func parseAndPushMetrics(client *remote.Client, data []byte, labels map[string]s
 
 	// Encode the request body into snappy encoding.
 	compressed := snappy.Encode(nil, raw)
-	err = client.Store(context.Background(), compressed, 0, remote.Version1, "snappy")
+	err = client.Store(context.Background(), compressed, 0)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "  FAILED:", err)
 		return false

--- a/config/config.go
+++ b/config/config.go
@@ -1026,9 +1026,6 @@ func CheckTargetAddress(address model.LabelValue) error {
 	return nil
 }
 
-// TODO(bwplotka): Remove in the next PRs (review split PR for readability).
-type RemoteWriteFormat int64
-
 // RemoteWriteProtoMsg represents the known protobuf message for the remote write
 // 1.0 and 2.0 specs.
 type RemoteWriteProtoMsg string
@@ -1054,7 +1051,7 @@ func (m RemoteWriteProtoMsgs) Strings() []string {
 }
 
 func (m RemoteWriteProtoMsgs) String() string {
-	return strings.Join(m.Strings(), ",")
+	return strings.Join(m.Strings(), ", ")
 }
 
 var (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1798,7 +1798,7 @@ var expectedErrors = []struct {
 	},
 	{
 		filename: "remote_write_wrong_msg.bad.yml",
-		errMsg:   `invalid protobuf_message value: unknown remote write protobuf message io.prometheus.writet.v2.Request, supported: prometheus.WriteRequest,io.prometheus.write.v2.Request`,
+		errMsg:   `invalid protobuf_message value: unknown remote write protobuf message io.prometheus.writet.v2.Request, supported: prometheus.WriteRequest, io.prometheus.write.v2.Request`,
 	},
 	{
 		filename: "remote_write_url_missing.bad.yml",

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -26,7 +26,7 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--web.enable-lifecycle</code> | Enable shutdown and reload via HTTP request. | `false` |
 | <code class="text-nowrap">--web.enable-admin-api</code> | Enable API endpoints for admin control actions. | `false` |
 | <code class="text-nowrap">--web.enable-remote-write-receiver</code> | Enable API endpoint accepting remote write requests. | `false` |
-| <code class="text-nowrap">--web.remote-write-receiver.accepted-protobuf-messages</code> | List of the remote write protobuf messages to accept when receiving the remote writes. Supported values: prometheus.WriteRequest,io.prometheus.write.v2.Request | `prometheus.WriteRequest` |
+| <code class="text-nowrap">--web.remote-write-receiver.accepted-protobuf-messages</code> | List of the remote write protobuf messages to accept when receiving the remote writes. Supported values: prometheus.WriteRequest, io.prometheus.write.v2.Request | `prometheus.WriteRequest` |
 | <code class="text-nowrap">--web.console.templates</code> | Path to the console template directory, available at /consoles. | `consoles` |
 | <code class="text-nowrap">--web.console.libraries</code> | Path to the console library directory. | `console_libraries` |
 | <code class="text-nowrap">--web.page-title</code> | Document title of Prometheus instance. | `Prometheus Time Series Collection and Processing Server` |

--- a/prompb/io/prometheus/write/v2/symbols.go
+++ b/prompb/io/prometheus/write/v2/symbols.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writev2
+
+import "github.com/prometheus/prometheus/model/labels"
+
+// SymbolsTable implements table for easy symbol use.
+type SymbolsTable struct {
+	strings    []string
+	symbolsMap map[string]uint32
+}
+
+// NewSymbolTable returns a symbol table.
+func NewSymbolTable() SymbolsTable {
+	return SymbolsTable{
+		// Empty string is required as a first element.
+		symbolsMap: map[string]uint32{"": 0},
+		strings:    []string{""},
+	}
+}
+
+// Symbolize adds (if not added before) a string to the symbols table,
+// while returning its reference number.
+func (t *SymbolsTable) Symbolize(str string) uint32 {
+	if ref, ok := t.symbolsMap[str]; ok {
+		return ref
+	}
+	ref := uint32(len(t.strings))
+	t.strings = append(t.strings, str)
+	t.symbolsMap[str] = ref
+	return ref
+}
+
+// SymbolizeLabels symbolize Prometheus labels.
+func (t *SymbolsTable) SymbolizeLabels(lbls labels.Labels, buf []uint32) []uint32 {
+	result := buf[:0]
+	lbls.Range(func(l labels.Label) {
+		off := t.Symbolize(l.Name)
+		result = append(result, off)
+		off = t.Symbolize(l.Value)
+		result = append(result, off)
+	})
+	return result
+}
+
+// Symbols returns computes symbols table to put in e.g. Request.Symbols.
+// As per spec, order does not matter.
+func (t *SymbolsTable) Symbols() []string {
+	return t.strings
+}
+
+// Reset clears symbols table.
+func (t *SymbolsTable) Reset() {
+	// NOTE: Make sure to keep empty symbol.
+	t.strings = t.strings[:1]
+	for k := range t.symbolsMap {
+		if k == "" {
+			continue
+		}
+		delete(t.symbolsMap, k)
+	}
+}
+
+// DesymbolizeLabels decodes label references, with given symbols to labels.
+func DesymbolizeLabels(labelRefs []uint32, symbols []string) labels.Labels {
+	b := labels.NewScratchBuilder(len(labelRefs))
+	for i := 0; i < len(labelRefs); i += 2 {
+		b.Add(symbols[labelRefs[i]], symbols[labelRefs[i+1]])
+	}
+	b.Sort()
+	return b.Labels()
+}

--- a/prompb/io/prometheus/write/v2/symbols_test.go
+++ b/prompb/io/prometheus/write/v2/symbols_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writev2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestSymbolsTable(t *testing.T) {
+	s := NewSymbolTable()
+	require.Equal(t, []string{""}, s.Symbols(), "required empty reference does not exist")
+	require.Equal(t, uint32(0), s.Symbolize(""))
+	require.Equal(t, []string{""}, s.Symbols())
+
+	require.Equal(t, uint32(1), s.Symbolize("abc"))
+	require.Equal(t, []string{"", "abc"}, s.Symbols())
+
+	require.Equal(t, uint32(2), s.Symbolize("__name__"))
+	require.Equal(t, []string{"", "abc", "__name__"}, s.Symbols())
+
+	require.Equal(t, uint32(3), s.Symbolize("foo"))
+	require.Equal(t, []string{"", "abc", "__name__", "foo"}, s.Symbols())
+
+	s.Reset()
+	require.Equal(t, []string{""}, s.Symbols(), "required empty reference does not exist")
+	require.Equal(t, uint32(0), s.Symbolize(""))
+
+	require.Equal(t, uint32(1), s.Symbolize("__name__"))
+	require.Equal(t, []string{"", "__name__"}, s.Symbols())
+
+	require.Equal(t, uint32(2), s.Symbolize("abc"))
+	require.Equal(t, []string{"", "__name__", "abc"}, s.Symbols())
+
+	ls := labels.FromStrings("__name__", "qwer", "zxcv", "1234")
+	encoded := s.SymbolizeLabels(ls, nil)
+	require.Equal(t, []uint32{1, 3, 4, 5}, encoded)
+	decoded := DesymbolizeLabels(encoded, s.Symbols())
+	require.Equal(t, ls, decoded)
+
+	// Different buf.
+	ls = labels.FromStrings("__name__", "qwer", "zxcv2222", "1234")
+	encoded = s.SymbolizeLabels(ls, []uint32{1, 3, 4, 5})
+	require.Equal(t, []uint32{1, 3, 6, 5}, encoded)
+}

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -73,7 +73,7 @@ func TestStoreHTTPErrorHandling(t *testing.T) {
 		c, err := NewWriteClient(hash, conf)
 		require.NoError(t, err)
 
-		err = c.Store(context.Background(), []byte{}, 0, Version1, "snappy")
+		err = c.Store(context.Background(), []byte{}, 0)
 		if test.err != nil {
 			require.EqualError(t, err, test.err.Error())
 		} else {
@@ -133,7 +133,7 @@ func TestClientRetryAfter(t *testing.T) {
 			c := getClient(getClientConfig(serverURL, tc.retryOnRateLimit))
 
 			var recErr RecoverableError
-			err = c.Store(context.Background(), []byte{}, 0, Version1, "snappy")
+			err = c.Store(context.Background(), []byte{}, 0)
 			require.Equal(t, tc.expectedRecoverable, errors.As(err, &recErr), "Mismatch in expected recoverable error status.")
 			if tc.expectedRecoverable {
 				require.Equal(t, tc.expectedRetryAfter, recErr.retryAfter)
@@ -203,7 +203,7 @@ func TestClientHeaders(t *testing.T) {
 	c, err := NewWriteClient("c", conf)
 	require.NoError(t, err)
 
-	err = c.Store(context.Background(), []byte{}, 0, Version1, "snappy")
+	err = c.Store(context.Background(), []byte{}, 0)
 	require.NoError(t, err)
 
 	require.True(t, called, "The remote server wasn't called")

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -15,6 +15,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -65,73 +66,11 @@ func newHighestTimestampMetric() *maxTimestamp {
 }
 
 type contentNegotiationStep struct {
-	lastRWHeader  string
-	compression   string
 	behaviour     error // or nil
 	attemptString string
 }
 
-func TestContentNegotiation(t *testing.T) {
-	testcases := []struct {
-		name       string
-		success    bool
-		qmRwFormat config.RemoteWriteProtoMsg
-		rwFormat   config.RemoteWriteFormat
-		steps      []contentNegotiationStep
-	}{
-		// Test a simple case where the v2 request we send is processed first time.
-		{
-			success: true, name: "v2 happy path", qmRwFormat: config.RemoteWriteProtoMsgV2, rwFormat: Version2, steps: []contentNegotiationStep{
-				{lastRWHeader: "2.0;snappy,0.1.0", compression: "snappy", behaviour: nil, attemptString: "0,1,snappy,ok"},
-			},
-		},
-		// Test a simple case where the v1 request we send is processed first time.
-		{
-			success: true, name: "v1 happy path", qmRwFormat: config.RemoteWriteProtoMsgV1, rwFormat: Version1, steps: []contentNegotiationStep{
-				{lastRWHeader: "0.1.0", compression: "snappy", behaviour: nil, attemptString: "0,0,snappy,ok"},
-			},
-		},
-		// Test a case where the v1 request has a temporary delay but goes through on retry.
-		// There is no content re-negotiation between first and retry attempts.
-		{
-			success: true, name: "v1 happy path with one 5xx retry", qmRwFormat: config.RemoteWriteProtoMsgV1, rwFormat: Version1, steps: []contentNegotiationStep{
-				{lastRWHeader: "0.1.0", compression: "snappy", behaviour: RecoverableError{fmt.Errorf("Pretend 500"), 1}, attemptString: "0,0,snappy,Pretend 500"},
-				{lastRWHeader: "0.1.0", compression: "snappy", behaviour: nil, attemptString: "1,0,snappy,ok"},
-			},
-		},
-		// Repeat the above test but with v2. The request has a temporary delay but goes through on retry.
-		// There is no content re-negotiation between first and retry attempts.
-		{
-			success: true, name: "v2 happy path with one 5xx retry", qmRwFormat: config.RemoteWriteProtoMsgV2, rwFormat: Version2, steps: []contentNegotiationStep{
-				{lastRWHeader: "2.0;snappy,0.1.0", compression: "snappy", behaviour: RecoverableError{fmt.Errorf("Pretend 500"), 1}, attemptString: "0,1,snappy,Pretend 500"},
-				{lastRWHeader: "2.0;snappy,0.1.0", compression: "snappy", behaviour: nil, attemptString: "1,1,snappy,ok"},
-			},
-		},
-		// Now test where the server suddenly stops speaking 2.0 and we need to downgrade.
-		{
-			success: true, name: "v2 request to v2 server that has downgraded via 406", qmRwFormat: config.RemoteWriteProtoMsgV2, rwFormat: Version2, steps: []contentNegotiationStep{
-				{lastRWHeader: "2.0;snappy,0.1.0", compression: "snappy", behaviour: &ErrRenegotiate{"", 406}, attemptString: "0,1,snappy,HTTP 406: msg: "},
-				{lastRWHeader: "0.1.0", compression: "snappy", behaviour: nil, attemptString: "0,0,snappy,ok"},
-			},
-		},
-		// Now test where the server suddenly stops speaking 2.0 and we need to downgrade because it returns a 400.
-		{
-			success: true, name: "v2 request to v2 server that has downgraded via 400", qmRwFormat: config.RemoteWriteProtoMsgV2, rwFormat: Version2, steps: []contentNegotiationStep{
-				{lastRWHeader: "2.0;snappy,0.1.0", compression: "snappy", behaviour: &ErrRenegotiate{"", 400}, attemptString: "0,1,snappy,HTTP 400: msg: "},
-				{lastRWHeader: "0.1.0", compression: "snappy", behaviour: nil, attemptString: "0,0,snappy,ok"},
-			},
-		},
-		// Now test where the server flip flops between "2.0;snappy" and "0.1.0" only.
-		{
-			success: false, name: "flip flopping", qmRwFormat: config.RemoteWriteProtoMsgV2, rwFormat: Version2, steps: []contentNegotiationStep{
-				{lastRWHeader: "2.0;snappy", compression: "snappy", behaviour: &ErrRenegotiate{"", 406}, attemptString: "0,1,snappy,HTTP 406: msg: "},
-				{lastRWHeader: "0.1.0", compression: "snappy", behaviour: &ErrRenegotiate{"", 406}, attemptString: "0,0,snappy,HTTP 406: msg: "},
-				{lastRWHeader: "2.0;snappy", compression: "snappy", behaviour: &ErrRenegotiate{"", 406}, attemptString: "0,1,snappy,HTTP 406: msg: "},
-				// There's no 4th attempt as we do a maximum of 3 sending attempts (not counting retries).
-			},
-		},
-	}
-
+func TestBasicContentNegotiation(t *testing.T) {
 	queueConfig := config.DefaultQueueConfig
 	queueConfig.BatchSendDeadline = model.Duration(100 * time.Millisecond)
 	queueConfig.MaxShards = 1
@@ -147,7 +86,60 @@ func TestContentNegotiation(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
+	for _, tc := range []struct {
+		name             string
+		success          bool
+		senderProtoMsg   config.RemoteWriteProtoMsg
+		receiverProtoMsg config.RemoteWriteProtoMsg
+		steps            []contentNegotiationStep
+	}{
+		{
+			success: true, name: "v2 happy path", senderProtoMsg: config.RemoteWriteProtoMsgV2, receiverProtoMsg: config.RemoteWriteProtoMsgV2, steps: []contentNegotiationStep{
+				{behaviour: nil, attemptString: "0,ok"},
+			},
+		},
+		{
+			success: true, name: "v1 happy path", senderProtoMsg: config.RemoteWriteProtoMsgV1, receiverProtoMsg: config.RemoteWriteProtoMsgV1, steps: []contentNegotiationStep{
+				{behaviour: nil, attemptString: "0,ok"},
+			},
+		},
+		// Test a case where the v1 request has a temporary delay but goes through on retry.
+		{
+			success: true, name: "v1 happy path with one 5xx retry", senderProtoMsg: config.RemoteWriteProtoMsgV1, receiverProtoMsg: config.RemoteWriteProtoMsgV1, steps: []contentNegotiationStep{
+				{behaviour: RecoverableError{errors.New("pretend 500"), 1}, attemptString: "0,pretend 500"},
+				{behaviour: nil, attemptString: "1,ok"},
+			},
+		},
+		// Repeat the above test but with v2. The request has a temporary delay but goes through on retry.
+		{
+			success: true, name: "v2 happy path with one 5xx retry", senderProtoMsg: config.RemoteWriteProtoMsgV2, receiverProtoMsg: config.RemoteWriteProtoMsgV2, steps: []contentNegotiationStep{
+				{behaviour: RecoverableError{errors.New("pretend 500"), 1}, attemptString: "0,pretend 500"},
+				{behaviour: nil, attemptString: "1,ok"},
+			},
+		},
+		// A few error cases of v2 talking to v1.
+		{
+			success: false, name: "v2 talks to v1 that gives 400 or 415", senderProtoMsg: config.RemoteWriteProtoMsgV2, receiverProtoMsg: config.RemoteWriteProtoMsgV1, steps: []contentNegotiationStep{
+				{behaviour: errors.New("pretend unrecoverable err"), attemptString: "0,pretend unrecoverable err"},
+			},
+		},
+		{
+			success: false, name: "v2 talks to v1 that tries to unmarshal v2 payload with v1 proto", senderProtoMsg: config.RemoteWriteProtoMsgV2, receiverProtoMsg: config.RemoteWriteProtoMsgV1, steps: []contentNegotiationStep{
+				{behaviour: nil, attemptString: "0,ok"}, // It's ok, because payload can be unmarshaled just fine, but it's empty.
+			},
+		},
+		// Opposite, v1 talking to v2 only server.
+		{
+			success: false, name: "v1 talks to v2 that gives 400 or 415", senderProtoMsg: config.RemoteWriteProtoMsgV1, receiverProtoMsg: config.RemoteWriteProtoMsgV2, steps: []contentNegotiationStep{
+				{behaviour: errors.New("pretend unrecoverable err"), attemptString: "0,pretend unrecoverable err"},
+			},
+		},
+		{
+			success: false, name: "v1 talks to (broken) v2 that tries to unmarshal v1 payload with v2 proto", senderProtoMsg: config.RemoteWriteProtoMsgV1, receiverProtoMsg: config.RemoteWriteProtoMsgV2, steps: []contentNegotiationStep{
+				{behaviour: nil, attemptString: "0,ok"}, // It's ok, because payload can be unmarshaled just fine, but it's empty.
+			},
+		},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, true)
@@ -167,13 +159,13 @@ func TestContentNegotiation(t *testing.T) {
 			queueConfig.Capacity = len(samples)
 			queueConfig.MaxSamplesPerSend = len(samples)
 			// For now we only ever have a single rw config in this test.
-			conf.RemoteWriteConfigs[0].ProtobufMessage = tc.qmRwFormat
+			conf.RemoteWriteConfigs[0].ProtobufMessage = tc.senderProtoMsg
 			require.NoError(t, s.ApplyConfig(conf))
 			hash, err := toHash(writeConfig)
 			require.NoError(t, err)
 			qm := s.rws.queues[hash]
 
-			c := NewTestWriteClient(tc.rwFormat)
+			c := NewTestWriteClient(tc.receiverProtoMsg)
 			c.setSteps(tc.steps) // set expected behaviour.
 			qm.SetClient(c)
 
@@ -183,6 +175,12 @@ func TestContentNegotiation(t *testing.T) {
 			// Did we expect some data back?
 			if tc.success {
 				c.expectSamples(samples, series)
+			} else {
+				// For case like v2 message being able to be unmarshaled as v1, let's
+				// don't end up in corrupted data.
+				// NOTE(bwplotka): Technically receiver MUST check content-type, but
+				// we want to avoid surprising state on implementation mistakes.
+				c.expectSamples(nil, nil)
 			}
 			qm.Append(samples)
 
@@ -196,38 +194,16 @@ func TestContentNegotiation(t *testing.T) {
 				c.waitForExpectedData(t, 5*time.Second)
 			}
 
-			require.Equal(t, len(c.sendAttempts), len(tc.steps))
+			require.Equal(t, len(tc.steps), len(c.sendAttempts))
 			for i, s := range c.sendAttempts {
-				require.Equal(t, s, tc.steps[i].attemptString)
+				require.Equal(t, tc.steps[i].attemptString, s)
 			}
 		})
 	}
 }
 
 func TestSampleDelivery(t *testing.T) {
-	testcases := []struct {
-		name            string
-		samples         bool
-		exemplars       bool
-		histograms      bool
-		floatHistograms bool
-		rwFormat        config.RemoteWriteFormat
-	}{
-		{samples: true, exemplars: false, histograms: false, floatHistograms: false, name: "samples only"},
-		{samples: true, exemplars: true, histograms: true, floatHistograms: true, name: "samples, exemplars, and histograms"},
-		{samples: false, exemplars: true, histograms: false, floatHistograms: false, name: "exemplars only"},
-		{samples: false, exemplars: false, histograms: true, floatHistograms: false, name: "histograms only"},
-		{samples: false, exemplars: false, histograms: false, floatHistograms: true, name: "float histograms only"},
-
-		// TODO(alexg): update some portion of this test to check for the 2.0 metadata
-		{samples: true, exemplars: false, histograms: false, floatHistograms: false, name: "samples only", rwFormat: Version2},
-		{samples: true, exemplars: true, histograms: true, floatHistograms: true, name: "samples, exemplars, and histograms", rwFormat: Version2},
-		{samples: false, exemplars: true, histograms: false, floatHistograms: false, name: "exemplars only", rwFormat: Version2},
-		{samples: false, exemplars: false, histograms: true, floatHistograms: false, name: "histograms only", rwFormat: Version2},
-		{samples: false, exemplars: false, histograms: false, floatHistograms: true, name: "float histograms only", rwFormat: Version2},
-	}
-
-	// Let's create an even number of send batches so we don't run into the
+	// Let's create an even number of send batches, so we don't run into the
 	// batch timeout case.
 	n := 3
 
@@ -247,9 +223,29 @@ func TestSampleDelivery(t *testing.T) {
 			writeConfig,
 		},
 	}
+	for _, tc := range []struct {
+		protoMsg config.RemoteWriteProtoMsg
 
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
+		name            string
+		samples         bool
+		exemplars       bool
+		histograms      bool
+		floatHistograms bool
+	}{
+		{protoMsg: config.RemoteWriteProtoMsgV1, samples: true, exemplars: false, histograms: false, floatHistograms: false, name: "samples only"},
+		{protoMsg: config.RemoteWriteProtoMsgV1, samples: true, exemplars: true, histograms: true, floatHistograms: true, name: "samples, exemplars, and histograms"},
+		{protoMsg: config.RemoteWriteProtoMsgV1, samples: false, exemplars: true, histograms: false, floatHistograms: false, name: "exemplars only"},
+		{protoMsg: config.RemoteWriteProtoMsgV1, samples: false, exemplars: false, histograms: true, floatHistograms: false, name: "histograms only"},
+		{protoMsg: config.RemoteWriteProtoMsgV1, samples: false, exemplars: false, histograms: false, floatHistograms: true, name: "float histograms only"},
+
+		// TODO(alexg): update some portion of this test to check for the 2.0 metadata
+		{protoMsg: config.RemoteWriteProtoMsgV2, samples: true, exemplars: false, histograms: false, floatHistograms: false, name: "samples only"},
+		{protoMsg: config.RemoteWriteProtoMsgV2, samples: true, exemplars: true, histograms: true, floatHistograms: true, name: "samples, exemplars, and histograms"},
+		{protoMsg: config.RemoteWriteProtoMsgV2, samples: false, exemplars: true, histograms: false, floatHistograms: false, name: "exemplars only"},
+		{protoMsg: config.RemoteWriteProtoMsgV2, samples: false, exemplars: false, histograms: true, floatHistograms: false, name: "histograms only"},
+		{protoMsg: config.RemoteWriteProtoMsgV2, samples: false, exemplars: false, histograms: false, floatHistograms: true, name: "float histograms only"},
+	} {
+		t.Run(fmt.Sprintf("%s-%s", tc.protoMsg, tc.name), func(t *testing.T) {
 			dir := t.TempDir()
 			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, true)
 			defer s.Close()
@@ -281,12 +277,14 @@ func TestSampleDelivery(t *testing.T) {
 			// Apply new config.
 			queueConfig.Capacity = len(samples)
 			queueConfig.MaxSamplesPerSend = len(samples) / 2
+			// For now we only ever have a single rw config in this test.
+			conf.RemoteWriteConfigs[0].ProtobufMessage = tc.protoMsg
 			require.NoError(t, s.ApplyConfig(conf))
 			hash, err := toHash(writeConfig)
 			require.NoError(t, err)
 			qm := s.rws.queues[hash]
 
-			c := NewTestWriteClient(tc.rwFormat)
+			c := NewTestWriteClient(tc.protoMsg)
 			qm.SetClient(c)
 
 			qm.StoreSeries(series, 0)
@@ -325,7 +323,7 @@ func testDefaultQueueConfig() config.QueueConfig {
 }
 
 func TestMetadataDelivery(t *testing.T) {
-	c := NewTestWriteClient(Version1)
+	c := NewTestWriteClient(config.RemoteWriteProtoMsgV1)
 
 	dir := t.TempDir()
 
@@ -333,7 +331,7 @@ func TestMetadataDelivery(t *testing.T) {
 	mcfg := config.DefaultMetadataConfig
 
 	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, Version1)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
 	m.Start()
 	defer m.Stop()
 
@@ -387,7 +385,7 @@ func TestWALMetadataDelivery(t *testing.T) {
 	require.NoError(t, err)
 	qm := s.rws.queues[hash]
 
-	c := NewTestWriteClient(Version1)
+	c := NewTestWriteClient(config.RemoteWriteProtoMsgV1)
 	qm.SetClient(c)
 
 	qm.StoreSeries(series, 0)
@@ -400,12 +398,12 @@ func TestWALMetadataDelivery(t *testing.T) {
 }
 
 func TestSampleDeliveryTimeout(t *testing.T) {
-	for _, rwFormat := range []config.RemoteWriteFormat{Version1, Version2} {
-		t.Run(fmt.Sprint(rwFormat), func(t *testing.T) {
+	for _, protoMsg := range []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1, config.RemoteWriteProtoMsgV2} {
+		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
 			// Let's send one less sample than batch size, and wait the timeout duration
 			n := 9
 			samples, series := createTimeseries(n, n)
-			c := NewTestWriteClient(rwFormat)
+			c := NewTestWriteClient(protoMsg)
 
 			cfg := testDefaultQueueConfig()
 			mcfg := config.DefaultMetadataConfig
@@ -414,7 +412,7 @@ func TestSampleDeliveryTimeout(t *testing.T) {
 			dir := t.TempDir()
 
 			metrics := newQueueManagerMetrics(nil, "", "")
-			m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, rwFormat)
+			m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, protoMsg)
 			m.StoreSeries(series, 0)
 			m.Start()
 			defer m.Stop()
@@ -432,8 +430,8 @@ func TestSampleDeliveryTimeout(t *testing.T) {
 }
 
 func TestSampleDeliveryOrder(t *testing.T) {
-	for _, rwFormat := range []config.RemoteWriteFormat{Version1, Version2} {
-		t.Run(fmt.Sprint(rwFormat), func(t *testing.T) {
+	for _, protoMsg := range []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1, config.RemoteWriteProtoMsgV2} {
+		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
 			ts := 10
 			n := config.DefaultQueueConfig.MaxSamplesPerSend * ts
 			samples := make([]record.RefSample, 0, n)
@@ -451,7 +449,7 @@ func TestSampleDeliveryOrder(t *testing.T) {
 				})
 			}
 
-			c := NewTestWriteClient(rwFormat)
+			c := NewTestWriteClient(protoMsg)
 			c.expectSamples(samples, series)
 
 			dir := t.TempDir()
@@ -460,7 +458,7 @@ func TestSampleDeliveryOrder(t *testing.T) {
 			mcfg := config.DefaultMetadataConfig
 
 			metrics := newQueueManagerMetrics(nil, "", "")
-			m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, rwFormat)
+			m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, protoMsg)
 			m.StoreSeries(series, 0)
 
 			m.Start()
@@ -482,7 +480,7 @@ func TestShutdown(t *testing.T) {
 	mcfg := config.DefaultMetadataConfig
 	metrics := newQueueManagerMetrics(nil, "", "")
 
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, Version1)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
 	n := 2 * config.DefaultQueueConfig.MaxSamplesPerSend
 	samples, series := createTimeseries(n, n)
 	m.StoreSeries(series, 0)
@@ -520,7 +518,7 @@ func TestSeriesReset(t *testing.T) {
 	cfg := testDefaultQueueConfig()
 	mcfg := config.DefaultMetadataConfig
 	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, Version1)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
 	for i := 0; i < numSegments; i++ {
 		series := []record.RefSeries{}
 		for j := 0; j < numSeries; j++ {
@@ -534,14 +532,14 @@ func TestSeriesReset(t *testing.T) {
 }
 
 func TestReshard(t *testing.T) {
-	for _, rwFormat := range []config.RemoteWriteFormat{Version1, Version2} {
-		t.Run(fmt.Sprint(rwFormat), func(t *testing.T) {
+	for _, protoMsg := range []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1, config.RemoteWriteProtoMsgV2} {
+		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
 			size := 10 // Make bigger to find more races.
 			nSeries := 6
 			nSamples := config.DefaultQueueConfig.Capacity * size
 			samples, series := createTimeseries(nSamples, nSeries)
 
-			c := NewTestWriteClient(rwFormat)
+			c := NewTestWriteClient(protoMsg)
 			c.expectSamples(samples, series)
 
 			cfg := testDefaultQueueConfig()
@@ -551,7 +549,7 @@ func TestReshard(t *testing.T) {
 			dir := t.TempDir()
 
 			metrics := newQueueManagerMetrics(nil, "", "")
-			m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, rwFormat)
+			m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, protoMsg)
 			m.StoreSeries(series, 0)
 
 			m.Start()
@@ -577,9 +575,9 @@ func TestReshard(t *testing.T) {
 }
 
 func TestReshardRaceWithStop(t *testing.T) {
-	for _, rwFormat := range []config.RemoteWriteFormat{Version1, Version2} {
-		t.Run(fmt.Sprint(rwFormat), func(t *testing.T) {
-			c := NewTestWriteClient(rwFormat)
+	for _, protoMsg := range []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1, config.RemoteWriteProtoMsgV2} {
+		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
+			c := NewTestWriteClient(protoMsg)
 			var m *QueueManager
 			h := sync.Mutex{}
 			h.Lock()
@@ -590,7 +588,7 @@ func TestReshardRaceWithStop(t *testing.T) {
 			go func() {
 				for {
 					metrics := newQueueManagerMetrics(nil, "", "")
-					m = NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, rwFormat)
+					m = NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, protoMsg)
 					m.Start()
 					h.Unlock()
 					h.Lock()
@@ -615,8 +613,8 @@ func TestReshardRaceWithStop(t *testing.T) {
 }
 
 func TestReshardPartialBatch(t *testing.T) {
-	for _, rwFormat := range []config.RemoteWriteFormat{Version1, Version2} {
-		t.Run(fmt.Sprint(rwFormat), func(t *testing.T) {
+	for _, protoMsg := range []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1, config.RemoteWriteProtoMsgV2} {
+		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
 			samples, series := createTimeseries(1, 10)
 
 			c := NewTestBlockedWriteClient()
@@ -629,7 +627,7 @@ func TestReshardPartialBatch(t *testing.T) {
 			cfg.BatchSendDeadline = model.Duration(batchSendDeadline)
 
 			metrics := newQueueManagerMetrics(nil, "", "")
-			m := NewQueueManager(metrics, nil, nil, nil, t.TempDir(), newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, flushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, rwFormat)
+			m := NewQueueManager(metrics, nil, nil, nil, t.TempDir(), newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, flushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, protoMsg)
 			m.StoreSeries(series, 0)
 
 			m.Start()
@@ -661,8 +659,8 @@ func TestReshardPartialBatch(t *testing.T) {
 // where a large scrape (> capacity + max samples per send) is appended at the
 // same time as a batch times out according to the batch send deadline.
 func TestQueueFilledDeadlock(t *testing.T) {
-	for _, rwFormat := range []config.RemoteWriteFormat{Version1, Version2} {
-		t.Run(fmt.Sprint(rwFormat), func(t *testing.T) {
+	for _, protoMsg := range []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1, config.RemoteWriteProtoMsgV2} {
+		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
 			samples, series := createTimeseries(50, 1)
 
 			c := NewNopWriteClient()
@@ -678,7 +676,7 @@ func TestQueueFilledDeadlock(t *testing.T) {
 
 			metrics := newQueueManagerMetrics(nil, "", "")
 
-			m := NewQueueManager(metrics, nil, nil, nil, t.TempDir(), newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, flushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, rwFormat)
+			m := NewQueueManager(metrics, nil, nil, nil, t.TempDir(), newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, flushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, protoMsg)
 			m.StoreSeries(series, 0)
 			m.Start()
 			defer m.Stop()
@@ -703,13 +701,13 @@ func TestQueueFilledDeadlock(t *testing.T) {
 }
 
 func TestReleaseNoninternedString(t *testing.T) {
-	for _, rwFormat := range []config.RemoteWriteFormat{Version1, Version2} {
-		t.Run(fmt.Sprint(rwFormat), func(t *testing.T) {
+	for _, protoMsg := range []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1, config.RemoteWriteProtoMsgV2} {
+		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
 			cfg := testDefaultQueueConfig()
 			mcfg := config.DefaultMetadataConfig
 			metrics := newQueueManagerMetrics(nil, "", "")
-			c := NewTestWriteClient(rwFormat)
-			m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, rwFormat)
+			c := NewTestWriteClient(protoMsg)
+			m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, protoMsg)
 			m.Start()
 			defer m.Stop()
 			for i := 1; i < 1000; i++ {
@@ -757,8 +755,8 @@ func TestShouldReshard(t *testing.T) {
 	for _, c := range cases {
 		metrics := newQueueManagerMetrics(nil, "", "")
 		// todo: test with new proto type(s)
-		client := NewTestWriteClient(Version1)
-		m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, Version1)
+		client := NewTestWriteClient(config.RemoteWriteProtoMsgV1)
+		m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
 		m.numShards = c.startingShards
 		m.dataIn.incr(c.samplesIn)
 		m.dataOut.incr(c.samplesOut)
@@ -804,7 +802,7 @@ func TestDisableReshardOnRetry(t *testing.T) {
 		}
 	)
 
-	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, Version1)
+	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
 	m.StoreSeries(fakeSeries, 0)
 
 	// Attempt to samples while the manager is running. We immediately stop the
@@ -955,6 +953,8 @@ func getSeriesNameFromRef(r record.RefSeries) string {
 	return r.Labels.Get("__name__")
 }
 
+// TestWriteClient represents write client which does not call remote storage,
+// but instead re-implements fake WriteHandler for test purposes.
 type TestWriteClient struct {
 	receivedSamples         map[string][]prompb.Sample
 	expectedSamples         map[string][]prompb.Sample
@@ -968,25 +968,26 @@ type TestWriteClient struct {
 	writesReceived          int
 	mtx                     sync.Mutex
 	buf                     []byte
-	rwFormat                config.RemoteWriteFormat
+	protoMsg                config.RemoteWriteProtoMsg
 	sendAttempts            []string
 	steps                   []contentNegotiationStep
 	currstep                int
 	retry                   bool
 }
 
-func NewTestWriteClient(rwFormat config.RemoteWriteFormat) *TestWriteClient {
+// NewTestWriteClient creates a new testing write client.
+func NewTestWriteClient(protoMsg config.RemoteWriteProtoMsg) *TestWriteClient {
 	return &TestWriteClient{
 		receivedSamples:  map[string][]prompb.Sample{},
 		expectedSamples:  map[string][]prompb.Sample{},
 		receivedMetadata: map[string][]prompb.MetricMetadata{},
-		rwFormat:         rwFormat,
+		protoMsg:         protoMsg,
 	}
 }
 
 func (c *TestWriteClient) setSteps(steps []contentNegotiationStep) {
 	c.steps = steps
-	c.currstep = -1 // incremented by GetLastRWHeader()
+	c.currstep = -1
 	c.retry = false
 }
 
@@ -1096,25 +1097,23 @@ func (c *TestWriteClient) waitForExpectedData(tb testing.TB, timeout time.Durati
 	}
 }
 
-func (c *TestWriteClient) Store(_ context.Context, req []byte, attemptNos int, rwFormat config.RemoteWriteFormat, compression string) error {
+func (c *TestWriteClient) Store(_ context.Context, req []byte, attemptNos int) error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 	// nil buffers are ok for snappy, ignore cast error.
 	if c.buf != nil {
 		c.buf = c.buf[:cap(c.buf)]
 	}
+
+	// TODO(bwplotka): Consider using WriteHandler instead?
 	reqBuf, err := snappy.Decode(c.buf, req)
 	c.buf = reqBuf
 	if err != nil {
 		return err
 	}
 
-	attemptString := fmt.Sprintf("%d,%d,%s", attemptNos, rwFormat, compression)
-
-	if attemptNos > 0 {
-		// If this is a second attempt then we need to bump to the next step otherwise we loop.
-		c.currstep++
-	}
+	attemptString := fmt.Sprintf("%d", attemptNos)
+	c.currstep++
 
 	// Check if we've been told to return something for this config.
 	if len(c.steps) > 0 {
@@ -1125,18 +1124,19 @@ func (c *TestWriteClient) Store(_ context.Context, req []byte, attemptNos int, r
 	}
 
 	var reqProto *prompb.WriteRequest
-	switch rwFormat {
-	case Version1:
+	switch c.protoMsg {
+	case config.RemoteWriteProtoMsgV1:
 		reqProto = &prompb.WriteRequest{}
 		err = proto.Unmarshal(reqBuf, reqProto)
-	case Version2:
-		var reqMin writev2.Request
-		err = proto.Unmarshal(reqBuf, &reqMin)
+	case config.RemoteWriteProtoMsgV2:
+		// NOTE(bwplotka): v1 msg can be unmarshaled to v2 sometimes, without
+		// errors.
+		var reqProtoV2 writev2.Request
+		err = proto.Unmarshal(reqBuf, &reqProtoV2)
 		if err == nil {
-			reqProto, err = MinimizedWriteRequestToWriteRequest(&reqMin)
+			reqProto, err = V2WriteRequestToWriteRequest(&reqProtoV2)
 		}
 	}
-
 	if err != nil {
 		c.sendAttempts = append(c.sendAttempts, attemptString+","+fmt.Sprintf("%s", err))
 		return err
@@ -1178,20 +1178,6 @@ func (c *TestWriteClient) Endpoint() string {
 	return "http://test-remote.com/1234"
 }
 
-func (c *TestWriteClient) probeRemoteVersions(_ context.Context) error {
-	return nil
-}
-
-func (c *TestWriteClient) GetLastRWHeader() string {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-	c.currstep++
-	if len(c.steps) > 0 {
-		return c.steps[c.currstep].lastRWHeader
-	}
-	return "2.0;snappy,0.1.0"
-}
-
 // TestBlockingWriteClient is a queue_manager WriteClient which will block
 // on any calls to Store(), until the request's Context is cancelled, at which
 // point the `numCalls` property will contain a count of how many times Store()
@@ -1204,7 +1190,7 @@ func NewTestBlockedWriteClient() *TestBlockingWriteClient {
 	return &TestBlockingWriteClient{}
 }
 
-func (c *TestBlockingWriteClient) Store(ctx context.Context, _ []byte, _ int, _ config.RemoteWriteFormat, _ string) error {
+func (c *TestBlockingWriteClient) Store(ctx context.Context, _ []byte, _ int) error {
 	c.numCalls.Inc()
 	<-ctx.Done()
 	return nil
@@ -1222,27 +1208,15 @@ func (c *TestBlockingWriteClient) Endpoint() string {
 	return "http://test-remote-blocking.com/1234"
 }
 
-func (c *TestBlockingWriteClient) probeRemoteVersions(_ context.Context) error {
-	return nil
-}
-
-func (c *TestBlockingWriteClient) GetLastRWHeader() string {
-	return "2.0;snappy,0.1.0"
-}
-
 // For benchmarking the send and not the receive side.
 type NopWriteClient struct{}
 
 func NewNopWriteClient() *NopWriteClient { return &NopWriteClient{} }
-func (c *NopWriteClient) Store(context.Context, []byte, int, config.RemoteWriteFormat, string) error {
+func (c *NopWriteClient) Store(context.Context, []byte, int) error {
 	return nil
 }
 func (c *NopWriteClient) Name() string     { return "nopwriteclient" }
 func (c *NopWriteClient) Endpoint() string { return "http://test-remote.com/1234" }
-func (c *NopWriteClient) probeRemoteVersions(_ context.Context) error {
-	return nil
-}
-func (c *NopWriteClient) GetLastRWHeader() string { return "2.0;snappy,0.1.0" }
 
 type MockWriteClient struct {
 	StoreFunc    func(context.Context, []byte, int) error
@@ -1250,19 +1224,11 @@ type MockWriteClient struct {
 	EndpointFunc func() string
 }
 
-func (c *MockWriteClient) Store(ctx context.Context, bb []byte, n int, _ config.RemoteWriteFormat, _ string) error {
+func (c *MockWriteClient) Store(ctx context.Context, bb []byte, n int) error {
 	return c.StoreFunc(ctx, bb, n)
 }
 func (c *MockWriteClient) Name() string     { return c.NameFunc() }
 func (c *MockWriteClient) Endpoint() string { return c.EndpointFunc() }
-
-// TODO(bwplotka): Mock it if needed.
-func (c *MockWriteClient) GetLastRWHeader() string { return "2.0;snappy,0.1.0" }
-
-// TODO(bwplotka): Mock it if needed.
-func (c *MockWriteClient) probeRemoteVersions(_ context.Context) error {
-	return nil
-}
 
 // Extra labels to make a more realistic workload - taken from Kubernetes' embedded cAdvisor metrics.
 var extraLabels []labels.Label = []labels.Label{
@@ -1302,7 +1268,7 @@ func BenchmarkSampleSend(b *testing.B) {
 
 	metrics := newQueueManagerMetrics(nil, "", "")
 	// todo: test with new proto type(s)
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, Version1)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
 	m.StoreSeries(series, 0)
 
 	// These should be received by the client.
@@ -1356,12 +1322,12 @@ func BenchmarkStoreSeries(b *testing.B) {
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				c := NewTestWriteClient(Version1)
+				c := NewTestWriteClient(config.RemoteWriteProtoMsgV1)
 				dir := b.TempDir()
 				cfg := config.DefaultQueueConfig
 				mcfg := config.DefaultMetadataConfig
 				metrics := newQueueManagerMetrics(nil, "", "")
-				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, Version1)
+				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
 				m.externalLabels = tc.externalLabels
 				m.relabelConfigs = tc.relabelConfigs
 
@@ -1401,7 +1367,7 @@ func BenchmarkStartup(b *testing.B) {
 		// todo: test with new proto type(s)
 		m := NewQueueManager(metrics, nil, nil, logger, dir,
 			newEWMARate(ewmaWeight, shardUpdateDuration),
-			cfg, mcfg, labels.EmptyLabels(), nil, c, 1*time.Minute, newPool(), newHighestTimestampMetric(), nil, false, false, Version1)
+			cfg, mcfg, labels.EmptyLabels(), nil, c, 1*time.Minute, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
 		m.watcher.SetStartTime(timestamp.Time(math.MaxInt64))
 		m.watcher.MaxSegment = segments[len(segments)-2]
 		err := m.watcher.Run()
@@ -1488,7 +1454,7 @@ func TestCalculateDesiredShards(t *testing.T) {
 	metrics := newQueueManagerMetrics(nil, "", "")
 	samplesIn := newEWMARate(ewmaWeight, shardUpdateDuration)
 	// todo: test with new proto type(s)
-	m := NewQueueManager(metrics, nil, nil, nil, dir, samplesIn, cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, Version1)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, samplesIn, cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
 
 	// Need to start the queue manager so the proper metrics are initialized.
 	// However we can stop it right away since we don't need to do any actual
@@ -1557,7 +1523,7 @@ func TestCalculateDesiredShards(t *testing.T) {
 }
 
 func TestCalculateDesiredShardsDetail(t *testing.T) {
-	c := NewTestWriteClient(Version1)
+	c := NewTestWriteClient(config.RemoteWriteProtoMsgV1)
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
 
@@ -1566,7 +1532,7 @@ func TestCalculateDesiredShardsDetail(t *testing.T) {
 	metrics := newQueueManagerMetrics(nil, "", "")
 	samplesIn := newEWMARate(ewmaWeight, shardUpdateDuration)
 	// todo: test with new proto type(s)
-	m := NewQueueManager(metrics, nil, nil, nil, dir, samplesIn, cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, Version1)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, samplesIn, cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
 
 	for _, tc := range []struct {
 		name            string
@@ -1886,7 +1852,7 @@ func BenchmarkBuildWriteRequest(b *testing.B) {
 	})
 }
 
-func BenchmarkBuildMinimizedWriteRequest(b *testing.B) {
+func BenchmarkBuildV2WriteRequest(b *testing.B) {
 	noopLogger := log.NewNopLogger()
 	type testcase struct {
 		batch []timeSeries
@@ -1897,7 +1863,7 @@ func BenchmarkBuildMinimizedWriteRequest(b *testing.B) {
 		{createDummyTimeSeries(100)},
 	}
 	for _, tc := range testCases {
-		symbolTable := newRwSymbolTable()
+		symbolTable := writev2.NewSymbolTable()
 		buff := make([]byte, 0)
 		seriesBuff := make([]writev2.TimeSeries, len(tc.batch))
 		for i := range seriesBuff {
@@ -1909,7 +1875,7 @@ func BenchmarkBuildMinimizedWriteRequest(b *testing.B) {
 		// Warmup buffers
 		for i := 0; i < 10; i++ {
 			populateV2TimeSeries(&symbolTable, tc.batch, seriesBuff, true, true)
-			buildV2WriteRequest(noopLogger, seriesBuff, symbolTable.LabelsStrings(), &pBuf, &buff, nil, "snappy")
+			buildV2WriteRequest(noopLogger, seriesBuff, symbolTable.Symbols(), &pBuf, &buff, nil, "snappy")
 		}
 
 		b.Run(fmt.Sprintf("%d-instances", len(tc.batch)), func(b *testing.B) {
@@ -1917,11 +1883,11 @@ func BenchmarkBuildMinimizedWriteRequest(b *testing.B) {
 			for j := 0; j < b.N; j++ {
 				populateV2TimeSeries(&symbolTable, tc.batch, seriesBuff, true, true)
 				b.ResetTimer()
-				req, _, _, err := buildV2WriteRequest(noopLogger, seriesBuff, symbolTable.LabelsStrings(), &pBuf, &buff, nil, "snappy")
+				req, _, _, err := buildV2WriteRequest(noopLogger, seriesBuff, symbolTable.Symbols(), &pBuf, &buff, nil, "snappy")
 				if err != nil {
 					b.Fatal(err)
 				}
-				symbolTable.clear()
+				symbolTable.Reset()
 				totalSize += len(req)
 				b.ReportMetric(float64(totalSize)/float64(b.N), "compressedSize/op")
 			}
@@ -1936,7 +1902,7 @@ func TestDropOldTimeSeries(t *testing.T) {
 	samples, newSamples, series := createTimeseriesWithOldSamples(nSamples, nSeries)
 
 	// TODO(alexg): test with new version
-	c := NewTestWriteClient(Version1)
+	c := NewTestWriteClient(config.RemoteWriteProtoMsgV1)
 	c.expectSamples(newSamples, series)
 
 	cfg := config.DefaultQueueConfig
@@ -1946,7 +1912,7 @@ func TestDropOldTimeSeries(t *testing.T) {
 	dir := t.TempDir()
 
 	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, Version1)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
 	m.StoreSeries(series, 0)
 
 	m.Start()

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -169,25 +169,15 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			name = rwConf.Name
 		}
 
-		// TODO(bwplotka): Remove in the next PR (split for readability).
-		protoVersion := func() config.RemoteWriteFormat {
-			switch rwConf.ProtobufMessage {
-			case config.RemoteWriteProtoMsgV2:
-				return Version2
-			default:
-				return Version1
-			}
-		}()
-
 		c, err := NewWriteClient(name, &ClientConfig{
-			URL:               rwConf.URL,
-			RemoteWriteFormat: protoVersion,
-			Timeout:           rwConf.RemoteTimeout,
-			HTTPClientConfig:  rwConf.HTTPClientConfig,
-			SigV4Config:       rwConf.SigV4Config,
-			AzureADConfig:     rwConf.AzureADConfig,
-			Headers:           rwConf.Headers,
-			RetryOnRateLimit:  rwConf.QueueConfig.RetryOnRateLimit,
+			URL:              rwConf.URL,
+			WriteProtoMsg:    rwConf.ProtobufMessage,
+			Timeout:          rwConf.RemoteTimeout,
+			HTTPClientConfig: rwConf.HTTPClientConfig,
+			SigV4Config:      rwConf.SigV4Config,
+			AzureADConfig:    rwConf.AzureADConfig,
+			Headers:          rwConf.Headers,
+			RetryOnRateLimit: rwConf.QueueConfig.RetryOnRateLimit,
 		})
 		if err != nil {
 			return err
@@ -200,21 +190,6 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			newQueues[hash] = queue
 			delete(rws.queues, hash)
 			continue
-		}
-
-		// Work out what protocol and compression to use for this endpoint.
-		// Default to Remote Write Version1.
-		rwFormat := Version1
-		switch protoVersion {
-		case Version1:
-			// We use the standard value as there's no negotiation to be had.
-		case Version2:
-			rwFormat = Version2
-			// If this newer remote write format is enabled then we need to probe the remote server
-			// to work out the desired protocol version and compressions.
-			// The value of the header is kept in the client so no need to see it here.
-			_ = c.probeRemoteVersions(context.Background())
-			// We ignore any error here, at some point we may choose to log it.
 		}
 
 		// Redacted to remove any passwords in the URL (that are
@@ -239,7 +214,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			rws.scraper,
 			rwConf.SendExemplars,
 			rwConf.SendNativeHistograms,
-			rwFormat,
+			rwConf.ProtobufMessage,
 		)
 		// Keep track of which queues are new so we know which to start.
 		newHashes = append(newHashes, hash)

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -154,7 +154,7 @@ func (h *writeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var req prompb.WriteRequest
 		if err := proto.Unmarshal(decompressed, &req); err != nil {
 			// TODO(bwplotka): Add more context to responded error?
-			level.Error(h.logger).Log("msg", "Error decoding remote write request", "protobuf_message", msg, "err", err.Error())
+			level.Error(h.logger).Log("msg", "Error decoding v1 remote write request", "protobuf_message", msg, "err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -163,7 +163,7 @@ func (h *writeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var req writev2.Request
 		if err := proto.Unmarshal(decompressed, &req); err != nil {
 			// TODO(bwplotka): Add more context to responded error?
-			level.Error(h.logger).Log("msg", "Error decoding remote write request", "protobuf_message", msg, "err", err.Error())
+			level.Error(h.logger).Log("msg", "Error decoding v2 remote write request", "protobuf_message", msg, "err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -15,6 +15,7 @@ package remote
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -43,11 +44,12 @@ func testRemoteWriteConfig() *config.RemoteWriteConfig {
 				Host:   "localhost",
 			},
 		},
-		QueueConfig: config.DefaultQueueConfig,
+		QueueConfig:     config.DefaultQueueConfig,
+		ProtobufMessage: config.RemoteWriteProtoMsgV1,
 	}
 }
 
-func TestNoDuplicateWriteConfigs(t *testing.T) {
+func TestWriteStorageApplyConfig_NoDuplicateWriteConfigs(t *testing.T) {
 	dir := t.TempDir()
 
 	cfg1 := config.RemoteWriteConfig{
@@ -58,7 +60,8 @@ func TestNoDuplicateWriteConfigs(t *testing.T) {
 				Host:   "localhost",
 			},
 		},
-		QueueConfig: config.DefaultQueueConfig,
+		QueueConfig:     config.DefaultQueueConfig,
+		ProtobufMessage: config.RemoteWriteProtoMsgV1,
 	}
 	cfg2 := config.RemoteWriteConfig{
 		Name: "write-2",
@@ -68,7 +71,8 @@ func TestNoDuplicateWriteConfigs(t *testing.T) {
 				Host:   "localhost",
 			},
 		},
-		QueueConfig: config.DefaultQueueConfig,
+		QueueConfig:     config.DefaultQueueConfig,
+		ProtobufMessage: config.RemoteWriteProtoMsgV1,
 	}
 	cfg3 := config.RemoteWriteConfig{
 		URL: &common_config.URL{
@@ -77,62 +81,49 @@ func TestNoDuplicateWriteConfigs(t *testing.T) {
 				Host:   "localhost",
 			},
 		},
-		QueueConfig: config.DefaultQueueConfig,
+		QueueConfig:     config.DefaultQueueConfig,
+		ProtobufMessage: config.RemoteWriteProtoMsgV1,
 	}
 
-	type testcase struct {
-		cfgs []*config.RemoteWriteConfig
-		err  bool
-	}
-
-	cases := []testcase{
+	for _, tc := range []struct {
+		cfgs        []*config.RemoteWriteConfig
+		expectedErr error
+	}{
 		{ // Two duplicates, we should get an error.
-			cfgs: []*config.RemoteWriteConfig{
-				&cfg1,
-				&cfg1,
-			},
-			err: true,
+			cfgs:        []*config.RemoteWriteConfig{&cfg1, &cfg1},
+			expectedErr: errors.New("duplicate remote write configs are not allowed, found duplicate for URL: http://localhost"),
 		},
 		{ // Duplicates but with different names, we should not get an error.
-			cfgs: []*config.RemoteWriteConfig{
-				&cfg1,
-				&cfg2,
-			},
-			err: false,
+			cfgs: []*config.RemoteWriteConfig{&cfg1, &cfg2},
 		},
 		{ // Duplicates but one with no name, we should not get an error.
-			cfgs: []*config.RemoteWriteConfig{
-				&cfg1,
-				&cfg3,
-			},
-			err: false,
+			cfgs: []*config.RemoteWriteConfig{&cfg1, &cfg3},
 		},
 		{ // Duplicates both with no name, we should get an error.
-			cfgs: []*config.RemoteWriteConfig{
-				&cfg3,
-				&cfg3,
-			},
-			err: true,
+			cfgs:        []*config.RemoteWriteConfig{&cfg3, &cfg3},
+			expectedErr: errors.New("duplicate remote write configs are not allowed, found duplicate for URL: http://localhost"),
 		},
-	}
+	} {
+		t.Run("", func(t *testing.T) {
+			s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false)
+			conf := &config.Config{
+				GlobalConfig:       config.DefaultGlobalConfig,
+				RemoteWriteConfigs: tc.cfgs,
+			}
+			err := s.ApplyConfig(conf)
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Equal(t, tc.expectedErr, err)
+			}
 
-	for _, tc := range cases {
-		// todo: test with new format type(s)
-		s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false)
-		conf := &config.Config{
-			GlobalConfig:       config.DefaultGlobalConfig,
-			RemoteWriteConfigs: tc.cfgs,
-		}
-		err := s.ApplyConfig(conf)
-		gotError := err != nil
-		require.Equal(t, tc.err, gotError)
-
-		err = s.Close()
-		require.NoError(t, err)
+			require.NoError(t, s.Close())
+		})
 	}
 }
 
-func TestRestartOnNameChange(t *testing.T) {
+func TestWriteStorageApplyConfig_RestartOnNameChange(t *testing.T) {
 	dir := t.TempDir()
 
 	cfg := testRemoteWriteConfig()
@@ -140,14 +131,11 @@ func TestRestartOnNameChange(t *testing.T) {
 	hash, err := toHash(cfg)
 	require.NoError(t, err)
 
-	// todo: test with new format type(s)
 	s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false)
 
 	conf := &config.Config{
-		GlobalConfig: config.DefaultGlobalConfig,
-		RemoteWriteConfigs: []*config.RemoteWriteConfig{
-			cfg,
-		},
+		GlobalConfig:       config.DefaultGlobalConfig,
+		RemoteWriteConfigs: []*config.RemoteWriteConfig{cfg},
 	}
 	require.NoError(t, s.ApplyConfig(conf))
 	require.Equal(t, s.queues[hash].client().Name(), cfg.Name)
@@ -159,14 +147,12 @@ func TestRestartOnNameChange(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, s.queues[hash].client().Name(), conf.RemoteWriteConfigs[0].Name)
 
-	err = s.Close()
-	require.NoError(t, err)
+	require.NoError(t, s.Close())
 }
 
-func TestUpdateWithRegisterer(t *testing.T) {
+func TestWriteStorageApplyConfig_UpdateWithRegisterer(t *testing.T) {
 	dir := t.TempDir()
 
-	// todo: test with new format type(s)
 	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Millisecond, nil, false)
 	c1 := &config.RemoteWriteConfig{
 		Name: "named",
@@ -176,7 +162,8 @@ func TestUpdateWithRegisterer(t *testing.T) {
 				Host:   "localhost",
 			},
 		},
-		QueueConfig: config.DefaultQueueConfig,
+		QueueConfig:     config.DefaultQueueConfig,
+		ProtobufMessage: config.RemoteWriteProtoMsgV1,
 	}
 	c2 := &config.RemoteWriteConfig{
 		URL: &common_config.URL{
@@ -185,7 +172,8 @@ func TestUpdateWithRegisterer(t *testing.T) {
 				Host:   "localhost",
 			},
 		},
-		QueueConfig: config.DefaultQueueConfig,
+		QueueConfig:     config.DefaultQueueConfig,
+		ProtobufMessage: config.RemoteWriteProtoMsgV1,
 	}
 	conf := &config.Config{
 		GlobalConfig:       config.DefaultGlobalConfig,
@@ -200,14 +188,12 @@ func TestUpdateWithRegisterer(t *testing.T) {
 		require.Equal(t, 10, queue.cfg.MaxShards)
 	}
 
-	err := s.Close()
-	require.NoError(t, err)
+	require.NoError(t, s.Close())
 }
 
-func TestWriteStorageLifecycle(t *testing.T) {
+func TestWriteStorageApplyConfig_Lifecycle(t *testing.T) {
 	dir := t.TempDir()
 
-	// todo: test with new format type(s)
 	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
@@ -218,14 +204,12 @@ func TestWriteStorageLifecycle(t *testing.T) {
 	require.NoError(t, s.ApplyConfig(conf))
 	require.Len(t, s.queues, 1)
 
-	err := s.Close()
-	require.NoError(t, err)
+	require.NoError(t, s.Close())
 }
 
-func TestUpdateExternalLabels(t *testing.T) {
+func TestWriteStorageApplyConfig_UpdateExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	// todo: test with new format type(s)
 	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Second, nil, false)
 
 	externalLabels := labels.FromStrings("external", "true")
@@ -248,14 +232,12 @@ func TestUpdateExternalLabels(t *testing.T) {
 	require.Len(t, s.queues, 1)
 	require.Equal(t, []labels.Label{{Name: "external", Value: "true"}}, s.queues[hash].externalLabels)
 
-	err = s.Close()
-	require.NoError(t, err)
+	require.NoError(t, s.Close())
 }
 
-func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
+func TestWriteStorageApplyConfig_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 
-	// todo: test with new format type(s)
 	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
@@ -274,14 +256,12 @@ func TestWriteStorageApplyConfigsIdempotent(t *testing.T) {
 	_, hashExists := s.queues[hash]
 	require.True(t, hashExists, "Queue pointer should have remained the same")
 
-	err = s.Close()
-	require.NoError(t, err)
+	require.NoError(t, s.Close())
 }
 
-func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
+func TestWriteStorageApplyConfig_PartialUpdate(t *testing.T) {
 	dir := t.TempDir()
 
-	// todo: test with new format type(s)
 	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
 
 	c0 := &config.RemoteWriteConfig{
@@ -292,6 +272,7 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 				Regex: relabel.MustNewRegexp(".+"),
 			},
 		},
+		ProtobufMessage: config.RemoteWriteProtoMsgV1,
 	}
 	c1 := &config.RemoteWriteConfig{
 		RemoteTimeout: model.Duration(20 * time.Second),
@@ -299,10 +280,12 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 		HTTPClientConfig: common_config.HTTPClientConfig{
 			BearerToken: "foo",
 		},
+		ProtobufMessage: config.RemoteWriteProtoMsgV1,
 	}
 	c2 := &config.RemoteWriteConfig{
-		RemoteTimeout: model.Duration(30 * time.Second),
-		QueueConfig:   config.DefaultQueueConfig,
+		RemoteTimeout:   model.Duration(30 * time.Second),
+		QueueConfig:     config.DefaultQueueConfig,
+		ProtobufMessage: config.RemoteWriteProtoMsgV1,
 	}
 
 	conf := &config.Config{
@@ -382,8 +365,7 @@ func TestWriteStorageApplyConfigsPartialUpdate(t *testing.T) {
 	_, hashExists = s.queues[hashes[2]]
 	require.True(t, hashExists, "Pointer of unchanged queue should have remained the same")
 
-	err = s.Close()
-	require.NoError(t, err)
+	require.NoError(t, s.Close())
 }
 
 func TestOTLPWriteHandler(t *testing.T) {


### PR DESCRIPTION
This is chained PR for review readability. See previous PR (chain1) first: https://github.com/prometheus/prometheus/pull/14335

Spec: https://prometheus.io/docs/specs/remote_write_spec_2_0

Supersedes https://github.com/prometheus/prometheus/pull/13968

## High-lvl changes

* Config (https://github.com/prometheus/prometheus/pull/14335)
* Removal of negotiation pieces introduced in https://github.com/prometheus/prometheus/pull/13921 as we decided to skip auto-neg in 2.0 (head handler, probing, automatic upg/downgr)
* Moved useful symbolization mechanisms next to proto writev2 pkg
* Enhanced/refactored some tests

