### PR TITLE
tests: Adding t.Parallel() for tests in model package

### DIFF
--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -222,7 +222,11 @@ func TestFloatHistogramMul(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.Equal(t, c.expected, c.in.Mul(c.scale))
 			// Has it also happened in-place?
 			require.Equal(t, c.expected, c.in)
@@ -284,7 +288,11 @@ func TestFloatHistogramCopy(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
+		// capture the range variable to avoid issues with concurrency
+		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			hCopy := tcase.orig.Copy()
 
 			// Modify a primitive value in the original histogram.
@@ -349,7 +357,11 @@ func TestFloatHistogramCopyTo(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
+		// capture the range variable to avoid issues with concurrency
+		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			hCopy := &FloatHistogram{}
 			tcase.orig.CopyTo(hCopy)
 
@@ -362,6 +374,7 @@ func TestFloatHistogramCopyTo(t *testing.T) {
 }
 
 func assertDeepCopyFHSpans(t *testing.T, orig, hCopy, expected *FloatHistogram) {
+	t.Helper()
 	// Do an in-place expansion of an original spans slice.
 	orig.PositiveSpans = expandSpans(orig.PositiveSpans)
 	orig.PositiveSpans[len(orig.PositiveSpans)-1] = Span{1, 2}
@@ -544,7 +557,11 @@ func TestFloatHistogramDiv(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.Equal(t, c.expected, c.fh.Div(c.s))
 			// Has it also happened in-place?
 			require.Equal(t, c.expected, c.fh)
@@ -1274,7 +1291,11 @@ func TestFloatHistogramDetectReset(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.Equal(t, c.resetExpected, c.current.DetectReset(c.previous))
 		})
 	}
@@ -1631,7 +1652,11 @@ func TestFloatHistogramCompact(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.Equal(t, c.expected, c.in.Compact(c.maxEmptyBuckets))
 			// Compact has happened in-place, too.
 			require.Equal(t, c.expected, c.in)
@@ -2309,7 +2334,11 @@ func TestFloatHistogramAdd(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			testHistogramAdd(t, c.in1, c.in2, c.expected, c.expErrMsg)
 			testHistogramAdd(t, c.in2, c.in1, c.expected, c.expErrMsg)
 		})
@@ -2317,6 +2346,7 @@ func TestFloatHistogramAdd(t *testing.T) {
 }
 
 func testHistogramAdd(t *testing.T, a, b, expected *FloatHistogram, expErrMsg string) {
+	t.Helper()
 	var (
 		aCopy        = a.Copy()
 		bCopy        = b.Copy()
@@ -2502,7 +2532,11 @@ func TestFloatHistogramSub(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			testFloatHistogramSub(t, c.in1, c.in2, c.expected, c.expErrMsg)
 
 			var expectedNegative *FloatHistogram
@@ -2515,6 +2549,7 @@ func TestFloatHistogramSub(t *testing.T) {
 }
 
 func testFloatHistogramSub(t *testing.T, a, b, expected *FloatHistogram, expErrMsg string) {
+	t.Helper()
 	var (
 		aCopy        = a.Copy()
 		bCopy        = b.Copy()
@@ -2627,7 +2662,11 @@ func TestFloatHistogramCopyToSchema(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			inCopy := c.in.Copy()
 			require.Equal(t, c.expected, c.in.CopyToSchema(c.targetSchema))
 			// Check that the receiver histogram was not mutated:
@@ -2637,6 +2676,8 @@ func TestFloatHistogramCopyToSchema(t *testing.T) {
 }
 
 func TestReverseFloatBucketIterator(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	h := &FloatHistogram{
 		Count:         405,
 		ZeroCount:     102,
@@ -2880,7 +2921,11 @@ func TestAllFloatBucketIterator(t *testing.T) {
 	}
 
 	for i, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			var expBuckets, actBuckets []Bucket[float64]
 
 			if c.includeNeg {
@@ -3106,7 +3151,11 @@ func TestAllReverseFloatBucketIterator(t *testing.T) {
 	}
 
 	for i, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			var expBuckets, actBuckets []Bucket[float64]
 
 			if c.includePos {
@@ -3150,6 +3199,8 @@ func TestAllReverseFloatBucketIterator(t *testing.T) {
 }
 
 func TestFloatBucketIteratorTargetSchema(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	h := FloatHistogram{
 		Count:  405,
 		Sum:    1008.4,
@@ -3244,7 +3295,11 @@ func TestFloatCustomBucketsIterators(t *testing.T) {
 	}
 
 	for i, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			{
 				it := c.h.AllBucketIterator()
 				for i, b := range c.expPositiveBuckets {
@@ -3303,6 +3358,8 @@ func TestFloatCustomBucketsIterators(t *testing.T) {
 // TestFloatHistogramEquals tests FloatHistogram with float-specific cases that
 // cannot be covered by TestHistogramEquals.
 func TestFloatHistogramEquals(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	h1 := FloatHistogram{
 		Schema:          3,
 		Count:           2.2,
@@ -3454,7 +3511,11 @@ func TestFloatHistogramSize(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.Equal(t, c.expected, c.fh.Size())
 		})
 	}
@@ -3505,7 +3566,11 @@ func TestFloatHistogramString(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.NoError(t, c.fh.Validate())
 			require.Equal(t, c.expected, c.fh.String())
 		})
@@ -3597,10 +3662,16 @@ func TestFloatHistogramReduceResolution(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
-		target := tc.origin.ReduceResolution(tc.target.Schema)
-		require.Equal(t, tc.target, target)
-		// Check that receiver histogram was mutated:
-		require.Equal(t, tc.target, tc.origin)
+	for testName, tc := range tcs {
+		// capture the range variable to avoid issues with concurrency
+		tc := tc
+		t.Run(testName, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
+			target := tc.origin.ReduceResolution(tc.target.Schema)
+			require.Equal(t, tc.target, target)
+			// Check that receiver histogram was mutated:
+			require.Equal(t, tc.target, tc.origin)
+		})
 	}
 }

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -222,10 +222,7 @@ func TestFloatHistogramMul(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, c.expected, c.in.Mul(c.scale))
 			// Has it also happened in-place?
@@ -288,10 +285,7 @@ func TestFloatHistogramCopy(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
-		// capture the range variable to avoid issues with concurrency
-		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			hCopy := tcase.orig.Copy()
 
@@ -357,10 +351,7 @@ func TestFloatHistogramCopyTo(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
-		// capture the range variable to avoid issues with concurrency
-		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			hCopy := &FloatHistogram{}
 			tcase.orig.CopyTo(hCopy)
@@ -557,10 +548,7 @@ func TestFloatHistogramDiv(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, c.expected, c.fh.Div(c.s))
 			// Has it also happened in-place?
@@ -1291,10 +1279,7 @@ func TestFloatHistogramDetectReset(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, c.resetExpected, c.current.DetectReset(c.previous))
 		})
@@ -1652,10 +1637,7 @@ func TestFloatHistogramCompact(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, c.expected, c.in.Compact(c.maxEmptyBuckets))
 			// Compact has happened in-place, too.
@@ -2334,10 +2316,7 @@ func TestFloatHistogramAdd(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			testHistogramAdd(t, c.in1, c.in2, c.expected, c.expErrMsg)
 			testHistogramAdd(t, c.in2, c.in1, c.expected, c.expErrMsg)
@@ -2532,10 +2511,7 @@ func TestFloatHistogramSub(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			testFloatHistogramSub(t, c.in1, c.in2, c.expected, c.expErrMsg)
 
@@ -2662,10 +2638,7 @@ func TestFloatHistogramCopyToSchema(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			inCopy := c.in.Copy()
 			require.Equal(t, c.expected, c.in.CopyToSchema(c.targetSchema))
@@ -2676,7 +2649,6 @@ func TestFloatHistogramCopyToSchema(t *testing.T) {
 }
 
 func TestReverseFloatBucketIterator(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	h := &FloatHistogram{
 		Count:         405,
@@ -2921,10 +2893,7 @@ func TestAllFloatBucketIterator(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			var expBuckets, actBuckets []Bucket[float64]
 
@@ -3151,10 +3120,7 @@ func TestAllReverseFloatBucketIterator(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			var expBuckets, actBuckets []Bucket[float64]
 
@@ -3199,7 +3165,6 @@ func TestAllReverseFloatBucketIterator(t *testing.T) {
 }
 
 func TestFloatBucketIteratorTargetSchema(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	h := FloatHistogram{
 		Count:  405,
@@ -3295,10 +3260,7 @@ func TestFloatCustomBucketsIterators(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			{
 				it := c.h.AllBucketIterator()
@@ -3358,7 +3320,6 @@ func TestFloatCustomBucketsIterators(t *testing.T) {
 // TestFloatHistogramEquals tests FloatHistogram with float-specific cases that
 // cannot be covered by TestHistogramEquals.
 func TestFloatHistogramEquals(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	h1 := FloatHistogram{
 		Schema:          3,
@@ -3511,10 +3472,7 @@ func TestFloatHistogramSize(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, c.expected, c.fh.Size())
 		})
@@ -3566,10 +3524,7 @@ func TestFloatHistogramString(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.NoError(t, c.fh.Validate())
 			require.Equal(t, c.expected, c.fh.String())
@@ -3663,10 +3618,7 @@ func TestFloatHistogramReduceResolution(t *testing.T) {
 	}
 
 	for testName, tc := range tcs {
-		// capture the range variable to avoid issues with concurrency
-		tc := tc
 		t.Run(testName, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			target := tc.origin.ReduceResolution(tc.target.Schema)
 			require.Equal(t, tc.target, target)

--- a/model/histogram/generic_test.go
+++ b/model/histogram/generic_test.go
@@ -106,10 +106,7 @@ func TestGetBoundExponential(t *testing.T) {
 	}
 
 	for i, s := range scenarios {
-		// capture the range variable to avoid issues with concurrency
-		s := s
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			got := getBoundExponential(s.idx, s.schema)
 			if s.want != got {
@@ -148,10 +145,7 @@ func TestReduceResolutionHistogram(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		// capture the range variable to avoid issues with concurrency
-		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			spansCopy, bucketsCopy := slices.Clone(tc.spans), slices.Clone(tc.buckets)
 			spans, buckets := reduceResolution(tc.spans, tc.buckets, tc.schema, tc.targetSchema, true, false)
@@ -202,10 +196,7 @@ func TestReduceResolutionFloatHistogram(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		// capture the range variable to avoid issues with concurrency
-		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			spansCopy, bucketsCopy := slices.Clone(tc.spans), slices.Clone(tc.buckets)
 			spans, buckets := reduceResolution(tc.spans, tc.buckets, tc.schema, tc.targetSchema, false, false)

--- a/model/histogram/histogram_test.go
+++ b/model/histogram/histogram_test.go
@@ -87,10 +87,7 @@ func TestHistogramString(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			actualString := c.histogram.String()
 			require.Equal(t, c.expectedString, actualString)
@@ -250,10 +247,7 @@ func TestCumulativeBucketIterator(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			it := c.histogram.CumulativeBucketIterator()
 			actualBuckets := make([]Bucket[uint64], 0, len(c.expectedBuckets))
@@ -470,10 +464,7 @@ func TestRegularBucketIterator(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			it := c.histogram.PositiveBucketIterator()
 			actualPositiveBuckets := make([]Bucket[uint64], 0, len(c.expectedPositiveBuckets))
@@ -557,10 +548,7 @@ func TestHistogramToFloat(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			fh := h.ToFloat(c.fh)
 			require.Equal(t, h.String(), fh.String())
@@ -628,10 +616,7 @@ func TestCustomBucketsHistogramToFloat(t *testing.T) {
 
 	require.NoError(t, h.Validate())
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			hStr := h.String()
 			fh := h.ToFloat(c.fh)
@@ -644,7 +629,6 @@ func TestCustomBucketsHistogramToFloat(t *testing.T) {
 
 // TestHistogramEquals tests both Histogram and FloatHistogram.
 func TestHistogramEquals(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	h1 := Histogram{
 		Schema:        3,
@@ -889,10 +873,7 @@ func TestHistogramCopy(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
-		// capture the range variable to avoid issues with concurrency
-		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			hCopy := tcase.orig.Copy()
 
@@ -958,10 +939,7 @@ func TestHistogramCopyTo(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
-		// capture the range variable to avoid issues with concurrency
-		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			hCopy := &Histogram{}
 			tcase.orig.CopyTo(hCopy)
@@ -1324,10 +1302,7 @@ func TestHistogramCompact(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, c.expected, c.in.Compact(c.maxEmptyBuckets))
 			// Compact has happened in-place, too.
@@ -1603,10 +1578,7 @@ func TestHistogramValidation(t *testing.T) {
 	}
 
 	for testName, tc := range tests {
-		// capture the range variable to avoid issues with concurrency
-		tc := tc
 		t.Run(testName, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			if err := tc.h.Validate(); tc.errMsg != "" {
 				require.EqualError(t, err, tc.errMsg)
@@ -1673,8 +1645,6 @@ func TestHistogramReduceResolution(t *testing.T) {
 	}
 
 	for caseName, tc := range tcs {
-		// capture the range variable to avoid issues with concurrency
-		tc := tc
 		t.Run(caseName, func(t *testing.T) {
 			target := tc.origin.ReduceResolution(tc.target.Schema)
 			require.Equal(t, tc.target, target)

--- a/model/histogram/histogram_test.go
+++ b/model/histogram/histogram_test.go
@@ -87,7 +87,11 @@ func TestHistogramString(t *testing.T) {
 	}
 
 	for i, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			actualString := c.histogram.String()
 			require.Equal(t, c.expectedString, actualString)
 		})
@@ -246,7 +250,11 @@ func TestCumulativeBucketIterator(t *testing.T) {
 	}
 
 	for i, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			it := c.histogram.CumulativeBucketIterator()
 			actualBuckets := make([]Bucket[uint64], 0, len(c.expectedBuckets))
 			for it.Next() {
@@ -462,7 +470,11 @@ func TestRegularBucketIterator(t *testing.T) {
 	}
 
 	for i, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			it := c.histogram.PositiveBucketIterator()
 			actualPositiveBuckets := make([]Bucket[uint64], 0, len(c.expectedPositiveBuckets))
 			for it.Next() {
@@ -545,7 +557,11 @@ func TestHistogramToFloat(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			fh := h.ToFloat(c.fh)
 			require.Equal(t, h.String(), fh.String())
 		})
@@ -612,7 +628,11 @@ func TestCustomBucketsHistogramToFloat(t *testing.T) {
 
 	require.NoError(t, h.Validate())
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			hStr := h.String()
 			fh := h.ToFloat(c.fh)
 			require.NoError(t, fh.Validate())
@@ -624,6 +644,8 @@ func TestCustomBucketsHistogramToFloat(t *testing.T) {
 
 // TestHistogramEquals tests both Histogram and FloatHistogram.
 func TestHistogramEquals(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	h1 := Histogram{
 		Schema:        3,
 		Count:         62,
@@ -867,7 +889,11 @@ func TestHistogramCopy(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
+		// capture the range variable to avoid issues with concurrency
+		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			hCopy := tcase.orig.Copy()
 
 			// Modify a primitive value in the original histogram.
@@ -932,7 +958,11 @@ func TestHistogramCopyTo(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
+		// capture the range variable to avoid issues with concurrency
+		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			hCopy := &Histogram{}
 			tcase.orig.CopyTo(hCopy)
 
@@ -945,6 +975,7 @@ func TestHistogramCopyTo(t *testing.T) {
 }
 
 func assertDeepCopyHSpans(t *testing.T, orig, hCopy, expected *Histogram) {
+	t.Helper()
 	// Do an in-place expansion of an original spans slice.
 	orig.PositiveSpans = expandSpans(orig.PositiveSpans)
 	orig.PositiveSpans[len(orig.PositiveSpans)-1] = Span{1, 2}
@@ -1293,7 +1324,11 @@ func TestHistogramCompact(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.Equal(t, c.expected, c.in.Compact(c.maxEmptyBuckets))
 			// Compact has happened in-place, too.
 			require.Equal(t, c.expected, c.in)
@@ -1568,7 +1603,11 @@ func TestHistogramValidation(t *testing.T) {
 	}
 
 	for testName, tc := range tests {
+		// capture the range variable to avoid issues with concurrency
+		tc := tc
 		t.Run(testName, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			if err := tc.h.Validate(); tc.errMsg != "" {
 				require.EqualError(t, err, tc.errMsg)
 			} else {
@@ -1633,10 +1672,14 @@ func TestHistogramReduceResolution(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs {
-		target := tc.origin.ReduceResolution(tc.target.Schema)
-		require.Equal(t, tc.target, target)
-		// Check that receiver histogram was mutated:
-		require.Equal(t, tc.target, tc.origin)
+	for caseName, tc := range tcs {
+		// capture the range variable to avoid issues with concurrency
+		tc := tc
+		t.Run(caseName, func(t *testing.T) {
+			target := tc.origin.ReduceResolution(tc.target.Schema)
+			require.Equal(t, tc.target, target)
+			// Check that receiver histogram was mutated:
+			require.Equal(t, tc.target, tc.origin)
+		})
 	}
 }

--- a/model/labels/labels_dedupelabels_test.go
+++ b/model/labels/labels_dedupelabels_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestVarint(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		v        int
 		expected []byte
@@ -39,6 +40,7 @@ func TestVarint(t *testing.T) {
 	}
 	var buf [16]byte
 	for _, c := range cases {
+		// tests cases cannot use parallelism because reusing the buffer causes a possible race condition
 		n := encodeVarint(buf[:], len(buf), c.v)
 		require.Equal(t, len(c.expected), len(buf)-n)
 		require.Equal(t, c.expected, buf[n:])

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -45,10 +45,7 @@ func TestLabels_String(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			str := c.labels.String()
 			require.Equal(t, c.expected, str)
@@ -133,10 +130,7 @@ func TestLabels_MatchLabels(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			got := labels.MatchLabels(test.on, test.providedNames...)
 			require.True(t, Equal(test.expected, got), "unexpected labelset for test case %d", i)
@@ -161,10 +155,7 @@ func TestLabels_HasDuplicateLabelNames(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			l, d := c.Input.HasDuplicateLabelNames()
 			require.Equal(t, c.Duplicate, d, "test %d: incorrect duplicate bool", i)
@@ -238,10 +229,7 @@ func TestLabels_WithoutEmpty(t *testing.T) {
 				"job", "check"),
 		},
 	} {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.True(t, Equal(test.expected, test.input.WithoutEmpty()))
 		})
@@ -298,10 +286,7 @@ func TestLabels_IsValid(t *testing.T) {
 			expected: false,
 		},
 	} {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, test.expected, test.input.IsValid(model.LegacyValidation))
 		})
@@ -309,7 +294,6 @@ func TestLabels_IsValid(t *testing.T) {
 }
 
 func TestLabels_ValidationModes(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	for _, test := range []struct {
 		input      Labels
@@ -423,10 +407,7 @@ func TestLabels_Equal(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			got := Equal(labels, test.compared)
 			require.Equal(t, test.expected, got, "unexpected comparison result for test case %d", i)
@@ -435,7 +416,6 @@ func TestLabels_Equal(t *testing.T) {
 }
 
 func TestLabels_FromStrings(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	labels := FromStrings("aaa", "111", "bbb", "222")
 	x := 0
@@ -535,10 +515,7 @@ func TestLabels_Compare(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			got := Compare(labels, test.compared)
 			require.Equal(t, sign(test.expected), sign(got), "unexpected comparison result for test case %d", i)
@@ -568,10 +545,7 @@ func TestLabels_Has(t *testing.T) {
 		"bbb", "222")
 
 	for i, test := range tests {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			got := labelsSet.Has(test.input)
 			require.Equal(t, test.expected, got, "unexpected comparison result for test case %d", i)
@@ -580,7 +554,6 @@ func TestLabels_Has(t *testing.T) {
 }
 
 func TestLabels_Get(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	require.Equal(t, "", FromStrings("aaa", "111", "bbb", "222").Get("foo"))
 	require.Equal(t, "111", FromStrings("aaaa", "111", "bbb", "222").Get("aaaa"))
@@ -588,7 +561,6 @@ func TestLabels_Get(t *testing.T) {
 }
 
 func TestLabels_DropMetricName(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	require.True(t, Equal(FromStrings("aaa", "111", "bbb", "222"), FromStrings("aaa", "111", "bbb", "222").DropMetricName()))
 	require.True(t, Equal(FromStrings("aaa", "111"), FromStrings(MetricName, "myname", "aaa", "111").DropMetricName()))
@@ -738,26 +710,22 @@ func BenchmarkLabels_Compare(b *testing.B) {
 }
 
 func TestLabels_Copy(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	require.Equal(t, FromStrings("aaa", "111", "bbb", "222"), FromStrings("aaa", "111", "bbb", "222").Copy())
 }
 
 func TestLabels_Map(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	require.Equal(t, map[string]string{"aaa": "111", "bbb": "222"}, FromStrings("aaa", "111", "bbb", "222").Map())
 }
 
 func TestLabels_BytesWithLabels(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	require.Equal(t, FromStrings("aaa", "111", "bbb", "222").Bytes(nil), FromStrings("aaa", "111", "bbb", "222", "ccc", "333").BytesWithLabels(nil, "aaa", "bbb"))
 	require.Equal(t, FromStrings().Bytes(nil), FromStrings("aaa", "111", "bbb", "222", "ccc", "333").BytesWithLabels(nil))
 }
 
 func TestLabels_BytesWithoutLabels(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	require.Equal(t, FromStrings("aaa", "111").Bytes(nil), FromStrings("aaa", "111", "bbb", "222", "ccc", "333").BytesWithoutLabels(nil, "bbb", "ccc"))
 	require.Equal(t, FromStrings(MetricName, "333", "aaa", "111").Bytes(nil), FromStrings(MetricName, "333", "aaa", "111", "bbb", "222").BytesWithoutLabels(nil, "bbb"))
@@ -861,12 +829,10 @@ func TestBuilder(t *testing.T) {
 			require.Equal(t, tcase.want.BytesWithoutLabels(nil, "aaa", "bbb"), b.Labels().Bytes(nil))
 		}
 		t.Run(fmt.Sprintf("NewBuilder %d", i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			test(t, NewBuilder(tcase.base))
 		})
 		t.Run(fmt.Sprintf("NewSymbolTable %d", i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			b := NewBuilderWithSymbolTable(NewSymbolTable())
 			b.Reset(tcase.base)
@@ -879,7 +845,6 @@ func TestBuilder(t *testing.T) {
 		})
 	}
 	t.Run("set_after_del", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		b := NewBuilder(FromStrings("aaa", "111"))
 		b.Del("bbb")
@@ -915,10 +880,7 @@ func TestScratchBuilder(t *testing.T) {
 			want: FromStrings("ddd", "444"),
 		},
 	} {
-		// capture the range variable to avoid issues with concurrency
-		tcase := tcase
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			b := NewScratchBuilder(len(tcase.add))
 			for _, lbl := range tcase.add {
@@ -933,7 +895,6 @@ func TestScratchBuilder(t *testing.T) {
 }
 
 func TestLabels_Hash(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	lbls := FromStrings("foo", "bar", "baz", "qux")
 	hash1, hash2 := lbls.Hash(), lbls.Hash()
@@ -1030,7 +991,6 @@ func BenchmarkLabels_Copy(b *testing.B) {
 }
 
 func TestMarshaling(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	lbls := FromStrings("aaa", "111", "bbb", "2222", "ccc", "33333")
 	expectedJSON := "{\"aaa\":\"111\",\"bbb\":\"2222\",\"ccc\":\"33333\"}"

--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func mustNewMatcher(t *testing.T, mType MatchType, value string) *Matcher {
+	t.Helper()
 	m, err := NewMatcher(mType, "test_label_name", value)
 	require.NoError(t, err)
 	return m
@@ -100,8 +101,14 @@ func TestMatcher(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		require.Equal(t, test.matcher.Matches(test.value), test.match)
+	for i, test := range tests {
+		// capture the range variable to avoid issues with concurrency
+		test := test
+		t.Run(fmt.Sprintf("%d: %s", i, test.matcher), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
+			require.Equal(t, test.matcher.Matches(test.value), test.match)
+		})
 	}
 }
 
@@ -128,10 +135,16 @@ func TestInverse(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		result, err := test.matcher.Inverse()
-		require.NoError(t, err)
-		require.Equal(t, test.expected.Type, result.Type)
+	for i, test := range tests {
+		// capture the range variable to avoid issues with concurrency
+		test := test
+		t.Run(fmt.Sprintf("%d: %s", i, test.matcher), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
+			result, err := test.matcher.Inverse()
+			require.NoError(t, err)
+			require.Equal(t, test.expected.Type, result.Type)
+		})
 	}
 }
 
@@ -181,7 +194,11 @@ func TestPrefix(t *testing.T) {
 			prefix:  "",
 		},
 	} {
+		// capture the range variable to avoid issues with concurrency
+		tc := tc
 		t.Run(fmt.Sprintf("%d: %s", i, tc.matcher), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.Equal(t, tc.prefix, tc.matcher.Prefix())
 		})
 	}
@@ -205,7 +222,11 @@ func TestIsRegexOptimized(t *testing.T) {
 			isRegexOptimized: true,
 		},
 	} {
+		// capture the range variable to avoid issues with concurrency
+		tc := tc
 		t.Run(fmt.Sprintf("%d: %s", i, tc.matcher), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.Equal(t, tc.isRegexOptimized, tc.matcher.IsRegexOptimized())
 		})
 	}

--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -102,10 +102,7 @@ func TestMatcher(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(fmt.Sprintf("%d: %s", i, test.matcher), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, test.matcher.Matches(test.value), test.match)
 		})
@@ -136,10 +133,7 @@ func TestInverse(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(fmt.Sprintf("%d: %s", i, test.matcher), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			result, err := test.matcher.Inverse()
 			require.NoError(t, err)
@@ -194,10 +188,7 @@ func TestPrefix(t *testing.T) {
 			prefix:  "",
 		},
 	} {
-		// capture the range variable to avoid issues with concurrency
-		tc := tc
 		t.Run(fmt.Sprintf("%d: %s", i, tc.matcher), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, tc.prefix, tc.matcher.Prefix())
 		})
@@ -222,10 +213,7 @@ func TestIsRegexOptimized(t *testing.T) {
 			isRegexOptimized: true,
 		},
 	} {
-		// capture the range variable to avoid issues with concurrency
-		tc := tc
 		t.Run(fmt.Sprintf("%d: %s", i, tc.matcher), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, tc.isRegexOptimized, tc.matcher.IsRegexOptimized())
 		})

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -167,10 +167,7 @@ func TestOptimizeConcatRegex(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.regex, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			parsed, err := syntax.Parse(c.regex, syntax.Perl|syntax.DotNL)
 			require.NoError(t, err)
@@ -272,7 +269,6 @@ func TestFindSetMatches(t *testing.T) {
 }
 
 func TestFastRegexMatcher_SetMatches_ShouldReturnACopy(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	m, err := NewFastRegexMatcher("a|b")
 	require.NoError(t, err)
@@ -482,10 +478,7 @@ func TestStringMatcherFromRegexp_LiteralPrefix(t *testing.T) {
 			expectedNotMatches:            []string{"XYZ-aaa", "xyz-aa", "yz-aaa", "aaa"},
 		},
 	} {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.pattern, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			parsed, err := syntax.Parse(c.pattern, syntax.Perl|syntax.DotNL)
 			require.NoError(t, err)
@@ -564,10 +557,7 @@ func TestStringMatcherFromRegexp_LiteralSuffix(t *testing.T) {
 			expectedNotMatches:            []string{"AAA", "XXXAAA", "BBBccc", "BBBCCC", "aaaBBB"},
 		},
 	} {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.pattern, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			parsed, err := syntax.Parse(c.pattern, syntax.Perl|syntax.DotNL)
 			require.NoError(t, err)
@@ -653,10 +643,7 @@ func TestStringMatcherFromRegexp_Quest(t *testing.T) {
 			expectedNotMatches:        []string{"aa", "Xbbb", "\nbbb"},
 		},
 	} {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.pattern, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			parsed, err := syntax.Parse(c.pattern, syntax.Perl|syntax.DotNL)
 			require.NoError(t, err)
@@ -797,10 +784,7 @@ func TestOptimizeEqualOrPrefixStringMatchers(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
-		// capture the range variable to avoid issues with concurrency
-		testData := testData
 		t.Run(testName, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			actualMatcher := optimizeEqualOrPrefixStringMatchers(testData.input, 0)
 
@@ -856,10 +840,7 @@ func TestNewEqualMultiStringMatcher(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
-		// capture the range variable to avoid issues with concurrency
-		testData := testData
 		t.Run(testName, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			// To keep this test simple, we always assume a min prefix length of 1.
 			minPrefixLength := 0
@@ -892,7 +873,6 @@ func TestNewEqualMultiStringMatcher(t *testing.T) {
 
 func TestEqualMultiStringMapMatcher_addPrefix(t *testing.T) {
 	t.Run("should panic if the matcher is case sensitive but the prefix is not case sensitive", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		matcher := newEqualMultiStringMatcher(true, 0, 1, 1)
 
@@ -904,7 +884,6 @@ func TestEqualMultiStringMapMatcher_addPrefix(t *testing.T) {
 	})
 
 	t.Run("should panic if the matcher is not case sensitive but the prefix is case sensitive", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		matcher := newEqualMultiStringMatcher(false, 0, 1, 1)
 
@@ -976,10 +955,7 @@ func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
-		// capture the range variable to avoid issues with concurrency
-		testData := testData
 		t.Run(testName, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			// To keep this test simple, we always assume a min prefix length of 1.
 			minPrefixLength := 0
@@ -1032,7 +1008,6 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	}
 
 	t.Run("empty matcher", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(emptyStringMatcher{})
 		require.False(t, actualOk)
@@ -1040,7 +1015,6 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal matchers (case sensitive)", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
@@ -1054,7 +1028,6 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal matchers (case insensitive)", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
@@ -1068,7 +1041,6 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal matchers (mixed case)", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
@@ -1082,7 +1054,6 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal prefix matchers (case sensitive)", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
@@ -1096,7 +1067,6 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal prefix matchers (case insensitive)", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
@@ -1110,7 +1080,6 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal prefix matchers (mixed case)", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
@@ -1124,7 +1093,6 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal string and prefix matchers (case sensitive)", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
@@ -1201,7 +1169,6 @@ func BenchmarkOptimizeEqualOrPrefixStringMatchers(b *testing.B) {
 
 func TestZeroOrOneCharacterStringMatcher(t *testing.T) {
 	t.Run("match newline", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		matcher := &zeroOrOneCharacterStringMatcher{matchNL: true}
 		require.True(t, matcher.Matches(""))
@@ -1212,7 +1179,6 @@ func TestZeroOrOneCharacterStringMatcher(t *testing.T) {
 	})
 
 	t.Run("do not match newline", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		matcher := &zeroOrOneCharacterStringMatcher{matchNL: false}
 		require.True(t, matcher.Matches(""))
@@ -1223,7 +1189,6 @@ func TestZeroOrOneCharacterStringMatcher(t *testing.T) {
 	})
 
 	t.Run("unicode", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		// Just for documentation purposes, emoji1 is 1 rune, emoji2 is 2 runes.
 		// Having this in mind, will make future readers fixing tests easier.
@@ -1242,7 +1207,6 @@ func TestZeroOrOneCharacterStringMatcher(t *testing.T) {
 	})
 
 	t.Run("invalid unicode", func(t *testing.T) {
-		// mark this test case as being run in parallel
 		t.Parallel()
 		// Just for reference, we also compare to what `^.?$` regular expression matches.
 		re := regexp.MustCompile("^.?$")
@@ -1296,7 +1260,6 @@ func BenchmarkZeroOrOneCharacterStringMatcher(b *testing.B) {
 }
 
 func TestLiteralPrefixSensitiveStringMatcher(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	m := &literalPrefixSensitiveStringMatcher{prefix: "mar", right: &emptyStringMatcher{}}
 	require.True(t, m.Matches("mar"))
@@ -1313,7 +1276,6 @@ func TestLiteralPrefixSensitiveStringMatcher(t *testing.T) {
 }
 
 func TestLiteralPrefixInsensitiveStringMatcher(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	m := &literalPrefixInsensitiveStringMatcher{prefix: "mar", right: &emptyStringMatcher{}}
 	require.True(t, m.Matches("mar"))
@@ -1323,7 +1285,6 @@ func TestLiteralPrefixInsensitiveStringMatcher(t *testing.T) {
 }
 
 func TestLiteralSuffixStringMatcher(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	m := &literalSuffixStringMatcher{left: &emptyStringMatcher{}, suffix: "co", suffixCaseSensitive: true}
 	require.True(t, m.Matches("co"))
@@ -1353,7 +1314,6 @@ func TestLiteralSuffixStringMatcher(t *testing.T) {
 }
 
 func TestHasPrefixCaseInsensitive(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	require.True(t, hasPrefixCaseInsensitive("marco", "mar"))
 	require.True(t, hasPrefixCaseInsensitive("mArco", "mar"))
@@ -1366,7 +1326,6 @@ func TestHasPrefixCaseInsensitive(t *testing.T) {
 }
 
 func TestHasSuffixCaseInsensitive(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	require.True(t, hasSuffixCaseInsensitive("marco", "rco"))
 	require.True(t, hasSuffixCaseInsensitive("marco", "RcO"))
@@ -1376,7 +1335,6 @@ func TestHasSuffixCaseInsensitive(t *testing.T) {
 }
 
 func TestContainsInOrder(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	require.True(t, containsInOrder("abcdefghilmno", []string{"ab", "cd", "no"}))
 	require.True(t, containsInOrder("abcdefghilmno", []string{"def", "hil"}))
@@ -1464,7 +1422,6 @@ func TestToNormalisedLower(t *testing.T) {
 	}
 	for input, expectedOutput := range testCases {
 		t.Run(input, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, expectedOutput, toNormalisedLower(input, nil))
 		})

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -167,13 +167,19 @@ func TestOptimizeConcatRegex(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		parsed, err := syntax.Parse(c.regex, syntax.Perl|syntax.DotNL)
-		require.NoError(t, err)
+		// capture the range variable to avoid issues with concurrency
+		c := c
+		t.Run(c.regex, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
+			parsed, err := syntax.Parse(c.regex, syntax.Perl|syntax.DotNL)
+			require.NoError(t, err)
 
-		prefix, suffix, contains := optimizeConcatRegex(parsed)
-		require.Equal(t, c.prefix, prefix)
-		require.Equal(t, c.suffix, suffix)
-		require.Equal(t, c.contains, contains)
+			prefix, suffix, contains := optimizeConcatRegex(parsed)
+			require.Equal(t, c.prefix, prefix)
+			require.Equal(t, c.suffix, suffix)
+			require.Equal(t, c.contains, contains)
+		})
 	}
 }
 
@@ -266,6 +272,8 @@ func TestFindSetMatches(t *testing.T) {
 }
 
 func TestFastRegexMatcher_SetMatches_ShouldReturnACopy(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	m, err := NewFastRegexMatcher("a|b")
 	require.NoError(t, err)
 	require.Equal(t, []string{"a", "b"}, m.SetMatches())
@@ -474,7 +482,11 @@ func TestStringMatcherFromRegexp_LiteralPrefix(t *testing.T) {
 			expectedNotMatches:            []string{"XYZ-aaa", "xyz-aa", "yz-aaa", "aaa"},
 		},
 	} {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.pattern, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			parsed, err := syntax.Parse(c.pattern, syntax.Perl|syntax.DotNL)
 			require.NoError(t, err)
 
@@ -552,7 +564,11 @@ func TestStringMatcherFromRegexp_LiteralSuffix(t *testing.T) {
 			expectedNotMatches:            []string{"AAA", "XXXAAA", "BBBccc", "BBBCCC", "aaaBBB"},
 		},
 	} {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.pattern, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			parsed, err := syntax.Parse(c.pattern, syntax.Perl|syntax.DotNL)
 			require.NoError(t, err)
 
@@ -637,7 +653,11 @@ func TestStringMatcherFromRegexp_Quest(t *testing.T) {
 			expectedNotMatches:        []string{"aa", "Xbbb", "\nbbb"},
 		},
 	} {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.pattern, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			parsed, err := syntax.Parse(c.pattern, syntax.Perl|syntax.DotNL)
 			require.NoError(t, err)
 
@@ -777,7 +797,11 @@ func TestOptimizeEqualOrPrefixStringMatchers(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		// capture the range variable to avoid issues with concurrency
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			actualMatcher := optimizeEqualOrPrefixStringMatchers(testData.input, 0)
 
 			if testData.expectedValues == nil {
@@ -832,7 +856,11 @@ func TestNewEqualMultiStringMatcher(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		// capture the range variable to avoid issues with concurrency
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			// To keep this test simple, we always assume a min prefix length of 1.
 			minPrefixLength := 0
 			if len(testData.caseSensitivePrefixes) > 0 {
@@ -864,6 +892,8 @@ func TestNewEqualMultiStringMatcher(t *testing.T) {
 
 func TestEqualMultiStringMapMatcher_addPrefix(t *testing.T) {
 	t.Run("should panic if the matcher is case sensitive but the prefix is not case sensitive", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		matcher := newEqualMultiStringMatcher(true, 0, 1, 1)
 
 		require.Panics(t, func() {
@@ -874,6 +904,8 @@ func TestEqualMultiStringMapMatcher_addPrefix(t *testing.T) {
 	})
 
 	t.Run("should panic if the matcher is not case sensitive but the prefix is case sensitive", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		matcher := newEqualMultiStringMatcher(false, 0, 1, 1)
 
 		require.Panics(t, func() {
@@ -944,7 +976,11 @@ func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		// capture the range variable to avoid issues with concurrency
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			// To keep this test simple, we always assume a min prefix length of 1.
 			minPrefixLength := 0
 			if len(testData.prefixes) > 0 {
@@ -996,12 +1032,16 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	}
 
 	t.Run("empty matcher", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(emptyStringMatcher{})
 		require.False(t, actualOk)
 		require.Empty(t, actualMatches)
 	})
 
 	t.Run("concat of literal matchers (case sensitive)", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&equalStringMatcher{s: "test-1", caseSensitive: true},
@@ -1014,6 +1054,8 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal matchers (case insensitive)", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&equalStringMatcher{s: "test-1", caseSensitive: false},
@@ -1026,6 +1068,8 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal matchers (mixed case)", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&equalStringMatcher{s: "test-1", caseSensitive: false},
@@ -1038,6 +1082,8 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal prefix matchers (case sensitive)", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&literalPrefixSensitiveStringMatcher{prefix: "test-1"},
@@ -1050,6 +1096,8 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal prefix matchers (case insensitive)", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&literalPrefixInsensitiveStringMatcher{prefix: "test-1"},
@@ -1062,6 +1110,8 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal prefix matchers (mixed case)", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&literalPrefixInsensitiveStringMatcher{prefix: "test-1"},
@@ -1074,6 +1124,8 @@ func TestFindEqualOrPrefixStringMatchers(t *testing.T) {
 	})
 
 	t.Run("concat of literal string and prefix matchers (case sensitive)", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		actualMatches, actualOk := findEqualOrPrefixStringMatchersAndCollectMatches(
 			orStringMatcher{
 				&equalStringMatcher{s: "test-1", caseSensitive: true},
@@ -1149,6 +1201,8 @@ func BenchmarkOptimizeEqualOrPrefixStringMatchers(b *testing.B) {
 
 func TestZeroOrOneCharacterStringMatcher(t *testing.T) {
 	t.Run("match newline", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		matcher := &zeroOrOneCharacterStringMatcher{matchNL: true}
 		require.True(t, matcher.Matches(""))
 		require.True(t, matcher.Matches("x"))
@@ -1158,6 +1212,8 @@ func TestZeroOrOneCharacterStringMatcher(t *testing.T) {
 	})
 
 	t.Run("do not match newline", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		matcher := &zeroOrOneCharacterStringMatcher{matchNL: false}
 		require.True(t, matcher.Matches(""))
 		require.True(t, matcher.Matches("x"))
@@ -1167,6 +1223,8 @@ func TestZeroOrOneCharacterStringMatcher(t *testing.T) {
 	})
 
 	t.Run("unicode", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		// Just for documentation purposes, emoji1 is 1 rune, emoji2 is 2 runes.
 		// Having this in mind, will make future readers fixing tests easier.
 		emoji1 := "😀"
@@ -1184,6 +1242,8 @@ func TestZeroOrOneCharacterStringMatcher(t *testing.T) {
 	})
 
 	t.Run("invalid unicode", func(t *testing.T) {
+		// mark this test case as being run in parallel
+		t.Parallel()
 		// Just for reference, we also compare to what `^.?$` regular expression matches.
 		re := regexp.MustCompile("^.?$")
 		matcher := &zeroOrOneCharacterStringMatcher{matchNL: true}
@@ -1236,6 +1296,8 @@ func BenchmarkZeroOrOneCharacterStringMatcher(b *testing.B) {
 }
 
 func TestLiteralPrefixSensitiveStringMatcher(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	m := &literalPrefixSensitiveStringMatcher{prefix: "mar", right: &emptyStringMatcher{}}
 	require.True(t, m.Matches("mar"))
 	require.False(t, m.Matches("marco"))
@@ -1251,6 +1313,8 @@ func TestLiteralPrefixSensitiveStringMatcher(t *testing.T) {
 }
 
 func TestLiteralPrefixInsensitiveStringMatcher(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	m := &literalPrefixInsensitiveStringMatcher{prefix: "mar", right: &emptyStringMatcher{}}
 	require.True(t, m.Matches("mar"))
 	require.False(t, m.Matches("marco"))
@@ -1259,6 +1323,8 @@ func TestLiteralPrefixInsensitiveStringMatcher(t *testing.T) {
 }
 
 func TestLiteralSuffixStringMatcher(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	m := &literalSuffixStringMatcher{left: &emptyStringMatcher{}, suffix: "co", suffixCaseSensitive: true}
 	require.True(t, m.Matches("co"))
 	require.False(t, m.Matches("marco"))
@@ -1287,6 +1353,8 @@ func TestLiteralSuffixStringMatcher(t *testing.T) {
 }
 
 func TestHasPrefixCaseInsensitive(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	require.True(t, hasPrefixCaseInsensitive("marco", "mar"))
 	require.True(t, hasPrefixCaseInsensitive("mArco", "mar"))
 	require.True(t, hasPrefixCaseInsensitive("marco", "MaR"))
@@ -1298,6 +1366,8 @@ func TestHasPrefixCaseInsensitive(t *testing.T) {
 }
 
 func TestHasSuffixCaseInsensitive(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	require.True(t, hasSuffixCaseInsensitive("marco", "rco"))
 	require.True(t, hasSuffixCaseInsensitive("marco", "RcO"))
 	require.True(t, hasSuffixCaseInsensitive("marco", "marco"))
@@ -1306,6 +1376,8 @@ func TestHasSuffixCaseInsensitive(t *testing.T) {
 }
 
 func TestContainsInOrder(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	require.True(t, containsInOrder("abcdefghilmno", []string{"ab", "cd", "no"}))
 	require.True(t, containsInOrder("abcdefghilmno", []string{"def", "hil"}))
 
@@ -1391,6 +1463,10 @@ func TestToNormalisedLower(t *testing.T) {
 		"ſſAſſa": "ssassa",
 	}
 	for input, expectedOutput := range testCases {
-		require.Equal(t, expectedOutput, toNormalisedLower(input, nil))
+		t.Run(input, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
+			require.Equal(t, expectedOutput, toNormalisedLower(input, nil))
+		})
 	}
 }

--- a/model/labels/sharding_test.go
+++ b/model/labels/sharding_test.go
@@ -28,10 +28,7 @@ func TestStableHash(t *testing.T) {
 		0x347c8ee7a9e29708: FromStrings("hello", "world"),
 		0xcbab40540f26097d: FromStrings(MetricName, "metric", "label", "value"),
 	} {
-		// capture the range variable to avoid issues with concurrency
-		lbls := lbls
 		t.Run(fmt.Sprintf("hash %d", expectedHash), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, expectedHash, StableHash(lbls))
 		})

--- a/model/labels/sharding_test.go
+++ b/model/labels/sharding_test.go
@@ -14,6 +14,7 @@
 package labels
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,6 +28,12 @@ func TestStableHash(t *testing.T) {
 		0x347c8ee7a9e29708: FromStrings("hello", "world"),
 		0xcbab40540f26097d: FromStrings(MetricName, "metric", "label", "value"),
 	} {
-		require.Equal(t, expectedHash, StableHash(lbls))
+		// capture the range variable to avoid issues with concurrency
+		lbls := lbls
+		t.Run(fmt.Sprintf("hash %d", expectedHash), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
+			require.Equal(t, expectedHash, StableHash(lbls))
+		})
 	}
 }

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -697,10 +697,7 @@ func TestRelabel(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			// Setting default fields, mimicking the behaviour in Prometheus.
 			for _, cfg := range test.relabel {
@@ -785,10 +782,7 @@ func TestRelabelValidate(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			err := test.config.Validate()
 			if test.expected == "" {
@@ -822,10 +816,7 @@ func TestTargetLabelLegacyValidity(t *testing.T) {
 		{"_${1}_", true},
 		{"foo${bar}foo", true},
 	} {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(test.str, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.Equal(t, test.valid, relabelTargetLegacy.Match([]byte(test.str)),
 				"Expected %q to be %v", test.str, test.valid)
@@ -1054,10 +1045,7 @@ action: replace
 		},
 	}
 	for _, test := range tests {
-		// capture the range variable to avoid issues with concurrency
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			unmarshalled := Config{}
 			err := yaml.Unmarshal([]byte(test.inputYaml), &unmarshalled)
@@ -1072,7 +1060,6 @@ action: replace
 }
 
 func TestRegexp_ShouldMarshalAndUnmarshalZeroValue(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	var zero Regexp
 

--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"io"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,8 @@ import (
 )
 
 func TestParseFileSuccess(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	_, errs := ParseFile("testdata/test.yaml", false)
 	require.Empty(t, errs, "unexpected errors parsing file")
 
@@ -79,7 +82,11 @@ func TestParseFileFailure(t *testing.T) {
 			errMsg:   "invalid field 'keep_firing_for' in recording rule",
 		},
 	} {
+		// capture the range variable to avoid issues with concurrency
+		c := c
 		t.Run(c.filename, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			_, errs := ParseFile(filepath.Join("testdata", c.filename), false)
 			require.NotEmpty(t, errs, "Expected error parsing %s but got none", c.filename)
 			require.ErrorContainsf(t, errs[0], c.errMsg, "Expected error for %s.", c.filename)
@@ -175,15 +182,23 @@ groups:
 		},
 	}
 
-	for _, tst := range tests {
-		rgs, errs := Parse([]byte(tst.ruleString), false)
-		require.NotNil(t, rgs, "Rule parsing, rule=\n"+tst.ruleString)
-		passed := (tst.shouldPass && len(errs) == 0) || (!tst.shouldPass && len(errs) > 0)
-		require.True(t, passed, "Rule validation failed, rule=\n"+tst.ruleString)
+	for i, tst := range tests {
+		// capture the range variable to avoid issues with concurrency
+		tst := tst
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
+			rgs, errs := Parse([]byte(tst.ruleString), false)
+			require.NotNil(t, rgs, "Rule parsing, rule=\n"+tst.ruleString)
+			passed := (tst.shouldPass && len(errs) == 0) || (!tst.shouldPass && len(errs) > 0)
+			require.True(t, passed, "Rule validation failed, rule=\n"+tst.ruleString)
+		})
 	}
 }
 
 func TestUniqueErrorNodes(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	group := `
 groups:
 - name: example
@@ -271,7 +286,11 @@ func TestError(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		// capture the range variable to avoid issues with concurrency
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.EqualError(t, tt.error, tt.want)
 		})
 	}
@@ -319,7 +338,11 @@ func TestWrappedError(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		// capture the range variable to avoid issues with concurrency
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.EqualError(t, tt.wrappedError, tt.want)
 		})
 	}
@@ -343,7 +366,11 @@ func TestErrorUnwrap(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		// capture the range variable to avoid issues with concurrency
+		tt := tt
 		t.Run(tt.wrappedError.Error(), func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			require.ErrorIs(t, tt.wrappedError, tt.unwrappedError)
 		})
 	}

--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestParseFileSuccess(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	_, errs := ParseFile("testdata/test.yaml", false)
 	require.Empty(t, errs, "unexpected errors parsing file")
@@ -82,10 +81,7 @@ func TestParseFileFailure(t *testing.T) {
 			errMsg:   "invalid field 'keep_firing_for' in recording rule",
 		},
 	} {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(c.filename, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			_, errs := ParseFile(filepath.Join("testdata", c.filename), false)
 			require.NotEmpty(t, errs, "Expected error parsing %s but got none", c.filename)
@@ -183,10 +179,7 @@ groups:
 	}
 
 	for i, tst := range tests {
-		// capture the range variable to avoid issues with concurrency
-		tst := tst
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			rgs, errs := Parse([]byte(tst.ruleString), false)
 			require.NotNil(t, rgs, "Rule parsing, rule=\n"+tst.ruleString)
@@ -197,7 +190,6 @@ groups:
 }
 
 func TestUniqueErrorNodes(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	group := `
 groups:
@@ -286,10 +278,7 @@ func TestError(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		// capture the range variable to avoid issues with concurrency
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.EqualError(t, tt.error, tt.want)
 		})
@@ -338,10 +327,7 @@ func TestWrappedError(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		// capture the range variable to avoid issues with concurrency
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.EqualError(t, tt.wrappedError, tt.want)
 		})
@@ -366,10 +352,7 @@ func TestErrorUnwrap(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		// capture the range variable to avoid issues with concurrency
-		tt := tt
 		t.Run(tt.wrappedError.Error(), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			require.ErrorIs(t, tt.wrappedError, tt.unwrappedError)
 		})

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -159,7 +159,6 @@ func TestNewParser(t *testing.T) {
 			err:                    "received unsupported Content-Type \"text/html\", using fallback_scrape_protocol \"text/plain\"",
 		},
 	} {
-		tt := tt // Copy to local variable before going parallel.
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func TestNewParser(t *testing.T) {
-	t.Parallel()
-
 	requireNilParser := func(t *testing.T, p Parser) {
 		require.Nil(t, p)
 	}
@@ -161,8 +159,8 @@ func TestNewParser(t *testing.T) {
 			err:                    "received unsupported Content-Type \"text/html\", using fallback_scrape_protocol \"text/plain\"",
 		},
 	} {
+		tt := tt // Copy to local variable before going parallel.
 		t.Run(name, func(t *testing.T) {
-			tt := tt // Copy to local variable before going parallel.
 			t.Parallel()
 
 			fallbackProtoMediaType := tt.fallbackScrapeProtocol.HeaderMediaType()

--- a/model/textparse/nhcbparse_test.go
+++ b/model/textparse/nhcbparse_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestNHCBParserOnOMParser(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	// The input is taken originally from TestOpenMetricsParse, with additional tests for the NHCBParser.
 
@@ -456,7 +455,6 @@ foobar{quantile="0.99"} 150.1`
 }
 
 func TestNHCBParserOMParser_MultipleHistograms(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	// The input is taken originally from TestOpenMetricsParse, with additional tests for the NHCBParser.
 
@@ -764,10 +762,7 @@ func TestNHCBParser_NoNHCBWhenExponential(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		// capture the range variable to avoid issues with concurrency
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			p := tc.parser(tc.classic)
 			if tc.nhcb {

--- a/model/textparse/nhcbparse_test.go
+++ b/model/textparse/nhcbparse_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 func TestNHCBParserOnOMParser(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	// The input is taken originally from TestOpenMetricsParse, with additional tests for the NHCBParser.
 
 	input := `# HELP go_gc_duration_seconds A summary of the GC invocation durations.
@@ -454,6 +456,8 @@ foobar{quantile="0.99"} 150.1`
 }
 
 func TestNHCBParserOMParser_MultipleHistograms(t *testing.T) {
+	// mark this test case as being run in parallel
+	t.Parallel()
 	// The input is taken originally from TestOpenMetricsParse, with additional tests for the NHCBParser.
 
 	input := `# HELP something Histogram with _created between buckets and summary
@@ -760,7 +764,11 @@ func TestNHCBParser_NoNHCBWhenExponential(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		// capture the range variable to avoid issues with concurrency
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			// mark this test case as being run in parallel
+			t.Parallel()
 			p := tc.parser(tc.classic)
 			if tc.nhcb {
 				p = NewNHCBParser(p, labels.NewSymbolTable(), tc.classic)
@@ -772,6 +780,7 @@ func TestNHCBParser_NoNHCBWhenExponential(t *testing.T) {
 }
 
 func createTestProtoBufHistogram(t *testing.T) *bytes.Buffer {
+	t.Helper()
 	testMetricFamilies := []string{`name: "test_histogram1"
 help: "Test histogram 1"
 type: HISTOGRAM

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -29,7 +29,6 @@ import (
 func int64p(x int64) *int64 { return &x }
 
 func TestOpenMetricsParse(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	input := `# HELP go_gc_duration_seconds A summary of the GC invocation durations.
 # TYPE go_gc_duration_seconds summary
@@ -855,10 +854,7 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			p := NewOpenMetricsParser([]byte(c.input), labels.NewSymbolTable(), WithOMParserCTSeriesSkipped())
 			var err error
@@ -926,10 +922,7 @@ func TestOMNullByteHandling(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			p := NewOpenMetricsParser([]byte(c.input), labels.NewSymbolTable(), WithOMParserCTSeriesSkipped())
 			var err error
@@ -1035,10 +1028,7 @@ foo_created{a="b"} 1520872608.123
 			},
 		},
 	} {
-		// capture the range variable to avoid issues with concurrency
-		tcase := tcase
 		t.Run(fmt.Sprintf("case=%v", tcase.name), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			p := NewOpenMetricsParser([]byte(tcase.input), labels.NewSymbolTable(), WithOMParserCTSeriesSkipped())
 			got := testParse(t, p)

--- a/model/textparse/promparse_test.go
+++ b/model/textparse/promparse_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestPromParse(t *testing.T) {
-	// mark this test case as being run in parallel
 	t.Parallel()
 	input := `# HELP go_gc_duration_seconds A summary of the GC invocation durations.
 # 	TYPE go_gc_duration_seconds summary
@@ -365,10 +364,7 @@ func TestPromParseErrors(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			p := NewPromParser([]byte(c.input), labels.NewSymbolTable())
 			var err error
@@ -424,10 +420,7 @@ func TestPromNullByteHandling(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// capture the range variable to avoid issues with concurrency
-		c := c
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			p := NewPromParser([]byte(c.input), labels.NewSymbolTable())
 			var err error

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -2532,13 +2532,13 @@ func TestProtobufParse(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
+		// capture the range variable to avoid issues with concurrency
+		scenario := scenario
 		t.Run(scenario.name, func(t *testing.T) {
-			var (
-				p   = scenario.parser
-				exp = scenario.expected
-			)
-			got := testParse(t, p)
-			requireEntries(t, exp, got)
+			// mark this test case as being run in parallel
+			t.Parallel()
+			got := testParse(t, scenario.parser)
+			requireEntries(t, scenario.expected, got)
 		})
 	}
 }

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -2532,10 +2532,7 @@ func TestProtobufParse(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
-		// capture the range variable to avoid issues with concurrency
-		scenario := scenario
 		t.Run(scenario.name, func(t *testing.T) {
-			// mark this test case as being run in parallel
 			t.Parallel()
 			got := testParse(t, scenario.parser)
 			requireEntries(t, scenario.expected, got)


### PR DESCRIPTION
I have added `t.Parallel()` to most tests in the models package as part of the checklist outlined in #15185.

Below is a comparison of execution times before and after these changes.

Before:

```bash
$ go test --tags=dedupelabels -race --count=1 ./model/...
?       github.com/prometheus/prometheus/model/exemplar [no test files]
?       github.com/prometheus/prometheus/model/metadata [no test files]
ok      github.com/prometheus/prometheus/model/histogram        1.095s
?       github.com/prometheus/prometheus/model/timestamp        [no test files]
?       github.com/prometheus/prometheus/model/value    [no test files]
ok      github.com/prometheus/prometheus/model/labels   3.038s
ok      github.com/prometheus/prometheus/model/relabel  1.086s
ok      github.com/prometheus/prometheus/model/rulefmt  1.091s
ok      github.com/prometheus/prometheus/model/textparse        1.293s
```

After:

```bash
$ go test --tags=dedupelabels -race --count=1 ./model/...
?       github.com/prometheus/prometheus/model/exemplar [no test files]
?       github.com/prometheus/prometheus/model/metadata [no test files]
?       github.com/prometheus/prometheus/model/timestamp        [no test files]
?       github.com/prometheus/prometheus/model/value    [no test files]
ok      github.com/prometheus/prometheus/model/histogram        1.059s
ok      github.com/prometheus/prometheus/model/labels   2.792s
ok      github.com/prometheus/prometheus/model/relabel  1.046s
ok      github.com/prometheus/prometheus/model/rulefmt  1.040s
ok      github.com/prometheus/prometheus/model/textparse        1.270s
```

The performance improvements are not as significant as in related PRs, but there is still a noticeable gain. Some tests cannot run in parallel due to race conditions caused by the use of global variables. Additionally, I left Benchmark tests in certain subpackages untouched. ~Interestingly, the execution time for the textparse package increased slightly, though the exact reason is unclear.~

Edit: I realized that some of the tests require a build label, which I had initially overlooked. I've updated the test results accordingly, and now all the subpackages show a gain, even if it's a slight one.
