### PR TITLE
PromQL: Improve BenchmarkJoinQuery

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -393,40 +393,44 @@ func BenchmarkJoinQuery(b *testing.B) {
 	}
 	engine := promqltest.NewTestEngineWithOpts(b, opts)
 
-	const interval = 10000 // 10s interval.
+	const (
+		interval     = 10000 // 10s interval.
+		steps        = 5000
+		numInstances = 1000
+	)
 
-	// A day of data plus 10k steps.
-	numIntervals := 8640 + 10000
+	// A day of data plus steps.
+	numIntervals := 8640 + steps
 
-	require.NoError(b, setupJoinQueryTestData(stor, engine, interval, numIntervals, 1000))
+	require.NoError(b, setupJoinQueryTestData(stor, engine, interval, numIntervals, numInstances))
 
 	for _, c := range []benchCase{
 		{
 			expr:  `rpc_request_success_total + rpc_request_error_total`,
-			steps: 10000,
+			steps: steps,
 		},
 		{
 			expr:  `rpc_request_success_total + ON (job, instance) GROUP_LEFT rpc_request_error_total`,
-			steps: 10000,
+			steps: steps,
 		},
 		{
 			expr:  `rpc_request_success_total AND rpc_request_error_total{instance=~"0.*"}`, // 0.* keeps 1/16 of UUID values
-			steps: 10000,
+			steps: steps,
 		},
 		{
 			expr:  `rpc_request_success_total OR rpc_request_error_total{instance=~"0.*"}`, // 0.* keeps 1/16 of UUID values
-			steps: 10000,
+			steps: steps,
 		},
 		{
 			expr:  `rpc_request_success_total UNLESS rpc_request_error_total{instance=~"0.*"}`, // 0.* keeps 1/16 of UUID values
-			steps: 10000,
+			steps: steps,
 		},
 	} {
 		name := fmt.Sprintf("expr=%s/steps=%d", c.expr, c.steps)
 		b.Run(name, func(b *testing.B) {
 			ctx := context.Background()
-			b.ReportAllocs()
-			for b.Loop() {
+
+			queryFn := func() {
 				qry, err := engine.NewRangeQuery(
 					ctx, stor, nil, c.expr,
 					timestamp.Time(int64((numIntervals-c.steps)*10_000)),
@@ -438,6 +442,14 @@ func BenchmarkJoinQuery(b *testing.B) {
 				require.NoError(b, res.Err)
 
 				qry.Close()
+			}
+
+			queryFn() // Warm up run.
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for b.Loop() {
+				queryFn()
 			}
 		})
 	}


### PR DESCRIPTION
I've noticed that the first benchmark run allocates almost an order of magnitude more memory (and then it stabilizes):
```
BenchmarkJoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"}/steps=5000-10                     	       2	 714095584 ns/op	110195344 B/op	  172768 allocs/op
BenchmarkJoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"}/steps=5000-10                     	       2	 710642021 ns/op	21452552 B/op	  171336 allocs/op
BenchmarkJoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"}/steps=5000-10                     	       2	 717076125 ns/op	21330240 B/op	  171347 allocs/op
BenchmarkJoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"}/steps=5000-10                     	       2	 717360167 ns/op	21457408 B/op	  171345 allocs/op
(...)
```

It looks like adding a singe query invocation before the actual benchmark run fixes that:
```
BenchmarkJoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"}/steps=5000-10                     	       2	 706275000 ns/op	21328772 B/op	  171336 allocs/op
BenchmarkJoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"}/steps=5000-10                     	       2	 723928458 ns/op	21314720 B/op	  171313 allocs/op
BenchmarkJoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"}/steps=5000-10                     	       2	 700843916 ns/op	21336248 B/op	  171350 allocs/op
BenchmarkJoinQuery/expr=rpc_request_success_total_OR_rpc_request_error_total{instance=~"0.*"}/steps=5000-10                     	       2	 709683458 ns/op	21326312 B/op	  171321 allocs/op
(...)
```

Also, made the benchmark easier to tune by extracting a `steps` constant (and reduced it 5000).

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
