### PR TITLE
[FIX] Promql-test: Fix error message for new eval syntax when `expect` line does not match with regex

### DIFF
--- a/promql/promqltest/README.md
+++ b/promql/promqltest/README.md
@@ -111,7 +111,7 @@ eval range from <start> to <end> step <step> <query>
 ### `expect` Syntax
 
 ```
-expect <type> <match_type> <string>
+expect <type> <match_type>: <string>
 ```
 
 #### Parameters
@@ -139,8 +139,8 @@ eval instant at 1m sum by (env) (my_metric)
     {env="test"} 20
     
 eval range from 0 to 3m step 1m sum by (env) (my_metric)
-    expect warn msg something went wrong
-    expect info regex something went (wrong|boom)
+    expect warn msg: something went wrong
+    expect info regex: something went (wrong|boom)
     {env="prod"} 2 5 10 20
     {env="test"} 10 20 30 45
 
@@ -148,10 +148,10 @@ eval instant at 1m ceil({__name__=~'testmetric1|testmetric2'})
 expect fail
 
 eval instant at 1m ceil({__name__=~'testmetric1|testmetric2'})
-expect fail msg "vector cannot contain metrics with the same labelset"
+expect fail msg: "vector cannot contain metrics with the same labelset"
 
 eval instant at 1m ceil({__name__=~'testmetric1|testmetric2'})
-expect fail regex "vector cannot contain metrics .*|something else went wrong"
+expect fail regex: "vector cannot contain metrics .*|something else went wrong"
 
 eval instant at 1m sum by (env) (my_metric)
 expect ordered

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -271,7 +271,7 @@ func parseExpect(defLine string) (expectCmdType, expectCmd, error) {
 	expectParts := patExpect.FindStringSubmatch(strings.TrimSpace(defLine))
 	expCmd := expectCmd{}
 	if expectParts == nil {
-		return 0, expCmd, errors.New("invalid expect statement, must match `expect <type> <match_type> <string>` format")
+		return 0, expCmd, errors.New("invalid expect statement, must match `expect <type> <match_type>: <string>` format")
 	}
 	var (
 		mode            = expectParts[1]

--- a/promql/promqltest/test_test.go
+++ b/promql/promqltest/test_test.go
@@ -699,7 +699,7 @@ load 5m
 eval_fail instant at 0m ceil({__name__=~'testmetric1|testmetric2'})
 	expect fail error: something went wrong
 `,
-			expectedError: "error in eval ceil({__name__=~'testmetric1|testmetric2'}) (line 7): invalid expect statement, must match `expect <type> <match_type> <string>` format",
+			expectedError: "error in eval ceil({__name__=~'testmetric1|testmetric2'}) (line 7): invalid expect statement, must match `expect <type> <match_type>: <string>` format",
 		},
 		"instant query expected not to care about annotations (with new eval syntax)": {
 			input: `


### PR DESCRIPTION
This PR fixes error messages and updates the README in `promql-test` when `expect` lines fail to match the regex.
