### PR TITLE
feature/azure-ad-certificate-auth

### DIFF
--- a/storage/remote/azuread/azuread_test.go
+++ b/storage/remote/azuread/azuread_test.go
@@ -231,6 +231,45 @@ func TestAzureAdConfig(t *testing.T) {
 		{
 			filename: "testdata/azuread_good_oauth_customscope.yaml",
 		},
+		// Valid certificate config.
+		{
+			filename: "testdata/azuread_good_certificate.yaml",
+		},
+		// Missing certificate client id.
+		{
+			filename: "testdata/azuread_bad_certificate_missingclientid.yaml",
+			err:      "must provide an Azure Certificate client_id in the Azure AD config",
+		},
+		// Missing certificate tenant id.
+		{
+			filename: "testdata/azuread_bad_certificate_missingtenantid.yaml",
+			err:      "must provide an Azure Certificate tenant_id in the Azure AD config",
+		},
+		// Missing certificate file.
+		{
+			filename: "testdata/azuread_bad_certificate_missingcertfile.yaml",
+			err:      "must provide an Azure Certificate certificate_file in the Azure AD config",
+		},
+		// Missing private key file.
+		{
+			filename: "testdata/azuread_bad_certificate_missingkeyfile.yaml",
+			err:      "must provide an Azure Certificate private_key_file in the Azure AD config",
+		},
+		// Invalid certificate client id.
+		{
+			filename: "testdata/azuread_bad_certificate_invalidclientid.yaml",
+			err:      "the provided Azure Certificate client_id is invalid",
+		},
+		// Invalid certificate tenant id.
+		{
+			filename: "testdata/azuread_bad_certificate_invalidtenantid.yaml",
+			err:      "the provided Azure Certificate tenant_id is invalid",
+		},
+		// Invalid config when both oauth and certificate is provided.
+		{
+			filename: "testdata/azuread_bad_oauthcertconfig.yaml",
+			err:      "cannot provide multiple authentication methods in the Azure AD config",
+		},
 	}
 	for _, c := range cases {
 		_, err := loadAzureAdConfig(c.filename)

--- a/storage/remote/azuread/testdata/azuread_bad_certificate_invalidclientid.yaml
+++ b/storage/remote/azuread/testdata/azuread_bad_certificate_invalidclientid.yaml
@@ -1,0 +1,6 @@
+cloud: AzurePublic
+certificate:
+  client_id: invalid-client-id
+  tenant_id: 00000000-a12b-3cd4-e56f-000000000000
+  certificate_file: /etc/prometheus/certs/app.crt
+  private_key_file: /etc/prometheus/certs/app.key

--- a/storage/remote/azuread/testdata/azuread_bad_certificate_invalidtenantid.yaml
+++ b/storage/remote/azuread/testdata/azuread_bad_certificate_invalidtenantid.yaml
@@ -1,0 +1,6 @@
+cloud: AzurePublic
+certificate:
+  client_id: 00000000-0000-0000-0000-000000000000
+  tenant_id: invalid@tenant#id
+  certificate_file: /etc/prometheus/certs/app.crt
+  private_key_file: /etc/prometheus/certs/app.key

--- a/storage/remote/azuread/testdata/azuread_bad_certificate_missingcertfile.yaml
+++ b/storage/remote/azuread/testdata/azuread_bad_certificate_missingcertfile.yaml
@@ -1,0 +1,5 @@
+cloud: AzurePublic
+certificate:
+  client_id: 00000000-0000-0000-0000-000000000000
+  tenant_id: 00000000-a12b-3cd4-e56f-000000000000
+  private_key_file: /etc/prometheus/certs/app.key

--- a/storage/remote/azuread/testdata/azuread_bad_certificate_missingclientid.yaml
+++ b/storage/remote/azuread/testdata/azuread_bad_certificate_missingclientid.yaml
@@ -1,0 +1,5 @@
+cloud: AzurePublic
+certificate:
+  tenant_id: 00000000-a12b-3cd4-e56f-000000000000
+  certificate_file: /etc/prometheus/certs/app.crt
+  private_key_file: /etc/prometheus/certs/app.key

--- a/storage/remote/azuread/testdata/azuread_bad_certificate_missingkeyfile.yaml
+++ b/storage/remote/azuread/testdata/azuread_bad_certificate_missingkeyfile.yaml
@@ -1,0 +1,5 @@
+cloud: AzurePublic
+certificate:
+  client_id: 00000000-0000-0000-0000-000000000000
+  tenant_id: 00000000-a12b-3cd4-e56f-000000000000
+  certificate_file: /etc/prometheus/certs/app.crt

--- a/storage/remote/azuread/testdata/azuread_bad_certificate_missingtenantid.yaml
+++ b/storage/remote/azuread/testdata/azuread_bad_certificate_missingtenantid.yaml
@@ -1,0 +1,5 @@
+cloud: AzurePublic
+certificate:
+  client_id: 00000000-0000-0000-0000-000000000000
+  certificate_file: /etc/prometheus/certs/app.crt
+  private_key_file: /etc/prometheus/certs/app.key

--- a/storage/remote/azuread/testdata/azuread_bad_oauthcertconfig.yaml
+++ b/storage/remote/azuread/testdata/azuread_bad_oauthcertconfig.yaml
@@ -1,0 +1,10 @@
+cloud: AzurePublic
+oauth:
+  client_id: 00000000-0000-0000-0000-000000000000
+  client_secret: Cl1ent$ecret!
+  tenant_id: 00000000-a12b-3cd4-e56f-000000000000
+certificate:
+  client_id: 00000000-0000-0000-0000-000000000000
+  tenant_id: 00000000-a12b-3cd4-e56f-000000000000
+  certificate_file: /etc/prometheus/certs/app.crt
+  private_key_file: /etc/prometheus/certs/app.key

--- a/storage/remote/azuread/testdata/azuread_good_certificate.yaml
+++ b/storage/remote/azuread/testdata/azuread_good_certificate.yaml
@@ -1,0 +1,6 @@
+cloud: AzurePublic
+certificate:
+  client_id: 00000000-0000-0000-0000-000000000000
+  tenant_id: 00000000-a12b-3cd4-e56f-000000000000
+  certificate_file: /etc/prometheus/certs/app.crt
+  private_key_file: /etc/prometheus/certs/app.key


### PR DESCRIPTION
<!--
release-notes
Add support for Azure AD authentication using ClientCertificateCredential,
comprehensive certificate and configuration validation, and new test coverage.
-->

This PR adds native support for certificate-based OAuth authentication for Azure AD remote write, addressing issue #17751.

Currently, Prometheus supports Azure AD authentication via client secrets, managed identities, and workload identity. However, it lacks support for certificate-based authentication, which is required by many enterprise security policies and provides stronger security than client secrets.

This implementation allows Prometheus to authenticate with Azure AD using X.509 client certificates, eliminating the need for the Microsoft sidecar (which is on the deprecation path) and enabling native integration with Azure Monitor.

Changes Made
Core Implementation
Added 
CertificateConfig
 struct for certificate-based authentication configuration
Extended 
AzureADConfig
 to include certificate as a new authentication method
Implemented 
newCertificateTokenCredential()
 function that:
Reads certificate and private key files from disk
Parses them using azidentity.ParseCertificates()
Creates ClientCertificateCredential for Azure AD authentication
Enhanced validation logic to support certificate configuration with proper error messages
Testing
Added 8 comprehensive test cases covering:
Valid certificate configuration
Missing required fields (client_id, tenant_id, certificate_file, private_key_file)
Invalid field formats (UUID validation, tenant ID pattern)
Multiple authentication method conflict detection
Created 8 test data YAML files for all validation scenarios
Files Changed
storage/remote/azuread/azuread.go
 (~100 lines added)
storage/remote/azuread/azuread_test.go
 (~40 lines added)
8 new test data files in storage/remote/azuread/testdata/
Configuration Example
yaml
remote_write:
  - url: https://<dce-endpoint>/dataCollectionRules/<dcr-id>/streams/Microsoft-PrometheusMetrics/api/v1/write
    azuread:
      cloud: AzurePublic
      certificate:
        client_id: "12345678-1234-1234-1234-123456789abc"
        tenant_id: "87654321-4321-4321-4321-cba987654321"
        certificate_file: "/etc/prometheus/certs/app.crt"
        private_key_file: "/etc/prometheus/certs/app.key"
Benefits
✅ Enhanced Security: Certificate-based authentication is more secure than client secrets
✅ No Sidecar Required: Eliminates the need for the Microsoft sidecar container
✅ Enterprise Compliance: Meets security policies requiring certificate-based authentication
✅ Certificate Rotation: Supports automatic certificate rotation without code changes
✅ Backwards Compatible: All existing authentication methods continue to work unchanged
✅ Native Integration: Follows Prometheus patterns and uses standard Azure SDK
Testing Performed
 All existing tests pass
 New unit tests added and passing
 Configuration validation tests for all error scenarios
 Code follows Go conventions and passes gofmt
 No breaking changes to existing functionality
Checklist
 Code follows the project's coding standards
 Tests added for new functionality
 All tests pass locally
 Documentation is clear in code comments
 Commits are signed off (DCO)
 No breaking changes
 Backwards compatible with existing configurations
Related Issues
Closes #17751

Additional Notes
This implementation:

Uses the existing Azure SDK's ClientCertificateCredential
Follows the same patterns as other authentication methods (OAuth, Managed Identity, Workload Identity)
Validates that only one authentication method is configured at a time
Provides clear, descriptive error messages for all validation failures
Reads certificate and key files at runtime using os.ReadFile()
Parses certificates using azidentity.ParseCertificates() which handles PEM-encoded files
The certificate and private key files should be in PEM format. For Kubernetes deployments, these can be mounted as secrets.
