### PR TITLE
wal: ignore os.ErrNotExist errors in DirSize during WAL size calculation

### DIFF
--- a/tsdb/fileutil/dir.go
+++ b/tsdb/fileutil/dir.go
@@ -22,6 +22,10 @@ func DirSize(dir string) (int64, error) {
 	var size int64
 	err := filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
 		if err != nil {
+			// Ignore missing files that may have been deleted during the walk.
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return err
 		}
 		if !info.IsDir() {


### PR DESCRIPTION
This change updates `DirSize` to ignore `os.ErrNotExist` errors, since they are expected during normal WAL cleanup. All other errors continue to propagate.

Fixes: #17005

