### PR TITLE
promql: return NaN from `irate()` if second-last sample is NaN

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -367,13 +367,9 @@ func instantValue(vals []parser.Value, args parser.Expressions, out Vector, isRa
 	}
 	switch {
 	case ss[1].H == nil && ss[0].H == nil:
-		if !isRate || ss[1].F >= ss[0].F {
-			// Gauge or counter without reset.
+		if !isRate || !(ss[1].F < ss[0].F) {
+			// Gauge, or counter without reset, or counter with NaN value.
 			resultSample.F = ss[1].F - ss[0].F
-		} else if math.IsNaN(ss[0].F) {
-			// We don't need to do anything extra to handle the case where ss[1].F is a NaN, but we do need to check
-			// ss[0].F in the case where we don't do the subtraction operation above.
-			resultSample.F = math.NaN()
 		}
 
 		// In case of a counter reset, we leave resultSample at

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -370,7 +370,12 @@ func instantValue(vals []parser.Value, args parser.Expressions, out Vector, isRa
 		if !isRate || ss[1].F >= ss[0].F {
 			// Gauge or counter without reset.
 			resultSample.F = ss[1].F - ss[0].F
+		} else if math.IsNaN(ss[0].F) {
+			// We don't need to do anything extra to handle the case where ss[1].F is a NaN, but we do need to check
+			// ss[0].F in the case where we don't do the subtraction operation above.
+			resultSample.F = math.NaN()
 		}
+
 		// In case of a counter reset, we leave resultSample at
 		// its current value, which is already ss[1].
 	case ss[1].H != nil && ss[0].H != nil:

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -218,6 +218,7 @@ clear
 load 5m
 	http_requests_total{path="/foo"}	0+10x10
 	http_requests_total{path="/bar"}	0+10x5 0+10x5
+	http_requests_nan{}               1 NaN NaN 5 11
 	http_requests_histogram{path="/a"} {{sum:2 count:2}}+{{sum:3 count:3}}x5
 	http_requests_histogram{path="/b"} 0 0 {{sum:1 count:1}} {{sum:4 count:4}}
 	http_requests_histogram{path="/c"} 0 0 {{sum:1 count:1}} {{sum:4 count:4 counter_reset_hint:gauge}}
@@ -234,6 +235,9 @@ eval instant at 50m irate(http_requests_total[50m])
 eval instant at 30m irate(http_requests_total[50m])
 	{path="/foo"} .03333333333333333333
 	{path="/bar"} 0
+
+eval range from 0 to 20m step 5m irate(http_requests_nan[15m1s])
+	{} _ NaN NaN NaN 0.02
 
 eval instant at 20m irate(http_requests_histogram{path="/a"}[20m])
 	{path="/a"} {{sum:0.01 count:0.01 counter_reset_hint:gauge}}
@@ -288,6 +292,7 @@ clear
 load 5m
 	http_requests{path="/foo"}	0 50 100 150
 	http_requests{path="/bar"}	0 50 100 50
+	http_requests_nan{}         1 NaN NaN 5 11
 	http_requests_histogram{path="/a"} {{sum:2 count:2 counter_reset_hint:gauge}}+{{sum:1 count:3 counter_reset_hint:gauge}}x5
 	http_requests_histogram{path="/b"} 0 0 {{sum:1 count:1 counter_reset_hint:gauge}} {{sum:2 count:2 counter_reset_hint:gauge}}
 	http_requests_histogram{path="/c"} 0 0 {{sum:1 count:1}} {{sum:2 count:2 counter_reset_hint:gauge}}
@@ -299,6 +304,9 @@ load 5m
 eval instant at 20m idelta(http_requests[20m])
 	{path="/foo"} 50
 	{path="/bar"} -50
+
+eval range from 0 to 20m step 5m idelta(http_requests_nan[15m1s])
+	{} _ NaN NaN NaN 6
 
 eval instant at 20m idelta(http_requests_histogram{path="/a"}[20m])
 	{path="/a"} {{sum:1 count:3 counter_reset_hint:gauge}}


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/prometheus/prometheus/pull/15853 that causes `irate()` to return a non-NaN value if the second-last point is a NaN but the last point is not.

In this case, then `irate()` would ignore the NaN and compute the rate as if a counter reset occurred before the last point.