### PR TITLE
chore: Sign project binary on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ benchmark.txt
 /cmd/prometheus/debug
 /benchout
 /cmd/promtool/data
+_CodeSignature
 
 !/.travis.yml
 !/.promu.yml

--- a/Makefile.common
+++ b/Makefile.common
@@ -201,7 +201,10 @@ common-unused:
 .PHONY: common-build
 common-build: promu
 	@echo ">> building binaries"
-	$(PROMU) build --prefix $(PREFIX) $(PROMU_BINARIES)
+	@$(PROMU) build --prefix $(PREFIX) $(PROMU_BINARIES) && \
+		if [ "$(GOHOSTOS)" = "darwin" ] && command -v codesign > /dev/null 2>&1; then \
+			codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime $(PREFIX) >/dev/null 2>&1; \
+		fi
 
 .PHONY: common-tarball
 common-tarball: promu


### PR DESCRIPTION
In order to be able to run the generated binary, it needs to be "cosigned". Also, please note that we use the "codesign" binary that's shipped in MacOS directly (instead of "promu codesign"), as that depends on an image that doesn't support linux/arm64 (w.r.t. darwin's rosetta emulation) yet:
```
WARNING: image platform (linux/amd64) does not match the expected platform (linux/arm64)
```
***
Blocks https://github.com/prometheus/node_exporter/pull/3160/files#r1895596246.
