### PR TITLE
mantine-ui: stable AND definitely unique key for /alerts cards

### DIFF
--- a/web/ui/mantine-ui/src/pages/AlertsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.tsx
@@ -221,7 +221,7 @@ export default function AlertsPage() {
           shadow="xs"
           withBorder
           p="md"
-          key={i} // TODO: Find a stable and definitely unique key.
+          key={`${g.name}-${g.file}`} // TODO: Find a stable and definitely unique key.
         >
           <Group mb="sm" justify="space-between">
             <Group align="baseline">

--- a/web/ui/mantine-ui/src/pages/AlertsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.tsx
@@ -216,7 +216,7 @@ export default function AlertsPage() {
   // convenient to have in the same file IMO).
   const renderedPageItems = useMemo(
     () =>
-      currentPageGroups.map((g, i) => (
+      currentPageGroups.map((g) => (
         <Card
           shadow="xs"
           withBorder

--- a/web/ui/mantine-ui/src/pages/AlertsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.tsx
@@ -221,7 +221,7 @@ export default function AlertsPage() {
           shadow="xs"
           withBorder
           p="md"
-          key={`${g.file}-${g.name}`} // TODO: Find a stable and definitely unique key.
+          key={`${g.file}-${g.name}`}
         >
           <Group mb="sm" justify="space-between">
             <Group align="baseline">

--- a/web/ui/mantine-ui/src/pages/AlertsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.tsx
@@ -221,7 +221,7 @@ export default function AlertsPage() {
           shadow="xs"
           withBorder
           p="md"
-          key={`${g.name}-${g.file}`} // TODO: Find a stable and definitely unique key.
+          key={`${g.file}-${g.name}`} // TODO: Find a stable and definitely unique key.
         >
           <Group mb="sm" justify="space-between">
             <Group align="baseline">

--- a/web/ui/mantine-ui/src/pages/RulesPage.tsx
+++ b/web/ui/mantine-ui/src/pages/RulesPage.tsx
@@ -92,7 +92,7 @@ export default function RulesPage() {
             withBorder
             p="md"
             mb="md"
-            key={`${g.file}-${g.name}`} // TODO: Find a stable and definitely unique key.
+            key={`${g.file}-${g.name}`}
           >
             <Group mb="sm" justify="space-between">
               <Group align="baseline">

--- a/web/ui/mantine-ui/src/pages/RulesPage.tsx
+++ b/web/ui/mantine-ui/src/pages/RulesPage.tsx
@@ -86,12 +86,13 @@ export default function RulesPage() {
           (effectiveActivePage - 1) * ruleGroupsPerPage,
           effectiveActivePage * ruleGroupsPerPage
         )
-        .map((g, i) => (
+        .map((g) => (
           <Card
             shadow="xs"
             withBorder
             p="md"
-            key={i} // TODO: Find a stable and definitely unique key.
+            mb="md"
+            key={`${g.file}-${g.name}`} // TODO: Find a stable and definitely unique key.
           >
             <Group mb="sm" justify="space-between">
               <Group align="baseline">


### PR DESCRIPTION
Replaced the index `i` with `g.name-g.file` which I think is stable (and unique) enough, I haven't caught any edge cases yet, but was also wondering maybe generate some unique ID (hash, uuid) and assign them. but re-renders when a card is removed might cause some issues. :thinking: