### PR TITLE
util/httputil: reduces heap allocations in newCompressedResponseWriter

### DIFF
--- a/util/httputil/compression.go
+++ b/util/httputil/compression.go
@@ -56,8 +56,13 @@ func (c *compressedResponseWriter) Close() {
 
 // Constructs a new compressedResponseWriter based on client request headers.
 func newCompressedResponseWriter(writer http.ResponseWriter, req *http.Request) *compressedResponseWriter {
-	encodings := strings.Split(req.Header.Get(acceptEncodingHeader), ",")
-	for _, encoding := range encodings {
+	raw := req.Header.Get(acceptEncodingHeader)
+	var (
+		encoding   string
+		commaFound bool
+	)
+	for {
+		encoding, raw, commaFound = strings.Cut(raw, ",")
 		switch strings.TrimSpace(encoding) {
 		case gzipEncoding:
 			writer.Header().Set(contentEncodingHeader, gzipEncoding)
@@ -71,6 +76,9 @@ func newCompressedResponseWriter(writer http.ResponseWriter, req *http.Request) 
 				ResponseWriter: writer,
 				writer:         zlib.NewWriter(writer),
 			}
+		}
+		if !commaFound {
+			break
 		}
 	}
 	return &compressedResponseWriter{

--- a/util/httputil/compression_test.go
+++ b/util/httputil/compression_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/klauspost/compress/gzip"
@@ -70,6 +71,17 @@ func TestCompressionHandler_PlainText(t *testing.T) {
 	expected := "Hello World!"
 	actual := string(contents)
 	require.Equal(t, expected, actual, "expected response with content")
+}
+
+func BenchmarkNewCompressionHandler_MaliciousAcceptEncoding(b *testing.B) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+	req.Header.Set("Accept-Encoding", strings.Repeat(",", http.DefaultMaxHeaderBytes))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		newCompressedResponseWriter(rec, req)
+	}
 }
 
 func TestCompressionHandler_Gzip(t *testing.T) {


### PR DESCRIPTION
`newCompressedResponseWriter` currently calls [strings.Split](https://pkg.go.dev/strings#Split) on the value of request's _Accept-Encoding_ header, which is untrusted data. As a result, in the face of a malicious request whose _Accept-Encoding_ header is full of commas, the handler in question allocates O(n) bytes (where n stands for the length of the request's _Accept-Encoding_ value), with a constant factor of about 16. Relevant weakness: [CWE-405: Asymmetric Resource Consumption (Amplification)](https://cwe.mitre.org/data/definitions/405.html)

With this change, `newCompressedResponseWriter` allocates O(1) bytes even in the face of such malicious requests.

---

Running the benchmark:

```shell
git checkout 827f47f466aad632e7037c0b6d52099fa8a7f33a
go test -benchmem -run=^$ -count 10 -bench '^BenchmarkNewCompressionHandler_MaliciousAcceptEncoding$' github.com/prometheus/prometheus/util/httputil > new
git checkout f72a58a218161bd1061c1ccc7fae513616d4a75a
go test -benchmem -run=^$ -count 10 -bench '^BenchmarkNewCompressionHandler_MaliciousAcceptEncoding$' github.com/prometheus/prometheus/util/httputil > old
benchstat old new
```

Some results:

```txt
goos: darwin
goarch: amd64
pkg: github.com/prometheus/prometheus/util/httputil
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
                                                │     old     │                 new                 │
                                                │   sec/op    │   sec/op     vs base                │
NewCompressionHandler_MaliciousAcceptEncoding-8   18.60m ± 2%   13.54m ± 3%  -27.17% (p=0.000 n=10)

                                                │       old        │                 new                 │
                                                │       B/op       │    B/op     vs base                 │
NewCompressionHandler_MaliciousAcceptEncoding-8   16785442.50 ± 0%   32.00 ± 0%  -100.00% (p=0.000 n=10)

                                                │    old     │                new                 │
                                                │ allocs/op  │ allocs/op   vs base                │
NewCompressionHandler_MaliciousAcceptEncoding-8   2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)

```