### PR TITLE
ci: add scheduled link checker for documentation

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,32 @@
+#Broken Link checker
+name: Docs Link Checker
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" #Runs once a day
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Docs Link Checker #Link checking is intentionally scoped to docs/ and documentation/ to reduce CI runtime and avoid scanning non-documentation files.
+        id: lychee
+        uses: lycheeverse/lychee-action@v2.6.1
+        with:
+          args: >
+            --accept '100..=103,200..=299,403,429'
+            --exclude-all-private
+            --timeout 60
+            docs/
+            documentation/
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Broken Link Detected in Docs (Help Wanted)
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue, documentation, good first issue


### PR DESCRIPTION
This PR adds a scheduled GitHub Actions workflow to automatically detect broken links in the documentation.

The workflow:
- Runs twice a month and can also be triggered manually
- Checks links only in the `docs/` and `documentation/` directories
- Uses `lycheeverse/lychee-action` for link validation
- Automatically opens an issue with a report if broken links are found

Link checking is intentionally scoped to documentation directories to reduce CI runtime and avoid scanning non-documentation files.

This change does not affect runtime behavior or existing CI pipelines, as it runs only on a schedule.

#### Which issue(s) does the PR fix:
NONE

#### Does this PR introduce a user-facing change?
NONE
```release-notes
NONE
```
