### PR TITLE
PromTool: Support Scrape Interval Lint Checking

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -73,11 +73,12 @@ const (
 	// Exit code 3 is used for "one or more lint issues detected".
 	lintErrExitCode = 3
 
-	lintOptionAll            = "all"
-	lintOptionDuplicateRules = "duplicate-rules"
-	lintOptionNone           = "none"
-	checkHealth              = "/-/healthy"
-	checkReadiness           = "/-/ready"
+	lintOptionAll                = "all"
+	lintOptionDuplicateRules     = "duplicate-rules"
+	lintOptionLongScrapeInterval = "long-scrape-inerval"
+	lintOptionNone               = "none"
+	checkHealth                  = "/-/healthy"
+	checkReadiness               = "/-/ready"
 )
 
 var lintOptions = []string{lintOptionAll, lintOptionDuplicateRules, lintOptionNone}
@@ -145,6 +146,10 @@ func main() {
 	checkRulesLintFatal := checkRulesCmd.Flag(
 		"lint-fatal",
 		"Make lint errors exit with exit code 3.").Default("false").Bool()
+	checkRulesLintLookbackDelta := checkRulesCmd.Flag(
+		"lint.lookback-delta",
+		"The maximum lookback duration. This config is only used for rules linting checks.",
+	).Default("5m").Duration()
 
 	checkMetricsCmd := checkCmd.Command("metrics", checkMetricsUsage)
 	checkMetricsExtended := checkCmd.Flag("extended", "Print extended information related to the cardinality of the metrics.").Bool()
@@ -341,7 +346,7 @@ func main() {
 		os.Exit(CheckSD(*sdConfigFile, *sdJobName, *sdTimeout, noDefaultScrapePort, prometheus.DefaultRegisterer))
 
 	case checkConfigCmd.FullCommand():
-		os.Exit(CheckConfig(*agentMode, *checkConfigSyntaxOnly, newLintConfig(*checkConfigLint, *checkConfigLintFatal), *configFiles...))
+		os.Exit(CheckConfig(*agentMode, *checkConfigSyntaxOnly, newLintConfig(*checkConfigLint, *checkConfigLintFatal, *checkRulesLintLookbackDelta), *configFiles...))
 
 	case checkServerHealthCmd.FullCommand():
 		os.Exit(checkErr(CheckServerStatus(serverURL, checkHealth, httpRoundTripper)))
@@ -353,7 +358,7 @@ func main() {
 		os.Exit(CheckWebConfig(*webConfigFiles...))
 
 	case checkRulesCmd.FullCommand():
-		os.Exit(CheckRules(newLintConfig(*checkRulesLint, *checkRulesLintFatal), *ruleFiles...))
+		os.Exit(CheckRules(newLintConfig(*checkRulesLint, *checkRulesLintFatal, *checkRulesLintLookbackDelta), *ruleFiles...))
 
 	case checkMetricsCmd.FullCommand():
 		os.Exit(CheckMetrics(*checkMetricsExtended))
@@ -447,15 +452,18 @@ func checkExperimental(f bool) {
 var errLint = fmt.Errorf("lint error")
 
 type lintConfig struct {
-	all            bool
-	duplicateRules bool
-	fatal          bool
+	all                bool
+	duplicateRules     bool
+	fatal              bool
+	longScrapeInterval bool
+	lookbackDelta      model.Duration
 }
 
-func newLintConfig(stringVal string, fatal bool) lintConfig {
+func newLintConfig(stringVal string, fatal bool, lookbackDelta time.Duration) lintConfig {
 	items := strings.Split(stringVal, ",")
 	ls := lintConfig{
-		fatal: fatal,
+		fatal:         fatal,
+		lookbackDelta: model.Duration(lookbackDelta),
 	}
 	for _, setting := range items {
 		switch setting {
@@ -463,6 +471,8 @@ func newLintConfig(stringVal string, fatal bool) lintConfig {
 			ls.all = true
 		case lintOptionDuplicateRules:
 			ls.duplicateRules = true
+		case lintOptionLongScrapeInterval:
+			ls.longScrapeInterval = true
 		case lintOptionNone:
 		default:
 			fmt.Printf("WARNING: unknown lint option %s\n", setting)
@@ -473,6 +483,10 @@ func newLintConfig(stringVal string, fatal bool) lintConfig {
 
 func (ls lintConfig) lintDuplicateRules() bool {
 	return ls.all || ls.duplicateRules
+}
+
+func (ls lintConfig) lintLongScrapeInterval() bool {
+	return ls.all || ls.longScrapeInterval
 }
 
 // CheckServerStatus - healthy & ready.
@@ -518,10 +532,10 @@ func CheckConfig(agentMode, checkSyntaxOnly bool, lintSettings lintConfig, files
 	hasErrors := false
 
 	for _, f := range files {
-		ruleFiles, err := checkConfig(agentMode, f, checkSyntaxOnly)
+		ruleFiles, err := checkConfig(agentMode, f, checkSyntaxOnly, lintSettings)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "  FAILED:", err)
-			hasErrors = true
+			hasErrors = !errors.Is(err, errLint)
 			failed = true
 		} else {
 			if len(ruleFiles) > 0 {
@@ -575,7 +589,7 @@ func checkFileExists(fn string) error {
 	return err
 }
 
-func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]string, error) {
+func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool, lintSettings lintConfig) ([]string, error) {
 	fmt.Println("Checking", filename)
 
 	cfg, err := config.LoadFile(filename, agentMode, false, log.NewNopLogger())
@@ -615,6 +629,12 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 	}
 
 	for _, scfg := range scfgs {
+		if lintSettings.lintLongScrapeInterval() {
+			if scfg.ScrapeInterval >= lintSettings.lookbackDelta {
+				errMessage := fmt.Sprintf("Long Scrape Interval found. Data point will be marked as stale. Job: %s. Interval: %s", scfg.JobName, scfg.ScrapeInterval.String())
+				return nil, fmt.Errorf("%w %s", errLint, errMessage)
+			}
+		}
 		if !checkSyntaxOnly && scfg.HTTPClientConfig.Authorization != nil {
 			if err := checkFileExists(scfg.HTTPClientConfig.Authorization.CredentialsFile); err != nil {
 				return nil, fmt.Errorf("error checking authorization credentials or bearer token file %q: %w", scfg.HTTPClientConfig.Authorization.CredentialsFile, err)

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -226,7 +226,7 @@ func TestCheckTargetConfig(t *testing.T) {
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := checkConfig(false, "testdata/"+test.file, false)
+			_, err := checkConfig(false, "testdata/"+test.file, false, newLintConfig(lintOptionNone, false, 5*time.Minute))
 			if test.err != "" {
 				require.Equalf(t, test.err, err.Error(), "Expected error %q, got %q", test.err, err.Error())
 				return
@@ -309,7 +309,7 @@ func TestCheckConfigSyntax(t *testing.T) {
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := checkConfig(false, "testdata/"+test.file, test.syntaxOnly)
+			_, err := checkConfig(false, "testdata/"+test.file, test.syntaxOnly, newLintConfig(lintOptionNone, false, 5*time.Minute))
 			expectedErrMsg := test.err
 			if strings.Contains(runtime.GOOS, "windows") {
 				expectedErrMsg = test.errWindows
@@ -343,7 +343,7 @@ func TestAuthorizationConfig(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := checkConfig(false, "testdata/"+test.file, false)
+			_, err := checkConfig(false, "testdata/"+test.file, false, newLintConfig(lintOptionNone, false, 5*time.Minute))
 			if test.err != "" {
 				require.Contains(t, err.Error(), test.err, "Expected error to contain %q, got %q", test.err, err.Error())
 				return
@@ -421,7 +421,7 @@ func TestExitCodes(t *testing.T) {
 				t.Run(strconv.FormatBool(lintFatal), func(t *testing.T) {
 					args := []string{"-test.main", "check", "config", "testdata/" + c.file}
 					if lintFatal {
-						args = append(args, "--lint-fatal")
+						args = append(args, "--lint-fatal", "--lint=all")
 					}
 					tool := exec.Command(promtoolPath, args...)
 					err := tool.Run()
@@ -491,7 +491,7 @@ func TestCheckRules(t *testing.T) {
 		defer func(v *os.File) { os.Stdin = v }(os.Stdin)
 		os.Stdin = r
 
-		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, false))
+		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, false, 5*time.Minute))
 		require.Equal(t, successExitCode, exitCode, "")
 	})
 
@@ -513,7 +513,7 @@ func TestCheckRules(t *testing.T) {
 		defer func(v *os.File) { os.Stdin = v }(os.Stdin)
 		os.Stdin = r
 
-		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, false))
+		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, false, 5*time.Minute))
 		require.Equal(t, failureExitCode, exitCode, "")
 	})
 
@@ -535,24 +535,49 @@ func TestCheckRules(t *testing.T) {
 		defer func(v *os.File) { os.Stdin = v }(os.Stdin)
 		os.Stdin = r
 
-		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, true))
+		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, true, 5*time.Minute))
 		require.Equal(t, lintErrExitCode, exitCode, "")
 	})
+
+	for _, c := range []struct {
+		lookbackDelta  time.Duration
+		expectedErrMsg string
+	}{
+		{
+			lookbackDelta:  5 * time.Minute,
+			expectedErrMsg: "lint error Long Scrape Interval found. Data point will be marked as stale. Job: long_scrape_interval_test. Interval: 10m",
+		},
+		{
+			lookbackDelta:  20 * time.Minute,
+			expectedErrMsg: "",
+		},
+	} {
+		t.Run("config-lint-fatal", func(t *testing.T) {
+			_, err := checkConfig(false, "./testdata/prometheus-config.lint.yml", false, newLintConfig(lintOptionLongScrapeInterval, false, c.lookbackDelta))
+			var errMsg string
+			if err != nil {
+				errMsg = err.Error()
+			} else {
+				errMsg = ""
+			}
+			require.Equalf(t, c.expectedErrMsg, errMsg, "Expected error %q, got %q", c.expectedErrMsg, errMsg)
+		})
+	}
 }
 
 func TestCheckRulesWithRuleFiles(t *testing.T) {
 	t.Run("rules-good", func(t *testing.T) {
-		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, false), "./testdata/rules.yml")
+		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, false, 5*time.Minute), "./testdata/rules.yml")
 		require.Equal(t, successExitCode, exitCode, "")
 	})
 
 	t.Run("rules-bad", func(t *testing.T) {
-		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, false), "./testdata/rules-bad.yml")
+		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, false, 5*time.Minute), "./testdata/rules-bad.yml")
 		require.Equal(t, failureExitCode, exitCode, "")
 	})
 
 	t.Run("rules-lint-fatal", func(t *testing.T) {
-		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, true), "./testdata/prometheus-rules.lint.yml")
+		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, true, 5*time.Minute), "./testdata/prometheus-rules.lint.yml")
 		require.Equal(t, lintErrExitCode, exitCode, "")
 	})
 }

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -553,7 +553,7 @@ func TestCheckRules(t *testing.T) {
 		},
 	} {
 		t.Run("config-lint-fatal", func(t *testing.T) {
-			_, err := checkConfig(false, "./testdata/prometheus-config.lint.yml", false, newLintConfig(lintOptionLongScrapeInterval, false, c.lookbackDelta))
+			_, err := checkConfig(false, "./testdata/prometheus-config.lint.long_scrape_interval.yml", false, newLintConfig(lintOptionLongScrapeInterval, false, c.lookbackDelta))
 			var errMsg string
 			if err != nil {
 				errMsg = err.Error()

--- a/cmd/promtool/testdata/prometheus-config.lint.long_scrape_interval.yml
+++ b/cmd/promtool/testdata/prometheus-config.lint.long_scrape_interval.yml
@@ -1,0 +1,3 @@
+scrape_configs:
+  - job_name: long_scrape_interval_test
+    scrape_interval: 10m

--- a/cmd/promtool/testdata/prometheus-config.lint.yml
+++ b/cmd/promtool/testdata/prometheus-config.lint.yml
@@ -1,2 +1,3 @@
-rule_files:
-  - prometheus-rules.lint.yml
+scrape_configs:
+  - job_name: long_scrape_interval_test
+    scrape_interval: 10m

--- a/cmd/promtool/testdata/prometheus-config.lint.yml
+++ b/cmd/promtool/testdata/prometheus-config.lint.yml
@@ -1,3 +1,2 @@
-scrape_configs:
-  - job_name: long_scrape_interval_test
-    scrape_interval: 10m
+rule_files:
+  - prometheus-rules.lint.yml

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -102,7 +102,8 @@ Check if the config files are valid or not.
 | Flag | Description | Default |
 | --- | --- | --- |
 | <code class="text-nowrap">--syntax-only</code> | Only check the config file syntax, ignoring file and content validation referenced in the config |  |
-| <code class="text-nowrap">--lint</code> | Linting checks to apply to the rules specified in the config. Available options are: all, duplicate-rules, none. Use --lint=none to disable linting | `duplicate-rules` |
+| <code class="text-nowrap">--lint</code> | Linting checks to apply to the rules specified in the config. Available options are: all, duplicate-rules, none, long-scrape-interval. Use --lint=none to disable linting | `duplicate-rules` |
+| <code class="text-nowrap">--lint.lookback-delta</code> | The maximum lookback duration. This config is only used for config linting checks. | `5m` |
 | <code class="text-nowrap">--lint-fatal</code> | Make lint errors exit with exit code 3. | `false` |
 | <code class="text-nowrap">--agent</code> | Check config file for Prometheus in Agent mode. |  |
 
@@ -177,7 +178,6 @@ Check if the rule files are valid or not.
 | --- | --- | --- |
 | <code class="text-nowrap">--lint</code> | Linting checks to apply. Available options are: all, duplicate-rules, none. Use --lint=none to disable linting | `duplicate-rules` |
 | <code class="text-nowrap">--lint-fatal</code> | Make lint errors exit with exit code 3. | `false` |
-| <code class="text-nowrap">--lint.lookback-delta</code> | The maximum lookback duration. This config is only used for rules linting checks. | `5m` |
 
 
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -177,6 +177,7 @@ Check if the rule files are valid or not.
 | --- | --- | --- |
 | <code class="text-nowrap">--lint</code> | Linting checks to apply. Available options are: all, duplicate-rules, none. Use --lint=none to disable linting | `duplicate-rules` |
 | <code class="text-nowrap">--lint-fatal</code> | Make lint errors exit with exit code 3. | `false` |
+| <code class="text-nowrap">--lint.lookback-delta</code> | The maximum lookback duration. This config is only used for rules linting checks. | `5m` |
 
 
 


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/10263

Support scrape interval lint checking in PromTool.
Add a flag to set the look back duration for linting check.