### PR TITLE
Fix full-page re-rendering when opening status nav menu

### DIFF
--- a/web/ui/mantine-ui/src/App.tsx
+++ b/web/ui/mantine-ui/src/App.tsx
@@ -224,6 +224,7 @@ function App() {
                       leftSection={p.icon}
                       rightSection={<IconChevronDown style={navIconStyle} />}
                       px={navLinkXPadding}
+                      onClick={(e) => e.preventDefault()}
                     >
                       Status <IconChevronRight style={navIconStyle} /> {p.title}
                     </Button>
@@ -236,14 +237,9 @@ function App() {
             element={
               <Menu.Target>
                 <Button
-                  component={NavLink}
-                  to="/"
                   className={classes.link}
                   leftSection={<IconServer style={navIconStyle} />}
                   rightSection={<IconChevronDown style={navIconStyle} />}
-                  onClick={(e) => {
-                    e.preventDefault();
-                  }}
                   px={navLinkXPadding}
                 >
                   Status
@@ -339,8 +335,12 @@ function App() {
                         >
                           <Group gap={10} wrap="nowrap">
                             <img src={PrometheusLogo} height={30} />
-                            <Text hiddenFrom="sm" fz={20}>Prometheus</Text>
-                            <Text visibleFrom="md" fz={20}>Prometheus</Text>
+                            <Text hiddenFrom="sm" fz={20}>
+                              Prometheus
+                            </Text>
+                            <Text visibleFrom="md" fz={20}>
+                              Prometheus
+                            </Text>
                             <Text fz={20}>{agentMode && "Agent"}</Text>
                           </Group>
                         </Link>


### PR DESCRIPTION
When opening the status pages menu while already viewing one of the status pages, the whole page would be re-rendered because the menu target's default action of following the current page's URL was not prevented. Also, we don't need to use a NavLink component for the menu target when we are not viewing a status page, because then the component won't need to be highlighted anyways.

Discovered + fixed with the help of react-scan.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
