### PR TITLE
Address data race in main_test.go

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -252,6 +252,8 @@ func TestWALSegmentSizeBounds(t *testing.T) {
 			// WaitGroup is used to ensure that we don't call t.Log() after the test has finished.
 			var wg sync.WaitGroup
 			wg.Add(1)
+			defer wg.Wait()
+
 			go func() {
 				defer wg.Done()
 				slurp, _ := io.ReadAll(stderr)
@@ -271,7 +273,6 @@ func TestWALSegmentSizeBounds(t *testing.T) {
 					prom.Process.Kill()
 					<-done
 				}
-				wg.Wait()
 				return
 			}
 
@@ -281,8 +282,6 @@ func TestWALSegmentSizeBounds(t *testing.T) {
 			require.ErrorAs(t, err, &exitError)
 			status := exitError.Sys().(syscall.WaitStatus)
 			require.Equal(t, tc.exitCode, status.ExitStatus())
-
-			wg.Wait()
 		})
 	}
 }
@@ -313,7 +312,14 @@ func TestMaxBlockChunkSegmentSizeBounds(t *testing.T) {
 			// Log stderr in case of failure.
 			stderr, err := prom.StderrPipe()
 			require.NoError(t, err)
+
+			// WaitGroup is used to ensure that we don't call t.Log() after the test has finished.
+			var wg sync.WaitGroup
+			wg.Add(1)
+			defer wg.Wait()
+
 			go func() {
+				defer wg.Done()
 				slurp, _ := io.ReadAll(stderr)
 				t.Log(string(slurp))
 			}()
@@ -511,6 +517,8 @@ func TestModeSpecificFlags(t *testing.T) {
 			// WaitGroup is used to ensure that we don't call t.Log() after the test has finished.
 			var wg sync.WaitGroup
 			wg.Add(1)
+			defer wg.Wait()
+
 			go func() {
 				defer wg.Done()
 				slurp, _ := io.ReadAll(stderr)
@@ -530,7 +538,6 @@ func TestModeSpecificFlags(t *testing.T) {
 					prom.Process.Kill()
 					<-done
 				}
-				wg.Wait()
 				return
 			}
 
@@ -543,8 +550,6 @@ func TestModeSpecificFlags(t *testing.T) {
 			} else {
 				t.Errorf("unable to retrieve the exit status for prometheus: %v", err)
 			}
-
-			wg.Wait()
 		})
 	}
 }


### PR DESCRIPTION
Address data race found in https://github.com/prometheus/prometheus/actions/runs/13908258160/job/38916230822?pr=16221:
```
==================
WARNING: DATA RACE
Read at 0x00c0005486c3 by goroutine 354:
  testing.(*common).logDepth()
      /usr/local/go/src/testing/testing.go:1024 +0x504
  testing.(*common).log()
      /usr/local/go/src/testing/testing.go:1011 +0x7d
  testing.(*common).Log()
      /usr/local/go/src/testing/testing.go:1052 +0x55
  github.com/prometheus/prometheus/cmd/prometheus.TestMaxBlockChunkSegmentSizeBounds.func1.1()
      /__w/prometheus/prometheus/cmd/prometheus/main_test.go:318 +0xba

Previous write at 0x00c0005[486](https://github.com/prometheus/prometheus/actions/runs/13908258160/job/38916230822?pr=16221#step:6:487)c3 by goroutine 40:
  testing.tRunner.func1()
      /usr/local/go/src/testing/testing.go:1677 +0x8fa
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:611 +0x5d
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x44

Goroutine 354 (running) created at:
  github.com/prometheus/prometheus/cmd/prometheus.TestMaxBlockChunkSegmentSizeBounds.func1()
      /__w/prometheus/prometheus/cmd/prometheus/main_test.go:316 +0x404
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x44

Goroutine 40 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1743 +0x825
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2168 +0x85
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x226
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2166 +0x8be
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2034 +0xf17
  github.com/prometheus/prometheus/cmd/prometheus.TestMain()
      /__w/prometheus/prometheus/cmd/prometheus/main_test.go:72 +0x271
  main.main()
      _testmain.go:79 +0x171
==================
```

Same fix as in https://github.com/prometheus/prometheus/pull/6727

The race happens because `wg.Wait()` isn't called if the test exits early due to an assertion failure, meaning the goroutine continues running and calls `t.Log` after the test has exited.