### PR TITLE
fix(promql): Ensure native histogram values are copied in subqueries

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3985,3 +3985,49 @@ func TestInconsistentHistogramCount(t *testing.T) {
 
 	require.Equal(t, countFromHistogram, countFromFunction, "histogram_count function should return the same count as the histogram itself")
 }
+
+// TestSubQueryHistogramsCopy reproduces a bug where native histogram values from subqueries are not copied.
+func TestSubQueryHistogramsCopy(t *testing.T) {
+	start := time.Unix(0, 0)
+	end := time.Unix(144, 0)
+	step := time.Second * 3
+
+	load := `load 2m
+			http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:110 sum:818.00 buckets:[1 14 95]}}+{{schema:0 count:110 buckets:[1 14 95]}}x20
+			http_request_duration_seconds{pod="nginx-2"} {{schema:0 count:210 sum:1598.00 buckets:[1 19 190]}}+{{schema:0 count:210 buckets:[1 19 190]}}x30`
+
+	subQuery := `min_over_time({__name__="http_request_duration_seconds"}[1h:1m])`
+	testQuery := `rate({__name__="http_request_duration_seconds"}[3m])`
+	ctx := context.Background()
+
+	for i := 0; i < 100; i++ {
+		queryable := promqltest.LoadedStorage(t, load)
+		engine := promqltest.NewTestEngine(t, false, 0, promqltest.DefaultMaxSamplesPerQuery)
+
+		q, err := engine.NewRangeQuery(ctx, queryable, nil, subQuery, start, end, step)
+		require.NoError(t, err)
+		q.Exec(ctx)
+		q.Close()
+		queryable.Close()
+	}
+
+	for i := 0; i < 100; i++ {
+		queryable := promqltest.LoadedStorage(t, load)
+		engine := promqltest.NewTestEngine(t, false, 0, promqltest.DefaultMaxSamplesPerQuery)
+
+		q, err := engine.NewRangeQuery(ctx, queryable, nil, testQuery, start, end, step)
+		require.NoError(t, err)
+		result := q.Exec(ctx)
+
+		mat, err := result.Matrix()
+		require.NoError(t, err)
+
+		for _, s := range mat {
+			for _, h := range s.Histograms {
+				require.NotEmpty(t, h.H.PositiveBuckets)
+			}
+		}
+		q.Close()
+		queryable.Close()
+	}
+}

--- a/promql/value.go
+++ b/promql/value.go
@@ -475,8 +475,12 @@ func (ssi *storageSeriesIterator) AtHistogram(*histogram.Histogram) (int64, *his
 	panic(errors.New("storageSeriesIterator: AtHistogram not supported"))
 }
 
-func (ssi *storageSeriesIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
-	return ssi.currT, ssi.currH
+func (ssi *storageSeriesIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+	if fh == nil {
+		return ssi.currT, ssi.currH.Copy()
+	}
+	ssi.currH.CopyTo(fh)
+	return ssi.currT, fh
 }
 
 func (ssi *storageSeriesIterator) AtT() int64 {


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

### Notes
While testing Thanos PromQL engine I found a very subtle bug in Prometheus engine. The NH samples returned from the iterator from subquery is  not copied. This causes the query results from the Prometheus engine to be incorrect results.


### Reproducing the bug
I originally discovered this this bug by comparing the results against Thanos engine. I also added a test in this PR.
This bug occurs when a subquery is run before other queries. 

In the below test, when a subquery is included `min_over_time({__name__="http_request_duration_seconds"}[1h:1m])` the results of the rate() and delta() are wrong. I'm suspecting this is because of array reuse in [`matrixIterSlice()`](https://github.com/prometheus/prometheus/blob/a37eb5359ab976c52b1883e9d4b0860d7afc0efa/promql/engine.go#L2446) (and maybe other places?).

```
func TestQueriesAgainstThanosEngine(t *testing.T) {
	start := time.Unix(0, 0)
	end := time.Unix(144, 0)
	step := time.Second * 3
	// Negative offset and at modifier are enabled by default
	// since Prometheus v2.33.0 so we also enable them.
	opts := promql.EngineOpts{
		Timeout:              1 * time.Hour,
		MaxSamples:           1e10,
		EnableNegativeOffset: true,
		EnableAtModifier:     true,
	}

	load := `load 2m
			http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:110 sum:818.00 buckets:[1 14 95]}}+{{schema:0 count:110 buckets:[1 14 95]}}x20
			http_request_duration_seconds{pod="nginx-2"} {{schema:0 count:210 sum:1598.00 buckets:[1 19 190]}}+{{schema:0 count:210 buckets:[1 19 190]}}x30`

	queryStrings := []string{
		`min_over_time({__name__="http_request_duration_seconds"}[1h:1m])`,
		`rate({__name__="http_request_duration_seconds"}[3m] offset -16s)`,
		`delta({__name__="http_request_duration_seconds"}[3m] offset -16s)`,
	}

	expected := make([]*promql.Result, len(queryStrings))

	thanosEngine := engine.New(engine.Opts{EngineOpts: opts})
	queryable := promqltest.LoadedStorage(t, load)
	t.Cleanup(func() {
		queryable.Close()
	})

	ctx := context.Background()
	for j, qs := range queryStrings {
		thanosQuery, err := thanosEngine.NewRangeQuery(ctx, queryable, nil, qs, start, end, step)
		testutil.Ok(t, err)
		thanosResult := thanosQuery.Exec(ctx)
		expected[j] = thanosResult
		t.Cleanup(func() {
			thanosQuery.Close()
		})
	}

	for i := 0; i < 1000; i++ {
		for j, qs := range queryStrings {
			t.Run(fmt.Sprintf("%s_%d_%d", "run", i, j), func(t *testing.T) {
				queryable2 := promqltest.LoadedStorage(t, load)
				defer queryable2.Close()
				promEngine := promql.NewEngine(opts)
				promQuery, err := promEngine.NewRangeQuery(ctx, queryable2, nil, qs, start, end, step)
				testutil.Ok(t, err)
				defer promQuery.Close()
				promResult := promQuery.Exec(ctx)

				testutil.WithGoCmp(comparer).Equals(t, promResult, expected[j])
			})
		}
	}
}
```


#### Failure
```
Diff:

        --- Expected

        +++ Actual

        @@ -1,31 +1,31 @@

         (*promql.Result)({pod="nginx-1"} =>

        -{count:0, sum:0} @[105000]

        -{count:0, sum:0} @[108000]

        -{count:0, sum:0} @[111000]

        -{count:0, sum:0} @[114000]

        -{count:0, sum:0} @[117000]

        -{count:0, sum:0} @[120000]

        -{count:0, sum:0} @[123000]

        +{count:0.9166666666666666, sum:0, (0.5,1]:0.008333333333333333, (1,2]:0.11666666666666667, (2,4]:0.7916666666666666} @[105000]

        +{count:0.9166666666666666, sum:0, (0.5,1]:0.008333333333333333, (1,2]:0.11666666666666667, (2,4]:0.7916666666666666} @[108000]

        +{count:0.9166666666666666, sum:0, (0.5,1]:0.008333333333333333, (1,2]:0.11666666666666667, (2,4]:0.7916666666666666} @[111000]

        +{count:0.9166666666666666, sum:0, (0.5,1]:0.008333333333333333, (1,2]:0.11666666666666667, (2,4]:0.7916666666666666} @[114000]

        +{count:0...(output trimmed)

``` 
