### PR TITLE
remote_write azure auth : add custom scope support

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3110,6 +3110,14 @@ azuread:
   [ sdk:
       [ tenant_id: <string> ] ]
 
+  # Optional custom OAuth 2.0 scope to request when acquiring tokens.
+  # If not specified, defaults to the appropriate monitoring scope for the cloud:
+  # - AzurePublic: https://monitor.azure.com//.default
+  # - AzureGovernment: https://monitor.azure.us//.default  
+  # - AzureChina: https://monitor.azure.cn//.default
+  # Use this to authenticate against custom Azure applications or non-standard endpoints.
+  [ scope: <string> ]
+
 # WARNING: Remote write is NOT SUPPORTED by Google Cloud. This configuration is reserved for future use.
 # Optional Google Cloud Monitoring configuration.
 # Cannot be used at the same time as basic_auth, authorization, oauth2, sigv4 or azuread.

--- a/storage/remote/azuread/testdata/azuread_bad_scope_invalid.yaml
+++ b/storage/remote/azuread/testdata/azuread_bad_scope_invalid.yaml
@@ -1,0 +1,6 @@
+cloud: AzurePublic
+oauth:
+  client_id: 00000000-0000-0000-0000-000000000000
+  client_secret: Cl1ent$ecret!
+  tenant_id: 00000000-a12b-3cd4-e56f-000000000000
+scope: "invalid<>scope*chars"

--- a/storage/remote/azuread/testdata/azuread_good_oauth_customscope.yaml
+++ b/storage/remote/azuread/testdata/azuread_good_oauth_customscope.yaml
@@ -1,0 +1,6 @@
+cloud: AzurePublic
+oauth:
+  client_id: 00000000-0000-0000-0000-000000000000
+  client_secret: Cl1ent$ecret!
+  tenant_id: 00000000-a12b-3cd4-e56f-000000000000
+scope: "https://custom-app.com/.default"


### PR DESCRIPTION
azuread: add custom scope support for remote write authentication

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

## Summary

This PR adds support for custom OAuth 2.0 scopes in Azure AD authentication for remote write endpoints. Previously, users were limited to cloud-specific monitoring scopes. This enhancement allows authentication against custom Azure applications and non-standard endpoints while maintaining full backward compatibility.

## Changes

### Core Implementation
- **Added `Scope` field** to `AzureADConfig` struct in `storage/remote/azuread/azuread.go`
- **Updated `newTokenProvider`** to use custom scope when provided, falling back to existing cloud-specific audiences
- **Added scope validation** using regex pattern to ensure valid OAuth 2.0 scope characters

## Behavior

### Before
Users could only authenticate against predefined monitoring endpoints:
- AzurePublic: `https://monitor.azure.com//.default`
- AzureGovernment: `https://monitor.azure.us//.default`
- AzureChina: `https://monitor.azure.cn//.default`

### After
Users can specify custom scopes while maintaining backward compatibility:

```yaml
remote_write:
  - url: "https://custom-endpoint.com/api/v1/write"
    azuread:
      cloud: AzurePublic
      oauth:
        client_id: "12345678-1234-1234-1234-123456789012"
        client_secret: "your-secret"
        tenant_id: "87654321-4321-4321-4321-210987654321"
      scope: "api://custom-app-id/.default"
```

When `scope` is not specified, the system automatically uses the appropriate cloud-specific monitoring scope, ensuring zero breaking changes.

## Use Cases

This enhancement enables:
- **Custom Azure applications**: Authenticate against user-registered Azure AD applications
- **Multi-tenant scenarios**: Use application-specific scopes for tenant isolation
- **Non-standard endpoints**: Support for custom monitoring solutions requiring specific OAuth scopes
- **Workload Identity with custom scopes**: Enhanced support for Kubernetes workload identity scenarios

#### Which issue(s) does the PR fix:
Fixes #16918

#### Does this PR introduce a user-facing change?

```release-notes
[ENHANCEMENT] azuread: Add custom scope support for remote write authentication. Users can now specify custom OAuth 2.0 scopes in Azure AD configuration while maintaining backward compatibility with existing cloud-specific monitoring scopes.
```


## Backward Compatibility

This change is fully backward compatible:
- **No breaking changes** to existing configurations