### PR TITLE
Allow blank issue reports again

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Prometheus Community Support
     url: https://prometheus.io/community/


### PR DESCRIPTION
I frequently find myself in the situation where the standard bug issue template fields are all irrelevant for what I want to report, and then I have to first shoehorn my info into the template somehow, save the issue, edit it, and remove all the unnecessary parts. This demotivates me from filing casual issues, e.g. when I see a CI test fail. We should have a way of still filing custom issues without all the templatey bits.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
