### PR TITLE
textparse: Refactored main testing utils for reusability; fixed proto Units.

### DIFF
--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -69,6 +69,8 @@ type Parser interface {
 	// CreatedTimestamp returns the created timestamp (in milliseconds) for the
 	// current sample. It returns nil if it is unknown e.g. if it wasn't set,
 	// if the scrape protocol or metric type does not support created timestamps.
+	// Assume the CreatedTimestamp returned pointer is only valid until
+	// the Next iteration.
 	CreatedTimestamp() *int64
 
 	// Next advances the parser to the next sample.

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -14,11 +14,18 @@
 package textparse
 
 import (
+	"errors"
+	"io"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/util/testutil"
 )
 
 func TestNewParser(t *testing.T) {
@@ -102,4 +109,94 @@ func TestNewParser(t *testing.T) {
 			}
 		})
 	}
+}
+
+// parsedEntry represents data that is parsed for each entry.
+type parsedEntry struct {
+	// In all but EntryComment, EntryInvalid.
+	m string
+
+	// In EntryHistogram.
+	shs *histogram.Histogram
+	fhs *histogram.FloatHistogram
+
+	// In EntrySeries.
+	v float64
+
+	// In EntrySeries and EntryHistogram.
+	lset labels.Labels
+	t    *int64
+	es   []exemplar.Exemplar
+	ct   *int64
+
+	// In EntryType.
+	typ model.MetricType
+	// In EntryHelp.
+	help string
+	// In EntryUnit.
+	unit string
+	// In EntryComment.
+	comment string
+}
+
+func requireEntries(t *testing.T, exp, got []parsedEntry) {
+	t.Helper()
+
+	testutil.RequireEqualWithOptions(t, exp, got, []cmp.Option{
+		cmp.AllowUnexported(parsedEntry{}),
+	})
+}
+
+func testParse(t *testing.T, p Parser) (ret []parsedEntry) {
+	t.Helper()
+
+	for {
+		et, err := p.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+
+		var got parsedEntry
+		var m []byte
+		switch et {
+		case EntryInvalid:
+			t.Fatal("entry invalid not expected")
+		case EntrySeries, EntryHistogram:
+			if et == EntrySeries {
+				m, got.t, got.v = p.Series()
+				got.m = string(m)
+			} else {
+				m, got.t, got.shs, got.fhs = p.Histogram()
+				got.m = string(m)
+			}
+
+			p.Metric(&got.lset)
+			for e := (exemplar.Exemplar{}); p.Exemplar(&e); {
+				got.es = append(got.es, e)
+			}
+			// Parser reuses int pointer.
+			if ct := p.CreatedTimestamp(); ct != nil {
+				got.ct = int64p(*ct)
+			}
+		case EntryType:
+			m, got.typ = p.Type()
+			got.m = string(m)
+
+		case EntryHelp:
+			m, h := p.Help()
+			got.m = string(m)
+			got.help = string(h)
+
+		case EntryUnit:
+			m, u := p.Unit()
+			got.m = string(m)
+			got.unit = string(u)
+
+		case EntryComment:
+			got.comment = string(p.Comment())
+		}
+		ret = append(ret, got)
+	}
+	return ret
 }

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -14,7 +14,6 @@
 package textparse
 
 import (
-	"errors"
 	"io"
 	"testing"
 
@@ -115,7 +114,7 @@ foobar{quantile="0.99"} 150.1`
 	input += "\nnull_byte_metric{a=\"abc\x00\"} 1"
 	input += "\n# EOF\n"
 
-	exp := []expectedParse{
+	exp := []parsedEntry{
 		{
 			m:    "go_gc_duration_seconds",
 			help: "A summary of the GC invocation durations.",
@@ -190,12 +189,16 @@ foobar{quantile="0.99"} 150.1`
 			m:    `hhh_bucket{le="+Inf"}`,
 			v:    1,
 			lset: labels.FromStrings("__name__", "hhh_bucket", "le", "+Inf"),
-			e:    &exemplar.Exemplar{Labels: labels.FromStrings("id", "histogram-bucket-test"), Value: 4},
+			es: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("id", "histogram-bucket-test"), Value: 4},
+			},
 		}, {
 			m:    `hhh_count`,
 			v:    1,
 			lset: labels.FromStrings("__name__", "hhh_count"),
-			e:    &exemplar.Exemplar{Labels: labels.FromStrings("id", "histogram-count-test"), Value: 4},
+			es: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("id", "histogram-count-test"), Value: 4},
+			},
 		}, {
 			m:   "ggh",
 			typ: model.MetricTypeGaugeHistogram,
@@ -203,12 +206,16 @@ foobar{quantile="0.99"} 150.1`
 			m:    `ggh_bucket{le="+Inf"}`,
 			v:    1,
 			lset: labels.FromStrings("__name__", "ggh_bucket", "le", "+Inf"),
-			e:    &exemplar.Exemplar{Labels: labels.FromStrings("id", "gaugehistogram-bucket-test", "xx", "yy"), Value: 4, HasTs: true, Ts: 123123},
+			es: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("id", "gaugehistogram-bucket-test", "xx", "yy"), Value: 4, HasTs: true, Ts: 123123},
+			},
 		}, {
 			m:    `ggh_count`,
 			v:    1,
 			lset: labels.FromStrings("__name__", "ggh_count"),
-			e:    &exemplar.Exemplar{Labels: labels.FromStrings("id", "gaugehistogram-count-test", "xx", "yy"), Value: 4, HasTs: true, Ts: 123123},
+			es: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("id", "gaugehistogram-count-test", "xx", "yy"), Value: 4, HasTs: true, Ts: 123123},
+			},
 		}, {
 			m:   "smr_seconds",
 			typ: model.MetricTypeSummary,
@@ -216,12 +223,16 @@ foobar{quantile="0.99"} 150.1`
 			m:    `smr_seconds_count`,
 			v:    2,
 			lset: labels.FromStrings("__name__", "smr_seconds_count"),
-			e:    &exemplar.Exemplar{Labels: labels.FromStrings("id", "summary-count-test"), Value: 1, HasTs: true, Ts: 123321},
+			es: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("id", "summary-count-test"), Value: 1, HasTs: true, Ts: 123321},
+			},
 		}, {
 			m:    `smr_seconds_sum`,
 			v:    42,
 			lset: labels.FromStrings("__name__", "smr_seconds_sum"),
-			e:    &exemplar.Exemplar{Labels: labels.FromStrings("id", "summary-sum-test"), Value: 1, HasTs: true, Ts: 123321},
+			es: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("id", "summary-sum-test"), Value: 1, HasTs: true, Ts: 123321},
+			},
 		}, {
 			m:   "ii",
 			typ: model.MetricTypeInfo,
@@ -270,15 +281,19 @@ foobar{quantile="0.99"} 150.1`
 			v:    17,
 			lset: labels.FromStrings("__name__", "foo_total"),
 			t:    int64p(1520879607789),
-			e:    &exemplar.Exemplar{Labels: labels.FromStrings("id", "counter-test"), Value: 5},
-			ct:   int64p(1520872607123),
+			es: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("id", "counter-test"), Value: 5},
+			},
+			ct: int64p(1520872607123),
 		}, {
 			m:    `foo_total{a="b"}`,
 			v:    17.0,
 			lset: labels.FromStrings("__name__", "foo_total", "a", "b"),
 			t:    int64p(1520879607789),
-			e:    &exemplar.Exemplar{Labels: labels.FromStrings("id", "counter-test"), Value: 5},
-			ct:   int64p(1520872607123),
+			es: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("id", "counter-test"), Value: 5},
+			},
+			ct: int64p(1520872607123),
 		}, {
 			m:    "bar",
 			help: "Summary with CT at the end, making sure we find CT even if it's multiple lines a far",
@@ -430,7 +445,8 @@ foobar{quantile="0.99"} 150.1`
 	}
 
 	p := NewOpenMetricsParser([]byte(input), labels.NewSymbolTable(), WithOMParserCTSeriesSkipped())
-	checkParseResultsWithCT(t, p, exp, true)
+	got := testParse(t, p)
+	requireEntries(t, exp, got)
 }
 
 func TestUTF8OpenMetricsParse(t *testing.T) {
@@ -455,7 +471,7 @@ func TestUTF8OpenMetricsParse(t *testing.T) {
 
 	input += "\n# EOF\n"
 
-	exp := []expectedParse{
+	exp := []parsedEntry{
 		{
 			m:    "go.gc_duration_seconds",
 			help: "A summary of the GC invocation durations.",
@@ -504,7 +520,8 @@ choices}`, "strange©™\n'quoted' \"name\"", "6"),
 	}
 
 	p := NewOpenMetricsParser([]byte(input), labels.NewSymbolTable(), WithOMParserCTSeriesSkipped())
-	checkParseResultsWithCT(t, p, exp, true)
+	got := testParse(t, p)
+	requireEntries(t, exp, got)
 }
 
 func TestOpenMetricsParseErrors(t *testing.T) {
@@ -878,8 +895,8 @@ func TestOMNullByteHandling(t *testing.T) {
 	}
 }
 
-// While not desirable, there are cases were CT fails to parse and
-// these tests show them.
+// TestCTParseFailures tests known failure edge cases, we know does not work due
+// current OM spec limitations or clients with broken OM format.
 // TODO(maniktherana): Make sure OM 1.1/2.0 pass CT via metadata or exemplar-like to avoid this.
 func TestCTParseFailures(t *testing.T) {
 	input := `# HELP thing Histogram with _created as first line
@@ -892,68 +909,37 @@ thing_bucket{le="+Inf"} 17`
 
 	input += "\n# EOF\n"
 
-	int64p := func(x int64) *int64 { return &x }
-
-	type expectCT struct {
-		m     string
-		ct    *int64
-		typ   model.MetricType
-		help  string
-		isErr bool
-	}
-
-	exp := []expectCT{
+	exp := []parsedEntry{
 		{
-			m:     "thing",
-			help:  "Histogram with _created as first line",
-			isErr: false,
+			m:    "thing",
+			help: "Histogram with _created as first line",
 		}, {
-			m:     "thing",
-			typ:   model.MetricTypeHistogram,
-			isErr: false,
+			m:   "thing",
+			typ: model.MetricTypeHistogram,
 		}, {
-			m:     `thing_count`,
-			ct:    int64p(1520872607123),
-			isErr: true,
+			m:  `thing_count`,
+			ct: nil, // Should be int64p(1520872607123).
 		}, {
-			m:     `thing_sum`,
-			ct:    int64p(1520872607123),
-			isErr: true,
+			m:  `thing_sum`,
+			ct: nil, // Should be int64p(1520872607123).
 		}, {
-			m:     `thing_bucket{le="0.0"}`,
-			ct:    int64p(1520872607123),
-			isErr: true,
+			m:  `thing_bucket{le="0.0"}`,
+			ct: nil, // Should be int64p(1520872607123).
 		}, {
-			m:     `thing_bucket{le="+Inf"}`,
-			ct:    int64p(1520872607123),
-			isErr: true,
+			m:  `thing_bucket{le="+Inf"}`,
+			ct: nil, // Should be int64p(1520872607123),
 		},
 	}
 
 	p := NewOpenMetricsParser([]byte(input), labels.NewSymbolTable(), WithOMParserCTSeriesSkipped())
-	i := 0
+	got := testParse(t, p)
+	resetValAndLset(got) // Keep this test focused on metric, basic entries and CT only.
+	requireEntries(t, exp, got)
+}
 
-	var res labels.Labels
-	for {
-		et, err := p.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		require.NoError(t, err)
-
-		switch et {
-		case EntrySeries:
-			p.Metric(&res)
-
-			if ct := p.CreatedTimestamp(); exp[i].isErr {
-				require.Nil(t, ct)
-			} else {
-				require.Equal(t, *exp[i].ct, *ct)
-			}
-		default:
-			i++
-			continue
-		}
-		i++
+func resetValAndLset(e []parsedEntry) {
+	for i := range e {
+		e[i].v = 0
+		e[i].lset = labels.EmptyLabels()
 	}
 }

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -457,6 +457,12 @@ func (p *ProtobufParser) Next() (Entry, error) {
 
 		p.state = EntryHelp
 	case EntryHelp:
+		if p.mf.Unit != "" {
+			p.state = EntryUnit
+		} else {
+			p.state = EntryType
+		}
+	case EntryUnit:
 		p.state = EntryType
 	case EntryType:
 		t := p.mf.GetType()

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -16,8 +16,6 @@ package textparse
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
-	"io"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -27,8 +25,6 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/util/testutil"
-
 	dto "github.com/prometheus/prometheus/prompb/io/prometheus/client"
 )
 
@@ -785,32 +781,17 @@ metric: <
 }
 
 func TestProtobufParse(t *testing.T) {
-	type parseResult struct {
-		lset    labels.Labels
-		m       string
-		t       int64
-		v       float64
-		typ     model.MetricType
-		help    string
-		unit    string
-		comment string
-		shs     *histogram.Histogram
-		fhs     *histogram.FloatHistogram
-		e       []exemplar.Exemplar
-		ct      int64
-	}
-
 	inputBuf := createTestProtoBuf(t)
 
 	scenarios := []struct {
 		name     string
 		parser   Parser
-		expected []parseResult
+		expected []parsedEntry
 	}{
 		{
 			name:   "ignore classic buckets of native histograms",
 			parser: NewProtobufParser(inputBuf.Bytes(), false, labels.NewSymbolTable()),
-			expected: []parseResult{
+			expected: []parsedEntry{
 				{
 					m:    "go_build_info",
 					help: "Build information about the main Go module.",
@@ -832,6 +813,9 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:    "go_memstats_alloc_bytes_total",
 					help: "Total number of bytes allocated, even if freed.",
+				},
+				{
+					m:    "go_memstats_alloc_bytes_total",
 					unit: "bytes",
 				},
 				{
@@ -844,7 +828,7 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "go_memstats_alloc_bytes_total",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "42"), Value: 12, HasTs: true, Ts: 1625851151233},
 					},
 				},
@@ -858,7 +842,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m: "something_untyped",
-					t: 1234567,
+					t: int64p(1234567),
 					v: 42,
 					lset: labels.FromStrings(
 						"__name__", "something_untyped",
@@ -874,7 +858,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m: "test_histogram",
-					t: 1234568,
+					t: int64p(1234568),
 					shs: &histogram.Histogram{
 						Count:         175,
 						ZeroCount:     2,
@@ -895,7 +879,7 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_histogram",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
@@ -909,7 +893,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m: "test_gauge_histogram",
-					t: 1234568,
+					t: int64p(1234568),
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.GaugeType,
 						Count:            175,
@@ -931,7 +915,7 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_histogram",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
@@ -945,7 +929,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m: "test_float_histogram",
-					t: 1234568,
+					t: int64p(1234568),
 					fhs: &histogram.FloatHistogram{
 						Count:         175.0,
 						ZeroCount:     2.0,
@@ -966,7 +950,7 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_float_histogram",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
@@ -980,7 +964,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m: "test_gauge_float_histogram",
-					t: 1234568,
+					t: int64p(1234568),
 					fhs: &histogram.FloatHistogram{
 						CounterResetHint: histogram.GaugeType,
 						Count:            175.0,
@@ -1002,7 +986,7 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_float_histogram",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
@@ -1043,7 +1027,7 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_histogram2_bucket",
 						"le", "-0.00038",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00038, HasTs: true, Ts: 1625851153146},
 					},
 				},
@@ -1054,7 +1038,7 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_histogram2_bucket",
 						"le", "1.0",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.000295, HasTs: false},
 					},
 				},
@@ -1237,7 +1221,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_counter_with_createdtimestamp",
 					v:  42,
-					ct: 1000,
+					ct: int64p(1000),
 					lset: labels.FromStrings(
 						"__name__", "test_counter_with_createdtimestamp",
 					),
@@ -1253,7 +1237,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_summary_with_createdtimestamp_count",
 					v:  42,
-					ct: 1000,
+					ct: int64p(1000),
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_count",
 					),
@@ -1261,7 +1245,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_summary_with_createdtimestamp_sum",
 					v:  1.234,
-					ct: 1000,
+					ct: int64p(1000),
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_sum",
 					),
@@ -1276,7 +1260,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m:  "test_histogram_with_createdtimestamp",
-					ct: 1000,
+					ct: int64p(1000),
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.UnknownCounterReset,
 						PositiveSpans:    []histogram.Span{},
@@ -1296,7 +1280,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m:  "test_gaugehistogram_with_createdtimestamp",
-					ct: 1000,
+					ct: int64p(1000),
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.GaugeType,
 						PositiveSpans:    []histogram.Span{},
@@ -1316,7 +1300,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m: "test_histogram_with_native_histogram_exemplars",
-					t: 1234568,
+					t: int64p(1234568),
 					shs: &histogram.Histogram{
 						Count:         175,
 						ZeroCount:     2,
@@ -1337,7 +1321,7 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59780"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 						{Labels: labels.FromStrings("dummyID", "59772"), Value: -0.00052, HasTs: true, Ts: 1625851160156},
 					},
@@ -1352,7 +1336,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m: "test_histogram_with_native_histogram_exemplars2",
-					t: 1234568,
+					t: int64p(1234568),
 					shs: &histogram.Histogram{
 						Count:         175,
 						ZeroCount:     2,
@@ -1373,7 +1357,7 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars2",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59780"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
@@ -1382,16 +1366,16 @@ func TestProtobufParse(t *testing.T) {
 		{
 			name:   "parse classic and native buckets",
 			parser: NewProtobufParser(inputBuf.Bytes(), true, labels.NewSymbolTable()),
-			expected: []parseResult{
-				{ // 0
+			expected: []parsedEntry{
+				{
 					m:    "go_build_info",
 					help: "Build information about the main Go module.",
 				},
-				{ // 1
+				{
 					m:   "go_build_info",
 					typ: model.MetricTypeGauge,
 				},
-				{ // 2
+				{
 					m: "go_build_info\xFFchecksum\xFF\xFFpath\xFFgithub.com/prometheus/client_golang\xFFversion\xFF(devel)",
 					v: 1,
 					lset: labels.FromStrings(
@@ -1401,51 +1385,55 @@ func TestProtobufParse(t *testing.T) {
 						"version", "(devel)",
 					),
 				},
-				{ // 3
+				{
 					m:    "go_memstats_alloc_bytes_total",
 					help: "Total number of bytes allocated, even if freed.",
 				},
-				{ // 4
+				{
+					m:    "go_memstats_alloc_bytes_total",
+					unit: "bytes",
+				},
+				{
 					m:   "go_memstats_alloc_bytes_total",
 					typ: model.MetricTypeCounter,
 				},
-				{ // 5
+				{
 					m: "go_memstats_alloc_bytes_total",
 					v: 1.546544e+06,
 					lset: labels.FromStrings(
 						"__name__", "go_memstats_alloc_bytes_total",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "42"), Value: 12, HasTs: true, Ts: 1625851151233},
 					},
 				},
-				{ // 6
+				{
 					m:    "something_untyped",
 					help: "Just to test the untyped type.",
 				},
-				{ // 7
+				{
 					m:   "something_untyped",
 					typ: model.MetricTypeUnknown,
 				},
-				{ // 8
+				{
 					m: "something_untyped",
-					t: 1234567,
+					t: int64p(1234567),
 					v: 42,
 					lset: labels.FromStrings(
 						"__name__", "something_untyped",
 					),
 				},
-				{ // 9
+				{
 					m:    "test_histogram",
 					help: "Test histogram with many buckets removed to keep it manageable in size.",
 				},
-				{ // 10
+				{
 					m:   "test_histogram",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 11
+				{
 					m: "test_histogram",
-					t: 1234568,
+					t: int64p(1234568),
 					shs: &histogram.Histogram{
 						Count:         175,
 						ZeroCount:     2,
@@ -1466,79 +1454,79 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_histogram",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
-				{ // 12
+				{
 					m: "test_histogram_count",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_count",
 					),
 				},
-				{ // 13
+				{
 					m: "test_histogram_sum",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 0.0008280461746287094,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_sum",
 					),
 				},
-				{ // 14
+				{
 					m: "test_histogram_bucket\xffle\xff-0.0004899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 2,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_bucket",
 						"le", "-0.0004899999999999998",
 					),
 				},
-				{ // 15
+				{
 					m: "test_histogram_bucket\xffle\xff-0.0003899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 4,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_bucket",
 						"le", "-0.0003899999999999998",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
-				{ // 16
+				{
 					m: "test_histogram_bucket\xffle\xff-0.0002899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 16,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_bucket",
 						"le", "-0.0002899999999999998",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
-				{ // 17
+				{
 					m: "test_histogram_bucket\xffle\xff+Inf",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_bucket",
 						"le", "+Inf",
 					),
 				},
-				{ // 18
+				{
 					m:    "test_gauge_histogram",
 					help: "Like test_histogram but as gauge histogram.",
 				},
-				{ // 19
+				{
 					m:   "test_gauge_histogram",
 					typ: model.MetricTypeGaugeHistogram,
 				},
-				{ // 20
+				{
 					m: "test_gauge_histogram",
-					t: 1234568,
+					t: int64p(1234568),
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.GaugeType,
 						Count:            175,
@@ -1560,79 +1548,79 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_histogram",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
-				{ // 21
+				{
 					m: "test_gauge_histogram_count",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_histogram_count",
 					),
 				},
-				{ // 22
+				{
 					m: "test_gauge_histogram_sum",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 0.0008280461746287094,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_histogram_sum",
 					),
 				},
-				{ // 23
+				{
 					m: "test_gauge_histogram_bucket\xffle\xff-0.0004899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 2,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_histogram_bucket",
 						"le", "-0.0004899999999999998",
 					),
 				},
-				{ // 24
+				{
 					m: "test_gauge_histogram_bucket\xffle\xff-0.0003899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 4,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_histogram_bucket",
 						"le", "-0.0003899999999999998",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
-				{ // 25
+				{
 					m: "test_gauge_histogram_bucket\xffle\xff-0.0002899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 16,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_histogram_bucket",
 						"le", "-0.0002899999999999998",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
-				{ // 26
+				{
 					m: "test_gauge_histogram_bucket\xffle\xff+Inf",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_histogram_bucket",
 						"le", "+Inf",
 					),
 				},
-				{ // 27
+				{
 					m:    "test_float_histogram",
 					help: "Test float histogram with many buckets removed to keep it manageable in size.",
 				},
-				{ // 28
+				{
 					m:   "test_float_histogram",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 29
+				{
 					m: "test_float_histogram",
-					t: 1234568,
+					t: int64p(1234568),
 					fhs: &histogram.FloatHistogram{
 						Count:         175.0,
 						ZeroCount:     2.0,
@@ -1653,79 +1641,79 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_float_histogram",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
-				{ // 30
+				{
 					m: "test_float_histogram_count",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_float_histogram_count",
 					),
 				},
-				{ // 31
+				{
 					m: "test_float_histogram_sum",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 0.0008280461746287094,
 					lset: labels.FromStrings(
 						"__name__", "test_float_histogram_sum",
 					),
 				},
-				{ // 32
+				{
 					m: "test_float_histogram_bucket\xffle\xff-0.0004899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 2,
 					lset: labels.FromStrings(
 						"__name__", "test_float_histogram_bucket",
 						"le", "-0.0004899999999999998",
 					),
 				},
-				{ // 33
+				{
 					m: "test_float_histogram_bucket\xffle\xff-0.0003899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 4,
 					lset: labels.FromStrings(
 						"__name__", "test_float_histogram_bucket",
 						"le", "-0.0003899999999999998",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
-				{ // 34
+				{
 					m: "test_float_histogram_bucket\xffle\xff-0.0002899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 16,
 					lset: labels.FromStrings(
 						"__name__", "test_float_histogram_bucket",
 						"le", "-0.0002899999999999998",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
-				{ // 35
+				{
 					m: "test_float_histogram_bucket\xffle\xff+Inf",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_float_histogram_bucket",
 						"le", "+Inf",
 					),
 				},
-				{ // 36
+				{
 					m:    "test_gauge_float_histogram",
 					help: "Like test_float_histogram but as gauge histogram.",
 				},
-				{ // 37
+				{
 					m:   "test_gauge_float_histogram",
 					typ: model.MetricTypeGaugeHistogram,
 				},
-				{ // 38
+				{
 					m: "test_gauge_float_histogram",
-					t: 1234568,
+					t: int64p(1234568),
 					fhs: &histogram.FloatHistogram{
 						CounterResetHint: histogram.GaugeType,
 						Count:            175.0,
@@ -1747,91 +1735,91 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_float_histogram",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
-				{ // 39
+				{
 					m: "test_gauge_float_histogram_count",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_float_histogram_count",
 					),
 				},
-				{ // 40
+				{
 					m: "test_gauge_float_histogram_sum",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 0.0008280461746287094,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_float_histogram_sum",
 					),
 				},
-				{ // 41
+				{
 					m: "test_gauge_float_histogram_bucket\xffle\xff-0.0004899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 2,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_float_histogram_bucket",
 						"le", "-0.0004899999999999998",
 					),
 				},
-				{ // 42
+				{
 					m: "test_gauge_float_histogram_bucket\xffle\xff-0.0003899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 4,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_float_histogram_bucket",
 						"le", "-0.0003899999999999998",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
-				{ // 43
+				{
 					m: "test_gauge_float_histogram_bucket\xffle\xff-0.0002899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 16,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_float_histogram_bucket",
 						"le", "-0.0002899999999999998",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
-				{ // 44
+				{
 					m: "test_gauge_float_histogram_bucket\xffle\xff+Inf",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_gauge_float_histogram_bucket",
 						"le", "+Inf",
 					),
 				},
-				{ // 45
+				{
 					m:    "test_histogram2",
 					help: "Similar histogram as before but now without sparse buckets.",
 				},
-				{ // 46
+				{
 					m:   "test_histogram2",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 47
+				{
 					m: "test_histogram2_count",
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram2_count",
 					),
 				},
-				{ // 48
+				{
 					m: "test_histogram2_sum",
 					v: 0.000828,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram2_sum",
 					),
 				},
-				{ // 49
+				{
 					m: "test_histogram2_bucket\xffle\xff-0.00048",
 					v: 2,
 					lset: labels.FromStrings(
@@ -1839,29 +1827,29 @@ func TestProtobufParse(t *testing.T) {
 						"le", "-0.00048",
 					),
 				},
-				{ // 50
+				{
 					m: "test_histogram2_bucket\xffle\xff-0.00038",
 					v: 4,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram2_bucket",
 						"le", "-0.00038",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00038, HasTs: true, Ts: 1625851153146},
 					},
 				},
-				{ // 51
+				{
 					m: "test_histogram2_bucket\xffle\xff1.0",
 					v: 16,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram2_bucket",
 						"le", "1.0",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.000295, HasTs: false},
 					},
 				},
-				{ // 52
+				{
 					m: "test_histogram2_bucket\xffle\xff+Inf",
 					v: 175,
 					lset: labels.FromStrings(
@@ -1869,15 +1857,15 @@ func TestProtobufParse(t *testing.T) {
 						"le", "+Inf",
 					),
 				},
-				{ // 53
+				{
 					m:    "test_histogram_family",
 					help: "Test histogram metric family with two very simple histograms.",
 				},
-				{ // 54
+				{
 					m:   "test_histogram_family",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 55
+				{
 					m: "test_histogram_family\xfffoo\xffbar",
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.UnknownCounterReset,
@@ -1895,7 +1883,7 @@ func TestProtobufParse(t *testing.T) {
 						"foo", "bar",
 					),
 				},
-				{ // 56
+				{
 					m: "test_histogram_family_count\xfffoo\xffbar",
 					v: 5,
 					lset: labels.FromStrings(
@@ -1903,7 +1891,7 @@ func TestProtobufParse(t *testing.T) {
 						"foo", "bar",
 					),
 				},
-				{ // 57
+				{
 					m: "test_histogram_family_sum\xfffoo\xffbar",
 					v: 12.1,
 					lset: labels.FromStrings(
@@ -1911,7 +1899,7 @@ func TestProtobufParse(t *testing.T) {
 						"foo", "bar",
 					),
 				},
-				{ // 58
+				{
 					m: "test_histogram_family_bucket\xfffoo\xffbar\xffle\xff1.1",
 					v: 2,
 					lset: labels.FromStrings(
@@ -1920,7 +1908,7 @@ func TestProtobufParse(t *testing.T) {
 						"le", "1.1",
 					),
 				},
-				{ // 59
+				{
 					m: "test_histogram_family_bucket\xfffoo\xffbar\xffle\xff2.2",
 					v: 3,
 					lset: labels.FromStrings(
@@ -1929,7 +1917,7 @@ func TestProtobufParse(t *testing.T) {
 						"le", "2.2",
 					),
 				},
-				{ // 60
+				{
 					m: "test_histogram_family_bucket\xfffoo\xffbar\xffle\xff+Inf",
 					v: 5,
 					lset: labels.FromStrings(
@@ -1938,7 +1926,7 @@ func TestProtobufParse(t *testing.T) {
 						"le", "+Inf",
 					),
 				},
-				{ // 61
+				{
 					m: "test_histogram_family\xfffoo\xffbaz",
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.UnknownCounterReset,
@@ -1956,7 +1944,7 @@ func TestProtobufParse(t *testing.T) {
 						"foo", "baz",
 					),
 				},
-				{ // 62
+				{
 					m: "test_histogram_family_count\xfffoo\xffbaz",
 					v: 6,
 					lset: labels.FromStrings(
@@ -1964,7 +1952,7 @@ func TestProtobufParse(t *testing.T) {
 						"foo", "baz",
 					),
 				},
-				{ // 63
+				{
 					m: "test_histogram_family_sum\xfffoo\xffbaz",
 					v: 13.1,
 					lset: labels.FromStrings(
@@ -1972,7 +1960,7 @@ func TestProtobufParse(t *testing.T) {
 						"foo", "baz",
 					),
 				},
-				{ // 64
+				{
 					m: "test_histogram_family_bucket\xfffoo\xffbaz\xffle\xff1.1",
 					v: 1,
 					lset: labels.FromStrings(
@@ -1981,7 +1969,7 @@ func TestProtobufParse(t *testing.T) {
 						"le", "1.1",
 					),
 				},
-				{ // 65
+				{
 					m: "test_histogram_family_bucket\xfffoo\xffbaz\xffle\xff2.2",
 					v: 5,
 					lset: labels.FromStrings(
@@ -1990,7 +1978,7 @@ func TestProtobufParse(t *testing.T) {
 						"le", "2.2",
 					),
 				},
-				{ // 66
+				{
 					m: "test_histogram_family_bucket\xfffoo\xffbaz\xffle\xff+Inf",
 					v: 6,
 					lset: labels.FromStrings(
@@ -1999,15 +1987,15 @@ func TestProtobufParse(t *testing.T) {
 						"le", "+Inf",
 					),
 				},
-				{ // 67
+				{
 					m:    "test_float_histogram_with_zerothreshold_zero",
 					help: "Test float histogram with a zero threshold of zero.",
 				},
-				{ // 68
+				{
 					m:   "test_float_histogram_with_zerothreshold_zero",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 69
+				{
 					m: "test_float_histogram_with_zerothreshold_zero",
 					fhs: &histogram.FloatHistogram{
 						Count:  5.0,
@@ -2023,15 +2011,15 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_float_histogram_with_zerothreshold_zero",
 					),
 				},
-				{ // 70
+				{
 					m:    "rpc_durations_seconds",
 					help: "RPC latency distributions.",
 				},
-				{ // 71
+				{
 					m:   "rpc_durations_seconds",
 					typ: model.MetricTypeSummary,
 				},
-				{ // 72
+				{
 					m: "rpc_durations_seconds_count\xffservice\xffexponential",
 					v: 262,
 					lset: labels.FromStrings(
@@ -2039,7 +2027,7 @@ func TestProtobufParse(t *testing.T) {
 						"service", "exponential",
 					),
 				},
-				{ // 73
+				{
 					m: "rpc_durations_seconds_sum\xffservice\xffexponential",
 					v: 0.00025551262820703587,
 					lset: labels.FromStrings(
@@ -2047,7 +2035,7 @@ func TestProtobufParse(t *testing.T) {
 						"service", "exponential",
 					),
 				},
-				{ // 74
+				{
 					m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.5",
 					v: 6.442786329648548e-07,
 					lset: labels.FromStrings(
@@ -2056,7 +2044,7 @@ func TestProtobufParse(t *testing.T) {
 						"service", "exponential",
 					),
 				},
-				{ // 75
+				{
 					m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.9",
 					v: 1.9435742936658396e-06,
 					lset: labels.FromStrings(
@@ -2065,7 +2053,7 @@ func TestProtobufParse(t *testing.T) {
 						"service", "exponential",
 					),
 				},
-				{ // 76
+				{
 					m: "rpc_durations_seconds\xffservice\xffexponential\xffquantile\xff0.99",
 					v: 4.0471608667037015e-06,
 					lset: labels.FromStrings(
@@ -2074,37 +2062,37 @@ func TestProtobufParse(t *testing.T) {
 						"service", "exponential",
 					),
 				},
-				{ // 77
+				{
 					m:    "without_quantiles",
 					help: "A summary without quantiles.",
 				},
-				{ // 78
+				{
 					m:   "without_quantiles",
 					typ: model.MetricTypeSummary,
 				},
-				{ // 79
+				{
 					m: "without_quantiles_count",
 					v: 42,
 					lset: labels.FromStrings(
 						"__name__", "without_quantiles_count",
 					),
 				},
-				{ // 80
+				{
 					m: "without_quantiles_sum",
 					v: 1.234,
 					lset: labels.FromStrings(
 						"__name__", "without_quantiles_sum",
 					),
 				},
-				{ // 81
+				{
 					m:    "empty_histogram",
 					help: "A histogram without observations and with a zero threshold of zero but with a no-op span to identify it as a native histogram.",
 				},
-				{ // 82
+				{
 					m:   "empty_histogram",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 83
+				{
 					m: "empty_histogram",
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.UnknownCounterReset,
@@ -2115,57 +2103,57 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "empty_histogram",
 					),
 				},
-				{ // 84
+				{
 					m:    "test_counter_with_createdtimestamp",
 					help: "A counter with a created timestamp.",
 				},
-				{ // 85
+				{
 					m:   "test_counter_with_createdtimestamp",
 					typ: model.MetricTypeCounter,
 				},
-				{ // 86
+				{
 					m:  "test_counter_with_createdtimestamp",
 					v:  42,
-					ct: 1000,
+					ct: int64p(1000),
 					lset: labels.FromStrings(
 						"__name__", "test_counter_with_createdtimestamp",
 					),
 				},
-				{ // 87
+				{
 					m:    "test_summary_with_createdtimestamp",
 					help: "A summary with a created timestamp.",
 				},
-				{ // 88
+				{
 					m:   "test_summary_with_createdtimestamp",
 					typ: model.MetricTypeSummary,
 				},
-				{ // 89
+				{
 					m:  "test_summary_with_createdtimestamp_count",
 					v:  42,
-					ct: 1000,
+					ct: int64p(1000),
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_count",
 					),
 				},
-				{ // 90
+				{
 					m:  "test_summary_with_createdtimestamp_sum",
 					v:  1.234,
-					ct: 1000,
+					ct: int64p(1000),
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_sum",
 					),
 				},
-				{ // 91
+				{
 					m:    "test_histogram_with_createdtimestamp",
 					help: "A histogram with a created timestamp.",
 				},
-				{ // 92
+				{
 					m:   "test_histogram_with_createdtimestamp",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 93
+				{
 					m:  "test_histogram_with_createdtimestamp",
-					ct: 1000,
+					ct: int64p(1000),
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.UnknownCounterReset,
 						PositiveSpans:    []histogram.Span{},
@@ -2175,17 +2163,17 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_histogram_with_createdtimestamp",
 					),
 				},
-				{ // 94
+				{
 					m:    "test_gaugehistogram_with_createdtimestamp",
 					help: "A gauge histogram with a created timestamp.",
 				},
-				{ // 95
+				{
 					m:   "test_gaugehistogram_with_createdtimestamp",
 					typ: model.MetricTypeGaugeHistogram,
 				},
-				{ // 96
+				{
 					m:  "test_gaugehistogram_with_createdtimestamp",
-					ct: 1000,
+					ct: int64p(1000),
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.GaugeType,
 						PositiveSpans:    []histogram.Span{},
@@ -2195,17 +2183,17 @@ func TestProtobufParse(t *testing.T) {
 						"__name__", "test_gaugehistogram_with_createdtimestamp",
 					),
 				},
-				{ // 97
+				{
 					m:    "test_histogram_with_native_histogram_exemplars",
 					help: "A histogram with native histogram exemplars.",
 				},
-				{ // 98
+				{
 					m:   "test_histogram_with_native_histogram_exemplars",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 99
+				{
 					m: "test_histogram_with_native_histogram_exemplars",
-					t: 1234568,
+					t: int64p(1234568),
 					shs: &histogram.Histogram{
 						Count:         175,
 						ZeroCount:     2,
@@ -2226,80 +2214,80 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59780"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 						{Labels: labels.FromStrings("dummyID", "59772"), Value: -0.00052, HasTs: true, Ts: 1625851160156},
 					},
 				},
-				{ // 100
+				{
 					m: "test_histogram_with_native_histogram_exemplars_count",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars_count",
 					),
 				},
-				{ // 101
+				{
 					m: "test_histogram_with_native_histogram_exemplars_sum",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 0.0008280461746287094,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars_sum",
 					),
 				},
-				{ // 102
+				{
 					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff-0.0004899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 2,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars_bucket",
 						"le", "-0.0004899999999999998",
 					),
 				},
-				{ // 103
+				{
 					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff-0.0003899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 4,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars_bucket",
 						"le", "-0.0003899999999999998",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59727"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
-				{ // 104
+				{
 					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff-0.0002899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 16,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars_bucket",
 						"le", "-0.0002899999999999998",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "5617"), Value: -0.00029, HasTs: false},
 					},
 				},
-				{ // 105
+				{
 					m: "test_histogram_with_native_histogram_exemplars_bucket\xffle\xff+Inf",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars_bucket",
 						"le", "+Inf",
 					),
 				},
-				{ // 106
+				{
 					m:    "test_histogram_with_native_histogram_exemplars2",
 					help: "Another histogram with native histogram exemplars.",
 				},
-				{ // 107
+				{
 					m:   "test_histogram_with_native_histogram_exemplars2",
 					typ: model.MetricTypeHistogram,
 				},
-				{ // 108
+				{
 					m: "test_histogram_with_native_histogram_exemplars2",
-					t: 1234568,
+					t: int64p(1234568),
 					shs: &histogram.Histogram{
 						Count:         175,
 						ZeroCount:     2,
@@ -2320,56 +2308,56 @@ func TestProtobufParse(t *testing.T) {
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars2",
 					),
-					e: []exemplar.Exemplar{
+					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("dummyID", "59780"), Value: -0.00039, HasTs: true, Ts: 1625851155146},
 					},
 				},
-				{ // 109
+				{
 					m: "test_histogram_with_native_histogram_exemplars2_count",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars2_count",
 					),
 				},
-				{ // 110
+				{
 					m: "test_histogram_with_native_histogram_exemplars2_sum",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 0.0008280461746287094,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars2_sum",
 					),
 				},
-				{ // 111
+				{
 					m: "test_histogram_with_native_histogram_exemplars2_bucket\xffle\xff-0.0004899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 2,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars2_bucket",
 						"le", "-0.0004899999999999998",
 					),
 				},
-				{ // 112
+				{
 					m: "test_histogram_with_native_histogram_exemplars2_bucket\xffle\xff-0.0003899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 4,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars2_bucket",
 						"le", "-0.0003899999999999998",
 					),
 				},
-				{ // 113
+				{
 					m: "test_histogram_with_native_histogram_exemplars2_bucket\xffle\xff-0.0002899999999999998",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 16,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars2_bucket",
 						"le", "-0.0002899999999999998",
 					),
 				},
-				{ // 114
+				{
 					m: "test_histogram_with_native_histogram_exemplars2_bucket\xffle\xff+Inf",
-					t: 1234568,
+					t: int64p(1234568),
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_native_histogram_exemplars2_bucket",
@@ -2383,94 +2371,11 @@ func TestProtobufParse(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			var (
-				i   int
-				res labels.Labels
 				p   = scenario.parser
 				exp = scenario.expected
 			)
-
-			for {
-				et, err := p.Next()
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				require.NoError(t, err)
-
-				switch et {
-				case EntrySeries:
-					m, ts, v := p.Series()
-
-					var e exemplar.Exemplar
-					p.Metric(&res)
-					eFound := p.Exemplar(&e)
-					ct := p.CreatedTimestamp()
-					require.Equal(t, exp[i].m, string(m), "i: %d", i)
-					if ts != nil {
-						require.Equal(t, exp[i].t, *ts, "i: %d", i)
-					} else {
-						require.Equal(t, int64(0), exp[i].t, "i: %d", i)
-					}
-					require.Equal(t, exp[i].v, v, "i: %d", i)
-					testutil.RequireEqual(t, exp[i].lset, res, "i: %d", i)
-					if len(exp[i].e) == 0 {
-						require.False(t, eFound, "i: %d", i)
-					} else {
-						require.True(t, eFound, "i: %d", i)
-						testutil.RequireEqual(t, exp[i].e[0], e, "i: %d", i)
-						require.False(t, p.Exemplar(&e), "too many exemplars returned, i: %d", i)
-					}
-					if exp[i].ct != 0 {
-						require.NotNilf(t, ct, "i: %d", i)
-						require.Equal(t, exp[i].ct, *ct, "i: %d", i)
-					} else {
-						require.Nilf(t, ct, "i: %d", i)
-					}
-
-				case EntryHistogram:
-					m, ts, shs, fhs := p.Histogram()
-					p.Metric(&res)
-					require.Equal(t, exp[i].m, string(m), "i: %d", i)
-					if ts != nil {
-						require.Equal(t, exp[i].t, *ts, "i: %d", i)
-					} else {
-						require.Equal(t, int64(0), exp[i].t, "i: %d", i)
-					}
-					testutil.RequireEqual(t, exp[i].lset, res, "i: %d", i)
-					require.Equal(t, exp[i].m, string(m), "i: %d", i)
-					if shs != nil {
-						require.Equal(t, exp[i].shs, shs, "i: %d", i)
-					} else {
-						require.Equal(t, exp[i].fhs, fhs, "i: %d", i)
-					}
-					j := 0
-					for e := (exemplar.Exemplar{}); p.Exemplar(&e); j++ {
-						testutil.RequireEqual(t, exp[i].e[j], e, "i: %d", i)
-						e = exemplar.Exemplar{}
-					}
-					require.Len(t, exp[i].e, j, "not enough exemplars found, i: %d", i)
-
-				case EntryType:
-					m, typ := p.Type()
-					require.Equal(t, exp[i].m, string(m), "i: %d", i)
-					require.Equal(t, exp[i].typ, typ, "i: %d", i)
-
-				case EntryHelp:
-					m, h := p.Help()
-					require.Equal(t, exp[i].m, string(m), "i: %d", i)
-					require.Equal(t, exp[i].help, string(h), "i: %d", i)
-
-				case EntryUnit:
-					m, u := p.Unit()
-					require.Equal(t, exp[i].m, string(m), "i: %d", i)
-					require.Equal(t, exp[i].unit, string(u), "i: %d", i)
-
-				case EntryComment:
-					require.Equal(t, exp[i].comment, string(p.Comment()), "i: %d", i)
-				}
-
-				i++
-			}
-			require.Len(t, exp, i)
+			got := testParse(t, p)
+			requireEntries(t, exp, got)
 		})
 	}
 }


### PR DESCRIPTION
This centralizes the parsing testing in one, composable space. Already found bug in proto parser thanks to that (Next never sets entry to `Unit`) cc @beorn7 @krajorama - hope fixing this in this refactor is ok (minor fix).


This is to make sure we can reuse same parsing test e.g. as we iterate on https://github.com/prometheus/prometheus/pull/14965  cc @Maniktherana @ArthurSens 