### PR TITLE
Corrects the behaviour of binary opperators between histogram and float

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -304,6 +304,7 @@ func (h *FloatHistogram) Div(scalar float64) *FloatHistogram {
 	h.ZeroCount /= scalar
 	h.Count /= scalar
 	h.Sum /= scalar
+	// Division by zero removes all buckets.
 	if scalar == 0 {
 		h.PositiveBuckets = nil
 		h.NegativeBuckets = nil

--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -304,6 +304,14 @@ func (h *FloatHistogram) Div(scalar float64) *FloatHistogram {
 	h.ZeroCount /= scalar
 	h.Count /= scalar
 	h.Sum /= scalar
+	if scalar == 0 {
+		h.PositiveBuckets = nil
+		h.NegativeBuckets = nil
+		h.PositiveSpans = nil
+		h.NegativeSpans = nil
+		h.ZeroCount = 0
+		return h
+	}
 	for i := range h.PositiveBuckets {
 		h.PositiveBuckets[i] /= scalar
 	}

--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -309,7 +309,6 @@ func (h *FloatHistogram) Div(scalar float64) *FloatHistogram {
 		h.NegativeBuckets = nil
 		h.PositiveSpans = nil
 		h.NegativeSpans = nil
-		h.ZeroCount = 0
 		return h
 	}
 	for i := range h.PositiveBuckets {

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -402,6 +402,7 @@ func TestFloatHistogramDiv(t *testing.T) {
 				ZeroThreshold: 0.01,
 				Count:         math.Inf(1),
 				Sum:           math.Inf(1),
+				ZeroCount:     math.Inf(1),
 			},
 		},
 		{

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -399,14 +399,9 @@ func TestFloatHistogramDiv(t *testing.T) {
 			},
 			0,
 			&FloatHistogram{
-				ZeroThreshold:   0.01,
-				ZeroCount:       math.Inf(1),
-				Count:           math.Inf(1),
-				Sum:             math.Inf(1),
-				PositiveSpans:   []Span{{-2, 1}, {2, 3}},
-				PositiveBuckets: []float64{math.Inf(1), math.Inf(1), math.Inf(1), math.Inf(1)},
-				NegativeSpans:   []Span{{3, 2}, {3, 2}},
-				NegativeBuckets: []float64{math.Inf(1), math.Inf(1), math.Inf(1), math.Inf(1)},
+				ZeroThreshold: 0.01,
+				Count:         math.Inf(1),
+				Sum:           math.Inf(1),
 			},
 		},
 		{

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -44,6 +44,7 @@ import (
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/annotations"

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2807,7 +2807,7 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 		if hlhs == nil && hrhs == nil {
 			return lhs + rhs, nil, true, nil
 		}
-		return 0, nil, false, annotations.NewMixedFloatsHistogramsInfo(pos)
+		return 0, nil, false, annotations.NewMixedFloatsHistogramsBinOpInfo(pos)
 	case parser.SUB:
 		if hlhs != nil && hrhs != nil {
 			res, err := hlhs.Copy().Sub(hrhs)
@@ -2819,7 +2819,7 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 		if hlhs == nil && hrhs == nil {
 			return lhs - rhs, nil, true, nil
 		}
-		return 0, nil, false, annotations.NewMixedFloatsHistogramsInfo(pos)
+		return 0, nil, false, annotations.NewMixedFloatsHistogramsBinOpInfo(pos)
 	case parser.MUL:
 		if hlhs != nil && hrhs == nil {
 			return 0, hlhs.Copy().Mul(rhs), true, nil
@@ -2828,7 +2828,7 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 			return 0, hrhs.Copy().Mul(lhs), true, nil
 		}
 		if hlhs != nil && hrhs != nil {
-			return 0, nil, false, annotations.NewMixedFloatsHistogramsInfo(pos)
+			return 0, nil, false, annotations.NewInvalidHistogramsBinOpInfo(pos)
 		}
 		return lhs * rhs, nil, true, nil
 	case parser.DIV:
@@ -2836,7 +2836,7 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 			return 0, hlhs.Copy().Div(rhs), true, nil
 		}
 		if hrhs != nil {
-			return 0, nil, false, annotations.NewMixedFloatsHistogramsInfo(pos)
+			return 0, nil, false, annotations.NewInvalidHistogramsBinOpInfo(pos)
 		}
 		return lhs / rhs, nil, true, nil
 	case parser.POW:

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2806,12 +2806,10 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 		if hlhs == nil && hrhs == nil {
 			return lhs + rhs, nil, true, nil
 		}
-		lhsTyp := "float"
-		rhsTyp := "histogram"
 		if hlhs != nil {
-			lhsTyp, rhsTyp = rhsTyp, lhsTyp
+			return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("histogram", "+", "float", pos)
 		}
-		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo(lhsTyp, "+", rhsTyp, pos)
+		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("float", "+", "histogram", pos)
 	case parser.SUB:
 		if hlhs != nil && hrhs != nil {
 			res, err := hlhs.Copy().Sub(hrhs)
@@ -2823,12 +2821,10 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 		if hlhs == nil && hrhs == nil {
 			return lhs - rhs, nil, true, nil
 		}
-		lhsTyp := "float"
-		rhsTyp := "histogram"
 		if hlhs != nil {
-			lhsTyp, rhsTyp = rhsTyp, lhsTyp
+			return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("histogram", "-", "float", pos)
 		}
-		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo(lhsTyp, "-", rhsTyp, pos)
+		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("float", "-", "histogram", pos)
 	case parser.MUL:
 		if hlhs != nil && hrhs == nil {
 			return 0, hlhs.Copy().Mul(rhs), true, nil
@@ -2845,11 +2841,10 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 			return 0, hlhs.Copy().Div(rhs), true, nil
 		}
 		if hrhs != nil {
-			lhsTyp := "float"
 			if hlhs != nil {
-				lhsTyp = "histogram"
+				return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("histogram", "/", "histogram", pos)
 			}
-			return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo(lhsTyp, "/", "histogram", pos)
+			return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("float", "/", "histogram", pos)
 		}
 		return lhs / rhs, nil, true, nil
 	case parser.POW:

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2811,7 +2811,7 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 		if hlhs != nil {
 			lhsTyp, rhsTyp = rhsTyp, lhsTyp
 		}
-		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo(lhsTyp, "+", lhsTyp, pos)
+		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo(lhsTyp, "+", rhsTyp, pos)
 	case parser.SUB:
 		if hlhs != nil && hrhs != nil {
 			res, err := hlhs.Copy().Sub(hrhs)
@@ -2828,7 +2828,7 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 		if hlhs != nil {
 			lhsTyp, rhsTyp = rhsTyp, lhsTyp
 		}
-		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("float", "-", "histogram", pos)
+		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo(lhsTyp, "-", rhsTyp, pos)
 	case parser.MUL:
 		if hlhs != nil && hrhs == nil {
 			return 0, hlhs.Copy().Mul(rhs), true, nil

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"io"
 	"math"
 	"reflect"

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2807,7 +2807,12 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 		if hlhs == nil && hrhs == nil {
 			return lhs + rhs, nil, true, nil
 		}
-		return 0, nil, false, annotations.NewMixedFloatsHistogramsBinOpInfo(pos)
+		lhsTyp := "float"
+		rhsTyp := "histogram"
+		if hlhs != nil {
+			lhsTyp, rhsTyp = rhsTyp, lhsTyp
+		}
+		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo(lhsTyp, "+", lhsTyp, pos)
 	case parser.SUB:
 		if hlhs != nil && hrhs != nil {
 			res, err := hlhs.Copy().Sub(hrhs)
@@ -2819,7 +2824,12 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 		if hlhs == nil && hrhs == nil {
 			return lhs - rhs, nil, true, nil
 		}
-		return 0, nil, false, annotations.NewMixedFloatsHistogramsBinOpInfo(pos)
+		lhsTyp := "float"
+		rhsTyp := "histogram"
+		if hlhs != nil {
+			lhsTyp, rhsTyp = rhsTyp, lhsTyp
+		}
+		return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("float", "-", "histogram", pos)
 	case parser.MUL:
 		if hlhs != nil && hrhs == nil {
 			return 0, hlhs.Copy().Mul(rhs), true, nil
@@ -2828,7 +2838,7 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 			return 0, hrhs.Copy().Mul(lhs), true, nil
 		}
 		if hlhs != nil && hrhs != nil {
-			return 0, nil, false, annotations.NewInvalidHistogramsBinOpInfo(pos)
+			return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo("histogram", "*", "histogram", pos)
 		}
 		return lhs * rhs, nil, true, nil
 	case parser.DIV:
@@ -2836,7 +2846,11 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 			return 0, hlhs.Copy().Div(rhs), true, nil
 		}
 		if hrhs != nil {
-			return 0, nil, false, annotations.NewInvalidHistogramsBinOpInfo(pos)
+			lhsTyp := "float"
+			if hlhs != nil {
+				lhsTyp = "histogram"
+			}
+			return 0, nil, false, annotations.NewIncompatibleTypesInBinOpInfo(lhsTyp, "/", "histogram", pos)
 		}
 		return lhs / rhs, nil, true, nil
 	case parser.POW:

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -957,13 +957,13 @@ eval instant at 10m histogram_mul_div/float_series_0
 eval instant at 10m histogram_mul_div*0/0
     {} {{schema:0 count:NaN sum:NaN z_bucket_w:0.001 z_bucket:NaN}}
 
-eval instant at 10m histogram_mul_div*histogram_mul_div
+eval_info instant at 10m histogram_mul_div*histogram_mul_div
 
-eval instant at 10m histogram_mul_div/histogram_mul_div
+eval_info instant at 10m histogram_mul_div/histogram_mul_div
 
-eval instant at 10m float_series_3/histogram_mul_div
+eval_info instant at 10m float_series_3/histogram_mul_div
 
-eval instant at 10m 0/histogram_mul_div
+eval_info instant at 10m 0/histogram_mul_div
 
 clear
 
@@ -974,13 +974,13 @@ load 10m
     histogram_sample {{schema:0 count:24 sum:100 z_bucket:4 z_bucket_w:0.001 buckets:[2 3 0 1 4] n_buckets:[2 3 0 1 4]}}x1
     float_sample 0x1
 
-eval instant at 10m float_sample+histogram_sample
+eval_info instant at 10m float_sample+histogram_sample
 
-eval instant at 10m histogram_sample+float_sample
+eval_info instant at 10m histogram_sample+float_sample
 
-eval instant at 10m float_sample-histogram_sample
+eval_info instant at 10m float_sample-histogram_sample
 
-eval instant at 10m histogram_sample-float_sample
+eval_info instant at 10m histogram_sample-float_sample
 
 # Counter reset only noticeable in a single bucket.
 load 5m

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -948,20 +948,27 @@ eval instant at 10m histogram_mul_div*float_series_0
 eval instant at 10m float_series_0*histogram_mul_div
     {} {{schema:0 count:0 sum:0 z_bucket:0 z_bucket_w:0.001 buckets:[0 0 0] n_buckets:[0 0 0]}}
 
-# TODO: (NeerajGartia21) remove all the histogram buckets in case of division with zero. See: https://github.com/prometheus/prometheus/issues/13934
 eval instant at 10m histogram_mul_div/0
-    {} {{schema:0 count:Inf sum:Inf z_bucket:Inf z_bucket_w:0.001 buckets:[Inf Inf Inf] n_buckets:[Inf Inf Inf]}}
+    {} {{schema:0 count:Inf sum:Inf z_bucket_w:0.001}}
 
 eval instant at 10m histogram_mul_div/float_series_0
-    {} {{schema:0 count:Inf sum:Inf z_bucket:Inf z_bucket_w:0.001 buckets:[Inf Inf Inf] n_buckets:[Inf Inf Inf]}}
+    {} {{schema:0 count:Inf sum:Inf z_bucket_w:0.001}}
 
 eval instant at 10m histogram_mul_div*0/0
-    {} {{schema:0 count:NaN sum:NaN z_bucket:NaN z_bucket_w:0.001 buckets:[NaN NaN NaN] n_buckets:[NaN NaN NaN]}}
+    {} {{schema:0 count:NaN sum:NaN z_bucket_w:0.001}}
+
+eval instant at 10m histogram_mul_div*histogram_mul_div
+
+eval instant at 10m histogram_mul_div/histogram_mul_div
+
+eval instant at 10m float_series_3/histogram_mul_div
+
+eval instant at 10m 0/histogram_mul_div
 
 clear
 
 # Apply binary operators to mixed histogram and float samples.
-# these tests will be moved to their respective locations when tests from engine_test.go will be moved here.
+# TODO:(NeerajGartia21) move these tests to their respective locations when tests from engine_test.go are be moved here.
 
 load 10m
     histogram_sample {{schema:0 count:24 sum:100 z_bucket:4 z_bucket_w:0.001 buckets:[2 3 0 1 4] n_buckets:[2 3 0 1 4]}}x1
@@ -974,15 +981,6 @@ eval instant at 10m histogram_sample+float_sample
 eval instant at 10m float_sample-histogram_sample
 
 eval instant at 10m histogram_sample-float_sample
-
-eval instant at 10m histogram_sample*histogram_sample
-
-eval instant at 10m histogram_sample/histogram_sample
-
-eval instant at 10m float_sample/histogram_sample
-
-eval instant at 10m histogram_sample/0
-     {} {{schema:0 count:Inf sum:Inf z_bucket_w:0.001}}
 
 # Counter reset only noticeable in a single bucket.
 load 5m

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -949,13 +949,13 @@ eval instant at 10m float_series_0*histogram_mul_div
     {} {{schema:0 count:0 sum:0 z_bucket:0 z_bucket_w:0.001 buckets:[0 0 0] n_buckets:[0 0 0]}}
 
 eval instant at 10m histogram_mul_div/0
-    {} {{schema:0 count:Inf sum:Inf z_bucket_w:0.001}}
+    {} {{schema:0 count:Inf sum:Inf z_bucket_w:0.001 z_bucket:Inf}}
 
 eval instant at 10m histogram_mul_div/float_series_0
-    {} {{schema:0 count:Inf sum:Inf z_bucket_w:0.001}}
+    {} {{schema:0 count:Inf sum:Inf z_bucket_w:0.001 z_bucket:Inf}}
 
 eval instant at 10m histogram_mul_div*0/0
-    {} {{schema:0 count:NaN sum:NaN z_bucket_w:0.001}}
+    {} {{schema:0 count:NaN sum:NaN z_bucket_w:0.001 z_bucket:NaN}}
 
 eval instant at 10m histogram_mul_div*histogram_mul_div
 

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -960,6 +960,30 @@ eval instant at 10m histogram_mul_div*0/0
 
 clear
 
+# Apply binary operators to mixed histogram and float samples.
+# these tests will be moved to their respective locations when tests from engine_test.go will be moved here.
+
+load 10m
+    histogram_sample {{schema:0 count:24 sum:100 z_bucket:4 z_bucket_w:0.001 buckets:[2 3 0 1 4] n_buckets:[2 3 0 1 4]}}x1
+    float_sample 0x1
+
+eval instant at 10m float_sample+histogram_sample
+
+eval instant at 10m histogram_sample+float_sample
+
+eval instant at 10m float_sample-histogram_sample
+
+eval instant at 10m histogram_sample-float_sample
+
+eval instant at 10m histogram_sample*histogram_sample
+
+eval instant at 10m histogram_sample/histogram_sample
+
+eval instant at 10m float_sample/histogram_sample
+
+eval instant at 10m histogram_sample/0
+     {} {{schema:0 count:Inf sum:Inf z_bucket_w:0.001}}
+
 # Counter reset only noticeable in a single bucket.
 load 5m
      reset_in_bucket {{schema:0 count:4 sum:5 buckets:[1 2 1]}} {{schema:0 count:5 sum:6 buckets:[1 1 3]}} {{schema:0 count:6 sum:7 buckets:[1 2 3]}}

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -146,7 +146,8 @@ var (
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
-	MixedFloatsHistogramsInfo               = fmt.Errorf("%w: encountered a mix of histograms and floats for", PromQLInfo)
+	MixedFloatsHistogramsBinOpInfo          = fmt.Errorf("%w: encountered a mix of histograms and floats for", PromQLInfo)
+	InvalidHistogramsBinOpInfo              = fmt.Errorf("%w: encountered two histograms for", PromQLInfo)
 )
 
 type annoErr struct {
@@ -275,12 +276,21 @@ func NewHistogramQuantileForcedMonotonicityInfo(metricName string, pos posrange.
 	}
 }
 
-// NewMixedFloatsHistogramsInfo is used when the queried series includes both
-// float samples and histogram samples for aggregators or operators that
-// produce unexpected results.
-func NewMixedFloatsHistogramsInfo(pos posrange.PositionRange) error {
+// NewMixedFloatsHistogramsBinOpInfo is used when binary operators
+// encounter a float on the one side and a histogram on the other side
+// for a binary operator that cannot combine a histogram and a float.
+func NewMixedFloatsHistogramsBinOpInfo(pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
-		Err:           fmt.Errorf("%w the query", MixedFloatsHistogramsInfo),
+		Err:           fmt.Errorf("%w binary operator", MixedFloatsHistogramsBinOpInfo),
+	}
+}
+
+// NewInvalidHistogramsBinOpInfo is used when binary operators encounter histograms on the both side
+// for a binary operator that cannot combine two histograms.
+func NewInvalidHistogramsBinOpInfo(pos posrange.PositionRange) error {
+	return annoErr{
+		PositionRange: pos,
+		Err:           fmt.Errorf("%w binary operator", InvalidHistogramsBinOpInfo),
 	}
 }

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -146,6 +146,7 @@ var (
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
+	MixedFloatsHistogramsInfo               = fmt.Errorf("%w: encountered a mix of histograms and floats for", PromQLInfo)
 )
 
 type annoErr struct {
@@ -271,5 +272,15 @@ func NewHistogramQuantileForcedMonotonicityInfo(metricName string, pos posrange.
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q", HistogramQuantileForcedMonotonicityInfo, metricName),
+	}
+}
+
+// NewMixedFloatsHistogramsInfo is used when the queried series includes both
+// float samples and histogram samples for aggregators or operators that
+// produce unexpected results.
+func NewMixedFloatsHistogramsInfo(pos posrange.PositionRange) error {
+	return annoErr{
+		PositionRange: pos,
+		Err:           fmt.Errorf("%w the query", MixedFloatsHistogramsInfo),
 	}
 }

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -146,8 +146,7 @@ var (
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
-	MixedFloatsHistogramsBinOpInfo          = fmt.Errorf("%w: encountered a mix of histograms and floats for", PromQLInfo)
-	InvalidHistogramsBinOpInfo              = fmt.Errorf("%w: encountered two histograms for", PromQLInfo)
+	IncompatibleTypesInBinOpInfo            = fmt.Errorf("%w: incompatible sample types encountered for binary operator", PromQLInfo)
 )
 
 type annoErr struct {
@@ -276,21 +275,11 @@ func NewHistogramQuantileForcedMonotonicityInfo(metricName string, pos posrange.
 	}
 }
 
-// NewMixedFloatsHistogramsBinOpInfo is used when binary operators
-// encounter a float on the one side and a histogram on the other side
-// for a binary operator that cannot combine a histogram and a float.
-func NewMixedFloatsHistogramsBinOpInfo(pos posrange.PositionRange) error {
+// NewIncompatibleTypesInBinOpInfo is used if binary operators act on a
+// combination of types that doesn't work and therefore returns no result.
+func NewIncompatibleTypesInBinOpInfo(lhsType, operator, rhsType string, pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
-		Err:           fmt.Errorf("%w binary operator", MixedFloatsHistogramsBinOpInfo),
-	}
-}
-
-// NewInvalidHistogramsBinOpInfo is used when binary operators encounter histograms on the both side
-// for a binary operator that cannot combine two histograms.
-func NewInvalidHistogramsBinOpInfo(pos posrange.PositionRange) error {
-	return annoErr{
-		PositionRange: pos,
-		Err:           fmt.Errorf("%w binary operator", InvalidHistogramsBinOpInfo),
+		Err:           fmt.Errorf("%w %q: %s %s %s)", IncompatibleTypesInBinOpInfo, operator, lhsType, operator, rhsType),
 	}
 }

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -280,6 +280,6 @@ func NewHistogramQuantileForcedMonotonicityInfo(metricName string, pos posrange.
 func NewIncompatibleTypesInBinOpInfo(lhsType, operator, rhsType string, pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
-		Err:           fmt.Errorf("%w %q: %s %s %s)", IncompatibleTypesInBinOpInfo, operator, lhsType, operator, rhsType),
+		Err:           fmt.Errorf("%w %q: %s %s %s", IncompatibleTypesInBinOpInfo, operator, lhsType, operator, rhsType),
 	}
 }


### PR DESCRIPTION
Issue: #13934 

This PR corrects the behaviour of some binary operators between histograms and floats.
 CC: @beorn7 

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
