### PR TITLE
Documented that WAL can still be written after memory-snapshot-on-shutdown

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -23,9 +23,8 @@ Exemplar storage is implemented as a fixed size circular buffer that stores exem
 
 `--enable-feature=memory-snapshot-on-shutdown`
 
-This takes the snapshot of the chunks that are in memory along with the series information when shutting down and stores it on disk 
-as a m-mapped structure. This will reduce the startup time since the memory state can now be restored with this snapshot 
-and m-mapped chunks without the need of WAL replay fetching hours of metrics by scanning through the disk again.
+This takes a snapshot of the chunks that are in memory along with the series information when shutting down and stores it on disk. This will reduce the startup time since the memory state can now be restored with this snapshot 
+and m-mapped chunks, while a WAL replay from disk is only needed for the parts of the WAL that are not part of the snapshot.
 
 ## Extra scrape metrics
 

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -23,9 +23,9 @@ Exemplar storage is implemented as a fixed size circular buffer that stores exem
 
 `--enable-feature=memory-snapshot-on-shutdown`
 
-This takes the snapshot of the chunks that are in memory along with the series information when shutting down and stores
-it on disk. This will reduce the startup time since the memory state can be restored with this snapshot and m-mapped
-chunks without the need of WAL replay.
+This takes the snapshot of the chunks that are in memory along with the series information when shutting down and stores it on disk 
+as a m-mapped structure. This will reduce the startup time since the memory state can now be restored with this snapshot 
+and m-mapped chunks without the need of WAL replay fetching hours of metrics by scanning through the disk again.
 
 ## Extra scrape metrics
 


### PR DESCRIPTION
#10824 - Document that WAL can still be written after memory-snapshot-on-shutdown

The explanation for "Memory snapshot on shutdown" under Feature flags documentation was modified to avoid misunderstanding of WAL still running after reboot, according to the comment section of issue #10824.

@beorn7 , Please have a look and let me know if it need improvement.



signed-off-by:Gopi-eng2202<gopi.singaravelan.k@gmail.com>