### PR TITLE
OTLP: Add configuration parameters to control label name translation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -266,6 +266,10 @@ var (
 	// DefaultOTLPConfig is the default OTLP configuration.
 	DefaultOTLPConfig = OTLPConfig{
 		TranslationStrategy: otlptranslator.UnderscoreEscapingWithSuffixes,
+		// For backwards compatibility.
+		LabelNameUnderscoreSanitization: true,
+		// For backwards compatibility.
+		LabelNamePreserveMultipleUnderscores: true,
 	}
 )
 
@@ -1654,6 +1658,14 @@ type OTLPConfig struct {
 	// PromoteScopeMetadata controls whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
 	// As per OTel spec, the aforementioned scope metadata should be identifying, i.e. made into metric labels.
 	PromoteScopeMetadata bool `yaml:"promote_scope_metadata,omitempty"`
+	// LabelNameUnderscoreSanitization controls whether to enable prepending of 'key_' to labels
+	// starting with '_'. Reserved labels starting with `__` are not modified.
+	// This is only relevant when AllowUTF8 is false (i.e., when using underscore escaping).
+	LabelNameUnderscoreSanitization bool `yaml:"label_name_underscore_sanitization,omitempty"`
+	// LabelNamePreserveMultipleUnderscores enables preserving of multiple consecutive underscores
+	// in label names when AllowUTF8 is false. When false, multiple consecutive underscores are
+	// collapsed to a single underscore during label name sanitization.
+	LabelNamePreserveMultipleUnderscores bool `yaml:"label_name_preserve_multiple_underscores,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -175,7 +175,9 @@ var expectedConf = &Config{
 		PromoteResourceAttributes: []string{
 			"k8s.cluster.name", "k8s.job.name", "k8s.namespace.name",
 		},
-		TranslationStrategy: otlptranslator.UnderscoreEscapingWithSuffixes,
+		TranslationStrategy:                  otlptranslator.UnderscoreEscapingWithSuffixes,
+		LabelNameUnderscoreSanitization:      true,
+		LabelNamePreserveMultipleUnderscores: true,
 	},
 
 	RemoteReadConfigs: []*RemoteReadConfig{
@@ -1871,6 +1873,48 @@ func TestOTLPPromoteScopeMetadata(t *testing.T) {
 		require.NoError(t, yaml.UnmarshalStrict(out, &got))
 
 		require.True(t, got.OTLPConfig.PromoteScopeMetadata)
+	})
+}
+
+func TestOTLPLabelUnderscoreSanitization(t *testing.T) {
+	t.Run("defaults to true", func(t *testing.T) {
+		conf, err := LoadFile(filepath.Join("testdata", "otlp_label_underscore_sanitization_defaults.good.yml"), false, promslog.NewNopLogger())
+		require.NoError(t, err)
+
+		// Test that default values are true
+		require.True(t, conf.OTLPConfig.LabelNameUnderscoreSanitization)
+		require.True(t, conf.OTLPConfig.LabelNamePreserveMultipleUnderscores)
+	})
+
+	t.Run("explicitly enabled", func(t *testing.T) {
+		conf, err := LoadFile(filepath.Join("testdata", "otlp_label_underscore_sanitization_enabled.good.yml"), false, promslog.NewNopLogger())
+		require.NoError(t, err)
+
+		out, err := yaml.Marshal(conf)
+		require.NoError(t, err)
+		var got Config
+		require.NoError(t, yaml.UnmarshalStrict(out, &got))
+
+		require.True(t, got.OTLPConfig.LabelNameUnderscoreSanitization)
+		require.True(t, got.OTLPConfig.LabelNamePreserveMultipleUnderscores)
+	})
+
+	t.Run("explicitly disabled", func(t *testing.T) {
+		conf, err := LoadFile(filepath.Join("testdata", "otlp_label_underscore_sanitization_disabled.good.yml"), false, promslog.NewNopLogger())
+		require.NoError(t, err)
+
+		// When explicitly set to false, they should be false
+		require.False(t, conf.OTLPConfig.LabelNameUnderscoreSanitization)
+		require.False(t, conf.OTLPConfig.LabelNamePreserveMultipleUnderscores)
+	})
+
+	t.Run("empty config uses defaults", func(t *testing.T) {
+		conf, err := LoadFile(filepath.Join("testdata", "otlp_empty.yml"), false, promslog.NewNopLogger())
+		require.NoError(t, err)
+
+		// Empty config should use default values (true)
+		require.True(t, conf.OTLPConfig.LabelNameUnderscoreSanitization)
+		require.True(t, conf.OTLPConfig.LabelNamePreserveMultipleUnderscores)
 	})
 }
 

--- a/config/testdata/otlp_label_underscore_sanitization_defaults.good.yml
+++ b/config/testdata/otlp_label_underscore_sanitization_defaults.good.yml
@@ -1,0 +1,2 @@
+otlp:
+  promote_resource_attributes: ["service.name"]

--- a/config/testdata/otlp_label_underscore_sanitization_disabled.good.yml
+++ b/config/testdata/otlp_label_underscore_sanitization_disabled.good.yml
@@ -1,0 +1,3 @@
+otlp:
+  label_name_underscore_sanitization: false
+  label_name_preserve_multiple_underscores: false

--- a/config/testdata/otlp_label_underscore_sanitization_enabled.good.yml
+++ b/config/testdata/otlp_label_underscore_sanitization_enabled.good.yml
@@ -1,0 +1,3 @@
+otlp:
+  label_name_underscore_sanitization: true
+  label_name_preserve_multiple_underscores: true

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -270,6 +270,15 @@ otlp:
   # Enables promotion of OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
   # This is disabled by default for backwards compatibility, but according to OTel spec, scope metadata _should_ be identifying, i.e. translated to metric labels.
   [ promote_scope_metadata: <boolean> | default = false ]
+  # Controls whether to enable prepending of 'key_' to labels starting with '_'.
+  # Reserved labels starting with '__' are not modified.
+  # This is only relevant when translation_strategy uses underscore escaping
+  # (e.g., "UnderscoreEscapingWithSuffixes" or "UnderscoreEscapingWithoutSuffixes").
+  [ label_name_underscore_sanitization: <boolean> | default = true ]
+  # Enables preserving of multiple consecutive underscores in label names when
+  # translation_strategy uses underscore escaping. When true (default), multiple
+  # consecutive underscores are preserved during label name sanitization.
+  [ label_name_preserve_multiple_underscores: <boolean> | default = true ]
 
 # Settings related to the remote read feature.
 remote_read:

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
@@ -93,7 +93,7 @@ func TestCreateAttributes(t *testing.T) {
 		promoteScope                         bool
 		ignoreResourceAttributes             []string
 		ignoreAttrs                          []string
-		labelNameUnderscoreLabelSanitization bool
+		labelNameUnderscoreSanitization      bool
 		labelNamePreserveMultipleUnderscores bool
 		expectedLabels                       labels.Labels
 	}{
@@ -277,7 +277,7 @@ func TestCreateAttributes(t *testing.T) {
 			resource:                             resourceWithUnderscores,
 			attrs:                                attrsWithUnderscores,
 			promoteResourceAttributes:            []string{"_private"},
-			labelNameUnderscoreLabelSanitization: true,
+			labelNameUnderscoreSanitization:      true,
 			labelNamePreserveMultipleUnderscores: true,
 			expectedLabels: labels.FromStrings(
 				"__name__", "test_metric",
@@ -293,7 +293,7 @@ func TestCreateAttributes(t *testing.T) {
 			resource:                             resourceWithUnderscores,
 			attrs:                                attrsWithUnderscores,
 			promoteResourceAttributes:            []string{"_private"},
-			labelNameUnderscoreLabelSanitization: false,
+			labelNameUnderscoreSanitization:      false,
 			labelNamePreserveMultipleUnderscores: true,
 			expectedLabels: labels.FromStrings(
 				"__name__", "test_metric",
@@ -309,7 +309,7 @@ func TestCreateAttributes(t *testing.T) {
 			resource:                             resourceWithUnderscores,
 			attrs:                                attrsWithUnderscores,
 			promoteResourceAttributes:            []string{"label___multi"},
-			labelNameUnderscoreLabelSanitization: false,
+			labelNameUnderscoreSanitization:      false,
 			labelNamePreserveMultipleUnderscores: true,
 			expectedLabels: labels.FromStrings(
 				"__name__", "test_metric",
@@ -325,7 +325,7 @@ func TestCreateAttributes(t *testing.T) {
 			resource:                             resourceWithUnderscores,
 			attrs:                                attrsWithUnderscores,
 			promoteResourceAttributes:            []string{"label___multi"},
-			labelNameUnderscoreLabelSanitization: false,
+			labelNameUnderscoreSanitization:      false,
 			labelNamePreserveMultipleUnderscores: false,
 			expectedLabels: labels.FromStrings(
 				"__name__", "test_metric",
@@ -341,7 +341,7 @@ func TestCreateAttributes(t *testing.T) {
 			resource:                             resourceWithUnderscores,
 			attrs:                                attrsWithUnderscores,
 			promoteResourceAttributes:            []string{"_private", "label___multi"},
-			labelNameUnderscoreLabelSanitization: true,
+			labelNameUnderscoreSanitization:      true,
 			labelNamePreserveMultipleUnderscores: true,
 			expectedLabels: labels.FromStrings(
 				"__name__", "test_metric",
@@ -358,7 +358,7 @@ func TestCreateAttributes(t *testing.T) {
 			resource:                             resourceWithUnderscores,
 			attrs:                                attrsWithUnderscores,
 			promoteResourceAttributes:            []string{"_private", "label___multi"},
-			labelNameUnderscoreLabelSanitization: false,
+			labelNameUnderscoreSanitization:      false,
 			labelNamePreserveMultipleUnderscores: false,
 			expectedLabels: labels.FromStrings(
 				"__name__", "test_metric",
@@ -375,7 +375,7 @@ func TestCreateAttributes(t *testing.T) {
 			resource:                             resourceWithUnderscores,
 			attrs:                                attrsWithUnderscores,
 			promoteResourceAttributes:            []string{"__reserved__"},
-			labelNameUnderscoreLabelSanitization: true,
+			labelNameUnderscoreSanitization:      true,
 			labelNamePreserveMultipleUnderscores: false,
 			expectedLabels: labels.FromStrings(
 				"__name__", "test_metric",
@@ -397,7 +397,7 @@ func TestCreateAttributes(t *testing.T) {
 					IgnoreResourceAttributes:     tc.ignoreResourceAttributes,
 				}),
 				PromoteScopeMetadata:                 tc.promoteScope,
-				LabelNameUnderscoreSanitization:      tc.labelNameUnderscoreLabelSanitization,
+				LabelNameUnderscoreSanitization:      tc.labelNameUnderscoreSanitization,
 				LabelNamePreserveMultipleUnderscores: tc.labelNamePreserveMultipleUnderscores,
 			}
 			// Use test case specific resource/attrs if provided, otherwise use defaults

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -671,19 +671,17 @@ func (rw *rwExporter) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) er
 	combinedAppender := otlptranslator.NewCombinedAppender(app, rw.logger, rw.ingestCTZeroSample, rw.metrics)
 	converter := otlptranslator.NewPrometheusConverter(combinedAppender)
 	annots, err := converter.FromMetrics(ctx, md, otlptranslator.Settings{
-		AddMetricSuffixes:                 otlpCfg.TranslationStrategy.ShouldAddSuffixes(),
-		AllowUTF8:                         !otlpCfg.TranslationStrategy.ShouldEscape(),
-		PromoteResourceAttributes:         otlptranslator.NewPromoteResourceAttributes(otlpCfg),
-		KeepIdentifyingResourceAttributes: otlpCfg.KeepIdentifyingResourceAttributes,
-		ConvertHistogramsToNHCB:           otlpCfg.ConvertHistogramsToNHCB,
-		PromoteScopeMetadata:              otlpCfg.PromoteScopeMetadata,
-		AllowDeltaTemporality:             rw.allowDeltaTemporality,
-		LookbackDelta:                     rw.lookbackDelta,
-		EnableTypeAndUnitLabels:           rw.enableTypeAndUnitLabels,
-		// For backwards compatibility.
-		LabelNameUnderscoreSanitization: true,
-		// For backwards compatibility.
-		LabelNamePreserveMultipleUnderscores: true,
+		AddMetricSuffixes:                    otlpCfg.TranslationStrategy.ShouldAddSuffixes(),
+		AllowUTF8:                            !otlpCfg.TranslationStrategy.ShouldEscape(),
+		PromoteResourceAttributes:            otlptranslator.NewPromoteResourceAttributes(otlpCfg),
+		KeepIdentifyingResourceAttributes:    otlpCfg.KeepIdentifyingResourceAttributes,
+		ConvertHistogramsToNHCB:              otlpCfg.ConvertHistogramsToNHCB,
+		PromoteScopeMetadata:                 otlpCfg.PromoteScopeMetadata,
+		AllowDeltaTemporality:                rw.allowDeltaTemporality,
+		LookbackDelta:                        rw.lookbackDelta,
+		EnableTypeAndUnitLabels:              rw.enableTypeAndUnitLabels,
+		LabelNameUnderscoreSanitization:      otlpCfg.LabelNameUnderscoreSanitization,
+		LabelNamePreserveMultipleUnderscores: otlpCfg.LabelNamePreserveMultipleUnderscores,
 	})
 
 	defer func() {


### PR DESCRIPTION
As a follow-up to #17344, add two configuration parameters for controlling label name translation, both defaulting to on for backwards compatibility (currently these behaviours are hardcoded as enabled):

* `otlp.label_name_underscore_sanitization` => Prefix label names starting with a single underscore with `key_` when translating OTel attribute names
* `otlp.label_name_preserve_multiple_underscores` => Keep multiple consecutive underscores in label names when translating OTel attribute names

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Related to https://github.com/prometheus/prometheus/issues/17342, although that's in itself fixed already by #17344. This PR just makes the behaviour configurable.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[ENHANCEMENT] OTLP: Add two configuration parameters (default on): `otlp.label_name_underscore_sanitization`, which enables or disables prefixing of label names starting with a single underscore with `key_` when translating OTel attribute names, and `otlp.label_name_preserve_multiple_underscores`, which enables or disables keeping of multiple consecutive underscores in label names when translating OTel attribute names
```
