### PR TITLE
Fix for error cases in promql eval of StepInvariantExpr with unnecessary ParentExpr (Issue 16880)

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2112,6 +2112,9 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		ev.samplesStats.IncrementSamplesAtTimestamp(ev.endTimestamp, newEv.samplesStats.TotalSamples)
 		return res, ws
 	case *parser.StepInvariantExpr:
+
+		unwrapParenExpr(&e.Expr)
+
 		switch ce := e.Expr.(type) {
 		case *parser.StringLiteral, *parser.NumberLiteral:
 			return ev.eval(ctx, ce)
@@ -3728,29 +3731,14 @@ func unwrapStepInvariantExpr(e parser.Expr) parser.Expr {
 	return e
 }
 
-func unwrapParentExprIfRedundant(e parser.Expr) parser.Expr {
-	switch n := e.(type) {
-	case *parser.ParenExpr:
-		switch n.Expr.(type) {
-		case *parser.MatrixSelector, *parser.StringLiteral, *parser.NumberLiteral, *parser.SubqueryExpr:
-			return n.Expr
-		case *parser.ParenExpr:
-			return unwrapParentExprIfRedundant(n.Expr)
-		}
-	}
-	return e
-}
-
 // PreprocessExpr wraps all possible step invariant parts of the given expression with
 // StepInvariantExpr. It also resolves the preprocessors and evaluates duration expressions
 // into their numeric values.
 func PreprocessExpr(expr parser.Expr, start, end time.Time, step time.Duration) (parser.Expr, error) {
 	detectHistogramStatsDecoding(expr)
 
-	// If the expression is a ParenExpr and the child is a MatrixSelector, SubqueryExpr, StringLiteral, or NumberLiteral we remove the ParenExpr from the chain.
-	// This is to avoid issues in the eval() case *parser.StepInvariantExpr handling where there are specific cases for these child expressions.
-	// Without removing the ParentExpr, these specific cases are not handled and errors can occur.
-	expr = unwrapParentExprIfRedundant(expr)
+	// Unwrap ParenExprs that are redundant.
+	unwrapParenExpr(&expr)
 
 	if err := parser.Walk(&durationVisitor{step: step}, expr, nil); err != nil {
 		return nil, err

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3731,6 +3731,9 @@ func unwrapStepInvariantExpr(e parser.Expr) parser.Expr {
 // PreprocessExpr wraps all possible step invariant parts of the given expression with
 // StepInvariantExpr. It also resolves the preprocessors and evaluates duration expressions
 // into their numeric values.
+// Top level ParenExprs (parentheses) are removed.
+// Note that this only unwraps ParenExprs at the root of this expression.
+// unwrapParenExpr() should still be called within the expression eval() relative to each expression type.
 func PreprocessExpr(expr parser.Expr, start, end time.Time, step time.Duration) (parser.Expr, error) {
 	detectHistogramStatsDecoding(expr)
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2113,6 +2113,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		return res, ws
 	case *parser.StepInvariantExpr:
 
+		// Unwrap ParenExprs / () that are redundant.
 		unwrapParenExpr(&e.Expr)
 
 		switch ce := e.Expr.(type) {
@@ -3737,7 +3738,7 @@ func unwrapStepInvariantExpr(e parser.Expr) parser.Expr {
 func PreprocessExpr(expr parser.Expr, start, end time.Time, step time.Duration) (parser.Expr, error) {
 	detectHistogramStatsDecoding(expr)
 
-	// Unwrap ParenExprs that are redundant.
+	// Unwrap ParenExprs / () that are redundant.
 	unwrapParenExpr(&expr)
 
 	if err := parser.Walk(&durationVisitor{step: step}, expr, nil); err != nil {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2112,10 +2112,6 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		ev.samplesStats.IncrementSamplesAtTimestamp(ev.endTimestamp, newEv.samplesStats.TotalSamples)
 		return res, ws
 	case *parser.StepInvariantExpr:
-
-		// Unwrap ParenExprs / () that are redundant.
-		unwrapParenExpr(&e.Expr)
-
 		switch ce := e.Expr.(type) {
 		case *parser.StringLiteral, *parser.NumberLiteral:
 			return ev.eval(ctx, ce)

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3193,7 +3193,7 @@ func TestEngine_Close(t *testing.T) {
 	})
 }
 
-// Without changes to how ParentExpr is handled these test expressions will fail with an "unexpected number of samples" error and "unexpected result in StepInvariantExpr evaluation: *parser.StepInvariantExpr" error
+// Test cases specific to removing redundant ParentExprs.
 func TestRedundantParenExpr(t *testing.T) {
 	engine := newTestEngine(t)
 
@@ -3204,7 +3204,7 @@ func TestRedundantParenExpr(t *testing.T) {
 	`)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
 
-	for _, expr := range []string{"(metric[2y]@12)", "(((metric[2y]@12)))", `("")`, `((""))`} {
+	for _, expr := range []string{"sum((metric)) / (max((metric)))", "(metric[2y]@12)", "(((metric[2y]@12)))", `("")`, `((""))`, `((("")))`} {
 		q, err := engine.NewInstantQuery(context.Background(), storage, nil, expr, time.Now())
 		require.NoError(t, err)
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3194,7 +3194,7 @@ func TestEngine_Close(t *testing.T) {
 }
 
 // Test cases specific to removing redundant ParentExprs.
-func TestRedundantParenExpr(t *testing.T) {
+func TestParenExprUnwrap(t *testing.T) {
 	engine := newTestEngine(t)
 
 	storage := promqltest.LoadedStorage(t, `
@@ -3204,7 +3204,7 @@ func TestRedundantParenExpr(t *testing.T) {
 	`)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
 
-	for _, expr := range []string{"sum((metric)) / (max((metric)))", "(metric[2y]@12)", "(((metric[2y]@12)))", `("")`, `((""))`, `((("")))`} {
+	for _, expr := range []string{"(sum((metric)) / (max((metric))))", "(metric[2y]@12)", "(((metric[2y]@12)))", `("")`, `((""))`, `((("")))`} {
 		q, err := engine.NewInstantQuery(context.Background(), storage, nil, expr, time.Now())
 		require.NoError(t, err)
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3243,6 +3243,11 @@ func TestInstantQueryWithRangeVectorSelector(t *testing.T) {
 			ts:       baseT,
 			expected: promql.Matrix{},
 		},
+		"no samples in range": {
+			expr:     "some_metric[1m]",
+			ts:       baseT.Add(20 * time.Minute),
+			expected: promql.Matrix{},
+		},
 		"empty string in parentheus": {
 			expr:     `("")`,
 			ts:       baseT,

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -696,6 +696,12 @@ load 10s
 			Start:  time.Unix(1, 0),
 		},
 		{
+			Query:       `("")`,
+			Start:       time.Unix(0, 0),
+			Result:      promql.String{T: timestamp.FromTime(time.Unix(0, 0)), V: ""},
+			ShouldError: false,
+		},
+		{
 			Query: "metric",
 			Result: promql.Vector{
 				promql.Sample{
@@ -2312,6 +2318,15 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 			},
 		},
 		{
+			input: `("")`,
+			expected: &parser.StepInvariantExpr{
+				Expr: &parser.StringLiteral{
+					Val:      "",
+					PosRange: posrange.PositionRange{Start: 1, End: 3},
+				},
+			},
+		},
+		{
 			input: `"foo"`,
 			expected: &parser.StepInvariantExpr{
 				Expr: &parser.StringLiteral{
@@ -3208,7 +3223,7 @@ func TestInstantQueryWithRangeVectorSelector(t *testing.T) {
 
 	testCases := map[string]struct {
 		expr     string
-		expected parser.Value
+		expected promql.Matrix
 		ts       time.Time
 	}{
 		"matches series with points in range": {
@@ -3247,11 +3262,6 @@ func TestInstantQueryWithRangeVectorSelector(t *testing.T) {
 			expr:     "some_metric[1m]",
 			ts:       baseT.Add(20 * time.Minute),
 			expected: promql.Matrix{},
-		},
-		"empty string in parentheus": {
-			expr:     `("")`,
-			ts:       baseT,
-			expected: promql.String{T: timestamp.FromTime(baseT), V: ""},
 		},
 		"metric with stale marker": {
 			expr: "some_metric_with_stale_marker[3m]",

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3204,7 +3204,7 @@ func TestRedundantParenExpr(t *testing.T) {
 	`)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
 
-	for _, expr := range []string{"(metric[2y]@12)", `("")`} {
+	for _, expr := range []string{"(metric[2y]@12)", "(((metric[2y]@12)))", `("")`, `((""))`} {
 		q, err := engine.NewInstantQuery(context.Background(), storage, nil, expr, time.Now())
 		require.NoError(t, err)
 


### PR DESCRIPTION
This PR relates to https://github.com/prometheus/prometheus/issues/16880

During Mimir Query Engine regression testing, a number of edge case promql queries returned an error in the Prometheus Query Engine. 

The edge cases involved redundant () around expressions, resulting in the additional wrapping of expressions with ParentExprs. 

During the eval() processing of parser.StepInvariantExpr, the code paths related to returning early on literals & matrix selectors were not taken, resulting in an error.

It seems that most of the other parser types already have specific handling for removing redundant ParentExprs. 

The suggested fix is to remove root level ParentExpr's early in the PreprocessExpr().

Unit tests with an example query string causing an error have been included.