### PR TITLE
fix: use context.Background consistently in ECS UnmarshalYAML

### DIFF
--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -138,7 +138,7 @@ func (c *ECSSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 
 	if c.Region == "" {
-		cfg, err := awsConfig.LoadDefaultConfig(context.TODO())
+		cfg, err := awsConfig.LoadDefaultConfig(context.Background())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Replace context.TODO() with context.Background() for consistency with the EC2 discovery implementation and other calls in the same function. context.Background() is the appropriate choice for initialization code where no parent context is available.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes

```
