### PR TITLE
add v3 tags to action conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
     if: |
       !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
       &&
+      !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
+      &&
       !(github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-'))
       &&
       !(github.event_name == 'push' && github.event.ref == 'refs/heads/main')
@@ -126,6 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
+      ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
       ||
       (github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-'))
       ||
@@ -211,7 +215,10 @@ jobs:
     name: Publish release artefacts
     runs-on: ubuntu-latest
     needs: [test_ui, test_go, test_go_more, test_go_oldest, test_windows, golangci, codeql, build_all]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.')
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
+      ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: prometheus/promci@3cb0c3871f223bd5ce1226995bd52ffb314798b6 # v0.1.0
@@ -242,17 +249,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - name: Check libraries version
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.')
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
+          ||
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
         run: ./scripts/ui_release.sh --check-package "$(echo ${{ github.ref_name }}|sed s/v2/v0/)"
       - name: build
         run: make assets
       - name: Copy files before publishing libs
         run: ./scripts/ui_release.sh --copy
       - name: Publish dry-run libraries
-        if: "!(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))"
+        if: |
+          !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
+          &&
+          !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
         run: ./scripts/ui_release.sh --publish dry-run
       - name: Publish libraries
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.')
+        if: |
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
+          ||
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
         run: ./scripts/ui_release.sh --publish
         env:
           # The setup-node action writes an .npmrc file with this env variable


### PR DESCRIPTION
Actions have several publish steps that are gated by pushes to tags starting with v2. This adds the same for tags starting with v3.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
