### PR TITLE
support nhcb custom values in RW 1.1

### DIFF
--- a/prompb/codec.go
+++ b/prompb/codec.go
@@ -90,7 +90,7 @@ func (h Histogram) ToIntHistogram() *histogram.Histogram {
 		PositiveBuckets:  h.GetPositiveDeltas(),
 		NegativeSpans:    spansProtoToSpans(h.GetNegativeSpans()),
 		NegativeBuckets:  h.GetNegativeDeltas(),
-		CustomValues:     h.CustomValues,
+		CustomValues:     h.GetCustomValues(),
 	}
 }
 
@@ -110,7 +110,7 @@ func (h Histogram) ToFloatHistogram() *histogram.FloatHistogram {
 			PositiveBuckets:  h.GetPositiveCounts(),
 			NegativeSpans:    spansProtoToSpans(h.GetNegativeSpans()),
 			NegativeBuckets:  h.GetNegativeCounts(),
-			CustomValues:     h.CustomValues,
+			CustomValues:     h.GetCustomValues(),
 		}
 	}
 	// Conversion from integer histogram.
@@ -125,6 +125,7 @@ func (h Histogram) ToFloatHistogram() *histogram.FloatHistogram {
 		PositiveBuckets:  deltasToCounts(h.GetPositiveDeltas()),
 		NegativeSpans:    spansProtoToSpans(h.GetNegativeSpans()),
 		NegativeBuckets:  deltasToCounts(h.GetNegativeDeltas()),
+		CustomValues:     h.GetCustomValues(),
 	}
 }
 
@@ -161,6 +162,7 @@ func FromIntHistogram(timestamp int64, h *histogram.Histogram) Histogram {
 		PositiveDeltas: h.PositiveBuckets,
 		ResetHint:      Histogram_ResetHint(h.CounterResetHint),
 		Timestamp:      timestamp,
+		CustomValues:   h.CustomValues,
 	}
 }
 
@@ -178,6 +180,7 @@ func FromFloatHistogram(timestamp int64, fh *histogram.FloatHistogram) Histogram
 		PositiveCounts: fh.PositiveBuckets,
 		ResetHint:      Histogram_ResetHint(fh.CounterResetHint),
 		Timestamp:      timestamp,
+		CustomValues:   fh.CustomValues,
 	}
 }
 

--- a/prompb/rwcommon/codec_test.go
+++ b/prompb/rwcommon/codec_test.go
@@ -195,23 +195,16 @@ func testFloatHistogram() histogram.FloatHistogram {
 }
 
 func TestFromIntToFloatOrIntHistogram(t *testing.T) {
+	testIntHist := testIntHistogram()
+	testFloatHist := testFloatHistogram()
 	t.Run("v1", func(t *testing.T) {
-		// v1 does not support nhcb.
-		testIntHistWithoutNHCB := testIntHistogram()
-		testIntHistWithoutNHCB.CustomValues = nil
-		testFloatHistWithoutNHCB := testFloatHistogram()
-		testFloatHistWithoutNHCB.CustomValues = nil
-
-		h := prompb.FromIntHistogram(123, &testIntHistWithoutNHCB)
+		h := prompb.FromIntHistogram(123, &testIntHist)
 		require.False(t, h.IsFloatHistogram())
 		require.Equal(t, int64(123), h.Timestamp)
-		require.Equal(t, testIntHistWithoutNHCB, *h.ToIntHistogram())
-		require.Equal(t, testFloatHistWithoutNHCB, *h.ToFloatHistogram())
+		require.Equal(t, testIntHist, *h.ToIntHistogram())
+		require.Equal(t, testFloatHist, *h.ToFloatHistogram())
 	})
 	t.Run("v2", func(t *testing.T) {
-		testIntHist := testIntHistogram()
-		testFloatHist := testFloatHistogram()
-
 		h := writev2.FromIntHistogram(123, &testIntHist)
 		require.False(t, h.IsFloatHistogram())
 		require.Equal(t, int64(123), h.Timestamp)
@@ -221,20 +214,15 @@ func TestFromIntToFloatOrIntHistogram(t *testing.T) {
 }
 
 func TestFromFloatToFloatHistogram(t *testing.T) {
+	testFloatHist := testFloatHistogram()
 	t.Run("v1", func(t *testing.T) {
-		// v1 does not support nhcb.
-		testFloatHistWithoutNHCB := testFloatHistogram()
-		testFloatHistWithoutNHCB.CustomValues = nil
-
-		h := prompb.FromFloatHistogram(123, &testFloatHistWithoutNHCB)
+		h := prompb.FromFloatHistogram(123, &testFloatHist)
 		require.True(t, h.IsFloatHistogram())
 		require.Equal(t, int64(123), h.Timestamp)
 		require.Nil(t, h.ToIntHistogram())
-		require.Equal(t, testFloatHistWithoutNHCB, *h.ToFloatHistogram())
+		require.Equal(t, testFloatHist, *h.ToFloatHistogram())
 	})
 	t.Run("v2", func(t *testing.T) {
-		testFloatHist := testFloatHistogram()
-
 		h := writev2.FromFloatHistogram(123, &testFloatHist)
 		require.True(t, h.IsFloatHistogram())
 		require.Equal(t, int64(123), h.Timestamp)


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR allows RW 1.1 to also send custom values through remote write, which is used by NHCB. Previous we only send custom values with RW 2.0. This benefits those backends that don't support RW 2.0 today but want to receive NHCB samples.

See:
https://github.com/prometheus/prometheus/blob/74a1d96c7272fcc8f6e0d2f74945cc6f7823f3b4/storage/remote/queue_manager.go#L1629 and https://github.com/prometheus/prometheus/blob/74a1d96c7272fcc8f6e0d2f74945cc6f7823f3b4/storage/remote/queue_manager.go#L1632 are places of how we convert histograms to prompb.Histogram but before we didn't convert custom values field so it ends up not being sent via remote write.