### PR TITLE
promqltest: Small formatting improvement for native histograms

### DIFF
--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -800,7 +800,7 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 			fp := v.Metric.Hash()
 			if _, ok := ev.metrics[fp]; !ok {
 				if v.H != nil {
-					return fmt.Errorf("unexpected metric %s in result, has value %v", v.Metric, v.H)
+					return fmt.Errorf("unexpected metric %s in result, has value %s", v.Metric, HistogramTestExpression(v.H))
 				}
 
 				return fmt.Errorf("unexpected metric %s in result, has value %v", v.Metric, v.F)
@@ -838,7 +838,7 @@ func (ev *evalCmd) compareResult(result parser.Value) error {
 		}
 		exp0 := ev.expected[0].vals[0]
 		if exp0.Histogram != nil {
-			return fmt.Errorf("expected histogram %v but got %s", exp0.Histogram.TestExpression(), val.String())
+			return fmt.Errorf("expected histogram %s but got %s", exp0.Histogram.TestExpression(), val.String())
 		}
 		if !almost.Equal(exp0.Value, val.V, defaultEpsilon) {
 			return fmt.Errorf("expected scalar %v but got %v", exp0.Value, val.V)

--- a/promql/promqltest/test_test.go
+++ b/promql/promqltest/test_test.go
@@ -247,7 +247,7 @@ load 5m
 
 eval instant at 0m testmetric
 `,
-			expectedError: `error in eval testmetric (line 5): unexpected metric {__name__="testmetric"} in result, has value {count:0, sum:0}`,
+			expectedError: `error in eval testmetric (line 5): unexpected metric {__name__="testmetric"} in result, has value {{}}`,
 		},
 		"instant query, but result is missing a series": {
 			input: testData + `


### PR DESCRIPTION
A `HistogramTestExpression` was missed in one case, which made the formatting weird in case a histogram got unexpectedly returned.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
