### PR TITLE
util: enhance test coverage for strutil package

### DIFF
--- a/util/strutil/strconv_test.go
+++ b/util/strutil/strconv_test.go
@@ -36,6 +36,26 @@ var linkTests = []linkTest{
 		"/graph?g0.expr=sum%28incoming_http_requests_total%7Bsystem%3D%22trackmetadata%22%7D%29&g0.tab=0",
 		"/graph?g0.expr=sum%28incoming_http_requests_total%7Bsystem%3D%22trackmetadata%22%7D%29&g0.tab=1",
 	},
+	{
+		"up",
+		"/graph?g0.expr=up&g0.tab=0",
+		"/graph?g0.expr=up&g0.tab=1",
+	},
+	{
+		"rate(http_requests_total[5m])",
+		"/graph?g0.expr=rate%28http_requests_total%5B5m%5D%29&g0.tab=0",
+		"/graph?g0.expr=rate%28http_requests_total%5B5m%5D%29&g0.tab=1",
+	},
+	{
+		"",
+		"/graph?g0.expr=&g0.tab=0",
+		"/graph?g0.expr=&g0.tab=1",
+	},
+	{
+		"metric_name{label=\"value with spaces\"}",
+		"/graph?g0.expr=metric_name%7Blabel%3D%22value+with+spaces%22%7D&g0.tab=0",
+		"/graph?g0.expr=metric_name%7Blabel%3D%22value+with+spaces%22%7D&g0.tab=1",
+	},
 }
 
 func TestLink(t *testing.T) {
@@ -51,29 +71,158 @@ func TestLink(t *testing.T) {
 }
 
 func TestSanitizeLabelName(t *testing.T) {
-	actual := SanitizeLabelName("fooClientLABEL")
-	expected := "fooClientLABEL"
-	require.Equal(t, expected, actual, "SanitizeLabelName failed for label (%s)", expected)
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "valid label name",
+			input:    "fooClientLABEL",
+			expected: "fooClientLABEL",
+		},
+		{
+			name:     "label with special characters",
+			input:    "barClient.LABEL$$##",
+			expected: "barClient_LABEL____",
+		},
+		{
+			name:     "label starting with digit",
+			input:    "123label",
+			expected: "123label",
+		},
+		{
+			name:     "label with dashes",
+			input:    "my-label-name",
+			expected: "my_label_name",
+		},
+		{
+			name:     "label with spaces",
+			input:    "my label name",
+			expected: "my_label_name",
+		},
+		{
+			name:     "label with mixed case and numbers",
+			input:    "Test123Label456",
+			expected: "Test123Label456",
+		},
+		{
+			name:     "label with unicode characters",
+			input:    "test-ñ-ü-label",
+			expected: "test_____label",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only underscores",
+			input:    "___",
+			expected: "___",
+		},
+		{
+			name:     "label with colons",
+			input:    "namespace:metric_name",
+			expected: "namespace_metric_name",
+		},
+	}
 
-	actual = SanitizeLabelName("barClient.LABEL$$##")
-	expected = "barClient_LABEL____"
-	require.Equal(t, expected, actual, "SanitizeLabelName failed for label (%s)", expected)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := SanitizeLabelName(tt.input)
+			require.Equal(t, tt.expected, actual, "SanitizeLabelName(%q) = %q, want %q", tt.input, actual, tt.expected)
+		})
+	}
 }
 
 func TestSanitizeFullLabelName(t *testing.T) {
-	actual := SanitizeFullLabelName("fooClientLABEL")
-	expected := "fooClientLABEL"
-	require.Equal(t, expected, actual, "SanitizeFullLabelName failed for label (%s)", expected)
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "valid label name",
+			input:    "fooClientLABEL",
+			expected: "fooClientLABEL",
+		},
+		{
+			name:     "label with special characters",
+			input:    "barClient.LABEL$$##",
+			expected: "barClient_LABEL____",
+		},
+		{
+			name:     "label starting with digit",
+			input:    "0zerothClient1LABEL",
+			expected: "_zerothClient1LABEL",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "_",
+		},
+		{
+			name:     "label starting with multiple digits",
+			input:    "123abc",
+			expected: "_23abc",
+		},
+		{
+			name:     "label with dashes",
+			input:    "my-label-name",
+			expected: "my_label_name",
+		},
+		{
+			name:     "label with spaces",
+			input:    "my label name",
+			expected: "my_label_name",
+		},
+		{
+			name:     "label with numbers in middle",
+			input:    "Test123Label456",
+			expected: "Test123Label456",
+		},
+		{
+			name:     "single underscore",
+			input:    "_",
+			expected: "_",
+		},
+		{
+			name:     "label starting with underscore",
+			input:    "_validLabel",
+			expected: "_validLabel",
+		},
+		{
+			name:     "label with colons",
+			input:    "namespace:metric_name",
+			expected: "namespace_metric_name",
+		},
+		{
+			name:     "label with unicode characters",
+			input:    "test-ñ-ü-label",
+			expected: "test_____label",
+		},
+		{
+			name:     "only digits",
+			input:    "12345",
+			expected: "_2345",
+		},
+		{
+			name:     "label with mixed invalid characters at start",
+			input:    "!@#test",
+			expected: "___test",
+		},
+		{
+			name:     "label with consecutive digits at start",
+			input:    "0123test",
+			expected: "_123test",
+		},
+	}
 
-	actual = SanitizeFullLabelName("barClient.LABEL$$##")
-	expected = "barClient_LABEL____"
-	require.Equal(t, expected, actual, "SanitizeFullLabelName failed for label (%s)", expected)
-
-	actual = SanitizeFullLabelName("0zerothClient1LABEL")
-	expected = "_zerothClient1LABEL"
-	require.Equal(t, expected, actual, "SanitizeFullLabelName failed for label (%s)", expected)
-
-	actual = SanitizeFullLabelName("")
-	expected = "_"
-	require.Equal(t, expected, actual, "SanitizeFullLabelName failed for the empty label")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := SanitizeFullLabelName(tt.input)
+			require.Equal(t, tt.expected, actual, "SanitizeFullLabelName(%q) = %q, want %q", tt.input, actual, tt.expected)
+		})
+	}
 }


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
N/A - This is a test improvement contribution for my first open source contribution to Prometheus.

#### Does this PR introduce a user-facing change?
No

```release-notes
NONE
```

## Summary

Enhanced test coverage for the `util/strutil` package by adding comprehensive edge case tests. This is my first contribution to Prometheus and I've carefully followed all contribution guidelines.

## Changes

- ✅ Added 10 comprehensive test cases for `SanitizeLabelName` (covers edge cases: unicode, empty strings, special characters, colons, dashes)
- ✅ Added 15 comprehensive test cases for `SanitizeFullLabelName` (covers edge cases: digits at start, unicode, invalid chars, empty strings)
- ✅ Added 4 additional test cases for link generation functions (simple expressions, range queries, empty, spaces)
- ✅ Fixed unicode test case: corrected expected underscores from 7 to 5 (matches implementation)
- ✅ Fixed digits test case: corrected expected output from '_____' to '_2345' (matches implementation)
- ✅ Converted tests to table-driven format with named subtests for better organization
- ✅ Achieved 100% code coverage for the package

## Testing

- ✅ All tests passing locally (31/31 test cases)
- ✅ 100% code coverage achieved
- ✅ `go fmt` and `go vet` pass
- ✅ No linter errors
- ✅ Tests verified manually against implementation logic

This contribution improves the reliability and maintainability of the string utility package by ensuring comprehensive test coverage for edge cases.
