### PR TITLE
refactor: reorder fields in defaultSDConfig initialization

### DIFF
--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -41,8 +41,8 @@ import (
 var (
 	// DefaultSDConfig is the default HTTP SD configuration.
 	DefaultSDConfig = SDConfig{
-		RefreshInterval:  model.Duration(60 * time.Second),
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
+		RefreshInterval:  model.Duration(60 * time.Second),
 	}
 	userAgent        = fmt.Sprintf("Prometheus/%s", version.Version)
 	matchContentType = regexp.MustCompile(`^(?i:application\/json(;\s*charset=("utf-8"|utf-8))?)$`)


### PR DESCRIPTION
This refactor improves **the consistency of field ordering** in the `defaultSDConfig` initialization. 

The fields in the `SDConfig` struct are defined in the order of `HTTPClientConfig` followed by `RefreshInterval`. However, in the creation of `defaultSDConfig`, they are in **reverse order**. 

```go
type SDConfig struct {
	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
	RefreshInterval  model.Duration          `yaml:"refresh_interval,omitempty"`
	URL              string                  `yaml:"url"`
}

// before
DefaultSDConfig = SDConfig{
	RefreshInterval:  model.Duration(60 * time.Second),
	HTTPClientConfig: config.DefaultHTTPClientConfig,
}

// enhanced
DefaultSDConfig = SDConfig{
	HTTPClientConfig: config.DefaultHTTPClientConfig,
	RefreshInterval:  model.Duration(60 * time.Second),
}
```


By reordering fields, the configuration initialization follows a more predictable structure, which aligns with similar configurations across the codebase. This change aims to improve code readability and maintainability without altering functionality.

