### PR TITLE
fix(web): properly format sub-millisecond durations in target status page

### DIFF
--- a/web/ui/mantine-ui/src/lib/formatTime.test.ts
+++ b/web/ui/mantine-ui/src/lib/formatTime.test.ts
@@ -57,6 +57,12 @@ describe("humanizeDuration", () => {
     expect(humanizeDuration(0)).toBe("0s");
   });
 
+  test("formats submilliseconds correctly", () => {
+    expect(humanizeDuration(0.1)).toBe("0ms");
+    expect(humanizeDuration(0.6)).toBe("1ms");
+    expect(humanizeDuration(0.000001)).toBe("0ms");
+  });
+
   test("formats milliseconds correctly", () => {
     expect(humanizeDuration(1)).toBe("1ms");
     expect(humanizeDuration(999)).toBe("999ms");

--- a/web/ui/mantine-ui/src/lib/formatTime.ts
+++ b/web/ui/mantine-ui/src/lib/formatTime.ts
@@ -86,6 +86,9 @@ const formatDuration = (
         r.push(`${v}${unit}`);
       }
     }
+    if (r.length == 0 && unit == "ms") {
+        r.push(`${Math.round(ms)}ms`)
+    }
   }
 
   return sign + r.join(componentSeparator || "");


### PR DESCRIPTION
Previously, scrapes durations that are very short (e.g., connection refused) could show as empty (durations under 1 millisecond).

This commit ensures that sub-millisecond durations are correctly displayed as "0ms" or "1ms" when necessary.

- Adjusted `humanizeDuration` to round sub-millisecond durations to the nearest millisecond.
- Updated unit tests to verify the correct handling of sub-millisecond values.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Before

![a](https://github.com/user-attachments/assets/2821d339-ebbb-4249-ac5e-f6713180ac43)

After

![b](https://github.com/user-attachments/assets/7267379a-d067-4e93-9c16-365cb04064aa)

