### PR TITLE
backport[2.55]: config: set gogc default value when config body is empty (#16052)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -145,6 +145,7 @@ var (
 	// DefaultConfig is the default top-level configuration.
 	DefaultConfig = Config{
 		GlobalConfig: DefaultGlobalConfig,
+		Runtime:      DefaultRuntimeConfig,
 	}
 
 	// DefaultGlobalConfig is the default global configuration.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2113,6 +2113,7 @@ func TestEmptyConfig(t *testing.T) {
 	require.NoError(t, err)
 	exp := DefaultConfig
 	require.Equal(t, exp, *c)
+	require.Equal(t, 75, c.Runtime.GoGC)
 }
 
 func TestExpandExternalLabels(t *testing.T) {
@@ -2164,7 +2165,6 @@ func TestEmptyGlobalBlock(t *testing.T) {
 	c, err := Load("global:\n", false, log.NewNopLogger())
 	require.NoError(t, err)
 	exp := DefaultConfig
-	exp.Runtime = DefaultRuntimeConfig
 	require.Equal(t, exp, *c)
 }
 


### PR DESCRIPTION
* fix: set gogc default value when config body is empty
* refactor: explicitly check value 75 in `TestGoGCDefaultValueOnEmptyConfigBody`
 
add GoGC assertion in `TestEmptyConfig`, also removed the no longer needed runtime config assignment in `TestEmptyGlobalBlock`

* refactor: remove `TestGoGCDefaultValueOnEmptyConfigBody` to reduce duplicate assertions
---
backporting https://github.com/prometheus/prometheus/pull/16052 to 2.55
---