### PR TITLE
Fix width for custom label badges in stacked layouts

### DIFF
--- a/web/ui/mantine-ui/src/Badge.module.css
+++ b/web/ui/mantine-ui/src/Badge.module.css
@@ -29,6 +29,7 @@
   height: calc(1.25rem * var(--mantine-scale));
   letter-spacing: calc(0.015625rem * var(--mantine-scale));
   white-space: nowrap;
+  width: fit-content;
 }
 
 .healthOk {


### PR DESCRIPTION
In stacked / flex layouts like on the service discovery page, elements get a 100% width unless you tell them to only be as wide as their contents:

![image](https://github.com/user-attachments/assets/875e0612-e5c6-4c92-832e-b61258a29c8a)

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
