### PR TITLE
Fix selector / series formatting for empty metric names

### DIFF
--- a/web/ui/mantine-ui/src/promql/serializeAndFormat.test.ts
+++ b/web/ui/mantine-ui/src/promql/serializeAndFormat.test.ts
@@ -157,6 +157,20 @@ describe("serializeNode and formatNode", () => {
         },
         output: "metric_name[5m] @ start() offset -10m",
       },
+      {
+        node: {
+          type: nodeType.vectorSelector,
+          name: "", // Test formatting a selector with an empty metric name.
+          matchers: [
+            { type: matchType.equal, name: "label1", value: "value1" },
+          ],
+          offset: 0,
+          timestamp: null,
+          startOrEnd: null,
+        },
+        output:
+          '{label1="value1"}',
+      },
 
       // Aggregations.
       {

--- a/web/ui/mantine-ui/src/promql/utils.ts
+++ b/web/ui/mantine-ui/src/promql/utils.ts
@@ -271,7 +271,7 @@ const metricNameRe = /^[a-zA-Z_:][a-zA-Z0-9_:]*$/;
 const labelNameCharsetRe = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 export const metricContainsExtendedCharset = (str: string) => {
-  return !metricNameRe.test(str);
+  return str !== "" && !metricNameRe.test(str);
 };
 
 export const labelNameContainsExtendedCharset = (str: string) => {


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/15335

Same fix as in https://github.com/prometheus/prometheus/pull/15340, but for the `release-3.0` branch.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
