### PR TITLE
Fix rules UI to display correct value for 'keepFiringFor'

### DIFF
--- a/web/ui/mantine-ui/src/components/RuleDefinition.tsx
+++ b/web/ui/mantine-ui/src/components/RuleDefinition.tsx
@@ -85,7 +85,7 @@ const RuleDefinition: FC<{ rule: Rule }> = ({ rule }) => {
               styles={{ label: { textTransform: "none" } }}
               leftSection={<IconClockPlay style={badgeIconStyle} />}
             >
-              keep_firing_for: {formatPrometheusDuration(rule.duration * 1000)}
+              keep_firing_for: {formatPrometheusDuration(rule.keepFiringFor * 1000)}
             </Badge>
           )}
         </Group>


### PR DESCRIPTION
Fixing new rules UI to show correct value for the `keepFiringFor` attribute. It currently displays the value set in `for` attribute which is a bug.





Signed-off-by: Mustafain Ali Khan <mustalik@amazon.com>
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
