### PR TITLE
Add util/compression package to consolidate snappy/zstd use in Prometheus.

### DIFF
--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -42,7 +42,7 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--storage.tsdb.no-lockfile</code> | Do not create lockfile in data directory. Use with server mode only. | `false` |
 | <code class="text-nowrap">--storage.tsdb.head-chunks-write-queue-size</code> | Size of the queue through which head chunks are written to the disk to be m-mapped, 0 disables the queue completely. Experimental. Use with server mode only. | `0` |
 | <code class="text-nowrap">--storage.agent.path</code> | Base path for metrics storage. Use with agent mode only. | `data-agent/` |
-| <code class="text-nowrap">--storage.agent.wal-compression</code> | Compress the agent WAL. Use with agent mode only. | `true` |
+| <code class="text-nowrap">--storage.agent.wal-compression</code> | Compress the agent WAL. If false, the --storage.agent.wal-compression-type flag is ignored. Use with agent mode only. | `true` |
 | <code class="text-nowrap">--storage.agent.retention.min-time</code> | Minimum age samples may be before being considered for deletion when the WAL is truncated Use with agent mode only. |  |
 | <code class="text-nowrap">--storage.agent.retention.max-time</code> | Maximum age samples may be before being forcibly deleted when the WAL is truncated Use with agent mode only. |  |
 | <code class="text-nowrap">--storage.agent.no-lockfile</code> | Do not create lockfile in data directory. Use with agent mode only. | `false` |

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -24,10 +24,11 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/util/compression"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -150,8 +151,8 @@ func (h *writeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Don't break yolo 1.0 clients if not needed. This is similar to what we did
 		// before 2.0: https://github.com/prometheus/prometheus/blob/d78253319daa62c8f28ed47e40bafcad2dd8b586/storage/remote/write_handler.go#L62
 		// We could give http.StatusUnsupportedMediaType, but let's assume snappy by default.
-	} else if enc != string(SnappyBlockCompression) {
-		err := fmt.Errorf("%v encoding (compression) is not accepted by this server; only %v is acceptable", enc, SnappyBlockCompression)
+	} else if strings.ToLower(enc) != compression.Snappy {
+		err := fmt.Errorf("%v encoding (compression) is not accepted by this server; only %v is acceptable", enc, compression.Snappy)
 		h.logger.Error("Error decoding remote write request", "err", err)
 		http.Error(w, err.Error(), http.StatusUnsupportedMediaType)
 	}
@@ -164,7 +165,7 @@ func (h *writeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	decompressed, err := snappy.Decode(nil, body)
+	decompressed, err := compression.Decode(compression.Snappy, body, nil)
 	if err != nil {
 		// TODO(bwplotka): Add more context to responded error?
 		h.logger.Error("Error decompressing remote write request", "err", err.Error())

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/util/compression"
+
 	"github.com/prometheus/common/promslog"
 
 	"github.com/prometheus/prometheus/config"
@@ -60,7 +62,7 @@ func TestRemoteWriteHandlerHeadersHandling_V1Message(t *testing.T) {
 			name: "correct PRW 1.0 headers",
 			reqHeaders: map[string]string{
 				"Content-Type":           remoteWriteContentTypeHeaders[config.RemoteWriteProtoMsgV1],
-				"Content-Encoding":       string(SnappyBlockCompression),
+				"Content-Encoding":       compression.Snappy,
 				RemoteWriteVersionHeader: RemoteWriteVersion20HeaderValue,
 			},
 			expectedCode: http.StatusNoContent,
@@ -69,7 +71,7 @@ func TestRemoteWriteHandlerHeadersHandling_V1Message(t *testing.T) {
 			name: "missing remote write version",
 			reqHeaders: map[string]string{
 				"Content-Type":     remoteWriteContentTypeHeaders[config.RemoteWriteProtoMsgV1],
-				"Content-Encoding": string(SnappyBlockCompression),
+				"Content-Encoding": compression.Snappy,
 			},
 			expectedCode: http.StatusNoContent,
 		},
@@ -81,7 +83,7 @@ func TestRemoteWriteHandlerHeadersHandling_V1Message(t *testing.T) {
 		{
 			name: "missing content-type",
 			reqHeaders: map[string]string{
-				"Content-Encoding":       string(SnappyBlockCompression),
+				"Content-Encoding":       compression.Snappy,
 				RemoteWriteVersionHeader: RemoteWriteVersion20HeaderValue,
 			},
 			expectedCode: http.StatusNoContent,
@@ -98,7 +100,7 @@ func TestRemoteWriteHandlerHeadersHandling_V1Message(t *testing.T) {
 			name: "wrong content-type",
 			reqHeaders: map[string]string{
 				"Content-Type":           "yolo",
-				"Content-Encoding":       string(SnappyBlockCompression),
+				"Content-Encoding":       compression.Snappy,
 				RemoteWriteVersionHeader: RemoteWriteVersion20HeaderValue,
 			},
 			expectedCode: http.StatusUnsupportedMediaType,
@@ -107,7 +109,7 @@ func TestRemoteWriteHandlerHeadersHandling_V1Message(t *testing.T) {
 			name: "wrong content-type2",
 			reqHeaders: map[string]string{
 				"Content-Type":           appProtoContentType + ";proto=yolo",
-				"Content-Encoding":       string(SnappyBlockCompression),
+				"Content-Encoding":       compression.Snappy,
 				RemoteWriteVersionHeader: RemoteWriteVersion20HeaderValue,
 			},
 			expectedCode: http.StatusUnsupportedMediaType,
@@ -157,7 +159,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 			name: "correct PRW 2.0 headers",
 			reqHeaders: map[string]string{
 				"Content-Type":           remoteWriteContentTypeHeaders[config.RemoteWriteProtoMsgV2],
-				"Content-Encoding":       string(SnappyBlockCompression),
+				"Content-Encoding":       compression.Snappy,
 				RemoteWriteVersionHeader: RemoteWriteVersion20HeaderValue,
 			},
 			expectedCode: http.StatusNoContent,
@@ -166,7 +168,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 			name: "missing remote write version",
 			reqHeaders: map[string]string{
 				"Content-Type":     remoteWriteContentTypeHeaders[config.RemoteWriteProtoMsgV2],
-				"Content-Encoding": string(SnappyBlockCompression),
+				"Content-Encoding": compression.Snappy,
 			},
 			expectedCode: http.StatusNoContent, // We don't check for now.
 		},
@@ -178,7 +180,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 		{
 			name: "missing content-type",
 			reqHeaders: map[string]string{
-				"Content-Encoding":       string(SnappyBlockCompression),
+				"Content-Encoding":       compression.Snappy,
 				RemoteWriteVersionHeader: RemoteWriteVersion20HeaderValue,
 			},
 			// This only gives 415, because we explicitly only support 2.0. If we supported both
@@ -199,7 +201,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 			name: "wrong content-type",
 			reqHeaders: map[string]string{
 				"Content-Type":           "yolo",
-				"Content-Encoding":       string(SnappyBlockCompression),
+				"Content-Encoding":       compression.Snappy,
 				RemoteWriteVersionHeader: RemoteWriteVersion20HeaderValue,
 			},
 			expectedCode: http.StatusUnsupportedMediaType,
@@ -208,7 +210,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 			name: "wrong content-type2",
 			reqHeaders: map[string]string{
 				"Content-Type":           appProtoContentType + ";proto=yolo",
-				"Content-Encoding":       string(SnappyBlockCompression),
+				"Content-Encoding":       compression.Snappy,
 				RemoteWriteVersionHeader: RemoteWriteVersion20HeaderValue,
 			},
 			expectedCode: http.StatusUnsupportedMediaType,
@@ -445,7 +447,7 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 			require.NoError(t, err)
 
 			req.Header.Set("Content-Type", remoteWriteContentTypeHeaders[config.RemoteWriteProtoMsgV2])
-			req.Header.Set("Content-Encoding", string(SnappyBlockCompression))
+			req.Header.Set("Content-Encoding", compression.Snappy)
 			req.Header.Set(RemoteWriteVersionHeader, RemoteWriteVersion20HeaderValue)
 
 			appendable := &mockAppendable{
@@ -715,7 +717,7 @@ func TestCommitErr_V2Message(t *testing.T) {
 	require.NoError(t, err)
 
 	req.Header.Set("Content-Type", remoteWriteContentTypeHeaders[config.RemoteWriteProtoMsgV2])
-	req.Header.Set("Content-Encoding", string(SnappyBlockCompression))
+	req.Header.Set("Content-Encoding", compression.Snappy)
 	req.Header.Set(RemoteWriteVersionHeader, RemoteWriteVersion20HeaderValue)
 
 	appendable := &mockAppendable{commitErr: errors.New("commit error")}

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -41,6 +41,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/tsdb/wlog"
+	"github.com/prometheus/prometheus/util/compression"
 	"github.com/prometheus/prometheus/util/zeropool"
 )
 
@@ -66,7 +67,7 @@ type Options struct {
 	WALSegmentSize int
 
 	// WALCompression configures the compression type to use on records in the WAL.
-	WALCompression wlog.CompressionType
+	WALCompression compression.Type
 
 	// StripeSize is the size (power of 2) in entries of the series hash map. Reducing the size will save memory but impact performance.
 	StripeSize int
@@ -90,7 +91,7 @@ type Options struct {
 func DefaultOptions() *Options {
 	return &Options{
 		WALSegmentSize:       wlog.DefaultSegmentSize,
-		WALCompression:       wlog.CompressionNone,
+		WALCompression:       compression.None,
 		StripeSize:           tsdb.DefaultStripeSize,
 		TruncateFrequency:    DefaultTruncateFrequency,
 		MinWALTime:           DefaultMinWALTime,
@@ -337,7 +338,7 @@ func validateOptions(opts *Options) *Options {
 	}
 
 	if opts.WALCompression == "" {
-		opts.WALCompression = wlog.CompressionNone
+		opts.WALCompression = compression.None
 	}
 
 	// Revert StripeSize to DefaultStripeSize if StripeSize is either 0 or not a power of 2.

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
-	"github.com/prometheus/prometheus/tsdb/wlog"
+	"github.com/prometheus/prometheus/util/compression"
 )
 
 func TestSplitByRange(t *testing.T) {
@@ -1447,7 +1447,7 @@ func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
 func TestHeadCompactionWithHistograms(t *testing.T) {
 	for _, floatTest := range []bool{true, false} {
 		t.Run(fmt.Sprintf("float=%t", floatTest), func(t *testing.T) {
-			head, _ := newTestHead(t, DefaultBlockDuration, wlog.CompressionNone, false)
+			head, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
 			require.NoError(t, head.Init(0))
 			t.Cleanup(func() {
 				require.NoError(t, head.Close())
@@ -1627,11 +1627,11 @@ func TestSparseHistogramSpaceSavings(t *testing.T) {
 				c.numBuckets,
 			),
 			func(t *testing.T) {
-				oldHead, _ := newTestHead(t, DefaultBlockDuration, wlog.CompressionNone, false)
+				oldHead, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
 				t.Cleanup(func() {
 					require.NoError(t, oldHead.Close())
 				})
-				sparseHead, _ := newTestHead(t, DefaultBlockDuration, wlog.CompressionNone, false)
+				sparseHead, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
 				t.Cleanup(func() {
 					require.NoError(t, sparseHead.Close())
 				})

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -46,6 +46,7 @@ import (
 	_ "github.com/prometheus/prometheus/tsdb/goversion" // Load the package into main to make sure minimum Go version is met.
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/tsdb/wlog"
+	"github.com/prometheus/prometheus/util/compression"
 )
 
 const (
@@ -80,7 +81,7 @@ func DefaultOptions() *Options {
 		MaxBlockDuration:            DefaultBlockDuration,
 		NoLockfile:                  false,
 		SamplesPerChunk:             DefaultSamplesPerChunk,
-		WALCompression:              wlog.CompressionNone,
+		WALCompression:              compression.None,
 		StripeSize:                  DefaultStripeSize,
 		HeadChunksWriteBufferSize:   chunks.DefaultWriteBufferSize,
 		IsolationDisabled:           defaultIsolationDisabled,
@@ -124,7 +125,7 @@ type Options struct {
 	NoLockfile bool
 
 	// WALCompression configures the compression type to use on records in the WAL.
-	WALCompression wlog.CompressionType
+	WALCompression compression.Type
 
 	// Maximum number of CPUs that can simultaneously processes WAL replay.
 	// If it is <=0, then GOMAXPROCS is used.

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-	"github.com/prometheus/prometheus/tsdb/wlog"
+	"github.com/prometheus/prometheus/util/compression"
 )
 
 func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
@@ -132,7 +132,7 @@ func BenchmarkHead_WalCommit(b *testing.B) {
 
 					for i := 0; i < b.N; i++ {
 						b.StopTimer()
-						h, w := newTestHead(b, 10000, wlog.CompressionNone, false)
+						h, w := newTestHead(b, 10000, compression.None, false)
 						b.Cleanup(func() {
 							if h != nil {
 								h.Close()

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -128,11 +128,10 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		var err error
 		dec := record.NewDecoder(syms)
 		for r.Next() {
-			rec := r.Record()
-			switch dec.Type(rec) {
+			switch dec.Type(r.Record()) {
 			case record.Series:
 				series := h.wlReplaySeriesPool.Get()[:0]
-				series, err = dec.Series(rec, series)
+				series, err = dec.Series(r.Record(), series)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
 						Err:     fmt.Errorf("decode series: %w", err),
@@ -144,7 +143,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				decoded <- series
 			case record.Samples:
 				samples := h.wlReplaySamplesPool.Get()[:0]
-				samples, err = dec.Samples(rec, samples)
+				samples, err = dec.Samples(r.Record(), samples)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
 						Err:     fmt.Errorf("decode samples: %w", err),
@@ -156,7 +155,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				decoded <- samples
 			case record.Tombstones:
 				tstones := h.wlReplaytStonesPool.Get()[:0]
-				tstones, err = dec.Tombstones(rec, tstones)
+				tstones, err = dec.Tombstones(r.Record(), tstones)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
 						Err:     fmt.Errorf("decode tombstones: %w", err),
@@ -168,7 +167,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				decoded <- tstones
 			case record.Exemplars:
 				exemplars := h.wlReplayExemplarsPool.Get()[:0]
-				exemplars, err = dec.Exemplars(rec, exemplars)
+				exemplars, err = dec.Exemplars(r.Record(), exemplars)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
 						Err:     fmt.Errorf("decode exemplars: %w", err),
@@ -180,7 +179,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				decoded <- exemplars
 			case record.HistogramSamples, record.CustomBucketsHistogramSamples:
 				hists := h.wlReplayHistogramsPool.Get()[:0]
-				hists, err = dec.HistogramSamples(rec, hists)
+				hists, err = dec.HistogramSamples(r.Record(), hists)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
 						Err:     fmt.Errorf("decode histograms: %w", err),
@@ -192,7 +191,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				decoded <- hists
 			case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
 				hists := h.wlReplayFloatHistogramsPool.Get()[:0]
-				hists, err = dec.FloatHistogramSamples(rec, hists)
+				hists, err = dec.FloatHistogramSamples(r.Record(), hists)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
 						Err:     fmt.Errorf("decode float histograms: %w", err),
@@ -204,7 +203,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				decoded <- hists
 			case record.Metadata:
 				meta := h.wlReplayMetadataPool.Get()[:0]
-				meta, err := dec.Metadata(rec, meta)
+				meta, err := dec.Metadata(r.Record(), meta)
 				if err != nil {
 					decodeErr = &wlog.CorruptionErr{
 						Err:     fmt.Errorf("decode metadata: %w", err),

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -72,7 +72,7 @@ func (o *OOOChunk) NumSamples() int {
 
 // ToEncodedChunks returns chunks with the samples in the OOOChunk.
 //
-//nolint:revive // unexported-return
+//nolint:revive
 func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error) {
 	if len(o.samples) == 0 {
 		return nil, nil

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
-	"github.com/prometheus/prometheus/tsdb/wlog"
+	"github.com/prometheus/prometheus/util/compression"
 )
 
 type chunkInterval struct {
@@ -300,7 +300,7 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 		for perm, intervals := range permutations {
 			for _, headChunk := range []bool{false, true} {
 				t.Run(fmt.Sprintf("name=%s, permutation=%d, headChunk=%t", tc.name, perm, headChunk), func(t *testing.T) {
-					h, _ := newTestHead(t, 1000, wlog.CompressionNone, true)
+					h, _ := newTestHead(t, 1000, compression.None, true)
 					defer func() {
 						require.NoError(t, h.Close())
 					}()
@@ -388,7 +388,7 @@ func TestOOOHeadChunkReader_LabelValues(t *testing.T) {
 //nolint:revive // unexported-return
 func testOOOHeadChunkReader_LabelValues(t *testing.T, scenario sampleTypeScenario) {
 	chunkRange := int64(2000)
-	head, _ := newTestHead(t, chunkRange, wlog.CompressionNone, true)
+	head, _ := newTestHead(t, chunkRange, compression.None, true)
 	head.opts.EnableOOONativeHistograms.Store(true)
 	t.Cleanup(func() { require.NoError(t, head.Close()) })
 

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -23,14 +23,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/prometheus/common/promslog"
+	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/util/compression"
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
@@ -170,7 +170,7 @@ func TestCheckpoint(t *testing.T) {
 		}
 	}
 
-	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
+	for _, compress := range compression.Types() {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
 			dir := t.TempDir()
 
@@ -385,7 +385,7 @@ func TestCheckpoint(t *testing.T) {
 func TestCheckpointNoTmpFolderAfterError(t *testing.T) {
 	// Create a new wlog with invalid data.
 	dir := t.TempDir()
-	w, err := NewSize(nil, nil, dir, 64*1024, CompressionNone)
+	w, err := NewSize(nil, nil, dir, 64*1024, compression.None)
 	require.NoError(t, err)
 	var enc record.Encoder
 	require.NoError(t, w.Log(enc.Series([]record.RefSeries{

--- a/tsdb/wlog/live_reader.go
+++ b/tsdb/wlog/live_reader.go
@@ -22,9 +22,9 @@ import (
 	"io"
 	"log/slog"
 
-	"github.com/golang/snappy"
-	"github.com/klauspost/compress/zstd"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus/prometheus/util/compression"
 )
 
 // LiveReaderMetrics holds all metrics exposed by the LiveReader.
@@ -51,14 +51,11 @@ func NewLiveReaderMetrics(reg prometheus.Registerer) *LiveReaderMetrics {
 
 // NewLiveReader returns a new live reader.
 func NewLiveReader(logger *slog.Logger, metrics *LiveReaderMetrics, r io.Reader) *LiveReader {
-	// Calling zstd.NewReader with a nil io.Reader and no options cannot return an error.
-	zstdReader, _ := zstd.NewReader(nil)
-
 	lr := &LiveReader{
-		logger:     logger,
-		rdr:        r,
-		zstdReader: zstdReader,
-		metrics:    metrics,
+		logger:  logger,
+		rdr:     r,
+		decBuf:  compression.NewSyncDecodeBuffer(),
+		metrics: metrics,
 
 		// Until we understand how they come about, make readers permissive
 		// to records spanning pages.
@@ -72,12 +69,13 @@ func NewLiveReader(logger *slog.Logger, metrics *LiveReaderMetrics, r io.Reader)
 // that are still in the process of being written, and returns records as soon
 // as they can be read.
 type LiveReader struct {
-	logger      *slog.Logger
-	rdr         io.Reader
-	err         error
-	rec         []byte
-	compressBuf []byte
-	zstdReader  *zstd.Decoder
+	logger *slog.Logger
+	rdr    io.Reader
+	err    error
+	rec    []byte
+
+	precomprBuf []byte
+	decBuf      compression.DecodeBuffer
 	hdr         [recordHeaderSize]byte
 	buf         [pageSize]byte
 	readIndex   int   // Index in buf to start at for next read.
@@ -195,18 +193,19 @@ func (r *LiveReader) buildRecord() (bool, error) {
 
 		rt := recTypeFromHeader(r.hdr[0])
 		if rt == recFirst || rt == recFull {
-			r.rec = r.rec[:0]
-			r.compressBuf = r.compressBuf[:0]
+			r.precomprBuf = r.precomprBuf[:0]
 		}
 
-		isSnappyCompressed := r.hdr[0]&snappyMask == snappyMask
-		isZstdCompressed := r.hdr[0]&zstdMask == zstdMask
-
-		if isSnappyCompressed || isZstdCompressed {
-			r.compressBuf = append(r.compressBuf, temp...)
-		} else {
-			r.rec = append(r.rec, temp...)
+		// Segment format has only 2 bits, so it's either of those 3 options.
+		// https://github.com/prometheus/prometheus/blob/main/tsdb/docs/format/wal.md#records-encoding
+		compr := compression.None
+		if r.hdr[0]&snappyMask == snappyMask {
+			compr = compression.Snappy
+		} else if r.hdr[0]&zstdMask == zstdMask {
+			compr = compression.Zstd
 		}
+
+		r.precomprBuf = append(r.precomprBuf, temp...)
 
 		if err := validateRecord(rt, r.index); err != nil {
 			r.index = 0
@@ -214,20 +213,9 @@ func (r *LiveReader) buildRecord() (bool, error) {
 		}
 		if rt == recLast || rt == recFull {
 			r.index = 0
-			if isSnappyCompressed && len(r.compressBuf) > 0 {
-				// The snappy library uses `len` to calculate if we need a new buffer.
-				// In order to allocate as few buffers as possible make the length
-				// equal to the capacity.
-				r.rec = r.rec[:cap(r.rec)]
-				r.rec, err = snappy.Decode(r.rec, r.compressBuf)
-				if err != nil {
-					return false, err
-				}
-			} else if isZstdCompressed && len(r.compressBuf) > 0 {
-				r.rec, err = r.zstdReader.DecodeAll(r.compressBuf, r.rec[:0])
-				if err != nil {
-					return false, err
-				}
+			r.rec, err = compression.Decode(compr, r.precomprBuf, r.decBuf)
+			if err != nil {
+				return false, err
 			}
 			return true, nil
 		}

--- a/tsdb/wlog/reader.go
+++ b/tsdb/wlog/reader.go
@@ -21,17 +21,17 @@ import (
 	"hash/crc32"
 	"io"
 
-	"github.com/golang/snappy"
-	"github.com/klauspost/compress/zstd"
+	"github.com/prometheus/prometheus/util/compression"
 )
 
 // Reader reads WAL records from an io.Reader.
 type Reader struct {
-	rdr         io.Reader
-	err         error
-	rec         []byte
-	compressBuf []byte
-	zstdReader  *zstd.Decoder
+	rdr io.Reader
+	err error
+	rec []byte
+
+	precomprBuf []byte
+	decBuf      compression.DecodeBuffer
 	buf         [pageSize]byte
 	total       int64   // Total bytes processed.
 	curRecTyp   recType // Used for checking that the last record is not torn.
@@ -39,15 +39,13 @@ type Reader struct {
 
 // NewReader returns a new reader.
 func NewReader(r io.Reader) *Reader {
-	// Calling zstd.NewReader with a nil io.Reader and no options cannot return an error.
-	zstdReader, _ := zstd.NewReader(nil)
-	return &Reader{rdr: r, zstdReader: zstdReader}
+	return &Reader{rdr: r, decBuf: compression.NewSyncDecodeBuffer()}
 }
 
 // Next advances the reader to the next records and returns true if it exists.
 // It must not be called again after it returned false.
 func (r *Reader) Next() bool {
-	err := r.next()
+	err := r.nextNew()
 	if err != nil && errors.Is(err, io.EOF) {
 		// The last WAL segment record shouldn't be torn(should be full or last).
 		// The last record would be torn after a crash just before
@@ -61,14 +59,13 @@ func (r *Reader) Next() bool {
 	return r.err == nil
 }
 
-func (r *Reader) next() (err error) {
+func (r *Reader) nextNew() (err error) {
 	// We have to use r.buf since allocating byte arrays here fails escape
 	// analysis and ends up on the heap, even though it seemingly should not.
 	hdr := r.buf[:recordHeaderSize]
 	buf := r.buf[recordHeaderSize:]
 
-	r.rec = r.rec[:0]
-	r.compressBuf = r.compressBuf[:0]
+	r.precomprBuf = r.precomprBuf[:0]
 
 	i := 0
 	for {
@@ -77,8 +74,13 @@ func (r *Reader) next() (err error) {
 		}
 		r.total++
 		r.curRecTyp = recTypeFromHeader(hdr[0])
-		isSnappyCompressed := hdr[0]&snappyMask == snappyMask
-		isZstdCompressed := hdr[0]&zstdMask == zstdMask
+
+		compr := compression.None
+		if hdr[0]&snappyMask == snappyMask {
+			compr = compression.Snappy
+		} else if hdr[0]&zstdMask == zstdMask {
+			compr = compression.Zstd
+		}
 
 		// Gobble up zero bytes.
 		if r.curRecTyp == recPageTerm {
@@ -133,29 +135,14 @@ func (r *Reader) next() (err error) {
 		if c := crc32.Checksum(buf[:length], castagnoliTable); c != crc {
 			return fmt.Errorf("unexpected checksum %x, expected %x", c, crc)
 		}
-
-		if isSnappyCompressed || isZstdCompressed {
-			r.compressBuf = append(r.compressBuf, buf[:length]...)
-		} else {
-			r.rec = append(r.rec, buf[:length]...)
-		}
-
 		if err := validateRecord(r.curRecTyp, i); err != nil {
 			return err
 		}
+
+		r.precomprBuf = append(r.precomprBuf, buf[:length]...)
 		if r.curRecTyp == recLast || r.curRecTyp == recFull {
-			if isSnappyCompressed && len(r.compressBuf) > 0 {
-				// The snappy library uses `len` to calculate if we need a new buffer.
-				// In order to allocate as few buffers as possible make the length
-				// equal to the capacity.
-				r.rec = r.rec[:cap(r.rec)]
-				r.rec, err = snappy.Decode(r.rec, r.compressBuf)
-				return err
-			} else if isZstdCompressed && len(r.compressBuf) > 0 {
-				r.rec, err = r.zstdReader.DecodeAll(r.compressBuf, r.rec[:0])
-				return err
-			}
-			return nil
+			r.rec, err = compression.Decode(compr, r.precomprBuf, r.decBuf)
+			return err
 		}
 
 		// Only increment i for non-zero records since we use it

--- a/tsdb/wlog/reader_test.go
+++ b/tsdb/wlog/reader_test.go
@@ -29,11 +29,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
-	"github.com/prometheus/common/promslog"
-
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	"github.com/prometheus/prometheus/util/compression"
 )
 
 type reader interface {
@@ -315,7 +315,7 @@ func allSegments(dir string) (io.ReadCloser, error) {
 
 func TestReaderFuzz(t *testing.T) {
 	for name, fn := range readerConstructors {
-		for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
+		for _, compress := range compression.Types() {
 			t.Run(fmt.Sprintf("%s,compress=%s", name, compress), func(t *testing.T) {
 				dir := t.TempDir()
 
@@ -354,7 +354,7 @@ func TestReaderFuzz(t *testing.T) {
 
 func TestReaderFuzz_Live(t *testing.T) {
 	logger := promslog.NewNopLogger()
-	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
+	for _, compress := range compression.Types() {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
 			dir := t.TempDir()
 
@@ -444,7 +444,7 @@ func TestLiveReaderCorrupt_ShortFile(t *testing.T) {
 	logger := promslog.NewNopLogger()
 	dir := t.TempDir()
 
-	w, err := NewSize(nil, nil, dir, pageSize, CompressionNone)
+	w, err := NewSize(nil, nil, dir, pageSize, compression.None)
 	require.NoError(t, err)
 
 	rec := make([]byte, pageSize-recordHeaderSize)
@@ -484,7 +484,7 @@ func TestLiveReaderCorrupt_RecordTooLongAndShort(t *testing.T) {
 	logger := promslog.NewNopLogger()
 	dir := t.TempDir()
 
-	w, err := NewSize(nil, nil, dir, pageSize*2, CompressionNone)
+	w, err := NewSize(nil, nil, dir, pageSize*2, compression.None)
 	require.NoError(t, err)
 
 	rec := make([]byte, pageSize-recordHeaderSize)
@@ -531,7 +531,7 @@ func TestReaderData(t *testing.T) {
 
 	for name, fn := range readerConstructors {
 		t.Run(name, func(t *testing.T) {
-			w, err := New(nil, nil, dir, CompressionSnappy)
+			w, err := New(nil, nil, dir, compression.Snappy)
 			require.NoError(t, err)
 
 			sr, err := allSegments(dir)

--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/util/compression"
 )
 
 var (
@@ -142,7 +143,7 @@ func TestTailSamples(t *testing.T) {
 	const samplesCount = 250
 	const exemplarsCount = 25
 	const histogramsCount = 50
-	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
+	for _, compress := range compression.Types() {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
 			now := time.Now()
 
@@ -290,7 +291,7 @@ func TestReadToEndNoCheckpoint(t *testing.T) {
 	const seriesCount = 10
 	const samplesCount = 250
 
-	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
+	for _, compress := range compression.Types() {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
 			dir := t.TempDir()
 			wdir := path.Join(dir, "wal")
@@ -358,7 +359,7 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 	const seriesCount = 10
 	const samplesCount = 250
 
-	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
+	for _, compress := range compression.Types() {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
 			dir := t.TempDir()
 
@@ -446,7 +447,7 @@ func TestReadCheckpoint(t *testing.T) {
 	const seriesCount = 10
 	const samplesCount = 250
 
-	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
+	for _, compress := range compression.Types() {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
 			dir := t.TempDir()
 
@@ -519,7 +520,7 @@ func TestReadCheckpointMultipleSegments(t *testing.T) {
 	const seriesCount = 20
 	const samplesCount = 300
 
-	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
+	for _, compress := range compression.Types() {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
 			dir := t.TempDir()
 
@@ -590,11 +591,11 @@ func TestCheckpointSeriesReset(t *testing.T) {
 	const seriesCount = 20
 	const samplesCount = 350
 	testCases := []struct {
-		compress CompressionType
+		compress compression.Type
 		segments int
 	}{
-		{compress: CompressionNone, segments: 14},
-		{compress: CompressionSnappy, segments: 13},
+		{compress: compression.None, segments: 14},
+		{compress: compression.Snappy, segments: 13},
 	}
 
 	for _, tc := range testCases {
@@ -681,8 +682,8 @@ func TestRun_StartupTime(t *testing.T) {
 	const seriesCount = 20
 	const samplesCount = 300
 
-	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
-		t.Run(string(compress), func(t *testing.T) {
+	for _, compress := range compression.Types() {
+		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
 			dir := t.TempDir()
 
 			wdir := path.Join(dir, "wal")
@@ -774,8 +775,8 @@ func TestRun_AvoidNotifyWhenBehind(t *testing.T) {
 	const seriesCount = 10
 	const samplesCount = 50
 
-	for _, compress := range []CompressionType{CompressionNone, CompressionSnappy, CompressionZstd} {
-		t.Run(string(compress), func(t *testing.T) {
+	for _, compress := range compression.Types() {
+		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
 			dir := t.TempDir()
 
 			wdir := path.Join(dir, "wal")

--- a/tsdb/wlog/wlog.go
+++ b/tsdb/wlog/wlog.go
@@ -29,12 +29,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/snappy"
-	"github.com/klauspost/compress/zstd"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/promslog"
 
 	"github.com/prometheus/prometheus/tsdb/fileutil"
+	"github.com/prometheus/prometheus/util/compression"
 )
 
 const (
@@ -169,26 +169,6 @@ func OpenReadSegment(fn string) (*Segment, error) {
 	return &Segment{SegmentFile: f, i: k, dir: filepath.Dir(fn)}, nil
 }
 
-type CompressionType string
-
-const (
-	CompressionNone   CompressionType = "none"
-	CompressionSnappy CompressionType = "snappy"
-	CompressionZstd   CompressionType = "zstd"
-)
-
-// ParseCompressionType parses the two compression-related configuration values and returns the CompressionType. If
-// compression is enabled but the compressType is unrecognized, we default to Snappy compression.
-func ParseCompressionType(compress bool, compressType string) CompressionType {
-	if compress {
-		if compressType == "zstd" {
-			return CompressionZstd
-		}
-		return CompressionSnappy
-	}
-	return CompressionNone
-}
-
 // WL is a write log that stores records in segment files.
 // It must be read from start to end once before logging new data.
 // If an error occurs during read, the repair procedure must be called
@@ -210,9 +190,8 @@ type WL struct {
 	stopc       chan chan struct{}
 	actorc      chan func()
 	closed      bool // To allow calling Close() more than once without blocking.
-	compress    CompressionType
-	compressBuf []byte
-	zstdWriter  *zstd.Encoder
+	compress    compression.Type
+	cEnc        compression.EncodeBuffer
 
 	WriteNotified WriteNotified
 
@@ -220,14 +199,17 @@ type WL struct {
 }
 
 type wlMetrics struct {
-	fsyncDuration   prometheus.Summary
-	pageFlushes     prometheus.Counter
-	pageCompletions prometheus.Counter
-	truncateFail    prometheus.Counter
-	truncateTotal   prometheus.Counter
-	currentSegment  prometheus.Gauge
-	writesFailed    prometheus.Counter
-	walFileSize     prometheus.GaugeFunc
+	fsyncDuration    prometheus.Summary
+	pageFlushes      prometheus.Counter
+	pageCompletions  prometheus.Counter
+	truncateFail     prometheus.Counter
+	truncateTotal    prometheus.Counter
+	currentSegment   prometheus.Gauge
+	writesFailed     prometheus.Counter
+	walFileSize      prometheus.GaugeFunc
+	recordPartWrites prometheus.Counter
+	recordPartBytes  prometheus.Counter
+	recordBytesSaved *prometheus.CounterVec
 
 	r prometheus.Registerer
 }
@@ -244,78 +226,78 @@ func (w *wlMetrics) Unregister() {
 	w.r.Unregister(w.currentSegment)
 	w.r.Unregister(w.writesFailed)
 	w.r.Unregister(w.walFileSize)
+	w.r.Unregister(w.recordPartWrites)
+	w.r.Unregister(w.recordPartBytes)
+	w.r.Unregister(w.recordBytesSaved)
 }
 
 func newWLMetrics(w *WL, r prometheus.Registerer) *wlMetrics {
-	m := &wlMetrics{
+	return &wlMetrics{
 		r: r,
+		fsyncDuration: promauto.With(r).NewSummary(prometheus.SummaryOpts{
+			Name:       "fsync_duration_seconds",
+			Help:       "Duration of write log fsync.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		}),
+		pageFlushes: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "page_flushes_total",
+			Help: "Total number of page flushes.",
+		}),
+		pageCompletions: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "completed_pages_total",
+			Help: "Total number of completed pages.",
+		}),
+		truncateFail: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "truncations_failed_total",
+			Help: "Total number of write log truncations that failed.",
+		}),
+		truncateTotal: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "truncations_total",
+			Help: "Total number of write log truncations attempted.",
+		}),
+		currentSegment: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "segment_current",
+			Help: "Write log segment index that TSDB is currently writing to.",
+		}),
+		writesFailed: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "writes_failed_total",
+			Help: "Total number of write log writes that failed.",
+		}),
+		walFileSize: promauto.With(r).NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "storage_size_bytes",
+			Help: "Size of the write log directory.",
+		}, func() float64 {
+			val, err := w.Size()
+			if err != nil {
+				w.logger.Error("Failed to calculate size of \"wal\" dir", "err", err.Error())
+			}
+			return float64(val)
+		}),
+		recordPartWrites: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "record_part_writes_total",
+			Help: "Total number of record parts written before flushing.",
+		}),
+		recordPartBytes: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Name: "record_parts_bytes_written_total",
+			Help: "Total number of record part bytes written before flushing, including" +
+				" CRC and compression headers.",
+		}),
+		recordBytesSaved: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "record_bytes_saved_total",
+			Help: "Total number of bytes saved by the optional record compression." +
+				" Use this metric to learn about the effectiveness compression.",
+		}, []string{"compression"}),
 	}
-
-	m.fsyncDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name:       "fsync_duration_seconds",
-		Help:       "Duration of write log fsync.",
-		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-	})
-	m.pageFlushes = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "page_flushes_total",
-		Help: "Total number of page flushes.",
-	})
-	m.pageCompletions = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "completed_pages_total",
-		Help: "Total number of completed pages.",
-	})
-	m.truncateFail = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "truncations_failed_total",
-		Help: "Total number of write log truncations that failed.",
-	})
-	m.truncateTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "truncations_total",
-		Help: "Total number of write log truncations attempted.",
-	})
-	m.currentSegment = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "segment_current",
-		Help: "Write log segment index that TSDB is currently writing to.",
-	})
-	m.writesFailed = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "writes_failed_total",
-		Help: "Total number of write log writes that failed.",
-	})
-	m.walFileSize = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "storage_size_bytes",
-		Help: "Size of the write log directory.",
-	}, func() float64 {
-		val, err := w.Size()
-		if err != nil {
-			w.logger.Error("Failed to calculate size of \"wal\" dir",
-				"err", err.Error())
-		}
-		return float64(val)
-	})
-
-	if r != nil {
-		r.MustRegister(
-			m.fsyncDuration,
-			m.pageFlushes,
-			m.pageCompletions,
-			m.truncateFail,
-			m.truncateTotal,
-			m.currentSegment,
-			m.writesFailed,
-			m.walFileSize,
-		)
-	}
-
-	return m
 }
 
 // New returns a new WAL over the given directory.
-func New(logger *slog.Logger, reg prometheus.Registerer, dir string, compress CompressionType) (*WL, error) {
+func New(logger *slog.Logger, reg prometheus.Registerer, dir string, compress compression.Type) (*WL, error) {
 	return NewSize(logger, reg, dir, DefaultSegmentSize, compress)
 }
 
 // NewSize returns a new write log over the given directory.
 // New segments are created with the specified size.
-func NewSize(logger *slog.Logger, reg prometheus.Registerer, dir string, segmentSize int, compress CompressionType) (*WL, error) {
+func NewSize(logger *slog.Logger, reg prometheus.Registerer, dir string, segmentSize int, compress compression.Type) (*WL, error) {
 	if segmentSize%pageSize != 0 {
 		return nil, errors.New("invalid segment size")
 	}
@@ -326,15 +308,6 @@ func NewSize(logger *slog.Logger, reg prometheus.Registerer, dir string, segment
 		logger = promslog.NewNopLogger()
 	}
 
-	var zstdWriter *zstd.Encoder
-	if compress == CompressionZstd {
-		var err error
-		zstdWriter, err = zstd.NewWriter(nil)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	w := &WL{
 		dir:         dir,
 		logger:      logger,
@@ -343,7 +316,7 @@ func NewSize(logger *slog.Logger, reg prometheus.Registerer, dir string, segment
 		actorc:      make(chan func(), 100),
 		stopc:       make(chan chan struct{}),
 		compress:    compress,
-		zstdWriter:  zstdWriter,
+		cEnc:        compression.NewSyncEncodeBuffer(),
 	}
 	prefix := "prometheus_tsdb_wal_"
 	if filepath.Base(dir) == WblDirName {
@@ -382,22 +355,16 @@ func Open(logger *slog.Logger, dir string) (*WL, error) {
 	if logger == nil {
 		logger = promslog.NewNopLogger()
 	}
-	zstdWriter, err := zstd.NewWriter(nil)
-	if err != nil {
-		return nil, err
-	}
 
 	w := &WL{
-		dir:        dir,
-		logger:     logger,
-		zstdWriter: zstdWriter,
+		dir:    dir,
+		logger: logger,
 	}
-
 	return w, nil
 }
 
 // CompressionType returns if compression is enabled on this WAL.
-func (w *WL) CompressionType() CompressionType {
+func (w *WL) CompressionType() compression.Type {
 	return w.compress
 }
 
@@ -715,26 +682,23 @@ func (w *WL) log(rec []byte, final bool) error {
 	}
 
 	// Compress the record before calculating if a new segment is needed.
-	compressed := false
-	if w.compress == CompressionSnappy && len(rec) > 0 {
-		// If MaxEncodedLen is less than 0 the record is too large to be compressed.
-		if len(rec) > 0 && snappy.MaxEncodedLen(len(rec)) >= 0 {
-			// The snappy library uses `len` to calculate if we need a new buffer.
-			// In order to allocate as few buffers as possible make the length
-			// equal to the capacity.
-			w.compressBuf = w.compressBuf[:cap(w.compressBuf)]
-			w.compressBuf = snappy.Encode(w.compressBuf, rec)
-			if len(w.compressBuf) < len(rec) {
-				rec = w.compressBuf
-				compressed = true
-			}
+	finalCompression := w.compress
+	enc, err := compression.Encode(w.compress, rec, w.cEnc)
+	if err != nil {
+		return err
+	}
+	if w.compress != compression.None {
+		savedBytes := len(rec) - len(enc)
+
+		// Even if the compression was applied, skip it, if there's no benefit
+		// in the WAL record size (we have a choice). For small records e.g. snappy
+		// compression can yield larger records than the uncompressed.
+		if savedBytes <= 0 {
+			enc = rec
+			finalCompression = compression.None
+			savedBytes = 0
 		}
-	} else if w.compress == CompressionZstd && len(rec) > 0 {
-		w.compressBuf = w.zstdWriter.EncodeAll(rec, w.compressBuf[:0])
-		if len(w.compressBuf) < len(rec) {
-			rec = w.compressBuf
-			compressed = true
-		}
+		w.metrics.recordBytesSaved.WithLabelValues(w.compress).Add(float64(savedBytes))
 	}
 
 	// If the record is too big to fit within the active page in the current
@@ -743,7 +707,7 @@ func (w *WL) log(rec []byte, final bool) error {
 	left := w.page.remaining() - recordHeaderSize                                   // Free space in the active page.
 	left += (pageSize - recordHeaderSize) * (w.pagesPerSegment() - w.donePages - 1) // Free pages in the active segment.
 
-	if len(rec) > left {
+	if len(enc) > left {
 		if _, err := w.nextSegment(true); err != nil {
 			return err
 		}
@@ -751,32 +715,36 @@ func (w *WL) log(rec []byte, final bool) error {
 
 	// Populate as many pages as necessary to fit the record.
 	// Be careful to always do one pass to ensure we write zero-length records.
-	for i := 0; i == 0 || len(rec) > 0; i++ {
+	for i := 0; i == 0 || len(enc) > 0; i++ {
 		p := w.page
 
 		// Find how much of the record we can fit into the page.
 		var (
-			l    = min(len(rec), (pageSize-p.alloc)-recordHeaderSize)
-			part = rec[:l]
+			l    = min(len(enc), (pageSize-p.alloc)-recordHeaderSize)
+			part = enc[:l]
 			buf  = p.buf[p.alloc:]
 			typ  recType
 		)
 
 		switch {
-		case i == 0 && len(part) == len(rec):
+		case i == 0 && len(part) == len(enc):
 			typ = recFull
-		case len(part) == len(rec):
+		case len(part) == len(enc):
 			typ = recLast
 		case i == 0:
 			typ = recFirst
 		default:
 			typ = recMiddle
 		}
-		if compressed {
-			if w.compress == CompressionSnappy {
+
+		if finalCompression != compression.None {
+			switch finalCompression {
+			case compression.Snappy:
 				typ |= snappyMask
-			} else if w.compress == CompressionZstd {
+			case compression.Zstd:
 				typ |= zstdMask
+			default:
+				return fmt.Errorf("unsupported compression type: %v", finalCompression)
 			}
 		}
 
@@ -788,6 +756,9 @@ func (w *WL) log(rec []byte, final bool) error {
 		copy(buf[recordHeaderSize:], part)
 		p.alloc += len(part) + recordHeaderSize
 
+		w.metrics.recordPartWrites.Inc()
+		w.metrics.recordPartBytes.Add(float64(len(part) + recordHeaderSize))
+
 		if w.page.full() {
 			if err := w.flushPage(true); err != nil {
 				// TODO When the flushing fails at this point and the record has not been
@@ -796,7 +767,7 @@ func (w *WL) log(rec []byte, final bool) error {
 				return err
 			}
 		}
-		rec = rec[l:]
+		enc = enc[l:]
 	}
 
 	// If it's the final record of the batch and the page is not empty, flush it.

--- a/util/compression/buffers.go
+++ b/util/compression/buffers.go
@@ -1,0 +1,142 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compression
+
+import (
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+type EncodeBuffer interface {
+	zstdEncBuf() *zstd.Encoder
+	get() []byte
+	set([]byte)
+}
+
+type syncEBuffer struct {
+	onceZstd sync.Once
+	w        *zstd.Encoder
+	buf      []byte
+}
+
+// NewSyncEncodeBuffer returns synchronous buffer that can only be used
+// on one encoding goroutine at once. Notably, the encoded byte slice returned
+// by Encode is valid only until the next Encode call.
+func NewSyncEncodeBuffer() EncodeBuffer {
+	return &syncEBuffer{}
+}
+
+func (b *syncEBuffer) zstdEncBuf() *zstd.Encoder {
+	b.onceZstd.Do(func() {
+		// Without params this never returns error.
+		b.w, _ = zstd.NewWriter(nil)
+	})
+	return b.w
+}
+
+func (b *syncEBuffer) get() []byte {
+	return b.buf
+}
+
+func (b *syncEBuffer) set(buf []byte) {
+	b.buf = buf
+}
+
+type concurrentEBuffer struct {
+	onceZstd sync.Once
+	w        *zstd.Encoder
+}
+
+// NewConcurrentEncodeBuffer returns a buffer that can be used concurrently.
+// NOTE: For Zstd compression, a concurrency limit equal to GOMAXPROCS is implied.
+func NewConcurrentEncodeBuffer() EncodeBuffer {
+	return &concurrentEBuffer{}
+}
+
+func (b *concurrentEBuffer) zstdEncBuf() *zstd.Encoder {
+	b.onceZstd.Do(func() {
+		// Without params this never returns error.
+		b.w, _ = zstd.NewWriter(nil)
+	})
+	return b.w
+}
+
+// TODO(bwplotka): We could use pool, but putting it back into the pool needs to be
+// on the caller side, so no pool for now.
+func (b *concurrentEBuffer) get() []byte {
+	return nil
+}
+
+func (b *concurrentEBuffer) set([]byte) {}
+
+type DecodeBuffer interface {
+	zstdDecBuf() *zstd.Decoder
+	get() []byte
+	set([]byte)
+}
+
+type syncDBuffer struct {
+	onceZstd sync.Once
+	r        *zstd.Decoder
+	buf      []byte
+}
+
+// NewSyncDecodeBuffer returns synchronous buffer that can only be used
+// on one decoding goroutine at once. Notably, the decoded byte slice returned
+// by Decode is valid only until the next Decode call.
+func NewSyncDecodeBuffer() DecodeBuffer {
+	return &syncDBuffer{}
+}
+
+func (b *syncDBuffer) zstdDecBuf() *zstd.Decoder {
+	b.onceZstd.Do(func() {
+		// Without params this never returns error.
+		b.r, _ = zstd.NewReader(nil)
+	})
+	return b.r
+}
+
+func (b *syncDBuffer) get() []byte {
+	return b.buf
+}
+
+func (b *syncDBuffer) set(buf []byte) {
+	b.buf = buf
+}
+
+type concurrentDBuffer struct {
+	onceZstd sync.Once
+	r        *zstd.Decoder
+}
+
+// NewConcurrentDecodeBuffer returns a buffer that can be used concurrently.
+// NOTE: For Zstd compression a concurrency limit, equal to GOMAXPROCS is implied.
+func NewConcurrentDecodeBuffer() DecodeBuffer {
+	return &concurrentDBuffer{}
+}
+
+func (b *concurrentDBuffer) zstdDecBuf() *zstd.Decoder {
+	b.onceZstd.Do(func() {
+		// Without params this never returns error.
+		b.r, _ = zstd.NewReader(nil)
+	})
+	return b.r
+}
+
+func (b *concurrentDBuffer) get() []byte {
+	return nil
+}
+
+func (b *concurrentDBuffer) set([]byte) {}

--- a/util/compression/compression.go
+++ b/util/compression/compression.go
@@ -1,0 +1,122 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compression
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/golang/snappy"
+)
+
+// Type represents a valid compression type supported by this package.
+type Type = string
+
+const (
+	// None represents no compression case.
+	// None is the default when Type is empty.
+	None Type = "none"
+	// Snappy represents snappy block format.
+	Snappy Type = "snappy"
+	// Zstd represents "speed" mode of Zstd (Zstandard https://facebook.github.io/zstd/).
+	// This is roughly equivalent to the default Zstandard mode (level 3).
+	Zstd Type = "zstd"
+)
+
+func Types() []Type { return []Type{None, Snappy, Zstd} }
+
+// Encode returns the encoded form of src for the given compression type.
+// For None or empty message the encoding is not attempted.
+//
+// The buf allows passing various buffer implementations that make encoding more
+// efficient. See NewSyncEncodeBuffer and NewConcurrentEncodeBuffer for further
+// details. For non-zstd compression types, it is valid to pass nil buf.
+//
+// Encode is concurrency-safe, however note the concurrency limits for the
+// buffer of your choice.
+func Encode(t Type, src []byte, buf EncodeBuffer) (ret []byte, err error) {
+	if len(src) == 0 || t == "" || t == None {
+		return src, nil
+	}
+	if t == Snappy {
+		// If MaxEncodedLen is less than 0 the record is too large to be compressed.
+		if snappy.MaxEncodedLen(len(src)) < 0 {
+			return src, fmt.Errorf("compression: Snappy can't encode such a large message: %v", len(src))
+		}
+		var b []byte
+		if buf != nil {
+			b = buf.get()
+			defer func() {
+				buf.set(ret)
+			}()
+		}
+
+		// The snappy library uses `len` to calculate if we need a new buffer.
+		// In order to allocate as few buffers as possible make the length
+		// equal to the capacity.
+		b = b[:cap(b)]
+		return snappy.Encode(b, src), nil
+	}
+	if t == Zstd {
+		if buf == nil {
+			return nil, errors.New("zstd requested but EncodeBuffer was not provided")
+		}
+		b := buf.get()
+		defer func() {
+			buf.set(ret)
+		}()
+
+		return buf.zstdEncBuf().EncodeAll(src, b[:0]), nil
+	}
+	return nil, fmt.Errorf("unsupported compression type: %s", t)
+}
+
+// Decode returns the decoded form of src for the given compression type.
+//
+// The buf allows passing various buffer implementations that make decoding more
+// efficient. See NewSyncDecodeBuffer and NewConcurrentDecodeBuffer for further
+// details. For non-zstd compression types, it is valid to pass nil buf.
+//
+// Decode is concurrency-safe, however note the concurrency limits for the
+// buffer of your choice.
+func Decode(t Type, src []byte, buf DecodeBuffer) (ret []byte, err error) {
+	if len(src) == 0 || t == "" || t == None {
+		return src, nil
+	}
+	if t == Snappy {
+		var b []byte
+		if buf != nil {
+			b = buf.get()
+			defer func() {
+				buf.set(ret)
+			}()
+		}
+		// The snappy library uses `len` to calculate if we need a new buffer.
+		// In order to allocate as few buffers as possible make the length
+		// equal to the capacity.
+		b = b[:cap(b)]
+		return snappy.Decode(b, src)
+	}
+	if t == Zstd {
+		if buf == nil {
+			return nil, errors.New("zstd requested but DecodeBuffer was not provided")
+		}
+		b := buf.get()
+		defer func() {
+			buf.set(ret)
+		}()
+		return buf.zstdDecBuf().DecodeAll(src, b[:0])
+	}
+	return nil, fmt.Errorf("unsupported compression type: %s", t)
+}

--- a/util/compression/compression_test.go
+++ b/util/compression/compression_test.go
@@ -1,0 +1,193 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compression
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const compressible = `ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa
+fsfsdfsfddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa2
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa12
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa1
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa121
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa324
+ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa145
+`
+
+func TestEncodeDecode(t *testing.T) {
+	for _, tcase := range []struct {
+		name string
+
+		src               string
+		types             []Type
+		encBuf            EncodeBuffer
+		decBuf            DecodeBuffer
+		expectCompression bool
+		expectEncErr      error
+	}{
+		{
+			name:              "empty src; no buffers",
+			types:             Types(),
+			src:               "",
+			expectCompression: false,
+		},
+		{
+			name:   "empty src; sync buffers",
+			types:  Types(),
+			encBuf: NewSyncEncodeBuffer(), decBuf: NewSyncDecodeBuffer(),
+			src:               "",
+			expectCompression: false,
+		},
+		{
+			name:   "empty src; concurrent buffers",
+			types:  Types(),
+			encBuf: NewConcurrentEncodeBuffer(), decBuf: NewConcurrentDecodeBuffer(),
+			src:               "",
+			expectCompression: false,
+		},
+		{
+			name:              "no buffers",
+			types:             []Type{None},
+			src:               compressible,
+			expectCompression: false,
+		},
+		{
+			name:              "no buffers",
+			types:             []Type{Snappy},
+			src:               compressible,
+			expectCompression: true,
+		},
+		{
+			name:         "no buffers",
+			types:        []Type{Zstd},
+			src:          compressible,
+			expectEncErr: errors.New("zstd requested but EncodeBuffer was not provided"),
+		},
+		{
+			name:   "sync buffers",
+			types:  []Type{None},
+			encBuf: NewSyncEncodeBuffer(), decBuf: NewSyncDecodeBuffer(),
+			src:               compressible,
+			expectCompression: false,
+		},
+		{
+			name:   "sync buffers",
+			types:  Types()[1:], // All but none
+			encBuf: NewSyncEncodeBuffer(), decBuf: NewSyncDecodeBuffer(),
+			src:               compressible,
+			expectCompression: true,
+		},
+		{
+			name:   "concurrent buffers",
+			types:  []Type{None},
+			encBuf: NewConcurrentEncodeBuffer(), decBuf: NewConcurrentDecodeBuffer(),
+			src:               compressible,
+			expectCompression: false,
+		},
+		{
+			name:   "concurrent buffers",
+			types:  Types()[1:], // All but none
+			encBuf: NewConcurrentEncodeBuffer(), decBuf: NewConcurrentDecodeBuffer(),
+			src:               compressible,
+			expectCompression: true,
+		},
+	} {
+		require.NotEmpty(t, tcase.types, "must specify at least one type")
+		for _, typ := range tcase.types {
+			t.Run(fmt.Sprintf("case=%v/type=%v", tcase.name, typ), func(t *testing.T) {
+				res, err := Encode(typ, []byte(tcase.src), tcase.encBuf)
+				if tcase.expectEncErr != nil {
+					require.ErrorContains(t, err, tcase.expectEncErr.Error())
+					return
+				}
+				require.NoError(t, err)
+				if tcase.expectCompression {
+					require.Less(t, len(res), len(tcase.src))
+				}
+
+				// Decode back.
+				got, err := Decode(typ, res, tcase.decBuf)
+				require.NoError(t, err)
+				require.Equal(t, tcase.src, string(got))
+			})
+		}
+	}
+}
+
+/*
+	export bench=encode-v1 && go test ./util/compression/... \
+		-run '^$' -bench '^BenchmarkEncode' \
+		-benchtime 5s -count 6 -cpu 2 -timeout 999m \
+		| tee ${bench}.txt
+*/
+func BenchmarkEncode(b *testing.B) {
+	for _, typ := range Types() {
+		b.Run(fmt.Sprintf("type=%v", typ), func(b *testing.B) {
+			var buf EncodeBuffer
+			compressible := []byte(compressible)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if buf == nil {
+					buf = NewSyncEncodeBuffer()
+				}
+				res, err := Encode(typ, compressible, buf)
+				require.NoError(b, err)
+				b.ReportMetric(float64(len(res)), "B")
+			}
+		})
+	}
+}
+
+/*
+	export bench=decode-v1 && go test ./util/compression/... \
+		-run '^$' -bench '^BenchmarkDecode' \
+		-benchtime 5s -count 6 -cpu 2 -timeout 999m \
+		| tee ${bench}.txt
+*/
+func BenchmarkDecode(b *testing.B) {
+	for _, typ := range Types() {
+		b.Run(fmt.Sprintf("type=%v", typ), func(b *testing.B) {
+			var buf DecodeBuffer
+			res, err := Encode(typ, []byte(compressible), NewConcurrentEncodeBuffer())
+			require.NoError(b, err)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if buf == nil {
+					buf = NewSyncDecodeBuffer()
+				}
+				_, err := Decode(typ, res, buf)
+				require.NoError(b, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We had a bit mess on our compression uses, trying to consolidate all compressions we use in one package.

At some point we can add gzip, and potentially replace all snappy uses with this util pkg. I noticed this and kind of needed in https://github.com/prometheus/prometheus/pull/16046 (e.g. for my micro-benchmarks that use compressions as well).