### PR TITLE
tsdb: compute head chunk count for status

### DIFF
--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -506,12 +506,22 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 	}
 
 	h.metrics.chunksCreated.Add(float64(len(mmc) + len(oooMmc)))
-	h.metrics.chunksRemoved.Add(float64(len(mSeries.mmappedChunks)))
-	h.metrics.chunks.Add(float64(len(mmc) + len(oooMmc) - len(mSeries.mmappedChunks)))
 
-	if mSeries.ooo != nil {
-		h.metrics.chunksRemoved.Add(float64(len(mSeries.ooo.oooMmappedChunks)))
-		h.metrics.chunks.Sub(float64(len(mSeries.ooo.oooMmappedChunks)))
+	// During WAL replay with duplicate series records (mSeries.ref != walSeriesRef),
+	// the old chunks in mSeries may not have been added to the gauge yet,
+	// so subtracting them would cause the gauge to go negative.
+	// Only count chunks as removed when we're certain they were previously added.
+	if mSeries.ref == walSeriesRef {
+		// Same series ref - old chunks were definitely counted, safe to subtract
+		h.metrics.chunksRemoved.Add(float64(len(mSeries.mmappedChunks)))
+		h.metrics.chunks.Add(float64(len(mmc) + len(oooMmc) - len(mSeries.mmappedChunks)))
+		if mSeries.ooo != nil {
+			h.metrics.chunksRemoved.Add(float64(len(mSeries.ooo.oooMmappedChunks)))
+			h.metrics.chunks.Sub(float64(len(mSeries.ooo.oooMmappedChunks)))
+		}
+	} else {
+		// Duplicate series with different ref - old chunks may not have been counted
+		h.metrics.chunks.Add(float64(len(mmc) + len(oooMmc)))
 	}
 
 	mSeries.mmappedChunks = mmc


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #10884

#### What this PR does / why we need it:
- Compute head chunk count from in-memory series data via `tsdb.Head.Stats` instead of casting `prometheus_tsdb_head_chunks`.
- Avoid negative chunkCount in `/api/v1/status/tsdb` when the metric drifts below zero.
- Add a unit test that validates the status endpoint uses the Stats value.

#### Does this PR introduce a user-facing change?
```release-notes
[BUGFIX] Use head series stats for chunkCount in /api/v1/status/tsdb to avoid negative values.
```

#### Testing
- `go test ./web/api/v1 -run TestTSDBStatusChunkCountFromStats`
