### PR TITLE
Replace `ListPostings.Seek`'s binary search call by the generic `slices.BinarySearch`

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -754,16 +754,8 @@ func (it *ListPostings) Seek(x storage.SeriesRef) bool {
 		return false
 	}
 
-	// Binary search for the value.
-	i, j := 0, len(it.list)
-	for i < j {
-		h := i + (j-i)/2
-		if it.list[h] < x {
-			i = h + 1
-		} else {
-			j = h
-		}
-	}
+	// Do binary search between current position and end.
+	i, _ := slices.BinarySearch(it.list, x)
 	if i < len(it.list) {
 		it.cur = it.list[i]
 		it.list = it.list[i+1:]

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -754,10 +754,16 @@ func (it *ListPostings) Seek(x storage.SeriesRef) bool {
 		return false
 	}
 
-	// Do binary search between current position and end.
-	i := sort.Search(len(it.list), func(i int) bool {
-		return it.list[i] >= x
-	})
+	// Binary search for the value.
+	i, j := 0, len(it.list)
+	for i < j {
+		h := i + (j-i)/2
+		if it.list[h] < x {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
 	if i < len(it.list) {
 		it.cur = it.list[i]
 		it.list = it.list[i+1:]


### PR DESCRIPTION
This is a hot path, and I saw it taking a while on some profiles.

First, I inlined the call, then on @bboreham suggestion I tried the generic version of the search, which turned out to be even faster (for some reason).

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb/index
                           │    main     │               inlined               │               generic               │
                           │   sec/op    │   sec/op     vs base                │   sec/op     vs base                │
Intersect/LongPostings1-12   30.38µ ± 1%   14.25µ ± 3%  -53.10% (p=0.000 n=10)   11.70µ ± 1%  -61.49% (p=0.000 n=10)
Intersect/LongPostings2-12   43.31m ± 2%   42.73m ± 2%        ~ (p=0.063 n=10)   43.35m ± 3%        ~ (p=0.315 n=10)
Intersect/ManyPostings-12    131.9m ± 2%   126.6m ± 2%   -4.04% (p=0.000 n=10)   133.7m ± 1%   +1.41% (p=0.004 n=10)
geomean                      5.578m        4.255m       -23.71%                  4.078m       -26.88%
```