### PR TITLE
fix (auto-reload): failing to auto-reload on changes to rule and scrape config files

### DIFF
--- a/config/reload.go
+++ b/config/reload.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -49,10 +50,15 @@ func GenerateChecksum(yamlFilePath string) (string, error) {
 	dir := filepath.Dir(yamlFilePath)
 
 	for i, file := range config.RuleFiles {
-		config.RuleFiles[i] = filepath.Join(dir, file)
+		if !strings.Contains(config.RuleFiles[i], dir) {
+			config.RuleFiles[i] = filepath.Join(dir, file) // Join the directory only if the parent directory is not present in the config
+		}
 	}
+
 	for i, file := range config.ScrapeConfigFiles {
-		config.ScrapeConfigFiles[i] = filepath.Join(dir, file)
+		if !strings.Contains(config.ScrapeConfigFiles[i], dir) {
+			config.ScrapeConfigFiles[i] = filepath.Join(dir, file) // Join the directory only if the parent directory is not present in the config
+		}
 	}
 
 	files := map[string][]string{

--- a/config/reload_test.go
+++ b/config/reload_test.go
@@ -40,8 +40,12 @@ func TestGenerateChecksum(t *testing.T) {
 	yamlContent := `
 rule_files:
   - rule_file.yml
+  - /etc/prometheus/rules/rule_file.yml
+  - /etc/prometheus/rules/glob/*.yml
 scrape_config_files:
   - scrape_config.yml
+  - /etc/prometheus/scrape_config_files/scrape_config.yml
+  - /etc/prometheus/scrape_config_files/glob/*.yml
 `
 
 	// Write initial content to files.
@@ -123,8 +127,12 @@ global:
   scrape_interval: 3s
 rule_files:
   - rule_file.yml
+  - /etc/prometheus/rules/rule_file.yml
+  - /etc/prometheus/rules/glob/*.yml
 scrape_config_files:
   - scrape_config.yml
+  - /etc/prometheus/scrape_config_files/scrape_config.yml
+  - /etc/prometheus/scrape_config_files/glob/*.yml
 `
 		require.NoError(t, os.WriteFile(yamlFilePath, []byte(modifiedYamlContent), 0o644))
 
@@ -145,6 +153,8 @@ scrape_config_files:
 		modifiedYamlContent := `
 scrape_config_files:
   - scrape_config.yml
+  - /etc/prometheus/scrape_config_files/scrape_config.yml
+  - /etc/prometheus/scrape_config_files/glob/*.yml
 `
 		require.NoError(t, os.WriteFile(yamlFilePath, []byte(modifiedYamlContent), 0o644))
 
@@ -165,6 +175,8 @@ scrape_config_files:
 		modifiedYamlContent := `
 rule_files:
   - rule_file.yml
+  - /etc/prometheus/rules/rule_file.yml
+  - /etc/prometheus/rules/glob/*.yml
 `
 		require.NoError(t, os.WriteFile(yamlFilePath, []byte(modifiedYamlContent), 0o644))
 


### PR DESCRIPTION
Fixes #15673

An issue was reported in the CNCF Slack regarding the new auto-reload feature in Prometheus 3.0 failing to reload on changes to rule files and scrape config files if they aren't in the same directory as `prometheus.yml`. 

This change verifies that `dir` does not exist in the specified rule/scrape_config_file string before setting it.

The previous behavior resulted in paths like this:
```
/etc/prometheus/etc/prometheus/scrape_config_files/scrape_config.yml
```
When we want this:
```
/etc/prometheus/scrape_config_files/scrape_config.yml
```

Configuration example:
```
rule_files:
  - rule_file.yml
  - /etc/prometheus/rules/rule_file.yml
  - /etc/prometheus/rules/glob/*.yml
scrape_config_files:
  - scrape_config.yml
  - /etc/prometheus/scrape_config_files/scrape_config.yml
  - /etc/prometheus/scrape_config_files/glob/*.yml
```

Logs of it working as intended:
```
# prometheus.yml (/etc/prometheus/prometheus.yml)
time=2024-12-13T19:14:22.819Z level=INFO source=main.go:1178 msg="Configuration file change detected, reloading the configuration."
time=2024-12-13T19:14:22.819Z level=INFO source=main.go:1442 msg="Loading configuration file" filename=/etc/prometheus/prometheus.yml
time=2024-12-13T19:14:23.258Z level=INFO source=main.go:1491 msg="Completed loading of configuration file" db_storage=1.71µs remote_storage=435.812µs web_handler=830ns query_engine=19.86µs scrape=18.849832ms scrape_sd=15.784323ms notify=141.87µs notify_sd=10.15µs rules=403.996265ms tracing=38.23µs filename=/etc/prometheus/prometheus.yml totalDuration=439.645443ms

# rules.yml (/etc/prometheus/rules/rule_file.yml)
time=2024-12-13T19:15:53.267Z level=INFO source=main.go:1178 msg="Configuration file change detected, reloading the configuration."
time=2024-12-13T19:15:53.267Z level=INFO source=main.go:1442 msg="Loading configuration file" filename=/etc/prometheus/prometheus.yml
time=2024-12-13T19:15:54.008Z level=INFO source=main.go:1491 msg="Completed loading of configuration file" db_storage=3.07µs remote_storage=576.493µs web_handler=890ns query_engine=22.82µs scrape=27.318201ms scrape_sd=23.386838ms notify=239.861µs notify_sd=17.11µs rules=688.309753ms tracing=15.61µs filename=/etc/prometheus/prometheus.yml totalDuration=740.420487ms


# scrape_config.yml (/etc/prometheus/scrape_config_files/scrape_config.yml)
time=2024-12-13T19:17:24.016Z level=INFO source=main.go:1178 msg="Configuration file change detected, reloading the configuration."
time=2024-12-13T19:17:24.016Z level=INFO source=main.go:1442 msg="Loading configuration file" filename=/etc/prometheus/prometheus.yml
time=2024-12-13T19:17:24.444Z level=INFO source=main.go:1491 msg="Completed loading of configuration file" db_storage=1.79µs remote_storage=367.732µs web_handler=600ns query_engine=18.59µs scrape=17.624679ms scrape_sd=12.13822ms notify=117.53µs notify_sd=9µs rules=397.346967ms tracing=10.78µs filename=/etc/prometheus/prometheus.yml totalDuration=427.959149ms
```

After collecting that, I do think it could be nice to specify which file was updated instead of only returning `filename=/etc/prometheus/prometheus.yml`, but that's in [reloadConfig](https://github.com/prometheus/prometheus/blob/main/cmd/prometheus/main.go#L1439) and maybe shouldn't be touched in this PR
