### PR TITLE
hot reload always_scrape_classic_histograms and convert_classic_histo…

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -330,6 +330,8 @@ func (sp *scrapePool) restartLoops(reuseCache bool) {
 		trackTimestampsStaleness = sp.config.TrackTimestampsStaleness
 		mrc                      = sp.config.MetricRelabelConfigs
 		fallbackScrapeProtocol   = sp.config.ScrapeFallbackProtocol.HeaderMediaType()
+		alwaysScrapeClassicHist  = sp.config.AlwaysScrapeClassicHistograms
+		convertClassicHistToNHCB = sp.config.ConvertClassicHistogramsToNHCB
 	)
 
 	validationScheme := model.UTF8Validation
@@ -377,6 +379,8 @@ func (sp *scrapePool) restartLoops(reuseCache bool) {
 				timeout:                  timeout,
 				validationScheme:         validationScheme,
 				fallbackScrapeProtocol:   fallbackScrapeProtocol,
+				alwaysScrapeClassicHist:  alwaysScrapeClassicHist,
+				convertClassicHistToNHCB: convertClassicHistToNHCB,
 			})
 		)
 		if err != nil {


### PR DESCRIPTION
…grams_to_nhcb configs properly

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Fixes https://github.com/prometheus/prometheus/issues/15464

`always_scrape_classic_histograms` was only applied during `scrapePool.sync` but not during  `scrapePool. restartLoops`, which is used by reload.

I noticed that `convert_classic_histograms` config has the same issue so this PR fixes it as well.

I don't see any existing test covering those reload behavior for each individual scrape configs. But I verified this PR locally and hot reload worked.