### PR TITLE
[BUGFIX] UI: Fixed codemirror-promql incorrectly showing label completion suggestions

### DIFF
--- a/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
@@ -300,6 +300,12 @@ describe('analyzeCompletion test', () => {
       expectedContext: [{ kind: ContextKind.LabelName, metricName: 'metric_name' }],
     },
     {
+      title: 'no label suggestions after closing matcher',
+      expr: 'up{job="prometheus"}',
+      pos: 20, // cursor is right after the closing curly bracket
+      expectedContext: [],
+    },
+    {
       title: 'continue autocomplete labelName that defined a metric',
       expr: '{myL}',
       pos: 4, // cursor is between the bracket after the string myL

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -400,12 +400,18 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode, pos: num
       // so we have or to autocomplete any kind of labelName or to autocomplete only the labelName associated to the metric
       result.push({ kind: ContextKind.LabelName, metricName: getMetricNameInGroupBy(node, state) });
       break;
-    case LabelMatchers:
+    case LabelMatchers: {
+      if (pos >= node.to) {
+        // Cursor is outside of the label matcher block (e.g. right after `}`),
+        // so don't offer label-related completions anymore.
+        break;
+      }
       // In that case we are in the given situation:
       //       metric_name{} or {}
       // so we have or to autocomplete any kind of labelName or to autocomplete only the labelName associated to the metric
       result.push({ kind: ContextKind.LabelName, metricName: getMetricNameInVectorSelector(node, state) });
       break;
+    }
     case LabelName:
       if (node.parent?.type.id === GroupingLabels) {
         // In this case we are in the given situation:


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"
    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    - Performance improvements would need a benchmark test to prove it.
    - All exposed objects should have a comment.
    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #14942

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] UI: Fixed codemirror-promql incorrectly showing label completion suggestions after the closing curly brace of a vector selector.
```

## Description

This PR fixes an issue in the codemirror-promql autocomplete logic where label name suggestions were incorrectly appearing after the closing curly brace of a vector selector (e.g., `up{job="prometheus"}<cursor>`).

### Changes
Added position validation for LabelMatchers and a test ensuring no label suggestions after the closing curly bracket.

The fix ensures that autocomplete behaves correctly by only offering label name completions when the cursor is actually inside the label matcher block, not after it has been closed.

Before:

https://github.com/user-attachments/assets/87016a29-fe8a-4b82-b036-14eb3e654d2f

After:

https://github.com/user-attachments/assets/00c84b7e-d335-4073-a69e-8ad2fb228706

