### PR TITLE
Native histograms: reduce resolution as needed when reading from chunk or remote read

### DIFF
--- a/model/histogram/generic.go
+++ b/model/histogram/generic.go
@@ -45,10 +45,15 @@ var (
 	ErrHistogramCustomBucketsNegBuckets = errors.New("custom buckets: must not have negative buckets")
 	ErrHistogramExpSchemaCustomBounds   = errors.New("histogram with exponential schema must not have custom bounds")
 	ErrHistogramsInvalidSchema          = fmt.Errorf("histogram has an invalid schema, which must be between %d and %d for exponential buckets, or %d for custom buckets", ExponentialSchemaMin, ExponentialSchemaMax, CustomBucketsSchema)
+	ErrHistogramsUnknownSchema          = fmt.Errorf("histogram has an unknown schema, which must be between %d and %d for exponential buckets, or %d for custom buckets", ExponentialSchemaMinReserved, ExponentialSchemaMaxReserved, CustomBucketsSchema)
 )
 
 func InvalidSchemaError(s int32) error {
 	return fmt.Errorf("%w, got schema %d", ErrHistogramsInvalidSchema, s)
+}
+
+func UnknownSchemaError(s int32) error {
+	return fmt.Errorf("%w, got schema %d", ErrHistogramsUnknownSchema, s)
 }
 
 func IsCustomBucketsSchema(s int32) bool {
@@ -65,6 +70,12 @@ func IsExponentialSchemaReserved(s int32) bool {
 
 func IsValidSchema(s int32) bool {
 	return IsCustomBucketsSchema(s) || IsExponentialSchema(s)
+}
+
+// IsKnownSchema returns bool if we known and accept the schema, but need to
+// reduce resolution to the nearest supported schema.
+func IsKnownSchema(s int32) bool {
+	return IsCustomBucketsSchema(s) || IsExponentialSchemaReserved(s)
 }
 
 // BucketCount is a type constraint for the count in a bucket, which can be

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -472,10 +472,10 @@ func (c *concreteSeriesIterator) Seek(t int64) chunkenc.ValueType {
 }
 
 func validateHistogramSchema(h *prompb.Histogram) error {
-	if histogram.IsAcceptibleSchema(h.Schema) {
+	if histogram.IsKnownSchema(h.Schema) {
 		return nil
 	}
-	return histogram.InvalidSchemaError(h.Schema)
+	return histogram.UnknownSchemaError(h.Schema)
 }
 
 func getHistogramValType(h *prompb.Histogram) chunkenc.ValueType {

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -570,24 +570,25 @@ func TestConcreteSeriesIterator_InvalidHistogramSamples(t *testing.T) {
 			require.Equal(t, chunkenc.ValFloat, it.Next())
 			require.Equal(t, chunkenc.ValNone, it.Next())
 			require.Error(t, it.Err())
+			require.ErrorIs(t, it.Err(), histogram.ErrHistogramsUnknownSchema)
 
 			it = series.Iterator(it)
 			require.Equal(t, chunkenc.ValFloat, it.Next())
 			require.Equal(t, chunkenc.ValNone, it.Next())
-			require.Error(t, it.Err())
+			require.ErrorIs(t, it.Err(), histogram.ErrHistogramsUnknownSchema)
 
 			it = series.Iterator(it)
 			require.Equal(t, chunkenc.ValNone, it.Seek(1))
-			require.Error(t, it.Err())
+			require.ErrorIs(t, it.Err(), histogram.ErrHistogramsUnknownSchema)
 
 			it = series.Iterator(it)
 			require.Equal(t, chunkenc.ValFloat, it.Seek(3))
 			require.Equal(t, chunkenc.ValNone, it.Next())
-			require.Error(t, it.Err())
+			require.ErrorIs(t, it.Err(), histogram.ErrHistogramsUnknownSchema)
 
 			it = series.Iterator(it)
 			require.Equal(t, chunkenc.ValNone, it.Seek(4))
-			require.Error(t, it.Err())
+			require.ErrorIs(t, it.Err(), histogram.ErrHistogramsUnknownSchema)
 		})
 	}
 }

--- a/tsdb/chunkenc/float_histogram_test.go
+++ b/tsdb/chunkenc/float_histogram_test.go
@@ -1492,3 +1492,33 @@ func TestFloatHistogramIteratorFailIfSchemaInValid(t *testing.T) {
 		})
 	}
 }
+
+func TestFloatHistogramIteratorReduceShema(t *testing.T) {
+	for _, schema := range []int32{9, 52} {
+		t.Run(fmt.Sprintf("schema %d", schema), func(t *testing.T) {
+			h := &histogram.FloatHistogram{
+				Schema:        schema,
+				Count:         10,
+				Sum:           15.0,
+				ZeroThreshold: 1e-100,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 2},
+					{Offset: 1, Length: 2},
+				},
+				PositiveBuckets: []float64{1, 2, 3, 4},
+			}
+
+			c := NewFloatHistogramChunk()
+			app, err := c.Appender()
+			require.NoError(t, err)
+
+			_, _, _, err = app.AppendFloatHistogram(nil, 1, h, false)
+			require.NoError(t, err)
+
+			it := c.Iterator(nil)
+			require.Equal(t, ValFloatHistogram, it.Next())
+			_, rh := it.AtFloatHistogram(nil)
+			require.Equal(t, histogram.ExponentialSchemaMax, rh.Schema)
+		})
+	}
+}

--- a/tsdb/chunkenc/float_histogram_test.go
+++ b/tsdb/chunkenc/float_histogram_test.go
@@ -1488,12 +1488,12 @@ func TestFloatHistogramIteratorFailIfSchemaInValid(t *testing.T) {
 
 			it := c.Iterator(nil)
 			require.Equal(t, ValNone, it.Next())
-			require.ErrorIs(t, it.Err(), histogram.ErrHistogramsInvalidSchema)
+			require.ErrorIs(t, it.Err(), histogram.ErrHistogramsUnknownSchema)
 		})
 	}
 }
 
-func TestFloatHistogramIteratorReduceShema(t *testing.T) {
+func TestFloatHistogramIteratorReduceSchema(t *testing.T) {
 	for _, schema := range []int32{9, 52} {
 		t.Run(fmt.Sprintf("schema %d", schema), func(t *testing.T) {
 			h := &histogram.FloatHistogram{

--- a/tsdb/chunkenc/histogram_test.go
+++ b/tsdb/chunkenc/histogram_test.go
@@ -1844,12 +1844,12 @@ func TestHistogramIteratorFailIfSchemaInValid(t *testing.T) {
 
 			it := c.Iterator(nil)
 			require.Equal(t, ValNone, it.Next())
-			require.ErrorIs(t, it.Err(), histogram.ErrHistogramsInvalidSchema)
+			require.ErrorIs(t, it.Err(), histogram.ErrHistogramsUnknownSchema)
 		})
 	}
 }
 
-func TestHistogramIteratorReduceShema(t *testing.T) {
+func TestHistogramIteratorReduceSchema(t *testing.T) {
 	for _, schema := range []int32{9, 52} {
 		t.Run(fmt.Sprintf("schema %d", schema), func(t *testing.T) {
 			h := &histogram.Histogram{


### PR DESCRIPTION
Reduce the resolution of native histograms read from chunks or remote read if the schema is exponential, but over the supported maximum (8).

#### Which issue(s) does the PR fix:

Related to #14168 
Follows #17189

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[ENHANCEMENT] Reduce the resolution of native histograms read from chunks or remote read if the schema is exponential, but over the supported maximum (8).
```
