### PR TITLE
Add urlQueryEscape to template functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [FEATURE] Templates: Add urlQueryEscape to template functions. #17403
+
 ## 3.7.2 / 2025-10-22
 
 * [BUGFIX] AWS SD: Fix AWS SDK v2 credentials handling for EC2 and Lightsail discovery. #17355

--- a/docs/configuration/template_reference.md
+++ b/docs/configuration/template_reference.md
@@ -78,6 +78,7 @@ versions.
 | tableLink  | expr | string | Returns path to tabular ("Table") view in the [expression browser](https://prometheus.io/docs/visualization/browser/) for the expression. |
 | parseDuration | string | float | Parses a duration string such as "1h" into the number of seconds it represents. |
 | stripDomain | string | string | Removes the domain part of a FQDN. Leaves port untouched. |
+| urlQueryEscape | string | string | [url.QueryEscape](https://pkg.go.dev/net/url#QueryEscape) Escapes the string so it can be safely placed inside a URL query. |
 
 ### Others
 

--- a/template/template.go
+++ b/template/template.go
@@ -288,6 +288,7 @@ func NewTemplateExpander(
 				}
 				return float64(time.Duration(v)) / float64(time.Second), nil
 			},
+			"urlQueryEscape": url.QueryEscape,
 		},
 		options: options,
 	}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

https://github.com/prometheus/prometheus/issues/17403

#### Does this PR introduce a user-facing change?

```release-notes
[FEATURE] Templates: Add urlQueryEscape to template functions. #17403
```
