### PR TITLE
[PERF] Regex: stop calling Simplify

### DIFF
--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -225,6 +225,13 @@ func BenchmarkNewMatcher(b *testing.B) {
 			NewMatcher(MatchRegexp, "foo", "bar")
 		}
 	})
+	b.Run("complex regex", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i <= b.N; i++ {
+			NewMatcher(MatchRegexp, "foo", "((.*)(bar|b|buzz)(.+)|foo){10}")
+		}
+	})
 }
 
 func BenchmarkMatcher_String(b *testing.B) {

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -67,8 +67,6 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Simplify the syntax tree to run faster.
-		parsed = parsed.Simplify()
 		m.re, err = regexp.Compile("^(?s:" + parsed.String() + ")$")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
It slows down compilation and doesn't make any of our benchmarks go faster. Assumed to be something that helped at an earlier point, but doesn't help now.

Add a benchmark with a more complicated regex to demonstrate the slowdown.

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```

Benchmarks (+- 5% assumed to be random variation on my workstation)
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Intel(R) Core(TM) i7-14700K
                                                        │  base.txt   │            nosimplify.txt            │
                                                        │   sec/op    │    sec/op      vs base               │
FastRegexMatcher/#00-28                                   30.73n ± 1%    30.63n ±  0%        ~ (p=0.069 n=6)
FastRegexMatcher/foo-28                                   36.59n ± 2%    36.73n ±  0%        ~ (p=0.071 n=6)
FastRegexMatcher/^foo-28                                  44.57n ± 1%    44.17n ±  1%   -0.90% (p=0.013 n=6)
FastRegexMatcher/(foo|bar)-28                             52.34n ± 2%    52.24n ±  2%        ~ (p=0.589 n=6)
FastRegexMatcher/foo.*-28                                 77.53n ± 1%    79.17n ±  2%   +2.11% (p=0.004 n=6)
FastRegexMatcher/.*foo-28                                 92.40n ± 2%    96.39n ±  2%   +4.31% (p=0.002 n=6)
FastRegexMatcher/^.*foo$-28                               91.66n ± 2%    94.48n ±  2%   +3.08% (p=0.004 n=6)
FastRegexMatcher/^.+foo$-28                               91.05n ± 2%    95.70n ±  3%   +5.11% (p=0.004 n=6)
FastRegexMatcher/.?-28                                    50.30n ± 1%    50.76n ±  2%   +0.92% (p=0.006 n=6)
FastRegexMatcher/.*-28                                    30.85n ± 1%    30.77n ±  1%        ~ (p=0.223 n=6)
FastRegexMatcher/.+-28                                    34.54n ± 1%    34.54n ±  1%        ~ (p=1.000 n=6)
FastRegexMatcher/foo.+-28                                 81.93n ± 1%    81.64n ±  1%        ~ (p=0.589 n=6)
FastRegexMatcher/.+foo-28                                 97.58n ± 1%    97.76n ±  2%        ~ (p=0.310 n=6)
FastRegexMatcher/foo_.+-28                                74.80n ± 2%    76.19n ±  1%   +1.84% (p=0.015 n=6)
FastRegexMatcher/foo_.*-28                                74.90n ± 1%    72.06n ±  2%   -3.78% (p=0.002 n=6)
FastRegexMatcher/.*foo.*-28                               139.2n ± 1%    139.7n ±  0%        ~ (p=0.329 n=6)
FastRegexMatcher/.+foo.+-28                               150.8n ± 0%    150.8n ±  0%        ~ (p=0.690 n=6)
FastRegexMatcher/(?s:.*)-28                               30.86n ± 1%    30.76n ±  1%        ~ (p=0.093 n=6)
FastRegexMatcher/(?s:.+)-28                               34.56n ± 0%    34.53n ±  1%        ~ (p=0.511 n=6)
FastRegexMatcher/(?s:^.*foo$)-28                          97.34n ± 1%    97.23n ±  2%        ~ (p=0.937 n=6)
FastRegexMatcher/(?i:foo)-28                              64.21n ± 1%    64.22n ±  0%        ~ (p=0.900 n=6)
FastRegexMatcher/(?i:(foo|bar))-28                        154.8n ± 1%    146.5n ±  0%   -5.42% (p=0.002 n=6)
FastRegexMatcher/(?i:(foo1|foo2|bar))-28                  241.5n ± 0%    243.2n ±  0%   +0.70% (p=0.002 n=6)
FastRegexMatcher/^(?i:foo|oo)|(bar)$-28                   546.2n ± 1%    537.6n ±  1%   -1.57% (p=0.002 n=6)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-28      484.2n ± 4%    481.9n ±  3%        ~ (p=0.699 n=6)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-28           351.5n ± 1%    354.5n ±  0%   +0.87% (p=0.002 n=6)
FastRegexMatcher/^$-28                                    30.80n ± 1%    30.81n ±  0%        ~ (p=0.963 n=6)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-28       113.5n ± 0%    114.2n ±  1%        ~ (p=0.087 n=6)
FastRegexMatcher/10\.0\.(1|2)\.+-28                       75.30n ± 2%    75.65n ±  1%        ~ (p=0.180 n=6)
FastRegexMatcher/10\.0\.(1|2).+-28                        75.30n ± 2%    74.80n ±  1%        ~ (p=0.589 n=6)
FastRegexMatcher/((fo(bar))|.+foo)-28                     194.1n ± 0%    194.5n ±  0%        ~ (p=0.169 n=6)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-28      126.0n ± 6%    121.6n ± 19%        ~ (p=0.485 n=6)
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-28      121.4n ± 7%    120.2n ± 11%        ~ (p=0.848 n=6)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-28      489.2n ± 2%    489.1n ±  4%        ~ (p=0.970 n=6)
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-28      292.2n ± 0%    284.2n ±  0%   -2.75% (p=0.002 n=6)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-28      202.4n ± 0%    191.3n ±  0%   -5.48% (p=0.002 n=6)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-28   335.8n ± 0%    327.3n ±  1%   -2.52% (p=0.002 n=6)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-28      5.455µ ± 0%    5.449µ ±  0%        ~ (p=0.738 n=6)
FastRegexMatcher/fo.?-28                                  82.63n ± 4%    80.80n ±  0%        ~ (p=0.180 n=6)
FastRegexMatcher/foo.?-28                                 82.16n ± 1%    82.16n ±  1%        ~ (p=0.589 n=6)
FastRegexMatcher/f.?o-28                                  82.73n ± 0%    82.45n ±  0%        ~ (p=0.071 n=6)
FastRegexMatcher/.*foo.?-28                               150.5n ± 1%    151.7n ±  1%        ~ (p=0.123 n=6)
FastRegexMatcher/.?foo.+-28                               144.8n ± 0%    147.0n ±  0%   +1.48% (p=0.002 n=6)
FastRegexMatcher/foo.?|bar-28                             140.5n ± 1%    140.8n ±  1%        ~ (p=0.333 n=6)
FastRegexMatcher/ſſs-28                                   36.37n ± 0%    36.35n ±  2%        ~ (p=0.848 n=6)
FastRegexMatcher/.*-.*-.*-.*-.*-28                        118.4n ± 1%    118.2n ±  1%        ~ (p=0.900 n=6)
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-28              120.6n ± 1%    118.9n ±  2%        ~ (p=0.093 n=6)
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-28      2.767µ ± 1%    2.782µ ± 11%   +0.52% (p=0.026 n=6)
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-28      2.245µ ± 1%    2.248µ ±  4%        ~ (p=0.485 n=6)
NewMatcher/regex_matcher_with_literal-28                  98.98n ± 2%   100.45n ±  0%   +1.49% (p=0.002 n=6)
NewMatcher/complex_regex-28                               39.56µ ± 1%    23.78µ ±  5%  -39.88% (p=0.002 n=6)
geomean                                                   137.7n         136.1n         -1.17%
```