### PR TITLE
promtool: support missing promql syntax features

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -314,7 +314,7 @@ func main() {
 	promQLLabelsDeleteQuery := promQLLabelsDeleteCmd.Arg("query", "PromQL query.").Required().String()
 	promQLLabelsDeleteName := promQLLabelsDeleteCmd.Arg("name", "Name of the label to delete.").Required().String()
 
-	featureList := app.Flag("enable-feature", "Comma separated feature names to enable. Valid options: promql-experimental-functions, promql-delayed-name-removal. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details").Default("").Strings()
+	featureList := app.Flag("enable-feature", "Comma separated feature names to enable. Valid options: promql-experimental-functions, promql-delayed-name-removal, promql-duration-expr, promql-extended-range-selectors. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details").Default("").Strings()
 
 	documentationCmd := app.Command("write-documentation", "Generate command line documentation. Internal use.").Hidden()
 
@@ -351,6 +351,10 @@ func main() {
 				parser.EnableExperimentalFunctions = true
 			case "promql-delayed-name-removal":
 				promqlEnableDelayedNameRemoval = true
+			case "promql-duration-expr":
+				parser.ExperimentalDurationExpr = true
+			case "promql-extended-range-selectors":
+				parser.EnableExtendedRangeSelectors = true
 			case "":
 				continue
 			default:

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -655,7 +655,7 @@ func TestCheckRulesWithFeatureFlag(t *testing.T) {
 	// As opposed to TestCheckRules calling CheckRules directly we run promtool
 	// so the feature flag parsing can be tested.
 
-	args := []string{"-test.main", "--enable-feature=promql-experimental-functions", "check", "rules", "testdata/features.yml"}
+	args := []string{"-test.main", "--enable-feature=promql-experimental-functions", "--enable-feature=promql-duration-expr", "--enable-feature=promql-extended-range-selectors", "check", "rules", "testdata/features.yml"}
 	tool := exec.Command(promtoolPath, args...)
 	err := tool.Run()
 	require.NoError(t, err)

--- a/cmd/promtool/testdata/features.yml
+++ b/cmd/promtool/testdata/features.yml
@@ -1,6 +1,10 @@
 groups:
   - name: features
     rules:
-      - record: x
-        # We don't expect anything from this, just want to check the function parses.
+        # We don't expect anything from these, just want to check the syntax parses.
+      - record: promql-experimental-functions
         expr: sort_by_label(up, "instance")
+      - record: promql-duration-expr
+        expr: rate(up[1m * 2])
+      - record: promql-extended-range-selectors
+        expr: rate(up[1m] anchored)

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -12,7 +12,7 @@ Tooling for the Prometheus monitoring system.
 | <code class="text-nowrap">-h</code>, <code class="text-nowrap">--help</code> | Show context-sensitive help (also try --help-long and --help-man). |
 | <code class="text-nowrap">--version</code> | Show application version. |
 | <code class="text-nowrap">--experimental</code> | Enable experimental commands. |
-| <code class="text-nowrap">--enable-feature</code> <code class="text-nowrap">...<code class="text-nowrap"> | Comma separated feature names to enable. Valid options: promql-experimental-functions, promql-delayed-name-removal. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details |
+| <code class="text-nowrap">--enable-feature</code> <code class="text-nowrap">...<code class="text-nowrap"> | Comma separated feature names to enable. Valid options: promql-experimental-functions, promql-delayed-name-removal, promql-duration-expr, promql-extended-range-selectors. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details |
 
 
 


### PR DESCRIPTION
Namely promql-duration-expr and promql-extended-range-selectors. This allows promtool to e.g. check rules files using syntax gated by these features.

#### Which issue(s) does the PR fix:
Fixes #17922.

#### Does this PR introduce a user-facing change?
```release-notes
[ENHANCEMENT] promtool: support promql syntax features `promql-duration-expr` and `promql-extended-range-selectors`
```
