### PR TITLE
promql: emit correct annotation in `quantile_over_time` when run over a range with histograms and floats

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -922,7 +922,7 @@ func funcQuantileOverTime(vals []parser.Value, args parser.Expressions, enh *Eva
 	}
 	if len(el.Histograms) > 0 {
 		metricName := el.Metric.Get(labels.MetricName)
-		annos.Add(annotations.NewHistogramIgnoredInAggregationInfo(metricName, args[0].PositionRange()))
+		annos.Add(annotations.NewHistogramIgnoredInMixedRangeInfo(metricName, args[0].PositionRange()))
 	}
 	values := make(vectorByValueHeap, 0, len(el.Floats))
 	for _, f := range el.Floats {


### PR DESCRIPTION
When `quantile_over_time` is run over a range that contains both histograms and floats, it currently emits an annotation like `PromQL info: ignored histogram in some_metric aggregation (1:20)`.

However, this is potentially confusing: `quantile_over_time` is not an aggregation. This is also different to the annotation emitted by other functions over range vectors in this scenario, such as `stddev_over_time` and `stdvar_over_time`. These functions emit an annotation like `PromQL info: ignored histograms in a range containing both floats and histograms for metric name "some_metric" (1:20)`.

This PR changes the behaviour of `quantile_over_time` to make it consistent with the other functions.

The original annotation behaviour was introduced in https://github.com/prometheus/prometheus/pull/15711.