### PR TITLE
tsdb: Make sure LeveledCompactor respect context cancellation during the time opening blocks

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -470,6 +470,12 @@ func (c *LeveledCompactor) CompactWithBlockPopulator(dest string, dirs []string,
 	start := time.Now()
 
 	for _, d := range dirs {
+		select {
+		case <-c.ctx.Done():
+			return nil, c.ctx.Err()
+		default:
+		}
+
 		meta, _, err := readMetaFile(d)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->


This PR is making sure LeveledCompactor could stop faster during opening blocks stage when context got cancelled. 

Without this change, if context cancelled when LeveledCompactor is still opening blocks for compaction and there are a lot of blocks, it would take a long time to have compaction cancelled due to context.