### PR TITLE
fix(remote): rename some remote read related metrics for better clarity and consistency

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -81,8 +81,8 @@ var (
 	remoteReadQueriesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "read_queries_total",
+			Subsystem: "remote_read_client",
+			Name:      "queries_total",
 			Help:      "The total number of remote read queries.",
 		},
 		[]string{remoteName, endpoint, "response_type", "code"},
@@ -90,8 +90,8 @@ var (
 	remoteReadQueries = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "remote_read_queries",
+			Subsystem: "remote_read_client",
+			Name:      "queries",
 			Help:      "The number of in-flight remote read queries.",
 		},
 		[]string{remoteName, endpoint},
@@ -99,8 +99,8 @@ var (
 	remoteReadQueryDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace:                       namespace,
-			Subsystem:                       subsystem,
-			Name:                            "read_request_duration_seconds",
+			Subsystem:                       "remote_read_client",
+			Name:                            "request_duration_seconds",
 			Help:                            "Histogram of the latency for remote read requests. Note that for streamed responses this is only the duration of the initial call and does not include the processing of the stream.",
 			Buckets:                         append(prometheus.DefBuckets, 25, 60),
 			NativeHistogramBucketFactor:     1.1,

--- a/storage/remote/read_handler.go
+++ b/storage/remote/read_handler.go
@@ -56,10 +56,10 @@ func NewReadHandler(logger *slog.Logger, r prometheus.Registerer, queryable stor
 		marshalPool:               &sync.Pool{},
 
 		queries: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: "prometheus",
-			Subsystem: "api", // TODO: changes to storage in Prometheus 3.0.
-			Name:      "remote_read_queries",
-			Help:      "The current number of remote read queries being executed or waiting.",
+			Namespace: namespace,
+			Subsystem: "remote_read_handler",
+			Name:      "queries",
+			Help:      "The current number of remote read queries that are either in execution or queued on the handler.",
 		}),
 	}
 	if r != nil {


### PR DESCRIPTION
supersedes https://github.com/prometheus/prometheus/pull/14642


```
From the remote read handler side:

prometheus_api_remote_read_queries -> prometheus_remote_read_handler_queries

From the remote read client side:

prometheus_remote_storage_read_queries_total -> prometheus_remote_read_client_queries_total 
prometheus_remote_storage_remote_read_queries -> prometheus_remote_read_client_queries 
prometheus_remote_storage_read_request_duration_seconds -> prometheus_remote_read_client_request_duration_seconds
```
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
