### PR TITLE
api: Add two new fields Hostname and ServerTime.

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -1158,6 +1158,8 @@ $ curl http://localhost:9090/api/v1/status/runtimeinfo
   "data": {
     "startTime": "2019-11-02T17:23:59.301361365+01:00",
     "CWD": "/",
+    "hostname" : "DESKTOP-717H17Q",
+    "serverTime": "2025-01-05T18:27:33Z",
     "reloadConfigSuccess": true,
     "lastConfigTime": "2019-11-02T17:23:59+01:00",
     "timeSeriesCount": 873,

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -144,6 +144,8 @@ type PrometheusVersion struct {
 type RuntimeInfo struct {
 	StartTime           time.Time `json:"startTime"`
 	CWD                 string    `json:"CWD"`
+	Hostname            string    `json:"hostname"`
+	ServerTime          time.Time `json:"serverTime"`
 	ReloadConfigSuccess bool      `json:"reloadConfigSuccess"`
 	LastConfigTime      time.Time `json:"lastConfigTime"`
 	CorruptionCount     int64     `json:"corruptionCount"`

--- a/web/ui/mantine-ui/src/pages/StatusPage.tsx
+++ b/web/ui/mantine-ui/src/pages/StatusPage.tsx
@@ -29,6 +29,12 @@ export default function StatusPage() {
         formatTimestamp(new Date(v as string).valueOf() / 1000, useLocalTime),
     },
     CWD: { title: "Working directory" },
+    hostname: { title: "Hostname" },
+    serverTime: {
+      title: "Server Time",
+      formatValue: (v: string | boolean) =>
+        formatTimestamp(new Date(v as string).valueOf() / 1000, useLocalTime),
+    },
     reloadConfigSuccess: {
       title: "Configuration reload",
       formatValue: (v: string | boolean) => (v ? "Successful" : "Unsuccessful"),

--- a/web/web.go
+++ b/web/web.go
@@ -804,6 +804,13 @@ func (h *Handler) runtimeInfo() (api_v1.RuntimeInfo, error) {
 		GODEBUG:        os.Getenv("GODEBUG"),
 	}
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		return status, fmt.Errorf("Error getting hostname: %w", err)
+	}
+	status.Hostname = hostname
+	status.ServerTime = time.Now().UTC()
+
 	if h.options.TSDBRetentionDuration != 0 {
 		status.StorageRetention = h.options.TSDBRetentionDuration.String()
 	}


### PR DESCRIPTION
This commit introduced two field in `/status` endpoint:
- The node currently serving the request.
- The current server time for debugging time drift issues.

![image](https://github.com/user-attachments/assets/d56a15b5-224b-4b56-8272-39c72cbe7752)


Fixes #15394

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
