### PR TITLE
tests: improve error handling and helper attribution in main_test.go

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -395,6 +395,7 @@ func TestTimeMetrics(t *testing.T) {
 }
 
 func getCurrentGaugeValuesFor(t *testing.T, reg prometheus.Gatherer, metricNames ...string) map[string]float64 {
+	t.Helper()
 	f, err := reg.Gather()
 	require.NoError(t, err)
 
@@ -426,7 +427,7 @@ func TestAgentSuccessfulStartup(t *testing.T) {
 	go func() { done <- prom.Wait() }()
 	select {
 	case err := <-done:
-		t.Logf("prometheus agent should be still running: %v", err)
+		t.Logf("prometheus agent exited early: %v", err)
 		actualExitStatus = prom.ProcessState.ExitCode()
 	case <-time.After(startupTime):
 		prom.Process.Kill()
@@ -571,12 +572,7 @@ func TestDocumentation(t *testing.T) {
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 
-	if err := cmd.Run(); err != nil {
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) && exitError.ExitCode() != 0 {
-			fmt.Println("Command failed with non-zero exit code")
-		}
-	}
+	require.NoError(t, cmd.Run(), "failed to generate CLI documentation via --write-documentation")
 
 	generatedContent := strings.ReplaceAll(stdout.String(), filepath.Base(promPath), strings.TrimSuffix(filepath.Base(promPath), ".test"))
 
@@ -753,7 +749,7 @@ global:
 			configFile := filepath.Join(tmpDir, "prometheus.yml")
 
 			port := testutil.RandomUnprivilegedPort(t)
-			os.WriteFile(configFile, []byte(tc.config), 0o777)
+			require.NoError(t, os.WriteFile(configFile, []byte(tc.config), 0o777))
 			prom := prometheusCommandWithLogging(
 				t,
 				configFile,
@@ -801,7 +797,7 @@ global:
 			newConfig := `
 runtime:
   gogc: 99`
-			os.WriteFile(configFile, []byte(newConfig), 0o777)
+			require.NoError(t, os.WriteFile(configFile, []byte(newConfig), 0o777))
 			reloadPrometheusConfig(t, reloadURL)
 			ensureGOGCValue(99.0)
 		})
@@ -834,7 +830,7 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:%d']
 `, port, port)
-			os.WriteFile(configFile, []byte(config), 0o777)
+			require.NoError(t, os.WriteFile(configFile, []byte(config), 0o777))
 
 			prom := prometheusCommandWithLogging(
 				t,
@@ -995,7 +991,7 @@ func TestRemoteWrite_ReshardingWithoutDeadlock(t *testing.T) {
 	config := fmt.Sprintf(`
 global:
   # Using a smaller interval may cause the scrape to time out.
-  scrape_interval: 1s  
+  scrape_interval: 1s
 scrape_configs:
   - job_name: 'self'
     static_configs:


### PR DESCRIPTION
This PR adds missing error checks for file write operations and improves test helper attribution in cmd/prometheus/main_test.go.

Previously, several tests using os.WriteFile didn't check for errors, which could lead to confusing test failures if file operations failed. I've added require.NoError checks to catch these failures early.

I also added t.Helper() to the getCurrentGaugeValuesFor function so that when tests fail, the error messages point to the actual test code rather than inside the helper function. The TestDocumentation function now properly asserts command success instead of silently continuing on failure.

These are small improvements that make the tests more reliable and easier to debug.


<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

<!--
#### Which issue(s) does the PR fix:
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

<!--

#### Does this PR introduce a user-facing change?

If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->

```release-notes
NONE
```