### PR TITLE
set ttlAutopurge to true as ttl is set for codemirror prometheus client cache

### DIFF
--- a/web/ui/module/codemirror-promql/src/client/prometheus.ts
+++ b/web/ui/module/codemirror-promql/src/client/prometheus.ts
@@ -294,7 +294,7 @@ class Cache {
   constructor(config?: CacheConfig) {
     const maxAge = {
       ttl: config && config.maxAge ? config.maxAge : 5 * 60 * 1000,
-      ttlAutopurge: false,
+      ttlAutopurge: true,
     };
     this.completeAssociation = new LRUCache<string, Map<string, Set<string>>>(maxAge);
     this.metricMetadata = {};


### PR DESCRIPTION
This PR sets the `ttlAutopurge` option to `true` as a `ttl` is provided. Follows the lru-cache documentation:  https://github.com/isaacs/node-lru-cache/blob/65c9971e3fef123ff0f17d67add53b2d99b461b0/src/index.ts#L698

Fixes #16023 