### PR TITLE
promql: fix histogram_fraction issue when lower falls within the first bucket

### DIFF
--- a/promql/promqltest/testdata/histograms.test
+++ b/promql/promqltest/testdata/histograms.test
@@ -158,15 +158,15 @@ eval instant at 50m histogram_fraction(0, 0.2, rate(testhistogram3_bucket[10m]))
 	{start="positive"} 0.6363636363636364
 	{start="negative"} 0
 
-# positive buckets, lower falls in the first bucket
+# Positive buckets, lower falls in the first bucket.
 load_with_nhcb 5m
 	positive_buckets_lower_falls_in_the_first_bucket_bucket{le="1"}	 1+0x10
 	positive_buckets_lower_falls_in_the_first_bucket_bucket{le="2"}	 3+0x10
 	positive_buckets_lower_falls_in_the_first_bucket_bucket{le="3"}	 6+0x10
 	positive_buckets_lower_falls_in_the_first_bucket_bucket{le="+Inf"} 100+0x10
 
-# - Bucket [0, 1]: contributes 1.0 observation (full bucket)
-# - Bucket [1, 2]: contributes (1.5-1)/(2-1) * (3-1) = 0.5 * 2 = 1.0 observations
+# - Bucket [0, 1]: contributes 1.0 observation (full bucket).
+# - Bucket [1, 2]: contributes (1.5-1)/(2-1) * (3-1) = 0.5 * 2 = 1.0 observations.
 # Total: (1.0 + 1.0) / 100.0 = 0.02
 
 eval instant at 50m histogram_fraction(0, 1.5, positive_buckets_lower_falls_in_the_first_bucket_bucket)
@@ -177,15 +177,15 @@ eval instant at 50m histogram_fraction(0, 1.5, positive_buckets_lower_falls_in_t
 	expect no_warn
 	{} 0.02
 
-# negative buckets, lower falls in the first bucket
+# Negative buckets, lower falls in the first bucket.
 load_with_nhcb 5m
 	negative_buckets_lower_falls_in_the_first_bucket_bucket{le="-3"}	 10+0x10
 	negative_buckets_lower_falls_in_the_first_bucket_bucket{le="-2"}	 12+0x10
 	negative_buckets_lower_falls_in_the_first_bucket_bucket{le="-1"}	 15+0x10
 	negative_buckets_lower_falls_in_the_first_bucket_bucket{le="+Inf"} 100+0x10
 
-# - Bucket [-Inf, -3]: contributes zero observations (no interpolation with infinite width bucket)
-# - Bucket [-3, -2]: contributes 12-10 = 2.0 observations (full bucket)
+# - Bucket [-Inf, -3]: contributes zero observations (no interpolation with infinite width bucket).
+# - Bucket [-3, -2]: contributes 12-10 = 2.0 observations (full bucket).
 # Total: 2.0 / 100.0 = 0.02
 
 eval instant at 50m histogram_fraction(-4, -2, negative_buckets_lower_falls_in_the_first_bucket_bucket)
@@ -196,16 +196,16 @@ eval instant at 50m histogram_fraction(-4, -2, negative_buckets_lower_falls_in_t
 	expect no_warn
 	{} 0.02
 
-# lower is -Inf
+# Lower is -Inf.
 load_with_nhcb 5m
 	lower_is_negative_Inf_bucket{le="-3"}	 10+0x10
 	lower_is_negative_Inf_bucket{le="-2"}	 12+0x10
 	lower_is_negative_Inf_bucket{le="-1"}	 15+0x10
 	lower_is_negative_Inf_bucket{le="+Inf"} 100+0x10
 
-# - Bucket [-Inf, -3]: contributes 10.0 observations (full bucket)
-# - Bucket [-3, -2]: contributes 12-10 = 2.0 observations (full bucket)
-# - Bucket [-2, -1]: contributes (-1.5-(-2))/(-1-(-2)) * (15-12) = 0.5 * 3 = 1.5 observations
+# - Bucket [-Inf, -3]: contributes 10.0 observations (full bucket).
+# - Bucket [-3, -2]: contributes 12-10 = 2.0 observations (full bucket).
+# - Bucket [-2, -1]: contributes (-1.5-(-2))/(-1-(-2)) * (15-12) = 0.5 * 3 = 1.5 observations.
 # Total: (10.0 + 2.0 + 1.5) / 100.0 = 0.135
 
 eval instant at 50m histogram_fraction(-Inf, -1.5, lower_is_negative_Inf_bucket)
@@ -216,14 +216,14 @@ eval instant at 50m histogram_fraction(-Inf, -1.5, lower_is_negative_Inf)
 	expect no_warn
 	{} 0.135
 
-# lower is -Inf and upper is +Inf (positive buckets)
+# Lower is -Inf and upper is +Inf (positive buckets).
 load_with_nhcb 5m
 	lower_is_negative_Inf_and_upper_is_positive_Inf__positive_buckets__bucket{le="1"}	 1+0x10
 	lower_is_negative_Inf_and_upper_is_positive_Inf__positive_buckets__bucket{le="2"}	 3+0x10
 	lower_is_negative_Inf_and_upper_is_positive_Inf__positive_buckets__bucket{le="3"}	 6+0x10
 	lower_is_negative_Inf_and_upper_is_positive_Inf__positive_buckets__bucket{le="+Inf"} 100+0x10
 
-# Range [-Inf, +Inf] captures all observations
+# Range [-Inf, +Inf] captures all observations.
 
 eval instant at 50m histogram_fraction(-Inf, +Inf, lower_is_negative_Inf_and_upper_is_positive_Inf__positive_buckets__bucket)
 	expect no_warn
@@ -233,14 +233,14 @@ eval instant at 50m histogram_fraction(-Inf, +Inf, lower_is_negative_Inf_and_upp
 	expect no_warn
 	{} 1.0
 
-# lower is -Inf and upper is +Inf (negative buckets)
+# Lower is -Inf and upper is +Inf (negative buckets).
 load_with_nhcb 5m
 	lower_is_negative_Inf_and_upper_is_positive_Inf__negative_buckets__bucket{le="-3"}	 10+0x10
 	lower_is_negative_Inf_and_upper_is_positive_Inf__negative_buckets__bucket{le="-2"}	 12+0x10
 	lower_is_negative_Inf_and_upper_is_positive_Inf__negative_buckets__bucket{le="-1"}	 15+0x10
 	lower_is_negative_Inf_and_upper_is_positive_Inf__negative_buckets__bucket{le="+Inf"} 100+0x10
 
-# Range [-Inf, +Inf] captures all observations
+# Range [-Inf, +Inf] captures all observations.
 
 eval instant at 50m histogram_fraction(-Inf, +Inf, lower_is_negative_Inf_and_upper_is_positive_Inf__negative_buckets__bucket)
 	expect no_warn
@@ -250,14 +250,14 @@ eval instant at 50m histogram_fraction(-Inf, +Inf, lower_is_negative_Inf_and_upp
 	expect no_warn
 	{} 1.0
 
-# lower and upper fall in last bucket (positive buckets)
+# Lower and upper fall in last bucket (positive buckets).
 load_with_nhcb 5m
 	lower_and_upper_fall_in_last_bucket__positive_buckets__bucket{le="1"}	 1+0x10
 	lower_and_upper_fall_in_last_bucket__positive_buckets__bucket{le="2"}	 3+0x10
 	lower_and_upper_fall_in_last_bucket__positive_buckets__bucket{le="3"}	 6+0x10
 	lower_and_upper_fall_in_last_bucket__positive_buckets__bucket{le="+Inf"} 100+0x10
 
-# - Bucket [3, +Inf]: contributes zero observations (no interpolation with infinite width bucket)
+# - Bucket [3, +Inf]: contributes zero observations (no interpolation with infinite width bucket).
 # Total: 0.0 / 100.0 = 0.0
 
 eval instant at 50m histogram_fraction(4, 5, lower_and_upper_fall_in_last_bucket__positive_buckets__bucket)
@@ -268,14 +268,14 @@ eval instant at 50m histogram_fraction(4, 5, lower_and_upper_fall_in_last_bucket
 	expect no_warn
 	{} 0.0
 
-# lower and upper fall in last bucket (negative buckets)
+# Lower and upper fall in last bucket (negative buckets).
 load_with_nhcb 5m
 	lower_and_upper_fall_in_last_bucket__negative_buckets__bucket{le="-3"}	 10+0x10
 	lower_and_upper_fall_in_last_bucket__negative_buckets__bucket{le="-2"}	 12+0x10
 	lower_and_upper_fall_in_last_bucket__negative_buckets__bucket{le="-1"}	 15+0x10
 	lower_and_upper_fall_in_last_bucket__negative_buckets__bucket{le="+Inf"} 100+0x10
 
-# - Bucket [-1, +Inf]: contributes zero observations (no interpolation with infinite width bucket)
+# - Bucket [-1, +Inf]: contributes zero observations (no interpolation with infinite width bucket).
 # Total: 0.0 / 100.0 = 0.0
 
 eval instant at 50m histogram_fraction(0, 1, lower_and_upper_fall_in_last_bucket__negative_buckets__bucket)
@@ -286,15 +286,15 @@ eval instant at 50m histogram_fraction(0, 1, lower_and_upper_fall_in_last_bucket
 	expect no_warn
 	{} 0.0
 
-# upper falls in last bucket
+# Upper falls in last bucket.
 load_with_nhcb 5m
 	upper_falls_in_last_bucket_bucket{le="1"}	 1+0x10
 	upper_falls_in_last_bucket_bucket{le="2"}	 3+0x10
 	upper_falls_in_last_bucket_bucket{le="3"}	 6+0x10
 	upper_falls_in_last_bucket_bucket{le="+Inf"} 100+0x10
 
-# - Bucket [2, 3]: 6-3 = 3.0 observations (full bucket)
-# - Bucket [3, +Inf]: contributes zero observations (no interpolation with infinite width bucket)
+# - Bucket [2, 3]: 6-3 = 3.0 observations (full bucket).
+# - Bucket [3, +Inf]: contributes zero observations (no interpolation with infinite width bucket).
 # Total: 3.0 / 100.0 = 0.03
 
 eval instant at 50m histogram_fraction(2, 5, upper_falls_in_last_bucket_bucket)
@@ -305,14 +305,14 @@ eval instant at 50m histogram_fraction(2, 5, upper_falls_in_last_bucket)
 	expect no_warn
 	{} 0.03
 
-# upper is +Inf
+# Upper is +Inf.
 load_with_nhcb 5m
 	upper_is_positive_Inf_bucket{le="1"}	 1+0x10
 	upper_is_positive_Inf_bucket{le="2"}	 3+0x10
 	upper_is_positive_Inf_bucket{le="3"}	 6+0x10
 	upper_is_positive_Inf_bucket{le="+Inf"} 100+0x10
 
-# All observations in +Inf bucket: 100-6 = 94.0 observations
+# All observations in +Inf bucket: 100-6 = 94.0 observations.
 # Total: 94.0 / 100.0 = 0.94
 
 eval instant at 50m histogram_fraction(400, +Inf, upper_is_positive_Inf_bucket)
@@ -323,14 +323,14 @@ eval instant at 50m histogram_fraction(400, +Inf, upper_is_positive_Inf)
 	expect no_warn
 	{} 0.94
 
-# lower equals upper
+# Lower equals upper.
 load_with_nhcb 5m
 	lower_equals_upper_bucket{le="1"}	 1+0x10
 	lower_equals_upper_bucket{le="2"}	 3+0x10
 	lower_equals_upper_bucket{le="3"}	 6+0x10
 	lower_equals_upper_bucket{le="+Inf"} 100+0x10
 
-# No observations can be captured in a zero-width range
+# No observations can be captured in a zero-width range.
 
 eval instant at 50m histogram_fraction(2, 2, lower_equals_upper_bucket)
 	expect no_warn
@@ -340,7 +340,7 @@ eval instant at 50m histogram_fraction(2, 2, lower_equals_upper)
 	expect no_warn
 	{} 0.0
 
-# lower greater than upper
+# Lower greater than upper.
 load_with_nhcb 5m
 	lower_greater_than_upper_bucket{le="1"}	 1+0x10
 	lower_greater_than_upper_bucket{le="2"}	 3+0x10
@@ -355,11 +355,11 @@ eval instant at 50m histogram_fraction(3, 2, lower_greater_than_upper)
 	expect no_warn
 	{} 0.0
 
-# single bucket
+# Single bucket.
 load_with_nhcb 5m
 	single_bucket_bucket{le="+Inf"} 100+0x10
 
-# - Bucket [0, +Inf]: contributes zero observations (no interpolation with infinite width bucket)
+# - Bucket [0, +Inf]: contributes zero observations (no interpolation with infinite width bucket).
 # Total: 0.0 / 100.0 = 0.0
 
 eval instant at 50m histogram_fraction(0, 1, single_bucket_bucket)
@@ -370,7 +370,7 @@ eval instant at 50m histogram_fraction(0, 1, single_bucket)
 	expect no_warn
 	{} 0.0
 
-# all zero counts
+# All zero counts.
 load_with_nhcb 5m
 	all_zero_counts_bucket{le="1"}	 0+0x10
 	all_zero_counts_bucket{le="2"}	 0+0x10
@@ -385,15 +385,15 @@ eval instant at 50m histogram_fraction(0, 5, all_zero_counts)
 	expect no_warn
 	{} NaN
 
-# lower exactly on bucket boundary
+# Lower exactly on bucket boundary.
 load_with_nhcb 5m
 	lower_exactly_on_bucket_boundary_bucket{le="1"}	 1+0x10
 	lower_exactly_on_bucket_boundary_bucket{le="2"}	 3+0x10
 	lower_exactly_on_bucket_boundary_bucket{le="3"}	 6+0x10
 	lower_exactly_on_bucket_boundary_bucket{le="+Inf"} 100+0x10
 
-# - Bucket [2, 3]: 6-3 = 3.0 observations (full bucket)
-# - Bucket [3, +Inf]: contributes zero observations (no interpolation with infinite width bucket)
+# - Bucket [2, 3]: 6-3 = 3.0 observations (full bucket).
+# - Bucket [3, +Inf]: contributes zero observations (no interpolation with infinite width bucket).
 # Total: 3.0 / 100.0 = 0.03
 
 eval instant at 50m histogram_fraction(2, 3.5, lower_exactly_on_bucket_boundary_bucket)
@@ -404,15 +404,15 @@ eval instant at 50m histogram_fraction(2, 3.5, lower_exactly_on_bucket_boundary)
 	expect no_warn
 	{} 0.03
 
-# upper exactly on bucket boundary
+# Upper exactly on bucket boundary.
 load_with_nhcb 5m
 	upper_exactly_on_bucket_boundary_bucket{le="1"}	 1+0x10
 	upper_exactly_on_bucket_boundary_bucket{le="2"}	 3+0x10
 	upper_exactly_on_bucket_boundary_bucket{le="3"}	 6+0x10
 	upper_exactly_on_bucket_boundary_bucket{le="+Inf"} 100+0x10
 
-# - Bucket [0, 1]: (1.0-0.5)/(1.0-0.0) * 1.0 = 0.5 * 1.0 = 0.5 observations
-# - Bucket [1, 2]: 3-1 = 2.0 observations (full bucket)
+# - Bucket [0, 1]: (1.0-0.5)/(1.0-0.0) * 1.0 = 0.5 * 1.0 = 0.5 observations.
+# - Bucket [1, 2]: 3-1 = 2.0 observations (full bucket).
 # Total: (0.5 + 2.0) / 100.0 = 0.025
 
 eval instant at 50m histogram_fraction(0.5, 2, upper_exactly_on_bucket_boundary_bucket)
@@ -423,15 +423,15 @@ eval instant at 50m histogram_fraction(0.5, 2, upper_exactly_on_bucket_boundary)
 	expect no_warn
 	{} 0.025
 
-# both bounds exactly on bucket boundaries
+# Both bounds exactly on bucket boundaries.
 load_with_nhcb 5m
 	both_bounds_exactly_on_bucket_boundaries_bucket{le="1"}	 1+0x10
 	both_bounds_exactly_on_bucket_boundaries_bucket{le="2"}	 3+0x10
 	both_bounds_exactly_on_bucket_boundaries_bucket{le="3"}	 6+0x10
 	both_bounds_exactly_on_bucket_boundaries_bucket{le="+Inf"} 100+0x10
 
-# - Bucket [1, 2]: 3-1 = 2.0 observations (full bucket)
-# - Bucket [2, 3]: 6-3 = 3.0 observations (full bucket)
+# - Bucket [1, 2]: 3-1 = 2.0 observations (full bucket).
+# - Bucket [2, 3]: 6-3 = 3.0 observations (full bucket).
 # Total: (2.0 + 3.0) / 100.0 = 0.05
 
 eval instant at 50m histogram_fraction(1, 3, both_bounds_exactly_on_bucket_boundaries_bucket)
@@ -442,14 +442,14 @@ eval instant at 50m histogram_fraction(1, 3, both_bounds_exactly_on_bucket_bound
 	expect no_warn
 	{} 0.05
 
-# fractional bucket bounds
+# Fractional bucket bounds.
 load_with_nhcb 5m
 	fractional_bucket_bounds_bucket{le="0.5"}	 2.5+0x10
 	fractional_bucket_bounds_bucket{le="1"}	 7.5+0x10
 	fractional_bucket_bounds_bucket{le="+Inf"} 100+0x10
 
-# - Bucket [0, 0.5]: (0.5-0.1)/(0.5-0.0) * 2.5 = 0.8 * 2.5 = 2.0 observations
-# - Bucket [0.5, 1.0]: (0.75-0.5)/(1.0-0.5) * (7.5-2.5) = 0.5 * 5.0 = 2.5 observations
+# - Bucket [0, 0.5]: (0.5-0.1)/(0.5-0.0) * 2.5 = 0.8 * 2.5 = 2.0 observations.
+# - Bucket [0.5, 1.0]: (0.75-0.5)/(1.0-0.5) * (7.5-2.5) = 0.5 * 5.0 = 2.5 observations.
 # Total: (2.0 + 2.5) / 100.0 = 0.045
 
 eval instant at 50m histogram_fraction(0.1, 0.75, fractional_bucket_bounds_bucket)
@@ -460,7 +460,7 @@ eval instant at 50m histogram_fraction(0.1, 0.75, fractional_bucket_bounds)
 	expect no_warn
 	{} 0.045
 
-# range crosses zero
+# Range crosses zero.
 load_with_nhcb 5m
 	range_crosses_zero_bucket{le="-2"}	 5+0x10
 	range_crosses_zero_bucket{le="-1"}	 10+0x10
@@ -468,8 +468,8 @@ load_with_nhcb 5m
 	range_crosses_zero_bucket{le="1"}	 20+0x10
 	range_crosses_zero_bucket{le="+Inf"} 100+0x10
 
-# - Bucket [-1, 0]: 15-10 = 5.0 observations (full bucket)
-# - Bucket [0, 1]: 20-15 = 5.0 observations (full bucket)
+# - Bucket [-1, 0]: 15-10 = 5.0 observations (full bucket).
+# - Bucket [0, 1]: 20-15 = 5.0 observations (full bucket).
 # Total: (5.0 + 5.0) / 100.0 = 0.1
 
 eval instant at 50m histogram_fraction(-1, 1, range_crosses_zero_bucket)
@@ -480,7 +480,7 @@ eval instant at 50m histogram_fraction(-1, 1, range_crosses_zero)
 	expect no_warn
 	{} 0.1
 
-# lower is NaN
+# Lower is NaN.
 load_with_nhcb 5m
 	lower_is_NaN_bucket{le="1"}	 1+0x10
 	lower_is_NaN_bucket{le="+Inf"} 100+0x10
@@ -493,7 +493,7 @@ eval instant at 50m histogram_fraction(NaN, 1, lower_is_NaN)
 	expect no_warn
 	{} NaN
 
-# upper is NaN
+# Upper is NaN.
 load_with_nhcb 5m
 	upper_is_NaN_bucket{le="1"}	 1+0x10
 	upper_is_NaN_bucket{le="+Inf"} 100+0x10
@@ -506,7 +506,7 @@ eval instant at 50m histogram_fraction(0, NaN, upper_is_NaN)
 	expect no_warn
 	{} NaN
 
-# range entirely below all buckets
+# Range entirely below all buckets.
 load_with_nhcb 5m
 	range_entirely_below_all_buckets_bucket{le="1"}	 1+0x10
 	range_entirely_below_all_buckets_bucket{le="2"}	 3+0x10
@@ -520,7 +520,7 @@ eval instant at 50m histogram_fraction(-10, -5, range_entirely_below_all_buckets
 	expect no_warn
 	{} 0.0
 
-# range entirely above all buckets
+# Range entirely above all buckets.
 load_with_nhcb 5m
 	range_entirely_above_all_buckets_bucket{le="1"}	 1+0x10
 	range_entirely_above_all_buckets_bucket{le="2"}	 3+0x10

--- a/promql/quantile.go
+++ b/promql/quantile.go
@@ -546,7 +546,7 @@ func BucketFraction(lower, upper float64, buckets Buckets) float64 {
 
 	// If the upper bound of the first bucket is greater than 0, we assume
 	// we are dealing with positive buckets only and lowerBound for the
-	// first bucket is set to 0; otherwise it is set to -Inf
+	// first bucket is set to 0; otherwise it is set to -Inf.
 	lowerBound := 0.0
 	if buckets[0].UpperBound <= 0 {
 		lowerBound = math.Inf(-1)


### PR DESCRIPTION
Fixes `histogram_fraction` returning `NaN` when `lower` falls within the first bucket for classic histograms and NHCB. The issue is described [here](https://github.com/prometheus/prometheus/issues/17367).

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
Fixes https://github.com/prometheus/prometheus/issues/17367
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] Fix `histogram_fraction` for classic histograms and NHCB if lower bound is in the first bucket.
```
