### PR TITLE
[BUGFIX] PromQL: Ignore histograms in all time related functions

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1553,6 +1553,10 @@ func dateWrapper(vals []parser.Value, enh *EvalNodeHelper, f func(time.Time) flo
 	}
 
 	for _, el := range vals[0].(Vector) {
+		if el.H != nil {
+			// Ignore histogram sample.
+			continue
+		}
 		t := time.Unix(int64(el.F), 0).UTC()
 		if !enh.enableDelayedNameRemoval {
 			el.Metric = el.Metric.DropMetricName()

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -901,6 +901,9 @@ eval_warn instant at 1m (quantile_over_time(2, (data[2m])))
 clear
 
 # Test time-related functions.
+load 5m
+    histogram_sample {{schema:0 sum:1 count:1}}
+
 eval instant at 0m year()
   {} 1970
 
@@ -981,6 +984,23 @@ eval instant at 0m days_in_month(vector(1454284800))
 # February 1st 2017 not in leap year.
 eval instant at 0m days_in_month(vector(1485907200))
   {} 28
+
+# Test for histograms.
+eval instant at 0m day_of_month(histogram_sample)
+
+eval instant at 0m day_of_week(histogram_sample)
+
+eval instant at 0m day_of_year(histogram_sample)
+
+eval instant at 0m days_in_month(histogram_sample)
+
+eval instant at 0m hour(histogram_sample)
+
+eval instant at 0m minute(histogram_sample)
+
+eval instant at 0m month(histogram_sample)
+
+eval instant at 0m year(histogram_sample)
 
 clear
 


### PR DESCRIPTION
Part of #13934.

Currently all the time related functions treats `histograms` as `0`, but they should ignore histograms. This PR fixes this behaviour.

CC: @beorn7 