### PR TITLE
[BUGFIX] PromQL: avoid panic when parsing malformed info call

### DIFF
--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -803,11 +803,14 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 				p.addParseErrf(node.PositionRange(), "expected type %s in %s, got %s", DocumentedType(ValueTypeVector), fmt.Sprintf("call to function %q", n.Func.Name), DocumentedType(n.Args[1].Type()))
 			}
 			// Check the vector selector in the input doesn't contain a metric name
-			if n.Args[1].(*VectorSelector).Name != "" {
+			if vs, ok := n.Args[1].(*VectorSelector); ok && vs.Name != "" {
 				p.addParseErrf(n.Args[1].PositionRange(), "expected label selectors only, got vector selector instead")
+			} else if ok {
+				// Set Vector Selector flag to bypass empty matcher check
+				vs.BypassEmptyMatcherCheck = true
+			} else {
+				p.addParseErrf(n.Args[1].PositionRange(), "expected label selectors only")
 			}
-			// Set Vector Selector flag to bypass empty matcher check
-			n.Args[1].(*VectorSelector).BypassEmptyMatcherCheck = true
 		}
 
 		for i, arg := range n.Args {

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -4375,6 +4375,17 @@ var testExpr = []struct {
 			PosRange: posrange.PositionRange{Start: 0, End: 73},
 		},
 	},
+	{
+		input: `info(http_request_counter_total{namespace="zzz"}, {foo="bar"} == 1)`,
+		fail:  true,
+		errors: ParseErrors{
+			ParseErr{
+				PositionRange: posrange.PositionRange{Start: 50, End: 66},
+				Err:           errors.New("expected label selectors only"),
+				Query:         `info(http_request_counter_total{namespace="zzz"}, {foo="bar"} == 1)`,
+			},
+		},
+	},
 	// Test that nested parentheses result in the correct position range.
 	{
 		input: `foo[11s+10s-5*2^2]`,


### PR DESCRIPTION
PromQL parser panics when processing a malformed `info` function call (such as having a binary expression as its second argument):
```
info(http_request_counter_total{namespace="zzz"}, {foo="bar"} == 1)

parser panic: interface conversion: parser.Expr is *parser.BinaryExpr, not *parser.VectorSelector
```
This PR modifies the parser to fail gracefully with an error message instead.

#### Does this PR introduce a user-facing change?
```release-notes
[BUGFIX] PromQL: avoid panic when parsing malformed info call
```
