### PR TITLE
Fix flaky TestReadClient/timeout test

### DIFF
--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -332,9 +332,9 @@ func TestReadClient(t *testing.T) {
 		},
 		{
 			name:                  "timeout",
-			httpHandler:           sampledResponseHTTPHandler(t),
-			timeout:               time.Nanosecond,
-			expectedErrorContains: "context deadline exceeded: request timed out after 1ns",
+			httpHandler:           delayedResponseHTTPHandler(t, 15*time.Millisecond),
+			timeout:               5 * time.Millisecond,
+			expectedErrorContains: "context deadline exceeded: request timed out after 5ms",
 		},
 	}
 
@@ -442,6 +442,19 @@ func sampledResponseHTTPHandler(t *testing.T) http.HandlerFunc {
 			},
 		}
 		b, err := proto.Marshal(&resp)
+		require.NoError(t, err)
+
+		_, err = w.Write(snappy.Encode(nil, b))
+		require.NoError(t, err)
+	}
+}
+
+func delayedResponseHTTPHandler(t *testing.T, delay time.Duration) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(delay)
+
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		b, err := proto.Marshal(&prompb.ReadResponse{})
 		require.NoError(t, err)
 
 		_, err = w.Write(snappy.Encode(nil, b))


### PR DESCRIPTION
Flakes:
- https://github.com/prometheus/prometheus/actions/runs/13927546021/job/38975956459?pr=16231
- https://github.com/prometheus/prometheus/actions/runs/13926644165/job/38972833073?pr=16221
- https://github.com/prometheus/prometheus/actions/runs/13927837493/job/38976978663?pr=16232

This changes the test to use a delay larger than the configured timeout to ensure a timeout happens.