### PR TITLE
promql: Add NaN tests for avg and avg_over_time

### DIFF
--- a/promql/promqltest/testdata/aggregators.test
+++ b/promql/promqltest/testdata/aggregators.test
@@ -543,6 +543,7 @@ load 10s
 	data{test="bigzero",point="b"} -9.988465674311579e+307
 	data{test="bigzero",point="c"} 9.988465674311579e+307
 	data{test="bigzero",point="d"} 9.988465674311579e+307
+	data{test="value is nan"} NaN
 
 eval instant at 1m avg(data{test="ten"})
 	{} 10
@@ -576,6 +577,10 @@ eval instant at 1m avg(data{test="-big"})
 
 eval instant at 1m avg(data{test="bigzero"})
 	{} 0
+
+# If NaN is in the mix, the result is NaN.
+eval instant at 1m avg(data)
+	{} NaN
 
 # Test summing and averaging extreme values.
 clear

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -713,6 +713,7 @@ load 10s
   metric8 9.988465674311579e+307 9.988465674311579e+307
   metric9 -9.988465674311579e+307 -9.988465674311579e+307 -9.988465674311579e+307
   metric10 -9.988465674311579e+307 9.988465674311579e+307
+  metric11 1 2 3 NaN NaN
 
 eval instant at 55s avg_over_time(metric[1m])
   {} 3
@@ -805,6 +806,19 @@ eval instant at 45s sum_over_time(metric10[1m])/count_over_time(metric10[1m])
 
 eval instant at 1m sum_over_time(metric10[2m])/count_over_time(metric10[2m])
   {} 0
+
+# NaN behavior.
+eval instant at 20s avg_over_time(metric11[1m])
+  {} 2
+
+eval instant at 30s avg_over_time(metric11[1m])
+  {} NaN
+
+eval instant at 1m avg_over_time(metric11[1m])
+  {} NaN
+
+eval instant at 1m sum_over_time(metric11[1m])/count_over_time(metric11[1m])
+  {} NaN
 
 # Test if very big intermediate values cause loss of detail.
 clear


### PR DESCRIPTION
#15450 showed some confusion about the behavior.

Personally, I think the current behavior is straightforward and expected from the usual IEEE 754 arithmetic. So arguably, it isn't even an edgecase. However, avoiding ambiguities is good, so the concern raised in #15450 that the behavior with NaN is not tested is legitimate. This adds tests for it.