### PR TITLE
tsdb documentation: More details about Chunks

### DIFF
--- a/tsdb/docs/format/chunks.md
+++ b/tsdb/docs/format/chunks.md
@@ -29,15 +29,16 @@ in-file offset (lower 4 bytes) and segment sequence number (upper 4 bytes).
 # Chunk
 
 ```
-┌───────────────┬───────────────────┬──────────────┬────────────────┐
-│ len <uvarint> │ encoding <1 byte> │ data <bytes> │ CRC32 <4 byte> │
-└───────────────┴───────────────────┴──────────────┴────────────────┘
+┌───────────────┬───────────────────┬──────────────┬─────────────────┐
+│ len <uvarint> │ encoding <1 byte> │ data <bytes> │ CRC32C <4 byte> │
+└───────────────┴───────────────────┴──────────────┴─────────────────┘
 ```
 
 Notes:
-* `<uvarint>` has 1 to 10 bytes.
-* `encoding`: Currently either `XOR` or `histogram`.
+* `<uvarint>` has 1 to 10 bytes, from [`encoding/binary`](https://go.dev/src/encoding/binary/varint.go).
+* `encoding`: Currently either `XOR` (1), `histogram` (2), or `float histogram` (3).
 * `data`: See below for each encoding.
+* `CRC32C`: CRC32 Castagnoli of `encoding` and `data`, serialised as an unsigned 32 bits big endian.
 
 ## XOR chunk data
 


### PR DESCRIPTION
Hi,

I'm implementing a parser and I thought I could add more details to the documentation:

 - I added a documentation link about the `uvarint` variable length encoding.
 - The type enum is a byte that is 0000 0001 (XOR), 0000 0002 (Histogram), or 0000 0003 (Float Histogram).
 - The CRC32 is actually a CRC32C (Castagnoli) and uses the type byte too.
 - The CRC32C is serialised using a big endian binary representation.