### PR TITLE
storage: add `AtT` method to `MemoizedSeriesIterator`

### DIFF
--- a/storage/memoized_iterator.go
+++ b/storage/memoized_iterator.go
@@ -136,6 +136,11 @@ func (b *MemoizedSeriesIterator) AtFloatHistogram() (int64, *histogram.FloatHist
 	return b.it.AtFloatHistogram(nil)
 }
 
+// AtT returns the timestamp of the current element of the iterator.
+func (b *MemoizedSeriesIterator) AtT() int64 {
+	return b.it.AtT()
+}
+
 // Err returns the last encountered error.
 func (b *MemoizedSeriesIterator) Err() error {
 	return b.it.Err()

--- a/storage/memoized_iterator_test.go
+++ b/storage/memoized_iterator_test.go
@@ -29,13 +29,15 @@ func TestMemoizedSeriesIterator(t *testing.T) {
 	sampleEq := func(ets int64, ev float64, efh *histogram.FloatHistogram) {
 		if efh == nil {
 			ts, v := it.At()
-			require.Equal(t, ets, ts, "timestamp mismatch")
-			require.Equal(t, ev, v, "value mismatch")
+			require.Equal(t, ets, ts, "At() timestamp mismatch")
+			require.Equal(t, ev, v, "At() value mismatch")
 		} else {
 			ts, fh := it.AtFloatHistogram()
-			require.Equal(t, ets, ts, "timestamp mismatch")
-			require.Equal(t, efh, fh, "histogram mismatch")
+			require.Equal(t, ets, ts, "AtFloatHistogram() timestamp mismatch")
+			require.Equal(t, efh, fh, "AtFloatHistogram() histogram mismatch")
 		}
+
+		require.Equal(t, ets, it.AtT(), "AtT() timestamp mismatch")
 	}
 	prevSampleEq := func(ets int64, ev float64, efh *histogram.FloatHistogram, eok bool) {
 		ts, v, fh, ok := it.PeekPrev()


### PR DESCRIPTION
This PR adds an `AtT()` method to `MemoizedSeriesIterator`.

This is useful for consumers that wish to know the current timestamp without needing to consider if the current sample is a float or histogram sample, or for consumers that don't wish to call `AtFloatHistogram()` again if the iterator is still pointing to the same histogram sample after a `Seek()` call.