### PR TITLE
BUGFIX: TSDB: panic in query during truncation with OOO head

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2061,7 +2061,7 @@ func (db *DB) Querier(mint, maxt int64) (_ storage.Querier, err error) {
 			}
 			headQuerier = nil
 		}
-		if getNew {
+		if getNew || overlapsOOO{
 			rh := NewRangeHead(db.head, newMint, maxt)
 			headQuerier, err = db.blockQuerierFunc(rh, newMint, maxt)
 			if err != nil {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2070,7 +2070,7 @@ func (db *DB) Querier(mint, maxt int64) (_ storage.Querier, err error) {
 		}
 	}
 
-	if overlapsOOO && headQuerier != nil {
+	if overlapsOOO {
 		// We need to fetch from in-order and out-of-order chunks: wrap the headQuerier.
 		isoState := db.head.oooIso.TrackReadAfter(db.lastGarbageCollectedMmapRef)
 		headQuerier = NewHeadAndOOOQuerier(mint, maxt, db.head, isoState, headQuerier)

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2061,7 +2061,7 @@ func (db *DB) Querier(mint, maxt int64) (_ storage.Querier, err error) {
 			}
 			headQuerier = nil
 		}
-		if getNew || overlapsOOO{
+		if getNew {
 			rh := NewRangeHead(db.head, newMint, maxt)
 			headQuerier, err = db.blockQuerierFunc(rh, newMint, maxt)
 			if err != nil {
@@ -2070,7 +2070,7 @@ func (db *DB) Querier(mint, maxt int64) (_ storage.Querier, err error) {
 		}
 	}
 
-	if overlapsOOO {
+	if overlapsOOO && headQuerier != nil {
 		// We need to fetch from in-order and out-of-order chunks: wrap the headQuerier.
 		isoState := db.head.oooIso.TrackReadAfter(db.lastGarbageCollectedMmapRef)
 		headQuerier = NewHeadAndOOOQuerier(mint, maxt, db.head, isoState, headQuerier)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -128,6 +128,7 @@ type Head struct {
 	writeNotified wlog.WriteNotified
 
 	memTruncationInProcess atomic.Bool
+	memTruncationCallBack  func() // For testing purposes.
 }
 
 type ExemplarStorage interface {
@@ -1128,6 +1129,10 @@ func (h *Head) truncateMemory(mint int64) (err error) {
 	h.lastMemoryTruncationTime.Store(mint)
 	h.memTruncationInProcess.Store(true)
 	defer h.memTruncationInProcess.Store(false)
+
+	if h.memTruncationCallBack != nil {
+		h.memTruncationCallBack()
+	}
 
 	// We wait for pending queries to end that overlap with this truncation.
 	if initialized {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3526,53 +3526,57 @@ func TestQueryOOOHeadDuringTruncate(t *testing.T) {
 
 	requireEqualOOOSamples(t, int(maxT/100-1), db)
 
-	db.Compact(context.Background()) // Compact and write blocks up to 3000 (maxtT/2).
-	// This mocks truncation.
-	db.head.memTruncationInProcess.Store(true)
-	db.head.lastMemoryTruncationTime.Store(maxT / 2)
+	// Synchronization points.
+	allowQueryToStart := make(chan struct{})
+	queryStarted := make(chan struct{})
+	compactionFinished := make(chan struct{})
 
-	t.Run("LabelNames", func(t *testing.T) {
-		// Query the head and overlap with the truncation time.
-		q, err := db.Querier(1500, 2500)
-		require.NoError(t, err)
-		defer q.Close()
-		ctx := context.Background()
-		res, annots, err := q.LabelNames(ctx, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
-		require.NoError(t, err)
-		require.Empty(t, annots)
-		require.Equal(t, []string{"a"}, res)
-		require.NoError(t, q.Close())
-	})
+	db.head.memTruncationCallBack = func() {
+		// Compaction has started, let the query start and wait for it to actually start to simulate race condition.
+		allowQueryToStart <- struct{}{}
+		<-queryStarted
+	}
 
-	t.Run("LabelValues", func(t *testing.T) {
-		// Query the head and overlap with the truncation time.
-		q, err := db.Querier(1500, 2500)
-		require.NoError(t, err)
-		defer q.Close()
-		ctx := context.Background()
-		res, annots, err := q.LabelValues(ctx, "a", nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
-		require.NoError(t, err)
-		require.Empty(t, annots)
-		require.Equal(t, []string{"b"}, res)
-		require.NoError(t, q.Close())
-	})
+	go func() {
+		db.Compact(context.Background()) // Compact and write blocks up to 3000 (maxtT/2).
+		compactionFinished <- struct{}{}
+	}()
 
-	t.Run("Select", func(t *testing.T) {
-		// Query the head and overlap with the truncation time.
-		q, err := db.Querier(1500, 2500)
-		require.NoError(t, err)
-		defer q.Close()
-		ctx := context.Background()
-		ss := q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
-		require.True(t, ss.Next())
-		s := ss.At()
-		require.False(t, ss.Next()) // One series.
-		it := s.Iterator(nil)
-		require.NotEqual(t, chunkenc.ValNone, it.Next()) // Has some data.
-		require.Equal(t, int64(1500), it.AtT())          // At the right time.
-		require.NoError(t, it.Err())
-		require.NoError(t, q.Close())
-	})
+	// Wait for the compaction to start.
+	<-allowQueryToStart
+
+	q, err := db.Querier(1500, 2500)
+	require.NoError(t, err)
+	queryStarted <- struct{}{} // Unblock the compaction.
+	ctx := context.Background()
+
+	// Label names.
+	res, annots, err := q.LabelNames(ctx, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
+	require.NoError(t, err)
+	require.Empty(t, annots)
+	require.Equal(t, []string{"a"}, res)
+
+	// Label values.
+	res, annots, err = q.LabelValues(ctx, "a", nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
+	require.NoError(t, err)
+	require.Empty(t, annots)
+	require.Equal(t, []string{"b"}, res)
+
+	// Samples
+	ss := q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchEqual, "a", "b"))
+	require.True(t, ss.Next())
+	s := ss.At()
+	require.False(t, ss.Next()) // One series.
+	it := s.Iterator(nil)
+	require.NotEqual(t, chunkenc.ValNone, it.Next()) // Has some data.
+	require.Equal(t, int64(1500), it.AtT())          // It is an in-order sample.
+	require.NotEqual(t, chunkenc.ValNone, it.Next()) // Has some data.
+	require.Equal(t, int64(1550), it.AtT())          // it is an out-of-order sample.
+	require.NoError(t, it.Err())
+
+	require.NoError(t, q.Close()) // Cannot be deferred as the compaction waits for queries to close before finishing.
+
+	<-compactionFinished // Wait for compaction otherwise Go test finds stray goroutines.
 }
 
 func TestAppendHistogram(t *testing.T) {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -513,7 +513,7 @@ type HeadAndOOOQuerier struct {
 	head       *Head
 	index      IndexReader
 	chunkr     ChunkReader
-	querier    storage.Querier // This might be nil if head was truncated.
+	querier    storage.Querier // Used for LabelNames, LabelValues, but may be nil if head was truncated in the mean time, in which case we ignore it and not close it in the end.
 }
 
 func NewHeadAndOOOQuerier(mint, maxt int64, head *Head, oooIsoState *oooIsolationState, querier storage.Querier) storage.Querier {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -513,7 +513,7 @@ type HeadAndOOOQuerier struct {
 	head       *Head
 	index      IndexReader
 	chunkr     ChunkReader
-	querier    storage.Querier
+	querier    storage.Querier // This might be nil if head was truncated.
 }
 
 func NewHeadAndOOOQuerier(mint, maxt int64, head *Head, oooIsoState *oooIsolationState, querier storage.Querier) storage.Querier {
@@ -534,15 +534,24 @@ func NewHeadAndOOOQuerier(mint, maxt int64, head *Head, oooIsoState *oooIsolatio
 }
 
 func (q *HeadAndOOOQuerier) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	if q.querier == nil {
+		return nil, nil, nil
+	}
 	return q.querier.LabelValues(ctx, name, hints, matchers...)
 }
 
 func (q *HeadAndOOOQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	if q.querier == nil {
+		return nil, nil, nil
+	}
 	return q.querier.LabelNames(ctx, hints, matchers...)
 }
 
 func (q *HeadAndOOOQuerier) Close() error {
 	q.chunkr.Close()
+	if q.querier == nil {
+		return nil
+	}
 	return q.querier.Close()
 }
 


### PR DESCRIPTION
Added regression test for #14822. Doesn't cause segfault before #14354

The segfault was due to a race condition between query start and compaction.
When compaction starts, in-order queries may overlap with the TSDB head, but also might fall into the truncated time of the head. In such case, the head querier `headQuerier` is nil in db.go here
https://github.com/prometheus/prometheus/blob/1e01e97151c9db59178dfbabd5e60f4b3916cb83/tsdb/db.go#L2062
and
https://github.com/prometheus/prometheus/blob/1e01e97151c9db59178dfbabd5e60f4b3916cb83/tsdb/db.go#L2137

That pointer is not used for selecting samples, but is referenced in `Close()` which causes the segfault.

The fix essentially restores the original function where we did not rely on the headQuerier in creating the OOO head querier: https://github.com/prometheus/prometheus/blob/9849418fac06ae0c0d3999891940939d8e0f8307/tsdb/db.go#L2157