### PR TITLE
promql parser: Use a function to determine if an aggregation function is experimental

### DIFF
--- a/promql/parser/lex.go
+++ b/promql/parser/lex.go
@@ -68,6 +68,12 @@ func (i ItemType) IsAggregatorWithParam() bool {
 	return i == TOPK || i == BOTTOMK || i == COUNT_VALUES || i == QUANTILE || i == LIMITK || i == LIMIT_RATIO
 }
 
+// IsExperimentalAggregator defines the experimental aggregation functions that are controlled
+// with EnableExperimentalFunctions.
+func (i ItemType) IsExperimentalAggregator() bool {
+	return i == LIMITK || i == LIMIT_RATIO
+}
+
 // IsKeyword returns true if the Item corresponds to a keyword.
 // Returns false otherwise.
 func (i ItemType) IsKeyword() bool { return i > keywordsStart && i < keywordsEnd }

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -447,8 +447,8 @@ func (p *parser) newAggregateExpr(op Item, modifier, args Node) (ret *AggregateE
 
 	desiredArgs := 1
 	if ret.Op.IsAggregatorWithParam() {
-		if !EnableExperimentalFunctions && (ret.Op == LIMITK || ret.Op == LIMIT_RATIO) {
-			p.addParseErrf(ret.PositionRange(), "limitk() and limit_ratio() are experimental and must be enabled with --enable-feature=promql-experimental-functions")
+		if !EnableExperimentalFunctions && ret.Op.IsExperimentalAggregator() {
+			p.addParseErrf(ret.PositionRange(), "%s() is experimental and must be enabled with --enable-feature=promql-experimental-functions", ret.Op)
 			return
 		}
 		desiredArgs = 2


### PR DESCRIPTION
Normal functions are clearly marked as experimental, but the experimental nature of aggregation functions like `limitk` and `limit_ratio` were previously hardcoded. This is a very simple PR to put that into a function so we can use it to find out if an aggregator is experimental, and it is easy to update (add new experimental aggregators or move an aggregator out of experimental status) without needing to update any hardcoded values separately downstream.