### PR TITLE
promtool: Add feature flags for promql features

### DIFF
--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -558,6 +558,16 @@ func TestCheckRules(t *testing.T) {
 	})
 }
 
+func TestCheckRulesWithFeatureFlag(t *testing.T) {
+	// As opposed to TestCheckRules calling CheckRules directly we run promtool
+	// so the feature flag parsing can be tested.
+
+	args := []string{"-test.main", "--enable-feature=promql-experimental-functions", "check", "rules", "testdata/features.yml"}
+	tool := exec.Command(promtoolPath, args...)
+	err := tool.Run()
+	require.NoError(t, err)
+}
+
 func TestCheckRulesWithRuleFiles(t *testing.T) {
 	t.Run("rules-good", func(t *testing.T) {
 		t.Parallel()

--- a/cmd/promtool/testdata/features.yml
+++ b/cmd/promtool/testdata/features.yml
@@ -1,0 +1,6 @@
+groups:
+  - name: features
+    rules:
+      - record: x
+        # We don't expect anything from this, just want to check the function parses.
+        expr: sort_by_label(up, "instance")

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -15,7 +15,7 @@ Tooling for the Prometheus monitoring system.
 | <code class="text-nowrap">-h</code>, <code class="text-nowrap">--help</code> | Show context-sensitive help (also try --help-long and --help-man). |
 | <code class="text-nowrap">--version</code> | Show application version. |
 | <code class="text-nowrap">--experimental</code> | Enable experimental commands. |
-| <code class="text-nowrap">--enable-feature</code> <code class="text-nowrap">...<code class="text-nowrap"> | Comma separated feature names to enable. Currently unused. |
+| <code class="text-nowrap">--enable-feature</code> <code class="text-nowrap">...<code class="text-nowrap"> | Comma separated feature names to enable. Valid options: promql-experimental-functions, promql-delayed-name-removal. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details |
 
 
 

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -1501,6 +1501,9 @@ type LazyLoaderOpts struct {
 	// Prometheus v2.33). They can still be disabled here for legacy and
 	// other uses.
 	EnableAtModifier, EnableNegativeOffset bool
+	// Currently defaults to false, matches the "promql-delayed-name-removal"
+	// feature flag.
+	EnableDelayedNameRemoval bool
 }
 
 // NewLazyLoader returns an initialized empty LazyLoader.
@@ -1563,7 +1566,7 @@ func (ll *LazyLoader) clear() error {
 		NoStepSubqueryIntervalFn: func(int64) int64 { return durationMilliseconds(ll.SubqueryInterval) },
 		EnableAtModifier:         ll.opts.EnableAtModifier,
 		EnableNegativeOffset:     ll.opts.EnableNegativeOffset,
-		EnableDelayedNameRemoval: true,
+		EnableDelayedNameRemoval: ll.opts.EnableDelayedNameRemoval,
 	}
 
 	ll.queryEngine = promql.NewEngine(opts)


### PR DESCRIPTION
These are supported in the main prometheus binary but the feature flags weren't supported in promtool.

Fixes #16412.
