### PR TITLE
test(kubernetes): replace equality check with JSON equality assertion

### DIFF
--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -199,7 +199,7 @@ func requireTargetGroups(t *testing.T, expected, res map[string]*targetgroup.Gro
 		panic(err)
 	}
 
-	require.Equal(t, string(b1), string(b2))
+	require.JSONEq(t, string(b1), string(b2))
 }
 
 // marshalTargetGroups serializes a set of target groups to JSON, ignoring the


### PR DESCRIPTION
#### Description

The difference in 
https://github.com/prometheus/prometheus/actions/runs/13956924464/job/39070222307#step:5:36 is not easy to read. This
replace equality check with JSON equality assertion to make the diff more readable.