### PR TITLE
PromQL: Adds tests for `delta` with histograms

### DIFF
--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -234,24 +234,24 @@ clear
 load 5m
 	http_requests{path="/foo"}	0 50 100 150 200
 	http_requests{path="/bar"}	200 150 100 50 0
-    http_requests_gauge{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}}+{{schema:0 sum:1 count:2 buckets:[1 1 1] counter_reset_hint:gauge}}x5
-    http_requests_counter{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0]}}+{{schema:0 sum:1 count:2 buckets:[1 1 1]}}x5
-    http_requests_mix{path="/foo"} 0 50 100 {{schema:0 sum:0 count:0 buckets:[0 0 0]}} {{schema:0 sum:1 count:2 buckets:[1 1 1]}}
+	http_requests_gauge{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}}+{{schema:0 sum:1 count:2 buckets:[1 1 1] counter_reset_hint:gauge}}x5
+	http_requests_counter{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0]}}+{{schema:0 sum:1 count:2 buckets:[1 1 1]}}x5
+	http_requests_mix{path="/foo"} 0 50 100 {{schema:0 sum:0 count:0 buckets:[0 0 0]}} {{schema:0 sum:1 count:2 buckets:[1 1 1]}}
 
 eval instant at 20m delta(http_requests[20m])
 	{path="/foo"} 200
 	{path="/bar"} -200
 
 eval instant at 20m delta(http_requests_gauge[20m])
-    {path="/foo"} {{schema:0 sum:4 count:8 buckets:[4 4 4]}}
+	{path="/foo"} {{schema:0 sum:4 count:8 buckets:[4 4 4]}}
 
 # delta emits warn annotation for non-gauge histogram types.
 eval_warn instant at 20m delta(http_requests_counter[20m])
-    {path="/foo"} {{schema:0 sum:4 count:8 buckets:[4 4 4]}}
+	{path="/foo"} {{schema:0 sum:4 count:8 buckets:[4 4 4]}}
 
 # delta emits warn annotation for mix of histogram and floats.
 eval_warn instant at 20m delta(http_requests_mix[20m])
-    #empty
+	#empty
 
 clear
 

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -236,7 +236,7 @@ load 5m
 	http_requests{path="/bar"}	200 150 100 50 0
 	http_requests_gauge{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}}+{{schema:0 sum:1 count:2 buckets:[1 1 1] counter_reset_hint:gauge}}x5
 	http_requests_counter{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0]}}+{{schema:0 sum:1 count:2 buckets:[1 1 1]}}x5
-	http_requests_mix{path="/foo"} 0 50 100 {{schema:0 sum:0 count:0 buckets:[0 0 0]}} {{schema:0 sum:1 count:2 buckets:[1 1 1]}}
+	http_requests_mix{path="/foo"} 0 50 100 {{schema:0 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}} {{schema:0 sum:1 count:2 buckets:[1 1 1] counter_reset_hint:gauge}}
 
 eval instant at 20m delta(http_requests[20m])
 	{path="/foo"} 200

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -234,10 +234,24 @@ clear
 load 5m
 	http_requests{path="/foo"}	0 50 100 150 200
 	http_requests{path="/bar"}	200 150 100 50 0
+    http_requests_gauge{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}}+{{schema:0 sum:1 count:2 buckets:[1 1 1] counter_reset_hint:gauge}}x5
+    http_requests_counter{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0]}}+{{schema:0 sum:1 count:2 buckets:[1 1 1]}}x5
+    http_requests_mix{path="/foo"} 0 50 100 {{schema:0 sum:0 count:0 buckets:[0 0 0]}} {{schema:0 sum:1 count:2 buckets:[1 1 1]}}
 
 eval instant at 20m delta(http_requests[20m])
 	{path="/foo"} 200
 	{path="/bar"} -200
+
+eval instant at 20m delta(http_requests_gauge[20m])
+    {path="/foo"} {{schema:0 sum:4 count:8 buckets:[4 4 4]}}
+
+# delta emits warn annotation for non-gauge histogram types.
+eval_warn instant at 20m delta(http_requests_counter[20m])
+    {path="/foo"} {{schema:0 sum:4 count:8 buckets:[4 4 4]}}
+
+# delta emits warn annotation for mix of histogram and floats.
+eval_warn instant at 20m delta(http_requests_mix[20m])
+    #empty
 
 clear
 


### PR DESCRIPTION
Part of #13934 .

This PR adds tests to verify the behaviour of `delta` function with histograms.

CC: @beorn7 