### PR TITLE
ci: fix build-all status trigger to contain always

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,10 +153,21 @@ jobs:
           parallelism: 12
           thread: ${{ matrix.thread }}
   build_all_status:
+    # This status check aggregates the individual matrix jobs of the "Build
+    # Prometheus for all architectures" step into a final status. Fails if a
+    # single matrix job fails, succeeds if all matrix jobs succeed.
+    # See https://github.com/orgs/community/discussions/4324 for why this is
+    # needed
     name: Report status of build Prometheus for all architectures
     runs-on: ubuntu-latest
     needs: [build_all]
-    if: github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-')
+    # The run condition needs to include always(). Otherwise actions
+    # behave unexpected:
+    # only "needs" will make the Status Report be skipped if one of the builds fails https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#defining-prerequisite-jobs
+    # And skipped is treated as success https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborat[…]n-repositories-with-code-quality-features/about-status-checks
+    # Adding always ensures that the status check is run independently of the
+    # results of Build All
+    if: always() && github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-')
     steps:
       - name: Successful build
         if: ${{ !(contains(needs.*.result, 'failure')) && !(contains(needs.*.result, 'cancelled')) }}


### PR DESCRIPTION
Otherwise a failure in the dependent job skips the status job, which is treated as success.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
