### PR TITLE
OTLP receiver: Clarify the NoUTF8EscapingWithSuffixes and UnderscoreEscapingWithSuffixes modes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1420,10 +1420,13 @@ func getGoGCEnv() int {
 type translationStrategyOption string
 
 var (
-	// NoUTF8EscapingWithSuffixes will keep UTF-8 characters as they are, units and type suffixes will still be added.
+	// NoUTF8EscapingWithSuffixes will accept metric/label names as they are.
+	// Unit and type suffixes may be added to metric names, according to certain rules.
 	NoUTF8EscapingWithSuffixes translationStrategyOption = "NoUTF8EscapingWithSuffixes"
 	// UnderscoreEscapingWithSuffixes is the default option for translating OTLP to Prometheus.
-	// This option will translate all UTF-8 characters to underscores, while adding units and type suffixes.
+	// This option will translate metric name characters that are not alphanumerics/underscores/colons to underscores,
+	// and label name characters that are not alphanumerics/underscores to underscores.
+	// Unit and type suffixes may be appended to metric names, according to certain rules.
 	UnderscoreEscapingWithSuffixes translationStrategyOption = "UnderscoreEscapingWithSuffixes"
 )
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -179,8 +179,8 @@ otlp:
   # - "UnderscoreEscapingWithSuffixes" refers to commonly agreed normalization used
   #   by OpenTelemetry in https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/translator/prometheus
   # - "NoUTF8EscapingWithSuffixes" is a mode that relies on UTF-8 support in Prometheus.
-  #   It preserves all special characters like dots, but it still add required suffixes
-  #   for units and _total like in UnderscoreEscapingWithSuffixes.
+  #   It preserves all special characters like dots, but still adds required metric name suffixes
+  #   for units and _total, as UnderscoreEscapingWithSuffixes does.
   [ translation_strategy: <string> | default = "UnderscoreEscapingWithSuffixes" ]
   # Enables adding "service.name", "service.namespace" and "service.instance.id"
   # resource attributes to the "target_info" metric, on top of converting

--- a/documentation/examples/prometheus-otlp.yml
+++ b/documentation/examples/prometheus-otlp.yml
@@ -22,7 +22,7 @@ otlp:
     - k8s.pod.name
     - k8s.replicaset.name
     - k8s.statefulset.name
-  # Ingest OTLP data keeping UTF-8 characters in metric/label names.
+  # Ingest OTLP data keeping all characters in metric/label names.
   translation_strategy: NoUTF8EscapingWithSuffixes
 
 storage:


### PR DESCRIPTION
On reviewing the `NoUTF8EscapingWithSuffixes` and `UnderscoreEscapingWithSuffixes` OTLP receiver translation mode definitions, I realized that they are somewhat misleading. I think they will at the very least be confusing to our users, as even I experienced some confusion and had to consult the source code.

The `NoUTF8EscapingWithSuffixes` definition says it "will keep UTF-8 characters as they are, units and type suffixes will still be added", but suffixes will only be added to _metric_ names (not label names) according to certain rules. This mode will also not do any translation of eventual non-UTF-8 characters as the definition might give the impression of, I think those would just lead to rejection upon metric/label name validation.

The `UnderscoreEscapingWithSuffixes` definition says it will "will translate all UTF-8 characters to underscores, while adding units and type suffixes". This is unfortunately misleading, since only a subset of UTF-8 characters will be translated to underscores, certainly not all of them. For metric names that subset is characters which are not alphanumerics/underscores/colons, whereas for label names it is alphanumerics/underscores.