### PR TITLE
util/httputil: Always add Vary header in SetCORS (fixes #15406)

### DIFF
--- a/util/httputil/cors.go
+++ b/util/httputil/cors.go
@@ -20,14 +20,14 @@ import (
 )
 
 var corsHeaders = map[string]string{
-	"Access-Control-Allow-Headers":  "Accept, Authorization, Content-Type, Origin",
+	"Access-Control-Allow-Headers":  "Accept, Authorization, Content-Type",
 	"Access-Control-Allow-Methods":  "GET, POST, OPTIONS",
 	"Access-Control-Expose-Headers": "Date",
-	"Vary":                          "Origin",
 }
 
-// SetCORS enables cross-site script calls.
+// SetCORS enables cross-origin script calls.
 func SetCORS(w http.ResponseWriter, o *regexp.Regexp, r *http.Request) {
+	w.Header().Add("Vary", "Origin")
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		return

--- a/util/httputil/cors_test.go
+++ b/util/httputil/cors_test.go
@@ -48,8 +48,10 @@ func TestCORSHandler(t *testing.T) {
 	resp, err := client.Do(req)
 	require.NoError(t, err, "client get failed with unexpected error")
 
-	AccessControlAllowOrigin := resp.Header.Get("Access-Control-Allow-Origin")
+	Vary := resp.Header.Get("Vary")
+	require.Equal(t, "Origin", Vary, `expected "Vary: Origin" header`)
 
+	AccessControlAllowOrigin := resp.Header.Get("Access-Control-Allow-Origin")
 	require.Equal(t, dummyOrigin, AccessControlAllowOrigin, "expected Access-Control-Allow-Origin header")
 
 	// OPTIONS with bad origin
@@ -59,6 +61,22 @@ func TestCORSHandler(t *testing.T) {
 	req.Header.Set("Origin", "https://not-foo.com")
 	resp, err = client.Do(req)
 	require.NoError(t, err, "client get failed with unexpected error")
+
+	AccessControlAllowOrigin = resp.Header.Get("Access-Control-Allow-Origin")
+	require.Empty(t, AccessControlAllowOrigin, "Access-Control-Allow-Origin header should not exist but it was set")
+
+	Vary = resp.Header.Get("Vary")
+	require.Equal(t, "Origin", Vary, `expected "Vary: Origin" header`)
+
+	// OPTIONS with no origin
+	req, err = http.NewRequest(http.MethodOptions, server.URL+"/any_path", nil)
+	require.NoError(t, err, "could not create request")
+
+	resp, err = client.Do(req)
+	require.NoError(t, err, "client get failed with unexpected error")
+
+	Vary = resp.Header.Get("Vary")
+	require.Equal(t, "Origin", Vary, `expected "Vary: Origin" header`)
 
 	AccessControlAllowOrigin = resp.Header.Get("Access-Control-Allow-Origin")
 	require.Empty(t, AccessControlAllowOrigin, "Access-Control-Allow-Origin header should not exist but it was set")


### PR DESCRIPTION
Closes #15406

Also, drop Origin from the Access-Control-Allow-Headers response header; see https://fetch.spec.whatwg.org/#forbidden-request-header.