### PR TITLE
fix(tsdb): remove useless code

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3740,12 +3740,12 @@ func TestHistogramRateWithFloatStaleness(t *testing.T) {
 		recoded bool
 	)
 
-	newc, recoded, app, err = app.AppendHistogram(nil, 0, 0, h1.Copy(), false)
+	newc, recoded, app, err = app.AppendHistogram(0, 0, h1.Copy(), false)
 	require.NoError(t, err)
 	require.False(t, recoded)
 	require.Nil(t, newc)
 
-	newc, recoded, _, err = app.AppendHistogram(nil, 0, 10, h1.Copy(), false)
+	newc, recoded, _, err = app.AppendHistogram(0, 10, h1.Copy(), false)
 	require.NoError(t, err)
 	require.False(t, recoded)
 	require.Nil(t, newc)
@@ -3766,12 +3766,12 @@ func TestHistogramRateWithFloatStaleness(t *testing.T) {
 	app, err = c3.Appender()
 	require.NoError(t, err)
 
-	newc, recoded, app, err = app.AppendHistogram(nil, 0, 30, h2.Copy(), false)
+	newc, recoded, app, err = app.AppendHistogram(0, 30, h2.Copy(), false)
 	require.NoError(t, err)
 	require.False(t, recoded)
 	require.Nil(t, newc)
 
-	newc, recoded, _, err = app.AppendHistogram(nil, 0, 40, h2.Copy(), false)
+	newc, recoded, _, err = app.AppendHistogram(0, 40, h2.Copy(), false)
 	require.NoError(t, err)
 	require.False(t, recoded)
 	require.Nil(t, newc)

--- a/storage/series.go
+++ b/storage/series.go
@@ -373,7 +373,7 @@ func (s *seriesToChunkEncoder) Iterator(it chunks.Iterator) chunks.Iterator {
 		case chunkenc.ValHistogram:
 			t, h = seriesIter.AtHistogram(nil)
 			st = seriesIter.AtST()
-			newChk, recoded, app, err = app.AppendHistogram(nil, st, t, h, false)
+			newChk, recoded, app, err = app.AppendHistogram(st, t, h, false)
 			if err != nil {
 				return errChunksIterator{err: err}
 			}
@@ -389,7 +389,7 @@ func (s *seriesToChunkEncoder) Iterator(it chunks.Iterator) chunks.Iterator {
 		case chunkenc.ValFloatHistogram:
 			t, fh = seriesIter.AtFloatHistogram(nil)
 			st = seriesIter.AtST()
-			newChk, recoded, app, err = app.AppendFloatHistogram(nil, st, t, fh, false)
+			newChk, recoded, app, err = app.AppendFloatHistogram(st, t, fh, false)
 			if err != nil {
 				return errChunksIterator{err: err}
 			}

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -114,8 +114,8 @@ type Appender interface {
 	// The returned bool isRecoded can be used to distinguish between the new Chunk c being a completely new Chunk
 	// or the current Chunk recoded to a new Chunk.
 	// The Appender app that can be used for the next append is always returned.
-	AppendHistogram(prev *HistogramAppender, st, t int64, h *histogram.Histogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
-	AppendFloatHistogram(prev *FloatHistogramAppender, st, t int64, h *histogram.FloatHistogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
+	AppendHistogram(st, t int64, h *histogram.Histogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
+	AppendFloatHistogram(st, t int64, h *histogram.FloatHistogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
 }
 
 // Iterator is a simple iterator that can only get the next value.

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -225,11 +225,11 @@ func (a *xorAppender) writeVDelta(v float64) {
 	xorWrite(a.b, v, a.v, &a.leading, &a.trailing)
 }
 
-func (*xorAppender) AppendHistogram(*HistogramAppender, int64, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
+func (*xorAppender) AppendHistogram(int64, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a histogram sample to a float chunk")
 }
 
-func (*xorAppender) AppendFloatHistogram(*FloatHistogramAppender, int64, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
+func (*xorAppender) AppendFloatHistogram(int64, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a float histogram sample to a float chunk")
 }
 

--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -167,7 +167,7 @@ func ChunkFromSamplesGeneric(s Samples) (Meta, error) {
 		case chunkenc.ValFloat:
 			ca.Append(s.Get(i).ST(), s.Get(i).T(), s.Get(i).F())
 		case chunkenc.ValHistogram:
-			newChunk, _, ca, err = ca.AppendHistogram(nil, s.Get(i).ST(), s.Get(i).T(), s.Get(i).H(), false)
+			newChunk, _, ca, err = ca.AppendHistogram(s.Get(i).ST(), s.Get(i).T(), s.Get(i).H(), false)
 			if err != nil {
 				return emptyChunk, err
 			}
@@ -175,7 +175,7 @@ func ChunkFromSamplesGeneric(s Samples) (Meta, error) {
 				return emptyChunk, errors.New("did not expect to start a second chunk")
 			}
 		case chunkenc.ValFloatHistogram:
-			newChunk, _, ca, err = ca.AppendFloatHistogram(nil, s.Get(i).ST(), s.Get(i).T(), s.Get(i).FH(), false)
+			newChunk, _, ca, err = ca.AppendFloatHistogram(s.Get(i).ST(), s.Get(i).T(), s.Get(i).FH(), false)
 			if err != nil {
 				return emptyChunk, err
 			}

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1860,9 +1860,6 @@ func (s *memSeries) appendHistogram(t int64, h *histogram.Histogram, appendID ui
 	// Head controls the execution of recoding, so that we own the proper
 	// chunk reference afterwards and mmap used up chunks.
 
-	// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
-	prevApp, _ := s.app.(*chunkenc.HistogramAppender)
-
 	c, sampleInOrder, chunkCreated := s.histogramsAppendPreprocessor(t, chunkenc.EncHistogram, o)
 	if !sampleInOrder {
 		return sampleInOrder, chunkCreated
@@ -1873,13 +1870,8 @@ func (s *memSeries) appendHistogram(t int64, h *histogram.Histogram, appendID ui
 		recoded  bool
 	)
 
-	if !chunkCreated {
-		// Ignore the previous appender if we continue the current chunk.
-		prevApp = nil
-	}
-
 	// TODO(krajorama): pass ST.
-	newChunk, recoded, s.app, _ = s.app.AppendHistogram(prevApp, 0, t, h, false) // false=request a new chunk if needed
+	newChunk, recoded, s.app, _ = s.app.AppendHistogram(0, t, h, false) // false=request a new chunk if needed
 
 	s.lastHistogramValue = h
 	s.lastFloatHistogramValue = nil
@@ -1918,9 +1910,6 @@ func (s *memSeries) appendFloatHistogram(t int64, fh *histogram.FloatHistogram, 
 	// Head controls the execution of recoding, so that we own the proper
 	// chunk reference afterwards and mmap used up chunks.
 
-	// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
-	prevApp, _ := s.app.(*chunkenc.FloatHistogramAppender)
-
 	c, sampleInOrder, chunkCreated := s.histogramsAppendPreprocessor(t, chunkenc.EncFloatHistogram, o)
 	if !sampleInOrder {
 		return sampleInOrder, chunkCreated
@@ -1931,13 +1920,8 @@ func (s *memSeries) appendFloatHistogram(t int64, fh *histogram.FloatHistogram, 
 		recoded  bool
 	)
 
-	if !chunkCreated {
-		// Ignore the previous appender if we continue the current chunk.
-		prevApp = nil
-	}
-
 	// TODO(krajorama): pass ST.
-	newChunk, recoded, s.app, _ = s.app.AppendFloatHistogram(prevApp, 0, t, fh, false) // False means request a new chunk if needed.
+	newChunk, recoded, s.app, _ = s.app.AppendFloatHistogram(0, t, fh, false) // False means request a new chunk if needed.
 
 	s.lastHistogramValue = nil
 	s.lastFloatHistogramValue = fh

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -2550,7 +2550,8 @@ func TestHeadAppenderV2_Append_CounterResetHeader(t *testing.T) {
 				appendHistogram(h)
 			}
 
-			checkExpCounterResetHeader(chunkenc.NotCounterReset, chunkenc.NotCounterReset)
+			// There is no check for implicit counter reset between chunks.
+			checkExpCounterResetHeader(chunkenc.UnknownCounterReset, chunkenc.UnknownCounterReset)
 
 			// Changing schema will cut a new chunk with unknown counter reset.
 			h.Schema++
@@ -2578,7 +2579,8 @@ func TestHeadAppenderV2_Append_CounterResetHeader(t *testing.T) {
 			for range 2000 {
 				appendHistogram(h)
 			}
-			checkExpCounterResetHeader(chunkenc.NotCounterReset, chunkenc.NotCounterReset)
+			// There is no check for implicit counter reset between chunks.
+			checkExpCounterResetHeader(chunkenc.UnknownCounterReset, chunkenc.UnknownCounterReset)
 
 			// Counter reset with counter reset in a positive bucket.
 			h.PositiveBuckets[len(h.PositiveBuckets)-1]--

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -5041,7 +5041,8 @@ func TestHistogramCounterResetHeader(t *testing.T) {
 				appendHistogram(h)
 			}
 
-			checkExpCounterResetHeader(chunkenc.NotCounterReset, chunkenc.NotCounterReset)
+			// There is no check for implicit counter reset between chunks.
+			checkExpCounterResetHeader(chunkenc.UnknownCounterReset, chunkenc.UnknownCounterReset)
 
 			// Changing schema will cut a new chunk with unknown counter reset.
 			h.Schema++
@@ -5069,7 +5070,8 @@ func TestHistogramCounterResetHeader(t *testing.T) {
 			for range 2000 {
 				appendHistogram(h)
 			}
-			checkExpCounterResetHeader(chunkenc.NotCounterReset, chunkenc.NotCounterReset)
+			// There is no check for implicit counter reset between chunks.
+			checkExpCounterResetHeader(chunkenc.UnknownCounterReset, chunkenc.UnknownCounterReset)
 
 			// Counter reset with counter reset in a positive bucket.
 			h.PositiveBuckets[len(h.PositiveBuckets)-1]--

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -103,9 +103,6 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error
 			encoding = chunkenc.EncFloatHistogram
 		}
 
-		// prevApp is the appender for the previous sample.
-		prevApp := app
-
 		if encoding != prevEncoding { // For the first sample, this will always be true as EncNone != EncXOR | EncHistogram | EncFloatHistogram
 			if prevEncoding != chunkenc.EncNone {
 				chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
@@ -131,14 +128,12 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error
 			// TODO(krajorama): pass ST.
 			app.Append(0, s.t, s.f)
 		case chunkenc.EncHistogram:
-			// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
-			prevHApp, _ := prevApp.(*chunkenc.HistogramAppender)
 			var (
 				newChunk chunkenc.Chunk
 				recoded  bool
 			)
 			// TODO(krajorama): pass ST.
-			newChunk, recoded, app, _ = app.AppendHistogram(prevHApp, 0, s.t, s.h, false)
+			newChunk, recoded, app, _ = app.AppendHistogram(0, s.t, s.h, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
 					chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
@@ -147,14 +142,12 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error
 				chunk = newChunk
 			}
 		case chunkenc.EncFloatHistogram:
-			// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
-			prevHApp, _ := prevApp.(*chunkenc.FloatHistogramAppender)
 			var (
 				newChunk chunkenc.Chunk
 				recoded  bool
 			)
 			// TODO(krajorama): pass ST.
-			newChunk, recoded, app, _ = app.AppendFloatHistogram(prevHApp, 0, s.t, s.fh, false)
+			newChunk, recoded, app, _ = app.AppendFloatHistogram(0, s.t, s.fh, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
 					chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -900,7 +900,7 @@ func (p *populateWithDelChunkSeriesIterator) populateCurrForSingleChunk() bool {
 			var h *histogram.Histogram
 			t, h = p.currDelIter.AtHistogram(nil)
 			st = p.currDelIter.AtST()
-			_, _, app, err = app.AppendHistogram(nil, st, t, h, true)
+			_, _, app, err = app.AppendHistogram(st, t, h, true)
 			if err != nil {
 				break
 			}
@@ -933,7 +933,7 @@ func (p *populateWithDelChunkSeriesIterator) populateCurrForSingleChunk() bool {
 			var h *histogram.FloatHistogram
 			t, h = p.currDelIter.AtFloatHistogram(nil)
 			st = p.currDelIter.AtST()
-			_, _, app, err = app.AppendFloatHistogram(nil, st, t, h, true)
+			_, _, app, err = app.AppendFloatHistogram(st, t, h, true)
 			if err != nil {
 				break
 			}
@@ -1024,7 +1024,7 @@ func (p *populateWithDelChunkSeriesIterator) populateChunksFromIterable() bool {
 				st = p.currDelIter.AtST()
 				// No need to set prevApp as AppendHistogram will set the
 				// counter reset header for the appender that's returned.
-				newChunk, recoded, app, err = app.AppendHistogram(nil, st, t, v, false)
+				newChunk, recoded, app, err = app.AppendHistogram(st, t, v, false)
 			}
 		case chunkenc.ValFloatHistogram:
 			{
@@ -1033,7 +1033,7 @@ func (p *populateWithDelChunkSeriesIterator) populateChunksFromIterable() bool {
 				st = p.currDelIter.AtST()
 				// No need to set prevApp as AppendHistogram will set the
 				// counter reset header for the appender that's returned.
-				newChunk, recoded, app, err = app.AppendFloatHistogram(nil, st, t, v, false)
+				newChunk, recoded, app, err = app.AppendFloatHistogram(st, t, v, false)
 			}
 		}
 

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -141,7 +141,7 @@ func createIdxChkReaders(t *testing.T, tc []seriesSamples) (IndexReader, ChunkRe
 				app, _ := chunk.Appender()
 				for _, smpl := range chk {
 					require.NotNil(t, smpl.fh, "chunk can only contain one type of sample")
-					_, _, _, err := app.AppendFloatHistogram(nil, 0, smpl.t, smpl.fh, true)
+					_, _, _, err := app.AppendFloatHistogram(0, smpl.t, smpl.fh, true)
 					require.NoError(t, err, "chunk should be appendable")
 				}
 				chkReader[chunkRef] = chunk
@@ -150,7 +150,7 @@ func createIdxChkReaders(t *testing.T, tc []seriesSamples) (IndexReader, ChunkRe
 				app, _ := chunk.Appender()
 				for _, smpl := range chk {
 					require.NotNil(t, smpl.h, "chunk can only contain one type of sample")
-					_, _, _, err := app.AppendHistogram(nil, 0, smpl.t, smpl.h, true)
+					_, _, _, err := app.AppendHistogram(0, smpl.t, smpl.h, true)
 					require.NoError(t, err, "chunk should be appendable")
 				}
 				chkReader[chunkRef] = chunk


### PR DESCRIPTION
We are calculating histogram counter reset at the beginning for chunks however, we always throw away the answer:
https://github.com/prometheus/prometheus/blob/076369fad0a553a76ab0f470e1f0d3027225af0d/tsdb/chunkenc/histogram_meta.go#L481

This PR removes this code and updates dependencies.

Related to
https://github.com/prometheus/prometheus/issues/15346

Also related to #17791 , where start time support will make the counter reset obsolete long term.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
