### PR TITLE
Use CopyTo when resetting histogram in stats iterator

### DIFF
--- a/promql/histogram_stats_iterator.go
+++ b/promql/histogram_stats_iterator.go
@@ -62,9 +62,13 @@ func (f *histogramStatsIterator) AtHistogram(h *histogram.Histogram) (int64, *hi
 		return t, h
 	}
 
-	h.CounterResetHint = f.getResetHint(f.currentH)
-	h.Count = f.currentH.Count
-	h.Sum = f.currentH.Sum
+	returnValue := histogram.Histogram{
+		CounterResetHint: f.getResetHint(f.currentH),
+		Count:            f.currentH.Count,
+		Sum:              f.currentH.Sum,
+	}
+	returnValue.CopyTo(h)
+
 	f.setLastH(f.currentH)
 	return t, h
 }
@@ -89,9 +93,13 @@ func (f *histogramStatsIterator) AtFloatHistogram(fh *histogram.FloatHistogram) 
 		return t, fh
 	}
 
-	fh.CounterResetHint = f.getFloatResetHint(f.currentFH.CounterResetHint)
-	fh.Count = f.currentFH.Count
-	fh.Sum = f.currentFH.Sum
+	returnValue := histogram.FloatHistogram{
+		CounterResetHint: f.getFloatResetHint(f.currentFH.CounterResetHint),
+		Count:            f.currentFH.Count,
+		Sum:              f.currentFH.Sum,
+	}
+	returnValue.CopyTo(fh)
+
 	f.setLastFH(f.currentFH)
 	return t, fh
 }


### PR DESCRIPTION
The histogram stats iterator does not fully clear the histogram object and is not resilient to new fields being added to the histogram type.

To resolve the issue, the commit uses the CopyTo methods which should be future proof to new fields being added.

There's no significant difference in benchmarks before and after.

```
prometheus $ benchstat main.out branch.out
name                                                          old time/op    new time/op    delta
NativeHistograms/sum-11                                          417ms ± 2%     408ms ± 1%  -2.06%  (p=0.016 n=5+5)
NativeHistograms/sum_rate_with_short_rate_interval-11            561ms ± 4%     548ms ± 5%    ~     (p=0.310 n=5+5)
NativeHistograms/sum_rate_with_long_rate_interval-11             928ms ± 1%     876ms ± 0%  -5.55%  (p=0.008 n=5+5)
NativeHistograms/histogram_count_with_short_rate_interval-11     368ms ± 6%     381ms ±17%    ~     (p=0.841 n=5+5)
NativeHistograms/histogram_count_with_long_rate_interval-11      568ms ± 5%     585ms ± 0%    ~     (p=0.151 n=5+5)

name                                                          old alloc/op   new alloc/op   delta
NativeHistograms/sum-11                                          448MB ± 0%     448MB ± 0%    ~     (p=0.841 n=5+5)
NativeHistograms/sum_rate_with_short_rate_interval-11            227MB ± 0%     227MB ± 0%    ~     (p=1.000 n=5+5)
NativeHistograms/sum_rate_with_long_rate_interval-11             349MB ± 0%     349MB ± 0%    ~     (p=0.310 n=5+5)
NativeHistograms/histogram_count_with_short_rate_interval-11     159MB ± 0%     159MB ± 0%    ~     (p=0.310 n=5+5)
NativeHistograms/histogram_count_with_long_rate_interval-11      155MB ± 0%     155MB ± 0%    ~     (p=0.905 n=4+5)

name                                                          old allocs/op  new allocs/op  delta
NativeHistograms/sum-11                                          5.16M ± 0%     5.16M ± 0%    ~     (p=0.310 n=5+5)
NativeHistograms/sum_rate_with_short_rate_interval-11            4.61M ± 0%     4.61M ± 0%    ~     (p=0.849 n=5+5)
NativeHistograms/sum_rate_with_long_rate_interval-11             6.12M ± 0%     6.12M ± 0%    ~     (p=0.667 n=4+5)
NativeHistograms/histogram_count_with_short_rate_interval-11     1.79M ± 0%     1.79M ± 0%    ~     (p=0.325 n=5+5)
NativeHistograms/histogram_count_with_long_rate_interval-11      1.68M ± 0%     1.68M ± 0%    ~     (p=0.429 n=5+5)
```

All credit for reproducing and solving the issue go to @krajorama 

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
