### PR TITLE
ci: address zizmor gh action vulnerabilities

### DIFF
--- a/.github/workflows/buf-lint.yml
+++ b/.github/workflows/buf-lint.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -13,6 +13,8 @@ jobs:
     if: github.repository_owner == 'prometheus'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   test_go:
     name: Go tests
@@ -14,6 +17,8 @@ jobs:
       image: quay.io/prometheus/golang-builder:1.24-base
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci@443c7fc2397e946bc9f5029e313a9c3441b9b86d # v0.4.7
       - uses: ./.github/promci/actions/setup_environment
         with:
@@ -30,6 +35,8 @@ jobs:
       image: quay.io/prometheus/golang-builder:1.24-base
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci@443c7fc2397e946bc9f5029e313a9c3441b9b86d # v0.4.7
       - uses: ./.github/promci/actions/setup_environment
       - run: go test --tags=dedupelabels ./...
@@ -49,6 +56,8 @@ jobs:
       image: quay.io/prometheus/golang-builder:1.23-base
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: make build
       # Don't run NPM build; don't run race-detector.
       - run: make test GO_ONLY=1 test-flags=""
@@ -63,6 +72,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci@443c7fc2397e946bc9f5029e313a9c3441b9b86d # v0.4.7
       - uses: ./.github/promci/actions/setup_environment
         with:
@@ -80,6 +91,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: 1.24.x
@@ -97,6 +110,8 @@ jobs:
       image: quay.io/prometheus/golang-builder:1.24-base
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: go install ./cmd/promtool/.
       - run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
       - run: go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
@@ -122,6 +137,8 @@ jobs:
         thread: [ 0, 1, 2 ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci@443c7fc2397e946bc9f5029e313a9c3441b9b86d # v0.4.7
       - uses: ./.github/promci/actions/build
         with:
@@ -147,6 +164,8 @@ jobs:
     # should also be updated.
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci@443c7fc2397e946bc9f5029e313a9c3441b9b86d # v0.4.7
       - uses: ./.github/promci/actions/build
         with:
@@ -181,6 +200,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Install Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
@@ -194,6 +215,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Install Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
@@ -212,6 +235,9 @@ jobs:
     if: github.event_name == 'pull_request'
   codeql:
     uses: ./.github/workflows/codeql-analysis.yml
+    permissions:
+      contents: read
+      security-events: write
 
   publish_main:
     name: Publish main branch artifacts
@@ -220,6 +246,8 @@ jobs:
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci@443c7fc2397e946bc9f5029e313a9c3441b9b86d # v0.4.7
       - uses: ./.github/promci/actions/publish_main
         with:
@@ -237,6 +265,8 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci@443c7fc2397e946bc9f5029e313a9c3441b9b86d # v0.4.7
       - uses: ./.github/promci/actions/publish_release
         with:
@@ -252,6 +282,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci@443c7fc2397e946bc9f5029e313a9c3441b9b86d # v0.4.7
       - name: Install nodejs
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
@@ -269,7 +301,9 @@ jobs:
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
           ||
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
-        run: ./scripts/ui_release.sh --check-package "$(./scripts/get_module_version.sh ${{ github.ref_name }})"
+        run: ./scripts/ui_release.sh --check-package "$(./scripts/get_module_version.sh ${GH_REF_NAME})"
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
       - name: build
         run: make assets
       - name: Copy files before publishing libs

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13

--- a/.github/workflows/container_description.yml
+++ b/.github/workflows/container_description.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: git checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set docker hub repo name
         run: echo "DOCKER_REPO_NAME=$(make docker-repo-name)" >> $GITHUB_ENV
       - name: Push README to Dockerhub
@@ -41,6 +43,8 @@ jobs:
     steps:
       - name: git checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set quay.io org name
         run: echo "DOCKER_REPO=$(echo quay.io/${GITHUB_REPOSITORY_OWNER} | tr -d '-')" >> $GITHUB_ENV
       - name: Set quay.io repo name

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - name: Build Fuzzers
         id: build
-        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@cafd7a0eb8ecb4e007c56897996a9b65c49c972f # master
         with:
           oss-fuzz-project-name: "prometheus"
           dry-run: false
       - name: Run Fuzzers
-        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@cafd7a0eb8ecb4e007c56897996a9b65c49c972f # master
         with:
           oss-fuzz-project-name: "prometheus"
           fuzz-seconds: 600

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -16,6 +16,8 @@ jobs:
           dry-run: false
       - name: Run Fuzzers
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@cafd7a0eb8ecb4e007c56897996a9b65c49c972f # master
+        # Note: Regularly check for updates to the pinned commit hash at:
+        # https://github.com/google/oss-fuzz/tree/master/infra/cifuzz/actions/run_fuzzers
         with:
           oss-fuzz-project-name: "prometheus"
           fuzz-seconds: 600

--- a/.github/workflows/prombench.yml
+++ b/.github/workflows/prombench.yml
@@ -2,6 +2,8 @@ on:
   repository_dispatch:
     types: [prombench_start, prombench_restart, prombench_stop]
 name: Prombench Workflow
+permissions:
+  contents: read
 env:
   AUTH_FILE: ${{ secrets.TEST_INFRA_PROVIDER_AUTH }}
   CLUSTER_NAME: test-infra

--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -14,6 +14,8 @@ jobs:
       image: quay.io/prometheus/golang-builder
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: ./scripts/sync_repo_files.sh
         env:
           GITHUB_TOKEN: ${{ secrets.PROMBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR addresses 40 medium and 3 high severity issues as reported by [zizmor](https://woodruffw.github.io/zizmor/)

<details><summary>Issue details</summary>
<pre><code>
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/buf-lint.yml:15:9
   |
15 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/buf.yml:15:9
   |
15 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/ci.yml:16:9
   |
16 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/ci.yml:32:9
   |
32 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/ci.yml:51:9
   |
51 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/ci.yml:65:9
   |
65 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/ci.yml:82:9
   |
82 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/ci.yml:99:9
   |
99 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/ci.yml:124:9
    |
124 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
    |         ------------------------------------------------------------------------ does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/ci.yml:149:9
    |
149 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
    |         ------------------------------------------------------------------------ does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/ci.yml:182:9
    |
182 |         - name: Checkout repository
    |  _________-
183 | |         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
    | |________________________________________________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/ci.yml:195:9
    |
195 |         - name: Checkout repository
    |  _________-
196 | |         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
    | |________________________________________________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/ci.yml:222:9
    |
222 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
    |         ------------------------------------------------------------------------ does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/ci.yml:239:9
    |
239 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
    |         ------------------------------------------------------------------------ does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/ci.yml:253:9
    |
253 |         - name: Checkout
    |  _________-
254 | |         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
    | |________________________________________________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:1:1
    |
  1 | / ---
  2 | | name: CI
...   |
291 | |           # as the placeholder for the auth token
292 | |           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
    | |____________________________________________________- default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/ci.yml:8:3
   |
 8 | /   test_go:
 9 | |     name: Go tests
...  |
23 | |       - run: make -C documentation/examples/remote_storage
24 | |       - run: make -C documentation/examples
   | |                                           -
   | |___________________________________________|
   |                                             this job
   |                                             default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/ci.yml:26:3
   |
26 | /   test_go_more:
27 | |     name: More Go tests
...  |
38 | |         with:
39 | |           version: "3.15.8"
   | |                           -
   | |___________________________|
   |                             this job
   |                             default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/ci.yml:41:3
   |
41 | /   test_go_oldest:
42 | |     name: Go tests with previous Go version
...  |
53 | |       # Don't run NPM build; don't run race-detector.
54 | |       - run: make test GO_ONLY=1 test-flags=""
   | |                                              -
   | |______________________________________________|
   |                                                this job
   |                                                default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/ci.yml:56:3
   |
56 | /   test_ui:
57 | |     name: UI tests
...  |
75 | |         with:
76 | |           directory: .tarballs
   | |                              -
   | |______________________________|
   |                                this job
   |                                default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/ci.yml:78:3
   |
78 | /   test_windows:
79 | |     name: Go tests on Windows
...  |
88 | |           go test $TestTargets -vet=off -v
89 | |         shell: powershell
   | |                         -
   | |_________________________|
   |                           this job
   |                           default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:91:3
    |
 91 | /   test_mixins:
 92 | |     name: Mixins tests
...   |
106 | |       - run: make -C documentation/prometheus-mixin
107 | |       - run: git diff --exit-code
    | |                                 -
    | |_________________________________|
    |                                   this job
    |                                   default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:109:3
    |
109 | /   build:
110 | |     name: Build Prometheus for common architectures
...   |
129 | |           parallelism: 3
130 | |           thread: ${{ matrix.thread }}
    | |                                      -
    | |______________________________________|
    |                                        this job
    |                                        default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:131:3
    |
131 | /   build_all:
132 | |     name: Build Prometheus for all architectures
...   |
153 | |           parallelism: 12
154 | |           thread: ${{ matrix.thread }}
    | |                                      -
    | |______________________________________|
    |                                        this job
    |                                        default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:155:3
    |
155 | /   build_all_status:
156 | |     # This status check aggregates the individual matrix jobs of the "Build
...   |
176 | |         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
177 | |         run: exit 1
    | |                   -
    | |___________________|
    |                     this job
    |                     default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:178:3
    |
178 | /   check_generated_parser:
179 | |     name: Check generated parser
...   |
189 | |       - name: Run goyacc and check for diff
190 | |         run: make install-goyacc check-generated-parser
    | |                                                       -
    | |_______________________________________________________|
    |                                                         this job
    |                                                         default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:191:3
    |
191 | /   golangci:
192 | |     name: golangci-lint
...   |
208 | |           # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
209 | |           version: v2.0.2
    | |                         -
    | |_________________________|
    |                           this job
    |                           default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:210:3
    |
210 | /   fuzzing:
211 | |     uses: ./.github/workflows/fuzzing.yml
212 | |     if: github.event_name == 'pull_request'
    | |                                           -
    | |___________________________________________|
    |                                             this job
    |                                             default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:213:3
    |
213 | /   codeql:
214 | |     uses: ./.github/workflows/codeql-analysis.yml
    | |                                                 -
    | |_________________________________________________|
    |                                                   this job
    |                                                   default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:216:3
    |
216 | /   publish_main:
217 | |     name: Publish main branch artifacts
...   |
228 | |           quay_io_login: ${{ secrets.quay_io_login }}
229 | |           quay_io_password: ${{ secrets.quay_io_password }}
    | |                                                           -
    | |___________________________________________________________|
    |                                                             this job
    |                                                             default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:230:3
    |
230 | /   publish_release:
231 | |     name: Publish release artefacts
...   |
246 | |           quay_io_password: ${{ secrets.quay_io_password }}
247 | |           github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}
    | |                                                           -
    | |___________________________________________________________|
    |                                                             this job
    |                                                             default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/ci.yml:248:3
    |
248 | /   publish_ui_release:
249 | |     name: Publish UI on npm Registry
...   |
291 | |           # as the placeholder for the auth token
292 | |           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
    | |                                                    -
    | |____________________________________________________|
    |                                                      this job
    |                                                      default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/ci.yml:267:9
    |
267 |       - name: Check libraries version
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
268 |         if: |
...
271 |           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v3.'))
272 |         run: ./scripts/ui_release.sh --check-package "$(./scripts/get_module_version.sh ${{ github.ref_name }})"
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ github.ref_name may expand into attacker-controllable code
    |
    = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/codeql-analysis.yml:26:9
   |
26 |         - name: Checkout repository
   |  _________-
27 | |         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   | |________________________________________________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/container_description.yml:20:9
   |
20 |         - name: git checkout
   |  _________-
21 | |         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   | |________________________________________________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/container_description.yml:42:9
   |
42 |         - name: git checkout
   |  _________-
43 | |         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   | |________________________________________________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/fuzzing.yml:13:9
   |
13 |         uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/fuzzing.yml:18:9
   |
18 |         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/prombench.yml:1:1
    |
  1 | / on:
  2 | |   repository_dispatch:
...   |
127 | |           --data '{"state":"success",  "context": "prombench-status-update-restart", "target_url": "'$GITHUB_STATUS_TARGET_URL'"}'
128 | |           "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
    | |______________________________________________________________________________________- default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/prombench.yml:22:3
   |
22 | /   benchmark_start:
23 | |     name: Benchmark Start
...  |
55 | |           --data '{"state":"success",  "context": "prombench-status-update-start", "target_url": "'$GITHUB_STATUS_TARGET_URL'"}'
56 | |           "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
   | |                                                                                     -
   | |_____________________________________________________________________________________|
   |                                                                                       this job
   |                                                                                       default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/prombench.yml:57:3
   |
57 | /   benchmark_cancel:
58 | |     name: Benchmark Cancel
...  |
90 | |           --data '{"state":"success",  "context": "prombench-status-update-cancel", "target_url": "'$GITHUB_STATUS_TARGET_URL'"}'
91 | |           "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
   | |                                                                                     -
   | |_____________________________________________________________________________________|
   |                                                                                       this job
   |                                                                                       default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/prombench.yml:92:3
    |
 92 | /   benchmark_restart:
 93 | |     name: Benchmark Restart
...   |
127 | |           --data '{"state":"success",  "context": "prombench-status-update-restart", "target_url": "'$GITHUB_STATUS_TARGET_URL'"}'
128 | |           "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$LAST_COMMIT_SHA"
    | |                                                                                      -
    | |______________________________________________________________________________________|
    |                                                                                        this job
    |                                                                                        default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/repo_sync.yml:16:9
   |
16 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   |         ------------------------------------------------------------------------ does not set persist-credentials: false
   |
   = note: audit confidence → Low

51 findings (8 suppressed): 0 unknown, 0 informational, 0 low, 40 medium, 3 high
</pre></code>
</details>

Two of these [high severity] issues are regarding unpinned GH actions:

```
error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/fuzzing.yml:13:9
   |
13 |         uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/fuzzing.yml:18:9
   |
18 |         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
```

There's no technical reason jumping out at me that might prevent these from being pinned to a digest instead of a tag, but others may have more context than me for this.