### PR TITLE
bugfix: Fix otlp translator switching colons to underscores in suffix adding mode

### DIFF
--- a/storage/remote/otlptranslator/prometheus/normalize_name.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_name.go
@@ -114,7 +114,7 @@ func normalizeName(metric pmetric.Metric, namespace string) string {
 	// Split metric name into "tokens" (remove all non-alphanumerics)
 	nameTokens := strings.FieldsFunc(
 		metric.Name(),
-		func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsDigit(r) },
+		func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != ':' },
 	)
 
 	// Split unit at the '/' if any

--- a/storage/remote/otlptranslator/prometheus/normalize_name_test.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_name_test.go
@@ -184,8 +184,8 @@ func TestBuildCompliantNameWithNormalize(t *testing.T) {
 	require.Equal(t, "system_network_io_bytes_total", BuildCompliantName(createCounter("network.io", "By"), "system", true))
 	require.Equal(t, "_3_14_digits", BuildCompliantName(createGauge("3.14 digits", ""), "", true))
 	require.Equal(t, "envoy_rule_engine_zlib_buf_error", BuildCompliantName(createGauge("envoy__rule_engine_zlib_buf_error", ""), "", true))
-	require.Equal(t, "foo_bar", BuildCompliantName(createGauge(":foo::bar", ""), "", true))
-	require.Equal(t, "foo_bar_total", BuildCompliantName(createCounter(":foo::bar", ""), "", true))
+	require.Equal(t, ":foo::bar", BuildCompliantName(createGauge(":foo::bar", ""), "", true))
+	require.Equal(t, ":foo::bar_total", BuildCompliantName(createCounter(":foo::bar", ""), "", true))
 	// Gauges with unit 1 are considered ratios.
 	require.Equal(t, "foo_bar_ratio", BuildCompliantName(createGauge("foo.bar", "1"), "", true))
 	// Slashes in units are converted.


### PR DESCRIPTION
Fixes #15199 

Colons are allowed in metric names even without UTF8 support. The usage of colons is a very common pattern for recording rules, [as documented in our website](https://prometheus.io/docs/practices/rules/) and by [PromLabs](https://training.promlabs.com/training/recording-rules/recording-rules-overview/rule-naming-conventions/), and broadly used by popular mixins.

This bug only occurs in suffix adding mode, not otherwise. Note that this mode is hard coded in Prometheus itself, but can be disabled when using Prometheus as a library.