### PR TITLE
[BUGFIX] Scraping: return empty label set if sample is not to be kept

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -613,7 +613,9 @@ func mutateSampleLabels(lset labels.Labels, target *Target, honor bool, rc []*re
 		}
 	}
 
-	relabel.ProcessBuilder(lb, rc...)
+	if keep := relabel.ProcessBuilder(lb, rc...); !keep {
+		return labels.EmptyLabels()
+	}
 
 	return lb.Labels()
 }


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
The change introduced in #17530 caused metric relabeling configs that did not modify any labels but instead only kept a subset of series (via `action: keep` or `action: drop`) to not take effect, as the actual label set was never modified by `relabel.ProcessBuilder`.

This is a minimally invasive fix restoring the old behavior, mirroring what `relabel.Process` does.

#### Does this PR introduce a user-facing change?
```release-notes
[BUGFIX] Scraping: drop sample if relabeling config says so
```
