### PR TITLE
Remove instances of `prometheus.DefaultRegisterer`

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -146,12 +146,13 @@ var (
 	agentOnlyFlags, serverOnlyFlags []string
 )
 
+var registry = prometheus.NewRegistry()
+
 func init() {
 	// This can be removed when the legacy global mode is fully deprecated.
 	//nolint:staticcheck
 	model.NameValidationScheme = model.UTF8Validation
-
-	prometheus.MustRegister(versioncollector.NewCollector(strings.ReplaceAll(appName, "-", "_")))
+	registry.MustRegister(versioncollector.NewCollector(strings.ReplaceAll(appName, "-", "_")))
 
 	var err error
 	defaultRetentionDuration, err = model.ParseDuration(defaultRetentionString)
@@ -367,26 +368,24 @@ func main() {
 		runtime.SetMutexProfileFraction(20)
 	}
 
-	// Unregister the default GoCollector, and reregister with our defaults.
-	if prometheus.Unregister(collectors.NewGoCollector()) {
-		prometheus.MustRegister(
-			collectors.NewGoCollector(
-				collectors.WithGoCollectorRuntimeMetrics(
-					collectors.MetricsGC,
-					collectors.MetricsScheduler,
-					collectors.GoRuntimeMetricsRule{Matcher: goregexp.MustCompile(`^/sync/mutex/wait/total:seconds$`)},
-				),
+	// Register with NewGoCollector and NewProcessCollector.
+	registry.MustRegister(
+		collectors.NewGoCollector(
+			collectors.WithGoCollectorRuntimeMetrics(
+				collectors.MetricsGC,
+				collectors.MetricsScheduler,
+				collectors.GoRuntimeMetricsRule{Matcher: goregexp.MustCompile(`^/sync/mutex/wait/total:seconds$`)},
 			),
-		)
-	}
+		),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 
 	cfg := flagConfig{
 		notifier: notifier.Options{
-			Registerer: prometheus.DefaultRegisterer,
+			Registerer: registry,
 		},
 		web: web.Options{
-			Registerer:      prometheus.DefaultRegisterer,
-			Gatherer:        prometheus.DefaultGatherer,
+			Registerer:      registry,
+			Gatherer:        registry,
 			FeatureRegistry: features.DefaultRegistry,
 		},
 		promslogConfig: promslog.Config{},
@@ -657,7 +656,7 @@ func main() {
 	logger := promslog.New(&cfg.promslogConfig)
 	slog.SetDefault(logger)
 
-	notifs := notifications.NewNotifications(cfg.maxNotificationsSubscribers, prometheus.DefaultRegisterer)
+	notifs := notifications.NewNotifications(cfg.maxNotificationsSubscribers, registry)
 	cfg.web.NotificationsSub = notifs.Sub
 	cfg.web.NotificationsGetter = notifs.Get
 	notifs.AddNotification(notifications.StartingUp)
@@ -909,7 +908,7 @@ func main() {
 	var (
 		localStorage  = &readyStorage{stats: tsdb.NewDBStats()}
 		scraper       = &readyScrapeManager{}
-		remoteStorage = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, cfg.scrape.EnableTypeAndUnitLabels)
+		remoteStorage = remote.NewStorage(logger.With("component", "remote"), registry, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, cfg.scrape.EnableTypeAndUnitLabels)
 		fanoutStorage = storage.NewFanout(logger, localStorage, remoteStorage)
 	)
 
@@ -930,25 +929,25 @@ func main() {
 	// can only register metrics specific to a SD instance.
 	// Kubernetes client metrics are the same for the whole process -
 	// they are not specific to an SD instance.
-	err = discovery.RegisterK8sClientMetricsWithPrometheus(prometheus.DefaultRegisterer)
+	err = discovery.RegisterK8sClientMetricsWithPrometheus(registry)
 	if err != nil {
 		logger.Error("failed to register Kubernetes client metrics", "err", err)
 		os.Exit(1)
 	}
 
-	sdMetrics, err := discovery.CreateAndRegisterSDMetrics(prometheus.DefaultRegisterer)
+	sdMetrics, err := discovery.CreateAndRegisterSDMetrics(registry)
 	if err != nil {
 		logger.Error("failed to register service discovery metrics", "err", err)
 		os.Exit(1)
 	}
 
-	discoveryManagerScrape = discovery.NewManager(ctxScrape, logger.With("component", "discovery manager scrape"), prometheus.DefaultRegisterer, sdMetrics, discovery.Name("scrape"), discovery.FeatureRegistry(features.DefaultRegistry))
+	discoveryManagerScrape = discovery.NewManager(ctxScrape, logger.With("component", "discovery manager scrape"), registry, sdMetrics, discovery.Name("scrape"), discovery.FeatureRegistry(features.DefaultRegistry))
 	if discoveryManagerScrape == nil {
 		logger.Error("failed to create a discovery manager scrape")
 		os.Exit(1)
 	}
 
-	discoveryManagerNotify = discovery.NewManager(ctxNotify, logger.With("component", "discovery manager notify"), prometheus.DefaultRegisterer, sdMetrics, discovery.Name("notify"), discovery.FeatureRegistry(features.DefaultRegistry))
+	discoveryManagerNotify = discovery.NewManager(ctxNotify, logger.With("component", "discovery manager notify"), registry, sdMetrics, discovery.Name("notify"), discovery.FeatureRegistry(features.DefaultRegistry))
 	if discoveryManagerNotify == nil {
 		logger.Error("failed to create a discovery manager notify")
 		os.Exit(1)
@@ -959,7 +958,7 @@ func main() {
 		logger.With("component", "scrape manager"),
 		logging.NewJSONFileLogger,
 		nil, fanoutStorage,
-		prometheus.DefaultRegisterer,
+		registry,
 	)
 	if err != nil {
 		logger.Error("failed to create a scrape manager", "err", err)
@@ -976,7 +975,7 @@ func main() {
 	if !agentMode {
 		opts := promql.EngineOpts{
 			Logger:                   logger.With("component", "query engine"),
-			Reg:                      prometheus.DefaultRegisterer,
+			Reg:                      registry,
 			MaxSamples:               cfg.queryMaxSamples,
 			Timeout:                  time.Duration(cfg.queryTimeout),
 			ActiveQueryTracker:       promql.NewActiveQueryTracker(localStoragePath, cfg.queryConcurrency, logger.With("component", "activeQueryTracker")),
@@ -1004,7 +1003,7 @@ func main() {
 			NotifyFunc:             rules.SendAlerts(notifierManager, cfg.web.ExternalURL.String()),
 			Context:                ctxRule,
 			ExternalURL:            cfg.web.ExternalURL,
-			Registerer:             prometheus.DefaultRegisterer,
+			Registerer:             registry,
 			Logger:                 logger.With("component", "rule manager"),
 			OutageTolerance:        time.Duration(cfg.outageTolerance),
 			ForGracePeriod:         time.Duration(cfg.forGracePeriod),
@@ -1183,8 +1182,8 @@ func main() {
 		},
 	}
 
-	prometheus.MustRegister(configSuccess)
-	prometheus.MustRegister(configSuccessTime)
+	registry.MustRegister(configSuccess)
+	registry.MustRegister(configSuccessTime)
 
 	// Start all components while we wait for TSDB to open but only load
 	// initial config and mark ourselves as ready after it completed.
@@ -1460,7 +1459,7 @@ func main() {
 					}
 				}
 
-				db, err := openDBWithMetrics(localStoragePath, logger, prometheus.DefaultRegisterer, &opts, localStorage.getStats())
+				db, err := openDBWithMetrics(localStoragePath, logger, registry, &opts, localStorage.getStats())
 				if err != nil {
 					return fmt.Errorf("opening storage failed: %w", err)
 				}
@@ -1518,7 +1517,7 @@ func main() {
 				}
 				db, err := agent.Open(
 					logger,
-					prometheus.DefaultRegisterer,
+					registry,
 					remoteStorage,
 					localStoragePath,
 					&opts,

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -372,7 +372,7 @@ func main() {
 
 	switch parsedCmd {
 	case sdCheckCmd.FullCommand():
-		os.Exit(CheckSD(*sdConfigFile, *sdJobName, *sdTimeout, prometheus.DefaultRegisterer))
+		os.Exit(CheckSD(*sdConfigFile, *sdJobName, *sdTimeout, prometheus.NewRegistry()))
 
 	case checkConfigCmd.FullCommand():
 		os.Exit(CheckConfig(*agentMode, *checkConfigSyntaxOnly, newConfigLintConfig(*checkConfigLint, *checkConfigLintFatal, *checkConfigIgnoreUnknownFields, model.UTF8Validation, model.Duration(*checkLookbackDelta)), promtoolParser, *configFiles...))

--- a/discovery/zookeeper/metrics.go
+++ b/discovery/zookeeper/metrics.go
@@ -73,11 +73,11 @@ func newDiscovererMetrics(reg prometheus.Registerer, _ discovery.RefreshMetricsI
 
 // Register implements discovery.DiscovererMetrics.
 // Metrics are registered in newDiscovererMetrics, so this is a no-op.
-func (m *zookeeperMetrics) Register() error {
+func (*zookeeperMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
 // The metrics are shared between ServerSet and Nerve SD, so they are not unregistered here.
-func (m *zookeeperMetrics) Unregister() {
+func (*zookeeperMetrics) Unregister() {
 }

--- a/discovery/zookeeper/metrics.go
+++ b/discovery/zookeeper/metrics.go
@@ -1,0 +1,83 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zookeeper
+
+import (
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus/prometheus/discovery"
+)
+
+type zookeeperMetrics struct {
+	// The total number of ZooKeeper failures.
+	failureCounter prometheus.Counter
+	// The current number of Zookeeper watcher goroutines.
+	numWatchers prometheus.Gauge
+}
+
+// Create and register metrics.
+func newDiscovererMetrics(reg prometheus.Registerer, _ discovery.RefreshMetricsInstantiator) discovery.DiscovererMetrics {
+	m := &zookeeperMetrics{
+		failureCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "prometheus",
+			Subsystem: "treecache",
+			Name:      "zookeeper_failures_total",
+			Help:      "The total number of ZooKeeper failures.",
+		}),
+		numWatchers: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "prometheus",
+			Subsystem: "treecache",
+			Name:      "watcher_goroutines",
+			Help:      "The current number of watcher goroutines.",
+		}),
+	}
+	// For historical reasons, both ServerSet and Nerve SD share the same zookeeper metrics.
+	// To not cause double registration problems, if both SD mechanisms are instantiated with
+	// the same registry, we are handling the AlreadyRegisteredError accordingly below.
+	// Because the metrics are shared, we also do not unregister them on config reloads.
+	// TODO: Consider separate zookeeper metrics for both SD mechanisms in the future.
+	if err := reg.Register(m.failureCounter); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if !errors.As(err, &are) {
+			panic(err)
+		}
+		m.failureCounter = are.ExistingCollector.(prometheus.Counter)
+	}
+
+	if err := reg.Register(m.numWatchers); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if !errors.As(err, &are) {
+			panic(err)
+		}
+		m.numWatchers = are.ExistingCollector.(prometheus.Gauge)
+	}
+
+	return &zookeeperMetrics{
+		failureCounter: m.failureCounter,
+		numWatchers:    m.numWatchers,
+	}
+}
+
+// Register implements discovery.DiscovererMetrics.
+// Metrics are registered in newDiscovererMetrics, so this is a no-op.
+func (m *zookeeperMetrics) Register() error {
+	return nil
+}
+
+// Unregister implements discovery.DiscovererMetrics.
+// The metrics are shared between ServerSet and Nerve SD, so they are not unregistered here.
+func (m *zookeeperMetrics) Unregister() {
+}

--- a/discovery/zookeeper/zookeeper_test.go
+++ b/discovery/zookeeper/zookeeper_test.go
@@ -33,6 +33,6 @@ func TestNewDiscoveryError(t *testing.T) {
 		[]string{"unreachable.invalid"},
 		time.Second, []string{"/"},
 		nil,
-		func([]byte, string) (model.LabelSet, error) { return nil, nil })
+		func(_ []byte, _ string) (model.LabelSet, error) { return nil, nil }, nil)
 	require.Error(t, err)
 }

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -124,7 +124,7 @@ type readClientMetrics struct {
 func newRemoteReadMetrics(
 	name string,
 	url string,
-	_ prometheus.Registerer, // ignored: remote-read carve-out uses the global registry
+	reg prometheus.Registerer,
 ) (
 	prometheus.Gauge,
 	*prometheus.CounterVec,
@@ -138,12 +138,6 @@ func newRemoteReadMetrics(
 			return old.readQueries, old.readQueriesTotalVec, old.readQueryDurationVec
 		}
 	}
-
-	// Carve-out: keep using the global registerer for remote-read.
-	wrappedReg := prometheus.WrapRegistererWith(prometheus.Labels{
-		"remote_name": name,
-		"endpoint":    url,
-	}, prometheus.DefaultRegisterer)
 
 	readQueries := prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
@@ -170,7 +164,18 @@ func newRemoteReadMetrics(
 		NativeHistogramMinResetDuration: time.Hour,
 	}, []string{"response_type"})
 
-	// Register OR reuse if already present (avoid panics and counter resets).
+	if reg == nil {
+		return readQueries, readQueriesTotalVec, readQueryDurationVec
+	}
+
+	// Each remote-read client gets its own metrics, distinguished by the
+	// remote_name and endpoint labels and registered with the provided registry.
+	wrappedReg := prometheus.WrapRegistererWith(prometheus.Labels{
+		"remote_name": name,
+		"endpoint":    url,
+	}, reg)
+
+	// Register OR reuse if already present (avoid panics and counter resets on reload).
 	var are prometheus.AlreadyRegisteredError
 	if err := wrappedReg.Register(readQueries); err != nil {
 		if !errors.As(err, &are) {
@@ -231,7 +236,7 @@ func NewReadClient(name string, conf *ClientConfig, reg prometheus.Registerer, o
 		acceptedResponseTypes = AcceptedResponseTypes
 	}
 
-	// Always create metrics; helper uses the default registry for the carve-out.
+	// Create (or reuse) the per-client read metrics, registered with the provided registry.
 	var (
 		readQueries         prometheus.Gauge
 		readQueriesTotal    *prometheus.CounterVec

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptrace"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -63,47 +64,13 @@ var (
 		remoteapi.WriteV2MessageType: appProtoContentType + ";proto=io.prometheus.write.v2.Request",
 	}
 
+	remoteReadMetricCache sync.Map // key: remoteName+url, value: *readClientMetrics
+
 	AcceptedResponseTypes = []prompb.ReadRequest_ResponseType{
 		prompb.ReadRequest_STREAMED_XOR_CHUNKS,
 		prompb.ReadRequest_SAMPLES,
 	}
-
-	remoteReadQueriesTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: "remote_read_client",
-			Name:      "queries_total",
-			Help:      "The total number of remote read queries.",
-		},
-		[]string{remoteName, endpoint, "response_type", "code"},
-	)
-	remoteReadQueries = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: "remote_read_client",
-			Name:      "queries",
-			Help:      "The number of in-flight remote read queries.",
-		},
-		[]string{remoteName, endpoint},
-	)
-	remoteReadQueryDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace:                       namespace,
-			Subsystem:                       "remote_read_client",
-			Name:                            "request_duration_seconds",
-			Help:                            "Histogram of the latency for remote read requests. Note that for streamed responses this is only the duration of the initial call and does not include the processing of the stream.",
-			Buckets:                         append(prometheus.DefBuckets, 25, 60),
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: 1 * time.Hour,
-		},
-		[]string{remoteName, endpoint, "response_type"},
-	)
 )
-
-func init() {
-	prometheus.MustRegister(remoteReadQueriesTotal, remoteReadQueries, remoteReadQueryDuration)
-}
 
 // Client allows reading and writing from/to a remote HTTP endpoint.
 type Client struct {
@@ -147,8 +114,106 @@ type ReadClient interface {
 	ReadMultiple(ctx context.Context, queries []*prompb.Query, sortSeries bool) (storage.SeriesSet, error)
 }
 
+type readClientMetrics struct {
+	readQueries          prometheus.Gauge
+	readQueriesTotalVec  *prometheus.CounterVec
+	readQueryDurationVec prometheus.ObserverVec
+	reg                  prometheus.Registerer
+}
+
+func newRemoteReadMetrics(
+	name string,
+	url string,
+	_ prometheus.Registerer, // ignored: remote-read carve-out uses the global registry
+) (
+	prometheus.Gauge,
+	*prometheus.CounterVec,
+	prometheus.ObserverVec,
+) {
+	key := name + "|" + url
+
+	// Reuse existing collectors (no unregister, no reset) if we've already created them.
+	if oldVal, ok := remoteReadMetricCache.Load(key); ok {
+		if old, ok := oldVal.(*readClientMetrics); ok {
+			return old.readQueries, old.readQueriesTotalVec, old.readQueryDurationVec
+		}
+	}
+
+	// Carve-out: keep using the global registerer for remote-read.
+	wrappedReg := prometheus.WrapRegistererWith(prometheus.Labels{
+		"remote_name": name,
+		"endpoint":    url,
+	}, prometheus.DefaultRegisterer)
+
+	readQueries := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "remote_read_client",
+		Name:      "queries",
+		Help:      "The number of in-flight remote read queries.",
+	})
+
+	readQueriesTotalVec := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "remote_read_client",
+		Name:      "queries_total",
+		Help:      "The total number of remote read queries.",
+	}, []string{"response_type", "code"})
+
+	readQueryDurationVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:                       namespace,
+		Subsystem:                       "remote_read_client",
+		Name:                            "request_duration_seconds",
+		Help:                            "Histogram of the latency for remote read requests. For streamed responses, this is only the duration of the initial call.",
+		Buckets:                         append(prometheus.DefBuckets, 25, 60),
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: time.Hour,
+	}, []string{"response_type"})
+
+	// Register OR reuse if already present (avoid panics and counter resets).
+	var are prometheus.AlreadyRegisteredError
+	if err := wrappedReg.Register(readQueries); err != nil {
+		if !errors.As(err, &are) {
+			panic(err)
+		}
+		readQueries = are.ExistingCollector.(prometheus.Gauge)
+	}
+	if err := wrappedReg.Register(readQueriesTotalVec); err != nil {
+		if !errors.As(err, &are) {
+			panic(err)
+		}
+		readQueriesTotalVec = are.ExistingCollector.(*prometheus.CounterVec)
+	}
+	if err := wrappedReg.Register(readQueryDurationVec); err != nil {
+		if !errors.As(err, &are) {
+			panic(err)
+		}
+		readQueryDurationVec = are.ExistingCollector.(*prometheus.HistogramVec)
+	}
+
+	remoteReadMetricCache.Store(key, &readClientMetrics{
+		readQueries:          readQueries,
+		readQueriesTotalVec:  readQueriesTotalVec,
+		readQueryDurationVec: readQueryDurationVec,
+		reg:                  wrappedReg, // keep for explicit cleanup when a remote is removed
+	})
+
+	return readQueries, readQueriesTotalVec, readQueryDurationVec
+}
+
+// Unregister metrics for a removed remote_read config.
+func unregisterRemoteReadMetrics(key string) {
+	if val, ok := remoteReadMetricCache.LoadAndDelete(key); ok {
+		if m, ok := val.(*readClientMetrics); ok && m.reg != nil {
+			m.reg.Unregister(m.readQueries)
+			m.reg.Unregister(m.readQueriesTotalVec)
+			m.reg.Unregister(m.readQueryDurationVec)
+		}
+	}
+}
+
 // NewReadClient creates a new client for remote read.
-func NewReadClient(name string, conf *ClientConfig, optFuncs ...config_util.HTTPClientOption) (ReadClient, error) {
+func NewReadClient(name string, conf *ClientConfig, reg prometheus.Registerer, optFuncs ...config_util.HTTPClientOption) (ReadClient, error) {
 	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client", optFuncs...)
 	if err != nil {
 		return nil, err
@@ -166,6 +231,14 @@ func NewReadClient(name string, conf *ClientConfig, optFuncs ...config_util.HTTP
 		acceptedResponseTypes = AcceptedResponseTypes
 	}
 
+	// Always create metrics; helper uses the default registry for the carve-out.
+	var (
+		readQueries         prometheus.Gauge
+		readQueriesTotal    *prometheus.CounterVec
+		readQueriesDuration prometheus.ObserverVec
+	)
+	readQueries, readQueriesTotal, readQueriesDuration = newRemoteReadMetrics(name, conf.URL.Redacted(), reg)
+
 	return &Client{
 		remoteName:            name,
 		urlString:             conf.URL.String(),
@@ -173,9 +246,9 @@ func NewReadClient(name string, conf *ClientConfig, optFuncs ...config_util.HTTP
 		timeout:               time.Duration(conf.Timeout),
 		chunkedReadLimit:      conf.ChunkedReadLimit,
 		acceptedResponseTypes: acceptedResponseTypes,
-		readQueries:           remoteReadQueries.WithLabelValues(name, conf.URL.String()),
-		readQueriesTotal:      remoteReadQueriesTotal.MustCurryWith(prometheus.Labels{remoteName: name, endpoint: conf.URL.String()}),
-		readQueriesDuration:   remoteReadQueryDuration.MustCurryWith(prometheus.Labels{remoteName: name, endpoint: conf.URL.String()}),
+		readQueries:           readQueries,
+		readQueriesTotal:      readQueriesTotal,
+		readQueriesDuration:   readQueriesDuration,
 	}, nil
 }
 

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -368,7 +369,12 @@ func TestReadClient(t *testing.T) {
 				Timeout:          model.Duration(test.timeout),
 				ChunkedReadLimit: config.DefaultChunkedReadLimit,
 			}
-			c, err := NewReadClient("test", conf)
+			reg := prometheus.NewRegistry()
+			old := prometheus.DefaultRegisterer
+			prometheus.DefaultRegisterer = reg
+			t.Cleanup(func() { prometheus.DefaultRegisterer = old })
+			t.Cleanup(func() { unregisterRemoteReadMetrics("test|" + conf.URL.Redacted()) })
+			c, err := NewReadClient("test", conf, reg)
 			require.NoError(t, err)
 
 			query := &prompb.Query{}
@@ -922,7 +928,7 @@ func TestReadMultipleWithChunks(t *testing.T) {
 				ChunkedReadLimit: config.DefaultChunkedReadLimit,
 			}
 
-			client, err := NewReadClient("test", cfg)
+			client, err := NewReadClient("test", cfg, prometheus.NewRegistry())
 			require.NoError(t, err)
 
 			// Test ReadMultiple

--- a/storage/remote/intern.go
+++ b/storage/remote/intern.go
@@ -19,14 +19,14 @@
 package remote
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/atomic"
 )
 
-var noReferenceReleases = promauto.NewCounter(prometheus.CounterOpts{
+var noReferenceReleases = prometheus.NewCounter(prometheus.CounterOpts{
 	Namespace: namespace,
 	Subsystem: subsystem,
 	Name:      "string_interner_zero_reference_releases_total",
@@ -48,7 +48,19 @@ func newEntry(s string) *entry {
 	return &entry{s: s}
 }
 
-func newPool() *pool {
+func newPool(reg prometheus.Registerer) *pool {
+	if reg != nil {
+		if err := reg.Register(noReferenceReleases); err != nil {
+			var are prometheus.AlreadyRegisteredError
+			// Preserve current behavior for unexpected errors.
+			if !errors.As(err, &are) {
+				panic(err)
+			}
+			// Reuse the existing collector so increments go to the same series.
+			noReferenceReleases = are.ExistingCollector.(prometheus.Counter)
+		}
+	}
+
 	return &pool{
 		pool: map[string]*entry{},
 	}

--- a/storage/remote/intern_test.go
+++ b/storage/remote/intern_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestIntern(t *testing.T) {
-	interner := newPool()
+	interner := newPool(nil)
 	testString := "TestIntern"
 	interner.intern(testString)
 	interned, ok := interner.pool[testString]
@@ -35,7 +35,7 @@ func TestIntern(t *testing.T) {
 }
 
 func TestIntern_MultiRef(t *testing.T) {
-	interner := newPool()
+	interner := newPool(nil)
 	testString := "TestIntern_MultiRef"
 
 	interner.intern(testString)
@@ -52,7 +52,7 @@ func TestIntern_MultiRef(t *testing.T) {
 }
 
 func TestIntern_DeleteRef(t *testing.T) {
-	interner := newPool()
+	interner := newPool(nil)
 	testString := "TestIntern_DeleteRef"
 
 	interner.intern(testString)
@@ -67,7 +67,7 @@ func TestIntern_DeleteRef(t *testing.T) {
 }
 
 func TestIntern_MultiRef_Concurrent(t *testing.T) {
-	interner := newPool()
+	interner := newPool(nil)
 	testString := "TestIntern_MultiRef_Concurrent"
 
 	interner.intern(testString)

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -306,7 +306,7 @@ func newTestClientAndQueueManager(t testing.TB, flushDeadline time.Duration, pro
 func newTestQueueManager(t testing.TB, cfg config.QueueConfig, mcfg config.MetadataConfig, deadline time.Duration, c WriteClient, protoMsg remoteapi.WriteMessageType) *QueueManager {
 	dir := t.TempDir()
 	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, protoMsg, record.NewBuffersPool())
+	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(nil), newHighestTimestampMetric(), nil, false, false, false, protoMsg, record.NewBuffersPool())
 
 	return m
 }
@@ -792,7 +792,7 @@ func TestDisableReshardOnRetry(t *testing.T) {
 		}
 	)
 
-	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, nil)
+	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(nil), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, nil)
 	m.StoreSeries(recs.Series, 0)
 
 	// Attempt to samples while the manager is running. We immediately stop the
@@ -1393,7 +1393,7 @@ func BenchmarkStoreSeries(b *testing.B) {
 				mcfg := config.DefaultMetadataConfig
 				metrics := newQueueManagerMetrics(nil, "", "")
 
-				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, record.NewBuffersPool())
+				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(nil), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, record.NewBuffersPool())
 				m.externalLabels = tc.externalLabels
 				m.relabelConfigs = tc.relabelConfigs
 

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -61,22 +61,28 @@ type Storage struct {
 	// For reads.
 	queryables             []storage.SampleAndChunkQueryable
 	localStartTimeCallback startTimeCallback
+
+	readRemotes map[string]struct{}
 }
 
 var _ storage.Storage = &Storage{}
 
 // NewStorage returns a remote.Storage.
 func NewStorage(l *slog.Logger, reg prometheus.Registerer, stCallback startTimeCallback, walDir string, flushDeadline time.Duration, sm ReadyScrapeManager, enableTypeAndUnitLabels bool) *Storage {
+	if reg != nil {
+		reg.MustRegister(samplesIn, histogramsIn, exemplarsIn)
+	}
+
 	if l == nil {
 		l = promslog.NewNopLogger()
 	}
 	deduper := logging.Dedupe(l, 1*time.Minute)
 	logger := slog.New(deduper)
-
 	s := &Storage{
 		logger:                 logger,
 		deduper:                deduper,
 		localStartTimeCallback: stCallback,
+		readRemotes:            make(map[string]struct{}),
 	}
 	s.rws = NewWriteStorage(s.logger, reg, walDir, flushDeadline, sm, enableTypeAndUnitLabels)
 	return s
@@ -95,9 +101,13 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		return err
 	}
 
+	// Track active remote_read keys in the current config.
+	activeReadRemotes := make(map[string]struct{})
+
 	// Update read clients
 	readHashes := make(map[string]struct{})
 	queryables := make([]storage.SampleAndChunkQueryable, 0, len(conf.RemoteReadConfigs))
+
 	for _, rrConf := range conf.RemoteReadConfigs {
 		hash, err := toHash(rrConf)
 		if err != nil {
@@ -110,13 +120,16 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		}
 		readHashes[hash] = struct{}{}
 
-		// Set the queue name to the config hash if the user has not set
-		// a name in their remote write config so we can still differentiate
-		// between queues that have the same remote write endpoint.
+		// Generate the remote name.
 		name := hash[:6]
 		if rrConf.Name != "" {
 			name = rrConf.Name
 		}
+
+		// Generate the remote key and track it. Use the redacted URL so it
+		// matches the cache key used in newRemoteReadMetrics and never embeds credentials.
+		key := name + "|" + rrConf.URL.Redacted()
+		activeReadRemotes[key] = struct{}{}
 
 		c, err := NewReadClient(name, &ClientConfig{
 			URL:              rrConf.URL,
@@ -124,7 +137,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 			ChunkedReadLimit: rrConf.ChunkedReadLimit,
 			HTTPClientConfig: rrConf.HTTPClientConfig,
 			Headers:          rrConf.Headers,
-		})
+		}, s.rws.reg)
 		if err != nil {
 			return err
 		}
@@ -133,6 +146,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 		if !rrConf.FilterExternalLabels {
 			externalLabels = labels.EmptyLabels()
 		}
+
 		queryables = append(queryables, NewSampleAndChunkQueryableClient(
 			c,
 			externalLabels,
@@ -141,6 +155,16 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 			s.localStartTimeCallback,
 		))
 	}
+
+	// Unregister metrics for any remote_read configs that were removed
+	for oldKey := range s.readRemotes {
+		if _, stillExists := activeReadRemotes[oldKey]; !stillExists {
+			unregisterRemoteReadMetrics(oldKey)
+		}
+	}
+
+	// Save new state
+	s.readRemotes = activeReadRemotes
 	s.queryables = queryables
 
 	return nil

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/promslog"
 
 	"github.com/prometheus/prometheus/config"
@@ -36,19 +35,19 @@ import (
 )
 
 var (
-	samplesIn = promauto.NewCounter(prometheus.CounterOpts{
+	samplesIn = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: subsystem,
 		Name:      "samples_in_total",
 		Help:      "Samples in to remote storage, compare to samples out for queue managers. Deprecated, check prometheus_wal_watcher_records_read_total and prometheus_remote_storage_samples_dropped_total",
 	})
-	exemplarsIn = promauto.NewCounter(prometheus.CounterOpts{
+	exemplarsIn = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: subsystem,
 		Name:      "exemplars_in_total",
 		Help:      "Exemplars in to remote storage, compare to exemplars out for queue managers. Deprecated, check prometheus_wal_watcher_records_read_total and prometheus_remote_storage_exemplars_dropped_total",
 	})
-	histogramsIn = promauto.NewCounter(prometheus.CounterOpts{
+	histogramsIn = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: subsystem,
 		Name:      "histograms_in_total",
@@ -94,7 +93,7 @@ func NewWriteStorage(logger *slog.Logger, reg prometheus.Registerer, dir string,
 		flushDeadline:     flushDeadline,
 		samplesIn:         newEWMARate(ewmaWeight, shardUpdateDuration),
 		dir:               dir,
-		interner:          newPool(),
+		interner:          newPool(reg),
 		scraper:           sm,
 		quit:              make(chan struct{}),
 		highestTimestamp: &maxTimestamp{

--- a/template/template.go
+++ b/template/template.go
@@ -53,9 +53,10 @@ var (
 	errNaNOrInf = errors.New("value is NaN or Inf")
 )
 
-func init() {
-	prometheus.MustRegister(templateTextExpansionFailures)
-	prometheus.MustRegister(templateTextExpansionTotal)
+// RegisterTemplateMetrics registers the template metrics. Caller is responsible for calling this only once per registry.
+func RegisterTemplateMetrics(registry prometheus.Registerer) {
+	registry.MustRegister(templateTextExpansionFailures)
+	registry.MustRegister(templateTextExpansionTotal)
 }
 
 // A version of vector that's easier to use from templates.

--- a/util/treecache/treecache.go
+++ b/util/treecache/treecache.go
@@ -26,26 +26,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var (
-	failureCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "prometheus",
-		Subsystem: "treecache",
-		Name:      "zookeeper_failures_total",
-		Help:      "The total number of ZooKeeper failures.",
-	})
-	numWatchers = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "prometheus",
-		Subsystem: "treecache",
-		Name:      "watcher_goroutines",
-		Help:      "The current number of watcher goroutines.",
-	})
-)
-
-func init() {
-	prometheus.MustRegister(failureCounter)
-	prometheus.MustRegister(numWatchers)
-}
-
 // ZookeeperLogger wraps a *slog.Logger into a zk.Logger.
 type ZookeeperLogger struct {
 	logger *slog.Logger
@@ -72,6 +52,9 @@ type ZookeeperTreeCache struct {
 	head   *zookeeperTreeCacheNode
 
 	logger *slog.Logger
+
+	failureCounter prometheus.Counter
+	numWatchers    prometheus.Gauge
 }
 
 // A ZookeeperTreeCacheEvent models a Zookeeper event for a path.
@@ -89,21 +72,27 @@ type zookeeperTreeCacheNode struct {
 }
 
 // NewZookeeperTreeCache creates a new ZookeeperTreeCache for a given path.
-func NewZookeeperTreeCache(conn *zk.Conn, path string, events chan ZookeeperTreeCacheEvent, logger *slog.Logger) *ZookeeperTreeCache {
+func NewZookeeperTreeCache(
+	conn *zk.Conn, path string,
+	events chan ZookeeperTreeCacheEvent,
+	logger *slog.Logger,
+	failureCounter prometheus.Counter, numWatchers prometheus.Gauge,
+) *ZookeeperTreeCache {
 	tc := &ZookeeperTreeCache{
-		conn:   conn,
-		prefix: path,
-		events: events,
-		stop:   make(chan struct{}),
-		wg:     &sync.WaitGroup{},
-
-		logger: logger,
+		conn:           conn,
+		prefix:         path,
+		events:         events,
+		stop:           make(chan struct{}),
+		wg:             &sync.WaitGroup{},
+		logger:         logger,
+		failureCounter: failureCounter,
+		numWatchers:    numWatchers,
 	}
 	tc.head = &zookeeperTreeCacheNode{
 		events:   make(chan zk.Event),
 		children: map[string]*zookeeperTreeCacheNode{},
 		done:     make(chan struct{}, 1),
-		stopped:  true, // Set head's stop to be true so that recursiveDelete will not stop the head node.
+		stopped:  true, // head node starts stopped
 	}
 	tc.wg.Add(1)
 	go tc.loop(path)
@@ -134,7 +123,7 @@ func (tc *ZookeeperTreeCache) loop(path string) {
 	retryChan := make(chan struct{})
 
 	failure := func() {
-		failureCounter.Inc()
+		tc.failureCounter.Inc()
 		failureMode = true
 		time.AfterFunc(time.Second*10, func() {
 			retryChan <- struct{}{}
@@ -266,7 +255,7 @@ func (tc *ZookeeperTreeCache) recursiveNodeUpdate(path string, node *zookeeperTr
 	}
 
 	tc.wg.Go(func() {
-		numWatchers.Inc()
+		tc.numWatchers.Inc()
 		// Pass up zookeeper events, until the node is deleted.
 		select {
 		case event := <-dataWatcher:
@@ -275,7 +264,7 @@ func (tc *ZookeeperTreeCache) recursiveNodeUpdate(path string, node *zookeeperTr
 			node.events <- event
 		case <-node.done:
 		}
-		numWatchers.Dec()
+		tc.numWatchers.Dec()
 	})
 	return nil
 }

--- a/web/web.go
+++ b/web/web.go
@@ -333,6 +333,11 @@ func New(logger *slog.Logger, o *Options) *Handler {
 		o.Parser = parser.NewParser(parser.Options{})
 	}
 
+	// Register the template metrics
+	if o.Registerer != nil {
+		template.RegisterTemplateMetrics(o.Registerer)
+	}
+
 	m := newMetrics(o.Registerer)
 	router := route.New().
 		WithInstrumentation(m.instrumentHandler).
@@ -499,7 +504,7 @@ func New(logger *slog.Logger, o *Options) *Handler {
 	}
 
 	router.Get("/version", h.version)
-	router.Get("/metrics", promhttp.Handler().ServeHTTP)
+	router.Get("/metrics", promhttp.HandlerFor(o.Gatherer, promhttp.HandlerOpts{}).ServeHTTP)
 
 	router.Get("/federate", readyf(httputil.CompressionHandler{
 		Handler: http.HandlerFunc(h.federation),


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/15725

No `prometheus.DefaultRegisterer` left outside tests and the remote storage adapter example. `cmd/prometheus` creates a registry and passes it down; ZooKeeper SD, `util/treecache`, `template`, `web`, `promtool` and the remote storage interner take a `prometheus.Registerer`.

The remote read client was the hard part. A reload builds a new client for every `remote_read` entry (storage/remote/storage.go:114), so per-client metrics need a cache, an unregister path and a map of active remotes to survive it. @beorn7 said that was a lot of machinery for the result.

Metrics now belong to `remote.Storage`, which outlives a reload (storage/remote/client.go:120). `remote_name` and `url` stay labels, so a client takes the children for its own remote and registers nothing. Duplicate registration is then impossible and no reload path can reset a counter. `scrape` (scrape/manager.go:73) and `notifier` (notifier/manager.go:118) do the same. @ptodev proposed this in review: pass the already registered metrics in a struct to `NewReadClient`. The cache, the unregister helper, the `AlreadyRegisteredError` fallbacks and the active-remotes map are gone.

`prometheus_remote_read_client_queries_total` on a reader instance, against a second instance serving `/api/v1/read`:

| step | main | previous revision | this revision |
|---|---|---|---|
| 3 queries | 3 | 3 | 3 |
| `remote_read` entry removed | 3 | 0, series gone | 3 |
| entry added back, 1 query | 4 | 1 | 4 |

A removed entry leaves its series until a restart, as on main; deleting the children would reset counters when the remote returns. ZooKeeper SD still shares one metric set between ServerSet and Nerve, with a comment and a TODO to split them (discovery/zookeeper/metrics.go:45).

```release-notes
[CHANGE] Replace the global prometheus.DefaultRegisterer with a dedicated registry across cmd, web, template, ZooKeeper service discovery, treecache and remote storage.
```
