### PR TITLE
promql: more Kahan summation (avg) and less incremental mean calculation (avg, avg_over_time)

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -166,6 +166,9 @@ func rangeQueryCases() []benchCase {
 			expr: "sum(a_X)",
 		},
 		{
+			expr: "avg(a_X)",
+		},
+		{
 			expr: "sum without (l)(h_X)",
 		},
 		{

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2780,7 +2780,7 @@ type groupedAggregation struct {
 	histogramValue    *histogram.FloatHistogram
 	floatMean         float64 // Mean, or "compensating value" for Kahan summation.
 	groupCount        float64
-	groupAggrComplete bool // Used by LIMITK to short-cut series loop when we've reached K elem on every group
+	groupAggrComplete bool // Used by LIMITK to short-cut series loop when we've reached K elem on every group.
 	heap              vectorByValueHeap
 }
 

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -593,7 +593,8 @@ func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 					continue
 				}
 			}
-			mean, c = kahanSumInc(f.F/count-mean/count, mean, c)
+			correctedMean := mean + c
+			mean, c = kahanSumInc(f.F/count-correctedMean/count, mean, c)
 		}
 
 		if math.IsInf(mean, 0) {

--- a/promql/promqltest/testdata/aggregators.test
+++ b/promql/promqltest/testdata/aggregators.test
@@ -503,7 +503,7 @@ eval instant at 1m avg(data{test="-big"})
 eval instant at 1m avg(data{test="bigzero"})
 	{} 0
 
-# Test summing extreme values.
+# Test summing and averaging extreme values.
 clear
 
 load 10s
@@ -529,7 +529,14 @@ load 10s
 eval instant at 1m sum(data{test="ten"})
 	{} 10
 
+eval instant at 1m avg(data{test="ten"})
+	{} 2.5
+
 eval instant at 1m sum by (group) (data{test="pos_inf"})
+	{group="1"} Inf
+	{group="2"} Inf
+
+eval instant at 1m avg by (group) (data{test="pos_inf"})
 	{group="1"} Inf
 	{group="2"} Inf
 
@@ -537,10 +544,21 @@ eval instant at 1m sum by (group) (data{test="neg_inf"})
 	{group="1"} -Inf
 	{group="2"} -Inf
 
+eval instant at 1m avg by (group) (data{test="neg_inf"})
+	{group="1"} -Inf
+	{group="2"} -Inf
+
 eval instant at 1m sum(data{test="inf_inf"})
 	{} NaN
 
+eval instant at 1m avg(data{test="inf_inf"})
+	{} NaN
+
 eval instant at 1m sum by (group) (data{test="nan"})
+	{group="1"} NaN
+	{group="2"} NaN
+
+eval instant at 1m avg by (group) (data{test="nan"})
 	{group="1"} NaN
 	{group="2"} NaN
 

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -737,7 +737,6 @@ eval instant at 1m avg_over_time(metric6c[1m])
 eval instant at 1m sum_over_time(metric6c[1m])/count_over_time(metric6c[1m])
   {} NaN
 
-
 eval instant at 1m avg_over_time(metric7[1m])
   {} NaN
 
@@ -771,6 +770,9 @@ load 10s
 
 eval instant at 1m sum_over_time(metric[1m])
   {} 2
+
+eval instant at 1m avg_over_time(metric[1m])
+  {} 0.5
 
 # Tests for stddev_over_time and stdvar_over_time.
 clear


### PR DESCRIPTION
See various commits for details.

Studying #14074, I noticed that the tests added for the `sum` aggregation wouldn't work for the `avg` aggregation. Also, the tests already there for `sum_over_time` (with a series `1 1e100 1 -1e100`) wouldn't work for `avg_over_time`.

Simply applying Kahan summation wouldn't help. (In fact, it was already applied to `avg_over_time`, but of course, without adding the test mentioned above.) The reason is that we always use incremental calculation of the mean value. That's a good approach if the sum of the averaged values overflow float64. But in general, it's just more costly and has way more potential of accumulating numerical errors.

This PR changes the behavior that incremental calculation of the mean is only used if the sum would overflow. It also uses Kahan summation in all cases, which should take care of errors happening when adding small numbers to large ones (which is a case where incremental calculation of the mean might help, too, but I believe Kahan summation is cheaper and better and also consistent with how we calculate sums).
