### PR TITLE
Persist alert 'keep firing for' state using file storage

### DIFF
--- a/cmd/promtool/rules.go
+++ b/cmd/promtool/rules.go
@@ -69,7 +69,7 @@ func newRuleImporter(logger log.Logger, config ruleImporterConfig, apiClient que
 
 // loadGroups parses groups from a list of recording rule files.
 func (importer *ruleImporter) loadGroups(_ context.Context, filenames []string) (errs []error) {
-	groups, errs := importer.ruleManager.LoadGroups(importer.config.evalInterval, labels.Labels{}, "", nil, filenames...)
+	groups, errs := importer.ruleManager.LoadGroups(importer.config.evalInterval, labels.Labels{}, "", nil, nil, filenames...)
 	if errs != nil {
 		return errs
 	}

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -199,7 +199,7 @@ func (tg *testGroup) test(evalInterval time.Duration, groupOrderMap map[string]i
 		Logger:     log.NewNopLogger(),
 	}
 	m := rules.NewManager(opts)
-	groupsMap, ers := m.LoadGroups(time.Duration(tg.Interval), tg.ExternalLabels, tg.ExternalURL, nil, ruleFiles...)
+	groupsMap, ers := m.LoadGroups(time.Duration(tg.Interval), tg.ExternalLabels, tg.ExternalURL, nil, nil, ruleFiles...)
 	if ers != nil {
 		return ers
 	}

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
@@ -41,7 +42,6 @@ const (
 	alertMetricName = "ALERTS"
 	// AlertForStateMetricName is the metric name for 'for' state of alert.
 	alertForStateMetricName = "ALERTS_FOR_STATE"
-
 	// AlertStateLabel is the label name indicating the state of an alert.
 	alertStateLabel = "alertstate"
 )
@@ -593,4 +593,15 @@ func (r *AlertingRule) String() string {
 	}
 
 	return string(byt)
+}
+
+func (r *AlertingRule) GetAlertFingerprint() uint64 {
+	return xxhash.Sum64([]byte(r.String()))
+}
+
+// SetActiveAlerts updates the active alerts of the alerting rule.
+func (r *AlertingRule) SetActiveAlerts(alerts map[uint64]*Alert) {
+	r.activeMtx.Lock()
+	defer r.activeMtx.Unlock()
+	r.active = alerts
 }

--- a/rules/group.go
+++ b/rules/group.go
@@ -75,6 +75,8 @@ type Group struct {
 
 	// concurrencyController controls the rules evaluation concurrency.
 	concurrencyController RuleConcurrencyController
+	alertStoreFunc        AlertStateStoreFunc
+	alertStore            AlertStore
 }
 
 // GroupEvalIterationFunc is used to implement and extend rule group
@@ -94,6 +96,8 @@ type GroupOptions struct {
 	QueryOffset       *time.Duration
 	done              chan struct{}
 	EvalIterationFunc GroupEvalIterationFunc
+	AlertStoreFunc    AlertStateStoreFunc
+	AlertStore        AlertStore
 }
 
 // NewGroup makes a new Group with the given name, options, and rules.
@@ -119,6 +123,12 @@ func NewGroup(o GroupOptions) *Group {
 		evalIterationFunc = DefaultEvalIterationFunc
 	}
 
+	alertStoreFunc := o.AlertStoreFunc
+	//var alertStore *AlertStore
+	if alertStoreFunc == nil {
+		alertStoreFunc = DefaultAlertStoreFunc
+	}
+
 	concurrencyController := o.Opts.RuleConcurrencyController
 	if concurrencyController == nil {
 		concurrencyController = sequentialRuleEvalController{}
@@ -140,6 +150,8 @@ func NewGroup(o GroupOptions) *Group {
 		logger:                log.With(o.Opts.Logger, "file", o.File, "group", o.Name),
 		metrics:               metrics,
 		evalIterationFunc:     evalIterationFunc,
+		alertStoreFunc:        alertStoreFunc,
+		alertStore:            o.AlertStore,
 		concurrencyController: concurrencyController,
 	}
 }
@@ -477,6 +489,18 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			}
 
 			g.metrics.EvalTotal.WithLabelValues(GroupKey(g.File(), g.Name())).Inc()
+
+			if g.alertStore != nil && g.lastEvalTimestamp.IsZero() {
+				// Restore alerts when feature is enabled and it is the first evaluation for the group
+				if ar, ok := rule.(*AlertingRule); ok {
+					restoredAlerts := g.alertStore.GetAlerts(ar.GetAlertFingerprint())
+					if restoredAlerts != nil {
+						level.Debug(g.logger).Log("msg", "Restoring alerts from file", "rule", ar.name)
+						ar.SetActiveAlerts(restoredAlerts)
+						level.Debug(g.logger).Log("msg", "Restored alerts from file", "rule", ar.name, "alerts", len(restoredAlerts))
+					}
+				}
+			}
 
 			vector, err := rule.Eval(ctx, ruleQueryOffset, ts, g.opts.QueryFunc, g.opts.ExternalURL, g.Limit())
 			if err != nil {

--- a/rules/state.go
+++ b/rules/state.go
@@ -1,0 +1,107 @@
+package rules
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+type State struct {
+	alerts []*Alert
+	key    uint64
+}
+
+type AlertStore interface {
+	// SetAlerts stores the provided list of alerts for a rule
+	SetAlerts(key uint64, alerts []*Alert)
+	// GetAlerts returns a list of alerts for each rule in group,
+	// rule is identified by a hash of its config.
+	GetAlerts(key uint64) map[uint64]*Alert
+}
+
+type FileStore struct {
+	logger      log.Logger
+	stateByRule map[uint64][]*Alert
+	//protects the `stateByRule` map
+	stateMtx sync.RWMutex
+	path     string
+}
+
+func NewFileStore(l log.Logger, storagePath string) *FileStore {
+	s := &FileStore{
+		logger:      l,
+		stateByRule: make(map[uint64][]*Alert),
+		path:        storagePath,
+	}
+	s.initState()
+	return s
+}
+
+// initState reads the state from file storage into the stateByRule map
+func (s *FileStore) initState() {
+	file, err := os.Open(s.path)
+	if err != nil {
+		level.Error(s.logger).Log("Error reading alerts state from file", err)
+	}
+	defer file.Close()
+
+	var stateByRule map[uint64][]*Alert
+	err = json.NewDecoder(file).Decode(&stateByRule)
+	if err != nil {
+		level.Error(s.logger).Log("Error reading alerts state from file", err)
+	}
+	if stateByRule == nil {
+		stateByRule = make(map[uint64][]*Alert)
+	}
+	s.stateByRule = stateByRule
+}
+
+// GetAlerts returns the stored alerts for an alerting rule
+// Alert state is read from the in memory map which is populated during initialization
+func (s *FileStore) GetAlerts(key uint64) map[uint64]*Alert {
+	s.stateMtx.RLock()
+	defer s.stateMtx.RUnlock()
+
+	restoredAlerts, ok := s.stateByRule[key]
+	if !ok {
+		return nil
+	}
+	alerts := make(map[uint64]*Alert)
+	for _, alert := range restoredAlerts {
+		if alert == nil {
+			continue
+		}
+		h := alert.Labels.Hash()
+		alerts[h] = alert
+	}
+
+	return alerts
+}
+
+// SetAlerts updates the stateByRule map and writes state to file storage
+func (s *FileStore) SetAlerts(key uint64, alerts []*Alert) {
+	s.stateMtx.Lock()
+	defer s.stateMtx.Unlock()
+	level.Debug(s.logger).Log("msg", "saving alert state", "key", key, "alerts", len(alerts))
+	// Update in memory
+	if alerts != nil {
+		s.stateByRule[key] = alerts
+	}
+
+	// flush in memory state to file storage
+	file, err := os.Create(s.path)
+	if err != nil {
+		level.Error(s.logger).Log("Error writing alerts state to file", err)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	err = encoder.Encode(s.stateByRule)
+
+	if err != nil {
+		level.Error(s.logger).Log("Error writing alerts state to file", err)
+	}
+}


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Alert state storage using file based implementation:
- Added a hook to store alerts, invoked at the end of each group evaluation
- Store uses an in memory map to optimize reads, map is populated when store is initialized
   - I.e we only read the file once initially
- When storing alerts, in memory map is updated before writing to file. Alerts are stored after each group evaluation given keepFiringFor is set
-  Custom AlertStore can be passed in by Cortex, along with its own hook implementation

Performance with ~1000 alerts:
each spike represents a server restart:
![image](https://github.com/prometheus/prometheus/assets/38258861/74cfef2c-f6bb-44ae-b57e-d0caf08eb22c)

