### PR TITLE
tsdb.CircularExemplarStorage: Avoid racing

### DIFF
--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -152,12 +152,12 @@ func (ce *CircularExemplarStorage) Querier(_ context.Context) (storage.ExemplarQ
 func (ce *CircularExemplarStorage) Select(start, end int64, matchers ...[]*labels.Matcher) ([]exemplar.QueryResult, error) {
 	ret := make([]exemplar.QueryResult, 0)
 
+	ce.lock.RLock()
+	defer ce.lock.RUnlock()
+
 	if len(ce.exemplars) == 0 {
 		return ret, nil
 	}
-
-	ce.lock.RLock()
-	defer ce.lock.RUnlock()
 
 	// Loop through each index entry, which will point us to first/last exemplar for each series.
 	for _, idx := range ce.index {
@@ -281,12 +281,12 @@ func (ce *CircularExemplarStorage) Resize(l int64) int {
 		l = 0
 	}
 
+	ce.lock.Lock()
+	defer ce.lock.Unlock()
+
 	if l == int64(len(ce.exemplars)) {
 		return 0
 	}
-
-	ce.lock.Lock()
-	defer ce.lock.Unlock()
 
 	oldBuffer := ce.exemplars
 	oldNextIndex := int64(ce.nextIndex)
@@ -349,10 +349,6 @@ func (ce *CircularExemplarStorage) migrate(entry *circularBufferEntry, buf []byt
 }
 
 func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemplar) error {
-	if len(ce.exemplars) == 0 {
-		return storage.ErrExemplarsDisabled
-	}
-
 	var buf [1024]byte
 	seriesLabels := l.Bytes(buf[:])
 
@@ -360,6 +356,10 @@ func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemp
 	// Optimize by moving the lock to be per series (& benchmark it).
 	ce.lock.Lock()
 	defer ce.lock.Unlock()
+
+	if len(ce.exemplars) == 0 {
+		return storage.ErrExemplarsDisabled
+	}
 
 	idx, ok := ce.index[string(seriesLabels)]
 	err := ce.validateExemplar(idx, e, true)

--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -349,9 +349,6 @@ func (ce *CircularExemplarStorage) migrate(entry *circularBufferEntry, buf []byt
 }
 
 func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemplar) error {
-	var buf [1024]byte
-	seriesLabels := l.Bytes(buf[:])
-
 	// TODO(bwplotka): This lock can lock all scrapers, there might high contention on this on scale.
 	// Optimize by moving the lock to be per series (& benchmark it).
 	ce.lock.Lock()
@@ -360,6 +357,9 @@ func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemp
 	if len(ce.exemplars) == 0 {
 		return storage.ErrExemplarsDisabled
 	}
+
+	var buf [1024]byte
+	seriesLabels := l.Bytes(buf[:])
 
 	idx, ok := ce.index[string(seriesLabels)]
 	err := ce.validateExemplar(idx, e, true)

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -501,6 +501,8 @@ func BenchmarkResizeExemplars(b *testing.B) {
 	}
 }
 
+// TestCircularExemplarStorage_Concurrent_AddExemplar_Resize tries to provoke a data race between AddExemplar and Resize.
+// Run with race detection enabled.
 func TestCircularExemplarStorage_Concurrent_AddExemplar_Resize(t *testing.T) {
 	exs, err := NewCircularExemplarStorage(0, eMetrics)
 	require.NoError(t, err)
@@ -518,8 +520,6 @@ func TestCircularExemplarStorage_Concurrent_AddExemplar_Resize(t *testing.T) {
 	t.Cleanup(wg.Wait)
 
 	started := make(chan struct{})
-
-	// Try to provoke data race between AddExemplar and Resize.
 
 	go func() {
 		defer wg.Done()

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -497,5 +498,42 @@ func BenchmarkResizeExemplars(b *testing.B) {
 				es.Resize(tc.endSize)
 			}
 		})
+	}
+}
+
+func TestCircularExemplarStorage_Concurrent_AddExemplar_Resize(t *testing.T) {
+	exs, err := NewCircularExemplarStorage(0, eMetrics)
+	require.NoError(t, err)
+	es := exs.(*CircularExemplarStorage)
+
+	l := labels.FromStrings("service", "asdf")
+	e := exemplar.Exemplar{
+		Labels: labels.FromStrings("trace_id", "qwerty"),
+		Value:  0.1,
+		Ts:     1,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	t.Cleanup(wg.Wait)
+
+	started := make(chan struct{})
+
+	// Try to provoke data race between AddExemplar and Resize.
+
+	go func() {
+		defer wg.Done()
+
+		<-started
+		for i := 0; i < 100; i++ {
+			require.NoError(t, es.AddExemplar(l, e))
+		}
+	}()
+
+	for i := 0; i < 100; i++ {
+		es.Resize(int64(i + 1))
+		if i == 0 {
+			close(started)
+		}
 	}
 }


### PR DESCRIPTION
Fix data race conditions in `tsdb.CircularExemplarStorage`. Also including a test that provokes a race for me.

Example data race:

```console
WARNING: DATA RACE
Read at 0x00c031f061a8 by goroutine 6078394:
  github.com/prometheus/prometheus/tsdb.(*CircularExemplarStorage).AddExemplar()
      /Users/arve/Projects/prometheus/tsdb/exemplar.go:352 +0x99
  github.com/prometheus/prometheus/tsdb.(*headAppender).Commit()
      /Users/arve/Projects/prometheus/tsdb/head_append.go:897 +0x525
  github.com/prometheus/prometheus/tsdb.dbAppender.Commit()
      /Users/arve/Projects/prometheus/tsdb/db.go:1278 +0x49
  github.com/prometheus/prometheus/tsdb.(*dbAppender).Commit()
[...]
Previous write at 0x00c031f061a8 by goroutine 948:
  github.com/prometheus/prometheus/tsdb.(*CircularExemplarStorage).Resize()
      /Users/arve/Projects/prometheus/tsdb/exemplar.go:294 +0x188
  github.com/prometheus/prometheus/tsdb.(*Head).ApplyConfig()
      /Users/arve/Projects/prometheus/tsdb/head.go:1033 +0x2e9
  github.com/prometheus/prometheus/tsdb.(*DB).ApplyConfig()
```