### PR TITLE
Improve tick rendering

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/uPlotChartHelpers.ts
+++ b/web/ui/mantine-ui/src/pages/query/uPlotChartHelpers.ts
@@ -332,6 +332,7 @@ export const getUPlotOptions = (
   axes: [
     // X axis (time).
     {
+      space: 80,
       labelSize: 20,
       stroke: light ? "#333" : "#eee",
       ticks: {
@@ -343,6 +344,33 @@ export const getUPlotOptions = (
         width: 2,
         dash: [],
       },
+      values: [
+        // See https://github.com/leeoniya/uPlot/tree/master/docs#axis--grid-opts and https://github.com/leeoniya/uPlot/issues/83.
+        //
+        // We want to achieve 24h-based time formatting instead of the default AM/PM-based time formatting.
+        // We also want to render dates in an unambiguous format that uses the abbreviated month name instead of a US-centric DD/MM/YYYY format.
+        //
+        // The "tick incr" column defines the breakpoint in seconds at which the format changes.
+        // The "default" column defines the default format for a tick at this breakpoint.
+        // The "year"/"month"/"day"/"hour"/"min"/"sec" columns define additional values to display for year/month/day/... rollovers occurring around a tick.
+        // The "mode" column value "1" means that rollover values will be concatenated with the default format (instead of replacing it).
+        //
+        // tick incr        default                  year                  month  day             hour   min    sec    mode
+        // prettier-ignore
+        [3600 * 24 * 365,   "{YYYY}",                null,                 null,  null,           null,  null,  null,     1],
+        // prettier-ignore
+        [3600 * 24 * 28,    "{MMM}",                 "\n{YYYY}",           null,  null,           null,  null,  null,     1],
+        // prettier-ignore
+        [3600 * 24,         "{MMM} {D}",             "\n{YYYY}",           null,  null,           null,  null,  null,     1],
+        // prettier-ignore
+        [3600,              "{HH}:{mm}",             "\n{MMM} {D} '{YY}",  null,  "\n{MMM} {D}",  null,  null,  null,     1],
+        // prettier-ignore
+        [60,                "{HH}:{mm}",             "\n{MMM} {D} '{YY}",  null,  "\n{MMM} {D}",  null,  null,  null,     1],
+        // prettier-ignore
+        [1,                 "{HH}:{mm}:{ss}",        "\n{MMM} {D} '{YY}",  null,  "\n{MMM} {D}",  null,  null,  null,     1],
+        // prettier-ignore
+        [0.001,             "{HH}:{mm}:{ss}.{fff}",  "\n{MMM} {D} '{YY}",  null,  "\n{MMM} {D}",  null,  null,  null,     1],
+      ],
     },
     // Y axis (sample value).
     {
@@ -382,7 +410,10 @@ export const getUPlotOptions = (
       (self: uPlot) => {
         // Disallow sub-second zoom as this cause inconsistenices in the X axis in uPlot.
         const leftVal = self.posToVal(self.select.left, "x");
-        const rightVal = Math.max(self.posToVal(self.select.left + self.select.width, "x"), leftVal + 1);
+        const rightVal = Math.max(
+          self.posToVal(self.select.left + self.select.width, "x"),
+          leftVal + 1
+        );
 
         onSelectRange(leftVal, rightVal);
       },


### PR DESCRIPTION
Move to 24h-based time formatting and unambiguous date formats. Also add more details to the default formatting of each tick instead of only showing e.g. minutes/seconds at rollover ticks for the shorter breakpoints.

Fixes https://github.com/prometheus/prometheus/issues/15913

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
