### PR TITLE
storage: add new interface to append with CT

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1746,21 +1746,27 @@ loop:
 		if seriesAlreadyScraped && parsedTimestamp == nil {
 			err = storage.ErrDuplicateSampleForTimestamp
 		} else {
+			var ct int64
+			var appWithCT storage.AppenderWithCT
+			var canEncodeCT bool
+
 			if sl.enableCTZeroIngestion {
+				appWithCT, canEncodeCT = app.(storage.AppenderWithCT)
 				if ctMs := p.CreatedTimestamp(); ctMs != nil {
+					ct = *ctMs
 					if isHistogram && sl.enableNativeHistogramIngestion {
 						if h != nil {
-							ref, err = app.AppendHistogramCTZeroSample(ref, lset, t, *ctMs, h, nil)
+							ref, err = app.AppendHistogramCTZeroSample(ref, lset, t, ct, h, nil)
 						} else {
-							ref, err = app.AppendHistogramCTZeroSample(ref, lset, t, *ctMs, nil, fh)
+							ref, err = app.AppendHistogramCTZeroSample(ref, lset, t, ct, nil, fh)
 						}
 					} else {
-						ref, err = app.AppendCTZeroSample(ref, lset, t, *ctMs)
+						ref, err = app.AppendCTZeroSample(ref, lset, t, ct)
 					}
 					if err != nil && !errors.Is(err, storage.ErrOutOfOrderCT) { // OOO is a common case, ignoring completely for now.
 						// CT is an experimental feature. For now, we don't need to fail the
 						// scrape on errors updating the created timestamp, log debug.
-						sl.l.Debug("Error when appending CT in scrape loop", "series", string(met), "ct", *ctMs, "t", t, "err", err)
+						sl.l.Debug("Error when appending CT in scrape loop", "series", string(met), "ct", ct, "t", t, "err", err)
 					}
 				}
 			}
@@ -1772,7 +1778,11 @@ loop:
 					ref, err = app.AppendHistogram(ref, lset, t, nil, fh)
 				}
 			} else {
-				ref, err = app.Append(ref, lset, t, val)
+				if canEncodeCT && ct != 0 {
+					ref, err = appWithCT.AppendWithCT(ref, lset, t, val, ct)
+				} else {
+					ref, err = app.Append(ref, lset, t, val)
+				}
 			}
 		}
 

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -285,6 +285,12 @@ type Appender interface {
 	CreatedTimestampAppender
 }
 
+type AppenderWithCT interface {
+	Appender
+
+	AppendWithCT(ref SeriesRef, l labels.Labels, t int64, v float64, ct int64) (SeriesRef, error)
+}
+
 // GetRef is an extra interface on Appenders used by downstream projects
 // (e.g. Cortex) to avoid maintaining a parallel set of references.
 type GetRef interface {

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -730,11 +730,12 @@ outer:
 			default:
 			}
 			if t.shards.enqueue(s.Ref, timeSeries{
-				seriesLabels: lbls,
-				metadata:     meta,
-				timestamp:    s.T,
-				value:        s.V,
-				sType:        tSample,
+				seriesLabels:     lbls,
+				metadata:         meta,
+				timestamp:        s.T,
+				createdTimestamp: s.CT,
+				value:            s.V,
+				sType:            tSample,
 			}) {
 				continue outer
 			}
@@ -1351,13 +1352,14 @@ type queue struct {
 }
 
 type timeSeries struct {
-	seriesLabels   labels.Labels
-	value          float64
-	histogram      *histogram.Histogram
-	floatHistogram *histogram.FloatHistogram
-	metadata       *metadata.Metadata
-	timestamp      int64
-	exemplarLabels labels.Labels
+	seriesLabels     labels.Labels
+	value            float64
+	histogram        *histogram.Histogram
+	floatHistogram   *histogram.FloatHistogram
+	metadata         *metadata.Metadata
+	timestamp        int64
+	createdTimestamp int64
+	exemplarLabels   labels.Labels
 	// The type of series: sample, exemplar, or histogram.
 	sType seriesType
 }
@@ -1949,6 +1951,7 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 				Value:     d.value,
 				Timestamp: d.timestamp,
 			})
+			pendingData[nPending].CreatedTimestamp = d.createdTimestamp
 			nPendingSamples++
 		case tExemplar:
 			pendingData[nPending].Exemplars = append(pendingData[nPending].Exemplars, writev2.Exemplar{

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -161,6 +161,7 @@ type RefSample struct {
 	Ref chunks.HeadSeriesRef
 	T   int64
 	V   float64
+	CT  int64
 }
 
 // RefMetadata is the metadata associated with a series ID.
@@ -312,8 +313,9 @@ func (d *Decoder) Samples(rec []byte, samples []RefSample) ([]RefSample, error) 
 		return samples, nil
 	}
 	var (
-		baseRef  = dec.Be64()
-		baseTime = dec.Be64int64()
+		baseRef         = dec.Be64()
+		baseTime        = dec.Be64int64()
+		baseCreatedTime = dec.Be64int64()
 	)
 	// Allow 1 byte for each varint and 8 for the value; the output slice must be at least that big.
 	if minSize := dec.Len() / (1 + 1 + 8); cap(samples) < minSize {
@@ -322,12 +324,14 @@ func (d *Decoder) Samples(rec []byte, samples []RefSample) ([]RefSample, error) 
 	for len(dec.B) > 0 && dec.Err() == nil {
 		dref := dec.Varint64()
 		dtime := dec.Varint64()
+		dcreatedTime := dec.Varint64()
 		val := dec.Be64()
 
 		samples = append(samples, RefSample{
 			Ref: chunks.HeadSeriesRef(int64(baseRef) + dref),
 			T:   baseTime + dtime,
 			V:   math.Float64frombits(val),
+			CT:  baseCreatedTime + dcreatedTime,
 		})
 	}
 
@@ -673,16 +677,20 @@ func (e *Encoder) Samples(samples []RefSample, b []byte) []byte {
 		return buf.Get()
 	}
 
-	// Store base timestamp and base reference number of first sample.
-	// All samples encode their timestamp and ref as delta to those.
+	// Store base base reference number, timestamp and created timestamp of
+	// first sample.  All samples encode their ref, timestamp and created
+	// timestamp as delta to those.
+	// TODO(ridwanmsharif): Can the timestamp be encoded as a delta with the CT?
 	first := samples[0]
 
 	buf.PutBE64(uint64(first.Ref))
 	buf.PutBE64int64(first.T)
+	buf.PutBE64int64(first.CT)
 
 	for _, s := range samples {
 		buf.PutVarint64(int64(s.Ref) - int64(first.Ref))
 		buf.PutVarint64(s.T - first.T)
+		buf.PutVarint64(s.CT - first.CT)
 		buf.PutBE64(math.Float64bits(s.V))
 	}
 	return buf.Get()

--- a/tsdb/record/record_test.go
+++ b/tsdb/record/record_test.go
@@ -225,6 +225,20 @@ func TestRecord_EncodeDecode(t *testing.T) {
 	require.Equal(t, floatHistograms, decGaugeFloatHistograms)
 }
 
+func TestRecord_EncodeDecodeCT(t *testing.T) {
+	var enc Encoder
+	dec := NewDecoder(labels.NewSymbolTable())
+
+	samples := []RefSample{
+		{Ref: 0, T: 122, V: 123, CT: 12345},
+		{Ref: 0, T: 123, V: 123, CT: -12345},
+		{Ref: 0, T: 123, V: 123, CT: 0},
+	}
+	decSamples, err := dec.Samples(enc.Samples(samples, nil), nil)
+	require.NoError(t, err)
+	require.Equal(t, samples, decSamples)
+}
+
 // TestRecord_Corrupted ensures that corrupted records return the correct error.
 // Bugfix check for pull/521 and pull/523.
 func TestRecord_Corrupted(t *testing.T) {

--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -517,7 +517,7 @@ func TestReadCheckpointMultipleSegments(t *testing.T) {
 
 	const segments = 1
 	const seriesCount = 20
-	const samplesCount = 300
+	const samplesCount = 350
 
 	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
@@ -593,8 +593,8 @@ func TestCheckpointSeriesReset(t *testing.T) {
 		compress CompressionType
 		segments int
 	}{
-		{compress: CompressionNone, segments: 14},
-		{compress: CompressionSnappy, segments: 13},
+		{compress: CompressionNone, segments: 15},
+		{compress: CompressionSnappy, segments: 14},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This change does the following:
- Add an interface to append a sample with CT
- Update headAppender and initAppender to implement AppendWithCT
- Update the RefSample to include CT
- Update the scrape loop to add the CT to samples when CT is enabled

This change doesn't update the remote storage wlog watcher to make use of the new CT feild in the RefSample, but that can be done in a following PR.

We should compare using benchmarks how this compares to adding the CT to the metadata (which also goes in the WAL)