### PR TITLE
tsdb: Fixup err nil checks

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -704,8 +704,7 @@ func (h *Head) Init(minValidTime int64) error {
 				snapshotLoaded = true
 				chunkSnapshotLoadDuration = time.Since(start)
 				h.logger.Info("Chunk snapshot loading time", "duration", chunkSnapshotLoadDuration.String())
-			}
-			if err != nil {
+			} else {
 				snapIdx, snapOffset = -1, 0
 				refSeries = make(map[chunks.HeadSeriesRef]*memSeries)
 

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1443,12 +1443,10 @@ func (h *Head) performChunkSnapshot() error {
 	startTime := time.Now()
 	stats, err := h.ChunkSnapshot()
 	elapsed := time.Since(startTime)
-	if err == nil {
-		h.logger.Info("chunk snapshot complete", "duration", elapsed.String(), "num_series", stats.TotalSeries, "dir", stats.Dir)
-	}
 	if err != nil {
 		return fmt.Errorf("chunk snapshot: %w", err)
 	}
+	h.logger.Info("chunk snapshot complete", "duration", elapsed.String(), "num_series", stats.TotalSeries, "dir", stats.Dir)
 	return nil
 }
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Cleanup double `if` statements for errors being nil / not-nil.

#### Does this PR introduce a user-facing change?

NONE
