### PR TITLE
Upgrade `mongodb/mongo-go-driver v1.17.6` dependency to v1.17.9 to fix security vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -231,7 +231,7 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
-	go.mongodb.org/mongo-driver v1.17.6 // indirect
+	go.mongodb.org/mongo-driver v1.17.9 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/confmap v1.51.0 // indirect
 	go.opentelemetry.io/collector/confmap/xconfmap v0.145.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -570,8 +570,8 @@ github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtX
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.mongodb.org/mongo-driver v1.17.6 h1:87JUG1wZfWsr6rIz3ZmpH90rL5tea7O3IHuSwHUpsss=
-go.mongodb.org/mongo-driver v1.17.6/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
+go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/collector/component v1.51.0 h1:btNW76MCRmpsk0ARRT5wspDXF9tvdaLd3uBtYXIiQn0=


### PR DESCRIPTION
There's a HIGH vulnerability in Prometheus coming from mongodb/mongo-go-driver v1.17.6 go dependency

- Short-Term fix: mongodb/mongo-go-driver v1.17.9 
- Long-Term fix: mongodb/mongo-go-driver v2.5.0

Vulnerability Description: **BDSA-2026-1849**

> The mongo-go-driver is vulnerable to a heap out-of-bounds read due to incorrect handling of string termination in the GSSAPI (Kerberos) authentication implementation. This could allow an attacker to read memory beyond the allocated heap buffer, potentially exposing sensitive information or causing unexpected behaviour.

#### Which issue(s) does the PR fix:
N/A

#### Does this PR introduce a user-facing change?
NONE

```release-notes
[SECURITY] Upgrade `mongodb/mongo-go-driver` from v1.17.6 to v1.17.9 to fix BDSA-2026-1849 security vulnerability
```
