### PR TITLE
FastRegexMatcher: Extract longer prefixes

### DIFF
--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -250,9 +250,10 @@ func TestFindSetMatches(t *testing.T) {
 			t.Parallel()
 			parsed, err := syntax.Parse(c.pattern, syntax.Perl|syntax.DotNL)
 			require.NoError(t, err)
-			matches, actualCaseSensitive := findSetMatches(parsed)
+			matches, prefixes, actualCaseSensitive := findSetMatches(parsed)
 			require.Equal(t, c.expMatches, matches)
 			require.Equal(t, c.expCaseSensitive, actualCaseSensitive)
+			require.Empty(t, prefixes)
 
 			if c.expCaseSensitive {
 				// When the regexp is case sensitive, we want to ensure that the
@@ -393,7 +394,7 @@ func TestStringMatcherFromRegexp(t *testing.T) {
 		{".*foo.*bar.*", nil},
 		{`\d*`, nil},
 		{".", nil},
-		{"/|/bar.*", &literalPrefixSensitiveStringMatcher{prefix: "/", right: orStringMatcher{emptyStringMatcher{}, &literalPrefixSensitiveStringMatcher{prefix: "bar", right: trueMatcher{}}}}},
+		{"/|/bar.*", orStringMatcher{&equalStringMatcher{s: "/", caseSensitive: true}, &literalPrefixSensitiveStringMatcher{prefix: "/bar", right: trueMatcher{}}}},
 		// This one is not supported because  `stringMatcherFromRegexp` is not reentrant for syntax.OpConcat.
 		// It would make the code too complex to handle it.
 		{"(.+)/(foo.*|bar$)", nil},


### PR DESCRIPTION
Given a regex like `a(b|c).*`, find `ab` and `ac` as prefixes.
Even though the original may have looked like `ab.*|ac.*`, Go extracts the sub-prefixes.
We want the longer strings when the optimisation to put them into a map applies.

Benchmarks show the desired speedup on `FastRegexMatcher`, with some slowdown of `EqualOrPrefixStringMatchers` which I think is acceptable.  No change to allocations.

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                                                                                                                                  │   main2.txt   │         faster-prefixes.txt          │
                                                                                                                                                  │    sec/op     │    sec/op      vs base               │
FastRegexMatcher/#00-4                                                                                                                               95.68n ±  8%    94.76n ±  2%        ~ (p=0.310 n=6)
FastRegexMatcher/foo-4                                                                                                                               124.3n ±  6%    120.2n ±  5%        ~ (p=0.589 n=6)
FastRegexMatcher/^foo-4                                                                                                                              90.95n ±  7%    94.72n ±  5%        ~ (p=0.485 n=6)
FastRegexMatcher/(foo|bar)-4                                                                                                                         115.6n ±  4%    117.7n ±  2%        ~ (p=0.258 n=6)
FastRegexMatcher/foo.*-4                                                                                                                             199.7n ±  3%    198.5n ±  2%        ~ (p=0.699 n=6)
FastRegexMatcher/.*foo-4                                                                                                                             246.2n ±  3%    246.1n ±  5%        ~ (p=0.699 n=6)
FastRegexMatcher/^.*foo$-4                                                                                                                           243.8n ±  2%    245.4n ±  3%        ~ (p=0.699 n=6)
FastRegexMatcher/^.+foo$-4                                                                                                                           245.7n ±  3%    245.2n ±  2%        ~ (p=0.818 n=6)
FastRegexMatcher/.?-4                                                                                                                                165.3n ±  4%    160.0n ±  1%        ~ (p=0.255 n=6)
FastRegexMatcher/.*-4                                                                                                                                93.50n ±  4%    94.12n ±  4%        ~ (p=0.589 n=6)
FastRegexMatcher/.+-4                                                                                                                                114.8n ±  4%    115.8n ±  3%        ~ (p=0.968 n=6)
FastRegexMatcher/foo.+-4                                                                                                                             199.7n ±  2%    199.3n ±  2%        ~ (p=0.981 n=6)
FastRegexMatcher/.+foo-4                                                                                                                             246.8n ±  4%    245.0n ±  5%        ~ (p=1.000 n=6)
FastRegexMatcher/foo_.+-4                                                                                                                            188.5n ±  2%    189.8n ±  4%        ~ (p=0.394 n=6)
FastRegexMatcher/foo_.*-4                                                                                                                            188.1n ±  7%    188.9n ±  3%        ~ (p=0.937 n=6)
FastRegexMatcher/.*foo.*-4                                                                                                                           432.6n ±  3%    422.1n ±  2%   -2.43% (p=0.004 n=6)
FastRegexMatcher/.+foo.+-4                                                                                                                           455.2n ±  3%    454.1n ±  3%        ~ (p=0.981 n=6)
FastRegexMatcher/(?s:.*)-4                                                                                                                           94.94n ±  3%    94.64n ±  3%        ~ (p=0.699 n=6)
FastRegexMatcher/(?s:.+)-4                                                                                                                           117.2n ±  3%    115.4n ±  3%        ~ (p=0.420 n=6)
FastRegexMatcher/(?s:^.*foo$)-4                                                                                                                      241.8n ±  3%    245.0n ±  7%        ~ (p=0.102 n=6)
FastRegexMatcher/(?i:foo)-4                                                                                                                          178.4n ±  8%    178.9n ±  3%        ~ (p=0.699 n=6)
FastRegexMatcher/(?i:(foo|bar))-4                                                                                                                    360.6n ±  2%    364.2n ±  3%        ~ (p=0.310 n=6)
FastRegexMatcher/(?i:(foo1|foo2|bar))-4                                                                                                              642.3n ±  3%    642.6n ±  4%        ~ (p=0.699 n=6)
FastRegexMatcher/^(?i:foo|oo)|(bar)$-4                                                                                                               1.671µ ±  2%    1.697µ ±  5%        ~ (p=1.000 n=6)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-4                                                                                                  1.966µ ±  3%    2.030µ ±  4%   +3.26% (p=0.026 n=6)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-4                                                                                                      1004.0n ±  4%    981.7n ± 12%        ~ (p=0.331 n=6)
FastRegexMatcher/^$-4                                                                                                                                96.55n ±  4%    95.21n ±  6%        ~ (p=0.699 n=6)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-4                                                                                                   367.5n ±  8%    363.0n ±  2%        ~ (p=0.180 n=6)
FastRegexMatcher/10\.0\.(1|2)\.+-4                                                                                                                   189.2n ±  3%    189.4n ±  3%        ~ (p=0.677 n=6)
FastRegexMatcher/10\.0\.(1|2).+-4                                                                                                                    189.1n ±  3%    188.0n ±  7%        ~ (p=0.818 n=6)
FastRegexMatcher/((fo(bar))|.+foo)-4                                                                                                                 459.1n ±  3%    461.2n ±  3%        ~ (p=0.589 n=6)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-4                                                                                                  505.3n ±  6%    496.4n ±  9%        ~ (p=0.394 n=6)
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-4                                                                                                  498.4n ± 13%    511.0n ±  8%        ~ (p=0.699 n=6)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-4                                                                                                  1.993µ ± 11%    2.040µ ±  3%        ~ (p=0.240 n=6)
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-4                                                                                                  800.9n ± 15%    789.0n ±  2%        ~ (p=0.394 n=6)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-4                                                                                                  544.7n ±  5%    533.4n ±  4%        ~ (p=0.132 n=6)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-4                                                                                               2.560µ ±  5%    2.188µ ±  8%  -14.53% (p=0.002 n=6)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-4                                                                                                  18.54µ ±  3%    18.50µ ±  3%        ~ (p=0.699 n=6)
FastRegexMatcher/fo.?-4                                                                                                                              202.0n ±  2%    200.3n ±  9%        ~ (p=0.937 n=6)
FastRegexMatcher/foo.?-4                                                                                                                             205.5n ±  5%    201.1n ±  9%        ~ (p=0.485 n=6)
FastRegexMatcher/f.?o-4                                                                                                                              198.8n ±  5%    198.7n ±  2%        ~ (p=0.970 n=6)
FastRegexMatcher/.*foo.?-4                                                                                                                           461.8n ±  3%    456.0n ±  3%        ~ (p=0.310 n=6)
FastRegexMatcher/.?foo.+-4                                                                                                                           440.6n ±  8%    445.5n ± 10%        ~ (p=0.937 n=6)
FastRegexMatcher/foo.?|bar-4                                                                                                                         331.6n ±  5%    342.6n ±  3%        ~ (p=0.132 n=6)
FastRegexMatcher/ſſs-4                                                                                                                               121.4n ±  4%    121.2n ±  2%        ~ (p=0.701 n=6)
FastRegexMatcher/.*-.*-.*-.*-.*-4                                                                                                                    423.1n ±  8%    416.9n ±  8%        ~ (p=0.485 n=6)
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-4                                                                                                          420.7n ±  8%    415.3n ±  3%        ~ (p=0.240 n=6)
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-4                                                                                                  8.923µ ±  3%    8.889µ ±  5%        ~ (p=1.000 n=6)
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-4                                                                                                  7.346µ ±  2%    7.219µ ±  4%        ~ (p=0.485 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_2_case_sensitive:_true_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4        313.6n ±  4%    313.4n ±  8%        ~ (p=0.699 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_2_case_sensitive:_true_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4           412.8n ±  8%    400.8n ±  3%   -2.91% (p=0.041 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_2_case_sensitive:_true_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4       289.5n ±  2%    286.6n ±  3%        ~ (p=0.589 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_2_case_sensitive:_true_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4          202.9n ±  2%    189.6n ±  3%   -6.55% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_2_case_sensitive:_false_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4       315.8n ±  2%    318.9n ±  3%        ~ (p=0.240 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_2_case_sensitive:_false_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4          1.678µ ±  6%    1.712µ ±  4%        ~ (p=0.180 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_2_case_sensitive:_false_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4      317.1n ±  3%    308.0n ± 10%        ~ (p=0.240 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_2_case_sensitive:_false_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4         222.8n ±  3%    251.9n ±  5%  +13.04% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_4_case_sensitive:_true_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4        533.8n ±  5%    538.6n ±  4%        ~ (p=0.937 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_4_case_sensitive:_true_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4           602.1n ±  3%    585.8n ±  2%   -2.72% (p=0.015 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_4_case_sensitive:_true_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4       497.8n ±  4%    493.1n ±  3%        ~ (p=0.394 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_4_case_sensitive:_true_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4          309.4n ±  2%    305.4n ±  2%        ~ (p=0.180 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_4_case_sensitive:_false_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4       422.7n ±  3%    551.5n ±  3%  +30.47% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_4_case_sensitive:_false_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4          1.767µ ±  6%    1.942µ ±  7%   +9.91% (p=0.004 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_4_case_sensitive:_false_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4      533.7n ±  7%    551.8n ±  2%        ~ (p=0.065 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_4_case_sensitive:_false_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4         395.5n ±  3%    386.4n ±  3%        ~ (p=0.065 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_8_case_sensitive:_true_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4        998.3n ±  7%   1027.5n ±  3%        ~ (p=0.310 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_8_case_sensitive:_true_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4           943.5n ±  3%    945.4n ±  4%        ~ (p=0.589 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_8_case_sensitive:_true_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4       882.2n ±  3%    862.5n ±  2%        ~ (p=0.093 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_8_case_sensitive:_true_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4          495.4n ±  7%    492.6n ±  4%        ~ (p=0.937 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_8_case_sensitive:_false_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4       1.081µ ±  2%    1.034µ ±  3%   -4.39% (p=0.004 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_8_case_sensitive:_false_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4          2.395µ ±  6%    2.429µ ±  6%        ~ (p=0.699 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_8_case_sensitive:_false_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4      1.042µ ±  3%    1.055µ ±  3%        ~ (p=0.180 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_8_case_sensitive:_false_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4         708.0n ±  8%    722.4n ±  8%        ~ (p=0.589 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_16_case_sensitive:_true_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4       2.118µ ±  4%    2.096µ ±  8%        ~ (p=0.455 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_16_case_sensitive:_true_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4          509.1n ±  3%    526.8n ±  1%   +3.46% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_16_case_sensitive:_true_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4      1.742µ ±  4%    1.749µ ±  3%        ~ (p=0.589 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_16_case_sensitive:_true_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4         363.9n ±  2%    374.7n ±  3%   +2.97% (p=0.015 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_16_case_sensitive:_false_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4      2.055µ ±  3%    2.104µ ±  4%        ~ (p=0.240 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_16_case_sensitive:_false_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4         1.734µ ±  6%    1.895µ ±  6%   +9.28% (p=0.004 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_16_case_sensitive:_false_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4     1.985µ ± 10%    2.001µ ±  3%        ~ (p=0.818 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_16_case_sensitive:_false_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4        1.639µ ±  6%    1.659µ ±  5%        ~ (p=0.394 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_32_case_sensitive:_true_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4       3.898µ ±  3%    3.909µ ±  7%        ~ (p=1.000 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_32_case_sensitive:_true_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4          413.1n ±  3%    463.3n ±  2%  +12.18% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_32_case_sensitive:_true_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4      3.324µ ±  7%    3.640µ ±  3%   +9.51% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_32_case_sensitive:_true_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4         377.9n ±  6%    355.8n ±  5%   -5.86% (p=0.009 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_32_case_sensitive:_false_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4      4.120µ ±  4%    4.261µ ±  3%        ~ (p=0.093 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_32_case_sensitive:_false_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4         1.748µ ±  5%    1.830µ ±  6%        ~ (p=0.065 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_32_case_sensitive:_false_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4     4.162µ ±  4%    3.907µ ±  3%   -6.14% (p=0.004 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_32_case_sensitive:_false_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4        1.631µ ±  7%    1.691µ ± 11%        ~ (p=0.093 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_64_case_sensitive:_true_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4       7.485µ ±  3%    7.546µ ±  3%        ~ (p=0.589 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_64_case_sensitive:_true_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4          427.2n ±  2%    488.7n ±  5%  +14.40% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_64_case_sensitive:_true_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4      6.539µ ±  3%    6.281µ ±  3%   -3.95% (p=0.009 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_64_case_sensitive:_true_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4         408.1n ±  4%    371.8n ±  4%   -8.89% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_64_case_sensitive:_false_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4      8.348µ ±  4%    8.299µ ±  4%        ~ (p=0.818 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_64_case_sensitive:_false_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4         2.000µ ±  5%    2.158µ ±  3%   +7.90% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_64_case_sensitive:_false_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4     8.505µ ±  3%    8.631µ ±  9%        ~ (p=0.699 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_64_case_sensitive:_false_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4        1.673µ ±  8%    1.726µ ±  6%        ~ (p=0.394 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_128_case_sensitive:_true_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4      15.10µ ±  8%    15.34µ ±  4%        ~ (p=1.000 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_128_case_sensitive:_true_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4         596.1n ±  4%    606.2n ±  3%        ~ (p=0.195 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_128_case_sensitive:_true_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4     12.52µ ±  5%    13.61µ ±  3%   +8.73% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_128_case_sensitive:_true_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4        366.5n ±  5%    382.0n ±  4%        ~ (p=0.132 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_128_case_sensitive:_false_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4     17.69µ ±  3%    16.76µ ±  3%   -5.26% (p=0.009 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_128_case_sensitive:_false_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4        2.202µ ±  4%    2.821µ ± 13%  +28.09% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_128_case_sensitive:_false_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4    16.92µ ±  3%    17.88µ ±  3%   +5.69% (p=0.004 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_128_case_sensitive:_false_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4       1.668µ ± 15%    1.701µ ±  9%        ~ (p=1.000 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_256_case_sensitive:_true_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4      29.84µ ±  3%    30.64µ ±  4%        ~ (p=0.132 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_256_case_sensitive:_true_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4         839.0n ±  3%   1044.0n ±  3%  +24.43% (p=0.002 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_256_case_sensitive:_true_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4     25.56µ ±  4%    26.28µ ±  4%        ~ (p=0.180 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_256_case_sensitive:_true_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4        376.8n ±  3%    367.4n ±  2%   -2.48% (p=0.015 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_256_case_sensitive:_false_prefix_matcher:_true/without_optimizeEqualOrPrefixStringMatchers()-4     39.32µ ± 10%    37.32µ ±  8%   -5.09% (p=0.041 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_256_case_sensitive:_false_prefix_matcher:_true/with_optimizeEqualOrPrefixStringMatchers()-4        2.917µ ±  8%    2.748µ ±  6%   -5.76% (p=0.026 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_256_case_sensitive:_false_prefix_matcher:_false/without_optimizeEqualOrPrefixStringMatchers()-4    36.63µ ±  2%    36.59µ ±  4%        ~ (p=0.937 n=6)
OptimizeEqualOrPrefixStringMatchers/alternations:_256_case_sensitive:_false_prefix_matcher:_false/with_optimizeEqualOrPrefixStringMatchers()-4       1.624µ ±  5%    1.665µ ±  5%        ~ (p=0.065 n=6)
geomean                                                                                                                                              814.2n          823.0n         +1.08%
```