### PR TITLE
engine: fix PossibleNonCounterInfo annotation for rate and increase.

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1904,9 +1904,9 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 						if typeLabel != string(model.MetricTypeCounter) {
 							warnings.Add(annotations.NewPossibleNonCounterLabelInfo(metricName, typeLabel, e.Args[0].PositionRange()))
 						}
-					} else if !strings.HasSuffix(metricName, "_total") ||
-						!strings.HasSuffix(metricName, "_sum") ||
-						!strings.HasSuffix(metricName, "_count") ||
+					} else if !strings.HasSuffix(metricName, "_total") &&
+						!strings.HasSuffix(metricName, "_sum") &&
+						!strings.HasSuffix(metricName, "_count") &&
 						!strings.HasSuffix(metricName, "_bucket") {
 						// Fallback to name suffix checking
 						warnings.Add(annotations.NewPossibleNonCounterInfo(metricName, e.Args[0].PositionRange()))

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3537,6 +3537,87 @@ func TestRateAnnotations(t *testing.T) {
 			expectedWarningAnnotations: []string{},
 			expectedInfoAnnotations:    []string{},
 		},
+		"no info annotation when rate() over rate() over series with _total suffix": {
+			data: `
+				series{label="a", __type__="counter"} 1 2 3
+			`,
+			expr:                       "rate(rate(series[1m1s])[1m1s])",
+			typeAndUnitLabelsEnabled:   false,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
+		"no info annotation when rate() over series with _total suffix": {
+			data: `
+				series_total{label="a"} 1 2 3
+			`,
+			expr:                     "rate(series_total[1m1s])",
+			typeAndUnitLabelsEnabled: false,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
+		"no info annotation when rate() over series with _sum suffix": {
+			data: `
+				series_sum{label="a"} 1 2 3
+			`,
+			expr:                     "rate(series_sum[1m1s])",
+			typeAndUnitLabelsEnabled: false,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
+		"no info annotation when rate() over series with _count suffix": {
+			data: `
+				series_count{label="a"} 1 2 3
+			`,
+			expr:                     "rate(series_count[1m1s])",
+			typeAndUnitLabelsEnabled: false,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
+		"no info annotation when rate() over series with _bucket suffix": {
+			data: `
+				series_bucket{label="a"} 1 2 3
+			`,
+			expr:                     "rate(series_bucket[1m1s])",
+			typeAndUnitLabelsEnabled: false,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
+		"no info annotation when increase() over series with _total suffix": {
+			data: `
+				series_total{label="a"} 1 2 3
+			`,
+			expr:                       "increase(series_total[1m1s])",
+			expectedWarningAnnotations: []string{},
+			typeAndUnitLabelsEnabled:   false,
+			expectedInfoAnnotations: []string{},
+		},
+		"no info annotation when increase() over series with _sum suffix": {
+			data: `
+				series_sum{label="a"} 1 2 3
+			`,
+			expr:                     "increase(series_sum[1m1s])",
+			typeAndUnitLabelsEnabled: false,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
+		"no info annotation when increase() over series with _count suffix": {
+			data: `
+				series_count{label="a"} 1 2 3
+			`,
+			expr:                     "increase(series_count[1m1s])",
+			typeAndUnitLabelsEnabled: false,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
+		"no info annotation when increase() over series with _bucket suffix": {
+			data: `
+				series_bucket{label="a"} 1 2 3
+			`,
+			expr:                     "increase(series_bucket[1m1s])",
+			typeAndUnitLabelsEnabled: false,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3537,15 +3537,6 @@ func TestRateAnnotations(t *testing.T) {
 			expectedWarningAnnotations: []string{},
 			expectedInfoAnnotations:    []string{},
 		},
-		"no info annotation when rate() over rate() over series with _total suffix": {
-			data: `
-				series{label="a", __type__="counter"} 1 2 3
-			`,
-			expr:                       "rate(rate(series[1m1s])[1m1s])",
-			typeAndUnitLabelsEnabled:   false,
-			expectedWarningAnnotations: []string{},
-			expectedInfoAnnotations:    []string{},
-		},
 		"no info annotation when rate() over series with _total suffix": {
 			data: `
 				series_total{label="a"} 1 2 3

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3541,8 +3541,8 @@ func TestRateAnnotations(t *testing.T) {
 			data: `
 				series_total{label="a"} 1 2 3
 			`,
-			expr:                     "rate(series_total[1m1s])",
-			typeAndUnitLabelsEnabled: false,
+			expr:                       "rate(series_total[1m1s])",
+			typeAndUnitLabelsEnabled:   false,
 			expectedWarningAnnotations: []string{},
 			expectedInfoAnnotations:    []string{},
 		},
@@ -3550,8 +3550,8 @@ func TestRateAnnotations(t *testing.T) {
 			data: `
 				series_sum{label="a"} 1 2 3
 			`,
-			expr:                     "rate(series_sum[1m1s])",
-			typeAndUnitLabelsEnabled: false,
+			expr:                       "rate(series_sum[1m1s])",
+			typeAndUnitLabelsEnabled:   false,
 			expectedWarningAnnotations: []string{},
 			expectedInfoAnnotations:    []string{},
 		},
@@ -3559,8 +3559,8 @@ func TestRateAnnotations(t *testing.T) {
 			data: `
 				series_count{label="a"} 1 2 3
 			`,
-			expr:                     "rate(series_count[1m1s])",
-			typeAndUnitLabelsEnabled: false,
+			expr:                       "rate(series_count[1m1s])",
+			typeAndUnitLabelsEnabled:   false,
 			expectedWarningAnnotations: []string{},
 			expectedInfoAnnotations:    []string{},
 		},
@@ -3568,8 +3568,8 @@ func TestRateAnnotations(t *testing.T) {
 			data: `
 				series_bucket{label="a"} 1 2 3
 			`,
-			expr:                     "rate(series_bucket[1m1s])",
-			typeAndUnitLabelsEnabled: false,
+			expr:                       "rate(series_bucket[1m1s])",
+			typeAndUnitLabelsEnabled:   false,
 			expectedWarningAnnotations: []string{},
 			expectedInfoAnnotations:    []string{},
 		},
@@ -3580,14 +3580,14 @@ func TestRateAnnotations(t *testing.T) {
 			expr:                       "increase(series_total[1m1s])",
 			expectedWarningAnnotations: []string{},
 			typeAndUnitLabelsEnabled:   false,
-			expectedInfoAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
 		},
 		"no info annotation when increase() over series with _sum suffix": {
 			data: `
 				series_sum{label="a"} 1 2 3
 			`,
-			expr:                     "increase(series_sum[1m1s])",
-			typeAndUnitLabelsEnabled: false,
+			expr:                       "increase(series_sum[1m1s])",
+			typeAndUnitLabelsEnabled:   false,
 			expectedWarningAnnotations: []string{},
 			expectedInfoAnnotations:    []string{},
 		},
@@ -3595,8 +3595,8 @@ func TestRateAnnotations(t *testing.T) {
 			data: `
 				series_count{label="a"} 1 2 3
 			`,
-			expr:                     "increase(series_count[1m1s])",
-			typeAndUnitLabelsEnabled: false,
+			expr:                       "increase(series_count[1m1s])",
+			typeAndUnitLabelsEnabled:   false,
 			expectedWarningAnnotations: []string{},
 			expectedInfoAnnotations:    []string{},
 		},
@@ -3604,8 +3604,8 @@ func TestRateAnnotations(t *testing.T) {
 			data: `
 				series_bucket{label="a"} 1 2 3
 			`,
-			expr:                     "increase(series_bucket[1m1s])",
-			typeAndUnitLabelsEnabled: false,
+			expr:                       "increase(series_bucket[1m1s])",
+			typeAndUnitLabelsEnabled:   false,
 			expectedWarningAnnotations: []string{},
 			expectedInfoAnnotations:    []string{},
 		},


### PR DESCRIPTION
Bring back the correct suffix check logic.

Fixes bug introduced in https://github.com/prometheus/prometheus/pull/16632. 
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
