### PR TITLE
Add old UI to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,23 @@ updates:
     directory: "/documentation/examples/remote_storage"
     schedule:
       interval: "monthly"
+  # New manteen-ui packages.
   - package-ecosystem: "npm"
     directory: "/web/ui"
+    labels:
+      - dependencies
+      - javascript
+      - manteen-ui
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 20
+  # Old react-app packages.
+  - package-ecosystem: "npm"
+    directory: "/web/ui/react-app"
+    labels:
+      - dependencies
+      - javascript
+      - old-react-ui
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 20


### PR DESCRIPTION
Until we have removed the code for the old UI, we should maintain the dependabot configuration for security warnings.
