### PR TITLE
[EXPERIMENT] Add type and unit labels in scrape loop.

### DIFF
--- a/model/labels/labels_common.go
+++ b/model/labels/labels_common.go
@@ -25,6 +25,8 @@ import (
 
 const (
 	MetricName   = "__name__"
+	MetricType   = "__type__"
+	MetricUnit   = "__unit__"
 	AlertName    = "alertname"
 	BucketLabel  = "le"
 	InstanceName = "instance"

--- a/model/textparse/interface.go
+++ b/model/textparse/interface.go
@@ -57,11 +57,8 @@ type Parser interface {
 	// The returned byte slice becomes invalid after the next call to Next.
 	Comment() []byte
 
-	// Metric writes the labels of the current sample into the passed labels.
-	// It returns the string from which the metric was parsed.
-	// The values of the "le" labels of classic histograms and "quantile" labels
-	// of summaries should follow the OpenMetrics formatting rules.
-	Metric(l *labels.Labels) string
+	// PopulateLabelsAndName uses provided builder to add labels and metric name.
+	PopulateLabelsAndName(l *labels.ScratchBuilder)
 
 	// Exemplar writes the exemplar of the current sample into the passed
 	// exemplar. It can be called repeatedly to retrieve multiple exemplars

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -217,6 +217,7 @@ func requireEntries(t *testing.T, exp, got []parsedEntry) {
 func testParse(t *testing.T, p Parser) (ret []parsedEntry) {
 	t.Helper()
 
+	lsetBuilder := labels.NewScratchBuilder(0)
 	for {
 		et, err := p.Next()
 		if errors.Is(err, io.EOF) {
@@ -238,7 +239,11 @@ func testParse(t *testing.T, p Parser) (ret []parsedEntry) {
 				got.m = string(m)
 			}
 
-			p.Metric(&got.lset)
+			lsetBuilder.Reset()
+			p.PopulateLabelsAndName(&lsetBuilder)
+			lsetBuilder.Sort()
+			got.lset = lsetBuilder.Labels()
+
 			// Parser reuses int pointer.
 			if ct := p.CreatedTimestamp(); ct != nil {
 				got.ct = int64p(*ct)

--- a/model/textparse/nhcbparse.go
+++ b/model/textparse/nhcbparse.go
@@ -67,8 +67,7 @@ type NHCBParser struct {
 	h     *histogram.Histogram
 	fh    *histogram.FloatHistogram
 	// For Metric.
-	lset         labels.Labels
-	metricString string
+	lset labels.Labels
 	// For Type.
 	bName []byte
 	typ   model.MetricType
@@ -141,13 +140,17 @@ func (p *NHCBParser) Comment() []byte {
 	return p.parser.Comment()
 }
 
-func (p *NHCBParser) Metric(l *labels.Labels) string {
+func (p *NHCBParser) PopulateLabelsAndName(l *labels.ScratchBuilder) {
+	// TODO(bwplotka): Optimize this.
 	if p.state == stateEmitting {
-		*l = p.lsetNHCB
-		return p.metricStringNHCB
+		p.lsetNHCB.Range(func(label labels.Label) {
+			l.Add(label.Name, label.Value)
+		})
+		return
 	}
-	*l = p.lset
-	return p.metricString
+	p.lset.Range(func(label labels.Label) {
+		l.Add(label.Name, label.Value)
+	})
 }
 
 func (p *NHCBParser) Exemplar(ex *exemplar.Exemplar) bool {
@@ -200,7 +203,10 @@ func (p *NHCBParser) Next() (Entry, error) {
 		switch p.entry {
 		case EntrySeries:
 			p.bytes, p.ts, p.value = p.parser.Series()
-			p.metricString = p.parser.Metric(&p.lset)
+
+			p.builder.Reset()
+			p.parser.PopulateLabelsAndName(&p.builder)
+			p.lset = p.builder.Labels()
 			// Check the label set to see if we can continue or need to emit the NHCB.
 			var isNHCB bool
 			if p.compareLabels() {
@@ -224,7 +230,10 @@ func (p *NHCBParser) Next() (Entry, error) {
 			return p.entry, p.err
 		case EntryHistogram:
 			p.bytes, p.ts, p.h, p.fh = p.parser.Histogram()
-			p.metricString = p.parser.Metric(&p.lset)
+
+			p.builder.Reset()
+			p.parser.PopulateLabelsAndName(&p.builder)
+			p.lset = p.builder.Labels()
 			p.storeExponentialLabels()
 		case EntryType:
 			p.bName, p.typ = p.parser.Type()

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -197,15 +197,11 @@ func (p *OpenMetricsParser) Comment() []byte {
 	return p.text
 }
 
-// Metric writes the labels of the current sample into the passed labels.
-// It returns the string from which the metric was parsed.
-func (p *OpenMetricsParser) Metric(l *labels.Labels) string {
-	// Copy the buffer to a string: this is only necessary for the return value.
-	s := string(p.series)
+func (p *OpenMetricsParser) PopulateLabelsAndName(l *labels.ScratchBuilder) {
+	s := yoloString(p.series)
 
-	p.builder.Reset()
 	metricName := unreplace(s[p.offsets[0]-p.start : p.offsets[1]-p.start])
-	p.builder.Add(labels.MetricName, metricName)
+	l.Add(labels.MetricName, metricName)
 
 	for i := 2; i < len(p.offsets); i += 4 {
 		a := p.offsets[i] - p.start
@@ -215,13 +211,8 @@ func (p *OpenMetricsParser) Metric(l *labels.Labels) string {
 		d := p.offsets[i+3] - p.start
 		value := normalizeFloatsInLabelValues(p.mtype, label, unreplace(s[c:d]))
 
-		p.builder.Add(label, value)
+		l.Add(label, value)
 	}
-
-	p.builder.Sort()
-	*l = p.builder.Labels()
-
-	return s
 }
 
 // Exemplar writes the exemplar of the current sample into the passed exemplar.

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -296,24 +296,14 @@ func (p *ProtobufParser) Comment() []byte {
 	return nil
 }
 
-// Metric writes the labels of the current sample into the passed labels.
-// It returns the string from which the metric was parsed.
-func (p *ProtobufParser) Metric(l *labels.Labels) string {
-	p.builder.Reset()
-	p.builder.Add(labels.MetricName, p.getMagicName())
-
+func (p *ProtobufParser) PopulateLabelsAndName(l *labels.ScratchBuilder) {
+	l.Add(labels.MetricName, p.getMagicName())
 	for _, lp := range p.mf.GetMetric()[p.metricPos].GetLabel() {
-		p.builder.Add(lp.GetName(), lp.GetValue())
+		l.Add(lp.GetName(), lp.GetValue())
 	}
 	if needed, name, value := p.getMagicLabel(); needed {
-		p.builder.Add(name, value)
+		l.Add(name, value)
 	}
-
-	// Sort labels to maintain the sorted labels invariant.
-	p.builder.Sort()
-	*l = p.builder.Labels()
-
-	return p.metricBytes.String()
 }
 
 // Exemplar writes the exemplar of the current sample into the passed

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1986,9 +1986,12 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 	require.NotNil(t, p)
 	require.NoError(t, warning)
 
-	var lset labels.Labels
+	builder := labels.NewScratchBuilder(15)
 	p.Next()
-	p.Metric(&lset)
+	builder.Reset()
+	p.PopulateLabelsAndName(&builder)
+	builder.Sort()
+	lset := builder.Labels()
 	hash := lset.Hash()
 
 	// Create a fake entry in the cache

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -395,15 +395,19 @@ func TestFederationWithNativeHistograms(t *testing.T) {
 	p := textparse.NewProtobufParser(body, false, labels.NewSymbolTable())
 	var actVec promql.Vector
 	metricFamilies := 0
-	l := labels.Labels{}
+	lb := labels.NewScratchBuilder(15)
 	for {
 		et, err := p.Next()
 		if err != nil && errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)
+		var l labels.Labels
 		if et == textparse.EntryHistogram || et == textparse.EntrySeries {
-			p.Metric(&l)
+			lb.Reset()
+			p.PopulateLabelsAndName(&lb)
+			lb.Sort()
+			l = lb.Labels()
 		}
 		switch et {
 		case textparse.EntryHelp:


### PR DESCRIPTION
Continuation of the https://github.com/prometheus/prometheus/pull/15683 experiment, just simplified (only scrape change) and moved to scrape loop (PopulateLabelsAndName might be a bit awkward, but good for experiment).

This adds naive injection of type and unit as labels, without a feature flag. This is to measure initial overhead of this approach proposed in https://github.com/prometheus/proposals/pull/39

When crafting this, I had realization that long term we might want to consider similar semantics of type and unit being part of strict series, however stored outside of labels e.g. in the new model/series.Series struct that wraps labels e.g.

```go
type Series struct {
  lset labels.Labels
  typ model.MetricType
  unit string
}
```
			
This allows gradual integration of type and unit into TSDB. This also offers choice of separate decisions for storage and input/output model e.g. NOT having __type__ and __unit__ labels propagated everywhere, but instead used in PromQL special syntax and obtained from the structured metadata from scrape protocols, OTLP and remote write.

