### PR TITLE
Require `MemPostings.Commit()` to actually index the series

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1695,6 +1695,9 @@ func (h *Head) String() string {
 	return "head"
 }
 
+// getOrCreate returns the series for the given hash and labels, creating it if it doesn't exist.
+// The bool return value indicates whether the series was created by this call.
+// If the series was created, its id will be higher than the ids of previously created series by same goroutine.
 func (h *Head) getOrCreate(hash uint64, lset labels.Labels) (*memSeries, bool, error) {
 	// Just using `getOrCreateWithID` below would be semantically sufficient, but we'd create
 	// a new series on every sample inserted via Add(), which causes allocations

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1422,6 +1422,9 @@ func (a *headAppender) Commit() (err error) {
 		a.head.writeNotified.Notify()
 	}
 
+	// Make sure all postings are committed, no matter if they were added by this or another appender.
+	a.head.postings.Commit()
+
 	a.commitExemplars()
 
 	defer a.head.metrics.activeAppenders.Dec()
@@ -1957,7 +1960,8 @@ func (a *headAppender) Rollback() (err error) {
 	a.histograms = nil
 	a.metadata = nil
 
-	// Series are created in the head memory regardless of rollback. Thus we have
-	// to log them to the WAL in any case.
+	// Series are created in the head memory regardless of rollback.
+	// Thus we have to commit them in the postings and to log them to the WAL in any case.
+	a.head.postings.Commit()
 	return a.log()
 }

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -44,6 +44,12 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		h.getOrCreate(uint64(i), labels.FromStrings("a", strconv.Itoa(i)))
+		// We aren't benchmarking MemPostings here,
+		// but we also don't want pending postings to accumulate there.
+		// So let's just commit from time to time.
+		if i%16 == 0 {
+			h.postings.Commit()
+		}
 	}
 }
 
@@ -63,6 +69,12 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 		for pb.Next() {
 			i := count.Inc()
 			h.getOrCreate(uint64(i), labels.FromStrings("a", strconv.Itoa(int(i))))
+			// We aren't benchmarking MemPostings here,
+			// but we also don't want pending postings to accumulate there.
+			// So let's just commit from time to time.
+			if i%16 == 0 {
+				h.postings.Commit()
+			}
 		}
 	})
 }
@@ -83,6 +95,12 @@ func BenchmarkHeadStripeSeriesCreate_PreCreationFailure(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		h.getOrCreate(uint64(i), labels.FromStrings("a", strconv.Itoa(i)))
+		// We aren't benchmarking MemPostings here,
+		// but we also don't want pending postings to accumulate there.
+		// So let's just commit from time to time.
+		if i%16 == 0 {
+			h.postings.Commit()
+		}
 	}
 }
 

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -48,7 +48,7 @@ func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 		// but we also don't want pending postings to accumulate there.
 		// So let's just commit from time to time.
 		if i%16 == 0 {
-			h.postings.Commit()
+			h.postings.CommitAll()
 		}
 	}
 }
@@ -73,7 +73,7 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 			// but we also don't want pending postings to accumulate there.
 			// So let's just commit from time to time.
 			if i%16 == 0 {
-				h.postings.Commit()
+				h.postings.CommitAll()
 			}
 		}
 	})
@@ -99,7 +99,7 @@ func BenchmarkHeadStripeSeriesCreate_PreCreationFailure(b *testing.B) {
 		// but we also don't want pending postings to accumulate there.
 		// So let's just commit from time to time.
 		if i%16 == 0 {
-			h.postings.Commit()
+			h.postings.CommitAll()
 		}
 	}
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -99,8 +99,12 @@ func BenchmarkCreateSeries(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	for _, s := range series {
-		h.getOrCreate(s.Labels().Hash(), s.Labels())
+	for i, s := range series {
+		getOrCreateAndCommit(h, s.Labels().Hash(), s.Labels())
+		// Commit from time to time.
+		if i%16 == 0 {
+			h.postings.Commit()
+		}
 	}
 }
 
@@ -887,7 +891,7 @@ func BenchmarkHead_Truncate(b *testing.B) {
 			}
 
 			allSeries[i] = labels.FromStrings(append(nameValues, "first", "a", "second", "a", "third", "a")...)
-			s, _, _ := h.getOrCreate(allSeries[i].Hash(), allSeries[i])
+			s, _, _ := getOrCreateAndCommit(h, allSeries[i].Hash(), allSeries[i])
 			s.mmappedChunks = []*mmappedChunk{
 				{minTime: 1000 * int64(i/churn), maxTime: 999 + 1000*int64(i/churn)},
 			}
@@ -924,10 +928,10 @@ func TestHead_Truncate(t *testing.T) {
 
 	ctx := context.Background()
 
-	s1, _, _ := h.getOrCreate(1, labels.FromStrings("a", "1", "b", "1"))
-	s2, _, _ := h.getOrCreate(2, labels.FromStrings("a", "2", "b", "1"))
-	s3, _, _ := h.getOrCreate(3, labels.FromStrings("a", "1", "b", "2"))
-	s4, _, _ := h.getOrCreate(4, labels.FromStrings("a", "2", "b", "2", "c", "1"))
+	s1, _, _ := getOrCreateAndCommit(h, 1, labels.FromStrings("a", "1", "b", "1"))
+	s2, _, _ := getOrCreateAndCommit(h, 2, labels.FromStrings("a", "2", "b", "1"))
+	s3, _, _ := getOrCreateAndCommit(h, 3, labels.FromStrings("a", "1", "b", "2"))
+	s4, _, _ := getOrCreateAndCommit(h, 4, labels.FromStrings("a", "2", "b", "2", "c", "1"))
 
 	s1.mmappedChunks = []*mmappedChunk{
 		{minTime: 0, maxTime: 999},
@@ -1913,7 +1917,7 @@ func TestGCChunkAccess(t *testing.T) {
 
 	h.initTime(0)
 
-	s, _, _ := h.getOrCreate(1, labels.FromStrings("a", "1"))
+	s, _, _ := getOrCreateAndCommit(h, 1, labels.FromStrings("a", "1"))
 
 	// Appending 2 samples for the first chunk.
 	ok, chunkCreated := s.append(0, 0, 0, cOpts)
@@ -1972,7 +1976,7 @@ func TestGCSeriesAccess(t *testing.T) {
 
 	h.initTime(0)
 
-	s, _, _ := h.getOrCreate(1, labels.FromStrings("a", "1"))
+	s, _, _ := getOrCreateAndCommit(h, 1, labels.FromStrings("a", "1"))
 
 	// Appending 2 samples for the first chunk.
 	ok, chunkCreated := s.append(0, 0, 0, cOpts)
@@ -2325,7 +2329,7 @@ func TestHeadReadWriterRepair(t *testing.T) {
 			samplesPerChunk: DefaultSamplesPerChunk,
 		}
 
-		s, created, _ := h.getOrCreate(1, labels.FromStrings("a", "1"))
+		s, created, _ := getOrCreateAndCommit(h, 1, labels.FromStrings("a", "1"))
 		require.True(t, created, "series was not created")
 
 		for i := 0; i < 7; i++ {
@@ -2685,7 +2689,7 @@ func TestIsolationAppendIDZeroIsNoop(t *testing.T) {
 		samplesPerChunk: DefaultSamplesPerChunk,
 	}
 
-	s, _, _ := h.getOrCreate(1, labels.FromStrings("a", "1"))
+	s, _, _ := getOrCreateAndCommit(h, 1, labels.FromStrings("a", "1"))
 
 	ok, _ := s.append(0, 0, 0, cOpts)
 	require.True(t, ok, "Series append failed.")
@@ -4580,7 +4584,7 @@ func TestHistogramCounterResetHeader(t *testing.T) {
 			checkExpCounterResetHeader := func(newHeaders ...chunkenc.CounterResetHeader) {
 				expHeaders = append(expHeaders, newHeaders...)
 
-				ms, _, err := head.getOrCreate(l.Hash(), l)
+				ms, _, err := getOrCreateAndCommit(head, l.Hash(), l)
 				require.NoError(t, err)
 				ms.mmapChunks(head.chunkDiskMapper)
 				require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
@@ -4708,7 +4712,7 @@ func TestOOOHistogramCounterResetHeaders(t *testing.T) {
 			checkOOOExpCounterResetHeader := func(newChunks ...expOOOMmappedChunks) {
 				expChunks = append(expChunks, newChunks...)
 
-				ms, _, err := head.getOrCreate(l.Hash(), l)
+				ms, _, err := getOrCreateAndCommit(head, l.Hash(), l)
 				require.NoError(t, err)
 
 				require.Len(t, ms.ooo.oooMmappedChunks, len(expChunks))
@@ -4852,7 +4856,7 @@ func TestAppendingDifferentEncodingToSameSeries(t *testing.T) {
 
 	var expResult []chunks.Sample
 	checkExpChunks := func(count int) {
-		ms, created, err := db.Head().getOrCreate(lbls.Hash(), lbls)
+		ms, created, err := getOrCreateAndCommit(db.Head(), lbls.Hash(), lbls)
 		require.NoError(t, err)
 		require.False(t, created)
 		require.NotNil(t, ms)
@@ -5157,7 +5161,7 @@ func testWBLReplay(t *testing.T, scenario sampleTypeScenario) {
 	require.NoError(t, h.Init(0)) // Replay happens here.
 
 	// Get the ooo samples from the Head.
-	ms, ok, err := h.getOrCreate(l.Hash(), l)
+	ms, ok, err := getOrCreateAndCommit(h, l.Hash(), l)
 	require.NoError(t, err)
 	require.False(t, ok)
 	require.NotNil(t, ms)
@@ -5227,7 +5231,7 @@ func testOOOMmapReplay(t *testing.T, scenario sampleTypeScenario) {
 		appendSample(mins)
 	}
 
-	ms, ok, err := h.getOrCreate(l.Hash(), l)
+	ms, ok, err := getOrCreateAndCommit(h, l.Hash(), l)
 	require.NoError(t, err)
 	require.False(t, ok)
 	require.NotNil(t, ms)
@@ -5255,7 +5259,7 @@ func testOOOMmapReplay(t *testing.T, scenario sampleTypeScenario) {
 	require.NoError(t, h.Init(0)) // Replay happens here.
 
 	// Get the mmap chunks from the Head.
-	ms, ok, err = h.getOrCreate(l.Hash(), l)
+	ms, ok, err = getOrCreateAndCommit(h, l.Hash(), l)
 	require.NoError(t, err)
 	require.False(t, ok)
 	require.NotNil(t, ms)
@@ -5310,7 +5314,7 @@ func TestHeadInit_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.NoError(t, app.Commit())
 	require.Greater(t, prom_testutil.ToFloat64(h.metrics.chunksCreated), 4.0)
 
-	series, created, err := h.getOrCreate(seriesLabels.Hash(), seriesLabels)
+	series, created, err := getOrCreateAndCommit(h, seriesLabels.Hash(), seriesLabels)
 	require.NoError(t, err)
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
@@ -5327,7 +5331,7 @@ func TestHeadInit_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, h.Init(0))
 
-	series, created, err = h.getOrCreate(seriesLabels.Hash(), seriesLabels)
+	series, created, err = getOrCreateAndCommit(h, seriesLabels.Hash(), seriesLabels)
 	require.NoError(t, err)
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
@@ -5525,7 +5529,7 @@ func testOOOAppendWithNoSeries(t *testing.T, appendFunc func(appender storage.Ap
 	}
 
 	verifyOOOSamples := func(lbls labels.Labels, expSamples int) {
-		ms, created, err := h.getOrCreate(lbls.Hash(), lbls)
+		ms, created, err := getOrCreateAndCommit(h, lbls.Hash(), lbls)
 		require.NoError(t, err)
 		require.False(t, created)
 		require.NotNil(t, ms)
@@ -5536,7 +5540,7 @@ func testOOOAppendWithNoSeries(t *testing.T, appendFunc func(appender storage.Ap
 	}
 
 	verifyInOrderSamples := func(lbls labels.Labels, expSamples int) {
-		ms, created, err := h.getOrCreate(lbls.Hash(), lbls)
+		ms, created, err := getOrCreateAndCommit(h, lbls.Hash(), lbls)
 		require.NoError(t, err)
 		require.False(t, created)
 		require.NotNil(t, ms)
@@ -5665,7 +5669,7 @@ func TestGaugeHistogramWALAndChunkHeader(t *testing.T) {
 
 	checkHeaders := func() {
 		head.mmapHeadChunks()
-		ms, _, err := head.getOrCreate(l.Hash(), l)
+		ms, _, err := getOrCreateAndCommit(head, l.Hash(), l)
 		require.NoError(t, err)
 		require.Len(t, ms.mmappedChunks, 3)
 		expHeaders := []chunkenc.CounterResetHeader{
@@ -5740,7 +5744,7 @@ func TestGaugeFloatHistogramWALAndChunkHeader(t *testing.T) {
 	appendHistogram(hists[4])
 
 	checkHeaders := func() {
-		ms, _, err := head.getOrCreate(l.Hash(), l)
+		ms, _, err := getOrCreateAndCommit(head, l.Hash(), l)
 		require.NoError(t, err)
 		head.mmapHeadChunks()
 		require.Len(t, ms.mmappedChunks, 3)
@@ -6580,4 +6584,11 @@ func testHeadAppendHistogramAndCommitConcurrency(t *testing.T, appendFn func(sto
 	}()
 
 	wg.Wait()
+}
+
+// getOrCreateAndCommit is a helper wrapper around Head.getOrCreate() that commits the postings list after the call.
+// This is what the appender would do.
+func getOrCreateAndCommit(head *Head, hash uint64, lbls labels.Labels) (*memSeries, bool, error) {
+	defer head.postings.Commit()
+	return head.getOrCreate(hash, lbls)
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -6236,9 +6236,11 @@ func TestPostingsCardinalityStats(t *testing.T) {
 	head := &Head{postings: index.NewMemPostings()}
 	head.postings.Add(1, labels.FromStrings(labels.MetricName, "t", "n", "v1"))
 	head.postings.Add(2, labels.FromStrings(labels.MetricName, "t", "n", "v2"))
+	head.postings.Commit()
 
 	statsForMetricName := head.PostingsCardinalityStats(labels.MetricName, 10)
 	head.postings.Add(3, labels.FromStrings(labels.MetricName, "t", "n", "v3"))
+	head.postings.Commit()
 	// Using cache.
 	require.Equal(t, statsForMetricName, head.PostingsCardinalityStats(labels.MetricName, 10))
 
@@ -6246,6 +6248,7 @@ func TestPostingsCardinalityStats(t *testing.T) {
 	// Cache should be evicted because of the change of label name.
 	require.NotEqual(t, statsForMetricName, statsForSomeLabel)
 	head.postings.Add(4, labels.FromStrings(labels.MetricName, "t", "n", "v4"))
+	head.postings.Commit()
 	// Using cache.
 	require.Equal(t, statsForSomeLabel, head.PostingsCardinalityStats("n", 10))
 	// Cache should be evicted because of the change of limit parameter.

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -95,6 +95,8 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		}
 	}()
 
+	defer h.postings.Commit()
+
 	wg.Add(concurrency)
 	for i := 0; i < concurrency; i++ {
 		processors[i].setup()
@@ -1507,6 +1509,8 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 		syms             = labels.NewSymbolTable() // New table for the whole snapshot.
 		dec              = record.NewDecoder(syms)
 	)
+
+	defer h.postings.Commit()
 
 	wg.Add(concurrency)
 	for i := 0; i < concurrency; i++ {

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -251,7 +251,7 @@ Outer:
 				idx := uint64(mSeries.ref) % uint64(concurrency)
 				processors[idx].input <- walSubsetProcessorInputItem{walSeriesRef: walSeries.Ref, existingSeries: mSeries}
 			}
-			h.postings.Commit()
+			h.postings.CommitAll()
 			seriesPool.Put(v)
 		case []record.RefSample:
 			samples := v
@@ -1519,7 +1519,7 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 				for range rc {
 				}
 			}()
-			defer h.postings.Commit()
+			defer h.postings.CommitAll()
 
 			shardedRefSeries[idx] = make(map[chunks.HeadSeriesRef]*memSeries)
 			localRefSeries := shardedRefSeries[idx]

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -386,6 +386,7 @@ func TestPersistence_index_e2e(t *testing.T) {
 		})
 		postings.Add(storage.SeriesRef(i), s.labels)
 	}
+	postings.Commit()
 
 	for p := range mi.postings {
 		gotp, err := ir.Postings(ctx, p.Name, p.Value)

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -385,8 +385,8 @@ func TestPersistence_index_e2e(t *testing.T) {
 			valset[l.Value] = struct{}{}
 		})
 		postings.Add(storage.SeriesRef(i), s.labels)
+		postings.Commit(storage.SeriesRef(i))
 	}
-	postings.Commit()
 
 	for p := range mi.postings {
 		gotp, err := ir.Postings(ctx, p.Name, p.Value)

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -370,6 +370,8 @@ func (p *MemPostings) Iter(f func(labels.Label, Postings) error) error {
 }
 
 // Add a pending to be committed label set to the postings index.
+// Callers of Add should expect Commit to be called at any time by other goroutines,
+// and they should call Commit themselves to ensure that all pending entries are committed.
 func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
 	p.pendingMtx.Lock()
 	defer p.pendingMtx.Unlock()
@@ -378,6 +380,7 @@ func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
 }
 
 // Commit will create the entries for all series pending to be committed.
+// Commit is a noop if there are no pending entries.
 func (p *MemPostings) Commit() {
 	p.pendingMtx.Lock()
 	defer p.pendingMtx.Unlock()

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -299,6 +299,11 @@ func (p *MemPostings) EnsureOrder(numberOfConcurrentProcesses int) {
 // Delete removes all ids in the given map from the postings lists.
 // affectedLabels contains all the labels that are affected by the deletion, there's no need to check other labels.
 func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected map[labels.Label]struct{}) {
+	// Commit first.
+	// We could instead iterate through the pending postings and see if one of them is deleted,
+	// but in reality we don't expect pending postings to be deleted, so committing them wastes less resources.
+	p.Commit()
+
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -395,7 +395,13 @@ func (p *MemPostings) Commit() {
 		p.addFor(p.pending[i].id, allPostingsKey)
 		p.pending[i] = pendingMemPostings{} // don't retain any kind of references, like labels.Labels.
 	}
-	p.pending = p.pending[:0]
+
+	// If the pending list is too large, discard it, otherwise just reset.
+	if cap(p.pending) > 1e6 {
+		p.pending = nil
+	} else {
+		p.pending = p.pending[:0]
+	}
 }
 
 func appendWithExponentialGrowth[T any](a []T, v T) []T {

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -952,6 +952,7 @@ func TestMemPostingsStats(t *testing.T) {
 	p.Add(1, labels.FromStrings("label", "value2"))
 	p.Add(1, labels.FromStrings("label", "value3"))
 	p.Add(2, labels.FromStrings("label", "value1"))
+	p.Commit()
 
 	// call the Stats method to calculate the cardinality statistics
 	stats := p.Stats("label", 10)
@@ -977,6 +978,7 @@ func TestMemPostings_Delete(t *testing.T) {
 	p.Add(1, labels.FromStrings("lbl1", "a"))
 	p.Add(2, labels.FromStrings("lbl1", "b"))
 	p.Add(3, labels.FromStrings("lbl2", "a"))
+	p.Commit()
 
 	before := p.Get(allPostingsKey.Name, allPostingsKey.Value)
 	deletedRefs := map[storage.SeriesRef]struct{}{
@@ -1058,6 +1060,7 @@ func BenchmarkMemPostings_Delete(b *testing.B) {
 					for i := range allSeries {
 						p.Add(storage.SeriesRef(i), allSeries[i])
 					}
+					p.Commit()
 
 					stop := make(chan struct{})
 					wg := sync.WaitGroup{}
@@ -1416,6 +1419,7 @@ func BenchmarkMemPostings_PostingsForLabelMatching(b *testing.B) {
 			for i := 0; i < labelValueCount; i++ {
 				mp.Add(storage.SeriesRef(i), labels.FromStrings("label", strconv.Itoa(i)))
 			}
+			mp.Commit()
 
 			fp, err := ExpandPostings(mp.PostingsForLabelMatching(context.Background(), "label", fast.MatchString))
 			require.NoError(b, err)
@@ -1444,6 +1448,7 @@ func TestMemPostings_PostingsForLabelMatching(t *testing.T) {
 	mp.Add(2, labels.FromStrings("foo", "2"))
 	mp.Add(3, labels.FromStrings("foo", "3"))
 	mp.Add(4, labels.FromStrings("foo", "4"))
+	mp.Commit()
 
 	isEven := func(v string) bool {
 		iv, err := strconv.Atoi(v)
@@ -1466,6 +1471,7 @@ func TestMemPostings_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	for i := 1; i <= seriesCount; i++ {
 		memP.Add(storage.SeriesRef(i), labels.FromStrings("__name__", fmt.Sprintf("%4d", i)))
 	}
+	memP.Commit()
 
 	failAfter := uint64(seriesCount / 2 / checkContextEveryNIterations)
 	ctx := &testutil.MockContextErrAfter{FailAfter: failAfter}

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -306,7 +306,7 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 					}()
 					require.NoError(t, h.Init(0))
 
-					s1, _, _ := h.getOrCreate(s1ID, s1Lset)
+					s1, _, _ := getOrCreateAndCommit(h, s1ID, s1Lset)
 					s1.ooo = &memSeriesOOOFields{}
 
 					// define our expected chunks, by looking at the expected ChunkIntervals and setting...

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -168,6 +168,7 @@ func createIdxChkReaders(t *testing.T, tc []seriesSamples) (IndexReader, ChunkRe
 		require.NoError(t, mi.AddSeries(storage.SeriesRef(i), ls, metas...))
 
 		postings.Add(storage.SeriesRef(i), ls)
+		postings.Commit()
 
 		ls.Range(func(l labels.Label) {
 			vs, present := lblIdx[l.Name]

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -168,7 +168,7 @@ func createIdxChkReaders(t *testing.T, tc []seriesSamples) (IndexReader, ChunkRe
 		require.NoError(t, mi.AddSeries(storage.SeriesRef(i), ls, metas...))
 
 		postings.Add(storage.SeriesRef(i), ls)
-		postings.Commit()
+		postings.Commit(storage.SeriesRef(i))
 
 		ls.Range(func(l labels.Label) {
 			vs, present := lblIdx[l.Name]


### PR DESCRIPTION
This changes the way we interact with MemPostings, by batching the additions into "pending" state, and then actually creating them in the "Commit" phase.

Anyone can call `Commit` at any moment, which will add all pending postings, not just the ones from that caller.

This is intended to reduce lock contention on very high churn instances, where lots of `Add()` calls compete with the reads: this way there will be only one `Add()` call that will create all pending to be created postings.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
