### PR TITLE
Allow NewReadClient to take in more config options

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -145,8 +145,8 @@ type ReadClient interface {
 }
 
 // NewReadClient creates a new client for remote read.
-func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
-	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client")
+func NewReadClient(name string, conf *ClientConfig, optFuncs ...config_util.HTTPClientOption) (ReadClient, error) {
+	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client", optFuncs...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`NewClientFromConfig` can already take in `optFuncs ...config_util.HTTPClientOption`, so here we make a similar change to `NewReadClient` so `optFuncs` can be passed from there. This allows us to do things like configure the dial timeout from `NewReadClient`.