### PR TITLE
test(scrape): additional http validation within TestTargetScraperScrapeOK

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -3752,8 +3752,9 @@ func TestRequestTraceparentHeader(t *testing.T) {
 
 func TestTargetScraperScrapeOK(t *testing.T) {
 	const (
-		configTimeout   = 1500 * time.Millisecond
-		expectedTimeout = "1.5"
+		configTimeout          = 1500 * time.Millisecond
+		expectedTimeout        = "1.5"
+		expectedAcceptEncoding = "gzip"
 	)
 
 	var (
@@ -3794,17 +3795,7 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 
 			require.Equal(t, http.MethodGet, r.Method, "HTTP method should be GET")
 
-			expectedHeaders := []string{"Accept", "Accept-Encoding", "User-Agent", "X-Prometheus-Scrape-Timeout-Seconds"}
-			for name := range r.Header {
-				found := false
-				for _, eh := range expectedHeaders {
-					if strings.EqualFold(name, eh) {
-						found = true
-						break
-					}
-				}
-				require.Truef(t, found, "Unexpected header found: %s", name)
-			}
+			require.Equal(t, expectedAcceptEncoding, r.Header.Get("Accept-Encoding"), "Unexpected Accept-Encoding header")
 
 			if allowUTF8 {
 				w.Header().Set("Content-Type", `text/plain; version=1.0.0; escaping=allow-utf-8`)
@@ -3830,9 +3821,10 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 				),
 				scrapeConfig: &config.ScrapeConfig{},
 			},
-			client:       http.DefaultClient,
-			timeout:      configTimeout,
-			acceptHeader: acceptHeader,
+			client:               http.DefaultClient,
+			timeout:              configTimeout,
+			acceptHeader:         acceptHeader,
+			acceptEncodingHeader: expectedAcceptEncoding,
 		}
 		var buf bytes.Buffer
 


### PR DESCRIPTION
## Summary 
Goal is to add additional testing for http validation on Prometheus scrape GET request to prevent regression.

- Verify User-Agent header correctness
- Ensure HTTP method is GET
~- Check for unexpected headers presence~
EDIT:
- Verify Accept-Encoding header correctness 
- q value correctness is already tested [here](https://github.com/prometheus/prometheus/pull/17492#issuecomment-3900441400)



<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
## Verification
```
sammy@DESKTOP-HE61M59:~/prom/prometheus$ go test ./scrape
ok      github.com/prometheus/prometheus/scrape 12.764s
```

#### Which issue(s) does the PR fix:
Related to #13556
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
