### PR TITLE
web/api: Remove non-functional DELETE /api/v1/series endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main / Unreleased
+
+* [CHANGE] API: Remove deprecated DELETE /api/v1/series endpoint. #17955
+
 ## 3.9.1 / 2026-01-07
 
  - [BUGFIX] Agent: fix crash shortly after startup from invalid type of object. #17802

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -437,7 +437,6 @@ func (api *API) Register(r *route.Router) {
 
 	r.Get("/series", wrapAgent(api.series))
 	r.Post("/series", wrapAgent(api.series))
-	r.Del("/series", wrapAgent(api.dropSeries))
 
 	r.Get("/scrape_pools", wrap(api.scrapePools))
 	r.Get("/targets", wrap(api.targets))
@@ -1039,10 +1038,6 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 	}
 
 	return apiFuncResult{metrics, nil, warnings, closer}
-}
-
-func (*API) dropSeries(*http.Request) apiFuncResult {
-	return apiFuncResult{nil, &apiError{errorInternal, errors.New("not implemented")}, nil, nil}
 }
 
 // Target has the information for one target.

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1754,10 +1754,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 			endpoint: api.series,
 			errType:  errorBadData,
 		},
-		{
-			endpoint: api.dropSeries,
-			errType:  errorInternal,
-		},
+
 		{
 			endpoint: api.targets,
 			response: &TargetDiscovery{

--- a/web/api/v1/openapi_paths.go
+++ b/web/api/v1/openapi_paths.go
@@ -224,13 +224,6 @@ func (*OpenAPIBuilder) seriesPath() *v3.PathItem {
 			RequestBody: formRequestBodyWithExamples("SeriesPostInputBody", seriesPostExamples(), "Submit a series query. This endpoint accepts the same parameters as the GET version."),
 			Responses:   responsesWithErrorExamples("SeriesOutputBody", seriesResponseExamples(), errorResponseExamples(), "Series returned matching the provided label matchers via POST.", "Error retrieving series via POST."),
 		},
-		Delete: &v3.Operation{
-			OperationId: "delete-series",
-			Summary:     "Delete series",
-			Description: "Delete series matching selectors. Note: This is deprecated, use POST /admin/tsdb/delete_series instead.",
-			Tags:        []string{"series"},
-			Responses:   responsesWithErrorExamples("SeriesDeleteOutputBody", seriesDeleteResponseExamples(), errorResponseExamples(), "Series marked for deletion.", "Error deleting series."),
-		},
 	}
 }
 

--- a/web/api/v1/testdata/openapi_3.1_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.1_golden.yaml
@@ -1182,37 +1182,6 @@ paths:
                                         error: TSDB not ready
                                         errorType: internal
                                         status: error
-        delete:
-            tags:
-                - series
-            summary: Delete series
-            description: 'Delete series matching selectors. Note: This is deprecated, use POST /admin/tsdb/delete_series instead.'
-            operationId: delete-series
-            responses:
-                "200":
-                    description: Series marked for deletion.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/SeriesDeleteOutputBody'
-                            examples:
-                                seriesDeleted:
-                                    summary: Series marked for deletion
-                                    value:
-                                        status: success
-                default:
-                    description: Error deleting series.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Error'
-                            examples:
-                                tsdbNotReady:
-                                    summary: TSDB not ready
-                                    value:
-                                        error: TSDB not ready
-                                        errorType: internal
-                                        status: error
     /metadata:
         get:
             tags:

--- a/web/api/v1/testdata/openapi_3.2_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.2_golden.yaml
@@ -1182,37 +1182,6 @@ paths:
                                         error: TSDB not ready
                                         errorType: internal
                                         status: error
-        delete:
-            tags:
-                - series
-            summary: Delete series
-            description: 'Delete series matching selectors. Note: This is deprecated, use POST /admin/tsdb/delete_series instead.'
-            operationId: delete-series
-            responses:
-                "200":
-                    description: Series marked for deletion.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/SeriesDeleteOutputBody'
-                            examples:
-                                seriesDeleted:
-                                    summary: Series marked for deletion
-                                    value:
-                                        status: success
-                default:
-                    description: Error deleting series.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Error'
-                            examples:
-                                tsdbNotReady:
-                                    summary: TSDB not ready
-                                    value:
-                                        error: TSDB not ready
-                                        errorType: internal
-                                        status: error
     /metadata:
         get:
             tags:


### PR DESCRIPTION
## Which issue(s) does the PR fix:

Fixes #17955

## What this PR does / why we need it:

- This PR removes the DELETE /api/v1/series endpoint which has been non-functional since Prometheus v2.0.0 (November 2017). The endpoint was deprecated in PR #2910 and has only been returning an HTTP 500 error with "not implemented" ever since.
- The endpoint registration and stub implementation serve no purpose other than to confuse users who attempt to use it. The replacement Admin API endpoint POST /api/v1/admin/tsdb/delete_series has been available since 2017.
- 

## Changes:

- Removed route registration for DELETE /api/v1/series in web/api/v1/api.go
- Removed the dropSeries stub function that only returned an error
- Cleaned up 7+ years of dead code

## Does this PR introduce a user-facing change?
release[CHANGE] API: Removed the non-functional DELETE /api/v1/series endpoint that has bee