### PR TITLE
OTLP: Upgrade prometheus/otlptranslator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -207,7 +207,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/otlptranslator v0.0.2
+	github.com/prometheus/otlptranslator v0.0.3-0.20250908172306-7f02967de014
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,8 @@ github.com/prometheus/common/assets v0.2.0 h1:0P5OrzoHrYBOSM1OigWL3mY8ZvV2N4zIE/
 github.com/prometheus/common/assets v0.2.0/go.mod h1:D17UVUE12bHbim7HzwUvtqm6gwBEaDQ0F+hIGbFbccI=
 github.com/prometheus/exporter-toolkit v0.14.0 h1:NMlswfibpcZZ+H0sZBiTjrA3/aBFHkNZqE+iCj5EmRg=
 github.com/prometheus/exporter-toolkit v0.14.0/go.mod h1:Gu5LnVvt7Nr/oqTBUC23WILZepW0nffNo10XdhQcwWA=
-github.com/prometheus/otlptranslator v0.0.2 h1:+1CdeLVrRQ6Psmhnobldo0kTp96Rj80DRXRd5OSnMEQ=
-github.com/prometheus/otlptranslator v0.0.2/go.mod h1:P8AwMgdD7XEr6QRUJ2QWLpiAZTgTE2UYgjlu3svompI=
+github.com/prometheus/otlptranslator v0.0.3-0.20250908172306-7f02967de014 h1:Un8kCOZQWmfy9CwtGU4vd4B6qnXF3Sc54f48q54xQjs=
+github.com/prometheus/otlptranslator v0.0.3-0.20250908172306-7f02967de014/go.mod h1:P8AwMgdD7XEr6QRUJ2QWLpiAZTgTE2UYgjlu3svompI=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper.go
@@ -88,7 +88,11 @@ func (c *PrometheusConverter) createAttributes(resource pcommon.Resource, attrib
 	c.scratchBuilder.Sort()
 	sortedLabels := c.scratchBuilder.Labels()
 
-	labelNamer := otlptranslator.LabelNamer{UTF8Allowed: settings.AllowUTF8}
+	labelNamer := otlptranslator.LabelNamer{
+		UTF8Allowed:                 settings.AllowUTF8,
+		UnderscoreLabelSanitization: settings.LabelNameUnderscoreLabelSanitization,
+		PreserveMultipleUnderscores: settings.LabelNamePreserveMultipleUnderscores,
+	}
 
 	if settings.AllowUTF8 {
 		// UTF8 is allowed, so conflicts aren't possible.

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -54,6 +54,12 @@ type Settings struct {
 	// PromoteScopeMetadata controls whether to promote OTel scope metadata to metric labels.
 	PromoteScopeMetadata    bool
 	EnableTypeAndUnitLabels bool
+	// LabelNameUnderscoreLabelSanitization controls whether to enable prepending of 'key' to labels
+	// starting with '_'. Reserved labels starting with `__` are not modified.
+	LabelNameUnderscoreLabelSanitization bool
+	// LabelNamePreserveMultipleUnderscores enables preserving of multiple
+	// consecutive underscores in label names when AllowUTF8 is false.
+	LabelNamePreserveMultipleUnderscores bool
 }
 
 // PrometheusConverter converts from OTel write format to Prometheus remote write format.


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

The upgrade to prometheus/otlptranslator@[7f02967de014](https://github.com/prometheus/otlptranslator/tree/7f02967de0146dd86e31cd706fabe9081f22b2de) fixes two label name translation bugs, _when in legacy name anslation mode_:

    * 'key' is no longer prefixed when label names start with an underscore

    * Multiple consecutive underscores are combined into one


TODO: Introduce configuration parameters for the new label name translation modes, since they have the potential of relabeling time series. Agreed w/ @ywwg and @ArthurSens.
#### Does this PR introduce a user-facing change?

```
[BUGFIX] OTLP: When in legacy name translation mode, 'key' is no longer prefixed when label names start with an underscore.
[BUGFIX] OTLP: When in legacy name translation mode, multiple consecutive underscores are combined into one.
```