### PR TITLE
tests: move OTLP handler tests to teststorage.Appendable; increase test coverage.

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -483,6 +483,8 @@ func (*writeHandler) handleHistogramZeroSample(app storage.Appender, ref storage
 	return ref, err
 }
 
+// TODO(bwplotka): Consider exposing timeLimitAppender and bucketLimitAppender appenders from scrape/target.go
+// to DRY, they do the same.
 type remoteWriteAppender struct {
 	storage.Appender
 

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -1267,6 +1267,7 @@ func genSeriesWithSample(numSeries int, ts int64) []prompb.TimeSeries {
 	return series
 }
 
+// TODO(bwplotka): Delete and switch all to teststorage.Appendable.
 type mockAppendable struct {
 	latestSample    map[uint64]int64
 	samples         []mockSample


### PR DESCRIPTION
Progresses https://github.com/prometheus/prometheus/issues/17632

Depends on [bwplotka/a2-otlp-1](https://github.com/prometheus/prometheus/pull/17990)

Switching tests to a new mock framework so switch to AppenderV2 PR will be clean.

On the way I increased test coverage:
* We now test all samples, by detailed expectations, including histogram translation, exemplar detail etc

And removed unnecessary cases e.g.:
* Test type and unit only once, those do not depend on translation.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
