### PR TITLE
fix(ci): run linter with all build tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,9 @@ jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build-tag: [stringlabels, slicelabels, dedupelabels]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -226,22 +229,10 @@ jobs:
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'
-      - name: Lint with stringlabels
+      - name: Lint with ${{ matrix.build-tag }}
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          args: --verbose --build-tags=stringlabels
-          # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
-          version: v2.2.1
-      - name: Lint with slicelabels
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          args: --verbose --build-tags=slicelabels
-          # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
-          version: v2.2.1
-      - name: Lint with dedupelabels
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          args: --verbose --build-tags=dedupelabels
+          args: --verbose --build-tags=${{ matrix.build-tag }}
           # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
           version: v2.2.1
   fuzzing:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,10 +226,22 @@ jobs:
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'
-      - name: Lint
+      - name: Lint with stringlabels
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          args: --verbose
+          args: --verbose --build-tags=stringlabels
+          # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
+          version: v2.2.1
+      - name: Lint with slicelabels
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          args: --verbose --build-tags=slicelabels
+          # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
+          version: v2.2.1
+      - name: Lint with dedupelabels
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          args: --verbose --build-tags=dedupelabels
           # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
           version: v2.2.1
   fuzzing:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,9 +214,6 @@ jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        build-tag: [stringlabels, slicelabels, dedupelabels]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -229,10 +226,22 @@ jobs:
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'
-      - name: Lint with ${{ matrix.build-tag }}
+      - name: Lint with stringlabels
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          args: --verbose --build-tags=${{ matrix.build-tag }}
+          args: --verbose --build-tags=stringlabels
+          # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
+          version: v2.2.1
+      - name: Lint with slicelabels
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          args: --verbose --build-tags=slicelabels
+          # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
+          version: v2.2.1
+      - name: Lint with dedupelabels
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          args: --verbose --build-tags=dedupelabels
           # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
           version: v2.2.1
   fuzzing:

--- a/model/labels/labels_slicelabels.go
+++ b/model/labels/labels_slicelabels.go
@@ -252,7 +252,7 @@ func (ls Labels) WithoutEmpty() Labels {
 // the two string headers size for name and value.
 // Slice header size is ignored because it should be amortized to zero.
 func (ls Labels) ByteSize() uint64 {
-	var size uint64 = 0
+	var size uint64
 	for _, l := range ls {
 		size += uint64(len(l.Name)+len(l.Value)) + 2*uint64(unsafe.Sizeof(""))
 	}
@@ -445,7 +445,7 @@ type SymbolTable struct{}
 
 func NewSymbolTable() *SymbolTable { return nil }
 
-func (t *SymbolTable) Len() int { return 0 }
+func (*SymbolTable) Len() int { return 0 }
 
 // NewScratchBuilder creates a ScratchBuilder initialized for Labels with n entries.
 func NewScratchBuilder(n int) ScratchBuilder {
@@ -462,7 +462,7 @@ func NewScratchBuilderWithSymbolTable(_ *SymbolTable, n int) ScratchBuilder {
 	return NewScratchBuilder(n)
 }
 
-func (b *ScratchBuilder) SetSymbolTable(*SymbolTable) {
+func (*ScratchBuilder) SetSymbolTable(*SymbolTable) {
 	// no-op
 }
 


### PR DESCRIPTION
Downstream project uses different default `model/labels` implementation  by build tag. Our CI fails due to linter errors.
Fix by checking all versions.

I wanted to use matrix strategy for parallel run, but then I reverted that because branch protection rules would need to change and I don't want to tackle that now. See revert commit. Without the change to the branch protection, CI will get stuck forever waiting for "golangci-lint" job to finish, but there would be 3 different "golangci-lint (stringlabels)", etc jobs. UPDATE: see https://github.com/prometheus/prometheus/pull/17027#issuecomment-3167237884