### PR TITLE
promql: add experimental rewrite package

### DIFF
--- a/promql/rewrite/nhcb.go
+++ b/promql/rewrite/nhcb.go
@@ -1,0 +1,271 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rewrite
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+)
+
+const (
+	bucketSuffix = "_bucket"
+	sumSuffix    = "_sum"
+	countSuffix  = "_count"
+)
+
+var (
+	histogramAvg      = parser.MustGetFunction("histogram_avg")
+	histogramQuantile = parser.MustGetFunction("histogram_quantile")
+	histogramCount    = parser.MustGetFunction("histogram_count")
+	histogramFraction = parser.MustGetFunction("histogram_fraction")
+	histogramSum      = parser.MustGetFunction("histogram_sum")
+)
+
+func TransformClassicHistograms(histograms []string) Transform {
+	return List{
+		// histogram_quantile(X, sum by (le, W) (rate(Y_bucket[Z]))) -> histogram_quantile(X, sum by (W) (rate(Y[Z])))
+		TransformFunc(func(expr parser.Expr) (parser.Expr, error) {
+			call, ok := expr.(*parser.Call)
+			if !ok {
+				return expr, nil
+			}
+			if call.Func != histogramQuantile {
+				return expr, nil
+			}
+			if len(call.Args) != 2 {
+				return expr, nil
+			}
+			sumAgg, ok := call.Args[1].(*parser.AggregateExpr)
+			if !ok {
+				return expr, nil
+			}
+			if !slices.Contains(sumAgg.Grouping, labels.BucketLabel) {
+				return expr, nil
+			}
+			innerCall, ok := sumAgg.Expr.(*parser.Call)
+			if !ok {
+				return expr, nil
+			}
+			switch innerCall.Func.Name {
+			case "delta", "idelta", "increase", "irate", "rate":
+			default:
+				return expr, fmt.Errorf("inner function %q cannot be converted", innerCall.Func.Name)
+			}
+			if len(innerCall.Args) != 1 {
+				return expr, nil
+			}
+			ms, ok := innerCall.Args[0].(*parser.MatrixSelector)
+			if !ok {
+				return expr, nil
+			}
+			vs, ok := ms.VectorSelector.(*parser.VectorSelector)
+			if !ok {
+				return expr, nil
+			}
+			if !strings.HasSuffix(vs.Name, bucketSuffix) {
+				return expr, nil
+			}
+			newName := histogramBaseName(vs.Name)
+			if !slices.Contains(histograms, newName) {
+				return expr, nil
+			}
+			newVs := cloneExpr(vs).(*parser.VectorSelector)
+			renameVectorSelector(newVs, newName)
+
+			return &parser.Call{
+				Func: call.Func,
+				Args: parser.Expressions{
+					call.Args[0],
+					&parser.AggregateExpr{
+						Op: sumAgg.Op,
+						Expr: &parser.Call{
+							Func: innerCall.Func,
+							Args: parser.Expressions{
+								&parser.MatrixSelector{
+									VectorSelector: newVs,
+									Range:          ms.Range,
+									RangeExpr:      ms.RangeExpr,
+									EndPos:         ms.EndPos,
+								},
+							},
+						},
+						Param:    sumAgg.Param,
+						Grouping: removeItem(sumAgg.Grouping, labels.BucketLabel),
+						Without:  sumAgg.Without,
+					},
+				},
+			}, nil
+		}),
+		// X_bucket{le="Y"} -> histogram_count(X) * histogram_fraction(-Inf, Y, X)
+		TransformFunc(func(expr parser.Expr) (parser.Expr, error) {
+			vs, ok := expr.(*parser.VectorSelector)
+			if !ok {
+				return expr, nil
+			}
+			if !strings.HasSuffix(vs.Name, bucketSuffix) {
+				return expr, nil
+			}
+			newName := histogramBaseName(vs.Name)
+			if !slices.Contains(histograms, newName) {
+				return expr, nil
+			}
+			// Ensure matching on LE label.
+			le := -1.0
+			for _, l := range vs.LabelMatchers {
+				if l.Name == labels.BucketLabel {
+					parsed, err := strconv.ParseFloat(l.Value, 64)
+					if err != nil {
+						return expr, fmt.Errorf("invalid le label value: %s", l.Value)
+					}
+					le = parsed
+					break
+				}
+			}
+			if le == -1 {
+				return expr, nil
+			}
+
+			newVs := cloneExpr(vs).(*parser.VectorSelector)
+			renameVectorSelector(newVs, newName)
+			removeLabelMatchers(newVs, labels.BucketLabel)
+
+			lhs := &parser.Call{
+				Func: histogramCount,
+				Args: parser.Expressions{newVs},
+			}
+			rhs := &parser.Call{
+				Func: histogramFraction,
+				Args: parser.Expressions{
+					&parser.NumberLiteral{
+						Val: math.Inf(-1),
+					},
+					&parser.NumberLiteral{
+						Val: le,
+					},
+					newVs,
+				},
+			}
+			return &parser.BinaryExpr{
+				Op:  parser.MUL,
+				LHS: lhs,
+				RHS: rhs,
+			}, nil
+		}),
+		// X_sum / X_count -> histogram_avg(X)
+		TransformFunc(func(node parser.Expr) (parser.Expr, error) {
+			bin, ok := node.(*parser.BinaryExpr)
+			if !ok {
+				return node, nil
+			}
+			if bin.Op != parser.DIV {
+				return node, nil
+			}
+			left, ok := bin.LHS.(*parser.VectorSelector)
+			if !ok {
+				return node, nil
+			}
+			right, ok := bin.RHS.(*parser.VectorSelector)
+			if !ok {
+				return node, nil
+			}
+			if selectorLabelsHash(left) != selectorLabelsHash(right) {
+				return node, nil
+			}
+			leftName, rightName := histogramBaseName(left.Name), histogramBaseName(right.Name)
+			if leftName != rightName {
+				return node, nil
+			}
+			if !slices.Contains(histograms, leftName) {
+				return node, nil
+			}
+			newVs := cloneExpr(left).(*parser.VectorSelector)
+			renameVectorSelector(newVs, leftName)
+			return &parser.Call{
+				Func:     histogramAvg,
+				Args:     parser.Expressions{newVs},
+				PosRange: posrange.PositionRange{},
+			}, nil
+		}),
+		// X_count -> histogram_count(X)
+		TransformFunc(func(expr parser.Expr) (parser.Expr, error) {
+			vs, ok := expr.(*parser.VectorSelector)
+			if !ok {
+				return expr, nil
+			}
+			if !strings.HasSuffix(vs.Name, countSuffix) {
+				return expr, nil
+			}
+			baseName := histogramBaseName(vs.Name)
+			if !slices.Contains(histograms, baseName) {
+				return expr, nil
+			}
+			newVs := cloneExpr(vs).(*parser.VectorSelector)
+			renameVectorSelector(newVs, histogramBaseName(vs.Name))
+			return &parser.Call{
+				Func: histogramCount,
+				Args: parser.Expressions{newVs},
+			}, nil
+		}),
+		// X_sum -> histogram_sum(X)
+		TransformFunc(func(expr parser.Expr) (parser.Expr, error) {
+			vs, ok := expr.(*parser.VectorSelector)
+			if !ok {
+				return expr, nil
+			}
+			if !strings.HasSuffix(vs.Name, sumSuffix) {
+				return expr, nil
+			}
+			baseName := histogramBaseName(vs.Name)
+			if !slices.Contains(histograms, baseName) {
+				return expr, nil
+			}
+			newVs := cloneExpr(vs).(*parser.VectorSelector)
+			renameVectorSelector(newVs, histogramBaseName(vs.Name))
+			return &parser.Call{
+				Func: histogramSum,
+				Args: parser.Expressions{newVs},
+			}, nil
+		}),
+	}
+}
+
+func selectorLabelsHash(vs *parser.VectorSelector) string {
+	h := md5.New()
+	for _, l := range vs.LabelMatchers {
+		// Skip reserved labels:
+		if strings.HasPrefix(l.Name, "__") && strings.HasSuffix(l.Name, "__") {
+			continue
+		}
+		h.Write([]byte(l.Name + ":" + l.Value + ","))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func histogramBaseName(s string) string {
+	for _, suffix := range []string{countSuffix, sumSuffix, bucketSuffix} {
+		if strings.HasSuffix(s, suffix) {
+			return s[:len(s)-len(suffix)]
+		}
+	}
+	return s
+}

--- a/promql/rewrite/nhcb_test.go
+++ b/promql/rewrite/nhcb_test.go
@@ -1,0 +1,111 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rewrite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+func TestTransformClassicHistograms(t *testing.T) {
+	testCases := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			input: `4 * rate(hist[5m])`,
+			want:  `4 * rate(hist[5m])`,
+		},
+		// histogram_quantile(X, sum by (le) (rate(Y_bucket[Z]))) -> histogram_quantile(X, sum (rate(Y[Z])))
+		{
+			input: `histogram_quantile(0.9, sum by (le) (rate(hist_bucket[5m])))`,
+			want:  `histogram_quantile(0.9, sum(rate(hist[5m])))`,
+		},
+		{
+			input: `histogram_quantile(0.9, sum by (le, f) (rate(hist_bucket[5m])))`,
+			want:  `histogram_quantile(0.9, sum by (f) (rate(hist[5m])))`,
+		},
+		{
+			input: `histogram_quantile(0.9, sum (rate(hist_bucket[5m])) by (f, le))`,
+			want:  `histogram_quantile(0.9, sum by (f) (rate(hist[5m])))`,
+		},
+		{
+			input: `histogram_quantile(0.9, sum (irate(hist_bucket[5m])) by (f, le))`,
+			want:  `histogram_quantile(0.9, sum by (f) (irate(hist[5m])))`,
+		},
+		{
+			input:   `histogram_quantile(0.9, sum (deriv(hist_bucket[5m])) by (f, le))`,
+			want:    `histogram_quantile(0.9, sum (deriv(hist_bucket[5m])) by (f, le))`,
+			wantErr: true,
+		},
+		// X_bucket{le="Y"} -> histogram_count(X) * histogram_fraction(-Inf, Y, X)
+		{
+			input: `hist_bucket{le="0.99"}`,
+			want:  `histogram_count(hist) * histogram_fraction(-Inf, 0.99, hist)`,
+		},
+		{
+			input: `hist_bucket{a="b", le="0.8"}`,
+			want:  `histogram_count(hist{a="b"}) * histogram_fraction(-Inf, 0.8, hist{a="b"})`,
+		},
+		//  X_sum / X_count -> histogram_avg(X)
+		{
+			input: `hist_sum / hist_count`,
+			want:  `histogram_avg(hist)`,
+		},
+		// X_count -> histogram_count(X)
+		{
+			input: `hist_count`,
+			want:  `histogram_count(hist)`,
+		},
+		{
+			input: `2 * hist_count{a=~"b"}`,
+			want:  `2 * histogram_count(hist{a=~"b"})`,
+		},
+		// X_sum -> histogram_sum(X)
+		{
+			input: `hist_sum`,
+			want:  `histogram_sum(hist)`,
+		},
+		{
+			input: `2 * hist_sum{a=~"b"}`,
+			want:  `2 * histogram_sum(hist{a=~"b"})`,
+		},
+		{
+			input: `hist_sum{a="a"} * hist_sum{a="b"}`,
+			want:  `histogram_sum(hist{a="a"}) * histogram_sum(hist{a="b"})`,
+		},
+	}
+	f := TransformClassicHistograms([]string{
+		"hist",
+		"hist2",
+	})
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			expr, err := parser.ParseExpr(tc.input)
+			require.NoError(t, err)
+			got, err := Rewrite(expr, f)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Equal(t, tc.want, got.String())
+		})
+	}
+}

--- a/promql/rewrite/transform.go
+++ b/promql/rewrite/transform.go
@@ -1,0 +1,145 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rewrite
+
+import (
+	"fmt"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+type Transform interface {
+	Transform(parser.Expr) (parser.Expr, error)
+}
+
+type TransformFunc func(parser.Expr) (parser.Expr, error)
+
+func (t TransformFunc) Transform(node parser.Expr) (parser.Expr, error) {
+	return t(node)
+}
+
+// Rewrite a node by applying transform recursively.
+func Rewrite(node parser.Expr, transform Transform) (parser.Expr, error) {
+	var err error
+	node, err = transform.Transform(node)
+	if err != nil {
+		return nil, err
+	}
+	switch n := node.(type) {
+	case *parser.Call:
+		for i := range n.Args {
+			n.Args[i], err = Rewrite(n.Args[i], transform)
+			if err != nil {
+				return nil, err
+			}
+		}
+	case *parser.StepInvariantExpr:
+		n.Expr, err = Rewrite(n.Expr, transform)
+	case *parser.SubqueryExpr:
+		n.Expr, err = Rewrite(n.Expr, transform)
+	case *parser.MatrixSelector:
+		n.VectorSelector, err = Rewrite(n.VectorSelector, transform)
+	case *parser.UnaryExpr:
+		n.Expr, err = Rewrite(n.Expr, transform)
+	case *parser.AggregateExpr:
+		n.Expr, err = Rewrite(n.Expr, transform)
+	case *parser.BinaryExpr:
+		n.LHS, err = Rewrite(n.LHS, transform)
+		if err != nil {
+			return nil, err
+		}
+		n.RHS, err = Rewrite(n.RHS, transform)
+		if err != nil {
+			return nil, err
+		}
+	case *parser.ParenExpr:
+		n.Expr, err = Rewrite(n.Expr, transform)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
+type List []Transform
+
+func (l List) Transform(node parser.Expr) (parser.Expr, error) {
+	for _, t := range l {
+		newNode, err := t.Transform(node)
+		if err != nil {
+			return nil, err
+		}
+		// If this is a newNode, we apply it and return.
+		if node != newNode {
+			return newNode, nil
+		}
+	}
+	return node, nil
+}
+
+func cloneExpr(n parser.Expr) parser.Expr {
+	switch n := n.(type) {
+	case *parser.VectorSelector:
+		matchers := make([]*labels.Matcher, len(n.LabelMatchers))
+		copy(matchers, n.LabelMatchers)
+		return &parser.VectorSelector{
+			Name:                    n.Name,
+			OriginalOffset:          n.OriginalOffset,
+			OriginalOffsetExpr:      n.OriginalOffsetExpr,
+			Offset:                  n.Offset,
+			Timestamp:               n.Timestamp,
+			SkipHistogramBuckets:    n.SkipHistogramBuckets,
+			StartOrEnd:              n.StartOrEnd,
+			LabelMatchers:           matchers,
+			UnexpandedSeriesSet:     n.UnexpandedSeriesSet,
+			Series:                  n.Series,
+			BypassEmptyMatcherCheck: n.BypassEmptyMatcherCheck,
+			Anchored:                n.Anchored,
+			Smoothed:                n.Smoothed,
+		}
+	default:
+		panic(fmt.Sprintf("cannot clone %T", n))
+	}
+}
+
+func renameVectorSelector(vs *parser.VectorSelector, newName string) {
+	vs.Name = newName
+	for i := len(vs.LabelMatchers) - 1; i >= 0; i-- {
+		if vs.LabelMatchers[i].Name == model.MetricNameLabel {
+			vs.LabelMatchers = append(vs.LabelMatchers[:i], vs.LabelMatchers[i+1:]...)
+			return
+		}
+	}
+}
+
+func removeLabelMatchers(vs *parser.VectorSelector, name string) {
+	for i := len(vs.LabelMatchers) - 1; i >= 0; i-- {
+		if vs.LabelMatchers[i].Name == name {
+			vs.LabelMatchers = append(vs.LabelMatchers[:i], vs.LabelMatchers[i+1:]...)
+		}
+	}
+}
+
+func removeItem[T comparable](arr []T, el T) []T {
+	out := make([]T, 0, len(arr))
+	for _, e := range arr {
+		if e != el {
+			out = append(out, e)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Adds a `rewrite` package that modifies promql AST based on transformations. 

Related to #17419