### PR TITLE
repo sync: allow manual triggering

### DIFF
--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -3,6 +3,7 @@ name: Sync repo files
 on:
   schedule:
     - cron: '44 17 * * *'
+  workflow_dispatch: {}
 permissions:
   contents: read
 


### PR DESCRIPTION
Add a [workflow dispatch](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch) trigger to allow [manual triggering](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) of the repo sync workflow.

I am often behind on merging the repo sync PRs. The script does not update them, and I don't have the nerve right now to figure _that_ out. As a workaround, it would be useful to trigger it manually after merging the outstanding ones, so I can get a fresh round on the same day.
