### PR TITLE
discovery: make endpointSlice discovery more efficient

### DIFF
--- a/discovery/kubernetes/endpointslice.go
+++ b/discovery/kubernetes/endpointslice.go
@@ -110,10 +110,7 @@ func NewEndpointSlice(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, n
 				e.logger.Error("converting to EndpointSlice object failed", "err", err)
 				continue
 			}
-			if es.Namespace != svc.Namespace {
-				continue
-			}
-                        // Only consider the underlying EndpointSlices in the same namespace.
+			// Only consider the underlying EndpointSlices in the same namespace.
 			if svcName, exists := es.Labels[v1.LabelServiceName]; exists && svcName == svc.Name && es.Namespace == svc.Namespace {
 				e.enqueue(es)
 			}


### PR DESCRIPTION
a change to a service with the same name but from another namespace won't enqueue the endpointSlice

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
