### PR TITLE
[chore] replace go.yaml.in/yaml/v2 with go.yaml.in/yaml/v4

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -43,7 +43,6 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
@@ -59,6 +58,7 @@ import (
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/util/documentcli"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 var promqlEnableDelayedNameRemoval = false
@@ -820,7 +820,7 @@ func checkSDFile(filename string) ([]*targetgroup.Group, error) {
 			return nil, err
 		}
 	case ".yml", ".yaml":
-		if err := yaml.UnmarshalStrict(content, &targetGroups); err != nil {
+		if err := yamlutil.UnmarshalStrict(content, &targetGroups); err != nil {
 			return nil, err
 		}
 	default:

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -33,7 +33,6 @@ import (
 	"github.com/nsf/jsondiff"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -43,6 +42,7 @@ import (
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/junitxml"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 // RulesUnitTest does unit testing of rules based on the unit testing files provided.
@@ -91,7 +91,7 @@ func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, run *reg
 	}
 
 	var unitTestInp unitTestFile
-	if err := yaml.UnmarshalStrict(b, &unitTestInp); err != nil {
+	if err := yamlutil.UnmarshalStrict(b, &unitTestInp); err != nil {
 		ts.Abort(err)
 		return []error{err}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -34,13 +34,13 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/otlptranslator"
 	"github.com/prometheus/sigv4"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/storage/remote/azuread"
 	"github.com/prometheus/prometheus/storage/remote/googleiam"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 var (
@@ -78,7 +78,7 @@ func Load(s string, logger *slog.Logger) (*Config, error) {
 	// point as well.
 	*cfg = DefaultConfig
 
-	err := yaml.UnmarshalStrict([]byte(s), cfg)
+	err := yamlutil.UnmarshalStrict([]byte(s), cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +320,7 @@ func (c *Config) SetDirectory(dir string) {
 }
 
 func (c Config) String() string {
-	b, err := yaml.Marshal(c)
+	b, err := yamlutil.Marshal(c)
 	if err != nil {
 		return fmt.Sprintf("<error creating config string: %s>", err)
 	}
@@ -359,7 +359,7 @@ func (c *Config) GetScrapeConfigs() ([]*ScrapeConfig, error) {
 			if err != nil {
 				return nil, fileErr(filename, err)
 			}
-			err = yaml.UnmarshalStrict(content, &cfg)
+			err = yamlutil.UnmarshalStrict(content, &cfg)
 			if err != nil {
 				return nil, fileErr(filename, err)
 			}

--- a/config/reload.go
+++ b/config/reload.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 
 	promconfig "github.com/prometheus/common/config"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 )
 
 type ExternalFilesConfig struct {

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -17,7 +17,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 func TestConfigsCustomUnMarshalMarshal(t *testing.T) {
@@ -27,10 +28,16 @@ func TestConfigsCustomUnMarshalMarshal(t *testing.T) {
   - bar:4321
 `
 	cfg := &Configs{}
-	err := yaml.UnmarshalStrict([]byte(input), cfg)
+	err := yamlutil.UnmarshalStrict([]byte(input), cfg)
 	require.NoError(t, err)
 
-	output, err := yaml.Marshal(cfg)
+	output, err := yamlutil.Marshal(cfg)
 	require.NoError(t, err)
-	require.Equal(t, input, string(output))
+	// yaml/v4 uses different sequence formatting than v2
+	expected := `static_configs:
+  - targets:
+      - foo:1234
+      - bar:4321
+`
+	require.Equal(t, expected, string(output))
 }

--- a/discovery/dns/dns_test.go
+++ b/discovery/dns/dns_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -33,10 +33,10 @@ import (
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 var (
@@ -398,7 +398,7 @@ func (d *Discovery) readFile(filename string) ([]*targetgroup.Group, error) {
 			return nil, err
 		}
 	case ".yml", ".yaml":
-		if err := yaml.UnmarshalStrict(content, &targetGroups); err != nil {
+		if err := yamlutil.UnmarshalStrict(content, &targetGroups); err != nil {
 			return nil, err
 		}
 	default:

--- a/discovery/moby/docker_test.go
+++ b/discovery/moby/docker_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/discovery"
 )

--- a/discovery/moby/mock_test.go
+++ b/discovery/moby/mock_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/util/strutil"
 )

--- a/discovery/moby/nodes_test.go
+++ b/discovery/moby/nodes_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/discovery"
 )

--- a/discovery/moby/services_test.go
+++ b/discovery/moby/services_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/discovery"
 )

--- a/discovery/moby/tasks_test.go
+++ b/discovery/moby/tasks_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/discovery"
 )

--- a/discovery/ovhcloud/dedicated_server_test.go
+++ b/discovery/ovhcloud/dedicated_server_test.go
@@ -24,7 +24,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 func TestOvhcloudDedicatedServerRefresh(t *testing.T) {
@@ -40,7 +41,7 @@ application_key: %s
 application_secret: %s
 consumer_key: %s`, mock.URL, ovhcloudApplicationKeyTest, ovhcloudApplicationSecretTest, ovhcloudConsumerKeyTest)
 
-	require.NoError(t, yaml.UnmarshalStrict([]byte(cfgString), &cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(cfgString), &cfg))
 	d, err := newRefresher(&cfg, promslog.NewNopLogger())
 	require.NoError(t, err)
 	ctx := context.Background()

--- a/discovery/ovhcloud/ovhcloud_test.go
+++ b/discovery/ovhcloud/ovhcloud_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 var (
@@ -52,7 +52,7 @@ service: %s
 
 func getMockConfFromString(confString string) (SDConfig, error) {
 	var conf SDConfig
-	err := yaml.UnmarshalStrict([]byte(confString), &conf)
+	err := yamlutil.UnmarshalStrict([]byte(confString), &conf)
 	return conf, err
 }
 

--- a/discovery/ovhcloud/vps_test.go
+++ b/discovery/ovhcloud/vps_test.go
@@ -24,7 +24,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	yaml "go.yaml.in/yaml/v2"
+
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 func TestOvhCloudVpsRefresh(t *testing.T) {
@@ -40,7 +41,7 @@ application_key: %s
 application_secret: %s
 consumer_key: %s`, mock.URL, ovhcloudApplicationKeyTest, ovhcloudApplicationSecretTest, ovhcloudConsumerKeyTest)
 
-	require.NoError(t, yaml.UnmarshalStrict([]byte(cfgString), &cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(cfgString), &cfg))
 
 	d, err := newRefresher(&cfg, promslog.NewNopLogger())
 	require.NoError(t, err)

--- a/discovery/registry.go
+++ b/discovery/registry.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
@@ -253,8 +253,10 @@ func replaceYAMLTypeError(err error, oldTyp, newTyp reflect.Type) error {
 	if errors.As(err, &e) {
 		oldStr := oldTyp.String()
 		newStr := newTyp.String()
-		for i, s := range e.Errors {
-			e.Errors[i] = strings.ReplaceAll(s, oldStr, newStr)
+		for _, ue := range e.Errors {
+			if ue.Err != nil {
+				ue.Err = errors.New(strings.ReplaceAll(ue.Err.Error(), oldStr, newStr))
+			}
 		}
 	}
 	return err

--- a/discovery/scaleway/instance_test.go
+++ b/discovery/scaleway/instance_test.go
@@ -23,7 +23,8 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 var (
@@ -46,7 +47,7 @@ access_key: %s
 api_url: %s
 `, testProjectID, testSecretKey, testAccessKey, mock.URL)
 	var cfg SDConfig
-	require.NoError(t, yaml.UnmarshalStrict([]byte(cfgString), &cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(cfgString), &cfg))
 
 	d, err := newRefresher(&cfg)
 	require.NoError(t, err)
@@ -200,7 +201,7 @@ access_key: %s
 api_url: %s
 `, testProjectID, testSecretKeyFile, testAccessKey, mock.URL)
 	var cfg SDConfig
-	require.NoError(t, yaml.UnmarshalStrict([]byte(cfgString), &cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(cfgString), &cfg))
 
 	d, err := newRefresher(&cfg)
 	require.NoError(t, err)

--- a/discovery/xds/kuma_test.go
+++ b/discovery/xds/kuma_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,6 @@ require (
 	go.uber.org/atomic v1.11.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/goleak v1.3.0
-	go.yaml.in/yaml/v2 v2.4.3
 	go.yaml.in/yaml/v3 v3.0.4
 	go.yaml.in/yaml/v4 v4.0.0-rc.3
 	golang.org/x/oauth2 v0.34.0
@@ -125,6 +124,7 @@ require (
 	github.com/pb33f/ordered-map/v2 v2.3.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 )
 
 var (

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -20,10 +20,11 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/util/testutil"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 func TestRelabel(t *testing.T) {
@@ -1060,7 +1061,7 @@ func BenchmarkRelabel(b *testing.B) {
 		},
 	}
 	for i := range tests {
-		err := yaml.UnmarshalStrict([]byte(tests[i].config), &tests[i].cfgs)
+		err := yamlutil.UnmarshalStrict([]byte(tests[i].config), &tests[i].cfgs)
 		require.NoError(b, err)
 	}
 	for _, tt := range tests {

--- a/notifier/alertmanagerset.go
+++ b/notifier/alertmanagerset.go
@@ -23,11 +23,11 @@ import (
 
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/sigv4"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 // alertmanagerSet contains a set of Alertmanagers discovered via a group of service
@@ -123,7 +123,7 @@ func (s *alertmanagerSet) sync(tgs []*targetgroup.Group) {
 }
 
 func (s *alertmanagerSet) configHash() (string, error) {
-	b, err := yaml.Marshal(s.cfg)
+	b, err := yamlutil.Marshal(s.cfg)
 	if err != nil {
 		return "", err
 	}

--- a/notifier/manager_test.go
+++ b/notifier/manager_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
@@ -44,6 +43,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/util/testutil/synctest"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 func alertsEqual(a, b []*Alert) error {
@@ -608,7 +608,7 @@ alerting:
   alertmanagers:
   - static_configs:
 `
-	err := yaml.UnmarshalStrict([]byte(s), cfg)
+	err := yamlutil.UnmarshalStrict([]byte(s), cfg)
 	require.NoError(t, err, "Unable to load YAML config.")
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 1)
 
@@ -659,7 +659,7 @@ alerting:
         regex: 'alertmanager:9093'
         action: drop
 `
-	err := yaml.UnmarshalStrict([]byte(s), cfg)
+	err := yamlutil.UnmarshalStrict([]byte(s), cfg)
 	require.NoError(t, err, "Unable to load YAML config.")
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 1)
 
@@ -1039,7 +1039,7 @@ alerting:
       - foo.json
 `
 	// 1. Ensure known alertmanagers are not dropped during ApplyConfig.
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(s), cfg))
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 1)
 
 	// First, apply the config and reload.
@@ -1065,7 +1065,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(s), cfg))
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 2)
 
 	require.NoError(t, n.ApplyConfig(cfg))
@@ -1088,7 +1088,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(s), cfg))
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 2)
 
 	require.NoError(t, n.ApplyConfig(cfg))
@@ -1115,7 +1115,7 @@ alerting:
       regex: 'doesntmatter:1234'
       action: drop
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(s), cfg))
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 2)
 
 	require.NoError(t, n.ApplyConfig(cfg))
@@ -1323,7 +1323,7 @@ alerting:
     - files:
       - bar.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	// Reload with target groups to discover alertmanagers.
@@ -1374,7 +1374,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	// CRITICAL CHECK: After ApplyConfig but BEFORE reload, the sendLoops should
@@ -1430,7 +1430,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	targetGroup := &targetgroup.Group{
@@ -1455,7 +1455,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	// Reload with target groups for both configs - same alertmanager URL for both.
@@ -1503,7 +1503,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	targetGroup := &targetgroup.Group{
@@ -1531,7 +1531,7 @@ alerting:
       - foo.json
     path_prefix: /changed
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, yamlutil.UnmarshalStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	// The old sendLoop should have been stopped since hash changed.

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/prometheus/common/model"
 	"go.uber.org/atomic"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
@@ -34,6 +33,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/template"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 const (
@@ -629,7 +629,7 @@ func (r *AlertingRule) String() string {
 		Annotations:   r.annotations.Map(),
 	}
 
-	byt, err := yaml.Marshal(ar)
+	byt, err := yamlutil.Marshal(ar)
 	if err != nil {
 		return fmt.Sprintf("error marshaling alerting rule: %s", err.Error())
 	}

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 // ErrDuplicateRecordingLabelSet is returned when a recording rule evaluation produces
@@ -128,7 +128,7 @@ func (rule *RecordingRule) String() string {
 		Labels: rule.labels.Map(),
 	}
 
-	byt, err := yaml.Marshal(r)
+	byt, err := yamlutil.Marshal(r)
 	if err != nil {
 		return fmt.Sprintf("error marshaling recording rule: %q", err.Error())
 	}

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/prometheus/prometheus/config"
@@ -53,6 +52,7 @@ import (
 	"github.com/prometheus/prometheus/util/runutil"
 	"github.com/prometheus/prometheus/util/teststorage"
 	"github.com/prometheus/prometheus/util/testutil"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 func TestPopulateLabels(t *testing.T) {
@@ -623,7 +623,7 @@ global:
 `
 
 		cfg := &config.Config{}
-		err := yaml.UnmarshalStrict([]byte(cfgText), cfg)
+		err := yamlutil.UnmarshalStrict([]byte(cfgText), cfg)
 		require.NoError(t, err, "Unable to load YAML config cfgYaml.")
 
 		return cfg

--- a/storage/remote/azuread/azuread_test.go
+++ b/storage/remote/azuread/azuread_test.go
@@ -28,7 +28,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"go.yaml.in/yaml/v2"
+
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 const (
@@ -142,7 +143,7 @@ func loadAzureAdConfig(filename string) (*AzureADConfig, error) {
 		return nil, err
 	}
 	cfg := AzureADConfig{}
-	if err = yaml.UnmarshalStrict(content, &cfg); err != nil {
+	if err = yamlutil.UnmarshalStrict(content, &cfg); err != nil {
 		return nil, err
 	}
 	return &cfg, nil
@@ -238,7 +239,7 @@ func TestAzureAdConfig(t *testing.T) {
 			if err == nil {
 				t.Fatalf("Did not receive expected error unmarshaling bad azuread config")
 			}
-			require.EqualError(t, err, c.err)
+			require.ErrorContains(t, err, c.err)
 		} else {
 			require.NoError(t, err)
 		}

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -25,13 +25,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/logging"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 // String constants for instrumentation.
@@ -227,7 +227,7 @@ func labelsToEqualityMatchers(ls model.LabelSet) []*labels.Matcher {
 
 // Used for hashing configs and diff'ing hashes in ApplyConfig.
 func toHash(data any) (string, error) {
-	bytes, err := yaml.Marshal(data)
+	bytes, err := yamlutil.Marshal(data)
 	if err != nil {
 		return "", err
 	}

--- a/util/yamlutil/yamlutil.go
+++ b/util/yamlutil/yamlutil.go
@@ -1,0 +1,51 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package yamlutil provides YAML utility functions.
+package yamlutil
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"go.yaml.in/yaml/v4"
+)
+
+// UnmarshalStrict is like yaml.Unmarshal but returns an error if there are
+// keys in the data that do not have corresponding struct members.
+func UnmarshalStrict(in []byte, out any) error {
+	dec := yaml.NewDecoder(bytes.NewReader(in))
+	dec.KnownFields(true)
+	err := dec.Decode(out)
+	// yaml/v4 returns io.EOF for empty input, but for compatibility with v2
+	// behavior we treat this as success (no error).
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	return err
+}
+
+// Marshal marshals v into YAML with 2-space indentation.
+func Marshal(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/web/api/v1/openapi_helpers.go
+++ b/web/api/v1/openapi_helpers.go
@@ -23,6 +23,7 @@ import (
 	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/util/yamlutil"
 )
 
 // Helper functions for building common structures.
@@ -227,7 +228,7 @@ func pathParam(name, description string, schema *base.SchemaProxy) *v3.Parameter
 // createYAMLNode converts Go data to yaml.Node for use in examples.
 func createYAMLNode(data any) *yaml.Node {
 	node := &yaml.Node{}
-	bytes, _ := yaml.Marshal(data)
+	bytes, _ := yamlutil.Marshal(data)
 	_ = yaml.Unmarshal(bytes, node)
 	return node
 }

--- a/web/api/v1/openapi_test.go
+++ b/web/api/v1/openapi_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v4"
 )
 
 // TestOpenAPIHTTPHandler verifies that the OpenAPI endpoint serves a valid specification
@@ -54,12 +54,12 @@ func TestOpenAPIHTTPHandler(t *testing.T) {
 	require.Equal(t, "3.1.0", spec["openapi"])
 
 	// Verify info section.
-	info, ok := spec["info"].(map[any]any)
+	info, ok := spec["info"].(map[string]any)
 	require.True(t, ok, "info should be a map")
 	require.Equal(t, "Prometheus API", info["title"])
 
 	// Verify paths exist.
-	paths, ok := spec["paths"].(map[any]any)
+	paths, ok := spec["paths"].(map[string]any)
 	require.True(t, ok, "paths should be a map")
 	require.NotEmpty(t, paths, "paths should not be empty")
 
@@ -128,7 +128,7 @@ func TestOpenAPIPathFiltering(t *testing.T) {
 			err := yaml.Unmarshal(rec.Body.Bytes(), &spec)
 			require.NoError(t, err)
 
-			paths, ok := spec["paths"].(map[any]any)
+			paths, ok := spec["paths"].(map[string]any)
 			require.True(t, ok, "paths should be a map")
 
 			for _, want := range tc.wantPaths {
@@ -155,10 +155,10 @@ func TestOpenAPISchemaCompleteness(t *testing.T) {
 	err := yaml.Unmarshal(rec.Body.Bytes(), &spec)
 	require.NoError(t, err)
 
-	components, ok := spec["components"].(map[any]any)
+	components, ok := spec["components"].(map[string]any)
 	require.True(t, ok, "components should be a map")
 
-	schemas, ok := components["schemas"].(map[any]any)
+	schemas, ok := components["schemas"].(map[string]any)
 	require.True(t, ok, "schemas should be a map")
 
 	// Verify essential schemas are present.
@@ -276,8 +276,8 @@ func TestOpenAPIVersionConsistency(t *testing.T) {
 	require.Equal(t, "3.2.0", spec32["openapi"])
 
 	// Verify /notifications/live is only in 3.2.
-	paths31 := spec31["paths"].(map[any]any)
-	paths32 := spec32["paths"].(map[any]any)
+	paths31 := spec31["paths"].(map[string]any)
+	paths32 := spec32["paths"].(map[string]any)
 
 	require.NotContains(t, paths31, "/notifications/live")
 


### PR DESCRIPTION
Replace `go.yaml.in/yaml/v2` with `go.yaml.in/yaml/v4`. Waiting for v4 to go stable.

#### Which issue(s) does the PR fix:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
