### PR TITLE
docs: promql: Update docs about ignoring info metrics

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -568,6 +568,8 @@ While `info` normally automatically finds all matching info series, it's possibl
 restrict them by providing a `__name__` label matcher, e.g.
 `{__name__="target_info"}`.
 
+Note that if there are any time series in `v` that match the `data-label-selector` (or the default `target_info` if that argument is not specified), they will be treated as info series and will be returned unchanged.
+
 ### Limitations
 
 In its current iteration, `info` defaults to considering only info series with

--- a/web/ui/mantine-ui/src/promql/functionDocs.tsx
+++ b/web/ui/mantine-ui/src/promql/functionDocs.tsx
@@ -1756,6 +1756,12 @@ const funcDocs: Record<string, React.ReactNode> = {
         .
       </p>
 
+      <p>
+        Note that if there are any time series in <code>v</code> that match the <code>data-label-selector</code> (or the
+        default <code>target_info</code> if that argument is not specified), they will be treated as info series and
+        will be returned unchanged.
+      </p>
+
       <h3>Limitations</h3>
 
       <p>


### PR DESCRIPTION
Description in title

#### Which issue(s) does the PR fix:

N/A

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```