### PR TITLE
tsdb: add count of histogram samples to block stats

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -188,10 +188,11 @@ type BlockMeta struct {
 
 // BlockStats contains stats about contents of a block.
 type BlockStats struct {
-	NumSamples    uint64 `json:"numSamples,omitempty"`
-	NumSeries     uint64 `json:"numSeries,omitempty"`
-	NumChunks     uint64 `json:"numChunks,omitempty"`
-	NumTombstones uint64 `json:"numTombstones,omitempty"`
+	NumSamples          uint64 `json:"numSamples,omitempty"`
+	NumHistogramSamples uint64 `json:"numHistogramSamples,omitempty"`
+	NumSeries           uint64 `json:"numSeries,omitempty"`
+	NumChunks           uint64 `json:"numChunks,omitempty"`
+	NumTombstones       uint64 `json:"numTombstones,omitempty"`
 }
 
 // BlockDesc describes a block by ULID and time range.

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -896,6 +896,10 @@ func (c DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compa
 		meta.Stats.NumSeries++
 		for _, chk := range chks {
 			meta.Stats.NumSamples += uint64(chk.Chunk.NumSamples())
+			enc := chk.Chunk.Encoding()
+			if enc == chunkenc.EncHistogram || enc == chunkenc.EncFloatHistogram {
+				meta.Stats.NumHistogramSamples += uint64(chk.Chunk.NumSamples())
+			}
 		}
 
 		for _, chk := range chks {

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1098,6 +1098,11 @@ func TestCompaction_populateBlock(t *testing.T) {
 				s.NumChunks += uint64(len(series.chunks))
 				for _, chk := range series.chunks {
 					s.NumSamples += uint64(len(chk))
+					for _, smpl := range chk {
+						if smpl.h != nil || smpl.fh != nil {
+							s.NumHistogramSamples++
+						}
+					}
 				}
 			}
 			require.Equal(t, s, meta.Stats)


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Currently TSDB metadata tracks the following stats
```
type BlockStats struct {
	NumSamples          uint64 `json:"numSamples,omitempty"`
	NumSeries           uint64 `json:"numSeries,omitempty"`
	NumChunks           uint64 `json:"numChunks,omitempty"`
	NumTombstones       uint64 `json:"numTombstones,omitempty"`
}
```

Native histogram samples have different properties compared to normal float/int samples, and can vary a lot in size. While they are counted as samples in `numSamples`, it is useful to have a separate metric that tracks how many native histograms samples there are in a block. 

The PR introduces this `numHistogramSamples` stat without touching any of the other existing stats.
```
	NumHistogramSamples uint64 `json:"numHistogramSamples,omitempty"`
```
