### PR TITLE
ci: Add job to report build_all status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,18 @@ jobs:
         with:
           parallelism: 12
           thread: ${{ matrix.thread }}
+  build_all_status:
+    name: Report status of build Prometheus for all architectures
+    runs-on: ubuntu-latest
+    needs: [build_all]
+    if: github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-')
+    steps:
+      - name: Successful build
+        if: ${{ !(contains(needs.*.result, 'failure')) && !(contains(needs.*.result, 'cancelled')) }}
+        run: exit 0
+      - name: Failing or cancelled build
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
   check_generated_parser:
     name: Check generated parser
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should enable proper status reporting of matrix jobs for release branches. See also https://github.com/orgs/community/discussions/4324.

The branch protection rule(s) for release branches need to be changed too.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
