### PR TITLE
Docs: Remove experimental note on out of order feature

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2940,8 +2940,6 @@ with this feature.
 
 `tsdb` lets you configure the runtime-reloadable configuration settings of the TSDB.
 
-NOTE: Out-of-order ingestion is an experimental feature, but you do not need any additional flag to enable it. Setting `out_of_order_time_window` to a positive duration enables it.
-
 ```yaml
 # Configures how old an out-of-order/out-of-bounds sample can be w.r.t. the TSDB max time.
 # An out-of-order/out-of-bounds sample is ingested into the TSDB as long as the timestamp


### PR DESCRIPTION
Relates to https://github.com/prometheus/prometheus/issues/12631

We've completed most of the pending tasks related to cleanup and necessary bits to trust this feature. We've also been running this in production for two years now to trust it to be stable enough. It is also an opt in feature so it can be enabled and disabled at will should it cause any trouble.

I only encountered one reference of it being experimental in the docs and I'm removing that.