### PR TITLE
POC: Anchor y axis at zero

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/Graph.tsx
+++ b/web/ui/mantine-ui/src/pages/query/Graph.tsx
@@ -23,6 +23,7 @@ export interface GraphProps {
   range: number;
   resolution: GraphResolution;
   showExemplars: boolean;
+  anchorYAxisAtZero: boolean,
   displayMode: GraphDisplayMode;
   retriggerIdx: number;
   onSelectRange: (start: number, end: number) => void;
@@ -35,6 +36,7 @@ const Graph: FC<GraphProps> = ({
   range,
   resolution,
   showExemplars,
+  anchorYAxisAtZero,
   displayMode,
   retriggerIdx,
   onSelectRange,
@@ -181,6 +183,7 @@ const Graph: FC<GraphProps> = ({
           range={dataAndRange.range}
           width={width}
           showExemplars={showExemplars}
+          anchorYAxisAtZero={anchorYAxisAtZero}
           displayMode={displayMode}
           onSelectRange={onSelectRange}
         />

--- a/web/ui/mantine-ui/src/pages/query/QueryPanel.tsx
+++ b/web/ui/mantine-ui/src/pages/query/QueryPanel.tsx
@@ -1,6 +1,7 @@
 import {
   Group,
   Tabs,
+  Checkbox,
   Center,
   Space,
   Box,
@@ -54,6 +55,8 @@ const QueryPanel: FC<PanelProps> = ({ idx, metricNames }) => {
 
   const panel = useAppSelector((state) => state.queryPage.panels[idx]);
   const dispatch = useAppDispatch();
+
+  const [anchorYAxisAtZero, setAnchorYAxisAtZero] = useState(false);
 
   const [selectedNode, setSelectedNode] = useState<{
     id: string;
@@ -247,6 +250,26 @@ const QueryPanel: FC<PanelProps> = ({ idx, metricNames }) => {
                 Show exemplars
               </Button> */}
 
+              <Checkbox
+                label="y axis starts at zero"
+                disabled={panel.visualizer.displayMode !== GraphDisplayMode.Lines}
+                checked={anchorYAxisAtZero}
+                onChange={(value) => {
+                  setAnchorYAxisAtZero(value.currentTarget.checked)
+
+                  dispatch(
+                    setVisualizer({
+                      idx,
+                      visualizer: {
+                        ...panel.visualizer,
+                        anchorYAxisAtZero: value.currentTarget.checked,
+                      },
+                    })
+                  )
+
+                }}
+              />
+
               <SegmentedControl
                 onChange={(value) =>
                   dispatch(
@@ -300,6 +323,7 @@ const QueryPanel: FC<PanelProps> = ({ idx, metricNames }) => {
             range={panel.visualizer.range}
             resolution={panel.visualizer.resolution}
             showExemplars={panel.visualizer.showExemplars}
+            anchorYAxisAtZero={panel.visualizer.anchorYAxisAtZero}
             displayMode={panel.visualizer.displayMode}
             retriggerIdx={retriggerIdx}
             onSelectRange={onSelectRange}

--- a/web/ui/mantine-ui/src/pages/query/UPlotChart.tsx
+++ b/web/ui/mantine-ui/src/pages/query/UPlotChart.tsx
@@ -23,6 +23,7 @@ export interface UPlotChartProps {
   range: UPlotChartRange;
   width: number;
   showExemplars: boolean;
+  anchorYAxisAtZero: boolean,
   displayMode: GraphDisplayMode;
   onSelectRange: (start: number, end: number) => void;
 }
@@ -34,6 +35,7 @@ const UPlotChart: FC<UPlotChartProps> = ({
   range: { startTime, endTime, resolution },
   width,
   displayMode,
+  anchorYAxisAtZero,
   onSelectRange,
 }) => {
   const [options, setOptions] = useState<uPlot.Options | null>(null);
@@ -63,6 +65,17 @@ const UPlotChart: FC<UPlotChartProps> = ({
       theme === "light",
       onSelectRange
     );
+
+    if (anchorYAxisAtZero) {
+      // force 0 to be the sum minimum this instead of the bottom series
+      opts.scales = opts.scales || {};
+      opts.scales.y = {
+        range: (_u, _min, max) => {
+          const minMax = uPlot.rangeNum(0, max, 0.1, true);
+          return [0, minMax[1]];
+        },
+      };
+    }
 
     if (displayMode === GraphDisplayMode.Stacked) {
       setProcessedData(setStackedOpts(opts, seriesData).data);

--- a/web/ui/mantine-ui/src/pages/query/urlStateEncoding.ts
+++ b/web/ui/mantine-ui/src/pages/query/urlStateEncoding.ts
@@ -73,6 +73,9 @@ export const decodePanelOptionsFromURLParams = (query: string): Panel[] => {
     decodeSetting("end_input", (value) => {
       panel.visualizer.endTime = parseTime(value);
     });
+    decodeSetting("anchor_y_axis", (value) => {
+      panel.visualizer.anchorYAxisAtZero = value === "1"
+    });
     // Legacy "step_input" parameter, overriden below by
     // "res_type" / "res_density" / "res_step" if present.
     decodeSetting("step_input", (value) => {
@@ -146,6 +149,8 @@ export const encodePanelOptionsToURLParams = (
       addParam(idx, "moment_input", formatTime(p.visualizer.endTime));
     }
     addParam(idx, "range_input", formatPrometheusDuration(p.visualizer.range));
+
+    addParam(idx, "anchor_y_axis", p.visualizer.anchorYAxisAtZero ? "1" : "0");
 
     switch (p.visualizer.resolution.type) {
       case "auto":

--- a/web/ui/mantine-ui/src/state/queryPageSlice.ts
+++ b/web/ui/mantine-ui/src/state/queryPageSlice.ts
@@ -58,6 +58,7 @@ export interface Visualizer {
   resolution: GraphResolution;
   displayMode: GraphDisplayMode;
   showExemplars: boolean;
+  anchorYAxisAtZero: boolean;
 }
 
 export type Panel = {
@@ -86,6 +87,7 @@ export const newDefaultPanel = (): Panel => ({
     resolution: { type: "auto", density: "medium" },
     displayMode: GraphDisplayMode.Lines,
     showExemplars: false,
+    anchorYAxisAtZero: false,
   },
 });
 


### PR DESCRIPTION
This would resolve a long standing issue of not being able to force the y axis to start at zero in line charts.

This is pretty useful to understand relative changes in the presence of multiple lines (say memory use of various containers over time).

Would resolve #520.

(Sorry for the naming both in code and in the UI, I was just trying to make this work. Also apologies for any React crimes, I'm a vanilla JS person in case I absolutely have to do frontend work.)