### PR TITLE
feat(metrics): add prometheus_sd_http_requests_total metric

### DIFF
--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -155,6 +155,9 @@ func (d *Discovery) Refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Increment the request count metric at the start of the request.
+	d.metrics.requestsCount.Inc()
+
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Prometheus-Refresh-Interval-Seconds", strconv.FormatFloat(d.refreshInterval.Seconds(), 'f', -1, 64))

--- a/discovery/http/metrics.go
+++ b/discovery/http/metrics.go
@@ -26,6 +26,8 @@ type httpMetrics struct {
 
 	failuresCount prometheus.Counter
 
+	requestsCount prometheus.Counter
+
 	metricRegisterer discovery.MetricRegisterer
 }
 
@@ -37,10 +39,16 @@ func newDiscovererMetrics(reg prometheus.Registerer, rmi discovery.RefreshMetric
 				Name: "prometheus_sd_http_failures_total",
 				Help: "Number of HTTP service discovery refresh failures.",
 			}),
+		requestsCount: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "prometheus_sd_http_requests_total",
+				Help: "Total number of HTTP service discovery requests.",
+			}),
 	}
 
 	m.metricRegisterer = discovery.NewMetricRegisterer(reg, []prometheus.Collector{
 		m.failuresCount,
+		m.requestsCount,
 	})
 
 	return m

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1697,7 +1697,8 @@ Example response body:
 
 The endpoint is queried periodically at the specified refresh interval.
 The `prometheus_sd_http_failures_total` counter metric tracks the number of
-refresh failures.
+refresh failures and the `prometheus_sd_http_requests_total` counter metric
+tracks the total number of refresh attempts.
 
 Each target has a meta label `__meta_url` during the
 [relabeling phase](#relabel_config). Its value is set to the

--- a/docs/http_sd.md
+++ b/docs/http_sd.md
@@ -40,7 +40,8 @@ an empty list `[]`. Target lists are unordered.
 Prometheus caches target lists. If an error occurs while fetching an updated
 targets list, Prometheus keeps using the current targets list. The targets list
 is not saved across restart. The `prometheus_sd_http_failures_total` counter
-metric tracks the number of refresh failures.
+metric tracks the number of refresh failures and the `prometheus_sd_http_requests_total`
+counter metric tracks the total number of refresh attempts.
 
 The whole list of targets must be returned on every scrape. There is no support
 for incremental updates. A Prometheus instance does not send its hostname and it

--- a/model/textparse/testdata/alltypes.237mfs.nometa.prom.txt
+++ b/model/textparse/testdata/alltypes.237mfs.nometa.prom.txt
@@ -1541,6 +1541,7 @@ prometheus_sd_file_scan_duration_seconds_sum 4.751347856999997
 prometheus_sd_file_scan_duration_seconds_count 11812
 prometheus_sd_file_watcher_errors_total 0
 prometheus_sd_http_failures_total 0
+prometheus_sd_http_requests_total 0
 prometheus_sd_kubernetes_events_total{event="add",role="endpoints"} 0
 prometheus_sd_kubernetes_events_total{event="add",role="endpointslice"} 0
 prometheus_sd_kubernetes_events_total{event="add",role="ingress"} 0

--- a/model/textparse/testdata/alltypes.237mfs.prom.txt
+++ b/model/textparse/testdata/alltypes.237mfs.prom.txt
@@ -1793,6 +1793,9 @@ prometheus_sd_file_watcher_errors_total 0
 # HELP prometheus_sd_http_failures_total Number of HTTP service discovery refresh failures.
 # TYPE prometheus_sd_http_failures_total counter
 prometheus_sd_http_failures_total 0
+# HELP prometheus_sd_http_requests_total Total number of HTTP service discovery requests.
+# TYPE prometheus_sd_http_requests_total counter
+prometheus_sd_http_requests_total 0
 # HELP prometheus_sd_kubernetes_events_total The number of Kubernetes events handled.
 # TYPE prometheus_sd_kubernetes_events_total counter
 prometheus_sd_kubernetes_events_total{event="add",role="endpoints"} 0

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1494,11 +1494,11 @@ func TestPromTextToProto(t *testing.T) {
 		}
 		got = append(got, mf.GetName())
 	}
-	require.Len(t, got, 237)
+	require.Len(t, got, 238)
 	// Check a few to see if those are not dups.
 	require.Equal(t, "go_gc_cycles_automatic_gc_cycles_total", got[0])
-	require.Equal(t, "prometheus_sd_kuma_fetch_duration_seconds", got[128])
-	require.Equal(t, "promhttp_metric_handler_requests_total", got[236])
+	require.Equal(t, "prometheus_sd_kuma_fetch_duration_seconds", got[129])
+	require.Equal(t, "promhttp_metric_handler_requests_total", got[237])
 }
 
 // BenchmarkScrapeLoopAppend benchmarks a core append function in a scrapeLoop


### PR DESCRIPTION
When attempting to make an SLO for prometheus_sd_http_failures_total I noticed there wasn't an accompanying `requests_total` metric. This is very helpful to form SLOs so you can get the entire context of the failure rate with:

`1 - (error / total)`

Some service discovery providers already follow this pattern like `prometheus_sd_dns_lookups_total`, but others also only have failures and could be improved too. I can add in more missing metrics to service discovery engines if this pattern is okay.

#### Which issue(s) does the PR fix:

N/A

#### Does this PR introduce a user-facing change?

```release-notes
[FEATURE] Adding prometheus_sd_http_requests_total time series
```
