### PR TITLE
web/api: Add maximum limit validation to TSDB status endpoint

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -1346,7 +1346,7 @@ GET /api/v1/status/tsdb
 ```
 URL query parameters:
 
-- `limit=<number>`: Limit the number of returned items to a given number for each set of statistics. By default, 10 items are returned.
+- `limit=<number>`: Limit the number of returned items to a given number for each set of statistics. By default, 10 items are returned. The maximum allowed limit is 10000.
 
 The `data` section of the query result consists of:
 

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1837,11 +1837,15 @@ func (api *API) serveTSDBBlocks(*http.Request) apiFuncResult {
 }
 
 func (api *API) serveTSDBStatus(r *http.Request) apiFuncResult {
+	const maxTSDBLimit = 10000
 	limit := 10
 	if s := r.FormValue("limit"); s != "" {
 		var err error
 		if limit, err = strconv.Atoi(s); err != nil || limit < 1 {
 			return apiFuncResult{nil, &apiError{errorBadData, errors.New("limit must be a positive number")}, nil, nil}
+		}
+		if limit > maxTSDBLimit {
+			return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("limit must not exceed %d", maxTSDBLimit)}, nil, nil}
 		}
 	}
 	s, err := api.db.Stats(labels.MetricName, limit)

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -4465,6 +4465,18 @@ func TestTSDBStatus(t *testing.T) {
 			values:   map[string][]string{"limit": {"0"}},
 			errType:  errorBadData,
 		},
+		{
+			db:       tsdb,
+			endpoint: tsdbStatusAPI,
+			values:   map[string][]string{"limit": {"10000"}},
+			errType:  errorNone,
+		},
+		{
+			db:       tsdb,
+			endpoint: tsdbStatusAPI,
+			values:   map[string][]string{"limit": {"10001"}},
+			errType:  errorBadData,
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			api := &API{db: tc.db, gatherer: prometheus.DefaultGatherer}


### PR DESCRIPTION
Add a maximum limit of 10,000 to the TSDB status endpoint to prevent resource exhaustion from excessively large limit values, as we preallocate []Stat for up to the limit:

https://github.com/prometheus/prometheus/blob/0279e14d4a1623e4cef3eac2b1c233cfb9546012/tsdb/index/postingsstats.go#L37

Note that the endpoint acquires a cardinality mutex during stats calculation, so this can not be run in parallel.

cc @GiedriusS @bwplotka Thanos might want to adopt the same limit.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[CHANGE] API: Add maximum limit of 10,000 sets of statistics to TSDB status endpoint
```
