### PR TITLE
fix(utf8): fix config logic for name validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -781,7 +781,9 @@ func (c *ScrapeConfig) Validate(globalConfig GlobalConfig) error {
 	default:
 		return fmt.Errorf("unknown name validation method specified, must be either 'legacy' or 'utf8', got %s", globalConfig.MetricNameValidationScheme)
 	}
-	c.MetricNameValidationScheme = globalConfig.MetricNameValidationScheme
+	if c.MetricNameValidationScheme == "" {
+		c.MetricNameValidationScheme = globalConfig.MetricNameValidationScheme
+	}
 
 	return nil
 }

--- a/config/testdata/scrape_config_default_validation_mode.yml
+++ b/config/testdata/scrape_config_default_validation_mode.yml
@@ -1,0 +1,2 @@
+scrape_configs:
+  - job_name: prometheus

--- a/config/testdata/scrape_config_global_validation_mode.yml
+++ b/config/testdata/scrape_config_global_validation_mode.yml
@@ -1,0 +1,4 @@
+global:
+  metric_name_validation_scheme: utf8
+scrape_configs:
+  - job_name: prometheus

--- a/config/testdata/scrape_config_local_global_validation_mode.yml
+++ b/config/testdata/scrape_config_local_global_validation_mode.yml
@@ -1,0 +1,5 @@
+global:
+  metric_name_validation_scheme: utf8
+scrape_configs:
+  - job_name: prometheus
+    metric_name_validation_scheme: legacy

--- a/config/testdata/scrape_config_local_validation_mode.yml
+++ b/config/testdata/scrape_config_local_validation_mode.yml
@@ -1,0 +1,3 @@
+scrape_configs:
+  - job_name: prometheus
+    metric_name_validation_scheme: utf8


### PR DESCRIPTION
We should only overwrite the ScrapeConfig if it is empty.

Added tests

part of https://github.com/prometheus/prometheus/issues/13095
