### PR TITLE
Remote Write: Close connection after 3 retries

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -271,6 +271,7 @@ func (c *Client) Store(ctx context.Context, req []byte, attempt int) (WriteRespo
 
 	if attempt > 0 {
 		httpReq.Header.Set("Retry-Attempt", strconv.Itoa(attempt))
+		httpReq.Close = attempt > 3
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)


### PR DESCRIPTION
I propose a change in remote write. If we error out for > 3 times, then we close the connection.

This is to help with user that are using load balancers and DNS, where the active connection might point to a wrong DNS entry but the load balancer of the old entry is still active, replying 503.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
