### PR TITLE
docker: add distroless container build

### DIFF
--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,0 +1,49 @@
+ARG ARCH="amd64"
+ARG OS="linux"
+
+# Stage: get CA certs and tzdata from a small Debian image
+FROM debian:trixie-slim AS certs
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+# Final minimal image based on distroless static
+FROM gcr.io/distroless/static:nonroot
+
+# Image metadata
+LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+LABEL org.opencontainers.image.authors="The Prometheus Authors" \
+    org.opencontainers.image.vendor="Prometheus" \
+    org.opencontainers.image.title="Prometheus" \
+    org.opencontainers.image.description="The Prometheus monitoring system and time series database" \
+    org.opencontainers.image.source="https://github.com/prometheus/prometheus" \
+    org.opencontainers.image.url="https://github.com/prometheus/prometheus" \
+    org.opencontainers.image.documentation="https://prometheus.io/docs" \
+    org.opencontainers.image.licenses="Apache License 2.0"
+
+# Copy CA certs and timezone data from certs stage
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy the static Prometheus binaries and config
+COPY .build/${OS}-${ARCH}/prometheus        /bin/prometheus
+COPY .build/${OS}-${ARCH}/promtool          /bin/promtool
+COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
+COPY LICENSE                                /LICENSE
+COPY NOTICE                                 /NOTICE
+COPY npm_licenses.tar.bz2                   /npm_licenses.tar.bz2
+
+WORKDIR /prometheus
+RUN mkdir -p /etc/prometheus /prometheus \
+    && chown -R 65532:65532 /etc/prometheus /prometheus
+
+# distroless static:nonroot uses nonroot user (uid 65532)
+USER 65532
+
+EXPOSE 9090
+VOLUME [ "/prometheus" ]
+ENTRYPOINT [ "/bin/prometheus" ]
+CMD [ "--config.file=/etc/prometheus/prometheus.yml", \
+      "--storage.tsdb.path=/prometheus" ]

--- a/Makefile.common
+++ b/Makefile.common
@@ -226,6 +226,18 @@ $(BUILD_DOCKER_ARCHS): common-docker-%:
 		--build-arg OS="linux" \
 		$(DOCKERBUILD_CONTEXT)
 
+# Distroless image build target. Builds a minimal image containing only the
+# statically-linked binary and CA/TZ data. Usage: `make common-docker-distroless`
+DOCKERFILE_DISTROLESS_PATH ?= ./Dockerfile.distroless
+.PHONY: common-docker-distroless
+common-docker-distroless: $(addprefix common-docker-distroless-,$(DOCKER_ARCHS))
+$(addprefix common-docker-distroless-,$(DOCKER_ARCHS)): common-docker-distroless-%:
+	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)" \
+		-f $(DOCKERFILE_DISTROLESS_PATH) \
+		--build-arg ARCH="$*" \
+		--build-arg OS="linux" \
+		$(DOCKERBUILD_CONTEXT)
+
 .PHONY: common-docker-publish $(PUBLISH_DOCKER_ARCHS)
 common-docker-publish: $(PUBLISH_DOCKER_ARCHS)
 $(PUBLISH_DOCKER_ARCHS): common-docker-publish-%:


### PR DESCRIPTION
docker: add distroless container build option

This PR introduces support for building Prometheus container images based on [distroless](https://github.com/GoogleContainerTools/distroless) as an alternative to the current busybox-based images. The new distroless images contain only the statically linked Prometheus binaries, CA certificates, and timezone data, minimizing the attack surface and reducing vulnerability scanner noise.

**Key changes:**
- Adds `Dockerfile.distroless` for building minimal images using `gcr.io/distroless/static:nonroot` as the base.
- Copies CA certificates and timezone data from a small build stage (Debian).
- Integrates a `common-docker-distroless` target into `Makefile.common` to build these images for all configured architectures.
- Ensures required binaries and npm license assets are built before the image build.
- No changes to the default image build flow; distroless images are opt-in.

**Rationale:**
- Removes busybox and shell utilities from the final image, as Prometheus does not require them at runtime.
- Reduces the number of reported vulnerabilities for end users and organizations using automated container scanning.
- Aligns with best practices for minimal, secure container images.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"
    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    - Performance improvements would need a benchmark test to prove it.
    - All exposed objects should have a comment.
    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue-using-a-keyword
-->
- If there are no dependencies to Busybox, such as shell scripts, lets consider just the statically linked binary, CA and TZ data in the Prometheus container images.
- Minimizing the footprint would help the end-user organizations to focus on the real vulnerabilities. Organizations that do container scanning are easily overloaded by the amount of vulnerabilities. They might not have the capacity to see if each one of those is exploitable. Someone not knowing any better might see many Prometheus ecosystem images show up on their vulnerabilities radar and staying there for some time. This also becomes a problem for whoever runs their observability stack.
- Discussion from my PR in https://github.com/prometheus/busybox/pull/66 (Add prom/busybox:alpine image) to fix vulnerabilities on busybox.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[ENHANCEMENT] Added support for building Prometheus container images using distroless as a base. Use `make common-docker-distroless` to build minimal images containing only the Prometheus binaries, CA certificates, and timezone data.