### PR TITLE
chore(kubernetes): deduplicate deprecation warning logs from the API

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -55,6 +55,7 @@ import (
 	toolkit_web "github.com/prometheus/exporter-toolkit/web"
 	"go.uber.org/atomic"
 	"go.uber.org/automaxprocs/maxprocs"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	klogv2 "k8s.io/klog/v2"
 
@@ -836,6 +837,9 @@ func main() {
 
 	klogv2.SetSlogLogger(logger.With("component", "k8s_client_runtime"))
 	klog.SetOutputBySeverity("INFO", klogv1Writer{})
+	// Avoid duplicate API deprecation warnings (e.g., "v1 Endpoints is deprecated in v1.33+...")
+	// that can pollute the logs.
+	rest.SetDefaultWarningHandlerWithContext(logging.NewDedupDeprecationWarningLogger())
 
 	modeAppName := "Prometheus Server"
 	mode := "server"

--- a/util/logging/dedupe.go
+++ b/util/logging/dedupe.go
@@ -18,6 +18,9 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/grafana/regexp"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -133,4 +136,45 @@ func (d *Deduper) run() {
 			return
 		}
 	}
+}
+
+// deprecationRegex matches the format of Kubernetes API deprecation warnings:
+// See https://github.com/kubernetes/kubernetes/blob/da663405beb487d66c27a0220ea4073305ae9077/staging/src/k8s.io/apiserver/pkg/endpoints/deprecation/deprecation.go#L117.
+var deprecationRegex = regexp.MustCompile(`\S+ \S+ is deprecated in v\d+\.\d+\+`)
+
+// Even though deprecation warnings should be bounded in number, this safeguard should help prevent leaks.
+const maxDeprecationWarnings = 32
+
+// DedupDeprecationWarningLogger deduplicates Kube API deprecation warnings by message before logging them.
+// Inspired by https://github.com/kubernetes/kubernetes/blob/3edae6c1c49958fd10a708d9cc8c4c9e7f5fb6e8/staging/src/k8s.io/client-go/rest/warnings.go#L113
+type DedupDeprecationWarningLogger struct {
+	logger rest.WarningHandlerWithContext
+	lock   sync.Mutex
+	logged map[string]struct{}
+}
+
+func NewDedupDeprecationWarningLogger() *DedupDeprecationWarningLogger {
+	return &DedupDeprecationWarningLogger{
+		logger: rest.WarningLogger{},
+		logged: make(map[string]struct{}),
+	}
+}
+
+func (w *DedupDeprecationWarningLogger) HandleWarningHeaderWithContext(ctx context.Context, code int, agent, message string) {
+	if code != 299 || message == "" {
+		return
+	}
+
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	if _, seen := w.logged[message]; seen {
+		return
+	}
+
+	if deprecationRegex.MatchString(message) && len(w.logged) < maxDeprecationWarnings {
+		w.logged[message] = struct{}{}
+	}
+
+	w.logger.HandleWarningHeaderWithContext(ctx, code, agent, message)
 }

--- a/util/logging/dedupe_test.go
+++ b/util/logging/dedupe_test.go
@@ -15,6 +15,8 @@ package logging
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -79,4 +81,34 @@ func TestDedupeConcurrent(t *testing.T) {
 	}
 
 	require.NotPanics(t, func() { concurrentWriteFunc() })
+}
+
+type fakeWarningLogger struct {
+	logs []string
+}
+
+func (fl *fakeWarningLogger) HandleWarningHeaderWithContext(_ context.Context, _ int, _, message string) {
+	fl.logs = append(fl.logs, message)
+}
+
+func TestDedupeDeprecationWarningLogger(t *testing.T) {
+	wl := DedupDeprecationWarningLogger{
+		logger: &fakeWarningLogger{},
+		logged: make(map[string]struct{}),
+	}
+
+	deprecationMessage := "v1 Endpoints is deprecated in v1.33+; use [discovery.k8s.io/v1](http://discovery.k8s.io/v1) EndpointSlice"
+	for range 10 {
+		wl.HandleWarningHeaderWithContext(context.Background(), 299, "", deprecationMessage)
+	}
+	require.Len(t, wl.logger.(*fakeWarningLogger).logs, 1)
+	require.Len(t, wl.logged, 1)
+	require.Equal(t, wl.logger.(*fakeWarningLogger).logs[0], deprecationMessage)
+
+	for i := range 10 {
+		wl.HandleWarningHeaderWithContext(context.Background(), 299, "", fmt.Sprintf("some other warning %d", i+1))
+	}
+	require.Len(t, wl.logger.(*fakeWarningLogger).logs, 11)
+	require.Len(t, wl.logged, 1)
+	require.Equal(t, "some other warning 10", wl.logger.(*fakeWarningLogger).logs[10])
 }


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
 
 API warnings (for example, “v1 endpoints are deprecated in v1.33+”) are logged redundantly by default. On some setups, these logs can become extremely verbose and confusing, particularly when users are unable to address the warning in the near term.

On a Prometheus instance running on a fairly active cluster: over a 40 minute period, more than 360 such log entries like `time=2026-01-06T18:44:13.494Z level=INFO source=warnings.go:110 msg="Warning: v1 Endpoints is deprecated in v1.33+; use [discovery.k8s.io/v1](http://discovery.k8s.io/v1) EndpointSlice" component=k8s_client_runtime` were generated.

Spamming Kubernetes API clients with warning logs is not an effective way to inform users about deprecations. This use case is better addressed through alerts, for example by leveraging the `apiserver_requested_deprecated_apis` metric.

The proposed change is to log each warning only once, reducing noise while still ensuring that deprecation information is available.

(I could try to change the default warning logger upstream, but I doubt such a change would be accepted. Still, I am willing to give it a try.)

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[ENHANCEMENT] Kubernetes SD: Deduplicate deprecation warning logs from the Kubernetes API to reduce noise.
```
