### PR TITLE
PromQL: Allow for promql tests to consider expected fail message during query preparation

### DIFF
--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -1430,6 +1430,11 @@ func (t *test) execEval(cmd *evalCmd, engine promql.QueryEngine) error {
 func (t *test) execRangeEval(cmd *evalCmd, engine promql.QueryEngine) error {
 	q, err := engine.NewRangeQuery(t.context, t.storage, nil, cmd.expr, cmd.start, cmd.end, cmd.step)
 	if err != nil {
+		if cmd.isFail() {
+			if err := cmd.checkExpectedFailure(err); err == nil {
+				return nil
+			}
+		}
 		return fmt.Errorf("error creating range query for %q (line %d): %w", cmd.expr, cmd.line, err)
 	}
 	defer q.Close()
@@ -1473,6 +1478,11 @@ func (t *test) execInstantEval(cmd *evalCmd, engine promql.QueryEngine) error {
 func (t *test) runInstantQuery(iq atModifierTestCase, cmd *evalCmd, engine promql.QueryEngine) error {
 	q, err := engine.NewInstantQuery(t.context, t.storage, nil, iq.expr, iq.evalTime)
 	if err != nil {
+		if cmd.isFail() {
+			if err := cmd.checkExpectedFailure(err); err == nil {
+				return nil
+			}
+		}
 		return fmt.Errorf("error creating instant query for %q (line %d): %w", cmd.expr, cmd.line, err)
 	}
 	defer q.Close()


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

This PR allows for promql tests to have their an expected failure message considered after query preparation, not just at evaluation time. 

This is an issue which arisen because MQE uses this test harness and it is returning errors in the MQE planning phase which the existing test code does not handle.

In the existing code, any error which occurs during the `engine.NewRangeQuery()` or `engine.NewInstantQuery()` is wrapped within a `error creating instant|range query for ...` error and returned. There is no consideration as to whether this error was an expected failure case.

For instance, this test case will pass correctly in prometheus but if MQE uses the test harness `promqltest.RunTest(t, testScript, engine)` the test will fail.

```
eval instant at 1m predict_linear(foo[3m] anchored, 4)
  expect fail msg: anchored modifier can only be used with: changes, delta, increase, rate, resets - not with predict_linear
``` 

#### Does this PR introduce a user-facing change?

No

```release-notes
NONE
```
