### PR TITLE
[TESTS] PromQL: shrink work done in BenchmarkRangeQuery

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -247,7 +247,6 @@ func rangeQueryCases() []benchCase {
 			tmp = append(tmp, c)
 		} else {
 			tmp = append(tmp, benchCase{expr: strings.ReplaceAll(c.expr, "X", "one"), steps: c.steps})
-			tmp = append(tmp, benchCase{expr: strings.ReplaceAll(c.expr, "X", "ten"), steps: c.steps})
 			tmp = append(tmp, benchCase{expr: strings.ReplaceAll(c.expr, "X", "hundred"), steps: c.steps})
 		}
 	}
@@ -260,7 +259,6 @@ func rangeQueryCases() []benchCase {
 			tmp = append(tmp, c)
 		} else {
 			tmp = append(tmp, benchCase{expr: c.expr, steps: 1})
-			tmp = append(tmp, benchCase{expr: c.expr, steps: 100})
 			tmp = append(tmp, benchCase{expr: c.expr, steps: 1000})
 		}
 	}


### PR DESCRIPTION
Previously, `BenchmarkRangeQuery` would run each case with three data sizes (1, 10, 100) and three range lengths (1, 100, 1000) for nine variations.

With 36 cases, running with `-count=6` to get dependable results, would take 40-50 minutes in total.

This PR removes the middle option in both dimensions, thus shrinking to four variations and about 20 minutes to run everything.

For the typical case of looking for regressions across PromQL, I don't feel the middle option adds very much.
It might be useful to see how time grows at different stages for one particular case, but you can add that back into the code when you work; it shouldn't be forced on all users.