### PR TITLE
Stop ignoring `ignoreCounterResets` in `requireEqualSeries` test method

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -7039,9 +7039,8 @@ func TestOOOHistogramCompactionWithCounterResets(t *testing.T) {
 			}
 			series1ExpSamplesPostCompact = append(series1ExpSamplesPostCompact, s)
 		}
-		// Counter reset.
+		// Counter reset, but set as unknown since the first sample of OOO chunks have UnknownCounterReset
 		s = addSample(int64(490), series1, 100000, histogram.UnknownCounterReset)
-		s = copyWithCounterReset(s, histogram.CounterReset)
 		series1ExpSamplesPreCompact = append(series1ExpSamplesPreCompact, s)
 		series1ExpSamplesPostCompact = append(series1ExpSamplesPostCompact, s)
 		// Add some more samples after the counter reset.
@@ -7064,9 +7063,8 @@ func TestOOOHistogramCompactionWithCounterResets(t *testing.T) {
 			}
 			series2ExpSamplesPostCompact = append(series2ExpSamplesPostCompact, s)
 		}
-		// Counter reset.
+		// Counter reset, but set as unknown since the first sample of OOO chunks have UnknownCounterReset
 		s = addSample(int64(300), series2, 100000, histogram.UnknownCounterReset)
-		s = copyWithCounterReset(s, histogram.CounterReset)
 		series2ExpSamplesPreCompact = append(series2ExpSamplesPreCompact, s)
 		series2ExpSamplesPostCompact = append(series2ExpSamplesPostCompact, s)
 		// Add some more samples after the counter reset.

--- a/tsdb/testutil.go
+++ b/tsdb/testutil.go
@@ -111,7 +111,11 @@ func requireEqualSeries(t *testing.T, expected, actual map[string][]chunks.Sampl
 	for name, expectedItem := range expected {
 		actualItem, ok := actual[name]
 		require.True(t, ok, "Expected series %s not found", name)
-		requireEqualSamples(t, name, expectedItem, actualItem, requireEqualSamplesIgnoreCounterResets)
+		if ignoreCounterResets {
+			requireEqualSamples(t, name, expectedItem, actualItem, requireEqualSamplesIgnoreCounterResets)
+		} else {
+			requireEqualSamples(t, name, expectedItem, actualItem)
+		}
 	}
 	for name := range actual {
 		_, ok := expected[name]


### PR DESCRIPTION
An addition to https://github.com/prometheus/prometheus/pull/15221

Previously the `ignoreCounterResets` arg in `requireEqualSeries` was being ignored. This PR fixes that and also updates TestOOOHistogramCompactionWithCounterResets after the changes in the linked PR (some counter resets are now unknown)