### PR TITLE
stats: Export QuerySamples StartTimestamp and Interval fields

### DIFF
--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -182,7 +182,7 @@ func (qs *QuerySamples) totalSamplesPerStepPoints() []stepStat {
 
 	ts := make([]stepStat, len(qs.TotalSamplesPerStep))
 	for i, c := range qs.TotalSamplesPerStep {
-		ts[i] = stepStat{T: qs.startTimestamp + int64(i)*qs.interval, V: c}
+		ts[i] = stepStat{T: qs.StartTimestamp + int64(i)*qs.Interval, V: c}
 	}
 	return ts
 }
@@ -246,8 +246,8 @@ type QuerySamples struct {
 	TotalSamplesPerStep []int64
 
 	EnablePerStepStats bool
-	startTimestamp     int64
-	interval           int64
+	StartTimestamp     int64
+	Interval           int64
 }
 
 type Stats struct {
@@ -262,8 +262,8 @@ func (qs *QuerySamples) InitStepTracking(start, end, interval int64) {
 
 	numSteps := int((end-start)/interval) + 1
 	qs.TotalSamplesPerStep = make([]int64, numSteps)
-	qs.startTimestamp = start
-	qs.interval = interval
+	qs.StartTimestamp = start
+	qs.Interval = interval
 }
 
 // IncrementSamplesAtStep increments the total samples count. Use this if you know the step index.
@@ -287,7 +287,7 @@ func (qs *QuerySamples) IncrementSamplesAtTimestamp(t, samples int64) {
 	qs.TotalSamples += samples
 
 	if qs.TotalSamplesPerStep != nil {
-		i := int((t - qs.startTimestamp) / qs.interval)
+		i := int((t - qs.StartTimestamp) / qs.Interval)
 		qs.TotalSamplesPerStep[i] += samples
 	}
 }


### PR DESCRIPTION
Some implementations of the Query interface may use a custom struct to track query stats instead of [Statistics](https://github.com/prometheus/prometheus/blob/41594cebb4731a795dec5b2322800d6a25a5119d/util/stats/query_stats.go#L219). However, they are still required to implement the Query.Stats() method , which must return a Statistics.

The Statistics struct uses [QuerySamples](https://github.com/prometheus/prometheus/blob/41594cebb4731a795dec5b2322800d6a25a5119d/util/stats/query_stats.go#L230) to track sample statistics. QuerySamples supports tracking TotalSamplesPerStep, and per-step stats can be rendered via the [statsRenderer](https://github.com/prometheus/prometheus/blob/41594cebb4731a795dec5b2322800d6a25a5119d/web/api/v1/api.go#L129). For per-step stats to be rendered correctly, both StartTimestamp and Interval must be set.

Currently, the only way to set these fields is by calling InitStepTracking(), which unnecessarily allocates an array—even if the custom implementation already handles the counting and only needs to report the results.

So, two ideas behind the change:
1. Enable setting StartTimestamp and Interval when converting from a custom stats implementation to query_stats.Statistics.
2. Allow reading these fields so that a custom StatsRenderer implementation can render per-step statistics as needed.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
