### PR TITLE
fix(config): check all fields in GlobalConfig.isZero()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -687,7 +687,16 @@ func (c *GlobalConfig) isZero() bool {
 		c.ScrapeProtocols == nil &&
 		c.ScrapeNativeHistograms == nil &&
 		!c.ConvertClassicHistogramsToNHCB &&
-		!c.AlwaysScrapeClassicHistograms
+		!c.AlwaysScrapeClassicHistograms &&
+		c.BodySizeLimit == 0 &&
+		c.SampleLimit == 0 &&
+		c.TargetLimit == 0 &&
+		c.LabelLimit == 0 &&
+		c.LabelNameLengthLimit == 0 &&
+		c.LabelValueLengthLimit == 0 &&
+		c.KeepDroppedTargets == 0 &&
+		c.MetricNameValidationScheme == model.UnsetValidation &&
+		c.MetricNameEscapingScheme == ""
 }
 
 const DefaultGoGCPercentage = 75


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

The `GlobalConfig.isZero()` method was missing checks for 9 fields that exist in the type. This caused the method to incorrectly return true when only these fields had non-zero values, resulting in user configurations being silently overwritten with defaults during YAML unmarshalling.

Added checks for: `BodySizeLimit`, `SampleLimit`, `TargetLimit`, `LabelLimit`, `LabelNameLengthLimit`, `LabelValueLengthLimit`, `KeepDroppedTargets`, `MetricNameValidationScheme`, and `MetricNameEscapingScheme`.

Consolidated `TestEmptyGlobalBlock` and new `GlobalConfig.isZero` tests under `TestGlobalConfig`.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] Config: Fix `global` block settings for `body_size_limit`, `sample_limit`, `target_limit`, `label_limit`, `label_name_length_limit`, `label_value_length_limit`, `keep_dropped_targets`, `metric_name_validation_scheme`, and `metric_name_escaping_scheme` being silently ignored when specified without other global settings
```
