### PR TITLE
Don't panic if ActiveQueryTracker is closed

### DIFF
--- a/promql/query_logger.go
+++ b/promql/query_logger.go
@@ -220,7 +220,7 @@ func (tracker ActiveQueryTracker) Delete(insertIndex int) {
 
 func (tracker ActiveQueryTracker) Insert(ctx context.Context, query string) (int, error) {
 	if !tracker.isRunning.Load() {
-		return 0, errors.New("ActiveQueryTracker is stopped")
+		return 0, nil
 	}
 	select {
 	case i := <-tracker.getNextIndex:


### PR DESCRIPTION
When ActiveQueryTracker is closed it closes the mmap-ed file it writes to, and so any query logged after that point will cause a panic. This change tracks when ActiveQueryTracker is closed and if that happens it stops trying to write to mmap-ed file.

Fixes #15232.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
