### PR TITLE
[PERF] PromQL: memoize metric hashes for VectorAnd/Or/Unless

### DIFF
--- a/promql/info.go
+++ b/promql/info.go
@@ -273,8 +273,8 @@ func (ev *evaluator) combineWithInfoSeries(ctx context.Context, mat, infoMat Mat
 		// Reset number of samples in memory after each timestamp.
 		ev.currentSamples = tempNumSamples
 		// Gather input vectors for this timestamp.
-		baseVector, _ = ev.gatherVector(ts, mat, baseVector, nil, nil, nil)
-		infoVector, _ = ev.gatherVector(ts, infoMat, infoVector, nil, nil, nil)
+		baseVector, _ = ev.gatherVector(ts, mat, baseVector, EvalSeriesHelpers{}, nil)
+		infoVector, _ = ev.gatherVector(ts, infoMat, infoVector, EvalSeriesHelpers{}, nil)
 
 		enh.Ts = ts
 		result, err := ev.combineWithInfoVector(baseVector, infoVector, ignoreSeries, baseSigs, infoSigs, enh, dataLabelMatchers)


### PR DESCRIPTION
This is the third PR in a series of PromQL join optimizations that I am planning. It depends on https://github.com/prometheus/prometheus/pull/17142, please review that first.

The original implementation is recomputing result metric hashes on every step, which is quite expensive as it is done for each datapoint. With this change, we are lazily memoizing (computing only once, and only for the series where they are needed) the hash values of input metrics and then using them to build the result matrix in VectorAnd/Or/Unless (as these binary operators do not modify metric label sets).

Benchmark results (relative to #17142):
```
                                                                                                                │  after2.txt  │             after3.txt              │
                                                                                                                │    sec/op    │   sec/op     vs base                │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total,steps=10000-10                                   3.641 ± 7%    3.512 ± 3%   -3.54% (p=0.023 n=10)
JoinQuery/expr=rpc_request_success_total_+_ON_(job,_instance)_GROUP_LEFT_rpc_request_error_total,steps=10000-10     4.127 ± 4%    4.010 ± 3%        ~ (p=0.247 n=10)
JoinQuery/expr=rpc_request_success_total_AND_rpc_request_error_total{instance=~"0.*"},steps=10000-10               598.3m ± 1%   593.1m ± 3%        ~ (p=0.123 n=10)
JoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"},steps=10000-10                 1.502 ± 8%    1.051 ± 3%  -30.03% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_UNLESS_rpc_request_error_total{instance=~"0.*"},steps=10000-10           1453.3m ± 1%   987.5m ± 2%  -32.05% (p=0.000 n=10)
geomean                                                                                                             1.814         1.540       -15.07%

                                                                                                                │  after2.txt  │             after3.txt              │
                                                                                                                │     B/op     │     B/op      vs base               │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total,steps=10000-10                                 54.49Mi ± 1%   54.53Mi ± 1%       ~ (p=0.218 n=10)
JoinQuery/expr=rpc_request_success_total_+_ON_(job,_instance)_GROUP_LEFT_rpc_request_error_total,steps=10000-10   1.245Gi ± 0%   1.245Gi ± 0%       ~ (p=0.739 n=10)
JoinQuery/expr=rpc_request_success_total_AND_rpc_request_error_total{instance=~"0.*"},steps=10000-10              38.27Mi ± 1%   38.18Mi ± 1%  -0.22% (p=0.029 n=10)
JoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"},steps=10000-10               38.65Mi ± 1%   38.58Mi ± 1%       ~ (p=0.393 n=10)
JoinQuery/expr=rpc_request_success_total_UNLESS_rpc_request_error_total{instance=~"0.*"},steps=10000-10           38.36Mi ± 1%   38.28Mi ± 1%       ~ (p=0.280 n=10)
geomean                                                                                                           83.01Mi        82.92Mi       -0.11%

                                                                                                                │ after2.txt  │             after3.txt             │
                                                                                                                │  allocs/op  │  allocs/op   vs base               │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total,steps=10000-10                                 562.8k ± 0%   562.8k ± 0%       ~ (p=0.698 n=10)
JoinQuery/expr=rpc_request_success_total_+_ON_(job,_instance)_GROUP_LEFT_rpc_request_error_total,steps=10000-10   20.57M ± 0%   20.57M ± 0%       ~ (p=0.078 n=10)
JoinQuery/expr=rpc_request_success_total_AND_rpc_request_error_total{instance=~"0.*"},steps=10000-10              308.6k ± 0%   307.5k ± 0%  -0.36% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"},steps=10000-10               308.6k ± 0%   307.5k ± 0%  -0.37% (p=0.001 n=10)
JoinQuery/expr=rpc_request_success_total_UNLESS_rpc_request_error_total{instance=~"0.*"},steps=10000-10           308.6k ± 0%   307.5k ± 0%  -0.37% (p=0.000 n=10)
geomean                                                                                                           806.1k        804.3k       -0.22%

```

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
