### PR TITLE
feat: promtool check rules to report WARNING instead of FAILED if all errors are lint

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -830,7 +830,7 @@ func checkRules(files []string, ls lintConfig) (bool, bool) {
 		if n, errs, isFatal := checkRuleGroups(rgs, ls); errs != nil {
 			msg := "  FAILED:"
 			if !isFatal {
-				msg = " WARNING:"
+				msg = "  WARNING:"
 			}
 			fmt.Fprintln(os.Stderr, msg)
 			for _, e := range errs {

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -793,8 +793,12 @@ func checkRulesFromStdin(ls lintConfig) (bool, bool) {
 			return failed, hasErrors
 		}
 	}
-	if n, errs := checkRuleGroups(rgs, ls); errs != nil {
-		fmt.Fprintln(os.Stderr, "  FAILED:")
+	if n, errs, isFatal := checkRuleGroups(rgs, ls); errs != nil {
+		msg := "  FAILED:"
+		if !isFatal {
+			msg = " WARNING:"
+		}
+		fmt.Fprintln(os.Stderr, msg)
 		for _, e := range errs {
 			fmt.Fprintln(os.Stderr, e.Error())
 		}
@@ -869,7 +873,7 @@ func checkRuleGroups(rgs *rulefmt.RuleGroups, lintSettings lintConfig) (int, []e
 		}
 	}
 
-	return numRules, nil
+	return numRules, nil, false
 }
 
 type compareRuleType struct {

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -827,8 +827,12 @@ func checkRules(files []string, ls lintConfig) (bool, bool) {
 				continue
 			}
 		}
-		if n, errs := checkRuleGroups(rgs, ls); errs != nil {
-			fmt.Fprintln(os.Stderr, "  FAILED:")
+		if n, errs, isFatal := checkRuleGroups(rgs, ls); errs != nil {
+			msg := "  FAILED:"
+			if !isFatal {
+				msg = " WARNING:"
+			}
+			fmt.Fprintln(os.Stderr, msg)
 			for _, e := range errs {
 				fmt.Fprintln(os.Stderr, e.Error())
 			}
@@ -844,7 +848,7 @@ func checkRules(files []string, ls lintConfig) (bool, bool) {
 	return failed, hasErrors
 }
 
-func checkRuleGroups(rgs *rulefmt.RuleGroups, lintSettings lintConfig) (int, []error) {
+func checkRuleGroups(rgs *rulefmt.RuleGroups, lintSettings lintConfig) (int, []error, bool) {
 	numRules := 0
 	for _, rg := range rgs.Groups {
 		numRules += len(rg.Rules)
@@ -861,7 +865,7 @@ func checkRuleGroups(rgs *rulefmt.RuleGroups, lintSettings lintConfig) (int, []e
 				})
 			}
 			errMessage += "Might cause inconsistency while recording expressions"
-			return 0, []error{fmt.Errorf("%w %s", errLint, errMessage)}
+			return 0, []error{fmt.Errorf("%w %s", errLint, errMessage)}, false
 		}
 	}
 


### PR DESCRIPTION
Hi, we use the promtool in CI and have the `--no-lint-fatal` flag enabled. 

If it encounters only lint errors it prints out something like

```
Checking foo/rules/all-apps.yaml
  FAILED:
lint error 1 duplicate rule(s) found.
Metric: SbrowserAllAppsUp
Label(s):
	service: foo
	severity: warning
Might cause inconsistency while recording expressions
```
The confusing thing here is that it pronts out `FAILED` but ends up as a success

Also we run the check multiple times in the same job and when looking for what failed, one cannot uze `ctrl + f` for `failed` since it matches also the non fatal results

So I'm suggesting to change the err message to `WARNING` if all the errors are lint only