### PR TITLE
Implement json encoder/decoder for regexp

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -85,7 +85,7 @@ func (a *Action) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type Config struct {
 	// A list of labels from which values are taken and concatenated
 	// with the configured separator in order.
-	SourceLabels model.LabelNames `yaml:"source_labels,flow,omitempty" json:"source_labels,omitempty"`
+	SourceLabels model.LabelNames `yaml:"source_labels,flow,omitempty" json:"sourceLabels,omitempty"`
 	// Separator is the string between concatenated values from the source labels.
 	Separator string `yaml:"separator,omitempty" json:"separator,omitempty"`
 	// Regex against which the concatenation is matched.
@@ -94,7 +94,7 @@ type Config struct {
 	Modulus uint64 `yaml:"modulus,omitempty" json:"modulus,omitempty"`
 	// TargetLabel is the label to which the resulting string is written in a replacement.
 	// Regexp interpolation is allowed for the replace action.
-	TargetLabel string `yaml:"target_label,omitempty" json:"target_label,omitempty"`
+	TargetLabel string `yaml:"target_label,omitempty" json:"targetLabel,omitempty"`
 	// Replacement is the regex replacement pattern to be used.
 	Replacement string `yaml:"replacement,omitempty" json:"replacement,omitempty"`
 	// Action is the action to be performed for the relabeling.

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -16,6 +16,7 @@ package relabel
 import (
 	"crypto/md5"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -205,6 +206,32 @@ func (re Regexp) MarshalYAML() (interface{}, error) {
 		return re.String(), nil
 	}
 	return nil, nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (re *Regexp) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Regex string `json:"regex"`
+	}{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	r, err := NewRegexp(v.Regex)
+	if err != nil {
+		return err
+	}
+	*re = r
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (re Regexp) MarshalJSON() ([]byte, error) {
+	v := &struct {
+		Regex string `json:"regex"`
+	}{
+		Regex: re.String(),
+	}
+	return json.Marshal(v)
 }
 
 // IsZero implements the yaml.IsZeroer interface.

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -85,20 +85,20 @@ func (a *Action) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type Config struct {
 	// A list of labels from which values are taken and concatenated
 	// with the configured separator in order.
-	SourceLabels model.LabelNames `yaml:"source_labels,flow,omitempty"`
+	SourceLabels model.LabelNames `yaml:"source_labels,flow,omitempty" json:"source_labels,omitempty"`
 	// Separator is the string between concatenated values from the source labels.
-	Separator string `yaml:"separator,omitempty"`
+	Separator string `yaml:"separator,omitempty" json:"separator,omitempty"`
 	// Regex against which the concatenation is matched.
-	Regex Regexp `yaml:"regex,omitempty"`
+	Regex Regexp `yaml:"regex,omitempty" json:"regex,omitempty"`
 	// Modulus to take of the hash of concatenated values from the source labels.
-	Modulus uint64 `yaml:"modulus,omitempty"`
+	Modulus uint64 `yaml:"modulus,omitempty" json:"modulus,omitempty"`
 	// TargetLabel is the label to which the resulting string is written in a replacement.
 	// Regexp interpolation is allowed for the replace action.
-	TargetLabel string `yaml:"target_label,omitempty"`
+	TargetLabel string `yaml:"target_label,omitempty" json:"target_label,omitempty"`
 	// Replacement is the regex replacement pattern to be used.
-	Replacement string `yaml:"replacement,omitempty"`
+	Replacement string `yaml:"replacement,omitempty" json:"replacement,omitempty"`
 	// Action is the action to be performed for the relabeling.
-	Action Action `yaml:"action,omitempty"`
+	Action Action `yaml:"action,omitempty" json:"action,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -210,13 +210,11 @@ func (re Regexp) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (re *Regexp) UnmarshalJSON(b []byte) error {
-	v := struct {
-		Regex string `json:"regex"`
-	}{}
-	if err := json.Unmarshal(b, &v); err != nil {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	r, err := NewRegexp(v.Regex)
+	r, err := NewRegexp(s)
 	if err != nil {
 		return err
 	}
@@ -226,12 +224,7 @@ func (re *Regexp) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (re Regexp) MarshalJSON() ([]byte, error) {
-	v := &struct {
-		Regex string `json:"regex"`
-	}{
-		Regex: re.String(),
-	}
-	return json.Marshal(v)
+	return json.Marshal(re.String())
 }
 
 // IsZero implements the yaml.IsZeroer interface.

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -986,7 +986,7 @@ func TestRegexp_JSONUnmarshalThenMarshal(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var unmarshalled Regexp
+			var unmarshalled Config
 			err := json.Unmarshal([]byte(test.input), &unmarshalled)
 			require.NoError(t, err)
 

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -14,6 +14,7 @@
 package relabel
 
 import (
+	"encoding/json"
 	"strconv"
 	"testing"
 
@@ -963,4 +964,36 @@ func TestRegexp_ShouldMarshalAndUnmarshalZeroValue(t *testing.T) {
 	err = yaml.Unmarshal(marshalled, &unmarshalled)
 	require.NoError(t, err)
 	require.Nil(t, unmarshalled.Regexp)
+}
+
+func TestRegexp_JSONUnmarshalThenMarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "Empty regex",
+			input: `{"regex":""}`,
+		},
+		{
+			name:  "string literal",
+			input: `{"regex":"foo"}`,
+		},
+		{
+			name:  "regex",
+			input: `{"regex":".*foo.*"}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var unmarshalled Regexp
+			err := json.Unmarshal([]byte(test.input), &unmarshalled)
+			require.NoError(t, err)
+
+			marshalled, err := json.Marshal(&unmarshalled)
+			require.NoError(t, err)
+
+			require.Equal(t, test.input, string(marshalled))
+		})
+	}
 }


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->


There is a usecase in Thanos where we need to marshal `relabel.Config` to JSON and store in Thanos metadata file. This PR implements the corresponding JSON encoding and decoding function for `Regexp`. Otherwise it causes panic.

This should fix https://github.com/thanos-io/thanos/issues/7844.