### PR TITLE
[PERF] PromQL: eliminate string-keyed maps in binary vector matching

### DIFF
--- a/promql/info.go
+++ b/promql/info.go
@@ -337,10 +337,10 @@ func (ev *evaluator) combineWithInfoVector(base, info Vector, ignoreSeries map[i
 	}
 
 	// All samples from the info Vector hashed by the matching label/values.
-	if enh.rightSigs == nil {
-		enh.rightSigs = make(map[string]Sample, len(enh.Out))
+	if enh.rightStrSigs == nil {
+		enh.rightStrSigs = make(map[string]Sample, len(enh.Out))
 	} else {
-		clear(enh.rightSigs)
+		clear(enh.rightStrSigs)
 	}
 
 	for i, s := range info {
@@ -351,7 +351,7 @@ func (ev *evaluator) combineWithInfoVector(base, info Vector, ignoreSeries map[i
 		origT := int64(s.F)
 
 		sig := infoSigs[i]
-		if existing, exists := enh.rightSigs[sig]; exists {
+		if existing, exists := enh.rightStrSigs[sig]; exists {
 			// We encode original info sample timestamps via the float value.
 			existingOrigT := int64(existing.F)
 			switch {
@@ -359,14 +359,14 @@ func (ev *evaluator) combineWithInfoVector(base, info Vector, ignoreSeries map[i
 				// Keep the other info sample, since it's newer.
 			case existingOrigT < origT:
 				// Keep this info sample, since it's newer.
-				enh.rightSigs[sig] = s
+				enh.rightStrSigs[sig] = s
 			default:
 				// The two info samples have the same timestamp - conflict.
 				name := s.Metric.Map()[labels.MetricName]
 				ev.errorf("found duplicate series for info metric %s", name)
 			}
 		} else {
-			enh.rightSigs[sig] = s
+			enh.rightStrSigs[sig] = s
 		}
 	}
 
@@ -387,7 +387,7 @@ func (ev *evaluator) combineWithInfoVector(base, info Vector, ignoreSeries map[i
 		// For every info metric name, try to find an info series with the same signature.
 		seenInfoMetrics := map[string]struct{}{}
 		for infoName, sig := range baseSigs[i] {
-			is, exists := enh.rightSigs[sig]
+			is, exists := enh.rightStrSigs[sig]
 			if !exists {
 				continue
 			}


### PR DESCRIPTION
This is the first PR in a series of PromQL join optimizations that I am planning. In this PR, we are eliminating expensive string-keyed (by signature) maps that are accessed for every sample processed. During preprocessing in `rangeEval`, we assign a unique number from 0 to n-1 to each of the n string signature values, and later only use this number as a label set signature.

I am using the new benchmark (https://github.com/prometheus/prometheus/pull/17130) for performance measurements, for the reasons outlined in that PR. Benchmark results:
```
                                                                                                        │ before.txt  │             after.txt              │
                                                                                                        │   sec/op    │   sec/op     vs base                │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total,steps=10000-10                          4.846 ± 2%    3.806 ± 2%  -21.48% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_AND_rpc_request_error_total{instance=~"0.*"},steps=10000-10      993.5m ± 3%   616.6m ± 2%  -37.93% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"},steps=10000-10        2.293 ± 1%    1.477 ± 4%  -35.58% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_UNLESS_rpc_request_error_total{instance=~"0.*"},steps=10000-10    1.764 ± 2%    1.464 ± 2%  -16.98% (p=0.000 n=10)
geomean                                                                                                    2.101         1.501       -28.55%

                                                                                                        │  before.txt   │              after.txt              │
                                                                                                        │     B/op      │     B/op      vs base                │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total,steps=10000-10                          53.93Mi ± 1%   54.44Mi ± 1%   +0.94% (p=0.015 n=10)
JoinQuery/expr=rpc_request_success_total_AND_rpc_request_error_total{instance=~"0.*"},steps=10000-10       79.18Mi ± 0%   38.11Mi ± 1%  -51.87% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"},steps=10000-10       844.45Mi ± 0%   38.47Mi ± 1%  -95.44% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_UNLESS_rpc_request_error_total{instance=~"0.*"},steps=10000-10    79.46Mi ± 1%   38.43Mi ± 1%  -51.64% (p=0.000 n=10)
geomean                                                                                                    130.1Mi        41.85Mi       -67.83%

                                                                                                        │ before.txt  │             after.txt              │
                                                                                                        │  allocs/op  │  allocs/op   vs base                │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total,steps=10000-10                         562.7k ± 0%   562.7k ± 0%        ~ (p=0.075 n=10)
JoinQuery/expr=rpc_request_success_total_AND_rpc_request_error_total{instance=~"0.*"},steps=10000-10      377.6k ± 0%   306.8k ± 0%  -18.75% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"},steps=10000-10       638.9k ± 0%   306.8k ± 0%  -51.97% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_UNLESS_rpc_request_error_total{instance=~"0.*"},steps=10000-10   377.5k ± 0%   306.8k ± 0%  -18.73% (p=0.000 n=10)
geomean                                                                                                   475.8k        357.1k       -24.96%
```

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
