### PR TITLE
UI: Make mantime UI assets relative

### DIFF
--- a/web/ui/mantine-ui/vite.config.ts
+++ b/web/ui/mantine-ui/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '',
   plugins: [react()],
   server: {
     proxy: {


### PR DESCRIPTION
While debugging the new prometheus UI in a dev deployment that was behind a proxy we noticed that the mantime UI assets were absolute and since we had a custom URL in front of prometheus they did not work properly.

In this PR you'll see I'm setting Vite's `base` config to `''`

![image](https://github.com/user-attachments/assets/eb72efbc-13d1-4855-aa7f-5840279e5ffa)


[Official documentation](https://vitejs.dev/config/shared-options.html#base)