### PR TITLE
remote write: use go 1.23 unique package to reduce duplication of interned labels when multiple remote writes are used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/prometheus
 
-go 1.21.0
+go 1.23.0
 
 toolchain go1.22.5
 

--- a/storage/remote/intern_test.go
+++ b/storage/remote/intern_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
+	"unique"
 
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +31,7 @@ func TestIntern(t *testing.T) {
 	interner := newPool()
 	testString := "TestIntern"
 	interner.intern(testString)
-	interned, ok := interner.pool[testString]
+	interned, ok := interner.pool[unique.Make(testString)]
 
 	require.True(t, ok)
 	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
@@ -41,13 +42,13 @@ func TestIntern_MultiRef(t *testing.T) {
 	testString := "TestIntern_MultiRef"
 
 	interner.intern(testString)
-	interned, ok := interner.pool[testString]
+	interned, ok := interner.pool[unique.Make(testString)]
 
 	require.True(t, ok)
 	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
 
 	interner.intern(testString)
-	interned, ok = interner.pool[testString]
+	interned, ok = interner.pool[unique.Make(testString)]
 
 	require.True(t, ok)
 	require.Equal(t, int64(2), interned.refs.Load(), fmt.Sprintf("expected refs to be 2 but it was %d", interned.refs.Load()))
@@ -58,13 +59,13 @@ func TestIntern_DeleteRef(t *testing.T) {
 	testString := "TestIntern_DeleteRef"
 
 	interner.intern(testString)
-	interned, ok := interner.pool[testString]
+	interned, ok := interner.pool[unique.Make(testString)]
 
 	require.True(t, ok)
 	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
 
 	interner.release(testString)
-	_, ok = interner.pool[testString]
+	_, ok = interner.pool[unique.Make(testString)]
 	require.False(t, ok)
 }
 
@@ -73,7 +74,7 @@ func TestIntern_MultiRef_Concurrent(t *testing.T) {
 	testString := "TestIntern_MultiRef_Concurrent"
 
 	interner.intern(testString)
-	interned, ok := interner.pool[testString]
+	interned, ok := interner.pool[unique.Make(testString)]
 	require.True(t, ok)
 	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
 
@@ -84,7 +85,7 @@ func TestIntern_MultiRef_Concurrent(t *testing.T) {
 	time.Sleep(time.Millisecond)
 
 	interner.mtx.RLock()
-	interned, ok = interner.pool[testString]
+	interned, ok = interner.pool[unique.Make(testString)]
 	interner.mtx.RUnlock()
 	require.True(t, ok)
 	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))


### PR DESCRIPTION
I was curious as to whether the new `unique` package in go 1.23 could help us anywhere. I knew the Grafana agent/alloy team had investigated having a single interning map across all configured remote writes, but that also increase the complexity of managing which interned strings should still be present, and which should be removed because of compaction/truncation of the WAL.

The `unique` package allows us to have a single backing interning structure from the `unique` package, and then each remote write's interning map is only containing the `unique.Handle`s along with the ref counter for whether that remote write is still using said `unique.Handle`. The map within remote write keeps the references to said handles, which in turn keeps the `unique` package from garbage collecting them until we no longer have any references across all remote writes.

Additionally, these changes could have knock on effects for projects that reuse the remote write code. For example, loki's ruler component runs a remote write per tenant who has rules configured.

Some benchmarks:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/storage/remote
cpu: AMD Ryzen 9 5950X 16-Core Processor
                                                   │     base     │                handle                 │
                                                   │    sec/op    │    sec/op      vs base                │
SampleSend-32                                        3.938m ± ∞ ¹    3.395m ± ∞ ¹   -13.78% (p=0.008 n=5)
StoreSeries/plain-32                                 830.0µ ± ∞ ¹   1788.6µ ± ∞ ¹  +115.50% (p=0.008 n=5)
StoreSeries/externalLabels-32                        1.611m ± ∞ ¹    2.769m ± ∞ ¹   +71.90% (p=0.008 n=5)
StoreSeries/relabel-32                               1.377m ± ∞ ¹    2.332m ± ∞ ¹   +69.37% (p=0.008 n=5)
StoreSeries/externalLabels+relabel-32                1.930m ± ∞ ¹    3.010m ± ∞ ¹   +56.00% (p=0.008 n=5)
StoreSeries_TwoEndpoints/plain-32                    1.652m ± ∞ ¹    3.554m ± ∞ ¹  +115.11% (p=0.008 n=5)
StoreSeries_TwoEndpoints/externalLabels-32           3.159m ± ∞ ¹    5.523m ± ∞ ¹   +74.80% (p=0.008 n=5)
StoreSeries_TwoEndpoints/relabel-32                  2.681m ± ∞ ¹    4.617m ± ∞ ¹   +72.23% (p=0.008 n=5)
StoreSeries_TwoEndpoints/externalLabels+relabel-32   4.062m ± ∞ ¹    5.964m ± ∞ ¹   +46.84% (p=0.008 n=5)
BuildWriteRequest/2_instances-32                     19.42µ ± ∞ ¹    18.42µ ± ∞ ¹    -5.16% (p=0.008 n=5)
BuildWriteRequest/10_instances-32                    90.11µ ± ∞ ¹    88.46µ ± ∞ ¹         ~ (p=0.421 n=5)
BuildWriteRequest/1k_instances-32                    912.8µ ± ∞ ¹    894.8µ ± ∞ ¹         ~ (p=0.095 n=5)
geomean                                              1.020m          1.459m         +43.02%
¹ need >= 6 samples for confidence interval at level 0.95

                                                   │      base      │                 handle                 │
                                                   │      B/op      │     B/op       vs base                 │
SampleSend-32                                         762.2Ki ± ∞ ¹   671.8Ki ± ∞ ¹        ~ (p=0.056 n=5)
StoreSeries/plain-32                                  415.1Ki ± ∞ ¹   365.8Ki ± ∞ ¹  -11.89% (p=0.008 n=5)
StoreSeries/externalLabels-32                        1040.9Ki ± ∞ ¹   997.4Ki ± ∞ ¹   -4.19% (p=0.008 n=5)
StoreSeries/relabel-32                                916.7Ki ± ∞ ¹   871.6Ki ± ∞ ¹   -4.93% (p=0.008 n=5)
StoreSeries/externalLabels+relabel-32                1010.8Ki ± ∞ ¹   966.7Ki ± ∞ ¹   -4.36% (p=0.008 n=5)
StoreSeries_TwoEndpoints/plain-32                     809.9Ki ± ∞ ¹   712.4Ki ± ∞ ¹  -12.04% (p=0.008 n=5)
StoreSeries_TwoEndpoints/externalLabels-32            2.013Mi ± ∞ ¹   1.928Mi ± ∞ ¹   -4.23% (p=0.008 n=5)
StoreSeries_TwoEndpoints/relabel-32                   1.770Mi ± ∞ ¹   1.682Mi ± ∞ ¹   -4.99% (p=0.008 n=5)
StoreSeries_TwoEndpoints/externalLabels+relabel-32    1.954Mi ± ∞ ¹   1.869Mi ± ∞ ¹   -4.36% (p=0.008 n=5)
BuildWriteRequest/2_instances-32                        80.00 ± ∞ ¹     80.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
BuildWriteRequest/10_instances-32                       80.00 ± ∞ ¹     80.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
BuildWriteRequest/1k_instances-32                       80.00 ± ∞ ¹     80.00 ± ∞ ¹        ~ (p=1.000 n=5) ²
geomean                                               98.95Ki         93.67Ki         -5.34%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

                                                   │     base     │                handle                 │
                                                   │  allocs/op   │  allocs/op    vs base                 │
SampleSend-32                                        1042.0 ± ∞ ¹    920.0 ± ∞ ¹  -11.71% (p=0.048 n=5)
StoreSeries/plain-32                                 1.666k ± ∞ ¹   1.780k ± ∞ ¹   +6.84% (p=0.008 n=5)
StoreSeries/externalLabels-32                        2.670k ± ∞ ¹   3.054k ± ∞ ¹  +14.38% (p=0.008 n=5)
StoreSeries/relabel-32                               5.665k ± ∞ ¹   5.979k ± ∞ ¹   +5.54% (p=0.008 n=5)
StoreSeries/externalLabels+relabel-32                5.670k ± ∞ ¹   6.041k ± ∞ ¹   +6.54% (p=0.008 n=5)
StoreSeries_TwoEndpoints/plain-32                    2.870k ± ∞ ¹   3.156k ± ∞ ¹   +9.97% (p=0.008 n=5)
StoreSeries_TwoEndpoints/externalLabels-32           4.879k ± ∞ ¹   5.649k ± ∞ ¹  +15.78% (p=0.008 n=5)
StoreSeries_TwoEndpoints/relabel-32                  10.87k ± ∞ ¹   11.49k ± ∞ ¹   +5.71% (p=0.008 n=5)
StoreSeries_TwoEndpoints/externalLabels+relabel-32   10.88k ± ∞ ¹   11.63k ± ∞ ¹   +6.97% (p=0.008 n=5)
BuildWriteRequest/2_instances-32                      1.000 ± ∞ ¹    1.000 ± ∞ ¹        ~ (p=1.000 n=5) ²
BuildWriteRequest/10_instances-32                     1.000 ± ∞ ¹    1.000 ± ∞ ¹        ~ (p=1.000 n=5) ²
BuildWriteRequest/1k_instances-32                     1.000 ± ∞ ¹    1.000 ± ∞ ¹        ~ (p=1.000 n=5) ²
geomean                                               500.4          524.2         +4.76%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

                                  │       base        │                  handle                   │
                                  │ compressedSize/op │ compressedSize/op  vs base                │
BuildWriteRequest/2_instances-32         1.933k ± ∞ ¹        1.933k ± ∞ ¹       ~ (p=1.000 n=5) ²
BuildWriteRequest/10_instances-32        8.156k ± ∞ ¹        8.156k ± ∞ ¹       ~ (p=1.000 n=5) ²
BuildWriteRequest/1k_instances-32        78.22k ± ∞ ¹        78.22k ± ∞ ¹       ~ (p=1.000 n=5) ²
geomean                                  10.72k              10.72k        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
```

At first glance I was concerned about the CPU increase, but when we run two prometheus instances, each of which are scaping themselves + avalanche with 100 metrics, and remote writing the data two endpoints, the resource usage looks fine.
![2024-08-26-172423_2054x910_scrot](https://github.com/user-attachments/assets/a7e69551-ffde-4632-91a8-33bc53e098d8)

