### PR TITLE
[TEST] Labels: Improve assertion failure message

### DIFF
--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -67,17 +67,19 @@ func TestSizeOfLabels(t *testing.T) {
 	require.Len(t, expectedSizeOfLabels, len(testCaseLabels))
 	for i, c := range expectedSizeOfLabels { // Declared in build-tag-specific files, e.g. labels_slicelabels_test.go.
 		var total uint64
-		testCaseLabels[i].Range(func(l Label) {
+		labels := testCaseLabels[i]
+		labels.Range(func(l Label) {
 			total += SizeOfLabels(l.Name, l.Value, 1)
 		})
-		require.Equal(t, c, total)
+		require.Equalf(t, c, total, "unexpected size for test case %d: %v", i, labels)
 	}
 }
 
 func TestByteSize(t *testing.T) {
 	require.Len(t, expectedByteSize, len(testCaseLabels))
 	for i, c := range expectedByteSize { // Declared in build-tag-specific files, e.g. labels_slicelabels_test.go.
-		require.Equal(t, c, testCaseLabels[i].ByteSize())
+		labels := testCaseLabels[i]
+		require.Equalf(t, c, labels.ByteSize(), "unexpected size for test case %d: %v", i, labels)
 	}
 }
 


### PR DESCRIPTION
Small improvement so that when it goes wrong you can see which case it was failing on.
Upstreaming from https://github.com/grafana/mimir-prometheus/pull/979

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
