### PR TITLE
[release 2.53] Backport 15161 Fix(lezer-promql): add missing types export in package.json

### DIFF
--- a/web/ui/module/lezer-promql/package.json
+++ b/web/ui/module/lezer-promql/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.cjs",
   "type": "module",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.es.js",
     "require": "./dist/index.cjs"
   },


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
See original PR targeting main #15161

The exports property in lezer-promql is lacking a types prop making it impossible to work with in TS projects that use `moduleResolution: node16|nodeNext|bundler` in their [tsconfig](https://www.typescriptlang.org/tsconfig/#moduleResolution).

Pinging release shepherd @bboreham 🙏 