### PR TITLE
Add Krajo and Arthur as release Shepherds for 3.7

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,8 @@ Please see [the v2.55 RELEASE.md](https://github.com/prometheus/prometheus/blob/
 | v3.4           | 2025-04-29                                 | Jan-Otto Kröpke (Github: @jkroepke)|
 | v3.5 LTS       | 2025-06-03                                 | Bryan Boreham (GitHub: @bboreham)  |
 | v3.6           | 2025-08-01                                 | Ayoub Mrini (Github: @machine424)  |
-| v3.7           | 2025-09-15                                 | **volunteer welcome**              |
+| v3.7           | 2025-09-25                                 | Arthur Sens and George Krajcsovits (Github: @ArthurSens and @krajorama)|
+| v3.8           | 2025-11-06                                 | **volunteer welcome**              |
 
 If you are interested in volunteering please create a pull request against the [prometheus/prometheus](https://github.com/prometheus/prometheus) repository and propose yourself for the release series of your choice.
 


### PR DESCRIPTION
The release process is quite tiresome, so for 3.7 @krajorama and I want to split the effort to make it more sustainable :)

### Release-notes

```release-notes
NONE
```