### PR TITLE
fix: typo in error message

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -985,7 +985,7 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 		return nil
 	}); err != nil {
 		// secondLastRef because the lastRef caused an error.
-		return nil, nil, secondLastRef, fmt.Errorf("iterate on on-disk chunks: %w", err)
+		return nil, nil, secondLastRef, fmt.Errorf("iterate on-disk chunks: %w", err)
 	}
 	return mmappedChunks, oooMmappedChunks, lastRef, nil
 }


### PR DESCRIPTION
Fix typo: `on on-disk` → `on-disk`

#### Which issue(s) does the PR fix:
N/A - typo fix only

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```