### PR TITLE
feat(tsdb/agent): Implement checkpoint based on series in memory

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -668,7 +668,7 @@ func main() {
 		os.Exit(3)
 	}
 
-	if agentMode && cfg.agent.CheckpointBatchSize == 0 {
+	if agentMode && cfg.agent.CheckpointBatchSize <= 0 {
 		fmt.Fprintln(os.Stderr, "--storage.agent.checkpoint-batch-size must be greater than 0.")
 		os.Exit(1)
 	}

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -557,6 +557,12 @@ func main() {
 		"Maximum age samples may be before being forcibly deleted when the WAL is truncated").
 		Default(agentDefaultMaxWALTime).SetValue(&cfg.agent.MaxWALTime)
 
+	agentOnlyFlag(a, "storage.agent.checkpoint-from-in-memory-series", "Use only in-memory series data when building a checkpoint.").
+		Default("false").BoolVar(&cfg.agent.CheckpointFromInMemorySeries)
+
+	agentOnlyFlag(a, "storage.agent.checkpoint-batch-size", "Size of a single WAL log entry chunk to be flushed. Has no effect without --storage.agent.checkpoint-from-in-memory-series flag.").
+		Default("1000").IntVar(&cfg.agent.CheckpointBatchSize)
+
 	agentOnlyFlag(a, "storage.agent.no-lockfile", "Do not create lockfile in data directory.").
 		Default("false").BoolVar(&cfg.agent.NoLockfile)
 
@@ -2078,15 +2084,17 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 // agentOptions is a version of agent.Options with defined units. This is required
 // as agent.Option fields are unit agnostic (time).
 type agentOptions struct {
-	WALSegmentSize         units.Base2Bytes
-	WALCompressionType     compression.Type
-	StripeSize             int
-	TruncateFrequency      model.Duration
-	MinWALTime, MaxWALTime model.Duration
-	NoLockfile             bool
-	OutOfOrderTimeWindow   int64 // TODO(bwplotka): Unused option, fix it or remove.
-	EnableSTAsZeroSample   bool
-	EnableSTStorage        bool
+	WALSegmentSize               units.Base2Bytes
+	WALCompressionType           compression.Type
+	StripeSize                   int
+	TruncateFrequency            model.Duration
+	MinWALTime, MaxWALTime       model.Duration
+	NoLockfile                   bool
+	OutOfOrderTimeWindow         int64 // TODO(bwplotka): Unused option, fix it or remove.
+	EnableSTAsZeroSample         bool
+	EnableSTStorage              bool
+	CheckpointFromInMemorySeries bool
+	CheckpointBatchSize          int
 }
 
 func (opts agentOptions) ToAgentOptions(outOfOrderTimeWindow int64) agent.Options {
@@ -2094,16 +2102,18 @@ func (opts agentOptions) ToAgentOptions(outOfOrderTimeWindow int64) agent.Option
 		outOfOrderTimeWindow = 0
 	}
 	return agent.Options{
-		WALSegmentSize:       int(opts.WALSegmentSize),
-		WALCompression:       opts.WALCompressionType,
-		StripeSize:           opts.StripeSize,
-		TruncateFrequency:    time.Duration(opts.TruncateFrequency),
-		MinWALTime:           durationToInt64Millis(time.Duration(opts.MinWALTime)),
-		MaxWALTime:           durationToInt64Millis(time.Duration(opts.MaxWALTime)),
-		NoLockfile:           opts.NoLockfile,
-		OutOfOrderTimeWindow: outOfOrderTimeWindow,
-		EnableSTAsZeroSample: opts.EnableSTAsZeroSample,
-		EnableSTStorage:      opts.EnableSTStorage,
+		WALSegmentSize:               int(opts.WALSegmentSize),
+		WALCompression:               opts.WALCompressionType,
+		StripeSize:                   opts.StripeSize,
+		TruncateFrequency:            time.Duration(opts.TruncateFrequency),
+		MinWALTime:                   durationToInt64Millis(time.Duration(opts.MinWALTime)),
+		MaxWALTime:                   durationToInt64Millis(time.Duration(opts.MaxWALTime)),
+		NoLockfile:                   opts.NoLockfile,
+		OutOfOrderTimeWindow:         outOfOrderTimeWindow,
+		EnableSTAsZeroSample:         opts.EnableSTAsZeroSample,
+		EnableSTStorage:              opts.EnableSTStorage,
+		CheckpointFromInMemorySeries: opts.CheckpointFromInMemorySeries,
+		CheckpointBatchSize:          opts.CheckpointBatchSize,
 	}
 }
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -668,6 +668,11 @@ func main() {
 		os.Exit(3)
 	}
 
+	if agentMode && cfg.agent.CheckpointBatchSize == 0 {
+		fmt.Fprintln(os.Stderr, "--storage.agent.checkpoint-batch-size must be greater than 0.")
+		os.Exit(1)
+	}
+
 	if cfg.memlimitRatio <= 0.0 || cfg.memlimitRatio > 1.0 {
 		fmt.Fprintf(os.Stderr, "--auto-gomemlimit.ratio must be greater than 0 and less than or equal to 1.")
 		os.Exit(1)

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -43,6 +43,8 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--storage.agent.wal-compression</code> | Compress the agent WAL. If false, the --storage.agent.wal-compression-type flag is ignored. Use with agent mode only. | `true` |
 | <code class="text-nowrap">--storage.agent.retention.min-time</code> | Minimum age samples may be before being considered for deletion when the WAL is truncated Use with agent mode only. | `5m` |
 | <code class="text-nowrap">--storage.agent.retention.max-time</code> | Maximum age samples may be before being forcibly deleted when the WAL is truncated Use with agent mode only. | `4h` |
+| <code class="text-nowrap">--storage.agent.checkpoint-from-in-memory-series</code> | Use only in-memory series data when building a checkpoint. Use with agent mode only. | `false` |
+| <code class="text-nowrap">--storage.agent.checkpoint-batch-size</code> | Size of a single WAL log entry chunk to be flushed. Has no effect without --storage.agent.checkpoint-from-in-memory-series flag. Use with agent mode only. | `1000` |
 | <code class="text-nowrap">--storage.agent.no-lockfile</code> | Do not create lockfile in data directory. Use with agent mode only. | `false` |
 | <code class="text-nowrap">--storage.remote.flush-deadline</code> | How long to wait flushing sample on shutdown or config reload. | `1m` |
 | <code class="text-nowrap">--storage.remote.read-sample-limit</code> | Maximum overall number of samples to return via the remote read interface, in a single query. 0 means no limit. This limit is ignored for streamed response types. Use with server mode only. | `5e7` |

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -65,5 +65,3 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--agent</code> | Run Prometheus in 'Agent mode'. |  |
 | <code class="text-nowrap">--log.level</code> | Only log messages with the given severity or above. One of: [debug, info, warn, error] | `info` |
 | <code class="text-nowrap">--log.format</code> | Output format of log messages. One of: [logfmt, json] | `logfmt` |
-
-

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -65,3 +65,5 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--agent</code> | Run Prometheus in 'Agent mode'. |  |
 | <code class="text-nowrap">--log.level</code> | Only log messages with the given severity or above. One of: [debug, info, warn, error] | `info` |
 | <code class="text-nowrap">--log.format</code> | Output format of log messages. One of: [logfmt, json] | `logfmt` |
+
+

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -1,0 +1,222 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+	"log/slog"
+	"os"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/wlog"
+)
+
+type ActiveSeries interface {
+	Ref() chunks.HeadSeriesRef
+	Labels() labels.Labels
+	LastSampleTimestamp() int64
+}
+
+type checkpointFlusher struct {
+	enc         record.Encoder
+	checkpoint  *wlog.WL
+	seriesBuff  []byte
+	samplesBuff []byte
+
+	seriesRecords []record.RefSeries
+	sampleRecords []record.RefSample
+	offset        int
+	batchSize     int
+}
+
+func newCheckpointFlusher(checkpoint *wlog.WL, batchSize int) *checkpointFlusher {
+	return &checkpointFlusher{
+		batchSize:     batchSize,
+		checkpoint:    checkpoint,
+		seriesRecords: make([]record.RefSeries, batchSize),
+		sampleRecords: make([]record.RefSample, batchSize),
+	}
+}
+
+func (cf *checkpointFlusher) flushRecords(withSamples bool) error {
+	cf.seriesBuff = cf.enc.Series(cf.seriesRecords, cf.seriesBuff)
+
+	var err error
+	if withSamples {
+		cf.samplesBuff = cf.enc.Samples(cf.sampleRecords, cf.samplesBuff)
+		err = cf.checkpoint.Log(cf.seriesBuff, cf.samplesBuff)
+	} else {
+		err = cf.checkpoint.Log(cf.seriesBuff)
+	}
+
+	if err != nil {
+		return fmt.Errorf("flush records: %w", err)
+	}
+
+	cf.seriesBuff = cf.seriesBuff[:0]
+	cf.samplesBuff = cf.samplesBuff[:0]
+	cf.offset = 0
+	return nil
+}
+
+func (cf *checkpointFlusher) writeSeries(seriesIter iter.Seq[ActiveSeries]) error {
+	for series := range seriesIter {
+		// If we filled the buffers, write them out and reset.
+		if cf.offset == cf.batchSize {
+			if err := cf.flushRecords(true); err != nil {
+				return fmt.Errorf("flush active series: %w", err)
+			}
+		}
+
+		cf.seriesRecords[cf.offset] = record.RefSeries{
+			Ref:    series.Ref(),
+			Labels: series.Labels(),
+		}
+
+		// Sample value is irrelevant, we only need the timestamp.
+		cf.sampleRecords[cf.offset] = record.RefSample{
+			Ref: series.Ref(),
+			T:   series.LastSampleTimestamp(),
+			V:   0,
+		}
+
+		cf.offset++
+	}
+
+	// Clear the last batch if we have one
+	if cf.offset != 0 {
+		return cf.flushRecords(true)
+	}
+
+	return nil
+}
+
+func (cf *checkpointFlusher) writeDeletedRecords(seriesRefIter iter.Seq[chunks.HeadSeriesRef]) error {
+	for ref := range seriesRefIter {
+		// If we filled the buffers, write them out and reset.
+		if cf.offset == cf.batchSize {
+			if err := cf.flushRecords(false); err != nil {
+				return fmt.Errorf("flush deleted series: %w", err)
+			}
+		}
+
+		// We don't care about timestamps here, so no samples.
+		cf.seriesRecords[cf.offset] = record.RefSeries{
+			Ref: ref,
+		}
+
+		cf.offset++
+	}
+
+	// Clear the last batch if we have one
+	if cf.offset != 0 {
+		return cf.flushRecords(false)
+	}
+
+	return nil
+}
+
+const defaultBatchSize = 1000
+
+type CheckpointParams struct {
+	// AtIndex is index at which a checkpoint should be created.
+	AtIndex int
+
+	// BatchSize is size of a single WAL log entry chunk to be flushed.
+	BatchSize int
+
+	// ActiveSeries is an iterator over active series.
+	ActiveSeries iter.Seq[ActiveSeries]
+
+	// DeletedSeries is iterator over recently deleted series.
+	DeletedSeries iter.Seq[chunks.HeadSeriesRef]
+}
+
+func (p CheckpointParams) withDefaults() CheckpointParams {
+	if p.BatchSize == 0 {
+		p.BatchSize = defaultBatchSize
+	}
+
+	return p
+}
+
+// Checkpoint creates an unindexed checkpoint containing record.RefSeries and
+// record.RefSample for ActiveSeries and  a record.RefSeries for the recentlyDeleted series.
+//
+// The difference between this implementation and [wlog.Checkpoint] is that it skips re-read current checkpoint + segments
+// and relies on data in memory.
+func Checkpoint(logger *slog.Logger, w *wlog.WL, p CheckpointParams) error {
+	p = p.withDefaults()
+	logger.Info("creating checkpoint from WAL", "atIndex", p.AtIndex)
+
+	dir, idx, err := wlog.LastCheckpoint(w.Dir())
+	if err != nil && !errors.Is(err, record.ErrNotFound) {
+		return fmt.Errorf("can't find last checkpoint: %w", err)
+	}
+
+	if idx >= p.AtIndex {
+		logger.Info(
+			"checkpoint already exists",
+			"dir", dir,
+			"index", idx,
+			"requested_index", p.AtIndex,
+		)
+		return nil
+	}
+
+	// TODO: cleanup old temp checkpoints
+	cpDir := wlog.CheckpointDir(w.Dir(), p.AtIndex)
+	cpTmpDir := cpDir + ".tmp"
+	if err := os.RemoveAll(cpTmpDir); err != nil {
+		return fmt.Errorf("remove previous temporary checkpoint dir: %w", err)
+	}
+
+	if err := os.MkdirAll(cpTmpDir, os.ModePerm); err != nil {
+		return fmt.Errorf("create checkpoint dir: %q", err)
+	}
+
+	cp, err := wlog.New(logger, nil, cpTmpDir, w.CompressionType())
+	if err != nil {
+		return fmt.Errorf("open checkpoint: %w", err)
+	}
+
+	defer func() {
+		os.RemoveAll(cpTmpDir)
+		cp.Close()
+	}()
+
+	flusher := newCheckpointFlusher(cp, p.BatchSize)
+	if err := flusher.writeSeries(p.ActiveSeries); err != nil {
+		return err
+	}
+
+	if err := flusher.writeDeletedRecords(p.DeletedSeries); err != nil {
+		return err
+	}
+
+	if err := cp.Close(); err != nil {
+		return fmt.Errorf("close checkpoint: %w", err)
+	}
+
+	// Sync temporary directory before rename.
+	df, err := fileutil.OpenDir(cpTmpDir)
+	if err != nil {
+		return fmt.Errorf("open temporary checkpoint directory: %w", err)
+	}
+	if err := df.Sync(); err != nil {
+		df.Close()
+		return fmt.Errorf("sync temporary checkpoint directory: %w", err)
+	}
+	if err = df.Close(); err != nil {
+		return fmt.Errorf("close temporary checkpoint directory: %w", err)
+	}
+
+	if err := fileutil.Replace(cpTmpDir, cpDir); err != nil {
+		return fmt.Errorf("rename checkpoint directory: %w", err)
+	}
+
+	return nil
+}

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -181,7 +181,7 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, p CheckpointParams) error {
 	}
 
 	if err := os.MkdirAll(cpTmpDir, os.ModePerm); err != nil {
-		return fmt.Errorf("create checkpoint dir: %q", err)
+		return fmt.Errorf("create checkpoint dir: %w", err)
 	}
 
 	cp, err := wlog.New(logger, nil, cpTmpDir, w.CompressionType())

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -7,18 +7,11 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/wlog"
 )
-
-type ActiveSeries interface {
-	Ref() chunks.HeadSeriesRef
-	Labels() labels.Labels
-	LastSampleTimestamp() int64
-}
 
 type checkpointFlusher struct {
 	enc         record.Encoder
@@ -144,7 +137,7 @@ func (p CheckpointParams) withDefaults() CheckpointParams {
 }
 
 // Checkpoint creates an unindexed checkpoint containing record.RefSeries and
-// record.RefSample for ActiveSeries and  a record.RefSeries for the recentlyDeleted series.
+// record.RefSample for ActiveSeries and a record.RefSeries for the recentlyDeleted series.
 //
 // The difference between this implementation and [wlog.Checkpoint] is that it skips re-read current checkpoint + segments
 // and relies on data in memory.

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -1,3 +1,16 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package agent
 
 import (

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -29,7 +29,8 @@ import (
 const defaultBatchSize = 1000
 
 type CheckpointParams struct {
-	// AtIndex is index at which a checkpoint should be created.
+	// AtIndex is the WAL segment index to name this checkpoint after.
+	// If a checkpoint at given index or higher already exists, creation is skipped.
 	AtIndex int
 
 	// BatchSize is size of a single WAL log entry chunk to be flushed.

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -31,8 +31,8 @@ const defaultBatchSize = 1000
 
 // ActiveSeries describes a live series to be written by [Checkpoint].
 //
-// This interface is intentionally exported so external TSDB implementations can
-// use [Checkpoint] without depending on Prometheus internal series types.
+// This interface is intentionally exported so downstream users of this package
+// can use [Checkpoint] without depending on Prometheus internal series types.
 type ActiveSeries interface {
 	Ref() chunks.HeadSeriesRef
 	Labels() labels.Labels
@@ -41,8 +41,8 @@ type ActiveSeries interface {
 
 // DeletedSeries describes a deleted series to be written by [Checkpoint].
 //
-// This interface is intentionally exported so external TSDB implementations can
-// use [Checkpoint] without depending on Prometheus internal series types.
+// This interface is intentionally exported so downstream users of this package
+// can use [Checkpoint] without depending on Prometheus internal series types.
 type DeletedSeries interface {
 	Ref() chunks.HeadSeriesRef
 	Labels() labels.Labels
@@ -51,7 +51,7 @@ type DeletedSeries interface {
 // Checkpoint creates an unindexed checkpoint containing record.RefSeries and
 // last timestamp for ActiveSeries and record.RefSeries for DeletedSeries.
 //
-// This API accepts interfaces so external TSDB implementations can provide
+// This API accepts interfaces so downstream users of this package can provide
 // their own series storage while reusing Prometheus checkpoint writing logic.
 //
 // The difference between this implementation and [wlog.Checkpoint] is that it skips re-read current checkpoint + segments

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -95,10 +95,10 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, p CheckpointParams) error {
 
 	success := false
 	defer func() {
-		os.RemoveAll(cpTmpDir)
 		if !success {
 			cp.Close()
 		}
+		os.RemoveAll(cpTmpDir)
 	}()
 
 	flusher := newCheckpointFlusher(cp, p.BatchSize)

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -27,49 +27,28 @@ import (
 
 const defaultBatchSize = 1000
 
-type CheckpointParams struct {
-	// AtIndex is the WAL segment index to name this checkpoint after.
-	// If a checkpoint at given index or higher already exists, creation is skipped.
-	AtIndex int
-
-	// BatchSize is size of a single WAL log entry chunk to be flushed.
-	BatchSize int
-
-	// ActiveSeries is an iterator over active series.
-	ActiveSeries iter.Seq[ActiveSeries]
-
-	// DeletedSeries is iterator over recently deleted series.
-	DeletedSeries iter.Seq[DeletedSeries]
-}
-
-func (p CheckpointParams) withDefaults() CheckpointParams {
-	if p.BatchSize <= 0 {
-		p.BatchSize = defaultBatchSize
-	}
-
-	return p
-}
-
 // Checkpoint creates an unindexed checkpoint containing record.RefSeries and
 // last timestamp for ActiveSeries and a record.RefSeries for the recentlyDeleted series.
 //
 // The difference between this implementation and [wlog.Checkpoint] is that it skips re-read current checkpoint + segments
 // and relies on data in memory.
-func Checkpoint(logger *slog.Logger, w *wlog.WL, p CheckpointParams) error {
-	p = p.withDefaults()
-	logger.Info("Creating checkpoint", "atIndex", p.AtIndex)
+func Checkpoint(logger *slog.Logger, w *wlog.WL, atIndex, batchSize int, activeSeries iter.Seq[ActiveSeries], deletedSeries iter.Seq[DeletedSeries]) error {
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+	logger.Info("Creating checkpoint", "atIndex", atIndex)
 
 	dir, idx, err := wlog.LastCheckpoint(w.Dir())
 	if err != nil && !errors.Is(err, record.ErrNotFound) {
 		return fmt.Errorf("can't find last checkpoint: %w", err)
 	}
 
-	if idx >= p.AtIndex {
+	if idx >= atIndex {
 		logger.Info(
 			"checkpoint already exists",
 			"dir", dir,
 			"index", idx,
-			"requested_index", p.AtIndex,
+			"requested_index", atIndex,
 		)
 		return nil
 	}
@@ -78,7 +57,7 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, p CheckpointParams) error {
 		return fmt.Errorf("failed to cleanup temporary checkpoints: %w", err)
 	}
 
-	cpDir := wlog.CheckpointDir(w.Dir(), p.AtIndex)
+	cpDir := wlog.CheckpointDir(w.Dir(), atIndex)
 	cpTmpDir := cpDir + wlog.CheckpointTempFileSuffix
 	if err := os.RemoveAll(cpTmpDir); err != nil {
 		return fmt.Errorf("remove previous temporary checkpoint dir: %w", err)
@@ -101,12 +80,12 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, p CheckpointParams) error {
 		os.RemoveAll(cpTmpDir)
 	}()
 
-	flusher := newCheckpointFlusher(cp, p.BatchSize)
-	if err := flusher.writeSeries(p.ActiveSeries); err != nil {
+	flusher := newCheckpointFlusher(cp, batchSize)
+	if err := flusher.writeSeries(activeSeries); err != nil {
 		return err
 	}
 
-	if err := flusher.writeDeletedRecords(p.DeletedSeries); err != nil {
+	if err := flusher.writeDeletedRecords(deletedSeries); err != nil {
 		return err
 	}
 
@@ -136,7 +115,7 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, p CheckpointParams) error {
 	return nil
 }
 
-type checkpointFlusher struct {
+type checkpointWriter struct {
 	enc         record.Encoder
 	checkpoint  *wlog.WL
 	seriesBuff  []byte
@@ -147,8 +126,8 @@ type checkpointFlusher struct {
 	batchSize     int
 }
 
-func newCheckpointFlusher(checkpoint *wlog.WL, batchSize int) *checkpointFlusher {
-	return &checkpointFlusher{
+func newCheckpointFlusher(checkpoint *wlog.WL, batchSize int) *checkpointWriter {
+	return &checkpointWriter{
 		batchSize:     batchSize,
 		checkpoint:    checkpoint,
 		seriesRecords: make([]record.RefSeries, 0, batchSize),
@@ -156,7 +135,7 @@ func newCheckpointFlusher(checkpoint *wlog.WL, batchSize int) *checkpointFlusher
 	}
 }
 
-func (cf *checkpointFlusher) flushRecords() error {
+func (cf *checkpointWriter) flushRecords() error {
 	withSamples := len(cf.sampleRecords) > 0
 	cf.seriesBuff = cf.enc.Series(cf.seriesRecords, cf.seriesBuff)
 
@@ -179,7 +158,7 @@ func (cf *checkpointFlusher) flushRecords() error {
 	return nil
 }
 
-func (cf *checkpointFlusher) writeSeries(seriesIter iter.Seq[ActiveSeries]) error {
+func (cf *checkpointWriter) writeSeries(seriesIter iter.Seq[ActiveSeries]) error {
 	for series := range seriesIter {
 		// If we filled the buffers, write them out and reset.
 		if len(cf.seriesRecords) == cf.batchSize {
@@ -209,7 +188,7 @@ func (cf *checkpointFlusher) writeSeries(seriesIter iter.Seq[ActiveSeries]) erro
 	return nil
 }
 
-func (cf *checkpointFlusher) writeDeletedRecords(seriesRefIter iter.Seq[DeletedSeries]) error {
+func (cf *checkpointWriter) writeDeletedRecords(seriesRefIter iter.Seq[DeletedSeries]) error {
 	for series := range seriesRefIter {
 		// If we filled the buffers, write them out and reset.
 		if len(cf.seriesRecords) == cf.batchSize {

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -201,7 +201,7 @@ func (cf *checkpointFlusher) writeSeries(seriesIter iter.Seq[ActiveSeries]) erro
 		})
 	}
 
-	// Fluch the last batch if we have one
+	// Flush the last batch if we have one
 	if len(cf.seriesRecords) != 0 {
 		return cf.flushRecords()
 	}

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -20,7 +20,6 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/wlog"
@@ -40,7 +39,7 @@ type CheckpointParams struct {
 	ActiveSeries iter.Seq[ActiveSeries]
 
 	// DeletedSeries is iterator over recently deleted series.
-	DeletedSeries iter.Seq[chunks.HeadSeriesRef]
+	DeletedSeries iter.Seq[DeletedSeries]
 }
 
 func (p CheckpointParams) withDefaults() CheckpointParams {
@@ -210,8 +209,8 @@ func (cf *checkpointFlusher) writeSeries(seriesIter iter.Seq[ActiveSeries]) erro
 	return nil
 }
 
-func (cf *checkpointFlusher) writeDeletedRecords(seriesRefIter iter.Seq[chunks.HeadSeriesRef]) error {
-	for ref := range seriesRefIter {
+func (cf *checkpointFlusher) writeDeletedRecords(seriesRefIter iter.Seq[DeletedSeries]) error {
+	for series := range seriesRefIter {
 		// If we filled the buffers, write them out and reset.
 		if len(cf.seriesRecords) == cf.batchSize {
 			if err := cf.flushRecords(); err != nil {
@@ -221,7 +220,8 @@ func (cf *checkpointFlusher) writeDeletedRecords(seriesRefIter iter.Seq[chunks.H
 
 		// We don't care about timestamps here, so no samples.
 		cf.seriesRecords = append(cf.seriesRecords, record.RefSeries{
-			Ref: ref,
+			Ref:    series.Ref(),
+			Labels: series.Labels(),
 		})
 	}
 

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -91,8 +91,6 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, atIndex, batchSize int, activeS
 		return fmt.Errorf("close checkpoint: %w", err)
 	}
 
-	// The original wlog.Checkpoint syncs temporary directory before rename.
-	// See tsdb/wlog/checkpoint.go:390
 	df, err := fileutil.OpenDir(cpTmpDir)
 	if err != nil {
 		return fmt.Errorf("open temporary checkpoint directory: %w", err)

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -52,7 +52,7 @@ func (p CheckpointParams) withDefaults() CheckpointParams {
 }
 
 // Checkpoint creates an unindexed checkpoint containing record.RefSeries and
-// record.RefSample for ActiveSeries and a record.RefSeries for the recentlyDeleted series.
+// last timestamp for ActiveSeries and a record.RefSeries for the recentlyDeleted series.
 //
 // The difference between this implementation and [wlog.Checkpoint] is that it skips re-read current checkpoint + segments
 // and relies on data in memory.
@@ -94,9 +94,12 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, p CheckpointParams) error {
 		return fmt.Errorf("open checkpoint: %w", err)
 	}
 
+	success := false
 	defer func() {
 		os.RemoveAll(cpTmpDir)
-		cp.Close()
+		if !success {
+			cp.Close()
+		}
 	}()
 
 	flusher := newCheckpointFlusher(cp, p.BatchSize)
@@ -108,6 +111,7 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, p CheckpointParams) error {
 		return err
 	}
 
+	success = true
 	if err := cp.Close(); err != nil {
 		return fmt.Errorf("close checkpoint: %w", err)
 	}

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -59,9 +59,6 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, atIndex, batchSize int, activeS
 
 	cpDir := wlog.CheckpointDir(w.Dir(), atIndex)
 	cpTmpDir := cpDir + wlog.CheckpointTempFileSuffix
-	if err := os.RemoveAll(cpTmpDir); err != nil {
-		return fmt.Errorf("remove previous temporary checkpoint dir: %w", err)
-	}
 
 	if err := os.MkdirAll(cpTmpDir, os.ModePerm); err != nil {
 		return fmt.Errorf("create checkpoint dir: %w", err)

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -201,7 +201,7 @@ func (cf *checkpointFlusher) writeSeries(seriesIter iter.Seq[ActiveSeries]) erro
 		})
 	}
 
-	// Clear the last batch if we have one
+	// Fluch the last batch if we have one
 	if len(cf.seriesRecords) != 0 {
 		return cf.flushRecords()
 	}

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -20,6 +20,8 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/wlog"
@@ -27,8 +29,30 @@ import (
 
 const defaultBatchSize = 1000
 
+// ActiveSeries describes a live series to be written by [Checkpoint].
+//
+// This interface is intentionally exported so external TSDB implementations can
+// use [Checkpoint] without depending on Prometheus internal series types.
+type ActiveSeries interface {
+	Ref() chunks.HeadSeriesRef
+	Labels() labels.Labels
+	LastSampleTimestamp() int64
+}
+
+// DeletedSeries describes a deleted series to be written by [Checkpoint].
+//
+// This interface is intentionally exported so external TSDB implementations can
+// use [Checkpoint] without depending on Prometheus internal series types.
+type DeletedSeries interface {
+	Ref() chunks.HeadSeriesRef
+	Labels() labels.Labels
+}
+
 // Checkpoint creates an unindexed checkpoint containing record.RefSeries and
-// last timestamp for ActiveSeries and a record.RefSeries for the recentlyDeleted series.
+// last timestamp for ActiveSeries and record.RefSeries for DeletedSeries.
+//
+// This API accepts interfaces so external TSDB implementations can provide
+// their own series storage while reusing Prometheus checkpoint writing logic.
 //
 // The difference between this implementation and [wlog.Checkpoint] is that it skips re-read current checkpoint + segments
 // and relies on data in memory.

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -43,7 +43,7 @@ type CheckpointParams struct {
 }
 
 func (p CheckpointParams) withDefaults() CheckpointParams {
-	if p.BatchSize == 0 {
+	if p.BatchSize <= 0 {
 		p.BatchSize = defaultBatchSize
 	}
 

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -74,9 +74,12 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, p CheckpointParams) error {
 		return nil
 	}
 
-	// TODO: cleanup old temp checkpoints
+	if err := wlog.DeleteTempCheckpoints(logger, w.Dir()); err != nil {
+		return fmt.Errorf("failed to cleanup temporary checkpoints: %w", err)
+	}
+
 	cpDir := wlog.CheckpointDir(w.Dir(), p.AtIndex)
-	cpTmpDir := cpDir + ".tmp"
+	cpTmpDir := cpDir + wlog.CheckpointTempFileSuffix
 	if err := os.RemoveAll(cpTmpDir); err != nil {
 		return fmt.Errorf("remove previous temporary checkpoint dir: %w", err)
 	}
@@ -108,7 +111,8 @@ func Checkpoint(logger *slog.Logger, w *wlog.WL, p CheckpointParams) error {
 		return fmt.Errorf("close checkpoint: %w", err)
 	}
 
-	// Sync temporary directory before rename.
+	// The original wlog.Checkpoint syncs temporary directory before rename.
+	// See tsdb/wlog/checkpoint.go:390
 	df, err := fileutil.OpenDir(cpTmpDir)
 	if err != nil {
 		return fmt.Errorf("open temporary checkpoint directory: %w", err)

--- a/tsdb/agent/checkpoint.go
+++ b/tsdb/agent/checkpoint.go
@@ -141,7 +141,6 @@ type checkpointFlusher struct {
 
 	seriesRecords []record.RefSeries
 	sampleRecords []record.RefSample
-	offset        int
 	batchSize     int
 }
 
@@ -149,8 +148,8 @@ func newCheckpointFlusher(checkpoint *wlog.WL, batchSize int) *checkpointFlusher
 	return &checkpointFlusher{
 		batchSize:     batchSize,
 		checkpoint:    checkpoint,
-		seriesRecords: make([]record.RefSeries, batchSize),
-		sampleRecords: make([]record.RefSample, batchSize),
+		seriesRecords: make([]record.RefSeries, 0, batchSize),
+		sampleRecords: make([]record.RefSample, 0, batchSize),
 	}
 }
 
@@ -172,36 +171,35 @@ func (cf *checkpointFlusher) flushRecords() error {
 
 	cf.seriesBuff = cf.seriesBuff[:0]
 	cf.samplesBuff = cf.samplesBuff[:0]
-	cf.offset = 0
+	cf.seriesRecords = cf.seriesRecords[:0]
+	cf.sampleRecords = cf.sampleRecords[:0]
 	return nil
 }
 
 func (cf *checkpointFlusher) writeSeries(seriesIter iter.Seq[ActiveSeries]) error {
 	for series := range seriesIter {
 		// If we filled the buffers, write them out and reset.
-		if cf.offset == cf.batchSize {
+		if len(cf.seriesRecords) == cf.batchSize {
 			if err := cf.flushRecords(); err != nil {
 				return fmt.Errorf("flush active series: %w", err)
 			}
 		}
 
-		cf.seriesRecords[cf.offset] = record.RefSeries{
+		cf.seriesRecords = append(cf.seriesRecords, record.RefSeries{
 			Ref:    series.Ref(),
 			Labels: series.Labels(),
-		}
+		})
 
 		// Sample value is irrelevant, we only need the timestamp.
-		cf.sampleRecords[cf.offset] = record.RefSample{
+		cf.sampleRecords = append(cf.sampleRecords, record.RefSample{
 			Ref: series.Ref(),
 			T:   series.LastSampleTimestamp(),
 			V:   0,
-		}
-
-		cf.offset++
+		})
 	}
 
 	// Clear the last batch if we have one
-	if cf.offset != 0 {
+	if len(cf.seriesRecords) != 0 {
 		return cf.flushRecords()
 	}
 
@@ -211,22 +209,20 @@ func (cf *checkpointFlusher) writeSeries(seriesIter iter.Seq[ActiveSeries]) erro
 func (cf *checkpointFlusher) writeDeletedRecords(seriesRefIter iter.Seq[chunks.HeadSeriesRef]) error {
 	for ref := range seriesRefIter {
 		// If we filled the buffers, write them out and reset.
-		if cf.offset == cf.batchSize {
+		if len(cf.seriesRecords) == cf.batchSize {
 			if err := cf.flushRecords(); err != nil {
 				return fmt.Errorf("flush deleted series: %w", err)
 			}
 		}
 
 		// We don't care about timestamps here, so no samples.
-		cf.seriesRecords[cf.offset] = record.RefSeries{
+		cf.seriesRecords = append(cf.seriesRecords, record.RefSeries{
 			Ref: ref,
-		}
-
-		cf.offset++
+		})
 	}
 
 	// Clear the last batch if we have one
-	if cf.offset != 0 {
+	if len(cf.seriesRecords) != 0 {
 		return cf.flushRecords()
 	}
 

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -21,20 +21,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/prometheus/prometheus/storage"
-	"github.com/prometheus/prometheus/storage/remote"
-	"github.com/prometheus/prometheus/tsdb/chunks"
-	"github.com/prometheus/prometheus/tsdb/tsdbutil"
-
 	"github.com/prometheus/common/promslog"
-
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/tsdb/wlog"
+	"github.com/stretchr/testify/require"
 )
 
 const walSegmentSize = 32 << 10 // must be aligned to the page size
@@ -391,64 +388,4 @@ func createCheckpointFixtures(t testing.TB, p checkpointFixtureParams) {
 		dt += p.dtDelta
 	}
 	require.NoError(t, w.Close(), "WAL.Close")
-}
-
-func makeHistogram(i int) *histogram.Histogram {
-	return &histogram.Histogram{
-		Count:         5 + uint64(i*4),
-		ZeroCount:     2 + uint64(i),
-		ZeroThreshold: 0.001,
-		Sum:           18.4 * float64(i+1),
-		Schema:        1,
-		PositiveSpans: []histogram.Span{
-			{Offset: 0, Length: 2},
-			{Offset: 1, Length: 2},
-		},
-		PositiveBuckets: []int64{int64(i + 1), 1, -1, 0},
-	}
-}
-
-func makeCustomBucketHistogram(i int) *histogram.Histogram {
-	return &histogram.Histogram{
-		Count:         5 + uint64(i*4),
-		ZeroCount:     2 + uint64(i),
-		ZeroThreshold: 0.001,
-		Sum:           18.4 * float64(i+1),
-		Schema:        -53,
-		PositiveSpans: []histogram.Span{
-			{Offset: 0, Length: 2},
-			{Offset: 1, Length: 2},
-		},
-		CustomValues: []float64{0, 1, 2, 3, 4},
-	}
-}
-
-func makeFloatHistogram(i int) *histogram.FloatHistogram {
-	return &histogram.FloatHistogram{
-		Count:         5 + float64(i*4),
-		ZeroCount:     2 + float64(i),
-		ZeroThreshold: 0.001,
-		Sum:           18.4 * float64(i+1),
-		Schema:        1,
-		PositiveSpans: []histogram.Span{
-			{Offset: 0, Length: 2},
-			{Offset: 1, Length: 2},
-		},
-		PositiveBuckets: []float64{float64(i + 1), 1, -1, 0},
-	}
-}
-
-func makeCustomBucketFloatHistogram(i int) *histogram.FloatHistogram {
-	return &histogram.FloatHistogram{
-		Count:         5 + float64(i*4),
-		ZeroCount:     2 + float64(i),
-		ZeroThreshold: 0.001,
-		Sum:           18.4 * float64(i+1),
-		Schema:        -53,
-		PositiveSpans: []histogram.Span{
-			{Offset: 0, Length: 2},
-			{Offset: 1, Length: 2},
-		},
-		CustomValues: []float64{0, 1, 2, 3, 4},
-	}
 }

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -1,0 +1,152 @@
+package agent
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/tsdb/chunks"
+
+	"github.com/prometheus/common/promslog"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/wlog"
+)
+
+const checkpointFixturesDir = "./testdata/db-fixtures/"
+
+func BenchmarkCheckpoint(b *testing.B) {
+}
+
+func TestCreateCheckpointFixtures(t *testing.T) {
+	createCheckpointFixtures(t, checkpointFixtureParams{
+		dir:         checkpointFixturesDir,
+		numSegments: 512,
+		numSeries:   32,
+		dtDelta:     10000,
+		segmentSize: 32 << 10, // must be aligned to page size
+	})
+}
+
+type checkpointFixtureParams struct {
+	dir         string
+	numSegments int
+	numSeries   int
+	segmentSize int
+	dtDelta     int64
+}
+
+func createCheckpointFixtures(t testing.TB, p checkpointFixtureParams) {
+	// Make a segment to put initial data
+	var enc record.Encoder
+
+	// Create first dummy segment to bump the start segment number.
+	seg, err := wlog.CreateSegment(p.dir, 100)
+	require.NoError(t, err)
+	require.NoError(t, seg.Close())
+
+	w, err := wlog.NewSize(promslog.NewNopLogger(), nil, p.dir, p.segmentSize, DefaultOptions().WALCompression)
+	require.NoError(t, err)
+
+	series := make([]record.RefSeries, 0, p.numSeries)
+	meta := make([]record.RefMetadata, 0, p.numSeries)
+	for i := range p.numSeries {
+		series = append(series, record.RefSeries{
+			Ref:    chunks.HeadSeriesRef(i),
+			Labels: labels.FromStrings("foo", "bar", "bar", strconv.Itoa(i)),
+		})
+		meta = append(meta, record.RefMetadata{
+			Ref:  chunks.HeadSeriesRef(i),
+			Unit: "unit",
+			Help: "help",
+		})
+	}
+
+	var dt int64
+	samples := make([]record.RefSample, 0, len(series))
+	for i := range p.numSegments {
+		if i == 0 {
+			// Write series required for samples
+			b := enc.Series(series, nil)
+			require.NoError(t, w.Log(b))
+
+			b = enc.Metadata(meta, nil)
+			require.NoError(t, w.Log(b))
+		}
+
+		samples = samples[:0]
+		for j := range len(series) {
+			samples = append(samples, record.RefSample{
+				Ref: chunks.HeadSeriesRef(j),
+				V:   float64(i),
+				T:   dt + int64(j+1),
+			})
+		}
+		require.NoError(t, w.Log(enc.Samples(samples, nil)))
+		dt += p.dtDelta
+	}
+	require.NoError(t, w.Close(), "WAL.Close")
+}
+
+func makeHistogram(i int) *histogram.Histogram {
+	return &histogram.Histogram{
+		Count:         5 + uint64(i*4),
+		ZeroCount:     2 + uint64(i),
+		ZeroThreshold: 0.001,
+		Sum:           18.4 * float64(i+1),
+		Schema:        1,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: 2},
+			{Offset: 1, Length: 2},
+		},
+		PositiveBuckets: []int64{int64(i + 1), 1, -1, 0},
+	}
+}
+
+func makeCustomBucketHistogram(i int) *histogram.Histogram {
+	return &histogram.Histogram{
+		Count:         5 + uint64(i*4),
+		ZeroCount:     2 + uint64(i),
+		ZeroThreshold: 0.001,
+		Sum:           18.4 * float64(i+1),
+		Schema:        -53,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: 2},
+			{Offset: 1, Length: 2},
+		},
+		CustomValues: []float64{0, 1, 2, 3, 4},
+	}
+}
+
+func makeFloatHistogram(i int) *histogram.FloatHistogram {
+	return &histogram.FloatHistogram{
+		Count:         5 + float64(i*4),
+		ZeroCount:     2 + float64(i),
+		ZeroThreshold: 0.001,
+		Sum:           18.4 * float64(i+1),
+		Schema:        1,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: 2},
+			{Offset: 1, Length: 2},
+		},
+		PositiveBuckets: []float64{float64(i + 1), 1, -1, 0},
+	}
+}
+
+func makeCustomBucketFloatHistogram(i int) *histogram.FloatHistogram {
+	return &histogram.FloatHistogram{
+		Count:         5 + float64(i*4),
+		ZeroCount:     2 + float64(i),
+		ZeroThreshold: 0.001,
+		Sum:           18.4 * float64(i+1),
+		Schema:        -53,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: 2},
+			{Offset: 1, Length: 2},
+		},
+		CustomValues: []float64{0, 1, 2, 3, 4},
+	}
+}

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -1,3 +1,16 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package agent
 
 import (

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -153,7 +153,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 		require.NoError(t, db.Close())
 	})
 
-	assertCheckpointExists(t, wlogWalDir, 1)
+	assertCheckpointExists(t, agentWalDir, 1)
 	openDBAndDo(newParams, func(db *DB) {
 		defer db.Close()
 		agentAfterSeries = db.series

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -47,8 +47,8 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	)
 
 	type openDBParams struct {
-		isNewCheckpoint bool
-		storageDir      string
+		isInMemCheckpoint bool
+		storageDir        string
 	}
 
 	openDBAndDo := func(params openDBParams, fn func(db *DB)) {
@@ -62,7 +62,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 
 		opts := DefaultOptions()
 		opts.OutOfOrderTimeWindow = math.MaxInt64 // Fixes "out of order sample" in benchmarks
-		opts.CheckpointFromInMemorySeries = params.isNewCheckpoint
+		opts.CheckpointFromInMemorySeries = params.isInMemCheckpoint
 		opts.WALSegmentSize = walSegmentSize // Set minimum size to get more segments for checkpoint.
 
 		db, err := Open(l, nil, rs, params.storageDir, opts)
@@ -112,8 +112,8 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	require.NoError(t, os.MkdirAll(wlogWalDir, os.ModePerm))
 
 	wlogParams := openDBParams{
-		isNewCheckpoint: false,
-		storageDir:      wlogStateRoot,
+		isInMemCheckpoint: false,
+		storageDir:        wlogStateRoot,
 	}
 
 	openDBAndDo(wlogParams, func(db *DB) {
@@ -128,7 +128,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	assertCheckpointExists(t, wlogWalDir, 1)
 
 	// Restore the database from the checkpoint.
-	wlogParams.isNewCheckpoint = true
+	wlogParams.isInMemCheckpoint = true
 	openDBAndDo(wlogParams, func(db *DB) {
 		defer db.Close()
 		wlogAfterSeries = db.series
@@ -140,8 +140,8 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	require.NoError(t, os.MkdirAll(agentWalDir, os.ModePerm))
 
 	newParams := openDBParams{
-		isNewCheckpoint: true,
-		storageDir:      agentStateRoot,
+		isInMemCheckpoint: true,
+		storageDir:        agentStateRoot,
 	}
 
 	openDBAndDo(newParams, func(db *DB) {

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -14,6 +14,7 @@
 package agent
 
 import (
+	"fmt"
 	"io/fs"
 	"math"
 	"os"
@@ -158,6 +159,10 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	require.Equal(t, oldAfterSeries, newAfterSeries, "agent.Checkpoint vs wlog.Checkpoint post-replay state doesn't match")
 }
 
+// To run the benchmark and display a diff, use the following command:
+//
+//	go test -bench="BenchmarkCheckpoint" . -run ^$ -benchmem -count 6 -benchtime 5s | tee benchmarks
+//	benchstat -col '/checkpoint' benchmarks
 func BenchmarkCheckpoint(b *testing.B) {
 	// Prepare in advance samples and labels that will be written into appender.
 	samples := genCheckpointTestSamples(checkpointTestSamplesParams{
@@ -178,34 +183,46 @@ func BenchmarkCheckpoint(b *testing.B) {
 		seriesLabels: samples.datapointLabels,
 	})
 
-	// Check what checkpoint implementation to use from a feature flag.
-	checkpointImpl := os.Getenv("TEST_CHECKPOINT_IMPL")
-	isNewCheckpointEnabled := checkpointImpl != "wlog"
+	configs := []struct {
+		name               string
+		useAgentCheckpoint bool
+	}{
+		{
+			name:               "wlog",
+			useAgentCheckpoint: false,
+		},
+		{
+			name:               "agent",
+			useAgentCheckpoint: true,
+		},
+	}
 
-	// Run the bench.
-	b.Run("checkpoint", func(b *testing.B) {
-		// Copy initial wlog state into a scratch directory for test.
-		// wlog.Open expects to have a "wal" subdirectory
-		wlogDir := filepath.Join(b.TempDir(), "testdata", "wal")
-		err := os.CopyFS(wlogDir, os.DirFS(testSamplesSrcDir))
-		require.NoErrorf(b, err, "failed to copy test samples from %q to %q", testSamplesSrcDir, wlogDir)
-		storageDir := filepath.Dir(wlogDir)
+	for _, cfg := range configs {
+		tname := fmt.Sprintf("checkpoint=%s", cfg.name)
+		b.Run(tname, func(b *testing.B) {
+			// Copy initial wlog state into a scratch directory for test.
+			// wlog.Open expects to have a "wal" subdirectory
+			wlogDir := filepath.Join(b.TempDir(), "testdata", "wal")
+			err := os.CopyFS(wlogDir, os.DirFS(testSamplesSrcDir))
+			require.NoErrorf(b, err, "failed to copy test samples from %q to %q", testSamplesSrcDir, wlogDir)
+			storageDir := filepath.Dir(wlogDir)
 
-		b.ReportAllocs()
-		b.ResetTimer()
+			b.ReportAllocs()
+			b.ResetTimer()
 
-		for b.Loop() {
-			benchCheckpoint(b, benchCheckpointParams{
-				storageDir:                  storageDir,
-				samples:                     samples,
-				skipCurrentCheckpointReRead: isNewCheckpointEnabled,
-			})
+			for b.Loop() {
+				benchCheckpoint(b, benchCheckpointParams{
+					storageDir:                  storageDir,
+					samples:                     samples,
+					skipCurrentCheckpointReRead: cfg.useAgentCheckpoint,
+				})
 
-			// Get the size of the checkpoint directory
-			checkpointSize := getCheckpointSize(b, wlogDir)
-			b.ReportMetric(float64(checkpointSize), "checkpoint_size")
-		}
-	})
+				// Get the size of the checkpoint directory
+				checkpointSize := getCheckpointSize(b, wlogDir)
+				b.ReportMetric(float64(checkpointSize), "checkpoint_size")
+			}
+		})
+	}
 }
 
 func getCheckpointSize(b testing.TB, walDir string) int64 {

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -41,8 +41,8 @@ const walSegmentSize = 32 << 10 // must be aligned to the page size
 func TestCheckpointReplayCompatibility(t *testing.T) {
 	// Test to ensure that WAL replay between wlog.Checkpoint and agent.Checkpoint are the same.
 	var (
-		oldAfterSeries *stripeSeries
-		newAfterSeries *stripeSeries
+		wlogAfterSeries  *stripeSeries
+		agentAfterSeries *stripeSeries
 	)
 
 	type openDBParams struct {
@@ -106,16 +106,16 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	// Write and replay for old wlog.Checkpoint
 
 	// wlog.Open expects to have a "wal" subdirectory
-	oldStateRoot := filepath.Join(t.TempDir(), "state-old")
-	oldWalDir := filepath.Join(oldStateRoot, "wal")
-	require.NoError(t, os.MkdirAll(oldWalDir, os.ModePerm))
+	wlogStateRoot := filepath.Join(t.TempDir(), "state-wlog")
+	wlogWalDir := filepath.Join(wlogStateRoot, "wal")
+	require.NoError(t, os.MkdirAll(wlogWalDir, os.ModePerm))
 
-	oldParams := openDBParams{
+	wlogParams := openDBParams{
 		isNewCheckpoint: false,
-		storageDir:      oldStateRoot,
+		storageDir:      wlogStateRoot,
 	}
 
-	openDBAndDo(oldParams, func(db *DB) {
+	openDBAndDo(wlogParams, func(db *DB) {
 		app := db.Appender(t.Context())
 		appendData(app)
 
@@ -126,20 +126,20 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	})
 
 	// Restore the database from the checkpoint.
-	oldParams.isNewCheckpoint = true
-	openDBAndDo(oldParams, func(db *DB) {
+	wlogParams.isNewCheckpoint = true
+	openDBAndDo(wlogParams, func(db *DB) {
 		defer db.Close()
-		oldAfterSeries = db.series
+		wlogAfterSeries = db.series
 	})
 
 	// Write and replay using agent.Checkpoint:
-	newStateRoot := filepath.Join(t.TempDir(), "state-new")
-	newWalDir := filepath.Join(newStateRoot, "wal")
-	require.NoError(t, os.MkdirAll(newWalDir, os.ModePerm))
+	agentStateRoot := filepath.Join(t.TempDir(), "state-agent")
+	agentWalDir := filepath.Join(agentStateRoot, "wal")
+	require.NoError(t, os.MkdirAll(agentWalDir, os.ModePerm))
 
 	newParams := openDBParams{
 		isNewCheckpoint: true,
-		storageDir:      newStateRoot,
+		storageDir:      agentStateRoot,
 	}
 
 	openDBAndDo(newParams, func(db *DB) {
@@ -153,10 +153,10 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 
 	openDBAndDo(newParams, func(db *DB) {
 		defer db.Close()
-		newAfterSeries = db.series
+		agentAfterSeries = db.series
 	})
 
-	require.Equal(t, oldAfterSeries, newAfterSeries, "agent.Checkpoint vs wlog.Checkpoint post-replay state doesn't match")
+	require.Equal(t, wlogAfterSeries, agentAfterSeries, "agent.Checkpoint vs wlog.Checkpoint post-replay state doesn't match")
 }
 
 // To run the benchmark and display a diff, use the following command:

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -302,7 +302,9 @@ type benchCheckpointParams struct {
 	samples                     checkpointTestSamples
 }
 
-func benchCheckpoint(b testing.TB, p benchCheckpointParams) {
+func benchCheckpoint(b *testing.B, p benchCheckpointParams) {
+	b.StopTimer()
+
 	l := promslog.NewNopLogger()
 	rs := remote.NewStorage(
 		promslog.NewNopLogger(), nil,
@@ -369,6 +371,7 @@ func benchCheckpoint(b testing.TB, p benchCheckpointParams) {
 	require.NoError(b, app.Commit())
 
 	// Trigger checkpoint call.
+	b.StartTimer()
 	err = db.truncate(-1)
 	require.NoError(b, err, "db.truncate")
 	require.NoError(b, db.Close())

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -14,6 +14,7 @@
 package agent
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"math"
@@ -74,7 +75,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 		labelPrefix:   t.Name(),
 		numDatapoints: 3,
 		numHistograms: 3,
-		numSeries:     3,
+		numSeries:     300,
 	})
 
 	appendData := func(app storage.Appender) {
@@ -124,6 +125,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 		require.NoError(t, err, "db.truncate")
 		require.NoError(t, db.Close())
 	})
+	assertCheckpointExists(t, wlogWalDir, 1)
 
 	// Restore the database from the checkpoint.
 	wlogParams.isNewCheckpoint = true
@@ -151,12 +153,29 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 		require.NoError(t, db.Close())
 	})
 
+	assertCheckpointExists(t, wlogWalDir, 1)
 	openDBAndDo(newParams, func(db *DB) {
 		defer db.Close()
 		agentAfterSeries = db.series
 	})
 
 	require.Equal(t, wlogAfterSeries, agentAfterSeries, "agent.Checkpoint vs wlog.Checkpoint post-replay state doesn't match")
+}
+
+func assertCheckpointExists(t *testing.T, walDir string, checkpointID int) {
+	d := wlog.CheckpointDir(walDir, checkpointID)
+	v, err := os.Stat(d)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("checkpoint doesn't exists in WAL dir %q", walDir)
+			return
+		}
+
+		t.Fatalf("can't stat checkpoint dir %q", err)
+		return
+	}
+
+	require.True(t, v.IsDir(), "checkpoint should be a dir")
 }
 
 // To run the benchmark and display a diff, use the following command:

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"math"
 	"os"
 	"path/filepath"
@@ -172,7 +173,40 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 		agentAfterSeries = db.series
 	})
 
-	require.Equal(t, wlogAfterSeries, agentAfterSeries, "agent.Checkpoint vs wlog.Checkpoint post-replay state doesn't match")
+	requireStripeSeriesEqual(t, wlogAfterSeries, agentAfterSeries)
+}
+
+// requireStripeSeriesEqual asserts that two stripeSeries are semantically
+// equivalent: same set of refs, each memSeries has matching labels (by
+// content) and lastTs. It avoids reflect.DeepEqual on labels.Labels because
+// under -tags=dedupelabels the struct carries a per-instance nameTable
+// pointer and symbol-table IDs whose layout depends on the order in which
+// records were interned during replay — an implementation detail, not a
+// behavioural property.
+func requireStripeSeriesEqual(t *testing.T, want, got *stripeSeries) {
+	t.Helper()
+
+	require.Equal(t, want.size, got.size, "stripeSeries size mismatch")
+
+	collect := func(s *stripeSeries) map[chunks.HeadSeriesRef]*memSeries {
+		out := map[chunks.HeadSeriesRef]*memSeries{}
+		for _, m := range s.series {
+			maps.Copy(out, m)
+		}
+		return out
+	}
+	wantByRef := collect(want)
+	gotByRef := collect(got)
+
+	require.Len(t, gotByRef, len(wantByRef), "series count mismatch")
+
+	for ref, w := range wantByRef {
+		g, ok := gotByRef[ref]
+		require.Truef(t, ok, "ref %d present in wlog path, missing in agent path", ref)
+		require.Truef(t, labels.Equal(w.lset, g.lset),
+			"ref %d labels mismatch: wlog=%s agent=%s", ref, w.lset.String(), g.lset.String())
+		require.Equalf(t, w.lastTs, g.lastTs, "ref %d lastTs mismatch", ref)
+	}
 }
 
 func assertCheckpointExists(t *testing.T, walDir string, checkpointID int) {

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -61,7 +61,6 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 		defer rs.Close()
 
 		opts := DefaultOptions()
-		opts.OutOfOrderTimeWindow = math.MaxInt64 // Fixes "out of order sample" in benchmarks
 		opts.CheckpointFromInMemorySeries = params.isInMemCheckpoint
 		opts.WALSegmentSize = walSegmentSize // Set minimum size to get more segments for checkpoint.
 
@@ -329,7 +328,7 @@ func benchCheckpoint(b testing.TB, p benchCheckpointParams) {
 	defer rs.Close()
 
 	opts := DefaultOptions()
-	opts.OutOfOrderTimeWindow = math.MaxInt64 // Fixes "out of order sample" in benchmarks
+	opts.OutOfOrderTimeWindow = math.MaxInt64 // Fixes "out of order sample" in benchmarks.
 	opts.CheckpointFromInMemorySeries = p.skipCurrentCheckpointReRead
 	opts.WALSegmentSize = walSegmentSize // Set minimum size to get more segments for checkpoint.
 

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -46,25 +46,20 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 		agentAfterSeries *stripeSeries
 	)
 
-	type openDBParams struct {
-		isInMemCheckpoint bool
-		storageDir        string
-	}
-
-	openDBAndDo := func(params openDBParams, fn func(db *DB)) {
+	openDBAndDo := func(isInMemCheckpoint bool, storageDir string, fn func(db *DB)) {
 		l := promslog.NewNopLogger()
 		rs := remote.NewStorage(
 			promslog.NewNopLogger(), nil,
-			startTime, params.storageDir,
+			startTime, storageDir,
 			30*time.Second, nil, false,
 		)
 		defer rs.Close()
 
 		opts := DefaultOptions()
-		opts.CheckpointFromInMemorySeries = params.isInMemCheckpoint
+		opts.CheckpointFromInMemorySeries = isInMemCheckpoint
 		opts.WALSegmentSize = walSegmentSize // Set minimum size to get more segments for checkpoint.
 
-		db, err := Open(l, nil, rs, params.storageDir, opts)
+		db, err := Open(l, nil, rs, storageDir, opts)
 		require.NoError(t, err, "Open")
 		fn(db)
 	}
@@ -126,12 +121,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	wlogWalDir := filepath.Join(wlogStateRoot, "wal")
 	require.NoError(t, os.MkdirAll(wlogWalDir, os.ModePerm))
 
-	wlogParams := openDBParams{
-		isInMemCheckpoint: false,
-		storageDir:        wlogStateRoot,
-	}
-
-	openDBAndDo(wlogParams, func(db *DB) {
+	openDBAndDo(false, wlogStateRoot, func(db *DB) {
 		appendData(db)
 
 		// Trigger checkpoint call.
@@ -142,8 +132,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	assertCheckpointExists(t, wlogWalDir, 1)
 
 	// Restore the database from the checkpoint.
-	wlogParams.isInMemCheckpoint = true
-	openDBAndDo(wlogParams, func(db *DB) {
+	openDBAndDo(true, wlogStateRoot, func(db *DB) {
 		defer db.Close()
 		wlogAfterSeries = db.series
 	})
@@ -153,12 +142,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	agentWalDir := filepath.Join(agentStateRoot, "wal")
 	require.NoError(t, os.MkdirAll(agentWalDir, os.ModePerm))
 
-	newParams := openDBParams{
-		isInMemCheckpoint: true,
-		storageDir:        agentStateRoot,
-	}
-
-	openDBAndDo(newParams, func(db *DB) {
+	openDBAndDo(true, agentStateRoot, func(db *DB) {
 		appendData(db)
 
 		err := db.truncate(-1)
@@ -167,7 +151,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	})
 
 	assertCheckpointExists(t, agentWalDir, 1)
-	openDBAndDo(newParams, func(db *DB) {
+	openDBAndDo(true, agentStateRoot, func(db *DB) {
 		defer db.Close()
 		agentAfterSeries = db.series
 	})

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -287,7 +287,6 @@ func benchCheckpoint(b testing.TB, p benchCheckpointParams) {
 	require.NoError(b, app.Commit())
 
 	// Trigger checkpoint call.
-	// err = db.truncate(timestamp.FromTime(time.Now()))
 	err = db.truncate(-1)
 	require.NoError(b, err, "db.truncate")
 	require.NoError(b, db.Close())

--- a/tsdb/agent/checkpoint_test.go
+++ b/tsdb/agent/checkpoint_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
@@ -78,7 +77,19 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 		numSeries:     300,
 	})
 
-	appendData := func(app storage.Appender) {
+	appendData := func(db *DB) {
+		app := db.Appender(t.Context())
+		const flushEvery = 1000
+		n := 0
+		maybeFlush := func() {
+			if n < flushEvery {
+				return
+			}
+			require.NoError(t, app.Commit())
+			app = db.Appender(t.Context())
+			n = 0
+		}
+
 		lbls := samples.datapointLabels
 		for i, l := range lbls {
 			lset := labels.New(l...)
@@ -89,6 +100,8 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 				// replay doesn't include exemplars, thus don't include them to remove them from assertion.
 				_, err := app.Append(0, lset, st, sf)
 				require.NoErrorf(t, err, "L: %v; S: %v", i, j)
+				n++
+				maybeFlush()
 			}
 		}
 
@@ -98,6 +111,8 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 			for j, sample := range histograms {
 				_, err := app.AppendHistogram(0, lset, int64(j), sample, nil)
 				require.NoError(t, err)
+				n++
+				maybeFlush()
 			}
 		}
 
@@ -117,8 +132,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	}
 
 	openDBAndDo(wlogParams, func(db *DB) {
-		app := db.Appender(t.Context())
-		appendData(app)
+		appendData(db)
 
 		// Trigger checkpoint call.
 		err := db.truncate(-1)
@@ -145,8 +159,7 @@ func TestCheckpointReplayCompatibility(t *testing.T) {
 	}
 
 	openDBAndDo(newParams, func(db *DB) {
-		app := db.Appender(t.Context())
-		appendData(app)
+		appendData(db)
 
 		err := db.truncate(-1)
 		require.NoError(t, err, "db.truncate")
@@ -290,6 +303,17 @@ func benchCheckpoint(b testing.TB, p benchCheckpointParams) {
 	require.NoError(b, err, "Open")
 
 	app := db.Appender(b.Context())
+	const flushEvery = 1000
+	n := 0
+	maybeFlush := func() {
+		if n < flushEvery {
+			return
+		}
+		require.NoError(b, app.Commit())
+		app = db.Appender(b.Context())
+		n = 0
+	}
+
 	lbls := p.samples.datapointLabels
 	for i, l := range lbls {
 		lset := labels.New(l...)
@@ -308,6 +332,9 @@ func benchCheckpoint(b testing.TB, p benchCheckpointParams) {
 
 			_, err = app.AppendExemplar(ref, lset, e)
 			require.NoError(b, err)
+
+			n += 2
+			maybeFlush()
 		}
 	}
 
@@ -317,6 +344,8 @@ func benchCheckpoint(b testing.TB, p benchCheckpointParams) {
 		for j, sample := range histograms {
 			_, err := app.AppendHistogram(0, lset, int64(j), sample, nil)
 			require.NoError(b, err)
+			n++
+			maybeFlush()
 		}
 	}
 

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -775,7 +775,7 @@ func (db *DB) truncate(mint int64) error {
 	db.metrics.checkpointCreationTotal.Inc()
 
 	if db.opts.CheckpointFromInMemorySeries {
-		err = Checkpoint(db.logger, db.wal, last, db.opts.CheckpointBatchSize, db.series.Iterate(), deletedSeriesIter(db.deleted, last))
+		err = Checkpoint(db.logger, db.wal, last, db.opts.CheckpointBatchSize, db.series.allSeries(), deletedSeriesIter(db.deleted, last))
 	} else {
 		_, err = wlog.Checkpoint(db.logger, db.wal, first, last, db.keepSeriesInWALCheckpointFn(last), mint, db.opts.EnableSTStorage)
 	}

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"math"
 	"path/filepath"
 	"sync"
@@ -248,6 +247,11 @@ func (m *dbMetrics) Unregister() {
 	}
 }
 
+type deletedRefMeta struct {
+	lastSegment int
+	labels      labels.Labels
+}
+
 // DB represents a WAL-only storage. It implements storage.DB.
 type DB struct {
 	mtx    sync.RWMutex
@@ -273,7 +277,7 @@ type DB struct {
 	series  *stripeSeries
 	// deleted is a map of (ref IDs that should be deleted from WAL) to (the WAL segment they
 	// must be kept around to).
-	deleted map[chunks.HeadSeriesRef]int
+	deleted map[chunks.HeadSeriesRef]deletedRefMeta
 
 	donec chan struct{}
 	stopc chan struct{}
@@ -315,7 +319,7 @@ func Open(l *slog.Logger, reg prometheus.Registerer, rs *remote.Storage, dir str
 
 		nextRef: atomic.NewUint64(0),
 		series:  newStripeSeries(opts.StripeSize),
-		deleted: make(map[chunks.HeadSeriesRef]int),
+		deleted: make(map[chunks.HeadSeriesRef]deletedRefMeta),
 
 		donec: make(chan struct{}),
 		stopc: make(chan struct{}),
@@ -576,8 +580,8 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 
 					// We want to track the largest segment where we encountered the duplicate ref, so we can ensure
 					// it remains in the checkpoint until we get past that segment.
-					if db.deleted[entry.Ref] <= currentSegmentOrCheckpoint {
-						db.deleted[entry.Ref] = currentSegmentOrCheckpoint
+					if meta := db.deleted[entry.Ref]; meta.lastSegment <= currentSegmentOrCheckpoint {
+						db.deleted[entry.Ref] = deletedRefMeta{lastSegment: currentSegmentOrCheckpoint, labels: entry.Labels}
 					}
 				} else {
 					db.metrics.numActiveSeries.Inc()
@@ -592,8 +596,9 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 				if ref, ok := duplicateRefToValidRef[entry.Ref]; ok {
 					// We want to track the largest segment where we encountered the duplicate ref, so we can ensure
 					// it remains in the checkpoint until we get past that segment.
-					if db.deleted[entry.Ref] <= currentSegmentOrCheckpoint {
-						db.deleted[entry.Ref] = currentSegmentOrCheckpoint
+					if meta, ok := db.deleted[entry.Ref]; ok && meta.lastSegment <= currentSegmentOrCheckpoint {
+						meta.lastSegment = currentSegmentOrCheckpoint
+						db.deleted[entry.Ref] = meta
 					}
 					entry.Ref = ref
 				}
@@ -615,8 +620,9 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 				if ref, ok := duplicateRefToValidRef[entry.Ref]; ok {
 					// We want to track the largest segment where we encountered the duplicate ref, so we can ensure
 					// it remains in the checkpoint until we get past that segment.
-					if db.deleted[entry.Ref] <= currentSegmentOrCheckpoint {
-						db.deleted[entry.Ref] = currentSegmentOrCheckpoint
+					if meta, ok := db.deleted[entry.Ref]; ok && meta.lastSegment <= currentSegmentOrCheckpoint {
+						meta.lastSegment = currentSegmentOrCheckpoint
+						db.deleted[entry.Ref] = meta
 					}
 					entry.Ref = ref
 				}
@@ -638,8 +644,9 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 				if ref, ok := duplicateRefToValidRef[entry.Ref]; ok {
 					// We want to track the largest segment where we encountered the duplicate ref, so we can ensure
 					// it remains in the checkpoint until we get past that segment.
-					if db.deleted[entry.Ref] <= currentSegmentOrCheckpoint {
-						db.deleted[entry.Ref] = currentSegmentOrCheckpoint
+					if meta, ok := db.deleted[entry.Ref]; ok && meta.lastSegment <= currentSegmentOrCheckpoint {
+						meta.lastSegment = currentSegmentOrCheckpoint
+						db.deleted[entry.Ref] = meta
 					}
 					entry.Ref = ref
 				}
@@ -723,8 +730,8 @@ func (db *DB) keepSeriesInWALCheckpointFn(last int) func(id chunks.HeadSeriesRef
 		}
 
 		// Keep the record if the series was recently deleted.
-		seg, ok := db.deleted[id]
-		return ok && seg > last
+		meta, ok := db.deleted[id]
+		return ok && meta.lastSegment > last
 	}
 }
 
@@ -770,7 +777,7 @@ func (db *DB) truncate(mint int64) error {
 			AtIndex:       last,
 			BatchSize:     db.opts.CheckpointBatchSize,
 			ActiveSeries:  db.series.Iterate(),
-			DeletedSeries: maps.Keys(db.deleted),
+			DeletedSeries: deletedSeriesIter(db.deleted),
 		})
 	} else {
 		_, err = wlog.Checkpoint(db.logger, db.wal, first, last, db.keepSeriesInWALCheckpointFn(last), mint, db.opts.EnableSTStorage)
@@ -793,8 +800,8 @@ func (db *DB) truncate(mint int64) error {
 
 	// The checkpoint is written and segments before it are truncated, so we
 	// no longer need to track deleted series that were being kept around.
-	for ref, segment := range db.deleted {
-		if segment <= last {
+	for ref, meta := range db.deleted {
+		if meta.lastSegment <= last {
 			delete(db.deleted, ref)
 		}
 	}
@@ -826,8 +833,8 @@ func (db *DB) gc(mint int64) {
 	// We want to keep series records for any newly deleted series
 	// until we've passed the last recorded segment. This prevents
 	// the WAL having samples for series records that no longer exist.
-	for ref := range deleted {
-		db.deleted[ref] = last
+	for ref, lset := range deleted {
+		db.deleted[ref] = deletedRefMeta{lastSegment: last, labels: lset}
 	}
 
 	db.metrics.numWALSeriesPendingDeletion.Set(float64(len(db.deleted)))

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"math"
 	"path/filepath"
 	"sync"
@@ -753,7 +754,21 @@ func (db *DB) truncate(mint int64) error {
 
 	db.metrics.checkpointCreationTotal.Inc()
 
-	if _, err = wlog.Checkpoint(db.logger, db.wal, first, last, db.keepSeriesInWALCheckpointFn(last), mint, db.opts.EnableSTStorage); err != nil {
+	// if _, err = wlog.Checkpoint(db.logger, db.wal, first, last, db.keepSeriesInWALCheckpointFn(last), mint, db.opts.EnableSTStorage); err != nil {
+	// 	db.metrics.checkpointCreationFail.Inc()
+	// 	var cerr *wlog.CorruptionErr
+	// 	if errors.As(err, &cerr) {
+	// 		db.metrics.walCorruptionsTotal.Inc()
+	// 	}
+	// 	return fmt.Errorf("create checkpoint: %w", err)
+	// }
+	err = Checkpoint(db.logger, db.wal, CheckpointParams{
+		AtIndex:       last, // TODO: is this correct to use last index here?
+		BatchSize:     defaultBatchSize,
+		ActiveSeries:  db.series.Iterate(),
+		DeletedSeries: maps.Keys(db.deleted),
+	})
+	if err != nil {
 		db.metrics.checkpointCreationFail.Inc()
 		var cerr *wlog.CorruptionErr
 		if errors.As(err, &cerr) {

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -100,6 +100,9 @@ type Options struct {
 	// persisted to the WAL for samples that include a non-zero start timestamp in
 	// supported record types.
 	EnableSTStorage bool
+
+	// SkipCurrentCheckpointReRead changes checkpoint implementation to use only in-memory data when building a new checkpoint and skip current checkpoint re-read from disk.
+	SkipCurrentCheckpointReRead bool
 }
 
 // DefaultOptions used for the WAL storage. They are reasonable for setups using
@@ -754,20 +757,24 @@ func (db *DB) truncate(mint int64) error {
 
 	db.metrics.checkpointCreationTotal.Inc()
 
-	// if _, err = wlog.Checkpoint(db.logger, db.wal, first, last, db.keepSeriesInWALCheckpointFn(last), mint, db.opts.EnableSTStorage); err != nil {
-	// 	db.metrics.checkpointCreationFail.Inc()
-	// 	var cerr *wlog.CorruptionErr
-	// 	if errors.As(err, &cerr) {
-	// 		db.metrics.walCorruptionsTotal.Inc()
-	// 	}
-	// 	return fmt.Errorf("create checkpoint: %w", err)
-	// }
-	err = Checkpoint(db.logger, db.wal, CheckpointParams{
-		AtIndex:       last, // TODO: is this correct to use last index here?
-		BatchSize:     defaultBatchSize,
-		ActiveSeries:  db.series.Iterate(),
-		DeletedSeries: maps.Keys(db.deleted),
-	})
+	if db.opts.SkipCurrentCheckpointReRead {
+		err = Checkpoint(db.logger, db.wal, CheckpointParams{
+			AtIndex:       last, // TODO: is this correct to use last index here?
+			BatchSize:     defaultBatchSize,
+			ActiveSeries:  db.series.Iterate(),
+			DeletedSeries: maps.Keys(db.deleted),
+		})
+	} else {
+		if _, err = wlog.Checkpoint(db.logger, db.wal, first, last, db.keepSeriesInWALCheckpointFn(last), mint, db.opts.EnableSTStorage); err != nil {
+			db.metrics.checkpointCreationFail.Inc()
+			var cerr *wlog.CorruptionErr
+			if errors.As(err, &cerr) {
+				db.metrics.walCorruptionsTotal.Inc()
+			}
+			return fmt.Errorf("create checkpoint: %w", err)
+		}
+	}
+
 	if err != nil {
 		db.metrics.checkpointCreationFail.Inc()
 		var cerr *wlog.CorruptionErr

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -825,7 +825,7 @@ func (db *DB) truncate(mint int64) error {
 // gc marks ref IDs that have not received a sample since mint as deleted in
 // s.deleted, along with the segment where they originally got deleted.
 func (db *DB) gc(mint int64) {
-	deleted := db.series.GC(mint)
+	deleted := db.series.GC(mint, db.opts.CheckpointFromInMemorySeries)
 	db.metrics.numActiveSeries.Sub(float64(len(deleted)))
 
 	_, last, _ := wlog.Segments(db.wal.Dir())

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -777,7 +777,7 @@ func (db *DB) truncate(mint int64) error {
 			AtIndex:       last,
 			BatchSize:     db.opts.CheckpointBatchSize,
 			ActiveSeries:  db.series.Iterate(),
-			DeletedSeries: deletedSeriesIter(db.deleted),
+			DeletedSeries: deletedSeriesIter(db.deleted, last),
 		})
 	} else {
 		_, err = wlog.Checkpoint(db.logger, db.wal, first, last, db.keepSeriesInWALCheckpointFn(last), mint, db.opts.EnableSTStorage)

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -775,14 +775,7 @@ func (db *DB) truncate(mint int64) error {
 	db.metrics.checkpointCreationTotal.Inc()
 
 	if db.opts.CheckpointFromInMemorySeries {
-		err = Checkpoint(db.logger, db.wal, CheckpointParams{
-			// Note: Checkpoint index here is technically correct but not necessarily factual for what the checkpoint represents.
-			// The checkpoint index suggests the index it applies to for the WAL while this one is everything in memory.
-			AtIndex:       last,
-			BatchSize:     db.opts.CheckpointBatchSize,
-			ActiveSeries:  db.series.Iterate(),
-			DeletedSeries: deletedSeriesIter(db.deleted, last),
-		})
+		err = Checkpoint(db.logger, db.wal, last, db.opts.CheckpointBatchSize, db.series.Iterate(), deletedSeriesIter(db.deleted, last))
 	} else {
 		_, err = wlog.Checkpoint(db.logger, db.wal, first, last, db.keepSeriesInWALCheckpointFn(last), mint, db.opts.EnableSTStorage)
 	}

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -101,8 +101,14 @@ type Options struct {
 	// supported record types.
 	EnableSTStorage bool
 
-	// SkipCurrentCheckpointReRead changes checkpoint implementation to use only in-memory data when building a new checkpoint and skip current checkpoint re-read from disk.
-	SkipCurrentCheckpointReRead bool
+	// CheckpointFromInMemorySeries changes checkpoint implementation to use only in-memory series data when building a checkpoint.
+	// This prevents re-reading the previous checkpoint and segments from disk.
+	CheckpointFromInMemorySeries bool
+
+	// CheckpointBatchSize specifies a size of a single WAL log entry chunk to be flushed.
+	//
+	// Has no effect if CheckpointFromInMemorySeries is false.
+	CheckpointBatchSize int
 }
 
 // DefaultOptions used for the WAL storage. They are reasonable for setups using
@@ -757,10 +763,12 @@ func (db *DB) truncate(mint int64) error {
 
 	db.metrics.checkpointCreationTotal.Inc()
 
-	if db.opts.SkipCurrentCheckpointReRead {
+	if db.opts.CheckpointFromInMemorySeries {
 		err = Checkpoint(db.logger, db.wal, CheckpointParams{
-			AtIndex:       last, // TODO: is this correct to use last index here?
-			BatchSize:     defaultBatchSize,
+			// Note: Checkpoint index here is technically correct but not necessarily factual for what the checkpoint represents.
+			// The checkpoint index suggests the index it applies to for the WAL while this one is everything in memory.
+			AtIndex:       last,
+			BatchSize:     db.opts.CheckpointBatchSize,
 			ActiveSeries:  db.series.Iterate(),
 			DeletedSeries: maps.Keys(db.deleted),
 		})

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -765,14 +765,7 @@ func (db *DB) truncate(mint int64) error {
 			DeletedSeries: maps.Keys(db.deleted),
 		})
 	} else {
-		if _, err = wlog.Checkpoint(db.logger, db.wal, first, last, db.keepSeriesInWALCheckpointFn(last), mint, db.opts.EnableSTStorage); err != nil {
-			db.metrics.checkpointCreationFail.Inc()
-			var cerr *wlog.CorruptionErr
-			if errors.As(err, &cerr) {
-				db.metrics.walCorruptionsTotal.Inc()
-			}
-			return fmt.Errorf("create checkpoint: %w", err)
-		}
+		_, err = wlog.Checkpoint(db.logger, db.wal, first, last, db.keepSeriesInWALCheckpointFn(last), mint, db.opts.EnableSTStorage)
 	}
 
 	if err != nil {

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -581,7 +581,11 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 					// We want to track the largest segment where we encountered the duplicate ref, so we can ensure
 					// it remains in the checkpoint until we get past that segment.
 					if meta := db.deleted[entry.Ref]; meta.lastSegment <= currentSegmentOrCheckpoint {
-						db.deleted[entry.Ref] = deletedRefMeta{lastSegment: currentSegmentOrCheckpoint, labels: entry.Labels}
+						var lbls labels.Labels
+						if db.opts.CheckpointFromInMemorySeries {
+							lbls = entry.Labels
+						}
+						db.deleted[entry.Ref] = deletedRefMeta{lastSegment: currentSegmentOrCheckpoint, labels: lbls}
 					}
 				} else {
 					db.metrics.numActiveSeries.Inc()

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -1533,7 +1533,7 @@ func BenchmarkGetOrCreate(b *testing.B) {
 		for i := range b.N {
 			if i%n == 0 && i > 0 {
 				b.StopTimer()
-				_ = s.series.GC(math.MaxInt64)
+				_ = s.series.GC(math.MaxInt64, false)
 				b.StartTimer()
 			}
 			app.getOrCreate(0, lbls[i%n])

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -384,11 +384,15 @@ func (s *stripeSeries) Iterate() iter.Seq[ActiveSeries] {
 }
 
 // deletedSeriesIter returns an iterator over deleted series from the given map.
-func deletedSeriesIter(m map[chunks.HeadSeriesRef]deletedRefMeta) iter.Seq[DeletedSeries] {
+// Only series whose lastSegment is greater than last are emitted, matching the
+// filtering behaviour of [wlog.Checkpoint] keep function.
+func deletedSeriesIter(m map[chunks.HeadSeriesRef]deletedRefMeta, last int) iter.Seq[DeletedSeries] {
 	return func(yield func(DeletedSeries) bool) {
 		for ref, meta := range m {
-			if !yield(deletedSeries{ref: ref, labels: meta.labels}) {
-				return
+			if meta.lastSegment > last {
+				if !yield(deletedSeries{ref: ref, labels: meta.labels}) {
+					return
+				}
 			}
 		}
 	}

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -325,6 +325,18 @@ func (s *stripeSeries) refLock(ref chunks.HeadSeriesRef) uint64 {
 	return uint64(ref) & uint64(s.size-1)
 }
 
+// seriesSnapshot is a point-in-time copy of a memSeries fields.
+// It is used to avoid holding series locks during checkpoint I/O.
+type seriesSnapshot struct {
+	ref    chunks.HeadSeriesRef
+	lset   labels.Labels
+	lastTs int64
+}
+
+func (s *seriesSnapshot) Ref() chunks.HeadSeriesRef { return s.ref }
+func (s *seriesSnapshot) Labels() labels.Labels      { return s.lset }
+func (s *seriesSnapshot) LastSampleTimestamp() int64  { return s.lastTs }
+
 func (s *stripeSeries) Iterate() iter.Seq[ActiveSeries] {
 	return func(yield func(ActiveSeries) bool) {
 		stop := false
@@ -332,16 +344,19 @@ func (s *stripeSeries) Iterate() iter.Seq[ActiveSeries] {
 			s.locks[i].RLock()
 
 			for _, series := range s.series[i] {
+				// Copy fields under the series lock, then release it
+				// before yielding so that disk I/O in the consumer
+				// does not block appends to this series.
 				series.Lock()
-
-				// Extra hash lock is skipped as we don't need to read the hashes map.
-				if !yield(series) {
-					stop = true
+				snapshot := seriesSnapshot{
+					ref:    series.ref,
+					lset:   series.lset,
+					lastTs: series.lastTs,
 				}
-
 				series.Unlock()
 
-				if stop {
+				if !yield(&snapshot) {
+					stop = true
 					break
 				}
 			}

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -14,12 +14,19 @@
 package agent
 
 import (
+	"iter"
 	"sync"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
+
+type ActiveSeries interface {
+	Ref() chunks.HeadSeriesRef
+	Labels() labels.Labels
+	LastSampleTimestamp() int64
+}
 
 // memSeries is a chunkless version of tsdb.memSeries.
 type memSeries struct {
@@ -43,6 +50,18 @@ func (m *memSeries) updateTimestamp(newTs int64) bool {
 		return true
 	}
 	return false
+}
+
+func (m *memSeries) Ref() chunks.HeadSeriesRef {
+	return m.ref
+}
+
+func (m *memSeries) Labels() labels.Labels {
+	return m.lset
+}
+
+func (m *memSeries) LastSampleTimestamp() int64 {
+	return m.lastTs
 }
 
 // seriesHashmap lets agent find a memSeries by its label set, via a 64-bit hash.
@@ -304,4 +323,40 @@ func (s *stripeSeries) hashLock(hash uint64) uint64 {
 
 func (s *stripeSeries) refLock(ref chunks.HeadSeriesRef) uint64 {
 	return uint64(ref) & uint64(s.size-1)
+}
+
+func (s *stripeSeries) Iterate() iter.Seq[ActiveSeries] {
+	return func(yield func(ActiveSeries) bool) {
+		stop := false
+		for i := 0; i < s.size; i++ {
+			s.locks[i].RLock()
+
+			for _, series := range s.series[i] {
+				series.Lock()
+
+				j := int(s.hashLock(series.lset.Hash()))
+				if i != j {
+					s.locks[j].RLock()
+				}
+
+				if !yield(series) {
+					stop = true
+				}
+
+				if i != j {
+					s.locks[j].RUnlock()
+				}
+				series.Unlock()
+
+				if stop {
+					break
+				}
+			}
+
+			s.locks[i].RUnlock()
+			if stop {
+				return
+			}
+		}
+	}
 }

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -347,14 +347,20 @@ func (s *seriesSnapshot) LastSampleTimestamp() int64 {
 
 func (s *stripeSeries) Iterate() iter.Seq[ActiveSeries] {
 	return func(yield func(ActiveSeries) bool) {
-		stop := false
+		var buf []*memSeries
 		for i := 0; i < s.size; i++ {
+			// Collect pointers under RLock to avoid blocking appenders during I/O.
 			s.locks[i].RLock()
-
+			buf = buf[:0]
 			for _, series := range s.series[i] {
-				// Copy fields under the series lock, then release it
-				// before yielding so that disk I/O in the consumer
-				// does not block appends to this series.
+				buf = append(buf, series)
+			}
+			s.locks[i].RUnlock()
+
+			// Snapshot and yield outside the stripe lock so that
+			// slow consumers (e.g. checkpoint disk I/O) do not
+			// block appends that need a write lock on this stripe.
+			for _, series := range buf {
 				series.Lock()
 				snapshot := seriesSnapshot{
 					ref:    series.ref,
@@ -364,14 +370,8 @@ func (s *stripeSeries) Iterate() iter.Seq[ActiveSeries] {
 				series.Unlock()
 
 				if !yield(&snapshot) {
-					stop = true
-					break
+					return
 				}
-			}
-
-			s.locks[i].RUnlock()
-			if stop {
-				return
 			}
 		}
 	}

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -184,7 +184,7 @@ func newStripeSeries(stripeSize int) *stripeSeries {
 
 // GC garbage collects old series that have not received a sample after mint
 // and will fully delete them.
-func (s *stripeSeries) GC(mint int64) map[chunks.HeadSeriesRef]labels.Labels {
+func (s *stripeSeries) GC(mint int64, retainLabels bool) map[chunks.HeadSeriesRef]labels.Labels {
 	// gcMut serializes GC calls. Within a single GC pass, the check function
 	// holds hashLock and then acquires refLock — callers must never hold both
 	// simultaneously, which SetUnlessAlreadySet satisfies.
@@ -211,7 +211,12 @@ func (s *stripeSeries) GC(mint int64) map[chunks.HeadSeriesRef]labels.Labels {
 			s.locks[refLock].Lock()
 		}
 
-		deleted[series.ref] = series.lset
+		if retainLabels {
+			deleted[series.ref] = series.lset
+		} else {
+			deleted[series.ref] = labels.EmptyLabels()
+		}
+
 		delete(s.series[refLock], series.ref)
 		s.hashes[hashLock].Delete(hash, series.ref)
 

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -356,7 +356,7 @@ func (s *seriesSnapshot) LastSampleTimestamp() int64 {
 	return s.lastTs
 }
 
-func (s *stripeSeries) Iterate() iter.Seq[ActiveSeries] {
+func (s *stripeSeries) allSeries() iter.Seq[ActiveSeries] {
 	return func(yield func(ActiveSeries) bool) {
 		var buf []*memSeries
 		for i := 0; i < s.size; i++ {

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -22,17 +22,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
 
-type ActiveSeries interface {
-	Ref() chunks.HeadSeriesRef
-	Labels() labels.Labels
-	LastSampleTimestamp() int64
-}
-
-type DeletedSeries interface {
-	Ref() chunks.HeadSeriesRef
-	Labels() labels.Labels
-}
-
 // memSeries is a chunkless version of tsdb.memSeries.
 type memSeries struct {
 	sync.Mutex
@@ -336,6 +325,8 @@ func (s *stripeSeries) refLock(ref chunks.HeadSeriesRef) uint64 {
 	return uint64(ref) & uint64(s.size-1)
 }
 
+var _ ActiveSeries = (*seriesSnapshot)(nil)
+
 // seriesSnapshot is a point-in-time copy of a memSeries fields.
 // It is used to avoid holding series locks during checkpoint I/O.
 type seriesSnapshot struct {
@@ -402,6 +393,8 @@ func deletedSeriesIter(m map[chunks.HeadSeriesRef]deletedRefMeta, last int) iter
 		}
 	}
 }
+
+var _ DeletedSeries = deletedSeries{}
 
 type deletedSeries struct {
 	ref    chunks.HeadSeriesRef

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -333,9 +333,17 @@ type seriesSnapshot struct {
 	lastTs int64
 }
 
-func (s *seriesSnapshot) Ref() chunks.HeadSeriesRef { return s.ref }
-func (s *seriesSnapshot) Labels() labels.Labels      { return s.lset }
-func (s *seriesSnapshot) LastSampleTimestamp() int64  { return s.lastTs }
+func (s *seriesSnapshot) Ref() chunks.HeadSeriesRef {
+	return s.ref
+}
+
+func (s *seriesSnapshot) Labels() labels.Labels {
+	return s.lset
+}
+
+func (s *seriesSnapshot) LastSampleTimestamp() int64 {
+	return s.lastTs
+}
 
 func (s *stripeSeries) Iterate() iter.Seq[ActiveSeries] {
 	return func(yield func(ActiveSeries) bool) {

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -334,18 +334,11 @@ func (s *stripeSeries) Iterate() iter.Seq[ActiveSeries] {
 			for _, series := range s.series[i] {
 				series.Lock()
 
-				j := int(s.hashLock(series.lset.Hash()))
-				if i != j {
-					s.locks[j].RLock()
-				}
-
+				// Extra hash lock is skipped as we don't need to read the hashes map.
 				if !yield(series) {
 					stop = true
 				}
 
-				if i != j {
-					s.locks[j].RUnlock()
-				}
 				series.Unlock()
 
 				if stop {

--- a/tsdb/agent/series.go
+++ b/tsdb/agent/series.go
@@ -28,6 +28,11 @@ type ActiveSeries interface {
 	LastSampleTimestamp() int64
 }
 
+type DeletedSeries interface {
+	Ref() chunks.HeadSeriesRef
+	Labels() labels.Labels
+}
+
 // memSeries is a chunkless version of tsdb.memSeries.
 type memSeries struct {
 	sync.Mutex
@@ -179,14 +184,15 @@ func newStripeSeries(stripeSize int) *stripeSeries {
 
 // GC garbage collects old series that have not received a sample after mint
 // and will fully delete them.
-func (s *stripeSeries) GC(mint int64) map[chunks.HeadSeriesRef]struct{} {
+func (s *stripeSeries) GC(mint int64) map[chunks.HeadSeriesRef]labels.Labels {
 	// gcMut serializes GC calls. Within a single GC pass, the check function
 	// holds hashLock and then acquires refLock — callers must never hold both
 	// simultaneously, which SetUnlessAlreadySet satisfies.
 	s.gcMut.Lock()
 	defer s.gcMut.Unlock()
 
-	deleted := map[chunks.HeadSeriesRef]struct{}{}
+	// labels of deleted series are used by agent.Checkpoint
+	deleted := map[chunks.HeadSeriesRef]labels.Labels{}
 
 	// For one series, truncate old chunks and check if any chunks left. If not, mark as deleted and collect the ID.
 	check := func(hashLock int, hash uint64, series *memSeries) {
@@ -205,7 +211,7 @@ func (s *stripeSeries) GC(mint int64) map[chunks.HeadSeriesRef]struct{} {
 			s.locks[refLock].Lock()
 		}
 
-		deleted[series.ref] = struct{}{}
+		deleted[series.ref] = series.lset
 		delete(s.series[refLock], series.ref)
 		s.hashes[hashLock].Delete(hash, series.ref)
 
@@ -375,4 +381,28 @@ func (s *stripeSeries) Iterate() iter.Seq[ActiveSeries] {
 			}
 		}
 	}
+}
+
+// deletedSeriesIter returns an iterator over deleted series from the given map.
+func deletedSeriesIter(m map[chunks.HeadSeriesRef]deletedRefMeta) iter.Seq[DeletedSeries] {
+	return func(yield func(DeletedSeries) bool) {
+		for ref, meta := range m {
+			if !yield(deletedSeries{ref: ref, labels: meta.labels}) {
+				return
+			}
+		}
+	}
+}
+
+type deletedSeries struct {
+	ref    chunks.HeadSeriesRef
+	labels labels.Labels
+}
+
+func (series deletedSeries) Ref() chunks.HeadSeriesRef {
+	return series.ref
+}
+
+func (series deletedSeries) Labels() labels.Labels {
+	return series.labels
 }

--- a/tsdb/agent/series_test.go
+++ b/tsdb/agent/series_test.go
@@ -40,7 +40,7 @@ func TestNoDeadlock(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-started
-			_ = stripeSeries.GC(math.MaxInt64)
+			_ = stripeSeries.GC(math.MaxInt64, false)
 		}()
 	}
 
@@ -224,7 +224,7 @@ func TestSetUnlessAlreadySetConcurrentGC(t *testing.T) {
 			case <-done:
 				return
 			default:
-				ss.GC(1) // removes series with lastTs < 1, i.e. lastTs==0
+				ss.GC(1, false) // removes series with lastTs < 1, i.e. lastTs==0
 			}
 		}
 	}()
@@ -248,7 +248,7 @@ func TestSetUnlessAlreadySetConcurrentGC(t *testing.T) {
 
 	// A final synchronous GC pass ensures all eligible series are fully removed,
 	// then verify they are unreachable via both lookup paths.
-	ss.GC(1)
+	ss.GC(1, false)
 	for _, s := range eligible {
 		require.Nil(t, ss.GetByID(s.ref))
 		require.Nil(t, ss.GetByHash(s.lset.Hash(), s.lset))
@@ -259,7 +259,7 @@ func TestStripeSeries_gc(t *testing.T) {
 	s, ms1, ms2 := stripeSeriesWithCollidingSeries(t)
 	hash := ms1.lset.Hash()
 
-	s.GC(1)
+	s.GC(1, false)
 
 	// Verify that we can get neither ms1 nor ms2 after gc-ing corresponding series
 	got := s.GetByHash(hash, ms1.lset)

--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -82,8 +82,8 @@ func DeleteCheckpoints(dir string, maxIndex int) error {
 	return errors.Join(errs...)
 }
 
-// checkpointTempFileSuffix is the suffix used when creating temporary checkpoint files.
-const checkpointTempFileSuffix = ".tmp"
+// CheckpointTempFileSuffix is the suffix used when creating temporary checkpoint files.
+const CheckpointTempFileSuffix = ".tmp"
 
 // DeleteTempCheckpoints deletes all temporary checkpoint directories in the given directory.
 func DeleteTempCheckpoints(logger *slog.Logger, dir string) error {
@@ -138,7 +138,7 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 	}
 
 	cpdir := CheckpointDir(w.Dir(), to)
-	cpdirtmp := cpdir + checkpointTempFileSuffix
+	cpdirtmp := cpdir + CheckpointTempFileSuffix
 
 	if err := os.MkdirAll(cpdirtmp, 0o777); err != nil {
 		return nil, fmt.Errorf("create checkpoint dir: %w", err)
@@ -446,5 +446,5 @@ func listCheckpoints(dir string) (refs []checkpointRef, err error) {
 }
 
 func isTempDir(fi fs.DirEntry) bool {
-	return strings.HasPrefix(fi.Name(), checkpointPrefix) && strings.HasSuffix(fi.Name(), checkpointTempFileSuffix)
+	return strings.HasPrefix(fi.Name(), checkpointPrefix) && strings.HasSuffix(fi.Name(), CheckpointTempFileSuffix)
 }

--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -137,7 +137,7 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 		return nil, err
 	}
 
-	cpdir := checkpointDir(w.Dir(), to)
+	cpdir := CheckpointDir(w.Dir(), to)
 	cpdirtmp := cpdir + checkpointTempFileSuffix
 
 	if err := os.MkdirAll(cpdirtmp, 0o777); err != nil {
@@ -407,7 +407,7 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 // checkpointPrefix is the prefix used for checkpoint files.
 const checkpointPrefix = "checkpoint."
 
-func checkpointDir(dir string, i int) string {
+func CheckpointDir(dir string, i int) string {
 	return filepath.Join(dir, fmt.Sprintf(checkpointPrefix+"%08d", i))
 }
 


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This PR addresses the [checkpoint based on series in memory](https://github.com/prometheus/prometheus/issues/17617) proposal.

PR adds `CheckpointFromInMemorySeries` option for `agent.Options` to enable a faster checkpoint implementation that skips segment re-read and just uses in-memory data instead.

The new options can be set with `--storage.agent.checkpoint-from-in-memory-series` and `--storage.agent.checkpoint-batch-size` command line flags.

PR is done in cooperation with @kgeckhart.

##### Public API

In addition to `agent.Checkpoint` function, this PR introduces 2 interfaces consumed by the function:

* `ActiveSeries`
* `DeletedSeries`

The reason to use interfaces instead of concrete types is to allow downstream projects like Grafana Alloy to use `agent.Checkpoint` with their own TSDB implementations.

##### Performance

Here is performance comparison of old `wlog.Checkpoint` and the new `agent.Checkpoint`:

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb/agent
cpu: AMD Ryzen 5 7600X 6-Core Processor             
              │     wlog      │                agent                │
              │    sec/op     │    sec/op     vs base               │
Checkpoint-12   429.38m ± 15%   51.83m ± 10%  -87.93% (p=0.002 n=6)

              │      wlog       │                 agent                  │
              │ checkpoint_size │ checkpoint_size  vs base               │
Checkpoint-12   121831.4k ± 14%       622.6k ± 0%  -99.49% (p=0.002 n=6)

              │      wlog      │                agent                │
              │      B/op      │     B/op      vs base               │
Checkpoint-12   543.61Mi ± 14%   67.49Mi ± 1%  -87.59% (p=0.002 n=6)

              │     wlog      │               agent                │
              │   allocs/op   │  allocs/op   vs base               │
Checkpoint-12   8404.4k ± 17%   423.4k ± 0%  -94.96% (p=0.002 n=6)

```

*`BenchmarkCheckpoint` results. Diff is done using the [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) tool.*

To replicate a worst case scenario and focus on I/O bound load, I had to adjust a segment size to lowest acceptable value (32KiB) and increase a number of series.

#### Which issue(s) does the PR fix:

Fixes #17617 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] TSDB & Agent: Add `CheckpointFromInMemorySeries` option to `agent.DB` that enables checkpoint based on in-memory series.
```
