### PR TITLE
promql: fix resets/changes to return empty for anchored selectors when samples outside range

### DIFF
--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -319,7 +319,6 @@ eval instant at 2m changes(metric[1m] anchored)
     {id="2"} 1
 
 eval instant at 3m changes(metric[1m] anchored)
-    {id="1"} 1
     {id="2"} 1
 
 eval instant at 8m changes(metric[1m] anchored)
@@ -342,7 +341,6 @@ eval instant at 2m resets(metric[1m] anchored)
     {id="2"} 1
 
 eval instant at 3m resets(metric[1m] anchored)
-    {id="1"} 1
     {id="2"} 1
 
 eval instant at 8m resets(metric[1m] anchored)


### PR DESCRIPTION
The funcResets and funcChanges functions now correctly return no result when all float samples are at or before the range start for anchored selectors, consistent with the behavior of rate/increase functions.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] PromQL: Fix resets/changes to return empty results for anchored selectors when all samples are outside the range
```
