### PR TITLE
WIP: Handling label conflicts in NHCB to classic histogram conversion

### DIFF
--- a/model/histogram/convert.go
+++ b/model/histogram/convert.go
@@ -1,0 +1,98 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package histogram
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type BucketEmitter func(labels labels.Labels, value float64) error
+
+func ConvertNHCBToClassicHistogram(nhcb interface{}, labels labels.Labels, lblBuilder *labels.Builder, bucketSeries BucketEmitter) error {
+	baseName := labels.Get("__name__")
+	if baseName == "" {
+		return errors.New("metric name label '__name__' is missing")
+	}
+
+	oldLabels := lblBuilder.Labels()
+	defer lblBuilder.Reset(oldLabels)
+
+	var (
+		customValues    []float64
+		positiveBuckets []float64
+		count, sum      float64
+	)
+
+	switch h := nhcb.(type) {
+	case *Histogram:
+		customValues = h.CustomValues
+		positiveBuckets = make([]float64, len(h.PositiveBuckets))
+		for i, v := range h.PositiveBuckets {
+			positiveBuckets[i] = float64(v)
+		}
+		count = float64(h.Count)
+		sum = h.Sum
+	case *FloatHistogram:
+		customValues = h.CustomValues
+		positiveBuckets = h.PositiveBuckets
+		count = h.Count
+		sum = h.Sum
+	default:
+		return errors.New("unsupported histogram type")
+	}
+
+	if len(customValues) != len(positiveBuckets) {
+		return errors.New("mismatched lengths of custom values and positive buckets")
+	}
+
+	currCount := float64(0)
+	for i := range customValues {
+		currCount += positiveBuckets[i]
+		lblBuilder.Reset(labels)
+		lblBuilder.Set("__name__", baseName+"_bucket")
+		lblBuilder.Set("le", fmt.Sprintf("%g", customValues[i]))
+		bucketLabels := lblBuilder.Labels()
+		if err := bucketSeries(bucketLabels, currCount); err != nil {
+			return err
+		}
+	}
+
+	lblBuilder.Reset(labels)
+	lblBuilder.Set("__name__", baseName+"_bucket")
+	lblBuilder.Set("le", fmt.Sprintf("%g", math.Inf(1)))
+	infBucketLabels := lblBuilder.Labels()
+	if err := bucketSeries(infBucketLabels, currCount); err != nil {
+		return err
+	}
+
+	lblBuilder.Reset(labels)
+	lblBuilder.Set("__name__", baseName+"_count")
+	countLabels := lblBuilder.Labels()
+	if err := bucketSeries(countLabels, count); err != nil {
+		return err
+	}
+
+	lblBuilder.Reset(labels)
+	lblBuilder.Set("__name__", baseName+"_sum")
+	sumLabels := lblBuilder.Labels()
+	if err := bucketSeries(sumLabels, sum); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/model/histogram/convert.go
+++ b/model/histogram/convert.go
@@ -23,6 +23,9 @@ import (
 
 type BucketEmitter func(labels labels.Labels, value float64) error
 
+// ConvertNHCBToClassicHistogram converts Native Histogram Custom Buckets (NHCB) to classic histogram series.
+// This conversion is needed in various scenarios where users need to get NHCB back to classic histogram format,
+// such as Remote Write v1 for external system compatibility and migration use cases.
 func ConvertNHCBToClassicHistogram(nhcb interface{}, labels labels.Labels, lblBuilder *labels.Builder, bucketSeries BucketEmitter) error {
 	baseName := labels.Get("__name__")
 	if baseName == "" {

--- a/model/histogram/convert_test.go
+++ b/model/histogram/convert_test.go
@@ -17,8 +17,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 type BucketExpectation struct {
@@ -187,7 +188,7 @@ func TestConvertNHCBToClassicHistogram(t *testing.T) {
 			})
 			require.Equal(t, tt.expectErr, err != nil, "unexpected error: %v", err)
 			if !tt.expectErr {
-				require.Equal(t, len(tt.expected.buckets), len(got.buckets))
+				require.Len(t, got.buckets, len(tt.expected.buckets))
 				for i, expBucket := range tt.expected.buckets {
 					require.Equal(t, expBucket, got.buckets[i])
 				}

--- a/model/histogram/convert_test.go
+++ b/model/histogram/convert_test.go
@@ -1,0 +1,184 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package histogram
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestConvertNHCBToClassicHistogram(t *testing.T) {
+	tests := []struct {
+		name           string
+		nhcb           interface{}
+		labels         labels.Labels
+		expectErr      bool
+		expectedLabels []labels.Labels
+		expectedValues []float64
+	}{
+		{
+			name: "Valid Histogram",
+			nhcb: &Histogram{
+				CustomValues:    []float64{1, 2, 3},
+				PositiveBuckets: []int64{10, 20, 30},
+				Count:           60,
+				Sum:             100.0,
+			},
+			labels: labels.FromStrings("__name__", "test_metric"),
+			expectedLabels: []labels.Labels{
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "1"),
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "2"),
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "3"),
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "+Inf"),
+				labels.FromStrings("__name__", "test_metric_count"),
+				labels.FromStrings("__name__", "test_metric_sum"),
+			},
+			expectedValues: []float64{10, 30, 60, 60, 60, 100},
+		},
+		{
+			name: "Valid FloatHistogram",
+			nhcb: &FloatHistogram{
+				CustomValues:    []float64{1, 2, 3},
+				PositiveBuckets: []float64{20.0, 40.0, 60.0},
+				Count:           120.0,
+				Sum:             100.0,
+			},
+			labels: labels.FromStrings("__name__", "test_metric"),
+			expectedLabels: []labels.Labels{
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "1"),
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "2"),
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "3"),
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "+Inf"),
+				labels.FromStrings("__name__", "test_metric_count"),
+				labels.FromStrings("__name__", "test_metric_sum"),
+			},
+			expectedValues: []float64{20, 60, 120, 120, 120, 100},
+		},
+		{
+			name: "Empty Histogram",
+			nhcb: &Histogram{
+				CustomValues:    []float64{},
+				PositiveBuckets: []int64{},
+				Count:           0,
+				Sum:             0.0,
+			},
+			labels: labels.FromStrings("__name__", "test_metric"),
+			expectedLabels: []labels.Labels{
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "+Inf"),
+				labels.FromStrings("__name__", "test_metric_count"),
+				labels.FromStrings("__name__", "test_metric_sum"),
+			},
+			expectedValues: []float64{0, 0, 0},
+		},
+		{
+			name: "Missing __name__ label",
+			nhcb: &Histogram{
+				CustomValues:    []float64{1, 2, 3},
+				PositiveBuckets: []int64{10, 20, 30},
+				Count:           60,
+				Sum:             100.0,
+			},
+			labels:    labels.FromStrings("job", "test_job"),
+			expectErr: true,
+		},
+		{
+			name:      "Unsupported histogram type",
+			nhcb:      nil,
+			labels:    labels.FromStrings("__name__", "test_metric"),
+			expectErr: true,
+		},
+		{
+			name: "Histogram with zero bucket counts",
+			nhcb: &Histogram{
+				CustomValues:    []float64{1, 2, 3},
+				PositiveBuckets: []int64{0, 10, 0},
+				Count:           10,
+				Sum:             50.0,
+			},
+			labels: labels.FromStrings("__name__", "test_metric"),
+			expectedLabels: []labels.Labels{
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "1"),
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "2"),
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "3"),
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "+Inf"),
+				labels.FromStrings("__name__", "test_metric_count"),
+				labels.FromStrings("__name__", "test_metric_sum"),
+			},
+			expectedValues: []float64{0, 10, 10, 10, 10, 50},
+		},
+		{
+			name: "Mismatched bucket lengths",
+			nhcb: &Histogram{
+				CustomValues:    []float64{1, 2},
+				PositiveBuckets: []int64{10, 20, 30},
+				Count:           60,
+				Sum:             100.0,
+			},
+			labels:    labels.FromStrings("__name__", "test_metric"),
+			expectErr: true,
+		},
+		{
+			name: "single series Histogram",
+			nhcb: &Histogram{
+				CustomValues:    []float64{1},
+				PositiveBuckets: []int64{10},
+				Count:           10,
+				Sum:             20.0,
+			},
+			labels: labels.FromStrings("__name__", "test_metric"),
+			expectedLabels: []labels.Labels{
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "1"),
+				labels.FromStrings("__name__", "test_metric_bucket", "le", "+Inf"),
+				labels.FromStrings("__name__", "test_metric_count"),
+				labels.FromStrings("__name__", "test_metric_sum"),
+			},
+			expectedValues: []float64{10, 10, 10, 20},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var actualLabels []labels.Labels
+			var actualValues []float64
+
+			err := ConvertNHCBToClassicHistogram(tt.nhcb, tt.labels, &labels.Builder{}, func(lbls labels.Labels, value float64) error {
+				actualLabels = append(actualLabels, lbls)
+				actualValues = append(actualValues, value)
+				return nil
+			})
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("ConvertNHCBToClassicHistogram() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+
+			if !tt.expectErr {
+				if len(actualLabels) != len(tt.expectedLabels) {
+					t.Errorf("Expected %d emissions, got %d", len(tt.expectedLabels), len(actualLabels))
+					return
+				}
+
+				for i, expectedLabel := range tt.expectedLabels {
+					if !labels.Equal(actualLabels[i], expectedLabel) {
+						t.Errorf("Expected label[%d] = %v, got %v", i, expectedLabel, actualLabels[i])
+					}
+					if actualValues[i] != tt.expectedValues[i] {
+						t.Errorf("Expected value[%d] = %f, got %f", i, tt.expectedValues[i], actualValues[i])
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[ENHANCEMENT] : Handling label conflicts in NHCB to classic histogram conversion
```
As we were exploring when unrolling Native Histograms to Classic Histogram we have to rebuild the time series for histogram we go into label collision problem what it means is 

We can store a native histogram like `my_histogram`, which can later be unrolled to classic histogram format by automatically creating multiple series with magic suffixes like `my_histogram_bucket`,  `my_histogram_count` and `my_histogram_sum`. This creates a collision problem where you end up with two different `my_histogram_bucket` series. 
1. The Unrolled native histogram to classic histogram.
2. User configured classic histogram.

In a similar way we can also have issues with “le” labels, User can configure and add in “le” labels to native histograms but this will end up clashing as when unrolling we add the custom values as “le” labels leading to a conflict in labels and series name

We will see a similar problem in Native Summaries as well, To address this issue @bwplotka recommended Honor label strategy that we could implement in this scenario

I have added
1. `_converted_to_classic_histogram` suffix to avoid Series Name clash
2. `exported_` prefix to avoid label clash

Test Labels :
```
NHCB
{__name__="test_metric", le="1.5"}

Classic Histogram
{__name__="test_metric_converted_to_classic_histogram_bucket", exported_le="1.5", le="1"}
{__name__="test_metric_converted_to_classic_histogram_bucket", exported_le="1.5", le="+Inf"}
{__name__="test_metric_converted_to_classic_histogram_count", exported_le="1.5"}
{__name__="test_metric_converted_to_classic_histogram_sum", exported_le="1.5"}
```
Relevant Links:
- #17166
- https://github.com/prometheus/docs/pull/2739#event-20012988104