### PR TITLE
[BUGFIX] TSDB: Fix issue where pending OOO read can be left dangling if creating querier fails

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2077,6 +2077,9 @@ func (db *DB) blockChunkQuerierForRange(mint, maxt int64) (_ []storage.ChunkQuer
 		rh := NewOOORangeHead(db.head, mint, maxt, db.lastGarbageCollectedMmapRef)
 		outOfOrderHeadQuerier, err := NewBlockChunkQuerier(rh, mint, maxt)
 		if err != nil {
+			// If NewBlockQuerier() failed, make sure to clean up the pending read created by NewOOORangeHead.
+			rh.isoState.Close()
+
 			return nil, fmt.Errorf("open block chunk querier for ooo head %s: %w", rh, err)
 		}
 


### PR DESCRIPTION
@bboreham [noticed](https://github.com/prometheus/prometheus/pull/13115/files/abb21d642c1592340b35ea6a2d65ac2ae76b6401#r1650831269) that this was missed in #13115. This could lead to OOO head truncation becoming permanently blocked.

I've checked for other instances of this omission and I don't believe there are any others.