### PR TITLE
promql: convert promql tests to the new syntax

### DIFF
--- a/promql/promqltest/testdata/aggregators.test
+++ b/promql/promqltest/testdata/aggregators.test
@@ -235,21 +235,25 @@ eval instant at 0m max(http_requests)
   {} 4
 
 # The histogram is ignored here so the result doesn't change but it has an info annotation now.
-eval_info instant at 0m max({job="api-server"})
+eval instant at 0m max({job="api-server"})
+  expect info
   {} 4
 
 # The histogram is ignored here so there is no result but it has an info annotation now.
-eval_info instant at 0m max(http_requests_histogram)
+eval instant at 0m max(http_requests_histogram)
+  expect info
 
 eval instant at 0m min(http_requests)
   {} 1
 
 # The histogram is ignored here so the result doesn't change but it has an info annotation now.
-eval_info instant at 0m min({job="api-server"})
+eval instant at 0m min({job="api-server"})
+  expect info
   {} 1
 
 # The histogram is ignored here so there is no result but it has an info annotation now.
-eval_info instant at 0m min(http_requests_histogram)
+eval instant at 0m min(http_requests_histogram)
+  expect info
 
 eval instant at 0m max by (group) (http_requests)
   {group="production"} 2
@@ -341,42 +345,54 @@ eval_ordered instant at 50m topk(scalar(foo), http_requests)
 	http_requests{group="production", instance="1", job="app-server"} 600
 
 # Tests for histogram: should ignore histograms.
-eval_info instant at 50m topk(100, http_requests_histogram)
+eval instant at 50m topk(100, http_requests_histogram)
+    expect info
     #empty
 
-eval_info range from 0 to 50m step 5m topk(100, http_requests_histogram)
+eval range from 0 to 50m step 5m topk(100, http_requests_histogram)
+    expect info
     #empty
 
-eval_info instant at 50m topk(1, {__name__=~"http_requests(_histogram)?"})
+eval instant at 50m topk(1, {__name__=~"http_requests(_histogram)?"})
+    expect info
     {__name__="http_requests", group="canary", instance="1", job="app-server"} 800
 
-eval_info instant at 50m count(topk(1000, {__name__=~"http_requests(_histogram)?"}))
+eval instant at 50m count(topk(1000, {__name__=~"http_requests(_histogram)?"}))
+    expect info
     {} 9
 
-eval_info range from 0 to 50m step 5m count(topk(1000, {__name__=~"http_requests(_histogram)?"}))
+eval range from 0 to 50m step 5m count(topk(1000, {__name__=~"http_requests(_histogram)?"}))
+    expect info
     {} 9x10
 
-eval_info instant at 50m topk by (instance) (1, {__name__=~"http_requests(_histogram)?"})
+eval instant at 50m topk by (instance) (1, {__name__=~"http_requests(_histogram)?"})
+    expect info
     {__name__="http_requests", group="canary", instance="0", job="app-server"} 700
     {__name__="http_requests", group="canary", instance="1", job="app-server"} 800
     {__name__="http_requests", group="production", instance="2", job="api-server"} NaN
 
-eval_info instant at 50m bottomk(100, http_requests_histogram)
+eval instant at 50m bottomk(100, http_requests_histogram)
+    expect info
     #empty
 
-eval_info range from 0 to 50m step 5m bottomk(100, http_requests_histogram)
+eval range from 0 to 50m step 5m bottomk(100, http_requests_histogram)
+    expect info
     #empty
 
-eval_info instant at 50m bottomk(1, {__name__=~"http_requests(_histogram)?"})
+eval instant at 50m bottomk(1, {__name__=~"http_requests(_histogram)?"})
+    expect info
     {__name__="http_requests", group="production", instance="0", job="api-server"} 100
 
-eval_info instant at 50m count(bottomk(1000, {__name__=~"http_requests(_histogram)?"}))
+eval instant at 50m count(bottomk(1000, {__name__=~"http_requests(_histogram)?"}))
+    expect info
     {} 9
 
-eval_info range from 0 to 50m step 5m count(bottomk(1000, {__name__=~"http_requests(_histogram)?"}))
+eval range from 0 to 50m step 5m count(bottomk(1000, {__name__=~"http_requests(_histogram)?"}))
+    expect info
     {} 9x10
 
-eval_info instant at 50m bottomk by (instance) (1, {__name__=~"http_requests(_histogram)?"})
+eval instant at 50m bottomk by (instance) (1, {__name__=~"http_requests(_histogram)?"})
+    expect info
     {__name__="http_requests", group="production", instance="0", job="api-server"} 100
     {__name__="http_requests", group="production", instance="1", job="api-server"} 200
     {__name__="http_requests", group="production", instance="2", job="api-server"} NaN
@@ -455,13 +471,15 @@ eval instant at 1m quantile without(point)(0.8, data)
 	{test="uneven samples"} 2.8
 
 # The histogram is ignored here so the result doesn't change but it has an info annotation now.
-eval_info instant at 1m quantile without(point)(0.8, {__name__=~"data(_histogram)?"})
+eval instant at 1m quantile without(point)(0.8, {__name__=~"data(_histogram)?"})
+	expect info
 	{test="two samples"} 0.8
 	{test="three samples"} 1.6
 	{test="uneven samples"} 2.8
 
 # The histogram is ignored here so there is no result but it has an info annotation now.
-eval_info instant at 1m quantile(0.8, data_histogram)
+eval instant at 1m quantile(0.8, data_histogram)
+	expect info
 
 # Bug #5276.
 eval instant at 1m quantile without(point)(scalar(foo), data)
@@ -665,22 +683,28 @@ load 5m
 	series{label="c"} {{schema:1 sum:15 count:10 buckets:[3 2 5 7 9]}}
 
 # The histogram is ignored here so the result doesn't change but it has an info annotation now.
-eval_info instant at 0m stddev(series)
+eval instant at 0m stddev(series)
+	expect info
 	{} 0.5
 
-eval_info instant at 0m stdvar(series)
+eval instant at 0m stdvar(series)
+	expect info
 	{} 0.25
 
 # The histogram is ignored here so there is no result but it has an info annotation now.
-eval_info instant at 0m stddev({label="c"})
+eval instant at 0m stddev({label="c"})
+	expect info
 
-eval_info instant at 0m stdvar({label="c"})
+eval instant at 0m stdvar({label="c"})
+	expect info
 
-eval_info instant at 0m stddev by (label) (series)
+eval instant at 0m stddev by (label) (series)
+	expect info
 	{label="a"} 0
 	{label="b"} 0
 
-eval_info instant at 0m stdvar by (label) (series)
+eval instant at 0m stdvar by (label) (series)
+	expect info
 	{label="a"} 0
 	{label="b"} 0
 
@@ -691,17 +715,21 @@ load 5m
 	series{label="b"} 1
 	series{label="c"} 2
 
-eval_info instant at 0m stddev(series)
+eval instant at 0m stddev(series)
+	expect info
 	{} 0.5
 
-eval_info instant at 0m stdvar(series)
+eval instant at 0m stdvar(series)
+	expect info
 	{} 0.25
 
-eval_info instant at 0m stddev by (label) (series)
+eval instant at 0m stddev by (label) (series)
+	expect info
 	{label="b"} 0
 	{label="c"} 0
 
-eval_info instant at 0m stdvar by (label) (series)
+eval instant at 0m stdvar by (label) (series)
+	expect info
 	{label="b"} 0
 	{label="c"} 0
 

--- a/promql/promqltest/testdata/at_modifier.test
+++ b/promql/promqltest/testdata/at_modifier.test
@@ -91,7 +91,8 @@ eval instant at 25s metric{job="1"} @ 50 + metric{job="1"} @ 100
   {job="1"} 15
 
 # Note that this triggers an info annotation because we are rate'ing a metric that does not end in `_total`.
-eval_info instant at 25s rate(metric{job="1"}[100s] @ 100) + label_replace(rate(metric{job="2"}[123s] @ 200), "job", "1", "", "")
+eval instant at 25s rate(metric{job="1"}[100s] @ 100) + label_replace(rate(metric{job="2"}[123s] @ 200), "job", "1", "", "")
+  expect info
   {job="1"} 0.3
 
 eval instant at 25s sum_over_time(metric{job="1"}[100s] @ 100) + label_replace(sum_over_time(metric{job="2"}[100s] @ 100), "job", "1", "", "")


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
This PR replaces some of the deprecated `eval_info` notations with the corresponding `eval` notation.

Partially fixes #16367.

This PR was initially created during Contribfest at KubeCon + CloudNativeCon Europe 2025. Tagging @beorn7, @bwplotka, @ArthurSens and @vesari as requested.