### PR TITLE
chore(test): make failures in TestRemoteWrite_PerQueueMetricsAfterRelabeling more explicit/rich to help with debugging the test when it flakes for GOARCH=386

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -890,8 +890,10 @@ func TestRemoteWrite_PerQueueMetricsAfterRelabeling(t *testing.T) {
 	port := testutil.RandomUnprivilegedPort(t)
 	targetPort := testutil.RandomUnprivilegedPort(t)
 
-	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		panic("should never be reached")
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Fail(t, "should never be reached because the remote write relabeling shouldn't yield anything", "header: %v, body: %s", r.Header, body)
 	}))
 	t.Cleanup(server.Close)
 


### PR DESCRIPTION

    tried to make it fail in the CI running the following, in vain:
    
    GOARCH=386 go test --timeout 4444444s --count=1000 --run=TestRemoteWrite_PerQueueMetricsAfterRelabeling ./cmd/prometheus/
    



<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
