### PR TITLE
WAL Watcher: never skip samples from live segments

### DIFF
--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -784,6 +784,13 @@ func TestRun_AvoidNotifyWhenBehind(t *testing.T) {
 			err = watcher.Run()
 			wg.Wait()
 			require.Less(t, time.Since(startTime), readTimeout)
+
+			// But samples records shouldn't get dropped
+			retry(t, defaultRetryInterval, defaultRetries, func() bool {
+				return wt.checkNumSeries() > 0
+			})
+			require.Greater(t, wt.samplesAppended, 0)
+
 			require.NoError(t, err)
 			require.NoError(t, w.Close())
 		})


### PR DESCRIPTION
On start-up, the WAL reader wants to skip samples, exemplars, etc. from older WAL segments for speed.

After we have read the old segments, every subsequent segment must be read in full.

Removed parameter `tail`; `readSegment()` decides what to do based on parameter `allData` instead.

`watch()` now only works on live segments. `readSegmentFile` is used for the older segments.

Elide error-handling part of `readAndHandleError` into the places it was called. Note it previously returned `ErrIgnorable` every time `tail==false`, even when there was no error.

Include a check from #14434 by @machine424 that samples are not dropped, in `TestRun_AvoidNotifyWhenBehind`.

fixes #14087