### PR TITLE
promql: fix ts_of_last_over_time for histogram vectors

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -795,7 +795,7 @@ func funcTsOfLastOverTime(vals []parser.Value, _ parser.Expressions, enh *EvalNo
 
 	var th int64
 	if len(el.Histograms) > 0 {
-		th = el.Floats[len(el.Floats)-1].T
+		th = el.Histograms[len(el.Histograms)-1].T
 	}
 
 	return append(enh.Out, Sample{

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -1201,12 +1201,20 @@ eval instant at 90s ts_of_max_over_time(metric[90s])
 clear
 load 10s53ms
 	metric 1 2 3 _ _
+	metric_histogram{type="only_histogram"} {{schema:1 sum:2 count:3}}x4
+	metric_histogram{type="mix"} 1 1 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1
 
 eval instant at 90s ts_of_last_over_time(metric[90s])
 	{} 20.106
 
 eval instant at 95s ts_of_last_over_time(metric[90s])
 	{} 20.106
+
+eval instant at 95s ts_of_last_over_time(metric_histogram{type="only_histogram"}[90s])
+	{type="only_histogram"} 40.212
+
+eval instant at 95s ts_of_last_over_time(metric_histogram{type="mix"}[90s])
+	{type="mix"} 50.265
 
 # Tests for quantile_over_time
 clear


### PR DESCRIPTION
    This PR fixes a bug in ts_of_last_over_time where the float samples
    where used when computing the last timestamp of the histogram samples.
    
    Signed-off-by: Michael Hoffmann <mhoffmann@cloudflare.com>
