### PR TITLE
docs: Point docs index to latest pages, resolving 404s

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,10 +11,10 @@ The documentation is available alongside all the project documentation at
 
 ## Content
 
-- [Getting started](getting_started.md)
-- [Installation](installation.md)
-- [Configuration](configuration/configuration.md)
-- [Querying](querying/basics.md)
-- [Storage](storage.md)
-- [Federation](federation.md)
-- [Migration](migration.md)
+- [Getting started](https://prometheus.io/docs/prometheus/latest/getting_started)
+- [Installation](https://prometheus.io/docs/prometheus/latest/installation)
+- [Configuration](https://prometheus.io/docs/prometheus/latest/configuration)
+- [Querying](https://prometheus.io/docs/prometheus/latest/querying/basics)
+- [Storage](https://prometheus.io/docs/prometheus/latest/storage)
+- [Federation](https://prometheus.io/docs/prometheus/latest/federation)
+- [Migration](https://prometheus.io/docs/prometheus/latest/migration)


### PR DESCRIPTION
Resolves https://github.com/prometheus/docs/issues/2384. 

Points the documentation links from the relative markdown link (which 404s when deployed) to the latest URL for those docs. I've checked each link to ensure it does not 404.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
