### PR TITLE
otlptranslator: fix silently swallowed error in addSumNumberDataPoints

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/number_data_points.go
@@ -86,7 +86,7 @@ func (c *PrometheusConverter) addSumNumberDataPoints(ctx context.Context, dataPo
 			meta.MetricFamilyName,
 		)
 		if err != nil {
-			return nil
+			return err
 		}
 		var val float64
 		switch pt.ValueType() {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #17953

#### Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] OTLP: Fix potential silent data loss for sum metrics
```

#### Description

The `createAttributes` error in `addSumNumberDataPoints` was incorrectly returning `nil` instead of `err`, causing errors to be silently discarded. This was introduced in #16951 during a refactor.

This fix aligns the error handling with `addGaugeNumberDataPoints` in the same file, which correctly returns the error.