### PR TITLE
Rules: Refactor concurrency controller interface

### DIFF
--- a/rules/group.go
+++ b/rules/group.go
@@ -623,12 +623,12 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 
 		// If the rule has no dependencies, it can run concurrently because no other rules in this group depend on its output.
 		// Try run concurrently if there are slots available.
-		if ctrl := g.concurrencyController; isRuleEligibleForConcurrentExecution(rule) && ctrl.Allow() {
+		if ctrl := g.concurrencyController; ctrl.Allow(ctx, g, rule) {
 			wg.Add(1)
 
 			go eval(i, rule, func() {
 				wg.Done()
-				ctrl.Done()
+				ctrl.Done(ctx, g, rule)
 			})
 		} else {
 			eval(i, rule, nil)
@@ -1093,8 +1093,4 @@ func buildDependencyMap(rules []Rule) dependencyMap {
 	}
 
 	return dependencies
-}
-
-func isRuleEligibleForConcurrentExecution(rule Rule) bool {
-	return rule.NoDependentRules() && rule.NoDependencyRules()
 }

--- a/rules/group.go
+++ b/rules/group.go
@@ -621,8 +621,6 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			}
 		}
 
-		// If the rule has no dependencies, it can run concurrently because no other rules in this group depend on its output.
-		// Try run concurrently if there are slots available.
 		if ctrl := g.concurrencyController; ctrl.Allow(ctx, g, rule) {
 			wg.Add(1)
 

--- a/rules/group.go
+++ b/rules/group.go
@@ -626,7 +626,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 
 			go eval(i, rule, func() {
 				wg.Done()
-				ctrl.Done(ctx, g, rule)
+				ctrl.Done(ctx)
 			})
 		} else {
 			eval(i, rule, nil)

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -462,7 +462,7 @@ type RuleConcurrencyController interface {
 	Allow(ctx context.Context, group *Group, rule Rule) bool
 
 	// Done releases a concurrent evaluation slot.
-	Done(ctx context.Context, group *Group, rule Rule)
+	Done(ctx context.Context)
 }
 
 // concurrentRuleEvalController holds a weighted semaphore which controls the concurrent evaluation of rules.
@@ -488,7 +488,7 @@ func (c *concurrentRuleEvalController) Allow(_ context.Context, _ *Group, rule R
 	return false
 }
 
-func (c *concurrentRuleEvalController) Done(_ context.Context, _ *Group, _ Rule) {
+func (c *concurrentRuleEvalController) Done(_ context.Context) {
 	c.sema.Release(1)
 }
 
@@ -499,4 +499,4 @@ func (c sequentialRuleEvalController) Allow(_ context.Context, _ *Group, _ Rule)
 	return false
 }
 
-func (c sequentialRuleEvalController) Done(_ context.Context, _ *Group, _ Rule) {}
+func (c sequentialRuleEvalController) Done(_ context.Context) {}

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -491,8 +491,8 @@ func (c *concurrentRuleEvalController) Done(_ context.Context, _ *Group, _ Rule)
 // sequentialRuleEvalController is a RuleConcurrencyController that runs every rule sequentially.
 type sequentialRuleEvalController struct{}
 
-func (c sequentialRuleEvalController) Allow(_ context.Context, _ *Group, rule Rule) bool {
-	return rule.NoDependentRules() && rule.NoDependencyRules()
+func (c sequentialRuleEvalController) Allow(_ context.Context, _ *Group, _ Rule) bool {
+	return false
 }
 
 func (c sequentialRuleEvalController) Done(_ context.Context, _ *Group, _ Rule) {}

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -459,6 +459,7 @@ func (c ruleDependencyController) AnalyseRules(rules []Rule) {
 type RuleConcurrencyController interface {
 	// Allow determines if the given rule is allowed to be evaluated concurrently.
 	// If Allow() returns true, then Done() must be called to release the acquired slot and corresponding cleanup is done.
+	// It is important that both *Group and Rule are not retained and only be used for the duration of the call.
 	Allow(ctx context.Context, group *Group, rule Rule) bool
 
 	// Done releases a concurrent evaluation slot.

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -467,15 +467,12 @@ type RuleConcurrencyController interface {
 
 // concurrentRuleEvalController holds a weighted semaphore which controls the concurrent evaluation of rules.
 type concurrentRuleEvalController struct {
-	sema      *semaphore.Weighted
-	depMapsMu sync.Mutex
-	depMaps   map[*Group]dependencyMap
+	sema *semaphore.Weighted
 }
 
 func newRuleConcurrencyController(maxConcurrency int64) RuleConcurrencyController {
 	return &concurrentRuleEvalController{
-		sema:    semaphore.NewWeighted(maxConcurrency),
-		depMaps: map[*Group]dependencyMap{},
+		sema: semaphore.NewWeighted(maxConcurrency),
 	}
 }
 

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -2096,7 +2096,7 @@ func TestBoundedRuleEvalConcurrency(t *testing.T) {
 	wg.Wait()
 
 	// Synchronous queries also count towards inflight, so at most we can have maxConcurrency+$groupCount inflight evaluations.
-	require.EqualValues(t, maxInflight.Load(), int32(maxConcurrency)+int32(groupCount))
+	require.LessOrEqual(t, maxInflight.Load(), int32(maxConcurrency)+int32(groupCount))
 }
 
 func TestUpdateWhenStopped(t *testing.T) {

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -2096,7 +2096,7 @@ func TestBoundedRuleEvalConcurrency(t *testing.T) {
 	wg.Wait()
 
 	// Synchronous queries also count towards inflight, so at most we can have maxConcurrency+$groupCount inflight evaluations.
-	require.LessOrEqual(t, maxInflight.Load(), int32(maxConcurrency)+int32(groupCount))
+	require.EqualValues(t, maxInflight.Load(), int32(maxConcurrency)+int32(groupCount))
 }
 
 func TestUpdateWhenStopped(t *testing.T) {


### PR DESCRIPTION
Even though the main purpose of this refactor is to modify the interface of the concurrency controller to accept a Context. I did two drive-by modifications that I think are sensible:

1. I have moved the check for dependencies on rules to the controller itself. This aligns with how the controller should behave, as it is a deciding factor in whether we should run concurrently or not.
2. I cleaned up some unused methods from the days of the old interface before #13527 changed it.