### PR TITLE
docs: Be more explicit about `promql-experimental-functions`

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -200,8 +200,9 @@ won't work when you push OTLP metrics.
 
 `--enable-feature=promql-experimental-functions`
 
-Enables PromQL functions that are considered experimental and whose name or
-semantics could change.
+Enables PromQL functions that are considered experimental. These functions
+might change their name, syntax, or semantics. They might also get removed
+entirely.
 
 ## Created Timestamps Zero Injection
 


### PR DESCRIPTION
We have not mentioned that experimental PromQL functions might get removed entirely, although that's one of the most important properties of functions declared experimental.

@juliusv as we discussed how important the ability to remove is.