### PR TITLE
[BUG] PromQL: Return early when `endtime` < `startime`

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1582,6 +1582,11 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 	if err := contextDone(ctx, "expression evaluation"); err != nil {
 		ev.error(err)
 	}
+
+	if ev.endTimestamp < ev.startTimestamp {
+		return Matrix{}, nil
+	}
+
 	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
 
 	// Create a new span to help investigate inner evaluation performances.

--- a/promql/promqltest/testdata/subquery.test
+++ b/promql/promqltest/testdata/subquery.test
@@ -150,3 +150,10 @@ eval instant at 10m increase(native_histogram[10m:3m])
 # by the sub-query multiple times.
 eval instant at 10m increase(native_histogram[10m:15s])
   {} {{count:30.769230769230766 sum:30.769230769230766}}
+
+# When range < resolution and the first evaluation time is out of range.
+load 5m
+	foo 3+0x10
+
+eval instant at 12m min_over_time((topk(1, foo))[1m:5m])
+	#empty


### PR DESCRIPTION
Fixes: #16094 

I assumed that `ev.eval` always returns a `Matrix` in all cases. Please let me know if I have overlooked any exceptions.