### PR TITLE
Fix a couple of broken links in configuration.md with space between the hyperlink

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2528,8 +2528,7 @@ in the configuration file), which can also be changed using relabeling.
 
 ### `<nerve_sd_config>`
 
-Nerve SD configurations allow retrieving scrape targets from [AirBnB's Nerve]
-(https://github.com/airbnb/nerve) which are stored in
+Nerve SD configurations allow retrieving scrape targets from [AirBnB's Nerve](https://github.com/airbnb/nerve) which are stored in
 [Zookeeper](https://zookeeper.apache.org/).
 
 The following meta labels are available on targets during [relabeling](#relabel_config):
@@ -2583,8 +2582,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 
 ### `<serverset_sd_config>`
 
-Serverset SD configurations allow retrieving scrape targets from [Serversets]
-(https://github.com/twitter/finagle/tree/develop/finagle-serversets) which are
+Serverset SD configurations allow retrieving scrape targets from [Serversets](https://github.com/twitter/finagle/tree/develop/finagle-serversets) which are
 stored in [Zookeeper](https://zookeeper.apache.org/). Serversets are commonly
 used by [Finagle](https://twitter.github.io/finagle/) and
 [Aurora](https://aurora.apache.org/).


### PR DESCRIPTION
There are a couple of links in the documentation where a space exists between the link text ([]) and the URL (()). This breaks standard Markdown link formatting and prevents the links from rendering correctly.

The affected links are:

- AirBnB's Nerve in https://prometheus.io/docs/prometheus/latest/configuration/configuration/#nerve_sd_config
- Serversets in https://prometheus.io/docs/prometheus/latest/configuration/configuration/#serverset_sd_config

For more information, refer to https://github.com/prometheus/prometheus/issues/18044

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```

Fix https://github.com/prometheus/prometheus/issues/18044