### PR TITLE
config: address edge case where local config specifies validation mode only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main / unreleased
 
 * [BUGFIX] OTLP receiver: Generate `target_info` samples between the earliest and latest samples per resource. #16737
+* [BUGFIX] Config: Infer escaping scheme when scrape config validation scheme is set.
 
 ## 3.5.0 / 2025-07-14
 

--- a/config/config.go
+++ b/config/config.go
@@ -913,6 +913,7 @@ func (c *ScrapeConfig) Validate(globalConfig GlobalConfig) error {
 	// that local ScrapeConfigs that only specify Legacy validation do not inherit
 	// the global AllowUTF8 escaping setting, which is an error.
 	if c.MetricNameEscapingScheme == "" {
+		//nolint:gocritic
 		if localValidationUnset {
 			c.MetricNameEscapingScheme = globalConfig.MetricNameEscapingScheme
 		} else if c.MetricNameValidationScheme == model.LegacyValidation {

--- a/config/config.go
+++ b/config/config.go
@@ -884,8 +884,10 @@ func (c *ScrapeConfig) Validate(globalConfig GlobalConfig) error {
 		return fmt.Errorf("unknown global name validation method specified, must be either '', 'legacy' or 'utf8', got %s", globalConfig.MetricNameValidationScheme)
 	}
 	// Scrapeconfig validation scheme matches global if left blank.
+	localValidationUnset := false
 	switch c.MetricNameValidationScheme {
 	case model.UnsetValidation:
+		localValidationUnset = true
 		c.MetricNameValidationScheme = globalConfig.MetricNameValidationScheme
 	case model.LegacyValidation, model.UTF8Validation:
 	default:
@@ -905,8 +907,19 @@ func (c *ScrapeConfig) Validate(globalConfig GlobalConfig) error {
 		return fmt.Errorf("unknown global name escaping method specified, must be one of '%s', '%s', '%s', or '%s', got %q", model.AllowUTF8, model.EscapeUnderscores, model.EscapeDots, model.EscapeValues, globalConfig.MetricNameEscapingScheme)
 	}
 
+	// Similarly, if ScrapeConfig escaping scheme is blank, infer it from the
+	// ScrapeConfig validation scheme if that was set, or the Global validation
+	// scheme if the ScrapeConfig validation scheme was also not set. This ensures
+	// that local ScrapeConfigs that only specify Legacy validation do not inherit
+	// the global AllowUTF8 escaping setting, which is an error.
 	if c.MetricNameEscapingScheme == "" {
-		c.MetricNameEscapingScheme = globalConfig.MetricNameEscapingScheme
+		if localValidationUnset {
+			c.MetricNameEscapingScheme = globalConfig.MetricNameEscapingScheme
+		} else if c.MetricNameValidationScheme == model.LegacyValidation {
+			c.MetricNameEscapingScheme = model.EscapeUnderscores
+		} else {
+			c.MetricNameEscapingScheme = model.AllowUTF8
+		}
 	}
 
 	switch c.MetricNameEscapingScheme {

--- a/config/testdata/scrape_config_local_infer_escaping.yml
+++ b/config/testdata/scrape_config_local_infer_escaping.yml
@@ -1,0 +1,3 @@
+scrape_configs:
+  - job_name: prometheus
+    metric_name_validation_scheme: legacy


### PR DESCRIPTION
This check ensures that local ScrapeConfigs that only specify Legacy validation do not inherit the default global AllowUTF8 escaping setting, which is an error.

Fixes issue reported by user: https://cloud-native.slack.com/archives/C01LSCJBXDZ/p1753376630087859