### PR TITLE
doc(nomad): adjust nomad_sd_config's server definition

### DIFF
--- a/discovery/nomad/nomad_test.go
+++ b/discovery/nomad/nomad_test.go
@@ -127,19 +127,37 @@ func (m *SDMock) HandleServiceHashiCupsGet() {
 }
 
 func TestConfiguredService(t *testing.T) {
-	conf := &SDConfig{
-		Server: "http://localhost:4646",
+	testCases := []struct {
+		name        string
+		server      string
+		acceptedURL bool
+	}{
+		{"invalid hostname URL", "http://foo.bar:4646", true},
+		{"invalid even though accepted by parsing", "foo.bar:4646", true},
+		{"valid address URL", "http://172.30.29.23:4646", true},
+		{"invalid URL", "172.30.29.23:4646", false},
 	}
 
-	reg := prometheus.NewRegistry()
-	refreshMetrics := discovery.NewRefreshMetrics(reg)
-	metrics := conf.NewDiscovererMetrics(reg, refreshMetrics)
-	require.NoError(t, metrics.Register())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := &SDConfig{
+				Server: tc.server,
+			}
 
-	_, err := NewDiscovery(conf, nil, metrics)
-	require.NoError(t, err)
+			reg := prometheus.NewRegistry()
+			refreshMetrics := discovery.NewRefreshMetrics(reg)
+			metrics := conf.NewDiscovererMetrics(reg, refreshMetrics)
+			require.NoError(t, metrics.Register())
+			defer metrics.Unregister()
 
-	metrics.Unregister()
+			_, err := NewDiscovery(conf, nil, metrics)
+			if tc.acceptedURL {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
 }
 
 func TestNomadSDRefresh(t *testing.T) {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2130,7 +2130,8 @@ The following meta labels are available on targets during [relabeling](#relabel_
 [ namespace: <string> | default = default ]
 [ refresh_interval: <duration> | default = 60s ]
 [ region: <string> | default = global ]
-[ server: <host> ]
+# The URL to connect to the API.
+[ server: <string> ]
 [ tag_separator: <string> | default = ,]
 
 # HTTP client settings, including authentication methods (such as basic auth and


### PR DESCRIPTION
test(nomad): extend TestConfiguredService with more valid/invalid servers configs

fixes https://github.com/prometheus/prometheus/issues/12306

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
