### PR TITLE
MemPostings: allocate ListPostings once in PostingsForAllLabelValues

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -454,10 +454,14 @@ func (p *MemPostings) PostingsForAllLabelValues(ctx context.Context, name string
 
 	e := p.m[name]
 	its := make([]Postings, 0, len(e))
+	lps := make([]ListPostings, len(e))
+	i := 0
 	for _, refs := range e {
 		if len(refs) > 0 {
-			its = append(its, NewListPostings(refs))
+			lps[i] = ListPostings{list: refs}
+			its = append(its, &lps[i])
 		}
+		i++
 	}
 
 	// Let the mutex go before merging.


### PR DESCRIPTION
Same as #15427 but for the new method added in #14144

Instead of allocating each ListPostings one by one, allocate them all in one go.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
