### PR TITLE
promql: Fix issue where some native histogram-related annotations are not emitted by `rate`

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -190,6 +190,8 @@ func histogramRate(points []HPoint, isCounter bool, metricName string, pos posra
 
 	var annos annotations.Annotations
 
+	// We check for gauge type histograms in the loop below, but the loop below does not run on the first and last point,
+	// so check the first and last point now.
 	if isCounter && (prev.CounterResetHint == histogram.GaugeType || last.CounterResetHint == histogram.GaugeType) {
 		annos.Add(annotations.NewNativeHistogramNotCounterWarning(metricName, pos))
 	}

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -748,3 +748,17 @@ eval instant at 5m histogram_quantile(0.5, custom_buckets_histogram)
 
 eval instant at 5m sum(custom_buckets_histogram)
     {} {{schema:-53 sum:5 count:4 custom_values:[5 10] buckets:[1 2 1]}}
+
+clear
+
+# Test 'this native histogram metric is not a gauge' warning for rate
+load 30s
+    some_metric {{schema:0 sum:1 count:1 buckets:[1] counter_reset_hint:gauge}} {{schema:0 sum:2 count:2 buckets:[2] counter_reset_hint:gauge}} {{schema:0 sum:3 count:3 buckets:[3] counter_reset_hint:gauge}}
+
+# Test the case where we only have two points for rate
+eval_warn instant at 30s rate(some_metric[30s])
+    {} {{count:0.03333333333333333 sum:0.03333333333333333 buckets:[0.03333333333333333]}}
+
+# Test the case where we have more than two points for rate
+eval_warn instant at 1m rate(some_metric[1m])
+    {} {{count:0.03333333333333333 sum:0.03333333333333333 buckets:[0.03333333333333333]}}


### PR DESCRIPTION
This PR fixes a couple of issues I noticed about the annotations emitted by `rate` when native histograms are used:

* some of the annotations returned by the `histogramRate()` function were ignored if `histogramRate()` did not return an error
* if `rate` is used over gauge-type histograms and rate is evaluating over a range with only two samples, the `this native histogram metric is not a gauge` warning was not emitted