### PR TITLE
Rules: Persist alerts 'keep_firing_for' state using file storage

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -206,11 +206,13 @@ type flagConfig struct {
 	featureList []string
 	// These options are extracted from featureList
 	// for ease of use.
-	enablePerStepStats       bool
-	enableConcurrentRuleEval bool
+	enablePerStepStats          bool
+	enableConcurrentRuleEval    bool
+	enableAlertStatePersistence bool
 
-	prometheusURL   string
-	corsRegexString string
+	prometheusURL    string
+	corsRegexString  string
+	alertStoragePath string
 
 	promqlEnableDelayedNameRemoval bool
 
@@ -247,6 +249,9 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 			case "concurrent-rule-eval":
 				c.enableConcurrentRuleEval = true
 				logger.Info("Experimental concurrent rule evaluation enabled.")
+			case "alert-state-persistence":
+				c.enableAlertStatePersistence = true
+				logger.Info("Experimental alert state persistence storage enabled for alerting rules using keep_firing_for.")
 			case "promql-experimental-functions":
 				parser.EnableExperimentalFunctions = true
 				logger.Info("Experimental PromQL functions enabled.")
@@ -526,6 +531,8 @@ func main() {
 
 	serverOnlyFlag(a, "rules.alert.resend-delay", "Minimum amount of time to wait before resending an alert to Alertmanager.").
 		Default("1m").SetValue(&cfg.resendDelay)
+	serverOnlyFlag(a, "rules.alert.state-storage-path", "Path for alert state storage.").
+		Default("data/alerts").StringVar(&cfg.alertStoragePath)
 
 	serverOnlyFlag(a, "rules.max-concurrent-evals", "Global concurrency limit for independent rules that can run concurrently. When set, \"query.max-concurrency\" may need to be adjusted accordingly.").
 		Default("4").Int64Var(&cfg.maxConcurrentEvals)
@@ -864,6 +871,10 @@ func main() {
 		}
 
 		queryEngine = promql.NewEngine(opts)
+		var alertStore rules.AlertStore
+		if cfg.enableAlertStatePersistence {
+			alertStore = rules.NewFileStore(logger.With("component", "alertStore"), cfg.alertStoragePath)
+		}
 
 		ruleManager = rules.NewManager(&rules.ManagerOptions{
 			Appendable:             fanoutStorage,
@@ -882,6 +893,8 @@ func main() {
 			DefaultRuleQueryOffset: func() time.Duration {
 				return time.Duration(cfgFile.GlobalConfig.RuleQueryOffset)
 			},
+			AlertStore:     alertStore,
+			AlertStoreFunc: rules.DefaultAlertStoreFunc,
 		})
 	}
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -873,7 +873,7 @@ func main() {
 		queryEngine = promql.NewEngine(opts)
 		var alertStore rules.AlertStore
 		if cfg.enableAlertStatePersistence {
-			alertStore = rules.NewFileStore(logger.With("component", "alertStore"), cfg.alertStoragePath)
+			alertStore = rules.NewFileStore(logger.With("component", "alertStore"), cfg.alertStoragePath, prometheus.DefaultRegisterer)
 		}
 
 		ruleManager = rules.NewManager(&rules.ManagerOptions{
@@ -893,8 +893,7 @@ func main() {
 			DefaultRuleQueryOffset: func() time.Duration {
 				return time.Duration(cfgFile.GlobalConfig.RuleQueryOffset)
 			},
-			AlertStore:     alertStore,
-			AlertStoreFunc: rules.DefaultAlertStoreFunc,
+			AlertStore: alertStore,
 		})
 	}
 

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -50,6 +50,7 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--rules.alert.for-outage-tolerance</code> | Max time to tolerate prometheus outage for restoring "for" state of alert. Use with server mode only. | `1h` |
 | <code class="text-nowrap">--rules.alert.for-grace-period</code> | Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. Use with server mode only. | `10m` |
 | <code class="text-nowrap">--rules.alert.resend-delay</code> | Minimum amount of time to wait before resending an alert to Alertmanager. Use with server mode only. | `1m` |
+| <code class="text-nowrap">--rules.alert.state-storage-path</code> | Path for alert state storage. Use with server mode only. | `data/alerts` |
 | <code class="text-nowrap">--rules.max-concurrent-evals</code> | Global concurrency limit for independent rules that can run concurrently. When set, "query.max-concurrency" may need to be adjusted accordingly. Use with server mode only. | `4` |
 | <code class="text-nowrap">--alertmanager.notification-queue-capacity</code> | The capacity of the queue for pending Alertmanager notifications. Use with server mode only. | `10000` |
 | <code class="text-nowrap">--alertmanager.notification-batch-size</code> | The maximum number of notifications per batch to send to the Alertmanager. Use with server mode only. | `256` |

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/common/model"
 	"go.uber.org/atomic"
 	"gopkg.in/yaml.v2"
@@ -41,7 +42,6 @@ const (
 	alertMetricName = "ALERTS"
 	// AlertForStateMetricName is the metric name for 'for' state of alert.
 	alertForStateMetricName = "ALERTS_FOR_STATE"
-
 	// AlertStateLabel is the label name indicating the state of an alert.
 	alertStateLabel = "alertstate"
 )
@@ -626,4 +626,17 @@ func (r *AlertingRule) String() string {
 	}
 
 	return string(byt)
+}
+
+// GetFingerprint returns a hash to uniquely identify an alerting rule,
+// using a combination of rule config and the groupKey.
+func (r *AlertingRule) GetFingerprint(groupKey string) uint64 {
+	return xxhash.Sum64(append([]byte(r.String()), []byte(groupKey)...))
+}
+
+// SetActiveAlerts updates the active alerts of the alerting rule.
+func (r *AlertingRule) SetActiveAlerts(alerts map[uint64]*Alert) {
+	r.activeMtx.Lock()
+	defer r.activeMtx.Unlock()
+	r.active = alerts
 }

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -42,6 +42,7 @@ const (
 	alertMetricName = "ALERTS"
 	// AlertForStateMetricName is the metric name for 'for' state of alert.
 	alertForStateMetricName = "ALERTS_FOR_STATE"
+
 	// AlertStateLabel is the label name indicating the state of an alert.
 	alertStateLabel = "alertstate"
 )
@@ -610,6 +611,8 @@ func (r *AlertingRule) sendAlerts(ctx context.Context, ts time.Time, resendDelay
 	notifyFunc(ctx, r.vector.String(), alerts...)
 }
 
+// Note that changing format of String() changes value of GetFingerprint() leading to loss of persisted state
+// when the `alert-state-persistence` feature is enabled.
 func (r *AlertingRule) String() string {
 	ar := rulefmt.Rule{
 		Alert:         r.name,

--- a/rules/group.go
+++ b/rules/group.go
@@ -73,7 +73,6 @@ type Group struct {
 	evalIterationFunc GroupEvalIterationFunc
 
 	appOpts               *storage.AppendOptions
-	alertStoreFunc        AlertStateStoreFunc
 	alertStore            AlertStore
 }
 
@@ -94,7 +93,6 @@ type GroupOptions struct {
 	QueryOffset       *time.Duration
 	done              chan struct{}
 	EvalIterationFunc GroupEvalIterationFunc
-	AlertStoreFunc    AlertStateStoreFunc
 	AlertStore        AlertStore
 }
 
@@ -126,11 +124,6 @@ func NewGroup(o GroupOptions) *Group {
 		evalIterationFunc = DefaultEvalIterationFunc
 	}
 
-	alertStoreFunc := o.AlertStoreFunc
-	if alertStoreFunc == nil {
-		alertStoreFunc = DefaultAlertStoreFunc
-	}
-
 	if opts.Logger == nil {
 		opts.Logger = promslog.NewNopLogger()
 	}
@@ -152,7 +145,6 @@ func NewGroup(o GroupOptions) *Group {
 		metrics:              metrics,
 		evalIterationFunc:    evalIterationFunc,
 		appOpts:              &storage.AppendOptions{DiscardOutOfOrder: true},
-		alertStoreFunc:       alertStoreFunc,
 		alertStore:           o.AlertStore,
 	}
 }
@@ -547,7 +539,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 				restoredAlerts, _ := g.alertStore.GetAlerts(ar.GetFingerprint(GroupKey(g.File(), g.Name())))
 				if len(restoredAlerts) > 0 {
 					ar.SetActiveAlerts(restoredAlerts)
-					logger.Info("Restored alerts from store", "rule", ar.name, "alerts", len(restoredAlerts))
+					g.logger.Info("Restored alerts from store", "rule", ar.name, "alerts", len(restoredAlerts))
 				}
 			}
 		}
@@ -1188,4 +1180,36 @@ func buildDependencyMap(rules []Rule) dependencyMap {
 	}
 
 	return dependencies
+}
+
+// AlertStore provides persistent storage of alert state.
+type AlertStore interface {
+	// SetAlerts stores the provided list of alerts for a rule.
+	SetAlerts(key uint64, groupKey string, alerts []*Alert) error
+	// GetAlerts returns a list of alerts for each alerting rule,
+	// alerting rule is identified by a fingerprint of its config.
+	GetAlerts(key uint64) (map[uint64]*Alert, error)
+}
+
+// StoreKeepFiringForState is periodically invoked to store the state of alerting rules using 'keep_firing_for'.
+func (g *Group) StoreKeepFiringForState() {
+	for _, rule := range g.rules {
+		ar, ok := rule.(*AlertingRule)
+		if !ok {
+			continue
+		}
+		if ar.KeepFiringFor() != 0 {
+			alertsToStore := make([]*Alert, 0)
+			ar.ForEachActiveAlert(func(alert *Alert) {
+				if !alert.KeepFiringSince.IsZero() {
+					alertsToStore = append(alertsToStore, alert)
+				}
+			})
+			groupKey := GroupKey(g.File(), g.Name())
+			err := g.alertStore.SetAlerts(ar.GetFingerprint(groupKey), groupKey, alertsToStore)
+			if err != nil {
+				g.logger.Error("Failed to store alerting rule state", "rule", ar.Name(), "err", err)
+			}
+		}
+	}
 }

--- a/rules/group.go
+++ b/rules/group.go
@@ -127,7 +127,6 @@ func NewGroup(o GroupOptions) *Group {
 	}
 
 	alertStoreFunc := o.AlertStoreFunc
-	//var alertStore *AlertStore
 	if alertStoreFunc == nil {
 		alertStoreFunc = DefaultAlertStoreFunc
 	}
@@ -546,13 +545,13 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			// Restore alerts when feature is enabled and it is the first evaluation for the group
 			if ar, ok := rule.(*AlertingRule); ok {
 				restoredAlerts, _ := g.alertStore.GetAlerts(ar.GetFingerprint(GroupKey(g.File(), g.Name())))
-				if restoredAlerts != nil && len(restoredAlerts) > 0 {
+				if len(restoredAlerts) > 0 {
 					ar.SetActiveAlerts(restoredAlerts)
 					logger.Info("Restored alerts from store", "rule", ar.name, "alerts", len(restoredAlerts))
 				}
 			}
 		}
-		
+
 		vector, err := rule.Eval(ctx, ruleQueryOffset, ts, g.opts.QueryFunc, g.opts.ExternalURL, g.Limit())
 		if err != nil {
 			rule.SetHealth(HealthBad)

--- a/rules/group.go
+++ b/rules/group.go
@@ -72,7 +72,9 @@ type Group struct {
 	// defaults to DefaultEvalIterationFunc.
 	evalIterationFunc GroupEvalIterationFunc
 
-	appOpts *storage.AppendOptions
+	appOpts               *storage.AppendOptions
+	alertStoreFunc        AlertStateStoreFunc
+	alertStore            AlertStore
 }
 
 // GroupEvalIterationFunc is used to implement and extend rule group
@@ -92,6 +94,8 @@ type GroupOptions struct {
 	QueryOffset       *time.Duration
 	done              chan struct{}
 	EvalIterationFunc GroupEvalIterationFunc
+	AlertStoreFunc    AlertStateStoreFunc
+	AlertStore        AlertStore
 }
 
 // NewGroup makes a new Group with the given name, options, and rules.
@@ -122,6 +126,12 @@ func NewGroup(o GroupOptions) *Group {
 		evalIterationFunc = DefaultEvalIterationFunc
 	}
 
+	alertStoreFunc := o.AlertStoreFunc
+	//var alertStore *AlertStore
+	if alertStoreFunc == nil {
+		alertStoreFunc = DefaultAlertStoreFunc
+	}
+
 	if opts.Logger == nil {
 		opts.Logger = promslog.NewNopLogger()
 	}
@@ -143,6 +153,8 @@ func NewGroup(o GroupOptions) *Group {
 		metrics:              metrics,
 		evalIterationFunc:    evalIterationFunc,
 		appOpts:              &storage.AppendOptions{DiscardOutOfOrder: true},
+		alertStoreFunc:       alertStoreFunc,
+		alertStore:           o.AlertStore,
 	}
 }
 
@@ -530,6 +542,17 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 
 		g.metrics.EvalTotal.WithLabelValues(GroupKey(g.File(), g.Name())).Inc()
 
+		if g.alertStore != nil && g.lastEvalTimestamp.IsZero() {
+			// Restore alerts when feature is enabled and it is the first evaluation for the group
+			if ar, ok := rule.(*AlertingRule); ok {
+				restoredAlerts, _ := g.alertStore.GetAlerts(ar.GetFingerprint(GroupKey(g.File(), g.Name())))
+				if restoredAlerts != nil && len(restoredAlerts) > 0 {
+					ar.SetActiveAlerts(restoredAlerts)
+					logger.Info("Restored alerts from store", "rule", ar.name, "alerts", len(restoredAlerts))
+				}
+			}
+		}
+		
 		vector, err := rule.Eval(ctx, ruleQueryOffset, ts, g.opts.QueryFunc, g.opts.ExternalURL, g.Limit())
 		if err != nil {
 			rule.SetHealth(HealthBad)

--- a/rules/group.go
+++ b/rules/group.go
@@ -71,9 +71,9 @@ type Group struct {
 	// Rule group evaluation iteration function,
 	// defaults to DefaultEvalIterationFunc.
 	evalIterationFunc GroupEvalIterationFunc
+	alertStore        AlertStore
 
-	appOpts               *storage.AppendOptions
-	alertStore            AlertStore
+	appOpts *storage.AppendOptions
 }
 
 // GroupEvalIterationFunc is used to implement and extend rule group
@@ -144,8 +144,8 @@ func NewGroup(o GroupOptions) *Group {
 		logger:               opts.Logger.With("file", o.File, "group", o.Name),
 		metrics:              metrics,
 		evalIterationFunc:    evalIterationFunc,
-		appOpts:              &storage.AppendOptions{DiscardOutOfOrder: true},
 		alertStore:           o.AlertStore,
+		appOpts:              &storage.AppendOptions{DiscardOutOfOrder: true},
 	}
 }
 

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/promslog"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
@@ -35,7 +36,6 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/strutil"
-	"golang.org/x/sync/semaphore"
 )
 
 // QueryFunc processes PromQL queries.
@@ -89,7 +89,7 @@ func DefaultEvalIterationFunc(ctx context.Context, g *Group, evalTimestamp time.
 	g.setLastEvalTimestamp(evalTimestamp)
 
 	if g.alertStore != nil {
-		//feature enabled
+		// feature enabled.
 		go func() {
 			g.alertStoreFunc(g)
 		}()

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -136,7 +136,6 @@ type ManagerOptions struct {
 	RestoreNewRuleGroups bool
 
 	Metrics *Metrics
-	
 }
 
 // NewManager returns an implementation of Manager, ready to be started

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -2586,7 +2586,7 @@ func TestKeepFiringForStateRestore(t *testing.T) {
 		Queryable:       testStorage,
 		Context:         context.Background(),
 		Logger:          promslog.NewNopLogger(),
-		NotifyFunc:      func(ctx context.Context, expr string, alerts ...*Alert) {},
+		NotifyFunc:      func(_ context.Context, _ string, _ ...*Alert) {},
 		OutageTolerance: 30 * time.Minute,
 		ForGracePeriod:  10 * time.Minute,
 		AlertStore:      alertStore,
@@ -2713,8 +2713,8 @@ func TestKeepFiringForStateRestore(t *testing.T) {
 
 			got := newRule.ActiveAlerts()
 			got2 := newRule2.ActiveAlerts()
-			require.Equal(t, len(exp), len(got))
-			require.Equal(t, len(exp2), len(got2))
+			require.Len(t, got, len(exp))
+			require.Len(t, got2, len(exp2))
 			require.Equal(t, tt.alertsExpected, len(got)+len(got2))
 
 			results := [][]*Alert{got, got2}
@@ -2733,7 +2733,7 @@ func TestKeepFiringForStateRestore(t *testing.T) {
 
 			for i, expected := range expectedAlerts {
 				got = results[i]
-				require.Equal(t, len(expected), len(got))
+				require.Len(t, got, len(expected))
 				for j, alert := range expected {
 					diff := float64(alert.KeepFiringSince.Unix() - got[j].KeepFiringSince.Unix())
 					require.Equal(t, 0.0, math.Abs(diff), "'keep_firing_for' restored time is wrong")

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -2561,6 +2561,188 @@ func TestParseFiles(t *testing.T) {
 	})
 }
 
+func TestKeepFiringForStateRestore(t *testing.T) {
+	testStorage := promqltest.LoadedStorage(t, `
+		load 5m
+		http_requests{job="app-server", instance="0", group="canary", severity="overwrite-me"}	75 0 0 0 0 0 0 0 
+		http_requests{job="app-server", instance="1", group="canary", severity="overwrite-me"}	100 0 0 0 0 0 0 0
+		http_requests_5xx{job="app-server", instance="2", group="canary", severity="overwrite-me"}	80 0 0 0 0 0 0 0
+	`)
+
+	testStoreFile := "testalertstore"
+
+	t.Cleanup(
+		func() {
+			testStorage.Close()
+			os.Remove(testStoreFile)
+		},
+	)
+
+	alertStore := NewFileStore(promslog.NewNopLogger(), testStoreFile)
+	ng := testEngine(t)
+	opts := &ManagerOptions{
+		QueryFunc:       EngineQueryFunc(ng, testStorage),
+		Appendable:      testStorage,
+		Queryable:       testStorage,
+		Context:         context.Background(),
+		Logger:          promslog.NewNopLogger(),
+		NotifyFunc:      func(ctx context.Context, expr string, alerts ...*Alert) {},
+		OutageTolerance: 30 * time.Minute,
+		ForGracePeriod:  10 * time.Minute,
+		AlertStore:      alertStore,
+	}
+
+	keepFiringForDuration := 30 * time.Minute
+	// Initial run before prometheus goes down.
+	expr, err := parser.ParseExpr(`http_requests{group="canary", job="app-server"} > 0`)
+	require.NoError(t, err)
+	expr2, err := parser.ParseExpr(`http_requests_5xx{group="canary", job="app-server"} > 0`)
+	require.NoError(t, err)
+
+	rule := NewAlertingRule(
+		"HTTPRequestRateLow",
+		expr,
+		0,
+		keepFiringForDuration,
+		labels.FromStrings("severity", "critical"),
+		labels.FromStrings("annotation1", "rule1"), labels.EmptyLabels(), "", true, nil,
+	)
+	keepFiringForDuration2 := 60 * time.Minute
+	rule2 := NewAlertingRule(
+		"HTTPRequestRateLow",
+		expr2,
+		0,
+		keepFiringForDuration2,
+		labels.FromStrings("severity", "critical"),
+		labels.FromStrings("annotation2", "rule2"), labels.EmptyLabels(), "", true, nil,
+	)
+
+	group := NewGroup(GroupOptions{
+		Name:           "default",
+		Interval:       time.Second,
+		Rules:          []Rule{rule, rule2},
+		ShouldRestore:  true,
+		Opts:           opts,
+		AlertStoreFunc: DefaultAlertStoreFunc,
+		AlertStore:     alertStore,
+	})
+
+	groups := make(map[string]*Group)
+	groups["default;"] = group
+
+	type testInput struct {
+		name            string
+		restoreDuration time.Duration
+		initialRuns     []time.Duration
+		alertsExpected  int
+	}
+
+	tests := []testInput{
+		{
+			name:            "normal restore - 3 alerts firing with keep_firing_for duration active",
+			restoreDuration: 30 * time.Minute,
+			initialRuns:     []time.Duration{0, 5 * time.Minute, 10 * time.Minute, 15 * time.Minute, 20 * time.Minute, 25 * time.Minute},
+			alertsExpected:  3,
+		},
+		{
+			name:            "restore after rule 1 keep firing for duration is over - 1 alert with keep_firing_for duration active",
+			restoreDuration: keepFiringForDuration + 10*time.Minute,
+			initialRuns:     []time.Duration{0, 5 * time.Minute, 10 * time.Minute, 15 * time.Minute, 20 * time.Minute, 50 * time.Minute},
+			alertsExpected:  1,
+		},
+		{
+			name:            "restore after keep firing for duration expires - 0 alerts active",
+			restoreDuration: 120 * time.Minute,
+			initialRuns:     []time.Duration{0, 5 * time.Minute, 10 * time.Minute, 15 * time.Minute, 20 * time.Minute, 110 * time.Minute},
+			alertsExpected:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseTime := time.Unix(0, 0)
+			for _, duration := range tt.initialRuns {
+				// Evaluating rule before restarting.
+				evalTime := baseTime.Add(duration)
+				group.Eval(opts.Context, evalTime)
+				group.setLastEvalTimestamp(evalTime)
+				// Manager will store alert state.
+				DefaultAlertStoreFunc(group)
+			}
+
+			exp := rule.ActiveAlerts()
+			exp2 := rule2.ActiveAlerts()
+			// Record alerts before restart.
+			expectedAlerts := [][]*Alert{exp, exp2}
+
+			// Prometheus goes down here. We create new rules and groups.
+			newRule := NewAlertingRule(
+				"HTTPRequestRateLow",
+				expr,
+				0,
+				keepFiringForDuration,
+				labels.FromStrings("severity", "critical"),
+				labels.FromStrings("annotation1", "rule1"), labels.EmptyLabels(), "", false, nil,
+			)
+			newRule2 := NewAlertingRule(
+				"HTTPRequestRateLow",
+				expr2,
+				0,
+				keepFiringForDuration2,
+				labels.FromStrings("severity", "critical"),
+				labels.FromStrings("annotation2", "rule2"), labels.EmptyLabels(), "", true, nil,
+			)
+			// Restart alert store
+			newAlertStore := NewFileStore(promslog.NewNopLogger(), testStoreFile)
+
+			newGroup := NewGroup(GroupOptions{
+				Name:           "default",
+				Interval:       time.Second,
+				Rules:          []Rule{newRule, newRule2},
+				ShouldRestore:  true,
+				Opts:           opts,
+				AlertStore:     newAlertStore,
+				AlertStoreFunc: DefaultAlertStoreFunc,
+			})
+
+			newGroups := make(map[string]*Group)
+			newGroups["default;"] = newGroup
+
+			restoreTime := baseTime.Add(tt.restoreDuration)
+
+			// First eval after restart.
+			newGroup.Eval(context.TODO(), restoreTime)
+
+			got := newRule.ActiveAlerts()
+			got2 := newRule2.ActiveAlerts()
+			require.Equal(t, len(exp), len(got))
+			require.Equal(t, len(exp2), len(got2))
+			require.Equal(t, tt.alertsExpected, len(got)+len(got2))
+
+			results := [][]*Alert{got, got2}
+
+			for i, result := range results {
+				sort.Slice(result, func(i, j int) bool {
+					return labels.Compare(got[i].Labels, got[j].Labels) < 0
+				})
+				sortAlerts(result)
+				sortAlerts(expectedAlerts[i])
+			}
+
+			for i, expected := range expectedAlerts {
+				got = results[i]
+				require.Equal(t, len(expected), len(got))
+				for j, alert := range expected {
+					require.Equal(t, alert.Labels, got[j].Labels)
+					require.Equal(t, alert.Annotations, got[j].Annotations)
+					require.Equal(t, alert.ActiveAt, got[j].ActiveAt)
+					require.Equal(t, alert.KeepFiringSince, got[j].KeepFiringSince)
+				}
+			}
+		})
+	}
+}
+
 func TestRuleDependencyController_AnalyseRules(t *testing.T) {
 	type expectedDependencies struct {
 		noDependentRules  bool

--- a/rules/store.go
+++ b/rules/store.go
@@ -20,7 +20,7 @@ type AlertStore interface {
 type FileStore struct {
 	logger       *slog.Logger
 	alertsByRule map[uint64][]*Alert
-	//protects the `alertsByRule` map
+	// protects the `alertsByRule` map.
 	stateMtx sync.RWMutex
 	path     string
 }
@@ -35,7 +35,7 @@ func NewFileStore(l *slog.Logger, storagePath string) *FileStore {
 	return s
 }
 
-// initState reads the state from file storage into the alertsByRule map
+// initState reads the state from file storage into the alertsByRule map.
 func (s *FileStore) initState() {
 	file, err := os.OpenFile(s.path, os.O_RDWR|os.O_CREATE, 0o666)
 	if err != nil {
@@ -56,7 +56,7 @@ func (s *FileStore) initState() {
 }
 
 // GetAlerts returns the stored alerts for an alerting rule
-// Alert state is read from the in memory map which is populated during initialization
+// Alert state is read from the in memory map which is populated during initialization.
 func (s *FileStore) GetAlerts(key uint64) (map[uint64]*Alert, error) {
 	s.stateMtx.RLock()
 	defer s.stateMtx.RUnlock()
@@ -76,7 +76,7 @@ func (s *FileStore) GetAlerts(key uint64) (map[uint64]*Alert, error) {
 	return alerts, nil
 }
 
-// SetAlerts updates the stateByRule map and writes state to file storage
+// SetAlerts updates the stateByRule map and writes state to file storage.
 func (s *FileStore) SetAlerts(key uint64, alerts []*Alert) error {
 	s.stateMtx.Lock()
 	defer s.stateMtx.Unlock()

--- a/rules/store.go
+++ b/rules/store.go
@@ -1,3 +1,16 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rules
 
 import (
@@ -65,9 +78,9 @@ func (s *FileStore) initState(registerer prometheus.Registerer) {
 	var data *FileData
 	err = json.NewDecoder(file).Decode(&data)
 	if err != nil {
-		data = nil
 		s.logger.Error("Failed reading alerts state from file", "err", err)
 		s.storeInitErrors.Inc()
+		return
 	}
 	alertsByRule := make(map[uint64][]*Alert)
 	if data != nil && data.Alerts != nil {

--- a/rules/store.go
+++ b/rules/store.go
@@ -5,41 +5,57 @@ import (
 	"log/slog"
 	"os"
 	"sync"
-)
 
-// AlertStore provides persistent storage of alert state.
-type AlertStore interface {
-	// SetAlerts stores the provided list of alerts for a rule.
-	SetAlerts(key uint64, alerts []*Alert) error
-	// GetAlerts returns a list of alerts for each alerting rule,
-	// alerting rule is identified by a fingerprint of its config.
-	GetAlerts(key uint64) (map[uint64]*Alert, error)
-}
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // FileStore implements the AlertStore interface.
 type FileStore struct {
 	logger       *slog.Logger
 	alertsByRule map[uint64][]*Alert
 	// protects the `alertsByRule` map.
-	stateMtx sync.RWMutex
-	path     string
+	stateMtx         sync.RWMutex
+	path             string
+	registerer       prometheus.Registerer
+	storeInitErrors  prometheus.Counter
+	alertStoreErrors *prometheus.CounterVec
 }
 
-func NewFileStore(l *slog.Logger, storagePath string) *FileStore {
+func NewFileStore(l *slog.Logger, storagePath string, registerer prometheus.Registerer) *FileStore {
 	s := &FileStore{
 		logger:       l,
 		alertsByRule: make(map[uint64][]*Alert),
 		path:         storagePath,
+		registerer:   registerer,
 	}
+	s.storeInitErrors = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "alert_store_init_errors_total",
+			Help:      "The total number of errors starting alert store.",
+		},
+	)
+	s.alertStoreErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "rule_group_alert_store_errors_total",
+			Help:      "The total number of errors in alert store.",
+		},
+		[]string{"rule_group"},
+	)
 	s.initState()
 	return s
 }
 
 // initState reads the state from file storage into the alertsByRule map.
 func (s *FileStore) initState() {
+	if s.registerer != nil {
+		s.registerer.MustRegister(s.alertStoreErrors, s.storeInitErrors)
+	}
 	file, err := os.OpenFile(s.path, os.O_RDWR|os.O_CREATE, 0o666)
 	if err != nil {
 		s.logger.Error("Failed reading alerts state from file", "err", err)
+		s.storeInitErrors.Inc()
 		return
 	}
 	defer file.Close()
@@ -48,6 +64,7 @@ func (s *FileStore) initState() {
 	err = json.NewDecoder(file).Decode(&alertsByRule)
 	if err != nil {
 		s.logger.Error("Failed reading alerts state from file", "err", err)
+		s.storeInitErrors.Inc()
 	}
 	if alertsByRule == nil {
 		alertsByRule = make(map[uint64][]*Alert)
@@ -77,7 +94,7 @@ func (s *FileStore) GetAlerts(key uint64) (map[uint64]*Alert, error) {
 }
 
 // SetAlerts updates the stateByRule map and writes state to file storage.
-func (s *FileStore) SetAlerts(key uint64, alerts []*Alert) error {
+func (s *FileStore) SetAlerts(key uint64, groupKey string, alerts []*Alert) error {
 	s.stateMtx.Lock()
 	defer s.stateMtx.Unlock()
 
@@ -88,6 +105,7 @@ func (s *FileStore) SetAlerts(key uint64, alerts []*Alert) error {
 	// flush in memory state to file storage
 	file, err := os.Create(s.path)
 	if err != nil {
+		s.alertStoreErrors.WithLabelValues(groupKey).Inc()
 		return err
 	}
 	defer file.Close()
@@ -95,6 +113,7 @@ func (s *FileStore) SetAlerts(key uint64, alerts []*Alert) error {
 	encoder := json.NewEncoder(file)
 	err = encoder.Encode(s.alertsByRule)
 	if err != nil {
+		s.alertStoreErrors.WithLabelValues(groupKey).Inc()
 		return err
 	}
 	return nil

--- a/rules/store.go
+++ b/rules/store.go
@@ -115,12 +115,12 @@ func (s *FileStore) SetAlerts(key uint64, groupKey string, alerts []*Alert) erro
 	s.stateMtx.Lock()
 	defer s.stateMtx.Unlock()
 
-	// Update in memory
-	if alerts != nil {
-		s.alertsByRule[key] = alerts
-	} else {
+	if alerts == nil {
 		return nil
 	}
+	// Update in memory
+	s.alertsByRule[key] = alerts
+
 	// flush in memory state to file storage
 	file, err := os.Create(s.path)
 	if err != nil {

--- a/rules/store.go
+++ b/rules/store.go
@@ -1,0 +1,101 @@
+package rules
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"sync"
+)
+
+// AlertStore provides persistent storage of alert state.
+type AlertStore interface {
+	// SetAlerts stores the provided list of alerts for a rule.
+	SetAlerts(key uint64, alerts []*Alert) error
+	// GetAlerts returns a list of alerts for each alerting rule,
+	// alerting rule is identified by a fingerprint of its config.
+	GetAlerts(key uint64) (map[uint64]*Alert, error)
+}
+
+// FileStore implements the AlertStore interface.
+type FileStore struct {
+	logger       *slog.Logger
+	alertsByRule map[uint64][]*Alert
+	//protects the `alertsByRule` map
+	stateMtx sync.RWMutex
+	path     string
+}
+
+func NewFileStore(l *slog.Logger, storagePath string) *FileStore {
+	s := &FileStore{
+		logger:       l,
+		alertsByRule: make(map[uint64][]*Alert),
+		path:         storagePath,
+	}
+	s.initState()
+	return s
+}
+
+// initState reads the state from file storage into the alertsByRule map
+func (s *FileStore) initState() {
+	file, err := os.OpenFile(s.path, os.O_RDWR|os.O_CREATE, 0o666)
+	if err != nil {
+		s.logger.Error("Failed reading alerts state from file", "err", err)
+		return
+	}
+	defer file.Close()
+
+	var alertsByRule map[uint64][]*Alert
+	err = json.NewDecoder(file).Decode(&alertsByRule)
+	if err != nil {
+		s.logger.Error("Failed reading alerts state from file", "err", err)
+	}
+	if alertsByRule == nil {
+		alertsByRule = make(map[uint64][]*Alert)
+	}
+	s.alertsByRule = alertsByRule
+}
+
+// GetAlerts returns the stored alerts for an alerting rule
+// Alert state is read from the in memory map which is populated during initialization
+func (s *FileStore) GetAlerts(key uint64) (map[uint64]*Alert, error) {
+	s.stateMtx.RLock()
+	defer s.stateMtx.RUnlock()
+
+	restoredAlerts, ok := s.alertsByRule[key]
+	if !ok {
+		return nil, nil
+	}
+	alerts := make(map[uint64]*Alert)
+	for _, alert := range restoredAlerts {
+		if alert == nil {
+			continue
+		}
+		h := alert.Labels.Hash()
+		alerts[h] = alert
+	}
+	return alerts, nil
+}
+
+// SetAlerts updates the stateByRule map and writes state to file storage
+func (s *FileStore) SetAlerts(key uint64, alerts []*Alert) error {
+	s.stateMtx.Lock()
+	defer s.stateMtx.Unlock()
+
+	// Update in memory
+	if alerts != nil {
+		s.alertsByRule[key] = alerts
+	}
+	// flush in memory state to file storage
+	file, err := os.Create(s.path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	err = encoder.Encode(s.alertsByRule)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/rules/store_test.go
+++ b/rules/store_test.go
@@ -1,0 +1,46 @@
+package rules
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/promslog"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertStore(t *testing.T) {
+	alertStore := NewFileStore(promslog.NewNopLogger(), "alertstoretest")
+	t.Cleanup(func() {
+		os.Remove("alertstoretest")
+	})
+
+	alertsByRule := make(map[uint64][]*Alert)
+	baseTime := time.Now()
+	al1 := &Alert{State: StateFiring, Labels: labels.FromStrings("a1", "1"), Annotations: labels.FromStrings("annotation1", "a1"), ActiveAt: baseTime, KeepFiringSince: baseTime}
+	al2 := &Alert{State: StateFiring, Labels: labels.FromStrings("a2", "2"), Annotations: labels.FromStrings("annotation2", "a2"), ActiveAt: baseTime, KeepFiringSince: baseTime}
+
+	alertsByRule[1] = []*Alert{al1, al2}
+	alertsByRule[2] = []*Alert{al2}
+	alertsByRule[3] = []*Alert{al1}
+	alertsByRule[4] = []*Alert{}
+
+	for key, alerts := range alertsByRule {
+		err := alertStore.SetAlerts(key, alerts)
+		require.NoError(t, err)
+
+		got, err := alertStore.GetAlerts(key)
+		require.NoError(t, err)
+		require.Equal(t, len(alerts), len(got))
+		j := 0
+		for _, al := range got {
+			require.Equal(t, alerts[j].State, al.State)
+			require.Equal(t, alerts[j].Labels, al.Labels)
+			require.Equal(t, alerts[j].Annotations, al.Annotations)
+			require.Equal(t, alerts[j].ActiveAt, al.ActiveAt)
+			require.Equal(t, alerts[j].KeepFiringSince, al.KeepFiringSince)
+			j++
+		}
+	}
+}

--- a/rules/store_test.go
+++ b/rules/store_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAlertStore(t *testing.T) {
@@ -27,14 +28,22 @@ func TestAlertStore(t *testing.T) {
 	alertsByRule[4] = []*Alert{}
 
 	for key, alerts := range alertsByRule {
+		sortAlerts(alerts)
 		err := alertStore.SetAlerts(key, alerts)
 		require.NoError(t, err)
 
 		got, err := alertStore.GetAlerts(key)
 		require.NoError(t, err)
 		require.Equal(t, len(alerts), len(got))
+
+		result := make([]*Alert, 0, len(got))
+		for _, value := range got {
+			result = append(result, value)
+		}
+		sortAlerts(result)
+
 		j := 0
-		for _, al := range got {
+		for _, al := range result {
 			require.Equal(t, alerts[j].State, al.State)
 			require.Equal(t, alerts[j].Labels, al.Labels)
 			require.Equal(t, alerts[j].Annotations, al.Annotations)

--- a/rules/store_test.go
+++ b/rules/store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/common/promslog"
@@ -12,7 +13,7 @@ import (
 )
 
 func TestAlertStore(t *testing.T) {
-	alertStore := NewFileStore(promslog.NewNopLogger(), "alertstoretest")
+	alertStore := NewFileStore(promslog.NewNopLogger(), "alertstoretest", prometheus.NewRegistry())
 	t.Cleanup(func() {
 		os.Remove("alertstoretest")
 	})
@@ -29,7 +30,7 @@ func TestAlertStore(t *testing.T) {
 
 	for key, alerts := range alertsByRule {
 		sortAlerts(alerts)
-		err := alertStore.SetAlerts(key, alerts)
+		err := alertStore.SetAlerts(key, "test/test1", alerts)
 		require.NoError(t, err)
 
 		got, err := alertStore.GetAlerts(key)

--- a/rules/store_test.go
+++ b/rules/store_test.go
@@ -48,7 +48,7 @@ func TestAlertStore(t *testing.T) {
 
 		got, err := alertStore.GetAlerts(key)
 		require.NoError(t, err)
-		require.Equal(t, len(alerts), len(got))
+		require.Len(t, got, len(alerts))
 
 		result := make([]*Alert, 0, len(got))
 		for _, value := range got {

--- a/rules/store_test.go
+++ b/rules/store_test.go
@@ -1,3 +1,16 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rules
 
 import (
@@ -6,9 +19,9 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
-	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/prometheus/model/labels"
 )
 


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR resolves issue #13957 

This is a second attempt using a file based storage to add persistence for alerts 'keep_firing_for' state which is currently lost whenever Prometheus restarts. Feedback on previous attempt was to use native storage similar to ALERTS_FOR_STATE.

Justification for not using TSDB:

- In case of alerts using keep_firing_for, when Prometheus restarts the alerts are no longer active since the expression was resolved prior to restart which means we lose the alert labels, annotations and value. To restore the alert we need more than just the `KeepFiringSince` timestamp. 
  - For each alert, need to store 2 label sets (alert labels & alert annotations), and 3 floating point values (ActiveAt and KeepFiringSince time, Value of alert expression)
- Since labels and annotations are dependent on user config, it can lead to high label cardinality samples.
- Inefficient to store multiple samples per alert when we only need to maintain latest alert state. Using an object/key-value store is more appropriate for this use case. There is no need to retain previous samples/data.
- Additional cost of samples to Prometheus users

Implementation details:

- Feature is behind a flag (`alert-state-persistence`), storage path can be set using `rules.alert.state-storage-path`
- Added a hook to store alerts, invoked at the end of each group evaluation. State is restored from storage during the first group evaluation.
- Store uses an in memory map to optimize reads, map is populated when store is initialized. I.e we only read the file once initially.
- When storing alerts, in memory map is updated before flushing state to file. Alerts are stored after each group evaluation given for each rule where `keep_firing_for` is set.


Performance with ~1000 rule groups:
each spike represents a server restart:
![image](https://github.com/prometheus/prometheus/assets/38258861/74cfef2c-f6bb-44ae-b57e-d0caf08eb22c) 
