### PR TITLE
Add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
       },
       {
         "description": "Group Mantine UI dependencies",
-        "matchFilenames": [
+        "matchFileNames": [
           "web/ui/mantine-ui/package.json"
         ],
         "groupName": "Mantine UI",
@@ -35,10 +35,19 @@
       },
       {
         "description": "Group React App dependencies",
-        "matchFilenames": [
+        "matchFileNames": [
           "web/ui/react-app/package.json"
         ],
         "groupName": "React App",
+        "matchUpdateTypes": ["minor", "patch"],
+        "enabled": true
+      },
+      {
+        "description": "Group module dependencies",
+        "matchFileNames": [
+          "web/ui/module/**/package.json"
+        ],
+        "groupName": "Modules",
         "matchUpdateTypes": ["minor", "patch"],
         "enabled": true
       }


### PR DESCRIPTION
Add [Renovate](https://www.mend.io/mend-renovate/) configuration, as agreed upon in last dev summit. I'm grouping together web/ui/mantine-ui, web/ui/react-app dependency and web/ui/module updates, respectively. I figure these groupings make sense, but open to discussion of course.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```