### PR TITLE
model/textparse: Remove unit validation in protobuf parsing

### DIFF
--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math"
 	"strconv"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/cespare/xxhash/v2"
@@ -518,6 +519,13 @@ func (p *OpenMetricsParser) Next() (Entry, error) {
 		case tType:
 			return EntryType, nil
 		case tUnit:
+			p.unit = string(p.text)
+			m := yoloString(p.l.b[p.offsets[0]:p.offsets[1]])
+			if len(p.unit) > 0 {
+				if !strings.HasSuffix(m, p.unit) || len(m) < len(p.unit)+1 || p.l.b[p.offsets[1]-len(p.unit)-1] != '_' {
+					return EntryInvalid, fmt.Errorf("unit %q not a suffix of metric %q", p.unit, m)
+				}
+			}
 			return EntryUnit, nil
 		}
 

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -814,6 +814,18 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 			err:   "expected text in TYPE",
 		},
 		{
+			input: "# UNIT metric suffix\n#EOF\n",
+			err:   "unit \"suffix\" not a suffix of metric \"metric\"",
+		},
+		{
+			input: "# UNIT metricsuffix suffix\n#EOF\n",
+			err:   "unit \"suffix\" not a suffix of metric \"metricsuffix\"",
+		},
+		{
+			input: "# UNIT m suffix\n#EOF\n",
+			err:   "unit \"suffix\" not a suffix of metric \"m\"",
+		},
+		{
 			input: "# UNIT \n#EOF\n",
 			err:   "expected metric name after UNIT, got \"\\n\" (\"INVALID\") while parsing: \"# UNIT \\n\"",
 		},


### PR DESCRIPTION
<!--
    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.
 -->

Fixes #16639.

This is needed to use a non-translation-mode with protobuf scraping. Otherwise, metrics that specify a UNIT in their metadata but do not have that same unit as part of their metric name (as it is generally the case for OTel semantic conventions) will be rejected in protobuf-based scrapes.

```release-notes
[ENHANCEMENT] Scrapes with the classic protobuf format do not require the unit from the metadata to show up in the metric name anymore. #16834
```