### PR TITLE
Remove default port from URL

### DIFF
--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -643,3 +643,154 @@ func TestMaxSchemaAppender(t *testing.T) {
 		}
 	}
 }
+
+func TestTarget_URL(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      *Target
+		expectedURL string
+	}{
+		{
+			name: "IPv4 address with http and port 80",
+			target: &Target{
+				params: map[string][]string{},
+				labels: labels.FromMap(map[string]string{
+					model.SchemeLabel:      "http",
+					model.AddressLabel:     "192.168.1.1:80",
+					model.MetricsPathLabel: "/metrics",
+				}),
+			},
+			expectedURL: "http://192.168.1.1/metrics",
+		},
+		{
+			name: "IPv4 address with https and port 443",
+			target: &Target{
+				params: map[string][]string{},
+				labels: labels.FromMap(map[string]string{
+					model.SchemeLabel:      "https",
+					model.AddressLabel:     "192.168.1.1:443",
+					model.MetricsPathLabel: "/metrics",
+				}),
+			},
+			expectedURL: "https://192.168.1.1/metrics",
+		},
+		{
+			name: "IPv4 address with http and non-default port",
+			target: &Target{
+				params: map[string][]string{},
+				labels: labels.FromMap(map[string]string{
+					model.SchemeLabel:      "http",
+					model.AddressLabel:     "192.168.1.1:8080",
+					model.MetricsPathLabel: "/metrics",
+				}),
+			},
+			expectedURL: "http://192.168.1.1:8080/metrics",
+		},
+		{
+			name: "IPv4 address with https and non-default port",
+			target: &Target{
+				params: map[string][]string{},
+				labels: labels.FromMap(map[string]string{
+					model.SchemeLabel:      "http",
+					model.AddressLabel:     "192.168.1.1:8443",
+					model.MetricsPathLabel: "/metrics",
+				}),
+			},
+			expectedURL: "http://192.168.1.1:8443/metrics",
+		},
+		{
+			name: "IPv6 address with http and port 80",
+			target: &Target{
+				params: map[string][]string{},
+				labels: labels.FromMap(map[string]string{
+					model.SchemeLabel:      "http",
+					model.AddressLabel:     "[2001:db8::1]:80",
+					model.MetricsPathLabel: "/metrics",
+				}),
+			},
+			expectedURL: "http://2001:db8::1/metrics",
+		},
+		{
+			name: "IPv6 address with https and port 80",
+			target: &Target{
+				params: map[string][]string{},
+				labels: labels.FromMap(map[string]string{
+					model.SchemeLabel:      "https",
+					model.AddressLabel:     "[2001:db8::1]:80",
+					model.MetricsPathLabel: "/metrics",
+				}),
+			},
+			expectedURL: "https://[2001:db8::1]:80/metrics",
+		},
+		{
+			name: "IPv6 address with https and port 443",
+			target: &Target{
+				params: map[string][]string{},
+				labels: labels.FromMap(map[string]string{
+					model.SchemeLabel:      "https",
+					model.AddressLabel:     "[2001:db8::1]:443",
+					model.MetricsPathLabel: "/metrics",
+				}),
+			},
+			expectedURL: "https://2001:db8::1/metrics",
+		},
+		{
+			name: "IPv6 address with http and non-default port",
+			target: &Target{
+				params: map[string][]string{},
+				labels: labels.FromMap(map[string]string{
+					model.SchemeLabel:      "http",
+					model.AddressLabel:     "[2001:db8::1]:8080",
+					model.MetricsPathLabel: "/metrics",
+				}),
+			},
+			expectedURL: "http://[2001:db8::1]:8080/metrics",
+		},
+		{
+			name: "IPv4 address without a port",
+			target: &Target{
+				params: map[string][]string{},
+				labels: labels.FromMap(map[string]string{
+					model.SchemeLabel:      "http",
+					model.AddressLabel:     "192.168.1.1",
+					model.MetricsPathLabel: "/metrics",
+				}),
+			},
+			expectedURL: "http://192.168.1.1/metrics",
+		},
+		{
+			name: "IPv6 address without a port",
+			target: &Target{
+				params: map[string][]string{},
+				labels: labels.FromMap(map[string]string{
+					model.SchemeLabel:      "http",
+					model.AddressLabel:     "[2001:db8::1]",
+					model.MetricsPathLabel: "/metrics",
+				}),
+			},
+			expectedURL: "http://[2001:db8::1]/metrics",
+		},
+		{
+			name: "IPv4 with additional params",
+			target: &Target{
+				params: map[string][]string{
+					"key1": {"value1"},
+					"key2": {"value2"},
+				},
+				labels: labels.FromMap(map[string]string{
+					model.SchemeLabel:      "http",
+					model.AddressLabel:     "192.168.1.1:8080",
+					model.MetricsPathLabel: "/metrics",
+				}),
+			},
+			expectedURL: "http://192.168.1.1:8080/metrics?key1=value1&key2=value2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualURL := tt.target.URL()
+			require.Equal(t, tt.expectedURL, actualURL.String())
+		})
+	}
+}


### PR DESCRIPTION
This commit modifies the URL construction logic by stripping default ports (80 for HTTP and 443 for HTTPS) from the URL, keeping the port information in the `__address__` label. This change simplifies the URL representation while maintaining the necessary port details separately.

The feature flag that was removed also changed the `__address__` label, while this pull request doesn't change it.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
