### PR TITLE
Fix health color for target pools with single target that is down

### DIFF
--- a/web/ui/mantine-ui/src/pages/targets/ScrapePoolsList.tsx
+++ b/web/ui/mantine-ui/src/pages/targets/ScrapePoolsList.tsx
@@ -54,7 +54,7 @@ type ScrapePools = {
 };
 
 const poolPanelHealthClass = (pool: ScrapePool) =>
-  pool.count > 1 && pool.downCount === pool.count
+  pool.count > 0 && pool.downCount === pool.count
     ? panelClasses.panelHealthErr
     : pool.downCount >= 1
       ? panelClasses.panelHealthWarn


### PR DESCRIPTION
It should be red instead of orange.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
