### PR TITLE
Added test to demonstrate unintuitive `avg_over_time` behavior related to `NaN` values

### DIFF
--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -1023,10 +1023,10 @@ eval instant at 1m last_over_time(data[2m])
 	data{type="only_nan"} NaN
 
 eval instant at 1m avg_over_time(data[2m])
+	data{type="some_nan3"} 0.5
 	data{type="numbers"} 1.6666666666666667
 	data{type="some_nan"} 1
 	data{type="some_nan2"} 1.5
-	data{type="some_nan3"} 0.5
 	data{type="only_nan"} NaN
 
 clear

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -1022,6 +1022,13 @@ eval instant at 1m last_over_time(data[2m])
 	data{type="some_nan3"} 1
 	data{type="only_nan"} NaN
 
+eval instant at 1m avg_over_time(data[2m])
+	data{type="numbers"} 1.6666666666666667
+	data{type="some_nan"} 1
+	data{type="some_nan2"} 1.5
+	data{type="some_nan3"} 0.5
+	data{type="only_nan"} NaN
+
 clear
 
 # Test for absent()


### PR DESCRIPTION
Add test with expected results to demonstrates bug reported via #15450, where `avg_over_time` doesn't ignore `NaN` values, unlike min_over_time and max_over_time functions
