### PR TITLE
convertnhcb: use CutSuffix instead of regex replace for histogram name

### DIFF
--- a/util/convertnhcb/convertnhcb.go
+++ b/util/convertnhcb/convertnhcb.go
@@ -19,29 +19,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/grafana/regexp"
-
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 )
-
-var histogramNameSuffixReplacements = []struct {
-	pattern *regexp.Regexp
-	repl    string
-}{
-	{
-		pattern: regexp.MustCompile(`_bucket$`),
-		repl:    "",
-	},
-	{
-		pattern: regexp.MustCompile(`_sum$`),
-		repl:    "",
-	},
-	{
-		pattern: regexp.MustCompile(`_count$`),
-		repl:    "",
-	},
-}
 
 // TempHistogram is used to collect information about classic histogram
 // samples incrementally before creating a histogram.Histogram or
@@ -176,9 +156,18 @@ func GetHistogramMetricBase(m labels.Labels, suffix string) labels.Labels {
 		Labels()
 }
 
+// GetHistogramMetricBaseName removes the suffixes _bucket, _sum, _count from
+// the metric name. We specifically do not remove the _created suffix as that
+// should be removed by the caller.
 func GetHistogramMetricBaseName(s string) string {
-	for _, rep := range histogramNameSuffixReplacements {
-		s = rep.pattern.ReplaceAllString(s, rep.repl)
+	if r, ok := strings.CutSuffix(s, "_bucket"); ok {
+		return r
+	}
+	if r, ok := strings.CutSuffix(s, "_sum"); ok {
+		return r
+	}
+	if r, ok := strings.CutSuffix(s, "_count"); ok {
+		return r
 	}
 	return s
 }


### PR DESCRIPTION
This is much quicker.

Measured with #14978 :
```
BenchmarkParse/data=omhistogramdata.txt/parser=nhcb_over_omtext-2         	   10000	    236983 ns/op	  17.68 MB/s	   74421 B/op	    1334 allocs/op
```
vs replaced with strings.CutSuffix:
```
BenchmarkParse/data=omhistogramdata.txt/parser=nhcb_over_omtext-2         	   17907	    144225 ns/op	  29.06 MB/s	   52984 B/op	     560 allocs/op
```