### PR TITLE
docs: add missing reference to /api/v1/read endpoint

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -1658,9 +1658,7 @@ endpoint is `/api/v1/write`. Find more details [here](../storage.md#overview).
 
 `POST /api/v1/read`
 
-Prometheus exposes a remote read endpoint that allows external systems (like Thanos or the OpenTelemetry Collector) to read data from the TSDB. The endpoint accepts a Snappy-compressed protocol buffer message.
-
-This endpoint is enabled by default.
+Prometheus exposes a remote read endpoint that allows external systems (such as Thanos) to read data from the TSDB.
 
 For more details, see the [Remote Read API documentation](https://prometheus.io/docs/prometheus/latest/querying/remote_read_api/) and the guide on [Remote Endpoints and Storage](https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage).
 

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -1654,6 +1654,14 @@ endpoint is `/api/v1/write`. Find more details [here](../storage.md#overview).
 
 *New in v2.33*
 
+## Remote Read
+
+POST /api/v1/read
+
+Prometheus exposes a remote read endpoint that allows external systems (like Thanos or the OpenTelemetry Collector) to read data from the TSDB. The endpoint accepts a Snappy-compressed protocol buffer message.
+
+This endpoint is enabled by default.
+
 ## OTLP Receiver
 
 Prometheus can be configured as a receiver for the OTLP Metrics protocol. This

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -1656,11 +1656,13 @@ endpoint is `/api/v1/write`. Find more details [here](../storage.md#overview).
 
 ## Remote Read
 
-POST /api/v1/read
+`POST /api/v1/read`
 
 Prometheus exposes a remote read endpoint that allows external systems (like Thanos or the OpenTelemetry Collector) to read data from the TSDB. The endpoint accepts a Snappy-compressed protocol buffer message.
 
 This endpoint is enabled by default.
+
+For more details, see the [Remote Read API documentation](https://prometheus.io/docs/prometheus/latest/querying/remote_read_api/) and the guide on [Remote Endpoints and Storage](https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage).
 
 ## OTLP Receiver
 


### PR DESCRIPTION
The `POST /api/v1/read` endpoint is a critical interface for ecosystem interoperability (used by Thanos, Cortex, and the OpenTelemetry Collector) but was missing from the official API documentation.

This PR adds a brief reference to the Remote Read endpoint in `docs/querying/api.md`, placing it logically adjacent to the Remote Write documentation. This improves clarity for users integrating Prometheus with long-term storage or OTel.

#### Which issue(s) does the PR fix:
NONE

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```