### PR TITLE
PromQL: Add a size-1 pool of FPoint slices

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2480,8 +2480,9 @@ func (ev *evaluator) vectorSelectorSingle(it *storage.MemoizedSeriesIterator, of
 }
 
 var (
-	fPointPool zeropool.Pool[[]FPoint]
-	hPointPool zeropool.Pool[[]HPoint]
+	fPointPool  zeropool.Pool[[]FPoint]
+	fPoint1Pool zeropool.Pool[[]FPoint]
+	hPointPool  zeropool.Pool[[]HPoint]
 
 	// matrixSelectorHPool holds reusable histogram slices used by the matrix
 	// selector. The key difference between this pool and the hPointPool is that
@@ -2492,7 +2493,11 @@ var (
 )
 
 func getFPointSlice(sz int) []FPoint {
-	if p := fPointPool.Get(); p != nil {
+	if sz == 1 {
+		if p := fPoint1Pool.Get(); p != nil {
+			return p
+		}
+	} else if p := fPointPool.Get(); p != nil {
 		return p
 	}
 
@@ -2507,7 +2512,11 @@ func getFPointSlice(sz int) []FPoint {
 // This function is called with an estimated size which often can be over-estimated.
 func putFPointSlice(p []FPoint) {
 	if p != nil {
-		fPointPool.Put(p[:0])
+		if cap(p) == 1 {
+			fPoint1Pool.Put(p[:0])
+		} else {
+			fPointPool.Put(p[:0])
+		}
 	}
 }
 


### PR DESCRIPTION
This should work better when the PromQL engine is executing instant queries and range queries in rapid succession.

#### Does this PR introduce a user-facing change?
```release-notes
[PERF] PromQL: improve performance when executing both instant queries and range queries in rapid succession
```
