### PR TITLE
tsdb/errors.MultiError: support errors.As

### DIFF
--- a/tsdb/errors/errors.go
+++ b/tsdb/errors/errors.go
@@ -94,6 +94,11 @@ func (es nonNilMultiError) Is(target error) bool {
 	return false
 }
 
+// Unwrap returns the list of errors contained in the multiError.
+func (es nonNilMultiError) Unwrap() []error {
+	return es.errs
+}
+
 // CloseAll closes all given closers while recording error in MultiError.
 func CloseAll(cs []io.Closer) error {
 	errs := NewMulti()

--- a/tsdb/errors/errors_test.go
+++ b/tsdb/errors/errors_test.go
@@ -1,3 +1,16 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package errors
 
 import (

--- a/tsdb/errors/errors_test.go
+++ b/tsdb/errors/errors_test.go
@@ -142,10 +142,10 @@ func TestMultiError_As(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			mErr := NewMulti(testCase.sourceErrors...).Err()
 			if testCase.as {
-				require.True(t, errors.As(mErr, &target))
+				require.ErrorAs(t, mErr, &target)
 				require.Equal(t, testCase.target, target)
 			} else {
-				require.False(t, errors.As(mErr, &target))
+				require.NotErrorAs(t, mErr, &target)
 			}
 		})
 	}

--- a/tsdb/errors/errors_test.go
+++ b/tsdb/errors/errors_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestMultiError_Is(t *testing.T) {
 	customErr1 := errors.New("test error 1")
-	customErr2 := fmt.Errorf("test error 2")
+	customErr2 := errors.New("test error 2")
 
 	testCases := map[string]struct {
 		sourceErrors []error

--- a/tsdb/errors/errors_test.go
+++ b/tsdb/errors/errors_test.go
@@ -1,0 +1,160 @@
+package errors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var anError = errors.New("test error")
+
+func TestMultiError_Is(t *testing.T) {
+	customErr := fmt.Errorf("my error")
+
+	testCases := map[string]struct {
+		sourceErrors []error
+		target       error
+		is           bool
+	}{
+		"adding a context cancellation doesn't lose the information": {
+			sourceErrors: []error{context.Canceled},
+			target:       context.Canceled,
+			is:           true,
+		},
+		"adding multiple context cancellations doesn't lose the information": {
+			sourceErrors: []error{context.Canceled, context.Canceled},
+			target:       context.Canceled,
+			is:           true,
+		},
+		"adding wrapped context cancellations doesn't lose the information": {
+			sourceErrors: []error{errors.New("some error"), fmt.Errorf("some message: %w", context.Canceled)},
+			target:       context.Canceled,
+			is:           true,
+		},
+		"adding a nil error doesn't lose the information": {
+			sourceErrors: []error{errors.New("some error"), fmt.Errorf("some message: %w", context.Canceled), nil},
+			target:       context.Canceled,
+			is:           true,
+		},
+		"errors with no context cancellation error are not a context canceled error": {
+			sourceErrors: []error{errors.New("first error"), errors.New("second error")},
+			target:       context.Canceled,
+			is:           false,
+		},
+		"no errors are not a context canceled error": {
+			sourceErrors: nil,
+			target:       context.Canceled,
+			is:           false,
+		},
+		"no errors are a nil error": {
+			sourceErrors: nil,
+			target:       nil,
+			is:           true,
+		},
+		"nested multi-error contains anError": {
+			sourceErrors: []error{
+				anError,
+				NewMulti(
+					customErr,
+					fmt.Errorf("wrapped %w", context.Canceled),
+				).Err(),
+			},
+			target: anError,
+			is:     true,
+		},
+		"nested multi-error contains custom error": {
+			sourceErrors: []error{
+				anError,
+				NewMulti(
+					customErr,
+					fmt.Errorf("wrapped %w", context.Canceled),
+				).Err(),
+			},
+			target: customErr,
+			is:     true,
+		},
+		"nested multi-error contains wrapped context.Canceled": {
+			sourceErrors: []error{
+				anError,
+				NewMulti(
+					customErr,
+					fmt.Errorf("wrapped %w", context.Canceled),
+				).Err(),
+			},
+			target: context.Canceled,
+			is:     true,
+		},
+		"nested multi-error does not contain context.DeadlineExceeded": {
+			sourceErrors: []error{
+				anError,
+				NewMulti(
+					customErr,
+					fmt.Errorf("wrapped %w", context.Canceled),
+				).Err(),
+			},
+			target: context.DeadlineExceeded,
+			is:     false, // make sure we still return false in valid cases
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			mErr := NewMulti(testCase.sourceErrors...)
+			require.Equal(t, testCase.is, errors.Is(mErr.Err(), testCase.target))
+		})
+	}
+}
+
+func TestMultiError_As(t *testing.T) {
+	tE1 := testError{"error cause 1"}
+	tE2 := testError{"error cause 2"}
+	var target testError
+	testCases := map[string]struct {
+		sourceErrors []error
+		target       error
+		as           bool
+	}{
+		"MultiError containing only a testError can be cast to that testError": {
+			sourceErrors: []error{tE1},
+			target:       tE1,
+			as:           true,
+		},
+		"MultiError containing multiple testErrors can be cast to the first testError added": {
+			sourceErrors: []error{tE1, tE2},
+			target:       tE1,
+			as:           true,
+		},
+		"MultiError containing multiple errors can be cast to the first testError added": {
+			sourceErrors: []error{context.Canceled, tE1, context.DeadlineExceeded, tE2},
+			target:       tE1,
+			as:           true,
+		},
+		"MultiError non containing a testError cannot be cast to a testError": {
+			sourceErrors: []error{context.Canceled, context.DeadlineExceeded},
+			as:           false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			mErr := NewMulti(testCase.sourceErrors...).Err()
+			if testCase.as {
+				require.True(t, errors.As(mErr, &target))
+				require.Equal(t, testCase.target, target)
+			} else {
+				require.False(t, errors.As(mErr, &target))
+			}
+		})
+	}
+}
+
+type testError struct {
+	cause string
+}
+
+func (e testError) Error() string {
+	return fmt.Sprintf("testError[cause: %s]", e.cause)
+}

--- a/tsdb/errors/errors_test.go
+++ b/tsdb/errors/errors_test.go
@@ -77,7 +77,7 @@ func TestMultiError_Is(t *testing.T) {
 			target: customErr1,
 			is:     true,
 		},
-		"nested multi-error contains custom error": {
+		"nested multi-error contains customErr2": {
 			sourceErrors: []error{
 				customErr1,
 				NewMulti(
@@ -144,7 +144,7 @@ func TestMultiError_As(t *testing.T) {
 			target:       tE1,
 			as:           true,
 		},
-		"MultiError non containing a testError cannot be cast to a testError": {
+		"MultiError not containing a testError cannot be cast to a testError": {
 			sourceErrors: []error{context.Canceled, context.DeadlineExceeded},
 			as:           false,
 		},

--- a/tsdb/errors/errors_test.go
+++ b/tsdb/errors/errors_test.go
@@ -9,10 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var anError = errors.New("test error")
-
 func TestMultiError_Is(t *testing.T) {
-	customErr := fmt.Errorf("my error")
+	customErr1 := errors.New("test error 1")
+	customErr2 := fmt.Errorf("test error 2")
 
 	testCases := map[string]struct {
 		sourceErrors []error
@@ -54,33 +53,33 @@ func TestMultiError_Is(t *testing.T) {
 			target:       nil,
 			is:           true,
 		},
-		"nested multi-error contains anError": {
+		"nested multi-error contains customErr1": {
 			sourceErrors: []error{
-				anError,
+				customErr1,
 				NewMulti(
-					customErr,
+					customErr2,
 					fmt.Errorf("wrapped %w", context.Canceled),
 				).Err(),
 			},
-			target: anError,
+			target: customErr1,
 			is:     true,
 		},
 		"nested multi-error contains custom error": {
 			sourceErrors: []error{
-				anError,
+				customErr1,
 				NewMulti(
-					customErr,
+					customErr2,
 					fmt.Errorf("wrapped %w", context.Canceled),
 				).Err(),
 			},
-			target: customErr,
+			target: customErr2,
 			is:     true,
 		},
 		"nested multi-error contains wrapped context.Canceled": {
 			sourceErrors: []error{
-				anError,
+				customErr1,
 				NewMulti(
-					customErr,
+					customErr2,
 					fmt.Errorf("wrapped %w", context.Canceled),
 				).Err(),
 			},
@@ -89,9 +88,9 @@ func TestMultiError_Is(t *testing.T) {
 		},
 		"nested multi-error does not contain context.DeadlineExceeded": {
 			sourceErrors: []error{
-				anError,
+				customErr1,
 				NewMulti(
-					customErr,
+					customErr2,
 					fmt.Errorf("wrapped %w", context.Canceled),
 				).Err(),
 			},


### PR DESCRIPTION
the multierror was hiding some errors in Mimir. I also added unit tests because I had them handy from a similar change I and @duricanikolic did in https://github.com/grafana/dskit/pull/522 and https://github.com/grafana/dskit/pull/254 some time ago.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
