### PR TITLE
Support arbitrary user IDs in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY NOTICE                                 /NOTICE
 COPY npm_licenses.tar.bz2                   /npm_licenses.tar.bz2
 
 WORKDIR /prometheus
-RUN chown -R nobody:nobody /etc/prometheus /prometheus
+RUN chgrp -R 0 /etc/prometheus /prometheus && chmod -R g=u /etc/prometheus /prometheus
 
 USER       nobody
 EXPOSE     9090


### PR DESCRIPTION
This PR changes the permissions of the Docker image for config (`/etc/prometheus`) and data (`/prometheus`) mounted paths to allow the user to set an arbitrary user ID within these paths (using the `docker run --user` flag, [reference](https://docs.docker.com/reference/cli/docker/container/run/#options)).

The command `chgrp -R 0` recursively sets the owner of these mounted paths to the ID 0 root group (whose members can edit any file under these paths), and then use the command `chmod -R g=u` to grant the group the same permissions as the root user.

This sets the directory and file permissions under the config and data mounted paths to allow users in the root group to access them in the built image. Because the container user is always a member of the root group, the container user can read and write these files.

Currently, this image does not support arbitrary container user IDs. In the case where one's persistent files have a different preferred file owner UID/GID (common ones are `1000:1000` or `99:100`), then attempting to run this image with a command such as `docker run -v '/mnt/user/appdata/prometheus/data':'/prometheus/':'rw' -v '/mnt/user/appdata/prometheus/config':'/etc/prometheus/':'ro' --user 99:100 'prom/prometheus'` immediately shuts down with a permissions error, example log:
```log
time=2024-12-02T16:09:23.690-05:00 level=INFO source=main.go:642 msg="No time or size retention was set so using the default time retention" duration=15d
time=2024-12-02T16:09:23.691-05:00 level=INFO source=main.go:689 msg="Starting Prometheus Server" mode=server version="(version=3.0.1, branch=HEAD, revision=1f56e8492c31a558ccea833027db4bd7f8b6d0e9)"
time=2024-12-02T16:09:23.691-05:00 level=INFO source=main.go:694 msg="operational information" build_context="(go=go1.23.3, platform=linux/amd64, user=root@9c13055ffc3c, date=20241128-17:20:55, tags=netgo,builtinassets,stringlabels)" host_details="(Linux 6.1.118-Unraid #1 SMP PREEMPT_DYNAMIC Thu Nov 21 15:54:38 PST 2024 x86_64 d4ab59445339 (none))" fd_limits="(soft=40960, hard=40960)" vm_limits="(soft=unlimited, hard=unlimited)"
time=2024-12-02T16:09:23.693-05:00 level=INFO source=main.go:770 msg="Leaving GOMAXPROCS=22: CPU quota undefined" component=automaxprocs
time=2024-12-02T16:09:23.694-05:00 level=ERROR source=query_logger.go:113 msg="Error opening query log file" component=activeQueryTracker file=/prometheus/queries.active err="open /prometheus/queries.active: permission denied"
panic: Unable to create mmap-ed active query log

goroutine 1 [running]:
github.com/prometheus/prometheus/promql.NewActiveQueryTracker({0x7ffd3e2a2f0e, 0xb}, 0x14, 0xc000a92a80)
        /app/promql/query_logger.go:145 +0x345
main.main()
        /app/cmd/prometheus/main.go:797 +0x82ec
```
This happens because the current Dockerfile's `chown` command uses the name `nobody:nobody` which persists the upstream user's UID/GID, and does not allow any other ID to read/write to these mounted paths.

```sh
$ docker run --name prometheus prom/prometheus
$ docker exec -ti prometheus sh
/prometheus $ whoami
nobody
/prometheus $ groups
nobody
/prometheus $ id -u
65534
```

At image build time, likely somewhere in the upstream base image (the furthest back I looked depends on an [upstream](https://github.com/prometheus/busybox/blob/master/glibc/Dockerfile#L3) `debian` image), the container's rootless user ID must have been set to `65534`. Since the Dockerfile's `chown -R nobody:nobody` command persists this ID, that ID is the only one with write permissions to the mounted paths. Therefore, one must set their owner of their mounted paths for the `prometheus.yml` and data directory to `65534` even on their host filesystem outside of the container for the container's current config to run.

This follows best practices according to Red Hat / OpenShift [documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.12/html/images/creating-images#use-uid_create-images), which OpenShift uses in their own Prometheus image [here](https://catalog.redhat.com/software/containers/openshift4/ose-prometheus/5cdc1e585a13467289f5841a?architecture=amd64&image=67341e5e446652d772e976c0&container-tabs=dockerfile).

This will resolve issue https://github.com/prometheus/prometheus/issues/3441.
This change is the same one made in PR https://github.com/prometheus/prometheus/pull/12728. That PR has been open for over a year, and is currently awaiting a Git signoff fix. Unfortunately there has been no activity on that PR for several months.
CCing the contributors involved in that PR @bboreham @marvinnitz18 for visibility.

Please let me know if there is anything else I should do in seeking approval of this PR. I am a first-time contributor to Prometheus.


<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
