### PR TITLE
OTLP receiver: Don't call NormalizeLabel in `NoUTF8EscapingWithSuffixes` mode

### DIFF
--- a/storage/remote/otlptranslator/prometheus/normalize_label.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_label.go
@@ -29,15 +29,15 @@ import (
 //
 // Labels that start with non-letter rune will be prefixed with "key_".
 // An exception is made for double-underscores which are allowed.
-func NormalizeLabel(label string, allowUTF8 bool) string {
-	// Trivial case
-	if len(label) == 0 || allowUTF8 {
+func NormalizeLabel(label string) string {
+	// Trivial case.
+	if len(label) == 0 {
 		return label
 	}
 
 	label = strutil.SanitizeLabelName(label)
 
-	// If label starts with a number, prepend with "key_"
+	// If label starts with a number, prepend with "key_".
 	if unicode.IsDigit(rune(label[0])) {
 		label = "key_" + label
 	} else if strings.HasPrefix(label, "_") && !strings.HasPrefix(label, "__") {

--- a/storage/remote/otlptranslator/prometheus/normalize_label_test.go
+++ b/storage/remote/otlptranslator/prometheus/normalize_label_test.go
@@ -22,27 +22,24 @@ import (
 
 func TestNormalizeLabel(t *testing.T) {
 	tests := []struct {
-		label        string
-		expected     string
-		expectedUTF8 string
+		label    string
+		expected string
 	}{
-		{"", "", ""},
-		{"label:with:colons", "label_with_colons", "label:with:colons"}, // Without UTF-8 support, colons are only allowed in metric names
-		{"LabelWithCapitalLetters", "LabelWithCapitalLetters", "LabelWithCapitalLetters"},
-		{"label!with&special$chars)", "label_with_special_chars_", "label!with&special$chars)"},
-		{"label_with_foreign_characters_字符", "label_with_foreign_characters___", "label_with_foreign_characters_字符"},
-		{"label.with.dots", "label_with_dots", "label.with.dots"},
-		{"123label", "key_123label", "123label"},
-		{"_label_starting_with_underscore", "key_label_starting_with_underscore", "_label_starting_with_underscore"},
-		{"__label_starting_with_2underscores", "__label_starting_with_2underscores", "__label_starting_with_2underscores"},
+		{"", ""},
+		{"label:with:colons", "label_with_colons"},
+		{"LabelWithCapitalLetters", "LabelWithCapitalLetters"},
+		{"label!with&special$chars)", "label_with_special_chars_"},
+		{"label_with_foreign_characters_字符", "label_with_foreign_characters___"},
+		{"label.with.dots", "label_with_dots"},
+		{"123label", "key_123label"},
+		{"_label_starting_with_underscore", "key_label_starting_with_underscore"},
+		{"__label_starting_with_2underscores", "__label_starting_with_2underscores"},
 	}
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
-			result := NormalizeLabel(test.label, false)
+			result := NormalizeLabel(test.label)
 			require.Equal(t, test.expected, result)
-			uTF8result := NormalizeLabel(test.label, true)
-			require.Equal(t, test.expectedUTF8, uTF8result)
 		})
 	}
 }

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper.go
@@ -157,7 +157,10 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, setting
 	// map ensures no duplicate label names.
 	l := make(map[string]string, maxLabelCount)
 	for _, label := range labels {
-		var finalKey = prometheustranslator.NormalizeLabel(label.Name, settings.AllowUTF8)
+		finalKey := label.Name
+		if !settings.AllowUTF8 {
+			finalKey = prometheustranslator.NormalizeLabel(finalKey)
+		}
 		if existingValue, alreadyExists := l[finalKey]; alreadyExists {
 			l[finalKey] = existingValue + ";" + label.Value
 		} else {
@@ -166,7 +169,10 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, setting
 	}
 
 	for _, lbl := range promotedAttrs {
-		normalized := prometheustranslator.NormalizeLabel(lbl.Name, settings.AllowUTF8)
+		normalized := lbl.Name
+		if !settings.AllowUTF8 {
+			normalized = prometheustranslator.NormalizeLabel(normalized)
+		}
 		if _, exists := l[normalized]; !exists {
 			l[normalized] = lbl.Value
 		}
@@ -204,8 +210,8 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, setting
 			log.Println("label " + name + " is overwritten. Check if Prometheus reserved labels are used.")
 		}
 		// internal labels should be maintained
-		if !(len(name) > 4 && name[:2] == "__" && name[len(name)-2:] == "__") {
-			name = prometheustranslator.NormalizeLabel(name, settings.AllowUTF8)
+		if !settings.AllowUTF8 && !(len(name) > 4 && name[:2] == "__" && name[len(name)-2:] == "__") {
+			name = prometheustranslator.NormalizeLabel(name)
 		}
 		l[name] = extras[i+1]
 	}


### PR DESCRIPTION
Some basic simplification of the OTLP translation logic, where it doesn't call `prometheustranslator.NormalizeLabel` if the translation mode is `NoUTF8EscapingWithSuffixes`. Behaviour doesn't change, the motivation is simply readability/maintainability.

Prior to the PR, `prometheustranslator.NormalizeLabel` is a no-op if the translation mode is `NoUTF8EscapingWithSuffixes`, so it's just confusing to the reader (and the doc comment is also misleading, as it doesn't take this mode into account).