### PR TITLE
docs: Document the stale_series_compaction_threshold config file option

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3499,7 +3499,7 @@ with this feature.
 # Configures the trigger point for compacting the stale series from the memory into persistent blocks
 # and remove those stale series from the memory.
 #
-# The threshold is a number between 0.0-1.0 and represents the ratio of stale series in the memory
+# The threshold is a number between 0.0 and 1.0. It represents the ratio of stale series in the memory
 # to the total series in the memory. The stale series compaction is triggered when this ratio crosses
 # the configured threshold. It may not trigger the stale series compaction if the usual head compaction
 # is about to happen soon.


### PR DESCRIPTION
Forgot to add docs in https://github.com/prometheus/prometheus/pull/16929. This PR adds docs for `stale_series_compaction_threshold`.

#### Which issue(s) does the PR fix:
None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
