### PR TITLE
Fix remote storage example to handle error returns from v2 methods.

### DIFF
--- a/documentation/examples/remote_storage/example_write_adapter/server.go
+++ b/documentation/examples/remote_storage/example_write_adapter/server.go
@@ -96,7 +96,11 @@ func printV1(req *prompb.WriteRequest) {
 func printV2(req *writev2.Request) {
 	b := labels.NewScratchBuilder(0)
 	for _, ts := range req.Timeseries {
-		l := ts.ToLabels(&b, req.Symbols)
+		l, err := ts.ToLabels(&b, req.Symbols)
+		if err != nil {
+			fmt.Printf("\tError converting labels: %v\n", err)
+			continue
+		}
 		m := ts.ToMetadata(req.Symbols)
 		fmt.Println(l, m)
 
@@ -104,7 +108,11 @@ func printV2(req *writev2.Request) {
 			fmt.Printf("\tSample:  %f %d\n", s.Value, s.Timestamp)
 		}
 		for _, ep := range ts.Exemplars {
-			e := ep.ToExemplar(&b, req.Symbols)
+			e, err := ep.ToExemplar(&b, req.Symbols)
+			if err != nil {
+				fmt.Printf("\tError converting exemplar: %v\n", err)
+				continue
+			}
 			fmt.Printf("\tExemplar:  %+v %f %d\n", e.Labels, e.Value, ep.Timestamp)
 		}
 		for _, hp := range ts.Histograms {


### PR DESCRIPTION
The ToLabels and ToExemplar methods return errors when used with v2 symbols, so proper error handling is required.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:

Fixes #17710 

<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
