### PR TITLE
test(notifier): add a test showing an alert mutation bug between alertmanager_config and fix it

### DIFF
--- a/notifier/alert.go
+++ b/notifier/alert.go
@@ -84,7 +84,18 @@ func relabelAlerts(relabelConfigs []*relabel.Config, externalLabels labels.Label
 		if !keep {
 			continue
 		}
-		a.Labels = lb.Labels()
+
+		// If relabeling has altered the labels, create a new Alert to preserve immutability.
+		if !labels.Equal(a.Labels, lb.Labels()) {
+			a = &Alert{
+				Labels:       lb.Labels(),
+				Annotations:  a.Annotations,
+				StartsAt:     a.StartsAt,
+				EndsAt:       a.EndsAt,
+				GeneratorURL: a.GeneratorURL,
+			}
+		}
+
 		relabeledAlerts = append(relabeledAlerts, a)
 	}
 	return relabeledAlerts

--- a/notifier/manager_test.go
+++ b/notifier/manager_test.go
@@ -1132,3 +1132,88 @@ alerting:
 	require.NoError(t, n.ApplyConfig(cfg))
 	require.Empty(t, n.Alertmanagers())
 }
+
+// TestAlerstRelabelingIsIsolated ensures that a mutation alerts relabeling in an
+// alertmanagerSet doesn't affect others.
+// See https://github.com/prometheus/prometheus/pull/17063.
+func TestAlerstRelabelingIsIsolated(t *testing.T) {
+	var (
+		errc      = make(chan error, 1)
+		expected1 = make([]*Alert, 0)
+		expected2 = make([]*Alert, 0)
+
+		status1, status2 atomic.Int32
+	)
+	status1.Store(int32(http.StatusOK))
+	status2.Store(int32(http.StatusOK))
+
+	server1 := newTestHTTPServerBuilder(&expected1, errc, "", "", &status1)
+	server2 := newTestHTTPServerBuilder(&expected2, errc, "", "", &status2)
+
+	defer server1.Close()
+	defer server2.Close()
+
+	h := NewManager(&Options{}, model.UTF8Validation, nil)
+	h.alertmanagers = make(map[string]*alertmanagerSet)
+
+	am1Cfg := config.DefaultAlertmanagerConfig
+	am1Cfg.Timeout = model.Duration(time.Second)
+	am1Cfg.AlertRelabelConfigs = []*relabel.Config{
+		{
+			SourceLabels:         model.LabelNames{"alertname"},
+			Regex:                relabel.MustNewRegexp("(.*)"),
+			TargetLabel:          "parasite",
+			Action:               relabel.Replace,
+			Replacement:          "yes",
+			NameValidationScheme: model.UTF8Validation,
+		},
+	}
+
+	am2Cfg := config.DefaultAlertmanagerConfig
+	am2Cfg.Timeout = model.Duration(time.Second)
+
+	h.alertmanagers = map[string]*alertmanagerSet{
+		"am1": {
+			ams: []alertmanager{
+				alertmanagerMock{
+					urlf: func() string { return server1.URL },
+				},
+			},
+			cfg: &am1Cfg,
+		},
+		"am2": {
+			ams: []alertmanager{
+				alertmanagerMock{
+					urlf: func() string { return server2.URL },
+				},
+			},
+			cfg: &am2Cfg,
+		},
+	}
+
+	testAlert := &Alert{
+		Labels: labels.FromStrings("alertname", "test"),
+	}
+	h.queue = []*Alert{testAlert}
+
+	expected1 = append(expected1, &Alert{
+		Labels: labels.FromStrings("alertname", "test", "parasite", "yes"),
+	})
+
+	// am2 shouldn't get the parasite label.
+	expected2 = append(expected2, &Alert{
+		Labels: labels.FromStrings("alertname", "test"),
+	})
+
+	checkNoErr := func() {
+		t.Helper()
+		select {
+		case err := <-errc:
+			require.NoError(t, err)
+		default:
+		}
+	}
+
+	require.True(t, h.sendAll(h.queue...))
+	checkNoErr()
+}


### PR DESCRIPTION
The alert_relabel_configs should only apply to the corresponding alertmanagerset

This is probably due to the `a.Labels = lb.Labels()` in https://github.com/prometheus/prometheus/blob/5dc3c976b461e9a958a983cdb282d27c755d47ef/notifier/alert.go#L71-L87

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX]: Alerting: Mutating alerts relabeling (using `replace` actions, etc.) within a `alertmanager_config.alert_relabel_configs` block is now scoped correctly and no longer yields altered alerts to subsequent blocks.
```
