### PR TITLE
feat: Unified AWS Service Discovery

### DIFF
--- a/discovery/aws/aws.go
+++ b/discovery/aws/aws.go
@@ -1,0 +1,226 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/discovery"
+)
+
+// DefaultSDConfig is the default AWS SD configuration.
+var DefaultSDConfig = SDConfig{
+	RefreshInterval:  model.Duration(60 * time.Second),
+	HTTPClientConfig: config.DefaultHTTPClientConfig,
+}
+
+func init() {
+	discovery.RegisterConfig(&SDConfig{})
+}
+
+// Role is role of the service in AWS.
+type Role string
+
+// The valid options for Role.
+const (
+	RoleEC2       Role = "ec2"
+	RoleECS       Role = "ecs"
+	RoleLightsail Role = "lightsail"
+)
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *Role) UnmarshalYAML(unmarshal func(any) error) error {
+	if err := unmarshal((*string)(c)); err != nil {
+		return err
+	}
+	switch *c {
+	case RoleEC2, RoleECS, RoleLightsail:
+		return nil
+	default:
+		return fmt.Errorf("unknown AWS SD role %q", *c)
+	}
+}
+
+func (c Role) String() string {
+	return string(c)
+}
+
+// SDConfig is the configuration for AWS service discovery.
+type SDConfig struct {
+	Role             Role                    `yaml:"role"`
+	Region           string                  `yaml:"region,omitempty"`
+	Endpoint         string                  `yaml:"endpoint,omitempty"`
+	AccessKey        string                  `yaml:"access_key,omitempty"`
+	SecretKey        config.Secret           `yaml:"secret_key,omitempty"`
+	Profile          string                  `yaml:"profile,omitempty"`
+	RoleARN          string                  `yaml:"role_arn,omitempty"`
+	RefreshInterval  model.Duration          `yaml:"refresh_interval,omitempty"`
+	Port             int                     `yaml:"port,omitempty"`
+	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
+
+	// ec2 specific
+	Filters []*EC2Filter `yaml:"filters,omitempty"`
+
+	// ecs specific
+	Clusters []string `yaml:"clusters,omitempty"`
+
+	// Embedded sub-configs (internal use only, not serialized)
+	*EC2SDConfig       `yaml:"-"`
+	*ECSSDConfig       `yaml:"-"`
+	*LightsailSDConfig `yaml:"-"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for SDConfig.
+func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	// Alias to avoid recursion
+	type plain SDConfig
+	var aux plain
+	// Unmarshal into aux
+	if err := unmarshal(&aux); err != nil {
+		return err
+	}
+	*c = SDConfig(aux)
+
+	switch c.Role {
+	case RoleEC2:
+		if c.EC2SDConfig == nil {
+			c.EC2SDConfig = &DefaultEC2SDConfig
+		}
+		c.EC2SDConfig.HTTPClientConfig = c.HTTPClientConfig
+		if c.Region != "" {
+			c.EC2SDConfig.Region = c.Region
+		}
+		if c.Endpoint != "" {
+			c.EC2SDConfig.Endpoint = c.Endpoint
+		}
+		if c.AccessKey != "" {
+			c.EC2SDConfig.AccessKey = c.AccessKey
+		}
+		if c.SecretKey != "" {
+			c.EC2SDConfig.SecretKey = c.SecretKey
+		}
+		if c.Profile != "" {
+			c.EC2SDConfig.Profile = c.Profile
+		}
+		if c.RoleARN != "" {
+			c.EC2SDConfig.RoleARN = c.RoleARN
+		}
+		if c.Port != 0 {
+			c.EC2SDConfig.Port = c.Port
+		}
+		if c.RefreshInterval != 0 {
+			c.EC2SDConfig.RefreshInterval = c.RefreshInterval
+		}
+		if c.Filters != nil {
+			c.EC2SDConfig.Filters = c.Filters
+		}
+	case RoleECS:
+		if c.ECSSDConfig == nil {
+			c.ECSSDConfig = &DefaultECSSDConfig
+		}
+		c.ECSSDConfig.HTTPClientConfig = c.HTTPClientConfig
+		if c.Region != "" {
+			c.ECSSDConfig.Region = c.Region
+		}
+		if c.Endpoint != "" {
+			c.ECSSDConfig.Endpoint = c.Endpoint
+		}
+		if c.AccessKey != "" {
+			c.ECSSDConfig.AccessKey = c.AccessKey
+		}
+		if c.SecretKey != "" {
+			c.ECSSDConfig.SecretKey = c.SecretKey
+		}
+		if c.Profile != "" {
+			c.ECSSDConfig.Profile = c.Profile
+		}
+		if c.RoleARN != "" {
+			c.ECSSDConfig.RoleARN = c.RoleARN
+		}
+		if c.Port != 0 {
+			c.ECSSDConfig.Port = c.Port
+		}
+		if c.RefreshInterval != 0 {
+			c.ECSSDConfig.RefreshInterval = c.RefreshInterval
+		}
+		if c.Clusters != nil {
+			c.ECSSDConfig.Clusters = c.Clusters
+		}
+	case RoleLightsail:
+		if c.LightsailSDConfig == nil {
+			c.LightsailSDConfig = &DefaultLightsailSDConfig
+		}
+		c.LightsailSDConfig.HTTPClientConfig = c.HTTPClientConfig
+		if c.Region != "" {
+			c.LightsailSDConfig.Region = c.Region
+		}
+		if c.Endpoint != "" {
+			c.LightsailSDConfig.Endpoint = c.Endpoint
+		}
+		if c.AccessKey != "" {
+			c.LightsailSDConfig.AccessKey = c.AccessKey
+		}
+		if c.SecretKey != "" {
+			c.LightsailSDConfig.SecretKey = c.SecretKey
+		}
+		if c.Profile != "" {
+			c.LightsailSDConfig.Profile = c.Profile
+		}
+		if c.RoleARN != "" {
+			c.LightsailSDConfig.RoleARN = c.RoleARN
+		}
+		if c.Port != 0 {
+			c.LightsailSDConfig.Port = c.Port
+		}
+		if c.RefreshInterval != 0 {
+			c.LightsailSDConfig.RefreshInterval = c.RefreshInterval
+		}
+	default:
+		return fmt.Errorf("unknown AWS SD role %q", c.Role)
+	}
+	return nil
+}
+
+// Name returns the name of the AWS Config.
+func (*SDConfig) Name() string { return "aws" }
+
+// NewDiscovererMetrics implements discovery.Config.
+func (*SDConfig) NewDiscovererMetrics(_ prometheus.Registerer, rmi discovery.RefreshMetricsInstantiator) discovery.DiscovererMetrics {
+	return &awsMetrics{refreshMetrics: rmi}
+}
+
+// NewDiscoverer returns a Discoverer for the AWS Config.
+func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Discoverer, error) {
+	awsMetrics, ok := opts.Metrics.(*awsMetrics)
+	if !ok {
+		return nil, errors.New("invalid discovery metrics type for AWS SD")
+	}
+
+	switch c.Role {
+	case RoleEC2:
+		return NewEC2Discovery(c.EC2SDConfig, opts.Logger, &ec2Metrics{refreshMetrics: awsMetrics.refreshMetrics})
+	case RoleECS:
+		return NewECSDiscovery(c.ECSSDConfig, opts.Logger, &ecsMetrics{refreshMetrics: awsMetrics.refreshMetrics})
+	case RoleLightsail:
+		return NewLightsailDiscovery(c.LightsailSDConfig, opts.Logger, &lightsailMetrics{refreshMetrics: awsMetrics.refreshMetrics})
+	default:
+		return nil, fmt.Errorf("unknown AWS SD role %q", c.Role)
+	}
+}

--- a/discovery/aws/aws_test.go
+++ b/discovery/aws/aws_test.go
@@ -1,0 +1,179 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRoleUnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Role
+		wantErr  bool
+	}{
+		{
+			name:     "EC2Role",
+			input:    "ec2",
+			expected: RoleEC2,
+			wantErr:  false,
+		},
+		{
+			name:     "LightsailRole",
+			input:    "lightsail",
+			expected: RoleLightsail,
+			wantErr:  false,
+		},
+		{
+			name:     "ECSRole",
+			input:    "ecs",
+			expected: RoleECS,
+			wantErr:  false,
+		},
+		{
+			name:     "InvalidRole",
+			input:    "invalid",
+			expected: "invalid",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r Role
+			err := r.UnmarshalYAML(func(v any) error {
+				ptr, ok := v.(*string)
+				if !ok {
+					return errors.New("not a string pointer")
+				}
+				*ptr = tt.input
+				return nil
+			})
+			if tt.wantErr {
+				require.Error(t, err, "expected error for input %q", tt.input)
+			} else {
+				require.NoError(t, err, "unexpected error for input %q", tt.input)
+				require.Equal(t, tt.expected, r, "unexpected role for input %q", tt.input)
+			}
+		})
+	}
+}
+
+func TestRoleString(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     Role
+		expected string
+	}{
+		{
+			name:     "EC2",
+			role:     RoleEC2,
+			expected: "ec2",
+		},
+		{
+			name:     "Lightsail",
+			role:     RoleLightsail,
+			expected: "lightsail",
+		},
+		{
+			name:     "ECS",
+			role:     RoleECS,
+			expected: "ecs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.role.String())
+		})
+	}
+}
+
+func TestSDConfigName(t *testing.T) {
+	cfg := &SDConfig{}
+	require.Equal(t, "aws", cfg.Name())
+}
+
+func TestDefaultSDConfig(t *testing.T) {
+	require.Equal(t, Role(""), DefaultSDConfig.Role)
+	require.Equal(t, model.Duration(60*time.Second), DefaultSDConfig.RefreshInterval)
+}
+
+func TestSDConfigUnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name         string
+		yaml         string
+		validateFunc func(t *testing.T, cfg *SDConfig)
+	}{
+		{
+			name: "EC2WithFlatFields",
+			yaml: `role: ec2
+region: us-west-2
+port: 9100
+filters:
+  - name: instance-state-name
+    values: [running]`,
+			validateFunc: func(t *testing.T, cfg *SDConfig) {
+				require.Equal(t, RoleEC2, cfg.Role)
+				require.NotNil(t, cfg.EC2SDConfig)
+				require.Equal(t, "us-west-2", cfg.EC2SDConfig.Region)
+				require.Equal(t, 9100, cfg.EC2SDConfig.Port)
+				require.Len(t, cfg.EC2SDConfig.Filters, 1)
+				require.Equal(t, "instance-state-name", cfg.EC2SDConfig.Filters[0].Name)
+				require.Equal(t, []string{"running"}, cfg.EC2SDConfig.Filters[0].Values)
+			},
+		},
+		{
+			name: "ECSWithFlatFields",
+			yaml: `role: ecs
+region: us-east-1
+port: 9200
+clusters: ["some-cluster"]`,
+			validateFunc: func(t *testing.T, cfg *SDConfig) {
+				require.Equal(t, RoleECS, cfg.Role)
+				require.NotNil(t, cfg.ECSSDConfig)
+				require.Equal(t, "us-east-1", cfg.ECSSDConfig.Region)
+				require.Equal(t, 9200, cfg.ECSSDConfig.Port)
+				require.Equal(t, []string{"some-cluster"}, cfg.ECSSDConfig.Clusters)
+			},
+		},
+		{
+			name: "LightsailWithFlatFields",
+			yaml: `role: lightsail
+region: eu-central-1
+port: 9300`,
+			validateFunc: func(t *testing.T, cfg *SDConfig) {
+				require.Equal(t, RoleLightsail, cfg.Role)
+				require.NotNil(t, cfg.LightsailSDConfig)
+				require.Equal(t, "eu-central-1", cfg.LightsailSDConfig.Region)
+				require.Equal(t, 9300, cfg.LightsailSDConfig.Port)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg SDConfig
+			require.NoError(t, yaml.Unmarshal([]byte(tt.yaml), &cfg))
+			tt.validateFunc(t, &cfg)
+		})
+	}
+}

--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -1,0 +1,663 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/refresh"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+const (
+	ecsLabel                 = model.MetaLabelPrefix + "ecs_"
+	ecsLabelCluster          = ecsLabel + "cluster"
+	ecsLabelClusterARN       = ecsLabel + "cluster_arn"
+	ecsLabelService          = ecsLabel + "service"
+	ecsLabelServiceARN       = ecsLabel + "service_arn"
+	ecsLabelServiceStatus    = ecsLabel + "service_status"
+	ecsLabelTaskGroup        = ecsLabel + "task_group"
+	ecsLabelTaskARN          = ecsLabel + "task_arn"
+	ecsLabelTaskDefinition   = ecsLabel + "task_definition"
+	ecsLabelRegion           = ecsLabel + "region"
+	ecsLabelAvailabilityZone = ecsLabel + "availability_zone"
+	ecsLabelAZID             = ecsLabel + "availability_zone_id"
+	ecsLabelSubnetID         = ecsLabel + "subnet_id"
+	ecsLabelIPAddress        = ecsLabel + "ip_address"
+	ecsLabelLaunchType       = ecsLabel + "launch_type"
+	ecsLabelDesiredStatus    = ecsLabel + "desired_status"
+	ecsLabelLastStatus       = ecsLabel + "last_status"
+	ecsLabelHealthStatus     = ecsLabel + "health_status"
+	ecsLabelPlatformFamily   = ecsLabel + "platform_family"
+	ecsLabelPlatformVersion  = ecsLabel + "platform_version"
+	ecsLabelTag              = ecsLabel + "tag_"
+	ecsLabelTagCluster       = ecsLabelTag + "cluster_"
+	ecsLabelTagService       = ecsLabelTag + "service_"
+	ecsLabelTagTask          = ecsLabelTag + "task_"
+	ecsLabelSeparator        = ","
+)
+
+// DefaultECSSDConfig is the default ECS SD configuration.
+var DefaultECSSDConfig = ECSSDConfig{
+	Port:               80,
+	RefreshInterval:    model.Duration(60 * time.Second),
+	RequestConcurrency: 20, // Aligned with AWS ECS API sustained rate limits (20 req/sec)
+	HTTPClientConfig:   config.DefaultHTTPClientConfig,
+}
+
+func init() {
+	discovery.RegisterConfig(&ECSSDConfig{})
+}
+
+// ECSSDConfig is the configuration for ECS based service discovery.
+type ECSSDConfig struct {
+	Region          string         `yaml:"region"`
+	Endpoint        string         `yaml:"endpoint"`
+	AccessKey       string         `yaml:"access_key,omitempty"`
+	SecretKey       config.Secret  `yaml:"secret_key,omitempty"`
+	Profile         string         `yaml:"profile,omitempty"`
+	RoleARN         string         `yaml:"role_arn,omitempty"`
+	Clusters        []string       `yaml:"clusters,omitempty"`
+	Port            int            `yaml:"port"`
+	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
+
+	// RequestConcurrency controls the maximum number of concurrent ECS API requests.
+	// Default is 20, which aligns with AWS ECS sustained rate limits:
+	// - Cluster read actions (DescribeClusters, ListClusters): 20 req/sec sustained
+	// - Service read actions (DescribeServices, ListServices): 20 req/sec sustained
+	// - Cluster resource read actions (DescribeTasks, ListTasks): 20 req/sec sustained
+	// See: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/request-throttling.html
+	RequestConcurrency int `yaml:"request_concurrency,omitempty"`
+
+	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
+}
+
+// NewDiscovererMetrics implements discovery.Config.
+func (*ECSSDConfig) NewDiscovererMetrics(_ prometheus.Registerer, rmi discovery.RefreshMetricsInstantiator) discovery.DiscovererMetrics {
+	return &ecsMetrics{
+		refreshMetrics: rmi,
+	}
+}
+
+// Name returns the name of the ECS Config.
+func (*ECSSDConfig) Name() string { return "ecs" }
+
+// NewDiscoverer returns a Discoverer for the EC2 Config.
+func (c *ECSSDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Discoverer, error) {
+	return NewECSDiscovery(c, opts.Logger, opts.Metrics)
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for the ECS Config.
+func (c *ECSSDConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultECSSDConfig
+	type plain ECSSDConfig
+	err := unmarshal((*plain)(c))
+	if err != nil {
+		return err
+	}
+
+	if c.Region == "" {
+		cfg, err := awsConfig.LoadDefaultConfig(context.TODO())
+		if err != nil {
+			return err
+		}
+		client := imds.NewFromConfig(cfg)
+		result, err := client.GetRegion(context.Background(), &imds.GetRegionInput{})
+		if err != nil {
+			return fmt.Errorf("ECS SD configuration requires a region. Tried to fetch it from the instance metadata: %w", err)
+		}
+		c.Region = result.Region
+	}
+
+	return c.HTTPClientConfig.Validate()
+}
+
+type ecsClient interface {
+	ListClusters(context.Context, *ecs.ListClustersInput, ...func(*ecs.Options)) (*ecs.ListClustersOutput, error)
+	DescribeClusters(context.Context, *ecs.DescribeClustersInput, ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error)
+	ListServices(context.Context, *ecs.ListServicesInput, ...func(*ecs.Options)) (*ecs.ListServicesOutput, error)
+	DescribeServices(context.Context, *ecs.DescribeServicesInput, ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error)
+	ListTasks(context.Context, *ecs.ListTasksInput, ...func(*ecs.Options)) (*ecs.ListTasksOutput, error)
+	DescribeTasks(context.Context, *ecs.DescribeTasksInput, ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error)
+}
+
+// ECSDiscovery periodically performs ECS-SD requests. It implements
+// the Discoverer interface.
+type ECSDiscovery struct {
+	*refresh.Discovery
+	logger *slog.Logger
+	cfg    *ECSSDConfig
+	ecs    ecsClient
+}
+
+// NewECSDiscovery returns a new ECSDiscovery which periodically refreshes its targets.
+func NewECSDiscovery(conf *ECSSDConfig, logger *slog.Logger, metrics discovery.DiscovererMetrics) (*ECSDiscovery, error) {
+	m, ok := metrics.(*ecsMetrics)
+	if !ok {
+		return nil, errors.New("invalid discovery metrics type")
+	}
+
+	if logger == nil {
+		logger = promslog.NewNopLogger()
+	}
+	d := &ECSDiscovery{
+		logger: logger,
+		cfg:    conf,
+	}
+	d.Discovery = refresh.NewDiscovery(
+		refresh.Options{
+			Logger:              logger,
+			Mech:                "ecs",
+			Interval:            time.Duration(d.cfg.RefreshInterval),
+			RefreshF:            d.refresh,
+			MetricsInstantiator: m.refreshMetrics,
+		},
+	)
+	return d, nil
+}
+
+func (d *ECSDiscovery) initEcsClient(ctx context.Context) error {
+	if d.ecs != nil {
+		return nil
+	}
+
+	if d.cfg.Region == "" {
+		return errors.New("region must be set for ECS service discovery")
+	}
+
+	// Build the HTTP client from the provided HTTPClientConfig.
+	client, err := config.NewClientFromConfig(d.cfg.HTTPClientConfig, "ecs_sd")
+	if err != nil {
+		return err
+	}
+
+	// Build the AWS config with the provided region.
+	var configOptions []func(*awsConfig.LoadOptions) error
+	configOptions = append(configOptions, awsConfig.WithRegion(d.cfg.Region))
+	configOptions = append(configOptions, awsConfig.WithHTTPClient(client))
+
+	// Only set static credentials if both access key and secret key are provided
+	// Otherwise, let AWS SDK use its default credential chain
+	if d.cfg.AccessKey != "" && d.cfg.SecretKey != "" {
+		credProvider := credentials.NewStaticCredentialsProvider(d.cfg.AccessKey, string(d.cfg.SecretKey), "")
+		configOptions = append(configOptions, awsConfig.WithCredentialsProvider(credProvider))
+	}
+
+	if d.cfg.Profile != "" {
+		configOptions = append(configOptions, awsConfig.WithSharedConfigProfile(d.cfg.Profile))
+	}
+
+	cfg, err := awsConfig.LoadDefaultConfig(ctx, configOptions...)
+	if err != nil {
+		d.logger.Error("Failed to create AWS config", "error", err)
+		return fmt.Errorf("could not create aws config: %w", err)
+	}
+
+	// If the role ARN is set, assume the role to get credentials and set the credentials provider in the config.
+	if d.cfg.RoleARN != "" {
+		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN)
+		cfg.Credentials = aws.NewCredentialsCache(assumeProvider)
+	}
+
+	d.ecs = ecs.NewFromConfig(cfg, func(options *ecs.Options) {
+		if d.cfg.Endpoint != "" {
+			options.BaseEndpoint = &d.cfg.Endpoint
+		}
+		options.HTTPClient = client
+	})
+
+	// Test credentials by making a simple API call
+	testCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	_, err = d.ecs.DescribeClusters(testCtx, &ecs.DescribeClustersInput{})
+	if err != nil {
+		d.logger.Error("Failed to test ECS credentials", "error", err)
+		return fmt.Errorf("ECS credential test failed: %w", err)
+	}
+
+	return nil
+}
+
+// listClusterARNs returns a slice of cluster arns.
+// This method does not use concurrency as it's a simple paginated call.
+// AWS ECS Cluster read actions have burst=50, sustained=20 req/sec limits.
+func (d *ECSDiscovery) listClusterARNs(ctx context.Context) ([]string, error) {
+	var (
+		clusterARNs []string
+		nextToken   *string
+	)
+	for {
+		resp, err := d.ecs.ListClusters(ctx, &ecs.ListClustersInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("could not list clusters: %w", err)
+		}
+
+		clusterARNs = append(clusterARNs, resp.ClusterArns...)
+
+		if resp.NextToken == nil {
+			break
+		}
+		nextToken = resp.NextToken
+	}
+
+	return clusterARNs, nil
+}
+
+// describeClusters returns a map of cluster ARN to a slice of clusters.
+// This method processes clusters in batches without concurrency as it's typically
+// a single call handling up to 100 clusters. AWS ECS Cluster read actions have
+// burst=50, sustained=20 req/sec limits.
+func (d *ECSDiscovery) describeClusters(ctx context.Context, clusters []string) (map[string]types.Cluster, error) {
+	clusterMap := make(map[string]types.Cluster)
+
+	// AWS DescribeClusters can handle up to 100 clusters per call
+	batchSize := 100
+	for _, batch := range batchSlice(clusters, batchSize) {
+		resp, err := d.ecs.DescribeClusters(ctx, &ecs.DescribeClustersInput{
+			Clusters: batch,
+			Include:  []types.ClusterField{"TAGS"},
+		})
+		if err != nil {
+			d.logger.Error("Failed to describe clusters", "clusters", batch, "error", err)
+			return nil, fmt.Errorf("could not describe clusters %v: %w", batch, err)
+		}
+
+		for _, c := range resp.Clusters {
+			if c.ClusterArn != nil {
+				clusterMap[*c.ClusterArn] = c
+			}
+		}
+	}
+
+	return clusterMap, nil
+}
+
+// listServiceARNs returns a map of cluster ARN to a slice of service ARNs.
+// Uses concurrent requests limited by RequestConcurrency to respect AWS API throttling.
+// AWS ECS Service read actions have burst=100, sustained=20 req/sec limits.
+func (d *ECSDiscovery) listServiceARNs(ctx context.Context, clusters []string) (map[string][]string, error) {
+	serviceARNsMu := sync.Mutex{}
+	serviceARNs := make(map[string][]string)
+	errg, ectx := errgroup.WithContext(ctx)
+	errg.SetLimit(d.cfg.RequestConcurrency)
+	for _, clusterARN := range clusters {
+		errg.Go(func() error {
+			var nextToken *string
+			var clusterServiceARNs []string
+			for {
+				resp, err := d.ecs.ListServices(ectx, &ecs.ListServicesInput{
+					Cluster:   aws.String(clusterARN),
+					NextToken: nextToken,
+				})
+				if err != nil {
+					return fmt.Errorf("could not list services for cluster %q: %w", clusterARN, err)
+				}
+
+				clusterServiceARNs = append(clusterServiceARNs, resp.ServiceArns...)
+
+				if resp.NextToken == nil {
+					break
+				}
+				nextToken = resp.NextToken
+			}
+
+			serviceARNsMu.Lock()
+			serviceARNs[clusterARN] = clusterServiceARNs
+			serviceARNsMu.Unlock()
+			return nil
+		})
+	}
+
+	return serviceARNs, errg.Wait()
+}
+
+// describeServices returns a map of cluster ARN to services.
+// Uses concurrent requests with batching (10 services per request) to respect AWS API limits.
+// AWS ECS Service read actions have burst=100, sustained=20 req/sec limits.
+func (d *ECSDiscovery) describeServices(ctx context.Context, clusterServiceARNsMap map[string][]string) (map[string][]types.Service, error) {
+	batchSize := 10 // AWS DescribeServices API limit is 10 services per request
+	serviceMu := sync.Mutex{}
+	services := make(map[string][]types.Service)
+	errg, ectx := errgroup.WithContext(ctx)
+	errg.SetLimit(d.cfg.RequestConcurrency)
+	for clusterARN, serviceARNs := range clusterServiceARNsMap {
+		for _, batch := range batchSlice(serviceARNs, batchSize) {
+			errg.Go(func() error {
+				resp, err := d.ecs.DescribeServices(ectx, &ecs.DescribeServicesInput{
+					Services: batch,
+					Cluster:  aws.String(clusterARN),
+					Include:  []types.ServiceField{"TAGS"},
+				})
+				if err != nil {
+					d.logger.Error("Failed to describe services", "cluster", clusterARN, "batch", batch, "error", err)
+					return fmt.Errorf("could not describe services for cluster %q: %w", clusterARN, err)
+				}
+
+				serviceMu.Lock()
+				services[clusterARN] = append(services[clusterARN], resp.Services...)
+				serviceMu.Unlock()
+
+				return nil
+			})
+		}
+	}
+
+	return services, errg.Wait()
+}
+
+// listTaskARNs returns a map of service ARN to a slice of task ARNs.
+// Uses concurrent requests limited by RequestConcurrency to respect AWS API throttling.
+// AWS ECS Cluster resource read actions have burst=100, sustained=20 req/sec limits.
+func (d *ECSDiscovery) listTaskARNs(ctx context.Context, services []types.Service) (map[string][]string, error) {
+	taskARNsMu := sync.Mutex{}
+	taskARNs := make(map[string][]string)
+	errg, ectx := errgroup.WithContext(ctx)
+	errg.SetLimit(d.cfg.RequestConcurrency)
+	for _, service := range services {
+		errg.Go(func() error {
+			serviceArn := aws.ToString(service.ServiceArn)
+
+			var nextToken *string
+			var serviceTaskARNs []string
+			for {
+				resp, err := d.ecs.ListTasks(ectx, &ecs.ListTasksInput{
+					Cluster:     aws.String(*service.ClusterArn),
+					ServiceName: aws.String(*service.ServiceName),
+					NextToken:   nextToken,
+				})
+				if err != nil {
+					return fmt.Errorf("could not list tasks for service %q: %w", serviceArn, err)
+				}
+
+				serviceTaskARNs = append(serviceTaskARNs, resp.TaskArns...)
+
+				if resp.NextToken == nil {
+					break
+				}
+				nextToken = resp.NextToken
+			}
+
+			taskARNsMu.Lock()
+			taskARNs[serviceArn] = serviceTaskARNs
+			taskARNsMu.Unlock()
+			return nil
+		})
+	}
+
+	return taskARNs, errg.Wait()
+}
+
+// describeTasks returns a map of task arn to a slice task.
+// Uses concurrent requests with batching (100 tasks per request) to respect AWS API limits.
+// AWS ECS Cluster resource read actions have burst=100, sustained=20 req/sec limits.
+func (d *ECSDiscovery) describeTasks(ctx context.Context, clusterARN string, taskARNsMap map[string][]string) (map[string][]types.Task, error) {
+	batchSize := 100 // AWS DescribeTasks API limit is 100 tasks per request
+	taskMu := sync.Mutex{}
+	tasks := make(map[string][]types.Task)
+	errg, ectx := errgroup.WithContext(ctx)
+	errg.SetLimit(d.cfg.RequestConcurrency)
+	for serviceARN, taskARNs := range taskARNsMap {
+		for _, batch := range batchSlice(taskARNs, batchSize) {
+			errg.Go(func() error {
+				resp, err := d.ecs.DescribeTasks(ectx, &ecs.DescribeTasksInput{
+					Cluster: aws.String(clusterARN),
+					Tasks:   batch,
+					Include: []types.TaskField{"TAGS"},
+				})
+				if err != nil {
+					d.logger.Error("Failed to describe tasks", "service", serviceARN, "cluster", clusterARN, "batch", batch, "error", err)
+					return fmt.Errorf("could not describe tasks for service %q in cluster %q: %w", serviceARN, clusterARN, err)
+				}
+
+				taskMu.Lock()
+				tasks[serviceARN] = append(tasks[serviceARN], resp.Tasks...)
+				taskMu.Unlock()
+
+				return nil
+			})
+		}
+	}
+
+	return tasks, errg.Wait()
+}
+
+func batchSlice[T any](a []T, size int) [][]T {
+	batches := make([][]T, 0, len(a)/size+1)
+	for i := 0; i < len(a); i += size {
+		end := i + size
+		if end > len(a) {
+			end = len(a)
+		}
+		batches = append(batches, a[i:end])
+	}
+	return batches
+}
+
+func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	err := d.initEcsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var clusters []string
+	if len(d.cfg.Clusters) == 0 {
+		clusters, err = d.listClusterARNs(ctx)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		clusters = d.cfg.Clusters
+	}
+
+	if len(clusters) == 0 {
+		return []*targetgroup.Group{
+			{
+				Source: d.cfg.Region,
+			},
+		}, nil
+	}
+
+	tg := &targetgroup.Group{
+		Source: d.cfg.Region,
+	}
+
+	clusterARNMap, err := d.describeClusters(ctx, clusters)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterServiceARNMap, err := d.listServiceARNs(ctx, clusters)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterServicesMap, err := d.describeServices(ctx, clusterServiceARNMap)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use goroutines to process clusters in parallel
+	var (
+		targetsMu sync.Mutex
+		wg        sync.WaitGroup
+	)
+
+	for clusterArn, clusterServices := range clusterServicesMap {
+		if len(clusterServices) == 0 {
+			continue
+		}
+
+		wg.Add(1)
+		go func(clusterArn string, clusterServices []types.Service) {
+			defer wg.Done()
+
+			serviceTaskARNMap, err := d.listTaskARNs(ctx, clusterServices)
+			if err != nil {
+				d.logger.Error("Failed to list task ARNs for cluster", "cluster", clusterArn, "error", err)
+				return
+			}
+
+			serviceTaskMap, err := d.describeTasks(ctx, clusterArn, serviceTaskARNMap)
+			if err != nil {
+				d.logger.Error("Failed to describe tasks for cluster", "cluster", clusterArn, "error", err)
+				return
+			}
+
+			// Process services within this cluster in parallel
+			var (
+				serviceWg      sync.WaitGroup
+				localTargets   []model.LabelSet
+				localTargetsMu sync.Mutex
+			)
+
+			for _, clusterService := range clusterServices {
+				serviceWg.Add(1)
+				go func(clusterService types.Service) {
+					defer serviceWg.Done()
+
+					serviceArn := *clusterService.ServiceArn
+
+					if tasks, exists := serviceTaskMap[serviceArn]; exists {
+						var serviceTargets []model.LabelSet
+
+						for _, task := range tasks {
+							// Find the ENI attachment to get the private IP address
+							var eniAttachment *types.Attachment
+							for _, attachment := range task.Attachments {
+								if attachment.Type != nil && *attachment.Type == "ElasticNetworkInterface" {
+									eniAttachment = &attachment
+									break
+								}
+							}
+							if eniAttachment == nil {
+								continue
+							}
+
+							var ipAddress, subnetID string
+							for _, detail := range eniAttachment.Details {
+								switch *detail.Name {
+								case "privateIPv4Address":
+									ipAddress = *detail.Value
+								case "subnetId":
+									subnetID = *detail.Value
+								}
+							}
+							if ipAddress == "" {
+								continue
+							}
+
+							labels := model.LabelSet{
+								ecsLabelClusterARN:       model.LabelValue(*clusterService.ClusterArn),
+								ecsLabelService:          model.LabelValue(*clusterService.ServiceName),
+								ecsLabelServiceARN:       model.LabelValue(*clusterService.ServiceArn),
+								ecsLabelServiceStatus:    model.LabelValue(*clusterService.Status),
+								ecsLabelTaskGroup:        model.LabelValue(*task.Group),
+								ecsLabelTaskARN:          model.LabelValue(*task.TaskArn),
+								ecsLabelTaskDefinition:   model.LabelValue(*task.TaskDefinitionArn),
+								ecsLabelIPAddress:        model.LabelValue(ipAddress),
+								ecsLabelSubnetID:         model.LabelValue(subnetID),
+								ecsLabelRegion:           model.LabelValue(d.cfg.Region),
+								ecsLabelLaunchType:       model.LabelValue(task.LaunchType),
+								ecsLabelAvailabilityZone: model.LabelValue(*task.AvailabilityZone),
+								ecsLabelDesiredStatus:    model.LabelValue(*task.DesiredStatus),
+								ecsLabelLastStatus:       model.LabelValue(*task.LastStatus),
+								ecsLabelHealthStatus:     model.LabelValue(task.HealthStatus),
+							}
+
+							if task.PlatformFamily != nil {
+								labels[ecsLabelPlatformFamily] = model.LabelValue(*task.PlatformFamily)
+							}
+							if task.PlatformVersion != nil {
+								labels[ecsLabelPlatformVersion] = model.LabelValue(*task.PlatformVersion)
+							}
+
+							labels[model.AddressLabel] = model.LabelValue(net.JoinHostPort(ipAddress, strconv.Itoa(d.cfg.Port)))
+
+							// Add cluster tags
+							if cluster, exists := clusterARNMap[*clusterService.ClusterArn]; exists {
+								if cluster.ClusterName != nil {
+									labels[ecsLabelCluster] = model.LabelValue(*cluster.ClusterName)
+								}
+
+								for _, clusterTag := range cluster.Tags {
+									if clusterTag.Key != nil && clusterTag.Value != nil {
+										labels[model.LabelName(ecsLabelTagCluster+strutil.SanitizeLabelName(*clusterTag.Key))] = model.LabelValue(*clusterTag.Value)
+									}
+								}
+							}
+
+							// Add service tags
+							for _, serviceTag := range clusterService.Tags {
+								if serviceTag.Key != nil && serviceTag.Value != nil {
+									labels[model.LabelName(ecsLabelTagService+strutil.SanitizeLabelName(*serviceTag.Key))] = model.LabelValue(*serviceTag.Value)
+								}
+							}
+
+							// Add task tags
+							for _, taskTag := range task.Tags {
+								if taskTag.Key != nil && taskTag.Value != nil {
+									labels[model.LabelName(ecsLabelTagTask+strutil.SanitizeLabelName(*taskTag.Key))] = model.LabelValue(*taskTag.Value)
+								}
+							}
+
+							serviceTargets = append(serviceTargets, labels)
+						}
+
+						// Add service targets to local targets with mutex protection
+						localTargetsMu.Lock()
+						localTargets = append(localTargets, serviceTargets...)
+						localTargetsMu.Unlock()
+					}
+				}(clusterService)
+			}
+
+			serviceWg.Wait()
+
+			// Add all local targets to main target group with mutex protection
+			targetsMu.Lock()
+			tg.Targets = append(tg.Targets, localTargets...)
+			targetsMu.Unlock()
+		}(clusterArn, clusterServices)
+	}
+
+	wg.Wait()
+
+	return []*targetgroup.Group{tg}, nil
+}

--- a/discovery/aws/ecs_test.go
+++ b/discovery/aws/ecs_test.go
@@ -1,0 +1,953 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+// Struct for test data.
+type ecsDataStore struct {
+	region string
+
+	clusters []ecsTypes.Cluster
+	services []ecsTypes.Service
+	tasks    []ecsTypes.Task
+}
+
+func TestECSDiscoveryListClusterARNs(t *testing.T) {
+	ctx := context.Background()
+
+	// iterate through the test cases
+	for _, tt := range []struct {
+		name     string
+		ecsData  *ecsDataStore
+		expected []string
+	}{
+		{
+			name: "MultipleClusters",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("test-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+					{
+						ClusterName: strptr("prod-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+			},
+			expected: []string{
+				"arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster",
+				"arn:aws:ecs:us-west-2:123456789012:cluster/prod-cluster",
+			},
+		},
+		{
+			name: "SingleCluster",
+			ecsData: &ecsDataStore{
+				region: "us-east-1",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("single-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-east-1:123456789012:cluster/single-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+			},
+			expected: []string{
+				"arn:aws:ecs:us-east-1:123456789012:cluster/single-cluster",
+			},
+		},
+		{
+			name: "NoClusters",
+			ecsData: &ecsDataStore{
+				region:   "us-east-1",
+				clusters: []ecsTypes.Cluster{},
+			},
+			expected: nil,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMockECSClient(tt.ecsData)
+
+			d := &ECSDiscovery{
+				ecs: client,
+				cfg: &ECSSDConfig{
+					Region:             tt.ecsData.region,
+					RequestConcurrency: 10,
+				},
+			}
+
+			clusters, err := d.listClusterARNs(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, clusters)
+		})
+	}
+}
+
+func TestECSDiscoveryDescribeClusters(t *testing.T) {
+	ctx := context.Background()
+
+	// iterate through the test cases
+	for _, tt := range []struct {
+		name        string
+		ecsData     *ecsDataStore
+		clusterARNs []string
+		expected    map[string]ecsTypes.Cluster
+	}{
+		{
+			name: "SingleClusterWithTags",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("test-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:      strptr("ACTIVE"),
+						Tags: []ecsTypes.Tag{
+							{Key: strptr("Environment"), Value: strptr("test")},
+							{Key: strptr("Team"), Value: strptr("backend")},
+						},
+					},
+				},
+			},
+			clusterARNs: []string{"arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"},
+			expected: map[string]ecsTypes.Cluster{
+				"arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster": {
+					ClusterName: strptr("test-cluster"),
+					ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+					Status:      strptr("ACTIVE"),
+					Tags: []ecsTypes.Tag{
+						{Key: strptr("Environment"), Value: strptr("test")},
+						{Key: strptr("Team"), Value: strptr("backend")},
+					},
+				},
+			},
+		},
+		{
+			name: "MultipleClusters",
+			ecsData: &ecsDataStore{
+				region: "us-east-1",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("cluster-1"),
+						ClusterArn:  strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1"),
+						Status:      strptr("ACTIVE"),
+					},
+					{
+						ClusterName: strptr("cluster-2"),
+						ClusterArn:  strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2"),
+						Status:      strptr("DRAINING"),
+						Tags: []ecsTypes.Tag{
+							{Key: strptr("Stage"), Value: strptr("prod")},
+						},
+					},
+				},
+			},
+			clusterARNs: []string{
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1",
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2",
+			},
+			expected: map[string]ecsTypes.Cluster{
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1": {
+					ClusterName: strptr("cluster-1"),
+					ClusterArn:  strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1"),
+					Status:      strptr("ACTIVE"),
+				},
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2": {
+					ClusterName: strptr("cluster-2"),
+					ClusterArn:  strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2"),
+					Status:      strptr("DRAINING"),
+					Tags: []ecsTypes.Tag{
+						{Key: strptr("Stage"), Value: strptr("prod")},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMockECSClient(tt.ecsData)
+
+			d := &ECSDiscovery{
+				ecs: client,
+				cfg: &ECSSDConfig{
+					Region:             tt.ecsData.region,
+					RequestConcurrency: 10,
+				},
+			}
+
+			clusterMap, err := d.describeClusters(ctx, tt.clusterARNs)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, clusterMap)
+		})
+	}
+}
+
+func TestECSDiscoveryListServiceARNs(t *testing.T) {
+	ctx := context.Background()
+
+	// iterate through the test cases
+	for _, tt := range []struct {
+		name        string
+		ecsData     *ecsDataStore
+		clusterARNs []string
+		expected    map[string][]string
+	}{
+		{
+			name: "SingleClusterWithServices",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("test-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+				services: []ecsTypes.Service{
+					{
+						ServiceName: strptr("web-service"),
+						ServiceArn:  strptr("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/web-service"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:      strptr("RUNNING"),
+					},
+					{
+						ServiceName: strptr("api-service"),
+						ServiceArn:  strptr("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/api-service"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:      strptr("RUNNING"),
+					},
+					{
+						// this is to test the old arn format without the cluster name in the service arn
+						// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-arn-migration.html
+						ServiceName: strptr("old-api-service"),
+						ServiceArn:  strptr("arn:aws:ecs:us-west-2:123456789012:service/old-api-service"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:      strptr("RUNNING"),
+					},
+				},
+			},
+			clusterARNs: []string{"arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"},
+			expected: map[string][]string{
+				"arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster": {
+					"arn:aws:ecs:us-west-2:123456789012:service/test-cluster/web-service",
+					"arn:aws:ecs:us-west-2:123456789012:service/test-cluster/api-service",
+					"arn:aws:ecs:us-west-2:123456789012:service/old-api-service",
+				},
+			},
+		},
+		{
+			name: "MultipleClustesWithServices",
+			ecsData: &ecsDataStore{
+				region: "us-east-1",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("cluster-1"),
+						ClusterArn:  strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1"),
+						Status:      strptr("ACTIVE"),
+					},
+					{
+						ClusterName: strptr("cluster-2"),
+						ClusterArn:  strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+				services: []ecsTypes.Service{
+					{
+						ServiceName: strptr("service-1"),
+						ServiceArn:  strptr("arn:aws:ecs:us-east-1:123456789012:service/cluster-1/service-1"),
+						ClusterArn:  strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1"),
+						Status:      strptr("RUNNING"),
+					},
+					{
+						ServiceName: strptr("service-2"),
+						ServiceArn:  strptr("arn:aws:ecs:us-east-1:123456789012:service/cluster-2/service-2"),
+						ClusterArn:  strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2"),
+						Status:      strptr("RUNNING"),
+					},
+				},
+			},
+			clusterARNs: []string{
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1",
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2",
+			},
+			expected: map[string][]string{
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1": {
+					"arn:aws:ecs:us-east-1:123456789012:service/cluster-1/service-1",
+				},
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2": {
+					"arn:aws:ecs:us-east-1:123456789012:service/cluster-2/service-2",
+				},
+			},
+		},
+		{
+			name: "ClusterWithNoServices",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("empty-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/empty-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+				services: []ecsTypes.Service{},
+			},
+			clusterARNs: []string{"arn:aws:ecs:us-west-2:123456789012:cluster/empty-cluster"},
+			expected: map[string][]string{
+				"arn:aws:ecs:us-west-2:123456789012:cluster/empty-cluster": nil,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMockECSClient(tt.ecsData)
+
+			d := &ECSDiscovery{
+				ecs: client,
+				cfg: &ECSSDConfig{
+					Region:             tt.ecsData.region,
+					RequestConcurrency: 1,
+				},
+			}
+
+			serviceMap, err := d.listServiceARNs(ctx, tt.clusterARNs)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, serviceMap)
+		})
+	}
+}
+
+func TestECSDiscoveryDescribeServices(t *testing.T) {
+	ctx := context.Background()
+
+	// iterate through the test cases
+	for _, tt := range []struct {
+		name                  string
+		ecsData               *ecsDataStore
+		clusterServiceARNsMap map[string][]string
+		expected              map[string][]ecsTypes.Service
+	}{
+		{
+			name: "SingleClusterServices",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				services: []ecsTypes.Service{
+					{
+						ServiceName:    strptr("web-service"),
+						ServiceArn:     strptr("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/web-service"),
+						ClusterArn:     strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:         strptr("RUNNING"),
+						TaskDefinition: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/web-task:1"),
+						Tags: []ecsTypes.Tag{
+							{Key: strptr("Environment"), Value: strptr("production")},
+						},
+					},
+					{
+						ServiceName:    strptr("api-service"),
+						ServiceArn:     strptr("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/api-service"),
+						ClusterArn:     strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:         strptr("RUNNING"),
+						TaskDefinition: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/api-task:2"),
+					},
+				},
+			},
+			clusterServiceARNsMap: map[string][]string{
+				"arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster": {
+					"arn:aws:ecs:us-west-2:123456789012:service/test-cluster/web-service",
+					"arn:aws:ecs:us-west-2:123456789012:service/test-cluster/api-service",
+				},
+			},
+			expected: map[string][]ecsTypes.Service{
+				"arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster": {
+					{
+						ServiceName:    strptr("web-service"),
+						ServiceArn:     strptr("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/web-service"),
+						ClusterArn:     strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:         strptr("RUNNING"),
+						TaskDefinition: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/web-task:1"),
+						Tags: []ecsTypes.Tag{
+							{Key: strptr("Environment"), Value: strptr("production")},
+						},
+					},
+					{
+						ServiceName:    strptr("api-service"),
+						ServiceArn:     strptr("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/api-service"),
+						ClusterArn:     strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:         strptr("RUNNING"),
+						TaskDefinition: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/api-task:2"),
+					},
+				},
+			},
+		},
+		{
+			name: "MultipleClustersServices",
+			ecsData: &ecsDataStore{
+				region: "us-east-1",
+				services: []ecsTypes.Service{
+					{
+						ServiceName:    strptr("service-1"),
+						ServiceArn:     strptr("arn:aws:ecs:us-east-1:123456789012:service/cluster-1/service-1"),
+						ClusterArn:     strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1"),
+						Status:         strptr("RUNNING"),
+						TaskDefinition: strptr("arn:aws:ecs:us-east-1:123456789012:task-definition/task-1:1"),
+					},
+					{
+						ServiceName:    strptr("service-2"),
+						ServiceArn:     strptr("arn:aws:ecs:us-east-1:123456789012:service/cluster-2/service-2"),
+						ClusterArn:     strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2"),
+						Status:         strptr("DRAINING"),
+						TaskDefinition: strptr("arn:aws:ecs:us-east-1:123456789012:task-definition/task-2:1"),
+					},
+				},
+			},
+			clusterServiceARNsMap: map[string][]string{
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1": {
+					"arn:aws:ecs:us-east-1:123456789012:service/cluster-1/service-1",
+				},
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2": {
+					"arn:aws:ecs:us-east-1:123456789012:service/cluster-2/service-2",
+				},
+			},
+			expected: map[string][]ecsTypes.Service{
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1": {
+					{
+						ServiceName:    strptr("service-1"),
+						ServiceArn:     strptr("arn:aws:ecs:us-east-1:123456789012:service/cluster-1/service-1"),
+						ClusterArn:     strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-1"),
+						Status:         strptr("RUNNING"),
+						TaskDefinition: strptr("arn:aws:ecs:us-east-1:123456789012:task-definition/task-1:1"),
+					},
+				},
+				"arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2": {
+					{
+						ServiceName:    strptr("service-2"),
+						ServiceArn:     strptr("arn:aws:ecs:us-east-1:123456789012:service/cluster-2/service-2"),
+						ClusterArn:     strptr("arn:aws:ecs:us-east-1:123456789012:cluster/cluster-2"),
+						Status:         strptr("DRAINING"),
+						TaskDefinition: strptr("arn:aws:ecs:us-east-1:123456789012:task-definition/task-2:1"),
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMockECSClient(tt.ecsData)
+
+			d := &ECSDiscovery{
+				ecs: client,
+				cfg: &ECSSDConfig{
+					Region:             tt.ecsData.region,
+					RequestConcurrency: 1,
+				},
+			}
+
+			serviceMap, err := d.describeServices(ctx, tt.clusterServiceARNsMap)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, serviceMap)
+		})
+	}
+}
+
+func TestECSDiscoveryListTaskARNs(t *testing.T) {
+	ctx := context.Background()
+
+	// iterate through the test cases
+	for _, tt := range []struct {
+		name     string
+		ecsData  *ecsDataStore
+		services []ecsTypes.Service
+		expected map[string][]string
+	}{
+		{
+			name: "ServicesWithTasks",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				tasks: []ecsTypes.Task{
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-1"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Group:             strptr("service:web-service"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/web-task:1"),
+					},
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-2"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Group:             strptr("service:web-service"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/web-task:1"),
+					},
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-3"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Group:             strptr("service:api-service"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/api-task:2"),
+					},
+				},
+			},
+			services: []ecsTypes.Service{
+				{
+					ServiceName: strptr("web-service"),
+					ServiceArn:  strptr("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/web-service"),
+					ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+					Status:      strptr("RUNNING"),
+				},
+				{
+					ServiceName: strptr("api-service"),
+					ServiceArn:  strptr("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/api-service"),
+					ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+					Status:      strptr("RUNNING"),
+				},
+			},
+			expected: map[string][]string{
+				"arn:aws:ecs:us-west-2:123456789012:service/test-cluster/web-service": {
+					"arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-1",
+					"arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-2",
+				},
+				"arn:aws:ecs:us-west-2:123456789012:service/test-cluster/api-service": {
+					"arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-3",
+				},
+			},
+		},
+		{
+			name: "ServiceWithNoTasks",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				tasks:  []ecsTypes.Task{},
+			},
+			services: []ecsTypes.Service{
+				{
+					ServiceName: strptr("empty-service"),
+					ServiceArn:  strptr("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/empty-service"),
+					ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+					Status:      strptr("RUNNING"),
+				},
+			},
+			expected: map[string][]string{
+				"arn:aws:ecs:us-west-2:123456789012:service/test-cluster/empty-service": nil,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMockECSClient(tt.ecsData)
+
+			d := &ECSDiscovery{
+				ecs: client,
+				cfg: &ECSSDConfig{
+					Region:             tt.ecsData.region,
+					RequestConcurrency: 1,
+				},
+			}
+
+			taskMap, err := d.listTaskARNs(ctx, tt.services)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, taskMap)
+		})
+	}
+}
+
+func TestECSDiscoveryDescribeTasks(t *testing.T) {
+	ctx := context.Background()
+
+	// iterate through the test cases
+	for _, tt := range []struct {
+		name        string
+		ecsData     *ecsDataStore
+		clusterARN  string
+		taskARNsMap map[string][]string
+		expected    map[string][]ecsTypes.Task
+	}{
+		{
+			name: "TasksInCluster",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				tasks: []ecsTypes.Task{
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-1"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Group:             strptr("service:web-service"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/web-task:1"),
+						LastStatus:        strptr("RUNNING"),
+						Tags: []ecsTypes.Tag{
+							{Key: strptr("Environment"), Value: strptr("production")},
+						},
+					},
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-2"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Group:             strptr("service:api-service"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/api-task:2"),
+						LastStatus:        strptr("RUNNING"),
+					},
+				},
+			},
+			clusterARN: "arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster",
+			taskARNsMap: map[string][]string{
+				"arn:aws:ecs:us-west-2:123456789012:service/test-cluster/web-service": {
+					"arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-1",
+				},
+				"arn:aws:ecs:us-west-2:123456789012:service/test-cluster/api-service": {
+					"arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-2",
+				},
+			},
+			expected: map[string][]ecsTypes.Task{
+				"arn:aws:ecs:us-west-2:123456789012:service/test-cluster/web-service": {
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-1"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Group:             strptr("service:web-service"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/web-task:1"),
+						LastStatus:        strptr("RUNNING"),
+						Tags: []ecsTypes.Tag{
+							{Key: strptr("Environment"), Value: strptr("production")},
+						},
+					},
+				},
+				"arn:aws:ecs:us-west-2:123456789012:service/test-cluster/api-service": {
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-2"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Group:             strptr("service:api-service"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/api-task:2"),
+						LastStatus:        strptr("RUNNING"),
+					},
+				},
+			},
+		},
+		{
+			name: "EmptyTaskARNsMap",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				tasks:  []ecsTypes.Task{},
+			},
+			clusterARN:  "arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster",
+			taskARNsMap: map[string][]string{},
+			expected:    map[string][]ecsTypes.Task{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMockECSClient(tt.ecsData)
+
+			d := &ECSDiscovery{
+				ecs: client,
+				cfg: &ECSSDConfig{
+					Region:             tt.ecsData.region,
+					RequestConcurrency: 1,
+				},
+			}
+
+			taskMap, err := d.describeTasks(ctx, tt.clusterARN, tt.taskARNsMap)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, taskMap)
+		})
+	}
+}
+
+func TestECSDiscoveryRefresh(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		ecsData  *ecsDataStore
+		expected []*targetgroup.Group
+	}{
+		{
+			name: "SingleClusterWithTasks",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("test-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:      strptr("ACTIVE"),
+						Tags: []ecsTypes.Tag{
+							{Key: strptr("Environment"), Value: strptr("test")},
+						},
+					},
+				},
+				services: []ecsTypes.Service{
+					{
+						ServiceName: strptr("web-service"),
+						ServiceArn:  strptr("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/web-service"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:      strptr("ACTIVE"),
+						Tags: []ecsTypes.Tag{
+							{Key: strptr("App"), Value: strptr("web")},
+						},
+					},
+				},
+				tasks: []ecsTypes.Task{
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-1"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/web-task:1"),
+						Group:             strptr("service:web-service"),
+						LaunchType:        ecsTypes.LaunchTypeFargate,
+						LastStatus:        strptr("RUNNING"),
+						DesiredStatus:     strptr("RUNNING"),
+						HealthStatus:      ecsTypes.HealthStatusHealthy,
+						AvailabilityZone:  strptr("us-west-2a"),
+						PlatformFamily:    strptr("Linux"),
+						PlatformVersion:   strptr("1.4.0"),
+						Attachments: []ecsTypes.Attachment{
+							{
+								Type: strptr("ElasticNetworkInterface"),
+								Details: []ecsTypes.KeyValuePair{
+									{Name: strptr("subnetId"), Value: strptr("subnet-12345")},
+									{Name: strptr("privateIPv4Address"), Value: strptr("10.0.1.100")},
+								},
+							},
+						},
+						Tags: []ecsTypes.Tag{
+							{Key: strptr("Version"), Value: strptr("v1.0")},
+						},
+					},
+				},
+			},
+			expected: []*targetgroup.Group{
+				{
+					Source: "us-west-2",
+					Targets: []model.LabelSet{
+						{
+							model.AddressLabel:                   model.LabelValue("10.0.1.100:80"),
+							"__meta_ecs_cluster":                 model.LabelValue("test-cluster"),
+							"__meta_ecs_cluster_arn":             model.LabelValue("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+							"__meta_ecs_service":                 model.LabelValue("web-service"),
+							"__meta_ecs_service_arn":             model.LabelValue("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/web-service"),
+							"__meta_ecs_service_status":          model.LabelValue("ACTIVE"),
+							"__meta_ecs_task_group":              model.LabelValue("service:web-service"),
+							"__meta_ecs_task_arn":                model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-1"),
+							"__meta_ecs_task_definition":         model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task-definition/web-task:1"),
+							"__meta_ecs_region":                  model.LabelValue("us-west-2"),
+							"__meta_ecs_availability_zone":       model.LabelValue("us-west-2a"),
+							"__meta_ecs_subnet_id":               model.LabelValue("subnet-12345"),
+							"__meta_ecs_ip_address":              model.LabelValue("10.0.1.100"),
+							"__meta_ecs_launch_type":             model.LabelValue("FARGATE"),
+							"__meta_ecs_desired_status":          model.LabelValue("RUNNING"),
+							"__meta_ecs_last_status":             model.LabelValue("RUNNING"),
+							"__meta_ecs_health_status":           model.LabelValue("HEALTHY"),
+							"__meta_ecs_platform_family":         model.LabelValue("Linux"),
+							"__meta_ecs_platform_version":        model.LabelValue("1.4.0"),
+							"__meta_ecs_tag_cluster_Environment": model.LabelValue("test"),
+							"__meta_ecs_tag_service_App":         model.LabelValue("web"),
+							"__meta_ecs_tag_task_Version":        model.LabelValue("v1.0"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "NoTasks",
+			ecsData: &ecsDataStore{
+				region: "us-east-1",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("empty-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-east-1:123456789012:cluster/empty-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+				services: []ecsTypes.Service{
+					{
+						ServiceName: strptr("empty-service"),
+						ServiceArn:  strptr("arn:aws:ecs:us-east-1:123456789012:service/empty-cluster/empty-service"),
+						ClusterArn:  strptr("arn:aws:ecs:us-east-1:123456789012:cluster/empty-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+				tasks: []ecsTypes.Task{},
+			},
+			expected: []*targetgroup.Group{
+				{
+					Source: "us-east-1",
+				},
+			},
+		},
+		{
+			name: "TaskWithoutENI",
+			ecsData: &ecsDataStore{
+				region: "us-west-2",
+				clusters: []ecsTypes.Cluster{
+					{
+						ClusterName: strptr("test-cluster"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+				services: []ecsTypes.Service{
+					{
+						ServiceName: strptr("service-1"),
+						ServiceArn:  strptr("arn:aws:ecs:us-west-2:123456789012:service/test-cluster/service-1"),
+						ClusterArn:  strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						Status:      strptr("ACTIVE"),
+					},
+				},
+				tasks: []ecsTypes.Task{
+					{
+						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/test-cluster/task-1"),
+						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/test-cluster"),
+						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/task-def:1"),
+						Group:             strptr("service:service-1"),
+						LaunchType:        ecsTypes.LaunchTypeEc2,
+						LastStatus:        strptr("RUNNING"),
+						DesiredStatus:     strptr("RUNNING"),
+						HealthStatus:      ecsTypes.HealthStatusHealthy,
+						AvailabilityZone:  strptr("us-west-2a"),
+						// No attachments - should be skipped
+						Attachments: []ecsTypes.Attachment{},
+					},
+				},
+			},
+			expected: []*targetgroup.Group{
+				{
+					Source: "us-west-2",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newMockECSClient(tt.ecsData)
+
+			d := &ECSDiscovery{
+				ecs: client,
+				cfg: &ECSSDConfig{
+					Region:             tt.ecsData.region,
+					Port:               80,
+					RequestConcurrency: 1,
+				},
+			}
+
+			groups, err := d.refresh(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, groups)
+		})
+	}
+}
+
+// ECS client mock.
+type mockECSClient struct {
+	ecsData ecsDataStore
+}
+
+func newMockECSClient(ecsData *ecsDataStore) *mockECSClient {
+	client := mockECSClient{
+		ecsData: *ecsData,
+	}
+	return &client
+}
+
+func (m *mockECSClient) ListClusters(_ context.Context, _ *ecs.ListClustersInput, _ ...func(*ecs.Options)) (*ecs.ListClustersOutput, error) {
+	clusterArns := make([]string, 0, len(m.ecsData.clusters))
+	for _, cluster := range m.ecsData.clusters {
+		clusterArns = append(clusterArns, *cluster.ClusterArn)
+	}
+
+	return &ecs.ListClustersOutput{
+		ClusterArns: clusterArns,
+	}, nil
+}
+
+func (m *mockECSClient) DescribeClusters(_ context.Context, input *ecs.DescribeClustersInput, _ ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error) {
+	var clusters []ecsTypes.Cluster
+	for _, clusterArn := range input.Clusters {
+		for _, cluster := range m.ecsData.clusters {
+			if *cluster.ClusterArn == clusterArn {
+				clusters = append(clusters, cluster)
+				break
+			}
+		}
+	}
+
+	return &ecs.DescribeClustersOutput{
+		Clusters: clusters,
+	}, nil
+}
+
+func (m *mockECSClient) ListServices(_ context.Context, input *ecs.ListServicesInput, _ ...func(*ecs.Options)) (*ecs.ListServicesOutput, error) {
+	var serviceArns []string
+	for _, service := range m.ecsData.services {
+		if *service.ClusterArn == *input.Cluster {
+			serviceArns = append(serviceArns, *service.ServiceArn)
+		}
+	}
+
+	return &ecs.ListServicesOutput{
+		ServiceArns: serviceArns,
+	}, nil
+}
+
+func (m *mockECSClient) DescribeServices(_ context.Context, input *ecs.DescribeServicesInput, _ ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error) {
+	var services []ecsTypes.Service
+	for _, serviceArn := range input.Services {
+		for _, service := range m.ecsData.services {
+			if *service.ServiceArn == serviceArn && *service.ClusterArn == *input.Cluster {
+				services = append(services, service)
+				break
+			}
+		}
+	}
+
+	return &ecs.DescribeServicesOutput{
+		Services: services,
+	}, nil
+}
+
+func (m *mockECSClient) ListTasks(_ context.Context, input *ecs.ListTasksInput, _ ...func(*ecs.Options)) (*ecs.ListTasksOutput, error) {
+	var taskArns []string
+	for _, task := range m.ecsData.tasks {
+		if *task.ClusterArn == *input.Cluster {
+			// If ServiceName is specified, filter by service
+			if input.ServiceName != nil {
+				expectedGroup := "service:" + *input.ServiceName
+				if task.Group != nil && *task.Group == expectedGroup {
+					taskArns = append(taskArns, *task.TaskArn)
+				}
+			} else {
+				taskArns = append(taskArns, *task.TaskArn)
+			}
+		}
+	}
+
+	return &ecs.ListTasksOutput{
+		TaskArns: taskArns,
+	}, nil
+}
+
+func (m *mockECSClient) DescribeTasks(_ context.Context, input *ecs.DescribeTasksInput, _ ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error) {
+	var tasks []ecsTypes.Task
+	for _, taskArn := range input.Tasks {
+		for _, task := range m.ecsData.tasks {
+			if *task.TaskArn == taskArn && *task.ClusterArn == *input.Cluster {
+				tasks = append(tasks, task)
+				break
+			}
+		}
+	}
+
+	return &ecs.DescribeTasksOutput{
+		Tasks: tasks,
+	}, nil
+}

--- a/discovery/aws/metrics_aws.go
+++ b/discovery/aws/metrics_aws.go
@@ -1,0 +1,32 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"github.com/prometheus/prometheus/discovery"
+)
+
+type awsMetrics struct {
+	refreshMetrics discovery.RefreshMetricsInstantiator
+}
+
+var _ discovery.DiscovererMetrics = (*awsMetrics)(nil)
+
+// Register implements discovery.DiscovererMetrics.
+func (*awsMetrics) Register() error {
+	return nil
+}
+
+// Unregister implements discovery.DiscovererMetrics.
+func (*awsMetrics) Unregister() {}

--- a/discovery/aws/metrics_ecs.go
+++ b/discovery/aws/metrics_ecs.go
@@ -1,0 +1,32 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"github.com/prometheus/prometheus/discovery"
+)
+
+type ecsMetrics struct {
+	refreshMetrics discovery.RefreshMetricsInstantiator
+}
+
+var _ discovery.DiscovererMetrics = (*ecsMetrics)(nil)
+
+// Register implements discovery.DiscovererMetrics.
+func (*ecsMetrics) Register() error {
+	return nil
+}
+
+// Unregister implements discovery.DiscovererMetrics.
+func (*ecsMetrics) Unregister() {}

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -395,6 +395,10 @@ params:
 # authorization), proxy configurations, TLS options, custom HTTP headers, etc.
 [ <http_config> ]
 
+# List of AWS service discovery configurations.
+aws_sd_configs:
+  [ - <aws_sd_config> ... ]
+
 # List of Azure service discovery configurations.
 azure_sd_configs:
   [ - <azure_sd_config> ... ]
@@ -810,6 +814,155 @@ http_headers:
     [ secrets: [<secret>, ...] ]
     # Files to read header values from.
     [ files: [<string>, ...] ] ]
+```
+
+### `<aws_sd_config>`
+
+AWS SD configurations allow retrieving scrape targets from AWS services.
+This is a unified service discovery that supports multiple AWS service types through the `role` parameter.
+
+One of the following `role` types can be configured to discover targets:
+
+#### `ec2`
+
+The `ec2` role discovers targets from AWS EC2 instances. The private IP address is used by default, but may be changed to
+the public IP address with relabeling.
+
+The IAM credentials used must have the `ec2:DescribeInstances` permission to
+discover scrape targets, and may optionally have the
+`ec2:DescribeAvailabilityZones` permission if you want the availability zone ID
+available as a label (see below).
+
+The following meta labels are available on targets during [relabeling](#relabel_config):
+
+* `__meta_ec2_ami`: the EC2 Amazon Machine Image
+* `__meta_ec2_architecture`: the architecture of the instance
+* `__meta_ec2_availability_zone`: the availability zone in which the instance is running
+* `__meta_ec2_availability_zone_id`: the [availability zone ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) in which the instance is running (requires `ec2:DescribeAvailabilityZones`)
+* `__meta_ec2_instance_id`: the EC2 instance ID
+* `__meta_ec2_instance_lifecycle`: the lifecycle of the EC2 instance, set only for 'spot' or 'scheduled' instances, absent otherwise
+* `__meta_ec2_instance_state`: the state of the EC2 instance
+* `__meta_ec2_instance_type`: the type of the EC2 instance
+* `__meta_ec2_ipv6_addresses`: comma separated list of IPv6 addresses assigned to the instance's network interfaces, if present
+* `__meta_ec2_owner_id`: the ID of the AWS account that owns the EC2 instance
+* `__meta_ec2_platform`: the Operating System platform, set to 'windows' on Windows servers, absent otherwise
+* `__meta_ec2_primary_ipv6_addresses`: comma separated list of the Primary IPv6 addresses of the instance, if present. The list is ordered based on the position of each corresponding network interface in the attachment order.
+* `__meta_ec2_primary_subnet_id`: the subnet ID of the primary network interface, if available
+* `__meta_ec2_private_dns_name`: the private DNS name of the instance, if available
+* `__meta_ec2_private_ip`: the private IP address of the instance, if present
+* `__meta_ec2_public_dns_name`: the public DNS name of the instance, if available
+* `__meta_ec2_public_ip`: the public IP address of the instance, if available
+* `__meta_ec2_region`: the region of the instance
+* `__meta_ec2_subnet_id`: comma separated list of subnets IDs in which the instance is running, if available
+* `__meta_ec2_tag_<tagkey>`: each tag value of the instance
+* `__meta_ec2_vpc_id`: the ID of the VPC in which the instance is running, if available
+
+#### `lightsail`
+
+The `lightsail` role discovers targets from [AWS Lightsail](https://aws.amazon.com/lightsail/)
+instances. The private IP address is used by default, but may be changed to
+the public IP address with relabeling.
+
+The following meta labels are available on targets during [relabeling](#relabel_config):
+
+* `__meta_lightsail_availability_zone`: the availability zone in which the instance is running
+* `__meta_lightsail_blueprint_id`: the Lightsail blueprint ID
+* `__meta_lightsail_bundle_id`: the Lightsail bundle ID
+* `__meta_lightsail_instance_name`: the name of the Lightsail instance
+* `__meta_lightsail_instance_state`: the state of the Lightsail instance
+* `__meta_lightsail_instance_support_code`: the support code of the Lightsail instance
+* `__meta_lightsail_ipv6_addresses`: comma separated list of IPv6 addresses assigned to the instance's network interfaces, if present
+* `__meta_lightsail_private_ip`: the private IP address of the instance
+* `__meta_lightsail_public_ip`: the public IP address of the instance, if available
+* `__meta_lightsail_region`: the region of the instance
+* `__meta_lightsail_tag_<tagkey>`: each tag value of the instance
+
+#### `ecs`
+
+The `ecs` role discovers targets from AWS ECS containers. The private IP address is used by default, but may be changed to
+the public IP address with relabeling.
+
+The IAM credentials used must have the following permissions to discover
+scrape targets:
+
+- `ecs:ListClusters`
+- `ecs:DescribeClusters`
+- `ecs:ListServices`
+- `ecs:DescribeServices`
+- `ecs:ListTasks`
+- `ecs:DescribeTasks`
+
+The following meta labels are available on targets during [relabeling](#relabel_config):
+
+* `__meta_ecs_cluster`: the name of the ECS cluster
+* `__meta_ecs_cluster_arn`: the ARN of the ECS cluster
+* `__meta_ecs_service`: the name of the ECS service
+* `__meta_ecs_service_arn`: the ARN of the ECS service
+* `__meta_ecs_service_status`: the status of the ECS service
+* `__meta_ecs_task_group`: the ECS task group (typically service:service-name)
+* `__meta_ecs_task_arn`: the ARN of the ECS task
+* `__meta_ecs_task_definition`: the ARN of the ECS task definition
+* `__meta_ecs_ip_address`: the private IP address of the task
+* `__meta_ecs_launch_type`: the launch type of the task (EC2 or Fargate)
+* `__meta_ecs_desired_status`: the desired status of the task
+* `__meta_ecs_last_status`: the last known status of the task
+* `__meta_ecs_health_status`: the health status of the task
+* `__meta_ecs_platform_family`: the platform family (e.g., Linux, Windows)
+* `__meta_ecs_platform_version`: the platform version
+* `__meta_ecs_subnet_id`: the subnet ID where the task is running
+* `__meta_ecs_availability_zone`: the availability zone where the task is running
+* `__meta_ecs_region`: the AWS region
+* `__meta_ecs_tag_cluster_<tagkey>`: each cluster tag value, keyed by tag name
+* `__meta_ecs_tag_service_<tagkey>`: each service tag value, keyed by tag name
+* `__meta_ecs_tag_task_<tagkey>`: each task tag value, keyed by tag name
+
+See below for the configuration options for AWS discovery:
+
+```yaml
+# The AWS role to use for service discovery.
+# Must be one of: ec2, lightsail, or ecs.
+role: <string>
+
+# The AWS region. If blank, the region from the instance metadata is used.
+[ region: <string> ]
+
+# Custom endpoint to be used.
+[ endpoint: <string> ]
+
+# AWS access key ID. If blank, the environment variable AWS_ACCESS_KEY_ID is used.
+[ access_key: <string> ]
+
+# AWS secret access key. If blank, the environment variable AWS_SECRET_ACCESS_KEY is used.
+[ secret_key: <secret> ]
+
+# Named AWS profile used to authenticate.
+[ profile: <string> ]
+
+# AWS Role ARN, an alternative to using AWS API keys.
+[ role_arn: <string> ]
+
+# Refresh interval to re-read the targets list.
+[ refresh_interval: <duration> | default = 60s ]
+
+# The port to scrape metrics from. If using the public IP address, this must
+# instead be specified in the relabeling rule.
+[ port: <int> | default = 80 ]
+
+# Filters can be used optionally to filter the instance list by other criteria (ec2 role only).
+# Available filter criteria can be found here:
+# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
+# Filter API documentation: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html
+filters:
+  [ - name: <string>
+      values: <string>, [...] ]
+
+# List of ECS cluster ARNs to discover (ecs role only). If empty, all clusters in the region are discovered.
+# This can significantly improve performance when you only need to monitor specific clusters.
+[ clusters: [<string>, ...] ]
+
+# HTTP client settings, including authentication methods (such as basic auth and
+# authorization), proxy configurations, TLS options, custom HTTP headers, etc.
+[ <http_config> ]
 ```
 
 ### `<azure_sd_config>`
@@ -2884,6 +3037,10 @@ sigv4:
 # HTTP client settings, including authentication methods (such as basic auth and
 # authorization), proxy configurations, TLS options, custom HTTP headers, etc.
 [ <http_config> ]
+
+# List of AWS service discovery configurations.
+aws_sd_configs:
+  [ - <aws_sd_config> ... ]
 
 # List of Azure service discovery configurations.
 azure_sd_configs:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.31.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.21
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.262.0
+	github.com/aws/aws-sdk-go-v2/service/ecs v1.67.2
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.50.4
 	github.com/aws/aws-sdk-go-v2/service/sts v1.39.1
 	github.com/aws/smithy-go v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEG
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.262.0 h1:5qBb1XV/D18qtCHd3bmmxoVglI+fZ4QWuS/EB8kIXYQ=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.262.0/go.mod h1:NDdDLLW5PtLLXN661gKcvJvqAH5OBXsfhMlmKVu1/pY=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.67.2 h1:oeICOX/+D0XXV1aMYJPXVe3CO37zYr7fB6HFgxchleU=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.67.2/go.mod h1:rrhqfkXfa2DSNq0RyFhnnFEAyI+yJB4+2QlZKeJvMjs=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.3 h1:x2Ibm/Af8Fi+BH+Hsn9TXGdT+hKbDd5XOTZxTMxDk7o=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.3/go.mod h1:IW1jwyrQgMdhisceG8fQLmQIydcT/jWY21rFhzgaKwo=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.13 h1:kDqdFvMY4AtKoACfzIGD8A0+hbT41KTKF//gq7jITfM=


### PR DESCRIPTION
Hi All,

Going on the feedback that was received for [17105](https://github.com/prometheus/prometheus/pull/17105), this PR implements Unified AWS Service Discovery, similar to how the Kubernetes one works. This should make adding more (eg MSK) easier in the future.

Currently this will support ec2, ecs and lightsail. Users using the existing ec2 and lightsail implementations will not be affected so they do not have to migrate if they don't want to.

An example of the config would be something along the lines of: 
```yaml
- job_name: ecs
  aws_sd_configs:
    role: ecs
    region: us-east-1
    ...
```

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] Add unified AWS service discovery #17046
```
