### PR TITLE
ruler: stop all rule groups asynchronously on shutdown

### DIFF
--- a/rules/group.go
+++ b/rules/group.go
@@ -298,6 +298,14 @@ func (g *Group) run(ctx context.Context) {
 	}
 }
 
+func (g *Group) stopAsync() {
+	close(g.done)
+}
+
+func (g *Group) awaitStopped() {
+	<-g.terminated
+}
+
 func (g *Group) stop() {
 	close(g.done)
 	<-g.terminated

--- a/rules/group.go
+++ b/rules/group.go
@@ -302,13 +302,13 @@ func (g *Group) stopAsync() {
 	close(g.done)
 }
 
-func (g *Group) awaitStopped() {
+func (g *Group) waitStopped() {
 	<-g.terminated
 }
 
 func (g *Group) stop() {
-	close(g.done)
-	<-g.terminated
+	g.stopAsync()
+	g.waitStopped()
 }
 
 func (g *Group) hash() uint64 {

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -178,7 +178,11 @@ func (m *Manager) Stop() {
 	level.Info(m.logger).Log("msg", "Stopping rule manager...")
 
 	for _, eg := range m.groups {
-		eg.stop()
+		eg.stopAsync()
+	}
+
+	for _, eg := range m.groups {
+		eg.awaitStopped()
 	}
 
 	// Shut down the groups waiting multiple evaluation intervals to write

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -177,6 +177,8 @@ func (m *Manager) Stop() {
 
 	level.Info(m.logger).Log("msg", "Stopping rule manager...")
 
+	// Stop all groups asynchronously, then wait for them to finish.
+	// This is faster than stopping and waiting for each group in sequence.
 	for _, eg := range m.groups {
 		eg.stopAsync()
 	}

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -182,7 +182,7 @@ func (m *Manager) Stop() {
 	}
 
 	for _, eg := range m.groups {
-		eg.awaitStopped()
+		eg.waitStopped()
 	}
 
 	// Shut down the groups waiting multiple evaluation intervals to write


### PR DESCRIPTION
During shutdown of the rules manager some rule groups have already stopped and are missing evaluations while we're waiting for other groups to finish their evaluation.

When there are many groups (in the thousands), the whole shutdown process can take up to 10 minutes, during which we get miss evaluations.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
