### PR TITLE
fix(promql): histogram_count and histogram_sum inconsistent

### DIFF
--- a/promql/histogram_stats_iterator_test.go
+++ b/promql/histogram_stats_iterator_test.go
@@ -156,7 +156,7 @@ func TestHistogramStatsMixedUse(t *testing.T) {
 	expectedHints := []histogram.CounterResetHint{
 		histogram.UnknownCounterReset,
 		histogram.NotCounterReset,
-		histogram.UnknownCounterReset,
+		histogram.CounterReset,
 	}
 	actualHints := make([]histogram.CounterResetHint, 3)
 	typ := statsIterator.Next()

--- a/promql/histogram_stats_iterator_test.go
+++ b/promql/histogram_stats_iterator_test.go
@@ -68,7 +68,7 @@ func TestHistogramStatsDecoding(t *testing.T) {
 				tsdbutil.GenerateTestHistogramWithHint(1, histogram.UnknownCounterReset),
 			},
 			expectedHints: []histogram.CounterResetHint{
-				histogram.NotCounterReset,
+				histogram.UnknownCounterReset,
 			},
 		},
 		{
@@ -78,7 +78,7 @@ func TestHistogramStatsDecoding(t *testing.T) {
 				tsdbutil.GenerateTestHistogramWithHint(1, histogram.UnknownCounterReset),
 			},
 			expectedHints: []histogram.CounterResetHint{
-				histogram.NotCounterReset,
+				histogram.UnknownCounterReset,
 				histogram.CounterReset,
 			},
 		},
@@ -90,7 +90,7 @@ func TestHistogramStatsDecoding(t *testing.T) {
 				tsdbutil.GenerateTestHistogramWithHint(1, histogram.UnknownCounterReset),
 			},
 			expectedHints: []histogram.CounterResetHint{
-				histogram.NotCounterReset,
+				histogram.UnknownCounterReset,
 				histogram.UnknownCounterReset,
 				histogram.CounterReset,
 			},
@@ -139,6 +139,41 @@ func TestHistogramStatsDecoding(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestHistogramStatsMixedUse(t *testing.T) {
+	histograms := []*histogram.Histogram{
+		tsdbutil.GenerateTestHistogramWithHint(2, histogram.UnknownCounterReset),
+		tsdbutil.GenerateTestHistogramWithHint(4, histogram.UnknownCounterReset),
+		tsdbutil.GenerateTestHistogramWithHint(0, histogram.UnknownCounterReset),
+	}
+
+	series := newHistogramSeries(histograms)
+	it := series.Iterator(nil)
+
+	statsIterator := NewHistogramStatsIterator(it)
+
+	expectedHints := []histogram.CounterResetHint{
+		histogram.UnknownCounterReset,
+		histogram.NotCounterReset,
+		histogram.UnknownCounterReset,
+	}
+	actualHints := make([]histogram.CounterResetHint, 3)
+	typ := statsIterator.Next()
+	require.Equal(t, chunkenc.ValHistogram, typ)
+	_, h := statsIterator.AtHistogram(nil)
+	actualHints[0] = h.CounterResetHint
+	typ = statsIterator.Next()
+	require.Equal(t, chunkenc.ValHistogram, typ)
+	_, h = statsIterator.AtHistogram(nil)
+	actualHints[1] = h.CounterResetHint
+	typ = statsIterator.Next()
+	require.Equal(t, chunkenc.ValHistogram, typ)
+	_, fh := statsIterator.AtFloatHistogram(nil)
+	actualHints[2] = fh.CounterResetHint
+
+	require.Equal(t, chunkenc.ValNone, statsIterator.Next())
+	require.Equal(t, expectedHints, actualHints)
 }
 
 type histogramSeries struct {


### PR DESCRIPTION
The problem is in the counter reset detection. The code that loads the
samples is matrixIterSlice which uses the typed Buffer iterator, which
will preload the integer histogram samples, however the last sample is
always(!) loaded as a float histogram sample in matrixIterSlice and the
optimized iterator fails to detect counter resets in that case.

This means that the error happens fairly rarely:
- query needs to have rate/irate/increase
- query needs to have histogram_count, histogram_sum, histogram_avg around the rate
- last sample in the range should trigger reset from previous sample

Also the iterator does not reset lastH, lastFH properly.

In light of this bug, I wonder if we should rewrite the iterator to always return float histograms. Or maybe add a version that does that. On the other hand maybe it's better to rewrite the engine to use `if`  for distinguishing between float samples and other samples and use generics for the "other" samples.

Fixes: https://github.com/prometheus/prometheus/issues/16681
