### PR TITLE
Strip newline in error when reading from remote client

### DIFF
--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -384,7 +384,8 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query, sortSeries bool)
 		_ = httpResp.Body.Close()
 
 		cancel()
-		err := errors.New(string(body))
+		errStr := strings.Trim(string(body), "\n")
+		err := errors.New(errStr)
 		return nil, fmt.Errorf("remote server %s returned http status %s: %w", c.urlString, httpResp.Status, err)
 	}
 

--- a/storage/remote/client_test.go
+++ b/storage/remote/client_test.go
@@ -342,7 +342,7 @@ func TestReadClient(t *testing.T) {
 			httpHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				http.Error(w, "test error", http.StatusBadRequest)
 			}),
-			expectedErrorContains: "test error\n",
+			expectedErrorContains: "test error",
 			unwrap:                true,
 		},
 	}


### PR DESCRIPTION
Follow up to https://github.com/prometheus/prometheus/pull/16437 , which did not really change the string form of the error returned (just made the error form multilayered to allow it to be unwrapped), the newline was always there.

This PR will now actually change the error, by removing the newline which is probably unwanted in most cases and is typically absent from most errors. (Merging this PR isn't particularly important to me as the newline can be easily removed downstream, but it seems better to get rid of it at the source if possible if no one has any use for it.)

---

Failures in the windows tests might be transient