### PR TITLE
clarify that 1.0 will eventually be deprecated, it is not yet deprecated

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1085,8 +1085,9 @@ func (m RemoteWriteProtoMsgs) String() string {
 }
 
 var (
-	// RemoteWriteProtoMsgV1 represents the deprecated `prometheus.WriteRequest` protobuf
-	// message introduced in the https://prometheus.io/docs/specs/remote_write_spec/.
+	// RemoteWriteProtoMsgV1 represents the `prometheus.WriteRequest` protobuf
+	// message introduced in the https://prometheus.io/docs/specs/remote_write_spec/,
+	// which will eventually be deprecated.
 	//
 	// NOTE: This string is used for both HTTP header values and config value, so don't change
 	// this reference.

--- a/documentation/examples/remote_storage/example_write_adapter/README.md
+++ b/documentation/examples/remote_storage/example_write_adapter/README.md
@@ -19,7 +19,7 @@ remote_write:
     protobuf_message: "io.prometheus.write.v2.Request"
 ```
 
-or for deprecated Remote Write 1.0 message:
+or for the eventually deprecated Remote Write 1.0 message:
 
 ```yaml
 remote_write:


### PR DESCRIPTION
Addressing comments from @bboreham on https://github.com/prometheus/prometheus/pull/14395 re: status of RW1.0