### PR TITLE
textparse: validate series against metric family to prevent wrong metadata

### DIFF
--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -112,6 +112,12 @@ type OpenMetricsParser struct {
 	visitedMFName           []byte
 	skipSTSeries            bool
 	enableTypeAndUnitLabels bool
+
+	// metaFamilyName is the metric family name from the last TYPE/HELP/UNIT metadata.
+	// This is used to validate that series belong to the correct metric family.
+	metaFamilyName []byte
+	// metaType is the type from the last TYPE metadata.
+	metaType model.MetricType
 }
 
 type openMetricsParserOptions struct {
@@ -194,7 +200,13 @@ func (p *OpenMetricsParser) Help() ([]byte, []byte) {
 // Must only be called after Next returned a type entry.
 // The returned byte slices become invalid after the next call to Next.
 func (p *OpenMetricsParser) Type() ([]byte, model.MetricType) {
-	return p.l.b[p.offsets[0]:p.offsets[1]], p.mtype
+	m := p.l.b[p.offsets[0]:p.offsets[1]]
+
+	// Store the metric family name and type for later validation.
+	p.metaFamilyName = m
+	p.metaType = p.mtype
+
+	return m, p.mtype
 }
 
 // Unit returns the metric name and unit in the current entry.
@@ -220,10 +232,20 @@ func (p *OpenMetricsParser) Labels(l *labels.Labels) {
 	p.builder.Reset()
 	metricName := unreplace(s[p.offsets[0]-p.start : p.offsets[1]-p.start])
 
+	// Validate if this series belongs to the current metric family.
+	// If not, clear the metadata to prevent wrong associations.
+	metaType := p.metaType
+	metaUnit := p.unit
+	if len(p.metaFamilyName) > 0 && !isSeriesPartOfFamily(metricName, p.metaFamilyName, p.metaType) {
+		// Series doesn't belong to the current metric family, use unknown type and empty unit.
+		metaType = model.MetricTypeUnknown
+		metaUnit = ""
+	}
+
 	m := schema.Metadata{
 		Name: metricName,
-		Type: p.mtype,
-		Unit: p.unit,
+		Type: metaType,
+		Unit: metaUnit,
 	}
 	if p.enableTypeAndUnitLabels {
 		m.AddToLabels(&p.builder)

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -183,7 +183,7 @@ foobar{quantile="0.99"} 150.1`
 				}, {
 					m:    `some:aggregate:rate5m{a_b="c"}`,
 					v:    1,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "some:aggregate:rate5m", "a_b", "c"), model.MetricTypeSummary),
+					lset: labels.FromStrings("__name__", "some:aggregate:rate5m", "a_b", "c"),
 				}, {
 					m:    "go_goroutines",
 					help: "Number of goroutines that currently exist.",
@@ -637,7 +637,7 @@ foobar{quantile="0.99"} 150.1`
 				}, {
 					m:    "null_byte_metric{a=\"abc\x00\"}",
 					v:    1,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "null_byte_metric", "a", "abc\x00"), model.MetricTypeSummary),
+					lset: labels.FromStrings("__name__", "null_byte_metric", "a", "abc\x00"),
 				},
 			}
 			opts := []OpenMetricsOption{WithOMParserSTSeriesSkipped()}

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -167,6 +167,12 @@ type PromParser struct {
 	offsets []int
 
 	enableTypeAndUnitLabels bool
+
+	// metaFamilyName is the metric family name from the last TYPE/HELP/UNIT metadata.
+	// This is used to validate that series belong to the correct metric family.
+	metaFamilyName []byte
+	// metaType is the type from the last TYPE metadata.
+	metaType model.MetricType
 }
 
 // NewPromParser returns a new parser of the byte slice.
@@ -210,14 +216,21 @@ func (p *PromParser) Help() ([]byte, []byte) {
 // Must only be called after Next returned a type entry.
 // The returned byte slices become invalid after the next call to Next.
 func (p *PromParser) Type() ([]byte, model.MetricType) {
-	return p.l.b[p.offsets[0]:p.offsets[1]], p.mtype
+	m := p.l.b[p.offsets[0]:p.offsets[1]]
+
+	// Store the metric family name and type for later validation.
+	p.metaFamilyName = m
+	p.metaType = p.mtype
+
+	return m, p.mtype
 }
 
 // Unit returns the metric name and unit in the current entry.
 // Must only be called after Next returned a unit entry.
 // The returned byte slices become invalid after the next call to Next.
-func (*PromParser) Unit() ([]byte, []byte) {
+func (p *PromParser) Unit() ([]byte, []byte) {
 	// The Prometheus format does not have units.
+	// Note: This method exists for interface compatibility but is not used in Prometheus text format.
 	return nil, nil
 }
 
@@ -236,12 +249,17 @@ func (p *PromParser) Labels(l *labels.Labels) {
 	p.builder.Reset()
 	metricName := unreplace(s[p.offsets[0]-p.start : p.offsets[1]-p.start])
 
+	// Validate if this series belongs to the current metric family.
+	// If not, clear the metadata to prevent wrong associations.
+	metaType := p.metaType
+	if len(p.metaFamilyName) > 0 && !isSeriesPartOfFamily(metricName, p.metaFamilyName, p.metaType) {
+		// Series doesn't belong to the current metric family, use unknown type.
+		metaType = model.MetricTypeUnknown
+	}
+
 	m := schema.Metadata{
 		Name: metricName,
-		// NOTE(bwplotka): There is a known case where the type is wrong on a broken exposition
-		// (see the TestPromParse windspeed metric). Fixing it would require extra
-		// allocs and benchmarks. Since it was always broken, don't fix for now.
-		Type: p.mtype,
+		Type: metaType,
 	}
 
 	if p.enableTypeAndUnitLabels {

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -228,7 +228,7 @@ func (p *PromParser) Type() ([]byte, model.MetricType) {
 // Unit returns the metric name and unit in the current entry.
 // Must only be called after Next returned a unit entry.
 // The returned byte slices become invalid after the next call to Next.
-func (p *PromParser) Unit() ([]byte, []byte) {
+func (*PromParser) Unit() ([]byte, []byte) {
 	// The Prometheus format does not have units.
 	// Note: This method exists for interface compatibility but is not used in Prometheus text format.
 	return nil, nil

--- a/model/textparse/promparse_test.go
+++ b/model/textparse/promparse_test.go
@@ -84,7 +84,7 @@ wind_speed{A="2",c="3"} 12345
 # comment with escaped \n newline
 # comment with escaped \ escape character
 # HELP nohelp1
-# HELP nohelp2 
+# HELP nohelp2
 go_gc_duration_seconds{ quantile="1.0", a="b" } 8.3835e-05
 go_gc_duration_seconds { quantile="1.0", a="b" } 8.3835e-05
 go_gc_duration_seconds { quantile= "1.0", a= "b", } 8.3835e-05
@@ -227,15 +227,9 @@ type_and_unit_test2{__type__="counter"} 123`
 					comment: "#",
 				},
 				{
-					m: `wind_speed{A="2",c="3"}`,
-					v: 12345,
-					lset: typeAndUnitLabels(
-						typeAndUnitEnabled,
-						// NOTE(bwplotka): This is knowingly broken, inheriting old type when TYPE was not specified on a new metric.
-						// This was broken forever on a case for a broken exposition. Don't fix for now (expensive).
-						labels.FromStrings("A", "2", "__name__", "wind_speed", "__type__", string(model.MetricTypeHistogram), "c", "3"),
-						labels.FromStrings("A", "2", "__name__", "wind_speed", "c", "3"),
-					),
+					m:    `wind_speed{A="2",c="3"}`,
+					v:    12345,
+					lset: labels.FromStrings("A", "2", "__name__", "wind_speed", "c", "3"),
 				},
 				{
 					comment: "# comment with escaped \\n newline",
@@ -254,38 +248,38 @@ type_and_unit_test2{__type__="counter"} 123`
 				{
 					m:    `go_gc_duration_seconds{ quantile="1.0", a="b" }`,
 					v:    8.3835e-05,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "go_gc_duration_seconds", "quantile", "1.0", "a", "b"), model.MetricTypeHistogram),
+					lset: labels.FromStrings("__name__", "go_gc_duration_seconds", "quantile", "1.0", "a", "b"),
 				},
 				{
 					m:    `go_gc_duration_seconds { quantile="1.0", a="b" }`,
 					v:    8.3835e-05,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "go_gc_duration_seconds", "quantile", "1.0", "a", "b"), model.MetricTypeHistogram),
+					lset: labels.FromStrings("__name__", "go_gc_duration_seconds", "quantile", "1.0", "a", "b"),
 				},
 				{
 					m:    `go_gc_duration_seconds { quantile= "1.0", a= "b", }`,
 					v:    8.3835e-05,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "go_gc_duration_seconds", "quantile", "1.0", "a", "b"), model.MetricTypeHistogram),
+					lset: labels.FromStrings("__name__", "go_gc_duration_seconds", "quantile", "1.0", "a", "b"),
 				},
 				{
 					m:    `go_gc_duration_seconds { quantile = "1.0", a = "b" }`,
 					v:    8.3835e-05,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "go_gc_duration_seconds", "quantile", "1.0", "a", "b"), model.MetricTypeHistogram),
+					lset: labels.FromStrings("__name__", "go_gc_duration_seconds", "quantile", "1.0", "a", "b"),
 				},
 				{
 					// NOTE: Unlike OpenMetrics, PromParser allows spaces between label terms. This appears to be unintended and should probably be fixed.
 					m:    `go_gc_duration_seconds { quantile = "2.0" a = "b" }`,
 					v:    8.3835e-05,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "go_gc_duration_seconds", "quantile", "2.0", "a", "b"), model.MetricTypeHistogram),
+					lset: labels.FromStrings("__name__", "go_gc_duration_seconds", "quantile", "2.0", "a", "b"),
 				},
 				{
 					m:    `go_gc_duration_seconds_count`,
 					v:    99,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "go_gc_duration_seconds_count"), model.MetricTypeHistogram),
+					lset: labels.FromStrings("__name__", "go_gc_duration_seconds_count"),
 				},
 				{
 					m:    `some:aggregate:rate5m{a_b="c"}`,
 					v:    1,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "some:aggregate:rate5m", "a_b", "c"), model.MetricTypeHistogram),
+					lset: labels.FromStrings("__name__", "some:aggregate:rate5m", "a_b", "c"),
 				},
 				{
 					m:    "go_goroutines",
@@ -329,22 +323,22 @@ type_and_unit_test2{__type__="counter"} 123`
 				{
 					m:    "_metric_starting_with_underscore",
 					v:    1,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "_metric_starting_with_underscore"), model.MetricTypeCounter),
+					lset: labels.FromStrings("__name__", "_metric_starting_with_underscore"),
 				},
 				{
 					m:    "testmetric{_label_starting_with_underscore=\"foo\"}",
 					v:    1,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "testmetric", "_label_starting_with_underscore", "foo"), model.MetricTypeCounter),
+					lset: labels.FromStrings("__name__", "testmetric", "_label_starting_with_underscore", "foo"),
 				},
 				{
 					m:    "testmetric{label=\"\\\"bar\\\"\"}",
 					v:    1,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "testmetric", "label", `"bar"`), model.MetricTypeCounter),
+					lset: labels.FromStrings("__name__", "testmetric", "label", `"bar"`),
 				},
 				{
 					m:    `testmetric{le="10"}`,
 					v:    1,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "testmetric", "le", "10"), model.MetricTypeCounter),
+					lset: labels.FromStrings("__name__", "testmetric", "le", "10"),
 				},
 				{
 					m:    "type_and_unit_test1",
@@ -370,7 +364,7 @@ type_and_unit_test2{__type__="counter"} 123`
 				{
 					m:    "type_and_unit_test2{__type__=\"counter\"}",
 					v:    123,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "type_and_unit_test2", "__type__", string(model.MetricTypeCounter)), model.MetricTypeGauge),
+					lset: labels.FromStrings("__name__", "type_and_unit_test2", "__type__", string(model.MetricTypeCounter)),
 				},
 				{
 					m:    "metric",
@@ -379,7 +373,7 @@ type_and_unit_test2{__type__="counter"} 123`
 				{
 					m:    "null_byte_metric{a=\"abc\x00\"}",
 					v:    1,
-					lset: todoDetectFamilySwitch(typeAndUnitEnabled, labels.FromStrings("__name__", "null_byte_metric", "a", "abc\x00"), model.MetricTypeGauge),
+					lset: labels.FromStrings("__name__", "null_byte_metric", "a", "abc\x00"),
 				},
 			}
 

--- a/model/textparse/promparse_test.go
+++ b/model/textparse/promparse_test.go
@@ -47,21 +47,6 @@ func typeAndUnitLabels(typeAndUnitEnabled bool, enabled, disabled labels.Labels)
 //
 // This problem is elevated for PROM-39 feature.
 //
-// Current metadata handling is semi broken here for this as the (a) is expensive and currently not fully accurate
-// see: https://github.com/prometheus/prometheus/blob/dbf5d01a62249eddcd202303069f6cf7dd3c4a73/scrape/scrape.go#L1916
-//
-// To iterate, we keep it "knowingly" broken behind the feature flag.
-// TODO(bwplotka): Remove this once we fix the problematic case e.g.
-//   - introduce more accurate isSeriesPartOfFamily shared helper or even parser method that tells when new metric family starts
-func todoDetectFamilySwitch(typeAndUnitEnabled bool, expected labels.Labels, brokenTypeInherited model.MetricType) labels.Labels {
-	if typeAndUnitEnabled && brokenTypeInherited != model.MetricTypeUnknown {
-		// Hack for now.
-		b := labels.NewBuilder(expected)
-		b.Set("__type__", string(brokenTypeInherited))
-		return b.Labels()
-	}
-	return expected
-}
 
 func TestPromParse(t *testing.T) {
 	input := `# HELP go_gc_duration_seconds A summary of the GC invocation durations.


### PR DESCRIPTION
Move metadata validation from `scrape.go` into text and OM parsers. Series now only inherit metadata when they actually belong to the metric family, preventing cases like `test_metric3_metric4` from incorrectly getting metadata from `test_metric3`.

This fixes a long-standing issue where metrics could inherit wrong TYPE/HELP/UNIT metadata from unrelated metric families. The validation logic using `isSeriesPartOfFamily` has been moved directly into the parser's `Labels()` method, making it more efficient and accurate.

**Changes:**
- Added `isSeriesPartOfFamily()` helper function in `textparse/interface.go`
- Modified `PromParser` and `OpenMetricsParser` to track current metric family and validate series membership
- Updated `Labels()` method to set metadata to unknown when series doesn't belong to the tracked family
- Fixed test expectations that were previously marked as "knowingly broken"

**Example of fixed behavior:**
```
# TYPE test_metric3 gauge
# HELP test_metric3 this represents tricky case of "broken" text
test_metric3_metric4{foo="bar"} 2
```



Before: `test_metric3_metric4` would incorrectly get `__type__="gauge"`  
After: `test_metric3_metric4` correctly gets no type label (unknown)

## Which issue(s) does the PR fix:

Fixes #17900

## Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] textparse: Fix incorrect metadata inheritance for series that don't belong to the current metric family.

