### PR TITLE
bugfix: Fix otlp translator for foreign characters

### DIFF
--- a/storage/remote/otlptranslator/prometheus/normalize_label.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_label.go
@@ -49,7 +49,7 @@ func NormalizeLabel(label string) string {
 
 // Return '_' for anything non-alphanumeric.
 func sanitizeRune(r rune) rune {
-	if unicode.IsLetter(r) || unicode.IsDigit(r) {
+	if unicode.IsLower(r) || unicode.IsUpper(r) || unicode.IsDigit(r) {
 		return r
 	}
 	return '_'

--- a/storage/remote/otlptranslator/prometheus/normalize_label_test.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_label_test.go
@@ -1,0 +1,45 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeLabel(t *testing.T) {
+	tests := []struct {
+		label    string
+		expected string
+	}{
+		{"", ""},
+		{"label:with:colons", "label_with_colons"}, // Without UTF-8 support, colons are only allowed in metric names
+		{"LabelWithCapitalLetters", "LabelWithCapitalLetters"},
+		{"label!with&special$chars)", "label_with_special_chars_"},
+		{"label_with_foreign_characteres_字符", "label_with_foreign_characteres___"},
+		{"label.with.dots", "label_with_dots"},
+		{"123label", "key_123label"},
+		{"_label_starting_with_underscore", "key_label_starting_with_underscore"},
+		{"__label_starting_with_2underscores", "__label_starting_with_2underscores"},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+			result := NormalizeLabel(test.label)
+			require.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/storage/remote/otlptranslator/prometheus/normalize_name.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_name.go
@@ -237,11 +237,13 @@ func removeSuffix(tokens []string, suffix string) []string {
 
 // Clean up specified string so it's Prometheus compliant
 func CleanUpString(s string) string {
-	return strings.Join(strings.FieldsFunc(s, func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsDigit(r) }), "_")
+	return strings.Join(strings.FieldsFunc(s, func(r rune) bool { return !unicode.IsUpper(r) && !unicode.IsLower(r) && !unicode.IsDigit(r) }), "_")
 }
 
 func RemovePromForbiddenRunes(s string) string {
-	return strings.Join(strings.FieldsFunc(s, func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != ':' }), "_")
+	return strings.Join(strings.FieldsFunc(s, func(r rune) bool {
+		return !unicode.IsUpper(r) && !unicode.IsLower(r) && !unicode.IsDigit(r) && r != '_' && r != ':'
+	}), "_")
 }
 
 // Retrieve the Prometheus "basic" unit corresponding to the specified "basic" unit

--- a/storage/remote/otlptranslator/prometheus/normalize_name_test.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_name_test.go
@@ -202,4 +202,5 @@ func TestBuildCompliantNameWithoutSuffixes(t *testing.T) {
 	require.Equal(t, ":foo::bar", BuildCompliantName(createCounter(":foo::bar", ""), "", false))
 	require.Equal(t, "foo_bar", BuildCompliantName(createGauge("foo.bar", "1"), "", false))
 	require.Equal(t, "system_io", BuildCompliantName(createCounter("system.io", "foo/bar"), "", false))
+	require.Equal(t, "metric_with___foreign_characteres", BuildCompliantName(createCounter("metric_with_字符_foreign_characteres", ""), "", false))
 }


### PR DESCRIPTION
The fix was originally proposed in https://github.com/prometheus/prometheus/pull/14974, but we're moving it to a separate PR to keep the scope of changes smaller.

In the end, I've also decided to go in a different direction than proposed in #14974 for this fix. I've looked up the [unicode table](https://www.compart.com/en/unicode/category) and just choose to use IsUpper and IsLower instead of the whole Letter category.