### PR TITLE
chore(changelog): fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## main / unreleased
 
-* [BUGFIX] OTLP receiver: Generate `target_info` samples between the earliest and latest samples per resource. #16737
-* [BUGFIX] Config: Infer escaping scheme when scrape config validation scheme is set.
+* [BUGFIX] Config: Infer valid escaping scheme when scrape config validation scheme is set. #16923
 * [BUGFIX] PromQL: Fix info function on churning series. #17135
 
 ## 3.6.0 / 2025-09-17


### PR DESCRIPTION
16737 was in 3.6.
16923 lacked number and a bit underdefined.

```release-notes
NONE
```
