### PR TITLE
[Comment] Correct the comment on Decbuf.UvarintBytes

### DIFF
--- a/tsdb/encoding/encoding.go
+++ b/tsdb/encoding/encoding.go
@@ -201,8 +201,9 @@ func (d *Decbuf) UvarintStr() string {
 	return string(d.UvarintBytes())
 }
 
-// UvarintBytes returns invalid values if the byte slice goes away.
-// Compared to UvarintStr, it avoid allocations.
+// UvarintBytes returns a pointer to internal data;
+// the return value becomes invalid if the byte slice goes away.
+// Compared to UvarintStr, this avoids allocations.
 func (d *Decbuf) UvarintBytes() []byte {
 	l := d.Uvarint64()
 	if d.E != nil {


### PR DESCRIPTION
The value is valid when returned, but can become invalid later.

Return to previous wording.
