### PR TITLE
golangci: Disable nolintlint due to known issues.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,8 @@ linters:
     - loggercheck
     - misspell
     - nilnesserr
-    - nolintlint
+    # TODO(bwplotka): Enable once https://github.com/golangci/golangci-lint/issues/3228 is fixed.
+    # - nolintlint
     - perfsprint
     - predeclared
     - revive


### PR DESCRIPTION
Fixes: https://github.com/prometheus/prometheus/issues/16203

Details: https://github.com/golangci/golangci-lint/issues/3228
