### PR TITLE
tsdb:Optimize LabelValues API performance (#14551)

### DIFF
--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1192,7 +1192,7 @@ func (p *postingsFailingAfterNthCall) Err() error {
 }
 
 func TestPostingsWithIndexHeap(t *testing.T) {
-	t.Run("iterate", func(t *testing.T) {
+	t.Run("seekHead", func(t *testing.T) {
 		h := postingsWithIndexHeap{
 			{index: 0, p: NewListPostings([]storage.SeriesRef{10, 20, 30})},
 			{index: 1, p: NewListPostings([]storage.SeriesRef{1, 5})},
@@ -1205,7 +1205,7 @@ func TestPostingsWithIndexHeap(t *testing.T) {
 
 		for _, expected := range []storage.SeriesRef{1, 5, 10, 20, 25, 30, 50} {
 			require.Equal(t, expected, h.at())
-			require.NoError(t, h.next())
+			require.NoError(t, h.seekHead(h.at()+1))
 		}
 		require.True(t, h.empty())
 	})
@@ -1223,7 +1223,7 @@ func TestPostingsWithIndexHeap(t *testing.T) {
 
 		for _, expected := range []storage.SeriesRef{1, 5, 10, 20} {
 			require.Equal(t, expected, h.at())
-			require.NoError(t, h.next())
+			require.NoError(t, h.seekHead(h.at()+1))
 		}
 		require.Equal(t, storage.SeriesRef(25), h.at())
 		node := heap.Pop(&h).(postingsWithIndex)

--- a/tsdb/label_values_bench_test.go
+++ b/tsdb/label_values_bench_test.go
@@ -1,0 +1,86 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/wlog"
+)
+
+// BenchmarkLabelValues_SlowPath benchmarks the performance of LabelValues when the matcher
+// is far ahead of the candidate posting list. This reproduces the performance regression
+// described in #14551 where dense candidates caused O(N) iteration instead of O(log N) seeking.
+func BenchmarkLabelValues_SlowPath(b *testing.B) {
+	// Create a head with some data.
+	opts := DefaultHeadOptions()
+	opts.ChunkDirRoot = b.TempDir()
+	h, err := NewHead(nil, nil, nil, nil, opts, nil)
+	require.NoError(b, err)
+	defer h.Close()
+
+	app := h.Appender(context.Background())
+	// 1. Create a large number of series for a "candidate" label (e.g. "job").
+	// We want these to NOT match the target matcher, but be candidates for a different label.
+	// We use "job=api" and "instance=..."
+	// We want the interaction to be:
+	// LabelValues("instance", "job"="api")
+	// "job"="api" will have 1 series at the END.
+	// "instance" will have 100k series.
+
+	// Actually, let's stick to the reproduction case:
+	// distinct values for "val1".
+	// "b"="1" matcher.
+
+	// Create 100k series with the same label value ("common") but without the matcher label.
+	// This results in a single large posting list for that value, simulating a dense candidate.
+	for i := range 100000 {
+		_, err := app.Append(0, labels.FromStrings("val1", "common", "extra", strconv.Itoa(i)), time.Now().UnixMilli(), 1)
+		require.NoError(b, err)
+	}
+
+	// Create 1 series that matches the label "b=1", with a series ID greater than all previous ones.
+	// This forces the intersection to skip over all 100k previous candidates.
+	_, err = app.Append(0, labels.FromStrings("val1", "common", "b", "1"), time.Now().UnixMilli(), 1)
+	require.NoError(b, err)
+
+	require.NoError(b, app.Commit())
+
+	ctx := context.Background()
+	matcher := labels.MustNewMatcher(labels.MatchEqual, "b", "1")
+
+	// Use the correct method to access label values.
+	idx, err := h.Index()
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		// "val1"="common" has 100k+1 postings.
+		// "b=1" has 1 posting (the last one).
+		vals, err := idx.LabelValues(ctx, "val1", nil, matcher)
+		require.NoError(b, err)
+		require.Equal(b, []string{"common"}, vals)
+	}
+}
+
+// Ensure wlog/wal needed for NewHead.
+var _ = wlog.WL{}


### PR DESCRIPTION
tsdb: Optimize LabelValues for sparse intersections (Fixes #14551)

#### Description
This PR optimizes the `FindIntersectingPostings` function to improve the performance of `LabelValues` queries when matchers are involved.

**The Problem:**
In scenarios where a matcher selects a range of IDs that is disjoint from or far ahead of the current candidate postings (e.g., `matcher` is at ID 1,000,000 but the `candidate` is at ID 0), the previous implementation would call `Next()` on the candidate roughly 1,000,000 times to catch up. This resulted in O(N) complexity where N is the number of non-matching IDs, causing significant performance degradation and even timeouts for large datasets.

**The Solution:**
I've updated `FindIntersectingPostings` to use `Seek()` on the candidate instead of `Next()`. This allows the iterator to skip non-matching ranges efficiently (O(log N)), aligning the performance of `LabelValues` with the much faster `Series` API for equivalent queries.

#### Benchmarks
I created a reproduction benchmark `BenchmarkLabelValues_SlowPath` to simulate the issue (dense candidates, sparse matcher).

**Results:**
- **Before Optimization:** The benchmark would timeout or take >1ms per operation.
- **After Optimization:** The benchmark completes in **~1290 ns/op** (verified locally).
<img width="562" height="465" alt="Screenshot 2026-02-12 at 3 35 55 PM" src="https://github.com/user-attachments/assets/4d383f72-3419-4f36-bb92-081ee35a9556" />


#### Verification
- Ran `go test ./tsdb/index/...` to ensure no regressions in the index package.
- Verified manually that `LabelValues` returns correct results with the optimization applied.

#### Which issue(s) does the PR fix:
Fixes #14551

#### Does this PR introduce a user-facing change?
```release-notes
[PERF] tsdb: Optimize LabelValues intersection performance for matchers
```
