### PR TITLE
fix: prevent invalid array access in aggregate expression

### DIFF
--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -451,6 +451,11 @@ func (p *parser) newAggregateExpr(op Item, modifier, args Node) (ret *AggregateE
 	ret = modifier.(*AggregateExpr)
 	arguments := args.(Expressions)
 
+	if len(p.closingParens) == 0 {
+		// Prevents invalid array accesses.
+		// The error is already captured by the parser.
+		return
+	}
 	ret.PosRange = posrange.PositionRange{
 		Start: op.Pos,
 		End:   p.closingParens[0],

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -4540,6 +4540,11 @@ var testExpr = []struct {
 			PosRange: posrange.PositionRange{Start: 0, End: 20},
 		},
 	},
+	{
+		input:  "sum(rate(",
+		fail:   true,
+		errMsg: "unclosed left parenthesis",
+	},
 }
 
 func makeInt64Pointer(val int64) *int64 {


### PR DESCRIPTION
This commit fixes the evaluation of invalid expressions like `sum(rate(`. Before that, it would trigger a panic in the PromQL engine because it tried to access an index which is out of range.

The bug was probably introduced by 06d0b063ea.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
