### PR TITLE
promql: add new function trailing increase

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1735,7 +1735,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		}
 		if e.Func.Name == "trailing_increase" {
 			selRange += ev.interval
-			ev.startTimestamp -= ev.interval // subtraction of right interval adds one more point.
+			ev.startTimestamp -= ev.interval // Subtraction of right interval adds one more point.
 		}
 		// Reuse objects across steps to save memory allocations.
 		var floats []FPoint

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1733,10 +1733,6 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		if stepRange > ev.interval {
 			stepRange = ev.interval
 		}
-		if e.Func.Name == "trailing_increase" {
-			selRange += ev.interval
-			ev.startTimestamp -= ev.interval // Subtraction of right interval adds one more point.
-		}
 		// Reuse objects across steps to save memory allocations.
 		var floats []FPoint
 		var histograms []HPoint

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1733,6 +1733,10 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		if stepRange > ev.interval {
 			stepRange = ev.interval
 		}
+		if e.Func.Name == "trailing_increase" {
+			selRange += ev.interval
+			ev.startTimestamp -= ev.interval // subtraction of right interval adds one more point.
+		}
 		// Reuse objects across steps to save memory allocations.
 		var floats []FPoint
 		var histograms []HPoint

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -283,7 +283,7 @@ func histogramRate(points []HPoint, isCounter bool, metricName string, pos posra
 }
 
 // === trailing_increase(node parser.ValueTypeMatrix) (Vector, Annotations) ===
-func funcTrailingIncrease(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+func funcJustIncrease(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
 	var (
 		samples            = vals[0].(Matrix)[0]
 		resultFloat        float64
@@ -1936,7 +1936,7 @@ var FunctionCalls = map[string]FunctionCall{
 	"tanh":                         funcTanh,
 	"time":                         funcTime,
 	"timestamp":                    funcTimestamp,
-	"trailing_increase":            funcTrailingIncrease,
+	"just_increase":                funcJustIncrease,
 	"vector":                       funcVector,
 	"year":                         funcYear,
 }

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -420,6 +420,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeVector},
 		ReturnType: ValueTypeVector,
 	},
+	"trailing_increase": {
+		Name:       "trailing_increase",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+	},
 	"vector": {
 		Name:       "vector",
 		ArgTypes:   []ValueType{ValueTypeScalar},

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -420,8 +420,8 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeVector},
 		ReturnType: ValueTypeVector,
 	},
-	"trailing_increase": {
-		Name:       "trailing_increase",
+	"just_increase": {
+		Name:       "just_increase",
 		ArgTypes:   []ValueType{ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 	},

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -2824,9 +2824,9 @@ var testExpr = []struct {
 		},
 	},
 	{
-		input: "trailing_increase(some_metric[5m])",
+		input: "just_increase(some_metric[5m])",
 		expected: &Call{
-			Func: MustGetFunction("trailing_increase"),
+			Func: MustGetFunction("just_increase"),
 			Args: Expressions{
 				&MatrixSelector{
 					VectorSelector: &VectorSelector{
@@ -2835,43 +2835,17 @@ var testExpr = []struct {
 							MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "some_metric"),
 						},
 						PosRange: posrange.PositionRange{
-							Start: 18,
-							End:   29,
+							Start: 14,
+							End:   25,
 						},
 					},
 					Range:  5 * time.Minute,
-					EndPos: 33,
+					EndPos: 29,
 				},
 			},
 			PosRange: posrange.PositionRange{
 				Start: 0,
-				End:   34,
-			},
-		},
-	},
-	{
-		input: "trailing_increase(some_metric[5m])",
-		expected: &Call{
-			Func: MustGetFunction("trailing_increase"),
-			Args: Expressions{
-				&MatrixSelector{
-					VectorSelector: &VectorSelector{
-						Name: "some_metric",
-						LabelMatchers: []*labels.Matcher{
-							MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "some_metric"),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 18,
-							End:   29,
-						},
-					},
-					Range:  5 * time.Minute,
-					EndPos: 33,
-				},
-			},
-			PosRange: posrange.PositionRange{
-				Start: 0,
-				End:   34,
+				End:   30,
 			},
 		},
 	},

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -2824,6 +2824,58 @@ var testExpr = []struct {
 		},
 	},
 	{
+		input: "trailing_increase(some_metric[5m])",
+		expected: &Call{
+			Func: MustGetFunction("trailing_increase"),
+			Args: Expressions{
+				&MatrixSelector{
+					VectorSelector: &VectorSelector{
+						Name: "some_metric",
+						LabelMatchers: []*labels.Matcher{
+							MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "some_metric"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 18,
+							End:   29,
+						},
+					},
+					Range:  5 * time.Minute,
+					EndPos: 33,
+				},
+			},
+			PosRange: posrange.PositionRange{
+				Start: 0,
+				End:   34,
+			},
+		},
+	},
+	{
+		input: "trailing_increase(some_metric[5m])",
+		expected: &Call{
+			Func: MustGetFunction("trailing_increase"),
+			Args: Expressions{
+				&MatrixSelector{
+					VectorSelector: &VectorSelector{
+						Name: "some_metric",
+						LabelMatchers: []*labels.Matcher{
+							MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "some_metric"),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 18,
+							End:   29,
+						},
+					},
+					Range:  5 * time.Minute,
+					EndPos: 33,
+				},
+			},
+			PosRange: posrange.PositionRange{
+				Start: 0,
+				End:   34,
+			},
+		},
+	},
+	{
 		input: "rate(some_metric[5m])",
 		expected: &Call{
 			Func: MustGetFunction("rate"),


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
This PR introduces a new function, ```trailing_increase```, which calculates the increase of a counter *without extrapolation*, using one additional sample point beyond what is strictly required by the query range.  

### Motivation  

I needed to accurately determine: *"How many queries have been completed in my system over a given time period?"*  

My system exposes a counter that increments whenever a query finishes. Initially, I tried using the standard ```increase()``` function, but encountered two issues:  
1. **Floating-point results**: The returned values were not whole numbers, despite the counter increasing in integer steps.  
2. **Inaccurate counts**: The function did not reliably reflect the actual number of completed queries, especially when the counter reset.  

Next, I experimented with:  
```sum_over_time(idelta(query_counter{}[30s])[5m:15s])```

While this approach was closer to what I needed, it had drawbacks:  
- **Verbosity and complexity**: The query is cumbersome and unintuitive.  
- **Performance overhead (possible)**: Aggregating fine-grained deltas could impose unnecessary load.  
- **No counter reset handling**: The method fails to account for counter resets.  

Since this is fundamentally a counter, there should be a straightforward way to compute its true increase over time.  

### Solution: trailing_increase  

The new ```trailing_increase``` function behaves similarly to ```increase``` but **avoids extrapolation**. It requires one additional sample point before the queried range to ensure accuracy.  

#### Why the Extra Sample?

Consider a scenario where _query_counter_ is scraped every 15 seconds, producing the series: ```[1, 2, 3, 4, 5]```.  
Using ```increase(query_counter{}[1m])``` (without extrapolation) on the last four points ```[2, 3, 4, 5]``` would return 5 - 2 = 3.  
However, this only reflects increases over 45 seconds (from t=15s to t=60s), not the full minute. We cannot determine whether the counter increased before the first observed value (2).  

By including one prior sample (1 in this case), ```trailing_increase``` ensures the calculation covers the entire requested window.  

#### Caveats  
- Correct interval required: The function assumes the queried range aligns with the scrape interval; otherwise, results may be inaccurate.  

This implementation provides a more intuitive and reliable way to measure counter increases, particularly for use cases requiring precise integer counts.