### PR TITLE
k8s discovery: Expose status.PodIPs as ipv4 and ipv6 if dualstack enabled

### DIFF
--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -276,6 +276,8 @@ const (
 	podUID                        = metaLabelPrefix + "pod_uid"
 	podControllerKind             = metaLabelPrefix + "pod_controller_kind"
 	podControllerName             = metaLabelPrefix + "pod_controller_name"
+	podIPv4Label                  = metaLabelPrefix + "pod_ipv4"
+	podIPv6Label                  = metaLabelPrefix + "pod_ipv6"
 )
 
 // GetControllerOf returns a pointer to a copy of the controllerRef if controllee has a controller
@@ -297,6 +299,36 @@ func podLabels(pod *apiv1.Pod, replicaSetInf, jobInf cache.SharedInformer, withD
 		podNodeNameLabel: lv(pod.Spec.NodeName),
 		podHostIPLabel:   lv(pod.Status.HostIP),
 		podUID:           lv(string(pod.UID)),
+	}
+
+	// PodIPs contains all the IP addresses of the eth0 network interface in the Pod container.
+	// The specific number of IP addresses depends on the specific cni plugin response, which means there may be more than two IP addresses.
+	// However, in most cases, there is one IP address (single-stack; IPv4 or IPv6) or two IP addresses (dual-stack; IPv4 and IPv6 co-existing simultaneously).
+	// If there are multiple IP addresses, use the first IPv4 and IPv6 respectively, this way, it can be consistent with the primary IP address (pod.Status.PodIP behavior) and avoid exposing redundant IP information.
+	// Reference1: https://github.com/kubernetes/kubernetes/blob/c8fb7c9174b03ebc9a072913ca12c08ef3ed83c6/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go#L317
+	// Reference2: https://github.com/containerd/containerd/blob/b99b82db7d05dfd257edcdb50bc72769e782d6c2/internal/cri/server/sandbox_run.go#L572
+	var ipv4Exists, ipv6Exists bool
+	for _, podIP := range pod.Status.PodIPs {
+		if podIP.IP == "" {
+			continue
+		}
+		_, ipv4Exists = ls[podIPv4Label]
+		_, ipv6Exists = ls[podIPv6Label]
+		if ipv4Exists && ipv6Exists {
+			break
+		}
+		ip := net.ParseIP(podIP.IP)
+		if ip != nil {
+			if ip.To4() != nil {
+				if !ipv4Exists {
+					ls[podIPv4Label] = lv(podIP.IP)
+				}
+			} else if ip.To16() != nil {
+				if !ipv6Exists {
+					ls[podIPv6Label] = lv(podIP.IP)
+				}
+			}
+		}
 	}
 
 	addObjectMetaLabels(ls, pod.ObjectMeta, RolePod)
@@ -409,8 +441,16 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
 		if len(c.Ports) == 0 {
 			// We don't have a port so we just set the address label to the pod IP.
 			// The user has to add a port manually.
+			addr := pod.Status.PodIP
+			ip := net.ParseIP(addr)
+			if ip != nil && ip.To4() == nil {
+				// If pod.Status.PodIP is a IPv6 address, addr should be "[pod.Status.PodIP]".
+				// Contrary to what net.JoinHostPort does when the port is empty, RFC3986 forbids a ":" delimiter as the last character in such cases, leaving us with the following implementation.
+				// Refer https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.3
+				addr = "[" + ip.String() + "]"
+			}
 			tg.Targets = append(tg.Targets, model.LabelSet{
-				model.AddressLabel:     lv(pod.Status.PodIP),
+				model.AddressLabel:     lv(addr),
 				podContainerNameLabel:  lv(c.Name),
 				podContainerIDLabel:    lv(cID),
 				podContainerImageLabel: lv(c.Image),

--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -1167,3 +1167,593 @@ func TestPodDiscoveryWithCronJobUpdate(t *testing.T) {
 		},
 	}.Run(t)
 }
+
+func TestPodDiscoveryAddWithDualStackIPv4First(t *testing.T) {
+	t.Parallel()
+	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
+
+	ns := "default"
+	key := fmt.Sprintf("pod/%s/testpod", ns)
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testpod",
+					Namespace: "default",
+					UID:       types.UID("abc123"),
+				},
+				Spec: v1.PodSpec{
+					NodeName: "testnode",
+					Containers: []v1.Container{
+						{
+							Name:  "testcontainer",
+							Image: "testcontainer:latest",
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "testport",
+									Protocol:      v1.ProtocolTCP,
+									ContainerPort: int32(9000),
+								},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					PodIP: "100.117.147.144",
+					PodIPs: []v1.PodIP{
+						{IP: "100.117.147.144"},
+						{IP: "2001::3238:634c:2ed4:ed01"},
+					},
+					HostIP: "2.3.4.5",
+					Phase:  "Running",
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "testcontainer",
+							ContainerID: "docker://a1b2c3d4e5f6",
+						},
+					},
+				},
+			}
+			c.CoreV1().Pods(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes: map[string]*targetgroup.Group{
+			key: {
+				Targets: []model.LabelSet{
+					{
+						"__address__":                                   "100.117.147.144:9000",
+						"__meta_kubernetes_pod_container_name":          "testcontainer",
+						"__meta_kubernetes_pod_container_image":         "testcontainer:latest",
+						"__meta_kubernetes_pod_container_port_name":     "testport",
+						"__meta_kubernetes_pod_container_port_number":   "9000",
+						"__meta_kubernetes_pod_container_port_protocol": "TCP",
+						"__meta_kubernetes_pod_container_init":          "false",
+						"__meta_kubernetes_pod_container_id":            "docker://a1b2c3d4e5f6",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_namespace":     lv(ns),
+					"__meta_kubernetes_pod_node_name": "testnode",
+					"__meta_kubernetes_pod_ip":        "100.117.147.144",
+					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
+					"__meta_kubernetes_pod_ready":     "true",
+					"__meta_kubernetes_pod_phase":     "Running",
+					"__meta_kubernetes_pod_uid":       "abc123",
+					"__meta_kubernetes_pod_ipv4":      "100.117.147.144",
+					"__meta_kubernetes_pod_ipv6":      "2001::3238:634c:2ed4:ed01",
+				},
+				Source: key,
+			},
+		},
+	}.Run(t)
+}
+
+func TestPodDiscoveryAddWithDualStackIPv6First(t *testing.T) {
+	t.Parallel()
+	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
+
+	ns := "default"
+	key := fmt.Sprintf("pod/%s/testpod", ns)
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testpod",
+					Namespace: "default",
+					UID:       types.UID("abc123"),
+				},
+				Spec: v1.PodSpec{
+					NodeName: "testnode",
+					Containers: []v1.Container{
+						{
+							Name:  "testcontainer",
+							Image: "testcontainer:latest",
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "testport",
+									Protocol:      v1.ProtocolTCP,
+									ContainerPort: int32(9000),
+								},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					PodIP: "2001::3238:634c:2ed4:ed01",
+					PodIPs: []v1.PodIP{
+						{IP: "2001::3238:634c:2ed4:ed01"},
+						{IP: "100.117.147.144"},
+					},
+					HostIP: "2.3.4.5",
+					Phase:  "Running",
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "testcontainer",
+							ContainerID: "docker://a1b2c3d4e5f6",
+						},
+					},
+				},
+			}
+			c.CoreV1().Pods(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes: map[string]*targetgroup.Group{
+			key: {
+				Targets: []model.LabelSet{
+					{
+						"__address__":                                   "[2001::3238:634c:2ed4:ed01]:9000",
+						"__meta_kubernetes_pod_container_name":          "testcontainer",
+						"__meta_kubernetes_pod_container_image":         "testcontainer:latest",
+						"__meta_kubernetes_pod_container_port_name":     "testport",
+						"__meta_kubernetes_pod_container_port_number":   "9000",
+						"__meta_kubernetes_pod_container_port_protocol": "TCP",
+						"__meta_kubernetes_pod_container_init":          "false",
+						"__meta_kubernetes_pod_container_id":            "docker://a1b2c3d4e5f6",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_namespace":     lv(ns),
+					"__meta_kubernetes_pod_node_name": "testnode",
+					"__meta_kubernetes_pod_ip":        "2001::3238:634c:2ed4:ed01",
+					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
+					"__meta_kubernetes_pod_ready":     "true",
+					"__meta_kubernetes_pod_phase":     "Running",
+					"__meta_kubernetes_pod_uid":       "abc123",
+					"__meta_kubernetes_pod_ipv4":      "100.117.147.144",
+					"__meta_kubernetes_pod_ipv6":      "2001::3238:634c:2ed4:ed01",
+				},
+				Source: key,
+			},
+		},
+	}.Run(t)
+}
+
+func TestPodDiscoveryAddWithSingleStackIPv4(t *testing.T) {
+	t.Parallel()
+	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
+
+	ns := "default"
+	key := fmt.Sprintf("pod/%s/testpod", ns)
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testpod",
+					Namespace: "default",
+					UID:       types.UID("abc123"),
+				},
+				Spec: v1.PodSpec{
+					NodeName: "testnode",
+					Containers: []v1.Container{
+						{
+							Name:  "testcontainer",
+							Image: "testcontainer:latest",
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "testport",
+									Protocol:      v1.ProtocolTCP,
+									ContainerPort: int32(9000),
+								},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					PodIP: "100.117.147.144",
+					PodIPs: []v1.PodIP{
+						{IP: "100.117.147.144"},
+					},
+					HostIP: "2.3.4.5",
+					Phase:  "Running",
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "testcontainer",
+							ContainerID: "docker://a1b2c3d4e5f6",
+						},
+					},
+				},
+			}
+			c.CoreV1().Pods(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes: map[string]*targetgroup.Group{
+			key: {
+				Targets: []model.LabelSet{
+					{
+						"__address__":                                   "100.117.147.144:9000",
+						"__meta_kubernetes_pod_container_name":          "testcontainer",
+						"__meta_kubernetes_pod_container_image":         "testcontainer:latest",
+						"__meta_kubernetes_pod_container_port_name":     "testport",
+						"__meta_kubernetes_pod_container_port_number":   "9000",
+						"__meta_kubernetes_pod_container_port_protocol": "TCP",
+						"__meta_kubernetes_pod_container_init":          "false",
+						"__meta_kubernetes_pod_container_id":            "docker://a1b2c3d4e5f6",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_namespace":     lv(ns),
+					"__meta_kubernetes_pod_node_name": "testnode",
+					"__meta_kubernetes_pod_ip":        "100.117.147.144",
+					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
+					"__meta_kubernetes_pod_ready":     "true",
+					"__meta_kubernetes_pod_phase":     "Running",
+					"__meta_kubernetes_pod_uid":       "abc123",
+					"__meta_kubernetes_pod_ipv4":      "100.117.147.144",
+				},
+				Source: key,
+			},
+		},
+	}.Run(t)
+}
+
+func TestPodDiscoveryAddWithSingleStackIPv6(t *testing.T) {
+	t.Parallel()
+	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
+
+	ns := "default"
+	key := fmt.Sprintf("pod/%s/testpod", ns)
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testpod",
+					Namespace: "default",
+					UID:       types.UID("abc123"),
+				},
+				Spec: v1.PodSpec{
+					NodeName: "testnode",
+					Containers: []v1.Container{
+						{
+							Name:  "testcontainer",
+							Image: "testcontainer:latest",
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "testport",
+									Protocol:      v1.ProtocolTCP,
+									ContainerPort: int32(9000),
+								},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					PodIP: "2001::3238:634c:2ed4:ed01",
+					PodIPs: []v1.PodIP{
+						{IP: "2001::3238:634c:2ed4:ed01"},
+					},
+					HostIP: "2.3.4.5",
+					Phase:  "Running",
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "testcontainer",
+							ContainerID: "docker://a1b2c3d4e5f6",
+						},
+					},
+				},
+			}
+			c.CoreV1().Pods(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes: map[string]*targetgroup.Group{
+			key: {
+				Targets: []model.LabelSet{
+					{
+						"__address__":                                   "[2001::3238:634c:2ed4:ed01]:9000",
+						"__meta_kubernetes_pod_container_name":          "testcontainer",
+						"__meta_kubernetes_pod_container_image":         "testcontainer:latest",
+						"__meta_kubernetes_pod_container_port_name":     "testport",
+						"__meta_kubernetes_pod_container_port_number":   "9000",
+						"__meta_kubernetes_pod_container_port_protocol": "TCP",
+						"__meta_kubernetes_pod_container_init":          "false",
+						"__meta_kubernetes_pod_container_id":            "docker://a1b2c3d4e5f6",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_namespace":     lv(ns),
+					"__meta_kubernetes_pod_node_name": "testnode",
+					"__meta_kubernetes_pod_ip":        "2001::3238:634c:2ed4:ed01",
+					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
+					"__meta_kubernetes_pod_ready":     "true",
+					"__meta_kubernetes_pod_phase":     "Running",
+					"__meta_kubernetes_pod_uid":       "abc123",
+					"__meta_kubernetes_pod_ipv6":      "2001::3238:634c:2ed4:ed01",
+				},
+				Source: key,
+			},
+		},
+	}.Run(t)
+}
+
+func TestPodDiscoveryAddWithSingleStackIPv6WithoutPorts(t *testing.T) {
+	t.Parallel()
+	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
+
+	ns := "default"
+	key := fmt.Sprintf("pod/%s/testpod", ns)
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testpod",
+					Namespace: "default",
+					UID:       types.UID("abc123"),
+				},
+				Spec: v1.PodSpec{
+					NodeName: "testnode",
+					Containers: []v1.Container{
+						{
+							Name:  "testcontainer",
+							Image: "testcontainer:latest",
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					PodIP: "2001::3238:634c:2ed4:ed01",
+					PodIPs: []v1.PodIP{
+						{IP: "2001::3238:634c:2ed4:ed01"},
+					},
+					HostIP: "2.3.4.5",
+					Phase:  "Running",
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "testcontainer",
+							ContainerID: "docker://a1b2c3d4e5f6",
+						},
+					},
+				},
+			}
+			c.CoreV1().Pods(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes: map[string]*targetgroup.Group{
+			key: {
+				Targets: []model.LabelSet{
+					{
+						"__address__":                           "[2001::3238:634c:2ed4:ed01]",
+						"__meta_kubernetes_pod_container_name":  "testcontainer",
+						"__meta_kubernetes_pod_container_image": "testcontainer:latest",
+						"__meta_kubernetes_pod_container_init":  "false",
+						"__meta_kubernetes_pod_container_id":    "docker://a1b2c3d4e5f6",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_namespace":     lv(ns),
+					"__meta_kubernetes_pod_node_name": "testnode",
+					"__meta_kubernetes_pod_ip":        "2001::3238:634c:2ed4:ed01",
+					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
+					"__meta_kubernetes_pod_ready":     "true",
+					"__meta_kubernetes_pod_phase":     "Running",
+					"__meta_kubernetes_pod_uid":       "abc123",
+					"__meta_kubernetes_pod_ipv6":      "2001::3238:634c:2ed4:ed01",
+				},
+				Source: key,
+			},
+		},
+	}.Run(t)
+}
+
+func TestPodDiscoveryAddWithSingleStackIPv4WithoutPorts(t *testing.T) {
+	t.Parallel()
+	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
+
+	ns := "default"
+	key := fmt.Sprintf("pod/%s/testpod", ns)
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testpod",
+					Namespace: "default",
+					UID:       types.UID("abc123"),
+				},
+				Spec: v1.PodSpec{
+					NodeName: "testnode",
+					Containers: []v1.Container{
+						{
+							Name:  "testcontainer",
+							Image: "testcontainer:latest",
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					PodIP: "100.117.147.144",
+					PodIPs: []v1.PodIP{
+						{IP: "100.117.147.144"},
+					},
+					HostIP: "2.3.4.5",
+					Phase:  "Running",
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "testcontainer",
+							ContainerID: "docker://a1b2c3d4e5f6",
+						},
+					},
+				},
+			}
+			c.CoreV1().Pods(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes: map[string]*targetgroup.Group{
+			key: {
+				Targets: []model.LabelSet{
+					{
+						"__address__":                           "100.117.147.144",
+						"__meta_kubernetes_pod_container_name":  "testcontainer",
+						"__meta_kubernetes_pod_container_image": "testcontainer:latest",
+						"__meta_kubernetes_pod_container_init":  "false",
+						"__meta_kubernetes_pod_container_id":    "docker://a1b2c3d4e5f6",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_namespace":     lv(ns),
+					"__meta_kubernetes_pod_node_name": "testnode",
+					"__meta_kubernetes_pod_ip":        "100.117.147.144",
+					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
+					"__meta_kubernetes_pod_ready":     "true",
+					"__meta_kubernetes_pod_phase":     "Running",
+					"__meta_kubernetes_pod_uid":       "abc123",
+					"__meta_kubernetes_pod_ipv4":      "100.117.147.144",
+				},
+				Source: key,
+			},
+		},
+	}.Run(t)
+}
+
+func TestPodDiscoveryAddWithDualStackAndMultiIPs(t *testing.T) {
+	t.Parallel()
+	n, c := makeDiscovery(RolePod, NamespaceDiscovery{})
+
+	ns := "default"
+	key := fmt.Sprintf("pod/%s/testpod", ns)
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testpod",
+					Namespace: "default",
+					UID:       types.UID("abc123"),
+				},
+				Spec: v1.PodSpec{
+					NodeName: "testnode",
+					Containers: []v1.Container{
+						{
+							Name:  "testcontainer",
+							Image: "testcontainer:latest",
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "testport",
+									Protocol:      v1.ProtocolTCP,
+									ContainerPort: int32(9000),
+								},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					PodIP: "100.117.147.144",
+					PodIPs: []v1.PodIP{
+						{IP: "100.117.147.144"},
+						{IP: "110.117.147.144"},
+						{IP: "2001::3238:634c:2ed4:ed01"},
+						{IP: "2002::3238:634c:2ed4:ed01"},
+					},
+					HostIP: "2.3.4.5",
+					Phase:  "Running",
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "testcontainer",
+							ContainerID: "docker://a1b2c3d4e5f6",
+						},
+					},
+				},
+			}
+			c.CoreV1().Pods(obj.Namespace).Create(context.Background(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes: map[string]*targetgroup.Group{
+			key: {
+				Targets: []model.LabelSet{
+					{
+						"__address__":                                   "100.117.147.144:9000",
+						"__meta_kubernetes_pod_container_name":          "testcontainer",
+						"__meta_kubernetes_pod_container_image":         "testcontainer:latest",
+						"__meta_kubernetes_pod_container_port_name":     "testport",
+						"__meta_kubernetes_pod_container_port_number":   "9000",
+						"__meta_kubernetes_pod_container_port_protocol": "TCP",
+						"__meta_kubernetes_pod_container_init":          "false",
+						"__meta_kubernetes_pod_container_id":            "docker://a1b2c3d4e5f6",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_pod_name":      "testpod",
+					"__meta_kubernetes_namespace":     lv(ns),
+					"__meta_kubernetes_pod_node_name": "testnode",
+					"__meta_kubernetes_pod_ip":        "100.117.147.144",
+					"__meta_kubernetes_pod_host_ip":   "2.3.4.5",
+					"__meta_kubernetes_pod_ready":     "true",
+					"__meta_kubernetes_pod_phase":     "Running",
+					"__meta_kubernetes_pod_uid":       "abc123",
+					"__meta_kubernetes_pod_ipv4":      "100.117.147.144",
+					"__meta_kubernetes_pod_ipv6":      "2001::3238:634c:2ed4:ed01",
+				},
+				Source: key,
+			},
+		},
+	}.Run(t)
+}

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2440,7 +2440,7 @@ Available meta labels:
 
 * `__meta_kubernetes_namespace`: The namespace of the pod object.
 * `__meta_kubernetes_pod_name`: The name of the pod object.
-* `__meta_kubernetes_pod_ip`: The pod IP of the pod object.
+* `__meta_kubernetes_pod_ip`: The pod IP of the pod object, corresponds to `pod.Status.PodIP`.
 * `__meta_kubernetes_pod_label_<labelname>`: Each label from the pod object, with any unsupported characters converted to an underscore.
 * `__meta_kubernetes_pod_labelpresent_<labelname>`: `true` for each label from the pod object, with any unsupported characters converted to an underscore.
 * `__meta_kubernetes_pod_annotation_<annotationname>`: Each annotation from the pod object.
@@ -2460,6 +2460,8 @@ Available meta labels:
 * `__meta_kubernetes_pod_uid`: The UID of the pod object.
 * `__meta_kubernetes_pod_controller_kind`: Object kind of the pod controller.
 * `__meta_kubernetes_pod_controller_name`: Name of the pod controller.
+* `__meta_kubernetes_pod_ipv4`: The pod IPv4 of the pod object, corresponds to `pod.Status.PodIPs`.
+* `__meta_kubernetes_pod_ipv6`: The pod IPv6 of the pod object, corresponds to `pod.Status.PodIPs`.
 * `__meta_kubernetes_pod_deployment_name`: Name of the deployment the pod belongs to. Requires `attach_metadata: {deployment: true}`.
 * `__meta_kubernetes_pod_cronjob_name`: Name of the cronjob the pod belongs to. Requires `attach_metadata: {cronjob: true}`.
 * `__meta_kubernetes_pod_job_name`: Name of the job the pod belongs to. Requires `attach_metadata: {job: true}`.


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

The goals of this PR are as follows:
1.Expose pod.Status.PodIPs as ipv4 and ipv6 if dualstack  enabled.
2.If pod.Status.PodIP is a IPv6 address and no ports defined, use JoinHostPort returns "[host]:port"

Resolves https://github.com/prometheus/prometheus/issues/14363.

The following points should be noted here::

- pod.Status.PodIP corresponds to the first IP address in the pod.Status.PodIPs list. The order of IPs in pod.Status.PodIPs depends on the CNI plugin's return value. In dual-stack scenarios, the order can be either **[IPv4, IPv6] or [IPv6, IPv4]**.

- For Pod roles, the `__address__` label defaults to pod.Status.PodIP. As described above, this value can be either an IPv4 or IPv6 address.

- For Endpoints([deprecated in Kubernetes v1.33+](https://kubernetes.io/blog/2025/04/24/endpoints-deprecation/)) and EndpointSlice roles, the IP in the `__address__` label is sourced from either the IPv4 or IPv6 address within pod.Status.PodIPs. This determination depends on the ipFamilies definition in the Service and does not necessarily correspond to pod.Status.PodIP. For example:
case1
service:
```
spec:
  clusterIP: fd00::52bd
  clusterIPs:
  - fd00::52bd
  - 10.96.2.229
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv6
  - IPv4
  ipFamilyPolicy: RequireDualStack
```
endpoints:
```
subsets:
- addresses:
  - ip: 2001::3238:634c:2ed4:ed01
    nodeName: test-node
    targetRef:
      kind: Pod
      name: nginx-dual-stack-6d55c967b5-m66zp
      namespace: default
      resourceVersion: "72045054"
      uid: e70fe83f-0bc0-4436-8c85-8b4ad0a791c7
```

case2
service:
```
spec:
  clusterIP: 10.96.2.15
  clusterIPs:
  - 10.96.2.15
  - fd00::189a
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  - IPv6
  ipFamilyPolicy: RequireDualStack
```
endpoints:
```
subsets:
- addresses:
  - ip: 100.117.147.144
    nodeName: test-node
    targetRef:
      kind: Pod
      name: nginx-dual-stack-6d55c967b5-m66zp
      namespace: default
      resourceVersion: "72045054"
      uid: e70fe83f-0bc0-4436-8c85-8b4ad0a791c7
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] Expose status.PodIPs as ipv4 and ipv6 if dualstack enabled
```