### PR TITLE
promqltest: Add test for unary minus with native histograms

### DIFF
--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1546,3 +1546,9 @@ eval instant at 5m rate(avg_over_time(metric{id="1"}[10m])[5m:])
   expect warn regex: this native histogram metric is not a counter: "metric"
   {id="1"} {{counter_reset_hint:gauge}}
 
+# Unary minus turns counters into gauges.
+eval instant at 5m -metric
+  expect no_warn
+  expect no_info
+  {id="1"} {{count:-4 sum:-4 counter_reset_hint:gauge buckets:[-1 -2 -1]}}
+  {id="2"} {{count:-4 sum:-4 counter_reset_hint:gauge buckets:[-1 -2 -1]}}


### PR DESCRIPTION
This verifies that a counter histogram becomes a gauge histogram if an unary minus is applied to it.

/cc @NeerajGartia21 @juliusmh

#### Which issue(s) does the PR fix:

Related to #16570 but not yet sufficient to close it.

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```
