### PR TITLE
ci: address golangci-lint issue with persist-credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
         with:
           args: --verbose
           # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
-          version: v2.1.5
+          version: v2.2.1
   fuzzing:
     uses: ./.github/workflows/fuzzing.yml
     if: github.event_name == 'pull_request'

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v2.1.5
+GOLANGCI_LINT_VERSION ?= v2.2.1
 GOLANGCI_FMT_OPTS ?=
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.

--- a/scripts/golangci-lint.yml
+++ b/scripts/golangci-lint.yml
@@ -38,4 +38,4 @@ jobs:
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           args: --verbose
-          version: v2.1.5
+          version: v2.2.1


### PR DESCRIPTION
Fixes the following zizmor warning:

```
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> scripts/golangci-lint.yml:26:9
   |
26 |         - name: Checkout repository
   |  _________-
27 | |         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
28 | |         # with:
29 | |         #   persist-credentials: false
   | |______________________________________- does not set persist-credentials: false
```

All other actions have been fixed in https://github.com/prometheus/prometheus/pull/16530

Credit to @jharvey10 who also addressed this particular issue in https://github.com/grafana/postgres_exporter/commit/a5bf67d897ac760f0205d87fb6354957516ee1ca

---

EDIT: while at it, updated `golangci-lint` to v2.2.1