### PR TITLE
Call `PostCreation` callback only after the new series is added to the Postings

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1730,6 +1730,11 @@ func (h *Head) getOrCreateWithID(id chunks.HeadSeriesRef, hash uint64, lset labe
 	h.numSeries.Inc()
 
 	h.postings.Add(storage.SeriesRef(id), lset)
+
+	// Adding the series in the postings marks the creation of series
+	// as any further calls to this and the read methods would return that series.
+	h.series.postCreation(lset)
+
 	return s, true, nil
 }
 
@@ -2037,9 +2042,6 @@ func (s *stripeSeries) getOrSet(hash uint64, lset labels.Labels, createSeries fu
 		// The callback prevented creation of series.
 		return nil, false, preCreationErr
 	}
-	// Setting the series in the s.hashes marks the creation of series
-	// as any further calls to this methods would return that series.
-	s.seriesLifecycleCallback.PostCreation(series.labels())
 
 	i = uint64(series.ref) & uint64(s.size-1)
 
@@ -2048,6 +2050,10 @@ func (s *stripeSeries) getOrSet(hash uint64, lset labels.Labels, createSeries fu
 	s.locks[i].Unlock()
 
 	return series, true, nil
+}
+
+func (s *stripeSeries) postCreation(lset labels.Labels) {
+	s.seriesLifecycleCallback.PostCreation(lset)
 }
 
 type sample struct {


### PR DESCRIPTION
Hi,

We recently added in [cortex](https://github.com/cortexproject/cortex/pull/6296) and [thanos](https://github.com/thanos-io/thanos/pull/7914) a way to cache "expanded postings" for the head blocks and we are relying on the `PostCreation` to invalidate this cache.

Unfortunately, recently we noticed that the `PostCreation` is called on the method [getOrSet](https://github.com/prometheus/prometheus/blob/e1bfdd22571d874e1f9154d1a35ce3a8569ded36/tsdb/head.go#L2042) before the created series is added to the postings on ([getOrCreateWithID](https://github.com/prometheus/prometheus/blob/e1bfdd22571d874e1f9154d1a35ce3a8569ded36/tsdb/head.go#L1732)). This causes problems where we invalidate the cache before the new series are available to be queried and so, we can end up caching results without this new series: See https://github.com/cortexproject/cortex/pull/6417

This change is proposing to only call the `PostCreation` callback after the series is added to the postings so we can rely on this hook to invalidate the cache. Adding the series to the postings is arguably part of the "creation" so, i think it would be more correct anyway.

I did not add tests as there are already tests around those hooks.


cc @codesome as its the author of the original PR: https://github.com/prometheus/prometheus/pull/7159
