### PR TITLE
TSDB: shrink memSeries by moving bools together

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2099,6 +2099,7 @@ type memSeries struct {
 
 	nextAt                           int64 // Timestamp at which to cut the next chunk.
 	histogramChunkHasComputedEndTime bool  // True if nextAt has been predicted for the current histograms chunk; false otherwise.
+	pendingCommit                    bool  // Whether there are samples waiting to be committed to this series.
 
 	// We keep the last value here (in addition to appending it to the chunk) so we can check for duplicates.
 	lastValue float64
@@ -2114,8 +2115,6 @@ type memSeries struct {
 
 	// txs is nil if isolation is disabled.
 	txs *txRing
-
-	pendingCommit bool // Whether there are samples waiting to be committed to this series.
 }
 
 // memSeriesOOOFields contains the fields required by memSeries


### PR DESCRIPTION
In each case the following object requires 8-byte alignment, so moving one beside the other shrinks memSeries from 176 to 168 bytes, when compiled with `-tags stringlabels`.
