### PR TITLE
config: Remove validation GetScrapeConfigs to avoid race and writes.

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -593,12 +593,14 @@ func main() {
 		logger.Error(fmt.Sprintf("Error loading config (--config.file=%s)", cfg.configFile), "file", absPath, "err", err)
 		os.Exit(2)
 	}
+	// Get scrape configs to validate dynamically loaded scrape_config_files.
+	// They can change over time, but do the extra validation on startup for better experience.
 	if _, err := cfgFile.GetScrapeConfigs(); err != nil {
 		absPath, pathErr := filepath.Abs(cfg.configFile)
 		if pathErr != nil {
 			absPath = cfg.configFile
 		}
-		logger.Error(fmt.Sprintf("Error loading scrape config files from config (--config.file=%q)", cfg.configFile), "file", absPath, "err", err)
+		logger.Error(fmt.Sprintf("Error loading dynamic scrape config files from config (--config.file=%q)", cfg.configFile), "file", absPath, "err", err)
 		os.Exit(2)
 	}
 	if cfg.tsdb.EnableExemplarStorage {


### PR DESCRIPTION
We should never modify (or even shallow copy) Config after config.Load; added comments and modified GetScrapeConfigs to do so. For GetScrapeConfigs the validation (even repeated) was likely doing writes (because global fields was 0). We GetScrapeConfigs concurrently in tests and ApplyConfig causing test races. In prod there were races but likelyt only to replace 0 with 0, so not too severe.

I remove validation since I don't see anyone using our config.Config without Load or UnmarshalYAML.

We can add another validation method if there are use cases for this.

Fixes #15538

Alternatives:
* Add config mutex for GetScrapeConfigs (more complex and slow)
* Copy Config (Config struct is huge and required complex deep copy)
* Second validate is noop
  * e.g. by checking if global is 0 (prone to errors in future)
  * e.g. once.Sync validation - this introduces state and mutex, let's avoid it until we know it's needed (multiple ways of loading config)
