### PR TITLE
tsdb: deprecate V1 block format with warning

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -39,6 +39,12 @@ import (
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 )
 
+var warnV1Once sync.Once
+
+func chunkDir(dir string) string {
+	return filepath.Join(dir, "chunks")
+}
+
 // IndexWriter serializes the index for a block of series data.
 // The methods must be called in the order they are specified in.
 type IndexWriter interface {
@@ -238,18 +244,27 @@ const (
 	CompactionHintFromOutOfOrder = "from-out-of-order"
 )
 
-func chunkDir(dir string) string { return filepath.Join(dir, "chunks") }
-
 func readMetaFile(dir string) (*BlockMeta, int64, error) {
+
 	b, err := os.ReadFile(filepath.Join(dir, metaFilename))
 	if err != nil {
 		return nil, 0, err
 	}
-	var m BlockMeta
 
+	var m BlockMeta
 	if err := json.Unmarshal(b, &m); err != nil {
 		return nil, 0, err
 	}
+
+	// ✅ Warning ONLY when V1 is used
+	if m.Version == metaVersion1 {
+		warnV1Once.Do(func() {
+			slog.Warn(
+				"TSDB V1 block format is deprecated and will be removed in a future release",
+			)
+		})
+	}
+
 	if m.Version != metaVersion1 {
 		return nil, 0, fmt.Errorf("unexpected meta file version %d", m.Version)
 	}


### PR DESCRIPTION
This PR deprecates support for TSDB V1 block format by adding a one-time warning when a V1 block is read.

Changes:
- Added `warnV1Once` global variable.
- Added a warning in readMetaFile() when a V1 block is detected.
- Ensures the warning is only logged once per process using sync.Once.

This does NOT remove V1 support yet. This is a first step to inform users that V1 blocks will be removed in a future Prometheus release (v4).

All TSDB tests pass.
