### PR TITLE
fix: omitzero for scrapeconfig bool values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -672,7 +672,7 @@ type ScrapeConfig struct {
 	// Indicator whether the scraped timestamps should be respected.
 	HonorTimestamps bool `yaml:"honor_timestamps"`
 	// Indicator whether to track the staleness of the scraped timestamps.
-	TrackTimestampsStaleness bool `yaml:"track_timestamps_staleness"`
+	TrackTimestampsStaleness bool `yaml:"track_timestamps_staleness,omitzero"`
 	// A set of query parameters with which the target is scraped.
 	Params url.Values `yaml:"params,omitempty"`
 	// How frequently to scrape the targets of this scrape config.
@@ -700,7 +700,7 @@ type ScrapeConfig struct {
 	// The URL scheme with which to fetch metrics from targets.
 	Scheme string `yaml:"scheme,omitempty"`
 	// Indicator whether to request compressed response from the target.
-	EnableCompression bool `yaml:"enable_compression"`
+	EnableCompression bool `yaml:"enable_compression,omitzero"`
 	// An uncompressed response body larger than this many bytes will cause the
 	// scrape to fail. 0 means no limit.
 	BodySizeLimit units.Base2Bytes `yaml:"body_size_limit,omitempty"`


### PR DESCRIPTION
When the `TrackTimestampStaleness` and `EnableCompression` options were added to the ScrapeConfig type in
https://github.com/prometheus/prometheus/commit/84aadfc45b10d3dd3db20fbbe931ea34ee18c434, these boolean values broke from the precedent of most fields being set to `omitempty`.

The omitempty behavior is useful for backwwards compatibility. If a scrape configuration is generated based on the types from a newer version of Prometheus, you can simply exclude the new fields and they will not be included in the marshalled output. This allows older versions of Prometheus to continue to interpret the configuration correctly unless new features are explicitly requested.

At the time the commit was merged, the way to preserve this behavior would have been by making the boolean types a reference to a boolean type, then handling nil values throughout the codebase. This can be clumsy and increase the likelihood of nil pointer deference bugs, which may have contributed to the decision not to use reference types for these new boolean fields.

[Go 1.24 introduced the omitzero
option](https://tip.golang.org/doc/go1.24#encodingjsonpkgencodingjson). This allows the field to be omitted when it is set to the zero value (false for a boolean). This avoids the potential for nil pointer dereferences, while assisting with backwards compatibility. It is especially useful in situations like this where a features must be enabled by setting the value to `true`.

This change proposes to use omitzero for these fields to assist in backwards compatibility for configuration marshalling and more firmly establish the precedent that future configuration fields should be optionally marshalled.

This change has no effect on existing functionality. However, it may break tests that explicitly test the output of marshalling these configuration formats. As a downstream consumer/tester of these types, I consider this a good tradeoff. Minor changes to output prevent much uglier solutions to get around marshalling these fields.

Briefly, workarounds include:

1. Forking the types and manually setting the struct tags differently. This approach is brittle and imposes undue maintenance burden on downstream consumers of these config types.
2. Using reflection to modify the type and marshalling behavior at runtime. This approach is slightly more robust to future changes, but adds quite a bit of complexity, especially when handling nested fields.
3. Just-in-time manipulation of the final output. This approach loses type safety and requires text manipulation, which is also likely to be brittle over time.

Personally, I do not consider any of these workarounds sustainable, especially when compared to this proposed change.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
