### PR TITLE
promql.Engine.Close: No-op if nil

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -435,6 +435,10 @@ func NewEngine(opts EngineOpts) *Engine {
 
 // Close closes ng.
 func (ng *Engine) Close() error {
+	if ng == nil {
+		return nil
+	}
+
 	if ng.activeQueryTracker != nil {
 		return ng.activeQueryTracker.Close()
 	}

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3019,6 +3019,29 @@ func TestEngineOptsValidation(t *testing.T) {
 	}
 }
 
+func TestEngine_Close(t *testing.T) {
+	t.Run("nil engine", func(t *testing.T) {
+		var ng *promql.Engine
+		require.NoError(t, ng.Close())
+	})
+
+	t.Run("non-nil engine", func(t *testing.T) {
+		ng := promql.NewEngine(promql.EngineOpts{
+			Logger:                   nil,
+			Reg:                      nil,
+			MaxSamples:               0,
+			Timeout:                  100 * time.Second,
+			NoStepSubqueryIntervalFn: nil,
+			EnableAtModifier:         true,
+			EnableNegativeOffset:     true,
+			EnablePerStepStats:       false,
+			LookbackDelta:            0,
+			EnableDelayedNameRemoval: true,
+		})
+		require.NoError(t, ng.Close())
+	})
+}
+
 func TestInstantQueryWithRangeVectorSelector(t *testing.T) {
 	engine := newTestEngine(t)
 


### PR DESCRIPTION
Make `promql.Engine.Close` return immediately if the engine is nil. Includes tests.

Fixes #14860.