### PR TITLE
Do not notify the prometheus/default-maintainers team for code reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,28 +1,24 @@
-# Prometheus team members are members of the "default maintainers" github team.
-# They are code owners by default for the whole repo.
-* @prometheus/default-maintainers
-
 #
 # Please keep this file in sync with the MAINTAINERS.md file!
 #
 
 # Subsystems.
-/Makefile @simonpasquier @SuperQ @prometheus/default-maintainers
-/cmd/promtool @dgl @prometheus/default-maintainers
-/documentation/prometheus-mixin @metalmatze @prometheus/default-maintainers
-/model/histogram @beorn7 @krajorama @prometheus/default-maintainers
-/web/ui @juliusv @prometheus/default-maintainers
-/web/ui/module @juliusv @nexucis @prometheus/default-maintainers
-/promql @roidelapluie @prometheus/default-maintainers
-/storage/remote @cstyan @bwplotka @tomwilkie @npazosmendez @alexgreenbank @prometheus/default-maintainers
-/storage/remote/otlptranslator @aknuds1 @jesusvazquez @ArthurSens @prometheus/default-maintainers
-/tsdb @jesusvazquez @codesome @bwplotka @krajorama @prometheus/default-maintainers
+/Makefile @simonpasquier @SuperQ
+/cmd/promtool @dgl
+/documentation/prometheus-mixin @metalmatze
+/model/histogram @beorn7 @krajorama
+/web/ui @juliusv
+/web/ui/module @juliusv @nexucis
+/promql @roidelapluie
+/storage/remote @cstyan @bwplotka @tomwilkie @npazosmendez @alexgreenbank
+/storage/remote/otlptranslator @aknuds1 @jesusvazquez @ArthurSens
+/tsdb @jesusvazquez @codesome @bwplotka @krajorama
 
 # Service discovery.
-/discovery/kubernetes @brancz @prometheus/default-maintainers
-/discovery/stackit @jkroepke @prometheus/default-maintainers
+/discovery/kubernetes @brancz
+/discovery/stackit @jkroepke
 # Pending
 # https://github.com/prometheus/prometheus/pull/17105#issuecomment-3248209452
-# /discovery/aws/ @matt-gp @prometheus/default-maintainers
+# /discovery/aws/ @matt-gp
 # https://github.com/prometheus/prometheus/pull/15212#issuecomment-3575225179
-# /discovery/aliyun @KeyOfSpectator @prometheus/default-maintainers
+# /discovery/aliyun @KeyOfSpectator


### PR DESCRIPTION
Remove default-maintainers as the backup for all code. Everybody in that team is a prometheus team member, but not everybody wants to get notified for all review requests.

Downside is that if we enable require codeowners approval, the team member cannot approve any PR anymore.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
