### PR TITLE
Rule: Introduce a new metric to get the number of consequently missed individual rule evaluations

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -270,6 +270,7 @@ func (m *Manager) Update(interval time.Duration, files []string, externalLabels 
 				m.IterationsMissed.DeleteLabelValues(n)
 				m.IterationsScheduled.DeleteLabelValues(n)
 				m.EvalTotal.DeleteLabelValues(n)
+				m.EvalMissed.DeleteLabelValues(n)
 				m.EvalFailures.DeleteLabelValues(n)
 				m.GroupInterval.DeleteLabelValues(n)
 				m.GroupLastEvalTime.DeleteLabelValues(n)


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
Initial Fix for :- [Stabilize missed ruler evaluations alerts](https://github.com/grafana/mimir/issues/11500)

the new `cortex_prometheus_rule_evaluations_missed_total` metric is incremented by the number of rules defined in that specific group for each missed iteration.
 `rule_evaluations_missed_total = (number of missed iterations for the group) * (number of rules in that group)`

Now for alerting :-

`Percentage_Missed_Rule_Evaluations = (Missed_Rule_Evaluations / (Successful_Rule_Evaluations + Failed_Rule_Evaluations + Missed_Rule_Evaluations)) * 100`