### PR TITLE
storage-prw: send Unit and Type when feature flag is enabled

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -782,7 +782,8 @@ func main() {
 	var (
 		localStorage  = &readyStorage{stats: tsdb.NewDBStats()}
 		scraper       = &readyScrapeManager{}
-		remoteStorage = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper)
+		enableTypeAndUnitLabels = cfg.scrape.EnableTypeAndUnitLabels
+		remoteStorage = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, enableTypeAndUnitLabels)
 		fanoutStorage = storage.NewFanout(logger, localStorage, remoteStorage)
 	)
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -780,11 +780,10 @@ func main() {
 	)
 
 	var (
-		localStorage            = &readyStorage{stats: tsdb.NewDBStats()}
-		scraper                 = &readyScrapeManager{}
-		enableTypeAndUnitLabels = cfg.scrape.EnableTypeAndUnitLabels
-		remoteStorage           = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, enableTypeAndUnitLabels)
-		fanoutStorage           = storage.NewFanout(logger, localStorage, remoteStorage)
+		localStorage  = &readyStorage{stats: tsdb.NewDBStats()}
+		scraper       = &readyScrapeManager{}
+		remoteStorage = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, cfg.scrape.EnableTypeAndUnitLabels)
+		fanoutStorage = storage.NewFanout(logger, localStorage, remoteStorage)
 	)
 
 	var (

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -780,11 +780,11 @@ func main() {
 	)
 
 	var (
-		localStorage  = &readyStorage{stats: tsdb.NewDBStats()}
-		scraper       = &readyScrapeManager{}
+		localStorage            = &readyStorage{stats: tsdb.NewDBStats()}
+		scraper                 = &readyScrapeManager{}
 		enableTypeAndUnitLabels = cfg.scrape.EnableTypeAndUnitLabels
-		remoteStorage = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, enableTypeAndUnitLabels)
-		fanoutStorage = storage.NewFanout(logger, localStorage, remoteStorage)
+		remoteStorage           = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, enableTypeAndUnitLabels)
+		fanoutStorage           = storage.NewFanout(logger, localStorage, remoteStorage)
 	)
 
 	var (

--- a/config/config.go
+++ b/config/config.go
@@ -1374,9 +1374,7 @@ type RemoteWriteConfig struct {
 	Name                 string            `yaml:"name,omitempty"`
 	SendExemplars        bool              `yaml:"send_exemplars,omitempty"`
 	SendNativeHistograms bool              `yaml:"send_native_histograms,omitempty"`
-	// EnableTypeAndUnitLabels is a feature flag to enable the type-and-unit-labels feature.
-	EnableTypeAndUnitLabels bool `yaml:"enable_type_and_unit_labels,omitempty"`
-	RoundRobinDNS           bool `yaml:"round_robin_dns,omitempty"`
+	RoundRobinDNS        bool              `yaml:"round_robin_dns,omitempty"`
 	// ProtobufMessage specifies the protobuf message to use against the remote
 	// receiver as specified in https://prometheus.io/docs/specs/remote_write_spec_2_0/
 	ProtobufMessage RemoteWriteProtoMsg `yaml:"protobuf_message,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -1374,7 +1374,9 @@ type RemoteWriteConfig struct {
 	Name                 string            `yaml:"name,omitempty"`
 	SendExemplars        bool              `yaml:"send_exemplars,omitempty"`
 	SendNativeHistograms bool              `yaml:"send_native_histograms,omitempty"`
-	RoundRobinDNS        bool              `yaml:"round_robin_dns,omitempty"`
+	// EnableTypeAndUnitLabels is a feature flag to enable the type-and-unit-labels feature.
+	EnableTypeAndUnitLabels bool `yaml:"enable_type_and_unit_labels,omitempty"`
+	RoundRobinDNS           bool `yaml:"round_robin_dns,omitempty"`
 	// ProtobufMessage specifies the protobuf message to use against the remote
 	// receiver as specified in https://prometheus.io/docs/specs/remote_write_spec_2_0/
 	ProtobufMessage RemoteWriteProtoMsg `yaml:"protobuf_message,omitempty"`

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -40,6 +40,7 @@ import (
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/prompb"
 	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
+	"github.com/prometheus/prometheus/schema"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
@@ -1927,11 +1928,9 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 			metricType := writev2.Metadata_METRIC_TYPE_UNSPECIFIED
 			var unit string
 			if enableTypeAndUnitLabels {
-				typeValue := d.seriesLabels.Get("__type__")
-				unit = d.seriesLabels.Get("__unit__")
-				if typeValue != "" {
-					metricType = modelTypeToWriteV2Type(typeValue)
-				}
+				metadata := schema.NewMetadataFromLabels(d.seriesLabels)
+				metricType = modelTypeToWriteV2Type(string(metadata.Type))
+				unit = metadata.Unit
 			}
 			// Safeguard against sending garbage in case of not having metadata
 			// for whatever reason.

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1946,7 +1946,6 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 				default:
 					metricType = writev2.Metadata_METRIC_TYPE_UNSPECIFIED
 				}
-
 			}
 			// Safeguard against sending garbage in case of not having metadata
 			// for whatever reason.

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1925,18 +1925,15 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 			pendingData[nPending].Metadata.UnitRef = symbolTable.Symbolize(d.metadata.Unit)
 			nPendingMetadata++
 		} else {
-			metricType := writev2.Metadata_METRIC_TYPE_UNSPECIFIED
-			var unit string
+			var m schema.Metadata
 			if enableTypeAndUnitLabels {
-				metadata := schema.NewMetadataFromLabels(d.seriesLabels)
-				metricType = modelTypeToWriteV2Type(string(metadata.Type))
-				unit = metadata.Unit
+				m = schema.NewMetadataFromLabels(d.seriesLabels)
 			}
 			// Safeguard against sending garbage in case of not having metadata
 			// for whatever reason.
-			pendingData[nPending].Metadata.Type = metricType
+			pendingData[nPending].Metadata.Type = writev2.FromMetadataType(m.Type)
+			pendingData[nPending].Metadata.UnitRef = symbolTable.Symbolize(m.Unit)
 			pendingData[nPending].Metadata.HelpRef = 0
-			pendingData[nPending].Metadata.UnitRef = symbolTable.Symbolize(unit)
 		}
 
 		if sendExemplars {

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1929,24 +1929,8 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 			if enableTypeAndUnitLabels {
 				typeValue := d.seriesLabels.Get("__type__")
 				unit = d.seriesLabels.Get("__unit__")
-				if typeValue != "" || unit != "" {
-					// convert string type to MetricMetadata_MetricType
-					switch typeValue {
-					case "counter":
-						metricType = writev2.Metadata_METRIC_TYPE_COUNTER
-					case "gauge":
-						metricType = writev2.Metadata_METRIC_TYPE_GAUGE
-					case "histogram":
-						metricType = writev2.Metadata_METRIC_TYPE_HISTOGRAM
-					case "summary":
-						metricType = writev2.Metadata_METRIC_TYPE_SUMMARY
-					case "info":
-						metricType = writev2.Metadata_METRIC_TYPE_INFO
-					case "stateset":
-						metricType = writev2.Metadata_METRIC_TYPE_STATESET
-					default:
-						metricType = writev2.Metadata_METRIC_TYPE_UNSPECIFIED
-					}
+				if typeValue != "" {
+					metricType = modelTypeToWriteV2Type(typeValue)
 				}
 			}
 			// Safeguard against sending garbage in case of not having metadata
@@ -1993,6 +1977,25 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 		}
 	}
 	return nPendingSamples, nPendingExemplars, nPendingHistograms, nPendingMetadata
+}
+
+func modelTypeToWriteV2Type(typeValue string) writev2.Metadata_MetricType {
+	switch typeValue {
+	case string(model.MetricTypeCounter):
+		return writev2.Metadata_METRIC_TYPE_COUNTER
+	case string(model.MetricTypeGauge):
+		return writev2.Metadata_METRIC_TYPE_GAUGE
+	case string(model.MetricTypeHistogram):
+		return writev2.Metadata_METRIC_TYPE_HISTOGRAM
+	case string(model.MetricTypeSummary):
+		return writev2.Metadata_METRIC_TYPE_SUMMARY
+	case string(model.MetricTypeInfo):
+		return writev2.Metadata_METRIC_TYPE_INFO
+	case string(model.MetricTypeStateset):
+		return writev2.Metadata_METRIC_TYPE_STATESET
+	default:
+		return writev2.Metadata_METRIC_TYPE_UNSPECIFIED
+	}
 }
 
 func (t *QueueManager) sendWriteRequestWithBackoff(ctx context.Context, attempt func(int) error, onRetry func()) error {

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1975,25 +1975,6 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 	return nPendingSamples, nPendingExemplars, nPendingHistograms, nPendingMetadata
 }
 
-func modelTypeToWriteV2Type(typeValue string) writev2.Metadata_MetricType {
-	switch typeValue {
-	case string(model.MetricTypeCounter):
-		return writev2.Metadata_METRIC_TYPE_COUNTER
-	case string(model.MetricTypeGauge):
-		return writev2.Metadata_METRIC_TYPE_GAUGE
-	case string(model.MetricTypeHistogram):
-		return writev2.Metadata_METRIC_TYPE_HISTOGRAM
-	case string(model.MetricTypeSummary):
-		return writev2.Metadata_METRIC_TYPE_SUMMARY
-	case string(model.MetricTypeInfo):
-		return writev2.Metadata_METRIC_TYPE_INFO
-	case string(model.MetricTypeStateset):
-		return writev2.Metadata_METRIC_TYPE_STATESET
-	default:
-		return writev2.Metadata_METRIC_TYPE_UNSPECIFIED
-	}
-}
-
 func (t *QueueManager) sendWriteRequestWithBackoff(ctx context.Context, attempt func(int) error, onRetry func()) error {
 	backoff := t.cfg.MinBackoff
 	sleepDuration := model.Duration(0)

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1924,11 +1924,9 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 			pendingData[nPending].Metadata.UnitRef = symbolTable.Symbolize(d.metadata.Unit)
 			nPendingMetadata++
 		} else {
-			fmt.Println("enableTypeAndUnitLabels", enableTypeAndUnitLabels)
 			metricType := writev2.Metadata_METRIC_TYPE_UNSPECIFIED
 			var unit string
 			if enableTypeAndUnitLabels {
-				fmt.Println("DEBUG enableTypeAndUnitLabels")
 				typeValue := d.seriesLabels.Get("__type__")
 				unit = d.seriesLabels.Get("__unit__")
 

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1914,7 +1914,7 @@ func (s *shards) sendV2SamplesWithBackoff(ctx context.Context, samples []writev2
 	return accumulatedStats, err
 }
 
-func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries, pendingData []writev2.TimeSeries, sendExemplars, sendNativeHistograms bool, enableTypeAndUnitLabels bool) (int, int, int, int) {
+func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries, pendingData []writev2.TimeSeries, sendExemplars, sendNativeHistograms, enableTypeAndUnitLabels bool) (int, int, int, int) {
 	var nPendingSamples, nPendingExemplars, nPendingHistograms, nPendingMetadata int
 	for nPending, d := range batch {
 		pendingData[nPending].Samples = pendingData[nPending].Samples[:0]

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1915,7 +1915,7 @@ func (s *shards) sendV2SamplesWithBackoff(ctx context.Context, samples []writev2
 	return accumulatedStats, err
 }
 
-func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries, pendingData []writev2.TimeSeries, sendExemplars, sendNativeHistograms bool, enableTypeAndUnitLabels bool) (int, int, int, int, int) {
+func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries, pendingData []writev2.TimeSeries, sendExemplars, sendNativeHistograms, enableTypeAndUnitLabels bool) (int, int, int, int, int) {
 	var nPendingSamples, nPendingExemplars, nPendingHistograms, nPendingMetadata, nUnexpectedMetadata int
 	for nPending, d := range batch {
 		pendingData[nPending].Samples = pendingData[nPending].Samples[:0]

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1929,25 +1929,22 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 			if enableTypeAndUnitLabels {
 				typeValue := d.seriesLabels.Get("__type__")
 				unit = d.seriesLabels.Get("__unit__")
-
-				if typeValue != "" || unit != "" {
-					// convert string type to MetricMetadata_MetricType
-					switch typeValue {
-					case "counter":
-						metricType = writev2.Metadata_METRIC_TYPE_COUNTER
-					case "gauge":
-						metricType = writev2.Metadata_METRIC_TYPE_GAUGE
-					case "histogram":
-						metricType = writev2.Metadata_METRIC_TYPE_HISTOGRAM
-					case "summary":
-						metricType = writev2.Metadata_METRIC_TYPE_SUMMARY
-					case "info":
-						metricType = writev2.Metadata_METRIC_TYPE_INFO
-					case "stateset":
-						metricType = writev2.Metadata_METRIC_TYPE_STATESET
-					default:
-						metricType = writev2.Metadata_METRIC_TYPE_UNSPECIFIED
-					}
+				// convert string type to MetricMetadata_MetricType
+				switch typeValue {
+				case "counter":
+					metricType = writev2.Metadata_METRIC_TYPE_COUNTER
+				case "gauge":
+					metricType = writev2.Metadata_METRIC_TYPE_GAUGE
+				case "histogram":
+					metricType = writev2.Metadata_METRIC_TYPE_HISTOGRAM
+				case "summary":
+					metricType = writev2.Metadata_METRIC_TYPE_SUMMARY
+				case "info":
+					metricType = writev2.Metadata_METRIC_TYPE_INFO
+				case "stateset":
+					metricType = writev2.Metadata_METRIC_TYPE_STATESET
+				default:
+					metricType = writev2.Metadata_METRIC_TYPE_UNSPECIFIED
 				}
 
 			}

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2354,7 +2354,7 @@ func TestPopulateV2TimeSeries_UnexpectedMetadata(t *testing.T) {
 	require.Equal(t, 2, nUnexpected, "Should count 2 unexpected metadata")
 }
 
-func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
+func TestPopulateV2TimeSeries_TypeAndUnitLabels(t *testing.T) {
 	symbolTable := writev2.NewSymbolTable()
 
 	testCases := []struct {

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -322,7 +322,7 @@ func newTestClientAndQueueManager(t testing.TB, flushDeadline time.Duration, pro
 func newTestQueueManager(t testing.TB, cfg config.QueueConfig, mcfg config.MetadataConfig, deadline time.Duration, c WriteClient, protoMsg config.RemoteWriteProtoMsg) *QueueManager {
 	dir := t.TempDir()
 	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, protoMsg)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, protoMsg)
 
 	return m
 }
@@ -782,7 +782,7 @@ func TestDisableReshardOnRetry(t *testing.T) {
 		}
 	)
 
-	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
+	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, false, config.RemoteWriteProtoMsgV1)
 	m.StoreSeries(fakeSeries, 0)
 
 	// Attempt to samples while the manager is running. We immediately stop the
@@ -1459,7 +1459,7 @@ func BenchmarkStoreSeries(b *testing.B) {
 				cfg := config.DefaultQueueConfig
 				mcfg := config.DefaultMetadataConfig
 				metrics := newQueueManagerMetrics(nil, "", "")
-				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, config.RemoteWriteProtoMsgV1)
+				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, config.RemoteWriteProtoMsgV1)
 				m.externalLabels = tc.externalLabels
 				m.relabelConfigs = tc.relabelConfigs
 
@@ -1938,7 +1938,7 @@ func BenchmarkBuildV2WriteRequest(b *testing.B) {
 
 		totalSize := 0
 		for i := 0; i < b.N; i++ {
-			populateV2TimeSeries(&symbolTable, batch, seriesBuff, true, true)
+			populateV2TimeSeries(&symbolTable, batch, seriesBuff, true, true, false)
 			req, _, _, err := buildV2WriteRequest(noopLogger, seriesBuff, symbolTable.Symbols(), &pBuf, nil, cEnc, "snappy")
 			if err != nil {
 				b.Fatal(err)
@@ -2329,5 +2329,168 @@ func BenchmarkBuildTimeSeries(b *testing.B) {
 		samples := createProtoTimeseriesWithOld(numSamples, 100, extraLabels...)
 		_, _, result, _, _, _ := buildTimeSeries(samples, filter)
 		require.NotNil(b, result)
+	}
+}
+
+// TestPopulateV2TimeSeries_enableTypeAndUnitLabels tests that the populateV2TimeSeries function correctly populates the type and unit labels when the feature flag is enabled.
+// func TestPopulateV2TimeSeries_enableTypeAndUnitLabels(t *testing.T) {
+// 	noopLogger := promslog.NewNopLogger()
+// 	symbolTable := writev2.NewSymbolTable()
+// 	pendingData := make([]writev2.TimeSeries, 100)
+// 	batch := make([]timeSeries, 100)
+// 	for i := 0; i < 100; i++ {
+// 		batch[i] = timeSeries{
+// 			seriesLabels: labels.NewScratchBuilder(1).Add("__name__", "test_metric").Add("__type__", "counter").Add("__unit__", "1").Labels(),
+// 		}
+// 	}
+// }
+
+// TestPopulateV2TimeSeries_typeAndUnitLabels tests that the populateV2TimeSeries function correctly populates the type and unit labels.
+func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
+	symbolTable := writev2.NewSymbolTable()
+
+	testCases := []struct {
+		name                    string
+		typeLabel               string
+		unitLabel               string
+		expectedType            writev2.Metadata_MetricType
+		description             string
+		enableTypeAndUnitLabels bool
+	}{
+		{
+			name:                    "counter_with_unit",
+			typeLabel:               "counter",
+			unitLabel:               "operations",
+			expectedType:            writev2.Metadata_METRIC_TYPE_COUNTER,
+			description:             "Counter metric with operations unit",
+			enableTypeAndUnitLabels: true,
+		},
+		{
+			name:                    "gauge_with_bytes",
+			typeLabel:               "gauge",
+			unitLabel:               "bytes",
+			expectedType:            writev2.Metadata_METRIC_TYPE_GAUGE,
+			description:             "Gauge metric with bytes unit",
+			enableTypeAndUnitLabels: true,
+		},
+		{
+			name:                    "histogram_with_seconds",
+			typeLabel:               "histogram",
+			unitLabel:               "seconds",
+			expectedType:            writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+			description:             "Histogram metric with seconds unit",
+			enableTypeAndUnitLabels: true,
+		},
+		{
+			name:                    "summary_with_ratio",
+			typeLabel:               "summary",
+			unitLabel:               "ratio",
+			expectedType:            writev2.Metadata_METRIC_TYPE_SUMMARY,
+			description:             "Summary metric with ratio unit",
+			enableTypeAndUnitLabels: true,
+		},
+		{
+			name:                    "info_no_unit",
+			typeLabel:               "info",
+			unitLabel:               "",
+			expectedType:            writev2.Metadata_METRIC_TYPE_INFO,
+			description:             "Info metric without unit",
+			enableTypeAndUnitLabels: true,
+		},
+		{
+			name:                    "stateset_no_unit",
+			typeLabel:               "stateset",
+			unitLabel:               "",
+			expectedType:            writev2.Metadata_METRIC_TYPE_STATESET,
+			description:             "Stateset metric without unit",
+			enableTypeAndUnitLabels: true,
+		},
+		{
+			name:                    "unknown_type",
+			typeLabel:               "unknown_type",
+			unitLabel:               "meters",
+			expectedType:            writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
+			description:             "Unknown type defaults to unspecified",
+			enableTypeAndUnitLabels: true,
+		},
+		{
+			name:                    "empty_type_with_unit",
+			typeLabel:               "",
+			unitLabel:               "watts",
+			expectedType:            writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
+			description:             "Empty type with unit",
+			enableTypeAndUnitLabels: true,
+		},
+		{
+			name:                    "type_no_unit",
+			typeLabel:               "gauge",
+			unitLabel:               "",
+			expectedType:            writev2.Metadata_METRIC_TYPE_GAUGE,
+			description:             "Type without unit",
+			enableTypeAndUnitLabels: true,
+		},
+		{
+			name:                    "no_type_no_unit",
+			typeLabel:               "",
+			unitLabel:               "",
+			expectedType:            writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
+			description:             "No type and no unit",
+			enableTypeAndUnitLabels: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			batch := make([]timeSeries, 1)
+			builder := labels.NewScratchBuilder(4)
+			builder.Add("__name__", "test_metric_"+tc.name)
+
+			if tc.typeLabel != "" {
+				builder.Add("__type__", tc.typeLabel)
+			}
+			if tc.unitLabel != "" {
+				builder.Add("__unit__", tc.unitLabel)
+			}
+
+			builder.Add("job", "test_job")
+			builder.Add("instance", "localhost:9090")
+
+			batch[0] = timeSeries{
+				seriesLabels: builder.Labels(),
+				value:        123.45,
+				timestamp:    time.Now().UnixMilli(),
+				sType:        tSample,
+				metadata:     nil, // Setting metadata to nil to force use of labels
+			}
+
+			pendingData := make([]writev2.TimeSeries, 1)
+
+			// Test with feature flag enabled.
+			// TODO(@perebaj): Remove this once the feature flag is removed.
+			if tc.enableTypeAndUnitLabels {
+				symbolTable.Reset()
+				nSamples, nExemplars, nHistograms, _ := populateV2TimeSeries(
+					&symbolTable,
+					batch,
+					pendingData,
+					false, // sendExemplars
+					false, // sendNativeHistograms
+					true,  // enableTypeAndUnitLabels
+				)
+
+				require.Equal(t, 1, nSamples, "Should have 1 sample")
+				require.Equal(t, 0, nExemplars, "Should have 0 exemplars")
+				require.Equal(t, 0, nHistograms, "Should have 0 histograms")
+
+				require.Equal(t, tc.expectedType, pendingData[0].Metadata.Type,
+					"Type should match expected for %s", tc.description)
+
+				unitRef := pendingData[0].Metadata.UnitRef
+
+				symbols := symbolTable.Symbols()
+				require.True(t, unitRef < uint32(len(symbols)), "Unit ref should be valid")
+				require.Equal(t, tc.unitLabel, symbols[unitRef], "Unit should match")
+			}
+		})
 	}
 }

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2333,6 +2333,27 @@ func BenchmarkBuildTimeSeries(b *testing.B) {
 	}
 }
 
+func TestPopulateV2TimeSeries_UnexpectedMetadata(t *testing.T) {
+	symbolTable := writev2.NewSymbolTable()
+	pendingData := make([]writev2.TimeSeries, 4)
+
+	batch := []timeSeries{
+		{sType: tSample, seriesLabels: labels.FromStrings("__name__", "metric1")},
+		{sType: tMetadata, seriesLabels: labels.FromStrings("__name__", "metric2")},
+		{sType: tSample, seriesLabels: labels.FromStrings("__name__", "metric3")},
+		{sType: tMetadata, seriesLabels: labels.FromStrings("__name__", "metric4")},
+	}
+
+	nSamples, nExemplars, nHistograms, nMetadata, nUnexpected := populateV2TimeSeries(
+		&symbolTable, batch, pendingData, false, false, false)
+
+	require.Equal(t, 2, nSamples, "Should count 2 samples")
+	require.Equal(t, 0, nExemplars, "Should count 0 exemplars")
+	require.Equal(t, 0, nHistograms, "Should count 0 histograms")
+	require.Equal(t, 0, nMetadata, "Should count 0 processed metadata")
+	require.Equal(t, 2, nUnexpected, "Should count 2 unexpected metadata")
+}
+
 func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
 	symbolTable := writev2.NewSymbolTable()
 

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2332,7 +2332,6 @@ func BenchmarkBuildTimeSeries(b *testing.B) {
 	}
 }
 
-// TestPopulateV2TimeSeries_typeAndUnitLabels tests that the populateV2TimeSeries function correctly populates the type and unit labels.
 func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
 	symbolTable := writev2.NewSymbolTable()
 

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2432,7 +2432,6 @@ func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
 				value:        123.45,
 				timestamp:    time.Now().UnixMilli(),
 				sType:        tSample,
-				metadata:     nil, // Setting metadata to nil to force use of labels
 			}
 
 			pendingData := make([]writev2.TimeSeries, 1)

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2332,19 +2332,6 @@ func BenchmarkBuildTimeSeries(b *testing.B) {
 	}
 }
 
-// TestPopulateV2TimeSeries_enableTypeAndUnitLabels tests that the populateV2TimeSeries function correctly populates the type and unit labels when the feature flag is enabled.
-// func TestPopulateV2TimeSeries_enableTypeAndUnitLabels(t *testing.T) {
-// 	noopLogger := promslog.NewNopLogger()
-// 	symbolTable := writev2.NewSymbolTable()
-// 	pendingData := make([]writev2.TimeSeries, 100)
-// 	batch := make([]timeSeries, 100)
-// 	for i := 0; i < 100; i++ {
-// 		batch[i] = timeSeries{
-// 			seriesLabels: labels.NewScratchBuilder(1).Add("__name__", "test_metric").Add("__type__", "counter").Add("__unit__", "1").Labels(),
-// 		}
-// 	}
-// }
-
 // TestPopulateV2TimeSeries_typeAndUnitLabels tests that the populateV2TimeSeries function correctly populates the type and unit labels.
 func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
 	symbolTable := writev2.NewSymbolTable()

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2336,92 +2336,81 @@ func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
 	symbolTable := writev2.NewSymbolTable()
 
 	testCases := []struct {
-		name                    string
-		typeLabel               string
-		unitLabel               string
-		expectedType            writev2.Metadata_MetricType
-		description             string
-		enableTypeAndUnitLabels bool
+		name         string
+		typeLabel    string
+		unitLabel    string
+		expectedType writev2.Metadata_MetricType
+		description  string
 	}{
 		{
-			name:                    "counter_with_unit",
-			typeLabel:               "counter",
-			unitLabel:               "operations",
-			expectedType:            writev2.Metadata_METRIC_TYPE_COUNTER,
-			description:             "Counter metric with operations unit",
-			enableTypeAndUnitLabels: true,
+			name:         "counter_with_unit",
+			typeLabel:    "counter",
+			unitLabel:    "operations",
+			expectedType: writev2.Metadata_METRIC_TYPE_COUNTER,
+			description:  "Counter metric with operations unit",
 		},
 		{
-			name:                    "gauge_with_bytes",
-			typeLabel:               "gauge",
-			unitLabel:               "bytes",
-			expectedType:            writev2.Metadata_METRIC_TYPE_GAUGE,
-			description:             "Gauge metric with bytes unit",
-			enableTypeAndUnitLabels: true,
+			name:         "gauge_with_bytes",
+			typeLabel:    "gauge",
+			unitLabel:    "bytes",
+			expectedType: writev2.Metadata_METRIC_TYPE_GAUGE,
+			description:  "Gauge metric with bytes unit",
 		},
 		{
-			name:                    "histogram_with_seconds",
-			typeLabel:               "histogram",
-			unitLabel:               "seconds",
-			expectedType:            writev2.Metadata_METRIC_TYPE_HISTOGRAM,
-			description:             "Histogram metric with seconds unit",
-			enableTypeAndUnitLabels: true,
+			name:         "histogram_with_seconds",
+			typeLabel:    "histogram",
+			unitLabel:    "seconds",
+			expectedType: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+			description:  "Histogram metric with seconds unit",
 		},
 		{
-			name:                    "summary_with_ratio",
-			typeLabel:               "summary",
-			unitLabel:               "ratio",
-			expectedType:            writev2.Metadata_METRIC_TYPE_SUMMARY,
-			description:             "Summary metric with ratio unit",
-			enableTypeAndUnitLabels: true,
+			name:         "summary_with_ratio",
+			typeLabel:    "summary",
+			unitLabel:    "ratio",
+			expectedType: writev2.Metadata_METRIC_TYPE_SUMMARY,
+			description:  "Summary metric with ratio unit",
 		},
 		{
-			name:                    "info_no_unit",
-			typeLabel:               "info",
-			unitLabel:               "",
-			expectedType:            writev2.Metadata_METRIC_TYPE_INFO,
-			description:             "Info metric without unit",
-			enableTypeAndUnitLabels: true,
+			name:         "info_no_unit",
+			typeLabel:    "info",
+			unitLabel:    "",
+			expectedType: writev2.Metadata_METRIC_TYPE_INFO,
+			description:  "Info metric without unit",
 		},
 		{
-			name:                    "stateset_no_unit",
-			typeLabel:               "stateset",
-			unitLabel:               "",
-			expectedType:            writev2.Metadata_METRIC_TYPE_STATESET,
-			description:             "Stateset metric without unit",
-			enableTypeAndUnitLabels: true,
+			name:         "stateset_no_unit",
+			typeLabel:    "stateset",
+			unitLabel:    "",
+			expectedType: writev2.Metadata_METRIC_TYPE_STATESET,
+			description:  "Stateset metric without unit",
 		},
 		{
-			name:                    "unknown_type",
-			typeLabel:               "unknown_type",
-			unitLabel:               "meters",
-			expectedType:            writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
-			description:             "Unknown type defaults to unspecified",
-			enableTypeAndUnitLabels: true,
+			name:         "unknown_type",
+			typeLabel:    "unknown_type",
+			unitLabel:    "meters",
+			expectedType: writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
+			description:  "Unknown type defaults to unspecified",
 		},
 		{
-			name:                    "empty_type_with_unit",
-			typeLabel:               "",
-			unitLabel:               "watts",
-			expectedType:            writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
-			description:             "Empty type with unit",
-			enableTypeAndUnitLabels: true,
+			name:         "empty_type_with_unit",
+			typeLabel:    "",
+			unitLabel:    "watts",
+			expectedType: writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
+			description:  "Empty type with unit",
 		},
 		{
-			name:                    "type_no_unit",
-			typeLabel:               "gauge",
-			unitLabel:               "",
-			expectedType:            writev2.Metadata_METRIC_TYPE_GAUGE,
-			description:             "Type without unit",
-			enableTypeAndUnitLabels: true,
+			name:         "type_no_unit",
+			typeLabel:    "gauge",
+			unitLabel:    "",
+			expectedType: writev2.Metadata_METRIC_TYPE_GAUGE,
+			description:  "Type without unit",
 		},
 		{
-			name:                    "no_type_no_unit",
-			typeLabel:               "",
-			unitLabel:               "",
-			expectedType:            writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
-			description:             "No type and no unit",
-			enableTypeAndUnitLabels: true,
+			name:         "no_type_no_unit",
+			typeLabel:    "",
+			unitLabel:    "",
+			expectedType: writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
+			description:  "No type and no unit",
 		},
 	}
 
@@ -2448,31 +2437,27 @@ func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
 
 			pendingData := make([]writev2.TimeSeries, 1)
 
-			// Test with feature flag enabled.
-			// TODO(@perebaj): Remove this once the feature flag is removed.
-			if tc.enableTypeAndUnitLabels {
-				symbolTable.Reset()
-				nSamples, nExemplars, nHistograms, _, _ := populateV2TimeSeries(
-					&symbolTable,
-					batch,
-					pendingData,
-					false, // sendExemplars
-					false, // sendNativeHistograms
-					true,  // enableTypeAndUnitLabels
-				)
+			symbolTable.Reset()
+			nSamples, nExemplars, nHistograms, _, _ := populateV2TimeSeries(
+				&symbolTable,
+				batch,
+				pendingData,
+				false, // sendExemplars
+				false, // sendNativeHistograms
+				true,  // enableTypeAndUnitLabels
+			)
 
-				require.Equal(t, 1, nSamples, "Should have 1 sample")
-				require.Equal(t, 0, nExemplars, "Should have 0 exemplars")
-				require.Equal(t, 0, nHistograms, "Should have 0 histograms")
+			require.Equal(t, 1, nSamples, "Should have 1 sample")
+			require.Equal(t, 0, nExemplars, "Should have 0 exemplars")
+			require.Equal(t, 0, nHistograms, "Should have 0 histograms")
 
-				require.Equal(t, tc.expectedType, pendingData[0].Metadata.Type,
-					"Type should match expected for %s", tc.description)
+			require.Equal(t, tc.expectedType, pendingData[0].Metadata.Type,
+				"Type should match expected for %s", tc.description)
 
-				unitRef := pendingData[0].Metadata.UnitRef
+			unitRef := pendingData[0].Metadata.UnitRef
 
-				symbols := symbolTable.Symbols()
-				require.Equal(t, tc.unitLabel, symbols[unitRef], "Unit should match")
-			}
+			symbols := symbolTable.Symbols()
+			require.Equal(t, tc.unitLabel, symbols[unitRef], "Unit should match")
 		})
 	}
 }

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2475,7 +2475,6 @@ func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
 				unitRef := pendingData[0].Metadata.UnitRef
 
 				symbols := symbolTable.Symbols()
-				require.True(t, unitRef < uint32(len(symbols)), "Unit ref should be valid")
 				require.Equal(t, tc.unitLabel, symbols[unitRef], "Unit should match")
 			}
 		})

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/prompb"
 	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
+	"github.com/prometheus/prometheus/schema"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
@@ -2418,14 +2419,13 @@ func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			batch := make([]timeSeries, 1)
 			builder := labels.NewScratchBuilder(2)
-			builder.Add("__name__", "test_metric_"+tc.name)
+			metadata := schema.Metadata{
+				Name: "test_metric_" + tc.name,
+				Type: model.MetricType(tc.typeLabel),
+				Unit: tc.unitLabel,
+			}
 
-			if tc.typeLabel != "" {
-				builder.Add("__type__", tc.typeLabel)
-			}
-			if tc.unitLabel != "" {
-				builder.Add("__unit__", tc.unitLabel)
-			}
+			metadata.AddToLabels(&builder)
 
 			batch[0] = timeSeries{
 				seriesLabels: builder.Labels(),

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -132,7 +132,7 @@ func TestBasicContentNegotiation(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
 			defer s.Close()
 
 			var (
@@ -241,7 +241,7 @@ func TestSampleDelivery(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%s-%s", tc.protoMsg, tc.name), func(t *testing.T) {
 			dir := t.TempDir()
-			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
 			defer s.Close()
 
 			var (
@@ -363,7 +363,7 @@ func TestMetadataDelivery(t *testing.T) {
 
 func TestWALMetadataDelivery(t *testing.T) {
 	dir := t.TempDir()
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
 	defer s.Close()
 
 	cfg := config.DefaultQueueConfig

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2429,7 +2429,7 @@ func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			batch := make([]timeSeries, 1)
-			builder := labels.NewScratchBuilder(4)
+			builder := labels.NewScratchBuilder(2)
 			builder.Add("__name__", "test_metric_"+tc.name)
 
 			if tc.typeLabel != "" {
@@ -2438,9 +2438,6 @@ func TestPopulateV2TimeSeries_typeAndUnitLabels(t *testing.T) {
 			if tc.unitLabel != "" {
 				builder.Add("__unit__", tc.unitLabel)
 			}
-
-			builder.Add("job", "test_job")
-			builder.Add("instance", "localhost:9090")
 
 			batch[0] = timeSeries{
 				seriesLabels: builder.Labels(),

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -93,7 +93,7 @@ func TestNoDuplicateReadConfigs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
-			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
 			conf := &config.Config{
 				GlobalConfig:      config.DefaultGlobalConfig,
 				RemoteReadConfigs: tc.cfgs,

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -59,12 +59,13 @@ type Storage struct {
 	rws *WriteStorage
 
 	// For reads.
-	queryables             []storage.SampleAndChunkQueryable
-	localStartTimeCallback startTimeCallback
+	queryables              []storage.SampleAndChunkQueryable
+	localStartTimeCallback  startTimeCallback
+	EnableTypeAndUnitLabels bool
 }
 
 // NewStorage returns a remote.Storage.
-func NewStorage(l *slog.Logger, reg prometheus.Registerer, stCallback startTimeCallback, walDir string, flushDeadline time.Duration, sm ReadyScrapeManager) *Storage {
+func NewStorage(l *slog.Logger, reg prometheus.Registerer, stCallback startTimeCallback, walDir string, flushDeadline time.Duration, sm ReadyScrapeManager, enableTypeAndUnitLabels bool) *Storage {
 	if l == nil {
 		l = promslog.NewNopLogger()
 	}
@@ -76,7 +77,7 @@ func NewStorage(l *slog.Logger, reg prometheus.Registerer, stCallback startTimeC
 		deduper:                deduper,
 		localStartTimeCallback: stCallback,
 	}
-	s.rws = NewWriteStorage(s.logger, reg, walDir, flushDeadline, sm)
+	s.rws = NewWriteStorage(s.logger, reg, walDir, flushDeadline, sm, enableTypeAndUnitLabels)
 	return s
 }
 

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -59,9 +59,8 @@ type Storage struct {
 	rws *WriteStorage
 
 	// For reads.
-	queryables              []storage.SampleAndChunkQueryable
-	localStartTimeCallback  startTimeCallback
-	EnableTypeAndUnitLabels bool
+	queryables             []storage.SampleAndChunkQueryable
+	localStartTimeCallback startTimeCallback
 }
 
 // NewStorage returns a remote.Storage.

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -29,7 +29,7 @@ import (
 func TestStorageLifecycle(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -56,7 +56,7 @@ func TestStorageLifecycle(t *testing.T) {
 func TestUpdateRemoteReadConfigs(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
@@ -77,7 +77,7 @@ func TestUpdateRemoteReadConfigs(t *testing.T) {
 func TestFilterExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{
@@ -102,7 +102,7 @@ func TestFilterExternalLabels(t *testing.T) {
 func TestIgnoreExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{
@@ -154,7 +154,7 @@ func baseRemoteReadConfig(host string) *config.RemoteReadConfig {
 // ApplyConfig runs concurrently with Notify
 // See https://github.com/prometheus/prometheus/issues/12747
 func TestWriteStorageApplyConfigsDuringCommit(t *testing.T) {
-	s := NewStorage(nil, nil, nil, t.TempDir(), defaultFlushDeadline, nil)
+	s := NewStorage(nil, nil, nil, t.TempDir(), defaultFlushDeadline, nil, false)
 
 	var wg sync.WaitGroup
 	wg.Add(2000)

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -73,11 +73,12 @@ type WriteStorage struct {
 	quit              chan struct{}
 
 	// For timestampTracker.
-	highestTimestamp *maxTimestamp
+	highestTimestamp        *maxTimestamp
+	enableTypeAndUnitLabels bool
 }
 
 // NewWriteStorage creates and runs a WriteStorage.
-func NewWriteStorage(logger *slog.Logger, reg prometheus.Registerer, dir string, flushDeadline time.Duration, sm ReadyScrapeManager) *WriteStorage {
+func NewWriteStorage(logger *slog.Logger, reg prometheus.Registerer, dir string, flushDeadline time.Duration, sm ReadyScrapeManager, enableTypeAndUnitLabels bool) *WriteStorage {
 	if logger == nil {
 		logger = promslog.NewNopLogger()
 	}
@@ -101,6 +102,7 @@ func NewWriteStorage(logger *slog.Logger, reg prometheus.Registerer, dir string,
 				Help:      "Highest timestamp that has come into the remote storage via the Appender interface, in seconds since epoch. Initialized to 0 when no data has been received yet.",
 			}),
 		},
+		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
 	}
 	if reg != nil {
 		reg.MustRegister(rws.highestTimestamp)
@@ -211,7 +213,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			rws.scraper,
 			rwConf.SendExemplars,
 			rwConf.SendNativeHistograms,
-			rwConf.EnableTypeAndUnitLabels,
+			rws.enableTypeAndUnitLabels,
 			rwConf.ProtobufMessage,
 		)
 		// Keep track of which queues are new so we know which to start.

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -73,7 +73,8 @@ type WriteStorage struct {
 	quit              chan struct{}
 
 	// For timestampTracker.
-	highestTimestamp *maxTimestamp
+	highestTimestamp        *maxTimestamp
+	enableTypeAndUnitLabels bool
 }
 
 // NewWriteStorage creates and runs a WriteStorage.
@@ -209,6 +210,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			rws.interner,
 			rws.highestTimestamp,
 			rws.scraper,
+			rws.enableTypeAndUnitLabels,
 			rwConf.SendExemplars,
 			rwConf.SendNativeHistograms,
 			rwConf.ProtobufMessage,

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -73,8 +73,7 @@ type WriteStorage struct {
 	quit              chan struct{}
 
 	// For timestampTracker.
-	highestTimestamp        *maxTimestamp
-	enableTypeAndUnitLabels bool
+	highestTimestamp *maxTimestamp
 }
 
 // NewWriteStorage creates and runs a WriteStorage.
@@ -210,9 +209,9 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			rws.interner,
 			rws.highestTimestamp,
 			rws.scraper,
-			rws.enableTypeAndUnitLabels,
 			rwConf.SendExemplars,
 			rwConf.SendNativeHistograms,
+			rwConf.EnableTypeAndUnitLabels,
 			rwConf.ProtobufMessage,
 		)
 		// Keep track of which queues are new so we know which to start.

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -118,7 +118,7 @@ func TestWriteStorageApplyConfig_NoDuplicateWriteConfigs(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil)
+			s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false)
 			conf := &config.Config{
 				GlobalConfig:       config.DefaultGlobalConfig,
 				RemoteWriteConfigs: tc.cfgs,
@@ -144,7 +144,7 @@ func TestWriteStorageApplyConfig_RestartOnNameChange(t *testing.T) {
 	hash, err := toHash(cfg)
 	require.NoError(t, err)
 
-	s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil)
+	s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false)
 
 	conf := &config.Config{
 		GlobalConfig:       config.DefaultGlobalConfig,
@@ -166,7 +166,7 @@ func TestWriteStorageApplyConfig_RestartOnNameChange(t *testing.T) {
 func TestWriteStorageApplyConfig_UpdateWithRegisterer(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Millisecond, nil)
+	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Millisecond, nil, false)
 	c1 := &config.RemoteWriteConfig{
 		Name: "named",
 		URL: &common_config.URL{
@@ -207,7 +207,7 @@ func TestWriteStorageApplyConfig_UpdateWithRegisterer(t *testing.T) {
 func TestWriteStorageApplyConfig_Lifecycle(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -223,7 +223,7 @@ func TestWriteStorageApplyConfig_Lifecycle(t *testing.T) {
 func TestWriteStorageApplyConfig_UpdateExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Second, nil)
+	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Second, nil, false)
 
 	externalLabels := labels.FromStrings("external", "true")
 	conf := &config.Config{
@@ -251,7 +251,7 @@ func TestWriteStorageApplyConfig_UpdateExternalLabels(t *testing.T) {
 func TestWriteStorageApplyConfig_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -275,7 +275,7 @@ func TestWriteStorageApplyConfig_Idempotent(t *testing.T) {
 func TestWriteStorageApplyConfig_PartialUpdate(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
 
 	c0 := &config.RemoteWriteConfig{
 		RemoteTimeout: model.Duration(10 * time.Second),
@@ -1082,7 +1082,7 @@ func TestWriteStorage_CanRegisterMetricsAfterClosing(t *testing.T) {
 	dir := t.TempDir()
 	reg := prometheus.NewPedanticRegistry()
 
-	s := NewWriteStorage(nil, reg, dir, time.Millisecond, nil)
+	s := NewWriteStorage(nil, reg, dir, time.Millisecond, nil, false)
 	require.NoError(t, s.Close())
-	require.NotPanics(t, func() { NewWriteStorage(nil, reg, dir, time.Millisecond, nil) })
+	require.NotPanics(t, func() { NewWriteStorage(nil, reg, dir, time.Millisecond, nil, false) })
 }

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -91,7 +91,7 @@ func createTestAgentDB(t testing.TB, reg prometheus.Registerer, opts *Options) *
 	t.Helper()
 
 	dbDir := t.TempDir()
-	rs := remote.NewStorage(promslog.NewNopLogger(), reg, startTime, dbDir, time.Second*30, nil)
+	rs := remote.NewStorage(promslog.NewNopLogger(), reg, startTime, dbDir, time.Second*30, nil, false)
 	t.Cleanup(func() {
 		require.NoError(t, rs.Close())
 	})
@@ -737,7 +737,7 @@ func TestLockfile(t *testing.T) {
 	tsdbutil.TestDirLockerUsage(t, func(t *testing.T, data string, createLock bool) (*tsdbutil.DirLocker, testutil.Closer) {
 		logger := promslog.NewNopLogger()
 		reg := prometheus.NewRegistry()
-		rs := remote.NewStorage(logger, reg, startTime, data, time.Second*30, nil)
+		rs := remote.NewStorage(logger, reg, startTime, data, time.Second*30, nil, false)
 		t.Cleanup(func() {
 			require.NoError(t, rs.Close())
 		})
@@ -757,7 +757,7 @@ func TestLockfile(t *testing.T) {
 
 func Test_ExistingWAL_NextRef(t *testing.T) {
 	dbDir := t.TempDir()
-	rs := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil)
+	rs := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false)
 	defer func() {
 		require.NoError(t, rs.Close())
 	}()

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -496,7 +496,7 @@ func TestEndpoints(t *testing.T) {
 
 		remote := remote.NewStorage(promslog.New(&promslogConfig), prometheus.DefaultRegisterer, func() (int64, error) {
 			return 0, nil
-		}, dbDir, 1*time.Second, nil)
+		}, dbDir, 1*time.Second, nil, false)
 
 		err = remote.ApplyConfig(&config.Config{
 			RemoteReadConfigs: []*config.RemoteReadConfig{


### PR DESCRIPTION
According to [this thread](https://cloud-native.slack.com/archives/C01LSCJBXDZ/p1752739853128809) we would like to send type and unit data to be accessed on the PRW2. This will unlock some issues that we are facing on the OTEL side. This because some metrics can be sent without type even if the feature flag is set, causing errors in the parsing process.

Related issue on otel-collector-contrib -> https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41840#issue-3300098518
<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:

Partially fixes: https://github.com/prometheus/prometheus/issues/16610.

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```

