### PR TITLE
storage/remote.writeHandler.ServeHTTP: Return upon receiving bad message type

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -142,6 +142,7 @@ func (h *writeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}())
 		h.logger.Error("Error decoding remote write request", "err", err)
 		http.Error(w, err.Error(), http.StatusUnsupportedMediaType)
+		return
 	}
 
 	enc := r.Header.Get("Content-Encoding")


### PR DESCRIPTION
Modify `storage/remote.writeHandler.ServeHTTP` to return after responding with an error due to receiving an unrecognized protobuf message type.