### PR TITLE
chore(discovery): disable some file update tests as flaky

### DIFF
--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"sync"
 	"testing"
@@ -319,6 +320,9 @@ func valid2Tg(file string) []*targetgroup.Group {
 }
 
 func TestInitialUpdate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flaky test, see https://github.com/prometheus/prometheus/issues/16212")
+	}
 	for _, tc := range []string{
 		"fixtures/valid.yml",
 		"fixtures/valid.json",
@@ -363,6 +367,9 @@ func TestInvalidFile(t *testing.T) {
 }
 
 func TestNoopFileUpdate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flaky test, see https://github.com/prometheus/prometheus/issues/16212")
+	}
 	t.Parallel()
 
 	runner := newTestRunner(t)
@@ -381,6 +388,9 @@ func TestNoopFileUpdate(t *testing.T) {
 }
 
 func TestFileUpdate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flaky test, see https://github.com/prometheus/prometheus/issues/16212")
+	}
 	t.Parallel()
 
 	runner := newTestRunner(t)
@@ -399,6 +409,9 @@ func TestFileUpdate(t *testing.T) {
 }
 
 func TestInvalidFileUpdate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flaky test, see https://github.com/prometheus/prometheus/issues/16212")
+	}
 	t.Parallel()
 
 	runner := newTestRunner(t)


### PR DESCRIPTION
discovery tests were enabled on windows in https://github.com/prometheus/prometheus/pull/16196

issue tracking the flakiness https://github.com/prometheus/prometheus/issues/16212

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
