### PR TITLE
Labels: Reduce stringlabels memory usage for common labels

### DIFF
--- a/cmd/prometheus/labels.go
+++ b/cmd/prometheus/labels.go
@@ -1,0 +1,26 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !stringlabels
+
+package main
+
+import (
+	"log/slog"
+
+	"github.com/prometheus/prometheus/tsdb"
+)
+
+func mapCommonLabelSymbols(_ *tsdb.DB, _ *slog.Logger) error {
+	return nil
+}

--- a/cmd/prometheus/labels_stringlabels.go
+++ b/cmd/prometheus/labels_stringlabels.go
@@ -101,9 +101,8 @@ func selectBlockStringsToMap(block *tsdb.Block) ([]string, error) {
 	})
 
 	mappedLabels := make([]string, 0, 256)
-	mappedLabels = append(mappedLabels, "") // We must always store empty string.
 	for i, c := range costs {
-		if i > 254 {
+		if i >= 256 {
 			break
 		}
 		mappedLabels = append(mappedLabels, c.name)
@@ -132,6 +131,6 @@ func mapCommonLabelSymbols(db *tsdb.DB, logger *slog.Logger) error {
 		return err
 	}
 	logger.Info("Mapped common label strings", slog.Int("count", len(mappedLabels)))
-	labels.MappedLabels = mappedLabels
+	labels.MapLabels(mappedLabels)
 	return nil
 }

--- a/cmd/prometheus/labels_stringlabels.go
+++ b/cmd/prometheus/labels_stringlabels.go
@@ -1,0 +1,137 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build stringlabels
+
+package main
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/index"
+)
+
+// countBlockSymbols reads given block index and counts how many time each string
+// occurs on time series labels.
+func countBlockSymbols(ctx context.Context, block *tsdb.Block) (map[string]int, error) {
+	names := map[string]int{}
+
+	ir, err := block.Index()
+	if err != nil {
+		return names, err
+	}
+
+	labelNames, err := ir.LabelNames(ctx)
+	if err != nil {
+		return names, err
+	}
+
+	for _, name := range labelNames {
+		name = strings.Clone(name)
+
+		if _, ok := names[name]; !ok {
+			names[name] = 0
+		}
+
+		values, err := ir.LabelValues(ctx, name)
+		if err != nil {
+			return names, err
+		}
+		for _, value := range values {
+			value = strings.Clone(value)
+
+			if _, ok := names[value]; !ok {
+				names[value] = 0
+			}
+
+			p, err := ir.Postings(ctx, name, value)
+			if err != nil {
+				return names, err
+			}
+
+			refs, err := index.ExpandPostings(p)
+			if err != nil {
+				return names, err
+			}
+
+			names[name] += len(refs)
+			names[value] += len(refs)
+		}
+	}
+	return names, ir.Close()
+}
+
+type labelCost struct {
+	name string
+	cost int
+}
+
+// selectBlockStringsToMap takes a block and returns a list of strings that are most commonly
+// present on all time series.
+// List is sorted starting with the most frequent strings.
+func selectBlockStringsToMap(block *tsdb.Block) ([]string, error) {
+	names, err := countBlockSymbols(context.Background(), block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build list of common strings in block %s: %w", block.Meta().ULID, err)
+	}
+
+	costs := make([]labelCost, 0, len(names))
+	for name, count := range names {
+		costs = append(costs, labelCost{name: name, cost: (len(name) - 1) * count})
+	}
+	slices.SortFunc(costs, func(a, b labelCost) int {
+		return cmp.Compare(b.cost, a.cost)
+	})
+
+	mappedLabels := make([]string, 0, 256)
+	mappedLabels = append(mappedLabels, "") // We must always store empty string.
+	for i, c := range costs {
+		if i > 254 {
+			break
+		}
+		mappedLabels = append(mappedLabels, c.name)
+	}
+	return mappedLabels, nil
+}
+
+func mapCommonLabelSymbols(db *tsdb.DB, logger *slog.Logger) error {
+	var block *tsdb.Block
+	for _, b := range db.Blocks() {
+		if block == nil || b.MaxTime() > block.MaxTime() {
+			block = b
+		}
+	}
+	if block == nil {
+		logger.Info("No tsdb blocks found, can't map common label strings")
+		return nil
+	}
+
+	logger.Info(
+		"Finding most common label strings in last block",
+		slog.String("block", block.String()),
+	)
+	mappedLabels, err := selectBlockStringsToMap(block)
+	if err != nil {
+		return err
+	}
+	logger.Info("Mapped common label strings", slog.Int("count", len(mappedLabels)))
+	labels.MappedLabels = mappedLabels
+	return nil
+}

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1242,6 +1242,10 @@ func main() {
 					return fmt.Errorf("opening storage failed: %w", err)
 				}
 
+				if err = mapCommonLabelSymbols(db, logger); err != nil {
+					logger.Warn("Failed to map common strings in labels", slog.Any("err", err))
+				}
+
 				switch fsType := prom_runtime.Statfs(localStoragePath); fsType {
 				case "NFS_SUPER_MAGIC":
 					logger.Warn("This filesystem is not supported and may lead to data corruption and data loss. Please carefully read https://prometheus.io/docs/prometheus/latest/storage/ to learn more about supported filesystems.", "fs_type", fsType)

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -853,6 +853,12 @@ func main() {
 
 	cfg.web.Flags = map[string]string{}
 
+	cfg.tsdb.PreInitFunc = func(db *tsdb.DB) {
+		if err = mapCommonLabelSymbols(db, logger); err != nil {
+			logger.Warn("Failed to map common strings in labels", slog.Any("err", err))
+		}
+	}
+
 	// Exclude kingpin default flags to expose only Prometheus ones.
 	boilerplateFlags := kingpin.New("", "").Version("")
 	for _, f := range a.Model().Flags {
@@ -1240,10 +1246,6 @@ func main() {
 				db, err := openDBWithMetrics(localStoragePath, logger, prometheus.DefaultRegisterer, &opts, localStorage.getStats())
 				if err != nil {
 					return fmt.Errorf("opening storage failed: %w", err)
-				}
-
-				if err = mapCommonLabelSymbols(db, logger); err != nil {
-					logger.Warn("Failed to map common strings in labels", slog.Any("err", err))
 				}
 
 				switch fsType := prom_runtime.Statfs(localStoragePath); fsType {
@@ -1801,6 +1803,7 @@ type tsdbOptions struct {
 	CompactionDelayMaxPercent      int
 	EnableOverlappingCompaction    bool
 	EnableOOONativeHistograms      bool
+	PreInitFunc                    tsdb.PreInitFunc
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -1825,6 +1828,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		EnableDelayedCompaction:        opts.EnableDelayedCompaction,
 		CompactionDelayMaxPercent:      opts.CompactionDelayMaxPercent,
 		EnableOverlappingCompaction:    opts.EnableOverlappingCompaction,
+		PreInitFunc:                    opts.PreInitFunc,
 	}
 }
 

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -25,14 +25,15 @@ import (
 
 // List of labels that should be mapped to a single byte value.
 // Obviously can't have more than 256 here.
-var mappedLabels = []string{
+var mappedLabels = [256]string{
 	// Empty string, this must be present here.
 	"",
 	// These label names are always present on every time series.
-	"__name__",
-	"instance",
+	MetricName,
+	InstanceName,
 	"job",
 	// Common label names.
+	BucketLabel,
 	"code",
 	"handler",
 	"quantile",
@@ -54,6 +55,56 @@ var mappedLabels = []string{
 	"process_start_time_seconds ",
 	"process_virtual_memory_bytes",
 	"process_virtual_memory_max_bytes",
+	// client_go specific metrics
+	"go_gc_heap_frees_by_size_bytes_bucket",
+	"go_gc_heap_allocs_by_size_bytes_bucket",
+	"net_conntrack_dialer_conn_failed_total",
+	"go_sched_pauses_total_other_seconds_bucket",
+	"go_sched_pauses_total_gc_seconds_bucket",
+	"go_sched_pauses_stopping_other_seconds_bucket",
+	"go_sched_pauses_stopping_gc_seconds_bucket",
+	"go_sched_latencies_seconds_bucket",
+	"go_gc_pauses_seconds_bucket",
+	"go_gc_duration_seconds",
+	// node_exporter metrics
+	"node_cpu_seconds_total",
+	"node_scrape_collector_success",
+	"node_scrape_collector_duration_seconds",
+	"node_cpu_scaling_governor",
+	"node_cpu_guest_seconds_total",
+	"node_hwmon_temp_celsius",
+	"node_hwmon_sensor_label",
+	"node_hwmon_temp_max_celsius",
+	"node_cooling_device_max_state",
+	"node_cooling_device_cur_state",
+	"node_softnet_times_squeezed_total",
+	"node_softnet_received_rps_total",
+	"node_softnet_processed_total",
+	"node_softnet_flow_limit_count_total",
+	"node_softnet_dropped_total",
+	"node_softnet_cpu_collision_total",
+	"node_softnet_backlog_len",
+	"node_schedstat_waiting_seconds_total",
+	"node_schedstat_timeslices_total",
+	"node_schedstat_running_seconds_total",
+	"node_cpu_scaling_frequency_min_hertz",
+	"node_cpu_scaling_frequency_max_hertz",
+	"node_cpu_scaling_frequency_hertz",
+	"node_cpu_frequency_min_hertz",
+	"node_cpu_frequency_max_hertz",
+	"node_hwmon_temp_crit_celsius",
+	"node_hwmon_temp_crit_alarm_celsius",
+	"node_cpu_core_throttles_total",
+	"node_thermal_zone_temp",
+	"node_hwmon_temp_min_celsius",
+	"node_hwmon_chip_names",
+	"node_filesystem_readonly",
+	"node_filesystem_device_error",
+	"node_filesystem_size_bytes",
+	"node_filesystem_free_bytes",
+	"node_filesystem_files_free",
+	"node_filesystem_files",
+	"node_filesystem_avail_bytes",
 }
 
 // Labels is implemented by a single flat string holding name/value pairs.
@@ -99,7 +150,7 @@ func decodeString(data string, index int) (string, int) {
 }
 
 func encodeShortString(s string) (int, byte) {
-	i := slices.Index(mappedLabels, s)
+	i := slices.Index(mappedLabels[:], s)
 	if i >= 0 {
 		return 0, byte(i)
 	}

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -25,7 +25,7 @@ import (
 
 // List of labels that should be mapped to a single byte value.
 // Obviously can't have more than 256 here.
-var mappedLabels = []string{
+var MappedLabels = []string{
 	// Empty string, this must be present here.
 	"",
 	// These label names are always present on every time series.
@@ -144,13 +144,13 @@ func decodeString(data string, index int) (string, int) {
 	size, index, mapped = decodeSize(data, index)
 	if mapped {
 		b := data[index]
-		return mappedLabels[int(b)], index + size
+		return MappedLabels[int(b)], index + size
 	}
 	return data[index : index+size], index + size
 }
 
 func encodeShortString(s string) (int, byte) {
-	i := slices.Index(mappedLabels, s)
+	i := slices.Index(MappedLabels, s)
 	if i >= 0 {
 		return 0, byte(i)
 	}

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -25,7 +25,7 @@ import (
 
 // List of labels that should be mapped to a single byte value.
 // Obviously can't have more than 256 here.
-var mappedLabels = [256]string{
+var mappedLabels = []string{
 	// Empty string, this must be present here.
 	"",
 	// These label names are always present on every time series.
@@ -118,7 +118,7 @@ func decodeSize(data string, index int) (int, int, bool) {
 	// Fast-path for common case of a single byte, value 0..127.
 	b := data[index]
 	index++
-	if b == 0 {
+	if b == 0x0 {
 		return 1, index, true
 	}
 	if b < 0x80 {
@@ -150,7 +150,7 @@ func decodeString(data string, index int) (string, int) {
 }
 
 func encodeShortString(s string) (int, byte) {
-	i := slices.Index(mappedLabels[:], s)
+	i := slices.Index(mappedLabels, s)
 	if i >= 0 {
 		return 0, byte(i)
 	}

--- a/tsdb/agent/series_test.go
+++ b/tsdb/agent/series_test.go
@@ -82,8 +82,8 @@ func labelsWithHashCollision() (labels.Labels, labels.Labels) {
 
 	if ls1.Hash() != ls2.Hash() {
 		// These ones are the same when using -tags stringlabels
-		ls1 = labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
-		ls2 = labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
+		ls1 = labels.FromStrings("__name__", "metric", "lbl", "D3opXYk")
+		ls2 = labels.FromStrings("__name__", "metric", "lbl", "G1__3.m")
 	}
 
 	if ls1.Hash() != ls2.Hash() {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -6176,8 +6176,8 @@ func labelsWithHashCollision() (labels.Labels, labels.Labels) {
 
 	if ls1.Hash() != ls2.Hash() {
 		// These ones are the same when using -tags stringlabels
-		ls1 = labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
-		ls2 = labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
+		ls1 = labels.FromStrings("__name__", "metric", "lbl", "D3opXYk")
+		ls2 = labels.FromStrings("__name__", "metric", "lbl", "G1__3.m")
 	}
 
 	if ls1.Hash() != ls2.Hash() {


### PR DESCRIPTION
stringlabels stores all time series labels as a single string using this format:

`<length><name><length><value>[<length><name><length><value> ...]`

So a label set for my_metric{job=foo, instance="bar", env="prod", blank=""} would be encoded as:

`[8]__name__[9]my_metric[3]job[3]foo[8]instance[3]bar[3]env[4]prod[5]blank[0]`

This is a huge improvement over 'classic' labels implementation that stores all label names & values as seperate strings. There is some room for improvement though since some string are present more often than others. For example `__name__` will be present for all label sets of every time series we store in HEAD, eating 1+8=9 bytes. Since `__name__` is well known string we can try to use a single byte to store it in our encoded string, rather than repeat it in full each time. To be able to store strings that are short cut into a single byte we need to somehow signal that to the reader of the encoded string, for that we use the fact that zero length strings are rare and generaly not stored on time series. If we have an encoded string with zero length then this will now signal that it represents a mapped value - to learn the true value of this string we need to read the next byte which gives us index in a static mapping. That mapping must include empty string, so that we can still encode empty strings using this scheme.

Example of our mapping (minimal version):

```
0: ""
1: "__name__"
2: "instance"
3: "job"
```

With that mapping our example label set would be encoded as:

`[0]1[9]my_metric[0]3[3]foo[0]2[3]bar[3]env[4]prod[5]blank[0]0`

Which would mean 40 bytes instead of 56.

Given that we have more possible mapping slots we could and should map more strings, but the tricky bit is how to populate this mapping with useful strings that will result in measurable memory savings. This is further complicated by the fact that the mapping must remain static and cannot be modified during Prometheus lifetime. We can use all the 255 slots we have inside our mapping byte with well known generic strings and that will provide some measurable savings for all Prometheus users, and is essentially a slightly more compact stringlabels variant. We could also allow users to pass in a list of well know strings via flags, which will allow Prometheus operators to reduce memory usage for any labels if they know those are popular. Third option is to discover most popular strings from TSDB or WAL on startup, but that's more complicated and we might pick a list that would be the best set of mapped strings on startup, but after some time is no longer the best set.

<details>
<summary>Benchmark results:</summary>

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels cpu: 13th Gen Intel(R) Core(TM) i7-13800H
                                                 │   main.txt   │                new1.txt                │
                                                 │    sec/op    │    sec/op      vs base                 │
String-20                                           863.8n ± 4%    873.0n ±  4%         ~ (p=0.353 n=10)
Labels_Get/with_5_labels/first_label/get-20         4.763n ± 1%    5.035n ±  0%    +5.72% (p=0.000 n=10)
Labels_Get/with_5_labels/first_label/has-20         3.439n ± 0%    3.967n ±  0%   +15.37% (p=0.000 n=10)
Labels_Get/with_5_labels/middle_label/get-20        7.077n ± 1%    9.588n ±  1%   +35.47% (p=0.000 n=10)
Labels_Get/with_5_labels/middle_label/has-20        5.166n ± 0%    6.990n ±  1%   +35.30% (p=0.000 n=10)
Labels_Get/with_5_labels/last_label/get-20          9.181n ± 1%   12.970n ±  1%   +41.26% (p=0.000 n=10)
Labels_Get/with_5_labels/last_label/has-20          8.101n ± 1%   11.640n ±  1%   +43.69% (p=0.000 n=10)
Labels_Get/with_5_labels/not-found_label/get-20     3.974n ± 0%    4.768n ±  0%   +19.98% (p=0.000 n=10)
Labels_Get/with_5_labels/not-found_label/has-20     3.974n ± 0%    5.033n ±  0%   +26.65% (p=0.000 n=10)
Labels_Get/with_10_labels/first_label/get-20        4.761n ± 0%    5.042n ±  0%    +5.90% (p=0.000 n=10)
Labels_Get/with_10_labels/first_label/has-20        3.442n ± 0%    3.972n ±  0%   +15.40% (p=0.000 n=10)
Labels_Get/with_10_labels/middle_label/get-20       10.62n ± 1%    14.85n ±  1%   +39.83% (p=0.000 n=10)
Labels_Get/with_10_labels/middle_label/has-20       9.360n ± 1%   13.375n ±  0%   +42.90% (p=0.000 n=10)
Labels_Get/with_10_labels/last_label/get-20         18.19n ± 1%    22.00n ±  0%   +20.97% (p=0.000 n=10)
Labels_Get/with_10_labels/last_label/has-20         16.51n ± 0%    20.50n ±  1%   +24.14% (p=0.000 n=10)
Labels_Get/with_10_labels/not-found_label/get-20    3.985n ± 0%    4.768n ±  0%   +19.62% (p=0.000 n=10)
Labels_Get/with_10_labels/not-found_label/has-20    3.973n ± 0%    5.045n ±  0%   +26.97% (p=0.000 n=10)
Labels_Get/with_30_labels/first_label/get-20        4.773n ± 0%    5.050n ±  1%    +5.80% (p=0.000 n=10)
Labels_Get/with_30_labels/first_label/has-20        3.443n ± 1%    3.976n ±  2%   +15.50% (p=0.000 n=10)
Labels_Get/with_30_labels/middle_label/get-20       31.93n ± 0%    43.50n ±  1%   +36.21% (p=0.000 n=10)
Labels_Get/with_30_labels/middle_label/has-20       30.53n ± 0%    41.75n ±  1%   +36.75% (p=0.000 n=10)
Labels_Get/with_30_labels/last_label/get-20        106.55n ± 0%    71.17n ±  0%   -33.21% (p=0.000 n=10)
Labels_Get/with_30_labels/last_label/has-20        104.70n ± 0%    69.21n ±  1%   -33.90% (p=0.000 n=10)
Labels_Get/with_30_labels/not-found_label/get-20    3.976n ± 1%    4.772n ±  0%   +20.03% (p=0.000 n=10)
Labels_Get/with_30_labels/not-found_label/has-20    3.974n ± 0%    5.032n ±  0%   +26.64% (p=0.000 n=10)
Labels_Equals/equal-20                              2.382n ± 0%    2.446n ±  0%    +2.67% (p=0.000 n=10)
Labels_Equals/not_equal-20                         0.2741n ± 2%   0.2662n ±  2%    -2.88% (p=0.001 n=10)
Labels_Equals/different_sizes-20                   0.2762n ± 3%   0.2652n ±  0%    -3.95% (p=0.000 n=10)
Labels_Equals/lots-20                               2.381n ± 0%    2.386n ±  1%    +0.23% (p=0.011 n=10)
Labels_Equals/real_long_equal-20                    6.087n ± 1%    5.558n ±  1%    -8.70% (p=0.000 n=10)
Labels_Equals/real_long_different_end-20            5.030n ± 0%    4.699n ±  0%    -6.57% (p=0.000 n=10)
Labels_Compare/equal-20                             4.814n ± 1%    4.777n ±  0%    -0.77% (p=0.000 n=10)
Labels_Compare/not_equal-20                         17.55n ± 8%    20.92n ±  1%   +19.24% (p=0.000 n=10)
Labels_Compare/different_sizes-20                   3.711n ± 1%    3.707n ±  0%         ~ (p=0.224 n=10)
Labels_Compare/lots-20                              27.09n ± 3%    28.73n ±  2%    +6.05% (p=0.000 n=10)
Labels_Compare/real_long_equal-20                   27.91n ± 3%    15.67n ±  1%   -43.86% (p=0.000 n=10)
Labels_Compare/real_long_different_end-20           33.92n ± 1%    35.35n ±  1%    +4.22% (p=0.000 n=10)
Labels_Hash/typical_labels_under_1KB-20             59.63n ± 0%    59.67n ±  0%         ~ (p=0.897 n=10)
Labels_Hash/bigger_labels_over_1KB-20               73.42n ± 1%    73.81n ±  1%         ~ (p=0.342 n=10)
Labels_Hash/extremely_large_label_value_10MB-20     720.3µ ± 2%    715.2µ ±  3%         ~ (p=0.971 n=10)
Builder-20                                          371.6n ± 4%   1191.0n ±  3%  +220.46% (p=0.000 n=10)
Labels_Copy-20                                      85.52n ± 4%    53.90n ± 48%   -36.97% (p=0.000 n=10)
geomean                                             13.26n         14.68n         +10.71%

                                                 │   main.txt   │               new1.txt               │
                                                 │     B/op     │    B/op     vs base                  │
String-20                                          240.0 ± 0%     240.0 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/first_label/get-20        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/first_label/has-20        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/middle_label/get-20       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/middle_label/has-20       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/last_label/get-20         0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/last_label/has-20         0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/not-found_label/get-20    0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/not-found_label/has-20    0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/first_label/get-20       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/first_label/has-20       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/middle_label/get-20      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/middle_label/has-20      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/last_label/get-20        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/last_label/has-20        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/not-found_label/get-20   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/not-found_label/has-20   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/first_label/get-20       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/first_label/has-20       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/middle_label/get-20      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/middle_label/has-20      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/last_label/get-20        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/last_label/has-20        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/not-found_label/get-20   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/not-found_label/has-20   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Equals/equal-20                             0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Equals/not_equal-20                         0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Equals/different_sizes-20                   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Equals/lots-20                              0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Equals/real_long_equal-20                   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Equals/real_long_different_end-20           0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Compare/equal-20                            0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Compare/not_equal-20                        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Compare/different_sizes-20                  0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Compare/lots-20                             0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Compare/real_long_equal-20                  0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Compare/real_long_different_end-20          0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Hash/typical_labels_under_1KB-20            0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Hash/bigger_labels_over_1KB-20              0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Labels_Hash/extremely_large_label_value_10MB-20    0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Builder-20                                         224.0 ± 0%     192.0 ± 0%  -14.29% (p=0.000 n=10)
Labels_Copy-20                                     224.0 ± 0%     192.0 ± 0%  -14.29% (p=0.000 n=10)
geomean                                                       ²                -0.73%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                 │   main.txt   │              new1.txt               │
                                                 │  allocs/op   │ allocs/op   vs base                 │
String-20                                          1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/first_label/get-20        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/first_label/has-20        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/middle_label/get-20       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/middle_label/has-20       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/last_label/get-20         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/last_label/has-20         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/not-found_label/get-20    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_5_labels/not-found_label/has-20    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/first_label/get-20       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/first_label/has-20       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/middle_label/get-20      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/middle_label/has-20      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/last_label/get-20        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/last_label/has-20        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/not-found_label/get-20   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_10_labels/not-found_label/has-20   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/first_label/get-20       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/first_label/has-20       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/middle_label/get-20      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/middle_label/has-20      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/last_label/get-20        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/last_label/has-20        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/not-found_label/get-20   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Get/with_30_labels/not-found_label/has-20   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Equals/equal-20                             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Equals/not_equal-20                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Equals/different_sizes-20                   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Equals/lots-20                              0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Equals/real_long_equal-20                   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Equals/real_long_different_end-20           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Compare/equal-20                            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Compare/not_equal-20                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Compare/different_sizes-20                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Compare/lots-20                             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Compare/real_long_equal-20                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Compare/real_long_different_end-20          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Hash/typical_labels_under_1KB-20            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Hash/bigger_labels_over_1KB-20              0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Hash/extremely_large_label_value_10MB-20    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Builder-20                                         1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Labels_Copy-20                                     1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                       ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

</details>