### PR TITLE
api: Improve doc comments for v1.MinTime and v1.MaxTime

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -824,12 +824,29 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 }
 
 var (
-	// MinTime is the default timestamp used for the begin of optional time ranges.
-	// Exposed to let downstream projects to reference it.
+	// MinTime is the default timestamp used for the start of optional time ranges.
+	// Exposed to let downstream projects reference it.
+	//
+	// The offset used here (62135596801) is inspired by the difference in
+	// seconds between the Unix time zero point (1970-01-01 00:00:00 UTC)
+	// and the Go time zero point (0001-01-01 00:00:00 UTC, following the
+	// Gregorian calendar), which is 62135596800 seconds. The offset is used
+	// to avoid overflow/underflow of an int64 when converting back to
+	// "milliseconds since Unix time epoch", which is what we use as the
+	// timestamp in Prometheus. However, the offset is in fact not needed
+	// for MinTime. It was introduced here in the past by accident, and we
+	// don't want to change the (exported!) MinTime value now. The value is
+	// still low enough for all practical purposes.
 	MinTime = time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
 
 	// MaxTime is the default timestamp used for the end of optional time ranges.
 	// Exposed to let downstream projects to reference it.
+	//
+	// See the note about the offset (62135596801) above, with the
+	// additional note that an offset is indeed needed in this case to avoid
+	// an overflow, but -1 would be sufficient (or alternatively, we could
+	// set the nsec argument to zero). Again, we don't want to change
+	// anything now, as the value is high enough for all practical purposes.
 	MaxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
 
 	minTimeFormatted = MinTime.Format(time.RFC3339Nano)

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -827,26 +827,19 @@ var (
 	// MinTime is the default timestamp used for the start of optional time ranges.
 	// Exposed to let downstream projects reference it.
 	//
-	// The offset used here (62135596801) is inspired by the difference in
-	// seconds between the Unix time zero point (1970-01-01 00:00:00 UTC)
-	// and the Go time zero point (0001-01-01 00:00:00 UTC, following the
-	// Gregorian calendar), which is 62135596800 seconds. The offset is used
-	// to avoid overflow/underflow of an int64 when converting back to
-	// "milliseconds since Unix time epoch", which is what we use as the
-	// timestamp in Prometheus. However, the offset is in fact not needed
-	// for MinTime. It was introduced here in the past by accident, and we
-	// don't want to change the (exported!) MinTime value now. The value is
-	// still low enough for all practical purposes.
+	// Historical note: This should just be time.Unix(math.MinInt64/1000, 0).UTC(),
+	// but it was set to a higher value in the past due to a misunderstanding.
+	// The value is still low enough for practical purposes, so we don't want
+	// to change it now, avoiding confusion for importers of this variable.
 	MinTime = time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
 
 	// MaxTime is the default timestamp used for the end of optional time ranges.
 	// Exposed to let downstream projects to reference it.
 	//
-	// See the note about the offset (62135596801) above, with the
-	// additional note that an offset is indeed needed in this case to avoid
-	// an overflow, but -1 would be sufficient (or alternatively, we could
-	// set the nsec argument to zero). Again, we don't want to change
-	// anything now, as the value is high enough for all practical purposes.
+	// Historical note: This should just be time.Unix(math.MaxInt64/1000, 0).UTC(),
+	// but it was set to a lower value in the past due to a misunderstanding.
+	// The value is still high enough for practical purposes, so we don't want
+	// to change it now, avoiding confusion for importers of this variable.
 	MaxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
 
 	minTimeFormatted = MinTime.Format(time.RFC3339Nano)


### PR DESCRIPTION
While investigated something mostly unrelated, I got nerd-sniped by the calculation of v1.MinTime and v1.MaxTime. The seemingly magic number in there (62135596801) needed an explanation. While looking for it, I found out that the offsets used here are actually needlessly conservative. Since the timestamps are so far in the past or future, respectively, there is no practical impact. Just that the calculation is needlessly obfuscated. However, we won't change the values now to not cause any confusion for users of this code. Still, I think the doc comment should explain the circumstances so nobody gets nerd-sniped again as I did today.

BTW, this is ancient code, see https://github.com/prometheus/prometheus/commit/157e6989588479b53daeb4fd1418bc245e831108 . So maybe there was a good reason to use these weird values. Or maybe I'm missing something. Reviewers, please tell me if you see a fault in my rationale.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
