### PR TITLE
PromQL: Modify HashRatioSampler to expose hash function and allow ratio test with existing hash

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -4132,9 +4132,12 @@ func makeInt64Pointer(val int64) *int64 {
 
 // RatioSampler allows unit-testing (previously: Randomizer).
 type RatioSampler interface {
-	// Return this sample "offset" between [0.0, 1.0]
-	sampleOffset(ts int64, sample *Sample) float64
-	AddRatioSample(r float64, sample *Sample) bool
+	// SampleOffset returns this sample "offset" between [0.0, 1.0].
+	SampleOffset(metric *labels.Labels) float64
+	// AddRatioSample reports whether the sampling offset for the given sample falls within the specified ratio limit.
+	AddRatioSample(ratioLimit float64, sample *Sample) bool
+	// AddRatioSampleWithOffset reports whether the given sampling offset falls within the specified ratio limit.
+	AddRatioSampleWithOffset(ratioLimit, sampleOffset float64) bool
 }
 
 // HashRatioSampler uses Hash(labels.String()) / maxUint64 as a "deterministic"
@@ -4148,22 +4151,14 @@ func NewHashRatioSampler() *HashRatioSampler {
 	return &HashRatioSampler{}
 }
 
-func (s *HashRatioSampler) sampleOffset(_ int64, sample *Sample) float64 {
-	return s.SampleOffsetByLabels(sample.Metric)
-}
-
-// SampleOffsetByLabels returns a deterministic sampling offset in the range [0, 1)
+// SampleOffset returns a deterministic sampling offset in the range [0, 1)
 // derived from the hash of the provided metric labels.
 //
 // The offset is computed by normalizing the 64-bit hash value of the label set
 // to a float64 fraction of math.MaxUint64. This ensures that metrics with the
 // same label set always produce the same offset, while different label sets
 // produce uniformly distributed offsets suitable for sampling decisions.
-//
-// Note that this function allows for the actual labels.Labels to be passed in,
-// by passing the need to pass in a Sample. This allows downstream projects, such as
-// Mimir to leverage this offset directly.
-func (*HashRatioSampler) SampleOffsetByLabels(metric labels.Labels) float64 {
+func (*HashRatioSampler) SampleOffset(metric *labels.Labels) float64 {
 	const (
 		float64MaxUint64 = float64(math.MaxUint64)
 	)
@@ -4173,10 +4168,10 @@ func (*HashRatioSampler) SampleOffsetByLabels(metric labels.Labels) float64 {
 // AddRatioSample returns a bool indicating if the sampling offset for the given sample is
 // within the given ratio limit.
 //
-// See SampleOffsetByLabels() for further details on the sample offset.
+// See SampleOffset() for further details on the sample offset.
 // See AddRatioSampleWithOffset() for further details on the ratioLimit and sampling offset comparison.
 func (s *HashRatioSampler) AddRatioSample(ratioLimit float64, sample *Sample) bool {
-	sampleOffset := s.sampleOffset(sample.T, sample)
+	sampleOffset := s.SampleOffset(&sample.Metric)
 	return s.AddRatioSampleWithOffset(ratioLimit, sampleOffset)
 }
 
@@ -4184,13 +4179,13 @@ func (s *HashRatioSampler) AddRatioSample(ratioLimit float64, sample *Sample) bo
 // the specified ratio limit.
 //
 // The ratioLimit must be in the range [-1, 1]. The sampleOffset should be derived
-// using SampleOffsetByLabels().
+// using SampleOffset().
 //
 // When ratioLimit >= 0, the function returns true if sampleOffset < ratioLimit.
 // When ratioLimit < 0, the function returns true if sampleOffset >= 1 + ratioLimit.
 //
-// Accepting the sampleOffset as a parameter allows downstream projects, such as
-// Mimir, to reuse this sampling logic directly in functional tests.
+// Note that this method could be moved into AddRatioSample and removed from the Prometheus codebase,
+// but it is useful for downstream projects using this code as a library.
 func (*HashRatioSampler) AddRatioSampleWithOffset(ratioLimit, sampleOffset float64) bool {
 	// If ratioLimit >= 0: add sample if sampleOffset is lesser than ratioLimit
 	//


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

This PR modifies the `HashRatioSampler` utility which is used for the limit_ratio aggregation.

The `HashRatioSampler` provides a function to take a Sample, calculate a "sample offset" based off a hash of the metric and compares this to a given ratio limit. 

In the existing implementation, the function to calculate the sample offset is not exported, so a Sample must be passed in to perform a ratio limit test.

MQE has recently implemented the `limit_ratio` aggregate and would like to leverage this `HashRatioSampler` utility to assist in maintaining parity with prometheus. Due to implementation differences in series data iteration, the MQE implementation would like to calculate the sample offset once for each series and then pass this pre-calculated offset into the ratio comparison test.

This PR would allow for this by; 

* exposing the sample offset function - so that this can be directly called for a given Sample (series)
* expose a function which takes the ratio limit and sample offset to perform the ratio comparison

Note - there is no prometheus issue here or in the way prometheus uses the `HashRatioSampler`, this change is purely to assist MQE in leveraging the same implementation. This would be a no-op change for prometheus.

#### Does this PR introduce a user-facing change?

No

```release-notes
NONE
```
