### PR TITLE
tsdb: add per-series rate limit for OOO head-chunk creation

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -158,6 +158,8 @@ type HeadOptions struct {
 
 	OutOfOrderTimeWindow atomic.Int64
 	OutOfOrderCapMax     atomic.Int64
+	// Minimum wall-clock interval between OOO head chunk creations per series. 0 disables rate limiting.
+	OutOfOrderOOOChunkMinIntervalMillis atomic.Int64
 
 	// EnableNativeHistograms enables the ingestion of native histograms.
 	EnableNativeHistograms atomic.Bool
@@ -2215,6 +2217,7 @@ type memSeriesOOOFields struct {
 	oooMmappedChunks []*mmappedChunk    // Immutable chunks on disk containing OOO samples.
 	oooHeadChunk     *oooHeadChunk      // Most recent chunk for ooo samples in memory that's still being built.
 	firstOOOChunkID  chunks.HeadChunkID // HeadOOOChunkID for oooMmappedChunks[0].
+	lastOOOChunkCutAtUnixMilli int64    // Wall-clock time in ms when we last cut an OOO head chunk (rate limiting).
 }
 
 func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, shardHash uint64, isolationDisabled, pendingCommit bool) *memSeries {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2214,10 +2214,10 @@ type memSeries struct {
 // memSeriesOOOFields contains the fields required by memSeries
 // to handle out-of-order data.
 type memSeriesOOOFields struct {
-	oooMmappedChunks []*mmappedChunk    // Immutable chunks on disk containing OOO samples.
-	oooHeadChunk     *oooHeadChunk      // Most recent chunk for ooo samples in memory that's still being built.
-	firstOOOChunkID  chunks.HeadChunkID // HeadOOOChunkID for oooMmappedChunks[0].
-	lastOOOChunkCutAtUnixMilli int64    // Wall-clock time in ms when we last cut an OOO head chunk (rate limiting).
+	oooMmappedChunks           []*mmappedChunk    // Immutable chunks on disk containing OOO samples.
+	oooHeadChunk               *oooHeadChunk      // Most recent chunk for ooo samples in memory that's still being built.
+	firstOOOChunkID            chunks.HeadChunkID // HeadOOOChunkID for oooMmappedChunks[0].
+	lastOOOChunkCutAtUnixMilli int64              // Wall-clock time in ms when we last cut an OOO head chunk (rate limiting).
 }
 
 func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, shardHash uint64, isolationDisabled, pendingCommit bool) *memSeries {

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -387,7 +387,7 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 			return 0, storage.ErrOutOfOrderSample
 		}
 		if err := a.enforceOOOHeadChunkRateLimitLocked(s, isOOO); err != nil {
-		return 0, err
+			return 0, err
 		}
 		s.pendingCommit = true
 	}
@@ -700,13 +700,12 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 		// to skip that sample from the WAL and write only in the WBL.
 		isOOO, delta, err := s.appendableHistogram(t, h, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err == nil {
-		if err2 := a.enforceOOOHeadChunkRateLimitLocked(s, isOOO); err2 != nil {
-		s.Unlock()
-		return 0, ErrOOOChunkRateLimited
+			if err2 := a.enforceOOOHeadChunkRateLimitLocked(s, isOOO); err2 != nil {
+				s.Unlock()
+				return 0, ErrOOOChunkRateLimited
+			}
+			s.pendingCommit = true
 		}
-		s.pendingCommit = true
-		}
-		
 		s.Unlock()
 		if delta > 0 {
 			a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
@@ -740,13 +739,12 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 		// to skip that sample from the WAL and write only in the WBL.
 		isOOO, delta, err := s.appendableFloatHistogram(t, fh, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err == nil {
-		if err2 := a.enforceOOOHeadChunkRateLimitLocked(s, isOOO); err2 != nil {
-		s.Unlock()
-		return 0, ErrOOOChunkRateLimited
+			if err2 := a.enforceOOOHeadChunkRateLimitLocked(s, isOOO); err2 != nil {
+				s.Unlock()
+				return 0, ErrOOOChunkRateLimited
+			}
+			s.pendingCommit = true
 		}
-		s.pendingCommit = true
-		}
-		
 		s.Unlock()
 		if delta > 0 {
 			a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #17165.

#### Does this PR introduce a user-facing change?
Yes. Adds an optional HeadOptions field to rate-limit per-series OOO head-chunk creation and returns a specific error when exceeded. Default is disabled.

```release-notes
[ENHANCEMENT] tsdb: Add optional per-series rate limit on out-of-order head-chunk creation controlled by HeadOptions.OutOfOrderOOOChunkMinIntervalMillis (0=disabled, default). If a new OOO head chunk would be cut before the configured interval elapses, Append returns ErrOOOChunkRateLimited. Default behavior is unchanged unless explicitly enabled.
```

#### Title
tsdb: add per-series rate limit for OOO head-chunk creation

#### Description
**Problem**

The OOO (out-of-order) path is intended for a small number of late samples. In misconfigurations (e.g., label collisions), thousands of OOO samples per series can arrive, causing the TSDB to cut many small OOO chunks, increasing CPU and memory overhead.

**Approach**

Cap the effective OOO sample rate per series by enforcing a minimum wall-clock interval between OOO head-chunk creations. Since each OOO head chunk holds up to `OutOfOrderCapMax` samples (default 32), limiting chunk creation frequency bounds the OOO sample rate.

The check runs before any WAL/WBL writes in the append path and only when a new OOO head chunk would be cut. If the interval hasn’t elapsed, append fails immediately with a specific error. This makes misconfigurations visible and avoids the extra cost.

**Changes**

- Add `HeadOptions.OutOfOrderOOOChunkMinIntervalMillis (int64)`:
  - `0` disables rate limiting (default = `0`). No behavior change unless explicitly enabled.
- Track last OOO head-chunk cut time per series:
  - `memSeriesOOOFields.lastOOOChunkCutAtUnixMilli` stores the wall-clock time in ms when an OOO head chunk is created.
- Enforce rate limiting in the append path:
  - For float, native histogram, and float histogram samples:
    - If the sample is determined to be OOO and a new OOO head chunk would be required (no current OOO head chunk or its sample count reached `OutOfOrderCapMax`), reject when `(now - lastCut) < OutOfOrderOOOChunkMinIntervalMillis`, before WAL/WBL writes.
    - Return a new error: `ErrOOOChunkRateLimited`.
  - Stamp the last cut time when actually cutting a new OOO head chunk.

**Notes**

- Default behavior is unchanged (feature off by default).
- The check is cheap and localized: done under the existing series lock and only when a new OOO head chunk would be cut.
- Error handling is early (during `Append`), addressing concerns about reporting only at `Commit` time.

#### Testing
- Package tests pass locally (tsdb and subpackages).
- Unit tests to add before marking ready for review:
  - Float: accept OOO samples into a single OOO head chunk up to `OutOfOrderCapMax`; immediately next OOO sample is rate-limited; accept after waiting `>= min interval`.
  - Native histogram and float histogram variants of the above.
  - Disabled path (`interval=0`) preserves current behavior.

#### Follow-ups
- Wire `OutOfOrderOOOChunkMinIntervalMillis` into TSDB YAML config.
- Consider a metric for rate-limited OOO samples.

#### DCO
Commits will be signed off per DCO. Please ensure you sign commits with `-s` / `--signoff` when committing, for example:

```bash
git commit -s -m "tsdb: add per-series rate limit for OOO head-chunk creation

Fixes #17165

(brief commit body)"
```

Signed-off-by: *Shivang Agrahari* <shivangagraharijee2023@gmail.com>

<!--
Checklist for PR author (not part of the human-visible changelog):
- [ ] Title follows "area: short description".
- [ ] Add unit/e2e tests for exported API behavior changes.
- [ ] Use only exported APIs in tests where possible.
- [ ] Add benchmark if this is a performance improvement.
- [ ] Ensure all exposed objects have comments.
- [ ] Ensure comments start with a capital letter and end with a full stop.
-->
