### PR TITLE
Promql: Prevent extrapolation of NH below zero

### DIFF
--- a/promql/promqltest/testdata/histograms.test
+++ b/promql/promqltest/testdata/histograms.test
@@ -546,7 +546,7 @@ load_with_nhcb 5m
     histogram_with_reset_sum{}          36 16 61
 
 eval instant at 10m increase(histogram_with_reset[15m])
-    {} {{schema:-53 count:27 sum:91.5 custom_values:[1 2 4 8] counter_reset_hint:gauge buckets:[13.5 0 4.5 9]}}
+    {} {{schema:-53 count:23.5 sum:91.5 custom_values:[1 2 4 8] counter_reset_hint:gauge buckets:[10 0 4.5 9]}}
 
 eval instant at 10m resets(histogram_with_reset[15m])
      {} 1

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -987,7 +987,7 @@ load 5m
      reset_in_bucket {{schema:0 count:4 sum:5 buckets:[1 2 1]}} {{schema:0 count:5 sum:6 buckets:[1 1 3]}} {{schema:0 count:6 sum:7 buckets:[1 2 3]}}
 
 eval instant at 10m increase(reset_in_bucket[15m])
-     {} {{count:9 sum:10.5 buckets:[1.5 3 4.5]}}
+     {} {{count:8.5 sum:10.5 buckets:[1.5 3 4]}}
 
 # The following two test the "fast path" where only sum and count is decoded.
 eval instant at 10m histogram_count(increase(reset_in_bucket[15m]))
@@ -1319,3 +1319,32 @@ eval instant at 10m histogram_sub_3{idx="0"} - ignoring(idx) histogram_sub_3{idx
     {} {{schema:0 count:-30 sum:-1111.1 z_bucket:-2 z_bucket_w:0.001 buckets:[-1 0 -1 -2 -1 -1 -1] n_buckets:[0 2 -2 -2 -7 0 0 0 0 -5 -5 -2]}}
 
 clear
+
+# Test prevent extrapolation of total count below zero for native histograms
+# This tests the logic where an increasing counter, if extrapolated linearly
+# backwards to rangeStart, would have a negative count. The clamping of
+# durationToStart to the point where the counter would have been zero
+# affects the extrapolation window and thus the final rate.
+load 10s
+    histo_total_count_clamp_positive_rate {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:0 sum:11 count:11 buckets:[11]}}
+
+eval instant at 10s rate(histo_total_count_clamp_positive_rate[20s])
+    {} {{schema:0 sum:0.55 count:0.55 buckets:[0.55]}}
+
+eval instant at 10s histogram_count(rate(histo_total_count_clamp_positive_rate[20s]))
+    {} 0.55
+
+eval instant at 10s histogram_sum(rate(histo_total_count_clamp_positive_rate[20s]))
+    {} 0.55
+
+clear
+
+# Per‑bucket clamp: bucket 0 would go negative without the fix.
+load 10s
+    histogram_bucket_extrapolation _  _  {{schema:0 sum:0.1 count:1 buckets:[0.1]}} {{schema:0 sum:5.1 count:6 buckets:[5.1]}}
+
+eval instant at 32s rate(histogram_bucket_extrapolation[20s])
+    {} {{schema:0 sum:0.35 count:0.305 buckets:[0.305]}}
+
+eval instant at 32s histogram_count(rate(histogram_bucket_extrapolation[20s]))
+    {} 0.35


### PR DESCRIPTION
fixes #15976 

# Problem statement

When calculating rates for Native Histograms (NH), we need to prevent extrapolation below zero to ensure consistent results with classic histograms.

### What we do now

1. **Zero-point from `count`**
   * Find when a linear back-extrapolation of `count` would hit 0.
   * If that moment lies inside the query range, we clamp the lower boundary to it.

2. **Clamp buckets*
   * Check if bucket would extrapolate below zero or if we clamped total count -  if so reduce the slope.

3. **Adjust  `count`**
   Bucket tweaks change the total count. We add the difference back to  total `count` 
