### PR TITLE
testing: enable experimental functions in promql benchmarks

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -342,7 +342,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 		Reg:        nil,
 		MaxSamples: 50000000,
 		Timeout:    100 * time.Second,
-		Parser:     parser.NewParser(parser.Options{EnableExtendedRangeSelectors: true}),
+		Parser:     parser.NewParser(parser.Options{EnableExtendedRangeSelectors: true, EnableExperimentalFunctions: true}),
 	}
 	engine := promqltest.NewTestEngineWithOpts(b, opts)
 
@@ -643,6 +643,7 @@ func BenchmarkInfoFunction(b *testing.B) {
 			Timeout:              100 * time.Second,
 			EnableAtModifier:     true,
 			EnableNegativeOffset: true,
+			Parser:               parser.NewParser(parser.Options{EnableExperimentalFunctions: true}),
 		}
 		engine := promql.NewEngine(opts)
 		b.Run(tc.name, func(b *testing.B) {


### PR DESCRIPTION
This PR enables experimental functions in the promql benchmarks that require them to be enabled to complete successfully.

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
