### PR TITLE
docs: Querying basics: remove what can be graphed

### DIFF
--- a/docs/querying/basics.md
+++ b/docs/querying/basics.md
@@ -35,8 +35,9 @@ evaluate to one of four types:
 
 Depending on the use-case (e.g. when graphing vs. displaying the output of an
 expression), only some of these types are legal as the result of a
-user-specified expression. For example, an expression that returns an instant
-vector is the only type which can be graphed.
+user-specified expression. 
+For [instant queries](api.md#instant-queries), any of the above data types are allowed as the root of the expression.
+[Range queries](api.md/#range-queries) only support scalar-typed and instant-vector-typed expressions.
 
 _Notes about the experimental native histograms:_
 


### PR DESCRIPTION
Put a scalar to query, it can be graphed.

And also, the range-queries, which used for graph, always returns a range vector https://promlabs.com/blog/2020/06/18/the-anatomy-of-a-promql-query/#range-queries.

So the doc says "an expression that returns an instant vector is the only type which can be graphed." is not correct?
it's confusing to read the statement, hence, remove it.
