### PR TITLE
Fix appendable: check whether last val was a histogram

### DIFF
--- a/storage/errors_test.go
+++ b/storage/errors_test.go
@@ -25,13 +25,14 @@ func TestErrDuplicateSampleForTimestamp(t *testing.T) {
 	require.ErrorIs(t, ErrDuplicateSampleForTimestamp, errDuplicateSampleForTimestamp{})
 
 	// Same type only is if it has same properties.
-	err1 := NewDuplicateFloatErr(1_000, 10, 20)
-	err2 := NewDuplicateFloatErr(1_001, 30, 40)
+	err := NewDuplicateFloatErr(1_000, 10, 20)
+	sameErr := NewDuplicateFloatErr(1_000, 10, 20)
+	differentErr := NewDuplicateFloatErr(1_001, 30, 40)
 
-	require.ErrorIs(t, err1, err1)
-	require.NotErrorIs(t, err1, err2)
+	require.ErrorIs(t, err, sameErr)
+	require.NotErrorIs(t, err, differentErr)
 
 	// Also works when err is wrapped.
-	require.ErrorIs(t, fmt.Errorf("failed: %w", err1), err1)
-	require.NotErrorIs(t, fmt.Errorf("failed: %w", err1), err2)
+	require.ErrorIs(t, fmt.Errorf("failed: %w", err), sameErr)
+	require.NotErrorIs(t, fmt.Errorf("failed: %w", err), differentErr)
 }

--- a/storage/errors_test.go
+++ b/storage/errors_test.go
@@ -1,3 +1,16 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package storage
 
 import (

--- a/storage/errors_test.go
+++ b/storage/errors_test.go
@@ -1,0 +1,25 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrDuplicateSampleForTimestamp(t *testing.T) {
+	// All errDuplicateSampleForTimestamp are ErrDuplicateSampleForTimestamp
+	require.True(t, errors.Is(ErrDuplicateSampleForTimestamp, errDuplicateSampleForTimestamp{}))
+
+	// Same type only is if it has same properties.
+	err1 := NewDuplicateFloatErr(1_000, 10, 20)
+	err2 := NewDuplicateFloatErr(1_001, 30, 40)
+
+	require.True(t, errors.Is(err1, err1))
+	require.False(t, errors.Is(err1, err2))
+
+	// Also works when err is wrapped.
+	require.True(t, errors.Is(fmt.Errorf("failed: %w", err1), err1))
+	require.False(t, errors.Is(fmt.Errorf("failed: %w", err1), err2))
+}

--- a/storage/errors_test.go
+++ b/storage/errors_test.go
@@ -14,7 +14,6 @@
 package storage
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -23,16 +22,16 @@ import (
 
 func TestErrDuplicateSampleForTimestamp(t *testing.T) {
 	// All errDuplicateSampleForTimestamp are ErrDuplicateSampleForTimestamp
-	require.True(t, errors.Is(ErrDuplicateSampleForTimestamp, errDuplicateSampleForTimestamp{}))
+	require.ErrorIs(t, ErrDuplicateSampleForTimestamp, errDuplicateSampleForTimestamp{})
 
 	// Same type only is if it has same properties.
 	err1 := NewDuplicateFloatErr(1_000, 10, 20)
 	err2 := NewDuplicateFloatErr(1_001, 30, 40)
 
-	require.True(t, errors.Is(err1, err1))
-	require.False(t, errors.Is(err1, err2))
+	require.ErrorIs(t, err1, err1)
+	require.NotErrorIs(t, err1, err2)
 
 	// Also works when err is wrapped.
-	require.True(t, errors.Is(fmt.Errorf("failed: %w", err1), err1))
-	require.False(t, errors.Is(fmt.Errorf("failed: %w", err1), err2))
+	require.ErrorIs(t, fmt.Errorf("failed: %w", err1), err1)
+	require.NotErrorIs(t, fmt.Errorf("failed: %w", err1), err2)
 }

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -466,6 +466,9 @@ func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime, oooTi
 			// like federation and erroring out at that time would be extremely noisy.
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
+			if s.lastHistogramValue != nil || s.lastFloatHistogramValue != nil {
+				return false, 0, storage.NewDuplicateHistogramToFloatErr(t, v)
+			}
 			if math.Float64bits(s.lastValue) != math.Float64bits(v) {
 				return false, 0, storage.NewDuplicateFloatErr(t, s.lastValue, v)
 			}


### PR DESCRIPTION
When appending a float, we were checking whether lastValue was equal to current value, but we didn't check whether last value was a float value.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
