### PR TITLE
tsdb: Fix appended sample count metrics when converting histogram staleness markers

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1331,6 +1331,9 @@ func (a *headAppender) commitFloats(b *appendBatch, acc *appenderCommitContext) 
 					H:   &histogram.Histogram{Sum: s.V},
 				})
 				b.histogramSeries = append(b.histogramSeries, series)
+				// This sample was counted as a float but is now a histogram
+				acc.floatsAppended--
+				acc.histogramsAppended++
 				series.Unlock()
 				continue
 			case series.lastFloatHistogramValue != nil:
@@ -1340,6 +1343,9 @@ func (a *headAppender) commitFloats(b *appendBatch, acc *appenderCommitContext) 
 					FH:  &histogram.FloatHistogram{Sum: s.V},
 				})
 				b.floatHistogramSeries = append(b.floatHistogramSeries, series)
+				// This sample was counted as a float but is now a float histogram
+				acc.floatsAppended--
+				acc.histogramsAppended++
 				series.Unlock()
 				continue
 			}


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

When a float staleness marker gets converted to a histogram staleness marker (due to the series previously having histogram data), the appended sample accounting becomes incorrect:
- The sample is initially counted as `floatsAppended` during batch initialization
- During `commitFloats()`, it gets converted and moved to the histogram batch
- The accounting counters are never adjusted to reflect this type change
- This causes` floatsAppended` to be overcounted and `histogramsAppended` to be undercounted
- In extreme cases with duplicate converted samples, `histogramsAppended` can go negative, causing Prometheus counter panics.

This PR decrements `floatsAppended` and increments the appropriate histogram metric when these conversions occur, and adds a regression test.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] TSDB: Correctly adjust appended sample counts when converting float staleness markers to histograms
```
