### PR TITLE
tsdb: Remove leftover debug fmt.Println

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -2238,7 +2238,6 @@ func (a *headAppender) Rollback() (err error) {
 	}()
 
 	var series *memSeries
-	fmt.Println("ROLLBACK")
 	for _, b := range a.batches {
 		for i := range b.floats {
 			series = b.floatSeries[i]


### PR DESCRIPTION


#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
