### PR TITLE
fix(histogram): treat first sample as CounterReset

### DIFF
--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -260,6 +260,9 @@ func (a *HistogramAppender) Append(int64, float64) {
 //     including the zero bucket.
 //   - The last sample in the chunk was stale while the current sample is not stale.
 //
+// For the first sample in the series, the counter reset hint is always set to `CounterReset`,
+// as per OpenMetrics guidelines.
+//
 // The method returns an additional boolean set to true if it is not appendable
 // because of a counter reset. If the given sample is stale, it is always ok to
 // append. If counterReset is true, okToAppend is always false.
@@ -274,6 +277,14 @@ func (a *HistogramAppender) appendable(h *histogram.Histogram) (
 	okToAppend bool, counterResetHint CounterResetHeader,
 ) {
 	counterResetHint = NotCounterReset
+
+	if a.NumSamples() == 0 {
+	// This is the first sample of the time series.
+	    counterResetHint = CounterReset
+	    okToAppend = true
+	    return
+    }
+
 	if a.NumSamples() > 0 && a.GetCounterResetHeader() == GaugeType {
 		return
 	}


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
 
 Set CounterReset as the counter reset hint for the initial (zero) sample in a new histogram time series. This change aligns with the OpenMetrics spec, which treats the first sample as a synthetic reset point.

Previously, the first sample would default to UnknownCounterReset, which was not technically wrong, but less semantically accurate.

Fixes: #16575
