### PR TITLE
chore: Update docs to reflect new oauth parameters

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -779,11 +779,11 @@ client_id: <string>
 # It is mutually exclusive with `client_secret`.
 [ client_secret_file: <filename> ]
 
-# RSA key to sign JWT with. Only used if
+# Secret key to sign JWT with. Only used if
 # GrantType is set to "urn:ietf:params:oauth:grant-type:jwt-bearer".
 [ client_certificate_key: <secret> ]
 
-# Read the RSA key from a file.
+# Read the secret key from a file.
 # It is mutually exclusive with `client_certificate_key`.
 [ client_certificate_key_file: <filename> ]
 
@@ -791,7 +791,7 @@ client_id: <string>
 # GrantType is set to "urn:ietf:params:oauth:grant-type:jwt-bearer".
 [ client_certificate_key_id: <string> ]
 
-# RSA algorithm used to sign JWT token. Only used if
+# Signature algorithm used to sign JWT token. Only used if
 # GrantType is set to "urn:ietf:params:oauth:grant-type:jwt-bearer".
 # Default value is RS256 and valid values RS256, RS384, RS512
 [ signature_algorithm: <string> ]


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
During [this PR](https://github.com/prometheus/prometheus/pull/17592), new parameters were added as part of bumping the dependency but they weren't added to docs as well.

```release-notes
NONE
```
