### PR TITLE
build: update react-router to v7.12.0 to fix CVE-2026-21884

### DIFF
--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -7823,9 +7823,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.5.tgz",
-      "integrity": "sha512-JmxqrnBZ6E9hWmf02jzNn9Jm3UqyeimyiwzD69NjxGySG6lIz/1LVPsoTCwN7NBX2XjCEa1LIX5EMz1j2b6u6A==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
+      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"


### PR DESCRIPTION
To fix CVE-2026-21884 HIGH severity vulnerability

#### Which issue(s) does the PR fix:
Fixes [CVE-2026-21884](https://nvd.nist.gov/vuln/detail/CVE-2026-21884).

#### Does this PR introduce a user-facing change?
[SECURITY] Update react-router to v7.12.0 to fix a high-severity XSS vulnerability (CVE-2026-21884) in the ScrollRestoration API during SSR.

```release-notes
NONE
```
