### PR TITLE
Merge 2.55 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ As is traditional with a beta release, we do **not** recommend users install 3.0
 * [FEATURE] Support config reload automatically - feature flag `auto-reload-config`. #14769
 * [BUGFIX] Scrape: Do not override target parameter labels with config params. #11029
 
+## 2.55.1 / 2024-01-04
+
+* [BUGFIX] `round()` function did not remove `__name__` label. #15250
+
 ## 2.55.0 / 2024-10-22
 
 * [FEATURE] PromQL: Add experimental `info` function. #14495

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -538,6 +538,9 @@ func funcRound(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 			continue
 		}
 		f := math.Floor(el.F*toNearestInverse+0.5) / toNearestInverse
+		if !enh.enableDelayedNameRemoval {
+			el.Metric = el.Metric.DropMetricName()
+		}
 		enh.Out = append(enh.Out, Sample{
 			Metric:   el.Metric,
 			F:        f,

--- a/promql/promqltest/testdata/name_label_dropping.test
+++ b/promql/promqltest/testdata/name_label_dropping.test
@@ -31,6 +31,10 @@ eval instant at 10m metric * 2
 eval instant at 10m clamp(metric, 0, 100)
 	{env="1"} 100
 
+# Drops __name__ for round function
+eval instant at 10m round(metric)
+	{env="1"} 120
+
 # Drops __name__ for range-vector functions
 eval instant at 10m rate(metric{env="1"}[10m])
 	{env="1"} 0.2


### PR DESCRIPTION
Bring bugfix #15250 into main.

Lots of `15m` in new tests had to be changed to `10m`; I'm not sure exactly why, but it matches the surrounding tests.
