### PR TITLE
chore: add --pull flag to Docker build commands

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -220,7 +220,7 @@ common-docker-repo-name:
 .PHONY: common-docker $(BUILD_DOCKER_ARCHS)
 common-docker: $(BUILD_DOCKER_ARCHS)
 $(BUILD_DOCKER_ARCHS): common-docker-%:
-	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)" \
+	docker build --pull -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)" \
 		-f $(DOCKERFILE_PATH) \
 		--build-arg ARCH="$*" \
 		--build-arg OS="linux" \


### PR DESCRIPTION
- Updated Docker build commands to include the `--pull` flag.
- Ensures that the latest base images are always pulled during the build process.
- Base image remains busybox, the image size is small, and pulling it each time should not impose a significant burden.

#### Which issue(s) does the PR fix:
https://github.com/prometheus-community/postgres_exporter/issues/1225


#### Does this PR introduce a user-facing change?

```release-notes
NONE
```
