### PR TITLE
Ruler Concurrency: Make rules sortable

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -101,6 +101,8 @@ This has the potential to improve rule group evaluation latency and resource uti
 
 The number of concurrent rule evaluations can be configured with `--rules.max-concurrent-rule-evals`, which is set to `4` by default.
 
+Rules can be optionally sorted (when loaded into the ruler), in a way that makes more of them runnable concurrently. This can be enabled with the `--rules.sort-for-concurrent-eval` flag.
+
 ## Serve old Prometheus UI
 
 Fall back to serving the old (Prometheus 2.x) web UI instead of the new UI. The new UI that was released as part of Prometheus 3.0 is a complete rewrite and aims to be cleaner, less cluttered, and more modern under the hood. However, it is not fully feature complete and battle-tested yet, so some users may still prefer using the old UI.

--- a/rules/fixtures/rules_multiple_dependents_on_base.yaml
+++ b/rules/fixtures/rules_multiple_dependents_on_base.yaml
@@ -1,0 +1,21 @@
+groups:
+  - name: concurrent_dependents
+    rules:
+      - record: job:http_requests:rate1m
+        expr: sum by (job)(rate(http_requests_total[1m]))
+      - record: job1:http_requests:rate1m
+        expr: job:http_requests:rate1m{job="job1"}
+      - record: job2:http_requests:rate1m
+        expr: job:http_requests:rate1m{job="job2"}
+      - record: job3:http_requests:rate1m
+        expr: job:http_requests:rate1m{job="job3"}
+
+      - record: job:http_requests:rate5m
+        expr: sum by (job)(rate(http_requests_total[5m]))
+      - record: job1:http_requests:rate5m
+        expr: job:http_requests:rate5m{job="job1"}
+      - record: job2:http_requests:rate5m
+        expr: job:http_requests:rate5m{job="job2"}
+      - record: job3:http_requests:rate5m
+        expr: job:http_requests:rate5m{job="job3"}
+


### PR DESCRIPTION
We want to expand concurrency of rules in Mimir but there's no easy way to hook in a new feature to sort rules before running them:
- `GroupLoader` runs before dependencies are computed, which would lead to duplicated work
- `RuleConcurrencyController` works on individual rules _after_ the order is baked in. It's too late at that point
- `EvalIterationFunc` calls `.Eval()` on a group but the order is also baked in that function

This PR adds a `RuleSortingController` interface to the the concurrency controller so that we can optionally sort rules before running them. I think it makes sense that it's bundled with the concurrency controller because there's not much possible benefit to sorting rules if we're running them sequentially
