### PR TITLE
chore(configuration.md): fix unit_testing_rules typo

### DIFF
--- a/docs/configuration/unit_testing_rules.md
+++ b/docs/configuration/unit_testing_rules.md
@@ -9,7 +9,7 @@ You can use `promtool` to test your rules.
 # For a single test file.
 ./promtool test rules test.yml
 
-# If you have multiple test files, say test1.yml,test2.yml,test2.yml
+# If you have multiple test files, say test1.yml,test2.yml,test3.yml
 ./promtool test rules test1.yml test2.yml test3.yml
 ```
 


### PR DESCRIPTION
this PR is for fixing the typo in unit testing rules explanation
@machine424 