### PR TITLE
tsdb: fix rare case of OOO exemplar insertion pointing to the exemplar being deleted

### DIFF
--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -191,6 +191,22 @@ func TestCircularExemplarStorage_AddExemplar(t *testing.T) {
 			},
 		},
 		{
+			name: "out-of-order insert where evicted entry is insertion point",
+			size: 3,
+			exemplars: []exemplar.Exemplar{
+				{Labels: series1, Value: 0.2, Ts: 2}, // pos 0, linked list middle
+				{Labels: series1, Value: 0.1, Ts: 1}, // pos 1, linked list oldest
+				{Labels: series1, Value: 0.5, Ts: 5}, // pos 2, linked list newest
+				{Labels: series1, Value: 0.3, Ts: 3},
+			},
+			matcher: series1Matcher,
+			wantExemplars: []exemplar.Exemplar{
+				{Labels: series1, Value: 0.1, Ts: 1},
+				{Labels: series1, Value: 0.3, Ts: 3},
+				{Labels: series1, Value: 0.5, Ts: 5},
+			},
+		},
+		{
 			name: "insert out of the OOO window",
 			size: 3,
 			exemplars: []exemplar.Exemplar{


### PR DESCRIPTION
This PR 

- handles the (rare) case that during OOO insertion we have to remove entry at the same position that we want to insert to. The current implementation would create self-links. To avoid this, we remove the element and recalculate the insertion index. This only happens under special circumstances and should not happen regularly.
- 
- correctly returns `migrated` entries during buffer growth


<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
n/a

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
