### PR TITLE
Rule Concurrency: Simpler loop for sequential (default) executions

### DIFF
--- a/rules/group.go
+++ b/rules/group.go
@@ -659,11 +659,12 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 		}
 	} else {
 		// Concurrent evaluation.
-		for _, batch := range ctrl.SplitGroupIntoBatches(ctx, g) {
+		for _, batch := range batches {
 			for _, ruleIndex := range batch {
 				// Check if the group has been stopped.
 				select {
 				case <-g.done:
+					wg.Wait()
 					return
 				default:
 				}

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -550,11 +550,7 @@ func (c sequentialRuleEvalController) Allow(_ context.Context, _ *Group, _ Rule)
 }
 
 func (c sequentialRuleEvalController) SplitGroupIntoBatches(_ context.Context, g *Group) []ConcurrentRules {
-	order := make([]ConcurrentRules, len(g.rules))
-	for i := range g.rules {
-		order[i] = []int{i}
-	}
-	return order
+	return nil
 }
 
 func (c sequentialRuleEvalController) Done(_ context.Context) {}

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -1989,12 +1989,7 @@ func TestAsyncRuleEvaluation(t *testing.T) {
 
 			// Expected evaluation order
 			order := group.opts.RuleConcurrencyController.SplitGroupIntoBatches(ctx, group)
-			require.Equal(t, []ConcurrentRules{
-				{0},
-				{1},
-				{2},
-				{3},
-			}, order)
+			require.Nil(t, order)
 
 			// Never expect more than 1 inflight query at a time.
 			require.EqualValues(t, 1, maxInflight.Load())


### PR DESCRIPTION
Follow-up to #15681, Supersedes #15796

Whenever a nil batching or one that is sequential (batches == rules), revert to fully sequential execution, without any goroutines

This ensures that the new concurrent loop will only run when it's explicitely enabled (RuleConcurrencyController is defined)
