### PR TITLE
Cache `mmMaxTime` in a map instead of `memSeries`

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2095,8 +2095,6 @@ type memSeries struct {
 
 	ooo *memSeriesOOOFields
 
-	mmMaxTime int64 // Max time of any mmapped chunk, only used during WAL replay.
-
 	nextAt                           int64 // Timestamp at which to cut the next chunk.
 	histogramChunkHasComputedEndTime bool  // True if nextAt has been predicted for the current histograms chunk; false otherwise.
 

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -479,13 +479,11 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 		}
 		*mSeries.ooo = memSeriesOOOFields{oooMmappedChunks: oooMmc}
 	}
-	// Cache the last mmapped chunk time, so we can skip calling append() for samples it will reject.
-	if len(mmc) == 0 {
-		mSeries.mmMaxTime = math.MinInt64
-	} else {
-		mSeries.mmMaxTime = mmc[len(mmc)-1].maxTime
-		h.updateMinMaxTime(mmc[0].minTime, mSeries.mmMaxTime)
+
+	if len(mmc) > 0 {
+		h.updateMinMaxTime(mmc[0].minTime, mmc[len(mmc)-1].maxTime)
 	}
+
 	if len(oooMmc) != 0 {
 		// Mint and maxt can be in any chunk, they are not sorted.
 		mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)
@@ -569,12 +567,18 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 		samplesPerChunk: h.opts.SamplesPerChunk,
 	}
 
+	// Cache the last mmapped chunk time, so we can skip calling append() for samples it will reject.
+	mmMaxTimes := map[chunks.HeadSeriesRef]int64{}
+
 	for in := range wp.input {
 		if in.existingSeries != nil {
 			mmc := mmappedChunks[in.walSeriesRef]
 			oooMmc := oooMmappedChunks[in.walSeriesRef]
 			if h.resetSeriesWithMMappedChunks(in.existingSeries, mmc, oooMmc, in.walSeriesRef) {
 				mmapOverlappingChunks++
+			}
+			if len(mmc) > 0 {
+				mmMaxTimes[in.existingSeries.ref] = mmc[len(mmc)-1].maxTime
 			}
 			continue
 		}
@@ -585,7 +589,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				unknownRefs++
 				continue
 			}
-			if s.T <= ms.mmMaxTime {
+			if mmMaxTime, ok := mmMaxTimes[s.Ref]; ok && s.T <= mmMaxTime {
 				continue
 			}
 			if _, chunkCreated := ms.append(s.T, s.V, 0, appendChunkOpts); chunkCreated {
@@ -614,7 +618,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				unknownHistogramRefs++
 				continue
 			}
-			if s.t <= ms.mmMaxTime {
+			if mmMaxTime, ok := mmMaxTimes[s.ref]; ok && s.t <= mmMaxTime {
 				continue
 			}
 			var chunkCreated bool


### PR DESCRIPTION
An alternative to https://github.com/prometheus/prometheus/pull/14472

Instead of calculating the value and storing it in memSeries, this caches the value in a temporary map.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
                                                                                                                                                             │     main      │               method                │              mapcache               │
                                                                                                                                                             │    sec/op     │    sec/op     vs base               │    sec/op     vs base               │
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12          165.6m ±  4%   164.7m ±  1%       ~ (p=0.052 n=10)   166.6m ±  1%       ~ (p=0.853 n=10)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         168.0m ±  1%   167.6m ±  1%       ~ (p=0.247 n=10)   167.5m ±  2%       ~ (p=0.353 n=10)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         171.1m ±  0%   170.5m ±  1%       ~ (p=0.165 n=10)   170.5m ±  1%  -0.31% (p=0.023 n=10)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12        198.0m ±  0%   197.6m ±  0%       ~ (p=0.315 n=10)   197.4m ±  1%       ~ (p=1.000 n=10)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12          220.8m ± 24%   220.2m ±  4%       ~ (p=0.631 n=10)   220.2m ±  2%       ~ (p=0.684 n=10)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12          243.1m ± 20%   235.6m ±  3%  -3.08% (p=0.043 n=10)   235.5m ±  3%  -3.12% (p=0.035 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12          79.11m ±  4%   79.04m ±  1%       ~ (p=0.912 n=10)   77.42m ±  0%  -2.13% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12          80.61m ±  1%   81.05m ±  0%       ~ (p=0.123 n=10)   79.53m ±  1%  -1.34% (p=0.002 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12          83.52m ±  1%   83.61m ±  1%       ~ (p=0.739 n=10)   81.85m ±  1%  -1.99% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12        100.54m ± 11%   99.69m ±  2%       ~ (p=0.190 n=10)   97.88m ±  1%  -2.65% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12      832.9m ±  4%   859.6m ± 11%  +3.21% (p=0.009 n=10)   860.4m ±  2%  +3.30% (p=0.015 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12      845.0m ±  2%   870.7m ±  2%  +3.05% (p=0.001 n=10)   892.2m ±  4%  +5.60% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12      886.3m ± 16%   888.8m ±  2%       ~ (p=0.853 n=10)   911.6m ± 15%       ~ (p=0.063 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12      1.084 ±  1%    1.118 ±  1%  +3.15% (p=0.000 n=10)    1.133 ±  1%  +4.54% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12         279.3m ±  6%   279.5m ±  3%       ~ (p=0.853 n=10)   278.7m ±  8%       ~ (p=0.971 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12         280.9m ±  1%   281.8m ±  1%       ~ (p=0.247 n=10)   281.4m ±  0%       ~ (p=0.315 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12         284.5m ±  1%   283.9m ±  1%       ~ (p=0.393 n=10)   284.5m ±  4%       ~ (p=0.912 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12        302.3m ±  2%   301.3m ±  1%       ~ (p=0.143 n=10)   301.0m ±  3%       ~ (p=0.315 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12          251.1m ±  1%   251.9m ±  6%       ~ (p=0.481 n=10)   250.2m ±  1%       ~ (p=0.165 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12          253.3m ±  4%   252.5m ±  1%       ~ (p=0.739 n=10)   253.1m ±  2%       ~ (p=0.971 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12          252.3m ±  1%   252.9m ±  1%       ~ (p=0.529 n=10)   256.1m ±  2%       ~ (p=0.143 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12         278.5m ±  4%   267.4m ±  4%       ~ (p=0.105 n=10)   266.6m ±  1%  -4.27% (p=0.035 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12      3.263 ±  2%    3.355 ±  6%  +2.82% (p=0.019 n=10)    3.297 ±  1%       ~ (p=0.280 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12      3.279 ±  1%    3.357 ±  3%  +2.40% (p=0.000 n=10)    3.286 ±  1%       ~ (p=0.123 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12      3.289 ±  2%    3.442 ±  2%  +4.66% (p=0.000 n=10)    3.342 ±  2%  +1.63% (p=0.019 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12     3.510 ±  2%    3.578 ±  4%  +1.94% (p=0.015 n=10)    3.520 ±  2%       ~ (p=0.739 n=10)
geomean                                                                                                                                                         372.0m         373.7m        +0.47%                  372.5m        +0.13%

                                                                                                                                                             │     main     │               method                │              mapcache               │
                                                                                                                                                             │     B/op     │     B/op      vs base               │     B/op      vs base               │
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         36.58Mi ± 0%   36.58Mi ± 0%       ~ (p=0.853 n=10)   36.64Mi ± 2%  +0.18% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12        39.36Mi ± 0%   39.37Mi ± 0%       ~ (p=0.165 n=10)   39.41Mi ± 0%  +0.13% (p=0.001 n=10)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12        41.06Mi ± 0%   41.05Mi ± 0%       ~ (p=0.739 n=10)   41.12Mi ± 0%  +0.15% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12       56.34Mi ± 0%   56.35Mi ± 0%       ~ (p=0.247 n=10)   56.39Mi ± 0%  +0.08% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         197.1Mi ± 3%   192.9Mi ± 3%  -2.17% (p=0.023 n=10)   195.3Mi ± 3%       ~ (p=0.247 n=10)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         234.7Mi ± 2%   231.0Mi ± 2%       ~ (p=0.052 n=10)   230.8Mi ± 1%  -1.67% (p=0.043 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         54.32Mi ± 2%   54.02Mi ± 3%       ~ (p=0.631 n=10)   55.02Mi ± 2%       ~ (p=0.063 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         56.30Mi ± 1%   56.09Mi ± 1%       ~ (p=0.393 n=10)   57.23Mi ± 1%  +1.64% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         58.06Mi ± 2%   57.65Mi ± 1%       ~ (p=0.247 n=10)   58.77Mi ± 2%  +1.21% (p=0.029 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12        67.74Mi ± 0%   67.56Mi ± 2%       ~ (p=0.089 n=10)   68.27Mi ± 1%  +0.78% (p=0.029 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12     263.5Mi ± 1%   272.2Mi ± 1%  +3.31% (p=0.000 n=10)   279.8Mi ± 1%  +6.20% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12     273.6Mi ± 1%   281.4Mi ± 1%  +2.83% (p=0.000 n=10)   291.9Mi ± 1%  +6.68% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12     285.9Mi ± 5%   294.6Mi ± 1%  +3.03% (p=0.029 n=10)   306.5Mi ± 5%  +7.19% (p=0.001 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12    386.8Mi ± 1%   399.7Mi ± 1%  +3.35% (p=0.000 n=10)   406.9Mi ± 1%  +5.21% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12        534.4Mi ± 0%   534.8Mi ± 0%  +0.08% (p=0.043 n=10)   535.8Mi ± 0%  +0.28% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12        536.4Mi ± 0%   536.7Mi ± 0%       ~ (p=0.796 n=10)   537.6Mi ± 0%  +0.22% (p=0.009 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12        537.4Mi ± 0%   538.4Mi ± 0%       ~ (p=0.063 n=10)   538.5Mi ± 0%  +0.20% (p=0.003 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12       547.8Mi ± 0%   547.4Mi ± 0%       ~ (p=0.739 n=10)   548.1Mi ± 0%       ~ (p=0.436 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12         455.5Mi ± 0%   454.9Mi ± 0%       ~ (p=0.247 n=10)   456.5Mi ± 0%       ~ (p=0.218 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12         456.8Mi ± 0%   456.0Mi ± 0%       ~ (p=1.000 n=10)   456.3Mi ± 0%       ~ (p=1.000 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12         457.0Mi ± 1%   455.9Mi ± 0%  -0.24% (p=0.009 n=10)   457.4Mi ± 1%       ~ (p=0.579 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12        465.7Mi ± 0%   465.7Mi ± 0%       ~ (p=0.481 n=10)   466.5Mi ± 0%  +0.19% (p=0.035 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12    4.124Gi ± 0%   4.131Gi ± 0%  +0.18% (p=0.000 n=10)   4.141Gi ± 0%  +0.41% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12    4.132Gi ± 0%   4.142Gi ± 0%  +0.24% (p=0.000 n=10)   4.153Gi ± 0%  +0.52% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12    4.143Gi ± 0%   4.161Gi ± 0%  +0.41% (p=0.000 n=10)   4.163Gi ± 0%  +0.47% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12   4.226Gi ± 0%   4.245Gi ± 0%  +0.43% (p=0.000 n=10)   4.249Gi ± 0%  +0.52% (p=0.000 n=10)
geomean                                                                                                                                                        296.1Mi        297.0Mi       +0.29%                  299.6Mi       +1.17%

                                                                                                                                                             │    main     │               method               │              mapcache              │
                                                                                                                                                             │  allocs/op  │  allocs/op   vs base               │  allocs/op   vs base               │
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         392.7k ± 0%   392.8k ± 0%  +0.02% (p=0.003 n=10)   393.0k ± 2%  +0.07% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12        509.1k ± 0%   509.2k ± 0%  +0.02% (p=0.000 n=10)   509.3k ± 0%  +0.05% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12        617.5k ± 0%   617.6k ± 0%  +0.01% (p=0.002 n=10)   617.7k ± 0%  +0.03% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12       1.484M ± 0%   1.485M ± 0%  +0.01% (p=0.000 n=10)   1.485M ± 0%  +0.01% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         2.009M ± 0%   2.008M ± 0%       ~ (p=0.143 n=10)   2.009M ± 0%       ~ (p=0.971 n=10)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         2.609M ± 0%   2.609M ± 0%       ~ (p=0.684 n=10)   2.609M ± 0%       ~ (p=0.579 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         401.8k ± 0%   401.7k ± 1%       ~ (p=1.000 n=10)   402.4k ± 0%       ~ (p=0.436 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         462.1k ± 0%   462.0k ± 0%       ~ (p=0.912 n=10)   462.9k ± 0%  +0.18% (p=0.001 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12         553.5k ± 0%   553.4k ± 0%       ~ (p=1.000 n=10)   552.9k ± 0%       ~ (p=0.165 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12        1.126M ± 0%   1.125M ± 0%       ~ (p=0.143 n=10)   1.126M ± 0%       ~ (p=0.481 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12     2.966M ± 0%   2.980M ± 0%  +0.47% (p=0.000 n=10)   2.983M ± 0%  +0.57% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12     3.565M ± 0%   3.577M ± 0%  +0.35% (p=0.000 n=10)   3.584M ± 0%  +0.54% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12     4.463M ± 0%   4.477M ± 0%  +0.30% (p=0.019 n=10)   4.486M ± 3%  +0.50% (p=0.002 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-12    10.31M ± 0%   10.33M ± 0%  +0.19% (p=0.000 n=10)   10.33M ± 0%  +0.22% (p=0.000 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12        2.572M ± 0%   2.573M ± 0%       ~ (p=0.105 n=10)   2.574M ± 0%  +0.07% (p=0.002 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12        2.632M ± 0%   2.632M ± 0%       ~ (p=0.436 n=10)   2.633M ± 0%       ~ (p=0.052 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12        2.721M ± 0%   2.722M ± 0%  +0.05% (p=0.011 n=10)   2.722M ± 0%  +0.05% (p=0.007 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-12       3.293M ± 0%   3.292M ± 0%       ~ (p=0.853 n=10)   3.292M ± 0%       ~ (p=0.739 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12         2.411M ± 0%   2.410M ± 0%       ~ (p=0.315 n=10)   2.411M ± 2%       ~ (p=0.631 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12         2.470M ± 2%   2.443M ± 1%       ~ (p=0.353 n=10)   2.418M ± 2%       ~ (p=0.280 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12         2.508M ± 2%   2.506M ± 0%  -0.08% (p=0.009 n=10)   2.507M ± 2%       ~ (p=0.631 n=10)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-12        3.076M ± 0%   3.078M ± 0%  +0.04% (p=0.002 n=10)   3.078M ± 0%  +0.05% (p=0.009 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12    20.86M ± 0%   20.88M ± 0%  +0.07% (p=0.000 n=10)   20.89M ± 0%  +0.10% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12    21.46M ± 0%   21.48M ± 0%  +0.08% (p=0.000 n=10)   21.48M ± 0%  +0.11% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12    22.36M ± 0%   22.38M ± 0%  +0.10% (p=0.000 n=10)   22.38M ± 0%  +0.10% (p=0.000 n=10)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-12   28.06M ± 0%   28.08M ± 0%  +0.09% (p=0.000 n=10)   28.08M ± 0%  +0.08% (p=0.000 n=10)
geomean                                                                                                                                                        2.563M        2.563M       +0.02%                  2.563M       +0.03%
```
