### PR TITLE
chore: add Makefile target to check Node.js version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ ui-lint:
 
 .PHONY: assets
 ifndef SKIP_UI_BUILD
-assets: ui-install ui-build
+assets: check-node-version ui-install ui-build
 
 .PHONY: npm_licenses
 npm_licenses: ui-install
@@ -143,7 +143,7 @@ install-goyacc:
 ifeq ($(GO_ONLY),1)
 test: common-test check-go-mod-version
 else
-test: check-generated-parser common-test ui-build-module ui-test ui-lint check-go-mod-version
+test: check-generated-parser common-test check-node-version ui-build-module ui-test ui-lint check-go-mod-version
 endif
 
 .PHONY: tarball
@@ -192,3 +192,7 @@ update-all-go-deps:
 		$(GO) get -d $$m; \
 	done
 	@cd ./documentation/examples/remote_storage/ && $(GO) mod tidy
+
+.PHONY: check-node-version
+check-node-version:
+	@./scripts/check-node-version.sh

--- a/scripts/check-node-version.sh
+++ b/scripts/check-node-version.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+MIN_NODE_VERSION=$(cat web/ui/.nvmrc | sed 's/v//')
+CURRENT_NODE_VERSION=$(node --version | sed 's/v//')
+
+if [ "$(echo -e "$CURRENT_NODE_VERSION\n$MIN_NODE_VERSION" | sort -V | head -n 1)" != "$MIN_NODE_VERSION" ]; then
+    printf "${YELLOW}Warning:${NC}: Node.js version mismatch! Required minimum: $MIN_NODE_VERSION Installed version: $CURRENT_NODE_VERSION\n"
+fi


### PR DESCRIPTION
This helps reduce confusion when UI-related targets fail without directly indicating a version mismatch.

Automatically runs during UI builds and tests. The check is only indicative.

The "go" binary can hard stop and print relevant messages on its own for mismatches, thus not covered here.

supersedes https://github.com/prometheus/prometheus/pull/15106

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
