### PR TITLE
promql: Fix counter reset detection in subqueries with histograms

### DIFF
--- a/promql/promqltest/testdata/subquery.test
+++ b/promql/promqltest/testdata/subquery.test
@@ -134,3 +134,19 @@ eval instant at 20s min_over_time(metric_total[15s:10s])
 eval instant at 20m min_over_time(rate(metric_total[5m])[20m:1m])
   {} 0.12119047619047618
 
+clear
+
+# This native histogram series has a counter reset at 5m.
+# TODO(beorn7): Write this more nicely once https://github.com/prometheus/prometheus/issues/15984 is fixed.
+load 1m
+  native_histogram {{sum:100 count:100}} {{sum:103 count:103}} {{sum:106 count:106}} {{sum:109 count:109}} {{sum:112 count:112}} {{sum:3 count:3 counter_reset_hint:reset}} {{sum:6 count:6}}+{{sum:3 count:3}}x5
+
+# This sub-query has to detect the counter reset even if it does
+# not include the exact sample where the counter reset has happened.
+eval instant at 10m increase(native_histogram[10m:3m])
+  {} {{count:25 sum:25}}
+# This sub-query must not detect the counter reset multiple times
+# even though the sample where the counter reset happened is returned
+# by the sub-query multiple times.
+eval instant at 10m increase(native_histogram[10m:15s])
+  {} {{count:30.769230769230766 sum:30.769230769230766}}


### PR DESCRIPTION
Subqueries might not return all samples from the underlying time series. Or they might even return some samples multiple times.

In the former case, we might miss the histogram sample where a counter reset happened. Since the other samples might have a counter reset hint of `NotCounterReset`, we'll trust this, which will lead to under-detection of counter resets and nonsensical results including negative rates.

In the latter case, we might over-detect counter resets if one and the same histogram marked with a counter reset hint of `CounterReset` is returned multiple times by the subquery. (Note that this case doesn't really happen at the moment because we do not trust counter reset hints for a 1st sample in a chunk, and that's the only place where `CounterReset` happens. Cf. https://github.com/prometheus/prometheus/issues/15346 .)

The easy way out is to generally ignore counter resets of `NotCounterReset` and `CounterReset` and treat them as `UnknownCounterReset`, triggering conventional counter reset detection again. We could do something smarter, like analyzing if we return the same sample multiple times and only unset the hint on the subsequent returns, or find out if subsequent samples were returned, in which case we could still trust `NotCounterReset`. However, subqueries with counter resets are problematic anyway, so we probably shouldn't try to hard to fix a use case that is broken in other ways.