### PR TITLE
docs: Remove recording rule note for native histograms

### DIFF
--- a/docs/configuration/recording_rules.md
+++ b/docs/configuration/recording_rules.md
@@ -17,10 +17,6 @@ Rule files use YAML.
 The rule files can be reloaded at runtime by sending `SIGHUP` to the Prometheus
 process. The changes are only applied if all rule files are well-formatted.
 
-_Note about native histograms (experimental feature): Native histogram are always
-recorded as gauge histograms (for now). Most cases will create gauge histograms
-naturally, e.g. after `rate()`._
-
 ## Syntax-checking rules
 
 To quickly check whether a rule file is syntactically correct without starting


### PR DESCRIPTION
We implemented proper type handling (gauge vs. counter histogram) a while ago. The note about it is obsolete.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
