### PR TITLE
Neater string vs byte-slice conversions

### DIFF
--- a/model/labels/labels_common.go
+++ b/model/labels/labels_common.go
@@ -218,5 +218,5 @@ func contains(s []Label, n string) bool {
 }
 
 func yoloString(b []byte) string {
-	return *((*string)(unsafe.Pointer(&b)))
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -16,7 +16,6 @@
 package labels
 
 import (
-	"reflect"
 	"slices"
 	"strings"
 	"unsafe"
@@ -299,10 +298,8 @@ func Equal(ls, o Labels) bool {
 func EmptyLabels() Labels {
 	return Labels{}
 }
-func yoloBytes(s string) (b []byte) {
-	*(*string)(unsafe.Pointer(&b)) = s
-	(*reflect.SliceHeader)(unsafe.Pointer(&b)).Cap = len(s)
-	return
+func yoloBytes(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 // New returns a sorted Labels from the given labels.
@@ -338,8 +335,8 @@ func Compare(a, b Labels) int {
 	}
 	i := 0
 	// First, go 8 bytes at a time. Data strings are expected to be 8-byte aligned.
-	sp := unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&shorter)).Data)
-	lp := unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&longer)).Data)
+	sp := unsafe.Pointer(unsafe.StringData(shorter))
+	lp := unsafe.Pointer(unsafe.StringData(longer))
 	for ; i < len(shorter)-8; i += 8 {
 		if *(*uint64)(unsafe.Add(sp, i)) != *(*uint64)(unsafe.Add(lp, i)) {
 			break

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -502,7 +502,7 @@ func unreplace(s string) string {
 }
 
 func yoloString(b []byte) string {
-	return *((*string)(unsafe.Pointer(&b)))
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }
 
 func parseFloat(s string) (float64, error) {

--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -20,7 +20,6 @@ import (
 	"hash"
 	"hash/crc32"
 	"math"
-	"unsafe"
 
 	"github.com/dennwc/varint"
 )
@@ -75,8 +74,7 @@ func (e *Encbuf) PutVarint64(x int64) {
 
 // PutUvarintStr writes a string to the buffer prefixed by its varint length (in bytes!).
 func (e *Encbuf) PutUvarintStr(s string) {
-	b := *(*[]byte)(unsafe.Pointer(&s))
-	e.PutUvarint(len(b))
+	e.PutUvarint(len(s))
 	e.PutString(s)
 }
 

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -2062,5 +2062,5 @@ func (dec *Decoder) Series(b []byte, builder *labels.ScratchBuilder, chks *[]chu
 }
 
 func yoloString(b []byte) string {
-	return *((*string)(unsafe.Pointer(&b)))
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }


### PR DESCRIPTION
`unsafe.Slice` and `unsafe.StringData` were added in Go 1.20

I can't see why `Encbuf.PutUvarintStr()` did an unsafe cast - perhaps the author thought `len(string)` counted runes?
