### PR TITLE
MAINTAINERS: add Jan-Otto Kröpke as an discovery/azure maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,7 @@ Maintainers for specific parts of the codebase:
 * `cmd`
   * `promtool`: David Leadbeater (<dgl@dgl.cx> / @dgl)
 * `discovery`
+  * `azure`: Jan-Otto Kröpke (<mail@jkroepke.de> / @jkroepke)
   * `k8s`: Frederic Branczyk (<fbranczyk@gmail.com> / @brancz)
 * `documentation`
   * `prometheus-mixin`: Matthias Loibl (<mail@matthiasloibl.com> / @metalmatze)


### PR DESCRIPTION
See:
* #14357