### PR TITLE
fix bug with metadata for rw2

### DIFF
--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -603,7 +603,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			}
 
 		case record.Metadata:
-			if !w.sendMetadata || !tail {
+			if !w.sendMetadata {
 				break
 			}
 			meta, err := dec.Metadata(rec, metadata[:0])


### PR DESCRIPTION
This fixes a bug for RW2.0 that @tonyli233 first ran into during his GSOC project, we only noticed because with the removal of gogoproto then repeated fields in protobuf now contain pointers. The receiver then tried to decode nil pointers.

The bug is that we don't read and send metadata records from the WAL to remote write during WAL replay.