### PR TITLE
TSDB: Add reload-on-change option for immediate changes

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -474,6 +474,8 @@ func main() {
 	serverOnlyFlag(a, "storage.tsdb.delayed-compaction.max-percent", "Sets the upper limit for the random compaction delay, specified as a percentage of the head chunk range. 100 means the compaction can be delayed by up to the entire head chunk range. Only effective when the delayed-compaction feature flag is enabled.").
 		Default("10").Hidden().IntVar(&cfg.tsdb.CompactionDelayMaxPercent)
 
+	serverOnlyFlag(a, "storage.tsdb.reload_on_change", "Reload TSDB when any changes are detected in the storage directory.").
+		Default("false").Hidden().BoolVar(&cfg.tsdb.ReloadOnChange)
 	agentOnlyFlag(a, "storage.agent.path", "Base path for metrics storage.").
 		Default("data-agent/").StringVar(&cfg.agentStoragePath)
 
@@ -667,6 +669,7 @@ func main() {
 	}
 	if cfgFile.StorageConfig.TSDBConfig != nil {
 		cfg.tsdb.OutOfOrderTimeWindow = cfgFile.StorageConfig.TSDBConfig.OutOfOrderTimeWindow
+		cfg.tsdb.ReloadOnChange = cfgFile.StorageConfig.TSDBConfig.ReloadOnChange
 	}
 
 	// Set Go runtime parameters before we get too far into initialization.
@@ -1318,6 +1321,7 @@ func main() {
 					"RetentionDuration", cfg.tsdb.RetentionDuration,
 					"WALSegmentSize", cfg.tsdb.WALSegmentSize,
 					"WALCompressionType", cfg.tsdb.WALCompressionType,
+					"ReloadOnChange", cfg.tsdb.ReloadOnChange,
 				)
 
 				startTimeMargin := int64(2 * time.Duration(cfg.tsdb.MinBlockDuration).Seconds() * 1000)
@@ -1860,6 +1864,7 @@ type tsdbOptions struct {
 	CompactionDelayMaxPercent      int
 	EnableOverlappingCompaction    bool
 	UseUncachedIO                  bool
+	ReloadOnChange                 bool
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -1884,6 +1889,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		CompactionDelayMaxPercent:      opts.CompactionDelayMaxPercent,
 		EnableOverlappingCompaction:    opts.EnableOverlappingCompaction,
 		UseUncachedIO:                  opts.UseUncachedIO,
+		ReloadOnChange:                 opts.ReloadOnChange,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -979,6 +979,9 @@ type TSDBConfig struct {
 	// During unmarshall, this is converted into milliseconds and stored in OutOfOrderTimeWindow.
 	// This should not be used directly and must be converted into OutOfOrderTimeWindow.
 	OutOfOrderTimeWindowFlag model.Duration `yaml:"out_of_order_time_window,omitempty"`
+
+	// ReloadOnChange sets if a TSDB Block should be reloaded when new data is written to it.
+	ReloadOnChange bool `yaml:"reload_on_change,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -988,6 +991,11 @@ func (t *TSDBConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal((*plain)(t)); err != nil {
 		return err
 	}
+
+	slog.Debug("TSDBConfig",
+		"out_of_order_time_window", t.OutOfOrderTimeWindowFlag,
+		"reload_on_change", t.ReloadOnChange,
+	)
 
 	t.OutOfOrderTimeWindow = time.Duration(t.OutOfOrderTimeWindowFlag).Milliseconds()
 


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Resolves: #16649 

This PR adds a new TSDB configuration option reload_on_change that allows users to customize if TSDB should reload when any changes occur.

Prometheus reloads TSDB blocks on a periodic basis. Users performing backfills, block imports, or manual block operations must wait for the next reload cycle before the data becomes available for querying.

This flag is to eliminate wait time when any change occurs in TSDB

## usage

``` bash
storage:
   tsdb:
      reload_on_change: true
```

## test

```
time=2025-06-21T12:35:51.724Z level=DEBUG source=db.go:1136 msg="filesystem event triggered reload" component=tsdb op=CREATE name=data/01JXPZ9TKTWSH3K398W1K282G8.tmp-for-deletion
time=2025-06-21T12:35:51.729Z level=DEBUG source=db.go:1136 msg="filesystem event triggered reload" component=tsdb op=REMOVE name=data/01JXPZ9TKTWSH3K398W1K282G8.tmp-for-deletion
time=2025-06-21T12:35:54.224Z level=DEBUG source=db.go:1136 msg="filesystem event triggered reload" component=tsdb op=CREATE name=data/01JXPZ9TKTWSH3K398W1K282G8
time=2025-06-21T12:35:54.228Z level=DEBUG source=db.go:1136 msg="filesystem event triggered reload" component=tsdb op=CREATE name=data/01JXPZ9TKTWSH3K398W1K282G8.tmp-for-deletion
time=2025-06-21T12:35:54.229Z level=DEBUG source=db.go:1136 msg="filesystem event triggered reload" component=tsdb op=REMOVE name=data/01JXPZ9TKTWSH3K398W1K282G8.tmp-for-deletion 
```