### PR TITLE
tsdb: export checkpointPrefix constant

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2320,7 +2320,7 @@ func isTmpDir(fi fs.DirEntry) bool {
 	fn := fi.Name()
 	ext := filepath.Ext(fn)
 	if ext == tmpForDeletionBlockDirSuffix || ext == tmpForCreationBlockDirSuffix || ext == tmpLegacy {
-		if strings.HasPrefix(fn, "checkpoint.") {
+		if strings.HasPrefix(fn, wlog.CheckpointPrefix) {
 			return true
 		}
 		if strings.HasPrefix(fn, chunkSnapshotPrefix) {

--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -81,7 +81,8 @@ func DeleteCheckpoints(dir string, maxIndex int) error {
 	return errs.Err()
 }
 
-const checkpointPrefix = "checkpoint."
+// CheckpointPrefix is the prefix used for checkpoint files.
+const CheckpointPrefix = "checkpoint."
 
 // Checkpoint creates a compacted checkpoint of segments in range [from, to] in the given WAL.
 // It includes the most recent checkpoint if it exists.
@@ -363,7 +364,7 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 }
 
 func checkpointDir(dir string, i int) string {
-	return filepath.Join(dir, fmt.Sprintf(checkpointPrefix+"%08d", i))
+	return filepath.Join(dir, fmt.Sprintf(CheckpointPrefix+"%08d", i))
 }
 
 type checkpointRef struct {
@@ -379,13 +380,13 @@ func listCheckpoints(dir string) (refs []checkpointRef, err error) {
 
 	for i := 0; i < len(files); i++ {
 		fi := files[i]
-		if !strings.HasPrefix(fi.Name(), checkpointPrefix) {
+		if !strings.HasPrefix(fi.Name(), CheckpointPrefix) {
 			continue
 		}
 		if !fi.IsDir() {
 			return nil, fmt.Errorf("checkpoint %s is not a directory", fi.Name())
 		}
-		idx, err := strconv.Atoi(fi.Name()[len(checkpointPrefix):])
+		idx, err := strconv.Atoi(fi.Name()[len(CheckpointPrefix):])
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
Exported the checkpointPrefix constant to be used in other packages.
Updated references to the constant in db.go and checkpoint.go files.
This change improves code readability and maintainability.
