### PR TITLE
tsdb/wlog: Remove any temproary checkpoints when creating a Checkpoint

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -852,7 +852,7 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 
 	for _, tmpDir := range []string{walDir, dir} {
 		// Remove tmp dirs.
-		if err := removeBestEffortTmpDirs(l, tmpDir); err != nil {
+		if err := tsdbutil.RemoveTmpDirs(l, tmpDir, isTmpDir); err != nil {
 			return nil, fmt.Errorf("remove tmp dirs: %w", err)
 		}
 	}
@@ -1036,26 +1036,6 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 	go db.run(ctx)
 
 	return db, nil
-}
-
-func removeBestEffortTmpDirs(l *slog.Logger, dir string) error {
-	files, err := os.ReadDir(dir)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	for _, f := range files {
-		if isTmpDir(f) {
-			if err := os.RemoveAll(filepath.Join(dir, f.Name())); err != nil {
-				l.Error("failed to delete tmp block dir", "dir", filepath.Join(dir, f.Name()), "err", err)
-				continue
-			}
-			l.Info("Found and deleted tmp block dir", "dir", filepath.Join(dir, f.Name()))
-		}
-	}
-	return nil
 }
 
 // StartTime implements the Storage interface.
@@ -2303,8 +2283,7 @@ func isBlockDir(fi fs.DirEntry) bool {
 	return err == nil
 }
 
-// isTmpDir returns true if the given file-info contains a block ULID, a checkpoint prefix,
-// or a chunk snapshot prefix and a tmp extension.
+// isTmpDir returns true if the given file-info contains a block ULID, or a chunk snapshot prefix and a tmp extension.
 func isTmpDir(fi fs.DirEntry) bool {
 	if !fi.IsDir() {
 		return false
@@ -2313,9 +2292,6 @@ func isTmpDir(fi fs.DirEntry) bool {
 	fn := fi.Name()
 	ext := filepath.Ext(fn)
 	if ext == tmpForDeletionBlockDirSuffix || ext == tmpForCreationBlockDirSuffix || ext == tmpLegacy {
-		if strings.HasPrefix(fn, wlog.CheckpointPrefix) {
-			return true
-		}
 		if strings.HasPrefix(fn, chunkSnapshotPrefix) {
 			return true
 		}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3224,11 +3224,8 @@ func TestOpen_VariousBlockStates(t *testing.T) {
 		_, err = writeMetaFile(promslog.New(&promslog.Config{}), dir, m)
 		require.NoError(t, err)
 	}
-	tmpCheckpointDir := path.Join(tmpDir, "wal/checkpoint.00000001.tmp")
-	err := os.MkdirAll(tmpCheckpointDir, 0o777)
-	require.NoError(t, err)
 	tmpChunkSnapshotDir := path.Join(tmpDir, chunkSnapshotPrefix+"0000.00000001.tmp")
-	err = os.MkdirAll(tmpChunkSnapshotDir, 0o777)
+	err := os.MkdirAll(tmpChunkSnapshotDir, 0o777)
 	require.NoError(t, err)
 
 	opts := DefaultOptions()
@@ -3259,8 +3256,6 @@ func TestOpen_VariousBlockStates(t *testing.T) {
 		}
 	}
 	require.Len(t, expectedIgnoredDirs, ignored)
-	_, err = os.Stat(tmpCheckpointDir)
-	require.True(t, os.IsNotExist(err))
 	_, err = os.Stat(tmpChunkSnapshotDir)
 	require.True(t, os.IsNotExist(err))
 }

--- a/tsdb/tsdbutil/remove_tmp_dirs.go
+++ b/tsdb/tsdbutil/remove_tmp_dirs.go
@@ -1,0 +1,29 @@
+package tsdbutil
+
+import (
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// RemoveTmpDirs attempts to remove directories in the specified directory which match the isTmpDir predicate.
+func RemoveTmpDirs(l *slog.Logger, dir string, isTmpDir func(fi fs.DirEntry) bool) error {
+	files, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, f := range files {
+		if isTmpDir(f) {
+			if err := os.RemoveAll(filepath.Join(dir, f.Name())); err != nil {
+				l.Error("failed to delete tmp dir", "dir", filepath.Join(dir, f.Name()), "err", err)
+				continue
+			}
+			l.Info("Found and deleted tmp dir", "dir", filepath.Join(dir, f.Name()))
+		}
+	}
+	return nil
+}

--- a/tsdb/tsdbutil/remove_tmp_dirs.go
+++ b/tsdb/tsdbutil/remove_tmp_dirs.go
@@ -1,3 +1,17 @@
+// Copyright 2018 The Prometheus Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tsdbutil
 
 import (

--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"math"
 	"os"
@@ -32,6 +33,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 )
 
 // CheckpointStats returns stats about a created checkpoint.
@@ -81,8 +83,8 @@ func DeleteCheckpoints(dir string, maxIndex int) error {
 	return errs.Err()
 }
 
-// CheckpointPrefix is the prefix used for checkpoint files.
-const CheckpointPrefix = "checkpoint."
+// checkpointTempFileSuffix is the suffix used when creating temporary checkpoint files.
+const checkpointTempFileSuffix = ".tmp"
 
 // Checkpoint creates a compacted checkpoint of segments in range [from, to] in the given WAL.
 // It includes the most recent checkpoint if it exists.
@@ -124,12 +126,12 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 		defer sgmReader.Close()
 	}
 
-	cpdir := checkpointDir(w.Dir(), to)
-	cpdirtmp := cpdir + ".tmp"
-
-	if err := os.RemoveAll(cpdirtmp); err != nil {
-		return nil, fmt.Errorf("remove previous temporary checkpoint dir: %w", err)
+	if err := tsdbutil.RemoveTmpDirs(logger, w.Dir(), isTempDir); err != nil {
+		return nil, fmt.Errorf("remove previous temporary checkpoint dirs: %w", err)
 	}
+
+	cpdir := checkpointDir(w.Dir(), to)
+	cpdirtmp := cpdir + checkpointTempFileSuffix
 
 	if err := os.MkdirAll(cpdirtmp, 0o777); err != nil {
 		return nil, fmt.Errorf("create checkpoint dir: %w", err)
@@ -395,8 +397,11 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 	return stats, nil
 }
 
+// checkpointPrefix is the prefix used for checkpoint files.
+const checkpointPrefix = "checkpoint."
+
 func checkpointDir(dir string, i int) string {
-	return filepath.Join(dir, fmt.Sprintf(CheckpointPrefix+"%08d", i))
+	return filepath.Join(dir, fmt.Sprintf(checkpointPrefix+"%08d", i))
 }
 
 type checkpointRef struct {
@@ -412,13 +417,13 @@ func listCheckpoints(dir string) (refs []checkpointRef, err error) {
 
 	for i := 0; i < len(files); i++ {
 		fi := files[i]
-		if !strings.HasPrefix(fi.Name(), CheckpointPrefix) {
+		if !strings.HasPrefix(fi.Name(), checkpointPrefix) {
 			continue
 		}
 		if !fi.IsDir() {
 			return nil, fmt.Errorf("checkpoint %s is not a directory", fi.Name())
 		}
-		idx, err := strconv.Atoi(fi.Name()[len(CheckpointPrefix):])
+		idx, err := strconv.Atoi(fi.Name()[len(checkpointPrefix):])
 		if err != nil {
 			continue
 		}
@@ -431,4 +436,8 @@ func listCheckpoints(dir string) (refs []checkpointRef, err error) {
 	})
 
 	return refs, nil
+}
+
+func isTempDir(fi fs.DirEntry) bool {
+	return strings.HasPrefix(fi.Name(), checkpointPrefix) && strings.HasSuffix(fi.Name(), checkpointTempFileSuffix)
 }

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -416,3 +416,55 @@ func TestCheckpointNoTmpFolderAfterError(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestCheckpointDeletesTemporaryCheckpoints(t *testing.T) {
+	testCases := []struct {
+		name                          string
+		checkpointDirectoriesToCreate []string
+		expectedDirectories           []string
+	}{
+		{
+			name:                          "no tmp checkpoints",
+			checkpointDirectoriesToCreate: nil,
+			expectedDirectories:           []string{"checkpoint.00001000"},
+		},
+		{
+			name:                          "one tmp checkpoint",
+			checkpointDirectoriesToCreate: []string{"checkpoint.00001000.tmp"},
+			expectedDirectories:           []string{"checkpoint.00001000"},
+		},
+		{
+			name:                          "many tmp checkpoints",
+			checkpointDirectoriesToCreate: []string{"checkpoint.00000001.tmp", "checkpoint.00001000.tmp", "checkpoint.00002000.tmp"},
+			expectedDirectories:           []string{"checkpoint.00001000"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, fn := range tc.checkpointDirectoriesToCreate {
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, fn), 0o777))
+			}
+
+			w, err := New(nil, nil, dir, compression.None)
+			defer w.Close()
+
+			require.NoError(t, err)
+			_, err = Checkpoint(promslog.NewNopLogger(), w, 0, 1000, func(x chunks.HeadSeriesRef, _ int) bool { return true }, 1000)
+			require.NoError(t, err)
+
+			files, err := os.ReadDir(dir)
+			require.NoError(t, err)
+
+			var actualDirectories []string
+			for _, f := range files {
+				if !f.IsDir() {
+					continue
+				}
+				actualDirectories = append(actualDirectories, f.Name())
+			}
+			require.Equal(t, tc.expectedDirectories, actualDirectories)
+		})
+	}
+}

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -448,10 +448,11 @@ func TestCheckpointDeletesTemporaryCheckpoints(t *testing.T) {
 			}
 
 			w, err := New(nil, nil, dir, compression.None)
+			require.NoError(t, err)
 			defer w.Close()
 
 			require.NoError(t, err)
-			_, err = Checkpoint(promslog.NewNopLogger(), w, 0, 1000, func(x chunks.HeadSeriesRef, _ int) bool { return true }, 1000)
+			_, err = Checkpoint(promslog.NewNopLogger(), w, 0, 1000, func(_ chunks.HeadSeriesRef, _ int) bool { return true }, 1000)
 			require.NoError(t, err)
 
 			files, err := os.ReadDir(dir)


### PR DESCRIPTION
This PR ensure `Checkpoint`will remove any temporary checkpoint that might exist before creating a new one. This can help prevent accumulation of temporary checkpoints in the event a OOM/other shutdown case causes the process to shutdown while creating the checkpoint.

Resolves: https://github.com/prometheus/prometheus/issues/16779

Note: Based on a suggestion I refactored the code used in `tsdb/db.go` to cleanup temporary files in to a utility function shared between the two. 