### PR TITLE
Fix logger syntax for timingsLogger

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1572,7 +1572,7 @@ func reloadConfig(filename string, enableExemplarStorage bool, logger *slog.Logg
 			logger.Error("Failed to apply configuration", "err", err)
 			failed = true
 		}
-		timingsLogger = timingsLogger.With((rl.name), time.Since(rstart))
+		timingsLogger = timingsLogger.With(rl.name, time.Since(rstart))
 	}
 	if failed {
 		return fmt.Errorf("one or more errors occurred while applying the new configuration (--config.file=%q)", filename)


### PR DESCRIPTION
fix: logger: improve timingsLogger syntax

This PR corrects the syntax for initializing the `timingsLogger` by removing unnecessary parentheses around the `rl.name` argument. The original code used `With((rl.name), ...)` which is redundant and non-idiomatic in Go. The updated `With(rl.name, ...)` aligns with standard Go practices and improves readability.

**Changes:**
- Simplify `timingsLogger.With` call by removing extraneous parentheses around `rl.name`.

**Testing:**
No functional changes - this is a stylistic adjustment. Existing tests cover logger behavior.

**Release Notes:**
```release-notes
NONE
```
Signed-off-by: [Your Name] <[Your Email]>
