### PR TITLE
relabeling: Fix labelmap action validation with legacy metric name scheme

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -145,7 +145,13 @@ func (c *Config) Validate(nameValidationScheme model.ValidationScheme) error {
 		// UTF-8 allows ${} characters, so standard validation allow $variables by default.
 		// TODO(bwplotka): Relabelling users cannot put $ and ${<...>} characters in metric names or values.
 		// Design escaping mechanism to allow that, once valid use case appears.
-		return c.NameValidationScheme.IsValidLabelName(value)
+		switch c.NameValidationScheme {
+		case model.UTF8Validation:
+			return c.NameValidationScheme.IsValidLabelName(value)
+		default:
+			// For legacy validation, use the legacy regex that allows $variables.
+			return relabelTargetLegacy.MatchString(value)
+		}
 	}
 	if c.Action == Replace && varInRegexTemplate(c.TargetLabel) && !isValidLabelNameWithRegexVarFn(c.TargetLabel) {
 		return fmt.Errorf("%q is invalid 'target_label' for %s action", c.TargetLabel, c.Action)

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -831,6 +831,22 @@ func TestRelabelValidate(t *testing.T) {
 				NameValidationScheme: model.UTF8Validation,
 			},
 		},
+		{
+			config: Config{
+				Regex:                MustNewRegexp("__meta_kubernetes_pod_label_(strimzi_io_.+)"),
+				Action:               LabelMap,
+				Replacement:          "$1",
+				NameValidationScheme: model.LegacyValidation,
+			},
+		},
+		{
+			config: Config{
+				Regex:                MustNewRegexp("__meta_(.+)"),
+				Action:               LabelMap,
+				Replacement:          "${1}",
+				NameValidationScheme: model.LegacyValidation,
+			},
+		},
 	}
 	for i, test := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {


### PR DESCRIPTION
Fixes #17370

In Prometheus v3.7.0, using labelmap actions with replacement patterns containing regex variables (e.g., `$1`, `${1}`) would fail validation when `metric_name_validation_scheme` was set to `legacy`, causing Prometheus to fail at startup with:
  "$1" is invalid 'replacement' for labelmap action

This was a regression as the same configuration worked in v3.6.0.

The issue was in the validation logic: while UTF-8 validation correctly allowed `$` characters, legacy validation incorrectly used `IsValidLabelName` which rejects `$` characters. The fix ensures legacy validation uses `relabelTargetLegacy` regex which explicitly supports regex template variables.

Added test cases to verify labelmap validation works with both `$1` and `${1}` replacement patterns under legacy validation scheme.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] relabeling: Fix labelmap action validation with legacy metric name scheme
```
