### PR TITLE
promql: preallocate slice in extendFloats optimization

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -4418,9 +4418,9 @@ func extendFloats(floats []FPoint, mint, maxt int64, smoothed bool) []FPoint {
 		lastSampleIndex--
 	}
 
-	// TODO: Preallocate the length of the new list.
-	out := make([]FPoint, 0)
-	// Create the new floats list with the boundary samples and the inner samples.
+	count := max(lastSampleIndex-firstSampleIndex+1, 0)
+	out := make([]FPoint, 0, count+2)
+
 	out = append(out, FPoint{T: mint, F: left})
 	out = append(out, floats[firstSampleIndex:lastSampleIndex+1]...)
 	out = append(out, FPoint{T: maxt, F: right})


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR addresses a TODO in `promql/engine.go` regarding slice preallocation in the `extendFloats` function.

Previously, `extendFloats` initialized an empty slice and appended elements to it, potentially causing multiple underlying array allocations as the slice grew. This change calculates the exact required capacity (number of inner elements + 2 boundary points) beforehand and allocates the slice with that capacity to improve performance.

**Changes:**
- Calculated the count of elements to be included from the original slice.
- Used `make([]FPoint, 0, count+2)` to preallocate the destination slice.
- Added a check for `count > 0` to safely handle the slicing range.

**Testing:**
- Ran full project tests `go test ./...`, and all tests passed.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
