### PR TITLE
rules: add unknown state for unevaluated alerting rules

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -536,10 +536,8 @@ func (r *AlertingRule) Eval(ctx context.Context, queryOffset time.Duration, ts t
 // State returns the maximum state of alert instances for this rule.
 // StateFiring > StatePending > StateInactive > StateUnknown.
 func (r *AlertingRule) State() AlertState {
-
 	r.activeMtx.Lock()
 	defer r.activeMtx.Unlock()
-	
 	// Check if the rule has been evaluated
 	if r.evaluationTimestamp.Load().IsZero() {
 		return StateUnknown

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -85,6 +85,8 @@ func TestAlertingRuleState(t *testing.T) {
 	for i, test := range tests {
 		rule := NewAlertingRule(test.name, nil, 0, 0, labels.EmptyLabels(), labels.EmptyLabels(), labels.EmptyLabels(), "", true, nil)
 		rule.active = test.active
+		// Set evaluation timestamp to simulate that the rule has been evaluated
+		rule.SetEvaluationTimestamp(time.Now())
 		got := rule.State()
 		require.Equal(t, test.want, got, "test case %d unexpected AlertState, want:%d got:%d", i, test.want, got)
 	}

--- a/web/ui/mantine-ui/src/api/responseTypes/rules.ts
+++ b/web/ui/mantine-ui/src/api/responseTypes/rules.ts
@@ -1,4 +1,4 @@
-type RuleState = "pending" | "firing" | "inactive";
+type RuleState = "pending" | "firing" | "inactive" | "unknown";
 
 export interface Alert {
   labels: Record<string, string>;


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #4510

#### Does this PR introduce a user-facing change?
```release-notes
[ENHANCEMENT] Rules: Add "unknown" state for alerting rules that haven't been evaluated yet. This provides better visibility into the state of newly created or recently reloaded rules.
```

## Description

This PR introduces a new `StateUnknown` state for alerting rules that haven't been evaluated yet. Previously, unevaluated rules would show as "inactive" which could be misleading as it suggests the rule has been evaluated and found no matching alerts.

### Changes:

1. **Backend (Go)**:
   - Added `StateUnknown` constant with value `-1` to the `AlertState` enum
   - Modified `AlertingRule.State()` to return `StateUnknown` when the rule's evaluation timestamp is zero (indicating it hasn't been evaluated)
   - Updated `AlertState.String()` to handle the new unknown state
   - Updated tests to set evaluation timestamp to ensure existing behavior is maintained

2. **Frontend (Mantine UI)**:
   - Extended `RuleState` type to include "unknown"
   - Updated alerts page to:
     - Track and display unknown state counts
     - Show appropriate badges for rules in unknown state
     - Include unknown state in the filter options
     - Apply proper styling to panels containing rules in unknown state

### Benefits:

- **Better observability**: Users can now distinguish between rules that haven't been evaluated yet and rules that have been evaluated but have no active alerts
- **Improved UX**: The UI now clearly indicates when rules are in an unknown state, helping users understand the system's current state better
- **Backwards compatible**: The change doesn't break existing functionality as the unknown state is only returned for unevaluated rules

### Testing:

The existing test suite has been updated to accommodate the new state. The test now sets the evaluation timestamp to ensure that the existing test cases continue to work as expected.

### Note on implementation:

The implementation checks if `evaluationTimestamp` is zero to determine if a rule has been evaluated. This is a reliable indicator as the timestamp is set during each evaluation cycle.
