### PR TITLE
promql: implement histogram_buckets function for NHCB

### DIFF
--- a/cmd/prometheus/testdata/features.json
+++ b/cmd/prometheus/testdata/features.json
@@ -72,6 +72,7 @@
     "first_over_time": false,
     "floor": true,
     "histogram_avg": true,
+    "histogram_buckets": true,
     "histogram_count": true,
     "histogram_fraction": true,
     "histogram_quantile": true,

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -233,6 +233,25 @@ Which is equivalent to the following query:
     /
       histogram_count(rate(http_request_duration_seconds[5m]))
 
+## `histogram_buckets()`
+
+`histogram_buckets(v instant-vector)` converts Native Histogram Custom Buckets
+(NHCB) to classic histogram bucket format. For each NHCB histogram sample in
+`v`, it returns multiple series (one per bucket) with the `_bucket` suffix
+appended to the metric name and an `le` label indicating the bucket boundary.
+Non-NHCB histograms (exponential schema) and float samples are ignored and do
+not show up in the returned vector.
+
+Use `histogram_buckets` to convert NHCB histograms to classic histogram format
+for compatibility with existing queries:
+
+    histogram_buckets(http_request_duration_seconds)
+
+This returns series like:
+- `http_request_duration_seconds_bucket{le="0.1"}` with cumulative count up to 0.1
+- `http_request_duration_seconds_bucket{le="0.5"}` with cumulative count up to 0.5
+- `http_request_duration_seconds_bucket{le="+Inf"}` with total count
+
 ## `histogram_count()` and `histogram_sum()`
 
 `histogram_count(v instant-vector)` returns the count of observations stored in

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1202,6 +1202,7 @@ type EvalNodeHelper struct {
 	// funcHistogramQuantile and funcHistogramFraction for classic histograms.
 	signatureToMetricWithBuckets map[string]*metricWithBuckets
 	nativeHistogramSamples       []Sample
+	metricsNameWithSuffix        map[string]string
 
 	lb           *labels.Builder
 	lblBuf       []byte

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1533,6 +1533,73 @@ func funcHistogramCount(vectorVals []Vector, _ Matrix, _ parser.Expressions, enh
 	}), nil
 }
 
+// === histogram_buckets(Vector parser.ValueTypeVector) (Vector, Annotations) ===
+func funcHistogramBuckets(vectorVals []Vector, _ Matrix, _ parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+	for _, el := range vectorVals[0] {
+		if el.H == nil {
+			continue
+		}
+
+
+		// Only process NHCB
+		if !histogram.IsCustomBucketsSchema(el.H.Schema) {
+			continue
+		}
+
+		baseName := el.Metric.Get(model.MetricNameLabel)
+		if baseName == "" {
+			continue
+		}
+
+		customValues := el.H.CustomValues
+		if len(customValues) == 0 {
+			continue
+		}
+
+		positiveBuckets := make([]float64, len(customValues)+1)
+		idx := 0
+		currIdx := 0
+
+		for _, span := range el.H.PositiveSpans {
+			idx += int(span.Offset)
+			for i := 0; i < int(span.Length); i++ {
+				if idx < len(positiveBuckets) {
+					positiveBuckets[idx] = el.H.PositiveBuckets[currIdx]
+					idx++
+					currIdx++
+				}
+			}
+		}
+
+		currCount := float64(0)
+		for i, val := range customValues {
+			currCount += positiveBuckets[i]
+			builder := labels.NewBuilder(el.Metric)
+			builder.Set(model.MetricNameLabel, baseName+"_bucket")
+			builder.Set(model.BucketLabel, labels.FormatOpenMetricsFloat(val))
+			enh.Out = append(enh.Out, Sample{
+				Metric:   builder.Labels(),
+				F:        currCount,
+				DropName: false,
+			})
+		}
+
+		// Add +Inf bucket with the overflow bucket
+		currCount += positiveBuckets[len(positiveBuckets)-1]
+		builder := labels.NewBuilder(el.Metric)
+		builder.Set(model.MetricNameLabel, baseName+"_bucket")
+		builder.Set(model.BucketLabel, labels.FormatOpenMetricsFloat(math.Inf(1)))
+
+		enh.Out = append(enh.Out, Sample{
+			Metric:   builder.Labels(),
+			F:        currCount,
+			DropName: false,
+		})
+	}
+
+	return enh.Out, nil
+}
+
 // === histogram_sum(Vector parser.ValueTypeVector) (Vector, Annotations) ===
 func funcHistogramSum(vectorVals []Vector, _ Matrix, _ parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
 	return simpleHistogramFunc(vectorVals, enh, func(h *histogram.FloatHistogram) float64 {
@@ -2016,6 +2083,7 @@ var FunctionCalls = map[string]FunctionCall{
 	"first_over_time":              funcFirstOverTime,
 	"floor":                        funcFloor,
 	"histogram_avg":                funcHistogramAvg,
+	"histogram_buckets":            funcHistogramBuckets,
 	"histogram_count":              funcHistogramCount,
 	"histogram_fraction":           funcHistogramFraction,
 	"histogram_quantile":           funcHistogramQuantile,

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1540,7 +1540,6 @@ func funcHistogramBuckets(vectorVals []Vector, _ Matrix, _ parser.Expressions, e
 			continue
 		}
 
-
 		// Only process NHCB
 		if !histogram.IsCustomBucketsSchema(el.H.Schema) {
 			continue

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -183,6 +183,11 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeVector},
 		ReturnType: ValueTypeVector,
 	},
+	"histogram_buckets": {
+		Name:       "histogram_buckets",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+	},
 	"histogram_sum": {
 		Name:       "histogram_sum",
 		ArgTypes:   []ValueType{ValueTypeVector},

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1872,3 +1872,65 @@ eval instant at 1m irate(nhcb_add_bucket[2m]) * 60
     expect no_warn
     expect no_info
     {} {{schema:-53 sum:56 count:15 custom_values:[2 3 4 6] buckets:[1 0 1 5 8] counter_reset_hint:gauge}}
+
+clear
+
+# Test histogram_buckets function with NHCB
+load 1m
+	nhcb_metric {{schema:-53 sum:55 count:15 custom_values:[2 4 6] buckets:[1 2 5 7]}}
+
+eval instant at 1m histogram_buckets(nhcb_metric)
+	expect no_warn
+	nhcb_metric_bucket{le="2.0"} 1
+    nhcb_metric_bucket{le="4.0"} 3
+	nhcb_metric_bucket{le="6.0"} 8
+	nhcb_metric_bucket{le="+Inf"} 15
+
+clear
+
+# Test histogram_buckets function with NHCB and empty buckets
+load 1m
+	nhcb_metric {{schema:-53 sum:2 count:2 custom_values:[2 4 6] buckets:[1 0 0 1]}}
+
+eval instant at 1m histogram_buckets(nhcb_metric)
+	expect no_warn
+	nhcb_metric_bucket{le="2.0"} 1
+    nhcb_metric_bucket{le="4.0"} 1
+	nhcb_metric_bucket{le="6.0"} 1
+	nhcb_metric_bucket{le="+Inf"} 2
+
+clear
+
+# Test histogram_buckets with multiple NHCB series
+load 1m
+	nhcb_metric1 {{schema:-53 sum:10 count:5 custom_values:[1 2] buckets:[2 1 2]}}
+	nhcb_metric2 {{schema:-53 sum:20 count:10 custom_values:[5 10] buckets:[3 4 3]}}
+
+eval instant at 1m histogram_buckets(nhcb_metric1)
+	expect no_warn
+	nhcb_metric1_bucket{le="1.0"} 2
+	nhcb_metric1_bucket{le="2.0"} 3
+	nhcb_metric1_bucket{le="+Inf"} 5
+
+eval instant at 1m histogram_buckets(nhcb_metric2)
+	expect no_warn
+	nhcb_metric2_bucket{le="5.0"} 3
+	nhcb_metric2_bucket{le="10.0"} 7
+	nhcb_metric2_bucket{le="+Inf"} 10
+
+clear
+
+# Test histogram_buckets ignores non-NHCB histograms
+load 1m
+	nhcb_metric {{schema:-53 sum:10 count:5 custom_values:[1 2] buckets:[2 1 2]}}
+	regular_histogram {{schema:0 sum:10 count:5 buckets:[1 2 2]}}
+
+eval instant at 1m histogram_buckets(nhcb_metric)
+	expect no_warn
+	nhcb_metric_bucket{le="1.0"} 2
+	nhcb_metric_bucket{le="2.0"} 3
+    nhcb_metric_bucket{le="+Inf"} 5
+
+eval instant at 1m histogram_buckets(regular_histogram)
+	expect no_warn
+

--- a/web/ui/mantine-ui/src/promql/functionDocs.tsx
+++ b/web/ui/mantine-ui/src/promql/functionDocs.tsx
@@ -1280,6 +1280,42 @@ const funcDocs: Record<string, React.ReactNode> = {
       </pre>
     </>
   ),
+  histogram_buckets: (
+    <>
+      <p>
+        <code>histogram_buckets(v instant-vector)</code> converts Native Histogram Custom Buckets (NHCB) to classic
+        histogram bucket format. For each NHCB histogram sample in
+        <code>v</code>, it returns multiple series (one per bucket) with the <code>_bucket</code> suffix appended to the
+        metric name and an <code>le</code> label indicating the bucket boundary. Non-NHCB histograms (exponential
+        schema) and float samples are ignored and do not show up in the returned vector.
+      </p>
+
+      <p>
+        Use <code>histogram_buckets</code> to convert NHCB histograms to classic histogram format for compatibility with
+        existing queries:
+      </p>
+
+      <pre>
+        <code>histogram_buckets(http_request_duration_seconds)</code>
+      </pre>
+
+      <p>
+        This returns series like: -{" "}
+        <code>
+          http_request_duration_seconds_bucket{"{"}le=&quot;0.1&quot;{"}"}
+        </code>{" "}
+        with cumulative count up to 0.1 -{" "}
+        <code>
+          http_request_duration_seconds_bucket{"{"}le=&quot;0.5&quot;{"}"}
+        </code>{" "}
+        with cumulative count up to 0.5 -{" "}
+        <code>
+          http_request_duration_seconds_bucket{"{"}le=&quot;+Inf&quot;{"}"}
+        </code>{" "}
+        with total count
+      </p>
+    </>
+  ),
   histogram_count: (
     <>
       <p>

--- a/web/ui/mantine-ui/src/promql/functionSignatures.ts
+++ b/web/ui/mantine-ui/src/promql/functionSignatures.ts
@@ -56,6 +56,12 @@ export const functionSignatures: Record<string, Func> = {
   first_over_time: { name: "first_over_time", argTypes: [valueType.matrix], variadic: 0, returnType: valueType.vector },
   floor: { name: "floor", argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
   histogram_avg: { name: "histogram_avg", argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  histogram_buckets: {
+    name: "histogram_buckets",
+    argTypes: [valueType.vector],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
   histogram_count: { name: "histogram_count", argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
   histogram_fraction: {
     name: "histogram_fraction",

--- a/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
+++ b/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
@@ -258,6 +258,12 @@ export const functionIdentifierTerms = [
     type: 'function',
   },
   {
+    label: 'histogram_buckets',
+    detail: 'function',
+    info: 'Convert a native histogram with custom buckets (NHCB) to classic histogram bucket series',
+    type: 'function',
+  },
+  {
     label: 'double_exponential_smoothing',
     detail: 'function',
     info: 'Calculate smoothed value of input series',

--- a/web/ui/module/codemirror-promql/src/types/function.ts
+++ b/web/ui/module/codemirror-promql/src/types/function.ts
@@ -47,6 +47,7 @@ import {
   HistogramStdDev,
   HistogramStdVar,
   HistogramSum,
+  HistogramBuckets,
   DoubleExponentialSmoothing,
   Hour,
   Idelta,
@@ -320,6 +321,12 @@ const promqlFunctions: { [key: number]: PromQLFunction } = {
   },
   [HistogramSum]: {
     name: 'histogram_sum',
+    argTypes: [ValueType.vector],
+    variadic: 0,
+    returnType: ValueType.vector,
+  },
+  [HistogramBuckets]: {
+    name: 'histogram_buckets',
     argTypes: [ValueType.vector],
     variadic: 0,
     returnType: ValueType.vector,

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -151,6 +151,7 @@ FunctionIdentifier {
   HistogramStdDev |
   HistogramStdVar |
   HistogramSum |
+  HistogramBuckets |
   HistogramAvg |
   DoubleExponentialSmoothing |
   Hour |
@@ -407,6 +408,7 @@ NumberDurationLiteralInDurationContext {
   HistogramStdDev { condFn<"histogram_stddev"> }
   HistogramStdVar { condFn<"histogram_stdvar"> }
   HistogramSum { condFn<"histogram_sum"> }
+  HistogramBuckets { condFn<"histogram_buckets"> }
   DoubleExponentialSmoothing { condFn<"double_exponential_smoothing"> }
   Hour { condFn<"hour"> }
   Idelta { condFn<"idelta"> }


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix: 16948
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] PromQL: New histogram_buckets function that converts NHCB to classic histogram
```

# What does this PR Introduces

This PR adds a new PromQL function to convert explicitely NHCB to classic histograms. For example:

This NHCB metric 

<img width="1710" height="847" alt="image" src="https://github.com/user-attachments/assets/653d8708-c918-462a-9691-451fb01419b7" />

Is converted to

<img width="1705" height="543" alt="image" src="https://github.com/user-attachments/assets/4626f465-f6dc-4af9-90f9-1e048a05ada4" />

# Motivation

This allows for Prometheus to ingest NHCB and make some aggregations to remote write to system that don't support native histograms yet
