### PR TITLE
[PERF] PromQL: Move more work to preprocessing step

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1787,8 +1787,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		}
 
 		unwrapParenExpr(&e.Args[matrixArgIndex])
-		arg := unwrapStepInvariantExpr(e.Args[matrixArgIndex])
-		unwrapParenExpr(&arg)
+		arg := e.Args[matrixArgIndex]
 		sel := arg.(*parser.MatrixSelector)
 		selVS := sel.VectorSelector.(*parser.VectorSelector)
 
@@ -3802,7 +3801,10 @@ func preprocessExprHelper(expr parser.Expr, start, end time.Time) (isStepInvaria
 		return false, false
 
 	case *parser.MatrixSelector:
-		return preprocessExprHelper(n.VectorSelector, start, end)
+		// We don't need to wrap a MatrixSelector because functions over range vectors evaluate those directly,
+		// and they can't appear at top level in a range query.
+		isStepInvariant, _ := preprocessExprHelper(n.VectorSelector, start, end)
+		return isStepInvariant, false
 
 	case *parser.SubqueryExpr:
 		// Since we adjust offset for the @ modifier evaluation,

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1672,8 +1672,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		sortedGrouping := e.Grouping
 		slices.Sort(sortedGrouping)
 
-		unwrapParenExpr(&e.Param)
-		param := unwrapStepInvariantExpr(e.Param)
+		param := e.Param
 		unwrapParenExpr(&param)
 
 		if e.Op == parser.COUNT_VALUES {
@@ -1730,8 +1729,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		)
 		for i := range e.Args {
 			unwrapParenExpr(&e.Args[i])
-			a := unwrapStepInvariantExpr(e.Args[i])
-			unwrapParenExpr(&a)
+			a := e.Args[i]
 			if _, ok := a.(*parser.MatrixSelector); ok {
 				matrixArgIndex = i
 				matrixArg = true

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -2423,23 +2423,21 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 		},
 		{
 			input: `test{a="b"}[5y] @ 1603774699`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.MatrixSelector{
-					VectorSelector: &parser.VectorSelector{
-						Name:      "test",
-						Timestamp: makeInt64Pointer(1603774699000),
-						LabelMatchers: []*labels.Matcher{
-							parser.MustLabelMatcher(labels.MatchEqual, "a", "b"),
-							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   11,
-						},
+			expected: &parser.MatrixSelector{
+				VectorSelector: &parser.VectorSelector{
+					Name:      "test",
+					Timestamp: makeInt64Pointer(1603774699000),
+					LabelMatchers: []*labels.Matcher{
+						parser.MustLabelMatcher(labels.MatchEqual, "a", "b"),
+						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
 					},
-					Range:  5 * 365 * 24 * time.Hour,
-					EndPos: 28,
+					PosRange: posrange.PositionRange{
+						Start: 0,
+						End:   11,
+					},
 				},
+				Range:  5 * 365 * 24 * time.Hour,
+				EndPos: 28,
 			},
 		},
 		{
@@ -2938,45 +2936,53 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 			},
 		},
 		{
-			input: `test[5y] @ start()`,
+			input: `sum_over_time(test[5y] @ start())`,
 			expected: &parser.StepInvariantExpr{
-				Expr: &parser.MatrixSelector{
-					VectorSelector: &parser.VectorSelector{
-						Name:       "test",
-						Timestamp:  makeInt64Pointer(timestamp.FromTime(startTime)),
-						StartOrEnd: parser.START,
-						LabelMatchers: []*labels.Matcher{
-							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   4,
+				Expr: &parser.Call{
+					Func: &parser.Function{
+						Name:       "sum_over_time",
+						ArgTypes:   []parser.ValueType{parser.ValueTypeMatrix},
+						ReturnType: parser.ValueTypeVector,
+					},
+					Args: parser.Expressions{
+						&parser.MatrixSelector{
+							VectorSelector: &parser.VectorSelector{
+								Name:       "test",
+								Timestamp:  makeInt64Pointer(timestamp.FromTime(startTime)),
+								StartOrEnd: parser.START,
+								LabelMatchers: []*labels.Matcher{
+									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
+								},
+								PosRange: posrange.PositionRange{
+									Start: 14,
+									End:   18,
+								},
+							},
+							Range:  5 * 365 * 24 * time.Hour,
+							EndPos: 32,
 						},
 					},
-					Range:  5 * 365 * 24 * time.Hour,
-					EndPos: 18,
+					PosRange: posrange.PositionRange{Start: 0, End: 32},
 				},
 			},
 		},
 		{
 			input: `test[5y] @ end()`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.MatrixSelector{
-					VectorSelector: &parser.VectorSelector{
-						Name:       "test",
-						Timestamp:  makeInt64Pointer(timestamp.FromTime(endTime)),
-						StartOrEnd: parser.END,
-						LabelMatchers: []*labels.Matcher{
-							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   4,
-						},
+			expected: &parser.MatrixSelector{
+				VectorSelector: &parser.VectorSelector{
+					Name:       "test",
+					Timestamp:  makeInt64Pointer(timestamp.FromTime(endTime)),
+					StartOrEnd: parser.END,
+					LabelMatchers: []*labels.Matcher{
+						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "test"),
 					},
-					Range:  5 * 365 * 24 * time.Hour,
-					EndPos: 16,
+					PosRange: posrange.PositionRange{
+						Start: 0,
+						End:   4,
+					},
 				},
+				Range:  5 * 365 * 24 * time.Hour,
+				EndPos: 16,
 			},
 		},
 		{

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -2304,20 +2304,16 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 	}{
 		{
 			input: "123.4567",
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.NumberLiteral{
-					Val:      123.4567,
-					PosRange: posrange.PositionRange{Start: 0, End: 8},
-				},
+			expected: &parser.NumberLiteral{
+				Val:      123.4567,
+				PosRange: posrange.PositionRange{Start: 0, End: 8},
 			},
 		},
 		{
 			input: `"foo"`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.StringLiteral{
-					Val:      "foo",
-					PosRange: posrange.PositionRange{Start: 0, End: 5},
-				},
+			expected: &parser.StringLiteral{
+				Val:      "foo",
+				PosRange: posrange.PositionRange{Start: 0, End: 5},
 			},
 		},
 		{

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1943,9 +1943,7 @@ func createLabelsForAbsentFunction(expr parser.Expr) labels.Labels {
 }
 
 func stringFromArg(e parser.Expr) string {
-	tmp := unwrapStepInvariantExpr(e) // Unwrap StepInvariant
-	unwrapParenExpr(&tmp)             // Optionally unwrap ParenExpr
-	return tmp.(*parser.StringLiteral).Val
+	return e.(*parser.StringLiteral).Val
 }
 
 func stringSliceFromArgs(args parser.Expressions) []string {


### PR DESCRIPTION
Instead of doing lots of unwrapping during the evaluation phase, take more care over what we wrap, and unwrap superfluous parens that the caller added, during the preprocessing step.

This means we only do it once, rather than on every step of a range query. Also the code gets a bit shorter.

Matrix selectors have a Timestamp which indicates they are time-invariant, so we don't need to wrap and then unwrap them when we come to use them.

Fix up tests that check very specific details which change due to this change of approach.

Separated into multiple commits for ease of understanding.

There is one remaining call to `unwrapStepInvariantExpr`, in the special handling for `timestep()`.  This seems like a bad smell, but I left it for another time.