### PR TITLE
tsdb: add XOR2 chunk encoding with varbit_int timestamp compression

### DIFF
--- a/cmd/prometheus/testdata/features.json
+++ b/cmd/prometheus/testdata/features.json
@@ -242,6 +242,7 @@
     "value": true
   },
   "tsdb": {
+    "chunk_encoding_xor2": false,
     "delayed_compaction": false,
     "exemplar_storage": false,
     "isolation": true,

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -298,6 +298,10 @@ func main() {
 		"A list of one or more files containing recording rules to be backfilled. All recording rules listed in the files will be backfilled. Alerting rules are not evaluated.",
 	).Required().ExistingFiles()
 
+	tsdbRewriteBlockCmd := tsdbCmd.Command("rewrite-block", "[Experimental] Rewrite a block with a different float chunk encoding.")
+	rewriteBlockPath := tsdbRewriteBlockCmd.Arg("block path", "Path to the block directory to rewrite.").Required().String()
+	rewriteBlockFloatEncoding := tsdbRewriteBlockCmd.Flag("float-chunk-encoding", "Target float chunk encoding.").Required().Enum("xor", "xor2")
+
 	promQLCmd := app.Command("promql", "PromQL formatting and editing. Requires the --experimental flag.")
 
 	promQLFormatCmd := promQLCmd.Command("format", "Format PromQL query to pretty printed form.")
@@ -447,6 +451,12 @@ func main() {
 
 	case importRulesCmd.FullCommand():
 		os.Exit(checkErr(importRules(serverURL, httpRoundTripper, *importRulesStart, *importRulesEnd, *importRulesOutputDir, *importRulesEvalInterval, *maxBlockDuration, model.UTF8Validation, *importRulesFiles...)))
+
+	case tsdbRewriteBlockCmd.FullCommand():
+		blockPath := filepath.Clean(*rewriteBlockPath)
+		blockID := filepath.Base(blockPath)
+		dbPath := filepath.Dir(blockPath)
+		os.Exit(checkErr(rewriteBlock(dbPath, blockID, *rewriteBlockFloatEncoding)))
 
 	case queryAnalyzeCmd.FullCommand():
 		os.Exit(checkErr(queryAnalyzeCfg.run(serverURL, httpRoundTripper)))

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -30,6 +30,7 @@ const (
 	EncXOR
 	EncHistogram
 	EncFloatHistogram
+	EncXOR2
 )
 
 func (e Encoding) String() string {
@@ -42,13 +43,15 @@ func (e Encoding) String() string {
 		return "histogram"
 	case EncFloatHistogram:
 		return "floathistogram"
+	case EncXOR2:
+		return "XOR2"
 	}
 	return "<unknown>"
 }
 
 // IsValidEncoding returns true for supported encodings.
 func IsValidEncoding(e Encoding) bool {
-	return e == EncXOR || e == EncHistogram || e == EncFloatHistogram
+	return e == EncXOR || e == EncHistogram || e == EncFloatHistogram || e == EncXOR2
 }
 
 const (
@@ -297,6 +300,7 @@ type Pool interface {
 // pool is a memory pool of chunk objects.
 type pool struct {
 	xor            sync.Pool
+	xor2           sync.Pool
 	histogram      sync.Pool
 	floatHistogram sync.Pool
 }
@@ -307,6 +311,11 @@ func NewPool() Pool {
 		xor: sync.Pool{
 			New: func() any {
 				return &XORChunk{b: bstream{}}
+			},
+		},
+		xor2: sync.Pool{
+			New: func() any {
+				return &XOR2Chunk{XORChunk: XORChunk{b: bstream{}}}
 			},
 		},
 		histogram: sync.Pool{
@@ -327,6 +336,8 @@ func (p *pool) Get(e Encoding, b []byte) (Chunk, error) {
 	switch e {
 	case EncXOR:
 		c = p.xor.Get().(*XORChunk)
+	case EncXOR2:
+		c = p.xor2.Get().(*XOR2Chunk)
 	case EncHistogram:
 		c = p.histogram.Get().(*HistogramChunk)
 	case EncFloatHistogram:
@@ -346,6 +357,9 @@ func (p *pool) Put(c Chunk) error {
 	case EncXOR:
 		_, ok = c.(*XORChunk)
 		sp = &p.xor
+	case EncXOR2:
+		_, ok = c.(*XOR2Chunk)
+		sp = &p.xor2
 	case EncHistogram:
 		_, ok = c.(*HistogramChunk)
 		sp = &p.histogram
@@ -374,6 +388,8 @@ func FromData(e Encoding, d []byte) (Chunk, error) {
 	switch e {
 	case EncXOR:
 		return &XORChunk{b: bstream{count: 0, stream: d}}, nil
+	case EncXOR2:
+		return &XOR2Chunk{XORChunk: XORChunk{b: bstream{count: 0, stream: d}}}, nil
 	case EncHistogram:
 		return &HistogramChunk{b: bstream{count: 0, stream: d}}, nil
 	case EncFloatHistogram:
@@ -387,6 +403,8 @@ func NewEmptyChunk(e Encoding) (Chunk, error) {
 	switch e {
 	case EncXOR:
 		return NewXORChunk(), nil
+	case EncXOR2:
+		return NewXOR2Chunk(), nil
 	case EncHistogram:
 		return NewHistogramChunk(), nil
 	case EncFloatHistogram:

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -447,6 +447,175 @@ func xorWrite(b *bstream, newValue, currentValue float64, leading, trailing *uin
 	b.writeBits(delta>>newTrailing, int(sigbits))
 }
 
+// XOR2Chunk holds XOR2 encoded sample data. It uses varbit_int encoding for
+// timestamp delta-of-delta instead of the coarse 4-bucket encoding used by XORChunk.
+type XOR2Chunk struct {
+	XORChunk
+}
+
+// NewXOR2Chunk returns a new chunk with XOR2 encoding.
+func NewXOR2Chunk() *XOR2Chunk {
+	b := make([]byte, chunkHeaderSize, chunkAllocationSize)
+	return &XOR2Chunk{XORChunk: XORChunk{b: bstream{stream: b, count: 0}}}
+}
+
+// Encoding returns the encoding type.
+func (*XOR2Chunk) Encoding() Encoding {
+	return EncXOR2
+}
+
+// Appender implements the Chunk interface.
+func (c *XOR2Chunk) Appender() (Appender, error) {
+	if len(c.b.stream) == chunkHeaderSize {
+		return &xor2Appender{xorAppender: xorAppender{b: &c.b, t: math.MinInt64, leading: 0xff}}, nil
+	}
+	it := c.iterator(nil)
+
+	// To get an appender we must know the state it would have if we had
+	// appended all existing data from scratch.
+	// We iterate through the end and populate via the iterator's state.
+	for it.Next() != ValNone {
+	}
+	if err := it.Err(); err != nil {
+		return nil, err
+	}
+
+	a := &xor2Appender{
+		xorAppender: xorAppender{
+			b:        &c.b,
+			t:        it.t,
+			v:        it.val,
+			tDelta:   it.tDelta,
+			leading:  it.leading,
+			trailing: it.trailing,
+		},
+	}
+	return a, nil
+}
+
+func (c *XOR2Chunk) iterator(it Iterator) *xor2Iterator {
+	if xor2Iter, ok := it.(*xor2Iterator); ok {
+		xor2Iter.Reset(c.b.bytes())
+		return xor2Iter
+	}
+	return &xor2Iterator{
+		xorIterator: xorIterator{
+			br:       newBReader(c.b.bytes()[chunkHeaderSize:]),
+			numTotal: binary.BigEndian.Uint16(c.b.bytes()),
+			t:        math.MinInt64,
+		},
+	}
+}
+
+// Iterator implements the Chunk interface.
+func (c *XOR2Chunk) Iterator(it Iterator) Iterator {
+	return c.iterator(it)
+}
+
+// xor2Appender uses varbit_int encoding for timestamp delta-of-delta.
+type xor2Appender struct {
+	xorAppender
+}
+
+func (a *xor2Appender) Append(_, t int64, v float64) {
+	var tDelta uint64
+	num := binary.BigEndian.Uint16(a.b.bytes())
+	switch num {
+	case 0:
+		buf := make([]byte, binary.MaxVarintLen64)
+		for _, b := range buf[:binary.PutVarint(buf, t)] {
+			a.b.writeByte(b)
+		}
+		a.b.writeBits(math.Float64bits(v), 64)
+	case 1:
+		tDelta = uint64(t - a.t)
+
+		buf := make([]byte, binary.MaxVarintLen64)
+		for _, b := range buf[:binary.PutUvarint(buf, tDelta)] {
+			a.b.writeByte(b)
+		}
+
+		a.writeVDelta(v)
+	default:
+		tDelta = uint64(t - a.t)
+		dod := int64(tDelta - a.tDelta)
+
+		putVarbitInt(a.b, dod)
+
+		a.writeVDelta(v)
+	}
+
+	a.t = t
+	a.v = v
+	binary.BigEndian.PutUint16(a.b.bytes(), num+1)
+	a.tDelta = tDelta
+}
+
+// xor2Iterator uses varbit_int decoding for timestamp delta-of-delta.
+type xor2Iterator struct {
+	xorIterator
+}
+
+func (it *xor2Iterator) Next() ValueType {
+	if it.err != nil || it.numRead == it.numTotal {
+		return ValNone
+	}
+
+	if it.numRead == 0 {
+		t, err := binary.ReadVarint(&it.br)
+		if err != nil {
+			it.err = err
+			return ValNone
+		}
+		v, err := it.br.readBits(64)
+		if err != nil {
+			it.err = err
+			return ValNone
+		}
+		it.t = t
+		it.val = math.Float64frombits(v)
+
+		it.numRead++
+		return ValFloat
+	}
+	if it.numRead == 1 {
+		tDelta, err := binary.ReadUvarint(&it.br)
+		if err != nil {
+			it.err = err
+			return ValNone
+		}
+		it.tDelta = tDelta
+		it.t += int64(it.tDelta)
+
+		return it.readValue()
+	}
+
+	// Read delta-of-delta using varbit_int encoding.
+	dod, err := readVarbitInt(&it.br)
+	if err != nil {
+		it.err = err
+		return ValNone
+	}
+
+	it.tDelta = uint64(int64(it.tDelta) + dod)
+	it.t += int64(it.tDelta)
+
+	return it.readValue()
+}
+
+func (it *xor2Iterator) Seek(t int64) ValueType {
+	if it.err != nil {
+		return ValNone
+	}
+
+	for t > it.t || it.numRead == 0 {
+		if it.Next() == ValNone {
+			return ValNone
+		}
+	}
+	return ValFloat
+}
+
 func xorRead(br *bstreamReader, value *float64, leading, trailing *uint8) error {
 	bit, err := br.readBitFast()
 	if err != nil {

--- a/tsdb/chunkenc/xor_test.go
+++ b/tsdb/chunkenc/xor_test.go
@@ -40,3 +40,197 @@ func BenchmarkXorRead(b *testing.B) {
 		_, _ = ts, v
 	}
 }
+
+func BenchmarkXor2Read(b *testing.B) {
+	c := NewXOR2Chunk()
+	app, err := c.Appender()
+	require.NoError(b, err)
+	for i := int64(0); i < 120*1000; i += 1000 {
+		app.Append(0, i, float64(i)+float64(i)/10+float64(i)/100+float64(i)/1000)
+	}
+
+	b.ReportAllocs()
+
+	var it Iterator
+	for b.Loop() {
+		var ts int64
+		var v float64
+		it = c.Iterator(it)
+		for it.Next() != ValNone {
+			ts, v = it.At()
+		}
+		_, _ = ts, v
+	}
+}
+
+func TestXOR2RoundTrip(t *testing.T) {
+	// Test that XOR2 encoding correctly round-trips data.
+	c := NewXOR2Chunk()
+	app, err := c.Appender()
+	require.NoError(t, err)
+
+	type sample struct {
+		t int64
+		v float64
+	}
+	var exp []sample
+
+	ts := int64(1000)
+	v := 123.456
+	for i := range 120 {
+		ts += 15000 + int64(i%10-5) // 15s with small jitter.
+		v += float64(i%20 - 10)
+		app.Append(0, ts, v)
+		exp = append(exp, sample{t: ts, v: v})
+	}
+
+	require.Equal(t, 120, c.NumSamples())
+	require.Equal(t, EncXOR2, c.Encoding())
+
+	// Verify iteration.
+	it := c.Iterator(nil)
+	var got []sample
+	for it.Next() == ValFloat {
+		ts, v := it.At()
+		got = append(got, sample{t: ts, v: v})
+	}
+	require.NoError(t, it.Err())
+	require.Equal(t, exp, got)
+}
+
+func TestXOR2VsXORCorrectness(t *testing.T) {
+	// Verify that XOR and XOR2 produce the same sample values.
+	xorChunk := NewXORChunk()
+	xor2Chunk := NewXOR2Chunk()
+
+	xorApp, err := xorChunk.Appender()
+	require.NoError(t, err)
+	xor2App, err := xor2Chunk.Appender()
+	require.NoError(t, err)
+
+	ts := int64(1000000)
+	v := 42.0
+	for range 120 {
+		ts += 15000
+		v += 1.5
+		xorApp.Append(0, ts, v)
+		xor2App.Append(0, ts, v)
+	}
+
+	xorIt := xorChunk.Iterator(nil)
+	xor2It := xor2Chunk.Iterator(nil)
+
+	for {
+		xorVal := xorIt.Next()
+		xor2Val := xor2It.Next()
+		require.Equal(t, xorVal, xor2Val)
+		if xorVal == ValNone {
+			break
+		}
+		xorT, xorV := xorIt.At()
+		xor2T, xor2V := xor2It.At()
+		require.Equal(t, xorT, xor2T)
+		require.Equal(t, xorV, xor2V)
+	}
+	require.NoError(t, xorIt.Err())
+	require.NoError(t, xor2It.Err())
+}
+
+func TestXOR2SmallerForJitteryTimestamps(t *testing.T) {
+	// XOR2 should produce smaller chunks when timestamps have small jitter,
+	// because varbit_int encoding has finer-grained bit buckets than XOR's
+	// coarse 4-bucket approach.
+	xorChunk := NewXORChunk()
+	xor2Chunk := NewXOR2Chunk()
+
+	xorApp, err := xorChunk.Appender()
+	require.NoError(t, err)
+	xor2App, err := xor2Chunk.Appender()
+	require.NoError(t, err)
+
+	ts := int64(1000000)
+	v := 42.0
+	for i := range 120 {
+		// Small jitter: delta-of-delta will be in the range [-5, 5].
+		ts += 15000 + int64(i%11-5)
+		v += 1.5
+		xorApp.Append(0, ts, v)
+		xor2App.Append(0, ts, v)
+	}
+
+	// XOR2 should be smaller or equal for this pattern.
+	require.LessOrEqual(t, len(xor2Chunk.Bytes()), len(xorChunk.Bytes()),
+		"XOR2 chunk should be smaller or equal to XOR for jittery timestamps")
+}
+
+func TestXOR2FromData(t *testing.T) {
+	// Test that FromData correctly creates an XOR2Chunk.
+	c := NewXOR2Chunk()
+	app, err := c.Appender()
+	require.NoError(t, err)
+
+	app.Append(0, 1000, 1.0)
+	app.Append(0, 2000, 2.0)
+	app.Append(0, 3000, 3.0)
+
+	// Create a chunk from the raw bytes.
+	c2, err := FromData(EncXOR2, c.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, EncXOR2, c2.Encoding())
+	require.Equal(t, 3, c2.NumSamples())
+
+	it := c2.Iterator(nil)
+	require.Equal(t, ValFloat, it.Next())
+	ts, v := it.At()
+	require.Equal(t, int64(1000), ts)
+	require.Equal(t, 1.0, v)
+
+	require.Equal(t, ValFloat, it.Next())
+	ts, v = it.At()
+	require.Equal(t, int64(2000), ts)
+	require.Equal(t, 2.0, v)
+
+	require.Equal(t, ValFloat, it.Next())
+	ts, v = it.At()
+	require.Equal(t, int64(3000), ts)
+	require.Equal(t, 3.0, v)
+
+	require.Equal(t, ValNone, it.Next())
+	require.NoError(t, it.Err())
+}
+
+func TestXOR2Appender(t *testing.T) {
+	// Test that getting an appender from a non-empty XOR2 chunk works.
+	c := NewXOR2Chunk()
+	app, err := c.Appender()
+	require.NoError(t, err)
+
+	app.Append(0, 1000, 1.0)
+	app.Append(0, 2000, 2.0)
+
+	// Get a new appender from the existing chunk.
+	app2, err := c.Appender()
+	require.NoError(t, err)
+	app2.Append(0, 3000, 3.0)
+
+	require.Equal(t, 3, c.NumSamples())
+
+	it := c.Iterator(nil)
+	require.Equal(t, ValFloat, it.Next())
+	ts, v := it.At()
+	require.Equal(t, int64(1000), ts)
+	require.Equal(t, 1.0, v)
+
+	require.Equal(t, ValFloat, it.Next())
+	ts, v = it.At()
+	require.Equal(t, int64(2000), ts)
+	require.Equal(t, 2.0, v)
+
+	require.Equal(t, ValFloat, it.Next())
+	ts, v = it.At()
+	require.Equal(t, int64(3000), ts)
+	require.Equal(t, 3.0, v)
+
+	require.Equal(t, ValNone, it.Next())
+	require.NoError(t, it.Err())
+}

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -919,7 +919,7 @@ func (DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compact
 			switch chk.Chunk.Encoding() {
 			case chunkenc.EncHistogram, chunkenc.EncFloatHistogram:
 				meta.Stats.NumHistogramSamples += samples
-			case chunkenc.EncXOR:
+			case chunkenc.EncXOR, chunkenc.EncXOR2:
 				meta.Stats.NumFloatSamples += samples
 			}
 		}

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -225,6 +225,11 @@ type Options struct {
 	// UseUncachedIO allows bypassing the page cache when appropriate.
 	UseUncachedIO bool
 
+	// EnableXOR2Encoding enables the experimental XOR2 chunk encoding which
+	// uses varbit_int for timestamp delta-of-delta instead of the coarse
+	// 4-bucket encoding used by XOR.
+	EnableXOR2Encoding bool
+
 	// EnableSTAsZeroSample represents 'created-timestamp-zero-ingestion' feature flag.
 	// If true, ST, if non-zero and earlier than sample timestamp, will be stored
 	// as a zero sample before the actual sample.
@@ -1023,6 +1028,7 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 	headOpts.EnableSharding = opts.EnableSharding
 	headOpts.EnableSTAsZeroSample = opts.EnableSTAsZeroSample
 	headOpts.EnableMetadataWALRecords = opts.EnableMetadataWALRecords
+	headOpts.EnableXOR2Encoding = opts.EnableXOR2Encoding
 	if opts.WALReplayConcurrency > 0 {
 		headOpts.WALReplayConcurrency = opts.WALReplayConcurrency
 	}

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1187,7 +1187,7 @@ func (s *memSeries) encodeToSnapshotRecord(b []byte) []byte {
 		buf.PutUvarintBytes(s.headChunks.chunk.Bytes())
 
 		switch enc {
-		case chunkenc.EncXOR:
+		case chunkenc.EncXOR, chunkenc.EncXOR2:
 			// Backwards compatibility for old sampleBuf which had last 4 samples.
 			for range 3 {
 				buf.PutBE64int64(0)
@@ -1240,7 +1240,7 @@ func decodeSeriesFromChunkSnapshot(d *record.Decoder, b []byte) (csr chunkSnapsh
 	csr.mc.chunk = chk
 
 	switch enc {
-	case chunkenc.EncXOR:
+	case chunkenc.EncXOR, chunkenc.EncXOR2:
 		// Backwards-compatibility for old sampleBuf which had last 4 samples.
 		for range 3 {
 			_ = dec.Be64int64()

--- a/tsdb/rewrite.go
+++ b/tsdb/rewrite.go
@@ -1,0 +1,349 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	"github.com/prometheus/prometheus/tsdb/fileutil"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
+)
+
+// RewriteBlock rewrites a block in the given database directory, converting
+// float chunks to the specified encoding. Non-float chunks are passed through
+// unchanged. The original block is replaced atomically.
+func RewriteBlock(logger *slog.Logger, dbPath, blockID string, targetEncoding chunkenc.Encoding) error {
+	if targetEncoding != chunkenc.EncXOR && targetEncoding != chunkenc.EncXOR2 {
+		return fmt.Errorf("unsupported target float chunk encoding: %s", targetEncoding)
+	}
+
+	blockDir := filepath.Join(dbPath, blockID)
+	if _, err := os.Stat(blockDir); os.IsNotExist(err) {
+		return fmt.Errorf("block directory does not exist: %s", blockDir)
+	}
+
+	pool := chunkenc.NewPool()
+	block, err := OpenBlock(logger, blockDir, pool, DefaultPostingsDecoderFactory)
+	if err != nil {
+		return fmt.Errorf("open block: %w", err)
+	}
+	defer func() {
+		if cerr := block.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	meta := block.Meta()
+	newULID := ulid.MustNew(ulid.Now(), rand.Reader)
+	newMeta := BlockMeta{
+		ULID:       newULID,
+		MinTime:    meta.MinTime,
+		MaxTime:    meta.MaxTime,
+		Compaction: meta.Compaction,
+	}
+	newMeta.Compaction.Sources = append([]ulid.ULID{}, meta.Compaction.Sources...)
+
+	tmp := filepath.Join(dbPath, newULID.String()+tmpForCreationBlockDirSuffix)
+	if err := os.RemoveAll(tmp); err != nil {
+		return fmt.Errorf("remove existing tmp dir: %w", err)
+	}
+	if err := os.MkdirAll(tmp, 0o777); err != nil {
+		return fmt.Errorf("create tmp dir: %w", err)
+	}
+	defer func() {
+		// Clean up tmp dir on error.
+		if err != nil {
+			if rerr := os.RemoveAll(tmp); rerr != nil {
+				logger.Error("Failed to remove tmp dir after error", "err", rerr)
+			}
+		}
+	}()
+
+	if err := rewriteBlockData(context.Background(), block, tmp, targetEncoding, pool, &newMeta); err != nil {
+		return fmt.Errorf("rewrite block data: %w", err)
+	}
+
+	if newMeta.Stats.NumSamples == 0 {
+		return fmt.Errorf("rewritten block has no samples")
+	}
+
+	if _, err := writeMetaFile(logger, tmp, &newMeta); err != nil {
+		return fmt.Errorf("write meta file: %w", err)
+	}
+
+	if _, err := tombstones.WriteFile(logger, tmp, tombstones.NewMemTombstones()); err != nil {
+		return fmt.Errorf("write tombstones file: %w", err)
+	}
+
+	df, err := fileutil.OpenDir(tmp)
+	if err != nil {
+		return fmt.Errorf("open tmp dir: %w", err)
+	}
+	if err := df.Sync(); err != nil {
+		df.Close()
+		return fmt.Errorf("sync tmp dir: %w", err)
+	}
+	if err := df.Close(); err != nil {
+		return fmt.Errorf("close tmp dir: %w", err)
+	}
+
+	// Move new block to final location.
+	finalDir := filepath.Join(dbPath, newULID.String())
+	if err := fileutil.Replace(tmp, finalDir); err != nil {
+		return fmt.Errorf("rename block dir: %w", err)
+	}
+
+	// Remove old block atomically.
+	tmpToDelete := filepath.Join(dbPath, fmt.Sprintf("%s%s", blockID, tmpForDeletionBlockDirSuffix))
+	if err := fileutil.Replace(blockDir, tmpToDelete); err != nil {
+		return fmt.Errorf("rename old block for deletion: %w", err)
+	}
+	if err := os.RemoveAll(tmpToDelete); err != nil {
+		logger.Warn("Failed to remove old block after rewrite", "err", err)
+	}
+
+	logger.Info("Block rewritten successfully", "old", blockID, "new", newULID.String(), "encoding", targetEncoding)
+	return nil
+}
+
+// rewriteBlockData reads all series and chunks from the source block, re-encodes
+// float chunks to the target encoding, and writes them to the destination directory.
+func rewriteBlockData(ctx context.Context, block *Block, destDir string, targetEncoding chunkenc.Encoding, pool chunkenc.Pool, meta *BlockMeta) error {
+	indexr, err := block.Index()
+	if err != nil {
+		return fmt.Errorf("open index reader: %w", err)
+	}
+	defer indexr.Close()
+
+	chunkr, err := block.Chunks()
+	if err != nil {
+		return fmt.Errorf("open chunk reader: %w", err)
+	}
+	defer chunkr.Close()
+
+	chunkw, err := chunks.NewWriter(chunkDir(destDir), chunks.WithSegmentSize(0))
+	if err != nil {
+		return fmt.Errorf("open chunk writer: %w", err)
+	}
+
+	indexw, err := index.NewWriter(ctx, filepath.Join(destDir, indexFilename))
+	if err != nil {
+		chunkw.Close()
+		return fmt.Errorf("open index writer: %w", err)
+	}
+
+	var closers []io.Closer
+	closers = append(closers, chunkw, indexw)
+	defer func() {
+		errs := tsdb_errors.NewMulti()
+		for _, c := range closers {
+			errs.Add(c.Close())
+		}
+	}()
+
+	// Write all symbols.
+	syms := indexr.Symbols()
+	for syms.Next() {
+		if err := indexw.AddSymbol(syms.At()); err != nil {
+			return fmt.Errorf("add symbol: %w", err)
+		}
+	}
+	if err := syms.Err(); err != nil {
+		return fmt.Errorf("symbols iterator: %w", err)
+	}
+
+	// Iterate all series.
+	k, v := index.AllPostingsKey()
+	all, err := indexr.Postings(ctx, k, v)
+	if err != nil {
+		return fmt.Errorf("get all postings: %w", err)
+	}
+	all = indexr.SortedPostings(all)
+
+	var (
+		ref     = storage.SeriesRef(0)
+		builder labels.ScratchBuilder
+		chks    []chunks.Meta
+	)
+
+	for all.Next() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err := indexr.Series(all.At(), &builder, &chks); err != nil {
+			return fmt.Errorf("read series: %w", err)
+		}
+
+		newChks := make([]chunks.Meta, 0, len(chks))
+		for _, chk := range chks {
+			c, _, err := chunkr.ChunkOrIterable(chk)
+			if err != nil {
+				return fmt.Errorf("read chunk: %w", err)
+			}
+
+			// Re-encode float chunks if needed.
+			if isFloatEncoding(c.Encoding()) && c.Encoding() != targetEncoding {
+				reencoded, err := reencodeFloatChunk(c, targetEncoding)
+				if err != nil {
+					return fmt.Errorf("re-encode chunk: %w", err)
+				}
+				for _, rc := range reencoded {
+					newChks = append(newChks, chunks.Meta{
+						Chunk:   rc.chunk,
+						MinTime: rc.minTime,
+						MaxTime: rc.maxTime,
+					})
+				}
+			} else {
+				newChks = append(newChks, chunks.Meta{
+					Chunk:   c,
+					MinTime: chk.MinTime,
+					MaxTime: chk.MaxTime,
+				})
+			}
+		}
+
+		if len(newChks) == 0 {
+			continue
+		}
+
+		if err := chunkw.WriteChunks(newChks...); err != nil {
+			return fmt.Errorf("write chunks: %w", err)
+		}
+		if err := indexw.AddSeries(ref, builder.Labels(), newChks...); err != nil {
+			return fmt.Errorf("add series: %w", err)
+		}
+
+		meta.Stats.NumChunks += uint64(len(newChks))
+		meta.Stats.NumSeries++
+		for _, chk := range newChks {
+			samples := uint64(chk.Chunk.NumSamples())
+			meta.Stats.NumSamples += samples
+			switch chk.Chunk.Encoding() {
+			case chunkenc.EncHistogram, chunkenc.EncFloatHistogram:
+				meta.Stats.NumHistogramSamples += samples
+			case chunkenc.EncXOR, chunkenc.EncXOR2:
+				meta.Stats.NumFloatSamples += samples
+			}
+		}
+
+		for _, chk := range newChks {
+			if err := pool.Put(chk.Chunk); err != nil {
+				return fmt.Errorf("put chunk: %w", err)
+			}
+		}
+		ref++
+	}
+	if err := all.Err(); err != nil {
+		return fmt.Errorf("postings iterator: %w", err)
+	}
+
+	// Explicitly close writers to check for errors.
+	errs := tsdb_errors.NewMulti()
+	for _, c := range closers {
+		errs.Add(c.Close())
+	}
+	closers = closers[:0]
+	return errs.Err()
+}
+
+type reencodedChunk struct {
+	chunk   chunkenc.Chunk
+	minTime int64
+	maxTime int64
+}
+
+// isFloatEncoding returns true if the encoding is a float chunk encoding.
+func isFloatEncoding(e chunkenc.Encoding) bool {
+	return e == chunkenc.EncXOR || e == chunkenc.EncXOR2
+}
+
+// reencodeFloatChunk re-encodes a float chunk to the target encoding.
+func reencodeFloatChunk(src chunkenc.Chunk, targetEncoding chunkenc.Encoding) ([]reencodedChunk, error) {
+	iter := src.Iterator(nil)
+
+	newChunk, err := chunkenc.NewEmptyChunk(targetEncoding)
+	if err != nil {
+		return nil, err
+	}
+	app, err := newChunk.Appender()
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		result  []reencodedChunk
+		minTime int64
+		lastTime int64
+		first   = true
+	)
+
+	for iter.Next() == chunkenc.ValFloat {
+		t, v := iter.At()
+		// Check if the chunk is full (reached the max byte size).
+		if newChunk.NumSamples() > 0 && len(newChunk.Bytes()) >= chunkenc.MaxBytesPerXORChunk {
+			result = append(result, reencodedChunk{
+				chunk:   newChunk,
+				minTime: minTime,
+				maxTime: lastTime,
+			})
+			newChunk, err = chunkenc.NewEmptyChunk(targetEncoding)
+			if err != nil {
+				return nil, err
+			}
+			app, err = newChunk.Appender()
+			if err != nil {
+				return nil, err
+			}
+			first = true
+		}
+
+		if first {
+			minTime = t
+			first = false
+		}
+		app.Append(0, t, v)
+		lastTime = t
+	}
+	if err := iter.Err(); err != nil {
+		return nil, err
+	}
+
+	if newChunk.NumSamples() > 0 {
+		result = append(result, reencodedChunk{
+			chunk:   newChunk,
+			minTime: minTime,
+			maxTime: lastTime,
+		})
+	}
+
+	return result, nil
+}

--- a/tsdb/rewrite_test.go
+++ b/tsdb/rewrite_test.go
@@ -1,0 +1,227 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/common/promslog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+func TestRewriteBlock(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		targetEncoding chunkenc.Encoding
+	}{
+		{
+			name:           "xor to xor2",
+			targetEncoding: chunkenc.EncXOR2,
+		},
+		{
+			name:           "xor to xor (noop)",
+			targetEncoding: chunkenc.EncXOR,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			logger := promslog.NewNopLogger()
+
+			// Create a block with XOR-encoded float data.
+			series := genSeries(10, 2, 1000, 10000)
+			blockDir := createBlock(t, dir, series)
+			blockID := filepath.Base(blockDir)
+
+			// Read original block data for comparison.
+			origSamples := readBlockSamples(t, dir, blockID)
+			require.Greater(t, len(origSamples), 0)
+
+			// Rewrite the block.
+			err := RewriteBlock(logger, dir, blockID, tc.targetEncoding)
+			require.NoError(t, err)
+
+			// The original block should be gone.
+			_, err = os.Stat(blockDir)
+			require.True(t, os.IsNotExist(err))
+
+			// Find the new block.
+			entries, err := os.ReadDir(dir)
+			require.NoError(t, err)
+			var newBlockID string
+			for _, e := range entries {
+				if e.IsDir() && e.Name() != blockID {
+					newBlockID = e.Name()
+					break
+				}
+			}
+			require.NotEmpty(t, newBlockID, "new block should exist")
+
+			// Verify data integrity.
+			newSamples := readBlockSamples(t, dir, newBlockID)
+			require.Equal(t, origSamples, newSamples)
+
+			// Verify encoding of chunks.
+			verifyBlockChunkEncoding(t, dir, newBlockID, tc.targetEncoding)
+		})
+	}
+}
+
+func TestRewriteBlockXOR2ToXOR(t *testing.T) {
+	dir := t.TempDir()
+	logger := promslog.NewNopLogger()
+
+	// Create a block with XOR data first.
+	series := genSeries(5, 2, 1000, 5000)
+	blockDir := createBlock(t, dir, series)
+	blockID := filepath.Base(blockDir)
+
+	// Rewrite to XOR2.
+	err := RewriteBlock(logger, dir, blockID, chunkenc.EncXOR2)
+	require.NoError(t, err)
+
+	// Find the XOR2 block.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var xor2BlockID string
+	for _, e := range entries {
+		if e.IsDir() {
+			xor2BlockID = e.Name()
+			break
+		}
+	}
+	require.NotEmpty(t, xor2BlockID)
+
+	// Read the XOR2 block samples.
+	xor2Samples := readBlockSamples(t, dir, xor2BlockID)
+
+	// Rewrite back to XOR.
+	err = RewriteBlock(logger, dir, xor2BlockID, chunkenc.EncXOR)
+	require.NoError(t, err)
+
+	// Find the new XOR block.
+	entries, err = os.ReadDir(dir)
+	require.NoError(t, err)
+	var xorBlockID string
+	for _, e := range entries {
+		if e.IsDir() {
+			xorBlockID = e.Name()
+			break
+		}
+	}
+	require.NotEmpty(t, xorBlockID)
+
+	// Verify data integrity after round-trip.
+	xorSamples := readBlockSamples(t, dir, xorBlockID)
+	require.Equal(t, xor2Samples, xorSamples)
+
+	// Verify encoding.
+	verifyBlockChunkEncoding(t, dir, xorBlockID, chunkenc.EncXOR)
+}
+
+type seriesSample struct {
+	labels string
+	t      int64
+	v      float64
+}
+
+// readBlockSamples reads all float samples from a block.
+func readBlockSamples(t *testing.T, dbPath, blockID string) []seriesSample {
+	t.Helper()
+	blockDir := filepath.Join(dbPath, blockID)
+	pool := chunkenc.NewPool()
+	block, err := OpenBlock(promslog.NewNopLogger(), blockDir, pool, DefaultPostingsDecoderFactory)
+	require.NoError(t, err)
+	defer block.Close()
+
+	indexr, err := block.Index()
+	require.NoError(t, err)
+	defer indexr.Close()
+
+	chunkr, err := block.Chunks()
+	require.NoError(t, err)
+	defer chunkr.Close()
+
+	var result []seriesSample
+	all := AllSortedPostings(context.Background(), indexr)
+	var builder labels.ScratchBuilder
+	var chks []chunks.Meta
+
+	for all.Next() {
+		require.NoError(t, indexr.Series(all.At(), &builder, &chks))
+		lset := builder.Labels().String()
+
+		for _, chk := range chks {
+			c, _, err := chunkr.ChunkOrIterable(chk)
+			require.NoError(t, err)
+
+			if !isFloatEncoding(c.Encoding()) {
+				continue
+			}
+
+			it := c.Iterator(nil)
+			for it.Next() == chunkenc.ValFloat {
+				ts, v := it.At()
+				result = append(result, seriesSample{labels: lset, t: ts, v: v})
+			}
+			require.NoError(t, it.Err())
+		}
+	}
+	require.NoError(t, all.Err())
+	return result
+}
+
+// verifyBlockChunkEncoding verifies that all float chunks in a block use the expected encoding.
+func verifyBlockChunkEncoding(t *testing.T, dbPath, blockID string, expectedEncoding chunkenc.Encoding) {
+	t.Helper()
+	blockDir := filepath.Join(dbPath, blockID)
+	pool := chunkenc.NewPool()
+	block, err := OpenBlock(promslog.NewNopLogger(), blockDir, pool, DefaultPostingsDecoderFactory)
+	require.NoError(t, err)
+	defer block.Close()
+
+	indexr, err := block.Index()
+	require.NoError(t, err)
+	defer indexr.Close()
+
+	chunkr, err := block.Chunks()
+	require.NoError(t, err)
+	defer chunkr.Close()
+
+	all := AllSortedPostings(context.Background(), indexr)
+	var builder labels.ScratchBuilder
+	var chks []chunks.Meta
+
+	for all.Next() {
+		require.NoError(t, indexr.Series(all.At(), &builder, &chks))
+
+		for _, chk := range chks {
+			c, _, err := chunkr.ChunkOrIterable(chk)
+			require.NoError(t, err)
+
+			if isFloatEncoding(c.Encoding()) {
+				require.Equal(t, expectedEncoding, c.Encoding(),
+					"chunk encoding mismatch for series %s", builder.Labels().String())
+			}
+		}
+	}
+	require.NoError(t, all.Err())
+}
+


### PR DESCRIPTION
Add EncXOR2 (encoding=4), an improved XOR variant that uses varbit_int for timestamp delta-of-delta instead of the coarse 4-bucket encoding. This provides finer-grained bit buckets (1,5,9,13,17,24,32,64,72 bits) compared to XOR's (1,16,20,24,68 bits), resulting in better compression for typical scrape intervals with small timestamp jitter.

Tested on my laptop's own Prometheus scrape data, rewriting blocks from XOR to XOR2 reduced chunk storage from 75M to 58M (22.7% decrease).

Gated behind --enable-feature=tsdb-chunks-encoding-xor2 (reading XOR2 works regardless of the flag).

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] TSDB: Add XOR2 chunk encoding with varbit_int timestamp compression
```
