### PR TITLE
[Refactor] PromQL: Simplify detectHistogramStatsDecoding

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3864,19 +3864,13 @@ func setOffsetForAtModifier(evalTime int64, expr parser.Expr) {
 // required for correctness.
 func detectHistogramStatsDecoding(expr parser.Expr) {
 	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
-		if n, ok := node.(*parser.BinaryExpr); ok {
-			detectHistogramStatsDecoding(n.LHS)
-			detectHistogramStatsDecoding(n.RHS)
-			return errors.New("stop")
-		}
-
 		n, ok := (node).(*parser.VectorSelector)
 		if !ok {
 			return nil
 		}
 
-		for _, p := range path {
-			call, ok := p.(*parser.Call)
+		for i := len(path) - 1; i > 0; i-- { // Walk backwards up the path.
+			call, ok := path[i].(*parser.Call)
 			if !ok {
 				continue
 			}


### PR DESCRIPTION
Restarting the depth-first walk on each leg of a binary expression is convoluted.
ISTM the correct logic is to walk the path backwards to the first relevant function.
