### PR TITLE
Histogram CT Zero ingestion

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1597,6 +1597,10 @@ func (n notReadyAppender) AppendHistogram(ref storage.SeriesRef, l labels.Labels
 	return 0, tsdb.ErrNotReady
 }
 
+func (n notReadyAppender) AppendHistogramCTZeroSample(ref storage.SeriesRef, l labels.Labels, t, ct int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	return 0, tsdb.ErrNotReady
+}
+
 func (n notReadyAppender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -39,8 +39,10 @@ import (
 	"github.com/prometheus/prometheus/discovery"
 	_ "github.com/prometheus/prometheus/discovery/file"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/util/runutil"
 	"github.com/prometheus/prometheus/util/testutil"
 )
@@ -854,6 +856,178 @@ func TestManagerCTZeroIngestion(t *testing.T) {
 			// Expect only one, valid sample.
 			require.Len(t, got, 1)
 			require.Equal(t, tc.counterSample.GetValue(), got[0])
+		})
+	}
+}
+
+// generateTestHistogram generates the same thing as tsdbutil.GenerateTestHistogram,
+// but in the form of dto.Histogram.
+func generateTestHistogram(i int) *dto.Histogram {
+	helper := tsdbutil.GenerateTestHistogram(i)
+	h := &dto.Histogram{}
+	h.SampleCount = proto.Uint64(helper.Count)
+	h.SampleSum = proto.Float64(helper.Sum)
+	h.Schema = proto.Int32(helper.Schema)
+	h.ZeroThreshold = proto.Float64(helper.ZeroThreshold)
+	h.ZeroCount = proto.Uint64(helper.ZeroCount)
+	h.PositiveSpan = make([]*dto.BucketSpan, len(helper.PositiveSpans))
+	for i, span := range helper.PositiveSpans {
+		h.PositiveSpan[i] = &dto.BucketSpan{
+			Offset: proto.Int32(span.Offset),
+			Length: proto.Uint32(span.Length),
+		}
+	}
+	h.PositiveDelta = helper.PositiveBuckets
+	h.NegativeSpan = make([]*dto.BucketSpan, len(helper.NegativeSpans))
+	for i, span := range helper.NegativeSpans {
+		h.NegativeSpan[i] = &dto.BucketSpan{
+			Offset: proto.Int32(span.Offset),
+			Length: proto.Uint32(span.Length),
+		}
+	}
+	h.NegativeDelta = helper.NegativeBuckets
+	return h
+}
+
+func TestManagerCTZeroIngestionHistogram(t *testing.T) {
+	const mName = "expected_histogram"
+
+	for _, tc := range []struct {
+		name                  string
+		inputHistSample       *dto.Histogram
+		enableCTZeroIngestion bool
+	}{
+		{
+			name: "disabled with CT on histogram",
+			inputHistSample: func() *dto.Histogram {
+				h := generateTestHistogram(0)
+				h.CreatedTimestamp = timestamppb.Now()
+				return h
+			}(),
+			enableCTZeroIngestion: false,
+		},
+		{
+			name: "enabled with CT on histogram",
+			inputHistSample: func() *dto.Histogram {
+				h := generateTestHistogram(0)
+				h.CreatedTimestamp = timestamppb.Now()
+				return h
+			}(),
+			enableCTZeroIngestion: true,
+		},
+		{
+			name: "enabled without CT on histogram",
+			inputHistSample: func() *dto.Histogram {
+				h := generateTestHistogram(0)
+				return h
+			}(),
+			enableCTZeroIngestion: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &collectResultAppender{}
+			scrapeManager, err := NewManager(
+				&Options{
+					EnableCreatedTimestampZeroIngestion: tc.enableCTZeroIngestion,
+					EnableNativeHistogramsIngestion:     true,
+					skipOffsetting:                      true,
+				},
+				log.NewLogfmtLogger(os.Stderr),
+				nil,
+				&collectResultAppendable{app},
+				prometheus.NewRegistry(),
+			)
+			require.NoError(t, err)
+
+			require.NoError(t, scrapeManager.ApplyConfig(&config.Config{
+				GlobalConfig: config.GlobalConfig{
+					// Disable regular scrapes.
+					ScrapeInterval: model.Duration(9999 * time.Minute),
+					ScrapeTimeout:  model.Duration(5 * time.Second),
+					// Ensure the proto is chosen. We need proto as it's the only protocol
+					// with the CT parsing support.
+					ScrapeProtocols: []config.ScrapeProtocol{config.PrometheusProto},
+				},
+				ScrapeConfigs: []*config.ScrapeConfig{{JobName: "test"}},
+			}))
+
+			once := sync.Once{}
+			// Start fake HTTP target to that allow one scrape only.
+			server := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					fail := true // TODO(bwplotka): Kill or use?
+					once.Do(func() {
+						fail = false
+						w.Header().Set("Content-Type", `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
+
+						ctrType := dto.MetricType_HISTOGRAM
+						w.Write(protoMarshalDelimited(t, &dto.MetricFamily{
+							Name:   proto.String(mName),
+							Type:   &ctrType,
+							Metric: []*dto.Metric{{Histogram: tc.inputHistSample}},
+						}))
+					})
+
+					if fail {
+						w.WriteHeader(http.StatusInternalServerError)
+					}
+				}),
+			)
+			defer server.Close()
+
+			serverURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			// Add fake target directly into tsets + reload. Normally users would use
+			// Manager.Run and wait for minimum 5s refresh interval.
+			scrapeManager.updateTsets(map[string][]*targetgroup.Group{
+				"test": {{
+					Targets: []model.LabelSet{{
+						model.SchemeLabel:  model.LabelValue(serverURL.Scheme),
+						model.AddressLabel: model.LabelValue(serverURL.Host),
+					}},
+				}},
+			})
+			scrapeManager.reload()
+
+			var got []histogramSample
+
+			// Wait for one scrape.
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			defer cancel()
+			require.NoError(t, runutil.Retry(100*time.Millisecond, ctx.Done(), func() error {
+				app.mtx.Lock()
+				defer app.mtx.Unlock()
+
+				// Check if scrape happened and grab the relevant histograms, they have to be there - or it's a bug
+				// and it's not worth waiting.
+				for _, h := range app.resultHistograms {
+					if h.metric.Get(model.MetricNameLabel) == mName {
+						got = append(got, h)
+					}
+				}
+				if len(app.resultHistograms) > 0 {
+					return nil
+				}
+				return fmt.Errorf("expected some histogram samples, got none")
+			}), "after 1 minute")
+			scrapeManager.Stop()
+
+			// Check for zero samples, assuming we only injected always one histogram sample.
+			// Did it contain CT to inject? If yes, was CT zero enabled?
+			if tc.inputHistSample.CreatedTimestamp.IsValid() && tc.enableCTZeroIngestion {
+				require.Len(t, got, 2)
+				// Zero sample.
+				require.Equal(t, histogram.Histogram{}, *got[0].h)
+				// Quick soft check to make sure it's the same sample or at least not zero.
+				require.Equal(t, tc.inputHistSample.GetSampleSum(), got[1].h.Sum)
+				return
+			}
+
+			// Expect only one, valid sample.
+			require.Len(t, got, 1)
+			// Quick soft check to make sure it's the same sample or at least not zero.
+			require.Equal(t, tc.inputHistSample.GetSampleSum(), got[0].h.Sum)
 		})
 	}
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1701,7 +1701,15 @@ loop:
 		} else {
 			if sl.enableCTZeroIngestion {
 				if ctMs := p.CreatedTimestamp(); ctMs != nil {
-					ref, err = app.AppendCTZeroSample(ref, lset, t, *ctMs)
+					if isHistogram && sl.enableNativeHistogramIngestion {
+						if h != nil {
+							ref, err = app.AppendHistogramCTZeroSample(ref, lset, t, *ctMs, h, nil)
+						} else {
+							ref, err = app.AppendHistogramCTZeroSample(ref, lset, t, *ctMs, nil, fh)
+						}
+					} else {
+						ref, err = app.AppendCTZeroSample(ref, lset, t, *ctMs)
+					}
 					if err != nil && !errors.Is(err, storage.ErrOutOfOrderCT) { // OOO is a common case, ignoring completely for now.
 						// CT is an experimental feature. For now, we don't need to fail the
 						// scrape on errors updating the created timestamp, log debug.

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1999,7 +1999,8 @@ metric: <
 `,
 			contentType: "application/vnd.google.protobuf",
 			histograms: []histogramSample{{
-				t: 1234568,
+				t:      1234568,
+				metric: labels.FromStrings("__name__", "test_histogram"),
 				h: &histogram.Histogram{
 					Count:         175,
 					ZeroCount:     2,
@@ -2125,7 +2126,8 @@ metric: <
 				{metric: labels.FromStrings("__name__", "test_histogram_bucket", "le", "+Inf"), t: 1234568, f: 175},
 			},
 			histograms: []histogramSample{{
-				t: 1234568,
+				t:      1234568,
+				metric: labels.FromStrings("__name__", "test_histogram"),
 				h: &histogram.Histogram{
 					Count:         175,
 					ZeroCount:     2,

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -190,6 +190,20 @@ func (f *fanoutAppender) AppendHistogram(ref SeriesRef, l labels.Labels, t int64
 	return ref, nil
 }
 
+func (f *fanoutAppender) AppendHistogramCTZeroSample(ref SeriesRef, l labels.Labels, t, ct int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (SeriesRef, error) {
+	ref, err := f.primary.AppendHistogramCTZeroSample(ref, l, t, ct, h, fh)
+	if err != nil {
+		return ref, err
+	}
+
+	for _, appender := range f.secondaries {
+		if _, err := appender.AppendHistogramCTZeroSample(ref, l, t, ct, h, fh); err != nil {
+			return 0, err
+		}
+	}
+	return ref, nil
+}
+
 func (f *fanoutAppender) UpdateMetadata(ref SeriesRef, l labels.Labels, m metadata.Metadata) (SeriesRef, error) {
 	ref, err := f.primary.UpdateMetadata(ref, l, m)
 	if err != nil {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -50,7 +50,8 @@ var (
 	// NOTE(bwplotka): This can be both an instrumentation failure or commonly expected
 	// behaviour, and we currently don't have a way to determine this. As a result
 	// it's recommended to ignore this error for now.
-	ErrOutOfOrderCT = fmt.Errorf("created timestamp out of order, ignoring")
+	ErrOutOfOrderCT      = fmt.Errorf("created timestamp out of order, ignoring")
+	ErrCTNewerThanSample = fmt.Errorf("CT is newer or the same as sample's timestamp, ignoring")
 )
 
 // SeriesRef is a generic series reference. In prometheus it is either a
@@ -313,6 +314,20 @@ type HistogramAppender interface {
 	// pointer. AppendHistogram won't mutate the histogram, but in turn
 	// depends on the caller to not mutate it either.
 	AppendHistogram(ref SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (SeriesRef, error)
+	// AppendHistogramCTZeroSample adds synthetic zero sample for the given ct timestamp,
+	// which will be associated with given series, labels and the incoming
+	// sample's t (timestamp). AppendHistogramCTZeroSample returns error if zero sample can't be
+	// appended, for example when ct is too old, or when it would collide with
+	// incoming sample (sample has priority).
+	//
+	// AppendHistogramCTZeroSample has to be called before the corresponding histogram AppendHistogram.
+	// A series reference number is returned which can be used to modify the
+	// CT for the given series in the same or later transactions.
+	// Returned reference numbers are ephemeral and may be rejected in calls
+	// to AppendHistogramCTZeroSample() at any point.
+	//
+	// If the reference is 0 it must not be used for caching.
+	AppendHistogramCTZeroSample(ref SeriesRef, l labels.Labels, t, ct int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (SeriesRef, error)
 }
 
 // MetadataUpdater provides an interface for associating metadata to stored series.

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -306,6 +306,11 @@ func (t *timestampTracker) AppendHistogram(_ storage.SeriesRef, _ labels.Labels,
 	return 0, nil
 }
 
+func (t *timestampTracker) AppendHistogramCTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, _ int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	// TODO: Implement
+	return 0, nil
+}
+
 func (t *timestampTracker) UpdateMetadata(_ storage.SeriesRef, _ labels.Labels, _ metadata.Metadata) (storage.SeriesRef, error) {
 	// TODO: Add and increment a `metadata` field when we get around to wiring metadata in remote_write.
 	// UpdateMetadata is no-op for remote write (where timestampTracker is being used) for now.

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -915,6 +915,13 @@ func (m *mockAppendable) AppendHistogram(_ storage.SeriesRef, l labels.Labels, t
 	return 0, nil
 }
 
+func (m *mockAppendable) AppendHistogramCTZeroSample(ref storage.SeriesRef, l labels.Labels, t, ct int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	// AppendCTZeroSample is no-op for remote-write for now.
+	// TODO(bwplotka/arthursens): Add support for PRW 2.0 for CT zero feature (but also we might
+	// replace this with in-metadata CT storage, see https://github.com/prometheus/prometheus/issues/14218).
+	return 0, nil
+}
+
 func (m *mockAppendable) UpdateMetadata(_ storage.SeriesRef, l labels.Labels, mp metadata.Metadata) (storage.SeriesRef, error) {
 	if m.updateMetadataErr != nil {
 		return 0, m.updateMetadataErr

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -972,6 +972,11 @@ func (a *appender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int
 	return storage.SeriesRef(series.ref), nil
 }
 
+func (a *appender) AppendHistogramCTZeroSample(ref storage.SeriesRef, l labels.Labels, t, ct int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	// TODO(bwplotka/arthursens): Wire metadata in the Agent's appender.
+	return 0, nil
+}
+
 func (a *appender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
 	// TODO: Wire metadata in the Agent's appender.
 	return 0, nil

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -6281,11 +6281,15 @@ func TestHeadAppender_AppendFloatWithSameTimestampAsPreviousHistogram(t *testing
 	require.ErrorIs(t, err, storage.NewDuplicateHistogramToFloatErr(2_000, 10.0))
 }
 
-func TestHeadAppender_AppendCTZeroSample(t *testing.T) {
+func TestHeadAppender_AppendCT(t *testing.T) {
+	testHistogram := tsdbutil.GenerateTestHistogram(1)
+	testFloatHistogram := tsdbutil.GenerateTestFloatHistogram(1)
 	type appendableSamples struct {
-		ts  int64
-		val float64
-		ct  int64
+		ts      int64
+		fSample float64
+		h       *histogram.Histogram
+		fh      *histogram.FloatHistogram
+		ct      int64
 	}
 	for _, tc := range []struct {
 		name              string
@@ -6293,20 +6297,10 @@ func TestHeadAppender_AppendCTZeroSample(t *testing.T) {
 		expectedSamples   []chunks.Sample
 	}{
 		{
-			name: "In order ct+normal sample",
+			name: "In order ct+normal sample/floatSample",
 			appendableSamples: []appendableSamples{
-				{ts: 100, val: 10, ct: 1},
-			},
-			expectedSamples: []chunks.Sample{
-				sample{t: 1, f: 0},
-				sample{t: 100, f: 10},
-			},
-		},
-		{
-			name: "Consecutive appends with same ct ignore ct",
-			appendableSamples: []appendableSamples{
-				{ts: 100, val: 10, ct: 1},
-				{ts: 101, val: 10, ct: 1},
+				{ts: 100, fSample: 10, ct: 1},
+				{ts: 101, fSample: 10, ct: 1},
 			},
 			expectedSamples: []chunks.Sample{
 				sample{t: 1, f: 0},
@@ -6314,77 +6308,13 @@ func TestHeadAppender_AppendCTZeroSample(t *testing.T) {
 				sample{t: 101, f: 10},
 			},
 		},
-		{
-			name: "Consecutive appends with newer ct do not ignore ct",
-			appendableSamples: []appendableSamples{
-				{ts: 100, val: 10, ct: 1},
-				{ts: 102, val: 10, ct: 101},
-			},
-			expectedSamples: []chunks.Sample{
-				sample{t: 1, f: 0},
-				sample{t: 100, f: 10},
-				sample{t: 101, f: 0},
-				sample{t: 102, f: 10},
-			},
-		},
-		{
-			name: "CT equals to previous sample timestamp is ignored",
-			appendableSamples: []appendableSamples{
-				{ts: 100, val: 10, ct: 1},
-				{ts: 101, val: 10, ct: 100},
-			},
-			expectedSamples: []chunks.Sample{
-				sample{t: 1, f: 0},
-				sample{t: 100, f: 10},
-				sample{t: 101, f: 10},
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			h, _ := newTestHead(t, DefaultBlockDuration, wlog.CompressionNone, false)
-			defer func() {
-				require.NoError(t, h.Close())
-			}()
-			a := h.Appender(context.Background())
-			lbls := labels.FromStrings("foo", "bar")
-			for _, sample := range tc.appendableSamples {
-				_, err := a.AppendCTZeroSample(0, lbls, sample.ts, sample.ct)
-				require.NoError(t, err)
-				_, err = a.Append(0, lbls, sample.ts, sample.val)
-				require.NoError(t, err)
-			}
-			require.NoError(t, a.Commit())
-
-			q, err := NewBlockQuerier(h, math.MinInt64, math.MaxInt64)
-			require.NoError(t, err)
-			result := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
-			require.Equal(t, tc.expectedSamples, result[`{foo="bar"}`])
-		})
-	}
-}
-
-func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
-	testHistogram := tsdbutil.GenerateTestHistogram(1)
-	testFloatHistogram := tsdbutil.GenerateTestFloatHistogram(1)
-	lbls := labels.FromStrings("foo", "bar")
-	type appendableHistograms struct {
-		ts int64
-		h  *histogram.Histogram
-		fh *histogram.FloatHistogram
-		ct int64
-	}
-	for _, tc := range []struct {
-		name                 string
-		appendableHistograms []appendableHistograms
-		expectedHistograms   []chunks.Sample
-	}{
 		{
 			name: "In order ct+normal sample/histogram",
-			appendableHistograms: []appendableHistograms{
+			appendableSamples: []appendableSamples{
 				{ts: 100, h: testHistogram, ct: 1},
 				{ts: 101, h: testHistogram, ct: 1},
 			},
-			expectedHistograms: func() []chunks.Sample {
+			expectedSamples: func() []chunks.Sample {
 				hNoCounterReset := *testHistogram
 				hNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
@@ -6396,11 +6326,11 @@ func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
 		},
 		{
 			name: "In order ct+normal sample/floathistogram",
-			appendableHistograms: []appendableHistograms{
+			appendableSamples: []appendableSamples{
 				{ts: 100, fh: testFloatHistogram, ct: 1},
 				{ts: 101, fh: testFloatHistogram, ct: 1},
 			},
-			expectedHistograms: func() []chunks.Sample {
+			expectedSamples: func() []chunks.Sample {
 				fhNoCounterReset := *testFloatHistogram
 				fhNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
@@ -6411,12 +6341,24 @@ func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
 			}(),
 		},
 		{
+			name: "Consecutive appends with same ct ignore ct/floatSample",
+			appendableSamples: []appendableSamples{
+				{ts: 100, fSample: 10, ct: 1},
+				{ts: 101, fSample: 10, ct: 1},
+			},
+			expectedSamples: []chunks.Sample{
+				sample{t: 1, f: 0},
+				sample{t: 100, f: 10},
+				sample{t: 101, f: 10},
+			},
+		},
+		{
 			name: "Consecutive appends with same ct ignore ct/histogram",
-			appendableHistograms: []appendableHistograms{
+			appendableSamples: []appendableSamples{
 				{ts: 100, h: testHistogram, ct: 1},
 				{ts: 101, h: testHistogram, ct: 1},
 			},
-			expectedHistograms: func() []chunks.Sample {
+			expectedSamples: func() []chunks.Sample {
 				hNoCounterReset := *testHistogram
 				hNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
@@ -6428,11 +6370,11 @@ func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
 		},
 		{
 			name: "Consecutive appends with same ct ignore ct/floathistogram",
-			appendableHistograms: []appendableHistograms{
+			appendableSamples: []appendableSamples{
 				{ts: 100, fh: testFloatHistogram, ct: 1},
 				{ts: 101, fh: testFloatHistogram, ct: 1},
 			},
-			expectedHistograms: func() []chunks.Sample {
+			expectedSamples: func() []chunks.Sample {
 				fhNoCounterReset := *testFloatHistogram
 				fhNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
@@ -6443,12 +6385,25 @@ func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
 			}(),
 		},
 		{
+			name: "Consecutive appends with newer ct do not ignore ct/floatSample",
+			appendableSamples: []appendableSamples{
+				{ts: 100, fSample: 10, ct: 1},
+				{ts: 102, fSample: 10, ct: 101},
+			},
+			expectedSamples: []chunks.Sample{
+				sample{t: 1, f: 0},
+				sample{t: 100, f: 10},
+				sample{t: 101, f: 0},
+				sample{t: 102, f: 10},
+			},
+		},
+		{
 			name: "Consecutive appends with newer ct do not ignore ct/histogram",
-			appendableHistograms: []appendableHistograms{
+			appendableSamples: []appendableSamples{
 				{ts: 100, h: testHistogram, ct: 1},
 				{ts: 102, h: testHistogram, ct: 101},
 			},
-			expectedHistograms: []chunks.Sample{
+			expectedSamples: []chunks.Sample{
 				sample{t: 1, h: &histogram.Histogram{}},
 				sample{t: 100, h: testHistogram},
 				sample{t: 101, h: &histogram.Histogram{CounterResetHint: histogram.CounterReset}},
@@ -6457,11 +6412,11 @@ func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
 		},
 		{
 			name: "Consecutive appends with newer ct do not ignore ct/floathistogram",
-			appendableHistograms: []appendableHistograms{
+			appendableSamples: []appendableSamples{
 				{ts: 100, fh: testFloatHistogram, ct: 1},
 				{ts: 102, fh: testFloatHistogram, ct: 101},
 			},
-			expectedHistograms: []chunks.Sample{
+			expectedSamples: []chunks.Sample{
 				sample{t: 1, fh: &histogram.FloatHistogram{}},
 				sample{t: 100, fh: testFloatHistogram},
 				sample{t: 101, fh: &histogram.FloatHistogram{CounterResetHint: histogram.CounterReset}},
@@ -6469,12 +6424,24 @@ func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
 			},
 		},
 		{
+			name: "CT equals to previous sample timestamp is ignored/floatSample",
+			appendableSamples: []appendableSamples{
+				{ts: 100, fSample: 10, ct: 1},
+				{ts: 101, fSample: 10, ct: 100},
+			},
+			expectedSamples: []chunks.Sample{
+				sample{t: 1, f: 0},
+				sample{t: 100, f: 10},
+				sample{t: 101, f: 10},
+			},
+		},
+		{
 			name: "CT equals to previous sample timestamp is ignored/histogram",
-			appendableHistograms: []appendableHistograms{
+			appendableSamples: []appendableSamples{
 				{ts: 100, h: testHistogram, ct: 1},
 				{ts: 101, h: testHistogram, ct: 100},
 			},
-			expectedHistograms: func() []chunks.Sample {
+			expectedSamples: func() []chunks.Sample {
 				hNoCounterReset := *testHistogram
 				hNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
@@ -6486,11 +6453,11 @@ func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
 		},
 		{
 			name: "CT equals to previous sample timestamp is ignored/floathistogram",
-			appendableHistograms: []appendableHistograms{
+			appendableSamples: []appendableSamples{
 				{ts: 100, fh: testFloatHistogram, ct: 1},
 				{ts: 101, fh: testFloatHistogram, ct: 100},
 			},
-			expectedHistograms: func() []chunks.Sample {
+			expectedSamples: func() []chunks.Sample {
 				fhNoCounterReset := *testFloatHistogram
 				fhNoCounterReset.CounterResetHint = histogram.NotCounterReset
 				return []chunks.Sample{
@@ -6502,23 +6469,35 @@ func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			head, _ := newTestHead(t, DefaultBlockDuration, wlog.CompressionNone, false)
+			h, _ := newTestHead(t, DefaultBlockDuration, wlog.CompressionNone, false)
 			defer func() {
-				require.NoError(t, head.Close())
+				require.NoError(t, h.Close())
 			}()
-			appender := head.Appender(context.Background())
-			for _, sample := range tc.appendableHistograms {
-				ref, err := appender.AppendHistogramCTZeroSample(0, lbls, sample.ts, sample.ct, sample.h, sample.fh)
-				require.NoError(t, err)
-				_, err = appender.AppendHistogram(ref, lbls, sample.ts, sample.h, sample.fh)
-				require.NoError(t, err)
-			}
-			require.NoError(t, appender.Commit())
+			a := h.Appender(context.Background())
+			lbls := labels.FromStrings("foo", "bar")
+			for _, sample := range tc.appendableSamples {
+				// Append float if it's a float test case
+				if sample.fSample != 0 {
+					_, err := a.AppendCTZeroSample(0, lbls, sample.ts, sample.ct)
+					require.NoError(t, err)
+					_, err = a.Append(0, lbls, sample.ts, sample.fSample)
+					require.NoError(t, err)
+				}
 
-			q, err := NewBlockQuerier(head, math.MinInt64, math.MaxInt64)
+				// Append histograms if it's a histogram test case
+				if sample.h != nil || sample.fh != nil {
+					ref, err := a.AppendHistogramCTZeroSample(0, lbls, sample.ts, sample.ct, sample.h, sample.fh)
+					require.NoError(t, err)
+					_, err = a.AppendHistogram(ref, lbls, sample.ts, sample.h, sample.fh)
+					require.NoError(t, err)
+				}
+			}
+			require.NoError(t, a.Commit())
+
+			q, err := NewBlockQuerier(h, math.MinInt64, math.MaxInt64)
 			require.NoError(t, err)
 			result := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
-			require.Equal(t, tc.expectedHistograms, result[`{foo="bar"}`])
+			require.Equal(t, tc.expectedSamples, result[`{foo="bar"}`])
 		})
 	}
 }


### PR DESCRIPTION
Fixes #13384

Fundamentally it follows the same logic used in `AppendCTZeroSample()`, used to append zeros for usual samples, but for histograms, we're using Go's zero value for `histogram.Histogram{}` and `histogram.FloatHistogram{}`

The tricky thing here is that the Histogram format has CounterResetHints, which the query engine uses to detect resets. From my understanding, however, this is a no-op during the scrape and the storage layer handles the addition of counter-reset hints. This PR is only tackling the scrape part of things.

There is one test in head_appender_test that queries the appended data and counter-reset hints are verified as well