### PR TITLE
Ignore empty chunks in index.AddSeries()

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -450,6 +450,11 @@ func (w *Writer) AddSeries(ref storage.SeriesRef, lset labels.Labels, chunks ...
 		}
 		lastChunkRef = c.Ref
 
+		// Skip empty chunks
+		if c.Chunk.NumSamples() == 0 {
+			continue
+		}
+
 		if ix > 0 && c.MinTime <= lastMaxT {
 			return fmt.Errorf("chunk minT %d is not higher than previous chunk maxT %d", c.MinTime, lastMaxT)
 		}


### PR DESCRIPTION
We're seeing compaction errors:

caller=db.go:1055 level=error component=tsdb msg="compaction failed" err="add series: chunk minT 1700423949098 is not higher than previous chunk maxT 1700423949098"

This is likely because some time series were deleted from Prometheus using /api/v1/admin/tsdb/delete_series and  https://github.com/prometheus/prometheus/pull/8085 introduced a check that now triggers this error. Ignore empty chunks in this check.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

@MichaHoffmann 