### PR TITLE
Add a test for aggregation wrapped in ParenExpr

### DIFF
--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -3947,6 +3947,26 @@ var testExpr = []struct {
 			},
 		},
 	},
+	{
+		input: "(sum(foo))",
+		expected: &ParenExpr{
+			Expr: &AggregateExpr{
+				Op: SUM,
+				Expr: &VectorSelector{
+					Name: "foo",
+					LabelMatchers: []*labels.Matcher{
+						MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+					},
+					PosRange: posrange.PositionRange{
+						Start: 5,
+						End:   8,
+					},
+				},
+				PosRange: posrange.PositionRange{Start: 1, End: 9},
+			},
+			PosRange: posrange.PositionRange{Start: 0, End: 10},
+		},
+	},
 }
 
 func makeInt64Pointer(val int64) *int64 {


### PR DESCRIPTION
For some reason the parser sets the wrong end position for aggregations wrapped inside `ParenExpr`. The end is set to the end of `ParenExpr` rather than the end of the `AggregateExpr`. This means that if you want to print the `AggregateExpr` using position information you get an extra token.
Example:
expr `(sum(foo))`
ParenExpr has `PosRange: posrange.PositionRange{Start: 0, End: 10`}, which is correct.
But the `AggregateExpr` gets `PosRange: posrange.PositionRange{Start: 1, End: 10}`, which is incorrect, it should be `{Start: 1, End: 9}`.

This PR adds a test to reproduce the issues.
I'm not sure what is happening in the parser and it's all generated, but I suspect that it's because the `ParenExpr` is only evaluated once we hit the end `)` for it, and at that point `p.lastClosing` is set to the closing `)` of our `ParenExpr` (https://github.com/prometheus/prometheus/blob/main/promql/parser/parse.go#L374-L375
), so when we then call `newAggregateExpr()` to generate a node for `AggregateExpr` 
 (https://github.com/prometheus/prometheus/blob/main/promql/parser/parse.go#L435-L438) we set the position to `p.lastClosing` which is (at that point too far).