### PR TITLE
mixin: add uid to remote write dashboard

### DIFF
--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -766,6 +766,7 @@ local row = panel.row;
       dashboard.new('%(prefix)sRemote Write' % $._config.grafanaPrometheus)
       + dashboard.time.withFrom('now-1h')
       + dashboard.withTags($._config.grafanaPrometheus.tags)
+      + dashboard.withUid('cb079f93-fde4-41f0-862b-d4301d7c1c56')
       + dashboard.timepicker.withRefreshIntervals($._config.grafanaPrometheus.refresh)
       + dashboard.withVariables([
         datasourceVariable,


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Similar to #16819, this introduces a fixed UID for the remote write dashboard. This solves problems with "stateless" deployments of Grafana that always build their dashboards via provisioning such that dashboards links can stay stable, but also solves the case covered in the referenced pull request for this dashboard.

#### Does this PR introduce a user-facing change?
```release-notes
[ENHANCEMENT] Mixin: The remote write dashboard now has a static UID.
```
