### PR TITLE
lezer-promql: fix missing types export in package.json

### DIFF
--- a/web/ui/module/lezer-promql/package.json
+++ b/web/ui/module/lezer-promql/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.cjs",
   "type": "module",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.es.js",
     "require": "./dist/index.cjs"
   },


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

NPM packages that declare themselves as es modules (`"type": "module`) in their package.json must declare an exports.types property for typescript to successfully resolve the types when the tsconfig moduleResolution is set to node16 or above. [Arethetypeswrong](https://arethetypeswrong.github.io/?p=%40prometheus-io%2Flezer-promql%400.300.0-beta.1) can be used to assert this.

![image](https://github.com/user-attachments/assets/ea6509b4-1727-4d57-a668-148be2b50fab)

Without this change projects that attempt to set `moduleResolution` to something other than `node` results in TS errors like:

```
Type-checking in progress...
ERROR in ./packages/grafana-prometheus/src/add_label_to_query.ts:2:40
TS7016: Could not find a declaration file for module '@prometheus-io/lezer-promql'. '/Users/jackwestbrook/dev/grafana/grafana/packages/grafana-prometheus/node_modules/@prometheus-io/lezer-promql/dist/index.es.js' implicitly has an 'any' type.
  There are types at '/Users/jackwestbrook/dev/grafana/grafana/packages/grafana-prometheus/node_modules/@prometheus-io/lezer-promql/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@prometheus-io/lezer-promql' library may need to update its package.json or typings.
    1 | // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/add_label_to_query.ts
  > 2 | import { parser, VectorSelector } from '@prometheus-io/lezer-promql';
      |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      ``` 
