### PR TITLE
query_logger : bugfix mmap file when no disk space

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -55,7 +55,8 @@ func TestMain(m *testing.M) {
 func TestQueryConcurrency(t *testing.T) {
 	maxConcurrency := 10
 
-	queryTracker := promql.NewActiveQueryTracker(t.TempDir(), maxConcurrency, nil)
+	queryTracker, err := promql.NewActiveQueryTracker(t.TempDir(), maxConcurrency, nil)
+	require.NoError(t, err)
 	opts := promql.EngineOpts{
 		Logger:             nil,
 		Reg:                nil,


### PR DESCRIPTION
If sparse files are supported, `ftruncate` will modify the `filesize` as asked, but will not actually allocate/reserve the space on disk.

When a write is attempted after memory mapping this file, `SIGBUS` is received.

It is preferable to report the lack of disk space to the user and terminate gracefully.

Additionally, mapped memory must be sync'd or changes may not be actually written. This is done by calling the Flush() api from mmap.

Fixes #9923
