### PR TITLE
test: fix flaky TestHeadCompactionWhileScraping

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -854,7 +854,7 @@ func TestHeadCompactionWhileScraping(t *testing.T) {
 	t.Parallel()
 
 	// To increase the chance of reproducing the data race
-	for i := range 5 {
+	for i := range 3 {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
@@ -865,11 +865,11 @@ func TestHeadCompactionWhileScraping(t *testing.T) {
 			config := fmt.Sprintf(`
 scrape_configs:
   - job_name: 'self1'
-    scrape_interval: 61ms
+    scrape_interval: 100ms
     static_configs:
       - targets: ['localhost:%d']
   - job_name: 'self2'
-    scrape_interval: 67ms
+    scrape_interval: 150ms
     static_configs:
       - targets: ['localhost:%d']
 `, port, port)
@@ -880,7 +880,7 @@ scrape_configs:
 				configFile,
 				port,
 				fmt.Sprintf("--storage.tsdb.path=%s", tmpDir),
-				"--storage.tsdb.min-block-duration=100ms",
+				"--storage.tsdb.min-block-duration=500ms",
 			)
 			require.NoError(t, prom.Start())
 
@@ -898,12 +898,12 @@ scrape_configs:
 					return false
 				}
 
-				// Wait for some compactions to run
+				// Wait for at least one compaction to run while scraping is happening.
 				compactions, err := getMetricValue(t, bytes.NewReader(metrics), model.MetricTypeCounter, "prometheus_tsdb_compactions_total")
 				if err != nil {
 					return false
 				}
-				if compactions < 3 {
+				if compactions < 1 {
 					return false
 				}
 
@@ -917,7 +917,7 @@ scrape_configs:
 				require.NoError(t, err)
 				require.Zero(t, failures)
 				return true
-			}, 15*time.Second, 500*time.Millisecond)
+			}, 60*time.Second, 500*time.Millisecond)
 		})
 	}
 }

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -854,7 +854,7 @@ func TestHeadCompactionWhileScraping(t *testing.T) {
 	t.Parallel()
 
 	// To increase the chance of reproducing the data race
-	for i := range 3 {
+	for i := range 5 {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
@@ -865,11 +865,11 @@ func TestHeadCompactionWhileScraping(t *testing.T) {
 			config := fmt.Sprintf(`
 scrape_configs:
   - job_name: 'self1'
-    scrape_interval: 101ms
+    scrape_interval: 1s
     static_configs:
       - targets: ['localhost:%d']
   - job_name: 'self2'
-    scrape_interval: 103ms
+    scrape_interval: 1s
     static_configs:
       - targets: ['localhost:%d']
 `, port, port)
@@ -880,7 +880,7 @@ scrape_configs:
 				configFile,
 				port,
 				fmt.Sprintf("--storage.tsdb.path=%s", tmpDir),
-				"--storage.tsdb.min-block-duration=500ms",
+				"--storage.tsdb.min-block-duration=1s",
 			)
 			require.NoError(t, prom.Start())
 
@@ -898,12 +898,12 @@ scrape_configs:
 					return false
 				}
 
-				// Wait for at least one compaction to run while scraping is happening.
+				// Wait for some compactions to run.
 				compactions, err := getMetricValue(t, bytes.NewReader(metrics), model.MetricTypeCounter, "prometheus_tsdb_compactions_total")
 				if err != nil {
 					return false
 				}
-				if compactions < 1 {
+				if compactions < 3 {
 					return false
 				}
 

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -865,11 +865,11 @@ func TestHeadCompactionWhileScraping(t *testing.T) {
 			config := fmt.Sprintf(`
 scrape_configs:
   - job_name: 'self1'
-    scrape_interval: 100ms
+    scrape_interval: 101ms
     static_configs:
       - targets: ['localhost:%d']
   - job_name: 'self2'
-    scrape_interval: 150ms
+    scrape_interval: 103ms
     static_configs:
       - targets: ['localhost:%d']
 `, port, port)
@@ -917,7 +917,7 @@ scrape_configs:
 				require.NoError(t, err)
 				require.Zero(t, failures)
 				return true
-			}, 60*time.Second, 500*time.Millisecond)
+			}, 30*time.Second, 500*time.Millisecond)
 		})
 	}
 }

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -67,7 +67,6 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/prometheus/prometheus/util/compression"
 	"github.com/prometheus/prometheus/util/testutil"
-	"github.com/prometheus/prometheus/util/testutil/synctest"
 )
 
 func TestMain(m *testing.M) {
@@ -9688,78 +9687,4 @@ func TestBeyondSizeRetentionWithPercentage(t *testing.T) {
 	deletable = BeyondSizeRetention(db, blocks)
 	require.Len(t, deletable, 1)
 	require.Contains(t, deletable, ulid)
-}
-
-// TestHeadCompactionWithConcurrentAppends verifies that head compaction
-// correctly waits for overlapping appenders before proceeding. This is
-// a deterministic unit test for the concurrent scraping+compaction scenario
-// described in https://github.com/prometheus/prometheus/issues/16490.
-func TestHeadCompactionWithConcurrentAppends(t *testing.T) {
-	// WaitForAppendersOverlapping relies on isolation to track open appenders.
-	// With isolation disabled, appenders are never registered, so compaction
-	// never blocks and the test's core assertion cannot hold.
-	if defaultIsolationDisabled {
-		t.Skip("skipping test since tsdb isolation is disabled")
-	}
-	t.Parallel()
-	synctest.Test(t, func(t *testing.T) {
-		db := newTestDB(t, withRngs(1000))
-		db.DisableCompactions()
-
-		// Open first appender and initialize the head with data at t=0.
-		appA := db.Appender(t.Context())
-		refA, err := appA.Append(0, labels.FromStrings("series", "A"), 0, 1.0)
-		require.NoError(t, err)
-
-		// Open second appender while head.MaxTime is still 0.
-		// This appender gets registered in isolation with minTime=0
-		// (from appendableMinValidTime), which overlaps the compaction
-		// range [0, 999] and will block compaction until committed.
-		appB := db.Appender(t.Context())
-		_, err = appB.Append(0, labels.FromStrings("series", "B"), 0, 2.0)
-		require.NoError(t, err)
-
-		// Extend data through first appender to make head compactable.
-		// With chunkRange=1000, head needs span > 1500 (1.5x chunkRange).
-		_, err = appA.Append(refA, labels.FromStrings("series", "A"), 2000, 3.0)
-		require.NoError(t, err)
-		require.NoError(t, appA.Commit())
-
-		require.True(t, db.head.compactable())
-
-		// Start compaction in a goroutine. It blocks on
-		// WaitForAppendersOverlapping because appB has minTime=0,
-		// overlapping the compaction range [0, 999].
-		compactResult := make(chan error, 1)
-		go func() {
-			compactResult <- db.Compact(t.Context())
-		}()
-
-		// Wait for the goroutine to reach the blocking
-		// WaitForAppendersOverlapping call.
-		synctest.Wait()
-		select {
-		case <-compactResult:
-			t.Fatal("compaction should block while overlapping appender is open")
-		default:
-		}
-
-		// Commit the overlapping appender to unblock compaction.
-		require.NoError(t, appB.Commit())
-
-		// Advance virtual time past the 500ms poll interval in
-		// WaitForAppendersOverlapping and let the goroutine proceed.
-		time.Sleep(time.Second)
-		synctest.Wait()
-
-		select {
-		case err := <-compactResult:
-			require.NoError(t, err)
-		default:
-			t.Fatal("compaction should complete after overlapping appender commits")
-		}
-
-		// Verify a block was created covering the compacted range.
-		require.NotEmpty(t, db.Blocks())
-	})
 }

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -67,6 +67,7 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/prometheus/prometheus/util/compression"
 	"github.com/prometheus/prometheus/util/testutil"
+	"github.com/prometheus/prometheus/util/testutil/synctest"
 )
 
 func TestMain(m *testing.M) {
@@ -9687,4 +9688,78 @@ func TestBeyondSizeRetentionWithPercentage(t *testing.T) {
 	deletable = BeyondSizeRetention(db, blocks)
 	require.Len(t, deletable, 1)
 	require.Contains(t, deletable, ulid)
+}
+
+// TestHeadCompactionWithConcurrentAppends verifies that head compaction
+// correctly waits for overlapping appenders before proceeding. This is
+// a deterministic unit test for the concurrent scraping+compaction scenario
+// described in https://github.com/prometheus/prometheus/issues/16490.
+func TestHeadCompactionWithConcurrentAppends(t *testing.T) {
+	// WaitForAppendersOverlapping relies on isolation to track open appenders.
+	// With isolation disabled, appenders are never registered, so compaction
+	// never blocks and the test's core assertion cannot hold.
+	if defaultIsolationDisabled {
+		t.Skip("skipping test since tsdb isolation is disabled")
+	}
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		db := newTestDB(t, withRngs(1000))
+		db.DisableCompactions()
+
+		// Open first appender and initialize the head with data at t=0.
+		appA := db.Appender(t.Context())
+		refA, err := appA.Append(0, labels.FromStrings("series", "A"), 0, 1.0)
+		require.NoError(t, err)
+
+		// Open second appender while head.MaxTime is still 0.
+		// This appender gets registered in isolation with minTime=0
+		// (from appendableMinValidTime), which overlaps the compaction
+		// range [0, 999] and will block compaction until committed.
+		appB := db.Appender(t.Context())
+		_, err = appB.Append(0, labels.FromStrings("series", "B"), 0, 2.0)
+		require.NoError(t, err)
+
+		// Extend data through first appender to make head compactable.
+		// With chunkRange=1000, head needs span > 1500 (1.5x chunkRange).
+		_, err = appA.Append(refA, labels.FromStrings("series", "A"), 2000, 3.0)
+		require.NoError(t, err)
+		require.NoError(t, appA.Commit())
+
+		require.True(t, db.head.compactable())
+
+		// Start compaction in a goroutine. It blocks on
+		// WaitForAppendersOverlapping because appB has minTime=0,
+		// overlapping the compaction range [0, 999].
+		compactResult := make(chan error, 1)
+		go func() {
+			compactResult <- db.Compact(t.Context())
+		}()
+
+		// Wait for the goroutine to reach the blocking
+		// WaitForAppendersOverlapping call.
+		synctest.Wait()
+		select {
+		case <-compactResult:
+			t.Fatal("compaction should block while overlapping appender is open")
+		default:
+		}
+
+		// Commit the overlapping appender to unblock compaction.
+		require.NoError(t, appB.Commit())
+
+		// Advance virtual time past the 500ms poll interval in
+		// WaitForAppendersOverlapping and let the goroutine proceed.
+		time.Sleep(time.Second)
+		synctest.Wait()
+
+		select {
+		case err := <-compactResult:
+			require.NoError(t, err)
+		default:
+			t.Fatal("compaction should complete after overlapping appender commits")
+		}
+
+		// Verify a block was created covering the compacted range.
+		require.NotEmpty(t, db.Blocks())
+	})
 }


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #17956

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```

#### Summary

`TestHeadCompactionWhileScraping` was flaky under `-race` in CI. @machine424 found that scrapes were timing out at the existing tight intervals: `scrape_timeout` defaults to `min(globalConfig.ScrapeTimeout=10s, scrape_interval)`, so at 61/67ms scrape intervals the effective timeout was ~67ms — too short for a Prometheus instance to HTTP-scrape its own `/metrics` under the race detector with parallel processes. Without completed scrapes, no head data accumulated, no compactions fired, and the 15s `Eventually` ran out waiting for 3 compactions.

The fix consists of the following:

- Raise both `scrape_interval`s to `1s` (so `scrape_timeout` becomes `1s`, plenty for self-scrapes).
- Raise `--storage.tsdb.min-block-duration` to 1s. Locally under `-race`, three compactions per sub-test accumulate in ~11s, well within the 30s deadline.
- Extend the `Eventually` deadline from 15s to 30s for CI slack.

Verified that this config still reveals #16490 on `release-3.4` (pre-fix code, by @machine424) and locally with `--tags=slicelabels -race` (corresponding to CI); reverting PR #16623's parser fix and running the test reproduces #16490's corruption symptoms.
