### PR TITLE
docs: add `use_fips_sts_endpoint` to sigv4 config

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2809,6 +2809,11 @@ sigv4:
   # AWS Role ARN, an alternative to using AWS API keys.
   [ role_arn: <string> ]
 
+  # Defines the FIPS mode for the AWS STS endpoint.
+  # Requires Prometheus >= 2.54.0
+  # Note: FIPS STS selection should be configured via use_fips_sts_endpoint rather than environment variables. (The problem report that motivated this: AWS_USE_FIPS_ENDPOINT no longer works.)
+  [ use_fips_sts_endpoint: <boolean> | default = false ]
+
 # HTTP client settings, including authentication methods (such as basic auth and
 # authorization), proxy configurations, TLS options, custom HTTP headers, etc.
 [ <http_config> ]
@@ -3010,6 +3015,11 @@ sigv4:
 
   # AWS Role ARN, an alternative to using AWS API keys.
   [ role_arn: <string> ]
+
+  # Defines the FIPS mode for the AWS STS endpoint.
+  # Requires Prometheus >= 2.54.0
+  # Note: FIPS STS selection should be configured via use_fips_sts_endpoint rather than environment variables. (The problem report that motivated this: AWS_USE_FIPS_ENDPOINT no longer works.)
+  [ use_fips_sts_endpoint: <boolean> | default = false ]
 
 # Optional AzureAD configuration.
 # Cannot be used at the same time as basic_auth, authorization, oauth2, sigv4 or google_iam.


### PR DESCRIPTION
#### What this PR does

Adds `use_fips_sts_endpoint` to the `sigv4` block in `docs/configuration/configuration.md`, including a short description, and minimum version note, The field enables use of the FIPS-compliant AWS STS endpoint when assuming roles.

* Field added in both occurrences of the shared `<http_config> → sigv4` section in the page.
* Notes that Prometheus **v2.54.0+** is required (first release with `prometheus/common v0.55.0`).

#### Rationale / background

Environment variable–based selection (`AWS_USE_FIPS_ENDPOINT`) no longer drives STS FIPS usage for this path; the documented way is the config knob `use_fips_sts_endpoint`. This closes the docs gap so users can discover the option directly from the Prometheus configuration page.

References:

* Feature introduced in `prometheus/common` and consumed by Prometheus in v2.54.0. [link](https://chromium.googlesource.com/external/github.com/prometheus/common/%2B/refs/tags/v0.55.0%5E1..refs/tags/v0.55.0/)
* Related discussion: AWS_USE_FIPS_ENDPOINT no longer works for this case.
* Operator surfaced the option in prometheus-operator and adjusted wording shortly after; this change aligns the server docs.

#### Example

```yaml
remote_write:
  - url: https://aps-workspaces.us-east-1.amazonaws.com/workspaces/XXXX/api/v1/remote_write
    http_config:
      sigv4:
        region: us-east-1
        role_arn: arn:aws:iam::111122223333:role/prom-remote-write
        use_fips_sts_endpoint: true
```

#### Which issue(s) does the PR fix:

* Fixes #17301

#### Related
* prometheus/prometheus#16752
* prometheus/common#649
* prometheus-operator/prometheus-operator#7987, #7992

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```

#### Checklist

* [x] Changes limited to documentation (`docs/configuration/configuration.md`).
* [x] DCO sign-off on commits (`git commit -s`).
* [x] Comments follow style (capitalized, end with a period).
* [x] Kept wording consistent with nearby `sigv4` entries.

**Reviewers to ping (suggested):** @roidelapluie @metalmatze
