### PR TITLE
Explain, vector-to-vector: Do not compute results for set operators

### DIFF
--- a/web/ui/mantine-ui/src/promql/binOp.ts
+++ b/web/ui/mantine-ui/src/promql/binOp.ts
@@ -8,7 +8,7 @@ import {
   vectorMatchCardinality,
   VectorMatching,
 } from "./ast";
-import { isComparisonOperator } from "./utils";
+import { isComparisonOperator, isSetOperator } from "./utils";
 
 // We use a special (otherwise invalid) sample value to indicate that
 // a sample has been filtered away by a comparison operator.
@@ -340,6 +340,11 @@ export const computeVectorVectorBinOp = (
 
   // Annotate the match groups with errors (if any) and populate the results.
   Object.values(groups).forEach((mg) => {
+    // Do not populate results for set operators.
+    if (isSetOperator(op)) {
+        return;
+    }
+
     if (matching.card === vectorMatchCardinality.oneToOne) {
       if (mg.lhs.length > 1 && mg.rhs.length > 1) {
         mg.error = { type: MatchErrorType.multipleMatchesOnBothSides };


### PR DESCRIPTION
Set operators are not displayed:
https://github.com/prometheus/prometheus/blob/31ce9dacf4a3714898e8620b09a753e16e2cf32a/web/ui/mantine-ui/src/pages/query/ExplainViews/BinaryExpr/VectorVector.tsx#L364

Therefore, do not compute results for them.

Fixes #14889

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
