### PR TITLE
model/textparse: Change parser interface Metric(...) string to Labels(...)

### DIFF
--- a/cmd/promtool/backfill.go
+++ b/cmd/promtool/backfill.go
@@ -149,7 +149,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				_, ts, v := p.Series()
 				if ts == nil {
 					l := labels.Labels{}
-					p.Metric(&l)
+					p.Labels(&l)
 					return fmt.Errorf("expected timestamp for series %v, got none", l)
 				}
 				if *ts < t {
@@ -163,7 +163,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				}
 
 				l := labels.Labels{}
-				p.Metric(&l)
+				p.Labels(&l)
 
 				lb.Reset(l)
 				for name, value := range customLabels {

--- a/model/textparse/benchmark_test.go
+++ b/model/textparse/benchmark_test.go
@@ -203,7 +203,7 @@ func benchParse(b *testing.B, data []byte, parser string) {
 				b.Fatal("not implemented entry", t)
 			}
 
-			_ = p.Metric(&res)
+			p.Labels(&res)
 			_ = p.CreatedTimestamp()
 			for hasExemplar := p.Exemplar(&e); hasExemplar; hasExemplar = p.Exemplar(&e) {
 			}

--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -57,11 +57,10 @@ type Parser interface {
 	// The returned byte slice becomes invalid after the next call to Next.
 	Comment() []byte
 
-	// Metric writes the labels of the current sample into the passed labels.
-	// It returns the string from which the metric was parsed.
+	// Labels writes the labels of the current sample into the passed labels.
 	// The values of the "le" labels of classic histograms and "quantile" labels
 	// of summaries should follow the OpenMetrics formatting rules.
-	Metric(l *labels.Labels) string
+	Labels(l *labels.Labels)
 
 	// Exemplar writes the exemplar of the current sample into the passed
 	// exemplar. It can be called repeatedly to retrieve multiple exemplars

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -238,7 +238,7 @@ func testParse(t *testing.T, p Parser) (ret []parsedEntry) {
 				got.m = string(m)
 			}
 
-			p.Metric(&got.lset)
+			p.Labels(&got.lset)
 			// Parser reuses int pointer.
 			if ct := p.CreatedTimestamp(); ct != nil {
 				got.ct = int64p(*ct)

--- a/model/textparse/nhcbparse.go
+++ b/model/textparse/nhcbparse.go
@@ -67,8 +67,7 @@ type NHCBParser struct {
 	h     *histogram.Histogram
 	fh    *histogram.FloatHistogram
 	// For Metric.
-	lset         labels.Labels
-	metricString string
+	lset labels.Labels
 	// For Type.
 	bName []byte
 	typ   model.MetricType
@@ -141,13 +140,12 @@ func (p *NHCBParser) Comment() []byte {
 	return p.parser.Comment()
 }
 
-func (p *NHCBParser) Metric(l *labels.Labels) string {
+func (p *NHCBParser) Labels(l *labels.Labels) {
 	if p.state == stateEmitting {
 		*l = p.lsetNHCB
-		return p.metricStringNHCB
+		return
 	}
 	*l = p.lset
-	return p.metricString
 }
 
 func (p *NHCBParser) Exemplar(ex *exemplar.Exemplar) bool {
@@ -200,7 +198,7 @@ func (p *NHCBParser) Next() (Entry, error) {
 		switch p.entry {
 		case EntrySeries:
 			p.bytes, p.ts, p.value = p.parser.Series()
-			p.metricString = p.parser.Metric(&p.lset)
+			p.parser.Labels(&p.lset)
 			// Check the label set to see if we can continue or need to emit the NHCB.
 			var isNHCB bool
 			if p.compareLabels() {
@@ -224,7 +222,7 @@ func (p *NHCBParser) Next() (Entry, error) {
 			return p.entry, p.err
 		case EntryHistogram:
 			p.bytes, p.ts, p.h, p.fh = p.parser.Histogram()
-			p.metricString = p.parser.Metric(&p.lset)
+			p.parser.Labels(&p.lset)
 			p.storeExponentialLabels()
 		case EntryType:
 			p.bName, p.typ = p.parser.Type()

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -198,10 +198,8 @@ func (p *OpenMetricsParser) Comment() []byte {
 }
 
 // Labels writes the labels of the current sample into the passed labels.
-// It returns the string from which the metric was parsed.
 func (p *OpenMetricsParser) Labels(l *labels.Labels) {
-	// Copy the buffer to a string: this is only necessary for the return value.
-	s := string(p.series)
+	s := yoloString(p.series)
 
 	p.builder.Reset()
 	metricName := unreplace(s[p.offsets[0]-p.start : p.offsets[1]-p.start])

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -197,9 +197,9 @@ func (p *OpenMetricsParser) Comment() []byte {
 	return p.text
 }
 
-// Metric writes the labels of the current sample into the passed labels.
+// Labels writes the labels of the current sample into the passed labels.
 // It returns the string from which the metric was parsed.
-func (p *OpenMetricsParser) Metric(l *labels.Labels) string {
+func (p *OpenMetricsParser) Labels(l *labels.Labels) {
 	// Copy the buffer to a string: this is only necessary for the return value.
 	s := string(p.series)
 
@@ -220,8 +220,6 @@ func (p *OpenMetricsParser) Metric(l *labels.Labels) string {
 
 	p.builder.Sort()
 	*l = p.builder.Labels()
-
-	return s
 }
 
 // Exemplar writes the exemplar of the current sample into the passed exemplar.

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -223,9 +223,9 @@ func (p *PromParser) Comment() []byte {
 	return p.text
 }
 
-// Metric writes the labels of the current sample into the passed labels.
+// Labels writes the labels of the current sample into the passed labels.
 // It returns the string from which the metric was parsed.
-func (p *PromParser) Metric(l *labels.Labels) string {
+func (p *PromParser) Labels(l *labels.Labels) {
 	// Copy the buffer to a string: this is only necessary for the return value.
 	s := string(p.series)
 
@@ -246,8 +246,6 @@ func (p *PromParser) Metric(l *labels.Labels) string {
 
 	p.builder.Sort()
 	*l = p.builder.Labels()
-
-	return s
 }
 
 // Exemplar implements the Parser interface. However, since the classic

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -224,10 +224,8 @@ func (p *PromParser) Comment() []byte {
 }
 
 // Labels writes the labels of the current sample into the passed labels.
-// It returns the string from which the metric was parsed.
 func (p *PromParser) Labels(l *labels.Labels) {
-	// Copy the buffer to a string: this is only necessary for the return value.
-	s := string(p.series)
+	s := yoloString(p.series)
 
 	p.builder.Reset()
 	metricName := unreplace(s[p.offsets[0]-p.start : p.offsets[1]-p.start])

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -296,9 +296,9 @@ func (p *ProtobufParser) Comment() []byte {
 	return nil
 }
 
-// Metric writes the labels of the current sample into the passed labels.
+// Labels writes the labels of the current sample into the passed labels.
 // It returns the string from which the metric was parsed.
-func (p *ProtobufParser) Metric(l *labels.Labels) string {
+func (p *ProtobufParser) Labels(l *labels.Labels) {
 	p.builder.Reset()
 	p.builder.Add(labels.MetricName, p.getMagicName())
 
@@ -312,8 +312,6 @@ func (p *ProtobufParser) Metric(l *labels.Labels) string {
 	// Sort labels to maintain the sorted labels invariant.
 	p.builder.Sort()
 	*l = p.builder.Labels()
-
-	return p.metricBytes.String()
 }
 
 // Exemplar writes the exemplar of the current sample into the passed

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1714,7 +1714,7 @@ loop:
 			lset = ce.lset
 			hash = ce.hash
 		} else {
-			p.Metric(&lset)
+			p.Labels(&lset)
 			hash = lset.Hash()
 
 			// Hash label set as it is seen local to the target. Then add target labels

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1988,7 +1988,7 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 
 	var lset labels.Labels
 	p.Next()
-	p.Metric(&lset)
+	p.Labels(&lset)
 	hash := lset.Hash()
 
 	// Create a fake entry in the cache

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -403,7 +403,7 @@ func TestFederationWithNativeHistograms(t *testing.T) {
 		}
 		require.NoError(t, err)
 		if et == textparse.EntryHistogram || et == textparse.EntrySeries {
-			p.Metric(&l)
+			p.Labels(&l)
 		}
 		switch et {
 		case textparse.EntryHelp:


### PR DESCRIPTION
Simplified the interface given no one is using the return argument. Renamed for clarity too.

Found and discussed https://github.com/prometheus/prometheus/pull/15731#discussion_r1950916842

This is a breaking change for downstream users. We are planning more changes too for efficiency.