### PR TITLE
[Backport 3.5LTS] [PERF] Regex: stop calling Simplify

### DIFF
--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -225,6 +225,13 @@ func BenchmarkNewMatcher(b *testing.B) {
 			NewMatcher(MatchRegexp, "foo", "bar")
 		}
 	})
+	b.Run("complex regex", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i <= b.N; i++ {
+			NewMatcher(MatchRegexp, "foo", "((.*)(bar|b|buzz)(.+)|foo){10}")
+		}
+	})
 }
 
 func BenchmarkMatcher_String(b *testing.B) {

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -67,8 +67,6 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Simplify the syntax tree to run faster.
-		parsed = parsed.Simplify()
 		m.re, err = regexp.Compile("^(?s:" + parsed.String() + ")$")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
[Backport of #17212]

It slows down compilation and doesn't make any of our benchmarks go faster. Assumed to be something that helped at an earlier point, but doesn't help now.

Add a benchmark with a more complicated regex to demonstrate the slowdown.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
Note: this was not in the release notes of Prometheus main.

```release-notes
NONE
```
