### PR TITLE
[PERF] Labels: faster encoding for -tags dedupelabels

### DIFF
--- a/model/labels/labels_dedupelabels.go
+++ b/model/labels/labels_dedupelabels.go
@@ -104,25 +104,27 @@ func (t *nameTable) ToName(num int) string {
 	return t.byNum[num]
 }
 
+// "Varint" in this file is non-standard: we encode small numbers (up to 32767) in 2 bytes,
+// because we expect most Prometheus to have more than 127 unique strings.
+// And we don't encode numbers larger than 4 bytes because we don't expect more than 536,870,912 unique strings.
 func decodeVarint(data string, index int) (int, int) {
-	// Fast-path for common case of a single byte, value 0..127.
-	b := data[index]
+	b := int(data[index]) + int(data[index+1])<<8
+	index += 2
+	if b < 0x8000 {
+		return b, index
+	}
+
+	value := int(b & 0x7FFF)
+	b = int(data[index])
 	index++
 	if b < 0x80 {
-		return int(b), index
+		return value | (b << 15), index
 	}
-	value := int(b & 0x7F)
-	for shift := uint(7); ; shift += 7 {
-		// Just panic if we go of the end of data, since all Labels strings are constructed internally and
-		// malformed data indicates a bug, or memory corruption.
-		b := data[index]
-		index++
-		value |= int(b&0x7F) << shift
-		if b < 0x80 {
-			break
-		}
-	}
-	return value, index
+
+	value |= (b & 0x7f) << 15
+	b = int(data[index])
+	index++
+	return value | (b << 22), index
 }
 
 func decodeString(t *nameTable, data string, index int) (string, int) {
@@ -641,29 +643,24 @@ func marshalNumbersToSizedBuffer(nums []int, data []byte) int {
 
 func sizeVarint(x uint64) (n int) {
 	// Most common case first
-	if x < 1<<7 {
-		return 1
+	if x < 1<<15 {
+		return 2
 	}
-	if x >= 1<<56 {
-		return 9
+	if x < 1<<22 {
+		return 3
 	}
-	if x >= 1<<28 {
-		x >>= 28
-		n = 4
+	if x >= 1<<29 {
+		panic("Number too large to represent")
 	}
-	if x >= 1<<14 {
-		x >>= 14
-		n += 2
-	}
-	if x >= 1<<7 {
-		n++
-	}
-	return n + 1
+	return 4
 }
 
 func encodeVarintSlow(data []byte, offset int, v uint64) int {
 	offset -= sizeVarint(v)
 	base := offset
+	data[offset] = uint8(v)
+	v >>= 8
+	offset++
 	for v >= 1<<7 {
 		data[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
@@ -673,11 +670,12 @@ func encodeVarintSlow(data []byte, offset int, v uint64) int {
 	return base
 }
 
-// Special code for the common case that a value is less than 128
+// Special code for the common case that a value is less than 32768
 func encodeVarint(data []byte, offset, v int) int {
-	if v < 1<<7 {
-		offset--
+	if v < 1<<15 {
+		offset -= 2
 		data[offset] = uint8(v)
+		data[offset+1] = uint8(v >> 8)
 		return offset
 	}
 	return encodeVarintSlow(data, offset, uint64(v))

--- a/model/labels/labels_dedupelabels_test.go
+++ b/model/labels/labels_dedupelabels_test.go
@@ -1,0 +1,50 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dedupelabels
+
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVarint(t *testing.T) {
+	cases := []struct {
+		v        int
+		expected []byte
+	}{
+		{0, []byte{0, 0}},
+		{1, []byte{1, 0}},
+		{2, []byte{2, 0}},
+		{0x7FFF, []byte{0xFF, 0x7F}},
+		{0x8000, []byte{0x00, 0x80, 0x01}},
+		{0x8001, []byte{0x01, 0x80, 0x01}},
+		{0x3FFFFF, []byte{0xFF, 0xFF, 0x7F}},
+		{0x400000, []byte{0x00, 0x80, 0x80, 0x01}},
+		{0x400001, []byte{0x01, 0x80, 0x80, 0x01}},
+		{0x1FFFFFFF, []byte{0xFF, 0xFF, 0xFF, 0x7F}},
+	}
+	var buf [16]byte
+	for _, c := range cases {
+		n := encodeVarint(buf[:], len(buf), c.v)
+		require.Equal(t, len(c.expected), len(buf)-n)
+		require.Equal(t, c.expected, buf[n:])
+		got, m := decodeVarint(string(buf[:]), n)
+		require.Equal(t, c.v, got)
+		require.Equal(t, len(buf), m)
+	}
+	require.Panics(t, func() { encodeVarint(buf[:], len(buf), 1<<29) })
+}


### PR DESCRIPTION
Change from regular varint to a non-standard version: we encode small numbers (up to 32767) in 2 bytes, because we expect most Prometheus to have more than 127 unique strings, and we don't encode numbers larger than 4 bytes because we don't expect more than 536,870,912 unique strings.

A bit of copy-paste inlining because I couldn't persuade the Go compiler to do it for me.

Benchmarks need to be tweaked because otherwise they are optimised unrealistically for a tiny tiny Prometheus.

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Intel(R) Core(TM) i7-14700K
                                                 │  before.txt  │             after.txt              │
                                                 │    sec/op    │   sec/op     vs base               │
Labels_Get/with_5_labels/first_label/get-28         4.988n ± 1%   4.083n ± 1%  -18.14% (p=0.002 n=6)
Labels_Get/with_5_labels/first_label/has-28         3.334n ± 0%   2.978n ± 0%  -10.71% (p=0.002 n=6)
Labels_Get/with_5_labels/middle_label/get-28        8.957n ± 1%   7.563n ± 0%  -15.57% (p=0.002 n=6)
Labels_Get/with_5_labels/middle_label/has-28        7.840n ± 1%   6.451n ± 1%  -17.72% (p=0.002 n=6)
Labels_Get/with_5_labels/last_label/get-28          13.13n ± 0%   10.96n ± 1%  -16.53% (p=0.002 n=6)
Labels_Get/with_5_labels/last_label/has-28         12.210n ± 1%   9.869n ± 1%  -19.17% (p=0.002 n=6)
Labels_Get/with_5_labels/not-found_label/get-28     6.857n ± 4%   5.684n ± 1%  -17.11% (p=0.002 n=6)
Labels_Get/with_5_labels/not-found_label/has-28     6.906n ± 0%   5.585n ± 1%  -19.12% (p=0.002 n=6)
Labels_Get/with_10_labels/first_label/get-28        4.923n ± 1%   4.091n ± 1%  -16.91% (p=0.002 n=6)
Labels_Get/with_10_labels/first_label/has-28        3.331n ± 0%   2.975n ± 1%  -10.67% (p=0.002 n=6)
Labels_Get/with_10_labels/middle_label/get-28       16.65n ± 1%   13.71n ± 1%  -17.65% (p=0.002 n=6)
Labels_Get/with_10_labels/middle_label/has-28       15.74n ± 1%   12.65n ± 1%  -19.66% (p=0.002 n=6)
Labels_Get/with_10_labels/last_label/get-28         25.06n ± 1%   20.70n ± 0%  -17.39% (p=0.002 n=6)
Labels_Get/with_10_labels/last_label/has-28         24.50n ± 0%   19.47n ± 0%  -20.55% (p=0.002 n=6)
Labels_Get/with_10_labels/not-found_label/get-28    6.857n ± 0%   5.686n ± 0%  -17.08% (p=0.002 n=6)
Labels_Get/with_10_labels/not-found_label/has-28    6.909n ± 0%   5.570n ± 1%  -19.38% (p=0.002 n=6)
Labels_Get/with_30_labels/first_label/get-28        4.900n ± 1%   4.072n ± 0%  -16.91% (p=0.002 n=6)
Labels_Get/with_30_labels/first_label/has-28        3.351n ± 1%   2.983n ± 0%  -11.00% (p=0.002 n=6)
Labels_Get/with_30_labels/middle_label/get-28       40.76n ± 1%   33.17n ± 1%  -18.62% (p=0.002 n=6)
Labels_Get/with_30_labels/middle_label/has-28       40.65n ± 0%   31.83n ± 1%  -21.69% (p=0.002 n=6)
Labels_Get/with_30_labels/last_label/get-28         72.53n ± 1%   59.25n ± 0%  -18.32% (p=0.002 n=6)
Labels_Get/with_30_labels/last_label/has-28         73.41n ± 1%   57.15n ± 1%  -22.14% (p=0.002 n=6)
Labels_Get/with_30_labels/not-found_label/get-28    6.861n ± 1%   5.681n ± 1%  -17.20% (p=0.002 n=6)
Labels_Get/with_30_labels/not-found_label/has-28    6.928n ± 1%   5.575n ± 0%  -19.53% (p=0.002 n=6)
Labels_Equals/equal-28                              20.66n ± 1%   19.54n ± 1%   -5.42% (p=0.002 n=6)
Labels_Equals/not_equal-28                          17.38n ± 1%   16.43n ± 1%   -5.47% (p=0.002 n=6)
Labels_Equals/different_sizes-28                    11.53n ± 0%   10.12n ± 1%  -12.23% (p=0.002 n=6)
Labels_Equals/lots-28                               82.61n ± 0%   71.60n ± 0%  -13.33% (p=0.002 n=6)
Labels_Equals/real_long_equal-28                    76.01n ± 0%   73.55n ± 1%   -3.23% (p=0.002 n=6)
Labels_Equals/real_long_different_end-28            74.29n ± 0%   72.83n ± 1%   -1.97% (p=0.002 n=6)
Labels_Compare/equal-28                             20.00n ± 1%   19.48n ± 1%   -2.55% (p=0.002 n=6)
Labels_Compare/not_equal-28                         17.98n ± 1%   17.45n ± 1%   -2.95% (p=0.002 n=6)
Labels_Compare/different_sizes-28                  10.030n ± 1%   9.637n ± 0%   -3.92% (p=0.002 n=6)
Labels_Compare/lots-28                              92.99n ± 0%   78.31n ± 0%  -15.79% (p=0.002 n=6)
Labels_Compare/real_long_equal-28                   74.19n ± 0%   75.32n ± 1%   +1.52% (p=0.002 n=6)
Labels_Compare/real_long_different_end-28           71.47n ± 0%   72.34n ± 1%   +1.21% (p=0.002 n=6)
Labels_Hash/typical_labels_under_1KB-28             105.2n ± 1%   106.9n ± 1%   +1.66% (p=0.002 n=6)
Labels_Hash/bigger_labels_over_1KB-28               129.1n ± 0%   131.1n ± 1%   +1.59% (p=0.002 n=6)
Labels_Hash/extremely_large_label_value_10MB-28     491.7µ ± 1%   496.2µ ± 1%        ~ (p=0.065 n=6)
Labels_Copy-28                                      13.72n ± 1%   13.82n ± 1%   +0.73% (p=0.002 n=6)
geomean                                             22.88n        20.07n       -12.29%
```