### PR TITLE
[rw2.0] change comment that allows timestamps to be optional

### DIFF
--- a/prompb/io/prometheus/write/v2/types.pb.go
+++ b/prompb/io/prometheus/write/v2/types.pb.go
@@ -302,15 +302,10 @@ type Exemplar struct {
 	// value represents an exact example value. This can be useful when the exemplar
 	// is attached to a histogram, which only gives an estimated value through buckets.
 	Value float64 `protobuf:"fixed64,2,opt,name=value,proto3" json:"value,omitempty"`
-	// timestamp represents an optional timestamp of the sample in ms.
+	// timestamp represents the timestamp of the exemplar in ms.
 	//
 	// For Go, see github.com/prometheus/prometheus/model/timestamp/timestamp.go
 	// for conversion from/to time.Time to Prometheus timestamp.
-	//
-	// Note that the "optional" keyword is omitted due to
-	// https://cloud.google.com/apis/design/design_patterns.md#optional_primitive_fields
-	// Zero value means value not set. If you need to use exactly zero value for
-	// the timestamp, use 1 millisecond before or after.
 	Timestamp            int64    `protobuf:"varint,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/prompb/io/prometheus/write/v2/types.proto
+++ b/prompb/io/prometheus/write/v2/types.proto
@@ -107,15 +107,10 @@ message Exemplar {
   // value represents an exact example value. This can be useful when the exemplar
   // is attached to a histogram, which only gives an estimated value through buckets.
   double value = 2;
-  // timestamp represents an optional timestamp of the sample in ms.
+  // timestamp represents the timestamp of the exemplar in ms.
   //
   // For Go, see github.com/prometheus/prometheus/model/timestamp/timestamp.go
   // for conversion from/to time.Time to Prometheus timestamp.
-  //
-  // Note that the "optional" keyword is omitted due to
-  // https://cloud.google.com/apis/design/design_patterns.md#optional_primitive_fields
-  // Zero value means value not set. If you need to use exactly zero value for
-  // the timestamp, use 1 millisecond before or after.
   int64 timestamp = 3;
 }
 


### PR DESCRIPTION
In addition to: https://github.com/prometheus/docs/pull/2496

The write handler should not need to change, a timestamp of `0` no longer means that the timestamp was not set, so we can just pass the exemplar from proto with it's timestamp to the appender and the appender can decide if it's valid or not. On top of that, nothing should need to change for the remote write code. We still gather samples from the WAL after they're written there, which if they go through scrape means they will have the scrape timestamp set as their timestamp if there was not one set in the exposition.