### PR TITLE
PromQL: Fix insufficient cardinality checking for filter ops

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2936,17 +2936,15 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 		if info != nil {
 			lastErr = info
 		}
-		switch {
-		case returnBool:
+		if returnBool {
 			histogramValue = nil
 			if keep {
 				floatValue = 1.0
 			} else {
 				floatValue = 0.0
 			}
-		case !keep:
-			continue
 		}
+
 		metric := resultMetric(ls.Metric, rs.Metric, op, matching, enh)
 		if !ev.enableDelayedNameRemoval && returnBool {
 			metric = metric.DropReserved(schema.IsMetadataLabel)
@@ -2970,6 +2968,10 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 				ev.errorf("multiple matches for labels: grouping labels must ensure unique matches")
 			}
 			insertedSigs[insertSig] = struct{}{}
+		}
+
+		if !keep && !returnBool {
+			continue
 		}
 
 		enh.Out = append(enh.Out, Sample{

--- a/promql/promqltest/testdata/operators.test
+++ b/promql/promqltest/testdata/operators.test
@@ -316,6 +316,27 @@ eval instant at 5m http_requests_histogram == http_requests_histogram
 eval instant at 5m http_requests_histogram != http_requests_histogram
     expect no_info
 
+clear
+
+# Check that we track many-to-one vector matching errors even when all but 0 or 1
+# series on the "many" side are filtered away.
+load 5m
+  many_side{label="foo",job="test"} 0
+  many_side{label="bar",job="test"} 1
+  one_side{job="test"} 1
+
+# Check 0 series surviving the filtering producing an error.
+eval instant at 0m many_side > on(job) one_side
+  expect fail
+
+# Check 1 series surviving the filtering producing an error.
+eval instant at 0m many_side >= on(job) one_side
+  expect fail
+
+# Check 2 series surviving the filtering producing an error.
+eval instant at 0m many_side <= on(job) one_side
+  expect fail
+
 # group_left/group_right.
 
 clear


### PR DESCRIPTION
Generally, binary operations between two vectors fail if there is a many-to-one or one-to-many matching situation between series within a match group and no `group_left()` or `group_right()` modifier is present. For filter ops this is also generally the case, but there can be situations where multiple series on one side can match a single series on the other side, but only 0 or 1 of those multiple series remains after the filter operator has been applied. In this case, the PromQL engine does not produce a matching error, since it only tracks series matching for those series that survive the filtering. IMO this is incorrect behavior (which can also erratically make a query sometimes fail and sometimes succeed, depending on current sample values), and we should always produce an error if there is a match error prior to applying the filter op.

This PR ensures that we do the cardinality / match tracking independently of the result of the filter operation.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] PromQL: Fix insufficient cardinality checking for filter ops.
```
