### PR TITLE
mixin: add uid to prometheus overview dashboard

### DIFF
--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -445,6 +445,7 @@ local row = panel.row;
       dashboard.new('%(prefix)sOverview' % $._config.grafanaPrometheus)
       + dashboard.time.withFrom('now-1h')
       + dashboard.withTags($._config.grafanaPrometheus.tags)
+      + dashboard.withUid('9fa0d141-d019-4ad7-8bc5-42196ee308bd')
       + dashboard.timepicker.withRefreshIntervals($._config.grafanaPrometheus.refresh)
       + dashboard.withVariables(std.prune([
         datasourceVariable,


### PR DESCRIPTION
 [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) uses the mixin in a sidecar and for me it's recreating the same dashboard over and over again. The reason is probably that Grafana started to allow having multiple dashboards with the same title (https://github.com/grafana/grafana/issues/105077) and Grafana no longer properly handles provisioning dashboards using a configmap if they don't have a uid (https://github.com/grafana/grafana/issues/101397). I hope this will be fixed in Grafana but adding the uid seems like an easier solution.

