### PR TITLE
rules: replace error strings with sentinel errors for duplicate labels sets

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -46,6 +46,10 @@ const (
 	alertStateLabel = "alertstate"
 )
 
+// ErrDuplicateAlertLabelSet is returned when an alerting rule evaluation produces
+// metrics with identical labelsets after applying alert labels.
+var ErrDuplicateAlertLabelSet = errors.New("vector contains metrics with the same labelset after applying alert labels")
+
 // AlertState denotes the state of an active alert.
 type AlertState int
 
@@ -441,7 +445,7 @@ func (r *AlertingRule) Eval(ctx context.Context, queryOffset time.Duration, ts t
 		resultFPs[h] = struct{}{}
 
 		if _, ok := alerts[h]; ok {
-			return nil, errors.New("vector contains metrics with the same labelset after applying alert labels")
+			return nil, ErrDuplicateAlertLabelSet
 		}
 
 		alerts[h] = &Alert{

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -612,7 +612,7 @@ func TestAlertingRuleDuplicate(t *testing.T) {
 	)
 	_, err := rule.Eval(ctx, 0, now, EngineQueryFunc(engine, storage), nil, 0)
 	require.Error(t, err)
-	require.EqualError(t, err, "vector contains metrics with the same labelset after applying alert labels")
+	require.ErrorIs(t, err, ErrDuplicateAlertLabelSet)
 }
 
 func TestAlertingRuleLimit(t *testing.T) {

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -30,6 +30,10 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
+// ErrDuplicateRecordingLabelSet is returned when a recording rule evaluation produces
+// metrics with identical labelsets after applying rule labels.
+var ErrDuplicateRecordingLabelSet = errors.New("vector contains metrics with the same labelset after applying rule labels")
+
 // A RecordingRule records its vector expression into new timeseries.
 type RecordingRule struct {
 	name   string
@@ -104,7 +108,7 @@ func (rule *RecordingRule) Eval(ctx context.Context, queryOffset time.Duration, 
 	// Check that the rule does not produce identical metrics after applying
 	// labels.
 	if vector.ContainsSameLabelset() {
-		return nil, errors.New("vector contains metrics with the same labelset after applying rule labels")
+		return nil, ErrDuplicateRecordingLabelSet
 	}
 
 	numSeries := len(vector)

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -176,7 +176,7 @@ func TestRuleEvalDuplicate(t *testing.T) {
 	rule := NewRecordingRule("foo", expr, labels.FromStrings("test", "test"))
 	_, err := rule.Eval(ctx, 0, now, EngineQueryFunc(engine, storage), nil, 0)
 	require.Error(t, err)
-	require.EqualError(t, err, "vector contains metrics with the same labelset after applying rule labels")
+	require.ErrorIs(t, err, ErrDuplicateRecordingLabelSet)
 }
 
 func TestRecordingRuleLimit(t *testing.T) {


### PR DESCRIPTION

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR introduces sentinel errors for duplicate labelset detection in both alerting and recording rules, replacing inline error strings with package-level error variables
- Added `ErrDuplicateAlertLabelSet` sentinel error in `rules/alerting.go`
- Added `ErrDuplicateRecordingLabelSet` sentinel error in `rules/recording.go`

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
