### PR TITLE
Tighter spacing for /alerts and /rules pages

### DIFF
--- a/web/ui/mantine-ui/src/pages/AlertsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.tsx
@@ -12,6 +12,7 @@ import {
   TextInput,
   Anchor,
   Pagination,
+  rem,
 } from "@mantine/core";
 import { useSuspenseAPIQuery } from "../api/api";
 import { AlertingRule, AlertingRulesResult } from "../api/responseTypes/rules";
@@ -222,7 +223,7 @@ export default function AlertsPage() {
           p="md"
           key={i} // TODO: Find a stable and definitely unique key.
         >
-          <Group mb="md" mt="xs" ml="xs" justify="space-between">
+          <Group mb="sm" justify="space-between">
             <Group align="baseline">
               <Text fz="xl" fw={600} c="var(--mantine-primary-color-filled)">
                 {g.name}
@@ -280,6 +281,7 @@ export default function AlertsPage() {
                   {items.map((r, j) => {
                     return (
                       <Accordion.Item
+                        mt={rem(5)}
                         styles={{
                           item: {
                             // TODO: This transparency hack is an OK workaround to make the collapsed items
@@ -299,7 +301,9 @@ export default function AlertsPage() {
                               : panelClasses.panelHealthOk
                         }
                       >
-                        <Accordion.Control>
+                        <Accordion.Control
+                          styles={{ label: { paddingBlock: rem(10) } }}
+                        >
                           <Group wrap="nowrap" justify="space-between" mr="lg">
                             <Text>{r.rule.name}</Text>
                             <Group gap="xs">

--- a/web/ui/mantine-ui/src/pages/RulesPage.tsx
+++ b/web/ui/mantine-ui/src/pages/RulesPage.tsx
@@ -91,10 +91,9 @@ export default function RulesPage() {
             shadow="xs"
             withBorder
             p="md"
-            mb="md"
             key={i} // TODO: Find a stable and definitely unique key.
           >
-            <Group mb="md" mt="xs" ml="xs" justify="space-between">
+            <Group mb="sm" justify="space-between">
               <Group align="baseline">
                 <Text fz="xl" fw={600} c="var(--mantine-primary-color-filled)">
                   {g.name}
@@ -147,6 +146,7 @@ export default function RulesPage() {
                 <Accordion multiple variant="separated">
                   {items.map((r, j) => (
                     <Accordion.Item
+                      mt={rem(5)}
                       styles={{
                         item: {
                           // TODO: This transparency hack is an OK workaround to make the collapsed items
@@ -167,7 +167,9 @@ export default function RulesPage() {
                               : "5px solid var(--mantine-color-green-4)",
                       }}
                     >
-                      <Accordion.Control>
+                      <Accordion.Control
+                        styles={{ label: { paddingBlock: rem(10) } }}
+                      >
                         <Group justify="space-between" mr="lg">
                           <Group gap="xs" wrap="nowrap">
                             {r.type === "alerting" ? (


### PR DESCRIPTION
As discussed in https://github.com/prometheus/prometheus/issues/15717, this should help show more information on one screen, to be more similar to the old UI in this regard.

Before + after for the /alerts page:

![image](https://github.com/user-attachments/assets/71818007-ff77-46b4-93c8-cfc6fed982bb)

Before + after for the /rules page:

![image](https://github.com/user-attachments/assets/bb84b11f-937c-4d99-ac97-4c6f03de8722)

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
