### PR TITLE
scrape: reorder the switch case of errors

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1962,6 +1962,10 @@ func isSeriesPartOfFamily(mName string, mfName []byte, typ model.MetricType) boo
 
 // Adds samples to the appender, checking the error, and then returns the # of samples added,
 // whether the caller should continue to process more samples, and any sample or bucket limit errors.
+// Switch error cases for Sample and Bucket limits are checked first since they're more common
+// during normal operation (e.g., accidental cardinality explosion, sudden traffic spikes).
+// Current case ordering prevents exercising other cases when limits are exceeded.
+// Remaining error cases typically occur only a few times, often during initial setup.
 func (sl *scrapeLoop) checkAddError(met []byte, err error, sampleLimitErr, bucketLimitErr *error, appErrs *appendErrors) (bool, error) {
 	switch {
 	case err == nil:


### PR DESCRIPTION
This PR changes the ordering in error identification switch cases for better production performance as described in [issue 13054](https://github.com/prometheus/prometheus/issues/13054).  
The reasoning changes are to bring sample and bucket limit errors in the switch to the very top of cases as these are most likely to be experienced in a working production environment (due to scale changes, increased traffic/load).  
Cases for out of order, out of bounds and duplicate samples are more often encountered during development/platform setup phases and should not be the first evaluated case.  
ErrNotFound has been moved to the bottom as it is the least encountered one.

Prometheus has been built succesfully and cases with `make test` and `make test-short` have been run succesfully (although with slightly downgraded lint packages for unrelated checks).

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
