### PR TITLE
Round function should ignore native histograms

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -551,6 +551,10 @@ func funcRound(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 	toNearestInverse := 1.0 / toNearest
 
 	for _, el := range vec {
+		if el.H != nil {
+			// Process only float samples.
+			continue
+		}
 		f := math.Floor(el.F*toNearestInverse+0.5) / toNearestInverse
 		enh.Out = append(enh.Out, Sample{
 			Metric:   el.Metric,

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -1258,3 +1258,12 @@ load 1m
 # We expect the value to be 0 for t=0s to t=59s (inclusive), then 60 for t=60s and t=61s.
 eval range from 0 to 61s step 1s timestamp(metric)
   {} 0x59 60 60
+
+clear
+
+# Check round with mixed data types
+load 1m
+	mixed_metric {{schema:0 sum:5 count:4 buckets:[1 2 1]}} 1 2 3 {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:8 count:6 buckets:[1 4 1]}}
+
+eval range from 0 to 5m step 1m round(mixed_metric)
+	{} _ 1 2 3


### PR DESCRIPTION
As per the documentation, native histograms are skipped. This is in line with other simpleFunc's.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
