### PR TITLE
UI: More inclusive metadata handling for _count/_sum/_bucket suffixes

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/MetricsExplorer/MetricsExplorer.tsx
+++ b/web/ui/mantine-ui/src/pages/query/MetricsExplorer/MetricsExplorer.tsx
@@ -1,11 +1,23 @@
 import { FC, useMemo, useState } from "react";
 import { useSuspenseAPIQuery } from "../../../api/api";
 import { MetadataResult } from "../../../api/responseTypes/metadata";
-import { ActionIcon, CopyButton, Group, Stack, Table, TextInput } from "@mantine/core";
+import {
+  ActionIcon,
+  CopyButton,
+  Group,
+  Stack,
+  Table,
+  TextInput,
+} from "@mantine/core";
 import React from "react";
 import { Fuzzy } from "@nexucis/fuzzy";
 import sanitizeHTML from "sanitize-html";
-import { IconCheck, IconCodePlus, IconCopy, IconZoomCode } from "@tabler/icons-react";
+import {
+  IconCheck,
+  IconCodePlus,
+  IconCopy,
+  IconZoomCode,
+} from "@tabler/icons-react";
 import LabelsExplorer from "./LabelsExplorer";
 import { useDebouncedValue } from "@mantine/hooks";
 import classes from "./MetricsExplorer.module.css";
@@ -55,10 +67,17 @@ const MetricsExplorer: FC<MetricsExplorerProps> = ({
     return getSearchMatches(debouncedFilterText, metricNames);
   }, [debouncedFilterText, metricNames]);
 
-  const getMeta = (m: string) =>
-    data.data[m.replace(/(_count|_sum|_bucket)$/, "")] || [
-      { help: "unknown", type: "unknown", unit: "unknown" },
-    ];
+  const getMeta = (m: string) => {
+    return (
+      // First check if the full metric name has metadata (even if it has one of the
+      // histogram/summary suffixes, it may be a metric that is not following naming
+      // conventions, see https://github.com/prometheus/prometheus/issues/16907).
+      data.data[m] ??
+      data.data[m.replace(/(_count|_sum|_bucket)$/, "")] ?? [
+        { help: "unknown", type: "unknown", unit: "unknown" },
+      ]
+    );
+  };
 
   if (selectedMetric !== null) {
     return (

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -664,9 +664,11 @@ export class HybridComplete implements CompleteStrategy {
       .then((metricMetadata) => {
         if (metricMetadata) {
           for (const [metricName, node] of metricCompletion) {
-            // For histograms and summaries, the metadata is only exposed for the base metric name,
-            // not separately for the _count, _sum, and _bucket time series.
-            const metadata = metricMetadata[metricName.replace(/(_count|_sum|_bucket)$/, '')];
+            // First check if the full metric name has metadata (even if it has one of the
+            // histogram/summary suffixes, it may be a metric that is not following naming
+            // conventions, see https://github.com/prometheus/prometheus/issues/16907).
+            // Then fall back to the base metric name if full metadata doesn't exist.
+            const metadata = metricMetadata[metricName] ?? metricMetadata[metricName.replace(/(_count|_sum|_bucket)$/, '')];
             if (metadata) {
               if (metadata.length > 1) {
                 // it means the metricName has different possible helper and type


### PR DESCRIPTION
Although these suffixes always need to be removed before querying metadata for metrics that follow the Prometheus naming best practices, there can also be metrics that don't follow these naming practices and have these suffixes without being part of either a histogram or a summary metric.

Fixes https://github.com/prometheus/prometheus/issues/16907

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
