### PR TITLE
promql: info function: fix unit test for ignoring info metrics themselves

### DIFF
--- a/promql/promqltest/testdata/info.test
+++ b/promql/promqltest/testdata/info.test
@@ -70,7 +70,11 @@ eval range from 0m to 10m step 5m info(metric, {__name__=~".+_info"})
     metric{instance="a", job="1", label="value", build_data="build", data="info", another_data="another info"} 0 1 2
 
 # Info metrics themselves are ignored when it comes to enriching with info metric data labels.
-eval range from 0m to 10m step 5m info(build_info, {__name__=~".+_info", build_data=~".+"})
+eval range from 0m to 10m step 5m info(build_info, {__name__=~".+_info", another_data=~".+"})
+    build_info{instance="a", job="1", build_data="build"} 1 1 1
+
+# Info metrics themselves are ignored when it comes to enriching with info metric data labels.
+eval range from 0m to 10m step 5m info(build_info, {__name__=~".+_info"})
     build_info{instance="a", job="1", build_data="build"} 1 1 1
 
 clear


### PR DESCRIPTION
Fixes the unit test for ignoring info metrics. The previous one defined `build_data=~".+"`, so it wouldn't match the other info metric `target_info`, so there was no other info to enrich `build_info` with. Updated it to specify  `another_data=~".+"` so it will match `target_info`, so it would normally enrich `build_info` with the `another_data` label from there, except that it should be ignored as `build_info` is an info metric.

Before this fix, the unit test would pass even when not implementing the logic to ignore info metrics in MQE. After the fix, when the logic wasn't implemented the new test would fail, and it would pass when implemented, proving that the fixed unit test correctly tests that we ignore info metrics.

The logic in Prometheus passes the new test as well.

#### Which issue(s) does the PR fix:

N/A

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```