### PR TITLE
golangci-lint: enable makezero linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - godot
     - gofumpt
     - goimports
+    - makezero
     - misspell
     - nolintlint
     - perfsprint

--- a/config/config.go
+++ b/config/config.go
@@ -287,10 +287,10 @@ func (c Config) String() string {
 
 // GetScrapeConfigs returns the scrape configurations.
 func (c *Config) GetScrapeConfigs() ([]*ScrapeConfig, error) {
-	scfgs := make([]*ScrapeConfig, len(c.ScrapeConfigs))
+	scfgs := make([]*ScrapeConfig, 0, len(c.ScrapeConfigs))
 
 	jobNames := map[string]string{}
-	for i, scfg := range c.ScrapeConfigs {
+	for _, scfg := range c.ScrapeConfigs {
 		// We do these checks for library users that would not call validate in
 		// Unmarshal.
 		if err := scfg.Validate(c.GlobalConfig); err != nil {
@@ -301,7 +301,7 @@ func (c *Config) GetScrapeConfigs() ([]*ScrapeConfig, error) {
 			return nil, fmt.Errorf("found multiple scrape configs with job name %q", scfg.JobName)
 		}
 		jobNames[scfg.JobName] = "main config file"
-		scfgs[i] = scfg
+		scfgs = append(scfgs, scfg)
 	}
 	for _, pat := range c.ScrapeConfigFiles {
 		fs, err := filepath.Glob(pat)

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1556,7 +1556,7 @@ func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string,
 		metadataChanged bool
 	)
 
-	exemplars := make([]exemplar.Exemplar, 1)
+	exemplars := make([]exemplar.Exemplar, 0, 1)
 
 	// updateMetadata updates the current iteration's metadata object and the
 	// metadataChanged value if we have metadata in the scrape cache AND the

--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -944,7 +944,7 @@ func (m *mockQuerier) Select(_ context.Context, sortSeries bool, _ *SelectHints,
 
 	var ret []Series
 	if len(m.toReturn) > 0 {
-		ret = make([]Series, len(m.toReturn))
+		ret = make([]Series, 0, len(m.toReturn))
 		copy(ret, m.toReturn)
 	} else if len(m.resp) > 0 {
 		ret = make([]Series, 0, len(m.resp))

--- a/tsdb/wlog/reader_test.go
+++ b/tsdb/wlog/reader_test.go
@@ -160,8 +160,8 @@ func encodedRecord(t recType, b []byte) []byte {
 	if t == recPageTerm {
 		return append([]byte{0}, b...)
 	}
-	r := make([]byte, recordHeaderSize)
-	r[0] = byte(t)
+	r := make([]byte, 0, recordHeaderSize)
+	r = append(r, byte(t))
 	binary.BigEndian.PutUint16(r[1:], uint16(len(b)))
 	binary.BigEndian.PutUint32(r[3:], crc32.Checksum(b, castagnoliTable))
 	return append(r, b...)
@@ -172,7 +172,7 @@ func TestReader(t *testing.T) {
 	for name, fn := range readerConstructors {
 		for i, c := range testReaderCases {
 			t.Run(fmt.Sprintf("%s/%d", name, i), func(t *testing.T) {
-				var buf []byte
+				buf := make([]byte, 0, len(c.t))
 				for _, r := range c.t {
 					buf = append(buf, encodedRecord(r.t, r.b)...)
 				}


### PR DESCRIPTION
Enables [makezero](https://golangci-lint.run/usage/linters/#makezero) linter

Closes #15026

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>