### PR TITLE
Add options to test for skipping warn and info

### DIFF
--- a/promql/promqltest/test_test.go
+++ b/promql/promqltest/test_test.go
@@ -25,6 +25,18 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
+func TestOption_WithSkipEvalInfo(t *testing.T) {
+	o := &options{}
+	WithSkipEvalInfo(true).apply(o)
+	require.True(t, o.skipEvalInfo)
+}
+
+func TestOption_WithSkipEvalWarn(t *testing.T) {
+	o := &options{}
+	WithSkipEvalWarn(true).apply(o)
+	require.True(t, o.skipEvalWarn)
+}
+
 func TestLazyLoader_WithSamplesTill(t *testing.T) {
 	type testCase struct {
 		ts             time.Time


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible, use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
 
This PR adds two test options, `skipEvalInfo` and `skipEvalWarn`. If true, they skip `eval_info` and `eval_warn` respectively.
It allows another engine to do an acceptance test without verifying `warn` and `info`. 
