### PR TITLE
tsdb/wlog: Reuse compression decode buffers in LiveReader to reduce allocations

### DIFF
--- a/tsdb/wlog/benchmark_test.go
+++ b/tsdb/wlog/benchmark_test.go
@@ -1,7 +1,22 @@
+// Copyright 2025 The Prometheus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package wlog
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -50,7 +65,7 @@ func BenchmarkLiveReader_ReadSegment(b *testing.B) {
 			_ = r.Record()
 		}
 		r.Close()
-		if r.Err() != nil && r.Err() != io.EOF {
+		if r.Err() != nil && !errors.Is(r.Err(), io.EOF) {
 			b.Fatal(r.Err())
 		}
 	}

--- a/tsdb/wlog/benchmark_test.go
+++ b/tsdb/wlog/benchmark_test.go
@@ -1,0 +1,57 @@
+package wlog
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/prometheus/common/promslog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/util/compression"
+)
+
+func BenchmarkLiveReader_ReadSegment(b *testing.B) {
+	dir := b.TempDir()
+	w, err := New(nil, nil, dir, compression.Snappy)
+	require.NoError(b, err)
+
+	// Create a dummy record roughly simulating a series or sample record.
+	// We want enough data to trigger compression and decoding.
+	rec := make([]byte, 1024)
+	for i := range rec {
+		rec[i] = byte(i % 256)
+	}
+
+	// Write enough records to fill a few pages.
+	var recs [][]byte
+	for range 1000 {
+		recs = append(recs, rec)
+	}
+	require.NoError(b, w.Log(recs...))
+	require.NoError(b, w.Close())
+
+	// Read the first segment file into memory.
+	segName := SegmentName(dir, 0)
+	segData, err := os.ReadFile(segName)
+	require.NoError(b, err)
+
+	logger := promslog.NewNopLogger()
+	// We reuse the metrics object as Watcher would (it's created once in NewWatcher)
+	metrics := NewLiveReaderMetrics(nil)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		// Simulate the loop in Watcher.readCheckpoint or similar where a new LiveReader is created for the segment.
+		r := NewLiveReader(logger, metrics, bytes.NewReader(segData))
+		for r.Next() {
+			_ = r.Record()
+		}
+		r.Close()
+		if r.Err() != nil && r.Err() != io.EOF {
+			b.Fatal(r.Err())
+		}
+	}
+}

--- a/tsdb/wlog/benchmark_test.go
+++ b/tsdb/wlog/benchmark_test.go
@@ -17,6 +17,7 @@ package wlog
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -27,46 +28,71 @@ import (
 	"github.com/prometheus/prometheus/util/compression"
 )
 
-func BenchmarkLiveReader_ReadSegment(b *testing.B) {
+func BenchmarkLiveReader_DecodeLargeRecord(b *testing.B) {
+	for _, readers := range []int{1, 16, 128} {
+		b.Run(fmt.Sprintf("readers=%d", readers), func(b *testing.B) {
+			benchmarkLiveReaderDecodeLargeRecord(b, readers)
+		})
+	}
+}
+
+func benchmarkLiveReaderDecodeLargeRecord(b *testing.B, readers int) {
 	dir := b.TempDir()
+
 	w, err := New(nil, nil, dir, compression.Snappy)
 	require.NoError(b, err)
 
-	// Create a dummy record roughly simulating a series or sample record.
-	// We want enough data to trigger compression and decoding.
-	rec := make([]byte, 1024)
-	for i := range rec {
-		rec[i] = byte(i % 256)
-	}
+	// Make the decoded record large, but highly compressible.
+	// This isolates the cost this benchmark is intended to expose:
+	// repeated snappy.Decode destination-buffer allocation when creating
+	// multiple LiveReader instances.
+	rec := bytes.Repeat([]byte{42}, 256*1024)
 
-	// Write enough records to fill a few pages.
-	var recs [][]byte
-	for range 1000 {
-		recs = append(recs, rec)
+	const records = 32
+	for range records {
+		require.NoError(b, w.Log(rec))
 	}
-	require.NoError(b, w.Log(recs...))
 	require.NoError(b, w.Close())
 
-	// Read the first segment file into memory.
-	segName := SegmentName(dir, 0)
-	segData, err := os.ReadFile(segName)
+	segData, err := os.ReadFile(SegmentName(dir, 0))
 	require.NoError(b, err)
 
 	logger := promslog.NewNopLogger()
-	// We reuse the metrics object as Watcher would (it's created once in NewWatcher)
 	metrics := NewLiveReaderMetrics(nil)
 
-	b.ResetTimer()
 	b.ReportAllocs()
+	b.SetBytes(int64(readers * records * len(rec)))
+	b.ResetTimer()
+
+	var sink int
 	for b.Loop() {
-		// Simulate the loop in Watcher.readCheckpoint or similar where a new LiveReader is created for the segment.
-		r := NewLiveReader(logger, metrics, bytes.NewReader(segData))
-		for r.Next() {
-			_ = r.Record()
+		total := 0
+		readRecords := 0
+
+		for range readers {
+			r := NewLiveReader(logger, metrics, bytes.NewReader(segData))
+			for r.Next() {
+				got := r.Record()
+				readRecords++
+				total += len(got)
+			}
+			r.Close()
+			if err := r.Err(); err != nil && !errors.Is(err, io.EOF) {
+				b.Fatal(err)
+			}
 		}
-		r.Close()
-		if r.Err() != nil && !errors.Is(r.Err(), io.EOF) {
-			b.Fatal(r.Err())
+
+		wantRecords := readers * records
+		if readRecords != wantRecords {
+			b.Fatalf("read %d records, want %d", readRecords, wantRecords)
 		}
+
+		wantBytes := readers * records * len(rec)
+		if total != wantBytes {
+			b.Fatalf("read %d bytes, want %d", total, wantBytes)
+		}
+
+		sink = total
 	}
+	_ = sink
 }

--- a/tsdb/wlog/live_reader.go
+++ b/tsdb/wlog/live_reader.go
@@ -107,10 +107,8 @@ type LiveReader struct {
 
 // Close closes the reader and returns the decode buffer to the pool.
 func (r *LiveReader) Close() {
-	if r.decBuf != nil {
-		compression.PutDecodeBuffer(r.decBuf)
-		r.decBuf = nil
-	}
+	compression.PutDecodeBuffer(r.decBuf)
+	r.decBuf = nil
 }
 
 // Err returns any errors encountered reading the WAL.  io.EOFs are not terminal

--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -397,6 +397,7 @@ func (w *Watcher) watch(segmentNum int, tail bool) error {
 	defer segment.Close()
 
 	reader := NewLiveReader(w.logger, w.readerMetrics, segment)
+	defer reader.Close()
 
 	size := int64(math.MaxInt64)
 	if !tail {
@@ -738,6 +739,7 @@ func (w *Watcher) readCheckpoint(checkpointDir string, readFn segmentReadFn) err
 
 		r := NewLiveReader(w.logger, w.readerMetrics, sr)
 		err = readFn(w, r, index, false)
+		r.Close()
 		sr.Close()
 		if err != nil && !errors.Is(err, io.EOF) {
 			return fmt.Errorf("readSegment %d: %w", index, err)


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

This PR addresses high memory allocations observed during WAL checkpoint reading, partially addressing #13174.

In `tsdb/wlog/watcher.go`, the `readCheckpoint` method iterates over WAL segments and creates a new `LiveReader` for each one. Previously, `LiveReader` initialized a fresh `compression.DecodeBuffer` every time. Consequently, the internal buffer passed to `snappy.Decode` always had zero capacity. 

Because the destination buffer was insufficient, `snappy.Decode` was forced to allocate a new byte slice for every decompressed record. In the context of a loop processing many segments, this resulted in excessive memory allocations and GC pressure.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
