### PR TITLE
[PERF] TSDB: Chunk encoding: shorten some write sequences

### DIFF
--- a/tsdb/chunkenc/bstream.go
+++ b/tsdb/chunkenc/bstream.go
@@ -95,10 +95,8 @@ func (b *bstream) writeByte(byt byte) {
 	// Complete the last byte with the leftmost b.count bits from byt.
 	b.stream[i] |= byt >> (8 - b.count)
 
-	b.stream = append(b.stream, 0)
-	i++
 	// Write the remainder, if any.
-	b.stream[i] = byt << b.count
+	b.stream = append(b.stream, byt<<b.count)
 }
 
 // writeBits writes the nbits right-most bits of u to the stream

--- a/tsdb/chunkenc/chunk_test.go
+++ b/tsdb/chunkenc/chunk_test.go
@@ -308,5 +308,4 @@ func benchmarkAppender(b *testing.B, deltas func() (int64, float64), newChunk fu
 			a.Append(p.t, p.v)
 		}
 	}
-
 }

--- a/tsdb/chunkenc/chunk_test.go
+++ b/tsdb/chunkenc/chunk_test.go
@@ -251,54 +251,62 @@ func benchmarkIterator(b *testing.B, newChunk func() Chunk) {
 	}
 }
 
+func newXORChunk() Chunk {
+	return NewXORChunk()
+}
+
 func BenchmarkXORIterator(b *testing.B) {
-	benchmarkIterator(b, func() Chunk {
-		return NewXORChunk()
-	})
+	benchmarkIterator(b, newXORChunk)
 }
 
 func BenchmarkXORAppender(b *testing.B) {
-	benchmarkAppender(b, func() Chunk {
-		return NewXORChunk()
+	r := rand.New(rand.NewSource(1))
+	b.Run("constant", func(b *testing.B) {
+		benchmarkAppender(b, func() (int64, float64) {
+			return 1000, 0
+		}, newXORChunk)
+	})
+	b.Run("random steps", func(b *testing.B) {
+		benchmarkAppender(b, func() (int64, float64) {
+			return int64(r.Intn(100) - 50 + 15000), // 15 seconds +- up to 100ms of jitter.
+				float64(r.Intn(100) - 50) // Varying from -50 to +50 in 100 discrete steps.
+		}, newXORChunk)
+	})
+	b.Run("random 0-1", func(b *testing.B) {
+		benchmarkAppender(b, func() (int64, float64) {
+			return int64(r.Intn(100) - 50 + 15000), // 15 seconds +- up to 100ms of jitter.
+				r.Float64() // Random between 0 and 1.0.
+		}, newXORChunk)
 	})
 }
 
-func benchmarkAppender(b *testing.B, newChunk func() Chunk) {
+func benchmarkAppender(b *testing.B, deltas func() (int64, float64), newChunk func() Chunk) {
 	var (
 		t = int64(1234123324)
 		v = 1243535.123
 	)
+	const nSamples = 120 // Same as tsdb.DefaultSamplesPerChunk.
 	var exp []pair
-	for i := 0; i < b.N; i++ {
-		// t += int64(rand.Intn(10000) + 1)
-		t += int64(1000)
-		// v = rand.Float64()
-		v += float64(100)
+	for i := 0; i < nSamples; i++ {
+		dt, dv := deltas()
+		t += dt
+		v += dv
 		exp = append(exp, pair{t: t, v: v})
 	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	var chunks []Chunk
-	for i := 0; i < b.N; {
+	for i := 0; i < b.N; i++ {
 		c := newChunk()
 
 		a, err := c.Appender()
 		if err != nil {
 			b.Fatalf("get appender: %s", err)
 		}
-		j := 0
 		for _, p := range exp {
-			if j > 250 {
-				break
-			}
 			a.Append(p.t, p.v)
-			i++
-			j++
 		}
-		chunks = append(chunks, c)
 	}
 
-	fmt.Println("num", b.N, "created chunks", len(chunks))
 }

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -191,8 +191,8 @@ func (a *xorAppender) Append(t int64, v float64) {
 		case dod == 0:
 			a.b.writeBit(zero)
 		case bitRange(dod, 14):
-			a.b.writeBits(0b10, 2)
-			a.b.writeBits(uint64(dod), 14)
+			a.b.writeByte(0b10<<6 | (uint8(dod>>8) & (1<<6 - 1))) // 0b10 size code combined with 6 bits of dod.
+			a.b.writeByte(uint8(dod))                             // Bottom 8 bits of dod.
 		case bitRange(dod, 17):
 			a.b.writeBits(0b110, 3)
 			a.b.writeBits(uint64(dod), 17)


### PR DESCRIPTION
First, I improved the benchmark: 
* Benchmarks must do the same work N times.
* Run 3 cases, where the values are constant, vary a bit, and vary a lot.
* Also aim for 120 samples per chubk, same as TSDB default.

Then, simplify `writeByte` - rather than append a zero then set the value at that position, append the value.

Finally, combine writes in timestamps - instead of a 2-bit write followed by a 14-bit write, do two 8-bit writes, which goes much faster since it avoids looping.
In the most common case timestamp delta-of-deltas is zero, but this impacts the next-most-common case where it is nonzero and fits in 14 bits. 

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb/chunkenc
cpu: Apple M2
                           │ before.txt  │              after.txt              │
                           │   sec/op    │    sec/op     vs base               │
XORAppender/constant-8       737.2n ± 4%   737.5n ±  0%        ~ (p=1.000 n=6)
XORAppender/random_steps-8   3.806µ ± 9%   2.063µ ± 13%  -45.80% (p=0.002 n=6)
XORAppender/random_0-1-8     5.048µ ± 3%   3.145µ ±  8%  -37.69% (p=0.002 n=6)
geomean                      2.419µ        1.685µ        -30.35%

                           │  before.txt  │              after.txt               │
                           │     B/op     │     B/op      vs base                │
XORAppender/constant-8         320.0 ± 0%     320.0 ± 0%       ~ (p=1.000 n=6) ¹
XORAppender/random_steps-8   1.062Ki ± 0%   1.062Ki ± 0%       ~ (p=1.000 n=6) ¹
XORAppender/random_0-1-8     1.938Ki ± 0%   1.938Ki ± 0%       ~ (p=1.000 n=6) ¹
geomean                        884.0          884.0       +0.00%
¹ all samples are equal

                           │ before.txt │             after.txt              │
                           │ allocs/op  │ allocs/op   vs base                │
XORAppender/constant-8       4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=6) ¹
XORAppender/random_steps-8   6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=6) ¹
XORAppender/random_0-1-8     7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                      5.518        5.518       +0.00%
¹ all samples are equal
```