### PR TITLE
tsdb: Extract index file path logic into a helper function

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -253,6 +253,8 @@ const (
 
 func chunkDir(dir string) string { return filepath.Join(dir, "chunks") }
 
+func indexFile(dir string) string { return filepath.Join(dir, indexFilename) }
+
 func readMetaFile(dir string) (*BlockMeta, int64, error) {
 	b, err := os.ReadFile(filepath.Join(dir, metaFilename))
 	if err != nil {
@@ -359,7 +361,7 @@ func OpenBlock(logger *slog.Logger, dir string, pool chunkenc.Pool, postingsDeco
 	if postingsDecoderFactory != nil {
 		decoder = postingsDecoderFactory(meta)
 	}
-	ir, err := index.NewFileReader(filepath.Join(dir, indexFilename), decoder)
+	ir, err := index.NewFileReader(indexFile(dir), decoder)
 	if err != nil {
 		return nil, err
 	}

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -661,7 +661,7 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blockPopulator Bl
 		}
 	}
 
-	indexw, err := index.NewWriterWithEncoder(c.ctx, filepath.Join(tmp, indexFilename), c.postingsEncoder)
+	indexw, err := index.NewWriterWithEncoder(c.ctx, indexFile(tmp), c.postingsEncoder)
 	if err != nil {
 		return fmt.Errorf("open index writer: %w", err)
 	}

--- a/tsdb/repair.go
+++ b/tsdb/repair.go
@@ -72,7 +72,7 @@ func repairBadIndexVersion(logger *slog.Logger, dir string) error {
 		}
 		tmpFiles = append(tmpFiles, repl.Name())
 
-		broken, err := os.Open(filepath.Join(d, indexFilename))
+		broken, err := os.Open(indexFile(d))
 		if err != nil {
 			return fmt.Errorf("open broken index for block dir: %v: %w", d, err)
 		}


### PR DESCRIPTION
- Added `indexFile` helper function to generate the index file path.
- Updated `block.go`, `compact.go`, and `repair.go` to use the new `indexFile` function for consistency and readability.

