### PR TITLE
[BUGFIX] PromQL: Fix `deriv`, `predict_linear` and `double_exponential_smoothing` with histograms

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -372,7 +372,7 @@ func funcDoubleExponentialSmoothing(vals []parser.Value, args parser.Expressions
 
 	// Add info annotation for ignoring histogram.
 	if len(samples.Histograms) > 0 {
-		annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("deriv", args.PositionRange()))
+		annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("double_exponential_smoothing", args.PositionRange()))
 	}
 
 	l := len(samples.Floats)
@@ -1140,7 +1140,7 @@ func funcPredictLinear(vals []parser.Value, args parser.Expressions, enh *EvalNo
 	var annos annotations.Annotations
 	// Add info annotation for ignoring histogram.
 	if len(samples.Histograms) > 0 {
-		annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("deriv", args.PositionRange()))
+		annos.Add(annotations.NewHistogramIgnoredInAggregationInfo("predict_linear", args.PositionRange()))
 	}
 	// No sense in trying to predict anything without at least two points.
 	// Drop this Vector element.

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -258,7 +258,7 @@ load 5m
 	http_requests_total{job="app-server", instance="1", group="canary"}		0+80x10
 	testcounter_reset_middle_mix	0+10x4 0+10x5 {{schema:0 sum:1 count:1}} {{schema:1 sum:2 count:2}}
 	http_requests_mix{job="app-server", instance="1", group="canary"}		0+80x10 {{schema:0 sum:1 count:1}}
-    http_requests_histogram{job="app-server", instance="1", group="canary"}		{{schema:0 sum:1 count:2}}x10
+	http_requests_histogram{job="app-server", instance="1", group="canary"}		{{schema:0 sum:1 count:2}}x10
 	http_requests_inf{job="app-server", instance="1", group="canary"}	-Inf 0+80x10 Inf
 
 # deriv should return the same as rate in simple cases.
@@ -279,7 +279,7 @@ eval_info instant at 110m deriv(http_requests_mix{group="canary", instance="1", 
 eval_info instant at 100m deriv(testcounter_reset_middle_mix[110m])
 	{} 0.010606060606060607
 
-eval_info instant at 50m deriv(http_requests_histogram[60m])
+eval instant at 50m deriv(http_requests_histogram[60m])
 	#empty
 
 # deriv should return NaN in case of +Inf or -Inf found.
@@ -327,6 +327,9 @@ eval_info instant at 60m predict_linear(testcounter_reset_middle_mix[60m], 3000)
 
 eval_info instant at 60m predict_linear(testcounter_reset_middle_mix[60m], 50m)
 	{} 70
+
+eval instant at 60m predict_linear(http_requests_histogram[60m], 50m)
+	#empty
 
 # predict_linear should return NaN in case of +Inf or -Inf found.
 eval instant at 100m predict_linear(http_requests_inf[100m], 6000)
@@ -754,7 +757,7 @@ eval_info instant at 20010s double_exponential_smoothing(http_requests_mix[1m], 
 	{job="api-server", instance="0", group="canary"} 80300
 	{job="api-server", instance="1", group="canary"} 80000
 
-eval_info instant at 10000s double_exponential_smoothing(http_requests_histogram[1m], 0.01, 0.1)
+eval instant at 10000s double_exponential_smoothing(http_requests_histogram[1m], 0.01, 0.1)
 	#empty
 
 # negative trends

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -259,6 +259,7 @@ load 5m
 	testcounter_reset_middle_mix	0+10x4 0+10x5 {{schema:0 sum:1 count:1}} {{schema:1 sum:2 count:2}}
 	http_requests_mix{job="app-server", instance="1", group="canary"}		0+80x10 {{schema:0 sum:1 count:1}}
     http_requests_histogram{job="app-server", instance="1", group="canary"}		{{schema:0 sum:1 count:2}}x10
+	http_requests_inf{job="app-server", instance="1", group="canary"}	-Inf 0+80x10 Inf
 
 # deriv should return the same as rate in simple cases.
 eval instant at 50m rate(http_requests_total{group="canary", instance="1", job="app-server"}[50m])
@@ -271,15 +272,19 @@ eval instant at 50m deriv(http_requests_total{group="canary", instance="1", job=
 eval instant at 50m deriv(testcounter_reset_middle_total[100m])
 	{} 0.010606060606060607
 
-# deriv should ignore histograms.
-eval instant at 110m deriv(http_requests_mix{group="canary", instance="1", job="app-server"}[110m])
+# deriv should ignore histograms with info annotation.
+eval_info instant at 110m deriv(http_requests_mix{group="canary", instance="1", job="app-server"}[110m])
 	{group="canary", instance="1", job="app-server"} 0.26666666666666666
 
-eval instant at 100m deriv(testcounter_reset_middle_mix[110m])
+eval_info instant at 100m deriv(testcounter_reset_middle_mix[110m])
 	{} 0.010606060606060607
 
-eval instant at 50m deriv(http_requests_histogram[60m])
+eval_info instant at 50m deriv(http_requests_histogram[60m])
     #empty
+
+# deriv should return NaN in case of +Inf or -Inf found.
+eval instant at 100m deriv(http_requests_inf[100m])
+	{job="app-server", instance="1", group="canary"} NaN
 
 # predict_linear should return correct result.
 # X/s = [  0, 300, 600, 900,1200,1500,1800,2100,2400,2700,3000]
@@ -315,6 +320,17 @@ eval instant at 10m predict_linear(testcounter_reset_middle_total[55m] @ 3000, 3
 # intercept at t = 4200+3600 = 7800
 eval instant at 70m predict_linear(testcounter_reset_middle_total[55m] @ 3000, 3600)
 	{} 89.54545454545455
+
+# predict_linear should ignore histogram with info annotation.
+eval_info instant at 60m predict_linear(testcounter_reset_middle_mix[60m], 3000)
+	{} 70
+
+eval_info instant at 60m predict_linear(testcounter_reset_middle_mix[60m], 50m)
+	{} 70
+
+# predict_linear should return NaN in case of +Inf or -Inf found.
+eval instant at 100m predict_linear(http_requests_inf[100m], 6000)
+	{job="app-server", instance="1", group="canary"} NaN
 
 # With http_requests_total, there is a sample value exactly at the end of
 # the range, and it has exactly the predicted value, so predict_linear
@@ -719,12 +735,27 @@ load 10s
 	http_requests{job="api-server", instance="1", group="production"}	0+20x1000 200+30x1000
 	http_requests{job="api-server", instance="0", group="canary"}		0+30x1000 300+80x1000
 	http_requests{job="api-server", instance="1", group="canary"}		0+40x2000
+	http_requests_mix{job="api-server", instance="0", group="production"}	0+10x1000 100+30x1000 {{schema:0 count:1 sum:2}}x1000
+	http_requests_mix{job="api-server", instance="1", group="production"}	0+20x1000 200+30x1000 {{schema:0 count:1 sum:2}}x1000
+	http_requests_mix{job="api-server", instance="0", group="canary"}		0+30x1000 300+80x1000 {{schema:0 count:1 sum:2}}x1000
+	http_requests_mix{job="api-server", instance="1", group="canary"}		0+40x2000 {{schema:0 count:1 sum:2}}x1000
+	http_requests_histogram{job="api-server", instance="1", group="canary"}	{{schema:0 count:1 sum:2}}x1000
 
 eval instant at 8000s double_exponential_smoothing(http_requests[1m], 0.01, 0.1)
 	{job="api-server", instance="0", group="production"} 8000
 	{job="api-server", instance="1", group="production"} 16000
 	{job="api-server", instance="0", group="canary"} 24000
 	{job="api-server", instance="1", group="canary"} 32000
+
+# double_exponential_smoothing should ignore histogram with info annotation.
+eval_info instant at 20010s double_exponential_smoothing(http_requests_mix[1m], 0.01, 0.1)
+	{job="api-server", instance="0", group="production"} 30100
+	{job="api-server", instance="1", group="production"} 30200
+	{job="api-server", instance="0", group="canary"} 80300
+	{job="api-server", instance="1", group="canary"} 80000
+
+eval_info instant at 10000s double_exponential_smoothing(http_requests_histogram[1m], 0.01, 0.1)
+	#empty
 
 # negative trends
 clear

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -280,7 +280,7 @@ eval_info instant at 100m deriv(testcounter_reset_middle_mix[110m])
 	{} 0.010606060606060607
 
 eval_info instant at 50m deriv(http_requests_histogram[60m])
-    #empty
+	#empty
 
 # deriv should return NaN in case of +Inf or -Inf found.
 eval instant at 100m deriv(http_requests_inf[100m])

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -148,6 +148,7 @@ var (
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
 	IncompatibleTypesInBinOpInfo            = fmt.Errorf("%w: incompatible sample types encountered for binary operator", PromQLInfo)
 	HistogramIgnoredInAggregationInfo       = fmt.Errorf("%w: ignored histogram in", PromQLInfo)
+	HistogramIgnoredInMixedRangeInfo        = fmt.Errorf("%w: ignored histograms in a range containing both floats and histograms for metric name", PromQLInfo)
 )
 
 type annoErr struct {
@@ -291,5 +292,12 @@ func NewHistogramIgnoredInAggregationInfo(aggregation string, pos posrange.Posit
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %s aggregation", HistogramIgnoredInAggregationInfo, aggregation),
+	}
+}
+
+func NewHistogramIgnoredInMixedRangeInfo(metricName string, pos posrange.PositionRange) error {
+	return annoErr{
+		PositionRange: pos,
+		Err:           fmt.Errorf("%w %q", HistogramIgnoredInMixedRangeInfo, metricName),
 	}
 }


### PR DESCRIPTION
Part of #13934.

This PR fixes the behaviour of `deriv`, `predict_linear` and `double_exponential_smoothing` with histograms. The correct behaviour for them is to ignore histograms and add info annotation.

CC: @beorn7 