### PR TITLE
rulefmt: fix description annotation index in TestParseFileSuccessWith…

### DIFF
--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -49,7 +49,7 @@ sum without(instance) (rate(requests_total[5m]))
 
 		require.Equal(t, "HighAlert", rg.Rules[2].Alert)
 		require.Equal(t, "critical", rg.Rules[2].Labels["severity"])
-		require.Equal(t, "stuff's happening with {{ $.labels.service }}", rg.Rules[0].Annotations["description"])
+		require.Equal(t, "stuff's happening with {{ $.labels.service }}", rg.Rules[2].Annotations["description"])
 
 		require.Equal(t, "HighAlert2", rg.Rules[3].Alert)
 		require.Equal(t, "critical", rg.Rules[3].Labels["severity"])


### PR DESCRIPTION
…Aliases

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR fixes an incorrect test assertion in TestParseFileSuccessWithAliases. The description annotation for the alert rule at index 2 was being asserted using rg.Rules[0], which seems to me was likely a copy-paste mistake.

/cc @machine424