### PR TITLE
Add from and to timestamps to LabelHints

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -232,8 +232,8 @@ type SelectHints struct {
 type LabelHints struct {
 	// Maximum number of results returned. Use a value of 0 to disable.
 	Limit int
-	From time.Time
-	To time.Time
+	From  time.Time
+	To    time.Time
 }
 
 // QueryableFunc is an adapter to allow the use of ordinary functions as

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -231,6 +232,8 @@ type SelectHints struct {
 type LabelHints struct {
 	// Maximum number of results returned. Use a value of 0 to disable.
 	Limit int
+	From time.Time
+	To time.Time
 }
 
 // QueryableFunc is an adapter to allow the use of ordinary functions as

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -718,8 +718,8 @@ func (api *API) labelNames(r *http.Request) apiFuncResult {
 
 	hints := &storage.LabelHints{
 		Limit: toHintLimit(limit),
-		From: start,
-		To: end,
+		From:  start,
+		To:    end,
 	}
 
 	q, err := api.Queryable.Querier(timestamp.FromTime(start), timestamp.FromTime(end))
@@ -809,8 +809,8 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 
 	hints := &storage.LabelHints{
 		Limit: toHintLimit(limit),
-		From: start,
-		To: end,
+		From:  start,
+		To:    end,
 	}
 
 	q, err := api.Queryable.Querier(timestamp.FromTime(start), timestamp.FromTime(end))

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -718,6 +718,8 @@ func (api *API) labelNames(r *http.Request) apiFuncResult {
 
 	hints := &storage.LabelHints{
 		Limit: toHintLimit(limit),
+		From: start,
+		To: end,
 	}
 
 	q, err := api.Queryable.Querier(timestamp.FromTime(start), timestamp.FromTime(end))
@@ -807,6 +809,8 @@ func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 
 	hints := &storage.LabelHints{
 		Limit: toHintLimit(limit),
+		From: start,
+		To: end,
 	}
 
 	q, err := api.Queryable.Querier(timestamp.FromTime(start), timestamp.FromTime(end))


### PR DESCRIPTION
This PR adds the "to" and "from" timestamps to the `LabelHints` struct so the `LabelNames()` function can access it. This is valuable so we can confidently scan the relevant time range without having to worry about missing labels or searching from the beginning of the dataset (expensive). This is not a breaking api change since it simply adds it to the LabelHints struct.

Fixes #16049

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
