### PR TITLE
refactor: make OTEL temporality check easier to read

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -138,6 +138,7 @@ func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metric
 					// Cumulative temporality is always valid.
 					// Delta temporality is also valid if AllowDeltaTemporality is true.
 					// All other temporality values are invalid.
+					//nolint:staticcheck // QF1001 Applying De Morgan’s law would make the conditions harder to read.
 					!(temporality == pmetric.AggregationTemporalityCumulative ||
 						(settings.AllowDeltaTemporality && temporality == pmetric.AggregationTemporalityDelta)) {
 					errs = multierr.Append(errs, fmt.Errorf("invalid temporality and type combination for metric %q", metric.Name()))


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Very small refactor to make the check for otel valid temporalities easier to read. I did write the previous version but looking back, it's a bit confusing to reason out because there's a lot of negation. No behavioural changes.

The linter complains with ` QF1001: could apply De Morgan's law (staticcheck)` when I make the edit but I think that should be ignored in this case.
