### PR TITLE
[BUILD] Remove Go toolchain line

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/prometheus/prometheus
 
 go 1.23.0
 
-toolchain go1.23.4
-
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -2,8 +2,6 @@ module github.com/prometheus/prometheus/internal/tools
 
 go 1.23.0
 
-toolchain go1.23.4
-
 require (
 	github.com/bufbuild/buf v1.50.1
 	github.com/daixiang0/gci v0.13.5


### PR DESCRIPTION
It doesn't reflect the version we use for CI builds, which is controlled by `.promu.yml`.

As such, I cannot see any justification to keep this line: it isn't necessary and it could confuse people.

(I was trying to work out why #16180 did not update this line, and decided it's best to remove it)
