### PR TITLE
[REFACTOR] Small improvement to top-level naming

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1369,10 +1369,12 @@ func main() {
 			},
 		)
 	}
-	if err := g.Run(); err != nil {
-		logger.Error("Error running goroutines from run.Group", "err", err)
-		os.Exit(1)
-	}
+	func() { // This function exists so the top of the stack is named 'main.main.funcxxx' and not 'oklog'.
+		if err := g.Run(); err != nil {
+			logger.Error("Fatal error", "err", err)
+			os.Exit(1)
+		}
+	}()
 	logger.Info("See you next time!")
 }
 


### PR DESCRIPTION
Previously, top-level initialization (including WAL reading) had this at the top of the stack:

    github.com/oklog/run.(*Group).Run.func1:38

I found this confusing, and thought it had something to do with logging.

Introducing another local function should make this clearer.
Also make the error message user-centric not code-centric.

