### PR TITLE
promtool: Add warning for multiple YAML documents in rule files

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -859,17 +859,17 @@ func checkRulesFromStdin(ls rulesLintConfig) (bool, bool) {
 	rgs, errs := rulefmt.Parse(data, ls.ignoreUnknownFields, ls.nameValidationScheme)
 	if errs != nil {
 		for _, e := range errs {
-            if errors.Is(e, rulefmt.ErrMultiDocWarning) {
-                fmt.Fprintln(os.Stderr, "  WARNING:", e.Error())
-                continue
-            }
-            failed = true
-            fmt.Fprintln(os.Stderr, "  FAILED:", e.Error())
-            hasErrors = hasErrors || !errors.Is(e, errLint)
-        }
-        if hasErrors {
-            return failed, hasErrors
-        }
+			if errors.Is(e, rulefmt.ErrMultiDocWarning) {
+				fmt.Fprintln(os.Stderr, "  WARNING:", e.Error())
+				continue
+			}
+			failed = true
+			fmt.Fprintln(os.Stderr, "  FAILED:", e.Error())
+			hasErrors = hasErrors || !errors.Is(e, errLint)
+		}
+		if hasErrors {
+			return failed, hasErrors
+		}
 	}
 	if n, errs := checkRuleGroups(rgs, ls); errs != nil {
 		fmt.Fprintln(os.Stderr, "  FAILED:")
@@ -896,14 +896,14 @@ func checkRules(files []string, ls rulesLintConfig) (bool, bool) {
 		rgs, errs := rulefmt.ParseFile(f, ls.ignoreUnknownFields, ls.nameValidationScheme)
 		if errs != nil {
 			for _, e := range errs {
-                if errors.Is(e, rulefmt.ErrMultiDocWarning) {
-                    fmt.Fprintln(os.Stderr, "  WARNING:", e.Error())
-                    continue
-                }
-                failed = true
-                fmt.Fprintln(os.Stderr, "  FAILED:", e.Error())
-                hasErrors = hasErrors || !errors.Is(e, errLint)
-            }
+				if errors.Is(e, rulefmt.ErrMultiDocWarning) {
+					fmt.Fprintln(os.Stderr, "  WARNING:", e.Error())
+					continue
+				}
+				failed = true
+				fmt.Fprintln(os.Stderr, "  FAILED:", e.Error())
+				hasErrors = hasErrors || !errors.Is(e, errLint)
+			}
 			if hasErrors {
 				continue
 			}

--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -33,9 +33,7 @@ import (
 	"github.com/prometheus/prometheus/util/namevalidationutil"
 )
 
-var (
-    ErrMultiDocWarning = fmt.Errorf("multiple YAML documents detected in rules file; only the first will be used")
-)
+var ErrMultiDocWarning = errors.New("multiple YAML documents detected in rules file; only the first will be used")
 
 // Error represents semantic errors on parsing rule groups.
 type Error struct {


### PR DESCRIPTION
Fixes [#15834](https://github.com/prometheus/prometheus/issues/15834)

<img width="1719" height="553" alt="Screenshot 2025-10-05 170317" src="https://github.com/user-attachments/assets/e3bb396d-03b5-45a6-8257-1bbc7ed4f651" />

#### Does this PR introduce a user-facing change?
```release-notes
[BUGFIX] Add a warning when multiple YAML documents are detected in Prometheus rule files; only the first document is used.
