### PR TITLE
Increase Renovate speed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,11 +9,13 @@
     "gomodTidy",
     "gomodUpdateImportPaths"
   ],
-  "schedule": ["* 11 21 * *"],
+  "schedule": ["* * 21 * *"],
   "timezone": "UTC",
   "github-actions": {
     "managerFilePatterns": ["scripts/**"]
   },
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 5,
   "packageRules": [
     {
       "description": "Don't update replace directives",


### PR DESCRIPTION
* Allow Renovate to run all day on the monthly day.
* Increase the max PRs from 10 to 20.
* Incresae the PR open rate from 2 to 5.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
