### PR TITLE
PoC for approach (3): limit histogram extrapolation to assumed zero point

### DIFF
--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1041,11 +1041,15 @@ eval_warn instant at 1m rate(some_metric[1m30s])
 eval_warn instant at 1m30s rate(some_metric[1m30s])
     # Should produce no results.
 
-# Start with custom, end with exponential. Return the exponential histogram divided by 30.
+# Start with custom, end with exponential. Return the exponential histogram divided by 48.
+# (The 1st sample is the NHCB with count:1. It is mostly ignored with the exception of the
+# count, which means the rate calculation extrapolates until the count hits 0.)
 eval instant at 1m rate(some_metric[1m])
-    {} {{schema:0 sum:0.16666666666666666 count:0.13333333333333333 buckets:[0.03333333333333333 0.06666666666666667 0.03333333333333333]}}
+    {} {{count:0.08333333333333333 sum:0.10416666666666666 counter_reset_hint:gauge buckets:[0.020833333333333332 0.041666666666666664 0.020833333333333332]}}
 
 # Start with exponential, end with custom. Return the custom buckets histogram divided by 30.
+# (With the 2nd sample having a count of 1, the extrapolation to zero lands exactly at the
+# left boundary of the range, so no extrapolation limitation needed.)
 eval instant at 30s rate(some_metric[1m])
     {} {{schema:-53 sum:0.03333333333333333 count:0.03333333333333333 custom_values:[5 10] buckets:[0.03333333333333333]}}
 
@@ -1376,21 +1380,22 @@ eval instant at 1m histogram_fraction(-Inf, +Inf, histogram_nan)
 
 clear
 
-# Tests to demonstrate how an extrapolation below zero is prevented for a float counter, but not for native histograms.
-# I.e. the float counter that behaves the same as the histogram count might yield a different result after `increase`.
+# Tests to demonstrate how an extrapolation below zero is prevented for both float counters and native counter histograms.
+# Note that the float counter behaves the same as the histogram count after `increase`.
 
 load 1m
   metric{type="histogram"} {{schema:0 count:15 sum:25 buckets:[5 10]}} {{schema:0 count:2490 sum:75 buckets:[15 2475]}}x55
   metric{type="counter"} 15 2490x55
 
 # End of range coincides with sample. Zero point of count is reached within the range.
+# As a result, we get the same as the last sample in the range as a result.
 eval instant at 55m increase(metric[90m])
-    {type="histogram"} {{count:2497.5 sum:50.45454545454545 counter_reset_hint:gauge buckets:[10.09090909090909 2487.409090909091]}}
+    {type="histogram"} {{count:2490 sum:75 counter_reset_hint:gauge buckets:[15 2475]}}
     {type="counter"} 2490
 
 # End of range does not coincide with sample. Zero point of count is reached within the range.
 eval instant at 54m30s increase(metric[90m])
-    {type="histogram"} {{count:2520.8333333333335 sum:50.92592592592593 counter_reset_hint:gauge buckets:[10.185185185185187 2510.6481481481483]}}
+    {type="histogram"} {{count:2512.9166666666665 sum:75.46296296296296 counter_reset_hint:gauge buckets:[15.092592592592593 2497.8240740740744]}}
     {type="counter"} 2512.9166666666665
     
 # End of range coincides with sample. Zero point of count is reached outside of (i.e. before) the range.

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1373,3 +1373,40 @@ eval instant at 1m histogram_fraction(-Inf, +Inf, histogram_nan)
     expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions for metric name "histogram_nan"
     {case="100% NaNs"} 0.0
     {case="20% NaNs"} 0.8
+
+clear
+
+# Tests to demonstrate how an extrapolation below zero is prevented for a float counter, but not for native histograms.
+# I.e. the float counter that behaves the same as the histogram count might yield a different result after `increase`.
+
+load 1m
+  metric{type="histogram"} {{schema:0 count:15 sum:25 buckets:[5 10]}} {{schema:0 count:2490 sum:75 buckets:[15 2475]}}x55
+  metric{type="counter"} 15 2490x55
+
+# End of range coincides with sample. Zero point of count is reached within the range.
+eval instant at 55m increase(metric[90m])
+    {type="histogram"} {{count:2497.5 sum:50.45454545454545 counter_reset_hint:gauge buckets:[10.09090909090909 2487.409090909091]}}
+    {type="counter"} 2490
+
+# End of range does not coincide with sample. Zero point of count is reached within the range.
+eval instant at 54m30s increase(metric[90m])
+    {type="histogram"} {{count:2520.8333333333335 sum:50.92592592592593 counter_reset_hint:gauge buckets:[10.185185185185187 2510.6481481481483]}}
+    {type="counter"} 2512.9166666666665
+    
+# End of range coincides with sample. Zero point of count is reached outside of (i.e. before) the range.
+# This means no change of extrapolation is required for the histogram count (and neither for the float counter),
+# however, the 2nd bucket's extrapolation will reach zero within the range. The overestimation is visible
+# easily here because the last sample in the range coincides with the boundary, where the 2nd bucket has
+# a value of 2475 but has increased by 2476.2045454545455 according to the returned result.
+eval instant at 55m increase(metric[55m15s])
+    {type="histogram"} {{count:2486.25 sum:50.227272727272734 counter_reset_hint:gauge buckets:[10.045454545454547 2476.2045454545455]}}
+    {type="counter"} 2486.25
+
+# End of range does not coincide with sample. Zero point of count is reached outside of (i.e. before) the range.
+# This means no change of extrapolation is required for the histogram count (and neither for the float counter),
+# however, the 2nd bucket's extrapolation will reach zero within the range.
+eval instant at 54m30s increase(metric[54m45s])
+    {type="histogram"} {{count:2509.375 sum:50.69444444444444 counter_reset_hint:gauge buckets:[10.13888888888889 2499.236111111111]}}
+    {type="counter"} 2509.375
+
+    


### PR DESCRIPTION
This is approach (3) in
https://github.com/prometheus/prometheus/issues/15976#issuecomment-3032095158

If we have limited the extrapolation of the count in a native
histogram, we manipulate the rest of the histogram around the
assumption that the zero point of the count is indeed the zero point
of the whole histogram. So we change the sum and all buckets including
the zero bucket in a way that it also reaches zero at the same point.
This keeps the histogram consistent by redistributing observations
between the buckets.

Cons I can think about right now:

- Our neat trick of ignoring incompatible bucket layouts of the 1st
  sample in case of a counter reset between the 1st and 2nd sample
  doesn't work anymore. (But it's probably not a big deal to drop this
  rarely relevant tweak.)

- If the extrapolation of count does _not_ go below zero, we do not
  change any of the other fields. However, they might still be
  extrapolated belew zero individually. This is maybe less of a deal
  with sum, as it could legitimately be below zero, but it will lead
  to exaggeration of some buckets in the result.

- The former point implies another weird behavior: If we change from a
  scenario where the count is very close to be extrapolated below zero
  to a scenario where the extrapolation of the count is limited by a
  small amount, the count will indeed only change by an infinitesimal
  amount. However, the individual buckets or the sum might change by a
  whole lot because suddenly we "switch on" the adjustment that was
  missing before.

Especially the latter point gives me headaches right now. We could go even further and assume zero points even before the range, still based on count. But maybe the assumption of a zero point solely based on the count is way too weak anyway.

Looking at the tests, we can also see how the sum changes quite significantly. However, changing just buckets but not the sum seems wrong to me.

An interesting point is to compare the test results here with the results for approach (4) #16791. In the cases where we do limit the count extrapolation, they are indeed the same, with the notable (and deliberate) exception of the `sum`.