### PR TITLE
promql: fix incorrect "native histogram ignored in aggregation" annotations

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3059,7 +3059,7 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 
 		case parser.MAX:
 			if h != nil {
-				annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("min", e.Expr.PositionRange()))
+				annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("max", e.Expr.PositionRange()))
 				continue
 			}
 			if group.floatValue < f || math.IsNaN(group.floatValue) {
@@ -3068,7 +3068,7 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 
 		case parser.MIN:
 			if h != nil {
-				annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("max", e.Expr.PositionRange()))
+				annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("min", e.Expr.PositionRange()))
 				continue
 			}
 			if group.floatValue > f || math.IsNaN(group.floatValue) {
@@ -3084,6 +3084,7 @@ func (ev *evaluator) aggregation(e *parser.AggregateExpr, q float64, inputMatrix
 				delta := f - group.floatMean
 				group.floatMean += delta / group.groupCount
 				group.floatValue += delta * (f - group.floatMean)
+			} else {
 				if op == parser.STDVAR {
 					annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("stdvar", e.Expr.PositionRange()))
 				} else {


### PR DESCRIPTION
This PR fixes two issues I noticed introduced by https://github.com/prometheus/prometheus/pull/15245:

* the `stdvar` and `stddev` annotations are always emitted, even if native histograms aren't present
* the `min` and `max` annotations are sometimes emitted with the wrong annotation name