### PR TITLE
fix(nhcb): flaky test TestConvertClassicHistogramsToNHCB

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -4775,6 +4775,8 @@ metric: <
 					}
 					content = buf.Bytes()
 				case "text/plain", "":
+					// The input text fragments already have a newline at the
+					// end, so we just concatenate them without separator.
 					content = []byte(strings.Join(metricsText.text, ""))
 					contentType = "text/plain"
 				default:


### PR DESCRIPTION
The test was e2e, including actually scraping an HTTP endpoint and running the scrape loop. This led to some timing issues.

I've simplified it to call the scrape loop append directly. I think that this isn't nice as that is a private interface, but should get rid of the flakiness and there's already a bunch of test doing this.

#### Which issue(s) does the PR fix:

Fixes: #16689

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```
