### PR TITLE
tsdb: clear pooled objects before returning to sync.Pool

### DIFF
--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -570,7 +570,10 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 					db.metrics.numActiveSeries.Inc()
 				}
 			}
-			db.walReplaySeriesPool.Put(v)
+			for i := range v { // Zero out to avoid retaining label data.
+				v[i].Labels = labels.EmptyLabels()
+			}
+			db.walReplaySeriesPool.Put(v[:0])
 		case []record.RefSample:
 			for _, entry := range v {
 				if ref, ok := duplicateRefToValidRef[entry.Ref]; ok {
@@ -615,7 +618,8 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 					series.lastTs = entry.T
 				}
 			}
-			db.walReplayHistogramsPool.Put(v)
+			clear(v) // Zero out to avoid retaining histogram data.
+			db.walReplayHistogramsPool.Put(v[:0])
 		case []record.RefFloatHistogramSample:
 			for _, entry := range v {
 				if ref, ok := duplicateRefToValidRef[entry.Ref]; ok {
@@ -637,7 +641,8 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 					series.lastTs = entry.T
 				}
 			}
-			db.walReplayFloatHistogramsPool.Put(v)
+			clear(v) // Zero out to avoid retaining histogram data.
+			db.walReplayFloatHistogramsPool.Put(v[:0])
 		default:
 			panic(fmt.Errorf("unexpected decoded type: %T", d))
 		}

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -270,7 +270,10 @@ Outer:
 				idx := uint64(mSeries.ref) % uint64(concurrency)
 				processors[idx].input <- walSubsetProcessorInputItem{walSeriesRef: walSeries.Ref, existingSeries: mSeries}
 			}
-			h.wlReplaySeriesPool.Put(v)
+			for i := range v { // Zero out to avoid retaining label data.
+				v[i].Labels = labels.EmptyLabels()
+			}
+			h.wlReplaySeriesPool.Put(v[:0])
 		case []record.RefSample:
 			samples := v
 			minValidTime := h.minValidTime.Load()
@@ -347,7 +350,8 @@ Outer:
 				}
 			}
 
-			h.wlReplaytStonesPool.Put(v)
+			clear(v) // Zero out to avoid retaining interval data.
+			h.wlReplaytStonesPool.Put(v[:0])
 		case []record.RefExemplar:
 			for _, e := range v {
 				if e.T < h.minValidTime.Load() {
@@ -360,7 +364,10 @@ Outer:
 				}
 				exemplarsInput <- e
 			}
-			h.wlReplayExemplarsPool.Put(v)
+			for i := range v { // Zero out to avoid retaining label data.
+				v[i].Labels = labels.EmptyLabels()
+			}
+			h.wlReplayExemplarsPool.Put(v[:0])
 		case []record.RefHistogramSample:
 			samples := v
 			minValidTime := h.minValidTime.Load()
@@ -395,7 +402,8 @@ Outer:
 				}
 				samples = samples[m:]
 			}
-			h.wlReplayHistogramsPool.Put(v)
+			clear(v) // Zero out to avoid retaining histogram data.
+			h.wlReplayHistogramsPool.Put(v[:0])
 		case []record.RefFloatHistogramSample:
 			samples := v
 			minValidTime := h.minValidTime.Load()
@@ -430,7 +438,8 @@ Outer:
 				}
 				samples = samples[m:]
 			}
-			h.wlReplayFloatHistogramsPool.Put(v)
+			clear(v) // Zero out to avoid retaining histogram data.
+			h.wlReplayFloatHistogramsPool.Put(v[:0])
 		case []record.RefMetadata:
 			for _, m := range v {
 				if r, ok := multiRef[m.Ref]; ok {
@@ -448,7 +457,8 @@ Outer:
 					Help: m.Help,
 				}
 			}
-			h.wlReplayMetadataPool.Put(v)
+			clear(v) // Zero out to avoid retaining metadata strings.
+			h.wlReplayMetadataPool.Put(v[:0])
 		default:
 			panic(fmt.Errorf("unexpected decoded type: %T", d))
 		}
@@ -938,7 +948,8 @@ func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				}
 				samples = samples[m:]
 			}
-			h.wlReplayHistogramsPool.Put(v)
+			clear(v) // Zero out to avoid retaining histogram data.
+			h.wlReplayHistogramsPool.Put(v[:0])
 		case []record.RefFloatHistogramSample:
 			samples := v
 			// We split up the samples into chunks of 5000 samples or less.
@@ -967,7 +978,8 @@ func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				}
 				samples = samples[m:]
 			}
-			h.wlReplayFloatHistogramsPool.Put(v)
+			clear(v) // Zero out to avoid retaining histogram data.
+			h.wlReplayFloatHistogramsPool.Put(v[:0])
 		default:
 			panic(fmt.Errorf("unexpected decodedCh type: %T", d))
 		}


### PR DESCRIPTION
## Summary

Clear WAL replay pool objects before `Put()` to avoid retaining references to Labels, Histograms, and other data that could prevent garbage collection. Follow-up to #17879.

The following pools now properly clear their contents before returning objects:

**tsdb/head_wal.go (loadWAL):**
- `wlReplaySeriesPool`: clear Labels field
- `wlReplaytStonesPool`: clear intervals
- `wlReplayExemplarsPool`: clear Labels field  
- `wlReplayHistogramsPool`: clear histogram pointers
- `wlReplayFloatHistogramsPool`: clear float histogram pointers
- `wlReplayMetadataPool`: clear metadata strings

**tsdb/head_wal.go (loadWBL):**
- `wlReplayHistogramsPool`: clear histogram pointers
- `wlReplayFloatHistogramsPool`: clear float histogram pointers

**tsdb/agent/db.go (loadWAL):**
- `walReplaySeriesPool`: clear Labels field
- `walReplayHistogramsPool`: clear histogram pointers
- `walReplayFloatHistogramsPool`: clear float histogram pointers

#### Which issue(s) does the PR fix:

N/A - preventive fix for potential memory retention issues.

#### Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] TSDB: Fix memory leaks in buffer pools by clearing reference fields before returning buffers to pools
```

## Test plan

- [x] Existing tests pass with `go test -race ./tsdb/...`
- [x] Build succeeds