### PR TITLE
parser: handle user-defined funcs as aliases to expand

### DIFF
--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -13,6 +13,10 @@
 
 package parser
 
+import (
+	"fmt"
+)
+
 // Function represents a function of the expression language and is
 // used by function nodes.
 type Function struct {
@@ -21,6 +25,21 @@ type Function struct {
 	Variadic     int
 	ReturnType   ValueType
 	Experimental bool
+}
+
+// UDF is a user-defined function that will be resolved to
+// a standard PromQL expression when Eval is called.
+type UDF struct {
+	Name         string `yaml:"name"`
+	ExpansionFmt string `yaml:"expansion"`
+}
+
+func (f *UDF) Eval(exprs Expressions) string {
+	var ee []any
+	for _, e := range exprs {
+		ee = append(ee, any(e.String()))
+	}
+	return fmt.Sprintf(f.ExpansionFmt, ee...)
 }
 
 // EnableExperimentalFunctions controls whether experimentalFunctions are enabled.
@@ -437,4 +456,10 @@ var Functions = map[string]*Function{
 func getFunction(name string, functions map[string]*Function) (*Function, bool) {
 	function, ok := functions[name]
 	return function, ok
+}
+
+// getUDF returns a user-defined function for the given name.
+func getUDF(name string, udfs map[string]*UDF) (*UDF, bool) {
+	udf, ok := udfs[name]
+	return udf, ok
 }

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -56,6 +56,9 @@ type parser struct {
 	// functions contains all functions supported by the parser instance.
 	functions map[string]*Function
 
+	// udfs contains all user-defined functions supported by the parser instance.
+	udfs map[string]*UDF
+
 	// Everytime an Item is lexed that could be the end
 	// of certain expressions its end position is stored here.
 	lastClosing posrange.Pos
@@ -78,6 +81,12 @@ type Opt func(p *parser)
 func WithFunctions(functions map[string]*Function) Opt {
 	return func(p *parser) {
 		p.functions = functions
+	}
+}
+
+func WithUserDefinedFunctions(udfs map[string]*UDF) Opt {
+	return func(p *parser) {
+		p.udfs = udfs
 	}
 }
 
@@ -753,10 +762,12 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 			n.VectorMatching.Card = CardManyToMany
 		}
 
-		for _, l1 := range n.VectorMatching.MatchingLabels {
-			for _, l2 := range n.VectorMatching.Include {
-				if l1 == l2 && n.VectorMatching.On {
-					p.addParseErrf(opRange(), "label %q must not occur in ON and GROUP clause at once", l1)
+		if n.VectorMatching != nil {
+			for _, l1 := range n.VectorMatching.MatchingLabels {
+				for _, l2 := range n.VectorMatching.Include {
+					if l1 == l2 && n.VectorMatching.On {
+						p.addParseErrf(opRange(), "label %q must not occur in ON and GROUP clause at once", l1)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The current PR adds support for registering user-defined functions (UDFs), which are basically aliases that expand into lengthier PromQL expressions when the parser builds its parse tree. 

This should allow developers to simplify long and complex PromQL expressions and to avoid duplication of common expressions by extracting PromQL chunks that tend to be repeated (e.g. adding info-metrics to decorate an expression result). The community has long requested a similar facility (see, for example, #6822). And some commercial [products](https://last9.io/docs/promql-macros/) are already offering it. Hacking the PromQL parser to intercept function calls is way better IMHO than solving this issue at a higher layer of abstraction, like learning a new configuration language (jsonnet, CUE, etc) only to reduce the length of a YAML file full of long byzantine PromQL expressions.

While in the short term, the benefits of having such UDFs would be limited to streamlining the developer experience, this change could unlock further enhancements, such as building a proxy that expands such aliases, as suggested by @ringerc [here](https://github.com/prometheus/prometheus/issues/14984#issuecomment-2392553753), similarly to [prom-label-proxy](https://github.com/prometheus-community/prom-label-proxy).