### PR TITLE
Fix histogram pool poisoning bug chunkenc.Iterator

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2356,6 +2356,11 @@ loop:
 		} else {
 			histograms = append(histograms, HPoint{H: &histogram.FloatHistogram{}})
 		}
+		if histograms[n].H == nil {
+			// Initialize to non zero to AtFloatHistogram does a copy for sure.
+			// Not an issue in the loop above since that uses an intermediate buffer.
+			histograms[n].H = &histogram.FloatHistogram{}
+		}
 		histograms[n].T, histograms[n].H = it.AtFloatHistogram(histograms[n].H)
 		if value.IsStaleNaN(histograms[n].H.Sum) {
 			histograms = histograms[:n]

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2357,7 +2357,7 @@ loop:
 			histograms = append(histograms, HPoint{H: &histogram.FloatHistogram{}})
 		}
 		if histograms[n].H == nil {
-			// Initialize to non zero to AtFloatHistogram does a copy for sure.
+			// Make sure to pass non zero H to AtFloatHistogram so that it does a deep-copy.
 			// Not an issue in the loop above since that uses an intermediate buffer.
 			histograms[n].H = &histogram.FloatHistogram{}
 		}

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3797,3 +3797,62 @@ func makeInt64Pointer(val int64) *int64 {
 	*valp = val
 	return valp
 }
+
+func TestHistogramCopyFromIteratorRegression(t *testing.T) {
+	// Loading the following histograms creates two chunks because there's a
+	// counter reset. Not only the counter is lower in the last histogram
+	// but also there's missing buckets.
+	// This in turns means that chunk iterators will have different spans.
+	load := `load 1m
+histogram {{sum:4 count:4 buckets:[2 2]}} {{sum:6 count:6 buckets:[3 3]}} {{sum:1 count:1 buckets:[1]}}
+`
+	storage := promqltest.LoadedStorage(t, load)
+	t.Cleanup(func() { storage.Close() })
+	engine := promqltest.NewTestEngine(false, 0, promqltest.DefaultMaxSamplesPerQuery)
+
+	verify := func(t *testing.T, qry promql.Query, expected []histogram.FloatHistogram) {
+		res := qry.Exec(context.Background())
+		require.NoError(t, res.Err)
+
+		m, ok := res.Value.(promql.Matrix)
+		require.True(t, ok)
+
+		require.Len(t, m, 1)
+		series := m[0]
+
+		require.Empty(t, series.Floats)
+		require.Len(t, series.Histograms, len(expected))
+		for i, e := range expected {
+			series.Histograms[i].H.CounterResetHint = histogram.UnknownCounterReset // Don't care.
+			require.Equal(t, &e, series.Histograms[i].H)
+		}
+	}
+
+	qry, err := engine.NewRangeQuery(context.Background(), storage, nil, "increase(histogram[60s])", time.Unix(0, 0), time.Unix(0, 0).Add(1*time.Minute), time.Minute)
+	require.NoError(t, err)
+	verify(t, qry, []histogram.FloatHistogram{
+		{
+			Count:           2,
+			Sum:             2,                                        // Increase from 4 to 6 is 2.
+			PositiveSpans:   []histogram.Span{{Offset: 0, Length: 2}}, // Two buckets changed between the first and second histogram.
+			PositiveBuckets: []float64{1, 1},                          // Increase from 2 to 3 is 1 in both buckets.
+		},
+	})
+
+	qry, err = engine.NewInstantQuery(context.Background(), storage, nil, "histogram[60s]", time.Unix(0, 0).Add(2*time.Minute))
+	require.NoError(t, err)
+	verify(t, qry, []histogram.FloatHistogram{
+		{
+			Count:           6,
+			Sum:             6,
+			PositiveSpans:   []histogram.Span{{Offset: 0, Length: 2}},
+			PositiveBuckets: []float64{3, 3},
+		},
+		{
+			Count:           1,
+			Sum:             1,
+			PositiveSpans:   []histogram.Span{{Offset: 0, Length: 1}},
+			PositiveBuckets: []float64{1},
+		},
+	})
+}


### PR DESCRIPTION
chunkenc.Iterator.AtFloatHistogram may do a shallow copy if it receives nil as input pointer. This can in turn share the span slice with multiple histograms in the matrixSelectorHPool, leading to unexpected errors.

From investigating https://github.com/grafana/mimir/issues/8889

The unit test runs a range query with internal vector selector that poisons the cache.
Without the fix you get:
```
--- FAIL: TestHistogramCopyFromIteratorRegression (0.03s)
    /home/krajo/go/github.com/krajorama/prometheus/promql/engine_test.go:3828: 
        	Error Trace:	/home/krajo/go/github.com/krajorama/prometheus/promql/engine_test.go:3828
        	            				/home/krajo/go/github.com/krajorama/prometheus/promql/engine_test.go:3893
        	Error:      	Not equal: 
        	            	expected: &histogram.FloatHistogram{CounterResetHint:0x0, Schema:0, ZeroThreshold:0, ZeroCount:0, Count:6, Sum:6, PositiveSpans:[]histogram.Span{histogram.Span{Offset:0, Length:0x2}}, NegativeSpans:[]histogram.Span(nil), PositiveBuckets:[]float64{3, 3}, NegativeBuckets:[]float64(nil), CustomValues:[]float64(nil)}
        	            	actual  : &histogram.FloatHistogram{CounterResetHint:0x0, Schema:0, ZeroThreshold:0, ZeroCount:0, Count:6, Sum:6, PositiveSpans:[]histogram.Span{histogram.Span{Offset:0, Length:0x1}}, NegativeSpans:[]histogram.Span(nil), PositiveBuckets:[]float64{3, 3}, NegativeBuckets:[]float64(nil), CustomValues:[]float64(nil)}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -10,3 +10,3 @@
        	            	    Offset: (int32) 0,
        	            	-   Length: (uint32) 2
        	            	+   Length: (uint32) 1
        	            	   }
        	Test:       	TestHistogramCopyFromIteratorRegression
```