### PR TITLE
promqltest: add tests for `histogram_count(increase(...))`

### DIFF
--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1416,3 +1416,16 @@ eval instant at 55m increase(metric[55m15s])
 eval instant at 54m30s increase(metric[54m45s])
     {type="histogram"} {{count:2509.375 sum:50.69444444444444 counter_reset_hint:gauge buckets:[10.13888888888889 2499.236111111111]}}
     {type="counter"} 2509.375
+
+# Try the same, but now extract just the histogram count via `histogram_count`.
+eval instant at 55m histogram_count(increase(metric[90m]))
+    {type="histogram"} 2490
+
+eval instant at 54m30s histogram_count(increase(metric[90m]))
+    {type="histogram"} 2512.9166666666665
+
+eval instant at 55m histogram_count(increase(metric[55m15s]))
+    {type="histogram"} 2486.25
+
+eval instant at 54m30s histogram_count(increase(metric[54m45s]))
+    {type="histogram"} 2509.375


### PR DESCRIPTION
As `histogram_count` is playing tricks to improve performance, we better make sure that the limitation of extrapolation below zero still works as expected.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
