### PR TITLE
Fix(discovery/aws): Create Copies of Default Config

### DIFF
--- a/discovery/aws/aws.go
+++ b/discovery/aws/aws.go
@@ -101,7 +101,8 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	switch c.Role {
 	case RoleEC2:
 		if c.EC2SDConfig == nil {
-			c.EC2SDConfig = &DefaultEC2SDConfig
+			ec2Config := DefaultEC2SDConfig
+			c.EC2SDConfig = &ec2Config
 		}
 		c.EC2SDConfig.HTTPClientConfig = c.HTTPClientConfig
 		if c.Region != "" {
@@ -133,7 +134,8 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 	case RoleECS:
 		if c.ECSSDConfig == nil {
-			c.ECSSDConfig = &DefaultECSSDConfig
+			ecsConfig := DefaultECSSDConfig
+			c.ECSSDConfig = &ecsConfig
 		}
 		c.ECSSDConfig.HTTPClientConfig = c.HTTPClientConfig
 		if c.Region != "" {
@@ -165,7 +167,8 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 	case RoleLightsail:
 		if c.LightsailSDConfig == nil {
-			c.LightsailSDConfig = &DefaultLightsailSDConfig
+			lightsailConfig := DefaultLightsailSDConfig
+			c.LightsailSDConfig = &lightsailConfig
 		}
 		c.LightsailSDConfig.HTTPClientConfig = c.HTTPClientConfig
 		if c.Region != "" {

--- a/discovery/aws/aws_test.go
+++ b/discovery/aws/aws_test.go
@@ -177,3 +177,109 @@ port: 9300`,
 		})
 	}
 }
+
+// TestMultipleSDConfigsDoNotShareState verifies that multiple AWS SD configs
+// don't share the same underlying configuration object. This was a bug where
+// all configs pointed to the same global default, causing port and other
+// settings from one job to overwrite settings in another job.
+func TestMultipleSDConfigsDoNotShareState(t *testing.T) {
+	tests := []struct {
+		name         string
+		yaml         string
+		validateFunc func(t *testing.T, cfg1, cfg2 *SDConfig)
+	}{
+		{
+			name: "EC2MultipleJobsDifferentPorts",
+			yaml: `
+- role: ec2
+  region: us-west-2
+  port: 9100
+  filters:
+    - name: tag:Name
+      values: [host-1]
+- role: ec2
+  region: us-west-2
+  port: 9101
+  filters:
+    - name: tag:Name
+      values: [host-2]`,
+			validateFunc: func(t *testing.T, cfg1, cfg2 *SDConfig) {
+				require.Equal(t, RoleEC2, cfg1.Role)
+				require.Equal(t, RoleEC2, cfg2.Role)
+				require.NotNil(t, cfg1.EC2SDConfig)
+				require.NotNil(t, cfg2.EC2SDConfig)
+
+				// Verify ports are different and not shared
+				require.Equal(t, 9100, cfg1.EC2SDConfig.Port)
+				require.Equal(t, 9101, cfg2.EC2SDConfig.Port)
+
+				// Verify filters are different and not shared
+				require.Len(t, cfg1.EC2SDConfig.Filters, 1)
+				require.Len(t, cfg2.EC2SDConfig.Filters, 1)
+				require.Equal(t, []string{"host-1"}, cfg1.EC2SDConfig.Filters[0].Values)
+				require.Equal(t, []string{"host-2"}, cfg2.EC2SDConfig.Filters[0].Values)
+
+				// Most importantly: verify they're not the same pointer
+				require.NotSame(t, cfg1.EC2SDConfig, cfg2.EC2SDConfig,
+					"EC2SDConfig objects should not share the same memory address")
+			},
+		},
+		{
+			name: "ECSMultipleJobsDifferentPorts",
+			yaml: `
+- role: ecs
+  region: us-east-1
+  port: 8080
+  clusters: [cluster-a]
+- role: ecs
+  region: us-east-1
+  port: 8081
+  clusters: [cluster-b]`,
+			validateFunc: func(t *testing.T, cfg1, cfg2 *SDConfig) {
+				require.Equal(t, RoleECS, cfg1.Role)
+				require.Equal(t, RoleECS, cfg2.Role)
+				require.NotNil(t, cfg1.ECSSDConfig)
+				require.NotNil(t, cfg2.ECSSDConfig)
+
+				require.Equal(t, 8080, cfg1.ECSSDConfig.Port)
+				require.Equal(t, 8081, cfg2.ECSSDConfig.Port)
+				require.Equal(t, []string{"cluster-a"}, cfg1.ECSSDConfig.Clusters)
+				require.Equal(t, []string{"cluster-b"}, cfg2.ECSSDConfig.Clusters)
+
+				require.NotSame(t, cfg1.ECSSDConfig, cfg2.ECSSDConfig,
+					"ECSSDConfig objects should not share the same memory address")
+			},
+		},
+		{
+			name: "LightsailMultipleJobsDifferentPorts",
+			yaml: `
+- role: lightsail
+  region: eu-west-1
+  port: 7070
+- role: lightsail
+  region: eu-west-1
+  port: 7071`,
+			validateFunc: func(t *testing.T, cfg1, cfg2 *SDConfig) {
+				require.Equal(t, RoleLightsail, cfg1.Role)
+				require.Equal(t, RoleLightsail, cfg2.Role)
+				require.NotNil(t, cfg1.LightsailSDConfig)
+				require.NotNil(t, cfg2.LightsailSDConfig)
+
+				require.Equal(t, 7070, cfg1.LightsailSDConfig.Port)
+				require.Equal(t, 7071, cfg2.LightsailSDConfig.Port)
+
+				require.NotSame(t, cfg1.LightsailSDConfig, cfg2.LightsailSDConfig,
+					"LightsailSDConfig objects should not share the same memory address")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var configs []SDConfig
+			require.NoError(t, yaml.Unmarshal([]byte(tt.yaml), &configs))
+			require.Len(t, configs, 2)
+			tt.validateFunc(t, &configs[0], &configs[1])
+		})
+	}
+}


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
When multiple jobs use `aws_sd_configs` with different configurations (like different ports/filters/clusters), they were all sharing the same underlying configuration object. This happened because the code was assigning pointers to global default configuration variables instead of making copies. This meant that when configuration was changed for one job, it was also change it for others.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
