### PR TITLE
Fix multi-arch support for distroless Docker image

### DIFF
--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,8 +1,10 @@
-FROM gcr.io/distroless/static-debian13:nonroot@sha256:f9f84bd968430d7d35e8e6d55c40efb0b980829ec42920a49e60e65eac0d83fc
-# Base image sets USER to 65532:65532 (nonroot user).
-
 ARG ARCH="amd64"
 ARG OS="linux"
+ARG DISTROLESS_ARCH="amd64"
+
+# Use DISTROLESS_ARCH for base image selection (handles armv7->arm mapping).
+FROM gcr.io/distroless/static-debian13:nonroot-${DISTROLESS_ARCH}
+# Base image sets USER to 65532:65532 (nonroot user).
 
 LABEL org.opencontainers.image.authors="The Prometheus Authors"
 LABEL org.opencontainers.image.vendor="Prometheus"

--- a/Makefile.common
+++ b/Makefile.common
@@ -250,12 +250,17 @@ $(BUILD_DOCKER_ARCHS): common-docker-%:
 	@for variant in $(DOCKERFILE_VARIANTS_WITH_NAMES); do \
 		dockerfile=$${variant#*:}; \
 		variant_name=$${variant%%:*}; \
+		distroless_arch="$*"; \
+		if [ "$*" = "armv7" ]; then \
+			distroless_arch="arm"; \
+		fi; \
 		if [ "$$dockerfile" = "Dockerfile" ]; then \
 			echo "Building default variant ($$variant_name) for linux-$* using $$dockerfile"; \
 			docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)" \
 				-f $$dockerfile \
 				--build-arg ARCH="$*" \
 				--build-arg OS="linux" \
+				--build-arg DISTROLESS_ARCH="$$distroless_arch" \
 				$(DOCKERBUILD_CONTEXT); \
 			if [ "$$variant_name" != "default" ]; then \
 				echo "Tagging default variant with $$variant_name suffix"; \
@@ -268,6 +273,7 @@ $(BUILD_DOCKER_ARCHS): common-docker-%:
 				-f $$dockerfile \
 				--build-arg ARCH="$*" \
 				--build-arg OS="linux" \
+				--build-arg DISTROLESS_ARCH="$$distroless_arch" \
 				$(DOCKERBUILD_CONTEXT); \
 		fi; \
 	done


### PR DESCRIPTION
The distroless Dockerfile was using a hardcoded SHA256 digest that referenced only the amd64 image, preventing builds for other architectures. This caused the main-distroless tag to only publish amd64 images while the regular main tag had all 5 architectures.

Changes:
- Use architecture-specific image tags (nonroot-${DISTROLESS_ARCH}) instead of SHA256 digest to enable multi-arch manifest resolution
- Add DISTROLESS_ARCH build arg to handle architecture name mapping (armv7 -> arm) between Prometheus and distroless conventions
- Move ARG declarations before FROM to support variable substitution

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
