### PR TITLE
tsdb/agent: prevent appenderBase from being put back into pool

### DIFF
--- a/tsdb/agent/db_append_v2.go
+++ b/tsdb/agent/db_append_v2.go
@@ -36,6 +36,26 @@ type appenderV2 struct {
 	appenderBase
 }
 
+func (a *appenderV2) Commit() error {
+	if err := a.commitBase(); err != nil {
+		return err
+	}
+	a.appenderV2Pool.Put(a)
+
+	if a.writeNotified != nil {
+		a.writeNotified.Notify()
+	}
+	return nil
+}
+
+func (a *appenderV2) Rollback() error {
+	if err := a.rollbackBase(); err != nil {
+		return err
+	}
+	a.appenderV2Pool.Put(a)
+	return nil
+}
+
 // Append appends pending sample to agent's DB.
 // TODO: Wire metadata in the Agent's appender.
 func (a *appenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, opts storage.AOptions) (storage.SeriesRef, error) {


### PR DESCRIPTION
When Commit() or Rollback() were called on an *appender, the method receiver was *appenderBase, causing the base struct to be put back into the pool instead of the full *appender. On the next Get(), the pool would return *appenderBase, which doesn't implement the full storage.Appender interface (missing Append method), causing a panic.

This fix moves Commit() and Rollback() from *appenderBase to *appender and *appenderV2, ensuring the correct types are returned to their respective pools.

Fixes #17800


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] Agent: Fix appender pool type conversion panic.
```
