### PR TITLE
tsdb: fix issue where a new segment file is created for every chunk if `WithSegmentSize` not called

### DIFF
--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -307,22 +307,27 @@ func WithUncachedIO(enabled bool) WriterOption {
 	}
 }
 
+// WithSegmentSize sets the chunk segment size for the writer.
+// Passing a value less than or equal to 0 causes the default segment size (DefaultChunkSegmentSize) to be used.
 func WithSegmentSize(segmentSize int64) WriterOption {
 	return func(o *writerOptions) {
+		if segmentSize <= 0 {
+			segmentSize = DefaultChunkSegmentSize
+		}
+
 		o.segmentSize = segmentSize
 	}
 }
 
 // NewWriter returns a new writer against the given directory.
+// It uses DefaultChunkSegmentSize as the default segment size.
 func NewWriter(dir string, opts ...WriterOption) (*Writer, error) {
-	options := &writerOptions{}
+	options := &writerOptions{
+		segmentSize: DefaultChunkSegmentSize,
+	}
 
 	for _, opt := range opts {
 		opt(options)
-	}
-
-	if options.segmentSize <= 0 {
-		options.segmentSize = DefaultChunkSegmentSize
 	}
 
 	if err := os.MkdirAll(dir, 0o777); err != nil {

--- a/tsdb/chunks/chunks_test.go
+++ b/tsdb/chunks/chunks_test.go
@@ -56,5 +56,5 @@ func TestWriterWithDefaultSegmentSize(t *testing.T) {
 
 	d, err := os.ReadDir(dir)
 	require.NoError(t, err)
-	require.Len(t, d, 1)
+	require.Len(t, d, 1, "expected only one segment to be created to hold both chunks")
 }


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/prometheus/prometheus/pull/15365.

If `chunks.NewWriter` is called without passing `WithSegmentSize`, then the writer is created with `segmentSize` set to 0, which causes it to emit a new segment file for every single chunk.

This PR fixes the issue by moving the check for an unset segment size back into `NewWriter`.