### PR TITLE
UI: Add support to duplicate query panels

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/ExpressionInput.tsx
+++ b/web/ui/mantine-ui/src/pages/query/ExpressionInput.tsx
@@ -58,6 +58,7 @@ import { lintKeymap } from "@codemirror/lint";
 import {
   IconAlignJustified,
   IconBinaryTree,
+  IconCopy,
   IconDotsVertical,
   IconSearch,
   IconTerminal,
@@ -121,6 +122,7 @@ interface ExpressionInputProps {
   executeQuery: (expr: string) => void;
   treeShown: boolean;
   setShowTree: (showTree: boolean) => void;
+  duplicatePanel: (expr: string) => void;
   removePanel: () => void;
 }
 
@@ -128,6 +130,7 @@ const ExpressionInput: FC<ExpressionInputProps> = ({
   initialExpr,
   metricNames,
   executeQuery,
+  duplicatePanel,
   removePanel,
   treeShown,
   setShowTree,
@@ -249,6 +252,12 @@ const ExpressionInput: FC<ExpressionInputProps> = ({
                 onClick={() => setShowTree(!treeShown)}
               >
                 {treeShown ? "Hide" : "Show"} tree view
+              </Menu.Item>
+              <Menu.Item
+                leftSection={<IconCopy style={menuIconStyle} />}
+                onClick={() => duplicatePanel(expr)}
+              >
+                Duplicate query
               </Menu.Item>
               <Menu.Item
                 color="red"

--- a/web/ui/mantine-ui/src/pages/query/QueryPanel.tsx
+++ b/web/ui/mantine-ui/src/pages/query/QueryPanel.tsx
@@ -23,6 +23,7 @@ import { FC, Suspense, useCallback, useMemo, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import {
   addQueryToHistory,
+  duplicatePanel,
   GraphDisplayMode,
   GraphResolution,
   removePanel,
@@ -110,6 +111,9 @@ const QueryPanel: FC<PanelProps> = ({ idx, metricNames }) => {
           if (!showTree) {
             setSelectedNode(null);
           }
+        }}
+        duplicatePanel={(expr: string) => {
+          dispatch(duplicatePanel({ idx, expr }));
         }}
         removePanel={() => {
           dispatch(removePanel(idx));

--- a/web/ui/mantine-ui/src/state/queryPageSlice.ts
+++ b/web/ui/mantine-ui/src/state/queryPageSlice.ts
@@ -115,6 +115,19 @@ export const queryPageSlice = createSlice({
       state.panels.push(newDefaultPanel());
       updateURL(state.panels);
     },
+    duplicatePanel: (
+      state,
+      { payload }: PayloadAction<{ idx: number; expr: string }>
+    ) => {
+      const newPanel = {
+        ...state.panels[payload.idx],
+        id: randomId(),
+        expr: payload.expr,
+      };
+      // Insert the duplicated panel just below the original panel.
+      state.panels.splice(payload.idx + 1, 0, newPanel);
+      updateURL(state.panels);
+    },
     removePanel: (state, { payload }: PayloadAction<number>) => {
       state.panels.splice(payload, 1);
       updateURL(state.panels);
@@ -153,6 +166,7 @@ export const {
   setPanels,
   addPanel,
   removePanel,
+  duplicatePanel,
   setExpr,
   addQueryToHistory,
   setShowTree,


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
This PR adds a "Duplicate query" button to Prometheus query panels, making it easier to write and run multiple queries with same time range, resolution etc. When you click on Duplicate query, a new copy of the panel being duplicated is added just below it. This new panel has the same query, time range, resolution, visualization mode as the original panel.

**Why?** - When you're troubleshooting an incident, you often need to compare different metrics within the exact same time window. Currently, you have to manually re-enter the time range, resolution, and display settings for every new panel, which is tedious.


https://github.com/user-attachments/assets/6a877c5d-42ba-428b-bd2e-2ed58e6e8c9b



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] UI: Add an option on the query drop-down menu to duplicate that query panel
```
