### PR TITLE
Upgrade to golangci-lint v2.1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
         with:
           args: --verbose
           # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
-          version: v2.0.2
+          version: v2.1.5
   fuzzing:
     uses: ./.github/workflows/fuzzing.yml
     if: github.event_name == 'pull_request'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -168,8 +168,6 @@ linters:
       disable:
         - float-compare
         - go-require
-        - len # FIXME
-        - useless-assert # FIXME: wait for golangci-lint > v2.0.2
       enable-all: true
 
 output:

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v2.0.2
+GOLANGCI_LINT_VERSION ?= v2.1.5
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/scripts/golangci-lint.yml
+++ b/scripts/golangci-lint.yml
@@ -36,4 +36,4 @@ jobs:
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           args: --verbose
-          version: v2.0.2
+          version: v2.1.5


### PR DESCRIPTION
Upgrade to golangci-lint v2.1.5. Re-enabling the `useless-assert` testifylint rule as it was disabled due to a bug in v2.0.2, and the `len` rule as it was marked with a FIXME, but works fine. No code changes needed.