### PR TITLE
fix(otlp): benchmark assert makes no sense

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -996,8 +996,13 @@ func BenchmarkPrometheusConverter_FromMetrics(b *testing.B) {
 												annots, err := converter.FromMetrics(context.Background(), payload.Metrics(), settings)
 												require.NoError(b, err)
 												require.Empty(b, annots)
-												require.NotNil(b, converter.TimeSeries())
-												require.NotNil(b, converter.Metadata())
+												if histogramCount+nonHistogramCount > 0 {
+													require.NotEmpty(b, converter.TimeSeries())
+													require.NotEmpty(b, converter.Metadata())
+												} else {
+													require.Empty(b, converter.TimeSeries())
+													require.Empty(b, converter.Metadata())
+												}
 											}
 										})
 									}


### PR DESCRIPTION
convert.Timeseries() and converter.Metadata() is never nil, because they are always initialized. It's better to assert on whether they are empty or not.
