### PR TITLE
[ENHANCEMENT] Optimize regexps with multiple prefixes

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -787,13 +787,16 @@ func (m *equalMultiStringSliceMatcher) Matches(s string) bool {
 	return false
 }
 
-// equalMultiStringMapMatcher matches a string exactly against a map of valid values.
+// equalMultiStringMapMatcher matches a string exactly against a map of valid values
+// or against a set of prefix matchers.
 type equalMultiStringMapMatcher struct {
 	// values contains values to match a string against. If the matching is case insensitive,
 	// the values here must be lowercase.
-	values   map[string]struct{}
+	values map[string]struct{}
+	// prefixes maps strings, all of length minPrefixLen, to sets of matchers to check the rest of the string.
+	// If the matching is case insensitive, prefixes are all lowercase.
 	prefixes map[string][]*literalPrefixStringMatcher
-
+	// minPrefixLen can be zero, meaning there are no prefix matchers.
 	minPrefixLen  int
 	caseSensitive bool
 }
@@ -807,6 +810,9 @@ func (m *equalMultiStringMapMatcher) add(s string) {
 }
 
 func (m *equalMultiStringMapMatcher) addPrefix(p *literalPrefixStringMatcher) {
+	if m.minPrefixLen == 0 {
+		panic("addPrefix called when no prefix length defined")
+	}
 	s := p.prefix[:m.minPrefixLen]
 	if !m.caseSensitive {
 		s = strings.ToLower(s)

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -811,7 +811,7 @@ func TestNewEqualMultiStringMatcher(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values))
+			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), 0, 0)
 			for _, v := range testData.values {
 				matcher.add(v)
 			}
@@ -864,7 +864,7 @@ func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values))
+			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), 0, 0)
 			for _, v := range testData.values {
 				matcher.add(v)
 			}
@@ -890,7 +890,7 @@ func TestFindEqualStringMatchers(t *testing.T) {
 		ok = findEqualStringMatchers(input, func(matcher *equalStringMatcher) bool {
 			matches = append(matches, match{matcher.s, matcher.caseSensitive})
 			return true
-		})
+		}, nil)
 		return
 	}
 
@@ -1204,10 +1204,16 @@ func visitStringMatcher(matcher StringMatcher, callback func(matcher StringMatch
 		}
 
 	// No nested matchers for the following ones.
+	case *equalMultiStringMapMatcher:
+		for _, prefixes := range casted.prefixes {
+			for _, matcher := range prefixes {
+				visitStringMatcher(matcher, callback)
+			}
+		}
+
 	case emptyStringMatcher:
 	case *equalStringMatcher:
 	case *equalMultiStringSliceMatcher:
-	case *equalMultiStringMapMatcher:
 	case anyStringWithoutNewlineMatcher:
 	case *anyNonEmptyStringMatcher:
 	case trueMatcher:

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -71,6 +71,8 @@ var (
 		// A long case insensitive alternation.
 		"(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKMimS|IecrXtPa|seTckYqt|NxnyHkgB|fIDlOgKb|UhlWIygH|OtNoJxHG|cUTkFVIV|mTgFIHjr|jQkoIDtE|PPMKxRXl|AwMfwVkQ|CQyMrTQJ|BzrqxVSi|nTpcWuhF|PertdywG|ZZDgCtXN|WWdDPyyE|uVtNQsKk|BdeCHvPZ|wshRnFlH|aOUIitIp|RxZeCdXT|CFZMslCj|AVBZRDxl|IzIGCnhw|ythYuWiz|oztXVXhl|VbLkwqQx|qvaUgyVC|VawUjPWC|ecloYJuj|boCLTdSU|uPrKeAZx|hrMWLWBq|JOnUNHRM|rYnujkPq|dDEdZhIj|DRrfvugG|yEGfDxVV|YMYdJWuP|PHUQZNWM|AmKNrLis|zTxndVfn|FPsHoJnc|EIulZTua|KlAPhdzg|ScHJJCLt|NtTfMzME|eMCwuFdo|SEpJVJbR|cdhXZeCx|sAVtBwRh|kVFEVcMI|jzJrxraA|tGLHTell|NNWoeSaw|DcOKSetX|UXZAJyka|THpMphDP|rizheevl|kDCBRidd|pCZZRqyu|pSygkitl|SwZGkAaW|wILOrfNX|QkwVOerj|kHOMxPDr|EwOVycJv|AJvtzQFS|yEOjKYYB|LizIINLL|JBRSsfcG|YPiUqqNl|IsdEbvee|MjEpGcBm|OxXZVgEQ|xClXGuxa|UzRCGFEb|buJbvfvA|IPZQxRet|oFYShsMc|oBHffuHO|bzzKrcBR|KAjzrGCl|IPUsAVls|OGMUMbIU|gyDccHuR|bjlalnDd|ZLWjeMna|fdsuIlxQ|dVXtiomV|XxedTjNg|XWMHlNoA|nnyqArQX|opfkWGhb|wYtnhdYb))",
 		"(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BBBBBBBBBBBBBBBBBBBBBBBB|cccccccccccccccccccccccC|ſſſſſſſſſſſſſſſſſſſſſſſſS|SSSSSSSSSSSSSSSSSSSSSSSSſ))",
+		// A short case insensitive alternation where each entry ends with ".*".
+		"(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuSoAl.*))",
 		// A long case insensitive alternation where each entry ends with ".*".
 		"(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuSoAl.*|qbvKMimS.*|IecrXtPa.*|seTckYqt.*|NxnyHkgB.*|fIDlOgKb.*|UhlWIygH.*|OtNoJxHG.*|cUTkFVIV.*|mTgFIHjr.*|jQkoIDtE.*|PPMKxRXl.*|AwMfwVkQ.*|CQyMrTQJ.*|BzrqxVSi.*|nTpcWuhF.*|PertdywG.*|ZZDgCtXN.*|WWdDPyyE.*|uVtNQsKk.*|BdeCHvPZ.*|wshRnFlH.*|aOUIitIp.*|RxZeCdXT.*|CFZMslCj.*|AVBZRDxl.*|IzIGCnhw.*|ythYuWiz.*|oztXVXhl.*|VbLkwqQx.*|qvaUgyVC.*|VawUjPWC.*|ecloYJuj.*|boCLTdSU.*|uPrKeAZx.*|hrMWLWBq.*|JOnUNHRM.*|rYnujkPq.*|dDEdZhIj.*|DRrfvugG.*|yEGfDxVV.*|YMYdJWuP.*|PHUQZNWM.*|AmKNrLis.*|zTxndVfn.*|FPsHoJnc.*|EIulZTua.*|KlAPhdzg.*|ScHJJCLt.*|NtTfMzME.*|eMCwuFdo.*|SEpJVJbR.*|cdhXZeCx.*|sAVtBwRh.*|kVFEVcMI.*|jzJrxraA.*|tGLHTell.*|NNWoeSaw.*|DcOKSetX.*|UXZAJyka.*|THpMphDP.*|rizheevl.*|kDCBRidd.*|pCZZRqyu.*|pSygkitl.*|SwZGkAaW.*|wILOrfNX.*|QkwVOerj.*|kHOMxPDr.*|EwOVycJv.*|AJvtzQFS.*|yEOjKYYB.*|LizIINLL.*|JBRSsfcG.*|YPiUqqNl.*|IsdEbvee.*|MjEpGcBm.*|OxXZVgEQ.*|xClXGuxa.*|UzRCGFEb.*|buJbvfvA.*|IPZQxRet.*|oFYShsMc.*|oBHffuHO.*|bzzKrcBR.*|KAjzrGCl.*|IPUsAVls.*|OGMUMbIU.*|gyDccHuR.*|bjlalnDd.*|ZLWjeMna.*|fdsuIlxQ.*|dVXtiomV.*|XxedTjNg.*|XWMHlNoA.*|nnyqArQX.*|opfkWGhb.*|wYtnhdYb.*))",
 		// A long case insensitive alternation where each entry starts with ".*".
@@ -686,7 +688,15 @@ func randStrings(randGenerator *rand.Rand, many, length int) []string {
 	return out
 }
 
-func TestOptimizeEqualStringMatchers(t *testing.T) {
+func randStringsWithSuffix(randGenerator *rand.Rand, many, length int, suffix string) []string {
+	out := randStrings(randGenerator, many, length)
+	for i := range out {
+		out[i] += suffix
+	}
+	return out
+}
+
+func TestOptimizeEqualOrPrefixStringMatchers(t *testing.T) {
 	tests := map[string]struct {
 		input                 StringMatcher
 		expectedValues        []string
@@ -767,7 +777,7 @@ func TestOptimizeEqualStringMatchers(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			actualMatcher := optimizeEqualStringMatchers(testData.input, 0)
+			actualMatcher := optimizeEqualOrPrefixStringMatchers(testData.input, 0)
 
 			if testData.expectedValues == nil {
 				require.IsType(t, testData.input, actualMatcher)
@@ -782,10 +792,12 @@ func TestOptimizeEqualStringMatchers(t *testing.T) {
 
 func TestNewEqualMultiStringMatcher(t *testing.T) {
 	tests := map[string]struct {
-		values             []string
-		caseSensitive      bool
-		expectedValuesMap  map[string]struct{}
-		expectedValuesList []string
+		values                []string
+		caseSensitivePrefixes []*literalPrefixSensitiveStringMatcher
+		caseSensitive         bool
+		expectedValuesMap     map[string]struct{}
+		expectedPrefixesMap   map[string][]StringMatcher
+		expectedValuesList    []string
 	}{
 		"few case sensitive values": {
 			values:             []string{"a", "B"},
@@ -797,27 +809,47 @@ func TestNewEqualMultiStringMatcher(t *testing.T) {
 			caseSensitive:      false,
 			expectedValuesList: []string{"a", "B"},
 		},
+		"few case sensitive values and prefixes": {
+			values:                []string{"a"},
+			caseSensitivePrefixes: []*literalPrefixSensitiveStringMatcher{{prefix: "B", right: anyStringWithoutNewlineMatcher{}}},
+			caseSensitive:         true,
+			expectedValuesMap:     map[string]struct{}{"a": {}},
+			expectedPrefixesMap:   map[string][]StringMatcher{"B": {&literalPrefixSensitiveStringMatcher{prefix: "B", right: anyStringWithoutNewlineMatcher{}}}},
+		},
 		"many case sensitive values": {
-			values:            []string{"a", "B", "c", "D", "e", "F", "g", "H", "i", "L", "m", "N", "o", "P", "q", "r"},
-			caseSensitive:     true,
-			expectedValuesMap: map[string]struct{}{"a": {}, "B": {}, "c": {}, "D": {}, "e": {}, "F": {}, "g": {}, "H": {}, "i": {}, "L": {}, "m": {}, "N": {}, "o": {}, "P": {}, "q": {}, "r": {}},
+			values:              []string{"a", "B", "c", "D", "e", "F", "g", "H", "i", "L", "m", "N", "o", "P", "q", "r"},
+			caseSensitive:       true,
+			expectedValuesMap:   map[string]struct{}{"a": {}, "B": {}, "c": {}, "D": {}, "e": {}, "F": {}, "g": {}, "H": {}, "i": {}, "L": {}, "m": {}, "N": {}, "o": {}, "P": {}, "q": {}, "r": {}},
+			expectedPrefixesMap: map[string][]StringMatcher{},
 		},
 		"many case insensitive values": {
-			values:            []string{"a", "B", "c", "D", "e", "F", "g", "H", "i", "L", "m", "N", "o", "P", "q", "r"},
-			caseSensitive:     false,
-			expectedValuesMap: map[string]struct{}{"a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {}, "g": {}, "h": {}, "i": {}, "l": {}, "m": {}, "n": {}, "o": {}, "p": {}, "q": {}, "r": {}},
+			values:              []string{"a", "B", "c", "D", "e", "F", "g", "H", "i", "L", "m", "N", "o", "P", "q", "r"},
+			caseSensitive:       false,
+			expectedValuesMap:   map[string]struct{}{"a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {}, "g": {}, "h": {}, "i": {}, "l": {}, "m": {}, "n": {}, "o": {}, "p": {}, "q": {}, "r": {}},
+			expectedPrefixesMap: map[string][]StringMatcher{},
 		},
 	}
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), 0, 0)
+			// To keep this test simple, we always assume a min prefix length of 1.
+			minPrefixLength := 0
+			if len(testData.caseSensitivePrefixes) > 0 {
+				minPrefixLength = 1
+			}
+
+			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), len(testData.caseSensitivePrefixes), minPrefixLength)
 			for _, v := range testData.values {
 				matcher.add(v)
 			}
-			if testData.expectedValuesMap != nil {
+			for _, p := range testData.caseSensitivePrefixes {
+				matcher.addPrefix(p.prefix, true, p)
+			}
+
+			if testData.expectedValuesMap != nil || testData.expectedPrefixesMap != nil {
 				require.IsType(t, &equalMultiStringMapMatcher{}, matcher)
 				require.Equal(t, testData.expectedValuesMap, matcher.(*equalMultiStringMapMatcher).values)
+				require.Equal(t, testData.expectedPrefixesMap, matcher.(*equalMultiStringMapMatcher).prefixes)
 				require.Equal(t, testData.caseSensitive, matcher.(*equalMultiStringMapMatcher).caseSensitive)
 			}
 			if testData.expectedValuesList != nil {
@@ -829,12 +861,36 @@ func TestNewEqualMultiStringMatcher(t *testing.T) {
 	}
 }
 
+func TestEqualMultiStringMapMatcher_addPrefix(t *testing.T) {
+	t.Run("should panic if the matcher is case sensitive but the prefix is not case sensitive", func(t *testing.T) {
+		matcher := newEqualMultiStringMatcher(true, 0, 1, 1)
+
+		require.Panics(t, func() {
+			matcher.addPrefix("a", false, &literalPrefixInsensitiveStringMatcher{
+				prefix: "a",
+			})
+		})
+	})
+
+	t.Run("should panic if the matcher is not case sensitive but the prefix is case sensitive", func(t *testing.T) {
+		matcher := newEqualMultiStringMatcher(false, 0, 1, 1)
+
+		require.Panics(t, func() {
+			matcher.addPrefix("a", true, &literalPrefixSensitiveStringMatcher{
+				prefix: "a",
+			})
+		})
+	})
+}
+
 func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 	tests := map[string]struct {
-		values             []string
-		caseSensitive      bool
-		expectedMatches    []string
-		expectedNotMatches []string
+		values                  []string
+		caseSensitivePrefixes   []*literalPrefixSensitiveStringMatcher
+		caseInsensitivePrefixes []*literalPrefixInsensitiveStringMatcher
+		caseSensitive           bool
+		expectedMatches         []string
+		expectedNotMatches      []string
 	}{
 		"few case sensitive values": {
 			values:             []string{"a", "B"},
@@ -848,6 +904,24 @@ func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 			expectedMatches:    []string{"a", "A", "b", "B"},
 			expectedNotMatches: []string{"c", "C"},
 		},
+		"few case sensitive prefixes": {
+			caseSensitivePrefixes: []*literalPrefixSensitiveStringMatcher{
+				{prefix: "a", right: anyStringWithoutNewlineMatcher{}},
+				{prefix: "B", right: anyStringWithoutNewlineMatcher{}},
+			},
+			caseSensitive:      true,
+			expectedMatches:    []string{"a", "aX", "B", "BX"},
+			expectedNotMatches: []string{"A", "b"},
+		},
+		"few case insensitive prefixes": {
+			caseInsensitivePrefixes: []*literalPrefixInsensitiveStringMatcher{
+				{prefix: "a", right: anyStringWithoutNewlineMatcher{}},
+				{prefix: "B", right: anyStringWithoutNewlineMatcher{}},
+			},
+			caseSensitive:      false,
+			expectedMatches:    []string{"a", "aX", "A", "AX", "b", "bX", "B", "BX"},
+			expectedNotMatches: []string{"c", "cX", "C", "CX"},
+		},
 		"many case sensitive values": {
 			values:             []string{"a", "B", "c", "D", "e", "F", "g", "H", "i", "L", "m", "N", "o", "P", "q", "r"},
 			caseSensitive:      true,
@@ -860,13 +934,32 @@ func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 			expectedMatches:    []string{"a", "A", "b", "B"},
 			expectedNotMatches: []string{"x", "X"},
 		},
+		"mixed values and prefixes": {
+			values:                []string{"a"},
+			caseSensitivePrefixes: []*literalPrefixSensitiveStringMatcher{{prefix: "B", right: anyStringWithoutNewlineMatcher{}}},
+			caseSensitive:         true,
+			expectedMatches:       []string{"a", "B", "BX"},
+			expectedNotMatches:    []string{"aX", "A", "b", "bX"},
+		},
 	}
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), 0, 0)
+			// To keep this test simple, we always assume a min prefix length of 1.
+			minPrefixLength := 0
+			if len(testData.caseSensitivePrefixes) > 0 || len(testData.caseInsensitivePrefixes) > 0 {
+				minPrefixLength = 1
+			}
+
+			matcher := newEqualMultiStringMatcher(testData.caseSensitive, len(testData.values), len(testData.caseSensitivePrefixes)+len(testData.caseInsensitivePrefixes), minPrefixLength)
 			for _, v := range testData.values {
 				matcher.add(v)
+			}
+			for _, p := range testData.caseSensitivePrefixes {
+				matcher.addPrefix(p.prefix, true, p)
+			}
+			for _, p := range testData.caseInsensitivePrefixes {
+				matcher.addPrefix(p.prefix, false, p)
 			}
 
 			for _, v := range testData.expectedMatches {
@@ -879,29 +972,38 @@ func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 	}
 }
 
-func TestFindEqualStringMatchers(t *testing.T) {
+func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	type match struct {
 		s             string
 		caseSensitive bool
 	}
 
-	// Utility to call findEqualStringMatchers() and collect all callback invocations.
-	findEqualStringMatchersAndCollectMatches := func(input StringMatcher) (matches []match, ok bool) {
-		ok = findEqualStringMatchers(input, func(matcher *equalStringMatcher) bool {
+	// Utility to call findEqualOrPrefixStringMatchers() and collect all callback invocations.
+	findEqualOrPrefixStringMatchersAndCollectMatches := func(input StringMatcher) (matches []match, ok bool) {
+		ok = findEqualOrPrefixStringMatchers(input, func(matcher *equalStringMatcher) bool {
 			matches = append(matches, match{matcher.s, matcher.caseSensitive})
 			return true
-		}, nil)
+		}, func(sensitiveMatcher *literalPrefixSensitiveStringMatcher, insensitiveMatcher *literalPrefixInsensitiveStringMatcher) bool {
+			if sensitiveMatcher != nil {
+				matches = append(matches, match{sensitiveMatcher.prefix, true})
+			}
+			if insensitiveMatcher != nil {
+				matches = append(matches, match{insensitiveMatcher.prefix, false})
+			}
+			return true
+		})
+
 		return
 	}
 
 	t.Run("empty matcher", func(t *testing.T) {
-		actualMatches, actualOk := findEqualStringMatchersAndCollectMatches(emptyStringMatcher{})
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(emptyStringMatcher{})
 		require.False(t, actualOk)
 		require.Empty(t, actualMatches)
 	})
 
 	t.Run("concat of literal matchers (case sensitive)", func(t *testing.T) {
-		actualMatches, actualOk := findEqualStringMatchersAndCollectMatches(
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&equalStringMatcher{s: "test-1", caseSensitive: true},
 				&equalStringMatcher{s: "test-2", caseSensitive: true},
@@ -913,7 +1015,7 @@ func TestFindEqualStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal matchers (case insensitive)", func(t *testing.T) {
-		actualMatches, actualOk := findEqualStringMatchersAndCollectMatches(
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&equalStringMatcher{s: "test-1", caseSensitive: false},
 				&equalStringMatcher{s: "test-2", caseSensitive: false},
@@ -925,7 +1027,7 @@ func TestFindEqualStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal matchers (mixed case)", func(t *testing.T) {
-		actualMatches, actualOk := findEqualStringMatchersAndCollectMatches(
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&equalStringMatcher{s: "test-1", caseSensitive: false},
 				&equalStringMatcher{s: "test-2", caseSensitive: true},
@@ -935,11 +1037,59 @@ func TestFindEqualStringMatchers(t *testing.T) {
 		require.True(t, actualOk)
 		require.Equal(t, []match{{"test-1", false}, {"test-2", true}}, actualMatches)
 	})
+
+	t.Run("concat of literal prefix matchers (case sensitive)", func(t *testing.T) {
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
+			orStringMatcher{
+				&literalPrefixSensitiveStringMatcher{prefix: "test-1"},
+				&literalPrefixSensitiveStringMatcher{prefix: "test-2"},
+			},
+		)
+
+		require.True(t, actualOk)
+		require.Equal(t, []match{{"test-1", true}, {"test-2", true}}, actualMatches)
+	})
+
+	t.Run("concat of literal prefix matchers (case insensitive)", func(t *testing.T) {
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
+			orStringMatcher{
+				&literalPrefixInsensitiveStringMatcher{prefix: "test-1"},
+				&literalPrefixInsensitiveStringMatcher{prefix: "test-2"},
+			},
+		)
+
+		require.True(t, actualOk)
+		require.Equal(t, []match{{"test-1", false}, {"test-2", false}}, actualMatches)
+	})
+
+	t.Run("concat of literal prefix matchers (mixed case)", func(t *testing.T) {
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
+			orStringMatcher{
+				&literalPrefixInsensitiveStringMatcher{prefix: "test-1"},
+				&literalPrefixSensitiveStringMatcher{prefix: "test-2"},
+			},
+		)
+
+		require.True(t, actualOk)
+		require.Equal(t, []match{{"test-1", false}, {"test-2", true}}, actualMatches)
+	})
+
+	t.Run("concat of literal string and prefix matchers (case sensitive)", func(t *testing.T) {
+		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
+			orStringMatcher{
+				&equalStringMatcher{s: "test-1", caseSensitive: true},
+				&literalPrefixSensitiveStringMatcher{prefix: "test-2"},
+			},
+		)
+
+		require.True(t, actualOk)
+		require.Equal(t, []match{{"test-1", true}, {"test-2", true}}, actualMatches)
+	})
 }
 
 // This benchmark is used to find a good threshold to use to apply the optimization
-// done by optimizeEqualStringMatchers().
-func BenchmarkOptimizeEqualStringMatchers(b *testing.B) {
+// done by optimizeEqualOrPrefixStringMatchers().
+func BenchmarkOptimizeEqualOrPrefixStringMatchers(b *testing.B) {
 	randGenerator := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	// Generate variable lengths random texts to match against.
@@ -949,42 +1099,51 @@ func BenchmarkOptimizeEqualStringMatchers(b *testing.B) {
 
 	for numAlternations := 2; numAlternations <= 256; numAlternations *= 2 {
 		for _, caseSensitive := range []bool{true, false} {
-			b.Run(fmt.Sprintf("alternations: %d case sensitive: %t", numAlternations, caseSensitive), func(b *testing.B) {
-				// Generate a regex with the expected number of alternations.
-				re := strings.Join(randStrings(randGenerator, numAlternations, 10), "|")
-				if !caseSensitive {
-					re = "(?i:(" + re + "))"
-				}
-
-				parsed, err := syntax.Parse(re, syntax.Perl)
-				require.NoError(b, err)
-
-				unoptimized := stringMatcherFromRegexpInternal(parsed)
-				require.IsType(b, orStringMatcher{}, unoptimized)
-
-				optimized := optimizeEqualStringMatchers(unoptimized, 0)
-				if numAlternations < minEqualMultiStringMatcherMapThreshold {
-					require.IsType(b, &equalMultiStringSliceMatcher{}, optimized)
-				} else {
-					require.IsType(b, &equalMultiStringMapMatcher{}, optimized)
-				}
-
-				b.Run("without optimizeEqualStringMatchers()", func(b *testing.B) {
-					for n := 0; n < b.N; n++ {
-						for _, t := range texts {
-							unoptimized.Matches(t)
-						}
+			for _, prefixMatcher := range []bool{true, false} {
+				b.Run(fmt.Sprintf("alternations: %d case sensitive: %t prefix matcher: %t", numAlternations, caseSensitive, prefixMatcher), func(b *testing.B) {
+					// If the test should run on prefix matchers, we add a wildcard matcher as suffix (prefix will be a literal).
+					suffix := ""
+					if prefixMatcher {
+						suffix = ".*"
 					}
-				})
 
-				b.Run("with optimizeEqualStringMatchers()", func(b *testing.B) {
-					for n := 0; n < b.N; n++ {
-						for _, t := range texts {
-							optimized.Matches(t)
-						}
+					// Generate a regex with the expected number of alternations.
+					re := strings.Join(randStringsWithSuffix(randGenerator, numAlternations, 10, suffix), "|")
+					if !caseSensitive {
+						re = "(?i:(" + re + "))"
 					}
+					b.Logf("regexp: %s", re)
+
+					parsed, err := syntax.Parse(re, syntax.Perl)
+					require.NoError(b, err)
+
+					unoptimized := stringMatcherFromRegexpInternal(parsed)
+					require.IsType(b, orStringMatcher{}, unoptimized)
+
+					optimized := optimizeEqualOrPrefixStringMatchers(unoptimized, 0)
+					if numAlternations < minEqualMultiStringMatcherMapThreshold && !prefixMatcher {
+						require.IsType(b, &equalMultiStringSliceMatcher{}, optimized)
+					} else {
+						require.IsType(b, &equalMultiStringMapMatcher{}, optimized)
+					}
+
+					b.Run("without optimizeEqualOrPrefixStringMatchers()", func(b *testing.B) {
+						for n := 0; n < b.N; n++ {
+							for _, t := range texts {
+								unoptimized.Matches(t)
+							}
+						}
+					})
+
+					b.Run("with optimizeEqualOrPrefixStringMatchers()", func(b *testing.B) {
+						for n := 0; n < b.N; n++ {
+							for _, t := range texts {
+								optimized.Matches(t)
+							}
+						}
+					})
 				})
-			})
+			}
 		}
 	}
 }


### PR DESCRIPTION
Like #13843 but based on top of `main`.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
                                                        │  before.txt   │             after.txt              │
                                                        │    sec/op     │   sec/op     vs base               │
FastRegexMatcher/#00-11                                    34.94n ±  1%   35.65n ± 0%   +2.05% (p=0.002 n=6)
FastRegexMatcher/foo-11                                    36.32n ±  0%   36.06n ± 0%   -0.70% (p=0.004 n=6)
FastRegexMatcher/^foo-11                                   34.24n ±  4%   33.78n ± 2%        ~ (p=0.169 n=6)
FastRegexMatcher/(foo|bar)-11                              47.35n ±  0%   47.14n ± 0%   -0.45% (p=0.002 n=6)
FastRegexMatcher/foo.*-11                                  83.58n ±  0%   83.66n ± 2%        ~ (p=0.145 n=6)
FastRegexMatcher/.*foo-11                                  99.32n ±  0%   99.33n ± 2%        ~ (p=0.310 n=6)
FastRegexMatcher/^.*foo$-11                                99.27n ±  0%   99.30n ± 0%        ~ (p=0.065 n=6)
FastRegexMatcher/^.+foo$-11                                99.60n ±  0%   99.61n ± 0%        ~ (p=0.450 n=6)
FastRegexMatcher/.?-11                                     55.55n ±  0%   55.56n ± 0%        ~ (p=0.314 n=6)
FastRegexMatcher/.*-11                                     66.83n ±  1%   68.41n ± 6%        ~ (p=0.071 n=6)
FastRegexMatcher/.+-11                                     70.67n ±  2%   71.02n ± 5%        ~ (p=0.420 n=6)
FastRegexMatcher/foo.+-11                                  83.88n ±  2%   83.92n ± 0%        ~ (p=0.818 n=6)
FastRegexMatcher/.+foo-11                                  99.61n ±  0%   99.60n ± 0%        ~ (p=0.909 n=6)
FastRegexMatcher/foo_.+-11                                 70.83n ±  0%   70.84n ± 1%        ~ (p=0.545 n=6)
FastRegexMatcher/foo_.*-11                                 70.84n ±  0%   70.84n ± 0%        ~ (p=0.470 n=6)
FastRegexMatcher/.*foo.*-11                                173.3n ±  1%   174.5n ± 7%        ~ (p=0.255 n=6)
FastRegexMatcher/.+foo.+-11                                183.9n ±  1%   183.9n ± 1%        ~ (p=0.779 n=6)
FastRegexMatcher/(?s:.*)-11                                34.35n ±  1%   34.06n ± 0%   -0.82% (p=0.002 n=6)
FastRegexMatcher/(?s:.+)-11                                35.09n ±  1%   34.74n ± 0%   -0.97% (p=0.002 n=6)
FastRegexMatcher/(?s:^.*foo$)-11                           97.00n ±  0%   96.98n ± 0%        ~ (p=0.972 n=6)
FastRegexMatcher/(?i:foo)-11                               63.74n ±  0%   63.47n ± 1%        ~ (p=0.394 n=6)
FastRegexMatcher/(?i:(foo|bar))-11                         150.0n ±  1%   142.8n ± 0%   -4.77% (p=0.002 n=6)
FastRegexMatcher/(?i:(foo1|foo2|bar))-11                   250.0n ±  1%   242.4n ± 0%   -3.00% (p=0.002 n=6)
FastRegexMatcher/^(?i:foo|oo)|(bar)$-11                    636.6n ±  0%   634.4n ± 1%        ~ (p=0.619 n=6)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-11       745.6n ±  4%   757.1n ± 6%        ~ (p=0.132 n=6)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-11            441.1n ±  1%   437.5n ± 0%   -0.79% (p=0.009 n=6)
FastRegexMatcher/^$-11                                     34.54n ±  0%   35.27n ± 0%   +2.14% (p=0.002 n=6)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-11        162.6n ±  3%   166.1n ± 3%        ~ (p=0.818 n=6)
FastRegexMatcher/10\.0\.(1|2)\.+-11                        70.99n ±  0%   70.81n ± 0%   -0.25% (p=0.032 n=6)
FastRegexMatcher/10\.0\.(1|2).+-11                         70.86n ±  0%   70.83n ± 0%        ~ (p=0.450 n=6)
FastRegexMatcher/((fo(bar))|.+foo)-11                      189.3n ±  0%   180.9n ± 0%   -4.44% (p=0.002 n=6)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-11       190.2n ±  6%   194.0n ± 7%        ~ (p=0.310 n=6)
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-11       182.1n ± 12%   186.8n ± 8%        ~ (p=0.394 n=6)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-11       201.8n ±  0%   197.4n ± 1%   -2.16% (p=0.002 n=6)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-11       762.4n ±  3%   771.0n ± 2%        ~ (p=0.180 n=6)
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-11       324.1n ±  0%   317.2n ± 0%   -2.14% (p=0.002 n=6)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-11   4703.0n ±  0%   989.6n ± 1%  -78.96% (p=0.002 n=6)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-11       6.150µ ±  0%   6.268µ ± 1%   +1.93% (p=0.002 n=6)
FastRegexMatcher/fo.?-11                                   83.54n ±  1%   83.29n ± 0%   -0.31% (p=0.043 n=6)
FastRegexMatcher/foo.?-11                                  82.87n ±  0%   82.86n ± 0%        ~ (p=0.574 n=6)
FastRegexMatcher/f.?o-11                                   71.48n ±  0%   71.45n ± 0%        ~ (p=0.937 n=6)
FastRegexMatcher/.*foo.?-11                                183.7n ±  0%   183.0n ± 4%        ~ (p=0.258 n=6)
FastRegexMatcher/.?foo.+-11                                173.9n ±  2%   173.1n ± 7%        ~ (p=0.368 n=6)
FastRegexMatcher/foo.?|bar-11                              133.8n ±  0%   129.5n ± 1%   -3.21% (p=0.002 n=6)
FastRegexMatcher/ſſs-11                                    36.05n ±  0%   36.09n ± 0%        ~ (p=0.193 n=6)
FastRegexMatcher/.*-.*-.*-.*-.*-11                         177.7n ±  2%   177.6n ± 2%        ~ (p=0.584 n=6)
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-11               176.9n ±  2%   178.1n ± 0%   +0.68% (p=0.026 n=6)
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-11       4.027µ ±  6%   4.062µ ± 0%        ~ (p=0.056 n=6)
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-11       3.269µ ±  2%   3.291µ ± 1%        ~ (p=0.063 n=6)
geomean                                                    148.9n         144.0n        -3.25%
```