### PR TITLE
notifier/scrape: fix CPU spin loop on shutdown when target channel closes

### DIFF
--- a/notifier/manager.go
+++ b/notifier/manager.go
@@ -204,6 +204,10 @@ func (n *Manager) ApplyConfig(conf *config.Config) error {
 // Refer to https://github.com/prometheus/prometheus/issues/13676 for more details.
 func (n *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) {
 	n.targetUpdateLoop(tsets)
+	// The target update loop also returns when tsets is closed, so wait for Stop before
+	// cleaning up the send loops. This keeps callers in control of shutdown ordering, so
+	// that rule evaluation can finish sending notifications.
+	<-n.stopRequested
 
 	n.mtx.Lock()
 	defer n.mtx.Unlock()
@@ -227,7 +231,8 @@ func (n *Manager) targetUpdateLoop(tsets <-chan map[string][]*targetgroup.Group)
 				return
 			case ts, ok := <-tsets:
 				if !ok {
-					break
+					// The discovery manager has closed the channel, no more updates are coming.
+					return
 				}
 				n.reload(ts)
 			}

--- a/notifier/manager_test.go
+++ b/notifier/manager_test.go
@@ -1127,6 +1127,77 @@ alerting:
 	require.Empty(t, n.Alertmanagers())
 }
 
+// TestManagerClosedTargetSetsChannel checks that the manager copes with the discovery
+// manager closing the target sets channel on shutdown: the target update loop stops
+// instead of busy-spinning on the closed channel, while Run keeps going until Stop is
+// called.
+func TestManagerClosedTargetSetsChannel(t *testing.T) {
+	t.Run("target update loop returns", func(t *testing.T) {
+		m := NewManager(&Options{}, model.UTF8Validation, nil)
+		defer m.Stop()
+
+		tsets := make(chan map[string][]*targetgroup.Group)
+		loopDone := make(chan struct{})
+		go func() {
+			m.targetUpdateLoop(tsets)
+			close(loopDone)
+		}()
+		close(tsets)
+
+		select {
+		case <-loopDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("target update loop did not stop after the target sets channel was closed")
+		}
+	})
+
+	t.Run("Run waits for Stop", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			m := NewManager(&Options{}, model.UTF8Validation, nil)
+			defer m.Stop()
+
+			amCfg := config.DefaultAlertmanagerConfig
+			ams := newTestAlertmanagerSet(&amCfg, nil, m.opts, m.metrics, "http://alertmanager:9093/api/v2/alerts")
+			m.alertmanagers = map[string]*alertmanagerSet{"test": ams}
+			ams.startSendLoops(ams.ams)
+
+			tsets := make(chan map[string][]*targetgroup.Group)
+			runDone := make(chan struct{})
+			go func() {
+				m.Run(tsets)
+				close(runDone)
+			}()
+			close(tsets)
+			synctest.Wait()
+
+			// Notifications must still be sent while rule evaluation finishes, so Run may
+			// only return, and clean up the send loops, once Stop has been called.
+			select {
+			case <-runDone:
+				t.Fatal("Run returned before Stop was called")
+			default:
+			}
+			ams.mtx.RLock()
+			sendLoops := len(ams.sendLoops)
+			ams.mtx.RUnlock()
+			require.Equal(t, 1, sendLoops, "send loop was cleaned up before Stop was called")
+
+			m.Stop()
+			synctest.Wait()
+
+			select {
+			case <-runDone:
+			default:
+				t.Fatal("Run did not return after Stop was called")
+			}
+			ams.mtx.RLock()
+			sendLoops = len(ams.sendLoops)
+			ams.mtx.RUnlock()
+			require.Zero(t, sendLoops, "send loop was not cleaned up after Stop was called")
+		})
+	})
+}
+
 // TestAlerstRelabelingIsIsolated ensures that a mutation alerts relabeling in an
 // alertmanagerSet doesn't affect others.
 // See https://github.com/prometheus/prometheus/pull/17063.


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes bug introduced by #14465.

#### Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] notifier: fix CPU spin loop on shutdown when target channel closes
```

---

## Summary

While looking into shutdown behavior, I noticed that Prometheus can briefly enter a **busy CPU spin** during a normal shutdown or restart.

What happens in practice is:

* The discovery manager shuts down and **closes its target update channel**
* The notifier manager is still running
* Its target update loop continues selecting on a channel that has already been closed

Because the `!ok` case only broke out of the inner `select`, the loop kept waking up immediately, doing no useful work, and burning CPU until the shutdown signal arrived.

Over time, this shows up as:

* One core hitting **100% CPU during shutdown**
* Shutdowns taking longer than necessary
* Increased risk of timeout-based kills in Kubernetes or systemd
* No logs or errors explaining what's happening

### Fix

The fix is to **return from the target update loop** when the input channel is closed, instead of breaking out of the `select`:

```go
case ts, ok := <-tsets:
    if !ok {
        // The discovery manager has closed the channel, no more updates are coming.
        return
    }
```

`Run` still blocks until `Stop` is called before cleaning up the send loops, so callers stay in control of shutdown ordering and rule evaluation can finish sending notifications. This keeps behavior unchanged during normal operation and reloads, and only changes what happens once the channel lifecycle has ended.

The equivalent fix for the scrape manager already landed in #19149, so this PR is notifier-only.

A regression test verifies that the target update loop exits promptly when the target channel is closed, and that `Run` still waits for `Stop` before cleaning up the send loops.
