### PR TITLE
discovery: Allow EC2 Service Discovery to work with IPv6-only instances

### DIFF
--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -55,6 +55,7 @@ const (
 	ec2LabelInstanceType         = ec2Label + "instance_type"
 	ec2LabelOwnerID              = ec2Label + "owner_id"
 	ec2LabelPlatform             = ec2Label + "platform"
+	ec2LabelDefaultIPv6Address   = ec2Label + "default_ipv6_address"
 	ec2LabelPrimaryIPv6Addresses = ec2Label + "primary_ipv6_addresses"
 	ec2LabelPrimarySubnetID      = ec2Label + "primary_subnet_id"
 	ec2LabelPrivateDNS           = ec2Label + "private_dns_name"
@@ -306,7 +307,9 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 
 		for _, r := range p.Reservations {
 			for _, inst := range r.Instances {
-				if inst.PrivateIpAddress == nil {
+				defaultIPv6Addr, primaryIPv6Addrs, ipv6Addrs := getInstanceIPv6Addresses(&inst)
+
+				if inst.PrivateIpAddress == nil && defaultIPv6Addr == nil {
 					continue
 				}
 
@@ -319,12 +322,20 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 					labels[ec2LabelOwnerID] = model.LabelValue(*r.OwnerId)
 				}
 
-				labels[ec2LabelPrivateIP] = model.LabelValue(*inst.PrivateIpAddress)
+				if defaultIPv6Addr != nil {
+					labels[ec2LabelDefaultIPv6Address] = model.LabelValue(*defaultIPv6Addr)
+				}
+
+				if inst.PrivateIpAddress != nil {
+					labels[ec2LabelPrivateIP] = model.LabelValue(*inst.PrivateIpAddress)
+					labels[model.AddressLabel] = model.LabelValue(net.JoinHostPort(*inst.PrivateIpAddress, strconv.Itoa(d.cfg.Port)))
+				} else {
+					labels[model.AddressLabel] = model.LabelValue(net.JoinHostPort(*defaultIPv6Addr, strconv.Itoa(d.cfg.Port)))
+				}
+
 				if inst.PrivateDnsName != nil {
 					labels[ec2LabelPrivateDNS] = model.LabelValue(*inst.PrivateDnsName)
 				}
-				addr := net.JoinHostPort(*inst.PrivateIpAddress, strconv.Itoa(d.cfg.Port))
-				labels[model.AddressLabel] = model.LabelValue(addr)
 
 				if inst.Platform != "" {
 					labels[ec2LabelPlatform] = model.LabelValue(inst.Platform)
@@ -334,6 +345,21 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 					labels[ec2LabelPublicIP] = model.LabelValue(*inst.PublicIpAddress)
 					labels[ec2LabelPublicDNS] = model.LabelValue(*inst.PublicDnsName)
 				}
+
+				if primaryIPv6Addrs != nil {
+					labels[ec2LabelPrimaryIPv6Addresses] = model.LabelValue(
+						ec2LabelSeparator +
+							strings.Join(primaryIPv6Addrs, ec2LabelSeparator) +
+							ec2LabelSeparator)
+				}
+
+				if ipv6Addrs != nil {
+					labels[ec2LabelIPv6Addresses] = model.LabelValue(
+						ec2LabelSeparator +
+							strings.Join(ipv6Addrs, ec2LabelSeparator) +
+							ec2LabelSeparator)
+				}
+
 				labels[ec2LabelAMI] = model.LabelValue(*inst.ImageId)
 				labels[ec2LabelAZ] = model.LabelValue(*inst.Placement.AvailabilityZone)
 				azID, ok := d.azToAZID[*inst.Placement.AvailabilityZone]
@@ -359,8 +385,6 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 					labels[ec2LabelPrimarySubnetID] = model.LabelValue(*inst.SubnetId)
 
 					var subnets []string
-					var ipv6addrs []string
-					var primaryipv6addrs []string
 					subnetsMap := make(map[string]struct{})
 					for _, eni := range inst.NetworkInterfaces {
 						if eni.SubnetId == nil {
@@ -371,36 +395,11 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 							subnetsMap[*eni.SubnetId] = struct{}{}
 							subnets = append(subnets, *eni.SubnetId)
 						}
-
-						for _, ipv6addr := range eni.Ipv6Addresses {
-							ipv6addrs = append(ipv6addrs, *ipv6addr.Ipv6Address)
-							if *ipv6addr.IsPrimaryIpv6 {
-								// we might have to extend the slice with more than one element
-								// that could leave empty strings in the list which is intentional
-								// to keep the position/device index information
-								for int32(len(primaryipv6addrs)) <= *eni.Attachment.DeviceIndex {
-									primaryipv6addrs = append(primaryipv6addrs, "")
-								}
-								primaryipv6addrs[*eni.Attachment.DeviceIndex] = *ipv6addr.Ipv6Address
-							}
-						}
 					}
 					labels[ec2LabelSubnetID] = model.LabelValue(
 						ec2LabelSeparator +
 							strings.Join(subnets, ec2LabelSeparator) +
 							ec2LabelSeparator)
-					if len(ipv6addrs) > 0 {
-						labels[ec2LabelIPv6Addresses] = model.LabelValue(
-							ec2LabelSeparator +
-								strings.Join(ipv6addrs, ec2LabelSeparator) +
-								ec2LabelSeparator)
-					}
-					if len(primaryipv6addrs) > 0 {
-						labels[ec2LabelPrimaryIPv6Addresses] = model.LabelValue(
-							ec2LabelSeparator +
-								strings.Join(primaryipv6addrs, ec2LabelSeparator) +
-								ec2LabelSeparator)
-					}
 				}
 
 				for _, t := range inst.Tags {
@@ -416,4 +415,40 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 	}
 
 	return []*targetgroup.Group{tg}, nil
+}
+
+func getInstanceIPv6Addresses(i *ec2Types.Instance) (*string, []string, []string) {
+	var primaryIPv6Addrs []string
+	var ipv6Addrs []string
+
+	if i.VpcId != nil {
+		for _, eni := range i.NetworkInterfaces {
+			if eni.SubnetId == nil {
+				continue
+			}
+
+			for _, ipv6addr := range eni.Ipv6Addresses {
+				ipv6Addrs = append(ipv6Addrs, *ipv6addr.Ipv6Address)
+				if *ipv6addr.IsPrimaryIpv6 {
+					// we might have to extend the slice with more than one element
+					// that could leave empty strings in the list which is intentional
+					// to keep the position/device index information
+					for int32(len(primaryIPv6Addrs)) <= *eni.Attachment.DeviceIndex {
+						primaryIPv6Addrs = append(primaryIPv6Addrs, "")
+					}
+					primaryIPv6Addrs[*eni.Attachment.DeviceIndex] = *ipv6addr.Ipv6Address
+				}
+			}
+		}
+
+		// Find an IPv6 address we can use by default. Pick the first primary one if
+		// there is any available, if not then pick the first non-primary address.
+		for _, ipv6addr := range append(primaryIPv6Addrs, ipv6Addrs...) {
+			if ipv6addr != "" {
+				return &ipv6addr, primaryIPv6Addrs, ipv6Addrs
+			}
+		}
+	}
+
+	return nil, primaryIPv6Addrs, ipv6Addrs
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -902,6 +902,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_ipv6_addresses`: comma separated list of IPv6 addresses assigned to the instance's network interfaces, if present
 * `__meta_ec2_owner_id`: the ID of the AWS account that owns the EC2 instance
 * `__meta_ec2_platform`: the Operating System platform, set to 'windows' on Windows servers, absent otherwise
+* `__meta_ec2_default_ipv6_address`: the first primary IPv6 address found if present, otherwise first non-primary IPv6 address, if present
 * `__meta_ec2_primary_ipv6_addresses`: comma separated list of the Primary IPv6 addresses of the instance, if present. The list is ordered based on the position of each corresponding network interface in the attachment order.
 * `__meta_ec2_primary_subnet_id`: the subnet ID of the primary network interface, if available
 * `__meta_ec2_private_dns_name`: the private DNS name of the instance, if available
@@ -1832,6 +1833,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_ec2_ipv6_addresses`: comma separated list of IPv6 addresses assigned to the instance's network interfaces, if present
 * `__meta_ec2_owner_id`: the ID of the AWS account that owns the EC2 instance
 * `__meta_ec2_platform`: the Operating System platform, set to 'windows' on Windows servers, absent otherwise
+* `__meta_ec2_default_ipv6_address`: the first primary IPv6 address found if present, otherwise first non-primary IPv6 address, if present
 * `__meta_ec2_primary_ipv6_addresses`: comma separated list of the Primary IPv6 addresses of the instance, if present. The list is ordered based on the position of each corresponding network interface in the attachment order.
 * `__meta_ec2_primary_subnet_id`: the subnet ID of the primary network interface, if available
 * `__meta_ec2_private_dns_name`: the private DNS name of the instance, if available


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Currently, if an EC2 instance does not have a private IP (IPv4) address, the auto discovery will drop it entirely. This pull request attempts to allow falling back to IPv6 if a valid IPv6 address can be found.

In cases where multiple IPv6 addresses can be found, it will use the first one it finds, with "primary" IPv6 addresses having priority. Obviously this might not be perfect for everybody, but should be good for 95%. The other 5% can at least use relabel config rather than having their instances dropped entirely.

**OPINIONS WELCOME**

- As you can see I have added a helper function for obtaining a "default" IPv6 address. This may be in the wrong place, please advice best practise for this.
- I'm not 100% sure if I am using pointers and dereferencing appropriately. Nothing crashes and everything works but please comment!

This pull request in its current form DOES work as expected. I have tested with IPv4 & IPv6 instances and IPv6 only instances.

Fixes: https://github.com/prometheus/prometheus/issues/16047

@machine424 (as per contributing guidelines) apologies if you are not the best one to tag!


#### Release notes for end users
```release-notes
[ENHANCEMENT]: Allows EC2 service discovery to discover IPv6 addresses to communicate with target endpoints. The private IPv4 address remains the default when both IPv4 and IPv6 addresses are present.
```