### PR TITLE
Fix round function not hornoring delayed name removal flag

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3501,3 +3501,65 @@ histogram {{sum:4 count:4 buckets:[2 2]}} {{sum:6 count:6 buckets:[3 3]}} {{sum:
 		},
 	})
 }
+
+func TestEvaluationWithDelayedNameRemovalDisabled(t *testing.T) {
+	opts := promql.EngineOpts{
+		Logger:                   nil,
+		Reg:                      nil,
+		EnableAtModifier:         true,
+		MaxSamples:               10000,
+		Timeout:                  10 * time.Second,
+		EnableDelayedNameRemoval: false,
+	}
+	engine := promqltest.NewTestEngineWithOpts(t, opts)
+
+	promqltest.RunTest(t, `
+load 5m
+	metric{env="1"}	0 60 120
+	another_metric{env="1"}	60 120 180
+
+# Does not drop __name__ for vector selector
+eval instant at 15m metric{env="1"}
+	metric{env="1"} 120
+
+# Drops __name__ for unary operators
+eval instant at 15m -metric
+	{env="1"} -120
+
+# Drops __name__ for binary operators
+eval instant at 15m metric + another_metric
+	{env="1"} 300
+
+# Does not drop __name__ for binary comparison operators
+eval instant at 15m metric <= another_metric
+	metric{env="1"} 120
+
+# Drops __name__ for binary comparison operators with "bool" modifier
+eval instant at 15m metric <= bool another_metric
+	{env="1"} 1
+
+# Drops __name__ for vector-scalar operations
+eval instant at 15m metric * 2
+	{env="1"} 240
+
+# Drops __name__ for instant-vector functions
+eval instant at 15m clamp(metric, 0, 100)
+	{env="1"} 100
+
+# Drops __name__ for round function
+eval instant at 15m round(metric)
+	{env="1"} 120
+
+# Drops __name__ for range-vector functions
+eval instant at 15m rate(metric{env="1"}[10m])
+	{env="1"} 0.2
+
+# Does not drop __name__ for last_over_time function
+eval instant at 15m last_over_time(metric{env="1"}[10m])
+	metric{env="1"} 120
+
+# Drops name for other _over_time functions
+eval instant at 15m max_over_time(metric{env="1"}[10m])
+	{env="1"} 120
+`, engine)
+}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -534,6 +534,9 @@ func funcRound(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 
 	for _, el := range vec {
 		f := math.Floor(el.F*toNearestInverse+0.5) / toNearestInverse
+		if !enh.enableDelayedNameRemoval {
+			el.Metric = el.Metric.DropMetricName()
+		}
 		enh.Out = append(enh.Out, Sample{
 			Metric:   el.Metric,
 			F:        f,

--- a/promql/promqltest/testdata/name_label_dropping.test
+++ b/promql/promqltest/testdata/name_label_dropping.test
@@ -31,6 +31,10 @@ eval instant at 15m metric * 2
 eval instant at 15m clamp(metric, 0, 100)
 	{env="1"} 100
 
+# Drops __name__ for round function
+eval instant at 15m round(metric)
+	{env="1"} 120
+
 # Drops __name__ for range-vector functions
 eval instant at 15m rate(metric{env="1"}[10m])
 	{env="1"} 0.2


### PR DESCRIPTION
Note: this is against the release 2.55 branch as I believe this is a user facing behavior change.

We observed an issue for `round` function where the default behavior got changed from Prometheus version 2.54 to 2.55.

If the new feature flag `promql-delayed-name-removal` is disabled, the metric name is not removed.

```
# version 2.55, flag enabled
curl -s  'localhost:9090/api/v1/query?query=round(up,1)'| jq .
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "instance": "localhost:9090",
          "job": "prometheus"
        },
        "value": [
          1730340756.818,
          "1"
        ]
      }
    ]
  }
}
# version 2.54
curl -s  'localhost:9091/api/v1/query?query=round(up,1)'| jq .
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "instance": "localhost:9090",
          "job": "prometheus"
        },
        "value": [
          1730340760.34,
          "1"
        ]
      }
    ]
  }
}
# version 2.55, flag disabled
curl -s  'localhost:9092/api/v1/query?query=round(up,1)'| jq .
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "__name__": "up",
          "instance": "localhost:9090",
          "job": "prometheus"
        },
        "value": [
          1730340763.361,
          "1"
        ]
      }
    ]
  }
}
```

We found out the issue in https://github.com/prometheus/prometheus/pull/14477/files#diff-d8538d074889981b3d2c55b012f620e45508e23b133996c7ca0b0594dd95e65fR547 where  the condition to check the feature flag was not added to `round` function so the metric name is not eventually removed if the FF is disabled.

This PR fixes the issue and adds relevant tests. Probably there are other functions that have the same issue but `round` is the same impacted function I found so far.
