### PR TITLE
test: Enable parallel execution for chunk write queue tests

### DIFF
--- a/tsdb/chunks/chunk_write_queue_test.go
+++ b/tsdb/chunks/chunk_write_queue_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestChunkWriteQueue_GettingChunkFromQueue(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	var blockWriterWg sync.WaitGroup
 	blockWriterWg.Add(1)
 
@@ -56,7 +56,7 @@ func TestChunkWriteQueue_GettingChunkFromQueue(t *testing.T) {
 }
 
 func TestChunkWriteQueue_WritingThroughQueue(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	var (
 		gotSeriesRef     HeadSeriesRef
 		gotMint, gotMaxt int64
@@ -99,7 +99,7 @@ func TestChunkWriteQueue_WritingThroughQueue(t *testing.T) {
 }
 
 func TestChunkWriteQueue_WrappingAroundSizeLimit(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	sizeLimit := 100
 	unblockChunkWriterCh := make(chan struct{}, sizeLimit)
 
@@ -186,7 +186,7 @@ func TestChunkWriteQueue_WrappingAroundSizeLimit(t *testing.T) {
 }
 
 func TestChunkWriteQueue_HandlerErrorViaCallback(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	testError := errors.New("test error")
 	chunkWriter := func(HeadSeriesRef, int64, int64, chunkenc.Chunk, ChunkDiskMapperRef, bool, bool) error {
 		return testError

--- a/tsdb/chunks/chunks_test.go
+++ b/tsdb/chunks/chunks_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestReaderWithInvalidBuffer(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	b := realByteSlice([]byte{0x81, 0x81, 0x81, 0x81, 0x81, 0x81})
 	r := &Reader{bs: []ByteSlice{b}}
 
@@ -32,7 +32,7 @@ func TestReaderWithInvalidBuffer(t *testing.T) {
 }
 
 func TestWriterWithDefaultSegmentSize(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	chk1, err := ChunkFromSamples([]Sample{
 		sample{t: 10, f: 11},
 		sample{t: 20, f: 12},

--- a/tsdb/chunks/head_chunks_test.go
+++ b/tsdb/chunks/head_chunks_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestChunkDiskMapper_WriteChunk_Chunk_IterateChunks(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	hrw := createChunkDiskMapper(t, "")
 	defer func() {
 		require.NoError(t, hrw.Close())
@@ -182,7 +182,7 @@ func TestChunkDiskMapper_WriteChunk_Chunk_IterateChunks(t *testing.T) {
 // * The active file is not deleted even if the passed time makes it eligible to be deleted.
 // * Non-empty current file leads to creation of another file after truncation.
 func TestChunkDiskMapper_Truncate(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	hrw := createChunkDiskMapper(t, "")
 	defer func() {
 		require.NoError(t, hrw.Close())
@@ -277,7 +277,7 @@ func TestChunkDiskMapper_Truncate(t *testing.T) {
 // This test exposes https://github.com/prometheus/prometheus/issues/7412 where the truncation
 // simply deleted all empty files instead of stopping once it encountered a non-empty file.
 func TestChunkDiskMapper_Truncate_PreservesFileSequence(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	hrw := createChunkDiskMapper(t, "")
 	defer func() {
 		require.NoError(t, hrw.Close())
@@ -362,7 +362,7 @@ func TestChunkDiskMapper_Truncate_PreservesFileSequence(t *testing.T) {
 }
 
 func TestChunkDiskMapper_Truncate_WriteQueueRaceCondition(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	hrw := createChunkDiskMapper(t, "")
 	t.Cleanup(func() {
 		require.NoError(t, hrw.Close())
@@ -415,7 +415,7 @@ func TestChunkDiskMapper_Truncate_WriteQueueRaceCondition(t *testing.T) {
 // TestHeadReadWriter_TruncateAfterFailedIterateChunks tests for
 // https://github.com/prometheus/prometheus/issues/7753
 func TestHeadReadWriter_TruncateAfterFailedIterateChunks(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	hrw := createChunkDiskMapper(t, "")
 	defer func() {
 		require.NoError(t, hrw.Close())
@@ -447,7 +447,7 @@ func TestHeadReadWriter_TruncateAfterFailedIterateChunks(t *testing.T) {
 }
 
 func TestHeadReadWriter_ReadRepairOnEmptyLastFile(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	hrw := createChunkDiskMapper(t, "")
 
 	timeRange := 0

--- a/tsdb/chunks/queue_test.go
+++ b/tsdb/chunks/queue_test.go
@@ -62,7 +62,7 @@ func (q *writeJobQueue) assertInvariants(t *testing.T) {
 }
 
 func TestQueuePushPopSingleGoroutine(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	seed := time.Now().UnixNano()
 	t.Log("seed:", seed)
 	r := rand.New(rand.NewSource(seed))
@@ -116,7 +116,7 @@ func TestQueuePushPopSingleGoroutine(t *testing.T) {
 }
 
 func TestQueuePushBlocksOnFullQueue(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	queue := newWriteJobQueue(5, 5)
 
 	pushTime := make(chan time.Time)
@@ -154,7 +154,7 @@ func TestQueuePushBlocksOnFullQueue(t *testing.T) {
 }
 
 func TestQueuePopBlocksOnEmptyQueue(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	queue := newWriteJobQueue(5, 5)
 
 	popTime := make(chan time.Time)
@@ -195,7 +195,7 @@ func TestQueuePopBlocksOnEmptyQueue(t *testing.T) {
 }
 
 func TestQueuePopUnblocksOnClose(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	queue := newWriteJobQueue(5, 5)
 
 	popTime := make(chan time.Time)
@@ -235,7 +235,7 @@ func TestQueuePopUnblocksOnClose(t *testing.T) {
 }
 
 func TestQueuePopAfterCloseReturnsAllElements(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	const count = 10
 
 	queue := newWriteJobQueue(count, count)
@@ -262,7 +262,7 @@ func TestQueuePopAfterCloseReturnsAllElements(t *testing.T) {
 }
 
 func TestQueuePushPopManyGoroutines(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	const readGoroutines = 5
 	const writeGoroutines = 10
 	const writes = 500
@@ -317,7 +317,7 @@ func TestQueuePushPopManyGoroutines(t *testing.T) {
 }
 
 func TestQueueSegmentIsKeptEvenIfEmpty(t *testing.T) {
-	 t.Parallel()
+	t.Parallel()
 	queue := newWriteJobQueue(1024, 64)
 
 	require.True(t, queue.push(chunkWriteJob{seriesRef: 1}))


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
-Addresses #15185

<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Changes:
Add t.Parallel() to all test functions in tsdb/chunks/ to enable parallel test execution.

## Performance improvement:

- Before: ~4.455s (wall: 4.854s)
- After: ~3.308s (wall: 3.928s)
- Improvement: ~1.15 seconds faster (26% reduction in test time)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
