### PR TITLE
api: add request headers as a parameter for codec interface

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -34,7 +34,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/regexp"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/munnerz/goautoneg"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
@@ -1794,14 +1793,8 @@ func (api *API) respond(w http.ResponseWriter, req *http.Request, data interface
 
 func (api *API) negotiateCodec(req *http.Request, resp *Response) (Codec, error) {
 	for _, codec := range api.codecs {
-		if !codec.CanEncode(req, resp) {
-			continue
-		}
-
-		for _, clause := range goautoneg.ParseAccept(req.Header.Get("Accept")) {
-			if codec.ContentType().Satisfies(clause) {
-				return codec, nil
-			}
+		if codec.CanEncode(req, resp) {
+			return codec, nil
 		}
 	}
 

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1777,7 +1777,7 @@ func (api *API) respond(w http.ResponseWriter, req *http.Request, data interface
 		return
 	}
 
-	b, err := codec.Encode(req, resp)
+	b, err := codec.Encode(resp)
 	if err != nil {
 		level.Error(api.logger).Log("msg", "error marshaling response", "url", req.URL, "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1778,7 +1778,7 @@ func (api *API) respond(w http.ResponseWriter, req *http.Request, data interface
 		return
 	}
 
-	b, err := codec.Encode(resp)
+	b, err := codec.Encode(req, resp)
 	if err != nil {
 		level.Error(api.logger).Log("msg", "error marshaling response", "url", req.URL, "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1795,14 +1795,14 @@ func (api *API) respond(w http.ResponseWriter, req *http.Request, data interface
 func (api *API) negotiateCodec(req *http.Request, resp *Response) (Codec, error) {
 	for _, clause := range goautoneg.ParseAccept(req.Header.Get("Accept")) {
 		for _, codec := range api.codecs {
-			if codec.ContentType().Satisfies(clause) && codec.CanEncode(resp) {
+			if codec.ContentType().Satisfies(clause) && codec.CanEncode(req, resp) {
 				return codec, nil
 			}
 		}
 	}
 
 	defaultCodec := api.codecs[0]
-	if !defaultCodec.CanEncode(resp) {
+	if !defaultCodec.CanEncode(req, resp) {
 		return nil, fmt.Errorf("cannot encode response as %s", defaultCodec.ContentType())
 	}
 

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1793,9 +1793,13 @@ func (api *API) respond(w http.ResponseWriter, req *http.Request, data interface
 }
 
 func (api *API) negotiateCodec(req *http.Request, resp *Response) (Codec, error) {
-	for _, clause := range goautoneg.ParseAccept(req.Header.Get("Accept")) {
-		for _, codec := range api.codecs {
-			if codec.ContentType().Satisfies(clause) && codec.CanEncode(req, resp) {
+	for _, codec := range api.codecs {
+		if !codec.CanEncode(req, resp) {
+			continue
+		}
+
+		for _, clause := range goautoneg.ParseAccept(req.Header.Get("Accept")) {
+			if codec.ContentType().Satisfies(clause) {
 				return codec, nil
 			}
 		}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -4112,11 +4112,11 @@ func (t *testCodec) ContentType() MIMEType {
 	return t.contentType
 }
 
-func (t *testCodec) CanEncode(_ *Response) bool {
+func (t *testCodec) CanEncode(_ *http.Request, _ *Response) bool {
 	return t.canEncode
 }
 
-func (t *testCodec) Encode(_ *Response) ([]byte, error) {
+func (t *testCodec) Encode(_ *http.Request, _ *Response) ([]byte, error) {
 	return []byte(fmt.Sprintf("response from %v codec", t.contentType)), nil
 }
 

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -4116,7 +4116,7 @@ func (t *testCodec) CanEncode(_ *http.Request, _ *Response) bool {
 	return t.canEncode
 }
 
-func (t *testCodec) Encode(_ *http.Request, _ *Response) ([]byte, error) {
+func (t *testCodec) Encode(_ *Response) ([]byte, error) {
 	return []byte(fmt.Sprintf("response from %v codec", t.contentType)), nil
 }
 

--- a/web/api/v1/codec.go
+++ b/web/api/v1/codec.go
@@ -13,7 +13,11 @@
 
 package v1
 
-import "github.com/munnerz/goautoneg"
+import (
+	"net/http"
+
+	"github.com/munnerz/goautoneg"
+)
 
 // A Codec performs encoding of API responses.
 type Codec interface {
@@ -21,10 +25,10 @@ type Codec interface {
 	ContentType() MIMEType
 
 	// CanEncode determines if this Codec can encode resp.
-	CanEncode(resp *Response) bool
+	CanEncode(req *http.Request, resp *Response) bool
 
 	// Encode encodes resp, ready for transmission to an API consumer.
-	Encode(resp *Response) ([]byte, error)
+	Encode(req *http.Request, resp *Response) ([]byte, error)
 }
 
 type MIMEType struct {

--- a/web/api/v1/codec.go
+++ b/web/api/v1/codec.go
@@ -28,7 +28,7 @@ type Codec interface {
 	CanEncode(req *http.Request, resp *Response) bool
 
 	// Encode encodes resp, ready for transmission to an API consumer.
-	Encode(req *http.Request, resp *Response) ([]byte, error)
+	Encode(resp *Response) ([]byte, error)
 }
 
 type MIMEType struct {

--- a/web/api/v1/json_codec.go
+++ b/web/api/v1/json_codec.go
@@ -43,7 +43,7 @@ func (j JSONCodec) ContentType() MIMEType {
 	return MIMEType{Type: "application", SubType: "json"}
 }
 
-func (j JSONCodec) CanEncode(req *http.Request, _ *Response) bool {
+func (j JSONCodec) CanEncode(_ *http.Request, _ *Response) bool {
 	return true
 }
 

--- a/web/api/v1/json_codec.go
+++ b/web/api/v1/json_codec.go
@@ -18,6 +18,7 @@ import (
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/munnerz/goautoneg"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
@@ -43,8 +44,13 @@ func (j JSONCodec) ContentType() MIMEType {
 	return MIMEType{Type: "application", SubType: "json"}
 }
 
-func (j JSONCodec) CanEncode(_ *http.Request, _ *Response) bool {
-	return true
+func (j JSONCodec) CanEncode(req *http.Request, _ *Response) bool {
+	for _, clause := range goautoneg.ParseAccept(req.Header.Get("Accept")) {
+		if j.ContentType().Satisfies(clause) {
+			return true
+		}
+	}
+	return false
 }
 
 func (j JSONCodec) Encode(_ *http.Request, resp *Response) ([]byte, error) {

--- a/web/api/v1/json_codec.go
+++ b/web/api/v1/json_codec.go
@@ -45,12 +45,7 @@ func (j JSONCodec) ContentType() MIMEType {
 }
 
 func (j JSONCodec) CanEncode(req *http.Request, _ *Response) bool {
-	for _, clause := range goautoneg.ParseAccept(req.Header.Get("Accept")) {
-		if j.ContentType().Satisfies(clause) {
-			return true
-		}
-	}
-	return false
+	return true
 }
 
 func (j JSONCodec) Encode(resp *Response) ([]byte, error) {

--- a/web/api/v1/json_codec.go
+++ b/web/api/v1/json_codec.go
@@ -14,6 +14,7 @@
 package v1
 
 import (
+	"net/http"
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
@@ -42,11 +43,11 @@ func (j JSONCodec) ContentType() MIMEType {
 	return MIMEType{Type: "application", SubType: "json"}
 }
 
-func (j JSONCodec) CanEncode(_ *Response) bool {
+func (j JSONCodec) CanEncode(_ *http.Request, _ *Response) bool {
 	return true
 }
 
-func (j JSONCodec) Encode(resp *Response) ([]byte, error) {
+func (j JSONCodec) Encode(_ *http.Request, resp *Response) ([]byte, error) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(resp)
 }

--- a/web/api/v1/json_codec.go
+++ b/web/api/v1/json_codec.go
@@ -53,7 +53,7 @@ func (j JSONCodec) CanEncode(req *http.Request, _ *Response) bool {
 	return false
 }
 
-func (j JSONCodec) Encode(_ *http.Request, resp *Response) ([]byte, error) {
+func (j JSONCodec) Encode(resp *Response) ([]byte, error) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(resp)
 }

--- a/web/api/v1/json_codec.go
+++ b/web/api/v1/json_codec.go
@@ -18,7 +18,6 @@ import (
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/munnerz/goautoneg"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"

--- a/web/api/v1/json_codec_test.go
+++ b/web/api/v1/json_codec_test.go
@@ -15,6 +15,7 @@ package v1
 
 import (
 	"math"
+	"net/http"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -197,7 +198,7 @@ func TestJsonCodec_Encode(t *testing.T) {
 	codec := JSONCodec{}
 
 	for _, c := range cases {
-		body, err := codec.Encode(&Response{
+		body, err := codec.Encode(&http.Request{}, &Response{
 			Status: statusSuccess,
 			Data:   c.response,
 		})

--- a/web/api/v1/json_codec_test.go
+++ b/web/api/v1/json_codec_test.go
@@ -15,7 +15,6 @@ package v1
 
 import (
 	"math"
-	"net/http"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -198,7 +197,7 @@ func TestJsonCodec_Encode(t *testing.T) {
 	codec := JSONCodec{}
 
 	for _, c := range cases {
-		body, err := codec.Encode(&http.Request{}, &Response{
+		body, err := codec.Encode(&Response{
 			Status: statusSuccess,
 			Data:   c.response,
 		})


### PR DESCRIPTION
The current codec interface allows implementing codecs to serialize query response data and installing them to the api. The only parameter passed to the codec is the data to be serialized itself.

I am writing a protobuf codec that handles range and instant queries differently. However, **_there is no way to distinguish between the two based on the response data alone_** (instant queries with matrix type and range queries share the exact structure).

This change to the codec interface allows passing the request headers along with the data to be serialized so that the codec implementation can handle the data in the context of the original request type.


<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
