### PR TITLE
promtool: Fixed tsdb dump silently dropping first samples of histogram series.

### DIFF
--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -755,17 +755,18 @@ func formatSeriesSet(ss storage.SeriesSet) error {
 		series := ss.At()
 		lbs := series.Labels()
 		it := series.Iterator(nil)
-		for it.Next() == chunkenc.ValFloat {
-			ts, val := it.At()
-			fmt.Printf("%s %g %d\n", lbs, val, ts)
-		}
-		for it.Next() == chunkenc.ValFloatHistogram {
-			ts, fh := it.AtFloatHistogram(nil)
-			fmt.Printf("%s %s %d\n", lbs, fh.String(), ts)
-		}
-		for it.Next() == chunkenc.ValHistogram {
-			ts, h := it.AtHistogram(nil)
-			fmt.Printf("%s %s %d\n", lbs, h.String(), ts)
+		for valType := it.Next(); valType != chunkenc.ValNone; valType = it.Next() {
+			switch valType {
+			case chunkenc.ValFloat:
+				ts, val := it.At()
+				fmt.Printf("%s %g %d\n", lbs, val, ts)
+			case chunkenc.ValFloatHistogram:
+				ts, fh := it.AtFloatHistogram(nil)
+				fmt.Printf("%s %s %d\n", lbs, fh.String(), ts)
+			case chunkenc.ValHistogram:
+				ts, h := it.AtHistogram(nil)
+				fmt.Printf("%s %s %d\n", lbs, h.String(), ts)
+			}
 		}
 		if it.Err() != nil {
 			return ss.Err()

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -766,6 +766,8 @@ func formatSeriesSet(ss storage.SeriesSet) error {
 			case chunkenc.ValHistogram:
 				ts, h := it.AtHistogram(nil)
 				fmt.Printf("%s %s %d\n", lbs, h.String(), ts)
+			default:
+				return fmt.Errorf("unknown sample type %s", valType.String())
 			}
 		}
 		if it.Err() != nil {

--- a/cmd/promtool/tsdb_test.go
+++ b/cmd/promtool/tsdb_test.go
@@ -185,6 +185,17 @@ func TestTSDBDump(t *testing.T) {
 	}
 }
 
+func TestTSDBDumpNativeHistogram(t *testing.T) {
+	storage := promqltest.LoadedStorage(t, `
+		load 1m
+			native_hist{job="test"} {{sum:1 count:1}} {{sum:2 count:2}} {{sum:3 count:3}}
+	`)
+
+	dumpedMetrics := getDumpedSamples(t, storage.Dir(), "", math.MinInt64, math.MaxInt64, []string{"{__name__=~'(?s:.*)'}"}, formatSeriesSet)
+	lines := strings.Split(strings.TrimSpace(dumpedMetrics), "\n")
+	require.Len(t, lines, 3, "expected 3 samples for native histogram series, got %d", len(lines))
+}
+
 func sortLines(buf string) string {
 	lines := strings.Split(buf, "\n")
 	slices.Sort(lines)

--- a/cmd/promtool/tsdb_test.go
+++ b/cmd/promtool/tsdb_test.go
@@ -27,9 +27,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/annotations"
 )
 
 func TestGenerateBucket(t *testing.T) {
@@ -186,15 +191,88 @@ func TestTSDBDump(t *testing.T) {
 }
 
 func TestTSDBDumpNativeHistogram(t *testing.T) {
-	storage := promqltest.LoadedStorage(t, `
+	testStorage := promqltest.LoadedStorage(t, `
 		load 1m
-			native_hist{job="test"} {{sum:1 count:1}} {{sum:2 count:2}} {{sum:3 count:3}}
+			mixed_hist{job="test"} 1 {{sum:2 count:2}} 3
 	`)
 
-	dumpedMetrics := getDumpedSamples(t, storage.Dir(), "", math.MinInt64, math.MaxInt64, []string{"{__name__=~'(?s:.*)'}"}, formatSeriesSet)
-	lines := strings.Split(strings.TrimSpace(dumpedMetrics), "\n")
-	require.Len(t, lines, 3, "expected 3 samples for native histogram series, got %d", len(lines))
+	app := testStorage.AppenderV2(context.Background())
+	for i := range 3 {
+		_, err := app.Append(
+			0,
+			labels.FromStrings(labels.MetricName, "integer_hist", "job", "test"),
+			0,
+			int64(i)*int64(time.Minute/time.Millisecond),
+			0,
+			&histogram.Histogram{
+				Count:         uint64(i + 1),
+				Sum:           float64(i + 1),
+				ZeroCount:     uint64(i + 1),
+				ZeroThreshold: 0.001,
+			},
+			nil,
+			storage.AppendV2Options{},
+		)
+		require.NoError(t, err)
+	}
+	require.NoError(t, app.Commit())
+
+	dumpedMetrics := getDumpedSamples(t, testStorage.Dir(), "", math.MinInt64, math.MaxInt64, []string{"{__name__=~'(?s:.*)'}"}, formatSeriesSet)
+	expected := `
+{__name__="integer_hist", job="test"} {count:1, sum:1, [-0.001,0.001]:1} 0
+{__name__="integer_hist", job="test"} {count:2, sum:2, [-0.001,0.001]:2} 60000
+{__name__="integer_hist", job="test"} {count:3, sum:3, [-0.001,0.001]:3} 120000
+{__name__="mixed_hist", job="test"} 1 0
+{__name__="mixed_hist", job="test"} {count:2, sum:2} 60000
+{__name__="mixed_hist", job="test"} 3 120000
+`
+	require.Equal(t, sortLines(strings.TrimSpace(expected)), sortLines(strings.TrimSpace(dumpedMetrics)))
 }
+
+func TestFormatSeriesSetRejectsUnknownSampleType(t *testing.T) {
+	ss := &singleSeriesSet{
+		series: &storage.SeriesEntry{
+			Lset: labels.FromStrings(labels.MetricName, "unknown"),
+			SampleIteratorFn: func(chunkenc.Iterator) chunkenc.Iterator {
+				return &unknownValueTypeIterator{}
+			},
+		},
+	}
+
+	require.EqualError(t, formatSeriesSet(ss), "unknown sample type unknown")
+}
+
+type singleSeriesSet struct {
+	series storage.Series
+	done   bool
+}
+
+func (s *singleSeriesSet) Next() bool {
+	if s.done {
+		return false
+	}
+	s.done = true
+	return true
+}
+
+func (s *singleSeriesSet) At() storage.Series              { return s.series }
+func (*singleSeriesSet) Err() error                        { return nil }
+func (*singleSeriesSet) Warnings() annotations.Annotations { return nil }
+
+type unknownValueTypeIterator struct {
+	chunkenc.Iterator
+	done bool
+}
+
+func (it *unknownValueTypeIterator) Next() chunkenc.ValueType {
+	if it.done {
+		return chunkenc.ValNone
+	}
+	it.done = true
+	return chunkenc.ValueType(255)
+}
+
+func (*unknownValueTypeIterator) Err() error { return nil }
 
 func sortLines(buf string) string {
 	lines := strings.Split(buf, "\n")


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None.

#### Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] promtool: Fixed `tsdb dump` silently dropping native histogram samples.
```

`promtool tsdb dump` silently drops all native histogram and float histogram samples. The `formatSeriesSet` function used three sequential `for` loops, each calling `it.Next()` as its loop condition. When loop 1 exits (eg because the series contains histogram data, not float), `it.Next()` has already advanced the iterator past the first histogram sample. Loop 2 then calls `it.Next()` again, skipping that sample entirely. The same problem occurs between loop 2 and loop 3.

The fix replaces the three sequential loops with a single loop and a `switch` on the value type returned by `it.Next()`. This matches the correct iterator pattern used elsewhere in the codebase (e.g. `tsdb/chunks/chunks.go`, `scrape/scrape_test.go`).

A test has been added.
