### PR TITLE
remote read: Use more informative error msg for timeouts

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -365,7 +365,8 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query, sortSeries bool)
 	httpReq.Header.Set("User-Agent", UserAgent)
 	httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
 
-	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	errTimeout := fmt.Errorf("request timed out after %s", c.timeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, c.timeout, errTimeout)
 
 	ctx, span := otel.Tracer("").Start(ctx, "Remote Read", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -365,7 +365,7 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query, sortSeries bool)
 	httpReq.Header.Set("User-Agent", UserAgent)
 	httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
 
-	errTimeout := fmt.Errorf("request timed out after %s", c.timeout)
+	errTimeout := fmt.Errorf("%w: request timed out after %s", context.DeadlineExceeded, c.timeout)
 	ctx, cancel := context.WithTimeoutCause(ctx, c.timeout, errTimeout)
 
 	ctx, span := otel.Tracer("").Start(ctx, "Remote Read", trace.WithSpanKind(trace.SpanKindClient))


### PR DESCRIPTION
Currently timed out requests return a "context deadline exceeded" error, this PR makes it slightly more informative so users know what is happening.