### PR TITLE
Process `MemPostings.Delete()` with `GOMAXPROCS` workers

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -295,7 +295,8 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 	defer p.mtx.Unlock()
 
 	// Deleting label names mutates p.m map, so it should be done from a single goroutine after nobody else is reading it.
-	deleteLabelNames := make(chan string, len(p.m))
+	// Adding +1 to length to account for allPostingsKey processing when MemPostings is empty.
+	deleteLabelNames := make(chan string, len(p.m)+1)
 
 	process := func(l labels.Label) {
 		orig := p.m[l.Name][l.Value]

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -973,37 +973,69 @@ func TestMemPostingsStats(t *testing.T) {
 }
 
 func TestMemPostings_Delete(t *testing.T) {
-	p := NewMemPostings()
-	p.Add(1, labels.FromStrings("lbl1", "a"))
-	p.Add(2, labels.FromStrings("lbl1", "b"))
-	p.Add(3, labels.FromStrings("lbl2", "a"))
+	t.Run("some postings", func(t *testing.T) {
+		p := NewMemPostings()
+		p.Add(1, labels.FromStrings("lbl1", "a"))
+		p.Add(2, labels.FromStrings("lbl1", "b"))
+		p.Add(3, labels.FromStrings("lbl2", "a"))
 
-	before := p.Get(allPostingsKey.Name, allPostingsKey.Value)
-	deletedRefs := map[storage.SeriesRef]struct{}{
-		2: {},
-	}
-	affectedLabels := map[labels.Label]struct{}{
-		{Name: "lbl1", Value: "b"}: {},
-	}
-	p.Delete(deletedRefs, affectedLabels)
-	after := p.Get(allPostingsKey.Name, allPostingsKey.Value)
+		before := p.Get(allPostingsKey.Name, allPostingsKey.Value)
+		deletedRefs := map[storage.SeriesRef]struct{}{
+			2: {},
+		}
+		affectedLabels := map[labels.Label]struct{}{
+			{Name: "lbl1", Value: "b"}: {},
+		}
+		p.Delete(deletedRefs, affectedLabels)
+		after := p.Get(allPostingsKey.Name, allPostingsKey.Value)
 
-	// Make sure postings gotten before the delete have the old data when
-	// iterated over.
-	expanded, err := ExpandPostings(before)
-	require.NoError(t, err)
-	require.Equal(t, []storage.SeriesRef{1, 2, 3}, expanded)
+		// Make sure postings gotten before the delete have the old data when
+		// iterated over.
+		expanded, err := ExpandPostings(before)
+		require.NoError(t, err)
+		require.Equal(t, []storage.SeriesRef{1, 2, 3}, expanded)
 
-	// Make sure postings gotten after the delete have the new data when
-	// iterated over.
-	expanded, err = ExpandPostings(after)
-	require.NoError(t, err)
-	require.Equal(t, []storage.SeriesRef{1, 3}, expanded)
+		// Make sure postings gotten after the delete have the new data when
+		// iterated over.
+		expanded, err = ExpandPostings(after)
+		require.NoError(t, err)
+		require.Equal(t, []storage.SeriesRef{1, 3}, expanded)
 
-	deleted := p.Get("lbl1", "b")
-	expanded, err = ExpandPostings(deleted)
-	require.NoError(t, err)
-	require.Empty(t, expanded, "expected empty postings, got %v", expanded)
+		deleted := p.Get("lbl1", "b")
+		expanded, err = ExpandPostings(deleted)
+		require.NoError(t, err)
+		require.Empty(t, expanded, "expected empty postings, got %v", expanded)
+	})
+
+	t.Run("all postings", func(t *testing.T) {
+		p := NewMemPostings()
+		p.Add(1, labels.FromStrings("lbl1", "a"))
+		p.Add(2, labels.FromStrings("lbl1", "b"))
+		p.Add(3, labels.FromStrings("lbl2", "a"))
+
+		deletedRefs := map[storage.SeriesRef]struct{}{1: {}, 2: {}, 3: {}}
+		affectedLabels := map[labels.Label]struct{}{
+			{Name: "lbl1", Value: "a"}: {},
+			{Name: "lbl1", Value: "b"}: {},
+			{Name: "lbl1", Value: "c"}: {},
+		}
+		p.Delete(deletedRefs, affectedLabels)
+		after := p.Get(allPostingsKey.Name, allPostingsKey.Value)
+		expanded, err := ExpandPostings(after)
+		require.NoError(t, err)
+		require.Empty(t, expanded)
+	})
+
+	t.Run("nothing on empty mempostings", func(t *testing.T) {
+		p := NewMemPostings()
+		deletedRefs := map[storage.SeriesRef]struct{}{}
+		affectedLabels := map[labels.Label]struct{}{}
+		p.Delete(deletedRefs, affectedLabels)
+		after := p.Get(allPostingsKey.Name, allPostingsKey.Value)
+		expanded, err := ExpandPostings(after)
+		require.NoError(t, err)
+		require.Empty(t, expanded)
+	})
 }
 
 // BenchmarkMemPostings_Delete is quite heavy, so consider running it with

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1025,7 +1025,7 @@ func BenchmarkMemPostings_Delete(b *testing.B) {
 		return s
 	}
 
-	const total = 1e6
+	const total = 2e6
 	allSeries := [total]labels.Labels{}
 	nameValues := make([]string, 0, 100)
 	for i := 0; i < total; i++ {


### PR DESCRIPTION
We are still seeing lock contention on `MemPostings.mtx` for customers with lots of labels per series, and `MemPostings.Delete()` is by far the most expensive operation on that mutex.

This adds parallelism to that method, trying to reduce the amount of time we spend with the mutex held.

I updated the benchmark to create more series to get a more meaningful result.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb/index
cpu: Apple M3 Pro
                                            │   main_2m    │             parallel_2m             │
                                            │    sec/op    │    sec/op     vs base               │
MemPostings_Delete/refs=1/readers=0-12        46.51m ± 10%   24.65m ±  4%  -47.00% (p=0.002 n=6)
MemPostings_Delete/refs=1/readers=1-12        46.23m ±  2%   24.00m ±  8%  -48.08% (p=0.002 n=6)
MemPostings_Delete/refs=1/readers=10-12       46.58m ±  7%   24.67m ± 11%  -47.04% (p=0.002 n=6)
MemPostings_Delete/refs=100/readers=0-12      68.75m ±  7%   36.97m ±  4%  -46.23% (p=0.002 n=6)
MemPostings_Delete/refs=100/readers=1-12      71.69m ±  9%   36.25m ±  5%  -49.43% (p=0.002 n=6)
MemPostings_Delete/refs=100/readers=10-12     71.19m ±  6%   36.64m ±  3%  -48.53% (p=0.002 n=6)
MemPostings_Delete/refs=10000/readers=0-12    68.39m ± 11%   56.41m ±  8%  -17.52% (p=0.002 n=6)
MemPostings_Delete/refs=10000/readers=1-12    69.07m ± 13%   58.22m ±  9%  -15.71% (p=0.002 n=6)
MemPostings_Delete/refs=10000/readers=10-12   70.15m ±  4%   58.45m ±  9%  -16.68% (p=0.002 n=6)
geomean                                       60.97m         37.24m        -38.93%
```

I recommend checking the diff hiding the whitespace changes.