### PR TITLE
UI: Fix double-loading of API data on pages with slow rendering

### DIFF
--- a/web/ui/mantine-ui/src/api/api.ts
+++ b/web/ui/mantine-ui/src/api/api.ts
@@ -125,6 +125,7 @@ export const useSuspenseAPIQuery = <T>({ key, path, params }: QueryOptions) => {
     queryKey: key !== undefined ? key : [path, params],
     retry: false,
     refetchOnWindowFocus: false,
+    staleTime: Infinity, // Required for suspense queries since the component is briefly unmounted when loading the data, which together with a gcTime of 0 will cause the data to be garbage collected before it can be used.
     gcTime: 0,
     queryFn: createQueryFn({ pathPrefix, path, params }),
   });


### PR DESCRIPTION
Without `staleTime: Infinity`, the query data would be immediately marked stale, and in combination with the `gcTime: 0` setting and a brief unmount during data loading (via Suspense), the data would have to be reloaded a second time during/after the first real render.

`gcTime: 0` + `staleTime: Infinity` should give us the desired behavior where data loaded for a page should be valid forever as long as that page is being displayed, but always thrown away (and later reloaded) whenever we navigate away and again to that page.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] UI: Fix duplicate loading of data from the API in some slow-to-render pages
```
