### PR TITLE
[PERF] PromQL: Reduce allocations when walking syntax tree

### DIFF
--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -333,10 +333,13 @@ func Walk(v Visitor, node Node, path []Node) error {
 	if v, err = v.Visit(node, path); v == nil || err != nil {
 		return err
 	}
-	path = append(path, node)
+	var pathToHere []Node // Initialized only when needed.
 
 	for e := range ChildrenIter(node) {
-		if err := Walk(v, e, path); err != nil {
+		if pathToHere == nil {
+			pathToHere = append(path, node)
+		}
+		if err := Walk(v, e, pathToHere); err != nil {
 			return err
 		}
 	}
@@ -370,8 +373,10 @@ func (f inspector) Visit(node Node, path []Node) (Visitor, error) {
 // Inspect traverses an AST in depth-first order: It starts by calling
 // f(node, path); node must not be nil. If f returns a nil error, Inspect invokes f
 // for all the non-nil children of node, recursively.
+// Note: path may be overwritten after f returns; copy path if you need to retain it.
 func Inspect(node Node, f inspector) {
-	Walk(f, node, nil) //nolint:errcheck
+	var pathBuf [4]Node        // To reduce allocations during recursion.
+	Walk(f, node, pathBuf[:0]) //nolint:errcheck
 }
 
 // ChildrenIter returns an iterator over all child nodes of a syntax tree node.

--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -335,7 +335,7 @@ func Walk(v Visitor, node Node, path []Node) error {
 	}
 	path = append(path, node)
 
-	for _, e := range Children(node) {
+	for e := range ChildrenIter(node) {
 		if err := Walk(v, e, path); err != nil {
 			return err
 		}
@@ -374,57 +374,65 @@ func Inspect(node Node, f inspector) {
 	Walk(f, node, nil) //nolint:errcheck
 }
 
-// Children returns a list of all child nodes of a syntax tree node.
-func Children(node Node) []Node {
-	// For some reasons these switches have significantly better performance than interfaces
-	switch n := node.(type) {
-	case *EvalStmt:
-		return []Node{n.Expr}
-	case Expressions:
-		// golang cannot convert slices of interfaces
-		ret := make([]Node, len(n))
-		for i, e := range n {
-			ret[i] = e
-		}
-		return ret
-	case *AggregateExpr:
-		// While this does not look nice, it should avoid unnecessary allocations
-		// caused by slice resizing
-		switch {
-		case n.Expr == nil && n.Param == nil:
-			return nil
-		case n.Expr == nil:
-			return []Node{n.Param}
-		case n.Param == nil:
-			return []Node{n.Expr}
+// ChildrenIter returns an iterator over all child nodes of a syntax tree node.
+func ChildrenIter(node Node) func(func(Node) bool) {
+	return func(yield func(Node) bool) {
+		// According to lore, these switches have significantly better performance than interfaces
+		switch n := node.(type) {
+		case *EvalStmt:
+			yield(n.Expr)
+		case Expressions:
+			for _, e := range n {
+				if !yield(e) {
+					return
+				}
+			}
+		case *AggregateExpr:
+			if n.Param != nil {
+				if !yield(n.Param) {
+					return
+				}
+			}
+			if n.Expr != nil {
+				yield(n.Expr)
+			}
+		case *BinaryExpr:
+			if !yield(n.LHS) {
+				return
+			}
+			yield(n.RHS)
+		case *Call:
+			for _, e := range n.Args {
+				if !yield(e) {
+					return
+				}
+			}
+		case *SubqueryExpr:
+			yield(n.Expr)
+		case *ParenExpr:
+			yield(n.Expr)
+		case *UnaryExpr:
+			yield(n.Expr)
+		case *MatrixSelector:
+			yield(n.VectorSelector)
+		case *StepInvariantExpr:
+			yield(n.Expr)
+		case *NumberLiteral, *StringLiteral, *VectorSelector:
+			// nothing to do
 		default:
-			return []Node{n.Expr, n.Param}
+			panic(fmt.Errorf("promql.Children: unhandled node type %T", node))
 		}
-	case *BinaryExpr:
-		return []Node{n.LHS, n.RHS}
-	case *Call:
-		// golang cannot convert slices of interfaces
-		ret := make([]Node, len(n.Args))
-		for i, e := range n.Args {
-			ret[i] = e
-		}
-		return ret
-	case *SubqueryExpr:
-		return []Node{n.Expr}
-	case *ParenExpr:
-		return []Node{n.Expr}
-	case *UnaryExpr:
-		return []Node{n.Expr}
-	case *MatrixSelector:
-		return []Node{n.VectorSelector}
-	case *StepInvariantExpr:
-		return []Node{n.Expr}
-	case *NumberLiteral, *StringLiteral, *VectorSelector:
-		// nothing to do
-		return []Node{}
-	default:
-		panic(fmt.Errorf("promql.Children: unhandled node type %T", node))
 	}
+}
+
+// Children returns a list of all child nodes of a syntax tree node.
+// Implemented for backwards-compatibility; prefer ChildrenIter().
+func Children(node Node) []Node {
+	ret := []Node{}
+	for e := range ChildrenIter(node) {
+		ret = append(ret, e)
+	}
+	return ret
 }
 
 // mergeRanges is a helper function to merge the PositionRanges of two Nodes.

--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -41,7 +41,7 @@ func tree(node Node, level string) string {
 
 	level += " · · ·"
 
-	for _, e := range Children(node) {
+	for e := range ChildrenIter(node) {
 		t += tree(e, level)
 	}
 


### PR DESCRIPTION
This is called a few times from the PromQL Engine.

Currently it allocates at least once on every recursion, and since `append` gives no extra space for 1 or 2 elements, will allocate several times for even modestly complex expressions.

Instead, allocate space for 4 elements to begin, and defer adding another until we need it.

Add a note that `path` may get overwritten; this was true previously.

Also: walk syntax tree using iterator, to avoid allocating a slice for `Children`.

