### PR TITLE
chore: enable early-return from revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -126,6 +126,9 @@ linters-settings:
           - allowTypesBefore: "*testing.T,testing.TB"
       - name: context-keys-type
       - name: dot-imports
+      - name: early-return
+        arguments:
+          - "preserveScope"
       # A lot of false positives: incorrectly identifies channel draining as "empty code block".
       # See https://github.com/mgechev/revive/issues/386
       - name: empty-block
@@ -137,6 +140,8 @@ linters-settings:
       - name: exported
       - name: increment-decrement
       - name: indent-error-flow
+        arguments:
+          - "preserveScope"
       - name: package-comments
         # TODO(beorn7): Currently, we have a lot of missing package doc comments. Maybe we should have them.
         disabled: true
@@ -144,6 +149,8 @@ linters-settings:
       - name: receiver-naming
       - name: redefines-builtin-id
       - name: superfluous-else
+        arguments:
+          - "preserveScope"
       - name: time-naming
       - name: unexported-return
       - name: unreachable-code

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -458,11 +458,10 @@ func (d *Discovery) vmToLabelSet(ctx context.Context, client client, vm virtualM
 				networkInterface, err = client.getVMScaleSetVMNetworkInterfaceByID(ctx, nicID, vm.ScaleSet, vm.InstanceID)
 			}
 			if err != nil {
-				if errors.Is(err, errorNotFound) {
-					d.logger.Warn("Network interface does not exist", "name", nicID, "err", err)
-				} else {
+				if !errors.Is(err, errorNotFound) {
 					return nil, err
 				}
+				d.logger.Warn("Network interface does not exist", "name", nicID, "err", err)
 				// Get out of this routine because we cannot continue without a network interface.
 				return nil, nil
 			}

--- a/discovery/linode/linode.go
+++ b/discovery/linode/linode.go
@@ -194,13 +194,12 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		events, err := d.client.ListEvents(ctx, &eventsOpts)
 		if err != nil {
 			var e *linodego.Error
-			if errors.As(err, &e) && e.Code == http.StatusUnauthorized {
-				// If we get a 401, the token doesn't have `events:read_only` scope.
-				// Disable event polling and fallback to doing a full refresh every interval.
-				d.eventPollingEnabled = false
-			} else {
+			if !(errors.As(err, &e) && e.Code == http.StatusUnauthorized) {
 				return nil, err
 			}
+			// If we get a 401, the token doesn't have `events:read_only` scope.
+			// Disable event polling and fallback to doing a full refresh every interval.
+			d.eventPollingEnabled = false
 		} else {
 			// Event polling tells us changes the Linode API is aware of. Actions issued outside of the Linode API,
 			// such as issuing a `shutdown` at the VM's console instead of using the API to power off an instance,

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -101,12 +101,12 @@ func NewManager(ctx context.Context, logger *slog.Logger, registerer prometheus.
 
 	// Register the metrics.
 	// We have to do this after setting all options, so that the name of the Manager is set.
-	if metrics, err := NewManagerMetrics(registerer, mgr.name); err == nil {
-		mgr.metrics = metrics
-	} else {
+	metrics, err := NewManagerMetrics(registerer, mgr.name)
+	if err != nil {
 		logger.Error("Failed to create discovery manager metrics", "manager", mgr.name, "err", err)
 		return nil
 	}
+	mgr.metrics = metrics
 
 	return mgr
 }

--- a/discovery/moby/docker.go
+++ b/discovery/moby/docker.go
@@ -237,17 +237,16 @@ func (d *DockerDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 		if len(networks) == 0 {
 			// Try to lookup shared networks
 			for {
-				if containerNetworkMode.IsContainer() {
-					tmpContainer, exists := allContainers[containerNetworkMode.ConnectedContainer()]
-					if !exists {
-						break
-					}
-					networks = tmpContainer.NetworkSettings.Networks
-					containerNetworkMode = container.NetworkMode(tmpContainer.HostConfig.NetworkMode)
-					if len(networks) > 0 {
-						break
-					}
-				} else {
+				if !containerNetworkMode.IsContainer() {
+					break
+				}
+				tmpContainer, exists := allContainers[containerNetworkMode.ConnectedContainer()]
+				if !exists {
+					break
+				}
+				networks = tmpContainer.NetworkSettings.Networks
+				containerNetworkMode = container.NetworkMode(tmpContainer.HostConfig.NetworkMode)
+				if len(networks) > 0 {
 					break
 				}
 			}

--- a/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
@@ -288,11 +288,11 @@ func valuesToSamples(timestamp time.Time, value interface{}) (prompb.Sample, err
 	var valueInt64 int64
 	var ok bool
 	if valueFloat64, ok = value.(float64); !ok {
-		if valueInt64, ok = value.(int64); ok {
-			valueFloat64 = float64(valueInt64)
-		} else {
+		valueInt64, ok = value.(int64)
+		if !ok {
 			return prompb.Sample{}, fmt.Errorf("unable to convert sample value to float64: %v", value)
 		}
+		valueFloat64 = float64(valueInt64)
 	}
 
 	return prompb.Sample{

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3553,11 +3553,11 @@ func formatDate(t time.Time) string {
 // unwrapParenExpr does the AST equivalent of removing parentheses around a expression.
 func unwrapParenExpr(e *parser.Expr) {
 	for {
-		if p, ok := (*e).(*parser.ParenExpr); ok {
-			*e = p.Expr
-		} else {
+		p, ok := (*e).(*parser.ParenExpr)
+		if !ok {
 			break
 		}
+		*e = p.Expr
 	}
 }
 

--- a/storage/remote/azuread/azuread.go
+++ b/storage/remote/azuread/azuread.go
@@ -349,11 +349,10 @@ func (tokenProvider *tokenProvider) getToken(ctx context.Context) error {
 func (tokenProvider *tokenProvider) updateRefreshTime(accessToken azcore.AccessToken) error {
 	tokenExpiryTimestamp := accessToken.ExpiresOn.UTC()
 	deltaExpirytime := time.Now().Add(time.Until(tokenExpiryTimestamp) / 2)
-	if deltaExpirytime.After(time.Now().UTC()) {
-		tokenProvider.refreshTime = deltaExpirytime
-	} else {
+	if !deltaExpirytime.After(time.Now().UTC()) {
 		return errors.New("access token expiry is less than the current time")
 	}
+	tokenProvider.refreshTime = deltaExpirytime
 	return nil
 }
 

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -1026,12 +1026,11 @@ func (a *appender) AppendHistogramCTZeroSample(ref storage.SeriesRef, l labels.L
 		return 0, storage.ErrOutOfOrderCT
 	}
 
-	if ct > series.lastTs {
-		series.lastTs = ct
-	} else {
+	if ct <= series.lastTs {
 		// discard the sample if it's out of order.
 		return 0, storage.ErrOutOfOrderCT
 	}
+	series.lastTs = ct
 
 	switch {
 	case h != nil:
@@ -1091,12 +1090,11 @@ func (a *appender) AppendCTZeroSample(ref storage.SeriesRef, l labels.Labels, t,
 		return 0, storage.ErrOutOfOrderSample
 	}
 
-	if ct > series.lastTs {
-		series.lastTs = ct
-	} else {
+	if ct <= series.lastTs {
 		// discard the sample if it's out of order.
 		return 0, storage.ErrOutOfOrderCT
 	}
+	series.lastTs = ct
 
 	// NOTE: always modify pendingSamples and sampleSeries together.
 	a.pendingSamples = append(a.pendingSamples, record.RefSample{

--- a/tsdb/isolation.go
+++ b/tsdb/isolation.go
@@ -275,12 +275,11 @@ func (txr *txRing) cleanupAppendIDsBelow(bound uint64) {
 	pos := int(txr.txIDFirst)
 
 	for txr.txIDCount > 0 {
-		if txr.txIDs[pos] < bound {
-			txr.txIDFirst++
-			txr.txIDCount--
-		} else {
+		if txr.txIDs[pos] >= bound {
 			break
 		}
+		txr.txIDFirst++
+		txr.txIDCount--
 
 		pos++
 		if pos == len(txr.txIDs) {


### PR DESCRIPTION
#### Description

[early-return](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return): In Go it is idiomatic to minimize nesting statements, a typical example is to avoid if-then-else constructions.