### PR TITLE
WIP: incorrect counter reset detection when compacting in-order and ooo chunks

### DIFF
--- a/storage/merge.go
+++ b/storage/merge.go
@@ -745,7 +745,6 @@ type compactChunkIterator struct {
 
 func (c *compactChunkIterator) At() chunks.Meta {
 	chunk := c.curr.Chunk
-	//TODO: only clear if counterreset != unknown?
 	if chunk.Encoding() == chunkenc.EncHistogram && !c.consecutive {
 		hc := chunk.(*chunkenc.HistogramChunk)
 		if hc.GetCounterResetHeader() != chunkenc.GaugeType &&
@@ -830,7 +829,7 @@ func (c *compactChunkIterator) Next() bool {
 		panic("unexpected seriesToChunkEncoder lack of iterations")
 	}
 	c.curr = iter.At()
-	c.consecutive = false // setting as not consecutive whenever we need to merge chunks. this could be true (e.g. multiple chunks from same iterator, the earliest timestamp comes from the previousIterator) but more complex to figure out.
+	c.consecutive = false // setting as not consecutive whenever we need to merge chunks. this could be true (e.g. first sample in merged chunk is from the prevIterator) but more complex to figure out.
 	c.prevIterator = iter
 	if iter.Next() {
 		heap.Push(&c.h, iter)

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -95,9 +95,9 @@ func (c *FloatHistogramChunk) GetCounterResetHeader() CounterResetHeader {
 // ClearCounterReset sets the counter reset header to UnknownCounterReset.
 func (c *FloatHistogramChunk) ClearCounterReset() {
 	// Hacky fix - make copy (needed for read-only slices)
-	writeable := make([]byte, len(c.Bytes()))
-	copy(writeable, c.Bytes())
-	c.Reset(writeable)
+	//writeable := make([]byte, len(c.Bytes()))
+	//copy(writeable, c.Bytes())
+	//c.Reset(writeable)
 	c.Bytes()[2] = (c.Bytes()[2] & (^CounterResetHeaderMask)) | byte(UnknownCounterReset)
 }
 

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -94,6 +94,10 @@ func (c *FloatHistogramChunk) GetCounterResetHeader() CounterResetHeader {
 
 // ClearCounterReset sets the counter reset header to UnknownCounterReset.
 func (c *FloatHistogramChunk) ClearCounterReset() {
+	// Hacky fix - make copy (needed for read-only slices)
+	writeable := make([]byte, len(c.Bytes()))
+	copy(writeable, c.Bytes())
+	c.Reset(writeable)
 	c.Bytes()[2] = (c.Bytes()[2] & (^CounterResetHeaderMask)) | byte(UnknownCounterReset)
 }
 

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -94,10 +94,11 @@ func (c *FloatHistogramChunk) GetCounterResetHeader() CounterResetHeader {
 
 // ClearCounterReset sets the counter reset header to UnknownCounterReset.
 func (c *FloatHistogramChunk) ClearCounterReset() {
-	// Hacky fix - make copy (needed for read-only slices)
-	//writeable := make([]byte, len(c.Bytes()))
-	//copy(writeable, c.Bytes())
-	//c.Reset(writeable)
+	// FIXME: this could be read only memory when reading from stored blocks
+	// Hacky fix (to be improved) - make copy (needed for read-only slices)
+	writeable := make([]byte, len(c.Bytes()))
+	copy(writeable, c.Bytes())
+	c.b.stream = writeable
 	c.Bytes()[2] = (c.Bytes()[2] & (^CounterResetHeaderMask)) | byte(UnknownCounterReset)
 }
 

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -105,6 +105,7 @@ func (c *HistogramChunk) GetCounterResetHeader() CounterResetHeader {
 
 // ClearCounterReset sets the counter reset header to UnknownCounterReset.
 func (c *HistogramChunk) ClearCounterReset() {
+	// FIXME: this could be read only memory when reading from stored blocks
 	c.Bytes()[2] = (c.Bytes()[2] & (^CounterResetHeaderMask)) | byte(UnknownCounterReset)
 }
 

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -107,9 +107,9 @@ func (c *HistogramChunk) GetCounterResetHeader() CounterResetHeader {
 func (c *HistogramChunk) ClearCounterReset() {
 	// FIXME: this could be read only memory when reading from stored blocks
 	// Hacky fix - make copy (needed for read-only slices)
-	writeable := make([]byte, len(c.Bytes()))
-	copy(writeable, c.Bytes())
-	c.Reset(writeable)
+	//writeable := make([]byte, len(c.Bytes()))
+	//copy(writeable, c.Bytes())
+	//c.Reset(writeable)
 	c.Bytes()[2] = (c.Bytes()[2] & (^CounterResetHeaderMask)) | byte(UnknownCounterReset)
 }
 

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -106,10 +106,10 @@ func (c *HistogramChunk) GetCounterResetHeader() CounterResetHeader {
 // ClearCounterReset sets the counter reset header to UnknownCounterReset.
 func (c *HistogramChunk) ClearCounterReset() {
 	// FIXME: this could be read only memory when reading from stored blocks
-	// Hacky fix - make copy (needed for read-only slices)
-	//writeable := make([]byte, len(c.Bytes()))
-	//copy(writeable, c.Bytes())
-	//c.Reset(writeable)
+	// Hacky fix (to be improved) - make copy (needed for read-only slices)
+	writeable := make([]byte, len(c.Bytes()))
+	copy(writeable, c.Bytes())
+	c.b.stream = writeable
 	c.Bytes()[2] = (c.Bytes()[2] & (^CounterResetHeaderMask)) | byte(UnknownCounterReset)
 }
 

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -106,6 +106,10 @@ func (c *HistogramChunk) GetCounterResetHeader() CounterResetHeader {
 // ClearCounterReset sets the counter reset header to UnknownCounterReset.
 func (c *HistogramChunk) ClearCounterReset() {
 	// FIXME: this could be read only memory when reading from stored blocks
+	// Hacky fix - make copy (needed for read-only slices)
+	writeable := make([]byte, len(c.Bytes()))
+	copy(writeable, c.Bytes())
+	c.Reset(writeable)
 	c.Bytes()[2] = (c.Bytes()[2] & (^CounterResetHeaderMask)) | byte(UnknownCounterReset)
 }
 

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -7347,7 +7347,7 @@ func TestOOOHistogramCompactionWithCounterResetsInterleaving(t *testing.T) {
 
 		// Final state. Blocks from normal and OOO head are merged.
 		// FIXME: erroring as T3 detected as counter reset incorrectly (when in-order and OOO blocks are merged if there are interleaved but not overlapping chunks, counter resets in the in-order chunks aren't corrected
-		verifyDBSamples(expSamples)
+		//verifyDBSamples(expSamples)
 	}
 }
 

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -7347,7 +7347,7 @@ func TestOOOHistogramCompactionWithCounterResetsInterleaving(t *testing.T) {
 
 		// Final state. Blocks from normal and OOO head are merged.
 		// FIXME: erroring as T3 detected as counter reset incorrectly (when in-order and OOO blocks are merged if there are interleaved but not overlapping chunks, counter resets in the in-order chunks aren't corrected
-		//verifyDBSamples(expSamples)
+		verifyDBSamples(expSamples)
 	}
 }
 


### PR DESCRIPTION
Similar to https://github.com/prometheus/prometheus/pull/15221. There are some cases in compaction where counter resets should be cleared when merging in-order and OOO NH chunks but aren't.

Compaction uses the [CompactingChunkSeriesMerger](https://github.com/prometheus/prometheus/blob/6ebfbd2d540af150c3e001d13e804ad199dbc103/tsdb/compact.go#L197) which uses the [compactChunkIterator](https://github.com/prometheus/prometheus/blob/12bd92a25ccc6516f7cda9f53b5798fb5992a6c3/storage/merge.go#L747). This iterator does merge chunks together (in the case of compaction, the merge func is the chainSampleIterator which will fix counter resets), but it only merges overlapping chunks. If it has chunks that are interleaved but not overlapping, then we can have the same issue of not fixing counter resets. This becomes a problem when compacting in-order and OOO blocks together.

**Example**
Samples: T0: 0, T1: 10, T2: 0 (counter reset), T3: 3
Ingestion order: T0, T1, T3, T2

T3 is detected as a counter reset before T2 is ingested

When first compacted, the in-order and out of order heads are compacted separated and we get two blocks:

In-order block: 
- Chunk 1: `[T0, T1]`, CounterResetHeader: Unknown
- Chunk 2: `[T3]`, CounterResetHeader: CounterReset 

Out-of-order block:
- Chunk 1: `[T2]`, CounterResetHeader: UnknownCounterReset

When these blocks are compacted together, since the in-order and OOO chunks don't overlap, the CounterReset for `[T3]` isn't corrected. 

Current draft PR only has a test that triggers the issue

**Proposed fix**
Similar to `chainSampleIterator`, keep track of whether chunks are coming from the same underlying iterator. If the chunk is a histogram/float histogram chunk and the underlying iterator has been switched, clear the counter reset for the chunk.