### PR TITLE
Labels: simpler/faster stringlabels encoding

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -32,8 +32,8 @@ func (ls Labels) Len() int           { return len(ls) }
 func (ls Labels) Swap(i, j int)      { ls[i], ls[j] = ls[j], ls[i] }
 func (ls Labels) Less(i, j int) bool { return ls[i].Name < ls[j].Name }
 
-// Bytes returns ls as a byte slice.
-// It uses an byte invalid character as a separator and so should not be used for printing.
+// Bytes returns an opaque, not-human-readable, encoding of ls, usable as a map key.
+// Encoding may change over time or between runs of Prometheus.
 func (ls Labels) Bytes(buf []byte) []byte {
 	b := bytes.NewBuffer(buf[:0])
 	b.WriteByte(labelSep)

--- a/model/labels/labels_dedupelabels.go
+++ b/model/labels/labels_dedupelabels.go
@@ -140,8 +140,8 @@ func decodeString(t *nameTable, data string, index int) (string, int) {
 	return t.ToName(num), index
 }
 
-// Bytes returns ls as a byte slice.
-// It uses non-printing characters and so should not be used for printing.
+// Bytes returns an opaque, not-human-readable, encoding of ls, usable as a map key.
+// Encoding may change over time or between runs of Prometheus.
 func (ls Labels) Bytes(buf []byte) []byte {
 	b := bytes.NewBuffer(buf[:0])
 	for i := 0; i < len(ls.data); {

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -33,16 +33,16 @@ type Labels struct {
 }
 
 func decodeSize(data string, index int) (int, int) {
-	// Fast-path for common case of a single byte, value 0..254.
 	b := data[index]
 	index++
-	if b < 255 {
-		return int(b), index
+	if b == 255 {
+		// Larger numbers are encoded as 3 bytes little-endian.
+		// Just panic if we go of the end of data, since all Labels strings are constructed internally and
+		// malformed data indicates a bug, or memory corruption.
+		return int(data[index]) + (int(data[index+1]) << 8) + (int(data[index+2]) << 16), index + 3
 	}
-	// Otherwise it's encoded as 3 bytes little-endian.
-	// Just panic if we go of the end of data, since all Labels strings are constructed internally and
-	// malformed data indicates a bug, or memory corruption.
-	return int(data[index]) + (int(data[index+1]) << 8) + (int(data[index+2]) << 16), index + 3
+	// More common case of a single byte, value 0..254.
+	return int(b), index
 }
 
 func decodeString(data string, index int) (string, int) {

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -35,13 +35,14 @@ type Labels struct {
 func decodeSize(data string, index int) (int, int) {
 	// Fast-path for common case of a single byte, value 0..254.
 	b := data[index]
+	index++
 	if b < 255 {
-		return int(b), index + 1
+		return int(b), index
 	}
 	// Otherwise it's encoded as 3 bytes little-endian.
 	// Just panic if we go of the end of data, since all Labels strings are constructed internally and
 	// malformed data indicates a bug, or memory corruption.
-	return int(data[index+1]) + (int(data[index+2]) << 8) + (int(data[index+3]) << 16), index + 4
+	return int(data[index]) + (int(data[index+1]) << 8) + (int(data[index+2]) << 16), index + 3
 }
 
 func decodeString(data string, index int) (string, int) {

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -522,7 +522,7 @@ func marshalLabelToSizedBuffer(m *Label, data []byte) int {
 }
 
 func sizeWhenEncoded(x uint64) (n int) {
-	if x < 254 {
+	if x < 255 {
 		return 1
 	}
 	return 4

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -524,8 +524,10 @@ func marshalLabelToSizedBuffer(m *Label, data []byte) int {
 func sizeWhenEncoded(x uint64) (n int) {
 	if x < 255 {
 		return 1
+	} else if x <= 1<<24 {
+		return 4
 	}
-	return 4
+	panic("String too long to encode as label.")
 }
 
 func encodeSize(data []byte, offset, v int) int {

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -51,8 +51,8 @@ func decodeString(data string, index int) (string, int) {
 	return data[index : index+size], index + size
 }
 
-// Bytes returns ls as a byte slice.
-// It uses non-printing characters and so should not be used for printing.
+// Bytes returns an opaque, not-human-readable, encoding of ls, usable as a map key.
+// Encoding may change over time or between runs of Prometheus.
 func (ls Labels) Bytes(buf []byte) []byte {
 	if cap(buf) < len(ls.data) {
 		buf = make([]byte, len(ls.data))

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestLabels_String(t *testing.T) {
+	s254 := strings.Repeat("x", 254) // Edge cases for stringlabels encoding.
+	s255 := strings.Repeat("x", 255)
 	cases := []struct {
 		labels   Labels
 		expected string
@@ -42,6 +44,14 @@ func TestLabels_String(t *testing.T) {
 		{
 			labels:   FromStrings("service.name", "t1", "whatever\\whatever", "t2"),
 			expected: `{"service.name"="t1", "whatever\\whatever"="t2"}`,
+		},
+		{
+			labels:   FromStrings("aaa", "111", "xx", s254),
+			expected: `{aaa="111", xx="` + s254 + `"}`,
+		},
+		{
+			labels:   FromStrings("aaa", "111", "xx", s255),
+			expected: `{aaa="111", xx="` + s255 + `"}`,
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
Instead of using varint to encode the size of each label, use a single byte for size 0-254, or a flag value of 255 followed by the size in 3 bytes little-endian.

This reduces the amount of code, and also the number of branches in commonly-executed code, so it runs faster.

The maximum allowed label name or value length is now 2^24 or 16MB.

Memory used by labels changes as follows:
* Labels from 0 to 127 bytes length: same
* From 128 to 254: 1 byte less
* From 255 to 16383: 2 bytes more
* From 16384 to 2MB: 1 byte more
* From 2MB to 16MB: same

Benchmarks - Go 1.24.0, x64:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Intel(R) Core(TM) i7-14700K
                                                 │ before-124.txt │            after-124.txt            │
                                                 │     sec/op     │    sec/op     vs base               │
Labels_Get/with_5_labels/first_label/get-28          3.348n ±  1%    3.344n ± 0%        ~ (p=0.420 n=6)
Labels_Get/with_5_labels/first_label/has-28          2.421n ±  0%    2.599n ± 1%   +7.33% (p=0.002 n=6)
Labels_Get/with_5_labels/middle_label/get-28         6.792n ±  1%    5.438n ± 0%  -19.94% (p=0.002 n=6)
Labels_Get/with_5_labels/middle_label/has-28         3.633n ±  1%    3.825n ± 1%   +5.30% (p=0.002 n=6)
Labels_Get/with_5_labels/last_label/get-28           8.537n ±  1%    7.258n ± 1%  -14.98% (p=0.002 n=6)
Labels_Get/with_5_labels/last_label/has-28           7.284n ±  1%    6.510n ± 0%  -10.63% (p=0.002 n=6)
Labels_Get/with_5_labels/not-found_label/get-28      2.794n ±  1%    2.945n ± 0%   +5.39% (p=0.002 n=6)
Labels_Get/with_5_labels/not-found_label/has-28      2.804n ±  1%    2.885n ± 1%   +2.89% (p=0.002 n=6)
Labels_Get/with_10_labels/first_label/get-28         3.338n ±  0%    3.331n ± 0%        ~ (p=0.102 n=6)
Labels_Get/with_10_labels/first_label/has-28         2.411n ±  1%    2.591n ± 0%   +7.42% (p=0.002 n=6)
Labels_Get/with_10_labels/middle_label/get-28        9.257n ±  1%    8.177n ± 1%  -11.66% (p=0.002 n=6)
Labels_Get/with_10_labels/middle_label/has-28        8.072n ±  1%    7.429n ± 0%   -7.97% (p=0.002 n=6)
Labels_Get/with_10_labels/last_label/get-28          12.60n ±  0%    13.54n ± 0%   +7.50% (p=0.002 n=6)
Labels_Get/with_10_labels/last_label/has-28          11.46n ±  0%    12.71n ± 0%  +10.96% (p=0.002 n=6)
Labels_Get/with_10_labels/not-found_label/get-28     2.772n ±  1%    2.945n ± 1%   +6.22% (p=0.002 n=6)
Labels_Get/with_10_labels/not-found_label/has-28     2.787n ±  1%    2.876n ± 1%   +3.19% (p=0.002 n=6)
Labels_Get/with_30_labels/first_label/get-28         3.343n ±  2%    3.334n ± 0%        ~ (p=0.563 n=6)
Labels_Get/with_30_labels/first_label/has-28         2.421n ±  1%    2.596n ± 1%   +7.21% (p=0.002 n=6)
Labels_Get/with_30_labels/middle_label/get-28        39.58n ±  2%    23.95n ± 0%  -39.48% (p=0.002 n=6)
Labels_Get/with_30_labels/middle_label/has-28        37.31n ±  3%    23.07n ± 1%  -38.17% (p=0.002 n=6)
Labels_Get/with_30_labels/last_label/get-28          74.30n ±  0%    73.53n ± 1%   -1.04% (p=0.004 n=6)
Labels_Get/with_30_labels/last_label/has-28          73.51n ±  1%    73.40n ± 1%        ~ (p=1.000 n=6)
Labels_Get/with_30_labels/not-found_label/get-28     2.788n ±  1%    2.970n ± 1%   +6.57% (p=0.002 n=6)
Labels_Get/with_30_labels/not-found_label/has-28     2.791n ±  1%    2.886n ± 1%   +3.39% (p=0.002 n=6)
Labels_Equals/equal-28                               1.668n ±  1%    1.669n ± 1%        ~ (p=0.468 n=6)
Labels_Equals/not_equal-28                          0.1863n ±  0%   0.1861n ± 1%        ~ (p=0.649 n=6)
Labels_Equals/different_sizes-28                    0.1864n ±  1%   0.1853n ± 1%        ~ (p=0.119 n=6)
Labels_Equals/lots-28                                1.667n ±  1%    1.679n ± 2%   +0.69% (p=0.013 n=6)
Labels_Equals/real_long_equal-28                     4.287n ±  1%    4.317n ± 1%   +0.68% (p=0.041 n=6)
Labels_Equals/real_long_different_end-28             3.474n ±  1%    3.448n ± 1%   -0.75% (p=0.024 n=6)
Labels_Compare/equal-28                              3.392n ±  1%    3.359n ± 0%   -0.97% (p=0.006 n=6)
Labels_Compare/not_equal-28                          12.79n ±  1%    10.22n ± 1%  -20.06% (p=0.002 n=6)
Labels_Compare/different_sizes-28                    2.595n ±  2%    2.605n ± 0%        ~ (p=0.061 n=6)
Labels_Compare/lots-28                               18.95n ±  1%    18.07n ± 1%   -4.65% (p=0.002 n=6)
Labels_Compare/real_long_equal-28                    19.61n ±  0%    19.38n ± 1%   -1.20% (p=0.002 n=6)
Labels_Compare/real_long_different_end-28            22.71n ±  1%    22.83n ± 1%   +0.51% (p=0.017 n=6)
Labels_Hash/typical_labels_under_1KB-28              41.52n ±  0%    41.68n ± 1%        ~ (p=0.084 n=6)
Labels_Hash/bigger_labels_over_1KB-28                50.95n ±  0%    50.81n ± 1%        ~ (p=0.662 n=6)
Labels_Hash/extremely_large_label_value_10MB-28      502.1µ ±  1%    514.2µ ± 1%   +2.42% (p=0.002 n=6)
Builder-28                                           229.8n ±  1%    214.3n ± 1%   -6.74% (p=0.002 n=6)
Labels_Copy-28                                       43.47n ± 17%    44.34n ± 6%        ~ (p=0.132 n=6)
geomean                                              8.780n          8.505n        -3.13%
```

Benchmarks - Go 1.24.0, ARM64:
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Apple M2
                                                │  before.txt   │              after.txt              │
                                                │    sec/op     │    sec/op     vs base               │
Labels_Get/with_5_labels/first_label/get-8         5.333n ±  1%    4.844n ± 3%   -9.18% (p=0.002 n=6)
Labels_Get/with_5_labels/first_label/has-8         4.444n ±  4%    4.495n ± 3%        ~ (p=0.240 n=6)
Labels_Get/with_5_labels/middle_label/get-8        8.277n ±  1%    7.799n ± 3%   -5.78% (p=0.002 n=6)
Labels_Get/with_5_labels/middle_label/has-8        7.386n ±  6%    7.424n ± 1%        ~ (p=0.132 n=6)
Labels_Get/with_5_labels/last_label/get-8          10.94n ±  2%    10.38n ± 1%   -5.08% (p=0.002 n=6)
Labels_Get/with_5_labels/last_label/has-8          10.05n ±  1%    10.09n ± 1%        ~ (p=0.139 n=6)
Labels_Get/with_5_labels/not-found_label/get-8     6.240n ±  1%    5.396n ± 1%  -13.53% (p=0.002 n=6)
Labels_Get/with_5_labels/not-found_label/has-8     5.333n ±  3%    5.328n ± 0%        ~ (p=0.561 n=6)
Labels_Get/with_10_labels/first_label/get-8        5.319n ±  1%    4.727n ± 0%  -11.12% (p=0.002 n=6)
Labels_Get/with_10_labels/first_label/has-8        4.431n ±  2%    4.445n ± 3%        ~ (p=0.584 n=6)
Labels_Get/with_10_labels/middle_label/get-8       12.71n ±  0%    12.12n ± 2%   -4.60% (p=0.002 n=6)
Labels_Get/with_10_labels/middle_label/has-8       11.84n ±  2%    11.85n ± 1%        ~ (p=0.935 n=6)
Labels_Get/with_10_labels/last_label/get-8         20.08n ±  0%    19.58n ± 1%   -2.49% (p=0.002 n=6)
Labels_Get/with_10_labels/last_label/has-8         18.58n ±  0%    18.54n ± 0%        ~ (p=0.167 n=6)
Labels_Get/with_10_labels/not-found_label/get-8    6.260n ±  1%    5.396n ± 1%  -13.80% (p=0.002 n=6)
Labels_Get/with_10_labels/not-found_label/has-8    5.341n ±  0%    5.326n ± 0%        ~ (p=0.325 n=6)
Labels_Get/with_30_labels/first_label/get-8        5.316n ±  0%    4.730n ± 0%  -11.02% (p=0.002 n=6)
Labels_Get/with_30_labels/first_label/has-8        4.449n ±  4%    4.434n ± 0%        ~ (p=0.556 n=6)
Labels_Get/with_30_labels/middle_label/get-8       37.02n ±  1%    36.44n ± 1%   -1.57% (p=0.002 n=6)
Labels_Get/with_30_labels/middle_label/has-8       35.12n ±  1%    35.62n ± 0%   +1.44% (p=0.013 n=6)
Labels_Get/with_30_labels/last_label/get-8         78.47n ±  2%    77.29n ± 1%   -1.50% (p=0.002 n=6)
Labels_Get/with_30_labels/last_label/has-8         75.53n ±  1%    75.83n ± 0%        ~ (p=0.093 n=6)
Labels_Get/with_30_labels/not-found_label/get-8    6.261n ±  1%    5.391n ± 0%  -13.89% (p=0.002 n=6)
Labels_Get/with_30_labels/not-found_label/has-8    5.324n ±  0%    5.332n ± 1%        ~ (p=0.058 n=6)
Labels_Equals/equal-8                              2.956n ±  0%    2.953n ± 1%        ~ (p=0.190 n=6)
Labels_Equals/not_equal-8                         0.3651n ± 14%   0.3140n ± 0%        ~ (p=0.320 n=6)
Labels_Equals/different_sizes-8                   0.3154n ±  1%   0.3137n ± 0%        ~ (p=0.093 n=6)
Labels_Equals/lots-8                               2.668n ±  1%    2.664n ± 0%        ~ (p=0.169 n=6)
Labels_Equals/real_long_equal-8                    7.975n ±  1%    8.003n ± 1%        ~ (p=0.126 n=6)
Labels_Equals/real_long_different_end-8            6.788n ±  1%    6.790n ± 1%        ~ (p=0.325 n=6)
Labels_Compare/equal-8                             6.621n ±  1%    6.580n ± 0%        ~ (p=0.065 n=6)
Labels_Compare/not_equal-8                         13.61n ±  1%    12.72n ± 1%   -6.54% (p=0.002 n=6)
Labels_Compare/different_sizes-8                   5.877n ±  2%    5.787n ± 1%   -1.54% (p=0.015 n=6)
Labels_Compare/lots-8                              26.50n ±  0%    25.68n ± 1%   -3.09% (p=0.002 n=6)
Labels_Compare/real_long_equal-8                   16.71n ±  0%    16.73n ± 2%        ~ (p=0.087 n=6)
Labels_Compare/real_long_different_end-8           28.27n ±  0%    26.87n ± 0%   -4.97% (p=0.002 n=6)
Labels_Hash/typical_labels_under_1KB-8             54.77n ±  0%    54.68n ± 0%   -0.17% (p=0.015 n=6)
Labels_Hash/bigger_labels_over_1KB-8               67.16n ±  0%    66.97n ± 0%   -0.28% (p=0.002 n=6)
Labels_Hash/extremely_large_label_value_10MB-8     678.5µ ±  0%    679.2µ ± 0%        ~ (p=0.394 n=6)
Builder-8                                          254.1n ±  0%    233.5n ± 0%   -8.09% (p=0.002 n=6)
Labels_Copy-8                                      28.27n ±  1%    27.52n ± 1%   -2.64% (p=0.002 n=6)
geomean                                            13.18n          12.74n        -3.34%
```