### PR TITLE
API: Enable remote write and otlp receivers by default

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -182,12 +182,6 @@ func (c *flagConfig) setFeatureListOptions(logger log.Logger) error {
 		opts := strings.Split(f, ",")
 		for _, o := range opts {
 			switch o {
-			case "remote-write-receiver":
-				c.web.EnableRemoteWriteReceiver = true
-				level.Warn(logger).Log("msg", "Remote write receiver enabled via feature flag remote-write-receiver. This is DEPRECATED. Use --web.enable-remote-write-receiver.")
-			case "otlp-write-receiver":
-				c.web.EnableOTLPWriteReceiver = true
-				level.Info(logger).Log("msg", "Experimental OTLP write receiver enabled")
 			case "expand-external-labels":
 				c.enableExpandExternalLabels = true
 				level.Info(logger).Log("msg", "Experimental expand-external-labels enabled")
@@ -351,11 +345,6 @@ func main() {
 
 	a.Flag("web.enable-admin-api", "Enable API endpoints for admin control actions.").
 		Default("false").BoolVar(&cfg.web.EnableAdminAPI)
-
-	// TODO(bwplotka): Consider allowing those remote receive flags to be changed in config.
-	// See https://github.com/prometheus/prometheus/issues/14410
-	a.Flag("web.enable-remote-write-receiver", "Enable API endpoint accepting remote write requests.").
-		Default("false").BoolVar(&cfg.web.EnableRemoteWriteReceiver)
 
 	supportedRemoteWriteProtoMsgs := config.RemoteWriteProtoMsgs{config.RemoteWriteProtoMsgV1, config.RemoteWriteProtoMsgV2}
 	a.Flag("web.remote-write-receiver.accepted-protobuf-messages", fmt.Sprintf("List of the remote write protobuf messages to accept when receiving the remote writes. Supported values: %v", supportedRemoteWriteProtoMsgs.String())).

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -26,7 +26,6 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--web.user-assets</code> | Path to static asset directory, available at /user. |  |
 | <code class="text-nowrap">--web.enable-lifecycle</code> | Enable shutdown and reload via HTTP request. | `false` |
 | <code class="text-nowrap">--web.enable-admin-api</code> | Enable API endpoints for admin control actions. | `false` |
-| <code class="text-nowrap">--web.enable-remote-write-receiver</code> | Enable API endpoint accepting remote write requests. | `false` |
 | <code class="text-nowrap">--web.remote-write-receiver.accepted-protobuf-messages</code> | List of the remote write protobuf messages to accept when receiving the remote writes. Supported values: prometheus.WriteRequest, io.prometheus.write.v2.Request | `prometheus.WriteRequest` |
 | <code class="text-nowrap">--web.console.templates</code> | Path to the console template directory, available at /consoles. | `consoles` |
 | <code class="text-nowrap">--web.console.libraries</code> | Path to the console library directory. | `console_libraries` |

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -248,9 +248,7 @@ func NewAPI(
 	gatherer prometheus.Gatherer,
 	registerer prometheus.Registerer,
 	statsRenderer StatsRenderer,
-	rwEnabled bool,
 	acceptRemoteWriteProtoMsgs []config.RemoteWriteProtoMsg,
-	otlpEnabled bool,
 ) *API {
 	a := &API{
 		QueryEngine:       qe,
@@ -287,16 +285,8 @@ func NewAPI(
 		a.statsRenderer = statsRenderer
 	}
 
-	if ap == nil && (rwEnabled || otlpEnabled) {
-		panic("remote write or otlp write enabled, but no appender passed in.")
-	}
-
-	if rwEnabled {
-		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, acceptRemoteWriteProtoMsgs)
-	}
-	if otlpEnabled {
-		a.otlpWriteHandler = remote.NewOTLPWriteHandler(logger, ap, configFunc)
-	}
+	a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, acceptRemoteWriteProtoMsgs)
+	a.otlpWriteHandler = remote.NewOTLPWriteHandler(logger, ap, configFunc)
 
 	return a
 }

--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -137,9 +137,7 @@ func createPrometheusAPI(t *testing.T, q storage.SampleAndChunkQueryable) *route
 		prometheus.DefaultGatherer,
 		nil,
 		nil,
-		false,
 		config.RemoteWriteProtoMsgs{config.RemoteWriteProtoMsgV1, config.RemoteWriteProtoMsgV2},
-		false,
 	)
 
 	promRouter := route.New().WithPrefix("/api/v1")

--- a/web/web.go
+++ b/web/web.go
@@ -277,8 +277,6 @@ type Options struct {
 	RemoteReadSampleLimit      int
 	RemoteReadConcurrencyLimit int
 	RemoteReadBytesInFrame     int
-	EnableRemoteWriteReceiver  bool
-	EnableOTLPWriteReceiver    bool
 	IsAgent                    bool
 	AppName                    string
 
@@ -338,12 +336,7 @@ func New(logger log.Logger, o *Options) *Handler {
 	factoryAr := func(_ context.Context) api_v1.AlertmanagerRetriever { return h.notifier }
 	FactoryRr := func(_ context.Context) api_v1.RulesRetriever { return h.ruleManager }
 
-	var app storage.Appendable
-	if o.EnableRemoteWriteReceiver || o.EnableOTLPWriteReceiver {
-		app = h.storage
-	}
-
-	h.apiV1 = api_v1.NewAPI(h.queryEngine, h.storage, app, h.exemplarStorage, factorySPr, factoryTr, factoryAr,
+	h.apiV1 = api_v1.NewAPI(h.queryEngine, h.storage, h.storage, h.exemplarStorage, factorySPr, factoryTr, factoryAr,
 		func() config.Config {
 			h.mtx.RLock()
 			defer h.mtx.RUnlock()
@@ -371,9 +364,7 @@ func New(logger log.Logger, o *Options) *Handler {
 		o.Gatherer,
 		o.Registerer,
 		nil,
-		o.EnableRemoteWriteReceiver,
 		o.AcceptRemoteWriteProtoMsgs,
-		o.EnableOTLPWriteReceiver,
 	)
 
 	if o.RoutePrefix != "/" {


### PR DESCRIPTION
A bit related to https://github.com/prometheus/prometheus/issues/14410 but suggesting a new approach.

Both endpoints have been in Prometheus for some time now and we consider them both stable. Up until now they were hidden by default and needed a flag to enable them. This PR suggests to enable them by default.