### PR TITLE
Support Ingest OOO Exemplar.

### DIFF
--- a/storage/interface.go
+++ b/storage/interface.go
@@ -29,13 +29,16 @@ import (
 
 // The errors exposed.
 var (
-	ErrNotFound = errors.New("not found")
+	ErrNotFound                            = errors.New("not found")
+	ErrOutOfOrderExemplarInsertionNotFound = errors.New("not found out of order exemplar insertion point")
 	// ErrOutOfOrderSample is when out of order support is disabled and the sample is out of order.
 	ErrOutOfOrderSample = errors.New("out of order sample")
 	// ErrOutOfBounds is when out of order support is disabled and the sample is older than the min valid time for the append.
 	ErrOutOfBounds = errors.New("out of bounds")
 	// ErrTooOldSample is when out of order support is enabled but the sample is outside the time window allowed.
 	ErrTooOldSample = errors.New("too old sample")
+	// ErrTooOldExemplar is when exemplar is outside the time out of order window allowed.
+	ErrTooOldExemplar = errors.New("too old exemplar")
 	// ErrDuplicateSampleForTimestamp is when the sample has same timestamp but different value.
 	ErrDuplicateSampleForTimestamp = errDuplicateSampleForTimestamp{}
 	ErrOutOfOrderExemplar          = errors.New("out of order exemplar")

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -315,7 +315,7 @@ func (h *Head) resetInMemoryState() error {
 	if em == nil {
 		em = NewExemplarMetrics(h.reg)
 	}
-	es, err := NewCircularExemplarStorage(h.opts.MaxExemplars.Load(), em)
+	es, err := NewCircularExemplarStorage(h.opts.MaxExemplars.Load(), em, h.opts.OutOfOrderTimeWindow.Load())
 	if err != nil {
 		return err
 	}

--- a/util/teststorage/storage.go
+++ b/util/teststorage/storage.go
@@ -66,7 +66,7 @@ func NewWithError(outOfOrderTimeWindow ...int64) (*TestStorage, error) {
 	reg := prometheus.NewRegistry()
 	eMetrics := tsdb.NewExemplarMetrics(reg)
 
-	es, err := tsdb.NewCircularExemplarStorage(10, eMetrics)
+	es, err := tsdb.NewCircularExemplarStorage(10, eMetrics, opts.OutOfOrderTimeWindow)
 	if err != nil {
 		return nil, fmt.Errorf("opening test exemplar storage: %w", err)
 	}


### PR DESCRIPTION
Fixes: #13577.

Todo:
- [x]  Implement Support for OOO Exemplar.
- [x] Consider oooTimeWindow for Exemplar.
- [ ] Comment by @krajorama in https://github.com/prometheus/prometheus/pull/13580#discussion_r1535755906_  (Figure out)
- [ ] Suggestion to use binary search instead of linear, but the trade-off is that we have to store per-series indexes.
- [ ] Also figure out whether to add oooExemplar to wbl or not.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes

```
