### PR TITLE
[RW2] Return 400 for Exemplars without Series or Histograms not written

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -428,6 +428,12 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 			continue
 		}
 
+		// Validate that the TimeSeries has at least one sample or histogram.
+		if len(ts.Samples) == 0 && len(ts.Histograms) == 0 {
+			badRequestErrs = append(badRequestErrs, fmt.Errorf("TimeSeries must contain at least one sample or histogram for series %v", ls.String()))
+			continue
+		}
+
 		allSamplesSoFar := rs.AllSamples()
 		var ref storage.SeriesRef
 

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -423,7 +423,7 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 			input: append(
 				// Series with only exemplars, no samples or histograms.
 				[]writev2.TimeSeries{{
-					LabelsRefs: []uint32{1, 2}, // __name__="test_metric1"
+					LabelsRefs: []uint32{1, 2},
 					Exemplars: []writev2.Exemplar{{
 						LabelsRefs: []uint32{},
 						Value:      1.0,

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -419,6 +419,22 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 			expectedRespBody: "parsing labels for series [1 999]: labelRefs 1 (name) = 999 (value) outside of symbols table (size 18)\n",
 		},
 		{
+			desc: "Partial write; TimeSeries with only exemplars (no samples or histograms)",
+			input: append(
+				// Series with only exemplars, no samples or histograms.
+				[]writev2.TimeSeries{{
+					LabelsRefs: []uint32{1, 2}, // __name__="test_metric1"
+					Exemplars: []writev2.Exemplar{{
+						LabelsRefs: []uint32{},
+						Value:      1.0,
+						Timestamp:  1,
+					}},
+				}},
+				writeV2RequestFixture.Timeseries...),
+			expectedCode:     http.StatusBadRequest,
+			expectedRespBody: "TimeSeries must contain at least one sample or histogram for series {__name__=\"test_metric1\"}\n",
+		},
+		{
 			desc: "Partial write; first series with one OOO sample",
 			input: func() []writev2.TimeSeries {
 				f := proto.Clone(writeV2RequestFixture).(*writev2.Request)


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes https://github.com/prometheus/prometheus/issues/17247

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] Remote write 2.0 handler, return 400 for exemplars without series or histograms instead of a silent drop of exemplar data.
```
