### PR TITLE
feat(tsdb/(head|agent)): reuse pools across segments to reduce garbage during WL replay

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -94,6 +94,16 @@ type Head struct {
 	bytesPool           zeropool.Pool[[]byte]
 	memChunkPool        sync.Pool
 
+	// These pools are used during WAL/WBL replay.
+	wlReplaySeriesPool          zeropool.Pool[[]record.RefSeries]
+	wlReplaySamplesPool         zeropool.Pool[[]record.RefSample]
+	wlReplaytStonesPool         zeropool.Pool[[]tombstones.Stone]
+	wlReplayExemplarsPool       zeropool.Pool[[]record.RefExemplar]
+	wlReplayHistogramsPool      zeropool.Pool[[]record.RefHistogramSample]
+	wlReplayFloatHistogramsPool zeropool.Pool[[]record.RefFloatHistogramSample]
+	wlReplayMetadataPool        zeropool.Pool[[]record.RefMetadata]
+	wlReplayMmapMarkersPool     zeropool.Pool[[]record.RefMmapMarker]
+
 	// All series addressable by their ID or hash.
 	series *stripeSeries
 


### PR DESCRIPTION
This is part of the "reduce WAL replay overhead/garbage" effort to help with https://github.com/prometheus/prometheus/issues/6934.

On some WALs I have around I got (`10*128MB`):

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz
               │   v1.txt   │              v2.txt              │
               │   sec/op   │   sec/op    vs base              │
LoadRealWLs-14   49.89 ± 1%   49.33 ± 0%  -1.10% (p=0.041 n=6)

               │    v1.txt    │               v2.txt               │
               │     B/op     │     B/op      vs base              │
LoadRealWLs-14   8.154Gi ± 0%   7.542Gi ± 0%  -7.50% (p=0.002 n=6)

               │   v1.txt    │              v2.txt               │
               │  allocs/op  │  allocs/op   vs base              │
LoadRealWLs-14   101.5M ± 0%   101.6M ± 0%  +0.02% (p=0.002 n=6)
```

- [x] Make sure the shared variables are well reset before use.
- [x] Make sure the memory is freed at the end.
- [x] Run more benchmarks. 
- [x] Do the same for agent mode?
- [ ] create issue for other data stores, `processors` etc. quantify the gain + state it needs more consideration

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
