### PR TITLE
docs(): fix gettingStarted outdated graph reference

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -79,7 +79,7 @@ navigating to its metrics endpoint:
 
 Let us explore data that Prometheus has collected about itself. To
 use Prometheus's built-in expression browser, navigate to
-http://localhost:9090/graph and choose the "Table" view within the "Graph" tab.
+http://localhost:9090/query and choose the "Graph" tab.
 
 As you can gather from [localhost:9090/metrics](http://localhost:9090/metrics),
 one metric that Prometheus exports about itself is named
@@ -113,7 +113,7 @@ For more about the expression language, see the
 
 ## Using the graphing interface
 
-To graph expressions, navigate to http://localhost:9090/graph and use the "Graph"
+To graph expressions, navigate to http://localhost:9090/query and use the "Graph"
 tab.
 
 For example, enter the following expression to graph the per-second rate of chunks


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
* "/graph" does NOT exist anymore in the new React app. It has been refactored by "/query" 

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```

#### How to review?
* using

```yml
global:
  scrape_interval:     15s # By default, scrape targets every 15 seconds.

  # Attach these labels to any time series or alerts when communicating with
  # external systems (federation, remote storage, Alertmanager).
  external_labels:
    monitor: 'codelab-monitor'

# A scrape configuration containing exactly one endpoint to scrape:
# Here it's Prometheus itself.
scrape_configs:
  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
  - job_name: 'prometheus'

    # Override the global default and scrape targets from this job every 5 seconds.
    scrape_interval: 5s

    static_configs:
      - targets: ['localhost:9090']
```

* on this path, `prometheus --config.file=prometheus.yml`
* on [this path](https://github.com/prometheus/prometheus/tree/main/web/ui), npm run start
* in the browser,
  * http://localhost:5173/query, exists & you can click in graph tab 
  * http://localhost:5173/graph, does NOT exist 
