### PR TITLE
otlptranslator: fix BenchmarkPrometheusConverter_FromMetrics

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -1067,7 +1067,7 @@ func BenchmarkPrometheusConverter_FromMetrics(b *testing.B) {
 
 											for b.Loop() {
 												app := &noOpAppender{}
-												mockAppender := NewCombinedAppender(app, noOpLogger, false, false, appMetrics)
+												mockAppender := NewCombinedAppender(app, noOpLogger, false, true, appMetrics)
 												converter := NewPrometheusConverter(mockAppender)
 												annots, err := converter.FromMetrics(context.Background(), payload.Metrics(), settings)
 												require.NoError(b, err)


### PR DESCRIPTION
## Summary
- Fix `BenchmarkPrometheusConverter_FromMetrics` that was incorrectly passing `appendMetadata=false` to `NewCombinedAppender`
- This caused `UpdateMetadata` to never be called, resulting in `app.metadata` always being 0
- The assertion `require.Positive(b, app.metadata)` was failing as a result

## Test plan
- [x] Run `go test -bench=BenchmarkPrometheusConverter_FromMetrics ./storage/remote/otlptranslator/prometheusremotewrite/...` to verify benchmark passes

```release-notes
NONE
```