### PR TITLE
Refactor: Add generics to refactor append functions in queue_manager.go

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -720,8 +720,13 @@ func isV2TimeSeriesOldFilter(metrics *queueManagerMetrics, baseTime time.Time, s
 	}
 }
 
+// refTypes is supported record types that can be appended to the queue manager.
+type refTypes interface {
+	record.RefSample | record.RefExemplar | record.RefHistogramSample | record.RefFloatHistogramSample
+}
+
 // appendItemConfig contains configuration for the appendWithRetry helper.
-type appendItemConfig[T any] struct {
+type appendItemConfig[T refTypes] struct {
 	// dataTypeName is used for logging (e.g., "sample", "exemplar", "histogram").
 	dataTypeName string
 
@@ -751,7 +756,7 @@ type appendItemConfig[T any] struct {
 // appendWithRetry is a generic helper function that implements the common append logic
 // for all data types (samples, exemplars, histograms, float histograms).
 // It handles age checking, series lookup, dropped series tracking, and retry logic.
-func appendWithRetry[T any](qm *QueueManager, items []T, cfg appendItemConfig[T]) bool {
+func appendWithRetry[T refTypes](qm *QueueManager, items []T, cfg appendItemConfig[T]) bool {
 	// Early return if this data type is not enabled
 	if !cfg.checkEnabled() {
 		return true


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
- Related to https://github.com/prometheus/prometheus/issues/13481 and https://github.com/prometheus/prometheus/issues/14409

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```

#### Benchmark
Running some benchmark:
```
go test \
  -run '^$' -bench '^BenchmarkSampleSend' \
  -benchtime 2s -count 6 -benchmem -cpu 2 -timeout 999m \
  | tee old.txt
```
On main branch: 

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/storage/remote
cpu: Apple M1 Pro
BenchmarkSampleSend/prometheus.WriteRequest-2                816           2733676 ns/op          234677 B/op        366 allocs/op
BenchmarkSampleSend/prometheus.WriteRequest-2                921           2748289 ns/op          210527 B/op        339 allocs/op
BenchmarkSampleSend/prometheus.WriteRequest-2                799           2768283 ns/op          242124 B/op        385 allocs/op
BenchmarkSampleSend/prometheus.WriteRequest-2                810           2734965 ns/op          238495 B/op        379 allocs/op
BenchmarkSampleSend/prometheus.WriteRequest-2                871           3315512 ns/op          222092 B/op        356 allocs/op
BenchmarkSampleSend/prometheus.WriteRequest-2                760           3282702 ns/op          254379 B/op        403 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         800           2847301 ns/op           74592 B/op        465 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         946           2780779 ns/op           64261 B/op        409 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         914           2876073 ns/op           66351 B/op        421 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         854           3215520 ns/op           70345 B/op        442 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         900           2772461 ns/op           67226 B/op        426 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         896           2777603 ns/op           67373 B/op        426 allocs/op
PASS
ok      github.com/prometheus/prometheus/storage/remote 30.928s
```

On this branch: 
```
go test \
  -run '^$' -bench '^BenchmarkSampleSend' \
  -benchtime 2s -count 6 -cpu 2 -timeout 999m \
  | tee new.txt
```
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/storage/remote
cpu: Apple M1 Pro
BenchmarkSampleSend/prometheus.WriteRequest-2                806           2800931 ns/op          238614 B/op        375 allocs/op
BenchmarkSampleSend/prometheus.WriteRequest-2                818           2765279 ns/op          236238 B/op        376 allocs/op
BenchmarkSampleSend/prometheus.WriteRequest-2                865           2764029 ns/op          223917 B/op        358 allocs/op
BenchmarkSampleSend/prometheus.WriteRequest-2                778           2764516 ns/op          248165 B/op        393 allocs/op
BenchmarkSampleSend/prometheus.WriteRequest-2                832           2798005 ns/op          232681 B/op        371 allocs/op
BenchmarkSampleSend/prometheus.WriteRequest-2                898           2735294 ns/op          215484 B/op        345 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         841           2806559 ns/op           70948 B/op        447 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         907           2793462 ns/op           66329 B/op        421 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         898           2792616 ns/op           67315 B/op        426 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         891           2795717 ns/op           67789 B/op        429 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         920           2797135 ns/op           65581 B/op        418 allocs/op
BenchmarkSampleSend/io.prometheus.write.v2.Request-2         912           2773823 ns/op           66345 B/op        420 allocs/op
PASS
ok      github.com/prometheus/prometheus/storage/remote 29.807s
```

Running benchstat to compare: 
```
➜  remote git:(refactor_queue_manager_2) ✗ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/storage/remote
cpu: Apple M1 Pro
                                            │   old.txt    │              new.txt              │
                                            │    sec/op    │   sec/op     vs base              │
SampleSend/prometheus.WriteRequest-2          2.758m ± 20%   2.765m ± 1%       ~ (p=0.937 n=6)
SampleSend/io.prometheus.write.v2.Request-2   2.814m ± 14%   2.795m ± 1%       ~ (p=0.818 n=6)
geomean                                       2.786m         2.780m       -0.23%

                                            │    old.txt    │              new.txt               │
                                            │     B/op      │     B/op      vs base              │
SampleSend/prometheus.WriteRequest-2          231.0Ki ± 11%   229.0Ki ± 8%       ~ (p=0.937 n=6)
SampleSend/io.prometheus.write.v2.Request-2   65.72Ki ± 11%   65.26Ki ± 6%       ~ (p=0.699 n=6)
geomean                                       123.2Ki         122.2Ki       -0.80%

                                            │  old.txt   │             new.txt              │
                                            │ allocs/op  │ allocs/op   vs base              │
SampleSend/prometheus.WriteRequest-2          372.5 ± 9%   373.0 ± 8%       ~ (p=0.937 n=6)
SampleSend/io.prometheus.write.v2.Request-2   426.0 ± 9%   423.5 ± 6%       ~ (p=0.732 n=6)
geomean                                       398.4        397.4       -0.23%
```

Seems like nothing has been changed