### PR TITLE
Parallelize tests in cmd/promtool/

### DIFF
--- a/cmd/promtool/analyze_test.go
+++ b/cmd/promtool/analyze_test.go
@@ -109,6 +109,7 @@ func init() {
 }
 
 func TestGetBucketCountsAtTime(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		matrix   model.Matrix
 		length   int
@@ -137,6 +138,7 @@ func TestGetBucketCountsAtTime(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("exampleMatrix@%d", c.timeIdx), func(t *testing.T) {
+			t.Parallel()
 			res, err := getBucketCountsAtTime(c.matrix, c.length, c.timeIdx)
 			require.NoError(t, err)
 			require.Equal(t, c.expected, res)
@@ -145,6 +147,7 @@ func TestGetBucketCountsAtTime(t *testing.T) {
 }
 
 func TestCalcClassicBucketStatistics(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		matrix   model.Matrix
 		expected *statistics
@@ -162,6 +165,7 @@ func TestCalcClassicBucketStatistics(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			t.Parallel()
 			res, err := calcClassicBucketStatistics(c.matrix)
 			require.NoError(t, err)
 			require.Equal(t, c.expected, res)

--- a/cmd/promtool/backfill_test.go
+++ b/cmd/promtool/backfill_test.go
@@ -86,6 +86,7 @@ func testBlocks(t *testing.T, db *tsdb.DB, expectedMinTime, expectedMaxTime, exp
 }
 
 func TestBackfill(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		ToParse              string
 		IsOk                 bool
@@ -729,6 +730,7 @@ after_eof 1 2
 	}
 	for _, test := range tests {
 		t.Run(test.Description, func(t *testing.T) {
+			t.Parallel()
 			t.Logf("Test:%s", test.Description)
 
 			outputDir := t.TempDir()

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -60,6 +60,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestQueryRange(t *testing.T) {
+	t.Parallel()
 	s, getRequest := mockServer(200, `{"status": "success", "data": {"resultType": "matrix", "result": []}}`)
 	defer s.Close()
 
@@ -83,6 +84,7 @@ func TestQueryRange(t *testing.T) {
 }
 
 func TestQueryInstant(t *testing.T) {
+	t.Parallel()
 	s, getRequest := mockServer(200, `{"status": "success", "data": {"resultType": "vector", "result": []}}`)
 	defer s.Close()
 
@@ -114,6 +116,7 @@ func mockServer(code int, body string) (*httptest.Server, func() *http.Request) 
 }
 
 func TestCheckSDFile(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		file string
@@ -144,6 +147,7 @@ func TestCheckSDFile(t *testing.T) {
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := checkSDFile(test.file)
 			if test.err != "" {
 				require.EqualErrorf(t, err, test.err, "Expected error %q, got %q", test.err, err.Error())
@@ -155,6 +159,7 @@ func TestCheckSDFile(t *testing.T) {
 }
 
 func TestCheckDuplicates(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name         string
 		ruleFile     string
@@ -179,6 +184,7 @@ func TestCheckDuplicates(t *testing.T) {
 	for _, test := range cases {
 		c := test
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
 			rgs, err := rulefmt.ParseFile(c.ruleFile)
 			require.Empty(t, err)
 			dups := checkDuplicates(rgs.Groups)
@@ -198,6 +204,7 @@ func BenchmarkCheckDuplicates(b *testing.B) {
 }
 
 func TestCheckTargetConfig(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		file string
@@ -226,6 +233,7 @@ func TestCheckTargetConfig(t *testing.T) {
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := checkConfig(false, "testdata/"+test.file, false)
 			if test.err != "" {
 				require.EqualErrorf(t, err, test.err, "Expected error %q, got %q", test.err, err.Error())
@@ -237,6 +245,7 @@ func TestCheckTargetConfig(t *testing.T) {
 }
 
 func TestCheckConfigSyntax(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name       string
 		file       string
@@ -309,6 +318,7 @@ func TestCheckConfigSyntax(t *testing.T) {
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := checkConfig(false, "testdata/"+test.file, test.syntaxOnly)
 			expectedErrMsg := test.err
 			if strings.Contains(runtime.GOOS, "windows") {
@@ -324,6 +334,7 @@ func TestCheckConfigSyntax(t *testing.T) {
 }
 
 func TestAuthorizationConfig(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		file string
@@ -343,6 +354,7 @@ func TestAuthorizationConfig(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := checkConfig(false, "testdata/"+test.file, false)
 			if test.err != "" {
 				require.ErrorContains(t, err, test.err, "Expected error to contain %q, got %q", test.err, err.Error())
@@ -357,6 +369,7 @@ func TestCheckMetricsExtended(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on windows")
 	}
+	t.Parallel()
 
 	f, err := os.Open("testdata/metrics-test.prom")
 	require.NoError(t, err)
@@ -393,6 +406,7 @@ func TestExitCodes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
+	t.Parallel()
 
 	for _, c := range []struct {
 		file      string
@@ -417,8 +431,10 @@ func TestExitCodes(t *testing.T) {
 		},
 	} {
 		t.Run(c.file, func(t *testing.T) {
+			t.Parallel()
 			for _, lintFatal := range []bool{true, false} {
 				t.Run(strconv.FormatBool(lintFatal), func(t *testing.T) {
+					t.Parallel()
 					args := []string{"-test.main", "check", "config", "testdata/" + c.file}
 					if lintFatal {
 						args = append(args, "--lint-fatal")
@@ -449,6 +465,7 @@ func TestDocumentation(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -542,16 +559,19 @@ func TestCheckRules(t *testing.T) {
 
 func TestCheckRulesWithRuleFiles(t *testing.T) {
 	t.Run("rules-good", func(t *testing.T) {
+		t.Parallel()
 		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, false), "./testdata/rules.yml")
 		require.Equal(t, successExitCode, exitCode, "")
 	})
 
 	t.Run("rules-bad", func(t *testing.T) {
+		t.Parallel()
 		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, false), "./testdata/rules-bad.yml")
 		require.Equal(t, failureExitCode, exitCode, "")
 	})
 
 	t.Run("rules-lint-fatal", func(t *testing.T) {
+		t.Parallel()
 		exitCode := CheckRules(newLintConfig(lintOptionDuplicateRules, true), "./testdata/prometheus-rules.lint.yml")
 		require.Equal(t, lintErrExitCode, exitCode, "")
 	})
@@ -561,6 +581,7 @@ func TestTSDBDumpCommand(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
+	t.Parallel()
 
 	storage := promqltest.LoadedStorage(t, `
 	load 1m
@@ -593,6 +614,7 @@ func TestTSDBDumpCommand(t *testing.T) {
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
 			args := []string{"-test.main", "tsdb", c.subCmd, storage.Dir()}
 			cmd := exec.Command(promtoolPath, args...)
 			require.NoError(t, cmd.Run())

--- a/cmd/promtool/rules_test.go
+++ b/cmd/promtool/rules_test.go
@@ -43,6 +43,7 @@ const defaultBlockDuration = time.Duration(tsdb.DefaultBlockDuration) * time.Mil
 
 // TestBackfillRuleIntegration is an integration test that runs all the rule importer code to confirm the parts work together.
 func TestBackfillRuleIntegration(t *testing.T) {
+	t.Parallel()
 	const (
 		testMaxSampleCount = 50
 		testValue          = 123
@@ -72,6 +73,7 @@ func TestBackfillRuleIntegration(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tmpDir := t.TempDir()
 			ctx := context.Background()
 
@@ -210,6 +212,7 @@ func createMultiRuleTestFiles(path string) error {
 // TestBackfillLabels confirms that the labels in the rule file override the labels from the metrics
 // received from Prometheus Query API, including the __name__ label.
 func TestBackfillLabels(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	ctx := context.Background()
 
@@ -251,6 +254,7 @@ func TestBackfillLabels(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("correct-labels", func(t *testing.T) {
+		t.Parallel()
 		selectedSeries := q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchRegexp, "", ".*"))
 		for selectedSeries.Next() {
 			series := selectedSeries.At()

--- a/cmd/promtool/sd_test.go
+++ b/cmd/promtool/sd_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestSDCheckResult(t *testing.T) {
+	t.Parallel()
 	targetGroups := []*targetgroup.Group{{
 		Targets: []model.LabelSet{
 			map[model.LabelName]model.LabelValue{"__address__": "localhost:8080", "foo": "bar"},

--- a/cmd/promtool/tsdb_test.go
+++ b/cmd/promtool/tsdb_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestGenerateBucket(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		min, max         int
 		start, end, step int

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestRulesUnitTest(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		files []string
 	}
@@ -141,12 +142,14 @@ func TestRulesUnitTest(t *testing.T) {
 			reuseCount[tt.want] += len(tt.args.files)
 		}
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := RulesUnitTest(tt.queryOpts, nil, false, false, tt.args.files...); got != tt.want {
 				t.Errorf("RulesUnitTest() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 	t.Run("Junit xml output ", func(t *testing.T) {
+		t.Parallel()
 		var buf bytes.Buffer
 		if got := RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, nil, false, false, reuseFiles...); got != 1 {
 			t.Errorf("RulesUnitTestResults() = %v, want 1", got)
@@ -185,6 +188,7 @@ func TestRulesUnitTest(t *testing.T) {
 }
 
 func TestRulesUnitTestRun(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		run   []string
 		files []string
@@ -230,6 +234,7 @@ func TestRulesUnitTestRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := RulesUnitTest(tt.queryOpts, tt.args.run, false, false, tt.args.files...)
 			require.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
# Changes
Parallelize testcases using `t.Parallel()` in the `cmd/promtool/` directory.
Related to https://github.com/prometheus/prometheus/issues/15185

- Tests that use `os.Stdin` or `os.Stdout` are not trivial to parallelize, hence remain unchanged.
- All other tests run in parallel.

## Time saved on my machine
Before, on main ([bab587b](https://github.com/prometheus/prometheus/commit/bab587b9dca16274e38babbbf56efba50956dbd2))
```
$ go test -race --count=1 ./cmd/promtool
ok   github.com/prometheus/prometheus/cmd/promtool   91.798s
```
After adding `t.Parallel()`
```bash
go test --count=1 ./cmd/promtool
ok       github.com/prometheus/prometheus/cmd/promtool   66.425s
```
Test execution time for `github.com/prometheus/prometheus/cmd/promtool` reduced by `~25%`: `91s -> 66s`.

Also verified no races using the race detector (`-race`)
```
$ go test -race --count=1 ./cmd/promtool
ok   github.com/prometheus/prometheus/cmd/promtool   76.337s
```

