### PR TITLE
[REFACTOR] Relabel: Remove unnecessary Process() function

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -269,22 +269,8 @@ func (re Regexp) String() string {
 	return str[5 : len(str)-2]
 }
 
-// Process returns a relabeled version of the given label set. The relabel configurations
-// are applied in order of input.
-// There are circumstances where Process will modify the input label.
-// If you want to avoid issues with the input label set being modified, at the cost of
-// higher memory usage, you can use lbls.Copy().
-// If a label set is dropped, EmptyLabels and false is returned.
-func Process(lbls labels.Labels, cfgs ...*Config) (ret labels.Labels, keep bool) {
-	lb := labels.NewBuilder(lbls)
-	if !ProcessBuilder(lb, cfgs...) {
-		return labels.EmptyLabels(), false
-	}
-	return lb.Labels(), true
-}
-
-// ProcessBuilder is like Process, but the caller passes a labels.Builder
-// containing the initial set of labels, which is mutated by the rules.
+// ProcessBuilder applies relabeling configurations (rules) to the labels in lb.
+// The rules are applied in order of input. Returns false if the rule says to drop.
 func ProcessBuilder(lb *labels.Builder, cfgs ...*Config) (keep bool) {
 	for _, cfg := range cfgs {
 		keep = relabel(cfg, lb)

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -751,10 +751,11 @@ func TestRelabel(t *testing.T) {
 			require.NoError(t, cfg.Validate(model.UTF8Validation))
 		}
 
-		res, keep := Process(test.input, test.relabel...)
+		lb := labels.NewBuilder(test.input)
+		keep := ProcessBuilder(lb, test.relabel...)
 		require.Equal(t, !test.drop, keep)
 		if keep {
-			testutil.RequireEqual(t, test.output, res)
+			testutil.RequireEqual(t, test.output, lb.Labels())
 		}
 	}
 }
@@ -1064,9 +1065,11 @@ func BenchmarkRelabel(b *testing.B) {
 		require.NoError(b, err)
 	}
 	for _, tt := range tests {
+		lb := labels.NewBuilder(labels.EmptyLabels())
 		b.Run(tt.name, func(b *testing.B) {
 			for b.Loop() {
-				_, _ = Process(tt.lbls, tt.cfgs...)
+				lb.Reset(tt.lbls)
+				_ = ProcessBuilder(lb, tt.cfgs...)
 			}
 		})
 	}


### PR DESCRIPTION
All uses can be replaced by ProcessBuilder, which is more efficient because we can reuse the `Builder`.
(Now that #17530 is merged)

This might give mild disruption do downstream users, but I think the fix is easy to apply.

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
