### PR TITLE
Run discovery/kubernetes tests in parallel

### DIFF
--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -97,6 +97,7 @@ func makeEndpoints() *v1.Endpoints {
 }
 
 func TestEndpointsDiscoveryBeforeRun(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -151,6 +152,7 @@ func TestEndpointsDiscoveryBeforeRun(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryAdd(t *testing.T) {
+	t.Parallel()
 	obj := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
@@ -276,6 +278,7 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryDelete(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
@@ -294,6 +297,7 @@ func TestEndpointsDiscoveryDelete(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryUpdate(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
@@ -365,6 +369,7 @@ func TestEndpointsDiscoveryUpdate(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryEmptySubsets(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
@@ -393,6 +398,7 @@ func TestEndpointsDiscoveryEmptySubsets(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryWithService(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
@@ -458,6 +464,7 @@ func TestEndpointsDiscoveryWithService(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryWithServiceUpdate(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints())
 
 	k8sDiscoveryTest{
@@ -538,6 +545,7 @@ func TestEndpointsDiscoveryWithServiceUpdate(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryWithNodeMetadata(t *testing.T) {
+	t.Parallel()
 	metadataConfig := AttachMetadataConfig{Node: true}
 	nodeLabels1 := map[string]string{"az": "us-east1"}
 	nodeLabels2 := map[string]string{"az": "us-west2"}
@@ -611,6 +619,7 @@ func TestEndpointsDiscoveryWithNodeMetadata(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryWithUpdatedNodeMetadata(t *testing.T) {
+	t.Parallel()
 	nodeLabels1 := map[string]string{"az": "us-east1"}
 	nodeLabels2 := map[string]string{"az": "us-west2"}
 	node1 := makeNode("foobar", "", "", nodeLabels1, nil)
@@ -688,6 +697,7 @@ func TestEndpointsDiscoveryWithUpdatedNodeMetadata(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
 	epOne := makeEndpoints()
 	epOne.Namespace = "ns1"
 	objs := []runtime.Object{
@@ -839,6 +849,7 @@ func TestEndpointsDiscoveryNamespaces(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryOwnNamespace(t *testing.T) {
+	t.Parallel()
 	epOne := makeEndpoints()
 	epOne.Namespace = "own-ns"
 
@@ -933,6 +944,7 @@ func TestEndpointsDiscoveryOwnNamespace(t *testing.T) {
 }
 
 func TestEndpointsDiscoveryEmptyPodStatus(t *testing.T) {
+	t.Parallel()
 	ep := makeEndpoints()
 	ep.Namespace = "ns"
 
@@ -978,6 +990,7 @@ func TestEndpointsDiscoveryEmptyPodStatus(t *testing.T) {
 // TestEndpointsDiscoveryUpdatePod makes sure that Endpoints discovery detects underlying Pods changes.
 // See https://github.com/prometheus/prometheus/issues/11305 for more details.
 func TestEndpointsDiscoveryUpdatePod(t *testing.T) {
+	t.Parallel()
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
@@ -1097,6 +1110,7 @@ func TestEndpointsDiscoveryUpdatePod(t *testing.T) {
 }
 
 func TestEndpointsDiscoverySidecarContainer(t *testing.T) {
+	t.Parallel()
 	objs := []runtime.Object{
 		&v1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{

--- a/discovery/kubernetes/endpointslice_adaptor_test.go
+++ b/discovery/kubernetes/endpointslice_adaptor_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func Test_EndpointSliceAdaptor_v1(t *testing.T) {
+	t.Parallel()
 	endpointSlice := makeEndpointSliceV1()
 	adaptor := newEndpointSliceAdaptorFromV1(endpointSlice)
 

--- a/discovery/kubernetes/endpointslice_test.go
+++ b/discovery/kubernetes/endpointslice_test.go
@@ -114,6 +114,7 @@ func makeEndpointSliceV1() *v1.EndpointSlice {
 }
 
 func TestEndpointSliceDiscoveryBeforeRun(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{Names: []string{"default"}})
 
 	k8sDiscoveryTest{
@@ -195,6 +196,7 @@ func TestEndpointSliceDiscoveryBeforeRun(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryAdd(t *testing.T) {
+	t.Parallel()
 	obj := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
@@ -322,6 +324,7 @@ func TestEndpointSliceDiscoveryAdd(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryDelete(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{Names: []string{"default"}}, makeEndpointSliceV1())
 
 	k8sDiscoveryTest{
@@ -340,6 +343,7 @@ func TestEndpointSliceDiscoveryDelete(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryUpdate(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{Names: []string{"default"}}, makeEndpointSliceV1())
 
 	k8sDiscoveryTest{
@@ -396,6 +400,7 @@ func TestEndpointSliceDiscoveryUpdate(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryEmptyEndpoints(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{Names: []string{"default"}}, makeEndpointSliceV1())
 
 	k8sDiscoveryTest{
@@ -424,6 +429,7 @@ func TestEndpointSliceDiscoveryEmptyEndpoints(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryWithService(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{Names: []string{"default"}}, makeEndpointSliceV1())
 
 	k8sDiscoveryTest{
@@ -516,6 +522,7 @@ func TestEndpointSliceDiscoveryWithService(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryWithServiceUpdate(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{Names: []string{"default"}}, makeEndpointSliceV1())
 
 	k8sDiscoveryTest{
@@ -623,6 +630,7 @@ func TestEndpointSliceDiscoveryWithServiceUpdate(t *testing.T) {
 }
 
 func TestEndpointsSlicesDiscoveryWithNodeMetadata(t *testing.T) {
+	t.Parallel()
 	metadataConfig := AttachMetadataConfig{Node: true}
 	nodeLabels1 := map[string]string{"az": "us-east1"}
 	nodeLabels2 := map[string]string{"az": "us-west2"}
@@ -722,6 +730,7 @@ func TestEndpointsSlicesDiscoveryWithNodeMetadata(t *testing.T) {
 }
 
 func TestEndpointsSlicesDiscoveryWithUpdatedNodeMetadata(t *testing.T) {
+	t.Parallel()
 	metadataConfig := AttachMetadataConfig{Node: true}
 	nodeLabels1 := map[string]string{"az": "us-east1"}
 	nodeLabels2 := map[string]string{"az": "us-west2"}
@@ -827,6 +836,7 @@ func TestEndpointsSlicesDiscoveryWithUpdatedNodeMetadata(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
 	epOne := makeEndpointSliceV1()
 	epOne.Namespace = "ns1"
 	objs := []runtime.Object{
@@ -1003,6 +1013,7 @@ func TestEndpointSliceDiscoveryNamespaces(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryOwnNamespace(t *testing.T) {
+	t.Parallel()
 	epOne := makeEndpointSliceV1()
 	epOne.Namespace = "own-ns"
 
@@ -1123,6 +1134,7 @@ func TestEndpointSliceDiscoveryOwnNamespace(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoveryEmptyPodStatus(t *testing.T) {
+	t.Parallel()
 	ep := makeEndpointSliceV1()
 	ep.Namespace = "ns"
 
@@ -1169,6 +1181,7 @@ func TestEndpointSliceDiscoveryEmptyPodStatus(t *testing.T) {
 // sets up indexing for the main Kube informer only when needed.
 // See: https://github.com/prometheus/prometheus/pull/13554#discussion_r1490965817
 func TestEndpointSliceInfIndexersCount(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		withNodeMetadata bool
@@ -1179,6 +1192,7 @@ func TestEndpointSliceInfIndexersCount(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			var (
 				n                    *Discovery
 				mainInfIndexersCount int
@@ -1204,6 +1218,7 @@ func TestEndpointSliceInfIndexersCount(t *testing.T) {
 }
 
 func TestEndpointSliceDiscoverySidecarContainer(t *testing.T) {
+	t.Parallel()
 	objs := []runtime.Object{
 		&v1.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{

--- a/discovery/kubernetes/ingress_test.go
+++ b/discovery/kubernetes/ingress_test.go
@@ -144,6 +144,7 @@ func expectedTargetGroups(ns string, tls TLSMode) map[string]*targetgroup.Group 
 }
 
 func TestIngressDiscoveryAdd(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
 
 	k8sDiscoveryTest{
@@ -158,6 +159,7 @@ func TestIngressDiscoveryAdd(t *testing.T) {
 }
 
 func TestIngressDiscoveryAddTLS(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
 
 	k8sDiscoveryTest{
@@ -172,6 +174,7 @@ func TestIngressDiscoveryAddTLS(t *testing.T) {
 }
 
 func TestIngressDiscoveryAddMixed(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"default"}})
 
 	k8sDiscoveryTest{
@@ -186,6 +189,7 @@ func TestIngressDiscoveryAddMixed(t *testing.T) {
 }
 
 func TestIngressDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{Names: []string{"ns1", "ns2"}})
 
 	expected := expectedTargetGroups("ns1", TLSNo)
@@ -207,6 +211,7 @@ func TestIngressDiscoveryNamespaces(t *testing.T) {
 }
 
 func TestIngressDiscoveryOwnNamespace(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleIngress, NamespaceDiscovery{IncludeOwnNamespace: true})
 
 	expected := expectedTargetGroups("own-ns", TLSNo)

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -273,6 +273,7 @@ func (s *Service) hasSynced() bool {
 }
 
 func TestRetryOnError(t *testing.T) {
+	t.Parallel()
 	for _, successAt := range []int{1, 2, 3} {
 		var called int
 		f := func() error {
@@ -288,6 +289,7 @@ func TestRetryOnError(t *testing.T) {
 }
 
 func TestFailuresCountMetric(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		role             Role
 		minFailedWatches int
@@ -324,6 +326,7 @@ func TestFailuresCountMetric(t *testing.T) {
 }
 
 func TestNodeName(t *testing.T) {
+	t.Parallel()
 	node := &apiv1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo",

--- a/discovery/kubernetes/node_test.go
+++ b/discovery/kubernetes/node_test.go
@@ -56,6 +56,7 @@ func makeEnumeratedNode(i int) *v1.Node {
 }
 
 func TestNodeDiscoveryBeforeStart(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -95,6 +96,7 @@ func TestNodeDiscoveryBeforeStart(t *testing.T) {
 }
 
 func TestNodeDiscoveryAdd(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -124,6 +126,7 @@ func TestNodeDiscoveryAdd(t *testing.T) {
 }
 
 func TestNodeDiscoveryDelete(t *testing.T) {
+	t.Parallel()
 	obj := makeEnumeratedNode(0)
 	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{}, obj)
 
@@ -142,6 +145,7 @@ func TestNodeDiscoveryDelete(t *testing.T) {
 }
 
 func TestNodeDiscoveryUpdate(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleNode, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{

--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -239,6 +239,7 @@ func expectedPodTargetGroupsWithNodeMeta(ns, nodeName string, nodeLabels map[str
 }
 
 func TestPodDiscoveryBeforeRun(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -302,6 +303,7 @@ func TestPodDiscoveryBeforeRun(t *testing.T) {
 }
 
 func TestPodDiscoveryInitContainer(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
 
 	ns := "default"
@@ -329,6 +331,7 @@ func TestPodDiscoveryInitContainer(t *testing.T) {
 }
 
 func TestPodDiscoveryAdd(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -343,6 +346,7 @@ func TestPodDiscoveryAdd(t *testing.T) {
 }
 
 func TestPodDiscoveryDelete(t *testing.T) {
+	t.Parallel()
 	obj := makePods()
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{}, obj)
 
@@ -362,6 +366,7 @@ func TestPodDiscoveryDelete(t *testing.T) {
 }
 
 func TestPodDiscoveryUpdate(t *testing.T) {
+	t.Parallel()
 	obj := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
@@ -403,6 +408,7 @@ func TestPodDiscoveryUpdate(t *testing.T) {
 }
 
 func TestPodDiscoveryUpdateEmptyPodIP(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
 	initialPod := makePods()
 
@@ -427,6 +433,7 @@ func TestPodDiscoveryUpdateEmptyPodIP(t *testing.T) {
 }
 
 func TestPodDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{Names: []string{"ns1", "ns2"}})
 
 	expected := expectedPodTargetGroups("ns1")
@@ -448,6 +455,7 @@ func TestPodDiscoveryNamespaces(t *testing.T) {
 }
 
 func TestPodDiscoveryOwnNamespace(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RolePod, NamespaceDiscovery{IncludeOwnNamespace: true})
 
 	expected := expectedPodTargetGroups("own-ns")
@@ -466,6 +474,7 @@ func TestPodDiscoveryOwnNamespace(t *testing.T) {
 }
 
 func TestPodDiscoveryWithNodeMetadata(t *testing.T) {
+	t.Parallel()
 	attachMetadata := AttachMetadataConfig{Node: true}
 	n, c := makeDiscoveryWithMetadata(RolePod, NamespaceDiscovery{}, attachMetadata)
 	nodeLbls := map[string]string{"l1": "v1"}
@@ -485,6 +494,7 @@ func TestPodDiscoveryWithNodeMetadata(t *testing.T) {
 }
 
 func TestPodDiscoveryWithNodeMetadataUpdateNode(t *testing.T) {
+	t.Parallel()
 	nodeLbls := map[string]string{"l2": "v2"}
 	attachMetadata := AttachMetadataConfig{Node: true}
 	n, c := makeDiscoveryWithMetadata(RolePod, NamespaceDiscovery{}, attachMetadata)

--- a/discovery/kubernetes/service_test.go
+++ b/discovery/kubernetes/service_test.go
@@ -118,6 +118,7 @@ func makeLoadBalancerService() *v1.Service {
 }
 
 func TestServiceDiscoveryAdd(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{
@@ -189,6 +190,7 @@ func TestServiceDiscoveryAdd(t *testing.T) {
 }
 
 func TestServiceDiscoveryDelete(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{}, makeService())
 
 	k8sDiscoveryTest{
@@ -207,6 +209,7 @@ func TestServiceDiscoveryDelete(t *testing.T) {
 }
 
 func TestServiceDiscoveryUpdate(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{}, makeService())
 
 	k8sDiscoveryTest{
@@ -251,6 +254,7 @@ func TestServiceDiscoveryUpdate(t *testing.T) {
 }
 
 func TestServiceDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{Names: []string{"ns1", "ns2"}})
 
 	k8sDiscoveryTest{
@@ -303,6 +307,7 @@ func TestServiceDiscoveryNamespaces(t *testing.T) {
 }
 
 func TestServiceDiscoveryOwnNamespace(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{IncludeOwnNamespace: true})
 
 	k8sDiscoveryTest{
@@ -338,6 +343,7 @@ func TestServiceDiscoveryOwnNamespace(t *testing.T) {
 }
 
 func TestServiceDiscoveryAllNamespaces(t *testing.T) {
+	t.Parallel()
 	n, c := makeDiscovery(RoleService, NamespaceDiscovery{})
 
 	k8sDiscoveryTest{


### PR DESCRIPTION
Uses `t.Parallel()` to parallelize tests in `discovery/kubernetes` directory. 
Related to #15185

## Time saved on my machine

Before, on main (https://github.com/prometheus/prometheus/commit/bab587b9dca16274e38babbbf56efba50956dbd2)
```
$ go test -count=1 ./discovery/kubernetes
ok         github.com/prometheus/prometheus/discovery/kubernetes   34.315s
```
After, with `t.Parallel()`
```
$ go test -count=1 ./discovery/kubernetes
ok         github.com/prometheus/prometheus/discovery/kubernetes   5.862s
```

**Test execution time of `discovery/kubernetes/` reduced by ~**80%** (from ~34s to ~6s).

Also ran the tests with `-race` to detect races.
```
$ go test ./discovery/kubernetes -race
ok       github.com/prometheus/prometheus/discovery/kubernetes   7.783s
```

## Time saved in CI
Before
```
ok  	github.com/prometheus/prometheus/discovery/kubernetes	33.290s
```
After
```
ok  	github.com/prometheus/prometheus/discovery/kubernetes	9.053s
```
Reduced by ~70%