### PR TITLE
perf(nhcb): reuse calculated metric name and hash

### DIFF
--- a/model/textparse/nhcbparse.go
+++ b/model/textparse/nhcbparse.go
@@ -36,6 +36,15 @@ const (
 	stateEmitting
 )
 
+// Keep track of what information we have already loaded about the next series.
+type histogramInfoPreloaded struct {
+	hasName    bool   // The metricName and suffix is loaded.
+	hasHash    bool   // The hash was calculated.
+	metricName string // Without magic suffixes.
+	suffixType convertnhcb.SuffixType
+	hash       uint64
+}
+
 // The NHCBParser wraps a Parser and converts classic histograms to native
 // histograms with custom buckets.
 //
@@ -58,6 +67,9 @@ type NHCBParser struct {
 
 	// State of the parser.
 	state collectionState
+
+	// Preloaded information about classic histogram series.
+	preload histogramInfoPreloaded
 
 	// Caches the values from the underlying parser.
 	// For Series and Histogram.
@@ -190,6 +202,11 @@ func (p *NHCBParser) Next() (Entry, error) {
 			return p.entry, p.err
 		}
 
+		// We are advancing the embedded parser, whatever we knew preloaded
+		// about the previous series is now invalid.
+		p.preload.hasName = false
+		p.preload.hasHash = false
+
 		p.entry, p.err = p.parser.Next()
 		if p.err != nil {
 			if errors.Is(p.err, io.EOF) && p.processNHCB() {
@@ -237,6 +254,7 @@ func (p *NHCBParser) Next() (Entry, error) {
 }
 
 // Return true if labels have changed and we should emit the NHCB.
+// Also store the calculated metric name and hash if possible for future use.
 func (p *NHCBParser) compareLabels() bool {
 	if p.state != stateCollecting {
 		return false
@@ -245,26 +263,38 @@ func (p *NHCBParser) compareLabels() bool {
 		// Different metric type.
 		return true
 	}
-	_, name := convertnhcb.GetHistogramMetricBaseName(p.lset.Get(labels.MetricName))
-	if p.lastHistogramName != name {
+	p.preload.hasName = true
+	p.preload.suffixType, p.preload.metricName = convertnhcb.GetHistogramMetricBaseName(p.lset.Get(labels.MetricName))
+	if p.lastHistogramName != p.preload.metricName {
 		// Different metric name.
 		return true
 	}
-	nextHash, _ := p.lset.HashWithoutLabels(p.hBuffer, labels.BucketLabel)
+	p.preload.hasHash = true
+	p.preload.hash, _ = p.lset.HashWithoutLabels(p.hBuffer, labels.BucketLabel)
 	// Different label values.
-	return p.lastHistogramLabelsHash != nextHash
+	return p.lastHistogramLabelsHash != p.preload.hash
 }
 
 // Save the label set of the classic histogram without suffix and bucket `le` label.
 func (p *NHCBParser) storeClassicLabels(name string) {
 	p.lastHistogramName = name
-	p.lastHistogramLabelsHash, _ = p.lset.HashWithoutLabels(p.hBuffer, labels.BucketLabel)
+	if p.preload.hasHash {
+		p.lastHistogramLabelsHash = p.preload.hash
+	} else {
+		p.lastHistogramLabelsHash, _ = p.lset.HashWithoutLabels(p.hBuffer, labels.BucketLabel)
+	}
 	p.lastHistogramExponential = false
 }
 
 func (p *NHCBParser) storeExponentialLabels() {
 	p.lastHistogramName = p.lset.Get(labels.MetricName)
-	p.lastHistogramLabelsHash, _ = p.lset.HashWithoutLabels(p.hBuffer)
+	if p.preload.hasHash {
+		p.lastHistogramLabelsHash = p.preload.hash
+	} else {
+		// In the current model and client_golang, "le" label is not allowed
+		// for histogram so ignoring "le" here is ok.
+		p.lastHistogramLabelsHash, _ = p.lset.HashWithoutLabels(p.hBuffer, labels.BucketLabel)
+	}
 	p.lastHistogramExponential = true
 }
 
@@ -276,9 +306,16 @@ func (p *NHCBParser) handleClassicHistogramSeries(lset labels.Labels) bool {
 	if p.typ != model.MetricTypeHistogram {
 		return false
 	}
-	mName := lset.Get(labels.MetricName)
+
+	var name string
+	var suffixType convertnhcb.SuffixType
+	if p.preload.hasName {
+		suffixType, name = p.preload.suffixType, p.preload.metricName
+	} else {
+		suffixType, name = convertnhcb.GetHistogramMetricBaseName(lset.Get(labels.MetricName))
+	}
+
 	// Sanity check to ensure that the TYPE metadata entry name is the same as the base name.
-	suffixType, name := convertnhcb.GetHistogramMetricBaseName(mName)
 	if name != string(p.bName) {
 		return false
 	}

--- a/model/textparse/nhcbparse_test.go
+++ b/model/textparse/nhcbparse_test.go
@@ -500,8 +500,8 @@ something_bucket{a="b",le="+Inf"} 9 # {id="something-test"} 2e100 123.000
 				Schema:          histogram.CustomBucketsSchema,
 				Count:           9,
 				Sum:             42123.0,
-				PositiveSpans:   []histogram.Span{{Offset: 0, Length: 3}},
-				PositiveBuckets: []int64{8, -8, 1},
+				PositiveSpans:   []histogram.Span{{Offset: 0, Length: 1}, {Offset: 1, Length: 1}},
+				PositiveBuckets: []int64{8, -7},
 				CustomValues:    []float64{0.0, 1.0}, // We do not store the +Inf boundary.
 			},
 			lset: labels.FromStrings("__name__", "something", "a", "b"),

--- a/util/convertnhcb/convertnhcb.go
+++ b/util/convertnhcb/convertnhcb.go
@@ -196,7 +196,7 @@ func (h TempHistogram) convertToIntegerHistogram(count uint64) (*histogram.Histo
 		return nil, nil, h.err
 	}
 
-	return rh.Compact(2), nil, nil
+	return rh.Compact(0), nil, nil
 }
 
 func (h TempHistogram) convertToFloatHistogram() (*histogram.Histogram, *histogram.FloatHistogram, error) {


### PR DESCRIPTION
The benchmark showed little improvement. I'll run prombench to see if it improved over https://github.com/prometheus/prometheus/pull/15467#issuecomment-2569844862
```
                                                         │   main.txt   │               pr.txt               │
                                                         │    sec/op    │    sec/op     vs base              │
Parse/data=omtestdata.txt/parser=omtext_with_nhcb-2        62.53µ ± 10%   62.14µ ± 13%       ~ (p=0.589 n=6)
Parse/data=omhistogramdata.txt/parser=omtext_with_nhcb-2   96.58µ ± 19%   86.50µ ± 17%       ~ (p=0.310 n=6)
geomean                                                    77.71µ         73.31µ        -5.66%

                                                         │   main.txt    │               pr.txt                │
                                                         │      B/s      │      B/s       vs base              │
Parse/data=omtestdata.txt/parser=omtext_with_nhcb-2        68.29Mi ± 11%   68.71Mi ± 14%       ~ (p=0.589 n=6)
Parse/data=omhistogramdata.txt/parser=omtext_with_nhcb-2   41.47Mi ± 24%   46.42Mi ± 15%       ~ (p=0.310 n=6)
geomean                                                    53.22Mi         56.48Mi        +6.13%

                                                         │   main.txt   │               pr.txt               │
                                                         │     B/op     │     B/op      vs base              │
Parse/data=omtestdata.txt/parser=omtext_with_nhcb-2        14.05Ki ± 0%   14.11Ki ± 0%  +0.44% (p=0.002 n=6)
Parse/data=omhistogramdata.txt/parser=omtext_with_nhcb-2   22.49Ki ± 0%   22.31Ki ± 0%  -0.76% (p=0.002 n=6)
geomean                                                    17.77Ki        17.74Ki       -0.16%

                                                         │  main.txt  │               pr.txt               │
                                                         │ allocs/op  │ allocs/op   vs base                │
Parse/data=omtestdata.txt/parser=omtext_with_nhcb-2        237.0 ± 0%   237.0 ± 0%       ~ (p=1.000 n=6) ¹
Parse/data=omhistogramdata.txt/parser=omtext_with_nhcb-2   355.0 ± 0%   347.0 ± 0%  -2.25% (p=0.002 n=6)
geomean                                                    290.1        286.8       -1.13%
¹ all samples are equal

```