### PR TITLE
fix(test): fall back to default direct I/O requirements in tests when statx isn't supported 

### DIFF
--- a/tsdb/fileutil/direct_io_writer_test.go
+++ b/tsdb/fileutil/direct_io_writer_test.go
@@ -27,7 +27,7 @@ import (
 func directIORqmtsForTest(tb testing.TB) *directIORqmts {
 	f, err := os.OpenFile(path.Join(tb.TempDir(), "foo"), os.O_CREATE|os.O_WRONLY, 0o666)
 	require.NoError(tb, err)
-	alignmentRqmts, err := fetchDirectIORqmts(f.Fd())
+	alignmentRqmts, err := fileDirectIORqmts(f)
 	require.NoError(tb, err)
 	return alignmentRqmts
 }


### PR DESCRIPTION
by using a higher lever util

fixes https://github.com/prometheus/prometheus/issues/16644

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
