### PR TITLE
tsdb: add cleanup handler to prevent mmap leaks

### DIFF
--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -14,6 +14,7 @@
 package fileutil
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -25,7 +26,7 @@ type mmapRef struct {
 
 func (m *mmapRef) close() error {
 	if m.b == nil {
-		return fmt.Errorf("mmap already closed")
+		return errors.New("mmap already closed")
 	}
 	err := munmap(m.b)
 	m.b = nil

--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -64,8 +64,7 @@ func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 		return nil, fmt.Errorf("mmap, size %d: %w", size, err)
 	}
 
-	mr := &mmapRef{b: b}
-	mmapFile := &MmapFile{f: f, m: mr}
+	mmapFile := &MmapFile{f: f, m: &mmapRef{b: b}}
 
 	runtime.AddCleanup(mmapFile, func(m *mmapRef) {
 		_ = m.close()

--- a/tsdb/fileutil/mmap.go
+++ b/tsdb/fileutil/mmap.go
@@ -16,11 +16,25 @@ package fileutil
 import (
 	"fmt"
 	"os"
+	"runtime"
 )
+
+type mmapRef struct {
+	b []byte
+}
+
+func (m *mmapRef) close() error {
+	if m.b == nil {
+		return fmt.Errorf("mmap already closed")
+	}
+	err := munmap(m.b)
+	m.b = nil
+	return err
+}
 
 type MmapFile struct {
 	f *os.File
-	b []byte
+	m *mmapRef
 }
 
 func OpenMmapFile(path string) (*MmapFile, error) {
@@ -50,11 +64,18 @@ func OpenMmapFileWithSize(path string, size int) (mf *MmapFile, retErr error) {
 		return nil, fmt.Errorf("mmap, size %d: %w", size, err)
 	}
 
-	return &MmapFile{f: f, b: b}, nil
+	mr := &mmapRef{b: b}
+	mmapFile := &MmapFile{f: f, m: mr}
+
+	runtime.AddCleanup(mmapFile, func(m *mmapRef) {
+		_ = m.close()
+	}, mmapFile.m)
+
+	return mmapFile, nil
 }
 
 func (f *MmapFile) Close() error {
-	err0 := munmap(f.b)
+	err0 := f.m.close()
 	err1 := f.f.Close()
 
 	if err0 != nil {
@@ -68,5 +89,5 @@ func (f *MmapFile) File() *os.File {
 }
 
 func (f *MmapFile) Bytes() []byte {
-	return f.b
+	return f.m.b
 }

--- a/tsdb/fileutil/mmap_test.go
+++ b/tsdb/fileutil/mmap_test.go
@@ -1,0 +1,148 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !js && !plan9
+
+package fileutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+func TestOpenMmapFile(t *testing.T) {
+	dir := testutil.NewTemporaryDirectory("test_mmap", t)
+	defer dir.Close()
+
+	content := []byte("lorem impsum, this content is mmapped")
+
+	file := filepath.Join(dir.Path(), "mmap_target")
+	err := os.WriteFile(file, content, 0666)
+	require.NoError(t, err, "Failed to write test target file %q.", file)
+
+	mmap, err := OpenMmapFile(file)
+	require.NoError(t, err, "Failed to mmap target file %q.", file)
+
+	defer mmap.Close()
+	require.Equal(t, content, mmap.Bytes(), "Mmap does not match the data in the file")
+}
+
+func TestOpenMmapFileWithSize(t *testing.T) {
+	dir := testutil.NewTemporaryDirectory("test_mmap", t)
+	defer dir.Close()
+
+	content := []byte("lorem impsum, this content is mmapped")
+	sizes := []int{len(content), 12}
+
+	for idx, size := range sizes {
+		file := filepath.Join(dir.Path(), fmt.Sprintf("mmap_target_%d", idx))
+		err := os.WriteFile(file, content, 0666)
+		require.NoError(t, err, "Failed to write test target file %q.", file)
+
+		mmap, err := OpenMmapFileWithSize(file, size)
+		require.NoError(t, err, "Failed to mmap target file %q.", file)
+
+		defer mmap.Close()
+		require.Equal(t, content[:size], mmap.Bytes(), "Mmap does not match the data in the file")
+	}
+}
+
+func TestClose(t *testing.T) {
+	dir := testutil.NewTemporaryDirectory("test_mmap", t)
+	defer dir.Close()
+
+	content := []byte("lorem impsum, this content is mmapped")
+
+	file := filepath.Join(dir.Path(), "mmap_target")
+	err := os.WriteFile(file, content, 0666)
+	require.NoError(t, err, "Failed to write test target file %q.", file)
+
+	mmap, err := OpenMmapFile(file)
+	require.NoError(t, err, "Failed to mmap target file %q.", file)
+
+	err = mmap.Close()
+	require.NoError(t, err, "Failed to close mmap.")
+
+	err = mmap.Close()
+	require.Error(t, err, "Closing mmap multiple times should error.")
+}
+
+func TestGCCleanup(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("inspecting process memorymaps not implemented on this platform")
+	}
+
+	_, err := os.ReadFile("/proc/self/maps")
+	if err != nil {
+		t.Skip("procfs is not mounted, cannot validate mmappings")
+	}
+
+	dir := testutil.NewTemporaryDirectory("test_mmap", t)
+	defer dir.Close()
+
+	content := []byte("lorem impsum, this content is mmapped")
+
+	file := filepath.Join(dir.Path(), "mmap_leak_target")
+	err = os.WriteFile(file, content, 0666)
+	require.NoError(t, err, "Failed to write test target file %q.", file)
+
+	mmap, err := OpenMmapFile(file)
+	require.NoError(t, err, "Failed to mmap target file %q.", file)
+
+	// ensure we can find the file in /proc/self/maps
+	mmapped, err := isPathMmapped(file)
+	require.NoError(t, err, "Failed to determine if file is mapped %q.", file)
+	require.True(t, mmapped, "mmap memory map was unexpectedly missing")
+
+	// leak the mmap. Note the statement here keeps the object alive. After this
+	// the mmap is eligible for GC
+	_ = mmap
+
+	// run GC to run cleanup. This is undeterministic so let's run it a few times
+	for retry := 0; retry < 3; retry++ {
+		runtime.GC()
+		mmapped, err = isPathMmapped(file)
+		require.NoError(t, err, "Failed to determine if file is mapped %q.", file)
+
+		if !mmapped {
+			// GC cleaned the mmap
+			break
+		}
+
+		// GC didn't clean the handle, retry
+		time.Sleep(time.Second)
+	}
+
+	// ensure the mmap was cleaned up, and we cannot find the mapping in /proc/self/maps
+	mmapped, err = isPathMmapped(file)
+	require.False(t, mmapped, "mmap memory map was unexpectedly leaked")
+}
+
+// Determines if this process has the given file in a file-backed memory map
+func isPathMmapped(file string) (bool, error) {
+	maps, err := os.ReadFile("/proc/self/maps")
+	if err != nil {
+		return false, err
+	}
+	// don't bother parsing maps. The test file path is unique enough
+	return strings.Contains(string(maps), file), nil
+}

--- a/tsdb/fileutil/mmap_test.go
+++ b/tsdb/fileutil/mmap_test.go
@@ -36,7 +36,7 @@ func TestOpenMmapFile(t *testing.T) {
 	content := []byte("lorem impsum, this content is mmapped")
 
 	file := filepath.Join(dir.Path(), "mmap_target")
-	err := os.WriteFile(file, content, 0666)
+	err := os.WriteFile(file, content, 0o666)
 	require.NoError(t, err, "Failed to write test target file %q.", file)
 
 	mmap, err := OpenMmapFile(file)
@@ -55,7 +55,7 @@ func TestOpenMmapFileWithSize(t *testing.T) {
 
 	for idx, size := range sizes {
 		file := filepath.Join(dir.Path(), fmt.Sprintf("mmap_target_%d", idx))
-		err := os.WriteFile(file, content, 0666)
+		err := os.WriteFile(file, content, 0o666)
 		require.NoError(t, err, "Failed to write test target file %q.", file)
 
 		mmap, err := OpenMmapFileWithSize(file, size)
@@ -73,7 +73,7 @@ func TestClose(t *testing.T) {
 	content := []byte("lorem impsum, this content is mmapped")
 
 	file := filepath.Join(dir.Path(), "mmap_target")
-	err := os.WriteFile(file, content, 0666)
+	err := os.WriteFile(file, content, 0o666)
 	require.NoError(t, err, "Failed to write test target file %q.", file)
 
 	mmap, err := OpenMmapFile(file)
@@ -102,7 +102,7 @@ func TestGCCleanup(t *testing.T) {
 	content := []byte("lorem impsum, this content is mmapped")
 
 	file := filepath.Join(dir.Path(), "mmap_leak_target")
-	err = os.WriteFile(file, content, 0666)
+	err = os.WriteFile(file, content, 0o666)
 	require.NoError(t, err, "Failed to write test target file %q.", file)
 
 	mmap, err := OpenMmapFile(file)
@@ -118,7 +118,7 @@ func TestGCCleanup(t *testing.T) {
 	_ = mmap
 
 	// run GC to run cleanup. This is undeterministic so let's run it a few times
-	for retry := 0; retry < 3; retry++ {
+	for range 3 {
 		runtime.GC()
 		mmapped, err = isPathMmapped(file)
 		require.NoError(t, err, "Failed to determine if file is mapped %q.", file)
@@ -133,11 +133,10 @@ func TestGCCleanup(t *testing.T) {
 	}
 
 	// ensure the mmap was cleaned up, and we cannot find the mapping in /proc/self/maps
-	mmapped, err = isPathMmapped(file)
 	require.False(t, mmapped, "mmap memory map was unexpectedly leaked")
 }
 
-// Determines if this process has the given file in a file-backed memory map
+// Determines if this process has the given file in a file-backed memory map.
 func isPathMmapped(file string) (bool, error) {
 	maps, err := os.ReadFile("/proc/self/maps")
 	if err != nil {


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```

## Description

This PR adds a GC cleanup routine to `fileUtil.MmapFile` that ensures the file reference is released even if the object is leaked and Close is not called.

This is achieved by moving the mmap pointer into a new `mmapRef` struct that owns the mapping. When `MmapFile` is leaked, the cleanup handler is ran for the `mmapRef`, unmapping the memory. As a side effect, calling `Close()` multiple times is now safe. It will return an error instead of using the dangling pointer to unmap some potentially later mapped memory.

### Background

Forgetting to call `Close()` is surprisingly dangerous. The open `mmap` keeps a reference to the underlying file, keeping it open.
If leaks continue, the number of open files in the system increases until system limit is reached. When this system limit is reached, the whole system is unstable and unusable as every operation that opens a new file will fail with `ENFILE`*.

What makes this especially subtle is that cleanup handler in `os.File` will release the file descriptor (the integer), while the file (`struct file`) remains open. This means the leaking will not hit the processes FD limit, but instead the file table system limit which then causes the system-wide issues.

As a concrete example, a downstream product failing to Close tsdb indices leaked 400k files, filled the server's file table, and caused some service downtime: https://github.com/grafana/loki/pull/19408

Rather than cat-and-mouse all downstream projects to ensure proper cleanup, this PR attempts to eliminate this whole class of resource leaks.

*) unless you have CAP_SYS_ADMIN

### Example

Let's say we have this example `cmd/fdleaktest` that leaks handles:

```go
package main

import (
	"fmt"
	"os"
	"runtime"
	"time"

	"github.com/prometheus/prometheus/tsdb/fileutil"
)

const NumLeaked int = 10

func main() {
	for range NumLeaked {
		LeakHandle()
	}
	runtime.GC()

	fmt.Printf("Leaked %v\n", NumLeaked)
	time.Sleep(time.Hour)
}

func LeakHandle() {
	file, err := os.CreateTemp("", "fd-leak-test")
	if err != nil {
		panic(err)
	}

	name := file.Name()
	_, err = file.WriteString("exampleContent")
	if err != nil {
		panic(err)
	}

	err = file.Close()
	if err != nil {
		panic(err)
	}

	mmap, err := fileutil.OpenMmapFile(name)
	if err != nil {
		panic(err)
	}

	_ = mmap
}
```

And then inspecting the open files after GC:
```sh
./fdleaktest & sleep 1; lsof -p $!; fg
```

**Before**
```
[2] 3560
3560
Leaked 10
COMMAND    PID USER   FD      TYPE DEVICE SIZE/OFF    NODE NAME
fdleaktes 3560 user  cwd       DIR    8,2     4096 5018021 /home/user/dev/prometheus
fdleaktes 3560 user  rtd       DIR    8,2     4096       2 /
fdleaktes 3560 user  txt       REG    8,2  2503367 1441809 /home/user/dev/prometheus/fdleaktest
fdleaktes 3560 user  mem       REG    8,2       14 1310794 /tmp/fd-leak-test937778275
fdleaktes 3560 user  mem       REG    8,2       14 1310793 /tmp/fd-leak-test462592239
fdleaktes 3560 user  mem       REG    8,2       14 1310792 /tmp/fd-leak-test1225511075
fdleaktes 3560 user  mem       REG    8,2       14 1310791 /tmp/fd-leak-test3024199063
fdleaktes 3560 user  mem       REG    8,2       14 1310790 /tmp/fd-leak-test2552334960
fdleaktes 3560 user  mem       REG    8,2       14 1310789 /tmp/fd-leak-test1566593892
fdleaktes 3560 user  mem       REG    8,2       14 1310788 /tmp/fd-leak-test3298073950
fdleaktes 3560 user  mem       REG    8,2       14 1310786 /tmp/fd-leak-test3783026895
fdleaktes 3560 user  mem       REG    8,2       14 1310785 /tmp/fd-leak-test904628009
fdleaktes 3560 user  mem       REG    8,2       14 1310784 /tmp/fd-leak-test2860826419
fdleaktes 3560 user    0u      CHR  136,0      0t0       3 /dev/pts/0
fdleaktes 3560 user    1u      CHR  136,0      0t0       3 /dev/pts/0
fdleaktes 3560 user    2u      CHR  136,0      0t0       3 /dev/pts/0
fdleaktes 3560 user    4u  a_inode   0,13        0    8966 [eventpoll]
fdleaktes 3560 user    5u  a_inode   0,13        0    8966 [eventfd]
```

**After**

```
./fdleaktest & echo $!; sleep 1; lsof -p $!; fg
[2] 3631
3631
Leaked 10
COMMAND    PID USER   FD      TYPE DEVICE SIZE/OFF    NODE NAME
fdleaktes 3631 user  cwd       DIR    8,2     4096 5018021 /home/user/dev/prometheus
fdleaktes 3631 user  rtd       DIR    8,2     4096       2 /
fdleaktes 3631 user  txt       REG    8,2  2522894 1441816 /home/user/dev/prometheus/fdleaktest
fdleaktes 3631 user    0u      CHR  136,0      0t0       3 /dev/pts/0
fdleaktes 3631 user    1u      CHR  136,0      0t0       3 /dev/pts/0
fdleaktes 3631 user    2u      CHR  136,0      0t0       3 /dev/pts/0
fdleaktes 3631 user    4u  a_inode   0,13        0    8966 [eventpoll]
fdleaktes 3631 user    5u  a_inode   0,13        0    8966 [eventfd]
```

### Risks

The automatic release of the mmap is sound when `MmapFile` is leaked as a whole.
However, if a downstream application keeps the `Bytes()` but leaks the container `MmapFile`, the byte slice will become a dangling pointer after cleanup runs and accessing this slice will segfault.

As an example, this will segfault with the PR:

```go
package main

import (
	"fmt"
	"os"
	"runtime"

	"github.com/prometheus/prometheus/tsdb/fileutil"
)

func main() {
	Crash()
}

func Crash() {
	file, err := os.CreateTemp("", "fd-leak-test")
	if err != nil {
		panic(err)
	}

	name := file.Name()
	_, err = file.WriteString("exampleContent")
	if err != nil {
		panic(err)
	}

	mmap, err := fileutil.OpenMmapFile(name)
	if err != nil {
		panic(err)
	}

	buf := mmap.Bytes()
	runtime.GC()

	fmt.Printf("Reading dangling pointer %v\n", buf[0])
}
```

Does this seem like a realistic pattern a downstream project could do?