### PR TITLE
Volunteer @jan--f as release shepherd for v3.8

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,8 @@ Please see [the v2.55 RELEASE.md](https://github.com/prometheus/prometheus/blob/
 | v3.5 LTS       | 2025-06-03                                 | Bryan Boreham (GitHub: @bboreham)  |
 | v3.6           | 2025-08-01                                 | Ayoub Mrini (Github: @machine424)  |
 | v3.7           | 2025-09-25                                 | Arthur Sens and George Krajcsovits (Github: @ArthurSens and @krajorama)|
-| v3.8           | 2025-11-06                                 | **volunteer welcome**              |
+| v3.8           | 2025-11-06                                 | Jan Fajerski (GitHub: @jan--f)     |
+| v3.9           | 2025-12-18                                 | **volunteer welcome**              |
 
 If you are interested in volunteering please create a pull request against the [prometheus/prometheus](https://github.com/prometheus/prometheus) repository and propose yourself for the release series of your choice.
 


### PR DESCRIPTION
@jan--f if I understood you correctly, you volunteered to be the release shepherd for v3.8.

@krajorama and myself will happily help out with any of the native histogram specifics (e.g. this should mention explicitly that the feature flag is being phased out and people should use the new `scrape_native_histograms` scrape config setting).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
