### PR TITLE
discovery/aws: Fix AWS SDK v2 credentials handling for EC2 and Lightsail discovery

### DIFF
--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -197,7 +197,6 @@ func (d *EC2Discovery) ec2Client(ctx context.Context) (ec2Client, error) {
 	if d.ec2 != nil {
 		return d.ec2, nil
 	}
-	credProvider := credentials.NewStaticCredentialsProvider(d.cfg.AccessKey, string(d.cfg.SecretKey), "")
 
 	// Build the HTTP client from the provided HTTPClientConfig.
 	httpClient, err := config.NewClientFromConfig(d.cfg.HTTPClientConfig, "ec2_sd")
@@ -205,14 +204,25 @@ func (d *EC2Discovery) ec2Client(ctx context.Context) (ec2Client, error) {
 		return nil, err
 	}
 
-	// Build the AWS config with the provided region and credentials.
-	cfg, err := awsConfig.LoadDefaultConfig(
-		ctx,
+	// Build the AWS config with the provided region.
+	configOptions := []func(*awsConfig.LoadOptions) error{
 		awsConfig.WithRegion(d.cfg.Region),
-		awsConfig.WithCredentialsProvider(credProvider),
-		awsConfig.WithSharedConfigProfile(d.cfg.Profile),
 		awsConfig.WithHTTPClient(httpClient),
-	)
+	}
+
+	// Only set static credentials if both access key and secret key are provided.
+	// Otherwise, let the AWS SDK use its default credential chain (environment variables, IAM role, etc.).
+	if d.cfg.AccessKey != "" && d.cfg.SecretKey != "" {
+		credProvider := credentials.NewStaticCredentialsProvider(d.cfg.AccessKey, string(d.cfg.SecretKey), "")
+		configOptions = append(configOptions, awsConfig.WithCredentialsProvider(credProvider))
+	}
+
+	// Set the profile if provided.
+	if d.cfg.Profile != "" {
+		configOptions = append(configOptions, awsConfig.WithSharedConfigProfile(d.cfg.Profile))
+	}
+
+	cfg, err := awsConfig.LoadDefaultConfig(ctx, configOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("could not create aws config: %w", err)
 	}

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -161,22 +161,31 @@ func (d *LightsailDiscovery) lightsailClient(ctx context.Context) (*lightsail.Cl
 		return d.lightsail, nil
 	}
 
-	credProvider := credentials.NewStaticCredentialsProvider(d.cfg.AccessKey, string(d.cfg.SecretKey), "")
-
 	// Build the HTTP client from the provided HTTPClientConfig.
 	httpClient, err := config.NewClientFromConfig(d.cfg.HTTPClientConfig, "lightsail_sd")
 	if err != nil {
 		return nil, err
 	}
 
-	// Build the AWS config with the provided region and credentials.
-	cfg, err := awsConfig.LoadDefaultConfig(
-		ctx,
+	// Build the AWS config with the provided region.
+	configOptions := []func(*awsConfig.LoadOptions) error{
 		awsConfig.WithRegion(d.cfg.Region),
-		awsConfig.WithCredentialsProvider(credProvider),
-		awsConfig.WithSharedConfigProfile(d.cfg.Profile),
 		awsConfig.WithHTTPClient(httpClient),
-	)
+	}
+
+	// Only set static credentials if both access key and secret key are provided.
+	// Otherwise, let the AWS SDK use its default credential chain (environment variables, IAM role, etc.).
+	if d.cfg.AccessKey != "" && d.cfg.SecretKey != "" {
+		credProvider := credentials.NewStaticCredentialsProvider(d.cfg.AccessKey, string(d.cfg.SecretKey), "")
+		configOptions = append(configOptions, awsConfig.WithCredentialsProvider(credProvider))
+	}
+
+	// Set the profile if provided.
+	if d.cfg.Profile != "" {
+		configOptions = append(configOptions, awsConfig.WithSharedConfigProfile(d.cfg.Profile))
+	}
+
+	cfg, err := awsConfig.LoadDefaultConfig(ctx, configOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("could not create aws config: %w", err)
 	}


### PR DESCRIPTION
After the upgrade to AWS SDK v2, the EC2 and Lightsail service discovery stopped working when using the default AWS credential chain (environment variables, IAM roles, EC2 instance metadata, etc.).

The issue was that the code unconditionally created a StaticCredentialsProvider with empty credentials when access_key and secret_key were not configured. In AWS SDK v2, this causes a "static credentials are empty" error and prevents the SDK from falling back to its default credential chain.

Fixes #17343 

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] discovery/aws: Fix AWS SDK v2 credentials handling for EC2 and Lightsail discovery
```
