### PR TITLE
[PERF] removing shadow variables

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -566,7 +566,7 @@ func main() {
 	cfg.web.NotificationsGetter = notifs.Get
 	notifs.AddNotification(notifications.StartingUp)
 
-	if err := cfg.setFeatureListOptions(logger); err != nil {
+	if err = cfg.setFeatureListOptions(logger); err != nil {
 		fmt.Fprintf(os.Stderr, "Error parsing feature list: %s\n", err)
 		os.Exit(1)
 	}
@@ -615,7 +615,7 @@ func main() {
 	}
 	// Get scrape configs to validate dynamically loaded scrape_config_files.
 	// They can change over time, but do the extra validation on startup for better experience.
-	if _, err := cfgFile.GetScrapeConfigs(); err != nil {
+	if _, err = cfgFile.GetScrapeConfigs(); err != nil {
 		absPath, pathErr := filepath.Abs(cfg.configFile)
 		if pathErr != nil {
 			absPath = cfg.configFile
@@ -787,13 +787,13 @@ func main() {
 		l := func(format string, a ...interface{}) {
 			logger.Info(fmt.Sprintf(strings.TrimPrefix(format, "maxprocs: "), a...), "component", "automaxprocs")
 		}
-		if _, err := maxprocs.Set(maxprocs.Logger(l)); err != nil {
+		if _, err = maxprocs.Set(maxprocs.Logger(l)); err != nil {
 			logger.Warn("Failed to set GOMAXPROCS automatically", "component", "automaxprocs", "err", err)
 		}
 	}
 
 	if cfg.memlimitEnable {
-		if _, err := memlimit.SetGoMemLimitWithOpts(
+		if _, err = memlimit.SetGoMemLimitWithOpts(
 			memlimit.WithRatio(cfg.memlimitRatio),
 			memlimit.WithProvider(
 				memlimit.ApplyFallback(


### PR DESCRIPTION
The `:=`  is causing new variables for errors to be created, this PR is just an example for https://github.com/mmorel-35/prometheus/actions/runs/13772600546/job/38514471955?pr=408 fixes, 

for example at some places like here:
https://github.com/miledxz/prometheus/blob/main/cmd/prometheus/main.go#L661 we just can't remove `:=` as the funcs returns another variable, one of the workarounds is renaming err variable while keeping code clean and simple