### PR TITLE
test(web): speed up test execution

### DIFF
--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -443,6 +443,7 @@ func TestEndpoints(t *testing.T) {
 	ng := testEngine(t)
 
 	t.Run("local", func(t *testing.T) {
+		t.Parallel()
 		algr := rulesRetrieverMock{testing: t}
 
 		algr.CreateAlertingRules()

--- a/web/api/v1/codec_test.go
+++ b/web/api/v1/codec_test.go
@@ -21,12 +21,14 @@ import (
 )
 
 func TestMIMEType_String(t *testing.T) {
+	t.Parallel()
 	m := MIMEType{Type: "application", SubType: "json"}
 
 	require.Equal(t, "application/json", m.String())
 }
 
 func TestMIMEType_Satisfies(t *testing.T) {
+	t.Parallel()
 	m := MIMEType{Type: "application", SubType: "json"}
 
 	scenarios := map[string]struct {
@@ -61,6 +63,7 @@ func TestMIMEType_Satisfies(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			actual := m.Satisfies(scenario.accept)
 			require.Equal(t, scenario.expected, actual)
 		})

--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -40,6 +40,7 @@ import (
 )
 
 func TestApiStatusCodes(t *testing.T) {
+	t.Parallel()
 	for name, tc := range map[string]struct {
 		err            error
 		expectedString string
@@ -87,6 +88,7 @@ func TestApiStatusCodes(t *testing.T) {
 			"error from seriesset": errorTestQueryable{q: errorTestQuerier{s: errorTestSeriesSet{err: tc.err}}},
 		} {
 			t.Run(fmt.Sprintf("%s/%s", name, k), func(t *testing.T) {
+				t.Parallel()
 				r := createPrometheusAPI(t, q)
 				rec := httptest.NewRecorder()
 

--- a/web/api/v1/json_codec_test.go
+++ b/web/api/v1/json_codec_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestJsonCodec_Encode(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		response interface{}
 		expected string

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -203,6 +203,7 @@ test_metric_without_labels{instance="baz"} 1001 6000000
 }
 
 func TestFederation(t *testing.T) {
+	t.Parallel()
 	storage := promqltest.LoadedStorage(t, `
 		load 1m
 			test_metric1{foo="bar",instance="i"}    0+100x100
@@ -254,8 +255,10 @@ func (notReadyReadStorage) Stats(string, int) (*tsdb.Stats, error) {
 
 // Regression test for https://github.com/prometheus/prometheus/issues/7181.
 func TestFederation_NotReady(t *testing.T) {
+	t.Parallel()
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			h := &Handler{
 				localStorage:  notReadyReadStorage{},
 				lookbackDelta: 5 * time.Minute,
@@ -302,6 +305,7 @@ func normalizeBody(body *bytes.Buffer) string {
 }
 
 func TestFederationWithNativeHistograms(t *testing.T) {
+	t.Parallel()
 	storage := teststorage.New(t)
 	t.Cleanup(func() { storage.Close() })
 


### PR DESCRIPTION
Parallelize testcases using t.Parallel() in the `web` package.
Also, I've reduced the waiting time for the web server of the test to run. 

related to #15185 

### On my machine

[1] Time spent on main ([`d0eecb1`](https://github.com/prometheus/prometheus/tree/d0eecb122393b72e763053586a64bc6972dd8c6b))

```text
$ go test -count=1 ./web
ok  github.com/prometheus/prometheus/web 15.532s
```

[2] After adding more t.Parallel():

```text
$ go test -count=1 ./web
ok  	github.com/prometheus/prometheus/web	5.774s
```

[3] After reducing the waiting time for the web server of the test to run. 

```text
$ go test -count=1 ./web
ok  	github.com/prometheus/prometheus/web	0.542s
```

### Reasons for Slow Test Execution

1. Each test in /web/web_test.go previously required a 5-second wait for the web server to start.
2. t.Parallel() was missing from two tests, resulting in an additional 10 seconds for these non-parallel tests, and around 5 seconds plus additional time for the remaining tests.
3. By adding t.Parallel() to all tests, the overall execution time was reduced to approximately 5 seconds, matching the server startup time.
4. I further optimized the waiting time for the web server by enabling test threads to start as soon as the server is up, with a 5-second timeout to ensure readiness.