### PR TITLE
chore: Add comment about DNS resolution issue for failing tests

### DIFF
--- a/discovery/zookeeper/zookeeper_test.go
+++ b/discovery/zookeeper/zookeeper_test.go
@@ -26,9 +26,11 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
 
+// TestNewDiscoveryError can fail if the DNS resolver mistakenly resolves the domain below.
+// See https://github.com/prometheus/prometheus/issues/16191 for a precedent.
 func TestNewDiscoveryError(t *testing.T) {
 	_, err := NewDiscovery(
-		[]string{"unreachable.test"},
+		[]string{"unreachable.invalid"},
 		time.Second, []string{"/"},
 		nil,
 		func(_ []byte, _ string) (model.LabelSet, error) { return nil, nil })

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -72,7 +72,7 @@ func (o *OOOChunk) NumSamples() int {
 
 // ToEncodedChunks returns chunks with the samples in the OOOChunk.
 //
-//nolint:revive // unexported-return
+//nolint:revive
 func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error) {
 	if len(o.samples) == 0 {
 		return nil, nil

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -72,7 +72,7 @@ func (o *OOOChunk) NumSamples() int {
 
 // ToEncodedChunks returns chunks with the samples in the OOOChunk.
 //
-//nolint:revive
+//nolint:revive // unexported-return
 func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error) {
 	if len(o.samples) == 0 {
 		return nil, nil


### PR DESCRIPTION
**What problem did we encounter?**
fixes #16191 

**Why make this change?**
For developers affected by regional restrictions (e.g., those unable to access Google or GitHub), using proxy tools like Clash with TUN mode enabled to route all local traffic is quite common. As a result, when they follow the [contribution guide](https://github.com/prometheus/prometheus/blob/main/CONTRIBUTING.md#steps-to-contribute) and run make test, they may be confused by failing unit tests and struggle to identify the root cause. The newly added comment can help them quickly resolve this issue.