### PR TITLE
Fix: panic: runtime error: index out of range [4] with length 4

### DIFF
--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -782,9 +782,10 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			// of the chunk.
 			if len(pForwardInserts) == 0 && len(nForwardInserts) == 0 {
 				// No new chunks from the histogram, so the spans of the appender can accommodate the new buckets.
-				h.PositiveSpans = resize(h.PositiveSpans, len(a.pSpans))
+				// However we need to make a copy in case the input is sharing spans from an iterator.
+				h.PositiveSpans = make([]histogram.Span, len(a.pSpans))
 				copy(h.PositiveSpans, a.pSpans)
-				h.NegativeSpans = resize(h.NegativeSpans, len(a.nSpans))
+				h.NegativeSpans = make([]histogram.Span, len(a.nSpans))
 				copy(h.NegativeSpans, a.nSpans)
 			} else {
 				// Spans need pre-adjusting to accommodate the new buckets.

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -419,6 +419,7 @@ loop:
 				// fill in the bucket in b and advance a.
 				if aCount == 0 {
 					bInter.num++ // Mark that we need to insert a bucket in b.
+					bInter.bucketIdx = aIdx
 					// Advance a
 					if aInter.num > 0 {
 						aInserts = append(aInserts, aInter)
@@ -436,6 +437,7 @@ loop:
 				return nil, nil, false
 			case aIdx > bIdx: // a misses a value that is in b. Forward b and recompare.
 				aInter.num++
+				bInter.bucketIdx = bIdx
 				// Advance b
 				if bInter.num > 0 {
 					bInserts = append(bInserts, bInter)
@@ -453,6 +455,7 @@ loop:
 			// fill in the bucket in b and advance a.
 			if aCount == 0 {
 				bInter.num++
+				bInter.bucketIdx = aIdx
 				// Advance a
 				if aInter.num > 0 {
 					aInserts = append(aInserts, aInter)
@@ -471,6 +474,7 @@ loop:
 			return nil, nil, false
 		case !aOK && bOK: // a misses a value that is in b. Forward b and recompare.
 			aInter.num++
+			bInter.bucketIdx = bIdx
 			// Advance b
 			if bInter.num > 0 {
 				bInserts = append(bInserts, bInter)
@@ -773,6 +777,22 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			happ.appendFloatHistogram(t, h)
 			return newChunk, false, app, nil
 		}
+		if len(pBackwardInserts) > 0 || len(nBackwardInserts) > 0 {
+			// The histogram needs to be expanded to have the extra empty buckets
+			// of the chunk.
+			if len(pForwardInserts) == 0 && len(nForwardInserts) == 0 {
+				// No new chunks from the histogram, so the spans of the appender can accommodate the new buckets.
+				h.PositiveSpans = resize(h.PositiveSpans, len(a.pSpans))
+				copy(h.PositiveSpans, a.pSpans)
+				h.NegativeSpans = resize(h.NegativeSpans, len(a.nSpans))
+				copy(h.NegativeSpans, a.nSpans)
+			} else {
+				// Spans need pre-adjusting to accommodate the new buckets.
+				h.PositiveSpans = adjustForInserts(h.PositiveSpans, pBackwardInserts)
+				h.NegativeSpans = adjustForInserts(h.NegativeSpans, nBackwardInserts)
+			}
+			a.recodeHistogram(h, pBackwardInserts, nBackwardInserts)
+		}
 		if len(pForwardInserts) > 0 || len(nForwardInserts) > 0 {
 			if appendOnly {
 				return nil, false, a, fmt.Errorf("float histogram layout change with %d positive and %d negative forwards inserts", len(pForwardInserts), len(nForwardInserts))
@@ -783,13 +803,6 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			)
 			app.(*FloatHistogramAppender).appendFloatHistogram(t, h)
 			return chk, true, app, nil
-		}
-		if len(pBackwardInserts) > 0 || len(nBackwardInserts) > 0 {
-			// The histogram needs to be expanded to have the extra empty buckets
-			// of the chunk.
-			h.PositiveSpans = a.pSpans
-			h.NegativeSpans = a.nSpans
-			a.recodeHistogram(h, pBackwardInserts, nBackwardInserts)
 		}
 		a.appendFloatHistogram(t, h)
 		return nil, false, a, nil

--- a/tsdb/chunkenc/float_histogram_test.go
+++ b/tsdb/chunkenc/float_histogram_test.go
@@ -453,7 +453,13 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 
 		// Check that h2 was recoded.
 		require.Equal(t, []float64{7, 0, 4, 3, 5, 0, 2, 3}, h2.PositiveBuckets)
-		require.Equal(t, emptyBucketH.PositiveSpans, h2.PositiveSpans)
+		require.Equal(t, []histogram.Span{
+			{Offset: 0, Length: 2}, // Added empty bucket.
+			{Offset: 2, Length: 1}, // Existing - offset adjusted.
+			{Offset: 3, Length: 2}, // Existing.
+			{Offset: 3, Length: 1}, // Added empty bucket.
+			{Offset: 1, Length: 2}, // Existing + the extra bucket.
+		}, h2.PositiveSpans)
 	}
 
 	{ // New histogram that has a counter reset while buckets are same.

--- a/tsdb/chunkenc/float_histogram_test.go
+++ b/tsdb/chunkenc/float_histogram_test.go
@@ -428,6 +428,34 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		require.Equal(t, emptyBucketH.PositiveSpans, h2.PositiveSpans)
 	}
 
+	{ // New histogram that has new buckets AND buckets missing but the buckets missing were empty.
+		emptyBucketH := eh.Copy()
+		emptyBucketH.PositiveBuckets = []float64{6, 0, 3, 2, 4, 0, 1}
+		c, hApp, ts, h1 := setup(emptyBucketH)
+		h2 := h1.Copy()
+		h2.PositiveSpans = []histogram.Span{
+			{Offset: 0, Length: 1},
+			{Offset: 3, Length: 1},
+			{Offset: 3, Length: 2},
+			{Offset: 5, Length: 2},
+		}
+		h2.PositiveBuckets = []float64{7, 4, 3, 5, 2, 3}
+
+		posInterjections, negInterjections, backwardPositiveInserts, backwardNegativeInserts, ok, cr := hApp.appendable(h2)
+		require.NotEmpty(t, posInterjections)
+		require.Empty(t, negInterjections)
+		require.NotEmpty(t, backwardPositiveInserts)
+		require.Empty(t, backwardNegativeInserts)
+		require.True(t, ok)
+		require.False(t, cr)
+
+		assertRecodedFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
+
+		// Check that h2 was recoded.
+		require.Equal(t, []float64{7, 0, 4, 3, 5, 0, 2, 3}, h2.PositiveBuckets)
+		require.Equal(t, emptyBucketH.PositiveSpans, h2.PositiveSpans)
+	}
+
 	{ // New histogram that has a counter reset while buckets are same.
 		c, hApp, ts, h1 := setup(eh)
 		h2 := h1.Copy()

--- a/tsdb/chunkenc/float_histogram_test.go
+++ b/tsdb/chunkenc/float_histogram_test.go
@@ -411,6 +411,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 			{Offset: 3, Length: 2},
 			{Offset: 5, Length: 1},
 		}
+		savedH2Spans := h2.PositiveSpans
 		h2.PositiveBuckets = []float64{7, 4, 3, 5, 2}
 
 		posInterjections, negInterjections, backwardPositiveInserts, backwardNegativeInserts, ok, cr := hApp.appendable(h2)
@@ -426,6 +427,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		// Check that h2 was recoded.
 		require.Equal(t, []float64{7, 0, 4, 3, 5, 0, 2}, h2.PositiveBuckets)
 		require.Equal(t, emptyBucketH.PositiveSpans, h2.PositiveSpans)
+		require.NotEqual(t, savedH2Spans, h2.PositiveSpans, "recoding must make a copy")
 	}
 
 	{ // New histogram that has new buckets AND buckets missing but the buckets missing were empty.
@@ -439,6 +441,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 			{Offset: 3, Length: 2},
 			{Offset: 5, Length: 2},
 		}
+		savedH2Spans := h2.PositiveSpans
 		h2.PositiveBuckets = []float64{7, 4, 3, 5, 2, 3}
 
 		posInterjections, negInterjections, backwardPositiveInserts, backwardNegativeInserts, ok, cr := hApp.appendable(h2)
@@ -460,6 +463,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 			{Offset: 3, Length: 1}, // Added empty bucket.
 			{Offset: 1, Length: 2}, // Existing + the extra bucket.
 		}, h2.PositiveSpans)
+		require.NotEqual(t, savedH2Spans, h2.PositiveSpans, "recoding must make a copy")
 	}
 
 	{ // New histogram that has a counter reset while buckets are same.

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -437,6 +437,7 @@ loop:
 				// fill in the bucket in b and advance a.
 				if aCount == 0 {
 					bInter.num++ // Mark that we need to insert a bucket in b.
+					bInter.bucketIdx = aIdx
 					// Advance a
 					if aInter.num > 0 {
 						aInserts = append(aInserts, aInter)
@@ -454,6 +455,7 @@ loop:
 				return nil, nil, false
 			case aIdx > bIdx: // a misses a value that is in b. Forward b and recompare.
 				aInter.num++
+				aInter.bucketIdx = bIdx
 				// Advance b
 				if bInter.num > 0 {
 					bInserts = append(bInserts, bInter)
@@ -471,6 +473,7 @@ loop:
 			// fill in the bucket in b and advance a.
 			if aCount == 0 {
 				bInter.num++
+				bInter.bucketIdx = aIdx
 				// Advance a
 				if aInter.num > 0 {
 					aInserts = append(aInserts, aInter)
@@ -489,6 +492,7 @@ loop:
 			return nil, nil, false
 		case !aOK && bOK: // a misses a value that is in b. Forward b and recompare.
 			aInter.num++
+			aInter.bucketIdx = bIdx
 			// Advance b
 			if bInter.num > 0 {
 				bInserts = append(bInserts, bInter)
@@ -807,6 +811,22 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 			happ.appendHistogram(t, h)
 			return newChunk, false, app, nil
 		}
+		if len(pBackwardInserts) > 0 || len(nBackwardInserts) > 0 {
+			// The histogram needs to be expanded to have the extra empty buckets
+			// of the chunk.
+			if len(pForwardInserts) == 0 && len(nForwardInserts) == 0 {
+				// No new chunks from the histogram, so the spans of the appender can accommodate the new buckets.
+				h.PositiveSpans = resize(h.PositiveSpans, len(a.pSpans))
+				copy(h.PositiveSpans, a.pSpans)
+				h.NegativeSpans = resize(h.NegativeSpans, len(a.nSpans))
+				copy(h.NegativeSpans, a.nSpans)
+			} else {
+				// Spans need pre-adjusting to accommodate the new buckets.
+				h.PositiveSpans = adjustForInserts(h.PositiveSpans, pBackwardInserts)
+				h.NegativeSpans = adjustForInserts(h.NegativeSpans, nBackwardInserts)
+			}
+			a.recodeHistogram(h, pBackwardInserts, nBackwardInserts)
+		}
 		if len(pForwardInserts) > 0 || len(nForwardInserts) > 0 {
 			if appendOnly {
 				return nil, false, a, fmt.Errorf("histogram layout change with %d positive and %d negative forwards inserts", len(pForwardInserts), len(nForwardInserts))
@@ -817,13 +837,6 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 			)
 			app.(*HistogramAppender).appendHistogram(t, h)
 			return chk, true, app, nil
-		}
-		if len(pBackwardInserts) > 0 || len(nBackwardInserts) > 0 {
-			// The histogram needs to be expanded to have the extra empty buckets
-			// of the chunk.
-			h.PositiveSpans = a.pSpans
-			h.NegativeSpans = a.nSpans
-			a.recodeHistogram(h, pBackwardInserts, nBackwardInserts)
 		}
 		a.appendHistogram(t, h)
 		return nil, false, a, nil

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -816,9 +816,10 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 			// of the chunk.
 			if len(pForwardInserts) == 0 && len(nForwardInserts) == 0 {
 				// No new chunks from the histogram, so the spans of the appender can accommodate the new buckets.
-				h.PositiveSpans = resize(h.PositiveSpans, len(a.pSpans))
+				// However we need to make a copy in case the input is sharing spans from an iterator.
+				h.PositiveSpans = make([]histogram.Span, len(a.pSpans))
 				copy(h.PositiveSpans, a.pSpans)
-				h.NegativeSpans = resize(h.NegativeSpans, len(a.nSpans))
+				h.NegativeSpans = make([]histogram.Span, len(a.nSpans))
 				copy(h.NegativeSpans, a.nSpans)
 			} else {
 				// Spans need pre-adjusting to accommodate the new buckets.

--- a/tsdb/chunkenc/histogram_meta.go
+++ b/tsdb/chunkenc/histogram_meta.go
@@ -593,8 +593,8 @@ func adjustForInserts(spans []histogram.Span, inserts []Insert) (mergedSpans []h
 	var (
 		lastBucket int
 		i          int
-		insertIdx  int = inserts[i].bucketIdx
-		insertNum  int = inserts[i].num
+		insertIdx  = inserts[i].bucketIdx
+		insertNum  = inserts[i].num
 	)
 
 	addBucket := func(b int) {

--- a/tsdb/chunkenc/histogram_meta.go
+++ b/tsdb/chunkenc/histogram_meta.go
@@ -278,6 +278,10 @@ func (b *bucketIterator) Next() (int, bool) {
 type Insert struct {
 	pos int
 	num int
+
+	// Optional: bucketIdx is the index of the bucket that is inserted.
+	// Can be used to adjust spans.
+	bucketIdx int
 }
 
 // Deprecated: expandSpansForward, use expandIntSpansAndBuckets or
@@ -576,4 +580,66 @@ func counterResetHint(crh CounterResetHeader, numRead uint16) histogram.CounterR
 		// might not be worth the effort and/or risk. To be vetted...
 		return histogram.UnknownCounterReset
 	}
+}
+
+// adjustForInserts adjusts the spans for the given inserts.
+func adjustForInserts(spans []histogram.Span, inserts []Insert) (mergedSpans []histogram.Span) {
+	if len(inserts) == 0 {
+		return spans
+	}
+
+	it := newBucketIterator(spans)
+
+	var (
+		lastBucket int
+		i          int
+		insertIdx  int = inserts[i].bucketIdx
+		insertNum  int = inserts[i].num
+	)
+
+	addBucket := func(b int) {
+		offset := b - lastBucket - 1
+		if offset == 0 && len(mergedSpans) > 0 {
+			mergedSpans[len(mergedSpans)-1].Length++
+		} else {
+			if len(mergedSpans) == 0 {
+				offset++
+			}
+			mergedSpans = append(mergedSpans, histogram.Span{
+				Offset: int32(offset),
+				Length: 1,
+			})
+		}
+
+		lastBucket = b
+	}
+	consumeInsert := func() {
+		// Consume the insert.
+		insertNum--
+		if insertNum == 0 {
+			i++
+			if i < len(inserts) {
+				insertIdx = inserts[i].bucketIdx
+				insertNum = inserts[i].num
+			}
+		} else {
+			insertIdx++
+		}
+	}
+
+	bucket, ok := it.Next()
+	for ok {
+		if i < len(inserts) && insertIdx < bucket {
+			addBucket(insertIdx)
+			consumeInsert()
+		} else {
+			addBucket(bucket)
+			bucket, ok = it.Next()
+		}
+	}
+	for i < len(inserts) {
+		addBucket(inserts[i].bucketIdx)
+		consumeInsert()
+	}
+	return
 }

--- a/tsdb/chunkenc/histogram_test.go
+++ b/tsdb/chunkenc/histogram_test.go
@@ -471,7 +471,13 @@ func TestHistogramChunkAppendable(t *testing.T) {
 
 		// Check that h2 was recoded.
 		require.Equal(t, []int64{7, -7, 2, 1, -3, 3, 1, 1}, h2.PositiveBuckets) // counts: 7, 0, 2, 3 , 0, 3, 5 (total 23)
-		require.Equal(t, emptyBucketH.PositiveSpans, h2.PositiveSpans)
+		require.Equal(t, []histogram.Span{
+			{Offset: 0, Length: 2}, // Added empty bucket.
+			{Offset: 2, Length: 1}, // Existing - offset adjusted.
+			{Offset: 3, Length: 2}, // Added empty bucket.
+			{Offset: 3, Length: 1}, // Existing - offset adjusted.
+			{Offset: 1, Length: 2}, // Existing.
+		}, h2.PositiveSpans)
 	}
 
 	{ // New histogram that has a counter reset while buckets are same.

--- a/tsdb/chunkenc/histogram_test.go
+++ b/tsdb/chunkenc/histogram_test.go
@@ -445,6 +445,35 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		require.Equal(t, emptyBucketH.PositiveSpans, h2.PositiveSpans)
 	}
 
+	{ // New histogram that has new buckets AND buckets missing but the buckets missing were empty.
+		emptyBucketH := eh.Copy()
+		emptyBucketH.PositiveBuckets = []int64{6, -6, 1, 1, -2, 1, 1} // counts: 6, 0, 1, 2, 0, 1, 2 (total 12)
+		c, hApp, ts, h1 := setup(emptyBucketH)
+		h2 := h1.Copy()
+		h2.PositiveSpans = []histogram.Span{ // Missing buckets at offset 1 and 9.
+			{Offset: 0, Length: 1},
+			{Offset: 3, Length: 1},
+			{Offset: 3, Length: 1},
+			{Offset: 4, Length: 1},
+			{Offset: 1, Length: 2},
+		}
+		h2.PositiveBuckets = []int64{7, -5, 1, 0, 1, 1} // counts: 7, 2, 3, 3, 4, 5 (total 23)
+
+		posInterjections, negInterjections, backwardPositiveInserts, backwardNegativeInserts, ok, cr := hApp.appendable(h2)
+		require.NotEmpty(t, posInterjections)
+		require.Empty(t, negInterjections)
+		require.NotEmpty(t, backwardPositiveInserts)
+		require.Empty(t, backwardNegativeInserts)
+		require.True(t, ok)
+		require.False(t, cr)
+
+		assertRecodedHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
+
+		// Check that h2 was recoded.
+		require.Equal(t, []int64{7, -7, 2, 1, -3, 3, 1, 1}, h2.PositiveBuckets) // counts: 7, 0, 2, 3 , 0, 3, 5 (total 23)
+		require.Equal(t, emptyBucketH.PositiveSpans, h2.PositiveSpans)
+	}
+
 	{ // New histogram that has a counter reset while buckets are same.
 		c, hApp, ts, h1 := setup(eh)
 		h2 := h1.Copy()

--- a/tsdb/chunkenc/histogram_test.go
+++ b/tsdb/chunkenc/histogram_test.go
@@ -428,6 +428,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 			{Offset: 4, Length: 1},
 			{Offset: 1, Length: 1},
 		}
+		savedH2Spans := h2.PositiveSpans
 		h2.PositiveBuckets = []int64{7, -5, 1, 0, 1} // counts: 7, 2, 3, 3, 4 (total 18)
 
 		posInterjections, negInterjections, backwardPositiveInserts, backwardNegativeInserts, ok, cr := hApp.appendable(h2)
@@ -443,6 +444,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		// Check that h2 was recoded.
 		require.Equal(t, []int64{7, -7, 2, 1, -3, 3, 1}, h2.PositiveBuckets) // counts: 7, 0, 2, 3 , 0, 3, 4 (total 18)
 		require.Equal(t, emptyBucketH.PositiveSpans, h2.PositiveSpans)
+		require.NotEqual(t, savedH2Spans, h2.PositiveSpans, "recoding must make a copy")
 	}
 
 	{ // New histogram that has new buckets AND buckets missing but the buckets missing were empty.
@@ -457,6 +459,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 			{Offset: 4, Length: 1},
 			{Offset: 1, Length: 2},
 		}
+		savedH2Spans := h2.PositiveSpans
 		h2.PositiveBuckets = []int64{7, -5, 1, 0, 1, 1} // counts: 7, 2, 3, 3, 4, 5 (total 23)
 
 		posInterjections, negInterjections, backwardPositiveInserts, backwardNegativeInserts, ok, cr := hApp.appendable(h2)
@@ -478,6 +481,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 			{Offset: 3, Length: 1}, // Existing - offset adjusted.
 			{Offset: 1, Length: 2}, // Existing.
 		}, h2.PositiveSpans)
+		require.NotEqual(t, savedH2Spans, h2.PositiveSpans, "recoding must make a copy")
 	}
 
 	{ // New histogram that has a counter reset while buckets are same.


### PR DESCRIPTION
Mimir compaction failed due to panic, introduced in #14513 

Two issues in (Float)Histogram Appander in the tsdb.chunkenc:
- In case of re-coding an incoming histogram, the spans of the histogram need to be updated as well. This was partially missing. There's two sub cases:
   - The chunk itself is not re-coded. In this case the new histogram is just missing some chunks, so we can simply copy the spans from the chunk. In the code this is the case when  `pForwardInserts` and `nForwardInserts` are empty.
   - The chunk itself is re-coded. Copying the current chunk spans doesn't work, since that doesn't have yet the new buckets, so we need to instead add the missing buckets to the spans directly. Using `adjustForInserts` (*).
- The other issue is that the incoming histogram may come from an iterator that shares its spans directly without copy. We must not overwrite the spans of the appended histogram, so we have to make sure to make a copy if we're changing the spans - such as when re-coding the appended histogram.

(*) this is a different strategy from handling gauge histograms, since there we always allocate a new slice for the spans , whether it's needed or not. In this code we do an extra loop over the buckets if we need to, which is more efficient than allocations, given how rare this case is.

```
panic: runtime error: index out of range [4] with length 4


goroutine 88061 [running]:
github.com/prometheus/prometheus/tsdb/chunkenc.insert[...]({0xc00aafe768?, 0xc00352a4c0?, 0x1b14725?}, {0xc0020ee4c0?, 0x0?, 0x4?}, {0xc0093945c0, 0x1, 0x1}, 0x0)
	/drone/src/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/histogram_meta.go:537 +0x158
github.com/prometheus/prometheus/tsdb/chunkenc.(*HistogramAppender).recode(0xc000e83000?, {0xc0093945c0, 0x1, 0x1}, {0x0, 0x0, 0x0}, {0xc009394598, 0x1, 0x1}, ...)
	/drone/src/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/histogram.go:728 +0x345
github.com/prometheus/prometheus/tsdb/chunkenc.(*HistogramAppender).AppendHistogram(0xc006f0e300, 0x0?, 0x1912220b803, 0xc006f13cc0, 0x0)
	/drone/src/vendor/github.com/prometheus/prometheus/tsdb/chunkenc/histogram.go:814 +0x115
github.com/prometheus/prometheus/storage.(*seriesToChunkEncoder).Iterator(0xc000e82f80?, {0x0, 0x0?})
	/drone/src/vendor/github.com/prometheus/prometheus/storage/series.go:344 +0x77d
github.com/prometheus/prometheus/storage.(*compactChunkIterator).Next(0xc000e038f0)
	/drone/src/vendor/github.com/prometheus/prometheus/storage/merge.go:821 +0x7d2
github.com/prometheus/prometheus/tsdb.DefaultBlockPopulator.PopulateBlock({}, {0x3ed9378, 0xc002b0c1e0}, 0xc002b281c0, {0x3eacb40, 0xc001e08410}, {0x3ec29c8, 0xc002b0ec80}, 0xc0023cb690, {0x4, ...}, ...)
	/drone/src/vendor/github.com/prometheus/prometheus/tsdb/compact.go:1161 +0x174f
github.com/prometheus/prometheus/tsdb.(*LeveledCompactor).write(0xc002b2c750, {0xc00264a050, 0x4d}, {0xc000ae8460, 0x1, 0x1}, {0x3eb2b60, 0x5a98640}, {0xc002d4f900, 0x8, ...})
	/drone/src/vendor/github.com/prometheus/prometheus/tsdb/compact.go:875 +0xa5e
github.com/prometheus/prometheus/tsdb.(*LeveledCompactor).CompactWithBlockPopulator(0xc002b2c750, {0xc00264a050, 0x4d}, {0xc000c5c000, 0x8, 0x8}, {0x0, 0x0, 0x0}, {0x3eb2b60, ...}, ...)
	/drone/src/vendor/github.com/prometheus/prometheus/tsdb/compact.go:544 +0x7e9
github.com/prometheus/prometheus/tsdb.(*LeveledCompactor).Compact(0xc00b006000?, {0xc00264a050?, 0xa?}, {0xc000c5c000?, 0xc000bfd000?, 0xc005159808?}, {0x0?, 0x7fa7fa4d5d78?, 0x3ee4150?})
	/drone/src/vendor/github.com/prometheus/prometheus/tsdb/compact.go:487 +0x4c
github.com/grafana/mimir/pkg/compactor.(*BucketCompactor).runCompactionJob(0xc0027caaa0, {0x3ed9378, 0xc000619540}, 0xc00104a1c0)
	/drone/src/vendor/github.com/grafana/mimir/pkg/compactor/bucket_compactor.go:365 +0x10b8
github.com/grafana/mimir/pkg/compactor.(*BucketCompactor).Compact.func2()
	/drone/src/vendor/github.com/grafana/mimir/pkg/compactor/bucket_compactor.go:857 +0x2ef
created by github.com/grafana/mimir/pkg/compactor.(*BucketCompactor).Compact in goroutine 110
	/drone/src/vendor/github.com/grafana/mimir/pkg/compactor/bucket_compactor.go:841 +0xbc7
```