### PR TITLE
AWS SD: Load Region Fallback

### DIFF
--- a/discovery/aws/aws_test.go
+++ b/discovery/aws/aws_test.go
@@ -341,13 +341,14 @@ func TestLoadRegion(t *testing.T) {
 		t.Setenv("AWS_ACCESS_KEY_ID", "dummy")
 		t.Setenv("AWS_SECRET_ACCESS_KEY", "dummy")
 		t.Setenv("AWS_CONFIG_FILE", "") // Ensure no config file is used
+		t.Setenv("AWS_PROFILE", "")     // Ensure no profile file is used
 
-		region, err := loadRegion(context.Background())
+		region, err := loadRegion(context.Background(), "")
 		require.NoError(t, err)
 		require.Equal(t, randomRegion, region)
 	})
 
-	t.Run("with_config_file", func(t *testing.T) {
+	t.Run("with_config_file_default_profile", func(t *testing.T) {
 		randomRegion := getRandomRegion()
 
 		// Create a temporary AWS config file
@@ -356,11 +357,11 @@ func TestLoadRegion(t *testing.T) {
 
 		configContent := `[default]
 region = ` + randomRegion + `
-output = json
 `
 
-		err := os.WriteFile(configFile, []byte(configContent), 0644)
+		err := os.WriteFile(configFile, []byte(configContent), 0o644)
 		require.NoError(t, err)
+		defer os.Remove(configFile)
 
 		// Set up environment to use the config file
 		t.Setenv("AWS_CONFIG_FILE", configFile)
@@ -368,11 +369,57 @@ output = json
 		t.Setenv("AWS_SECRET_ACCESS_KEY", "dummy")
 		// Clear any region environment variables to force config file usage
 		t.Setenv("AWS_REGION", "")
+		t.Setenv("AWS_PROFILE", "") // Ensure no profile file is used
 		t.Setenv("AWS_DEFAULT_REGION", "")
 
-		region, err := loadRegion(context.Background())
+		region, err := loadRegion(context.Background(), "")
 		require.NoError(t, err)
 		require.Equal(t, randomRegion, region)
+	})
+
+	t.Run("with_config_file_named_profile", func(t *testing.T) {
+		randomRegion := getRandomRegion()
+
+		// Create a temporary AWS config file
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "config")
+
+		configContent := `[default]
+region = ` + getRandomRegion() + `
+
+[profile ` + randomRegion + `-profile]
+region = ` + randomRegion + `
+`
+
+		err := os.WriteFile(configFile, []byte(configContent), 0o644)
+		require.NoError(t, err)
+		defer os.Remove(configFile)
+
+		// Set up environment to use the config file
+		t.Setenv("AWS_CONFIG_FILE", configFile)
+		t.Setenv("AWS_PROFILE", randomRegion+"-profile")
+		t.Setenv("AWS_ACCESS_KEY_ID", "dummy")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "dummy")
+		// Clear any region environment variables to force config file usage
+		t.Setenv("AWS_REGION", "")
+		t.Setenv("AWS_DEFAULT_REGION", "")
+
+		region, err := loadRegion(context.Background(), "")
+		require.NoError(t, err)
+		require.Equal(t, randomRegion, region)
+	})
+
+	t.Run("with_specified_region", func(t *testing.T) {
+		specifiedRegion := getRandomRegion()
+
+		// Even with environment region set differently, specified region should take precedence
+		t.Setenv("AWS_REGION", getRandomRegion())
+		t.Setenv("AWS_ACCESS_KEY_ID", "dummy")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "dummy")
+
+		region, err := loadRegion(context.Background(), specifiedRegion)
+		require.NoError(t, err)
+		require.Equal(t, specifiedRegion, region)
 	})
 
 	t.Run("imds_fallback", func(t *testing.T) {
@@ -400,11 +447,43 @@ output = json
 		t.Setenv("AWS_REGION", "")
 		t.Setenv("AWS_DEFAULT_REGION", "")
 		t.Setenv("AWS_CONFIG_FILE", "") // Ensure no config file is used
+		t.Setenv("AWS_PROFILE", "")     // Ensure no profile file is used
 		// Point IMDS to our mock server
 		t.Setenv("AWS_EC2_METADATA_SERVICE_ENDPOINT", mockIMDS.URL)
 
-		region, err := loadRegion(context.Background())
+		region, err := loadRegion(context.Background(), "")
 		require.NoError(t, err)
 		require.Equal(t, randomRegion, region)
+	})
+
+	t.Run("imds_empty_region", func(t *testing.T) {
+		// Mock IMDS server that returns empty region
+		mockIMDS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Handle instance identity document with empty region
+			if r.URL.Path == "/latest/dynamic/instance-identity/document" {
+				imdsPayload := `{"region": ""}`
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(imdsPayload))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer mockIMDS.Close()
+
+		// Set up environment with no region but valid credentials
+		t.Setenv("AWS_ACCESS_KEY_ID", "dummy")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "dummy")
+		// Unset any existing region
+		t.Setenv("AWS_REGION", "")
+		t.Setenv("AWS_DEFAULT_REGION", "")
+		t.Setenv("AWS_CONFIG_FILE", "") // Ensure no config file is used
+		t.Setenv("AWS_PROFILE", "")     // Ensure no profile file is used
+		// Point IMDS to our mock server
+		t.Setenv("AWS_EC2_METADATA_SERVICE_ENDPOINT", mockIMDS.URL)
+
+		_, err := loadRegion(context.Background(), "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get region from IMDS")
 	})
 }

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -124,16 +124,10 @@ func (c *EC2SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	// If region is not set, attempt to load it from the AWS SDK.
-	if c.Region == "" {
-		c.Region, err = loadRegion(context.Background())
-		if err != nil {
-			return fmt.Errorf("could not determine AWS region: %w", err)
-		}
-
-		if c.Region == "" {
-			return errors.New("ec2 sd configuration requires a region")
-		}
+	// Check if the region is set, if not attempt to load it from the AWS SDK.
+	c.Region, err = loadRegion(context.Background(), c.Region)
+	if err != nil {
+		return fmt.Errorf("could not determine AWS region: %w", err)
 	}
 
 	for _, f := range c.Filters {

--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -136,16 +136,9 @@ func (c *ECSSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	// If region is not set, attempt to load it from the AWS SDK.
-	if c.Region == "" {
-		c.Region, err = loadRegion(context.Background())
-		if err != nil {
-			return fmt.Errorf("could not determine AWS region: %w", err)
-		}
-
-		if c.Region == "" {
-			return errors.New("ecs sd configuration requires a region")
-		}
+	c.Region, err = loadRegion(context.Background(), c.Region)
+	if err != nil {
+		return fmt.Errorf("could not determine AWS region: %w", err)
 	}
 
 	return c.HTTPClientConfig.Validate()

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -105,16 +105,9 @@ func (c *LightsailSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	// If region is not set, attempt to load it from the AWS SDK.
-	if c.Region == "" {
-		c.Region, err = loadRegion(context.Background())
-		if err != nil {
-			return fmt.Errorf("could not determine AWS region: %w", err)
-		}
-
-		if c.Region == "" {
-			return errors.New("lightsail sd configuration requires a region")
-		}
+	c.Region, err = loadRegion(context.Background(), c.Region)
+	if err != nil {
+		return fmt.Errorf("could not determine AWS region: %w", err)
 	}
 
 	return c.HTTPClientConfig.Validate()

--- a/discovery/aws/msk.go
+++ b/discovery/aws/msk.go
@@ -135,16 +135,9 @@ func (c *MSKSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	// If region is not set, attempt to load it from the AWS SDK.
-	if c.Region == "" {
-		c.Region, err = loadRegion(context.Background())
-		if err != nil {
-			return fmt.Errorf("could not determine AWS region: %w", err)
-		}
-
-		if c.Region == "" {
-			return errors.New("msk sd configuration requires a region")
-		}
+	c.Region, err = loadRegion(context.Background(), c.Region)
+	if err != nil {
+		return fmt.Errorf("could not determine AWS region: %w", err)
 	}
 
 	return c.HTTPClientConfig.Validate()


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
This PR breaks out the Region loading and imds fallback into a dedicated function that can be used in all AWS SD roles. This was discussed in https://github.com/prometheus/prometheus/pull/17684.

Currently this is implemented for AWS/EC2/Lighsail/ECS/MSK, once we remove the dedicated EC2/Lighstail roles and switch to just the AWS one, we can remove a lot of this duplication. 

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
