### PR TITLE
chore(cmd): Add info log for automemlimit config

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -671,6 +671,7 @@ func main() {
 					memlimit.FromSystem,
 				),
 			),
+			memlimit.WithLogger(logger.With("component", "automemlimit")),
 		); err != nil {
 			logger.Warn("automemlimit", "msg", "Failed to set GOMEMLIMIT automatically", "err", err)
 		}


### PR DESCRIPTION
to get a log for automemlimit as well

```
time=2025-05-01T15:10:07.358Z level=INFO source=main.go:1525 msg="updated GOGC" old=100 new=75
time=2025-05-01T15:10:07.358Z level=INFO source=main.go:658 msg="Leaving GOMAXPROCS=12: CPU quota undefined" component=automaxprocs



time=2025-05-01T15:10:07.358Z level=INFO source=memlimit.go:198 msg="GOMEMLIMIT is updated" component=automemlimit package=github.com/KimMachineGun/automemlimit/memlimit GOMEMLIMIT=30923764531 previous=9223372036854775807
```

don't think there is an easy way to get rid of `package=github.com/KimMachineGun/automemlimit/memlimit`  https://github.com/KimMachineGun/automemlimit/blob/a9a712bee9977065cf72b4f29fcaf3a4e0573e13/memlimit/memlimit.go#L90

maybe as DEBUG?



<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
