### PR TITLE
WIP: move dataIn increment/highestTimestamp tracking into various Append functions

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -730,6 +730,9 @@ outer:
 		// filling a queue/resharding as quickly as possible.
 		// TODO: Consider using the average duration of a request as the backoff.
 		backoff := model.Duration(5 * time.Millisecond)
+
+		t.metrics.highestTimestamp.Set(float64(s.T / 1000))
+		t.dataIn.incr(1)
 		for {
 			select {
 			case <-t.quit:
@@ -786,6 +789,9 @@ outer:
 		t.seriesMtx.Unlock()
 		// This will only loop if the queues are being resharded.
 		backoff := t.cfg.MinBackoff
+
+		t.metrics.highestTimestamp.Set(float64(s.T / 1000))
+		t.dataIn.incr(1)
 		for {
 			select {
 			case <-t.quit:
@@ -847,6 +853,9 @@ outer:
 		t.seriesMtx.Unlock()
 
 		backoff := model.Duration(5 * time.Millisecond)
+
+		t.metrics.highestTimestamp.Set(float64(s.T / 1000))
+		t.dataIn.incr(1)
 		for {
 			select {
 			case <-t.quit:
@@ -907,6 +916,9 @@ outer:
 		t.seriesMtx.Unlock()
 
 		backoff := model.Duration(5 * time.Millisecond)
+
+		t.metrics.highestTimestamp.Set(float64(s.T / 1000))
+		t.dataIn.incr(1)
 		for {
 			select {
 			case <-t.quit:
@@ -1348,8 +1360,6 @@ func (s *shards) enqueue(ref chunks.HeadSeriesRef, data timeSeries) bool {
 		default:
 			return true
 		}
-		s.qm.metrics.highestTimestamp.Set(float64(data.timestamp / 1000))
-		s.qm.dataIn.incr(1)
 		return true
 	}
 }


### PR DESCRIPTION
This is in response to: https://github.com/prometheus/prometheus/issues/17384

Here we're moving dataIn increment/highestTimestamp tracking into various Append functions functions rather than in enqueue. At least part of the issue with the new shard calculation function is that we're only updating the `dataIn` rate after we successfully enqueue a sample to a shard. If a majority of shards are already full this will significantly reduce the desired shards value, if not completely stabilize it at a lower than needed value.

In reality, I don't think a sharding calculation that doesn't include the `dataIn` rate as measured from the viewpoint of the samples being written to the WAL is ever going to be correct. IMO the simplest path forward is to revert: https://github.com/prometheus/prometheus/pull/17065