### PR TITLE
promql: histogram_fraction for bucket histograms

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -253,10 +253,20 @@ histogram samples:
 
 ## `histogram_fraction()`
 
-`histogram_fraction(lower scalar, upper scalar, v instant-vector)` returns the
+`histogram_fraction(lower scalar, upper scalar, b instant-vector)` returns the
 estimated fraction of observations between the provided lower and upper values
-for each histogram sample in `v`. Float samples are ignored and do not show up
-in the returned vector.
+for each histogram sample in `b`.
+It can handle
+[classic histograms](https://prometheus.io/docs/concepts/metric_types/#histogram)
+or native histograms.
+If used with classic histogram take care that the `lower` and `upper` values dont
+stray far from the exported bucket boundaries, otherwise interpolation will lead
+to a potentially large margin of error. The interpolation method for classic historams
+is the same as the one used for `histogram_quantile()`.
+(See
+[here](https://prometheus.io/docs/practices/histograms/#apdex-score) for a more
+informed approach to compute fractions for classic histograms using the exported
+bucket boundaries directly.)
 
 For example, the following expression calculates the fraction of HTTP requests
 over the last hour that took 200ms or less:
@@ -280,8 +290,8 @@ feature inclusive upper boundaries and exclusive lower boundaries for positive
 values, and vice versa for negative values.) Without a precise alignment of
 boundaries, the function uses interpolation to estimate the fraction. With the
 resulting uncertainty, it becomes irrelevant if the boundaries are inclusive or
-exclusive. The interpolation method is the same as the one used for
-`histogram_quantile()`. See there for more details.
+exclusive.
+
 
 ## `histogram_quantile()`
 

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -255,18 +255,21 @@ histogram samples:
 
 `histogram_fraction(lower scalar, upper scalar, b instant-vector)` returns the
 estimated fraction of observations between the provided lower and upper values
-for each histogram sample in `b`.
-It can handle
-[classic histograms](https://prometheus.io/docs/concepts/metric_types/#histogram)
-or native histograms.
-If used with classic histogram take care that the `lower` and `upper` values dont
-stray far from the exported bucket boundaries, otherwise interpolation will lead
-to a potentially large margin of error. The interpolation method for classic historams
-is the same as the one used for `histogram_quantile()`.
-(See
-[here](https://prometheus.io/docs/practices/histograms/#apdex-score) for a more
-informed approach to compute fractions for classic histograms using the exported
-bucket boundaries directly.)
+for each classic or native histogram contained in `b`. Float samples in `b` are 
+considered the counts of observations in each bucket of one or more classic
+histograms, while native histogram samples in `b` are treated each individually 
+as a separate histogram. This works in the same way as for `histogram_quantile()`.
+(See there for more details.)
+
+If the provided lower and upper values do not coincide with bucket boundaries,
+the calculated fraction is an estimate, using the same interpolation method as for
+`histogram_quantile()`. (See there for more details.) Especially with classic
+histograms, it is easy to accidentally pick lower or upper values that are very
+far away from any bucket boundary, leading to large margins of error. Rather than
+using `histogram_fraction()` with classic histograms, it is often a more robust approach
+to directly act on the bucket series when calculating fractions. See the
+[calculation of the Apdex scare](https://prometheus.io/docs/practices/histograms/#apdex-score)
+as a typical example.
 
 For example, the following expression calculates the fraction of HTTP requests
 over the last hour that took 200ms or less:

--- a/promql/promqltest/testdata/histograms.test
+++ b/promql/promqltest/testdata/histograms.test
@@ -113,6 +113,11 @@ eval instant at 50m histogram_fraction(0, 0.2, rate(testhistogram3[10m]))
 	{start="positive"} 0.6363636363636364
 	{start="negative"} 0
 
+
+eval instant at 50m histogram_fraction(0, 0.2, rate(testhistogram3_bucket[10m]))
+	{start="positive"} 0.6363636363636364
+	{start="negative"} 0
+
 # In the classic histogram, we can access the corresponding bucket (if
 # it exists) and divide by the count to get the same result.
 

--- a/promql/promqltest/testdata/histograms.test
+++ b/promql/promqltest/testdata/histograms.test
@@ -104,8 +104,31 @@ eval instant at 50m histogram_stdvar(testhistogram3)
 	{start="negative"} 17.495112615949154
 
 # Test histogram_fraction.
+#
+eval instant at 50m histogram_fraction(0, 4, testhistogram2)
+	{} 0.6666666666666666
+
+eval instant at 50m histogram_fraction(0, 4, testhistogram2_bucket)
+	{} 0.6666666666666666
+
+eval instant at 50m histogram_fraction(0, 6, testhistogram2)
+	{} 1
+
+eval instant at 50m histogram_fraction(0, 6, testhistogram2_bucket)
+	{} 1
+
+eval instant at 50m histogram_fraction(0, 3.5, testhistogram2)
+	{} 0.5833333333333334
+
+eval instant at 50m histogram_fraction(0, 3.5, testhistogram2_bucket)
+	{} 0.5833333333333334
+
 
 eval instant at 50m histogram_fraction(0, 0.2, testhistogram3)
+	{start="positive"} 0.6363636363636364
+	{start="negative"} 0
+
+eval instant at 50m histogram_fraction(0, 0.2, testhistogram3_bucket)
 	{start="positive"} 0.6363636363636364
 	{start="negative"} 0
 

--- a/promql/quantile.go
+++ b/promql/quantile.go
@@ -448,6 +448,84 @@ func HistogramFraction(lower, upper float64, h *histogram.FloatHistogram) float6
 	return (upperRank - lowerRank) / h.Count
 }
 
+// BucketFraction is a version of HistogramFraction for classic histograms.
+func BucketFraction(lower, upper float64, buckets Buckets) float64 {
+	slices.SortFunc(buckets, func(a, b Bucket) int {
+		// We don't expect the bucket boundary to be a NaN.
+		if a.UpperBound < b.UpperBound {
+			return -1
+		}
+		if a.UpperBound > b.UpperBound {
+			return +1
+		}
+		return 0
+	})
+	if !math.IsInf(buckets[len(buckets)-1].UpperBound, +1) {
+		return math.NaN()
+	}
+	buckets = coalesceBuckets(buckets)
+
+	count := buckets[len(buckets)-1].Count
+	if count == 0 || math.IsNaN(lower) || math.IsNaN(upper) {
+		return math.NaN()
+	}
+	if lower >= upper {
+		return 0
+	}
+
+	var (
+		rank, lowerRank, upperRank float64
+		lowerSet, upperSet         bool
+	)
+	for i, b := range buckets {
+		lowerBound := math.Inf(-1)
+		if i > 0 {
+			lowerBound = buckets[i-1].UpperBound
+		}
+		upperBound := b.UpperBound
+
+		interpolateLinearly := func(v float64) float64 {
+			return rank + b.Count*(v-lowerBound)/(upperBound-lowerBound)
+		}
+
+		if !lowerSet && lowerBound >= lower {
+			// We have hit the lower value at the lower bucket boundary.
+			lowerRank = rank
+			lowerSet = true
+		}
+		if !upperSet && lowerBound >= upper {
+			// We have hit the upper value at the lower bucket boundary.
+			upperRank = rank
+			upperSet = true
+		}
+		if lowerSet && upperSet {
+			break
+		}
+		if !lowerSet && lowerBound < lower && upperBound > lower {
+			// The lower value is in this bucket.
+			lowerRank = interpolateLinearly(lower)
+			lowerSet = true
+		}
+		if !upperSet && lowerBound < upper && upperBound > upper {
+			// The upper value is in this bucket.
+			upperRank = interpolateLinearly(upper)
+			upperSet = true
+		}
+		if lowerSet && upperSet {
+			break
+		}
+		rank = b.Count
+	}
+	if !lowerSet || lowerRank > count {
+		lowerRank = count
+	}
+	if !upperSet || upperRank > count {
+		upperRank = count
+	}
+
+	return (upperRank - lowerRank) / count
+}
+
 // coalesceBuckets merges buckets with the same upper bound.
 //
 // The input buckets must be sorted.

--- a/promql/quantile.go
+++ b/promql/quantile.go
@@ -485,7 +485,7 @@ func BucketFraction(lower, upper float64, buckets Buckets) float64 {
 		upperBound := b.UpperBound
 
 		interpolateLinearly := func(v float64) float64 {
-			return rank + b.Count*(v-lowerBound)/(upperBound-lowerBound)
+			return rank + (b.Count-rank)*(v-lowerBound)/(upperBound-lowerBound)
 		}
 
 		if !lowerSet && lowerBound >= lower {


### PR DESCRIPTION
This PR extends the `histogram_fraction` function to also work with classic bucket histograms. This is beneficial because it allows expressions like `sum(increase(my_bucket{le="0.5"}[10m]))/sum(increase(my_total[10m]))` to be written without knowing the actual values of the "le" label, easing the transition to native histograms later on.
It also feels natural since `histogram_quantile` also can deal with classic histograms.

The code was cobbled together from the parts that let `histogram_quantile` work with buckets and native histograms and parts of the `HistogramFraction` functions adjusted for classic histograms. Being cobbled together like this it involves a bit of code duplication that could probably be refactored. I wanted to open the PR already though to see if this is reasonable in the first place though!