### PR TITLE
[tsdb] Add CounterResetHint: CounterReset to first sample

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -782,6 +782,7 @@ func (a *headAppender) AppendHistogramCTZeroSample(ref storage.SeriesRef, lset l
 	switch {
 	case h != nil:
 		zeroHistogram := &histogram.Histogram{
+			// The CTZeroSample represents a counter reset by definition.
 			CounterResetHint: histogram.CounterReset,
 		}
 		s.Lock()
@@ -822,6 +823,7 @@ func (a *headAppender) AppendHistogramCTZeroSample(ref storage.SeriesRef, lset l
 		a.histogramSeries = append(a.histogramSeries, s)
 	case fh != nil:
 		zeroFloatHistogram := &histogram.FloatHistogram{
+			// The CTZeroSample represents a counter reset by definition.
 			CounterResetHint: histogram.CounterReset,
 		}
 		s.Lock()

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -781,7 +781,9 @@ func (a *headAppender) AppendHistogramCTZeroSample(ref storage.SeriesRef, lset l
 
 	switch {
 	case h != nil:
-		zeroHistogram := &histogram.Histogram{}
+		zeroHistogram := &histogram.Histogram{
+			CounterResetHint: histogram.CounterReset,
+		}
 		s.Lock()
 
 		// TODO(krajorama): reorganize Commit() to handle samples in append order
@@ -819,7 +821,9 @@ func (a *headAppender) AppendHistogramCTZeroSample(ref storage.SeriesRef, lset l
 		})
 		a.histogramSeries = append(a.histogramSeries, s)
 	case fh != nil:
-		zeroFloatHistogram := &histogram.FloatHistogram{}
+		zeroFloatHistogram := &histogram.FloatHistogram{
+			CounterResetHint: histogram.CounterReset,
+		}
 		s.Lock()
 
 		// TODO(krajorama): reorganize Commit() to handle samples in append order


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
- Fixes https://github.com/prometheus/prometheus/issues/16575
- Refers to https://github.com/prometheus/prometheus/pull/16696#pullrequestreview-2965222149\

**Note**
- The current test: 
```
func TestHeadAppender_AppendCT(t *testing.T) {
....
		{
			name: "CT equals to previous sample timestamp is ignored/floathistogram",
			appendableSamples: []appendableSamples{
				{ts: 100, fh: testFloatHistogram, ct: 1},
				{ts: 101, fh: testFloatHistogram, ct: 100},
			},
			expectedSamples: func() []chunks.Sample {
				fhNoCounterReset := *testFloatHistogram
				fhNoCounterReset.CounterResetHint = histogram.NotCounterReset
				return []chunks.Sample{
					sample{t: 1, fh: &histogram.FloatHistogram{}},
					sample{t: 100, fh: testFloatHistogram},
					sample{t: 101, fh: &fhNoCounterReset},
				}
			}(),
		},

```
is still passing, which is supposed to be failed because `sample{t: 1, fh: &histogram.FloatHistogram{}}` should be `sample{t: 1, fh: &histogram.FloatHistogram{CounterResetHint: CounterReset}}`, but there is no such error. I debug further and see that the error is not causing may be possible because of these line of code: https://github.com/prometheus/prometheus/blob/64808d4f56c4db7c493a0be8f5308c17b8e7495f/tsdb/chunkenc/histogram_meta.go#L471
which reset the CounterReset to UnknownCounterReset. Thus our changes does not have any impact. Please let me know If you do have any proposal for this. Thanks!


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```