### PR TITLE
[release 2.55] fix(autoreload): Reload invalid yaml files (backport #14947)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 2.55.0-rc.0 / 2024-09-20
 
 * [FEATURE] Support UTF-8 characters in label names - feature flag `utf8-names`. #14482, #14880, #14736, #14727
-* [FEATURE] Support config reload automatically - feature flag `auto-reload-config`. #14769
+* [FEATURE] Support config reload automatically - feature flag `auto-reload-config`. #14769, #14947
 * [FEATURE] Scraping: Add the ability to set custom `http_headers` in config. #14817
 * [FEATURE] Scraping: Support feature flag `created-timestamp-zero-ingestion` in OpenMetrics. #14356, #14815
 * [FEATURE] Scraping: `scrape_failure_log_file` option to log failures to a file. #14734

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1188,9 +1188,7 @@ func main() {
 						currentChecksum, err := config.GenerateChecksum(cfg.configFile)
 						if err != nil {
 							level.Error(logger).Log("msg", "Failed to generate checksum during configuration reload", "err", err)
-							continue
-						}
-						if currentChecksum == checksum {
+						} else if currentChecksum == checksum {
 							continue
 						}
 						level.Info(logger).Log("msg", "Configuration file change detected, reloading the configuration.")


### PR DESCRIPTION
When a YAML file is invalid, trigger auto-reload anyway so that user is aware that the configuration file is incorrect.

Failing to do so does not change the reload status in metrics and api.

[Backport of #14947]