### PR TITLE
TSDB: Shrink `memSeries` by using a single pointer and two bools for last histogram and float histogram values

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2127,7 +2127,7 @@ type memSeries struct {
 
 	// We keep the last histogram value here (in addition to appending it to the chunk) so we can check for duplicates.
 	// The lastValueIsHistogram and lastValueIsFloatHistogram above indicate whether the last value was a histogram or float histogram (or neither).
-	lastHistogramOrFloatHistogramValue unsafe.Pointer // Pointer to the last *histogram.Histogram or *histogram.FloatHistogram value.
+	lastHistogramOrFloatHistogramValue unsafe.Pointer // Last *histogram.Histogram or *histogram.FloatHistogram value.
 
 	// Current appender for the head chunk. Set when a new head chunk is cut.
 	// It is nil only if headChunks is nil. E.g. if there was an appender that created a new series, but rolled back the commit

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -959,9 +959,9 @@ func (s *memSeries) encodeToSnapshotRecord(b []byte) []byte {
 			buf.PutBE64int64(0)
 			buf.PutBEFloat64(s.lastValue)
 		case chunkenc.EncHistogram:
-			record.EncodeHistogram(&buf, s.lastHistogramValue)
+			record.EncodeHistogram(&buf, s.lastHistogramValue())
 		default: // chunkenc.FloatHistogram.
-			record.EncodeFloatHistogram(&buf, s.lastFloatHistogramValue)
+			record.EncodeFloatHistogram(&buf, s.lastFloatHistogramValue())
 		}
 	}
 	s.Unlock()
@@ -1401,9 +1401,12 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 				series.nextAt = csr.mc.maxTime // This will create a new chunk on append.
 				series.headChunks = csr.mc
 				series.lastValue = csr.lastValue
-				series.lastHistogramValue = csr.lastHistogramValue
-				series.lastFloatHistogramValue = csr.lastFloatHistogramValue
-
+				if csr.lastHistogramValue != nil {
+					series.setLastHistogramValue(csr.lastHistogramValue)
+				}
+				if csr.lastFloatHistogramValue != nil {
+					series.setLastFloatHistogramValue(csr.lastFloatHistogramValue)
+				}
 				app, err := series.headChunks.chunk.Appender()
 				if err != nil {
 					errChan <- err


### PR DESCRIPTION
Follow up on https://github.com/prometheus/prometheus/pull/14525

This PR changes `memSeries` to have two bools and one `unsafe.Pointer` instead of two pointers for `lastHistogramValue` and `lastFloatHistogramValue`. Since [we already have some bools](https://github.com/prometheus/prometheus/pull/14474) packed there, adding two extra ones don't add extra size, so we reduce the entire size of memSeries by 8 bytes here.

This 8 bytes reduction is important for `dedupelabels` build tag, where `memSeries` is now 160 bytes, so it moves to the [previous class](https://go.dev/src/runtime/sizeclasses.go) and allocates 160 instead of 176 bytes per series.

I also added (copied) a benchmark for appending float histogram. I ran both benchmarks and didn't get conclusive results (read: some runs looked worse), so I ran them again (`new2`) and the difference makes even less sense now.

```
                                                                                                 │     main     │                 new                  │                 new2                 │
                                                                                                 │    sec/op    │    sec/op     vs base                │    sec/op     vs base                │
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=1-12           176.9µ ±  6%   173.8µ ±  7%        ~ (p=0.853 n=10)   155.1µ ± 13%  -12.32% (p=0.002 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=2-12           345.8µ ±  5%   355.0µ ± 10%        ~ (p=0.436 n=10)   278.2µ ±  2%  -19.54% (p=0.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=5-12           807.3µ ±  3%   820.8µ ±  2%        ~ (p=0.315 n=10)   650.9µ ±  2%  -19.37% (p=0.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=100-12         3.143m ±  3%   3.121m ±  3%        ~ (p=0.912 n=10)   3.461m ±  2%  +10.11% (p=0.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=1-12          2.437m ±  5%   2.463m ±  4%        ~ (p=0.190 n=10)   1.897m ±  2%  -22.17% (p=0.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=2-12          3.647m ±  6%   3.572m ±  4%        ~ (p=0.105 n=10)   2.800m ± 25%  -23.22% (p=0.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=5-12          3.231m ±  3%   3.255m ±  2%        ~ (p=0.912 n=10)   3.384m ±  2%   +4.75% (p=0.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=100-12        5.805m ±  1%   6.071m ±  1%   +4.58% (p=0.000 n=10)   6.285m ±  2%   +8.26% (p=0.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=1-12         3.591m ±  1%   3.667m ±  2%   +2.09% (p=0.023 n=10)   3.428m ±  3%   -4.56% (p=0.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=2-12         3.881m ±  3%   3.865m ±  0%        ~ (p=0.739 n=10)   3.800m ±  1%   -2.10% (p=0.043 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=5-12         5.709m ±  5%   5.746m ±  1%        ~ (p=0.853 n=10)   5.722m ±  1%        ~ (p=0.971 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=100-12       62.07m ±  4%   61.50m ±  1%        ~ (p=0.684 n=10)   61.34m ±  3%        ~ (p=0.853 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=1-12       597.5µ ± 11%   560.8µ ±  2%   -6.13% (p=0.002 n=10)   560.8µ ±  3%   -6.13% (p=0.004 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=2-12       1.248m ±  3%   1.210m ±  5%        ~ (p=0.165 n=10)   1.272m ±  3%        ~ (p=0.190 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=5-12       2.960m ±  6%   2.969m ±  3%        ~ (p=0.971 n=10)   2.831m ±  4%   -4.35% (p=0.043 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=100-12     3.788m ±  1%   3.794m ±  1%        ~ (p=0.529 n=10)   3.837m ±  2%        ~ (p=0.105 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=1-12      3.177m ±  6%   3.198m ±  9%        ~ (p=0.739 n=10)   3.182m ±  8%        ~ (p=0.631 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=2-12      3.294m ±  4%   3.638m ±  5%  +10.46% (p=0.000 n=10)   3.518m ±  2%   +6.80% (p=0.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=5-12      3.441m ±  2%   3.688m ±  7%   +7.19% (p=0.009 n=10)   3.490m ±  4%        ~ (p=0.353 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=100-12    31.32m ±  1%   32.13m ±  4%   +2.60% (p=0.003 n=10)   31.53m ±  1%   +0.67% (p=0.035 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=1-12     5.437m ±  2%   5.382m ±  1%        ~ (p=0.105 n=10)   5.379m ±  1%        ~ (p=0.052 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=2-12     13.80m ±  4%   13.79m ±  2%        ~ (p=0.631 n=10)   13.73m ±  0%        ~ (p=0.089 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=5-12     23.56m ±  3%   22.89m ±  1%   -2.84% (p=0.004 n=10)   22.88m ±  5%        ~ (p=0.063 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=100-12   301.1m ±  1%   304.5m ±  1%        ~ (p=0.075 n=10)   305.5m ±  4%   +1.44% (p=0.043 n=10)
geomean                                                                                            4.140m         4.167m         +0.65%                  3.978m         -3.90%
```

<details>
<summary>Allocations don't significantly</summary>

```
                                                                                                 │     main      │                 new                  │                 new2                 │
                                                                                                 │     B/op      │     B/op       vs base               │     B/op       vs base               │
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=1-12           3.930Ki ±  0%   3.929Ki ±  0%       ~ (p=0.535 n=10)   3.933Ki ±  0%  +0.09% (p=0.017 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=2-12           3.954Ki ±  0%   3.954Ki ±  1%       ~ (p=0.694 n=10)   3.955Ki ±  0%       ~ (p=0.984 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=5-12           6.529Ki ±  1%   6.520Ki ±  0%       ~ (p=0.138 n=10)   6.513Ki ±  0%  -0.25% (p=0.043 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=100-12         63.34Ki ±  2%   63.43Ki ±  2%       ~ (p=0.590 n=10)   62.02Ki ±  2%       ~ (p=0.233 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=1-12          36.76Ki ±  0%   36.69Ki ±  1%       ~ (p=0.579 n=10)   36.64Ki ±  0%       ~ (p=0.089 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=2-12          37.22Ki ±  1%   37.28Ki ±  1%       ~ (p=0.089 n=10)   37.32Ki ±  1%       ~ (p=0.105 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=5-12          61.17Ki ±  1%   61.27Ki ±  2%       ~ (p=0.896 n=10)   61.07Ki ±  1%       ~ (p=0.579 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=100-12        708.4Ki ±  9%   737.0Ki ±  9%       ~ (p=0.542 n=10)   737.9Ki ±  9%       ~ (p=0.247 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=1-12         361.5Ki ±  2%   362.2Ki ±  2%       ~ (p=0.579 n=10)   359.5Ki ±  1%       ~ (p=0.516 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=2-12         366.4Ki ±  1%   368.5Ki ±  2%       ~ (p=0.796 n=10)   364.0Ki ±  1%       ~ (p=0.218 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=5-12         626.4Ki ±  3%   622.4Ki ±  5%       ~ (p=0.927 n=10)   620.4Ki ±  3%       ~ (p=0.579 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=100-12       12.53Mi ± 79%   12.89Mi ± 54%       ~ (p=0.971 n=10)   10.89Mi ± 98%       ~ (p=0.631 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=1-12       12.39Ki ±  0%   12.39Ki ±  0%       ~ (p=0.839 n=10)   12.39Ki ±  0%       ~ (p=0.926 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=2-12       103.6Ki ±  0%   103.6Ki ±  0%  +0.03% (p=0.035 n=10)   103.6Ki ±  0%       ~ (p=0.494 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=5-12       109.5Ki ±  0%   109.3Ki ±  0%       ~ (p=0.075 n=10)   109.3Ki ±  0%  -0.16% (p=0.009 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=100-12     609.6Ki ±  2%   612.3Ki ±  3%       ~ (p=0.529 n=10)   619.6Ki ±  2%       ~ (p=0.190 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=1-12      117.0Ki ±  1%   116.6Ki ±  1%       ~ (p=0.481 n=10)   117.1Ki ±  1%       ~ (p=1.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=2-12      1.017Mi ±  0%   1.018Mi ±  0%       ~ (p=0.971 n=10)   1.018Mi ±  0%       ~ (p=0.353 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=5-12      1.137Mi ±  1%   1.134Mi ±  1%       ~ (p=0.404 n=10)   1.136Mi ±  1%       ~ (p=0.579 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=100-12    9.752Mi ±  9%   9.550Mi ±  8%       ~ (p=0.796 n=10)   9.527Mi ± 15%       ~ (p=0.853 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=1-12     1.283Mi ±  3%   1.271Mi ±  2%       ~ (p=0.105 n=10)   1.284Mi ±  3%       ~ (p=0.739 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=2-12     10.68Mi ±  1%   10.69Mi ±  1%       ~ (p=0.436 n=10)   10.77Mi ±  1%       ~ (p=0.353 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=5-12     12.89Mi ±  4%   12.67Mi ±  5%       ~ (p=0.436 n=10)   12.87Mi ±  4%       ~ (p=0.315 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=100-12   128.8Mi ± 47%   128.8Mi ± 47%       ~ (p=0.897 n=10)   128.8Mi ± 47%       ~ (p=0.494 n=10)
geomean                                                                                            319.0Ki         319.3Ki        +0.09%                  317.0Ki        -0.61%

                                                                                                 │    main     │                 new                  │                 new2                 │
                                                                                                 │  allocs/op  │  allocs/op   vs base                 │  allocs/op   vs base                 │
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=1-12            51.00 ± 0%    51.00 ± 0%       ~ (p=1.000 n=10) ¹    51.00 ± 0%       ~ (p=1.000 n=10) ¹
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=2-12            51.00 ± 0%    51.00 ± 0%       ~ (p=1.000 n=10) ¹    51.00 ± 0%       ~ (p=1.000 n=10) ¹
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=5-12            62.00 ± 0%    62.00 ± 0%       ~ (p=1.000 n=10) ¹    62.00 ± 0%       ~ (p=1.000 n=10) ¹
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=100/samples_per_append=100-12          609.0 ± 0%    609.0 ± 0%       ~ (p=1.000 n=10) ¹    609.0 ± 0%       ~ (p=1.000 n=10) ¹
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=1-12           504.0 ± 0%    503.0 ± 0%       ~ (p=0.781 n=10)      502.5 ± 0%       ~ (p=0.192 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=2-12           507.0 ± 0%    507.0 ± 0%       ~ (p=0.935 n=10)      506.5 ± 0%       ~ (p=0.672 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=5-12           598.5 ± 1%    602.0 ± 1%       ~ (p=0.337 n=10)      599.0 ± 1%       ~ (p=1.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=1000/samples_per_append=100-12        6.009k ± 0%   6.010k ± 0%       ~ (p=0.656 n=10)     6.010k ± 0%       ~ (p=0.656 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=1-12         4.957k ± 1%   4.969k ± 1%       ~ (p=0.986 n=10)     4.942k ± 1%       ~ (p=0.402 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=2-12         4.962k ± 2%   4.993k ± 2%       ~ (p=0.489 n=10)     4.977k ± 1%       ~ (p=0.567 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=5-12         5.878k ± 2%   5.810k ± 3%       ~ (p=0.958 n=10)     5.905k ± 2%       ~ (p=0.638 n=10)
HeadAppender_Append_Commit_ExistingSeries_FloatValues/series=10000/samples_per_append=100-12       60.02k ± 0%   60.02k ± 0%       ~ (p=0.723 n=10)     60.02k ± 0%       ~ (p=0.670 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=1-12        120.0 ± 1%    120.0 ± 0%       ~ (p=0.303 n=10)      119.0 ± 1%       ~ (p=0.656 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=2-12       1.113k ± 0%   1.113k ± 0%       ~ (p=0.303 n=10)     1.113k ± 0%       ~ (p=1.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=5-12       1.119k ± 0%   1.119k ± 0%       ~ (p=1.000 n=10)     1.119k ± 0%       ~ (p=1.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=100/samples_per_append=100-12     1.439k ± 0%   1.439k ± 0%       ~ (p=1.000 n=10) ¹   1.439k ± 0%       ~ (p=1.000 n=10) ¹
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=1-12      1.113k ± 1%   1.110k ± 1%       ~ (p=0.867 n=10)     1.107k ± 1%       ~ (p=0.361 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=2-12      11.02k ± 0%   11.02k ± 0%       ~ (p=1.000 n=10)     11.02k ± 0%       ~ (p=1.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=5-12      11.03k ± 0%   11.03k ± 0%       ~ (p=1.000 n=10)     11.03k ± 0%       ~ (p=1.000 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=1000/samples_per_append=100-12    14.05k ± 0%   14.05k ± 0%       ~ (p=0.871 n=10)     14.05k ± 0%       ~ (p=0.992 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=1-12     10.93k ± 1%   10.90k ± 3%       ~ (p=0.584 n=10)     10.67k ± 4%       ~ (p=0.440 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=2-12     110.0k ± 0%   110.0k ± 0%       ~ (p=0.296 n=10)     110.0k ± 0%       ~ (p=0.225 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=5-12     110.1k ± 0%   110.1k ± 0%       ~ (p=0.199 n=10)     110.1k ± 0%       ~ (p=0.127 n=10)
HeadAppender_Append_Commit_ExistingSeries_HistogramValues/series=10000/samples_per_append=100-12   141.6k ± 0%   141.6k ± 0%       ~ (p=0.925 n=10)     141.6k ± 0%       ~ (p=0.304 n=10)
geomean                                                                                            2.555k        2.555k       -0.01%                    2.551k       -0.15%
¹ all samples are equal
```

</details>