### PR TITLE
Fix(discovery/aws): Added SetDirectory method to EC2SDConfig.

### DIFF
--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -116,6 +116,11 @@ func (c *EC2SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery
 	return NewEC2Discovery(c, opts)
 }
 
+// SetDirectory joins any relative file paths with dir.
+func (c *EC2SDConfig) SetDirectory(dir string) {
+	c.HTTPClientConfig.SetDirectory(dir)
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the EC2 Config.
 func (c *EC2SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultEC2SDConfig


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

NONE

#### Description:

EC2SDConfig has `HTTPClientConfig` (like TLS alerts) but does not implement SetDirectory, which is required as written in the README for configs with file paths. Others can be done similarly.

Should I start an issue regarding this first?

#### Does this PR introduce a user-facing change?

```release-note
BUGFIX: Ensure EC2 service discovery resolves file-based configuration paths correctly by implementing SetDirectory.
