### PR TITLE
remote: Allow unwrapping of errors when reading from remote client

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -384,7 +384,8 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query, sortSeries bool)
 		_ = httpResp.Body.Close()
 
 		cancel()
-		return nil, fmt.Errorf("remote server %s returned http status %s: %s", c.urlString, httpResp.Status, string(body))
+		err := errors.New(string(body))
+		return nil, fmt.Errorf("remote server %s returned http status %s: %w", c.urlString, httpResp.Status, err)
 	}
 
 	contentType := httpResp.Header.Get("Content-Type")

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -342,7 +342,7 @@ func TestReadClient(t *testing.T) {
 			httpHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				http.Error(w, "test error", http.StatusBadRequest)
 			}),
-			expectedErrorContains: "test error",
+			expectedErrorContains: "test error\n",
 			unwrap:                true,
 		},
 	}
@@ -377,7 +377,7 @@ func TestReadClient(t *testing.T) {
 				require.ErrorContains(t, err, test.expectedErrorContains)
 				if test.unwrap {
 					err = errors.Unwrap(err)
-					require.EqualError(t, err, test.expectedErrorContains+"\n")
+					require.EqualError(t, err, test.expectedErrorContains)
 				}
 				return
 			}


### PR DESCRIPTION
When `fmt.Errorf` uses only %s and no %w, it can't be unwrapped, but when it does, it can be unwrapped to just the %w part.

This change allows us to unwrap the error we get from here, so previously an error like `remote_read: remote server http://127.0.0.1:45687/api/v1/read returned http status 500 Internal Server Error: execution error` couldn't be unwrapped, but now it can be unwrapped to just `execution error`.