### PR TITLE
rules notifier: track failed notifications, not failed batches

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -73,19 +73,16 @@
             expr: |||
               (
                 rate(prometheus_notifications_errors_total{%(prometheusSelector)s}[5m])
-              /
-                rate(prometheus_notifications_sent_total{%(prometheusSelector)s}[5m])
               )
-              * 100
-              > 1
+              > 0
             ||| % $._config,
             'for': '15m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              summary: 'Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.',
-              description: '{{ printf "%%.1f" $value }}%% errors while sending alerts from Prometheus %(prometheusName)s to Alertmanager {{$labels.alertmanager}}.' % $._config,
+              summary: 'Prometheus has encountered errors sending alerts to a specific Alertmanager.',
+              description: '{{ printf "%%.1f" $value }} errors/sec while sending alerts from Prometheus %(prometheusName)s to Alertmanager {{$labels.alertmanager}}.' % $._config,
             },
           },
           {

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -610,12 +610,12 @@ func (n *Manager) sendAll(alerts ...*Alert) bool {
 			go func(ctx context.Context, client *http.Client, url string, payload []byte, count int) {
 				if err := n.sendOne(ctx, client, url, payload); err != nil {
 					level.Error(n.logger).Log("alertmanager", url, "count", count, "msg", "Error sending alert", "err", err)
-					n.metrics.errors.WithLabelValues(url).Inc()
+					n.metrics.errors.WithLabelValues(url).Add(float64(count))
 				} else {
 					numSuccess.Inc()
 				}
 				n.metrics.latency.WithLabelValues(url).Observe(time.Since(begin).Seconds())
-				n.metrics.sent.WithLabelValues(url).Add(float64(len(amAlerts)))
+				n.metrics.sent.WithLabelValues(url).Add(float64(count))
 
 				wg.Done()
 			}(ctx, ams.client, am.url().String(), payload, len(amAlerts))


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This changes `prometheus_notifications_errors_total` to track each failed notification instead of each failed batch of notifications. The [mixin assumes](https://github.com/prometheus/prometheus/blob/f9ca6c4ae613ec997297843f32cae3f6c4f0f20a/documentation/prometheus-mixin/alerts.libsonnet#L71-L90) that the ratio between `prometheus_notifications_sent_total` and `prometheus_notifications_errors_total` is between 0 and 1, but in reality they're measuring in different units.

