### PR TITLE
PromQL: add annotations for short ranges in rate like functions

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -120,7 +120,9 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 			prevValue = currPoint.F
 		}
 	default:
-		// TODO: add RangeTooShortWarning
+		var newAnnos annotations.Annotations
+		newAnnos.Add(annotations.RangeTooShortWarning)
+		annos.Merge(newAnnos)
 		return enh.Out, annos
 	}
 

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -134,6 +134,7 @@ var (
 	PromQLInfo    = errors.New("PromQL info")
 	PromQLWarning = errors.New("PromQL warning")
 
+	RangeTooShortWarning                       = fmt.Errorf("%w: range too short, some series have been dropped because the range contained too few samples to calculate an extrapolated rate", PromQLWarning)
 	InvalidRatioWarning                        = fmt.Errorf("%w: ratio value should be between -1 and 1", PromQLWarning)
 	InvalidQuantileWarning                     = fmt.Errorf("%w: quantile value should be between 0 and 1", PromQLWarning)
 	BadBucketLabelWarning                      = fmt.Errorf("%w: bucket label %q is missing or has a malformed value", PromQLWarning, model.BucketLabel)


### PR DESCRIPTION
Right now if we have a query like `sum(rate(X[2m]))` its not obvious to the user that some series that are aggregated might just be missing. As an operator I get complaints about that every now and then. This warning might help guiding the user to a fix i hope. 
There is the caveat that this will fire if a series gets stale during a range query, not sure if that can be improved.

Screenshot of an earlier version:
![image](https://github.com/user-attachments/assets/009da1d4-49c1-473e-abed-09594deb4b17)
