### PR TITLE
parser: fix parsing utf8 label in grouping

### DIFF
--- a/promql/parser/generated_parser.y
+++ b/promql/parser/generated_parser.y
@@ -368,7 +368,7 @@ grouping_label  : maybe_label
                         $$ = $1
                         }
                 | STRING {
-                         if !model.LabelName(yylex.(*parser).unquoteString($1.Val)).IsValid() && $1.Val[0] != '"' {
+                        if !model.LabelName(yylex.(*parser).unquoteString($1.Val)).IsValid() && $1.Val[0] != '"' {
                                 yylex.(*parser).unexpected("grouping opts", "label")
                         }
                         $$ = $1

--- a/promql/parser/generated_parser.y
+++ b/promql/parser/generated_parser.y
@@ -368,12 +368,15 @@ grouping_label  : maybe_label
                         $$ = $1
                         }
                 | STRING {
-                        if !model.LabelName(yylex.(*parser).unquoteString($1.Val)).IsValid() {
+                         if !model.LabelName(yylex.(*parser).unquoteString($1.Val)).IsValid() && $1.Val[0] != '"' {
                                 yylex.(*parser).unexpected("grouping opts", "label")
                         }
                         $$ = $1
                         $$.Pos++
-                        $$.Val = yylex.(*parser).unquoteString($$.Val)
+                        if $1.Val[0] != '"' {
+                                $$.Val = yylex.(*parser).unquoteString($$.Val)
+                        }
+                        $$.Val = $$.Val
                         }
                 | error
                         { yylex.(*parser).unexpected("grouping opts", "label"); $$ = Item{} }

--- a/promql/parser/generated_parser.y.go
+++ b/promql/parser/generated_parser.y.go
@@ -1266,12 +1266,15 @@ yydefault:
 	case 59:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
-			if !model.LabelName(yylex.(*parser).unquoteString(yyDollar[1].item.Val)).IsValid() {
+			if !model.LabelName(yylex.(*parser).unquoteString(yyDollar[1].item.Val)).IsValid() && yyDollar[1].item.Val[0] != '"' {
 				yylex.(*parser).unexpected("grouping opts", "label")
 			}
 			yyVAL.item = yyDollar[1].item
 			yyVAL.item.Pos++
-			yyVAL.item.Val = yylex.(*parser).unquoteString(yyVAL.item.Val)
+			if yyDollar[1].item.Val[0] != '"' {
+				yyVAL.item.Val = yylex.(*parser).unquoteString(yyVAL.item.Val)
+			}
+			yyVAL.item.Val = yyVAL.item.Val
 		}
 	case 60:
 		yyDollar = yyS[yypt-1 : yypt+1]

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -2410,10 +2410,31 @@ var testExpr = []struct {
 					End:   34,
 				},
 			},
-			Grouping: []string{"foo bar"},
+			Grouping: []string{`"foo bar"`},
 			PosRange: posrange.PositionRange{
 				Start: 0,
 				End:   35,
+			},
+		},
+	},
+	{
+		input: `sum by("utf8.job") (http_requests_total)`,
+		expected: &AggregateExpr{
+			Op: SUM,
+			Expr: &VectorSelector{
+				Name: "http_requests_total",
+				LabelMatchers: []*labels.Matcher{
+					MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "http_requests_total"),
+				},
+				PosRange: posrange.PositionRange{
+					Start: 20,
+					End:   39,
+				},
+			},
+			Grouping: []string{`"utf8.job"`},
+			PosRange: posrange.PositionRange{
+				Start: 0,
+				End:   40,
 			},
 		},
 	},
@@ -2435,7 +2456,7 @@ var testExpr = []struct {
 					End:   42,
 				},
 			},
-			Grouping: []string{"foo", "bar", "baz"},
+			Grouping: []string{`"foo"`, "bar", "baz"},
 			PosRange: posrange.PositionRange{
 				Start: 0,
 				End:   43,


### PR DESCRIPTION
When we use utf8 label in grouping the parser was returning error and wrong label. 
Example query: 

```
sum by ("utf8.job") (http_requests_total)
```

For the query above as a grouping label we should get `"utf8.label"` not `utf8l.abel`.
Also when we try to parse the query parser returns error. Run the code below to reproduce it

```
package main

import (
	"fmt"

	"github.com/prometheus/prometheus/promql/parser"
)

func main() {
	promql := `sum by ("utf8.job") (http_requests_total)`
	_, err := parser.ParseExpr(promql)
	if err != nil {
		fmt.Println(err)
		return
	}

	fmt.Println("parsed successfully")
}

// The output is 
// 1:9: parse error: unexpected string "\"utf8.job\"" in grouping opts, expected label
```

The problem was inside the `.y` file where it handles the grouping, if it sees `"` it returns error. 
In this PR, I am checking the quote explicitly and returning the label accordingly.
