### PR TITLE
[PERF] Labels: stop coping with blanks in Builder.reset

### DIFF
--- a/model/labels/labels_dedupelabels.go
+++ b/model/labels/labels_dedupelabels.go
@@ -619,11 +619,6 @@ func (b *Builder) Reset(base Labels) {
 	b.base = base
 	b.del = b.del[:0]
 	b.add = b.add[:0]
-	base.Range(func(l Label) {
-		if l.Value == "" {
-			b.del = append(b.del, l.Name)
-		}
-	})
 }
 
 // Labels returns the labels from the builder.

--- a/model/labels/labels_slicelabels.go
+++ b/model/labels/labels_slicelabels.go
@@ -405,11 +405,6 @@ func (b *Builder) Reset(base Labels) {
 	b.base = base
 	b.del = b.del[:0]
 	b.add = b.add[:0]
-	b.base.Range(func(l Label) {
-		if l.Value == "" {
-			b.del = append(b.del, l.Name)
-		}
-	})
 }
 
 // Labels returns the labels from the builder.

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -472,11 +472,6 @@ func (b *Builder) Reset(base Labels) {
 	b.base = base
 	b.del = b.del[:0]
 	b.add = b.add[:0]
-	b.base.Range(func(l Label) {
-		if l.Value == "" {
-			b.del = append(b.del, l.Name)
-		}
-	})
 }
 
 // Labels returns the labels from the builder.

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -784,10 +784,6 @@ func TestBuilder(t *testing.T) {
 			set:  []Label{{"ddd", "444"}},
 			want: FromStrings("aaa", "111", "ccc", "333", "ddd", "444"),
 		},
-		{ // Blank value is interpreted as delete.
-			base: FromStrings("aaa", "111", "bbb", "", "ccc", "333"),
-			want: FromStrings("aaa", "111", "ccc", "333"),
-		},
 		{
 			base: FromStrings("aaa", "111", "bbb", "222", "ccc", "333"),
 			set:  []Label{{"bbb", ""}},

--- a/notifier/alert.go
+++ b/notifier/alert.go
@@ -73,7 +73,7 @@ func relabelAlerts(relabelConfigs []*relabel.Config, externalLabels labels.Label
 	var relabeledAlerts []*Alert
 
 	for _, a := range alerts {
-		lb.Reset(a.Labels)
+		lb.Reset(a.Labels.WithoutEmpty())
 		externalLabels.Range(func(l labels.Label) {
 			if a.Labels.Get(l.Name) == "" {
 				lb.Set(l.Name, l.Value)

--- a/promql/promqltest/testdata/type_and_unit.test
+++ b/promql/promqltest/testdata/type_and_unit.test
@@ -217,7 +217,7 @@ eval instant at 50m rate(http_requests_total[25m]) * 25 * 60
 
 eval instant at 50m http_requests_total{group="canary"} and http_requests_total{instance="0"}
 	http_requests_total{__type__="gauge", __unit__="not-request", group="canary", instance="0", job="api-server"} 300
-	http_requests_total{__type__="counter", __unit__="", group="canary", instance="0", job="app-server"} 700
+	http_requests_total{__type__="counter", group="canary", instance="0", job="app-server"} 700
 
 eval instant at 50m (http_requests_total{group="canary"} + 1) and http_requests_total{instance="0"}
 	{group="canary", instance="0", job="api-server"} 301
@@ -225,7 +225,7 @@ eval instant at 50m (http_requests_total{group="canary"} + 1) and http_requests_
 
 eval instant at 50m http_requests_total{group="canary"} or http_requests_total{group="production"}
 	http_requests_total{__type__="gauge", __unit__="not-request", group="canary", instance="0", job="api-server"} 300
-	http_requests_total{__type__="counter", __unit__="", group="canary", instance="0", job="app-server"} 700
+	http_requests_total{__type__="counter", group="canary", instance="0", job="app-server"} 700
 	http_requests_total{__type__="counter", __unit__="not-request", group="canary", instance="1", job="api-server"} 400
 	http_requests_total{group="canary", instance="1", job="app-server"} 800
 	http_requests_total{__type__="counter", __unit__="request", group="production", instance="0", job="api-server"} 100

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -169,7 +169,7 @@ func NewAlertingRule(
 		vector:              vec,
 		holdDuration:        hold,
 		keepFiringFor:       keepFiringFor,
-		labels:              labels,
+		labels:              labels.WithoutEmpty(),
 		annotations:         annotations,
 		externalLabels:      el,
 		externalURL:         externalURL,

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -592,7 +592,7 @@ func verifyLabelLimits(lset labels.Labels, limits *labelLimits) error {
 }
 
 func mutateSampleLabels(lset labels.Labels, target *Target, honor bool, rc []*relabel.Config) labels.Labels {
-	lb := labels.NewBuilder(lset)
+	lb := labels.NewBuilder(lset.WithoutEmpty())
 
 	if honor {
 		target.LabelsRange(func(l labels.Label) {


### PR DESCRIPTION
Blank label values are not normally allowed in Prometheus. This code is a drag everywhere that `Builder` is used, e.g. as observed in #17524.

Unfortunately there are a few places where blank labels _are_ allowed, such as Federation, so we need to take care which places we remove  blanks.

These tests require that blank labels are allowed:
* `TestExpandExternalLabels`
* `TestAlertingRuleEmptyLabelFromTemplate`
* `TestFederationWithNativeHistograms`
* `TestRemoteWriteHandler_V2Message`

See also #11024.

#### Does this PR introduce a user-facing change?
```release-notes
[PERF] Labels: small optimisation to stop checking for blank values, which are never allowed in Prometheus.
```
