### PR TITLE
GitHub: Add citation file to enable "Cite this repository" feature

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-title: "Prometheus"
+title: "Prometheus: A Next-Generation Monitoring System"
 message: "If you use this software, please cite it as below."
 authors:
   - family-names: Rabenstein

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,8 @@
+cff-version: 1.2.0
+title: "Prometheus"
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: Rabenstein
+    given-names: Björn
+  - family-names: Volz
+    given-names: Julius


### PR DESCRIPTION
Recently I wanted to cite Prometheus for an academic work. Doing some online searching I found https://www.usenix.org/conference/srecon15europe/program/presentation/rabenstein which is what I plan to cite (unless you have a better recommendation!).

GitHub is able to show a "Cite this repository" if a citation file is added to the root of the repository as described in https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files. Personally I find this feature quite useful as it eliminates any confusion when searching for a citation for a piece of software.

I thought I might make this PR to add a citation file based on the Prometheus talk mentioned above in case you find this appropiate. Since this PR comes from a fork and you cannot push to this branch, I am happy to do any modifications to the citation file, such as adding additional authors, etc.

Cheers!