### PR TITLE
fuzzing: fix artifact path and experimental parser flags

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -29,7 +29,7 @@ jobs:
         if: failure()
         with:
           name: fuzz-artifacts-${{ matrix.fuzz_test }}
-          path: promql/testdata/fuzz/${{ matrix.fuzz_test }}
+          path: util/fuzzing/testdata/fuzz/${{ matrix.fuzz_test }}
   fuzzing_status:
     # This status check aggregates the individual matrix jobs of the fuzzing
     # step into a final status. Fails if a single matrix job fails, succeeds if

--- a/util/fuzzing/corpus.go
+++ b/util/fuzzing/corpus.go
@@ -58,15 +58,17 @@ func GetCorpusForFuzzParseMetricSelector() []string {
 
 // GetCorpusForFuzzParseExpr returns the seed corpus for FuzzParseExpr.
 func GetCorpusForFuzzParseExpr() ([]string, error) {
+	// Save original values and restore them after parsing test expressions.
+	defer func(funcs, durationExpr, rangeSelectors bool) {
+		parser.EnableExperimentalFunctions = funcs
+		parser.ExperimentalDurationExpr = durationExpr
+		parser.EnableExtendedRangeSelectors = rangeSelectors
+	}(parser.EnableExperimentalFunctions, parser.ExperimentalDurationExpr, parser.EnableExtendedRangeSelectors)
+
 	// Enable experimental features to parse all test expressions.
 	parser.EnableExperimentalFunctions = true
 	parser.ExperimentalDurationExpr = true
 	parser.EnableExtendedRangeSelectors = true
-	defer func() {
-		parser.EnableExperimentalFunctions = false
-		parser.ExperimentalDurationExpr = false
-		parser.EnableExtendedRangeSelectors = false
-	}()
 
 	// Get built-in test expressions.
 	builtInExprs, err := promqltest.GetBuiltInExprs()


### PR DESCRIPTION
Fix two issues in fuzzing infrastructure:
- Correct artifact upload path from promql/testdata/fuzz to util/fuzzing/testdata/fuzz to match where Go stores crash artifacts
- Fix GetCorpusForFuzzParseExpr to preserve original parser flag values instead of always resetting them to false, which was disabling experimental features before actual fuzzing ran

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
