### PR TITLE
test: remove obsolete queue manager test

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2003,7 +2003,7 @@ func TestIsSampleOld(t *testing.T) {
 func TestSendSamplesWithBackoffWithSampleAgeLimit(t *testing.T) {
 	t.Parallel()
 	maxSamplesPerSend := 10
-	sampleAgeLimit := time.Second
+	sampleAgeLimit := time.Second * 2
 
 	cfg := config.DefaultQueueConfig
 	cfg.MaxShards = 1


### PR DESCRIPTION
As mentioned in #16182, the BenchmarkStartup test for the queue manager covers an old API and uses settings that will not occur in production.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
```release-notes
NONE
```