### PR TITLE
Add parse alerting for rules files before loading WAL

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -642,6 +642,17 @@ func main() {
 		logger.Error(fmt.Sprintf("Error loading dynamic scrape config files from config (--config.file=%q)", cfg.configFile), "file", absPath, "err", err)
 		os.Exit(2)
 	}
+
+	// Parse rule files to verify they exist and contain valid rules.
+	if err := rules.ParseFiles(cfgFile.RuleFiles); err != nil {
+		absPath, pathErr := filepath.Abs(cfg.configFile)
+		if pathErr != nil {
+			absPath = cfg.configFile
+		}
+		logger.Error(fmt.Sprintf("Error loading rule file patterns from config (--config.file=%q)", cfg.configFile), "file", absPath, "err", err)
+		os.Exit(2)
+	}
+
 	if cfg.tsdb.EnableExemplarStorage {
 		if cfgFile.StorageConfig.ExemplarsConfig == nil {
 			cfgFile.StorageConfig.ExemplarsConfig = &config.DefaultExemplarsConfig

--- a/rules/fixtures/invalid_rules.yaml
+++ b/rules/fixtures/invalid_rules.yaml
@@ -1,0 +1,6 @@
+groups:
+  - name: invalid
+    rules:
+      - record: job:http_requests:rate5m
+        expr: sum by (job)(rate(http_requests_total[5m]))
+        unexpected_field: this_field_should_not_be_here

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"os"
 	"path"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strconv"
@@ -2547,6 +2548,17 @@ func TestLabels_FromMaps(t *testing.T) {
 	)
 
 	require.Equal(t, expected, mLabels, "unexpected labelset")
+}
+
+func TestParseFiles(t *testing.T) {
+	t.Run("good files", func(t *testing.T) {
+		err := ParseFiles([]string{filepath.Join("fixtures", "rules.y*ml")})
+		require.NoError(t, err)
+	})
+	t.Run("bad files", func(t *testing.T) {
+		err := ParseFiles([]string{filepath.Join("fixtures", "invalid_rules.y*ml")})
+		require.ErrorContains(t, err, "field unexpected_field not found in type rulefmt.Rule")
+	})
 }
 
 func TestRuleDependencyController_AnalyseRules(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/11486

#### Add functionality (and corresponding test) to parse rules files before loading the WAL.
- Builds on top of the previous PR to fix issues and add an invalid rules file in `rules/fixtures` to test the error case of the parse function.

This eliminates infinite systemd crash-restart loops due to invalid rules files that caused disk exhaustion and multi-day outages as mentioned in the issue.

Refs. https://github.com/prometheus/prometheus/issues/7322, https://github.com/prometheus/prometheus/pull/7399