### PR TITLE
feat: rename CreatedTimestamp to StartTimestamp

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -263,8 +263,8 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 			case "ooo-native-histograms":
 				logger.Warn("This option for --enable-feature is now permanently enabled and therefore a no-op.", "option", o)
 			case "created-timestamp-zero-ingestion":
-				c.scrape.EnableCreatedTimestampZeroIngestion = true
-				c.web.CTZeroIngestionEnabled = true
+				c.scrape.EnableStartTimestampZeroIngestion = true
+				c.web.STZeroIngestionEnabled = true
 				// Change relevant global variables. Hacky, but it's hard to pass a new option or default to unmarshallers.
 				config.DefaultConfig.GlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols
 				config.DefaultGlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols
@@ -1729,7 +1729,7 @@ func (notReadyAppender) AppendHistogram(storage.SeriesRef, labels.Labels, int64,
 	return 0, tsdb.ErrNotReady
 }
 
-func (notReadyAppender) AppendHistogramCTZeroSample(storage.SeriesRef, labels.Labels, int64, int64, *histogram.Histogram, *histogram.FloatHistogram) (storage.SeriesRef, error) {
+func (notReadyAppender) AppendHistogramSTZeroSample(storage.SeriesRef, labels.Labels, int64, int64, *histogram.Histogram, *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
 
@@ -1737,7 +1737,7 @@ func (notReadyAppender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadat
 	return 0, tsdb.ErrNotReady
 }
 
-func (notReadyAppender) AppendCTZeroSample(storage.SeriesRef, labels.Labels, int64, int64) (storage.SeriesRef, error) {
+func (notReadyAppender) AppendSTZeroSample(storage.SeriesRef, labels.Labels, int64, int64) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
 

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -67,20 +67,27 @@ Enables PromQL functions that are considered experimental. These functions
 might change their name, syntax, or semantics. They might also get removed
 entirely.
 
-## Created Timestamps Zero Injection
+## Start (Created) Timestamps Zero Injection
 
 `--enable-feature=created-timestamp-zero-ingestion`
 
-Enables ingestion of created timestamp. Created timestamps are injected as 0 valued samples when appropriate. See [PromCon talk](https://youtu.be/nWf0BfQ5EEA) for details.
+> NOTE: CreatedTimestamp feature was renamed to StartTimestamp for consistency. The above flag uses old name for stability.
 
-Currently Prometheus supports created timestamps only on the traditional
-Prometheus Protobuf protocol (WIP for other protocols). Therefore, enabling
-this feature pre-sets the global `scrape_protocols` configuration option to 
-`[ PrometheusProto, OpenMetricsText1.0.0, OpenMetricsText0.0.1, PrometheusText0.0.4 ]`,
-resulting in negotiating the Prometheus Protobuf protocol with first priority
-(unless the `scrape_protocols` option is set to a different value explicitly).
+Enables ingestion of start timestamp. Start timestamps are injected as 0 valued samples when appropriate. See [PromCon talk](https://youtu.be/nWf0BfQ5EEA) for details.
 
-Besides enabling this feature in Prometheus, created timestamps need to be exposed by the application being scraped.
+Currently, Prometheus supports start timestamps on the
+
+* `PrometheusProto`
+* `OpenMetrics1.0.0`
+  
+
+From the above, Prometheus recommends `PrometheusProto`. This is because OpenMetrics 1.0 Start Timestamp information is shared as a `<metric>_created` metric and parsing those
+are prone to errors and expensive (thus, adding an overhead). You also need to be careful to not pollute your Prometheus with extra `_created` metrics.
+  
+Therefore, when `created-timestamp-zero-ingestion` is enabled Prometheus changes the global `scrape_protocols` default configuration option to 
+`[ PrometheusProto, OpenMetricsText1.0.0, OpenMetricsText0.0.1, PrometheusText0.0.4 ]`, resulting in negotiating the Prometheus Protobuf protocol first (unless the `scrape_protocols` option is set to a different value explicitly).
+
+Besides enabling this feature in Prometheus, start timestamps need to be exposed by the application being scraped.
 
 ## Concurrent evaluation of independent rules
 

--- a/model/textparse/benchmark_test.go
+++ b/model/textparse/benchmark_test.go
@@ -36,7 +36,7 @@ import (
 // and allows comparison with expfmt decoders if applicable.
 //
 // NOTE(bwplotka): Previous iterations of this benchmark had different cases for isolated
-// Series, Series+Metrics with and without reuse, Series+CT. Those cases are sometimes
+// Series, Series+Metrics with and without reuse, Series+ST. Those cases are sometimes
 // good to know if you are working on a certain optimization, but it does not
 // make sense to persist such cases for everybody (e.g. for CI one day).
 // For local iteration, feel free to adjust cases/comment out code etc.
@@ -153,7 +153,7 @@ func benchParse(b *testing.B, data []byte, parser string) {
 		}
 	case "omtext":
 		newParserFn = func(b []byte, st *labels.SymbolTable) Parser {
-			return NewOpenMetricsParser(b, st, WithOMParserCTSeriesSkipped())
+			return NewOpenMetricsParser(b, st, WithOMParserSTSeriesSkipped())
 		}
 	case "omtext_with_nhcb":
 		newParserFn = func(buf []byte, st *labels.SymbolTable) Parser {
@@ -206,7 +206,7 @@ func benchParse(b *testing.B, data []byte, parser string) {
 			}
 
 			p.Labels(&res)
-			_ = p.CreatedTimestamp()
+			_ = p.StartTimestamp()
 			for hasExemplar := p.Exemplar(&e); hasExemplar; hasExemplar = p.Exemplar(&e) {
 			}
 		}
@@ -266,11 +266,11 @@ func readTestdataFile(tb testing.TB, file string) []byte {
 
 /*
 	export bench=v1 && go test ./model/textparse/... \
-		 -run '^$' -bench '^BenchmarkCreatedTimestampPromProto' \
+		 -run '^$' -bench '^BenchmarkStartTimestampPromProto' \
 		 -benchtime 2s -count 6 -cpu 2 -benchmem -timeout 999m \
 	 | tee ${bench}.txt
 */
-func BenchmarkCreatedTimestampPromProto(b *testing.B) {
+func BenchmarkStartTimestampPromProto(b *testing.B) {
 	data := createTestProtoBuf(b).Bytes()
 
 	st := labels.NewSymbolTable()
@@ -301,7 +301,7 @@ Inner:
 		b.ReportAllocs()
 		b.ResetTimer()
 		for b.Loop() {
-			if p.CreatedTimestamp() != 0 {
+			if p.StartTimestamp() != 0 {
 				b.Fatal("should be nil")
 			}
 		}
@@ -331,7 +331,7 @@ Inner2:
 		b.ReportAllocs()
 		b.ResetTimer()
 		for b.Loop() {
-			if p.CreatedTimestamp() == 0 {
+			if p.StartTimestamp() == 0 {
 				b.Fatal("should be not nil")
 			}
 		}

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -195,7 +195,7 @@ type parsedEntry struct {
 	lset labels.Labels
 	t    *int64
 	es   []exemplar.Exemplar
-	ct   int64
+	st   int64
 
 	// In EntryType.
 	typ model.MetricType
@@ -255,7 +255,7 @@ func testParse(t *testing.T, p Parser) (ret []parsedEntry) {
 			}
 			got.m = string(m)
 			p.Labels(&got.lset)
-			got.ct = p.CreatedTimestamp()
+			got.st = p.StartTimestamp()
 
 			for e := (exemplar.Exemplar{}); p.Exemplar(&e); {
 				got.es = append(got.es, e)

--- a/model/textparse/nhcbparse_test.go
+++ b/model/textparse/nhcbparse_test.go
@@ -67,13 +67,13 @@ ss{A="a"} 0
 _metric_starting_with_underscore 1
 testmetric{_label_starting_with_underscore="foo"} 1
 testmetric{label="\"bar\""} 1
-# HELP foo Counter with and without labels to certify CT is parsed for both cases
+# HELP foo Counter with and without labels to certify ST is parsed for both cases
 # TYPE foo counter
 foo_total 17.0 1520879607.789 # {id="counter-test"} 5
 foo_created 1520872607.123
 foo_total{a="b"} 17.0 1520879607.789 # {id="counter-test"} 5
 foo_created{a="b"} 1520872607.123
-# HELP bar Summary with CT at the end, making sure we find CT even if it's multiple lines a far
+# HELP bar Summary with ST at the end, making sure we find ST even if it's multiple lines a far
 # TYPE bar summary
 bar_count 17.0
 bar_sum 324789.3
@@ -87,7 +87,7 @@ baz_bucket{le="+Inf"} 17
 baz_count 17
 baz_sum 324789.3
 baz_created 1520872609.125
-# HELP fizz_created Gauge which shouldn't be parsed as CT
+# HELP fizz_created Gauge which shouldn't be parsed as ST
 # TYPE fizz_created gauge
 fizz_created 17.0
 # HELP something Histogram with _created between buckets and summary
@@ -279,7 +279,7 @@ foobar{quantile="0.99"} 150.1`
 			lset: labels.FromStrings("__name__", "testmetric", "label", `"bar"`),
 		}, {
 			m:    "foo",
-			help: "Counter with and without labels to certify CT is parsed for both cases",
+			help: "Counter with and without labels to certify ST is parsed for both cases",
 		}, {
 			m:   "foo",
 			typ: model.MetricTypeCounter,
@@ -289,17 +289,17 @@ foobar{quantile="0.99"} 150.1`
 			lset: labels.FromStrings("__name__", "foo_total"),
 			t:    int64p(1520879607789),
 			es:   []exemplar.Exemplar{{Labels: labels.FromStrings("id", "counter-test"), Value: 5}},
-			ct:   1520872607123,
+			st:   1520872607123,
 		}, {
 			m:    `foo_total{a="b"}`,
 			v:    17.0,
 			lset: labels.FromStrings("__name__", "foo_total", "a", "b"),
 			t:    int64p(1520879607789),
 			es:   []exemplar.Exemplar{{Labels: labels.FromStrings("id", "counter-test"), Value: 5}},
-			ct:   1520872607123,
+			st:   1520872607123,
 		}, {
 			m:    "bar",
-			help: "Summary with CT at the end, making sure we find CT even if it's multiple lines a far",
+			help: "Summary with ST at the end, making sure we find ST even if it's multiple lines a far",
 		}, {
 			m:   "bar",
 			typ: model.MetricTypeSummary,
@@ -307,22 +307,22 @@ foobar{quantile="0.99"} 150.1`
 			m:    "bar_count",
 			v:    17.0,
 			lset: labels.FromStrings("__name__", "bar_count"),
-			ct:   1520872608124,
+			st:   1520872608124,
 		}, {
 			m:    "bar_sum",
 			v:    324789.3,
 			lset: labels.FromStrings("__name__", "bar_sum"),
-			ct:   1520872608124,
+			st:   1520872608124,
 		}, {
 			m:    `bar{quantile="0.95"}`,
 			v:    123.7,
 			lset: labels.FromStrings("__name__", "bar", "quantile", "0.95"),
-			ct:   1520872608124,
+			st:   1520872608124,
 		}, {
 			m:    `bar{quantile="0.99"}`,
 			v:    150.0,
 			lset: labels.FromStrings("__name__", "bar", "quantile", "0.99"),
-			ct:   1520872608124,
+			st:   1520872608124,
 		}, {
 			m:    "baz",
 			help: "Histogram with the same objective as above's summary",
@@ -340,10 +340,10 @@ foobar{quantile="0.99"} 150.1`
 				CustomValues:    []float64{0.0}, // We do not store the +Inf boundary.
 			},
 			lset: labels.FromStrings("__name__", "baz"),
-			ct:   1520872609125,
+			st:   1520872609125,
 		}, {
 			m:    "fizz_created",
-			help: "Gauge which shouldn't be parsed as CT",
+			help: "Gauge which shouldn't be parsed as ST",
 		}, {
 			m:   "fizz_created",
 			typ: model.MetricTypeGauge,
@@ -368,7 +368,7 @@ foobar{quantile="0.99"} 150.1`
 				CustomValues:    []float64{0.0}, // We do not store the +Inf boundary.
 			},
 			lset: labels.FromStrings("__name__", "something"),
-			ct:   1520430001000,
+			st:   1520430001000,
 		}, {
 			m: `something{a="b"}`,
 			shs: &histogram.Histogram{
@@ -380,7 +380,7 @@ foobar{quantile="0.99"} 150.1`
 				CustomValues:    []float64{0.0}, // We do not store the +Inf boundary.
 			},
 			lset: labels.FromStrings("__name__", "something", "a", "b"),
-			ct:   1520430002000,
+			st:   1520430002000,
 		}, {
 			m:    "yum",
 			help: "Summary with _created between sum and quantiles",
@@ -391,22 +391,22 @@ foobar{quantile="0.99"} 150.1`
 			m:    `yum_count`,
 			v:    20,
 			lset: labels.FromStrings("__name__", "yum_count"),
-			ct:   1520430003000,
+			st:   1520430003000,
 		}, {
 			m:    `yum_sum`,
 			v:    324789.5,
 			lset: labels.FromStrings("__name__", "yum_sum"),
-			ct:   1520430003000,
+			st:   1520430003000,
 		}, {
 			m:    `yum{quantile="0.95"}`,
 			v:    123.7,
 			lset: labels.FromStrings("__name__", "yum", "quantile", "0.95"),
-			ct:   1520430003000,
+			st:   1520430003000,
 		}, {
 			m:    `yum{quantile="0.99"}`,
 			v:    150.0,
 			lset: labels.FromStrings("__name__", "yum", "quantile", "0.99"),
-			ct:   1520430003000,
+			st:   1520430003000,
 		}, {
 			m:    "foobar",
 			help: "Summary with _created as the first line",
@@ -417,22 +417,22 @@ foobar{quantile="0.99"} 150.1`
 			m:    `foobar_count`,
 			v:    21,
 			lset: labels.FromStrings("__name__", "foobar_count"),
-			ct:   1520430004000,
+			st:   1520430004000,
 		}, {
 			m:    `foobar_sum`,
 			v:    324789.6,
 			lset: labels.FromStrings("__name__", "foobar_sum"),
-			ct:   1520430004000,
+			st:   1520430004000,
 		}, {
 			m:    `foobar{quantile="0.95"}`,
 			v:    123.8,
 			lset: labels.FromStrings("__name__", "foobar", "quantile", "0.95"),
-			ct:   1520430004000,
+			st:   1520430004000,
 		}, {
 			m:    `foobar{quantile="0.99"}`,
 			v:    150.1,
 			lset: labels.FromStrings("__name__", "foobar", "quantile", "0.99"),
-			ct:   1520430004000,
+			st:   1520430004000,
 		}, {
 			m:    "metric",
 			help: "foo\x00bar",
@@ -587,8 +587,8 @@ func TestNHCBParser_NoNHCBWhenExponential(t *testing.T) {
 	}
 
 	type parserOptions struct {
-		useUTF8sep          bool
-		hasCreatedTimeStamp bool
+		useUTF8sep        bool
+		hasStartTimestamp bool
 	}
 	// Defines the parser name, the Parser factory and the test cases
 	// supported by the parser and parser options.
@@ -598,14 +598,14 @@ func TestNHCBParser_NoNHCBWhenExponential(t *testing.T) {
 				inputBuf := createTestProtoBufHistogram(t)
 				return New(inputBuf.Bytes(), "application/vnd.google.protobuf", labels.NewSymbolTable(), ParserOptions{KeepClassicOnClassicAndNativeHistograms: keepClassic, ConvertClassicHistogramsToNHCB: nhcb})
 			}
-			return "ProtoBuf", factory, []int{1, 2, 3}, parserOptions{useUTF8sep: true, hasCreatedTimeStamp: true}
+			return "ProtoBuf", factory, []int{1, 2, 3}, parserOptions{useUTF8sep: true, hasStartTimestamp: true}
 		},
 		func() (string, parserFactory, []int, parserOptions) {
 			factory := func(keepClassic, nhcb bool) (Parser, error) {
 				input := createTestOpenMetricsHistogram()
 				return New([]byte(input), "application/openmetrics-text", labels.NewSymbolTable(), ParserOptions{KeepClassicOnClassicAndNativeHistograms: keepClassic, ConvertClassicHistogramsToNHCB: nhcb})
 			}
-			return "OpenMetrics", factory, []int{1}, parserOptions{hasCreatedTimeStamp: true}
+			return "OpenMetrics", factory, []int{1}, parserOptions{hasStartTimestamp: true}
 		},
 		func() (string, parserFactory, []int, parserOptions) {
 			factory := func(keepClassic, nhcb bool) (Parser, error) {
@@ -643,9 +643,9 @@ func TestNHCBParser_NoNHCBWhenExponential(t *testing.T) {
 						typ: model.MetricTypeHistogram,
 					})
 
-					var ct int64
-					if options.hasCreatedTimeStamp {
-						ct = 1000
+					var st int64
+					if options.hasStartTimestamp {
+						st = 1000
 					}
 
 					var bucketForMetric func(string) string
@@ -677,7 +677,7 @@ func TestNHCBParser_NoNHCBWhenExponential(t *testing.T) {
 								},
 								lset: labels.FromStrings("__name__", metric),
 								t:    int64p(1234568),
-								ct:   ct,
+								st:   st,
 							},
 						}
 						tc.exp = append(tc.exp, exponentialSeries...)
@@ -690,42 +690,42 @@ func TestNHCBParser_NoNHCBWhenExponential(t *testing.T) {
 								v:    175,
 								lset: labels.FromStrings("__name__", metric+"_count"),
 								t:    int64p(1234568),
-								ct:   ct,
+								st:   st,
 							},
 							{
 								m:    metric + "_sum",
 								v:    0.0008280461746287094,
 								lset: labels.FromStrings("__name__", metric+"_sum"),
 								t:    int64p(1234568),
-								ct:   ct,
+								st:   st,
 							},
 							{
 								m:    metric + bucketForMetric("-0.0004899999999999998"),
 								v:    2,
 								lset: labels.FromStrings("__name__", metric+"_bucket", "le", "-0.0004899999999999998"),
 								t:    int64p(1234568),
-								ct:   ct,
+								st:   st,
 							},
 							{
 								m:    metric + bucketForMetric("-0.0003899999999999998"),
 								v:    4,
 								lset: labels.FromStrings("__name__", metric+"_bucket", "le", "-0.0003899999999999998"),
 								t:    int64p(1234568),
-								ct:   ct,
+								st:   st,
 							},
 							{
 								m:    metric + bucketForMetric("-0.0002899999999999998"),
 								v:    16,
 								lset: labels.FromStrings("__name__", metric+"_bucket", "le", "-0.0002899999999999998"),
 								t:    int64p(1234568),
-								ct:   ct,
+								st:   st,
 							},
 							{
 								m:    metric + bucketForMetric("+Inf"),
 								v:    175,
 								lset: labels.FromStrings("__name__", metric+"_bucket", "le", "+Inf"),
 								t:    int64p(1234568),
-								ct:   ct,
+								st:   st,
 							},
 						}
 						tc.exp = append(tc.exp, classicSeries...)
@@ -745,7 +745,7 @@ func TestNHCBParser_NoNHCBWhenExponential(t *testing.T) {
 								},
 								lset: labels.FromStrings("__name__", metric),
 								t:    int64p(1234568),
-								ct:   ct,
+								st:   st,
 							},
 						}
 						tc.exp = append(tc.exp, nhcbSeries...)
@@ -952,7 +952,7 @@ something_bucket{a="b",le="+Inf"} 9
 				CustomValues:    []float64{0.0}, // We do not store the +Inf boundary.
 			},
 			lset: labels.FromStrings("__name__", "something", "a", "b"),
-			ct:   1520430002000,
+			st:   1520430002000,
 		},
 	}
 
@@ -1061,7 +1061,7 @@ metric: <
 			},
 			lset: labels.FromStrings("__name__", "test_histogram1"),
 			t:    int64p(1234568),
-			ct:   1000,
+			st:   1000,
 		},
 		{
 			m:    "test_histogram2",
@@ -1083,7 +1083,7 @@ metric: <
 			},
 			lset: labels.FromStrings("__name__", "test_histogram2"),
 			t:    int64p(1234568),
-			ct:   1000,
+			st:   1000,
 		},
 	}
 

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -66,7 +66,7 @@ ss{A="a"} 0
 _metric_starting_with_underscore 1
 testmetric{_label_starting_with_underscore="foo"} 1
 testmetric{label="\"bar\""} 1
-# HELP foo Counter with and without labels to certify CT is parsed for both cases
+# HELP foo Counter with and without labels to certify ST is parsed for both cases
 # TYPE foo counter
 foo_total 17.0 1520879607.789 # {id="counter-test"} 5
 foo_created 1520872607.123
@@ -75,7 +75,7 @@ foo_created{a="b"} 1520872607.123
 foo_total{le="c"} 21.0
 foo_created{le="c"} 1520872621.123
 foo_total{le="1"} 10.0
-# HELP bar Summary with CT at the end, making sure we find CT even if it's multiple lines a far
+# HELP bar Summary with ST at the end, making sure we find ST even if it's multiple lines a far
 # TYPE bar summary
 bar_count 17.0
 bar_sum 324789.3
@@ -89,7 +89,7 @@ baz_bucket{le="+Inf"} 17
 baz_count 17
 baz_sum 324789.3
 baz_created 1520872609.125
-# HELP fizz_created Gauge which shouldn't be parsed as CT
+# HELP fizz_created Gauge which shouldn't be parsed as ST
 # TYPE fizz_created gauge
 fizz_created 17.0
 # HELP something Histogram with _created between buckets and summary
@@ -351,7 +351,7 @@ foobar{quantile="0.99"} 150.1`
 					lset: labels.FromStrings("__name__", "testmetric", "label", `"bar"`),
 				}, {
 					m:    "foo",
-					help: "Counter with and without labels to certify CT is parsed for both cases",
+					help: "Counter with and without labels to certify ST is parsed for both cases",
 				}, {
 					m:   "foo",
 					typ: model.MetricTypeCounter,
@@ -367,7 +367,7 @@ foobar{quantile="0.99"} 150.1`
 					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("id", "counter-test"), Value: 5},
 					},
-					ct: 1520872607123,
+					st: 1520872607123,
 				}, {
 					m: `foo_total{a="b"}`,
 					v: 17.0,
@@ -380,7 +380,7 @@ foobar{quantile="0.99"} 150.1`
 					es: []exemplar.Exemplar{
 						{Labels: labels.FromStrings("id", "counter-test"), Value: 5},
 					},
-					ct: 1520872607123,
+					st: 1520872607123,
 				}, {
 					m: `foo_total{le="c"}`,
 					v: 21.0,
@@ -389,7 +389,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "foo_total", "__type__", string(model.MetricTypeCounter), "le", "c"),
 						labels.FromStrings("__name__", "foo_total", "le", "c"),
 					),
-					ct: 1520872621123,
+					st: 1520872621123,
 				}, {
 					m: `foo_total{le="1"}`,
 					v: 10.0,
@@ -400,7 +400,7 @@ foobar{quantile="0.99"} 150.1`
 					),
 				}, {
 					m:    "bar",
-					help: "Summary with CT at the end, making sure we find CT even if it's multiple lines a far",
+					help: "Summary with ST at the end, making sure we find ST even if it's multiple lines a far",
 				}, {
 					m:   "bar",
 					typ: model.MetricTypeSummary,
@@ -412,7 +412,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "bar_count", "__type__", string(model.MetricTypeSummary)),
 						labels.FromStrings("__name__", "bar_count"),
 					),
-					ct: 1520872608124,
+					st: 1520872608124,
 				}, {
 					m: "bar_sum",
 					v: 324789.3,
@@ -421,7 +421,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "bar_sum", "__type__", string(model.MetricTypeSummary)),
 						labels.FromStrings("__name__", "bar_sum"),
 					),
-					ct: 1520872608124,
+					st: 1520872608124,
 				}, {
 					m: `bar{quantile="0.95"}`,
 					v: 123.7,
@@ -430,7 +430,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "bar", "__type__", string(model.MetricTypeSummary), "quantile", "0.95"),
 						labels.FromStrings("__name__", "bar", "quantile", "0.95"),
 					),
-					ct: 1520872608124,
+					st: 1520872608124,
 				}, {
 					m: `bar{quantile="0.99"}`,
 					v: 150.0,
@@ -439,7 +439,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "bar", "__type__", string(model.MetricTypeSummary), "quantile", "0.99"),
 						labels.FromStrings("__name__", "bar", "quantile", "0.99"),
 					),
-					ct: 1520872608124,
+					st: 1520872608124,
 				}, {
 					m:    "baz",
 					help: "Histogram with the same objective as above's summary",
@@ -454,7 +454,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "baz_bucket", "__type__", string(model.MetricTypeHistogram), "le", "0.0"),
 						labels.FromStrings("__name__", "baz_bucket", "le", "0.0"),
 					),
-					ct: 1520872609125,
+					st: 1520872609125,
 				}, {
 					m: `baz_bucket{le="+Inf"}`,
 					v: 17,
@@ -463,7 +463,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "baz_bucket", "__type__", string(model.MetricTypeHistogram), "le", "+Inf"),
 						labels.FromStrings("__name__", "baz_bucket", "le", "+Inf"),
 					),
-					ct: 1520872609125,
+					st: 1520872609125,
 				}, {
 					m: `baz_count`,
 					v: 17,
@@ -472,7 +472,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "baz_count", "__type__", string(model.MetricTypeHistogram)),
 						labels.FromStrings("__name__", "baz_count"),
 					),
-					ct: 1520872609125,
+					st: 1520872609125,
 				}, {
 					m: `baz_sum`,
 					v: 324789.3,
@@ -481,10 +481,10 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "baz_sum", "__type__", string(model.MetricTypeHistogram)),
 						labels.FromStrings("__name__", "baz_sum"),
 					),
-					ct: 1520872609125,
+					st: 1520872609125,
 				}, {
 					m:    "fizz_created",
-					help: "Gauge which shouldn't be parsed as CT",
+					help: "Gauge which shouldn't be parsed as ST",
 				}, {
 					m:   "fizz_created",
 					typ: model.MetricTypeGauge,
@@ -510,7 +510,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "something_count", "__type__", string(model.MetricTypeHistogram)),
 						labels.FromStrings("__name__", "something_count"),
 					),
-					ct: 1520430001000,
+					st: 1520430001000,
 				}, {
 					m: `something_sum`,
 					v: 324789.4,
@@ -519,7 +519,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "something_sum", "__type__", string(model.MetricTypeHistogram)),
 						labels.FromStrings("__name__", "something_sum"),
 					),
-					ct: 1520430001000,
+					st: 1520430001000,
 				}, {
 					m: `something_bucket{le="0.0"}`,
 					v: 1,
@@ -528,7 +528,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "something_bucket", "__type__", string(model.MetricTypeHistogram), "le", "0.0"),
 						labels.FromStrings("__name__", "something_bucket", "le", "0.0"),
 					),
-					ct: 1520430001000,
+					st: 1520430001000,
 				}, {
 					m: `something_bucket{le="1"}`,
 					v: 2,
@@ -537,7 +537,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "something_bucket", "__type__", string(model.MetricTypeHistogram), "le", "1.0"),
 						labels.FromStrings("__name__", "something_bucket", "le", "1.0"),
 					),
-					ct: 1520430001000,
+					st: 1520430001000,
 				}, {
 					m: `something_bucket{le="+Inf"}`,
 					v: 18,
@@ -546,7 +546,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "something_bucket", "__type__", string(model.MetricTypeHistogram), "le", "+Inf"),
 						labels.FromStrings("__name__", "something_bucket", "le", "+Inf"),
 					),
-					ct: 1520430001000,
+					st: 1520430001000,
 				}, {
 					m:    "yum",
 					help: "Summary with _created between sum and quantiles",
@@ -561,7 +561,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "yum_count", "__type__", string(model.MetricTypeSummary)),
 						labels.FromStrings("__name__", "yum_count"),
 					),
-					ct: 1520430003000,
+					st: 1520430003000,
 				}, {
 					m: `yum_sum`,
 					v: 324789.5,
@@ -570,7 +570,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "yum_sum", "__type__", string(model.MetricTypeSummary)),
 						labels.FromStrings("__name__", "yum_sum"),
 					),
-					ct: 1520430003000,
+					st: 1520430003000,
 				}, {
 					m: `yum{quantile="0.95"}`,
 					v: 123.7,
@@ -579,7 +579,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "yum", "__type__", string(model.MetricTypeSummary), "quantile", "0.95"),
 						labels.FromStrings("__name__", "yum", "quantile", "0.95"),
 					),
-					ct: 1520430003000,
+					st: 1520430003000,
 				}, {
 					m: `yum{quantile="0.99"}`,
 					v: 150.0,
@@ -588,7 +588,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "yum", "__type__", string(model.MetricTypeSummary), "quantile", "0.99"),
 						labels.FromStrings("__name__", "yum", "quantile", "0.99"),
 					),
-					ct: 1520430003000,
+					st: 1520430003000,
 				}, {
 					m:    "foobar",
 					help: "Summary with _created as the first line",
@@ -603,7 +603,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "foobar_count", "__type__", string(model.MetricTypeSummary)),
 						labels.FromStrings("__name__", "foobar_count"),
 					),
-					ct: 1520430004000,
+					st: 1520430004000,
 				}, {
 					m: `foobar_sum`,
 					v: 324789.6,
@@ -612,7 +612,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "foobar_sum", "__type__", string(model.MetricTypeSummary)),
 						labels.FromStrings("__name__", "foobar_sum"),
 					),
-					ct: 1520430004000,
+					st: 1520430004000,
 				}, {
 					m: `foobar{quantile="0.95"}`,
 					v: 123.8,
@@ -621,7 +621,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "foobar", "__type__", string(model.MetricTypeSummary), "quantile", "0.95"),
 						labels.FromStrings("__name__", "foobar", "quantile", "0.95"),
 					),
-					ct: 1520430004000,
+					st: 1520430004000,
 				}, {
 					m: `foobar{quantile="0.99"}`,
 					v: 150.1,
@@ -630,7 +630,7 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "foobar", "__type__", string(model.MetricTypeSummary), "quantile", "0.99"),
 						labels.FromStrings("__name__", "foobar", "quantile", "0.99"),
 					),
-					ct: 1520430004000,
+					st: 1520430004000,
 				}, {
 					m:    "metric",
 					help: "foo\x00bar",
@@ -640,7 +640,7 @@ foobar{quantile="0.99"} 150.1`
 					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "null_byte_metric", "a", "abc\x00"), model.MetricTypeSummary),
 				},
 			}
-			opts := []OpenMetricsOption{WithOMParserCTSeriesSkipped()}
+			opts := []OpenMetricsOption{WithOMParserSTSeriesSkipped()}
 			if typeAndUnitEnabled {
 				opts = append(opts, WithOMParserTypeAndUnitLabels())
 			}
@@ -684,12 +684,12 @@ quotedexemplar2_count 1 # {"id.thing"="histogram-count-test",other="hello"} 4
 			m:    `{"go.gc_duration_seconds",quantile="0"}`,
 			v:    4.9351e-05,
 			lset: labels.FromStrings("__name__", "go.gc_duration_seconds", "quantile", "0.0"),
-			ct:   1520872607123,
+			st:   1520872607123,
 		}, {
 			m:    `{"go.gc_duration_seconds",quantile="0.25"}`,
 			v:    7.424100000000001e-05,
 			lset: labels.FromStrings("__name__", "go.gc_duration_seconds", "quantile", "0.25"),
-			ct:   1520872607123,
+			st:   1520872607123,
 		}, {
 			m:    `{"go.gc_duration_seconds",quantile="0.5",a="b"}`,
 			v:    8.3835e-05,
@@ -732,7 +732,7 @@ choices}`, "strange©™\n'quoted' \"name\"", "6"),
 		},
 	}
 
-	p := NewOpenMetricsParser([]byte(input), labels.NewSymbolTable(), WithOMParserCTSeriesSkipped())
+	p := NewOpenMetricsParser([]byte(input), labels.NewSymbolTable(), WithOMParserSTSeriesSkipped())
 	got := testParse(t, p)
 	requireEntries(t, exp, got)
 }
@@ -1028,7 +1028,7 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		p := NewOpenMetricsParser([]byte(c.input), labels.NewSymbolTable(), WithOMParserCTSeriesSkipped())
+		p := NewOpenMetricsParser([]byte(c.input), labels.NewSymbolTable(), WithOMParserSTSeriesSkipped())
 		var err error
 		for err == nil {
 			_, err = p.Next()
@@ -1093,7 +1093,7 @@ func TestOMNullByteHandling(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		p := NewOpenMetricsParser([]byte(c.input), labels.NewSymbolTable(), WithOMParserCTSeriesSkipped())
+		p := NewOpenMetricsParser([]byte(c.input), labels.NewSymbolTable(), WithOMParserSTSeriesSkipped())
 		var err error
 		for err == nil {
 			_, err = p.Next()
@@ -1108,10 +1108,10 @@ func TestOMNullByteHandling(t *testing.T) {
 	}
 }
 
-// TestCTParseFailures tests known failure edge cases, we know does not work due
+// TestSTParseFailures tests known failure edge cases, we know does not work due
 // current OM spec limitations or clients with broken OM format.
-// TODO(maniktherana): Make sure OM 1.1/2.0 pass CT via metadata or exemplar-like to avoid this.
-func TestCTParseFailures(t *testing.T) {
+// TODO(maniktherana): Make sure OM 1.1/2.0 pass ST via metadata or exemplar-like to avoid this.
+func TestSTParseFailures(t *testing.T) {
 	for _, tcase := range []struct {
 		name     string
 		input    string
@@ -1143,19 +1143,19 @@ thing_c_total 14123.232
 				},
 				{
 					m:  `thing_count`,
-					ct: 0, // Should be int64p(1520872607123).
+					st: 0, // Should be int64p(1520872607123).
 				},
 				{
 					m:  `thing_sum`,
-					ct: 0, // Should be int64p(1520872607123).
+					st: 0, // Should be int64p(1520872607123).
 				},
 				{
 					m:  `thing_bucket{le="0.0"}`,
-					ct: 0, // Should be int64p(1520872607123).
+					st: 0, // Should be int64p(1520872607123).
 				},
 				{
 					m:  `thing_bucket{le="+Inf"}`,
-					ct: 0, // Should be int64p(1520872607123),
+					st: 0, // Should be int64p(1520872607123),
 				},
 				{
 					m:    "thing_c",
@@ -1167,7 +1167,7 @@ thing_c_total 14123.232
 				},
 				{
 					m:  `thing_c_total`,
-					ct: 0, // Should be int64p(1520872607123).
+					st: 0, // Should be int64p(1520872607123).
 				},
 			},
 		},
@@ -1197,9 +1197,9 @@ foo_created{a="b"} 1520872608.123
 		},
 	} {
 		t.Run(fmt.Sprintf("case=%v", tcase.name), func(t *testing.T) {
-			p := NewOpenMetricsParser([]byte(tcase.input), labels.NewSymbolTable(), WithOMParserCTSeriesSkipped())
+			p := NewOpenMetricsParser([]byte(tcase.input), labels.NewSymbolTable(), WithOMParserSTSeriesSkipped())
 			got := testParse(t, p)
-			resetValAndLset(got) // Keep this test focused on metric, basic entries and CT only.
+			resetValAndLset(got) // Keep this test focused on metric, basic entries and ST only.
 			requireEntries(t, tcase.expected, got)
 		})
 	}

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -274,9 +274,9 @@ func (*PromParser) Exemplar(*exemplar.Exemplar) bool {
 	return false
 }
 
-// CreatedTimestamp returns 0 as it's not implemented yet.
+// StartTimestamp returns 0 as it's not implemented yet.
 // TODO(bwplotka): https://github.com/prometheus/prometheus/issues/12980
-func (*PromParser) CreatedTimestamp() int64 {
+func (*PromParser) StartTimestamp() int64 {
 	return 0
 }
 

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -400,24 +400,24 @@ func (p *ProtobufParser) Exemplar(ex *exemplar.Exemplar) bool {
 	return true
 }
 
-// CreatedTimestamp returns CT or 0 if CT is not present on counters, summaries or histograms.
-func (p *ProtobufParser) CreatedTimestamp() int64 {
-	var ct *types.Timestamp
+// StartTimestamp returns ST or 0 if ST is not present on counters, summaries or histograms.
+func (p *ProtobufParser) StartTimestamp() int64 {
+	var st *types.Timestamp
 	switch p.dec.GetType() {
 	case dto.MetricType_COUNTER:
-		ct = p.dec.GetCounter().GetCreatedTimestamp()
+		st = p.dec.GetCounter().GetCreatedTimestamp()
 	case dto.MetricType_SUMMARY:
-		ct = p.dec.GetSummary().GetCreatedTimestamp()
+		st = p.dec.GetSummary().GetCreatedTimestamp()
 	case dto.MetricType_HISTOGRAM, dto.MetricType_GAUGE_HISTOGRAM:
-		ct = p.dec.GetHistogram().GetCreatedTimestamp()
+		st = p.dec.GetHistogram().GetCreatedTimestamp()
 	default:
 	}
-	if ct == nil {
+	if st == nil {
 		return 0
 	}
 	// Same as the gogo proto types.TimestampFromProto but straight to integer.
 	// and without validation.
-	return ct.GetSeconds()*1e3 + int64(ct.GetNanos())/1e6
+	return st.GetSeconds()*1e3 + int64(st.GetNanos())/1e6
 }
 
 // Next advances the parser to the next "sample" (emulating the behavior of a

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -1334,7 +1334,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_counter_with_createdtimestamp",
 					v:  42,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_counter_with_createdtimestamp",
 					),
@@ -1350,7 +1350,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_summary_with_createdtimestamp_count",
 					v:  42,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_count",
 					),
@@ -1358,7 +1358,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_summary_with_createdtimestamp_sum",
 					v:  1.234,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_sum",
 					),
@@ -1373,7 +1373,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m:  "test_histogram_with_createdtimestamp",
-					ct: 1625851153146,
+					st: 1625851153146,
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.UnknownCounterReset,
 						PositiveSpans:    []histogram.Span{},
@@ -1393,7 +1393,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m:  "test_gaugehistogram_with_createdtimestamp",
-					ct: 1625851153146,
+					st: 1625851153146,
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.GaugeType,
 						PositiveSpans:    []histogram.Span{},
@@ -1999,7 +1999,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_counter_with_createdtimestamp\xff__type__\xffcounter",
 					v:  42,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_counter_with_createdtimestamp",
 						"__type__", string(model.MetricTypeCounter),
@@ -2016,7 +2016,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_summary_with_createdtimestamp_count\xff__type__\xffsummary",
 					v:  42,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_count",
 						"__type__", string(model.MetricTypeSummary),
@@ -2025,7 +2025,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_summary_with_createdtimestamp_sum\xff__type__\xffsummary",
 					v:  1.234,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_sum",
 						"__type__", string(model.MetricTypeSummary),
@@ -2041,7 +2041,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m:  "test_histogram_with_createdtimestamp\xff__type__\xffhistogram",
-					ct: 1625851153146,
+					st: 1625851153146,
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.UnknownCounterReset,
 						PositiveSpans:    []histogram.Span{},
@@ -2062,7 +2062,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m:  "test_gaugehistogram_with_createdtimestamp\xff__type__\xffgaugehistogram",
-					ct: 1625851153146,
+					st: 1625851153146,
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.GaugeType,
 						PositiveSpans:    []histogram.Span{},
@@ -2959,7 +2959,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_counter_with_createdtimestamp",
 					v:  42,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_counter_with_createdtimestamp",
 					),
@@ -2975,7 +2975,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_summary_with_createdtimestamp_count",
 					v:  42,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_count",
 					),
@@ -2983,7 +2983,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_summary_with_createdtimestamp_sum",
 					v:  1.234,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_sum",
 					),
@@ -2998,7 +2998,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m:  "test_histogram_with_createdtimestamp",
-					ct: 1625851153146,
+					st: 1625851153146,
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.UnknownCounterReset,
 						PositiveSpans:    []histogram.Span{},
@@ -3018,7 +3018,7 @@ func TestProtobufParse(t *testing.T) {
 				},
 				{
 					m:  "test_gaugehistogram_with_createdtimestamp",
-					ct: 1625851153146,
+					st: 1625851153146,
 					shs: &histogram.Histogram{
 						CounterResetHint: histogram.GaugeType,
 						PositiveSpans:    []histogram.Span{},
@@ -3893,7 +3893,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_counter_with_createdtimestamp",
 					v:  42,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_counter_with_createdtimestamp",
 					),
@@ -3909,7 +3909,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_summary_with_createdtimestamp_count",
 					v:  42,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_count",
 					),
@@ -3917,7 +3917,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_summary_with_createdtimestamp_sum",
 					v:  1.234,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_summary_with_createdtimestamp_sum",
 					),
@@ -3933,7 +3933,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_histogram_with_createdtimestamp_count",
 					v:  0,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_createdtimestamp_count",
 					),
@@ -3941,7 +3941,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_histogram_with_createdtimestamp_sum",
 					v:  0,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_createdtimestamp_sum",
 					),
@@ -3949,7 +3949,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_histogram_with_createdtimestamp_bucket\xffle\xff+Inf",
 					v:  0,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_histogram_with_createdtimestamp_bucket",
 						"le", "+Inf",
@@ -3966,7 +3966,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_gaugehistogram_with_createdtimestamp_count",
 					v:  0,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_gaugehistogram_with_createdtimestamp_count",
 					),
@@ -3974,7 +3974,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_gaugehistogram_with_createdtimestamp_sum",
 					v:  0,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_gaugehistogram_with_createdtimestamp_sum",
 					),
@@ -3982,7 +3982,7 @@ func TestProtobufParse(t *testing.T) {
 				{
 					m:  "test_gaugehistogram_with_createdtimestamp_bucket\xffle\xff+Inf",
 					v:  0,
-					ct: 1625851153146,
+					st: 1625851153146,
 					lset: labels.FromStrings(
 						"__name__", "test_gaugehistogram_with_createdtimestamp_bucket",
 						"le", "+Inf",

--- a/scrape/helpers_test.go
+++ b/scrape/helpers_test.go
@@ -57,7 +57,7 @@ func (nopAppender) AppendHistogram(storage.SeriesRef, labels.Labels, int64, *his
 	return 3, nil
 }
 
-func (nopAppender) AppendHistogramCTZeroSample(storage.SeriesRef, labels.Labels, int64, int64, *histogram.Histogram, *histogram.FloatHistogram) (storage.SeriesRef, error) {
+func (nopAppender) AppendHistogramSTZeroSample(storage.SeriesRef, labels.Labels, int64, int64, *histogram.Histogram, *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	return 0, nil
 }
 
@@ -65,7 +65,7 @@ func (nopAppender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Met
 	return 4, nil
 }
 
-func (nopAppender) AppendCTZeroSample(storage.SeriesRef, labels.Labels, int64, int64) (storage.SeriesRef, error) {
+func (nopAppender) AppendSTZeroSample(storage.SeriesRef, labels.Labels, int64, int64) (storage.SeriesRef, error) {
 	return 5, nil
 }
 
@@ -184,11 +184,11 @@ func (a *collectResultAppender) AppendHistogram(ref storage.SeriesRef, l labels.
 	return a.next.AppendHistogram(ref, l, t, h, fh)
 }
 
-func (a *collectResultAppender) AppendHistogramCTZeroSample(ref storage.SeriesRef, l labels.Labels, _, ct int64, h *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
+func (a *collectResultAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, l labels.Labels, _, st int64, h *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	if h != nil {
-		return a.AppendHistogram(ref, l, ct, &histogram.Histogram{}, nil)
+		return a.AppendHistogram(ref, l, st, &histogram.Histogram{}, nil)
 	}
-	return a.AppendHistogram(ref, l, ct, nil, &histogram.FloatHistogram{})
+	return a.AppendHistogram(ref, l, st, nil, &histogram.FloatHistogram{})
 }
 
 func (a *collectResultAppender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
@@ -205,8 +205,8 @@ func (a *collectResultAppender) UpdateMetadata(ref storage.SeriesRef, l labels.L
 	return a.next.UpdateMetadata(ref, l, m)
 }
 
-func (a *collectResultAppender) AppendCTZeroSample(ref storage.SeriesRef, l labels.Labels, _, ct int64) (storage.SeriesRef, error) {
-	return a.Append(ref, l, ct, 0.0)
+func (a *collectResultAppender) AppendSTZeroSample(ref storage.SeriesRef, l labels.Labels, _, st int64) (storage.SeriesRef, error) {
+	return a.Append(ref, l, st, 0.0)
 }
 
 func (a *collectResultAppender) Commit() error {

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -85,7 +85,7 @@ type Options struct {
 	DiscoveryReloadInterval model.Duration
 	// Option to enable the ingestion of the created timestamp as a synthetic zero sample.
 	// See: https://github.com/prometheus/proposals/blob/main/proposals/2023-06-13_created-timestamp.md
-	EnableCreatedTimestampZeroIngestion bool
+	EnableStartTimestampZeroIngestion bool
 
 	// EnableTypeAndUnitLabels
 	EnableTypeAndUnitLabels bool

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -3281,8 +3281,8 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 			}
 
 			contentTypes := strings.SplitSeq(accept, ",")
-			for ct := range contentTypes {
-				match := qValuePattern.FindStringSubmatch(ct)
+			for st := range contentTypes {
+				match := qValuePattern.FindStringSubmatch(st)
 				require.Len(t, match, 3)
 				qValue, err := strconv.ParseFloat(match[1], 64)
 				require.NoError(t, err, "Error parsing q value")

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -199,14 +199,14 @@ func (f *fanoutAppender) AppendHistogram(ref SeriesRef, l labels.Labels, t int64
 	return ref, nil
 }
 
-func (f *fanoutAppender) AppendHistogramCTZeroSample(ref SeriesRef, l labels.Labels, t, ct int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (SeriesRef, error) {
-	ref, err := f.primary.AppendHistogramCTZeroSample(ref, l, t, ct, h, fh)
+func (f *fanoutAppender) AppendHistogramSTZeroSample(ref SeriesRef, l labels.Labels, t, st int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (SeriesRef, error) {
+	ref, err := f.primary.AppendHistogramSTZeroSample(ref, l, t, st, h, fh)
 	if err != nil {
 		return ref, err
 	}
 
 	for _, appender := range f.secondaries {
-		if _, err := appender.AppendHistogramCTZeroSample(ref, l, t, ct, h, fh); err != nil {
+		if _, err := appender.AppendHistogramSTZeroSample(ref, l, t, st, h, fh); err != nil {
 			return 0, err
 		}
 	}
@@ -227,14 +227,14 @@ func (f *fanoutAppender) UpdateMetadata(ref SeriesRef, l labels.Labels, m metada
 	return ref, nil
 }
 
-func (f *fanoutAppender) AppendCTZeroSample(ref SeriesRef, l labels.Labels, t, ct int64) (SeriesRef, error) {
-	ref, err := f.primary.AppendCTZeroSample(ref, l, t, ct)
+func (f *fanoutAppender) AppendSTZeroSample(ref SeriesRef, l labels.Labels, t, st int64) (SeriesRef, error) {
+	ref, err := f.primary.AppendSTZeroSample(ref, l, t, st)
 	if err != nil {
 		return ref, err
 	}
 
 	for _, appender := range f.secondaries {
-		if _, err := appender.AppendCTZeroSample(ref, l, t, ct); err != nil {
+		if _, err := appender.AppendSTZeroSample(ref, l, t, st); err != nil {
 			return 0, err
 		}
 	}

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -122,7 +122,7 @@ var (
 					writev2.FromIntHistogram(30, &testHistogramCustomBuckets),
 					writev2.FromFloatHistogram(40, testHistogramCustomBuckets.ToFloat(nil)),
 				},
-				CreatedTimestamp: 1, // CT needs to be lower than the sample's timestamp.
+				CreatedTimestamp: 1, // ST needs to be lower than the sample's timestamp.
 			},
 			{
 				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, // Same series as first.

--- a/storage/remote/otlptranslator/prometheusremotewrite/combined_appender.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/combined_appender.go
@@ -49,10 +49,10 @@ type Metadata struct {
 type CombinedAppender interface {
 	// AppendSample appends a sample and related exemplars, metadata, and
 	// created timestamp to the storage.
-	AppendSample(ls labels.Labels, meta Metadata, ct, t int64, v float64, es []exemplar.Exemplar) error
+	AppendSample(ls labels.Labels, meta Metadata, st, t int64, v float64, es []exemplar.Exemplar) error
 	// AppendHistogram appends a histogram and related exemplars, metadata, and
 	// created timestamp to the storage.
-	AppendHistogram(ls labels.Labels, meta Metadata, ct, t int64, h *histogram.Histogram, es []exemplar.Exemplar) error
+	AppendHistogram(ls labels.Labels, meta Metadata, st, t int64, h *histogram.Histogram, es []exemplar.Exemplar) error
 }
 
 // CombinedAppenderMetrics is for the metrics observed by the
@@ -82,11 +82,11 @@ func NewCombinedAppenderMetrics(reg prometheus.Registerer) CombinedAppenderMetri
 // NewCombinedAppender creates a combined appender that sets start times and
 // updates metadata for each series only once, and appends samples and
 // exemplars for each call.
-func NewCombinedAppender(app storage.Appender, logger *slog.Logger, ingestCTZeroSample, appendMetadata bool, metrics CombinedAppenderMetrics) CombinedAppender {
+func NewCombinedAppender(app storage.Appender, logger *slog.Logger, ingestSTZeroSample, appendMetadata bool, metrics CombinedAppenderMetrics) CombinedAppender {
 	return &combinedAppender{
 		app:                            app,
 		logger:                         logger,
-		ingestCTZeroSample:             ingestCTZeroSample,
+		ingestSTZeroSample:             ingestSTZeroSample,
 		appendMetadata:                 appendMetadata,
 		refs:                           make(map[uint64]seriesRef),
 		samplesAppendedWithoutMetadata: metrics.samplesAppendedWithoutMetadata,
@@ -96,7 +96,7 @@ func NewCombinedAppender(app storage.Appender, logger *slog.Logger, ingestCTZero
 
 type seriesRef struct {
 	ref  storage.SeriesRef
-	ct   int64
+	st   int64
 	ls   labels.Labels
 	meta metadata.Metadata
 }
@@ -106,7 +106,7 @@ type combinedAppender struct {
 	logger                         *slog.Logger
 	samplesAppendedWithoutMetadata prometheus.Counter
 	outOfOrderExemplars            prometheus.Counter
-	ingestCTZeroSample             bool
+	ingestSTZeroSample             bool
 	appendMetadata                 bool
 	// Used to ensure we only update metadata and created timestamps once, and to share storage.SeriesRefs.
 	// To detect hash collision it also stores the labels.
@@ -114,20 +114,20 @@ type combinedAppender struct {
 	refs map[uint64]seriesRef
 }
 
-func (b *combinedAppender) AppendSample(ls labels.Labels, meta Metadata, ct, t int64, v float64, es []exemplar.Exemplar) (err error) {
-	return b.appendFloatOrHistogram(ls, meta.Metadata, ct, t, v, nil, es)
+func (b *combinedAppender) AppendSample(ls labels.Labels, meta Metadata, st, t int64, v float64, es []exemplar.Exemplar) (err error) {
+	return b.appendFloatOrHistogram(ls, meta.Metadata, st, t, v, nil, es)
 }
 
-func (b *combinedAppender) AppendHistogram(ls labels.Labels, meta Metadata, ct, t int64, h *histogram.Histogram, es []exemplar.Exemplar) (err error) {
+func (b *combinedAppender) AppendHistogram(ls labels.Labels, meta Metadata, st, t int64, h *histogram.Histogram, es []exemplar.Exemplar) (err error) {
 	if h == nil {
 		// Sanity check, we should never get here with a nil histogram.
 		b.logger.Error("Received nil histogram in CombinedAppender.AppendHistogram", "series", ls.String())
 		return errors.New("internal error, attempted to append nil histogram")
 	}
-	return b.appendFloatOrHistogram(ls, meta.Metadata, ct, t, 0, h, es)
+	return b.appendFloatOrHistogram(ls, meta.Metadata, st, t, 0, h, es)
 }
 
-func (b *combinedAppender) appendFloatOrHistogram(ls labels.Labels, meta metadata.Metadata, ct, t int64, v float64, h *histogram.Histogram, es []exemplar.Exemplar) (err error) {
+func (b *combinedAppender) appendFloatOrHistogram(ls labels.Labels, meta metadata.Metadata, st, t int64, v float64, h *histogram.Histogram, es []exemplar.Exemplar) (err error) {
 	hash := ls.Hash()
 	series, exists := b.refs[hash]
 	ref := series.ref
@@ -140,28 +140,28 @@ func (b *combinedAppender) appendFloatOrHistogram(ls labels.Labels, meta metadat
 		exists = false
 		ref = 0
 	}
-	updateRefs := !exists || series.ct != ct
-	if updateRefs && ct != 0 && ct < t && b.ingestCTZeroSample {
+	updateRefs := !exists || series.st != st
+	if updateRefs && st != 0 && st < t && b.ingestSTZeroSample {
 		var newRef storage.SeriesRef
 		if h != nil {
-			newRef, err = b.app.AppendHistogramCTZeroSample(ref, ls, t, ct, h, nil)
+			newRef, err = b.app.AppendHistogramSTZeroSample(ref, ls, t, st, h, nil)
 		} else {
-			newRef, err = b.app.AppendCTZeroSample(ref, ls, t, ct)
+			newRef, err = b.app.AppendSTZeroSample(ref, ls, t, st)
 		}
 		if err != nil {
-			if !errors.Is(err, storage.ErrOutOfOrderCT) && !errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+			if !errors.Is(err, storage.ErrOutOfOrderST) && !errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
 				// Even for the first sample OOO is a common scenario because
-				// we can't tell if a CT was already ingested in a previous request.
+				// we can't tell if a ST was already ingested in a previous request.
 				// We ignore the error.
 				// ErrDuplicateSampleForTimestamp is also a common scenario because
 				// unknown start times in Opentelemetry are indicated by setting
 				// the start time to the same as the first sample time.
 				// https://opentelemetry.io/docs/specs/otel/metrics/data-model/#cumulative-streams-handling-unknown-start-time
-				b.logger.Warn("Error when appending CT from OTLP", "err", err, "series", ls.String(), "created_timestamp", ct, "timestamp", t, "sample_type", sampleType(h))
+				b.logger.Warn("Error when appending ST from OTLP", "err", err, "series", ls.String(), "start_timestamp", st, "timestamp", t, "sample_type", sampleType(h))
 			}
 		} else {
 			// We only use the returned reference on success as otherwise an
-			// error of CT append could invalidate the series reference.
+			// error of ST append could invalidate the series reference.
 			ref = newRef
 		}
 	}
@@ -197,7 +197,7 @@ func (b *combinedAppender) appendFloatOrHistogram(ls labels.Labels, meta metadat
 	if updateRefs || metadataChanged {
 		b.refs[hash] = seriesRef{
 			ref:  ref,
-			ct:   ct,
+			st:   st,
 			ls:   ls,
 			meta: meta,
 		}

--- a/storage/remote/otlptranslator/prometheusremotewrite/combined_appender_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/combined_appender_test.go
@@ -52,7 +52,7 @@ type combinedSample struct {
 	ls               labels.Labels
 	meta             metadata.Metadata
 	t                int64
-	ct               int64
+	st               int64
 	v                float64
 	es               []exemplar.Exemplar
 }
@@ -62,31 +62,31 @@ type combinedHistogram struct {
 	ls               labels.Labels
 	meta             metadata.Metadata
 	t                int64
-	ct               int64
+	st               int64
 	h                *histogram.Histogram
 	es               []exemplar.Exemplar
 }
 
-func (m *mockCombinedAppender) AppendSample(ls labels.Labels, meta Metadata, ct, t int64, v float64, es []exemplar.Exemplar) error {
+func (m *mockCombinedAppender) AppendSample(ls labels.Labels, meta Metadata, st, t int64, v float64, es []exemplar.Exemplar) error {
 	m.pendingSamples = append(m.pendingSamples, combinedSample{
 		metricFamilyName: meta.MetricFamilyName,
 		ls:               ls,
 		meta:             meta.Metadata,
 		t:                t,
-		ct:               ct,
+		st:               st,
 		v:                v,
 		es:               es,
 	})
 	return nil
 }
 
-func (m *mockCombinedAppender) AppendHistogram(ls labels.Labels, meta Metadata, ct, t int64, h *histogram.Histogram, es []exemplar.Exemplar) error {
+func (m *mockCombinedAppender) AppendHistogram(ls labels.Labels, meta Metadata, st, t int64, h *histogram.Histogram, es []exemplar.Exemplar) error {
 	m.pendingHistograms = append(m.pendingHistograms, combinedHistogram{
 		metricFamilyName: meta.MetricFamilyName,
 		ls:               ls,
 		meta:             meta.Metadata,
 		t:                t,
-		ct:               ct,
+		st:               st,
 		h:                h,
 		es:               es,
 	})
@@ -108,12 +108,12 @@ func requireEqual(t testing.TB, expected, actual any, msgAndArgs ...any) {
 // TestCombinedAppenderOnTSDB runs some basic tests on a real TSDB to check
 // that the combinedAppender works on a real TSDB.
 func TestCombinedAppenderOnTSDB(t *testing.T) {
-	t.Run("ingestCTZeroSample=false", func(t *testing.T) { testCombinedAppenderOnTSDB(t, false) })
+	t.Run("ingestSTZeroSample=false", func(t *testing.T) { testCombinedAppenderOnTSDB(t, false) })
 
-	t.Run("ingestCTZeroSample=true", func(t *testing.T) { testCombinedAppenderOnTSDB(t, true) })
+	t.Run("ingestSTZeroSample=true", func(t *testing.T) { testCombinedAppenderOnTSDB(t, true) })
 }
 
-func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
+func testCombinedAppenderOnTSDB(t *testing.T, ingestSTZeroSample bool) {
 	t.Helper()
 
 	now := time.Now()
@@ -165,9 +165,9 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 		extraAppendFunc   func(*testing.T, CombinedAppender)
 		expectedSamples   []sample
 		expectedExemplars []exemplar.QueryResult
-		expectedLogsForCT []string
+		expectedLogsForST []string
 	}{
-		"single float sample, zero CT": {
+		"single float sample, zero ST": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendSample(seriesLabels.Copy(), floatMetadata, 0, now.UnixMilli(), 42.0, testExemplars))
 			},
@@ -179,7 +179,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 			},
 			expectedExemplars: expectedExemplars,
 		},
-		"single float sample, very old CT": {
+		"single float sample, very old ST": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendSample(seriesLabels.Copy(), floatMetadata, 1, now.UnixMilli(), 42.0, nil))
 			},
@@ -189,18 +189,18 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 					f: 42.0,
 				},
 			},
-			expectedLogsForCT: []string{
-				"Error when appending CT from OTLP",
+			expectedLogsForST: []string{
+				"Error when appending ST from OTLP",
 				"out of bound",
 			},
 		},
-		"single float sample, normal CT": {
+		"single float sample, normal ST": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendSample(seriesLabels.Copy(), floatMetadata, now.Add(-2*time.Minute).UnixMilli(), now.UnixMilli(), 42.0, nil))
 			},
 			expectedSamples: []sample{
 				{
-					ctZero: true,
+					stZero: true,
 					t:      now.Add(-2 * time.Minute).UnixMilli(),
 				},
 				{
@@ -209,7 +209,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 				},
 			},
 		},
-		"single float sample, CT same time as sample": {
+		"single float sample, ST same time as sample": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendSample(seriesLabels.Copy(), floatMetadata, now.UnixMilli(), now.UnixMilli(), 42.0, nil))
 			},
@@ -220,7 +220,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 				},
 			},
 		},
-		"two float samples in different messages, CT same time as first sample": {
+		"two float samples in different messages, ST same time as first sample": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendSample(seriesLabels.Copy(), floatMetadata, now.UnixMilli(), now.UnixMilli(), 42.0, nil))
 			},
@@ -238,7 +238,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 				},
 			},
 		},
-		"single float sample, CT in the future of the sample": {
+		"single float sample, ST in the future of the sample": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendSample(seriesLabels.Copy(), floatMetadata, now.Add(time.Minute).UnixMilli(), now.UnixMilli(), 42.0, nil))
 			},
@@ -249,7 +249,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 				},
 			},
 		},
-		"single histogram sample, zero CT": {
+		"single histogram sample, zero ST": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendHistogram(seriesLabels.Copy(), histogramMetadata, 0, now.UnixMilli(), tsdbutil.GenerateTestHistogram(42), testExemplars))
 			},
@@ -261,7 +261,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 			},
 			expectedExemplars: expectedExemplars,
 		},
-		"single histogram sample, very old CT": {
+		"single histogram sample, very old ST": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendHistogram(seriesLabels.Copy(), histogramMetadata, 1, now.UnixMilli(), tsdbutil.GenerateTestHistogram(42), nil))
 			},
@@ -271,18 +271,18 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 					h: tsdbutil.GenerateTestHistogram(42),
 				},
 			},
-			expectedLogsForCT: []string{
-				"Error when appending CT from OTLP",
+			expectedLogsForST: []string{
+				"Error when appending ST from OTLP",
 				"out of bound",
 			},
 		},
-		"single histogram sample, normal CT": {
+		"single histogram sample, normal ST": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendHistogram(seriesLabels.Copy(), histogramMetadata, now.Add(-2*time.Minute).UnixMilli(), now.UnixMilli(), tsdbutil.GenerateTestHistogram(42), nil))
 			},
 			expectedSamples: []sample{
 				{
-					ctZero: true,
+					stZero: true,
 					t:      now.Add(-2 * time.Minute).UnixMilli(),
 					h:      &histogram.Histogram{},
 				},
@@ -292,7 +292,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 				},
 			},
 		},
-		"single histogram sample, CT same time as sample": {
+		"single histogram sample, ST same time as sample": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendHistogram(seriesLabels.Copy(), histogramMetadata, now.UnixMilli(), now.UnixMilli(), tsdbutil.GenerateTestHistogram(42), nil))
 			},
@@ -303,7 +303,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 				},
 			},
 		},
-		"two histogram samples in different messages, CT same time as first sample": {
+		"two histogram samples in different messages, ST same time as first sample": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendHistogram(seriesLabels.Copy(), floatMetadata, now.UnixMilli(), now.UnixMilli(), tsdbutil.GenerateTestHistogram(42), nil))
 			},
@@ -321,7 +321,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 				},
 			},
 		},
-		"single histogram sample, CT in the future of the sample": {
+		"single histogram sample, ST in the future of the sample": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendHistogram(seriesLabels.Copy(), histogramMetadata, now.Add(time.Minute).UnixMilli(), now.UnixMilli(), tsdbutil.GenerateTestHistogram(42), nil))
 			},
@@ -364,14 +364,14 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 				},
 			},
 		},
-		"float samples with CT changing": {
+		"float samples with ST changing": {
 			appendFunc: func(t *testing.T, app CombinedAppender) {
 				require.NoError(t, app.AppendSample(seriesLabels.Copy(), floatMetadata, now.Add(-4*time.Second).UnixMilli(), now.Add(-3*time.Second).UnixMilli(), 42.0, nil))
 				require.NoError(t, app.AppendSample(seriesLabels.Copy(), floatMetadata, now.Add(-1*time.Second).UnixMilli(), now.UnixMilli(), 62.0, nil))
 			},
 			expectedSamples: []sample{
 				{
-					ctZero: true,
+					stZero: true,
 					t:      now.Add(-4 * time.Second).UnixMilli(),
 				},
 				{
@@ -379,7 +379,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 					f: 42.0,
 				},
 				{
-					ctZero: true,
+					stZero: true,
 					t:      now.Add(-1 * time.Second).UnixMilli(),
 				},
 				{
@@ -393,8 +393,8 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var expectedLogs []string
-			if ingestCTZeroSample {
-				expectedLogs = append(expectedLogs, tc.expectedLogsForCT...)
+			if ingestSTZeroSample {
+				expectedLogs = append(expectedLogs, tc.expectedLogsForST...)
 			}
 
 			dir := t.TempDir()
@@ -413,13 +413,13 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 			reg := prometheus.NewRegistry()
 			cappMetrics := NewCombinedAppenderMetrics(reg)
 			app := db.Appender(ctx)
-			capp := NewCombinedAppender(app, logger, ingestCTZeroSample, false, cappMetrics)
+			capp := NewCombinedAppender(app, logger, ingestSTZeroSample, false, cappMetrics)
 			tc.appendFunc(t, capp)
 			require.NoError(t, app.Commit())
 
 			if tc.extraAppendFunc != nil {
 				app = db.Appender(ctx)
-				capp = NewCombinedAppender(app, logger, ingestCTZeroSample, false, cappMetrics)
+				capp = NewCombinedAppender(app, logger, ingestSTZeroSample, false, cappMetrics)
 				tc.extraAppendFunc(t, capp)
 				require.NoError(t, app.Commit())
 			}
@@ -446,7 +446,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 			series := ss.At()
 			it := series.Iterator(nil)
 			for i, sample := range tc.expectedSamples {
-				if !ingestCTZeroSample && sample.ctZero {
+				if !ingestSTZeroSample && sample.stZero {
 					continue
 				}
 				if sample.h == nil {
@@ -476,7 +476,7 @@ func testCombinedAppenderOnTSDB(t *testing.T, ingestCTZeroSample bool) {
 }
 
 type sample struct {
-	ctZero bool
+	stZero bool
 
 	t int64
 	f float64
@@ -500,7 +500,7 @@ func TestCombinedAppenderSeriesRefs(t *testing.T) {
 		MetricFamilyName: "test_bytes_total",
 	}
 
-	t.Run("happy case with CT zero, reference is passed and reused", func(t *testing.T) {
+	t.Run("happy case with ST zero, reference is passed and reused", func(t *testing.T) {
 		app := &appenderRecorder{}
 		capp := NewCombinedAppender(app, promslog.NewNopLogger(), true, false, NewCombinedAppenderMetrics(prometheus.NewRegistry()))
 
@@ -514,31 +514,31 @@ func TestCombinedAppenderSeriesRefs(t *testing.T) {
 		}))
 
 		require.Len(t, app.records, 5)
-		requireEqualOpAndRef(t, "AppendCTZeroSample", 0, app.records[0])
+		requireEqualOpAndRef(t, "AppendSTZeroSample", 0, app.records[0])
 		ref := app.records[0].outRef
 		require.NotZero(t, ref)
 		requireEqualOpAndRef(t, "Append", ref, app.records[1])
-		requireEqualOpAndRef(t, "AppendCTZeroSample", ref, app.records[2])
+		requireEqualOpAndRef(t, "AppendSTZeroSample", ref, app.records[2])
 		requireEqualOpAndRef(t, "Append", ref, app.records[3])
 		requireEqualOpAndRef(t, "AppendExemplar", ref, app.records[4])
 	})
 
-	t.Run("error on second CT ingest doesn't update the reference", func(t *testing.T) {
+	t.Run("error on second ST ingest doesn't update the reference", func(t *testing.T) {
 		app := &appenderRecorder{}
 		capp := NewCombinedAppender(app, promslog.NewNopLogger(), true, false, NewCombinedAppenderMetrics(prometheus.NewRegistry()))
 
 		require.NoError(t, capp.AppendSample(seriesLabels.Copy(), floatMetadata, 1, 2, 42.0, nil))
 
-		app.appendCTZeroSampleError = errors.New("test error")
+		app.appendSTZeroSampleError = errors.New("test error")
 		require.NoError(t, capp.AppendSample(seriesLabels.Copy(), floatMetadata, 3, 4, 62.0, nil))
 
 		require.Len(t, app.records, 4)
-		requireEqualOpAndRef(t, "AppendCTZeroSample", 0, app.records[0])
+		requireEqualOpAndRef(t, "AppendSTZeroSample", 0, app.records[0])
 		ref := app.records[0].outRef
 		require.NotZero(t, ref)
 		requireEqualOpAndRef(t, "Append", ref, app.records[1])
-		requireEqualOpAndRef(t, "AppendCTZeroSample", ref, app.records[2])
-		require.Zero(t, app.records[2].outRef, "the second AppendCTZeroSample returned 0")
+		requireEqualOpAndRef(t, "AppendSTZeroSample", ref, app.records[2])
+		require.Zero(t, app.records[2].outRef, "the second AppendSTZeroSample returned 0")
 		requireEqualOpAndRef(t, "Append", ref, app.records[3])
 	})
 
@@ -577,12 +577,12 @@ func TestCombinedAppenderSeriesRefs(t *testing.T) {
 		}))
 
 		require.Len(t, app.records, 7)
-		requireEqualOpAndRef(t, "AppendCTZeroSample", 0, app.records[0])
+		requireEqualOpAndRef(t, "AppendSTZeroSample", 0, app.records[0])
 		ref := app.records[0].outRef
 		require.NotZero(t, ref)
 		requireEqualOpAndRef(t, "Append", ref, app.records[1])
 		requireEqualOpAndRef(t, "UpdateMetadata", ref, app.records[2])
-		requireEqualOpAndRef(t, "AppendCTZeroSample", ref, app.records[3])
+		requireEqualOpAndRef(t, "AppendSTZeroSample", ref, app.records[3])
 		requireEqualOpAndRef(t, "Append", ref, app.records[4])
 		require.Zero(t, app.records[4].outRef, "the second Append returned 0")
 		requireEqualOpAndRef(t, "UpdateMetadata", ref, app.records[5])
@@ -619,13 +619,13 @@ func TestCombinedAppenderSeriesRefs(t *testing.T) {
 		}))
 
 		require.Len(t, app.records, 5)
-		requireEqualOpAndRef(t, "AppendCTZeroSample", 0, app.records[0])
+		requireEqualOpAndRef(t, "AppendSTZeroSample", 0, app.records[0])
 		ref := app.records[0].outRef
 		require.NotZero(t, ref)
 		requireEqualOpAndRef(t, "Append", ref, app.records[1])
-		requireEqualOpAndRef(t, "AppendCTZeroSample", 0, app.records[2])
+		requireEqualOpAndRef(t, "AppendSTZeroSample", 0, app.records[2])
 		newRef := app.records[2].outRef
-		require.NotEqual(t, ref, newRef, "the second AppendCTZeroSample returned a different reference")
+		require.NotEqual(t, ref, newRef, "the second AppendSTZeroSample returned a different reference")
 		requireEqualOpAndRef(t, "Append", newRef, app.records[3])
 		requireEqualOpAndRef(t, "AppendExemplar", newRef, app.records[4])
 	})
@@ -651,12 +651,12 @@ func TestCombinedAppenderSeriesRefs(t *testing.T) {
 
 			if appendMetadata {
 				require.Len(t, app.records, 3)
-				requireEqualOp(t, "AppendCTZeroSample", app.records[0])
+				requireEqualOp(t, "AppendSTZeroSample", app.records[0])
 				requireEqualOp(t, "Append", app.records[1])
 				requireEqualOp(t, "UpdateMetadata", app.records[2])
 			} else {
 				require.Len(t, app.records, 2)
-				requireEqualOp(t, "AppendCTZeroSample", app.records[0])
+				requireEqualOp(t, "AppendSTZeroSample", app.records[0])
 				requireEqualOp(t, "Append", app.records[1])
 			}
 		})
@@ -720,12 +720,12 @@ func TestCombinedAppenderMetadataChanges(t *testing.T) {
 
 			// Verify expected operations.
 			require.Len(t, app.records, 7)
-			requireEqualOpAndRef(t, "AppendCTZeroSample", 0, app.records[0])
+			requireEqualOpAndRef(t, "AppendSTZeroSample", 0, app.records[0])
 			ref := app.records[0].outRef
 			require.NotZero(t, ref)
 			requireEqualOpAndRef(t, "Append", ref, app.records[1])
 			requireEqualOpAndRef(t, "UpdateMetadata", ref, app.records[2])
-			requireEqualOpAndRef(t, "AppendCTZeroSample", ref, app.records[3])
+			requireEqualOpAndRef(t, "AppendSTZeroSample", ref, app.records[3])
 			requireEqualOpAndRef(t, "Append", ref, app.records[4])
 			requireEqualOpAndRef(t, "UpdateMetadata", ref, app.records[5])
 			requireEqualOpAndRef(t, "Append", ref, app.records[6])
@@ -756,9 +756,9 @@ type appenderRecorder struct {
 	records  []appenderRecord
 
 	appendError                      error
-	appendCTZeroSampleError          error
+	appendSTZeroSampleError          error
 	appendHistogramError             error
-	appendHistogramCTZeroSampleError error
+	appendHistogramSTZeroSampleError error
 	updateMetadataError              error
 	appendExemplarError              error
 }
@@ -789,10 +789,10 @@ func (a *appenderRecorder) Append(ref storage.SeriesRef, ls labels.Labels, _ int
 	return ref, nil
 }
 
-func (a *appenderRecorder) AppendCTZeroSample(ref storage.SeriesRef, ls labels.Labels, _, _ int64) (storage.SeriesRef, error) {
-	a.records = append(a.records, appenderRecord{op: "AppendCTZeroSample", ref: ref, ls: ls})
-	if a.appendCTZeroSampleError != nil {
-		return 0, a.appendCTZeroSampleError
+func (a *appenderRecorder) AppendSTZeroSample(ref storage.SeriesRef, ls labels.Labels, _, _ int64) (storage.SeriesRef, error) {
+	a.records = append(a.records, appenderRecord{op: "AppendSTZeroSample", ref: ref, ls: ls})
+	if a.appendSTZeroSampleError != nil {
+		return 0, a.appendSTZeroSampleError
 	}
 	if ref == 0 {
 		ref = a.newRef()
@@ -813,10 +813,10 @@ func (a *appenderRecorder) AppendHistogram(ref storage.SeriesRef, ls labels.Labe
 	return ref, nil
 }
 
-func (a *appenderRecorder) AppendHistogramCTZeroSample(ref storage.SeriesRef, ls labels.Labels, _, _ int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
-	a.records = append(a.records, appenderRecord{op: "AppendHistogramCTZeroSample", ref: ref, ls: ls})
-	if a.appendHistogramCTZeroSampleError != nil {
-		return 0, a.appendHistogramCTZeroSampleError
+func (a *appenderRecorder) AppendHistogramSTZeroSample(ref storage.SeriesRef, ls labels.Labels, _, _ int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	a.records = append(a.records, appenderRecord{op: "AppendHistogramSTZeroSample", ref: ref, ls: ls})
+	if a.appendHistogramSTZeroSampleError != nil {
+		return 0, a.appendHistogramSTZeroSampleError
 	}
 	if ref == 0 {
 		ref = a.newRef()

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
@@ -482,7 +482,7 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 							model.MetricNameLabel, "test_summary"+sumStr,
 						),
 						t:  convertTimeStamp(ts),
-						ct: convertTimeStamp(ts),
+						st: convertTimeStamp(ts),
 						v:  0,
 					},
 					{
@@ -491,7 +491,7 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 							model.MetricNameLabel, "test_summary"+countStr,
 						),
 						t:  convertTimeStamp(ts),
-						ct: convertTimeStamp(ts),
+						st: convertTimeStamp(ts),
 						v:  0,
 					},
 				}
@@ -526,7 +526,7 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 						ls: labels.FromStrings(append(scopeLabels,
 							model.MetricNameLabel, "test_summary"+sumStr)...),
 						t:  convertTimeStamp(ts),
-						ct: convertTimeStamp(ts),
+						st: convertTimeStamp(ts),
 						v:  0,
 					},
 					{
@@ -534,7 +534,7 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 						ls: labels.FromStrings(append(scopeLabels,
 							model.MetricNameLabel, "test_summary"+countStr)...),
 						t:  convertTimeStamp(ts),
-						ct: convertTimeStamp(ts),
+						st: convertTimeStamp(ts),
 						v:  0,
 					},
 				}
@@ -706,7 +706,7 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 							model.MetricNameLabel, "test_hist"+countStr,
 						),
 						t:  convertTimeStamp(ts),
-						ct: convertTimeStamp(ts),
+						st: convertTimeStamp(ts),
 						v:  0,
 					},
 					{
@@ -716,7 +716,7 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 							model.BucketLabel, "+Inf",
 						),
 						t:  convertTimeStamp(ts),
-						ct: convertTimeStamp(ts),
+						st: convertTimeStamp(ts),
 						v:  0,
 					},
 				}
@@ -751,7 +751,7 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 						ls: labels.FromStrings(append(scopeLabels,
 							model.MetricNameLabel, "test_hist"+countStr)...),
 						t:  convertTimeStamp(ts),
-						ct: convertTimeStamp(ts),
+						st: convertTimeStamp(ts),
 						v:  0,
 					},
 					{
@@ -760,7 +760,7 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 							model.MetricNameLabel, "test_hist_bucket",
 							model.BucketLabel, "+Inf")...),
 						t:  convertTimeStamp(ts),
-						ct: convertTimeStamp(ts),
+						st: convertTimeStamp(ts),
 						v:  0,
 					},
 				}

--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
@@ -67,13 +67,13 @@ func (c *PrometheusConverter) addExponentialHistogramDataPoints(ctx context.Cont
 			return annots, err
 		}
 		ts := convertTimeStamp(pt.Timestamp())
-		ct := convertTimeStamp(pt.StartTimestamp())
+		st := convertTimeStamp(pt.StartTimestamp())
 		exemplars, err := c.getPromExemplars(ctx, pt.Exemplars())
 		if err != nil {
 			return annots, err
 		}
 		// OTel exponential histograms are always Int Histograms.
-		if err = c.appender.AppendHistogram(lbls, meta, ct, ts, hp, exemplars); err != nil {
+		if err = c.appender.AppendHistogram(lbls, meta, st, ts, hp, exemplars); err != nil {
 			return annots, err
 		}
 	}
@@ -286,12 +286,12 @@ func (c *PrometheusConverter) addCustomBucketsHistogramDataPoints(ctx context.Co
 			return annots, err
 		}
 		ts := convertTimeStamp(pt.Timestamp())
-		ct := convertTimeStamp(pt.StartTimestamp())
+		st := convertTimeStamp(pt.StartTimestamp())
 		exemplars, err := c.getPromExemplars(ctx, pt.Exemplars())
 		if err != nil {
 			return annots, err
 		}
-		if err = c.appender.AppendHistogram(lbls, meta, ct, ts, hp, exemplars); err != nil {
+		if err = c.appender.AppendHistogram(lbls, meta, st, ts, hp, exemplars); err != nil {
 			return annots, err
 		}
 	}

--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms_test.go
@@ -673,7 +673,7 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 						ls:               lbls,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           7,
 							Schema:          1,
@@ -689,7 +689,7 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 						ls:               lbls,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           4,
 							Schema:          1,
@@ -746,7 +746,7 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 						ls:               lbls,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           7,
 							Schema:          1,
@@ -762,7 +762,7 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 						ls:               lbls,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           4,
 							Schema:          1,
@@ -819,7 +819,7 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 						ls:               lbls,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           7,
 							Schema:          1,
@@ -835,7 +835,7 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 						ls:               labelsAnother,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           4,
 							Schema:          1,
@@ -1146,7 +1146,7 @@ func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
 						ls:               lbls,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           3,
 							Sum:             3,
@@ -1162,7 +1162,7 @@ func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
 						ls:               lbls,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           11,
 							Sum:             5,
@@ -1219,7 +1219,7 @@ func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
 						ls:               lbls,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           3,
 							Sum:             3,
@@ -1235,7 +1235,7 @@ func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
 						ls:               lbls,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           11,
 							Sum:             5,
@@ -1292,7 +1292,7 @@ func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
 						ls:               lbls,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           6,
 							Sum:             3,
@@ -1308,7 +1308,7 @@ func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
 						ls:               labelsAnother,
 						meta:             metadata.Metadata{},
 						t:                0,
-						ct:               0,
+						st:               0,
 						h: &histogram.Histogram{
 							Count:           11,
 							Sum:             5,

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -1105,7 +1105,7 @@ func (a *noOpAppender) Append(_ storage.SeriesRef, _ labels.Labels, _ int64, _ f
 	return 1, nil
 }
 
-func (*noOpAppender) AppendCTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, _ int64) (storage.SeriesRef, error) {
+func (*noOpAppender) AppendSTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, _ int64) (storage.SeriesRef, error) {
 	return 1, nil
 }
 
@@ -1114,7 +1114,7 @@ func (a *noOpAppender) AppendHistogram(_ storage.SeriesRef, _ labels.Labels, _ i
 	return 1, nil
 }
 
-func (*noOpAppender) AppendHistogramCTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, _ int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
+func (*noOpAppender) AppendHistogramSTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, _ int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	return 1, nil
 }
 

--- a/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
@@ -61,8 +61,8 @@ func (c *PrometheusConverter) addGaugeNumberDataPoints(ctx context.Context, data
 			val = math.Float64frombits(value.StaleNaN)
 		}
 		ts := convertTimeStamp(pt.Timestamp())
-		ct := convertTimeStamp(pt.StartTimestamp())
-		if err := c.appender.AppendSample(labels, meta, ct, ts, val, nil); err != nil {
+		st := convertTimeStamp(pt.StartTimestamp())
+		if err := c.appender.AppendSample(labels, meta, st, ts, val, nil); err != nil {
 			return err
 		}
 	}
@@ -104,12 +104,12 @@ func (c *PrometheusConverter) addSumNumberDataPoints(ctx context.Context, dataPo
 			val = math.Float64frombits(value.StaleNaN)
 		}
 		ts := convertTimeStamp(pt.Timestamp())
-		ct := convertTimeStamp(pt.StartTimestamp())
+		st := convertTimeStamp(pt.StartTimestamp())
 		exemplars, err := c.getPromExemplars(ctx, pt.Exemplars())
 		if err != nil {
 			return err
 		}
-		if err := c.appender.AppendSample(lbls, meta, ct, ts, val, exemplars); err != nil {
+		if err := c.appender.AppendSample(lbls, meta, st, ts, val, exemplars); err != nil {
 			return err
 		}
 	}

--- a/storage/remote/otlptranslator/prometheusremotewrite/number_data_points_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/number_data_points_test.go
@@ -272,7 +272,7 @@ func TestPrometheusConverter_addSumNumberDataPoints(t *testing.T) {
 						ls:               lbls,
 						meta:             metadata.Metadata{},
 						t:                convertTimeStamp(ts),
-						ct:               convertTimeStamp(ts),
+						st:               convertTimeStamp(ts),
 						v:                1,
 					},
 				}

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -318,22 +318,22 @@ func (t *timestampTracker) AppendHistogram(_ storage.SeriesRef, _ labels.Labels,
 	return 0, nil
 }
 
-func (t *timestampTracker) AppendCTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, ct int64) (storage.SeriesRef, error) {
+func (t *timestampTracker) AppendSTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, st int64) (storage.SeriesRef, error) {
 	t.samples++
-	if ct > t.highestTimestamp {
-		// Theoretically, we should never see a CT zero sample with a timestamp higher than the highest timestamp we've seen so far.
+	if st > t.highestTimestamp {
+		// Theoretically, we should never see a ST zero sample with a timestamp higher than the highest timestamp we've seen so far.
 		// However, we're not going to enforce that here, as it is not the responsibility of the tracker to enforce this.
-		t.highestTimestamp = ct
+		t.highestTimestamp = st
 	}
 	return 0, nil
 }
 
-func (t *timestampTracker) AppendHistogramCTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, ct int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
+func (t *timestampTracker) AppendHistogramSTZeroSample(_ storage.SeriesRef, _ labels.Labels, _, st int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	t.histograms++
-	if ct > t.highestTimestamp {
-		// Theoretically, we should never see a CT zero sample with a timestamp higher than the highest timestamp we've seen so far.
+	if st > t.highestTimestamp {
+		// Theoretically, we should never see a ST zero sample with a timestamp higher than the highest timestamp we've seen so far.
 		// However, we're not going to enforce that here, as it is not the responsibility of the tracker to enforce this.
-		t.highestTimestamp = ct
+		t.highestTimestamp = st
 	}
 	return 0, nil
 }

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -938,7 +938,7 @@ func TestOTLPWriteHandler(t *testing.T) {
 	}
 }
 
-// Check that start time is ingested if ingestCTZeroSample is enabled
+// Check that start time is ingested if ingestSTZeroSample is enabled
 // and the start time is actually set (non-zero).
 func TestOTLPWriteHandler_StartTime(t *testing.T) {
 	timestamp := time.Now()
@@ -1023,72 +1023,72 @@ func TestOTLPWriteHandler_StartTime(t *testing.T) {
 		},
 	}
 
-	expectedSamplesWithCTZero := make([]mockSample, 0, len(expectedSamples)*2-1) // All samples will get CT zero, except target_info.
+	expectedSamplesWithSTZero := make([]mockSample, 0, len(expectedSamples)*2-1) // All samples will get ST zero, except target_info.
 	for _, s := range expectedSamples {
 		if s.l.Get(model.MetricNameLabel) != "target_info" {
-			expectedSamplesWithCTZero = append(expectedSamplesWithCTZero, mockSample{
+			expectedSamplesWithSTZero = append(expectedSamplesWithSTZero, mockSample{
 				l: s.l.Copy(),
 				t: startTime.UnixMilli(),
 				v: 0,
 			})
 		}
-		expectedSamplesWithCTZero = append(expectedSamplesWithCTZero, s)
+		expectedSamplesWithSTZero = append(expectedSamplesWithSTZero, s)
 	}
-	expectedHistogramsWithCTZero := make([]mockHistogram, 0, len(expectedHistograms)*2)
+	expectedHistogramsWithSTZero := make([]mockHistogram, 0, len(expectedHistograms)*2)
 	for _, s := range expectedHistograms {
 		if s.l.Get(model.MetricNameLabel) != "target_info" {
-			expectedHistogramsWithCTZero = append(expectedHistogramsWithCTZero, mockHistogram{
+			expectedHistogramsWithSTZero = append(expectedHistogramsWithSTZero, mockHistogram{
 				l: s.l.Copy(),
 				t: startTime.UnixMilli(),
 				h: &histogram.Histogram{},
 			})
 		}
-		expectedHistogramsWithCTZero = append(expectedHistogramsWithCTZero, s)
+		expectedHistogramsWithSTZero = append(expectedHistogramsWithSTZero, s)
 	}
 
 	for _, testCase := range []struct {
 		name               string
 		otlpOpts           OTLPOptions
 		startTime          time.Time
-		expectCTZero       bool
+		expectSTZero       bool
 		expectedSamples    []mockSample
 		expectedHistograms []mockHistogram
 	}{
 		{
-			name: "IngestCTZero=false/startTime=0",
+			name: "IngestSTZero=false/startTime=0",
 			otlpOpts: OTLPOptions{
-				IngestCTZeroSample: false,
+				IngestSTZeroSample: false,
 			},
 			startTime:          zeroTime,
 			expectedSamples:    expectedSamples,
 			expectedHistograms: expectedHistograms,
 		},
 		{
-			name: "IngestCTZero=true/startTime=0",
+			name: "IngestSTZero=true/startTime=0",
 			otlpOpts: OTLPOptions{
-				IngestCTZeroSample: true,
+				IngestSTZeroSample: true,
 			},
 			startTime:          zeroTime,
 			expectedSamples:    expectedSamples,
 			expectedHistograms: expectedHistograms,
 		},
 		{
-			name: "IngestCTZero=false/startTime=ts-1ms",
+			name: "IngestSTZero=false/startTime=ts-1ms",
 			otlpOpts: OTLPOptions{
-				IngestCTZeroSample: false,
+				IngestSTZeroSample: false,
 			},
 			startTime:          startTime,
 			expectedSamples:    expectedSamples,
 			expectedHistograms: expectedHistograms,
 		},
 		{
-			name: "IngestCTZero=true/startTime=ts-1ms",
+			name: "IngestSTZero=true/startTime=ts-1ms",
 			otlpOpts: OTLPOptions{
-				IngestCTZeroSample: true,
+				IngestSTZeroSample: true,
 			},
 			startTime:          startTime,
-			expectedSamples:    expectedSamplesWithCTZero,
-			expectedHistograms: expectedHistogramsWithCTZero,
+			expectedSamples:    expectedSamplesWithSTZero,
+			expectedHistograms: expectedHistogramsWithSTZero,
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -6715,7 +6715,7 @@ func TestHeadAppender_AppendFloatWithSameTimestampAsPreviousHistogram(t *testing
 	require.ErrorIs(t, err, storage.NewDuplicateHistogramToFloatErr(2_000, 10.0))
 }
 
-func TestHeadAppender_AppendCT(t *testing.T) {
+func TestHeadAppender_AppendST(t *testing.T) {
 	testHistogram := tsdbutil.GenerateTestHistogram(1)
 	testHistogram.CounterResetHint = histogram.NotCounterReset
 	testFloatHistogram := tsdbutil.GenerateTestFloatHistogram(1)
@@ -6743,7 +6743,7 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 		fSample float64
 		h       *histogram.Histogram
 		fh      *histogram.FloatHistogram
-		ct      int64
+		st      int64
 	}
 	for _, tc := range []struct {
 		name              string
@@ -6753,8 +6753,8 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 		{
 			name: "In order ct+normal sample/floatSample",
 			appendableSamples: []appendableSamples{
-				{ts: 100, fSample: 10, ct: 1},
-				{ts: 101, fSample: 10, ct: 1},
+				{ts: 100, fSample: 10, st: 1},
+				{ts: 101, fSample: 10, st: 1},
 			},
 			expectedSamples: []chunks.Sample{
 				sample{t: 1, f: 0},
@@ -6765,8 +6765,8 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 		{
 			name: "In order ct+normal sample/histogram",
 			appendableSamples: []appendableSamples{
-				{ts: 100, h: testHistogram, ct: 1},
-				{ts: 101, h: testHistogram, ct: 1},
+				{ts: 100, h: testHistogram, st: 1},
+				{ts: 101, h: testHistogram, st: 1},
 			},
 			expectedSamples: func() []chunks.Sample {
 				return []chunks.Sample{
@@ -6779,8 +6779,8 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 		{
 			name: "In order ct+normal sample/floathistogram",
 			appendableSamples: []appendableSamples{
-				{ts: 100, fh: testFloatHistogram, ct: 1},
-				{ts: 101, fh: testFloatHistogram, ct: 1},
+				{ts: 100, fh: testFloatHistogram, st: 1},
+				{ts: 101, fh: testFloatHistogram, st: 1},
 			},
 			expectedSamples: func() []chunks.Sample {
 				return []chunks.Sample{
@@ -6791,10 +6791,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 			}(),
 		},
 		{
-			name: "Consecutive appends with same ct ignore ct/floatSample",
+			name: "Consecutive appends with same st ignore st/floatSample",
 			appendableSamples: []appendableSamples{
-				{ts: 100, fSample: 10, ct: 1},
-				{ts: 101, fSample: 10, ct: 1},
+				{ts: 100, fSample: 10, st: 1},
+				{ts: 101, fSample: 10, st: 1},
 			},
 			expectedSamples: []chunks.Sample{
 				sample{t: 1, f: 0},
@@ -6803,10 +6803,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 			},
 		},
 		{
-			name: "Consecutive appends with same ct ignore ct/histogram",
+			name: "Consecutive appends with same st ignore st/histogram",
 			appendableSamples: []appendableSamples{
-				{ts: 100, h: testHistogram, ct: 1},
-				{ts: 101, h: testHistogram, ct: 1},
+				{ts: 100, h: testHistogram, st: 1},
+				{ts: 101, h: testHistogram, st: 1},
 			},
 			expectedSamples: func() []chunks.Sample {
 				return []chunks.Sample{
@@ -6817,10 +6817,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 			}(),
 		},
 		{
-			name: "Consecutive appends with same ct ignore ct/floathistogram",
+			name: "Consecutive appends with same st ignore st/floathistogram",
 			appendableSamples: []appendableSamples{
-				{ts: 100, fh: testFloatHistogram, ct: 1},
-				{ts: 101, fh: testFloatHistogram, ct: 1},
+				{ts: 100, fh: testFloatHistogram, st: 1},
+				{ts: 101, fh: testFloatHistogram, st: 1},
 			},
 			expectedSamples: func() []chunks.Sample {
 				return []chunks.Sample{
@@ -6831,10 +6831,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 			}(),
 		},
 		{
-			name: "Consecutive appends with newer ct do not ignore ct/floatSample",
+			name: "Consecutive appends with newer st do not ignore st/floatSample",
 			appendableSamples: []appendableSamples{
-				{ts: 100, fSample: 10, ct: 1},
-				{ts: 102, fSample: 10, ct: 101},
+				{ts: 100, fSample: 10, st: 1},
+				{ts: 102, fSample: 10, st: 101},
 			},
 			expectedSamples: []chunks.Sample{
 				sample{t: 1, f: 0},
@@ -6844,10 +6844,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 			},
 		},
 		{
-			name: "Consecutive appends with newer ct do not ignore ct/histogram",
+			name: "Consecutive appends with newer st do not ignore st/histogram",
 			appendableSamples: []appendableSamples{
-				{ts: 100, h: testHistogram, ct: 1},
-				{ts: 102, h: testHistogram, ct: 101},
+				{ts: 100, h: testHistogram, st: 1},
+				{ts: 102, h: testHistogram, st: 101},
 			},
 			expectedSamples: []chunks.Sample{
 				sample{t: 1, h: testZeroHistogram},
@@ -6857,10 +6857,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 			},
 		},
 		{
-			name: "Consecutive appends with newer ct do not ignore ct/floathistogram",
+			name: "Consecutive appends with newer st do not ignore st/floathistogram",
 			appendableSamples: []appendableSamples{
-				{ts: 100, fh: testFloatHistogram, ct: 1},
-				{ts: 102, fh: testFloatHistogram, ct: 101},
+				{ts: 100, fh: testFloatHistogram, st: 1},
+				{ts: 102, fh: testFloatHistogram, st: 101},
 			},
 			expectedSamples: []chunks.Sample{
 				sample{t: 1, fh: testZeroFloatHistogram},
@@ -6870,10 +6870,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 			},
 		},
 		{
-			name: "CT equals to previous sample timestamp is ignored/floatSample",
+			name: "ST equals to previous sample timestamp is ignored/floatSample",
 			appendableSamples: []appendableSamples{
-				{ts: 100, fSample: 10, ct: 1},
-				{ts: 101, fSample: 10, ct: 100},
+				{ts: 100, fSample: 10, st: 1},
+				{ts: 101, fSample: 10, st: 100},
 			},
 			expectedSamples: []chunks.Sample{
 				sample{t: 1, f: 0},
@@ -6882,10 +6882,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 			},
 		},
 		{
-			name: "CT equals to previous sample timestamp is ignored/histogram",
+			name: "ST equals to previous sample timestamp is ignored/histogram",
 			appendableSamples: []appendableSamples{
-				{ts: 100, h: testHistogram, ct: 1},
-				{ts: 101, h: testHistogram, ct: 100},
+				{ts: 100, h: testHistogram, st: 1},
+				{ts: 101, h: testHistogram, st: 100},
 			},
 			expectedSamples: func() []chunks.Sample {
 				return []chunks.Sample{
@@ -6896,10 +6896,10 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 			}(),
 		},
 		{
-			name: "CT equals to previous sample timestamp is ignored/floathistogram",
+			name: "ST equals to previous sample timestamp is ignored/floathistogram",
 			appendableSamples: []appendableSamples{
-				{ts: 100, fh: testFloatHistogram, ct: 1},
-				{ts: 101, fh: testFloatHistogram, ct: 100},
+				{ts: 100, fh: testFloatHistogram, st: 1},
+				{ts: 101, fh: testFloatHistogram, st: 100},
 			},
 			expectedSamples: func() []chunks.Sample {
 				return []chunks.Sample{
@@ -6920,7 +6920,7 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 			for _, sample := range tc.appendableSamples {
 				// Append float if it's a float test case
 				if sample.fSample != 0 {
-					_, err := a.AppendCTZeroSample(0, lbls, sample.ts, sample.ct)
+					_, err := a.AppendSTZeroSample(0, lbls, sample.ts, sample.st)
 					require.NoError(t, err)
 					_, err = a.Append(0, lbls, sample.ts, sample.fSample)
 					require.NoError(t, err)
@@ -6928,7 +6928,7 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 
 				// Append histograms if it's a histogram test case
 				if sample.h != nil || sample.fh != nil {
-					ref, err := a.AppendHistogramCTZeroSample(0, lbls, sample.ts, sample.ct, sample.h, sample.fh)
+					ref, err := a.AppendHistogramSTZeroSample(0, lbls, sample.ts, sample.st, sample.h, sample.fh)
 					require.NoError(t, err)
 					_, err = a.AppendHistogram(ref, lbls, sample.ts, sample.h, sample.fh)
 					require.NoError(t, err)
@@ -6944,12 +6944,12 @@ func TestHeadAppender_AppendCT(t *testing.T) {
 	}
 }
 
-func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
+func TestHeadAppender_AppendHistogramSTZeroSample(t *testing.T) {
 	type appendableSamples struct {
 		ts int64
 		h  *histogram.Histogram
 		fh *histogram.FloatHistogram
-		ct int64 // 0 if no created timestamp.
+		st int64 // 0 if no created timestamp.
 	}
 	for _, tc := range []struct {
 		name              string
@@ -6957,32 +6957,32 @@ func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
 		expectedError     error
 	}{
 		{
-			name: "integer histogram CT lower than minValidTime initiates ErrOutOfBounds",
+			name: "integer histogram ST lower than minValidTime initiates ErrOutOfBounds",
 			appendableSamples: []appendableSamples{
-				{ts: 100, h: tsdbutil.GenerateTestHistogram(1), ct: -1},
+				{ts: 100, h: tsdbutil.GenerateTestHistogram(1), st: -1},
 			},
 			expectedError: storage.ErrOutOfBounds,
 		},
 		{
-			name: "float histograms CT lower than minValidTime initiates ErrOutOfBounds",
+			name: "float histograms ST lower than minValidTime initiates ErrOutOfBounds",
 			appendableSamples: []appendableSamples{
-				{ts: 100, fh: tsdbutil.GenerateTestFloatHistogram(1), ct: -1},
+				{ts: 100, fh: tsdbutil.GenerateTestFloatHistogram(1), st: -1},
 			},
 			expectedError: storage.ErrOutOfBounds,
 		},
 		{
-			name: "integer histogram CT duplicates an existing sample",
+			name: "integer histogram ST duplicates an existing sample",
 			appendableSamples: []appendableSamples{
 				{ts: 100, h: tsdbutil.GenerateTestHistogram(1)},
-				{ts: 200, h: tsdbutil.GenerateTestHistogram(1), ct: 100},
+				{ts: 200, h: tsdbutil.GenerateTestHistogram(1), st: 100},
 			},
 			expectedError: storage.ErrDuplicateSampleForTimestamp,
 		},
 		{
-			name: "float histogram CT duplicates an existing sample",
+			name: "float histogram ST duplicates an existing sample",
 			appendableSamples: []appendableSamples{
 				{ts: 100, fh: tsdbutil.GenerateTestFloatHistogram(1)},
-				{ts: 200, fh: tsdbutil.GenerateTestFloatHistogram(1), ct: 100},
+				{ts: 200, fh: tsdbutil.GenerateTestFloatHistogram(1), st: 100},
 			},
 			expectedError: storage.ErrDuplicateSampleForTimestamp,
 		},
@@ -7000,8 +7000,8 @@ func TestHeadAppender_AppendHistogramCTZeroSample(t *testing.T) {
 			for _, sample := range tc.appendableSamples {
 				a := h.Appender(context.Background())
 				var err error
-				if sample.ct != 0 {
-					ref, err = a.AppendHistogramCTZeroSample(ref, lbls, sample.ts, sample.ct, sample.h, sample.fh)
+				if sample.st != 0 {
+					ref, err = a.AppendHistogramSTZeroSample(ref, lbls, sample.ts, sample.st, sample.h, sample.fh)
 					require.ErrorIs(t, err, tc.expectedError)
 				}
 

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -290,7 +290,7 @@ func NewAPI(
 	rwEnabled bool,
 	acceptRemoteWriteProtoMsgs remoteapi.MessageTypes,
 	otlpEnabled, otlpDeltaToCumulative, otlpNativeDeltaIngestion bool,
-	ctZeroIngestionEnabled bool,
+	stZeroIngestionEnabled bool,
 	lookbackDelta time.Duration,
 	enableTypeAndUnitLabels bool,
 	appendMetadata bool,
@@ -339,14 +339,14 @@ func NewAPI(
 	}
 
 	if rwEnabled {
-		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, acceptRemoteWriteProtoMsgs, ctZeroIngestionEnabled, enableTypeAndUnitLabels, appendMetadata)
+		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, acceptRemoteWriteProtoMsgs, stZeroIngestionEnabled, enableTypeAndUnitLabels, appendMetadata)
 	}
 	if otlpEnabled {
 		a.otlpWriteHandler = remote.NewOTLPWriteHandler(logger, registerer, ap, configFunc, remote.OTLPOptions{
 			ConvertDelta:            otlpDeltaToCumulative,
 			NativeDelta:             otlpNativeDeltaIngestion,
 			LookbackDelta:           lookbackDelta,
-			IngestCTZeroSample:      ctZeroIngestionEnabled,
+			IngestSTZeroSample:      stZeroIngestionEnabled,
 			EnableTypeAndUnitLabels: enableTypeAndUnitLabels,
 			AppendMetadata:          appendMetadata,
 		})

--- a/web/web.go
+++ b/web/web.go
@@ -293,7 +293,7 @@ type Options struct {
 	ConvertOTLPDelta           bool
 	NativeOTLPDeltaIngestion   bool
 	IsAgent                    bool
-	CTZeroIngestionEnabled     bool
+	STZeroIngestionEnabled     bool
 	EnableTypeAndUnitLabels    bool
 	AppendMetadata             bool
 	AppName                    string
@@ -394,7 +394,7 @@ func New(logger *slog.Logger, o *Options) *Handler {
 		o.EnableOTLPWriteReceiver,
 		o.ConvertOTLPDelta,
 		o.NativeOTLPDeltaIngestion,
-		o.CTZeroIngestionEnabled,
+		o.STZeroIngestionEnabled,
 		o.LookbackDelta,
 		o.EnableTypeAndUnitLabels,
 		o.AppendMetadata,


### PR DESCRIPTION
Partially fixes https://github.com/prometheus/prometheus/issues/17416 by renaming all CT* names to ST* in the whole codebase except protos:
* RW2 (this is done in separate [PR](https://github.com/prometheus/prometheus/pull/17411)) 
* PrometheusProto exposition proto (not sure if we want to change this)

```
CreatedTimestamp -> StartTimestamp
CreatedTimeStamp -> StartTimestamp
created_timestamp -> start_timestamp
CT -> ST
ct -> st
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
