### PR TITLE
FastRegex: Skip simplify step if it makes the regexp a lot longer 

### DIFF
--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -218,13 +218,32 @@ func BenchmarkMatchType_String(b *testing.B) {
 }
 
 func BenchmarkNewMatcher(b *testing.B) {
-	b.Run("regex matcher with literal", func(b *testing.B) {
-		b.ReportAllocs()
-		b.ResetTimer()
-		for i := 0; i <= b.N; i++ {
-			NewMatcher(MatchRegexp, "foo", "bar")
-		}
-	})
+	type benchCase struct {
+		name string
+		t    MatchType
+		v    string
+	}
+	cases := []benchCase{
+		{
+			name: "regex matcher with literal",
+			t:    MatchRegexp,
+			v:    "bar",
+		},
+		{
+			name: "complicated regex",
+			t:    MatchRegexp,
+			v:    "(a||b){1000}",
+		},
+	}
+	for _, bc := range cases {
+		b.Run(bc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i <= b.N; i++ {
+				NewMatcher(bc.t, "foo", bc.v)
+			}
+		})
+	}
 }
 
 func BenchmarkMatcher_String(b *testing.B) {

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -69,7 +69,12 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 		}
 		// Simplify the syntax tree to run faster.
 		parsed = parsed.Simplify()
-		m.re, err = regexp.Compile("^(?s:" + parsed.String() + ")$")
+		simplifiedString := parsed.String()
+		if len(simplifiedString) > len(v)+1024 {
+			// Simplified string got a lot longer; it's probably not something we handle well. Use the original version.
+			simplifiedString = v
+		}
+		m.re, err = regexp.Compile("^(?s:" + simplifiedString + ")$")
 		if err != nil {
 			return nil, err
 		}

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -60,6 +60,7 @@ var (
 		"10\\.0\\.(1|2)\\.+",
 		"10\\.0\\.(1|2).+",
 		"((fo(bar))|.+foo)",
+		"(a||b){1000}",
 		// A long case sensitive alternation.
 		"zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKMimS|IecrXtPa|seTckYqt|NxnyHkgB|fIDlOgKb|UhlWIygH|OtNoJxHG|cUTkFVIV|mTgFIHjr|jQkoIDtE|PPMKxRXl|AwMfwVkQ|CQyMrTQJ|BzrqxVSi|nTpcWuhF|PertdywG|ZZDgCtXN|WWdDPyyE|uVtNQsKk|BdeCHvPZ|wshRnFlH|aOUIitIp|RxZeCdXT|CFZMslCj|AVBZRDxl|IzIGCnhw|ythYuWiz|oztXVXhl|VbLkwqQx|qvaUgyVC|VawUjPWC|ecloYJuj|boCLTdSU|uPrKeAZx|hrMWLWBq|JOnUNHRM|rYnujkPq|dDEdZhIj|DRrfvugG|yEGfDxVV|YMYdJWuP|PHUQZNWM|AmKNrLis|zTxndVfn|FPsHoJnc|EIulZTua|KlAPhdzg|ScHJJCLt|NtTfMzME|eMCwuFdo|SEpJVJbR|cdhXZeCx|sAVtBwRh|kVFEVcMI|jzJrxraA|tGLHTell|NNWoeSaw|DcOKSetX|UXZAJyka|THpMphDP|rizheevl|kDCBRidd|pCZZRqyu|pSygkitl|SwZGkAaW|wILOrfNX|QkwVOerj|kHOMxPDr|EwOVycJv|AJvtzQFS|yEOjKYYB|LizIINLL|JBRSsfcG|YPiUqqNl|IsdEbvee|MjEpGcBm|OxXZVgEQ|xClXGuxa|UzRCGFEb|buJbvfvA|IPZQxRet|oFYShsMc|oBHffuHO|bzzKrcBR|KAjzrGCl|IPUsAVls|OGMUMbIU|gyDccHuR|bjlalnDd|ZLWjeMna|fdsuIlxQ|dVXtiomV|XxedTjNg|XWMHlNoA|nnyqArQX|opfkWGhb|wYtnhdYb",
 		// An extremely long case sensitive alternation. This is a special


### PR DESCRIPTION
I noticed that in some cases the preparation to optimise a regexp in `FastRegexMatcher` can get costly.
This adds a small check to see if the `Simplify` step has made the regexp a lot longer, in which case we will scan the original string.

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Intel(R) Core(TM) i7-14700K
                                         │    before    │               after                │
                                         │    sec/op    │   sec/op     vs base               │
NewMatcher/regex_matcher_with_literal-28    78.73n ± 0%   78.71n ± 1%        ~ (p=0.937 n=6)
NewMatcher/complicated_regex-28            1226.3µ ± 2%   457.0µ ± 4%  -62.73% (p=0.002 n=6)
FastRegexMatcher/(a||b){1000}-28            480.1µ ± 2%   471.2µ ± 1%   -1.85% (p=0.009 n=6)
geomean                                     35.92µ        25.69µ       -28.49%

                                         │    before    │                  after                  │
                                         │     B/op     │      B/op       vs base                 │
NewMatcher/regex_matcher_with_literal-28     240.0 ± 0%     240.0 ±   0%        ~ (p=1.000 n=6) ¹
NewMatcher/complicated_regex-28            2.965Mi ± 0%   1.833Mi ±   0%  -38.19% (p=0.002 n=6)
FastRegexMatcher/(a||b){1000}-28           14706.5 ± 9%     325.5 ± 100%  -97.79% (p=0.002 n=6)
geomean                                    21.70Ki        5.190Ki         -76.08%
¹ all samples are equal

                                         │   before    │                after                │
                                         │  allocs/op  │ allocs/op   vs base                 │
NewMatcher/regex_matcher_with_literal-28    5.000 ± 0%   5.000 ± 0%        ~ (p=1.000 n=6) ¹
NewMatcher/complicated_regex-28            9170.0 ± 0%   122.0 ± 0%  -98.67% (p=0.002 n=6)
FastRegexMatcher/(a||b){1000}-28            1.000 ± 0%   1.000 ±  ?        ~ (p=0.455 n=6)
geomean                                     35.79        8.481       -76.30%
¹ all samples are equal
```