### PR TITLE
chore(docs/kubernetes SD): add a note about Endpoints API being deprecated in kubernetes 1.33+

### DIFF
--- a/discovery/kubernetes/endpoints.go
+++ b/discovery/kubernetes/endpoints.go
@@ -49,6 +49,7 @@ type Endpoints struct {
 }
 
 // NewEndpoints returns a new endpoints discovery.
+// Endpoints API is deprecated in k8s v1.33+, but we should still support it.
 func NewEndpoints(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, node cache.SharedInformer, eventCount *prometheus.CounterVec) *Endpoints {
 	if l == nil {
 		l = promslog.NewNopLogger()

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1834,6 +1834,9 @@ The `endpoints` role discovers targets from listed endpoints of a service. For e
 address one target is discovered per port. If the endpoint is backed by a pod, all
 additional container ports of the pod, not bound to an endpoint port, are discovered as targets as well.
 
+Note that the Endpoints API is [deprecated in Kubernetes v1.33+](https://kubernetes.io/blog/2025/04/24/endpoints-deprecation/),
+it is recommended to use EndpointSlices instead and switch to the `endpointslice` role below.
+
 Available meta labels:
 
 * `__meta_kubernetes_namespace`: The namespace of the endpoints object.


### PR DESCRIPTION
chore(discovery/kubernetes): add Endpoints API deprecation comment

Prometheus/the client will log warnings like

```
time=2025-06-03T18:40:18.666Z level=INFO source=warnings.go:70 msg="v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice" component=k8s_client_runtime
```

when used against 1.33+ with endpoints role.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
