### PR TITLE
chore(sd-ownership): add default-maintainers as default code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 /web/ui                         @prometheus/default-maintainers @juliusv
 /web/ui/module                  @prometheus/default-maintainers @juliusv @nexucis
 /promql                         @prometheus/default-maintainers @roidelapluie
-/storage/remote                 @prometheus/default-maintainers @cstyan @bwplotka @tomwilkie @npazosmendez @alexgreenbank
+/storage/remote                 @prometheus/default-maintainers @cstyan @bwplotka @tomwilkie @alexgreenbank
 /storage/remote/otlptranslator  @prometheus/default-maintainers @aknuds1 @jesusvazquez @ArthurSens
 /tsdb                           @prometheus/default-maintainers @jesusvazquez @codesome @bwplotka @krajorama
 


### PR DESCRIPTION
In accordance with dev summit decision.
At the same time I've set up auto assignment for code review, meaning that not everybody will get notified for all PRs. If there's already a maintainer assigned, you don't get notified. Otherwise the assignment is round-robin, 1 at a time. Also you can opt out.

Settings:
<img width="914" height="816" alt="image" src="https://github.com/user-attachments/assets/a0339e25-08bb-45d3-9015-8fbaa22395fb" />


<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
