### PR TITLE
[REFACTOR] PromQL: remove label_join and label_replace stubs

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1514,11 +1514,6 @@ func (ev *evaluator) evalLabelReplace(ctx context.Context, args parser.Expressio
 	return matrix, ws
 }
 
-// === label_replace(Vector parser.ValueTypeVector, dst_label, replacement, src_labelname, regex parser.ValueTypeString) (Vector, Annotations) ===
-func funcLabelReplace(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
-	panic("funcLabelReplace wrong implementation called")
-}
-
 // === Vector(s Scalar) (Vector, Annotations) ===
 func funcVector(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
 	return append(enh.Out,
@@ -1568,11 +1563,6 @@ func (ev *evaluator) evalLabelJoin(ctx context.Context, args parser.Expressions)
 	}
 
 	return matrix, ws
-}
-
-// === label_join(vector model.ValVector, dest_labelname, separator, src_labelname...) (Vector, Annotations) ===
-func funcLabelJoin(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
-	panic("funcLabelReplace wrong implementation called")
 }
 
 // Common code for date related functions.
@@ -1696,8 +1686,8 @@ var FunctionCalls = map[string]FunctionCall{
 	"idelta":                       funcIdelta,
 	"increase":                     funcIncrease,
 	"irate":                        funcIrate,
-	"label_replace":                funcLabelReplace,
-	"label_join":                   funcLabelJoin,
+	"label_replace":                nil, // evalLabelReplace not called via this map.
+	"label_join":                   nil, // evalLabelJoin not called via this map.
 	"ln":                           funcLn,
 	"log10":                        funcLog10,
 	"log2":                         funcLog2,


### PR DESCRIPTION
`label_join` and `label_replace` operate on whole series, not on samples, so they do not fit into the table of functions that return a Vector. Remove the stub entries that were left to help downstream users of the code identify what changed.

We cannot remove the entries from the `FunctionCalls` map without breaking `TestFunctionList`, so put some nils in to keep it happy.

H/T to #14495 for noticing that the panic message was wrong on one stub.
