### PR TITLE
Add additional incompatible nhcb schemas tests for functions and comparison operators

### DIFF
--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1165,16 +1165,16 @@ clear
 
 # Test incompatible schemas with comparison binary operators
 load 6m
-  metric{series="1"} {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
-  metric{series="2"} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+  metric1 {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+  metric2 {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
 
-eval range from 0 to 6m step 6m metric{series="1"} == ignoring (series) metric{series="2"}
-metric{} _ {{schema:-53 count:1 sum:1 custom_values:[5 10] buckets:[1]}}
+eval range from 0 to 6m step 6m metric1 == metric2
+metric1{} _ {{schema:-53 count:1 sum:1 custom_values:[5 10] buckets:[1]}}
 
-eval range from 0 to 6m step 6m metric{series="1"} != ignoring (series) metric{series="2"}
-metric{} {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}} _
+eval range from 0 to 6m step 6m metric1 != metric2
+metric1{} {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}} _
 
-eval_info range from 0 to 6m step 6m metric{series="1"} > ignoring (series) metric{series="2"}
+eval_info range from 0 to 6m step 6m metric2 > metric2
 
 clear
 

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1163,6 +1163,21 @@ eval_warn range from 0 to 12m step 6m metric{series="2"} - ignoring (series) met
 
 clear
 
+# Test incompatible schemas with comparison binary operators
+load 6m
+  metric{series="1"} {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+  metric{series="2"} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+
+eval range from 0 to 6m step 6m metric{series="1"} == ignoring (series) metric{series="2"}
+metric{} _ {{schema:-53 count:1 sum:1 custom_values:[5 10] buckets:[1]}}
+
+eval range from 0 to 6m step 6m metric{series="1"} != ignoring (series) metric{series="2"}
+metric{} {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}} _
+
+eval_info range from 0 to 6m step 6m metric{series="1"} > ignoring (series) metric{series="2"}
+
+clear
+
 load 6m
   nhcb_metric {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
 
@@ -1177,6 +1192,18 @@ eval instant at 12m count_over_time(nhcb_metric[13m])
 {} 3
 
 eval instant at 12m present_over_time(nhcb_metric[13m])
+{} 1
+
+eval instant at 12m changes(nhcb_metric[13m])
+{} 1
+
+eval_warn instant at 12m delta(nhcb_metric[13m])
+
+eval_warn instant at 12m increase(nhcb_metric[13m])
+
+eval_warn instant at 12m rate(nhcb_metric[13m])
+
+eval instant at 12m resets(nhcb_metric[13m])
 {} 1
 
 clear

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1163,6 +1163,24 @@ eval_warn range from 0 to 12m step 6m metric{series="2"} - ignoring (series) met
 
 clear
 
+load 6m
+  nhcb_metric {{schema:-53 sum:1 count:1 custom_values:[2] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+
+eval_warn instant at 12m sum_over_time(nhcb_metric[13m])
+
+eval_warn instant at 12m avg_over_time(nhcb_metric[13m])
+
+eval instant at 12m last_over_time(nhcb_metric[13m])
+nhcb_metric{} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+
+eval instant at 12m count_over_time(nhcb_metric[13m])
+{} 3
+
+eval instant at 12m present_over_time(nhcb_metric[13m])
+{} 1
+
+clear
+
 load 1m
   metric{group="just-floats", series="1"} 2
   metric{group="just-floats", series="2"} 3


### PR DESCRIPTION
Part of https://github.com/prometheus/prometheus/issues/13494

Specifically this PR checks:
- `==` and `!=` -  treats histograms with incompatible schema as unequal
- other comparison operators (e.g. `>`) - no samples returned, plus an info annotation (note: these are the only operators/functions I found which returned an info rather than warning. [this matches the spec for binary operators](https://github.com/prometheus/docs/blob/main/content/docs/specs/native_histograms.md#binary-operators))
- `sum_over_time` and `avg_over_time` - no samples returned, plus a warning annotation
- `count_over_time`, `last_over_time`, and `present_over_time` - work as normal - sample values don't matter
- `delta()`, `increase()` and `rate()` - no samples returned, plus a warning annotation
-  `changes()` and `resets()` - count schema changes as changes/resets