### PR TITLE
Consolidate around prometheus/common/model.ValidationScheme

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,11 +68,6 @@ var (
 	}
 )
 
-const (
-	LegacyValidationConfig = "legacy"
-	UTF8ValidationConfig   = "utf8"
-)
-
 // Load parses the YAML input s into a Config.
 func Load(s string, logger *slog.Logger) (*Config, error) {
 	cfg := &Config{}
@@ -112,7 +107,7 @@ func Load(s string, logger *slog.Logger) (*Config, error) {
 	case UnderscoreEscapingWithSuffixes:
 	case "":
 	case NoTranslation, NoUTF8EscapingWithSuffixes:
-		if cfg.GlobalConfig.MetricNameValidationScheme == LegacyValidationConfig {
+		if cfg.GlobalConfig.MetricNameValidationScheme == model.LegacyValidation {
 			return nil, fmt.Errorf("OTLP translation strategy %q is not allowed when UTF8 is disabled", cfg.OTLPConfig.TranslationStrategy)
 		}
 	default:
@@ -172,7 +167,7 @@ var (
 		ScrapeProtocols:                DefaultScrapeProtocols,
 		ConvertClassicHistogramsToNHCB: false,
 		AlwaysScrapeClassicHistograms:  false,
-		MetricNameValidationScheme:     UTF8ValidationConfig,
+		MetricNameValidationScheme:     model.UTF8Validation,
 		MetricNameEscapingScheme:       model.AllowUTF8,
 	}
 
@@ -486,8 +481,8 @@ type GlobalConfig struct {
 	// 0 means no limit.
 	KeepDroppedTargets uint `yaml:"keep_dropped_targets,omitempty"`
 	// Allow UTF8 Metric and Label Names. Can be blank in config files but must
-	// have a value if a ScrapeConfig is created programmatically.
-	MetricNameValidationScheme string `yaml:"metric_name_validation_scheme,omitempty"`
+	// have a value if a GlobalConfig is created programmatically.
+	MetricNameValidationScheme model.ValidationScheme `yaml:"metric_name_validation_scheme,omitempty"`
 	// Metric name escaping mode to request through content negotiation. Can be
 	// blank in config files but must have a value if a ScrapeConfig is created
 	// programmatically.
@@ -755,7 +750,7 @@ type ScrapeConfig struct {
 	KeepDroppedTargets uint `yaml:"keep_dropped_targets,omitempty"`
 	// Allow UTF8 Metric and Label Names. Can be blank in config files but must
 	// have a value if a ScrapeConfig is created programmatically.
-	MetricNameValidationScheme string `yaml:"metric_name_validation_scheme,omitempty"`
+	MetricNameValidationScheme model.ValidationScheme `yaml:"metric_name_validation_scheme,omitempty"`
 	// Metric name escaping mode to request through content negotiation. Can be
 	// blank in config files but must have a value if a ScrapeConfig is created
 	// programmatically.
@@ -882,25 +877,25 @@ func (c *ScrapeConfig) Validate(globalConfig GlobalConfig) error {
 	}
 
 	switch globalConfig.MetricNameValidationScheme {
-	case "":
-		globalConfig.MetricNameValidationScheme = UTF8ValidationConfig
-	case LegacyValidationConfig, UTF8ValidationConfig:
+	case model.UnsetValidation:
+		globalConfig.MetricNameValidationScheme = model.UTF8Validation
+	case model.LegacyValidation, model.UTF8Validation:
 	default:
-		return fmt.Errorf("unknown global name validation method specified, must be either 'legacy' or 'utf8', got %s", globalConfig.MetricNameValidationScheme)
+		return fmt.Errorf("unknown global name validation method specified, must be either '', 'legacy' or 'utf8', got %s", globalConfig.MetricNameValidationScheme)
 	}
 	// Scrapeconfig validation scheme matches global if left blank.
 	switch c.MetricNameValidationScheme {
-	case "":
+	case model.UnsetValidation:
 		c.MetricNameValidationScheme = globalConfig.MetricNameValidationScheme
-	case LegacyValidationConfig, UTF8ValidationConfig:
+	case model.LegacyValidation, model.UTF8Validation:
 	default:
-		return fmt.Errorf("unknown scrape config name validation method specified, must be either 'legacy' or 'utf8', got %s", c.MetricNameValidationScheme)
+		return fmt.Errorf("unknown scrape config name validation method specified, must be either '', 'legacy' or 'utf8', got %s", c.MetricNameValidationScheme)
 	}
 
 	// Escaping scheme is based on the validation scheme if left blank.
 	switch globalConfig.MetricNameEscapingScheme {
 	case "":
-		if globalConfig.MetricNameValidationScheme == LegacyValidationConfig {
+		if globalConfig.MetricNameValidationScheme == model.LegacyValidation {
 			globalConfig.MetricNameEscapingScheme = model.EscapeUnderscores
 		} else {
 			globalConfig.MetricNameEscapingScheme = model.AllowUTF8
@@ -916,7 +911,7 @@ func (c *ScrapeConfig) Validate(globalConfig GlobalConfig) error {
 
 	switch c.MetricNameEscapingScheme {
 	case model.AllowUTF8:
-		if c.MetricNameValidationScheme != UTF8ValidationConfig {
+		if c.MetricNameValidationScheme != model.UTF8Validation {
 			return errors.New("utf8 metric names requested but validation scheme is not set to UTF8")
 		}
 	case model.EscapeUnderscores, model.EscapeDots, model.EscapeValues:
@@ -942,26 +937,6 @@ func (c *ScrapeConfig) MarshalYAML() (interface{}, error) {
 	return discovery.MarshalYAMLWithInlineConfigs(c)
 }
 
-// ToValidationScheme returns the validation scheme for the given string config value.
-func ToValidationScheme(s string) (validationScheme model.ValidationScheme, err error) {
-	switch s {
-	case "":
-		// This is a workaround for third party exporters that don't set the validation scheme.
-		if DefaultGlobalConfig.MetricNameValidationScheme == "" {
-			return model.UTF8Validation, errors.New("global metric name validation scheme is not set")
-		}
-		return ToValidationScheme(DefaultGlobalConfig.MetricNameValidationScheme)
-	case UTF8ValidationConfig:
-		validationScheme = model.UTF8Validation
-	case LegacyValidationConfig:
-		validationScheme = model.LegacyValidation
-	default:
-		return model.UTF8Validation, fmt.Errorf("invalid metric name validation scheme, %s", s)
-	}
-
-	return validationScheme, nil
-}
-
 // ToEscapingScheme wraps the equivalent common library function with the
 // desired default behavior based on the given validation scheme. This is a
 // workaround for third party exporters that don't set the escaping scheme.
@@ -972,6 +947,10 @@ func ToEscapingScheme(s string, v model.ValidationScheme) (model.EscapingScheme,
 			return model.NoEscaping, nil
 		case model.LegacyValidation:
 			return model.UnderscoreEscaping, nil
+		case model.UnsetValidation:
+			return model.NoEscaping, fmt.Errorf("v is unset: %s", v)
+		default:
+			panic(fmt.Errorf("unhandled validation scheme: %s", v))
 		}
 	}
 	return model.ToEscapingScheme(s)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2581,7 +2581,7 @@ func TestGetScrapeConfigs(t *testing.T) {
 			ScrapeInterval:             opts.ScrapeInterval,
 			ScrapeTimeout:              opts.ScrapeTimeout,
 			ScrapeProtocols:            DefaultGlobalConfig.ScrapeProtocols,
-			MetricNameValidationScheme: UTF8ValidationConfig,
+			MetricNameValidationScheme: model.UTF8Validation,
 			MetricNameEscapingScheme:   model.AllowUTF8,
 
 			MetricsPath:       "/metrics",
@@ -2641,7 +2641,7 @@ func TestGetScrapeConfigs(t *testing.T) {
 					ScrapeInterval:                 model.Duration(60 * time.Second),
 					ScrapeTimeout:                  DefaultGlobalConfig.ScrapeTimeout,
 					ScrapeProtocols:                DefaultGlobalConfig.ScrapeProtocols,
-					MetricNameValidationScheme:     UTF8ValidationConfig,
+					MetricNameValidationScheme:     model.UTF8Validation,
 					MetricNameEscapingScheme:       model.AllowUTF8,
 					AlwaysScrapeClassicHistograms:  boolPtr(false),
 					ConvertClassicHistogramsToNHCB: boolPtr(false),
@@ -2678,7 +2678,7 @@ func TestGetScrapeConfigs(t *testing.T) {
 					ScrapeInterval:                 model.Duration(15 * time.Second),
 					ScrapeTimeout:                  DefaultGlobalConfig.ScrapeTimeout,
 					ScrapeProtocols:                DefaultGlobalConfig.ScrapeProtocols,
-					MetricNameValidationScheme:     UTF8ValidationConfig,
+					MetricNameValidationScheme:     model.UTF8Validation,
 					MetricNameEscapingScheme:       model.AllowUTF8,
 					AlwaysScrapeClassicHistograms:  boolPtr(false),
 					ConvertClassicHistogramsToNHCB: boolPtr(false),
@@ -2802,27 +2802,27 @@ func TestScrapeConfigNameValidationSettings(t *testing.T) {
 	tests := []struct {
 		name         string
 		inputFile    string
-		expectScheme string
+		expectScheme model.ValidationScheme
 	}{
 		{
 			name:         "blank config implies default",
 			inputFile:    "scrape_config_default_validation_mode",
-			expectScheme: "utf8",
+			expectScheme: model.UTF8Validation,
 		},
 		{
 			name:         "global setting implies local settings",
 			inputFile:    "scrape_config_global_validation_mode",
-			expectScheme: "legacy",
+			expectScheme: model.LegacyValidation,
 		},
 		{
 			name:         "local setting",
 			inputFile:    "scrape_config_local_validation_mode",
-			expectScheme: "legacy",
+			expectScheme: model.LegacyValidation,
 		},
 		{
 			name:         "local setting overrides global setting",
 			inputFile:    "scrape_config_local_global_validation_mode",
-			expectScheme: "utf8",
+			expectScheme: model.UTF8Validation,
 		},
 	}
 
@@ -2846,31 +2846,31 @@ func TestScrapeConfigNameEscapingSettings(t *testing.T) {
 	tests := []struct {
 		name                   string
 		inputFile              string
-		expectValidationScheme string
+		expectValidationScheme model.ValidationScheme
 		expectEscapingScheme   string
 	}{
 		{
 			name:                   "blank config implies default",
 			inputFile:              "scrape_config_default_validation_mode",
-			expectValidationScheme: "utf8",
+			expectValidationScheme: model.UTF8Validation,
 			expectEscapingScheme:   "allow-utf-8",
 		},
 		{
 			name:                   "global setting implies local settings",
 			inputFile:              "scrape_config_global_validation_mode",
-			expectValidationScheme: "legacy",
+			expectValidationScheme: model.LegacyValidation,
 			expectEscapingScheme:   "dots",
 		},
 		{
 			name:                   "local setting",
 			inputFile:              "scrape_config_local_validation_mode",
-			expectValidationScheme: "legacy",
+			expectValidationScheme: model.LegacyValidation,
 			expectEscapingScheme:   "values",
 		},
 		{
 			name:                   "local setting overrides global setting",
 			inputFile:              "scrape_config_local_global_validation_mode",
-			expectValidationScheme: "utf8",
+			expectValidationScheme: model.UTF8Validation,
 			expectEscapingScheme:   "dots",
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/prometheus/alertmanager v0.28.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2
-	github.com/prometheus/common v0.65.0
+	github.com/prometheus/common v0.65.1-0.20250703115700-7f8b2a0d32d3
 	github.com/prometheus/common/assets v0.2.0
 	github.com/prometheus/exporter-toolkit v0.14.0
 	github.com/prometheus/sigv4 v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -454,8 +454,8 @@ github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNw
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
-github.com/prometheus/common v0.65.0 h1:QDwzd+G1twt//Kwj/Ww6E9FQq1iVMmODnILtW1t2VzE=
-github.com/prometheus/common v0.65.0/go.mod h1:0gZns+BLRQ3V6NdaerOhMbwwRbNh9hkGINtQAsP5GS8=
+github.com/prometheus/common v0.65.1-0.20250703115700-7f8b2a0d32d3 h1:R/zO7ombSHCI8bjQusgCMSL+cE669w5/R2upq5WlPD0=
+github.com/prometheus/common v0.65.1-0.20250703115700-7f8b2a0d32d3/go.mod h1:0gZns+BLRQ3V6NdaerOhMbwwRbNh9hkGINtQAsP5GS8=
 github.com/prometheus/common/assets v0.2.0 h1:0P5OrzoHrYBOSM1OigWL3mY8ZvV2N4zIE/5AahrSrfM=
 github.com/prometheus/common/assets v0.2.0/go.mod h1:D17UVUE12bHbim7HzwUvtqm6gwBEaDQ0F+hIGbFbccI=
 github.com/prometheus/exporter-toolkit v0.14.0 h1:NMlswfibpcZZ+H0sZBiTjrA3/aBFHkNZqE+iCj5EmRg=

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -149,12 +149,8 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed 
 		return nil, fmt.Errorf("error creating HTTP client: %w", err)
 	}
 
-	validationScheme, err := config.ToValidationScheme(cfg.MetricNameValidationScheme)
-	if err != nil {
-		return nil, fmt.Errorf("invalid metric name validation scheme: %w", err)
-	}
 	var escapingScheme model.EscapingScheme
-	escapingScheme, err = config.ToEscapingScheme(cfg.MetricNameEscapingScheme, validationScheme)
+	escapingScheme, err = config.ToEscapingScheme(cfg.MetricNameEscapingScheme, cfg.MetricNameValidationScheme)
 	if err != nil {
 		return nil, fmt.Errorf("invalid metric name escaping scheme, %w", err)
 	}
@@ -172,7 +168,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed 
 		logger:               logger,
 		metrics:              metrics,
 		httpOpts:             options.HTTPClientOptions,
-		validationScheme:     validationScheme,
+		validationScheme:     cfg.MetricNameValidationScheme,
 		escapingScheme:       escapingScheme,
 	}
 	sp.newLoop = func(opts scrapeLoopOptions) loop {
@@ -325,11 +321,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 	sp.config = cfg
 	oldClient := sp.client
 	sp.client = client
-	validationScheme, err := config.ToValidationScheme(cfg.MetricNameValidationScheme)
-	if err != nil {
-		return fmt.Errorf("invalid metric name validation scheme: %w", err)
-	}
-	sp.validationScheme = validationScheme
+	sp.validationScheme = cfg.MetricNameValidationScheme
 	var escapingScheme model.EscapingScheme
 	escapingScheme, err = model.ToEscapingScheme(cfg.MetricNameEscapingScheme)
 	if err != nil {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -84,7 +84,7 @@ func TestNewScrapePool(t *testing.T) {
 	var (
 		app = &nopAppendable{}
 		cfg = &config.ScrapeConfig{
-			MetricNameValidationScheme: config.UTF8ValidationConfig,
+			MetricNameValidationScheme: model.UTF8Validation,
 			MetricNameEscapingScheme:   model.AllowUTF8,
 		}
 		sp, err = newScrapePool(cfg, app, 0, nil, nil, &Options{}, newTestScrapeMetrics(t))
@@ -327,7 +327,7 @@ func TestDroppedTargetsList(t *testing.T) {
 		cfg = &config.ScrapeConfig{
 			JobName:                    "dropMe",
 			ScrapeInterval:             model.Duration(1),
-			MetricNameValidationScheme: config.UTF8ValidationConfig,
+			MetricNameValidationScheme: model.UTF8Validation,
 			MetricNameEscapingScheme:   model.AllowUTF8,
 			RelabelConfigs: []*relabel.Config{
 				{
@@ -374,7 +374,7 @@ func TestDiscoveredLabelsUpdate(t *testing.T) {
 	sp.config = &config.ScrapeConfig{
 		ScrapeInterval:             model.Duration(1),
 		ScrapeTimeout:              model.Duration(1),
-		MetricNameValidationScheme: config.UTF8ValidationConfig,
+		MetricNameValidationScheme: model.UTF8Validation,
 		MetricNameEscapingScheme:   model.AllowUTF8,
 	}
 	sp.activeTargets = make(map[uint64]*Target)
@@ -506,7 +506,7 @@ func TestScrapePoolReload(t *testing.T) {
 	reloadCfg := &config.ScrapeConfig{
 		ScrapeInterval:             model.Duration(3 * time.Second),
 		ScrapeTimeout:              model.Duration(2 * time.Second),
-		MetricNameValidationScheme: config.UTF8ValidationConfig,
+		MetricNameValidationScheme: model.UTF8Validation,
 		MetricNameEscapingScheme:   model.AllowUTF8,
 	}
 	// On starting to run, new loops created on reload check whether their preceding
@@ -600,7 +600,7 @@ func TestScrapePoolReloadPreserveRelabeledIntervalTimeout(t *testing.T) {
 	reloadCfg := &config.ScrapeConfig{
 		ScrapeInterval:             model.Duration(3 * time.Second),
 		ScrapeTimeout:              model.Duration(2 * time.Second),
-		MetricNameValidationScheme: config.UTF8ValidationConfig,
+		MetricNameValidationScheme: model.UTF8Validation,
 		MetricNameEscapingScheme:   model.AllowUTF8,
 	}
 	newLoop := func(opts scrapeLoopOptions) loop {
@@ -701,7 +701,7 @@ func TestScrapePoolTargetLimit(t *testing.T) {
 		require.NoError(t, sp.reload(&config.ScrapeConfig{
 			ScrapeInterval:             model.Duration(3 * time.Second),
 			ScrapeTimeout:              model.Duration(2 * time.Second),
-			MetricNameValidationScheme: config.UTF8ValidationConfig,
+			MetricNameValidationScheme: model.UTF8Validation,
 			MetricNameEscapingScheme:   model.AllowUTF8,
 			TargetLimit:                l,
 		}))
@@ -791,7 +791,7 @@ func TestScrapePoolTargetLimit(t *testing.T) {
 
 func TestScrapePoolAppender(t *testing.T) {
 	cfg := &config.ScrapeConfig{
-		MetricNameValidationScheme: config.UTF8ValidationConfig,
+		MetricNameValidationScheme: model.UTF8Validation,
 		MetricNameEscapingScheme:   model.AllowUTF8,
 	}
 	app := &nopAppendable{}
@@ -869,7 +869,7 @@ func TestScrapePoolRaces(t *testing.T) {
 		return &config.ScrapeConfig{
 			ScrapeInterval:             interval,
 			ScrapeTimeout:              timeout,
-			MetricNameValidationScheme: config.UTF8ValidationConfig,
+			MetricNameValidationScheme: model.UTF8Validation,
 			MetricNameEscapingScheme:   model.AllowUTF8,
 		}
 	}
@@ -943,7 +943,7 @@ func TestScrapePoolScrapeLoopsStarted(t *testing.T) {
 	require.NoError(t, sp.reload(&config.ScrapeConfig{
 		ScrapeInterval:             model.Duration(3 * time.Second),
 		ScrapeTimeout:              model.Duration(2 * time.Second),
-		MetricNameValidationScheme: config.UTF8ValidationConfig,
+		MetricNameValidationScheme: model.UTF8Validation,
 		MetricNameEscapingScheme:   model.AllowUTF8,
 	}))
 	sp.Sync(tgs)
@@ -3621,14 +3621,14 @@ func TestReuseScrapeCache(t *testing.T) {
 			ScrapeTimeout:              model.Duration(5 * time.Second),
 			ScrapeInterval:             model.Duration(5 * time.Second),
 			MetricsPath:                "/metrics",
-			MetricNameValidationScheme: config.UTF8ValidationConfig,
+			MetricNameValidationScheme: model.UTF8Validation,
 			MetricNameEscapingScheme:   model.AllowUTF8,
 		}
 		sp, _ = newScrapePool(cfg, app, 0, nil, nil, &Options{}, newTestScrapeMetrics(t))
 		t1    = &Target{
 			labels: labels.FromStrings("labelNew", "nameNew", "labelNew1", "nameNew1", "labelNew2", "nameNew2"),
 			scrapeConfig: &config.ScrapeConfig{
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 		}
@@ -3648,7 +3648,7 @@ func TestReuseScrapeCache(t *testing.T) {
 				ScrapeInterval:             model.Duration(5 * time.Second),
 				ScrapeTimeout:              model.Duration(5 * time.Second),
 				MetricsPath:                "/metrics",
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 		},
@@ -3659,7 +3659,7 @@ func TestReuseScrapeCache(t *testing.T) {
 				ScrapeInterval:             model.Duration(5 * time.Second),
 				ScrapeTimeout:              model.Duration(15 * time.Second),
 				MetricsPath:                "/metrics2",
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 		},
@@ -3671,7 +3671,7 @@ func TestReuseScrapeCache(t *testing.T) {
 				ScrapeInterval:             model.Duration(5 * time.Second),
 				ScrapeTimeout:              model.Duration(15 * time.Second),
 				MetricsPath:                "/metrics2",
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 		},
@@ -3684,7 +3684,7 @@ func TestReuseScrapeCache(t *testing.T) {
 				ScrapeInterval:             model.Duration(5 * time.Second),
 				ScrapeTimeout:              model.Duration(15 * time.Second),
 				MetricsPath:                "/metrics2",
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 		},
@@ -3700,7 +3700,7 @@ func TestReuseScrapeCache(t *testing.T) {
 				ScrapeInterval:             model.Duration(5 * time.Second),
 				ScrapeTimeout:              model.Duration(15 * time.Second),
 				MetricsPath:                "/metrics2",
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 		},
@@ -3714,7 +3714,7 @@ func TestReuseScrapeCache(t *testing.T) {
 				ScrapeInterval:             model.Duration(5 * time.Second),
 				ScrapeTimeout:              model.Duration(15 * time.Second),
 				MetricsPath:                "/metrics2",
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 		},
@@ -3726,7 +3726,7 @@ func TestReuseScrapeCache(t *testing.T) {
 				ScrapeTimeout:              model.Duration(15 * time.Second),
 				MetricsPath:                "/metrics",
 				LabelLimit:                 1,
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 		},
@@ -3738,7 +3738,7 @@ func TestReuseScrapeCache(t *testing.T) {
 				ScrapeTimeout:              model.Duration(15 * time.Second),
 				MetricsPath:                "/metrics",
 				LabelLimit:                 15,
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 		},
@@ -3751,7 +3751,7 @@ func TestReuseScrapeCache(t *testing.T) {
 				MetricsPath:                "/metrics",
 				LabelLimit:                 15,
 				LabelNameLengthLimit:       5,
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 		},
@@ -3765,7 +3765,7 @@ func TestReuseScrapeCache(t *testing.T) {
 				LabelLimit:                 15,
 				LabelNameLengthLimit:       5,
 				LabelValueLengthLimit:      7,
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 		},
@@ -3830,7 +3830,7 @@ func TestReuseCacheRace(t *testing.T) {
 			ScrapeTimeout:              model.Duration(5 * time.Second),
 			ScrapeInterval:             model.Duration(5 * time.Second),
 			MetricsPath:                "/metrics",
-			MetricNameValidationScheme: config.UTF8ValidationConfig,
+			MetricNameValidationScheme: model.UTF8Validation,
 			MetricNameEscapingScheme:   model.AllowUTF8,
 		}
 		buffers = pool.New(1e3, 100e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
@@ -3854,7 +3854,7 @@ func TestReuseCacheRace(t *testing.T) {
 			ScrapeInterval:             model.Duration(1 * time.Millisecond),
 			MetricsPath:                "/metrics",
 			SampleLimit:                i,
-			MetricNameValidationScheme: config.UTF8ValidationConfig,
+			MetricNameValidationScheme: model.UTF8Validation,
 			MetricNameEscapingScheme:   model.AllowUTF8,
 		})
 	}
@@ -3932,7 +3932,7 @@ func TestScrapeReportLimit(t *testing.T) {
 		Scheme:                     "http",
 		ScrapeInterval:             model.Duration(100 * time.Millisecond),
 		ScrapeTimeout:              model.Duration(100 * time.Millisecond),
-		MetricNameValidationScheme: config.UTF8ValidationConfig,
+		MetricNameValidationScheme: model.UTF8Validation,
 		MetricNameEscapingScheme:   model.AllowUTF8,
 	}
 
@@ -3988,7 +3988,7 @@ func TestScrapeUTF8(t *testing.T) {
 		Scheme:                     "http",
 		ScrapeInterval:             model.Duration(100 * time.Millisecond),
 		ScrapeTimeout:              model.Duration(100 * time.Millisecond),
-		MetricNameValidationScheme: config.UTF8ValidationConfig,
+		MetricNameValidationScheme: model.UTF8Validation,
 		MetricNameEscapingScheme:   model.AllowUTF8,
 	}
 	ts, scrapedTwice := newScrapableServer("{\"with.dots\"} 42\n")
@@ -4124,7 +4124,7 @@ func TestTargetScrapeIntervalAndTimeoutRelabel(t *testing.T) {
 	config := &config.ScrapeConfig{
 		ScrapeInterval:             interval,
 		ScrapeTimeout:              timeout,
-		MetricNameValidationScheme: config.UTF8ValidationConfig,
+		MetricNameValidationScheme: model.UTF8Validation,
 		MetricNameEscapingScheme:   model.AllowUTF8,
 		RelabelConfigs: []*relabel.Config{
 			{
@@ -4186,7 +4186,7 @@ func TestLeQuantileReLabel(t *testing.T) {
 		Scheme:                     "http",
 		ScrapeInterval:             model.Duration(100 * time.Millisecond),
 		ScrapeTimeout:              model.Duration(100 * time.Millisecond),
-		MetricNameValidationScheme: config.UTF8ValidationConfig,
+		MetricNameValidationScheme: model.UTF8Validation,
 		MetricNameEscapingScheme:   model.AllowUTF8,
 	}
 
@@ -4698,7 +4698,7 @@ metric: <
 					ScrapeTimeout:                  model.Duration(25 * time.Millisecond),
 					AlwaysScrapeClassicHistograms:  tc.alwaysScrapeClassicHistograms,
 					ConvertClassicHistogramsToNHCB: tc.convertClassicHistToNHCB,
-					MetricNameValidationScheme:     config.UTF8ValidationConfig,
+					MetricNameValidationScheme:     model.UTF8Validation,
 					MetricNameEscapingScheme:       model.AllowUTF8,
 				}
 
@@ -4826,7 +4826,7 @@ func TestTypeUnitReLabel(t *testing.T) {
 		Scheme:                     "http",
 		ScrapeInterval:             model.Duration(100 * time.Millisecond),
 		ScrapeTimeout:              model.Duration(100 * time.Millisecond),
-		MetricNameValidationScheme: config.UTF8ValidationConfig,
+		MetricNameValidationScheme: model.UTF8Validation,
 		MetricNameEscapingScheme:   model.AllowUTF8,
 	}
 
@@ -4967,7 +4967,7 @@ func TestScrapeLoopCompression(t *testing.T) {
 				ScrapeInterval:             model.Duration(100 * time.Millisecond),
 				ScrapeTimeout:              model.Duration(100 * time.Millisecond),
 				EnableCompression:          tc.enableCompression,
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			}
 
@@ -5123,7 +5123,7 @@ func BenchmarkTargetScraperGzip(b *testing.B) {
 						model.AddressLabel, serverURL.Host,
 					),
 					scrapeConfig: &config.ScrapeConfig{
-						MetricNameValidationScheme: config.UTF8ValidationConfig,
+						MetricNameValidationScheme: model.UTF8Validation,
 						MetricNameEscapingScheme:   model.AllowUTF8,
 						Params:                     url.Values{"count": []string{strconv.Itoa(scenario.metricsCount)}},
 					},
@@ -5379,7 +5379,7 @@ func TestTargetScrapeConfigWithLabels(t *testing.T) {
 				JobName:                    jobName,
 				Scheme:                     httpScheme,
 				MetricsPath:                expectedPath,
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 			},
 			targets: []*targetgroup.Group{
@@ -5398,7 +5398,7 @@ func TestTargetScrapeConfigWithLabels(t *testing.T) {
 				JobName:                    jobName,
 				Scheme:                     httpScheme,
 				MetricsPath:                secondPath,
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 				Params:                     url.Values{"param": []string{secondParam}},
 			},
@@ -5423,7 +5423,7 @@ func TestTargetScrapeConfigWithLabels(t *testing.T) {
 				JobName:                    jobName,
 				Scheme:                     httpScheme,
 				MetricsPath:                secondPath,
-				MetricNameValidationScheme: config.UTF8ValidationConfig,
+				MetricNameValidationScheme: model.UTF8Validation,
 				MetricNameEscapingScheme:   model.AllowUTF8,
 				Params:                     url.Values{"param": []string{secondParam}},
 				RelabelConfigs: []*relabel.Config{
@@ -5504,7 +5504,7 @@ func TestScrapePoolScrapeAfterReload(t *testing.T) {
 		Scheme:                     "http",
 		ScrapeInterval:             model.Duration(100 * time.Millisecond),
 		ScrapeTimeout:              model.Duration(100 * time.Millisecond),
-		MetricNameValidationScheme: config.UTF8ValidationConfig,
+		MetricNameValidationScheme: model.UTF8Validation,
 		MetricNameEscapingScheme:   model.AllowUTF8,
 		EnableCompression:          false,
 		ServiceDiscoveryConfigs: discovery.Configs{


### PR DESCRIPTION
Consolidate around `prometheus/common/model.ValidationScheme`, dropping the duplicated representations `config.LegacyValidationConfig` and `config.UTF8ValidationConfig`.

This is made possible by a change to prometheus/common in https://github.com/prometheus/common/pull/799, where `model.ValidationScheme` becomes YAML serializable, so I'm upgrading to prometheus/common@main.