### PR TITLE
Bring back BenchmarkLoadRealWLs

### DIFF
--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -441,21 +441,10 @@ func BenchmarkLoadWLs(b *testing.B) {
 
 // BenchmarkLoadRealWLs will be skipped unless the BENCHMARK_LOAD_REAL_WLS_DIR environment variable is set.
 // BENCHMARK_LOAD_REAL_WLS_DIR should be the folder where `wal` and `chunks_head` are located.
-// Optionally, BENCHMARK_LOAD_REAL_WLS_PROFILE can be set to a file path to write a CPU profile.
 func BenchmarkLoadRealWLs(b *testing.B) {
 	dir := os.Getenv("BENCHMARK_LOAD_REAL_WLS_DIR")
 	if dir == "" {
 		b.Skipped()
-	}
-
-	profileFile := os.Getenv("BENCHMARK_LOAD_REAL_WLS_PROFILE")
-	if profileFile != "" {
-		b.Logf("Will profile in %s", profileFile)
-		f, err := os.Create(profileFile)
-		require.NoError(b, err)
-		b.Cleanup(func() { f.Close() })
-		require.NoError(b, pprof.StartCPUProfile(f))
-		b.Cleanup(pprof.StopCPUProfile)
 	}
 
 	wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), wlog.CompressionNone)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -23,7 +23,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"runtime/pprof"
 	"sort"
 	"strconv"
 	"strings"

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"runtime/pprof"
 	"sort"
 	"strconv"
 	"strings"
@@ -435,6 +436,43 @@ func BenchmarkLoadWLs(b *testing.B) {
 					}
 				})
 		}
+	}
+}
+
+// BenchmarkLoadRealWLs will be skipped unless the BENCHMARK_LOAD_REAL_WLS_DIR environment variable is set.
+// BENCHMARK_LOAD_REAL_WLS_DIR should be the folder where `wal` and `chunks_head` are located.
+// Optionally, BENCHMARK_LOAD_REAL_WLS_PROFILE can be set to a file path to write a CPU profile.
+func BenchmarkLoadRealWLs(b *testing.B) {
+	dir := os.Getenv("BENCHMARK_LOAD_REAL_WLS_DIR")
+	if dir == "" {
+		b.Skipped()
+	}
+
+	profileFile := os.Getenv("BENCHMARK_LOAD_REAL_WLS_PROFILE")
+	if profileFile != "" {
+		b.Logf("Will profile in %s", profileFile)
+		f, err := os.Create(profileFile)
+		require.NoError(b, err)
+		b.Cleanup(func() { f.Close() })
+		require.NoError(b, pprof.StartCPUProfile(f))
+		b.Cleanup(pprof.StopCPUProfile)
+	}
+
+	wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), wlog.CompressionNone)
+	require.NoError(b, err)
+	b.Cleanup(func() { wal.Close() })
+
+	wbl, err := wlog.New(nil, nil, filepath.Join(dir, "wbl"), wlog.CompressionNone)
+	require.NoError(b, err)
+	b.Cleanup(func() { wbl.Close() })
+
+	// Load the WAL.
+	for i := 0; i < b.N; i++ {
+		opts := DefaultHeadOptions()
+		opts.ChunkDirRoot = dir
+		h, err := NewHead(nil, nil, wal, wbl, opts, nil)
+		require.NoError(b, err)
+		require.NoError(b, h.Init(0))
 	}
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -443,7 +443,7 @@ func BenchmarkLoadWLs(b *testing.B) {
 func BenchmarkLoadRealWLs(b *testing.B) {
 	dir := os.Getenv("BENCHMARK_LOAD_REAL_WLS_DIR")
 	if dir == "" {
-		b.Skipped()
+		b.SkipNow()
 	}
 
 	wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), wlog.CompressionNone)


### PR DESCRIPTION
This was part of #14525 which was reverted.
I still think that having this benchmark committed in to the repo is useful.