### PR TITLE
feature: implement match_first_port for moby/docker_sd discovery

### DIFF
--- a/discovery/moby/docker.go
+++ b/discovery/moby/docker.go
@@ -63,6 +63,7 @@ var DefaultDockerSDConfig = DockerSDConfig{
 	HostNetworkingHost: "localhost",
 	HTTPClientConfig:   config.DefaultHTTPClientConfig,
 	MatchFirstNetwork:  true,
+	MatchFirstPort:     false,
 }
 
 func init() {
@@ -80,6 +81,7 @@ type DockerSDConfig struct {
 
 	RefreshInterval   model.Duration `yaml:"refresh_interval"`
 	MatchFirstNetwork bool           `yaml:"match_first_network"`
+	MatchFirstPort    bool           `yaml:"match_first_port"`
 }
 
 // NewDiscovererMetrics implements discovery.Config.
@@ -126,6 +128,7 @@ type DockerDiscovery struct {
 	hostNetworkingHost string
 	filters            filters.Args
 	matchFirstNetwork  bool
+	matchFirstPort     bool
 }
 
 // NewDockerDiscovery returns a new DockerDiscovery which periodically refreshes its targets.
@@ -139,6 +142,7 @@ func NewDockerDiscovery(conf *DockerSDConfig, logger *slog.Logger, metrics disco
 		port:               conf.Port,
 		hostNetworkingHost: conf.HostNetworkingHost,
 		matchFirstNetwork:  conf.MatchFirstNetwork,
+		matchFirstPort:     conf.MatchFirstPort,
 	}
 
 	hostURL, err := url.Parse(conf.Host)
@@ -298,6 +302,9 @@ func (d *DockerDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 				labels[model.AddressLabel] = model.LabelValue(addr)
 				tg.Targets = append(tg.Targets, labels)
 				added = true
+				if d.matchFirstPort {
+					break
+				}
 			}
 
 			if !added {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -964,6 +964,11 @@ host: <string>
 # thus avoiding collecting duplicate targets.
 [ match_first_network: <boolean> | default = true ]
 
+# By default, one scrape per exposed port is created. If this is set to true,
+# only a scrape for the first port is created. This might be useful if you configure
+# the scrapes via labels.
+[ match_first_port: <boolean> | default = false ]
+
 # Optional filters to limit the discovery process to a subset of available
 # resources.
 # The available filters are listed in the upstream documentation:


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Creating one scrape per exposed port for a container does not make sense in every scenario. I have added an option which creates only one scrape per container, which is mainly made for use-cases where this port is overriden via labels.
