### PR TITLE
Revert: OTLP Support including scope metadata as metric labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * [FEATURE] PromQL: Add experimental type and unit metadata labels, behind feature flag `type-and-unit-labels`. #16228 #16632 #16718 #16743
 * [FEATURE] PromQL: Add `ts_of_(min|max|last)_over_time`, behind feature flag `experimental-promql-functions`. #16722 #16733
 * [FEATURE] Scraping: Add global option `always_scrape_classic_histograms` to scrape a classic histogram even if it is also exposed as native. #16452
-* [FEATURE] OTLP: Support promoting OTel scope name/version/schema URL/attributes as metric labels, via `otlp.promote_scope_metadata`. #16730 #16760
 * [FEATURE] OTLP: New config options `promote_all_resource_attributes` and `ignore_resource_attributes`. #16426
 * [FEATURE] Discovery: New service discovery for STACKIT Cloud. #16401
 * [ENHANCEMENT] Hetzner SD: Add `label_selector` to filter servers. #16512

--- a/config/config.go
+++ b/config/config.go
@@ -1588,9 +1588,6 @@ type OTLPConfig struct {
 	TranslationStrategy               translationStrategyOption `yaml:"translation_strategy,omitempty"`
 	KeepIdentifyingResourceAttributes bool                      `yaml:"keep_identifying_resource_attributes,omitempty"`
 	ConvertHistogramsToNHCB           bool                      `yaml:"convert_histograms_to_nhcb,omitempty"`
-	// PromoteScopeMetadata controls whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
-	// As per OTel spec, the aforementioned scope metadata should be identifying, i.e. made into metric labels.
-	PromoteScopeMetadata bool `yaml:"promote_scope_metadata,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1808,20 +1808,6 @@ func TestOTLPConvertHistogramsToNHCB(t *testing.T) {
 	})
 }
 
-func TestOTLPPromoteScopeMetadata(t *testing.T) {
-	t.Run("good config", func(t *testing.T) {
-		want, err := LoadFile(filepath.Join("testdata", "otlp_promote_scope_metadata.good.yml"), false, promslog.NewNopLogger())
-		require.NoError(t, err)
-
-		out, err := yaml.Marshal(want)
-		require.NoError(t, err)
-		var got Config
-		require.NoError(t, yaml.UnmarshalStrict(out, &got))
-
-		require.True(t, got.OTLPConfig.PromoteScopeMetadata)
-	})
-}
-
 func TestOTLPAllowUTF8(t *testing.T) {
 	t.Run("good config - NoUTF8EscapingWithSuffixes", func(t *testing.T) {
 		fpath := filepath.Join("testdata", "otlp_allow_utf8.good.yml")

--- a/config/testdata/otlp_promote_scope_metadata.good.yml
+++ b/config/testdata/otlp_promote_scope_metadata.good.yml
@@ -1,2 +1,0 @@
-otlp:
-  promote_scope_metadata: true

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -214,9 +214,6 @@ otlp:
   [ keep_identifying_resource_attributes: <boolean> | default = false ]
   # Configures optional translation of OTLP explicit bucket histograms into native histograms with custom buckets.
   [ convert_histograms_to_nhcb: <boolean> | default = false ]
-  # Enables promotion of OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
-  # This is disabled by default for backwards compatibility, but according to OTel spec, scope metadata _should_ be identifying, i.e. translated to metric labels.
-  [ promote_scope_metadata: <boolean> | default = false ]
 
 # Settings related to the remote read feature.
 remote_read:

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
@@ -43,17 +43,6 @@ func TestCreateAttributes(t *testing.T) {
 		// This one is for testing conflict with auto-generated instance attribute.
 		"instance": "resource value",
 	}
-	scopeAttrs := pcommon.NewMap()
-	scopeAttrs.FromRaw(map[string]any{
-		"attr1": "value1",
-		"attr2": "value2",
-	})
-	defaultScope := scope{
-		name:       "test-scope",
-		version:    "1.0.0",
-		schemaURL:  "https://schema.com",
-		attributes: scopeAttrs,
-	}
 
 	resource := pcommon.NewResource()
 	for k, v := range resourceAttrs {
@@ -65,19 +54,15 @@ func TestCreateAttributes(t *testing.T) {
 
 	testCases := []struct {
 		name                         string
-		scope                        scope
 		promoteAllResourceAttributes bool
 		promoteResourceAttributes    []string
-		promoteScope                 bool
 		ignoreResourceAttributes     []string
 		ignoreAttrs                  []string
 		expectedLabels               []prompb.Label
 	}{
 		{
-			name:                      "Successful conversion without resource attribute promotion and without scope promotion",
-			scope:                     defaultScope,
+			name:                      "Successful conversion without resource attribute promotion",
 			promoteResourceAttributes: nil,
-			promoteScope:              false,
 			expectedLabels: []prompb.Label{
 				{
 					Name:  "__name__",
@@ -102,86 +87,8 @@ func TestCreateAttributes(t *testing.T) {
 			},
 		},
 		{
-			name:                      "Successful conversion without resource attribute promotion and with scope promotion",
-			scope:                     defaultScope,
+			name:                      "Successful conversion with some attributes ignored",
 			promoteResourceAttributes: nil,
-			promoteScope:              true,
-			expectedLabels: []prompb.Label{
-				{
-					Name:  "__name__",
-					Value: "test_metric",
-				},
-				{
-					Name:  "instance",
-					Value: "service ID",
-				},
-				{
-					Name:  "job",
-					Value: "service name",
-				},
-				{
-					Name:  "metric_attr",
-					Value: "metric value",
-				},
-				{
-					Name:  "metric_attr_other",
-					Value: "metric value other",
-				},
-				{
-					Name:  "otel_scope_name",
-					Value: defaultScope.name,
-				},
-				{
-					Name:  "otel_scope_schema_url",
-					Value: defaultScope.schemaURL,
-				},
-				{
-					Name:  "otel_scope_version",
-					Value: defaultScope.version,
-				},
-				{
-					Name:  "otel_scope_attr1",
-					Value: "value1",
-				},
-				{
-					Name:  "otel_scope_attr2",
-					Value: "value2",
-				},
-			},
-		},
-		{
-			name:                      "Successful conversion without resource attribute promotion and with scope promotion, but without scope",
-			scope:                     scope{},
-			promoteResourceAttributes: nil,
-			promoteScope:              true,
-			expectedLabels: []prompb.Label{
-				{
-					Name:  "__name__",
-					Value: "test_metric",
-				},
-				{
-					Name:  "instance",
-					Value: "service ID",
-				},
-				{
-					Name:  "job",
-					Value: "service name",
-				},
-				{
-					Name:  "metric_attr",
-					Value: "metric value",
-				},
-				{
-					Name:  "metric_attr_other",
-					Value: "metric value other",
-				},
-			},
-		},
-		{
-			name:                      "Successful conversion with some attributes ignored and with scope promotion",
-			scope:                     defaultScope,
-			promoteResourceAttributes: nil,
-			promoteScope:              true,
 			ignoreAttrs:               []string{"metric-attr-other"},
 			expectedLabels: []prompb.Label{
 				{
@@ -200,33 +107,11 @@ func TestCreateAttributes(t *testing.T) {
 					Name:  "metric_attr",
 					Value: "metric value",
 				},
-				{
-					Name:  "otel_scope_name",
-					Value: defaultScope.name,
-				},
-				{
-					Name:  "otel_scope_schema_url",
-					Value: defaultScope.schemaURL,
-				},
-				{
-					Name:  "otel_scope_version",
-					Value: defaultScope.version,
-				},
-				{
-					Name:  "otel_scope_attr1",
-					Value: "value1",
-				},
-				{
-					Name:  "otel_scope_attr2",
-					Value: "value2",
-				},
 			},
 		},
 		{
-			name:                      "Successful conversion with resource attribute promotion and with scope promotion",
-			scope:                     defaultScope,
+			name:                      "Successful conversion with resource attribute promotion",
 			promoteResourceAttributes: []string{"non-existent-attr", "existent-attr"},
-			promoteScope:              true,
 			expectedLabels: []prompb.Label{
 				{
 					Name:  "__name__",
@@ -252,33 +137,11 @@ func TestCreateAttributes(t *testing.T) {
 					Name:  "existent_attr",
 					Value: "resource value",
 				},
-				{
-					Name:  "otel_scope_name",
-					Value: defaultScope.name,
-				},
-				{
-					Name:  "otel_scope_schema_url",
-					Value: defaultScope.schemaURL,
-				},
-				{
-					Name:  "otel_scope_version",
-					Value: defaultScope.version,
-				},
-				{
-					Name:  "otel_scope_attr1",
-					Value: "value1",
-				},
-				{
-					Name:  "otel_scope_attr2",
-					Value: "value2",
-				},
 			},
 		},
 		{
-			name:                      "Successful conversion with resource attribute promotion and with scope promotion, conflicting resource attributes are ignored",
-			scope:                     defaultScope,
+			name:                      "Successful conversion with resource attribute promotion, conflicting resource attributes are ignored",
 			promoteResourceAttributes: []string{"non-existent-attr", "existent-attr", "metric-attr", "job", "instance"},
-			promoteScope:              true,
 			expectedLabels: []prompb.Label{
 				{
 					Name:  "__name__",
@@ -304,33 +167,11 @@ func TestCreateAttributes(t *testing.T) {
 					Name:  "metric_attr_other",
 					Value: "metric value other",
 				},
-				{
-					Name:  "otel_scope_name",
-					Value: defaultScope.name,
-				},
-				{
-					Name:  "otel_scope_schema_url",
-					Value: defaultScope.schemaURL,
-				},
-				{
-					Name:  "otel_scope_version",
-					Value: defaultScope.version,
-				},
-				{
-					Name:  "otel_scope_attr1",
-					Value: "value1",
-				},
-				{
-					Name:  "otel_scope_attr2",
-					Value: "value2",
-				},
 			},
 		},
 		{
-			name:                      "Successful conversion with resource attribute promotion and with scope promotion, attributes are only promoted once",
-			scope:                     defaultScope,
+			name:                      "Successful conversion with resource attribute promotion, attributes are only promoted once",
 			promoteResourceAttributes: []string{"existent-attr", "existent-attr"},
-			promoteScope:              true,
 			expectedLabels: []prompb.Label{
 				{
 					Name:  "__name__",
@@ -356,33 +197,11 @@ func TestCreateAttributes(t *testing.T) {
 					Name:  "metric_attr_other",
 					Value: "metric value other",
 				},
-				{
-					Name:  "otel_scope_name",
-					Value: defaultScope.name,
-				},
-				{
-					Name:  "otel_scope_schema_url",
-					Value: defaultScope.schemaURL,
-				},
-				{
-					Name:  "otel_scope_version",
-					Value: defaultScope.version,
-				},
-				{
-					Name:  "otel_scope_attr1",
-					Value: "value1",
-				},
-				{
-					Name:  "otel_scope_attr2",
-					Value: "value2",
-				},
 			},
 		},
 		{
-			name:                         "Successful conversion promoting all resource attributes and with scope promotion",
-			scope:                        defaultScope,
+			name:                         "Successful conversion promoting all resource attributes",
 			promoteAllResourceAttributes: true,
-			promoteScope:                 true,
 			expectedLabels: []prompb.Label{
 				{
 					Name:  "__name__",
@@ -416,33 +235,11 @@ func TestCreateAttributes(t *testing.T) {
 					Name:  "service_instance_id",
 					Value: "service ID",
 				},
-				{
-					Name:  "otel_scope_name",
-					Value: defaultScope.name,
-				},
-				{
-					Name:  "otel_scope_schema_url",
-					Value: defaultScope.schemaURL,
-				},
-				{
-					Name:  "otel_scope_version",
-					Value: defaultScope.version,
-				},
-				{
-					Name:  "otel_scope_attr1",
-					Value: "value1",
-				},
-				{
-					Name:  "otel_scope_attr2",
-					Value: "value2",
-				},
 			},
 		},
 		{
-			name:                         "Successful conversion promoting all resource attributes and with scope promotion, ignoring 'service.instance.id'",
-			scope:                        defaultScope,
+			name:                         "Successful conversion promoting all resource attributes, ignoring 'service.instance.id'",
 			promoteAllResourceAttributes: true,
-			promoteScope:                 true,
 			ignoreResourceAttributes: []string{
 				"service.instance.id",
 			},
@@ -475,26 +272,6 @@ func TestCreateAttributes(t *testing.T) {
 					Name:  "service_name",
 					Value: "service name",
 				},
-				{
-					Name:  "otel_scope_name",
-					Value: defaultScope.name,
-				},
-				{
-					Name:  "otel_scope_schema_url",
-					Value: defaultScope.schemaURL,
-				},
-				{
-					Name:  "otel_scope_version",
-					Value: defaultScope.version,
-				},
-				{
-					Name:  "otel_scope_attr1",
-					Value: "value1",
-				},
-				{
-					Name:  "otel_scope_attr2",
-					Value: "value2",
-				},
 			},
 		},
 	}
@@ -506,9 +283,8 @@ func TestCreateAttributes(t *testing.T) {
 					PromoteResourceAttributes:    tc.promoteResourceAttributes,
 					IgnoreResourceAttributes:     tc.ignoreResourceAttributes,
 				}),
-				PromoteScopeMetadata: tc.promoteScope,
 			}
-			lbls := createAttributes(resource, attrs, tc.scope, settings, tc.ignoreAttrs, false, model.MetricNameLabel, "test_metric")
+			lbls := createAttributes(resource, attrs, settings, tc.ignoreAttrs, false, model.MetricNameLabel, "test_metric")
 
 			require.ElementsMatch(t, lbls, tc.expectedLabels)
 		})
@@ -534,28 +310,14 @@ func Test_convertTimeStamp(t *testing.T) {
 }
 
 func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
-	scopeAttrs := pcommon.NewMap()
-	scopeAttrs.FromRaw(map[string]any{
-		"attr1": "value1",
-		"attr2": "value2",
-	})
-	defaultScope := scope{
-		name:       "test-scope",
-		version:    "1.0.0",
-		schemaURL:  "https://schema.com",
-		attributes: scopeAttrs,
-	}
-
 	ts := pcommon.Timestamp(time.Now().UnixNano())
 	tests := []struct {
-		name         string
-		metric       func() pmetric.Metric
-		scope        scope
-		promoteScope bool
-		want         func() map[uint64]*prompb.TimeSeries
+		name   string
+		metric func() pmetric.Metric
+		want   func() map[uint64]*prompb.TimeSeries
 	}{
 		{
-			name: "summary with start time and without scope promotion",
+			name: "summary with start time",
 			metric: func() pmetric.Metric {
 				metric := pmetric.NewMetric()
 				metric.SetName("test_summary")
@@ -567,8 +329,6 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 
 				return metric
 			},
-			scope:        defaultScope,
-			promoteScope: false,
 			want: func() map[uint64]*prompb.TimeSeries {
 				countLabels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_summary" + countStr},
@@ -602,79 +362,7 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 			},
 		},
 		{
-			name: "summary with start time and with scope promotion",
-			metric: func() pmetric.Metric {
-				metric := pmetric.NewMetric()
-				metric.SetName("test_summary")
-				metric.SetEmptySummary()
-
-				dp := metric.Summary().DataPoints().AppendEmpty()
-				dp.SetTimestamp(ts)
-				dp.SetStartTimestamp(ts)
-
-				return metric
-			},
-			scope:        defaultScope,
-			promoteScope: true,
-			want: func() map[uint64]*prompb.TimeSeries {
-				scopeLabels := []prompb.Label{
-					{
-						Name:  "otel_scope_attr1",
-						Value: "value1",
-					},
-					{
-						Name:  "otel_scope_attr2",
-						Value: "value2",
-					},
-					{
-						Name:  "otel_scope_name",
-						Value: defaultScope.name,
-					},
-					{
-						Name:  "otel_scope_schema_url",
-						Value: defaultScope.schemaURL,
-					},
-					{
-						Name:  "otel_scope_version",
-						Value: defaultScope.version,
-					},
-				}
-				countLabels := append([]prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_summary" + countStr},
-				}, scopeLabels...)
-				sumLabels := append([]prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_summary" + sumStr},
-				}, scopeLabels...)
-				createdLabels := append([]prompb.Label{
-					{
-						Name:  model.MetricNameLabel,
-						Value: "test_summary" + createdSuffix,
-					},
-				}, scopeLabels...)
-				return map[uint64]*prompb.TimeSeries{
-					timeSeriesSignature(countLabels): {
-						Labels: countLabels,
-						Samples: []prompb.Sample{
-							{Value: 0, Timestamp: convertTimeStamp(ts)},
-						},
-					},
-					timeSeriesSignature(sumLabels): {
-						Labels: sumLabels,
-						Samples: []prompb.Sample{
-							{Value: 0, Timestamp: convertTimeStamp(ts)},
-						},
-					},
-					timeSeriesSignature(createdLabels): {
-						Labels: createdLabels,
-						Samples: []prompb.Sample{
-							{Value: float64(convertTimeStamp(ts)), Timestamp: convertTimeStamp(ts)},
-						},
-					},
-				}
-			},
-		},
-		{
-			name: "summary without start time and without scope promotion",
+			name: "summary without start time",
 			metric: func() pmetric.Metric {
 				metric := pmetric.NewMetric()
 				metric.SetName("test_summary")
@@ -685,7 +373,6 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 
 				return metric
 			},
-			promoteScope: false,
 			want: func() map[uint64]*prompb.TimeSeries {
 				countLabels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_summary" + countStr},
@@ -720,11 +407,9 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 				metric.Summary().DataPoints(),
 				pcommon.NewResource(),
 				Settings{
-					PromoteScopeMetadata: tt.promoteScope,
-					ExportCreatedMetric:  true,
+					ExportCreatedMetric: true,
 				},
 				metric.Name(),
-				tt.scope,
 			)
 
 			testutil.RequireEqual(t, tt.want(), converter.unique)
@@ -734,28 +419,14 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 }
 
 func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
-	scopeAttrs := pcommon.NewMap()
-	scopeAttrs.FromRaw(map[string]any{
-		"attr1": "value1",
-		"attr2": "value2",
-	})
-	defaultScope := scope{
-		name:       "test-scope",
-		version:    "1.0.0",
-		schemaURL:  "https://schema.com",
-		attributes: scopeAttrs,
-	}
-
 	ts := pcommon.Timestamp(time.Now().UnixNano())
 	tests := []struct {
-		name         string
-		metric       func() pmetric.Metric
-		scope        scope
-		promoteScope bool
-		want         func() map[uint64]*prompb.TimeSeries
+		name   string
+		metric func() pmetric.Metric
+		want   func() map[uint64]*prompb.TimeSeries
 	}{
 		{
-			name: "histogram with start time and without scope promotion",
+			name: "histogram with start time",
 			metric: func() pmetric.Metric {
 				metric := pmetric.NewMetric()
 				metric.SetName("test_hist")
@@ -767,8 +438,6 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 
 				return metric
 			},
-			scope:        defaultScope,
-			promoteScope: false,
 			want: func() map[uint64]*prompb.TimeSeries {
 				countLabels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_hist" + countStr},
@@ -780,76 +449,6 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 					{Name: model.MetricNameLabel, Value: "test_hist_bucket"},
 					{Name: model.BucketLabel, Value: "+Inf"},
 				}
-				return map[uint64]*prompb.TimeSeries{
-					timeSeriesSignature(countLabels): {
-						Labels: countLabels,
-						Samples: []prompb.Sample{
-							{Value: 0, Timestamp: convertTimeStamp(ts)},
-						},
-					},
-					timeSeriesSignature(infLabels): {
-						Labels: infLabels,
-						Samples: []prompb.Sample{
-							{Value: 0, Timestamp: convertTimeStamp(ts)},
-						},
-					},
-					timeSeriesSignature(createdLabels): {
-						Labels: createdLabels,
-						Samples: []prompb.Sample{
-							{Value: float64(convertTimeStamp(ts)), Timestamp: convertTimeStamp(ts)},
-						},
-					},
-				}
-			},
-		},
-		{
-			name: "histogram with start time and with scope promotion",
-			metric: func() pmetric.Metric {
-				metric := pmetric.NewMetric()
-				metric.SetName("test_hist")
-				metric.SetEmptyHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-
-				pt := metric.Histogram().DataPoints().AppendEmpty()
-				pt.SetTimestamp(ts)
-				pt.SetStartTimestamp(ts)
-
-				return metric
-			},
-			scope:        defaultScope,
-			promoteScope: true,
-			want: func() map[uint64]*prompb.TimeSeries {
-				scopeLabels := []prompb.Label{
-					{
-						Name:  "otel_scope_attr1",
-						Value: "value1",
-					},
-					{
-						Name:  "otel_scope_attr2",
-						Value: "value2",
-					},
-					{
-						Name:  "otel_scope_name",
-						Value: defaultScope.name,
-					},
-					{
-						Name:  "otel_scope_schema_url",
-						Value: defaultScope.schemaURL,
-					},
-					{
-						Name:  "otel_scope_version",
-						Value: defaultScope.version,
-					},
-				}
-				countLabels := append([]prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_hist" + countStr},
-				}, scopeLabels...)
-				infLabels := append([]prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_hist_bucket"},
-					{Name: model.BucketLabel, Value: "+Inf"},
-				}, scopeLabels...)
-				createdLabels := append([]prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_hist" + createdSuffix},
-				}, scopeLabels...)
 				return map[uint64]*prompb.TimeSeries{
 					timeSeriesSignature(countLabels): {
 						Labels: countLabels,
@@ -919,11 +518,9 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 				metric.Histogram().DataPoints(),
 				pcommon.NewResource(),
 				Settings{
-					ExportCreatedMetric:  true,
-					PromoteScopeMetadata: tt.promoteScope,
+					ExportCreatedMetric: true,
 				},
 				metric.Name(),
-				tt.scope,
 			)
 
 			require.Equal(t, tt.want(), converter.unique)

--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
@@ -37,7 +37,6 @@ const defaultZeroThreshold = 1e-128
 // as native histogram samples.
 func (c *PrometheusConverter) addExponentialHistogramDataPoints(ctx context.Context, dataPoints pmetric.ExponentialHistogramDataPointSlice,
 	resource pcommon.Resource, settings Settings, promName string, temporality pmetric.AggregationTemporality,
-	scope scope,
 ) (annotations.Annotations, error) {
 	var annots annotations.Annotations
 	for x := 0; x < dataPoints.Len(); x++ {
@@ -56,7 +55,6 @@ func (c *PrometheusConverter) addExponentialHistogramDataPoints(ctx context.Cont
 		lbls := createAttributes(
 			resource,
 			pt.Attributes(),
-			scope,
 			settings,
 			nil,
 			true,
@@ -254,7 +252,6 @@ func convertBucketsLayout(bucketCounts []uint64, offset, scaleDown int32, adjust
 
 func (c *PrometheusConverter) addCustomBucketsHistogramDataPoints(ctx context.Context, dataPoints pmetric.HistogramDataPointSlice,
 	resource pcommon.Resource, settings Settings, promName string, temporality pmetric.AggregationTemporality,
-	scope scope,
 ) (annotations.Annotations, error) {
 	var annots annotations.Annotations
 
@@ -274,7 +271,6 @@ func (c *PrometheusConverter) addCustomBucketsHistogramDataPoints(ctx context.Co
 		lbls := createAttributes(
 			resource,
 			pt.Attributes(),
-			scope,
 			settings,
 			nil,
 			true,

--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms_test.go
@@ -620,27 +620,13 @@ func validateNativeHistogramCount(t *testing.T, h prompb.Histogram) {
 }
 
 func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
-	scopeAttrs := pcommon.NewMap()
-	scopeAttrs.FromRaw(map[string]any{
-		"attr1": "value1",
-		"attr2": "value2",
-	})
-	defaultScope := scope{
-		name:       "test-scope",
-		version:    "1.0.0",
-		schemaURL:  "https://schema.com",
-		attributes: scopeAttrs,
-	}
-
 	tests := []struct {
-		name         string
-		metric       func() pmetric.Metric
-		scope        scope
-		promoteScope bool
-		wantSeries   func() map[uint64]*prompb.TimeSeries
+		name       string
+		metric     func() pmetric.Metric
+		wantSeries func() map[uint64]*prompb.TimeSeries
 	}{
 		{
-			name: "histogram data points with same labels and without scope promotion",
+			name: "histogram data points with same labels",
 			metric: func() pmetric.Metric {
 				metric := pmetric.NewMetric()
 				metric.SetName("test_hist")
@@ -664,8 +650,6 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 
 				return metric
 			},
-			scope:        defaultScope,
-			promoteScope: false,
 			wantSeries: func() map[uint64]*prompb.TimeSeries {
 				labels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_hist"},
@@ -701,73 +685,7 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 			},
 		},
 		{
-			name: "histogram data points with same labels and with scope promotion",
-			metric: func() pmetric.Metric {
-				metric := pmetric.NewMetric()
-				metric.SetName("test_hist")
-				metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-
-				pt := metric.ExponentialHistogram().DataPoints().AppendEmpty()
-				pt.SetCount(7)
-				pt.SetScale(1)
-				pt.Positive().SetOffset(-1)
-				pt.Positive().BucketCounts().FromRaw([]uint64{4, 2})
-				pt.Exemplars().AppendEmpty().SetDoubleValue(1)
-				pt.Attributes().PutStr("attr", "test_attr")
-
-				pt = metric.ExponentialHistogram().DataPoints().AppendEmpty()
-				pt.SetCount(4)
-				pt.SetScale(1)
-				pt.Positive().SetOffset(-1)
-				pt.Positive().BucketCounts().FromRaw([]uint64{4, 2, 1})
-				pt.Exemplars().AppendEmpty().SetDoubleValue(2)
-				pt.Attributes().PutStr("attr", "test_attr")
-
-				return metric
-			},
-			scope:        defaultScope,
-			promoteScope: true,
-			wantSeries: func() map[uint64]*prompb.TimeSeries {
-				labels := []prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_hist"},
-					{Name: "attr", Value: "test_attr"},
-					{Name: "otel_scope_name", Value: defaultScope.name},
-					{Name: "otel_scope_schema_url", Value: defaultScope.schemaURL},
-					{Name: "otel_scope_version", Value: defaultScope.version},
-					{Name: "otel_scope_attr1", Value: "value1"},
-					{Name: "otel_scope_attr2", Value: "value2"},
-				}
-				return map[uint64]*prompb.TimeSeries{
-					timeSeriesSignature(labels): {
-						Labels: labels,
-						Histograms: []prompb.Histogram{
-							{
-								Count:          &prompb.Histogram_CountInt{CountInt: 7},
-								Schema:         1,
-								ZeroThreshold:  defaultZeroThreshold,
-								ZeroCount:      &prompb.Histogram_ZeroCountInt{ZeroCountInt: 0},
-								PositiveSpans:  []prompb.BucketSpan{{Offset: 0, Length: 2}},
-								PositiveDeltas: []int64{4, -2},
-							},
-							{
-								Count:          &prompb.Histogram_CountInt{CountInt: 4},
-								Schema:         1,
-								ZeroThreshold:  defaultZeroThreshold,
-								ZeroCount:      &prompb.Histogram_ZeroCountInt{ZeroCountInt: 0},
-								PositiveSpans:  []prompb.BucketSpan{{Offset: 0, Length: 3}},
-								PositiveDeltas: []int64{4, -2, -1},
-							},
-						},
-						Exemplars: []prompb.Exemplar{
-							{Value: 1},
-							{Value: 2},
-						},
-					},
-				}
-			},
-		},
-		{
-			name: "histogram data points with different labels and without scope promotion",
+			name: "histogram data points with different labels",
 			metric: func() pmetric.Metric {
 				metric := pmetric.NewMetric()
 				metric.SetName("test_hist")
@@ -791,8 +709,6 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 
 				return metric
 			},
-			scope:        defaultScope,
-			promoteScope: false,
 			wantSeries: func() map[uint64]*prompb.TimeSeries {
 				labels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_hist"},
@@ -853,12 +769,10 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 				metric.ExponentialHistogram().DataPoints(),
 				pcommon.NewResource(),
 				Settings{
-					ExportCreatedMetric:  true,
-					PromoteScopeMetadata: tt.promoteScope,
+					ExportCreatedMetric: true,
 				},
 				namer.Build(TranslatorMetricFromOtelMetric(metric)),
 				pmetric.AggregationTemporalityCumulative,
-				tt.scope,
 			)
 			require.NoError(t, err)
 			require.Empty(t, annots)
@@ -1077,27 +991,13 @@ func TestHistogramToCustomBucketsHistogram(t *testing.T) {
 }
 
 func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
-	scopeAttrs := pcommon.NewMap()
-	scopeAttrs.FromRaw(map[string]any{
-		"attr1": "value1",
-		"attr2": "value2",
-	})
-	defaultScope := scope{
-		name:       "test-scope",
-		version:    "1.0.0",
-		schemaURL:  "https://schema.com",
-		attributes: scopeAttrs,
-	}
-
 	tests := []struct {
-		name         string
-		metric       func() pmetric.Metric
-		scope        scope
-		promoteScope bool
-		wantSeries   func() map[uint64]*prompb.TimeSeries
+		name       string
+		metric     func() pmetric.Metric
+		wantSeries func() map[uint64]*prompb.TimeSeries
 	}{
 		{
-			name: "histogram data points with same labels and without scope promotion",
+			name: "histogram data points with same labels",
 			metric: func() pmetric.Metric {
 				metric := pmetric.NewMetric()
 				metric.SetName("test_hist_to_nhcb")
@@ -1121,8 +1021,6 @@ func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
 
 				return metric
 			},
-			scope:        defaultScope,
-			promoteScope: false,
 			wantSeries: func() map[uint64]*prompb.TimeSeries {
 				labels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_hist_to_nhcb"},
@@ -1158,73 +1056,7 @@ func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
 			},
 		},
 		{
-			name: "histogram data points with same labels and with scope promotion",
-			metric: func() pmetric.Metric {
-				metric := pmetric.NewMetric()
-				metric.SetName("test_hist_to_nhcb")
-				metric.SetEmptyHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-
-				pt := metric.Histogram().DataPoints().AppendEmpty()
-				pt.SetCount(3)
-				pt.SetSum(3)
-				pt.BucketCounts().FromRaw([]uint64{2, 0, 1})
-				pt.ExplicitBounds().FromRaw([]float64{5, 10})
-				pt.Exemplars().AppendEmpty().SetDoubleValue(1)
-				pt.Attributes().PutStr("attr", "test_attr")
-
-				pt = metric.Histogram().DataPoints().AppendEmpty()
-				pt.SetCount(11)
-				pt.SetSum(5)
-				pt.BucketCounts().FromRaw([]uint64{3, 8, 0})
-				pt.ExplicitBounds().FromRaw([]float64{0, 1})
-				pt.Exemplars().AppendEmpty().SetDoubleValue(2)
-				pt.Attributes().PutStr("attr", "test_attr")
-
-				return metric
-			},
-			scope:        defaultScope,
-			promoteScope: true,
-			wantSeries: func() map[uint64]*prompb.TimeSeries {
-				labels := []prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_hist_to_nhcb"},
-					{Name: "attr", Value: "test_attr"},
-					{Name: "otel_scope_name", Value: defaultScope.name},
-					{Name: "otel_scope_schema_url", Value: defaultScope.schemaURL},
-					{Name: "otel_scope_version", Value: defaultScope.version},
-					{Name: "otel_scope_attr1", Value: "value1"},
-					{Name: "otel_scope_attr2", Value: "value2"},
-				}
-				return map[uint64]*prompb.TimeSeries{
-					timeSeriesSignature(labels): {
-						Labels: labels,
-						Histograms: []prompb.Histogram{
-							{
-								Count:          &prompb.Histogram_CountInt{CountInt: 3},
-								Sum:            3,
-								Schema:         -53,
-								PositiveSpans:  []prompb.BucketSpan{{Offset: 0, Length: 3}},
-								PositiveDeltas: []int64{2, -2, 1},
-								CustomValues:   []float64{5, 10},
-							},
-							{
-								Count:          &prompb.Histogram_CountInt{CountInt: 11},
-								Sum:            5,
-								Schema:         -53,
-								PositiveSpans:  []prompb.BucketSpan{{Offset: 0, Length: 3}},
-								PositiveDeltas: []int64{3, 5, -8},
-								CustomValues:   []float64{0, 1},
-							},
-						},
-						Exemplars: []prompb.Exemplar{
-							{Value: 1},
-							{Value: 2},
-						},
-					},
-				}
-			},
-		},
-		{
-			name: "histogram data points with different labels and without scope promotion",
+			name: "histogram data points with different labels",
 			metric: func() pmetric.Metric {
 				metric := pmetric.NewMetric()
 				metric.SetName("test_hist_to_nhcb")
@@ -1248,8 +1080,6 @@ func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
 
 				return metric
 			},
-			scope:        defaultScope,
-			promoteScope: false,
 			wantSeries: func() map[uint64]*prompb.TimeSeries {
 				labels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_hist_to_nhcb"},
@@ -1312,11 +1142,9 @@ func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
 				Settings{
 					ExportCreatedMetric:     true,
 					ConvertHistogramsToNHCB: true,
-					PromoteScopeMetadata:    tt.promoteScope,
 				},
 				namer.Build(TranslatorMetricFromOtelMetric(metric)),
 				pmetric.AggregationTemporalityCumulative,
-				tt.scope,
 			)
 
 			require.NoError(t, err)

--- a/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (c *PrometheusConverter) addGaugeNumberDataPoints(ctx context.Context, dataPoints pmetric.NumberDataPointSlice,
-	resource pcommon.Resource, settings Settings, name string, scope scope,
+	resource pcommon.Resource, settings Settings, name string,
 ) error {
 	for x := 0; x < dataPoints.Len(); x++ {
 		if err := c.everyN.checkContext(ctx); err != nil {
@@ -40,7 +40,6 @@ func (c *PrometheusConverter) addGaugeNumberDataPoints(ctx context.Context, data
 		labels := createAttributes(
 			resource,
 			pt.Attributes(),
-			scope,
 			settings,
 			nil,
 			true,
@@ -67,7 +66,7 @@ func (c *PrometheusConverter) addGaugeNumberDataPoints(ctx context.Context, data
 }
 
 func (c *PrometheusConverter) addSumNumberDataPoints(ctx context.Context, dataPoints pmetric.NumberDataPointSlice,
-	resource pcommon.Resource, metric pmetric.Metric, settings Settings, name string, scope scope,
+	resource pcommon.Resource, metric pmetric.Metric, settings Settings, name string,
 ) error {
 	for x := 0; x < dataPoints.Len(); x++ {
 		if err := c.everyN.checkContext(ctx); err != nil {
@@ -78,7 +77,6 @@ func (c *PrometheusConverter) addSumNumberDataPoints(ctx context.Context, dataPo
 		lbls := createAttributes(
 			resource,
 			pt.Attributes(),
-			scope,
 			settings,
 			nil,
 			true,

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -596,7 +596,6 @@ func (rw *rwExporter) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) er
 		KeepIdentifyingResourceAttributes: otlpCfg.KeepIdentifyingResourceAttributes,
 		ConvertHistogramsToNHCB:           otlpCfg.ConvertHistogramsToNHCB,
 		AllowDeltaTemporality:             rw.allowDeltaTemporality,
-		PromoteScopeMetadata:              otlpCfg.PromoteScopeMetadata,
 	})
 	if err != nil {
 		rw.logger.Warn("Error translating OTLP metrics to Prometheus write request", "err", err)


### PR DESCRIPTION
Reverts #16730 and #16760

[This is being done because we've noticed a problem in the spec](https://github.com/open-telemetry/semantic-conventions/pull/2489#issuecomment-3046057964) that could lead to name collisions if attributes `name`, `version` or `schema_url` are added to the scope. They would collide with the already reserved labels `otel_scope_name`, `otel_scope_version` and `otel_scope_schema_url`.

Since this new configuration option never made it into a release, we can safely remove it from the 3.5 release. We'll sort this out for the 3.6 release