### PR TITLE
remote_write: add debug log for unexpected metadata in populateV2TimeSeries

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -64,36 +64,35 @@ const (
 type queueManagerMetrics struct {
 	reg prometheus.Registerer
 
-	samplesTotal            prometheus.Counter
-	exemplarsTotal          prometheus.Counter
-	histogramsTotal         prometheus.Counter
-	metadataTotal           prometheus.Counter
-	failedSamplesTotal      prometheus.Counter
-	failedExemplarsTotal    prometheus.Counter
-	failedHistogramsTotal   prometheus.Counter
-	failedMetadataTotal     prometheus.Counter
-	retriedSamplesTotal     prometheus.Counter
-	retriedExemplarsTotal   prometheus.Counter
-	retriedHistogramsTotal  prometheus.Counter
-	retriedMetadataTotal    prometheus.Counter
-	droppedSamplesTotal     *prometheus.CounterVec
-	droppedExemplarsTotal   *prometheus.CounterVec
-	droppedHistogramsTotal  *prometheus.CounterVec
-	enqueueRetriesTotal     prometheus.Counter
-	sentBatchDuration       prometheus.Histogram
-	highestSentTimestamp    *maxTimestamp
-	pendingSamples          prometheus.Gauge
-	pendingExemplars        prometheus.Gauge
-	pendingHistograms       prometheus.Gauge
-	shardCapacity           prometheus.Gauge
-	numShards               prometheus.Gauge
-	maxNumShards            prometheus.Gauge
-	minNumShards            prometheus.Gauge
-	desiredNumShards        prometheus.Gauge
-	sentBytesTotal          prometheus.Counter
-	metadataBytesTotal      prometheus.Counter
-	maxSamplesPerSend       prometheus.Gauge
-	unexpectedMetadataTotal prometheus.Counter
+	samplesTotal           prometheus.Counter
+	exemplarsTotal         prometheus.Counter
+	histogramsTotal        prometheus.Counter
+	metadataTotal          prometheus.Counter
+	failedSamplesTotal     prometheus.Counter
+	failedExemplarsTotal   prometheus.Counter
+	failedHistogramsTotal  prometheus.Counter
+	failedMetadataTotal    prometheus.Counter
+	retriedSamplesTotal    prometheus.Counter
+	retriedExemplarsTotal  prometheus.Counter
+	retriedHistogramsTotal prometheus.Counter
+	retriedMetadataTotal   prometheus.Counter
+	droppedSamplesTotal    *prometheus.CounterVec
+	droppedExemplarsTotal  *prometheus.CounterVec
+	droppedHistogramsTotal *prometheus.CounterVec
+	enqueueRetriesTotal    prometheus.Counter
+	sentBatchDuration      prometheus.Histogram
+	highestSentTimestamp   *maxTimestamp
+	pendingSamples         prometheus.Gauge
+	pendingExemplars       prometheus.Gauge
+	pendingHistograms      prometheus.Gauge
+	shardCapacity          prometheus.Gauge
+	numShards              prometheus.Gauge
+	maxNumShards           prometheus.Gauge
+	minNumShards           prometheus.Gauge
+	desiredNumShards       prometheus.Gauge
+	sentBytesTotal         prometheus.Counter
+	metadataBytesTotal     prometheus.Counter
+	maxSamplesPerSend      prometheus.Gauge
 }
 
 func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManagerMetrics {
@@ -314,13 +313,6 @@ func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManager
 		Help:        "The maximum number of samples to be sent, in a single request, to the remote storage. Note that, when sending of exemplars over remote write is enabled, exemplars count towards this limt.",
 		ConstLabels: constLabels,
 	})
-	m.unexpectedMetadataTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace:   namespace,
-		Subsystem:   subsystem,
-		Name:        "unexpected_metadata_total",
-		Help:        "Total number of unexpected metadata entries in populateV2TimeSeries indicating routing bugs.",
-		ConstLabels: constLabels,
-	})
 
 	return m
 }
@@ -357,7 +349,6 @@ func (m *queueManagerMetrics) register() {
 			m.sentBytesTotal,
 			m.metadataBytesTotal,
 			m.maxSamplesPerSend,
-			m.unexpectedMetadataTotal,
 		)
 	}
 }
@@ -393,7 +384,6 @@ func (m *queueManagerMetrics) unregister() {
 		m.reg.Unregister(m.sentBytesTotal)
 		m.reg.Unregister(m.metadataBytesTotal)
 		m.reg.Unregister(m.maxSamplesPerSend)
-		m.reg.Unregister(m.unexpectedMetadataTotal)
 	}
 }
 
@@ -1556,7 +1546,7 @@ func (s *shards) runShard(ctx context.Context, shardID int, queue *queue) {
 			nPendingSamples, nPendingExemplars, nPendingHistograms, nPendingMetadata, nUnexpectedMetadata := populateV2TimeSeries(&symbolTable, batch, pendingDataV2, s.qm.sendExemplars, s.qm.sendNativeHistograms)
 			n := nPendingSamples + nPendingExemplars + nPendingHistograms
 			if nUnexpectedMetadata > 0 {
-				s.qm.metrics.unexpectedMetadataTotal.Add(float64(nUnexpectedMetadata))
+				s.qm.logger.Warn("unexpected metadata sType in populateV2TimeSeries", "count", nUnexpectedMetadata)
 			}
 			_ = s.sendV2Samples(ctx, pendingDataV2[:n], symbolTable.Symbols(), nPendingSamples, nPendingExemplars, nPendingHistograms, nPendingMetadata, &pBufRaw, encBuf, compr)
 			symbolTable.Reset()


### PR DESCRIPTION
This PR addresses the TODO comment in `populateV2TimeSeries` by handling unexpected metadata entries in samples-only batches through logging instead of metrics tracking.

### Changes

- Removed the `unexpectedMetadataTotal` metric that was previously added.
- Added debug-level logging in `populateV2TimeSeries` when unexpected metadata is encountered.

### Related Issues

Addresses TODO comment in populateV2TimeSeries

Related to [14405](https://github.com/prometheus/prometheus/issues/14405)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[ENHANCEMENT] Remote write: Add logging for unexpected metadata in samples batches. When metadata entries are found in samples-only remote write batches, Prometheus now logs a warning message to improve observability.
```