### PR TITLE
[CHANGE] Remote-write: default enable_http2 to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * [CHANGE] Scraping: Remove implicit fallback to the Prometheus text format in case of invalid/missing Content-Type and fail the scrape instead. Add ability to specify a `fallback_scrape_protocol` in the scrape config. #15136
+* [CHANGE] Remote-write: default enable_http2 to false.
 * [ENHANCEMENT] Scraping, rules: handle targets reappearing, or rules moving group, when out-of-order is enabled. #14710 
 - [BUGFIX] PromQL: Fix stddev+stdvar aggregations to always ignore native histograms. #14941
 - [BUGFIX] PromQL: Fix stddev+stdvar aggregations to treat Infinity consistently. #14941

--- a/config/config.go
+++ b/config/config.go
@@ -181,13 +181,18 @@ var (
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 
+	DefaultRemoteWriteHTTPClientConfig = config.HTTPClientConfig{
+		FollowRedirects: true,
+		EnableHTTP2:     false,
+	}
+
 	// DefaultRemoteWriteConfig is the default remote write configuration.
 	DefaultRemoteWriteConfig = RemoteWriteConfig{
 		RemoteTimeout:    model.Duration(30 * time.Second),
 		ProtobufMessage:  RemoteWriteProtoMsgV1,
 		QueueConfig:      DefaultQueueConfig,
 		MetadataConfig:   DefaultMetadataConfig,
-		HTTPClientConfig: config.DefaultHTTPClientConfig,
+		HTTPClientConfig: DefaultRemoteWriteHTTPClientConfig,
 	}
 
 	// DefaultQueueConfig is the default remote queue configuration.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2889,6 +2889,7 @@ metadata_config:
 
 # HTTP client settings, including authentication methods (such as basic auth and
 # authorization), proxy configurations, TLS options, custom HTTP headers, etc.
+# enable_http2 defaults to false for remote-write.
 [ <http_config> ]
 ```
 


### PR DESCRIPTION
Remote-write creates several shards to parallelise sending, each with its own http connection.
We do not want them all combined onto one socket by http2.

This can cause problems due to head-of-line blocking, or per-connection bandwidth limits.

Some more background at #10155.

[Note I haven't tried this code yet.]