### PR TITLE
config: set gogc default value when config body is empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -156,6 +156,7 @@ var (
 	// DefaultConfig is the default top-level configuration.
 	DefaultConfig = Config{
 		GlobalConfig: DefaultGlobalConfig,
+		Runtime:      DefaultRuntimeConfig,
 	}
 
 	// DefaultGlobalConfig is the default global configuration.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2566,9 +2566,3 @@ func TestGetScrapeConfigs_Loaded(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
-
-func TestGoGCDefaultValueOnEmptyConfigBody(t *testing.T) {
-	c, err := Load("", promslog.NewNopLogger())
-	require.NoError(t, err)
-	require.Equal(t, 75, c.Runtime.GoGC)
-}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2566,3 +2566,10 @@ func TestGetScrapeConfigs_Loaded(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestGoGCDefaultValueOnEmptyConfigBody(t *testing.T) {
+	c, err := Load("", promslog.NewNopLogger())
+	require.NoError(t, err)
+	exp := DefaultRuntimeConfig
+	require.Equal(t, exp.GoGC, c.Runtime.GoGC)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2222,6 +2222,7 @@ func TestEmptyConfig(t *testing.T) {
 	exp := DefaultConfig
 	exp.loaded = true
 	require.Equal(t, exp, *c)
+	require.Equal(t, 75, c.Runtime.GoGC)
 }
 
 func TestExpandExternalLabels(t *testing.T) {
@@ -2269,7 +2270,6 @@ func TestEmptyGlobalBlock(t *testing.T) {
 	c, err := Load("global:\n", promslog.NewNopLogger())
 	require.NoError(t, err)
 	exp := DefaultConfig
-	exp.Runtime = DefaultRuntimeConfig
 	exp.loaded = true
 	require.Equal(t, exp, *c)
 }
@@ -2570,6 +2570,5 @@ func TestGetScrapeConfigs_Loaded(t *testing.T) {
 func TestGoGCDefaultValueOnEmptyConfigBody(t *testing.T) {
 	c, err := Load("", promslog.NewNopLogger())
 	require.NoError(t, err)
-	exp := DefaultRuntimeConfig
-	require.Equal(t, exp.GoGC, c.Runtime.GoGC)
+	require.Equal(t, 75, c.Runtime.GoGC)
 }


### PR DESCRIPTION
This PR resolves the issue where running Prometheus with an empty config body results in `GoGC` being set to `0`. The fix ensures that the default value of `GoGC` is properly set in `DefaultConfig`.

Fixes #16029 