### PR TITLE
Docs: Add storage.agent.wal-truncate-frequency flag documentation

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -435,7 +435,7 @@ func main() {
 
 	agentOnlyFlag(a, "storage.agent.wal-truncate-frequency",
 		"The frequency at which to truncate the WAL and remove old data.").
-		Hidden().PlaceHolder("<duration>").SetValue(&cfg.agent.TruncateFrequency)
+		Default("2h").PlaceHolder("<duration>").SetValue(&cfg.agent.TruncateFrequency)
 
 	agentOnlyFlag(a, "storage.agent.retention.min-time",
 		"Minimum age samples may be before being considered for deletion when the WAL is truncated").

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -40,6 +40,7 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--storage.tsdb.head-chunks-write-queue-size</code> | Size of the queue through which head chunks are written to the disk to be m-mapped, 0 disables the queue completely. Experimental. Use with server mode only. | `0` |
 | <code class="text-nowrap">--storage.agent.path</code> | Base path for metrics storage. Use with agent mode only. | `data-agent/` |
 | <code class="text-nowrap">--storage.agent.wal-compression</code> | Compress the agent WAL. Use with agent mode only. | `true` |
+| <code class="text-nowrap">--storage.agent.wal-truncate-frequency</code> | The frequency at which to truncate the WAL and remove old data. Use with agent mode only. | `2h` |
 | <code class="text-nowrap">--storage.agent.retention.min-time</code> | Minimum age samples may be before being considered for deletion when the WAL is truncated Use with agent mode only. |  |
 | <code class="text-nowrap">--storage.agent.retention.max-time</code> | Maximum age samples may be before being forcibly deleted when the WAL is truncated Use with agent mode only. |  |
 | <code class="text-nowrap">--storage.agent.no-lockfile</code> | Do not create lockfile in data directory. Use with agent mode only. | `false` |


### PR DESCRIPTION
## Overview

This PR adds documentation for the `--storage.agent.wal-truncate-frequency` flag, which I found implemented in [cmd/prometheus/main.go](https://github.com/prometheus/prometheus/blob/main/cmd/prometheus/main.go) but noticed it was not documented. The flag controls how frequently the Write-Ahead Log (WAL) truncates segments to manage disk usage and optimize system performance. This addition aims to help users configure this flag effectively.

I've noticed many developers searching for this flag but unable to find any documentation on it. This flag is useful and should be documented, similar to how important configuration flags are documented in other tools like [Grafana Agent.](https://grafana.com/docs/agent/latest/static/configuration/metrics-config/#data-retention)