### PR TITLE
[Perf] Merge negated matchers on same label into a single regexp matcher

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -198,7 +198,7 @@ func PostingsForMatchers(ctx context.Context, ix IndexReader, ms ...*labels.Matc
 		k, v := index.AllPostingsKey()
 		return ix.Postings(ctx, k, v)
 	}
-	ms = joinNegatedMatchers(ms)
+	ms = mergeNegatedMatchers(ms)
 
 	var its, notIts []index.Postings
 	// See which label must be non-empty.
@@ -466,7 +466,7 @@ func labelNamesWithMatchers(ctx context.Context, r IndexReader, matchers ...*lab
 	return r.LabelNamesFor(ctx, p)
 }
 
-func joinNegatedMatchers(ms []*labels.Matcher) []*labels.Matcher {
+func mergeNegatedMatchers(ms []*labels.Matcher) []*labels.Matcher {
 	labelNot := make(map[string]int, len(ms))
 	for _, m := range ms {
 		if m.Type == labels.MatchNotEqual || m.Type == labels.MatchNotRegexp {

--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -111,6 +111,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	iStar1Star := labels.MustNewMatcher(labels.MatchRegexp, "i", ".*1.*")
 	iPlus := labels.MustNewMatcher(labels.MatchRegexp, "i", ".+")
 	i1Plus := labels.MustNewMatcher(labels.MatchRegexp, "i", "1.+")
+	iNot1Plus := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "1.+")
 	iEmptyRe := labels.MustNewMatcher(labels.MatchRegexp, "i", "")
 	iNotEmpty := labels.MustNewMatcher(labels.MatchNotEqual, "i", "")
 	iNot2 := labels.MustNewMatcher(labels.MatchNotEqual, "i", "2"+postingsBenchSuffix)
@@ -122,6 +123,14 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 	iCharSet := labels.MustNewMatcher(labels.MatchRegexp, "i", "1[0-9]")
 	iAlternate := labels.MustNewMatcher(labels.MatchRegexp, "i", "(1|2|3|4|5|6|20|55)")
 	iNotAlternate := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "(1|2|3|4|5|6|20|55)")
+	iNotRe1 := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "1")
+	iNotRe2 := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "2")
+	iNotRe3 := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "3")
+	iNotRe4 := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "4")
+	iNotRe5 := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "5")
+	iNotRe6 := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "6")
+	iNotRe20 := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "20")
+	iNotRe55 := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "55")
 	iXYZ := labels.MustNewMatcher(labels.MatchRegexp, "i", "X|Y|Z")
 	iNotXYZ := labels.MustNewMatcher(labels.MatchNotRegexp, "i", "X|Y|Z")
 	cases := []struct {
@@ -142,6 +151,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 		{`j=~"X.+"`, []*labels.Matcher{jXplus}},
 		{`i=~"(1|2|3|4|5|6|20|55)"`, []*labels.Matcher{iAlternate}},
 		{`i!~"(1|2|3|4|5|6|20|55)"`, []*labels.Matcher{iNotAlternate}},
+		{`RUN i!~"1",...,i!~"55"`, []*labels.Matcher{iNotRe1, iNotRe2, iNotRe3, iNotRe4, iNotRe5, iNotRe6, iNotRe20, iNotRe55}},
 		{`i=~"X|Y|Z"`, []*labels.Matcher{iXYZ}},
 		{`i!~"X|Y|Z"`, []*labels.Matcher{iNotXYZ}},
 		{`i=~".*"`, []*labels.Matcher{iStar}},
@@ -149,6 +159,7 @@ func benchmarkPostingsForMatchers(b *testing.B, ir IndexReader) {
 		{`i=~".*1"`, []*labels.Matcher{iStar1}},
 		{`i=~".+"`, []*labels.Matcher{iPlus}},
 		{`i=~".+",j=~"X.+"`, []*labels.Matcher{iPlus, jXplus}},
+		{`RUN i!~"1.+",i!~".*2.*",i!="2"`, []*labels.Matcher{iNot1Plus, iNotStar2Star, iNot2}},
 		{`i=~""`, []*labels.Matcher{iEmptyRe}},
 		{`i!=""`, []*labels.Matcher{iNotEmpty}},
 		{`n="1",i=~".*",j="foo"`, []*labels.Matcher{n1, iStar, jFoo}},

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3828,7 +3828,7 @@ func TestMergeQuerierConcurrentSelectMatchers(t *testing.T) {
 	require.Equal(t, originalMatchers, matchers)
 }
 
-func TestJoinNegatedMatchers(t *testing.T) {
+func TestMergeNegatedMatchers(t *testing.T) {
 	for _, tc := range []struct {
 		in  string
 		out string
@@ -3857,7 +3857,7 @@ func TestJoinNegatedMatchers(t *testing.T) {
 		t.Run(tc.in, func(t *testing.T) {
 			ms, err := parser.ParseMetricSelector(tc.in)
 			require.NoError(t, err)
-			ms = joinNegatedMatchers(ms)
+			ms = mergeNegatedMatchers(ms)
 			got := (&parser.VectorSelector{LabelMatchers: ms}).String()
 			require.Equal(t, tc.out, got)
 		})


### PR DESCRIPTION
This is a first naive attempt to fix https://github.com/prometheus/prometheus/issues/14619

However, this only shows worse performance:

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Apple M3 Pro
                                                                   │     main     │                  join                  │
                                                                   │    sec/op    │    sec/op      vs base                 │
Querier/Head/PostingsForMatchers/RUN_i!~"1",...,i!~"55"-12           923.3n ± 10%   2626.0n ± 19%  +184.41% (p=0.000 n=10)
Querier/Head/PostingsForMatchers/RUN_i!~"1.+",i!~".*2.*",i!="2"-12   8.078m ± 22%    8.881m ± 14%         ~ (p=0.481 n=10)
geomean                                                              86.36µ          152.7µ         +76.83%

                                                                   │     main     │                 join                  │
                                                                   │     B/op     │     B/op      vs base                 │
Querier/Head/PostingsForMatchers/RUN_i!~"1",...,i!~"55"-12             560.0 ± 0%    3320.0 ± 0%  +492.86% (p=0.000 n=10)
Querier/Head/PostingsForMatchers/RUN_i!~"1.+",i!~".*2.*",i!="2"-12   8.633Mi ± 0%   6.723Mi ± 0%   -22.12% (p=0.000 n=10)
geomean                                                              69.53Ki        149.4Ki       +114.87%

                                                                   │    main    │                 join                 │
                                                                   │ allocs/op  │  allocs/op   vs base                 │
Querier/Head/PostingsForMatchers/RUN_i!~"1",...,i!~"55"-12           23.00 ± 0%    56.00 ± 0%  +143.48% (p=0.000 n=10)
Querier/Head/PostingsForMatchers/RUN_i!~"1.+",i!~".*2.*",i!="2"-12   25.00 ± 0%   170.00 ± 0%  +580.00% (p=0.000 n=10)
geomean                                                              23.98         97.57       +306.90%
```

I'll leave this PR here for a few days while I think about it, unless someone has a clue of what's going so wrong.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
