### PR TITLE
[Release 2.53] [BUGFIX] Scraping: bump cache iteration after error

### DIFF
--- a/scrape/helpers_test.go
+++ b/scrape/helpers_test.go
@@ -44,23 +44,23 @@ func (a nopAppendable) Appender(_ context.Context) storage.Appender {
 type nopAppender struct{}
 
 func (a nopAppender) Append(storage.SeriesRef, labels.Labels, int64, float64) (storage.SeriesRef, error) {
-	return 0, nil
+	return 1, nil
 }
 
 func (a nopAppender) AppendExemplar(storage.SeriesRef, labels.Labels, exemplar.Exemplar) (storage.SeriesRef, error) {
-	return 0, nil
+	return 2, nil
 }
 
 func (a nopAppender) AppendHistogram(storage.SeriesRef, labels.Labels, int64, *histogram.Histogram, *histogram.FloatHistogram) (storage.SeriesRef, error) {
-	return 0, nil
+	return 3, nil
 }
 
 func (a nopAppender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
-	return 0, nil
+	return 4, nil
 }
 
 func (a nopAppender) AppendCTZeroSample(storage.SeriesRef, labels.Labels, int64, int64) (storage.SeriesRef, error) {
-	return 0, nil
+	return 5, nil
 }
 
 func (a nopAppender) Commit() error   { return nil }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -947,8 +947,6 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 			}
 		}
 		c.metaMtx.Unlock()
-
-		c.iter++
 	}
 
 	// Swap current and previous series.
@@ -958,6 +956,8 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 	for k := range c.seriesCur {
 		delete(c.seriesCur, k)
 	}
+
+	c.iter++
 }
 
 func (c *scrapeCache) get(met []byte) (*cacheEntry, bool, bool) {


### PR DESCRIPTION
Backport #16174 to release 2.53.

Requires backport of bc9210e393d520d460dd197bf640578f2daca90a which was part of #15720, otherwise the test doesn't work as expected.

We use the cache iteration number to detect when the same metric has occurred twice in a scrape. We need to bump this number at the end of every scrape, not just successful scrapes.

The `iter` number is also used:
* After a successful scrape, to delete older metrics and metadata.
* To detect when metadata changed in this scrape.

None of those additional cases is broken by incrementing the number on error.