### PR TITLE
Parallelize tests for `prompb` package

### DIFF
--- a/prompb/io/prometheus/write/v2/custom_test.go
+++ b/prompb/io/prometheus/write/v2/custom_test.go
@@ -77,6 +77,7 @@ func TestOptimizedMarshal(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// Keep the slice allocated to mimic what std Marshal
 			// would give to sized Marshal.
 			got := make([]byte, 0)

--- a/prompb/io/prometheus/write/v2/types_test.go
+++ b/prompb/io/prometheus/write/v2/types_test.go
@@ -45,6 +45,7 @@ func TestInteropV2UnmarshalWithV1_DeterministicEmpty(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
 			in, err := proto.Marshal(tc.incoming)
 			require.NoError(t, err)
 
@@ -80,6 +81,7 @@ func TestInteropV1UnmarshalWithV2_DeterministicEmpty(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
 			in, err := proto.Marshal(tc.incoming)
 			require.NoError(t, err)
 

--- a/prompb/rwcommon/codec_test.go
+++ b/prompb/rwcommon/codec_test.go
@@ -30,6 +30,7 @@ func TestToLabels(t *testing.T) {
 	expected := labels.FromStrings("__name__", "metric1", "foo", "bar")
 
 	t.Run("v1", func(t *testing.T) {
+		t.Parallel()
 		ts := prompb.TimeSeries{Labels: []prompb.Label{{Name: "__name__", Value: "metric1"}, {Name: "foo", Value: "bar"}}}
 		b := labels.NewScratchBuilder(2)
 		require.Equal(t, expected, ts.ToLabels(&b, nil))
@@ -37,6 +38,7 @@ func TestToLabels(t *testing.T) {
 		require.Equal(t, ts.Labels, prompb.FromLabels(expected, ts.Labels))
 	})
 	t.Run("v2", func(t *testing.T) {
+		t.Parallel()
 		v2Symbols := []string{"", "__name__", "metric1", "foo", "bar"}
 		ts := writev2.TimeSeries{LabelsRefs: []uint32{1, 2, 3, 4}}
 		b := labels.NewScratchBuilder(2)
@@ -73,9 +75,11 @@ func TestFromMetadataType(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Run("v1", func(t *testing.T) {
+				t.Parallel()
 				require.Equal(t, tc.expectedV1, prompb.FromMetadataType(tc.input))
 			})
 			t.Run("v2", func(t *testing.T) {
+				t.Parallel()
 				require.Equal(t, tc.expectedV2, writev2.FromMetadataType(tc.input))
 			})
 		})
@@ -127,6 +131,7 @@ func TestToMetadata(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
 			ts := writev2.TimeSeries{Metadata: tc.input}
 			require.Equal(t, tc.expected, ts.ToMetadata(sym.Symbols()))
 		})
@@ -135,10 +140,12 @@ func TestToMetadata(t *testing.T) {
 
 func TestToHistogram_Empty(t *testing.T) {
 	t.Run("v1", func(t *testing.T) {
+		t.Parallel()
 		require.NotNilf(t, prompb.Histogram{}.ToIntHistogram(), "")
 		require.NotNilf(t, prompb.Histogram{}.ToFloatHistogram(), "")
 	})
 	t.Run("v2", func(t *testing.T) {
+		t.Parallel()
 		require.NotNilf(t, writev2.Histogram{}.ToIntHistogram(), "")
 		require.NotNilf(t, writev2.Histogram{}.ToFloatHistogram(), "")
 	})
@@ -196,6 +203,7 @@ func testFloatHistogram() histogram.FloatHistogram {
 
 func TestFromIntToFloatOrIntHistogram(t *testing.T) {
 	t.Run("v1", func(t *testing.T) {
+		t.Parallel()
 		// v1 does not support nhcb.
 		testIntHistWithoutNHCB := testIntHistogram()
 		testIntHistWithoutNHCB.CustomValues = nil
@@ -209,6 +217,7 @@ func TestFromIntToFloatOrIntHistogram(t *testing.T) {
 		require.Equal(t, testFloatHistWithoutNHCB, *h.ToFloatHistogram())
 	})
 	t.Run("v2", func(t *testing.T) {
+		t.Parallel()
 		testIntHist := testIntHistogram()
 		testFloatHist := testFloatHistogram()
 
@@ -222,6 +231,7 @@ func TestFromIntToFloatOrIntHistogram(t *testing.T) {
 
 func TestFromFloatToFloatHistogram(t *testing.T) {
 	t.Run("v1", func(t *testing.T) {
+		t.Parallel()
 		// v1 does not support nhcb.
 		testFloatHistWithoutNHCB := testFloatHistogram()
 		testFloatHistWithoutNHCB.CustomValues = nil
@@ -233,6 +243,7 @@ func TestFromFloatToFloatHistogram(t *testing.T) {
 		require.Equal(t, testFloatHistWithoutNHCB, *h.ToFloatHistogram())
 	})
 	t.Run("v2", func(t *testing.T) {
+		t.Parallel()
 		testFloatHist := testFloatHistogram()
 
 		h := writev2.FromFloatHistogram(123, &testFloatHist)
@@ -272,6 +283,7 @@ func TestFromIntOrFloatHistogram_ResetHint(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			t.Run("v1", func(t *testing.T) {
+				t.Parallel()
 				h := testIntHistogram()
 				h.CounterResetHint = tc.input
 				got := prompb.FromIntHistogram(1337, &h)
@@ -283,6 +295,7 @@ func TestFromIntOrFloatHistogram_ResetHint(t *testing.T) {
 				require.Equal(t, tc.expectedV1, got2.GetResetHint())
 			})
 			t.Run("v2", func(t *testing.T) {
+				t.Parallel()
 				h := testIntHistogram()
 				h.CounterResetHint = tc.input
 				got := writev2.FromIntHistogram(1337, &h)


### PR DESCRIPTION
part of #15185 

On main https://github.com/prometheus/prometheus/commit/76432aaf4e82076e2fe5dfbda671019f74364feb
<details>
<summary> dropdown </summary>
❯ go test ./prompb/... -count=1 -race -v
?       github.com/prometheus/prometheus/prompb [no test files]
?       github.com/prometheus/prometheus/prompb/io/prometheus/client    [no test files]
=== RUN   TestOptimizedMarshal
=== RUN   TestOptimizedMarshal/empty
=== RUN   TestOptimizedMarshal/simple
--- PASS: TestOptimizedMarshal (0.00s)
    --- PASS: TestOptimizedMarshal/empty (0.00s)
    --- PASS: TestOptimizedMarshal/simple (0.00s)
=== RUN   TestSymbolsTable
--- PASS: TestSymbolsTable (0.00s)
=== RUN   TestInteropV2UnmarshalWithV1_DeterministicEmpty
=== RUN   TestInteropV2UnmarshalWithV1_DeterministicEmpty/#00
=== RUN   TestInteropV2UnmarshalWithV1_DeterministicEmpty/#01
=== RUN   TestInteropV2UnmarshalWithV1_DeterministicEmpty/#02
--- PASS: TestInteropV2UnmarshalWithV1_DeterministicEmpty (0.00s)
    --- PASS: TestInteropV2UnmarshalWithV1_DeterministicEmpty/#00 (0.00s)
    --- PASS: TestInteropV2UnmarshalWithV1_DeterministicEmpty/#01 (0.00s)
    --- PASS: TestInteropV2UnmarshalWithV1_DeterministicEmpty/#02 (0.00s)
=== RUN   TestInteropV1UnmarshalWithV2_DeterministicEmpty
=== RUN   TestInteropV1UnmarshalWithV2_DeterministicEmpty/#00
=== RUN   TestInteropV1UnmarshalWithV2_DeterministicEmpty/#01
--- PASS: TestInteropV1UnmarshalWithV2_DeterministicEmpty (0.00s)
    --- PASS: TestInteropV1UnmarshalWithV2_DeterministicEmpty/#00 (0.00s)
    --- PASS: TestInteropV1UnmarshalWithV2_DeterministicEmpty/#01 (0.00s)
PASS
ok      github.com/prometheus/prometheus/prompb/io/prometheus/write/v2  1.024s
=== RUN   TestToLabels
=== RUN   TestToLabels/v1
=== RUN   TestToLabels/v2
--- PASS: TestToLabels (0.00s)
    --- PASS: TestToLabels/v1 (0.00s)
    --- PASS: TestToLabels/v2 (0.00s)
=== RUN   TestFromMetadataType
=== RUN   TestFromMetadataType/with_a_single-word_metric
=== RUN   TestFromMetadataType/with_a_single-word_metric/v1
=== RUN   TestFromMetadataType/with_a_single-word_metric/v2
=== RUN   TestFromMetadataType/with_a_two-word_metric
=== RUN   TestFromMetadataType/with_a_two-word_metric/v1
=== RUN   TestFromMetadataType/with_a_two-word_metric/v2
=== RUN   TestFromMetadataType/with_an_unknown_metric
=== RUN   TestFromMetadataType/with_an_unknown_metric/v1
=== RUN   TestFromMetadataType/with_an_unknown_metric/v2
--- PASS: TestFromMetadataType (0.00s)
    --- PASS: TestFromMetadataType/with_a_single-word_metric (0.00s)
        --- PASS: TestFromMetadataType/with_a_single-word_metric/v1 (0.00s)
        --- PASS: TestFromMetadataType/with_a_single-word_metric/v2 (0.00s)
    --- PASS: TestFromMetadataType/with_a_two-word_metric (0.00s)
        --- PASS: TestFromMetadataType/with_a_two-word_metric/v1 (0.00s)
        --- PASS: TestFromMetadataType/with_a_two-word_metric/v2 (0.00s)
    --- PASS: TestFromMetadataType/with_an_unknown_metric (0.00s)
        --- PASS: TestFromMetadataType/with_an_unknown_metric/v1 (0.00s)
        --- PASS: TestFromMetadataType/with_an_unknown_metric/v2 (0.00s)
=== RUN   TestToMetadata
=== RUN   TestToMetadata/#00
=== RUN   TestToMetadata/#01
=== RUN   TestToMetadata/#02
=== RUN   TestToMetadata/#03
--- PASS: TestToMetadata (0.00s)
    --- PASS: TestToMetadata/#00 (0.00s)
    --- PASS: TestToMetadata/#01 (0.00s)
    --- PASS: TestToMetadata/#02 (0.00s)
    --- PASS: TestToMetadata/#03 (0.00s)
=== RUN   TestToHistogram_Empty
=== RUN   TestToHistogram_Empty/v1
=== RUN   TestToHistogram_Empty/v2
--- PASS: TestToHistogram_Empty (0.00s)
    --- PASS: TestToHistogram_Empty/v1 (0.00s)
    --- PASS: TestToHistogram_Empty/v2 (0.00s)
=== RUN   TestFromIntToFloatOrIntHistogram
=== RUN   TestFromIntToFloatOrIntHistogram/v1
=== RUN   TestFromIntToFloatOrIntHistogram/v2
--- PASS: TestFromIntToFloatOrIntHistogram (0.00s)
    --- PASS: TestFromIntToFloatOrIntHistogram/v1 (0.00s)
    --- PASS: TestFromIntToFloatOrIntHistogram/v2 (0.00s)
=== RUN   TestFromFloatToFloatHistogram
=== RUN   TestFromFloatToFloatHistogram/v1
=== RUN   TestFromFloatToFloatHistogram/v2
--- PASS: TestFromFloatToFloatHistogram (0.00s)
    --- PASS: TestFromFloatToFloatHistogram/v1 (0.00s)
    --- PASS: TestFromFloatToFloatHistogram/v2 (0.00s)
=== RUN   TestFromIntOrFloatHistogram_ResetHint
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#00
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#00/v1
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#00/v2
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#01
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#01/v1
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#01/v2
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#02
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#02/v1
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#02/v2
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#03
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#03/v1
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#03/v2
--- PASS: TestFromIntOrFloatHistogram_ResetHint (0.00s)
    --- PASS: TestFromIntOrFloatHistogram_ResetHint/#00 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#00/v1 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#00/v2 (0.00s)
    --- PASS: TestFromIntOrFloatHistogram_ResetHint/#01 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#01/v1 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#01/v2 (0.00s)
    --- PASS: TestFromIntOrFloatHistogram_ResetHint/#02 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#02/v1 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#02/v2 (0.00s)
    --- PASS: TestFromIntOrFloatHistogram_ResetHint/#03 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#03/v1 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#03/v2 (0.00s)
PASS
ok      github.com/prometheus/prometheus/prompb/rwcommon        1.026s
</details>

With tests parallelized
<details>
<summary> dropdown </summary>
```sh
❯ go test ./prompb/... -count=1 -race -v
?       github.com/prometheus/prometheus/prompb [no test files]
?       github.com/prometheus/prometheus/prompb/io/prometheus/client    [no test files]
=== RUN   TestOptimizedMarshal
=== RUN   TestOptimizedMarshal/empty
=== PAUSE TestOptimizedMarshal/empty
=== RUN   TestOptimizedMarshal/simple
=== PAUSE TestOptimizedMarshal/simple
=== CONT  TestOptimizedMarshal/simple
=== CONT  TestOptimizedMarshal/empty
--- PASS: TestOptimizedMarshal (0.00s)
    --- PASS: TestOptimizedMarshal/empty (0.00s)
    --- PASS: TestOptimizedMarshal/simple (0.00s)
=== RUN   TestSymbolsTable
--- PASS: TestSymbolsTable (0.00s)
=== RUN   TestInteropV2UnmarshalWithV1_DeterministicEmpty
=== RUN   TestInteropV2UnmarshalWithV1_DeterministicEmpty/#00
=== PAUSE TestInteropV2UnmarshalWithV1_DeterministicEmpty/#00
=== RUN   TestInteropV2UnmarshalWithV1_DeterministicEmpty/#01
=== PAUSE TestInteropV2UnmarshalWithV1_DeterministicEmpty/#01
=== RUN   TestInteropV2UnmarshalWithV1_DeterministicEmpty/#02
=== PAUSE TestInteropV2UnmarshalWithV1_DeterministicEmpty/#02
=== CONT  TestInteropV2UnmarshalWithV1_DeterministicEmpty/#02
=== CONT  TestInteropV2UnmarshalWithV1_DeterministicEmpty/#01
=== CONT  TestInteropV2UnmarshalWithV1_DeterministicEmpty/#00
--- PASS: TestInteropV2UnmarshalWithV1_DeterministicEmpty (0.00s)
    --- PASS: TestInteropV2UnmarshalWithV1_DeterministicEmpty/#01 (0.00s)
    --- PASS: TestInteropV2UnmarshalWithV1_DeterministicEmpty/#02 (0.00s)
    --- PASS: TestInteropV2UnmarshalWithV1_DeterministicEmpty/#00 (0.00s)
=== RUN   TestInteropV1UnmarshalWithV2_DeterministicEmpty
=== RUN   TestInteropV1UnmarshalWithV2_DeterministicEmpty/#00
=== PAUSE TestInteropV1UnmarshalWithV2_DeterministicEmpty/#00
=== RUN   TestInteropV1UnmarshalWithV2_DeterministicEmpty/#01
=== PAUSE TestInteropV1UnmarshalWithV2_DeterministicEmpty/#01
=== CONT  TestInteropV1UnmarshalWithV2_DeterministicEmpty/#01
=== CONT  TestInteropV1UnmarshalWithV2_DeterministicEmpty/#00
--- PASS: TestInteropV1UnmarshalWithV2_DeterministicEmpty (0.00s)
    --- PASS: TestInteropV1UnmarshalWithV2_DeterministicEmpty/#01 (0.00s)
    --- PASS: TestInteropV1UnmarshalWithV2_DeterministicEmpty/#00 (0.00s)
PASS
ok      github.com/prometheus/prometheus/prompb/io/prometheus/write/v2  1.025s
=== RUN   TestToLabels
=== RUN   TestToLabels/v1
=== PAUSE TestToLabels/v1
=== RUN   TestToLabels/v2
=== PAUSE TestToLabels/v2
=== CONT  TestToLabels/v2
=== CONT  TestToLabels/v1
--- PASS: TestToLabels (0.00s)
    --- PASS: TestToLabels/v2 (0.00s)
    --- PASS: TestToLabels/v1 (0.00s)
=== RUN   TestFromMetadataType
=== RUN   TestFromMetadataType/with_a_single-word_metric
=== RUN   TestFromMetadataType/with_a_single-word_metric/v1
=== PAUSE TestFromMetadataType/with_a_single-word_metric/v1
=== RUN   TestFromMetadataType/with_a_single-word_metric/v2
=== PAUSE TestFromMetadataType/with_a_single-word_metric/v2
=== CONT  TestFromMetadataType/with_a_single-word_metric/v1
=== CONT  TestFromMetadataType/with_a_single-word_metric/v2
=== RUN   TestFromMetadataType/with_a_two-word_metric
=== RUN   TestFromMetadataType/with_a_two-word_metric/v1
=== PAUSE TestFromMetadataType/with_a_two-word_metric/v1
=== RUN   TestFromMetadataType/with_a_two-word_metric/v2
=== PAUSE TestFromMetadataType/with_a_two-word_metric/v2
=== CONT  TestFromMetadataType/with_a_two-word_metric/v2
=== CONT  TestFromMetadataType/with_a_two-word_metric/v1
=== RUN   TestFromMetadataType/with_an_unknown_metric
=== RUN   TestFromMetadataType/with_an_unknown_metric/v1
=== PAUSE TestFromMetadataType/with_an_unknown_metric/v1
=== RUN   TestFromMetadataType/with_an_unknown_metric/v2
=== PAUSE TestFromMetadataType/with_an_unknown_metric/v2
=== CONT  TestFromMetadataType/with_an_unknown_metric/v2
=== CONT  TestFromMetadataType/with_an_unknown_metric/v1
--- PASS: TestFromMetadataType (0.00s)
    --- PASS: TestFromMetadataType/with_a_single-word_metric (0.00s)
        --- PASS: TestFromMetadataType/with_a_single-word_metric/v1 (0.00s)
        --- PASS: TestFromMetadataType/with_a_single-word_metric/v2 (0.00s)
    --- PASS: TestFromMetadataType/with_a_two-word_metric (0.00s)
        --- PASS: TestFromMetadataType/with_a_two-word_metric/v2 (0.00s)
        --- PASS: TestFromMetadataType/with_a_two-word_metric/v1 (0.00s)
    --- PASS: TestFromMetadataType/with_an_unknown_metric (0.00s)
        --- PASS: TestFromMetadataType/with_an_unknown_metric/v2 (0.00s)
        --- PASS: TestFromMetadataType/with_an_unknown_metric/v1 (0.00s)
=== RUN   TestToMetadata
=== RUN   TestToMetadata/#00
=== PAUSE TestToMetadata/#00
=== RUN   TestToMetadata/#01
=== PAUSE TestToMetadata/#01
=== RUN   TestToMetadata/#02
=== PAUSE TestToMetadata/#02
=== RUN   TestToMetadata/#03
=== PAUSE TestToMetadata/#03
=== CONT  TestToMetadata/#00
=== CONT  TestToMetadata/#02
=== CONT  TestToMetadata/#01
=== CONT  TestToMetadata/#03
--- PASS: TestToMetadata (0.00s)
    --- PASS: TestToMetadata/#00 (0.00s)
    --- PASS: TestToMetadata/#02 (0.00s)
    --- PASS: TestToMetadata/#01 (0.00s)
    --- PASS: TestToMetadata/#03 (0.00s)
=== RUN   TestToHistogram_Empty
=== RUN   TestToHistogram_Empty/v1
=== PAUSE TestToHistogram_Empty/v1
=== RUN   TestToHistogram_Empty/v2
=== PAUSE TestToHistogram_Empty/v2
=== CONT  TestToHistogram_Empty/v1
=== CONT  TestToHistogram_Empty/v2
--- PASS: TestToHistogram_Empty (0.00s)
    --- PASS: TestToHistogram_Empty/v1 (0.00s)
    --- PASS: TestToHistogram_Empty/v2 (0.00s)
=== RUN   TestFromIntToFloatOrIntHistogram
=== RUN   TestFromIntToFloatOrIntHistogram/v1
=== PAUSE TestFromIntToFloatOrIntHistogram/v1
=== RUN   TestFromIntToFloatOrIntHistogram/v2
=== PAUSE TestFromIntToFloatOrIntHistogram/v2
=== CONT  TestFromIntToFloatOrIntHistogram/v2
=== CONT  TestFromIntToFloatOrIntHistogram/v1
--- PASS: TestFromIntToFloatOrIntHistogram (0.00s)
    --- PASS: TestFromIntToFloatOrIntHistogram/v2 (0.00s)
    --- PASS: TestFromIntToFloatOrIntHistogram/v1 (0.00s)
=== RUN   TestFromFloatToFloatHistogram
=== RUN   TestFromFloatToFloatHistogram/v1
=== PAUSE TestFromFloatToFloatHistogram/v1
=== RUN   TestFromFloatToFloatHistogram/v2
=== PAUSE TestFromFloatToFloatHistogram/v2
=== CONT  TestFromFloatToFloatHistogram/v2
=== CONT  TestFromFloatToFloatHistogram/v1
--- PASS: TestFromFloatToFloatHistogram (0.00s)
    --- PASS: TestFromFloatToFloatHistogram/v2 (0.00s)
    --- PASS: TestFromFloatToFloatHistogram/v1 (0.00s)
=== RUN   TestFromIntOrFloatHistogram_ResetHint
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#00
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#00/v1
=== PAUSE TestFromIntOrFloatHistogram_ResetHint/#00/v1
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#00/v2
=== PAUSE TestFromIntOrFloatHistogram_ResetHint/#00/v2
=== CONT  TestFromIntOrFloatHistogram_ResetHint/#00/v1
=== CONT  TestFromIntOrFloatHistogram_ResetHint/#00/v2
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#01
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#01/v1
=== PAUSE TestFromIntOrFloatHistogram_ResetHint/#01/v1
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#01/v2
=== PAUSE TestFromIntOrFloatHistogram_ResetHint/#01/v2
=== CONT  TestFromIntOrFloatHistogram_ResetHint/#01/v2
=== CONT  TestFromIntOrFloatHistogram_ResetHint/#01/v1
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#02
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#02/v1
=== PAUSE TestFromIntOrFloatHistogram_ResetHint/#02/v1
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#02/v2
=== PAUSE TestFromIntOrFloatHistogram_ResetHint/#02/v2
=== CONT  TestFromIntOrFloatHistogram_ResetHint/#02/v2
=== CONT  TestFromIntOrFloatHistogram_ResetHint/#02/v1
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#03
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#03/v1
=== PAUSE TestFromIntOrFloatHistogram_ResetHint/#03/v1
=== RUN   TestFromIntOrFloatHistogram_ResetHint/#03/v2
=== PAUSE TestFromIntOrFloatHistogram_ResetHint/#03/v2
=== CONT  TestFromIntOrFloatHistogram_ResetHint/#03/v1
=== CONT  TestFromIntOrFloatHistogram_ResetHint/#03/v2
--- PASS: TestFromIntOrFloatHistogram_ResetHint (0.00s)
    --- PASS: TestFromIntOrFloatHistogram_ResetHint/#00 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#00/v1 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#00/v2 (0.00s)
    --- PASS: TestFromIntOrFloatHistogram_ResetHint/#01 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#01/v2 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#01/v1 (0.00s)
    --- PASS: TestFromIntOrFloatHistogram_ResetHint/#02 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#02/v2 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#02/v1 (0.00s)
    --- PASS: TestFromIntOrFloatHistogram_ResetHint/#03 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#03/v1 (0.00s)
        --- PASS: TestFromIntOrFloatHistogram_ResetHint/#03/v2 (0.00s)
PASS
ok      github.com/prometheus/prometheus/prompb/rwcommon        1.030s
```
</details>
