### PR TITLE
[PERF] PromQL: only reset labels builder when needed

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2951,7 +2951,6 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 		enh.resultMetric = make(map[string]labels.Labels, len(enh.Out))
 	}
 
-	enh.resetBuilder(lhs)
 	buf := bytes.NewBuffer(enh.lblResultBuf[:0])
 	enh.lblBuf = lhs.Bytes(enh.lblBuf)
 	buf.Write(enh.lblBuf)
@@ -2964,6 +2963,7 @@ func resultMetric(lhs, rhs labels.Labels, op parser.ItemType, matching *parser.V
 	}
 	str := string(enh.lblResultBuf)
 
+	enh.resetBuilder(lhs)
 	if changesMetricSchema(op) {
 		// Setting empty Metadata causes the deletion of those if they exists.
 		schema.Metadata{}.SetToLabels(enh.lb)


### PR DESCRIPTION
Currently, `resultMetric` function is resetting labels builder before checking the labels cache (effectively, for every resulting sample). We can defer this reset to be done after a cache miss (effectively, once for every resulting time series), as that is the only case when the builder is getting used.

The benchmark is showing ~8% performance improvement from this one line change:
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/promql
cpu: Apple M1 Pro
                                                                                                                │  main.txt  │ defer-enh-labels-builder-reset.txt │
                                                                                                                │   sec/op   │   sec/op     vs base               │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total/steps=10000-10                                 3.431 ± 3%    3.118 ± 2%  -9.13% (p=0.000 n=10)
JoinQuery/expr=rpc_request_success_total_+_ON_(job,_instance)_GROUP_LEFT_rpc_request_error_total/steps=10000-10   4.290 ± 1%    3.993 ± 0%  -6.92% (p=0.000 n=10)
geomean                                                                                                           3.837         3.529       -8.03%

                                                                                                                │   main.txt   │ defer-enh-labels-builder-reset.txt  │
                                                                                                                │     B/op     │     B/op      vs base               │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total/steps=10000-10                                 53.93Mi ± 1%   53.94Mi ± 1%       ~ (p=0.971 n=10)
JoinQuery/expr=rpc_request_success_total_+_ON_(job,_instance)_GROUP_LEFT_rpc_request_error_total/steps=10000-10   1.841Gi ± 0%   1.841Gi ± 0%       ~ (p=0.190 n=10)
geomean                                                                                                           318.9Mi        318.9Mi       -0.01%

                                                                                                                │  main.txt   │ defer-enh-labels-builder-reset.txt │
                                                                                                                │  allocs/op  │  allocs/op   vs base               │
JoinQuery/expr=rpc_request_success_total_+_rpc_request_error_total/steps=10000-10                                 562.7k ± 0%   562.7k ± 0%       ~ (p=0.725 n=10)
JoinQuery/expr=rpc_request_success_total_+_ON_(job,_instance)_GROUP_LEFT_rpc_request_error_total/steps=10000-10   20.57M ± 0%   20.57M ± 0%       ~ (p=0.341 n=10)
geomean                                                                                                           3.402M        3.402M       -0.00%
```

#### Does this PR introduce a user-facing change?
```release-notes
[PERF] PromQL: small optimisation to reset labels per series instead of per sample
```
