### PR TITLE
[ENHANCEMENT] AWS SD: Add optional external_id field

### DIFF
--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -93,6 +93,7 @@ type EC2SDConfig struct {
 	SecretKey       config.Secret  `yaml:"secret_key,omitempty"`
 	Profile         string         `yaml:"profile,omitempty"`
 	RoleARN         string         `yaml:"role_arn,omitempty"`
+	ExternalID      string         `yaml:"external_id,omitempty"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
 	Port            int            `yaml:"port"`
 	Filters         []*EC2Filter   `yaml:"filters"`
@@ -219,7 +220,11 @@ func (d *EC2Discovery) ec2Client(ctx context.Context) (ec2Client, error) {
 
 	// If the role ARN is set, assume the role to get credentials and set the credentials provider in the config.
 	if d.cfg.RoleARN != "" {
-		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN)
+		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN, func(o *stscreds.AssumeRoleOptions) {
+			if d.cfg.ExternalID != "" {
+				o.ExternalID = aws.String(d.cfg.ExternalID)
+			}
+		})
 		cfg.Credentials = aws.NewCredentialsCache(assumeProvider)
 	}
 

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -76,6 +76,7 @@ type LightsailSDConfig struct {
 	SecretKey       config.Secret  `yaml:"secret_key,omitempty"`
 	Profile         string         `yaml:"profile,omitempty"`
 	RoleARN         string         `yaml:"role_arn,omitempty"`
+	ExternalID      string         `yaml:"external_id,omitempty"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
 	Port            int            `yaml:"port"`
 
@@ -183,7 +184,11 @@ func (d *LightsailDiscovery) lightsailClient(ctx context.Context) (*lightsail.Cl
 
 	// If the role ARN is set, assume the role to get credentials and set the credentials provider in the config.
 	if d.cfg.RoleARN != "" {
-		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN)
+		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN, func(o *stscreds.AssumeRoleOptions) {
+			if d.cfg.ExternalID != "" {
+				o.ExternalID = aws.String(d.cfg.ExternalID)
+			}
+		})
 		cfg.Credentials = aws.NewCredentialsCache(assumeProvider)
 	}
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1208,6 +1208,9 @@ See below for the configuration options for EC2 discovery:
 # AWS Role ARN, an alternative to using AWS API keys.
 [ role_arn: <string> ]
 
+# Optional External ID that can go along with role_arn.
+[ external_id: <string> ]
+
 # Refresh interval to re-read the instance list.
 [ refresh_interval: <duration> | default = 60s ]
 
@@ -2067,6 +2070,9 @@ See below for the configuration options for Lightsail discovery:
 
 # AWS Role ARN, an alternative to using AWS API keys.
 [ role_arn: <string> ]
+
+# Optional External ID that can go along with role_arn.
+[ external_id: <string> ]
 
 # Refresh interval to re-read the instance list.
 [ refresh_interval: <duration> | default = 60s ]


### PR DESCRIPTION
AWS recommends that roles use an external ID to avoid accidentally granting access to the wrong account.

#### Which issue(s) does the PR fix:
Fixes #16314

Note it does not cover alertmanager or remote-write, for which I raised https://github.com/prometheus/sigv4/issues/46.

#### Does this PR introduce a user-facing change?
```release-notes
[ENHANCEMENT] AWS Service Discovery: Add optional `external_id` field.
```

PS: Someone else needs to test this; I have no expectation of using it. Just that by the time I'd finished understanding the issue detail I was ready to type in the code.