### PR TITLE
chore(discovery): disable additional test as flaky on windows

### DIFF
--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -434,6 +434,9 @@ func TestInvalidFileUpdate(t *testing.T) {
 }
 
 func TestUpdateFileWithPartialWrites(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flaky test, see https://github.com/prometheus/prometheus/issues/16212")
+	}
 	t.Parallel()
 
 	runner := newTestRunner(t)


### PR DESCRIPTION
Tracked in https://github.com/prometheus/prometheus/issues/16212

Some tests were disabled on Windows in https://github.com/prometheus/prometheus/pull/16213, but this test has also flaked:
- https://github.com/prometheus/prometheus/actions/runs/13892691555/job/38912208160?pr=16166
- https://github.com/prometheus/prometheus/actions/runs/13873697622/job/38823406351?pr=16214