### PR TITLE
Hide alert annotations by default

### DIFF
--- a/web/ui/mantine-ui/src/state/settingsSlice.ts
+++ b/web/ui/mantine-ui/src/state/settingsSlice.ts
@@ -102,7 +102,7 @@ export const initialState: Settings = {
   ),
   showAnnotations: initializeFromLocalStorage<boolean>(
     localStorageKeyShowAnnotations,
-    true
+    false
   ),
   showQueryWarnings: initializeFromLocalStorage<boolean>(
     localStorageKeyShowQueryWarnings,


### PR DESCRIPTION
See https://github.com/prometheus/prometheus/issues/16911

This will create a denser layout by default, enabling people to see more information on the page without having to discover the global settings menu.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:

Fixes https://github.com/prometheus/prometheus/issues/16911

#### Does this PR introduce a user-facing change?

```release-notes
[CHANGE] UI: Hide expanded alert annotations by default, enabling more information density on the /alerts page
```
