### PR TITLE
scrape: fix nil panic after scrape loop reload

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -359,6 +359,7 @@ func (sp *scrapePool) restartLoops(reuseCache bool) {
 				bodySizeLimit:        bodySizeLimit,
 				acceptHeader:         acceptHeader(sp.config.ScrapeProtocols, validationScheme),
 				acceptEncodingHeader: acceptEncodingHeader(enableCompression),
+				metrics:              sp.metrics,
 			}
 			newLoop = sp.newLoop(scrapeLoopOptions{
 				target:                   t,

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -4795,7 +4795,8 @@ func newScrapableServer(scrapeText string) (s *httptest.Server, scrapedTwice cha
 	})), scrapedTwice
 }
 
-func TestTargetScraperSetsMetricsField(t *testing.T) {
+// Regression test for the panic fixed in https://github.com/prometheus/prometheus/pull/15523.
+func TestScrapePoolScrapeAfterReload(t *testing.T) {
 	h := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte{0x42, 0x42})


### PR DESCRIPTION
Don't forget to set `metrics` field as otherwise scraping will lead to a nil panic in case the body size limit is reached.

Fixes the following panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa0 pc=0x29f38c2]

goroutine 240719 [running]:
github.com/prometheus/prometheus/scrape.(*targetScraper).readResponse(0xc0077f80c0, {0x0?, 0x3e8?}, 0xc0013954d0, {0x4526440, 0xc01c2b66f0})
        /app/scrape/scrape.go:774 +0xa02
github.com/prometheus/prometheus/scrape.(*scrapeLoop).scrapeAndReport(0xc01d28bd40, {0xedede7841?, 0x6402080?, 0x0?}, {0xedede7841?, 0x6402080?, 0x6402080?}, 0x0)
        /app/scrape/scrape.go:1333 +0x92f
github.com/prometheus/prometheus/scrape.(*scrapeLoop).run(0xc01d28bd40, 0x0)
        /app/scrape/scrape.go:1253 +0x376
github.com/prometheus/prometheus/scrape.(*scrapePool).restartLoops.func1({0x45668c0?, 0xc00dff0fc0?}, {0x45668c0, 0xc01d28bd40})
        /app/scrape/scrape.go:356 +0x89
created by github.com/prometheus/prometheus/scrape.(*scrapePool).restartLoops in goroutine 240712
        /app/scrape/scrape.go:351 +0x7f3
```