### PR TITLE
chore: Add golangci-lint fmt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ formatters:
   enable:
     - gci
     - gofumpt
+    - goimports
   settings:
     gci:
       sections:
@@ -10,6 +11,9 @@ formatters:
         - prefix(github.com/prometheus/prometheus)
     gofumpt:
       extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/prometheus/prometheus
 
 issues:
   max-issues-per-linter: 0

--- a/Makefile.common
+++ b/Makefile.common
@@ -62,6 +62,7 @@ SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
 GOLANGCI_LINT_VERSION ?= v2.1.5
+GOLANGCI_FMT_OPTS ?=
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))
@@ -156,9 +157,13 @@ $(GOTEST_DIR):
 	@mkdir -p $@
 
 .PHONY: common-format
-common-format:
+common-format: $(GOLANGCI_LINT)
 	@echo ">> formatting code"
 	$(GO) fmt $(pkgs)
+ifdef GOLANGCI_LINT
+	@echo ">> formatting code with golangci-lint"
+	$(GOLANGCI_LINT) fmt $(GOLANGCI_FMT_OPTS)
+endif
 
 .PHONY: common-vet
 common-vet:

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -39,8 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
-	// Required to get the GCP auth provider working.
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Required to get the GCP auth provider working.
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"


### PR DESCRIPTION
With golangci-lint v2, it now has "formatters" that can be configured. Add `golangci-lint fmt` to the `make format` in Makefile.common.
* Enable goimports formatter.

