### PR TITLE
Revert "chore(deps): bump github.com/fsnotify/fsnotify from 1.7.0 to 1.8.0 (#15300)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/envoyproxy/go-control-plane v0.13.1
 	github.com/envoyproxy/protoc-gen-validate v1.1.0
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
-	github.com/fsnotify/fsnotify v1.8.0
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-zookeeper/zk v1.0.4
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
 github.com/frankban/quicktest v1.14.5/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
-github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=


### PR DESCRIPTION
This reverts commit e243ed66b9638fe78d334b7e3fb9fc41863fb3cd.

The [update to fsnotify 1.8.0](https://github.com/prometheus/prometheus/pull/15300) appears to cause a lot of test flakes on Windows, due to a goroutine leak. See [Slack thread](https://cloud-native.slack.com/archives/C01AUBA4PFE/p1732538979012299) and example:

```console
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 790 in state select, locked to thread, with github.com/fsnotify/fsnotify.(*readDirChangesW).sendEvent on top of the stack:
github.com/fsnotify/fsnotify.(*readDirChangesW).sendEvent(0xc0005c65c0, {0xc000418600?, 0xc000036fc0?}, {0x0?, 0xffffffff?}, 0xc00038dc00?)
	C:/Users/runneradmin/go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_windows.go:72 +0x176
```