### PR TITLE
promql: fix double quoting in invalid label name error from `count_values`

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1604,7 +1604,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		if e.Op == parser.COUNT_VALUES {
 			valueLabel := param.(*parser.StringLiteral)
 			if !model.LabelName(valueLabel.Val).IsValid() {
-				ev.errorf("invalid label name %q", valueLabel.Val)
+				ev.errorf("invalid label name %s", valueLabel)
 			}
 			if !e.Without {
 				sortedGrouping = append(sortedGrouping, valueLabel.Val)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1604,7 +1604,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		if e.Op == parser.COUNT_VALUES {
 			valueLabel := param.(*parser.StringLiteral)
 			if !model.LabelName(valueLabel.Val).IsValid() {
-				ev.errorf("invalid label name %q", valueLabel)
+				ev.errorf("invalid label name %q", valueLabel.Val)
 			}
 			if !e.Without {
 				sortedGrouping = append(sortedGrouping, valueLabel.Val)

--- a/promql/promqltest/testdata/aggregators.test
+++ b/promql/promqltest/testdata/aggregators.test
@@ -430,6 +430,10 @@ eval instant at 1m count_values by (job, group)("job", version)
 	{job="7", group="canary"} 2
     {job="{count:20, sum:10, [-2,-1):2, [-1,-0.5):1, [-0.001,0.001]:2, (0.5,1]:1, (1,2]:2}", group="canary"} 2
 
+# Test an invalid label value.
+eval_fail instant at 0 count_values("a\xc5z", version)
+  expected_fail_message invalid label name "a\xc5z"
+
 # Tests for quantile.
 clear
 


### PR DESCRIPTION
This PR fixes an issue where passing an invalid label name to `count_values` would return the label name surrounded with two sets of quotes.

For example, `count_values` previously returned `invalid label name "\"foo"\"` instead of `invalid label name "foo"`.