### PR TITLE
promql: clarify error message logged when panic occurs during query evaluation

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1057,7 +1057,7 @@ func (ev *evaluator) recover(expr parser.Expr, ws *annotations.Annotations, errp
 		buf := make([]byte, 64<<10)
 		buf = buf[:runtime.Stack(buf, false)]
 
-		level.Error(ev.logger).Log("msg", "runtime panic in parser", "expr", expr.String(), "err", e, "stacktrace", string(buf))
+		level.Error(ev.logger).Log("msg", "runtime panic during query evaluation", "expr", expr.String(), "err", e, "stacktrace", string(buf))
 		*errp = fmt.Errorf("unexpected error: %w", err)
 	case errWithWarnings:
 		*errp = err.err


### PR DESCRIPTION
When a panic occurs during query evaluation, `runtime panic in parser` is logged. However this is misleading: there's no guarantee the issue occurred in the parser, and the panic could have occurred in other stages of query evaluation.

This PR makes the message more generic.