### PR TITLE
[BUGFIX]_UI: Replace entire metric name in autocomplete regardless of cursor position

### DIFF
--- a/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
@@ -1297,6 +1297,18 @@ describe('autocomplete promQL test', () => {
       },
     },
     {
+      title: 'online autocomplete replaces full metric when cursor mid-identifier',
+      expr: 'alertmanager_config_last__timestamp_seconds',
+      pos: 25,
+      conf: { remote: { url: 'http://localhost:8080' } },
+      expectedResult: {
+        options: ([] as Completion[]).concat(mockedMetricsTerms, functionIdentifierTerms, aggregateOpTerms, numberTerms, snippets),
+        from: 0,
+        to: 43,
+        validFor: /^[a-zA-Z0-9_:]+$/,
+      },
+    },
+    {
       title: 'online autocomplete of label name corresponding to a metric',
       expr: 'alertmanager_alerts{}',
       pos: 20,


### PR DESCRIPTION
### Description
Previously, when selecting a metric name from autocomplete suggestions with the cursor positioned mid-identifier, only the text before the cursor was replaced, leaving the suffix intact and resulting in duplicate or malformed metric names.

**Changes:**
- Added `computeEndCompleteMetricPosition()` function to scan forward from cursor position and find the complete end boundary of the metric name
- Modified autocomplete logic to compute the correct `to` position for metric context replacements
- Added test case covering mid-identifier autocomplete scenario

#### Which issue(s) does the PR fix:
Fixes #15839

#### Does this PR introduce a user-facing change?
```release-notes
[BUGFIX] Web UI: Fixed metric name autocomplete to replace the entire metric name regardless of cursor position, preventing duplicate or malformed names when editing queries.
```

Resulting Behavior:

https://github.com/user-attachments/assets/4660fed5-8a73-46c1-9c6c-9ce96970e0a4

