### PR TITLE
[DOCS] API: Document the lookback_delta parameter

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -85,6 +85,7 @@ URL query parameters:
 - `timeout=<duration>`: Evaluation timeout. Optional. Defaults to and
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Doesn’t affect scalars or strings but truncates the number of series for matrices and vectors. Optional. 0 means disabled.
+- `lookback_delta=<number>`: Override the the [lookback period](#staleness) just for this query. Optional.
 
 The current server time is used if the `time` parameter is omitted.
 
@@ -157,6 +158,7 @@ URL query parameters:
 - `timeout=<duration>`: Evaluation timeout. Optional. Defaults to and
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Optional. 0 means disabled.
+- `lookback_delta=<number>`: Override the the [lookback period](#staleness) just for this query. Optional.
 
 You can URL-encode these parameters directly in the request body by using the `POST` method and
 `Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large

--- a/docs/querying/basics.md
+++ b/docs/querying/basics.md
@@ -393,6 +393,7 @@ Prometheus needs to assign a value at those timestamps for each relevant time
 series. It does so by taking the newest sample that is less than the lookback period ago.
 The lookback period is 5 minutes by default, but can be
 [set with the `--query.lookback-delta` flag](../command-line/prometheus.md)
+or overridden on an individual query via the `lookback_delta` parameter.
 
 If a target scrape or rule evaluation no longer returns a sample for a time
 series that was previously present, this time series will be marked as stale.


### PR DESCRIPTION
`lookback_delta` was added to the API in #12088.

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
