### PR TITLE
[BUILD] Don't specify -d for go get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,6 @@ update-all-go-deps:
 	@$(MAKE) update-go-deps
 	@echo ">> updating Go dependencies in ./documentation/examples/remote_storage/"
 	@cd ./documentation/examples/remote_storage/ && for m in $$($(GO) list -mod=readonly -m -f '{{ if and (not .Indirect) (not .Main)}}{{.Path}}{{end}}' all); do \
-		$(GO) get -d $$m; \
+		$(GO) get $$m; \
 	done
 	@cd ./documentation/examples/remote_storage/ && $(GO) mod tidy

--- a/Makefile.common
+++ b/Makefile.common
@@ -139,7 +139,7 @@ common-deps:
 update-go-deps:
 	@echo ">> updating Go dependencies"
 	@for m in $$($(GO) list -mod=readonly -m -f '{{ if and (not .Indirect) (not .Main)}}{{.Path}}{{end}}' all); do \
-		$(GO) get -d $$m; \
+		$(GO) get $$m; \
 	done
 	$(GO) mod tidy
 


### PR DESCRIPTION
It is deprecated; see https://golang.org/doc/go1.18#go-get

Otherwise we get messages like this:

```
$ make update-all-go-deps
make[1]: Entering directory '/home/bryan/src/github.com/prometheus/prometheus'
>> updating Go dependencies
go: -d flag is deprecated. -d=true is a no-op
go: downloading github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
go: -d flag is deprecated. -d=true is a no-op
...
```
