### PR TITLE
security: remove bcrypt hashes from web-config example

### DIFF
--- a/documentation/examples/web-config.yml
+++ b/documentation/examples/web-config.yml
@@ -8,5 +8,5 @@ tls_server_config:
 # Usernames and passwords required to connect to Prometheus.
 # Passwords are hashed with bcrypt: https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md#about-bcrypt
 basic_auth_users:
-  alice: $2y$10$mDwo.lAisC94iLAyP81MCesa29IzH37oigHC/42V2pdJlUprsJPze
-  bob: $2y$10$hLqFl9jSjoAAy95Z/zw8Ye8wkdMBM8c5Bn1ptYqP/AXyV0.oy0S8m
+  alice: <bcrypt_hash_for_password>
+  bob: <bcrypt_hash_for_password>


### PR DESCRIPTION
This PR fixes a SAST finding by replacing real bcrypt password hashes in an example configuration file with placeholder values, removing sensitive data while preserving the documentation structure and intent.
