### PR TITLE
Corrects the behaviour of some operator and aggregators

### DIFF
--- a/promql/promqltest/testdata/aggregators.test
+++ b/promql/promqltest/testdata/aggregators.test
@@ -229,12 +229,27 @@ load 5m
   http_requests{job="api-server", instance="0", group="canary"}		NaN
   http_requests{job="api-server", instance="1", group="canary"}		3
   http_requests{job="api-server", instance="2", group="canary"}		4
+  http_requests_histogram{job="api-server", instance="3", group="canary"} {{schema:2 count:4 sum:10 buckets:[1 0 0 0 1 0 0 1 1]}}
 
 eval instant at 0m max(http_requests)
   {} 4
 
+# should produce same results ignoring histograms with info annotations.
+eval_info instant at 0m max({job="api-server"})
+  {} 4
+
+# should produce no result in case of only histograms with info annotations.
+eval_info instant at 0m max(http_requests_histogram)
+
 eval instant at 0m min(http_requests)
   {} 1
+
+# should produce same results ignoring histograms with info annotations.
+eval_info instant at 0m min({job="api-server"})
+  {} 1
+
+# should produce no result in case of only histograms with info annotations.
+eval_info instant at 0m min(http_requests_histogram)
 
 eval instant at 0m max by (group) (http_requests)
   {group="production"} 2
@@ -380,12 +395,22 @@ load 10s
 	data{test="uneven samples",point="a"} 0
 	data{test="uneven samples",point="b"} 1
 	data{test="uneven samples",point="c"} 4
+	data_histogram{test="histogram sample", point="c"} {{schema:2 count:4 sum:10 buckets:[1 0 0 0 1 0 0 1 1]}}
 	foo .8
 
 eval instant at 1m quantile without(point)(0.8, data)
 	{test="two samples"} 0.8
 	{test="three samples"} 1.6
 	{test="uneven samples"} 2.8
+
+# should produce same results ignoring histograms with info annotations.
+eval_info instant at 1m quantile without(point)(0.8, {__name__=~"^data(_histogram)?$"})
+	{test="two samples"} 0.8
+	{test="three samples"} 1.6
+	{test="uneven samples"} 2.8
+
+# should produce no result in case of only histograms with info annotations.
+eval_info instant at 1m quantile(0.8, data_histogram)
 
 # Bug #5276.
 eval instant at 1m quantile without(point)(scalar(foo), data)
@@ -581,11 +606,17 @@ load 5m
 	series{label="b"} 2
 	series{label="c"} {{schema:1 sum:15 count:10 buckets:[3 2 5 7 9]}}
 
-eval instant at 0m stddev(series)
+# should produce same results ignoring histograms with info annotations.
+eval_info instant at 0m stddev(series)
 	{} 0.5
 
-eval instant at 0m stdvar(series)
+eval_info instant at 0m stdvar(series)
 	{} 0.25
+
+# should produce no result in case of only histograms with info annotations.
+eval_info instant at 0m stddev({label="c"})
+
+eval_info instant at 0m stdvar({label="c"})
 
 eval instant at 0m stddev by (label) (series)
 	{label="a"} 0

--- a/promql/promqltest/testdata/operators.test
+++ b/promql/promqltest/testdata/operators.test
@@ -7,6 +7,7 @@ load 5m
 	http_requests{job="app-server", instance="1", group="production"}	0+60x10
 	http_requests{job="app-server", instance="0", group="canary"}		0+70x10
 	http_requests{job="app-server", instance="1", group="canary"}		0+80x10
+    http_requests_histogram{job="app-server", instance="1", group="production"} {{schema:1 sum:15 count:10 buckets:[3 2 5 7 9]}}x11
 
 load 5m
 	vector_matching_a{l="x"} 0+1x100
@@ -286,6 +287,26 @@ eval instant at 50m 1 == bool 1
 
 eval instant at 50m http_requests{job="api-server", instance="0", group="production"} == bool 100
 	{job="api-server", instance="0", group="production"} 1
+
+# should ignore histograms with info annotations in comparison between float and histogram.
+eval_info instant at 5m {job="app-server"} == 80
+    http_requests{group="canary", instance="1", job="app-server"} 80
+
+eval_info instant at 5m http_requests_histogram != 80
+
+eval_info instant at 5m http_requests_histogram > 80
+
+eval_info instant at 5m http_requests_histogram < 80
+
+eval_info instant at 5m http_requests_histogram >= 80
+
+eval_info instant at 5m http_requests_histogram <= 80
+
+# should produce valid results in-case of (in)equality between two histograms.
+eval instant at 5m http_requests_histogram == http_requests_histogram
+    http_requests_histogram{job="app-server", instance="1", group="production"} {{schema:1 sum:15 count:10 buckets:[3 2 5 7 9]}}
+
+eval instant at 5m http_requests_histogram != http_requests_histogram
 
 # group_left/group_right.
 

--- a/promql/promqltest/testdata/test.test
+++ b/promql/promqltest/testdata/test.test
@@ -1,0 +1,7 @@
+# Test native histograms with sum_over_time, avg_over_time.
+load 1m
+    min_histogram{idx="2"} 1 2
+    min_histogram3{idx="1"} -1 1
+    min_histogram4{idx="1"} 2 1
+    min_histogram2{idx="1"} {{schema:0 count:25 sum:1234.5 z_bucket:4 z_bucket_w:0.001 buckets:[1 2 0 1 1] n_buckets:[2 4 0 0 1 9]}} {{schema:0 count:25 sum:1234.5 z_bucket:4 z_bucket_w:0.001 buckets:[1 2 0 1 1] n_buckets:[2 4 0 0 1 9]}}
+    min_histogram5{idx="1"} {{schema:0 count:25 sum:1234.5 z_bucket:4 z_bucket_w:0.001 buckets:[1 2 0 1 1] n_buckets:[2 4 0 0 1 9]}} {{schema:0 count:25 sum:1234.5 z_bucket:4 z_bucket_w:0.001 buckets:[1 2 0 1 1] n_buckets:[2 4 0 0 1 9]}}

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -147,6 +147,7 @@ var (
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
 	IncompatibleTypesInBinOpInfo            = fmt.Errorf("%w: incompatible sample types encountered for binary operator", PromQLInfo)
+	MixedFloatsHistogramsInfo               = fmt.Errorf("%w: encountered a mix of histograms and floats for", PromQLInfo)
 )
 
 type annoErr struct {
@@ -281,5 +282,14 @@ func NewIncompatibleTypesInBinOpInfo(lhsType, operator, rhsType string, pos posr
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q: %s %s %s", IncompatibleTypesInBinOpInfo, operator, lhsType, operator, rhsType),
+	}
+}
+
+// NewMixedFloatsHistogramsAggInfo is used when the queried series includes both
+// float samples and histogram samples in an aggregation.
+func NewMixedFloatsHistogramsAggInfo(aggregation string, pos posrange.PositionRange) error {
+	return annoErr{
+		PositionRange: pos,
+		Err:           fmt.Errorf("%w %s aggregation", MixedFloatsHistogramsInfo, aggregation),
 	}
 }


### PR DESCRIPTION
Related to #13934 .

Corrects the behaviour of `max`, `min`, `quantile`, `stddev`, `stdvar` aggregators and `==`, `!=`, `>`, `<`, `>=`, `<=` comparators with native histograms.

CC: @beorn7.
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
