### PR TITLE
discovery/http: add retry support

### DIFF
--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
@@ -42,6 +43,7 @@ var (
 	DefaultSDConfig = SDConfig{
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 		RefreshInterval:  model.Duration(60 * time.Second),
+		MinBackoff:       0,
 	}
 	userAgent        = version.PrometheusUserAgent()
 	matchContentType = regexp.MustCompile(`^(?i:application\/json(;\s*charset=("utf-8"|utf-8))?)$`)
@@ -56,6 +58,8 @@ type SDConfig struct {
 	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 	RefreshInterval  model.Duration          `yaml:"refresh_interval,omitempty"`
 	URL              string                  `yaml:"url"`
+	// MinBackoff is the initial delay between retries. A zero value disables retries.
+	MinBackoff model.Duration `yaml:"min_backoff,omitempty"`
 }
 
 // NewDiscovererMetrics implements discovery.Config.
@@ -97,6 +101,12 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if parsedURL.Host == "" {
 		return errors.New("host is missing in URL")
 	}
+	if c.MinBackoff < 0 {
+		return errors.New("min_backoff must not be negative")
+	}
+	if c.MinBackoff > c.RefreshInterval {
+		return errors.New("min_backoff must not be greater than refresh_interval")
+	}
 	return c.HTTPClientConfig.Validate()
 }
 
@@ -109,6 +119,7 @@ type Discovery struct {
 	url             string
 	client          *http.Client
 	refreshInterval time.Duration
+	minBackoff      time.Duration
 	tgLastLength    int
 	metrics         *httpMetrics
 }
@@ -134,6 +145,7 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 		url:             conf.URL,
 		client:          client,
 		refreshInterval: time.Duration(conf.RefreshInterval), // Stored to be sent as headers.
+		minBackoff:      time.Duration(conf.MinBackoff),
 		metrics:         m,
 	}
 
@@ -151,6 +163,53 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 }
 
 func (d *Discovery) Refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	tgs, err := d.refresh(ctx)
+	if err != nil {
+		d.metrics.failuresCount.Inc()
+	}
+	return tgs, err
+}
+
+func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	if d.minBackoff == 0 {
+		return d.doRefresh(ctx)
+	}
+
+	retryCtx, cancel := context.WithTimeout(ctx, d.refreshInterval)
+	defer cancel()
+
+	b := &backoff.ExponentialBackOff{
+		InitialInterval:     d.minBackoff,
+		RandomizationFactor: 0,
+		Multiplier:          2,
+		MaxInterval:         d.refreshInterval,
+	}
+	return backoff.Retry(retryCtx, func() ([]*targetgroup.Group, error) {
+		tgs, err := d.doRefresh(retryCtx)
+		if err == nil {
+			return tgs, nil
+		}
+		var retryableErr *retryableError
+		if !errors.As(err, &retryableErr) {
+			return nil, backoff.Permanent(err)
+		}
+		return nil, err
+	}, backoff.WithBackOff(b), backoff.WithMaxElapsedTime(d.refreshInterval))
+}
+
+type retryableError struct {
+	err error
+}
+
+func (e *retryableError) Error() string {
+	return e.err.Error()
+}
+
+func (e *retryableError) Unwrap() error {
+	return e.err
+}
+
+func (d *Discovery) doRefresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	req, err := http.NewRequest(http.MethodGet, d.url, http.NoBody)
 	if err != nil {
 		return nil, err
@@ -161,8 +220,10 @@ func (d *Discovery) Refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 	resp, err := d.client.Do(req.WithContext(ctx))
 	if err != nil {
-		d.metrics.failuresCount.Inc()
-		return nil, err
+		if ctx.Err() != nil {
+			return nil, context.Cause(ctx)
+		}
+		return nil, &retryableError{err: err}
 	}
 	defer func() {
 		io.Copy(io.Discard, resp.Body)
@@ -170,31 +231,30 @@ func (d *Discovery) Refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		d.metrics.failuresCount.Inc()
-		return nil, fmt.Errorf("server returned HTTP status %s", resp.Status)
+		err := fmt.Errorf("server returned HTTP status %s", resp.Status)
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 && resp.StatusCode <= 599 {
+			return nil, &retryableError{err: err}
+		}
+		return nil, err
 	}
 
 	if !matchContentType.MatchString(strings.TrimSpace(resp.Header.Get("Content-Type"))) {
-		d.metrics.failuresCount.Inc()
 		return nil, fmt.Errorf("unsupported content type %q", resp.Header.Get("Content-Type"))
 	}
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		d.metrics.failuresCount.Inc()
-		return nil, err
+		return nil, &retryableError{err: err}
 	}
 
 	var targetGroups []*targetgroup.Group
 
 	if err := json.Unmarshal(b, &targetGroups); err != nil {
-		d.metrics.failuresCount.Inc()
 		return nil, err
 	}
 
 	for i, tg := range targetGroups {
 		if tg == nil {
-			d.metrics.failuresCount.Inc()
 			err = errors.New("nil target group item found")
 			return nil, err
 		}

--- a/discovery/http/http_test.go
+++ b/discovery/http/http_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -223,6 +225,178 @@ func TestContentTypeRegex(t *testing.T) {
 			require.Equal(t, test.match, matchContentType.MatchString(test.header))
 		})
 	}
+}
+
+func TestMinBackoffConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		config          string
+		wantMinBackoff  model.Duration
+		wantErrContains string
+	}{
+		{
+			name: "disabled by default",
+			config: `url: http://example.com
+refresh_interval: 1m
+`,
+		},
+		{
+			name: "configured",
+			config: `url: http://example.com
+refresh_interval: 1m
+min_backoff: 5s
+`,
+			wantMinBackoff: model.Duration(5 * time.Second),
+		},
+		{
+			name: "greater than refresh interval",
+			config: `url: http://example.com
+refresh_interval: 5s
+min_backoff: 10s
+`,
+			wantErrContains: "min_backoff must not be greater than refresh_interval",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var cfg SDConfig
+			err := yaml.Unmarshal([]byte(test.config), &cfg)
+			if test.wantErrContains != "" {
+				require.ErrorContains(t, err, test.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.wantMinBackoff, cfg.MinBackoff)
+		})
+	}
+}
+
+func TestHTTPRetry(t *testing.T) {
+	tests := []struct {
+		name            string
+		minBackoff      time.Duration
+		statusCodes     []int
+		wantAttempts    int32
+		wantTargets     int
+		wantErrContains string
+	}{
+		{
+			name:       "server errors then success",
+			minBackoff: time.Millisecond,
+			statusCodes: []int{
+				http.StatusInternalServerError,
+				http.StatusBadGateway,
+				http.StatusOK,
+			},
+			wantAttempts: 3,
+			wantTargets:  1,
+		},
+		{
+			name:       "rate limit then success",
+			minBackoff: time.Millisecond,
+			statusCodes: []int{
+				http.StatusTooManyRequests,
+				http.StatusOK,
+			},
+			wantAttempts: 2,
+			wantTargets:  1,
+		},
+		{
+			name: "disabled",
+			statusCodes: []int{
+				http.StatusInternalServerError,
+				http.StatusOK,
+			},
+			wantAttempts:    1,
+			wantErrContains: "server returned HTTP status 500 Internal Server Error",
+		},
+		{
+			name:       "client error",
+			minBackoff: time.Millisecond,
+			statusCodes: []int{
+				http.StatusBadRequest,
+				http.StatusOK,
+			},
+			wantAttempts:    1,
+			wantErrContains: "server returned HTTP status 400 Bad Request",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var attempts atomic.Int32
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				attempt := int(attempts.Add(1)) - 1
+				statusCode := test.statusCodes[min(attempt, len(test.statusCodes)-1)]
+				if statusCode == http.StatusOK {
+					w.Header().Set("Content-Type", "application/json")
+				}
+				w.WriteHeader(statusCode)
+				if statusCode == http.StatusOK {
+					fmt.Fprint(w, `[{"targets":["127.0.0.1:9090"]}]`)
+				}
+			}))
+			t.Cleanup(ts.Close)
+
+			d := newTestDiscovery(t, SDConfig{
+				HTTPClientConfig: config.DefaultHTTPClientConfig,
+				URL:              ts.URL,
+				RefreshInterval:  model.Duration(100 * time.Millisecond),
+				MinBackoff:       model.Duration(test.minBackoff),
+			})
+			tgs, err := d.Refresh(context.Background())
+			if test.wantErrContains != "" {
+				require.ErrorContains(t, err, test.wantErrContains)
+				require.Equal(t, 1.0, getFailureCount(d.metrics.failuresCount))
+			} else {
+				require.NoError(t, err)
+				require.Len(t, tgs, test.wantTargets)
+				require.Equal(t, 0.0, getFailureCount(d.metrics.failuresCount))
+			}
+			require.Equal(t, test.wantAttempts, attempts.Load())
+		})
+	}
+}
+
+func TestHTTPRetryBudget(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(ts.Close)
+
+	d := newTestDiscovery(t, SDConfig{
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
+		URL:              ts.URL,
+		RefreshInterval:  model.Duration(100 * time.Millisecond),
+		MinBackoff:       model.Duration(5 * time.Millisecond),
+	})
+	start := time.Now()
+	_, err := d.Refresh(context.Background())
+	require.EqualError(t, err, "server returned HTTP status 500 Internal Server Error")
+	require.Greater(t, attempts.Load(), int32(1))
+	require.Less(t, time.Since(start), 500*time.Millisecond)
+	require.Equal(t, 1.0, getFailureCount(d.metrics.failuresCount))
+}
+
+func newTestDiscovery(t *testing.T, cfg SDConfig) *Discovery {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	refreshMetrics := discovery.NewRefreshMetrics(reg)
+	t.Cleanup(refreshMetrics.Unregister)
+	metrics := cfg.NewDiscovererMetrics(reg, refreshMetrics)
+	require.NoError(t, metrics.Register())
+	t.Cleanup(metrics.Unregister)
+
+	d, err := NewDiscovery(&cfg, discovery.DiscovererOptions{
+		Logger:  promslog.NewNopLogger(),
+		Metrics: metrics,
+		SetName: "http",
+	})
+	require.NoError(t, err)
+	return d
 }
 
 func TestSourceDisappeared(t *testing.T) {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2363,6 +2363,9 @@ Example response body:
 ```
 
 The endpoint is queried periodically at the specified refresh interval.
+Transient transport errors, HTTP 429 responses, and HTTP 5xx responses can be
+retried with exponential backoff by setting `min_backoff`. The total retry
+window is limited to the refresh interval.
 The `prometheus_sd_http_failures_total` counter metric tracks the number of
 refresh failures.
 
@@ -2380,6 +2383,10 @@ url: <string>
 
 # Refresh interval to re-query the endpoint.
 [ refresh_interval: <duration> | default = 60s ]
+
+# Initial delay between retries. The delay doubles after each failed attempt.
+# Retries are disabled when this is zero.
+[ min_backoff: <duration> | default = 0s ]
 
 # HTTP client settings, including authentication methods (such as basic auth and
 # authorization), proxy configurations, TLS options, custom HTTP headers, etc.

--- a/docs/http_sd.md
+++ b/docs/http_sd.md
@@ -39,7 +39,10 @@ an empty list `[]`. Target lists are unordered.
 
 Prometheus caches target lists. If an error occurs while fetching an updated
 targets list, Prometheus keeps using the current targets list. The targets list
-is not saved across restart. The `prometheus_sd_refresh_failures_total` counter
+is not saved across restart. When `min_backoff` is configured, Prometheus
+retries transport errors, HTTP 429 responses, and HTTP 5xx responses with
+exponential backoff. Retries stop when the refresh interval is exhausted.
+The `prometheus_sd_refresh_failures_total` counter
 metric tracks the number of refresh failures and the `prometheus_sd_refresh_duration_seconds`
 bucket can be used to track HTTP SD refresh attempts or performance. These metrics are
 removed when the underlying scrape job disappears on Prometheus configuration reload.


### PR DESCRIPTION
## Summary

Adds optional exponential-backoff retries to HTTP service discovery.

- `min_backoff` defaults to `0`, preserving the existing no-retry behavior.
- Transport errors, HTTP 429 responses, and HTTP 5xx responses are retried.
- The delay doubles after each failed attempt, and the total retry window is bounded by `refresh_interval`.
- Per-attempt metrics and logs are intentionally avoided; the existing failure counter records a final refresh failure once.

This revision incorporates the earlier review feedback by replacing the multi-field retry configuration with one `min_backoff` setting and substantially reducing the retry implementation and tests.

Fixes #17137

## Tests

- `go test ./discovery/http`
- `go test -race ./discovery/http`
- `go test -count=10 ./discovery/http -run 'Test(MinBackoffConfig|HTTPRetry|HTTPRetryBudget)$'`
- `go test ./discovery/... ./config`
- `make lint`

```release-notes
[FEATURE] HTTP SD: Add optional retries for transient refresh failures.
```
