### PR TITLE
docs: update required go version in readme to 1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Prometheus will now be reachable at <http://localhost:9090/>.
 
 To build Prometheus from source code, You need:
 
-* Go [version 1.17 or greater](https://golang.org/doc/install).
+* Go [version 1.22 or greater](https://golang.org/doc/install).
 * NodeJS [version 16 or greater](https://nodejs.org/).
 * npm [version 7 or greater](https://www.npmjs.com/).
 


### PR DESCRIPTION
It was bumped during 3.0 with the adoption of log/slog and other dep
updates.

```
~/go/src/github.com/prometheus/prometheus (main [  ]) -> grep '^go' go.mod
go 1.22.0
```

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
