### PR TITLE
Fix `histogram_quantile` annotation in range query when delayed name removal is disabled

### DIFF
--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -320,6 +320,11 @@ func FromStrings(ss ...string) Labels {
 	return New(ls...)
 }
 
+// FromByteString creates new labels from byte string.
+func FromByteString(b string) Labels {
+	return Labels{data: b}
+}
+
 // Compare compares the two label sets.
 // The result will be 0 if a==b, <0 if a < b, and >0 if a > b.
 func Compare(a, b Labels) int {

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -997,3 +997,10 @@ func TestMarshaling(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, f, gotFY)
 }
+
+func TestLabels_FromStringBytes(t *testing.T) {
+	lbls := FromStrings("foo", "bar", "baz", "qux")
+	bytes := lbls.Bytes(nil)
+	newLbls := FromByteString(string(bytes))
+	require.Equal(t, lbls, newLbls)
+}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1451,11 +1451,11 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 	}
 
 	// Deal with classic histograms that have already been filtered for conflicting native histograms.
-	for _, mb := range enh.signatureToMetricWithBuckets {
+	for sig, mb := range enh.signatureToMetricWithBuckets {
 		if len(mb.buckets) > 0 {
 			res, forcedMonotonicity, _ := BucketQuantile(q, mb.buckets)
 			if forcedMonotonicity {
-				annos.Add(annotations.NewHistogramQuantileForcedMonotonicityInfo(mb.metric.Get(labels.MetricName), args[1].PositionRange()))
+				annos.Add(annotations.NewHistogramQuantileForcedMonotonicityInfo(labels.FromByteString(sig).Get(model.MetricNameLabel), args[1].PositionRange()))
 			}
 
 			if !enh.enableDelayedNameRemoval {

--- a/promql/promqltest/testdata/histograms.test
+++ b/promql/promqltest/testdata/histograms.test
@@ -606,3 +606,16 @@ eval instant at 0 histogram_fraction(-Inf, 1, series)
   expect no_info
   expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
   # Should return no results.
+
+# Test fixed monotonicity info annotation for histogram in case of range query.
+load 5m
+    series{le="0.1"}  2x10
+    series{le="1"}    1x10
+    series{le="10"}   5x10
+    series{le="100"}  4x10
+    series{le="1000"} 9x10
+    series{le="+Inf"} 8x10
+
+eval range from 0m to 10m step 5m histogram_quantile(0.5, series)
+    expect info msg: PromQL info: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name "series"
+	{} 8.5 8.5 8.5


### PR DESCRIPTION
Fixes: #16553 

CC: @beorn7 @charleskorn 