### PR TITLE
Simplify target_info addition in the otlptranslator

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/helper.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper.go
@@ -656,12 +656,10 @@ func addResourceTargetInfo(resource pcommon.Resource, settings Settings, earlies
 			Timestamp: timestamp.UnixMilli(),
 		})
 	}
-	if len(ts.Samples) == 0 || ts.Samples[len(ts.Samples)-1].Timestamp < latestTimestamp.UnixMilli() {
-		ts.Samples = append(ts.Samples, prompb.Sample{
-			Value:     float64(1),
-			Timestamp: latestTimestamp.UnixMilli(),
-		})
-	}
+	ts.Samples = append(ts.Samples, prompb.Sample{
+		Value:     float64(1),
+		Timestamp: latestTimestamp.UnixMilli(),
+	})
 }
 
 // convertTimeStamp converts OTLP timestamp in ns to timestamp in ms.


### PR DESCRIPTION
Forked from https://github.com/prometheus/prometheus/pull/16855#discussion_r2198023417

`ts.Samples[len(ts.Samples)-1].Timestamp < latestTimestamp.UnixMilli()` is almost always true since it is usually equivalent to `timestamp.Before(latestTimestamp)` for the `timestamp` of the final iteration of the loop above, which we already know returns true. The only case where it could be false is if the batch of OTLP points all have the **exact same timestamp** (so the timestamp will be equal to latestTimestamp, not less than). In that case, you will not get a target_info metric at all, which I think is a bug

@aknuds1 .