### PR TITLE
[PERF] TSDB: Default stripe size=256 (was 16384)

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1893,7 +1893,7 @@ func (m *seriesHashmap) del(hash uint64, ref chunks.HeadSeriesRef) {
 
 const (
 	// DefaultStripeSize is the default number of entries to allocate in the stripeSeries hash map.
-	DefaultStripeSize = 1 << 14
+	DefaultStripeSize = 256
 )
 
 // stripeSeries holds series by HeadSeriesRef ("ID") and also by hash of their labels.


### PR DESCRIPTION
Expected to reduce resource usage without noticeable extra contention

#### Which issue(s) does the PR fix:
Fixes #17100 

#### Does this PR introduce a user-facing change?
```release-notes
[PERF] TSDB: Reduce size of internal data structures to suit typical installations. 
```

[Draft because I expect we will want to add a CLI flag to let people set it higher if they perceive contention]