### PR TITLE
Stripe series: build a map to be accessed without locking after gc

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1917,41 +1917,42 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
 		s.hashes[hashShard].del(hash, series.ref)
-		delete(s.series[refShard], series.ref)
 		deletedForCallback[series.ref] = series.lset
+
+		delete(s.series[refShard], series.ref)
 	}
 
-	s.iterForDeletion(checkSeriesFromStripe)
+	s.iterSripesForGC(checkSeriesFromStripe)
 
 	// For survivors series, truncate old chunks and check if any chunks left.
 	// If survivors, move it to survivors.
 	// If not, we need to remove it from the hashes.
-	deletedCompactedSeriesSet := make(map[chunks.HeadSeriesRef]labels.Labels)
-	checkCompactedSeries := func(series *memSeries) {
+	deletedSurvivorsForCallback := make(map[chunks.HeadSeriesRef]labels.Labels)
+
+	// Check survivors.
+	for _, series := range prevSurvivors {
 		series.Lock()
-		defer series.Unlock()
 
 		rmChunks += series.truncateChunksBefore(mint, minOOOMmapRef)
 		var keep bool
 		actualMint, minOOOTime, minMmapFile, keep = shouldKeepMemSeries(series, actualMint, minOOOTime, minMmapFile)
 		if keep {
 			survivors[series.ref] = series
-			return
+			series.Unlock()
+			continue
 		}
 
 		hash := series.lset.Hash()
 		hashShard := hash & uint64(s.size-1)
 
 		s.locks[hashShard].Lock()
-		defer s.locks[hashShard].Unlock()
-
+		deleted[storage.SeriesRef(series.ref)] = struct{}{}
+		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
 		s.hashes[hashShard].del(hash, series.ref)
-		deletedCompactedSeriesSet[series.ref] = series.lset
-	}
+		deletedSurvivorsForCallback[series.ref] = series.lset
+		s.locks[hashShard].Unlock()
 
-	// Check survivors.
-	for _, series := range prevSurvivors {
-		checkCompactedSeries(series)
+		series.Unlock()
 	}
 	// Update survivors.
 	s.survivors.Store(survivors)
@@ -1980,7 +1981,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		s.locks[i].Unlock()
 	}
 
-	s.seriesLifecycleCallback.PostDeletion(deletedCompactedSeriesSet)
+	s.seriesLifecycleCallback.PostDeletion(deletedSurvivorsForCallback)
 
 	if actualMint == math.MaxInt64 {
 		actualMint = mint
@@ -1989,10 +1990,10 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 	return deleted, affected, rmChunks, actualMint, minOOOTime, minMmapFile
 }
 
-// The iterForDeletion function iterates through all series, invoking the checkDeletedFunc for each.
+// The iterSripesForGC function iterates through all series from the stripes, invoking the checkDeletedFunc for each.
 // The checkDeletedFunc takes a map as input and should add to it all series that were deleted and should be included
 // when invoking the PostDeletion hook.
-func (s *stripeSeries) iterForDeletion(checkDeletedFunc func(int, uint64, *memSeries, map[chunks.HeadSeriesRef]labels.Labels)) {
+func (s *stripeSeries) iterSripesForGC(checkDeletedFunc func(int, uint64, *memSeries, map[chunks.HeadSeriesRef]labels.Labels)) {
 	seriesSetFromPrevStripe := 0
 	// Run through all series shard by shard
 	for i := 0; i < s.size; i++ {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -506,6 +506,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 		r.MustRegister(
 			m.activeAppenders,
 			m.series,
+			m.stripeSeries,
 			m.chunks,
 			m.chunksCreated,
 			m.chunksRemoved,

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -311,7 +311,6 @@ func (h *Head) resetInMemoryState() error {
 	}
 
 	if h.series != nil {
-
 		// reset the existing series to make sure we call the appropriated hooks
 		// and increment the series removed metrics
 		fs := h.series.callPostDeletionBeforeReset()

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2140,7 +2140,8 @@ func (s *stripeSeries) getOrSet(hash uint64, lset labels.Labels, createSeries fu
 	i = uint64(series.ref) & uint64(s.size-1)
 
 	s.locks[i].Lock()
-	if prevMin := s.minSeriesRef[i].Load(); !s.minSeriesRef[i].CompareAndSwap(prevMin, int64(series.ref)) {
+	prevMin := s.minSeriesRef[i].Load()
+	if prevMin > int64(series.ref) && !s.minSeriesRef[i].CompareAndSwap(prevMin, int64(series.ref)) {
 		panic("someone else updated the min, but we're holding the mutex")
 	}
 	s.series[i][series.ref] = series


### PR DESCRIPTION
I saw in the profiles that a significant amount of time is spent locking the different stripes, especially when `ShardedPostings` is used, as it has to traverse all the postings to find the shard of each series.

I was wondering how we can do that without locking, and decided to try this solution.

I'm adding a `survivors` (as they survived gc) `atomic.Value` that holds a single huge map of refs to series. This map is populated in `gc()`, and we set another atomic value signalling the lower watermark of the usual stripe series. 

If the looked up series is lower than the watermark, we know we have to look for it in the survivors. If it's higher, it's most likely in the series (there's a corner case where it could also be in the survivors).

