### PR TITLE
ui: add scrape interval column to targets page

### DIFF
--- a/web/ui/mantine-ui/src/pages/targets/ScrapePoolsList.tsx
+++ b/web/ui/mantine-ui/src/pages/targets/ScrapePoolsList.tsx
@@ -303,6 +303,7 @@ const ScrapePoolList: FC<ScrapePoolListProp> = memo(
                             <Table.Tr>
                               <Table.Th w="25%">Endpoint</Table.Th>
                               <Table.Th>Labels</Table.Th>
+                              <Table.Th w={120}>Scrape Interval</Table.Th>
                               <Table.Th w={230}>Last scrape</Table.Th>
                               <Table.Th w={100}>State</Table.Th>
                             </Table.Tr>
@@ -334,6 +335,39 @@ const ScrapePoolList: FC<ScrapePoolListProp> = memo(
                                   <Table.Td valign="top">
                                     <Group gap="xs" wrap="wrap">
                                       <Tooltip
+                                        label={`Scrape interval: ${target.scrapeInterval}`}
+                                        withArrow
+                                      >
+                                        <Badge
+                                          variant="light"
+                                          className={badgeClasses.statsBadge}
+                                          styles={{
+                                            label: { textTransform: "none" },
+                                          }}
+                                        >
+                                          {target.scrapeInterval}
+                                        </Badge>
+                                      </Tooltip>
+                                      
+                                      <Tooltip
+                                        label={`Scrape timeout: ${target.scrapeTimeout}`}
+                                        withArrow
+                                      >
+                                        <Badge
+                                          variant="light"
+                                          className={badgeClasses.statsBadge}
+                                          styles={{
+                                            label: { textTransform: "none" },
+                                          }}
+                                        >
+                                          {target.scrapeTimeout}
+                                        </Badge>
+                                      </Tooltip>
+                                    </Group>
+                                  </Table.Td>
+                                  <Table.Td valign="top">
+                                    <Group gap="xs" wrap="wrap">
+                                      <Tooltip
                                         label="Last target scrape"
                                         withArrow
                                       >
@@ -357,7 +391,13 @@ const ScrapePoolList: FC<ScrapePoolListProp> = memo(
                                       </Tooltip>
 
                                       <Tooltip
-                                        label="Duration of last target scrape"
+                                        label={
+                                          <Stack gap={0}>
+                                            <Text size="xs">Duration of last target scrape</Text>
+                                            <Text size="xs">Interval: {target.scrapeInterval}</Text>
+                                            <Text size="xs">Timeout: {target.scrapeTimeout}</Text>
+                                          </Stack>
+                                        }
                                         withArrow
                                       >
                                         <Badge
@@ -391,7 +431,7 @@ const ScrapePoolList: FC<ScrapePoolListProp> = memo(
                                 </Table.Tr>
                                 {target.lastError && (
                                   <Table.Tr>
-                                    <Table.Td colSpan={5} valign="top">
+                                    <Table.Td colSpan={6} valign="top">
                                       <Alert
                                         color="red"
                                         mb="sm"

--- a/web/ui/react-app/src/pages/targets/ScrapePoolContent.tsx
+++ b/web/ui/react-app/src/pages/targets/ScrapePoolContent.tsx
@@ -9,7 +9,7 @@ import TargetScrapeDuration from './TargetScrapeDuration';
 import EndpointLink from './EndpointLink';
 import CustomInfiniteScroll, { InfiniteScrollItemsProps } from '../../components/CustomInfiniteScroll';
 
-const columns = ['Endpoint', 'State', 'Labels', 'Last Scrape', 'Scrape Duration', 'Error'];
+const columns = ['Endpoint', 'State', 'Labels', 'Scrape Interval', 'Last Scrape', 'Scrape Duration', 'Error'];
 
 interface ScrapePoolContentProps {
   targets: Target[];
@@ -36,6 +36,13 @@ const ScrapePoolContentTable: FC<InfiniteScrollItemsProps<Target>> = ({ items })
             </td>
             <td className={styles.labels}>
               <TargetLabels discoveredLabels={target.discoveredLabels} labels={target.labels} />
+            </td>
+            <td className={styles['scrape-interval']}>
+              <Badge color="secondary">{target.scrapeInterval}</Badge>
+              <br />
+              <Badge color="secondary" size="sm">
+                {target.scrapeTimeout}
+              </Badge>
             </td>
             <td className={styles['last-scrape']}>{formatRelative(target.lastScrape, now())}</td>
             <td className={styles['scrape-duration']}>


### PR DESCRIPTION
## Summary
Display the final scrape interval and timeout values after label relabelling in both React and Mantine UI implementations. This addresses issue #17085 by restoring the visibility of scrape intervals that was previously available in v2.46.0.

## Changes
- **Mantine UI**: Added new "Scrape Interval" column showing both scrape interval and timeout as badges with tooltips
- **React UI**: Added new "Scrape Interval" column displaying scrape interval and timeout as badges
- Enhanced existing scrape duration tooltips in Mantine UI to also show interval/timeout information
- Updated table column spans to accommodate the new column

## Test plan
- [x] Built both React and Mantine UI successfully
- [x] Verified scrape interval and timeout are displayed prominently in dedicated column
- [x] Maintained existing tooltip functionality
- [x] Updated error row spans to match new column count

#### Does this PR introduce a user-facing change?

```release-notes
[ENHANCEMENT] UI: Add scrape interval column to targets page. #17085
```

Fixes #17085