### PR TITLE
Turn `memSeries.mmMaxTime` into a method

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2217,7 +2217,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 	return removedInOrder + removedOOO
 }
 
-// mmMaxTime returns the time of any mmapped chunk.
+// mmMaxTime returns the max time of any mmapped chunk, or math.MinInt64 if there are none.
 // Only used during WAL replay, so we can skip calling append() for samples it will reject.
 func (s *memSeries) mmMaxTime() int64 {
 	if len(s.mmappedChunks) > 0 {


### PR DESCRIPTION
As the comment on this method states: we only use it during WAL replay. I was going to initially just build a temporary map in `processWALSamples` that would hold `mmMaxTime` valuesm but then I realized that we can just read it from `memSeries.mmappedChunks` as we assign the memory mmapped chunks there.

Maybe there's something I'm missing?