### PR TITLE
[FEATURE] PromQL: Add experimental info function MVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [CHANGE] Scraping: Remove implicit fallback to the Prometheus text format in case of invalid/missing Content-Type and fail the scrape instead. Add ability to specify a `fallback_scrape_protocol` in the scrape config. #15136
 * [CHANGE] Remote-write: default enable_http2 to false.
+* [FEATURE] PromQL: Add experimental `info` function. #15233
 * [ENHANCEMENT] Scraping, rules: handle targets reappearing, or rules moving group, when out-of-order is enabled. #14710 
 - [BUGFIX] PromQL: Fix stddev+stdvar aggregations to always ignore native histograms. #14941
 - [BUGFIX] PromQL: Fix stddev+stdvar aggregations to treat Infinity consistently. #14941

--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -378,6 +380,126 @@ func BenchmarkNativeHistograms(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkInfoFunction(b *testing.B) {
+	// Initialize test storage and generate test series data.
+	testStorage := teststorage.New(b)
+	defer testStorage.Close()
+
+	start := time.Unix(0, 0)
+	end := start.Add(2 * time.Hour)
+	step := 30 * time.Second
+
+	// Generate time series data for the benchmark.
+	generateInfoFunctionTestSeries(b, testStorage, 100, 2000, 3600)
+
+	// Define test cases with queries to benchmark.
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "Joining info metrics with other metrics with group_left example 1",
+			query: "rate(http_server_request_duration_seconds_count[2m]) * on (job, instance) group_left (k8s_cluster_name) target_info{k8s_cluster_name=\"us-east\"}",
+		},
+		{
+			name:  "Joining info metrics with other metrics with info() example 1",
+			query: `info(rate(http_server_request_duration_seconds_count[2m]), {k8s_cluster_name="us-east"})`,
+		},
+		{
+			name:  "Joining info metrics with other metrics with group_left example 2",
+			query: "sum by (k8s_cluster_name, http_status_code) (rate(http_server_request_duration_seconds_count[2m]) * on (job, instance) group_left (k8s_cluster_name) target_info)",
+		},
+		{
+			name:  "Joining info metrics with other metrics with info() example 2",
+			query: `sum by (k8s_cluster_name, http_status_code) (info(rate(http_server_request_duration_seconds_count[2m]), {k8s_cluster_name=~".+"}))`,
+		},
+	}
+
+	// Benchmark each query type.
+	for _, tc := range cases {
+		// Initialize the PromQL engine once for all benchmarks.
+		opts := promql.EngineOpts{
+			Logger:               nil,
+			Reg:                  nil,
+			MaxSamples:           50000000,
+			Timeout:              100 * time.Second,
+			EnableAtModifier:     true,
+			EnableNegativeOffset: true,
+		}
+		engine := promql.NewEngine(opts)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer() // Stop the timer to exclude setup time.
+				qry, err := engine.NewRangeQuery(context.Background(), testStorage, nil, tc.query, start, end, step)
+				require.NoError(b, err)
+				b.StartTimer()
+				result := qry.Exec(context.Background())
+				require.NoError(b, result.Err)
+			}
+		})
+	}
+
+	// Report allocations.
+	b.ReportAllocs()
+}
+
+// Helper function to generate target_info and http_server_request_duration_seconds_count series for info function benchmarking.
+func generateInfoFunctionTestSeries(tb testing.TB, stor *teststorage.TestStorage, infoSeriesNum, interval, numIntervals int) {
+	tb.Helper()
+
+	ctx := context.Background()
+	statusCodes := []string{"200", "400", "500"}
+
+	// Generate target_info metrics with instance and job labels, and k8s_cluster_name label.
+	// Generate http_server_request_duration_seconds_count metrics with instance and job labels, and http_status_code label.
+	// the classic target_info metrics is gauge type.
+	metrics := make([]labels.Labels, 0, infoSeriesNum+len(statusCodes))
+	for i := 0; i < infoSeriesNum; i++ {
+		clusterName := "us-east"
+		if i >= infoSeriesNum/2 {
+			clusterName = "eu-south"
+		}
+		metrics = append(metrics, labels.FromStrings(
+			"__name__", "target_info",
+			"instance", "instance"+strconv.Itoa(i),
+			"job", "job"+strconv.Itoa(i),
+			"k8s_cluster_name", clusterName,
+		))
+	}
+
+	for _, statusCode := range statusCodes {
+		metrics = append(metrics, labels.FromStrings(
+			"__name__", "http_server_request_duration_seconds_count",
+			"instance", "instance0",
+			"job", "job0",
+			"http_status_code", statusCode,
+		))
+	}
+
+	// Append the generated metrics and samples to the storage.
+	refs := make([]storage.SeriesRef, len(metrics))
+
+	for i := 0; i < numIntervals; i++ {
+		a := stor.Appender(context.Background())
+		ts := int64(i * interval)
+		for j, metric := range metrics[:infoSeriesNum] {
+			ref, _ := a.Append(refs[j], metric, ts, 1)
+			refs[j] = ref
+		}
+
+		for j, metric := range metrics[infoSeriesNum:] {
+			ref, _ := a.Append(refs[j+infoSeriesNum], metric, ts, float64(i))
+			refs[j+infoSeriesNum] = ref
+		}
+
+		require.NoError(tb, a.Commit())
+	}
+
+	stor.DB.ForceHeadMMap() // Ensure we have at most one head chunk for every series.
+	stor.DB.Compact(ctx)
 }
 
 func generateNativeHistogramSeries(app storage.Appender, numSeries int) error {

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1671,6 +1671,7 @@ var FunctionCalls = map[string]FunctionCall{
 	"hour":                         funcHour,
 	"idelta":                       funcIdelta,
 	"increase":                     funcIncrease,
+	"info":                         nil,
 	"irate":                        funcIrate,
 	"label_replace":                nil, // evalLabelReplace not called via this map.
 	"label_join":                   nil, // evalLabelJoin not called via this map.

--- a/promql/info.go
+++ b/promql/info.go
@@ -1,0 +1,454 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/grafana/regexp"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+const targetInfo = "target_info"
+
+// identifyingLabels are the labels we consider as identifying for info metrics.
+// Currently hard coded, so we don't need knowledge of individual info metrics.
+var identifyingLabels = []string{"instance", "job"}
+
+// evalInfo implements the info PromQL function.
+func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (parser.Value, annotations.Annotations) {
+	val, annots := ev.eval(ctx, args[0])
+	mat := val.(Matrix)
+	// Map from data label name to matchers.
+	dataLabelMatchers := map[string][]*labels.Matcher{}
+	var infoNameMatchers []*labels.Matcher
+	if len(args) > 1 {
+		// TODO: Introduce a dedicated LabelSelector type.
+		labelSelector := args[1].(*parser.VectorSelector)
+		for _, m := range labelSelector.LabelMatchers {
+			dataLabelMatchers[m.Name] = append(dataLabelMatchers[m.Name], m)
+			if m.Name == labels.MetricName {
+				infoNameMatchers = append(infoNameMatchers, m)
+			}
+		}
+	} else {
+		infoNameMatchers = []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, targetInfo)}
+	}
+
+	// Don't try to enrich info series.
+	ignoreSeries := map[int]struct{}{}
+loop:
+	for i, s := range mat {
+		name := s.Metric.Get(labels.MetricName)
+		for _, m := range infoNameMatchers {
+			if m.Matches(name) {
+				ignoreSeries[i] = struct{}{}
+				continue loop
+			}
+		}
+	}
+
+	selectHints := ev.infoSelectHints(args[0])
+	infoSeries, ws, err := ev.fetchInfoSeries(ctx, mat, ignoreSeries, dataLabelMatchers, selectHints)
+	if err != nil {
+		ev.error(err)
+	}
+	annots.Merge(ws)
+
+	res, ws := ev.combineWithInfoSeries(ctx, mat, infoSeries, ignoreSeries, dataLabelMatchers)
+	annots.Merge(ws)
+	return res, annots
+}
+
+// infoSelectHints calculates the storage.SelectHints for selecting info series, given expr (first argument to info call).
+func (ev *evaluator) infoSelectHints(expr parser.Expr) storage.SelectHints {
+	var nodeTimestamp *int64
+	var offset int64
+	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
+		switch n := node.(type) {
+		case *parser.VectorSelector:
+			if n.Timestamp != nil {
+				nodeTimestamp = n.Timestamp
+			}
+			offset = durationMilliseconds(n.OriginalOffset)
+			return fmt.Errorf("end traversal")
+		default:
+			return nil
+		}
+	})
+
+	start := ev.startTimestamp
+	end := ev.endTimestamp
+	if nodeTimestamp != nil {
+		// The timestamp on the selector overrides everything.
+		start = *nodeTimestamp
+		end = *nodeTimestamp
+	}
+	// Reduce the start by one fewer ms than the lookback delta
+	// because wo want to exclude samples that are precisely the
+	// lookback delta before the eval time.
+	start -= durationMilliseconds(ev.lookbackDelta) - 1
+	start -= offset
+	end -= offset
+
+	return storage.SelectHints{
+		Start: start,
+		End:   end,
+		Step:  ev.interval,
+		Func:  "info",
+	}
+}
+
+// fetchInfoSeries fetches info series given matching identifying labels in mat.
+// Series in ignoreSeries are not fetched.
+// dataLabelMatchers may be mutated.
+func (ev *evaluator) fetchInfoSeries(ctx context.Context, mat Matrix, ignoreSeries map[int]struct{}, dataLabelMatchers map[string][]*labels.Matcher, selectHints storage.SelectHints) (Matrix, annotations.Annotations, error) {
+	// A map of values for all identifying labels we are interested in.
+	idLblValues := map[string]map[string]struct{}{}
+	for i, s := range mat {
+		if _, exists := ignoreSeries[i]; exists {
+			continue
+		}
+
+		// Register relevant values per identifying label for this series.
+		for _, l := range identifyingLabels {
+			val := s.Metric.Get(l)
+			if val == "" {
+				continue
+			}
+
+			if idLblValues[l] == nil {
+				idLblValues[l] = map[string]struct{}{}
+			}
+			idLblValues[l][val] = struct{}{}
+		}
+	}
+	if len(idLblValues) == 0 {
+		return nil, nil, nil
+	}
+
+	// Generate regexps for every interesting value per identifying label.
+	var sb strings.Builder
+	idLblRegexps := make(map[string]string, len(idLblValues))
+	for name, vals := range idLblValues {
+		sb.Reset()
+		i := 0
+		for v := range vals {
+			if i > 0 {
+				sb.WriteRune('|')
+			}
+			sb.WriteString(regexp.QuoteMeta(v))
+			i++
+		}
+		idLblRegexps[name] = sb.String()
+	}
+
+	var infoLabelMatchers []*labels.Matcher
+	for name, re := range idLblRegexps {
+		infoLabelMatchers = append(infoLabelMatchers, labels.MustNewMatcher(labels.MatchRegexp, name, re))
+	}
+	var nameMatcher *labels.Matcher
+	for name, ms := range dataLabelMatchers {
+		for i, m := range ms {
+			if m.Name == labels.MetricName {
+				nameMatcher = m
+				ms = slices.Delete(ms, i, i+1)
+			}
+			infoLabelMatchers = append(infoLabelMatchers, m)
+		}
+		if len(ms) > 0 {
+			dataLabelMatchers[name] = ms
+		} else {
+			delete(dataLabelMatchers, name)
+		}
+	}
+	if nameMatcher == nil {
+		// Default to using the target_info metric.
+		infoLabelMatchers = append([]*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, targetInfo)}, infoLabelMatchers...)
+	}
+
+	infoIt := ev.querier.Select(ctx, false, &selectHints, infoLabelMatchers...)
+	infoSeries, ws, err := expandSeriesSet(ctx, infoIt)
+	if err != nil {
+		return nil, ws, err
+	}
+
+	infoMat := ev.evalSeries(ctx, infoSeries, 0, true)
+	return infoMat, ws, nil
+}
+
+// combineWithInfoSeries combines mat with select data labels from infoMat.
+func (ev *evaluator) combineWithInfoSeries(ctx context.Context, mat, infoMat Matrix, ignoreSeries map[int]struct{}, dataLabelMatchers map[string][]*labels.Matcher) (Matrix, annotations.Annotations) {
+	buf := make([]byte, 0, 1024)
+	lb := labels.NewScratchBuilder(0)
+	sigFunction := func(name string) func(labels.Labels) string {
+		return func(lset labels.Labels) string {
+			lb.Reset()
+			lb.Add(labels.MetricName, name)
+			lset.MatchLabels(true, identifyingLabels...).Range(func(l labels.Label) {
+				lb.Add(l.Name, l.Value)
+			})
+			lb.Sort()
+			return string(lb.Labels().Bytes(buf))
+		}
+	}
+
+	infoMetrics := map[string]struct{}{}
+	for _, is := range infoMat {
+		lblMap := is.Metric.Map()
+		infoMetrics[lblMap[labels.MetricName]] = struct{}{}
+	}
+	sigfs := make(map[string]func(labels.Labels) string, len(infoMetrics))
+	for name := range infoMetrics {
+		sigfs[name] = sigFunction(name)
+	}
+
+	// Keep a copy of the original point slices so they can be returned to the pool.
+	origMatrices := []Matrix{
+		make(Matrix, len(mat)),
+		make(Matrix, len(infoMat)),
+	}
+	copy(origMatrices[0], mat)
+	copy(origMatrices[1], infoMat)
+
+	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
+	originalNumSamples := ev.currentSamples
+
+	// Create an output vector that is as big as the input matrix with
+	// the most time series.
+	biggestLen := max(len(mat), len(infoMat))
+	baseVector := make(Vector, 0, len(mat))
+	infoVector := make(Vector, 0, len(infoMat))
+	enh := &EvalNodeHelper{
+		Out: make(Vector, 0, biggestLen),
+	}
+	type seriesAndTimestamp struct {
+		Series
+		ts int64
+	}
+	seriess := make(map[uint64]seriesAndTimestamp, biggestLen) // Output series by series hash.
+	tempNumSamples := ev.currentSamples
+
+	// For every base series, compute signature per info metric.
+	baseSigs := make([]map[string]string, 0, len(mat))
+	for _, s := range mat {
+		sigs := make(map[string]string, len(infoMetrics))
+		for infoName := range infoMetrics {
+			sigs[infoName] = sigfs[infoName](s.Metric)
+		}
+		baseSigs = append(baseSigs, sigs)
+	}
+
+	infoSigs := make([]string, 0, len(infoMat))
+	for _, s := range infoMat {
+		name := s.Metric.Map()[labels.MetricName]
+		infoSigs = append(infoSigs, sigfs[name](s.Metric))
+	}
+
+	var warnings annotations.Annotations
+	for ts := ev.startTimestamp; ts <= ev.endTimestamp; ts += ev.interval {
+		if err := contextDone(ctx, "expression evaluation"); err != nil {
+			ev.error(err)
+		}
+
+		// Reset number of samples in memory after each timestamp.
+		ev.currentSamples = tempNumSamples
+		// Gather input vectors for this timestamp.
+		baseVector, _ = ev.gatherVector(ts, mat, baseVector, nil, nil)
+		infoVector, _ = ev.gatherVector(ts, infoMat, infoVector, nil, nil)
+
+		enh.Ts = ts
+		result, err := ev.combineWithInfoVector(baseVector, infoVector, ignoreSeries, baseSigs, infoSigs, enh, dataLabelMatchers)
+		if err != nil {
+			ev.error(err)
+		}
+		enh.Out = result[:0] // Reuse result vector.
+
+		vecNumSamples := result.TotalSamples()
+		ev.currentSamples += vecNumSamples
+		// When we reset currentSamples to tempNumSamples during the next iteration of the loop it also
+		// needs to include the samples from the result here, as they're still in memory.
+		tempNumSamples += vecNumSamples
+		ev.samplesStats.UpdatePeak(ev.currentSamples)
+		if ev.currentSamples > ev.maxSamples {
+			ev.error(ErrTooManySamples(env))
+		}
+
+		// Add samples in result vector to output series.
+		for _, sample := range result {
+			h := sample.Metric.Hash()
+			ss, exists := seriess[h]
+			if exists {
+				if ss.ts == ts { // If we've seen this output series before at this timestamp, it's a duplicate.
+					ev.errorf("vector cannot contain metrics with the same labelset")
+				}
+				ss.ts = ts
+			} else {
+				ss = seriesAndTimestamp{Series{Metric: sample.Metric}, ts}
+			}
+			addToSeries(&ss.Series, enh.Ts, sample.F, sample.H, numSteps)
+			seriess[h] = ss
+		}
+	}
+
+	// Reuse the original point slices.
+	for _, m := range origMatrices {
+		for _, s := range m {
+			putFPointSlice(s.Floats)
+			putHPointSlice(s.Histograms)
+		}
+	}
+	// Assemble the output matrix. By the time we get here we know we don't have too many samples.
+	numSamples := 0
+	output := make(Matrix, 0, len(seriess))
+	for _, ss := range seriess {
+		numSamples += len(ss.Floats) + totalHPointSize(ss.Histograms)
+		output = append(output, ss.Series)
+	}
+	ev.currentSamples = originalNumSamples + numSamples
+	ev.samplesStats.UpdatePeak(ev.currentSamples)
+	return output, warnings
+}
+
+// combineWithInfoVector combines base and info Vectors.
+// Base series in ignoreSeries are not combined.
+func (ev *evaluator) combineWithInfoVector(base, info Vector, ignoreSeries map[int]struct{}, baseSigs []map[string]string, infoSigs []string, enh *EvalNodeHelper, dataLabelMatchers map[string][]*labels.Matcher) (Vector, error) {
+	if len(base) == 0 {
+		return nil, nil // Short-circuit: nothing is going to match.
+	}
+
+	// All samples from the info Vector hashed by the matching label/values.
+	if enh.rightSigs == nil {
+		enh.rightSigs = make(map[string]Sample, len(enh.Out))
+	} else {
+		clear(enh.rightSigs)
+	}
+
+	for i, s := range info {
+		if s.H != nil {
+			ev.error(errors.New("info sample should be float"))
+		}
+		// We encode original info sample timestamps via the float value.
+		origT := int64(s.F)
+
+		sig := infoSigs[i]
+		if existing, exists := enh.rightSigs[sig]; exists {
+			// We encode original info sample timestamps via the float value.
+			existingOrigT := int64(existing.F)
+			switch {
+			case existingOrigT > origT:
+				// Keep the other info sample, since it's newer.
+			case existingOrigT < origT:
+				// Keep this info sample, since it's newer.
+				enh.rightSigs[sig] = s
+			default:
+				// The two info samples have the same timestamp - conflict.
+				name := s.Metric.Map()[labels.MetricName]
+				ev.errorf("found duplicate series for info metric %s", name)
+			}
+		} else {
+			enh.rightSigs[sig] = s
+		}
+	}
+
+	for i, bs := range base {
+		if _, exists := ignoreSeries[i]; exists {
+			// This series should not be enriched with info metric data labels.
+			enh.Out = append(enh.Out, Sample{
+				Metric: bs.Metric,
+				F:      bs.F,
+				H:      bs.H,
+			})
+			continue
+		}
+
+		baseLabels := bs.Metric.Map()
+		enh.resetBuilder(labels.Labels{})
+
+		// For every info metric name, try to find an info series with the same signature.
+		seenInfoMetrics := map[string]struct{}{}
+		for infoName, sig := range baseSigs[i] {
+			is, exists := enh.rightSigs[sig]
+			if !exists {
+				continue
+			}
+			if _, exists := seenInfoMetrics[infoName]; exists {
+				continue
+			}
+
+			err := is.Metric.Validate(func(l labels.Label) error {
+				if l.Name == labels.MetricName {
+					return nil
+				}
+				if _, exists := dataLabelMatchers[l.Name]; len(dataLabelMatchers) > 0 && !exists {
+					// Not among the specified data label matchers.
+					return nil
+				}
+
+				if v := enh.lb.Get(l.Name); v != "" && v != l.Value {
+					return fmt.Errorf("conflicting label: %s", l.Name)
+				}
+				if _, exists := baseLabels[l.Name]; exists {
+					// Skip labels already on the base metric.
+					return nil
+				}
+
+				enh.lb.Set(l.Name, l.Value)
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			seenInfoMetrics[infoName] = struct{}{}
+		}
+
+		infoLbls := enh.lb.Labels()
+		if infoLbls.Len() == 0 {
+			// If there's at least one data label matcher not matching the empty string,
+			// we have to ignore this series as there are no matching info series.
+			allMatchersMatchEmpty := true
+			for _, ms := range dataLabelMatchers {
+				for _, m := range ms {
+					if !m.Matches("") {
+						allMatchersMatchEmpty = false
+						break
+					}
+				}
+			}
+			if !allMatchersMatchEmpty {
+				continue
+			}
+		}
+
+		enh.resetBuilder(bs.Metric)
+		infoLbls.Range(func(l labels.Label) {
+			enh.lb.Set(l.Name, l.Value)
+		})
+
+		enh.Out = append(enh.Out, Sample{
+			Metric: enh.lb.Labels(),
+			F:      bs.F,
+			H:      bs.H,
+		})
+	}
+	return enh.Out, nil
+}

--- a/promql/info_test.go
+++ b/promql/info_test.go
@@ -1,0 +1,140 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/promqltest"
+)
+
+// The "info" function is experimental. This is why we write those tests here for now instead of promqltest/testdata/info.test.
+func TestInfo(t *testing.T) {
+	engine := promqltest.NewTestEngine(t, false, 0, promqltest.DefaultMaxSamplesPerQuery)
+	promqltest.RunTest(t, `
+load 5m
+  metric{instance="a", job="1", label="value"} 0 1 2
+  metric_not_matching_target_info{instance="a", job="2", label="value"} 0 1 2
+  metric_with_overlapping_label{instance="a", job="1", label="value", data="base"} 0 1 2
+  target_info{instance="a", job="1", data="info", another_data="another info"} 1 1 1
+  build_info{instance="a", job="1", build_data="build"} 1 1 1
+
+# Include one info metric data label.
+eval range from 0m to 10m step 5m info(metric, {data=~".+"})
+  metric{data="info", instance="a", job="1", label="value"} 0 1 2
+
+# Include all info metric data labels.
+eval range from 0m to 10m step 5m info(metric)
+  metric{data="info", instance="a", job="1", label="value", another_data="another info"} 0 1 2
+
+# Try including all info metric data labels, but non-matching identifying labels.
+eval range from 0m to 10m step 5m info(metric_not_matching_target_info)
+  metric_not_matching_target_info{instance="a", job="2", label="value"} 0 1 2
+
+# Try including a certain info metric data label with a non-matching matcher not accepting empty labels.
+# Metric is ignored, due there being a data label matcher not matching empty labels,
+# and there being no info series matches.
+eval range from 0m to 10m step 5m info(metric, {non_existent=~".+"})
+
+# Include a certain info metric data label together with a non-matching matcher accepting empty labels.
+# Since the non_existent matcher matches empty labels, it's simply ignored when there's no match.
+# XXX: This case has to include a matcher not matching empty labels, due the PromQL limitation
+# that vector selectors have to contain at least one matcher not accepting empty labels.
+# We might need another construct than vector selector to get around this limitation.
+eval range from 0m to 10m step 5m info(metric, {data=~".+", non_existent=~".*"})
+  metric{data="info", instance="a", job="1", label="value"} 0 1 2
+
+# Info series data labels overlapping with those of base series are ignored.
+eval range from 0m to 10m step 5m info(metric_with_overlapping_label)
+  metric_with_overlapping_label{data="base", instance="a", job="1", label="value", another_data="another info"} 0 1 2
+
+# Include data labels from target_info specifically.
+eval range from 0m to 10m step 5m info(metric, {__name__="target_info"})
+  metric{data="info", instance="a", job="1", label="value", another_data="another info"} 0 1 2
+
+# Try to include all data labels from a non-existent info metric.
+eval range from 0m to 10m step 5m info(metric, {__name__="non_existent"})
+  metric{instance="a", job="1", label="value"} 0 1 2
+
+# Try to include a certain data label from a non-existent info metric.
+eval range from 0m to 10m step 5m info(metric, {__name__="non_existent", data=~".+"})
+
+# Include data labels from build_info.
+eval range from 0m to 10m step 5m info(metric, {__name__="build_info"})
+  metric{instance="a", job="1", label="value", build_data="build"} 0 1 2
+
+# Include data labels from build_info and target_info.
+eval range from 0m to 10m step 5m info(metric, {__name__=~".+_info"})
+  metric{instance="a", job="1", label="value", build_data="build", data="info", another_data="another info"} 0 1 2
+
+# Info metrics themselves are ignored when it comes to enriching with info metric data labels.
+eval range from 0m to 10m step 5m info(build_info, {__name__=~".+_info", build_data=~".+"})
+  build_info{instance="a", job="1", build_data="build"} 1 1 1
+
+clear
+
+# Overlapping target_info series.
+load 5m
+  metric{instance="a", job="1", label="value"} 0 1 2
+  target_info{instance="a", job="1", data="info", another_data="another info"} 1 1 _
+  target_info{instance="a", job="1", data="updated info", another_data="another info"} _ _ 1
+
+# Conflicting info series are resolved through picking the latest sample.
+eval range from 0m to 10m step 5m info(metric)
+  metric{data="info", instance="a", job="1", label="value", another_data="another info"} 0 1 _
+  metric{data="updated info", instance="a", job="1", label="value", another_data="another info"} _ _ 2
+
+clear
+
+# Non-overlapping target_info series.
+load 5m
+  metric{instance="a", job="1", label="value"} 0 1 2
+  target_info{instance="a", job="1", data="info"} 1 1 stale
+  target_info{instance="a", job="1", data="updated info"} _ _ 1
+
+# Include info metric data labels from a metric which data labels change over time.
+eval range from 0m to 10m step 5m info(metric)
+  metric{data="info", instance="a", job="1", label="value"} 0 1 _
+  metric{data="updated info", instance="a", job="1", label="value"} _ _ 2
+
+clear
+
+# Info series selector matches histogram series, info metrics should be float type.
+load 5m
+  metric{instance="a", job="1", label="value"} 0 1 2
+  histogram{instance="a", job="1"} {{schema:1 sum:3 count:22 buckets:[5 10 7]}}
+
+eval_fail range from 0m to 10m step 5m info(metric, {__name__="histogram"})
+
+clear
+
+# Series with skipped scrape.
+load 1m
+  metric{instance="a", job="1", label="value"} 0 _ 2 3 4
+  target_info{instance="a", job="1", data="info"} 1 _ 1 1 1
+
+# Lookback works also for the info series.
+eval range from 1m to 4m step 1m info(metric)
+  metric{data="info", instance="a", job="1", label="value"} 0 2 3 4
+
+# @ operator works also with info.
+# Note that we pick the timestamp missing a sample, lookback should pick previous sample.
+eval range from 1m to 4m step 1m info(metric @ 60)
+  metric{data="info", instance="a", job="1", label="value"} 0 0 0 0
+
+# offset operator works also with info.
+eval range from 1m to 4m step 1m info(metric offset 1m)
+  metric{data="info", instance="a", job="1", label="value"} 0 0 2 3
+`, engine)
+}

--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -208,6 +208,10 @@ type VectorSelector struct {
 	UnexpandedSeriesSet storage.SeriesSet
 	Series              []storage.Series
 
+	// BypassEmptyMatcherCheck is true when the VectorSelector isn't required to have at least one matcher matching the empty string.
+	// This is the case when VectorSelector is used to represent the info function's second argument.
+	BypassEmptyMatcherCheck bool
+
 	PosRange posrange.PositionRange
 }
 

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -224,6 +224,13 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 	},
+	"info": {
+		Name:         "info",
+		ArgTypes:     []ValueType{ValueTypeVector, ValueTypeVector},
+		ReturnType:   ValueTypeVector,
+		Experimental: true,
+		Variadic:     1,
+	},
 	"irate": {
 		Name:       "irate",
 		ArgTypes:   []ValueType{ValueTypeMatrix},

--- a/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
+++ b/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
@@ -282,6 +282,12 @@ export const functionIdentifierTerms = [
     type: 'function',
   },
   {
+    label: 'info',
+    detail: 'function',
+    info: 'Add data labels from corresponding info metrics',
+    type: 'function',
+  },
+  {
     label: 'irate',
     detail: 'function',
     info: 'Calculate the per-second increase over the last two samples of a range vector (for counters)',

--- a/web/ui/module/codemirror-promql/src/parser/parser.test.ts
+++ b/web/ui/module/codemirror-promql/src/parser/parser.test.ts
@@ -968,6 +968,23 @@ describe('promql operations', () => {
       expectedValueType: ValueType.vector,
       expectedDiag: [],
     },
+    {
+      expr: 'info(rate(http_request_counter_total{}[5m]))',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [],
+    },
+    {
+      expr: 'info(rate(http_request_counter_total[5m]), target_info{service_version=~".+"})',
+      expectedValueType: ValueType.vector,
+      expectedDiag: [
+        {
+          from: 0,
+          to: 78,
+          message: `expected label selectors as the second argument to "info" function, got [object Object]`,
+          severity: 'error',
+        },
+      ],
+    },
   ];
   testCases.forEach((value) => {
     const state = createEditorState(value.expr);

--- a/web/ui/module/codemirror-promql/src/parser/parser.ts
+++ b/web/ui/module/codemirror-promql/src/parser/parser.ts
@@ -275,6 +275,13 @@ export class Parser {
       }
     }
 
+    if (funcSignature.name === 'info') {
+      // Verify that the data label selector expression is not prefixed with metric name.
+      if (args.length > 1 && args[1].getChild(Identifier)) {
+        this.addDiagnostic(node, `expected label selectors as the second argument to "info" function, got ${args[1].type}`);
+      }
+    }
+
     let j = 0;
     for (let i = 0; i < args.length; i++) {
       j = i;

--- a/web/ui/module/codemirror-promql/src/types/function.ts
+++ b/web/ui/module/codemirror-promql/src/types/function.ts
@@ -50,6 +50,7 @@ import {
   Hour,
   Idelta,
   Increase,
+  Info,
   Irate,
   LabelJoin,
   LabelReplace,
@@ -334,6 +335,12 @@ const promqlFunctions: { [key: number]: PromQLFunction } = {
     name: 'increase',
     argTypes: [ValueType.matrix],
     variadic: 0,
+    returnType: ValueType.vector,
+  },
+  [Info]: {
+    name: 'info',
+    argTypes: [ValueType.vector, ValueType.vector],
+    variadic: 1,
     returnType: ValueType.vector,
   },
   [Irate]: {

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -145,6 +145,7 @@ FunctionIdentifier {
   Hour |
   Idelta |
   Increase |
+  Info |
   Irate |
   LabelReplace |
   LabelJoin |
@@ -392,6 +393,7 @@ NumberDurationLiteralInDurationContext {
   Hour { condFn<"hour"> }
   Idelta { condFn<"idelta"> }
   Increase { condFn<"increase"> }
+  Info { condFn<"info"> }
   Irate { condFn<"irate"> }
   LabelReplace { condFn<"label_replace"> }
   LabelJoin { condFn<"label_join"> }


### PR DESCRIPTION
**Port of #14495 from v2.55. Agreed w/ @jesusvazquez that I port the feature to main through a cherry-pick PR.**

This _experimental_ MVP of the [PromQL `info` function](https://github.com/prometheus/proposals/pull/37) simplifies the implementation by assuming:

* Only support for the `target_info` metric
* That `target_info`'s identifying labels are `job` and `instance`

`info` is implemented following the same pattern as traditional join queries, and achieves even (significantly) better performance by only selecting RHS (info) series w/ the correct identifying labels (`instance` and `job`). I believe it's possible though to optimize corresponding join queries in the same way, provided that the RHS is a vector selector (the same heuristic should be applicable). The main motivation for following the join query pattern, i.e. perform a second select for corresponding info series and then join, is that info series may be sharded independently of the corresponding non-info series.

Another significant benefit over traditional join queries is that `info` will resolve conflicts between info series with the same identifying labels, that align to the same timestamp, whereas traditional joins will raise an error for this case. As an example, let's say we have the two following `target_info` series, both identified by the `instance` and `job` labels:

1. `{__name__="target_info", instance="1", job="a", pid="1"}`
1. `{__name__="target_info", instance="1", job="a", pid="2"}`

If series 1's last sample is at timestamp 1, and series 2's last sample is at timestamp 2, `info` will need to choose between the two of them for timestamp 2 (since also series 1 is viable for timestamp 2 due to lookback). `info` picks series 2 since it has the newer sample (timestamp 2 versus timestamp 1).

The `info` function is disabled by default, and has to be enabled via `--enable-feature=promql-experimental-functions`.

The below screenshot demonstrates the `info` function, including three different data labels from `target_info` (`k8s_cluster_name`, `k8s_container_name` and `k8s_cronjob_name`).

![prometheus](https://github.com/user-attachments/assets/4099052f-bb89-4ce9-b6f3-83dc92254f97)

## Usage

Without the `info` function, to include `target_info` labels (Prometheus' encoding of OTel resource attributes), you have to write a join query like the following:

```promql
sum by (k8s_cluster_name, http_status_code) (
  rate(http_server_request_duration_seconds_count[2m])
  * on (job, instance) group_left (k8s_cluster_name)
  target_info
)
```

With the `info` function, you can instead of the above write:

```promql
sum by (k8s_cluster_name, http_status_code) (
  info(
    rate(http_server_request_duration_seconds_count[2m]),
    {k8s_cluster_name=~".+"}
  )
)
```

## Known problems

* The data label matcher auto completion is imprecise, in that it looks up labels for all time series instead of just relevant info series (by default: `target_info`)
  * Maybe this can easily be fixed in the frontend code? 

## Benchmark results

<details>
<summary>Benchmark stats for join query vs. <code>info</code> function</summary>

```console
✗ benchstat join.txt info.txt
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/promql
cpu: AMD Ryzen 9 3950X 16-Core Processor            
                                                                  │   join.txt   │              info.txt              │
                                                                  │    sec/op    │   sec/op     vs base               │
InfoFunction/Joining_info_metrics_with_other_metrics_example_1-32    7.370m ± 6%   2.112m ± 7%  -71.35% (p=0.002 n=6)
InfoFunction/Joining_info_metrics_with_other_metrics_example_2-32   13.278m ± 3%   2.156m ± 3%  -83.76% (p=0.002 n=6)
geomean                                                              9.892m        2.134m       -78.43%

                                                                  │   join.txt   │              info.txt               │
                                                                  │     B/op     │     B/op      vs base               │
InfoFunction/Joining_info_metrics_with_other_metrics_example_1-32   452.3Ki ± 0%   397.2Ki ± 0%  -12.17% (p=0.002 n=6)
InfoFunction/Joining_info_metrics_with_other_metrics_example_2-32   705.7Ki ± 1%   400.6Ki ± 0%  -43.24% (p=0.002 n=6)
geomean                                                             564.9Ki        398.9Ki       -29.39%

                                                                  │  join.txt   │              info.txt              │
                                                                  │  allocs/op  │  allocs/op   vs base               │
InfoFunction/Joining_info_metrics_with_other_metrics_example_1-32   3.474k ± 0%   3.280k ± 0%   -5.60% (p=0.002 n=6)
InfoFunction/Joining_info_metrics_with_other_metrics_example_2-32   5.465k ± 0%   3.322k ± 0%  -39.21% (p=0.002 n=6)
geomean                                                             4.357k        3.301k       -24.24%
```
</details>