### PR TITLE
chore: remove testutil.T which is no longer needed since Go 1.13

### DIFF
--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -111,7 +111,7 @@ var ruleEvalTestScenarios = []struct {
 	},
 }
 
-func setUpRuleEvalTest(t require.TestingT) *teststorage.TestStorage {
+func setUpRuleEvalTest(t testing.TB) *teststorage.TestStorage {
 	return promqltest.LoadedStorage(t, `
 		load 1m
 			metric{label_a="1",label_b="3"} 1

--- a/util/teststorage/storage.go
+++ b/util/teststorage/storage.go
@@ -16,6 +16,7 @@ package teststorage
 import (
 	"fmt"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,14 +26,13 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
-	"github.com/prometheus/prometheus/util/testutil"
 )
 
 type Option func(opt *tsdb.Options)
 
 // New returns a new TestStorage for testing purposes
 // that removes all associated files on closing.
-func New(t testutil.T, o ...Option) *TestStorage {
+func New(t testing.TB, o ...Option) *TestStorage {
 	s, err := NewWithError(o...)
 	require.NoError(t, err)
 	return s

--- a/util/testutil/directory.go
+++ b/util/testutil/directory.go
@@ -60,20 +60,11 @@ type (
 	// their interactions.
 	temporaryDirectory struct {
 		path   string
-		tester T
+		tester testing.TB
 	}
 
 	callbackCloser struct {
 		fn func()
-	}
-
-	// T implements the needed methods of testing.TB so that we do not need
-	// to actually import testing (which has the side effect of adding all
-	// the test flags, which we do not want in non-test binaries even if
-	// they make use of these utilities for some reason).
-	T interface {
-		Errorf(format string, args ...any)
-		FailNow()
 	}
 )
 
@@ -113,7 +104,7 @@ func (t temporaryDirectory) Path() string {
 
 // NewTemporaryDirectory creates a new temporary directory for transient POSIX
 // activities.
-func NewTemporaryDirectory(name string, t T) (handler TemporaryDirectory) {
+func NewTemporaryDirectory(name string, t testing.TB) (handler TemporaryDirectory) {
 	var (
 		directory string
 		err       error


### PR DESCRIPTION
testutil.T was needed before https://go.dev/doc/go1.13#testingpkgtesting

Now it's inconsistent and confusing, so let's kill it.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
