### PR TITLE
build: Make /prometheus group writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY NOTICE                                 /NOTICE
 COPY npm_licenses.tar.bz2                   /npm_licenses.tar.bz2
 
 WORKDIR /prometheus
-RUN chown -R nobody:nobody /etc/prometheus /prometheus
+RUN chown -R nobody:nobody /etc/prometheus /prometheus && chmod g+w /prometheus
 
 USER       nobody
 EXPOSE     9090


### PR DESCRIPTION
As outlined in #3441 this is the minimal change needed to allow changing UID/GID in Docker when combined with a supplementary group. This only helps with volumes managed by Docker, not bind mounted to the host (because Docker doesn't manage permissions / ownership of those, but users have always been able to chown those and this change doesn't impact that).

Manual tests:

```
$ docker run -it --entrypoint=/bin/sh docker.io/prom/prometheus-linux-amd64:docker-chmod
/prometheus $ id
uid=65534(nobody) gid=65534(nobody) groups=65534(nobody)
/prometheus $ ls -ld /prometheus
drwxrwxr-x    2 nobody   nobody        4096 Feb 25 01:29 /prometheus
/prometheus $

$ docker run -it --entrypoint=/bin/sh prom/prometheus
/prometheus $ id
uid=65534(nobody) gid=65534(nobody) groups=65534(nobody)
/prometheus $ ls -ld /prometheus
drwxr-xr-x    2 nobody   nobody        4096 Feb 17 19:10 /prometheus

$ docker run -it --user 9090:9090 --group-add 65534 docker.io/prom/prometheus-linux-amd64:docker-chmod
[...snip good startup...]
time=2025-02-25T01:33:10.856Z level=INFO source=main.go:1213 msg="Server is ready to receive web requests."
time=2025-02-25T01:33:10.856Z level=INFO source=manager.go:175 msg="Starting rule manager..." component="rule manager"

$ docker run -it --user 9090:9090 --group-add 65534 --mount source=prometheus-db-test1,destination=/prometheus prom/prometheus
[...old image; error...]
time=2025-02-25T01:40:05.492Z level=ERROR source=query_logger.go:113 msg="Error opening query log file" component=activeQueryTracker file=/prometheus/queries.active err="open /prometheus/queries.active: permission denied"
panic: Unable to create mmap-ed active query log

$ docker run -it --user 9090:9090 --group-add 65534 --mount source=prometheus-db-test2,destination=/prometheus docker.io/prom/prometheus-linux-amd64:docker-chmod
[...works...]
time=2025-02-25T01:41:24.553Z level=INFO source=main.go:1213 msg="Server is ready to receive web requests."
time=2025-02-25T01:41:24.553Z level=INFO source=manager.go:175 msg="Starting rule manager..." component="rule manager"
```

Fixes #3441.