### PR TITLE
chore(deps): use `version.PrometheusUserAgent`

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -328,7 +328,7 @@ func main() {
 			kingpin.Fatalf("Failed to load HTTP config file: %v", err)
 		}
 
-		httpRoundTripper, err = promconfig.NewRoundTripperFromConfig(*httpConfig, "promtool", promconfig.WithUserAgent("promtool/"+version.Version))
+		httpRoundTripper, err = promconfig.NewRoundTripperFromConfig(*httpConfig, "promtool", promconfig.WithUserAgent(version.ComponentUserAgent("promtool")))
 		if err != nil {
 			kingpin.Fatalf("Failed to create a new HTTP round tripper: %v", err)
 		}

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -70,18 +70,14 @@ const (
 	authMethodManagedIdentity = "ManagedIdentity"
 )
 
-var (
-	userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
-
-	// DefaultSDConfig is the default Azure SD configuration.
-	DefaultSDConfig = SDConfig{
-		Port:                 80,
-		RefreshInterval:      model.Duration(5 * time.Minute),
-		Environment:          "AzurePublicCloud",
-		AuthenticationMethod: authMethodOAuth,
-		HTTPClientConfig:     config_util.DefaultHTTPClientConfig,
-	}
-)
+// DefaultSDConfig is the default Azure SD configuration.
+var DefaultSDConfig = SDConfig{
+	Port:                 80,
+	RefreshInterval:      model.Duration(5 * time.Minute),
+	Environment:          "AzurePublicCloud",
+	AuthenticationMethod: authMethodOAuth,
+	HTTPClientConfig:     config_util.DefaultHTTPClientConfig,
+}
 
 var environments = map[string]cloud.Configuration{
 	"AZURECHINACLOUD":        cloud.AzureChina,
@@ -244,7 +240,7 @@ func (d *Discovery) createAzureClient() (client, error) {
 	c.logger = d.logger
 
 	telemetry := policy.TelemetryOptions{
-		ApplicationID: userAgent,
+		ApplicationID: version.PrometheusUserAgent(),
 	}
 
 	credential, err := newCredential(*d.cfg, policy.ClientOptions{

--- a/discovery/digitalocean/digitalocean.go
+++ b/discovery/digitalocean/digitalocean.go
@@ -132,7 +132,7 @@ func NewDiscovery(conf *SDConfig, logger *slog.Logger, metrics discovery.Discove
 			Transport: rt,
 			Timeout:   time.Duration(conf.RefreshInterval),
 		},
-		godo.SetUserAgent(fmt.Sprintf("Prometheus/%s", version.Version)),
+		godo.SetUserAgent(version.PrometheusUserAgent()),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up digital ocean agent: %w", err)

--- a/discovery/eureka/client.go
+++ b/discovery/eureka/client.go
@@ -23,7 +23,7 @@ import (
 	"github.com/prometheus/common/version"
 )
 
-var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+var userAgent = version.PrometheusUserAgent()
 
 type Applications struct {
 	VersionsDelta int           `xml:"versions__delta"`

--- a/discovery/hetzner/robot.go
+++ b/discovery/hetzner/robot.go
@@ -39,7 +39,7 @@ const (
 	hetznerLabelRobotCancelled = hetznerRobotLabelPrefix + "cancelled"
 )
 
-var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+var userAgent = version.PrometheusUserAgent()
 
 // Discovery periodically performs Hetzner Robot requests. It implements
 // the Discoverer interface.

--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -44,7 +44,7 @@ var (
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 		RefreshInterval:  model.Duration(60 * time.Second),
 	}
-	userAgent        = fmt.Sprintf("Prometheus/%s", version.Version)
+	userAgent        = version.PrometheusUserAgent()
 	matchContentType = regexp.MustCompile(`^(?i:application\/json(;\s*charset=("utf-8"|utf-8))?)$`)
 )
 

--- a/discovery/ionos/server.go
+++ b/discovery/ionos/server.go
@@ -15,7 +15,6 @@ package ionos
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -77,7 +76,7 @@ func newServerDiscovery(conf *SDConfig, _ *slog.Logger) (*serverDiscovery, error
 		Transport: rt,
 		Timeout:   time.Duration(conf.RefreshInterval),
 	}
-	cfg.UserAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+	cfg.UserAgent = version.PrometheusUserAgent()
 
 	d.client = ionoscloud.NewAPIClient(cfg)
 

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -59,14 +59,10 @@ const (
 	presentValue    = model.LabelValue("true")
 )
 
-var (
-	// Http header.
-	userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
-	// DefaultSDConfig is the default Kubernetes SD configuration.
-	DefaultSDConfig = SDConfig{
-		HTTPClientConfig: config.DefaultHTTPClientConfig,
-	}
-)
+// DefaultSDConfig is the default Kubernetes SD configuration.
+var DefaultSDConfig = SDConfig{
+	HTTPClientConfig: config.DefaultHTTPClientConfig,
+}
 
 func init() {
 	discovery.RegisterConfig(&SDConfig{})
@@ -336,7 +332,7 @@ func New(l *slog.Logger, metrics discovery.DiscovererMetrics, conf *SDConfig) (*
 		}
 	}
 
-	kcfg.UserAgent = userAgent
+	kcfg.UserAgent = version.PrometheusUserAgent()
 	kcfg.ContentType = "application/vnd.kubernetes.protobuf"
 
 	c, err := kubernetes.NewForConfig(kcfg)

--- a/discovery/linode/linode.go
+++ b/discovery/linode/linode.go
@@ -165,7 +165,7 @@ func NewDiscovery(conf *SDConfig, logger *slog.Logger, metrics discovery.Discove
 			Timeout:   time.Duration(conf.RefreshInterval),
 		},
 	)
-	client.SetUserAgent(fmt.Sprintf("Prometheus/%s", version.Version))
+	client.SetUserAgent(version.PrometheusUserAgent())
 	d.client = &client
 
 	d.Discovery = refresh.NewDiscovery(

--- a/discovery/moby/docker.go
+++ b/discovery/moby/docker.go
@@ -33,6 +33,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/version"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/refresh"
@@ -173,7 +174,7 @@ func NewDockerDiscovery(conf *DockerSDConfig, logger *slog.Logger, metrics disco
 			}),
 			client.WithScheme(hostURL.Scheme),
 			client.WithHTTPHeaders(map[string]string{
-				"User-Agent": userAgent,
+				"User-Agent": version.PrometheusUserAgent(),
 			}),
 		)
 	}

--- a/discovery/moby/dockerswarm.go
+++ b/discovery/moby/dockerswarm.go
@@ -38,8 +38,6 @@ const (
 	swarmLabel = model.MetaLabelPrefix + "dockerswarm_"
 )
 
-var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
-
 // DefaultDockerSwarmSDConfig is the default Docker Swarm SD configuration.
 var DefaultDockerSwarmSDConfig = DockerSwarmSDConfig{
 	RefreshInterval:  model.Duration(60 * time.Second),
@@ -169,7 +167,7 @@ func NewDiscovery(conf *DockerSwarmSDConfig, logger *slog.Logger, metrics discov
 			}),
 			client.WithScheme(hostURL.Scheme),
 			client.WithHTTPHeaders(map[string]string{
-				"User-Agent": userAgent,
+				"User-Agent": version.PrometheusUserAgent(),
 			}),
 		)
 	}

--- a/discovery/puppetdb/puppetdb.go
+++ b/discovery/puppetdb/puppetdb.go
@@ -64,7 +64,7 @@ var (
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	matchContentType = regexp.MustCompile(`^(?i:application\/json(;\s*charset=("utf-8"|utf-8))?)$`)
-	userAgent        = fmt.Sprintf("Prometheus/%s", version.Version)
+	userAgent        = version.PrometheusUserAgent()
 )
 
 func init() {

--- a/discovery/scaleway/baremetal.go
+++ b/discovery/scaleway/baremetal.go
@@ -93,7 +93,7 @@ func newBaremetalDiscovery(conf *SDConfig) (*baremetalDiscovery, error) {
 			Transport: rt,
 			Timeout:   time.Duration(conf.RefreshInterval),
 		}),
-		scw.WithUserAgent(fmt.Sprintf("Prometheus/%s", version.Version)),
+		scw.WithUserAgent(version.PrometheusUserAgent()),
 		scw.WithProfile(profile),
 	)
 	if err != nil {

--- a/discovery/scaleway/instance.go
+++ b/discovery/scaleway/instance.go
@@ -104,7 +104,7 @@ func newInstanceDiscovery(conf *SDConfig) (*instanceDiscovery, error) {
 			Transport: rt,
 			Timeout:   time.Duration(conf.RefreshInterval),
 		}),
-		scw.WithUserAgent(fmt.Sprintf("Prometheus/%s", version.Version)),
+		scw.WithUserAgent(version.PrometheusUserAgent()),
 		scw.WithProfile(profile),
 	)
 	if err != nil {

--- a/discovery/vultr/vultr.go
+++ b/discovery/vultr/vultr.go
@@ -135,7 +135,7 @@ func NewDiscovery(conf *SDConfig, logger *slog.Logger, metrics discovery.Discove
 		Timeout:   time.Duration(conf.RefreshInterval),
 	})
 
-	d.client.SetUserAgent(fmt.Sprintf("Prometheus/%s", version.Version))
+	d.client.SetUserAgent(version.PrometheusUserAgent())
 
 	if err != nil {
 		return nil, fmt.Errorf("error setting up vultr agent: %w", err)

--- a/discovery/xds/client.go
+++ b/discovery/xds/client.go
@@ -30,7 +30,7 @@ import (
 	"github.com/prometheus/common/version"
 )
 
-var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+var userAgent = version.PrometheusUserAgent()
 
 // ResourceClient exposes the xDS protocol for a single resource type.
 // See https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#rest-json-polling-subscriptions .

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -56,7 +56,7 @@ const (
 	alertmanagerLabel = "alertmanager"
 )
 
-var userAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+var userAgent = version.PrometheusUserAgent()
 
 // Alert is a generic representation of an alert in the Prometheus eco-system.
 type Alert struct {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -792,7 +792,7 @@ func acceptEncodingHeader(enableCompression bool) string {
 	return "identity"
 }
 
-var UserAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+var UserAgent = version.PrometheusUserAgent()
 
 func (s *targetScraper) scrape(ctx context.Context) (*http.Response, error) {
 	if s.req == nil {

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -66,7 +66,7 @@ const (
 
 var (
 	// UserAgent represents Prometheus version to use for user agent header.
-	UserAgent = fmt.Sprintf("Prometheus/%s", version.Version)
+	UserAgent = version.PrometheusUserAgent()
 
 	remoteWriteContentTypeHeaders = map[config.RemoteWriteProtoMsg]string{
 		config.RemoteWriteProtoMsgV1: appProtoContentType, // Also application/x-protobuf;proto=prometheus.WriteRequest but simplified for compatibility with 1.x spec.


### PR DESCRIPTION
#### Description

This uses `version.PrometheusUserAgent()` instead of  `fmt.Sprintf("Prometheus/%s", version.Version)` and `version.ComponentUserAgent("promtool")` instead of `"promtool/"+version.Version`