### PR TITLE
ci: add scheduled link checker for documentation

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,5 +1,5 @@
 #Broken Link checker
-name: Links Checker
+name: Docs Link Checker
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Link Checker (Docs only) #Link checking is intentionally scoped to docs/ and documentation/ to reduce CI runtime and avoid scanning non-documentation files.
+      - name: Docs Link Checker #Link checking is intentionally scoped to docs/ and documentation/ to reduce CI runtime and avoid scanning non-documentation files.
         id: lychee
         uses: lycheeverse/lychee-action@v2.6.1
         with:


### PR DESCRIPTION
This PR adds a scheduled GitHub Actions workflow to automatically detect broken links in the documentation.

The workflow:
- Runs once a day at midnight and can also be triggered manually
- Checks links only in the `docs/` and `documentation/` directories
- Uses `lycheeverse/lychee-action` for link validation
- Automatically opens an issue with a report if broken links are found

Link checking is intentionally scoped to documentation directories to reduce CI runtime and avoid scanning non-documentation files.

This change does not affect runtime behavior or existing CI pipelines, as it runs only on a schedule.

#### Which issue(s) does the PR fix:
NONE

#### Does this PR introduce a user-facing change?
NONE

```release-notes

```
