### PR TITLE
Clear counter reset headers for non-gauge histograms

### DIFF
--- a/storage/series_test.go
+++ b/storage/series_test.go
@@ -378,7 +378,7 @@ func TestHistogramSeriesToChunks(t *testing.T) {
 				hSample{t: 1, h: h2},
 				hSample{t: 2, h: h1},
 			},
-			expectedCounterResetHeaders: []chunkenc.CounterResetHeader{chunkenc.UnknownCounterReset, chunkenc.CounterReset},
+			expectedCounterResetHeaders: []chunkenc.CounterResetHeader{chunkenc.UnknownCounterReset, chunkenc.UnknownCounterReset},
 		},
 		"histogram and stale sample encoded to two chunks": {
 			samples: []chunks.Sample{
@@ -400,7 +400,7 @@ func TestHistogramSeriesToChunks(t *testing.T) {
 				hSample{t: 1, h: h1},
 				hSample{t: 2, h: h2down},
 			},
-			expectedCounterResetHeaders: []chunkenc.CounterResetHeader{chunkenc.UnknownCounterReset, chunkenc.CounterReset},
+			expectedCounterResetHeaders: []chunkenc.CounterResetHeader{chunkenc.UnknownCounterReset, chunkenc.UnknownCounterReset},
 		},
 		// Float histograms.
 		"single float histogram to single chunk": {
@@ -432,7 +432,7 @@ func TestHistogramSeriesToChunks(t *testing.T) {
 				fhSample{t: 1, fh: fh2},
 				fhSample{t: 2, fh: fh1},
 			},
-			expectedCounterResetHeaders: []chunkenc.CounterResetHeader{chunkenc.UnknownCounterReset, chunkenc.CounterReset},
+			expectedCounterResetHeaders: []chunkenc.CounterResetHeader{chunkenc.UnknownCounterReset, chunkenc.UnknownCounterReset},
 		},
 		"float histogram and stale sample encoded to two chunks": {
 			samples: []chunks.Sample{
@@ -454,7 +454,7 @@ func TestHistogramSeriesToChunks(t *testing.T) {
 				fhSample{t: 1, fh: fh1},
 				fhSample{t: 2, fh: fh2down},
 			},
-			expectedCounterResetHeaders: []chunkenc.CounterResetHeader{chunkenc.UnknownCounterReset, chunkenc.CounterReset},
+			expectedCounterResetHeaders: []chunkenc.CounterResetHeader{chunkenc.UnknownCounterReset, chunkenc.UnknownCounterReset},
 		},
 		// Mixed.
 		"histogram and float histogram encoded to two chunks": {

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -790,16 +790,16 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 				panic(err) // This should never happen for an empty float histogram chunk.
 			}
 			happ := app.(*FloatHistogramAppender)
-			if counterReset {
-				// We are currently not setting non-gauge histogram chunk headers. This will result in all non-gauge histogram
-				// chunks having the UnknownCounterReset header.
-				// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
-				// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
-				// to properly resolve the counter reset issues.
-				// See: https://github.com/prometheus/prometheus/pull/15342
-				// The original code for setting the header has been commented out below.
-				// happ.setCounterResetHeader(CounterReset)
-			}
+			// We are currently not setting non-gauge histogram chunk headers. This will result in all non-gauge histogram
+			// chunks having the UnknownCounterReset header.
+			// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
+			// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
+			// to properly resolve the counter reset issues.
+			// See: https://github.com/prometheus/prometheus/pull/15342
+			// The original code for setting the header has been commented out below.
+			// if counterReset {
+			// happ.setCounterResetHeader(CounterReset)
+			// }
 			happ.appendFloatHistogram(t, h)
 			return newChunk, false, app, nil
 		}

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -707,7 +707,14 @@ func (a *FloatHistogramAppender) recode(
 		happ.appendFloatHistogram(tOld, hOld)
 	}
 
-	happ.setCounterResetHeader(CounterResetHeader(byts[2] & CounterResetHeaderMask))
+	// We are currently not setting non-gauge histogram chunk headers. This will result in all non-gauge histogram
+	// chunks having the UnknownCounterReset header.
+	// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
+	// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
+	// to properly resolve the counter reset issues.
+	// See: TODO: PR link
+	// The original code for setting the header has been commented out below.
+	// happ.setCounterResetHeader(CounterResetHeader(byts[2] & CounterResetHeaderMask))
 	return hc, app
 }
 
@@ -739,19 +746,28 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			return nil, false, a, nil
 		}
 
-		switch {
-		case h.CounterResetHint == histogram.CounterReset:
-			// Always honor the explicit counter reset hint.
-			a.setCounterResetHeader(CounterReset)
-		case prev != nil:
-			// This is a new chunk, but continued from a previous one. We need to calculate the reset header unless already set.
-			_, _, _, _, _, counterReset := prev.appendable(h)
-			if counterReset {
+		// We are currently not setting non-gauge histogram chunk headers. This will result in all non-gauge histogram
+		// chunks having the UnknownCounterReset header.
+		// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
+		// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
+		// to properly resolve the counter reset issues.
+		// See: TODO: PR link
+		// The original code for setting the header has been commented out below.
+		/*
+			switch {
+			case h.CounterResetHint == histogram.CounterReset:
+				// Always honor the explicit counter reset hint.
 				a.setCounterResetHeader(CounterReset)
-			} else {
-				a.setCounterResetHeader(NotCounterReset)
+			case prev != nil:
+				// This is a new chunk, but continued from a previous one. We need to calculate the reset header unless already set.
+				_, _, _, _, _, counterReset := prev.appendable(h)
+				if counterReset {
+					a.setCounterResetHeader(CounterReset)
+				} else {
+					a.setCounterResetHeader(NotCounterReset)
+				}
 			}
-		}
+		*/
 		return nil, false, a, nil
 	}
 
@@ -772,7 +788,14 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			}
 			happ := app.(*FloatHistogramAppender)
 			if counterReset {
-				happ.setCounterResetHeader(CounterReset)
+				// We are currently not setting non-gauge histogram chunk headers. This will result in all non-gauge histogram
+				// chunks having the UnknownCounterReset header.
+				// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
+				// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
+				// to properly resolve the counter reset issues.
+				// See: TODO: PR link
+				// The original code for setting the header has been commented out below.
+				// happ.setCounterResetHeader(CounterReset)
 			}
 			happ.appendFloatHistogram(t, h)
 			return newChunk, false, app, nil

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -712,7 +712,7 @@ func (a *FloatHistogramAppender) recode(
 	// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
 	// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
 	// to properly resolve the counter reset issues.
-	// See: TODO: PR link
+	// See: https://github.com/prometheus/prometheus/pull/15342
 	// The original code for setting the header has been commented out below.
 	// happ.setCounterResetHeader(CounterResetHeader(byts[2] & CounterResetHeaderMask))
 	return hc, app
@@ -751,7 +751,7 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 		// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
 		// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
 		// to properly resolve the counter reset issues.
-		// See: TODO: PR link
+		// See: https://github.com/prometheus/prometheus/pull/15342
 		// The original code for setting the header has been commented out below.
 		/*
 			switch {
@@ -793,7 +793,7 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 				// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
 				// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
 				// to properly resolve the counter reset issues.
-				// See: TODO: PR link
+				// See: https://github.com/prometheus/prometheus/pull/15342
 				// The original code for setting the header has been commented out below.
 				// happ.setCounterResetHeader(CounterReset)
 			}

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -714,6 +714,9 @@ func (a *FloatHistogramAppender) recode(
 	// to properly resolve the counter reset issues.
 	// See: https://github.com/prometheus/prometheus/pull/15342
 	// The original code for setting the header has been commented out below.
+	if CounterResetHeader(byts[2]&CounterResetHeaderMask) == GaugeType {
+		happ.setCounterResetHeader(GaugeType)
+	}
 	// happ.setCounterResetHeader(CounterResetHeader(byts[2] & CounterResetHeaderMask))
 	return hc, app
 }

--- a/tsdb/chunkenc/float_histogram_test.go
+++ b/tsdb/chunkenc/float_histogram_test.go
@@ -33,8 +33,10 @@ func TestFirstFloatHistogramExplicitCounterReset(t *testing.T) {
 		expHeader CounterResetHeader
 	}{
 		"CounterReset": {
-			hint:      histogram.CounterReset,
-			expHeader: CounterReset,
+			hint: histogram.CounterReset,
+			// We are currently setting non-gauge histogram chunks to have an UnknownCounterReset
+			// https://github.com/prometheus/prometheus/pull/15342
+			expHeader: UnknownCounterReset,
 		},
 		"NotCounterReset": {
 			hint:      histogram.NotCounterReset,
@@ -397,7 +399,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		require.False(t, ok) // Need to cut a new chunk.
 		require.True(t, cr)
 
-		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // New histogram that has buckets missing but the buckets missing were empty.
@@ -480,7 +482,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		require.False(t, ok) // Need to cut a new chunk.
 		require.True(t, cr)
 
-		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // New histogram that has a counter reset while new buckets were added.
@@ -503,7 +505,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		require.False(t, ok) // Need to cut a new chunk.
 		require.True(t, cr)
 
-		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{
@@ -532,7 +534,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		require.False(t, ok) // Need to cut a new chunk.
 		require.True(t, cr)
 
-		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // New histogram that has an explicit counter reset.
@@ -540,7 +542,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		h2 := h1.Copy()
 		h2.CounterResetHint = histogram.CounterReset
 
-		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // Start new chunk explicitly, and append a new histogram that is considered appendable to the previous chunk.
@@ -556,7 +558,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		require.False(t, recoded)
 		require.Equal(t, app, newApp)
 		assertSampleCount(t, nextChunk, 1, ValFloatHistogram)
-		require.Equal(t, NotCounterReset, nextChunk.GetCounterResetHeader())
+		require.Equal(t, UnknownCounterReset, nextChunk.GetCounterResetHeader())
 	}
 
 	{ // Start new chunk explicitly, and append a new histogram that is not considered appendable to the previous chunk.
@@ -573,7 +575,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		require.False(t, recoded)
 		require.Equal(t, app, newApp)
 		assertSampleCount(t, nextChunk, 1, ValFloatHistogram)
-		require.Equal(t, CounterReset, nextChunk.GetCounterResetHeader())
+		require.Equal(t, UnknownCounterReset, nextChunk.GetCounterResetHeader())
 	}
 
 	{ // Start new chunk explicitly, and append a new histogram that would need recoding if we added it to the chunk.
@@ -599,7 +601,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		require.False(t, recoded)
 		require.Equal(t, app, newApp)
 		assertSampleCount(t, nextChunk, 1, ValFloatHistogram)
-		require.Equal(t, NotCounterReset, nextChunk.GetCounterResetHeader())
+		require.Equal(t, UnknownCounterReset, nextChunk.GetCounterResetHeader())
 	}
 
 	{
@@ -664,7 +666,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		_, _, _, _, ok, _ := hApp.appendable(h2)
 		require.False(t, ok)
 
-		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // Custom buckets, change only in custom bounds.
@@ -674,7 +676,7 @@ func TestFloatHistogramChunkAppendable(t *testing.T) {
 		_, _, _, _, ok, _ := hApp.appendable(h2)
 		require.False(t, ok)
 
-		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewFloatHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // Custom buckets, with more buckets.

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -744,7 +744,10 @@ func (a *HistogramAppender) recode(
 	// to properly resolve the counter reset issues.
 	// See: https://github.com/prometheus/prometheus/pull/15342
 	// The original code for setting the header has been commented out below.
-	//happ.setCounterResetHeader(CounterResetHeader(byts[2] & CounterResetHeaderMask))
+	if CounterResetHeader(byts[2]&CounterResetHeaderMask) == GaugeType {
+		happ.setCounterResetHeader(GaugeType)
+	}
+	// happ.setCounterResetHeader(CounterResetHeader(byts[2] & CounterResetHeaderMask))
 	return hc, app
 }
 

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -790,7 +790,7 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 		// to properly resolve the counter reset issues.
 		// See: https://github.com/prometheus/prometheus/pull/15342
 		// The original code for setting the header has been commented out below.
-		/*switch {
+		/* switch {
 		case h.CounterResetHint == histogram.CounterReset:
 			// Always honor the explicit counter reset hint.
 			a.setCounterResetHeader(CounterReset)
@@ -802,7 +802,7 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 			} else {
 				a.setCounterResetHeader(NotCounterReset)
 			}
-		}*/
+		} */
 		return nil, false, a, nil
 	}
 
@@ -822,16 +822,16 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 				panic(err) // This should never happen for an empty histogram chunk.
 			}
 			happ := app.(*HistogramAppender)
-			if counterReset {
-				// We are currently not setting non-gauge histogram chunk headers. This will result in all non-gauge histogram
-				// chunks having the UnknownCounterReset header.
-				// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
-				// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
-				// to properly resolve the counter reset issues.
-				// See: https://github.com/prometheus/prometheus/pull/15342
-				// The original code for setting the header has been commented out below.
-				// happ.setCounterResetHeader(CounterReset)
-			}
+			// We are currently not setting non-gauge histogram chunk headers. This will result in all non-gauge histogram
+			// chunks having the UnknownCounterReset header.
+			// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
+			// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
+			// to properly resolve the counter reset issues.
+			// See: https://github.com/prometheus/prometheus/pull/15342
+			// The original code for setting the header has been commented out below.
+			// if counterReset {
+			// happ.setCounterResetHeader(CounterReset)
+			// }
 			happ.appendHistogram(t, h)
 			return newChunk, false, app, nil
 		}

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -742,7 +742,7 @@ func (a *HistogramAppender) recode(
 	// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
 	// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
 	// to properly resolve the counter reset issues.
-	// See: TODO: PR link
+	// See: https://github.com/prometheus/prometheus/pull/15342
 	// The original code for setting the header has been commented out below.
 	//happ.setCounterResetHeader(CounterResetHeader(byts[2] & CounterResetHeaderMask))
 	return hc, app
@@ -785,7 +785,7 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 		// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
 		// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
 		// to properly resolve the counter reset issues.
-		// See: TODO: PR link
+		// See: https://github.com/prometheus/prometheus/pull/15342
 		// The original code for setting the header has been commented out below.
 		/*switch {
 		case h.CounterResetHint == histogram.CounterReset:
@@ -825,7 +825,7 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 				// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
 				// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
 				// to properly resolve the counter reset issues.
-				// See: TODO: PR link
+				// See: https://github.com/prometheus/prometheus/pull/15342
 				// The original code for setting the header has been commented out below.
 				// happ.setCounterResetHeader(CounterReset)
 			}

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -737,7 +737,14 @@ func (a *HistogramAppender) recode(
 		happ.appendHistogram(tOld, hOld)
 	}
 
-	happ.setCounterResetHeader(CounterResetHeader(byts[2] & CounterResetHeaderMask))
+	// We are currently not setting non-gauge histogram chunk headers. This will result in all non-gauge histogram
+	// chunks having the UnknownCounterReset header.
+	// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
+	// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
+	// to properly resolve the counter reset issues.
+	// See: TODO: PR link
+	// The original code for setting the header has been commented out below.
+	//happ.setCounterResetHeader(CounterResetHeader(byts[2] & CounterResetHeaderMask))
 	return hc, app
 }
 
@@ -773,7 +780,14 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 			return nil, false, a, nil
 		}
 
-		switch {
+		// We are currently not setting non-gauge histogram chunk headers. This will result in all non-gauge histogram
+		// chunks having the UnknownCounterReset header.
+		// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
+		// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
+		// to properly resolve the counter reset issues.
+		// See: TODO: PR link
+		// The original code for setting the header has been commented out below.
+		/*switch {
 		case h.CounterResetHint == histogram.CounterReset:
 			// Always honor the explicit counter reset hint.
 			a.setCounterResetHeader(CounterReset)
@@ -785,7 +799,7 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 			} else {
 				a.setCounterResetHeader(NotCounterReset)
 			}
-		}
+		}*/
 		return nil, false, a, nil
 	}
 
@@ -806,7 +820,14 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, t int64, h 
 			}
 			happ := app.(*HistogramAppender)
 			if counterReset {
-				happ.setCounterResetHeader(CounterReset)
+				// We are currently not setting non-gauge histogram chunk headers. This will result in all non-gauge histogram
+				// chunks having the UnknownCounterReset header.
+				// Counter reset detection can be buggy when chunks from different sources are merged (e.g. out-of-order, backfill).
+				// It's always safe to set the header to UnknownCounterReset so we are doing that as a quick fix and take the time
+				// to properly resolve the counter reset issues.
+				// See: TODO: PR link
+				// The original code for setting the header has been commented out below.
+				// happ.setCounterResetHeader(CounterReset)
 			}
 			happ.appendHistogram(t, h)
 			return newChunk, false, app, nil

--- a/tsdb/chunkenc/histogram_test.go
+++ b/tsdb/chunkenc/histogram_test.go
@@ -34,8 +34,10 @@ func TestFirstHistogramExplicitCounterReset(t *testing.T) {
 		expHeader CounterResetHeader
 	}{
 		"CounterReset": {
-			hint:      histogram.CounterReset,
-			expHeader: CounterReset,
+			hint: histogram.CounterReset,
+			// We are currently setting non-gauge histogram chunks to have an UnknownCounterReset
+			// https://github.com/prometheus/prometheus/pull/15342
+			expHeader: UnknownCounterReset,
 		},
 		"NotCounterReset": {
 			hint:      histogram.NotCounterReset,
@@ -413,7 +415,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		require.False(t, ok) // Need to cut a new chunk.
 		require.True(t, cr)
 
-		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // New histogram that has buckets missing but the buckets missing were empty.
@@ -498,7 +500,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		require.False(t, ok) // Need to cut a new chunk.
 		require.True(t, cr)
 
-		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // New histogram that has a counter reset while new buckets were added.
@@ -524,7 +526,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		require.False(t, ok) // Need to cut a new chunk.
 		require.True(t, cr)
 
-		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{
@@ -556,7 +558,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		require.False(t, ok) // Need to cut a new chunk.
 		require.True(t, cr)
 
-		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // New histogram that has an explicit counter reset.
@@ -564,7 +566,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		h2 := h1.Copy()
 		h2.CounterResetHint = histogram.CounterReset
 
-		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // Start new chunk explicitly, and append a new histogram that is considered appendable to the previous chunk.
@@ -580,7 +582,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		require.False(t, recoded)
 		require.Equal(t, app, newApp)
 		assertSampleCount(t, nextChunk, 1, ValHistogram)
-		require.Equal(t, NotCounterReset, nextChunk.GetCounterResetHeader())
+		require.Equal(t, UnknownCounterReset, nextChunk.GetCounterResetHeader())
 	}
 
 	{ // Start new chunk explicitly, and append a new histogram that is not considered appendable to the previous chunk.
@@ -597,7 +599,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		require.False(t, recoded)
 		require.Equal(t, app, newApp)
 		assertSampleCount(t, nextChunk, 1, ValHistogram)
-		require.Equal(t, CounterReset, nextChunk.GetCounterResetHeader())
+		require.Equal(t, UnknownCounterReset, nextChunk.GetCounterResetHeader())
 	}
 
 	{ // Start new chunk explicitly, and append a new histogram that would need recoding if we added it to the chunk.
@@ -626,7 +628,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		require.False(t, recoded)
 		require.Equal(t, app, newApp)
 		assertSampleCount(t, nextChunk, 1, ValHistogram)
-		require.Equal(t, NotCounterReset, nextChunk.GetCounterResetHeader())
+		require.Equal(t, UnknownCounterReset, nextChunk.GetCounterResetHeader())
 	}
 
 	{
@@ -691,7 +693,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		_, _, _, _, ok, _ := hApp.appendable(h2)
 		require.False(t, ok)
 
-		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // Custom buckets, change only in custom bounds.
@@ -701,7 +703,7 @@ func TestHistogramChunkAppendable(t *testing.T) {
 		_, _, _, _, ok, _ := hApp.appendable(h2)
 		require.False(t, ok)
 
-		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, CounterReset)
+		assertNewHistogramChunkOnAppend(t, c, hApp, ts+1, h2, UnknownCounterReset)
 	}
 
 	{ // Custom buckets, with more buckets.

--- a/tsdb/ooo_head_test.go
+++ b/tsdb/ooo_head_test.go
@@ -203,7 +203,7 @@ func TestOOOChunks_ToEncodedChunks(t *testing.T) {
 				{t: 1000, h: h2},
 				{t: 1100, h: h1},
 			},
-			expectedCounterResets: []histogram.CounterResetHint{histogram.UnknownCounterReset, histogram.CounterReset},
+			expectedCounterResets: []histogram.CounterResetHint{histogram.UnknownCounterReset, histogram.UnknownCounterReset},
 			expectedChunks: []chunkVerify{
 				{encoding: chunkenc.EncHistogram, minTime: 1000, maxTime: 1000},
 				{encoding: chunkenc.EncHistogram, minTime: 1100, maxTime: 1100},


### PR DESCRIPTION
Counter reset detection can be buggy when chunks from different sources are merged (e.g. https://github.com/prometheus/prometheus/pull/15221, https://github.com/prometheus/prometheus/pull/15253). It's always safe to set the counter reset header of a histogram chunk to UnknownCounterReset so we are doing that as a quick fix and take the time to properly resolve the counter reset issues.

TODO: add tests from the compaction fix PR