### PR TITLE
parser: fix non-constant format string call

### DIFF
--- a/promql/parser/generated_parser.y
+++ b/promql/parser/generated_parser.y
@@ -488,7 +488,7 @@ matrix_selector : expr LEFT_BRACKET number_duration_literal RIGHT_BRACKET
 
                         if errMsg != ""{
                                 errRange := mergeRanges(&$2, &$4)
-                                yylex.(*parser).addParseErrf(errRange, errMsg)
+                                yylex.(*parser).addParseErrf(errRange, "%s", errMsg)
                         }
 
 			numLit, _ := $3.(*NumberLiteral)

--- a/promql/parser/generated_parser.y.go
+++ b/promql/parser/generated_parser.y.go
@@ -1385,7 +1385,7 @@ yydefault:
 
 			if errMsg != "" {
 				errRange := mergeRanges(&yyDollar[2].item, &yyDollar[4].item)
-				yylex.(*parser).addParseErrf(errRange, errMsg)
+				yylex.(*parser).addParseErrf(errRange, "%s", errMsg)
 			}
 
 			numLit, _ := yyDollar[3].node.(*NumberLiteral)


### PR DESCRIPTION
Go 1.24 enhanced vet's printf analyzer to report calls of the form fmt.Printf(s), where s is a non-constant format string, with no other arguments. This change makes parser tests to fail.

~~~
./generated_parser.y.go:1388:44: non-constant format string in call to (*github.com/prometheus/prometheus/promql/parser.parser).addParseErrf
~~~

~~~
$ go version
go version go1.24rc1 linux/amd64
$ go vet -printf
./generated_parser.y.go:1388:44: non-constant format string in call to (*github.com/prometheus/prometheus/promql/parser.parser).addParseErrf
~~~

~~~
$ go version
go version go1.23.4 linux/amd64
$ go vet -printf
$ echo $?
0
~~~

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
