### PR TITLE
Ensure connection is re-established on 403 status by closing Keep-Alive.

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -801,6 +801,12 @@ func (s *targetScraper) readResponse(ctx context.Context, resp *http.Response, w
 		resp.Body.Close()
 	}()
 
+	if resp.StatusCode == http.StatusForbidden {
+		s.req.Close = !s.req.Close
+	} else {
+		s.req.Close = false
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("server returned HTTP status %s", resp.Status)
 	}


### PR DESCRIPTION
This change closes the Keep-Alive connection on receiving a 403 status, ensuring that a new connection is opened. This helps re-read the TLS client certificates for the subsequent requests.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
