### PR TITLE
mantine-ui: fix /alerts accordian theme colors

### DIFF
--- a/web/ui/mantine-ui/src/pages/AlertsPage.module.css
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.module.css
@@ -1,0 +1,8 @@
+.item {
+    background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
+  }
+  
+.item[data-active] {
+    background-color: light-dark(var(--mantine-color-body-light), var(--mantine-color-body-dark));
+  }
+  

--- a/web/ui/mantine-ui/src/pages/AlertsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.tsx
@@ -36,6 +36,7 @@ import { useDebouncedValue } from "@mantine/hooks";
 import { KVSearch } from "@nexucis/kvsearch";
 import { inputIconStyle } from "../styles";
 import CustomInfiniteScroll from "../components/CustomInfiniteScroll";
+import classes from "./AlertsPage.module.css";
 
 type AlertsPageData = {
   // How many rules are in each state across all groups.
@@ -276,19 +277,10 @@ export default function AlertsPage() {
             <CustomInfiniteScroll
               allItems={g.rules}
               child={({ items }) => (
-                <Accordion multiple variant="separated">
+                <Accordion multiple variant="separated" classNames={classes}>
                   {items.map((r, j) => {
                     return (
                       <Accordion.Item
-                        styles={{
-                          item: {
-                            // TODO: This transparency hack is an OK workaround to make the collapsed items
-                            // have a different background color than their surrounding group card in dark mode,
-                            // but it would be better to use CSS to override the light/dark colors for
-                            // collapsed/expanded accordion items.
-                            backgroundColor: "#c0c0c015",
-                          },
-                        }}
                         key={j}
                         value={j.toString()}
                         className={


### PR DESCRIPTION
Replaced static inline value with a `css` file override through `classNames`. Created dynamic styles for both collapsed and expanded states along with distinct styles for light and dark themes using Styles API.
