### PR TITLE
chore: enable unused-receiver rule from revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -160,6 +160,7 @@ linters:
         - name: unexported-return
         - name: unreachable-code
         - name: unused-parameter
+        - name: unused-receiver
         - name: var-declaration
         - name: var-naming
     testifylint:

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -99,7 +99,7 @@ type klogv1Writer struct{}
 // This is a hack to support klogv1 without use of go-kit/log. It is inspired
 // by klog's upstream klogv1/v2 coexistence example:
 // https://github.com/kubernetes/klog/blob/main/examples/coexist_klog_v1_and_v2/coexist_klog_v1_and_v2.go
-func (kw klogv1Writer) Write(p []byte) (n int, err error) {
+func (klogv1Writer) Write(p []byte) (n int, err error) {
 	if len(p) < klogv1DefaultPrefixLength {
 		klogv2.InfoDepth(klogv1OutputCallDepth, string(p))
 		return len(p), nil
@@ -157,7 +157,7 @@ func init() {
 // serverOnlyFlag creates server-only kingpin flag.
 func serverOnlyFlag(app *kingpin.Application, name, help string) *kingpin.FlagClause {
 	return app.Flag(name, fmt.Sprintf("%s Use with server mode only.", help)).
-		PreAction(func(_ *kingpin.ParseContext) error {
+		PreAction(func(*kingpin.ParseContext) error {
 			// This will be invoked only if flag is actually provided by user.
 			serverOnlyFlags = append(serverOnlyFlags, "--"+name)
 			return nil
@@ -167,7 +167,7 @@ func serverOnlyFlag(app *kingpin.Application, name, help string) *kingpin.FlagCl
 // agentOnlyFlag creates agent-only kingpin flag.
 func agentOnlyFlag(app *kingpin.Application, name, help string) *kingpin.FlagClause {
 	return app.Flag(name, fmt.Sprintf("%s Use with agent mode only.", help)).
-		PreAction(func(_ *kingpin.ParseContext) error {
+		PreAction(func(*kingpin.ParseContext) error {
 			// This will be invoked only if flag is actually provided by user.
 			agentOnlyFlags = append(agentOnlyFlags, "--"+name)
 			return nil
@@ -568,7 +568,7 @@ func main() {
 
 	promslogflag.AddFlags(a, &cfg.promslogConfig)
 
-	a.Flag("write-documentation", "Generate command line documentation. Internal use.").Hidden().Action(func(_ *kingpin.ParseContext) error {
+	a.Flag("write-documentation", "Generate command line documentation. Internal use.").Hidden().Action(func(*kingpin.ParseContext) error {
 		if err := documentcli.GenerateMarkdown(a.Model(), os.Stdout); err != nil {
 			os.Exit(1)
 			return err
@@ -1082,7 +1082,7 @@ func main() {
 				}
 				return nil
 			},
-			func(_ error) {
+			func(error) {
 				close(cancel)
 				webHandler.SetReady(web.Stopping)
 				notifs.AddNotification(notifications.ShuttingDown)
@@ -1097,7 +1097,7 @@ func main() {
 				logger.Info("Scrape discovery manager stopped")
 				return err
 			},
-			func(_ error) {
+			func(error) {
 				logger.Info("Stopping scrape discovery manager...")
 				cancelScrape()
 			},
@@ -1111,7 +1111,7 @@ func main() {
 				logger.Info("Notify discovery manager stopped")
 				return err
 			},
-			func(_ error) {
+			func(error) {
 				logger.Info("Stopping notify discovery manager...")
 				cancelNotify()
 			},
@@ -1125,7 +1125,7 @@ func main() {
 				ruleManager.Run()
 				return nil
 			},
-			func(_ error) {
+			func(error) {
 				ruleManager.Stop()
 			},
 		)
@@ -1144,7 +1144,7 @@ func main() {
 				logger.Info("Scrape manager stopped")
 				return err
 			},
-			func(_ error) {
+			func(error) {
 				// Scrape manager needs to be stopped before closing the local TSDB
 				// so that it doesn't try to write samples to a closed storage.
 				// We should also wait for rule manager to be fully stopped to ensure
@@ -1162,7 +1162,7 @@ func main() {
 				tracingManager.Run()
 				return nil
 			},
-			func(_ error) {
+			func(error) {
 				tracingManager.Stop()
 			},
 		)
@@ -1243,7 +1243,7 @@ func main() {
 					}
 				}
 			},
-			func(_ error) {
+			func(error) {
 				// Wait for any in-progress reloads to complete to avoid
 				// reloading things after they have been shutdown.
 				cancel <- struct{}{}
@@ -1275,7 +1275,7 @@ func main() {
 				<-cancel
 				return nil
 			},
-			func(_ error) {
+			func(error) {
 				close(cancel)
 			},
 		)
@@ -1328,7 +1328,7 @@ func main() {
 				<-cancel
 				return nil
 			},
-			func(_ error) {
+			func(error) {
 				if err := fanoutStorage.Close(); err != nil {
 					logger.Error("Error stopping storage", "err", err)
 				}
@@ -1383,7 +1383,7 @@ func main() {
 				<-cancel
 				return nil
 			},
-			func(_ error) {
+			func(error) {
 				if err := fanoutStorage.Close(); err != nil {
 					logger.Error("Error stopping storage", "err", err)
 				}
@@ -1400,7 +1400,7 @@ func main() {
 				}
 				return nil
 			},
-			func(_ error) {
+			func(error) {
 				cancelWeb()
 			},
 		)
@@ -1422,7 +1422,7 @@ func main() {
 				logger.Info("Notifier manager stopped")
 				return nil
 			},
-			func(_ error) {
+			func(error) {
 				notifierManager.Stop()
 			},
 		)
@@ -1703,35 +1703,35 @@ func (s *readyStorage) Appender(ctx context.Context) storage.Appender {
 type notReadyAppender struct{}
 
 // SetOptions does nothing in this appender implementation.
-func (n notReadyAppender) SetOptions(_ *storage.AppendOptions) {}
+func (notReadyAppender) SetOptions(*storage.AppendOptions) {}
 
-func (n notReadyAppender) Append(_ storage.SeriesRef, _ labels.Labels, _ int64, _ float64) (storage.SeriesRef, error) {
+func (notReadyAppender) Append(storage.SeriesRef, labels.Labels, int64, float64) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
 
-func (n notReadyAppender) AppendExemplar(_ storage.SeriesRef, _ labels.Labels, _ exemplar.Exemplar) (storage.SeriesRef, error) {
+func (notReadyAppender) AppendExemplar(storage.SeriesRef, labels.Labels, exemplar.Exemplar) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
 
-func (n notReadyAppender) AppendHistogram(_ storage.SeriesRef, _ labels.Labels, _ int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
+func (notReadyAppender) AppendHistogram(storage.SeriesRef, labels.Labels, int64, *histogram.Histogram, *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
 
-func (n notReadyAppender) AppendHistogramCTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, _ int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
+func (notReadyAppender) AppendHistogramCTZeroSample(storage.SeriesRef, labels.Labels, int64, int64, *histogram.Histogram, *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
 
-func (n notReadyAppender) UpdateMetadata(_ storage.SeriesRef, _ labels.Labels, _ metadata.Metadata) (storage.SeriesRef, error) {
+func (notReadyAppender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
 
-func (n notReadyAppender) AppendCTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, _ int64) (storage.SeriesRef, error) {
+func (notReadyAppender) AppendCTZeroSample(storage.SeriesRef, labels.Labels, int64, int64) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
 
-func (n notReadyAppender) Commit() error { return tsdb.ErrNotReady }
+func (notReadyAppender) Commit() error { return tsdb.ErrNotReady }
 
-func (n notReadyAppender) Rollback() error { return tsdb.ErrNotReady }
+func (notReadyAppender) Rollback() error { return tsdb.ErrNotReady }
 
 // Close implements the Storage interface.
 func (s *readyStorage) Close() error {
@@ -1941,7 +1941,7 @@ func rwProtoMsgFlagValue(msgs *[]config.RemoteWriteProtoMsg) kingpin.Value {
 }
 
 // IsCumulative is used by kingpin to tell if it's an array or not.
-func (p *rwProtoMsgFlagParser) IsCumulative() bool {
+func (*rwProtoMsgFlagParser) IsCumulative() bool {
 	return true
 }
 

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -1190,17 +1190,17 @@ type printer interface {
 
 type promqlPrinter struct{}
 
-func (p *promqlPrinter) printValue(v model.Value) {
+func (*promqlPrinter) printValue(v model.Value) {
 	fmt.Println(v)
 }
 
-func (p *promqlPrinter) printSeries(val []model.LabelSet) {
+func (*promqlPrinter) printSeries(val []model.LabelSet) {
 	for _, v := range val {
 		fmt.Println(v)
 	}
 }
 
-func (p *promqlPrinter) printLabelValues(val model.LabelValues) {
+func (*promqlPrinter) printLabelValues(val model.LabelValues) {
 	for _, v := range val {
 		fmt.Println(v)
 	}
@@ -1208,17 +1208,17 @@ func (p *promqlPrinter) printLabelValues(val model.LabelValues) {
 
 type jsonPrinter struct{}
 
-func (j *jsonPrinter) printValue(v model.Value) {
+func (*jsonPrinter) printValue(v model.Value) {
 	//nolint:errcheck
 	json.NewEncoder(os.Stdout).Encode(v)
 }
 
-func (j *jsonPrinter) printSeries(v []model.LabelSet) {
+func (*jsonPrinter) printSeries(v []model.LabelSet) {
 	//nolint:errcheck
 	json.NewEncoder(os.Stdout).Encode(v)
 }
 
-func (j *jsonPrinter) printLabelValues(v model.LabelValues) {
+func (*jsonPrinter) printLabelValues(v model.LabelValues) {
 	//nolint:errcheck
 	json.NewEncoder(os.Stdout).Encode(v)
 }

--- a/cmd/promtool/rules_test.go
+++ b/cmd/promtool/rules_test.go
@@ -35,7 +35,7 @@ type mockQueryRangeAPI struct {
 	samples model.Matrix
 }
 
-func (mockAPI mockQueryRangeAPI) QueryRange(_ context.Context, _ string, _ v1.Range, _ ...v1.Option) (model.Value, v1.Warnings, error) {
+func (mockAPI mockQueryRangeAPI) QueryRange(context.Context, string, v1.Range, ...v1.Option) (model.Value, v1.Warnings, error) {
 	return mockAPI.samples, v1.Warnings{}, nil
 }
 

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -225,7 +225,7 @@ func (tg *testGroup) test(testname string, evalInterval time.Duration, groupOrde
 		QueryFunc:  rules.EngineQueryFunc(suite.QueryEngine(), suite.Storage()),
 		Appendable: suite.Storage(),
 		Context:    context.Background(),
-		NotifyFunc: func(_ context.Context, _ string, _ ...*rules.Alert) {},
+		NotifyFunc: func(context.Context, string, ...*rules.Alert) {},
 		Logger:     promslog.NewNopLogger(),
 	}
 	m := rules.NewManager(opts)

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -399,7 +399,7 @@ func newMockEC2Client(ec2Data *ec2DataStore) *mockEC2Client {
 	return &client
 }
 
-func (m *mockEC2Client) DescribeAvailabilityZonesWithContext(_ aws.Context, _ *ec2.DescribeAvailabilityZonesInput, _ ...request.Option) (*ec2.DescribeAvailabilityZonesOutput, error) {
+func (m *mockEC2Client) DescribeAvailabilityZonesWithContext(aws.Context, *ec2.DescribeAvailabilityZonesInput, ...request.Option) (*ec2.DescribeAvailabilityZonesOutput, error) {
 	if len(m.ec2Data.azToAZID) == 0 {
 		return nil, errors.New("No AZs found")
 	}

--- a/discovery/aws/metrics_ec2.go
+++ b/discovery/aws/metrics_ec2.go
@@ -24,9 +24,9 @@ type ec2Metrics struct {
 var _ discovery.DiscovererMetrics = (*ec2Metrics)(nil)
 
 // Register implements discovery.DiscovererMetrics.
-func (m *ec2Metrics) Register() error {
+func (*ec2Metrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *ec2Metrics) Unregister() {}
+func (*ec2Metrics) Unregister() {}

--- a/discovery/aws/metrics_lightsail.go
+++ b/discovery/aws/metrics_lightsail.go
@@ -24,9 +24,9 @@ type lightsailMetrics struct {
 var _ discovery.DiscovererMetrics = (*lightsailMetrics)(nil)
 
 // Register implements discovery.DiscovererMetrics.
-func (m *lightsailMetrics) Register() error {
+func (*lightsailMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *lightsailMetrics) Unregister() {}
+func (*lightsailMetrics) Unregister() {}

--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -723,11 +723,11 @@ func createMockAzureClient(t *testing.T, vmResp []armcompute.VirtualMachinesClie
 
 func defaultMockInterfaceServer(interfaceResp armnetwork.Interface) fakenetwork.InterfacesServer {
 	return fakenetwork.InterfacesServer{
-		Get: func(_ context.Context, _, _ string, _ *armnetwork.InterfacesClientGetOptions) (resp azfake.Responder[armnetwork.InterfacesClientGetResponse], errResp azfake.ErrorResponder) {
+		Get: func(context.Context, string, string, *armnetwork.InterfacesClientGetOptions) (resp azfake.Responder[armnetwork.InterfacesClientGetResponse], errResp azfake.ErrorResponder) {
 			resp.SetResponse(http.StatusOK, armnetwork.InterfacesClientGetResponse{Interface: interfaceResp}, nil)
 			return
 		},
-		GetVirtualMachineScaleSetNetworkInterface: func(_ context.Context, _, _, _, _ string, _ *armnetwork.InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceOptions) (resp azfake.Responder[armnetwork.InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse], errResp azfake.ErrorResponder) {
+		GetVirtualMachineScaleSetNetworkInterface: func(context.Context, string, string, string, string, *armnetwork.InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceOptions) (resp azfake.Responder[armnetwork.InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse], errResp azfake.ErrorResponder) {
 			resp.SetResponse(http.StatusOK, armnetwork.InterfacesClientGetVirtualMachineScaleSetNetworkInterfaceResponse{Interface: interfaceResp}, nil)
 			return
 		},
@@ -736,7 +736,7 @@ func defaultMockInterfaceServer(interfaceResp armnetwork.Interface) fakenetwork.
 
 func defaultMockVMServer(vmResp []armcompute.VirtualMachinesClientListAllResponse) fake.VirtualMachinesServer {
 	return fake.VirtualMachinesServer{
-		NewListAllPager: func(_ *armcompute.VirtualMachinesClientListAllOptions) (resp azfake.PagerResponder[armcompute.VirtualMachinesClientListAllResponse]) {
+		NewListAllPager: func(*armcompute.VirtualMachinesClientListAllOptions) (resp azfake.PagerResponder[armcompute.VirtualMachinesClientListAllResponse]) {
 			for _, page := range vmResp {
 				resp.AddPage(http.StatusOK, page, nil)
 			}
@@ -747,7 +747,7 @@ func defaultMockVMServer(vmResp []armcompute.VirtualMachinesClientListAllRespons
 
 func defaultMockVMSSServer(vmssResp []armcompute.VirtualMachineScaleSetsClientListAllResponse) fake.VirtualMachineScaleSetsServer {
 	return fake.VirtualMachineScaleSetsServer{
-		NewListAllPager: func(_ *armcompute.VirtualMachineScaleSetsClientListAllOptions) (resp azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListAllResponse]) {
+		NewListAllPager: func(*armcompute.VirtualMachineScaleSetsClientListAllOptions) (resp azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListAllResponse]) {
 			for _, page := range vmssResp {
 				resp.AddPage(http.StatusOK, page, nil)
 			}

--- a/discovery/digitalocean/metrics.go
+++ b/discovery/digitalocean/metrics.go
@@ -24,9 +24,9 @@ type digitaloceanMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *digitaloceanMetrics) Register() error {
+func (*digitaloceanMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *digitaloceanMetrics) Unregister() {}
+func (*digitaloceanMetrics) Unregister() {}

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -148,7 +148,7 @@ func (c StaticConfig) NewDiscoverer(DiscovererOptions) (Discoverer, error) {
 
 // NewDiscovererMetrics returns NoopDiscovererMetrics because no metrics are
 // needed for this service discovery mechanism.
-func (c StaticConfig) NewDiscovererMetrics(prometheus.Registerer, RefreshMetricsInstantiator) DiscovererMetrics {
+func (StaticConfig) NewDiscovererMetrics(prometheus.Registerer, RefreshMetricsInstantiator) DiscovererMetrics {
 	return &NoopDiscovererMetrics{}
 }
 

--- a/discovery/dns/dns_test.go
+++ b/discovery/dns/dns_test.go
@@ -52,7 +52,7 @@ func TestDNS(t *testing.T) {
 				Port:            80,
 				Type:            "A",
 			},
-			lookup: func(_ string, _ uint16, _ *slog.Logger) (*dns.Msg, error) {
+			lookup: func(string, uint16, *slog.Logger) (*dns.Msg, error) {
 				return nil, errors.New("some error")
 			},
 			expected: []*targetgroup.Group{},
@@ -65,7 +65,7 @@ func TestDNS(t *testing.T) {
 				Port:            80,
 				Type:            "A",
 			},
-			lookup: func(_ string, _ uint16, _ *slog.Logger) (*dns.Msg, error) {
+			lookup: func(string, uint16, *slog.Logger) (*dns.Msg, error) {
 				return &dns.Msg{
 						Answer: []dns.RR{
 							&dns.A{A: net.IPv4(192, 0, 2, 2)},
@@ -97,7 +97,7 @@ func TestDNS(t *testing.T) {
 				Port:            80,
 				Type:            "AAAA",
 			},
-			lookup: func(_ string, _ uint16, _ *slog.Logger) (*dns.Msg, error) {
+			lookup: func(string, uint16, *slog.Logger) (*dns.Msg, error) {
 				return &dns.Msg{
 						Answer: []dns.RR{
 							&dns.AAAA{AAAA: net.IPv6loopback},
@@ -128,7 +128,7 @@ func TestDNS(t *testing.T) {
 				Type:            "SRV",
 				RefreshInterval: model.Duration(time.Minute),
 			},
-			lookup: func(_ string, _ uint16, _ *slog.Logger) (*dns.Msg, error) {
+			lookup: func(string, uint16, *slog.Logger) (*dns.Msg, error) {
 				return &dns.Msg{
 						Answer: []dns.RR{
 							&dns.SRV{Port: 3306, Target: "db1.example.com."},
@@ -167,7 +167,7 @@ func TestDNS(t *testing.T) {
 				Names:           []string{"_mysql._tcp.db.example.com."},
 				RefreshInterval: model.Duration(time.Minute),
 			},
-			lookup: func(_ string, _ uint16, _ *slog.Logger) (*dns.Msg, error) {
+			lookup: func(string, uint16, *slog.Logger) (*dns.Msg, error) {
 				return &dns.Msg{
 						Answer: []dns.RR{
 							&dns.SRV{Port: 3306, Target: "db1.example.com."},
@@ -198,7 +198,7 @@ func TestDNS(t *testing.T) {
 				Names:           []string{"_mysql._tcp.db.example.com."},
 				RefreshInterval: model.Duration(time.Minute),
 			},
-			lookup: func(_ string, _ uint16, _ *slog.Logger) (*dns.Msg, error) {
+			lookup: func(string, uint16, *slog.Logger) (*dns.Msg, error) {
 				return &dns.Msg{}, nil
 			},
 			expected: []*targetgroup.Group{
@@ -215,7 +215,7 @@ func TestDNS(t *testing.T) {
 				Port:            25,
 				RefreshInterval: model.Duration(time.Minute),
 			},
-			lookup: func(_ string, _ uint16, _ *slog.Logger) (*dns.Msg, error) {
+			lookup: func(string, uint16, *slog.Logger) (*dns.Msg, error) {
 				return &dns.Msg{
 						Answer: []dns.RR{
 							&dns.MX{Preference: 0, Mx: "smtp1.example.com."},

--- a/discovery/eureka/metrics.go
+++ b/discovery/eureka/metrics.go
@@ -24,9 +24,9 @@ type eurekaMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *eurekaMetrics) Register() error {
+func (*eurekaMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *eurekaMetrics) Unregister() {}
+func (*eurekaMetrics) Unregister() {}

--- a/discovery/gce/metrics.go
+++ b/discovery/gce/metrics.go
@@ -24,9 +24,9 @@ type gceMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *gceMetrics) Register() error {
+func (*gceMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *gceMetrics) Unregister() {}
+func (*gceMetrics) Unregister() {}

--- a/discovery/hetzner/metrics.go
+++ b/discovery/hetzner/metrics.go
@@ -24,9 +24,9 @@ type hetznerMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *hetznerMetrics) Register() error {
+func (*hetznerMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *hetznerMetrics) Unregister() {}
+func (*hetznerMetrics) Unregister() {}

--- a/discovery/ionos/ionos.go
+++ b/discovery/ionos/ionos.go
@@ -96,7 +96,7 @@ func (*SDConfig) NewDiscovererMetrics(_ prometheus.Registerer, rmi discovery.Ref
 }
 
 // Name returns the name of the IONOS Cloud service discovery.
-func (c SDConfig) Name() string {
+func (SDConfig) Name() string {
 	return "ionos"
 }
 

--- a/discovery/ionos/metrics.go
+++ b/discovery/ionos/metrics.go
@@ -24,9 +24,9 @@ type ionosMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *ionosMetrics) Register() error {
+func (*ionosMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *ionosMetrics) Unregister() {}
+func (*ionosMetrics) Unregister() {}

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -311,7 +311,7 @@ func TestFailuresCountMetric(t *testing.T) {
 			require.Equal(t, float64(0), prom_testutil.ToFloat64(n.metrics.failuresCount))
 
 			// Simulate an error on watch requests.
-			c.Discovery().(*fakediscovery.FakeDiscovery).PrependWatchReactor("*", func(_ kubetesting.Action) (bool, watch.Interface, error) {
+			c.Discovery().(*fakediscovery.FakeDiscovery).PrependWatchReactor("*", func(kubetesting.Action) (bool, watch.Interface, error) {
 				return true, nil, apierrors.NewUnauthorized("unauthorized")
 			})
 

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -258,7 +258,7 @@ func podLabels(pod *apiv1.Pod) model.LabelSet {
 	return ls
 }
 
-func (p *Pod) findPodContainerStatus(statuses *[]apiv1.ContainerStatus, containerName string) (*apiv1.ContainerStatus, error) {
+func (*Pod) findPodContainerStatus(statuses *[]apiv1.ContainerStatus, containerName string) (*apiv1.ContainerStatus, error) {
 	for _, s := range *statuses {
 		if s.Name == containerName {
 			return &s, nil

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -1158,7 +1158,7 @@ func TestApplyConfigDoesNotModifyStaticTargets(t *testing.T) {
 
 type errorConfig struct{ err error }
 
-func (e errorConfig) Name() string                                        { return "error" }
+func (errorConfig) Name() string                                          { return "error" }
 func (e errorConfig) NewDiscoverer(DiscovererOptions) (Discoverer, error) { return nil, e.err }
 
 // NewDiscovererMetrics implements discovery.Config.
@@ -1176,7 +1176,7 @@ func (lockStaticConfig) NewDiscovererMetrics(prometheus.Registerer, RefreshMetri
 	return &NoopDiscovererMetrics{}
 }
 
-func (s lockStaticConfig) Name() string { return "lockstatic" }
+func (lockStaticConfig) Name() string { return "lockstatic" }
 func (s lockStaticConfig) NewDiscoverer(DiscovererOptions) (Discoverer, error) {
 	return (lockStaticDiscoverer)(s), nil
 }
@@ -1521,7 +1521,7 @@ func (*testDiscoverer) NewDiscovererMetrics(prometheus.Registerer, RefreshMetric
 }
 
 // Name implements Config.
-func (t *testDiscoverer) Name() string {
+func (*testDiscoverer) Name() string {
 	return "test"
 }
 

--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -64,7 +64,7 @@ func testUpdateServices(client appListClient) ([]*targetgroup.Group, error) {
 func TestMarathonSDHandleError(t *testing.T) {
 	var (
 		errTesting = errors.New("testing failure")
-		client     = func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+		client     = func(context.Context, *http.Client, string) (*appList, error) {
 			return nil, errTesting
 		}
 	)
@@ -74,7 +74,7 @@ func TestMarathonSDHandleError(t *testing.T) {
 }
 
 func TestMarathonSDEmptyList(t *testing.T) {
-	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) { return &appList{}, nil }
+	client := func(context.Context, *http.Client, string) (*appList, error) { return &appList{}, nil }
 	tgs, err := testUpdateServices(client)
 	require.NoError(t, err)
 	require.Empty(t, tgs, "Expected no target groups.")
@@ -107,7 +107,7 @@ func marathonTestAppList(labels map[string]string, runningTasks int) *appList {
 }
 
 func TestMarathonSDSendGroup(t *testing.T) {
-	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppList(marathonValidLabel, 1), nil
 	}
 	tgs, err := testUpdateServices(client)
@@ -135,7 +135,7 @@ func TestMarathonSDRemoveApp(t *testing.T) {
 	md, err := NewDiscovery(cfg, nil, metrics)
 	require.NoError(t, err)
 
-	md.appsClient = func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+	md.appsClient = func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppList(marathonValidLabel, 1), nil
 	}
 	tgs, err := md.refresh(context.Background())
@@ -143,7 +143,7 @@ func TestMarathonSDRemoveApp(t *testing.T) {
 	require.Len(t, tgs, 1, "Expected 1 targetgroup.")
 	tg1 := tgs[0]
 
-	md.appsClient = func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+	md.appsClient = func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppList(marathonValidLabel, 0), nil
 	}
 	tgs, err = md.refresh(context.Background())
@@ -184,7 +184,7 @@ func marathonTestAppListWithMultiplePorts(labels map[string]string, runningTasks
 }
 
 func TestMarathonSDSendGroupWithMultiplePort(t *testing.T) {
-	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithMultiplePorts(marathonValidLabel, 1), nil
 	}
 	tgs, err := testUpdateServices(client)
@@ -229,7 +229,7 @@ func marathonTestZeroTaskPortAppList(labels map[string]string, runningTasks int)
 }
 
 func TestMarathonZeroTaskPorts(t *testing.T) {
-	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestZeroTaskPortAppList(marathonValidLabel, 1), nil
 	}
 	tgs, err := testUpdateServices(client)
@@ -287,7 +287,7 @@ func marathonTestAppListWithPortDefinitions(labels map[string]string, runningTas
 }
 
 func TestMarathonSDSendGroupWithPortDefinitions(t *testing.T) {
-	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithPortDefinitions(marathonValidLabel, 1), nil
 	}
 	tgs, err := testUpdateServices(client)
@@ -341,7 +341,7 @@ func marathonTestAppListWithPortDefinitionsRequirePorts(labels map[string]string
 }
 
 func TestMarathonSDSendGroupWithPortDefinitionsRequirePorts(t *testing.T) {
-	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithPortDefinitionsRequirePorts(marathonValidLabel, 1), nil
 	}
 	tgs, err := testUpdateServices(client)
@@ -388,7 +388,7 @@ func marathonTestAppListWithPorts(labels map[string]string, runningTasks int) *a
 }
 
 func TestMarathonSDSendGroupWithPorts(t *testing.T) {
-	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithPorts(marathonValidLabel, 1), nil
 	}
 	tgs, err := testUpdateServices(client)
@@ -444,7 +444,7 @@ func marathonTestAppListWithContainerPortMappings(labels map[string]string, runn
 }
 
 func TestMarathonSDSendGroupWithContainerPortMappings(t *testing.T) {
-	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithContainerPortMappings(marathonValidLabel, 1), nil
 	}
 	tgs, err := testUpdateServices(client)
@@ -500,7 +500,7 @@ func marathonTestAppListWithDockerContainerPortMappings(labels map[string]string
 }
 
 func TestMarathonSDSendGroupWithDockerContainerPortMappings(t *testing.T) {
-	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithDockerContainerPortMappings(marathonValidLabel, 1), nil
 	}
 	tgs, err := testUpdateServices(client)
@@ -560,7 +560,7 @@ func marathonTestAppListWithContainerNetworkAndPortMappings(labels map[string]st
 }
 
 func TestMarathonSDSendGroupWithContainerNetworkAndPortMapping(t *testing.T) {
-	client := func(_ context.Context, _ *http.Client, _ string) (*appList, error) {
+	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithContainerNetworkAndPortMappings(marathonValidLabel, 1), nil
 	}
 	tgs, err := testUpdateServices(client)

--- a/discovery/marathon/metrics.go
+++ b/discovery/marathon/metrics.go
@@ -24,9 +24,9 @@ type marathonMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *marathonMetrics) Register() error {
+func (*marathonMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *marathonMetrics) Unregister() {}
+func (*marathonMetrics) Unregister() {}

--- a/discovery/metrics_k8s_client.go
+++ b/discovery/metrics_k8s_client.go
@@ -176,27 +176,27 @@ func (f *clientGoWorkqueueMetricsProvider) RegisterWithK8sGoClient() {
 	workqueue.SetProvider(f)
 }
 
-func (f *clientGoWorkqueueMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
+func (*clientGoWorkqueueMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
 	return clientGoWorkqueueDepthMetricVec.WithLabelValues(name)
 }
 
-func (f *clientGoWorkqueueMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
+func (*clientGoWorkqueueMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
 	return clientGoWorkqueueAddsMetricVec.WithLabelValues(name)
 }
 
-func (f *clientGoWorkqueueMetricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
+func (*clientGoWorkqueueMetricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
 	return clientGoWorkqueueLatencyMetricVec.WithLabelValues(name)
 }
 
-func (f *clientGoWorkqueueMetricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
+func (*clientGoWorkqueueMetricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
 	return clientGoWorkqueueWorkDurationMetricVec.WithLabelValues(name)
 }
 
-func (f *clientGoWorkqueueMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
+func (*clientGoWorkqueueMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
 	return clientGoWorkqueueUnfinishedWorkSecondsMetricVec.WithLabelValues(name)
 }
 
-func (f *clientGoWorkqueueMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
+func (*clientGoWorkqueueMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
 	return clientGoWorkqueueLongestRunningProcessorMetricVec.WithLabelValues(name)
 }
 

--- a/discovery/moby/metrics_docker.go
+++ b/discovery/moby/metrics_docker.go
@@ -24,9 +24,9 @@ type dockerMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *dockerMetrics) Register() error {
+func (*dockerMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *dockerMetrics) Unregister() {}
+func (*dockerMetrics) Unregister() {}

--- a/discovery/moby/metrics_dockerswarm.go
+++ b/discovery/moby/metrics_dockerswarm.go
@@ -24,9 +24,9 @@ type dockerswarmMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *dockerswarmMetrics) Register() error {
+func (*dockerswarmMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *dockerswarmMetrics) Unregister() {}
+func (*dockerswarmMetrics) Unregister() {}

--- a/discovery/openstack/metrics.go
+++ b/discovery/openstack/metrics.go
@@ -24,9 +24,9 @@ type openstackMetrics struct {
 var _ discovery.DiscovererMetrics = (*openstackMetrics)(nil)
 
 // Register implements discovery.DiscovererMetrics.
-func (m *openstackMetrics) Register() error {
+func (*openstackMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *openstackMetrics) Unregister() {}
+func (*openstackMetrics) Unregister() {}

--- a/discovery/ovhcloud/dedicated_server.go
+++ b/discovery/ovhcloud/dedicated_server.go
@@ -93,7 +93,7 @@ func getDedicatedServerDetails(client *ovh.Client, serverName string) (*dedicate
 	return &dedicatedServerDetails, nil
 }
 
-func (d *dedicatedServerDiscovery) getService() string {
+func (*dedicatedServerDiscovery) getService() string {
 	return "dedicated_server"
 }
 

--- a/discovery/ovhcloud/metrics.go
+++ b/discovery/ovhcloud/metrics.go
@@ -24,9 +24,9 @@ type ovhcloudMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *ovhcloudMetrics) Register() error {
+func (*ovhcloudMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *ovhcloudMetrics) Unregister() {}
+func (*ovhcloudMetrics) Unregister() {}

--- a/discovery/ovhcloud/ovhcloud.go
+++ b/discovery/ovhcloud/ovhcloud.go
@@ -61,7 +61,7 @@ func (*SDConfig) NewDiscovererMetrics(_ prometheus.Registerer, rmi discovery.Ref
 }
 
 // Name implements the Discoverer interface.
-func (c SDConfig) Name() string {
+func (SDConfig) Name() string {
 	return "ovhcloud"
 }
 

--- a/discovery/ovhcloud/vps.go
+++ b/discovery/ovhcloud/vps.go
@@ -109,7 +109,7 @@ func getVpsList(client *ovh.Client) ([]string, error) {
 	return vpsListName, nil
 }
 
-func (d *vpsDiscovery) getService() string {
+func (*vpsDiscovery) getService() string {
 	return "vps"
 }
 

--- a/discovery/puppetdb/metrics.go
+++ b/discovery/puppetdb/metrics.go
@@ -24,9 +24,9 @@ type puppetdbMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *puppetdbMetrics) Register() error {
+func (*puppetdbMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *puppetdbMetrics) Unregister() {}
+func (*puppetdbMetrics) Unregister() {}

--- a/discovery/refresh/refresh_test.go
+++ b/discovery/refresh/refresh_test.go
@@ -56,7 +56,7 @@ func TestRefresh(t *testing.T) {
 	}
 
 	var i int
-	refresh := func(_ context.Context) ([]*targetgroup.Group, error) {
+	refresh := func(context.Context) ([]*targetgroup.Group, error) {
 		i++
 		switch i {
 		case 1:

--- a/discovery/scaleway/metrics.go
+++ b/discovery/scaleway/metrics.go
@@ -24,9 +24,9 @@ type scalewayMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *scalewayMetrics) Register() error {
+func (*scalewayMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *scalewayMetrics) Unregister() {}
+func (*scalewayMetrics) Unregister() {}

--- a/discovery/scaleway/scaleway.go
+++ b/discovery/scaleway/scaleway.go
@@ -111,7 +111,7 @@ func (*SDConfig) NewDiscovererMetrics(_ prometheus.Registerer, rmi discovery.Ref
 	}
 }
 
-func (c SDConfig) Name() string {
+func (SDConfig) Name() string {
 	return "scaleway"
 }
 

--- a/discovery/stackit/metrics.go
+++ b/discovery/stackit/metrics.go
@@ -24,9 +24,9 @@ type stackitMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *stackitMetrics) Register() error {
+func (*stackitMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *stackitMetrics) Unregister() {}
+func (*stackitMetrics) Unregister() {}

--- a/discovery/triton/metrics.go
+++ b/discovery/triton/metrics.go
@@ -24,9 +24,9 @@ type tritonMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *tritonMetrics) Register() error {
+func (*tritonMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *tritonMetrics) Unregister() {}
+func (*tritonMetrics) Unregister() {}

--- a/discovery/uyuni/metrics.go
+++ b/discovery/uyuni/metrics.go
@@ -24,9 +24,9 @@ type uyuniMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *uyuniMetrics) Register() error {
+func (*uyuniMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *uyuniMetrics) Unregister() {}
+func (*uyuniMetrics) Unregister() {}

--- a/discovery/uyuni/uyuni.go
+++ b/discovery/uyuni/uyuni.go
@@ -330,7 +330,7 @@ func (d *Discovery) getTargetsForSystems(
 	return result, nil
 }
 
-func (d *Discovery) refresh(_ context.Context) ([]*targetgroup.Group, error) {
+func (d *Discovery) refresh(context.Context) ([]*targetgroup.Group, error) {
 	rpcClient, err := xmlrpc.NewClient(d.apiURL.String(), d.roundTripper)
 	if err != nil {
 		return nil, err

--- a/discovery/vultr/metrics.go
+++ b/discovery/vultr/metrics.go
@@ -24,9 +24,9 @@ type vultrMetrics struct {
 }
 
 // Register implements discovery.DiscovererMetrics.
-func (m *vultrMetrics) Register() error {
+func (*vultrMetrics) Register() error {
 	return nil
 }
 
 // Unregister implements discovery.DiscovererMetrics.
-func (m *vultrMetrics) Unregister() {}
+func (*vultrMetrics) Unregister() {}

--- a/discovery/xds/client_test.go
+++ b/discovery/xds/client_test.go
@@ -106,7 +106,7 @@ func createTestHTTPResourceClient(t *testing.T, conf *HTTPResourceClientConfig, 
 }
 
 func TestHTTPResourceClientFetchEmptyResponse(t *testing.T) {
-	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(_ *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
+	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(*v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		return nil, nil
 	})
 	defer cleanup()
@@ -146,7 +146,7 @@ func TestHTTPResourceClientFetchFullResponse(t *testing.T) {
 }
 
 func TestHTTPResourceClientServerError(t *testing.T) {
-	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(_ *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
+	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(*v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		return nil, errors.New("server error")
 	})
 	defer cleanup()

--- a/discovery/xds/kuma.go
+++ b/discovery/xds/kuma.go
@@ -88,7 +88,7 @@ func (c *KumaSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return c.HTTPClientConfig.Validate()
 }
 
-func (c *KumaSDConfig) Name() string {
+func (*KumaSDConfig) Name() string {
 	return "kuma"
 }
 

--- a/discovery/xds/xds_test.go
+++ b/discovery/xds/xds_test.go
@@ -85,7 +85,7 @@ func createTestHTTPServer(t *testing.T, responder discoveryResponder) *httptest.
 }
 
 func constantResourceParser(targets []model.LabelSet, err error) resourceParser {
-	return func(_ []*anypb.Any, _ string) ([]model.LabelSet, error) {
+	return func([]*anypb.Any, string) ([]model.LabelSet, error) {
 		return targets, err
 	}
 }
@@ -111,16 +111,16 @@ func (rc testResourceClient) Fetch(ctx context.Context) (*v3.DiscoveryResponse, 
 	return rc.fetch(ctx)
 }
 
-func (rc testResourceClient) ID() string {
+func (testResourceClient) ID() string {
 	return "test-client"
 }
 
-func (rc testResourceClient) Close() {
+func (testResourceClient) Close() {
 }
 
 func TestPollingRefreshSkipUpdate(t *testing.T) {
 	rc := &testResourceClient{
-		fetch: func(_ context.Context) (*v3.DiscoveryResponse, error) {
+		fetch: func(context.Context) (*v3.DiscoveryResponse, error) {
 			return nil, nil
 		},
 	}
@@ -167,7 +167,7 @@ func TestPollingRefreshAttachesGroupMetadata(t *testing.T) {
 	rc := &testResourceClient{
 		server:          server,
 		protocolVersion: ProtocolV3,
-		fetch: func(_ context.Context) (*v3.DiscoveryResponse, error) {
+		fetch: func(context.Context) (*v3.DiscoveryResponse, error) {
 			return &v3.DiscoveryResponse{}, nil
 		},
 	}
@@ -223,14 +223,14 @@ func TestPollingDisappearingTargets(t *testing.T) {
 	rc := &testResourceClient{
 		server:          server,
 		protocolVersion: ProtocolV3,
-		fetch: func(_ context.Context) (*v3.DiscoveryResponse, error) {
+		fetch: func(context.Context) (*v3.DiscoveryResponse, error) {
 			return &v3.DiscoveryResponse{}, nil
 		},
 	}
 
 	// On the first poll, send back two targets. On the next, send just one.
 	counter := 0
-	parser := func(_ []*anypb.Any, _ string) ([]model.LabelSet, error) {
+	parser := func([]*anypb.Any, string) ([]model.LabelSet, error) {
 		counter++
 		if counter == 1 {
 			return []model.LabelSet{

--- a/discovery/zookeeper/zookeeper.go
+++ b/discovery/zookeeper/zookeeper.go
@@ -59,7 +59,7 @@ type ServersetSDConfig struct {
 }
 
 // NewDiscovererMetrics implements discovery.Config.
-func (*ServersetSDConfig) NewDiscovererMetrics(_ prometheus.Registerer, _ discovery.RefreshMetricsInstantiator) discovery.DiscovererMetrics {
+func (*ServersetSDConfig) NewDiscovererMetrics(prometheus.Registerer, discovery.RefreshMetricsInstantiator) discovery.DiscovererMetrics {
 	return &discovery.NoopDiscovererMetrics{}
 }
 
@@ -101,7 +101,7 @@ type NerveSDConfig struct {
 }
 
 // NewDiscovererMetrics implements discovery.Config.
-func (*NerveSDConfig) NewDiscovererMetrics(_ prometheus.Registerer, _ discovery.RefreshMetricsInstantiator) discovery.DiscovererMetrics {
+func (*NerveSDConfig) NewDiscovererMetrics(prometheus.Registerer, discovery.RefreshMetricsInstantiator) discovery.DiscovererMetrics {
 	return &discovery.NoopDiscovererMetrics{}
 }
 

--- a/discovery/zookeeper/zookeeper_test.go
+++ b/discovery/zookeeper/zookeeper_test.go
@@ -33,6 +33,6 @@ func TestNewDiscoveryError(t *testing.T) {
 		[]string{"unreachable.invalid"},
 		time.Second, []string{"/"},
 		nil,
-		func(_ []byte, _ string) (model.LabelSet, error) { return nil, nil })
+		func([]byte, string) (model.LabelSet, error) { return nil, nil })
 	require.Error(t, err)
 }

--- a/documentation/examples/custom-sd/adapter-usage/main.go
+++ b/documentation/examples/custom-sd/adapter-usage/main.go
@@ -94,7 +94,7 @@ type discovery struct {
 	oldSourceList   map[string]bool
 }
 
-func (d *discovery) parseServiceNodes(resp *http.Response, name string) (*targetgroup.Group, error) {
+func (*discovery) parseServiceNodes(resp *http.Response, name string) (*targetgroup.Group, error) {
 	var nodes []*CatalogService
 	tgroup := targetgroup.Group{
 		Source: name,

--- a/documentation/examples/remote_storage/remote_storage_adapter/graphite/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/graphite/client.go
@@ -104,6 +104,6 @@ func (c *Client) Write(samples model.Samples) error {
 }
 
 // Name identifies the client as a Graphite client.
-func (c Client) Name() string {
+func (Client) Name() string {
 	return "graphite"
 }

--- a/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
@@ -326,7 +326,7 @@ func mergeSamples(a, b []prompb.Sample) []prompb.Sample {
 }
 
 // Name identifies the client as an InfluxDB client.
-func (c Client) Name() string {
+func (Client) Name() string {
 	return "influxdb"
 }
 

--- a/documentation/examples/remote_storage/remote_storage_adapter/opentsdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/opentsdb/client.go
@@ -139,6 +139,6 @@ func (c *Client) Write(samples model.Samples) error {
 }
 
 // Name identifies the client as an OpenTSDB client.
-func (c Client) Name() string {
+func (Client) Name() string {
 	return "opentsdb"
 }

--- a/model/labels/labels_slicelabels.go
+++ b/model/labels/labels_slicelabels.go
@@ -453,7 +453,7 @@ func NewScratchBuilder(n int) ScratchBuilder {
 }
 
 // NewBuilderWithSymbolTable creates a Builder, for api parity with dedupelabels.
-func NewBuilderWithSymbolTable(_ *SymbolTable) *Builder {
+func NewBuilderWithSymbolTable(*SymbolTable) *Builder {
 	return NewBuilder(EmptyLabels())
 }
 
@@ -462,7 +462,7 @@ func NewScratchBuilderWithSymbolTable(_ *SymbolTable, n int) ScratchBuilder {
 	return NewScratchBuilder(n)
 }
 
-func (b *ScratchBuilder) SetSymbolTable(_ *SymbolTable) {
+func (b *ScratchBuilder) SetSymbolTable(*SymbolTable) {
 	// no-op
 }
 

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -449,11 +449,11 @@ func (ls Labels) DropReserved(shouldDropFn func(name string) bool) Labels {
 }
 
 // InternStrings is a no-op because it would only save when the whole set of labels is identical.
-func (ls *Labels) InternStrings(_ func(string) string) {
+func (*Labels) InternStrings(func(string) string) {
 }
 
 // ReleaseStrings is a no-op for the same reason as InternStrings.
-func (ls Labels) ReleaseStrings(_ func(string)) {
+func (Labels) ReleaseStrings(func(string)) {
 }
 
 // Builder allows modifying Labels.
@@ -664,10 +664,10 @@ type SymbolTable struct{}
 
 func NewSymbolTable() *SymbolTable { return nil }
 
-func (t *SymbolTable) Len() int { return 0 }
+func (*SymbolTable) Len() int { return 0 }
 
 // NewBuilderWithSymbolTable creates a Builder, for api parity with dedupelabels.
-func NewBuilderWithSymbolTable(_ *SymbolTable) *Builder {
+func NewBuilderWithSymbolTable(*SymbolTable) *Builder {
 	return NewBuilder(EmptyLabels())
 }
 
@@ -676,7 +676,7 @@ func NewScratchBuilderWithSymbolTable(_ *SymbolTable, n int) ScratchBuilder {
 	return NewScratchBuilder(n)
 }
 
-func (b *ScratchBuilder) SetSymbolTable(_ *SymbolTable) {
+func (*ScratchBuilder) SetSymbolTable(*SymbolTable) {
 	// no-op
 }
 

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -695,7 +695,7 @@ func (m *literalSuffixStringMatcher) Matches(s string) bool {
 // emptyStringMatcher matches an empty string.
 type emptyStringMatcher struct{}
 
-func (m emptyStringMatcher) Matches(s string) bool {
+func (emptyStringMatcher) Matches(s string) bool {
 	return len(s) == 0
 }
 
@@ -756,7 +756,7 @@ func (m *equalMultiStringSliceMatcher) add(s string) {
 	m.values = append(m.values, s)
 }
 
-func (m *equalMultiStringSliceMatcher) addPrefix(_ string, _ bool, _ StringMatcher) {
+func (*equalMultiStringSliceMatcher) addPrefix(string, bool, StringMatcher) {
 	panic("not implemented")
 }
 
@@ -897,7 +897,7 @@ func toNormalisedLowerSlow(s string, i int, a []byte) string {
 // (including an empty one) as far as it doesn't contain any newline character.
 type anyStringWithoutNewlineMatcher struct{}
 
-func (m anyStringWithoutNewlineMatcher) Matches(s string) bool {
+func (anyStringWithoutNewlineMatcher) Matches(s string) bool {
 	// We need to make sure it doesn't contain a newline. Since the newline is
 	// an ASCII character, we can use strings.IndexByte().
 	return strings.IndexByte(s, '\n') == -1
@@ -947,7 +947,7 @@ func (m *zeroOrOneCharacterStringMatcher) Matches(s string) bool {
 // trueMatcher is a stringMatcher which matches any string (always returns true).
 type trueMatcher struct{}
 
-func (m trueMatcher) Matches(_ string) bool {
+func (trueMatcher) Matches(string) bool {
 	return true
 }
 

--- a/model/textparse/nhcbparse_test.go
+++ b/model/textparse/nhcbparse_test.go
@@ -603,14 +603,14 @@ func TestNHCBParser_NoNHCBWhenExponential(t *testing.T) {
 			return "ProtoBuf", factory, []int{1, 2, 3}, parserOptions{useUTF8sep: true, hasCreatedTimeStamp: true}
 		},
 		func() (string, parserFactory, []int, parserOptions) {
-			factory := func(_ bool) Parser {
+			factory := func(bool) Parser {
 				input := createTestOpenMetricsHistogram()
 				return NewOpenMetricsParser([]byte(input), labels.NewSymbolTable(), WithOMParserCTSeriesSkipped())
 			}
 			return "OpenMetrics", factory, []int{1}, parserOptions{hasCreatedTimeStamp: true}
 		},
 		func() (string, parserFactory, []int, parserOptions) {
-			factory := func(_ bool) Parser {
+			factory := func(bool) Parser {
 				input := createTestPromHistogram()
 				return NewPromParser([]byte(input), labels.NewSymbolTable(), false)
 			}

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -172,7 +172,7 @@ func (p *OpenMetricsParser) Series() ([]byte, *int64, float64) {
 
 // Histogram returns (nil, nil, nil, nil) for now because OpenMetrics does not
 // support sparse histograms yet.
-func (p *OpenMetricsParser) Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram) {
+func (*OpenMetricsParser) Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram) {
 	return nil, nil, nil, nil
 }
 

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -189,7 +189,7 @@ func (p *PromParser) Series() ([]byte, *int64, float64) {
 
 // Histogram returns (nil, nil, nil, nil) for now because the Prometheus text
 // format does not support sparse histograms yet.
-func (p *PromParser) Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram) {
+func (*PromParser) Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram) {
 	return nil, nil, nil, nil
 }
 
@@ -216,7 +216,7 @@ func (p *PromParser) Type() ([]byte, model.MetricType) {
 // Unit returns the metric name and unit in the current entry.
 // Must only be called after Next returned a unit entry.
 // The returned byte slices become invalid after the next call to Next.
-func (p *PromParser) Unit() ([]byte, []byte) {
+func (*PromParser) Unit() ([]byte, []byte) {
 	// The Prometheus format does not have units.
 	return nil, nil
 }
@@ -270,13 +270,13 @@ func (p *PromParser) Labels(l *labels.Labels) {
 // Exemplar implements the Parser interface. However, since the classic
 // Prometheus text format does not support exemplars, this implementation simply
 // returns false and does nothing else.
-func (p *PromParser) Exemplar(*exemplar.Exemplar) bool {
+func (*PromParser) Exemplar(*exemplar.Exemplar) bool {
 	return false
 }
 
 // CreatedTimestamp returns 0 as it's not implemented yet.
 // TODO(bwplotka): https://github.com/prometheus/prometheus/issues/12980
-func (p *PromParser) CreatedTimestamp() int64 {
+func (*PromParser) CreatedTimestamp() int64 {
 	return 0
 }
 

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -299,7 +299,7 @@ func (p *ProtobufParser) Unit() ([]byte, []byte) {
 
 // Comment always returns nil because comments aren't supported by the protobuf
 // format.
-func (p *ProtobufParser) Comment() []byte {
+func (*ProtobufParser) Comment() []byte {
 	return nil
 }
 

--- a/notifier/manager_test.go
+++ b/notifier/manager_test.go
@@ -725,7 +725,7 @@ func TestHangingNotifier(t *testing.T) {
 
 	// Set up a faulty Alertmanager.
 	var faultyCalled atomic.Bool
-	faultyServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+	faultyServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		faultyCalled.Store(true)
 		select {
 		case <-done:
@@ -737,7 +737,7 @@ func TestHangingNotifier(t *testing.T) {
 
 	// Set up a functional Alertmanager.
 	var functionalCalled atomic.Bool
-	functionalServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+	functionalServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		functionalCalled.Store(true)
 	}))
 	functionalURL, err := url.Parse(functionalServer.URL)

--- a/prompb/io/prometheus/client/decoder.go
+++ b/prompb/io/prometheus/client/decoder.go
@@ -146,11 +146,11 @@ func (m *MetricStreamingDecoder) resetMetric() {
 	}
 }
 
-func (m *MetricStreamingDecoder) GetMetric() {
+func (*MetricStreamingDecoder) GetMetric() {
 	panic("don't use GetMetric, use Metric directly")
 }
 
-func (m *MetricStreamingDecoder) GetLabel() {
+func (*MetricStreamingDecoder) GetLabel() {
 	panic("don't use GetLabel, use Label instead")
 }
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1087,7 +1087,7 @@ func (ev *evaluator) errorf(format string, args ...interface{}) {
 }
 
 // error causes a panic with the given error.
-func (ev *evaluator) error(err error) {
+func (*evaluator) error(err error) {
 	panic(err)
 }
 
@@ -2562,7 +2562,7 @@ loop:
 	return floats, histograms
 }
 
-func (ev *evaluator) VectorAnd(lhs, rhs Vector, matching *parser.VectorMatching, lhsh, rhsh []EvalSeriesHelper, enh *EvalNodeHelper) Vector {
+func (*evaluator) VectorAnd(lhs, rhs Vector, matching *parser.VectorMatching, lhsh, rhsh []EvalSeriesHelper, enh *EvalNodeHelper) Vector {
 	if matching.Card != parser.CardManyToMany {
 		panic("set operations must only use many-to-many matching")
 	}
@@ -2586,7 +2586,7 @@ func (ev *evaluator) VectorAnd(lhs, rhs Vector, matching *parser.VectorMatching,
 	return enh.Out
 }
 
-func (ev *evaluator) VectorOr(lhs, rhs Vector, matching *parser.VectorMatching, lhsh, rhsh []EvalSeriesHelper, enh *EvalNodeHelper) Vector {
+func (*evaluator) VectorOr(lhs, rhs Vector, matching *parser.VectorMatching, lhsh, rhsh []EvalSeriesHelper, enh *EvalNodeHelper) Vector {
 	switch {
 	case matching.Card != parser.CardManyToMany:
 		panic("set operations must only use many-to-many matching")
@@ -2613,7 +2613,7 @@ func (ev *evaluator) VectorOr(lhs, rhs Vector, matching *parser.VectorMatching, 
 	return enh.Out
 }
 
-func (ev *evaluator) VectorUnless(lhs, rhs Vector, matching *parser.VectorMatching, lhsh, rhsh []EvalSeriesHelper, enh *EvalNodeHelper) Vector {
+func (*evaluator) VectorUnless(lhs, rhs Vector, matching *parser.VectorMatching, lhsh, rhsh []EvalSeriesHelper, enh *EvalNodeHelper) Vector {
 	if matching.Card != parser.CardManyToMany {
 		panic("set operations must only use many-to-many matching")
 	}
@@ -3523,7 +3523,7 @@ seriesLoop:
 
 // aggregationCountValues evaluates count_values on vec.
 // Outputs as many series per group as there are values in the input.
-func (ev *evaluator) aggregationCountValues(e *parser.AggregateExpr, grouping []string, valueLabel string, vec Vector, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+func (*evaluator) aggregationCountValues(e *parser.AggregateExpr, grouping []string, valueLabel string, vec Vector, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
 	type groupCount struct {
 		labels labels.Labels
 		count  int
@@ -3607,7 +3607,7 @@ func addToSeries(ss *Series, ts int64, f float64, h *histogram.FloatHistogram, n
 	ss.Histograms = append(ss.Histograms, HPoint{T: ts, H: h})
 }
 
-func (ev *evaluator) nextValues(ts int64, series *Series) (f float64, h *histogram.FloatHistogram, b bool) {
+func (*evaluator) nextValues(ts int64, series *Series) (f float64, h *histogram.FloatHistogram, b bool) {
 	switch {
 	case len(series.Floats) > 0 && series.Floats[0].T == ts:
 		f = series.Floats[0].F
@@ -3922,7 +3922,7 @@ func NewHashRatioSampler() *HashRatioSampler {
 	return &HashRatioSampler{}
 }
 
-func (s *HashRatioSampler) sampleOffset(_ int64, sample *Sample) float64 {
+func (*HashRatioSampler) sampleOffset(_ int64, sample *Sample) float64 {
 	const (
 		float64MaxUint64 = float64(math.MaxUint64)
 	)

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -250,10 +250,10 @@ type errSeriesSet struct {
 	err error
 }
 
-func (errSeriesSet) Next() bool                          { return false }
-func (errSeriesSet) At() storage.Series                  { return nil }
-func (e errSeriesSet) Err() error                        { return e.err }
-func (e errSeriesSet) Warnings() annotations.Annotations { return nil }
+func (errSeriesSet) Next() bool                        { return false }
+func (errSeriesSet) At() storage.Series                { return nil }
+func (e errSeriesSet) Err() error                      { return e.err }
+func (errSeriesSet) Warnings() annotations.Annotations { return nil }
 
 func TestQueryError(t *testing.T) {
 	opts := promql.EngineOpts{
@@ -2282,7 +2282,7 @@ func TestQueryLogger_error(t *testing.T) {
 	ctx = promql.NewOriginContext(ctx, map[string]interface{}{"foo": "bar"})
 	defer cancelCtx()
 	testErr := errors.New("failure")
-	query := engine.NewTestQuery(func(_ context.Context) error {
+	query := engine.NewTestQuery(func(context.Context) error {
 		return testErr
 	})
 
@@ -3790,7 +3790,7 @@ func TestHistogramRateWithFloatStaleness(t *testing.T) {
 	require.Nil(t, newc)
 
 	querier := storage.MockQuerier{
-		SelectMockFunction: func(_ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+		SelectMockFunction: func(bool, *storage.SelectHints, ...*labels.Matcher) storage.SeriesSet {
 			return &singleSeriesSet{
 				series: mockSeries{chunks: []chunkenc.Chunk{c1, c2, c3}, labelSet: []string{"__name__", "foo"}},
 			}
@@ -3825,10 +3825,10 @@ type singleSeriesSet struct {
 	consumed bool
 }
 
-func (s *singleSeriesSet) Next() bool                       { c := s.consumed; s.consumed = true; return !c }
-func (s singleSeriesSet) At() storage.Series                { return s.series }
-func (s singleSeriesSet) Err() error                        { return nil }
-func (s singleSeriesSet) Warnings() annotations.Annotations { return nil }
+func (s *singleSeriesSet) Next() bool                     { c := s.consumed; s.consumed = true; return !c }
+func (s singleSeriesSet) At() storage.Series              { return s.series }
+func (singleSeriesSet) Err() error                        { return nil }
+func (singleSeriesSet) Warnings() annotations.Annotations { return nil }
 
 type mockSeries struct {
 	chunks   []chunkenc.Chunk

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1018,7 +1018,7 @@ func funcAbsentOverTime(_ []Vector, _ Matrix, _ parser.Expressions, enh *EvalNod
 
 // === present_over_time(Vector parser.ValueTypeMatrix) (Vector, Annotations) ===
 func funcPresentOverTime(_ []Vector, matrixVals Matrix, _ parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
-	return aggrOverTime(matrixVals, enh, func(_ Series) float64 {
+	return aggrOverTime(matrixVals, enh, func(Series) float64 {
 		return 1
 	}), nil
 }
@@ -1154,7 +1154,7 @@ func funcDeg(vectorVals []Vector, _ Matrix, _ parser.Expressions, enh *EvalNodeH
 }
 
 // === pi() Scalar ===
-func funcPi(_ []Vector, _ Matrix, _ parser.Expressions, _ *EvalNodeHelper) (Vector, annotations.Annotations) {
+func funcPi([]Vector, Matrix, parser.Expressions, *EvalNodeHelper) (Vector, annotations.Annotations) {
 	return Vector{Sample{F: math.Pi}}, nil
 }
 

--- a/promql/histogram_stats_iterator_test.go
+++ b/promql/histogram_stats_iterator_test.go
@@ -221,9 +221,9 @@ func newHistogramSeries(histograms []*histogram.Histogram) *histogramSeries {
 	}
 }
 
-func (m histogramSeries) Labels() labels.Labels { return labels.EmptyLabels() }
+func (histogramSeries) Labels() labels.Labels { return labels.EmptyLabels() }
 
-func (m histogramSeries) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
+func (m histogramSeries) Iterator(chunkenc.Iterator) chunkenc.Iterator {
 	return &histogramIterator{
 		i:          -1,
 		histograms: m.histograms,
@@ -243,18 +243,18 @@ func (h *histogramIterator) Next() chunkenc.ValueType {
 	return chunkenc.ValNone
 }
 
-func (h *histogramIterator) Seek(_ int64) chunkenc.ValueType { panic("not implemented") }
+func (*histogramIterator) Seek(int64) chunkenc.ValueType { panic("not implemented") }
 
-func (h *histogramIterator) At() (int64, float64) { panic("not implemented") }
+func (*histogramIterator) At() (int64, float64) { panic("not implemented") }
 
-func (h *histogramIterator) AtHistogram(_ *histogram.Histogram) (int64, *histogram.Histogram) {
+func (h *histogramIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
 	return 0, h.histograms[h.i]
 }
 
-func (h *histogramIterator) AtFloatHistogram(_ *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+func (h *histogramIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
 	return 0, h.histograms[h.i].ToFloat(nil)
 }
 
-func (h *histogramIterator) AtT() int64 { return 0 }
+func (*histogramIterator) AtT() int64 { return 0 }
 
-func (h *histogramIterator) Err() error { return nil }
+func (*histogramIterator) Err() error { return nil }

--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -243,15 +243,15 @@ func (TestStmt) PositionRange() posrange.PositionRange {
 		End:   -1,
 	}
 }
-func (e *AggregateExpr) Type() ValueType  { return ValueTypeVector }
-func (e *Call) Type() ValueType           { return e.Func.ReturnType }
-func (e *MatrixSelector) Type() ValueType { return ValueTypeMatrix }
-func (e *SubqueryExpr) Type() ValueType   { return ValueTypeMatrix }
-func (e *NumberLiteral) Type() ValueType  { return ValueTypeScalar }
-func (e *ParenExpr) Type() ValueType      { return e.Expr.Type() }
-func (e *StringLiteral) Type() ValueType  { return ValueTypeString }
-func (e *UnaryExpr) Type() ValueType      { return e.Expr.Type() }
-func (e *VectorSelector) Type() ValueType { return ValueTypeVector }
+func (*AggregateExpr) Type() ValueType  { return ValueTypeVector }
+func (e *Call) Type() ValueType         { return e.Func.ReturnType }
+func (*MatrixSelector) Type() ValueType { return ValueTypeMatrix }
+func (*SubqueryExpr) Type() ValueType   { return ValueTypeMatrix }
+func (*NumberLiteral) Type() ValueType  { return ValueTypeScalar }
+func (e *ParenExpr) Type() ValueType    { return e.Expr.Type() }
+func (*StringLiteral) Type() ValueType  { return ValueTypeString }
+func (e *UnaryExpr) Type() ValueType    { return e.Expr.Type() }
+func (*VectorSelector) Type() ValueType { return ValueTypeVector }
 func (e *BinaryExpr) Type() ValueType {
 	if e.LHS.Type() == ValueTypeScalar && e.RHS.Type() == ValueTypeScalar {
 		return ValueTypeScalar
@@ -259,7 +259,7 @@ func (e *BinaryExpr) Type() ValueType {
 	return ValueTypeVector
 }
 func (e *StepInvariantExpr) Type() ValueType { return e.Expr.Type() }
-func (e *DurationExpr) Type() ValueType      { return ValueTypeScalar }
+func (*DurationExpr) Type() ValueType        { return ValueTypeScalar }
 
 func (*AggregateExpr) PromQLExpr()     {}
 func (*BinaryExpr) PromQLExpr()        {}

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -334,7 +334,7 @@ func (p *parser) unexpected(context, expected string) {
 var errUnexpected = errors.New("unexpected error")
 
 // recover is the handler that turns panics into returns from the top level of Parse.
-func (p *parser) recover(errp *error) {
+func (*parser) recover(errp *error) {
 	e := recover()
 	switch _, ok := e.(runtime.Error); {
 	case ok:
@@ -402,7 +402,7 @@ func (p *parser) Lex(lval *yySymType) int {
 // It is a no-op since the parsers error routines are triggered
 // by mechanisms that allow more fine-grained control
 // For more information, see https://pkg.go.dev/golang.org/x/tools/cmd/goyacc.
-func (p *parser) Error(string) {
+func (*parser) Error(string) {
 }
 
 // InjectItem allows injecting a single Item at the beginning of the token stream
@@ -425,7 +425,7 @@ func (p *parser) InjectItem(typ ItemType) {
 	p.injecting = true
 }
 
-func (p *parser) newBinaryExpression(lhs Node, op Item, modifiers, rhs Node) *BinaryExpr {
+func (*parser) newBinaryExpression(lhs Node, op Item, modifiers, rhs Node) *BinaryExpr {
 	ret := modifiers.(*BinaryExpr)
 
 	ret.LHS = lhs.(Expr)
@@ -435,7 +435,7 @@ func (p *parser) newBinaryExpression(lhs Node, op Item, modifiers, rhs Node) *Bi
 	return ret
 }
 
-func (p *parser) assembleVectorSelector(vs *VectorSelector) {
+func (*parser) assembleVectorSelector(vs *VectorSelector) {
 	// If the metric name was set outside the braces, add a matcher for it.
 	// If the metric name was inside the braces we don't need to do anything.
 	if vs.Name != "" {
@@ -493,7 +493,7 @@ func (p *parser) newAggregateExpr(op Item, modifier, args Node) (ret *AggregateE
 }
 
 // newMap is used when building the FloatHistogram from a map.
-func (p *parser) newMap() (ret map[string]interface{}) {
+func (*parser) newMap() (ret map[string]interface{}) {
 	return map[string]interface{}{}
 }
 
@@ -522,7 +522,7 @@ func (p *parser) histogramsDecreaseSeries(base, inc *histogram.FloatHistogram, t
 	})
 }
 
-func (p *parser) histogramsSeries(base, inc *histogram.FloatHistogram, times uint64,
+func (*parser) histogramsSeries(base, inc *histogram.FloatHistogram, times uint64,
 	combine func(*histogram.FloatHistogram, *histogram.FloatHistogram) (*histogram.FloatHistogram, error),
 ) ([]SequenceValue, error) {
 	ret := make([]SequenceValue, times+1)

--- a/promql/parser/prettier.go
+++ b/promql/parser/prettier.go
@@ -105,7 +105,7 @@ func (e *Call) Pretty(level int) string {
 	return s
 }
 
-func (e *EvalStmt) Pretty(_ int) string {
+func (e *EvalStmt) Pretty(int) string {
 	return "EVAL " + e.Expr.String()
 }
 

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -314,7 +314,7 @@ func validateExpectedCmds(cmd *evalCmd) error {
 	return nil
 }
 
-func (t *test) parseEval(lines []string, i int) (int, *evalCmd, error) {
+func (*test) parseEval(lines []string, i int) (int, *evalCmd, error) {
 	instantParts := patEvalInstant.FindStringSubmatch(lines[i])
 	rangeParts := patEvalRange.FindStringSubmatch(lines[i])
 
@@ -532,7 +532,7 @@ func newLoadCmd(gap time.Duration, withNHCB bool) *loadCmd {
 	}
 }
 
-func (cmd loadCmd) String() string {
+func (loadCmd) String() string {
 	return "load"
 }
 
@@ -795,7 +795,7 @@ func newRangeEvalCmd(expr string, start, end time.Time, step time.Duration, line
 	}
 }
 
-func (ev *evalCmd) String() string {
+func (*evalCmd) String() string {
 	return "eval"
 }
 
@@ -1195,7 +1195,7 @@ func HistogramTestExpression(h *histogram.FloatHistogram) string {
 // clearCmd is a command that wipes the test's storage state.
 type clearCmd struct{}
 
-func (cmd clearCmd) String() string {
+func (clearCmd) String() string {
 	return "clear"
 }
 

--- a/promql/value.go
+++ b/promql/value.go
@@ -471,7 +471,7 @@ func (ssi *storageSeriesIterator) At() (t int64, v float64) {
 	return ssi.currT, ssi.currF
 }
 
-func (ssi *storageSeriesIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
+func (*storageSeriesIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
 	panic(errors.New("storageSeriesIterator: AtHistogram not supported"))
 }
 
@@ -535,7 +535,7 @@ func (ssi *storageSeriesIterator) Next() chunkenc.ValueType {
 	}
 }
 
-func (ssi *storageSeriesIterator) Err() error {
+func (*storageSeriesIterator) Err() error {
 	return nil
 }
 

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -109,7 +109,7 @@ func TestAlertingRuleTemplateWithHistogram(t *testing.T) {
 		NegativeBuckets: []float64{-2, 2, 2, 7, 5, 5, 2},
 	}
 
-	q := func(_ context.Context, _ string, _ time.Time) (promql.Vector, error) {
+	q := func(context.Context, string, time.Time) (promql.Vector, error) {
 		return []promql.Sample{{H: &h}}, nil
 	}
 
@@ -678,7 +678,7 @@ func TestQueryForStateSeries(t *testing.T) {
 	tests := []testInput{
 		// Test for empty series.
 		{
-			selectMockFunction: func(_ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+			selectMockFunction: func(bool, *storage.SelectHints, ...*labels.Matcher) storage.SeriesSet {
 				return storage.EmptySeriesSet()
 			},
 			expectedSeries: nil,
@@ -686,7 +686,7 @@ func TestQueryForStateSeries(t *testing.T) {
 		},
 		// Test for error series.
 		{
-			selectMockFunction: func(_ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+			selectMockFunction: func(bool, *storage.SelectHints, ...*labels.Matcher) storage.SeriesSet {
 				return storage.ErrSeriesSet(testError)
 			},
 			expectedSeries: nil,
@@ -694,7 +694,7 @@ func TestQueryForStateSeries(t *testing.T) {
 		},
 		// Test for mock series.
 		{
-			selectMockFunction: func(_ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+			selectMockFunction: func(bool, *storage.SelectHints, ...*labels.Matcher) storage.SeriesSet {
 				return storage.TestSeriesSet(storage.MockSeries(
 					[]int64{1, 2, 3},
 					[]float64{1, 2, 3},

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -377,7 +377,7 @@ func TestForStateRestore(t *testing.T) {
 				Queryable:       storage,
 				Context:         context.Background(),
 				Logger:          promslog.NewNopLogger(),
-				NotifyFunc:      func(_ context.Context, _ string, _ ...*Alert) {},
+				NotifyFunc:      func(context.Context, string, ...*Alert) {},
 				OutageTolerance: 30 * time.Minute,
 				ForGracePeriod:  10 * time.Minute,
 			}
@@ -1355,7 +1355,7 @@ func TestRuleGroupEvalIterationFunc(t *testing.T) {
 		testValue = 3
 	}
 
-	skipEvalIterationFunc := func(_ context.Context, _ *Group, _ time.Time) {
+	skipEvalIterationFunc := func(context.Context, *Group, time.Time) {
 		testValue = 4
 	}
 
@@ -1394,7 +1394,7 @@ func TestRuleGroupEvalIterationFunc(t *testing.T) {
 			Queryable:       storage,
 			Context:         context.Background(),
 			Logger:          promslog.NewNopLogger(),
-			NotifyFunc:      func(_ context.Context, _ string, _ ...*Alert) {},
+			NotifyFunc:      func(context.Context, string, ...*Alert) {},
 			OutageTolerance: 30 * time.Minute,
 			ForGracePeriod:  10 * time.Minute,
 		}
@@ -1527,7 +1527,7 @@ func TestManager_LoadGroups_ShouldCheckWhetherEachRuleHasDependentsAndDependenci
 		Context:    context.Background(),
 		Logger:     promslog.NewNopLogger(),
 		Appendable: storage,
-		QueryFunc:  func(_ context.Context, _ string, _ time.Time) (promql.Vector, error) { return nil, nil },
+		QueryFunc:  func(context.Context, string, time.Time) (promql.Vector, error) { return nil, nil },
 	})
 
 	t.Run("load a mix of dependent and independent rules", func(t *testing.T) {
@@ -2299,11 +2299,11 @@ func TestNewRuleGroupRestoration(t *testing.T) {
 	option := optsFactory(store, &maxInflight, &inflightQueries, maxConcurrency)
 	option.Queryable = store
 	option.Appendable = store
-	option.NotifyFunc = func(_ context.Context, _ string, _ ...*Alert) {}
+	option.NotifyFunc = func(context.Context, string, ...*Alert) {}
 
 	var evalCount atomic.Int32
 	ch := make(chan int32)
-	noopEvalIterFunc := func(_ context.Context, _ *Group, _ time.Time) {
+	noopEvalIterFunc := func(context.Context, *Group, time.Time) {
 		evalCount.Inc()
 		ch <- evalCount.Load()
 	}
@@ -2363,11 +2363,11 @@ func TestNewRuleGroupRestorationWithRestoreNewGroupOption(t *testing.T) {
 	option.Queryable = store
 	option.Appendable = store
 	option.RestoreNewRuleGroups = true
-	option.NotifyFunc = func(_ context.Context, _ string, _ ...*Alert) {}
+	option.NotifyFunc = func(context.Context, string, ...*Alert) {}
 
 	var evalCount atomic.Int32
 	ch := make(chan int32)
-	noopEvalIterFunc := func(_ context.Context, _ *Group, _ time.Time) {
+	noopEvalIterFunc := func(context.Context, *Group, time.Time) {
 		evalCount.Inc()
 		ch <- evalCount.Load()
 	}
@@ -2669,7 +2669,7 @@ func TestRuleDependencyController_AnalyseRules(t *testing.T) {
 				Context:    context.Background(),
 				Logger:     promslog.NewNopLogger(),
 				Appendable: storage,
-				QueryFunc:  func(_ context.Context, _ string, _ time.Time) (promql.Vector, error) { return nil, nil },
+				QueryFunc:  func(context.Context, string, time.Time) (promql.Vector, error) { return nil, nil },
 			})
 
 			groups, errs := ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, false, tc.ruleFile)
@@ -2698,7 +2698,7 @@ func BenchmarkRuleDependencyController_AnalyseRules(b *testing.B) {
 		Context:    context.Background(),
 		Logger:     promslog.NewNopLogger(),
 		Appendable: storage,
-		QueryFunc:  func(_ context.Context, _ string, _ time.Time) (promql.Vector, error) { return nil, nil },
+		QueryFunc:  func(context.Context, string, time.Time) (promql.Vector, error) { return nil, nil },
 	})
 
 	groups, errs := ruleManager.LoadGroups(time.Second, labels.EmptyLabels(), "", nil, false, "fixtures/rules_multiple.yaml")

--- a/rules/origin_test.go
+++ b/rules/origin_test.go
@@ -29,27 +29,27 @@ import (
 
 type unknownRule struct{}
 
-func (u unknownRule) Name() string          { return "" }
-func (u unknownRule) Labels() labels.Labels { return labels.EmptyLabels() }
-func (u unknownRule) Eval(context.Context, time.Duration, time.Time, QueryFunc, *url.URL, int) (promql.Vector, error) {
+func (unknownRule) Name() string          { return "" }
+func (unknownRule) Labels() labels.Labels { return labels.EmptyLabels() }
+func (unknownRule) Eval(context.Context, time.Duration, time.Time, QueryFunc, *url.URL, int) (promql.Vector, error) {
 	return nil, nil
 }
-func (u unknownRule) String() string                       { return "" }
-func (u unknownRule) Query() parser.Expr                   { return nil }
-func (u unknownRule) SetLastError(error)                   {}
-func (u unknownRule) LastError() error                     { return nil }
-func (u unknownRule) SetHealth(RuleHealth)                 {}
-func (u unknownRule) Health() RuleHealth                   { return "" }
-func (u unknownRule) SetEvaluationDuration(time.Duration)  {}
-func (u unknownRule) GetEvaluationDuration() time.Duration { return 0 }
-func (u unknownRule) SetEvaluationTimestamp(time.Time)     {}
-func (u unknownRule) GetEvaluationTimestamp() time.Time    { return time.Time{} }
-func (u unknownRule) SetDependentRules([]Rule)             {}
-func (u unknownRule) NoDependentRules() bool               { return false }
-func (u unknownRule) DependentRules() []Rule               { return nil }
-func (u unknownRule) SetDependencyRules([]Rule)            {}
-func (u unknownRule) NoDependencyRules() bool              { return false }
-func (u unknownRule) DependencyRules() []Rule              { return nil }
+func (unknownRule) String() string                       { return "" }
+func (unknownRule) Query() parser.Expr                   { return nil }
+func (unknownRule) SetLastError(error)                   {}
+func (unknownRule) LastError() error                     { return nil }
+func (unknownRule) SetHealth(RuleHealth)                 {}
+func (unknownRule) Health() RuleHealth                   { return "" }
+func (unknownRule) SetEvaluationDuration(time.Duration)  {}
+func (unknownRule) GetEvaluationDuration() time.Duration { return 0 }
+func (unknownRule) SetEvaluationTimestamp(time.Time)     {}
+func (unknownRule) GetEvaluationTimestamp() time.Time    { return time.Time{} }
+func (unknownRule) SetDependentRules([]Rule)             {}
+func (unknownRule) NoDependentRules() bool               { return false }
+func (unknownRule) DependentRules() []Rule               { return nil }
+func (unknownRule) SetDependencyRules([]Rule)            {}
+func (unknownRule) NoDependencyRules() bool              { return false }
+func (unknownRule) DependencyRules() []Rule              { return nil }
 
 func TestNewRuleDetailPanics(t *testing.T) {
 	require.PanicsWithValue(t, `unknown rule type "rules.unknownRule"`, func() {

--- a/scrape/helpers_test.go
+++ b/scrape/helpers_test.go
@@ -37,40 +37,40 @@ import (
 
 type nopAppendable struct{}
 
-func (a nopAppendable) Appender(_ context.Context) storage.Appender {
+func (nopAppendable) Appender(context.Context) storage.Appender {
 	return nopAppender{}
 }
 
 type nopAppender struct{}
 
-func (a nopAppender) SetOptions(_ *storage.AppendOptions) {}
+func (nopAppender) SetOptions(*storage.AppendOptions) {}
 
-func (a nopAppender) Append(storage.SeriesRef, labels.Labels, int64, float64) (storage.SeriesRef, error) {
+func (nopAppender) Append(storage.SeriesRef, labels.Labels, int64, float64) (storage.SeriesRef, error) {
 	return 1, nil
 }
 
-func (a nopAppender) AppendExemplar(storage.SeriesRef, labels.Labels, exemplar.Exemplar) (storage.SeriesRef, error) {
+func (nopAppender) AppendExemplar(storage.SeriesRef, labels.Labels, exemplar.Exemplar) (storage.SeriesRef, error) {
 	return 2, nil
 }
 
-func (a nopAppender) AppendHistogram(storage.SeriesRef, labels.Labels, int64, *histogram.Histogram, *histogram.FloatHistogram) (storage.SeriesRef, error) {
+func (nopAppender) AppendHistogram(storage.SeriesRef, labels.Labels, int64, *histogram.Histogram, *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	return 3, nil
 }
 
-func (a nopAppender) AppendHistogramCTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, _ int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
+func (nopAppender) AppendHistogramCTZeroSample(storage.SeriesRef, labels.Labels, int64, int64, *histogram.Histogram, *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	return 0, nil
 }
 
-func (a nopAppender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+func (nopAppender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
 	return 4, nil
 }
 
-func (a nopAppender) AppendCTZeroSample(storage.SeriesRef, labels.Labels, int64, int64) (storage.SeriesRef, error) {
+func (nopAppender) AppendCTZeroSample(storage.SeriesRef, labels.Labels, int64, int64) (storage.SeriesRef, error) {
 	return 5, nil
 }
 
-func (a nopAppender) Commit() error   { return nil }
-func (a nopAppender) Rollback() error { return nil }
+func (nopAppender) Commit() error   { return nil }
+func (nopAppender) Rollback() error { return nil }
 
 type floatSample struct {
 	metric labels.Labels
@@ -115,7 +115,7 @@ type collectResultAppendable struct {
 	*collectResultAppender
 }
 
-func (a *collectResultAppendable) Appender(_ context.Context) storage.Appender {
+func (a *collectResultAppendable) Appender(context.Context) storage.Appender {
 	return a
 }
 
@@ -137,7 +137,7 @@ type collectResultAppender struct {
 	pendingMetadata      []metadataEntry
 }
 
-func (a *collectResultAppender) SetOptions(_ *storage.AppendOptions) {}
+func (*collectResultAppender) SetOptions(*storage.AppendOptions) {}
 
 func (a *collectResultAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
 	a.mtx.Lock()

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -474,7 +474,7 @@ func (sp *scrapePool) Sync(tgs []*targetgroup.Group) {
 		for _, t := range targets {
 			// Replicate .Labels().IsEmpty() with a loop here to avoid generating garbage.
 			nonEmpty := false
-			t.LabelsRange(func(_ labels.Label) { nonEmpty = true })
+			t.LabelsRange(func(labels.Label) { nonEmpty = true })
 			switch {
 			case nonEmpty:
 				all = append(all, t)

--- a/storage/buffer.go
+++ b/storage/buffer.go
@@ -175,15 +175,15 @@ func (s fSample) F() float64 {
 	return s.f
 }
 
-func (s fSample) H() *histogram.Histogram {
+func (fSample) H() *histogram.Histogram {
 	panic("H() called for fSample")
 }
 
-func (s fSample) FH() *histogram.FloatHistogram {
+func (fSample) FH() *histogram.FloatHistogram {
 	panic("FH() called for fSample")
 }
 
-func (s fSample) Type() chunkenc.ValueType {
+func (fSample) Type() chunkenc.ValueType {
 	return chunkenc.ValFloat
 }
 
@@ -200,7 +200,7 @@ func (s hSample) T() int64 {
 	return s.t
 }
 
-func (s hSample) F() float64 {
+func (hSample) F() float64 {
 	panic("F() called for hSample")
 }
 
@@ -212,7 +212,7 @@ func (s hSample) FH() *histogram.FloatHistogram {
 	return s.h.ToFloat(nil)
 }
 
-func (s hSample) Type() chunkenc.ValueType {
+func (hSample) Type() chunkenc.ValueType {
 	return chunkenc.ValHistogram
 }
 
@@ -229,11 +229,11 @@ func (s fhSample) T() int64 {
 	return s.t
 }
 
-func (s fhSample) F() float64 {
+func (fhSample) F() float64 {
 	panic("F() called for fhSample")
 }
 
-func (s fhSample) H() *histogram.Histogram {
+func (fhSample) H() *histogram.Histogram {
 	panic("H() called for fhSample")
 }
 
@@ -241,7 +241,7 @@ func (s fhSample) FH() *histogram.FloatHistogram {
 	return s.fh
 }
 
-func (s fhSample) Type() chunkenc.ValueType {
+func (fhSample) Type() chunkenc.ValueType {
 	return chunkenc.ValFloatHistogram
 }
 

--- a/storage/buffer_test.go
+++ b/storage/buffer_test.go
@@ -390,15 +390,15 @@ func (m *mockSeriesIterator) At() (int64, float64)            { return m.at() }
 func (m *mockSeriesIterator) Next() chunkenc.ValueType        { return m.next() }
 func (m *mockSeriesIterator) Err() error                      { return m.err() }
 
-func (m *mockSeriesIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
+func (*mockSeriesIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
 	return 0, nil // Not really mocked.
 }
 
-func (m *mockSeriesIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+func (*mockSeriesIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
 	return 0, nil // Not really mocked.
 }
 
-func (m *mockSeriesIterator) AtT() int64 {
+func (*mockSeriesIterator) AtT() int64 {
 	return 0 // Not really mocked.
 }
 
@@ -444,4 +444,4 @@ func (it *fakeSeriesIterator) Seek(t int64) chunkenc.ValueType {
 	return chunkenc.ValFloat
 }
 
-func (it *fakeSeriesIterator) Err() error { return nil }
+func (*fakeSeriesIterator) Err() error { return nil }

--- a/storage/fanout_test.go
+++ b/storage/fanout_test.go
@@ -224,9 +224,9 @@ type errChunkQuerier struct{ errQuerier }
 func (errStorage) ChunkQuerier(_, _ int64) (storage.ChunkQuerier, error) {
 	return errChunkQuerier{}, nil
 }
-func (errStorage) Appender(_ context.Context) storage.Appender { return nil }
-func (errStorage) StartTime() (int64, error)                   { return 0, nil }
-func (errStorage) Close() error                                { return nil }
+func (errStorage) Appender(context.Context) storage.Appender { return nil }
+func (errStorage) StartTime() (int64, error)                 { return 0, nil }
+func (errStorage) Close() error                              { return nil }
 
 func (errQuerier) Select(context.Context, bool, *storage.SelectHints, ...*labels.Matcher) storage.SeriesSet {
 	return storage.ErrSeriesSet(errSelect)

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -125,15 +125,15 @@ type MockQuerier struct {
 	SelectMockFunction func(sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) SeriesSet
 }
 
-func (q *MockQuerier) LabelValues(context.Context, string, *LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+func (*MockQuerier) LabelValues(context.Context, string, *LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, nil
 }
 
-func (q *MockQuerier) LabelNames(context.Context, *LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+func (*MockQuerier) LabelNames(context.Context, *LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, nil
 }
 
-func (q *MockQuerier) Close() error {
+func (*MockQuerier) Close() error {
 	return nil
 }
 
@@ -408,10 +408,10 @@ type testSeriesSet struct {
 	series Series
 }
 
-func (s testSeriesSet) Next() bool                        { return true }
-func (s testSeriesSet) At() Series                        { return s.series }
-func (s testSeriesSet) Err() error                        { return nil }
-func (s testSeriesSet) Warnings() annotations.Annotations { return nil }
+func (testSeriesSet) Next() bool                        { return true }
+func (s testSeriesSet) At() Series                      { return s.series }
+func (testSeriesSet) Err() error                        { return nil }
+func (testSeriesSet) Warnings() annotations.Annotations { return nil }
 
 // TestSeriesSet returns a mock series set.
 func TestSeriesSet(series Series) SeriesSet {
@@ -422,10 +422,10 @@ type errSeriesSet struct {
 	err error
 }
 
-func (s errSeriesSet) Next() bool                        { return false }
-func (s errSeriesSet) At() Series                        { return nil }
-func (s errSeriesSet) Err() error                        { return s.err }
-func (s errSeriesSet) Warnings() annotations.Annotations { return nil }
+func (errSeriesSet) Next() bool                        { return false }
+func (errSeriesSet) At() Series                        { return nil }
+func (s errSeriesSet) Err() error                      { return s.err }
+func (errSeriesSet) Warnings() annotations.Annotations { return nil }
 
 // ErrSeriesSet returns a series set that wraps an error.
 func ErrSeriesSet(err error) SeriesSet {
@@ -443,10 +443,10 @@ type errChunkSeriesSet struct {
 	err error
 }
 
-func (s errChunkSeriesSet) Next() bool                        { return false }
-func (s errChunkSeriesSet) At() ChunkSeries                   { return nil }
-func (s errChunkSeriesSet) Err() error                        { return s.err }
-func (s errChunkSeriesSet) Warnings() annotations.Annotations { return nil }
+func (errChunkSeriesSet) Next() bool                        { return false }
+func (errChunkSeriesSet) At() ChunkSeries                   { return nil }
+func (s errChunkSeriesSet) Err() error                      { return s.err }
+func (errChunkSeriesSet) Warnings() annotations.Annotations { return nil }
 
 // ErrChunkSeriesSet returns a chunk series set that wraps an error.
 func ErrChunkSeriesSet(err error) ChunkSeriesSet {

--- a/storage/merge_test.go
+++ b/storage/merge_test.go
@@ -1053,9 +1053,9 @@ func (m *mockChunkSeriesSet) Next() bool {
 
 func (m *mockChunkSeriesSet) At() ChunkSeries { return m.series[m.idx] }
 
-func (m *mockChunkSeriesSet) Err() error { return nil }
+func (*mockChunkSeriesSet) Err() error { return nil }
 
-func (m *mockChunkSeriesSet) Warnings() annotations.Annotations { return nil }
+func (*mockChunkSeriesSet) Warnings() annotations.Annotations { return nil }
 
 func TestChainSampleIterator(t *testing.T) {
 	for sampleType, sampleFunc := range map[string]func(int64) chunks.Sample{
@@ -1409,7 +1409,7 @@ func BenchmarkMergeLabelValuesWithLimit(b *testing.B) {
 		},
 	}
 
-	b.Run("benchmark", func(_ *testing.B) {
+	b.Run("benchmark", func(*testing.B) {
 		ctx := context.Background()
 		hints := &LabelHints{
 			Limit: 1000,
@@ -1692,27 +1692,27 @@ type errIterator struct {
 	err error
 }
 
-func (e errIterator) Next() chunkenc.ValueType {
+func (errIterator) Next() chunkenc.ValueType {
 	return chunkenc.ValNone
 }
 
-func (e errIterator) Seek(_ int64) chunkenc.ValueType {
+func (errIterator) Seek(int64) chunkenc.ValueType {
 	return chunkenc.ValNone
 }
 
-func (e errIterator) At() (int64, float64) {
+func (errIterator) At() (int64, float64) {
 	return 0, 0
 }
 
-func (e errIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
+func (errIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
 	return 0, nil
 }
 
-func (e errIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+func (errIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
 	return 0, nil
 }
 
-func (e errIterator) AtT() int64 {
+func (errIterator) AtT() int64 {
 	return 0
 }
 

--- a/storage/remote/client.go
+++ b/storage/remote/client.go
@@ -418,7 +418,7 @@ func (c *Client) Read(ctx context.Context, query *prompb.Query, sortSeries bool)
 	}
 }
 
-func (c *Client) handleSampledResponse(req *prompb.ReadRequest, httpResp *http.Response, sortSeries bool) (storage.SeriesSet, error) {
+func (*Client) handleSampledResponse(req *prompb.ReadRequest, httpResp *http.Response, sortSeries bool) (storage.SeriesSet, error) {
 	compressed, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response. HTTP status code: %s: %w", httpResp.Status, err)

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -340,7 +340,7 @@ func (e errSeriesSet) Err() error {
 	return e.err
 }
 
-func (e errSeriesSet) Warnings() annotations.Annotations { return nil }
+func (errSeriesSet) Warnings() annotations.Annotations { return nil }
 
 // concreteSeriesSet implements storage.SeriesSet.
 type concreteSeriesSet struct {
@@ -357,11 +357,11 @@ func (c *concreteSeriesSet) At() storage.Series {
 	return c.series[c.cur-1]
 }
 
-func (c *concreteSeriesSet) Err() error {
+func (*concreteSeriesSet) Err() error {
 	return nil
 }
 
-func (c *concreteSeriesSet) Warnings() annotations.Annotations { return nil }
+func (*concreteSeriesSet) Warnings() annotations.Annotations { return nil }
 
 // concreteSeries implements storage.Series.
 type concreteSeries struct {
@@ -536,7 +536,7 @@ func (c *concreteSeriesIterator) Next() chunkenc.ValueType {
 }
 
 // Err implements chunkenc.Iterator.
-func (c *concreteSeriesIterator) Err() error {
+func (*concreteSeriesIterator) Err() error {
 	return nil
 }
 
@@ -607,7 +607,7 @@ func (s *chunkedSeriesSet) Err() error {
 	return s.err
 }
 
-func (s *chunkedSeriesSet) Warnings() annotations.Annotations {
+func (*chunkedSeriesSet) Warnings() annotations.Annotations {
 	return nil
 }
 

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -719,9 +719,9 @@ func (c *mockChunkSeriesSet) At() storage.ChunkSeries {
 	}
 }
 
-func (c *mockChunkSeriesSet) Warnings() annotations.Annotations { return nil }
+func (*mockChunkSeriesSet) Warnings() annotations.Annotations { return nil }
 
-func (c *mockChunkSeriesSet) Err() error {
+func (*mockChunkSeriesSet) Err() error {
 	return nil
 }
 
@@ -748,7 +748,7 @@ func (c *mockChunkIterator) Next() bool {
 	return c.index < len(c.chunks)
 }
 
-func (c *mockChunkIterator) Err() error {
+func (*mockChunkIterator) Err() error {
 	return nil
 }
 
@@ -986,7 +986,7 @@ func TestChunkedSeriesSet(t *testing.T) {
 // mockFlusher implements http.Flusher.
 type mockFlusher struct{}
 
-func (f *mockFlusher) Flush() {}
+func (*mockFlusher) Flush() {}
 
 type oneShotCloser struct {
 	r      io.Reader

--- a/storage/remote/metadata_watcher.go
+++ b/storage/remote/metadata_watcher.go
@@ -37,7 +37,7 @@ type Watchable interface {
 
 type noopScrapeManager struct{}
 
-func (noop *noopScrapeManager) Get() (*scrape.Manager, error) {
+func (*noopScrapeManager) Get() (*scrape.Manager, error) {
 	return nil, errors.New("scrape manager not ready")
 }
 

--- a/storage/remote/metadata_watcher_test.go
+++ b/storage/remote/metadata_watcher_test.go
@@ -50,8 +50,8 @@ func (s *TestMetaStore) GetMetadata(mfName string) (scrape.MetricMetadata, bool)
 	return scrape.MetricMetadata{}, false
 }
 
-func (s *TestMetaStore) SizeMetadata() int   { return 0 }
-func (s *TestMetaStore) LengthMetadata() int { return 0 }
+func (*TestMetaStore) SizeMetadata() int   { return 0 }
+func (*TestMetaStore) LengthMetadata() int { return 0 }
 
 type writeMetadataToMock struct {
 	metadataAppended int

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -764,7 +764,7 @@ func TestDisableReshardOnRetry(t *testing.T) {
 		metrics = newQueueManagerMetrics(nil, "", "")
 
 		client = &MockWriteClient{
-			StoreFunc: func(_ context.Context, _ []byte, _ int) (WriteResponseStats, error) {
+			StoreFunc: func(context.Context, []byte, int) (WriteResponseStats, error) {
 				onStoreCalled()
 
 				return WriteResponseStats{}, RecoverableError{
@@ -1235,11 +1235,11 @@ func (c *TestWriteClient) Store(_ context.Context, req []byte, _ int) (WriteResp
 	return rs, nil
 }
 
-func (c *TestWriteClient) Name() string {
+func (*TestWriteClient) Name() string {
 	return "testwriteclient"
 }
 
-func (c *TestWriteClient) Endpoint() string {
+func (*TestWriteClient) Endpoint() string {
 	return "http://test-remote.com/1234"
 }
 
@@ -1325,11 +1325,11 @@ func (c *TestBlockingWriteClient) NumCalls() uint64 {
 	return c.numCalls.Load()
 }
 
-func (c *TestBlockingWriteClient) Name() string {
+func (*TestBlockingWriteClient) Name() string {
 	return "testblockingwriteclient"
 }
 
-func (c *TestBlockingWriteClient) Endpoint() string {
+func (*TestBlockingWriteClient) Endpoint() string {
 	return "http://test-remote-blocking.com/1234"
 }
 
@@ -1337,11 +1337,11 @@ func (c *TestBlockingWriteClient) Endpoint() string {
 type NopWriteClient struct{}
 
 func NewNopWriteClient() *NopWriteClient { return &NopWriteClient{} }
-func (c *NopWriteClient) Store(context.Context, []byte, int) (WriteResponseStats, error) {
+func (*NopWriteClient) Store(context.Context, []byte, int) (WriteResponseStats, error) {
 	return WriteResponseStats{}, nil
 }
-func (c *NopWriteClient) Name() string     { return "nopwriteclient" }
-func (c *NopWriteClient) Endpoint() string { return "http://test-remote.com/1234" }
+func (*NopWriteClient) Name() string     { return "nopwriteclient" }
+func (*NopWriteClient) Endpoint() string { return "http://test-remote.com/1234" }
 
 type MockWriteClient struct {
 	StoreFunc    func(context.Context, []byte, int) (WriteResponseStats, error)

--- a/storage/remote/read.go
+++ b/storage/remote/read.go
@@ -210,19 +210,19 @@ func (q querier) addExternalLabels(ms []*labels.Matcher) ([]*labels.Matcher, []s
 }
 
 // LabelValues implements storage.Querier and is a noop.
-func (q *querier) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+func (*querier) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	// TODO: Implement: https://github.com/prometheus/prometheus/issues/3351
 	return nil, nil, errors.New("not implemented")
 }
 
 // LabelNames implements storage.Querier and is a noop.
-func (q *querier) LabelNames(context.Context, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+func (*querier) LabelNames(context.Context, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	// TODO: Implement: https://github.com/prometheus/prometheus/issues/3351
 	return nil, nil, errors.New("not implemented")
 }
 
 // Close implements storage.Querier and is a noop.
-func (q *querier) Close() error {
+func (*querier) Close() error {
 	return nil
 }
 

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -145,7 +145,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 }
 
 // StartTime implements the Storage interface.
-func (s *Storage) StartTime() (int64, error) {
+func (*Storage) StartTime() (int64, error) {
 	return int64(model.Latest), nil
 }
 

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -233,7 +233,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 }
 
 // Appender implements storage.Storage.
-func (rws *WriteStorage) Appender(_ context.Context) storage.Appender {
+func (rws *WriteStorage) Appender(context.Context) storage.Appender {
 	return &timestampTracker{
 		writeStorage:         rws,
 		highestRecvTimestamp: rws.highestTimestamp,
@@ -302,7 +302,7 @@ func (t *timestampTracker) Append(_ storage.SeriesRef, _ labels.Labels, ts int64
 	return 0, nil
 }
 
-func (t *timestampTracker) AppendExemplar(_ storage.SeriesRef, _ labels.Labels, _ exemplar.Exemplar) (storage.SeriesRef, error) {
+func (t *timestampTracker) AppendExemplar(storage.SeriesRef, labels.Labels, exemplar.Exemplar) (storage.SeriesRef, error) {
 	t.exemplars++
 	return 0, nil
 }
@@ -335,7 +335,7 @@ func (t *timestampTracker) AppendHistogramCTZeroSample(_ storage.SeriesRef, _ la
 	return 0, nil
 }
 
-func (t *timestampTracker) UpdateMetadata(_ storage.SeriesRef, _ labels.Labels, _ metadata.Metadata) (storage.SeriesRef, error) {
+func (*timestampTracker) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
 	// TODO: Add and increment a `metadata` field when we get around to wiring metadata in remote_write.
 	// UpdateMetadata is no-op for remote write (where timestampTracker is being used) for now.
 	return 0, nil

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -92,7 +92,7 @@ func NewWriteHandler(logger *slog.Logger, reg prometheus.Registerer, appendable 
 	return h
 }
 
-func (h *writeHandler) parseProtoMsg(contentType string) (config.RemoteWriteProtoMsg, error) {
+func (*writeHandler) parseProtoMsg(contentType string) (config.RemoteWriteProtoMsg, error) {
 	contentType = strings.TrimSpace(contentType)
 
 	parts := strings.Split(contentType, ";")
@@ -513,7 +513,7 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 
 // handleHistogramZeroSample appends CT as a zero-value sample with CT value as the sample timestamp.
 // It doesn't return errors in case of out of order CT.
-func (h *writeHandler) handleHistogramZeroSample(app storage.Appender, ref storage.SeriesRef, l labels.Labels, hist writev2.Histogram, ct int64) (storage.SeriesRef, error) {
+func (*writeHandler) handleHistogramZeroSample(app storage.Appender, ref storage.SeriesRef, l labels.Labels, hist writev2.Histogram, ct int64) (storage.SeriesRef, error) {
 	var err error
 	if hist.IsFloatHistogram() {
 		ref, err = app.AppendHistogramCTZeroSample(ref, l, hist.Timestamp, ct, nil, hist.ToFloatHistogram())
@@ -625,7 +625,7 @@ func (rw *rwExporter) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) er
 	return err
 }
 
-func (rw *rwExporter) Capabilities() consumer.Capabilities {
+func (*rwExporter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -878,7 +878,7 @@ func requireEqual(t *testing.T, expected, actual interface{}, msgAndArgs ...inte
 		msgAndArgs...)
 }
 
-func (m *mockAppendable) Appender(_ context.Context) storage.Appender {
+func (m *mockAppendable) Appender(context.Context) storage.Appender {
 	if m.latestSample == nil {
 		m.latestSample = map[uint64]int64{}
 	}
@@ -894,7 +894,7 @@ func (m *mockAppendable) Appender(_ context.Context) storage.Appender {
 	return m
 }
 
-func (m *mockAppendable) SetOptions(_ *storage.AppendOptions) {
+func (*mockAppendable) SetOptions(*storage.AppendOptions) {
 	panic("unimplemented")
 }
 

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -757,7 +757,7 @@ func TestOTLPDelta(t *testing.T) {
 		{t: milli(1), l: ls, v: 1}, // +1
 		{t: milli(2), l: ls, v: 3}, // +2
 	}
-	if diff := cmp.Diff(want, appendable.samples, cmp.Exporter(func(_ reflect.Type) bool { return true })); diff != "" {
+	if diff := cmp.Diff(want, appendable.samples, cmp.Exporter(func(reflect.Type) bool { return true })); diff != "" {
 		t.Fatal(diff)
 	}
 }

--- a/storage/series.go
+++ b/storage/series.go
@@ -65,7 +65,7 @@ func NewListChunkSeriesFromSamples(lset labels.Labels, samples ...[]chunks.Sampl
 		if err != nil {
 			return &ChunkSeriesEntry{
 				Lset: lset,
-				ChunkIteratorFn: func(_ chunks.Iterator) chunks.Iterator {
+				ChunkIteratorFn: func(chunks.Iterator) chunks.Iterator {
 					return errChunksIterator{err: err}
 				},
 			}
@@ -169,7 +169,7 @@ func (it *listSeriesIterator) Seek(t int64) chunkenc.ValueType {
 	return it.samples.Get(it.idx).Type()
 }
 
-func (it *listSeriesIterator) Err() error { return nil }
+func (*listSeriesIterator) Err() error { return nil }
 
 type listSeriesIteratorWithCopy struct {
 	*listSeriesIterator
@@ -223,7 +223,7 @@ func (it *listChunkSeriesIterator) Next() bool {
 	return it.idx < len(it.chks)
 }
 
-func (it *listChunkSeriesIterator) Err() error { return nil }
+func (*listChunkSeriesIterator) Err() error { return nil }
 
 type chunkSetToSeriesSet struct {
 	ChunkSeriesSet
@@ -432,9 +432,9 @@ type errChunksIterator struct {
 	err error
 }
 
-func (e errChunksIterator) At() chunks.Meta { return chunks.Meta{} }
-func (e errChunksIterator) Next() bool      { return false }
-func (e errChunksIterator) Err() error      { return e.err }
+func (errChunksIterator) At() chunks.Meta { return chunks.Meta{} }
+func (errChunksIterator) Next() bool      { return false }
+func (e errChunksIterator) Err() error    { return e.err }
 
 // ExpandSamples iterates over all samples in the iterator, buffering all in slice.
 // Optionally it takes samples constructor, useful when you want to compare sample slices with different

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -605,7 +605,7 @@ func testTemplateExpansion(t *testing.T, scenarios []scenario) {
 	}
 
 	for _, s := range scenarios {
-		queryFunc := func(_ context.Context, _ string, _ time.Time) (promql.Vector, error) {
+		queryFunc := func(context.Context, string, time.Time) (promql.Vector, error) {
 			return s.queryResult, nil
 		}
 		var result string

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -736,22 +736,22 @@ func (db *DB) gc(mint int64) {
 }
 
 // StartTime implements the Storage interface.
-func (db *DB) StartTime() (int64, error) {
+func (*DB) StartTime() (int64, error) {
 	return int64(model.Latest), nil
 }
 
 // Querier implements the Storage interface.
-func (db *DB) Querier(int64, int64) (storage.Querier, error) {
+func (*DB) Querier(int64, int64) (storage.Querier, error) {
 	return nil, ErrUnsupported
 }
 
 // ChunkQuerier implements the Storage interface.
-func (db *DB) ChunkQuerier(int64, int64) (storage.ChunkQuerier, error) {
+func (*DB) ChunkQuerier(int64, int64) (storage.ChunkQuerier, error) {
 	return nil, ErrUnsupported
 }
 
 // ExemplarQuerier implements the Storage interface.
-func (db *DB) ExemplarQuerier(context.Context) (storage.ExemplarQuerier, error) {
+func (*DB) ExemplarQuerier(context.Context) (storage.ExemplarQuerier, error) {
 	return nil, ErrUnsupported
 }
 
@@ -988,7 +988,7 @@ func (a *appender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int
 	return storage.SeriesRef(series.ref), nil
 }
 
-func (a *appender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+func (*appender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
 	// TODO: Wire metadata in the Agent's appender.
 	return 0, nil
 }

--- a/tsdb/agent/series_test.go
+++ b/tsdb/agent/series_test.go
@@ -94,7 +94,7 @@ func labelsWithHashCollision() (labels.Labels, labels.Labels) {
 }
 
 // stripeSeriesWithCollidingSeries returns a stripeSeries with two memSeries having the same, colliding, hash.
-func stripeSeriesWithCollidingSeries(_ *testing.T) (*stripeSeries, *memSeries, *memSeries) {
+func stripeSeriesWithCollidingSeries(*testing.T) (*stripeSeries, *memSeries, *memSeries) {
 	lbls1, lbls2 := labelsWithHashCollision()
 	ms1 := memSeries{
 		lset: lbls1,

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -602,7 +602,7 @@ func testPostingsForLabelMatching(t *testing.T, offset storage.SeriesRef, setUp 
 		{
 			name:      "missing label",
 			labelName: "missing",
-			match: func(_ string) bool {
+			match: func(string) bool {
 				return true
 			},
 			exp: nil,

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -223,17 +223,17 @@ type mockSeriesIterator struct {
 	currIndex  int
 }
 
-func (it *mockSeriesIterator) Seek(int64) ValueType { return ValNone }
+func (*mockSeriesIterator) Seek(int64) ValueType { return ValNone }
 
 func (it *mockSeriesIterator) At() (int64, float64) {
 	return it.timeStamps[it.currIndex], it.values[it.currIndex]
 }
 
-func (it *mockSeriesIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
+func (*mockSeriesIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
 	return math.MinInt64, nil
 }
 
-func (it *mockSeriesIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+func (*mockSeriesIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
 	return math.MinInt64, nil
 }
 
@@ -249,7 +249,7 @@ func (it *mockSeriesIterator) Next() ValueType {
 
 	return ValNone
 }
-func (it *mockSeriesIterator) Err() error { return nil }
+func (*mockSeriesIterator) Err() error { return nil }
 
 // NewNopIterator returns a new chunk iterator that does not hold any data.
 func NewNopIterator() Iterator {

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -58,7 +58,7 @@ type xorValue struct {
 }
 
 // Encoding returns the encoding type.
-func (c *FloatHistogramChunk) Encoding() Encoding {
+func (*FloatHistogramChunk) Encoding() Encoding {
 	return EncFloatHistogram
 }
 
@@ -215,7 +215,7 @@ func (a *FloatHistogramAppender) NumSamples() int {
 
 // Append implements Appender. This implementation panics because normal float
 // samples must never be appended to a histogram chunk.
-func (a *FloatHistogramAppender) Append(int64, float64) {
+func (*FloatHistogramAppender) Append(int64, float64) {
 	panic("appended a float sample to a histogram chunk")
 }
 
@@ -688,7 +688,7 @@ func (a *FloatHistogramAppender) recode(
 
 // recodeHistogram converts the current histogram (in-place) to accommodate an expansion of the set of
 // (positive and/or negative) buckets used.
-func (a *FloatHistogramAppender) recodeHistogram(
+func (*FloatHistogramAppender) recodeHistogram(
 	fh *histogram.FloatHistogram,
 	pBackwardInter, nBackwardInter []Insert,
 ) {
@@ -702,7 +702,7 @@ func (a *FloatHistogramAppender) recodeHistogram(
 	}
 }
 
-func (a *FloatHistogramAppender) AppendHistogram(*HistogramAppender, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
+func (*FloatHistogramAppender) AppendHistogram(*HistogramAppender, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a histogram sample to a float histogram chunk")
 }
 
@@ -872,11 +872,11 @@ func (it *floatHistogramIterator) Seek(t int64) ValueType {
 	return ValFloatHistogram
 }
 
-func (it *floatHistogramIterator) At() (int64, float64) {
+func (*floatHistogramIterator) At() (int64, float64) {
 	panic("cannot call floatHistogramIterator.At")
 }
 
-func (it *floatHistogramIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
+func (*floatHistogramIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
 	panic("cannot call floatHistogramIterator.AtHistogram")
 }
 

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -51,7 +51,7 @@ func (c *HistogramChunk) Reset(stream []byte) {
 }
 
 // Encoding returns the encoding type.
-func (c *HistogramChunk) Encoding() Encoding {
+func (*HistogramChunk) Encoding() Encoding {
 	return EncHistogram
 }
 
@@ -234,7 +234,7 @@ func (a *HistogramAppender) NumSamples() int {
 
 // Append implements Appender. This implementation panics because normal float
 // samples must never be appended to a histogram chunk.
-func (a *HistogramAppender) Append(int64, float64) {
+func (*HistogramAppender) Append(int64, float64) {
 	panic("appended a float sample to a histogram chunk")
 }
 
@@ -731,7 +731,7 @@ func (a *HistogramAppender) recode(
 
 // recodeHistogram converts the current histogram (in-place) to accommodate an
 // expansion of the set of (positive and/or negative) buckets used.
-func (a *HistogramAppender) recodeHistogram(
+func (*HistogramAppender) recodeHistogram(
 	h *histogram.Histogram,
 	pBackwardInserts, nBackwardInserts []Insert,
 ) {
@@ -749,7 +749,7 @@ func (a *HistogramAppender) writeSumDelta(v float64) {
 	xorWrite(a.b, v, a.sum, &a.leading, &a.trailing)
 }
 
-func (a *HistogramAppender) AppendFloatHistogram(*FloatHistogramAppender, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
+func (*HistogramAppender) AppendFloatHistogram(*FloatHistogramAppender, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a float histogram sample to a histogram chunk")
 }
 
@@ -926,7 +926,7 @@ func (it *histogramIterator) Seek(t int64) ValueType {
 	return ValHistogram
 }
 
-func (it *histogramIterator) At() (int64, float64) {
+func (*histogramIterator) At() (int64, float64) {
 	panic("cannot call histogramIterator.At")
 }
 

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -71,7 +71,7 @@ func (c *XORChunk) Reset(stream []byte) {
 }
 
 // Encoding returns the encoding type.
-func (c *XORChunk) Encoding() Encoding {
+func (*XORChunk) Encoding() Encoding {
 	return EncXOR
 }
 
@@ -223,11 +223,11 @@ func (a *xorAppender) writeVDelta(v float64) {
 	xorWrite(a.b, v, a.v, &a.leading, &a.trailing)
 }
 
-func (a *xorAppender) AppendHistogram(*HistogramAppender, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
+func (*xorAppender) AppendHistogram(*HistogramAppender, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a histogram sample to a float chunk")
 }
 
-func (a *xorAppender) AppendFloatHistogram(*FloatHistogramAppender, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
+func (*xorAppender) AppendFloatHistogram(*FloatHistogramAppender, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a float histogram sample to a float chunk")
 }
 
@@ -263,11 +263,11 @@ func (it *xorIterator) At() (int64, float64) {
 	return it.t, it.val
 }
 
-func (it *xorIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
+func (*xorIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
 	panic("cannot call xorIterator.AtHistogram")
 }
 
-func (it *xorIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+func (*xorIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
 	panic("cannot call xorIterator.AtFloatHistogram")
 }
 

--- a/tsdb/chunks/chunk_write_queue_test.go
+++ b/tsdb/chunks/chunk_write_queue_test.go
@@ -31,7 +31,7 @@ func TestChunkWriteQueue_GettingChunkFromQueue(t *testing.T) {
 	blockWriterWg.Add(1)
 
 	// blockingChunkWriter blocks until blockWriterWg is done.
-	blockingChunkWriter := func(_ HeadSeriesRef, _, _ int64, _ chunkenc.Chunk, _ ChunkDiskMapperRef, _, _ bool) error {
+	blockingChunkWriter := func(HeadSeriesRef, int64, int64, chunkenc.Chunk, ChunkDiskMapperRef, bool, bool) error {
 		blockWriterWg.Wait()
 		return nil
 	}
@@ -82,7 +82,7 @@ func TestChunkWriteQueue_WritingThroughQueue(t *testing.T) {
 	ref := newChunkDiskMapperRef(321, 123)
 	cutFile := true
 	awaitCb := make(chan struct{})
-	require.NoError(t, q.addJob(chunkWriteJob{seriesRef: seriesRef, mint: mint, maxt: maxt, chk: chunk, ref: ref, cutFile: cutFile, callback: func(_ error) {
+	require.NoError(t, q.addJob(chunkWriteJob{seriesRef: seriesRef, mint: mint, maxt: maxt, chk: chunk, ref: ref, cutFile: cutFile, callback: func(error) {
 		close(awaitCb)
 	}}))
 	<-awaitCb
@@ -101,7 +101,7 @@ func TestChunkWriteQueue_WrappingAroundSizeLimit(t *testing.T) {
 	unblockChunkWriterCh := make(chan struct{}, sizeLimit)
 
 	// blockingChunkWriter blocks until the unblockChunkWriterCh channel returns a value.
-	blockingChunkWriter := func(_ HeadSeriesRef, _, _ int64, _ chunkenc.Chunk, _ ChunkDiskMapperRef, _, _ bool) error {
+	blockingChunkWriter := func(HeadSeriesRef, int64, int64, chunkenc.Chunk, ChunkDiskMapperRef, bool, bool) error {
 		<-unblockChunkWriterCh
 		return nil
 	}
@@ -117,7 +117,7 @@ func TestChunkWriteQueue_WrappingAroundSizeLimit(t *testing.T) {
 		callbackWg.Add(1)
 		require.NoError(t, q.addJob(chunkWriteJob{
 			ref: chunkRef,
-			callback: func(_ error) {
+			callback: func(error) {
 				callbackWg.Done()
 			},
 		}))
@@ -184,7 +184,7 @@ func TestChunkWriteQueue_WrappingAroundSizeLimit(t *testing.T) {
 
 func TestChunkWriteQueue_HandlerErrorViaCallback(t *testing.T) {
 	testError := errors.New("test error")
-	chunkWriter := func(_ HeadSeriesRef, _, _ int64, _ chunkenc.Chunk, _ ChunkDiskMapperRef, _, _ bool) error {
+	chunkWriter := func(HeadSeriesRef, int64, int64, chunkenc.Chunk, ChunkDiskMapperRef, bool, bool) error {
 		return testError
 	}
 
@@ -212,7 +212,7 @@ func BenchmarkChunkWriteQueue_addJob(b *testing.B) {
 			for _, concurrentWrites := range []int{1, 10, 100, 1000} {
 				b.Run(fmt.Sprintf("%d concurrent writes", concurrentWrites), func(b *testing.B) {
 					issueReadSignal := make(chan struct{})
-					q := newChunkWriteQueue(nil, 1000, func(_ HeadSeriesRef, _, _ int64, _ chunkenc.Chunk, _ ChunkDiskMapperRef, _, _ bool) error {
+					q := newChunkWriteQueue(nil, 1000, func(HeadSeriesRef, int64, int64, chunkenc.Chunk, ChunkDiskMapperRef, bool, bool) error {
 						if withReads {
 							select {
 							case issueReadSignal <- struct{}{}:

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -172,7 +172,7 @@ func (f *chunkPos) shouldCutNewFile(bytesToWrite uint64) bool {
 // bytesToWriteForChunk returns the number of bytes that will need to be written for the given chunk size,
 // including all meta data before and after the chunk data.
 // Head chunk format: https://github.com/prometheus/prometheus/blob/main/tsdb/docs/format/head_chunks.md#chunk
-func (f *chunkPos) bytesToWriteForChunk(chkLen uint64) uint64 {
+func (*chunkPos) bytesToWriteForChunk(chkLen uint64) uint64 {
 	// Headers.
 	bytes := uint64(SeriesRefSize) + 2*MintMaxtSize + ChunkEncodingSize
 
@@ -283,16 +283,16 @@ const (
 	OutOfOrderMask = uint8(0b10000000)
 )
 
-func (cdm *ChunkDiskMapper) ApplyOutOfOrderMask(sourceEncoding chunkenc.Encoding) chunkenc.Encoding {
+func (*ChunkDiskMapper) ApplyOutOfOrderMask(sourceEncoding chunkenc.Encoding) chunkenc.Encoding {
 	enc := uint8(sourceEncoding) | OutOfOrderMask
 	return chunkenc.Encoding(enc)
 }
 
-func (cdm *ChunkDiskMapper) IsOutOfOrderChunk(e chunkenc.Encoding) bool {
+func (*ChunkDiskMapper) IsOutOfOrderChunk(e chunkenc.Encoding) bool {
 	return (uint8(e) & OutOfOrderMask) != 0
 }
 
-func (cdm *ChunkDiskMapper) RemoveMasks(sourceEncoding chunkenc.Encoding) chunkenc.Encoding {
+func (*ChunkDiskMapper) RemoveMasks(sourceEncoding chunkenc.Encoding) chunkenc.Encoding {
 	restored := uint8(sourceEncoding) & (^OutOfOrderMask)
 	return chunkenc.Encoding(restored)
 }

--- a/tsdb/chunks/head_chunks_test.go
+++ b/tsdb/chunks/head_chunks_test.go
@@ -433,7 +433,7 @@ func TestHeadReadWriter_TruncateAfterFailedIterateChunks(t *testing.T) {
 	hrw = createChunkDiskMapper(t, dir)
 
 	// Forcefully failing IterateAllChunks.
-	require.Error(t, hrw.IterateAllChunks(func(_ HeadSeriesRef, _ ChunkDiskMapperRef, _, _ int64, _ uint16, _ chunkenc.Encoding, _ bool) error {
+	require.Error(t, hrw.IterateAllChunks(func(HeadSeriesRef, ChunkDiskMapperRef, int64, int64, uint16, chunkenc.Encoding, bool) error {
 		return errors.New("random error")
 	}))
 
@@ -545,7 +545,7 @@ func createChunkDiskMapper(t *testing.T, dir string) *ChunkDiskMapper {
 	hrw, err := NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), DefaultWriteBufferSize, writeQueueSize)
 	require.NoError(t, err)
 	require.False(t, hrw.fileMaxtSet)
-	require.NoError(t, hrw.IterateAllChunks(func(_ HeadSeriesRef, _ ChunkDiskMapperRef, _, _ int64, _ uint16, _ chunkenc.Encoding, _ bool) error {
+	require.NoError(t, hrw.IterateAllChunks(func(HeadSeriesRef, ChunkDiskMapperRef, int64, int64, uint16, chunkenc.Encoding, bool) error {
 		return nil
 	}))
 	require.True(t, hrw.fileMaxtSet)
@@ -574,7 +574,7 @@ func createChunk(t *testing.T, idx int, hrw *ChunkDiskMapper) (seriesRef HeadSer
 	if rand.Intn(2) == 0 {
 		isOOO = true
 	}
-	chunkRef = hrw.WriteChunk(seriesRef, mint, maxt, chunk, isOOO, func(_ error) {
+	chunkRef = hrw.WriteChunk(seriesRef, mint, maxt, chunk, isOOO, func(error) {
 		require.NoError(t, err)
 		close(awaitCb)
 	})

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -178,7 +178,7 @@ type LeveledCompactorOptions struct {
 
 type PostingsDecoderFactory func(meta *BlockMeta) index.PostingsDecoder
 
-func DefaultPostingsDecoderFactory(_ *BlockMeta) index.PostingsDecoder {
+func DefaultPostingsDecoderFactory(*BlockMeta) index.PostingsDecoder {
 	return index.DecodePostingsRaw
 }
 
@@ -761,7 +761,7 @@ type DefaultBlockPopulator struct{}
 // PopulateBlock fills the index and chunk writers with new data gathered as the union
 // of the provided blocks. It returns meta information for the new block.
 // It expects sorted blocks input by mint.
-func (c DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *CompactorMetrics, logger *slog.Logger, chunkPool chunkenc.Pool, mergeFunc storage.VerticalChunkSeriesMergeFunc, blocks []BlockReader, meta *BlockMeta, indexw IndexWriter, chunkw ChunkWriter, postingsFunc IndexReaderPostingsFunc) (err error) {
+func (DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *CompactorMetrics, logger *slog.Logger, chunkPool chunkenc.Pool, mergeFunc storage.VerticalChunkSeriesMergeFunc, blocks []BlockReader, meta *BlockMeta, indexw IndexWriter, chunkw ChunkWriter, postingsFunc IndexReaderPostingsFunc) (err error) {
 	if len(blocks) == 0 {
 		return errors.New("cannot populate block from no readers")
 	}

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1926,7 +1926,7 @@ func OverlappingBlocks(bm []BlockMeta) Overlaps {
 	return overlapGroups
 }
 
-func (db *DB) String() string {
+func (*DB) String() string {
 	return "HEAD"
 }
 

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1552,7 +1552,7 @@ func TestSizeRetention(t *testing.T) {
 	// Create a WAL checkpoint, and compare sizes.
 	first, last, err := wlog.Segments(db.Head().wal.Dir())
 	require.NoError(t, err)
-	_, err = wlog.Checkpoint(promslog.NewNopLogger(), db.Head().wal, first, last-1, func(_ chunks.HeadSeriesRef, _ int) bool { return false }, 0)
+	_, err = wlog.Checkpoint(promslog.NewNopLogger(), db.Head().wal, first, last-1, func(chunks.HeadSeriesRef, int) bool { return false }, 0)
 	require.NoError(t, err)
 	blockSize = int64(prom_testutil.ToFloat64(db.metrics.blocksBytes)) // Use the actual internal metrics.
 	walSize, err = db.Head().wal.Size()
@@ -5602,7 +5602,7 @@ func testQuerierOOOQuery(t *testing.T,
 	series1 := labels.FromStrings("foo", "bar1")
 
 	type filterFunc func(t int64) bool
-	defaultFilterFunc := func(_ int64) bool { return true }
+	defaultFilterFunc := func(int64) bool { return true }
 
 	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }
 	addSample := func(db *DB, fromMins, toMins, queryMinT, queryMaxT int64, expSamples []chunks.Sample, filter filterFunc, counterReset bool) ([]chunks.Sample, int) {
@@ -5932,7 +5932,7 @@ func testChunkQuerierOOOQuery(t *testing.T,
 	series1 := labels.FromStrings("foo", "bar1")
 
 	type filterFunc func(t int64) bool
-	defaultFilterFunc := func(_ int64) bool { return true }
+	defaultFilterFunc := func(int64) bool { return true }
 
 	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }
 	addSample := func(db *DB, fromMins, toMins, queryMinT, queryMaxT int64, expSamples []chunks.Sample, filter filterFunc, counterReset bool) ([]chunks.Sample, int) {
@@ -6211,7 +6211,7 @@ func testOOONativeHistogramsWithCounterResets(t *testing.T, scenario sampleTypeS
 	opts.OutOfOrderTimeWindow = 24 * time.Hour.Milliseconds()
 
 	type resetFunc func(v int64) bool
-	defaultResetFunc := func(_ int64) bool { return false }
+	defaultResetFunc := func(int64) bool { return false }
 
 	lbls := labels.FromStrings("foo", "bar1")
 	minutes := func(m int64) int64 { return m * time.Minute.Milliseconds() }
@@ -9205,15 +9205,15 @@ type mockCompactorFn struct {
 	writeFn   func() ([]ulid.ULID, error)
 }
 
-func (c *mockCompactorFn) Plan(_ string) ([]string, error) {
+func (c *mockCompactorFn) Plan(string) ([]string, error) {
 	return c.planFn()
 }
 
-func (c *mockCompactorFn) Compact(_ string, _ []string, _ []*Block) ([]ulid.ULID, error) {
+func (c *mockCompactorFn) Compact(string, []string, []*Block) ([]ulid.ULID, error) {
 	return c.compactFn()
 }
 
-func (c *mockCompactorFn) Write(_ string, _ BlockReader, _, _ int64, _ *BlockMeta) ([]ulid.ULID, error) {
+func (c *mockCompactorFn) Write(string, BlockReader, int64, int64, *BlockMeta) ([]ulid.ULID, error) {
 	return c.writeFn()
 }
 
@@ -9263,7 +9263,7 @@ func TestNewCompactorFunc(t *testing.T) {
 	opts := DefaultOptions()
 	block1 := ulid.MustNew(1, nil)
 	block2 := ulid.MustNew(2, nil)
-	opts.NewCompactorFunc = func(_ context.Context, _ prometheus.Registerer, _ *slog.Logger, _ []int64, _ chunkenc.Pool, _ *Options) (Compactor, error) {
+	opts.NewCompactorFunc = func(context.Context, prometheus.Registerer, *slog.Logger, []int64, chunkenc.Pool, *Options) (Compactor, error) {
 		return &mockCompactorFn{
 			planFn: func() ([]string, error) {
 				return []string{block1.String(), block2.String()}, nil

--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -140,11 +140,11 @@ func (ce *CircularExemplarStorage) Appender() *CircularExemplarStorage {
 	return ce
 }
 
-func (ce *CircularExemplarStorage) ExemplarQuerier(_ context.Context) (storage.ExemplarQuerier, error) {
+func (ce *CircularExemplarStorage) ExemplarQuerier(context.Context) (storage.ExemplarQuerier, error) {
 	return ce, nil
 }
 
-func (ce *CircularExemplarStorage) Querier(_ context.Context) (storage.ExemplarQuerier, error) {
+func (ce *CircularExemplarStorage) Querier(context.Context) (storage.ExemplarQuerier, error) {
 	return ce, nil
 }
 

--- a/tsdb/fileutil/direct_io_unsupported.go
+++ b/tsdb/fileutil/direct_io_unsupported.go
@@ -24,6 +24,6 @@ func NewBufioWriterWithSeek(f *os.File, size int) (BufWriter, error) {
 	return &writer{bufio.NewWriterSize(f, size)}, nil
 }
 
-func NewDirectIOWriter(_ *os.File, _ int) (BufWriter, error) {
+func NewDirectIOWriter(*os.File, int) (BufWriter, error) {
 	return nil, errDirectIOUnsupported
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1730,7 +1730,7 @@ func (h *Head) Close() error {
 // String returns an human readable representation of the TSDB head. It's important to
 // keep this function in order to avoid the struct dump when the head is stringified in
 // errors or logs.
-func (h *Head) String() string {
+func (*Head) String() string {
 	return "head"
 }
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -148,7 +148,7 @@ func (a *initAppender) Rollback() error {
 }
 
 // Appender returns a new Appender on the database.
-func (h *Head) Appender(_ context.Context) storage.Appender {
+func (h *Head) Appender(context.Context) storage.Appender {
 	h.metrics.activeAppenders.Inc()
 
 	// The head cache might not have a starting point yet. The init appender

--- a/tsdb/head_other.go
+++ b/tsdb/head_other.go
@@ -27,6 +27,6 @@ func (s *memSeries) labels() labels.Labels {
 }
 
 // RebuildSymbolTable is a no-op when not using dedupelabels.
-func (h *Head) RebuildSymbolTable(_ *slog.Logger) *labels.SymbolTable {
+func (*Head) RebuildSymbolTable(*slog.Logger) *labels.SymbolTable {
 	return nil
 }

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -49,7 +49,7 @@ type headIndexReader struct {
 	mint, maxt int64
 }
 
-func (h *headIndexReader) Close() error {
+func (*headIndexReader) Close() error {
 	return nil
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -84,7 +84,7 @@ func newTestHeadWithOptions(t testing.TB, compressWAL compression.Type, opts *He
 	h, err := NewHead(nil, nil, wal, nil, opts, nil)
 	require.NoError(t, err)
 
-	require.NoError(t, h.chunkDiskMapper.IterateAllChunks(func(_ chunks.HeadSeriesRef, _ chunks.ChunkDiskMapperRef, _, _ int64, _ uint16, _ chunkenc.Encoding, _ bool) error {
+	require.NoError(t, h.chunkDiskMapper.IterateAllChunks(func(chunks.HeadSeriesRef, chunks.ChunkDiskMapperRef, int64, int64, uint16, chunkenc.Encoding, bool) error {
 		return nil
 	}))
 
@@ -2709,7 +2709,7 @@ func TestMemSeriesIsolation(t *testing.T) {
 		return i
 	}
 
-	testIsolation := func(_ *Head, _ int) {
+	testIsolation := func(*Head, int) {
 	}
 
 	// Test isolation without restart of Head.
@@ -5567,7 +5567,7 @@ func newUnsupportedChunk() *unsupportedChunk {
 	return &unsupportedChunk{chunkenc.NewXORChunk()}
 }
 
-func (c *unsupportedChunk) Encoding() chunkenc.Encoding {
+func (*unsupportedChunk) Encoding() chunkenc.Encoding {
 	return EncUnsupportedXOR
 }
 
@@ -6097,7 +6097,7 @@ func TestCuttingNewHeadChunks(t *testing.T) {
 	}{
 		"float samples": {
 			numTotalSamples: 180,
-			floatValFunc: func(_ int) float64 {
+			floatValFunc: func(int) float64 {
 				return 1.
 			},
 			expectedChks: []struct {
@@ -6804,8 +6804,8 @@ type countSeriesLifecycleCallback struct {
 	deleted atomic.Int64
 }
 
-func (c *countSeriesLifecycleCallback) PreCreation(labels.Labels) error { return nil }
-func (c *countSeriesLifecycleCallback) PostCreation(labels.Labels)      { c.created.Inc() }
+func (*countSeriesLifecycleCallback) PreCreation(labels.Labels) error { return nil }
+func (c *countSeriesLifecycleCallback) PostCreation(labels.Labels)    { c.created.Inc() }
 func (c *countSeriesLifecycleCallback) PostDeletion(s map[chunks.HeadSeriesRef]labels.Labels) {
 	c.deleted.Add(int64(len(s)))
 }

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1845,7 +1845,7 @@ func (r *Reader) postingsForLabelMatchingV1(ctx context.Context, name string, ma
 
 // SortedPostings returns the given postings list reordered so that the backing series
 // are sorted.
-func (r *Reader) SortedPostings(p Postings) Postings {
+func (*Reader) SortedPostings(p Postings) Postings {
 	return p
 }
 
@@ -1920,7 +1920,7 @@ func (s *stringListIter) Next() bool {
 	return true
 }
 func (s stringListIter) At() string { return s.cur }
-func (s stringListIter) Err() error { return nil }
+func (stringListIter) Err() error   { return nil }
 
 // Decoder provides decoding methods for the v1 and v2 index file format.
 //
@@ -1946,7 +1946,7 @@ func DecodePostingsRaw(d encoding.Decbuf) (int, Postings, error) {
 
 // LabelNamesOffsetsFor decodes the offsets of the name symbols for a given series.
 // They are returned in the same order they're stored, which should be sorted lexicographically.
-func (dec *Decoder) LabelNamesOffsetsFor(b []byte) ([]uint32, error) {
+func (*Decoder) LabelNamesOffsetsFor(b []byte) ([]uint32, error) {
 	d := encoding.Decbuf{B: b}
 	k := d.Uvarint()
 

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -90,7 +90,7 @@ func (m mockIndex) AddSeries(ref storage.SeriesRef, l labels.Labels, chunks ...c
 	return nil
 }
 
-func (m mockIndex) Close() error {
+func (mockIndex) Close() error {
 	return nil
 }
 

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -564,10 +564,10 @@ type errPostings struct {
 	err error
 }
 
-func (e errPostings) Next() bool                  { return false }
-func (e errPostings) Seek(storage.SeriesRef) bool { return false }
-func (e errPostings) At() storage.SeriesRef       { return 0 }
-func (e errPostings) Err() error                  { return e.err }
+func (errPostings) Next() bool                  { return false }
+func (errPostings) Seek(storage.SeriesRef) bool { return false }
+func (errPostings) At() storage.SeriesRef       { return 0 }
+func (e errPostings) Err() error                { return e.err }
 
 var emptyPostings = errPostings{}
 
@@ -861,7 +861,7 @@ func (it *ListPostings) Seek(x storage.SeriesRef) bool {
 	return false
 }
 
-func (it *ListPostings) Err() error {
+func (*ListPostings) Err() error {
 	return nil
 }
 
@@ -914,7 +914,7 @@ func (it *bigEndianPostings) Seek(x storage.SeriesRef) bool {
 	return false
 }
 
-func (it *bigEndianPostings) Err() error {
+func (*bigEndianPostings) Err() error {
 	return nil
 }
 

--- a/tsdb/isolation_test.go
+++ b/tsdb/isolation_test.go
@@ -72,7 +72,7 @@ func TestIsolation(t *testing.T) {
 
 func countOpenReads(iso *isolation) int {
 	count := 0
-	iso.TraverseOpenReads(func(_ *isolationState) bool {
+	iso.TraverseOpenReads(func(*isolationState) bool {
 		count++
 		return true
 	})

--- a/tsdb/mocks_test.go
+++ b/tsdb/mocks_test.go
@@ -63,8 +63,8 @@ type mockBReader struct {
 
 func (r *mockBReader) Index() (IndexReader, error)  { return r.ir, nil }
 func (r *mockBReader) Chunks() (ChunkReader, error) { return r.cr, nil }
-func (r *mockBReader) Tombstones() (tombstones.Reader, error) {
+func (*mockBReader) Tombstones() (tombstones.Reader, error) {
 	return tombstones.NewMemTombstones(), nil
 }
 func (r *mockBReader) Meta() BlockMeta { return BlockMeta{MinTime: r.mint, MaxTime: r.maxt} }
-func (r *mockBReader) Size() int64     { return 0 }
+func (*mockBReader) Size() int64       { return 0 }

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -386,7 +386,7 @@ func (ch *OOOCompactionHead) Chunks() (ChunkReader, error) {
 	return NewHeadAndOOOChunkReader(ch.head, ch.mint, ch.maxt, nil, nil, ch.lastMmapRef), nil
 }
 
-func (ch *OOOCompactionHead) Tombstones() (tombstones.Reader, error) {
+func (*OOOCompactionHead) Tombstones() (tombstones.Reader, error) {
 	return tombstones.NewMemTombstones(), nil
 }
 
@@ -418,7 +418,7 @@ func (ch *OOOCompactionHead) CloneForTimeRange(mint, maxt int64) *OOOCompactionH
 	}
 }
 
-func (ch *OOOCompactionHead) Size() int64                            { return 0 }
+func (*OOOCompactionHead) Size() int64                               { return 0 }
 func (ch *OOOCompactionHead) MinTime() int64                         { return ch.mint }
 func (ch *OOOCompactionHead) MaxTime() int64                         { return ch.maxt }
 func (ch *OOOCompactionHead) ChunkRange() int64                      { return ch.chunkRange }
@@ -446,15 +446,15 @@ func (ir *OOOCompactionHeadIndexReader) Postings(_ context.Context, name string,
 	return index.NewListPostings(ir.ch.postings), nil
 }
 
-func (ir *OOOCompactionHeadIndexReader) PostingsForLabelMatching(context.Context, string, func(string) bool) index.Postings {
+func (*OOOCompactionHeadIndexReader) PostingsForLabelMatching(context.Context, string, func(string) bool) index.Postings {
 	return index.ErrPostings(errors.New("not supported"))
 }
 
-func (ir *OOOCompactionHeadIndexReader) PostingsForAllLabelValues(context.Context, string) index.Postings {
+func (*OOOCompactionHeadIndexReader) PostingsForAllLabelValues(context.Context, string) index.Postings {
 	return index.ErrPostings(errors.New("not supported"))
 }
 
-func (ir *OOOCompactionHeadIndexReader) SortedPostings(p index.Postings) index.Postings {
+func (*OOOCompactionHeadIndexReader) SortedPostings(p index.Postings) index.Postings {
 	// This will already be sorted from the Postings() call above.
 	return p
 }
@@ -484,31 +484,31 @@ func (ir *OOOCompactionHeadIndexReader) Series(ref storage.SeriesRef, builder *l
 	return getOOOSeriesChunks(s, ir.ch.mint, ir.ch.maxt, 0, ir.ch.lastMmapRef, false, 0, chks)
 }
 
-func (ir *OOOCompactionHeadIndexReader) SortedLabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, error) {
+func (*OOOCompactionHeadIndexReader) SortedLabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (ir *OOOCompactionHeadIndexReader) LabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, error) {
+func (*OOOCompactionHeadIndexReader) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (ir *OOOCompactionHeadIndexReader) PostingsForMatchers(_ context.Context, _ bool, _ ...*labels.Matcher) (index.Postings, error) {
+func (*OOOCompactionHeadIndexReader) PostingsForMatchers(context.Context, bool, ...*labels.Matcher) (index.Postings, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (ir *OOOCompactionHeadIndexReader) LabelNames(context.Context, ...*labels.Matcher) ([]string, error) {
+func (*OOOCompactionHeadIndexReader) LabelNames(context.Context, ...*labels.Matcher) ([]string, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (ir *OOOCompactionHeadIndexReader) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {
+func (*OOOCompactionHeadIndexReader) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {
 	return "", errors.New("not implemented")
 }
 
-func (ir *OOOCompactionHeadIndexReader) LabelNamesFor(_ context.Context, _ index.Postings) ([]string, error) {
+func (*OOOCompactionHeadIndexReader) LabelNamesFor(context.Context, index.Postings) ([]string, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (ir *OOOCompactionHeadIndexReader) Close() error {
+func (*OOOCompactionHeadIndexReader) Close() error {
 	return nil
 }
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -588,7 +588,7 @@ func (b *blockBaseSeriesSet) Err() error {
 	return b.p.Err()
 }
 
-func (b *blockBaseSeriesSet) Warnings() annotations.Annotations { return nil }
+func (*blockBaseSeriesSet) Warnings() annotations.Annotations { return nil }
 
 // populateWithDelGenericSeriesIterator allows to iterate over given chunk
 // metas. In each iteration it ensures that chunks are trimmed based on given
@@ -1266,4 +1266,4 @@ func (cr nopChunkReader) ChunkOrIterable(chunks.Meta) (chunkenc.Chunk, chunkenc.
 	return cr.emptyChunk, nil, nil
 }
 
-func (cr nopChunkReader) Close() error { return nil }
+func (nopChunkReader) Close() error { return nil }

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -798,7 +798,7 @@ func (it *mockSampleIterator) Next() chunkenc.ValueType {
 	return chunkenc.ValNone
 }
 
-func (it *mockSampleIterator) Err() error { return nil }
+func (*mockSampleIterator) Err() error { return nil }
 
 func TestPopulateWithTombSeriesIterators(t *testing.T) {
 	type minMaxTimes struct {
@@ -2082,7 +2082,7 @@ func (cr mockChunkReader) ChunkOrIterable(meta chunks.Meta) (chunkenc.Chunk, chu
 	return nil, nil, errors.New("Chunk with ref not found")
 }
 
-func (cr mockChunkReader) Close() error {
+func (mockChunkReader) Close() error {
 	return nil
 }
 
@@ -2249,7 +2249,7 @@ func (m mockIndex) WritePostings(name, value string, it index.Postings) error {
 	return nil
 }
 
-func (m mockIndex) Close() error {
+func (mockIndex) Close() error {
 	return nil
 }
 
@@ -3305,53 +3305,53 @@ func benchQuery(b *testing.B, expExpansions int, q storage.Querier, selectors la
 // mockMatcherIndex is used to check if the regex matcher works as expected.
 type mockMatcherIndex struct{}
 
-func (m mockMatcherIndex) Symbols() index.StringIter { return nil }
+func (mockMatcherIndex) Symbols() index.StringIter { return nil }
 
-func (m mockMatcherIndex) Close() error { return nil }
+func (mockMatcherIndex) Close() error { return nil }
 
 // SortedLabelValues will return error if it is called.
-func (m mockMatcherIndex) SortedLabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (mockMatcherIndex) SortedLabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
 	return []string{}, errors.New("sorted label values called")
 }
 
 // LabelValues will return error if it is called.
-func (m mockMatcherIndex) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (mockMatcherIndex) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
 	return []string{}, errors.New("label values called")
 }
 
-func (m mockMatcherIndex) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {
+func (mockMatcherIndex) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {
 	return "", errors.New("label value for called")
 }
 
-func (m mockMatcherIndex) LabelNamesFor(_ context.Context, _ index.Postings) ([]string, error) {
+func (mockMatcherIndex) LabelNamesFor(context.Context, index.Postings) ([]string, error) {
 	return nil, errors.New("label names for called")
 }
 
-func (m mockMatcherIndex) Postings(context.Context, string, ...string) (index.Postings, error) {
+func (mockMatcherIndex) Postings(context.Context, string, ...string) (index.Postings, error) {
 	return index.EmptyPostings(), nil
 }
 
-func (m mockMatcherIndex) SortedPostings(_ index.Postings) index.Postings {
+func (mockMatcherIndex) SortedPostings(index.Postings) index.Postings {
 	return index.EmptyPostings()
 }
 
-func (m mockMatcherIndex) ShardedPostings(ps index.Postings, _, _ uint64) index.Postings {
+func (mockMatcherIndex) ShardedPostings(ps index.Postings, _, _ uint64) index.Postings {
 	return ps
 }
 
-func (m mockMatcherIndex) Series(_ storage.SeriesRef, _ *labels.ScratchBuilder, _ *[]chunks.Meta) error {
+func (mockMatcherIndex) Series(storage.SeriesRef, *labels.ScratchBuilder, *[]chunks.Meta) error {
 	return nil
 }
 
-func (m mockMatcherIndex) LabelNames(context.Context, ...*labels.Matcher) ([]string, error) {
+func (mockMatcherIndex) LabelNames(context.Context, ...*labels.Matcher) ([]string, error) {
 	return []string{}, nil
 }
 
-func (m mockMatcherIndex) PostingsForLabelMatching(context.Context, string, func(string) bool) index.Postings {
+func (mockMatcherIndex) PostingsForLabelMatching(context.Context, string, func(string) bool) index.Postings {
 	return index.ErrPostings(errors.New("PostingsForLabelMatching called"))
 }
 
-func (m mockMatcherIndex) PostingsForAllLabelValues(context.Context, string) index.Postings {
+func (mockMatcherIndex) PostingsForAllLabelValues(context.Context, string) index.Postings {
 	return index.ErrPostings(errors.New("PostingsForAllLabelValues called"))
 }
 
@@ -3595,13 +3595,13 @@ func TestQueryWithDeletedHistograms(t *testing.T) {
 		"intCounter": func(i int) (*histogram.Histogram, *histogram.FloatHistogram) {
 			return tsdbutil.GenerateTestHistogram(int64(i)), nil
 		},
-		"intgauge": func(_ int) (*histogram.Histogram, *histogram.FloatHistogram) {
+		"intgauge": func(int) (*histogram.Histogram, *histogram.FloatHistogram) {
 			return tsdbutil.GenerateTestGaugeHistogram(rand.Int63() % 1000), nil
 		},
 		"floatCounter": func(i int) (*histogram.Histogram, *histogram.FloatHistogram) {
 			return nil, tsdbutil.GenerateTestFloatHistogram(int64(i))
 		},
-		"floatGauge": func(_ int) (*histogram.Histogram, *histogram.FloatHistogram) {
+		"floatGauge": func(int) (*histogram.Histogram, *histogram.FloatHistogram) {
 			return nil, tsdbutil.GenerateTestGaugeFloatHistogram(rand.Int63() % 1000)
 		},
 	}
@@ -3757,55 +3757,55 @@ type mockReaderOfLabels struct{}
 
 const mockReaderOfLabelsSeriesCount = checkContextEveryNIterations * 10
 
-func (m mockReaderOfLabels) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (mockReaderOfLabels) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
 	return make([]string, mockReaderOfLabelsSeriesCount), nil
 }
 
-func (m mockReaderOfLabels) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {
+func (mockReaderOfLabels) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {
 	panic("LabelValueFor called")
 }
 
-func (m mockReaderOfLabels) SortedLabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+func (mockReaderOfLabels) SortedLabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
 	panic("SortedLabelValues called")
 }
 
-func (m mockReaderOfLabels) Close() error {
+func (mockReaderOfLabels) Close() error {
 	return nil
 }
 
-func (m mockReaderOfLabels) LabelNames(context.Context, ...*labels.Matcher) ([]string, error) {
+func (mockReaderOfLabels) LabelNames(context.Context, ...*labels.Matcher) ([]string, error) {
 	panic("LabelNames called")
 }
 
-func (m mockReaderOfLabels) LabelNamesFor(context.Context, index.Postings) ([]string, error) {
+func (mockReaderOfLabels) LabelNamesFor(context.Context, index.Postings) ([]string, error) {
 	panic("LabelNamesFor called")
 }
 
-func (m mockReaderOfLabels) PostingsForLabelMatching(context.Context, string, func(string) bool) index.Postings {
+func (mockReaderOfLabels) PostingsForLabelMatching(context.Context, string, func(string) bool) index.Postings {
 	panic("PostingsForLabelMatching called")
 }
 
-func (m mockReaderOfLabels) PostingsForAllLabelValues(context.Context, string) index.Postings {
+func (mockReaderOfLabels) PostingsForAllLabelValues(context.Context, string) index.Postings {
 	panic("PostingsForAllLabelValues called")
 }
 
-func (m mockReaderOfLabels) Postings(context.Context, string, ...string) (index.Postings, error) {
+func (mockReaderOfLabels) Postings(context.Context, string, ...string) (index.Postings, error) {
 	panic("Postings called")
 }
 
-func (m mockReaderOfLabels) ShardedPostings(index.Postings, uint64, uint64) index.Postings {
+func (mockReaderOfLabels) ShardedPostings(index.Postings, uint64, uint64) index.Postings {
 	panic("Postings called")
 }
 
-func (m mockReaderOfLabels) SortedPostings(index.Postings) index.Postings {
+func (mockReaderOfLabels) SortedPostings(index.Postings) index.Postings {
 	panic("SortedPostings called")
 }
 
-func (m mockReaderOfLabels) Series(storage.SeriesRef, *labels.ScratchBuilder, *[]chunks.Meta) error {
+func (mockReaderOfLabels) Series(storage.SeriesRef, *labels.ScratchBuilder, *[]chunks.Meta) error {
 	panic("Series called")
 }
 
-func (m mockReaderOfLabels) Symbols() index.StringIter {
+func (mockReaderOfLabels) Symbols() index.StringIter {
 	panic("Series called")
 }
 

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -204,13 +204,13 @@ type Decoder struct {
 	builder labels.ScratchBuilder
 }
 
-func NewDecoder(_ *labels.SymbolTable) Decoder { // FIXME remove t
+func NewDecoder(*labels.SymbolTable) Decoder { // FIXME remove t
 	return Decoder{builder: labels.NewScratchBuilder(0)}
 }
 
 // Type returns the type of the record.
 // Returns RecordUnknown if no valid record type is found.
-func (d *Decoder) Type(rec []byte) Type {
+func (*Decoder) Type(rec []byte) Type {
 	if len(rec) < 1 {
 		return Unknown
 	}
@@ -247,7 +247,7 @@ func (d *Decoder) Series(rec []byte, series []RefSeries) ([]RefSeries, error) {
 }
 
 // Metadata appends metadata in rec to the given slice.
-func (d *Decoder) Metadata(rec []byte, metadata []RefMetadata) ([]RefMetadata, error) {
+func (*Decoder) Metadata(rec []byte, metadata []RefMetadata) ([]RefMetadata, error) {
 	dec := encoding.Decbuf{B: rec}
 
 	if Type(dec.Byte()) != Metadata {
@@ -302,7 +302,7 @@ func (d *Decoder) DecodeLabels(dec *encoding.Decbuf) labels.Labels {
 }
 
 // Samples appends samples in rec to the given slice.
-func (d *Decoder) Samples(rec []byte, samples []RefSample) ([]RefSample, error) {
+func (*Decoder) Samples(rec []byte, samples []RefSample) ([]RefSample, error) {
 	dec := encoding.Decbuf{B: rec}
 
 	if Type(dec.Byte()) != Samples {
@@ -341,7 +341,7 @@ func (d *Decoder) Samples(rec []byte, samples []RefSample) ([]RefSample, error) 
 }
 
 // Tombstones appends tombstones in rec to the given slice.
-func (d *Decoder) Tombstones(rec []byte, tstones []tombstones.Stone) ([]tombstones.Stone, error) {
+func (*Decoder) Tombstones(rec []byte, tstones []tombstones.Stone) ([]tombstones.Stone, error) {
 	dec := encoding.Decbuf{B: rec}
 
 	if Type(dec.Byte()) != Tombstones {
@@ -405,7 +405,7 @@ func (d *Decoder) ExemplarsFromBuffer(dec *encoding.Decbuf, exemplars []RefExemp
 	return exemplars, nil
 }
 
-func (d *Decoder) MmapMarkers(rec []byte, markers []RefMmapMarker) ([]RefMmapMarker, error) {
+func (*Decoder) MmapMarkers(rec []byte, markers []RefMmapMarker) ([]RefMmapMarker, error) {
 	dec := encoding.Decbuf{B: rec}
 	t := Type(dec.Byte())
 	if t != MmapMarkers {
@@ -433,7 +433,7 @@ func (d *Decoder) MmapMarkers(rec []byte, markers []RefMmapMarker) ([]RefMmapMar
 	return markers, nil
 }
 
-func (d *Decoder) HistogramSamples(rec []byte, histograms []RefHistogramSample) ([]RefHistogramSample, error) {
+func (*Decoder) HistogramSamples(rec []byte, histograms []RefHistogramSample) ([]RefHistogramSample, error) {
 	dec := encoding.Decbuf{B: rec}
 	t := Type(dec.Byte())
 	if t != HistogramSamples && t != CustomBucketsHistogramSamples {
@@ -525,7 +525,7 @@ func DecodeHistogram(buf *encoding.Decbuf, h *histogram.Histogram) {
 	}
 }
 
-func (d *Decoder) FloatHistogramSamples(rec []byte, histograms []RefFloatHistogramSample) ([]RefFloatHistogramSample, error) {
+func (*Decoder) FloatHistogramSamples(rec []byte, histograms []RefFloatHistogramSample) ([]RefFloatHistogramSample, error) {
 	dec := encoding.Decbuf{B: rec}
 	t := Type(dec.Byte())
 	if t != FloatHistogramSamples && t != CustomBucketsFloatHistogramSamples {
@@ -622,7 +622,7 @@ func DecodeFloatHistogram(buf *encoding.Decbuf, fh *histogram.FloatHistogram) {
 type Encoder struct{}
 
 // Series appends the encoded series to b and returns the resulting slice.
-func (e *Encoder) Series(series []RefSeries, b []byte) []byte {
+func (*Encoder) Series(series []RefSeries, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(Series))
 
@@ -634,7 +634,7 @@ func (e *Encoder) Series(series []RefSeries, b []byte) []byte {
 }
 
 // Metadata appends the encoded metadata to b and returns the resulting slice.
-func (e *Encoder) Metadata(metadata []RefMetadata, b []byte) []byte {
+func (*Encoder) Metadata(metadata []RefMetadata, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(Metadata))
 
@@ -665,7 +665,7 @@ func EncodeLabels(buf *encoding.Encbuf, lbls labels.Labels) {
 }
 
 // Samples appends the encoded samples to b and returns the resulting slice.
-func (e *Encoder) Samples(samples []RefSample, b []byte) []byte {
+func (*Encoder) Samples(samples []RefSample, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(Samples))
 
@@ -689,7 +689,7 @@ func (e *Encoder) Samples(samples []RefSample, b []byte) []byte {
 }
 
 // Tombstones appends the encoded tombstones to b and returns the resulting slice.
-func (e *Encoder) Tombstones(tstones []tombstones.Stone, b []byte) []byte {
+func (*Encoder) Tombstones(tstones []tombstones.Stone, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(Tombstones))
 
@@ -716,7 +716,7 @@ func (e *Encoder) Exemplars(exemplars []RefExemplar, b []byte) []byte {
 	return buf.Get()
 }
 
-func (e *Encoder) EncodeExemplarsIntoBuffer(exemplars []RefExemplar, buf *encoding.Encbuf) {
+func (*Encoder) EncodeExemplarsIntoBuffer(exemplars []RefExemplar, buf *encoding.Encbuf) {
 	// Store base timestamp and base reference number of first sample.
 	// All samples encode their timestamp and ref as delta to those.
 	first := exemplars[0]
@@ -732,7 +732,7 @@ func (e *Encoder) EncodeExemplarsIntoBuffer(exemplars []RefExemplar, buf *encodi
 	}
 }
 
-func (e *Encoder) MmapMarkers(markers []RefMmapMarker, b []byte) []byte {
+func (*Encoder) MmapMarkers(markers []RefMmapMarker, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(MmapMarkers))
 
@@ -744,7 +744,7 @@ func (e *Encoder) MmapMarkers(markers []RefMmapMarker, b []byte) []byte {
 	return buf.Get()
 }
 
-func (e *Encoder) HistogramSamples(histograms []RefHistogramSample, b []byte) ([]byte, []RefHistogramSample) {
+func (*Encoder) HistogramSamples(histograms []RefHistogramSample, b []byte) ([]byte, []RefHistogramSample) {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(HistogramSamples))
 
@@ -778,7 +778,7 @@ func (e *Encoder) HistogramSamples(histograms []RefHistogramSample, b []byte) ([
 	return buf.Get(), customBucketHistograms
 }
 
-func (e *Encoder) CustomBucketsHistogramSamples(histograms []RefHistogramSample, b []byte) []byte {
+func (*Encoder) CustomBucketsHistogramSamples(histograms []RefHistogramSample, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(CustomBucketsHistogramSamples))
 
@@ -843,7 +843,7 @@ func EncodeHistogram(buf *encoding.Encbuf, h *histogram.Histogram) {
 	}
 }
 
-func (e *Encoder) FloatHistogramSamples(histograms []RefFloatHistogramSample, b []byte) ([]byte, []RefFloatHistogramSample) {
+func (*Encoder) FloatHistogramSamples(histograms []RefFloatHistogramSample, b []byte) ([]byte, []RefFloatHistogramSample) {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(FloatHistogramSamples))
 
@@ -878,7 +878,7 @@ func (e *Encoder) FloatHistogramSamples(histograms []RefFloatHistogramSample, b 
 	return buf.Get(), customBucketsFloatHistograms
 }
 
-func (e *Encoder) CustomBucketsFloatHistogramSamples(histograms []RefFloatHistogramSample, b []byte) []byte {
+func (*Encoder) CustomBucketsFloatHistogramSamples(histograms []RefFloatHistogramSample, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(CustomBucketsFloatHistogramSamples))
 

--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -102,7 +102,7 @@ func (wtm *writeToMock) StoreSeries(series []record.RefSeries, index int) {
 	wtm.UpdateSeriesSegment(series, index)
 }
 
-func (wtm *writeToMock) StoreMetadata(_ []record.RefMetadata) { /* no-op */ }
+func (*writeToMock) StoreMetadata([]record.RefMetadata) { /* no-op */ }
 
 func (wtm *writeToMock) UpdateSeriesSegment(series []record.RefSeries, index int) {
 	wtm.seriesLock.Lock()
@@ -400,7 +400,7 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 				}
 			}
 
-			Checkpoint(promslog.NewNopLogger(), w, 0, 1, func(_ chunks.HeadSeriesRef, _ int) bool { return true }, 0)
+			Checkpoint(promslog.NewNopLogger(), w, 0, 1, func(chunks.HeadSeriesRef, int) bool { return true }, 0)
 			w.Truncate(1)
 
 			// Write more records after checkpointing.
@@ -491,7 +491,7 @@ func TestReadCheckpoint(t *testing.T) {
 			}
 			_, err = w.NextSegmentSync()
 			require.NoError(t, err)
-			_, err = Checkpoint(promslog.NewNopLogger(), w, 30, 31, func(_ chunks.HeadSeriesRef, _ int) bool { return true }, 0)
+			_, err = Checkpoint(promslog.NewNopLogger(), w, 30, 31, func(chunks.HeadSeriesRef, int) bool { return true }, 0)
 			require.NoError(t, err)
 			require.NoError(t, w.Truncate(32))
 
@@ -654,7 +654,7 @@ func TestCheckpointSeriesReset(t *testing.T) {
 				return wt.checkNumSeries() == seriesCount
 			}, 10*time.Second, 1*time.Second)
 
-			_, err = Checkpoint(promslog.NewNopLogger(), w, 2, 4, func(_ chunks.HeadSeriesRef, _ int) bool { return true }, 0)
+			_, err = Checkpoint(promslog.NewNopLogger(), w, 2, 4, func(chunks.HeadSeriesRef, int) bool { return true }, 0)
 			require.NoError(t, err)
 
 			err = w.Truncate(5)

--- a/util/compression/buffers.go
+++ b/util/compression/buffers.go
@@ -75,11 +75,11 @@ func (b *concurrentEBuffer) zstdEncBuf() *zstd.Encoder {
 
 // TODO(bwplotka): We could use pool, but putting it back into the pool needs to be
 // on the caller side, so no pool for now.
-func (b *concurrentEBuffer) get() []byte {
+func (*concurrentEBuffer) get() []byte {
 	return nil
 }
 
-func (b *concurrentEBuffer) set([]byte) {}
+func (*concurrentEBuffer) set([]byte) {}
 
 type DecodeBuffer interface {
 	zstdDecBuf() *zstd.Decoder
@@ -135,8 +135,8 @@ func (b *concurrentDBuffer) zstdDecBuf() *zstd.Decoder {
 	return b.r
 }
 
-func (b *concurrentDBuffer) get() []byte {
+func (*concurrentDBuffer) get() []byte {
 	return nil
 }
 
-func (b *concurrentDBuffer) set([]byte) {}
+func (*concurrentDBuffer) set([]byte) {}

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -323,7 +323,7 @@ func NewQuerySamples(enablePerStepStats bool) *QuerySamples {
 	return &qs
 }
 
-func (qs *QuerySamples) NewChild() *QuerySamples {
+func (*QuerySamples) NewChild() *QuerySamples {
 	return NewQuerySamples(false)
 }
 

--- a/util/testutil/context.go
+++ b/util/testutil/context.go
@@ -27,7 +27,7 @@ type MockContext struct {
 }
 
 // Deadline always will return not set.
-func (c *MockContext) Deadline() (deadline time.Time, ok bool) {
+func (*MockContext) Deadline() (deadline time.Time, ok bool) {
 	return time.Time{}, false
 }
 
@@ -42,7 +42,7 @@ func (c *MockContext) Err() error {
 }
 
 // Value ignores the Value and always returns nil.
-func (c *MockContext) Value(interface{}) interface{} {
+func (*MockContext) Value(interface{}) interface{} {
 	return nil
 }
 

--- a/util/testutil/directory.go
+++ b/util/testutil/directory.go
@@ -77,7 +77,7 @@ type (
 	}
 )
 
-func (c nilCloser) Close() {
+func (nilCloser) Close() {
 }
 
 func (c callbackCloser) Close() {

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -445,7 +445,7 @@ func invalidParamError(err error, parameter string) apiFuncResult {
 	}, nil, nil}
 }
 
-func (api *API) options(*http.Request) apiFuncResult {
+func (*API) options(*http.Request) apiFuncResult {
 	return apiFuncResult{nil, nil, nil, nil}
 }
 
@@ -518,7 +518,7 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 	}, nil, warnings, qry.Close}
 }
 
-func (api *API) formatQuery(r *http.Request) (result apiFuncResult) {
+func (*API) formatQuery(r *http.Request) (result apiFuncResult) {
 	expr, err := parser.ParseExpr(r.FormValue("query"))
 	if err != nil {
 		return invalidParamError(err, "query")
@@ -527,7 +527,7 @@ func (api *API) formatQuery(r *http.Request) (result apiFuncResult) {
 	return apiFuncResult{expr.Pretty(0), nil, nil, nil}
 }
 
-func (api *API) parseQuery(r *http.Request) apiFuncResult {
+func (*API) parseQuery(r *http.Request) apiFuncResult {
 	expr, err := parser.ParseExpr(r.FormValue("query"))
 	if err != nil {
 		return invalidParamError(err, "query")
@@ -998,7 +998,7 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 	return apiFuncResult{metrics, nil, warnings, closer}
 }
 
-func (api *API) dropSeries(_ *http.Request) apiFuncResult {
+func (*API) dropSeries(*http.Request) apiFuncResult {
 	return apiFuncResult{nil, &apiError{errorInternal, errors.New("not implemented")}, nil, nil}
 }
 
@@ -1692,7 +1692,7 @@ type prometheusConfig struct {
 	YAML string `json:"yaml"`
 }
 
-func (api *API) serveRuntimeInfo(_ *http.Request) apiFuncResult {
+func (api *API) serveRuntimeInfo(*http.Request) apiFuncResult {
 	status, err := api.runtimeInfo()
 	if err != nil {
 		return apiFuncResult{status, &apiError{errorInternal, err}, nil, nil}
@@ -1700,18 +1700,18 @@ func (api *API) serveRuntimeInfo(_ *http.Request) apiFuncResult {
 	return apiFuncResult{status, nil, nil, nil}
 }
 
-func (api *API) serveBuildInfo(_ *http.Request) apiFuncResult {
+func (api *API) serveBuildInfo(*http.Request) apiFuncResult {
 	return apiFuncResult{api.buildInfo, nil, nil, nil}
 }
 
-func (api *API) serveConfig(_ *http.Request) apiFuncResult {
+func (api *API) serveConfig(*http.Request) apiFuncResult {
 	cfg := &prometheusConfig{
 		YAML: api.config().String(),
 	}
 	return apiFuncResult{cfg, nil, nil, nil}
 }
 
-func (api *API) serveFlags(_ *http.Request) apiFuncResult {
+func (api *API) serveFlags(*http.Request) apiFuncResult {
 	return apiFuncResult{api.flagsMap, nil, nil, nil}
 }
 
@@ -1749,7 +1749,7 @@ func TSDBStatsFromIndexStats(stats []index.Stat) []TSDBStat {
 	return result
 }
 
-func (api *API) serveTSDBBlocks(_ *http.Request) apiFuncResult {
+func (api *API) serveTSDBBlocks(*http.Request) apiFuncResult {
 	blockMetas, err := api.db.BlockMetas()
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("error getting block metadata: %w", err)}, nil, nil}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -93,8 +93,8 @@ func (s *testMetaStore) GetMetadata(metric string) (scrape.MetricMetadata, bool)
 	return scrape.MetricMetadata{}, false
 }
 
-func (s *testMetaStore) SizeMetadata() int   { return 0 }
-func (s *testMetaStore) LengthMetadata() int { return 0 }
+func (*testMetaStore) SizeMetadata() int   { return 0 }
+func (*testMetaStore) LengthMetadata() int { return 0 }
 
 // testTargetRetriever represents a list of targets to scrape.
 // It is used to represent targets as part of test cases.
@@ -190,7 +190,7 @@ func (t *testTargetRetriever) toFactory() func(context.Context) TargetRetriever 
 
 type testAlertmanagerRetriever struct{}
 
-func (t testAlertmanagerRetriever) Alertmanagers() []*url.URL {
+func (testAlertmanagerRetriever) Alertmanagers() []*url.URL {
 	return []*url.URL{
 		{
 			Scheme: "http",
@@ -200,7 +200,7 @@ func (t testAlertmanagerRetriever) Alertmanagers() []*url.URL {
 	}
 }
 
-func (t testAlertmanagerRetriever) DroppedAlertmanagers() []*url.URL {
+func (testAlertmanagerRetriever) DroppedAlertmanagers() []*url.URL {
 	return []*url.URL{
 		{
 			Scheme: "http",
@@ -315,7 +315,7 @@ func (m *rulesRetrieverMock) CreateRuleGroups() {
 		Appendable: storage,
 		Context:    context.Background(),
 		Logger:     promslog.NewNopLogger(),
-		NotifyFunc: func(_ context.Context, _ string, _ ...*rules.Alert) {},
+		NotifyFunc: func(context.Context, string, ...*rules.Alert) {},
 	}
 
 	var r []rules.Rule
@@ -3806,7 +3806,7 @@ func (f *fakeDB) BlockMetas() ([]tsdb.BlockMeta, error) {
 }
 func (f *fakeDB) Delete(context.Context, int64, int64, ...*labels.Matcher) error { return f.err }
 func (f *fakeDB) Snapshot(string, bool) error                                    { return f.err }
-func (f *fakeDB) Stats(statsByLabelName string, limit int) (_ *tsdb.Stats, retErr error) {
+func (*fakeDB) Stats(statsByLabelName string, limit int) (_ *tsdb.Stats, retErr error) {
 	dbDir, err := os.MkdirTemp("", "tsdb-api-ready")
 	if err != nil {
 		return nil, err
@@ -3823,7 +3823,7 @@ func (f *fakeDB) Stats(statsByLabelName string, limit int) (_ *tsdb.Stats, retEr
 	return h.Stats(statsByLabelName, limit), nil
 }
 
-func (f *fakeDB) WALReplayStatus() (tsdb.WALReplayStatus, error) {
+func (*fakeDB) WALReplayStatus() (tsdb.WALReplayStatus, error) {
 	return tsdb.WALReplayStatus{}, nil
 }
 
@@ -4637,11 +4637,11 @@ func (t *testCodec) ContentType() MIMEType {
 	return t.contentType
 }
 
-func (t *testCodec) CanEncode(_ *Response) bool {
+func (t *testCodec) CanEncode(*Response) bool {
 	return t.canEncode
 }
 
-func (t *testCodec) Encode(_ *Response) ([]byte, error) {
+func (t *testCodec) Encode(*Response) ([]byte, error) {
 	return []byte(fmt.Sprintf("response from %v codec", t.contentType)), nil
 }
 
@@ -4765,11 +4765,11 @@ type fakeEngine struct {
 	query fakeQuery
 }
 
-func (e *fakeEngine) NewInstantQuery(_ context.Context, _ storage.Queryable, _ promql.QueryOpts, _ string, _ time.Time) (promql.Query, error) {
+func (e *fakeEngine) NewInstantQuery(context.Context, storage.Queryable, promql.QueryOpts, string, time.Time) (promql.Query, error) {
 	return &e.query, nil
 }
 
-func (e *fakeEngine) NewRangeQuery(_ context.Context, _ storage.Queryable, _ promql.QueryOpts, _ string, _, _ time.Time, _ time.Duration) (promql.Query, error) {
+func (e *fakeEngine) NewRangeQuery(context.Context, storage.Queryable, promql.QueryOpts, string, time.Time, time.Time, time.Duration) (promql.Query, error) {
 	return &e.query, nil
 }
 
@@ -4788,17 +4788,17 @@ func (q *fakeQuery) Exec(ctx context.Context) *promql.Result {
 	}
 }
 
-func (q *fakeQuery) Close() {}
+func (*fakeQuery) Close() {}
 
-func (q *fakeQuery) Statement() parser.Statement {
+func (*fakeQuery) Statement() parser.Statement {
 	return nil
 }
 
-func (q *fakeQuery) Stats() *stats.Statistics {
+func (*fakeQuery) Stats() *stats.Statistics {
 	return nil
 }
 
-func (q *fakeQuery) Cancel() {}
+func (*fakeQuery) Cancel() {}
 
 func (q *fakeQuery) String() string {
 	return q.query

--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -161,7 +161,7 @@ type errorTestQueryable struct {
 	err error
 }
 
-func (t errorTestQueryable) ExemplarQuerier(_ context.Context) (storage.ExemplarQuerier, error) {
+func (t errorTestQueryable) ExemplarQuerier(context.Context) (storage.ExemplarQuerier, error) {
 	return nil, t.err
 }
 
@@ -189,11 +189,11 @@ func (t errorTestQuerier) LabelNames(context.Context, *storage.LabelHints, ...*l
 	return nil, nil, t.err
 }
 
-func (t errorTestQuerier) Close() error {
+func (errorTestQuerier) Close() error {
 	return nil
 }
 
-func (t errorTestQuerier) Select(_ context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+func (t errorTestQuerier) Select(context.Context, bool, *storage.SelectHints, ...*labels.Matcher) storage.SeriesSet {
 	if t.s != nil {
 		return t.s
 	}
@@ -204,11 +204,11 @@ type errorTestSeriesSet struct {
 	err error
 }
 
-func (t errorTestSeriesSet) Next() bool {
+func (errorTestSeriesSet) Next() bool {
 	return false
 }
 
-func (t errorTestSeriesSet) At() storage.Series {
+func (errorTestSeriesSet) At() storage.Series {
 	return nil
 }
 
@@ -216,7 +216,7 @@ func (t errorTestSeriesSet) Err() error {
 	return t.err
 }
 
-func (t errorTestSeriesSet) Warnings() annotations.Annotations {
+func (errorTestSeriesSet) Warnings() annotations.Annotations {
 	return nil
 }
 

--- a/web/api/v1/json_codec.go
+++ b/web/api/v1/json_codec.go
@@ -38,15 +38,15 @@ func init() {
 // JSONCodec is a Codec that encodes API responses as JSON.
 type JSONCodec struct{}
 
-func (j JSONCodec) ContentType() MIMEType {
+func (JSONCodec) ContentType() MIMEType {
 	return MIMEType{Type: "application", SubType: "json"}
 }
 
-func (j JSONCodec) CanEncode(_ *Response) bool {
+func (JSONCodec) CanEncode(*Response) bool {
 	return true
 }
 
-func (j JSONCodec) Encode(resp *Response) ([]byte, error) {
+func (JSONCodec) Encode(resp *Response) ([]byte, error) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(resp)
 }

--- a/web/web.go
+++ b/web/web.go
@@ -347,10 +347,10 @@ func New(logger *slog.Logger, o *Options) *Handler {
 	}
 	h.SetReady(NotReady)
 
-	factorySPr := func(_ context.Context) api_v1.ScrapePoolsRetriever { return h.scrapeManager }
-	factoryTr := func(_ context.Context) api_v1.TargetRetriever { return h.scrapeManager }
-	factoryAr := func(_ context.Context) api_v1.AlertmanagerRetriever { return h.notifier }
-	FactoryRr := func(_ context.Context) api_v1.RulesRetriever { return h.ruleManager }
+	factorySPr := func(context.Context) api_v1.ScrapePoolsRetriever { return h.scrapeManager }
+	factoryTr := func(context.Context) api_v1.TargetRetriever { return h.scrapeManager }
+	factoryAr := func(context.Context) api_v1.AlertmanagerRetriever { return h.notifier }
+	FactoryRr := func(context.Context) api_v1.RulesRetriever { return h.ruleManager }
 
 	var app storage.Appendable
 	if o.EnableRemoteWriteReceiver || o.EnableOTLPWriteReceiver {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -60,7 +60,7 @@ func (a *dbAdapter) Stats(statsByLabelName string, limit int) (*tsdb.Stats, erro
 	return a.Head().Stats(statsByLabelName, limit), nil
 }
 
-func (a *dbAdapter) WALReplayStatus() (tsdb.WALReplayStatus, error) {
+func (*dbAdapter) WALReplayStatus() (tsdb.WALReplayStatus, error) {
 	return tsdb.WALReplayStatus{}, nil
 }
 


### PR DESCRIPTION
#### Description

Enable and fixes [unused-receiver](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unused-receiver) rule from revive

It also remove the names of the parameters of functions that dont use any their parameters