### PR TITLE
docs: fix heading for `limitk` docs

### DIFF
--- a/docs/querying/operators.md
+++ b/docs/querying/operators.md
@@ -425,7 +425,7 @@ To get the 5 instances with the highest memory consumption across all instances 
 
     topk(5, memory_consumption_bytes)
 
-#### `limitk` and `limit_ratio`
+#### `limitk`
 
 `limitk(k, v)` returns a subset of `k` input samples, including
 the original labels in the result vector. 


### PR DESCRIPTION
This PR fixes a typo introduced in https://github.com/prometheus/prometheus/pull/16837, where the heading for the `limitk` section also mentions `limit_ratio`, but `limit_ratio` has a section of its own.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

(none)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
