### PR TITLE
web: fix /-/ready stopping header and add tests

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -634,8 +634,8 @@ func (h *Handler) testReady(f http.HandlerFunc) http.HandlerFunc {
 		case Ready:
 			f(w, r)
 		case NotReady:
-			w.WriteHeader(http.StatusServiceUnavailable)
 			w.Header().Set("X-Prometheus-Stopping", "false")
+			w.WriteHeader(http.StatusServiceUnavailable)
 			fmt.Fprintf(w, "Service Unavailable")
 		case Stopping:
 			w.Header().Set("X-Prometheus-Stopping", "true")

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -140,11 +140,32 @@ func TestReadyAndHealthy(t *testing.T) {
 		resp, err = http.Get(u)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		require.Equal(t, "false", resp.Header.Get("X-Prometheus-Stopping"))
 		cleanupTestResponse(t, resp)
 
 		resp, err = http.Head(u)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		require.Equal(t, "false", resp.Header.Get("X-Prometheus-Stopping"))
+		cleanupTestResponse(t, resp)
+	}
+
+	// Set to stopping
+	webHandler.SetReady(Stopping)
+
+	for _, u := range []string{
+		baseURL + "/-/ready",
+	} {
+		resp, err = http.Get(u)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		require.Equal(t, "true", resp.Header.Get("X-Prometheus-Stopping"))
+		cleanupTestResponse(t, resp)
+
+		resp, err = http.Head(u)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		require.Equal(t, "true", resp.Header.Get("X-Prometheus-Stopping"))
 		cleanupTestResponse(t, resp)
 	}
 


### PR DESCRIPTION
### What this PR does

1. Fixes the missing `X-Prometheus-Stopping` header issue for the `/-/ready` endpoint when Prometheus is in `NotReady` state (previously, the header was never sent for this state).  
2. Adds comprehensive test coverage to verify:
   - `X-Prometheus-Stopping: false` is returned for `NotReady` state.
   - `X-Prometheus-Stopping: true` is returned for `Stopping` state.
   - Consistency of the above behavior across `GET` and `HEAD` requests to the `/-/ready` endpoint.

### Why

The existing tests only asserted HTTP status codes and did not verify the presence or value of the `X-Prometheus-Stopping` header, which could cause unclear readiness status signals.

### Notes

The test assertions are intentionally kept explicit to make the readiness state transitions
(`NotReady` → `Stopping` → `Ready`) and their HTTP behavior easy to read and debug.
If a more DRY-style test structure is preferred, I’m happy to follow up and refactor accordingly.

#### Which issue(s) does the PR fix:

NONE

#### Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] Web: Fix missing `X-Prometheus-Stopping` header for `/-/ready` endpoint in `NotReady` state, and add test coverage for header validation. #17795
```
