### PR TITLE
Error code

### DIFF
--- a/util/grpcutil/grpcutil.go
+++ b/util/grpcutil/grpcutil.go
@@ -2,21 +2,22 @@ package grpcutil
 
 import (
 	"errors"
+	"net/http"
 
 	"google.golang.org/grpc/status"
 )
 
-// StatusCodeFromErrorChain retrieves the first status code from the chain of gRPC error
-func StatusCodeFromErrorChain(err error) (int32, bool) {
+// HTTPStatusCodeFromErrorChain retrieves the first HTTP status code from the chain of gRPC error
+func HTTPStatusCodeFromErrorChain(err error) (int32, bool) {
 	if err == nil || len(err.Error()) == 0 {
 		return 0, false
 	}
 
 	code, ok := statusCodeFromError(err)
-	if ok {
+	if ok && http.StatusText(int(code)) != "" {
 		return code, true
 	}
-	return StatusCodeFromErrorChain(errors.Unwrap(err))
+	return HTTPStatusCodeFromErrorChain(errors.Unwrap(err))
 }
 
 // statusCodeFromError retrieves the status code from the gRPC error

--- a/util/grpcutil/grpcutil.go
+++ b/util/grpcutil/grpcutil.go
@@ -1,0 +1,30 @@
+package grpcutil
+
+import (
+	"errors"
+
+	"google.golang.org/grpc/status"
+)
+
+// StatusCodeFromErrorChain retrieves the first status code from the chain of gRPC error
+func StatusCodeFromErrorChain(err error) (int32, bool) {
+	if err == nil || len(err.Error()) == 0 {
+		return 0, false
+	}
+
+	code, ok := statusCodeFromError(err)
+	if ok {
+		return code, true
+	}
+	return StatusCodeFromErrorChain(errors.Unwrap(err))
+}
+
+// statusCodeFromError retrieves the status code from the gRPC error
+func statusCodeFromError(err error) (int32, bool) {
+	s, ok := status.FromError(err)
+	if !ok {
+		return 0, false
+	}
+
+	return s.Proto().GetCode(), true
+}

--- a/util/grpcutil/grpcutil_test.go
+++ b/util/grpcutil/grpcutil_test.go
@@ -1,0 +1,36 @@
+package grpcutil
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestStatusCodeFromErrorChain(t *testing.T) {
+	err1 := status.Error(codes.ResourceExhausted, "resource exhausted")
+	err2 := errors.Wrapf(err1, "some error")
+
+	code, ok := StatusCodeFromErrorChain(err2)
+	require.True(t, ok)
+	require.Equal(t, int32(codes.ResourceExhausted), code)
+
+	err1 = status.ErrorProto(&spb.Status{
+		Code:    429,
+		Message: "resource exhausted",
+	})
+	err2 = errors.Wrapf(err1, "some error")
+
+	code, ok = StatusCodeFromErrorChain(err2)
+	require.True(t, ok)
+	require.Equal(t, int32(429), code)
+
+	err1 = errors.New("error without code")
+	err2 = errors.Wrapf(err1, "some error")
+
+	code, ok = StatusCodeFromErrorChain(err2)
+	require.False(t, ok)
+}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -2024,7 +2024,7 @@ func (api *API) respondError(w http.ResponseWriter, apiErr *apiError, data inter
 	case errorBadData:
 		code = http.StatusBadRequest
 	case errorExec:
-		c, ok := grpcutil.StatusCodeFromErrorChain(apiErr.err)
+		c, ok := grpcutil.HTTPStatusCodeFromErrorChain(apiErr.err)
 		if ok {
 			code = int(c)
 		} else {

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -54,6 +54,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/util/annotations"
+	"github.com/prometheus/prometheus/util/grpcutil"
 	"github.com/prometheus/prometheus/util/httputil"
 	"github.com/prometheus/prometheus/util/notifications"
 	"github.com/prometheus/prometheus/util/stats"
@@ -2023,7 +2024,12 @@ func (api *API) respondError(w http.ResponseWriter, apiErr *apiError, data inter
 	case errorBadData:
 		code = http.StatusBadRequest
 	case errorExec:
-		code = http.StatusUnprocessableEntity
+		c, ok := grpcutil.StatusCodeFromErrorChain(apiErr.err)
+		if ok {
+			code = int(c)
+		} else {
+			code = http.StatusUnprocessableEntity
+		}
 	case errorCanceled:
 		code = statusClientClosedConnection
 	case errorTimeout:

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -4155,6 +4155,12 @@ func TestRespondError(t *testing.T) {
 			code:    http.StatusTooManyRequests,
 			msg:     "some error: rpc error: code = Code(429) desc = message",
 		},
+		{
+			errType: errorExec,
+			err:     grpcstatus.Error(998, "message"),
+			code:    http.StatusUnprocessableEntity, // Return 422 if the code is not a valid HTTP status
+			msg:     "rpc error: code = Code(998) desc = message",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

### Description

Currently the API always returns http code 422 for engine execution error, regardless of the HTTP error codes embedded in the gRPC error chain.

This PR improves it to retrieve the first valid HTTP error code, if applicable, and return it.

Before the PR:

```
Body: {"status":"error","data":"test","errorType":"execution","error":"some error: rpc error: code = Code(429) desc = message"}
Status Code: 422

Body: {"status":"error","data":"test","errorType":"execution","error":"some error: rpc error: code = Code(998) desc = message"}
Status Code: 422
```

After the PR:

```
Body: {"status":"error","data":"test","errorType":"execution","error":"some error: rpc error: code = Code(429) desc = message"}
Status Code: 429

Body: {"status":"error","data":"test","errorType":"execution","error":"some error: rpc error: code = Code(998) desc = message"}
Status Code: 422 // still 422 since 998 is an invalid HTTP status
```

### Testing

Added unit tests