### PR TITLE
tsdb(wal): st-per-sample initial code and benchmarks

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -200,7 +200,6 @@ func TestBasicContentNegotiation(t *testing.T) {
 }
 
 func TestSampleDelivery(t *testing.T) {
-	t.Parallel()
 	// Let's create an even number of send batches, so we don't run into the
 	// batch timeout case.
 	n := 3
@@ -409,7 +408,6 @@ func TestWALMetadataDelivery(t *testing.T) {
 }
 
 func TestSampleDeliveryTimeout(t *testing.T) {
-	t.Parallel()
 	for _, protoMsg := range []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType} {
 		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
 			// Let's send one less sample than batch size, and wait the timeout duration
@@ -2038,7 +2036,6 @@ func TestIsSampleOld(t *testing.T) {
 
 // Simulates scenario in which remote write endpoint is down and a subset of samples is dropped due to age limit while backoffing.
 func TestSendSamplesWithBackoffWithSampleAgeLimit(t *testing.T) {
-	t.Parallel()
 	for _, protoMsg := range []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType} {
 		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
 			maxSamplesPerSend := 10

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -225,7 +225,7 @@ func TestCommit(t *testing.T) {
 			require.NoError(t, err)
 			walSeriesCount += len(series)
 
-		case record.Samples:
+		case record.Samples, record.SamplesV2:
 			var samples []record.RefSample
 			samples, err = dec.Samples(rec, samples)
 			require.NoError(t, err)
@@ -361,7 +361,7 @@ func TestRollback(t *testing.T) {
 			require.NoError(t, err)
 			walSeriesCount += len(series)
 
-		case record.Samples:
+		case record.Samples, record.SamplesV2:
 			var samples []record.RefSample
 			samples, err = dec.Samples(rec, samples)
 			require.NoError(t, err)
@@ -1344,7 +1344,7 @@ func readWALSamples(t *testing.T, walDir string) []walSample {
 			series, err := dec.Series(rec, nil)
 			require.NoError(t, err)
 			lastSeries = series[0]
-		case record.Samples:
+		case record.Samples, record.SamplesV2:
 			samples, err = dec.Samples(rec, samples[:0])
 			require.NoError(t, err)
 			for _, s := range samples {

--- a/tsdb/compression/compression.go
+++ b/tsdb/compression/compression.go
@@ -1,0 +1,130 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compression
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/golang/snappy"
+	"github.com/klauspost/compress/zstd"
+)
+
+// Type represents the compression type used for encoding and decoding data.
+type Type string
+
+const (
+	// None represents no compression case.
+	// None it's a default when Type is empty.
+	None Type = "none"
+	// Snappy represents snappy block format.
+	Snappy Type = "snappy"
+	// Zstd represents zstd compression.
+	Zstd Type = "zstd"
+)
+
+// Encoder provides compression encoding functionality for supported compression
+// types. It is agnostic to the content being compressed, operating on byte
+// slices of serialized data streams. The encoder maintains internal state for
+// Zstd compression and can handle multiple compression types including None,
+// Snappy, and Zstd.
+type Encoder struct {
+	w *zstd.Encoder
+}
+
+// NewEncoder creates a new Encoder. Returns an error if the zstd encoder cannot
+// be initialized.
+func NewEncoder() (*Encoder, error) {
+	e := &Encoder{}
+	w, err := zstd.NewWriter(nil)
+	if err != nil {
+		return nil, err
+	}
+	e.w = w
+	return e, nil
+}
+
+// Encode returns the encoded form of src for the given compression type. It also
+// returns the indicator if the compression was performed. Encode may skip
+// compressing for None type, but also when src is too large e.g. for Snappy block format.
+//
+// The buf is used as a buffer for returned encoding, and it must not overlap with
+// src. It is valid to pass a nil buf.
+func (e *Encoder) Encode(t Type, src, buf []byte) (_ []byte, compressed bool, err error) {
+	switch {
+	case len(src) == 0, t == "", t == None:
+		return src, false, nil
+	case t == Snappy:
+		// If MaxEncodedLen is less than 0 the record is too large to be compressed.
+		if snappy.MaxEncodedLen(len(src)) < 0 {
+			return src, false, nil
+		}
+
+		// The snappy library uses `len` to calculate if we need a new buffer.
+		// In order to allocate as few buffers as possible make the length
+		// equal to the capacity.
+		buf = buf[:cap(buf)]
+		return snappy.Encode(buf, src), true, nil
+	case t == Zstd:
+		if e == nil {
+			return nil, false, errors.New("zstd requested but encoder was not initialized with NewEncoder()")
+		}
+		return e.w.EncodeAll(src, buf[:0]), true, nil
+	default:
+		return nil, false, fmt.Errorf("unsupported compression type: %s", t)
+	}
+}
+
+// Decoder provides decompression functionality for supported compression types.
+// It is agnostic to the content being decompressed, operating on byte slices of
+// serialized data streams. The decoder maintains internal state for Zstd
+// decompression and can handle multiple compression types including None,
+// Snappy, and Zstd.
+type Decoder struct {
+	r *zstd.Decoder
+}
+
+// NewDecoder creates a new Decoder.
+func NewDecoder() *Decoder {
+	d := &Decoder{}
+
+	// Calling zstd.NewReader with a nil io.Reader and no options cannot return an error.
+	r, _ := zstd.NewReader(nil)
+	d.r = r
+	return d
+}
+
+// Decode returns the decoded form of src or error, given expected compression type.
+//
+// The buf is used as a buffer for the returned decoded entry, and it must not
+// overlap with src. It is valid to pass a nil buf.
+func (d *Decoder) Decode(t Type, src, buf []byte) (_ []byte, err error) {
+	switch {
+	case len(src) == 0, t == "", t == None:
+		return src, nil
+	case t == Snappy:
+		// The snappy library uses `len` to calculate if we need a new buffer.
+		// In order to allocate as few buffers as possible make the length
+		// equal to the capacity.
+		buf = buf[:cap(buf)]
+		return snappy.Decode(buf, src)
+	case t == Zstd:
+		if d == nil {
+			return nil, errors.New("zstd requested but Decoder was not initialized with NewDecoder()")
+		}
+		return d.r.DecodeAll(src, buf[:0])
+	default:
+		return nil, fmt.Errorf("unsupported compression type: %s", t)
+	}
+}

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -395,7 +395,7 @@ func TestDataNotAvailableAfterRollback(t *testing.T) {
 			require.NoError(t, err)
 			walSeriesCount += len(series)
 
-		case record.Samples:
+		case record.Samples, record.SamplesV2:
 			var samples []record.RefSample
 			samples, err = dec.Samples(rec, samples)
 			require.NoError(t, err)
@@ -1170,24 +1170,25 @@ func TestWALReplayRaceOnSamplesLoggedBeforeSeries(t *testing.T) {
 
 	// We test both with few and many samples appended after series creation. If samples are < 120 then there's no
 	// mmap-ed chunk, otherwise there's at least 1 mmap-ed chunk when replaying the WAL.
-	for _, numSamplesAfterSeriesCreation := range []int{1, 1000} {
-		for run := 1; run <= numRuns; run++ {
-			t.Run(fmt.Sprintf("samples after series creation = %d, run = %d", numSamplesAfterSeriesCreation, run), func(t *testing.T) {
-				testWALReplayRaceOnSamplesLoggedBeforeSeries(t, numSamplesBeforeSeriesCreation, numSamplesAfterSeriesCreation)
-			})
+	for _, enableStStorage := range []bool{false, true} {
+		for _, numSamplesAfterSeriesCreation := range []int{1, 1000} {
+			for run := 1; run <= numRuns; run++ {
+				t.Run(fmt.Sprintf("samples after series creation = %d, run = %d, stStorage=%v", numSamplesAfterSeriesCreation, run, enableStStorage), func(t *testing.T) {
+					testWALReplayRaceOnSamplesLoggedBeforeSeries(t, numSamplesBeforeSeriesCreation, numSamplesAfterSeriesCreation, enableStStorage)
+				})
+			}
 		}
 	}
 }
 
-func testWALReplayRaceOnSamplesLoggedBeforeSeries(t *testing.T, numSamplesBeforeSeriesCreation, numSamplesAfterSeriesCreation int) {
+func testWALReplayRaceOnSamplesLoggedBeforeSeries(t *testing.T, numSamplesBeforeSeriesCreation, numSamplesAfterSeriesCreation int, enableStStorage bool) {
 	const numSeries = 1000
-
 	db := newTestDB(t)
 	db.DisableCompactions()
 
 	for seriesRef := 1; seriesRef <= numSeries; seriesRef++ {
 		// Log samples before the series is logged to the WAL.
-		var enc record.Encoder
+		enc := record.Encoder{EnableSTStorage: enableStStorage}
 		var samples []record.RefSample
 
 		for ts := range numSamplesBeforeSeriesCreation {
@@ -1551,139 +1552,143 @@ func TestRetentionDurationMetric(t *testing.T) {
 
 func TestSizeRetention(t *testing.T) {
 	t.Parallel()
-	opts := DefaultOptions()
-	opts.OutOfOrderTimeWindow = 100
-	db := newTestDB(t, withOpts(opts), withRngs(100))
+	for _, enableStStorage := range []bool{false, true} {
+		t.Run("enableStStorage="+strconv.FormatBool(enableStStorage), func(t *testing.T) {
+			opts := DefaultOptions()
+			opts.OutOfOrderTimeWindow = 100
+			db := newTestDB(t, withOpts(opts), withRngs(100))
 
-	blocks := []*BlockMeta{
-		{MinTime: 100, MaxTime: 200}, // Oldest block
-		{MinTime: 200, MaxTime: 300},
-		{MinTime: 300, MaxTime: 400},
-		{MinTime: 400, MaxTime: 500},
-		{MinTime: 500, MaxTime: 600}, // Newest Block
-	}
+			blocks := []*BlockMeta{
+				{MinTime: 100, MaxTime: 200}, // Oldest block
+				{MinTime: 200, MaxTime: 300},
+				{MinTime: 300, MaxTime: 400},
+				{MinTime: 400, MaxTime: 500},
+				{MinTime: 500, MaxTime: 600}, // Newest Block
+			}
 
-	for _, m := range blocks {
-		createBlock(t, db.Dir(), genSeries(100, 10, m.MinTime, m.MaxTime))
-	}
+			for _, m := range blocks {
+				createBlock(t, db.Dir(), genSeries(100, 10, m.MinTime, m.MaxTime))
+			}
 
-	headBlocks := []*BlockMeta{
-		{MinTime: 700, MaxTime: 800},
-	}
+			headBlocks := []*BlockMeta{
+				{MinTime: 700, MaxTime: 800},
+			}
 
-	// Add some data to the WAL.
-	headApp := db.Head().Appender(context.Background())
-	var aSeries labels.Labels
-	var it chunkenc.Iterator
-	for _, m := range headBlocks {
-		series := genSeries(100, 10, m.MinTime, m.MaxTime+1)
-		for _, s := range series {
-			aSeries = s.Labels()
-			it = s.Iterator(it)
-			for it.Next() == chunkenc.ValFloat {
-				tim, v := it.At()
-				_, err := headApp.Append(0, s.Labels(), tim, v)
+			// Add some data to the WAL.
+			headApp := db.Head().Appender(context.Background())
+			var aSeries labels.Labels
+			var it chunkenc.Iterator
+			for _, m := range headBlocks {
+				series := genSeries(100, 10, m.MinTime, m.MaxTime+1)
+				for _, s := range series {
+					aSeries = s.Labels()
+					it = s.Iterator(it)
+					for it.Next() == chunkenc.ValFloat {
+						tim, v := it.At()
+						_, err := headApp.Append(0, s.Labels(), tim, v)
+						require.NoError(t, err)
+					}
+					require.NoError(t, it.Err())
+				}
+			}
+			require.NoError(t, headApp.Commit())
+			db.Head().mmapHeadChunks()
+
+			require.Eventually(t, func() bool {
+				return db.Head().chunkDiskMapper.IsQueueEmpty()
+			}, 2*time.Second, 100*time.Millisecond)
+
+			// Test that registered size matches the actual disk size.
+			require.NoError(t, db.reloadBlocks())                               // Reload the db to register the new db size.
+			require.Len(t, db.Blocks(), len(blocks))                            // Ensure all blocks are registered.
+			blockSize := int64(prom_testutil.ToFloat64(db.metrics.blocksBytes)) // Use the actual internal metrics.
+			walSize, err := db.Head().wal.Size()
+			require.NoError(t, err)
+			cdmSize, err := db.Head().chunkDiskMapper.Size()
+			require.NoError(t, err)
+			require.NotZero(t, cdmSize)
+			// Expected size should take into account block size + WAL size + Head
+			// chunks size
+			expSize := blockSize + walSize + cdmSize
+			actSize, err := fileutil.DirSize(db.Dir())
+			require.NoError(t, err)
+			require.Equal(t, expSize, actSize, "registered size doesn't match actual disk size")
+
+			// Create a WAL checkpoint, and compare sizes.
+			first, last, err := wlog.Segments(db.Head().wal.Dir())
+			require.NoError(t, err)
+			_, err = wlog.Checkpoint(promslog.NewNopLogger(), db.Head().wal, first, last-1, func(chunks.HeadSeriesRef) bool { return false }, 0, enableStStorage)
+			require.NoError(t, err)
+			blockSize = int64(prom_testutil.ToFloat64(db.metrics.blocksBytes)) // Use the actual internal metrics.
+			walSize, err = db.Head().wal.Size()
+			require.NoError(t, err)
+			cdmSize, err = db.Head().chunkDiskMapper.Size()
+			require.NoError(t, err)
+			require.NotZero(t, cdmSize)
+			expSize = blockSize + walSize + cdmSize
+			actSize, err = fileutil.DirSize(db.Dir())
+			require.NoError(t, err)
+			require.Equal(t, expSize, actSize, "registered size doesn't match actual disk size")
+
+			// Truncate Chunk Disk Mapper and compare sizes.
+			require.NoError(t, db.Head().chunkDiskMapper.Truncate(900))
+			cdmSize, err = db.Head().chunkDiskMapper.Size()
+			require.NoError(t, err)
+			require.NotZero(t, cdmSize)
+			expSize = blockSize + walSize + cdmSize
+			actSize, err = fileutil.DirSize(db.Dir())
+			require.NoError(t, err)
+			require.Equal(t, expSize, actSize, "registered size doesn't match actual disk size")
+
+			// Add some out of order samples to check the size of WBL.
+			headApp = db.Head().Appender(context.Background())
+			for ts := int64(750); ts < 800; ts++ {
+				_, err := headApp.Append(0, aSeries, ts, float64(ts))
 				require.NoError(t, err)
 			}
-			require.NoError(t, it.Err())
-		}
+			require.NoError(t, headApp.Commit())
+
+			walSize, err = db.Head().wal.Size()
+			require.NoError(t, err)
+			wblSize, err := db.Head().wbl.Size()
+			require.NoError(t, err)
+			require.NotZero(t, wblSize)
+			cdmSize, err = db.Head().chunkDiskMapper.Size()
+			require.NoError(t, err)
+			expSize = blockSize + walSize + wblSize + cdmSize
+			actSize, err = fileutil.DirSize(db.Dir())
+			require.NoError(t, err)
+			require.Equal(t, expSize, actSize, "registered size doesn't match actual disk size")
+
+			// Decrease the max bytes limit so that a delete is triggered.
+			// Check total size, total count and check that the oldest block was deleted.
+			firstBlockSize := db.Blocks()[0].Size()
+			sizeLimit := actSize - firstBlockSize
+			db.opts.MaxBytes = sizeLimit          // Set the new db size limit one block smaller that the actual size.
+			require.NoError(t, db.reloadBlocks()) // Reload the db to register the new db size.
+
+			expBlocks := blocks[1:]
+			actBlocks := db.Blocks()
+			blockSize = int64(prom_testutil.ToFloat64(db.metrics.blocksBytes))
+			walSize, err = db.Head().wal.Size()
+			require.NoError(t, err)
+			cdmSize, err = db.Head().chunkDiskMapper.Size()
+			require.NoError(t, err)
+			require.NotZero(t, cdmSize)
+			// Expected size should take into account block size + WAL size + WBL size
+			expSize = blockSize + walSize + wblSize + cdmSize
+			actRetentionCount := int(prom_testutil.ToFloat64(db.metrics.sizeRetentionCount))
+			actSize, err = fileutil.DirSize(db.Dir())
+			require.NoError(t, err)
+
+			require.Equal(t, 1, actRetentionCount, "metric retention count mismatch")
+			require.Equal(t, expSize, actSize, "metric db size doesn't match actual disk size")
+			require.LessOrEqual(t, expSize, sizeLimit, "actual size (%v) is expected to be less than or equal to limit (%v)", expSize, sizeLimit)
+			require.Len(t, actBlocks, len(blocks)-1, "new block count should be decreased from:%v to:%v", len(blocks), len(blocks)-1)
+			require.Equal(t, expBlocks[0].MaxTime, actBlocks[0].meta.MaxTime, "maxT mismatch of the first block")
+			require.Equal(t, expBlocks[len(expBlocks)-1].MaxTime, actBlocks[len(actBlocks)-1].meta.MaxTime, "maxT mismatch of the last block")
+		})
 	}
-	require.NoError(t, headApp.Commit())
-	db.Head().mmapHeadChunks()
-
-	require.Eventually(t, func() bool {
-		return db.Head().chunkDiskMapper.IsQueueEmpty()
-	}, 2*time.Second, 100*time.Millisecond)
-
-	// Test that registered size matches the actual disk size.
-	require.NoError(t, db.reloadBlocks())                               // Reload the db to register the new db size.
-	require.Len(t, db.Blocks(), len(blocks))                            // Ensure all blocks are registered.
-	blockSize := int64(prom_testutil.ToFloat64(db.metrics.blocksBytes)) // Use the actual internal metrics.
-	walSize, err := db.Head().wal.Size()
-	require.NoError(t, err)
-	cdmSize, err := db.Head().chunkDiskMapper.Size()
-	require.NoError(t, err)
-	require.NotZero(t, cdmSize)
-	// Expected size should take into account block size + WAL size + Head
-	// chunks size
-	expSize := blockSize + walSize + cdmSize
-	actSize, err := fileutil.DirSize(db.Dir())
-	require.NoError(t, err)
-	require.Equal(t, expSize, actSize, "registered size doesn't match actual disk size")
-
-	// Create a WAL checkpoint, and compare sizes.
-	first, last, err := wlog.Segments(db.Head().wal.Dir())
-	require.NoError(t, err)
-	_, err = wlog.Checkpoint(promslog.NewNopLogger(), db.Head().wal, first, last-1, func(chunks.HeadSeriesRef) bool { return false }, 0)
-	require.NoError(t, err)
-	blockSize = int64(prom_testutil.ToFloat64(db.metrics.blocksBytes)) // Use the actual internal metrics.
-	walSize, err = db.Head().wal.Size()
-	require.NoError(t, err)
-	cdmSize, err = db.Head().chunkDiskMapper.Size()
-	require.NoError(t, err)
-	require.NotZero(t, cdmSize)
-	expSize = blockSize + walSize + cdmSize
-	actSize, err = fileutil.DirSize(db.Dir())
-	require.NoError(t, err)
-	require.Equal(t, expSize, actSize, "registered size doesn't match actual disk size")
-
-	// Truncate Chunk Disk Mapper and compare sizes.
-	require.NoError(t, db.Head().chunkDiskMapper.Truncate(900))
-	cdmSize, err = db.Head().chunkDiskMapper.Size()
-	require.NoError(t, err)
-	require.NotZero(t, cdmSize)
-	expSize = blockSize + walSize + cdmSize
-	actSize, err = fileutil.DirSize(db.Dir())
-	require.NoError(t, err)
-	require.Equal(t, expSize, actSize, "registered size doesn't match actual disk size")
-
-	// Add some out of order samples to check the size of WBL.
-	headApp = db.Head().Appender(context.Background())
-	for ts := int64(750); ts < 800; ts++ {
-		_, err := headApp.Append(0, aSeries, ts, float64(ts))
-		require.NoError(t, err)
-	}
-	require.NoError(t, headApp.Commit())
-
-	walSize, err = db.Head().wal.Size()
-	require.NoError(t, err)
-	wblSize, err := db.Head().wbl.Size()
-	require.NoError(t, err)
-	require.NotZero(t, wblSize)
-	cdmSize, err = db.Head().chunkDiskMapper.Size()
-	require.NoError(t, err)
-	expSize = blockSize + walSize + wblSize + cdmSize
-	actSize, err = fileutil.DirSize(db.Dir())
-	require.NoError(t, err)
-	require.Equal(t, expSize, actSize, "registered size doesn't match actual disk size")
-
-	// Decrease the max bytes limit so that a delete is triggered.
-	// Check total size, total count and check that the oldest block was deleted.
-	firstBlockSize := db.Blocks()[0].Size()
-	sizeLimit := actSize - firstBlockSize
-	db.opts.MaxBytes = sizeLimit          // Set the new db size limit one block smaller that the actual size.
-	require.NoError(t, db.reloadBlocks()) // Reload the db to register the new db size.
-
-	expBlocks := blocks[1:]
-	actBlocks := db.Blocks()
-	blockSize = int64(prom_testutil.ToFloat64(db.metrics.blocksBytes))
-	walSize, err = db.Head().wal.Size()
-	require.NoError(t, err)
-	cdmSize, err = db.Head().chunkDiskMapper.Size()
-	require.NoError(t, err)
-	require.NotZero(t, cdmSize)
-	// Expected size should take into account block size + WAL size + WBL size
-	expSize = blockSize + walSize + wblSize + cdmSize
-	actRetentionCount := int(prom_testutil.ToFloat64(db.metrics.sizeRetentionCount))
-	actSize, err = fileutil.DirSize(db.Dir())
-	require.NoError(t, err)
-
-	require.Equal(t, 1, actRetentionCount, "metric retention count mismatch")
-	require.Equal(t, expSize, actSize, "metric db size doesn't match actual disk size")
-	require.LessOrEqual(t, expSize, sizeLimit, "actual size (%v) is expected to be less than or equal to limit (%v)", expSize, sizeLimit)
-	require.Len(t, actBlocks, len(blocks)-1, "new block count should be decreased from:%v to:%v", len(blocks), len(blocks)-1)
-	require.Equal(t, expBlocks[0].MaxTime, actBlocks[0].meta.MaxTime, "maxT mismatch of the first block")
-	require.Equal(t, expBlocks[len(expBlocks)-1].MaxTime, actBlocks[len(actBlocks)-1].meta.MaxTime, "maxT mismatch of the last block")
 }
 
 func TestSizeRetentionMetric(t *testing.T) {
@@ -2072,33 +2077,36 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		require.Equal(t, int64(1000), db.head.MaxTime())
 		require.True(t, db.head.initialized())
 	})
-	t.Run("wal-only", func(t *testing.T) {
-		dir := t.TempDir()
 
-		require.NoError(t, os.MkdirAll(path.Join(dir, "wal"), 0o777))
-		w, err := wlog.New(nil, nil, path.Join(dir, "wal"), compression.None)
-		require.NoError(t, err)
+	for _, enableStStorage := range []bool{false, true} {
+		t.Run("wal-only-st-"+strconv.FormatBool(enableStStorage), func(t *testing.T) {
+			dir := t.TempDir()
 
-		var enc record.Encoder
-		err = w.Log(
-			enc.Series([]record.RefSeries{
-				{Ref: 123, Labels: labels.FromStrings("a", "1")},
-				{Ref: 124, Labels: labels.FromStrings("a", "2")},
-			}, nil),
-			enc.Samples([]record.RefSample{
-				{Ref: 123, T: 5000, V: 1},
-				{Ref: 124, T: 15000, V: 1},
-			}, nil),
-		)
-		require.NoError(t, err)
-		require.NoError(t, w.Close())
+			require.NoError(t, os.MkdirAll(path.Join(dir, "wal"), 0o777))
+			w, err := wlog.New(nil, nil, path.Join(dir, "wal"), compression.None)
+			require.NoError(t, err)
 
-		db := newTestDB(t, withDir(dir))
+			enc := record.Encoder{EnableSTStorage: enableStStorage}
+			err = w.Log(
+				enc.Series([]record.RefSeries{
+					{Ref: 123, Labels: labels.FromStrings("a", "1")},
+					{Ref: 124, Labels: labels.FromStrings("a", "2")},
+				}, nil),
+				enc.Samples([]record.RefSample{
+					{Ref: 123, T: 5000, V: 1},
+					{Ref: 124, T: 15000, V: 1},
+				}, nil),
+			)
+			require.NoError(t, err)
+			require.NoError(t, w.Close())
 
-		require.Equal(t, int64(5000), db.head.MinTime())
-		require.Equal(t, int64(15000), db.head.MaxTime())
-		require.True(t, db.head.initialized())
-	})
+			db := newTestDB(t, withDir(dir))
+
+			require.Equal(t, int64(5000), db.head.MinTime())
+			require.Equal(t, int64(15000), db.head.MaxTime())
+			require.True(t, db.head.initialized())
+		})
+	}
 	t.Run("existing-block", func(t *testing.T) {
 		dir := t.TempDir()
 
@@ -2110,37 +2118,40 @@ func TestInitializeHeadTimestamp(t *testing.T) {
 		require.Equal(t, int64(2000), db.head.MaxTime())
 		require.True(t, db.head.initialized())
 	})
-	t.Run("existing-block-and-wal", func(t *testing.T) {
-		dir := t.TempDir()
 
-		createBlock(t, dir, genSeries(1, 1, 1000, 6000))
+	for _, enableStStorage := range []bool{false, true} {
+		t.Run("existing-block-and-wal,enableStStorage="+strconv.FormatBool(enableStStorage), func(t *testing.T) {
+			dir := t.TempDir()
 
-		require.NoError(t, os.MkdirAll(path.Join(dir, "wal"), 0o777))
-		w, err := wlog.New(nil, nil, path.Join(dir, "wal"), compression.None)
-		require.NoError(t, err)
+			createBlock(t, dir, genSeries(1, 1, 1000, 6000))
 
-		var enc record.Encoder
-		err = w.Log(
-			enc.Series([]record.RefSeries{
-				{Ref: 123, Labels: labels.FromStrings("a", "1")},
-				{Ref: 124, Labels: labels.FromStrings("a", "2")},
-			}, nil),
-			enc.Samples([]record.RefSample{
-				{Ref: 123, T: 5000, V: 1},
-				{Ref: 124, T: 15000, V: 1},
-			}, nil),
-		)
-		require.NoError(t, err)
-		require.NoError(t, w.Close())
+			require.NoError(t, os.MkdirAll(path.Join(dir, "wal"), 0o777))
+			w, err := wlog.New(nil, nil, path.Join(dir, "wal"), compression.None)
+			require.NoError(t, err)
 
-		db := newTestDB(t, withDir(dir))
+			enc := record.Encoder{EnableSTStorage: enableStStorage}
+			err = w.Log(
+				enc.Series([]record.RefSeries{
+					{Ref: 123, Labels: labels.FromStrings("a", "1")},
+					{Ref: 124, Labels: labels.FromStrings("a", "2")},
+				}, nil),
+				enc.Samples([]record.RefSample{
+					{Ref: 123, T: 5000, V: 1},
+					{Ref: 124, T: 15000, V: 1},
+				}, nil),
+			)
+			require.NoError(t, err)
+			require.NoError(t, w.Close())
 
-		require.Equal(t, int64(6000), db.head.MinTime())
-		require.Equal(t, int64(15000), db.head.MaxTime())
-		require.True(t, db.head.initialized())
-		// Check that old series has been GCed.
-		require.Equal(t, 1.0, prom_testutil.ToFloat64(db.head.metrics.series))
-	})
+			db := newTestDB(t, withDir(dir))
+
+			require.Equal(t, int64(6000), db.head.MinTime())
+			require.Equal(t, int64(15000), db.head.MaxTime())
+			require.True(t, db.head.initialized())
+			// Check that old series has been GCed.
+			require.Equal(t, 1.0, prom_testutil.ToFloat64(db.head.metrics.series))
+		})
+	}
 }
 
 func TestNoEmptyBlocks(t *testing.T) {
@@ -4531,7 +4542,7 @@ func testOOOWALWrite(t *testing.T,
 				series, err := dec.Series(rec, nil)
 				require.NoError(t, err)
 				records = append(records, series)
-			case record.Samples:
+			case record.Samples, record.SamplesV2:
 				samples, err := dec.Samples(rec, nil)
 				require.NoError(t, err)
 				records = append(records, samples)
@@ -4692,102 +4703,106 @@ func TestMetadataCheckpointingOnlyKeepsLatestEntry(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	ctx := context.Background()
-	numSamples := 10000
-	hb, w := newTestHead(t, int64(numSamples)*10, compression.None, false)
+	for _, enableStStorage := range []bool{false, true} {
+		t.Run("enableStStorage="+strconv.FormatBool(enableStStorage), func(t *testing.T) {
+			ctx := context.Background()
+			numSamples := 10000
+			hb, w := newTestHead(t, int64(numSamples)*10, compression.None, false)
 
-	// Add some series so we can append metadata to them.
-	app := hb.Appender(ctx)
-	s1 := labels.FromStrings("a", "b")
-	s2 := labels.FromStrings("c", "d")
-	s3 := labels.FromStrings("e", "f")
-	s4 := labels.FromStrings("g", "h")
+			// Add some series so we can append metadata to them.
+			app := hb.Appender(ctx)
+			s1 := labels.FromStrings("a", "b")
+			s2 := labels.FromStrings("c", "d")
+			s3 := labels.FromStrings("e", "f")
+			s4 := labels.FromStrings("g", "h")
 
-	for _, s := range []labels.Labels{s1, s2, s3, s4} {
-		_, err := app.Append(0, s, 0, 0)
-		require.NoError(t, err)
+			for _, s := range []labels.Labels{s1, s2, s3, s4} {
+				_, err := app.Append(0, s, 0, 0)
+				require.NoError(t, err)
+			}
+			require.NoError(t, app.Commit())
+
+			// Add a first round of metadata to the first three series.
+			// Re-take the Appender, as the previous Commit will have it closed.
+			m1 := metadata.Metadata{Type: "gauge", Unit: "unit_1", Help: "help_1"}
+			m2 := metadata.Metadata{Type: "gauge", Unit: "unit_2", Help: "help_2"}
+			m3 := metadata.Metadata{Type: "gauge", Unit: "unit_3", Help: "help_3"}
+			m4 := metadata.Metadata{Type: "gauge", Unit: "unit_4", Help: "help_4"}
+			app = hb.Appender(ctx)
+			updateMetadata(t, app, s1, m1)
+			updateMetadata(t, app, s2, m2)
+			updateMetadata(t, app, s3, m3)
+			updateMetadata(t, app, s4, m4)
+			require.NoError(t, app.Commit())
+
+			// Update metadata for first series.
+			m5 := metadata.Metadata{Type: "counter", Unit: "unit_5", Help: "help_5"}
+			app = hb.Appender(ctx)
+			updateMetadata(t, app, s1, m5)
+			require.NoError(t, app.Commit())
+
+			// Switch back-and-forth metadata for second series.
+			// Since it ended on a new metadata record, we expect a single new entry.
+			m6 := metadata.Metadata{Type: "counter", Unit: "unit_6", Help: "help_6"}
+
+			app = hb.Appender(ctx)
+			updateMetadata(t, app, s2, m6)
+			require.NoError(t, app.Commit())
+
+			app = hb.Appender(ctx)
+			updateMetadata(t, app, s2, m2)
+			require.NoError(t, app.Commit())
+
+			app = hb.Appender(ctx)
+			updateMetadata(t, app, s2, m6)
+			require.NoError(t, app.Commit())
+
+			app = hb.Appender(ctx)
+			updateMetadata(t, app, s2, m2)
+			require.NoError(t, app.Commit())
+
+			app = hb.Appender(ctx)
+			updateMetadata(t, app, s2, m6)
+			require.NoError(t, app.Commit())
+
+			// Let's create a checkpoint.
+			first, last, err := wlog.Segments(w.Dir())
+			require.NoError(t, err)
+			keep := func(id chunks.HeadSeriesRef) bool {
+				return id != 3
+			}
+			_, err = wlog.Checkpoint(promslog.NewNopLogger(), w, first, last-1, keep, 0, enableStStorage)
+			require.NoError(t, err)
+
+			// Confirm there's been a checkpoint.
+			cdir, _, err := wlog.LastCheckpoint(w.Dir())
+			require.NoError(t, err)
+
+			// Read in checkpoint and WAL.
+			recs := readTestWAL(t, cdir)
+			var gotMetadataBlocks [][]record.RefMetadata
+			for _, rec := range recs {
+				if mr, ok := rec.([]record.RefMetadata); ok {
+					gotMetadataBlocks = append(gotMetadataBlocks, mr)
+				}
+			}
+
+			// There should only be 1 metadata block present, with only the latest
+			// metadata kept around.
+			wantMetadata := []record.RefMetadata{
+				{Ref: 1, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
+				{Ref: 2, Type: record.GetMetricType(m6.Type), Unit: m6.Unit, Help: m6.Help},
+				{Ref: 4, Type: record.GetMetricType(m4.Type), Unit: m4.Unit, Help: m4.Help},
+			}
+			require.Len(t, gotMetadataBlocks, 1)
+			require.Len(t, gotMetadataBlocks[0], 3)
+			gotMetadataBlock := gotMetadataBlocks[0]
+
+			sort.Slice(gotMetadataBlock, func(i, j int) bool { return gotMetadataBlock[i].Ref < gotMetadataBlock[j].Ref })
+			require.Equal(t, wantMetadata, gotMetadataBlock)
+			require.NoError(t, hb.Close())
+		})
 	}
-	require.NoError(t, app.Commit())
-
-	// Add a first round of metadata to the first three series.
-	// Re-take the Appender, as the previous Commit will have it closed.
-	m1 := metadata.Metadata{Type: "gauge", Unit: "unit_1", Help: "help_1"}
-	m2 := metadata.Metadata{Type: "gauge", Unit: "unit_2", Help: "help_2"}
-	m3 := metadata.Metadata{Type: "gauge", Unit: "unit_3", Help: "help_3"}
-	m4 := metadata.Metadata{Type: "gauge", Unit: "unit_4", Help: "help_4"}
-	app = hb.Appender(ctx)
-	updateMetadata(t, app, s1, m1)
-	updateMetadata(t, app, s2, m2)
-	updateMetadata(t, app, s3, m3)
-	updateMetadata(t, app, s4, m4)
-	require.NoError(t, app.Commit())
-
-	// Update metadata for first series.
-	m5 := metadata.Metadata{Type: "counter", Unit: "unit_5", Help: "help_5"}
-	app = hb.Appender(ctx)
-	updateMetadata(t, app, s1, m5)
-	require.NoError(t, app.Commit())
-
-	// Switch back-and-forth metadata for second series.
-	// Since it ended on a new metadata record, we expect a single new entry.
-	m6 := metadata.Metadata{Type: "counter", Unit: "unit_6", Help: "help_6"}
-
-	app = hb.Appender(ctx)
-	updateMetadata(t, app, s2, m6)
-	require.NoError(t, app.Commit())
-
-	app = hb.Appender(ctx)
-	updateMetadata(t, app, s2, m2)
-	require.NoError(t, app.Commit())
-
-	app = hb.Appender(ctx)
-	updateMetadata(t, app, s2, m6)
-	require.NoError(t, app.Commit())
-
-	app = hb.Appender(ctx)
-	updateMetadata(t, app, s2, m2)
-	require.NoError(t, app.Commit())
-
-	app = hb.Appender(ctx)
-	updateMetadata(t, app, s2, m6)
-	require.NoError(t, app.Commit())
-
-	// Let's create a checkpoint.
-	first, last, err := wlog.Segments(w.Dir())
-	require.NoError(t, err)
-	keep := func(id chunks.HeadSeriesRef) bool {
-		return id != 3
-	}
-	_, err = wlog.Checkpoint(promslog.NewNopLogger(), w, first, last-1, keep, 0)
-	require.NoError(t, err)
-
-	// Confirm there's been a checkpoint.
-	cdir, _, err := wlog.LastCheckpoint(w.Dir())
-	require.NoError(t, err)
-
-	// Read in checkpoint and WAL.
-	recs := readTestWAL(t, cdir)
-	var gotMetadataBlocks [][]record.RefMetadata
-	for _, rec := range recs {
-		if mr, ok := rec.([]record.RefMetadata); ok {
-			gotMetadataBlocks = append(gotMetadataBlocks, mr)
-		}
-	}
-
-	// There should only be 1 metadata block present, with only the latest
-	// metadata kept around.
-	wantMetadata := []record.RefMetadata{
-		{Ref: 1, Type: record.GetMetricType(m5.Type), Unit: m5.Unit, Help: m5.Help},
-		{Ref: 2, Type: record.GetMetricType(m6.Type), Unit: m6.Unit, Help: m6.Help},
-		{Ref: 4, Type: record.GetMetricType(m4.Type), Unit: m4.Unit, Help: m4.Help},
-	}
-	require.Len(t, gotMetadataBlocks, 1)
-	require.Len(t, gotMetadataBlocks[0], 3)
-	gotMetadataBlock := gotMetadataBlocks[0]
-
-	sort.Slice(gotMetadataBlock, func(i, j int) bool { return gotMetadataBlock[i].Ref < gotMetadataBlock[j].Ref })
-	require.Equal(t, wantMetadata, gotMetadataBlock)
-	require.NoError(t, hb.Close())
 }
 
 func TestMetadataAssertInMemoryData(t *testing.T) {

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1742,6 +1742,9 @@ func (a *headAppenderBase) Commit() (err error) {
 			chunkRange:      h.chunkRange.Load(),
 			samplesPerChunk: h.opts.SamplesPerChunk,
 		},
+		enc: record.Encoder{
+			EnableSTStorage: false,
+		},
 	}
 
 	for _, b := range a.batches {

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -169,7 +169,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 					return
 				}
 				decoded <- series
-			case record.Samples:
+			case record.Samples, record.SamplesV2:
 				samples := h.wlReplaySamplesPool.Get()[:0]
 				samples, err = dec.Samples(r.Record(), samples)
 				if err != nil {
@@ -798,7 +798,7 @@ func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 			var err error
 			rec := r.Record()
 			switch dec.Type(rec) {
-			case record.Samples:
+			case record.Samples, record.SamplesV2:
 				samples := h.wlReplaySamplesPool.Get()[:0]
 				samples, err = dec.Samples(rec, samples)
 				if err != nil {
@@ -1400,7 +1400,7 @@ func (h *Head) ChunkSnapshot() (*ChunkSnapshotStats, error) {
 	// Assuming 100 bytes (overestimate) per exemplar, that's ~1MB.
 	maxExemplarsPerRecord := 10000
 	batch := make([]record.RefExemplar, 0, maxExemplarsPerRecord)
-	enc := record.Encoder{}
+	enc := record.Encoder{EnableSTStorage: h.opts.EnableSTStorage}
 	flushExemplars := func() error {
 		if len(batch) == 0 {
 			return nil

--- a/tsdb/record/bench_test.go
+++ b/tsdb/record/bench_test.go
@@ -1,0 +1,207 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/tsdb/compression"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/util/testrecord"
+)
+
+func zeroOutSTs(samples []record.RefSample) []record.RefSample {
+	out := make([]record.RefSample, len(samples))
+	for i := range samples {
+		out[i] = samples[i]
+		out[i].ST = 0
+	}
+	return out
+}
+
+func TestEncodeDecode(t *testing.T) {
+	for _, enableStStorage := range []bool{false, true} {
+		for _, tcase := range []testrecord.RefSamplesCase{
+			testrecord.Realistic1000Samples,
+			testrecord.Realistic1000WithVariableSTSamples,
+			testrecord.Realistic1000WithConstSTSamples,
+			testrecord.WorstCase1000,
+			testrecord.WorstCase1000WithSTSamples,
+		} {
+			var (
+				dec record.Decoder
+				buf []byte
+				enc = record.Encoder{EnableSTStorage: enableStStorage}
+			)
+
+			s := testrecord.GenTestRefSamplesCase(t, tcase)
+
+			{
+				got, err := dec.Samples(enc.Samples(s, nil), nil)
+				require.NoError(t, err)
+				// if ST is off, we expect all STs to be zero
+				expected := s
+				if !enableStStorage {
+					expected = zeroOutSTs(s)
+				}
+
+				require.Equal(t, expected, got)
+			}
+
+			//  With byte buffer (append!)
+			{
+				buf = make([]byte, 10, 1e5)
+				got, err := dec.Samples(enc.Samples(s, buf)[10:], nil)
+				require.NoError(t, err)
+
+				expected := s
+				if !enableStStorage {
+					expected = zeroOutSTs(s)
+				}
+				require.Equal(t, expected, got)
+			}
+
+			// With sample slice
+			{
+				samples := make([]record.RefSample, 0, len(s)+1)
+				got, err := dec.Samples(enc.Samples(s, nil), samples)
+				require.NoError(t, err)
+				expected := s
+				if !enableStStorage {
+					expected = zeroOutSTs(s)
+				}
+				require.Equal(t, expected, got)
+			}
+
+			// With compression.
+			{
+				buf := enc.Samples(s, nil)
+
+				cEnc, err := compression.NewEncoder()
+				require.NoError(t, err)
+				buf, _, err = cEnc.Encode(compression.Zstd, buf, nil)
+				require.NoError(t, err)
+
+				buf, err = compression.NewDecoder().Decode(compression.Zstd, buf, nil)
+				require.NoError(t, err)
+
+				got, err := dec.Samples(buf, nil)
+				require.NoError(t, err)
+				expected := s
+				if !enableStStorage {
+					expected = zeroOutSTs(s)
+				}
+				require.Equal(t, expected, got)
+			}
+		}
+	}
+}
+
+var (
+	compressions = []compression.Type{compression.None, compression.Snappy, compression.Zstd}
+	dataCases    = []testrecord.RefSamplesCase{
+		testrecord.Realistic1000Samples,
+		testrecord.Realistic1000WithVariableSTSamples,
+		testrecord.Realistic1000WithConstSTSamples,
+		testrecord.WorstCase1000,
+		testrecord.WorstCase1000WithSTSamples,
+	}
+	UseV2 = true
+)
+
+/*
+	export bench=encode-v2 && go test ./tsdb/record/... \
+		-run '^$' -bench '^BenchmarkEncode_Samples' \
+		-benchtime 5s -count 6 -cpu 2 -timeout 999m \
+		| tee ${bench}.txt
+*/
+func BenchmarkEncode_Samples(b *testing.B) {
+	for _, compr := range compressions {
+		for _, data := range dataCases {
+			b.Run(fmt.Sprintf("compr=%v/data=%v", compr, data), func(b *testing.B) {
+				var (
+					samples = testrecord.GenTestRefSamplesCase(b, data)
+					enc     = record.Encoder{EnableSTStorage: UseV2}
+					buf     []byte
+					cBuf    []byte
+				)
+
+				cEnc, err := compression.NewEncoder()
+				require.NoError(b, err)
+
+				// Warm up.
+				buf = enc.Samples(samples, buf[:0])
+				cBuf, _, err = cEnc.Encode(compr, buf, cBuf[:0])
+				require.NoError(b, err)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					buf = enc.Samples(samples, buf[:0])
+					b.ReportMetric(float64(len(buf)), "B/rec")
+
+					cBuf, _, _ = cEnc.Encode(compr, buf, cBuf[:0])
+					b.ReportMetric(float64(len(cBuf)), "B/compressed-rec")
+				}
+			})
+		}
+	}
+}
+
+/*
+	export bench=decode-v2 && go test ./tsdb/record/... \
+		-run '^$' -bench '^BenchmarkDecode_Samples' \
+		-benchtime 5s -count 6 -cpu 2 -timeout 999m \
+		| tee ${bench}.txt
+*/
+func BenchmarkDecode_Samples(b *testing.B) {
+	for _, compr := range compressions {
+		for _, data := range dataCases {
+			b.Run(fmt.Sprintf("compr=%v/data=%v", compr, data), func(b *testing.B) {
+				var (
+					samples    = testrecord.GenTestRefSamplesCase(b, data)
+					enc        = record.Encoder{EnableSTStorage: UseV2}
+					dec        record.Decoder
+					cDec       = compression.NewDecoder()
+					cBuf       []byte
+					samplesBuf []record.RefSample
+				)
+
+				buf := enc.Samples(samples, nil)
+
+				cEnc, err := compression.NewEncoder()
+				require.NoError(b, err)
+
+				buf, _, err = cEnc.Encode(compr, buf, nil)
+				require.NoError(b, err)
+
+				// Warm up.
+				cBuf, err = cDec.Decode(compr, buf, cBuf[:0])
+				require.NoError(b, err)
+				samplesBuf, err = dec.Samples(cBuf, samplesBuf[:0])
+				require.NoError(b, err)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					cBuf, _ = cDec.Decode(compr, buf, cBuf[:0])
+					samplesBuf, _ = dec.Samples(cBuf, samplesBuf[:0])
+				}
+			})
+		}
+	}
+}

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -171,249 +171,255 @@ func TestCheckpoint(t *testing.T) {
 		}
 	}
 
-	for _, compress := range compression.Types() {
-		t.Run(fmt.Sprintf("compress=%s", compress), func(t *testing.T) {
-			dir := t.TempDir()
+	for _, enableStStorage := range []bool{false, true} {
+		for _, compress := range compression.Types() {
+			t.Run(fmt.Sprintf("compress=%s,stStorage=%v", compress, enableStStorage), func(t *testing.T) {
+				dir := t.TempDir()
 
-			var enc record.Encoder
-			// Create a dummy segment to bump the initial number.
-			seg, err := CreateSegment(dir, 100)
-			require.NoError(t, err)
-			require.NoError(t, seg.Close())
-
-			// Manually create checkpoint for 99 and earlier.
-			w, err := New(nil, nil, filepath.Join(dir, "checkpoint.0099"), compress)
-			require.NoError(t, err)
-
-			// Add some data we expect to be around later.
-			err = w.Log(enc.Series([]record.RefSeries{
-				{Ref: 0, Labels: labels.FromStrings("a", "b", "c", "0")},
-				{Ref: 1, Labels: labels.FromStrings("a", "b", "c", "1")},
-			}, nil))
-			require.NoError(t, err)
-			// Log an unknown record, that might have come from a future Prometheus version.
-			require.NoError(t, w.Log([]byte{255}))
-			require.NoError(t, w.Close())
-
-			// Start a WAL and write records to it as usual.
-			w, err = NewSize(nil, nil, dir, 128*1024, compress)
-			require.NoError(t, err)
-
-			samplesInWAL, histogramsInWAL, floatHistogramsInWAL := 0, 0, 0
-			var last int64
-			for i := 0; ; i++ {
-				_, n, err := Segments(w.Dir())
+				enc := record.Encoder{EnableSTStorage: enableStStorage}
+				// Create a dummy segment to bump the initial number.
+				seg, err := CreateSegment(dir, 100)
 				require.NoError(t, err)
-				if n >= 106 {
-					break
-				}
-				// Write some series initially.
-				if i == 0 {
-					b := enc.Series([]record.RefSeries{
-						{Ref: 2, Labels: labels.FromStrings("a", "b", "c", "2")},
-						{Ref: 3, Labels: labels.FromStrings("a", "b", "c", "3")},
-						{Ref: 4, Labels: labels.FromStrings("a", "b", "c", "4")},
-						{Ref: 5, Labels: labels.FromStrings("a", "b", "c", "5")},
+				require.NoError(t, seg.Close())
+
+				// Manually create checkpoint for 99 and earlier.
+				w, err := New(nil, nil, filepath.Join(dir, "checkpoint.0099"), compress)
+				require.NoError(t, err)
+
+				// Add some data we expect to be around later.
+				err = w.Log(enc.Series([]record.RefSeries{
+					{Ref: 0, Labels: labels.FromStrings("a", "b", "c", "0")},
+					{Ref: 1, Labels: labels.FromStrings("a", "b", "c", "1")},
+				}, nil))
+				require.NoError(t, err)
+				// Log an unknown record, that might have come from a future Prometheus version.
+				require.NoError(t, w.Log([]byte{255}))
+				require.NoError(t, w.Close())
+
+				// Start a WAL and write records to it as usual.
+				w, err = NewSize(nil, nil, dir, 128*1024, compress)
+				require.NoError(t, err)
+
+				samplesInWAL, histogramsInWAL, floatHistogramsInWAL := 0, 0, 0
+				var last int64
+				for i := 0; ; i++ {
+					_, n, err := Segments(w.Dir())
+					require.NoError(t, err)
+					if n >= 106 {
+						break
+					}
+					// Write some series initially.
+					if i == 0 {
+						b := enc.Series([]record.RefSeries{
+							{Ref: 2, Labels: labels.FromStrings("a", "b", "c", "2")},
+							{Ref: 3, Labels: labels.FromStrings("a", "b", "c", "3")},
+							{Ref: 4, Labels: labels.FromStrings("a", "b", "c", "4")},
+							{Ref: 5, Labels: labels.FromStrings("a", "b", "c", "5")},
+						}, nil)
+						require.NoError(t, w.Log(b))
+
+						b = enc.Metadata([]record.RefMetadata{
+							{Ref: 2, Unit: "unit", Help: "help"},
+							{Ref: 3, Unit: "unit", Help: "help"},
+							{Ref: 4, Unit: "unit", Help: "help"},
+							{Ref: 5, Unit: "unit", Help: "help"},
+						}, nil)
+						require.NoError(t, w.Log(b))
+					}
+					// Write samples until the WAL has enough segments.
+					// Make them have drifting timestamps within a record to see that they
+					// get filtered properly.
+					b := enc.Samples([]record.RefSample{
+						{Ref: 0, T: last, V: float64(i)},
+						{Ref: 1, T: last + 10000, V: float64(i)},
+						{Ref: 2, T: last + 20000, V: float64(i)},
+						{Ref: 3, T: last + 30000, V: float64(i)},
+					}, nil)
+					require.NoError(t, w.Log(b))
+					samplesInWAL += 4
+					h := makeHistogram(i)
+					b, _ = enc.HistogramSamples([]record.RefHistogramSample{
+						{Ref: 0, T: last, H: h},
+						{Ref: 1, T: last + 10000, H: h},
+						{Ref: 2, T: last + 20000, H: h},
+						{Ref: 3, T: last + 30000, H: h},
+					}, nil)
+					require.NoError(t, w.Log(b))
+					histogramsInWAL += 4
+					cbh := makeCustomBucketHistogram(i)
+					b = enc.CustomBucketsHistogramSamples([]record.RefHistogramSample{
+						{Ref: 0, T: last, H: cbh},
+						{Ref: 1, T: last + 10000, H: cbh},
+						{Ref: 2, T: last + 20000, H: cbh},
+						{Ref: 3, T: last + 30000, H: cbh},
+					}, nil)
+					require.NoError(t, w.Log(b))
+					histogramsInWAL += 4
+					fh := makeFloatHistogram(i)
+					b, _ = enc.FloatHistogramSamples([]record.RefFloatHistogramSample{
+						{Ref: 0, T: last, FH: fh},
+						{Ref: 1, T: last + 10000, FH: fh},
+						{Ref: 2, T: last + 20000, FH: fh},
+						{Ref: 3, T: last + 30000, FH: fh},
+					}, nil)
+					require.NoError(t, w.Log(b))
+					floatHistogramsInWAL += 4
+					cbfh := makeCustomBucketFloatHistogram(i)
+					b = enc.CustomBucketsFloatHistogramSamples([]record.RefFloatHistogramSample{
+						{Ref: 0, T: last, FH: cbfh},
+						{Ref: 1, T: last + 10000, FH: cbfh},
+						{Ref: 2, T: last + 20000, FH: cbfh},
+						{Ref: 3, T: last + 30000, FH: cbfh},
+					}, nil)
+					require.NoError(t, w.Log(b))
+					floatHistogramsInWAL += 4
+
+					b = enc.Exemplars([]record.RefExemplar{
+						{Ref: 1, T: last, V: float64(i), Labels: labels.FromStrings("trace_id", fmt.Sprintf("trace-%d", i))},
 					}, nil)
 					require.NoError(t, w.Log(b))
 
+					// Write changing metadata for each series. In the end, only the latest
+					// version should end up in the checkpoint.
 					b = enc.Metadata([]record.RefMetadata{
-						{Ref: 2, Unit: "unit", Help: "help"},
-						{Ref: 3, Unit: "unit", Help: "help"},
-						{Ref: 4, Unit: "unit", Help: "help"},
-						{Ref: 5, Unit: "unit", Help: "help"},
+						{Ref: 0, Unit: strconv.FormatInt(last, 10), Help: strconv.FormatInt(last, 10)},
+						{Ref: 1, Unit: strconv.FormatInt(last, 10), Help: strconv.FormatInt(last, 10)},
+						{Ref: 2, Unit: strconv.FormatInt(last, 10), Help: strconv.FormatInt(last, 10)},
+						{Ref: 3, Unit: strconv.FormatInt(last, 10), Help: strconv.FormatInt(last, 10)},
 					}, nil)
 					require.NoError(t, w.Log(b))
+
+					last += 100
 				}
-				// Write samples until the WAL has enough segments.
-				// Make them have drifting timestamps within a record to see that they
-				// get filtered properly.
-				b := enc.Samples([]record.RefSample{
-					{Ref: 0, T: last, V: float64(i)},
-					{Ref: 1, T: last + 10000, V: float64(i)},
-					{Ref: 2, T: last + 20000, V: float64(i)},
-					{Ref: 3, T: last + 30000, V: float64(i)},
-				}, nil)
-				require.NoError(t, w.Log(b))
-				samplesInWAL += 4
-				h := makeHistogram(i)
-				b, _ = enc.HistogramSamples([]record.RefHistogramSample{
-					{Ref: 0, T: last, H: h},
-					{Ref: 1, T: last + 10000, H: h},
-					{Ref: 2, T: last + 20000, H: h},
-					{Ref: 3, T: last + 30000, H: h},
-				}, nil)
-				require.NoError(t, w.Log(b))
-				histogramsInWAL += 4
-				cbh := makeCustomBucketHistogram(i)
-				b = enc.CustomBucketsHistogramSamples([]record.RefHistogramSample{
-					{Ref: 0, T: last, H: cbh},
-					{Ref: 1, T: last + 10000, H: cbh},
-					{Ref: 2, T: last + 20000, H: cbh},
-					{Ref: 3, T: last + 30000, H: cbh},
-				}, nil)
-				require.NoError(t, w.Log(b))
-				histogramsInWAL += 4
-				fh := makeFloatHistogram(i)
-				b, _ = enc.FloatHistogramSamples([]record.RefFloatHistogramSample{
-					{Ref: 0, T: last, FH: fh},
-					{Ref: 1, T: last + 10000, FH: fh},
-					{Ref: 2, T: last + 20000, FH: fh},
-					{Ref: 3, T: last + 30000, FH: fh},
-				}, nil)
-				require.NoError(t, w.Log(b))
-				floatHistogramsInWAL += 4
-				cbfh := makeCustomBucketFloatHistogram(i)
-				b = enc.CustomBucketsFloatHistogramSamples([]record.RefFloatHistogramSample{
-					{Ref: 0, T: last, FH: cbfh},
-					{Ref: 1, T: last + 10000, FH: cbfh},
-					{Ref: 2, T: last + 20000, FH: cbfh},
-					{Ref: 3, T: last + 30000, FH: cbfh},
-				}, nil)
-				require.NoError(t, w.Log(b))
-				floatHistogramsInWAL += 4
+				require.NoError(t, w.Close())
 
-				b = enc.Exemplars([]record.RefExemplar{
-					{Ref: 1, T: last, V: float64(i), Labels: labels.FromStrings("trace_id", fmt.Sprintf("trace-%d", i))},
-				}, nil)
-				require.NoError(t, w.Log(b))
+				stats, err := Checkpoint(promslog.NewNopLogger(), w, 100, 106, func(x chunks.HeadSeriesRef) bool {
+					return x%2 == 0
+				}, last/2, enableStStorage)
+				require.NoError(t, err)
+				require.NoError(t, w.Truncate(107))
+				require.NoError(t, DeleteCheckpoints(w.Dir(), 106))
+				require.Equal(t, histogramsInWAL+floatHistogramsInWAL+samplesInWAL, stats.TotalSamples)
+				require.Positive(t, stats.DroppedSamples)
 
-				// Write changing metadata for each series. In the end, only the latest
-				// version should end up in the checkpoint.
-				b = enc.Metadata([]record.RefMetadata{
-					{Ref: 0, Unit: strconv.FormatInt(last, 10), Help: strconv.FormatInt(last, 10)},
-					{Ref: 1, Unit: strconv.FormatInt(last, 10), Help: strconv.FormatInt(last, 10)},
-					{Ref: 2, Unit: strconv.FormatInt(last, 10), Help: strconv.FormatInt(last, 10)},
-					{Ref: 3, Unit: strconv.FormatInt(last, 10), Help: strconv.FormatInt(last, 10)},
-				}, nil)
-				require.NoError(t, w.Log(b))
+				// Only the new checkpoint should be left.
+				files, err := os.ReadDir(dir)
+				require.NoError(t, err)
+				require.Len(t, files, 1)
+				require.Equal(t, "checkpoint.00000106", files[0].Name())
 
-				last += 100
-			}
-			require.NoError(t, w.Close())
+				sr, err := NewSegmentsReader(filepath.Join(dir, "checkpoint.00000106"))
+				require.NoError(t, err)
+				defer sr.Close()
 
-			stats, err := Checkpoint(promslog.NewNopLogger(), w, 100, 106, func(x chunks.HeadSeriesRef) bool {
-				return x%2 == 0
-			}, last/2)
-			require.NoError(t, err)
-			require.NoError(t, w.Truncate(107))
-			require.NoError(t, DeleteCheckpoints(w.Dir(), 106))
-			require.Equal(t, histogramsInWAL+floatHistogramsInWAL+samplesInWAL, stats.TotalSamples)
-			require.Positive(t, stats.DroppedSamples)
+				dec := record.NewDecoder(labels.NewSymbolTable(), promslog.NewNopLogger())
+				var series []record.RefSeries
+				var metadata []record.RefMetadata
+				r := NewReader(sr)
 
-			// Only the new checkpoint should be left.
-			files, err := os.ReadDir(dir)
-			require.NoError(t, err)
-			require.Len(t, files, 1)
-			require.Equal(t, "checkpoint.00000106", files[0].Name())
+				samplesInCheckpoint, histogramsInCheckpoint, floatHistogramsInCheckpoint := 0, 0, 0
+				for r.Next() {
+					rec := r.Record()
 
-			sr, err := NewSegmentsReader(filepath.Join(dir, "checkpoint.00000106"))
-			require.NoError(t, err)
-			defer sr.Close()
-
-			dec := record.NewDecoder(labels.NewSymbolTable(), promslog.NewNopLogger())
-			var series []record.RefSeries
-			var metadata []record.RefMetadata
-			r := NewReader(sr)
-
-			samplesInCheckpoint, histogramsInCheckpoint, floatHistogramsInCheckpoint := 0, 0, 0
-			for r.Next() {
-				rec := r.Record()
-
-				switch dec.Type(rec) {
-				case record.Series:
-					series, err = dec.Series(rec, series)
-					require.NoError(t, err)
-				case record.Samples:
-					samples, err := dec.Samples(rec, nil)
-					require.NoError(t, err)
-					for _, s := range samples {
-						require.GreaterOrEqual(t, s.T, last/2, "sample with wrong timestamp")
+					switch dec.Type(rec) {
+					case record.Series:
+						series, err = dec.Series(rec, series)
+						require.NoError(t, err)
+					case record.Samples, record.SamplesV2:
+						samples, err := dec.Samples(rec, nil)
+						require.NoError(t, err)
+						for _, s := range samples {
+							require.GreaterOrEqual(t, s.T, last/2, "sample with wrong timestamp")
+						}
+						samplesInCheckpoint += len(samples)
+					case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+						histograms, err := dec.HistogramSamples(rec, nil)
+						require.NoError(t, err)
+						for _, h := range histograms {
+							require.GreaterOrEqual(t, h.T, last/2, "histogram with wrong timestamp")
+						}
+						histogramsInCheckpoint += len(histograms)
+					case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+						floatHistograms, err := dec.FloatHistogramSamples(rec, nil)
+						require.NoError(t, err)
+						for _, h := range floatHistograms {
+							require.GreaterOrEqual(t, h.T, last/2, "float histogram with wrong timestamp")
+						}
+						floatHistogramsInCheckpoint += len(floatHistograms)
+					case record.Exemplars:
+						exemplars, err := dec.Exemplars(rec, nil)
+						require.NoError(t, err)
+						for _, e := range exemplars {
+							require.GreaterOrEqual(t, e.T, last/2, "exemplar with wrong timestamp")
+						}
+					case record.Metadata:
+						metadata, err = dec.Metadata(rec, metadata)
+						require.NoError(t, err)
 					}
-					samplesInCheckpoint += len(samples)
-				case record.HistogramSamples, record.CustomBucketsHistogramSamples:
-					histograms, err := dec.HistogramSamples(rec, nil)
-					require.NoError(t, err)
-					for _, h := range histograms {
-						require.GreaterOrEqual(t, h.T, last/2, "histogram with wrong timestamp")
-					}
-					histogramsInCheckpoint += len(histograms)
-				case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
-					floatHistograms, err := dec.FloatHistogramSamples(rec, nil)
-					require.NoError(t, err)
-					for _, h := range floatHistograms {
-						require.GreaterOrEqual(t, h.T, last/2, "float histogram with wrong timestamp")
-					}
-					floatHistogramsInCheckpoint += len(floatHistograms)
-				case record.Exemplars:
-					exemplars, err := dec.Exemplars(rec, nil)
-					require.NoError(t, err)
-					for _, e := range exemplars {
-						require.GreaterOrEqual(t, e.T, last/2, "exemplar with wrong timestamp")
-					}
-				case record.Metadata:
-					metadata, err = dec.Metadata(rec, metadata)
-					require.NoError(t, err)
 				}
-			}
-			require.NoError(t, r.Err())
-			// Making sure we replayed some samples. We expect >50% samples to be still present.
-			require.Greater(t, float64(samplesInCheckpoint)/float64(samplesInWAL), 0.5)
-			require.Less(t, float64(samplesInCheckpoint)/float64(samplesInWAL), 0.8)
-			require.Greater(t, float64(histogramsInCheckpoint)/float64(histogramsInWAL), 0.5)
-			require.Less(t, float64(histogramsInCheckpoint)/float64(histogramsInWAL), 0.8)
-			require.Greater(t, float64(floatHistogramsInCheckpoint)/float64(floatHistogramsInWAL), 0.5)
-			require.Less(t, float64(floatHistogramsInCheckpoint)/float64(floatHistogramsInWAL), 0.8)
+				require.NoError(t, r.Err())
+				// Making sure we replayed some samples. We expect >50% samples to be still present.
+				require.Greater(t, float64(samplesInCheckpoint)/float64(samplesInWAL), 0.5)
+				require.Less(t, float64(samplesInCheckpoint)/float64(samplesInWAL), 0.8)
+				require.Greater(t, float64(histogramsInCheckpoint)/float64(histogramsInWAL), 0.5)
+				require.Less(t, float64(histogramsInCheckpoint)/float64(histogramsInWAL), 0.8)
+				require.Greater(t, float64(floatHistogramsInCheckpoint)/float64(floatHistogramsInWAL), 0.5)
+				require.Less(t, float64(floatHistogramsInCheckpoint)/float64(floatHistogramsInWAL), 0.8)
 
-			expectedRefSeries := []record.RefSeries{
-				{Ref: 0, Labels: labels.FromStrings("a", "b", "c", "0")},
-				{Ref: 2, Labels: labels.FromStrings("a", "b", "c", "2")},
-				{Ref: 4, Labels: labels.FromStrings("a", "b", "c", "4")},
-			}
-			testutil.RequireEqual(t, expectedRefSeries, series)
+				expectedRefSeries := []record.RefSeries{
+					{Ref: 0, Labels: labels.FromStrings("a", "b", "c", "0")},
+					{Ref: 2, Labels: labels.FromStrings("a", "b", "c", "2")},
+					{Ref: 4, Labels: labels.FromStrings("a", "b", "c", "4")},
+				}
+				testutil.RequireEqual(t, expectedRefSeries, series)
 
-			expectedRefMetadata := []record.RefMetadata{
-				{Ref: 0, Unit: strconv.FormatInt(last-100, 10), Help: strconv.FormatInt(last-100, 10)},
-				{Ref: 2, Unit: strconv.FormatInt(last-100, 10), Help: strconv.FormatInt(last-100, 10)},
-				{Ref: 4, Unit: "unit", Help: "help"},
-			}
-			sort.Slice(metadata, func(i, j int) bool { return metadata[i].Ref < metadata[j].Ref })
-			require.Equal(t, expectedRefMetadata, metadata)
-		})
+				expectedRefMetadata := []record.RefMetadata{
+					{Ref: 0, Unit: strconv.FormatInt(last-100, 10), Help: strconv.FormatInt(last-100, 10)},
+					{Ref: 2, Unit: strconv.FormatInt(last-100, 10), Help: strconv.FormatInt(last-100, 10)},
+					{Ref: 4, Unit: "unit", Help: "help"},
+				}
+				sort.Slice(metadata, func(i, j int) bool { return metadata[i].Ref < metadata[j].Ref })
+				require.Equal(t, expectedRefMetadata, metadata)
+			})
+		}
 	}
 }
 
 func TestCheckpointNoTmpFolderAfterError(t *testing.T) {
-	// Create a new wlog with invalid data.
-	dir := t.TempDir()
-	w, err := NewSize(nil, nil, dir, 64*1024, compression.None)
-	require.NoError(t, err)
-	var enc record.Encoder
-	require.NoError(t, w.Log(enc.Series([]record.RefSeries{
-		{Ref: 0, Labels: labels.FromStrings("a", "b", "c", "2")},
-	}, nil)))
-	require.NoError(t, w.Close())
+	for _, enableStStorage := range []bool{false, true} {
+		t.Run("enableStStorage="+strconv.FormatBool(enableStStorage), func(t *testing.T) {
+			// Create a new wlog with invalid data.
+			dir := t.TempDir()
+			w, err := NewSize(nil, nil, dir, 64*1024, compression.None)
+			require.NoError(t, err)
+			enc := record.Encoder{EnableSTStorage: enableStStorage}
+			require.NoError(t, w.Log(enc.Series([]record.RefSeries{
+				{Ref: 0, Labels: labels.FromStrings("a", "b", "c", "2")},
+			}, nil)))
+			require.NoError(t, w.Close())
 
-	// Corrupt data.
-	f, err := os.OpenFile(filepath.Join(w.Dir(), "00000000"), os.O_WRONLY, 0o666)
-	require.NoError(t, err)
-	_, err = f.WriteAt([]byte{42}, 1)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
+			// Corrupt data.
+			f, err := os.OpenFile(filepath.Join(w.Dir(), "00000000"), os.O_WRONLY, 0o666)
+			require.NoError(t, err)
+			_, err = f.WriteAt([]byte{42}, 1)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
 
-	// Run the checkpoint and since the wlog contains corrupt data this should return an error.
-	_, err = Checkpoint(promslog.NewNopLogger(), w, 0, 1, nil, 0)
-	require.Error(t, err)
+			// Run the checkpoint and since the wlog contains corrupt data this should return an error.
+			_, err = Checkpoint(promslog.NewNopLogger(), w, 0, 1, nil, 0, enableStStorage)
+			require.Error(t, err)
 
-	// Walk the wlog dir to make sure there are no tmp folder left behind after the error.
-	err = filepath.Walk(w.Dir(), func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return fmt.Errorf("access err %q: %w", path, err)
-		}
-		if info.IsDir() && strings.HasSuffix(info.Name(), ".tmp") {
-			return fmt.Errorf("wlog dir contains temporary folder:%s", info.Name())
-		}
-		return nil
-	})
-	require.NoError(t, err)
+			// Walk the wlog dir to make sure there are no tmp folder left behind after the error.
+			err = filepath.Walk(w.Dir(), func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return fmt.Errorf("access err %q: %w", path, err)
+				}
+				if info.IsDir() && strings.HasSuffix(info.Name(), ".tmp") {
+					return fmt.Errorf("wlog dir contains temporary folder:%s", info.Name())
+				}
+				return nil
+			})
+			require.NoError(t, err)
+		})
+	}
 }

--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -519,7 +519,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			}
 			w.writer.StoreSeries(series, segmentNum)
 
-		case record.Samples:
+		case record.Samples, record.SamplesV2:
 			// If we're not tailing a segment we can ignore any samples records we see.
 			// This speeds up replay of the WAL by > 10x.
 			if !tail {

--- a/util/testrecord/record.go
+++ b/util/testrecord/record.go
@@ -1,0 +1,96 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testrecord
+
+import (
+	"math"
+	"testing"
+
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/record"
+)
+
+type RefSamplesCase string
+
+const (
+	Realistic1000Samples               RefSamplesCase = "real1000"
+	Realistic1000WithVariableSTSamples RefSamplesCase = "real1000-vst"
+	Realistic1000WithConstSTSamples    RefSamplesCase = "real1000-cst"
+	WorstCase1000                      RefSamplesCase = "worst1000"
+	WorstCase1000WithSTSamples         RefSamplesCase = "worst1000-st"
+)
+
+func GenTestRefSamplesCase(t testing.TB, c RefSamplesCase) []record.RefSample {
+	t.Helper()
+
+	ret := make([]record.RefSample, 1e3)
+	switch c {
+	// Samples are across series, so likely all have the same timestamp.
+	case Realistic1000Samples:
+		for i := range ret {
+			ret[i].Ref = chunks.HeadSeriesRef(i)
+			ret[i].T = int64(12423423)
+			ret[i].V = highVarianceFloat(i)
+		}
+	// Likely the start times will all be the same with deltas.
+	case Realistic1000WithConstSTSamples:
+		for i := range ret {
+			ret[i].Ref = chunks.HeadSeriesRef(i)
+			ret[i].ST = int64(12423423)
+			ret[i].T = int64(12423423 + 15)
+			ret[i].V = highVarianceFloat(i)
+		}
+	// Maybe series have different start times though
+	case Realistic1000WithVariableSTSamples:
+		for i := range ret {
+			ret[i].Ref = chunks.HeadSeriesRef(i)
+			ret[i].ST = int64((12423423 / 9) * (i % 10))
+			ret[i].T = int64(12423423)
+			ret[i].V = highVarianceFloat(i)
+		}
+	case WorstCase1000:
+		for i := range ret {
+			ret[i].Ref = chunks.HeadSeriesRef(i)
+			ret[i].T = highVarianceInt(i)
+			ret[i].V = highVarianceFloat(i)
+		}
+	case WorstCase1000WithSTSamples:
+		for i := range ret {
+			ret[i].Ref = chunks.HeadSeriesRef(i)
+
+			// Worst case is when the values are significantly different
+			// to each other which breaks delta encoding.
+			ret[i].ST = highVarianceInt(i+1) / 1024 // Make sure ST is not comparable to T
+			ret[i].T = highVarianceInt(i)
+			ret[i].V = highVarianceFloat(i)
+		}
+	default:
+		t.Fatal("unknown case", c)
+	}
+	return ret
+}
+
+func highVarianceInt(i int) int64 {
+	if i%2 == 0 {
+		return math.MinInt32
+	}
+	return math.MaxInt32
+}
+
+func highVarianceFloat(i int) float64 {
+	if i%2 == 0 {
+		return math.SmallestNonzeroFloat32
+	}
+	return math.MaxFloat32
+}


### PR DESCRIPTION
Implement an experimental "SamplesV2" encoding method that includes support for Start Time per sample. Part of https://github.com/prometheus/prometheus/issues/17790. Since each slice of refs is only one sample per series, compression quality will be highly dependent on how similar data is between series, ie similar scrape times or start times.

This is a very partial implementation, consisting only of regular counter support as proof-of-concept and not for histograms. This feature is off by default, but tests have been updated to use it. Configuration options exist for the feature for future use by a feature flag in the binary.


## Benchmarks

A naive implementation should result in a 33% increase in data size since each record goes from `3*64` to `4*64` bits. Numbers better than 33% are an improvement. In this case, because we add a marker byte when the ST is not easily predictable, we would expect a 37% increase at worst.

Current benchmarks... I think I still need to work on generating representative artificial data samples, it's too easy to construct data that compresses much too well. 

```
$ benchstat encode-v1.txt encode-v2.txt
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb/record
cpu: Intel(R) Core(TM) Ultra 7 155U
                                                │ encode-v1.txt │            encode-v2.txt             │
                                                │    sec/op     │    sec/op      vs base               │
Encode_Samples/compr=none/data=real1000-2           7.226µ ± 7%    7.593µ ±  7%        ~ (p=0.065 n=6)
Encode_Samples/compr=none/data=real1000-dst-2       6.869µ ± 6%    7.759µ ±  8%  +12.97% (p=0.002 n=6)
Encode_Samples/compr=none/data=real1000-cst-2       6.795µ ± 4%    7.621µ ±  5%  +12.16% (p=0.002 n=6)
Encode_Samples/compr=none/data=worst1000-2          8.133µ ± 3%    8.194µ ±  3%        ~ (p=0.699 n=6)
Encode_Samples/compr=none/data=worst1000-st-2       8.008µ ± 3%   13.971µ ±  8%  +74.47% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=real1000-2        15.553µ ± 5%    8.569µ ±  6%  -44.91% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=real1000-dst-2    15.634µ ± 4%    9.005µ ±  3%  -42.40% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=real1000-cst-2    15.115µ ± 4%    9.351µ ± 14%  -38.14% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=worst1000-2        17.34µ ± 5%    10.07µ ±  2%  -41.92% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=worst1000-st-2     17.61µ ± 4%    15.07µ ± 15%  -14.39% (p=0.009 n=6)
Encode_Samples/compr=zstd/data=real1000-2           39.37µ ± 7%    13.32µ ±  4%  -66.16% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=real1000-dst-2       39.60µ ± 7%    13.20µ ±  5%  -66.66% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=real1000-cst-2       39.41µ ± 6%    12.76µ ±  8%  -67.62% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=worst1000-2          39.99µ ± 4%    15.81µ ±  4%  -60.46% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=worst1000-st-2       42.50µ ± 5%    22.22µ ±  6%  -47.73% (p=0.002 n=6)
geomean                                             16.88µ         11.04µ        -34.57%

                                                │  encode-v1.txt   │              encode-v2.txt              │
                                                │ B/compressed-rec │ B/compressed-rec  vs base               │
Encode_Samples/compr=none/data=real1000-2             10.70Ki ± 0%       10.75Ki ± 0%   +0.47% (p=0.002 n=6)
Encode_Samples/compr=none/data=real1000-dst-2         10.70Ki ± 0%       10.75Ki ± 0%   +0.47% (p=0.002 n=6)
Encode_Samples/compr=none/data=real1000-cst-2         10.70Ki ± 0%       10.77Ki ± 0%   +0.65% (p=0.002 n=6)
Encode_Samples/compr=none/data=worst1000-2            12.65Ki ± 0%       12.70Ki ± 0%   +0.40% (p=0.002 n=6)
Encode_Samples/compr=none/data=worst1000-st-2         12.65Ki ± 0%       17.58Ki ± 0%  +39.00% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=real1000-2            4022.0 ± 0%         544.0 ± 0%  -86.47% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=real1000-dst-2        4022.0 ± 0%         545.0 ± 0%  -86.45% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=real1000-cst-2        4022.0 ± 0%         585.0 ± 0%  -85.45% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=worst1000-2           4528.0 ± 0%         643.0 ± 0%  -85.80% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=worst1000-st-2        4528.0 ± 0%         887.0 ± 0%  -80.41% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=real1000-2             1069.00 ± 0%         45.00 ± 0%  -95.79% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=real1000-dst-2         1072.00 ± 0%         46.00 ± 0%  -95.71% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=real1000-cst-2         1071.00 ± 0%         86.00 ± 0%  -91.97% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=worst1000-2            1207.00 ± 0%         53.00 ± 0%  -95.61% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=worst1000-st-2         1207.00 ± 0%         61.00 ± 0%  -94.95% (p=0.002 n=6)
geomean                                               3.725Ki              764.5       -79.96%

                                                │ encode-v1.txt │            encode-v2.txt            │
                                                │     B/rec     │    B/rec      vs base               │
Encode_Samples/compr=none/data=real1000-2          10.70Ki ± 0%   10.75Ki ± 0%   +0.47% (p=0.002 n=6)
Encode_Samples/compr=none/data=real1000-dst-2      10.70Ki ± 0%   10.75Ki ± 0%   +0.47% (p=0.002 n=6)
Encode_Samples/compr=none/data=real1000-cst-2      10.70Ki ± 0%   10.77Ki ± 0%   +0.65% (p=0.002 n=6)
Encode_Samples/compr=none/data=worst1000-2         12.65Ki ± 0%   12.70Ki ± 0%   +0.40% (p=0.002 n=6)
Encode_Samples/compr=none/data=worst1000-st-2      12.65Ki ± 0%   17.58Ki ± 0%  +39.00% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=real1000-2        10.70Ki ± 0%   10.75Ki ± 0%   +0.47% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=real1000-dst-2    10.70Ki ± 0%   10.75Ki ± 0%   +0.47% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=real1000-cst-2    10.70Ki ± 0%   10.77Ki ± 0%   +0.65% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=worst1000-2       12.65Ki ± 0%   12.70Ki ± 0%   +0.40% (p=0.002 n=6)
Encode_Samples/compr=snappy/data=worst1000-st-2    12.65Ki ± 0%   17.58Ki ± 0%  +39.00% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=real1000-2          10.70Ki ± 0%   10.75Ki ± 0%   +0.47% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=real1000-dst-2      10.70Ki ± 0%   10.75Ki ± 0%   +0.47% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=real1000-cst-2      10.70Ki ± 0%   10.77Ki ± 0%   +0.65% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=worst1000-2         12.65Ki ± 0%   12.70Ki ± 0%   +0.40% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=worst1000-st-2      12.65Ki ± 0%   17.58Ki ± 0%  +39.00% (p=0.002 n=6)
geomean                                            11.44Ki        12.27Ki        +7.23%

                                                │ encode-v1.txt │             encode-v2.txt              │
                                                │     B/op      │    B/op     vs base                    │
Encode_Samples/compr=none/data=real1000-2          0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
Encode_Samples/compr=none/data=real1000-dst-2      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
Encode_Samples/compr=none/data=real1000-cst-2      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
Encode_Samples/compr=none/data=worst1000-2         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
Encode_Samples/compr=none/data=worst1000-st-2      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
Encode_Samples/compr=snappy/data=real1000-2        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
Encode_Samples/compr=snappy/data=real1000-dst-2    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
Encode_Samples/compr=snappy/data=real1000-cst-2    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
Encode_Samples/compr=snappy/data=worst1000-2       0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
Encode_Samples/compr=snappy/data=worst1000-st-2    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
Encode_Samples/compr=zstd/data=real1000-2          2.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=real1000-dst-2      2.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=real1000-cst-2      2.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=worst1000-2         2.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
Encode_Samples/compr=zstd/data=worst1000-st-2      2.000 ± 0%     1.000 ± 0%   -50.00% (p=0.002 n=6)
geomean                                                       ²               ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                                │ encode-v1.txt │           encode-v2.txt            │
                                                │   allocs/op   │ allocs/op   vs base                │
Encode_Samples/compr=none/data=real1000-2          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=none/data=real1000-dst-2      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=none/data=real1000-cst-2      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=none/data=worst1000-2         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=none/data=worst1000-st-2      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=snappy/data=real1000-2        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=snappy/data=real1000-dst-2    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=snappy/data=real1000-cst-2    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=snappy/data=worst1000-2       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=snappy/data=worst1000-st-2    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=zstd/data=real1000-2          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=zstd/data=real1000-dst-2      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=zstd/data=real1000-cst-2      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=zstd/data=worst1000-2         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Encode_Samples/compr=zstd/data=worst1000-st-2      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                       ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

#### Does this PR introduce a user-facing change?
Increases size of all WAL RefSample objects by an int64 (a 33% increase) regardless of whether the new ST Storage option is enabled. Prombench does not show significant increase in memory usage, however.

```release-notes
[CHANGE] Adds Start Time value to all WAL RefSamples in memory, and therefore may increase memory usage.
```