### PR TITLE
fix(deduper): use ptr to sync.RWMutex, fix panic during concurrent use

### DIFF
--- a/util/logging/dedupe.go
+++ b/util/logging/dedupe.go
@@ -33,7 +33,7 @@ type Deduper struct {
 	next   *slog.Logger
 	repeat time.Duration
 	quit   chan struct{}
-	mtx    sync.RWMutex
+	mtx    *sync.RWMutex
 	seen   map[string]time.Time
 }
 
@@ -43,6 +43,7 @@ func Dedupe(next *slog.Logger, repeat time.Duration) *Deduper {
 		next:   next,
 		repeat: repeat,
 		quit:   make(chan struct{}),
+		mtx:    new(sync.RWMutex),
 		seen:   map[string]time.Time{},
 	}
 	go d.run()
@@ -88,6 +89,7 @@ func (d *Deduper) WithAttrs(attrs []slog.Attr) slog.Handler {
 		repeat: d.repeat,
 		quit:   d.quit,
 		seen:   d.seen,
+		mtx:    d.mtx,
 	}
 }
 
@@ -103,6 +105,7 @@ func (d *Deduper) WithGroup(name string) slog.Handler {
 		repeat: d.repeat,
 		quit:   d.quit,
 		seen:   d.seen,
+		mtx:    d.mtx,
 	}
 }
 


### PR DESCRIPTION
Resolves: #15559

As accurately noted in the issue description, the map is shared among child loggers that get created when `WithAttr()`/`WithGroup()` are called on the underlying handler, which happens via `log.With()` and `log.WithGroup()` respectively.

The RW mutex was a value in the previous implementation that used go-kit/log, and I should've updated it to use a pointer when I converted the deduper.

Also adds a test.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
