### PR TITLE
tsdb: Disable more tests on MS Windows

### DIFF
--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1988,7 +1988,7 @@ func TestDelayedCompaction(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if c.compactionDelay > 0 && runtime.GOOS == "windows" {
+			if runtime.GOOS == "windows" {
 				t.Skip("Time imprecision on windows makes the test flaky, see https://github.com/prometheus/prometheus/issues/16450")
 			}
 			t.Parallel()


### PR DESCRIPTION
Also the other `TestDelayedCompaction` test fails very often on MS Windows.
Let's for now disable both cases.

I'm doing this in the release branch so that we are not affected by flaky tests in the release process. (Will merge back into main soon.)

#### Which issue(s) does the PR fix:

Fixes #16450

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```
