### PR TITLE
PromQL: Refactor parser to use instance configuration instead of global flags

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -632,6 +632,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Set the process-wide parser configuration. All components (engine, rules, web) use this.
+	parser.SetDefaultOptions(cfg.parserOpts)
+
 	if agentMode && len(serverOnlyFlags) > 0 {
 		fmt.Fprintf(os.Stderr, "The following flag(s) can not be used in agent mode: %q", serverOnlyFlags)
 		os.Exit(3)
@@ -922,7 +925,6 @@ func main() {
 			EnablePerStepStats:       cfg.enablePerStepStats,
 			EnableDelayedNameRemoval: cfg.promqlEnableDelayedNameRemoval,
 			EnableTypeAndUnitLabels:  cfg.scrape.EnableTypeAndUnitLabels,
-			ParserOptions:            cfg.parserOpts,
 			FeatureRegistry:          features.DefaultRegistry,
 		}
 
@@ -943,7 +945,6 @@ func main() {
 			ResendDelay:            time.Duration(cfg.resendDelay),
 			MaxConcurrentEvals:     cfg.maxConcurrentEvals,
 			ConcurrentEvalsEnabled: cfg.enableConcurrentRuleEval,
-			ParserOptions:          cfg.parserOpts,
 			DefaultRuleQueryOffset: func() time.Duration {
 				return time.Duration(cfgFile.GlobalConfig.RuleQueryOffset)
 			},
@@ -961,7 +962,6 @@ func main() {
 	cfg.web.Storage = fanoutStorage
 	cfg.web.ExemplarStorage = localStorage
 	cfg.web.QueryEngine = queryEngine
-	cfg.web.ParserOptions = cfg.parserOpts
 	cfg.web.ScrapeManager = scrapeManager
 	cfg.web.RuleManager = ruleManager
 	cfg.web.Notifier = notifierManager

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -218,6 +218,8 @@ type flagConfig struct {
 
 	promqlEnableDelayedNameRemoval bool
 
+	parserOpts parser.Options
+
 	promslogConfig promslog.Config
 }
 
@@ -255,10 +257,10 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 				c.enableConcurrentRuleEval = true
 				logger.Info("Experimental concurrent rule evaluation enabled.")
 			case "promql-experimental-functions":
-				parser.EnableExperimentalFunctions = true
+				c.parserOpts.EnableExperimentalFunctions = true
 				logger.Info("Experimental PromQL functions enabled.")
 			case "promql-duration-expr":
-				parser.ExperimentalDurationExpr = true
+				c.parserOpts.ExperimentalDurationExpr = true
 				logger.Info("Experimental duration expression parsing enabled.")
 			case "native-histograms":
 				logger.Warn("This option for --enable-feature is a no-op. To scrape native histograms, set the scrape_native_histograms scrape config setting to true.", "option", o)
@@ -292,10 +294,10 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 				c.promqlEnableDelayedNameRemoval = true
 				logger.Info("Experimental PromQL delayed name removal enabled.")
 			case "promql-extended-range-selectors":
-				parser.EnableExtendedRangeSelectors = true
+				c.parserOpts.EnableExtendedRangeSelectors = true
 				logger.Info("Experimental PromQL extended range selectors enabled.")
 			case "promql-binop-fill-modifiers":
-				parser.EnableBinopFillModifiers = true
+				c.parserOpts.EnableBinopFillModifiers = true
 				logger.Info("Experimental PromQL binary operator fill modifiers enabled.")
 			case "":
 				continue
@@ -920,6 +922,7 @@ func main() {
 			EnablePerStepStats:       cfg.enablePerStepStats,
 			EnableDelayedNameRemoval: cfg.promqlEnableDelayedNameRemoval,
 			EnableTypeAndUnitLabels:  cfg.scrape.EnableTypeAndUnitLabels,
+			ParserOptions:            cfg.parserOpts,
 			FeatureRegistry:          features.DefaultRegistry,
 		}
 
@@ -940,6 +943,7 @@ func main() {
 			ResendDelay:            time.Duration(cfg.resendDelay),
 			MaxConcurrentEvals:     cfg.maxConcurrentEvals,
 			ConcurrentEvalsEnabled: cfg.enableConcurrentRuleEval,
+			ParserOptions:          cfg.parserOpts,
 			DefaultRuleQueryOffset: func() time.Duration {
 				return time.Duration(cfgFile.GlobalConfig.RuleQueryOffset)
 			},
@@ -957,6 +961,7 @@ func main() {
 	cfg.web.Storage = fanoutStorage
 	cfg.web.ExemplarStorage = localStorage
 	cfg.web.QueryEngine = queryEngine
+	cfg.web.ParserOptions = cfg.parserOpts
 	cfg.web.ScrapeManager = scrapeManager
 	cfg.web.RuleManager = ruleManager
 	cfg.web.Notifier = notifierManager

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -365,6 +365,7 @@ func main() {
 			}
 		}
 	}
+	parser.SetDefaultOptions(promtoolParserOpts)
 
 	switch parsedCmd {
 	case sdCheckCmd.FullCommand():
@@ -873,7 +874,7 @@ func checkRulesFromStdin(ls rulesLintConfig) (bool, bool) {
 		fmt.Fprintln(os.Stderr, "  FAILED:", err)
 		return true, true
 	}
-	rgs, errs := rulefmt.Parse(data, ls.ignoreUnknownFields, ls.nameValidationScheme, promtoolParserOpts)
+	rgs, errs := rulefmt.Parse(data, ls.ignoreUnknownFields, ls.nameValidationScheme)
 	if errs != nil {
 		failed = true
 		fmt.Fprintln(os.Stderr, "  FAILED:")
@@ -907,7 +908,7 @@ func checkRules(files []string, ls rulesLintConfig) (bool, bool) {
 	hasErrors := false
 	for _, f := range files {
 		fmt.Println("Checking", f)
-		rgs, errs := rulefmt.ParseFile(f, ls.ignoreUnknownFields, ls.nameValidationScheme, promtoolParserOpts)
+		rgs, errs := rulefmt.ParseFile(f, ls.ignoreUnknownFields, ls.nameValidationScheme)
 		if errs != nil {
 			failed = true
 			fmt.Fprintln(os.Stderr, "  FAILED:")
@@ -1349,7 +1350,7 @@ func checkTargetGroupsForScrapeConfig(targetGroups []*targetgroup.Group, scfg *c
 }
 
 func formatPromQL(query string) error {
-	expr, err := parser.ParseExpr(query, parser.WithOptions(promtoolParserOpts))
+	expr, err := parser.ParseExpr(query)
 	if err != nil {
 		return err
 	}
@@ -1359,7 +1360,7 @@ func formatPromQL(query string) error {
 }
 
 func labelsSetPromQL(query, labelMatchType, name, value string) error {
-	expr, err := parser.ParseExpr(query, parser.WithOptions(promtoolParserOpts))
+	expr, err := parser.ParseExpr(query)
 	if err != nil {
 		return err
 	}
@@ -1404,7 +1405,7 @@ func labelsSetPromQL(query, labelMatchType, name, value string) error {
 }
 
 func labelsDeletePromQL(query, name string) error {
-	expr, err := parser.ParseExpr(query, parser.WithOptions(promtoolParserOpts))
+	expr, err := parser.ParseExpr(query)
 	if err != nil {
 		return err
 	}

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -873,7 +873,7 @@ func checkRulesFromStdin(ls rulesLintConfig) (bool, bool) {
 		fmt.Fprintln(os.Stderr, "  FAILED:", err)
 		return true, true
 	}
-	rgs, errs := rulefmt.Parse(data, ls.ignoreUnknownFields, ls.nameValidationScheme)
+	rgs, errs := rulefmt.Parse(data, ls.ignoreUnknownFields, ls.nameValidationScheme, promtoolParserOpts)
 	if errs != nil {
 		failed = true
 		fmt.Fprintln(os.Stderr, "  FAILED:")
@@ -907,7 +907,7 @@ func checkRules(files []string, ls rulesLintConfig) (bool, bool) {
 	hasErrors := false
 	for _, f := range files {
 		fmt.Println("Checking", f)
-		rgs, errs := rulefmt.ParseFile(f, ls.ignoreUnknownFields, ls.nameValidationScheme)
+		rgs, errs := rulefmt.ParseFile(f, ls.ignoreUnknownFields, ls.nameValidationScheme, promtoolParserOpts)
 		if errs != nil {
 			failed = true
 			fmt.Fprintln(os.Stderr, "  FAILED:")

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -355,9 +355,9 @@ func main() {
 			case "promql-delayed-name-removal":
 				promqlEnableDelayedNameRemoval = true
 			case "promql-duration-expr":
-				parser.ExperimentalDurationExpr = true
+				promtoolParserOpts.ExperimentalDurationExpr = true
 			case "promql-extended-range-selectors":
-				parser.EnableExtendedRangeSelectors = true
+				promtoolParserOpts.EnableExtendedRangeSelectors = true
 			case "":
 				continue
 			default:
@@ -365,7 +365,7 @@ func main() {
 			}
 		}
 	}
-	parser.SetDefaultOptions(promtoolParserOpts)
+	promtoolParser := parser.NewParser(promtoolParserOpts)
 
 	switch parsedCmd {
 	case sdCheckCmd.FullCommand():
@@ -384,7 +384,7 @@ func main() {
 		os.Exit(CheckWebConfig(*webConfigFiles...))
 
 	case checkRulesCmd.FullCommand():
-		os.Exit(CheckRules(newRulesLintConfig(*checkRulesLint, *checkRulesLintFatal, *checkRulesIgnoreUnknownFields, model.UTF8Validation), *ruleFiles...))
+		os.Exit(CheckRules(newRulesLintConfig(*checkRulesLint, *checkRulesLintFatal, *checkRulesIgnoreUnknownFields, model.UTF8Validation), promtoolParser, *ruleFiles...))
 
 	case checkMetricsCmd.FullCommand():
 		os.Exit(CheckMetrics(*checkMetricsExtended, *checkMetricsLint))
@@ -424,6 +424,7 @@ func main() {
 				EnableNegativeOffset:     true,
 				EnableDelayedNameRemoval: promqlEnableDelayedNameRemoval,
 			},
+			promtoolParser,
 			*testRulesRun,
 			*testRulesDiff,
 			*testRulesDebug,
@@ -435,7 +436,7 @@ func main() {
 		os.Exit(checkErr(benchmarkWrite(*benchWriteOutPath, *benchSamplesFile, *benchWriteNumMetrics, *benchWriteNumScrapes)))
 
 	case tsdbAnalyzeCmd.FullCommand():
-		os.Exit(checkErr(analyzeBlock(ctx, *analyzePath, *analyzeBlockID, *analyzeLimit, *analyzeRunExtended, *analyzeMatchers)))
+		os.Exit(checkErr(analyzeBlock(ctx, *analyzePath, *analyzeBlockID, *analyzeLimit, *analyzeRunExtended, *analyzeMatchers, promtoolParser)))
 
 	case tsdbListCmd.FullCommand():
 		os.Exit(checkErr(listBlocks(*listPath, *listHumanReadable)))
@@ -445,10 +446,10 @@ func main() {
 		if *dumpFormat == "seriesjson" {
 			format = formatSeriesSetLabelsToJSON
 		}
-		os.Exit(checkErr(dumpTSDBData(ctx, *dumpPath, *dumpSandboxDirRoot, *dumpMinTime, *dumpMaxTime, *dumpMatch, format)))
+		os.Exit(checkErr(dumpTSDBData(ctx, *dumpPath, *dumpSandboxDirRoot, *dumpMinTime, *dumpMaxTime, *dumpMatch, format, promtoolParser)))
 
 	case tsdbDumpOpenMetricsCmd.FullCommand():
-		os.Exit(checkErr(dumpTSDBData(ctx, *dumpOpenMetricsPath, *dumpOpenMetricsSandboxDirRoot, *dumpOpenMetricsMinTime, *dumpOpenMetricsMaxTime, *dumpOpenMetricsMatch, formatSeriesSetOpenMetrics)))
+		os.Exit(checkErr(dumpTSDBData(ctx, *dumpOpenMetricsPath, *dumpOpenMetricsSandboxDirRoot, *dumpOpenMetricsMinTime, *dumpOpenMetricsMaxTime, *dumpOpenMetricsMatch, formatSeriesSetOpenMetrics, promtoolParser)))
 	// TODO(aSquare14): Work on adding support for custom block size.
 	case openMetricsImportCmd.FullCommand():
 		os.Exit(backfillOpenMetrics(*importFilePath, *importDBPath, *importHumanReadable, *importQuiet, *maxBlockDuration, *openMetricsLabels))
@@ -464,15 +465,15 @@ func main() {
 
 	case promQLFormatCmd.FullCommand():
 		checkExperimental(*experimental)
-		os.Exit(checkErr(formatPromQL(*promQLFormatQuery)))
+		os.Exit(checkErr(formatPromQL(*promQLFormatQuery, promtoolParser)))
 
 	case promQLLabelsSetCmd.FullCommand():
 		checkExperimental(*experimental)
-		os.Exit(checkErr(labelsSetPromQL(*promQLLabelsSetQuery, *promQLLabelsSetType, *promQLLabelsSetName, *promQLLabelsSetValue)))
+		os.Exit(checkErr(labelsSetPromQL(*promQLLabelsSetQuery, *promQLLabelsSetType, *promQLLabelsSetName, *promQLLabelsSetValue, promtoolParser)))
 
 	case promQLLabelsDeleteCmd.FullCommand():
 		checkExperimental(*experimental)
-		os.Exit(checkErr(labelsDeletePromQL(*promQLLabelsDeleteQuery, *promQLLabelsDeleteName)))
+		os.Exit(checkErr(labelsDeletePromQL(*promQLLabelsDeleteQuery, *promQLLabelsDeleteName, promtoolParser)))
 	}
 }
 
@@ -618,7 +619,7 @@ func CheckConfig(agentMode, checkSyntaxOnly bool, lintSettings configLintConfig,
 		if !checkSyntaxOnly {
 			scrapeConfigsFailed := lintScrapeConfigs(scrapeConfigs, lintSettings)
 			failed = failed || scrapeConfigsFailed
-			rulesFailed, rulesHaveErrors := checkRules(ruleFiles, lintSettings.rulesLintConfig)
+			rulesFailed, rulesHaveErrors := checkRules(ruleFiles, lintSettings.rulesLintConfig, parser.NewParser(parser.Options{}))
 			failed = failed || rulesFailed
 			hasErrors = hasErrors || rulesHaveErrors
 		}
@@ -845,13 +846,13 @@ func checkSDFile(filename string) ([]*targetgroup.Group, error) {
 }
 
 // CheckRules validates rule files.
-func CheckRules(ls rulesLintConfig, files ...string) int {
+func CheckRules(ls rulesLintConfig, p parser.Parser, files ...string) int {
 	failed := false
 	hasErrors := false
 	if len(files) == 0 {
-		failed, hasErrors = checkRulesFromStdin(ls)
+		failed, hasErrors = checkRulesFromStdin(ls, p)
 	} else {
-		failed, hasErrors = checkRules(files, ls)
+		failed, hasErrors = checkRules(files, ls, p)
 	}
 
 	if failed && hasErrors {
@@ -865,7 +866,7 @@ func CheckRules(ls rulesLintConfig, files ...string) int {
 }
 
 // checkRulesFromStdin validates rule from stdin.
-func checkRulesFromStdin(ls rulesLintConfig) (bool, bool) {
+func checkRulesFromStdin(ls rulesLintConfig, p parser.Parser) (bool, bool) {
 	failed := false
 	hasErrors := false
 	fmt.Println("Checking standard input")
@@ -874,7 +875,7 @@ func checkRulesFromStdin(ls rulesLintConfig) (bool, bool) {
 		fmt.Fprintln(os.Stderr, "  FAILED:", err)
 		return true, true
 	}
-	rgs, errs := rulefmt.Parse(data, ls.ignoreUnknownFields, ls.nameValidationScheme)
+	rgs, errs := rulefmt.Parse(data, ls.ignoreUnknownFields, ls.nameValidationScheme, p)
 	if errs != nil {
 		failed = true
 		fmt.Fprintln(os.Stderr, "  FAILED:")
@@ -903,12 +904,12 @@ func checkRulesFromStdin(ls rulesLintConfig) (bool, bool) {
 }
 
 // checkRules validates rule files.
-func checkRules(files []string, ls rulesLintConfig) (bool, bool) {
+func checkRules(files []string, ls rulesLintConfig, p parser.Parser) (bool, bool) {
 	failed := false
 	hasErrors := false
 	for _, f := range files {
 		fmt.Println("Checking", f)
-		rgs, errs := rulefmt.ParseFile(f, ls.ignoreUnknownFields, ls.nameValidationScheme)
+		rgs, errs := rulefmt.ParseFile(f, ls.ignoreUnknownFields, ls.nameValidationScheme, p)
 		if errs != nil {
 			failed = true
 			fmt.Fprintln(os.Stderr, "  FAILED:")
@@ -1349,8 +1350,8 @@ func checkTargetGroupsForScrapeConfig(targetGroups []*targetgroup.Group, scfg *c
 	return nil
 }
 
-func formatPromQL(query string) error {
-	expr, err := parser.ParseExpr(query)
+func formatPromQL(query string, p parser.Parser) error {
+	expr, err := p.ParseExpr(query)
 	if err != nil {
 		return err
 	}
@@ -1359,8 +1360,8 @@ func formatPromQL(query string) error {
 	return nil
 }
 
-func labelsSetPromQL(query, labelMatchType, name, value string) error {
-	expr, err := parser.ParseExpr(query)
+func labelsSetPromQL(query, labelMatchType, name, value string, p parser.Parser) error {
+	expr, err := p.ParseExpr(query)
 	if err != nil {
 		return err
 	}
@@ -1404,8 +1405,8 @@ func labelsSetPromQL(query, labelMatchType, name, value string) error {
 	return nil
 }
 
-func labelsDeletePromQL(query, name string) error {
-	expr, err := parser.ParseExpr(query)
+func labelsDeletePromQL(query, name string, p parser.Parser) error {
+	expr, err := p.ParseExpr(query)
 	if err != nil {
 		return err
 	}

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -61,7 +61,10 @@ import (
 	"github.com/prometheus/prometheus/util/documentcli"
 )
 
-var promqlEnableDelayedNameRemoval = false
+var (
+	promqlEnableDelayedNameRemoval = false
+	promtoolParserOpts             parser.Options
+)
 
 func init() {
 	// This can be removed when the legacy global mode is fully deprecated.
@@ -348,7 +351,7 @@ func main() {
 		for o := range strings.SplitSeq(f, ",") {
 			switch o {
 			case "promql-experimental-functions":
-				parser.EnableExperimentalFunctions = true
+				promtoolParserOpts.EnableExperimentalFunctions = true
 			case "promql-delayed-name-removal":
 				promqlEnableDelayedNameRemoval = true
 			case "promql-duration-expr":
@@ -1346,7 +1349,7 @@ func checkTargetGroupsForScrapeConfig(targetGroups []*targetgroup.Group, scfg *c
 }
 
 func formatPromQL(query string) error {
-	expr, err := parser.ParseExpr(query)
+	expr, err := parser.ParseExpr(query, parser.WithOptions(promtoolParserOpts))
 	if err != nil {
 		return err
 	}
@@ -1356,7 +1359,7 @@ func formatPromQL(query string) error {
 }
 
 func labelsSetPromQL(query, labelMatchType, name, value string) error {
-	expr, err := parser.ParseExpr(query)
+	expr, err := parser.ParseExpr(query, parser.WithOptions(promtoolParserOpts))
 	if err != nil {
 		return err
 	}
@@ -1401,7 +1404,7 @@ func labelsSetPromQL(query, labelMatchType, name, value string) error {
 }
 
 func labelsDeletePromQL(query, name string) error {
-	expr, err := parser.ParseExpr(query)
+	expr, err := parser.ParseExpr(query, parser.WithOptions(promtoolParserOpts))
 	if err != nil {
 		return err
 	}

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 )
 
@@ -187,7 +188,7 @@ func TestCheckDuplicates(t *testing.T) {
 		c := test
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			rgs, err := rulefmt.ParseFile(c.ruleFile, false, model.UTF8Validation)
+			rgs, err := rulefmt.ParseFile(c.ruleFile, false, model.UTF8Validation, parser.NewParser(parser.Options{}))
 			require.Empty(t, err)
 			dups := checkDuplicates(rgs.Groups)
 			require.Equal(t, c.expectedDups, dups)
@@ -196,7 +197,7 @@ func TestCheckDuplicates(t *testing.T) {
 }
 
 func BenchmarkCheckDuplicates(b *testing.B) {
-	rgs, err := rulefmt.ParseFile("./testdata/rules_large.yml", false, model.UTF8Validation)
+	rgs, err := rulefmt.ParseFile("./testdata/rules_large.yml", false, model.UTF8Validation, parser.NewParser(parser.Options{}))
 	require.Empty(b, err)
 
 	for b.Loop() {
@@ -602,7 +603,7 @@ func TestCheckRules(t *testing.T) {
 		defer func(v *os.File) { os.Stdin = v }(os.Stdin)
 		os.Stdin = r
 
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation))
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), parser.NewParser(parser.Options{}))
 		require.Equal(t, successExitCode, exitCode)
 	})
 
@@ -624,7 +625,7 @@ func TestCheckRules(t *testing.T) {
 		defer func(v *os.File) { os.Stdin = v }(os.Stdin)
 		os.Stdin = r
 
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation))
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), parser.NewParser(parser.Options{}))
 		require.Equal(t, failureExitCode, exitCode)
 	})
 
@@ -646,7 +647,7 @@ func TestCheckRules(t *testing.T) {
 		defer func(v *os.File) { os.Stdin = v }(os.Stdin)
 		os.Stdin = r
 
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, true, false, model.UTF8Validation))
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, true, false, model.UTF8Validation), parser.NewParser(parser.Options{}))
 		require.Equal(t, lintErrExitCode, exitCode)
 	})
 }
@@ -664,19 +665,19 @@ func TestCheckRulesWithFeatureFlag(t *testing.T) {
 func TestCheckRulesWithRuleFiles(t *testing.T) {
 	t.Run("rules-good", func(t *testing.T) {
 		t.Parallel()
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), "./testdata/rules.yml")
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), parser.NewParser(parser.Options{}), "./testdata/rules.yml")
 		require.Equal(t, successExitCode, exitCode)
 	})
 
 	t.Run("rules-bad", func(t *testing.T) {
 		t.Parallel()
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), "./testdata/rules-bad.yml")
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), parser.NewParser(parser.Options{}), "./testdata/rules-bad.yml")
 		require.Equal(t, failureExitCode, exitCode)
 	})
 
 	t.Run("rules-lint-fatal", func(t *testing.T) {
 		t.Parallel()
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, true, false, model.UTF8Validation), "./testdata/prometheus-rules.lint.yml")
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, true, false, model.UTF8Validation), parser.NewParser(parser.Options{}), "./testdata/prometheus-rules.lint.yml")
 		require.Equal(t, lintErrExitCode, exitCode)
 	})
 }

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 )
 
@@ -188,7 +187,7 @@ func TestCheckDuplicates(t *testing.T) {
 		c := test
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			rgs, err := rulefmt.ParseFile(c.ruleFile, false, model.UTF8Validation, parser.Options{})
+			rgs, err := rulefmt.ParseFile(c.ruleFile, false, model.UTF8Validation)
 			require.Empty(t, err)
 			dups := checkDuplicates(rgs.Groups)
 			require.Equal(t, c.expectedDups, dups)
@@ -197,7 +196,7 @@ func TestCheckDuplicates(t *testing.T) {
 }
 
 func BenchmarkCheckDuplicates(b *testing.B) {
-	rgs, err := rulefmt.ParseFile("./testdata/rules_large.yml", false, model.UTF8Validation, parser.Options{})
+	rgs, err := rulefmt.ParseFile("./testdata/rules_large.yml", false, model.UTF8Validation)
 	require.Empty(b, err)
 
 	for b.Loop() {

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 )
 
@@ -187,7 +188,7 @@ func TestCheckDuplicates(t *testing.T) {
 		c := test
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			rgs, err := rulefmt.ParseFile(c.ruleFile, false, model.UTF8Validation)
+			rgs, err := rulefmt.ParseFile(c.ruleFile, false, model.UTF8Validation, parser.Options{})
 			require.Empty(t, err)
 			dups := checkDuplicates(rgs.Groups)
 			require.Equal(t, c.expectedDups, dups)
@@ -196,7 +197,7 @@ func TestCheckDuplicates(t *testing.T) {
 }
 
 func BenchmarkCheckDuplicates(b *testing.B) {
-	rgs, err := rulefmt.ParseFile("./testdata/rules_large.yml", false, model.UTF8Validation)
+	rgs, err := rulefmt.ParseFile("./testdata/rules_large.yml", false, model.UTF8Validation, parser.Options{})
 	require.Empty(b, err)
 
 	for b.Loop() {

--- a/cmd/promtool/rules.go
+++ b/cmd/promtool/rules.go
@@ -66,6 +66,7 @@ func newRuleImporter(logger *slog.Logger, config ruleImporterConfig, apiClient q
 		apiClient: apiClient,
 		ruleManager: rules.NewManager(&rules.ManagerOptions{
 			NameValidationScheme: config.nameValidationScheme,
+			ParserOptions:        promtoolParserOpts,
 		}),
 	}
 }

--- a/cmd/promtool/rules.go
+++ b/cmd/promtool/rules.go
@@ -66,7 +66,6 @@ func newRuleImporter(logger *slog.Logger, config ruleImporterConfig, apiClient q
 		apiClient: apiClient,
 		ruleManager: rules.NewManager(&rules.ManagerOptions{
 			NameValidationScheme: config.nameValidationScheme,
-			ParserOptions:        promtoolParserOpts,
 		}),
 	}
 }

--- a/cmd/promtool/tsdb_test.go
+++ b/cmd/promtool/tsdb_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/tsdb"
 )
@@ -71,6 +72,7 @@ func getDumpedSamples(t *testing.T, databasePath, sandboxDirRoot string, mint, m
 		maxt,
 		match,
 		formatter,
+		parser.NewParser(parser.Options{}),
 	)
 	require.NoError(t, err)
 

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -247,12 +247,11 @@ func (tg *testGroup) test(testname string, evalInterval time.Duration, groupOrde
 
 	// Load the rule files.
 	opts := &rules.ManagerOptions{
-		QueryFunc:     rules.EngineQueryFunc(suite.QueryEngine(), suite.Storage()),
-		Appendable:    suite.Storage(),
-		Context:       context.Background(),
-		NotifyFunc:    func(context.Context, string, ...*rules.Alert) {},
-		Logger:        promslog.NewNopLogger(),
-		ParserOptions: promtoolParserOpts,
+		QueryFunc:  rules.EngineQueryFunc(suite.QueryEngine(), suite.Storage()),
+		Appendable: suite.Storage(),
+		Context:    context.Background(),
+		NotifyFunc: func(context.Context, string, ...*rules.Alert) {},
+		Logger:     promslog.NewNopLogger(),
 	}
 	m := rules.NewManager(opts)
 	groupsMap, ers := m.LoadGroups(time.Duration(tg.Interval), tg.ExternalLabels, tg.ExternalURL, nil, ignoreUnknownFields, ruleFiles...)

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -247,11 +247,12 @@ func (tg *testGroup) test(testname string, evalInterval time.Duration, groupOrde
 
 	// Load the rule files.
 	opts := &rules.ManagerOptions{
-		QueryFunc:  rules.EngineQueryFunc(suite.QueryEngine(), suite.Storage()),
-		Appendable: suite.Storage(),
-		Context:    context.Background(),
-		NotifyFunc: func(context.Context, string, ...*rules.Alert) {},
-		Logger:     promslog.NewNopLogger(),
+		QueryFunc:     rules.EngineQueryFunc(suite.QueryEngine(), suite.Storage()),
+		Appendable:    suite.Storage(),
+		Context:       context.Background(),
+		NotifyFunc:    func(context.Context, string, ...*rules.Alert) {},
+		Logger:        promslog.NewNopLogger(),
+		ParserOptions: promtoolParserOpts,
 	}
 	m := rules.NewManager(opts)
 	groupsMap, ers := m.LoadGroups(time.Duration(tg.Interval), tg.ExternalLabels, tg.ExternalURL, nil, ignoreUnknownFields, ruleFiles...)

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/util/junitxml"
 )
@@ -153,7 +154,7 @@ func TestRulesUnitTest(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := RulesUnitTest(tt.queryOpts, nil, false, false, false, tt.args.files...); got != tt.want {
+			if got := RulesUnitTest(tt.queryOpts, parser.NewParser(parser.Options{}), nil, false, false, false, tt.args.files...); got != tt.want {
 				t.Errorf("RulesUnitTest() = %v, want %v", got, tt.want)
 			}
 		})
@@ -161,7 +162,7 @@ func TestRulesUnitTest(t *testing.T) {
 	t.Run("Junit xml output ", func(t *testing.T) {
 		t.Parallel()
 		var buf bytes.Buffer
-		if got := RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, nil, false, false, false, reuseFiles...); got != 1 {
+		if got := RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, parser.NewParser(parser.Options{}), nil, false, false, false, reuseFiles...); got != 1 {
 			t.Errorf("RulesUnitTestResults() = %v, want 1", got)
 		}
 		var test junitxml.JUnitXML
@@ -277,7 +278,7 @@ func TestRulesUnitTestRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := RulesUnitTest(tt.queryOpts, tt.args.run, false, false, tt.ignoreUnknownFields, tt.args.files...)
+			got := RulesUnitTest(tt.queryOpts, parser.NewParser(parser.Options{}), tt.args.run, false, false, tt.ignoreUnknownFields, tt.args.files...)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -97,7 +97,7 @@ type ruleGroups struct {
 }
 
 // Validate validates all rules in the rule groups.
-func (g *RuleGroups) Validate(node ruleGroups, nameValidationScheme model.ValidationScheme, parserOpts parser.Options) (errs []error) {
+func (g *RuleGroups) Validate(node ruleGroups, nameValidationScheme model.ValidationScheme) (errs []error) {
 	if err := namevalidationutil.CheckNameValidationScheme(nameValidationScheme); err != nil {
 		errs = append(errs, err)
 		return errs
@@ -134,7 +134,7 @@ func (g *RuleGroups) Validate(node ruleGroups, nameValidationScheme model.Valida
 		set[g.Name] = struct{}{}
 
 		for i, r := range g.Rules {
-			for _, node := range r.Validate(node.Groups[j].Rules[i], nameValidationScheme, parserOpts) {
+			for _, node := range r.Validate(node.Groups[j].Rules[i], nameValidationScheme) {
 				var ruleName string
 				if r.Alert != "" {
 					ruleName = r.Alert
@@ -198,7 +198,7 @@ type RuleNode struct {
 }
 
 // Validate the rule and return a list of encountered errors.
-func (r *Rule) Validate(node RuleNode, nameValidationScheme model.ValidationScheme, parserOpts parser.Options) (nodes []WrappedError) {
+func (r *Rule) Validate(node RuleNode, nameValidationScheme model.ValidationScheme) (nodes []WrappedError) {
 	if r.Record != "" && r.Alert != "" {
 		nodes = append(nodes, WrappedError{
 			err:     errors.New("only one of 'record' and 'alert' must be set"),
@@ -219,7 +219,7 @@ func (r *Rule) Validate(node RuleNode, nameValidationScheme model.ValidationSche
 			err:  errors.New("field 'expr' must be set in rule"),
 			node: &node.Expr,
 		})
-	} else if _, err := parser.ParseExpr(r.Expr, parser.WithOptions(parserOpts)); err != nil {
+	} else if _, err := parser.ParseExpr(r.Expr); err != nil {
 		nodes = append(nodes, WrappedError{
 			err:  fmt.Errorf("could not parse expression: %w", err),
 			node: &node.Expr,
@@ -339,7 +339,7 @@ func testTemplateParsing(rl *Rule) (errs []error) {
 }
 
 // Parse parses and validates a set of rules.
-func Parse(content []byte, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme, parserOpts parser.Options) (*RuleGroups, []error) {
+func Parse(content []byte, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) (*RuleGroups, []error) {
 	var (
 		groups RuleGroups
 		node   ruleGroups
@@ -364,16 +364,16 @@ func Parse(content []byte, ignoreUnknownFields bool, nameValidationScheme model.
 		return nil, errs
 	}
 
-	return &groups, groups.Validate(node, nameValidationScheme, parserOpts)
+	return &groups, groups.Validate(node, nameValidationScheme)
 }
 
 // ParseFile reads and parses rules from a file.
-func ParseFile(file string, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme, parserOpts parser.Options) (*RuleGroups, []error) {
+func ParseFile(file string, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) (*RuleGroups, []error) {
 	b, err := os.ReadFile(file)
 	if err != nil {
 		return nil, []error{fmt.Errorf("%s: %w", file, err)}
 	}
-	rgs, errs := Parse(b, ignoreUnknownFields, nameValidationScheme, parserOpts)
+	rgs, errs := Parse(b, ignoreUnknownFields, nameValidationScheme)
 	for i := range errs {
 		errs[i] = fmt.Errorf("%s: %w", file, errs[i])
 	}

--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -97,7 +97,7 @@ type ruleGroups struct {
 }
 
 // Validate validates all rules in the rule groups.
-func (g *RuleGroups) Validate(node ruleGroups, nameValidationScheme model.ValidationScheme) (errs []error) {
+func (g *RuleGroups) Validate(node ruleGroups, nameValidationScheme model.ValidationScheme, parserOpts parser.Options) (errs []error) {
 	if err := namevalidationutil.CheckNameValidationScheme(nameValidationScheme); err != nil {
 		errs = append(errs, err)
 		return errs
@@ -134,7 +134,7 @@ func (g *RuleGroups) Validate(node ruleGroups, nameValidationScheme model.Valida
 		set[g.Name] = struct{}{}
 
 		for i, r := range g.Rules {
-			for _, node := range r.Validate(node.Groups[j].Rules[i], nameValidationScheme) {
+			for _, node := range r.Validate(node.Groups[j].Rules[i], nameValidationScheme, parserOpts) {
 				var ruleName string
 				if r.Alert != "" {
 					ruleName = r.Alert
@@ -198,7 +198,7 @@ type RuleNode struct {
 }
 
 // Validate the rule and return a list of encountered errors.
-func (r *Rule) Validate(node RuleNode, nameValidationScheme model.ValidationScheme) (nodes []WrappedError) {
+func (r *Rule) Validate(node RuleNode, nameValidationScheme model.ValidationScheme, parserOpts parser.Options) (nodes []WrappedError) {
 	if r.Record != "" && r.Alert != "" {
 		nodes = append(nodes, WrappedError{
 			err:     errors.New("only one of 'record' and 'alert' must be set"),
@@ -219,7 +219,7 @@ func (r *Rule) Validate(node RuleNode, nameValidationScheme model.ValidationSche
 			err:  errors.New("field 'expr' must be set in rule"),
 			node: &node.Expr,
 		})
-	} else if _, err := parser.ParseExpr(r.Expr); err != nil {
+	} else if _, err := parser.ParseExpr(r.Expr, parser.WithOptions(parserOpts)); err != nil {
 		nodes = append(nodes, WrappedError{
 			err:  fmt.Errorf("could not parse expression: %w", err),
 			node: &node.Expr,
@@ -339,7 +339,7 @@ func testTemplateParsing(rl *Rule) (errs []error) {
 }
 
 // Parse parses and validates a set of rules.
-func Parse(content []byte, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) (*RuleGroups, []error) {
+func Parse(content []byte, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme, parserOpts parser.Options) (*RuleGroups, []error) {
 	var (
 		groups RuleGroups
 		node   ruleGroups
@@ -364,16 +364,16 @@ func Parse(content []byte, ignoreUnknownFields bool, nameValidationScheme model.
 		return nil, errs
 	}
 
-	return &groups, groups.Validate(node, nameValidationScheme)
+	return &groups, groups.Validate(node, nameValidationScheme, parserOpts)
 }
 
 // ParseFile reads and parses rules from a file.
-func ParseFile(file string, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) (*RuleGroups, []error) {
+func ParseFile(file string, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme, parserOpts parser.Options) (*RuleGroups, []error) {
 	b, err := os.ReadFile(file)
 	if err != nil {
 		return nil, []error{fmt.Errorf("%s: %w", file, err)}
 	}
-	rgs, errs := Parse(b, ignoreUnknownFields, nameValidationScheme)
+	rgs, errs := Parse(b, ignoreUnknownFields, nameValidationScheme, parserOpts)
 	for i := range errs {
 		errs[i] = fmt.Errorf("%s: %w", file, errs[i])
 	}

--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -22,17 +22,20 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
+
+	"github.com/prometheus/prometheus/promql/parser"
 )
 
 func TestParseFileSuccess(t *testing.T) {
-	_, errs := ParseFile("testdata/test.yaml", false, model.UTF8Validation)
+	opts := parser.Options{}
+	_, errs := ParseFile("testdata/test.yaml", false, model.UTF8Validation, opts)
 	require.Empty(t, errs, "unexpected errors parsing file")
 
-	_, errs = ParseFile("testdata/utf-8_lname.good.yaml", false, model.UTF8Validation)
+	_, errs = ParseFile("testdata/utf-8_lname.good.yaml", false, model.UTF8Validation, opts)
 	require.Empty(t, errs, "unexpected errors parsing file")
-	_, errs = ParseFile("testdata/utf-8_annotation.good.yaml", false, model.UTF8Validation)
+	_, errs = ParseFile("testdata/utf-8_annotation.good.yaml", false, model.UTF8Validation, opts)
 	require.Empty(t, errs, "unexpected errors parsing file")
-	_, errs = ParseFile("testdata/legacy_validation_annotation.good.yaml", false, model.LegacyValidation)
+	_, errs = ParseFile("testdata/legacy_validation_annotation.good.yaml", false, model.LegacyValidation, opts)
 	require.Empty(t, errs, "unexpected errors parsing file")
 }
 
@@ -41,7 +44,7 @@ func TestParseFileSuccessWithAliases(t *testing.T) {
 /
 sum without(instance) (rate(requests_total[5m]))
 `
-	rgs, errs := ParseFile("testdata/test_aliases.yaml", false, model.UTF8Validation)
+	rgs, errs := ParseFile("testdata/test_aliases.yaml", false, model.UTF8Validation, parser.Options{})
 	require.Empty(t, errs, "unexpected errors parsing file")
 	for _, rg := range rgs.Groups {
 		require.Equal(t, "HighAlert", rg.Rules[0].Alert)
@@ -119,7 +122,7 @@ func TestParseFileFailure(t *testing.T) {
 			if c.nameValidationScheme == model.UnsetValidation {
 				c.nameValidationScheme = model.UTF8Validation
 			}
-			_, errs := ParseFile(filepath.Join("testdata", c.filename), false, c.nameValidationScheme)
+			_, errs := ParseFile(filepath.Join("testdata", c.filename), false, c.nameValidationScheme, parser.Options{})
 			require.NotEmpty(t, errs, "Expected error parsing %s but got none", c.filename)
 			require.ErrorContainsf(t, errs[0], c.errMsg, "Expected error for %s.", c.filename)
 		})
@@ -215,7 +218,7 @@ groups:
 	}
 
 	for _, tst := range tests {
-		rgs, errs := Parse([]byte(tst.ruleString), false, model.UTF8Validation)
+		rgs, errs := Parse([]byte(tst.ruleString), false, model.UTF8Validation, parser.Options{})
 		require.NotNil(t, rgs, "Rule parsing, rule=\n"+tst.ruleString)
 		passed := (tst.shouldPass && len(errs) == 0) || (!tst.shouldPass && len(errs) > 0)
 		require.True(t, passed, "Rule validation failed, rule=\n"+tst.ruleString)
@@ -242,7 +245,7 @@ groups:
     annotations:
       summary: "Instance {{ $labels.instance }} up"
 `
-	_, errs := Parse([]byte(group), false, model.UTF8Validation)
+	_, errs := Parse([]byte(group), false, model.UTF8Validation, parser.Options{})
 	require.Len(t, errs, 2, "Expected two errors")
 	var err00 *Error
 	require.ErrorAs(t, errs[0], &err00)

--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -22,20 +22,17 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
-
-	"github.com/prometheus/prometheus/promql/parser"
 )
 
 func TestParseFileSuccess(t *testing.T) {
-	opts := parser.Options{}
-	_, errs := ParseFile("testdata/test.yaml", false, model.UTF8Validation, opts)
+	_, errs := ParseFile("testdata/test.yaml", false, model.UTF8Validation)
 	require.Empty(t, errs, "unexpected errors parsing file")
 
-	_, errs = ParseFile("testdata/utf-8_lname.good.yaml", false, model.UTF8Validation, opts)
+	_, errs = ParseFile("testdata/utf-8_lname.good.yaml", false, model.UTF8Validation)
 	require.Empty(t, errs, "unexpected errors parsing file")
-	_, errs = ParseFile("testdata/utf-8_annotation.good.yaml", false, model.UTF8Validation, opts)
+	_, errs = ParseFile("testdata/utf-8_annotation.good.yaml", false, model.UTF8Validation)
 	require.Empty(t, errs, "unexpected errors parsing file")
-	_, errs = ParseFile("testdata/legacy_validation_annotation.good.yaml", false, model.LegacyValidation, opts)
+	_, errs = ParseFile("testdata/legacy_validation_annotation.good.yaml", false, model.LegacyValidation)
 	require.Empty(t, errs, "unexpected errors parsing file")
 }
 
@@ -44,7 +41,7 @@ func TestParseFileSuccessWithAliases(t *testing.T) {
 /
 sum without(instance) (rate(requests_total[5m]))
 `
-	rgs, errs := ParseFile("testdata/test_aliases.yaml", false, model.UTF8Validation, parser.Options{})
+	rgs, errs := ParseFile("testdata/test_aliases.yaml", false, model.UTF8Validation)
 	require.Empty(t, errs, "unexpected errors parsing file")
 	for _, rg := range rgs.Groups {
 		require.Equal(t, "HighAlert", rg.Rules[0].Alert)
@@ -122,7 +119,7 @@ func TestParseFileFailure(t *testing.T) {
 			if c.nameValidationScheme == model.UnsetValidation {
 				c.nameValidationScheme = model.UTF8Validation
 			}
-			_, errs := ParseFile(filepath.Join("testdata", c.filename), false, c.nameValidationScheme, parser.Options{})
+			_, errs := ParseFile(filepath.Join("testdata", c.filename), false, c.nameValidationScheme)
 			require.NotEmpty(t, errs, "Expected error parsing %s but got none", c.filename)
 			require.ErrorContainsf(t, errs[0], c.errMsg, "Expected error for %s.", c.filename)
 		})
@@ -218,7 +215,7 @@ groups:
 	}
 
 	for _, tst := range tests {
-		rgs, errs := Parse([]byte(tst.ruleString), false, model.UTF8Validation, parser.Options{})
+		rgs, errs := Parse([]byte(tst.ruleString), false, model.UTF8Validation)
 		require.NotNil(t, rgs, "Rule parsing, rule=\n"+tst.ruleString)
 		passed := (tst.shouldPass && len(errs) == 0) || (!tst.shouldPass && len(errs) > 0)
 		require.True(t, passed, "Rule validation failed, rule=\n"+tst.ruleString)
@@ -245,7 +242,7 @@ groups:
     annotations:
       summary: "Instance {{ $labels.instance }} up"
 `
-	_, errs := Parse([]byte(group), false, model.UTF8Validation, parser.Options{})
+	_, errs := Parse([]byte(group), false, model.UTF8Validation)
 	require.Len(t, errs, 2, "Expected two errors")
 	var err00 *Error
 	require.ErrorAs(t, errs[0], &err00)

--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -332,10 +332,6 @@ func rangeQueryCases() []benchCase {
 }
 
 func BenchmarkRangeQuery(b *testing.B) {
-	parser.EnableExtendedRangeSelectors = true
-	b.Cleanup(func() {
-		parser.EnableExtendedRangeSelectors = false
-	})
 	stor := teststorage.New(b)
 	stor.DisableCompactions() // Don't want auto-compaction disrupting timings.
 
@@ -344,6 +340,9 @@ func BenchmarkRangeQuery(b *testing.B) {
 		Reg:        nil,
 		MaxSamples: 50000000,
 		Timeout:    100 * time.Second,
+		ParserOptions: parser.Options{
+			EnableExtendedRangeSelectors: true,
+		},
 	}
 	engine := promqltest.NewTestEngineWithOpts(b, opts)
 

--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/prometheus/prometheus/util/teststorage"
 )
 
+var testParser = parser.NewParser(parser.Options{})
+
 func setupRangeQueryTestData(stor *teststorage.TestStorage, _ *promql.Engine, interval, numIntervals int) error {
 	ctx := context.Background()
 
@@ -335,12 +337,12 @@ func BenchmarkRangeQuery(b *testing.B) {
 	stor := teststorage.New(b)
 	stor.DisableCompactions() // Don't want auto-compaction disrupting timings.
 
-	parser.SetDefaultOptions(parser.Options{EnableExtendedRangeSelectors: true})
 	opts := promql.EngineOpts{
 		Logger:     nil,
 		Reg:        nil,
 		MaxSamples: 50000000,
 		Timeout:    100 * time.Second,
+		Parser:     parser.NewParser(parser.Options{EnableExtendedRangeSelectors: true}),
 	}
 	engine := promqltest.NewTestEngineWithOpts(b, opts)
 
@@ -801,13 +803,13 @@ func BenchmarkParser(b *testing.B) {
 		b.Run(c, func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				parser.ParseExpr(c)
+				testParser.ParseExpr(c)
 			}
 		})
 	}
 	for _, c := range cases {
 		b.Run("preprocess "+c, func(b *testing.B) {
-			expr, _ := parser.ParseExpr(c)
+			expr, _ := testParser.ParseExpr(c)
 			start, end := time.Now().Add(-time.Hour), time.Now()
 			for b.Loop() {
 				promql.PreprocessExpr(expr, start, end, 0)
@@ -819,7 +821,7 @@ func BenchmarkParser(b *testing.B) {
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				parser.ParseExpr(c)
+				testParser.ParseExpr(c)
 			}
 		})
 	}

--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -335,14 +335,12 @@ func BenchmarkRangeQuery(b *testing.B) {
 	stor := teststorage.New(b)
 	stor.DisableCompactions() // Don't want auto-compaction disrupting timings.
 
+	parser.SetDefaultOptions(parser.Options{EnableExtendedRangeSelectors: true})
 	opts := promql.EngineOpts{
 		Logger:     nil,
 		Reg:        nil,
 		MaxSamples: 50000000,
 		Timeout:    100 * time.Second,
-		ParserOptions: parser.Options{
-			EnableExtendedRangeSelectors: true,
-		},
 	}
 	engine := promqltest.NewTestEngineWithOpts(b, opts)
 

--- a/promql/durations_test.go
+++ b/promql/durations_test.go
@@ -23,11 +23,7 @@ import (
 )
 
 func TestDurationVisitor(t *testing.T) {
-	// Enable experimental duration expression parsing.
-	parser.ExperimentalDurationExpr = true
-	t.Cleanup(func() {
-		parser.ExperimentalDurationExpr = false
-	})
+	opts := parser.WithOptions(parser.Options{ExperimentalDurationExpr: true})
 	complexExpr := `sum_over_time(
 		rate(metric[5m] offset 1h)[10m:30s] offset 2h
 	) + 
@@ -38,7 +34,7 @@ func TestDurationVisitor(t *testing.T) {
 		metric[2h * 0.5]
 	)`
 
-	expr, err := parser.ParseExpr(complexExpr)
+	expr, err := parser.ParseExpr(complexExpr, opts)
 	require.NoError(t, err)
 
 	err = parser.Walk(&durationVisitor{}, expr, nil)

--- a/promql/durations_test.go
+++ b/promql/durations_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestDurationVisitor(t *testing.T) {
-	opts := parser.WithOptions(parser.Options{ExperimentalDurationExpr: true})
+	p := parser.NewParser(parser.Options{ExperimentalDurationExpr: true})
 	complexExpr := `sum_over_time(
 		rate(metric[5m] offset 1h)[10m:30s] offset 2h
 	) + 
@@ -34,7 +34,7 @@ func TestDurationVisitor(t *testing.T) {
 		metric[2h * 0.5]
 	)`
 
-	expr, err := parser.ParseExpr(complexExpr, opts)
+	expr, err := p.ParseExpr(complexExpr)
 	require.NoError(t, err)
 
 	err = parser.Walk(&durationVisitor{}, expr, nil)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -335,6 +335,9 @@ type EngineOpts struct {
 
 	// FeatureRegistry is the registry for tracking enabled/disabled features.
 	FeatureRegistry features.Collector
+
+	// Parser is the PromQL parser instance used for parsing expressions.
+	Parser parser.Parser
 }
 
 // Engine handles the lifetime of queries from beginning to end.
@@ -354,6 +357,7 @@ type Engine struct {
 	enablePerStepStats       bool
 	enableDelayedNameRemoval bool
 	enableTypeAndUnitLabels  bool
+	parser                   parser.Parser
 }
 
 // NewEngine returns a new engine.
@@ -432,6 +436,10 @@ func NewEngine(opts EngineOpts) *Engine {
 		metrics.maxConcurrentQueries.Set(-1)
 	}
 
+	if opts.Parser == nil {
+		opts.Parser = parser.NewParser(parser.Options{})
+	}
+
 	if opts.LookbackDelta == 0 {
 		opts.LookbackDelta = defaultLookbackDelta
 		if l := opts.Logger; l != nil {
@@ -460,7 +468,9 @@ func NewEngine(opts EngineOpts) *Engine {
 		r.Enable(features.PromQL, "per_query_lookback_delta")
 		r.Enable(features.PromQL, "subqueries")
 
-		parser.RegisterFeatures(r, parser.DefaultOptions())
+		if opts.Parser != nil {
+			opts.Parser.RegisterFeatures(r)
+		}
 	}
 
 	return &Engine{
@@ -476,6 +486,7 @@ func NewEngine(opts EngineOpts) *Engine {
 		enablePerStepStats:       opts.EnablePerStepStats,
 		enableDelayedNameRemoval: opts.EnableDelayedNameRemoval,
 		enableTypeAndUnitLabels:  opts.EnableTypeAndUnitLabels,
+		parser:                   opts.Parser,
 	}
 }
 
@@ -524,7 +535,7 @@ func (ng *Engine) NewInstantQuery(ctx context.Context, q storage.Queryable, opts
 		return nil, err
 	}
 	defer finishQueue()
-	expr, err := parser.ParseExpr(qs)
+	expr, err := ng.parser.ParseExpr(qs)
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +556,7 @@ func (ng *Engine) NewRangeQuery(ctx context.Context, q storage.Queryable, opts Q
 		return nil, err
 	}
 	defer finishQueue()
-	expr, err := parser.ParseExpr(qs)
+	expr, err := ng.parser.ParseExpr(qs)
 	if err != nil {
 		return nil, err
 	}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -333,9 +333,6 @@ type EngineOpts struct {
 	// EnableTypeAndUnitLabels will allow PromQL Engine to make decisions based on the type and unit labels.
 	EnableTypeAndUnitLabels bool
 
-	// ParserOptions is the parser configuration used when parsing queries.
-	ParserOptions parser.Options
-
 	// FeatureRegistry is the registry for tracking enabled/disabled features.
 	FeatureRegistry features.Collector
 }
@@ -357,7 +354,6 @@ type Engine struct {
 	enablePerStepStats       bool
 	enableDelayedNameRemoval bool
 	enableTypeAndUnitLabels  bool
-	parserOptions            parser.Options
 }
 
 // NewEngine returns a new engine.
@@ -464,7 +460,7 @@ func NewEngine(opts EngineOpts) *Engine {
 		r.Enable(features.PromQL, "per_query_lookback_delta")
 		r.Enable(features.PromQL, "subqueries")
 
-		parser.RegisterFeatures(r, opts.ParserOptions)
+		parser.RegisterFeatures(r, parser.DefaultOptions())
 	}
 
 	return &Engine{
@@ -480,7 +476,6 @@ func NewEngine(opts EngineOpts) *Engine {
 		enablePerStepStats:       opts.EnablePerStepStats,
 		enableDelayedNameRemoval: opts.EnableDelayedNameRemoval,
 		enableTypeAndUnitLabels:  opts.EnableTypeAndUnitLabels,
-		parserOptions:            opts.ParserOptions,
 	}
 }
 
@@ -529,7 +524,7 @@ func (ng *Engine) NewInstantQuery(ctx context.Context, q storage.Queryable, opts
 		return nil, err
 	}
 	defer finishQueue()
-	expr, err := parser.ParseExpr(qs, parser.WithOptions(ng.parserOptions))
+	expr, err := parser.ParseExpr(qs)
 	if err != nil {
 		return nil, err
 	}
@@ -550,7 +545,7 @@ func (ng *Engine) NewRangeQuery(ctx context.Context, q storage.Queryable, opts Q
 		return nil, err
 	}
 	defer finishQueue()
-	expr, err := parser.ParseExpr(qs, parser.WithOptions(ng.parserOptions))
+	expr, err := parser.ParseExpr(qs)
 	if err != nil {
 		return nil, err
 	}

--- a/promql/engine_internal_test.go
+++ b/promql/engine_internal_test.go
@@ -27,12 +27,14 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 )
 
+var testParser = parser.NewParser(parser.Options{})
+
 func TestRecoverEvaluatorRuntime(t *testing.T) {
 	var output bytes.Buffer
 	logger := promslog.New(&promslog.Config{Writer: &output})
 	ev := &evaluator{logger: logger}
 
-	expr, _ := parser.ParseExpr("sum(up)")
+	expr, _ := testParser.ParseExpr("sum(up)")
 
 	var err error
 

--- a/promql/fuzz.go
+++ b/promql/fuzz.go
@@ -60,6 +60,8 @@ const (
 // Use package-scope symbol table to avoid memory allocation on every fuzzing operation.
 var symbolTable = labels.NewSymbolTable()
 
+var fuzzParser = parser.NewParser(parser.Options{})
+
 func fuzzParseMetricWithContentType(in []byte, contentType string) int {
 	p, warning := textparse.New(in, contentType, symbolTable, textparse.ParserOptions{})
 	if p == nil || warning != nil {
@@ -103,7 +105,7 @@ func FuzzParseMetricSelector(in []byte) int {
 	if len(in) > maxInputSize {
 		return fuzzMeh
 	}
-	_, err := parser.ParseMetricSelector(string(in))
+	_, err := fuzzParser.ParseMetricSelector(string(in))
 	if err == nil {
 		return fuzzInteresting
 	}
@@ -116,7 +118,7 @@ func FuzzParseExpr(in []byte) int {
 	if len(in) > maxInputSize {
 		return fuzzMeh
 	}
-	_, err := parser.ParseExpr(string(in))
+	_, err := fuzzParser.ParseExpr(string(in))
 	if err == nil {
 		return fuzzInteresting
 	}

--- a/promql/parser/features.go
+++ b/promql/parser/features.go
@@ -18,16 +18,16 @@ import "github.com/prometheus/prometheus/util/features"
 // RegisterFeatures registers all PromQL features with the feature registry.
 // This includes operators (arithmetic and comparison/set), aggregators (standard
 // and experimental), and functions.
-func RegisterFeatures(r features.Collector) {
+func RegisterFeatures(r features.Collector, opts Options) {
 	// Register core PromQL language keywords.
 	for keyword, itemType := range key {
 		if itemType.IsKeyword() {
 			// Handle experimental keywords separately.
 			switch keyword {
 			case "anchored", "smoothed":
-				r.Set(features.PromQL, keyword, EnableExtendedRangeSelectors)
+				r.Set(features.PromQL, keyword, opts.EnableExtendedRangeSelectors)
 			case "fill", "fill_left", "fill_right":
-				r.Set(features.PromQL, keyword, EnableBinopFillModifiers)
+				r.Set(features.PromQL, keyword, opts.EnableBinopFillModifiers)
 			default:
 				r.Enable(features.PromQL, keyword)
 			}
@@ -44,16 +44,16 @@ func RegisterFeatures(r features.Collector) {
 	// Register aggregators.
 	for a := ItemType(aggregatorsStart + 1); a < aggregatorsEnd; a++ {
 		if a.IsAggregator() {
-			experimental := a.IsExperimentalAggregator() && !EnableExperimentalFunctions
+			experimental := a.IsExperimentalAggregator() && !opts.EnableExperimentalFunctions
 			r.Set(features.PromQLOperators, a.String(), !experimental)
 		}
 	}
 
 	// Register functions.
 	for f, fc := range Functions {
-		r.Set(features.PromQLFunctions, f, !fc.Experimental || EnableExperimentalFunctions)
+		r.Set(features.PromQLFunctions, f, !fc.Experimental || opts.EnableExperimentalFunctions)
 	}
 
 	// Register experimental parser features.
-	r.Set(features.PromQL, "duration_expr", ExperimentalDurationExpr)
+	r.Set(features.PromQL, "duration_expr", opts.ExperimentalDurationExpr)
 }

--- a/promql/parser/features.go
+++ b/promql/parser/features.go
@@ -18,16 +18,15 @@ import "github.com/prometheus/prometheus/util/features"
 // RegisterFeatures registers all PromQL features with the feature registry.
 // This includes operators (arithmetic and comparison/set), aggregators (standard
 // and experimental), and functions.
-func RegisterFeatures(r features.Collector, opts Options) {
+func (pql *promQLParser) RegisterFeatures(r features.Collector) {
 	// Register core PromQL language keywords.
 	for keyword, itemType := range key {
 		if itemType.IsKeyword() {
-			// Handle experimental keywords separately.
 			switch keyword {
 			case "anchored", "smoothed":
-				r.Set(features.PromQL, keyword, opts.EnableExtendedRangeSelectors)
+				r.Set(features.PromQL, keyword, pql.options.EnableExtendedRangeSelectors)
 			case "fill", "fill_left", "fill_right":
-				r.Set(features.PromQL, keyword, opts.EnableBinopFillModifiers)
+				r.Set(features.PromQL, keyword, pql.options.EnableBinopFillModifiers)
 			default:
 				r.Enable(features.PromQL, keyword)
 			}
@@ -44,16 +43,16 @@ func RegisterFeatures(r features.Collector, opts Options) {
 	// Register aggregators.
 	for a := ItemType(aggregatorsStart + 1); a < aggregatorsEnd; a++ {
 		if a.IsAggregator() {
-			experimental := a.IsExperimentalAggregator() && !opts.EnableExperimentalFunctions
+			experimental := a.IsExperimentalAggregator() && !pql.options.EnableExperimentalFunctions
 			r.Set(features.PromQLOperators, a.String(), !experimental)
 		}
 	}
 
 	// Register functions.
 	for f, fc := range Functions {
-		r.Set(features.PromQLFunctions, f, !fc.Experimental || opts.EnableExperimentalFunctions)
+		r.Set(features.PromQLFunctions, f, !fc.Experimental || pql.options.EnableExperimentalFunctions)
 	}
 
 	// Register experimental parser features.
-	r.Set(features.PromQL, "duration_expr", opts.ExperimentalDurationExpr)
+	r.Set(features.PromQL, "duration_expr", pql.options.ExperimentalDurationExpr)
 }

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -23,9 +23,6 @@ type Function struct {
 	Experimental bool
 }
 
-// EnableExperimentalFunctions controls whether experimentalFunctions are enabled.
-var EnableExperimentalFunctions bool
-
 // Functions is a list of all functions supported by PromQL, including their types.
 var Functions = map[string]*Function{
 	"abs": {

--- a/promql/parser/generated_parser.y
+++ b/promql/parser/generated_parser.y
@@ -456,7 +456,7 @@ function_call   : IDENTIFIER function_call_body
                         if !exist{
                                 yylex.(*parser).addParseErrf($1.PositionRange(),"unknown function with name %q", $1.Val)
                         }
-                        if fn != nil && fn.Experimental && !EnableExperimentalFunctions {
+                        if fn != nil && fn.Experimental && !yylex.(*parser).options.EnableExperimentalFunctions {
                                 yylex.(*parser).addParseErrf($1.PositionRange(),"function %q is not enabled", $1.Val)
                         }
                         $$ = &Call{

--- a/promql/parser/generated_parser.y.go
+++ b/promql/parser/generated_parser.y.go
@@ -1459,7 +1459,7 @@ yydefault:
 			if !exist {
 				yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "unknown function with name %q", yyDollar[1].item.Val)
 			}
-			if fn != nil && fn.Experimental && !EnableExperimentalFunctions {
+			if fn != nil && fn.Experimental && !yylex.(*parser).options.EnableExperimentalFunctions {
 				yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "function %q is not enabled", yyDollar[1].item.Val)
 			}
 			yyVAL.node = &Call{

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -39,6 +39,20 @@ var parserPool = sync.Pool{
 	},
 }
 
+// defaultOptions is the default parser configuration.
+var defaultOptions Options
+
+// SetDefaultOptions sets the default parser configuration.
+// It should be called once at startup before any parsing; after that, the value must not be modified.
+func SetDefaultOptions(opts Options) {
+	defaultOptions = opts
+}
+
+// DefaultOptions returns the default parser configuration.
+func DefaultOptions() Options {
+	return defaultOptions
+}
+
 // Options holds the configuration for the PromQL parser.
 type Options struct {
 	EnableExperimentalFunctions  bool
@@ -101,7 +115,7 @@ func NewParser(input string, opts ...Opt) *parser { //nolint:revive // unexporte
 	p.parseErrors = nil
 	p.generatedParserResult = nil
 	p.lastClosing = posrange.Pos(0)
-	p.options = Options{}
+	p.options = DefaultOptions()
 
 	// Clear lexer struct before reusing.
 	p.lex = Lexer{

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -5297,18 +5297,14 @@ func readable(s string) string {
 }
 
 func TestParseExpressions(t *testing.T) {
-	// Enable experimental functions testing.
-	EnableExperimentalFunctions = true
-	// Enable experimental duration expression parsing.
-	ExperimentalDurationExpr = true
-	t.Cleanup(func() {
-		EnableExperimentalFunctions = false
-		ExperimentalDurationExpr = false
+	opts := WithOptions(Options{
+		EnableExperimentalFunctions: true,
+		ExperimentalDurationExpr:    true,
 	})
 
 	for _, test := range testExpr {
 		t.Run(readable(test.input), func(t *testing.T) {
-			expr, err := ParseExpr(test.input)
+			expr, err := ParseExpr(test.input, opts)
 
 			// Unexpected errors are always caused by a bug.
 			require.NotEqual(t, err, errUnexpected, "unexpected error occurred")

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
+var testParser = NewParser(Options{})
+
 func repeatError(query string, err error, start, startStep, end, endStep, count int) (errs ParseErrors) {
 	for i := range count {
 		errs = append(errs, ParseErr{
@@ -5297,14 +5299,14 @@ func readable(s string) string {
 }
 
 func TestParseExpressions(t *testing.T) {
-	opts := WithOptions(Options{
+	optsParser := NewParser(Options{
 		EnableExperimentalFunctions: true,
 		ExperimentalDurationExpr:    true,
 	})
 
 	for _, test := range testExpr {
 		t.Run(readable(test.input), func(t *testing.T) {
-			expr, err := ParseExpr(test.input, opts)
+			expr, err := optsParser.ParseExpr(test.input)
 
 			// Unexpected errors are always caused by a bug.
 			require.NotEqual(t, err, errUnexpected, "unexpected error occurred")
@@ -5432,7 +5434,7 @@ func TestParseSeriesDesc(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			l, v, err := ParseSeriesDesc(tc.input)
+			l, v, err := testParser.ParseSeriesDesc(tc.input)
 			if tc.expectError != "" {
 				require.Contains(t, err.Error(), tc.expectError)
 			} else {
@@ -5446,7 +5448,7 @@ func TestParseSeriesDesc(t *testing.T) {
 
 // NaN has no equality. Thus, we need a separate test for it.
 func TestNaNExpression(t *testing.T) {
-	expr, err := ParseExpr("NaN")
+	expr, err := testParser.ParseExpr("NaN")
 	require.NoError(t, err)
 
 	nl, ok := expr.(*NumberLiteral)
@@ -5874,7 +5876,7 @@ func TestParseHistogramSeries(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, vals, err := ParseSeriesDesc(test.input)
+			_, vals, err := testParser.ParseSeriesDesc(test.input)
 			if test.expectedError != "" {
 				require.EqualError(t, err, test.expectedError)
 				return
@@ -5946,7 +5948,7 @@ func TestHistogramTestExpression(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			expression := test.input.TestExpression()
 			require.Equal(t, test.expected, expression)
-			_, vals, err := ParseSeriesDesc("{} " + expression)
+			_, vals, err := testParser.ParseSeriesDesc("{} " + expression)
 			require.NoError(t, err)
 			require.Len(t, vals, 1)
 			canonical := vals[0].Histogram
@@ -5958,7 +5960,7 @@ func TestHistogramTestExpression(t *testing.T) {
 
 func TestParseSeries(t *testing.T) {
 	for _, test := range testSeries {
-		metric, vals, err := ParseSeriesDesc(test.input)
+		metric, vals, err := testParser.ParseSeriesDesc(test.input)
 
 		// Unexpected errors are always caused by a bug.
 		require.NotEqual(t, err, errUnexpected, "unexpected error occurred")
@@ -5974,7 +5976,7 @@ func TestParseSeries(t *testing.T) {
 }
 
 func TestRecoverParserRuntime(t *testing.T) {
-	p := NewParser("foo bar")
+	p := newParser("foo bar", Options{})
 	var err error
 
 	defer func() {
@@ -5987,7 +5989,7 @@ func TestRecoverParserRuntime(t *testing.T) {
 }
 
 func TestRecoverParserError(t *testing.T) {
-	p := NewParser("foo bar")
+	p := newParser("foo bar", Options{})
 	var err error
 
 	e := errors.New("custom error")
@@ -6022,12 +6024,12 @@ func TestExtractSelectors(t *testing.T) {
 			[]string{},
 		},
 	} {
-		expr, err := ParseExpr(tc.input)
+		expr, err := testParser.ParseExpr(tc.input)
 		require.NoError(t, err)
 
 		var expected [][]*labels.Matcher
 		for _, s := range tc.expected {
-			selector, err := ParseMetricSelector(s)
+			selector, err := testParser.ParseMetricSelector(s)
 			require.NoError(t, err)
 			expected = append(expected, selector)
 		}
@@ -6044,11 +6046,37 @@ func TestParseCustomFunctions(t *testing.T) {
 		ReturnType: ValueTypeVector,
 	}
 	input := "custom_func(metric[1m])"
-	p := NewParser(input, WithFunctions(funcs))
-	expr, err := p.ParseExpr()
+	p := newParserWithFunctions(input, Options{}, funcs)
+	expr, err := p.parseExpr()
 	require.NoError(t, err)
 
 	call, ok := expr.(*Call)
 	require.True(t, ok)
 	require.Equal(t, "custom_func", call.Func.Name)
+}
+
+func TestNewParser(t *testing.T) {
+	p := NewParser(Options{
+		EnableExperimentalFunctions: true,
+		ExperimentalDurationExpr:    true,
+	})
+
+	// ParseExpr should work.
+	expr, err := p.ParseExpr("up")
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+
+	// ParseMetricSelector should work.
+	matchers, err := p.ParseMetricSelector(`{job="prometheus"}`)
+	require.NoError(t, err)
+	require.Len(t, matchers, 1)
+
+	// ParseMetricSelectors should work.
+	matcherSets, err := p.ParseMetricSelectors([]string{`{job="prometheus"}`, `{job="grafana"}`})
+	require.NoError(t, err)
+	require.Len(t, matcherSets, 2)
+
+	// Invalid input should return errors.
+	_, err = p.ParseExpr("===")
+	require.Error(t, err)
 }

--- a/promql/parser/prettier_test.go
+++ b/promql/parser/prettier_test.go
@@ -114,7 +114,7 @@ task:errors:rate10s{job="s"}))`,
 		},
 	}
 	for _, test := range inputs {
-		expr, err := ParseExpr(test.in)
+		expr, err := testParser.ParseExpr(test.in)
 		require.NoError(t, err)
 
 		require.Equal(t, test.out, Prettify(expr))
@@ -185,7 +185,7 @@ func TestBinaryExprPretty(t *testing.T) {
 	}
 	for _, test := range inputs {
 		t.Run(test.in, func(t *testing.T) {
-			expr, err := ParseExpr(test.in)
+			expr, err := testParser.ParseExpr(test.in)
 			require.NoError(t, err)
 
 			require.Equal(t, test.out, Prettify(expr))
@@ -261,7 +261,7 @@ func TestCallExprPretty(t *testing.T) {
 		},
 	}
 	for _, test := range inputs {
-		expr, err := ParseExpr(test.in)
+		expr, err := testParser.ParseExpr(test.in)
 		require.NoError(t, err)
 
 		fmt.Println("=>", expr.String())
@@ -308,7 +308,7 @@ func TestParenExprPretty(t *testing.T) {
 		},
 	}
 	for _, test := range inputs {
-		expr, err := ParseExpr(test.in)
+		expr, err := testParser.ParseExpr(test.in)
 		require.NoError(t, err)
 
 		require.Equal(t, test.out, Prettify(expr))
@@ -334,7 +334,7 @@ func TestStepInvariantExpr(t *testing.T) {
 		},
 	}
 	for _, test := range inputs {
-		expr, err := ParseExpr(test.in)
+		expr, err := testParser.ParseExpr(test.in)
 		require.NoError(t, err)
 
 		require.Equal(t, test.out, Prettify(expr))
@@ -594,7 +594,7 @@ or
 		},
 	}
 	for _, test := range inputs {
-		expr, err := ParseExpr(test.in)
+		expr, err := testParser.ParseExpr(test.in)
 		require.NoError(t, err)
 		require.Equal(t, test.out, Prettify(expr))
 	}
@@ -662,7 +662,7 @@ func TestUnaryPretty(t *testing.T) {
 	}
 	for _, test := range inputs {
 		t.Run(test.in, func(t *testing.T) {
-			expr, err := ParseExpr(test.in)
+			expr, err := testParser.ParseExpr(test.in)
 			require.NoError(t, err)
 			require.Equal(t, test.out, Prettify(expr))
 		})
@@ -670,7 +670,7 @@ func TestUnaryPretty(t *testing.T) {
 }
 
 func TestDurationExprPretty(t *testing.T) {
-	opts := WithOptions(Options{ExperimentalDurationExpr: true})
+	optsParser := NewParser(Options{ExperimentalDurationExpr: true})
 	maxCharactersPerLine = 10
 	inputs := []struct {
 		in, out string
@@ -696,7 +696,7 @@ func TestDurationExprPretty(t *testing.T) {
 	}
 	for _, test := range inputs {
 		t.Run(test.in, func(t *testing.T) {
-			expr, err := ParseExpr(test.in, opts)
+			expr, err := optsParser.ParseExpr(test.in)
 			require.NoError(t, err)
 			require.Equal(t, test.out, Prettify(expr))
 		})

--- a/promql/parser/prettier_test.go
+++ b/promql/parser/prettier_test.go
@@ -670,11 +670,7 @@ func TestUnaryPretty(t *testing.T) {
 }
 
 func TestDurationExprPretty(t *testing.T) {
-	// Enable experimental duration expression parsing.
-	ExperimentalDurationExpr = true
-	t.Cleanup(func() {
-		ExperimentalDurationExpr = false
-	})
+	opts := WithOptions(Options{ExperimentalDurationExpr: true})
 	maxCharactersPerLine = 10
 	inputs := []struct {
 		in, out string
@@ -700,7 +696,7 @@ func TestDurationExprPretty(t *testing.T) {
 	}
 	for _, test := range inputs {
 		t.Run(test.in, func(t *testing.T) {
-			expr, err := ParseExpr(test.in)
+			expr, err := ParseExpr(test.in, opts)
 			require.NoError(t, err)
 			require.Equal(t, test.out, Prettify(expr))
 		})

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestExprString(t *testing.T) {
-	optsExtended := WithOptions(Options{
+	optsParser := NewParser(Options{
 		ExperimentalDurationExpr:     true,
 		EnableExtendedRangeSelectors: true,
 		EnableBinopFillModifiers:     true,
@@ -321,7 +321,7 @@ func TestExprString(t *testing.T) {
 
 	for _, test := range inputs {
 		t.Run(test.in, func(t *testing.T) {
-			expr, err := ParseExpr(test.in, optsExtended)
+			expr, err := optsParser.ParseExpr(test.in)
 			require.NoError(t, err)
 
 			exp := test.in
@@ -346,7 +346,7 @@ func BenchmarkExprString(b *testing.B) {
 
 	for _, test := range inputs {
 		b.Run(readable(test), func(b *testing.B) {
-			expr, err := ParseExpr(test)
+			expr, err := testParser.ParseExpr(test)
 			require.NoError(b, err)
 			for b.Loop() {
 				_ = expr.String()
@@ -478,7 +478,7 @@ func TestBinaryExprUTF8Labels(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			expr, err := ParseExpr(tc.input)
+			expr, err := testParser.ParseExpr(tc.input)
 			if err != nil {
 				t.Fatalf("Failed to parse: %v", err)
 			}

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -22,11 +22,10 @@ import (
 )
 
 func TestExprString(t *testing.T) {
-	ExperimentalDurationExpr = true
-	EnableBinopFillModifiers = true
-	t.Cleanup(func() {
-		ExperimentalDurationExpr = false
-		EnableBinopFillModifiers = false
+	optsExtended := WithOptions(Options{
+		ExperimentalDurationExpr:     true,
+		EnableExtendedRangeSelectors: true,
+		EnableBinopFillModifiers:     true,
 	})
 	// A list of valid expressions that are expected to be
 	// returned as out when calling String(). If out is empty the output
@@ -320,14 +319,9 @@ func TestExprString(t *testing.T) {
 		},
 	}
 
-	EnableExtendedRangeSelectors = true
-	t.Cleanup(func() {
-		EnableExtendedRangeSelectors = false
-	})
-
 	for _, test := range inputs {
 		t.Run(test.in, func(t *testing.T) {
-			expr, err := ParseExpr(test.in)
+			expr, err := ParseExpr(test.in, optsExtended)
 			require.NoError(t, err)
 
 			exp := test.in

--- a/promql/promql_test.go
+++ b/promql/promql_test.go
@@ -40,15 +40,15 @@ func TestEvaluations(t *testing.T) {
 func TestConcurrentRangeQueries(t *testing.T) {
 	stor := teststorage.New(t)
 
-	parser.SetDefaultOptions(parser.Options{
-		EnableExperimentalFunctions:  true,
-		EnableExtendedRangeSelectors: true,
-	})
 	opts := promql.EngineOpts{
 		Logger:     nil,
 		Reg:        nil,
 		MaxSamples: 50000000,
 		Timeout:    100 * time.Second,
+		Parser: parser.NewParser(parser.Options{
+			EnableExperimentalFunctions:  true,
+			EnableExtendedRangeSelectors: true,
+		}),
 	}
 	engine := promqltest.NewTestEngineWithOpts(t, opts)
 

--- a/promql/promql_test.go
+++ b/promql/promql_test.go
@@ -40,15 +40,15 @@ func TestEvaluations(t *testing.T) {
 func TestConcurrentRangeQueries(t *testing.T) {
 	stor := teststorage.New(t)
 
+	parser.SetDefaultOptions(parser.Options{
+		EnableExperimentalFunctions:  true,
+		EnableExtendedRangeSelectors: true,
+	})
 	opts := promql.EngineOpts{
 		Logger:     nil,
 		Reg:        nil,
 		MaxSamples: 50000000,
 		Timeout:    100 * time.Second,
-		ParserOptions: parser.Options{
-			EnableExperimentalFunctions:  true,
-			EnableExtendedRangeSelectors: true,
-		},
 	}
 	engine := promqltest.NewTestEngineWithOpts(t, opts)
 

--- a/promql/promql_test.go
+++ b/promql/promql_test.go
@@ -45,14 +45,11 @@ func TestConcurrentRangeQueries(t *testing.T) {
 		Reg:        nil,
 		MaxSamples: 50000000,
 		Timeout:    100 * time.Second,
+		ParserOptions: parser.Options{
+			EnableExperimentalFunctions:  true,
+			EnableExtendedRangeSelectors: true,
+		},
 	}
-	// Enable experimental functions testing
-	parser.EnableExperimentalFunctions = true
-	parser.EnableExtendedRangeSelectors = true
-	t.Cleanup(func() {
-		parser.EnableExperimentalFunctions = false
-		parser.EnableExtendedRangeSelectors = false
-	})
 	engine := promqltest.NewTestEngineWithOpts(t, opts)
 
 	const interval = 10000 // 10s interval.

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -88,6 +88,12 @@ func LoadedStorage(t testing.TB, input string) *teststorage.TestStorage {
 
 // NewTestEngine creates a promql.Engine with enablePerStepStats, lookbackDelta and maxSamples, and returns it.
 func NewTestEngine(tb testing.TB, enablePerStepStats bool, lookbackDelta time.Duration, maxSamples int) *promql.Engine {
+	parser.SetDefaultOptions(parser.Options{
+		EnableExperimentalFunctions:  true,
+		ExperimentalDurationExpr:     true,
+		EnableExtendedRangeSelectors: true,
+		EnableBinopFillModifiers:     true,
+	})
 	return NewTestEngineWithOpts(tb, promql.EngineOpts{
 		Logger:                   nil,
 		Reg:                      nil,
@@ -99,12 +105,6 @@ func NewTestEngine(tb testing.TB, enablePerStepStats bool, lookbackDelta time.Du
 		EnablePerStepStats:       enablePerStepStats,
 		LookbackDelta:            lookbackDelta,
 		EnableDelayedNameRemoval: true,
-		ParserOptions: parser.Options{
-			EnableExperimentalFunctions:  true,
-			ExperimentalDurationExpr:     true,
-			EnableExtendedRangeSelectors: true,
-			EnableBinopFillModifiers:     true,
-		},
 	})
 }
 

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -115,7 +115,7 @@ func TestAlertingRuleTemplateWithHistogram(t *testing.T) {
 		return []promql.Sample{{H: &h}}, nil
 	}
 
-	expr, err := parser.ParseExpr("foo")
+	expr, err := testParser.ParseExpr("foo")
 	require.NoError(t, err)
 
 	rule := NewAlertingRule(
@@ -159,7 +159,7 @@ func TestAlertingRuleLabelsUpdate(t *testing.T) {
 			http_requests{job="app-server", instance="0"}	75 85 70 70 stale
 	`)
 
-	expr, err := parser.ParseExpr(`http_requests < 100`)
+	expr, err := testParser.ParseExpr(`http_requests < 100`)
 	require.NoError(t, err)
 
 	rule := NewAlertingRule(
@@ -264,7 +264,7 @@ func TestAlertingRuleExternalLabelsInTemplate(t *testing.T) {
 			http_requests{job="app-server", instance="0"}	75 85 70 70
 	`)
 
-	expr, err := parser.ParseExpr(`http_requests < 100`)
+	expr, err := testParser.ParseExpr(`http_requests < 100`)
 	require.NoError(t, err)
 
 	ruleWithoutExternalLabels := NewAlertingRule(
@@ -358,7 +358,7 @@ func TestAlertingRuleExternalURLInTemplate(t *testing.T) {
 			http_requests{job="app-server", instance="0"}	75 85 70 70
 	`)
 
-	expr, err := parser.ParseExpr(`http_requests < 100`)
+	expr, err := testParser.ParseExpr(`http_requests < 100`)
 	require.NoError(t, err)
 
 	ruleWithoutExternalURL := NewAlertingRule(
@@ -452,7 +452,7 @@ func TestAlertingRuleEmptyLabelFromTemplate(t *testing.T) {
 			http_requests{job="app-server", instance="0"}	75 85 70 70
 	`)
 
-	expr, err := parser.ParseExpr(`http_requests < 100`)
+	expr, err := testParser.ParseExpr(`http_requests < 100`)
 	require.NoError(t, err)
 
 	rule := NewAlertingRule(
@@ -507,7 +507,7 @@ func TestAlertingRuleQueryInTemplate(t *testing.T) {
 			http_requests{job="app-server", instance="0"}	70 85 70 70
 	`)
 
-	expr, err := parser.ParseExpr(`sum(http_requests) < 100`)
+	expr, err := testParser.ParseExpr(`sum(http_requests) < 100`)
 	require.NoError(t, err)
 
 	ruleWithQueryInTemplate := NewAlertingRule(
@@ -592,7 +592,7 @@ func TestAlertingRuleDuplicate(t *testing.T) {
 
 	now := time.Now()
 
-	expr, _ := parser.ParseExpr(`vector(0) or label_replace(vector(0),"test","x","","")`)
+	expr, _ := testParser.ParseExpr(`vector(0) or label_replace(vector(0),"test","x","","")`)
 	rule := NewAlertingRule(
 		"foo",
 		expr,
@@ -635,7 +635,7 @@ func TestAlertingRuleLimit(t *testing.T) {
 		},
 	}
 
-	expr, _ := parser.ParseExpr(`metric > 0`)
+	expr, _ := testParser.ParseExpr(`metric > 0`)
 	rule := NewAlertingRule(
 		"foo",
 		expr,
@@ -758,7 +758,7 @@ func TestSendAlertsDontAffectActiveAlerts(t *testing.T) {
 	al := &Alert{State: StateFiring, Labels: lbls, ActiveAt: time.Now()}
 	rule.active[h] = al
 
-	expr, err := parser.ParseExpr("foo")
+	expr, err := testParser.ParseExpr("foo")
 	require.NoError(t, err)
 	rule.vector = expr
 
@@ -799,7 +799,7 @@ func TestKeepFiringFor(t *testing.T) {
 			http_requests{job="app-server", instance="0"}	75 85 70 70 10x5
 	`)
 
-	expr, err := parser.ParseExpr(`http_requests > 50`)
+	expr, err := testParser.ParseExpr(`http_requests > 50`)
 	require.NoError(t, err)
 
 	rule := NewAlertingRule(
@@ -909,7 +909,7 @@ func TestPendingAndKeepFiringFor(t *testing.T) {
 			http_requests{job="app-server", instance="0"}	75 10x10
 	`)
 
-	expr, err := parser.ParseExpr(`http_requests > 50`)
+	expr, err := testParser.ParseExpr(`http_requests > 50`)
 	require.NoError(t, err)
 
 	rule := NewAlertingRule(
@@ -969,7 +969,7 @@ func TestAlertingEvalWithOrigin(t *testing.T) {
 		lbs    = labels.FromStrings("test", "test")
 	)
 
-	expr, err := parser.ParseExpr(query)
+	expr, err := testParser.ParseExpr(query)
 	require.NoError(t, err)
 
 	rule := NewAlertingRule(

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -138,6 +138,9 @@ type ManagerOptions struct {
 
 	// FeatureRegistry is used to register rule manager features.
 	FeatureRegistry features.Collector
+
+	// Parser is the PromQL parser used for parsing rule expressions.
+	Parser parser.Parser
 }
 
 // NewManager returns an implementation of Manager, ready to be started
@@ -158,8 +161,12 @@ func NewManager(o *ManagerOptions) *Manager {
 		o.Metrics = NewGroupMetrics(o.Registerer)
 	}
 
+	if o.Parser == nil {
+		o.Parser = parser.NewParser(parser.Options{})
+	}
+
 	if o.GroupLoader == nil {
-		o.GroupLoader = FileLoader{}
+		o.GroupLoader = FileLoader{parser: o.Parser}
 	}
 
 	if o.RuleConcurrencyController == nil {
@@ -320,15 +327,17 @@ type GroupLoader interface {
 }
 
 // FileLoader is the default GroupLoader implementation. It defers to rulefmt.ParseFile
-// and parser.ParseExpr and parser.DefaultOptions.
-type FileLoader struct{}
-
-func (FileLoader) Load(identifier string, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) (*rulefmt.RuleGroups, []error) {
-	return rulefmt.ParseFile(identifier, ignoreUnknownFields, nameValidationScheme)
+// for loading and uses the configured Parser for expression parsing.
+type FileLoader struct {
+	parser parser.Parser
 }
 
-func (FileLoader) Parse(query string) (parser.Expr, error) {
-	return parser.ParseExpr(query)
+func (fl FileLoader) Load(identifier string, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) (*rulefmt.RuleGroups, []error) {
+	return rulefmt.ParseFile(identifier, ignoreUnknownFields, nameValidationScheme, fl.parser)
+}
+
+func (fl FileLoader) Parse(query string) (parser.Expr, error) {
+	return fl.parser.ParseExpr(query)
 }
 
 // LoadGroups reads groups from a list of files.
@@ -608,7 +617,7 @@ func FromMaps(maps ...map[string]string) labels.Labels {
 }
 
 // ParseFiles parses the rule files corresponding to glob patterns.
-func ParseFiles(patterns []string, nameValidationScheme model.ValidationScheme) error {
+func ParseFiles(patterns []string, nameValidationScheme model.ValidationScheme, p parser.Parser) error {
 	files := map[string]string{}
 	for _, pat := range patterns {
 		fns, err := filepath.Glob(pat)
@@ -628,7 +637,7 @@ func ParseFiles(patterns []string, nameValidationScheme model.ValidationScheme) 
 		}
 	}
 	for fn, pat := range files {
-		_, errs := rulefmt.ParseFile(fn, false, nameValidationScheme)
+		_, errs := rulefmt.ParseFile(fn, false, nameValidationScheme, p)
 		if len(errs) > 0 {
 			return fmt.Errorf("parse rules from file %q (pattern: %q): %w", fn, pat, errors.Join(errs...))
 		}

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -327,8 +327,8 @@ type FileLoader struct {
 	ParserOptions parser.Options
 }
 
-func (FileLoader) Load(identifier string, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) (*rulefmt.RuleGroups, []error) {
-	return rulefmt.ParseFile(identifier, ignoreUnknownFields, nameValidationScheme)
+func (fl FileLoader) Load(identifier string, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) (*rulefmt.RuleGroups, []error) {
+	return rulefmt.ParseFile(identifier, ignoreUnknownFields, nameValidationScheme, fl.ParserOptions)
 }
 
 func (fl FileLoader) Parse(query string) (parser.Expr, error) {
@@ -632,7 +632,7 @@ func ParseFiles(patterns []string, nameValidationScheme model.ValidationScheme) 
 		}
 	}
 	for fn, pat := range files {
-		_, errs := rulefmt.ParseFile(fn, false, nameValidationScheme)
+		_, errs := rulefmt.ParseFile(fn, false, nameValidationScheme, parser.Options{})
 		if len(errs) > 0 {
 			return fmt.Errorf("parse rules from file %q (pattern: %q): %w", fn, pat, errors.Join(errs...))
 		}

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -809,7 +809,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	// Groups will be recreated if updated.
-	rgs, errs := rulefmt.ParseFile("fixtures/rules.yaml", false, model.UTF8Validation, parser.Options{})
+	rgs, errs := rulefmt.ParseFile("fixtures/rules.yaml", false, model.UTF8Validation)
 	require.Empty(t, errs, "file parsing failures")
 
 	tmpFile, err := os.CreateTemp("", "rules.test.*.yaml")

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -809,7 +809,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	// Groups will be recreated if updated.
-	rgs, errs := rulefmt.ParseFile("fixtures/rules.yaml", false, model.UTF8Validation)
+	rgs, errs := rulefmt.ParseFile("fixtures/rules.yaml", false, model.UTF8Validation, parser.Options{})
 	require.Empty(t, errs, "file parsing failures")
 
 	tmpFile, err := os.CreateTemp("", "rules.test.*.yaml")

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -29,10 +29,12 @@ import (
 	"github.com/prometheus/prometheus/util/testutil"
 )
 
+var testParser = parser.NewParser(parser.Options{})
+
 var (
 	ruleEvaluationTime       = time.Unix(0, 0).UTC()
-	exprWithMetricName, _    = parser.ParseExpr(`sort(metric)`)
-	exprWithoutMetricName, _ = parser.ParseExpr(`sort(metric + metric)`)
+	exprWithMetricName, _    = testParser.ParseExpr(`sort(metric)`)
+	exprWithoutMetricName, _ = testParser.ParseExpr(`sort(metric + metric)`)
 )
 
 var ruleEvalTestScenarios = []struct {
@@ -170,7 +172,7 @@ func TestRuleEvalDuplicate(t *testing.T) {
 
 	now := time.Now()
 
-	expr, _ := parser.ParseExpr(`vector(0) or label_replace(vector(0),"test","x","","")`)
+	expr, _ := testParser.ParseExpr(`vector(0) or label_replace(vector(0),"test","x","","")`)
 	rule := NewRecordingRule("foo", expr, labels.FromStrings("test", "test"))
 	_, err := rule.Eval(ctx, 0, now, EngineQueryFunc(engine, storage), nil, 0)
 	require.Error(t, err)
@@ -203,7 +205,7 @@ func TestRecordingRuleLimit(t *testing.T) {
 		},
 	}
 
-	expr, _ := parser.ParseExpr(`metric > 0`)
+	expr, _ := testParser.ParseExpr(`metric > 0`)
 	rule := NewRecordingRule(
 		"foo",
 		expr,
@@ -238,7 +240,7 @@ func TestRecordingEvalWithOrigin(t *testing.T) {
 		lbs    = labels.FromStrings("foo", "bar")
 	)
 
-	expr, err := parser.ParseExpr(query)
+	expr, err := testParser.ParseExpr(query)
 	require.NoError(t, err)
 
 	rule := NewRecordingRule(name, expr, lbs)

--- a/util/fuzzing/corpus.go
+++ b/util/fuzzing/corpus.go
@@ -14,7 +14,6 @@
 package fuzzing
 
 import (
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 )
 
@@ -58,18 +57,6 @@ func GetCorpusForFuzzParseMetricSelector() []string {
 
 // GetCorpusForFuzzParseExpr returns the seed corpus for FuzzParseExpr.
 func GetCorpusForFuzzParseExpr() ([]string, error) {
-	// Save original values and restore them after parsing test expressions.
-	defer func(funcs, durationExpr, rangeSelectors bool) {
-		parser.EnableExperimentalFunctions = funcs
-		parser.ExperimentalDurationExpr = durationExpr
-		parser.EnableExtendedRangeSelectors = rangeSelectors
-	}(parser.EnableExperimentalFunctions, parser.ExperimentalDurationExpr, parser.EnableExtendedRangeSelectors)
-
-	// Enable experimental features to parse all test expressions.
-	parser.EnableExperimentalFunctions = true
-	parser.ExperimentalDurationExpr = true
-	parser.EnableExtendedRangeSelectors = true
-
 	// Get built-in test expressions.
 	builtInExprs, err := promqltest.GetBuiltInExprs()
 	if err != nil {

--- a/util/fuzzing/fuzz_test.go
+++ b/util/fuzzing/fuzz_test.go
@@ -117,17 +117,6 @@ func FuzzParseMetricSelector(f *testing.F) {
 
 // FuzzParseExpr fuzzes the expression parser.
 func FuzzParseExpr(f *testing.F) {
-	parser.EnableExperimentalFunctions = true
-	parser.ExperimentalDurationExpr = true
-	parser.EnableExtendedRangeSelectors = true
-	parser.EnableBinopFillModifiers = true
-	f.Cleanup(func() {
-		parser.EnableExperimentalFunctions = false
-		parser.ExperimentalDurationExpr = false
-		parser.EnableExtendedRangeSelectors = false
-		parser.EnableBinopFillModifiers = false
-	})
-
 	// Add seed corpus from built-in test expressions
 	corpus, err := GetCorpusForFuzzParseExpr()
 	if err != nil {
@@ -141,11 +130,17 @@ func FuzzParseExpr(f *testing.F) {
 		f.Add(expr)
 	}
 
+	parserOpts := parser.WithOptions(parser.Options{
+		EnableExperimentalFunctions:  true,
+		ExperimentalDurationExpr:     true,
+		EnableExtendedRangeSelectors: true,
+		EnableBinopFillModifiers:     true,
+	})
 	f.Fuzz(func(t *testing.T, in string) {
 		if len(in) > maxInputSize {
 			t.Skip()
 		}
-		_, err := parser.ParseExpr(in)
+		_, err := parser.ParseExpr(in, parserOpts)
 		// We don't care about errors, just that we don't panic.
 		_ = err
 	})

--- a/util/fuzzing/fuzz_test.go
+++ b/util/fuzzing/fuzz_test.go
@@ -33,6 +33,8 @@ const (
 // Use package-scope symbol table to avoid memory allocation on every fuzzing operation.
 var symbolTable = labels.NewSymbolTable()
 
+var fuzzParser = parser.NewParser(parser.Options{})
+
 // FuzzParseMetricText fuzzes the metric parser with "text/plain" content type.
 //
 // Note that this is not the parser for the text-based exposition-format; that
@@ -109,7 +111,7 @@ func FuzzParseMetricSelector(f *testing.F) {
 		if len(in) > maxInputSize {
 			t.Skip()
 		}
-		_, err := parser.ParseMetricSelector(in)
+		_, err := fuzzParser.ParseMetricSelector(in)
 		// We don't care about errors, just that we don't panic.
 		_ = err
 	})
@@ -130,7 +132,7 @@ func FuzzParseExpr(f *testing.F) {
 		f.Add(expr)
 	}
 
-	parserOpts := parser.WithOptions(parser.Options{
+	p := parser.NewParser(parser.Options{
 		EnableExperimentalFunctions:  true,
 		ExperimentalDurationExpr:     true,
 		EnableExtendedRangeSelectors: true,
@@ -140,7 +142,7 @@ func FuzzParseExpr(f *testing.F) {
 		if len(in) > maxInputSize {
 			t.Skip()
 		}
-		_, err := parser.ParseExpr(in, parserOpts)
+		_, err := p.ParseExpr(in)
 		// We don't care about errors, just that we don't panic.
 		_ = err
 	})

--- a/web/api/testhelpers/fixtures.go
+++ b/web/api/testhelpers/fixtures.go
@@ -25,6 +25,8 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
+var testParser = parser.NewParser(parser.Options{})
+
 // FixtureSeries creates a simple series with the "up" metric.
 func FixtureSeries() []storage.Series {
 	// Use timestamps relative to "now" so queries work.
@@ -73,7 +75,7 @@ func FixtureMultipleSeries() []storage.Series {
 // FixtureRuleGroups creates a simple set of rule groups for testing.
 func FixtureRuleGroups() []*rules.Group {
 	// Create a simple recording rule.
-	expr, _ := parser.ParseExpr("up == 1")
+	expr, _ := testParser.ParseExpr("up == 1")
 	recordingRule := rules.NewRecordingRule(
 		"job:up:sum",
 		expr,
@@ -81,7 +83,7 @@ func FixtureRuleGroups() []*rules.Group {
 	)
 
 	// Create a simple alerting rule.
-	alertExpr, _ := parser.ParseExpr("up == 0")
+	alertExpr, _ := testParser.ParseExpr("up == 0")
 	alertingRule := rules.NewAlertingRule(
 		"InstanceDown",
 		alertExpr,

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -257,6 +257,7 @@ type API struct {
 
 	codecs []Codec
 
+	parserOptions   parser.Options
 	featureRegistry features.Collector
 	openAPIBuilder  *OpenAPIBuilder
 }
@@ -299,6 +300,7 @@ func NewAPI(
 	enableTypeAndUnitLabels bool,
 	appendMetadata bool,
 	overrideErrorCode OverrideErrorCode,
+	parserOptions parser.Options,
 	featureRegistry features.Collector,
 	openAPIOptions OpenAPIOptions,
 ) *API {
@@ -330,6 +332,7 @@ func NewAPI(
 		notificationsGetter: notificationsGetter,
 		notificationsSub:    notificationsSub,
 		overrideErrorCode:   overrideErrorCode,
+		parserOptions:       parserOptions,
 		featureRegistry:     featureRegistry,
 		openAPIBuilder:      NewOpenAPIBuilder(openAPIOptions, logger),
 
@@ -560,8 +563,8 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 	}, nil, warnings, qry.Close}
 }
 
-func (*API) formatQuery(r *http.Request) (result apiFuncResult) {
-	expr, err := parser.ParseExpr(r.FormValue("query"))
+func (api *API) formatQuery(r *http.Request) (result apiFuncResult) {
+	expr, err := parser.ParseExpr(r.FormValue("query"), parser.WithOptions(api.parserOptions))
 	if err != nil {
 		return invalidParamError(err, "query")
 	}
@@ -569,8 +572,8 @@ func (*API) formatQuery(r *http.Request) (result apiFuncResult) {
 	return apiFuncResult{expr.Pretty(0), nil, nil, nil}
 }
 
-func (*API) parseQuery(r *http.Request) apiFuncResult {
-	expr, err := parser.ParseExpr(r.FormValue("query"))
+func (api *API) parseQuery(r *http.Request) apiFuncResult {
+	expr, err := parser.ParseExpr(r.FormValue("query"), parser.WithOptions(api.parserOptions))
 	if err != nil {
 		return invalidParamError(err, "query")
 	}
@@ -699,7 +702,7 @@ func (api *API) queryExemplars(r *http.Request) apiFuncResult {
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
 
-	expr, err := parser.ParseExpr(r.FormValue("query"))
+	expr, err := parser.ParseExpr(r.FormValue("query"), parser.WithOptions(api.parserOptions))
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -257,7 +257,6 @@ type API struct {
 
 	codecs []Codec
 
-	parserOptions   parser.Options
 	featureRegistry features.Collector
 	openAPIBuilder  *OpenAPIBuilder
 }
@@ -300,7 +299,6 @@ func NewAPI(
 	enableTypeAndUnitLabels bool,
 	appendMetadata bool,
 	overrideErrorCode OverrideErrorCode,
-	parserOptions parser.Options,
 	featureRegistry features.Collector,
 	openAPIOptions OpenAPIOptions,
 ) *API {
@@ -332,7 +330,6 @@ func NewAPI(
 		notificationsGetter: notificationsGetter,
 		notificationsSub:    notificationsSub,
 		overrideErrorCode:   overrideErrorCode,
-		parserOptions:       parserOptions,
 		featureRegistry:     featureRegistry,
 		openAPIBuilder:      NewOpenAPIBuilder(openAPIOptions, logger),
 
@@ -563,8 +560,8 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 	}, nil, warnings, qry.Close}
 }
 
-func (api *API) formatQuery(r *http.Request) (result apiFuncResult) {
-	expr, err := parser.ParseExpr(r.FormValue("query"), parser.WithOptions(api.parserOptions))
+func (*API) formatQuery(r *http.Request) (result apiFuncResult) {
+	expr, err := parser.ParseExpr(r.FormValue("query"))
 	if err != nil {
 		return invalidParamError(err, "query")
 	}
@@ -572,8 +569,8 @@ func (api *API) formatQuery(r *http.Request) (result apiFuncResult) {
 	return apiFuncResult{expr.Pretty(0), nil, nil, nil}
 }
 
-func (api *API) parseQuery(r *http.Request) apiFuncResult {
-	expr, err := parser.ParseExpr(r.FormValue("query"), parser.WithOptions(api.parserOptions))
+func (*API) parseQuery(r *http.Request) apiFuncResult {
+	expr, err := parser.ParseExpr(r.FormValue("query"))
 	if err != nil {
 		return invalidParamError(err, "query")
 	}
@@ -702,7 +699,7 @@ func (api *API) queryExemplars(r *http.Request) apiFuncResult {
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}
 
-	expr, err := parser.ParseExpr(r.FormValue("query"), parser.WithOptions(api.parserOptions))
+	expr, err := parser.ParseExpr(r.FormValue("query"))
 	if err != nil {
 		return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
 	}

--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
@@ -170,6 +171,7 @@ func createPrometheusAPI(t *testing.T, q storage.SampleAndChunkQueryable, overri
 		overrideErrorCode,
 		nil,
 		OpenAPIOptions{},
+		parser.NewParser(parser.Options{}),
 	)
 
 	promRouter := route.New().WithPrefix("/api/v1")

--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
@@ -168,6 +169,7 @@ func createPrometheusAPI(t *testing.T, q storage.SampleAndChunkQueryable, overri
 		false,
 		false,
 		overrideErrorCode,
+		parser.Options{},
 		nil,
 		OpenAPIOptions{},
 	)

--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
@@ -169,7 +168,6 @@ func createPrometheusAPI(t *testing.T, q storage.SampleAndChunkQueryable, overri
 		false,
 		false,
 		overrideErrorCode,
-		parser.Options{},
 		nil,
 		OpenAPIOptions{},
 	)

--- a/web/api/v1/test_helpers.go
+++ b/web/api/v1/test_helpers.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/prometheus/common/route"
 
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/web/api/testhelpers"
 )
 
@@ -90,19 +91,20 @@ func newTestAPI(t *testing.T, cfg testhelpers.APIConfig) *testhelpers.APIWrapper
 		params.NotificationsSub,
 		params.Gatherer,
 		params.Registerer,
-		nil,              // statsRenderer
-		false,            // rwEnabled
-		nil,              // acceptRemoteWriteProtoMsgs
-		false,            // otlpEnabled
-		false,            // otlpDeltaToCumulative
-		false,            // otlpNativeDeltaIngestion
-		false,            // stZeroIngestionEnabled
-		5*time.Minute,    // lookbackDelta
-		false,            // enableTypeAndUnitLabels
-		false,            // appendMetadata
-		nil,              // overrideErrorCode
-		nil,              // featureRegistry
-		OpenAPIOptions{}, // openAPIOptions
+		nil,                                // statsRenderer
+		false,                              // rwEnabled
+		nil,                                // acceptRemoteWriteProtoMsgs
+		false,                              // otlpEnabled
+		false,                              // otlpDeltaToCumulative
+		false,                              // otlpNativeDeltaIngestion
+		false,                              // stZeroIngestionEnabled
+		5*time.Minute,                      // lookbackDelta
+		false,                              // enableTypeAndUnitLabels
+		false,                              // appendMetadata
+		nil,                                // overrideErrorCode
+		nil,                                // featureRegistry
+		OpenAPIOptions{},                   // openAPIOptions
+		parser.NewParser(parser.Options{}), // promqlParser
 	)
 
 	// Register routes.

--- a/web/api/v1/test_helpers.go
+++ b/web/api/v1/test_helpers.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/prometheus/common/route"
 
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/web/api/testhelpers"
 )
 
@@ -102,7 +101,6 @@ func newTestAPI(t *testing.T, cfg testhelpers.APIConfig) *testhelpers.APIWrapper
 		false,            // enableTypeAndUnitLabels
 		false,            // appendMetadata
 		nil,              // overrideErrorCode
-		parser.Options{}, // parserOptions
 		nil,              // featureRegistry
 		OpenAPIOptions{}, // openAPIOptions
 	)

--- a/web/api/v1/test_helpers.go
+++ b/web/api/v1/test_helpers.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/prometheus/common/route"
 
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/web/api/testhelpers"
 )
 
@@ -101,6 +102,7 @@ func newTestAPI(t *testing.T, cfg testhelpers.APIConfig) *testhelpers.APIWrapper
 		false,            // enableTypeAndUnitLabels
 		false,            // appendMetadata
 		nil,              // overrideErrorCode
+		parser.Options{}, // parserOptions
 		nil,              // featureRegistry
 		OpenAPIOptions{}, // openAPIOptions
 	)

--- a/web/federate.go
+++ b/web/federate.go
@@ -32,7 +32,6 @@ import (
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -64,7 +63,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	matcherSets, err := parser.ParseMetricSelectors(req.Form["match[]"])
+	matcherSets, err := h.options.Parser.ParseMetricSelectors(req.Form["match[]"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -35,12 +35,15 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/util/teststorage"
 	"github.com/prometheus/prometheus/util/testutil"
 )
+
+var testParser = parser.NewParser(parser.Options{})
 
 var scenarios = map[string]struct {
 	params         string
@@ -220,6 +223,7 @@ func TestFederation(t *testing.T) {
 		config: &config.Config{
 			GlobalConfig: config.GlobalConfig{},
 		},
+		options: &Options{Parser: testParser},
 	}
 
 	for name, scenario := range scenarios {
@@ -264,6 +268,7 @@ func TestFederation_NotReady(t *testing.T) {
 						ExternalLabels: scenario.externalLabels,
 					},
 				},
+				options: &Options{Parser: testParser},
 			}
 
 			req := httptest.NewRequest(http.MethodGet, "http://example.org/federate?"+scenario.params, nil)
@@ -440,6 +445,7 @@ func TestFederationWithNativeHistograms(t *testing.T) {
 		config: &config.Config{
 			GlobalConfig: config.GlobalConfig{},
 		},
+		options: &Options{Parser: testParser},
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.org/federate?match[]=test_metric", nil)

--- a/web/web.go
+++ b/web/web.go
@@ -54,6 +54,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
@@ -307,12 +308,18 @@ type Options struct {
 	Gatherer        prometheus.Gatherer
 	Registerer      prometheus.Registerer
 	FeatureRegistry features.Collector
+
+	// Parser is the PromQL parser used for parsing query expressions.
+	Parser parser.Parser
 }
 
 // New initializes a new web Handler.
 func New(logger *slog.Logger, o *Options) *Handler {
 	if logger == nil {
 		logger = promslog.NewNopLogger()
+	}
+	if o.Parser == nil {
+		o.Parser = parser.NewParser(parser.Options{})
 	}
 
 	m := newMetrics(o.Registerer)
@@ -417,6 +424,7 @@ func New(logger *slog.Logger, o *Options) *Handler {
 			ExternalURL: o.ExternalURL.String(),
 			Version:     version,
 		},
+		o.Parser,
 	)
 
 	if r := o.FeatureRegistry; r != nil {

--- a/web/web.go
+++ b/web/web.go
@@ -54,6 +54,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
@@ -306,6 +307,7 @@ type Options struct {
 
 	Gatherer        prometheus.Gatherer
 	Registerer      prometheus.Registerer
+	ParserOptions   parser.Options
 	FeatureRegistry features.Collector
 }
 
@@ -412,6 +414,7 @@ func New(logger *slog.Logger, o *Options) *Handler {
 		o.EnableTypeAndUnitLabels,
 		o.AppendMetadata,
 		nil,
+		o.ParserOptions,
 		o.FeatureRegistry,
 		api_v1.OpenAPIOptions{
 			ExternalURL: o.ExternalURL.String(),

--- a/web/web.go
+++ b/web/web.go
@@ -54,7 +54,6 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
@@ -307,7 +306,6 @@ type Options struct {
 
 	Gatherer        prometheus.Gatherer
 	Registerer      prometheus.Registerer
-	ParserOptions   parser.Options
 	FeatureRegistry features.Collector
 }
 
@@ -414,7 +412,6 @@ func New(logger *slog.Logger, o *Options) *Handler {
 		o.EnableTypeAndUnitLabels,
 		o.AppendMetadata,
 		nil,
-		o.ParserOptions,
 		o.FeatureRegistry,
 		api_v1.OpenAPIOptions{
 			ExternalURL: o.ExternalURL.String(),


### PR DESCRIPTION
This PR addresses the package-level parser flags. They are now configured per engine/API/loader via `parser.Options` and `WithOptions(...)`.

- Updated test so they no longer rely on overriding global package variables.
- Parser config is thread-safe and per-instance.


<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes https://github.com/prometheus/prometheus/issues/17874

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
