### PR TITLE
PROM-39: Do not return info annotation for rate/increase when type is histogram

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1908,7 +1908,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 					if ev.enableTypeAndUnitLabels {
 						// When type-and-unit-labels feature is enabled, check __type__ label
 						typeLabel := inMatrix[0].Metric.Get("__type__")
-						if typeLabel != string(model.MetricTypeCounter) {
+						if typeLabel != string(model.MetricTypeCounter) && typeLabel != string(model.MetricTypeHistogram) {
 							warnings.Add(annotations.NewPossibleNonCounterLabelInfo(metricName, typeLabel, e.Args[0].PositionRange()))
 						}
 					} else if !strings.HasSuffix(metricName, "_total") &&

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3504,7 +3504,7 @@ func TestRateAnnotations(t *testing.T) {
 			expr:                     "rate(series[1m1s])",
 			typeAndUnitLabelsEnabled: true,
 			expectedInfoAnnotations: []string{
-				`PromQL info: metric might not be a counter, __type__ label is not set to "counter", got "": "series" (1:6)`,
+				`PromQL info: metric might not be a counter, __type__ label is not set to "counter" or "histogram", got "": "series" (1:6)`,
 			},
 			expectedWarningAnnotations: []string{},
 		},
@@ -3515,7 +3515,7 @@ func TestRateAnnotations(t *testing.T) {
 			expr:                     "increase(series[1m1s])",
 			typeAndUnitLabelsEnabled: true,
 			expectedInfoAnnotations: []string{
-				`PromQL info: metric might not be a counter, __type__ label is not set to "counter", got "": "series" (1:10)`,
+				`PromQL info: metric might not be a counter, __type__ label is not set to "counter" or "histogram", got "": "series" (1:10)`,
 			},
 			expectedWarningAnnotations: []string{},
 		},
@@ -3528,9 +3528,27 @@ func TestRateAnnotations(t *testing.T) {
 			expectedWarningAnnotations: []string{},
 			expectedInfoAnnotations:    []string{},
 		},
+		"no info annotation when rate() over series with __type__=histogram label": {
+			data: `
+				series{label="a", __type__="histogram"} 1 2 3
+			`,
+			expr:                       "rate(series[1m1s])",
+			typeAndUnitLabelsEnabled:   true,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
 		"no info annotation when increase() over series with __type__=counter label": {
 			data: `
 				series{label="a", __type__="counter"} 1 2 3
+			`,
+			expr:                       "increase(series[1m1s])",
+			typeAndUnitLabelsEnabled:   true,
+			expectedWarningAnnotations: []string{},
+			expectedInfoAnnotations:    []string{},
+		},
+		"no info annotation when increase() over series with __type__=histogram label": {
+			data: `
+				series{label="a", __type__="histogram"} 1 2 3
 			`,
 			expr:                       "increase(series[1m1s])",
 			typeAndUnitLabelsEnabled:   true,

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -147,7 +147,7 @@ var (
 	IncompatibleBucketLayoutInBinOpWarning     = fmt.Errorf("%w: incompatible bucket layout encountered for binary operator", PromQLWarning)
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
-	PossibleNonCounterLabelInfo             = fmt.Errorf("%w: metric might not be a counter, __type__ label is not set to %q", PromQLInfo, model.MetricTypeCounter)
+	PossibleNonCounterLabelInfo             = fmt.Errorf("%w: metric might not be a counter, __type__ label is not set to %q or %q", PromQLInfo, model.MetricTypeCounter, model.MetricTypeHistogram)
 	HistogramQuantileForcedMonotonicityInfo = fmt.Errorf("%w: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name", PromQLInfo)
 	IncompatibleTypesInBinOpInfo            = fmt.Errorf("%w: incompatible sample types encountered for binary operator", PromQLInfo)
 	HistogramIgnoredInAggregationInfo       = fmt.Errorf("%w: ignored histogram in", PromQLInfo)


### PR DESCRIPTION
#16632 added PromQL info annotations when `rate()` or `increase()` was used with series that did not have a `__type__` of "counter". However, it is valid to use `rate()` or `increase()` on histograms as well. This PR prevents the info annotation from being returned for series with `__type__` of "histogram" as well.

See docs:
https://prometheus.io/docs/prometheus/latest/querying/functions/#increase
https://prometheus.io/docs/prometheus/latest/querying/functions/#rate

Part of #16610.  