### PR TITLE
chore: Remove dead code

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -190,7 +190,6 @@ type flagConfig struct {
 	queryConcurrency            int
 	queryMaxSamples             int
 	RemoteFlushDeadline         model.Duration
-	nameEscapingScheme          string
 	maxNotificationsSubscribers int
 
 	enableAutoReload   bool
@@ -549,15 +548,6 @@ func main() {
 	if err := cfg.setFeatureListOptions(logger); err != nil {
 		fmt.Fprintln(os.Stderr, fmt.Errorf("Error parsing feature list: %w", err))
 		os.Exit(1)
-	}
-
-	if cfg.nameEscapingScheme != "" {
-		scheme, err := model.ToEscapingScheme(cfg.nameEscapingScheme)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, `Invalid name escaping scheme: %q; Needs to be one of "values", "underscores", or "dots"`, cfg.nameEscapingScheme)
-			os.Exit(1)
-		}
-		model.NameEscapingScheme = scheme
 	}
 
 	if agentMode && len(serverOnlyFlags) > 0 {

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -94,8 +94,6 @@ type Options struct {
 	skipOffsetting bool
 }
 
-const DefaultNameEscapingScheme = model.ValueEncodingEscaping
-
 // Manager maintains a set of scrape pools and manages start/stop cycles
 // when receiving new target groups from the discovery manager.
 type Manager struct {


### PR DESCRIPTION
While working on #15258 I've noticed that we have deadcode around name validation scheme. Probably leftovers from a time where UTF8 configuration was done via feature-flags?