### PR TITLE
Rules: Store dependencies instead of boolean

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -144,8 +144,8 @@ type AlertingRule struct {
 	logger *slog.Logger
 
 	dependenciesMutex sync.RWMutex
-	dependentRules    map[string]struct{}
-	dependencyRules   map[string]struct{}
+	dependentRules    []Rule
+	dependencyRules   []Rule
 }
 
 // NewAlertingRule constructs a new AlertingRule.
@@ -319,10 +319,8 @@ func (r *AlertingRule) SetDependentRules(dependents []Rule) {
 	r.dependenciesMutex.Lock()
 	defer r.dependenciesMutex.Unlock()
 
-	r.dependentRules = make(map[string]struct{})
-	for _, dependent := range dependents {
-		r.dependentRules[dependent.Name()] = struct{}{}
-	}
+	r.dependentRules = make([]Rule, len(dependents))
+	copy(r.dependentRules, dependents)
 }
 
 func (r *AlertingRule) NoDependentRules() bool {
@@ -336,7 +334,7 @@ func (r *AlertingRule) NoDependentRules() bool {
 	return len(r.dependentRules) == 0
 }
 
-func (r *AlertingRule) DependentRules() map[string]struct{} {
+func (r *AlertingRule) DependentRules() []Rule {
 	r.dependenciesMutex.RLock()
 	defer r.dependenciesMutex.RUnlock()
 	return r.dependentRules
@@ -346,10 +344,8 @@ func (r *AlertingRule) SetDependencyRules(dependencies []Rule) {
 	r.dependenciesMutex.Lock()
 	defer r.dependenciesMutex.Unlock()
 
-	r.dependencyRules = make(map[string]struct{})
-	for _, dependency := range dependencies {
-		r.dependencyRules[dependency.Name()] = struct{}{}
-	}
+	r.dependencyRules = make([]Rule, len(dependencies))
+	copy(r.dependencyRules, dependencies)
 }
 
 func (r *AlertingRule) NoDependencyRules() bool {
@@ -363,7 +359,7 @@ func (r *AlertingRule) NoDependencyRules() bool {
 	return len(r.dependencyRules) == 0
 }
 
-func (r *AlertingRule) DependencyRules() map[string]struct{} {
+func (r *AlertingRule) DependencyRules() []Rule {
 	r.dependenciesMutex.RLock()
 	defer r.dependenciesMutex.RUnlock()
 	return r.dependencyRules

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -999,6 +999,8 @@ func TestAlertingEvalWithOrigin(t *testing.T) {
 }
 
 func TestAlertingRule_SetDependentRules(t *testing.T) {
+	dependentRule := NewRecordingRule("test1", nil, labels.EmptyLabels())
+
 	rule := NewAlertingRule(
 		"test",
 		&parser.NumberLiteral{Val: 1},
@@ -1012,9 +1014,9 @@ func TestAlertingRule_SetDependentRules(t *testing.T) {
 	)
 	require.False(t, rule.NoDependentRules())
 
-	rule.SetDependentRules([]Rule{NewRecordingRule("test1", nil, labels.EmptyLabels())})
+	rule.SetDependentRules([]Rule{dependentRule})
 	require.False(t, rule.NoDependentRules())
-	require.Equal(t, map[string]struct{}{"test1": {}}, rule.DependentRules())
+	require.Equal(t, []Rule{dependentRule}, rule.DependentRules())
 
 	rule.SetDependentRules([]Rule{})
 	require.True(t, rule.NoDependentRules())
@@ -1022,6 +1024,8 @@ func TestAlertingRule_SetDependentRules(t *testing.T) {
 }
 
 func TestAlertingRule_SetDependencyRules(t *testing.T) {
+	dependencyRule := NewRecordingRule("test1", nil, labels.EmptyLabels())
+
 	rule := NewAlertingRule(
 		"test",
 		&parser.NumberLiteral{Val: 1},
@@ -1035,9 +1039,9 @@ func TestAlertingRule_SetDependencyRules(t *testing.T) {
 	)
 	require.False(t, rule.NoDependencyRules())
 
-	rule.SetDependencyRules([]Rule{NewRecordingRule("test1", nil, labels.EmptyLabels())})
+	rule.SetDependencyRules([]Rule{dependencyRule})
 	require.False(t, rule.NoDependencyRules())
-	require.Equal(t, map[string]struct{}{"test1": {}}, rule.DependencyRules())
+	require.Equal(t, []Rule{dependencyRule}, rule.DependencyRules())
 
 	rule.SetDependencyRules([]Rule{})
 	require.True(t, rule.NoDependencyRules())

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -998,7 +998,7 @@ func TestAlertingEvalWithOrigin(t *testing.T) {
 	require.Equal(t, detail, NewRuleDetail(rule))
 }
 
-func TestAlertingRule_SetNoDependentRules(t *testing.T) {
+func TestAlertingRule_SetDependentRules(t *testing.T) {
 	rule := NewAlertingRule(
 		"test",
 		&parser.NumberLiteral{Val: 1},
@@ -1012,14 +1012,16 @@ func TestAlertingRule_SetNoDependentRules(t *testing.T) {
 	)
 	require.False(t, rule.NoDependentRules())
 
-	rule.SetNoDependentRules(false)
+	rule.SetDependentRules([]Rule{NewRecordingRule("test1", nil, labels.EmptyLabels())})
 	require.False(t, rule.NoDependentRules())
+	require.Equal(t, map[string]struct{}{"test1": {}}, rule.DependentRules())
 
-	rule.SetNoDependentRules(true)
+	rule.SetDependentRules([]Rule{})
 	require.True(t, rule.NoDependentRules())
+	require.Empty(t, rule.DependentRules())
 }
 
-func TestAlertingRule_SetNoDependencyRules(t *testing.T) {
+func TestAlertingRule_SetDependencyRules(t *testing.T) {
 	rule := NewAlertingRule(
 		"test",
 		&parser.NumberLiteral{Val: 1},
@@ -1033,11 +1035,13 @@ func TestAlertingRule_SetNoDependencyRules(t *testing.T) {
 	)
 	require.False(t, rule.NoDependencyRules())
 
-	rule.SetNoDependencyRules(false)
+	rule.SetDependencyRules([]Rule{NewRecordingRule("test1", nil, labels.EmptyLabels())})
 	require.False(t, rule.NoDependencyRules())
+	require.Equal(t, map[string]struct{}{"test1": {}}, rule.DependencyRules())
 
-	rule.SetNoDependencyRules(true)
+	rule.SetDependencyRules([]Rule{})
 	require.True(t, rule.NoDependencyRules())
+	require.Empty(t, rule.DependencyRules())
 }
 
 func TestAlertingRule_ActiveAlertsCount(t *testing.T) {

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -444,8 +444,8 @@ func SendAlerts(s Sender, externalURL string) NotifyFunc {
 // RuleDependencyController controls whether a set of rules have dependencies between each other.
 type RuleDependencyController interface {
 	// AnalyseRules analyses dependencies between the input rules. For each rule that it's guaranteed
-	// not having any dependants and/or dependency, this function should call Rule.SetNoDependentRules(true)
-	// and/or Rule.SetNoDependencyRules(true).
+	// not having any dependants and/or dependency, this function should call Rule.SetDependentRules(...)
+	// and/or Rule.SetDependencyRules(...).
 	AnalyseRules(rules []Rule)
 }
 
@@ -460,8 +460,8 @@ func (c ruleDependencyController) AnalyseRules(rules []Rule) {
 	}
 
 	for _, r := range rules {
-		r.SetNoDependentRules(depMap.dependents(r) == 0)
-		r.SetNoDependencyRules(depMap.dependencies(r) == 0)
+		r.SetDependentRules(depMap.dependents(r))
+		r.SetDependencyRules(depMap.dependencies(r))
 	}
 }
 

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -1423,8 +1423,6 @@ func TestRuleGroupEvalIterationFunc(t *testing.T) {
 			evaluationTimestamp: atomic.NewTime(time.Time{}),
 			evaluationDuration:  atomic.NewDuration(0),
 			lastError:           atomic.NewError(nil),
-			noDependentRules:    atomic.NewBool(false),
-			noDependencyRules:   atomic.NewBool(false),
 		}
 
 		group := NewGroup(GroupOptions{
@@ -1613,11 +1611,12 @@ func TestDependencyMap(t *testing.T) {
 	depMap := buildDependencyMap(group.rules)
 
 	require.Zero(t, depMap.dependencies(rule))
-	require.Equal(t, 2, depMap.dependents(rule))
+	require.Equal(t, []Rule{rule2, rule4}, depMap.dependents(rule))
+	require.Len(t, depMap.dependents(rule), 2)
 	require.False(t, depMap.isIndependent(rule))
 
 	require.Zero(t, depMap.dependents(rule2))
-	require.Equal(t, 1, depMap.dependencies(rule2))
+	require.Equal(t, []Rule{rule}, depMap.dependencies(rule2))
 	require.False(t, depMap.isIndependent(rule2))
 
 	require.Zero(t, depMap.dependents(rule3))
@@ -1625,7 +1624,7 @@ func TestDependencyMap(t *testing.T) {
 	require.True(t, depMap.isIndependent(rule3))
 
 	require.Zero(t, depMap.dependents(rule4))
-	require.Equal(t, 1, depMap.dependencies(rule4))
+	require.Equal(t, []Rule{rule}, depMap.dependencies(rule4))
 	require.False(t, depMap.isIndependent(rule4))
 }
 
@@ -1958,7 +1957,8 @@ func TestDependencyMapUpdatesOnGroupUpdate(t *testing.T) {
 		require.NotEqual(t, orig[h], depMap)
 		// We expect there to be some dependencies since the new rule group contains a dependency.
 		require.NotEmpty(t, depMap)
-		require.Equal(t, 1, depMap.dependents(rr))
+		require.Len(t, depMap.dependents(rr), 1)
+		require.Equal(t, "HighRequestRate", depMap.dependents(rr)[0].Name())
 		require.Zero(t, depMap.dependencies(rr))
 	}
 }

--- a/rules/origin_test.go
+++ b/rules/origin_test.go
@@ -47,10 +47,10 @@ func (u unknownRule) SetEvaluationTimestamp(time.Time)     {}
 func (u unknownRule) GetEvaluationTimestamp() time.Time    { return time.Time{} }
 func (u unknownRule) SetDependentRules([]Rule)             {}
 func (u unknownRule) NoDependentRules() bool               { return false }
-func (u unknownRule) DependentRules() map[string]struct{}  { return nil }
+func (u unknownRule) DependentRules() []Rule               { return nil }
 func (u unknownRule) SetDependencyRules([]Rule)            {}
 func (u unknownRule) NoDependencyRules() bool              { return false }
-func (u unknownRule) DependencyRules() map[string]struct{} { return nil }
+func (u unknownRule) DependencyRules() []Rule              { return nil }
 
 func TestNewRuleDetailPanics(t *testing.T) {
 	require.PanicsWithValue(t, `unknown rule type "rules.unknownRule"`, func() {

--- a/rules/origin_test.go
+++ b/rules/origin_test.go
@@ -45,10 +45,12 @@ func (u unknownRule) SetEvaluationDuration(time.Duration)  {}
 func (u unknownRule) GetEvaluationDuration() time.Duration { return 0 }
 func (u unknownRule) SetEvaluationTimestamp(time.Time)     {}
 func (u unknownRule) GetEvaluationTimestamp() time.Time    { return time.Time{} }
-func (u unknownRule) SetNoDependentRules(bool)             {}
+func (u unknownRule) SetDependentRules([]Rule)             {}
 func (u unknownRule) NoDependentRules() bool               { return false }
-func (u unknownRule) SetNoDependencyRules(bool)            {}
+func (u unknownRule) DependentRules() map[string]struct{}  { return nil }
+func (u unknownRule) SetDependencyRules([]Rule)            {}
 func (u unknownRule) NoDependencyRules() bool              { return false }
+func (u unknownRule) DependencyRules() map[string]struct{} { return nil }
 
 func TestNewRuleDetailPanics(t *testing.T) {
 	require.PanicsWithValue(t, `unknown rule type "rules.unknownRule"`, func() {
@@ -76,12 +78,12 @@ func TestNewRuleDetail(t *testing.T) {
 		require.False(t, detail.NoDependentRules)
 		require.False(t, detail.NoDependencyRules)
 
-		rule.SetNoDependentRules(true)
+		rule.SetDependentRules([]Rule{})
 		detail = NewRuleDetail(rule)
 		require.True(t, detail.NoDependentRules)
 		require.False(t, detail.NoDependencyRules)
 
-		rule.SetNoDependencyRules(true)
+		rule.SetDependencyRules([]Rule{})
 		detail = NewRuleDetail(rule)
 		require.True(t, detail.NoDependentRules)
 		require.True(t, detail.NoDependencyRules)
@@ -104,12 +106,12 @@ func TestNewRuleDetail(t *testing.T) {
 		require.False(t, detail.NoDependentRules)
 		require.False(t, detail.NoDependencyRules)
 
-		rule.SetNoDependentRules(true)
+		rule.SetDependentRules([]Rule{})
 		detail = NewRuleDetail(rule)
 		require.True(t, detail.NoDependentRules)
 		require.False(t, detail.NoDependencyRules)
 
-		rule.SetNoDependencyRules(true)
+		rule.SetDependencyRules([]Rule{})
 		detail = NewRuleDetail(rule)
 		require.True(t, detail.NoDependentRules)
 		require.True(t, detail.NoDependencyRules)

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -45,8 +45,8 @@ type RecordingRule struct {
 	evaluationDuration *atomic.Duration
 
 	dependenciesMutex sync.RWMutex
-	dependentRules    map[string]struct{}
-	dependencyRules   map[string]struct{}
+	dependentRules    []Rule
+	dependencyRules   []Rule
 }
 
 // NewRecordingRule returns a new recording rule.
@@ -176,10 +176,8 @@ func (rule *RecordingRule) SetDependentRules(dependents []Rule) {
 	rule.dependenciesMutex.Lock()
 	defer rule.dependenciesMutex.Unlock()
 
-	rule.dependentRules = make(map[string]struct{})
-	for _, r := range dependents {
-		rule.dependentRules[r.Name()] = struct{}{}
-	}
+	rule.dependentRules = make([]Rule, len(dependents))
+	copy(rule.dependentRules, dependents)
 }
 
 func (rule *RecordingRule) NoDependentRules() bool {
@@ -193,7 +191,7 @@ func (rule *RecordingRule) NoDependentRules() bool {
 	return len(rule.dependentRules) == 0
 }
 
-func (rule *RecordingRule) DependentRules() map[string]struct{} {
+func (rule *RecordingRule) DependentRules() []Rule {
 	rule.dependenciesMutex.RLock()
 	defer rule.dependenciesMutex.RUnlock()
 	return rule.dependentRules
@@ -203,10 +201,8 @@ func (rule *RecordingRule) SetDependencyRules(dependencies []Rule) {
 	rule.dependenciesMutex.Lock()
 	defer rule.dependenciesMutex.Unlock()
 
-	rule.dependencyRules = make(map[string]struct{})
-	for _, r := range dependencies {
-		rule.dependencyRules[r.Name()] = struct{}{}
-	}
+	rule.dependencyRules = make([]Rule, len(dependencies))
+	copy(rule.dependencyRules, dependencies)
 }
 
 func (rule *RecordingRule) NoDependencyRules() bool {
@@ -220,7 +216,7 @@ func (rule *RecordingRule) NoDependencyRules() bool {
 	return len(rule.dependencyRules) == 0
 }
 
-func (rule *RecordingRule) DependencyRules() map[string]struct{} {
+func (rule *RecordingRule) DependencyRules() []Rule {
 	rule.dependenciesMutex.RLock()
 	defer rule.dependenciesMutex.RUnlock()
 	return rule.dependencyRules

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -256,12 +256,14 @@ func TestRecordingEvalWithOrigin(t *testing.T) {
 }
 
 func TestRecordingRule_SetDependentRules(t *testing.T) {
+	dependentRule := NewRecordingRule("test1", nil, labels.EmptyLabels())
+
 	rule := NewRecordingRule("1", &parser.NumberLiteral{Val: 1}, labels.EmptyLabels())
 	require.False(t, rule.NoDependentRules())
 
-	rule.SetDependentRules([]Rule{NewRecordingRule("test1", nil, labels.EmptyLabels())})
+	rule.SetDependentRules([]Rule{dependentRule})
 	require.False(t, rule.NoDependentRules())
-	require.Equal(t, map[string]struct{}{"test1": {}}, rule.DependentRules())
+	require.Equal(t, []Rule{dependentRule}, rule.DependentRules())
 
 	rule.SetDependentRules([]Rule{})
 	require.True(t, rule.NoDependentRules())
@@ -269,12 +271,14 @@ func TestRecordingRule_SetDependentRules(t *testing.T) {
 }
 
 func TestRecordingRule_SetDependencyRules(t *testing.T) {
+	dependencyRule := NewRecordingRule("test1", nil, labels.EmptyLabels())
+
 	rule := NewRecordingRule("1", &parser.NumberLiteral{Val: 1}, labels.EmptyLabels())
 	require.False(t, rule.NoDependencyRules())
 
-	rule.SetDependencyRules([]Rule{NewRecordingRule("test1", nil, labels.EmptyLabels())})
+	rule.SetDependencyRules([]Rule{dependencyRule})
 	require.False(t, rule.NoDependencyRules())
-	require.Equal(t, map[string]struct{}{"test1": {}}, rule.DependencyRules())
+	require.Equal(t, []Rule{dependencyRule}, rule.DependencyRules())
 
 	rule.SetDependencyRules([]Rule{})
 	require.True(t, rule.NoDependencyRules())

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -255,24 +255,28 @@ func TestRecordingEvalWithOrigin(t *testing.T) {
 	require.Equal(t, detail, NewRuleDetail(rule))
 }
 
-func TestRecordingRule_SetNoDependentRules(t *testing.T) {
+func TestRecordingRule_SetDependentRules(t *testing.T) {
 	rule := NewRecordingRule("1", &parser.NumberLiteral{Val: 1}, labels.EmptyLabels())
 	require.False(t, rule.NoDependentRules())
 
-	rule.SetNoDependentRules(false)
+	rule.SetDependentRules([]Rule{NewRecordingRule("test1", nil, labels.EmptyLabels())})
 	require.False(t, rule.NoDependentRules())
+	require.Equal(t, map[string]struct{}{"test1": {}}, rule.DependentRules())
 
-	rule.SetNoDependentRules(true)
+	rule.SetDependentRules([]Rule{})
 	require.True(t, rule.NoDependentRules())
+	require.Empty(t, rule.DependentRules())
 }
 
-func TestRecordingRule_SetNoDependencyRules(t *testing.T) {
+func TestRecordingRule_SetDependencyRules(t *testing.T) {
 	rule := NewRecordingRule("1", &parser.NumberLiteral{Val: 1}, labels.EmptyLabels())
 	require.False(t, rule.NoDependencyRules())
 
-	rule.SetNoDependencyRules(false)
+	rule.SetDependencyRules([]Rule{NewRecordingRule("test1", nil, labels.EmptyLabels())})
 	require.False(t, rule.NoDependencyRules())
+	require.Equal(t, map[string]struct{}{"test1": {}}, rule.DependencyRules())
 
-	rule.SetNoDependencyRules(true)
+	rule.SetDependencyRules([]Rule{})
 	require.True(t, rule.NoDependencyRules())
+	require.Empty(t, rule.DependencyRules())
 }

--- a/rules/rule.go
+++ b/rules/rule.go
@@ -70,8 +70,8 @@ type Rule interface {
 	// means there may or may not be other rules depending on this one.
 	NoDependentRules() bool
 
-	// DependentRules returns the rules (names) which depend on the output of this rule.
-	DependentRules() map[string]struct{}
+	// DependentRules returns the rules which depend on the output of this rule.
+	DependentRules() []Rule
 
 	// SetDependencyRules sets rules on which this rule depends.
 	SetDependencyRules(rules []Rule)
@@ -81,6 +81,6 @@ type Rule interface {
 	// means the rule may or may not depend on other rules.
 	NoDependencyRules() bool
 
-	// DependencyRules returns the rules (names) on which this rule depends.
-	DependencyRules() map[string]struct{}
+	// DependencyRules returns the rules on which this rule depends.
+	DependencyRules() []Rule
 }

--- a/rules/rule.go
+++ b/rules/rule.go
@@ -62,19 +62,25 @@ type Rule interface {
 	// NOTE: Used dynamically by rules.html template.
 	GetEvaluationTimestamp() time.Time
 
-	// SetNoDependentRules sets whether there's no other rule in the rule group that depends on this rule.
-	SetNoDependentRules(bool)
+	// SetDependentRules sets rules which depend on the output of this rule.
+	SetDependentRules(rules []Rule)
 
 	// NoDependentRules returns true if it's guaranteed that in the rule group there's no other rule
 	// which depends on this one. In case this function returns false there's no such guarantee, which
 	// means there may or may not be other rules depending on this one.
 	NoDependentRules() bool
 
-	// SetNoDependencyRules sets whether this rule doesn't depend on the output of any rule in the rule group.
-	SetNoDependencyRules(bool)
+	// DependentRules returns the rules (names) which depend on the output of this rule.
+	DependentRules() map[string]struct{}
+
+	// SetDependencyRules sets rules on which this rule depends.
+	SetDependencyRules(rules []Rule)
 
 	// NoDependencyRules returns true if it's guaranteed that this rule doesn't depend on the output of
 	// any other rule in the group. In case this function returns false there's no such guarantee, which
 	// means the rule may or may not depend on other rules.
 	NoDependencyRules() bool
+
+	// DependencyRules returns the rules (names) on which this rule depends.
+	DependencyRules() map[string]struct{}
 }


### PR DESCRIPTION
To improve https://github.com/prometheus/prometheus/pull/15681 further, we'll need to store the dependencies and dependents of each

Right now, if a rule has both (at least 1) dependents and dependencies, it is not possible to determine the order to run the rules and they must all run sequentially

This PR only changes the dependents and dependencies attributes of rules, it does not implement a new topological sort algorithm