### PR TITLE
fix(storage/mergeQuerier): fix a data race

### DIFF
--- a/storage/merge.go
+++ b/storage/merge.go
@@ -155,19 +155,16 @@ func (q *mergeGenericQuerier) Select(ctx context.Context, sortSeries bool, hints
 	for _, querier := range q.queriers {
 		// copy the matchers as some queriers may alter the slice.
 		// See https://github.com/prometheus/prometheus/issues/14723
-		// matchersCopy := make([]*labels.Matcher, len(matchers))
-		// copy(matchersCopy, matchers)
+		matchersCopy := make([]*labels.Matcher, len(matchers))
+		copy(matchersCopy, matchers)
 
 		wg.Add(1)
-		go func(qr genericQuerier) {
-			// go func(qr genericQuerier, m []*labels.Matcher) {
+		go func(qr genericQuerier, m []*labels.Matcher) {
 			defer wg.Done()
 
 			// We need to sort for NewMergeSeriesSet to work.
-			// seriesSetChan <- qr.Select(ctx, true, hints, m...)
-			seriesSetChan <- qr.Select(ctx, true, hints, matchers...)
-		}(querier)
-		// }(querier, matchersCopy)
+			seriesSetChan <- qr.Select(ctx, true, hints, m...)
+		}(querier, matchersCopy)
 	}
 	go func() {
 		wg.Wait()

--- a/storage/merge.go
+++ b/storage/merge.go
@@ -153,13 +153,21 @@ func (q *mergeGenericQuerier) Select(ctx context.Context, sortSeries bool, hints
 	)
 	// Schedule all Selects for all queriers we know about.
 	for _, querier := range q.queriers {
+		// copy the matchers as some queriers may alter the slice.
+		// See https://github.com/prometheus/prometheus/issues/14723
+		// matchersCopy := make([]*labels.Matcher, len(matchers))
+		// copy(matchersCopy, matchers)
+
 		wg.Add(1)
 		go func(qr genericQuerier) {
+			// go func(qr genericQuerier, m []*labels.Matcher) {
 			defer wg.Done()
 
 			// We need to sort for NewMergeSeriesSet to work.
+			// seriesSetChan <- qr.Select(ctx, true, hints, m...)
 			seriesSetChan <- qr.Select(ctx, true, hints, matchers...)
 		}(querier)
+		// }(querier, matchersCopy)
 	}
 	go func() {
 		wg.Wait()


### PR DESCRIPTION
fixes https://github.com/prometheus/prometheus/issues/14723


<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
