### PR TITLE
Optimize memoization and search debouncing on /targets page

### DIFF
--- a/web/ui/mantine-ui/src/pages/targets/TargetsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/targets/TargetsPage.tsx
@@ -30,8 +30,15 @@ import ScrapePoolList from "./ScrapePoolsList";
 import { useSuspenseAPIQuery } from "../../api/api";
 import { ScrapePoolsResult } from "../../api/responseTypes/scrapePools";
 import { expandIconStyle, inputIconStyle } from "../../styles";
+import { useDebouncedValue } from "@mantine/hooks";
 
 export const targetPoolDisplayLimit = 20;
+
+// Should be defined as a constant here instead of inline as a value
+// to avoid unnecessary re-renders. Otherwise the empty array has
+// a different reference on each render and causes subsequent memoized
+// computations to re-run as long as no state filter is selected.
+const emptyHealthFilter: string[] = [];
 
 export default function TargetsPage() {
   // Load the list of all available scrape pools.
@@ -48,12 +55,13 @@ export default function TargetsPage() {
   const [scrapePool, setScrapePool] = useQueryParam("pool", StringParam);
   const [healthFilter, setHealthFilter] = useQueryParam(
     "health",
-    withDefault(ArrayParam, [])
+    withDefault(ArrayParam, emptyHealthFilter)
   );
   const [searchFilter, setSearchFilter] = useQueryParam(
     "search",
     withDefault(StringParam, "")
   );
+  const [debouncedSearch] = useDebouncedValue<string>(searchFilter.trim(), 250);
 
   const { collapsedPools, showLimitAlert } = useAppSelector(
     (state) => state.targetsPage
@@ -147,7 +155,7 @@ export default function TargetsPage() {
             poolNames={scrapePools}
             selectedPool={(limited && scrapePools[0]) || scrapePool || null}
             healthFilter={healthFilter as string[]}
-            searchFilter={searchFilter}
+            searchFilter={debouncedSearch}
           />
         </Suspense>
       </ErrorBoundary>


### PR DESCRIPTION
Moving the debouncing of the search field to the parent component and then memoizing the ScrapePoolsList component prevents a lot of superfluous re-renders of the entire scrape pools list that previously got triggered immediately when you typed in the search box or even just collapsed a pool. (While the computation of what data to show was already memoized in the ScrapePoolList component, the component itself still had to re-render a lot with the same data.)

Discovered this problem + verified fix using react-scan.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
