### PR TITLE
chore: improve LTS versions backport process

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,28 @@
+name: 'Check LTS backport labels'
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check_release_notes:
+    name: check
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'prometheus' || github.repository_owner == 'prometheus-community' # Don't run this workflow on forks.
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: |
+            backport-to-lts
+            no-lts-backport
+          add_comment: true
+          message: "With the help of the reviewer(s), please decide whether the changes in this PR should be marked for backporting to the LTS version(s), by setting one of the following labels: {{ provided }}."


### PR DESCRIPTION
Allow the PR author and reviewer(s) to decide whether changes—primarily bug fixes—should be backported to LTS versions.

This should help ensure important changes are not missed and make the LTS version(s) shepherd’s job easier when identifying and releasing such changes.

<!--
    Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    If your PR is to fix an issue, put "Fixes #issue-number" in the description.

    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
