### PR TITLE
discovery(openstack): remove duplicated error handling for floatingips.List

### DIFF
--- a/discovery/openstack/loadbalancer.go
+++ b/discovery/openstack/loadbalancer.go
@@ -119,9 +119,6 @@ func (i *LoadBalancerDiscovery) refresh(ctx context.Context) ([]*targetgroup.Gro
 	// Fetch all floating IPs
 	fipPages, err := floatingips.List(networkClient, floatingips.ListOpts{}).AllPages(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list all fips: %w", err)
-	}
-	if err != nil {
 		return nil, fmt.Errorf("failed to list floating IPs: %w", err)
 	}
 


### PR DESCRIPTION
Remove duplicate error handling for floating IPs in OpenStack LoadBalancer discovery.
