### PR TITLE
[TESTS] TSDB: Faster WAL benchmarks

### DIFF
--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -149,24 +149,29 @@ func BenchmarkHeadAppender_Append_Commit_ExistingSeries(b *testing.B) {
 	}
 }
 
-func populateTestWL(t testing.TB, w *wlog.WL, recs []interface{}) {
+func populateTestWL(t testing.TB, w *wlog.WL, recs []interface{}, buf []byte) []byte {
 	var enc record.Encoder
 	for _, r := range recs {
+		buf = buf[:0]
 		switch v := r.(type) {
 		case []record.RefSeries:
-			require.NoError(t, w.Log(enc.Series(v, nil)))
+			buf = enc.Series(v, buf)
 		case []record.RefSample:
-			require.NoError(t, w.Log(enc.Samples(v, nil)))
+			buf = enc.Samples(v, buf)
 		case []tombstones.Stone:
-			require.NoError(t, w.Log(enc.Tombstones(v, nil)))
+			buf = enc.Tombstones(v, buf)
 		case []record.RefExemplar:
-			require.NoError(t, w.Log(enc.Exemplars(v, nil)))
+			buf = enc.Exemplars(v, buf)
 		case []record.RefMmapMarker:
-			require.NoError(t, w.Log(enc.MmapMarkers(v, nil)))
+			buf = enc.MmapMarkers(v, buf)
 		case []record.RefMetadata:
-			require.NoError(t, w.Log(enc.Metadata(v, nil)))
+			buf = enc.Metadata(v, buf)
+		default:
+			continue
 		}
+		require.NoError(t, w.Log(buf))
 	}
+	return buf
 }
 
 func readTestWAL(t testing.TB, dir string) (recs []interface{}) {
@@ -309,6 +314,7 @@ func BenchmarkLoadWLs(b *testing.B) {
 
 						// Write series.
 						refSeries := make([]record.RefSeries, 0, c.seriesPerBatch)
+						var buf []byte
 						for k := 0; k < c.batches; k++ {
 							refSeries = refSeries[:0]
 							for i := k * c.seriesPerBatch; i < (k+1)*c.seriesPerBatch; i++ {
@@ -333,7 +339,7 @@ func BenchmarkLoadWLs(b *testing.B) {
 								writeSeries = newWriteSeries
 							}
 
-							populateTestWL(b, wal, []interface{}{writeSeries})
+							buf = populateTestWL(b, wal, []interface{}{writeSeries}, buf)
 						}
 
 						// Write samples.
@@ -359,7 +365,7 @@ func BenchmarkLoadWLs(b *testing.B) {
 										V:   float64(i) * 100,
 									})
 								}
-								populateTestWL(b, wal, []interface{}{refSamples})
+								buf = populateTestWL(b, wal, []interface{}{refSamples}, buf)
 							}
 						}
 
@@ -398,7 +404,7 @@ func BenchmarkLoadWLs(b *testing.B) {
 										Labels: labels.FromStrings("trace_id", fmt.Sprintf("trace-%d", i)),
 									})
 								}
-								populateTestWL(b, wal, []interface{}{refExemplars})
+								buf = populateTestWL(b, wal, []interface{}{refExemplars}, buf)
 							}
 						}
 
@@ -427,10 +433,10 @@ func BenchmarkLoadWLs(b *testing.B) {
 									})
 								}
 								if shouldAddMarkers {
-									populateTestWL(b, wbl, []interface{}{refMarkers})
+									populateTestWL(b, wbl, []interface{}{refMarkers}, buf)
 								}
-								populateTestWL(b, wal, []interface{}{refSamples})
-								populateTestWL(b, wbl, []interface{}{refSamples})
+								buf = populateTestWL(b, wal, []interface{}{refSamples}, buf)
+								buf = populateTestWL(b, wbl, []interface{}{refSamples}, buf)
 							}
 						}
 
@@ -739,7 +745,7 @@ func TestHead_ReadWAL(t *testing.T) {
 				require.NoError(t, head.Close())
 			}()
 
-			populateTestWL(t, w, entries)
+			populateTestWL(t, w, entries, nil)
 
 			require.NoError(t, head.Init(math.MinInt64))
 			require.Equal(t, uint64(101), head.lastSeriesID.Load())
@@ -1383,7 +1389,7 @@ func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {
 				require.NoError(t, head.Close())
 			}()
 
-			populateTestWL(t, w, entries)
+			populateTestWL(t, w, entries, nil)
 
 			require.NoError(t, head.Init(math.MinInt64))
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -315,15 +315,15 @@ func BenchmarkLoadWLs(b *testing.B) {
 						// Write series.
 						refSeries := make([]record.RefSeries, 0, c.seriesPerBatch)
 						var buf []byte
+						builder := labels.NewBuilder(labels.EmptyLabels())
+						for j := 1; j < labelsPerSeries; j++ {
+							builder.Set(defaultLabelName+strconv.Itoa(j), defaultLabelValue+strconv.Itoa(j))
+						}
 						for k := 0; k < c.batches; k++ {
 							refSeries = refSeries[:0]
 							for i := k * c.seriesPerBatch; i < (k+1)*c.seriesPerBatch; i++ {
-								lbls := make(map[string]string, labelsPerSeries)
-								lbls[defaultLabelName] = strconv.Itoa(i)
-								for j := 1; len(lbls) < labelsPerSeries; j++ {
-									lbls[defaultLabelName+strconv.Itoa(j)] = defaultLabelValue + strconv.Itoa(j)
-								}
-								refSeries = append(refSeries, record.RefSeries{Ref: chunks.HeadSeriesRef(i) * 101, Labels: labels.FromMap(lbls)})
+								builder.Set(defaultLabelName, strconv.Itoa(i))
+								refSeries = append(refSeries, record.RefSeries{Ref: chunks.HeadSeriesRef(i) * 101, Labels: builder.Labels()})
 							}
 
 							writeSeries := refSeries


### PR DESCRIPTION
* Reuse buffer for writing the WAL records. Less garbage collection, goes faster.
* More efficient label creation - use the Builder abstraction instead of going via a map.

Before:
```
go test -run XXX -bench 'BenchmarkLoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=
0.300,oooCapMax=32,missingSeriesPct=0.000' ./tsdb/
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Core(TM) i7-14700K
BenchmarkLoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32,missingSeriesPct=0.000-28                    1        3104853168 ns/op
PASS
ok      github.com/prometheus/prometheus/tsdb   4.310s
```

After:
```
go test -run XXX -bench 'BenchmarkLoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32,missingSeriesPct=0.000' ./tsdb/
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Core(TM) i7-14700K
BenchmarkLoadWLs/batches=100,seriesPerBatch=1000,samplesPerSeries=480,exemplarsPerSeries=0,mmappedChunkT=3800,oooSeriesPct=0.200,oooSamplesPct=0.300,oooCapMax=32,missingSeriesPct=0.000-28                    1        3024799543 ns/op
PASS
ok      github.com/prometheus/prometheus/tsdb   3.863s
```

It makes even more of a difference if you push the number of series up.
