### PR TITLE
perf(tsdb): reuse map of sample types to speed up head appender

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -93,6 +93,7 @@ type Head struct {
 	floatHistogramsPool zeropool.Pool[[]record.RefFloatHistogramSample]
 	metadataPool        zeropool.Pool[[]record.RefMetadata]
 	seriesPool          zeropool.Pool[[]*memSeries]
+	typeMapPool         zeropool.Pool[map[chunks.HeadSeriesRef]sampleType]
 	bytesPool           zeropool.Pool[[]byte]
 	memChunkPool        sync.Pool
 

--- a/util/testutil/synctest/disabled.go
+++ b/util/testutil/synctest/disabled.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 )
 
-func Test(t *testing.T, f func(t *testing.T)) {
+func Test(t *testing.T, _ func(t *testing.T)) {
 	t.Skip("goexperiment.synctest is not enabled")
 }
 


### PR DESCRIPTION
While investigating +10% CPU in v3.7 release, found that ~5% is from expanding the types map. Try reuse.

Also fix a linter error.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
