### PR TITLE
chore: add a "make bump-go-version" to handle Go bumps across all files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,3 +196,8 @@ update-all-go-deps:
 .PHONY: check-node-version
 check-node-version:
 	@./scripts/check-node-version.sh
+
+.PHONY: bump-go-version
+bump-go-version:
+	@echo ">> bumping Go minor version"
+	@./scripts/bump_go_version.sh

--- a/scripts/bump_go_version.sh
+++ b/scripts/bump_go_version.sh
@@ -24,9 +24,10 @@ go mod edit -go=${NEW_VERSION}.0 documentation/examples/remote_storage/go.mod
 sed -i "s/version: ${NEW_VERSION}/version: ${LATEST_VERSION}/g" .promu.yml
 
 # Update GitHub Actions workflows
-sed -i "s/go-version: ${CURRENT_VERSION}\.x/go-version: ${NEW_VERSION}.x/g" scripts/golangci-lint.yml .github/workflows/*.yml
+# Keep ordered so some versions aren't bumped twice
 sed -i "s/go-version: ${NEW_VERSION}\.x/go-version: ${LATEST_VERSION}.x/g" scripts/golangci-lint.yml .github/workflows/*.yml
-sed -i "s/golang-builder:${CURRENT_VERSION}-base/golang-builder:${NEW_VERSION}-base/g" .github/workflows/*.yml
 sed -i "s/golang-builder:${NEW_VERSION}-base/golang-builder:${LATEST_VERSION}-base/g" .github/workflows/*.yml
+sed -i "s/go-version: ${CURRENT_VERSION}\.x/go-version: ${NEW_VERSION}.x/g" scripts/golangci-lint.yml .github/workflows/*.yml
+sed -i "s/golang-builder:${CURRENT_VERSION}-base/golang-builder:${NEW_VERSION}-base/g" .github/workflows/*.yml
 
 echo "Please review the changes and commit them."

--- a/scripts/bump_go_version.sh
+++ b/scripts/bump_go_version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -u -o pipefail
+
+# Bump Go version (minor version bump only) across the repository.
+# Run from repo root.
+
+IFS='.' read -r current_major current_minor _ <<< "$(go mod edit -json go.mod | jq -r .Go)"
+new_minor=$((current_minor + 1))
+# We need to support latest-1.
+latest_minor=$((current_minor + 2))
+
+CURRENT_VERSION="${current_major}.${current_minor}"
+NEW_VERSION="${current_major}.${new_minor}"
+LATEST_VERSION="${current_major}.${latest_minor}"
+
+printf "Current minimum supported version: ${CURRENT_VERSION}\nNew minimum supported version: ${NEW_VERSION}\nLatest version: ${LATEST_VERSION}\n"
+
+# Update go.mod files
+go mod edit -go=${NEW_VERSION}.0
+go mod edit -go=${NEW_VERSION}.0 documentation/examples/remote_storage/go.mod
+
+# Update .promu.yml
+sed -i "s/version: ${NEW_VERSION}/version: ${LATEST_VERSION}/g" .promu.yml
+
+# Update GitHub Actions workflows
+sed -i "s/go-version: ${CURRENT_VERSION}\.x/go-version: ${NEW_VERSION}.x/g" scripts/golangci-lint.yml .github/workflows/*.yml
+sed -i "s/go-version: ${NEW_VERSION}\.x/go-version: ${LATEST_VERSION}.x/g" scripts/golangci-lint.yml .github/workflows/*.yml
+sed -i "s/golang-builder:${CURRENT_VERSION}-base/golang-builder:${NEW_VERSION}-base/g" .github/workflows/*.yml
+sed -i "s/golang-builder:${NEW_VERSION}-base/golang-builder:${LATEST_VERSION}-base/g" .github/workflows/*.yml
+
+echo "Please review the changes and commit them."


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes https://github.com/prometheus/prometheus/issues/16446

Supersedes https://github.com/prometheus/prometheus/pull/16488 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```

This should help with partial updates like in https://github.com/prometheus/prometheus/pull/17080, we currently need to bump the version in too many places, the script can help keep track of that.

run using `make bump-go-version`


