### PR TITLE
Fix CSS for ScrapePoolPanel page

### DIFF
--- a/web/ui/react-app/src/pages/targets/ScrapePoolPanel.module.css
+++ b/web/ui/react-app/src/pages/targets/ScrapePoolPanel.module.css
@@ -23,21 +23,13 @@
 
 .cell {
   height: auto;
-  word-wrap: break-word;
-  word-break: break-all;
 }
 
-.endpoint, .labels {
-  composes: cell;
-  width: 25%;
+.endpoint, .state, .last-scrape {
+  white-space: nowrap;   
 }
 
-.state, .last-scrape {
-  composes: cell;
-  width: 10%;
-}
-
-.errors {
-  composes: cell;
-  width: 30%;
+.labels, .errors {
+  word-break: break-word;  
+  white-space: normal;
 }


### PR DESCRIPTION
Hi, I made some changes in the UI and noticed this bug.  
I’m not sure if my fix is correct yet. Please don’t close the PR; I’ll continue testing and update it.

<img width="605" height="884" alt="Screenshot 2025-10-02 144549" src="https://github.com/user-attachments/assets/acb5486b-5990-44b1-ac06-b6959dd14af4" />

#### Does this PR introduce a user-facing change?
```release-notes
[BUGFIX] Fix UI bug on ScrapePoolPanel page

