### PR TITLE
Fix serialization for empty `ignoring()` in combination with `group_x()`

### DIFF
--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -147,12 +147,14 @@ func (node *BinaryExpr) ShortString() string {
 func (node *BinaryExpr) getMatchingStr() string {
 	matching := ""
 	vm := node.VectorMatching
-	if vm != nil && (len(vm.MatchingLabels) > 0 || vm.On) {
-		vmTag := "ignoring"
-		if vm.On {
-			vmTag = "on"
+	if vm != nil {
+		if len(vm.MatchingLabels) > 0 || vm.On || vm.Card == CardManyToOne || vm.Card == CardOneToMany {
+			vmTag := "ignoring"
+			if vm.On {
+				vmTag = "on"
+			}
+			matching = fmt.Sprintf(" %s (%s)", vmTag, strings.Join(vm.MatchingLabels, ", "))
 		}
-		matching = fmt.Sprintf(" %s (%s)", vmTag, strings.Join(vm.MatchingLabels, ", "))
 
 		if vm.Card == CardManyToOne || vm.Card == CardOneToMany {
 			vmCard := "right"

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -95,6 +95,25 @@ func TestExprString(t *testing.T) {
 			out: `a - c`,
 		},
 		{
+			// This is a bit of an odd case, but valid. If the user specifies ignoring() with
+			// no labels, it means that both label sets have to be exactly the same on both
+			// sides (except for the metric name). This is the same behavior as specifying
+			// no matching modifier at all, but if the user wants to include the metric name
+			// from either side in the output via group_x(__name__), they have to specify
+			// ignoring() explicitly to be able to do so, since the grammar does not allow
+			// grouping modifiers without either ignoring(...) or on(...). So we need to
+			// preserve the empty ignoring() clause in this case.
+			//
+			//   a - group_left(__name__) c             <--- Parse error
+			//   a - ignoring() group_left(__name__) c  <--- Valid
+			in:  `a - ignoring() group_left(__metric__) c`,
+			out: `a - ignoring () group_left (__metric__) c`,
+		},
+		{
+			in:  `a - ignoring() group_left c`,
+			out: `a - ignoring () group_left () c`,
+		},
+		{
 			in: `up > bool 0`,
 		},
 		{

--- a/web/ui/mantine-ui/src/promql/format.tsx
+++ b/web/ui/mantine-ui/src/promql/format.tsx
@@ -266,22 +266,19 @@ const formatNodeInternal = (
       let matching = <></>;
       let grouping = <></>;
       const vm = node.matching;
-      if (vm !== null && (vm.labels.length > 0 || vm.on)) {
-        if (vm.on) {
+      if (vm !== null) {
+        if (
+          vm.labels.length > 0 ||
+          vm.on ||
+          vm.card === vectorMatchCardinality.manyToOne ||
+          vm.card === vectorMatchCardinality.oneToMany
+        ) {
           matching = (
             <>
               {" "}
-              <span className="promql-keyword">on</span>
-              <span className="promql-paren">(</span>
-              {labelNameList(vm.labels)}
-              <span className="promql-paren">)</span>
-            </>
-          );
-        } else {
-          matching = (
-            <>
-              {" "}
-              <span className="promql-keyword">ignoring</span>
+              <span className="promql-keyword">
+                {vm.on ? "on" : "ignoring"}
+              </span>
               <span className="promql-paren">(</span>
               {labelNameList(vm.labels)}
               <span className="promql-paren">)</span>

--- a/web/ui/mantine-ui/src/promql/serialize.ts
+++ b/web/ui/mantine-ui/src/promql/serialize.ts
@@ -136,11 +136,14 @@ const serializeNode = (
       let matching = "";
       let grouping = "";
       const vm = node.matching;
-      if (vm !== null && (vm.labels.length > 0 || vm.on)) {
-        if (vm.on) {
-          matching = ` on(${labelNameList(vm.labels)})`;
-        } else {
-          matching = ` ignoring(${labelNameList(vm.labels)})`;
+      if (vm !== null) {
+        if (
+          vm.labels.length > 0 ||
+          vm.on ||
+          vm.card === vectorMatchCardinality.manyToOne ||
+          vm.card === vectorMatchCardinality.oneToMany
+        ) {
+          matching = ` ${vm.on ? "on" : "ignoring"}(${labelNameList(vm.labels)})`;
         }
 
         if (

--- a/web/ui/mantine-ui/src/promql/serializeAndFormat.test.ts
+++ b/web/ui/mantine-ui/src/promql/serializeAndFormat.test.ts
@@ -192,8 +192,7 @@ describe("serializeNode and formatNode", () => {
           anchored: false,
           smoothed: false,
         },
-        output:
-          '{label1="value1"}',
+        output: '{label1="value1"}',
       },
 
       // Anchored and smoothed modifiers.
@@ -722,6 +721,46 @@ describe("serializeNode and formatNode", () => {
         output: "… + ignoring(label1, label2) …",
         prettyOutput: `  …
 + ignoring(label1, label2)
+  …`,
+      },
+      {
+        // Empty ignoring() without group modifiers can be stripped away.
+        node: {
+          type: nodeType.binaryExpr,
+          op: binaryOperatorType.add,
+          lhs: { type: nodeType.placeholder, children: [] },
+          rhs: { type: nodeType.placeholder, children: [] },
+          matching: {
+            card: vectorMatchCardinality.oneToOne,
+            labels: [],
+            on: false,
+            include: [],
+          },
+          bool: false,
+        },
+        output: "… + …",
+        prettyOutput: `  …
++
+  …`,
+      },
+      {
+        // Empty ignoring() with group modifiers may not be stripped away.
+        node: {
+          type: nodeType.binaryExpr,
+          op: binaryOperatorType.add,
+          lhs: { type: nodeType.placeholder, children: [] },
+          rhs: { type: nodeType.placeholder, children: [] },
+          matching: {
+            card: vectorMatchCardinality.manyToOne,
+            labels: [],
+            on: false,
+            include: ["__name__"],
+          },
+          bool: false,
+        },
+        output: "… + ignoring() group_left(__name__) …",
+        prettyOutput: `  …
++ ignoring() group_left(__name__)
   …`,
       },
       {


### PR DESCRIPTION
Currently both the backend and frontend printers/formatters/serializers incorrectly transform the following expression:

```
up * ignoring() group_left(__name__) node_boot_time_seconds
```

...into:

```
up * node_boot_time_seconds
```

...which yields a different result (including the metric name in the result vs. no metric name).

We need to keep empty `ignoring()` modifiers if there is a grouping modifier present.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] PromQL: Fix serialization for empty `ignoring()` clause in combination with grouping modifiers
```
