### PR TITLE
discovery: adding kubernetes node condition labels

### DIFF
--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -550,8 +550,8 @@ func TestEndpointsDiscoveryWithNodeMetadata(t *testing.T) {
 	metadataConfig := AttachMetadataConfig{Node: true}
 	nodeLabels1 := map[string]string{"az": "us-east1"}
 	nodeLabels2 := map[string]string{"az": "us-west2"}
-	node1 := makeNode("foobar", "", "", nodeLabels1, nil)
-	node2 := makeNode("barbaz", "", "", nodeLabels2, nil)
+	node1 := makeNode("foobar", "", "", nodeLabels1, nil, nil)
+	node2 := makeNode("barbaz", "", "", nodeLabels2, nil, nil)
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testendpoints",
@@ -623,8 +623,8 @@ func TestEndpointsDiscoveryWithUpdatedNodeMetadata(t *testing.T) {
 	t.Parallel()
 	nodeLabels1 := map[string]string{"az": "us-east1"}
 	nodeLabels2 := map[string]string{"az": "us-west2"}
-	node1 := makeNode("foobar", "", "", nodeLabels1, nil)
-	node2 := makeNode("barbaz", "", "", nodeLabels2, nil)
+	node1 := makeNode("foobar", "", "", nodeLabels1, nil, nil)
+	node2 := makeNode("barbaz", "", "", nodeLabels2, nil, nil)
 	metadataConfig := AttachMetadataConfig{Node: true}
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/discovery/kubernetes/endpointslice_test.go
+++ b/discovery/kubernetes/endpointslice_test.go
@@ -654,7 +654,7 @@ func TestEndpointsSlicesDiscoveryWithNodeMetadata(t *testing.T) {
 			},
 		},
 	}
-	objs := []runtime.Object{makeEndpointSliceV1("default"), makeNode("foobar", "", "", nodeLabels1, nil), makeNode("barbaz", "", "", nodeLabels2, nil), svc}
+	objs := []runtime.Object{makeEndpointSliceV1("default"), makeNode("foobar", "", "", nodeLabels1, nil, nil), makeNode("barbaz", "", "", nodeLabels2, nil, nil), svc}
 	n, _ := makeDiscoveryWithMetadata(RoleEndpointSlice, NamespaceDiscovery{}, metadataConfig, objs...)
 
 	k8sDiscoveryTest{
@@ -754,8 +754,8 @@ func TestEndpointsSlicesDiscoveryWithUpdatedNodeMetadata(t *testing.T) {
 			},
 		},
 	}
-	node1 := makeNode("foobar", "", "", nodeLabels1, nil)
-	node2 := makeNode("barbaz", "", "", nodeLabels2, nil)
+	node1 := makeNode("foobar", "", "", nodeLabels1, nil, nil)
+	node2 := makeNode("barbaz", "", "", nodeLabels2, nil, nil)
 	objs := []runtime.Object{makeEndpointSliceV1("default"), node1, node2, svc}
 	n, c := makeDiscoveryWithMetadata(RoleEndpointSlice, NamespaceDiscovery{}, metadataConfig, objs...)
 

--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -481,7 +481,7 @@ func TestPodDiscoveryWithNodeMetadata(t *testing.T) {
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
-			nodes := makeNode("testnode", "", "", nodeLbls, nil)
+			nodes := makeNode("testnode", "", "", nodeLbls, nil, nil)
 			c.CoreV1().Nodes().Create(context.Background(), nodes, metav1.CreateOptions{})
 
 			pods := makePods("default")
@@ -502,14 +502,14 @@ func TestPodDiscoveryWithNodeMetadataUpdateNode(t *testing.T) {
 		discovery: n,
 		beforeRun: func() {
 			oldNodeLbls := map[string]string{"l1": "v1"}
-			nodes := makeNode("testnode", "", "", oldNodeLbls, nil)
+			nodes := makeNode("testnode", "", "", oldNodeLbls, nil, nil)
 			c.CoreV1().Nodes().Create(context.Background(), nodes, metav1.CreateOptions{})
 		},
 		afterStart: func() {
 			pods := makePods("default")
 			c.CoreV1().Pods(pods.Namespace).Create(context.Background(), pods, metav1.CreateOptions{})
 
-			nodes := makeNode("testnode", "", "", nodeLbls, nil)
+			nodes := makeNode("testnode", "", "", nodeLbls, nil, nil)
 			c.CoreV1().Nodes().Update(context.Background(), nodes, metav1.UpdateOptions{})
 		},
 		expectedMaxItems: 2,

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2002,6 +2002,7 @@ Available meta labels:
 
 * `__meta_kubernetes_node_name`: The name of the node object.
 * `__meta_kubernetes_node_provider_id`: The cloud provider's name for the node object.
+* `__meta_kubernetes_node_condition_<condition_type>`: For every entry in node.Status.Conditions, a label with the condition type in lowercase. Possible values are `true`, `false`, or `unknown`. Examples: `__meta_kubernetes_node_condition_ready`, `__meta_kubernetes_node_condition_memorypressure`, `__meta_kubernetes_node_condition_diskpressure`.
 * `__meta_kubernetes_node_label_<labelname>`: Each label from the node object, with any unsupported characters converted to an underscore.
 * `__meta_kubernetes_node_labelpresent_<labelname>`: `true` for each label from the node object, with any unsupported characters converted to an underscore.
 * `__meta_kubernetes_node_annotation_<annotationname>`: Each annotation from the node object.


### PR DESCRIPTION
This PR adds Kubernetes node condition labels to Prometheus service discovery and exports all node conditions (Ready, MemoryPressure, DiskPressure, PIDPressure, etc.) as individual meta labels in a lowercase format

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
-->

#### Which issue(s) does the PR fix:
Fixes: https://github.com/prometheus/prometheus/issues/16707

#### Does this PR introduce a user-facing change?
```release-notes
[FEATURE] Kubernetes SD: Export node status conditions (Ready, MemoryPressure, DiskPressure, PIDPressure, etc.) as individual meta labels for service discovery.

