### PR TITLE
[BUGFIX] PromQL: Noinline kahanSumInc, to avoid compiler optimisations

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1188,6 +1188,9 @@ func funcTimestamp(vals []parser.Value, _ parser.Expressions, enh *EvalNodeHelpe
 	return enh.Out, nil
 }
 
+// We get incorrect results if this function is inlined; see https://github.com/prometheus/prometheus/issues/16714.
+//
+//go:noinline
 func kahanSumInc(inc, sum, c float64) (newSum, newC float64) {
 	t := sum + inc
 	switch {


### PR DESCRIPTION
Observed on go1.24.4 darwin/arm64, the compensation variable is not correctly calculated.

Note you may have to run the tests several times to see it, to get the right ordering of series.

Since the problem went away when I tried to run under the debugger (which disables optimisations), and went away when I added sufficient printf statements (which discourages inlining), I hit upon the idea of disabling inlining for this one function.

See https://github.com/prometheus/prometheus/issues/16714#issuecomment-3092355237

It's going to slow things down a bit, but turns out `IsInf` is pretty slow already.

Fixes #16714.
