### PR TITLE
scrape: switch scrape manager to AppenderV2

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -885,29 +885,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	var scrapeManager *scrape.Manager
-	{
-		// TODO(bwplotka): Switch to AppendableV2 by default.
-		// See: https://github.com/prometheus/prometheus/issues/17632
-		var (
-			scrapeAppendable   storage.Appendable = fanoutStorage
-			scrapeAppendableV2 storage.AppendableV2
-		)
-		if cfg.tsdb.EnableSTStorage {
-			scrapeAppendable = nil
-			scrapeAppendableV2 = fanoutStorage
-		}
-		scrapeManager, err = scrape.NewManager(
-			&cfg.scrape,
-			logger.With("component", "scrape manager"),
-			logging.NewJSONFileLogger,
-			scrapeAppendable, scrapeAppendableV2,
-			prometheus.DefaultRegisterer,
-		)
-		if err != nil {
-			logger.Error("failed to create a scrape manager", "err", err)
-			os.Exit(1)
-		}
+	scrapeManager, err := scrape.NewManager(
+		&cfg.scrape,
+		logger.With("component", "scrape manager"),
+		logging.NewJSONFileLogger,
+		nil, fanoutStorage,
+		prometheus.DefaultRegisterer,
+	)
+	if err != nil {
+		logger.Error("failed to create a scrape manager", "err", err)
+		os.Exit(1)
 	}
 
 	var (


### PR DESCRIPTION
Related to https://github.com/prometheus/prometheus/issues/17632

See also https://github.com/prometheus/prometheus/pull/17960

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
