### PR TITLE
fix(remotewrite2): do not send uninitialized garbage if no metadata

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1928,8 +1928,8 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 			// Safeguard against sending garbage in case of not having metadata
 			// for whatever reason.
 			pendingData[nPending].Metadata.Type = writev2.Metadata_METRIC_TYPE_UNSPECIFIED
-			pendingData[nPending].Metadata.HelpRef = symbolTable.Symbolize("")
-			pendingData[nPending].Metadata.UnitRef = symbolTable.Symbolize("")
+			pendingData[nPending].Metadata.HelpRef = 0
+			pendingData[nPending].Metadata.UnitRef = 0
 		}
 
 		if sendExemplars {

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1919,12 +1919,17 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 	var nPendingSamples, nPendingExemplars, nPendingHistograms, nPendingMetadata int
 	for nPending, d := range batch {
 		pendingData[nPending].Samples = pendingData[nPending].Samples[:0]
-		// todo: should we also safeguard against empty metadata here?
 		if d.metadata != nil {
 			pendingData[nPending].Metadata.Type = writev2.FromMetadataType(d.metadata.Type)
 			pendingData[nPending].Metadata.HelpRef = symbolTable.Symbolize(d.metadata.Help)
 			pendingData[nPending].Metadata.UnitRef = symbolTable.Symbolize(d.metadata.Unit)
 			nPendingMetadata++
+		} else {
+			// Safeguard against sending garbage in case of not having metadata
+			// for whatever reason.
+			pendingData[nPending].Metadata.Type = writev2.Metadata_METRIC_TYPE_UNSPECIFIED
+			pendingData[nPending].Metadata.HelpRef = symbolTable.Symbolize("")
+			pendingData[nPending].Metadata.UnitRef = symbolTable.Symbolize("")
 		}
 
 		if sendExemplars {


### PR DESCRIPTION
Found during testing for
https://github.com/grafana/mimir/issues/9072

Debug printout showed:
```
KRAJO: seriesName=cortex_request_duration_seconds_bucket, metricFamily=cortex_request_duration_seconds_bucket, type=GAUGE,
help=cortex_bucket_index_load_duration_seconds_sum, unit=
```
which is nonsense.

I can imagine more cases where this is the case and makes actual sense. Some targets might miss metadata and if there's a pipeline that loses it.
