### PR TITLE
Fix bug in `lbl!~".+"` postings for matchers shortcut

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -271,7 +271,7 @@ func PostingsForMatchers(ctx context.Context, ix IndexReader, ms ...*labels.Matc
 			its = append(its, it)
 		case m.Type == labels.MatchNotRegexp && m.Value == ".+":
 			// .+ regexp matches any non-empty string: get postings for all label values and remove them.
-			its = append(notIts, ix.PostingsForAllLabelValues(ctx, m.Name))
+			notIts = append(notIts, ix.PostingsForAllLabelValues(ctx, m.Name))
 
 		case labelMustBeSet[m.Name]:
 			// If this matcher must be non-empty, we can be smarter.

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3017,6 +3017,15 @@ func TestPostingsForMatchers(t *testing.T) {
 			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "n", "1"), labels.MustNewMatcher(labels.MatchNotRegexp, "i", "^.*$")},
 			exp:      []labels.Labels{},
 		},
+		// Test shortcut i!~".+"
+		{
+			matchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "n", ".*"), labels.MustNewMatcher(labels.MatchNotRegexp, "i", ".+")},
+			exp: []labels.Labels{
+				labels.FromStrings("n", "1"),
+				labels.FromStrings("n", "2"),
+				labels.FromStrings("n", "2.5"),
+			},
+		},
 	}
 
 	ir, err := h.Index()


### PR DESCRIPTION
We were appending to the wrong slice, so instead of removing values, we were adding them.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
