### PR TITLE
Parllelize tests for config package

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1536,6 +1536,7 @@ func TestRemoteWriteRetryOnRateLimit(t *testing.T) {
 
 func TestOTLPSanitizeResourceAttributes(t *testing.T) {
 	t.Run("good config", func(t *testing.T) {
+		t.Parallel()
 		want, err := LoadFile(filepath.Join("testdata", "otlp_sanitize_resource_attributes.good.yml"), false, promslog.NewNopLogger())
 		require.NoError(t, err)
 
@@ -1548,6 +1549,7 @@ func TestOTLPSanitizeResourceAttributes(t *testing.T) {
 	})
 
 	t.Run("bad config", func(t *testing.T) {
+		t.Parallel()
 		_, err := LoadFile(filepath.Join("testdata", "otlp_sanitize_resource_attributes.bad.yml"), false, promslog.NewNopLogger())
 		require.ErrorContains(t, err, `duplicated promoted OTel resource attribute "k8s.job.name"`)
 		require.ErrorContains(t, err, `empty promoted OTel resource attribute`)
@@ -2405,6 +2407,7 @@ func TestGetScrapeConfigs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			c, err := LoadFile(tc.configFile, false, promslog.NewNopLogger())
 			require.NoError(t, err)
 
@@ -2437,9 +2440,9 @@ func TestScrapeConfigDisableCompression(t *testing.T) {
 
 func TestScrapeConfigNameValidationSettings(t *testing.T) {
 	model.NameValidationScheme = model.UTF8Validation
-	defer func() {
+	defer t.Cleanup(func() {
 		model.NameValidationScheme = model.LegacyValidation
-	}()
+	})
 
 	tests := []struct {
 		name         string
@@ -2470,6 +2473,7 @@ func TestScrapeConfigNameValidationSettings(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			want, err := LoadFile(fmt.Sprintf("testdata/%s.yml", tc.inputFile), false, promslog.NewNopLogger())
 			require.NoError(t, err)
 
@@ -2528,6 +2532,7 @@ func TestScrapeProtocolHeader(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			mediaType := tc.proto.HeaderMediaType()
 
 			require.Equal(t, tc.expectedValue, mediaType)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2440,7 +2440,7 @@ func TestScrapeConfigDisableCompression(t *testing.T) {
 
 func TestScrapeConfigNameValidationSettings(t *testing.T) {
 	model.NameValidationScheme = model.UTF8Validation
-	defer t.Cleanup(func() {
+	t.Cleanup(func() {
 		model.NameValidationScheme = model.LegacyValidation
 	})
 


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
 
 Part of https://github.com/prometheus/prometheus/issues/15185

on `parllelize-tests-for-config`
```sh
❯ go test ./config -count=1
ok  	github.com/prometheus/prometheus/config	0.075s
```

on main at https://github.com/prometheus/prometheus/commit/101b1c307f2b80b142c38f7cebcc3db50084ed8f

```sh
❯ go test ./config -count=1                  
ok  	github.com/prometheus/prometheus/config	0.100s
```

The reduction is not much but raised the PR to cover the tests in `config` package. 

