### PR TITLE
Parralel test in ./rules directory

### DIFF
--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -1048,6 +1048,7 @@ func TestMetricsUpdate(t *testing.T) {
 }
 
 func TestGroupStalenessOnRemoval(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -1126,6 +1127,7 @@ func TestGroupStalenessOnRemoval(t *testing.T) {
 }
 
 func TestMetricsStalenessOnManagerShutdown(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -1195,6 +1197,7 @@ func countStaleNaN(t *testing.T, st storage.Storage) int {
 }
 
 func TestRuleMovedBetweenGroups(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -1338,6 +1341,7 @@ func TestRuleHealthUpdates(t *testing.T) {
 }
 
 func TestRuleGroupEvalIterationFunc(t *testing.T) {
+	t.Parallel()
 	storage := promqltest.LoadedStorage(t, `
 		load 5m
 		http_requests{instance="0"}	75  85 50 0 0 25 0 0 40 0 120
@@ -2272,6 +2276,7 @@ func TestAsyncRuleEvaluation(t *testing.T) {
 }
 
 func TestNewRuleGroupRestoration(t *testing.T) {
+	t.Parallel()
 	store := teststorage.New(t)
 	t.Cleanup(func() { store.Close() })
 	var (
@@ -2335,6 +2340,7 @@ func TestNewRuleGroupRestoration(t *testing.T) {
 }
 
 func TestNewRuleGroupRestorationWithRestoreNewGroupOption(t *testing.T) {
+	t.Parallel()
 	store := teststorage.New(t)
 	t.Cleanup(func() { store.Close() })
 	var (


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Related to https://github.com/prometheus/prometheus/issues/15185

On my machine:

Reducing exec time for github.com/prometheus/prometheus/rules by ~50%: ~60s -> ~30s

After adding t.Parralel(): 
```
➜  prometheus git:(Parralel_test) ✗ go test -race --count=1 ./rules
ok      github.com/prometheus/prometheus/rules  30.370s

```
on main branch

```
➜  prometheus git:(main) ✗ go test -race --count=1 ./rules
ok      github.com/prometheus/prometheus/rules  60.038s
```

This PR's CI log: 
`ok  	github.com/prometheus/prometheus/rules	28.442s
`

**Note**
I analyse the bottleneck of the test and just parrallel the test that take most time. If we parrallel everything, it’s not worth it and may cause aome overhead and a lot of code changing without much value. Also there are some tests that are not designed for running in paralell.