### PR TITLE
storage: require selectors to always return matching results

### DIFF
--- a/docs/querying/remote_read_api.md
+++ b/docs/querying/remote_read_api.md
@@ -17,7 +17,8 @@ Request are made to the following endpoint.
 
 ### Samples
 
-This returns a message that includes a list of raw samples.
+This returns a message that includes a list of raw samples matching the 
+requested query.
 
 ### Streamed Chunks
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -114,6 +114,8 @@ type Querier interface {
 	LabelQuerier
 
 	// Select returns a set of series that matches the given label matchers.
+	// Results are not checked whether they match. Results that do not match
+	// may cause undefined behavior.
 	// Caller can specify if it requires returned series to be sorted. Prefer not requiring sorting for better performance.
 	// It allows passing hints that can help in optimising select, but it's up to implementation how this is used if used at all.
 	Select(ctx context.Context, sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) SeriesSet
@@ -152,6 +154,8 @@ type ChunkQuerier interface {
 	LabelQuerier
 
 	// Select returns a set of series that matches the given label matchers.
+	// Results are not checked whether they match. Results that do not match
+	// may cause undefined behavior.
 	// Caller can specify if it requires returned series to be sorted. Prefer not requiring sorting for better performance.
 	// It allows passing hints that can help in optimising select, but it's up to implementation how this is used if used at all.
 	Select(ctx context.Context, sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) ChunkSeriesSet


### PR DESCRIPTION
This seeks to address https://github.com/prometheus/prometheus/issues/13586.

Does the `ExemplarQuerier` interface need a similar hint?

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
