### PR TITLE
Revert "Merge pull request #17065 from machine424/queuelevel"

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"math"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -881,87 +880,4 @@ scrape_configs:
 			}, 15*time.Second, 500*time.Millisecond)
 		})
 	}
-}
-
-// This test verifies that metrics for the highest timestamps per queue account for relabelling.
-// See: https://github.com/prometheus/prometheus/pull/17065.
-func TestRemoteWrite_PerQueueMetricsAfterRelabeling(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "prometheus.yml")
-
-	port := testutil.RandomUnprivilegedPort(t)
-	targetPort := testutil.RandomUnprivilegedPort(t)
-
-	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		panic("should never be reached")
-	}))
-	t.Cleanup(server.Close)
-
-	// Simulate a remote write relabeling that doesn't yield any series.
-	config := fmt.Sprintf(`
-global:
-  scrape_interval: 1s
-scrape_configs:
-  - job_name: 'self'
-    static_configs:
-      - targets: ['localhost:%d']
-  - job_name: 'target'
-    static_configs:
-      - targets: ['localhost:%d']
-
-remote_write:
-  - url: %s
-    write_relabel_configs:
-      - source_labels: [job,__name__]
-        regex: 'target,special_metric'
-        action: keep
-`, port, targetPort, server.URL)
-	require.NoError(t, os.WriteFile(configFile, []byte(config), 0o777))
-
-	prom := prometheusCommandWithLogging(
-		t,
-		configFile,
-		port,
-		fmt.Sprintf("--storage.tsdb.path=%s", tmpDir),
-	)
-	require.NoError(t, prom.Start())
-
-	require.Eventually(t, func() bool {
-		r, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/metrics", port))
-		if err != nil {
-			return false
-		}
-		defer r.Body.Close()
-		if r.StatusCode != http.StatusOK {
-			return false
-		}
-
-		metrics, err := io.ReadAll(r.Body)
-		if err != nil {
-			return false
-		}
-
-		gHighestTimestamp, err := getMetricValue(t, bytes.NewReader(metrics), model.MetricTypeGauge, "prometheus_remote_storage_highest_timestamp_in_seconds")
-		// The highest timestamp at storage level sees all samples, it should also consider the ones that are filtered out by relabeling.
-		if err != nil || gHighestTimestamp == 0 {
-			return false
-		}
-
-		// The queue shouldn't see and send any sample, all samples are dropped due to relabeling, the metrics should reflect that.
-		droppedSamples, err := getMetricValue(t, bytes.NewReader(metrics), model.MetricTypeCounter, "prometheus_remote_storage_samples_dropped_total")
-		if err != nil || droppedSamples == 0 {
-			return false
-		}
-
-		highestTimestamp, err := getMetricValue(t, bytes.NewReader(metrics), model.MetricTypeGauge, "prometheus_remote_storage_queue_highest_timestamp_seconds")
-		require.NoError(t, err)
-		require.Zero(t, highestTimestamp)
-
-		highestSentTimestamp, err := getMetricValue(t, bytes.NewReader(metrics), model.MetricTypeGauge, "prometheus_remote_storage_queue_highest_sent_timestamp_seconds")
-		require.NoError(t, err)
-		require.Zero(t, highestSentTimestamp)
-		return true
-	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -212,8 +212,8 @@
               # Without max_over_time, failed scrapes could create false negatives, see
               # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
               (
-                max_over_time(prometheus_remote_storage_queue_highest_timestamp_seconds{%(prometheusSelector)s}[5m])
-              -
+                max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{%(prometheusSelector)s}[5m])
+              - ignoring(remote_name, url) group_right
                 max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{%(prometheusSelector)s}[5m])
               )
               > 120

--- a/documentation/prometheus-mixin/dashboards.libsonnet
+++ b/documentation/prometheus-mixin/dashboards.libsonnet
@@ -527,7 +527,7 @@ local row = panel.row;
       ;
 
       local timestampComparison =
-        panel.timeSeries.new('Highest Enqueued Timestamp vs. Highest Timestamp Sent')
+        panel.timeSeries.new('Highest Timestamp In vs. Highest Timestamp Sent')
         + panelTimeSeriesStdOptions
         + panel.timeSeries.standardOptions.withUnit('short')
         + panel.timeSeries.queryOptions.withTargets([
@@ -535,9 +535,9 @@ local row = panel.row;
             '$datasource',
             |||
               (
-                prometheus_remote_storage_queue_highest_timestamp_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"}
+                prometheus_remote_storage_highest_timestamp_in_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance"}
               -
-                prometheus_remote_storage_queue_highest_sent_timestamp_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"}
+                ignoring(remote_name, url) group_right(instance) (prometheus_remote_storage_queue_highest_sent_timestamp_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"} != 0)
               )
             ||| % $._config
           )
@@ -555,9 +555,9 @@ local row = panel.row;
             '$datasource',
             |||
               clamp_min(
-                rate(prometheus_remote_storage_queue_highest_timestamp_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"}[5m])
+                rate(prometheus_remote_storage_highest_timestamp_in_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance"}[5m])
               -
-                rate(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"}[5m])
+                ignoring (remote_name, url) group_right(instance) rate(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{%(clusterLabel)s=~"$cluster", instance=~"$instance", url=~"$url"}[5m])
               , 0)
             ||| % $._config
           )

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -54,6 +54,17 @@ import (
 
 const defaultFlushDeadline = 1 * time.Minute
 
+func newHighestTimestampMetric() *maxTimestamp {
+	return &maxTimestamp{
+		Gauge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "highest_timestamp_in_seconds",
+			Help:      "Highest timestamp that has come into the remote storage via the Appender interface, in seconds since epoch. Initialized to 0 when no data has been received yet",
+		}),
+	}
+}
+
 func TestBasicContentNegotiation(t *testing.T) {
 	t.Parallel()
 	queueConfig := config.DefaultQueueConfig
@@ -313,7 +324,7 @@ func newTestClientAndQueueManager(t testing.TB, flushDeadline time.Duration, pro
 func newTestQueueManager(t testing.TB, cfg config.QueueConfig, mcfg config.MetadataConfig, deadline time.Duration, c WriteClient, protoMsg config.RemoteWriteProtoMsg) *QueueManager {
 	dir := t.TempDir()
 	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), nil, false, false, false, protoMsg)
+	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, protoMsg)
 
 	return m
 }
@@ -769,7 +780,7 @@ func TestDisableReshardOnRetry(t *testing.T) {
 		}
 	)
 
-	m := NewQueueManager(metrics, nil, nil, nil, "", cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), nil, false, false, false, config.RemoteWriteProtoMsgV1)
+	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, false, config.RemoteWriteProtoMsgV1)
 	m.StoreSeries(fakeSeries, 0)
 
 	// Attempt to samples while the manager is running. We immediately stop the
@@ -1457,8 +1468,7 @@ func BenchmarkStoreSeries(b *testing.B) {
 				cfg := config.DefaultQueueConfig
 				mcfg := config.DefaultMetadataConfig
 				metrics := newQueueManagerMetrics(nil, "", "")
-
-				m := NewQueueManager(metrics, nil, nil, nil, dir, cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), nil, false, false, false, config.RemoteWriteProtoMsgV1)
+				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, config.RemoteWriteProtoMsgV1)
 				m.externalLabels = tc.externalLabels
 				m.relabelConfigs = tc.relabelConfigs
 
@@ -1558,8 +1568,9 @@ func TestCalculateDesiredShards(t *testing.T) {
 	addSamples := func(s int64, ts time.Duration) {
 		pendingSamples += s
 		samplesIn.incr(s)
+		samplesIn.tick()
 
-		m.metrics.highestTimestamp.Set(float64(startedAt.Add(ts).Unix()))
+		m.highestRecvTimestamp.Set(float64(startedAt.Add(ts).Unix()))
 	}
 
 	// helper function for sending samples.
@@ -1616,6 +1627,7 @@ func TestCalculateDesiredShardsDetail(t *testing.T) {
 		prevShards      int
 		dataIn          int64 // Quantities normalised to seconds.
 		dataOut         int64
+		dataDropped     int64
 		dataOutDuration float64
 		backlog         float64
 		expectedShards  int
@@ -1762,9 +1774,11 @@ func TestCalculateDesiredShardsDetail(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			m.numShards = tc.prevShards
 			forceEMWA(samplesIn, tc.dataIn*int64(shardUpdateDuration/time.Second))
+			samplesIn.tick()
 			forceEMWA(m.dataOut, tc.dataOut*int64(shardUpdateDuration/time.Second))
+			forceEMWA(m.dataDropped, tc.dataDropped*int64(shardUpdateDuration/time.Second))
 			forceEMWA(m.dataOutDuration, int64(tc.dataOutDuration*float64(shardUpdateDuration)))
-			m.metrics.highestTimestamp.value = tc.backlog // Not Set() because it can only increase value.
+			m.highestRecvTimestamp.value = tc.backlog // Not Set() because it can only increase value.
 
 			require.Equal(t, tc.expectedShards, m.calculateDesiredShards())
 		})
@@ -2487,7 +2501,7 @@ func TestHighestTimestampOnAppend(t *testing.T) {
 			m.Start()
 			defer m.Stop()
 
-			require.Equal(t, 0.0, m.metrics.highestTimestamp.Get())
+			require.Equal(t, 0.0, m.highestRecvTimestamp.Get())
 
 			m.StoreSeries(series, 0)
 			require.True(t, m.Append(samples))
@@ -2495,7 +2509,7 @@ func TestHighestTimestampOnAppend(t *testing.T) {
 			// Check that Append sets the highest timestamp correctly.
 			highestTs := float64((nSamples - 1) / 1000)
 			require.Greater(t, highestTs, 0.0)
-			require.Equal(t, highestTs, m.metrics.highestTimestamp.Get())
+			require.Equal(t, highestTs, m.highestRecvTimestamp.Get())
 		})
 	}
 }


### PR DESCRIPTION
This reverts commit c5743037ef55f29445397f26bcf9ef1c32a27642, reversing changes made to 2cbeef6d9582d7dee2bbe493a7cb42bda8f37553.

Revets https://github.com/prometheus/prometheus/pull/17065 (had to manually resolve conflicts in queue_manager_test.go, left extra test too)

Fixes https://github.com/prometheus/prometheus/issues/17384

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->

I am not sure how to present this, but we revert certain additions, adding "reverting" notes, hope that helps. But ideally we remove the 3.7 related items from changelog?

```release-notes
[CHANGE] Remote-write: Remove `prometheus_remote_storage_queue_highest_timestamp_seconds` metric, which tracks the highest timestamp that was actually enqueued per queue, accounting for relabeling.
[ENHANCEMENT] Mixin: Replace new `prometheus_remote_storage_queue_highest_timestamp_seconds` metric with the old `prometheus_remote_storage_highest_timestamp_in_seconds` metric in dashboards and alerts.
[CHANGE] Remote-write: Un-deprecate `prometheus_remote_storage_{samples,exemplars,histograms}_in_total` and `prometheus_remote_storage_highest_timestamp_in_seconds` metrics.
```
