### PR TITLE
tsdb: Reduce TestHeadSeriesChunkRace number of iterations to 100

### DIFF
--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3167,7 +3167,7 @@ func TestIsolationAppendIDZeroIsNoop(t *testing.T) {
 
 func TestHeadSeriesChunkRace(t *testing.T) {
 	t.Parallel()
-	for range 1000 {
+	for range 100 {
 		testHeadSeriesChunkRace(t)
 	}
 }
@@ -3314,17 +3314,17 @@ func testHeadSeriesChunkRace(t *testing.T) {
 	}
 	require.NoError(t, app.Commit())
 
-	var wg sync.WaitGroup
 	matcher := labels.MustNewMatcher(labels.MatchEqual, "", "")
 	q, err := NewBlockQuerier(h, 18, 22)
 	require.NoError(t, err)
 	defer q.Close()
 
+	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		h.updateMinMaxTime(20, 25)
 		h.gc()
-		wg.Done()
 	}()
 	ss := q.Select(context.Background(), false, nil, matcher)
 	for ss.Next() {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Reduce `tsdb.TestHeadSeriesChunkRace` number of iterations from 1000 to
100, to stop this test from timing out under CI.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
