### PR TITLE
Allow built-in tests to be customized

### DIFF
--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -55,6 +55,11 @@ const (
 	DefaultMaxSamplesPerQuery = 10000
 )
 
+type TBRun interface {
+	testing.TB
+	Run(string, func(*testing.T)) bool
+}
+
 var testStartTime = time.Unix(0, 0).UTC()
 
 // LoadedStorage returns storage with generated data using the provided load statements.
@@ -89,7 +94,7 @@ func NewTestEngine(enablePerStepStats bool, lookbackDelta time.Duration, maxSamp
 }
 
 // RunBuiltinTests runs an acceptance test suite against the provided engine.
-func RunBuiltinTests(t *testing.T, engine promql.QueryEngine) {
+func RunBuiltinTests(t TBRun, engine promql.QueryEngine) {
 	t.Cleanup(func() { parser.EnableExperimentalFunctions = false })
 	parser.EnableExperimentalFunctions = true
 


### PR DESCRIPTION
The RunBuiltinTests function accepts a concrete type which makes it hard to exclude certain tests from the suite. It would be great if we could skip tests which might not be critical in order to unblock updates.

By accepting an interface instead, we can inject a custom implementation which would skips select test cases.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
