### PR TITLE
fix(config): respect GOGC environment variable if no "runtime" block exists

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -685,12 +685,11 @@ func TestRuntimeGOGCConfig(t *testing.T) {
 			name:         "empty config file",
 			expectedGOGC: 75,
 		},
-		// the GOGC env var is ignored in this case, see https://github.com/prometheus/prometheus/issues/16334
-		/* 		{
+		{
 			name:         "empty config file with GOGC env var set",
 			gogcEnvVar:   "66",
 			expectedGOGC: 66,
-		}, */
+		},
 		{
 			name: "gogc set through config",
 			config: `
@@ -719,15 +718,14 @@ runtime:`,
 			gogcEnvVar:   "88",
 			expectedGOGC: 88,
 		},
-		// the GOGC env var is ignored in this case, see https://github.com/prometheus/prometheus/issues/16334
-		/* 		{
-					name: "unrelated config and GOGC env var set",
-					config: `
-		global:
-		  scrape_interval: 500ms`,
-					gogcEnvVar:   "80",
-					expectedGOGC: 80,
-				}, */
+		{
+			name: "unrelated config and GOGC env var set",
+			config: `
+global:
+  scrape_interval: 500ms`,
+			gogcEnvVar:   "80",
+			expectedGOGC: 80,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/config/config.go
+++ b/config/config.go
@@ -175,7 +175,7 @@ var (
 
 	DefaultRuntimeConfig = RuntimeConfig{
 		// Go runtime tuning.
-		GoGC: 75,
+		GoGC: getGoGC(),
 	}
 
 	// DefaultScrapeConfig is the default scrape configuration.
@@ -385,8 +385,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// We have to restore it here.
 	if c.Runtime.isZero() {
 		c.Runtime = DefaultRuntimeConfig
-		// Use the GOGC env var value if the runtime section is empty.
-		c.Runtime.GoGC = getGoGCEnv()
 	}
 
 	for _, rf := range c.RuleFiles {
@@ -651,6 +649,8 @@ func (c *GlobalConfig) isZero() bool {
 		!c.ConvertClassicHistogramsToNHCB &&
 		!c.AlwaysScrapeClassicHistograms
 }
+
+const DefaultGoGCPercentage = 75
 
 // RuntimeConfig configures the values for the process behavior.
 type RuntimeConfig struct {
@@ -1494,7 +1494,7 @@ func fileErr(filename string, err error) error {
 	return fmt.Errorf("%q: %w", filePath(filename), err)
 }
 
-func getGoGCEnv() int {
+func getGoGC() int {
 	goGCEnv := os.Getenv("GOGC")
 	// If the GOGC env var is set, use the same logic as upstream Go.
 	if goGCEnv != "" {
@@ -1507,7 +1507,7 @@ func getGoGCEnv() int {
 			return i
 		}
 	}
-	return DefaultRuntimeConfig.GoGC
+	return DefaultGoGCPercentage
 }
 
 type translationStrategyOption string


### PR DESCRIPTION
Fixes: https://github.com/prometheus/prometheus/issues/16334

Related to:
- https://github.com/prometheus/prometheus/pull/15238
- https://github.com/prometheus/prometheus/pull/16052

Currently, when the GOGC environment variable is set -- and no `runtime` block is set in the Prometheus config file -- it is ignored and the default value of 75% is always used.

However, if there is an empty runtime block (e.g. `runtime: {}`), _then_ the GOGC environment variable is checked.

This PR changes this behavior to consistently check and use the GOGC environment variable when it is set (unless the `gogc` field is set in the `runtime` block of the loaded config file, in which case it still gives that precedence).