### PR TITLE
prompb: set custom values when converting to prompb histograms

### DIFF
--- a/prompb/codec.go
+++ b/prompb/codec.go
@@ -161,6 +161,7 @@ func FromIntHistogram(timestamp int64, h *histogram.Histogram) Histogram {
 		PositiveDeltas: h.PositiveBuckets,
 		ResetHint:      Histogram_ResetHint(h.CounterResetHint),
 		Timestamp:      timestamp,
+		CustomValues:   h.CustomValues,
 	}
 }
 
@@ -178,6 +179,7 @@ func FromFloatHistogram(timestamp int64, fh *histogram.FloatHistogram) Histogram
 		PositiveCounts: fh.PositiveBuckets,
 		ResetHint:      Histogram_ResetHint(fh.CounterResetHint),
 		Timestamp:      timestamp,
+		CustomValues:   fh.CustomValues,
 	}
 }
 


### PR DESCRIPTION
I came across this while working on custom `storage.Storage` implementation and noticed wrong round trips between prompb and native histograms.


