### PR TITLE
TSDB: Allocate series ID after seriesLifecycleCallback; simplify code.

### DIFF
--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1152,7 +1152,7 @@ func TestHead_KeepSeriesInWALCheckpoint(t *testing.T) {
 		{
 			name: "keep series still in the head",
 			prepare: func(t *testing.T, h *Head) {
-				_, _, err := h.getOrCreateWithID(chunks.HeadSeriesRef(existingRef), existingLbls.Hash(), existingLbls, false)
+				_, _, err := h.getOrCreateWithOptionalID(chunks.HeadSeriesRef(existingRef), existingLbls.Hash(), existingLbls, false)
 				require.NoError(t, err)
 			},
 			expected: true,

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -255,7 +255,7 @@ Outer:
 		switch v := d.(type) {
 		case []record.RefSeries:
 			for _, walSeries := range v {
-				mSeries, created, err := h.getOrCreateWithID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels, false)
+				mSeries, created, err := h.getOrCreateWithOptionalID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels, false)
 				if err != nil {
 					seriesCreationErr = err
 					break Outer
@@ -1590,7 +1590,7 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 			localRefSeries := shardedRefSeries[idx]
 
 			for csr := range rc {
-				series, _, err := h.getOrCreateWithID(csr.ref, csr.lset.Hash(), csr.lset, false)
+				series, _, err := h.getOrCreateWithOptionalID(csr.ref, csr.lset.Hash(), csr.lset, false)
 				if err != nil {
 					errChan <- err
 					return


### PR DESCRIPTION
Alternative to #17163.
    
`seriesLifecycleCallback` is not used by Prometheus, but in downstream projects it
is wasteful to allocate an ID only to abandon it.

Refactor the code so that everything proceeds linearly, and is hence much simpler.

Remove lengthy commment which I feel is distracting from the flow.
Also renamed `getOrSet` to `setUnlessAlreadySet` to emphasise that the caller is expecting it not to be set.

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
