### PR TITLE
test(tsdb): enable float histogram test for both true and false cases

### DIFF
--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -5026,7 +5026,7 @@ func testHistogramStaleSampleHelper(t *testing.T, floatHistogram bool) {
 }
 
 func TestHistogramCounterResetHeader(t *testing.T) {
-	for _, floatHisto := range []bool{true} { // FIXME
+	for _, floatHisto := range []bool{true, false} {
 		t.Run(fmt.Sprintf("floatHistogram=%t", floatHisto), func(t *testing.T) {
 			l := labels.FromStrings("a", "b")
 			head, _ := newTestHead(t, 1000, compression.None, false)


### PR DESCRIPTION
fixes FIXME in TestHistogramCounterResetHeader to test both integer and float histogram variants, for the sake of test coverage for counter reset header functionality...

enables the test to run for both `true` and `false` cases
#### Which issue(s) does the PR fix:

na: - Addresses inline FIXME comment in test code.

#### Does this PR introduce a user-facing change?

```release-notes
NONE
