### PR TITLE
fix(rules.Manager): ensure non-nil context

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -145,6 +145,10 @@ func NewManager(o *ManagerOptions) *Manager {
 	default:
 		panic(fmt.Errorf("unrecognized name validation scheme: %s", o.NameValidationScheme))
 	}
+	if o.Context == nil {
+		o.Context = context.Background()
+	}
+
 	if o.Metrics == nil {
 		o.Metrics = NewGroupMetrics(o.Registerer)
 	}


### PR DESCRIPTION
Saw some panic on main due to lack of defaulting:
https://github.com/prometheus/prometheus/actions/runs/17317373582/job/49162760911
