### PR TITLE
tsdb: Avoid zero point detection in rate() if the first value is zero.

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -149,7 +149,7 @@ func extrapolatedRate(vals []parser.Value, args parser.Expressions, enh *EvalNod
 	if durationToStart >= extrapolationThreshold {
 		durationToStart = averageDurationBetweenSamples / 2
 	}
-	if isCounter && resultFloat > 0 && len(samples.Floats) > 0 && samples.Floats[0].F >= 0 {
+	if isCounter && resultFloat > 0 && len(samples.Floats) > 0 && samples.Floats[0].F > 0 {
 		// Counters cannot be negative. If we have any slope at all
 		// (i.e. resultFloat went up), we can extrapolate the zero point
 		// of the counter. If the duration to the zero point is shorter

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -133,8 +133,8 @@ eval instant at 50m increase(http_requests_total[50m])
 # t=-30s. Here the extrapolation to t=-2m30s would reach a negative
 # value, and therefore the extrapolation happens only by 30s.
 eval instant at 50m increase(http_requests_total[100m])
-	{path="/foo"}   100
-	{path="/bar"}   162
+	{path="/foo"}   105
+	{path="/bar"}   170.1
 	{path="/dings"} 105
 	{path="/bumms"} 101
 
@@ -196,7 +196,7 @@ load 4m
 # reach half a sampling interval (2m). Beyond that, we only
 # extrapolate by half a sampling interval.
 eval instant at 10m rate(testcounter_zero_cutoff_total[20m])
-	{start="0m"} 0.5
+	{start="0m"} 0.6
 	{start="1m"} 0.55
 	{start="2m"} 0.6
 	{start="3m"} 0.6


### PR DESCRIPTION
Previously, the function would extrapolate an extra sampled interval to guess a zero point even though the first value was zero. This would result in an artifically low rate.
E.g. given the inputs:
T+15s = 0
T+30s = 6
T+45s = 9
and a 1 minute step:
Previous result: 9 / 45s = 0.225
New result: 9 / 30s = 0.3

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
