### PR TITLE
OTLP: Document histogram conversion methods / clean up code a bit

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/helper.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper.go
@@ -182,12 +182,13 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, externa
 		if i+1 >= len(extras) {
 			break
 		}
-		_, found := l[extras[i]]
+
+		name := extras[i]
+		_, found := l[name]
 		if found && logOnOverwrite {
-			log.Println("label " + extras[i] + " is overwritten. Check if Prometheus reserved labels are used.")
+			log.Println("label " + name + " is overwritten. Check if Prometheus reserved labels are used.")
 		}
 		// internal labels should be maintained
-		name := extras[i]
 		if !(len(name) > 4 && name[:2] == "__" && name[len(name)-2:] == "__") {
 			name = prometheustranslator.NormalizeLabel(name)
 		}

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper.go
@@ -220,6 +220,13 @@ func isValidAggregationTemporality(metric pmetric.Metric) bool {
 	return false
 }
 
+// addHistogramDataPoints adds OTel histogram data points to the corresponding Prometheus time series
+// as classical histogram samples.
+//
+// Note that we can't convert to native histograms, since these have exponential buckets and don't line up
+// with the user defined bucket boundaries of non-exponential OTel histograms.
+// However, work is under way to resolve this shortcoming through a feature called native histograms custom buckets:
+// https://github.com/prometheus/prometheus/issues/13485.
 func (c *PrometheusConverter) addHistogramDataPoints(dataPoints pmetric.HistogramDataPointSlice,
 	resource pcommon.Resource, settings Settings, baseName string) {
 	for x := 0; x < dataPoints.Len(); x++ {

--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
@@ -30,6 +30,8 @@ import (
 
 const defaultZeroThreshold = 1e-128
 
+// addExponentialHistogramDataPoints adds OTel exponential histogram data points to the corresponding time series
+// as native histogram samples.
 func (c *PrometheusConverter) addExponentialHistogramDataPoints(dataPoints pmetric.ExponentialHistogramDataPointSlice,
 	resource pcommon.Resource, settings Settings, promName string) error {
 	for x := 0; x < dataPoints.Len(); x++ {

--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
@@ -31,9 +31,15 @@ import (
 const defaultZeroThreshold = 1e-128
 
 func (c *PrometheusConverter) addExponentialHistogramDataPoints(dataPoints pmetric.ExponentialHistogramDataPointSlice,
-	resource pcommon.Resource, settings Settings, baseName string) error {
+	resource pcommon.Resource, settings Settings, promName string) error {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
+
+		histogram, err := exponentialToNativeHistogram(pt)
+		if err != nil {
+			return err
+		}
+
 		lbls := createAttributes(
 			resource,
 			pt.Attributes(),
@@ -41,14 +47,9 @@ func (c *PrometheusConverter) addExponentialHistogramDataPoints(dataPoints pmetr
 			nil,
 			true,
 			model.MetricNameLabel,
-			baseName,
+			promName,
 		)
 		ts, _ := c.getOrCreateTimeSeries(lbls)
-
-		histogram, err := exponentialToNativeHistogram(pt)
-		if err != nil {
-			return err
-		}
 		ts.Histograms = append(ts.Histograms, histogram)
 
 		exemplars := getPromExemplars[pmetric.ExponentialHistogramDataPoint](pt)
@@ -58,7 +59,7 @@ func (c *PrometheusConverter) addExponentialHistogramDataPoints(dataPoints pmetr
 	return nil
 }
 
-// exponentialToNativeHistogram  translates OTel Exponential Histogram data point
+// exponentialToNativeHistogram translates OTel Exponential Histogram data point
 // to Prometheus Native Histogram.
 func exponentialToNativeHistogram(p pmetric.ExponentialHistogramDataPoint) (prompb.Histogram, error) {
 	scale := p.Scale()


### PR DESCRIPTION
Document OTLP histogram conversion methods, including why non-exponential OTel histograms are converted to classical Prometheus histograms as opposed to native ones. Also clean up OTLP code slightly.