### PR TITLE
Fix promtool analyze block shows metric name with 0 cardinality

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -589,7 +589,10 @@ func analyzeBlock(ctx context.Context, path, blockID string, limit int, runExten
 		if err != nil {
 			return err
 		}
-		postings = index.Intersect(postings, index.NewListPostings(refs))
+		// Only intersect postings if matchers are specified.
+		if len(matchers) > 0 {
+			postings = index.Intersect(postings, index.NewListPostings(refs))
+		}
 		count := 0
 		for postings.Next() {
 			count++


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Using latest promtool with `tsdb analyze block` command, it shows highest cardinality metric as 0.

I got output as following.

```
Highest cardinality metric names:
0 go_gc_cycles_automatic_gc_cycles_total
0 go_gc_cycles_forced_gc_cycles_total
0 go_gc_cycles_total_gc_cycles_total
0 go_gc_duration_seconds
0 go_gc_duration_seconds_count
0 go_gc_duration_seconds_sum
0 go_gc_gogc_percent
0 go_gc_gomemlimit_bytes
```

With this fix, I am able to get cardinality correctly.

```
Highest cardinality metric names:
60 prometheus_http_request_duration_seconds_bucket
54 prometheus_http_response_size_bytes_bucket
51 prometheus_http_requests_total
18 prometheus_sd_kubernetes_events_total
15 prometheus_tsdb_compaction_duration_seconds_bucket
13 prometheus_tsdb_compaction_chunk_size_bytes_bucket
13 prometheus_tsdb_compaction_chunk_samples_bucket
```

The bug here is that `refs` is empty if non matchers are specified. Intersect empty postings will match 0 series. To fix it, we only add posting intersection when matchers specified.