### PR TITLE
Make rules Manager Update method  no-op after Close

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -190,7 +190,7 @@ func (m *Manager) Stop() {
 
 // Update the rule manager's state as the config requires. If
 // loading the new rules failed the old rule set is restored.
-// This method will no-op in case the manager is already stopped
+// This method will no-op in case the manager is already stopped.
 func (m *Manager) Update(interval time.Duration, files []string, externalLabels labels.Labels, externalURL string, groupEvalIterationFunc GroupEvalIterationFunc) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -190,9 +190,17 @@ func (m *Manager) Stop() {
 
 // Update the rule manager's state as the config requires. If
 // loading the new rules failed the old rule set is restored.
+// This method will no-op in case the manager is already stopped
 func (m *Manager) Update(interval time.Duration, files []string, externalLabels labels.Labels, externalURL string, groupEvalIterationFunc GroupEvalIterationFunc) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
+
+	// We cannot update a stopped manager
+	select {
+	case <-m.done:
+		return nil
+	default:
+	}
 
 	groups, errs := m.LoadGroups(interval, externalLabels, externalURL, groupEvalIterationFunc, files...)
 

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -2099,6 +2099,23 @@ func TestBoundedRuleEvalConcurrency(t *testing.T) {
 	require.EqualValues(t, maxInflight.Load(), int32(maxConcurrency)+int32(groupCount))
 }
 
+func TestUpdateWhenStopped(t *testing.T) {
+	files := []string{"fixtures/rules.yaml"}
+	ruleManager := NewManager(&ManagerOptions{
+		Context: context.Background(),
+		Logger:  log.NewNopLogger(),
+	})
+	ruleManager.start()
+	err := ruleManager.Update(10*time.Second, files, labels.EmptyLabels(), "", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, ruleManager.groups)
+
+	ruleManager.Stop()
+	// Updates following a stop are no-op
+	err = ruleManager.Update(10*time.Second, []string{}, labels.EmptyLabels(), "", nil)
+	require.NoError(t, err)
+}
+
 const artificialDelay = 250 * time.Millisecond
 
 func optsFactory(storage storage.Storage, maxInflight, inflightQueries *atomic.Int32, maxConcurrent int64) *ManagerOptions {

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -2111,7 +2111,7 @@ func TestUpdateWhenStopped(t *testing.T) {
 	require.NotEmpty(t, ruleManager.groups)
 
 	ruleManager.Stop()
-	// Updates following a stop are no-op
+	// Updates following a stop are no-op.
 	err = ruleManager.Update(10*time.Second, []string{}, labels.EmptyLabels(), "", nil)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Fixes #14146

This is an alternative approach to PR #14175

I considered @machine424's initial [suggestion](https://github.com/prometheus/prometheus/pull/14175#issuecomment-2177823903) to set `m.groups` to empty slice. However in case `Update` is called after `Close` we would end up with new rule groups running and that cannot be stopped using `Stop` since it is not possible to call `Stop` twice. Actually the same thing happens with #14175 . The approach in this PR makes for a cleaner shutdown: no dangling go-routines that are stopped in an unpredictable way.

As @roidelapluie mentioned, we don't have any case were we restart a stopped ruler, so I think this approach is acceptable.

Credits to @machine424 for providing the unit tests.

_____
PS:
Another approach that I also considered, but that I don't think it is worth implementing is to make `Update` after `Close` return an error, (i.e.: make it illegal), but that would not solve the problem of the race condition during shutdown because it would produce misleading error messages in case there is a reload after SIGTERM. 
We would need to either:
 * Avoid calling `Update` during reload in case the manager is already closed by adding a new method to it `IsClosed` and a mutex that controls the access to the manager.
 * Implement error types for the `Update` method that the reloader could use to distinguish between real errors and expected errors.