### PR TITLE
[CHORE] TSDB: Remove unused LabelValueFor function

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -102,11 +102,6 @@ type IndexReader interface {
 	// LabelNames returns all the unique label names present in the index in sorted order.
 	LabelNames(ctx context.Context, matchers ...*labels.Matcher) ([]string, error)
 
-	// LabelValueFor returns label value for the given label name in the series referred to by ID.
-	// If the series couldn't be found or the series doesn't have the requested label a
-	// storage.ErrNotFound is returned as error.
-	LabelValueFor(ctx context.Context, id storage.SeriesRef, label string) (string, error)
-
 	// LabelNamesFor returns all the label names for the series referred to by the postings.
 	// The names returned are sorted.
 	LabelNamesFor(ctx context.Context, postings index.Postings) ([]string, error)
@@ -549,11 +544,6 @@ func (r blockIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchB
 func (r blockIndexReader) Close() error {
 	r.b.pendingReaders.Done()
 	return nil
-}
-
-// LabelValueFor returns label value for the given label name in the series referred to by ID.
-func (r blockIndexReader) LabelValueFor(ctx context.Context, id storage.SeriesRef, label string) (string, error) {
-	return r.ir.LabelValueFor(ctx, id, label)
 }
 
 // LabelNamesFor returns all the label names for the series referred to by the postings.

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -261,21 +261,6 @@ func unpackHeadChunkRef(ref chunks.ChunkRef) (seriesID chunks.HeadSeriesRef, chu
 	return sid, (cid & (oooChunkIDMask - 1)), (cid & oooChunkIDMask) != 0
 }
 
-// LabelValueFor returns label value for the given label name in the series referred to by ID.
-func (h *headIndexReader) LabelValueFor(_ context.Context, id storage.SeriesRef, label string) (string, error) {
-	memSeries := h.head.series.getByID(chunks.HeadSeriesRef(id))
-	if memSeries == nil {
-		return "", storage.ErrNotFound
-	}
-
-	value := memSeries.labels().Get(label)
-	if value == "" {
-		return "", storage.ErrNotFound
-	}
-
-	return value, nil
-}
-
 // LabelNamesFor returns all the label names for the series referred to by the postings.
 // The names returned are sorted.
 func (h *headIndexReader) LabelNamesFor(ctx context.Context, series index.Postings) ([]string, error) {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -500,10 +500,6 @@ func (*OOOCompactionHeadIndexReader) LabelNames(context.Context, ...*labels.Matc
 	return nil, errors.New("not implemented")
 }
 
-func (*OOOCompactionHeadIndexReader) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {
-	return "", errors.New("not implemented")
-}
-
 func (*OOOCompactionHeadIndexReader) LabelNamesFor(context.Context, index.Postings) ([]string, error) {
 	return nil, errors.New("not implemented")
 }

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2294,10 +2294,6 @@ func (m mockIndex) LabelValues(_ context.Context, name string, hints *storage.La
 	return values, nil
 }
 
-func (m mockIndex) LabelValueFor(_ context.Context, id storage.SeriesRef, label string) (string, error) {
-	return m.series[id].l.Get(label), nil
-}
-
 func (m mockIndex) LabelNamesFor(_ context.Context, postings index.Postings) ([]string, error) {
 	namesMap := make(map[string]bool)
 	for postings.Next() {
@@ -3315,10 +3311,6 @@ func (mockMatcherIndex) LabelValues(context.Context, string, *storage.LabelHints
 	return []string{}, errors.New("label values called")
 }
 
-func (mockMatcherIndex) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {
-	return "", errors.New("label value for called")
-}
-
 func (mockMatcherIndex) LabelNamesFor(context.Context, index.Postings) ([]string, error) {
 	return nil, errors.New("label names for called")
 }
@@ -3737,10 +3729,6 @@ const mockReaderOfLabelsSeriesCount = checkContextEveryNIterations * 10
 
 func (mockReaderOfLabels) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
 	return make([]string, mockReaderOfLabelsSeriesCount), nil
-}
-
-func (mockReaderOfLabels) LabelValueFor(context.Context, storage.SeriesRef, string) (string, error) {
-	panic("LabelValueFor called")
 }
 
 func (mockReaderOfLabels) SortedLabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {


### PR DESCRIPTION
The last use of this inside Prometheus was removed 4 years ago in #9907.

I also searched [Thanos](https://github.com/search?q=repo%3Athanos-io%2Fthanos%20LabelValueFor%20&type=code) and [Cortex](https://github.com/search?q=repo%3Acortexproject%2Fcortex+LabelValueFor+&type=code).

Mimir has one use, but it looks like it can be removed.

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
