### PR TITLE
UI: optimize pool searching in /targets page

### DIFF
--- a/web/ui/mantine-ui/src/pages/targets/TargetsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/targets/TargetsPage.tsx
@@ -12,7 +12,7 @@ import {
   IconSearch,
 } from "@tabler/icons-react";
 import { StateMultiSelect } from "../../components/StateMultiSelect";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import badgeClasses from "../../Badge.module.css";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import {
@@ -45,7 +45,11 @@ export default function TargetsPage() {
 
   const dispatch = useAppDispatch();
 
+  const poolDefaultPlaceholder = "Select scrape pool";
+
   const [scrapePool, setScrapePool] = useQueryParam("pool", StringParam);
+  const [poolPlaceholder, setPoolPlaceholder] = useState<string>(poolDefaultPlaceholder);
+  const [poolSelecting, setPoolSelecting] = useState<boolean>(false);
   const [healthFilter, setHealthFilter] = useQueryParam(
     "health",
     withDefault(ArrayParam, [])
@@ -78,14 +82,22 @@ export default function TargetsPage() {
     <>
       <Group mb="md" mt="xs">
         <Select
-          placeholder="Select scrape pool"
+          placeholder={poolPlaceholder}
           data={[{ label: "All pools", value: "" }, ...scrapePools]}
-          value={(limited && scrapePools[0]) || scrapePool || null}
+          value={poolSelecting ? null : (limited && scrapePools[0]) || scrapePool || null}
           onChange={(value) => {
             setScrapePool(value);
             if (showLimitAlert) {
               dispatch(setShowLimitAlert(false));
             }
+          }}
+          onDropdownOpen={() => {
+            setPoolPlaceholder(scrapePool || poolDefaultPlaceholder)
+            setPoolSelecting(true)
+          }}
+          onDropdownClose={() => {
+            setPoolPlaceholder(poolDefaultPlaceholder)
+            setPoolSelecting(false)
           }}
           searchable
         />


### PR DESCRIPTION
When searching in pool selection form, users need to clear all texts before inputing search text, which is not very convenient.

Old way:
![image](https://github.com/user-attachments/assets/4e9572d1-f660-4a25-9359-6d841c033981)

New way:
![image](https://github.com/user-attachments/assets/80327cbe-b85d-4057-b497-521daf3e99d6)

Ant UI component library provides the function natively, https://ant-design.antgroup.com/components/select
![image](https://github.com/user-attachments/assets/c6112600-4c01-4a39-b2fc-464f51e7f1bd)
