### PR TITLE
UI: fix redirect when web.routePrefix configured

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -417,12 +417,12 @@ func New(logger *slog.Logger, o *Options) *Handler {
 	readyf := h.testReady
 
 	router.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, path.Join(o.ExternalURL.Path, homePage), http.StatusFound)
+		http.Redirect(w, r, path.Join(o.RoutePrefix, homePage), http.StatusFound)
 	})
 
 	if !o.UseOldUI {
 		router.Get("/graph", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, path.Join(o.ExternalURL.Path, "/query?"+r.URL.RawQuery), http.StatusFound)
+			http.Redirect(w, r, path.Join(o.RoutePrefix, "/query?"+r.URL.RawQuery), http.StatusFound)
 		})
 	}
 


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

I actually just wanted to configure the URL sent to alertmanager and was surprised to find, that even with `web.routePrefix=/`, just accessing e.g. http://localhost:9090 gives me a redirect to the path in the `web.externalUrl` - which then gives a 404, since routePrefix is `/`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] UI: fix redirect to path of web.externalUrl if web.routePrefix is configured
```

This might change setups using the `kube-prometheus-stack` Helm chart, as that defaults to configuring `web.routePrefix=/` instead of leaving that flag alone or explicitly defaulting to `""`. I don't think it will break anything though, as that was either already broken or hidden, since reverse proxies hit it at the expected address.