### PR TITLE
[TESTS] Scraping: Reset appender in BenchmarkScrapeLoopAppend

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1384,6 +1384,8 @@ func BenchmarkScrapeLoopAppend(b *testing.B) {
 						if err != nil {
 							b.Fatal(err)
 						}
+						app.Rollback() // Reset the appender so it doesn't grow indefinitely.
+						app = sl.appender()
 					}
 				})
 			}


### PR DESCRIPTION
Otherwise performance is dominated by adding to a slice that gets longer and longer as the benchmark progresses.

I chose to Rollback rather than Commit because that should do less work.

Timings are not much different with 1s benchmark time, but memory allocation is dramatically lower.

Before
```
% go test -run xxx -benchtime 1s -bench ScrapeLoop ./scrape      
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/scrape
cpu: Apple M2
BenchmarkScrapeLoopAppend/data=1Fam1000Gauges/fmt=PromText-8                2187            469905 ns/op          336303 B/op         20 allocs/op
BenchmarkScrapeLoopAppend/data=1Fam1000Gauges/fmt=OMText-8                  2498            420310 ns/op          347747 B/op         20 allocs/op
BenchmarkScrapeLoopAppend/data=1Fam1000Gauges/fmt=PromProto-8               2188            526434 ns/op          447239 B/op         35 allocs/op
BenchmarkScrapeLoopAppend/data=237FamsAllTypes/fmt=PromText-8               1698            671935 ns/op          327551 B/op         22 allocs/op
BenchmarkScrapeLoopAppend/data=237FamsAllTypes/fmt=OMText-8                 1690            660194 ns/op          329209 B/op         23 allocs/op
BenchmarkScrapeLoopAppend/data=237FamsAllTypes/fmt=PromProto-8              1964            612212 ns/op          427050 B/op       2237 allocs/op
```
After
```
BenchmarkScrapeLoopAppend/data=1Fam1000Gauges/fmt=PromText-8                2468            422806 ns/op            3200 B/op         24 allocs/op
BenchmarkScrapeLoopAppend/data=1Fam1000Gauges/fmt=OMText-8                  2760            417487 ns/op            3178 B/op         24 allocs/op
BenchmarkScrapeLoopAppend/data=1Fam1000Gauges/fmt=PromProto-8               2334            478437 ns/op          114843 B/op         40 allocs/op
BenchmarkScrapeLoopAppend/data=237FamsAllTypes/fmt=PromText-8               1618            654198 ns/op            4132 B/op         28 allocs/op
BenchmarkScrapeLoopAppend/data=237FamsAllTypes/fmt=OMText-8                 1747            667375 ns/op            4231 B/op         28 allocs/op
BenchmarkScrapeLoopAppend/data=237FamsAllTypes/fmt=PromProto-8              2058            545998 ns/op           77676 B/op       2242 allocs/op
```

(I introduced this problem in #9299, and the benchmark has been refactored a couple of times, so I am mystified that nobody noticed this until now.)

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
