### PR TITLE
[PERF] textparse: lightweight `p.isCreatedSeries()`

### DIFF
--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -652,9 +652,8 @@ func (p *OpenMetricsParser) parseLVals(offsets []int, isExemplar bool) ([]int, e
 
 // isCreatedSeries returns true if the current series is a _created series.
 func (p *OpenMetricsParser) isCreatedSeries() bool {
-	s := string(p.series)
-	metricName := unreplace(s[p.offsets[0]-p.start : p.offsets[1]-p.start])
-	if typeRequiresCT(p.mtype) && strings.HasSuffix(metricName, "_created") {
+	metricName := p.series[p.offsets[0]-p.start : p.offsets[1]-p.start]
+	if typeRequiresCT(p.mtype) && len(metricName) >= 8 && string(metricName[len(metricName)-8:]) == "_created" {
 		return true
 	}
 	return false

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -653,6 +653,7 @@ func (p *OpenMetricsParser) parseLVals(offsets []int, isExemplar bool) ([]int, e
 // isCreatedSeries returns true if the current series is a _created series.
 func (p *OpenMetricsParser) isCreatedSeries() bool {
 	metricName := p.series[p.offsets[0]-p.start : p.offsets[1]-p.start]
+	// check length so the metric is longer than len("_created")
 	if typeRequiresCT(p.mtype) && len(metricName) >= 8 && string(metricName[len(metricName)-8:]) == "_created" {
 		return true
 	}

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -652,10 +652,9 @@ func (p *OpenMetricsParser) parseLVals(offsets []int, isExemplar bool) ([]int, e
 
 // isCreatedSeries returns true if the current series is a _created series.
 func (p *OpenMetricsParser) isCreatedSeries() bool {
-	var newLbs labels.Labels
-	p.Metric(&newLbs)
-	name := newLbs.Get(model.MetricNameLabel)
-	if typeRequiresCT(p.mtype) && strings.HasSuffix(name, "_created") {
+	s := string(p.series)
+	metricName := unreplace(s[p.offsets[0]-p.start : p.offsets[1]-p.start])
+	if typeRequiresCT(p.mtype) && strings.HasSuffix(metricName, "_created") {
 		return true
 	}
 	return false


### PR DESCRIPTION
#14823

I forgot that `p.Metric` was still being used in `p.isCreatedSeries` and this has a significant memory footprint when calling `p.Next` and thus `p.CreatedTimestamp`


<img width="611" alt="Screenshot 2024-10-11 at 10 10 26 PM" src="https://github.com/user-attachments/assets/00a8524e-7ca1-471c-b80f-087c645011b4">

Here `isCreatedSeries` pretty much takes up most of the mem allocations for `p.Next`

The result? Much smaller footprint of `p.Next` when it comes to memory allocations

<img width="663" alt="Screenshot 2024-10-11 at 10 11 36 PM" src="https://github.com/user-attachments/assets/07a8d027-5e91-4d05-b281-97e9877d1d79">


```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/textparse
cpu: Apple M1
                              │   main.txt   │            this-pr.txt             │
                              │    sec/op    │    sec/op     vs base              │
Parse omtestdata.txt omtext     35.55µ ± 11%   33.20µ ± 22%       ~ (p=0.310 n=6)
Parse promtestdata.txt omtext   2.573m ±  1%   2.510m ±  2%  -2.44% (p=0.026 n=6)
geomean                         302.4µ         288.7µ        -4.54%

                              │   main.txt    │             this-pr.txt             │
                              │      B/s      │      B/s       vs base              │
Parse omtestdata.txt omtext     120.1Mi ± 10%   128.7Mi ± 18%       ~ (p=0.310 n=6)
Parse promtestdata.txt omtext   12.36Mi ±  1%   12.68Mi ±  2%  +2.55% (p=0.024 n=6)
geomean                         38.54Mi         40.40Mi        +4.84%

                              │   main.txt   │             this-pr.txt             │
                              │     B/op     │     B/op      vs base               │
Parse omtestdata.txt omtext     17.44Ki ± 0%   13.88Ki ± 0%  -20.43% (p=0.002 n=6)
Parse promtestdata.txt omtext   164.2Ki ± 0%   133.4Ki ± 0%  -18.79% (p=0.002 n=6)
geomean                         53.51Ki        43.02Ki       -19.61%

                              │  main.txt   │            this-pr.txt             │
                              │  allocs/op  │  allocs/op   vs base               │
Parse omtestdata.txt omtext      317.0 ± 0%    264.0 ± 0%  -16.72% (p=0.002 n=6)
Parse promtestdata.txt omtext   3.102k ± 0%   2.692k ± 0%  -13.22% (p=0.002 n=6)
geomean                          991.6         843.0       -14.99%
```

[mem profile](https://pprof.me/a7b1dd3c93aadc02d3628c47b4b09236/)
[cpu profile](https://pprof.me/34ddd11a7eecbc8f3e9c02cf9a5977fc/?profileType=profile%3Acpu%3Ananoseconds%3Acpu%3Ananoseconds%3Adelta)