### PR TITLE
chore: enable usetesting linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - unconvert
     - unused
     - usestdlibvars
+    - usetesting
     - whitespace
 
 issues:

--- a/cmd/prometheus/query_log_test.go
+++ b/cmd/prometheus/query_log_test.go
@@ -284,10 +284,10 @@ func (p *queryLogTest) run(t *testing.T) {
 	p.skip(t)
 
 	// Setup temporary files for this test.
-	queryLogFile, err := os.CreateTemp("", "query")
+	queryLogFile, err := os.CreateTemp(t.TempDir(), "query")
 	require.NoError(t, err)
 	defer os.Remove(queryLogFile.Name())
-	p.configFile, err = os.CreateTemp("", "config")
+	p.configFile, err = os.CreateTemp(t.TempDir(), "config")
 	require.NoError(t, err)
 	defer os.Remove(p.configFile.Name())
 
@@ -382,7 +382,7 @@ func (p *queryLogTest) run(t *testing.T) {
 		return
 	}
 	// Move the file, Prometheus should still write to the old file.
-	newFile, err := os.CreateTemp("", "newLoc")
+	newFile, err := os.CreateTemp(t.TempDir(), "newLoc")
 	require.NoError(t, err)
 	require.NoError(t, newFile.Close())
 	defer os.Remove(newFile.Name())

--- a/documentation/examples/custom-sd/adapter/adapter_test.go
+++ b/documentation/examples/custom-sd/adapter/adapter_test.go
@@ -224,7 +224,7 @@ func TestGenerateTargetGroups(t *testing.T) {
 // TestWriteOutput checks the adapter can write a file to disk.
 func TestWriteOutput(t *testing.T) {
 	ctx := context.Background()
-	tmpfile, err := os.CreateTemp("", "sd_adapter_test")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "sd_adapter_test")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 	tmpfile.Close()

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -811,7 +811,7 @@ func TestUpdate(t *testing.T) {
 	rgs, errs := rulefmt.ParseFile("fixtures/rules.yaml", false)
 	require.Empty(t, errs, "file parsing failures")
 
-	tmpFile, err := os.CreateTemp("", "rules.test.*.yaml")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "rules.test.*.yaml")
 	require.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -1120,7 +1120,7 @@ func runManagers(t *testing.T, ctx context.Context, opts *Options, app storage.A
 func writeIntoFile(t *testing.T, content, filePattern string) *os.File {
 	t.Helper()
 
-	file, err := os.CreateTemp("", filePattern)
+	file, err := os.CreateTemp(t.TempDir(), filePattern)
 	require.NoError(t, err)
 	_, err = file.WriteString(content)
 	require.NoError(t, err)

--- a/tsdb/wlog/reader_test.go
+++ b/tsdb/wlog/reader_test.go
@@ -200,7 +200,7 @@ func TestReader_Live(t *testing.T) {
 
 	for i := range testReaderCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			writeFd, err := os.CreateTemp("", "TestReader_Live")
+			writeFd, err := os.CreateTemp(t.TempDir(), "TestReader_Live")
 			require.NoError(t, err)
 			defer os.Remove(writeFd.Name())
 

--- a/util/logging/file_test.go
+++ b/util/logging/file_test.go
@@ -37,7 +37,7 @@ func getLogLines(t *testing.T, name string) []string {
 }
 
 func TestJSONFileLogger_basic(t *testing.T) {
-	f, err := os.CreateTemp("", "logging")
+	f, err := os.CreateTemp(t.TempDir(), "logging")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, f.Close())
@@ -66,7 +66,7 @@ func TestJSONFileLogger_basic(t *testing.T) {
 }
 
 func TestJSONFileLogger_parallel(t *testing.T) {
-	f, err := os.CreateTemp("", "logging")
+	f, err := os.CreateTemp(t.TempDir(), "logging")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, f.Close())


### PR DESCRIPTION
#### Description

Enables and fixes [usetesting](https://golangci-lint.run/usage/linters/#usetesting): Reports uses of functions with replacement inside the testing package.