### PR TITLE
FastRegexMatcher: use stack memory for lowercase copy of string

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -802,7 +802,7 @@ type equalMultiStringMapMatcher struct {
 
 func (m *equalMultiStringMapMatcher) add(s string) {
 	if !m.caseSensitive {
-		s = toNormalisedLower(s)
+		s = toNormalisedLower(s, nil) // Don't pass a stack buffer here - it will always escape to heap.
 	}
 
 	m.values[s] = struct{}{}
@@ -840,15 +840,24 @@ func (m *equalMultiStringMapMatcher) setMatches() []string {
 }
 
 func (m *equalMultiStringMapMatcher) Matches(s string) bool {
-	if !m.caseSensitive {
-		s = toNormalisedLower(s)
+	if len(m.values) > 0 {
+		sNorm := s
+		var a [32]byte
+		if !m.caseSensitive {
+			sNorm = toNormalisedLower(s, a[:])
+		}
+		if _, ok := m.values[sNorm]; ok {
+			return true
+		}
 	}
 
-	if _, ok := m.values[s]; ok {
-		return true
-	}
 	if m.minPrefixLen > 0 && len(s) >= m.minPrefixLen {
-		for _, matcher := range m.prefixes[s[:m.minPrefixLen]] {
+		prefix := s[:m.minPrefixLen]
+		var a [32]byte
+		if !m.caseSensitive {
+			prefix = toNormalisedLower(s[:m.minPrefixLen], a[:])
+		}
+		for _, matcher := range m.prefixes[prefix] {
 			if matcher.Matches(s) {
 				return true
 			}
@@ -859,22 +868,37 @@ func (m *equalMultiStringMapMatcher) Matches(s string) bool {
 
 // toNormalisedLower normalise the input string using "Unicode Normalization Form D" and then convert
 // it to lower case.
-func toNormalisedLower(s string) string {
-	var buf []byte
+func toNormalisedLower(s string, a []byte) string {
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		if c >= utf8.RuneSelf {
 			return strings.Map(unicode.ToLower, norm.NFKD.String(s))
 		}
 		if 'A' <= c && c <= 'Z' {
-			if buf == nil {
-				buf = []byte(s)
-			}
-			buf[i] = c + 'a' - 'A'
+			return toNormalisedLowerSlow(s, i, a)
 		}
 	}
-	if buf == nil {
-		return s
+	return s
+}
+
+// toNormalisedLowerSlow is split from toNormalisedLower because having a call
+// to `copy` slows it down even when it is not called.
+func toNormalisedLowerSlow(s string, i int, a []byte) string {
+	var buf []byte
+	if cap(a) > len(s) {
+		buf = a[:len(s)]
+		copy(buf, s)
+	} else {
+		buf = []byte(s)
+	}
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c >= utf8.RuneSelf {
+			return strings.Map(unicode.ToLower, norm.NFKD.String(s))
+		}
+		if 'A' <= c && c <= 'Z' {
+			buf[i] = c + 'a' - 'A'
+		}
 	}
 	return yoloString(buf)
 }

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -333,7 +333,8 @@ func BenchmarkToNormalizedLower(b *testing.B) {
 							}
 							b.ResetTimer()
 							for n := 0; n < b.N; n++ {
-								toNormalisedLower(inputs[n%len(inputs)])
+								var a [256]byte
+								toNormalisedLower(inputs[n%len(inputs)], a[:])
 							}
 						})
 					}
@@ -1390,6 +1391,6 @@ func TestToNormalisedLower(t *testing.T) {
 		"ſſAſſa": "ssassa",
 	}
 	for input, expectedOutput := range testCases {
-		require.Equal(t, expectedOutput, toNormalisedLower(input))
+		require.Equal(t, expectedOutput, toNormalisedLower(input, nil))
 	}
 }


### PR DESCRIPTION
Use a buffer on the stack of the caller for modest-sized strings: saves garbage, runs faster.

For prefixes, only `toLower` the part we need for the map lookup.

Benchmarks:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                                            │   main.txt    │         faster-tolower.txt          │
                                                            │    sec/op     │    sec/op     vs base               │
FastRegexMatcher/#00-4                                         96.16n ±  2%   97.41n ±  8%        ~ (p=0.394 n=6)
FastRegexMatcher/foo-4                                         122.7n ±  3%   119.7n ±  5%        ~ (p=0.370 n=6)
FastRegexMatcher/^foo-4                                        93.95n ±  3%   91.20n ±  4%        ~ (p=0.132 n=6)
FastRegexMatcher/(foo|bar)-4                                   115.8n ±  2%   116.9n ±  5%        ~ (p=0.372 n=6)
FastRegexMatcher/foo.*-4                                       196.8n ±  4%   200.2n ±  3%        ~ (p=0.589 n=6)
FastRegexMatcher/.*foo-4                                       267.8n ±  1%   243.8n ±  6%   -8.96% (p=0.002 n=6)
FastRegexMatcher/^.*foo$-4                                     268.7n ±  5%   244.3n ±  3%   -9.10% (p=0.002 n=6)
FastRegexMatcher/^.+foo$-4                                     266.6n ±  1%   245.1n ±  4%   -8.03% (p=0.002 n=6)
FastRegexMatcher/.?-4                                          161.7n ±  1%   160.8n ±  4%        ~ (p=0.329 n=6)
FastRegexMatcher/.*-4                                          95.59n ±  8%   95.14n ±  3%        ~ (p=0.394 n=6)
FastRegexMatcher/.+-4                                          115.5n ±  2%   117.2n ±  5%        ~ (p=0.165 n=6)
FastRegexMatcher/foo.+-4                                       198.3n ±  2%   198.6n ±  4%        ~ (p=0.669 n=6)
FastRegexMatcher/.+foo-4                                       270.1n ±  5%   243.5n ±  3%   -9.81% (p=0.002 n=6)
FastRegexMatcher/foo_.+-4                                      190.0n ±  3%   187.1n ±  4%        ~ (p=0.310 n=6)
FastRegexMatcher/foo_.*-4                                      188.0n ±  3%   188.2n ±  3%        ~ (p=0.699 n=6)
FastRegexMatcher/.*foo.*-4                                     429.2n ±  7%   420.8n ±  4%        ~ (p=0.169 n=6)
FastRegexMatcher/.+foo.+-4                                     457.6n ±  4%   444.6n ±  4%        ~ (p=0.240 n=6)
FastRegexMatcher/(?s:.*)-4                                     95.13n ±  3%   94.92n ±  9%        ~ (p=0.818 n=6)
FastRegexMatcher/(?s:.+)-4                                     114.8n ±  2%   115.3n ±  5%        ~ (p=0.485 n=6)
FastRegexMatcher/(?s:^.*foo$)-4                                267.3n ±  4%   242.2n ±  9%   -9.41% (p=0.009 n=6)
FastRegexMatcher/(?i:foo)-4                                    175.8n ±  2%   178.2n ±  3%        ~ (p=0.180 n=6)
FastRegexMatcher/(?i:(foo|bar))-4                              368.4n ±  3%   363.9n ±  5%        ~ (p=0.589 n=6)
FastRegexMatcher/(?i:(foo1|foo2|bar))-4                        647.3n ±  5%   642.6n ±  2%        ~ (p=0.589 n=6)
FastRegexMatcher/^(?i:foo|oo)|(bar)$-4                         1.717µ ±  4%   1.701µ ±  5%        ~ (p=0.515 n=6)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-4            2.271µ ±  5%   1.341µ ± 15%  -40.97% (p=0.002 n=6)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-4                 998.1n ±  8%   991.1n ±  5%        ~ (p=0.699 n=6)
FastRegexMatcher/^$-4                                          95.30n ±  4%   96.44n ± 12%        ~ (p=0.699 n=6)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-4             363.9n ±  3%   361.2n ±  9%        ~ (p=0.937 n=6)
FastRegexMatcher/10\.0\.(1|2)\.+-4                             187.9n ±  8%   188.3n ±  3%        ~ (p=0.900 n=6)
FastRegexMatcher/10\.0\.(1|2).+-4                              190.6n ±  4%   188.3n ±  3%        ~ (p=0.288 n=6)
FastRegexMatcher/((fo(bar))|.+foo)-4                           484.7n ±  3%   460.5n ±  6%        ~ (p=0.065 n=6)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-4            495.2n ± 13%   521.5n ± 11%        ~ (p=0.734 n=6)
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-4            476.4n ± 15%   521.1n ±  6%        ~ (p=0.102 n=6)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-4            2.244µ ±  3%   1.378µ ± 11%  -38.59% (p=0.002 n=6)
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-4            793.1n ±  4%   796.9n ±  4%        ~ (p=0.485 n=6)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-4            534.2n ±  5%   538.9n ±  3%        ~ (p=0.563 n=6)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-4        2841.0n ±  4%   947.7n ±  7%  -66.64% (p=0.002 n=6)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-4            18.32µ ±  5%   18.16µ ±  3%        ~ (p=0.818 n=6)
FastRegexMatcher/fo.?-4                                        204.2n ±  4%   201.8n ±  8%        ~ (p=0.818 n=6)
FastRegexMatcher/foo.?-4                                       202.6n ±  7%   203.6n ±  3%        ~ (p=0.729 n=6)
FastRegexMatcher/f.?o-4                                        196.5n ±  3%   196.3n ±  2%        ~ (p=0.853 n=6)
FastRegexMatcher/.*foo.?-4                                     468.1n ±  3%   458.9n ±  2%   -1.97% (p=0.041 n=6)
FastRegexMatcher/.?foo.+-4                                     445.9n ±  5%   442.8n ±  4%        ~ (p=0.394 n=6)
FastRegexMatcher/foo.?|bar-4                                   334.5n ±  5%   344.3n ±  2%        ~ (p=0.093 n=6)
FastRegexMatcher/ſſs-4                                         121.1n ±  2%   121.1n ±  6%        ~ (p=0.937 n=6)
FastRegexMatcher/.*-.*-.*-.*-.*-4                              427.7n ±  3%   421.6n ±  2%        ~ (p=0.180 n=6)
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-4                    425.8n ±  4%   420.5n ±  4%        ~ (p=0.485 n=6)
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-4            9.020µ ±  6%   8.909µ ±  2%        ~ (p=0.223 n=6)
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-4            7.389µ ±  9%   7.309µ ±  4%        ~ (p=0.394 n=6)
ToNormalizedLower/length=10/uppercase=none/ascii=true-4        12.12n ±  3%   14.76n ±  4%  +21.78% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=none/ascii=false-4       365.5n ±  4%   369.8n ±  6%        ~ (p=0.818 n=6)
ToNormalizedLower/length=10/uppercase=first/ascii=true-4       63.61n ±  4%   23.52n ± 12%  -63.02% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=first/ascii=false-4      449.9n ±  2%   418.7n ±  2%   -6.95% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=last/ascii=true-4        65.05n ±  4%   23.14n ±  6%  -64.42% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=last/ascii=false-4       409.2n ±  8%   403.8n ±  2%        ~ (p=0.058 n=6)
ToNormalizedLower/length=10/uppercase=all/ascii=true-4         69.95n ±  3%   27.59n ±  5%  -60.56% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=all/ascii=false-4        425.1n ±  9%   402.4n ±  3%   -5.35% (p=0.009 n=6)
ToNormalizedLower/length=100/uppercase=none/ascii=true-4       87.95n ±  2%   96.80n ±  5%  +10.07% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=none/ascii=false-4      5.354µ ±  4%   4.938µ ±  9%   -7.76% (p=0.015 n=6)
ToNormalizedLower/length=100/uppercase=first/ascii=true-4      212.4n ±  6%   114.1n ±  3%  -46.26% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=first/ascii=false-4     5.610µ ±  4%   5.068µ ±  3%   -9.66% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=last/ascii=true-4       206.4n ±  4%   108.7n ±  2%  -47.34% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=last/ascii=false-4      5.468µ ±  9%   4.934µ ±  3%   -9.76% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=all/ascii=true-4        267.6n ±  6%   148.8n ±  4%  -44.37% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=all/ascii=false-4       5.175µ ±  5%   4.726µ ±  6%   -8.68% (p=0.002 n=6)
ToNormalizedLower/length=1000/uppercase=none/ascii=true-4      725.0n ±  2%   827.6n ±  5%  +14.16% (p=0.002 n=6)
ToNormalizedLower/length=1000/uppercase=none/ascii=false-4     44.25µ ±  9%   42.24µ ±  6%   -4.55% (p=0.026 n=6)
ToNormalizedLower/length=1000/uppercase=first/ascii=true-4     1.452µ ±  8%   1.200µ ±  5%  -17.36% (p=0.002 n=6)
ToNormalizedLower/length=1000/uppercase=first/ascii=false-4    45.75µ ±  2%   43.81µ ±  3%   -4.25% (p=0.002 n=6)
ToNormalizedLower/length=1000/uppercase=last/ascii=true-4      1.492µ ±  5%   1.266µ ±  5%  -15.18% (p=0.002 n=6)
ToNormalizedLower/length=1000/uppercase=last/ascii=false-4     44.17µ ±  4%   43.00µ ±  3%   -2.66% (p=0.026 n=6)
ToNormalizedLower/length=1000/uppercase=all/ascii=true-4       2.117µ ±  3%   1.750µ ±  5%  -17.34% (p=0.002 n=6)
ToNormalizedLower/length=1000/uppercase=all/ascii=false-4      41.73µ ±  3%   39.65µ ±  6%   -4.99% (p=0.015 n=6)
ToNormalizedLower/length=4000/uppercase=none/ascii=true-4      2.877µ ±  6%   3.247µ ±  3%  +12.84% (p=0.002 n=6)
ToNormalizedLower/length=4000/uppercase=none/ascii=false-4     173.9µ ±  3%   167.9µ ±  2%   -3.45% (p=0.026 n=6)
ToNormalizedLower/length=4000/uppercase=first/ascii=true-4     5.860µ ±  9%   4.818µ ±  4%  -17.78% (p=0.002 n=6)
ToNormalizedLower/length=4000/uppercase=first/ascii=false-4    178.9µ ±  2%   173.1µ ±  3%   -3.26% (p=0.041 n=6)
ToNormalizedLower/length=4000/uppercase=last/ascii=true-4      5.723µ ±  3%   4.855µ ± 10%  -15.17% (p=0.002 n=6)
ToNormalizedLower/length=4000/uppercase=last/ascii=false-4     171.1µ ±  3%   167.0µ ±  4%        ~ (p=0.180 n=6)
ToNormalizedLower/length=4000/uppercase=all/ascii=true-4       7.953µ ±  3%   6.669µ ±  3%  -16.14% (p=0.002 n=6)
ToNormalizedLower/length=4000/uppercase=all/ascii=false-4      165.7µ ±  3%   156.1µ ±  7%   -5.79% (p=0.026 n=6)
ZeroOrOneCharacterStringMatcher-4                              9.025n ±  2%   9.160n ±  5%        ~ (p=0.394 n=6)
geomean                                                        729.8n         655.5n        -10.18%

                                                            │    main.txt    │            faster-tolower.txt            │
                                                            │      B/op      │     B/op      vs base                    │
FastRegexMatcher/#00-4                                          0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo-4                                          0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/^foo-4                                         0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(foo|bar)-4                                    0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo.*-4                                        0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.*foo-4                                        0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/^.*foo$-4                                      0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/^.+foo$-4                                      0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.?-4                                           0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.*-4                                           0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.+-4                                           0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo.+-4                                        0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.+foo-4                                        0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo_.+-4                                       0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo_.*-4                                       0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.*foo.*-4                                      0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.+foo.+-4                                      0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?s:.*)-4                                      0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?s:.+)-4                                      0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?s:^.*foo$)-4                                 0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:foo)-4                                     0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(foo|bar))-4                               0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(foo1|foo2|bar))-4                         0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/^(?i:foo|oo)|(bar)$-4                          0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-4             560.0 ± 0%       240.0 ± 0%   -57.14% (p=0.002 n=6)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-4                  0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/^$-4                                           0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-4              0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/10\.0\.(1|2)\.+-4                              0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/10\.0\.(1|2).+-4                               0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/((fo(bar))|.+foo)-4                            0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-4             0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-4             0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-4             560.0 ± 0%       240.0 ± 0%   -57.14% (p=0.002 n=6)
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-4             0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-4             0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-4          560.0 ± 0%         0.0 ± 0%  -100.00% (p=0.002 n=6)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-4             0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/fo.?-4                                         0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo.?-4                                        0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/f.?o-4                                         0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.*foo.?-4                                      0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.?foo.+-4                                      0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo.?|bar-4                                    0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/ſſs-4                                          0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.*-.*-.*-.*-.*-4                               0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-4                     0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-4             0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-4             0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=10/uppercase=none/ascii=true-4         0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=10/uppercase=none/ascii=false-4        9.000 ± 0%       9.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=10/uppercase=first/ascii=true-4        16.00 ± 0%        0.00 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=first/ascii=false-4       17.00 ± 0%       11.00 ± 0%   -35.29% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=last/ascii=true-4         16.00 ± 0%        0.00 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=last/ascii=false-4        11.00 ± 0%       11.00 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=10/uppercase=all/ascii=true-4          16.00 ± 0%        0.00 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=all/ascii=false-4         22.00 ± 0%       16.00 ± 0%   -27.27% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=none/ascii=true-4        0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=100/uppercase=none/ascii=false-4     1.050Ki ± 0%     1.050Ki ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=100/uppercase=first/ascii=true-4       112.0 ± 0%         0.0 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=first/ascii=false-4    1.104Ki ± 0%     1.061Ki ± 0%    -3.98% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=last/ascii=true-4        112.0 ± 0%         0.0 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=last/ascii=false-4     1.061Ki ± 0%     1.061Ki ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=100/uppercase=all/ascii=true-4         112.0 ± 0%         0.0 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=all/ascii=false-4      1.137Ki ± 0%     1.094Ki ± 0%    -3.78% (p=0.002 n=6)
ToNormalizedLower/length=1000/uppercase=none/ascii=true-4       0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=none/ascii=false-4    4.862Ki ± 0%     4.862Ki ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=first/ascii=true-4    1.000Ki ± 0%     1.000Ki ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=first/ascii=false-4   5.375Ki ± 0%     5.375Ki ± 0%         ~ (p=0.455 n=6)
ToNormalizedLower/length=1000/uppercase=last/ascii=true-4     1.000Ki ± 0%     1.000Ki ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=last/ascii=false-4    4.975Ki ± 0%     4.975Ki ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=all/ascii=true-4      1.000Ki ± 0%     1.000Ki ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=all/ascii=false-4     5.712Ki ± 0%     5.712Ki ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=none/ascii=true-4       0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=none/ascii=false-4    17.41Ki ± 0%     17.41Ki ± 0%         ~ (p=1.000 n=6)
ToNormalizedLower/length=4000/uppercase=first/ascii=true-4    4.000Ki ± 0%     4.000Ki ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=first/ascii=false-4   19.49Ki ± 0%     19.49Ki ± 0%         ~ (p=0.242 n=6)
ToNormalizedLower/length=4000/uppercase=last/ascii=true-4     4.000Ki ± 0%     4.000Ki ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=last/ascii=false-4    17.89Ki ± 0%     17.89Ki ± 0%         ~ (p=0.545 n=6)
ToNormalizedLower/length=4000/uppercase=all/ascii=true-4      4.000Ki ± 0%     4.000Ki ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=all/ascii=false-4     20.91Ki ± 0%     20.91Ki ± 0%         ~ (p=1.000 n=6) ¹
ZeroOrOneCharacterStringMatcher-4                               0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=6) ¹
geomean                                                                    ²                 ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                                            │   main.txt    │           faster-tolower.txt           │
                                                            │   allocs/op   │ allocs/op   vs base                    │
FastRegexMatcher/#00-4                                         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo-4                                         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/^foo-4                                        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(foo|bar)-4                                   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo.*-4                                       0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.*foo-4                                       0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/^.*foo$-4                                     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/^.+foo$-4                                     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.?-4                                          0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.*-4                                          0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.+-4                                          0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo.+-4                                       0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.+foo-4                                       0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo_.+-4                                      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo_.*-4                                      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.*foo.*-4                                     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.+foo.+-4                                     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?s:.*)-4                                     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?s:.+)-4                                     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?s:^.*foo$)-4                                0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:foo)-4                                    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(foo|bar))-4                              0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(foo1|foo2|bar))-4                        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/^(?i:foo|oo)|(bar)$-4                         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-4           18.000 ± 0%     3.000 ± 0%   -83.33% (p=0.002 n=6)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-4                 0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/^$-4                                          0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-4             0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/10\.0\.(1|2)\.+-4                             0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/10\.0\.(1|2).+-4                              0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/((fo(bar))|.+foo)-4                           0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-4            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-4            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-4           18.000 ± 0%     3.000 ± 0%   -83.33% (p=0.002 n=6)
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-4            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-4            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-4         18.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-4            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/fo.?-4                                        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo.?-4                                       0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/f.?o-4                                        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.*foo.?-4                                     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.?foo.+-4                                     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/foo.?|bar-4                                   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/ſſs-4                                         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/.*-.*-.*-.*-.*-4                              0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-4                    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-4            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-4            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=10/uppercase=none/ascii=true-4        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=10/uppercase=none/ascii=false-4       0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=10/uppercase=first/ascii=true-4       1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=first/ascii=false-4      1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=last/ascii=true-4        1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=last/ascii=false-4       0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=10/uppercase=all/ascii=true-4         1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=10/uppercase=all/ascii=false-4        1.000 ± 0%     1.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=100/uppercase=none/ascii=true-4       0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=100/uppercase=none/ascii=false-4      4.000 ± 0%     4.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=100/uppercase=first/ascii=true-4      1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=first/ascii=false-4     5.000 ± 0%     4.000 ± 0%   -20.00% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=last/ascii=true-4       1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=last/ascii=false-4      4.000 ± 0%     4.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=100/uppercase=all/ascii=true-4        1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
ToNormalizedLower/length=100/uppercase=all/ascii=false-4       5.000 ± 0%     5.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=none/ascii=true-4      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=none/ascii=false-4     4.000 ± 0%     4.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=first/ascii=true-4     1.000 ± 0%     1.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=first/ascii=false-4    5.000 ± 0%     5.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=last/ascii=true-4      1.000 ± 0%     1.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=last/ascii=false-4     4.000 ± 0%     4.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=all/ascii=true-4       1.000 ± 0%     1.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=1000/uppercase=all/ascii=false-4      5.000 ± 0%     5.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=none/ascii=true-4      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=none/ascii=false-4     4.000 ± 0%     4.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=first/ascii=true-4     1.000 ± 0%     1.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=first/ascii=false-4    5.000 ± 0%     5.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=last/ascii=true-4      1.000 ± 0%     1.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=last/ascii=false-4     4.000 ± 0%     4.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=all/ascii=true-4       1.000 ± 0%     1.000 ± 0%         ~ (p=1.000 n=6) ¹
ToNormalizedLower/length=4000/uppercase=all/ascii=false-4      5.000 ± 0%     5.000 ± 0%         ~ (p=1.000 n=6) ¹
ZeroOrOneCharacterStringMatcher-4                              0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
geomean                                                                   ²               ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```
