### PR TITLE
scrape+tsdb: Optimize AppenderV2 path.

### DIFF
--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -32,6 +32,8 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
+const exemplarsForParsing = 1 // const for readability.
+
 // appenderWithLimits returns an appender with additional validation.
 func appenderV2WithLimits(app storage.AppenderV2, sampleLimit, bucketLimit int, maxSchema int32) storage.AppenderV2 {
 	app = &timeLimitAppenderV2{
@@ -122,17 +124,18 @@ func (sl *scrapeLoopAppenderV2) append(b []byte, contentType string, ts time.Tim
 			"err", err,
 		)
 	}
+
 	var (
 		appErrs        = appendErrors{}
 		sampleLimitErr error
 		bucketLimitErr error
-		lset           labels.Labels     // Escapes to heap so hoisted out of loop.
-		e              exemplar.Exemplar // Escapes to heap so hoisted out of loop.
 		lastMeta       *metaEntry
 		lastMFName     []byte
-	)
 
-	exemplars := make([]exemplar.Exemplar, 0, 1)
+		// Below variables escape to heap, so they're hoisted out of loop.
+		lset      labels.Labels
+		exemplars = make([]exemplar.Exemplar, exemplarsForParsing) // First sample is a buffer for parser fetches.
+	)
 
 	// Take an appender with limits.
 	app := appenderV2WithLimits(sl.AppenderV2, sl.sampleLimit, sl.bucketLimit, sl.maxSchema)
@@ -240,8 +243,7 @@ loop:
 			}
 		}
 
-		exemplars = exemplars[:0] // Reset and reuse the exemplar slice.
-
+		appOpts := storage.AOptions{}
 		if seriesAlreadyScraped && parsedTimestamp == nil {
 			err = storage.ErrDuplicateSampleForTimestamp
 		} else {
@@ -259,8 +261,14 @@ loop:
 				st = p.StartTimestamp()
 			}
 
-			for hasExemplar := p.Exemplar(&e); hasExemplar; hasExemplar = p.Exemplar(&e) {
-				if !e.HasTs {
+			// Fetch exemplars from the parser, if any, while using exemplar slice.
+			exemplars = exemplars[:exemplarsForParsing]
+			for {
+				exemplars[0] = exemplar.Exemplar{} // Always reset, before fetching.
+				if !p.Exemplar(&(exemplars[0])) {
+					break
+				}
+				if !exemplars[0].HasTs {
 					if isHistogram {
 						// We drop exemplars for native histograms if they don't have a timestamp.
 						// Missing timestamps are deliberately not supported as we want to start
@@ -269,21 +277,18 @@ loop:
 						// between repeated exemplars and new instances with the same values.
 						// This is done silently without logs as it is not an error but out of spec.
 						// This does not affect classic histograms so that behaviour is unchanged.
-						e = exemplar.Exemplar{} // Reset for the next fetch.
 						continue
 					}
-					e.Ts = t
+					exemplars[0].Ts = t
 				}
-				exemplars = append(exemplars, e)
-				e = exemplar.Exemplar{} // Reset for the next fetch.
+				exemplars = append(exemplars, exemplars[0])
 			}
 
 			// Prepare append call.
-			appOpts := storage.AOptions{}
-			if len(exemplars) > 0 {
+			if len(exemplars) > exemplarsForParsing {
 				// Sort so that checking for duplicates / out of order is more efficient during validation.
-				slices.SortFunc(exemplars, exemplar.Compare)
-				appOpts.Exemplars = exemplars
+				appOpts.Exemplars = exemplars[exemplarsForParsing:]
+				slices.SortFunc(appOpts.Exemplars, exemplar.Compare)
 			}
 
 			// Metadata path mimicks the scrape appender V1 flow. Once we remove v2
@@ -314,7 +319,7 @@ loop:
 			// Append sample to the storage.
 			ref, err = app.Append(ref, lset, st, t, val, h, fh, appOpts)
 		}
-		sampleAdded, err = sl.checkAddError(met, exemplars, err, &sampleLimitErr, &bucketLimitErr, &appErrs)
+		sampleAdded, err = sl.checkAddError(met, appOpts.Exemplars, err, &sampleLimitErr, &bucketLimitErr, &appErrs)
 		if err != nil {
 			if !errors.Is(err, storage.ErrNotFound) {
 				sl.l.Debug("Unexpected error", "series", string(met), "err", err)

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1726,47 +1726,66 @@ func TestScrapeLoopAppend_WithStorage(t *testing.T) {
 // BenchmarkScrapeLoopAppend benchmarks scrape appends for typical cases.
 //
 // Benchmark compares append function run across 4 dimensions:
-// * `appV2`: appender V1 or V2
-// * `appendMetadataToWAL`: metadata-wal-records feature enabled or not
-// *`data`: different sizes of metrics scraped e.g. one big gauge metric family
+// * `withStorage`: without storage isolates the benchmark to the scrape loop append code. With storage is an
+// integration benchmark with the TSDB head appender code. For acceptance criteria run with storage, without for debugging.
+// * `appV2`: appender V1 or V2.
+// * `appendMetadataToWAL`: metadata-wal-records feature enabled or not (problematic feature we might need to change
+// soon, see https://github.com/prometheus/prometheus/issues/15911.
+// * `data`: different sizes of metrics scraped e.g. one big gauge metric family
 //  with a thousand series and more realistic scenario with common types.
-// *`fmt`: different scrape formats which will benchmark different parsers e.g.
+// * `fmt`: different scrape formats which will benchmark different parsers e.g.
 //  promtext, omtext and promproto.
 //
-// Recommended CLI invocation:
+// NOTE: withStorage=true uses sync.Pool buffers which is heavily non-deterministic and shared across go routines.
+// As a results, it's recommended to run dimensions you want to compare with in separate go tool invocations e.g.
+// Recommended CLI invocation(s):
 /*
-	export bench=append && go test ./scrape/... \
-		-run '^$' -bench '^BenchmarkScrapeLoopAppend$' \
+	# Acceptance: With storage with V1 and V2 in separate process:
+	export bench=appendV1 && go test ./scrape/... \
+		-run '^$' -bench '^BenchmarkScrapeLoopAppend/withStorage=true/appV2=false/$' \
+		-benchtime 2s -count 6 -cpu 2 -timeout 999m \
+		| tee ${bench}.txt
+
+	export bench=appendV2 && go test ./scrape/... \
+		-run '^$' -bench '^BenchmarkScrapeLoopAppend/withStorage=true/appV2=true/$' \
+		-benchtime 2s -count 6 -cpu 2 -timeout 999m \
+		| tee ${bench}.txt
+
+	# For debugging scrape overheads:
+	export bench=appendNoStorage && go test ./scrape/... \
+		-run '^$' -bench '^BenchmarkScrapeLoopAppend/withStorage=false/$' \
 		-benchtime 2s -count 6 -cpu 2 -timeout 999m \
 		| tee ${bench}.txt
 */
 func BenchmarkScrapeLoopAppend(b *testing.B) {
-	for _, appV2 := range []bool{false, true} {
-		for _, appendMetadataToWAL := range []bool{false, true} {
-			for _, data := range []struct {
-				name         string
-				parsableText []byte
-			}{
-				{name: "1Fam2000Gauges", parsableText: makeTestGauges(2000)},         // ~68.1 KB, ~77.9 KB in proto.
-				{name: "237FamsAllTypes", parsableText: readTextParseTestMetrics(b)}, // ~185.7 KB, ~70.6 KB in proto.
-			} {
-				b.Run(fmt.Sprintf("appV2=%v/appendMetadataToWAL=%v/data=%v", appV2, appendMetadataToWAL, data.name), func(b *testing.B) {
-					metricsProto := promTextToProto(b, data.parsableText)
+	for _, withStorage := range []bool{false, true} {
+		for _, appV2 := range []bool{false, true} {
+			for _, appendMetadataToWAL := range []bool{false, true} {
+				for _, data := range []struct {
+					name         string
+					parsableText []byte
+				}{
+					{name: "1Fam2000Gauges", parsableText: makeTestGauges(2000)},         // ~68.1 KB, ~77.9 KB in proto.
+					{name: "237FamsAllTypes", parsableText: readTextParseTestMetrics(b)}, // ~185.7 KB, ~70.6 KB in proto.
+				} {
+					b.Run(fmt.Sprintf("withStorage=%v/appV2=%v/appendMetadataToWAL=%v/data=%v", withStorage, appV2, appendMetadataToWAL, data.name), func(b *testing.B) {
+						metricsProto := promTextToProto(b, data.parsableText)
 
-					for _, bcase := range []struct {
-						name        string
-						contentType string
-						parsable    []byte
-					}{
-						{name: "PromText", contentType: "text/plain", parsable: data.parsableText},
-						{name: "OMText", contentType: "application/openmetrics-text", parsable: data.parsableText},
-						{name: "PromProto", contentType: "application/vnd.google.protobuf", parsable: metricsProto},
-					} {
-						b.Run(fmt.Sprintf("fmt=%v", bcase.name), func(b *testing.B) {
-							benchScrapeLoopAppend(b, appV2, bcase.parsable, bcase.contentType, appendMetadataToWAL, false)
-						})
-					}
-				})
+						for _, bcase := range []struct {
+							name        string
+							contentType string
+							parsable    []byte
+						}{
+							{name: "PromText", contentType: "text/plain", parsable: data.parsableText},
+							{name: "OMText", contentType: "application/openmetrics-text", parsable: data.parsableText},
+							{name: "PromProto", contentType: "application/vnd.google.protobuf", parsable: metricsProto},
+						} {
+							b.Run(fmt.Sprintf("fmt=%v", bcase.name), func(b *testing.B) {
+								benchScrapeLoopAppend(b, withStorage, appV2, bcase.parsable, bcase.contentType, appendMetadataToWAL, false)
+							})
+						}
+					})
+				}
 			}
 		}
 	}
@@ -1774,30 +1793,32 @@ func BenchmarkScrapeLoopAppend(b *testing.B) {
 
 func benchScrapeLoopAppend(
 	b *testing.B,
+	withStorage bool,
 	appV2 bool,
 	parsable []byte,
 	contentType string,
 	appendMetadataToWAL bool,
 	enableExemplarStorage bool,
 ) {
-	// Need a full storage for correct Add/AddFast semantics.
-	s := teststorage.New(b, func(opt *tsdb.Options) {
-		opt.EnableMetadataWALRecords = appendMetadataToWAL
-		if enableExemplarStorage {
-			opt.EnableExemplarStorage = true
-			opt.MaxExemplars = 1e5
-		}
-	})
-
-	sl, _ := newTestScrapeLoop(b, withAppendable(s, appV2), func(sl *scrapeLoop) {
+	var a compatAppendable = teststorage.NewAppendable().SkipRecording(true) // Make it noop for benchmark purposes.
+	if withStorage {
+		a = teststorage.New(b, func(opt *tsdb.Options) {
+			opt.EnableMetadataWALRecords = appendMetadataToWAL
+			if enableExemplarStorage {
+				opt.EnableExemplarStorage = true
+				opt.MaxExemplars = 1e5
+			}
+		})
+	}
+	sl, _ := newTestScrapeLoop(b, withAppendable(a, appV2), func(sl *scrapeLoop) {
 		sl.appendMetadataToWAL = appendMetadataToWAL
 	})
-	app := sl.appender()
 	ts := time.Time{}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
+		app := sl.appender()
 		ts = ts.Add(time.Second)
 		_, _, _, err := app.append(parsable, contentType, ts)
 		if err != nil {
@@ -1808,7 +1829,6 @@ func benchScrapeLoopAppend(
 		if err := app.Rollback(); err != nil {
 			b.Fatal(err)
 		}
-		app = sl.appender()
 	}
 }
 
@@ -1827,7 +1847,7 @@ func BenchmarkScrapeLoopAppend_HistogramsWithExemplars(b *testing.B) {
 	for _, appV2 := range []bool{false, true} {
 		b.Run(fmt.Sprintf("appV2=%v", appV2), func(b *testing.B) {
 			parsable := makeTestHistogramsWithExemplars(100) // ~255.8 KB in OM text.
-			benchScrapeLoopAppend(b, appV2, parsable, "application/openmetrics-text", false, true)
+			benchScrapeLoopAppend(b, true, appV2, parsable, "application/openmetrics-text", false, true)
 		})
 	}
 }
@@ -3398,7 +3418,9 @@ metric: <
 				}
 				sl.alwaysScrapeClassicHist = test.alwaysScrapeClassicHist
 				// This test does not care about metadata.
-				// TODO(bwplotka): Add metadata expectations and turn it on.
+				// Having this true would mean we need to add metadata to sample
+				// expectations.
+				// TODO(bwplotka): Add cases for append metadata to WAL and pass metadata
 				sl.appendMetadataToWAL = false
 			})
 			app := sl.appender()

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -458,23 +458,7 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 		// we do not need to check for the difference between "unknown
 		// series" and "known series with stNone".
 	}
-
-	s.Lock()
-	defer s.Unlock()
-	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
-	// to skip that sample from the WAL and write only in the WBL.
-	isOOO, delta, err := s.appendable(t, v, a.headMaxt, a.minValidTime, a.oooTimeWindow)
-	if err == nil {
-		if isOOO && a.hints != nil && a.hints.DiscardOutOfOrder {
-			a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
-			return 0, storage.ErrOutOfOrderSample
-		}
-		s.pendingCommit = true
-	}
-	if delta > 0 {
-		a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
-	}
-	if err != nil {
+	if err := a.appendFloat(s, t, v, a.hints != nil && a.hints.DiscardOutOfOrder); err != nil {
 		switch {
 		case errors.Is(err, storage.ErrOutOfOrderSample):
 			a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeFloat).Inc()

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -357,6 +357,18 @@ const (
 	stCustomBucketFloatHistogram                   // Native float histograms with custom bucket boundaries. Goes to `floatHistograms`.
 )
 
+// TypeLabel returns a name to use for instrumentation to reflect histogram vs float operations.
+func (s sampleType) TypeLabel() string {
+	switch s {
+	default:
+		return ""
+	case stFloat:
+		return sampleMetricTypeFloat
+	case stHistogram, stCustomBucketHistogram, stFloatHistogram, stCustomBucketFloatHistogram:
+		return sampleMetricTypeHistogram
+	}
+}
+
 // appendBatch is used to partition all the appended data into batches that are
 // "type clean", i.e. every series receives only samples of one type within the
 // batch. Types in this regard are defined by the sampleType enum above.

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -103,31 +103,43 @@ type headAppenderV2 struct {
 	headAppenderBase
 }
 
+// toBasicSampleType detects sample type based on a typical multi sample Append API.
+// Basic because this does not detect some details like custom bucket histogram or native.
+// TODO: Improve with https://github.com/prometheus/prometheus/issues/17925
+func toBasicSampleType(v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) sampleType {
+	if v != 0 || (h == nil && fh == nil) {
+		return stFloat // Fast path.
+	}
+	if fh != nil {
+		return stFloatHistogram
+	}
+	return stHistogram
+}
+
 func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, opts storage.AOptions) (storage.SeriesRef, error) {
 	var (
+		sTyp    = toBasicSampleType(v, h, fh)
+		isStale bool
 		// Avoid shadowing err variables for reliability.
-		valErr, appErr, partialErr error
-		sampleMetricType           = sampleMetricTypeFloat
-		isStale                    bool
+		appErr, partialErr error
 	)
-	// Fail fast on incorrect histograms.
 
-	switch {
-	case fh != nil:
-		sampleMetricType = sampleMetricTypeHistogram
-		valErr = fh.Validate()
-	case h != nil:
-		sampleMetricType = sampleMetricTypeHistogram
-		valErr = h.Validate()
-	}
-	if valErr != nil {
-		return 0, valErr
+	switch sTyp {
+	default:
+	case stFloatHistogram:
+		if err := fh.Validate(); err != nil {
+			return 0, err
+		}
+	case stHistogram:
+		if err := h.Validate(); err != nil {
+			return 0, err
+		}
 	}
 
 	// Fail fast if OOO is disabled and the sample is out of bounds.
 	// Otherwise, a full check will be done later to decide if the sample is in-order or out-of-order.
 	if a.oooTimeWindow == 0 && t < a.minValidTime {
-		a.head.metrics.outOfBoundSamples.WithLabelValues(sampleMetricType).Inc()
+		a.head.metrics.outOfBoundSamples.WithLabelValues(sTyp.TypeLabel()).Inc()
 		return 0, storage.ErrOutOfBounds
 	}
 
@@ -141,15 +153,15 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	}
 
 	// TODO(bwplotka): Handle ST natively (as per PROM-60).
-	if a.head.opts.EnableSTAsZeroSample && st != 0 {
+	if st != 0 && a.head.opts.EnableSTAsZeroSample {
 		a.bestEffortAppendSTZeroSample(s, ls, st, t, h, fh)
 	}
 
-	switch {
-	case fh != nil:
+	switch sTyp {
+	case stFloatHistogram:
 		isStale = value.IsStaleNaN(fh.Sum)
 		appErr = a.appendFloatHistogram(s, t, fh, opts.RejectOutOfOrder)
-	case h != nil:
+	case stHistogram:
 		isStale = value.IsStaleNaN(h.Sum)
 		appErr = a.appendHistogram(s, t, h, opts.RejectOutOfOrder)
 	default:
@@ -171,6 +183,7 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 				return a.Append(storage.SeriesRef(s.ref), ls, st, t, 0, nil, &histogram.FloatHistogram{Sum: v}, storage.AOptions{
 					RejectOutOfOrder: opts.RejectOutOfOrder,
 				})
+			default:
 			}
 			// Note that a series reference not yet in the map will come out
 			// as stNone, but since we do not handle that case separately,
@@ -179,13 +192,14 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 		}
 		appErr = a.appendFloat(s, t, v, opts.RejectOutOfOrder)
 	}
+
 	// Handle append error, if any.
 	if appErr != nil {
 		switch {
 		case errors.Is(appErr, storage.ErrOutOfOrderSample):
-			a.head.metrics.outOfOrderSamples.WithLabelValues(sampleMetricType).Inc()
+			a.head.metrics.outOfOrderSamples.WithLabelValues(sTyp.TypeLabel()).Inc()
 		case errors.Is(appErr, storage.ErrTooOldSample):
-			a.head.metrics.tooOldSamples.WithLabelValues(sampleMetricType).Inc()
+			a.head.metrics.tooOldSamples.WithLabelValues(sTyp.TypeLabel()).Inc()
 		}
 		return 0, appErr
 	}

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -218,16 +218,16 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	return storage.SeriesRef(s.ref), partialErr
 }
 
-func (a *headAppenderV2) appendFloat(s *memSeries, t int64, v float64, fastRejectOOO bool) error {
+func (a *headAppenderBase) appendFloat(s *memSeries, t int64, v float64, fastRejectOOO bool) error {
 	s.Lock()
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
 	isOOO, delta, err := s.appendable(t, v, a.headMaxt, a.minValidTime, a.oooTimeWindow)
-	if isOOO && fastRejectOOO {
-		s.Unlock()
-		return storage.ErrOutOfOrderSample
-	}
 	if err == nil {
+		if isOOO && fastRejectOOO {
+			s.Unlock()
+			return storage.ErrOutOfOrderSample
+		}
 		s.pendingCommit = true
 	}
 	s.Unlock()


### PR DESCRIPTION
Related to https://github.com/prometheus/prometheus/issues/17632

This PR:
* Adds `withStorage` dimension to benchmarks to isolate the overheads better.
* Optimizes allocs for scrape + tsdb V2 path
* Optimizes cpu for scrape (without tsdb) V2 path

We are fighting for small allocs/speed up, but still - I managed to optimize allocs fully (parity with V1) for scrape:

### Improvement to AppenderV2

```
benchstat -filter "/appV2:true"  x.bwplotka/appendold.txt x.bwplotka/append3-en.txt 
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/scrape
cpu: Apple M4 Pro
                                                                                           │ x.bwplotka/appendold.txt │     x.bwplotka/append3-en.txt     │
                                                                                           │          sec/op          │   sec/op     vs base              │
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromText-2                  327.8µ ± 2%   329.8µ ± 1%       ~ (p=0.310 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=OMText-2                    325.5µ ± 3%   328.4µ ± 1%       ~ (p=0.065 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromProto-2                 381.6µ ± 2%   384.8µ ± 8%       ~ (p=0.065 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2                 510.6µ ± 2%   513.5µ ± 1%       ~ (p=0.132 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2                   504.2µ ± 1%   511.0µ ± 4%  +1.37% (p=0.015 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2                431.1µ ± 5%   434.1µ ± 7%       ~ (p=0.180 n=6)
geomean                                                                                                   406.6µ        410.0µ       +0.83%

                                                                                           │ x.bwplotka/appendold.txt │     x.bwplotka/append3-en.txt      │
                                                                                           │           B/op           │     B/op      vs base              │
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromText-2                 3.433Ki ± 1%   3.346Ki ± 1%  -2.55% (p=0.002 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=OMText-2                   3.575Ki ± 1%   3.488Ki ± 3%       ~ (p=0.061 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromProto-2                112.0Ki ± 0%   112.1Ki ± 0%       ~ (p=0.058 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2                3.551Ki ± 3%   3.463Ki ± 0%  -2.48% (p=0.002 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2                  3.681Ki ± 0%   3.605Ki ± 1%  -2.06% (p=0.002 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2               75.10Ki ± 0%   75.10Ki ± 0%       ~ (p=0.814 n=6)
geomean                                                                                                  10.51Ki        10.35Ki       -1.58%

                                                                                           │ x.bwplotka/appendold.txt │     x.bwplotka/append3-en.txt     │
                                                                                           │        allocs/op         │  allocs/op   vs base              │
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromText-2                   27.00 ± 0%    26.00 ± 0%  -3.70% (p=0.002 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=OMText-2                     28.00 ± 0%    27.00 ± 0%  -3.57% (p=0.002 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromProto-2                  42.00 ± 0%    41.00 ± 0%  -2.38% (p=0.002 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2                  27.00 ± 4%    25.00 ± 4%  -7.41% (p=0.004 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2                    28.00 ± 4%    26.00 ± 4%  -7.14% (p=0.004 n=6)
ScrapeLoopAppend/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2                2.243k ± 0%   2.242k ± 0%  -0.04% (p=0.015 n=6)
geomean                                                                                                    61.45         58.94       -4.08%
```

With exemplars:
```
benchstat -filter "/appV2:true"  x.bwplotka/appendHistWithExemplarsmain.txt x.bwplotka/appendHistWithExemplars.txt 
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/scrape
cpu: Apple M4 Pro
                                                      │ x.bwplotka/appendHistWithExemplarsmain.txt │ x.bwplotka/appendHistWithExemplars.txt │
                                                      │                   sec/op                   │        sec/op          vs base         │
ScrapeLoopAppend_HistogramsWithExemplars/appV2=true-2                                  757.4µ ± 5%             767.4µ ± 3%  ~ (p=0.818 n=6)

                                                      │ x.bwplotka/appendHistWithExemplarsmain.txt │ x.bwplotka/appendHistWithExemplars.txt │
                                                      │                    B/op                    │       B/op        vs base              │
ScrapeLoopAppend_HistogramsWithExemplars/appV2=true-2                                 133.5Ki ± 0%       133.5Ki ± 0%  +0.02% (p=0.002 n=6)

                                                      │ x.bwplotka/appendHistWithExemplarsmain.txt │ x.bwplotka/appendHistWithExemplars.txt │
                                                      │                 allocs/op                  │      allocs/op       vs base           │
ScrapeLoopAppend_HistogramsWithExemplars/appV2=true-2                                  2.430k ± 0%           2.430k ± 0%  ~ (p=1.000 n=6) ¹
```

### Parity

There's some slight work for latency, but it's now clear it's on TSDB side.

```
benchstat -col /appV2 x.bwplotka/append3.txt             
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/scrape
cpu: Apple M4 Pro
                                                                                                  │    false     │                true                │
                                                                                                  │    sec/op    │    sec/op     vs base              │
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromText-2     280.9µ ±  8%   276.3µ ±  1%  -1.63% (p=0.004 n=6)
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=OMText-2       275.8µ ±  1%   273.9µ ± 11%       ~ (p=0.485 n=6)
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromProto-2    339.2µ ±  3%   329.6µ ±  1%  -2.85% (p=0.002 n=6)
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2    458.2µ ±  5%   458.5µ ±  4%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2      454.9µ ±  8%   459.1µ ±  1%       ~ (p=0.589 n=6)
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2   380.8µ ±  1%   376.5µ ± 10%       ~ (p=0.180 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromText-2      317.4µ ±  4%   329.8µ ±  1%  +3.90% (p=0.004 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=OMText-2        311.0µ ±  1%   328.4µ ±  1%  +5.57% (p=0.002 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromProto-2     377.1µ ± 11%   384.8µ ±  8%       ~ (p=0.065 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2     494.3µ ±  1%   513.5µ ±  1%  +3.88% (p=0.002 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2       491.8µ ±  7%   511.0µ ±  4%  +3.92% (p=0.041 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2    421.7µ ±  6%   434.1µ ±  7%  +2.94% (p=0.041 n=6)
geomean                                                                                             375.9µ         381.1µ        +1.38%

                                                                                                  │    false     │                 true                 │
                                                                                                  │     B/op     │     B/op      vs base                │
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromText-2     1.587Ki ± 0%   1.587Ki ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=OMText-2       1.729Ki ± 0%   1.729Ki ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromProto-2    110.1Ki ± 0%   110.1Ki ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2    1.972Ki ± 1%   1.972Ki ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2      2.114Ki ± 1%   2.114Ki ± 1%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2   73.54Ki ± 0%   73.54Ki ± 0%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromText-2      3.346Ki ± 1%   3.346Ki ± 1%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=OMText-2        3.488Ki ± 3%   3.488Ki ± 3%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromProto-2     112.0Ki ± 0%   112.1Ki ± 0%       ~ (p=0.372 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2     3.463Ki ± 0%   3.463Ki ± 0%       ~ (p=0.857 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2       3.605Ki ± 1%   3.605Ki ± 1%       ~ (p=0.184 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2    75.09Ki ± 0%   75.10Ki ± 0%       ~ (p=0.457 n=6)
geomean                                                                                             8.342Ki        8.342Ki       +0.00%
¹ all samples are equal

                                                                                                  │    false    │                true                 │
                                                                                                  │  allocs/op  │  allocs/op   vs base                │
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromText-2      17.00 ± 0%    17.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=OMText-2        18.00 ± 0%    18.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromProto-2     32.00 ± 0%    32.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2     18.00 ± 0%    18.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2       19.00 ± 0%    19.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2   2.235k ± 0%   2.235k ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromText-2       26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=OMText-2         27.00 ± 0%    27.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=1Fam1000Gauges/fmt=PromProto-2      41.00 ± 0%    41.00 ± 0%       ~ (p=1.000 n=6) ¹
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2      25.00 ± 4%    25.00 ± 4%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=OMText-2        26.00 ± 0%    26.00 ± 4%       ~ (p=1.000 n=6)
ScrapeLoopAppend/withStorage=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromProto-2    2.242k ± 0%   2.242k ± 0%       ~ (p=1.000 n=6)
geomean                                                                                              51.06         51.06       +0.00%
¹ all samples are equal
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
