### PR TITLE
Fix: Broken URL for Querying Prometheus

### DIFF
--- a/docs/querying/basics.md
+++ b/docs/querying/basics.md
@@ -41,7 +41,7 @@ vector is the only type which can be graphed.
 _Notes about the experimental native histograms:_
 
 * Ingesting native histograms has to be enabled via a [feature
-  flag](../../feature_flags.md#native-histograms).
+  flag](../feature_flags.md#native-histograms).
 * Once native histograms have been ingested into the TSDB (and even after
   disabling the feature flag again), both instant vectors and range vectors may
   now contain samples that aren't simple floating point numbers (float samples)


### PR DESCRIPTION
Fix the broken URL for feature flags native histograms in `Querying Prometheus` documentation.

# Issue
Whenever a user clicks on a link that is supposed to redirect them to the `Native Histograms` section of `Feature Flags`, it results in a 404 error page.

![image](https://github.com/user-attachments/assets/a6bb01d6-499b-4a3f-9929-eb3adf21cf4b)

# Solution
The current redirection link in the `docs/querying/basics.md` documentation appears to be broken. I've fixed it, and it now works as expected.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
