### PR TITLE
TSDB benchmarks: Commit periodically to speed up init

### DIFF
--- a/tsdb/querier_bench_test.go
+++ b/tsdb/querier_bench_test.go
@@ -55,6 +55,8 @@ func BenchmarkQuerier(b *testing.B) {
 			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", "1_"+strconv.Itoa(n)+postingsBenchSuffix, "j", "bar"))
 			addSeries(labels.FromStrings("i", strconv.Itoa(i)+postingsBenchSuffix, "n", "2_"+strconv.Itoa(n)+postingsBenchSuffix, "j", "foo"))
 		}
+		require.NoError(b, app.Commit())
+		app = h.Appender(context.Background())
 	}
 	require.NoError(b, app.Commit())
 
@@ -270,6 +272,10 @@ func createHeadForBenchmarkSelect(b *testing.B, numSeries int, addSeries func(ap
 	app := h.Appender(context.Background())
 	for i := 0; i < numSeries; i++ {
 		addSeries(app, i)
+		if i%1000 == 999 { // Commit every so often, so the appender doesn't get too big.
+			require.NoError(b, app.Commit())
+			app = h.Appender(context.Background())
+		}
 	}
 	require.NoError(b, app.Commit())
 	return h, db


### PR DESCRIPTION
When creating dummy data for benchmarks, call `Commit()` periodically to avoid growing the appender to enormous size.

To illustrate, ask Go to run nonexistent sub-benchmarks so it just does the initialization:

Before:
```
$ go test -v -tags stringlabels -run xxx -bench 'Querier/x'  ./tsdb 
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Core(TM) i7-14700K
BenchmarkQuerier
BenchmarkQuerierSelect
BenchmarkQuerierSelectWithOutOfOrder
BenchmarkHeadChunkQuerier
BenchmarkHeadQuerier
PASS
ok      github.com/prometheus/prometheus/tsdb   464.839s
```

After:
```
$ go test -v -tags stringlabels -run xxx -bench 'Querier/x'  ./tsdb 
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Core(TM) i7-14700K
BenchmarkQuerier
BenchmarkQuerierSelect
BenchmarkQuerierSelectWithOutOfOrder
BenchmarkHeadChunkQuerier
BenchmarkHeadQuerier
PASS
ok      github.com/prometheus/prometheus/tsdb   19.136s
```