### PR TITLE
POC: Drop __name__ label late and allow preserving it via label_replace

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1386,6 +1386,9 @@ func (ev *evaluator) evalLabelReplace(args parser.Expressions) (parser.Value, an
 	lb := labels.NewBuilder(labels.EmptyLabels())
 
 	for i, el := range matrix {
+		if src == labels.MetricName {
+			matrix[i].Metric = matrix[i].Metric.RestoreMetricName()
+		}
 		srcVal := el.Metric.Get(src)
 		indexes := regex.FindStringSubmatchIndex(srcVal)
 		if indexes != nil { // Only replace when regexp matches.
@@ -1393,6 +1396,9 @@ func (ev *evaluator) evalLabelReplace(args parser.Expressions) (parser.Value, an
 			lb.Reset(el.Metric)
 			lb.Set(dst, string(res))
 			matrix[i].Metric = lb.Labels()
+		}
+		if dst != labels.MetricName {
+			matrix[i].Metric = matrix[i].Metric.FlagMetricNameForDeletion()
 		}
 	}
 	if matrix.ContainsSameLabelset() {


### PR DESCRIPTION
  - Preserve __name__ label on function evaluations by renaming it to __delete__name__ and deleting it in a last step.
  - Label replace function un-does this behaviour temporarily if the source is the __name__ label; it marks if for deletion again unless __name__ is the target label (in which case it is preserved).
  - Un-exhaustive, un-tested
  - See https://github.com/prometheus/prometheus/issues/11397
