### PR TITLE
docs: document external_labels behavior with remote read API

### DIFF
--- a/docs/querying/remote_read_api.md
+++ b/docs/querying/remote_read_api.md
@@ -14,6 +14,25 @@ Request are made to the following endpoint.
 /api/v1/read
 ```
 
+## Behavior with external_labels
+
+When using `external_labels` in the global configuration, it's important to understand how they interact with remote read:
+
+**When exposing a remote read endpoint:**
+- Prometheus serves the data as-is from its local storage through the remote read API
+- The `external_labels` configured in `global.external_labels` are **not** automatically added to the time series returned via remote read
+- Remote read returns the raw data exactly as it is stored in the Prometheus TSDB
+
+**When using remote read to query another Prometheus:**
+- When Prometheus queries a remote read endpoint, it receives the time series without any external labels from the remote source
+- The querying Prometheus instance will match series based on the selectors in the query, ignoring any `external_labels` that may be configured on either side
+- If you need to distinguish between local and remote data sources in queries, consider using source-specific labels during metric ingestion rather than relying on `external_labels`
+
+**Important considerations:**
+- `external_labels` are primarily used for federation, remote write, and Alertmanager integrations, not for remote read
+- If `external_labels` are set and remote read is being used, there will be no errors, but the external labels won't affect remote read queries
+- For proper remote read functionality across Prometheus instances with `external_labels`, ensure that label matching in your queries accounts for the actual labels present in the stored metrics, not the external labels
+
 ## Samples
 
 This returns a message that includes a list of raw samples matching the


### PR DESCRIPTION
## Description

This PR addresses issue #7192 by documenting how external_labels behave with the remote read API.

## Changes

Added a new section to docs/querying/remote_read_api.md explaining:
- How external_labels work when exposing a remote read endpoint
- How external_labels work when using remote read to query another Prometheus
- Important considerations for users working with both features

## Fixes

Closes #7192

## Background

Multiple users reported confusion about the interaction between external_labels and remote read (see issue comments). The April 2024 bug scrub identified this as a documentation gap and suggested acceptance criteria: **add documentation for behavior on external_labels with remote read exposing and using**.

This PR directly addresses those acceptance criteria by clarifying that:
- external_labels are NOT added to time series returned via remote read
- Remote read returns raw TSDB data without modification  
- external_labels are primarily for federation, remote write, and Alertmanager

## Testing

Documentation-only change. No code modifications.