### PR TITLE
test(discovery/xds): speed up tests with t.Parallel()

### DIFF
--- a/discovery/xds/client_test.go
+++ b/discovery/xds/client_test.go
@@ -49,6 +49,8 @@ func urlMustParse(str string) *url.URL {
 }
 
 func TestMakeXDSResourceHttpEndpointEmptyServerURLScheme(t *testing.T) {
+	t.Parallel()
+
 	endpointURL, err := makeXDSResourceHTTPEndpointURL(ProtocolV3, urlMustParse("127.0.0.1"), "monitoring")
 
 	require.Empty(t, endpointURL)
@@ -56,6 +58,8 @@ func TestMakeXDSResourceHttpEndpointEmptyServerURLScheme(t *testing.T) {
 }
 
 func TestMakeXDSResourceHttpEndpointEmptyServerURLHost(t *testing.T) {
+	t.Parallel()
+
 	endpointURL, err := makeXDSResourceHTTPEndpointURL(ProtocolV3, urlMustParse("grpc://127.0.0.1"), "monitoring")
 
 	require.Empty(t, endpointURL)
@@ -63,6 +67,8 @@ func TestMakeXDSResourceHttpEndpointEmptyServerURLHost(t *testing.T) {
 }
 
 func TestMakeXDSResourceHttpEndpoint(t *testing.T) {
+	t.Parallel()
+
 	endpointURL, err := makeXDSResourceHTTPEndpointURL(ProtocolV3, urlMustParse("http://127.0.0.1:5000"), "monitoring")
 
 	require.NoError(t, err)
@@ -70,6 +76,8 @@ func TestMakeXDSResourceHttpEndpoint(t *testing.T) {
 }
 
 func TestCreateNewHTTPResourceClient(t *testing.T) {
+	t.Parallel()
+
 	c := &HTTPResourceClientConfig{
 		HTTPClientConfig: sdConf.HTTPClientConfig,
 		Name:             "test",
@@ -106,6 +114,8 @@ func createTestHTTPResourceClient(t *testing.T, conf *HTTPResourceClientConfig, 
 }
 
 func TestHTTPResourceClientFetchEmptyResponse(t *testing.T) {
+	t.Parallel()
+
 	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(*v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		return nil, nil
 	})
@@ -117,6 +127,8 @@ func TestHTTPResourceClientFetchEmptyResponse(t *testing.T) {
 }
 
 func TestHTTPResourceClientFetchFullResponse(t *testing.T) {
+	t.Parallel()
+
 	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		if request.VersionInfo == "1" {
 			return nil, nil
@@ -146,6 +158,8 @@ func TestHTTPResourceClientFetchFullResponse(t *testing.T) {
 }
 
 func TestHTTPResourceClientServerError(t *testing.T) {
+	t.Parallel()
+
 	client, cleanup := createTestHTTPResourceClient(t, testHTTPResourceConfig(), ProtocolV3, func(*v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		return nil, errors.New("server error")
 	})

--- a/discovery/xds/kuma_test.go
+++ b/discovery/xds/kuma_test.go
@@ -131,6 +131,8 @@ func newKumaTestHTTPDiscovery(c KumaSDConfig) (*fetchDiscovery, error) {
 }
 
 func TestKumaMadsV1ResourceParserInvalidTypeURL(t *testing.T) {
+	t.Parallel()
+
 	resources := make([]*anypb.Any, 0)
 	groups, err := kumaMadsV1ResourceParser(resources, "type.googleapis.com/some.api.v1.Monitoring")
 	require.Nil(t, groups)
@@ -138,6 +140,8 @@ func TestKumaMadsV1ResourceParserInvalidTypeURL(t *testing.T) {
 }
 
 func TestKumaMadsV1ResourceParserEmptySlice(t *testing.T) {
+	t.Parallel()
+
 	resources := make([]*anypb.Any, 0)
 	groups, err := kumaMadsV1ResourceParser(resources, KumaMadsV1ResourceTypeURL)
 	require.Empty(t, groups)
@@ -145,6 +149,8 @@ func TestKumaMadsV1ResourceParserEmptySlice(t *testing.T) {
 }
 
 func TestKumaMadsV1ResourceParserValidResources(t *testing.T) {
+	t.Parallel()
+
 	res, err := getKumaMadsV1DiscoveryResponse(testKumaMadsV1Resources...)
 	require.NoError(t, err)
 
@@ -192,6 +198,8 @@ func TestKumaMadsV1ResourceParserValidResources(t *testing.T) {
 }
 
 func TestKumaMadsV1ResourceParserInvalidResources(t *testing.T) {
+	t.Parallel()
+
 	data, err := protoJSONMarshalOptions.Marshal(&MonitoringAssignment_Target{})
 	require.NoError(t, err)
 
@@ -206,6 +214,8 @@ func TestKumaMadsV1ResourceParserInvalidResources(t *testing.T) {
 }
 
 func TestNewKumaHTTPDiscovery(t *testing.T) {
+	t.Parallel()
+
 	kd, err := newKumaTestHTTPDiscovery(kumaConf)
 	require.NoError(t, err)
 	require.NotNil(t, kd)
@@ -221,6 +231,8 @@ func TestNewKumaHTTPDiscovery(t *testing.T) {
 }
 
 func TestKumaHTTPDiscoveryRefresh(t *testing.T) {
+	t.Parallel()
+
 	s := createTestHTTPServer(t, func(request *v3.DiscoveryRequest) (*v3.DiscoveryResponse, error) {
 		if request.VersionInfo == "1" {
 			return nil, nil

--- a/discovery/xds/xds_test.go
+++ b/discovery/xds/xds_test.go
@@ -119,6 +119,8 @@ func (testResourceClient) Close() {
 }
 
 func TestPollingRefreshSkipUpdate(t *testing.T) {
+	t.Parallel()
+
 	rc := &testResourceClient{
 		fetch: func(context.Context) (*v3.DiscoveryResponse, error) {
 			return nil, nil
@@ -162,6 +164,8 @@ func TestPollingRefreshSkipUpdate(t *testing.T) {
 }
 
 func TestPollingRefreshAttachesGroupMetadata(t *testing.T) {
+	t.Parallel()
+
 	server := "http://198.161.2.0"
 	source := "test"
 	rc := &testResourceClient{
@@ -218,6 +222,8 @@ func TestPollingRefreshAttachesGroupMetadata(t *testing.T) {
 }
 
 func TestPollingDisappearingTargets(t *testing.T) {
+	t.Parallel()
+
 	server := "http://198.161.2.0"
 	source := "test"
 	rc := &testResourceClient{


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Related to #15185 
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
Add `t.Parallel()` to all test functions in `discovery/xds` to enable parallel execution.

**Changes:**
- Added `t.Parallel()` to 14 test functions across 3 test files:
  - `kuma_test.go`: 4 tests
  - `xds_test.go`: 3 tests  
  - `client_test.go`: 7 tests

**Performance:**
- Before: ~2.019s
- After: ~1.008s
- **Improvement: 50% faster (~1.01s saved)**
```release-notes
NONE
```
