### PR TITLE
Fix: OTLP translator now keeps multiple separators in metric names

### DIFF
--- a/storage/remote/otlptranslator/prometheus/helpers_from_stdlib.go
+++ b/storage/remote/otlptranslator/prometheus/helpers_from_stdlib.go
@@ -63,21 +63,20 @@ func getTokensAndSeparators(s string, f func(rune) bool, allowUTF8 bool) ([]stri
 	a := make([]string, len(tokens))
 	// Separators are infered from the position gaps between tokens.
 	separators := make([]string, 0, len(tokens)-1)
-	for i := 0; i < len(tokens); i++ {
+	a[0] = s[tokens[0].start:tokens[0].end]
+	for i := 1; i < len(tokens); i++ {
 		a[i] = s[tokens[i].start:tokens[i].end]
-		if i > 0 {
-			if allowUTF8 {
-				separators = append(separators, s[tokens[i-1].end:tokens[i].start])
-			} else {
-				sep := ""
-				// We measure the rune count instead of using len because len returns amount of
-				// bytes in the string, and utf-8 runes can be multiple bytes long.
-				runeCount := utf8.RuneCountInString(s[tokens[i-1].end:tokens[i].start])
-				for j := 0; j < runeCount; j++ {
-					sep += "_"
-				}
-				separators = append(separators, sep)
+		if allowUTF8 {
+			separators = append(separators, s[tokens[i-1].end:tokens[i].start])
+		} else {
+			sep := ""
+			// We measure the rune count instead of using len because len returns amount of
+			// bytes in the string, and utf-8 runes can be multiple bytes long.
+			runeCount := utf8.RuneCountInString(s[tokens[i-1].end:tokens[i].start])
+			for j := 0; j < runeCount; j++ {
+				sep += "_"
 			}
+			separators = append(separators, sep)
 		}
 	}
 

--- a/storage/remote/otlptranslator/prometheus/helpers_from_stdlib.go
+++ b/storage/remote/otlptranslator/prometheus/helpers_from_stdlib.go
@@ -18,12 +18,11 @@ package prometheus
 
 import (
 	"strings"
-	"unicode/utf8"
 )
 
 // getTokensAndSeparators was originally a copy of strings.FieldsFunc from the Go standard library.
 // We've made a few changes to it, making sure we return the separator between tokens. If
-// UTF-8 isn't allowed, we replace all runes from the separator with an underscore.
+// UTF-8 isn't allowed, we replace all runes from the separator with one underscore.
 func getTokensAndSeparators(s string, f func(rune) bool, allowUTF8 bool) ([]string, []string) {
 	// A token is used to record a slice of s of the form s[start:end].
 	// The start index is inclusive and the end index is exclusive.
@@ -61,7 +60,7 @@ func getTokensAndSeparators(s string, f func(rune) bool, allowUTF8 bool) ([]stri
 
 	// Create strings from recorded field indices.
 	a := make([]string, len(tokens))
-	// Separators are infered from the position gaps between tokens.
+	// Separators are inferred from the position gaps between tokens.
 	separators := make([]string, 0, len(tokens)-1)
 	a[0] = s[tokens[0].start:tokens[0].end]
 	for i := 1; i < len(tokens); i++ {
@@ -69,14 +68,7 @@ func getTokensAndSeparators(s string, f func(rune) bool, allowUTF8 bool) ([]stri
 		if allowUTF8 {
 			separators = append(separators, s[tokens[i-1].end:tokens[i].start])
 		} else {
-			sep := ""
-			// We measure the rune count instead of using len because len returns amount of
-			// bytes in the string, and utf-8 runes can be multiple bytes long.
-			runeCount := utf8.RuneCountInString(s[tokens[i-1].end:tokens[i].start])
-			for j := 0; j < runeCount; j++ {
-				sep += "_"
-			}
-			separators = append(separators, sep)
+			separators = append(separators, "_")
 		}
 	}
 

--- a/storage/remote/otlptranslator/prometheus/helpers_from_stdlib.go
+++ b/storage/remote/otlptranslator/prometheus/helpers_from_stdlib.go
@@ -16,7 +16,10 @@
 
 package prometheus
 
-import "strings"
+import (
+	"strings"
+	"unicode/utf8"
+)
 
 // getTokensAndSeparators was originally a copy of strings.FieldsFunc from the Go standard library.
 // We've made a few changes to it, making sure we return the separator between tokens. If
@@ -67,7 +70,10 @@ func getTokensAndSeparators(s string, f func(rune) bool, allowUTF8 bool) ([]stri
 				separators = append(separators, s[tokens[i-1].end:tokens[i].start])
 			} else {
 				sep := ""
-				for j := tokens[i-1].end; j < tokens[i].start; j++ {
+				// We measure the rune count instead of using len because len returns amount of
+				// bytes in the string, and utf-8 runes can be multiple bytes long.
+				runeCount := utf8.RuneCountInString(s[tokens[i-1].end:tokens[i].start])
+				for j := 0; j < runeCount; j++ {
 					sep += "_"
 				}
 				separators = append(separators, sep)

--- a/storage/remote/otlptranslator/prometheus/normalize_name.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_name.go
@@ -130,6 +130,8 @@ func normalizeName(metric pmetric.Metric, namespace string, allowUTF8 bool) stri
 		translationFunc = func(r rune) bool { return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != ':' }
 	}
 	// Split metric name into "tokens" (of supported metric name runes).
+	// If UTF-8 isn't allowed, note that this has the side effect of replacing multiple consecutive underscores with a single underscore.
+	// This is part of the OTel to Prometheus specification: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.38.0/specification/compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus.
 	nameTokens, separators := getTokensAndSeparators(metric.Name(), translationFunc, allowUTF8)
 
 	// Split unit at the '/' if any

--- a/storage/remote/otlptranslator/prometheus/normalize_name_test.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_name_test.go
@@ -88,31 +88,15 @@ func TestAllowUTF8(t *testing.T) {
 		require.Equal(t, "unsupported.metric.weird_+=.:,!* & #", normalizeName(createGauge("unsupported.metric.weird", "+=.:,!* & #"), "", true))
 		require.Equal(t, "unsupported.metric.redundant___test $_per_°C", normalizeName(createGauge("unsupported.metric.redundant", "__test $/°C"), "", true))
 		require.Equal(t, "metric_with_字符_foreign_characters_ど", normalizeName(createGauge("metric_with_字符_foreign_characters", "ど"), "", true))
+		require.Equal(t, "metric....split_=+by_//utf8characters", normalizeName(createGauge("metric....split_=+by_//utf8characters", ""), "", true))
 	})
 	t.Run("disallow UTF8", func(t *testing.T) {
 		require.Equal(t, "unsupported_metric_temperature_F", normalizeName(createGauge("unsupported.metric.temperature", "°F"), "", false))
 		require.Equal(t, "unsupported_metric_weird", normalizeName(createGauge("unsupported.metric.weird", "+=.:,!* & #"), "", false))
 		require.Equal(t, "unsupported_metric_redundant_test_per_C", normalizeName(createGauge("unsupported.metric.redundant", "__test $/°C"), "", false))
-		require.Equal(t, "metric_with_foreign_characters", normalizeName(createGauge("metric_with_字符_foreign_characters", "ど"), "", false))
+		require.Equal(t, "metric_with____foreign_characters", normalizeName(createGauge("metric_with_字符_foreign_characters", "ど"), "", false))
+		require.Equal(t, "metric____split___by___utf8characters", normalizeName(createGauge("metric....split_=+by_//utf8characters", ""), "", false))
 	})
-}
-
-func TestAllowUTF8KnownBugs(t *testing.T) {
-	// Due to historical reasons, the translator code was copied from OpenTelemetry collector codebase.
-	// Over there, they tried to provide means to translate metric names following Prometheus conventions that are documented here:
-	// https://prometheus.io/docs/practices/naming/
-	//
-	// Althogh not explicitly said, it was implied that words should be separated by a single underscore and the codebase was written
-	// with that in mind.
-	//
-	// Now that we're allowing OTel users to have their original names stored in prometheus without any transformation, we're facing problems
-	// where two (or more) UTF-8 characters are being used to separate words.
-	// TODO(arthursens): Fix it!
-
-	// We're asserting on 'NotEqual', which proves the bug.
-	require.NotEqual(t, "metric....split_=+by_//utf8characters", normalizeName(createGauge("metric....split_=+by_//utf8characters", ""), "", true))
-	// Here we're asserting on 'Equal', showing the current behavior.
-	require.Equal(t, "metric.split_by_utf8characters", normalizeName(createGauge("metric....split_=+by_//utf8characters", ""), "", true))
 }
 
 func TestOTelReceivers(t *testing.T) {
@@ -210,7 +194,7 @@ func TestBuildCompliantNameWithSuffixes(t *testing.T) {
 	require.Equal(t, "system_io_bytes_total", BuildCompliantName(createCounter("system.io", "By"), "", true, false))
 	require.Equal(t, "system_network_io_bytes_total", BuildCompliantName(createCounter("network.io", "By"), "system", true, false))
 	require.Equal(t, "_3_14_digits", BuildCompliantName(createGauge("3.14 digits", ""), "", true, false))
-	require.Equal(t, "envoy_rule_engine_zlib_buf_error", BuildCompliantName(createGauge("envoy__rule_engine_zlib_buf_error", ""), "", true, false))
+	require.Equal(t, "envoy__rule_engine_zlib_buf_error", BuildCompliantName(createGauge("envoy__rule_engine_zlib_buf_error", ""), "", true, false))
 	require.Equal(t, ":foo::bar", BuildCompliantName(createGauge(":foo::bar", ""), "", true, false))
 	require.Equal(t, ":foo::bar_total", BuildCompliantName(createCounter(":foo::bar", ""), "", true, false))
 	// Gauges with unit 1 are considered ratios.

--- a/storage/remote/otlptranslator/prometheus/normalize_name_test.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_name_test.go
@@ -201,7 +201,7 @@ func TestBuildCompliantNameWithSuffixes(t *testing.T) {
 	require.Equal(t, "foo_bar_ratio", BuildCompliantName(createGauge("foo.bar", "1"), "", true, false))
 	// Slashes in units are converted.
 	require.Equal(t, "system_io_foo_per_bar_total", BuildCompliantName(createCounter("system.io", "foo/bar"), "", true, false))
-	require.Equal(t, "metric_with_foreign_characters_total", BuildCompliantName(createCounter("metric_with_字符_foreign_characters", ""), "", true, false))
+	require.Equal(t, "metric_with____foreign_characters_total", BuildCompliantName(createCounter("metric_with_字符_foreign_characters", ""), "", true, false))
 }
 
 func TestBuildCompliantNameWithoutSuffixes(t *testing.T) {

--- a/storage/remote/otlptranslator/prometheus/normalize_name_test.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_name_test.go
@@ -85,17 +85,17 @@ func TestEmpty(t *testing.T) {
 func TestAllowUTF8(t *testing.T) {
 	t.Run("allow UTF8", func(t *testing.T) {
 		require.Equal(t, "unsupported.metric.temperature_°F", normalizeName(createGauge("unsupported.metric.temperature", "°F"), "", true))
-		require.Equal(t, "unsupported.metric.weird_+=.:,!* & #", normalizeName(createGauge("unsupported.metric.weird", "+=.:,!* & #"), "", true))
+		require.Equal(t, "unsupported.metric.+weird_+=.:,!* & #", normalizeName(createGauge("unsupported.metric.+weird", "+=.:,!* & #"), "", true))
 		require.Equal(t, "unsupported.metric.redundant___test $_per_°C", normalizeName(createGauge("unsupported.metric.redundant", "__test $/°C"), "", true))
 		require.Equal(t, "metric_with_字符_foreign_characters_ど", normalizeName(createGauge("metric_with_字符_foreign_characters", "ど"), "", true))
 		require.Equal(t, "metric....split_=+by_//utf8characters", normalizeName(createGauge("metric....split_=+by_//utf8characters", ""), "", true))
 	})
 	t.Run("disallow UTF8", func(t *testing.T) {
 		require.Equal(t, "unsupported_metric_temperature_F", normalizeName(createGauge("unsupported.metric.temperature", "°F"), "", false))
-		require.Equal(t, "unsupported_metric_weird", normalizeName(createGauge("unsupported.metric.weird", "+=.:,!* & #"), "", false))
+		require.Equal(t, "unsupported_metric_weird", normalizeName(createGauge("unsupported.metric.+weird", "+=.:,!* & #"), "", false))
 		require.Equal(t, "unsupported_metric_redundant_test_per_C", normalizeName(createGauge("unsupported.metric.redundant", "__test $/°C"), "", false))
-		require.Equal(t, "metric_with____foreign_characters", normalizeName(createGauge("metric_with_字符_foreign_characters", "ど"), "", false))
-		require.Equal(t, "metric____split___by___utf8characters", normalizeName(createGauge("metric....split_=+by_//utf8characters", ""), "", false))
+		require.Equal(t, "metric_with_foreign_characters", normalizeName(createGauge("metric_with_字符_foreign_characters", "ど"), "", false))
+		require.Equal(t, "metric_split_by_utf8characters", normalizeName(createGauge("metric....split_=+by_//utf8characters", ""), "", false))
 	})
 }
 
@@ -194,14 +194,14 @@ func TestBuildCompliantNameWithSuffixes(t *testing.T) {
 	require.Equal(t, "system_io_bytes_total", BuildCompliantName(createCounter("system.io", "By"), "", true, false))
 	require.Equal(t, "system_network_io_bytes_total", BuildCompliantName(createCounter("network.io", "By"), "system", true, false))
 	require.Equal(t, "_3_14_digits", BuildCompliantName(createGauge("3.14 digits", ""), "", true, false))
-	require.Equal(t, "envoy__rule_engine_zlib_buf_error", BuildCompliantName(createGauge("envoy__rule_engine_zlib_buf_error", ""), "", true, false))
+	require.Equal(t, "envoy_rule_engine_zlib_buf_error", BuildCompliantName(createGauge("envoy__rule_engine_zlib_buf_error", ""), "", true, false))
 	require.Equal(t, ":foo::bar", BuildCompliantName(createGauge(":foo::bar", ""), "", true, false))
 	require.Equal(t, ":foo::bar_total", BuildCompliantName(createCounter(":foo::bar", ""), "", true, false))
 	// Gauges with unit 1 are considered ratios.
 	require.Equal(t, "foo_bar_ratio", BuildCompliantName(createGauge("foo.bar", "1"), "", true, false))
 	// Slashes in units are converted.
 	require.Equal(t, "system_io_foo_per_bar_total", BuildCompliantName(createCounter("system.io", "foo/bar"), "", true, false))
-	require.Equal(t, "metric_with____foreign_characters_total", BuildCompliantName(createCounter("metric_with_字符_foreign_characters", ""), "", true, false))
+	require.Equal(t, "metric_with_foreign_characters_total", BuildCompliantName(createCounter("metric_with_字符_foreign_characters", ""), "", true, false))
 }
 
 func TestBuildCompliantNameWithoutSuffixes(t *testing.T) {


### PR DESCRIPTION
Fixes #15362 

---

To solve this, I've refactored the function that splits metric names into tokens and separators. Now, the separators are inferred from the position gaps between tokens.

~The fix looks easy, but I've hit a strange behavior with foreign characters. Foreign characters skip positions when looping over an array of runes (a string). As shown in this playground: https://go.dev/play/p/qYywzhbbXcf Notice how the positions of `字` and `符` do not follow the numeral order.~ Fixed in the second commit :)