### PR TITLE
test: Fix flaky test on Windows by replacing `os.Rename` with `os.WriteFile`

### DIFF
--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -16,10 +16,8 @@ package file
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"sync"
 	"testing"
@@ -75,20 +73,11 @@ func (t *testRunner) copyFile(src string) string {
 func (t *testRunner) copyFileTo(src, name string) string {
 	t.Helper()
 
-	newf, err := os.CreateTemp(t.dir, "")
+	newf, err := os.ReadFile(src)
 	require.NoError(t, err)
-
-	f, err := os.Open(src)
-	require.NoError(t, err)
-
-	_, err = io.Copy(newf, f)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-	require.NoError(t, newf.Close())
 
 	dst := filepath.Join(t.dir, name)
-	err = os.Rename(newf.Name(), dst)
-	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dst, newf, 0o644))
 
 	return dst
 }
@@ -97,15 +86,7 @@ func (t *testRunner) copyFileTo(src, name string) string {
 func (t *testRunner) writeString(file, data string) {
 	t.Helper()
 
-	newf, err := os.CreateTemp(t.dir, "")
-	require.NoError(t, err)
-
-	_, err = newf.WriteString(data)
-	require.NoError(t, err)
-	require.NoError(t, newf.Close())
-
-	err = os.Rename(newf.Name(), file)
-	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(file, []byte(data), 0o644))
 }
 
 // appendString appends a string to a file.
@@ -320,9 +301,6 @@ func valid2Tg(file string) []*targetgroup.Group {
 }
 
 func TestInitialUpdate(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("flaky test, see https://github.com/prometheus/prometheus/issues/16212")
-	}
 	for _, tc := range []string{
 		"fixtures/valid.yml",
 		"fixtures/valid.json",
@@ -365,9 +343,6 @@ func TestInvalidFile(t *testing.T) {
 }
 
 func TestNoopFileUpdate(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("flaky test, see https://github.com/prometheus/prometheus/issues/16212")
-	}
 	t.Parallel()
 
 	runner := newTestRunner(t)
@@ -386,9 +361,6 @@ func TestNoopFileUpdate(t *testing.T) {
 }
 
 func TestFileUpdate(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("flaky test, see https://github.com/prometheus/prometheus/issues/16212")
-	}
 	t.Parallel()
 
 	runner := newTestRunner(t)
@@ -407,9 +379,6 @@ func TestFileUpdate(t *testing.T) {
 }
 
 func TestInvalidFileUpdate(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("flaky test, see https://github.com/prometheus/prometheus/issues/16212")
-	}
 	t.Parallel()
 
 	runner := newTestRunner(t)
@@ -432,9 +401,6 @@ func TestInvalidFileUpdate(t *testing.T) {
 }
 
 func TestUpdateFileWithPartialWrites(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("flaky test, see https://github.com/prometheus/prometheus/issues/16212")
-	}
 	t.Parallel()
 
 	runner := newTestRunner(t)


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes [#16212](https://github.com/prometheus/prometheus/issues/16212)
#### Problem

The problem is that the `os.Rename()` mechanism, when combined with the file watcher (`Run` function in `file.go`) on Windows, creates a file-locking race condition. This test fails because it creates a race condition that exposes a fundamental Windows file system behavior: an `os.Rename` operation will fail with "Access is denied" if any other process—in this case, the file watcher—holds an open handle to the target file.  


#### Solution

My solution is replacing `os.Rename()` mechanism with `os.WriteFile()`. This new approach solves the race condition by
eliminating the intermediate temporary file and removing the `os.Rename()` call.  

#### Verification
```
for i in {1..100}; do go test -v ./discovery/file; done
```

Running the above command passes in Windows and macOS/Linux.

#### Does this PR introduce a user-facing change?
NONE