### PR TITLE
TSDB: Optimization: Merge postings using concrete type

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -103,20 +103,7 @@ func (h *headIndexReader) LabelNames(ctx context.Context, matchers ...*labels.Ma
 
 // Postings returns the postings list iterator for the label pairs.
 func (h *headIndexReader) Postings(ctx context.Context, name string, values ...string) (index.Postings, error) {
-	switch len(values) {
-	case 0:
-		return index.EmptyPostings(), nil
-	case 1:
-		return h.head.postings.Get(name, values[0]), nil
-	default:
-		res := make([]index.Postings, 0, len(values))
-		for _, value := range values {
-			if p := h.head.postings.Get(name, value); !index.IsEmptyPostingsType(p) {
-				res = append(res, p)
-			}
-		}
-		return index.Merge(ctx, res...), nil
-	}
+	return h.head.postings.Postings(ctx, name, values...), nil
 }
 
 func (h *headIndexReader) PostingsForLabelMatching(ctx context.Context, name string, match func(string) bool) index.Postings {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -962,12 +962,12 @@ func TestHead_Truncate(t *testing.T) {
 	require.Nil(t, h.series.getByID(s3.ref))
 	require.Nil(t, h.series.getByID(s4.ref))
 
-	postingsA1, _ := index.ExpandPostings(h.postings.Get("a", "1"))
-	postingsA2, _ := index.ExpandPostings(h.postings.Get("a", "2"))
-	postingsB1, _ := index.ExpandPostings(h.postings.Get("b", "1"))
-	postingsB2, _ := index.ExpandPostings(h.postings.Get("b", "2"))
-	postingsC1, _ := index.ExpandPostings(h.postings.Get("c", "1"))
-	postingsAll, _ := index.ExpandPostings(h.postings.Get("", ""))
+	postingsA1, _ := index.ExpandPostings(h.postings.Postings(ctx, "a", "1"))
+	postingsA2, _ := index.ExpandPostings(h.postings.Postings(ctx, "a", "2"))
+	postingsB1, _ := index.ExpandPostings(h.postings.Postings(ctx, "b", "1"))
+	postingsB2, _ := index.ExpandPostings(h.postings.Postings(ctx, "b", "2"))
+	postingsC1, _ := index.ExpandPostings(h.postings.Postings(ctx, "c", "1"))
+	postingsAll, _ := index.ExpandPostings(h.postings.Postings(ctx, "", ""))
 
 	require.Equal(t, []storage.SeriesRef{storage.SeriesRef(s1.ref)}, postingsA1)
 	require.Equal(t, []storage.SeriesRef{storage.SeriesRef(s2.ref)}, postingsA2)

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -660,7 +660,7 @@ func (it *intersectPostings) Err() error {
 }
 
 // Merge returns a new iterator over the union of the input iterators.
-func Merge(_ context.Context, its ...Postings) Postings {
+func Merge[T Postings](_ context.Context, its ...T) Postings {
 	if len(its) == 0 {
 		return EmptyPostings()
 	}
@@ -675,19 +675,19 @@ func Merge(_ context.Context, its ...Postings) Postings {
 	return p
 }
 
-type mergedPostings struct {
-	p   []Postings
-	h   *loser.Tree[storage.SeriesRef, Postings]
+type mergedPostings[T Postings] struct {
+	p   []T
+	h   *loser.Tree[storage.SeriesRef, T]
 	cur storage.SeriesRef
 }
 
-func newMergedPostings(p []Postings) (m *mergedPostings, nonEmpty bool) {
+func newMergedPostings[T Postings](p []T) (m *mergedPostings[T], nonEmpty bool) {
 	const maxVal = storage.SeriesRef(math.MaxUint64) // This value must be higher than all real values used in the tree.
 	lt := loser.New(p, maxVal)
-	return &mergedPostings{p: p, h: lt}, true
+	return &mergedPostings[T]{p: p, h: lt}, true
 }
 
-func (it *mergedPostings) Next() bool {
+func (it *mergedPostings[T]) Next() bool {
 	for {
 		if !it.h.Next() {
 			return false
@@ -701,7 +701,7 @@ func (it *mergedPostings) Next() bool {
 	}
 }
 
-func (it *mergedPostings) Seek(id storage.SeriesRef) bool {
+func (it *mergedPostings[T]) Seek(id storage.SeriesRef) bool {
 	for !it.h.IsEmpty() && it.h.At() < id {
 		finished := !it.h.Winner().Seek(id)
 		it.h.Fix(finished)
@@ -713,11 +713,11 @@ func (it *mergedPostings) Seek(id storage.SeriesRef) bool {
 	return true
 }
 
-func (it mergedPostings) At() storage.SeriesRef {
+func (it mergedPostings[T]) At() storage.SeriesRef {
 	return it.cur
 }
 
-func (it mergedPostings) Err() error {
+func (it mergedPostings[T]) Err() error {
 	for _, p := range it.p {
 		if err := p.Err(); err != nil {
 			return err

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -392,7 +392,7 @@ func BenchmarkMerge(t *testing.B) {
 		refs = append(refs, temp)
 	}
 
-	its := make([]Postings, len(refs))
+	its := make([]*ListPostings, len(refs))
 	for _, nSeries := range []int{1, 10, 10000, 100000} {
 		t.Run(strconv.Itoa(nSeries), func(bench *testing.B) {
 			ctx := context.Background()

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -393,7 +393,7 @@ func BenchmarkMerge(t *testing.B) {
 	}
 
 	its := make([]Postings, len(refs))
-	for _, nSeries := range []int{1, 10, 100, 1000, 10000, 100000} {
+	for _, nSeries := range []int{1, 10, 10000, 100000} {
 		t.Run(strconv.Itoa(nSeries), func(bench *testing.B) {
 			ctx := context.Background()
 			for i := 0; i < bench.N; i++ {

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -979,7 +979,7 @@ func TestMemPostings_Delete(t *testing.T) {
 	p.Add(2, labels.FromStrings("lbl1", "b"))
 	p.Add(3, labels.FromStrings("lbl2", "a"))
 
-	before := p.Get(allPostingsKey.Name, allPostingsKey.Value)
+	before := p.Postings(context.Background(), allPostingsKey.Name, allPostingsKey.Value)
 	deletedRefs := map[storage.SeriesRef]struct{}{
 		2: {},
 	}
@@ -987,7 +987,7 @@ func TestMemPostings_Delete(t *testing.T) {
 		{Name: "lbl1", Value: "b"}: {},
 	}
 	p.Delete(deletedRefs, affectedLabels)
-	after := p.Get(allPostingsKey.Name, allPostingsKey.Value)
+	after := p.Postings(context.Background(), allPostingsKey.Name, allPostingsKey.Value)
 
 	// Make sure postings gotten before the delete have the old data when
 	// iterated over.
@@ -1001,7 +1001,7 @@ func TestMemPostings_Delete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []storage.SeriesRef{1, 3}, expanded)
 
-	deleted := p.Get("lbl1", "b")
+	deleted := p.Postings(context.Background(), "lbl1", "b")
 	expanded, err = ExpandPostings(deleted)
 	require.NoError(t, err)
 	require.Empty(t, expanded, "expected empty postings, got %v", expanded)
@@ -1073,7 +1073,7 @@ func BenchmarkMemPostings_Delete(b *testing.B) {
 									return
 								default:
 									// Get a random value of this label.
-									p.Get(lbl, itoa(rand.Intn(10000))).Next()
+									p.Postings(context.Background(), lbl, itoa(rand.Intn(10000))).Next()
 								}
 							}
 						}(i)

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1410,12 +1410,15 @@ func BenchmarkMemPostings_PostingsForLabelMatching(b *testing.B) {
 	slowRegexp := "^" + slowRegexpString() + "$"
 	b.Logf("Slow regexp length = %d", len(slowRegexp))
 	slow := regexp.MustCompile(slowRegexp)
+	const seriesPerLabel = 10
 
 	for _, labelValueCount := range []int{1_000, 10_000, 100_000} {
 		b.Run(fmt.Sprintf("labels=%d", labelValueCount), func(b *testing.B) {
 			mp := NewMemPostings()
 			for i := 0; i < labelValueCount; i++ {
-				mp.Add(storage.SeriesRef(i), labels.FromStrings("label", strconv.Itoa(i)))
+				for j := 0; j < seriesPerLabel; j++ {
+					mp.Add(storage.SeriesRef(i*seriesPerLabel+j), labels.FromStrings("__name__", strconv.Itoa(j), "label", strconv.Itoa(i)))
+				}
 			}
 
 			fp, err := ExpandPostings(mp.PostingsForLabelMatching(context.Background(), "label", fast.MatchString))
@@ -1433,6 +1436,18 @@ func BenchmarkMemPostings_PostingsForLabelMatching(b *testing.B) {
 			b.Run("matcher=slow", func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					mp.PostingsForLabelMatching(context.Background(), "label", slow.MatchString).Next()
+				}
+			})
+
+			b.Run("matcher=all", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					// Match everything.
+					p := mp.PostingsForLabelMatching(context.Background(), "label", func(_ string) bool { return true })
+					var sum storage.SeriesRef
+					// Iterate through all results to exercise merge function.
+					for p.Next() {
+						sum += p.At()
+					}
 				}
 			})
 		})


### PR DESCRIPTION
Make `mergedPostings` generic, so we can call it with more specific types which is more efficient than making everything go through the `Postings` interface.

Move merge of head postings into index; remove the `Get` member which was not used for anything else, and fix up
tests.

~Unexport `PostingsFromDecbuf`; it looks like it should not have been exported.~

Preparatory work:
* Extend BenchmarkMemPostings_PostingsForLabelMatching to check merge speed.
* TSDB BenchmarkMerge: run fewer sizes.

Benchmark results:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb/index
cpu: Intel(R) Core(TM) i7-14700K
                                                                   │ before.txt  │              after.txt              │
                                                                   │   sec/op    │    sec/op     vs base               │
Intersect/LongPostings1-28                                           10.70µ ± 0%    10.75µ ± 1%   +0.46% (p=0.026 n=6)
Intersect/LongPostings2-28                                           42.63m ± 2%    41.13m ± 1%   -3.53% (p=0.002 n=6)
Intersect/ManyPostings-28                                            111.9m ± 2%    111.0m ± 3%        ~ (p=0.699 n=6)
Merge/1-28                                                           193.5n ± 0%    177.8n ± 1%   -8.09% (p=0.002 n=6)
Merge/10-28                                                          9.947µ ± 0%   10.327µ ± 0%   +3.82% (p=0.002 n=6)
Merge/10000-28                                                       17.16m ± 2%    15.29m ± 3%  -10.92% (p=0.002 n=6)
Merge/100000-28                                                      241.8m ± 8%    199.3m ± 7%  -17.57% (p=0.002 n=6)
MemPostings_PostingsForLabelMatching/labels=1000/matcher=fast-28     27.89µ ± 0%    27.08µ ± 2%   -2.91% (p=0.002 n=6)
MemPostings_PostingsForLabelMatching/labels=1000/matcher=slow-28     4.894µ ± 4%    4.675µ ± 1%   -4.48% (p=0.002 n=6)
MemPostings_PostingsForLabelMatching/labels=1000/matcher=all-28      176.7µ ± 2%    159.1µ ± 0%   -9.95% (p=0.002 n=6)
MemPostings_PostingsForLabelMatching/labels=10000/matcher=fast-28    282.2µ ± 1%    282.0µ ± 1%        ~ (p=0.818 n=6)
MemPostings_PostingsForLabelMatching/labels=10000/matcher=slow-28    185.7m ± 2%    188.0m ± 3%        ~ (p=0.394 n=6)
MemPostings_PostingsForLabelMatching/labels=10000/matcher=all-28     2.055m ± 7%    1.804m ± 2%  -12.25% (p=0.002 n=6)
MemPostings_PostingsForLabelMatching/labels=100000/matcher=fast-28   2.902m ± 1%    2.842m ± 1%   -2.07% (p=0.004 n=6)
MemPostings_PostingsForLabelMatching/labels=100000/matcher=slow-28    2.371 ± 3%     2.331 ± 2%        ~ (p=0.240 n=6)
MemPostings_PostingsForLabelMatching/labels=100000/matcher=all-28    24.17m ± 1%    21.35m ± 1%  -11.67% (p=0.002 n=6)
PostingStatsMaxHep-28                                                54.28m ± 0%    34.04m ± 0%  -37.28% (p=0.002 n=6)
geomean                                                              1.715m         1.586m        -7.49%

                                                                   │    before.txt    │               after.txt                │
                                                                   │       B/op       │     B/op       vs base                 │
Intersect/LongPostings1-28                                              224.0 ±  0%       224.0 ±  0%        ~ (p=1.000 n=6) ¹
Intersect/LongPostings2-28                                              224.0 ±  0%       224.0 ±  0%        ~ (p=1.000 n=6) ¹
Intersect/ManyPostings-28                                               32.00 ±  0%       32.00 ±  0%        ~ (p=1.000 n=6) ¹
Merge/1-28                                                              0.000 ±  0%       0.000 ±  0%        ~ (p=1.000 n=6) ¹
Merge/10-28                                                             784.0 ±  0%       560.0 ±  0%  -28.57% (p=0.002 n=6)
Merge/10000-28                                                        632.1Ki ±  0%     472.1Ki ±  0%  -25.31% (p=0.002 n=6)
Merge/100000-28                                                       6.109Mi ±  0%     4.578Mi ±  0%  -25.06% (p=0.002 n=6)
MemPostings_PostingsForLabelMatching/labels=1000/matcher=fast-28      16.33Ki ±  0%     16.28Ki ±  0%   -0.29% (p=0.002 n=6)
MemPostings_PostingsForLabelMatching/labels=1000/matcher=slow-28      16.02Ki ±  0%     16.02Ki ±  0%        ~ (p=1.000 n=6) ¹
MemPostings_PostingsForLabelMatching/labels=1000/matcher=all-28       128.1Ki ±  0%     104.1Ki ±  0%  -18.74% (p=0.002 n=6)
MemPostings_PostingsForLabelMatching/labels=10000/matcher=fast-28     160.4Ki ±  0%     160.3Ki ±  0%   -0.03% (p=0.002 n=6)
MemPostings_PostingsForLabelMatching/labels=10000/matcher=slow-28     356.2Ki ± 55%     355.9Ki ± 55%        ~ (p=0.143 n=6)
MemPostings_PostingsForLabelMatching/labels=10000/matcher=all-28      1.242Mi ±  0%     1.008Mi ±  0%  -18.87% (p=0.002 n=6)
MemPostings_PostingsForLabelMatching/labels=100000/matcher=fast-28    1.532Mi ±  0%     1.532Mi ±  0%   -0.00% (p=0.002 n=6)
MemPostings_PostingsForLabelMatching/labels=100000/matcher=slow-28    2.483Mi ± 23%     2.971Mi ±  0%        ~ (p=1.000 n=6)
MemPostings_PostingsForLabelMatching/labels=100000/matcher=all-28    12.227Mi ±  0%     9.930Mi ±  0%  -18.79% (p=0.002 n=6)
PostingStatsMaxHep-28                                                   240.0 ±  0%       240.0 ±  0%        ~ (p=1.000 n=6) ¹
geomean                                                                             ²                   -7.72%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                                   │   before.txt    │               after.txt                │
                                                                   │    allocs/op    │   allocs/op     vs base                │
Intersect/LongPostings1-28                                            6.000 ±   0%       6.000 ±   0%       ~ (p=1.000 n=6) ¹
Intersect/LongPostings2-28                                            6.000 ±   0%       6.000 ±   0%       ~ (p=1.000 n=6) ¹
Intersect/ManyPostings-28                                             1.000 ±   0%       1.000 ±   0%       ~ (p=1.000 n=6) ¹
Merge/1-28                                                            0.000 ±   0%       0.000 ±   0%       ~ (p=1.000 n=6) ¹
Merge/10-28                                                           3.000 ±   0%       3.000 ±   0%       ~ (p=1.000 n=6) ¹
Merge/10000-28                                                        3.000 ±   0%       3.000 ±   0%       ~ (p=1.000 n=6) ¹
Merge/100000-28                                                       3.000 ±   0%       3.000 ±   0%       ~ (p=1.000 n=6) ¹
MemPostings_PostingsForLabelMatching/labels=1000/matcher=fast-28      6.000 ±   0%       6.000 ±   0%       ~ (p=1.000 n=6) ¹
MemPostings_PostingsForLabelMatching/labels=1000/matcher=slow-28      2.000 ±   0%       2.000 ±   0%       ~ (p=1.000 n=6) ¹
MemPostings_PostingsForLabelMatching/labels=1000/matcher=all-28       6.000 ±   0%       6.000 ±   0%       ~ (p=1.000 n=6) ¹
MemPostings_PostingsForLabelMatching/labels=10000/matcher=fast-28     6.000 ±   0%       6.000 ±   0%       ~ (p=1.000 n=6) ¹
MemPostings_PostingsForLabelMatching/labels=10000/matcher=slow-28    2.042k ± 100%      2.032k ± 100%       ~ (p=0.147 n=6)
MemPostings_PostingsForLabelMatching/labels=10000/matcher=all-28      6.000 ±   0%       6.000 ±   0%       ~ (p=1.000 n=6) ¹
MemPostings_PostingsForLabelMatching/labels=100000/matcher=fast-28    6.000 ±   0%       6.000 ±   0%       ~ (p=1.000 n=6) ¹
MemPostings_PostingsForLabelMatching/labels=100000/matcher=slow-28   6.129k ± 100%     12.186k ±   0%       ~ (p=1.000 n=6)
MemPostings_PostingsForLabelMatching/labels=100000/matcher=all-28     6.000 ±   0%       6.000 ±   0%       ~ (p=1.000 n=6) ¹
PostingStatsMaxHep-28                                                 1.000 ±   0%       1.000 ±   0%       ~ (p=1.000 n=6) ¹
geomean                                                                            ²                   +4.10%               ²
```
