### PR TITLE
OTLP receiver: Don't append _total suffix to non-monotonic OTel sums

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -77,7 +77,7 @@ func TranslatorMetricFromOtelMetric(metric pmetric.Metric) otlptranslator.Metric
 	case pmetric.MetricTypeGauge:
 		m.Type = otlptranslator.MetricTypeGauge
 	case pmetric.MetricTypeSum:
-		if metric.Sum().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
+		if metric.Sum().IsMonotonic() {
 			m.Type = otlptranslator.MetricTypeMonotonicCounter
 		} else {
 			m.Type = otlptranslator.MetricTypeNonMonotonicCounter

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -804,48 +804,41 @@ func TestTranslatorMetricFromOtelMetric(t *testing.T) {
 	}
 }
 
-func createOTelGaugeForTranslator(name, unit, description string) pmetric.Metric {
+func createOTelMetricForTranslator(name, unit, description string) pmetric.Metric {
 	m := pmetric.NewMetric()
 	m.SetName(name)
 	m.SetUnit(unit)
 	m.SetDescription(description)
+	return m
+}
+
+func createOTelGaugeForTranslator(name, unit, description string) pmetric.Metric {
+	m := createOTelMetricForTranslator(name, unit, description)
 	m.SetEmptyGauge()
 	return m
 }
 
 func createOTelSumForTranslator(name, unit, description string, isMonotonic bool) pmetric.Metric {
-	m := pmetric.NewMetric()
-	m.SetName(name)
-	m.SetUnit(unit)
-	m.SetDescription(description)
+	m := createOTelMetricForTranslator(name, unit, description)
 	sum := m.SetEmptySum()
 	sum.SetIsMonotonic(isMonotonic)
 	return m
 }
 
 func createOTelHistogramForTranslator(name, unit, description string) pmetric.Metric {
-	m := pmetric.NewMetric()
-	m.SetName(name)
-	m.SetUnit(unit)
-	m.SetDescription(description)
+	m := createOTelMetricForTranslator(name, unit, description)
 	m.SetEmptyHistogram()
 	return m
 }
 
 func createOTelExponentialHistogramForTranslator(name, unit, description string) pmetric.Metric {
-	m := pmetric.NewMetric()
-	m.SetName(name)
-	m.SetUnit(unit)
-	m.SetDescription(description)
+	m := createOTelMetricForTranslator(name, unit, description)
 	m.SetEmptyExponentialHistogram()
 	return m
 }
 
 func createOTelSummaryForTranslator(name, unit, description string) pmetric.Metric {
-	m := pmetric.NewMetric()
-	m.SetName(name)
-	m.SetUnit(unit)
-	m.SetDescription(description)
+	m := createOTelMetricForTranslator(name, unit, description)
 	m.SetEmptySummary()
 	return m
 }


### PR DESCRIPTION
Fix the OTLP receiver so the suffix `_total` isn't appended to metrics converted from non-monotonic OTel sum metrics, if `otlp.translation_strategy` is `UnderscoreEscapingWithSuffixes` or `NoUTF8EscapingWithSuffixes`.

I'm including tests for the relevant function: `TranslatorMetricFromOtelMetric`, and data driven cases in `TestFromMetrics`.

Fixes #16775