### PR TITLE
Enable auto-gomaxprocs by default

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -196,6 +196,7 @@ type flagConfig struct {
 	enableAutoReload   bool
 	autoReloadInterval model.Duration
 
+	maxprocsEnable bool
 	memlimitEnable bool
 	memlimitRatio  float64
 
@@ -203,7 +204,6 @@ type flagConfig struct {
 	// These options are extracted from featureList
 	// for ease of use.
 	enablePerStepStats       bool
-	enableAutoGOMAXPROCS     bool
 	enableConcurrentRuleEval bool
 
 	prometheusURL   string
@@ -235,9 +235,6 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 			case "promql-per-step-stats":
 				c.enablePerStepStats = true
 				logger.Info("Experimental per-step statistics reporting")
-			case "auto-gomaxprocs":
-				c.enableAutoGOMAXPROCS = true
-				logger.Info("Automatically set GOMAXPROCS to match Linux container CPU quota")
 			case "auto-reload-config":
 				c.enableAutoReload = true
 				if s := time.Duration(c.autoReloadInterval).Seconds(); s > 0 && s < 1 {
@@ -330,6 +327,8 @@ func main() {
 	a.Flag("web.listen-address", "Address to listen on for UI, API, and telemetry. Can be repeated.").
 		Default("0.0.0.0:9090").StringsVar(&cfg.web.ListenAddresses)
 
+	a.Flag("auto-gomaxprocs", "Automatically set GOMAXPROCS to match Linux container CPU quota").
+		Default("true").BoolVar(&cfg.maxprocsEnable)
 	a.Flag("auto-gomemlimit", "Automatically set GOMEMLIMIT to match Linux container or system memory limit").
 		Default("true").BoolVar(&cfg.memlimitEnable)
 	a.Flag("auto-gomemlimit.ratio", "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory").
@@ -766,7 +765,7 @@ func main() {
 		ruleManager *rules.Manager
 	)
 
-	if cfg.enableAutoGOMAXPROCS {
+	if cfg.maxprocsEnable {
 		l := func(format string, a ...interface{}) {
 			logger.Info(fmt.Sprintf(strings.TrimPrefix(format, "maxprocs: "), a...), "component", "automaxprocs")
 		}

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -17,6 +17,7 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--config.file</code> | Prometheus configuration file path. | `prometheus.yml` |
 | <code class="text-nowrap">--config.auto-reload-interval</code> | Specifies the interval for checking and automatically reloading the Prometheus configuration file upon detecting changes. | `30s` |
 | <code class="text-nowrap">--web.listen-address</code> <code class="text-nowrap">...<code class="text-nowrap"> | Address to listen on for UI, API, and telemetry. Can be repeated. | `0.0.0.0:9090` |
+| <code class="text-nowrap">--auto-gomaxprocs</code> | Automatically set GOMAXPROCS to match Linux container CPU quota | `true` |
 | <code class="text-nowrap">--auto-gomemlimit</code> | Automatically set GOMEMLIMIT to match Linux container or system memory limit | `true` |
 | <code class="text-nowrap">--auto-gomemlimit.ratio</code> | The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory | `0.9` |
 | <code class="text-nowrap">--web.config.file</code> | [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication. |  |

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -47,12 +47,6 @@ statistics. Currently this is limited to totalQueryableSamples.
 When disabled in either the engine or the query, per-step statistics are not
 computed at all.
 
-## Auto GOMAXPROCS
-
-`--enable-feature=auto-gomaxprocs`
-
-When enabled, GOMAXPROCS variable is automatically set to match Linux container CPU quota.
-
 ## Native Histograms
 
 `--enable-feature=native-histograms`


### PR DESCRIPTION
Enable the `auto-gomaxprocs` feature flag by default.
* Add command line flag `--no-auto-gomaxprocs` to disable.
