### PR TITLE
fix (auto-reload): failing to auto-reload on changes to rule and scrape config files

### DIFF
--- a/config/reload.go
+++ b/config/reload.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 
+	promconfig "github.com/prometheus/common/config"
 	"gopkg.in/yaml.v2"
 )
 
@@ -49,10 +50,10 @@ func GenerateChecksum(yamlFilePath string) (string, error) {
 	dir := filepath.Dir(yamlFilePath)
 
 	for i, file := range config.RuleFiles {
-		config.RuleFiles[i] = filepath.Join(dir, file)
+		config.RuleFiles[i] = promconfig.JoinDir(dir, file)
 	}
 	for i, file := range config.ScrapeConfigFiles {
-		config.ScrapeConfigFiles[i] = filepath.Join(dir, file)
+		config.ScrapeConfigFiles[i] = promconfig.JoinDir(dir, file)
 	}
 
 	files := map[string][]string{

--- a/config/reload_test.go
+++ b/config/reload_test.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,8 +27,10 @@ func TestGenerateChecksum(t *testing.T) {
 
 	// Define paths for the temporary files.
 	yamlFilePath := filepath.Join(tmpDir, "test.yml")
-	ruleFilePath := filepath.Join(tmpDir, "rule_file.yml")
-	scrapeConfigFilePath := filepath.Join(tmpDir, "scrape_config.yml")
+	ruleFile := "rule_file.yml"
+	ruleFilePath := filepath.Join(tmpDir, ruleFile)
+	scrapeConfigFile := "scrape_config.yml"
+	scrapeConfigFilePath := filepath.Join(tmpDir, scrapeConfigFile)
 
 	// Define initial and modified content for the files.
 	originalRuleContent := "groups:\n- name: example\n  rules:\n  - alert: ExampleAlert"
@@ -36,181 +39,202 @@ func TestGenerateChecksum(t *testing.T) {
 	originalScrapeConfigContent := "scrape_configs:\n- job_name: example"
 	modifiedScrapeConfigContent := "scrape_configs:\n- job_name: modified_example"
 
-	// Define YAML content referencing the rule and scrape config files.
-	yamlContent := `
+	testCases := []struct {
+		name                 string
+		ruleFilePath         string
+		scrapeConfigFilePath string
+	}{
+		{
+			name:                 "Auto reload using relative path.",
+			ruleFilePath:         ruleFile,
+			scrapeConfigFilePath: scrapeConfigFile,
+		},
+		{
+			name:                 "Auto reload using absolute path.",
+			ruleFilePath:         ruleFilePath,
+			scrapeConfigFilePath: scrapeConfigFilePath,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Define YAML content referencing the rule and scrape config files.
+			yamlContent := fmt.Sprintf(`
 rule_files:
-  - rule_file.yml
+  - %s
 scrape_config_files:
-  - scrape_config.yml
-`
+  - %s
+`, tc.ruleFilePath, tc.scrapeConfigFilePath)
 
-	// Write initial content to files.
-	require.NoError(t, os.WriteFile(ruleFilePath, []byte(originalRuleContent), 0o644))
-	require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(originalScrapeConfigContent), 0o644))
-	require.NoError(t, os.WriteFile(yamlFilePath, []byte(yamlContent), 0o644))
+			// Write initial content to files.
+			require.NoError(t, os.WriteFile(ruleFilePath, []byte(originalRuleContent), 0o644))
+			require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(originalScrapeConfigContent), 0o644))
+			require.NoError(t, os.WriteFile(yamlFilePath, []byte(yamlContent), 0o644))
 
-	// Generate the original checksum.
-	originalChecksum := calculateChecksum(t, yamlFilePath)
+			// Generate the original checksum.
+			originalChecksum := calculateChecksum(t, yamlFilePath)
 
-	t.Run("Rule File Change", func(t *testing.T) {
-		// Modify the rule file.
-		require.NoError(t, os.WriteFile(ruleFilePath, []byte(modifiedRuleContent), 0o644))
+			t.Run("Rule File Change", func(t *testing.T) {
+				// Modify the rule file.
+				require.NoError(t, os.WriteFile(ruleFilePath, []byte(modifiedRuleContent), 0o644))
 
-		// Checksum should change.
-		modifiedChecksum := calculateChecksum(t, yamlFilePath)
-		require.NotEqual(t, originalChecksum, modifiedChecksum)
+				// Checksum should change.
+				modifiedChecksum := calculateChecksum(t, yamlFilePath)
+				require.NotEqual(t, originalChecksum, modifiedChecksum)
 
-		// Revert the rule file.
-		require.NoError(t, os.WriteFile(ruleFilePath, []byte(originalRuleContent), 0o644))
+				// Revert the rule file.
+				require.NoError(t, os.WriteFile(ruleFilePath, []byte(originalRuleContent), 0o644))
 
-		// Checksum should return to the original.
-		revertedChecksum := calculateChecksum(t, yamlFilePath)
-		require.Equal(t, originalChecksum, revertedChecksum)
-	})
+				// Checksum should return to the original.
+				revertedChecksum := calculateChecksum(t, yamlFilePath)
+				require.Equal(t, originalChecksum, revertedChecksum)
+			})
 
-	t.Run("Scrape Config Change", func(t *testing.T) {
-		// Modify the scrape config file.
-		require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(modifiedScrapeConfigContent), 0o644))
+			t.Run("Scrape Config Change", func(t *testing.T) {
+				// Modify the scrape config file.
+				require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(modifiedScrapeConfigContent), 0o644))
 
-		// Checksum should change.
-		modifiedChecksum := calculateChecksum(t, yamlFilePath)
-		require.NotEqual(t, originalChecksum, modifiedChecksum)
+				// Checksum should change.
+				modifiedChecksum := calculateChecksum(t, yamlFilePath)
+				require.NotEqual(t, originalChecksum, modifiedChecksum)
 
-		// Revert the scrape config file.
-		require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(originalScrapeConfigContent), 0o644))
+				// Revert the scrape config file.
+				require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(originalScrapeConfigContent), 0o644))
 
-		// Checksum should return to the original.
-		revertedChecksum := calculateChecksum(t, yamlFilePath)
-		require.Equal(t, originalChecksum, revertedChecksum)
-	})
+				// Checksum should return to the original.
+				revertedChecksum := calculateChecksum(t, yamlFilePath)
+				require.Equal(t, originalChecksum, revertedChecksum)
+			})
 
-	t.Run("Rule File Deletion", func(t *testing.T) {
-		// Delete the rule file.
-		require.NoError(t, os.Remove(ruleFilePath))
+			t.Run("Rule File Deletion", func(t *testing.T) {
+				// Delete the rule file.
+				require.NoError(t, os.Remove(ruleFilePath))
 
-		// Checksum should change.
-		deletedChecksum := calculateChecksum(t, yamlFilePath)
-		require.NotEqual(t, originalChecksum, deletedChecksum)
+				// Checksum should change.
+				deletedChecksum := calculateChecksum(t, yamlFilePath)
+				require.NotEqual(t, originalChecksum, deletedChecksum)
 
-		// Restore the rule file.
-		require.NoError(t, os.WriteFile(ruleFilePath, []byte(originalRuleContent), 0o644))
+				// Restore the rule file.
+				require.NoError(t, os.WriteFile(ruleFilePath, []byte(originalRuleContent), 0o644))
 
-		// Checksum should return to the original.
-		revertedChecksum := calculateChecksum(t, yamlFilePath)
-		require.Equal(t, originalChecksum, revertedChecksum)
-	})
+				// Checksum should return to the original.
+				revertedChecksum := calculateChecksum(t, yamlFilePath)
+				require.Equal(t, originalChecksum, revertedChecksum)
+			})
 
-	t.Run("Scrape Config Deletion", func(t *testing.T) {
-		// Delete the scrape config file.
-		require.NoError(t, os.Remove(scrapeConfigFilePath))
+			t.Run("Scrape Config Deletion", func(t *testing.T) {
+				// Delete the scrape config file.
+				require.NoError(t, os.Remove(scrapeConfigFilePath))
 
-		// Checksum should change.
-		deletedChecksum := calculateChecksum(t, yamlFilePath)
-		require.NotEqual(t, originalChecksum, deletedChecksum)
+				// Checksum should change.
+				deletedChecksum := calculateChecksum(t, yamlFilePath)
+				require.NotEqual(t, originalChecksum, deletedChecksum)
 
-		// Restore the scrape config file.
-		require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(originalScrapeConfigContent), 0o644))
+				// Restore the scrape config file.
+				require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(originalScrapeConfigContent), 0o644))
 
-		// Checksum should return to the original.
-		revertedChecksum := calculateChecksum(t, yamlFilePath)
-		require.Equal(t, originalChecksum, revertedChecksum)
-	})
+				// Checksum should return to the original.
+				revertedChecksum := calculateChecksum(t, yamlFilePath)
+				require.Equal(t, originalChecksum, revertedChecksum)
+			})
 
-	t.Run("Main File Change", func(t *testing.T) {
-		// Modify the main YAML file.
-		modifiedYamlContent := `
+			t.Run("Main File Change", func(t *testing.T) {
+				// Modify the main YAML file.
+				modifiedYamlContent := fmt.Sprintf(`
 global:
   scrape_interval: 3s
 rule_files:
-  - rule_file.yml
+  - %s
 scrape_config_files:
-  - scrape_config.yml
-`
-		require.NoError(t, os.WriteFile(yamlFilePath, []byte(modifiedYamlContent), 0o644))
+  - %s
+`, tc.ruleFilePath, tc.scrapeConfigFilePath)
+				require.NoError(t, os.WriteFile(yamlFilePath, []byte(modifiedYamlContent), 0o644))
 
-		// Checksum should change.
-		modifiedChecksum := calculateChecksum(t, yamlFilePath)
-		require.NotEqual(t, originalChecksum, modifiedChecksum)
+				// Checksum should change.
+				modifiedChecksum := calculateChecksum(t, yamlFilePath)
+				require.NotEqual(t, originalChecksum, modifiedChecksum)
 
-		// Revert the main YAML file.
-		require.NoError(t, os.WriteFile(yamlFilePath, []byte(yamlContent), 0o644))
+				// Revert the main YAML file.
+				require.NoError(t, os.WriteFile(yamlFilePath, []byte(yamlContent), 0o644))
 
-		// Checksum should return to the original.
-		revertedChecksum := calculateChecksum(t, yamlFilePath)
-		require.Equal(t, originalChecksum, revertedChecksum)
-	})
+				// Checksum should return to the original.
+				revertedChecksum := calculateChecksum(t, yamlFilePath)
+				require.Equal(t, originalChecksum, revertedChecksum)
+			})
 
-	t.Run("Rule File Removed from YAML Config", func(t *testing.T) {
-		// Modify the YAML content to remove the rule file.
-		modifiedYamlContent := `
+			t.Run("Rule File Removed from YAML Config", func(t *testing.T) {
+				// Modify the YAML content to remove the rule file.
+				modifiedYamlContent := fmt.Sprintf(`
 scrape_config_files:
-  - scrape_config.yml
-`
-		require.NoError(t, os.WriteFile(yamlFilePath, []byte(modifiedYamlContent), 0o644))
+  - %s
+`, tc.scrapeConfigFilePath)
+				require.NoError(t, os.WriteFile(yamlFilePath, []byte(modifiedYamlContent), 0o644))
 
-		// Checksum should change.
-		modifiedChecksum := calculateChecksum(t, yamlFilePath)
-		require.NotEqual(t, originalChecksum, modifiedChecksum)
+				// Checksum should change.
+				modifiedChecksum := calculateChecksum(t, yamlFilePath)
+				require.NotEqual(t, originalChecksum, modifiedChecksum)
 
-		// Revert the YAML content.
-		require.NoError(t, os.WriteFile(yamlFilePath, []byte(yamlContent), 0o644))
+				// Revert the YAML content.
+				require.NoError(t, os.WriteFile(yamlFilePath, []byte(yamlContent), 0o644))
 
-		// Checksum should return to the original.
-		revertedChecksum := calculateChecksum(t, yamlFilePath)
-		require.Equal(t, originalChecksum, revertedChecksum)
-	})
+				// Checksum should return to the original.
+				revertedChecksum := calculateChecksum(t, yamlFilePath)
+				require.Equal(t, originalChecksum, revertedChecksum)
+			})
 
-	t.Run("Scrape Config Removed from YAML Config", func(t *testing.T) {
-		// Modify the YAML content to remove the scrape config file.
-		modifiedYamlContent := `
+			t.Run("Scrape Config Removed from YAML Config", func(t *testing.T) {
+				// Modify the YAML content to remove the scrape config file.
+				modifiedYamlContent := fmt.Sprintf(`
 rule_files:
-  - rule_file.yml
-`
-		require.NoError(t, os.WriteFile(yamlFilePath, []byte(modifiedYamlContent), 0o644))
+  - %s
+`, tc.ruleFilePath)
+				require.NoError(t, os.WriteFile(yamlFilePath, []byte(modifiedYamlContent), 0o644))
 
-		// Checksum should change.
-		modifiedChecksum := calculateChecksum(t, yamlFilePath)
-		require.NotEqual(t, originalChecksum, modifiedChecksum)
+				// Checksum should change.
+				modifiedChecksum := calculateChecksum(t, yamlFilePath)
+				require.NotEqual(t, originalChecksum, modifiedChecksum)
 
-		// Revert the YAML content.
-		require.NoError(t, os.WriteFile(yamlFilePath, []byte(yamlContent), 0o644))
+				// Revert the YAML content.
+				require.NoError(t, os.WriteFile(yamlFilePath, []byte(yamlContent), 0o644))
 
-		// Checksum should return to the original.
-		revertedChecksum := calculateChecksum(t, yamlFilePath)
-		require.Equal(t, originalChecksum, revertedChecksum)
-	})
+				// Checksum should return to the original.
+				revertedChecksum := calculateChecksum(t, yamlFilePath)
+				require.Equal(t, originalChecksum, revertedChecksum)
+			})
 
-	t.Run("Empty Rule File", func(t *testing.T) {
-		// Write an empty rule file.
-		require.NoError(t, os.WriteFile(ruleFilePath, []byte(""), 0o644))
+			t.Run("Empty Rule File", func(t *testing.T) {
+				// Write an empty rule file.
+				require.NoError(t, os.WriteFile(ruleFilePath, []byte(""), 0o644))
 
-		// Checksum should change.
-		emptyChecksum := calculateChecksum(t, yamlFilePath)
-		require.NotEqual(t, originalChecksum, emptyChecksum)
+				// Checksum should change.
+				emptyChecksum := calculateChecksum(t, yamlFilePath)
+				require.NotEqual(t, originalChecksum, emptyChecksum)
 
-		// Restore the rule file.
-		require.NoError(t, os.WriteFile(ruleFilePath, []byte(originalRuleContent), 0o644))
+				// Restore the rule file.
+				require.NoError(t, os.WriteFile(ruleFilePath, []byte(originalRuleContent), 0o644))
 
-		// Checksum should return to the original.
-		revertedChecksum := calculateChecksum(t, yamlFilePath)
-		require.Equal(t, originalChecksum, revertedChecksum)
-	})
+				// Checksum should return to the original.
+				revertedChecksum := calculateChecksum(t, yamlFilePath)
+				require.Equal(t, originalChecksum, revertedChecksum)
+			})
 
-	t.Run("Empty Scrape Config File", func(t *testing.T) {
-		// Write an empty scrape config file.
-		require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(""), 0o644))
+			t.Run("Empty Scrape Config File", func(t *testing.T) {
+				// Write an empty scrape config file.
+				require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(""), 0o644))
 
-		// Checksum should change.
-		emptyChecksum := calculateChecksum(t, yamlFilePath)
-		require.NotEqual(t, originalChecksum, emptyChecksum)
+				// Checksum should change.
+				emptyChecksum := calculateChecksum(t, yamlFilePath)
+				require.NotEqual(t, originalChecksum, emptyChecksum)
 
-		// Restore the scrape config file.
-		require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(originalScrapeConfigContent), 0o644))
+				// Restore the scrape config file.
+				require.NoError(t, os.WriteFile(scrapeConfigFilePath, []byte(originalScrapeConfigContent), 0o644))
 
-		// Checksum should return to the original.
-		revertedChecksum := calculateChecksum(t, yamlFilePath)
-		require.Equal(t, originalChecksum, revertedChecksum)
-	})
+				// Checksum should return to the original.
+				revertedChecksum := calculateChecksum(t, yamlFilePath)
+				require.Equal(t, originalChecksum, revertedChecksum)
+			})
+		})
+	}
 }
 
 // calculateChecksum generates a checksum for the given YAML file path.


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/15673

[The original PR](https://github.com/prometheus/prometheus/pull/15675) for this issue has seemingly stalled out and I need this resolved. This PR should address the concerns brought up by @bboreham and utilizes the common config function `JoinDir` following what is done in [SetDirectory](https://github.com/prometheus/prometheus/blob/8cea05dfe4c7372f242c678fc41b58956c8be6e8/config/config.go#L281)