### PR TITLE
discovery: fix constructor arguments in aws discovery

### DIFF
--- a/discovery/aws/aws.go
+++ b/discovery/aws/aws.go
@@ -215,11 +215,13 @@ func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Di
 
 	switch c.Role {
 	case RoleEC2:
-		return NewEC2Discovery(c.EC2SDConfig, opts.Logger, &ec2Metrics{refreshMetrics: awsMetrics.refreshMetrics})
+		opts.Metrics = &ec2Metrics{refreshMetrics: awsMetrics.refreshMetrics}
+		return NewEC2Discovery(c.EC2SDConfig, opts)
 	case RoleECS:
 		return NewECSDiscovery(c.ECSSDConfig, opts.Logger, &ecsMetrics{refreshMetrics: awsMetrics.refreshMetrics})
 	case RoleLightsail:
-		return NewLightsailDiscovery(c.LightsailSDConfig, opts.Logger, &lightsailMetrics{refreshMetrics: awsMetrics.refreshMetrics})
+		opts.Metrics = &lightsailMetrics{refreshMetrics: awsMetrics.refreshMetrics}
+		return NewLightsailDiscovery(c.LightsailSDConfig, opts)
 	default:
 		return nil, fmt.Errorf("unknown AWS SD role %q", c.Role)
 	}


### PR DESCRIPTION
CI was broken by a collision between #17406 and #17138 which were both tested independently.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```