### PR TITLE
tsdb: reject out-of-order labels at append time

### DIFF
--- a/model/labels/labels_dedupelabels.go
+++ b/model/labels/labels_dedupelabels.go
@@ -382,6 +382,21 @@ func (ls Labels) HasDuplicateLabelNames() (string, bool) {
 	return "", false
 }
 
+// HasOutOfOrderLabel checks if labels are not sorted by name (including duplicates).
+// Since labels are expected to be sorted, out-of-order labels indicate corruption.
+func (ls Labels) HasOutOfOrderLabel() (string, bool) {
+	var prev string
+	for i := 0; i < len(ls.data); {
+		lName, newI := decodeString(ls.syms, ls.data, i)
+		_, i = decodeVarint(ls.data, newI)
+		if prev != "" && lName <= prev {
+			return lName, true
+		}
+		prev = lName
+	}
+	return "", false
+}
+
 // WithoutEmpty returns the labelset without empty labels.
 // May return the same labelset.
 func (ls Labels) WithoutEmpty() Labels {

--- a/model/labels/labels_dedupelabels.go
+++ b/model/labels/labels_dedupelabels.go
@@ -17,6 +17,7 @@ package labels
 
 import (
 	"bytes"
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -366,35 +367,26 @@ func (ls Labels) Has(name string) bool {
 	return false
 }
 
-// HasDuplicateLabelNames returns whether ls has duplicate label names.
-// It assumes that the labelset is sorted.
-func (ls Labels) HasDuplicateLabelNames() (string, bool) {
-	prevNum := -1
-	for i := 0; i < len(ls.data); {
-		var lNum int
-		lNum, i = decodeVarint(ls.data, i)
-		_, i = decodeVarint(ls.data, i)
-		if lNum == prevNum {
-			return ls.syms.ToName(lNum), true
-		}
-		prevNum = lNum
+// ValidateOrder checks that label names are strictly increasing.
+// It returns an error for the first duplicate or out-of-order name.
+func (ls Labels) ValidateOrder() error {
+	if ls.data == "" {
+		return nil
 	}
-	return "", false
-}
-
-// HasOutOfOrderLabel checks if labels are not sorted by name (including duplicates).
-// Since labels are expected to be sorted, out-of-order labels indicate corruption.
-func (ls Labels) HasOutOfOrderLabel() (string, bool) {
-	var prev string
-	for i := 0; i < len(ls.data); {
-		lName, newI := decodeString(ls.syms, ls.data, i)
-		_, i = decodeVarint(ls.data, newI)
-		if prev != "" && lName <= prev {
-			return lName, true
+	prev, i := decodeString(ls.syms, ls.data, 0)
+	_, i = decodeVarint(ls.data, i)
+	for i < len(ls.data) {
+		name, next := decodeString(ls.syms, ls.data, i)
+		_, i = decodeVarint(ls.data, next)
+		if name <= prev {
+			if name == prev {
+				return fmt.Errorf("label name %q is not unique", name)
+			}
+			return fmt.Errorf("label name %q is out of order", name)
 		}
-		prev = lName
+		prev = name
 	}
-	return "", false
+	return nil
 }
 
 // WithoutEmpty returns the labelset without empty labels.

--- a/model/labels/labels_slicelabels.go
+++ b/model/labels/labels_slicelabels.go
@@ -233,6 +233,17 @@ func (ls Labels) HasDuplicateLabelNames() (string, bool) {
 	return "", false
 }
 
+// HasOutOfOrderLabel checks if labels are not sorted by name (including duplicates).
+// Since labels are expected to be sorted, out-of-order labels indicate corruption.
+func (ls Labels) HasOutOfOrderLabel() (string, bool) {
+	for i := 1; i < len(ls); i++ {
+		if ls[i].Name <= ls[i-1].Name {
+			return ls[i].Name, true
+		}
+	}
+	return "", false
+}
+
 // WithoutEmpty returns the labelset without empty labels.
 // May return the same labelset.
 func (ls Labels) WithoutEmpty() Labels {

--- a/model/labels/labels_slicelabels.go
+++ b/model/labels/labels_slicelabels.go
@@ -17,6 +17,7 @@ package labels
 
 import (
 	"bytes"
+	"fmt"
 	"slices"
 	"strings"
 	"unique"
@@ -219,29 +220,19 @@ func (ls Labels) Has(name string) bool {
 	return false
 }
 
-// HasDuplicateLabelNames returns whether ls has duplicate label names.
-// It assumes that the labelset is sorted.
-func (ls Labels) HasDuplicateLabelNames() (string, bool) {
-	for i, l := range ls {
-		if i == 0 {
-			continue
-		}
-		if l.Name == ls[i-1].Name {
-			return l.Name, true
-		}
-	}
-	return "", false
-}
-
-// HasOutOfOrderLabel checks if labels are not sorted by name (including duplicates).
-// Since labels are expected to be sorted, out-of-order labels indicate corruption.
-func (ls Labels) HasOutOfOrderLabel() (string, bool) {
+// ValidateOrder checks that label names are strictly increasing.
+// It returns an error for the first duplicate or out-of-order name.
+func (ls Labels) ValidateOrder() error {
 	for i := 1; i < len(ls); i++ {
-		if ls[i].Name <= ls[i-1].Name {
-			return ls[i].Name, true
+		name, prev := ls[i].Name, ls[i-1].Name
+		if name <= prev {
+			if name == prev {
+				return fmt.Errorf("label name %q is not unique", name)
+			}
+			return fmt.Errorf("label name %q is out of order", name)
 		}
 	}
-	return "", false
+	return nil
 }
 
 // WithoutEmpty returns the labelset without empty labels.

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -256,6 +256,21 @@ func (ls Labels) HasDuplicateLabelNames() (string, bool) {
 	return "", false
 }
 
+// HasOutOfOrderLabel checks if labels are not sorted by name (including duplicates).
+// Since labels are expected to be sorted, out-of-order labels indicate corruption.
+func (ls Labels) HasOutOfOrderLabel() (string, bool) {
+	var prev string
+	for i := 0; i < len(ls.data); {
+		lName, newI := decodeString(ls.data, i)
+		_, i = decodeString(ls.data, newI)
+		if prev != "" && lName <= prev {
+			return lName, true
+		}
+		prev = lName
+	}
+	return "", false
+}
+
 // WithoutEmpty returns the labelset without empty labels.
 // May return the same labelset.
 func (ls Labels) WithoutEmpty() Labels {

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -16,6 +16,7 @@
 package labels
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"unsafe"
@@ -241,34 +242,26 @@ func (ls Labels) Has(name string) bool {
 	return false
 }
 
-// HasDuplicateLabelNames returns whether ls has duplicate label names.
-// It assumes that the labelset is sorted.
-func (ls Labels) HasDuplicateLabelNames() (string, bool) {
-	var lName, prevName string
-	for i := 0; i < len(ls.data); {
-		lName, i = decodeString(ls.data, i)
-		_, i = decodeString(ls.data, i)
-		if lName == prevName {
-			return lName, true
-		}
-		prevName = lName
+// ValidateOrder checks that label names are strictly increasing.
+// It returns an error for the first duplicate or out-of-order name.
+func (ls Labels) ValidateOrder() error {
+	if ls.data == "" {
+		return nil
 	}
-	return "", false
-}
-
-// HasOutOfOrderLabel checks if labels are not sorted by name (including duplicates).
-// Since labels are expected to be sorted, out-of-order labels indicate corruption.
-func (ls Labels) HasOutOfOrderLabel() (string, bool) {
-	var prev string
-	for i := 0; i < len(ls.data); {
-		lName, newI := decodeString(ls.data, i)
-		_, i = decodeString(ls.data, newI)
-		if prev != "" && lName <= prev {
-			return lName, true
+	prev, i := decodeString(ls.data, 0)
+	_, i = decodeString(ls.data, i)
+	for i < len(ls.data) {
+		name, next := decodeString(ls.data, i)
+		_, i = decodeString(ls.data, next)
+		if name <= prev {
+			if name == prev {
+				return fmt.Errorf("label name %q is not unique", name)
+			}
+			return fmt.Errorf("label name %q is out of order", name)
 		}
-		prev = lName
+		prev = name
 	}
-	return "", false
+	return nil
 }
 
 // WithoutEmpty returns the labelset without empty labels.

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -206,6 +206,60 @@ func TestLabels_HasDuplicateLabelNames(t *testing.T) {
 	}
 }
 
+func TestLabels_HasOutOfOrderLabel(t *testing.T) {
+	// Helper to create unsorted labels using ScratchBuilder without Sort().
+	unsortedLabels := func(ss ...string) Labels {
+		b := NewScratchBuilder(len(ss) / 2)
+		for i := 0; i < len(ss); i += 2 {
+			b.Add(ss[i], ss[i+1])
+		}
+		return b.Labels()
+	}
+
+	cases := []struct {
+		name       string
+		input      Labels
+		outOfOrder bool
+		labelName  string
+	}{
+		{
+			name:       "sorted labels",
+			input:      FromMap(map[string]string{"__name__": "up", "hostname": "localhost"}),
+			outOfOrder: false,
+		},
+		{
+			name:       "duplicate labels",
+			input:      unsortedLabels("__name__", "up", "hostname", "localhost", "hostname", "127.0.0.1"),
+			outOfOrder: true,
+			labelName:  "hostname",
+		},
+		{
+			name:       "out of order labels",
+			input:      unsortedLabels("b", "1", "a", "2"),
+			outOfOrder: true,
+			labelName:  "a",
+		},
+		{
+			name:       "empty labels",
+			input:      EmptyLabels(),
+			outOfOrder: false,
+		},
+		{
+			name:       "single label",
+			input:      FromStrings("a", "1"),
+			outOfOrder: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			l, ooo := c.input.HasOutOfOrderLabel()
+			require.Equal(t, c.outOfOrder, ooo, "incorrect out of order bool")
+			require.Equal(t, c.labelName, l, "incorrect label name")
+		})
+	}
+}
+
 func TestLabels_WithoutEmpty(t *testing.T) {
 	for _, test := range []struct {
 		input    Labels

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -183,79 +183,45 @@ func TestLabels_MatchLabels(t *testing.T) {
 	}
 }
 
-func TestLabels_HasDuplicateLabelNames(t *testing.T) {
-	cases := []struct {
-		Input     Labels
-		Duplicate bool
-		LabelName string
+func TestLabels_ValidateOrder(t *testing.T) {
+	// Seed names in reverse order so symbol IDs cannot stand in for name ordering.
+	syms := NewSymbolTable()
+	seed := NewScratchBuilderWithSymbolTable(syms, 2)
+	seed.Add("z", "last")
+	seed.Add("a", "first")
+	_ = seed.Labels()
+
+	for _, tc := range []struct {
+		name    string
+		pairs   []string
+		wantErr string
 	}{
-		{
-			Input:     FromMap(map[string]string{"__name__": "up", "hostname": "localhost"}),
-			Duplicate: false,
-		}, {
-			Input:     FromStrings("__name__", "up", "hostname", "localhost", "hostname", "127.0.0.1"),
-			Duplicate: true,
-			LabelName: "hostname",
-		},
-	}
-
-	for i, c := range cases {
-		l, d := c.Input.HasDuplicateLabelNames()
-		require.Equal(t, c.Duplicate, d, "test %d: incorrect duplicate bool", i)
-		require.Equal(t, c.LabelName, l, "test %d: incorrect label name", i)
-	}
-}
-
-func TestLabels_HasOutOfOrderLabel(t *testing.T) {
-	// Helper to create unsorted labels using ScratchBuilder without Sort().
-	unsortedLabels := func(ss ...string) Labels {
-		b := NewScratchBuilder(len(ss) / 2)
-		for i := 0; i < len(ss); i += 2 {
-			b.Add(ss[i], ss[i+1])
-		}
-		return b.Labels()
-	}
-
-	cases := []struct {
-		name       string
-		input      Labels
-		outOfOrder bool
-		labelName  string
-	}{
-		{
-			name:       "sorted labels",
-			input:      FromMap(map[string]string{"__name__": "up", "hostname": "localhost"}),
-			outOfOrder: false,
-		},
-		{
-			name:       "duplicate labels",
-			input:      unsortedLabels("__name__", "up", "hostname", "localhost", "hostname", "127.0.0.1"),
-			outOfOrder: true,
-			labelName:  "hostname",
-		},
-		{
-			name:       "out of order labels",
-			input:      unsortedLabels("b", "1", "a", "2"),
-			outOfOrder: true,
-			labelName:  "a",
-		},
-		{
-			name:       "empty labels",
-			input:      EmptyLabels(),
-			outOfOrder: false,
-		},
-		{
-			name:       "single label",
-			input:      FromStrings("a", "1"),
-			outOfOrder: false,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			l, ooo := c.input.HasOutOfOrderLabel()
-			require.Equal(t, c.outOfOrder, ooo, "incorrect out of order bool")
-			require.Equal(t, c.labelName, l, "incorrect label name")
+		{name: "empty labels"},
+		{name: "single label", pairs: []string{"a", "1"}},
+		{name: "single empty name", pairs: []string{"", "1"}},
+		{name: "leading empty name", pairs: []string{"", "1", "a", "2"}},
+		{name: "sorted labels", pairs: []string{"__name__", "up", "hostname", "localhost"}},
+		{name: "sorted names with reverse symbol IDs", pairs: []string{"a", "1", "z", "2"}},
+		{name: "duplicate labels", pairs: []string{"a", "1", "a", "2"}, wantErr: `label name "a" is not unique`},
+		{name: "identical labels", pairs: []string{"a", "1", "a", "1"}, wantErr: `label name "a" is not unique`},
+		{name: "duplicate empty names", pairs: []string{"", "1", "", "2"}, wantErr: `label name "" is not unique`},
+		{name: "non-adjacent duplicates", pairs: []string{"__name__", "up", "job", "prometheus", "__name__", "down"}, wantErr: `label name "__name__" is out of order`},
+		{name: "descending names", pairs: []string{"z", "1", "a", "2"}, wantErr: `label name "a" is out of order`},
+		{name: "descending empty name", pairs: []string{"a", "1", "", "2"}, wantErr: `label name "" is out of order`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := NewScratchBuilderWithSymbolTable(syms, len(tc.pairs)/2)
+			for i := 0; i < len(tc.pairs); i += 2 {
+				builder.Add(tc.pairs[i], tc.pairs[i+1])
+			}
+			ls := builder.Labels()
+			before := ls.Copy()
+			if tc.wantErr == "" {
+				require.NoError(t, ls.ValidateOrder())
+			} else {
+				require.EqualError(t, ls.ValidateOrder(), tc.wantErr)
+			}
+			require.True(t, Equal(before, ls), "Validation must not change labels")
 		})
 	}
 }

--- a/model/labels/labels_validate_order_bench_test.go
+++ b/model/labels/labels_validate_order_bench_test.go
@@ -1,0 +1,52 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labels
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+func BenchmarkLabels_ValidateOrder(b *testing.B) {
+	names := []string{
+		"__name__", "cluster", "container", "endpoint", "env", "handler",
+		"host", "instance", "job", "le", "method", "namespace", "node",
+		"operation", "path", "pod", "port", "protocol", "region", "replica",
+		"route", "scheme", "service", "source", "status", "target",
+		"team", "tenant", "version", "zone",
+	}
+	for _, size := range []int{5, 10, 30} {
+		for _, scenario := range []string{"valid", "duplicate", "descending"} {
+			b.Run(fmt.Sprintf("labels=%d/%s", size, scenario), func(b *testing.B) {
+				labelNames := slices.Clone(names[:size])
+				switch scenario {
+				case "duplicate":
+					labelNames[size-1] = labelNames[size-2]
+				case "descending":
+					labelNames[size-1], labelNames[size-2] = labelNames[size-2], labelNames[size-1]
+				}
+				builder := NewScratchBuilder(size)
+				for _, name := range labelNames {
+					builder.Add(name, "prometheus")
+				}
+				ls := builder.Labels()
+				b.ReportAllocs()
+				for b.Loop() {
+					_ = ls.ValidateOrder()
+				}
+			})
+		}
+	}
+}

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -177,8 +177,8 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 			h.logger.Warn("Invalid metric names or labels", "got", ls.String())
 			samplesWithInvalidLabels++
 			continue
-		} else if duplicateLabel, hasDuplicate := ls.HasDuplicateLabelNames(); hasDuplicate {
-			h.logger.Warn("Invalid labels for series.", "labels", ls.String(), "duplicated_label", duplicateLabel)
+		} else if err := ls.ValidateOrder(); err != nil {
+			h.logger.Warn("Invalid labels for series.", "labels", ls.String(), "err", err)
 			samplesWithInvalidLabels++
 			continue
 		}
@@ -345,8 +345,8 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 			badRequestErrs = append(badRequestErrs, fmt.Errorf("invalid metric name or labels, got %v", ls.String()))
 			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)
 			continue
-		} else if duplicateLabel, hasDuplicate := ls.HasDuplicateLabelNames(); hasDuplicate {
-			badRequestErrs = append(badRequestErrs, fmt.Errorf("invalid labels for series, labels %v, duplicated label %s", ls.String(), duplicateLabel))
+		} else if err := ls.ValidateOrder(); err != nil {
+			badRequestErrs = append(badRequestErrs, fmt.Errorf("invalid labels for series, labels %v: %w", ls.String(), err))
 			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)
 			continue
 		}

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -30,6 +31,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	remoteapi "github.com/prometheus/client_golang/exp/api/remote"
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
@@ -291,51 +294,86 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 }
 
 func TestRemoteWriteHandler_V1Message(t *testing.T) {
-	payload, _, _, err := buildWriteRequest(nil, writeRequestFixture.Timeseries, nil, nil, nil, nil, "snappy")
-	require.NoError(t, err)
+	unsorted := proto.Clone(writeRequestFixture).(*prompb.WriteRequest)
+	slices.Reverse(unsorted.Timeseries[0].Labels)
+	for _, tc := range []struct {
+		name          string
+		input         []prompb.TimeSeries
+		invalidLabels int
+	}{
+		{name: "sorted labels", input: writeRequestFixture.Timeseries},
+		{name: "unsorted unique labels", input: unsorted.Timeseries},
+		{
+			name: "non-adjacent duplicates",
+			input: append([]prompb.TimeSeries{{
+				Labels:  []prompb.Label{{Name: "__name__", Value: "test_metric1"}, {Name: "b", Value: "c"}, {Name: "baz", Value: "qux"}, {Name: "b", Value: "c"}},
+				Samples: []prompb.Sample{{Timestamp: 1, Value: 1}, {Timestamp: 2, Value: 2}},
+			}}, writeRequestFixture.Timeseries...),
+			invalidLabels: 1, // V1 counts invalid series, regardless of their sample count.
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, _, _, err := buildWriteRequest(nil, tc.input, nil, nil, nil, nil, "snappy")
+			require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(payload))
-	require.NoError(t, err)
+			req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(payload))
+			require.NoError(t, err)
 
-	// NOTE: Strictly speaking, even for 1.0 we require headers, but we never verified those
-	// in Prometheus, so keeping like this to not break existing 1.0 clients.
+			// NOTE: Strictly speaking, even for 1.0 we require headers, but we never verified those
+			// in Prometheus, so keeping like this to not break existing 1.0 clients.
 
-	appendable := &mockAppendable{}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			appendable := &mockAppendable{}
+			reg := prometheus.NewRegistry()
+			handler := NewWriteHandler(promslog.NewNopLogger(), reg, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
-	recorder := httptest.NewRecorder()
-	handler.ServeHTTP(recorder, req)
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
 
-	resp := recorder.Result()
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+			resp := recorder.Result()
+			t.Cleanup(func() { require.NoError(t, resp.Body.Close()) })
+			require.Equal(t, http.StatusNoContent, resp.StatusCode)
 
-	b := labels.NewScratchBuilder(0)
-	i := 0
-	j := 0
-	k := 0
-	for _, ts := range writeRequestFixture.Timeseries {
-		labels := ts.ToLabels(&b, nil)
-		for _, s := range ts.Samples {
-			requireEqual(t, mockSample{labels, s.Timestamp, s.Value}, appendable.samples[i])
-			i++
-		}
-		for _, e := range ts.Exemplars {
-			exemplarLabels := e.ToExemplar(&b, nil).Labels
-			requireEqual(t, mockExemplar{labels, exemplarLabels, e.Timestamp, e.Value}, appendable.exemplars[j])
-			j++
-		}
-		for _, hp := range ts.Histograms {
-			if hp.IsFloatHistogram() {
-				fh := hp.ToFloatHistogram()
-				requireEqual(t, mockHistogram{labels, hp.Timestamp, nil, fh}, appendable.histograms[k])
-			} else {
-				h := hp.ToIntHistogram()
-				requireEqual(t, mockHistogram{labels, hp.Timestamp, h, nil}, appendable.histograms[k])
+			b := labels.NewScratchBuilder(0)
+			i := 0
+			j := 0
+			k := 0
+			for _, ts := range writeRequestFixture.Timeseries {
+				labels := ts.ToLabels(&b, nil)
+				for _, s := range ts.Samples {
+					requireEqual(t, mockSample{labels, s.Timestamp, s.Value}, appendable.samples[i])
+					i++
+				}
+				for _, e := range ts.Exemplars {
+					exemplarLabels := e.ToExemplar(&b, nil).Labels
+					requireEqual(t, mockExemplar{labels, exemplarLabels, e.Timestamp, e.Value}, appendable.exemplars[j])
+					j++
+				}
+				for _, hp := range ts.Histograms {
+					if hp.IsFloatHistogram() {
+						fh := hp.ToFloatHistogram()
+						requireEqual(t, mockHistogram{labels, hp.Timestamp, nil, fh}, appendable.histograms[k])
+					} else {
+						h := hp.ToIntHistogram()
+						requireEqual(t, mockHistogram{labels, hp.Timestamp, h, nil}, appendable.histograms[k])
+					}
+
+					k++
+				}
 			}
-
-			k++
-		}
+			require.Len(t, appendable.samples, i)
+			require.Len(t, appendable.exemplars, j)
+			require.Len(t, appendable.histograms, k)
+			requireInvalidLabelSamples(t, reg, tc.invalidLabels)
+		})
 	}
+}
+
+func requireInvalidLabelSamples(t *testing.T, reg prometheus.Gatherer, want int) {
+	t.Helper()
+	require.NoError(t, promtestutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`# HELP prometheus_api_remote_write_invalid_labels_samples_total The total number of received remote write samples and histogram samples which were rejected due to invalid labels.
+# TYPE prometheus_api_remote_write_invalid_labels_samples_total counter
+prometheus_api_remote_write_invalid_labels_samples_total %d
+`, want)), "prometheus_api_remote_write_invalid_labels_samples_total"))
 }
 
 func expectHeaderValue(t testing.TB, expected int, got string) {
@@ -350,11 +388,13 @@ func expectHeaderValue(t testing.TB, expected int, got string) {
 func TestRemoteWriteHandler_V2Message(t *testing.T) {
 	// V2 supports partial writes for non-retriable errors, so test them.
 	for _, tc := range []struct {
-		desc             string
-		input            []writev2.TimeSeries
-		symbols          []string // Custom symbol table for tests that need it
-		expectedCode     int
-		expectedRespBody string
+		desc                  string
+		input                 []writev2.TimeSeries
+		symbols               []string // Custom symbol table for tests that need it
+		expectedCode          int
+		expectedRespBody      string
+		checkInvalidLabels    bool
+		expectedInvalidLabels int
 
 		commitErr             error
 		appendSampleErr       error
@@ -378,6 +418,28 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 			desc:         "All timeseries accepted/ct_disabled",
 			input:        writeV2RequestFixture.Timeseries,
 			expectedCode: http.StatusNoContent,
+		},
+		{
+			desc: "Unsorted unique labels are normalized",
+			input: func() []writev2.TimeSeries {
+				f := proto.Clone(writeV2RequestFixture).(*writev2.Request)
+				refs := f.Timeseries[0].LabelsRefs
+				f.Timeseries[0].LabelsRefs = append(slices.Clone(refs[2:]), refs[:2]...)
+				return f.Timeseries
+			}(),
+			expectedCode:       http.StatusNoContent,
+			checkInvalidLabels: true,
+		},
+		{
+			desc: "Partial write; non-adjacent duplicate labels",
+			input: append([]writev2.TimeSeries{{
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 3, 4},
+				Samples:    []writev2.Sample{{Timestamp: 1, Value: 1}, {Timestamp: 2, Value: 2}},
+			}}, writeV2RequestFixture.Timeseries...),
+			expectedCode:          http.StatusBadRequest,
+			expectedRespBody:      `invalid labels for series, labels {__name__="test_metric1", b="c", b="c", baz="qux"}: label name "b" is not unique` + "\n",
+			checkInvalidLabels:    true,
+			expectedInvalidLabels: 2,
 		},
 		{
 			desc: "Partial write; first series with invalid labels (no metric name)",
@@ -407,7 +469,7 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 				writeV2RequestFixture.Timeseries...,
 			),
 			expectedCode:     http.StatusBadRequest,
-			expectedRespBody: "invalid labels for series, labels {__name__=\"test_metric1\", test_metric1=\"test_metric1\", test_metric1=\"test_metric1\"}, duplicated label test_metric1\n",
+			expectedRespBody: "invalid labels for series, labels {__name__=\"test_metric1\", test_metric1=\"test_metric1\", test_metric1=\"test_metric1\"}: label name \"test_metric1\" is not unique\n",
 		},
 		{
 			desc: "Partial write; first series with odd number of label refs",
@@ -744,16 +806,21 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 				appendExemplarErr:     tc.appendExemplarErr,
 				updateMetadataErr:     tc.updateMetadataErr,
 			}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, tc.ingestSTZeroSample, tc.enableTypeAndUnitLabels, tc.appendMetadata)
+			reg := prometheus.NewRegistry()
+			handler := NewWriteHandler(promslog.NewNopLogger(), reg, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, tc.ingestSTZeroSample, tc.enableTypeAndUnitLabels, tc.appendMetadata)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
 
 			resp := recorder.Result()
+			t.Cleanup(func() { require.NoError(t, resp.Body.Close()) })
 			require.Equal(t, tc.expectedCode, resp.StatusCode)
 			respBody, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedRespBody, string(respBody))
+			if tc.checkInvalidLabels {
+				requireInvalidLabelSamples(t, reg, tc.expectedInvalidLabels)
+			}
 
 			if tc.expectedCode == http.StatusInternalServerError {
 				// We don't expect writes for partial writes with retry-able code.
@@ -930,8 +997,7 @@ func TestRemoteWriteHandler_V2Message_NoDuplicateTypeAndUnitLabels(t *testing.T)
 			require.Len(t, appendable.samples, 1)
 			receivedLabels := appendable.samples[0].l
 
-			duplicateLabel, hasDuplicate := receivedLabels.HasDuplicateLabelNames()
-			require.False(t, hasDuplicate, "Labels should NOT contain duplicates, but found duplicate label: %s\nReceived labels: %s", duplicateLabel, receivedLabels.String())
+			require.NoError(t, receivedLabels.ValidateOrder(), "Labels should have unique, sorted names")
 
 			require.Equal(t, tc.expectedLabels.String(), receivedLabels.String(), "Labels should match expected")
 
@@ -1396,7 +1462,7 @@ func (m *mockAppendable) Append(_ storage.SeriesRef, l labels.Labels, t int64, v
 	if l.IsEmpty() {
 		return 0, tsdb.ErrInvalidSample
 	}
-	if _, hasDuplicates := l.HasDuplicateLabelNames(); hasDuplicates {
+	if err := l.ValidateOrder(); err != nil {
 		return 0, tsdb.ErrInvalidSample
 	}
 
@@ -1459,7 +1525,7 @@ func (m *mockAppendable) AppendHistogram(_ storage.SeriesRef, l labels.Labels, t
 	if l.IsEmpty() {
 		return 0, tsdb.ErrInvalidSample
 	}
-	if _, hasDuplicates := l.HasDuplicateLabelNames(); hasDuplicates {
+	if err := l.ValidateOrder(); err != nil {
 		return 0, tsdb.ErrInvalidSample
 	}
 
@@ -1499,7 +1565,7 @@ func (m *mockAppendable) AppendHistogramSTZeroSample(_ storage.SeriesRef, l labe
 		return 0, tsdb.ErrInvalidSample
 	}
 
-	if _, hasDuplicates := l.HasDuplicateLabelNames(); hasDuplicates {
+	if err := l.ValidateOrder(); err != nil {
 		return 0, tsdb.ErrInvalidSample
 	}
 
@@ -1543,7 +1609,7 @@ func (m *mockAppendable) AppendSTZeroSample(_ storage.SeriesRef, l labels.Labels
 	if l.IsEmpty() {
 		return 0, tsdb.ErrInvalidSample
 	}
-	if _, hasDuplicates := l.HasDuplicateLabelNames(); hasDuplicates {
+	if err := l.ValidateOrder(); err != nil {
 		return 0, tsdb.ErrInvalidSample
 	}
 

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -940,15 +940,15 @@ func (a *appenderBase) getOrCreate(ref chunks.HeadSeriesRef, l labels.Labels) (s
 		}
 	}
 
-	// Ensure no empty or duplicate labels have gotten through. This mirrors the
+	// Ensure no empty or out-of-order labels have gotten through. This mirrors the
 	// equivalent validation code in the TSDB's headAppender.
 	l = l.WithoutEmpty()
 	if l.IsEmpty() {
 		return nil, fmt.Errorf("empty labelset: %w", tsdb.ErrInvalidSample)
 	}
 
-	if lbl, dup := l.HasDuplicateLabelNames(); dup {
-		return nil, fmt.Errorf(`label name "%s" is not unique: %w`, lbl, tsdb.ErrInvalidSample)
+	if lbl, outOfOrder := l.HasOutOfOrderLabel(); outOfOrder {
+		return nil, fmt.Errorf(`label name "%s" is out of order: %w`, lbl, tsdb.ErrInvalidSample)
 	}
 
 	hash := l.Hash()
@@ -1014,8 +1014,8 @@ func (a *appender) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, e exem
 }
 
 func (a *appenderBase) validateExemplar(ref chunks.HeadSeriesRef, e exemplar.Exemplar) error {
-	if lbl, dup := e.Labels.HasDuplicateLabelNames(); dup {
-		return fmt.Errorf(`label name "%s" is not unique: %w`, lbl, tsdb.ErrInvalidExemplar)
+	if lbl, outOfOrder := e.Labels.HasOutOfOrderLabel(); outOfOrder {
+		return fmt.Errorf(`label name "%s" is out of order: %w`, lbl, tsdb.ErrInvalidExemplar)
 	}
 
 	// Exemplar label length does not include chars involved in text rendering such as quotes

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -940,15 +940,14 @@ func (a *appenderBase) getOrCreate(ref chunks.HeadSeriesRef, l labels.Labels) (s
 		}
 	}
 
-	// Ensure no empty or out-of-order labels have gotten through. This mirrors the
-	// equivalent validation code in the TSDB's headAppender.
+	// Match the TSDB head's label normalization and validation.
 	l = l.WithoutEmpty()
 	if l.IsEmpty() {
 		return nil, fmt.Errorf("empty labelset: %w", tsdb.ErrInvalidSample)
 	}
 
-	if lbl, outOfOrder := l.HasOutOfOrderLabel(); outOfOrder {
-		return nil, fmt.Errorf(`label name "%s" is out of order: %w`, lbl, tsdb.ErrInvalidSample)
+	if err := l.ValidateOrder(); err != nil {
+		return nil, fmt.Errorf("%w: %w", err, tsdb.ErrInvalidSample)
 	}
 
 	hash := l.Hash()
@@ -1014,8 +1013,8 @@ func (a *appender) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, e exem
 }
 
 func (a *appenderBase) validateExemplar(ref chunks.HeadSeriesRef, e exemplar.Exemplar) error {
-	if lbl, outOfOrder := e.Labels.HasOutOfOrderLabel(); outOfOrder {
-		return fmt.Errorf(`label name "%s" is out of order: %w`, lbl, tsdb.ErrInvalidExemplar)
+	if err := e.Labels.ValidateOrder(); err != nil {
+		return fmt.Errorf("%w: %w", err, tsdb.ErrInvalidExemplar)
 	}
 
 	// Exemplar label length does not include chars involved in text rendering such as quotes

--- a/tsdb/agent/db_append_v2_test.go
+++ b/tsdb/agent/db_append_v2_test.go
@@ -51,7 +51,7 @@ func TestDB_InvalidSeries_AppendV2(t *testing.T) {
 		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject empty labels")
 
 		_, err = app.Append(0, labels.FromStrings("a", "1", "a", "2"), 0, 0, 0, nil, nil, storage.AOptions{})
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject duplicate labels")
+		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject out of order labels")
 	})
 
 	t.Run("Histograms", func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestDB_InvalidSeries_AppendV2(t *testing.T) {
 		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject empty labels")
 
 		_, err = app.Append(0, labels.FromStrings("a", "1", "a", "2"), 0, 0, 0, tsdbutil.GenerateTestHistograms(1)[0], nil, storage.AOptions{})
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject duplicate labels")
+		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject out of order labels")
 	})
 
 	t.Run("Exemplars", func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestDB_InvalidSeries_AppendV2(t *testing.T) {
 		partErr := &storage.AppendPartialError{}
 		require.ErrorAs(t, err, &partErr)
 		require.Len(t, partErr.ExemplarErrors, 1)
-		require.ErrorIs(t, partErr.ExemplarErrors[0], tsdb.ErrInvalidExemplar, "should reject duplicate labels")
+		require.ErrorIs(t, partErr.ExemplarErrors[0], tsdb.ErrInvalidExemplar, "should reject out of order labels")
 
 		e = exemplar.Exemplar{Labels: labels.FromStrings("a_somewhat_long_trace_id", "nYJSNtFrFTY37VR7mHzEE/LIDt7cdAQcuOzFajgmLDAdBSRHYPDzrxhMA4zz7el8naI/AoXFv9/e/G0vcETcIoNUi3OieeLfaIRQci2oa")}
 		_, err = app.Append(0, labels.FromStrings("a", "2"), 0, 0, 0, nil, nil, storage.AOptions{

--- a/tsdb/agent/db_append_v2_test.go
+++ b/tsdb/agent/db_append_v2_test.go
@@ -33,62 +33,12 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
-	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/tsdb/wlog"
 	"github.com/prometheus/prometheus/util/testutil"
 )
-
-func TestDB_InvalidSeries_AppendV2(t *testing.T) {
-	s := createTestAgentDB(t, nil, DefaultOptions())
-	defer s.Close()
-
-	app := s.AppenderV2(context.Background())
-	t.Run("Samples", func(t *testing.T) {
-		_, err := app.Append(0, labels.Labels{}, 0, 0, 0, nil, nil, storage.AOptions{})
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject empty labels")
-
-		_, err = app.Append(0, labels.FromStrings("a", "1", "a", "2"), 0, 0, 0, nil, nil, storage.AOptions{})
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject out of order labels")
-	})
-
-	t.Run("Histograms", func(t *testing.T) {
-		_, err := app.Append(0, labels.Labels{}, 0, 0, 0, tsdbutil.GenerateTestHistograms(1)[0], nil, storage.AOptions{})
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject empty labels")
-
-		_, err = app.Append(0, labels.FromStrings("a", "1", "a", "2"), 0, 0, 0, tsdbutil.GenerateTestHistograms(1)[0], nil, storage.AOptions{})
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject out of order labels")
-	})
-
-	t.Run("Exemplars", func(t *testing.T) {
-		e := exemplar.Exemplar{Labels: labels.FromStrings("a", "1", "a", "2")}
-		_, err := app.Append(0, labels.FromStrings("a", "1"), 0, 0, 0, nil, nil, storage.AOptions{
-			Exemplars: []exemplar.Exemplar{e},
-		})
-		partErr := &storage.AppendPartialError{}
-		require.ErrorAs(t, err, &partErr)
-		require.Len(t, partErr.ExemplarErrors, 1)
-		require.ErrorIs(t, partErr.ExemplarErrors[0], tsdb.ErrInvalidExemplar, "should reject out of order labels")
-
-		e = exemplar.Exemplar{Labels: labels.FromStrings("a_somewhat_long_trace_id", "nYJSNtFrFTY37VR7mHzEE/LIDt7cdAQcuOzFajgmLDAdBSRHYPDzrxhMA4zz7el8naI/AoXFv9/e/G0vcETcIoNUi3OieeLfaIRQci2oa")}
-		_, err = app.Append(0, labels.FromStrings("a", "2"), 0, 0, 0, nil, nil, storage.AOptions{
-			Exemplars: []exemplar.Exemplar{e},
-		})
-		partErr = &storage.AppendPartialError{}
-		require.ErrorAs(t, err, &partErr)
-		require.Len(t, partErr.ExemplarErrors, 1)
-		require.ErrorIs(t, partErr.ExemplarErrors[0], storage.ErrExemplarLabelLength, "should reject too long label length")
-
-		// Inverse check.
-		e = exemplar.Exemplar{Labels: labels.FromStrings("a", "1"), Value: 20, Ts: 10, HasTs: true}
-		_, err = app.Append(0, labels.FromStrings("a", "1"), 0, 0, 0, nil, nil, storage.AOptions{
-			Exemplars: []exemplar.Exemplar{e},
-		})
-		require.NoError(t, err, "should not reject valid exemplars")
-	})
-}
 
 // TestCommit_AppendV2 tests Appender commit.
 // TODO(bwplotka): Rewrite this so Refs are generated, then appended, then expected so we test the

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -56,7 +56,7 @@ func TestDB_InvalidSeries(t *testing.T) {
 		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject empty labels")
 
 		_, err = app.Append(0, labels.FromStrings("a", "1", "a", "2"), 0, 0)
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject duplicate labels")
+		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject out of order labels")
 	})
 
 	t.Run("Histograms", func(t *testing.T) {
@@ -64,7 +64,7 @@ func TestDB_InvalidSeries(t *testing.T) {
 		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject empty labels")
 
 		_, err = app.AppendHistogram(0, labels.FromStrings("a", "1", "a", "2"), 0, tsdbutil.GenerateTestHistograms(1)[0], nil)
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject duplicate labels")
+		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject out of order labels")
 	})
 
 	t.Run("Exemplars", func(t *testing.T) {
@@ -76,7 +76,7 @@ func TestDB_InvalidSeries(t *testing.T) {
 
 		e := exemplar.Exemplar{Labels: labels.FromStrings("a", "1", "a", "2")}
 		_, err = app.AppendExemplar(sRef, labels.EmptyLabels(), e)
-		require.ErrorIs(t, err, tsdb.ErrInvalidExemplar, "should reject duplicate labels")
+		require.ErrorIs(t, err, tsdb.ErrInvalidExemplar, "should reject out of order labels")
 
 		e = exemplar.Exemplar{Labels: labels.FromStrings("a_somewhat_long_trace_id", "nYJSNtFrFTY37VR7mHzEE/LIDt7cdAQcuOzFajgmLDAdBSRHYPDzrxhMA4zz7el8naI/AoXFv9/e/G0vcETcIoNUi3OieeLfaIRQci2oa")}
 		_, err = app.AppendExemplar(sRef, labels.EmptyLabels(), e)

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -46,47 +47,235 @@ import (
 )
 
 func TestDB_InvalidSeries(t *testing.T) {
-	s := createTestAgentDB(t, nil, DefaultOptions())
-	defer s.Close()
+	cases := []struct {
+		name    string
+		pairs   []string
+		wantErr string
+	}{
+		{name: "empty labels", wantErr: "empty labelset"},
+		{name: "duplicate labels", pairs: []string{"a", "1", "a", "2"}, wantErr: `label name "a" is not unique`},
+		{name: "non-adjacent duplicates", pairs: []string{"__name__", "up", "job", "prometheus", "__name__", "down"}, wantErr: `label name "__name__" is out of order`},
+		{name: "descending labels", pairs: []string{"z", "1", "a", "2"}, wantErr: `label name "a" is out of order`},
+		{name: "duplicate empty names", pairs: []string{"", "first", "", "second"}, wantErr: `label name "" is not unique`},
+	}
+	for _, useV2 := range []bool{false, true} {
+		for _, commit := range []bool{false, true} {
+			t.Run(fmt.Sprintf("appV2=%t/commit=%t", useV2, commit), func(t *testing.T) {
+				s := createTestAgentDB(t, nil, DefaultOptions())
+				dbClosed := false
+				t.Cleanup(func() {
+					if !dbClosed {
+						require.NoError(t, s.Close())
+					}
+				})
+				var app storage.AppenderTransaction
+				var a1 storage.Appender
+				var a2 storage.AppenderV2
+				if useV2 {
+					a2 = s.AppenderV2(t.Context())
+					app = a2
+				} else {
+					a1 = s.Appender(t.Context())
+					app = a1
+				}
+				appClosed := false
+				t.Cleanup(func() {
+					if !appClosed {
+						require.NoError(t, app.Rollback())
+					}
+				})
+				appendSample := func(ref storage.SeriesRef, ls labels.Labels, ts int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+					if useV2 {
+						return a2.Append(ref, ls, 0, ts, 0, h, fh, storage.AOptions{})
+					}
+					if h != nil || fh != nil {
+						return a1.AppendHistogram(ref, ls, ts, h, fh)
+					}
+					return a1.Append(ref, ls, ts, 0)
+				}
+				for _, sampleType := range []struct {
+					name string
+					h    *histogram.Histogram
+					fh   *histogram.FloatHistogram
+				}{
+					{name: "samples"},
+					{name: "histograms", h: tsdbutil.GenerateTestHistograms(1)[0]},
+					{name: "float histograms", fh: tsdbutil.GenerateTestFloatHistograms(1)[0]},
+				} {
+					for _, tc := range cases {
+						t.Run(sampleType.name+"/"+tc.name, func(t *testing.T) {
+							builder := labels.NewScratchBuilder(len(tc.pairs) / 2)
+							for i := 0; i < len(tc.pairs); i += 2 {
+								builder.Add(tc.pairs[i], tc.pairs[i+1])
+							}
+							_, err := appendSample(0, builder.Labels(), 1, sampleType.h, sampleType.fh)
+							require.ErrorIs(t, err, tsdb.ErrInvalidSample, "Should reject "+tc.name)
+							require.EqualError(t, err, tc.wantErr+": invalid sample")
+						})
+					}
+				}
 
-	app := s.Appender(context.Background())
+				ref, err := appendSample(0, labels.FromStrings("a", "1"), 10, nil, nil)
+				require.NoError(t, err)
+				// A valid reference must continue to bypass series-label validation.
+				nextRef, err := appendSample(ref, labels.EmptyLabels(), 11, nil, nil)
+				require.NoError(t, err)
+				require.Equal(t, ref, nextRef)
+				headRef := chunks.HeadSeriesRef(ref)
+				wantSeries := []record.RefSeries{{Ref: headRef, Labels: labels.FromStrings("a", "1")}}
+				wantSamples := []record.RefSample{{Ref: headRef, T: 10}, {Ref: headRef, T: 11}}
+				var wantExemplars []record.RefExemplar
+				if !useV2 {
+					_, err := a1.AppendExemplar(0, labels.EmptyLabels(), exemplar.Exemplar{})
+					require.EqualError(t, err, "unknown series ref when trying to add exemplar: 0")
+				}
+				for i, tc := range cases {
+					if len(tc.pairs) == 0 {
+						continue // Empty exemplar label sets are allowed.
+					}
+					t.Run("exemplars/"+tc.name, func(t *testing.T) {
+						builder := labels.NewScratchBuilder(len(tc.pairs) / 2)
+						for j := 0; j < len(tc.pairs); j += 2 {
+							builder.Add(tc.pairs[j], tc.pairs[j+1])
+						}
+						exemplars := []exemplar.Exemplar{
+							{Labels: labels.FromStrings("trace_id", fmt.Sprintf("before_%d", i)), Value: 1, Ts: int64(20 + i), HasTs: true},
+							{Labels: builder.Labels(), Value: 1, Ts: int64(20 + i), HasTs: true},
+							{Labels: labels.FromStrings("trace_id", fmt.Sprintf("after_%d", i)), Value: 1, Ts: int64(20 + i), HasTs: true},
+						}
+						var validationErr error
+						if useV2 {
+							_, err := a2.Append(ref, labels.EmptyLabels(), 0, int64(20+i), 0, nil, nil, storage.AOptions{Exemplars: exemplars})
+							var partialErr *storage.AppendPartialError
+							require.ErrorAs(t, err, &partialErr)
+							require.Len(t, partialErr.ExemplarErrors, 1)
+							validationErr = partialErr.ExemplarErrors[0]
+							wantSamples = append(wantSamples, record.RefSample{Ref: headRef, T: int64(20 + i)})
+						} else {
+							_, err := a1.AppendExemplar(ref, labels.EmptyLabels(), exemplars[0])
+							require.NoError(t, err)
+							_, validationErr = a1.AppendExemplar(ref, labels.EmptyLabels(), exemplars[1])
+							_, err = a1.AppendExemplar(ref, labels.EmptyLabels(), exemplars[2])
+							require.NoError(t, err)
+						}
+						require.ErrorIs(t, validationErr, tsdb.ErrInvalidExemplar, "Should reject "+tc.name)
+						require.EqualError(t, validationErr, tc.wantErr+": invalid exemplar")
+						for _, e := range []exemplar.Exemplar{exemplars[0], exemplars[2]} {
+							wantExemplars = append(wantExemplars, record.RefExemplar{Ref: headRef, T: e.Ts, V: e.Value, Labels: e.Labels})
+						}
+					})
+				}
+				t.Run("exemplars/too long labels", func(t *testing.T) {
+					e := exemplar.Exemplar{Labels: labels.FromStrings("trace_id", strings.Repeat("a", exemplar.ExemplarMaxLabelSetLength))}
+					if useV2 {
+						_, err := a2.Append(ref, labels.EmptyLabels(), 0, 100, 0, nil, nil, storage.AOptions{Exemplars: []exemplar.Exemplar{e}})
+						var partialErr *storage.AppendPartialError
+						require.ErrorAs(t, err, &partialErr)
+						require.Len(t, partialErr.ExemplarErrors, 1)
+						require.ErrorIs(t, partialErr.ExemplarErrors[0], storage.ErrExemplarLabelLength)
+						wantSamples = append(wantSamples, record.RefSample{Ref: headRef, T: 100})
+					} else {
+						_, err := a1.AppendExemplar(ref, labels.EmptyLabels(), e)
+						require.ErrorIs(t, err, storage.ErrExemplarLabelLength)
+					}
+				})
+				if useV2 {
+					for _, tc := range []struct {
+						name        string
+						ls          labels.Labels
+						e           exemplar.Exemplar
+						wantErr     error
+						wantErrText string
+					}{
+						{
+							name:        "duplicate labels",
+							ls:          labels.FromStrings("a", "2"),
+							e:           exemplar.Exemplar{Labels: labels.FromStrings("a", "1", "a", "2")},
+							wantErr:     tsdb.ErrInvalidExemplar,
+							wantErrText: `label name "a" is not unique: invalid exemplar`,
+						},
+						{
+							name:    "too long labels",
+							ls:      labels.FromStrings("a", "3"),
+							e:       exemplar.Exemplar{Labels: labels.FromStrings("a_somewhat_long_trace_id", "nYJSNtFrFTY37VR7mHzEE/LIDt7cdAQcuOzFajgmLDAdBSRHYPDzrxhMA4zz7el8naI/AoXFv9/e/G0vcETcIoNUi3OieeLfaIRQci2oa")},
+							wantErr: storage.ErrExemplarLabelLength,
+						},
+					} {
+						t.Run("exemplars/new series/"+tc.name, func(t *testing.T) {
+							newRef, err := a2.Append(0, tc.ls, 0, 0, 0, nil, nil, storage.AOptions{Exemplars: []exemplar.Exemplar{tc.e}})
+							var partialErr *storage.AppendPartialError
+							require.ErrorAs(t, err, &partialErr)
+							require.Len(t, partialErr.ExemplarErrors, 1)
+							require.ErrorIs(t, partialErr.ExemplarErrors[0], tc.wantErr)
+							if tc.wantErrText != "" {
+								require.EqualError(t, partialErr.ExemplarErrors[0], tc.wantErrText)
+							}
+							require.NotZero(t, newRef)
+							newHeadRef := chunks.HeadSeriesRef(newRef)
+							for _, series := range wantSeries {
+								require.NotEqual(t, series.Ref, newHeadRef)
+							}
+							wantSeries = append(wantSeries, record.RefSeries{Ref: newHeadRef, Labels: tc.ls})
+							wantSamples = append(wantSamples, record.RefSample{Ref: newHeadRef})
 
-	t.Run("Samples", func(t *testing.T) {
-		_, err := app.Append(0, labels.Labels{}, 0, 0)
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject empty labels")
+							// Look up the newly created series by labels and accept a valid exemplar.
+							e := exemplar.Exemplar{Labels: labels.FromStrings("a", "1"), Value: 20, Ts: 10, HasTs: true}
+							nextRef, err := a2.Append(0, tc.ls, 0, 0, 0, nil, nil, storage.AOptions{Exemplars: []exemplar.Exemplar{e}})
+							require.NoError(t, err)
+							require.Equal(t, newRef, nextRef)
+							wantSamples = append(wantSamples, record.RefSample{Ref: newHeadRef})
+							wantExemplars = append(wantExemplars, record.RefExemplar{Ref: newHeadRef, T: e.Ts, V: e.Value, Labels: e.Labels})
+						})
+					}
+				}
+				if commit {
+					err = app.Commit()
+				} else {
+					err = app.Rollback()
+					// Rollback still writes series records so later appends can reference them.
+					wantSamples, wantExemplars = nil, nil
+				}
+				appClosed = true
+				require.NoError(t, err)
+				require.NoError(t, s.Close())
+				dbClosed = true
 
-		_, err = app.Append(0, labels.FromStrings("a", "1", "a", "2"), 0, 0)
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject out of order labels")
-	})
-
-	t.Run("Histograms", func(t *testing.T) {
-		_, err := app.AppendHistogram(0, labels.Labels{}, 0, tsdbutil.GenerateTestHistograms(1)[0], nil)
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject empty labels")
-
-		_, err = app.AppendHistogram(0, labels.FromStrings("a", "1", "a", "2"), 0, tsdbutil.GenerateTestHistograms(1)[0], nil)
-		require.ErrorIs(t, err, tsdb.ErrInvalidSample, "should reject out of order labels")
-	})
-
-	t.Run("Exemplars", func(t *testing.T) {
-		sRef, err := app.Append(0, labels.FromStrings("a", "1"), 0, 0)
-		require.NoError(t, err, "should not reject valid series")
-
-		_, err = app.AppendExemplar(0, labels.EmptyLabels(), exemplar.Exemplar{})
-		require.EqualError(t, err, "unknown series ref when trying to add exemplar: 0")
-
-		e := exemplar.Exemplar{Labels: labels.FromStrings("a", "1", "a", "2")}
-		_, err = app.AppendExemplar(sRef, labels.EmptyLabels(), e)
-		require.ErrorIs(t, err, tsdb.ErrInvalidExemplar, "should reject out of order labels")
-
-		e = exemplar.Exemplar{Labels: labels.FromStrings("a_somewhat_long_trace_id", "nYJSNtFrFTY37VR7mHzEE/LIDt7cdAQcuOzFajgmLDAdBSRHYPDzrxhMA4zz7el8naI/AoXFv9/e/G0vcETcIoNUi3OieeLfaIRQci2oa")}
-		_, err = app.AppendExemplar(sRef, labels.EmptyLabels(), e)
-		require.ErrorIs(t, err, storage.ErrExemplarLabelLength, "should reject too long label length")
-
-		// Inverse check
-		e = exemplar.Exemplar{Labels: labels.FromStrings("a", "1"), Value: 20, Ts: 10, HasTs: true}
-		_, err = app.AppendExemplar(sRef, labels.EmptyLabels(), e)
-		require.NoError(t, err, "should not reject valid exemplars")
-	})
+				sr, err := wlog.NewSegmentsReader(s.wal.Dir())
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, sr.Close()) })
+				r := wlog.NewReader(sr)
+				dec := record.NewDecoder(labels.NewSymbolTable(), promslog.NewNopLogger())
+				var (
+					gotSeries    []record.RefSeries
+					gotSamples   []record.RefSample
+					gotExemplars []record.RefExemplar
+				)
+				for r.Next() {
+					rec := r.Record()
+					switch dec.Type(rec) {
+					case record.Series:
+						series, err := dec.Series(rec, nil)
+						require.NoError(t, err)
+						gotSeries = append(gotSeries, series...)
+					case record.Samples, record.SamplesV2:
+						samples, err := dec.Samples(rec, nil)
+						require.NoError(t, err)
+						gotSamples = append(gotSamples, samples...)
+					case record.Exemplars:
+						exemplars, err := dec.Exemplars(rec, nil)
+						require.NoError(t, err)
+						gotExemplars = append(gotExemplars, exemplars...)
+					default:
+						t.Fatalf("Unexpected WAL record type: %v", dec.Type(rec))
+					}
+				}
+				require.NoError(t, r.Err())
+				testutil.RequireEqual(t, wantSeries, gotSeries, "Only the valid series should reach the WAL")
+				testutil.RequireEqual(t, wantSamples, gotSamples)
+				testutil.RequireEqual(t, wantExemplars, gotExemplars)
+			})
+		}
+	}
 }
 
 func createTestAgentDB(t testing.TB, reg prometheus.Registerer, opts *Options) *DB {

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -566,8 +566,8 @@ func (a *headAppenderBase) getOrCreate(lset labels.Labels) (s *memSeries, create
 	if lset.IsEmpty() {
 		return nil, false, fmt.Errorf("empty labelset: %w", ErrInvalidSample)
 	}
-	if l, dup := lset.HasDuplicateLabelNames(); dup {
-		return nil, false, fmt.Errorf(`label name "%s" is not unique: %w`, l, ErrInvalidSample)
+	if l, outOfOrder := lset.HasOutOfOrderLabel(); outOfOrder {
+		return nil, false, fmt.Errorf(`label name "%s" is out of order: %w`, l, ErrInvalidSample)
 	}
 	s, created, err = a.head.getOrCreate(lset.Hash(), lset, true)
 	if err != nil {

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -566,8 +566,8 @@ func (a *headAppenderBase) getOrCreate(lset labels.Labels) (s *memSeries, create
 	if lset.IsEmpty() {
 		return nil, false, fmt.Errorf("empty labelset: %w", ErrInvalidSample)
 	}
-	if l, outOfOrder := lset.HasOutOfOrderLabel(); outOfOrder {
-		return nil, false, fmt.Errorf(`label name "%s" is out of order: %w`, l, ErrInvalidSample)
+	if err := lset.ValidateOrder(); err != nil {
+		return nil, false, fmt.Errorf("%w: %w", err, ErrInvalidSample)
 	}
 	s, created, err = a.head.getOrCreate(lset.Hash(), lset, true)
 	if err != nil {

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -771,21 +771,39 @@ func TestHeadAppenderV2_NewWalSegmentOnTruncate(t *testing.T) {
 	require.Equal(t, 2, last)
 }
 
-func TestHeadAppenderV2_Append_DuplicateLabelName(t *testing.T) {
+func TestHeadAppenderV2_Append_OutOfOrderLabelName(t *testing.T) {
 	h, _ := newTestHead(t, 1000, compression.None, false)
 	defer func() {
 		require.NoError(t, h.Close())
 	}()
 
-	add := func(labels labels.Labels, labelName string) {
+	add := func(lbls labels.Labels, labelName string) {
 		app := h.AppenderV2(context.Background())
-		_, err := app.Append(0, labels, 0, 0, 0, nil, nil, storage.AOptions{})
-		require.EqualError(t, err, fmt.Sprintf(`label name "%s" is not unique: invalid sample`, labelName))
+		_, err := app.Append(0, lbls, 0, 0, 0, nil, nil, storage.AOptions{})
+		require.EqualError(t, err, fmt.Sprintf(`label name "%s" is out of order: invalid sample`, labelName))
 	}
 
+	// Test adjacent duplicates (created via FromStrings which sorts).
 	add(labels.FromStrings("a", "c", "a", "b"), "a")
 	add(labels.FromStrings("a", "c", "a", "c"), "a")
 	add(labels.FromStrings("__name__", "up", "job", "prometheus", "le", "500", "le", "400", "unit", "s"), "le")
+
+	// Helper to create unsorted labels using ScratchBuilder without Sort().
+	unsortedLabels := func(ss ...string) labels.Labels {
+		b := labels.NewScratchBuilder(len(ss) / 2)
+		for i := 0; i < len(ss); i += 2 {
+			b.Add(ss[i], ss[i+1])
+		}
+		return b.Labels()
+	}
+
+	// Test non-adjacent duplicates (the bug that was previously missed).
+	// These labels have duplicate __name__ but they're not adjacent because labels are unsorted.
+	add(unsortedLabels("__name__", "up", "job", "prometheus", "__name__", "down"), "__name__")
+
+	// Test purely out-of-order labels (no duplicates, just unsorted).
+	add(unsortedLabels("z", "1", "a", "2"), "a")
+	add(unsortedLabels("b", "1", "a", "2", "c", "3"), "a")
 }
 
 func TestHeadAppenderV2_MemSeriesIsolation(t *testing.T) {

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -771,41 +771,6 @@ func TestHeadAppenderV2_NewWalSegmentOnTruncate(t *testing.T) {
 	require.Equal(t, 2, last)
 }
 
-func TestHeadAppenderV2_Append_OutOfOrderLabelName(t *testing.T) {
-	h, _ := newTestHead(t, 1000, compression.None, false)
-	defer func() {
-		require.NoError(t, h.Close())
-	}()
-
-	add := func(lbls labels.Labels, labelName string) {
-		app := h.AppenderV2(context.Background())
-		_, err := app.Append(0, lbls, 0, 0, 0, nil, nil, storage.AOptions{})
-		require.EqualError(t, err, fmt.Sprintf(`label name "%s" is out of order: invalid sample`, labelName))
-	}
-
-	// Test adjacent duplicates (created via FromStrings which sorts).
-	add(labels.FromStrings("a", "c", "a", "b"), "a")
-	add(labels.FromStrings("a", "c", "a", "c"), "a")
-	add(labels.FromStrings("__name__", "up", "job", "prometheus", "le", "500", "le", "400", "unit", "s"), "le")
-
-	// Helper to create unsorted labels using ScratchBuilder without Sort().
-	unsortedLabels := func(ss ...string) labels.Labels {
-		b := labels.NewScratchBuilder(len(ss) / 2)
-		for i := 0; i < len(ss); i += 2 {
-			b.Add(ss[i], ss[i+1])
-		}
-		return b.Labels()
-	}
-
-	// Test non-adjacent duplicates (the bug that was previously missed).
-	// These labels have duplicate __name__ but they're not adjacent because labels are unsorted.
-	add(unsortedLabels("__name__", "up", "job", "prometheus", "__name__", "down"), "__name__")
-
-	// Test purely out-of-order labels (no duplicates, just unsorted).
-	add(unsortedLabels("z", "1", "a", "2"), "a")
-	add(unsortedLabels("b", "1", "a", "2", "c", "3"), "a")
-}
-
 func TestHeadAppenderV2_MemSeriesIsolation(t *testing.T) {
 	if defaultIsolationDisabled {
 		t.Skip("skipping test since tsdb isolation is disabled")

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3316,18 +3316,36 @@ func TestNewWalSegmentOnTruncate(t *testing.T) {
 	require.Equal(t, 2, last)
 }
 
-func TestAddDuplicateLabelName(t *testing.T) {
+func TestAddOutOfOrderLabelName(t *testing.T) {
 	h, _ := newTestHead(t, 1000, compression.None, false)
 
-	add := func(labels labels.Labels, labelName string) {
+	add := func(lbls labels.Labels, labelName string) {
 		app := h.Appender(context.Background())
-		_, err := app.Append(0, labels, 0, 0)
-		require.EqualError(t, err, fmt.Sprintf(`label name "%s" is not unique: invalid sample`, labelName))
+		_, err := app.Append(0, lbls, 0, 0)
+		require.EqualError(t, err, fmt.Sprintf(`label name "%s" is out of order: invalid sample`, labelName))
 	}
 
+	// Test adjacent duplicates (created via FromStrings which sorts).
 	add(labels.FromStrings("a", "c", "a", "b"), "a")
 	add(labels.FromStrings("a", "c", "a", "c"), "a")
 	add(labels.FromStrings("__name__", "up", "job", "prometheus", "le", "500", "le", "400", "unit", "s"), "le")
+
+	// Helper to create unsorted labels using ScratchBuilder without Sort().
+	unsortedLabels := func(ss ...string) labels.Labels {
+		b := labels.NewScratchBuilder(len(ss) / 2)
+		for i := 0; i < len(ss); i += 2 {
+			b.Add(ss[i], ss[i+1])
+		}
+		return b.Labels()
+	}
+
+	// Test non-adjacent duplicates (the bug that was previously missed).
+	// These labels have duplicate __name__ but they're not adjacent because labels are unsorted.
+	add(unsortedLabels("__name__", "up", "job", "prometheus", "__name__", "down"), "__name__")
+
+	// Test purely out-of-order labels (no duplicates, just unsorted).
+	add(unsortedLabels("z", "1", "a", "2"), "a")
+	add(unsortedLabels("b", "1", "a", "2", "c", "3"), "a")
 }
 
 func TestMemSeriesIsolation(t *testing.T) {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3316,36 +3316,85 @@ func TestNewWalSegmentOnTruncate(t *testing.T) {
 	require.Equal(t, 2, last)
 }
 
-func TestAddOutOfOrderLabelName(t *testing.T) {
-	h, _ := newTestHead(t, 1000, compression.None, false)
-
-	add := func(lbls labels.Labels, labelName string) {
-		app := h.Appender(context.Background())
-		_, err := app.Append(0, lbls, 0, 0)
-		require.EqualError(t, err, fmt.Sprintf(`label name "%s" is out of order: invalid sample`, labelName))
-	}
-
-	// Test adjacent duplicates (created via FromStrings which sorts).
-	add(labels.FromStrings("a", "c", "a", "b"), "a")
-	add(labels.FromStrings("a", "c", "a", "c"), "a")
-	add(labels.FromStrings("__name__", "up", "job", "prometheus", "le", "500", "le", "400", "unit", "s"), "le")
-
-	// Helper to create unsorted labels using ScratchBuilder without Sort().
-	unsortedLabels := func(ss ...string) labels.Labels {
-		b := labels.NewScratchBuilder(len(ss) / 2)
-		for i := 0; i < len(ss); i += 2 {
-			b.Add(ss[i], ss[i+1])
+func TestHeadAppender_ValidateOrder(t *testing.T) {
+	for _, appV2 := range []bool{false, true} {
+		for _, sampleType := range []string{"float", "histogram", "float histogram"} {
+			for _, commit := range []bool{false, true} {
+				t.Run(fmt.Sprintf("appV2=%t/type=%s/commit=%t", appV2, sampleType, commit), func(t *testing.T) {
+					h, wal := newTestHead(t, 1000, compression.None, false)
+					var app storage.AppenderTransaction
+					var appendSample func(labels.Labels) error
+					var hist *histogram.Histogram
+					var floatHist *histogram.FloatHistogram
+					switch sampleType {
+					case "histogram":
+						hist = tsdbutil.GenerateTestHistograms(1)[0]
+					case "float histogram":
+						floatHist = tsdbutil.GenerateTestFloatHistograms(1)[0]
+					}
+					if appV2 {
+						a := h.AppenderV2(t.Context())
+						app = a
+						appendSample = func(ls labels.Labels) error {
+							_, err := a.Append(0, ls, 0, 1, 1, hist, floatHist, storage.AOptions{})
+							return err
+						}
+					} else {
+						a := h.Appender(t.Context())
+						app = a
+						appendSample = func(ls labels.Labels) error {
+							if hist != nil || floatHist != nil {
+								_, err := a.AppendHistogram(0, ls, 1, hist, floatHist)
+								return err
+							}
+							_, err := a.Append(0, ls, 1, 1)
+							return err
+						}
+					}
+					closed := false
+					t.Cleanup(func() {
+						if !closed {
+							require.NoError(t, app.Rollback())
+						}
+					})
+					for _, tc := range []struct {
+						name    string
+						pairs   []string
+						wantErr string
+					}{
+						{name: "duplicate labels", pairs: []string{"a", "c", "a", "b"}, wantErr: `label name "a" is not unique`},
+						{name: "identical labels", pairs: []string{"a", "c", "a", "c"}, wantErr: `label name "a" is not unique`},
+						{name: "duplicate bucket labels", pairs: []string{"__name__", "up", "job", "prometheus", "le", "500", "le", "400", "unit", "s"}, wantErr: `label name "le" is not unique`},
+						{name: "duplicate empty names", pairs: []string{"", "first", "", "second"}, wantErr: `label name "" is not unique`},
+						{name: "non-adjacent duplicates", pairs: []string{"__name__", "up", "job", "prometheus", "__name__", "down"}, wantErr: `label name "__name__" is out of order`},
+						{name: "descending labels", pairs: []string{"z", "1", "a", "2"}, wantErr: `label name "a" is out of order`},
+						{name: "descending labels before last", pairs: []string{"b", "1", "a", "2", "c", "3"}, wantErr: `label name "a" is out of order`},
+					} {
+						t.Run(tc.name, func(t *testing.T) {
+							builder := labels.NewScratchBuilder(len(tc.pairs) / 2)
+							for i := 0; i < len(tc.pairs); i += 2 {
+								builder.Add(tc.pairs[i], tc.pairs[i+1])
+							}
+							err := appendSample(builder.Labels())
+							require.ErrorIs(t, err, ErrInvalidSample)
+							require.EqualError(t, err, tc.wantErr+": invalid sample")
+						})
+					}
+					var err error
+					if commit {
+						err = app.Commit()
+					} else {
+						err = app.Rollback()
+					}
+					closed = true
+					require.NoError(t, err)
+					require.Zero(t, h.NumSeries())
+					require.NoError(t, h.Close())
+					require.Empty(t, readTestWAL(t, wal.Dir()), "Rejected series must not reach the WAL")
+				})
+			}
 		}
-		return b.Labels()
 	}
-
-	// Test non-adjacent duplicates (the bug that was previously missed).
-	// These labels have duplicate __name__ but they're not adjacent because labels are unsorted.
-	add(unsortedLabels("__name__", "up", "job", "prometheus", "__name__", "down"), "__name__")
-
-	// Test purely out-of-order labels (no duplicates, just unsorted).
-	add(unsortedLabels("z", "1", "a", "2"), "a")
-	add(unsortedLabels("b", "1", "a", "2", "c", "3"), "a")
 }
 
 func TestMemSeriesIsolation(t *testing.T) {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Related to #11505. This PR enforces label ordering at the TSDB append boundary; remote-write requests with unsorted labels are still normalized and accepted.

#### Does this PR introduce a user-facing change?

```release-notes
[ENHANCEMENT] TSDB: Reject series with out-of-order labels at append time, preventing corrupted series from being written to WAL.
```

#### Motivation

Replace `labels.HasDuplicateLabelNames()` with `Labels.ValidateOrder()` in the TSDB append path validation. This catches both duplicate labels AND unsorted labels, preventing corrupted series from being written to the WAL. The PR comes out of a [suggestion](https://github.com/prometheus/prometheus/pull/17891#pullrequestreview-3702996728) from @codesome.

Previously, `HasDuplicateLabelNames()` only detected adjacent duplicates, assuming labels were sorted. If a buggy client sent unsorted labels with non-adjacent duplicates (e.g., `__name__="up", job="x", __name__="down"`), the validation would pass, the corrupted series would be written to WAL, and later cause compaction failures.

#### Performance

Default `stringlabels` build, Go 1.27.1, Apple M4 Pro (darwin/arm64). Six repetitions with 1-second benchmark windows, `-benchmem`, and `GOMAXPROCS=2`, run serially.

`baseline` is the duplicate-only implementation at `53144df54`. `revised` is the `ValidateOrder` implementation measured during review, before subsequent rebases.

Strict ordering adds approximately 4.8–31.4 ns for 5–30 labels. Valid-input validation remains allocation-free. No statistically significant slowdown was observed in the measured head-appender or scrape workloads.

<details>
<summary>Benchstat timings</summary>

**Direct label validation**

```text
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Apple M4 Pro
                                       │  baseline   │               revised                │
                                       │   sec/op    │    sec/op     vs base                │
Labels_ValidateOrder/labels=5/valid-2    6.757n ± 1%   11.525n ± 2%   +70.56% (p=0.002 n=6)
Labels_ValidateOrder/labels=10/valid-2   12.04n ± 1%    26.99n ± 6%  +124.22% (p=0.002 n=6)
Labels_ValidateOrder/labels=30/valid-2   45.41n ± 1%    76.84n ± 1%   +69.22% (p=0.002 n=6)
geomean                                  15.46n         28.80n        +86.36%
```

**Head append/commit**

These cases use `ref=0`, exercising label validation.

```text
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Apple M4 Pro
                                                                                    │  baseline   │              revised              │
                                                                                    │   sec/op    │   sec/op     vs base              │
HeadAppender_AppendCommit/appender=v1/case=floats/series=10/samples_per_append=1-2    20.43µ ± 4%   21.44µ ± 7%       ~ (p=0.093 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=1-2   167.9µ ± 3%   169.5µ ± 8%       ~ (p=0.093 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=10/samples_per_append=1-2    20.28µ ± 3%   20.79µ ± 6%       ~ (p=0.093 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=1-2   167.6µ ± 5%   168.8µ ± 3%       ~ (p=0.485 n=6)
geomean                                                                               58.44µ        59.76µ       +2.27%
```

**Scrape with storage — Appender V1**

Scrape benchmarks include series-reference caching and complement the
`ref=0` head-appender measurements.

```text
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/scrape
cpu: Apple M4 Pro
                                                                                                            │  baseline   │              revised              │
                                                                                                            │   sec/op    │   sec/op     vs base              │
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2    330.4µ ± 1%   329.6µ ± 2%       ~ (p=0.394 n=6)
ScrapeLoopAppend/withStorage=true/appV2=false/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2   518.3µ ± 1%   517.2µ ± 2%       ~ (p=1.000 n=6)
geomean                                                                                                       413.8µ        412.9µ       -0.22%
```

**Scrape with storage — Appender V2**

```text
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/scrape
cpu: Apple M4 Pro
                                                                                                           │  baseline   │              revised              │
                                                                                                           │   sec/op    │   sec/op     vs base              │
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=1Fam2000Gauges/fmt=PromText-2    374.6µ ± 2%   368.7µ ± 1%  -1.57% (p=0.002 n=6)
ScrapeLoopAppend/withStorage=true/appV2=true/appendMetadataToWAL=false/data=237FamsAllTypes/fmt=PromText-2   548.0µ ± 2%   548.9µ ± 0%       ~ (p=0.699 n=6)
geomean                                                                                                      453.1µ        449.8µ       -0.71%
```

</details>
