### PR TITLE
PromQL Editor: add destroy() method to PromQLExtension for memory leak prevention

### DIFF
--- a/web/ui/module/codemirror-promql/src/client/prometheus.test.ts
+++ b/web/ui/module/codemirror-promql/src/client/prometheus.test.ts
@@ -1,0 +1,97 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { HTTPPrometheusClient, CachedPrometheusClient } from './prometheus';
+
+describe('HTTPPrometheusClient destroy', () => {
+  it('should be safe to call destroy multiple times', () => {
+    const client = new HTTPPrometheusClient({ url: 'http://localhost:8080' });
+    // First call
+    client.destroy();
+    // Second call should not throw
+    expect(() => client.destroy()).not.toThrow();
+  });
+
+  it('should abort in-flight requests when destroy is called', async () => {
+    let abortSignal: AbortSignal | null | undefined;
+
+    const mockFetch = (_url: RequestInfo, init?: RequestInit): Promise<Response> => {
+      abortSignal = init?.signal;
+      // Return a promise that never resolves to simulate an in-flight request
+      return new Promise(() => {});
+    };
+
+    const client = new HTTPPrometheusClient({
+      url: 'http://localhost:8080',
+      fetchFn: mockFetch,
+    });
+
+    // Start a request (don't await it)
+    client.labelNames();
+
+    // Verify the signal was captured and not aborted yet
+    expect(abortSignal).toBeDefined();
+    expect(abortSignal?.aborted).toBe(false);
+
+    // Destroy the client
+    client.destroy();
+
+    // Verify the request was aborted
+    expect(abortSignal?.aborted).toBe(true);
+  });
+});
+
+describe('CachedPrometheusClient destroy', () => {
+  it('should be safe to call destroy multiple times', () => {
+    const httpClient = new HTTPPrometheusClient({ url: 'http://localhost:8080' });
+    const cachedClient = new CachedPrometheusClient(httpClient);
+
+    // First call
+    cachedClient.destroy();
+    // Second call should not throw
+    expect(() => cachedClient.destroy()).not.toThrow();
+  });
+
+  it('should call destroy on the underlying HTTPPrometheusClient', () => {
+    const httpClient = new HTTPPrometheusClient({ url: 'http://localhost:8080' });
+
+    let destroyCalled = false;
+    const originalDestroy = httpClient.destroy.bind(httpClient);
+    httpClient.destroy = () => {
+      destroyCalled = true;
+      originalDestroy();
+    };
+
+    const cachedClient = new CachedPrometheusClient(httpClient);
+    cachedClient.destroy();
+
+    expect(destroyCalled).toBe(true);
+  });
+
+  it('should handle underlying clients without destroy method', () => {
+    // Create a minimal PrometheusClient without destroy
+    const minimalClient = {
+      labelNames: () => Promise.resolve([]),
+      labelValues: () => Promise.resolve([]),
+      metricMetadata: () => Promise.resolve({}),
+      series: () => Promise.resolve([]),
+      metricNames: () => Promise.resolve([]),
+      flags: () => Promise.resolve({}),
+    };
+
+    const cachedClient = new CachedPrometheusClient(minimalClient);
+
+    // Should not throw even though underlying client has no destroy
+    expect(() => cachedClient.destroy()).not.toThrow();
+  });
+});

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -575,6 +575,10 @@ export class HybridComplete implements CompleteStrategy {
     return this.prometheusClient;
   }
 
+  destroy(): void {
+    this.prometheusClient?.destroy?.();
+  }
+
   promQL(context: CompletionContext): Promise<CompletionResult | null> | CompletionResult | null {
     const { state, pos } = context;
     const tree = syntaxTree(state).resolve(pos, -1);

--- a/web/ui/module/codemirror-promql/src/complete/index.ts
+++ b/web/ui/module/codemirror-promql/src/complete/index.ts
@@ -19,6 +19,7 @@ import { CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 // Every different completion mode must implement this interface.
 export interface CompleteStrategy {
   promQL(context: CompletionContext): Promise<CompletionResult | null> | CompletionResult | null;
+  destroy?(): void;
 }
 
 // CompleteConfiguration should be used to customize the autocompletion.

--- a/web/ui/module/codemirror-promql/src/promql.test.ts
+++ b/web/ui/module/codemirror-promql/src/promql.test.ts
@@ -1,0 +1,58 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { PromQLExtension } from './promql';
+import { CompleteStrategy } from './complete';
+import { CompletionResult } from '@codemirror/autocomplete';
+
+describe('PromQLExtension destroy', () => {
+  it('should be safe to call destroy multiple times', () => {
+    const extension = new PromQLExtension();
+    // First call
+    extension.destroy();
+    // Second call should not throw
+    expect(() => extension.destroy()).not.toThrow();
+  });
+
+  it('should call destroy on the complete strategy if available', () => {
+    const extension = new PromQLExtension();
+
+    // Set up a mock complete strategy with destroy
+    let destroyCalled = false;
+    const mockCompleteStrategy: CompleteStrategy = {
+      promQL: (): CompletionResult | null => null,
+      destroy: () => {
+        destroyCalled = true;
+      },
+    };
+
+    extension.setComplete({ completeStrategy: mockCompleteStrategy });
+    extension.destroy();
+
+    expect(destroyCalled).toBe(true);
+  });
+
+  it('should handle complete strategies without destroy method', () => {
+    const extension = new PromQLExtension();
+
+    // Set up a mock complete strategy without destroy
+    const mockCompleteStrategy: CompleteStrategy = {
+      promQL: (): CompletionResult | null => null,
+    };
+
+    extension.setComplete({ completeStrategy: mockCompleteStrategy });
+
+    // Should not throw even though complete strategy has no destroy
+    expect(() => extension.destroy()).not.toThrow();
+  });
+});

--- a/web/ui/module/codemirror-promql/src/promql.ts
+++ b/web/ui/module/codemirror-promql/src/promql.ts
@@ -79,6 +79,10 @@ export class PromQLExtension {
     return this;
   }
 
+  destroy(): void {
+    this.complete.destroy?.();
+  }
+
   asExtension(languageType = LanguageType.PromQL): Extension {
     const language = promQLLanguage(languageType);
     let extension: Extension = [language];


### PR DESCRIPTION
When React components mount/unmount repeatedly, each creating a new PromQLExtension, memory leaks occur due to LRU caches with `ttlAutopurge` timers keeping references alive and in-flight HTTP requests holding closure references. This adds `destroy()` methods throughout the class hierarchy to properly release resources on unmount.

Changes:
- Add `destroy()` to PrometheusClient interface (optional)
- `HTTPPrometheusClient`: track `AbortController`s and abort pending requests
- `CachedPrometheusClient`: delegate to cache and underlying client
- `HybridComplete`: delegate to `prometheusClient`
- `CompleteStrategy`: add optional `destroy()` method
- `PromQLExtension`: delegate to complete strategy

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
Not yet reported.

<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
NONE
