### PR TITLE
remote write: Add visibility to end-to-end processing of batch

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -221,7 +221,8 @@ func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManager
 		ConstLabels: constLabels,
 	})
 	m.processBatchDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{Namespace: namespace,
+		prometheus.HistogramOpts{
+			Namespace:                       namespace,
 			Subsystem:                       subsystem,
 			Name:                            "process_batch_duration_seconds",
 			Help:                            "Duration of processing a batch from the queue to being sent to the remote storage.",


### PR DESCRIPTION
This PR adjusts how we calculate metrics for batch send to ensure all aspects of sending a batch are covered. The current calculation for data out does not include the time to build the time series, the time to release the batch, and for v2 the time to reset the symbol table. I also added a histogram to cover the same path to get a better perspective on end-to-end batch processing time.

As noted in, https://github.com/prometheus/prometheus/issues/17277, PRWv2 can end up in a death spiral at high send rates. I haven't experienced this personally but will note that a high amount of memory and CPU utilization occurs from `populateV2TimeSeries` and `symbolTable.Reset()` and any time from those operations is not currently counted in our data out rate. Example profiles from one of our highest traffic clusters,

Memory
<img width="1659" height="204" alt="image" src="https://github.com/user-attachments/assets/b78ecb08-f5f4-4ff4-98db-ae0afa04d5f9" />

CPU
<img width="1659" height="230" alt="image" src="https://github.com/user-attachments/assets/d874c9db-a0e1-45c4-8f3f-510b15697fbf" />

My hypothesis is that excluding these operations from the data out calculation is causing shards to be too low for too long and by the time it scales up it's going too high too fast and triggers the queue contention noted in the issue. I wasn't sure how to prove it without more data though. 

#### Which issue(s) does the PR fix:
Related to: https://github.com/prometheus/prometheus/issues/17277

#### Does this PR introduce a user-facing change?

```release-notes
[ENHANCEMENT] Start tracking time for calculating the data out rate of remote write from when the batch is triggered and Introduce a process_batch_duration_seconds to add visibility on end-to-end batch time 
```
