### PR TITLE
storage: Update LabelQuerier interface to return sorted label values

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -157,7 +157,7 @@ type ChunkQuerier interface {
 
 // LabelQuerier provides querying access over labels.
 type LabelQuerier interface {
-	// LabelValues returns all potential values for a label name.
+	// LabelValues returns all potential values for a label name in sorted order.
 	// It is not safe to use the strings beyond the lifetime of the querier.
 	// If matchers are specified the returned result set is reduced
 	// to label values of metrics matching the matchers.


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

### Changes
- The `LabelValues()` method was always implicitly expected to return sorted values in merge querier.
  - see: https://github.com/prometheus/prometheus/blob/main/storage/merge.go#L190
- This change makes it more explicit and visible in the interface.


### Existing implementations

I audited that the existing implementations are sorted:

- https://github.com/prometheus/prometheus/blob/536d9f9ce989b670974e94b5db12f7bee0276e8e/tsdb/ooo_head_read.go#L536
- https://github.com/prometheus/prometheus/blob/536d9f9ce989b670974e94b5db12f7bee0276e8e/tsdb/ooo_head_read.go#L178
- https://github.com/prometheus/prometheus/blob/536d9f9ce989b670974e94b5db12f7bee0276e8e/tsdb/querier.go#L80