### PR TITLE
Use Clock injection in ScrapeManager for improved testability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -233,7 +233,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools/v3 v3.0.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
-	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/scrape/helpers_test.go
+++ b/scrape/helpers_test.go
@@ -22,10 +22,12 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
+	testingclock "k8s.io/utils/clock/testing"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -270,4 +272,10 @@ func protoMarshalDelimited(t *testing.T, mf *dto.MetricFamily) []byte {
 	buf.Write(varintBuf[:varintLength])
 	buf.Write(protoBuf)
 	return buf.Bytes()
+}
+
+// newTestFakeClock creates a new fake clock for testing.
+// The fake clock starts at the current time and can be advanced manually.
+func newTestFakeClock() *testingclock.FakeClock {
+	return testingclock.NewFakeClock(time.Now())
 }

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"go.uber.org/atomic"
+	"k8s.io/utils/clock"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -93,8 +94,20 @@ type Options struct {
 	// Optional HTTP client options to use when scraping.
 	HTTPClientOptions []config_util.HTTPClientOption
 
+	// Clock is used for time-related operations. If nil, the real clock is used.
+	// This is primarily useful for testing to control time progression.
+	Clock clock.WithTicker
+
 	// private option for testability.
 	skipOffsetting bool
+}
+
+// clock returns the clock from Options, or a real clock if not set.
+func (o *Options) clock() clock.WithTicker {
+	if o.Clock != nil {
+		return o.Clock
+	}
+	return clock.RealClock{}
 }
 
 // Manager maintains a set of scrape pools and manages start/stop cycles

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"k8s.io/utils/clock"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
@@ -1204,6 +1205,11 @@ func runManagers(t *testing.T, ctx context.Context, opts *Options, app storage.A
 	opts.DiscoveryReloadInterval = model.Duration(100 * time.Millisecond)
 	if app == nil {
 		app = nopAppendable{}
+	}
+
+	// Tests can pass a fake clock via opts.Clock to control time.
+	if opts.Clock == nil {
+		opts.Clock = clock.RealClock{}
 	}
 
 	reg := prometheus.NewRegistry()


### PR DESCRIPTION
The scrape package tests rely on real-time operations (`time.Sleep`, `time.After`, `time.NewTicker`), which causes two issues:
1. Slow tests: Tests that have to `time.Sleep(1 * time.Second)` just to verify timing behavior, making the test suite unnecessarily slow.
1. Flaky tests: Tests depending on real time are susceptible to timing variations on loaded systems, leading to intermittent failures. Flakiness in otel-collector tests (they use ScrapeManager as a library) is super common[[1](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42892)].

In this PR, I'm experimenting with an injectable `Clock` interface using `k8s.io/utils/clock`, following the dependency injection pattern. The clock is added to `scrape.Options` and propagates to the scrapeLoop, allowing tests to use a fake clock that can be controlled programmatically.

I've also updated a few existing tests to demonstrate how this would work, but I wanted to open the PR early to gather feedback on the approach. If folks are happy with it, I'm happy to update more tests with this pattern

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
