### PR TITLE
tsdb: kill unused mint,maxt tracking

### DIFF
--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -89,8 +88,6 @@ func (h *Head) appenderV2() *headAppenderV2 {
 		headAppenderBase: headAppenderBase{
 			head:                  h,
 			minValidTime:          minValidTime,
-			mint:                  math.MaxInt64,
-			maxt:                  math.MinInt64,
 			headMaxt:              h.MaxTime(),
 			oooTimeWindow:         h.opts.OutOfOrderTimeWindow.Load(),
 			seriesRefs:            h.getRefSeriesBuffer(),
@@ -191,13 +188,6 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 			a.head.metrics.tooOldSamples.WithLabelValues(sampleMetricType).Inc()
 		}
 		return 0, appErr
-	}
-
-	if t < a.mint {
-		a.mint = t
-	}
-	if t > a.maxt {
-		a.maxt = t
 	}
 
 	if isStale {
@@ -389,10 +379,6 @@ func (a *headAppenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.La
 		}
 		a.head.logger.Debug("Error when appending ST", "series", s.lset.String(), "st", st, "t", t, "err", err)
 		return
-	}
-
-	if st > a.maxt {
-		a.maxt = st
 	}
 }
 


### PR DESCRIPTION
Those vars are no longer used since the introduction to OOO support https://github.com/prometheus/prometheus/pull/11075

* Those were used in very past to update [head min and max time](https://github.com/prometheus/prometheus/blob/c8062622063179bff4eed36df0bf81be3890902b/tsdb/head.go#L1236).
* However, currently this is done and tracked [in the Commit](https://github.com/prometheus/prometheus/blob/36ea75d20336ef5b54a85e957c223c47e6f5783f/tsdb/head_append.go#L1796)


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
