### PR TITLE
promtool: Report TSDB disk usage by metric name

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -937,12 +937,21 @@ func displayDiskUsage(data map[string]uint64, total uint64) {
 	})
 
 	fmt.Printf("Top %d metric names by disk usage:\n", n)
+
+	var sum uint64
 	for i := range sorted[:n] {
+		sum += sorted[i].v
 		var percent float64
 		if total > 0 {
 			percent = float64(sorted[i].v) / float64(total) * 100
 		}
 		fmt.Printf("%12d bytes (%6.2f%%) %s\n", sorted[i].v, percent, sorted[i].k)
 	}
+
+	var topPercent float64
+	if total > 0 {
+		topPercent = float64(sum) / float64(total) * 100
+	}
+	fmt.Printf("  total (top %8d): %12d bytes (%.2f%%)\n", n, sum, topPercent)
 	fmt.Printf("  total (all %8d): %12d bytes\n", len(data), total)
 }

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -17,8 +17,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"log/slog"
 	"os"
@@ -636,6 +638,8 @@ func analyzeCompaction(ctx context.Context, block tsdb.BlockReader, indexr tsdb.
 	histogramChunkSamplesCount := make([]int, 0)
 	histogramChunkSize := make([]int, 0)
 	histogramChunkBucketsCount := make([]int, 0)
+	buf := make([]byte, chunks.MaxChunkLengthFieldSize)
+	diskUsage := map[string]uint64{}
 	var builder labels.ScratchBuilder
 	for postingsr.Next() {
 		var chks []chunks.Meta
@@ -690,6 +694,10 @@ func analyzeCompaction(ctx context.Context, block tsdb.BlockReader, indexr tsdb.
 				histogramChunkBucketsCount = append(histogramChunkBucketsCount, bucketCount)
 			}
 			totalChunks++
+			chunkDataLength := len(chk.Bytes())
+			chunkDataLengthUvarintLength := binary.PutUvarint(buf, uint64(chunkDataLength))
+			chunkSize := uint64(chunkDataLengthUvarintLength) + chunks.ChunkEncodingSize + uint64(chunkDataLength) + crc32.Size
+			diskUsage[builder.Labels().Get("__name__")] += chunkSize
 		}
 	}
 
@@ -704,6 +712,9 @@ func analyzeCompaction(ctx context.Context, block tsdb.BlockReader, indexr tsdb.
 	displayHistogram("bytes per histogram chunk", histogramChunkSize, totalChunks)
 
 	displayHistogram("buckets per histogram chunk", histogramChunkBucketsCount, totalChunks)
+
+	displayDiskUsage(diskUsage)
+
 	return nil
 }
 
@@ -893,4 +904,38 @@ func generateBucket(minVal, maxVal int) (start, end, step int) {
 	end = maxVal - maxVal%step + step
 
 	return
+}
+
+func displayDiskUsage(data map[string]uint64) {
+	type kv struct {
+		k string
+		v uint64
+	}
+
+	n := 20
+	if len(data) < n {
+		n = len(data)
+	}
+
+	sorted := make([]kv, 0, len(data))
+	for k, v := range data {
+		sorted = append(sorted, kv{k, v})
+	}
+
+	// sort descending by value
+	slices.SortFunc(sorted, func(a, b kv) int {
+		switch {
+		case a.v < b.v:
+			return 1
+		case a.v > b.v:
+			return -1
+		default:
+			return 0
+		}
+	})
+
+	fmt.Printf("Top %d metric names by disk usage:\n", n)
+	for i := range sorted[:n] {
+		fmt.Printf("%d %s\n", sorted[i].v, sorted[i].k)
+	}
 }

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -938,7 +938,11 @@ func displayDiskUsage(data map[string]uint64, total uint64) {
 
 	fmt.Printf("Top %d metric names by disk usage:\n", n)
 	for i := range sorted[:n] {
-		fmt.Printf("%d %s\n", sorted[i].v, sorted[i].k)
+		var percent float64
+		if total > 0 {
+			percent = float64(sorted[i].v) / float64(total) * 100
+		}
+		fmt.Printf("%12d bytes (%6.2f%%) %s\n", sorted[i].v, percent, sorted[i].k)
 	}
 	fmt.Printf("  total (all %8d): %12d bytes\n", len(data), total)
 }

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -640,6 +640,7 @@ func analyzeCompaction(ctx context.Context, block tsdb.BlockReader, indexr tsdb.
 	histogramChunkBucketsCount := make([]int, 0)
 	buf := make([]byte, chunks.MaxChunkLengthFieldSize)
 	diskUsage := map[string]uint64{}
+	diskUsageTotal := uint64(0)
 	var builder labels.ScratchBuilder
 	for postingsr.Next() {
 		var chks []chunks.Meta
@@ -698,6 +699,7 @@ func analyzeCompaction(ctx context.Context, block tsdb.BlockReader, indexr tsdb.
 			chunkDataLengthUvarintLength := binary.PutUvarint(buf, uint64(chunkDataLength))
 			chunkSize := uint64(chunkDataLengthUvarintLength) + chunks.ChunkEncodingSize + uint64(chunkDataLength) + crc32.Size
 			diskUsage[builder.Labels().Get("__name__")] += chunkSize
+			diskUsageTotal += chunkSize
 		}
 	}
 
@@ -713,7 +715,7 @@ func analyzeCompaction(ctx context.Context, block tsdb.BlockReader, indexr tsdb.
 
 	displayHistogram("buckets per histogram chunk", histogramChunkBucketsCount, totalChunks)
 
-	displayDiskUsage(diskUsage)
+	displayDiskUsage(diskUsage, diskUsageTotal)
 
 	return nil
 }
@@ -906,7 +908,7 @@ func generateBucket(minVal, maxVal int) (start, end, step int) {
 	return
 }
 
-func displayDiskUsage(data map[string]uint64) {
+func displayDiskUsage(data map[string]uint64, total uint64) {
 	type kv struct {
 		k string
 		v uint64
@@ -938,4 +940,5 @@ func displayDiskUsage(data map[string]uint64) {
 	for i := range sorted[:n] {
 		fmt.Printf("%d %s\n", sorted[i].v, sorted[i].k)
 	}
+	fmt.Printf("  total (all %8d): %12d bytes\n", len(data), total)
 }

--- a/tsdb/docs/format/chunks.md
+++ b/tsdb/docs/format/chunks.md
@@ -35,7 +35,7 @@ in-file offset (lower 4 bytes) and segment sequence number (upper 4 bytes).
 
 Notes:
 
-* `len`: Chunk size in bytes. 1 to 10 bytes long using the [`<uvarint>` encoding](https://go.dev/src/encoding/binary/varint.go).
+* `len`: Chunk size in bytes. 1 to 5 bytes long using the [`<uvarint>` encoding](https://go.dev/src/encoding/binary/varint.go).
 * `encoding`: Currently either `XOR`, `histogram`, or `floathistogram`, see [code for numerical values](https://github.com/prometheus/prometheus/blob/02d0de9987ad99dee5de21853715954fadb3239f/tsdb/chunkenc/chunk.go#L28-L47).
 * `data`: See below for each encoding.
 * `checksum`: Checksum of `encoding` and `data`. It's a [cyclic redundancy check](https://en.wikipedia.org/wiki/Cyclic_redundancy_check) with the Castagnoli polynomial, serialised as an unsigned 32 bits big endian number. Can be referred as a `CRC-32C`.


### PR DESCRIPTION
This PR enhances the `--extended` flag of `promtool tsdb analyze` to provide a detailed breakdown of disk usage by metric name.

## Motivation

In some environments, disk retention has triggered earlier than expected, resulting in the loss of more historical data than intended. Existing analyses from `promtool tsdb analyze` (such as series or label pair counts) are insufficient to diagnose high disk usage. Metric name cardinality can increase due to label churn without a corresponding rise in disk consumption, and series with constant or infrequent values are efficiently compacted. As a result, it is difficult to identify which metrics are responsible for high disk usage.

## Implementation

This change iterates over all chunk files in a TSDB block, calculates the disk usage for each chunk according to the [TSDB chunk format documentation](https://github.com/prometheus/prometheus/blob/main/tsdb/docs/format/chunks.md), and aggregates usage by metric name. The 8-byte header of each chunk file is excluded from the calculation. For readability, only the top 20 metric names by disk usage are displayed, along with the total disk usage and the percentage contribution of each metric.

## Example Output

Below is an example output from a TSDB block backfilled with synthetic data. The block contains 30 series with 29 unique metric names (`test_{i=1..29}`), each populated with randomly generated values. The metric name `test_1` appears in two series (with different label sets), so it is expected to use approximately twice the disk space of the others. The block contains two chunk files. The total disk usage reported here differs from the output of `du` by 8 bytes per chunk file, due to the excluded headers.

```console
> tree data
data
└── 01JWZH0B4N3CKJ94HCAPKGQ7EJ
    ├── chunks
    │   ├── 000001
    │   └── 000002
    ├── index
    ├── meta.json
    └── tombstones

3 directories, 5 files

> promtool tsdb analyze data --extended
Top 20 metric names by disk usage:
    44950286 bytes (  6.67%) test_1
    22476114 bytes (  3.33%) test_11
    22476114 bytes (  3.33%) test_9
    22475488 bytes (  3.33%) test_4
    22475395 bytes (  3.33%) test_6
    22475344 bytes (  3.33%) test_13
    22475329 bytes (  3.33%) test_8
    22475123 bytes (  3.33%) test_29
    22475118 bytes (  3.33%) test_3
    22474934 bytes (  3.33%) test_21
    22474925 bytes (  3.33%) test_24
    22474912 bytes (  3.33%) test_7
    22474870 bytes (  3.33%) test_23
    22474800 bytes (  3.33%) test_5
    22474569 bytes (  3.33%) test_20
    22474555 bytes (  3.33%) test_10
    22474433 bytes (  3.33%) test_12
    22474320 bytes (  3.33%) test_28
    22474262 bytes (  3.33%) test_19
    22474174 bytes (  3.33%) test_15
  total (top       20):    471975065 bytes (70.00%)
  total (all       29):    674233623 bytes

> du -s --bytes data/01JWZH0B4N3CKJ94HCAPKGQ7EJ/chunks
674233639       data/01JWZH0B4N3CKJ94HCAPKGQ7EJ/chunks

> jq -n '674233639-674233623'
16
```

## Impact

This feature helps users quickly identify which metrics are responsible for the majority of TSDB disk usage, making it easier to optimize storage and retention policies.
