### PR TITLE
test(discovery/file): enable parallel execution for initial and invalid file tests

### DIFF
--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -329,7 +329,6 @@ func TestInitialUpdate(t *testing.T) {
 		"fixtures/valid.yml",
 		"fixtures/valid.json",
 	} {
-		tc := tc
 		t.Run(tc, func(t *testing.T) {
 			t.Parallel()
 
@@ -352,7 +351,6 @@ func TestInvalidFile(t *testing.T) {
 		"fixtures/invalid_nil.yml",
 		"fixtures/invalid_nil.json",
 	} {
-		tc := tc
 		t.Run(tc, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Add `t.Parallel()` to test functions in `discovery/file` to enable parallel execution.

Related to #15185 

**Performance:**
- Before: ~2.347s
- After: ~1.205s
- **Improvement: 49% faster (~1.14s saved)**
```release-notes
NONE
```
