### PR TITLE
feat(nh): mark native histograms as stable and keep optional

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -259,7 +259,7 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 				// Change relevant global variables. Hacky, but it's hard to pass a new option or default to unmarshallers.
 				config.DefaultConfig.GlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols
 				config.DefaultGlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols
-				logger.Info("Experimental native histogram support enabled. Changed default scrape_protocols to prefer PrometheusProto format.", "global.scrape_protocols", fmt.Sprintf("%v", config.DefaultGlobalConfig.ScrapeProtocols))
+				logger.Info("Native histogram support enabled. Changed default scrape_protocols to prefer PrometheusProto format.", "global.scrape_protocols", fmt.Sprintf("%v", config.DefaultGlobalConfig.ScrapeProtocols))
 			case "ooo-native-histograms":
 				logger.Warn("This option for --enable-feature is now permanently enabled and therefore a no-op.", "option", o)
 			case "created-timestamp-zero-ingestion":

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -50,23 +50,31 @@ computed at all.
 `--enable-feature=native-histograms`
 
 When enabled, Prometheus will ingest native histograms (formerly also known as
-sparse histograms or high-res histograms). Native histograms are still highly
-experimental. Expect breaking changes to happen (including those rendering the
-TSDB unreadable).
+sparse histograms or high-res histograms). Native histograms are considered a
+stable feature.
+
+Native histograms may be directly scraped from targets (see below). Prometheus
+can also convert classic histograms scraped from targets into native histograms
+with custom buckets during scrape. Native histograms may be ingested on
+Remote-Write 1.0, 2.0, OTLP.
 
 Native histograms are currently only supported in the traditional Prometheus
-protobuf exposition format. This feature flag therefore also enables a new (and
-also experimental) protobuf parser, through which _all_ metrics are ingested
-(i.e. not only native histograms). Prometheus will try to negotiate the
-protobuf format first. The instrumented target needs to support the protobuf
-format, too, _and_ it needs to expose native histograms. The protobuf format
-allows to expose classic and native histograms side by side. With this feature
-flag disabled, Prometheus will continue to parse the classic histogram (albeit
-via the text format). With this flag enabled, Prometheus will still ingest
-those classic histograms that do not come with a corresponding native
-histogram. However, if a native histogram is present, Prometheus will ignore
-the corresponding classic histogram, with the notable exception of exemplars,
-which are always ingested. To keep the classic histograms as well, enable
+protobuf exposition format. This feature flag therefore also enables a the
+protobuf parser by changing the default for the `scrape_protocols` scrape
+configuration parameter to `[ PrometheusProto, OpenMetricsText1.0.0,
+OpenMetricsText0.0.1, PrometheusText0.0.4 ]`. Which means that Prometheus
+will try to negotiate the protobuf format first and if the target supports
+the protobuf expostion format then _all_ metrics are ingested via protobuf
+(i.e. not only native histograms). The protobuf format allows to expose
+classic and native histograms side by side.
+
+With this feature flag disabled, Prometheus will continue to parse the classic
+histogram (albeit via the text format).
+With this flag enabled, Prometheus will still ingest those classic histograms
+that do not come with a corresponding native histogram. However, if a native
+histogram is present, Prometheus will ignore the corresponding classic
+histogram, with the notable exception of exemplars, which are always ingested.
+To keep the classic histograms as well, enable
 `always_scrape_classic_histograms` in the scrape job.
 
 ## Experimental PromQL functions

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -6,10 +6,10 @@ sort_rank: 6
 Federation allows a Prometheus server to scrape selected time series from
 another Prometheus server.
 
-_Note about native histograms (experimental feature): To scrape native histograms
-via federation, the scraping Prometheus server needs to run with native histograms
-enabled (via the command line flag `--enable-feature=native-histograms`), implying
-that the protobuf format is used for scraping. Should the federated metrics contain
+_Note about native histograms: To scrape native histograms via federation, the
+scraping Prometheus server needs to run with native histograms enabled (via the
+command line flag `--enable-feature=native-histograms`), implying that the
+protobuf format is used for scraping. Should the federated metrics contain
 a mix of different sample types (float64, counter histogram, gauge histogram) for
 the same metric name, the federation payload will contain multiple metric families
 with the same name (but different types). Technically, this violates the rules of

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -578,9 +578,9 @@ sample values. JSON does not support special float values such as `NaN`, `Inf`,
 and `-Inf`, so sample values are transferred as quoted JSON strings rather than
 raw numbers.
 
-The keys `"histogram"` and `"histograms"` only show up if the experimental
-native histograms are present in the response. Their placeholder `<histogram>`
-is explained in detail in its own section below.
+The keys `"histogram"` and `"histograms"` only show up if native histograms
+are present in the response. Their placeholder `<histogram>` is explained
+in detail in its own section below.
 
 ### Range vectors
 
@@ -647,9 +647,6 @@ String results are returned as result type `string`. The corresponding
 ### Native histograms
 
 The `<histogram>` placeholder used above is formatted as follows.
-
-_Note that native histograms are an experimental feature, and the format below
-might still change._
 
 ```json
 {

--- a/docs/querying/basics.md
+++ b/docs/querying/basics.md
@@ -37,7 +37,7 @@ user-specified expression.
 For [instant queries](api.md#instant-queries), any of the above data types are allowed as the root of the expression.
 [Range queries](api.md#range-queries) only support scalar-typed and instant-vector-typed expressions.
 
-_Notes about the experimental native histograms:_
+_Notes about the native histograms:_
 
 * Ingesting native histograms has to be enabled via a [feature
   flag](../feature_flags.md#native-histograms).

--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -563,7 +563,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			w.writer.AppendExemplars(exemplars)
 
 		case record.HistogramSamples, record.CustomBucketsHistogramSamples:
-			// Skip if experimental "histograms over remote write" is not enabled.
+			// Skip if "histograms over remote write" is not enabled.
 			if !w.sendHistograms {
 				break
 			}
@@ -591,7 +591,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			}
 
 		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
-			// Skip if experimental "histograms over remote write" is not enabled.
+			// Skip if "histograms over remote write" is not enabled.
 			if !w.sendHistograms {
 				break
 			}


### PR DESCRIPTION
Keep the feature optional but mark as stable, meaning that breaking changes are only allowed together with major version release of Prometheus.


#### Which issue(s) does the PR fix:

Related to: #16572

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] Mark native histograms as a stable feature while keeping it optional via the feature flag. This means that breaking are only allowed together with a major Prometheus release.
```
