### PR TITLE
promql: don't emit a value from `histogram_fraction` or `histogram_quantile` if classic and native histograms are present at the same timestamp

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1202,7 +1202,7 @@ func (enh *EvalNodeHelper) resetHistograms(inVec Vector, arg parser.Expr) annota
 		mb.buckets = append(mb.buckets, Bucket{upperBound, sample.F})
 	}
 
-	for _, sample := range enh.nativeHistogramSamples {
+	for idx, sample := range enh.nativeHistogramSamples {
 		// We have to reconstruct the exact same signature as above for
 		// a classic histogram, just ignoring any le label.
 		enh.lblBuf = sample.Metric.Bytes(enh.lblBuf)
@@ -1212,6 +1212,7 @@ func (enh *EvalNodeHelper) resetHistograms(inVec Vector, arg parser.Expr) annota
 			// labels. Do not evaluate anything.
 			annos.Add(annotations.NewMixedClassicNativeHistogramsWarning(sample.Metric.Get(labels.MetricName), arg.PositionRange()))
 			delete(enh.signatureToMetricWithBuckets, string(enh.lblBuf))
+			enh.nativeHistogramSamples[idx].H = nil
 			continue
 		}
 	}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1404,6 +1404,10 @@ func funcHistogramFraction(vals []parser.Value, args parser.Expressions, enh *Ev
 
 	// Deal with the native histograms.
 	for _, sample := range enh.nativeHistogramSamples {
+		if sample.H == nil {
+			// Native histogram conflicts with classic histogram at the same timestamp, ignore.
+			continue
+		}
 		if !enh.enableDelayedNameRemoval {
 			sample.Metric = sample.Metric.DropMetricName()
 		}
@@ -1446,6 +1450,10 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 
 	// Deal with the native histograms.
 	for _, sample := range enh.nativeHistogramSamples {
+		if sample.H == nil {
+			// Native histogram conflicts with classic histogram at the same timestamp, ignore.
+			continue
+		}
 		if !enh.enableDelayedNameRemoval {
 			sample.Metric = sample.Metric.DropMetricName()
 		}

--- a/promql/promqltest/testdata/histograms.test
+++ b/promql/promqltest/testdata/histograms.test
@@ -584,3 +584,25 @@ eval instant at 10m histogram_count(increase(histogram_with_reset[15m]))
 
 eval instant at 10m histogram_sum(increase(histogram_with_reset[15m]))
      {} 91.5
+
+clear
+
+# Test histogram_quantile and histogram_fraction with conflicting classic and native histograms.
+load 1m
+  series{host="a"}            {{schema:0 sum:5 count:4 buckets:[9 2 1]}}
+  series{host="a", le="0.1"}  2
+  series{host="a", le="1"}    3
+  series{host="a", le="10"}   5
+  series{host="a", le="100"}  6
+  series{host="a", le="1000"} 8
+  series{host="a", le="+Inf"} 9
+
+eval instant at 0 histogram_quantile(0.8, series)
+  expect no_info
+  expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+  # Should return no results.
+
+eval instant at 0 histogram_fraction(-Inf, 1, series)
+  expect no_info
+  expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+  # Should return no results.


### PR DESCRIPTION
This PR fixes #16551, which is a regression introduced in #16095.