### PR TITLE
fix: prevent stale exemplars leaking to histogram _sum/_count

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/helper.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper.go
@@ -228,6 +228,9 @@ func (c *PrometheusConverter) addHistogramDataPoints(
 		}
 
 		pt := dataPoints.At(x)
+		// Clear stale exemplars from the previous data point to prevent
+		// them from leaking into _sum and _count of this data point.
+		appOpts.Exemplars = nil
 		timestamp := convertTimeStamp(pt.Timestamp())
 		startTimestamp := convertTimeStamp(pt.StartTimestamp())
 		baseLabels, err := c.createAttributes(pt.Attributes(), settings, reservedLabelNames, false, appOpts.Metadata)


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

NONE

#### Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] OTLP: Fix exemplars getting mixed between incorrect parts of a histogram
```

#### Summary

In `addHistogramDataPoints`, exemplars assigned to the `+Inf` bucket of one data point were carried over into the `_sum` and `_count` `Append` calls of the next data point via the shared `appOpts`. This happened because the AppenderV2 migration replaced per-call `nil` exemplar arguments with a shared `appOpts` struct that wasn't cleared between iterations.

The fix clears `appOpts.Exemplars` at the start of each loop iteration, restoring the nil-exemplar semantics that existed before the migration.

A regression test with two histogram data points verifies exemplars don't leak across data point boundaries.