### PR TITLE
[ENHANCEMEN] Remote-Write: optionally use a DNS resolver that picks a random IP

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1181,6 +1181,7 @@ type RemoteWriteConfig struct {
 	Name                 string            `yaml:"name,omitempty"`
 	SendExemplars        bool              `yaml:"send_exemplars,omitempty"`
 	SendNativeHistograms bool              `yaml:"send_native_histograms,omitempty"`
+	RoundRobinDNSEnabled bool              `yaml:"round_robin_dns_enabled,omitempty"`
 	// ProtobufMessage specifies the protobuf message to use against the remote
 	// receiver as specified in https://prometheus.io/docs/specs/remote_write_spec_2_0/
 	ProtobufMessage RemoteWriteProtoMsg `yaml:"protobuf_message,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -1181,7 +1181,7 @@ type RemoteWriteConfig struct {
 	Name                 string            `yaml:"name,omitempty"`
 	SendExemplars        bool              `yaml:"send_exemplars,omitempty"`
 	SendNativeHistograms bool              `yaml:"send_native_histograms,omitempty"`
-	RoundRobinDNSEnabled bool              `yaml:"round_robin_dns_enabled,omitempty"`
+	RoundRobinDNS        bool              `yaml:"round_robin_dns,omitempty"`
 	// ProtobufMessage specifies the protobuf message to use against the remote
 	// receiver as specified in https://prometheus.io/docs/specs/remote_write_spec_2_0/
 	ProtobufMessage RemoteWriteProtoMsg `yaml:"protobuf_message,omitempty"`

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2797,6 +2797,11 @@ write_relabel_configs:
 # For the `io.prometheus.write.v2.Request` message, this option is noop (always true).
 [ send_native_histograms: <boolean> | default = false ]
 
+# When enabled, DNS lookup of URL's host name returns a corresponding IP address in a round robin fashion.
+# More precisely, when a DNS lookup of a host name returns multiple IP addresses, this feature tries to choose a random one and creates a connection to it.
+# This is an experimental feature, and its behavior might still change, or even get removed.
+[ round_robin_dns_enabled: <boolean> | default = false ]
+
 # Optionally configures AWS's Signature Verification 4 signing process to
 # sign requests. Cannot be set at the same time as basic_auth, authorization, oauth2, or azuread.
 # To use the default credentials from the AWS SDK, use `sigv4: {}`.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2797,13 +2797,10 @@ write_relabel_configs:
 # For the `io.prometheus.write.v2.Request` message, this option is noop (always true).
 [ send_native_histograms: <boolean> | default = false ]
 
-# When disabled, DNS lookup relies on Go's defaults. In that case, when the remote URL's host name is resolved to multiple IPs, 
-# Go sequentially tries to establish a connection to all resolved IPs, choosing the first successfully created one. 
-# Any configured dial timeout is equally spread over all attempts to establish a connection to one of the resolved IPs.
-# When enabled, DNS lookup works in a round robin fashion. More precisely, when the remote-write URL's host name is resolved 
-# to multiple IP addresses, this feature chooses one of them randomly, and tries to establish a connection to it. 
-# In this case, any configured dial timeout is used for this attempt only.
-# This is an experimental feature, it applies to remote-write only, and its behavior might still change, or even get removed.
+# When enabled, remote-write will resolve the URL host name via DNS, choose one of the IP addresses at random, and connect to it. 
+# When disabled, remote-write relies on Go's standard behavior, which is to try to connect to each address in turn.
+# The connection timeout applies to the whole operation, i.e. in the latter case it is spread over all attempt.
+# This is an experimental feature, and its behavior might still change, or even get removed.
 [ round_robin_dns: <boolean> | default = false ]
 
 # Optionally configures AWS's Signature Verification 4 signing process to

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2797,9 +2797,13 @@ write_relabel_configs:
 # For the `io.prometheus.write.v2.Request` message, this option is noop (always true).
 [ send_native_histograms: <boolean> | default = false ]
 
-# When enabled, DNS lookup of URL's host name returns a corresponding IP address in a round robin fashion.
-# More precisely, when a DNS lookup of a host name returns multiple IP addresses, this feature tries to choose a random one and creates a connection to it.
-# This is an experimental feature, and its behavior might still change, or even get removed.
+# When disabled, DNS lookup relies on Go's defaults. In that case, when the remote URL's host name is resolved to multiple IPs, 
+# Go sequentially tries to establish a connection to all resolved IPs, choosing the first successfully created one. 
+# Any configured dial timeout is equally spread over all attempts to establish a connection to one of the resolved IPs.
+# When enabled, DNS lookup works in a round robin fashion. More precisely, when the remote-write URL's host name is resolved 
+# to multiple IP addresses, this feature chooses one of them randomly, and tries to establish a connection to it. 
+# In this case, any configured dial timeout is used for this attempt only.
+# This is an experimental feature, it applies to remote-write only, and its behavior might still change, or even get removed.
 [ round_robin_dns: <boolean> | default = false ]
 
 # Optionally configures AWS's Signature Verification 4 signing process to

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2800,7 +2800,7 @@ write_relabel_configs:
 # When enabled, DNS lookup of URL's host name returns a corresponding IP address in a round robin fashion.
 # More precisely, when a DNS lookup of a host name returns multiple IP addresses, this feature tries to choose a random one and creates a connection to it.
 # This is an experimental feature, and its behavior might still change, or even get removed.
-[ round_robin_dns_enabled: <boolean> | default = false ]
+[ round_robin_dns: <boolean> | default = false ]
 
 # Optionally configures AWS's Signature Verification 4 signing process to
 # sign requests. Cannot be set at the same time as basic_auth, authorization, oauth2, or azuread.

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -183,7 +183,7 @@ func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
 func NewWriteClient(name string, conf *ClientConfig) (WriteClient, error) {
 	var httpOpts []config_util.HTTPClientOption
 	if conf.RoundRobinDNS {
-		httpOpts = []config_util.HTTPClientOption{config_util.WithDialContextFunc(newDialContextWithRoundRobinDNS().dialContext)}
+		httpOpts = []config_util.HTTPClientOption{config_util.WithDialContextFunc(newDialContextWithRoundRobinDNS().dialContextFn())}
 	}
 	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_write_client", httpOpts...)
 	if err != nil {

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -145,7 +145,7 @@ type ClientConfig struct {
 	RetryOnRateLimit     bool
 	WriteProtoMsg        config.RemoteWriteProtoMsg
 	ChunkedReadLimit     uint64
-	RoundRobinDnsEnabled bool
+	RoundRobinDNSEnabled bool
 }
 
 // ReadClient will request the STREAMED_XOR_CHUNKS method of remote read but can
@@ -182,7 +182,7 @@ func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
 // NewWriteClient creates a new client for remote write.
 func NewWriteClient(name string, conf *ClientConfig) (WriteClient, error) {
 	var httpOpts []config_util.HTTPClientOption
-	if conf.RoundRobinDnsEnabled {
+	if conf.RoundRobinDNSEnabled {
 		httpOpts = []config_util.HTTPClientOption{config_util.WithDialContextFunc(newDialContextWithRoundRobinDNS().dialContext)}
 	}
 	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_write_client", httpOpts...)

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -155,7 +155,7 @@ type ReadClient interface {
 
 // NewReadClient creates a new client for remote read.
 func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
-	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client")
+	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client", config_util.WithDialContextFunc(newDialContextWithRandomConnections().dialContextFn()))
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
 
 // NewWriteClient creates a new client for remote write.
 func NewWriteClient(name string, conf *ClientConfig) (WriteClient, error) {
-	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_write_client")
+	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_write_client", config_util.WithDialContextFunc(newDialContextWithRandomConnections().dialContextFn()))
 	if err != nil {
 		return nil, err
 	}

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -135,17 +135,17 @@ type Client struct {
 
 // ClientConfig configures a client.
 type ClientConfig struct {
-	URL                  *config_util.URL
-	Timeout              model.Duration
-	HTTPClientConfig     config_util.HTTPClientConfig
-	SigV4Config          *sigv4.SigV4Config
-	AzureADConfig        *azuread.AzureADConfig
-	GoogleIAMConfig      *googleiam.Config
-	Headers              map[string]string
-	RetryOnRateLimit     bool
-	WriteProtoMsg        config.RemoteWriteProtoMsg
-	ChunkedReadLimit     uint64
-	RoundRobinDNSEnabled bool
+	URL              *config_util.URL
+	Timeout          model.Duration
+	HTTPClientConfig config_util.HTTPClientConfig
+	SigV4Config      *sigv4.SigV4Config
+	AzureADConfig    *azuread.AzureADConfig
+	GoogleIAMConfig  *googleiam.Config
+	Headers          map[string]string
+	RetryOnRateLimit bool
+	WriteProtoMsg    config.RemoteWriteProtoMsg
+	ChunkedReadLimit uint64
+	RoundRobinDNS    bool
 }
 
 // ReadClient will request the STREAMED_XOR_CHUNKS method of remote read but can
@@ -182,7 +182,7 @@ func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
 // NewWriteClient creates a new client for remote write.
 func NewWriteClient(name string, conf *ClientConfig) (WriteClient, error) {
 	var httpOpts []config_util.HTTPClientOption
-	if conf.RoundRobinDNSEnabled {
+	if conf.RoundRobinDNS {
 		httpOpts = []config_util.HTTPClientOption{config_util.WithDialContextFunc(newDialContextWithRoundRobinDNS().dialContext)}
 	}
 	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_write_client", httpOpts...)

--- a/storage/remote/dial_context.go
+++ b/storage/remote/dial_context.go
@@ -1,0 +1,62 @@
+package remote
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"net/http"
+
+	"github.com/prometheus/common/config"
+)
+
+type hostResolver interface {
+	lookupHost(context.Context, string) ([]string, error)
+}
+
+type defaultHostResolver struct{}
+
+func (hr *defaultHostResolver) lookupHost(ctx context.Context, host string) ([]string, error) {
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+type customDialContext interface {
+	dialContextFn() config.DialContextFunc
+}
+
+type dialContextWithRandomConnections struct {
+	dialContext config.DialContextFunc
+	resolver    hostResolver
+}
+
+func newDialContextWithRandomConnections() *dialContextWithRandomConnections {
+	return &dialContextWithRandomConnections{
+		dialContext: http.DefaultTransport.(*http.Transport).DialContext,
+		resolver:    &defaultHostResolver{},
+	}
+}
+
+func (dc *dialContextWithRandomConnections) setDefaultDialContext(defaultDialContext config.DialContextFunc) {
+	dc.dialContext = defaultDialContext
+}
+
+func (dc *dialContextWithRandomConnections) setResolver(resolver hostResolver) {
+	dc.resolver = resolver
+}
+
+func (dc *dialContextWithRandomConnections) dialContextFn() config.DialContextFunc {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return dc.dialContext(ctx, network, addr)
+		}
+
+		addrs, err := dc.resolver.lookupHost(ctx, host)
+		if err != nil {
+			return dc.dialContext(ctx, network, addr)
+		}
+
+		randomAddr := addrs[rand.Intn(len(addrs))]
+		randomAddr = net.JoinHostPort(randomAddr, port)
+		return dc.dialContext(ctx, network, randomAddr)
+	}
+}

--- a/storage/remote/dial_context.go
+++ b/storage/remote/dial_context.go
@@ -1,3 +1,16 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package remote
 
 import (

--- a/storage/remote/dial_context.go
+++ b/storage/remote/dial_context.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Prometheus Authors
+// Copyright 2024 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/storage/remote/dial_context.go
+++ b/storage/remote/dial_context.go
@@ -27,14 +27,15 @@ type hostResolver interface {
 	LookupHost(context.Context, string) ([]string, error)
 }
 
-// dialContextWithRoundRobinDNS is needed to facilitate testing, because
-// it allows specifying custom dial context functions and host resolvers.
 type dialContextWithRoundRobinDNS struct {
 	dialContext config.DialContextFunc
 	resolver    hostResolver
 	rand        *rand.Rand
 }
 
+// newDialContextWithRoundRobinDNS creates a new dialContextWithRoundRobinDNS.
+// We discourage creating new instances of struct dialContextWithRoundRobinDNS by explicitly setting its members,
+// except for testing purposes, and recommend using newDialContextWithRoundRobinDNS.
 func newDialContextWithRoundRobinDNS() *dialContextWithRoundRobinDNS {
 	return &dialContextWithRoundRobinDNS{
 		dialContext: http.DefaultTransport.(*http.Transport).DialContext,
@@ -51,7 +52,7 @@ func (dc *dialContextWithRoundRobinDNS) dialContextFn() config.DialContextFunc {
 		}
 
 		addrs, err := dc.resolver.LookupHost(ctx, host)
-		if err != nil {
+		if err != nil || len(addrs) == 0 {
 			return dc.dialContext(ctx, network, addr)
 		}
 

--- a/storage/remote/dial_context_test.go
+++ b/storage/remote/dial_context_test.go
@@ -1,3 +1,16 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package remote
 
 import (
@@ -73,9 +86,7 @@ func (lh *mockedLookupHost) lookupHost(context.Context, string) ([]string, error
 
 func TestDialContextWithRandomConnections(t *testing.T) {
 	numberOfRuns := 2 * len(testLookupResult)
-	var (
-		mdc *mockDialContext
-	)
+	var mdc *mockDialContext
 	testCases := map[string]struct {
 		addr                              string
 		setup                             func() customDialContext

--- a/storage/remote/dial_context_test.go
+++ b/storage/remote/dial_context_test.go
@@ -89,7 +89,7 @@ func TestDialContextWithRandomConnections(t *testing.T) {
 	var mdc *mockDialContext
 	testCases := map[string]struct {
 		addr                              string
-		setup                             func() customDialContext
+		setup                             func() dialContextWithRoundRobinDNS
 		check                             func()
 		withLookupHostErr                 bool
 		expectedDefaultContextArguments   []string
@@ -97,9 +97,9 @@ func TestDialContextWithRandomConnections(t *testing.T) {
 	}{
 		"if address contains no port call default DealContext": {
 			addr: testAddrWithoutPort,
-			setup: func() customDialContext {
+			setup: func() dialContextWithRoundRobinDNS {
 				mdc = newMockDialContext([]string{testAddrWithoutPort})
-				return &dialContextWithRandomConnections{
+				return dialContextWithRoundRobinDNS{
 					dialContext: mdc.dialContext,
 					resolver:    &mockedLookupHost{withErr: false},
 				}
@@ -110,9 +110,9 @@ func TestDialContextWithRandomConnections(t *testing.T) {
 		},
 		"if lookup host returns error call default DealContext": {
 			addr: testAddrWithPort,
-			setup: func() customDialContext {
+			setup: func() dialContextWithRoundRobinDNS {
 				mdc = newMockDialContext([]string{testAddrWithPort})
-				return &dialContextWithRandomConnections{
+				return dialContextWithRoundRobinDNS{
 					dialContext: mdc.dialContext,
 					resolver:    &mockedLookupHost{withErr: true},
 				}
@@ -123,9 +123,9 @@ func TestDialContextWithRandomConnections(t *testing.T) {
 		},
 		"if lookup host is successful, shuffle results": {
 			addr: testAddrWithPort,
-			setup: func() customDialContext {
+			setup: func() dialContextWithRoundRobinDNS {
 				mdc = newMockDialContext(testLookupResultWithPort)
-				return &dialContextWithRandomConnections{
+				return dialContextWithRoundRobinDNS{
 					dialContext: mdc.dialContext,
 					resolver:    &mockedLookupHost{result: testLookupResult},
 				}

--- a/storage/remote/dial_context_test.go
+++ b/storage/remote/dial_context_test.go
@@ -15,7 +15,7 @@ package remote
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net"
 	"sync"
 	"testing"
@@ -35,7 +35,7 @@ const (
 )
 
 var (
-	errMockLookupHost        = fmt.Errorf("this is a mocked error")
+	errMockLookupHost        = errors.New("this is a mocked error")
 	testLookupResult         = []string{ip1, ip2, ip3}
 	testLookupResultWithPort = []string{net.JoinHostPort(ip1, testPort), net.JoinHostPort(ip2, testPort), net.JoinHostPort(ip3, testPort)}
 )

--- a/storage/remote/dial_context_test.go
+++ b/storage/remote/dial_context_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The Prometheus Authors
+// Copyright 2024 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/storage/remote/dial_context_test.go
+++ b/storage/remote/dial_context_test.go
@@ -1,0 +1,139 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testNetwork         = "tcp"
+	testAddrWithoutPort = "this-is-my-addr.without-port"
+	testAddrWithPort    = "this-is-my-addr.without-port:123"
+	testPort            = "123"
+	ip1                 = "1.2.3.4"
+	ip2                 = "5.6.7.8"
+	ip3                 = "9.0.1.2"
+)
+
+var (
+	errMockLookupHost        = fmt.Errorf("this is a mocked error")
+	testLookupResult         = []string{ip1, ip2, ip3}
+	testLookupResultWithPort = []string{net.JoinHostPort(ip1, testPort), net.JoinHostPort(ip2, testPort), net.JoinHostPort(ip3, testPort)}
+)
+
+type mockDialContext struct {
+	mock.Mock
+
+	addrFrequencyMu sync.Mutex
+	addrFrequency   map[string]int
+}
+
+func newMockDialContext(acceptableAddresses []string) *mockDialContext {
+	m := &mockDialContext{
+		addrFrequencyMu: sync.Mutex{},
+		addrFrequency:   make(map[string]int),
+	}
+	for _, acceptableAddr := range acceptableAddresses {
+		m.On("dialContext", mock.Anything, mock.Anything, acceptableAddr).Return(nil, nil)
+	}
+	return m
+}
+
+func (dc *mockDialContext) dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	dc.addrFrequencyMu.Lock()
+	defer dc.addrFrequencyMu.Unlock()
+	args := dc.MethodCalled("dialContext", ctx, network, addr)
+	dc.addrFrequency[addr]++
+	return nil, args.Error(1)
+}
+
+func (dc *mockDialContext) getCount(addr string) int {
+	dc.addrFrequencyMu.Lock()
+	defer dc.addrFrequencyMu.Unlock()
+	return dc.addrFrequency[addr]
+}
+
+type mockedLookupHost struct {
+	withErr bool
+	result  []string
+}
+
+func (lh *mockedLookupHost) lookupHost(context.Context, string) ([]string, error) {
+	if lh.withErr {
+		return nil, errMockLookupHost
+	}
+	return lh.result, nil
+}
+
+func TestDialContextWithRandomConnections(t *testing.T) {
+	numberOfRuns := 2 * len(testLookupResult)
+	var (
+		mdc *mockDialContext
+	)
+	testCases := map[string]struct {
+		addr                              string
+		setup                             func() customDialContext
+		check                             func()
+		withLookupHostErr                 bool
+		expectedDefaultContextArguments   []string
+		unexpectedDefaultContextArguments []string
+	}{
+		"if address contains no port call default DealContext": {
+			addr: testAddrWithoutPort,
+			setup: func() customDialContext {
+				dc := newDialContextWithRandomConnections()
+				mdc = newMockDialContext([]string{testAddrWithoutPort})
+				dc.setDefaultDialContext(mdc.dialContext)
+				return dc
+			},
+			check: func() {
+				require.Equal(t, numberOfRuns, mdc.getCount(testAddrWithoutPort))
+			},
+		},
+		"if lookup host returns error call default DealContext": {
+			addr: testAddrWithPort,
+			setup: func() customDialContext {
+				dc := newDialContextWithRandomConnections()
+				mdc = newMockDialContext([]string{testAddrWithPort})
+				dc.setDefaultDialContext(mdc.dialContext)
+				dc.setResolver(&mockedLookupHost{withErr: true})
+				return dc
+			},
+			check: func() {
+				require.Equal(t, numberOfRuns, mdc.getCount(testAddrWithPort))
+			},
+		},
+		"if lookup host is successful, shuffle results": {
+			addr: testAddrWithPort,
+			setup: func() customDialContext {
+				dc := newDialContextWithRandomConnections()
+				mdc = newMockDialContext(testLookupResultWithPort)
+				dc.setDefaultDialContext(mdc.dialContext)
+				dc.setResolver(&mockedLookupHost{result: testLookupResult})
+				return dc
+			},
+			check: func() {
+				// we ensure that not all runs will choose the first element of the lookup
+				require.NotEqual(t, numberOfRuns, mdc.getCount(testLookupResultWithPort[0]))
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			dc := tc.setup()
+			require.NotNil(t, dc)
+			for i := 0; i < numberOfRuns; i++ {
+				_, err := dc.dialContextFn()(context.Background(), testNetwork, tc.addr)
+				require.NoError(t, err)
+			}
+			tc.check()
+		})
+	}
+}

--- a/storage/remote/dial_context_test.go
+++ b/storage/remote/dial_context_test.go
@@ -124,6 +124,16 @@ func TestDialContextWithRandomConnections(t *testing.T) {
 				require.Equal(t, numberOfRuns, mdc.getCount(testAddrWithPort))
 			},
 		},
+		"if lookup returns no addresses call default DealContext": {
+			addr: testAddrWithPort,
+			setup: func() dialContextWithRoundRobinDNS {
+				mdc = newMockDialContext([]string{testAddrWithPort})
+				return createDialContextWithRoundRobinDNS(mdc.dialContext, &mockedLookupHost{}, rand.New(rand.NewSource(time.Now().Unix())))
+			},
+			check: func() {
+				require.Equal(t, numberOfRuns, mdc.getCount(testAddrWithPort))
+			},
+		},
 		"if lookup host is successful, shuffle results": {
 			addr: testAddrWithPort,
 			setup: func() dialContextWithRoundRobinDNS {

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -171,15 +171,16 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 		}
 
 		c, err := NewWriteClient(name, &ClientConfig{
-			URL:              rwConf.URL,
-			WriteProtoMsg:    rwConf.ProtobufMessage,
-			Timeout:          rwConf.RemoteTimeout,
-			HTTPClientConfig: rwConf.HTTPClientConfig,
-			SigV4Config:      rwConf.SigV4Config,
-			AzureADConfig:    rwConf.AzureADConfig,
-			GoogleIAMConfig:  rwConf.GoogleIAMConfig,
-			Headers:          rwConf.Headers,
-			RetryOnRateLimit: rwConf.QueueConfig.RetryOnRateLimit,
+			URL:                  rwConf.URL,
+			WriteProtoMsg:        rwConf.ProtobufMessage,
+			Timeout:              rwConf.RemoteTimeout,
+			HTTPClientConfig:     rwConf.HTTPClientConfig,
+			SigV4Config:          rwConf.SigV4Config,
+			AzureADConfig:        rwConf.AzureADConfig,
+			GoogleIAMConfig:      rwConf.GoogleIAMConfig,
+			Headers:              rwConf.Headers,
+			RetryOnRateLimit:     rwConf.QueueConfig.RetryOnRateLimit,
+			RoundRobinDnsEnabled: rwConf.RoundRobinDNSEnabled,
 		})
 		if err != nil {
 			return err

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -180,7 +180,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			GoogleIAMConfig:      rwConf.GoogleIAMConfig,
 			Headers:              rwConf.Headers,
 			RetryOnRateLimit:     rwConf.QueueConfig.RetryOnRateLimit,
-			RoundRobinDnsEnabled: rwConf.RoundRobinDNSEnabled,
+			RoundRobinDNSEnabled: rwConf.RoundRobinDNSEnabled,
 		})
 		if err != nil {
 			return err

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -171,16 +171,16 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 		}
 
 		c, err := NewWriteClient(name, &ClientConfig{
-			URL:                  rwConf.URL,
-			WriteProtoMsg:        rwConf.ProtobufMessage,
-			Timeout:              rwConf.RemoteTimeout,
-			HTTPClientConfig:     rwConf.HTTPClientConfig,
-			SigV4Config:          rwConf.SigV4Config,
-			AzureADConfig:        rwConf.AzureADConfig,
-			GoogleIAMConfig:      rwConf.GoogleIAMConfig,
-			Headers:              rwConf.Headers,
-			RetryOnRateLimit:     rwConf.QueueConfig.RetryOnRateLimit,
-			RoundRobinDNSEnabled: rwConf.RoundRobinDNSEnabled,
+			URL:              rwConf.URL,
+			WriteProtoMsg:    rwConf.ProtobufMessage,
+			Timeout:          rwConf.RemoteTimeout,
+			HTTPClientConfig: rwConf.HTTPClientConfig,
+			SigV4Config:      rwConf.SigV4Config,
+			AzureADConfig:    rwConf.AzureADConfig,
+			GoogleIAMConfig:  rwConf.GoogleIAMConfig,
+			Headers:          rwConf.Headers,
+			RetryOnRateLimit: rwConf.QueueConfig.RetryOnRateLimit,
+			RoundRobinDNS:    rwConf.RoundRobinDNS,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR addresses the issues explained in https://github.com/prometheus/prometheus/issues/15262.
Namely, in case a remote-write is executed towards a host name that is resolved to multiple IP addresses, this PR introduces a possibility to force creation of new connections used for the remote-write request to a randomly chosen IP address from the ones corresponding to the host name. The default behavior remains unchanged, i.s., the IP address used for the connection creation remains the one chosen by Go.

This is an experimental feature, it is disabled by default, and can be enabled by setting
```
  remote_write:
    round_robin_dns_enabled: true
```