### PR TITLE
discovery/kubernetes: Support node role selectors for pod roles

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2315,7 +2315,7 @@ var expectedErrors = []struct {
 	},
 	{
 		filename: "kubernetes_selectors_pod.bad.yml",
-		errMsg:   "pod role supports only pod selectors",
+		errMsg:   "pod role supports only pod, node selectors",
 	},
 	{
 		filename: "kubernetes_selectors_service.bad.yml",

--- a/config/testdata/kubernetes_selectors_pod.bad.yml
+++ b/config/testdata/kubernetes_selectors_pod.bad.yml
@@ -6,3 +6,6 @@ scrape_configs:
           - role: "node"
             label: "foo=bar"
             field: "metadata.status=Running"
+          - role: "service"
+            label: "baz=que"
+            field: "metadata.status=Running"

--- a/config/testdata/kubernetes_selectors_pod.good.yml
+++ b/config/testdata/kubernetes_selectors_pod.good.yml
@@ -11,3 +11,8 @@ scrape_configs:
           - role: "pod"
             label: "foo in (bar,baz)"
             field: "metadata.status=Running"
+      - role: pod
+        selectors:
+          - role: "node"
+            label: "foo=bar"
+            field: "metadata.status=Running"

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -194,7 +194,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 	foundSelectorRoles := make(map[Role]struct{})
 	allowedSelectors := map[Role][]string{
-		RolePod:           {string(RolePod)},
+		RolePod:           {string(RolePod), string(RoleNode)},
 		RoleService:       {string(RoleService)},
 		RoleEndpointSlice: {string(RolePod), string(RoleService), string(RoleEndpointSlice)},
 		RoleEndpoint:      {string(RolePod), string(RoleService), string(RoleEndpoint)},


### PR DESCRIPTION
The node informers for pod roles respected filtering based on selectors ([1]). However, node selectors for pod roles were not allowed. This patch address that, and additionally adds pod filtering logic, to not populate their target groups when they belong to a filtered node.

[1]:https://github.com/prometheus/prometheus/pull/10080/changes#diff-e9ca22962ad7d9a7bb4cb82d209dc2dd5301f457d8242da5535557866d2ea1eaR667

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix: #13525 
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
(since this behavior is already mentioned in the docs)