### PR TITLE
fix: storage/remote.pool interned refs count and flaky test

### DIFF
--- a/storage/remote/intern_test.go
+++ b/storage/remote/intern_test.go
@@ -20,7 +20,6 @@ package remote
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -74,17 +73,21 @@ func TestIntern_MultiRef_Concurrent(t *testing.T) {
 	interner.intern(testString)
 	interned, ok := interner.pool[testString]
 	require.True(t, ok)
-	require.Equalf(t, int64(1), interned.refs.Load(), "expected refs to be 1 but it was %d", interned.refs.Load())
+	require.Equalf(t, int64(1), interned.refs.Load(), "wrong interned refs count")
 
-	go interner.release(testString)
-
-	interner.intern(testString)
-
-	time.Sleep(time.Millisecond)
+	for i := 0; i < 1000; i++ {
+		released := make(chan struct{})
+		go func() {
+			interner.release(testString)
+			close(released)
+		}()
+		interner.intern(testString)
+		<-released
+	}
 
 	interner.mtx.RLock()
 	interned, ok = interner.pool[testString]
 	interner.mtx.RUnlock()
 	require.True(t, ok)
-	require.Equalf(t, int64(1), interned.refs.Load(), "expected refs to be 1 but it was %d", interned.refs.Load())
+	require.Equalf(t, int64(1), interned.refs.Load(), "wrong interned refs count")
 }


### PR DESCRIPTION
I saw TestIntern_MultiRef_Concurrent failing on a different PR saying 'expected refs to be 1 but it was 2'.

I took a look, and it definitely can be racy, especially with a time.Sleep() of just 1ms.

I'm fixing that by explicitly waiting until it has been released, and by repeating that 1000 times, otherwise it's just a recipe for a future flaky test.

OTOH, I also took a look at the implementation and saw that we were not holding the RLock() when increasing the references count, so when releasing there was a race condition for the cleanup, I fixed that by holding RLock() while increasing the references count.