### PR TITLE
Keep track of what series have new head chunks to avoid iterating over all timeseries every minute to mmap new chunks

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1057,49 +1057,67 @@ func (db *DB) Dir() string {
 
 func (db *DB) run(ctx context.Context) {
 	defer close(db.donec)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 
-	backoff := time.Duration(0)
-
-	for {
-		select {
-		case <-db.stopc:
-			return
-		case <-time.After(backoff):
-		}
-
-		select {
-		case <-time.After(1 * time.Minute):
-			db.cmtx.Lock()
-			if err := db.reloadBlocks(); err != nil {
-				level.Error(db.logger).Log("msg", "reloadBlocks", "err", err)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-db.stopc:
+				return
+			case <-time.After(1 * time.Minute):
+				// We attempt mmapping of head chunks regularly.
+				db.head.mmapHeadChunks()
 			}
-			db.cmtx.Unlock()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		backoff := time.Duration(0)
+		for {
+			select {
+			case <-db.stopc:
+				return
+			case <-time.After(backoff):
+			}
 
 			select {
-			case db.compactc <- struct{}{}:
-			default:
-			}
-			// We attempt mmapping of head chunks regularly.
-			db.head.mmapHeadChunks()
-		case <-db.compactc:
-			db.metrics.compactionsTriggered.Inc()
-
-			db.autoCompactMtx.Lock()
-			if db.autoCompact {
-				if err := db.Compact(ctx); err != nil {
-					level.Error(db.logger).Log("msg", "compaction failed", "err", err)
-					backoff = exponential(backoff, 1*time.Second, 1*time.Minute)
-				} else {
-					backoff = 0
+			case <-time.After(1 * time.Minute):
+				db.cmtx.Lock()
+				if err := db.reloadBlocks(); err != nil {
+					level.Error(db.logger).Log("msg", "reloadBlocks", "err", err)
 				}
-			} else {
-				db.metrics.compactionsSkipped.Inc()
+				db.cmtx.Unlock()
+
+				select {
+				case db.compactc <- struct{}{}:
+				default:
+				}
+			case <-db.compactc:
+				db.metrics.compactionsTriggered.Inc()
+
+				db.autoCompactMtx.Lock()
+				if db.autoCompact {
+					if err := db.Compact(ctx); err != nil {
+						level.Error(db.logger).Log("msg", "compaction failed", "err", err)
+						backoff = exponential(backoff, 1*time.Second, 1*time.Minute)
+					} else {
+						backoff = 0
+					}
+				} else {
+					db.metrics.compactionsSkipped.Inc()
+				}
+				db.autoCompactMtx.Unlock()
+			case <-db.stopc:
+				return
 			}
-			db.autoCompactMtx.Unlock()
-		case <-db.stopc:
-			return
 		}
-	}
+	}()
+
+	wg.Wait()
 }
 
 // Appender opens a new appender against the database.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1765,7 +1765,7 @@ func (h *Head) mmapHeadChunks() {
 	}
 	h.metrics.mmapChunksTotal.Add(float64(count))
 	h.seriesForMMapLock.Lock()
-	h.seriesForMMap = append(h.seriesForMMap[:0], h.seriesForMMap[len(h.seriesForMMap):]...)
+	h.seriesForMMap = append(h.seriesForMMap[:0], h.seriesForMMap[len(series):]...)
 	h.seriesForMMapLock.Unlock()
 }
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -996,6 +996,9 @@ func (a *headAppender) Commit() (err error) {
 		if chunkCreated {
 			a.head.metrics.chunks.Inc()
 			a.head.metrics.chunksCreated.Inc()
+			a.head.seriesForMMapLock.Lock()
+			a.head.seriesForMMap = append(a.head.seriesForMMap, series)
+			a.head.seriesForMMapLock.Unlock()
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1025,6 +1028,9 @@ func (a *headAppender) Commit() (err error) {
 		if chunkCreated {
 			a.head.metrics.chunks.Inc()
 			a.head.metrics.chunksCreated.Inc()
+			a.head.seriesForMMapLock.Lock()
+			a.head.seriesForMMap = append(a.head.seriesForMMap, series)
+			a.head.seriesForMMapLock.Unlock()
 		}
 	}
 
@@ -1050,6 +1056,9 @@ func (a *headAppender) Commit() (err error) {
 		if chunkCreated {
 			a.head.metrics.chunks.Inc()
 			a.head.metrics.chunksCreated.Inc()
+			a.head.seriesForMMapLock.Lock()
+			a.head.seriesForMMap = append(a.head.seriesForMMap, series)
+			a.head.seriesForMMapLock.Unlock()
 		}
 	}
 

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -629,6 +629,9 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()
+				h.seriesForMMapLock.Lock()
+				h.seriesForMMap = append(h.seriesForMMap, ms)
+				h.seriesForMMapLock.Unlock()
 			}
 			if s.t > maxt {
 				maxt = s.t
@@ -894,6 +897,9 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (unknownRefs uint64) {
 			if chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()
+				h.seriesForMMapLock.Lock()
+				h.seriesForMMap = append(h.seriesForMMap, ms)
+				h.seriesForMMapLock.Unlock()
 			}
 			if ok {
 				if s.T < mint {


### PR DESCRIPTION
This is another approach for https://github.com/prometheus/prometheus/pull/14610

We still can mmap chunks during head compaction but also now we keep track of the series with new chunks in order to avoid extra locks on the stripped series and also avoid iterating over all series every minute.