### PR TITLE
discovery: Improve Azure test coverage to 50%

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -36,7 +36,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	cache "github.com/Code-Hex/go-generics-cache"
 	"github.com/Code-Hex/go-generics-cache/policy/lru"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/promslog"
@@ -412,7 +411,7 @@ func (d *Discovery) refreshAzureClient(ctx context.Context, client client) ([]*t
 }
 
 func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
-	defer level.Debug(d.logger).Log("msg", "Azure discovery completed")
+	defer d.logger.Debug("Azure discovery completed")
 
 	client, err := d.createAzureClient()
 	if err != nil {

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -234,7 +234,7 @@ type azureClient struct {
 
 var _ client = &azureClient{}
 
-// createAzureClient is a helper function for creating an Azure compute client to ARM.
+// createAzureClient is a helper method for creating an Azure compute client to ARM.
 func (d *Discovery) createAzureClient() (client, error) {
 	cloudConfiguration, err := CloudConfigurationFromName(d.cfg.Environment)
 	if err != nil {

--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -554,7 +554,6 @@ func TestAzureRefresh(t *testing.T) {
 					},
 				},
 			},
-
 			expectedTG: []*targetgroup.Group{
 				{
 					Targets: []model.LabelSet{
@@ -649,9 +648,7 @@ func TestAzureRefresh(t *testing.T) {
 			},
 		},
 	}
-	for _, test := range tests {
-		tc := test
-
+	for _, tc := range tests {
 		t.Run(tc.scenario, func(t *testing.T) {
 			t.Parallel()
 			azureSDConfig := &DefaultSDConfig

--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -15,7 +15,7 @@ package azure
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
@@ -678,7 +678,7 @@ type mockAzureClient struct {
 	azureClient
 }
 
-func createMockAzureClient(t *testing.T, vmResp []armcompute.VirtualMachinesClientListAllResponse, vmssResp []armcompute.VirtualMachineScaleSetsClientListAllResponse, vmssvmResp []armcompute.VirtualMachineScaleSetVMsClientListResponse, interfaceResp armnetwork.Interface, logger log.Logger) client {
+func createMockAzureClient(t *testing.T, vmResp []armcompute.VirtualMachinesClientListAllResponse, vmssResp []armcompute.VirtualMachineScaleSetsClientListAllResponse, vmssvmResp []armcompute.VirtualMachineScaleSetVMsClientListResponse, interfaceResp armnetwork.Interface, logger *slog.Logger) client {
 	t.Helper()
 	mockVMServer := defaultMockVMServer(vmResp)
 	mockVMSSServer := defaultMockVMSSServer(vmssResp)


### PR DESCRIPTION
The azure service discovery had 25% test coverage. This PR improves the coverage to 50% by providing a way to test the `discovery.refresh()` function.

main:
```
mviswanathsai@pop-os:~/prometheus/discovery/azure$ go test -cover
PASS
coverage: 25.0% of statements
ok      github.com/prometheus/prometheus/discovery/azure        0.005s
```
This PR:
```
mviswanathsai@pop-os:~/prometheus/discovery/azure$ go test -cover
PASS
coverage: 54.0% of statements
ok      github.com/prometheus/prometheus/discovery/azure        0.009s
```