### PR TITLE
[PERF] Scraping: skip an unnecessary step when there are relabel rules

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -716,13 +716,9 @@ func mutateSampleLabels(lset labels.Labels, target *Target, honor bool, rc []*re
 		}
 	}
 
-	res := lb.Labels()
+	relabel.ProcessBuilder(lb, rc...)
 
-	if len(rc) > 0 {
-		res, _ = relabel.Process(res, rc...)
-	}
-
-	return res
+	return lb.Labels()
 }
 
 func resolveConflictingExposedLabels(lb *labels.Builder, conflictingExposedLabels []labels.Label) {


### PR DESCRIPTION
Before it would do Builder->Labels->Builder, now we skip the conversions.
This should have been done right after #12048, but was forgotten.

#### Does this PR introduce a user-facing change?
```release-notes
[PERF] Scraping: skip an unnecessary step when relabelling series
```
