### PR TITLE
tsdb: fix handle leak on mmap failure on MS Windows

### DIFF
--- a/tsdb/fileutil/mmap_windows.go
+++ b/tsdb/fileutil/mmap_windows.go
@@ -27,12 +27,13 @@ func mmap(f *os.File, size int) ([]byte, error) {
 	}
 
 	addr, errno := syscall.MapViewOfFile(h, syscall.FILE_MAP_READ, 0, 0, uintptr(size))
-	if addr == 0 {
-		return nil, os.NewSyscallError("MapViewOfFile", errno)
-	}
 
 	if err := syscall.CloseHandle(syscall.Handle(h)); err != nil {
 		return nil, os.NewSyscallError("CloseHandle", err)
+	}
+
+	if addr == 0 {
+		return nil, os.NewSyscallError("MapViewOfFile", errno)
 	}
 
 	return (*[maxMapSize]byte)(unsafe.Pointer(addr))[:size], nil


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```

## Description

In case `syscall.MapViewOfFile` fails, close the handle to the FileMapping.

In practice I don't expect this to happen very often or even at all. In fact I'm not even sure of the conditions in which MapViewOfFile would return an error. But if anything, it's a red herring when debugging handle leaks.

