### PR TITLE
deps: switch from gopkg.in/yaml to go.yaml.in/yaml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,10 @@ linters:
               desc: "Use github.com/klauspost/compress instead of zlib"
             - pkg: "golang.org/x/exp/slices"
               desc: "Use 'slices' instead."
+            - pkg: "gopkg.in/yaml.v2"
+              desc: "Use go.yaml.in/yaml/v2 instead of gopkg.in/yaml.v2"
+            - pkg: "gopkg.in/yaml.v3"
+              desc: "Use go.yaml.in/yaml/v3 instead of gopkg.in/yaml.v3"
     errcheck:
       exclude-functions:
         # Don't flag lines such as "io.Copy(io.Discard, resp.Body)".

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20251222181119-0a764e51fe1b
 	google.golang.org/grpc v1.78.0
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.3
 	k8s.io/apimachinery v0.34.3
 	k8s.io/client-go v0.34.3
@@ -124,6 +123,8 @@ require (
 	github.com/pb33f/ordered-map/v2 v2.3.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
 
@@ -246,7 +247,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect

--- a/web/api/v1/openapi_golden_test.go
+++ b/web/api/v1/openapi_golden_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/web/api/testhelpers"
 )

--- a/web/api/v1/openapi_test.go
+++ b/web/api/v1/openapi_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v2"
 )
 
 // TestOpenAPIHTTPHandler verifies that the OpenAPI endpoint serves a valid specification


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

N/A

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```

#### Summary

This PR switches some remaining YAML library imports from `gopkg.in/yaml.v2` and `gopkg.in/yaml.v3` to `go.yaml.in/yaml/v2` and `go.yaml.in/yaml/v3` respectively.

The `go.yaml.in/yaml` packages are the new canonical import paths for the go-yaml library, as the project has moved away from gopkg.in.

Changes:
- Update imports in `web/api/v1/openapi_test.go` and `web/api/v1/openapi_golden_test.go`
- Update `go.mod` to use the new import paths
- Add depguard rules to `.golangci.yml` to prevent accidental use of the old `gopkg.in/yaml.v*` packages