### PR TITLE
PromQL: Adds tests for `sum_over_time` and `avg_over_time` with histograms

### DIFF
--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -419,7 +419,7 @@ clear
 
 # Tests for vector, time and timestamp.
 load 10s
-  metric 1 1
+  metric 1 1 {{schema:0 sum:1 count:1}}
 
 eval instant at 0s timestamp(metric)
   {} 0
@@ -435,6 +435,9 @@ eval instant at 10s timestamp(metric)
 
 eval instant at 10s timestamp(((metric)))
   {} 10
+
+eval instant at 20s timestamp(metric)
+  {} 20
 
 # Tests for label_join.
 load 5m

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -810,6 +810,8 @@ load 10s
   metric9 -9.988465674311579e+307 -9.988465674311579e+307 -9.988465674311579e+307
   metric10 -9.988465674311579e+307 9.988465674311579e+307
   metric11 1 2 3 NaN NaN
+  metric12 1 2 3 {{schema:0 sum:1 count:1}} {{schema:0 sum:3 count:3}}
+  metric13 {{schema:0 sum:1 count:1}}x5
 
 eval instant at 55s avg_over_time(metric[1m])
   {} 3
@@ -915,6 +917,23 @@ eval instant at 1m avg_over_time(metric11[1m])
 
 eval instant at 1m sum_over_time(metric11[1m])/count_over_time(metric11[1m])
   {} NaN
+
+# Tests for samples with mix of floats and histograms.
+eval_warn instant at 1m sum_over_time(metric12[1m])
+	# no result.
+
+eval_warn instant at 1m avg_over_time(metric12[1m])
+	# no result.
+
+# Tests for samples with only histograms.
+eval instant at 1m sum_over_time(metric13[1m])
+	{} {{schema:0 sum:5 count:5}}
+
+eval instant at 1m avg_over_time(metric13[1m])
+	{} {{schema:0 sum:1 count:1}}
+
+eval instant at 1m sum_over_time(metric13[1m])/count_over_time(metric13[1m])
+	{} {{schema:0 sum:1 count:1}}
 
 # Test if very big intermediate values cause loss of detail.
 clear


### PR DESCRIPTION
Part of #13934.

This PR adds tests for `sum_over_time`, `avg_over_time` and `timestamp` with histograms.

CC: @beorn7 