### PR TITLE
tsdb: improve `initTime` busy-wait loop

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"runtime"
 	"time"
 
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -126,12 +127,18 @@ func (h *Head) initTime(t int64) {
 		// Another goroutine already won the init race. Wait until it also sets
 		// minTime, so callers that next read initialized() can rely on both
 		// bounds being valid.
-		antiDeadlockTimeout := time.After(500 * time.Millisecond)
+		// This should complete in microseconds under normal operation.
+		antiDeadlockTimeout := time.After(100 * time.Millisecond)
 		for h.minTime.Load() == math.MaxInt64 {
 			select {
 			case <-antiDeadlockTimeout:
+				// This should never happen in normal operation.
+				// If it does, there may be a bug or the system is severely overloaded.
+				h.logger.Warn("initTime timeout waiting for minTime initialization")
 				return
 			default:
+				// Yield to allow the initializing goroutine to complete.
+				runtime.Gosched()
 			}
 		}
 		return

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -127,8 +127,7 @@ func (h *Head) initTime(t int64) {
 		// Another goroutine already won the init race. Wait until it also sets
 		// minTime, so callers that next read initialized() can rely on both
 		// bounds being valid.
-		// This should complete in microseconds under normal operation.
-		antiDeadlockTimeout := time.After(100 * time.Millisecond)
+		antiDeadlockTimeout := time.After(500 * time.Millisecond)
 		for h.minTime.Load() == math.MaxInt64 {
 			select {
 			case <-antiDeadlockTimeout:


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

In `tsdb.Head.initTime`:
- Add `runtime.Gosched()` to yield CPU during the busy-wait loop
- Reduce timeout from 500ms to 100ms (actual wait should be microseconds)
- Add warning log when timeout occurs to aid debugging

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[ENHANCEMENT] Reduce TSDB head CPU utilization when initializing
```
