### PR TITLE
storage: fix ToError() to return nil for empty partial errors

### DIFF
--- a/storage/errors_test.go
+++ b/storage/errors_test.go
@@ -20,6 +20,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAppendPartialErrorToError(t *testing.T) {
+	// nil receiver returns nil.
+	var nilErr *AppendPartialError
+	require.NoError(t, nilErr.ToError())
+
+	// Empty ExemplarErrors returns nil.
+	emptyErr := &AppendPartialError{}
+	require.NoError(t, emptyErr.ToError())
+
+	// Also test explicitly empty slice.
+	emptySliceErr := &AppendPartialError{ExemplarErrors: []error{}}
+	require.NoError(t, emptySliceErr.ToError())
+
+	// Non-empty ExemplarErrors returns the error.
+	nonEmptyErr := &AppendPartialError{ExemplarErrors: []error{ErrOutOfOrderExemplar}}
+	require.ErrorIs(t, nonEmptyErr.ToError(), nonEmptyErr)
+}
+
 func TestErrDuplicateSampleForTimestamp(t *testing.T) {
 	// All errDuplicateSampleForTimestamp are ErrDuplicateSampleForTimestamp
 	require.ErrorIs(t, ErrDuplicateSampleForTimestamp, errDuplicateSampleForTimestamp{})

--- a/storage/interface_append.go
+++ b/storage/interface_append.go
@@ -104,7 +104,7 @@ func (e *AppendPartialError) Error() string {
 // ToError returns AppendPartialError as error, returning nil
 // if there are no errors.
 func (e *AppendPartialError) ToError() error {
-	if e == nil {
+	if e == nil || len(e.ExemplarErrors) == 0 {
 		return nil
 	}
 	return e


### PR DESCRIPTION
Fix `storage.ToError()` so it returns nil for empty partial errors. Not sure if this actually affects any functionality, but better safe than sorry.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
