### PR TITLE
[BUGFIX] PromQL: Corrects the behaviour of binary operator with bool modifier in case of Histograms

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2615,6 +2615,7 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 			} else {
 				floatValue = 0.0
 			}
+			histogramValue = nil
 		case !keep:
 			continue
 		}

--- a/promql/promqltest/testdata/operators.test
+++ b/promql/promqltest/testdata/operators.test
@@ -308,6 +308,13 @@ eval instant at 5m http_requests_histogram == http_requests_histogram
 
 eval instant at 5m http_requests_histogram != http_requests_histogram
 
+# Should produce valid results in case of (in)equality with bool modifier between two histograms.
+eval instant at 5m http_requests_histogram == bool http_requests_histogram
+    {job="app-server", instance="1", group="production"} 1
+
+eval instant at 5m http_requests_histogram != bool http_requests_histogram
+    {job="app-server", instance="1", group="production"} 0
+
 # group_left/group_right.
 
 clear


### PR DESCRIPTION
Related to #13934 .

Fixes the behaviour of binary operator with bool modifier when any operand is histogram.