### PR TITLE
chore: Export rulefmt.ruleNode

### DIFF
--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -165,7 +165,7 @@ type ruleGroupNode struct {
 	Interval    model.Duration    `yaml:"interval,omitempty"`
 	QueryOffset *model.Duration   `yaml:"query_offset,omitempty"`
 	Limit       int               `yaml:"limit,omitempty"`
-	Rules       []ruleNode        `yaml:"rules"`
+	Rules       []RuleNode        `yaml:"rules"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
 }
 
@@ -180,8 +180,8 @@ type Rule struct {
 	Annotations   map[string]string `yaml:"annotations,omitempty"`
 }
 
-// ruleNode adds yaml.v3 layer to support line and column outputs for invalid rules.
-type ruleNode struct {
+// RuleNode adds yaml.v3 layer to support line and column outputs for invalid rules.
+type RuleNode struct {
 	Record        yaml.Node         `yaml:"record,omitempty"`
 	Alert         yaml.Node         `yaml:"alert,omitempty"`
 	Expr          yaml.Node         `yaml:"expr"`
@@ -192,7 +192,7 @@ type ruleNode struct {
 }
 
 // Validate the rule and return a list of encountered errors.
-func (r *Rule) Validate(node ruleNode) (nodes []WrappedError) {
+func (r *Rule) Validate(node RuleNode) (nodes []WrappedError) {
 	if r.Record != "" && r.Alert != "" {
 		nodes = append(nodes, WrappedError{
 			err:     errors.New("only one of 'record' and 'alert' must be set"),

--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -92,7 +92,7 @@ type RuleGroups struct {
 }
 
 type ruleGroups struct {
-	Groups []ruleGroupNode `yaml:"groups"`
+	Groups []RuleGroupNode `yaml:"groups"`
 }
 
 // Validate validates all rules in the rule groups.
@@ -158,8 +158,8 @@ type RuleGroup struct {
 	Labels      map[string]string `yaml:"labels,omitempty"`
 }
 
-// ruleGroupNode adds yaml.v3 layer to support line and columns outputs for invalid rule groups.
-type ruleGroupNode struct {
+// RuleGroupNode adds yaml.v3 layer to support line and columns outputs for invalid rule groups.
+type RuleGroupNode struct {
 	yaml.Node
 	Name        string            `yaml:"name"`
 	Interval    model.Duration    `yaml:"interval,omitempty"`


### PR DESCRIPTION
As part of https://github.com/prometheus/prometheus/pull/14957, which converted the previous type called `RuleNode` to a new type `Rule`, a new type was introduced using the old name `ruleNode` for improving error output by carrying yaml positional info.

This unexported type is now an argument to `Rule.Validate`, and there is no exported way to construct a `ruleNode`. Thus, downstream tooling which might want to validate a rule can't call `Validate` anymore. This PR simply exports the type as [described in the original PR](https://github.com/prometheus/prometheus/pull/14957#issue-2540520618).

I've also exported its parent type `RuleGroupNode` for consistency. It does increase API surface - if we don't need these types to be consistent, I'd be happy to revert that portion.

**Alternatives considered:**
- Making the `ruleNode` argument optional, e.g. `*ruleNode`. `Validate()` is now callable, but clients might indeed _want_ the positional error enrichment that `ruleNode` brings.
- Exporting `ruleNode` **and** making it optional. This has merit for situations which don't have yaml decode info. However, the old version of `Validate()` also depended on `yaml.Node` indirectly, so this has always been required. Thus, it felt unlikely that downstream tooling actually needed it.
- Decoding into RuleNode only and converting into Rule. The current structure of objects requires [double deserialization in client tooling](https://github.com/prometheus/prometheus/blob/f5f22e7201ccb92eadb4decb53a87bd04e2b97b8/model/rulefmt/rulefmt.go#L343-L355), one for the model type and one for the positional info type. I think it would be nice to avoid this, but not required; I haven't found tooling that specifically needs it, so it didn't seem worth introducing that much risk. A conversion function might be prone to bugs where we forget to touch it for new fields.