### PR TITLE
Bring back documentation link in the form of an action button

### DIFF
--- a/web/ui/mantine-ui/src/App.tsx
+++ b/web/ui/mantine-ui/src/App.tsx
@@ -6,6 +6,7 @@ import classes from "./App.module.css";
 import PrometheusLogo from "./images/prometheus-logo.svg";
 
 import {
+  ActionIcon,
   AppShell,
   Box,
   Burger,
@@ -22,6 +23,7 @@ import { useDisclosure } from "@mantine/hooks";
 import {
   IconBell,
   IconBellFilled,
+  IconBook,
   IconChevronDown,
   IconChevronRight,
   IconCloudDataConnection,
@@ -306,17 +308,24 @@ function App() {
             ))}
         </Menu.Dropdown>
       </Menu>
+    </>
+  );
 
-      {/* <Button
+  const navActionIcons = (
+    <>
+      <ThemeSelector />
+      <SettingsMenu />
+      <ActionIcon
         component="a"
         href="https://prometheus.io/docs/prometheus/latest/getting_started/"
-        className={classes.link}
-        leftSection={<IconHelp style={navIconStyle} />}
         target="_blank"
-        px={navLinkXPadding}
+        color="gray"
+        title="Documentation"
+        aria-label="Documentation"
+        size={32}
       >
-        Help
-      </Button> */}
+        <IconBook size={20} />
+      </ActionIcon>
     </>
   );
 
@@ -359,9 +368,8 @@ function App() {
                         {navLinks}
                       </Group>
                     </Group>
-                    <Group visibleFrom="xs" wrap="nowrap">
-                      <ThemeSelector />
-                      <SettingsMenu />
+                    <Group visibleFrom="xs" wrap="nowrap" gap="xs">
+                      {navActionIcons}
                     </Group>
                   </Group>
                   <Burger
@@ -377,8 +385,7 @@ function App() {
               <AppShell.Navbar py="md" px={4} bg="rgb(65, 73, 81)" c="#fff">
                 {navLinks}
                 <Group mt="md" hiddenFrom="xs" justify="center">
-                  <ThemeSelector />
-                  <SettingsMenu />
+                  {navActionIcons}
                 </Group>
               </AppShell.Navbar>
 

--- a/web/ui/mantine-ui/src/components/SettingsMenu.tsx
+++ b/web/ui/mantine-ui/src/components/SettingsMenu.tsx
@@ -18,7 +18,12 @@ const SettingsMenu: FC = () => {
   return (
     <Popover position="bottom" withArrow shadow="md">
       <Popover.Target>
-        <ActionIcon color="gray" aria-label="Settings" size={32}>
+        <ActionIcon
+          color="gray"
+          title="Settings"
+          aria-label="Settings"
+          size={32}
+        >
           <IconSettings size={20} />
         </ActionIcon>
       </Popover.Target>


### PR DESCRIPTION
IMO this looks nicer than adding it as a normal page nav link as in https://github.com/prometheus/prometheus/pull/14878

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
