### PR TITLE
chore(prombench): re-roder checks on nodes to avoid deadlocks start a…

### DIFF
--- a/.github/workflows/prombench.yml
+++ b/.github/workflows/prombench.yml
@@ -38,8 +38,8 @@ jobs:
         uses: docker://prominfra/prombench:master
         with:
           args: >-
-            until make all_nodes_deleted; do echo "waiting for nodepools to be deleted"; sleep 10; done;
             make deploy;
+            until make all_nodes_running; do echo "waiting for nodepools to be created"; sleep 10; done;
       - name: Update status to failure
         if: failure()
         run: >-
@@ -73,8 +73,8 @@ jobs:
         uses: docker://prominfra/prombench:master
         with:
           args: >-
-            until make all_nodes_running; do echo "waiting for nodepools to be created"; sleep 10; done;
             make clean;
+            until make all_nodes_deleted; do echo "waiting for nodepools to be deleted"; sleep 10; done;
       - name: Update status to failure
         if: failure()
         run: >-
@@ -108,10 +108,10 @@ jobs:
         uses: docker://prominfra/prombench:master
         with:
           args: >-
-            until make all_nodes_running; do echo "waiting for nodepools to be created"; sleep 10; done;
             make clean;
             until make all_nodes_deleted; do echo "waiting for nodepools to be deleted"; sleep 10; done;
             make deploy;
+            until make all_nodes_running; do echo "waiting for nodepools to be created"; sleep 10; done;
       - name: Update status to failure
         if: failure()
         run: >-


### PR DESCRIPTION
…nd cancel and in restart

the start job requires the node pools to be gone before creating them, and the cleanup and restart jobs require the pools to be running to delete them, When the initial start is partial (only one pool was created), no command can move forward...

the preconditions should be relaxed, for more robustness.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes

```
