### PR TITLE
Make DesymbolizeLabels func public

### DIFF
--- a/prompb/io/prometheus/write/v2/codec.go
+++ b/prompb/io/prometheus/write/v2/codec.go
@@ -26,7 +26,7 @@ import (
 
 // ToLabels return model labels.Labels from timeseries' remote labels.
 func (m TimeSeries) ToLabels(b *labels.ScratchBuilder, symbols []string) labels.Labels {
-	return desymbolizeLabels(b, m.GetLabelsRefs(), symbols)
+	return DesymbolizeLabels(b, m.GetLabelsRefs(), symbols)
 }
 
 // ToMetadata return model metadata from timeseries' remote metadata.
@@ -208,7 +208,7 @@ func (m Exemplar) ToExemplar(b *labels.ScratchBuilder, symbols []string) exempla
 	timestamp := m.Timestamp
 
 	return exemplar.Exemplar{
-		Labels: desymbolizeLabels(b, m.LabelsRefs, symbols),
+		Labels: DesymbolizeLabels(b, m.LabelsRefs, symbols),
 		Value:  m.Value,
 		Ts:     timestamp,
 		HasTs:  timestamp != 0,

--- a/prompb/io/prometheus/write/v2/symbols.go
+++ b/prompb/io/prometheus/write/v2/symbols.go
@@ -72,8 +72,8 @@ func (t *SymbolsTable) Reset() {
 	}
 }
 
-// desymbolizeLabels decodes label references, with given symbols to labels.
-func desymbolizeLabels(b *labels.ScratchBuilder, labelRefs []uint32, symbols []string) labels.Labels {
+// DesymbolizeLabels decodes label references, with given symbols to labels.
+func DesymbolizeLabels(b *labels.ScratchBuilder, labelRefs []uint32, symbols []string) labels.Labels {
 	b.Reset()
 	for i := 0; i < len(labelRefs); i += 2 {
 		b.Add(symbols[labelRefs[i]], symbols[labelRefs[i+1]])

--- a/prompb/io/prometheus/write/v2/symbols_test.go
+++ b/prompb/io/prometheus/write/v2/symbols_test.go
@@ -50,7 +50,7 @@ func TestSymbolsTable(t *testing.T) {
 	encoded := s.SymbolizeLabels(ls, nil)
 	require.Equal(t, []uint32{1, 3, 4, 5}, encoded)
 	b := labels.NewScratchBuilder(len(encoded))
-	decoded := desymbolizeLabels(&b, encoded, s.Symbols())
+	decoded := DesymbolizeLabels(&b, encoded, s.Symbols())
 	require.Equal(t, ls, decoded)
 
 	// Different buf.


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

As metioned in this draft PR https://github.com/prometheus/client_golang/pull/1658#discussion_r1809266310 which will still take quite some time to merge, it would be great if we could call `DesymbolizeLabels ` in otel collector to prometheus translation layer for testing purposes https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/translator/prometheusremotewrite/metrics_to_prw_v2_test.go#L30. 