### PR TITLE
WIP: feat(chunkenc): use an iterator pool to avoid generating garbage during WAL replay

### DIFF
--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -47,6 +47,7 @@ import (
 	"encoding/binary"
 	"math"
 	"math/bits"
+	"sync"
 
 	"github.com/prometheus/prometheus/model/histogram"
 )
@@ -54,6 +55,13 @@ import (
 const (
 	chunkCompactCapacityThreshold = 32
 )
+
+// appenderIterPool is exclusively used in XORChunk.Appender()
+var appenderIterPool = sync.Pool{
+	New: func() interface{} {
+		return &xorIterator{}
+	},
+}
 
 // XORChunk holds XOR encoded sample data.
 type XORChunk struct {
@@ -98,7 +106,8 @@ func (c *XORChunk) Compact() {
 // It is not valid to call Appender() multiple times concurrently or to use multiple
 // Appenders on the same chunk.
 func (c *XORChunk) Appender() (Appender, error) {
-	it := c.iterator(nil)
+	it := c.iterator(appenderIterPool.Get().(*xorIterator))
+	defer appenderIterPool.Put(it)
 
 	// To get an appender we must know the state it would have if we had
 	// appended all existing data from scratch.


### PR DESCRIPTION
This is part of the "reduce WAL replay overhead/garbage" effort to help with https://github.com/prometheus/prometheus/issues/6934.

A `xorIterator` is ~100 bytes on average per head chunk ~ per time series.

With 10M series in the head, `xorIterator` could generate more than 1GB of garbage.

- [ ] Currently, only `xorIterator` is concerned; generalize to others, maybe via the existing pool in chunks.go?
- [ ] How to improve on using a global variable/pool? Without bending the existing API
- [ ] During WAL replay, ~ `h.opts.WALReplayConcurrency` pool.Get() calls could run at the same time, so the risk of bloating the pool is minimal.
- [ ] Check how the appender is used during scrapingi (and the iterator during querying). Maybe to avoid bloat, limit the pool to WAL replay and dereference it at the end.
- [ ] Run other benchmarks

### Benchmarks

<details>
<summary>BenchmarkLoadWLs</summary>

Ran as `go test ./tsdb/ -run '^$' -bench '^BenchmarkLoadWLs' -benchtime 1x -count 6 -cpu 2 -benchmem -timeout 999m `

```console
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         306.9m ±  6%   268.8m ±  5%  -12.42% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2        292.6m ± 18%   270.3m ±  7%   -7.64% (p=0.009 n=6)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2        291.9m ± 51%   272.9m ±  6%        ~ (p=0.240 n=6)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2       328.4m ± 10%   293.1m ±  2%  -10.75% (p=0.009 n=6)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         430.1m ± 23%   377.3m ± 18%        ~ (p=0.132 n=6)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         463.2m ± 15%   395.7m ±  5%  -14.58% (p=0.026 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         243.9m ± 12%   200.5m ± 18%  -17.82% (p=0.015 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         242.6m ± 19%   194.6m ±  9%  -19.78% (p=0.004 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         206.1m ± 13%   200.5m ±  2%        ~ (p=0.589 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2        254.1m ± 15%   215.1m ±  3%  -15.37% (p=0.009 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2      2.043 ± 20%    1.479 ± 18%  -27.59% (p=0.009 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2      1.923 ± 19%    1.589 ± 17%  -17.38% (p=0.041 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2      1.956 ± 15%    1.651 ± 25%        ~ (p=0.065 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2     2.282 ± 21%    1.948 ± 14%  -14.62% (p=0.026 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2        566.5m ±  7%   515.8m ±  4%   -8.96% (p=0.004 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2        589.7m ±  9%   529.2m ±  7%  -10.26% (p=0.015 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2        591.8m ± 11%   519.5m ± 10%  -12.23% (p=0.009 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2       555.1m ±  9%   604.5m ± 12%        ~ (p=0.589 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2         541.7m ± 11%   472.8m ±  9%  -12.72% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2         486.9m ±  8%   488.8m ± 16%        ~ (p=1.000 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2         564.9m ±  4%   481.2m ± 15%  -14.83% (p=0.009 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2        560.5m ± 10%   502.5m ± 17%        ~ (p=0.132 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2     7.178 ±  6%    6.481 ± 14%        ~ (p=0.180 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2     7.710 ± 11%    7.114 ±  3%   -7.74% (p=0.026 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2     7.849 ± 12%    7.344 ± 14%        ~ (p=0.818 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2    7.719 ±  5%    8.646 ±  4%  +12.02% (p=0.002 n=6)
geomean                                                                                                                                                       798.3m         713.6m        -10.62%

                                                                                                                                                            │    v1.txt    │                v2.txt                │
                                                                                                                                                            │     B/op     │     B/op       vs base               │
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         69.68Mi ± 0%   61.90Mi ±  0%  -11.16% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2        71.40Mi ± 0%   63.67Mi ±  0%  -10.83% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2        73.17Mi ± 0%   65.37Mi ±  0%  -10.67% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2       88.41Mi ± 0%   80.64Mi ±  0%   -8.79% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         222.9Mi ± 3%   203.1Mi ±  4%   -8.89% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         252.0Mi ± 4%   242.2Mi ±  5%   -3.90% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         77.79Mi ± 0%   72.37Mi ±  0%   -6.96% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         80.06Mi ± 0%   74.48Mi ±  1%   -6.96% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         81.33Mi ± 1%   75.43Mi ±  1%   -7.26% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2        90.20Mi ± 0%   84.81Mi ±  0%   -5.98% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2     316.3Mi ± 3%   265.0Mi ±  5%  -16.22% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2     332.2Mi ± 6%   272.4Mi ± 13%  -18.02% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2     344.1Mi ± 5%   301.2Mi ±  7%  -12.45% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2    437.4Mi ± 4%   388.6Mi ±  3%  -11.16% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2        556.4Mi ± 0%   536.7Mi ±  1%   -3.54% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2        558.8Mi ± 0%   536.7Mi ±  0%   -3.95% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2        559.3Mi ± 0%   539.5Mi ±  0%   -3.55% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2       569.5Mi ± 1%   549.4Mi ±  0%   -3.52% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2         481.1Mi ± 0%   461.6Mi ±  0%   -4.06% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2         482.9Mi ± 0%   463.3Mi ±  0%   -4.05% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2         485.0Mi ± 0%   464.3Mi ±  0%   -4.26% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2        493.7Mi ± 0%   472.8Mi ±  0%   -4.22% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2    4.244Gi ± 1%   4.065Gi ±  1%   -4.22% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2    4.255Gi ± 0%   4.087Gi ±  0%   -3.95% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2    4.275Gi ± 1%   4.103Gi ±  0%   -4.03% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2   4.363Gi ± 0%   4.192Gi ±  0%   -3.91% (p=0.002 n=6)
geomean                                                                                                                                                       358.8Mi        332.7Mi         -7.27%

                                                                                                                                                            │   v1.txt    │               v2.txt               │
                                                                                                                                                            │  allocs/op  │  allocs/op   vs base               │
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         676.3k ± 0%   603.6k ± 0%  -10.75% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=36,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2        784.1k ± 0%   711.6k ± 0%   -9.24% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=72,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2        892.9k ± 0%   820.2k ± 0%   -8.15% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=100,samplesPerSeries=7200,exemplarsPerSeries=360,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2       1.760M ± 0%   1.687M ± 0%   -4.13% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         2.024M ± 0%   1.920M ± 0%   -5.11% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=10000,samplesPerSeries=50,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         2.622M ± 0%   2.522M ± 0%   -3.81% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         615.1k ± 0%   565.1k ± 0%   -8.13% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         675.3k ± 0%   625.2k ± 0%   -7.42% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2         765.2k ± 0%   715.3k ± 0%   -6.53% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2        1.335M ± 0%   1.285M ± 0%   -3.74% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2     3.174M ± 0%   2.933M ± 1%   -7.59% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2     3.781M ± 1%   3.529M ± 1%   -6.67% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2     4.679M ± 1%   4.450M ± 1%   -4.89% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.000,oooSamplesPct=0.000,oooCapMax=0-2    10.39M ± 0%   10.15M ± 0%   -2.29% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2        2.824M ± 0%   2.638M ± 0%   -6.58% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2        2.885M ± 0%   2.695M ± 0%   -6.60% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2        2.973M ± 0%   2.788M ± 0%   -6.22% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.500,oooSamplesPct=0.500,oooCapMax=32-2       3.547M ± 0%   3.361M ± 0%   -5.24% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2         2.639M ± 0%   2.454M ± 0%   -7.00% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2         2.699M ± 0%   2.508M ± 0%   -7.07% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2         2.789M ± 0%   2.596M ± 0%   -6.93% (p=0.002 n=6)
LoadWLs/batches=10,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=0,oooSeriesPct=0.100,oooSamplesPct=0.100,oooCapMax=0-2        3.363M ± 0%   3.166M ± 0%   -5.83% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2    23.82M ± 0%   22.17M ± 0%   -6.93% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=2,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2    24.42M ± 0%   22.79M ± 0%   -6.70% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=5,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2    25.33M ± 0%   23.69M ± 0%   -6.48% (p=0.002 n=6)
LoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=24,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32-2   31.04M ± 0%   29.40M ± 0%   -5.28% (p=0.002 n=6)
geomean  
```
</details>

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
