### PR TITLE
scrape: stop erroring on empty scrapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* [BUGFIX] Scraping: Don't log errors on empty scrapes. #15352
 * [CHANGE] Scraping: Remove implicit fallback to the Prometheus text format in case of invalid/missing Content-Type and fail the scrape instead. Add ability to specify a `fallback_scrape_protocol` in the scrape config. #15136
 * [CHANGE] Remote-write: default enable_http2 to false. #15219
 * [CHANGE] Scraping: normalize "le" and "quantile" label values upon ingestion. #15164

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1886,7 +1886,7 @@ loop:
 		sl.l.Warn("Error on ingesting out-of-order exemplars", "num_dropped", appErrs.numExemplarOutOfOrder)
 	}
 	if err == nil {
-		sl.updateStaleMarkers(app, defTime)
+		err = sl.updateStaleMarkers(app, defTime)
 	}
 	return
 }


### PR DESCRIPTION
Fixes #15337.

Empty scrapes should not cause an error (from lack of Content-Type) or fail to append a stale marker.

Existing tests have been updated to stop defaulting to "text/plain" except in cases where no header is provided and the fallback protocol has to be specified explicitly.

New tests added to cover negative (non-blank scrape with no `Content-Type` header) and positive cases (blank scrape with no `Content-Type header`).