### PR TITLE
api: fix typo in list rules API response

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1374,7 +1374,7 @@ func (api *API) metricMetadata(r *http.Request) apiFuncResult {
 // RuleDiscovery has info for all rules.
 type RuleDiscovery struct {
 	RuleGroups     []*RuleGroup `json:"groups"`
-	GroupNextToken string       `json:"groupNextToken:omitempty"`
+	GroupNextToken string       `json:"groupNextToken,omitempty"`
 }
 
 // RuleGroup has info for rules which are part of a group.

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -2899,6 +2899,14 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 			errType:  errorBadData,
 			zeroFunc: rulesZeroFunc,
 		},
+		{ // groupNextToken should not be in empty response
+			endpoint: api.rules,
+			query: url.Values{
+				"match[]":     []string{`{testlabel="abc-cannot-find"}`},
+				"group_limit": []string{"1"},
+			},
+			responseAsJSON: `{"groups":[]}`,
+		},
 		{
 			endpoint: api.queryExemplars,
 			query: url.Values{


### PR DESCRIPTION
Fix typo in the list rules API response

~~obs.: I notice that we don't have end to end unit tests for the API, is this correct?~~