### PR TITLE
chore: use directories to simplify dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"
+  - package-ecosystem: "docker"
     directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/scripts"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/documentation/examples/remote_storage"
+      - "/internal/tools"
     schedule:
       interval: "monthly"
     groups:
@@ -12,10 +25,6 @@ updates:
         patterns:
           - "go.opentelemetry.io/*"
     open-pull-requests-limit: 20
-  - package-ecosystem: "gomod"
-    directory: "/documentation/examples/remote_storage"
-    schedule:
-      interval: "monthly"
   # New manteen-ui packages.
   - package-ecosystem: "npm"
     directory: "/web/ui"
@@ -36,15 +45,3 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 20
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-  - package-ecosystem: "github-actions"
-    directory: "/scripts"
-    schedule:
-      interval: "monthly"
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "monthly"


### PR DESCRIPTION
#### Description

Dependabot support [multiple directories](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--) instead of one, this way, the updates definitions can be grouped.

This also sort updates definitions by package-ecosystems.