### PR TITLE
Make translatorMetricFromOtelMetric public

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms_test.go
@@ -771,7 +771,7 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 				Settings{
 					ExportCreatedMetric: true,
 				},
-				namer.Build(translatorMetricFromOtelMetric(metric)),
+				namer.Build(TranslatorMetricFromOtelMetric(metric)),
 				pmetric.AggregationTemporalityCumulative,
 			)
 			require.NoError(t, err)
@@ -1143,7 +1143,7 @@ func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
 					ExportCreatedMetric:     true,
 					ConvertHistogramsToNHCB: true,
 				},
-				namer.Build(translatorMetricFromOtelMetric(metric)),
+				namer.Build(TranslatorMetricFromOtelMetric(metric)),
 				pmetric.AggregationTemporalityCumulative,
 			)
 

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -65,7 +65,7 @@ func NewPrometheusConverter() *PrometheusConverter {
 	}
 }
 
-func translatorMetricFromOtelMetric(metric pmetric.Metric) otlptranslator.Metric {
+func TranslatorMetricFromOtelMetric(metric pmetric.Metric) otlptranslator.Metric {
 	m := otlptranslator.Metric{
 		Name: metric.Name(),
 		Unit: metric.Unit(),
@@ -144,7 +144,7 @@ func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metric
 					continue
 				}
 
-				promName := namer.Build(translatorMetricFromOtelMetric(metric))
+				promName := namer.Build(TranslatorMetricFromOtelMetric(metric))
 				c.metadata = append(c.metadata, prompb.MetricMetadata{
 					Type:             otelMetricTypeToPromMetricType(metric),
 					MetricFamilyName: promName,

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -49,7 +49,7 @@ func TestFromMetrics(t *testing.T) {
 					for k := 0; k < metricSlice.Len(); k++ {
 						metric := metricSlice.At(k)
 						namer := otlptranslator.MetricNamer{}
-						promName := namer.Build(translatorMetricFromOtelMetric(metric))
+						promName := namer.Build(TranslatorMetricFromOtelMetric(metric))
 						expMetadata = append(expMetadata, prompb.MetricMetadata{
 							Type:             otelMetricTypeToPromMetricType(metric),
 							MetricFamilyName: promName,


### PR DESCRIPTION
The changes in otlptranslator API and https://github.com/prometheus/prometheus/pull/16626 made lines like `otlptranslator.BuildCompliantMetricName(metric, "", true)` that use a public function into `namer.Build(translatorMetricFromOtelMetric(metric))` which is a private function, so any code that was using `BuildCompliantMetricName` would need to copy `translatorMetricFromOtelMetric` into its own package, so let's export it instead.

e.g. see PR https://github.com/grafana/mimir/pull/11607 which has a copy, will remove that after the changes here make it into there