### PR TITLE
[WIP] feat(metrics): add config label to refresh metrics

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -54,6 +54,9 @@ type DiscovererOptions struct {
 	// Extra HTTP client options to expose to Discoverers. This field may be
 	// ignored; Discoverer implementations must opt-in to reading it.
 	HTTPClientOptions []config.HTTPClientOption
+
+	// ConfigName is the config key (setName/job name) used for metrics labeling.
+	ConfigName string
 }
 
 // RefreshMetrics are used by the "refresh" package.
@@ -66,7 +69,7 @@ type RefreshMetrics struct {
 
 // RefreshMetricsInstantiator instantiates the metrics used by the "refresh" package.
 type RefreshMetricsInstantiator interface {
-	Instantiate(mech string) *RefreshMetrics
+	Instantiate(mech, config string) *RefreshMetrics
 }
 
 // RefreshMetricsManager is an interface for registering, unregistering, and

--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -69,7 +69,7 @@ func (*SDConfig) Name() string { return "http" }
 
 // NewDiscoverer returns a Discoverer for the Config.
 func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Discoverer, error) {
-	return NewDiscovery(c, opts.Logger, opts.HTTPClientOptions, opts.Metrics)
+	return NewDiscovery(c, opts.Logger, opts.HTTPClientOptions, opts.Metrics, opts.ConfigName)
 }
 
 // SetDirectory joins any relative file paths with dir.
@@ -115,7 +115,7 @@ type Discovery struct {
 }
 
 // NewDiscovery returns a new HTTP discovery for the given config.
-func NewDiscovery(conf *SDConfig, logger *slog.Logger, clientOpts []config.HTTPClientOption, metrics discovery.DiscovererMetrics) (*Discovery, error) {
+func NewDiscovery(conf *SDConfig, logger *slog.Logger, clientOpts []config.HTTPClientOption, metrics discovery.DiscovererMetrics, configName string) (*Discovery, error) {
 	m, ok := metrics.(*httpMetrics)
 	if !ok {
 		return nil, errors.New("invalid discovery metrics type")
@@ -142,6 +142,7 @@ func NewDiscovery(conf *SDConfig, logger *slog.Logger, clientOpts []config.HTTPC
 		refresh.Options{
 			Logger:              logger,
 			Mech:                "http",
+			Config:              configName,
 			Interval:            time.Duration(conf.RefreshInterval),
 			RefreshF:            d.Refresh,
 			MetricsInstantiator: m.refreshMetrics,

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -479,6 +479,7 @@ func (m *Manager) registerProviders(cfgs Configs, setName string) int {
 			Logger:            m.logger.With("discovery", typ, "config", setName),
 			HTTPClientOptions: m.httpOpts,
 			Metrics:           m.sdMetrics[typ],
+			ConfigName:        setName,
 		})
 		if err != nil {
 			m.logger.Error("Cannot create service discovery", "err", err, "type", typ, "config", setName)

--- a/discovery/metrics_refresh.go
+++ b/discovery/metrics_refresh.go
@@ -36,14 +36,14 @@ func NewRefreshMetrics(reg prometheus.Registerer) RefreshMetricsManager {
 				Name: "prometheus_sd_refresh_failures_total",
 				Help: "Number of refresh failures for the given SD mechanism.",
 			},
-			[]string{"mechanism"}),
+			[]string{"mechanism", "config"}),
 		durationVec: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
 				Name:       "prometheus_sd_refresh_duration_seconds",
 				Help:       "The duration of a refresh in seconds for the given SD mechanism.",
 				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 			},
-			[]string{"mechanism"}),
+			[]string{"mechanism", "config"}),
 	}
 
 	// The reason we register metric vectors instead of metrics is so that
@@ -56,11 +56,12 @@ func NewRefreshMetrics(reg prometheus.Registerer) RefreshMetricsManager {
 	return m
 }
 
-// Instantiate returns metrics out of metric vectors.
-func (m *RefreshMetricsVecs) Instantiate(mech string) *RefreshMetrics {
+// Instantiate returns metrics out of metric vectors for a given mechanism and config.
+func (m *RefreshMetricsVecs) Instantiate(mech, config string) *RefreshMetrics {
+
 	return &RefreshMetrics{
-		Failures: m.failuresVec.WithLabelValues(mech),
-		Duration: m.durationVec.WithLabelValues(mech),
+		Failures: m.failuresVec.WithLabelValues(mech, config),
+		Duration: m.durationVec.WithLabelValues(mech, config),
 	}
 }
 

--- a/discovery/refresh/refresh.go
+++ b/discovery/refresh/refresh.go
@@ -28,6 +28,7 @@ import (
 type Options struct {
 	Logger              *slog.Logger
 	Mech                string
+	Config              string
 	Interval            time.Duration
 	RefreshF            func(ctx context.Context) ([]*targetgroup.Group, error)
 	MetricsInstantiator discovery.RefreshMetricsInstantiator
@@ -43,7 +44,7 @@ type Discovery struct {
 
 // NewDiscovery returns a Discoverer function that calls a refresh() function at every interval.
 func NewDiscovery(opts Options) *Discovery {
-	m := opts.MetricsInstantiator.Instantiate(opts.Mech)
+	m := opts.MetricsInstantiator.Instantiate(opts.Mech, opts.Config)
 
 	var logger *slog.Logger
 	if opts.Logger == nil {

--- a/docs/http_sd.md
+++ b/docs/http_sd.md
@@ -39,8 +39,9 @@ an empty list `[]`. Target lists are unordered.
 
 Prometheus caches target lists. If an error occurs while fetching an updated
 targets list, Prometheus keeps using the current targets list. The targets list
-is not saved across restart. The `prometheus_sd_http_failures_total` counter
-metric tracks the number of refresh failures.
+is not saved across restart. The `prometheus_sd_refresh_failures_total` counter
+metric tracks the number of refresh failures and the `prometheus_sd_refresh_duration_seconds`
+bucket can be used to track HTTP SD refresh attempts or performance.
 
 The whole list of targets must be returned on every scrape. There is no support
 for incremental updates. A Prometheus instance does not send its hostname and it


### PR DESCRIPTION
Adds a `config` label (similar to `prometheus_sd_discovered_targets`) to refresh metrics to help identify the source of refresh issues or performance stats. In particular for HTTP SD, it can be common to have multiple disparate HTTP SD sources that should be identified and not lumped together. For example if one HTTP SD service has failures, that should be evident in its own time series separate from other HTTP SD sources.

`config` seemed more appropriate than `endpoint` as a general standard for `prometheus_sd` metrics.

Docs were also updated for HTTP SD to point at the new refresh metrics rather than the older metrics.

- [ ] TODO: add the config label for each service discovery endpoint

```release-notes
[ENHANCEMENT] adds a `config` label indicating specific jobs for `prometheus_sd_refresh_duration_seconds` and `prometheus_sd_refresh_failures_total` metrics
```
