### PR TITLE
Use a custom swiss-like seriesHashmap impl.

### DIFF
--- a/tsdb/fastrand.go
+++ b/tsdb/fastrand.go
@@ -1,0 +1,32 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Provenance-includes-location: https://github.com/dolthub/swiss/blob/f4b2babd2bc1cf0a2d66bab4e579ca35b6202338/fastrand_1.22.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: Copyright 2023 Dolthub, Inc.
+
+//go:build !go1.22
+
+package tsdb
+
+import (
+	_ "unsafe"
+)
+
+//go:linkname fastrand runtime.fastrand
+func fastrand() uint32
+
+// randIntN returns a random number in the interval [0, n).
+func randIntN(n int) uint32 {
+	return fastModN(fastrand(), uint32(n))
+}

--- a/tsdb/fastrand_1.22.go
+++ b/tsdb/fastrand_1.22.go
@@ -1,0 +1,29 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Provenance-includes-location: https://github.com/dolthub/swiss/blob/f4b2babd2bc1cf0a2d66bab4e579ca35b6202338/fastrand.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: Copyright 2023 Dolthub, Inc.
+
+//go:build go1.22
+
+package tsdb
+
+import (
+	"math/rand/v2"
+)
+
+// randIntN returns a random number in the interval [0, n).
+func randIntN(n int) uint32 {
+	return rand.Uint32N(uint32(n))
+}

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -35,9 +35,53 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 	require.NoError(b, err)
 	defer h.Close()
 
+	lsets := make([]labels.Labels, b.N)
+	hashes := make([]uint64, b.N)
 	for i := 0; i < b.N; i++ {
-		h.getOrCreate(uint64(i), labels.FromStrings("a", strconv.Itoa(i)))
+		lsets[i] = labels.FromStrings(labels.MetricName, "test_metric", "lbl", strconv.Itoa(i))
+		hashes[i] = lsets[i].Hash()
 	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, created, _ := h.getOrCreate(hashes[i], lsets[i])
+		if !created {
+			panic("should create new series")
+		}
+	}
+}
+
+func BenchmarkHeadStripeSeriesGetExisting(b *testing.B) {
+	chunkDir := b.TempDir()
+	// Put a series, select it. GC it and then access it.
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChunkDirRoot = chunkDir
+	opts.StripeSize = 16
+	lsets := make([]labels.Labels, 1024)
+	hashes := make([]uint64, 1024)
+	h, err := NewHead(nil, nil, nil, nil, opts, nil)
+	require.NoError(b, err)
+	defer h.Close()
+
+	for i := range lsets {
+		lsets[i] = labels.FromStrings(labels.MetricName, "test_metric", "lbl", strconv.Itoa(i))
+		hashes[i] = lsets[i].Hash()
+		_, created, _ := h.getOrCreate(hashes[i], lsets[i])
+		if !created {
+			panic("should create new series")
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n := i % 1024
+		_, created, _ := h.getOrCreate(hashes[n], lsets[n])
+		if created {
+			panic("unexpected series creation")
+		}
+	}
+	b.StopTimer()
 }
 
 func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
@@ -54,8 +98,13 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			i := count.Inc()
-			h.getOrCreate(uint64(i), labels.FromStrings("a", strconv.Itoa(int(i))))
+			lset := labels.FromStrings("a", strconv.Itoa(int(count.Inc())))
+			// Use a real hash instead of just the count because the seriesHashmap relies
+			// on the fact that hashes are evenly distributed across uint64 values.
+			_, created, _ := h.getOrCreate(lset.Hash(), lset)
+			if !created {
+				panic("should create new series")
+			}
 		}
 	})
 }

--- a/tsdb/head_dedupelabels.go
+++ b/tsdb/head_dedupelabels.go
@@ -45,20 +45,12 @@ func (h *Head) RebuildSymbolTable(logger log.Logger) *labels.SymbolTable {
 
 	for i := 0; i < h.series.size; i++ {
 		h.series.locks[i].Lock()
-
-		for _, s := range h.series.hashes[i].unique {
+		h.series.hashes[i].iter(func(_ uint64, s *memSeries) (stop bool) {
 			s.Lock()
 			s.lset = rebuildLabels(s.lset)
 			s.Unlock()
-		}
-
-		for _, all := range h.series.hashes[i].conflicts {
-			for _, s := range all {
-				s.Lock()
-				s.lset = rebuildLabels(s.lset)
-				s.Unlock()
-			}
-		}
+			return false
+		})
 
 		h.series.locks[i].Unlock()
 	}

--- a/tsdb/series_hashmap.go
+++ b/tsdb/series_hashmap.go
@@ -1,0 +1,295 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Provenance-includes-location: https://github.com/dolthub/swiss/blob/f4b2babd2bc1cf0a2d66bab4e579ca35b6202338/map.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: Copyright 2023 Dolthub, Inc.
+
+package tsdb
+
+import (
+	"math/bits"
+	"math/rand/v2"
+	"unsafe"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+const (
+	initialSeriesHashmapSize = 16
+)
+
+// Map is an open-addressing hash map
+// based on Abseil's flat_hash_map.
+type seriesHashmap struct {
+	ctrl     []hashSuffixes
+	groups   []group
+	resident uint32
+	dead     uint32
+	limit    uint32
+}
+
+// hashSuffixes is the h2 hashSuffixes array for a group.
+// find operations first probe the controls bytes
+// to filter candidates before matching keys
+type hashSuffixes [groupSize]uint8
+
+// group is a group of 16 key-value pairs
+type group struct {
+	hashes [groupSize]uint64
+	series [groupSize]*memSeries
+}
+
+const (
+	h1Mask    uint64 = 0xffff_ffff_ffff_ff80
+	h2Mask    uint64 = 0x0000_0000_0000_007f
+	h2Offset         = 2
+	empty     uint8  = 0b0000_0000
+	tombstone uint8  = 0b0000_0001
+)
+
+// h1 is a 57 bit hash prefix
+type h1 uint64
+
+// h2 is a 7 bit hash suffix
+type h2 uint8
+
+func (m *seriesHashmap) get(hash uint64, lset labels.Labels) *memSeries {
+	if len(m.groups) == 0 {
+		return nil
+	}
+
+	hi, lo := splitHash(hash)
+	g := probeStart(hi, len(m.groups))
+	for { // inlined find loop
+		matches := metaMatchH2(&m.ctrl[g], lo)
+		for matches != 0 {
+			s := nextMatch(&matches)
+			if hash == m.groups[g].hashes[s] && labels.Equal(lset, m.groups[g].series[s].labels()) {
+				return m.groups[g].series[s]
+			}
+		}
+		// |key| is not in group |g|,
+		// stop probing if we see an empty slot
+		matches = metaMatchEmpty(&m.ctrl[g])
+		if matches != 0 {
+			return nil
+		}
+		g += 1 // linear probing
+		if g >= uint32(len(m.groups)) {
+			g = 0
+		}
+	}
+	return nil
+}
+
+func (m *seriesHashmap) set(hash uint64, series *memSeries) {
+	if m.resident >= m.limit {
+		m.rehash(m.nextSize())
+	}
+
+	hi, lo := splitHash(hash)
+	g := probeStart(hi, len(m.groups))
+	for { // inlined find loop
+		matches := metaMatchH2(&m.ctrl[g], lo)
+		for matches != 0 {
+			s := nextMatch(&matches)
+			// We only read series.labels() if we actually have the same hash,
+			// because the implementation of series.labels() is expensive with dedupelabels.
+			if hash == m.groups[g].hashes[s] && labels.Equal(series.labels(), m.groups[g].series[s].labels()) { // update (do we expect updates here? this is just inherited from swiss map)
+				m.groups[g].hashes[s] = hash
+				m.groups[g].series[s] = series
+				return
+			}
+		}
+		// |key| is not in group |g|,
+		// stop probing if we see an empty slot
+		if matches := metaMatchEmpty(&m.ctrl[g]); matches != 0 { // insert
+			s := nextMatch(&matches)
+			m.groups[g].hashes[s] = hash
+			m.groups[g].series[s] = series
+			m.ctrl[g][s] = uint8(lo)
+			m.resident++
+			return
+		}
+		g += 1 // linear probing
+		if g >= uint32(len(m.groups)) {
+			g = 0
+		}
+	}
+}
+
+func (m *seriesHashmap) del(hash uint64, ref chunks.HeadSeriesRef) {
+	if len(m.groups) == 0 {
+		return
+	}
+
+	hi, lo := splitHash(hash)
+	g := probeStart(hi, len(m.groups))
+	for {
+		matches := metaMatchH2(&m.ctrl[g], lo)
+		for matches != 0 {
+			s := nextMatch(&matches)
+			if hash == m.groups[g].hashes[s] && ref == m.groups[g].series[s].ref { // update (do we expect updates here? this is just inherited from swiss map)
+				// optimization: if |m.ctrl[g]| contains any empty
+				// hashSuffixes bytes, we can physically delete |key|
+				// rather than placing a tombstone.
+				// The observation is that any probes into group |g|
+				// would already be terminated by the existing empty
+				// slot, and therefore reclaiming slot |s| will not
+				// cause premature termination of probes into |g|.
+				if metaMatchEmpty(&m.ctrl[g]) != 0 {
+					m.ctrl[g][s] = empty
+					m.resident--
+				} else {
+					m.ctrl[g][s] = tombstone
+					m.dead++
+				}
+				m.groups[g].hashes[s] = 0
+				m.groups[g].series[s] = nil
+				return
+			}
+		}
+		// |key| is not in group |g|,
+		// stop probing if we see an empty slot
+		if matches := metaMatchEmpty(&m.ctrl[g]); matches != 0 { // |key| absent
+			return
+		}
+		g += 1 // linear probing
+		if g >= uint32(len(m.groups)) {
+			g = 0
+		}
+	}
+}
+
+// iter iterates the series of the seriesHashmap, passing them to the callback.
+// It guarantees that any key in the Map will be visited only once,
+// and or un-mutated maps, every key will be visited once.
+// Series added while iterating might, or might not be visited.
+// Series deleted from outside the iterator's callback might be iterated.
+func (m *seriesHashmap) iter(cb func(uint64, *memSeries) (stop bool)) {
+	if len(m.groups) == 0 {
+		return
+	}
+
+	// take a consistent view of the table in case
+	// we rehash during iteration
+	ctrl, groups := m.ctrl, m.groups
+	// pick a random starting group
+	g := randIntN(len(groups))
+	for n := 0; n < len(groups); n++ {
+		for s, c := range ctrl[g] {
+			if c == empty || c == tombstone {
+				continue
+			}
+			if stop := cb(groups[g].hashes[s], groups[g].series[s]); stop {
+				return
+			}
+		}
+		g++
+		if g >= uint32(len(groups)) {
+			g = 0
+		}
+	}
+}
+
+func (m *seriesHashmap) nextSize() (n uint32) {
+	if len(m.groups) == 0 {
+		return numGroups(initialSeriesHashmapSize)
+	}
+	n = uint32(len(m.groups)) * 2
+	if m.dead >= (m.resident / 2) {
+		n = uint32(len(m.groups))
+	}
+	return
+}
+
+func (m *seriesHashmap) rehash(n uint32) {
+	groups, ctrl := m.groups, m.ctrl
+	m.groups = make([]group, n)
+	m.ctrl = make([]hashSuffixes, n)
+	m.limit = n * maxAvgSeriesHashmapGroupLoad
+	m.resident, m.dead = 0, 0
+	for g := range ctrl {
+		for s := range ctrl[g] {
+			c := ctrl[g][s]
+			if c == empty || c == tombstone {
+				continue
+			}
+			m.set(groups[g].hashes[s], groups[g].series[s])
+		}
+	}
+}
+
+// numGroups returns the minimum number of groups needed to store |n| elems.
+func numGroups(n uint32) (groups uint32) {
+	groups = (n + maxAvgSeriesHashmapGroupLoad - 1) / maxAvgSeriesHashmapGroupLoad
+	if groups == 0 {
+		groups = 1
+	}
+	return
+}
+
+// splitHash extracts the h1 and h2 components from a 64 bit hash.
+// h1 is the upper 57 bits, h2 is the lower 7 bits plus two.
+// By adding 2, it ensures that h2 is never uint8(0) or uint8(1).
+func splitHash(h uint64) (h1, h2) {
+	return h1((h & h1Mask) >> 7), h2(h&h2Mask) + h2Offset
+}
+
+func probeStart(hi h1, groups int) uint32 {
+	return fastModN(uint32(hi), uint32(groups))
+}
+
+// lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+func fastModN(x, n uint32) uint32 {
+	return uint32((uint64(x) * uint64(n)) >> 32)
+}
+
+// randIntN returns a random number in the interval [0, n).
+func randIntN(n int) uint32 {
+	return rand.Uint32N(uint32(n))
+}
+
+const (
+	groupSize                    = 8
+	maxAvgSeriesHashmapGroupLoad = 7
+
+	loBits uint64 = 0x0101010101010101
+	hiBits uint64 = 0x8080808080808080
+)
+
+type bitset uint64
+
+func metaMatchH2(m *hashSuffixes, h h2) bitset {
+	// https://graphics.stanford.edu/~seander/bithacks.html##ValueInWord
+	return hasZeroByte(castUint64(m) ^ (loBits * uint64(h)))
+}
+
+func metaMatchEmpty(m *hashSuffixes) bitset {
+	return hasZeroByte(castUint64(m))
+}
+
+func nextMatch(b *bitset) uint32 {
+	s := uint32(bits.TrailingZeros64(uint64(*b)))
+	*b &= ^(1 << s) // clear bit |s|
+	return s >> 3   // div by 8
+}
+
+func hasZeroByte(x uint64) bitset {
+	return bitset(((x - loBits) & ^(x)) & hiBits)
+}
+
+func castUint64(m *hashSuffixes) uint64 {
+	return *(*uint64)((unsafe.Pointer)(m))
+}

--- a/tsdb/series_hashmap.go
+++ b/tsdb/series_hashmap.go
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 // Provenance-includes-location: https://github.com/dolthub/swiss/blob/f4b2babd2bc1cf0a2d66bab4e579ca35b6202338/map.go
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: Copyright 2023 Dolthub, Inc.

--- a/tsdb/series_hashmap.go
+++ b/tsdb/series_hashmap.go
@@ -40,11 +40,10 @@ type seriesHashmap struct {
 }
 
 // hashSuffixes is the h2 hashSuffixes array for a group.
-// find operations first probe the controls bytes
-// to filter candidates before matching keys
+// Find operations first probe the controls bytes to filter candidates before matching keys.
 type hashSuffixes [groupSize]uint8
 
-// group is a group of 16 key-value pairs
+// group is a group of 16 key-value pairs.
 type group struct {
 	hashes [groupSize]uint64
 	series [groupSize]*memSeries
@@ -58,10 +57,10 @@ const (
 	tombstone uint8  = 0b0000_0001
 )
 
-// h1 is a 57 bit hash prefix
+// h1 is a 57 bit hash prefix.
 type h1 uint64
 
-// h2 is a 7 bit hash suffix
+// h2 is a 7 bit hash suffix.
 type h2 uint8
 
 func (m *seriesHashmap) get(hash uint64, lset labels.Labels) *memSeries {
@@ -85,12 +84,10 @@ func (m *seriesHashmap) get(hash uint64, lset labels.Labels) *memSeries {
 		if matches != 0 {
 			return nil
 		}
-		g += 1 // linear probing
-		if g >= uint32(len(m.groups)) {
+		if g++; g >= uint32(len(m.groups)) {
 			g = 0
 		}
 	}
-	return nil
 }
 
 func (m *seriesHashmap) set(hash uint64, series *memSeries) {
@@ -122,8 +119,7 @@ func (m *seriesHashmap) set(hash uint64, series *memSeries) {
 			m.resident++
 			return
 		}
-		g += 1 // linear probing
-		if g >= uint32(len(m.groups)) {
+		if g++; g >= uint32(len(m.groups)) {
 			g = 0
 		}
 	}
@@ -165,8 +161,7 @@ func (m *seriesHashmap) del(hash uint64, ref chunks.HeadSeriesRef) {
 		if matches := metaMatchEmpty(&m.ctrl[g]); matches != 0 { // |key| absent
 			return
 		}
-		g += 1 // linear probing
-		if g >= uint32(len(m.groups)) {
+		if g++; g >= uint32(len(m.groups)) {
 			g = 0
 		}
 	}
@@ -251,7 +246,8 @@ func probeStart(hi h1, groups int) uint32 {
 	return fastModN(uint32(hi), uint32(groups))
 }
 
-// lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+// fastModN is an alternative to modulo operation to evenly distribute keys.
+// lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/.
 func fastModN(x, n uint32) uint32 {
 	return uint32((uint64(x) * uint64(n)) >> 32)
 }

--- a/tsdb/series_hashmap.go
+++ b/tsdb/series_hashmap.go
@@ -18,7 +18,6 @@ package tsdb
 
 import (
 	"math/bits"
-	"math/rand/v2"
 	"unsafe"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -250,11 +249,6 @@ func probeStart(hi h1, groups int) uint32 {
 // lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/.
 func fastModN(x, n uint32) uint32 {
 	return uint32((uint64(x) * uint64(n)) >> 32)
-}
-
-// randIntN returns a random number in the interval [0, n).
-func randIntN(n int) uint32 {
-	return rand.Uint32N(uint32(n))
 }
 
 const (

--- a/tsdb/series_hashmap.go
+++ b/tsdb/series_hashmap.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	initialSeriesHashmapSize = 16
+	initialSeriesHashmapSize = 128
 )
 
 // Map is an open-addressing hash map


### PR DESCRIPTION
Right now `seriesHashmap` is a struct with two maps, one for the happy case, and one for the hash collisions we'd have.

Let's ignore for a moment the hash collisions: we have a hash, and we put it in a map so we have to hash the hash. Same for the retrievals.

What if we just used our hash as the internal hash for the hashmap?

This takes the swiss map implementation from github.com/dolthub/swiss plus some PRs I sent there to avoid having to pre-fill the internal datastructures with `empty` values, and copies that to our `tsdb` package making non-generic adjustments for our use case:
- empty value of the struct is valid, we allocate slices on first put.
- we already have a hash, use it
- store the hash where the original implementation stored the keys, and compare it after we found a hash suffix: so we avoid checking lset equality all the time
- only check lset equality when hash matches, accessing to memSeries internals (leveraging the fact that the implementation isn't generic)
- remove has(), clear(), etc. we don't need them.
- since we store the hash, rehashing is just allocating a new slice and copying the data.
- in this initial version, I didn't add the SIMD instructions, which would increase the performance on amd64.
  - [adding SIMD is trivial though](https://github.com/colega/prometheus/commit/5f600772f3bede13c623b0eda79f74ccf406eb42)

I didn't spend time on copying the tests from the original implementation: this structure is already covered by most of our tests, which should be enough to start reviewing. If we decide that we need them, I can bring them.

Benchmark results:
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
                                             │    main     │               swapped               │
                                             │   sec/op    │   sec/op     vs base                │
HeadStripeSeriesCreate-12                      742.9n ± 5%   658.6n ± 1%  -11.35% (p=0.000 n=20)
HeadStripeSeriesGetExisting-12                 28.06n ± 0%   16.43n ± 0%  -41.46% (p=0.000 n=20)
HeadStripeSeriesCreateParallel-12              745.5n ± 2%   706.1n ± 3%   -5.29% (p=0.000 n=20)
HeadStripeSeriesCreate_PreCreationFailure-12   72.31n ± 0%   66.32n ± 0%   -8.28% (p=0.000 n=20)
geomean                                        183.1n        150.0n       -18.06%

                                             │     main      │               swapped               │
                                             │     B/op      │    B/op     vs base                 │
HeadStripeSeriesCreate-12                      658.5 ± 12%     639.5 ± 2%       ~ (p=1.000 n=20)
HeadStripeSeriesGetExisting-12                 0.000 ±  0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
HeadStripeSeriesCreateParallel-12              585.0 ±  1%     538.0 ± 0%  -8.03% (p=0.000 n=20)
HeadStripeSeriesCreate_PreCreationFailure-12   56.00 ±  0%     56.00 ± 0%       ~ (p=1.000 n=20) ¹
geomean                                                    ²               -2.79%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                             │     main     │               swapped               │
                                             │  allocs/op   │ allocs/op   vs base                 │
HeadStripeSeriesCreate-12                      3.000 ± 0%     3.000 ± 0%       ~ (p=1.000 n=20) ¹
HeadStripeSeriesGetExisting-12                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
HeadStripeSeriesCreateParallel-12              5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=20) ¹
HeadStripeSeriesCreate_PreCreationFailure-12   3.000 ± 0%     3.000 ± 0%       ~ (p=1.000 n=20) ¹
geomean                                                   ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Also, I took a profile of `BenchmarkHeadStripeSeriesCreate` with 50M series, and zooming into getOrSet:
![image](https://github.com/prometheus/prometheus/assets/1511481/ed1be45a-2547-4d20-8ac1-70131f67c65d)

Here it's seen that creating an entry in `map[ref]*memSeries` (`runtime.mapassign_fast64`) takes much longer than calling `seriesHashmap.set()`, while both things are called once from `getOrSet`.