### PR TITLE
[PERF] TSDB: Grow postings by doubling

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -345,13 +345,22 @@ func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
 	p.mtx.Unlock()
 }
 
+func appendWithExponentialGrowth[T any](a []T, v T) []T {
+	if cap(a) < len(a)+1 {
+		newList := make([]T, len(a), len(a)*2+1)
+		copy(newList, a)
+		a = newList
+	}
+	return append(a, v)
+}
+
 func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
 	nm, ok := p.m[l.Name]
 	if !ok {
 		nm = map[string][]storage.SeriesRef{}
 		p.m[l.Name] = nm
 	}
-	list := append(nm[l.Value], id)
+	list := appendWithExponentialGrowth(nm[l.Value], id)
 	nm[l.Value] = list
 
 	if !p.ordered {


### PR DESCRIPTION
Go's built-in append() grows larger slices with factor 1.3, which means we do a lot more allocating and copying for larger postings.

Benchmarks:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Core(TM) i7-14700K
                                             │  before.txt  │             after.txt              │
                                             │    sec/op    │   sec/op     vs base               │
HeadStripeSeriesCreate-28                      722.9n ±  6%   710.7n ± 3%        ~ (p=0.065 n=6)
HeadStripeSeriesCreateParallel-28              746.5n ±  2%   723.8n ± 1%   -3.03% (p=0.002 n=6)
HeadStripeSeriesCreate_PreCreationFailure-28   89.70n ±  1%   89.72n ± 2%        ~ (p=0.699 n=6)
CreateSeries-28                                1.173µ ± 12%   1.029µ ± 3%  -12.24% (p=0.002 n=6)
geomean                                        488.1n         466.8n        -4.36%

                                             │ before.txt │              after.txt              │
                                             │    B/op    │    B/op     vs base                 │
HeadStripeSeriesCreate-28                      553.5 ± 3%   529.5 ± 4%   -4.34% (p=0.009 n=6)
HeadStripeSeriesCreateParallel-28              564.0 ± 2%   535.5 ± 1%   -5.05% (p=0.002 n=6)
HeadStripeSeriesCreate_PreCreationFailure-28   71.00 ± 0%   71.00 ± 0%        ~ (p=1.000 n=6) ¹
CreateSeries-28                                989.0 ± 0%   740.0 ± 0%  -25.18% (p=0.002 n=6)
geomean                                        384.8        349.4        -9.20%
¹ all samples are equal

                                             │ before.txt │             after.txt              │
                                             │ allocs/op  │ allocs/op   vs base                │
HeadStripeSeriesCreate-28                      6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=6) ¹
HeadStripeSeriesCreateParallel-28              6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=6) ¹
HeadStripeSeriesCreate_PreCreationFailure-28   4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=6) ¹
CreateSeries-28                                3.000 ± 0%   3.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                        4.559        4.559       +0.00%
¹ all samples are equal
```