### PR TITLE
feat: add a way to pass release notes from the PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,5 @@
 <!--
-    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"
-
-    If your PR is to fix an issue, put "Fixes #issue-number" in the description.
-
-    Don't forget!
+    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"
 
     - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.
 
@@ -17,3 +13,21 @@
 
     - All comments should start with a capital letter and end with a full stop.
  -->
+
+#### Which issue(s) does the PR fix:
+<!--
+If it applies.
+Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+-->
+
+#### Does this PR introduce a user-facing change?
+<!--
+If no, just write "NONE" in the release-notes block below.
+Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
+[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
+-->
+```release-notes
+
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,8 @@ More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-i
 If no, just write "NONE" in the release-notes block below.
 Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
 [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
+Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
+If you need help formulating your entries, consult the reviewer(s).
 -->
 ```release-notes
 

--- a/.github/workflows/check_release_notes.yml
+++ b/.github/workflows/check_release_notes.yml
@@ -1,0 +1,23 @@
+name: 'Check release notes'
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check_release_notes:
+    name: check
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'prometheus' || github.repository_owner == 'prometheus-community' # Don't run this workflow on forks.
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - env:
+          PR_DESCRIPTION: ${{ github.event.pull_request.body }}
+        run: |
+          echo "$PR_DESCRIPTION" | ./scripts/check_release_notes.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -106,7 +106,7 @@ Changes for a patch release or release candidate should be merged into the previ
 
 Bump the version in the `VERSION` file and update `CHANGELOG.md`. Do this in a proper PR pointing to the release branch as this gives others the opportunity to chime in on the release in general and on the addition to the changelog in particular. For a release candidate, append something like `-rc.0` to the version (with the corresponding changes to the tag name, the release name etc.).
 
-When updating the `CHANGELOG.md` look at all PRs included in the release since the last release and verify if they need a changelog entry.
+When updating the `CHANGELOG.md` look at all PRs included in the release since the last release and verify if they need a changelog entry. Most PRs will have their changelog entries specified in the `release-notes` blocks within their PR descriptions.
 
 Note that `CHANGELOG.md` should only document changes relevant to users of Prometheus, including external API changes, performance improvements, and new features. Do not document changes of internal interfaces, code refactorings and clean-ups, changes to the build process, etc. People interested in these are asked to refer to the git history.
 
@@ -118,6 +118,7 @@ Entries in the `CHANGELOG.md` are meant to be in this order:
 * `[CHANGE]`
 * `[FEATURE]`
 * `[ENHANCEMENT]`
+* `[PERF]`
 * `[BUGFIX]`
 
 Then bump the UI module version:

--- a/scripts/check_release_notes.sh
+++ b/scripts/check_release_notes.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+echo "Checking the release-notes block in the PR description"
+
+content=$(cat | tr -d '\r' | sed -n '/```release-notes/,/```/p' | grep -v '```' | grep -v '^[[:space:]]*$' || true)
+
+if [[ -z "$content" ]]; then
+    echo "Error: release-notes block empty or not found, see template at https://github.com/prometheus/prometheus/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1"
+    exit 1
+fi
+
+if [[ "$content" == "NONE" ]]; then
+    echo "Release note check passed, content is NONE"
+    exit 0
+fi
+
+prefixes='FEATURE|ENHANCEMENT|PERF|BUGFIX|SECURITY|CHANGE'
+
+while IFS= read -r line; do
+  if [[ ! $line =~ ^\[($prefixes)\] ]]; then
+    echo "Error: Invalid prefix in '$line'"
+    # Convert pipes to brackets
+    echo "Content should be NONE or entries should start with one of: [${prefixes//|/] [}]"
+    exit 1
+  fi
+done <<<"$content"
+
+echo "Release note check passed"

--- a/scripts/check_release_notes.sh
+++ b/scripts/check_release_notes.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -u -o pipefail
 
 echo "Checking the release-notes block in the PR description"
 
-content=$(cat | tr -d '\r' | sed -n '/```release-notes/,/```/p' | grep -v '```' | grep -v '^[[:space:]]*$' || true)
+content=$(cat | tr -d '\r' | sed -n '/```release-notes/,/```/p' | grep -v '```' | grep -v '^[[:space:]]*$')
 
 if [[ -z "$content" ]]; then
     echo "Error: release-notes block empty or not found, see template at https://github.com/prometheus/prometheus/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1"


### PR DESCRIPTION
make the release note block part of .github/PULL_REQUEST_TEMPLATE.md (inspired by k8s')

A CI check would check the input.

Once merged, this should also cover already open PRs, given a change on them is triggered?.

---

Using the PR description makes it easy for the reviewers to contribute.
Also, IMHO, it's simpler than having to run commands or add files to have it as part of the git.

We can discuss the changelog generation part later, but this should help streamline the shephard's workflow and improve their overall experience.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
-->


```release-notes
NONE
```
