### PR TITLE
Remove dependabot configs for npm-based dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,23 +25,3 @@ updates:
         patterns:
           - "go.opentelemetry.io/*"
     open-pull-requests-limit: 20
-  # New manteen-ui packages.
-  - package-ecosystem: "npm"
-    directory: "/web/ui"
-    labels:
-      - dependencies
-      - javascript
-      - manteen-ui
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 20
-  # Old react-app packages.
-  - package-ecosystem: "npm"
-    directory: "/web/ui/react-app"
-    labels:
-      - dependencies
-      - javascript
-      - old-react-ui
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 20


### PR DESCRIPTION
This is just IMO, but getting my inbox flooded every month with hundreds of dependabot PRs is annoying, even if I don't end up handling most of them myself (thanks to others who do!). And then philosophically, I don't know if this is even the right approach. I don't think that whoever merges these PRs actually has the capacity or the knowledge to check that everything is still working as expected. Often subtle things can break after package updates, like a class name from an npm package not fitting to a style definition in our code anymore (as happened once with e.g. codemirror in the past, and nobody noticed when merging, and that bug is still present in Thanos' port of our UI). And you can't look in detail at the UI for every little PR that dependabot sends.

Node module dependencies are inherently very noisy because there are so many of them, but I think a better approach would be to update them maybe once or twice a year (or whenever really needed), with all deps updated together, at a time when a maintainer has the time to really look at things carefully, and then do a comprehensive manual check of the UI to see that everything is still behaving as before.

![image](https://github.com/user-attachments/assets/3ae83c60-4f18-49f6-8570-1b7b66a994f0)

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
