### PR TITLE
tsdb: Introduced new constructor for LeveledCompactor to take in metrics

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -193,6 +193,10 @@ func NewLeveledCompactor(ctx context.Context, r prometheus.Registerer, l *slog.L
 }
 
 func NewLeveledCompactorWithOptions(ctx context.Context, r prometheus.Registerer, l *slog.Logger, ranges []int64, pool chunkenc.Pool, opts LeveledCompactorOptions) (*LeveledCompactor, error) {
+	return NewLeveledCompactorWithOptionsAndMetrics(ctx, l, ranges, pool, opts, NewCompactorMetrics(r))
+}
+
+func NewLeveledCompactorWithOptionsAndMetrics(ctx context.Context, l *slog.Logger, ranges []int64, pool chunkenc.Pool, opts LeveledCompactorOptions, metrics *CompactorMetrics) (*LeveledCompactor, error) {
 	if len(ranges) == 0 {
 		return nil, errors.New("at least one range must be provided")
 	}
@@ -218,7 +222,7 @@ func NewLeveledCompactorWithOptions(ctx context.Context, r prometheus.Registerer
 		ranges:                      ranges,
 		chunkPool:                   pool,
 		logger:                      l,
-		metrics:                     NewCompactorMetrics(r),
+		metrics:                     metrics,
 		ctx:                         ctx,
 		maxBlockChunkSegmentSize:    maxBlockChunkSegmentSize,
 		mergeFunc:                   mergeFunc,


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Introduced new constructor for LeveledCompactor to take in metrics so that caller could reuse same set of metrics for different LeveledCompactor instance. This also allowed caller to change context without recreating same metrics everytime.
