### PR TITLE
Remote write: Return after writing error response for invalid compression

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -154,6 +154,7 @@ func (h *writeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err := fmt.Errorf("%v encoding (compression) is not accepted by this server; only %v is acceptable", enc, compression.Snappy)
 		h.logger.Error("Error decoding remote write request", "err", err)
 		http.Error(w, err.Error(), http.StatusUnsupportedMediaType)
+		return
 	}
 
 	// Read the request body.


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fix remote write HTTP handler to return after writing error response for invalid compression (non-Snappy).

Same kind of fix as https://github.com/prometheus/prometheus/pull/16997.

#### Does this PR introduce a user-facing change?
```release-notes
[BUGFIX] Remote write: Fix HTTP handler to return after writing error response for invalid compression.
```
