### PR TITLE
tlsconfig: support for nextProtos

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -73,7 +73,7 @@ func (m *Manager) ApplyConfig(cfg *config.Config) error {
 	// set, we have to restart the manager to make sure that new TLS
 	// certificates are picked up.
 	var blankTLSConfig config_util.TLSConfig
-	if reflect.DeepEqual(m.config, cfg.TracingConfig) && m.config.TLSConfig == blankTLSConfig {
+	if reflect.DeepEqual(m.config, cfg.TracingConfig) && reflect.DeepEqual(m.config.TLSConfig, blankTLSConfig) {
 		return nil
 	}
 

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -82,7 +82,8 @@ func TestReinstallingTracerProviderWithTLS(t *testing.T) {
 			Endpoint:   "localhost:1234",
 			ClientType: config.TracingClientGRPC,
 			TLSConfig: config_util.TLSConfig{
-				CAFile: "testdata/ca.cer",
+				CAFile:     "testdata/ca.cer",
+				NextProtos: []string{"h2"},
 			},
 		},
 	}


### PR DESCRIPTION
Builds successfully with local go.mod replace pointing to https://github.com/prometheus/common/pull/713

Unsure if there are additional e2e tests to run / update or consumers of the change in common above, this was the only one I could find.
