### PR TITLE
Document special labels that affect scraping and targets (`__address__`, `__scheme__`, `__metrics_path__`, `__scrape_interval__`, `__scrape_timeout__`)

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2973,11 +2973,10 @@ labels:
   [ <labelname>: <labelvalue> ... ]
 ```
 
-You can also use special labels like `__address__`, `__scheme__`, `__metrics_path__`,
-`__scrape_interval__`, `__scrape_timeout__` to customize the defined targets. These will
-override the respective settings in the scrape configuration. This is especially useful
-when combined with any of the service discovery mechanisms that do not support these
-settings directly.
+The special labels mentioned in the [relabeling](#relabel_config) section can also be
+used here to override the respective settings in the scrape configuration. This is
+especially useful when combined with any of the service discovery mechanisms that do not
+support these settings directly.
 
 ### `<relabel_config>`
 
@@ -2988,6 +2987,11 @@ in the configuration file.
 
 Initially, aside from the configured per-target labels, a target's `job`
 label is set to the `job_name` value of the respective scrape configuration.
+
+You can also use special labels like `__address__`, `__scheme__`, `__metrics_path__`,
+`__scrape_interval__`, `__scrape_timeout__` to customize the defined targets. These will
+override the respective settings in the scrape configuration.
+
 The `__address__` label is set to the `<host>:<port>` address of the target.
 After relabeling, the `instance` label is set to the value of `__address__` by default if
 it was not set during relabeling.


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
 
 Document special labels (`__address__`, `__scheme__`, `__metrics_path__`, `__scrape_interval__`, `__scrape_timeout__`) that affect scraping and targets.
 
Perhaps this is an apparent behavior of how Prometheus works but I wasn't able to pick up on any of this nuance from how the docs are currently written. I can kinda see the hints of how things work in the [`relabel_config`](https://github.com/prometheus/prometheus/blob/cfc88f80bcc0f37f63d893608b27cdecf34791c9/docs/configuration/configuration.md#relabel_config) docs but only after exposing myself to the following issues. And even so, it still feels unexplained that labels are able to affect how the target is scraped (that is not what I would assume).

 - https://github.com/prometheus/prometheus/discussions/13217
     - This is the best consolidated explanation how how `__metrics_path__` works
 - https://github.com/prometheus/prometheus/issues/1852
 - https://github.com/prometheus/prometheus/issues/4121
 - https://github.com/prometheus/prometheus/issues/4001
 - https://github.com/prometheus/prometheus/issues/910
 - https://github.com/prometheus/prometheus/issues/1176
 - https://github.com/prometheus/prometheus/discussions/9466
 - https://github.com/prometheus/prometheus/issues/2697#issuecomment-300424640
 - https://github.com/prometheus/prometheus/issues/4037
 - https://groups.google.com/g/prometheus-users/search?q=__metrics_path__
 
 ---
 
 For reference and for the curious, here is my real-life use case; using HTTP service discovery and proxying metrics from many processes under the same host/port (differentiated by the `__metrics_path__`): https://github.com/element-hq/synapse/pull/19336
 
 ### Dev notes
 
 - https://prometheus.io/docs/prometheus/latest/configuration/configuration/
 - https://prometheus.io/docs/prometheus/latest/http_sd/ 


#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```

Do documentation changes need a changelog?
