### PR TITLE
mantine-ui: Fix navbar layout overflow in narrow desktop views.

### DIFF
--- a/web/ui/mantine-ui/src/App.tsx
+++ b/web/ui/mantine-ui/src/App.tsx
@@ -319,7 +319,7 @@ function App() {
                 width: 300,
                 // TODO: On pages with a long title like "/status", the navbar
                 // breaks in an ugly way for narrow windows. Fix this.
-                breakpoint: "sm",
+                breakpoint: "md",
                 collapsed: { desktop: true, mobile: !opened },
               }}
               padding="md"
@@ -342,7 +342,7 @@ function App() {
                             <Text fz={20}>Prometheus{agentMode && " Agent"}</Text>
                           </Group>
                         </Link>
-                        <Group gap={12} visibleFrom="sm" wrap="nowrap">
+                        <Group gap={12} visibleFrom="md" wrap="nowrap">
                           {navLinks}
                         </Group>
                       </Group>
@@ -353,7 +353,7 @@ function App() {
                     <Burger
                       opened={opened}
                       onClick={toggle}
-                      hiddenFrom="sm"
+                      hiddenFrom="md"
                       size="sm"
                       color="gray.2"
                     />


### PR DESCRIPTION
Adjusted navbar breakpoints to prevent nav links and action icons from overflowing.

![before](https://github.com/user-attachments/assets/f1b3e3bc-e84d-403d-b3c1-bacd3d0d576d)
--------------------------------------------------------------------
![after](https://github.com/user-attachments/assets/5d2b0d34-8a75-4209-8fa9-e14ab9b8a848)
