### PR TITLE
Fix ARG scoping in Dockerfile.distroless

### DIFF
--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,10 +1,11 @@
-ARG ARCH="amd64"
-ARG OS="linux"
 ARG DISTROLESS_ARCH="amd64"
 
 # Use DISTROLESS_ARCH for base image selection (handles armv7->arm mapping).
 FROM gcr.io/distroless/static-debian13:nonroot-${DISTROLESS_ARCH}
 # Base image sets USER to 65532:65532 (nonroot user).
+
+ARG ARCH="amd64"
+ARG OS="linux"
 
 LABEL org.opencontainers.image.authors="The Prometheus Authors"
 LABEL org.opencontainers.image.vendor="Prometheus"


### PR DESCRIPTION
ARG declarations before FROM are only available within the FROM instruction and go out of scope afterward. Re-declare ARCH and OS after FROM so they're available for the COPY instructions.

This fixes the build failure where ${OS}-${ARCH} resolved to empty strings, causing "not found" errors for .build/-/prometheus.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
