### PR TITLE
promql: fix issues with comparison binary operations with `bool` modifier and native histograms

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2730,6 +2730,7 @@ func (ev *evaluator) VectorscalarBinop(op parser.ItemType, lhs Vector, rhs Scala
 		float, histogram, keep, err := vectorElemBinop(op, lf, rf, lh, rh, pos)
 		if err != nil {
 			lastErr = err
+			continue
 		}
 		// Catch cases where the scalar is the LHS in a scalar-vector comparison operation.
 		// We want to always keep the vector element value as the output value, even if it's on the RHS.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2610,6 +2610,7 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 		}
 		switch {
 		case returnBool:
+			histogramValue = nil
 			if keep {
 				floatValue = 1.0
 			} else {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2607,6 +2607,7 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 		floatValue, histogramValue, keep, err := vectorElemBinop(op, fl, fr, hl, hr, pos)
 		if err != nil {
 			lastErr = err
+			continue
 		}
 		switch {
 		case returnBool:

--- a/promql/promqltest/testdata/operators.test
+++ b/promql/promqltest/testdata/operators.test
@@ -508,3 +508,125 @@ eval instant at 1m 10 atan2 20
 
 eval instant at 1m 10 atan2 NaN
     NaN
+
+clear
+
+load 6m
+  left_floats  1 2 _ _ 3 stale 4  5  NaN Inf -Inf
+  right_floats 4 _ _ 5 3 7     -1 20 NaN Inf -Inf
+  left_histograms  {{schema:3 sum:4 count:4 buckets:[1 2 1]}} {{schema:3 sum:4.5 count:5 buckets:[1 3 1]}} _                                          _ {{schema:3 sum:4.5 count:5 buckets:[1 3 1]}}
+  right_histograms {{schema:3 sum:4 count:4 buckets:[1 2 1]}} {{schema:3 sum:4 count:4 buckets:[1 2 1]}}   {{schema:3 sum:4 count:4 buckets:[1 2 1]}} _ _
+  right_floats_for_histograms 0 -1 2 3 4
+
+eval range from 0 to 60m step 6m left_floats == right_floats
+  left_floats _ _ _ _ 3 _ _ _ _ Inf -Inf
+
+eval range from 0 to 60m step 6m left_floats == bool right_floats
+  {} 0 _ _ _ 1 _ 0 0 0 1 1
+
+eval range from 0 to 60m step 6m left_floats == does_not_match
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms == right_histograms
+  left_histograms {{schema:3 sum:4 count:4 buckets:[1 2 1]}} _ _ _ _
+
+eval range from 0 to 24m step 6m left_histograms == bool right_histograms
+  {} 1 0 _ _ _
+
+eval range from 0 to 24m step 6m left_histograms == right_floats_for_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms == bool right_floats_for_histograms
+  {} 0 0 _ _ 0
+
+eval range from 0 to 60m step 6m left_floats != right_floats
+  left_floats 1 _ _ _ _ _ 4 5 NaN _ _
+
+eval range from 0 to 60m step 6m left_floats != bool right_floats
+  {} 1 _ _ _ 0 _ 1 1 1 0 0
+
+eval range from 0 to 24m step 6m left_histograms != right_histograms
+  left_histograms _ {{schema:3 sum:4.5 count:5 buckets:[1 3 1]}} _ _ _
+
+eval range from 0 to 24m step 6m left_histograms != bool right_histograms
+  {} 0 1 _ _ _
+
+eval range from 0 to 24m step 6m left_histograms != right_floats_for_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms != bool right_floats_for_histograms
+  {} 0 0 _ _ 0
+
+eval range from 0 to 60m step 6m left_floats > right_floats
+  left_floats _ _ _ _ _ _ 4 _ _ _ _
+
+eval range from 0 to 60m step 6m left_floats > bool right_floats
+  {} 0 _ _ _ 0 _ 1 0 0 0 0
+
+eval range from 0 to 24m step 6m left_histograms > right_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms > bool right_histograms
+  {} 0 0 _ _ _
+
+eval range from 0 to 24m step 6m left_histograms > right_floats_for_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms > bool right_floats_for_histograms
+  {} 0 0 _ _ 0
+
+eval range from 0 to 60m step 6m left_floats >= right_floats
+  left_floats _ _ _ _ 3 _ 4 _ _ Inf -Inf
+
+eval range from 0 to 60m step 6m left_floats >= bool right_floats
+  {} 0 _ _ _ 1 _ 1 0 0 1 1
+
+eval range from 0 to 24m step 6m left_histograms >= right_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms >= bool right_histograms
+  {} 0 0 _ _ _
+
+eval range from 0 to 24m step 6m left_histograms >= right_floats_for_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms >= bool right_floats_for_histograms
+  {} 0 0 _ _ 0
+
+eval range from 0 to 60m step 6m left_floats < right_floats
+  left_floats 1 _ _ _ _ _ _ 5 _ _ _
+
+eval range from 0 to 60m step 6m left_floats < bool right_floats
+  {} 1 _ _ _ 0 _ 0 1 0 0 0
+
+eval range from 0 to 24m step 6m left_histograms < right_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms < bool right_histograms
+  {} 0 0 _ _ _
+
+eval range from 0 to 24m step 6m left_histograms < right_floats_for_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms < bool right_floats_for_histograms
+  {} 0 0 _ _ 0
+
+eval range from 0 to 60m step 6m left_floats <= right_floats
+  left_floats 1 _ _ _ 3 _ _ 5 _ Inf -Inf
+
+eval range from 0 to 60m step 6m left_floats <= bool right_floats
+  {} 1 _ _ _ 1 _ 0 1 0 1 1
+
+eval range from 0 to 24m step 6m left_histograms <= right_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms <= bool right_histograms
+  {} 0 0 _ _ _
+
+eval range from 0 to 24m step 6m left_histograms <= right_floats_for_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms <= bool right_floats_for_histograms
+  {} 0 0 _ _ 0
+
+clear

--- a/promql/promqltest/testdata/operators.test
+++ b/promql/promqltest/testdata/operators.test
@@ -630,4 +630,180 @@ eval_info range from 0 to 24m step 6m left_histograms <= right_floats_for_histog
 eval_info range from 0 to 24m step 6m left_histograms <= bool right_floats_for_histograms
   # No results.
 
+# Vector / scalar combinations with scalar on right side
+eval range from 0 to 60m step 6m left_floats == 3
+  left_floats _ _ _ _ 3 _ _ _ _ _ _
+
+eval range from 0 to 60m step 6m left_floats != 3
+  left_floats 1 2 _ _ _ _ 4 5 NaN Inf -Inf
+
+eval range from 0 to 60m step 6m left_floats > 3
+  left_floats _ _ _ _ _ _ 4 5 _ Inf _
+
+eval range from 0 to 60m step 6m left_floats >= 3
+  left_floats _ _ _ _ 3 _ 4 5 _ Inf _
+
+eval range from 0 to 60m step 6m left_floats < 3
+  left_floats 1 2 _ _ _ _ _ _ _ _ -Inf
+
+eval range from 0 to 60m step 6m left_floats <= 3
+  left_floats 1 2 _ _ 3 _ _ _ _ _ -Inf
+
+eval range from 0 to 60m step 6m left_floats == bool 3
+  {} 0 0 _ _ 1 _ 0 0 0 0 0
+
+eval range from 0 to 60m step 6m left_floats == Inf
+  left_floats _ _ _ _ _ _ _ _ _ Inf _
+
+eval range from 0 to 60m step 6m left_floats == bool Inf
+  {} 0 0 _ _ 0 _ 0 0 0 1 0
+
+eval range from 0 to 60m step 6m left_floats == NaN
+  # No results.
+
+eval range from 0 to 60m step 6m left_floats == bool NaN
+  {} 0 0 _ _ 0 _ 0 0 0 0 0
+
+eval_info range from 0 to 24m step 6m left_histograms == 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms == 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms != 3
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms != 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > 0
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms >= 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms >= 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms <= 3
+  # No results.
+
+eval range from 0 to 24m step 6m left_histograms <= 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms == bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms == bool 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms != bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms != bool 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > bool 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms >= bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms >= bool 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < bool 0
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms <= bool 3
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms <= bool 0
+  # No results.
+
+# Vector / scalar combinations with scalar on left side
+eval range from 0 to 60m step 6m 3 == left_floats
+  left_floats _ _ _ _ 3 _ _ _ _ _ _
+
+eval range from 0 to 60m step 6m 3 != left_floats
+  left_floats 1 2 _ _ _ _ 4 5 NaN Inf -Inf
+
+eval range from 0 to 60m step 6m 3 < left_floats
+  left_floats _ _ _ _ _ _ 4 5 _ Inf _
+
+eval range from 0 to 60m step 6m 3 <= left_floats
+  left_floats _ _ _ _ 3 _ 4 5 _ Inf _
+
+eval range from 0 to 60m step 6m 3 > left_floats
+  left_floats 1 2 _ _ _ _ _ _ _ _ -Inf
+
+eval range from 0 to 60m step 6m 3 >= left_floats
+  left_floats 1 2 _ _ 3 _ _ _ _ _ -Inf
+
+eval range from 0 to 60m step 6m 3 == bool left_floats
+  {} 0 0 _ _ 1 _ 0 0 0 0 0
+
+eval range from 0 to 60m step 6m Inf == left_floats
+  left_floats _ _ _ _ _ _ _ _ _ Inf _
+
+eval range from 0 to 60m step 6m Inf == bool left_floats
+  {} 0 0 _ _ 0 _ 0 0 0 1 0
+
+eval range from 0 to 60m step 6m NaN == left_floats
+  # No results.
+
+eval range from 0 to 60m step 6m NaN == bool left_floats
+  {} 0 0 _ _ 0 _ 0 0 0 0 0
+
+eval range from 0 to 24m step 6m 3 == left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 == left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 3 != left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 != left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 3 < left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 < left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 3 < left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 < left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 3 > left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 > left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 3 >= left_histograms
+  # No results.
+
+eval range from 0 to 24m step 6m 0 >= left_histograms
+  # No results.
+
 clear

--- a/promql/promqltest/testdata/operators.test
+++ b/promql/promqltest/testdata/operators.test
@@ -511,6 +511,7 @@ eval instant at 1m 10 atan2 NaN
 
 clear
 
+# Test comparison operations with floats and histograms.
 load 6m
   left_floats  1 2 _ _ 3 stale 4  5  NaN Inf -Inf
   right_floats 4 _ _ 5 3 7     -1 20 NaN Inf -Inf

--- a/promql/promqltest/testdata/operators.test
+++ b/promql/promqltest/testdata/operators.test
@@ -533,11 +533,11 @@ eval range from 0 to 24m step 6m left_histograms == right_histograms
 eval range from 0 to 24m step 6m left_histograms == bool right_histograms
   {} 1 0 _ _ _
 
-eval range from 0 to 24m step 6m left_histograms == right_floats_for_histograms
+eval_info range from 0 to 24m step 6m left_histograms == right_floats_for_histograms
   # No results.
 
-eval range from 0 to 24m step 6m left_histograms == bool right_floats_for_histograms
-  {} 0 0 _ _ 0
+eval_info range from 0 to 24m step 6m left_histograms == bool right_floats_for_histograms
+  # No results.
 
 eval range from 0 to 60m step 6m left_floats != right_floats
   left_floats 1 _ _ _ _ _ 4 5 NaN _ _
@@ -551,11 +551,11 @@ eval range from 0 to 24m step 6m left_histograms != right_histograms
 eval range from 0 to 24m step 6m left_histograms != bool right_histograms
   {} 0 1 _ _ _
 
-eval range from 0 to 24m step 6m left_histograms != right_floats_for_histograms
+eval_info range from 0 to 24m step 6m left_histograms != right_floats_for_histograms
   # No results.
 
-eval range from 0 to 24m step 6m left_histograms != bool right_floats_for_histograms
-  {} 0 0 _ _ 0
+eval_info range from 0 to 24m step 6m left_histograms != bool right_floats_for_histograms
+  # No results.
 
 eval range from 0 to 60m step 6m left_floats > right_floats
   left_floats _ _ _ _ _ _ 4 _ _ _ _
@@ -563,17 +563,17 @@ eval range from 0 to 60m step 6m left_floats > right_floats
 eval range from 0 to 60m step 6m left_floats > bool right_floats
   {} 0 _ _ _ 0 _ 1 0 0 0 0
 
-eval range from 0 to 24m step 6m left_histograms > right_histograms
+eval_info range from 0 to 24m step 6m left_histograms > right_histograms
   # No results.
 
-eval range from 0 to 24m step 6m left_histograms > bool right_histograms
-  {} 0 0 _ _ _
-
-eval range from 0 to 24m step 6m left_histograms > right_floats_for_histograms
+eval_info range from 0 to 24m step 6m left_histograms > bool right_histograms
   # No results.
 
-eval range from 0 to 24m step 6m left_histograms > bool right_floats_for_histograms
-  {} 0 0 _ _ 0
+eval_info range from 0 to 24m step 6m left_histograms > right_floats_for_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms > bool right_floats_for_histograms
+  # No results.
 
 eval range from 0 to 60m step 6m left_floats >= right_floats
   left_floats _ _ _ _ 3 _ 4 _ _ Inf -Inf
@@ -581,17 +581,17 @@ eval range from 0 to 60m step 6m left_floats >= right_floats
 eval range from 0 to 60m step 6m left_floats >= bool right_floats
   {} 0 _ _ _ 1 _ 1 0 0 1 1
 
-eval range from 0 to 24m step 6m left_histograms >= right_histograms
+eval_info range from 0 to 24m step 6m left_histograms >= right_histograms
   # No results.
 
-eval range from 0 to 24m step 6m left_histograms >= bool right_histograms
-  {} 0 0 _ _ _
-
-eval range from 0 to 24m step 6m left_histograms >= right_floats_for_histograms
+eval_info range from 0 to 24m step 6m left_histograms >= bool right_histograms
   # No results.
 
-eval range from 0 to 24m step 6m left_histograms >= bool right_floats_for_histograms
-  {} 0 0 _ _ 0
+eval_info range from 0 to 24m step 6m left_histograms >= right_floats_for_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms >= bool right_floats_for_histograms
+  # No results.
 
 eval range from 0 to 60m step 6m left_floats < right_floats
   left_floats 1 _ _ _ _ _ _ 5 _ _ _
@@ -599,17 +599,17 @@ eval range from 0 to 60m step 6m left_floats < right_floats
 eval range from 0 to 60m step 6m left_floats < bool right_floats
   {} 1 _ _ _ 0 _ 0 1 0 0 0
 
-eval range from 0 to 24m step 6m left_histograms < right_histograms
+eval_info range from 0 to 24m step 6m left_histograms < right_histograms
   # No results.
 
-eval range from 0 to 24m step 6m left_histograms < bool right_histograms
-  {} 0 0 _ _ _
-
-eval range from 0 to 24m step 6m left_histograms < right_floats_for_histograms
+eval_info range from 0 to 24m step 6m left_histograms < bool right_histograms
   # No results.
 
-eval range from 0 to 24m step 6m left_histograms < bool right_floats_for_histograms
-  {} 0 0 _ _ 0
+eval_info range from 0 to 24m step 6m left_histograms < right_floats_for_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms < bool right_floats_for_histograms
+  # No results.
 
 eval range from 0 to 60m step 6m left_floats <= right_floats
   left_floats 1 _ _ _ 3 _ _ 5 _ Inf -Inf
@@ -617,16 +617,16 @@ eval range from 0 to 60m step 6m left_floats <= right_floats
 eval range from 0 to 60m step 6m left_floats <= bool right_floats
   {} 1 _ _ _ 1 _ 0 1 0 1 1
 
-eval range from 0 to 24m step 6m left_histograms <= right_histograms
+eval_info range from 0 to 24m step 6m left_histograms <= right_histograms
   # No results.
 
-eval range from 0 to 24m step 6m left_histograms <= bool right_histograms
-  {} 0 0 _ _ _
-
-eval range from 0 to 24m step 6m left_histograms <= right_floats_for_histograms
+eval_info range from 0 to 24m step 6m left_histograms <= bool right_histograms
   # No results.
 
-eval range from 0 to 24m step 6m left_histograms <= bool right_floats_for_histograms
-  {} 0 0 _ _ 0
+eval_info range from 0 to 24m step 6m left_histograms <= right_floats_for_histograms
+  # No results.
+
+eval_info range from 0 to 24m step 6m left_histograms <= bool right_floats_for_histograms
+  # No results.
 
 clear


### PR DESCRIPTION
This PR fixes two issues:

* a query like `some_native_histograms == bool some_other_native_histograms` would return the histogram values from `some_native_histograms` for matching points, rather than 0 or 1 for non-matching / matching points
* a query like `some_native_histograms == bool some_floats` or `some_native_histograms == bool 3` would return values rather than no samples at all and a "incompatible samples types encountered in binary operation" annotation

Related to https://github.com/prometheus/prometheus/pull/15245 and https://github.com/prometheus/prometheus/issues/13934.