### PR TITLE
PROM-39: Provide PromQL info annotations when rate()/increase() over series without `__type__`="counter" label

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -860,6 +860,7 @@ func main() {
 			EnableNegativeOffset:     true,
 			EnablePerStepStats:       cfg.enablePerStepStats,
 			EnableDelayedNameRemoval: cfg.promqlEnableDelayedNameRemoval,
+			EnableTypeAndUnitLabels:  cfg.scrape.EnableTypeAndUnitLabels,
 		}
 
 		queryEngine = promql.NewEngine(opts)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1901,8 +1901,8 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 					if ev.enableTypeAndUnitLabels {
 						// When type-and-unit-labels feature is enabled, check __type__ label
 						typeLabel := inMatrix[0].Metric.Get("__type__")
-						if typeLabel != "counter" {
-							warnings.Add(annotations.NewPossibleNonCounterLabelInfo(metricName, e.Args[0].PositionRange()))
+						if typeLabel != string(model.MetricTypeCounter) {
+							warnings.Add(annotations.NewPossibleNonCounterLabelInfo(metricName, typeLabel, e.Args[0].PositionRange()))
 						}
 					} else if !strings.HasSuffix(metricName, "_total") ||
 						!strings.HasSuffix(metricName, "_sum") ||

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3503,7 +3503,7 @@ func TestRateAnnotations(t *testing.T) {
 			expr:                     "rate(series[1m1s])",
 			typeAndUnitLabelsEnabled: true,
 			expectedInfoAnnotations: []string{
-				`PromQL info: metric might not be a counter, __type__ label is not set to "counter": "series" (1:6)`,
+				`PromQL info: metric might not be a counter, __type__ label is not set to "counter", got "": "series" (1:6)`,
 			},
 			expectedWarningAnnotations: []string{},
 		},
@@ -3514,7 +3514,7 @@ func TestRateAnnotations(t *testing.T) {
 			expr:                     "increase(series[1m1s])",
 			typeAndUnitLabelsEnabled: true,
 			expectedInfoAnnotations: []string{
-				`PromQL info: metric might not be a counter, __type__ label is not set to "counter": "series" (1:10)`,
+				`PromQL info: metric might not be a counter, __type__ label is not set to "counter", got "": "series" (1:10)`,
 			},
 			expectedWarningAnnotations: []string{},
 		},

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3428,6 +3428,7 @@ func TestRateAnnotations(t *testing.T) {
 	testCases := map[string]struct {
 		data                       string
 		expr                       string
+		typeAndUnitLabelsEnabled   bool
 		expectedWarningAnnotations []string
 		expectedInfoAnnotations    []string
 	}{
@@ -3475,13 +3476,85 @@ func TestRateAnnotations(t *testing.T) {
 			expectedWarningAnnotations: []string{},
 			expectedInfoAnnotations:    []string{},
 		},
+		"info annotation when rate() over series without _total suffix": {
+			data: `
+				series{label="a"} 1 2 3
+			`,
+			expr: "rate(series[1m1s])",
+			expectedInfoAnnotations: []string{
+				`PromQL info: metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "series" (1:6)`,
+			},
+			expectedWarningAnnotations: []string{},
+		},
+		"info annotation when increase() over series without _total suffix": {
+			data: `
+				series{label="a"} 1 2 3
+			`,
+			expr: "increase(series[1m1s])",
+			expectedInfoAnnotations: []string{
+				`PromQL info: metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "series" (1:10)`,
+			},
+			expectedWarningAnnotations: []string{},
+		},
+		"info annotation when rate() over series without __type__=counter label": {
+			data: `
+				series{label="a"} 1 2 3
+			`,
+			expr:                     "rate(series[1m1s])",
+			typeAndUnitLabelsEnabled: true,
+			expectedInfoAnnotations: []string{
+				`PromQL info: metric might not be a counter, __type__ label is not set to "counter": "series" (1:6)`,
+			},
+			expectedWarningAnnotations: []string{},
+		},
+		"info annotation when increase() over series without __type__=counter label": {
+			data: `
+				series{label="a"} 1 2 3
+			`,
+			expr:                     "increase(series[1m1s])",
+			typeAndUnitLabelsEnabled: true,
+			expectedInfoAnnotations: []string{
+				`PromQL info: metric might not be a counter, __type__ label is not set to "counter": "series" (1:10)`,
+			},
+			expectedWarningAnnotations: []string{},
+		},
+		"no info annotation when rate() over series with __type__=counter label": {
+			data: `
+				series{label="a", __type__="counter"} 1 2 3
+			`,
+			expr:                       "rate(series[1m1s])",
+			typeAndUnitLabelsEnabled:   true,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
+		"no info annotation when increase() over series with __type__=counter label": {
+			data: `
+				series{label="a", __type__="counter"} 1 2 3
+			`,
+			expr:                       "increase(series[1m1s])",
+			typeAndUnitLabelsEnabled:   true,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			store := promqltest.LoadedStorage(t, "load 1m\n"+strings.TrimSpace(testCase.data))
 			t.Cleanup(func() { _ = store.Close() })
 
-			engine := newTestEngine(t)
+			engine := promqltest.NewTestEngineWithOpts(t, promql.EngineOpts{
+				Logger:                   nil,
+				Reg:                      nil,
+				MaxSamples:               promqltest.DefaultMaxSamplesPerQuery,
+				Timeout:                  100 * time.Minute,
+				NoStepSubqueryIntervalFn: func(int64) int64 { return int64((1 * time.Minute / time.Millisecond / time.Nanosecond)) },
+				EnableAtModifier:         true,
+				EnableNegativeOffset:     true,
+				EnablePerStepStats:       false,
+				LookbackDelta:            0,
+				EnableDelayedNameRemoval: true,
+				EnableTypeAndUnitLabels:  testCase.typeAndUnitLabelsEnabled,
+			})
 			query, err := engine.NewInstantQuery(context.Background(), store, nil, testCase.expr, timestamp.Time(0).Add(1*time.Minute))
 			require.NoError(t, err)
 			t.Cleanup(query.Close)

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -147,7 +147,7 @@ var (
 	IncompatibleBucketLayoutInBinOpWarning     = fmt.Errorf("%w: incompatible bucket layout encountered for binary operator", PromQLWarning)
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
-	PossibleNonCounterLabelInfo             = fmt.Errorf("%w: metric might not be a counter, __type__ label is not set to %q:", PromQLInfo, "counter")
+	PossibleNonCounterLabelInfo             = fmt.Errorf("%w: metric might not be a counter, __type__ label is not set to %q", PromQLInfo, model.MetricTypeCounter)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
 	IncompatibleTypesInBinOpInfo            = fmt.Errorf("%w: incompatible sample types encountered for binary operator", PromQLInfo)
 	HistogramIgnoredInAggregationInfo       = fmt.Errorf("%w: ignored histogram in", PromQLInfo)
@@ -273,10 +273,10 @@ func NewPossibleNonCounterInfo(metricName string, pos posrange.PositionRange) er
 
 // NewPossibleNonCounterLabelInfo is used when a named counter metric with only float samples does not
 // have the __type__ label set to "counter".
-func NewPossibleNonCounterLabelInfo(metricName string, pos posrange.PositionRange) error {
+func NewPossibleNonCounterLabelInfo(metricName, typeLabel string, pos posrange.PositionRange) error {
 	return annoErr{
 		PositionRange: pos,
-		Err:           fmt.Errorf("%w %q", PossibleNonCounterLabelInfo, metricName),
+		Err:           fmt.Errorf("%w, got %q: %q", PossibleNonCounterLabelInfo, typeLabel, metricName),
 	}
 }
 

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -147,6 +147,7 @@ var (
 	IncompatibleBucketLayoutInBinOpWarning     = fmt.Errorf("%w: incompatible bucket layout encountered for binary operator", PromQLWarning)
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
+	PossibleNonCounterLabelInfo             = fmt.Errorf("%w: metric might not be a counter, __type__ label is not set to %q:", PromQLInfo, "counter")
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
 	IncompatibleTypesInBinOpInfo            = fmt.Errorf("%w: incompatible sample types encountered for binary operator", PromQLInfo)
 	HistogramIgnoredInAggregationInfo       = fmt.Errorf("%w: ignored histogram in", PromQLInfo)
@@ -267,6 +268,15 @@ func NewPossibleNonCounterInfo(metricName string, pos posrange.PositionRange) er
 	return annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %q", PossibleNonCounterInfo, metricName),
+	}
+}
+
+// NewPossibleNonCounterLabelInfo is used when a named counter metric with only float samples does not
+// have the __type__ label set to "counter".
+func NewPossibleNonCounterLabelInfo(metricName string, pos posrange.PositionRange) error {
+	return annoErr{
+		PositionRange: pos,
+		Err:           fmt.Errorf("%w %q", PossibleNonCounterLabelInfo, metricName),
 	}
 }
 


### PR DESCRIPTION
Part of #16610

This PR implements PromQL warning when performing rate() and increase() over series without the correct `__type__` label.