### PR TITLE
promql: fix behaviour of range vector selectors with 0 length range

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2357,6 +2357,11 @@ func (ev *evaluator) matrixIterSlice(
 		}
 	}
 
+	if mint == maxt {
+		// Empty range: return the empty slices.
+		return floats, histograms
+	}
+
 	soughtValueType := it.Seek(maxt)
 	if soughtValueType == chunkenc.ValNone {
 		if it.Err() != nil {

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1900,6 +1900,15 @@ func TestSubquerySelector(t *testing.T) {
 					},
 					Start: time.Unix(35, 0),
 				},
+				{
+					Query: "metric[0:10s]",
+					Result: promql.Result{
+						nil,
+						promql.Matrix{},
+						nil,
+					},
+					Start: time.Unix(10, 0),
+				},
 			},
 		},
 		{
@@ -3250,6 +3259,11 @@ func TestInstantQueryWithRangeVectorSelector(t *testing.T) {
 					},
 				},
 			},
+		},
+		"matches series but range is 0": {
+			expr:     "some_metric[0]",
+			ts:       baseT.Add(2 * time.Minute),
+			expected: promql.Matrix{},
 		},
 	}
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3208,6 +3208,7 @@ func TestInstantQueryWithRangeVectorSelector(t *testing.T) {
 		load 1m
 			some_metric{env="1"} 0+1x4
 			some_metric{env="2"} 0+2x4
+			some_metric{env="3"} {{count:0}}+{{count:1}}x4
 			some_metric_with_stale_marker 0 1 stale 3
 	`)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
@@ -3233,6 +3234,13 @@ func TestInstantQueryWithRangeVectorSelector(t *testing.T) {
 					Floats: []promql.FPoint{
 						{T: timestamp.FromTime(baseT.Add(time.Minute)), F: 2},
 						{T: timestamp.FromTime(baseT.Add(2 * time.Minute)), F: 4},
+					},
+				},
+				{
+					Metric: labels.FromStrings("__name__", "some_metric", "env", "3"),
+					Histograms: []promql.HPoint{
+						{T: timestamp.FromTime(baseT.Add(time.Minute)), H: &histogram.FloatHistogram{Count: 1, CounterResetHint: histogram.NotCounterReset}},
+						{T: timestamp.FromTime(baseT.Add(2 * time.Minute)), H: &histogram.FloatHistogram{Count: 2, CounterResetHint: histogram.NotCounterReset}},
 					},
 				},
 			},


### PR DESCRIPTION
Fixes #15969.

I also took this opportunity to expand `TestInstantQueryWithRangeSelector` to cover histograms as well.