### PR TITLE
docs: Improve, clarify, and fix documentation on scrape limits

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -71,8 +71,11 @@ global:
   # How frequently to evaluate rules.
   [ evaluation_interval: <duration> | default = 1m ]
 
-  # Offset the rule evaluation timestamp of this particular group by the specified duration into the past to ensure the underlying metrics have been received.
-  # Metric availability delays are more likely to occur when Prometheus is running as a remote write target, but can also occur when there's anomalies with scraping.
+  # Offset the rule evaluation timestamp of this particular group by the
+  # specified duration into the past to ensure the underlying metrics have
+  # been received. Metric availability delays are more likely to occur when
+  # Prometheus is running as a remote write target, but can also occur when
+  # there's anomalies with scraping.
   [ rule_query_offset: <duration> | default = 0s ]
 
   # The labels to add to any time series or alerts when communicating with
@@ -94,27 +97,29 @@ global:
   # change or be removed in the future.
   [ body_size_limit: <size> | default = 0 ]
 
-  # Per-scrape limit on number of scraped samples that will be accepted.
+  # Per-scrape limit on the number of scraped samples that will be accepted.
   # If more than this number of samples are present after metric relabeling
   # the entire scrape will be treated as failed. 0 means no limit.
   [ sample_limit: <int> | default = 0 ]
 
-  # Per-scrape limit on number of labels that will be accepted for a sample. If
-  # more than this number of labels are present post metric-relabeling, the
-  # entire scrape will be treated as failed. 0 means no limit.
+  # Limit on the number of labels that will be accepted per sample. If more
+  # than this number of labels are present on any sample post metric-relabeling,
+  # the entire scrape will be treated as failed. 0 means no limit.
   [ label_limit: <int> | default = 0 ]
 
-  # Per-scrape limit on length of labels name that will be accepted for a sample.
-  # If a label name is longer than this number post metric-relabeling, the entire
-  # scrape will be treated as failed. 0 means no limit.
+  # Limit on the length (in bytes) of each individual label name. If any label
+  # name in a scrape is longer than this number post metric-relabeling, the
+  # entire scrape will be treated as failed. Note that label names are UTF-8
+  # encoded, and characters can take up to 4 bytes. 0 means no limit.
   [ label_name_length_limit: <int> | default = 0 ]
 
-  # Per-scrape limit on length of labels value that will be accepted for a sample.
-  # If a label value is longer than this number post metric-relabeling, the
-  # entire scrape will be treated as failed. 0 means no limit.
+  # Limit on the length (in bytes) of each individual label value. If any label
+  # value in a scrape is longer than this number post metric-relabeling, the
+  # entire scrape will be treated as failed. Note that label values are UTF-8
+  # encoded, and characters can take up to 4 bytes. 0 means no limit.
   [ label_value_length_limit: <int> | default = 0 ]
 
-  # Per-scrape config limit on number of unique targets that will be
+  # Limit per scrape config on number of unique targets that will be
   # accepted. If more than this number of targets are present after target
   # relabeling, Prometheus will mark the targets as failed without scraping them.
   # 0 means no limit. This is an experimental feature, this behaviour could
@@ -456,34 +461,36 @@ metric_relabel_configs:
 # change or be removed in the future.
 [ body_size_limit: <size> | default = 0 ]
 
-# Per-scrape limit on number of scraped samples that will be accepted.
+# Per-scrape limit on the number of scraped samples that will be accepted.
 # If more than this number of samples are present after metric relabeling
 # the entire scrape will be treated as failed. 0 means no limit.
 [ sample_limit: <int> | default = 0 ]
 
-# Per-scrape limit on number of labels that will be accepted for a sample. If
-# more than this number of labels are present post metric-relabeling, the
-# entire scrape will be treated as failed. 0 means no limit.
+# Limit on the number of labels that will be accepted per sample. If more
+# than this number of labels are present on any sample post metric-relabeling,
+# the entire scrape will be treated as failed. 0 means no limit.
 [ label_limit: <int> | default = 0 ]
 
-# Per-scrape limit on length of labels name that will be accepted for a sample.
-# If a label name is longer than this number post metric-relabeling, the entire
-# scrape will be treated as failed. 0 means no limit.
+# Limit on the length (in bytes) of each individual label name. If any label
+# name in a scrape is longer than this number post metric-relabeling, the
+# entire scrape will be treated as failed. Note that label names are UTF-8
+# encoded, and characters can take up to 4 bytes. 0 means no limit.
 [ label_name_length_limit: <int> | default = 0 ]
 
-# Per-scrape limit on length of labels value that will be accepted for a sample.
-# If a label value is longer than this number post metric-relabeling, the
-# entire scrape will be treated as failed. 0 means no limit.
+# Limit on the length (in bytes) of each individual label value. If any label
+# value in a scrape is longer than this number post metric-relabeling, the
+# entire scrape will be treated as failed. Note that label values are UTF-8
+# encoded, and characters can take up to 4 bytes. 0 means no limit.
 [ label_value_length_limit: <int> | default = 0 ]
 
-# Per-scrape config limit on number of unique targets that will be
+# Limit per scrape config on number of unique targets that will be
 # accepted. If more than this number of targets are present after target
 # relabeling, Prometheus will mark the targets as failed without scraping them.
 # 0 means no limit. This is an experimental feature, this behaviour could
 # change in the future.
 [ target_limit: <int> | default = 0 ]
 
-# Per-job limit on the number of targets dropped by relabeling
+# Limit per scrape config on the number of targets dropped by relabeling
 # that will be kept in memory. 0 means no limit.
 [ keep_dropped_targets: <int> | default = 0 ]
 


### PR DESCRIPTION
In detail:

- Clarify that label name and value length limits are in byte, not in UTF-8 data points.

- More consistent formatting to keep 80 characters line limet.

- Clarify various misleading specifications around "per sample", "per scrape", "per scrape config", "per job"...

- Fix grammar.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
