### PR TITLE
Add additional tests for operators over incompatible nhcb

### DIFF
--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1135,9 +1135,13 @@ eval range from 0 to 12m step 6m count(metric)
 eval range from 0 to 12m step 6m group(metric)
   {} 1 1 1
 
-eval range from 0 to 12m step 6m limitk(1, metric)
+eval range from 0 to 12m step 6m count(limitk(1, metric))
+  {} 1 1 1
+
+eval range from 0 to 12m step 6m limitk(3, metric)
   metric{series="1"} _                                                             {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
-  metric{series="2"} {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}}    _                                                             _
+  metric{series="2"} {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}}    _                                                             {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}}
+  metric{series="3"} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
 
 eval range from 0 to 12m step 6m limit_ratio(1, metric)
   metric{series="1"} _                                                             {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1128,6 +1128,35 @@ eval_warn range from 0 to 12m step 6m sum(metric)
 eval_warn range from 0 to 12m step 6m avg(metric)
   {} _ {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} _
 
+# Test incompatible schemas with additional aggregation operators
+eval range from 0 to 12m step 6m count(metric)
+  {} 2 2 3
+
+eval range from 0 to 12m step 6m group(metric)
+  {} 1 1 1
+
+eval range from 0 to 12m step 6m limitk(1, metric)
+  metric{series="1"} _                                                             {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+  metric{series="2"} {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}}    _                                                             _
+
+eval range from 0 to 12m step 6m limit_ratio(1, metric)
+  metric{series="1"} _                                                             {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+  metric{series="2"} {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}}    _                                                             {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}}
+  metric{series="3"} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+
+# Test incompatible schemas with and/or
+eval range from 0 to 12m step 6m metric{series="1"} and ignoring(series) metric{series="2"}
+  metric{series="1"} _ _ {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+
+eval range from 0 to 12m step 6m metric{series="1"} or ignoring(series) metric{series="2"}
+  metric{series="1"} _                                                          {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+  metric{series="2"} {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}} _                                                             _
+
+# Test incompatible schemas with arithmetic binary operators
+eval_warn range from 0 to 12m step 6m metric{series="2"} + ignoring (series) metric{series="3"}
+
+eval_warn range from 0 to 12m step 6m metric{series="2"} - ignoring (series) metric{series="3"}
+
 clear
 
 load 1m


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Part of https://github.com/prometheus/prometheus/issues/13494

Adding some additional tests for operators over nhcb with incompatible schema. 

Specifically this PR checks:
- logical/set binary operators work as normal - sample values don't matter
- `+` and `-` arithmetic operators return no samples and a warning
- `count`, `group`, `limitk`, `limit_ratio` aggregation operators work as normal - sample values don't matter
