### PR TITLE
[FEATURE] Promltest: support to test expectation annotations

### DIFF
--- a/promql/promqltest/README.md
+++ b/promql/promqltest/README.md
@@ -22,7 +22,9 @@ Each test file contains a series of commands. There are three kinds of commands:
 
 * `load`
 * `clear`
-* `eval` (including the variants `eval_fail`, `eval_warn`, `eval_info`, and `eval_ordered`)
+* `eval`
+
+> **Note:** The `eval` command variants (`eval_fail`, `eval_warn`, `eval_info`, and `eval_ordered`) are deprecated. Use the new `expect` lines instead (explained in the [`eval` command](#eval-command) section). Additionally, `expected_fail_message` and `expected_fail_regexp` are also deprecated.
 
 Each command is executed in the order given in the file.
 
@@ -73,8 +75,8 @@ When loading a batch of classic histogram float series, you can optionally appen
 
 ## `eval` command
 
-`eval` runs a query against the test environment and asserts that the result is as expected.
-It requires the query to succeed without any (info or warn) annotations.
+`eval` runs a query against the test environment and asserts that the result is as expected. 
+It requires the query to succeed without any failures.
 
 Both instant and range queries are supported.
 
@@ -83,12 +85,18 @@ The syntax is as follows:
 ```
 # Instant query
 eval instant at <time> <query>
+    <expect>
+    ...
+    <expect>
     <series> <points>
     ...
     <series> <points>
     
 # Range query
 eval range from <start> to <end> step <step> <query>
+    <expect>
+    ...
+    <expect>
     <series> <points>
     ...
     <series> <points>
@@ -96,45 +104,63 @@ eval range from <start> to <end> step <step> <query>
 
 * `<time>` is the timestamp to evaluate the instant query at (eg. `1m`)
 * `<start>` and `<end>` specify the time range of the range query, and use the same syntax as `<time>`
-* `<step>` is the step of the range query, and uses the same syntax as `<time>` (eg. `30s`)
+* `<step>` is the step of the range query, and uses the same syntax as `<time>` (eg. `30s`) 
+* `<expect>`(optional) specifies expected annotations, errors, or result ordering.
 * `<series>` and `<points>` specify the expected values, and follow the same syntax as for `load` above
+
+### `expect` Syntax
+
+```
+expect <type> <match_type> <string>
+```
+
+#### Parameters
+
+* `<type>` is the expectation type:
+    * `fail` expects the query to fail.
+    * `info` expects the query to return at least one info annotation.
+    * `warn` expects the query to return at least one warn annotation.
+    * `no_info` expects the query to return no info annotation.
+    * `no_warn` expects the query to return no warn annotation.
+    * `ordered`: expects the query to return the results in the specified order.
+* `<match_type>` (optional) specifies message matching type for annotations:
+    * `msg` for exact string match.
+    * `regex` for regular expression match.
+    * **Not applicable** for `ordered`, `no_info`, and `no_warn`.
+* `<string>`: Expected annotation message.
 
 For example:
 
 ```
 eval instant at 1m sum by (env) (my_metric)
+    expect warn
+    expect no_info
     {env="prod"} 5
     {env="test"} 20
     
 eval range from 0 to 3m step 1m sum by (env) (my_metric)
+    expect warn msg something went wrong
+    expect info regex something went (wrong|boom)
     {env="prod"} 2 5 10 20
     {env="test"} 10 20 30 45
+
+eval instant at 1m ceil({__name__=~'testmetric1|testmetric2'})
+expect fail
+
+eval instant at 1m ceil({__name__=~'testmetric1|testmetric2'})
+expect fail msg "vector cannot contain metrics with the same labelset"
+
+eval instant at 1m ceil({__name__=~'testmetric1|testmetric2'})
+expect fail regex "vector cannot contain metrics .*|something else went wrong"
+
+eval instant at 1m sum by (env) (my_metric)
+expect ordered
+{env="prod"} 5
+{env="test"} 20
 ```
 
-To assert that a query succeeds with an info or warn annotation, use the
-`eval_info` or `eval_warn` commands, respectively.
+There can be multiple `<expect>` lines for a given `<type>`. Each `<type>` validates its corresponding annotation, error, or ordering while ignoring others.
 
-Instant queries also support asserting that the series are returned in exactly
-the order specified: use `eval_ordered instant ...` instead of `eval instant
-...`. `eval_ordered` ignores any annotations. The assertion always fails for
-matrix results.
+Every `<expect>` line must match at least one corresponding annotation or error.
 
-To assert that a query fails, use the `eval_fail` command. `eval_fail` does not
-expect any result lines. Instead, it optionally accepts an expected error
-message string or regular expression to assert that the error message is as
-expected.
-
-For example:
-
-```
-# Assert that the query fails for any reason without asserting on the error message.
-eval_fail instant at 1m ceil({__name__=~'testmetric1|testmetric2'})
-
-# Assert that the query fails with exactly the provided error message string.
-eval_fail instant at 1m ceil({__name__=~'testmetric1|testmetric2'})
-    expected_fail_message vector cannot contain metrics with the same labelset
-
-# Assert that the query fails with an error message matching the regexp provided.
-eval_fail instant at 1m ceil({__name__=~'testmetric1|testmetric2'})
-    expected_fail_regexp (vector cannot contain metrics .*|something else went wrong)
-```
+If at least one `<expect>` line of a specific `<type>` is present, then all corresponding annotations must have a matching `expect` line.

--- a/promql/promqltest/README.md
+++ b/promql/promqltest/README.md
@@ -122,12 +122,12 @@ expect <type> <match_type> <string>
     * `warn` expects the query to return at least one warn annotation.
     * `no_info` expects the query to return no info annotation.
     * `no_warn` expects the query to return no warn annotation.
-    * `ordered`: expects the query to return the results in the specified order.
+    * `ordered` expects the query to return the results in the specified order.
 * `<match_type>` (optional) specifies message matching type for annotations:
     * `msg` for exact string match.
     * `regex` for regular expression match.
     * **Not applicable** for `ordered`, `no_info`, and `no_warn`.
-* `<string>`: Expected annotation message.
+* `<string>` is the expected annotation message.
 
 For example:
 

--- a/promql/promqltest/README.md
+++ b/promql/promqltest/README.md
@@ -76,7 +76,7 @@ When loading a batch of classic histogram float series, you can optionally appen
 ## `eval` command
 
 `eval` runs a query against the test environment and asserts that the result is as expected. 
-It requires the query to succeed without any failures.
+It requires the query to succeed without any failures unless an `expect fail` line is provided. Previously `eval` expected no `info` or `warn` annotation, but now `expect no_info` and `expect no_warn` lines must be explicitly provided.
 
 Both instant and range queries are supported.
 
@@ -163,4 +163,4 @@ There can be multiple `<expect>` lines for a given `<type>`. Each `<type>` valid
 
 Every `<expect>` line must match at least one corresponding annotation or error.
 
-If at least one `<expect>` line of a specific `<type>` is present, then all corresponding annotations must have a matching `expect` line.
+If at least one `<expect>` line of type `warn` or `info` is present, then all corresponding annotations must have a matching `expect` line.

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -52,6 +52,7 @@ var (
 	patEvalInstant = regexp.MustCompile(`^eval(?:_(fail|warn|ordered|info))?\s+instant\s+(?:at\s+(.+?))?\s+(.+)$`)
 	patEvalRange   = regexp.MustCompile(`^eval(?:_(fail|warn|info))?\s+range\s+from\s+(.+)\s+to\s+(.+)\s+step\s+(.+?)\s+(.+)$`)
 	patExpect      = regexp.MustCompile(`^expect\s+(ordered|fail|warn|no_warn|info|no_info)(?:\s+(regex|msg):(.+))?$`)
+	patMatchAny    = regexp.MustCompile(`^.*$`)
 )
 
 const (
@@ -275,7 +276,6 @@ func parseExpect(defLine string) (expectCmdType, expectCmd, error) {
 	var (
 		mode            = expectParts[1]
 		hasOptionalPart = expectParts[2] != ""
-		matchAnyRegex   = regexp.MustCompile(`^.*$`)
 	)
 	expectType, ok := expectTypeStr[mode]
 	if !ok {
@@ -296,7 +296,7 @@ func parseExpect(defLine string) (expectCmdType, expectCmd, error) {
 			return 0, expCmd, fmt.Errorf("invalid token %s after %s", expectParts[2], mode)
 		}
 	} else {
-		expCmd.regex = matchAnyRegex
+		expCmd.regex = patMatchAny
 	}
 	return expectType, expCmd, nil
 }
@@ -827,8 +827,6 @@ func validateExpectedAnnotations(expr string, expectedAnnotations []expectCmd, a
 func (ev *evalCmd) checkAnnotations(expr string, annos annotations.Annotations) error {
 	countWarnings, countInfo := annos.CountWarningsAndInfo()
 	switch {
-	case ev.ordered:
-		// Ignore annotations if testing for order.
 	case ev.warn && countWarnings == 0:
 		return fmt.Errorf("expected warnings evaluating query %q (line %d) but got none", expr, ev.line)
 	case ev.info && countInfo == 0:

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -271,7 +271,7 @@ func parseExpect(defLine string) (expectCmdType, expectCmd, error) {
 	expectParts := patExpect.FindStringSubmatch(strings.TrimSpace(defLine))
 	expCmd := expectCmd{}
 	if expectParts == nil {
-		return 0, expCmd, fmt.Errorf("invalid expect statement, must match `expect <type> <match_type> <string>` format")
+		return 0, expCmd, errors.New("invalid expect statement, must match `expect <type> <match_type> <string>` format")
 	}
 	var (
 		mode            = expectParts[1]
@@ -303,13 +303,13 @@ func parseExpect(defLine string) (expectCmdType, expectCmd, error) {
 
 func validateExpectedCmds(cmd *evalCmd) error {
 	if len(cmd.expectedCmds[Info]) > 0 && len(cmd.expectedCmds[NoInfo]) > 0 {
-		return fmt.Errorf("invalid expect lines, info and no_info cannot be used together")
+		return errors.New("invalid expect lines, info and no_info cannot be used together")
 	}
 	if len(cmd.expectedCmds[Warn]) > 0 && len(cmd.expectedCmds[NoWarn]) > 0 {
-		return fmt.Errorf("invalid expect lines, warn and no_warn cannot be used together")
+		return errors.New("invalid expect lines, warn and no_warn cannot be used together")
 	}
 	if len(cmd.expectedCmds[Fail]) > 1 {
-		return fmt.Errorf("invalid expect lines, multiple expect fail lines are not allowed")
+		return errors.New("invalid expect lines, multiple expect fail lines are not allowed")
 	}
 	return nil
 }
@@ -866,7 +866,7 @@ func (ev *evalCmd) checkAnnotations(expr string, annos annotations.Annotations) 
 		case errors.Is(err, annotations.PromQLInfo):
 			infos = append(infos, err.Error())
 		default:
-			return fmt.Errorf("actual annotation must be either info or warn")
+			return errors.New("actual annotation must be either info or warn")
 		}
 	}
 	if err := validateExpectedAnnotations(expr, ev.expectedCmds[Warn], warnings, ev.line, "warn"); err != nil {

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -266,7 +266,7 @@ func parseSeries(defLine string, line int) (labels.Labels, []parser.SequenceValu
 	return metric, vals, nil
 }
 
-func parseExpect(defLine string, i int) (expectCmdType, expectCmd, error) {
+func parseExpect(defLine string) (expectCmdType, expectCmd, error) {
 	expectParts := patExpect.FindStringSubmatch(strings.TrimSpace(defLine))
 	expCmd := expectCmd{}
 	if expectParts == nil {
@@ -415,7 +415,7 @@ func (t *test) parseEval(lines []string, i int) (int, *evalCmd, error) {
 
 		// This would still allow a metric named 'expect' if it is written as 'expect{}'.
 		if strings.Split(defLine, " ")[0] == "expect" {
-			annoType, expectedAnno, err := parseExpect(defLine, i)
+			annoType, expectedAnno, err := parseExpect(defLine)
 			if err != nil {
 				return i, nil, formatErr("%w", err)
 			}
@@ -804,9 +804,7 @@ func validateExpectedAnnotations(expr string, expectedAnnotations []expectCmd, a
 
 	// Check if all expected annotations are found in actual.
 	for _, e := range expectedAnnotations {
-		matchFound := slices.ContainsFunc(actualAnnotations, func(anno string) bool {
-			return e.CheckMatch(anno)
-		})
+		matchFound := slices.ContainsFunc(actualAnnotations, e.CheckMatch)
 		if !matchFound {
 			return fmt.Errorf("expected %s annotation %q but no matching annotation was found for query %q (line %d)", annotationType, e.String(), expr, line)
 		}

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -50,8 +50,8 @@ var (
 	patSpace        = regexp.MustCompile("[\t ]+")
 	patLoad         = regexp.MustCompile(`^load(?:_(with_nhcb))?\s+(.+?)$`)
 	patEvalInstant  = regexp.MustCompile(`^eval(?:_(fail|warn|ordered|info))?\s+instant\s+(?:at\s+(.+?))?\s+(.+)$`)
-	patEvalRange    = regexp.MustCompile(`^eval(?:_(fail|warn|info))?\s+range\s+from\s+(.+)\s+to\s+(.+)\s+step\s+(.+?)\s+(.+)$`)
-	patExpectedAnno = regexp.MustCompile(`^expect\s+(ordered|fail|warn|no_warn|info|no_info)(?:\s+(regex|msg):(.+))?$`)
+	patEvalRange = regexp.MustCompile(`^eval(?:_(fail|warn|info))?\s+range\s+from\s+(.+)\s+to\s+(.+)\s+step\s+(.+?)\s+(.+)$`)
+	patExpect    = regexp.MustCompile(`^expect\s+(ordered|fail|warn|no_warn|info|no_info)(?:\s+(regex|msg):(.+))?$`)
 )
 
 const (
@@ -267,9 +267,9 @@ func parseSeries(defLine string, line int) (labels.Labels, []parser.SequenceValu
 }
 
 func parseExpect(defLine string, i int) (expectCmdType, *expectCmd, error) {
-	expectParts := patExpectedAnno.FindStringSubmatch(strings.TrimSpace(defLine))
+	expectParts := patExpect.FindStringSubmatch(strings.TrimSpace(defLine))
 	if expectParts == nil {
-		return 0, nil, fmt.Errorf("invalid expect statement, must match `%s`", patExpectedAnno.String())
+		return 0, nil, fmt.Errorf("invalid expect statement, must match `%s`", patExpect.String())
 	}
 	var (
 		mode            = expectParts[1]

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -47,11 +47,11 @@ import (
 )
 
 var (
-	patSpace        = regexp.MustCompile("[\t ]+")
-	patLoad         = regexp.MustCompile(`^load(?:_(with_nhcb))?\s+(.+?)$`)
-	patEvalInstant  = regexp.MustCompile(`^eval(?:_(fail|warn|ordered|info))?\s+instant\s+(?:at\s+(.+?))?\s+(.+)$`)
-	patEvalRange = regexp.MustCompile(`^eval(?:_(fail|warn|info))?\s+range\s+from\s+(.+)\s+to\s+(.+)\s+step\s+(.+?)\s+(.+)$`)
-	patExpect    = regexp.MustCompile(`^expect\s+(ordered|fail|warn|no_warn|info|no_info)(?:\s+(regex|msg):(.+))?$`)
+	patSpace       = regexp.MustCompile("[\t ]+")
+	patLoad        = regexp.MustCompile(`^load(?:_(with_nhcb))?\s+(.+?)$`)
+	patEvalInstant = regexp.MustCompile(`^eval(?:_(fail|warn|ordered|info))?\s+instant\s+(?:at\s+(.+?))?\s+(.+)$`)
+	patEvalRange   = regexp.MustCompile(`^eval(?:_(fail|warn|info))?\s+range\s+from\s+(.+)\s+to\s+(.+)\s+step\s+(.+?)\s+(.+)$`)
+	patExpect      = regexp.MustCompile(`^expect\s+(ordered|fail|warn|no_warn|info|no_info)(?:\s+(regex|msg):(.+))?$`)
 )
 
 const (

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -275,14 +275,6 @@ func parseExpect(defLine string, i int) (expectCmdType, *expectCmd, error) {
 		mode            = expectParts[1]
 		hasOptionalPart = expectParts[2] != ""
 	)
-	var expectTypeStr = map[string]expectCmdType{
-		"fail":    Fail,
-		"ordered": Ordered,
-		"warn":    Warn,
-		"no_warn": NoWarn,
-		"info":    Info,
-		"no_info": NoInfo,
-	}
 	expectType, ok := expectTypeStr[mode]
 	if !ok {
 		return 0, nil, fmt.Errorf("invalid expected error/annotation type %s", mode)
@@ -723,6 +715,15 @@ const (
 	NoInfo
 )
 
+var expectTypeStr = map[string]expectCmdType{
+	"fail":    Fail,
+	"ordered": Ordered,
+	"warn":    Warn,
+	"no_warn": NoWarn,
+	"info":    Info,
+	"no_info": NoInfo,
+}
+
 type expectCmd struct {
 	message string
 	regex   *regexp.Regexp
@@ -731,17 +732,15 @@ type expectCmd struct {
 func (e *expectCmd) CheckMatch(str string) bool {
 	if e.regex == nil {
 		return e.message == str
-	} else {
-		return e.regex.MatchString(str)
 	}
+	return e.regex.MatchString(str)
 }
 
 func (e *expectCmd) String() string {
 	if e.regex == nil {
 		return e.message
-	} else {
-		return e.regex.String()
 	}
+	return e.regex.String()
 }
 
 type entry struct {

--- a/promql/promqltest/test_test.go
+++ b/promql/promqltest/test_test.go
@@ -637,6 +637,279 @@ eval range from 0 to 5m step 5m testmetric
 3 @[30000]
 3 @[60000]`,
 		},
+		"instant query expected to fail with specific error message, and query fails with that error (with new eval syntax)": {
+			input: `
+load 5m
+	testmetric1{src="a",dst="b"} 0
+	testmetric2{src="a",dst="b"} 1
+
+eval_fail instant at 0m ceil({__name__=~'testmetric1|testmetric2'})
+	expect fail msg: vector cannot contain metrics with the same labelset
+`,
+		},
+		"instant query expected to fail with specific error message, and query does not fail with that error (with new eval syntax)": {
+			input: `
+load 5m
+	testmetric1{src="a",dst="b"} 0
+	testmetric2{src="a",dst="b"} 1
+
+eval_fail instant at 0m ceil({__name__=~'testmetric1|testmetric2'})
+	expect fail msg: something went wrong
+`,
+			expectedError: `expected error matching "something went wrong" evaluating query "ceil({__name__=~'testmetric1|testmetric2'})" (line 6), but got: vector cannot contain metrics with the same labelset`,
+		},
+		"instant query expected to fail with specific error regex, and query fails with that error (with new eval syntax)": {
+			input: `
+load 5m
+	testmetric1{src="a",dst="b"} 0
+	testmetric2{src="a",dst="b"} 1
+
+eval_fail instant at 0m ceil({__name__=~'testmetric1|testmetric2'})
+	expect fail regex: .*labelset.*
+`,
+		},
+		"instant query expected to fail with specific error regex, and query does not fail with that error (with new eval syntax)": {
+			input: `
+load 5m
+	testmetric1{src="a",dst="b"} 0
+	testmetric2{src="a",dst="b"} 1
+
+eval_fail instant at 0m ceil({__name__=~'testmetric1|testmetric2'})
+	expect fail regex: something went (wrong|boom)
+`,
+			expectedError: `expected error matching "something went (wrong|boom)" evaluating query "ceil({__name__=~'testmetric1|testmetric2'})" (line 6), but got: vector cannot contain metrics with the same labelset`,
+		},
+		"instant query expected to only to fail (with new eval syntax)": {
+			input: `
+load 5m
+	testmetric1{src="a",dst="b"} 0
+	testmetric2{src="a",dst="b"} 1
+
+eval_fail instant at 0m ceil({__name__=~'testmetric1|testmetric2'})
+	expect fail
+`,
+		},
+		"invalid fail syntax with error as token instead of regex or msg(with new eval syntax)": {
+			input: `
+load 5m
+	testmetric1{src="a",dst="b"} 0
+	testmetric2{src="a",dst="b"} 1
+
+eval_fail instant at 0m ceil({__name__=~'testmetric1|testmetric2'})
+	expect fail error: something went wrong
+`,
+			expectedError: "error in eval ceil({__name__=~'testmetric1|testmetric2'}) (line 7): invalid expect statement, must match `^expect\\s+(ordered|fail|warn|no_warn|info|no_info)(?:\\s+(regex|msg):(.+))?$`",
+		},
+		"instant query expected not to care about annotations (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_warn instant at 0m sum(metric)
+`,
+		},
+		"instant query expected to only have warn annotation (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_warn instant at 0m sum(metric)
+	expect warn
+`,
+		},
+		"instant query expected to have warn annotation with specific message (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_warn instant at 0m sum(metric)
+	expect warn msg: PromQL warning: encountered a mix of histograms and floats for aggregation
+`,
+		},
+		"instant query expected to have warn but not with the specific message (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_warn instant at 0m sum(metric)
+	expect warn msg: PromQL warning: encountered a mix
+`,
+			expectedError: `expected warn annotation "PromQL warning: encountered a mix" but no matching annotation was found for query "sum(metric)" (line 6)`,
+		},
+		"instant query expected to have warn annotation with specific regex (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_warn instant at 0m sum(metric)
+	expect warn regex: PromQL warning: encountered a mix
+`,
+		},
+		"instant query expected to have warn but not with the specific regex (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_warn instant at 0m sum(metric)
+	expect warn regex: PromQL warning: something went (wrong|boom)
+`,
+			expectedError: `expected warn annotation "PromQL warning: something went (wrong|boom)" but no matching annotation was found for query "sum(metric)" (line 6)`,
+		},
+		"instant query expected to have warn annotation and no info annotation (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_warn instant at 0m sum(metric)
+	expect warn
+	expect no_info
+`,
+		},
+		"instant query expected to warn and info annotation but got only warn annotation (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_warn instant at 0m sum(metric)
+	expect warn
+	expect info
+`,
+			expectedError: `expected info annotations but none were found for query "sum(metric)" (line 6)`,
+		},
+		"instant query expected to have no warn but got warn annotation (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_warn instant at 0m sum(metric)
+	expect no_warn
+`,
+			expectedError: `unexpected warning annotations evaluating query "sum(metric)" (line 6): [PromQL warning: encountered a mix of histograms and floats for aggregation]`,
+		},
+		"instant query expected to only have info annotation (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_info instant at 0m min(metric)
+	expect info
+	{} 1
+`,
+		},
+		"instant query expected have info annotation with specific message (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_info instant at 0m min(metric)
+	expect info msg: PromQL info: ignored histogram in min aggregation
+	{} 1
+`,
+		},
+		"instant query expected to have info annotation but not with the specific message (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_info instant at 0m min(metric)
+	expect info msg: something went wrong
+	{} 1
+`,
+			expectedError: `expected info annotation "something went wrong" but no matching annotation was found for query "min(metric)" (line 6)`,
+		},
+		"instant query expected to have info annotation with specific regex (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_info instant at 0m min(metric)
+	expect info regex: PromQL info: ignored histogram
+	{} 1
+`,
+		},
+		"instant query expected to only have warn but not with the specific regex (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_info instant at 0m min(metric)
+	expect info regex: something went (wrong|boom)
+	{} 1
+`,
+			expectedError: `expected info annotation "something went (wrong|boom)" but no matching annotation was found for query "min(metric)" (line 6)`,
+		},
+		"instant query expected to have info annotation and no warn annotation (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_info instant at 0m min(metric)
+	expect info
+	expect no_warn
+	{} 1
+`,
+		},
+		"instant query expected to have warn and info annotation but got only info annotation (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_info instant at 0m min(metric)
+	expect info
+	expect warn
+	{} 1
+`,
+			expectedError: `expected warn annotations but none were found for query "min(metric)" (line 6)`,
+		},
+		"instant query expected to have no info annotation but got info annotation (with new eval syntax)": {
+			input: `
+load 5m
+	metric{src="a"} {{schema:0 sum:1 count:2}}
+	metric{src="b"} 1
+
+eval_info instant at 0m min(metric)
+	expect no_info
+	{} 1
+`,
+			expectedError: `unexpected info annotations evaluating query "min(metric)" (line 6): [PromQL info: ignored histogram in min aggregation]`,
+		},
+		"instant query with results expected to match provided order, and result is in expected order (with new eval syntax)": {
+			input: testData + `
+eval_ordered instant at 50m sort(http_requests)
+	expect ordered
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="canary", instance="1", job="api-server"} 400
+`,
+		},
+		"instant query with results expected to match provided order, but result is out of order (with new eval syntax)": {
+			input: testData + `
+eval_ordered instant at 50m sort(http_requests)
+	expect ordered
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="0", job="api-server"} 300
+`,
+			expectedError: `error in eval sort(http_requests) (line 10): expected metric {__name__="http_requests", group="canary", instance="0", job="api-server"} with [300.000000] at position 4 but was at 3`,
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/promql/promqltest/test_test.go
+++ b/promql/promqltest/test_test.go
@@ -374,6 +374,7 @@ eval_info instant at 50m sort(rate(http_requests[10m]))
 		"instant query with unexpected info annotation": {
 			input: testData + `
 eval instant at 50m sort(rate(http_requests[10m]))
+	expect no_info
 	{group="production", instance="0", job="api-server"} 0.03333333333333333
 	{group="production", instance="1", job="api-server"} 0.06666666666666667
 	{group="canary", instance="0", job="api-server"} 0.1


### PR DESCRIPTION
Resolves #15794 

This PR enhances the PromQL testing framework by allowing tests to check for expected annotations while keeping the existing syntax unchanged. Now, you can use `expect` lines to verify expected annotations. For example:  

```
eval instant at 10m ()
expect warn msg: something went wrong
```
For more details see: https://github.com/prometheus/prometheus/issues/15794#issuecomment-2577383092

CC: @beorn7 @charleskorn 
