### PR TITLE
discovery: add upcloud support

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,7 @@ Maintainers for specific parts of the codebase:
   * `azure`: Jan-Otto Kröpke (<mail@jkroepke.de> / @jkroepke)
   * `k8s`: Frederic Branczyk (<fbranczyk@gmail.com> / @brancz)
   * `stackit`: Jan-Otto Kröpke (<mail@jkroepke.de> / @jkroepke)
+  * `upcloud`: Ville Vesilehto (<ville@vesilehto.fi> / @thevilledev)
 * `documentation`
   * `prometheus-mixin`: Matthias Loibl (<mail@matthiasloibl.com> / @metalmatze)
 * `model/histogram` and other code related to native histograms: Björn Rabenstein (<beorn@grafana.com> / @beorn7),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/stackit"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/discovery/triton"
+	"github.com/prometheus/prometheus/discovery/upcloud"
 	"github.com/prometheus/prometheus/discovery/uyuni"
 	"github.com/prometheus/prometheus/discovery/vultr"
 	"github.com/prometheus/prometheus/discovery/xds"
@@ -1644,6 +1645,43 @@ var expectedConf = &Config{
 				},
 			},
 		},
+		{
+			JobName:                        "upcloud",
+			HonorTimestamps:                true,
+			ScrapeInterval:                 model.Duration(15 * time.Second),
+			ScrapeTimeout:                  DefaultGlobalConfig.ScrapeTimeout,
+			EnableCompression:              true,
+			BodySizeLimit:                  globBodySizeLimit,
+			SampleLimit:                    globSampleLimit,
+			TargetLimit:                    globTargetLimit,
+			LabelLimit:                     globLabelLimit,
+			LabelNameLengthLimit:           globLabelNameLengthLimit,
+			LabelValueLengthLimit:          globLabelValueLengthLimit,
+			ScrapeProtocols:                DefaultGlobalConfig.ScrapeProtocols,
+			ScrapeFailureLogFile:           globScrapeFailureLogFile,
+			MetricNameValidationScheme:     DefaultGlobalConfig.MetricNameValidationScheme,
+			MetricNameEscapingScheme:       DefaultGlobalConfig.MetricNameEscapingScheme,
+			AlwaysScrapeClassicHistograms:  boolPtr(false),
+			ConvertClassicHistogramsToNHCB: boolPtr(false),
+
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
+			ServiceDiscoveryConfigs: discovery.Configs{
+				&upcloud.SDConfig{
+					HTTPClientConfig: config.HTTPClientConfig{
+						Authorization: &config.Authorization{
+							Type:        "Bearer",
+							Credentials: "abcdef",
+						},
+						FollowRedirects: true,
+						EnableHTTP2:     true,
+					},
+					Port:            80,
+					RefreshInterval: model.Duration(60 * time.Second),
+				},
+			},
+		},
 	},
 	AlertingConfig: AlertingConfig{
 		AlertmanagerConfigs: []*AlertmanagerConfig{
@@ -2003,7 +2041,7 @@ func TestElideSecrets(t *testing.T) {
 	yamlConfig := string(config)
 
 	matches := secretRe.FindAllStringIndex(yamlConfig, -1)
-	require.Len(t, matches, 25, "wrong number of secret matches found")
+	require.Len(t, matches, 26, "wrong number of secret matches found")
 	require.NotContains(t, yamlConfig, "mysecret",
 		"yaml marshal reveals authentication credentials.")
 }

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -440,6 +440,11 @@ scrape_configs:
       - authorization:
           credentials: abcdef
 
+  - job_name: upcloud
+    upcloud_sd_configs:
+      - authorization:
+          credentials: abcdef
+
 alerting:
   alertmanagers:
     - scheme: https

--- a/discovery/install/install.go
+++ b/discovery/install/install.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/prometheus/prometheus/discovery/scaleway"     // register scaleway
 	_ "github.com/prometheus/prometheus/discovery/stackit"      // register stackit
 	_ "github.com/prometheus/prometheus/discovery/triton"       // register triton
+	_ "github.com/prometheus/prometheus/discovery/upcloud"      // register upcloud
 	_ "github.com/prometheus/prometheus/discovery/uyuni"        // register uyuni
 	_ "github.com/prometheus/prometheus/discovery/vultr"        // register vultr
 	_ "github.com/prometheus/prometheus/discovery/xds"          // register xds

--- a/discovery/upcloud/metrics.go
+++ b/discovery/upcloud/metrics.go
@@ -1,0 +1,32 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upcloud
+
+import (
+	"github.com/prometheus/prometheus/discovery"
+)
+
+var _ discovery.DiscovererMetrics = (*upcloudMetrics)(nil)
+
+type upcloudMetrics struct {
+	refreshMetrics discovery.RefreshMetricsInstantiator
+}
+
+// Register implements discovery.DiscovererMetrics.
+func (*upcloudMetrics) Register() error {
+	return nil
+}
+
+// Unregister implements discovery.DiscovererMetrics.
+func (*upcloudMetrics) Unregister() {}

--- a/discovery/upcloud/mock_test.go
+++ b/discovery/upcloud/mock_test.go
@@ -1,0 +1,317 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upcloud
+
+import (
+	"context"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
+)
+
+// MockUpCloudClient is a mock implementation of the UpCloudClient interface for testing.
+type MockUpCloudClient struct {
+	servers       *upcloud.Servers
+	serverDetails map[string]*upcloud.ServerDetails
+	err           error
+}
+
+// NewMockUpCloudClient creates a new mock client.
+func NewMockUpCloudClient() *MockUpCloudClient {
+	return &MockUpCloudClient{
+		serverDetails: make(map[string]*upcloud.ServerDetails),
+	}
+}
+
+// SetServers sets the servers that will be returned by GetServers.
+func (m *MockUpCloudClient) SetServers(servers *upcloud.Servers) {
+	m.servers = servers
+}
+
+// SetServerDetails sets the server details for a specific UUID.
+func (m *MockUpCloudClient) SetServerDetails(uuid string, details *upcloud.ServerDetails) {
+	m.serverDetails[uuid] = details
+}
+
+// SetError sets an error that will be returned by GetServers.
+func (m *MockUpCloudClient) SetError(err error) {
+	m.err = err
+}
+
+// GetServers implements the UpCloudClient interface.
+func (m *MockUpCloudClient) GetServers(_ context.Context) (*upcloud.Servers, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.servers, nil
+}
+
+// GetServerDetails implements the UpCloudClient interface.
+func (m *MockUpCloudClient) GetServerDetails(_ context.Context, uuid string) (*upcloud.ServerDetails, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if details, ok := m.serverDetails[uuid]; ok {
+		return details, nil
+	}
+	return nil, nil
+}
+
+// CreateTestServers creates a set of test servers for testing.
+func CreateTestServers() *upcloud.Servers {
+	return &upcloud.Servers{
+		Servers: []upcloud.Server{
+			{
+				UUID:         "00798b85-efdc-41ca-8021-f6ef457b8531",
+				Title:        "web-server-1",
+				Hostname:     "web1.example.com",
+				Zone:         "fi-hel1",
+				Plan:         "1xCPU-1GB",
+				State:        "started",
+				CoreNumber:   1,
+				MemoryAmount: 1024,
+				Tags:         upcloud.ServerTagSlice{"production", "web"},
+			},
+			{
+				UUID:         "01798b85-efdc-41ca-8021-f6ef457b8532",
+				Title:        "db-server-1",
+				Hostname:     "db1.example.com",
+				Zone:         "fi-hel2",
+				Plan:         "2xCPU-4GB",
+				State:        "started",
+				CoreNumber:   2,
+				MemoryAmount: 4096,
+				Tags:         upcloud.ServerTagSlice{"production", "database"},
+			},
+			{
+				UUID:         "02798b85-efdc-41ca-8021-f6ef457b8533",
+				Title:        "test-server-1",
+				Hostname:     "test1.example.com",
+				Zone:         "us-chi1",
+				Plan:         "1xCPU-2GB",
+				State:        "stopped",
+				CoreNumber:   1,
+				MemoryAmount: 2048,
+				Tags:         upcloud.ServerTagSlice{"development"},
+			},
+		},
+	}
+}
+
+// CreateEmptyServers creates an empty server list for testing.
+func CreateEmptyServers() *upcloud.Servers {
+	return &upcloud.Servers{
+		Servers: []upcloud.Server{},
+	}
+}
+
+// CreateSingleTestServer creates a single test server for testing.
+func CreateSingleTestServer() *upcloud.Servers {
+	return &upcloud.Servers{
+		Servers: []upcloud.Server{
+			{
+				UUID:         "test-server",
+				Title:        "test-server",
+				Hostname:     "test.example.com",
+				Zone:         "fi-hel1",
+				Plan:         "1xCPU-1GB",
+				State:        "started",
+				CoreNumber:   1,
+				MemoryAmount: 1024,
+				Tags:         upcloud.ServerTagSlice{"test"},
+			},
+		},
+	}
+}
+
+// CreateServersWithoutIPs creates servers that have no IP addresses.
+func CreateServersWithoutIPs() *upcloud.Servers {
+	return &upcloud.Servers{
+		Servers: []upcloud.Server{
+			{
+				UUID:         "no-ip-server",
+				Title:        "no-ip-server",
+				Hostname:     "noip.example.com",
+				Zone:         "fi-hel1",
+				Plan:         "1xCPU-1GB",
+				State:        "started",
+				CoreNumber:   1,
+				MemoryAmount: 1024,
+				Tags:         upcloud.ServerTagSlice{"test"},
+			},
+		},
+	}
+}
+
+// CreateTestServerDetails creates detailed server information for testing.
+func CreateTestServerDetails() map[string]*upcloud.ServerDetails {
+	return map[string]*upcloud.ServerDetails{
+		"00798b85-efdc-41ca-8021-f6ef457b8531": {
+			Server: upcloud.Server{
+				UUID:         "00798b85-efdc-41ca-8021-f6ef457b8531",
+				Title:        "web-server-1",
+				Hostname:     "web1.example.com",
+				Zone:         "fi-hel1",
+				Plan:         "1xCPU-1GB",
+				State:        "started",
+				CoreNumber:   1,
+				MemoryAmount: 1024,
+				Tags:         upcloud.ServerTagSlice{"production", "web"},
+			},
+			IPAddresses: upcloud.IPAddressSlice{
+				{
+					Access:  upcloud.IPAddressAccessPublic,
+					Address: "192.0.2.1",
+					Family:  upcloud.IPAddressFamilyIPv4,
+				},
+				{
+					Access:  upcloud.IPAddressAccessPrivate,
+					Address: "10.0.0.1",
+					Family:  upcloud.IPAddressFamilyIPv4,
+				},
+				{
+					Access:  upcloud.IPAddressAccessPublic,
+					Address: "2001:db8::1",
+					Family:  upcloud.IPAddressFamilyIPv6,
+				},
+			},
+			Labels: upcloud.LabelSlice{
+				{Key: "environment", Value: "production"},
+				{Key: "team", Value: "platform"},
+			},
+		},
+		"01798b85-efdc-41ca-8021-f6ef457b8532": {
+			Server: upcloud.Server{
+				UUID:         "01798b85-efdc-41ca-8021-f6ef457b8532",
+				Title:        "db-server-1",
+				Hostname:     "db1.example.com",
+				Zone:         "fi-hel2",
+				Plan:         "2xCPU-4GB",
+				State:        "started",
+				CoreNumber:   2,
+				MemoryAmount: 4096,
+				Tags:         upcloud.ServerTagSlice{"production", "database"},
+			},
+			IPAddresses: upcloud.IPAddressSlice{
+				{
+					Access:  upcloud.IPAddressAccessPublic,
+					Address: "192.0.2.2",
+					Family:  upcloud.IPAddressFamilyIPv4,
+				},
+				{
+					Access:  upcloud.IPAddressAccessPrivate,
+					Address: "10.0.0.2",
+					Family:  upcloud.IPAddressFamilyIPv4,
+				},
+			},
+		},
+		"02798b85-efdc-41ca-8021-f6ef457b8533": {
+			Server: upcloud.Server{
+				UUID:         "02798b85-efdc-41ca-8021-f6ef457b8533",
+				Title:        "test-server-1",
+				Hostname:     "test1.example.com",
+				Zone:         "us-chi1",
+				Plan:         "1xCPU-2GB",
+				State:        "stopped",
+				CoreNumber:   1,
+				MemoryAmount: 2048,
+				Tags:         upcloud.ServerTagSlice{"development"},
+			},
+			IPAddresses: upcloud.IPAddressSlice{
+				{
+					Access:  upcloud.IPAddressAccessPrivate,
+					Address: "10.0.0.3",
+					Family:  upcloud.IPAddressFamilyIPv4,
+				},
+			},
+			Labels: upcloud.LabelSlice{
+				{Key: "environment", Value: "development"},
+			},
+		},
+	}
+}
+
+// CreateServerDetailsWithoutIPs creates server details with no IP addresses.
+func CreateServerDetailsWithoutIPs() map[string]*upcloud.ServerDetails {
+	return map[string]*upcloud.ServerDetails{
+		"no-ip-server": {
+			Server: upcloud.Server{
+				UUID:         "no-ip-server",
+				Title:        "no-ip-server",
+				Hostname:     "noip.example.com",
+				Zone:         "fi-hel1",
+				Plan:         "1xCPU-1GB",
+				State:        "started",
+				CoreNumber:   1,
+				MemoryAmount: 1024,
+				Tags:         upcloud.ServerTagSlice{"test"},
+			},
+			IPAddresses: upcloud.IPAddressSlice{},
+			Labels:      upcloud.LabelSlice{},
+		},
+	}
+}
+
+// CreateServerDetailsWithIPv6Only creates server details with only IPv6 addresses.
+func CreateServerDetailsWithIPv6Only() map[string]*upcloud.ServerDetails {
+	return map[string]*upcloud.ServerDetails{
+		"test-server": {
+			Server: upcloud.Server{
+				UUID:         "test-server",
+				Title:        "test-server",
+				Hostname:     "test.example.com",
+				Zone:         "fi-hel1",
+				Plan:         "1xCPU-1GB",
+				State:        "started",
+				CoreNumber:   1,
+				MemoryAmount: 1024,
+				Tags:         upcloud.ServerTagSlice{"test"},
+			},
+			IPAddresses: upcloud.IPAddressSlice{
+				{
+					Access:  upcloud.IPAddressAccessPublic,
+					Address: "2001:db8::1",
+					Family:  upcloud.IPAddressFamilyIPv6,
+				},
+			},
+			Labels: upcloud.LabelSlice{},
+		},
+	}
+}
+
+// CreateServerDetailsWithPrivateOnly creates server details with only private IP addresses.
+func CreateServerDetailsWithPrivateOnly() map[string]*upcloud.ServerDetails {
+	return map[string]*upcloud.ServerDetails{
+		"test-server": {
+			Server: upcloud.Server{
+				UUID:         "test-server",
+				Title:        "test-server",
+				Hostname:     "test.example.com",
+				Zone:         "fi-hel1",
+				Plan:         "1xCPU-1GB",
+				State:        "started",
+				CoreNumber:   1,
+				MemoryAmount: 1024,
+				Tags:         upcloud.ServerTagSlice{"test"},
+			},
+			IPAddresses: upcloud.IPAddressSlice{
+				{
+					Access:  upcloud.IPAddressAccessPrivate,
+					Address: "10.0.0.1",
+					Family:  upcloud.IPAddressFamilyIPv4,
+				},
+			},
+			Labels: upcloud.LabelSlice{},
+		},
+	}
+}

--- a/discovery/upcloud/testdata/server_00798b85-efdc-41ca-8021-f6ef457b8531.json
+++ b/discovery/upcloud/testdata/server_00798b85-efdc-41ca-8021-f6ef457b8531.json
@@ -1,0 +1,62 @@
+{
+  "server": {
+    "uuid": "00798b85-efdc-41ca-8021-f6ef457b8531",
+    "title": "web-server-1",
+    "hostname": "web1.example.com",
+    "zone": "fi-hel1",
+    "plan": "1xCPU-1GB",
+    "state": "started",
+    "core_number": "1",
+    "memory_amount": "1024",
+    "tags": {
+      "tag": ["production", "web"]
+    },
+    "labels": {
+      "label": [
+        {
+          "key": "environment",
+          "value": "production"
+        },
+        {
+          "key": "team",
+          "value": "platform"
+        }
+      ]
+    },
+    "ip_addresses": {
+      "ip_address": [
+        {
+          "access": "public",
+          "address": "192.0.2.1",
+          "family": "IPv4"
+        },
+        {
+          "access": "private",
+          "address": "10.0.0.1",
+          "family": "IPv4"
+        },
+        {
+          "access": "public",
+          "address": "2001:db8::1",
+          "family": "IPv6"
+        }
+      ]
+    },
+    "boot_order": "disk",
+    "firewall": "on",
+    "host": 765331107,
+    "license": 0,
+    "nic_model": "virtio",
+    "plan_ipv4_bytes": "0",
+    "plan_ipv6_bytes": "0",
+    "remote_access_enabled": "yes",
+    "remote_access_type": "vnc",
+    "remote_access_host": "fi-hel1.vnc.upcloud.com",
+    "remote_access_password": "aabbccdd",
+    "remote_access_port": "3000",
+    "server_group": "",
+    "simple_backup": "",
+    "timezone": "UTC",
+    "video_model": "vga"
+  }
+} 

--- a/discovery/upcloud/testdata/server_00898b85-efdc-41ca-8021-f6ef457b8532.json
+++ b/discovery/upcloud/testdata/server_00898b85-efdc-41ca-8021-f6ef457b8532.json
@@ -1,0 +1,66 @@
+{
+  "server": {
+    "uuid": "00898b85-efdc-41ca-8021-f6ef457b8532",
+    "title": "db-server-1",
+    "hostname": "db1.example.com",
+    "zone": "fi-hel2",
+    "plan": "2xCPU-4GB",
+    "state": "started",
+    "core_number": "2",
+    "memory_amount": "4096",
+    "tags": {
+      "tag": ["production", "database"]
+    },
+    "labels": {
+      "label": [
+        {
+          "key": "environment",
+          "value": "production"
+        },
+        {
+          "key": "role",
+          "value": "database"
+        },
+        {
+          "key": "backup",
+          "value": "enabled"
+        }
+      ]
+    },
+    "ip_addresses": {
+      "ip_address": [
+        {
+          "access": "public",
+          "address": "192.0.2.2",
+          "family": "IPv4"
+        },
+        {
+          "access": "private",
+          "address": "10.0.0.2",
+          "family": "IPv4"
+        },
+        {
+          "access": "public",
+          "address": "2001:db8::2",
+          "family": "IPv6"
+        }
+      ]
+    },
+    "boot_order": "disk",
+    "firewall": "on",
+    "host": 765331108,
+    "license": 0,
+    "nic_model": "virtio",
+    "plan_ipv4_bytes": "0",
+    "plan_ipv6_bytes": "0",
+    "remote_access_enabled": "yes",
+    "remote_access_type": "vnc",
+    "remote_access_host": "fi-hel2.vnc.upcloud.com",
+    "remote_access_password": "eeffgghh",
+    "remote_access_port": "3001",
+    "server_group": "",
+    "simple_backup": "dailies",
+    "timezone": "UTC",
+    "video_model": "vga"
+  }
+} 

--- a/discovery/upcloud/testdata/server_00998b85-efdc-41ca-8021-f6ef457b8533.json
+++ b/discovery/upcloud/testdata/server_00998b85-efdc-41ca-8021-f6ef457b8533.json
@@ -1,0 +1,52 @@
+{
+  "server": {
+    "uuid": "00998b85-efdc-41ca-8021-f6ef457b8533",
+    "title": "test-server-1",
+    "hostname": "test1.example.com",
+    "zone": "us-chi1",
+    "plan": "1xCPU-2GB",
+    "state": "stopped",
+    "core_number": "1",
+    "memory_amount": "2048",
+    "tags": {
+      "tag": ["development"]
+    },
+    "labels": {
+      "label": [
+        {
+          "key": "environment",
+          "value": "development"
+        },
+        {
+          "key": "temporary",
+          "value": "true"
+        }
+      ]
+    },
+    "ip_addresses": {
+      "ip_address": [
+        {
+          "access": "private",
+          "address": "10.0.0.3",
+          "family": "IPv4"
+        }
+      ]
+    },
+    "boot_order": "disk",
+    "firewall": "off",
+    "host": 765331109,
+    "license": 0,
+    "nic_model": "virtio",
+    "plan_ipv4_bytes": "0",
+    "plan_ipv6_bytes": "0",
+    "remote_access_enabled": "no",
+    "remote_access_type": "",
+    "remote_access_host": "",
+    "remote_access_password": "",
+    "remote_access_port": "0",
+    "server_group": "",
+    "simple_backup": "",
+    "timezone": "UTC",
+    "video_model": "vga"
+  }
+} 

--- a/discovery/upcloud/testdata/servers.json
+++ b/discovery/upcloud/testdata/servers.json
@@ -1,0 +1,106 @@
+{
+  "servers": {
+    "server": [
+      {
+        "uuid": "00798b85-efdc-41ca-8021-f6ef457b8531",
+        "title": "web-server-1",
+        "hostname": "web1.example.com",
+        "zone": "fi-hel1",
+        "plan": "1xCPU-1GB",
+        "state": "started",
+        "core_number": "1",
+        "memory_amount": "1024",
+        "created": 1740658164,
+        "host": 7617135235,
+        "license": 0,
+        "plan_ipv4_bytes": "285493498",
+        "plan_ipv6_bytes": "0",
+        "server_group": "0b1e2bb3-6698-497a-a40b-f3cb730330d5",
+        "simple_backup": "no",
+        "labels": {
+          "label": [
+            {
+              "key": "environment",
+              "value": "production"
+            },
+            {
+              "key": "team",
+              "value": "platform"
+            }
+          ]
+        },
+        "tags": {
+          "tag": ["production", "web"]
+        }
+      },
+      {
+        "uuid": "00898b85-efdc-41ca-8021-f6ef457b8532",
+        "title": "db-server-1",
+        "hostname": "db1.example.com",
+        "zone": "fi-hel2",
+        "plan": "2xCPU-4GB",
+        "state": "started",
+        "core_number": "2",
+        "memory_amount": "4096",
+        "created": 1740658174,
+        "host": 7617135236,
+        "license": 0,
+        "plan_ipv4_bytes": "313451708",
+        "plan_ipv6_bytes": "0",
+        "server_group": "0b1e2bb3-6698-497a-a40b-f3cb730330d5",
+        "simple_backup": "dailies",
+        "labels": {
+          "label": [
+            {
+              "key": "environment",
+              "value": "production"
+            },
+            {
+              "key": "role",
+              "value": "database"
+            },
+            {
+              "key": "backup",
+              "value": "enabled"
+            }
+          ]
+        },
+        "tags": {
+          "tag": ["production", "database"]
+        }
+      },
+      {
+        "uuid": "00998b85-efdc-41ca-8021-f6ef457b8533",
+        "title": "test-server-1",
+        "hostname": "test1.example.com",
+        "zone": "us-chi1",
+        "plan": "1xCPU-2GB",
+        "state": "stopped",
+        "core_number": "1",
+        "memory_amount": "2048",
+        "created": 1740658177,
+        "host": 7617135237,
+        "license": 0,
+        "plan_ipv4_bytes": "276497407",
+        "plan_ipv6_bytes": "0",
+        "server_group": null,
+        "simple_backup": "no",
+        "labels": {
+          "label": [
+            {
+              "key": "environment",
+              "value": "development"
+            },
+            {
+              "key": "temporary",
+              "value": "true"
+            }
+          ]
+        },
+        "tags": {
+          "tag": ["development"]
+        }
+      }
+    ]
+  }
+} 

--- a/discovery/upcloud/upcloud.go
+++ b/discovery/upcloud/upcloud.go
@@ -1,0 +1,289 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upcloud
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/client"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/service"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/refresh"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+const (
+	upcloudServerLabel             = model.MetaLabelPrefix + "upcloud_server_"
+	upcloudServerLabelUUID         = upcloudServerLabel + "uuid"
+	upcloudServerLabelTitle        = upcloudServerLabel + "title"
+	upcloudServerLabelHostname     = upcloudServerLabel + "hostname"
+	upcloudServerLabelZone         = upcloudServerLabel + "zone"
+	upcloudServerLabelPlan         = upcloudServerLabel + "plan"
+	upcloudServerLabelState        = upcloudServerLabel + "state"
+	upcloudServerLabelCoreNumber   = upcloudServerLabel + "core_number"
+	upcloudServerLabelMemoryAmount = upcloudServerLabel + "memory_amount"
+	upcloudServerLabelTags         = upcloudServerLabel + "tags"
+	upcloudServerLabelTag          = upcloudServerLabel + "tag_"
+	upcloudServerLabelLabel        = upcloudServerLabel + "label_"
+	upcloudServerLabelPublicIPv4   = upcloudServerLabel + "public_ipv4"
+	upcloudServerLabelPrivateIPv4  = upcloudServerLabel + "private_ipv4"
+	upcloudServerLabelPublicIPv6   = upcloudServerLabel + "public_ipv6"
+	upcloudServerLabelPrivateIPv6  = upcloudServerLabel + "private_ipv6"
+	separator                      = ","
+)
+
+// DefaultSDConfig is the default UpCloud SD configuration.
+var DefaultSDConfig = SDConfig{
+	Port:             80,
+	RefreshInterval:  model.Duration(60 * time.Second),
+	HTTPClientConfig: config.DefaultHTTPClientConfig,
+}
+
+func init() {
+	discovery.RegisterConfig(&SDConfig{})
+}
+
+type SDConfig struct {
+	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
+
+	RefreshInterval model.Duration `yaml:"refresh_interval"`
+	Port            int            `yaml:"port"`
+}
+
+// NewDiscovererMetrics implements discovery.Config.
+func (*SDConfig) NewDiscovererMetrics(_ prometheus.Registerer, rmi discovery.RefreshMetricsInstantiator) discovery.DiscovererMetrics {
+	return &upcloudMetrics{
+		refreshMetrics: rmi,
+	}
+}
+
+// Name returns the name of the Config.
+func (*SDConfig) Name() string { return "upcloud" }
+
+// NewDiscoverer returns a Discoverer for the Config.
+func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Discoverer, error) {
+	return NewDiscovery(c, opts.Logger, opts.Metrics)
+}
+
+// SetDirectory joins any relative file paths with dir.
+func (c *SDConfig) SetDirectory(dir string) {
+	c.HTTPClientConfig.SetDirectory(dir)
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *SDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultSDConfig
+	type plain SDConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+
+	return c.HTTPClientConfig.Validate()
+}
+
+// Client is an interface that allows mocking the UpCloud API client for testing.
+type Client interface {
+	GetServers(ctx context.Context) (*upcloud.Servers, error)
+	GetServerDetails(ctx context.Context, uuid string) (*upcloud.ServerDetails, error)
+}
+
+// upcloudClientImpl wraps the actual UpCloud service client.
+type upcloudClientImpl struct {
+	service *service.Service
+}
+
+func (c *upcloudClientImpl) GetServers(ctx context.Context) (*upcloud.Servers, error) {
+	return c.service.GetServers(ctx)
+}
+
+func (c *upcloudClientImpl) GetServerDetails(ctx context.Context, uuid string) (*upcloud.ServerDetails, error) {
+	return c.service.GetServerDetails(ctx, &request.GetServerDetailsRequest{UUID: uuid})
+}
+
+// Discovery periodically performs UpCloud requests. It implements the Discoverer interface.
+type Discovery struct {
+	*refresh.Discovery
+	client Client
+	port   int
+}
+
+// NewDiscovery returns a new Discovery which periodically refreshes its targets.
+func NewDiscovery(conf *SDConfig, logger *slog.Logger, metrics discovery.DiscovererMetrics) (*Discovery, error) {
+	m, ok := metrics.(*upcloudMetrics)
+	if !ok {
+		return nil, errors.New("invalid discovery metrics type")
+	}
+
+	if conf.Port == 0 {
+		conf.Port = DefaultSDConfig.Port
+	}
+
+	d := &Discovery{
+		port: conf.Port,
+	}
+
+	rt, err := config.NewRoundTripperFromConfig(conf.HTTPClientConfig, "upcloud_sd")
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{
+		Transport: rt,
+		Timeout:   time.Duration(conf.RefreshInterval),
+	}
+
+	upcloudClient, err := client.NewFromEnv(
+		client.WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	d.client = &upcloudClientImpl{
+		service: service.New(upcloudClient),
+	}
+
+	d.Discovery = refresh.NewDiscovery(
+		refresh.Options{
+			Logger:              logger,
+			Mech:                "upcloud",
+			Interval:            time.Duration(conf.RefreshInterval),
+			RefreshF:            d.refresh,
+			MetricsInstantiator: m.refreshMetrics,
+		},
+	)
+	return d, nil
+}
+
+func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	tg := &targetgroup.Group{
+		Source: "UpCloud",
+	}
+
+	servers, err := d.client.GetServers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, server := range servers.Servers {
+		serverDetails, err := d.client.GetServerDetails(ctx, server.UUID)
+		if err != nil {
+			return nil, err
+		}
+
+		labels := model.LabelSet{
+			upcloudServerLabelUUID:         model.LabelValue(serverDetails.UUID),
+			upcloudServerLabelTitle:        model.LabelValue(serverDetails.Title),
+			upcloudServerLabelHostname:     model.LabelValue(serverDetails.Hostname),
+			upcloudServerLabelZone:         model.LabelValue(serverDetails.Zone),
+			upcloudServerLabelPlan:         model.LabelValue(serverDetails.Plan),
+			upcloudServerLabelState:        model.LabelValue(serverDetails.State),
+			upcloudServerLabelCoreNumber:   model.LabelValue(strconv.Itoa(serverDetails.CoreNumber)),
+			upcloudServerLabelMemoryAmount: model.LabelValue(strconv.Itoa(serverDetails.MemoryAmount)),
+		}
+
+		// Find the primary public IP address for the target address
+		var primaryIP, primaryIPv4, primaryIPv6 string
+		var publicIPs, privateIPs, publicIPv6s []string
+
+		for _, ipAddress := range serverDetails.IPAddresses {
+			switch ipAddress.Access {
+			case upcloud.IPAddressAccessPublic:
+				switch ipAddress.Family {
+				case upcloud.IPAddressFamilyIPv4:
+					publicIPs = append(publicIPs, ipAddress.Address)
+					if primaryIPv4 == "" {
+						primaryIPv4 = ipAddress.Address
+					}
+				case upcloud.IPAddressFamilyIPv6:
+					if primaryIPv6 == "" {
+						primaryIPv6 = ipAddress.Address
+					}
+					publicIPv6s = append(publicIPv6s, ipAddress.Address)
+				}
+			case upcloud.IPAddressAccessPrivate:
+				// Only IPv4 addresses can be private in UpCloud
+				if ipAddress.Family == upcloud.IPAddressFamilyIPv4 {
+					privateIPs = append(privateIPs, ipAddress.Address)
+				}
+			}
+		}
+
+		// Prefer public IPv4 over public IPv6
+		if primaryIPv4 != "" {
+			primaryIP = primaryIPv4
+		}
+
+		// If no public IPv4 found, use public IPv6
+		if primaryIP == "" && primaryIPv6 != "" {
+			primaryIP = primaryIPv6
+		}
+
+		// If no public IP found, try first available private IP
+		if primaryIP == "" && len(privateIPs) > 0 {
+			primaryIP = privateIPs[0]
+		}
+
+		// Skip servers without any usable IP address
+		if primaryIP == "" {
+			slog.Info("Skipping server without any usable IP address", "server", serverDetails.Title)
+			continue
+		}
+
+		// Set the target address
+		addr := net.JoinHostPort(primaryIP, strconv.Itoa(d.port))
+		labels[model.AddressLabel] = model.LabelValue(addr)
+
+		// Add IP address labels
+		if len(publicIPs) > 0 {
+			labels[upcloudServerLabelPublicIPv4] = model.LabelValue(strings.Join(publicIPs, ","))
+		}
+		if len(privateIPs) > 0 {
+			labels[upcloudServerLabelPrivateIPv4] = model.LabelValue(strings.Join(privateIPs, ","))
+		}
+		if len(publicIPv6s) > 0 {
+			labels[upcloudServerLabelPublicIPv6] = model.LabelValue(strings.Join(publicIPv6s, ","))
+		}
+
+		// Add individual "tag" labels
+		for _, tag := range serverDetails.Tags {
+			name := strutil.SanitizeLabelName(tag)
+			labels[upcloudServerLabelTag+model.LabelName(name)] = model.LabelValue("true")
+		}
+
+		// Add individual "label" labels
+		for _, label := range serverDetails.Labels {
+			name := strutil.SanitizeLabelName(label.Key)
+			labels[upcloudServerLabelLabel+model.LabelName(name)] = model.LabelValue(label.Value)
+		}
+
+		tg.Targets = append(tg.Targets, labels)
+	}
+
+	return []*targetgroup.Group{tg}, nil
+}

--- a/discovery/upcloud/upcloud_fixtures_test.go
+++ b/discovery/upcloud/upcloud_fixtures_test.go
@@ -1,0 +1,196 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upcloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpCloudRefreshWithFixtures(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(mockUpCloudAPI))
+	defer mock.Close()
+
+	cfg := &SDConfig{
+		HTTPClientConfig: config.HTTPClientConfig{
+			BearerToken: "test-token",
+		},
+		RefreshInterval: model.Duration(30 * time.Second),
+		Port:            9100,
+	}
+
+	logger := slog.Default()
+	metrics := &upcloudMetrics{
+		refreshMetrics: &mockRefreshMetricsInstantiator{},
+	}
+
+	// Create discovery with mock server
+	t.Setenv("UPCLOUD_TOKEN", "test-token")
+	d, err := NewDiscovery(cfg, logger, metrics)
+	require.NoError(t, err)
+
+	// Replace the client with one that uses our HTTP fixtures
+	d.client = &httpFixtureClient{
+		baseURL: mock.URL,
+	}
+
+	ctx := context.Background()
+	targetGroups, err := d.refresh(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, targetGroups, 1)
+	targetGroup := targetGroups[0]
+	require.NotNil(t, targetGroup)
+	require.Equal(t, "UpCloud", targetGroup.Source)
+	require.Len(t, targetGroup.Targets, 3)
+
+	// Verify first target (web-server-1)
+	target1 := targetGroup.Targets[0]
+	require.Equal(t, model.LabelValue("192.0.2.1:9100"), target1[model.AddressLabel])
+	require.Equal(t, model.LabelValue("00798b85-efdc-41ca-8021-f6ef457b8531"), target1[upcloudServerLabelUUID])
+	require.Equal(t, model.LabelValue("web-server-1"), target1[upcloudServerLabelTitle])
+	require.Equal(t, model.LabelValue("web1.example.com"), target1[upcloudServerLabelHostname])
+	require.Equal(t, model.LabelValue("fi-hel1"), target1[upcloudServerLabelZone])
+	require.Equal(t, model.LabelValue("1xCPU-1GB"), target1[upcloudServerLabelPlan])
+	require.Equal(t, model.LabelValue("started"), target1[upcloudServerLabelState])
+	require.Equal(t, model.LabelValue("1"), target1[upcloudServerLabelCoreNumber])
+	require.Equal(t, model.LabelValue("1024"), target1[upcloudServerLabelMemoryAmount])
+	require.Equal(t, model.LabelValue("192.0.2.1"), target1[upcloudServerLabelPublicIPv4])
+	require.Equal(t, model.LabelValue("10.0.0.1"), target1[upcloudServerLabelPrivateIPv4])
+	require.Equal(t, model.LabelValue("2001:db8::1"), target1[upcloudServerLabelPublicIPv6])
+	require.Equal(t, model.LabelValue("true"), target1[upcloudServerLabelTag+"production"])
+	require.Equal(t, model.LabelValue("true"), target1[upcloudServerLabelTag+"web"])
+	require.Equal(t, model.LabelValue("production"), target1[upcloudServerLabelLabel+"environment"])
+	require.Equal(t, model.LabelValue("platform"), target1[upcloudServerLabelLabel+"team"])
+
+	// Verify second target (db-server-1)
+	target2 := targetGroup.Targets[1]
+	require.Equal(t, model.LabelValue("192.0.2.2:9100"), target2[model.AddressLabel])
+	require.Equal(t, model.LabelValue("00898b85-efdc-41ca-8021-f6ef457b8532"), target2[upcloudServerLabelUUID])
+	require.Equal(t, model.LabelValue("db-server-1"), target2[upcloudServerLabelTitle])
+	require.Equal(t, model.LabelValue("2"), target2[upcloudServerLabelCoreNumber])
+	require.Equal(t, model.LabelValue("4096"), target2[upcloudServerLabelMemoryAmount])
+	require.Equal(t, model.LabelValue("true"), target2[upcloudServerLabelTag+"production"])
+	require.Equal(t, model.LabelValue("true"), target2[upcloudServerLabelTag+"database"])
+	require.Equal(t, model.LabelValue("production"), target2[upcloudServerLabelLabel+"environment"])
+	require.Equal(t, model.LabelValue("database"), target2[upcloudServerLabelLabel+"role"])
+	require.Equal(t, model.LabelValue("enabled"), target2[upcloudServerLabelLabel+"backup"])
+
+	// Verify third target (test-server-1) - uses private IP since no public IP
+	target3 := targetGroup.Targets[2]
+	require.Equal(t, model.LabelValue("10.0.0.3:9100"), target3[model.AddressLabel])
+	require.Equal(t, model.LabelValue("00998b85-efdc-41ca-8021-f6ef457b8533"), target3[upcloudServerLabelUUID])
+	require.Equal(t, model.LabelValue("test-server-1"), target3[upcloudServerLabelTitle])
+	require.Equal(t, model.LabelValue("stopped"), target3[upcloudServerLabelState])
+	require.Equal(t, model.LabelValue("true"), target3[upcloudServerLabelTag+"development"])
+	require.Equal(t, model.LabelValue("development"), target3[upcloudServerLabelLabel+"environment"])
+	require.Equal(t, model.LabelValue("true"), target3[upcloudServerLabelLabel+"temporary"])
+}
+
+// httpFixtureClient implements the Client interface using HTTP requests to fixture data.
+type httpFixtureClient struct {
+	baseURL string
+}
+
+func (c *httpFixtureClient) GetServers(_ context.Context) (*upcloud.Servers, error) {
+	resp, err := http.Get(c.baseURL + "/1.3/server")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	var servers upcloud.Servers
+	if err := json.NewDecoder(resp.Body).Decode(&servers); err != nil {
+		return nil, err
+	}
+
+	return &servers, nil
+}
+
+func (c *httpFixtureClient) GetServerDetails(_ context.Context, uuid string) (*upcloud.ServerDetails, error) {
+	resp, err := http.Get(c.baseURL + "/1.3/server/" + uuid)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	var serverDetails upcloud.ServerDetails
+	if err := json.NewDecoder(resp.Body).Decode(&serverDetails); err != nil {
+		return nil, err
+	}
+
+	return &serverDetails, nil
+}
+
+// mockUpCloudAPI simulates the UpCloud API responses using test fixtures.
+func mockUpCloudAPI(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	switch r.URL.Path {
+	case "/1.3/server":
+		serversData, err := os.ReadFile("testdata/servers.json")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(serversData)
+
+	case "/1.3/server/00798b85-efdc-41ca-8021-f6ef457b8531":
+		serverData, err := os.ReadFile("testdata/server_00798b85-efdc-41ca-8021-f6ef457b8531.json")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(serverData)
+
+	case "/1.3/server/00898b85-efdc-41ca-8021-f6ef457b8532":
+		serverData, err := os.ReadFile("testdata/server_00898b85-efdc-41ca-8021-f6ef457b8532.json")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(serverData)
+
+	case "/1.3/server/00998b85-efdc-41ca-8021-f6ef457b8533":
+		serverData, err := os.ReadFile("testdata/server_00998b85-efdc-41ca-8021-f6ef457b8533.json")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(serverData)
+
+	default:
+		http.Error(w, "Not found", http.StatusNotFound)
+	}
+}

--- a/discovery/upcloud/upcloud_test.go
+++ b/discovery/upcloud/upcloud_test.go
@@ -1,0 +1,597 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upcloud
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
+
+	"github.com/prometheus/prometheus/discovery"
+)
+
+type invalidMetricsType struct{}
+
+func (*invalidMetricsType) Register() error {
+	return nil
+}
+
+func (*invalidMetricsType) Unregister() {
+}
+
+type mockRefreshMetricsInstantiator struct{}
+
+func (*mockRefreshMetricsInstantiator) Instantiate(_ string) *discovery.RefreshMetrics {
+	return &discovery.RefreshMetrics{}
+}
+
+func TestNewDiscovery(t *testing.T) {
+	logger := slog.Default()
+
+	tests := []struct {
+		name        string
+		config      *SDConfig
+		metrics     discovery.DiscovererMetrics
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid config",
+			config: &SDConfig{
+				Port:             9100,
+				RefreshInterval:  model.Duration(30 * time.Second),
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
+			},
+			metrics: &upcloudMetrics{
+				refreshMetrics: &mockRefreshMetricsInstantiator{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid metrics type",
+			config: &SDConfig{
+				Port:             9100,
+				RefreshInterval:  model.Duration(30 * time.Second),
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
+			},
+			metrics:     &invalidMetricsType{},
+			wantErr:     true,
+			errContains: "invalid discovery metrics type",
+		},
+		{
+			name: "invalid TLS config",
+			config: &SDConfig{
+				Port:            9100,
+				RefreshInterval: model.Duration(30 * time.Second),
+				HTTPClientConfig: config.HTTPClientConfig{
+					TLSConfig: config.TLSConfig{
+						CertFile: "/nonexistent/cert.pem",
+						KeyFile:  "/nonexistent/key.pem",
+					},
+				},
+			},
+			metrics: &upcloudMetrics{
+				refreshMetrics: &mockRefreshMetricsInstantiator{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "default port",
+			config: &SDConfig{
+				RefreshInterval:  model.Duration(60 * time.Second),
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
+			},
+			metrics: &upcloudMetrics{
+				refreshMetrics: &mockRefreshMetricsInstantiator{},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("UPCLOUD_TOKEN", "test-token")
+			discovery, err := NewDiscovery(tt.config, logger, tt.metrics)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, discovery)
+				if tt.errContains != "" {
+					require.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, discovery)
+			require.NotNil(t, discovery.client)
+			require.NotNil(t, discovery.Discovery)
+
+			expectedPort := tt.config.Port
+			if expectedPort == 0 {
+				expectedPort = DefaultSDConfig.Port
+			}
+			require.Equal(t, expectedPort, discovery.port)
+		})
+	}
+}
+
+func TestDiscovery_refresh(t *testing.T) {
+	tests := []struct {
+		name              string
+		setupMock         func(*MockUpCloudClient)
+		expectedTargets   int
+		expectedLabels    map[string]model.LabelValue
+		wantErr           bool
+		errContains       string
+		expectedAddresses []string
+	}{
+		{
+			name: "successful discovery with multiple servers",
+			setupMock: func(mock *MockUpCloudClient) {
+				servers := CreateTestServers()
+				serverDetails := CreateTestServerDetails()
+				mock.SetServers(servers)
+				for uuid, details := range serverDetails {
+					mock.SetServerDetails(uuid, details)
+				}
+			},
+			expectedTargets: 3,
+			expectedLabels: map[string]model.LabelValue{
+				"__meta_upcloud_server_uuid":              "00798b85-efdc-41ca-8021-f6ef457b8531",
+				"__meta_upcloud_server_title":             "web-server-1",
+				"__meta_upcloud_server_hostname":          "web1.example.com",
+				"__meta_upcloud_server_zone":              "fi-hel1",
+				"__meta_upcloud_server_plan":              "1xCPU-1GB",
+				"__meta_upcloud_server_state":             "started",
+				"__meta_upcloud_server_core_number":       "1",
+				"__meta_upcloud_server_memory_amount":     "1024",
+				"__meta_upcloud_server_public_ipv4":       "192.0.2.1",
+				"__meta_upcloud_server_private_ipv4":      "10.0.0.1",
+				"__meta_upcloud_server_public_ipv6":       "2001:db8::1",
+				"__meta_upcloud_server_tag_production":    "true",
+				"__meta_upcloud_server_tag_web":           "true",
+				"__meta_upcloud_server_label_environment": "production",
+				"__meta_upcloud_server_label_team":        "platform",
+			},
+			expectedAddresses: []string{"192.0.2.1:80", "192.0.2.2:80", "10.0.0.3:80"},
+		},
+		{
+			name: "GetServers API error",
+			setupMock: func(mock *MockUpCloudClient) {
+				mock.SetError(errors.New("API error"))
+			},
+			wantErr:     true,
+			errContains: "API error",
+		},
+		{
+			name: "empty server list",
+			setupMock: func(mock *MockUpCloudClient) {
+				mock.SetServers(CreateEmptyServers())
+			},
+			expectedTargets: 0,
+		},
+		{
+			name: "server without IP addresses",
+			setupMock: func(mock *MockUpCloudClient) {
+				servers := CreateServersWithoutIPs()
+				serverDetails := CreateServerDetailsWithoutIPs()
+				mock.SetServers(servers)
+				for uuid, details := range serverDetails {
+					mock.SetServerDetails(uuid, details)
+				}
+			},
+			expectedTargets: 0, // Should skip servers without IPs
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("UPCLOUD_TOKEN", "test-token")
+			mock := NewMockUpCloudClient()
+			tt.setupMock(mock)
+
+			d := &Discovery{
+				client: mock,
+				port:   80,
+			}
+
+			ctx := context.Background()
+			tgs, err := d.refresh(ctx)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, tgs, 1)
+
+			tg := tgs[0]
+			require.Equal(t, "UpCloud", tg.Source)
+			require.Len(t, tg.Targets, tt.expectedTargets)
+
+			if tt.expectedTargets > 0 && tt.expectedLabels != nil {
+				target := tg.Targets[0]
+				for labelName, expectedValue := range tt.expectedLabels {
+					actualValue, exists := target[model.LabelName(labelName)]
+					require.True(t, exists, "Label %s should exist", labelName)
+					require.Equal(t, expectedValue, actualValue, "Label %s mismatch", labelName)
+				}
+			}
+
+			if len(tt.expectedAddresses) > 0 {
+				for i, expectedAddr := range tt.expectedAddresses {
+					require.Equal(t, model.LabelValue(expectedAddr), tg.Targets[i][model.AddressLabel])
+				}
+			}
+		})
+	}
+}
+
+func TestSDConfig_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    *SDConfig
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid minimal config",
+			input: `
+refresh_interval: 30s
+port: 9090
+`,
+			expected: &SDConfig{
+				RefreshInterval:  model.Duration(30 * time.Second),
+				Port:             9090,
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
+			},
+		},
+		{
+			name:     "valid config with defaults",
+			input:    `{}`,
+			expected: &DefaultSDConfig,
+		},
+		{
+			name: "invalid refresh interval",
+			input: `
+refresh_interval: invalid
+port: 9090
+`,
+			wantErr: true,
+		},
+		{
+			name: "invalid port type",
+			input: `
+refresh_interval: 30s
+port: "not_a_number"
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config SDConfig
+			err := yaml.Unmarshal([]byte(tt.input), &config)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.expected != nil {
+				require.Equal(t, tt.expected.RefreshInterval, config.RefreshInterval)
+				require.Equal(t, tt.expected.Port, config.Port)
+			}
+		})
+	}
+}
+
+func TestSDConfig_Methods(t *testing.T) {
+	t.Run("Name", func(t *testing.T) {
+		config := &SDConfig{}
+		require.Equal(t, "upcloud", config.Name())
+	})
+
+	t.Run("NewDiscovererMetrics", func(t *testing.T) {
+		config := &SDConfig{}
+		metrics := config.NewDiscovererMetrics(nil, &mockRefreshMetricsInstantiator{})
+		require.NotNil(t, metrics)
+		require.IsType(t, &upcloudMetrics{}, metrics)
+	})
+
+	t.Run("SetDirectory", func(t *testing.T) {
+		config := &SDConfig{
+			HTTPClientConfig: config.HTTPClientConfig{
+				TLSConfig: config.TLSConfig{
+					CertFile: "cert.pem",
+					KeyFile:  "key.pem",
+				},
+			},
+		}
+
+		config.SetDirectory("/test/dir")
+		require.Equal(t, filepath.Join("/test/dir", "cert.pem"), config.HTTPClientConfig.TLSConfig.CertFile)
+		require.Equal(t, filepath.Join("/test/dir", "key.pem"), config.HTTPClientConfig.TLSConfig.KeyFile)
+	})
+}
+
+func TestDiscovery_IPAddressPriority(t *testing.T) {
+	tests := []struct {
+		name               string
+		setupServerDetails func() map[string]*upcloud.ServerDetails
+		expectedAddress    string
+	}{
+		{
+			name: "prefers public IPv4",
+			setupServerDetails: func() map[string]*upcloud.ServerDetails {
+				details := CreateTestServerDetails()
+				return map[string]*upcloud.ServerDetails{
+					"test-server": details["00798b85-efdc-41ca-8021-f6ef457b8531"],
+				}
+			},
+			expectedAddress: "192.0.2.1:80",
+		},
+		{
+			name:               "falls back to public IPv6 when no IPv4",
+			setupServerDetails: CreateServerDetailsWithIPv6Only,
+			expectedAddress:    "[2001:db8::1]:80",
+		},
+		{
+			name:               "falls back to private IPv4 when no public",
+			setupServerDetails: CreateServerDetailsWithPrivateOnly,
+			expectedAddress:    "10.0.0.1:80",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := NewMockUpCloudClient()
+			serverDetails := tt.setupServerDetails()
+
+			servers := CreateSingleTestServer()
+			mock.SetServers(servers)
+			for uuid, details := range serverDetails {
+				mock.SetServerDetails(uuid, details)
+			}
+
+			d := &Discovery{
+				client: mock,
+				port:   80,
+			}
+
+			ctx := context.Background()
+			tgs, err := d.refresh(ctx)
+			require.NoError(t, err)
+			require.Len(t, tgs, 1)
+			require.Len(t, tgs[0].Targets, 1)
+
+			target := tgs[0].Targets[0]
+			require.Equal(t, model.LabelValue(tt.expectedAddress), target[model.AddressLabel])
+		})
+	}
+}
+
+func TestSDConfig_NewDiscoverer(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *SDConfig
+		options     discovery.DiscovererOptions
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid config and options",
+			config: &SDConfig{
+				Port:             9100,
+				RefreshInterval:  model.Duration(30 * time.Second),
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
+			},
+			options: discovery.DiscovererOptions{
+				Logger: slog.Default(),
+				Metrics: &upcloudMetrics{
+					refreshMetrics: &mockRefreshMetricsInstantiator{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid metrics type in options",
+			config: &SDConfig{
+				Port:             9100,
+				RefreshInterval:  model.Duration(30 * time.Second),
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
+			},
+			options: discovery.DiscovererOptions{
+				Logger:  slog.Default(),
+				Metrics: &invalidMetricsType{},
+			},
+			wantErr:     true,
+			errContains: "invalid discovery metrics type",
+		},
+		{
+			name: "invalid TLS config",
+			config: &SDConfig{
+				Port:            9100,
+				RefreshInterval: model.Duration(30 * time.Second),
+				HTTPClientConfig: config.HTTPClientConfig{
+					TLSConfig: config.TLSConfig{
+						CertFile: "/nonexistent/cert.pem",
+						KeyFile:  "/nonexistent/key.pem",
+					},
+				},
+			},
+			options: discovery.DiscovererOptions{
+				Logger: slog.Default(),
+				Metrics: &upcloudMetrics{
+					refreshMetrics: &mockRefreshMetricsInstantiator{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil logger in options",
+			config: &SDConfig{
+				Port:             9100,
+				RefreshInterval:  model.Duration(30 * time.Second),
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
+			},
+			options: discovery.DiscovererOptions{
+				Logger: nil,
+				Metrics: &upcloudMetrics{
+					refreshMetrics: &mockRefreshMetricsInstantiator{},
+				},
+			},
+			wantErr: false, // Should handle nil logger gracefully
+		},
+		{
+			name: "with HTTP client options",
+			config: &SDConfig{
+				Port:             9100,
+				RefreshInterval:  model.Duration(30 * time.Second),
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
+			},
+			options: discovery.DiscovererOptions{
+				Logger: slog.Default(),
+				Metrics: &upcloudMetrics{
+					refreshMetrics: &mockRefreshMetricsInstantiator{},
+				},
+				HTTPClientOptions: []config.HTTPClientOption{},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("UPCLOUD_TOKEN", "test-token")
+			discoverer, err := tt.config.NewDiscoverer(tt.options)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, discoverer)
+				if tt.errContains != "" {
+					require.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, discoverer)
+
+			// Verify the discoverer is of the correct type
+			discovery, ok := discoverer.(*Discovery)
+			require.True(t, ok, "NewDiscoverer should return a *Discovery")
+			require.NotNil(t, discovery.client)
+			require.NotNil(t, discovery.Discovery)
+
+			// Verify the port is set correctly
+			expectedPort := tt.config.Port
+			if expectedPort == 0 {
+				expectedPort = DefaultSDConfig.Port
+			}
+			require.Equal(t, expectedPort, discovery.port)
+		})
+	}
+}
+
+func TestNewDiscovery_EnvironmentVariables(t *testing.T) {
+	tests := []struct {
+		name        string
+		envVars     map[string]string
+		config      *SDConfig
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid token environment variable",
+			envVars: map[string]string{
+				"UPCLOUD_TOKEN": "test-token-123",
+			},
+			config: &SDConfig{
+				Port:             9100,
+				RefreshInterval:  model.Duration(30 * time.Second),
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid token environment variable",
+			envVars: map[string]string{
+				"UPCLOUD_TOKEN": "",
+			},
+			config: &SDConfig{
+				Port:             9100,
+				RefreshInterval:  model.Duration(30 * time.Second),
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("UPCLOUD_TOKEN", "")
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
+			logger := slog.Default()
+			metrics := &upcloudMetrics{
+				refreshMetrics: &mockRefreshMetricsInstantiator{},
+			}
+
+			discovery, err := NewDiscovery(tt.config, logger, metrics)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, discovery)
+				if tt.errContains != "" {
+					require.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, discovery)
+			require.NotNil(t, discovery.client)
+			require.NotNil(t, discovery.Discovery)
+
+			expectedPort := tt.config.Port
+			if expectedPort == 0 {
+				expectedPort = DefaultSDConfig.Port
+			}
+			require.Equal(t, expectedPort, discovery.port)
+		})
+	}
+}

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2917,6 +2917,10 @@ stackit_sd_configs:
 triton_sd_configs:
   [ - <triton_sd_config> ... ]
 
+# List of UpCloud service discovery configurations.
+upcloud_sd_configs:
+  [ - <upcloud_sd_config> ... ]
+
 # List of Uyuni service discovery configurations.
 uyuni_sd_configs:
   [ - <uyuni_sd_config> ... ]
@@ -3198,4 +3202,39 @@ headers:
 # TLS configuration.
 tls_config:
   [ <tls_config> ]
+```
+
+### `<upcloud_sd_config>`
+
+UpCloud SD configurations allow retrieving scrape targets from UpCloud servers.
+The target address defaults to the first existing address in the following priority
+order: public IPv4, public IPv6, private IPv4. This can be changed with relabeling,
+as demonstrated in [the Prometheus upcloud-sd configuration file](/documentation/examples/prometheus-upcloud.yml).
+
+The following meta labels are available on targets during [relabeling](#relabel_config):
+
+* `__meta_upcloud_server_uuid`: the UUID of the server
+* `__meta_upcloud_server_title`: the title of the server
+* `__meta_upcloud_server_hostname`: the hostname of the server
+* `__meta_upcloud_server_zone`: the zone of the server
+* `__meta_upcloud_server_plan`: the plan of the server
+* `__meta_upcloud_server_state`: the state of the server
+* `__meta_upcloud_server_core_number`: the number of CPU cores of the server
+* `__meta_upcloud_server_memory_amount`: the amount of memory of the server
+* `__meta_upcloud_server_public_ipv4`: the comma-separated list of public IPv4 addresses of the server
+* `__meta_upcloud_server_private_ipv4`: the comma-separated list of private IPv4 addresses of the server
+* `__meta_upcloud_server_public_ipv6`: the comma-separated list of public IPv6 addresses of the server
+* `__meta_upcloud_server_tag_<tagname>`: each tag of the server, with any unsupported characters converted to an underscore
+* `__meta_upcloud_server_label_<labelname>`: each label of the server, with any unsupported characters converted to an underscore
+
+```yaml
+# The port to scrape metrics from.
+[ port: <int> | default = 80 ]
+
+# The time after which the servers are refreshed.
+[ refresh_interval: <duration> | default = 60s ]
+
+# HTTP client settings, including authentication methods (such as basic auth and
+# authorization), proxy configurations, TLS options, custom HTTP headers, etc.
+[ <http_config> ]
 ```

--- a/documentation/examples/prometheus-upcloud.yml
+++ b/documentation/examples/prometheus-upcloud.yml
@@ -1,0 +1,18 @@
+# An example scrape configuration for running Prometheus
+# with UpCloud.
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # Discover Node Exporter instances to scrape.
+  - job_name: "node"
+    upcloud_sd_configs:
+      - port: 9100
+        refresh_interval: 10s
+    relabel_configs:
+      # Only scrape targets that have a label 'monitoring'.
+      - source_labels: [__meta_upcloud_server_label_monitoring]
+        regex: "true"
+        action: keep

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0
 	github.com/Code-Hex/go-generics-cache v1.5.1
 	github.com/KimMachineGun/automemlimit v0.7.4
+	github.com/UpCloudLtd/upcloud-go-api/v8 v8.29.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b
 	github.com/aws/aws-sdk-go-v2 v1.39.2

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/KimMachineGun/automemlimit v0.7.4 h1:UY7QYOIfrr3wjjOAqahFmC3IaQCLWvur
 github.com/KimMachineGun/automemlimit v0.7.4/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/UpCloudLtd/upcloud-go-api/v8 v8.29.0 h1:Vl9XvTT1KrQxwORhBAROKfQDY3O+rvbdC2G10P6LOrc=
+github.com/UpCloudLtd/upcloud-go-api/v8 v8.29.0/go.mod h1:NBh1d/ip1bhdAIhuPWbyPme7tbLzDTV7dhutUmU1vg8=
 github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/plugins.yml
+++ b/plugins.yml
@@ -18,6 +18,7 @@
 - github.com/prometheus/prometheus/discovery/scaleway
 - github.com/prometheus/prometheus/discovery/stackit
 - github.com/prometheus/prometheus/discovery/triton
+- github.com/prometheus/prometheus/discovery/upcloud
 - github.com/prometheus/prometheus/discovery/uyuni
 - github.com/prometheus/prometheus/discovery/vultr
 - github.com/prometheus/prometheus/discovery/xds

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -56,6 +56,8 @@ import (
 	_ "github.com/prometheus/prometheus/discovery/stackit"
 	// Register triton plugin.
 	_ "github.com/prometheus/prometheus/discovery/triton"
+	// Register upcloud plugin.
+	_ "github.com/prometheus/prometheus/discovery/upcloud"
 	// Register uyuni plugin.
 	_ "github.com/prometheus/prometheus/discovery/uyuni"
 	// Register vultr plugin.


### PR DESCRIPTION
Add service discovery support for [UpCloud](https://upcloud.com).

Includes mock tests with fixtures.

Signed-off-by: Ville Vesilehto <ville.vesilehto@upcloud.com>

#### Which issue(s) does the PR fix:

None.

#### Does this PR introduce a user-facing change?

```release-notes
[FEATURE] Discovery: New service discovery for UpCloud. #16719
```

