### PR TITLE
fix(autoreload): Reload invalid yaml files

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1119,9 +1119,7 @@ func main() {
 						currentChecksum, err := config.GenerateChecksum(cfg.configFile)
 						if err != nil {
 							level.Error(logger).Log("msg", "Failed to generate checksum during configuration reload", "err", err)
-							continue
-						}
-						if currentChecksum == checksum {
+						} else if currentChecksum == checksum {
 							continue
 						}
 						level.Info(logger).Log("msg", "Configuration file change detected, reloading the configuration.")


### PR DESCRIPTION
When a YAML file is invalid, trigger auto-reload anyway so that user is aware that the configuration file is incorrect.

Failing to do so does not change the reload status in metrics and api.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
