### PR TITLE
feat(api): expose human-readable duration fields in parse_query

### DIFF
--- a/web/api/v1/translate_ast.go
+++ b/web/api/v1/translate_ast.go
@@ -8,7 +8,7 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
+// See the License for the specific lanaguage governing permissions and
 // limitations under the License.
 
 package v1
@@ -17,6 +17,7 @@ import (
 	"strconv"
 
 	"github.com/prometheus/common/model"
+
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )


### PR DESCRIPTION
I) added rangeText/offsetText/stepText alongside millis in AST jSON for MatrixSelector,SubqueryExpr,and VectorSelector with the indentation of the case statement(fields in /api/v1/parse_query output)
//model package
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix: na
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
[ENHANCEMENT] API: parse_query now includes string duration fields (as said above) in addition to millisecond values for MatrixSelector, SubqueryExpression, & VectorSelector.
```release-notes
[ENHANCEMENT] API: parse_query now includes string duration fields (as said above) in addition to millisecond values for MatrixSelector, SubqueryExpression, & VectorSelector.

```
