### PR TITLE
feat: ProtobufParse.formatOpenMetricsFloat: improve float formatting …

### DIFF
--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strconv"
 	"strings"
+	"sync"
 	"unicode/utf8"
 
 	"github.com/gogo/protobuf/proto"
@@ -33,6 +35,15 @@ import (
 
 	dto "github.com/prometheus/prometheus/prompb/io/prometheus/client"
 )
+
+// floatFormatBufPool is exclusively used in formatOpenMetricsFloat.
+var floatFormatBufPool = sync.Pool{
+	New: func() interface{} {
+		// To contain at most 17 digits and additional syntax for a float64.
+		b := make([]byte, 0, 24)
+		return &b
+	},
+}
 
 // ProtobufParser is a very inefficient way of unmarshaling the old Prometheus
 // protobuf format and then present it as it if were parsed by a
@@ -629,11 +640,15 @@ func formatOpenMetricsFloat(f float64) string {
 	case math.IsInf(f, -1):
 		return "-Inf"
 	}
-	s := fmt.Sprint(f)
-	if strings.ContainsAny(s, "e.") {
-		return s
+	bp := floatFormatBufPool.Get().(*[]byte)
+	defer floatFormatBufPool.Put(bp)
+
+	*bp = strconv.AppendFloat((*bp)[:0], f, 'g', -1, 64)
+	if bytes.ContainsAny(*bp, "e.") {
+		return string(*bp)
 	}
-	return s + ".0"
+	*bp = append(*bp, '.', '0')
+	return string(*bp)
 }
 
 // isNativeHistogram returns false iff the provided histograms has no spans at

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -410,6 +410,49 @@ metric: <
 >
 
 `,
+		`name: "test_histogram3"
+help: "Similar histogram as before but now with integer buckets."
+type: HISTOGRAM
+metric: <
+  histogram: <
+    sample_count: 6
+    sample_sum: 50
+    bucket: <
+      cumulative_count: 2
+      upper_bound: -20
+    >
+    bucket: <
+      cumulative_count: 4
+      upper_bound: 20
+      exemplar: <
+        label: <
+          name: "dummyID"
+          value: "59727"
+        >
+        value: 15
+        timestamp: <
+          seconds: 1625851153
+          nanos: 146848499
+        >
+      >
+    >
+    bucket: <
+      cumulative_count: 6
+      upper_bound: 30
+      exemplar: <
+        label: <
+          name: "dummyID"
+          value: "5617"
+        >
+        value: 25
+      >
+    >
+    schema: 0
+    zero_threshold: 0
+  >
+>
+
+`,
 		`name: "test_histogram_family"
 help: "Test histogram metric family with two very simple histograms."
 type: HISTOGRAM
@@ -1047,6 +1090,66 @@ func TestProtobufParse(t *testing.T) {
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram2_bucket",
+						"le", "+Inf",
+					),
+				},
+				{
+					m:    "test_histogram3",
+					help: "Similar histogram as before but now with integer buckets.",
+				},
+				{
+					m:   "test_histogram3",
+					typ: model.MetricTypeHistogram,
+				},
+				{
+					m: "test_histogram3_count",
+					v: 6,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_count",
+					),
+				},
+				{
+					m: "test_histogram3_sum",
+					v: 50,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_sum",
+					),
+				},
+				{
+					m: "test_histogram3_bucket\xffle\xff-20.0",
+					v: 2,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_bucket",
+						"le", "-20.0",
+					),
+				},
+				{
+					m: "test_histogram3_bucket\xffle\xff20.0",
+					v: 4,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_bucket",
+						"le", "20.0",
+					),
+					es: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: 15, HasTs: true, Ts: 1625851153146},
+					},
+				},
+				{
+					m: "test_histogram3_bucket\xffle\xff30.0",
+					v: 6,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_bucket",
+						"le", "30.0",
+					),
+					es: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: 25, HasTs: false},
+					},
+				},
+				{
+					m: "test_histogram3_bucket\xffle\xff+Inf",
+					v: 6,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_bucket",
 						"le", "+Inf",
 					),
 				},
@@ -1854,6 +1957,66 @@ func TestProtobufParse(t *testing.T) {
 					v: 175,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram2_bucket",
+						"le", "+Inf",
+					),
+				},
+				{
+					m:    "test_histogram3",
+					help: "Similar histogram as before but now with integer buckets.",
+				},
+				{
+					m:   "test_histogram3",
+					typ: model.MetricTypeHistogram,
+				},
+				{
+					m: "test_histogram3_count",
+					v: 6,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_count",
+					),
+				},
+				{
+					m: "test_histogram3_sum",
+					v: 50,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_sum",
+					),
+				},
+				{
+					m: "test_histogram3_bucket\xffle\xff-20.0",
+					v: 2,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_bucket",
+						"le", "-20.0",
+					),
+				},
+				{
+					m: "test_histogram3_bucket\xffle\xff20.0",
+					v: 4,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_bucket",
+						"le", "20.0",
+					),
+					es: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "59727"), Value: 15, HasTs: true, Ts: 1625851153146},
+					},
+				},
+				{
+					m: "test_histogram3_bucket\xffle\xff30.0",
+					v: 6,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_bucket",
+						"le", "30.0",
+					),
+					es: []exemplar.Exemplar{
+						{Labels: labels.FromStrings("dummyID", "5617"), Value: 25, HasTs: false},
+					},
+				},
+				{
+					m: "test_histogram3_bucket\xffle\xff+Inf",
+					v: 6,
+					lset: labels.FromStrings(
+						"__name__", "test_histogram3_bucket",
 						"le", "+Inf",
 					),
 				},


### PR DESCRIPTION
…by using strconv.AppendFloat instead of fmt.Sprint

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
 
 ```
                                                      │    v0.txt    │               v1.txt               │
                                                     │    sec/op    │    sec/op     vs base              │
Parse/data=promtestdata.txt/parser=promtext-2          126.7µ ± 11%   129.5µ ±  7%       ~ (p=0.310 n=6)
Parse/data=promtestdata.txt/parser=xpfmt-2             693.5µ ± 24%   744.2µ ± 18%  +7.30% (p=0.041 n=6)
Parse/data=promtestdata.nometa.txt/parser=promtext-2   113.1µ ±  4%   110.3µ ±  5%       ~ (p=0.310 n=6)
Parse/data=promtestdata.nometa.txt/parser=xpfmt-2      508.7µ ±  3%   498.1µ ±  4%       ~ (p=0.240 n=6)
Parse/data=createTestProtoBuf()/parser=promproto-2     37.61µ ± 20%   35.54µ ±  3%  -5.48% (p=0.004 n=6)
Parse/data=omtestdata.txt/parser=omtext-2              30.03µ ±  3%   29.91µ ±  2%       ~ (p=0.937 n=6)
Parse/data=promtestdata.txt/parser=omtext-2            2.413m ± 10%   2.392m ±  4%       ~ (p=0.394 n=6)
geomean                                                202.1µ         201.4µ        -0.34%

                                                     │    v0.txt     │               v1.txt                │
                                                     │      B/s      │      B/s       vs base              │
Parse/data=promtestdata.txt/parser=promtext-2          251.1Mi ± 10%   245.8Mi ±  7%       ~ (p=0.310 n=6)
Parse/data=promtestdata.txt/parser=xpfmt-2             45.89Mi ± 19%   42.77Mi ± 15%  -6.80% (p=0.041 n=6)
Parse/data=promtestdata.nometa.txt/parser=promtext-2   213.1Mi ±  3%   218.5Mi ±  5%       ~ (p=0.310 n=6)
Parse/data=promtestdata.nometa.txt/parser=xpfmt-2      47.36Mi ±  3%   48.38Mi ±  4%       ~ (p=0.240 n=6)
Parse/data=createTestProtoBuf()/parser=promproto-2     92.33Mi ± 17%   97.69Mi ±  3%  +5.80% (p=0.004 n=6)
Parse/data=omtestdata.txt/parser=omtext-2              142.2Mi ±  3%   142.8Mi ±  2%       ~ (p=0.937 n=6)
Parse/data=promtestdata.txt/parser=omtext-2            13.18Mi ± 10%   13.30Mi ±  4%       ~ (p=0.416 n=6)
geomean                                                79.53Mi         79.81Mi        +0.34%

                                                     │    v0.txt    │                v1.txt                │
                                                     │     B/op     │     B/op      vs base                │
Parse/data=promtestdata.txt/parser=promtext-2          57.07Ki ± 0%   57.07Ki ± 0%       ~ (p=1.000 n=6)
Parse/data=promtestdata.txt/parser=xpfmt-2             536.9Ki ± 0%   536.9Ki ± 0%       ~ (p=0.117 n=6)
Parse/data=promtestdata.nometa.txt/parser=promtext-2   57.07Ki ± 0%   57.07Ki ± 0%       ~ (p=1.000 n=6) ¹
Parse/data=promtestdata.nometa.txt/parser=xpfmt-2      381.1Ki ± 0%   381.1Ki ± 0%       ~ (p=1.000 n=6)
Parse/data=createTestProtoBuf()/parser=promproto-2     38.26Ki ± 0%   37.86Ki ± 0%  -1.06% (p=0.002 n=6)
Parse/data=omtestdata.txt/parser=omtext-2              10.55Ki ± 0%   10.55Ki ± 0%       ~ (p=1.000 n=6) ¹
Parse/data=promtestdata.txt/parser=omtext-2            108.4Ki ± 0%   108.4Ki ± 0%       ~ (p=0.922 n=6)
geomean                                                83.85Ki        83.72Ki       -0.15%
¹ all samples are equal

                                                     │   v0.txt    │               v1.txt                │
                                                     │  allocs/op  │  allocs/op   vs base                │
Parse/data=promtestdata.txt/parser=promtext-2           828.0 ± 0%    828.0 ± 0%       ~ (p=1.000 n=6) ¹
Parse/data=promtestdata.txt/parser=xpfmt-2             12.35k ± 0%   12.35k ± 0%       ~ (p=0.182 n=6)
Parse/data=promtestdata.nometa.txt/parser=promtext-2    828.0 ± 0%    828.0 ± 0%       ~ (p=1.000 n=6) ¹
Parse/data=promtestdata.nometa.txt/parser=xpfmt-2      10.01k ± 0%   10.01k ± 0%       ~ (p=1.000 n=6) ¹
Parse/data=createTestProtoBuf()/parser=promproto-2      863.0 ± 0%    810.0 ± 0%  -6.14% (p=0.002 n=6)
Parse/data=omtestdata.txt/parser=omtext-2               211.0 ± 0%    211.0 ± 0%       ~ (p=1.000 n=6) ¹
Parse/data=promtestdata.txt/parser=omtext-2            2.282k ± 0%   2.282k ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                1.663k        1.648k       -0.90%
¹ all samples are equal

 ```
 For `BenchmarkParse` use case (use "a lot" of summaries)
 
 ` v1.txt` being the PR.
 
 Still cannot justify the `Parse/data=promtestdata.txt/parser=xpfmt-2             693.5µ ± 24%   744.2µ ± 18%  +7.30% (p=0.041 n=6)` as `formatOpenMetricsFloat` is only used by `promproto`
 

---

Ran with `sync.Pool`

```
                                                   │   v0.txt    │               v1.txt               │
                                                   │   sec/op    │   sec/op     vs base               │
Parse/data=createTestProtoBuf()/parser=promproto-2   45.57µ ± 1%   42.98µ ± 3%  -5.67% (p=0.002 n=10)

                                                   │    v0.txt    │               v1.txt                │
                                                   │     B/s      │     B/s       vs base               │
Parse/data=createTestProtoBuf()/parser=promproto-2   76.20Mi ± 1%   80.79Mi ± 3%  +6.01% (p=0.002 n=10)

                                                   │    v0.txt    │               v1.txt                │
                                                   │     B/op     │     B/op      vs base               │
Parse/data=createTestProtoBuf()/parser=promproto-2   38.26Ki ± 0%   37.81Ki ± 0%  -1.18% (p=0.000 n=10)

                                                   │   v0.txt   │              v1.txt               │
                                                   │ allocs/op  │ allocs/op   vs base               │
Parse/data=createTestProtoBuf()/parser=promproto-2   863.0 ± 0%   809.0 ± 0%  -6.26% (p=0.000 n=10)

```
