### PR TITLE
httputil: remove allocation in newCompressedResponseWriter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go v1.54.19
 	github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3
 	github.com/cespare/xxhash/v2 v2.3.0
+	github.com/clipperhouse/split v0.1.0
 	github.com/dennwc/varint v1.0.0
 	github.com/digitalocean/godo v1.119.0
 	github.com/docker/docker v27.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/clipperhouse/split v0.1.0 h1:S04Yrll072lSzZXaF/ZeKBFXHMqscmssTywFkgTIvIU=
+github.com/clipperhouse/split v0.1.0/go.mod h1:f9pYJ/g022HLBhfqDCDhmNCB+gNPoVvItKDu2yuw7kc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b h1:ga8SEFjZ60pxLcmhnThWgvH2wg8376yUJmPhEH4H3kw=
 github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=

--- a/util/httputil/compression.go
+++ b/util/httputil/compression.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/clipperhouse/split"
 	"github.com/klauspost/compress/gzip"
 	"github.com/klauspost/compress/zlib"
 )
@@ -56,9 +57,9 @@ func (c *compressedResponseWriter) Close() {
 
 // Constructs a new compressedResponseWriter based on client request headers.
 func newCompressedResponseWriter(writer http.ResponseWriter, req *http.Request) *compressedResponseWriter {
-	encodings := strings.Split(req.Header.Get(acceptEncodingHeader), ",")
-	for _, encoding := range encodings {
-		switch strings.TrimSpace(encoding) {
+	encodings := split.String(req.Header.Get(acceptEncodingHeader), ",")
+	for encodings.Next() {
+		switch strings.TrimSpace(encodings.Value()) {
 		case gzipEncoding:
 			writer.Header().Set(contentEncodingHeader, gzipEncoding)
 			return &compressedResponseWriter{

--- a/util/httputil/compression_test.go
+++ b/util/httputil/compression_test.go
@@ -145,7 +145,7 @@ func TestCompressionHandler_Deflate(t *testing.T) {
 func BenchmarkNewCompressedResponseWriter(b *testing.B) {
 	handler := http.HandlerFunc(getCompressionHandlerFunc().ServeHTTP)
 
-	req, err := http.NewRequest("GET", "/foo", nil)
+	req, err := http.NewRequest(http.MethodGet, "/foo", nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/util/httputil/compression_test.go
+++ b/util/httputil/compression_test.go
@@ -141,3 +141,23 @@ func TestCompressionHandler_Deflate(t *testing.T) {
 	expected := "Hello World!"
 	require.Equal(t, expected, actual, "expected response with content")
 }
+
+func BenchmarkNewCompressedResponseWriter(b *testing.B) {
+	handler := http.HandlerFunc(getCompressionHandlerFunc().ServeHTTP)
+
+	req, err := http.NewRequest("GET", "/foo", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+
+	encodings := []string{"", gzipEncoding, deflateEncoding, "invalid"}
+
+	for i := 0; i < b.N; i++ {
+		for _, encoding := range encodings {
+			req.Header.Set("accept-encoding", encoding)
+		}
+		handler.ServeHTTP(resp, req)
+	}
+}


### PR DESCRIPTION
Replaces a `string.Split` with an iterator to save one `[]string` allocation in what seems to be a hot path.

It imports a new dependency, which will need to be reviewed. If the reviewers like this pattern, there are several other places where this could be applied.

Some preliminary benchmarks:

Old:

```
319.6 ns/op	     165 B/op	       7 allocs/op
```

New:
```
308.1 ns/op	     147 B/op	       6 allocs/op
```

Tagging @juliusv as it seems to be their area. Thanks for the consideration.