### PR TITLE
fix TestSelectExemplar_MultiSeries assertion message

### DIFF
--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -211,14 +211,14 @@ func TestSelectExemplar_MultiSeries(t *testing.T) {
 	ret, err := es.Select(100, 200, []*labels.Matcher{m})
 	require.NoError(t, err)
 	require.Len(t, ret, 1, "select should have returned samples for a single series only")
-	require.Len(t, ret[0].Exemplars, 3, "didn't get expected 8 exemplars, got %d", len(ret[0].Exemplars))
+	require.Len(t, ret[0].Exemplars, 3, "didn't get expected 3 exemplars, got %d", len(ret[0].Exemplars))
 
 	m, err = labels.NewMatcher(labels.MatchEqual, labels.MetricName, l1Name)
 	require.NoError(t, err, "error creating label matcher for exemplar query")
 	ret, err = es.Select(100, 200, []*labels.Matcher{m})
 	require.NoError(t, err)
 	require.Len(t, ret, 1, "select should have returned samples for a single series only")
-	require.Len(t, ret[0].Exemplars, 2, "didn't get expected 8 exemplars, got %d", len(ret[0].Exemplars))
+	require.Len(t, ret[0].Exemplars, 2, "didn't get expected 2 exemplars, got %d", len(ret[0].Exemplars))
 }
 
 func TestSelectExemplar_TimeRange(t *testing.T) {


### PR DESCRIPTION
WHile porting the test, the  message were confusing. The value used in the message were not matching expected value.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
