### PR TITLE
Change subsystem to "storage" in remote_read_queries gauge

### DIFF
--- a/storage/remote/read_handler.go
+++ b/storage/remote/read_handler.go
@@ -57,8 +57,8 @@ func NewReadHandler(logger log.Logger, r prometheus.Registerer, queryable storag
 		marshalPool:               &sync.Pool{},
 
 		queries: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "prometheus",
-			Subsystem: "api", // TODO: changes to storage in Prometheus 3.0.
+			Namespace: namespace,
+			Subsystem: "remote_read_handler",
 			Name:      "remote_read_queries",
 			Help:      "The current number of remote read queries being executed or waiting.",
 		}),


### PR DESCRIPTION
Updated the Prometheus gauge definition for `remote_read_queries` to reflect the correct subsystem ("storage" instead of "api").

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
