### PR TITLE
Scraping: stop storing discovered labels

### DIFF
--- a/cmd/promtool/sd.go
+++ b/cmd/promtool/sd.go
@@ -144,7 +144,9 @@ func getSDCheckResult(targetGroups []*targetgroup.Group, scrapeConfig *config.Sc
 				}
 			}
 
-			res, orig, err := scrape.PopulateLabels(lb, scrapeConfig)
+			scrape.PopulateDiscoveredLabels(lb, scrapeConfig, target, targetGroup.Labels)
+			orig := lb.Labels()
+			res, err := scrape.PopulateLabels(lb, scrapeConfig, target, targetGroup.Labels)
 			result := sdCheckResult{
 				DiscoveredLabels: orig,
 				Labels:           res,

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -458,13 +458,11 @@ func TestPopulateLabels(t *testing.T) {
 			require.EqualError(t, err, c.err)
 		} else {
 			require.NoError(t, err)
-		}
-		require.Equal(t, c.in, in)
-		testutil.RequireEqual(t, c.res, res)
-		if err == nil {
+			testutil.RequireEqual(t, c.res, res)
 			PopulateDiscoveredLabels(lb, c.cfg, c.in, nil)
 			testutil.RequireEqual(t, c.resOrig, lb.Labels())
 		}
+		require.Equal(t, c.in, in) // Check this wasn't altered by PopulateLabels().
 	}
 }
 

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -445,7 +445,7 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 			switch {
 			case nonEmpty:
 				all = append(all, t)
-			case !t.discoveredLabels.IsEmpty():
+			default:
 				if sp.config.KeepDroppedTargets == 0 || uint(len(sp.droppedTargets)) < sp.config.KeepDroppedTargets {
 					sp.droppedTargets = append(sp.droppedTargets, t)
 				}
@@ -548,9 +548,9 @@ func (sp *scrapePool) sync(targets []*Target) {
 			if _, ok := uniqueLoops[hash]; !ok {
 				uniqueLoops[hash] = nil
 			}
-			// Need to keep the most updated labels information
-			// for displaying it in the Service Discovery web page.
-			sp.activeTargets[hash].SetDiscoveredLabels(t.DiscoveredLabels())
+			// Need to keep the most updated ScrapeConfig for
+			// displaying labels in the Service Discovery web page.
+			sp.activeTargets[hash].SetScrapeConfig(sp.config, t.tlset, t.tgLabels)
 		}
 	}
 

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -550,7 +550,7 @@ func (sp *scrapePool) sync(targets []*Target) {
 			}
 			// Need to keep the most updated ScrapeConfig for
 			// displaying labels in the Service Discovery web page.
-			sp.activeTargets[hash].SetScrapeConfig(sp.config, t.tlset, t.tgLabels)
+			sp.activeTargets[hash].SetScrapeConfig(sp.config, t.tLabels, t.tgLabels)
 		}
 	}
 

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -207,7 +207,8 @@ func TestDroppedTargetsList(t *testing.T) {
 	sp.Sync(tgs)
 	require.Len(t, sp.droppedTargets, expectedLength)
 	require.Equal(t, expectedLength, sp.droppedTargetsCount)
-	require.Equal(t, expectedLabelSetString, sp.droppedTargets[0].DiscoveredLabels().String())
+	lb := labels.NewBuilder(labels.EmptyLabels())
+	require.Equal(t, expectedLabelSetString, sp.droppedTargets[0].DiscoveredLabels(lb).String())
 
 	// Check that count is still correct when we don't retain all dropped targets.
 	sp.config.KeepDroppedTargets = 1
@@ -230,16 +231,19 @@ func TestDiscoveredLabelsUpdate(t *testing.T) {
 	}
 	sp.activeTargets = make(map[uint64]*Target)
 	t1 := &Target{
-		discoveredLabels: labels.FromStrings("label", "name"),
+		tlset:        model.LabelSet{"label": "name"},
+		scrapeConfig: sp.config,
 	}
 	sp.activeTargets[t1.hash()] = t1
 
 	t2 := &Target{
-		discoveredLabels: labels.FromStrings("labelNew", "nameNew"),
+		tlset:        model.LabelSet{"labelNew": "nameNew"},
+		scrapeConfig: sp.config,
 	}
 	sp.sync([]*Target{t2})
 
-	require.Equal(t, t2.DiscoveredLabels(), sp.activeTargets[t1.hash()].DiscoveredLabels())
+	lb := labels.NewBuilder(labels.EmptyLabels())
+	require.Equal(t, t2.DiscoveredLabels(lb), sp.activeTargets[t1.hash()].DiscoveredLabels(lb))
 }
 
 type testLoop struct {
@@ -304,7 +308,8 @@ func TestScrapePoolStop(t *testing.T) {
 
 	for i := 0; i < numTargets; i++ {
 		t := &Target{
-			labels: labels.FromStrings(model.AddressLabel, fmt.Sprintf("example.com:%d", i)),
+			labels:       labels.FromStrings(model.AddressLabel, fmt.Sprintf("example.com:%d", i)),
+			scrapeConfig: &config.ScrapeConfig{},
 		}
 		l := &testLoop{}
 		d := time.Duration((i+1)*20) * time.Millisecond
@@ -388,8 +393,8 @@ func TestScrapePoolReload(t *testing.T) {
 	for i := 0; i < numTargets; i++ {
 		labels := labels.FromStrings(model.AddressLabel, fmt.Sprintf("example.com:%d", i))
 		t := &Target{
-			labels:           labels,
-			discoveredLabels: labels,
+			labels:       labels,
+			scrapeConfig: &config.ScrapeConfig{},
 		}
 		l := &testLoop{}
 		d := time.Duration((i+1)*20) * time.Millisecond
@@ -2617,6 +2622,7 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 					model.SchemeLabel, serverURL.Scheme,
 					model.AddressLabel, serverURL.Host,
 				),
+				scrapeConfig: &config.ScrapeConfig{},
 			},
 			client:       http.DefaultClient,
 			timeout:      configTimeout,
@@ -2667,6 +2673,7 @@ func TestTargetScrapeScrapeCancel(t *testing.T) {
 				model.SchemeLabel, serverURL.Scheme,
 				model.AddressLabel, serverURL.Host,
 			),
+			scrapeConfig: &config.ScrapeConfig{},
 		},
 		client:       http.DefaultClient,
 		acceptHeader: acceptHeader(config.DefaultGlobalConfig.ScrapeProtocols, model.LegacyValidation),
@@ -2722,6 +2729,7 @@ func TestTargetScrapeScrapeNotFound(t *testing.T) {
 				model.SchemeLabel, serverURL.Scheme,
 				model.AddressLabel, serverURL.Host,
 			),
+			scrapeConfig: &config.ScrapeConfig{},
 		},
 		client:       http.DefaultClient,
 		acceptHeader: acceptHeader(config.DefaultGlobalConfig.ScrapeProtocols, model.LegacyValidation),
@@ -2765,6 +2773,7 @@ func TestTargetScraperBodySizeLimit(t *testing.T) {
 				model.SchemeLabel, serverURL.Scheme,
 				model.AddressLabel, serverURL.Host,
 			),
+			scrapeConfig: &config.ScrapeConfig{},
 		},
 		client:        http.DefaultClient,
 		bodySizeLimit: bodySizeLimit,
@@ -3035,7 +3044,8 @@ func TestReuseScrapeCache(t *testing.T) {
 		}
 		sp, _ = newScrapePool(cfg, app, 0, nil, nil, &Options{}, newTestScrapeMetrics(t))
 		t1    = &Target{
-			discoveredLabels: labels.FromStrings("labelNew", "nameNew", "labelNew1", "nameNew1", "labelNew2", "nameNew2"),
+			labels:       labels.FromStrings("labelNew", "nameNew", "labelNew1", "nameNew1", "labelNew2", "nameNew2"),
+			scrapeConfig: &config.ScrapeConfig{},
 		}
 		proxyURL, _ = url.Parse("http://localhost:2128")
 	)
@@ -3219,7 +3229,8 @@ func TestReuseCacheRace(t *testing.T) {
 		buffers = pool.New(1e3, 100e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
 		sp, _   = newScrapePool(cfg, app, 0, nil, buffers, &Options{}, newTestScrapeMetrics(t))
 		t1      = &Target{
-			discoveredLabels: labels.FromStrings("labelNew", "nameNew"),
+			labels:       labels.FromStrings("labelNew", "nameNew"),
+			scrapeConfig: &config.ScrapeConfig{},
 		}
 	)
 	defer sp.stop()
@@ -4401,7 +4412,9 @@ func BenchmarkTargetScraperGzip(b *testing.B) {
 						model.SchemeLabel, serverURL.Scheme,
 						model.AddressLabel, serverURL.Host,
 					),
-					params: url.Values{"count": []string{strconv.Itoa(scenario.metricsCount)}},
+					scrapeConfig: &config.ScrapeConfig{
+						Params: url.Values{"count": []string{strconv.Itoa(scenario.metricsCount)}},
+					},
 				},
 				client:  client,
 				timeout: time.Second,

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -231,13 +231,13 @@ func TestDiscoveredLabelsUpdate(t *testing.T) {
 	}
 	sp.activeTargets = make(map[uint64]*Target)
 	t1 := &Target{
-		tlset:        model.LabelSet{"label": "name"},
+		tLabels:      model.LabelSet{"label": "name"},
 		scrapeConfig: sp.config,
 	}
 	sp.activeTargets[t1.hash()] = t1
 
 	t2 := &Target{
-		tlset:        model.LabelSet{"labelNew": "nameNew"},
+		tLabels:      model.LabelSet{"labelNew": "nameNew"},
 		scrapeConfig: sp.config,
 	}
 	sp.sync([]*Target{t2})

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -45,12 +45,12 @@ const (
 
 // Target refers to a singular HTTP or HTTPS endpoint.
 type Target struct {
-	// Labels before any processing.
-	discoveredLabels labels.Labels
 	// Any labels that are added to this target and its metrics.
 	labels labels.Labels
-	// Additional URL parameters that are part of the target URL.
-	params url.Values
+	// ScrapeConfig used to create this target.
+	scrapeConfig *config.ScrapeConfig
+	// Labels from SD and TargetGroup used to create this target.
+	tlset, tgLabels model.LabelSet
 
 	mtx                sync.RWMutex
 	lastError          error
@@ -61,12 +61,13 @@ type Target struct {
 }
 
 // NewTarget creates a reasonably configured target for querying.
-func NewTarget(labels, discoveredLabels labels.Labels, params url.Values) *Target {
+func NewTarget(labels labels.Labels, scrapeConfig *config.ScrapeConfig, tlset, tgLabels model.LabelSet) *Target {
 	return &Target{
-		labels:           labels,
-		discoveredLabels: discoveredLabels,
-		params:           params,
-		health:           HealthUnknown,
+		labels:       labels,
+		tlset:        tlset,
+		tgLabels:     tgLabels,
+		scrapeConfig: scrapeConfig,
+		health:       HealthUnknown,
 	}
 }
 
@@ -168,11 +169,11 @@ func (t *Target) offset(interval time.Duration, offsetSeed uint64) time.Duration
 }
 
 // Labels returns a copy of the set of all public labels of the target.
-func (t *Target) Labels(b *labels.ScratchBuilder) labels.Labels {
-	b.Reset()
+func (t *Target) Labels(b *labels.Builder) labels.Labels {
+	b.Reset(labels.EmptyLabels())
 	t.labels.Range(func(l labels.Label) {
 		if !strings.HasPrefix(l.Name, model.ReservedLabelPrefix) {
-			b.Add(l.Name, l.Value)
+			b.Set(l.Name, l.Value)
 		}
 	})
 	return b.Labels()
@@ -188,24 +189,31 @@ func (t *Target) LabelsRange(f func(l labels.Label)) {
 }
 
 // DiscoveredLabels returns a copy of the target's labels before any processing.
-func (t *Target) DiscoveredLabels() labels.Labels {
+func (t *Target) DiscoveredLabels(lb *labels.Builder) labels.Labels {
 	t.mtx.Lock()
-	defer t.mtx.Unlock()
-	return t.discoveredLabels.Copy()
+	cfg, tlset, tgLabels := t.scrapeConfig, t.tlset, t.tgLabels
+	t.mtx.Unlock()
+	PopulateDiscoveredLabels(lb, cfg, tlset, tgLabels)
+	return lb.Labels()
 }
 
-// SetDiscoveredLabels sets new DiscoveredLabels.
-func (t *Target) SetDiscoveredLabels(l labels.Labels) {
+// SetScrapeConfig sets new ScrapeConfig.
+func (t *Target) SetScrapeConfig(scrapeConfig *config.ScrapeConfig, tlset, tgLabels model.LabelSet) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-	t.discoveredLabels = l
+	t.scrapeConfig = scrapeConfig
+	t.tlset = tlset
+	t.tgLabels = tgLabels
 }
 
 // URL returns a copy of the target's URL.
 func (t *Target) URL() *url.URL {
+	t.mtx.Lock()
+	configParams := t.scrapeConfig.Params
+	t.mtx.Unlock()
 	params := url.Values{}
 
-	for k, v := range t.params {
+	for k, v := range configParams {
 		params[k] = make([]string, len(v))
 		copy(params[k], v)
 	}
@@ -420,10 +428,18 @@ func (app *maxSchemaAppender) AppendHistogram(ref storage.SeriesRef, lset labels
 	return ref, nil
 }
 
-// PopulateLabels builds a label set from the given label set and scrape configuration.
-// It returns a label set before relabeling was applied as the second return value.
-// Returns the original discovered label set found before relabelling was applied if the target is dropped during relabeling.
-func PopulateLabels(lb *labels.Builder, cfg *config.ScrapeConfig) (res, orig labels.Labels, err error) {
+func PopulateDiscoveredLabels(lb *labels.Builder, cfg *config.ScrapeConfig, tlset, tgLabels model.LabelSet) {
+	lb.Reset(labels.EmptyLabels())
+
+	for ln, lv := range tlset {
+		lb.Set(string(ln), string(lv))
+	}
+	for ln, lv := range tgLabels {
+		if _, ok := tlset[ln]; !ok {
+			lb.Set(string(ln), string(lv))
+		}
+	}
+
 	// Copy labels into the labelset for the target if they are not set already.
 	scrapeLabels := []labels.Label{
 		{Name: model.JobLabel, Value: cfg.JobName},
@@ -444,44 +460,48 @@ func PopulateLabels(lb *labels.Builder, cfg *config.ScrapeConfig) (res, orig lab
 			lb.Set(name, v[0])
 		}
 	}
+}
 
-	preRelabelLabels := lb.Labels()
+// PopulateLabels builds a label set from the given label set and scrape configuration.
+// A return of empty labels and nil error means the target was dropped by relabeling.
+func PopulateLabels(lb *labels.Builder, cfg *config.ScrapeConfig, tlset, tgLabels model.LabelSet) (res labels.Labels, err error) {
+	PopulateDiscoveredLabels(lb, cfg, tlset, tgLabels)
 	keep := relabel.ProcessBuilder(lb, cfg.RelabelConfigs...)
 
 	// Check if the target was dropped.
 	if !keep {
-		return labels.EmptyLabels(), preRelabelLabels, nil
+		return labels.EmptyLabels(), nil
 	}
 	if v := lb.Get(model.AddressLabel); v == "" {
-		return labels.EmptyLabels(), labels.EmptyLabels(), errors.New("no address")
+		return labels.EmptyLabels(), errors.New("no address")
 	}
 
 	addr := lb.Get(model.AddressLabel)
 
 	if err := config.CheckTargetAddress(model.LabelValue(addr)); err != nil {
-		return labels.EmptyLabels(), labels.EmptyLabels(), err
+		return labels.EmptyLabels(), err
 	}
 
 	interval := lb.Get(model.ScrapeIntervalLabel)
 	intervalDuration, err := model.ParseDuration(interval)
 	if err != nil {
-		return labels.EmptyLabels(), labels.EmptyLabels(), fmt.Errorf("error parsing scrape interval: %w", err)
+		return labels.EmptyLabels(), fmt.Errorf("error parsing scrape interval: %w", err)
 	}
 	if time.Duration(intervalDuration) == 0 {
-		return labels.EmptyLabels(), labels.EmptyLabels(), errors.New("scrape interval cannot be 0")
+		return labels.EmptyLabels(), errors.New("scrape interval cannot be 0")
 	}
 
 	timeout := lb.Get(model.ScrapeTimeoutLabel)
 	timeoutDuration, err := model.ParseDuration(timeout)
 	if err != nil {
-		return labels.EmptyLabels(), labels.EmptyLabels(), fmt.Errorf("error parsing scrape timeout: %w", err)
+		return labels.EmptyLabels(), fmt.Errorf("error parsing scrape timeout: %w", err)
 	}
 	if time.Duration(timeoutDuration) == 0 {
-		return labels.EmptyLabels(), labels.EmptyLabels(), errors.New("scrape timeout cannot be 0")
+		return labels.EmptyLabels(), errors.New("scrape timeout cannot be 0")
 	}
 
 	if timeoutDuration > intervalDuration {
-		return labels.EmptyLabels(), labels.EmptyLabels(), fmt.Errorf("scrape timeout cannot be greater than scrape interval (%q > %q)", timeout, interval)
+		return labels.EmptyLabels(), fmt.Errorf("scrape timeout cannot be greater than scrape interval (%q > %q)", timeout, interval)
 	}
 
 	// Meta labels are deleted after relabelling. Other internal labels propagate to
@@ -506,9 +526,9 @@ func PopulateLabels(lb *labels.Builder, cfg *config.ScrapeConfig) (res, orig lab
 		return nil
 	})
 	if err != nil {
-		return labels.EmptyLabels(), labels.EmptyLabels(), err
+		return labels.EmptyLabels(), err
 	}
-	return res, preRelabelLabels, nil
+	return res, nil
 }
 
 // TargetsFromGroup builds targets based on the given TargetGroup and config.
@@ -517,23 +537,11 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig, targets [
 	failures := []error{}
 
 	for i, tlset := range tg.Targets {
-		lb.Reset(labels.EmptyLabels())
-
-		for ln, lv := range tlset {
-			lb.Set(string(ln), string(lv))
-		}
-		for ln, lv := range tg.Labels {
-			if _, ok := tlset[ln]; !ok {
-				lb.Set(string(ln), string(lv))
-			}
-		}
-
-		lset, origLabels, err := PopulateLabels(lb, cfg)
+		lset, err := PopulateLabels(lb, cfg, tlset, tg.Labels)
 		if err != nil {
 			failures = append(failures, fmt.Errorf("instance %d in group %s: %w", i, tg, err))
-		}
-		if !lset.IsEmpty() || !origLabels.IsEmpty() {
-			targets = append(targets, NewTarget(lset, origLabels, cfg.Params))
+		} else {
+			targets = append(targets, NewTarget(lset, cfg, tlset, tg.Labels))
 		}
 	}
 	return targets, failures

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1078,12 +1078,12 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 	showActive := state == "" || state == "any" || state == "active"
 	showDropped := state == "" || state == "any" || state == "dropped"
 	res := &TargetDiscovery{}
+	builder := labels.NewBuilder(labels.EmptyLabels())
 
 	if showActive {
 		targetsActive := api.targetRetriever(r.Context()).TargetsActive()
 		activeKeys, numTargets := sortKeys(targetsActive)
 		res.ActiveTargets = make([]*Target, 0, numTargets)
-		builder := labels.NewScratchBuilder(0)
 
 		for _, key := range activeKeys {
 			if scrapePool != "" && key != scrapePool {
@@ -1099,8 +1099,8 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 				globalURL, err := getGlobalURL(target.URL(), api.globalURLOptions)
 
 				res.ActiveTargets = append(res.ActiveTargets, &Target{
-					DiscoveredLabels: target.DiscoveredLabels(),
-					Labels:           target.Labels(&builder),
+					DiscoveredLabels: target.DiscoveredLabels(builder),
+					Labels:           target.Labels(builder),
 					ScrapePool:       key,
 					ScrapeURL:        target.URL().String(),
 					GlobalURL:        globalURL.String(),
@@ -1138,7 +1138,7 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 			}
 			for _, target := range targetsDropped[key] {
 				res.DroppedTargets = append(res.DroppedTargets, &DroppedTarget{
-					DiscoveredLabels: target.DiscoveredLabels(),
+					DiscoveredLabels: target.DiscoveredLabels(builder),
 				})
 			}
 		}
@@ -1176,7 +1176,7 @@ func (api *API) targetMetadata(r *http.Request) apiFuncResult {
 		}
 	}
 
-	builder := labels.NewScratchBuilder(0)
+	builder := labels.NewBuilder(labels.EmptyLabels())
 	metric := r.FormValue("metric")
 	res := []metricMetadata{}
 	for _, tt := range api.targetRetriever(r.Context()).TargetsActive() {
@@ -1184,7 +1184,7 @@ func (api *API) targetMetadata(r *http.Request) apiFuncResult {
 			if limit >= 0 && len(res) >= limit {
 				break
 			}
-			targetLabels := t.Labels(&builder)
+			targetLabels := t.Labels(builder)
 			// Filter targets that don't satisfy the label matchers.
 			if matchTarget != "" && !matchLabels(targetLabels, matchers) {
 				continue

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -103,12 +103,12 @@ type testTargetRetriever struct {
 }
 
 type testTargetParams struct {
-	Identifier       string
-	Labels           labels.Labels
-	DiscoveredLabels labels.Labels
-	Params           url.Values
-	Reports          []*testReport
-	Active           bool
+	Identifier   string
+	Labels       labels.Labels
+	targetLabels model.LabelSet
+	Params       url.Values
+	Reports      []*testReport
+	Active       bool
 }
 
 type testReport struct {
@@ -124,7 +124,7 @@ func newTestTargetRetriever(targetsInfo []*testTargetParams) *testTargetRetrieve
 	droppedTargets = make(map[string][]*scrape.Target)
 
 	for _, t := range targetsInfo {
-		nt := scrape.NewTarget(t.Labels, t.DiscoveredLabels, t.Params)
+		nt := scrape.NewTarget(t.Labels, &config.ScrapeConfig{Params: t.Params}, t.targetLabels, nil)
 
 		for _, r := range t.Reports {
 			nt.Report(r.Start, r.Duration, r.Error)
@@ -1002,10 +1002,9 @@ func setupTestTargetRetriever(t *testing.T) *testTargetRetriever {
 				model.ScrapeIntervalLabel: "15s",
 				model.ScrapeTimeoutLabel:  "5s",
 			}),
-			DiscoveredLabels: labels.EmptyLabels(),
-			Params:           url.Values{},
-			Reports:          []*testReport{{scrapeStart, 70 * time.Millisecond, nil}},
-			Active:           true,
+			Params:  url.Values{},
+			Reports: []*testReport{{scrapeStart, 70 * time.Millisecond, nil}},
+			Active:  true,
 		},
 		{
 			Identifier: "blackbox",
@@ -1017,22 +1016,21 @@ func setupTestTargetRetriever(t *testing.T) *testTargetRetriever {
 				model.ScrapeIntervalLabel: "20s",
 				model.ScrapeTimeoutLabel:  "10s",
 			}),
-			DiscoveredLabels: labels.EmptyLabels(),
-			Params:           url.Values{"target": []string{"example.com"}},
-			Reports:          []*testReport{{scrapeStart, 100 * time.Millisecond, errors.New("failed")}},
-			Active:           true,
+			Params:  url.Values{"target": []string{"example.com"}},
+			Reports: []*testReport{{scrapeStart, 100 * time.Millisecond, errors.New("failed")}},
+			Active:  true,
 		},
 		{
 			Identifier: "blackbox",
 			Labels:     labels.EmptyLabels(),
-			DiscoveredLabels: labels.FromMap(map[string]string{
+			targetLabels: model.LabelSet{
 				model.SchemeLabel:         "http",
 				model.AddressLabel:        "http://dropped.example.com:9115",
 				model.MetricsPathLabel:    "/probe",
 				model.JobLabel:            "blackbox",
 				model.ScrapeIntervalLabel: "30s",
 				model.ScrapeTimeoutLabel:  "15s",
-			}),
+			},
 			Params: url.Values{},
 			Active: false,
 		},
@@ -1504,7 +1502,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels:   labels.FromStrings(),
+						DiscoveredLabels:   labels.FromStrings("__param_target", "example.com", "__scrape_interval__", "0s", "__scrape_timeout__", "0s"),
 						Labels:             labels.FromStrings("job", "blackbox"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1517,7 +1515,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels:   labels.FromStrings(),
+						DiscoveredLabels:   labels.FromStrings("__scrape_interval__", "0s", "__scrape_timeout__", "0s"),
 						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
@@ -1553,7 +1551,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels:   labels.FromStrings(),
+						DiscoveredLabels:   labels.FromStrings("__param_target", "example.com", "__scrape_interval__", "0s", "__scrape_timeout__", "0s"),
 						Labels:             labels.FromStrings("job", "blackbox"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1566,7 +1564,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels:   labels.FromStrings(),
+						DiscoveredLabels:   labels.FromStrings("__scrape_interval__", "0s", "__scrape_timeout__", "0s"),
 						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",
@@ -1602,7 +1600,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{
 					{
-						DiscoveredLabels:   labels.FromStrings(),
+						DiscoveredLabels:   labels.FromStrings("__param_target", "example.com", "__scrape_interval__", "0s", "__scrape_timeout__", "0s"),
 						Labels:             labels.FromStrings("job", "blackbox"),
 						ScrapePool:         "blackbox",
 						ScrapeURL:          "http://localhost:9115/probe?target=example.com",
@@ -1615,7 +1613,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 						ScrapeTimeout:      "10s",
 					},
 					{
-						DiscoveredLabels:   labels.FromStrings(),
+						DiscoveredLabels:   labels.FromStrings("__scrape_interval__", "0s", "__scrape_timeout__", "0s"),
 						Labels:             labels.FromStrings("job", "test"),
 						ScrapePool:         "test",
 						ScrapeURL:          "http://example.com:8080/metrics",


### PR DESCRIPTION
Instead of storing discovered labels on every target, recompute them if required.

This moves the load from every Prometheus all of the time, to just when someone views Targets or Service Discovery in the UI.

The `Target` struct now needs to hold some more data required to recompute them, such as ScrapeConfig.

The way `PopulateLabels` is used changes; you are no longer expected to call it with a part-populated `labels.Builder`.

The signature of `Target.Labels` changes to take a `labels.Builder` instead of a `ScratchBuilder`, for consistency with `DiscoveredLabels`.

This will save a lot of work when many targets are filtered out in relabeling.
Combine with `keep_dropped_targets` to avoid ever computing most labels for dropped targets.