### PR TITLE
Parallel tsdb/wlog test

### DIFF
--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -113,6 +113,7 @@ func TestDeleteCheckpoints(t *testing.T) {
 }
 
 func TestCheckpoint(t *testing.T) {
+	t.Parallel()
 	makeHistogram := func(i int) *histogram.Histogram {
 		return &histogram.Histogram{
 			Count:         5 + uint64(i*4),

--- a/tsdb/wlog/reader_test.go
+++ b/tsdb/wlog/reader_test.go
@@ -314,6 +314,7 @@ func allSegments(dir string) (io.ReadCloser, error) {
 }
 
 func TestReaderFuzz(t *testing.T) {
+	t.Parallel()
 	for name, fn := range readerConstructors {
 		for _, compress := range compression.Types() {
 			t.Run(fmt.Sprintf("%s,compress=%s", name, compress), func(t *testing.T) {
@@ -353,6 +354,7 @@ func TestReaderFuzz(t *testing.T) {
 }
 
 func TestReaderFuzz_Live(t *testing.T) {
+	t.Parallel()
 	logger := promslog.NewNopLogger()
 	for _, compress := range compression.Types() {
 		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {

--- a/tsdb/wlog/watcher_test.go
+++ b/tsdb/wlog/watcher_test.go
@@ -443,6 +443,7 @@ func TestReadToEndWithCheckpoint(t *testing.T) {
 }
 
 func TestReadCheckpoint(t *testing.T) {
+	t.Parallel()
 	pageSize := 32 * 1024
 	const seriesCount = 10
 	const samplesCount = 250
@@ -677,6 +678,7 @@ func TestCheckpointSeriesReset(t *testing.T) {
 }
 
 func TestRun_StartupTime(t *testing.T) {
+	t.Parallel()
 	const pageSize = 32 * 1024
 	const segments = 10
 	const seriesCount = 20

--- a/tsdb/wlog/wlog_test.go
+++ b/tsdb/wlog/wlog_test.go
@@ -369,6 +369,7 @@ func TestSegmentMetric(t *testing.T) {
 }
 
 func TestCompression(t *testing.T) {
+	t.Parallel()
 	bootstrap := func(compressed compression.Type) string {
 		const (
 			segmentSize = pageSize


### PR DESCRIPTION
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Related to https://github.com/prometheus/prometheus/issues/15185

On my machine:

Reducing exec time for github.com/prometheus/prometheus/tsdb/wlog by ~25%: ~40s -> ~30s

After adding t.Parralel(): 
```
➜  prometheus git:(parallelize_tsdb/wlog) ✗ go test -race --count=1 ./tsdb/wlog
ok      github.com/prometheus/prometheus/tsdb/wlog      31.539s
```
on main branch

```
➜  prometheus git:(main) ✗ go test -race --count=1 ./tsdb/wlog
ok      github.com/prometheus/prometheus/tsdb/wlog      39.169s
```

This PR's CI log: 
`
ok  	github.com/prometheus/prometheus/tsdb/wlog	26.341s
`

Note
I analyse the bottleneck of the test and just parrallel the test that take most time. If we parrallel everything, it’s not worth it and may cause aome overhead and a lot of code changing without much value. Also there are some tests that are not designed for running in paralell.