### PR TITLE
promql: Deactivate three failing tests for the time being

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -682,7 +682,7 @@ func funcAvgOverTime(vals []parser.Value, args parser.Expressions, enh *EvalNode
 	// https://stackoverflow.com/questions/61665473/is-it-beneficial-for-precision-to-calculate-the-incremental-mean-average
 	// Additional note: For even better numerical accuracy, we would need to
 	// process the values in a particular order. For avg_over_time, that
-	// would be more or less feasible, but it would be more expensivo, and
+	// would be more or less feasible, but it would be more expensive, and
 	// it would also be much harder for the avg aggregator, given how the
 	// PromQL engine works.
 	if len(firstSeries.Floats) == 0 {

--- a/promql/promqltest/testdata/aggregators.test
+++ b/promql/promqltest/testdata/aggregators.test
@@ -593,8 +593,10 @@ eval instant at 1m avg(data{test="big"})
 eval instant at 1m avg(data{test="-big"})
 	{} -9.988465674311579e+307
 
-eval instant at 1m avg(data{test="bigzero"})
-	{} 0
+# This test fails on darwin/arm64.
+# Deactivated until issue #16714 is fixed.
+# eval instant at 1m avg(data{test="bigzero"})
+#	{} 0
 
 # If NaN is in the mix, the result is NaN.
 eval instant at 1m avg(data)

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -1086,8 +1086,8 @@ load 5s
 # relevant this scenario is.
 # eval instant at 55s avg_over_time(metric11[1m])
 #   {} -44.848083237000004 <- This is the correct value.
-#   {} -1.881783551706252e+203 <- This is the relust on linux/amd64.
-#   {} 2.303079268822384e+202 <- This is the relust on darwin/arm64.
+#   {} -1.881783551706252e+203 <- This is the result on linux/amd64.
+#   {} 2.303079268822384e+202 <- This is the result on darwin/arm64.
 
 # Test per-series aggregation on dense samples.
 clear

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -1010,8 +1010,10 @@ load 10s
 eval instant at 1m sum_over_time(metric[2m])
   {} 2
 
-eval instant at 1m avg_over_time(metric[2m])
-  {} 0.5
+# This test fails on darwin/arm64.
+# Deactivated until issue #16714 is fixed.
+# eval instant at 1m avg_over_time(metric[2m])
+#  {} 0.5
 
 # More tests for extreme values.
 clear
@@ -1082,9 +1084,10 @@ load 5s
 # needed to do something like sorting the values (which is hard given
 # how the PromQL engine works). The question is how practically
 # relevant this scenario is.
-eval instant at 55s avg_over_time(metric11[1m])
-  {} -1.881783551706252e+203
-# {} -44.848083237000004 <- This is the correct value.
+# eval instant at 55s avg_over_time(metric11[1m])
+#   {} -44.848083237000004 <- This is the correct value.
+#   {} -1.881783551706252e+203 <- This is the relust on linux/amd64.
+#   {} 2.303079268822384e+202 <- This is the relust on darwin/arm64.
 
 # Test per-series aggregation on dense samples.
 clear


### PR DESCRIPTION
These tests fail on darwin/arm64.

One is expected, because the test demonstrates the limits of the numerical accuracy of our methods, and different inaccurate outcomes on different hardware are expected.

The other two are mysterious at the moment, see
https://github.com/prometheus/prometheus/issues/16714 for detailed discussion and debugging.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
