### PR TITLE
Upgrade to golangci-lint v1.62.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
         with:
           args: --verbose
           # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
-          version: v1.61.0
+          version: v1.62.0
   fuzzing:
     uses: ./.github/workflows/fuzzing.yml
     if: github.event_name == 'pull_request'

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.61.0
+GOLANGCI_LINT_VERSION ?= v1.62.0
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/documentation/examples/remote_storage/remote_storage_adapter/opentsdb/client_test.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/opentsdb/client_test.go
@@ -43,14 +43,14 @@ func TestMarshalStoreSamplesRequest(t *testing.T) {
 		Value:     3.1415,
 		Tags:      tagsFromMetric(metric),
 	}
-	expectedJSON := []byte(`{"metric":"test_.metric","timestamp":4711,"value":3.1415,"tags":{"many_chars":"abc_21ABC_.012-3_2145_C3_B667_7E89./","testlabel":"test_.value"}}`)
+	expectedJSON := `{"metric":"test_.metric","timestamp":4711,"value":3.1415,"tags":{"many_chars":"abc_21ABC_.012-3_2145_C3_B667_7E89./","testlabel":"test_.value"}}`
 
 	resultingJSON, err := json.Marshal(request)
 	require.NoError(t, err, "Marshal(request) resulted in err.")
-	require.Equal(t, expectedJSON, resultingJSON)
+	require.JSONEq(t, expectedJSON, string(resultingJSON))
 
 	var unmarshaledRequest StoreSamplesRequest
-	err = json.Unmarshal(expectedJSON, &unmarshaledRequest)
+	err = json.Unmarshal([]byte(expectedJSON), &unmarshaledRequest)
 	require.NoError(t, err, "Unmarshal(expectedJSON, &unmarshaledRequest) resulted in err.")
 	require.Equal(t, request, unmarshaledRequest)
 }

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -954,7 +954,7 @@ func TestMarshaling(t *testing.T) {
 	expectedJSON := "{\"aaa\":\"111\",\"bbb\":\"2222\",\"ccc\":\"33333\"}"
 	b, err := json.Marshal(lbls)
 	require.NoError(t, err)
-	require.Equal(t, expectedJSON, string(b))
+	require.JSONEq(t, expectedJSON, string(b))
 
 	var gotJ Labels
 	err = json.Unmarshal(b, &gotJ)
@@ -964,7 +964,7 @@ func TestMarshaling(t *testing.T) {
 	expectedYAML := "aaa: \"111\"\nbbb: \"2222\"\nccc: \"33333\"\n"
 	b, err = yaml.Marshal(lbls)
 	require.NoError(t, err)
-	require.Equal(t, expectedYAML, string(b))
+	require.YAMLEq(t, expectedYAML, string(b))
 
 	var gotY Labels
 	err = yaml.Unmarshal(b, &gotY)
@@ -980,7 +980,7 @@ func TestMarshaling(t *testing.T) {
 	b, err = json.Marshal(f)
 	require.NoError(t, err)
 	expectedJSONFromStruct := "{\"a_labels\":" + expectedJSON + "}"
-	require.Equal(t, expectedJSONFromStruct, string(b))
+	require.JSONEq(t, expectedJSONFromStruct, string(b))
 
 	var gotFJ foo
 	err = json.Unmarshal(b, &gotFJ)
@@ -990,7 +990,7 @@ func TestMarshaling(t *testing.T) {
 	b, err = yaml.Marshal(f)
 	require.NoError(t, err)
 	expectedYAMLFromStruct := "a_labels:\n  aaa: \"111\"\n  bbb: \"2222\"\n  ccc: \"33333\"\n"
-	require.Equal(t, expectedYAMLFromStruct, string(b))
+	require.YAMLEq(t, expectedYAMLFromStruct, string(b))
 
 	var gotFY foo
 	err = yaml.Unmarshal(b, &gotFY)

--- a/promql/histogram_stats_iterator_test.go
+++ b/promql/histogram_stats_iterator_test.go
@@ -14,7 +14,6 @@
 package promql
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
@@ -108,7 +107,7 @@ func TestHistogramStatsDecoding(t *testing.T) {
 					decodedStats = append(decodedStats, h)
 				}
 				for i := 0; i < len(tc.histograms); i++ {
-					require.Equal(t, tc.expectedHints[i], decodedStats[i].CounterResetHint, fmt.Sprintf("mismatch in counter reset hint for histogram %d", i))
+					require.Equalf(t, tc.expectedHints[i], decodedStats[i].CounterResetHint, "mismatch in counter reset hint for histogram %d", i)
 					h := tc.histograms[i]
 					if value.IsStaleNaN(h.Sum) {
 						require.True(t, value.IsStaleNaN(decodedStats[i].Sum))

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2609,7 +2609,7 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			accept := r.Header.Get("Accept")
 			if allowUTF8 {
-				require.Truef(t, strings.Contains(accept, "escaping=allow-utf-8"), "Expected Accept header to allow utf8, got %q", accept)
+				require.Containsf(t, accept, "escaping=allow-utf-8", "Expected Accept header to allow utf8, got %q", accept)
 			}
 			if protobufParsing {
 				require.True(t, strings.HasPrefix(accept, "application/vnd.google.protobuf;"),

--- a/scripts/golangci-lint.yml
+++ b/scripts/golangci-lint.yml
@@ -36,4 +36,4 @@ jobs:
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
           args: --verbose
-          version: v1.61.0
+          version: v1.62.0

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -526,7 +526,7 @@ func TestFromQueryResultWithDuplicates(t *testing.T) {
 
 	require.True(t, isErrSeriesSet, "Expected resulting series to be an errSeriesSet")
 	errMessage := errSeries.Err().Error()
-	require.Equal(t, "duplicate label with name: foo", errMessage, fmt.Sprintf("Expected error to be from duplicate label, but got: %s", errMessage))
+	require.Equalf(t, "duplicate label with name: foo", errMessage, "Expected error to be from duplicate label, but got: %s", errMessage)
 }
 
 func TestNegotiateResponseType(t *testing.T) {

--- a/storage/remote/intern_test.go
+++ b/storage/remote/intern_test.go
@@ -19,7 +19,6 @@
 package remote
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -33,7 +32,7 @@ func TestIntern(t *testing.T) {
 	interned, ok := interner.pool[testString]
 
 	require.True(t, ok)
-	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
+	require.Equalf(t, int64(1), interned.refs.Load(), "expected refs to be 1 but it was %d", interned.refs.Load())
 }
 
 func TestIntern_MultiRef(t *testing.T) {
@@ -44,13 +43,13 @@ func TestIntern_MultiRef(t *testing.T) {
 	interned, ok := interner.pool[testString]
 
 	require.True(t, ok)
-	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
+	require.Equalf(t, int64(1), interned.refs.Load(), "expected refs to be 1 but it was %d", interned.refs.Load())
 
 	interner.intern(testString)
 	interned, ok = interner.pool[testString]
 
 	require.True(t, ok)
-	require.Equal(t, int64(2), interned.refs.Load(), fmt.Sprintf("expected refs to be 2 but it was %d", interned.refs.Load()))
+	require.Equalf(t, int64(2), interned.refs.Load(), "expected refs to be 2 but it was %d", interned.refs.Load())
 }
 
 func TestIntern_DeleteRef(t *testing.T) {
@@ -61,7 +60,7 @@ func TestIntern_DeleteRef(t *testing.T) {
 	interned, ok := interner.pool[testString]
 
 	require.True(t, ok)
-	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
+	require.Equalf(t, int64(1), interned.refs.Load(), "expected refs to be 1 but it was %d", interned.refs.Load())
 
 	interner.release(testString)
 	_, ok = interner.pool[testString]
@@ -75,7 +74,7 @@ func TestIntern_MultiRef_Concurrent(t *testing.T) {
 	interner.intern(testString)
 	interned, ok := interner.pool[testString]
 	require.True(t, ok)
-	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
+	require.Equalf(t, int64(1), interned.refs.Load(), "expected refs to be 1 but it was %d", interned.refs.Load())
 
 	go interner.release(testString)
 
@@ -87,5 +86,5 @@ func TestIntern_MultiRef_Concurrent(t *testing.T) {
 	interned, ok = interner.pool[testString]
 	interner.mtx.RUnlock()
 	require.True(t, ok)
-	require.Equal(t, int64(1), interned.refs.Load(), fmt.Sprintf("expected refs to be 1 but it was %d", interned.refs.Load()))
+	require.Equalf(t, int64(1), interned.refs.Load(), "expected refs to be 1 but it was %d", interned.refs.Load())
 }

--- a/storage/series_test.go
+++ b/storage/series_test.go
@@ -14,7 +14,6 @@
 package storage
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
@@ -612,36 +611,36 @@ func testHistogramsSeriesToChunks(t *testing.T, test histogramTest) {
 		encodedSample := encodedSamples[i]
 		switch expectedSample := s.(type) {
 		case hSample:
-			require.Equal(t, chunkenc.ValHistogram, encodedSample.Type(), "expect histogram", fmt.Sprintf("at idx %d", i))
+			require.Equalf(t, chunkenc.ValHistogram, encodedSample.Type(), "expect histogram at idx %d", i)
 			h := encodedSample.H()
 			// Ignore counter reset if not gauge here, will check on chunk level.
 			if expectedSample.h.CounterResetHint != histogram.GaugeType {
 				h.CounterResetHint = histogram.UnknownCounterReset
 			}
 			if value.IsStaleNaN(expectedSample.h.Sum) {
-				require.True(t, value.IsStaleNaN(h.Sum), fmt.Sprintf("at idx %d", i))
+				require.Truef(t, value.IsStaleNaN(h.Sum), "at idx %d", i)
 				continue
 			}
-			require.Equal(t, *expectedSample.h, *h, fmt.Sprintf("at idx %d", i))
+			require.Equalf(t, *expectedSample.h, *h, "at idx %d", i)
 		case fhSample:
-			require.Equal(t, chunkenc.ValFloatHistogram, encodedSample.Type(), "expect float histogram", fmt.Sprintf("at idx %d", i))
+			require.Equalf(t, chunkenc.ValFloatHistogram, encodedSample.Type(), "expect float histogram at idx %d", i)
 			fh := encodedSample.FH()
 			// Ignore counter reset if not gauge here, will check on chunk level.
 			if expectedSample.fh.CounterResetHint != histogram.GaugeType {
 				fh.CounterResetHint = histogram.UnknownCounterReset
 			}
 			if value.IsStaleNaN(expectedSample.fh.Sum) {
-				require.True(t, value.IsStaleNaN(fh.Sum), fmt.Sprintf("at idx %d", i))
+				require.Truef(t, value.IsStaleNaN(fh.Sum), "at idx %d", i)
 				continue
 			}
-			require.Equal(t, *expectedSample.fh, *fh, fmt.Sprintf("at idx %d", i))
+			require.Equalf(t, *expectedSample.fh, *fh, "at idx %d", i)
 		default:
 			t.Error("internal error, unexpected type")
 		}
 	}
 
 	for i, expectedCounterResetHint := range test.expectedCounterResetHeaders {
-		require.Equal(t, expectedCounterResetHint, getCounterResetHint(chks[i]), fmt.Sprintf("chunk at index %d", i))
+		require.Equalf(t, expectedCounterResetHint, getCounterResetHint(chks[i]), "chunk at index %d", i)
 	}
 }
 

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -331,7 +331,7 @@ func TestPostingsMany(t *testing.T) {
 				exp = append(exp, e)
 			}
 		}
-		require.Equal(t, exp, got, fmt.Sprintf("input: %v", c.in))
+		require.Equalf(t, exp, got, "input: %v", c.in)
 	}
 }
 

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -3862,7 +3862,7 @@ func TestRespondSuccess_DefaultCodecCannotEncodeResponse(t *testing.T) {
 
 	require.Equal(t, http.StatusNotAcceptable, resp.StatusCode)
 	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	require.Equal(t, `{"status":"error","errorType":"not_acceptable","error":"cannot encode response as application/default-format"}`, string(body))
+	require.JSONEq(t, `{"status":"error","errorType":"not_acceptable","error":"cannot encode response as application/default-format"}`, string(body))
 }
 
 func TestRespondError(t *testing.T) {


### PR DESCRIPTION
Upgrade to golangci-lint v1.62.0, and fix linting failures.