### PR TITLE
[BUGFIX] Protobuf scraping: reset exemplar position

### DIFF
--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -409,6 +409,7 @@ func (p *ProtobufParser) Next() (Entry, error) {
 	switch p.state {
 	case EntryInvalid:
 		p.metricPos = 0
+		p.exemplarPos = 0
 		p.fieldPos = -2
 		n, err := readDelimited(p.in[p.inPos:], p.mf)
 		p.inPos += n
@@ -485,6 +486,7 @@ func (p *ProtobufParser) Next() (Entry, error) {
 			p.metricPos++
 			p.fieldPos = -2
 			p.fieldsDone = false
+			p.exemplarPos = 0
 			// If this is a metric family containing native
 			// histograms, we have to switch back to native
 			// histograms after parsing a classic histogram.

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -696,6 +696,70 @@ metric: <
 >
 
 `,
+
+		`name: "test_histogram_with_native_histogram_exemplars2"
+help: "Another histogram with native histogram exemplars."
+type: HISTOGRAM
+metric: <
+  histogram: <
+    sample_count: 175
+    sample_sum: 0.0008280461746287094
+    bucket: <
+      cumulative_count: 2
+      upper_bound: -0.0004899999999999998
+    >
+    bucket: <
+      cumulative_count: 4
+      upper_bound: -0.0003899999999999998
+    >
+    bucket: <
+      cumulative_count: 16
+      upper_bound: -0.0002899999999999998
+    >
+    schema: 3
+    zero_threshold: 2.938735877055719e-39
+    zero_count: 2
+    negative_span: <
+      offset: -162
+      length: 1
+    >
+    negative_span: <
+      offset: 23
+      length: 4
+    >
+    negative_delta: 1
+    negative_delta: 3
+    negative_delta: -2
+    negative_delta: -1
+    negative_delta: 1
+    positive_span: <
+      offset: -161
+      length: 1
+    >
+    positive_span: <
+      offset: 8
+      length: 3
+    >
+    positive_delta: 1
+    positive_delta: 2
+    positive_delta: -1
+    positive_delta: -1
+    exemplars: <
+      label: <
+        name: "dummyID"
+        value: "59780"
+      >
+      value: -0.00039
+      timestamp: <
+        seconds: 1625851155
+        nanos: 146848499
+      >
+    >
+  >
+  timestamp_ms: 1234568
+>
+
+`,
 	}
 
 	varintBuf := make([]byte, binary.MaxVarintLen32)
@@ -1274,6 +1338,41 @@ func TestProtobufParse(t *testing.T) {
 					e: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59780"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 						{Labels: labels.FromStrings("dummyID", "59772"), Value: -0.00052, HasTs: true, Ts: 1625851160156},
+					},
+				},
+				{
+					m:    "test_histogram_with_native_histogram_exemplars2",
+					help: "Another histogram with native histogram exemplars.",
+				},
+				{
+					m:   "test_histogram_with_native_histogram_exemplars2",
+					typ: model.MetricTypeHistogram,
+				},
+				{
+					m: "test_histogram_with_native_histogram_exemplars2",
+					t: 1234568,
+					shs: &histogram.Histogram{
+						Count:         175,
+						ZeroCount:     2,
+						Sum:           0.0008280461746287094,
+						ZeroThreshold: 2.938735877055719e-39,
+						Schema:        3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []int64{1, 2, -1, -1},
+						NegativeBuckets: []int64{1, 3, -2, -1, 1},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars2",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59780"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
 			},
@@ -2185,6 +2284,93 @@ func TestProtobufParse(t *testing.T) {
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars_bucket",
+						"le", "+Inf",
+					),
+				},
+				{ // 106
+					m:    "test_histogram_with_native_histogram_exemplars2",
+					help: "Another histogram with native histogram exemplars.",
+				},
+				{ // 107
+					m:   "test_histogram_with_native_histogram_exemplars2",
+					typ: model.MetricTypeHistogram,
+				},
+				{ // 108
+					m: "test_histogram_with_native_histogram_exemplars2",
+					t: 1234568,
+					shs: &histogram.Histogram{
+						Count:         175,
+						ZeroCount:     2,
+						Sum:           0.0008280461746287094,
+						ZeroThreshold: 2.938735877055719e-39,
+						Schema:        3,
+						PositiveSpans: []histogram.Span{
+							{Offset: -161, Length: 1},
+							{Offset: 8, Length: 3},
+						},
+						NegativeSpans: []histogram.Span{
+							{Offset: -162, Length: 1},
+							{Offset: 23, Length: 4},
+						},
+						PositiveBuckets: []int64{1, 2, -1, -1},
+						NegativeBuckets: []int64{1, 3, -2, -1, 1},
+					},
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars2",
+					),
+					e: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59780"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
+					},
+				},
+				{ // 109
+					m: "test_histogram_with_native_histogram_exemplars2_count",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars2_count",
+					),
+				},
+				{ // 110
+					m: "test_histogram_with_native_histogram_exemplars2_sum",
+					t: 1234568,
+					v: 0.0008280461746287094,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars2_sum",
+					),
+				},
+				{ // 111
+					m: "test_histogram_with_native_histogram_exemplars2_bucket\xffle\xff-0.0004899999999999998",
+					t: 1234568,
+					v: 2,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars2_bucket",
+						"le", "-0.0004899999999999998",
+					),
+				},
+				{ // 112
+					m: "test_histogram_with_native_histogram_exemplars2_bucket\xffle\xff-0.0003899999999999998",
+					t: 1234568,
+					v: 4,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars2_bucket",
+						"le", "-0.0003899999999999998",
+					),
+				},
+				{ // 113
+					m: "test_histogram_with_native_histogram_exemplars2_bucket\xffle\xff-0.0002899999999999998",
+					t: 1234568,
+					v: 16,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars2_bucket",
+						"le", "-0.0002899999999999998",
+					),
+				},
+				{ // 114
+					m: "test_histogram_with_native_histogram_exemplars2_bucket\xffle\xff+Inf",
+					t: 1234568,
+					v: 175,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram_with_native_histogram_exemplars2_bucket",
 						"le", "+Inf",
 					),
 				},

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -1995,15 +1995,15 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "without_quantiles_sum",
 					),
 				},
-				{ // 78
+				{ // 81
 					m:    "empty_histogram",
 					help: "A histogram without observations and with a zero threshold of zero but with a no-op span to identify it as a native histogram.",
 				},
-				{ // 79
+				{ // 82
 					m:   "empty_histogram",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 80
+				{ // 83
 					m: "empty_histogram",
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.UnknownCounterReset,
@@ -2014,15 +2014,15 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "empty_histogram",
 					),
 				},
-				{ // 81
+				{ // 84
 					m:    "test_counter_with_createdtimestamp",
 					help: "A counter with a created timestamp.",
 				},
-				{ // 82
+				{ // 85
 					m:   "test_counter_with_createdtimestamp",
 					typ: model.MetricTypeCounter,
 				},
-				{ // 83
+				{ // 86
 					m:  "test_counter_with_createdtimestamp",
 					v:  42,
 					ct: 1000,
@@ -2030,15 +2030,15 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_counter_with_createdtimestamp",
 					),
 				},
-				{ // 84
+				{ // 87
 					m:    "test_summary_with_createdtimestamp",
 					help: "A summary with a created timestamp.",
 				},
-				{ // 85
+				{ // 88
 					m:   "test_summary_with_createdtimestamp",
 					typ: model.MetricTypeSummary,
 				},
-				{ // 86
+				{ // 89
 					m:  "test_summary_with_createdtimestamp_count",
 					v:  42,
 					ct: 1000,
@@ -2046,7 +2046,7 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_summary_with_createdtimestamp_count",
 					),
 				},
-				{ // 87
+				{ // 90
 					m:  "test_summary_with_createdtimestamp_sum",
 					v:  1.234,
 					ct: 1000,
@@ -2054,15 +2054,15 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_summary_with_createdtimestamp_sum",
 					),
 				},
-				{ // 88
+				{ // 91
 					m:    "test_histogram_with_createdtimestamp",
 					help: "A histogram with a created timestamp.",
 				},
-				{ // 89
+				{ // 92
 					m:   "test_histogram_with_createdtimestamp",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 90
+				{ // 93
 					m:  "test_histogram_with_createdtimestamp",
 					ct: 1000,
 					shs: &histogram.Histogram{
@@ -2074,15 +2074,15 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_histogram_with_createdtimestamp",
 					),
 				},
-				{ // 91
+				{ // 94
 					m:    "test_gaugehistogram_with_createdtimestamp",
 					help: "A gauge histogram with a created timestamp.",
 				},
-				{ // 92
+				{ // 95
 					m:   "test_gaugehistogram_with_createdtimestamp",
 					typ: model.MetricTypeGaugeHistogram,
 				},
-				{ // 93
+				{ // 96
 					m:  "test_gaugehistogram_with_createdtimestamp",
 					ct: 1000,
 					shs: &histogram.Histogram{
@@ -2094,15 +2094,15 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_gaugehistogram_with_createdtimestamp",
 					),
 				},
-				{ // 94
+				{ // 97
 					m:    "test_histogram_with_native_histogram_exemplars",
 					help: "A histogram with native histogram exemplars.",
 				},
-				{ // 95
+				{ // 98
 					m:   "test_histogram_with_native_histogram_exemplars",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 96
+				{ // 99
 					m: "test_histogram_with_native_histogram_exemplars",
 					t: 1234568,
 					shs: &histogram.Histogram{
@@ -2130,7 +2130,7 @@ func TestProtobufParse(t *testing.T) {
 						{Labels: labels.FromStrings("dummyID", "59772"), Value: -0.00052, HasTs: true, Ts: 1625851160156},
 					},
 				},
-				{ // 97
+				{ // 100
 					m: "test_histogram_with_native_histogram_exemplars_count",
 					t: 1234568,
 					v: 175,
@@ -2138,7 +2138,7 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_histogram_with_native_histogram_exemplars_count",
 					),
 				},
-				{ // 98
+				{ // 101
 					m: "test_histogram_with_native_histogram_exemplars_sum",
 					t: 1234568,
 					v: 0.0008280461746287094,
@@ -2146,7 +2146,7 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_histogram_with_native_histogram_exemplars_sum",
 					),
 				},
-				{ // 99
+				{ // 102
 					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff-0.0004899999999999998",
 					t: 1234568,
 					v: 2,
@@ -2155,7 +2155,7 @@ func TestProtobufParse(t *testing.T) {
 						"le", "-0.0004899999999999998",
 					),
 				},
-				{ // 100
+				{ // 103
 					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff-0.0003899999999999998",
 					t: 1234568,
 					v: 4,
@@ -2167,7 +2167,7 @@ func TestProtobufParse(t *testing.T) {
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
-				{ // 101
+				{ // 104
 					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff-0.0002899999999999998",
 					t: 1234568,
 					v: 16,
@@ -2179,7 +2179,7 @@ func TestProtobufParse(t *testing.T) {
 						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
-				{ // 102
+				{ // 105
 					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff+Inf",
 					t: 1234568,
 					v: 175,


### PR DESCRIPTION
`exemplarPos` needs to be reset to zero when we move on to the next histogram.
Extend tests to have a case with two histograms.

Also fix commented test case numbers which were not monotonic.
