### PR TITLE
fix(promql): native histogram custom buckets rate with empty buckets

### DIFF
--- a/promql/promqltest/testdata/histograms.test
+++ b/promql/promqltest/testdata/histograms.test
@@ -708,3 +708,36 @@ eval instant at 0 histogram_fraction(-Inf, 1, series)
   expect no_info
   expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
   # Should return no results.
+
+clear
+
+# Test what happens if NHCB has more buckets at the end of the `rate` interval
+# than the beginning of the interval. In the test data, two new buckets show up
+# after each other around midway through.
+load_with_nhcb 15s
+	testhistogram_bucket{le="0.01"} 0x10 1x10
+	testhistogram_bucket{le="0.02"} 0x9 1 2x10
+	testhistogram_bucket{le="0.05"} 1x9 2 3x10
+	testhistogram_bucket{le="0.1"} 3x9 4 5x10
+	testhistogram_bucket{le="+Inf"} 3x9 4 5x10
+	testhistogram_count 3x9 4 5x10
+	testhistogram_sum 10x20
+
+eval instant at 5m histogram_quantile(0.99, rate(testhistogram_bucket[5m]))
+	{} 0.043999999999999984
+
+# Should result in the same value as the classic quantile.
+eval instant at 5m histogram_quantile(0.99, rate(testhistogram[5m]))
+	{} 0.019799999999999998
+
+eval instant at 5m rate(testhistogram_bucket[5m])
+	{le="0.01"} 0.0033333333333333335
+	{le="0.02"} 0.006666666666666667
+	{le="0.05"} 0.007017543859649122
+	{le="0.1"} 0.007017543859649122
+	{le="+Inf"} 0.007017543859649122
+
+# Should have the same value projected from cumulative buckets to
+# absolute buckets.
+eval instant at 5m rate(testhistogram[5m])
+	{} {{schema:-53 count:0.007017543859649122 custom_values:[0.01 0.02 0.05 0.1] counter_reset_hint:gauge buckets:[0.003508771929824561 0.003508771929824561]}}


### PR DESCRIPTION
While working migrating some dashboards I noticed that some classic histogram and NHCB quantiles don't match up exactly.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] PromQL: handle empty buckets in NHCB rate calculation correctly.
```
