### PR TITLE
discovery: aws/ec2 unit tests

### DIFF
--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -148,7 +149,7 @@ type EC2Discovery struct {
 	*refresh.Discovery
 	logger *slog.Logger
 	cfg    *EC2SDConfig
-	ec2    *ec2.EC2
+	ec2    ec2iface.EC2API
 
 	// azToAZID maps this account's availability zones to their underlying AZ
 	// ID, e.g. eu-west-2a -> euw2-az2. Refreshes are performed sequentially, so
@@ -182,7 +183,7 @@ func NewEC2Discovery(conf *EC2SDConfig, logger *slog.Logger, metrics discovery.D
 	return d, nil
 }
 
-func (d *EC2Discovery) ec2Client(context.Context) (*ec2.EC2, error) {
+func (d *EC2Discovery) ec2Client(context.Context) (ec2iface.EC2API, error) {
 	if d.ec2 != nil {
 		return d.ec2, nil
 	}

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Prometheus Authors
+// Copyright 2024 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -111,13 +111,13 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 					"azname-c": "azid-3",
 				},
 				instances: []*ec2.Instance{
-					&ec2.Instance{
+					{
 						InstanceId: addrS("instance-id-noprivateip"),
 					},
 				},
 			},
 			expected: []*targetgroup.Group{
-				&targetgroup.Group{
+				{
 					Source: "region-noprivateip",
 				},
 			},
@@ -135,7 +135,7 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 				},
 				ownerID: "owner-id-novpc",
 				instances: []*ec2.Instance{
-					&ec2.Instance{
+					{
 						// set every possible options and test them here
 						Architecture:      addrS("architecture-novpc"),
 						ImageId:           addrS("ami-novpc"),
@@ -151,20 +151,20 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 						State:             &ec2.InstanceState{Name: addrS("running")},
 						// test tags once and for all
 						Tags: []*ec2.Tag{
-							&ec2.Tag{Key: addrS("tag-1-key"), Value: addrS("tag-1-value")},
-							&ec2.Tag{Key: addrS("tag-2-key"), Value: addrS("tag-2-value")},
+							{Key: addrS("tag-1-key"), Value: addrS("tag-1-value")},
+							{Key: addrS("tag-2-key"), Value: addrS("tag-2-value")},
 							nil,
-							&ec2.Tag{Value: addrS("tag-4-value")},
-							&ec2.Tag{Key: addrS("tag-5-key")},
+							{Value: addrS("tag-4-value")},
+							{Key: addrS("tag-5-key")},
 						},
 					},
 				},
 			},
 			expected: []*targetgroup.Group{
-				&targetgroup.Group{
+				{
 					Source: "region-novpc",
 					Targets: []model.LabelSet{
-						model.LabelSet{
+						{
 							"__address__":                     model.LabelValue("1.2.3.4:4242"),
 							"__meta_ec2_ami":                  model.LabelValue("ami-novpc"),
 							"__meta_ec2_architecture":         model.LabelValue("architecture-novpc"),
@@ -200,7 +200,7 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 					"azname-c": "azid-3",
 				},
 				instances: []*ec2.Instance{
-					&ec2.Instance{
+					{
 						// just the minimum needed for the refresh work
 						ImageId:          addrS("ami-ipv4"),
 						InstanceId:       addrS("instance-id-ipv4"),
@@ -213,21 +213,21 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 						// network intefaces
 						NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 							// interface without subnet -> should be ignored
-							&ec2.InstanceNetworkInterface{
+							{
 								Ipv6Addresses: []*ec2.InstanceIpv6Address{
-									&ec2.InstanceIpv6Address{
+									{
 										Ipv6Address:   addrS("2001:db8:1::1"),
 										IsPrimaryIpv6: addrB(true),
 									},
 								},
 							},
 							// interface with subnet, no IPv6
-							&ec2.InstanceNetworkInterface{
+							{
 								Ipv6Addresses: []*ec2.InstanceIpv6Address{},
 								SubnetId:      addrS("azid-3"),
 							},
 							// interface with another subnet, no IPv6
-							&ec2.InstanceNetworkInterface{
+							{
 								Ipv6Addresses: []*ec2.InstanceIpv6Address{},
 								SubnetId:      addrS("azid-1"),
 							},
@@ -236,10 +236,10 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 				},
 			},
 			expected: []*targetgroup.Group{
-				&targetgroup.Group{
+				{
 					Source: "region-ipv4",
 					Targets: []model.LabelSet{
-						model.LabelSet{
+						{
 							"__address__":                     model.LabelValue("5.6.7.8:4242"),
 							"__meta_ec2_ami":                  model.LabelValue("ami-ipv4"),
 							"__meta_ec2_availability_zone":    model.LabelValue("azname-c"),
@@ -270,7 +270,7 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 					"azname-c": "azid-3",
 				},
 				instances: []*ec2.Instance{
-					&ec2.Instance{
+					{
 						// just the minimum needed for the refresh work
 						ImageId:          addrS("ami-ipv6"),
 						InstanceId:       addrS("instance-id-ipv6"),
@@ -283,12 +283,12 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 						// network intefaces
 						NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 							// interface without primary IPv6, index 2
-							&ec2.InstanceNetworkInterface{
+							{
 								Attachment: &ec2.InstanceNetworkInterfaceAttachment{
 									DeviceIndex: addrI(3),
 								},
 								Ipv6Addresses: []*ec2.InstanceIpv6Address{
-									&ec2.InstanceIpv6Address{
+									{
 										Ipv6Address:   addrS("2001:db8:2::1:1"),
 										IsPrimaryIpv6: addrB(false),
 									},
@@ -296,16 +296,16 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 								SubnetId: addrS("azid-2"),
 							},
 							// interface with primary IPv6, index 1
-							&ec2.InstanceNetworkInterface{
+							{
 								Attachment: &ec2.InstanceNetworkInterfaceAttachment{
 									DeviceIndex: addrI(1),
 								},
 								Ipv6Addresses: []*ec2.InstanceIpv6Address{
-									&ec2.InstanceIpv6Address{
+									{
 										Ipv6Address:   addrS("2001:db8:2::2:1"),
 										IsPrimaryIpv6: addrB(false),
 									},
-									&ec2.InstanceIpv6Address{
+									{
 										Ipv6Address:   addrS("2001:db8:2::2:2"),
 										IsPrimaryIpv6: addrB(true),
 									},
@@ -313,12 +313,12 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 								SubnetId: addrS("azid-2"),
 							},
 							// interface with primary IPv6, index 3
-							&ec2.InstanceNetworkInterface{
+							{
 								Attachment: &ec2.InstanceNetworkInterfaceAttachment{
 									DeviceIndex: addrI(3),
 								},
 								Ipv6Addresses: []*ec2.InstanceIpv6Address{
-									&ec2.InstanceIpv6Address{
+									{
 										Ipv6Address:   addrS("2001:db8:2::3:1"),
 										IsPrimaryIpv6: addrB(true),
 									},
@@ -326,7 +326,7 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 								SubnetId: addrS("azid-1"),
 							},
 							// interface without primary IPv6, index 0
-							&ec2.InstanceNetworkInterface{
+							{
 								Attachment: &ec2.InstanceNetworkInterfaceAttachment{
 									DeviceIndex: addrI(0),
 								},
@@ -338,10 +338,10 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 				},
 			},
 			expected: []*targetgroup.Group{
-				&targetgroup.Group{
+				{
 					Source: "region-ipv6",
 					Targets: []model.LabelSet{
-						model.LabelSet{
+						{
 							"__address__":                       model.LabelValue("9.10.11.12:4242"),
 							"__meta_ec2_ami":                    model.LabelValue("ami-ipv6"),
 							"__meta_ec2_availability_zone":      model.LabelValue("azname-b"),

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -91,7 +91,7 @@ func TestRefreshAZIDsHandleError(t *testing.T) {
 	}
 
 	err := d.refreshAZIDs(ctx)
-	require.Equal(t, "No AZs found", err.Error())
+	require.Error(t, err)
 }
 
 // Tests for the refresh function.

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -378,7 +378,7 @@ func generateRefreshIpv6(d *EC2Discovery) []*targetgroup.Group {
 	return expected
 }
 
-func TestRefresh(t *testing.T) {
+func TestEC2DiscoveryRefresh(t *testing.T) {
 	ctx := context.Background()
 	client := newMockEC2Client()
 

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -15,19 +15,32 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
 
 // "Helper" functions.
 const chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandIpv4() string {
+	return fmt.Sprintf("%d.%d.%d.%d", RandNumber(1, 255), RandNumber(0, 255), RandNumber(0, 255), RandNumber(0, 255))
+}
+
+func RandNumber(minimum int, maximum int) int {
+	return rand.Intn(maximum-minimum) + minimum
+}
 
 func RandString(n int) string {
 	b := make([]byte, n)
@@ -40,26 +53,80 @@ func RandString(n int) string {
 
 // Struct for test data.
 type EC2Data struct {
+	region string
+
 	azNames  []string
 	azIDs    []string
 	azToAZID map[string]string
+
+	ownerId string
+
+	instances []*ec2.Instance
 }
 
 var ec2Data EC2Data
 
-// Prepare test data.
-func init() {
+// Generate test data.
+func GenerateTestAzData() {
+	// tabula rasa
+	ec2Data = EC2Data{}
+
+	// region information
+	ec2Data.region = fmt.Sprintf("region-%s", RandString(4))
+
 	// availability zone information
-	azCount := rand.Intn(3) + 2
+	azCount := RandNumber(2, 5)
 	ec2Data.azNames = make([]string, azCount)
 	ec2Data.azIDs = make([]string, azCount)
 	ec2Data.azToAZID = make(map[string]string, azCount)
 
 	for i := 0; i < azCount; i++ {
-		ec2Data.azNames[i] = RandString(5)
-		ec2Data.azIDs[i] = RandString(6)
+		ec2Data.azNames[i] = fmt.Sprintf("azname-%s", RandString(5))
+		ec2Data.azIDs[i] = fmt.Sprintf("azid-%s", RandString(5))
 		ec2Data.azToAZID[ec2Data.azNames[i]] = ec2Data.azIDs[i]
 	}
+
+	// ownerId for the reservation
+	ec2Data.ownerId = fmt.Sprintf("ownerid-%s", RandString(5))
+}
+
+func GenerateTestInstanceData() int {
+	// without VPC configuration, just the "basics"
+	azIdx := RandNumber(0, len(ec2Data.azNames))
+
+	placement := ec2.Placement{}
+	placement.SetAvailabilityZone(ec2Data.azNames[azIdx])
+
+	// FIXME: this could be a "global" variable
+	state := ec2.InstanceState{}
+	state.SetName("running")
+
+	instance := ec2.Instance{}
+	instance.SetArchitecture(fmt.Sprintf("architecture-%s", RandString(8)))
+	instance.SetImageId(fmt.Sprintf("ami-%s", RandString(8)))
+	instance.SetInstanceId(fmt.Sprintf("instance-id-%s", RandString(8)))
+	instance.SetInstanceLifecycle(fmt.Sprintf("instance-lifecycle-%s", RandString(8)))
+	instance.SetInstanceType(fmt.Sprintf("instance-type-%s", RandString(8)))
+	instance.SetPlacement(&placement)
+	instance.SetPlatform(fmt.Sprintf("platform-%s", RandString(8)))
+	instance.SetPrivateDnsName(fmt.Sprintf("private-dns-%s", RandString(8)))
+	instance.SetPrivateIpAddress(RandIpv4())
+	instance.SetPublicDnsName(fmt.Sprintf("public-ip-%s", RandString(8)))
+	instance.SetPublicIpAddress(RandIpv4())
+	instance.SetState(&state)
+
+	tags := make([]*ec2.Tag, RandNumber(2, 5))
+	for i := 0; i < len(tags); i++ {
+		tags[i] = &ec2.Tag{}
+		tags[i].SetKey(fmt.Sprintf("tag-%d-key-%s", i, RandString(8)))
+		tags[i].SetValue(fmt.Sprintf("tag-%d-value-%s", i, RandString(8)))
+	}
+
+	instance.SetTags(tags)
+
+	ec2Data.instances = append(ec2Data.instances, &instance)
+
+	return azIdx
 }
 
 // The tests itself.
@@ -71,15 +138,107 @@ func TestRefreshAZIDs(t *testing.T) {
 	ctx := context.Background()
 	client := &mockEC2Client{}
 
+	GenerateTestAzData()
+
 	d := &EC2Discovery{
 		ec2: client,
 	}
 
 	err := d.refreshAZIDs(ctx)
-	if err != nil {
-		t.Fatalf("refreshAZIDs returned with an error [%v]\n", err)
-	}
+	require.Nil(t, err)
 	require.Equal(t, ec2Data.azToAZID, d.azToAZID)
+}
+
+func TestRefreshAZIDsHandleError(t *testing.T) {
+	ctx := context.Background()
+	client := &mockEC2Client{}
+
+	ec2Data = EC2Data{}
+
+	d := &EC2Discovery{
+		ec2: client,
+	}
+
+	err := d.refreshAZIDs(ctx)
+	require.Equal(t, "No AZs found", err.Error())
+}
+
+func TestRefreshNoPrivateIp(t *testing.T) {
+	ctx := context.Background()
+	client := &mockEC2Client{}
+
+	GenerateTestAzData()
+
+	instance := ec2.Instance{}
+	instance.SetInstanceId(fmt.Sprintf("instance-id-%s", RandString(8)))
+
+	ec2Data.instances = append(ec2Data.instances, &instance)
+
+	d := &EC2Discovery{
+		ec2: client,
+		cfg: &EC2SDConfig{
+			Region: ec2Data.region,
+		},
+	}
+
+	expected := make([]*targetgroup.Group, 1)
+	expected[0] = &targetgroup.Group{
+		Source: ec2Data.region,
+	}
+
+	g, err := d.refresh(ctx)
+	require.Equal(t, expected, g)
+	require.Nil(t, err)
+}
+
+func TestRefreshNoVpc(t *testing.T) {
+	ctx := context.Background()
+	client := &mockEC2Client{}
+
+	GenerateTestAzData()
+	azIdx := GenerateTestInstanceData()
+
+	d := &EC2Discovery{
+		ec2: client,
+		cfg: &EC2SDConfig{
+			Port:   RandNumber(1024, 65535),
+			Region: ec2Data.region,
+		},
+	}
+
+	labels := model.LabelSet{
+		"__address__":                     model.LabelValue(fmt.Sprintf("%s:%d", *ec2Data.instances[0].PrivateIpAddress, d.cfg.Port)),
+		"__meta_ec2_ami":                  model.LabelValue(*ec2Data.instances[0].ImageId),
+		"__meta_ec2_architecture":         model.LabelValue(*ec2Data.instances[0].Architecture),
+		"__meta_ec2_availability_zone":    model.LabelValue(ec2Data.azNames[azIdx]),
+		"__meta_ec2_availability_zone_id": model.LabelValue(ec2Data.azIDs[azIdx]),
+		"__meta_ec2_instance_id":          model.LabelValue(*ec2Data.instances[0].InstanceId),
+		"__meta_ec2_instance_lifecycle":   model.LabelValue(*ec2Data.instances[0].InstanceLifecycle),
+		"__meta_ec2_instance_state":       model.LabelValue(*ec2Data.instances[0].State.Name),
+		"__meta_ec2_instance_type":        model.LabelValue(*ec2Data.instances[0].InstanceType),
+		"__meta_ec2_owner_id":             model.LabelValue(ec2Data.ownerId),
+		"__meta_ec2_platform":             model.LabelValue(*ec2Data.instances[0].Platform),
+		"__meta_ec2_private_dns_name":     model.LabelValue(*ec2Data.instances[0].PrivateDnsName),
+		"__meta_ec2_private_ip":           model.LabelValue(*ec2Data.instances[0].PrivateIpAddress),
+		"__meta_ec2_public_dns_name":      model.LabelValue(*ec2Data.instances[0].PublicDnsName),
+		"__meta_ec2_public_ip":            model.LabelValue(*ec2Data.instances[0].PublicIpAddress),
+		"__meta_ec2_region":               model.LabelValue(ec2Data.region),
+	}
+
+	for i := 0; i < len(ec2Data.instances[0].Tags); i++ {
+		key := strings.Replace(fmt.Sprintf("__meta_ec2_tag_%s", *ec2Data.instances[0].Tags[i].Key), "-", "_", -1)
+		labels[model.LabelName(key)] = model.LabelValue(*ec2Data.instances[0].Tags[i].Value)
+	}
+
+	expected := make([]*targetgroup.Group, 1)
+	expected[0] = &targetgroup.Group{
+		Source: ec2Data.region,
+	}
+	expected[0].Targets = append(expected[0].Targets, labels)
+
+	g, err := d.refresh(ctx)
+	require.Equal(t, expected, g)
+	require.Nil(t, err)
 }
 
 // EC2 client mock.
@@ -88,16 +247,33 @@ type mockEC2Client struct {
 }
 
 func (m *mockEC2Client) DescribeAvailabilityZonesWithContext(ctx aws.Context, input *ec2.DescribeAvailabilityZonesInput, opts ...request.Option) (*ec2.DescribeAvailabilityZonesOutput, error) {
-	azs := make([]*ec2.AvailabilityZone, len(ec2Data.azNames))
+	if len(ec2Data.azNames) > 0 {
+		azs := make([]*ec2.AvailabilityZone, len(ec2Data.azNames))
 
-	for i := range ec2Data.azNames {
-		azs[i] = &ec2.AvailabilityZone{
-			ZoneName: &ec2Data.azNames[i],
-			ZoneId:   &ec2Data.azIDs[i],
+		for i := range ec2Data.azNames {
+			azs[i] = &ec2.AvailabilityZone{
+				ZoneName: &ec2Data.azNames[i],
+				ZoneId:   &ec2Data.azIDs[i],
+			}
 		}
-	}
 
-	return &ec2.DescribeAvailabilityZonesOutput{
-		AvailabilityZones: azs,
-	}, nil
+		return &ec2.DescribeAvailabilityZonesOutput{
+			AvailabilityZones: azs,
+		}, nil
+	} else {
+		return nil, errors.New("No AZs found")
+	}
+}
+
+func (m *mockEC2Client) DescribeInstancesPagesWithContext(ctx aws.Context, input *ec2.DescribeInstancesInput, fn func(*ec2.DescribeInstancesOutput, bool) bool, opts ...request.Option) error {
+	r := ec2.Reservation{}
+	r.SetInstances(ec2Data.instances)
+	r.SetOwnerId(ec2Data.ownerId)
+
+	o := ec2.DescribeInstancesOutput{}
+	o.SetReservations([]*ec2.Reservation{&r})
+
+	_ = fn(&o, true)
+
+	return nil
 }

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -26,9 +26,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 // "Helper" functions.
@@ -38,7 +39,7 @@ func RandIpv4() string {
 	return fmt.Sprintf("%d.%d.%d.%d", RandNumber(1, 255), RandNumber(0, 255), RandNumber(0, 255), RandNumber(0, 255))
 }
 
-func RandNumber(minimum int, maximum int) int {
+func RandNumber(minimum, maximum int) int {
 	return rand.Intn(maximum-minimum) + minimum
 }
 

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -27,7 +26,7 @@ import (
 	"go.uber.org/goleak"
 )
 
-// "helper" functions
+// "Helper" functions.
 const chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 func RandString(n int) string {
@@ -39,7 +38,7 @@ func RandString(n int) string {
 	return string(b)
 }
 
-// struct for test data
+// Struct for test data.
 type EC2Data struct {
 	azNames  []string
 	azIDs    []string
@@ -48,10 +47,8 @@ type EC2Data struct {
 
 var ec2Data EC2Data
 
-// prepare test data
+// Prepare test data.
 func init() {
-	rand.Seed(time.Now().UnixNano())
-
 	// availability zone information
 	azCount := rand.Intn(3) + 2
 	ec2Data.azNames = make([]string, azCount)
@@ -65,7 +62,7 @@ func init() {
 	}
 }
 
-// tests
+// The tests itself.
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
@@ -85,7 +82,7 @@ func TestRefreshAZIDs(t *testing.T) {
 	require.Equal(t, ec2Data.azToAZID, d.azToAZID)
 }
 
-// EC2 client mock
+// EC2 client mock.
 type mockEC2Client struct {
 	ec2iface.EC2API
 }

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -204,32 +204,8 @@ func TestRefreshAZIDsHandleError(t *testing.T) {
 }
 
 // Tests for the refresh function.
-//
-//	name - the name of the test
-//	generator - a generator function for the input and expected output
+// The generator function type which creates input and expected output data.
 type generatorFunction func(*EC2Discovery) []*targetgroup.Group
-
-var refreshTests = []struct {
-	name      string
-	generator generatorFunction
-}{
-	{
-		name:      "NoPrivateIp",
-		generator: generateRefreshNoPrivateIP,
-	},
-	{
-		name:      "NoVpc",
-		generator: generateRefreshNoVpc,
-	},
-	{
-		name:      "Ipv4",
-		generator: generateRefreshIpv4,
-	},
-	{
-		name:      "Ipv6",
-		generator: generateRefreshIpv6,
-	},
-}
 
 func generateRefreshNoPrivateIP(d *EC2Discovery) []*targetgroup.Group {
 	ec2Data := &d.ec2.(*mockEC2Client).ec2Data
@@ -407,8 +383,28 @@ func TestRefresh(t *testing.T) {
 	ctx := context.Background()
 	client := newMockEC2Client()
 
-	// iterate through the refreshTests array
-	for _, tt := range refreshTests {
+	// iterate through the test cases
+	for _, tt := range []struct {
+		name      string
+		generator generatorFunction
+	}{
+		{
+			name:      "NoPrivateIp",
+			generator: generateRefreshNoPrivateIP,
+		},
+		{
+			name:      "NoVpc",
+			generator: generateRefreshNoVpc,
+		},
+		{
+			name:      "Ipv4",
+			generator: generateRefreshIpv4,
+		},
+		{
+			name:      "Ipv6",
+			generator: generateRefreshIpv6,
+		},
+	} {
 		t.Run(tt.name, func(t *testing.T) {
 			// generate basic availability zone test data
 			client.ec2Data = ec2DataStore{}

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -207,15 +207,15 @@ func TestRefreshAZIDsHandleError(t *testing.T) {
 //
 //	name - the name of the test
 //	generator - a generator function for the input and expected output
-type generator_function func(*EC2Discovery) []*targetgroup.Group
+type generatorFunction func(*EC2Discovery) []*targetgroup.Group
 
 var refreshTests = []struct {
 	name      string
-	generator generator_function
+	generator generatorFunction
 }{
 	{
 		name:      "NoPrivateIp",
-		generator: generateRefreshNoPrivateIp,
+		generator: generateRefreshNoPrivateIP,
 	},
 	{
 		name:      "NoVpc",
@@ -231,7 +231,7 @@ var refreshTests = []struct {
 	},
 }
 
-func generateRefreshNoPrivateIp(d *EC2Discovery) []*targetgroup.Group {
+func generateRefreshNoPrivateIP(d *EC2Discovery) []*targetgroup.Group {
 	ec2Data := &d.ec2.(*mockEC2Client).ec2Data
 
 	instance := ec2.Instance{}
@@ -429,7 +429,6 @@ func TestRefresh(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-
 }
 
 // EC2 client mock.

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -110,7 +110,6 @@ func generateTestInstanceData(ec2Data *ec2DataStore) int {
 	placement := ec2.Placement{}
 	placement.SetAvailabilityZone(ec2Data.azNames[azIdx])
 
-	// FIXME: this could be a "global" variable
 	state := ec2.InstanceState{}
 	state.SetName("running")
 

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -16,9 +16,6 @@ package aws
 import (
 	"context"
 	"errors"
-	"fmt"
-	"math/rand"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -31,43 +28,6 @@ import (
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
-
-// "Helper" functions.
-const (
-	chars     = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	ipv6chars = "0123456789abcdef"
-)
-
-func randIpv4() string {
-	return fmt.Sprintf("%d.%d.%d.%d", randNumber(1, 255), randNumber(0, 255), randNumber(0, 255), randNumber(0, 255))
-}
-
-func randIpv6() string {
-	address := "2000"
-
-	for i := 0; i < 7; i++ {
-		e := make([]byte, 4)
-		for j := range e {
-			e[j] = ipv6chars[rand.Intn(len(ipv6chars))]
-		}
-		address += ":" + string(e)
-	}
-
-	return address
-}
-
-func randNumber(minimum, maximum int) int {
-	return rand.Intn(maximum-minimum) + minimum
-}
-
-func randString(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = chars[rand.Intn(len(chars))]
-	}
-
-	return string(b)
-}
 
 // Struct for test data.
 type ec2DataStore struct {
@@ -82,93 +42,6 @@ type ec2DataStore struct {
 	instances []*ec2.Instance
 }
 
-// Generate test data.
-func generateTestAzData(ec2Data *ec2DataStore) {
-	// region information
-	ec2Data.region = fmt.Sprintf("region-%s", randString(4))
-
-	// availability zone information
-	azCount := randNumber(3, 5)
-	ec2Data.azNames = make([]string, azCount)
-	ec2Data.azIDs = make([]string, azCount)
-	ec2Data.azToAZID = make(map[string]string, azCount)
-
-	for i := 0; i < azCount; i++ {
-		ec2Data.azNames[i] = fmt.Sprintf("azname-%s", randString(5))
-		ec2Data.azIDs[i] = fmt.Sprintf("azid-%s", randString(5))
-		ec2Data.azToAZID[ec2Data.azNames[i]] = ec2Data.azIDs[i]
-	}
-
-	// ownerId for the reservation
-	ec2Data.ownerID = fmt.Sprintf("ownerid-%s", randString(5))
-}
-
-func generateTestInstanceData(ec2Data *ec2DataStore) int {
-	// without VPC configuration, just the "basics"
-	azIdx := randNumber(0, len(ec2Data.azNames))
-
-	placement := ec2.Placement{}
-	placement.SetAvailabilityZone(ec2Data.azNames[azIdx])
-
-	state := ec2.InstanceState{}
-	state.SetName("running")
-
-	instance := ec2.Instance{}
-	instance.SetArchitecture(fmt.Sprintf("architecture-%s", randString(8)))
-	instance.SetImageId(fmt.Sprintf("ami-%s", randString(8)))
-	instance.SetInstanceId(fmt.Sprintf("instance-id-%s", randString(8)))
-	instance.SetInstanceLifecycle(fmt.Sprintf("instance-lifecycle-%s", randString(8)))
-	instance.SetInstanceType(fmt.Sprintf("instance-type-%s", randString(8)))
-	instance.SetPlacement(&placement)
-	instance.SetPlatform(fmt.Sprintf("platform-%s", randString(8)))
-	instance.SetPrivateDnsName(fmt.Sprintf("private-dns-%s", randString(8)))
-	instance.SetPrivateIpAddress(randIpv4())
-	instance.SetPublicDnsName(fmt.Sprintf("public-ip-%s", randString(8)))
-	instance.SetPublicIpAddress(randIpv4())
-	instance.SetState(&state)
-
-	tags := make([]*ec2.Tag, randNumber(2, 5))
-	for i := 0; i < len(tags); i++ {
-		tags[i] = &ec2.Tag{}
-		tags[i].SetKey(fmt.Sprintf("tag-%d-key-%s", i, randString(8)))
-		tags[i].SetValue(fmt.Sprintf("tag-%d-value-%s", i, randString(8)))
-	}
-
-	instance.SetTags(tags)
-
-	ec2Data.instances = append(ec2Data.instances, &instance)
-
-	return azIdx
-}
-
-func generateExpectedLabels(ec2Data *ec2DataStore, azIdx, port int) model.LabelSet {
-	labels := model.LabelSet{
-		"__address__":                     model.LabelValue(fmt.Sprintf("%s:%d", *ec2Data.instances[0].PrivateIpAddress, port)),
-		"__meta_ec2_ami":                  model.LabelValue(*ec2Data.instances[0].ImageId),
-		"__meta_ec2_architecture":         model.LabelValue(*ec2Data.instances[0].Architecture),
-		"__meta_ec2_availability_zone":    model.LabelValue(ec2Data.azNames[azIdx]),
-		"__meta_ec2_availability_zone_id": model.LabelValue(ec2Data.azIDs[azIdx]),
-		"__meta_ec2_instance_id":          model.LabelValue(*ec2Data.instances[0].InstanceId),
-		"__meta_ec2_instance_lifecycle":   model.LabelValue(*ec2Data.instances[0].InstanceLifecycle),
-		"__meta_ec2_instance_state":       model.LabelValue(*ec2Data.instances[0].State.Name),
-		"__meta_ec2_instance_type":        model.LabelValue(*ec2Data.instances[0].InstanceType),
-		"__meta_ec2_owner_id":             model.LabelValue(ec2Data.ownerID),
-		"__meta_ec2_platform":             model.LabelValue(*ec2Data.instances[0].Platform),
-		"__meta_ec2_private_dns_name":     model.LabelValue(*ec2Data.instances[0].PrivateDnsName),
-		"__meta_ec2_private_ip":           model.LabelValue(*ec2Data.instances[0].PrivateIpAddress),
-		"__meta_ec2_public_dns_name":      model.LabelValue(*ec2Data.instances[0].PublicDnsName),
-		"__meta_ec2_public_ip":            model.LabelValue(*ec2Data.instances[0].PublicIpAddress),
-		"__meta_ec2_region":               model.LabelValue(ec2Data.region),
-	}
-
-	for i := 0; i < len(ec2Data.instances[0].Tags); i++ {
-		key := strings.ReplaceAll(fmt.Sprintf("__meta_ec2_tag_%s", *ec2Data.instances[0].Tags[i].Key), "-", "_")
-		labels[model.LabelName(key)] = model.LabelValue(*ec2Data.instances[0].Tags[i].Value)
-	}
-
-	return labels
-}
-
 // The tests itself.
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
@@ -176,10 +49,17 @@ func TestMain(m *testing.M) {
 
 func TestRefreshAZIDs(t *testing.T) {
 	ctx := context.Background()
-	client := newMockEC2Client()
-	ec2Data := &client.ec2Data
-
-	generateTestAzData(ec2Data)
+	client := newMockEC2Client(
+		&ec2DataStore{
+			azNames: []string{"azname-a", "azname-b", "azname-c"},
+			azIDs:   []string{"azid-1", "azid-2", "azid-3"},
+			azToAZID: map[string]string{
+				"azname-a": "azid-1",
+				"azname-b": "azid-2",
+				"azname-c": "azid-3",
+			},
+		},
+	)
 
 	d := &EC2Discovery{
 		ec2: client,
@@ -187,12 +67,14 @@ func TestRefreshAZIDs(t *testing.T) {
 
 	err := d.refreshAZIDs(ctx)
 	require.NoError(t, err)
-	require.Equal(t, ec2Data.azToAZID, d.azToAZID)
+	require.Equal(t, client.ec2Data.azToAZID, d.azToAZID)
 }
 
 func TestRefreshAZIDsHandleError(t *testing.T) {
 	ctx := context.Background()
-	client := newMockEC2Client()
+	client := newMockEC2Client(
+		&ec2DataStore{},
+	)
 
 	d := &EC2Discovery{
 		ec2: client,
@@ -203,225 +85,298 @@ func TestRefreshAZIDsHandleError(t *testing.T) {
 }
 
 // Tests for the refresh function.
-// The generator function type which creates input and expected output data.
-type generatorFunction func(*EC2Discovery) []*targetgroup.Group
-
-func generateRefreshNoPrivateIP(d *EC2Discovery) []*targetgroup.Group {
-	ec2Data := &d.ec2.(*mockEC2Client).ec2Data
-
-	instance := ec2.Instance{}
-	instance.SetInstanceId(fmt.Sprintf("instance-id-%s", randString(8)))
-
-	ec2Data.instances = append(ec2Data.instances, &instance)
-
-	expected := make([]*targetgroup.Group, 1)
-	expected[0] = &targetgroup.Group{
-		Source: ec2Data.region,
-	}
-
-	return expected
-}
-
-func generateRefreshNoVpc(d *EC2Discovery) []*targetgroup.Group {
-	ec2Data := &d.ec2.(*mockEC2Client).ec2Data
-
-	azIdx := generateTestInstanceData(ec2Data)
-
-	expected := make([]*targetgroup.Group, 1)
-	expected[0] = &targetgroup.Group{
-		Source: ec2Data.region,
-	}
-	expected[0].Targets = append(expected[0].Targets, generateExpectedLabels(ec2Data, azIdx, d.cfg.Port))
-
-	return expected
-}
-
-func generateRefreshIpv4(d *EC2Discovery) []*targetgroup.Group {
-	ec2Data := &d.ec2.(*mockEC2Client).ec2Data
-
-	azIdx := generateTestInstanceData(ec2Data)
-
-	ec2Data.instances[0].SetSubnetId(ec2Data.azIDs[azIdx])
-	ec2Data.instances[0].SetVpcId(fmt.Sprintf("vpc-%s", randString(8)))
-
-	enis := make([]*ec2.InstanceNetworkInterface, 4)
-
-	// interface in the primary subnet
-	enis[0] = &ec2.InstanceNetworkInterface{}
-	enis[0].SetIpv6Addresses([]*ec2.InstanceIpv6Address{})
-	enis[0].SetSubnetId(*ec2Data.instances[0].SubnetId)
-
-	// interface without any subnet
-	enis[1] = &ec2.InstanceNetworkInterface{}
-	enis[1].SetIpv6Addresses([]*ec2.InstanceIpv6Address{})
-	// azIdx + 1 modulo #azs
-	secondAzID := (azIdx + 1) % len(ec2Data.azIDs)
-	enis[1].SetSubnetId(ec2Data.azIDs[secondAzID])
-
-	// interface in another subnet
-	enis[2] = &ec2.InstanceNetworkInterface{}
-	enis[2].SetIpv6Addresses([]*ec2.InstanceIpv6Address{})
-
-	// inteface in the primary subnet
-	enis[3] = &ec2.InstanceNetworkInterface{}
-	enis[3].SetIpv6Addresses([]*ec2.InstanceIpv6Address{})
-	enis[3].SetSubnetId(*ec2Data.instances[0].SubnetId)
-
-	ec2Data.instances[0].SetNetworkInterfaces(enis)
-
-	labels := generateExpectedLabels(ec2Data, azIdx, d.cfg.Port)
-
-	labels["__meta_ec2_primary_subnet_id"] = model.LabelValue(*ec2Data.instances[0].SubnetId)
-	labels["__meta_ec2_subnet_id"] = model.LabelValue(fmt.Sprintf(",%s,%s,", ec2Data.azIDs[azIdx], ec2Data.azIDs[secondAzID]))
-	labels["__meta_ec2_vpc_id"] = model.LabelValue(*ec2Data.instances[0].VpcId)
-
-	expected := make([]*targetgroup.Group, 1)
-	expected[0] = &targetgroup.Group{
-		Source: ec2Data.region,
-	}
-	expected[0].Targets = append(expected[0].Targets, labels)
-
-	return expected
-}
-
-func generateRefreshIpv6(d *EC2Discovery) []*targetgroup.Group {
-	ec2Data := &d.ec2.(*mockEC2Client).ec2Data
-
-	azIdx := generateTestInstanceData(ec2Data)
-
-	ec2Data.instances[0].SetSubnetId(ec2Data.azIDs[azIdx])
-	ec2Data.instances[0].SetVpcId(fmt.Sprintf("vpc-%s", randString(8)))
-
-	attachments := make([]*ec2.InstanceNetworkInterfaceAttachment, 4)
-	enis := make([]*ec2.InstanceNetworkInterface, 4)
-	ips := make([][]*ec2.InstanceIpv6Address, 4)
-
-	// interface without primary IPv6
-	attachments[0] = &ec2.InstanceNetworkInterfaceAttachment{}
-	attachments[0].SetDeviceIndex(3)
-
-	ips[0] = make([]*ec2.InstanceIpv6Address, 1)
-	ips[0][0] = &ec2.InstanceIpv6Address{}
-	ips[0][0].SetIpv6Address(randIpv6())
-	ips[0][0].SetIsPrimaryIpv6(false)
-
-	enis[0] = &ec2.InstanceNetworkInterface{}
-	enis[0].SetAttachment(attachments[0])
-	enis[0].SetIpv6Addresses(ips[0])
-	enis[0].SetSubnetId(*ec2Data.instances[0].SubnetId)
-
-	// interface with primary IPv6
-	attachments[1] = &ec2.InstanceNetworkInterfaceAttachment{}
-	attachments[1].SetDeviceIndex(2)
-
-	ips[1] = make([]*ec2.InstanceIpv6Address, 2)
-	ips[1][0] = &ec2.InstanceIpv6Address{}
-	ips[1][0].SetIpv6Address(randIpv6())
-	ips[1][0].SetIsPrimaryIpv6(false)
-	ips[1][1] = &ec2.InstanceIpv6Address{}
-	ips[1][1].SetIpv6Address(randIpv6())
-	ips[1][1].SetIsPrimaryIpv6(true)
-
-	enis[1] = &ec2.InstanceNetworkInterface{}
-	enis[1].SetAttachment(attachments[1])
-	enis[1].SetIpv6Addresses(ips[1])
-	enis[1].SetSubnetId(*ec2Data.instances[0].SubnetId)
-
-	// interface with primary IPv6
-	attachments[2] = &ec2.InstanceNetworkInterfaceAttachment{}
-	attachments[2].SetDeviceIndex(1)
-
-	ips[2] = make([]*ec2.InstanceIpv6Address, 1)
-	ips[2][0] = &ec2.InstanceIpv6Address{}
-	ips[2][0].SetIpv6Address(randIpv6())
-	ips[2][0].SetIsPrimaryIpv6(true)
-
-	enis[2] = &ec2.InstanceNetworkInterface{}
-	enis[2].SetAttachment(attachments[2])
-	enis[2].SetIpv6Addresses(ips[2])
-	enis[2].SetSubnetId(*ec2Data.instances[0].SubnetId)
-
-	// interface without primary IPv6
-	attachments[3] = &ec2.InstanceNetworkInterfaceAttachment{}
-	attachments[3].SetDeviceIndex(0)
-
-	enis[3] = &ec2.InstanceNetworkInterface{}
-	enis[3].SetAttachment(attachments[3])
-	enis[3].SetIpv6Addresses([]*ec2.InstanceIpv6Address{})
-	enis[3].SetSubnetId(*ec2Data.instances[0].SubnetId)
-
-	ec2Data.instances[0].SetNetworkInterfaces(enis)
-
-	labels := generateExpectedLabels(ec2Data, azIdx, d.cfg.Port)
-
-	labels["__meta_ec2_ipv6_addresses"] = model.LabelValue(
-		fmt.Sprintf(",%s,%s,%s,%s,",
-			*ips[0][0].Ipv6Address,
-			*ips[1][0].Ipv6Address,
-			*ips[1][1].Ipv6Address,
-			*ips[2][0].Ipv6Address,
-		),
-	)
-	labels["__meta_ec2_primary_ipv6_addresses"] = model.LabelValue(
-		fmt.Sprintf(",,%s,%s,", *ips[2][0].Ipv6Address, *ips[1][1].Ipv6Address),
-	)
-	labels["__meta_ec2_primary_subnet_id"] = model.LabelValue(*ec2Data.instances[0].SubnetId)
-	labels["__meta_ec2_subnet_id"] = model.LabelValue(fmt.Sprintf(",%s,", ec2Data.azIDs[azIdx]))
-	labels["__meta_ec2_vpc_id"] = model.LabelValue(*ec2Data.instances[0].VpcId)
-
-	expected := make([]*targetgroup.Group, 1)
-	expected[0] = &targetgroup.Group{
-		Source: ec2Data.region,
-	}
-	expected[0].Targets = append(expected[0].Targets, labels)
-
-	return expected
-}
-
 func TestEC2DiscoveryRefresh(t *testing.T) {
+	// we need to get addresses of untyped string, int64 and boolean(!) constants as the AWS SDK expects
+	addrB := func(b bool) *bool { return &b }
+	addrI := func(i int64) *int64 { return &i }
+	addrS := func(s string) *string { return &s }
+
 	ctx := context.Background()
-	client := newMockEC2Client()
 
 	// iterate through the test cases
 	for _, tt := range []struct {
-		name      string
-		generator generatorFunction
+		name     string
+		ec2Data  *ec2DataStore
+		expected []*targetgroup.Group
 	}{
 		{
-			name:      "NoPrivateIp",
-			generator: generateRefreshNoPrivateIP,
+			name: "NoPrivateIp",
+			ec2Data: &ec2DataStore{
+				region:  "region-noprivateip",
+				azNames: []string{"azname-a", "azname-b", "azname-c"},
+				azIDs:   []string{"azid-1", "azid-2", "azid-3"},
+				azToAZID: map[string]string{
+					"azname-a": "azid-1",
+					"azname-b": "azid-2",
+					"azname-c": "azid-3",
+				},
+				instances: []*ec2.Instance{
+					&ec2.Instance{
+						InstanceId: addrS("instance-id-noprivateip"),
+					},
+				},
+			},
+			expected: []*targetgroup.Group{
+				&targetgroup.Group{
+					Source: "region-noprivateip",
+				},
+			},
 		},
 		{
-			name:      "NoVpc",
-			generator: generateRefreshNoVpc,
+			name: "NoVpc",
+			ec2Data: &ec2DataStore{
+				region:  "region-novpc",
+				azNames: []string{"azname-a", "azname-b", "azname-c"},
+				azIDs:   []string{"azid-1", "azid-2", "azid-3"},
+				azToAZID: map[string]string{
+					"azname-a": "azid-1",
+					"azname-b": "azid-2",
+					"azname-c": "azid-3",
+				},
+				ownerID: "owner-id-novpc",
+				instances: []*ec2.Instance{
+					&ec2.Instance{
+						// set every possible options and test them here
+						Architecture:      addrS("architecture-novpc"),
+						ImageId:           addrS("ami-novpc"),
+						InstanceId:        addrS("instance-id-novpc"),
+						InstanceLifecycle: addrS("instance-lifecycle-novpc"),
+						InstanceType:      addrS("instance-type-novpc"),
+						Placement:         &ec2.Placement{AvailabilityZone: addrS("azname-b")},
+						Platform:          addrS("platform-novpc"),
+						PrivateDnsName:    addrS("private-dns-novpc"),
+						PrivateIpAddress:  addrS("1.2.3.4"),
+						PublicDnsName:     addrS("public-dns-novpc"),
+						PublicIpAddress:   addrS("42.42.42.2"),
+						State:             &ec2.InstanceState{Name: addrS("running")},
+						// test tags once and for all
+						Tags: []*ec2.Tag{
+							&ec2.Tag{Key: addrS("tag-1-key"), Value: addrS("tag-1-value")},
+							&ec2.Tag{Key: addrS("tag-2-key"), Value: addrS("tag-2-value")},
+							nil,
+							&ec2.Tag{Value: addrS("tag-4-value")},
+							&ec2.Tag{Key: addrS("tag-5-key")},
+						},
+					},
+				},
+			},
+			expected: []*targetgroup.Group{
+				&targetgroup.Group{
+					Source: "region-novpc",
+					Targets: []model.LabelSet{
+						model.LabelSet{
+							"__address__":                     model.LabelValue("1.2.3.4:4242"),
+							"__meta_ec2_ami":                  model.LabelValue("ami-novpc"),
+							"__meta_ec2_architecture":         model.LabelValue("architecture-novpc"),
+							"__meta_ec2_availability_zone":    model.LabelValue("azname-b"),
+							"__meta_ec2_availability_zone_id": model.LabelValue("azid-2"),
+							"__meta_ec2_instance_id":          model.LabelValue("instance-id-novpc"),
+							"__meta_ec2_instance_lifecycle":   model.LabelValue("instance-lifecycle-novpc"),
+							"__meta_ec2_instance_type":        model.LabelValue("instance-type-novpc"),
+							"__meta_ec2_instance_state":       model.LabelValue("running"),
+							"__meta_ec2_owner_id":             model.LabelValue("owner-id-novpc"),
+							"__meta_ec2_platform":             model.LabelValue("platform-novpc"),
+							"__meta_ec2_private_dns_name":     model.LabelValue("private-dns-novpc"),
+							"__meta_ec2_private_ip":           model.LabelValue("1.2.3.4"),
+							"__meta_ec2_public_dns_name":      model.LabelValue("public-dns-novpc"),
+							"__meta_ec2_public_ip":            model.LabelValue("42.42.42.2"),
+							"__meta_ec2_region":               model.LabelValue("region-novpc"),
+							"__meta_ec2_tag_tag_1_key":        model.LabelValue("tag-1-value"),
+							"__meta_ec2_tag_tag_2_key":        model.LabelValue("tag-2-value"),
+						},
+					},
+				},
+			},
 		},
 		{
-			name:      "Ipv4",
-			generator: generateRefreshIpv4,
+			name: "Ipv4",
+			ec2Data: &ec2DataStore{
+				region:  "region-ipv4",
+				azNames: []string{"azname-a", "azname-b", "azname-c"},
+				azIDs:   []string{"azid-1", "azid-2", "azid-3"},
+				azToAZID: map[string]string{
+					"azname-a": "azid-1",
+					"azname-b": "azid-2",
+					"azname-c": "azid-3",
+				},
+				instances: []*ec2.Instance{
+					&ec2.Instance{
+						// just the minimum needed for the refresh work
+						ImageId:          addrS("ami-ipv4"),
+						InstanceId:       addrS("instance-id-ipv4"),
+						InstanceType:     addrS("instance-type-ipv4"),
+						Placement:        &ec2.Placement{AvailabilityZone: addrS("azname-c")},
+						PrivateIpAddress: addrS("5.6.7.8"),
+						State:            &ec2.InstanceState{Name: addrS("running")},
+						SubnetId:         addrS("azid-3"),
+						VpcId:            addrS("vpc-ipv4"),
+						// network intefaces
+						NetworkInterfaces: []*ec2.InstanceNetworkInterface{
+							// interface without subnet -> should be ignored
+							&ec2.InstanceNetworkInterface{
+								Ipv6Addresses: []*ec2.InstanceIpv6Address{
+									&ec2.InstanceIpv6Address{
+										Ipv6Address:   addrS("2001:db8:1::1"),
+										IsPrimaryIpv6: addrB(true),
+									},
+								},
+							},
+							// interface with subnet, no IPv6
+							&ec2.InstanceNetworkInterface{
+								Ipv6Addresses: []*ec2.InstanceIpv6Address{},
+								SubnetId:      addrS("azid-3"),
+							},
+							// interface with another subnet, no IPv6
+							&ec2.InstanceNetworkInterface{
+								Ipv6Addresses: []*ec2.InstanceIpv6Address{},
+								SubnetId:      addrS("azid-1"),
+							},
+						},
+					},
+				},
+			},
+			expected: []*targetgroup.Group{
+				&targetgroup.Group{
+					Source: "region-ipv4",
+					Targets: []model.LabelSet{
+						model.LabelSet{
+							"__address__":                     model.LabelValue("5.6.7.8:4242"),
+							"__meta_ec2_ami":                  model.LabelValue("ami-ipv4"),
+							"__meta_ec2_availability_zone":    model.LabelValue("azname-c"),
+							"__meta_ec2_availability_zone_id": model.LabelValue("azid-3"),
+							"__meta_ec2_instance_id":          model.LabelValue("instance-id-ipv4"),
+							"__meta_ec2_instance_state":       model.LabelValue("running"),
+							"__meta_ec2_instance_type":        model.LabelValue("instance-type-ipv4"),
+							"__meta_ec2_owner_id":             model.LabelValue(""),
+							"__meta_ec2_primary_subnet_id":    model.LabelValue("azid-3"),
+							"__meta_ec2_private_ip":           model.LabelValue("5.6.7.8"),
+							"__meta_ec2_region":               model.LabelValue("region-ipv4"),
+							"__meta_ec2_subnet_id":            model.LabelValue(",azid-3,azid-1,"),
+							"__meta_ec2_vpc_id":               model.LabelValue("vpc-ipv4"),
+						},
+					},
+				},
+			},
 		},
 		{
-			name:      "Ipv6",
-			generator: generateRefreshIpv6,
+			name: "Ipv6",
+			ec2Data: &ec2DataStore{
+				region:  "region-ipv6",
+				azNames: []string{"azname-a", "azname-b", "azname-c"},
+				azIDs:   []string{"azid-1", "azid-2", "azid-3"},
+				azToAZID: map[string]string{
+					"azname-a": "azid-1",
+					"azname-b": "azid-2",
+					"azname-c": "azid-3",
+				},
+				instances: []*ec2.Instance{
+					&ec2.Instance{
+						// just the minimum needed for the refresh work
+						ImageId:          addrS("ami-ipv6"),
+						InstanceId:       addrS("instance-id-ipv6"),
+						InstanceType:     addrS("instance-type-ipv6"),
+						Placement:        &ec2.Placement{AvailabilityZone: addrS("azname-b")},
+						PrivateIpAddress: addrS("9.10.11.12"),
+						State:            &ec2.InstanceState{Name: addrS("running")},
+						SubnetId:         addrS("azid-2"),
+						VpcId:            addrS("vpc-ipv6"),
+						// network intefaces
+						NetworkInterfaces: []*ec2.InstanceNetworkInterface{
+							// interface without primary IPv6, index 2
+							&ec2.InstanceNetworkInterface{
+								Attachment: &ec2.InstanceNetworkInterfaceAttachment{
+									DeviceIndex: addrI(3),
+								},
+								Ipv6Addresses: []*ec2.InstanceIpv6Address{
+									&ec2.InstanceIpv6Address{
+										Ipv6Address:   addrS("2001:db8:2::1:1"),
+										IsPrimaryIpv6: addrB(false),
+									},
+								},
+								SubnetId: addrS("azid-2"),
+							},
+							// interface with primary IPv6, index 1
+							&ec2.InstanceNetworkInterface{
+								Attachment: &ec2.InstanceNetworkInterfaceAttachment{
+									DeviceIndex: addrI(1),
+								},
+								Ipv6Addresses: []*ec2.InstanceIpv6Address{
+									&ec2.InstanceIpv6Address{
+										Ipv6Address:   addrS("2001:db8:2::2:1"),
+										IsPrimaryIpv6: addrB(false),
+									},
+									&ec2.InstanceIpv6Address{
+										Ipv6Address:   addrS("2001:db8:2::2:2"),
+										IsPrimaryIpv6: addrB(true),
+									},
+								},
+								SubnetId: addrS("azid-2"),
+							},
+							// interface with primary IPv6, index 3
+							&ec2.InstanceNetworkInterface{
+								Attachment: &ec2.InstanceNetworkInterfaceAttachment{
+									DeviceIndex: addrI(3),
+								},
+								Ipv6Addresses: []*ec2.InstanceIpv6Address{
+									&ec2.InstanceIpv6Address{
+										Ipv6Address:   addrS("2001:db8:2::3:1"),
+										IsPrimaryIpv6: addrB(true),
+									},
+								},
+								SubnetId: addrS("azid-1"),
+							},
+							// interface without primary IPv6, index 0
+							&ec2.InstanceNetworkInterface{
+								Attachment: &ec2.InstanceNetworkInterfaceAttachment{
+									DeviceIndex: addrI(0),
+								},
+								Ipv6Addresses: []*ec2.InstanceIpv6Address{},
+								SubnetId:      addrS("azid-3"),
+							},
+						},
+					},
+				},
+			},
+			expected: []*targetgroup.Group{
+				&targetgroup.Group{
+					Source: "region-ipv6",
+					Targets: []model.LabelSet{
+						model.LabelSet{
+							"__address__":                       model.LabelValue("9.10.11.12:4242"),
+							"__meta_ec2_ami":                    model.LabelValue("ami-ipv6"),
+							"__meta_ec2_availability_zone":      model.LabelValue("azname-b"),
+							"__meta_ec2_availability_zone_id":   model.LabelValue("azid-2"),
+							"__meta_ec2_instance_id":            model.LabelValue("instance-id-ipv6"),
+							"__meta_ec2_instance_state":         model.LabelValue("running"),
+							"__meta_ec2_instance_type":          model.LabelValue("instance-type-ipv6"),
+							"__meta_ec2_ipv6_addresses":         model.LabelValue(",2001:db8:2::1:1,2001:db8:2::2:1,2001:db8:2::2:2,2001:db8:2::3:1,"),
+							"__meta_ec2_owner_id":               model.LabelValue(""),
+							"__meta_ec2_primary_ipv6_addresses": model.LabelValue(",,2001:db8:2::2:2,,2001:db8:2::3:1,"),
+							"__meta_ec2_primary_subnet_id":      model.LabelValue("azid-2"),
+							"__meta_ec2_private_ip":             model.LabelValue("9.10.11.12"),
+							"__meta_ec2_region":                 model.LabelValue("region-ipv6"),
+							"__meta_ec2_subnet_id":              model.LabelValue(",azid-2,azid-1,azid-3,"),
+							"__meta_ec2_vpc_id":                 model.LabelValue("vpc-ipv6"),
+						},
+					},
+				},
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			// generate basic availability zone test data
-			client.ec2Data = ec2DataStore{}
-			generateTestAzData(&client.ec2Data)
+			client := newMockEC2Client(tt.ec2Data)
 
 			d := &EC2Discovery{
 				ec2: client,
 				cfg: &EC2SDConfig{
-					Port:   randNumber(1024, 65535),
+					Port:   4242,
 					Region: client.ec2Data.region,
 				},
 			}
 
-			expected := tt.generator(d)
-
 			g, err := d.refresh(ctx)
 			require.NoError(t, err)
-			require.Equal(t, expected, g)
+			require.Equal(t, tt.expected, g)
 		})
 	}
 }
@@ -432,9 +387,9 @@ type mockEC2Client struct {
 	ec2Data ec2DataStore
 }
 
-func newMockEC2Client() *mockEC2Client {
+func newMockEC2Client(ec2Data *ec2DataStore) *mockEC2Client {
 	client := mockEC2Client{
-		ec2Data: ec2DataStore{},
+		ec2Data: *ec2Data,
 	}
 	return &client
 }

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -1,0 +1,106 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// "helper" functions
+const chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = chars[rand.Intn(len(chars))]
+	}
+
+	return string(b)
+}
+
+// struct for test data
+type EC2Data struct {
+	azNames  []string
+	azIDs    []string
+	azToAZID map[string]string
+}
+
+var ec2Data EC2Data
+
+// prepare test data
+func init() {
+	rand.Seed(time.Now().UnixNano())
+
+	// availability zone information
+	azCount := rand.Intn(3) + 2
+	ec2Data.azNames = make([]string, azCount)
+	ec2Data.azIDs = make([]string, azCount)
+	ec2Data.azToAZID = make(map[string]string, azCount)
+
+	for i := 0; i < azCount; i++ {
+		ec2Data.azNames[i] = RandString(5)
+		ec2Data.azIDs[i] = RandString(6)
+		ec2Data.azToAZID[ec2Data.azNames[i]] = ec2Data.azIDs[i]
+	}
+}
+
+// tests
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func TestRefreshAZIDs(t *testing.T) {
+	ctx := context.Background()
+	client := &mockEC2Client{}
+
+	d := &EC2Discovery{
+		ec2: client,
+	}
+
+	err := d.refreshAZIDs(ctx)
+	if err != nil {
+		t.Fatalf("refreshAZIDs returned with an error [%v]\n", err)
+	}
+	require.Equal(t, ec2Data.azToAZID, d.azToAZID)
+}
+
+// EC2 client mock
+type mockEC2Client struct {
+	ec2iface.EC2API
+}
+
+func (m *mockEC2Client) DescribeAvailabilityZonesWithContext(ctx aws.Context, input *ec2.DescribeAvailabilityZonesInput, opts ...request.Option) (*ec2.DescribeAvailabilityZonesOutput, error) {
+	azs := make([]*ec2.AvailabilityZone, len(ec2Data.azNames))
+
+	for i := range ec2Data.azNames {
+		azs[i] = &ec2.AvailabilityZone{
+			ZoneName: &ec2Data.azNames[i],
+			ZoneId:   &ec2Data.azIDs[i],
+		}
+	}
+
+	return &ec2.DescribeAvailabilityZonesOutput{
+		AvailabilityZones: azs,
+	}, nil
+}

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -292,8 +292,8 @@ func TestRefreshIpv4(t *testing.T) {
 	enis[1] = &ec2.InstanceNetworkInterface{}
 	enis[1].SetIpv6Addresses([]*ec2.InstanceIpv6Address{})
 	// azIdx + 1 modulo #azs
-	secondAzId := (azIdx + 1) % len(ec2Data.azIDs)
-	enis[1].SetSubnetId(ec2Data.azIDs[secondAzId])
+	secondAzID := (azIdx + 1) % len(ec2Data.azIDs)
+	enis[1].SetSubnetId(ec2Data.azIDs[secondAzID])
 
 	// interface in another subnet
 	enis[2] = &ec2.InstanceNetworkInterface{}
@@ -309,7 +309,7 @@ func TestRefreshIpv4(t *testing.T) {
 	labels := GenerateExpectedLabels(azIdx, d.cfg.Port)
 
 	labels["__meta_ec2_primary_subnet_id"] = model.LabelValue(*ec2Data.instances[0].SubnetId)
-	labels["__meta_ec2_subnet_id"] = model.LabelValue(fmt.Sprintf(",%s,%s,", ec2Data.azIDs[azIdx], ec2Data.azIDs[secondAzId]))
+	labels["__meta_ec2_subnet_id"] = model.LabelValue(fmt.Sprintf(",%s,%s,", ec2Data.azIDs[azIdx], ec2Data.azIDs[secondAzID]))
 	labels["__meta_ec2_vpc_id"] = model.LabelValue(*ec2Data.instances[0].VpcId)
 
 	expected := make([]*targetgroup.Group, 1)

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -83,7 +83,7 @@ type ec2DataStore struct {
 }
 
 // Generate test data.
-func GenerateTestAzData(ec2Data *ec2DataStore) {
+func generateTestAzData(ec2Data *ec2DataStore) {
 	// region information
 	ec2Data.region = fmt.Sprintf("region-%s", randString(4))
 
@@ -103,7 +103,7 @@ func GenerateTestAzData(ec2Data *ec2DataStore) {
 	ec2Data.ownerID = fmt.Sprintf("ownerid-%s", randString(5))
 }
 
-func GenerateTestInstanceData(ec2Data *ec2DataStore) int {
+func generateTestInstanceData(ec2Data *ec2DataStore) int {
 	// without VPC configuration, just the "basics"
 	azIdx := randNumber(0, len(ec2Data.azNames))
 
@@ -142,7 +142,7 @@ func GenerateTestInstanceData(ec2Data *ec2DataStore) int {
 	return azIdx
 }
 
-func GenerateExpectedLabels(ec2Data *ec2DataStore, azIdx, port int) model.LabelSet {
+func generateExpectedLabels(ec2Data *ec2DataStore, azIdx, port int) model.LabelSet {
 	labels := model.LabelSet{
 		"__address__":                     model.LabelValue(fmt.Sprintf("%s:%d", *ec2Data.instances[0].PrivateIpAddress, port)),
 		"__meta_ec2_ami":                  model.LabelValue(*ec2Data.instances[0].ImageId),
@@ -180,7 +180,7 @@ func TestRefreshAZIDs(t *testing.T) {
 	client := newMockEC2Client()
 	ec2Data := &client.ec2Data
 
-	GenerateTestAzData(ec2Data)
+	generateTestAzData(ec2Data)
 
 	d := &EC2Discovery{
 		ec2: client,
@@ -250,13 +250,13 @@ func generateRefreshNoPrivateIP(d *EC2Discovery) []*targetgroup.Group {
 func generateRefreshNoVpc(d *EC2Discovery) []*targetgroup.Group {
 	ec2Data := &d.ec2.(*mockEC2Client).ec2Data
 
-	azIdx := GenerateTestInstanceData(ec2Data)
+	azIdx := generateTestInstanceData(ec2Data)
 
 	expected := make([]*targetgroup.Group, 1)
 	expected[0] = &targetgroup.Group{
 		Source: ec2Data.region,
 	}
-	expected[0].Targets = append(expected[0].Targets, GenerateExpectedLabels(ec2Data, azIdx, d.cfg.Port))
+	expected[0].Targets = append(expected[0].Targets, generateExpectedLabels(ec2Data, azIdx, d.cfg.Port))
 
 	return expected
 }
@@ -264,7 +264,7 @@ func generateRefreshNoVpc(d *EC2Discovery) []*targetgroup.Group {
 func generateRefreshIpv4(d *EC2Discovery) []*targetgroup.Group {
 	ec2Data := &d.ec2.(*mockEC2Client).ec2Data
 
-	azIdx := GenerateTestInstanceData(ec2Data)
+	azIdx := generateTestInstanceData(ec2Data)
 
 	ec2Data.instances[0].SetSubnetId(ec2Data.azIDs[azIdx])
 	ec2Data.instances[0].SetVpcId(fmt.Sprintf("vpc-%s", randString(8)))
@@ -294,7 +294,7 @@ func generateRefreshIpv4(d *EC2Discovery) []*targetgroup.Group {
 
 	ec2Data.instances[0].SetNetworkInterfaces(enis)
 
-	labels := GenerateExpectedLabels(ec2Data, azIdx, d.cfg.Port)
+	labels := generateExpectedLabels(ec2Data, azIdx, d.cfg.Port)
 
 	labels["__meta_ec2_primary_subnet_id"] = model.LabelValue(*ec2Data.instances[0].SubnetId)
 	labels["__meta_ec2_subnet_id"] = model.LabelValue(fmt.Sprintf(",%s,%s,", ec2Data.azIDs[azIdx], ec2Data.azIDs[secondAzID]))
@@ -312,7 +312,7 @@ func generateRefreshIpv4(d *EC2Discovery) []*targetgroup.Group {
 func generateRefreshIpv6(d *EC2Discovery) []*targetgroup.Group {
 	ec2Data := &d.ec2.(*mockEC2Client).ec2Data
 
-	azIdx := GenerateTestInstanceData(ec2Data)
+	azIdx := generateTestInstanceData(ec2Data)
 
 	ec2Data.instances[0].SetSubnetId(ec2Data.azIDs[azIdx])
 	ec2Data.instances[0].SetVpcId(fmt.Sprintf("vpc-%s", randString(8)))
@@ -377,7 +377,7 @@ func generateRefreshIpv6(d *EC2Discovery) []*targetgroup.Group {
 
 	ec2Data.instances[0].SetNetworkInterfaces(enis)
 
-	labels := GenerateExpectedLabels(ec2Data, azIdx, d.cfg.Port)
+	labels := generateExpectedLabels(ec2Data, azIdx, d.cfg.Port)
 
 	labels["__meta_ec2_ipv6_addresses"] = model.LabelValue(
 		fmt.Sprintf(",%s,%s,%s,%s,",
@@ -412,7 +412,7 @@ func TestRefresh(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// generate basic availability zone test data
 			client.ec2Data = ec2DataStore{}
-			GenerateTestAzData(&client.ec2Data)
+			generateTestAzData(&client.ec2Data)
 
 			d := &EC2Discovery{
 				ec2: client,

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -425,8 +425,8 @@ func TestRefresh(t *testing.T) {
 			expected := tt.generator(d)
 
 			g, err := d.refresh(ctx)
-			require.Equal(t, expected, g)
 			require.NoError(t, err)
+			require.Equal(t, expected, g)
 		})
 	}
 }


### PR DESCRIPTION
In it's current form this is a very minimalistic implementation of the unit test "framework" for the aws discovery. It unit tests a very short function only which makes only one call to the AWS API. So it is a good demo and people can check the logic and the implementation and possibly start a discussion.

If it passes the scrutiny then I - or any other volunteer - can implement the other, more useful tests in this or in a different PR.

Please note that my Golang knowledge is very-very basic so there could be basic issues in the code itself. I am happy to learn and improve my skills on this domain.

Related to #14310.