### PR TITLE
tsdb: guard chunk length overflow in head chunk reader

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -778,7 +778,7 @@ func (cdm *ChunkDiskMapper) Chunk(ref ChunkDiskMapperRef) (chunkenc.Chunk, error
 	}
 
 	chkDataLenInt := int(chkDataLen)
-	if chkDataLenStart > math.MaxInt - n - chkDataLenInt {
+	if chkDataLenStart > math.MaxInt-n-chkDataLenInt {
 		return nil, &CorruptionErr{
 			Dir:       cdm.dir.Name(),
 			FileIndex: sgmIndex,


### PR DESCRIPTION
Description
Add an overflow check when decoding the chunk length.
We now reject any chunk whose encoded length can’t fit in int, so chkDataLenStart + n + len can never wrap.

Which issue(s) does the PR fix:
I did not create an issue.

Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] tsdb: Reject chunk files whose encoded chunk length overflows int.
```
