### PR TITLE
Correctly generate rulesLintConfig when --lint=none is set

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -476,13 +476,15 @@ type rulesLintConfig struct {
 }
 
 func newRulesLintConfig(stringVal string, fatal, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) rulesLintConfig {
-	items := strings.Split(stringVal, ",")
 	ls := rulesLintConfig{
 		fatal:                fatal,
 		ignoreUnknownFields:  ignoreUnknownFields,
 		nameValidationScheme: nameValidationScheme,
 	}
-	for _, setting := range items {
+	if stringVal == "" {
+		return ls
+	}
+	for _, setting := range strings.Split(stringVal, ",") {
 		switch setting {
 		case lintOptionAll:
 			ls.all = true
@@ -534,9 +536,7 @@ func newConfigLintConfig(optionsStr string, fatal, ignoreUnknownFields bool, nam
 		rulesOptions = nil
 	}
 
-	if len(rulesOptions) > 0 {
-		c.rulesLintConfig = newRulesLintConfig(strings.Join(rulesOptions, ","), fatal, ignoreUnknownFields, nameValidationScheme)
-	}
+	c.rulesLintConfig = newRulesLintConfig(strings.Join(rulesOptions, ","), fatal, ignoreUnknownFields, nameValidationScheme)
 
 	return c
 }


### PR DESCRIPTION
If I run promtool check config --lint=none I get:

```
Checking rules.yml
  FAILED:
rules.yml: unset nameValidationScheme
```

This is becuase passing --lint=none stops newConfigLintConfig from generating rulesLintConfig which is needed for validation. It means that defaults are used then, one of which is unset value for metric name validation, causing this error. Fix this by handling --lint=none case correctly and still generating rulesLintConfig.

Fixes #17398.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] promtool: check config would fail when --lint=none flag was set
```
