### PR TITLE
promql: use histogram stats decoder for histogram_avg

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3721,14 +3721,15 @@ func detectHistogramStatsDecoding(expr parser.Expr) {
 			if !ok {
 				continue
 			}
-			if call.Func.Name == "histogram_count" || call.Func.Name == "histogram_sum" {
+			switch call.Func.Name {
+			case "histogram_count", "histogram_sum", "histogram_avg":
 				n.SkipHistogramBuckets = true
-				break
-			}
-			if call.Func.Name == "histogram_quantile" || call.Func.Name == "histogram_fraction" {
+			case "histogram_quantile", "histogram_fraction":
 				n.SkipHistogramBuckets = false
-				break
+			default:
+				continue
 			}
+			break
 		}
 		return errors.New("stop")
 	})


### PR DESCRIPTION
`histogram_avg` would also benefit from the optimizations introduced in https://github.com/prometheus/prometheus/pull/14097, just like `histogram_sum` and `histogram_count` (because it only depends on `Count` and `Sum` fields of the histogram object).