### PR TITLE
Allows the program to use promtool related check functions by introducing the package

### DIFF
--- a/cmd/promtool/config/config.go
+++ b/cmd/promtool/config/config.go
@@ -1,0 +1,632 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	promconfig "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
+	"go.yaml.in/yaml/v2"
+
+	config2 "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/file"
+	"github.com/prometheus/prometheus/discovery/kubernetes"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/rulefmt"
+	"github.com/prometheus/prometheus/notifier"
+	_ "github.com/prometheus/prometheus/plugins" // Register plugins.
+	"github.com/prometheus/prometheus/rules"
+	"github.com/prometheus/prometheus/scrape"
+)
+
+const (
+	SuccessExitCode = 0
+	FailureExitCode = 1
+	// LintErrExitCode code 3 is used for "one or more lint issues detected".
+	LintErrExitCode = 3
+
+	LintOptionAll                   = "all"
+	LintOptionDuplicateRules        = "duplicate-rules"
+	LintOptionTooLongScrapeInterval = "too-long-scrape-interval"
+	LintOptionNone                  = "none"
+)
+
+var errLint = errors.New("lint error")
+
+type RulesLintConfig struct {
+	All                  bool
+	DuplicateRules       bool
+	Fatal                bool
+	IgnoreUnknownFields  bool
+	nameValidationScheme model.ValidationScheme
+}
+
+func NewRulesLintConfig(stringVal string, fatal, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) RulesLintConfig {
+	items := strings.Split(stringVal, ",")
+	ls := RulesLintConfig{
+		Fatal:                fatal,
+		IgnoreUnknownFields:  ignoreUnknownFields,
+		nameValidationScheme: nameValidationScheme,
+	}
+	for _, setting := range items {
+		switch setting {
+		case LintOptionAll:
+			ls.All = true
+		case LintOptionDuplicateRules:
+			ls.DuplicateRules = true
+		case LintOptionNone:
+		default:
+			fmt.Printf("WARNING: unknown lint option: %q\n", setting)
+		}
+	}
+	return ls
+}
+
+//revive:disable:exported
+type ConfigLintConfig struct {
+	RulesLintConfig
+
+	lookbackDelta model.Duration
+}
+
+func NewConfigLintConfig(optionsStr string, fatal, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme, lookbackDelta model.Duration) ConfigLintConfig {
+	c := ConfigLintConfig{
+		RulesLintConfig: RulesLintConfig{
+			Fatal: fatal,
+		},
+	}
+
+	lintNone := false
+	var rulesOptions []string
+	for _, option := range strings.Split(optionsStr, ",") {
+		switch option {
+		case LintOptionAll, LintOptionTooLongScrapeInterval:
+			c.lookbackDelta = lookbackDelta
+			if option == LintOptionAll {
+				rulesOptions = append(rulesOptions, LintOptionAll)
+			}
+		case LintOptionNone:
+			lintNone = true
+		default:
+			rulesOptions = append(rulesOptions, option)
+		}
+	}
+
+	if lintNone {
+		c.lookbackDelta = 0
+		rulesOptions = nil
+	}
+
+	if len(rulesOptions) > 0 {
+		c.RulesLintConfig = NewRulesLintConfig(strings.Join(rulesOptions, ","), fatal, ignoreUnknownFields, nameValidationScheme)
+	}
+
+	return c
+}
+
+type CompareRuleType struct {
+	Metric string
+	Label  labels.Labels
+}
+
+type compareRuleTypes []CompareRuleType
+
+func (c compareRuleTypes) Len() int           { return len(c) }
+func (c compareRuleTypes) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c compareRuleTypes) Less(i, j int) bool { return compare(c[i], c[j]) < 0 }
+
+func compare(a, b CompareRuleType) int {
+	if res := strings.Compare(a.Metric, b.Metric); res != 0 {
+		return res
+	}
+
+	return labels.Compare(a.Label, b.Label)
+}
+
+func (ls RulesLintConfig) lintDuplicateRules() bool {
+	return ls.All || ls.DuplicateRules
+}
+
+type OutputWriter interface {
+	OutWriter() io.Writer
+	ErrWriter() io.Writer
+}
+
+type StdWriter struct{}
+
+func (*StdWriter) OutWriter() io.Writer {
+	return os.Stdout
+}
+
+func (*StdWriter) ErrWriter() io.Writer {
+	return os.Stderr
+}
+
+type ByteBufferWriter struct {
+	outBuffer *bytes.Buffer
+}
+
+func (b *ByteBufferWriter) String() string {
+	return b.outBuffer.String()
+}
+
+func (b *ByteBufferWriter) OutWriter() io.Writer {
+	return b.outBuffer
+}
+
+func (b *ByteBufferWriter) ErrWriter() io.Writer {
+	return b.outBuffer
+}
+
+func CheckConfigWithOutput(agentMode, checkSyntaxOnly bool, lintSettings ConfigLintConfig, files ...string) (int, string) {
+	writer := &ByteBufferWriter{
+		outBuffer: bytes.NewBuffer(nil),
+	}
+	exitCode := doCheckConfig(writer, agentMode, checkSyntaxOnly, lintSettings, files...)
+	output := writer.String()
+	return exitCode, output
+}
+
+func CheckConfig(agentMode, checkSyntaxOnly bool, lintSettings ConfigLintConfig, files ...string) int {
+	return doCheckConfig(&StdWriter{}, agentMode, checkSyntaxOnly, lintSettings, files...)
+}
+
+func doCheckConfig(writer OutputWriter, agentMode, checkSyntaxOnly bool, lintSettings ConfigLintConfig, files ...string) int {
+	failed := false
+	hasErrors := false
+
+	for _, f := range files {
+		ruleFiles, scrapeConfigs, err := checkConfig(writer, agentMode, f, checkSyntaxOnly)
+		if err != nil {
+			fmt.Fprintln(writer.ErrWriter(), "  FAILED:", err)
+			hasErrors = true
+			failed = true
+		} else {
+			if len(ruleFiles) > 0 {
+				fmt.Fprintf(writer.OutWriter(), "  SUCCESS: %d rule files found\n", len(ruleFiles))
+			}
+			fmt.Fprintf(writer.OutWriter(), " SUCCESS: %s is valid prometheus config file syntax\n", f)
+		}
+		fmt.Fprintln(writer.OutWriter())
+
+		if !checkSyntaxOnly {
+			scrapeConfigsFailed := lintScrapeConfigs(writer, scrapeConfigs, lintSettings)
+			failed = failed || scrapeConfigsFailed
+			rulesFailed, rulesHaveErrors := checkRules(writer, ruleFiles, lintSettings.RulesLintConfig)
+			failed = failed || rulesFailed
+			hasErrors = hasErrors || rulesHaveErrors
+		}
+	}
+	if failed && hasErrors {
+		return FailureExitCode
+	}
+	if failed && lintSettings.Fatal {
+		return LintErrExitCode
+	}
+	return SuccessExitCode
+}
+
+func checkConfig(writer OutputWriter, agentMode bool, filename string, checkSyntaxOnly bool) ([]string, []*config2.ScrapeConfig, error) {
+	fmt.Fprintln(writer.OutWriter(), "Checking", filename)
+
+	cfg, err := config2.LoadFile(filename, agentMode, promslog.NewNopLogger())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ruleFiles []string
+	if !checkSyntaxOnly {
+		for _, rf := range cfg.RuleFiles {
+			rfs, err := filepath.Glob(rf)
+			if err != nil {
+				return nil, nil, err
+			}
+			// If an explicit file was given, error if it is not accessible.
+			if !strings.Contains(rf, "*") {
+				if len(rfs) == 0 {
+					return nil, nil, fmt.Errorf("%q does not point to an existing file", rf)
+				}
+				if err := checkFileExists(rfs[0]); err != nil {
+					return nil, nil, fmt.Errorf("error checking rule file %q: %w", rfs[0], err)
+				}
+			}
+			ruleFiles = append(ruleFiles, rfs...)
+		}
+	}
+
+	var scfgs []*config2.ScrapeConfig
+	if checkSyntaxOnly {
+		scfgs = cfg.ScrapeConfigs
+	} else {
+		var err error
+		scfgs, err = cfg.GetScrapeConfigs()
+		if err != nil {
+			return nil, nil, fmt.Errorf("error loading scrape configs: %w", err)
+		}
+	}
+
+	for _, scfg := range scfgs {
+		if !checkSyntaxOnly && scfg.HTTPClientConfig.Authorization != nil {
+			if err := checkFileExists(scfg.HTTPClientConfig.Authorization.CredentialsFile); err != nil {
+				return nil, nil, fmt.Errorf("error checking authorization credentials or bearer token file %q: %w", scfg.HTTPClientConfig.Authorization.CredentialsFile, err)
+			}
+		}
+
+		if err := checkTLSConfig(scfg.HTTPClientConfig.TLSConfig, checkSyntaxOnly); err != nil {
+			return nil, nil, err
+		}
+
+		for _, c := range scfg.ServiceDiscoveryConfigs {
+			switch c := c.(type) {
+			case *kubernetes.SDConfig:
+				if err := checkTLSConfig(c.HTTPClientConfig.TLSConfig, checkSyntaxOnly); err != nil {
+					return nil, nil, err
+				}
+			case *file.SDConfig:
+				if checkSyntaxOnly {
+					break
+				}
+				for _, file := range c.Files {
+					files, err := filepath.Glob(file)
+					if err != nil {
+						return nil, nil, err
+					}
+					if len(files) != 0 {
+						for _, f := range files {
+							var targetGroups []*targetgroup.Group
+							targetGroups, err = checkSDFile(f)
+							if err != nil {
+								return nil, nil, fmt.Errorf("checking SD file %q: %w", file, err)
+							}
+							if err := checkTargetGroupsForScrapeConfig(targetGroups, scfg); err != nil {
+								return nil, nil, err
+							}
+						}
+						continue
+					}
+					fmt.Printf("  WARNING: file %q for file_sd in scrape job %q does not exist\n", file, scfg.JobName)
+				}
+			case discovery.StaticConfig:
+				if err := checkTargetGroupsForScrapeConfig(c, scfg); err != nil {
+					return nil, nil, err
+				}
+			}
+		}
+	}
+
+	alertConfig := cfg.AlertingConfig
+	for _, amcfg := range alertConfig.AlertmanagerConfigs {
+		for _, c := range amcfg.ServiceDiscoveryConfigs {
+			switch c := c.(type) {
+			case *file.SDConfig:
+				if checkSyntaxOnly {
+					break
+				}
+				for _, file := range c.Files {
+					files, err := filepath.Glob(file)
+					if err != nil {
+						return nil, nil, err
+					}
+					if len(files) != 0 {
+						for _, f := range files {
+							var targetGroups []*targetgroup.Group
+							targetGroups, err = checkSDFile(f)
+							if err != nil {
+								return nil, nil, fmt.Errorf("checking SD file %q: %w", file, err)
+							}
+
+							if err := checkTargetGroupsForAlertmanager(targetGroups, amcfg); err != nil {
+								return nil, nil, err
+							}
+						}
+						continue
+					}
+					fmt.Printf("  WARNING: file %q for file_sd in alertmanager config does not exist\n", file)
+				}
+			case discovery.StaticConfig:
+				if err := checkTargetGroupsForAlertmanager(c, amcfg); err != nil {
+					return nil, nil, err
+				}
+			}
+		}
+	}
+	return ruleFiles, scfgs, nil
+}
+
+func checkTLSConfig(tlsConfig promconfig.TLSConfig, checkSyntaxOnly bool) error {
+	if len(tlsConfig.CertFile) > 0 && len(tlsConfig.KeyFile) == 0 {
+		return fmt.Errorf("client cert file %q specified without client key file", tlsConfig.CertFile)
+	}
+	if len(tlsConfig.KeyFile) > 0 && len(tlsConfig.CertFile) == 0 {
+		return fmt.Errorf("client key file %q specified without client cert file", tlsConfig.KeyFile)
+	}
+
+	if checkSyntaxOnly {
+		return nil
+	}
+
+	if err := checkFileExists(tlsConfig.CertFile); err != nil {
+		return fmt.Errorf("error checking client cert file %q: %w", tlsConfig.CertFile, err)
+	}
+	if err := checkFileExists(tlsConfig.KeyFile); err != nil {
+		return fmt.Errorf("error checking client key file %q: %w", tlsConfig.KeyFile, err)
+	}
+
+	return nil
+}
+
+func lintScrapeConfigs(writer OutputWriter, scrapeConfigs []*config2.ScrapeConfig, lintSettings ConfigLintConfig) bool {
+	for _, scfg := range scrapeConfigs {
+		if lintSettings.lookbackDelta > 0 && scfg.ScrapeInterval >= lintSettings.lookbackDelta {
+			fmt.Fprintf(writer.ErrWriter(), "  FAILED: too long scrape interval found, data point will be marked as stale - job: %s, interval: %s\n", scfg.JobName, scfg.ScrapeInterval)
+			return true
+		}
+	}
+	return false
+}
+
+func checkRules(writer OutputWriter, files []string, ls RulesLintConfig) (bool, bool) {
+	failed := false
+	hasErrors := false
+	for _, f := range files {
+		fmt.Fprintln(writer.OutWriter(), "Checking", f)
+		rgs, errs := rulefmt.ParseFile(f, ls.IgnoreUnknownFields, model.UTF8Validation)
+		if errs != nil {
+			failed = true
+			fmt.Fprintln(writer.ErrWriter(), "  FAILED:")
+			for _, e := range errs {
+				fmt.Fprintln(writer.ErrWriter(), e.Error())
+				hasErrors = hasErrors || !errors.Is(e, errLint)
+			}
+			if hasErrors {
+				continue
+			}
+		}
+		if n, errs := checkRuleGroups(rgs, ls); errs != nil {
+			fmt.Fprintln(writer.ErrWriter(), "  FAILED:")
+			for _, e := range errs {
+				fmt.Fprintln(writer.ErrWriter(), e.Error())
+			}
+			failed = true
+			for _, err := range errs {
+				hasErrors = hasErrors || !errors.Is(err, errLint)
+			}
+		} else {
+			fmt.Fprintf(writer.OutWriter(), "  SUCCESS: %d rules found\n", n)
+		}
+		fmt.Fprintln(writer.OutWriter())
+	}
+	return failed, hasErrors
+}
+
+func checkRuleGroups(rgs *rulefmt.RuleGroups, lintSettings RulesLintConfig) (int, []error) {
+	numRules := 0
+	for _, rg := range rgs.Groups {
+		numRules += len(rg.Rules)
+	}
+
+	if lintSettings.lintDuplicateRules() {
+		dRules := CheckDuplicates(rgs.Groups)
+		if len(dRules) != 0 {
+			errMessage := fmt.Sprintf("%d duplicate rule(s) found.\n", len(dRules))
+			for _, n := range dRules {
+				errMessage += fmt.Sprintf("Metric: %s\nLabel(s):\n", n.Metric)
+				n.Label.Range(func(l labels.Label) {
+					errMessage += fmt.Sprintf("\t%s: %s\n", l.Name, l.Value)
+				})
+			}
+			errMessage += "Might cause inconsistency while recording expressions"
+			return 0, []error{fmt.Errorf("%w %s", errLint, errMessage)}
+		}
+	}
+
+	return numRules, nil
+}
+
+func checkTargetGroupsForAlertmanager(targetGroups []*targetgroup.Group, amcfg *config2.AlertmanagerConfig) error {
+	for _, tg := range targetGroups {
+		if _, _, err := notifier.AlertmanagerFromGroup(tg, amcfg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkTargetGroupsForScrapeConfig(targetGroups []*targetgroup.Group, scfg *config2.ScrapeConfig) error {
+	var targets []*scrape.Target
+	lb := labels.NewBuilder(labels.EmptyLabels())
+	for _, tg := range targetGroups {
+		var failures []error
+		targets, failures = scrape.TargetsFromGroup(tg, scfg, targets, lb)
+		if len(failures) > 0 {
+			first := failures[0]
+			return first
+		}
+	}
+
+	return nil
+}
+
+func CheckDuplicates(groups []rulefmt.RuleGroup) []CompareRuleType {
+	var duplicates []CompareRuleType
+	var cRules compareRuleTypes
+
+	for _, group := range groups {
+		for _, rule := range group.Rules {
+			cRules = append(cRules, CompareRuleType{
+				Metric: ruleMetric(rule),
+				Label:  rules.FromMaps(group.Labels, rule.Labels),
+			})
+		}
+	}
+	if len(cRules) < 2 {
+		return duplicates
+	}
+	sort.Sort(cRules)
+
+	last := cRules[0]
+	for i := 1; i < len(cRules); i++ {
+		if compare(last, cRules[i]) == 0 {
+			// Don't add a duplicated rule multiple times.
+			if len(duplicates) == 0 || compare(last, duplicates[len(duplicates)-1]) != 0 {
+				duplicates = append(duplicates, cRules[i])
+			}
+		}
+		last = cRules[i]
+	}
+
+	return duplicates
+}
+
+func checkSDFile(filename string) ([]*targetgroup.Group, error) {
+	fd, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	content, err := io.ReadAll(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	var targetGroups []*targetgroup.Group
+
+	switch ext := filepath.Ext(filename); strings.ToLower(ext) {
+	case ".json":
+		if err := json.Unmarshal(content, &targetGroups); err != nil {
+			return nil, err
+		}
+	case ".yml", ".yaml":
+		if err := yaml.UnmarshalStrict(content, &targetGroups); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("invalid file extension: %q", ext)
+	}
+
+	for i, tg := range targetGroups {
+		if tg == nil {
+			return nil, fmt.Errorf("nil target group item found (index %d)", i)
+		}
+	}
+
+	return targetGroups, nil
+}
+
+func ruleMetric(rule rulefmt.Rule) string {
+	if rule.Alert != "" {
+		return rule.Alert
+	}
+	return rule.Record
+}
+
+func checkFileExists(fn string) error {
+	// Nothing set, nothing to error on.
+	if fn == "" {
+		return nil
+	}
+	_, err := os.Stat(fn)
+	return err
+}
+
+func CheckRulesWithOutput(ls RulesLintConfig, files ...string) (int, string) {
+	writer := &ByteBufferWriter{
+		outBuffer: bytes.NewBuffer(nil),
+	}
+
+	failed, hasErrors := checkRules(writer, files, ls)
+	output := writer.String()
+	if failed && hasErrors {
+		return FailureExitCode, output
+	}
+	if failed && ls.Fatal {
+		return LintErrExitCode, output
+	}
+
+	return SuccessExitCode, output
+}
+
+// CheckRules validates rule files.
+func CheckRules(ls RulesLintConfig, enableStdin bool, files ...string) int {
+	failed := false
+	hasErrors := false
+	if len(files) == 0 {
+		if enableStdin {
+			failed, hasErrors = CheckRulesFromStdin(ls)
+		}
+	} else {
+		failed, hasErrors = checkRules(&StdWriter{}, files, ls)
+	}
+
+	if failed && hasErrors {
+		return FailureExitCode
+	}
+	if failed && ls.Fatal {
+		return LintErrExitCode
+	}
+
+	return SuccessExitCode
+}
+
+// CheckRulesFromStdin validates rule from stdin.
+func CheckRulesFromStdin(ls RulesLintConfig) (bool, bool) {
+	failed := false
+	hasErrors := false
+	fmt.Println("Checking standard input")
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "  FAILED:", err)
+		return true, true
+	}
+	rgs, errs := rulefmt.Parse(data, ls.IgnoreUnknownFields, model.UTF8Validation)
+	if errs != nil {
+		failed = true
+		fmt.Fprintln(os.Stderr, "  FAILED:")
+		for _, e := range errs {
+			fmt.Fprintln(os.Stderr, e.Error())
+			hasErrors = hasErrors || !errors.Is(e, errLint)
+		}
+		if hasErrors {
+			return failed, hasErrors
+		}
+	}
+	if n, errs := checkRuleGroups(rgs, ls); errs != nil {
+		fmt.Fprintln(os.Stderr, "  FAILED:")
+		for _, e := range errs {
+			fmt.Fprintln(os.Stderr, e.Error())
+		}
+		failed = true
+		for _, err := range errs {
+			hasErrors = hasErrors || !errors.Is(err, errLint)
+		}
+	} else {
+		fmt.Printf("  SUCCESS: %d rules found\n", n)
+	}
+	fmt.Println()
+	return failed, hasErrors
+}

--- a/cmd/promtool/config/config_test.go
+++ b/cmd/promtool/config/config_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckScrapeConfigs(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		lookbackDelta model.Duration
+		expectError   bool
+	}{
+		{
+			name:          "scrape interval less than lookback delta",
+			lookbackDelta: model.Duration(11 * time.Minute),
+			expectError:   false,
+		},
+		{
+			name:          "scrape interval greater than lookback delta",
+			lookbackDelta: model.Duration(5 * time.Minute),
+			expectError:   true,
+		},
+		{
+			name:          "scrape interval same as lookback delta",
+			lookbackDelta: model.Duration(10 * time.Minute),
+			expectError:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Non-fatal linting.
+			code := CheckConfig(false, false, NewConfigLintConfig(LintOptionTooLongScrapeInterval, false, false, model.UTF8Validation, tc.lookbackDelta), "../testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			require.Equal(t, SuccessExitCode, code, "Non-fatal linting should return success")
+			// Fatal linting.
+			code = CheckConfig(false, false, NewConfigLintConfig(LintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), "../testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			if tc.expectError {
+				require.Equal(t, LintErrExitCode, code, "Fatal linting should return error")
+			} else {
+				require.Equal(t, SuccessExitCode, code, "Fatal linting should return success when there are no problems")
+			}
+			// Check syntax only, no linting.
+			code = CheckConfig(false, true, NewConfigLintConfig(LintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), "../testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			require.Equal(t, SuccessExitCode, code, "Fatal linting should return success when checking syntax only")
+			// Lint option "none" should disable linting.
+			code = CheckConfig(false, false, NewConfigLintConfig(LintOptionNone+","+LintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), "../testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			require.Equal(t, SuccessExitCode, code, `Fatal linting should return success when lint option "none" is specified`)
+		})
+	}
+}
+
+func TestCheckScrapeConfigsWithOutput(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		lookbackDelta model.Duration
+		expectError   bool
+	}{
+		{
+			name:          "scrape interval less than lookback delta",
+			lookbackDelta: model.Duration(11 * time.Minute),
+			expectError:   false,
+		},
+		{
+			name:          "scrape interval greater than lookback delta",
+			lookbackDelta: model.Duration(5 * time.Minute),
+			expectError:   true,
+		},
+		{
+			name:          "scrape interval same as lookback delta",
+			lookbackDelta: model.Duration(10 * time.Minute),
+			expectError:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Non-fatal linting.
+			code, output := CheckConfigWithOutput(false, false, NewConfigLintConfig(LintOptionTooLongScrapeInterval, false, false, model.UTF8Validation, tc.lookbackDelta), "../testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			require.Equal(t, SuccessExitCode, code, "Non-fatal linting should return success")
+			require.NotEmpty(t, output, "Non-fatal linting should produce output")
+			// Fatal linting.
+			code, output = CheckConfigWithOutput(false, false, NewConfigLintConfig(LintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), "../testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			if tc.expectError {
+				require.Equal(t, LintErrExitCode, code, "Fatal linting should return error")
+			} else {
+				require.Equal(t, SuccessExitCode, code, "Fatal linting should return success when there are no problems")
+			}
+			require.NotEmpty(t, output, "Non-fatal linting should produce output")
+			// Check syntax only, no linting.
+			code, output = CheckConfigWithOutput(false, true, NewConfigLintConfig(LintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), "../testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			require.Equal(t, SuccessExitCode, code, "Fatal linting should return success when checking syntax only")
+			require.NotEmpty(t, output, "Non-fatal linting should produce output")
+			// Lint option "none" should disable linting.
+			code, output = CheckConfigWithOutput(false, false, NewConfigLintConfig(LintOptionNone+","+LintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), "../testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			require.Equal(t, SuccessExitCode, code, `Fatal linting should return success when lint option "none" is specified`)
+			require.NotEmpty(t, output, "Non-fatal linting should produce output")
+		})
+	}
+}
+
+func TestCheckRulesWithOutput(t *testing.T) {
+	t.Run("rules-good", func(t *testing.T) {
+		t.Parallel()
+		exitCode, output := CheckRulesWithOutput(NewRulesLintConfig(LintOptionDuplicateRules, false, false, model.UTF8Validation), "../testdata/rules.yml")
+		require.NotEmpty(t, output, "rules-good should produce output")
+		t.Logf("rules-good output:\n%s", output)
+		require.Equal(t, SuccessExitCode, exitCode)
+	})
+
+	t.Run("rules-bad", func(t *testing.T) {
+		t.Parallel()
+		exitCode, output := CheckRulesWithOutput(NewRulesLintConfig(LintOptionDuplicateRules, false, false, model.UTF8Validation), "../testdata/rules-bad.yml")
+		require.NotEmpty(t, output, "rules-bad should produce output")
+		t.Logf("rules-bad output:\n%s", output)
+		require.Equal(t, FailureExitCode, exitCode)
+	})
+
+	t.Run("rules-lint-fatal", func(t *testing.T) {
+		t.Parallel()
+		exitCode, output := CheckRulesWithOutput(NewRulesLintConfig(LintOptionDuplicateRules, true, false, model.UTF8Validation), "../testdata/prometheus-rules.lint.yml")
+		require.NotEmpty(t, output, "rules-lint-fatal should produce output")
+		t.Logf("rules-lint-fatal output:\n%s", output)
+		require.Equal(t, LintErrExitCode, exitCode)
+	})
+}

--- a/cmd/promtool/config/sd_test.go
+++ b/cmd/promtool/config/sd_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"testing"
@@ -72,4 +72,69 @@ func TestSDCheckResult(t *testing.T) {
 	}
 
 	testutil.RequireEqual(t, expectedSDCheckResult, getSDCheckResult(targetGroups, scrapeConfig))
+}
+
+func TestCheckSD(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		file     string
+		jobName  string
+		exitCode int
+	}{
+		{
+			name:     "check SD with good job name",
+			file:     "config_with_service_discovery_files.yml",
+			jobName:  "prometheus",
+			exitCode: SuccessExitCode,
+		},
+		{
+			name:     "check SD with bad job name",
+			file:     "config_with_service_discovery_files.yml",
+			jobName:  "bad_job_name",
+			exitCode: FailureExitCode,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			exitCode := CheckSD("../testdata/"+test.file, test.jobName, 5*time.Second, nil)
+			require.Equal(t, test.exitCode, exitCode)
+		})
+	}
+}
+
+func TestCheckSDWithOutput(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		file      string
+		jobName   string
+		exitCode  int
+		logOutput bool
+	}{
+		{
+			name:     "check SD with good job name",
+			file:     "config_with_service_discovery_files.yml",
+			jobName:  "prometheus",
+			exitCode: SuccessExitCode,
+		},
+		{
+			name:      "check SD with bad job name",
+			file:      "config_with_service_discovery_files.yml",
+			jobName:   "bad_job_name",
+			exitCode:  FailureExitCode,
+			logOutput: true,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			exitCode, output := CheckSDWithOutput("../testdata/"+test.file, test.jobName, 5*time.Second, nil)
+			if test.logOutput {
+				t.Logf("%s output:\n%s", test.name, output)
+			}
+			require.Equal(t, test.exitCode, exitCode)
+		})
+	}
 }

--- a/cmd/promtool/metrics.go
+++ b/cmd/promtool/metrics.go
@@ -26,6 +26,7 @@ import (
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
+	"github.com/prometheus/prometheus/cmd/promtool/config"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/util/compression"
 	"github.com/prometheus/prometheus/util/fmtutil"
@@ -36,7 +37,7 @@ func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[strin
 	addressURL, err := url.Parse(url.String())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return failureExitCode
+		return config.FailureExitCode
 	}
 
 	// build remote write client
@@ -46,7 +47,7 @@ func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[strin
 	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return failureExitCode
+		return config.FailureExitCode
 	}
 
 	// set custom tls config from httpConfigFilePath
@@ -54,7 +55,7 @@ func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[strin
 	client, ok := writeClient.(*remote.Client)
 	if !ok {
 		fmt.Fprintln(os.Stderr, fmt.Errorf("unexpected type %T", writeClient))
-		return failureExitCode
+		return config.FailureExitCode
 	}
 	client.Client.Transport = &setHeadersTransport{
 		RoundTripper: roundTripper,
@@ -68,14 +69,14 @@ func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[strin
 		data, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "  FAILED:", err)
-			return failureExitCode
+			return config.FailureExitCode
 		}
 		fmt.Printf("Parsing standard input\n")
 		if parseAndPushMetrics(client, data, labels) {
 			fmt.Printf("  SUCCESS: metrics pushed to remote write.\n")
-			return successExitCode
+			return config.SuccessExitCode
 		}
-		return failureExitCode
+		return config.FailureExitCode
 	}
 
 	for _, file := range files {
@@ -95,10 +96,10 @@ func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[strin
 	}
 
 	if failed {
-		return failureExitCode
+		return config.FailureExitCode
 	}
 
-	return successExitCode
+	return config.SuccessExitCode
 }
 
 // TODO(bwplotka): Add PRW 2.0 support.

--- a/cmd/promtool/query.go
+++ b/cmd/promtool/query.go
@@ -29,6 +29,7 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/prometheus/prometheus/cmd/promtool/config"
 	_ "github.com/prometheus/prometheus/plugins" // Register plugins.
 )
 
@@ -65,7 +66,7 @@ func QueryInstant(url *url.URL, roundTripper http.RoundTripper, query, evalTime 
 	api, err := newAPI(url, roundTripper, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating API client:", err)
-		return failureExitCode
+		return config.FailureExitCode
 	}
 
 	eTime := time.Now()
@@ -73,7 +74,7 @@ func QueryInstant(url *url.URL, roundTripper http.RoundTripper, query, evalTime 
 		eTime, err = parseTime(evalTime)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "error parsing evaluation time:", err)
-			return failureExitCode
+			return config.FailureExitCode
 		}
 	}
 
@@ -87,7 +88,7 @@ func QueryInstant(url *url.URL, roundTripper http.RoundTripper, query, evalTime 
 
 	p.printValue(val)
 
-	return successExitCode
+	return config.SuccessExitCode
 }
 
 // QueryRange performs a range query against a Prometheus server.
@@ -95,7 +96,7 @@ func QueryRange(url *url.URL, roundTripper http.RoundTripper, headers map[string
 	api, err := newAPI(url, roundTripper, headers)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating API client:", err)
-		return failureExitCode
+		return config.FailureExitCode
 	}
 
 	var stime, etime time.Time
@@ -106,7 +107,7 @@ func QueryRange(url *url.URL, roundTripper http.RoundTripper, headers map[string
 		etime, err = parseTime(end)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "error parsing end time:", err)
-			return failureExitCode
+			return config.FailureExitCode
 		}
 	}
 
@@ -116,13 +117,13 @@ func QueryRange(url *url.URL, roundTripper http.RoundTripper, headers map[string
 		stime, err = parseTime(start)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "error parsing start time:", err)
-			return failureExitCode
+			return config.FailureExitCode
 		}
 	}
 
 	if !stime.Before(etime) {
 		fmt.Fprintln(os.Stderr, "start time is not before end time")
-		return failureExitCode
+		return config.FailureExitCode
 	}
 
 	if step == 0 {
@@ -142,7 +143,7 @@ func QueryRange(url *url.URL, roundTripper http.RoundTripper, headers map[string
 	}
 
 	p.printValue(val)
-	return successExitCode
+	return config.SuccessExitCode
 }
 
 // QuerySeries queries for a series against a Prometheus server.
@@ -150,13 +151,13 @@ func QuerySeries(url *url.URL, roundTripper http.RoundTripper, matchers []string
 	api, err := newAPI(url, roundTripper, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating API client:", err)
-		return failureExitCode
+		return config.FailureExitCode
 	}
 
 	stime, etime, err := parseStartTimeAndEndTime(start, end)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return failureExitCode
+		return config.FailureExitCode
 	}
 
 	// Run query against client.
@@ -169,7 +170,7 @@ func QuerySeries(url *url.URL, roundTripper http.RoundTripper, matchers []string
 	}
 
 	p.printSeries(val)
-	return successExitCode
+	return config.SuccessExitCode
 }
 
 // QueryLabels queries for label values against a Prometheus server.
@@ -177,13 +178,13 @@ func QueryLabels(url *url.URL, roundTripper http.RoundTripper, matchers []string
 	api, err := newAPI(url, roundTripper, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating API client:", err)
-		return failureExitCode
+		return config.FailureExitCode
 	}
 
 	stime, etime, err := parseStartTimeAndEndTime(start, end)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return failureExitCode
+		return config.FailureExitCode
 	}
 
 	// Run query against client.
@@ -199,7 +200,7 @@ func QueryLabels(url *url.URL, roundTripper http.RoundTripper, matchers []string
 	}
 
 	p.printLabelValues(val)
-	return successExitCode
+	return config.SuccessExitCode
 }
 
 func handleAPIError(err error) int {
@@ -210,7 +211,7 @@ func handleAPIError(err error) int {
 		fmt.Fprintln(os.Stderr, "query error:", err)
 	}
 
-	return failureExitCode
+	return config.FailureExitCode
 }
 
 func parseStartTimeAndEndTime(start, end string) (time.Time, time.Time, error) {

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"go.yaml.in/yaml/v2"
 
+	"github.com/prometheus/prometheus/cmd/promtool/config"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -78,9 +79,9 @@ func RulesUnitTestResult(results io.Writer, queryOpts promqltest.LazyLoaderOpts,
 		fmt.Fprintf(os.Stderr, "failed to write JUnit XML: %s\n", err)
 	}
 	if failed {
-		return failureExitCode
+		return config.FailureExitCode
 	}
-	return successExitCode
+	return config.SuccessExitCode
 }
 
 func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, run *regexp.Regexp, diffFlag, debug, ignoreUnknownFields bool, ts *junitxml.TestSuite) []error {


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
This PR places promtool-related APIs in its own package, supporting promtool and external calls.
When called through go lib, the original standard (including exceptions) output will be output through the return parameter to facilitate logging.
Resolves https://github.com/prometheus/prometheus/issues/15852.

Example:
```
package main

import (
	"fmt"
	"github.com/prometheus/common/model"
	"github.com/prometheus/prometheus/cmd/promtool/config"
	"time"
)

func main() {

	code, output := config.CheckConfigWithOutput(false, false, config.NewConfigLintConfig(config.LintOptionTooLongScrapeInterval, false, false, model.Duration(5*time.Minute)), "./testdata/prometheus-config.lint.too_long_scrape_interval.yml")
	fmt.Println("Exit code:", code)
	fmt.Println("Output:")
	fmt.Print(output)
}
```

Result:
```
Exit code: 0
Output:
Checking ./testdata/prometheus-config.lint.too_long_scrape_interval.yml
 SUCCESS: ./testdata/prometheus-config.lint.too_long_scrape_interval.yml is valid prometheus config file syntax

  FAILED: too long scrape interval found, data point will be marked as stale - job: too_long_scrape_interval_test, interval: 10m

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[ENHANCEMENT] Allows the program to use promtool related check functions by introducing the package
```


