### PR TITLE
[BUGFIX] TSDB: Head compaction race condition

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1149,13 +1149,15 @@ func (h *Head) truncateMemory(mint int64) (err error) {
 		h.memTruncationCallBack()
 	}
 
+	// Set the minTime that new queries will see, before waiting for queries to finish.
+	h.minTime.Store(mint)
+	// Don't allow samples to be added before this time.
+	h.minValidTime.Store(mint)
+
 	// We wait for pending queries to end that overlap with this truncation.
 	if initialized {
 		h.WaitForPendingReadersInTimeRange(h.MinTime(), mint)
 	}
-
-	h.minTime.Store(mint)
-	h.minValidTime.Store(mint)
 
 	// Ensure that max time is at least as high as min time.
 	for h.MaxTime() < mint {


### PR DESCRIPTION
There was a small time window where things can go wrong, if a query starts after `WaitForPendingReadersInTimeRange` returns, but before `minTime` is stored.

The context is that data before `minTime` has been written to blocks, and we are about to start clearing it out of memory.
If we allow a new query to start, looking before `minTime`, then it can find the chunks have disappeared.
