### PR TITLE
promql: Add metric to track total samples read per query

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -42,7 +42,13 @@ When enabled, for each instance scrape, Prometheus stores a sample in the follow
 `--enable-feature=promql-per-step-stats`
 
 When enabled, passing `stats=all` in a query request returns per-step
-statistics. Currently this is limited to totalQueryableSamples.
+statistics. The following sample statistics are included:
+
+- **totalQueryableSamples** / **totalQueryableSamplesPerStep**: Total number of samples *loaded* during the query. For range-vector functions (e.g. `rate`, `sum_over_time`) evaluated over multiple steps, each step counts the full window (the same point may be counted in multiple steps).
+- **samplesRead** / **samplesReadPerStep**: Total number of samples *read* (I/O). For range-vector functions in range queries, only *new* points per step are counted (step 0: full window; later steps: points not seen in the previous step). For other query types, this equals totalQueryableSamples.
+- **peakSamples**: Peak number of samples in memory during evaluation (used for the `query.max-samples` limit).
+
+The Prometheus server exposes two counters for observability: `prometheus_engine_query_samples_total` (samples loaded, full window per step) and `prometheus_engine_query_samples_read_total` (samples read, delta per step for range-vector).
 
 When disabled in either the engine or the query, per-step statistics are not
 computed at all.

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -102,7 +102,7 @@ URL query parameters:
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Doesn't affect scalars or strings but truncates the number of series for matrices and vectors. Optional. 0 means disabled.
 - `lookback_delta=<duration | float>`: Override the [lookback period](#staleness) just for this query in `duration` format or float number of seconds. Optional.
-- `stats=<string>`: Include query statistics in the response. If set to `all`, includes detailed statistics. Optional.
+- `stats=<string>`: Include query statistics in the response. If set to `all`, includes detailed statistics (timings and sample counts). Optional. See [Query statistics](#query-statistics).
 
 The current server time is used if the `time` parameter is omitted.
 
@@ -176,7 +176,7 @@ URL query parameters:
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Optional. 0 means disabled.
 - `lookback_delta=<duration | float>`: Override the [lookback period](#staleness) just for this query in `duration` format or float number of seconds. Optional.
-- `stats=<string>`: Include query statistics in the response. If set to `all`, includes detailed statistics. Optional.
+- `stats=<string>`: Include query statistics in the response. If set to `all`, includes detailed statistics (timings and sample counts). Optional. See [Query statistics](#query-statistics).
 
 You can URL-encode these parameters directly in the request body by using the `POST` method and
 `Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large
@@ -235,6 +235,20 @@ curl 'http://localhost:9090/api/v1/query_range?query=up&start=2015-07-01T20:10:3
    }
 }
 ```
+
+### Query statistics
+
+When the `stats` parameter is set (e.g. `stats=all`), the response `data` includes a `stats` object with the following structure:
+
+- **timings**: Durations (in seconds) for different phases of query execution (e.g. `evalTotalTime`, `execQueueTime`).
+- **samples**:
+  - **totalQueryableSamples**: Total number of samples *loaded* during the query. For range-vector functions over multiple steps, each step counts the full window.
+  - **totalQueryableSamplesPerStep**: (Only with `stats=all` and when per-step stats are enabled.) Per-step count of samples loaded; same semantics as `totalQueryableSamples` per step.
+  - **samplesRead**: Total number of samples *read* (I/O). For range-vector functions in range queries, only new points per step are counted; for other queries this equals `totalQueryableSamples`.
+  - **samplesReadPerStep**: (Only with `stats=all` and when per-step stats are enabled.) Per-step count of samples read (delta semantics for range-vector).
+  - **peakSamples**: Peak number of samples in memory during evaluation.
+
+The server also exposes two Prometheus metrics: `prometheus_engine_query_samples_total` (samples loaded) and `prometheus_engine_query_samples_read_total` (samples read). See [Per-step stats](../feature_flags.md#per-step-stats) for the `promql-per-step-stats` feature flag.
 
 ## Formatting query expressions
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2279,12 +2279,13 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 						counter++
 					}
 				}
-				var samplesReadCount int64
+				var maxt int64
 				// Evaluate the matrix selector for this series
 				// for this step, but only if this is the 1st
 				// iteration or no @ modifier has been used.
-				if ts == ev.startTimestamp || selVS.Timestamp == nil {
-					maxt := ts - offset
+				refetch := ts == ev.startTimestamp || selVS.Timestamp == nil
+				if refetch {
+					maxt = ts - offset
 					mint := maxt - selRange
 					switch {
 					case selVS.Anchored:
@@ -2294,16 +2295,9 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 						maxt += durationMilliseconds(ev.lookbackDelta)
 					}
 					floats, histograms, startTimestamps = ev.matrixIterSlice(it, mint, maxt, floats, histograms, startTimestamps)
-					// For subquery-derived matrices, SamplesRead was already counted
-					// inside evalSubquery via MergeSamplesReadFromSubquery; skip here
-					// to avoid double-counting the storage I/O.
-					if !matrixFromSubquery {
-						if step == 0 {
-							samplesReadCount = int64(len(floats) + totalHPointSize(histograms))
-						} else {
-							samplesReadCount = countSamplesAfter(floats, histograms, maxt-ev.interval)
-						}
-					}
+				}
+				if len(floats)+len(histograms) == 0 {
+					continue
 				}
 				// fullWindowCount reflects the matrix window consumed at this
 				// step. With an @ modifier the same window is reused across all
@@ -2311,8 +2305,18 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 				// this after the conditional re-fetch handles both cases
 				// uniformly.
 				fullWindowCount := int64(len(floats) + totalHPointSize(histograms))
-				if len(floats)+len(histograms) == 0 {
-					continue
+				// For subquery-derived matrices, SamplesRead was already counted
+				// inside evalSubquery via MergeSamplesReadFromSubquery; skip here
+				// to avoid double-counting the storage I/O. On step 0 the full
+				// window is new; on later steps only points past the previous
+				// step's cutoff are new.
+				var samplesReadCount int64
+				if refetch && !matrixFromSubquery {
+					if step == 0 {
+						samplesReadCount = fullWindowCount
+					} else {
+						samplesReadCount = countSamplesAfter(floats, histograms, maxt-ev.interval)
+					}
 				}
 				inMatrix[0].Floats = floats
 				inMatrix[0].Histograms = histograms
@@ -2323,7 +2327,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 				outVec, annos := call(vectorVals, inMatrix, e.Args, enh)
 				warnings.Merge(annos)
 				ev.samplesStats.IncrementSamplesAtStep(step, fullWindowCount)
-				if !matrixFromSubquery {
+				if samplesReadCount > 0 {
 					ev.samplesStats.IncrementSamplesReadAtStep(step, samplesReadCount)
 				}
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -91,6 +91,7 @@ type engineMetrics struct {
 	queryResultSort           prometheus.Observer
 	queryResultSortHistogram  prometheus.Observer
 	querySamples              prometheus.Counter
+	querySamplesRead          prometheus.Counter
 }
 
 type (
@@ -422,7 +423,13 @@ func NewEngine(opts EngineOpts) *Engine {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "query_samples_total",
-			Help:      "The total number of samples loaded by all queries.",
+			Help:      "The total number of samples loaded by all queries (full window per step for range-vector).",
+		}),
+		querySamplesRead: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "query_samples_read_total",
+			Help:      "The total number of samples read by all queries (only new points per step for range-vector).",
 		}),
 		queryQueueTime:            queryResultSummary.WithLabelValues("queue_time"),
 		queryQueueTimeHistogram:   queryResultHistogram.WithLabelValues("queue_time"),
@@ -458,6 +465,7 @@ func NewEngine(opts EngineOpts) *Engine {
 			metrics.queryLogEnabled,
 			metrics.queryLogFailures,
 			metrics.querySamples,
+			metrics.querySamplesRead,
 			queryResultSummary,
 			queryResultHistogram,
 		)
@@ -680,6 +688,7 @@ func (ng *Engine) exec(ctx context.Context, q *query) (v parser.Value, ws annota
 	defer func() {
 		ng.metrics.currentQueries.Dec()
 		ng.metrics.querySamples.Add(float64(q.sampleStats.TotalSamples))
+		ng.metrics.querySamplesRead.Add(float64(q.sampleStats.SamplesRead))
 	}()
 
 	ctx, cancel := context.WithTimeout(ctx, ng.timeout)
@@ -1859,6 +1868,7 @@ func (ev *evaluator) evalSeries(ctx context.Context, series []storage.Series, of
 			if h == nil {
 				ev.currentSamples++
 				ev.samplesStats.IncrementSamplesAtStep(step, 1)
+				ev.samplesStats.IncrementSamplesReadAtStep(step, 1)
 				if ev.currentSamples > ev.maxSamples {
 					ev.error(ErrTooManySamples(env))
 				}
@@ -1881,6 +1891,7 @@ func (ev *evaluator) evalSeries(ctx context.Context, series []storage.Series, of
 				histSize := point.size()
 				ev.currentSamples += histSize
 				ev.samplesStats.IncrementSamplesAtStep(step, int64(histSize))
+				ev.samplesStats.IncrementSamplesReadAtStep(step, int64(histSize))
 				if ev.currentSamples > ev.maxSamples {
 					ev.error(ErrTooManySamples(env))
 				}
@@ -1902,14 +1913,20 @@ func (ev *evaluator) evalSeries(ctx context.Context, series []storage.Series, of
 
 // evalSubquery evaluates given SubqueryExpr and returns an equivalent
 // evaluated MatrixSelector in its place. Note that the Name and LabelMatchers are not set.
+// Only SamplesRead (and SamplesReadPerStep when per-step stats are enabled) from the
+// subquery are merged into the parent; TotalSamples and TotalSamplesPerStep are left unchanged.
 func (ev *evaluator) evalSubquery(ctx context.Context, subq *parser.SubqueryExpr) (*parser.MatrixSelector, int, annotations.Annotations) {
-	samplesStats := ev.samplesStats
-	// Avoid double counting samples when running a subquery, those samples will be counted in later stage.
-	ev.samplesStats = ev.samplesStats.NewChild()
+	// Store the parent samples stats for later use.
+	parentSamplesStats := ev.samplesStats
+	// Create a child samples stats object to track the subquery samples read.
+	ev.samplesStats = stats.NewChildWithStepTracking(parentSamplesStats.StepTrackingEnabled(), ev.startTimestamp, ev.endTimestamp, ev.interval)
+	// Evaluate the subquery.
 	val, ws := ev.eval(ctx, subq)
-	// But do incorporate the peak from the subquery.
-	samplesStats.UpdatePeakFromSubquery(ev.samplesStats)
-	ev.samplesStats = samplesStats
+	// Update the parent samples stats with the subquery samples stats.
+	parentSamplesStats.UpdatePeakFromSubquery(ev.samplesStats)
+	parentSamplesStats.MergeSamplesReadFromSubquery(ev.samplesStats)
+	// Restore the parent samples stats.
+	ev.samplesStats = parentSamplesStats
 	mat := val.(Matrix)
 	vs := &parser.VectorSelector{
 		OriginalOffset: subq.OriginalOffset,
@@ -2025,9 +2042,10 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 
 		// Check if the function has a matrix argument.
 		var (
-			matrixArgIndex int
-			matrixArg      bool
-			warnings       annotations.Annotations
+			matrixArgIndex     int
+			matrixArg          bool
+			matrixFromSubquery bool
+			warnings           annotations.Annotations
 		)
 		for i := range e.Args {
 			a := e.Args[i]
@@ -2040,6 +2058,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 			if subq, ok := a.(*parser.SubqueryExpr); ok {
 				matrixArgIndex = i
 				matrixArg = true
+				matrixFromSubquery = true
 				// Replacing parser.SubqueryExpr with parser.MatrixSelector.
 				val, totalSamples, ws := ev.evalSubquery(ctx, subq)
 				e.Args[i] = val
@@ -2207,6 +2226,9 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 						counter++
 					}
 				}
+				// Full window count for TotalSamples (unchanged semantics); delta for SamplesRead.
+				// When we reuse data (@ modifier), we don't increment either.
+				var fullWindowCount, samplesReadCount int64
 				// Evaluate the matrix selector for this series
 				// for this step, but only if this is the 1st
 				// iteration or no @ modifier has been used.
@@ -2221,6 +2243,17 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 						maxt += durationMilliseconds(ev.lookbackDelta)
 					}
 					floats, histograms, startTimestamps = ev.matrixIterSlice(it, mint, maxt, floats, histograms, startTimestamps)
+					fullWindowCount = int64(len(floats) + totalHPointSize(histograms))
+					// For subquery-derived matrices, SamplesRead was already counted
+					// inside evalSubquery via MergeSamplesReadFromSubquery; skip here
+					// to avoid double-counting the storage I/O.
+					if !matrixFromSubquery {
+						if step == 0 {
+							samplesReadCount = fullWindowCount
+						} else {
+							samplesReadCount = countSamplesAfter(floats, histograms, maxt-ev.interval)
+						}
+					}
 				}
 				if len(floats)+len(histograms) == 0 {
 					continue
@@ -2233,7 +2266,10 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 				// Make the function call.
 				outVec, annos := call(vectorVals, inMatrix, e.Args, enh)
 				warnings.Merge(annos)
-				ev.samplesStats.IncrementSamplesAtStep(step, int64(len(floats)+totalHPointSize(histograms)))
+				ev.samplesStats.IncrementSamplesAtStep(step, fullWindowCount)
+				if !matrixFromSubquery {
+					ev.samplesStats.IncrementSamplesReadAtStep(step, samplesReadCount)
+				}
 
 				enh.Out = outVec[:0]
 				if len(outVec) > 0 {
@@ -2435,13 +2471,29 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 	case *parser.SubqueryExpr:
 		offsetMillis := durationMilliseconds(e.Offset)
 		rangeMillis := durationMilliseconds(e.Range)
+		subqEnd := ev.endTimestamp - offsetMillis
+		var subqInterval, subqStart int64
+		if e.Step != 0 {
+			subqInterval = durationMilliseconds(e.Step)
+		} else {
+			subqInterval = ev.noStepSubqueryIntervalFn(rangeMillis)
+		}
+		subqStart = subqInterval * ((ev.startTimestamp - offsetMillis - rangeMillis) / subqInterval)
+		if subqStart <= (ev.startTimestamp - offsetMillis - rangeMillis) {
+			subqStart += subqInterval
+		}
+
+		subqSamplesStats := stats.NewChildWithStepTracking(ev.samplesStats.StepTrackingEnabled(), subqStart, subqEnd, subqInterval)
+
 		newEv := &evaluator{
-			endTimestamp:             ev.endTimestamp - offsetMillis,
+			startTimestamp:           subqStart,
+			endTimestamp:             subqEnd,
+			interval:                 subqInterval,
 			currentSamples:           ev.currentSamples,
 			maxSamples:               ev.maxSamples,
 			logger:                   ev.logger,
 			lookbackDelta:            ev.lookbackDelta,
-			samplesStats:             ev.samplesStats.NewChild(),
+			samplesStats:             subqSamplesStats,
 			noStepSubqueryIntervalFn: ev.noStepSubqueryIntervalFn,
 			enableDelayedNameRemoval: ev.enableDelayedNameRemoval,
 			enableTypeAndUnitLabels:  ev.enableTypeAndUnitLabels,
@@ -2449,30 +2501,40 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 			querier:                  ev.querier,
 		}
 
-		if e.Step != 0 {
-			newEv.interval = durationMilliseconds(e.Step)
-		} else {
-			newEv.interval = ev.noStepSubqueryIntervalFn(rangeMillis)
-		}
-
-		// Start with the first timestamp after (ev.startTimestamp - offset - range)
-		// that is aligned with the step (multiple of 'newEv.interval').
-		newEv.startTimestamp = newEv.interval * ((ev.startTimestamp - offsetMillis - rangeMillis) / newEv.interval)
-		if newEv.startTimestamp <= (ev.startTimestamp - offsetMillis - rangeMillis) {
-			newEv.startTimestamp += newEv.interval
-		}
-
-		if newEv.startTimestamp != ev.startTimestamp {
+		if subqStart != ev.startTimestamp {
 			// Adjust the offset of selectors based on the new
 			// start time of the evaluator since the calculation
 			// of the offset with @ happens w.r.t. the start time.
-			setOffsetForAtModifier(newEv.startTimestamp, e.Expr)
+			setOffsetForAtModifier(subqStart, e.Expr)
 		}
 
 		res, ws := newEv.eval(ctx, e.Expr)
 		ev.currentSamples = newEv.currentSamples
 		ev.samplesStats.UpdatePeakFromSubquery(newEv.samplesStats)
 		ev.samplesStats.IncrementSamplesAtTimestamp(ev.endTimestamp, newEv.samplesStats.TotalSamples)
+		// Merge SamplesRead with incremental attribution; subquery steps before/after outer window → step 0 / last step.
+		if ev.samplesStats.SamplesReadPerStep != nil && newEv.samplesStats.SamplesReadPerStep != nil {
+			ev.samplesStats.SamplesRead += newEv.samplesStats.SamplesRead
+			numOuterSteps := len(ev.samplesStats.SamplesReadPerStep)
+			for k := 0; k < len(newEv.samplesStats.SamplesReadPerStep); k++ {
+				tk := newEv.startTimestamp + int64(k)*newEv.interval
+				n := newEv.samplesStats.SamplesReadPerStep[k]
+				if n == 0 {
+					continue
+				}
+				outerStep := 0
+				if tk > ev.startTimestamp {
+					outerStep = int((tk - ev.startTimestamp + ev.samplesStats.Interval - 1) / ev.samplesStats.Interval)
+				}
+				// After last outer step; attribute to last step so all disk reads are counted.
+				if outerStep >= numOuterSteps {
+					outerStep = numOuterSteps - 1
+				}
+				ev.samplesStats.SamplesReadPerStep[outerStep] += n
+			}
+		} else {
+			ev.samplesStats.IncrementSamplesReadAtTimestamp(ev.endTimestamp, newEv.samplesStats.SamplesRead)
+		}
 		return res, ws
 	case *parser.StepInvariantExpr:
 		newEv := &evaluator{
@@ -2497,6 +2559,8 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 			step++
 			ev.samplesStats.IncrementSamplesAtStep(step, newEv.samplesStats.TotalSamples)
 		}
+		// Subquery ran once; add SamplesRead once at step 0 (not per outer step).
+		ev.samplesStats.IncrementSamplesReadAtStep(0, newEv.samplesStats.SamplesRead)
 		switch e.Expr.(type) {
 		case *parser.MatrixSelector, *parser.SubqueryExpr:
 			// We do not duplicate results for range selectors since result is a matrix
@@ -2602,6 +2666,7 @@ func (ev *evaluator) rangeEvalTimestampFunctionOverVectorSelector(ctx context.Co
 
 			ev.currentSamples++
 			ev.samplesStats.IncrementSamplesAtTimestamp(enh.Ts, 1)
+			ev.samplesStats.IncrementSamplesReadAtTimestamp(enh.Ts, 1)
 			if ev.currentSamples > ev.maxSamples {
 				ev.error(ErrTooManySamples(env))
 			}
@@ -2770,6 +2835,7 @@ func (ev *evaluator) matrixSelector(ctx context.Context, node *parser.MatrixSele
 		}
 		totalSize := int64(len(ss.Floats)) + int64(totalHPointSize(ss.Histograms))
 		ev.samplesStats.IncrementSamplesAtTimestamp(ev.startTimestamp, totalSize)
+		ev.samplesStats.IncrementSamplesReadAtTimestamp(ev.startTimestamp, totalSize)
 
 		if totalSize > 0 {
 			matrix = append(matrix, ss)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1924,7 +1924,7 @@ func (ev *evaluator) evalSubquery(ctx context.Context, subq *parser.SubqueryExpr
 	val, ws := ev.eval(ctx, subq)
 	// Update the parent samples stats with the subquery samples stats.
 	parentSamplesStats.UpdatePeakFromSubquery(ev.samplesStats)
-	parentSamplesStats.MergeSamplesReadFromSubquery(ev.samplesStats)
+	parentSamplesStats.MergeSamplesReadFromSubquery(ev.samplesStats, 0)
 	// Restore the parent samples stats.
 	ev.samplesStats = parentSamplesStats
 	mat := val.(Matrix)
@@ -2226,8 +2226,6 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 						counter++
 					}
 				}
-				// Full window count for TotalSamples (unchanged semantics); delta for SamplesRead.
-				// When we reuse data (@ modifier), we don't increment either.
 				var fullWindowCount, samplesReadCount int64
 				// Evaluate the matrix selector for this series
 				// for this step, but only if this is the 1st
@@ -2483,7 +2481,10 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 			subqStart += subqInterval
 		}
 
-		subqSamplesStats := stats.NewChildWithStepTracking(ev.samplesStats.StepTrackingEnabled(), subqStart, subqEnd, subqInterval)
+		// Always enable per-step tracking on the subquery child so that
+		// MergeSamplesReadFromSubquery can apply range-windowed attribution
+		// regardless of whether the parent tracks per-step stats.
+		subqSamplesStats := stats.NewChildWithStepTracking(true, subqStart, subqEnd, subqInterval)
 
 		newEv := &evaluator{
 			startTimestamp:           subqStart,
@@ -2512,12 +2513,18 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		ev.currentSamples = newEv.currentSamples
 		ev.samplesStats.UpdatePeakFromSubquery(newEv.samplesStats)
 		ev.samplesStats.IncrementSamplesAtTimestamp(ev.endTimestamp, newEv.samplesStats.TotalSamples)
-		// Merge SamplesRead with incremental attribution; subquery steps before/after outer window → step 0 / last step.
-		if ev.samplesStats.SamplesReadPerStep != nil && newEv.samplesStats.SamplesReadPerStep != nil {
-			ev.samplesStats.MergeSamplesReadFromSubquery(newEv.samplesStats)
-		} else {
-			ev.samplesStats.IncrementSamplesReadAtTimestamp(ev.endTimestamp, newEv.samplesStats.SamplesRead)
+		// Merge SamplesRead from the subquery into the parent. When neither
+		// offset nor @ modifier is used, apply range-windowed attribution so
+		// that only subquery steps inside each parent step's
+		// [parentTs-range, parentTs] window are counted, consistent with
+		// range vector selectors. With offset or @ modifier the subquery's
+		// time frame is shifted relative to the parent, so we attribute all
+		// steps without windowing.
+		effectiveRange := rangeMillis
+		if offsetMillis != 0 || e.Timestamp != nil {
+			effectiveRange = 0
 		}
+		ev.samplesStats.MergeSamplesReadFromSubquery(newEv.samplesStats, effectiveRange)
 		return res, ws
 	case *parser.StepInvariantExpr:
 		newEv := &evaluator{

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1911,6 +1911,15 @@ func (ev *evaluator) evalSeries(ctx context.Context, series []storage.Series, of
 	return mat
 }
 
+// numSteps returns the number of steps in the evaluator's range,
+// treating an instant query (interval == 0) as a single step.
+func (ev *evaluator) numSteps() int {
+	if ev.interval <= 0 {
+		return 1
+	}
+	return int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
+}
+
 // runSubquery evaluates the given SubqueryExpr in a fresh child evaluator
 // aligned to the subquery's own step grid and returns the result along with
 // the child's samples stats. The caller decides how to merge the child stats
@@ -1942,7 +1951,12 @@ func (ev *evaluator) runSubquery(ctx context.Context, e *parser.SubqueryExpr) (p
 		subqStart += subqInterval
 	}
 
-	childStats := stats.NewChildWithStepTracking(ev.samplesStats.StepTrackingEnabled(), subqStart, subqEnd, subqInterval)
+	// Subquery children always track per-step samples-read (independent of
+	// the parent's per-step setting) so MergeSamplesReadFromSubquery can
+	// attribute each subquery iteration to a parent step and drop iterations
+	// that fall in gaps between parent windows. The arrays don't escape this
+	// call.
+	childStats := stats.NewChildWithStepTracking(subqStart, subqEnd, subqInterval)
 	newEv := &evaluator{
 		startTimestamp:           subqStart,
 		endTimestamp:             subqEnd,
@@ -1976,10 +1990,16 @@ func (ev *evaluator) runSubquery(ctx context.Context, e *parser.SubqueryExpr) (p
 // Only PeakSamples and SamplesRead from the subquery are merged into the
 // parent; TotalSamples is intentionally not merged because the call/range-vector
 // caller will count samples again from the materialized matrix.
-func (ev *evaluator) evalSubquery(ctx context.Context, subq *parser.SubqueryExpr) (*parser.MatrixSelector, int, annotations.Annotations) {
+//
+// outerOffset is durationMilliseconds(subq.OriginalOffset) so the merge can
+// shift child timestamps to match the parent step that consumes them.
+// outerRange is the outer call's selRange so the merge can drop subquery
+// iterations whose timestamps fall in gaps between consecutive outer-step
+// windows (i.e. when the outer step is wider than the subquery range).
+func (ev *evaluator) evalSubquery(ctx context.Context, subq *parser.SubqueryExpr, outerOffset, outerRange int64) (*parser.MatrixSelector, int, annotations.Annotations) {
 	val, childStats, ws := ev.runSubquery(ctx, subq)
 	ev.samplesStats.UpdatePeakFromSubquery(childStats)
-	ev.samplesStats.MergeSamplesReadFromSubquery(childStats)
+	ev.samplesStats.MergeSamplesReadFromSubquery(childStats, ev.startTimestamp, ev.interval, ev.numSteps(), outerOffset, outerRange)
 	mat := val.(Matrix)
 	vs := &parser.VectorSelector{
 		OriginalOffset: subq.OriginalOffset,
@@ -2113,7 +2133,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 				matrixArg = true
 				matrixFromSubquery = true
 				// Replacing parser.SubqueryExpr with parser.MatrixSelector.
-				val, totalSamples, ws := ev.evalSubquery(ctx, subq)
+				val, totalSamples, ws := ev.evalSubquery(ctx, subq, durationMilliseconds(subq.OriginalOffset), durationMilliseconds(subq.Range))
 				e.Args[i] = val
 				warnings.Merge(ws)
 				defer func() {
@@ -2534,7 +2554,9 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		// Attribute the subquery's TotalSamples to the parent's end step
 		// so they appear in the parent's TotalSamples stat.
 		ev.samplesStats.IncrementSamplesAtTimestamp(ev.endTimestamp, childStats.TotalSamples)
-		ev.samplesStats.MergeSamplesReadFromSubquery(childStats)
+		// outerOffset=0, outerRange=0: every subquery iteration becomes part of
+		// the parent's matrix output, so no shifting or gap filtering is needed.
+		ev.samplesStats.MergeSamplesReadFromSubquery(childStats, ev.startTimestamp, ev.interval, ev.numSteps(), 0, 0)
 		return res, ws
 	case *parser.StepInvariantExpr:
 		newEv := &evaluator{

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2514,24 +2514,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		ev.samplesStats.IncrementSamplesAtTimestamp(ev.endTimestamp, newEv.samplesStats.TotalSamples)
 		// Merge SamplesRead with incremental attribution; subquery steps before/after outer window → step 0 / last step.
 		if ev.samplesStats.SamplesReadPerStep != nil && newEv.samplesStats.SamplesReadPerStep != nil {
-			ev.samplesStats.SamplesRead += newEv.samplesStats.SamplesRead
-			numOuterSteps := len(ev.samplesStats.SamplesReadPerStep)
-			for k := 0; k < len(newEv.samplesStats.SamplesReadPerStep); k++ {
-				tk := newEv.startTimestamp + int64(k)*newEv.interval
-				n := newEv.samplesStats.SamplesReadPerStep[k]
-				if n == 0 {
-					continue
-				}
-				outerStep := 0
-				if tk > ev.startTimestamp {
-					outerStep = int((tk - ev.startTimestamp + ev.samplesStats.Interval - 1) / ev.samplesStats.Interval)
-				}
-				// After last outer step; attribute to last step so all disk reads are counted.
-				if outerStep >= numOuterSteps {
-					outerStep = numOuterSteps - 1
-				}
-				ev.samplesStats.SamplesReadPerStep[outerStep] += n
-			}
+			ev.samplesStats.MergeSamplesReadFromSubquery(newEv.samplesStats)
 		} else {
 			ev.samplesStats.IncrementSamplesReadAtTimestamp(ev.endTimestamp, newEv.samplesStats.SamplesRead)
 		}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2226,7 +2226,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 						counter++
 					}
 				}
-				var fullWindowCount, samplesReadCount int64
+				var samplesReadCount int64
 				// Evaluate the matrix selector for this series
 				// for this step, but only if this is the 1st
 				// iteration or no @ modifier has been used.
@@ -2241,18 +2241,23 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 						maxt += durationMilliseconds(ev.lookbackDelta)
 					}
 					floats, histograms, startTimestamps = ev.matrixIterSlice(it, mint, maxt, floats, histograms, startTimestamps)
-					fullWindowCount = int64(len(floats) + totalHPointSize(histograms))
 					// For subquery-derived matrices, SamplesRead was already counted
 					// inside evalSubquery via MergeSamplesReadFromSubquery; skip here
 					// to avoid double-counting the storage I/O.
 					if !matrixFromSubquery {
 						if step == 0 {
-							samplesReadCount = fullWindowCount
+							samplesReadCount = int64(len(floats) + totalHPointSize(histograms))
 						} else {
 							samplesReadCount = countSamplesAfter(floats, histograms, maxt-ev.interval)
 						}
 					}
 				}
+				// fullWindowCount reflects the matrix window consumed at this
+				// step. With an @ modifier the same window is reused across all
+				// steps, so floats/histograms persist from step 0; computing
+				// this after the conditional re-fetch handles both cases
+				// uniformly.
+				fullWindowCount := int64(len(floats) + totalHPointSize(histograms))
 				if len(floats)+len(histograms) == 0 {
 					continue
 				}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1911,22 +1911,75 @@ func (ev *evaluator) evalSeries(ctx context.Context, series []storage.Series, of
 	return mat
 }
 
+// runSubquery evaluates the given SubqueryExpr in a fresh child evaluator
+// aligned to the subquery's own step grid and returns the result along with
+// the child's samples stats. The caller decides how to merge the child stats
+// into the parent: peak and samples-read are always safe to absorb, while
+// TotalSamples should only be absorbed when the caller does not later
+// re-count the materialized matrix (e.g. evalSubquery does not absorb it).
+func (ev *evaluator) runSubquery(ctx context.Context, e *parser.SubqueryExpr) (parser.Value, *stats.QuerySamples, annotations.Annotations) {
+	offsetMillis := durationMilliseconds(e.Offset)
+	rangeMillis := durationMilliseconds(e.Range)
+
+	// Align the parent end timestamp down to the parent's step grid before
+	// applying the subquery offset, so the subquery does not evaluate past
+	// the parent's last actual evaluation point when the caller supplied
+	// an end timestamp that is not step-aligned.
+	parentEnd := ev.endTimestamp
+	if ev.interval > 0 {
+		parentEnd = ev.startTimestamp + ((ev.endTimestamp-ev.startTimestamp)/ev.interval)*ev.interval
+	}
+	subqEnd := parentEnd - offsetMillis
+
+	var subqInterval int64
+	if e.Step != 0 {
+		subqInterval = durationMilliseconds(e.Step)
+	} else {
+		subqInterval = ev.noStepSubqueryIntervalFn(rangeMillis)
+	}
+	subqStart := subqInterval * ((ev.startTimestamp - offsetMillis - rangeMillis) / subqInterval)
+	if subqStart <= (ev.startTimestamp - offsetMillis - rangeMillis) {
+		subqStart += subqInterval
+	}
+
+	childStats := stats.NewChildWithStepTracking(ev.samplesStats.StepTrackingEnabled(), subqStart, subqEnd, subqInterval)
+	newEv := &evaluator{
+		startTimestamp:           subqStart,
+		endTimestamp:             subqEnd,
+		interval:                 subqInterval,
+		currentSamples:           ev.currentSamples,
+		maxSamples:               ev.maxSamples,
+		logger:                   ev.logger,
+		lookbackDelta:            ev.lookbackDelta,
+		samplesStats:             childStats,
+		noStepSubqueryIntervalFn: ev.noStepSubqueryIntervalFn,
+		enableDelayedNameRemoval: ev.enableDelayedNameRemoval,
+		enableTypeAndUnitLabels:  ev.enableTypeAndUnitLabels,
+		useStartTimestamps:       ev.useStartTimestamps,
+		querier:                  ev.querier,
+	}
+
+	if subqStart != ev.startTimestamp {
+		// Adjust the offset of selectors based on the new start time of
+		// the evaluator since the calculation of the offset with @ happens
+		// w.r.t. the start time.
+		setOffsetForAtModifier(subqStart, e.Expr)
+	}
+
+	res, ws := newEv.eval(ctx, e.Expr)
+	ev.currentSamples = newEv.currentSamples
+	return res, childStats, ws
+}
+
 // evalSubquery evaluates given SubqueryExpr and returns an equivalent
 // evaluated MatrixSelector in its place. Note that the Name and LabelMatchers are not set.
-// Only SamplesRead (and SamplesReadPerStep when per-step stats are enabled) from the
-// subquery are merged into the parent; TotalSamples and TotalSamplesPerStep are left unchanged.
+// Only PeakSamples and SamplesRead from the subquery are merged into the
+// parent; TotalSamples is intentionally not merged because the call/range-vector
+// caller will count samples again from the materialized matrix.
 func (ev *evaluator) evalSubquery(ctx context.Context, subq *parser.SubqueryExpr) (*parser.MatrixSelector, int, annotations.Annotations) {
-	// Store the parent samples stats for later use.
-	parentSamplesStats := ev.samplesStats
-	// Create a child samples stats object to track the subquery samples read.
-	ev.samplesStats = stats.NewChildWithStepTracking(parentSamplesStats.StepTrackingEnabled(), ev.startTimestamp, ev.endTimestamp, ev.interval)
-	// Evaluate the subquery.
-	val, ws := ev.eval(ctx, subq)
-	// Update the parent samples stats with the subquery samples stats.
-	parentSamplesStats.UpdatePeakFromSubquery(ev.samplesStats)
-	parentSamplesStats.MergeSamplesReadFromSubquery(ev.samplesStats)
-	// Restore the parent samples stats.
-	ev.samplesStats = parentSamplesStats
+	val, childStats, ws := ev.runSubquery(ctx, subq)
+	ev.samplesStats.UpdatePeakFromSubquery(childStats)
+	ev.samplesStats.MergeSamplesReadFromSubquery(childStats)
 	mat := val.(Matrix)
 	vs := &parser.VectorSelector{
 		OriginalOffset: subq.OriginalOffset,
@@ -2472,57 +2525,12 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		return ev.matrixSelector(ctx, e)
 
 	case *parser.SubqueryExpr:
-		offsetMillis := durationMilliseconds(e.Offset)
-		rangeMillis := durationMilliseconds(e.Range)
-		// Use the last actual parent evaluation timestamp rather than the
-		// raw endTimestamp so the subquery does not evaluate past the
-		// parent's range when endTimestamp is not step-aligned.
-		parentEnd := ev.endTimestamp
-		if ev.interval > 0 {
-			parentEnd = ev.startTimestamp + ((ev.endTimestamp-ev.startTimestamp)/ev.interval)*ev.interval
-		}
-		subqEnd := parentEnd - offsetMillis
-		var subqInterval, subqStart int64
-		if e.Step != 0 {
-			subqInterval = durationMilliseconds(e.Step)
-		} else {
-			subqInterval = ev.noStepSubqueryIntervalFn(rangeMillis)
-		}
-		subqStart = subqInterval * ((ev.startTimestamp - offsetMillis - rangeMillis) / subqInterval)
-		if subqStart <= (ev.startTimestamp - offsetMillis - rangeMillis) {
-			subqStart += subqInterval
-		}
-
-		subqSamplesStats := stats.NewChildWithStepTracking(ev.samplesStats.StepTrackingEnabled(), subqStart, subqEnd, subqInterval)
-
-		newEv := &evaluator{
-			startTimestamp:           subqStart,
-			endTimestamp:             subqEnd,
-			interval:                 subqInterval,
-			currentSamples:           ev.currentSamples,
-			maxSamples:               ev.maxSamples,
-			logger:                   ev.logger,
-			lookbackDelta:            ev.lookbackDelta,
-			samplesStats:             subqSamplesStats,
-			noStepSubqueryIntervalFn: ev.noStepSubqueryIntervalFn,
-			enableDelayedNameRemoval: ev.enableDelayedNameRemoval,
-			enableTypeAndUnitLabels:  ev.enableTypeAndUnitLabels,
-			useStartTimestamps:       ev.useStartTimestamps,
-			querier:                  ev.querier,
-		}
-
-		if subqStart != ev.startTimestamp {
-			// Adjust the offset of selectors based on the new
-			// start time of the evaluator since the calculation
-			// of the offset with @ happens w.r.t. the start time.
-			setOffsetForAtModifier(subqStart, e.Expr)
-		}
-
-		res, ws := newEv.eval(ctx, e.Expr)
-		ev.currentSamples = newEv.currentSamples
-		ev.samplesStats.UpdatePeakFromSubquery(newEv.samplesStats)
-		ev.samplesStats.IncrementSamplesAtTimestamp(ev.endTimestamp, newEv.samplesStats.TotalSamples)
-		ev.samplesStats.MergeSamplesReadFromSubquery(newEv.samplesStats)
+		res, childStats, ws := ev.runSubquery(ctx, e)
+		ev.samplesStats.UpdatePeakFromSubquery(childStats)
+		// Attribute the subquery's TotalSamples to the parent's end step
+		// so they appear in the parent's TotalSamples stat.
+		ev.samplesStats.IncrementSamplesAtTimestamp(ev.endTimestamp, childStats.TotalSamples)
+		ev.samplesStats.MergeSamplesReadFromSubquery(childStats)
 		return res, ws
 	case *parser.StepInvariantExpr:
 		newEv := &evaluator{

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1924,7 +1924,7 @@ func (ev *evaluator) evalSubquery(ctx context.Context, subq *parser.SubqueryExpr
 	val, ws := ev.eval(ctx, subq)
 	// Update the parent samples stats with the subquery samples stats.
 	parentSamplesStats.UpdatePeakFromSubquery(ev.samplesStats)
-	parentSamplesStats.MergeSamplesReadFromSubquery(ev.samplesStats, 0)
+	parentSamplesStats.MergeSamplesReadFromSubquery(ev.samplesStats)
 	// Restore the parent samples stats.
 	ev.samplesStats = parentSamplesStats
 	mat := val.(Matrix)
@@ -2469,7 +2469,14 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 	case *parser.SubqueryExpr:
 		offsetMillis := durationMilliseconds(e.Offset)
 		rangeMillis := durationMilliseconds(e.Range)
-		subqEnd := ev.endTimestamp - offsetMillis
+		// Use the last actual parent evaluation timestamp rather than the
+		// raw endTimestamp so the subquery does not evaluate past the
+		// parent's range when endTimestamp is not step-aligned.
+		parentEnd := ev.endTimestamp
+		if ev.interval > 0 {
+			parentEnd = ev.startTimestamp + ((ev.endTimestamp-ev.startTimestamp)/ev.interval)*ev.interval
+		}
+		subqEnd := parentEnd - offsetMillis
 		var subqInterval, subqStart int64
 		if e.Step != 0 {
 			subqInterval = durationMilliseconds(e.Step)
@@ -2481,10 +2488,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 			subqStart += subqInterval
 		}
 
-		// Always enable per-step tracking on the subquery child so that
-		// MergeSamplesReadFromSubquery can apply range-windowed attribution
-		// regardless of whether the parent tracks per-step stats.
-		subqSamplesStats := stats.NewChildWithStepTracking(true, subqStart, subqEnd, subqInterval)
+		subqSamplesStats := stats.NewChildWithStepTracking(ev.samplesStats.StepTrackingEnabled(), subqStart, subqEnd, subqInterval)
 
 		newEv := &evaluator{
 			startTimestamp:           subqStart,
@@ -2513,18 +2517,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		ev.currentSamples = newEv.currentSamples
 		ev.samplesStats.UpdatePeakFromSubquery(newEv.samplesStats)
 		ev.samplesStats.IncrementSamplesAtTimestamp(ev.endTimestamp, newEv.samplesStats.TotalSamples)
-		// Merge SamplesRead from the subquery into the parent. When neither
-		// offset nor @ modifier is used, apply range-windowed attribution so
-		// that only subquery steps inside each parent step's
-		// [parentTs-range, parentTs] window are counted, consistent with
-		// range vector selectors. With offset or @ modifier the subquery's
-		// time frame is shifted relative to the parent, so we attribute all
-		// steps without windowing.
-		effectiveRange := rangeMillis
-		if offsetMillis != 0 || e.Timestamp != nil {
-			effectiveRange = 0
-		}
-		ev.samplesStats.MergeSamplesReadFromSubquery(newEv.samplesStats, effectiveRange)
+		ev.samplesStats.MergeSamplesReadFromSubquery(newEv.samplesStats)
 		return res, ws
 	case *parser.StepInvariantExpr:
 		newEv := &evaluator{

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1416,7 +1416,7 @@ load 10s
 			Start:        time.Unix(201, 0),
 			End:          time.Unix(220, 0),
 			Interval:     5 * time.Second,
-			PeakSamples:  72,
+			PeakSamples:  69,
 			TotalSamples: 144, // 3 sample per query * 12 queries (60/5) * 4 steps
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 36,
@@ -1437,7 +1437,7 @@ load 10s
 			Start:        time.Unix(201, 0),
 			End:          time.Unix(220, 0),
 			Interval:     5 * time.Second,
-			PeakSamples:  32,
+			PeakSamples:  31,
 			TotalSamples: 48, // 1 sample per query * 12 queries (60/5) * 4 steps
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
@@ -1458,7 +1458,7 @@ load 10s
 			Start:        time.Unix(201, 0),
 			End:          time.Unix(220, 0),
 			Interval:     5 * time.Second,
-			PeakSamples:  32,
+			PeakSamples:  31,
 			TotalSamples: 48, // 1 sample per query * 12 queries (60/5) * 4 steps
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
@@ -1479,7 +1479,7 @@ load 10s
 			Start:        time.Unix(201, 0),
 			End:          time.Unix(220, 0),
 			Interval:     5 * time.Second,
-			PeakSamples:  76,
+			PeakSamples:  73,
 			TotalSamples: 288, // 2 * (3 sample per query * 12 queries (60/5) * 4 steps)
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 72,
@@ -1500,7 +1500,7 @@ load 10s
 			Start:        time.Unix(201, 0),
 			End:          time.Unix(220, 0),
 			Interval:     5 * time.Second,
-			PeakSamples:  72,
+			PeakSamples:  69,
 			TotalSamples: 192, // (1 sample per query * 12 queries (60/5) + 3 sample per query * 12 queries (60/5)) * 4 steps
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 48,
@@ -1653,7 +1653,7 @@ load 10s
 			Start:        time.Unix(200, 0),
 			End:          time.Unix(400, 0),
 			Interval:     30 * time.Second,
-			PeakSamples:  105,
+			PeakSamples:  99,
 			TotalSamples: 126,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				200000: 18,
@@ -1676,7 +1676,7 @@ load 10s
 			},
 		},
 
-		// Subquery with @ modifier: effectiveRange = 0, windowing disabled.
+		// Subquery with @ modifier.
 		{
 			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[20s:10s] @ 200)",
 			Start:        time.Unix(250, 0),

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1612,6 +1612,25 @@ load 10s
 			},
 		},
 
+		// Range query + subquery, outer step wider than subquery range.
+		{
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[30s:10s])",
+			Start:        time.Unix(201, 0),
+			End:          time.Unix(261, 0),
+			Interval:     1 * time.Minute,
+			PeakSamples:  14,
+			TotalSamples: 6,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 3,
+				261000: 3,
+			},
+			SamplesRead: 9,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 3,
+				261000: 6,
+			},
+		},
+
 		// Histogram subquery: histogram size counting in subquery path.
 		{
 			Query:        "histogram_count(max_over_time(metricWith1HistogramEvery10Seconds[20s:10s]))",

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -48,7 +48,6 @@ import (
 const (
 	env                  = "query execution"
 	defaultLookbackDelta = 5 * time.Minute
-	defaultEpsilon       = 0.000001 // Relative error allowed for sample values.
 )
 
 func TestMain(m *testing.M) {
@@ -788,6 +787,8 @@ load 10s
 		SkipMaxCheck        bool
 		TotalSamples        int64
 		TotalSamplesPerStep stats.TotalSamplesPerStep
+		SamplesRead         int64                     // samples read (delta for range-vector)
+		SamplesReadPerStep  stats.TotalSamplesPerStep // per-step samples read
 		PeakSamples         int
 		Start               time.Time
 		End                 time.Time
@@ -801,6 +802,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				21000: 0,
 			},
+			SamplesRead: 0,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				21000: 0,
+			},
 		},
 		{
 			Query:        "1",
@@ -808,6 +813,10 @@ load 10s
 			TotalSamples: 0,
 			PeakSamples:  1,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				21000: 0,
+			},
+			SamplesRead: 0,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				21000: 0,
 			},
 		},
@@ -819,6 +828,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				21000: 1,
 			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				21000: 1,
+			},
 		},
 		{
 			Query:        "metricWith1HistogramEvery10Seconds",
@@ -826,6 +839,10 @@ load 10s
 			PeakSamples:  13,
 			TotalSamples: 13, // 1 histogram HPoint of size 13 / 10 seconds
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				21000: 13,
+			},
+			SamplesRead: 13,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				21000: 13,
 			},
 		},
@@ -838,6 +855,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				21000: 1,
 			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				21000: 1,
+			},
 		},
 		{
 			Query:        "timestamp(metricWith1HistogramEvery10Seconds)",
@@ -845,6 +866,10 @@ load 10s
 			PeakSamples:  2,
 			TotalSamples: 1, // 1 float sample (because of timestamp) / 10 seconds
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				21000: 1,
+			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				21000: 1,
 			},
 		},
@@ -856,6 +881,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				22000: 1, // Aligned to the step time, not the sample time.
 			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				22000: 1,
+			},
 		},
 		{
 			Query:        "metricWith1SampleEvery10Seconds offset 10s",
@@ -863,6 +892,10 @@ load 10s
 			PeakSamples:  1,
 			TotalSamples: 1, // 1 sample / 10 seconds
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				21000: 1,
+			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				21000: 1,
 			},
 		},
@@ -874,6 +907,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				21000: 1,
 			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				21000: 1,
+			},
 		},
 		{
 			Query:        `metricWith3SampleEvery10Seconds{a="1"}`,
@@ -881,6 +918,10 @@ load 10s
 			PeakSamples:  1,
 			TotalSamples: 1, // 1 sample / 10 seconds
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				21000: 1,
+			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				21000: 1,
 			},
 		},
@@ -892,6 +933,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				21000: 1,
 			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				21000: 1,
+			},
 		},
 		{
 			Query:        `metricWith3SampleEvery10Seconds{a="1"}[20s] @ 19`,
@@ -899,6 +944,10 @@ load 10s
 			PeakSamples:  2,
 			TotalSamples: 2, // (1 sample / 10 seconds) * 20s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				21000: 2,
+			},
+			SamplesRead: 2,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				21000: 2,
 			},
 		},
@@ -910,6 +959,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				21000: 3,
 			},
+			SamplesRead: 3,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				21000: 3,
+			},
 		},
 		{
 			Query:        "metricWith1SampleEvery10Seconds[60s]",
@@ -917,6 +970,10 @@ load 10s
 			PeakSamples:  6,
 			TotalSamples: 6, // 1 sample / 10 seconds * 60 seconds
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 6,
 			},
 		},
@@ -928,6 +985,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 78,
 			},
+			SamplesRead: 78,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 78,
+			},
 		},
 		{
 			Query:        "max_over_time(metricWith1SampleEvery10Seconds[60s])[20s:5s]",
@@ -936,6 +997,10 @@ load 10s
 			TotalSamples: 24, // (1 sample / 10 seconds * 60 seconds) * 4
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 24,
+			},
+			SamplesRead: 8, // delta: 6 at step 0 + 2 new over 3 steps
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 8,
 			},
 		},
 		{
@@ -947,6 +1012,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 26,
 			},
+			SamplesRead: 8,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 8,
+			},
 		},
 		{
 			Query:        "max_over_time(metricWith1HistogramEvery10Seconds[60s])[20s:5s]",
@@ -956,6 +1025,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 312,
 			},
+			SamplesRead: 104,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 104,
+			},
 		},
 		{
 			Query:        "metricWith1SampleEvery10Seconds[60s] @ 30",
@@ -963,6 +1036,10 @@ load 10s
 			PeakSamples:  4,
 			TotalSamples: 4, // @ modifier force the evaluation to at 30 seconds - So it brings 4 datapoints (0, 10, 20, 30 seconds) * 1 series
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 4,
+			},
+			SamplesRead: 4,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 4,
 			},
 		},
@@ -974,6 +1051,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 52,
 			},
+			SamplesRead: 52,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 52,
+			},
 		},
 		{
 			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[60s] @ 30))",
@@ -981,6 +1062,10 @@ load 10s
 			PeakSamples:  7,
 			TotalSamples: 12, // @ modifier force the evaluation to at 30 seconds - So it brings 4 datapoints (0, 10, 20, 30 seconds) * 3 series
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 12,
+			},
+			SamplesRead: 12,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
 			},
 		},
@@ -992,6 +1077,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
 			},
+			SamplesRead: 12,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 12,
+			},
 		},
 		{
 			Query:        "metricWith1SampleEvery10Seconds[60s] offset 10s",
@@ -999,6 +1088,10 @@ load 10s
 			PeakSamples:  6,
 			TotalSamples: 6, // 1 sample / 10 seconds * 60 seconds
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 6,
 			},
 		},
@@ -1010,6 +1103,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 18,
 			},
+			SamplesRead: 18,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 18,
+			},
 		},
 		{
 			Query:        "max_over_time(metricWith1SampleEvery10Seconds[60s])",
@@ -1017,6 +1114,10 @@ load 10s
 			PeakSamples:  7,
 			TotalSamples: 6, // 1 sample / 10 seconds * 60 seconds
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 6,
 			},
 		},
@@ -1028,6 +1129,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 6,
 			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+			},
 		},
 		{
 			Query:        "max_over_time(metricWith3SampleEvery10Seconds[60s])",
@@ -1035,6 +1140,10 @@ load 10s
 			PeakSamples:  9,
 			TotalSamples: 18, // 3 sample / 10 seconds * 60 seconds
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 18,
+			},
+			SamplesRead: 18,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 18,
 			},
 		},
@@ -1046,6 +1155,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
 			},
+			SamplesRead: 12,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 12,
+			},
 		},
 		{
 			Query:        "metricWith1SampleEvery10Seconds[60s:5s] offset 10s",
@@ -1053,6 +1166,10 @@ load 10s
 			PeakSamples:  12,
 			TotalSamples: 12, // 1 sample per query * 12 queries (60/5)
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 12,
+			},
+			SamplesRead: 12, // all subquery steps attributed (steps before first window → step 0)
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
 			},
 		},
@@ -1064,6 +1181,10 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 36,
 			},
+			SamplesRead: 36,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 36,
+			},
 		},
 		{
 			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[60s:5s])) + sum(max_over_time(metricWith3SampleEvery10Seconds[60s:5s]))",
@@ -1071,6 +1192,10 @@ load 10s
 			PeakSamples:  52,
 			TotalSamples: 72, // 2 * (3 sample per query * 12 queries (60/5))
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 72,
+			},
+			SamplesRead: 72,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 72,
 			},
 		},
@@ -1082,6 +1207,13 @@ load 10s
 			PeakSamples:  4,
 			TotalSamples: 4, // 1 sample per query * 4 steps
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 1,
+				206000: 1,
+				211000: 1,
+				216000: 1,
+			},
+			SamplesRead: 4,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 1,
 				206000: 1,
 				211000: 1,
@@ -1101,6 +1233,13 @@ load 10s
 				214000: 1,
 				219000: 1,
 			},
+			SamplesRead: 4,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				204000: 1,
+				209000: 1,
+				214000: 1,
+				219000: 1,
+			},
 		},
 		{
 			Query:        `metricWith1HistogramEvery10Seconds`,
@@ -1115,6 +1254,13 @@ load 10s
 				214000: 13,
 				219000: 13,
 			},
+			SamplesRead: 52,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				204000: 13,
+				209000: 13,
+				214000: 13,
+				219000: 13,
+			},
 		},
 		{
 			// timestamp function has a special handling
@@ -1125,6 +1271,13 @@ load 10s
 			PeakSamples:  5,
 			TotalSamples: 4, // 1 sample per query * 4 steps
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 1,
+				206000: 1,
+				211000: 1,
+				216000: 1,
+			},
+			SamplesRead: 4,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 1,
 				206000: 1,
 				211000: 1,
@@ -1145,6 +1298,13 @@ load 10s
 				211000: 1,
 				216000: 1,
 			},
+			SamplesRead: 4,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 1,
+				206000: 1,
+				211000: 1,
+				216000: 1,
+			},
 		},
 		{
 			Query:        `max_over_time(metricWith3SampleEvery10Seconds{a="1"}[10s])`,
@@ -1154,6 +1314,13 @@ load 10s
 			PeakSamples:  2,
 			TotalSamples: 2, // 1 sample per query * 2 steps with data
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				991000:  1,
+				1001000: 1,
+				1011000: 0,
+				1021000: 0,
+			},
+			SamplesRead: 2,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				991000:  1,
 				1001000: 1,
 				1011000: 0,
@@ -1173,6 +1340,13 @@ load 10s
 				211000: 1,
 				216000: 1,
 			},
+			SamplesRead: 4,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 1,
+				206000: 1,
+				211000: 1,
+				216000: 1,
+			},
 		},
 		{
 			Query:        "max_over_time(metricWith3SampleEvery10Seconds[60s] @ 30)",
@@ -1187,6 +1361,13 @@ load 10s
 				211000: 12,
 				216000: 12,
 			},
+			SamplesRead: 12, // StepInvariantExpr: added once at step 0 only
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 12,
+				206000: 0,
+				211000: 0,
+				216000: 0,
+			},
 		},
 		{
 			Query:        `metricWith3SampleEvery10Seconds`,
@@ -1196,6 +1377,13 @@ load 10s
 			Interval:     5 * time.Second,
 			TotalSamples: 12, // 3 sample per query * 4 steps
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 3,
+				206000: 3,
+				211000: 3,
+				216000: 3,
+			},
+			SamplesRead: 12,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 3,
 				206000: 3,
 				211000: 3,
@@ -1215,6 +1403,13 @@ load 10s
 				211000: 18,
 				216000: 18,
 			},
+			SamplesRead: 21,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 18,
+				206000: 0,
+				211000: 3,
+				216000: 0,
+			},
 		},
 		{
 			Query:        "max_over_time(metricWith3SampleEvery10Seconds[60s:5s])",
@@ -1228,6 +1423,13 @@ load 10s
 				206000: 36,
 				211000: 36,
 				216000: 36,
+			},
+			SamplesRead: 48,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 36,
+				206000: 3,
+				211000: 3,
+				216000: 6, // steps after last outer → last step
 			},
 		},
 		{
@@ -1243,6 +1445,13 @@ load 10s
 				211000: 12,
 				216000: 12,
 			},
+			SamplesRead: 16,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 12,
+				206000: 1,
+				211000: 1,
+				216000: 2, // steps after last outer → last step
+			},
 		},
 		{
 			Query:        "sum by (b) (max_over_time(metricWith1SampleEvery10Seconds[60s:5s]))",
@@ -1256,6 +1465,13 @@ load 10s
 				206000: 12,
 				211000: 12,
 				216000: 12,
+			},
+			SamplesRead: 16,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 12,
+				206000: 1,
+				211000: 1,
+				216000: 2, // steps after last outer → last step
 			},
 		},
 		{
@@ -1271,6 +1487,13 @@ load 10s
 				211000: 72,
 				216000: 72,
 			},
+			SamplesRead: 96,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 72,
+				206000: 6,
+				211000: 6,
+				216000: 12, // steps after last outer → last step
+			},
 		},
 		{
 			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[60s:5s])) + sum(max_over_time(metricWith1SampleEvery10Seconds[60s:5s]))",
@@ -1285,6 +1508,869 @@ load 10s
 				211000: 48,
 				216000: 48,
 			},
+			SamplesRead: 64,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 48,
+				206000: 4,
+				211000: 4,
+				216000: 8, // steps after last outer → last step
+			},
+		},
+
+		// ===================================================================================
+		// ENHANCED SUBQUERY TESTING - Focused on key patterns
+		// ===================================================================================
+
+		// Simple subquery with multiple inner steps - subquery evaluates inner at each step (instant)
+		{
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[20s:10s])",
+			Start:        time.Unix(201, 0),
+			PeakSamples:  5,
+			TotalSamples: 2, // 2 inner steps * 1 sample
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 2,
+			},
+			SamplesRead: 2,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 2,
+			},
+		},
+
+		// Single inner step: step equals range so only one subquery evaluation
+		{
+			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[30s:30s])",
+			Start:        time.Unix(90, 0),
+			PeakSamples:  3,
+			TotalSamples: 1,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				90000: 1,
+			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				90000: 1,
+			},
+		},
+
+		// Multiple series subquery - 2 inner steps * 3 series
+		{
+			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[20s:10s]))",
+			Start:        time.Unix(201, 0),
+			PeakSamples:  11,
+			TotalSamples: 6,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+			},
+		},
+
+		// Basic range query with subquery - 2 parent steps, 3 inner steps each
+		{
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[30s:10s])",
+			Start:        time.Unix(201, 0),
+			End:          time.Unix(231, 0),
+			Interval:     30 * time.Second,
+			PeakSamples:  11,
+			TotalSamples: 6, // 2 parent steps * 3 inner samples
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 3,
+				231000: 3,
+			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 3,
+				231000: 3,
+			},
+		},
+
+		// Range query where subquery range (20s) > query step interval (10s):
+		// overlapping windows share inner subquery steps across parent steps.
+		{
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[20s:10s])",
+			Start:        time.Unix(201, 0),
+			End:          time.Unix(261, 0),
+			Interval:     10 * time.Second,
+			PeakSamples:  17,
+			TotalSamples: 14,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 2,
+				211000: 2,
+				221000: 2,
+				231000: 2,
+				241000: 2,
+				251000: 2,
+				261000: 2,
+			},
+			SamplesRead: 8,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 2,
+				211000: 1,
+				221000: 1,
+				231000: 1,
+				241000: 1,
+				251000: 1,
+				261000: 1,
+			},
+		},
+
+		// Subquery range query showing per-step delta attribution
+		{
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[20s:10s])",
+			Start:        time.Unix(201, 0),
+			End:          time.Unix(231, 0),
+			Interval:     30 * time.Second,
+			PeakSamples:  9,
+			TotalSamples: 4,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 2,
+				231000: 2,
+			},
+			SamplesRead: 5,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 2,
+				231000: 3,
+			},
+		},
+
+		// Large step size - single inner step
+		{
+			Query:        "avg_over_time(metricWith1SampleEvery10Seconds[60s:2m])",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  3,
+			TotalSamples: 1,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 1,
+			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 1,
+			},
+		},
+
+		// High cardinality with multiple steps
+		{
+			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[30s:10s])[2m:1m]",
+			Start:        time.Unix(180, 0),
+			PeakSamples:  36,
+			TotalSamples: 18,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				180000: 18,
+			},
+			SamplesRead: 27, // subquery SamplesRead merged into outer
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				180000: 27,
+			},
+		},
+
+		// Steps larger than inner range
+		{
+			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[30s])[2m:1m]",
+			Start:        time.Unix(120, 0),
+			PeakSamples:  5,
+			TotalSamples: 6,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				120000: 6,
+			},
+			SamplesRead: 6, // subquery SamplesRead merged into outer
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				120000: 6,
+			},
+		},
+
+		// Non-aligned step boundaries
+		{
+			Query:        "avg_over_time(metricWith3SampleEvery10Seconds[73s:17s])[5m:43s]",
+			Start:        time.Unix(300, 0),
+			PeakSamples:  77,
+			TotalSamples: 78,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				300000: 78,
+			},
+			SamplesRead: 54, // all subquery steps attributed (steps before first window → step 0)
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				300000: 54,
+			},
+		},
+
+		// Large step count with reasonable data size
+		{
+			Query:        "avg_over_time(metricWith1SampleEvery10Seconds[30s])[30m:10s]",
+			Start:        time.Unix(1800, 0),
+			PeakSamples:  102,
+			TotalSamples: 302,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				1800000: 302,
+			},
+			SamplesRead: 101, // subquery SamplesRead merged into outer
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				1800000: 101,
+			},
+		},
+
+		// Test with different series cardinality
+		{
+			Query:        "sum(rate(metricWith3SampleEvery10Seconds[120s:40s]))[4m:1m]",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  36,
+			TotalSamples: 33,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 33,
+			},
+			SamplesRead: 21, // subquery SamplesRead merged into outer
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 21,
+			},
+		},
+
+		// ===================================================================================
+		// FOCUSED KEY PATTERNS - Validated Examples
+		// ===================================================================================
+
+		// Histogram function with subquery
+		{
+			Query:        "histogram_count(max_over_time(metricWith1HistogramEvery10Seconds[60s]))",
+			Start:        time.Unix(201, 0),
+			PeakSamples:  66,
+			TotalSamples: 66,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 66,
+			},
+			SamplesRead: 66,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 66,
+			},
+		},
+
+		// Basic aggregation with existing proven pattern
+		{
+			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[60s]))",
+			Start:        time.Unix(201, 0),
+			PeakSamples:  9,  // Based on existing 3-series pattern
+			TotalSamples: 18, // 3 series * 6 samples from existing [60s] pattern
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 18,
+			},
+			SamplesRead: 18, // Single parent step
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 18,
+			},
+		},
+
+		// Histogram subquery
+		{
+			Query:        "histogram_count(max_over_time(metricWith1HistogramEvery10Seconds[20s:10s]))",
+			Start:        time.Unix(201, 0),
+			PeakSamples:  52,
+			TotalSamples: 26,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 26,
+			},
+			SamplesRead: 26,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 26,
+			},
+		},
+
+		// @ modifier subquery
+		{
+			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[20s:10s] @ 200)",
+			Start:        time.Unix(250, 0),
+			PeakSamples:  11,
+			TotalSamples: 6,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				250000: 6,
+			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				250000: 6,
+			},
+		},
+
+		// Mixed functions with histogram subquery
+		{
+			Query:        "histogram_sum(avg_over_time(metricWith1HistogramEvery10Seconds[1m:20s]))",
+			Start:        time.Unix(120, 0),
+			PeakSamples:  91,
+			TotalSamples: 39,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				120000: 39,
+			},
+			SamplesRead: 39,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				120000: 39,
+			},
+		},
+
+		// Subquery with @ modifier
+		{
+			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[60s:20s] @ 200)",
+			Start:        time.Unix(300, 0),
+			PeakSamples:  15,
+			TotalSamples: 9,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				300000: 9,
+			},
+			SamplesRead: 9,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				300000: 9,
+			},
+		},
+
+		// Nested subqueries with @ modifier
+		{
+			Query:        "sum_over_time(max_over_time(metricWith3SampleEvery10Seconds[60s] @ 300)[5m:1m] @ 600)[10m:2m]",
+			Start:        time.Unix(800, 0),
+			PeakSamples:  23,
+			TotalSamples: 75,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				800000: 75,
+			},
+			SamplesRead: 18, // subquery SamplesRead merged into outer
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				800000: 18,
+			},
+		},
+
+		// ===================================================================================
+		// AGGREGATION AND GROUPING WITH SUBQUERIES
+		// ===================================================================================
+
+		// Aggregation with subquery
+		{
+			Query:        "sum by (a) (max_over_time(metricWith3SampleEvery10Seconds[20s:10s]))",
+			Start:        time.Unix(201, 0),
+			PeakSamples:  11,
+			TotalSamples: 6,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+			},
+		},
+
+		// Range query with aggregation and subquery
+		{
+			Query:        "sum by (b) (max_over_time(metricWith3SampleEvery10Seconds[20s:10s]))",
+			Start:        time.Unix(201, 0),
+			End:          time.Unix(261, 0),
+			Interval:     30 * time.Second,
+			PeakSamples:  35,
+			TotalSamples: 18,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+				231000: 6,
+				261000: 6,
+			},
+			SamplesRead: 24,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+				231000: 9,
+				261000: 9,
+			},
+		},
+
+		// Histogram quantile with subquery
+		{
+			Query:        "histogram_quantile(0.9, max_over_time(metricWith1HistogramEvery10Seconds[20s:10s]))",
+			Start:        time.Unix(201, 0),
+			PeakSamples:  53,
+			TotalSamples: 26,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 26,
+			},
+			SamplesRead: 26,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 26,
+			},
+		},
+
+		// Aggregation with subqueries
+		{
+			Query:        "sum by (b) (max_over_time(metricWith3SampleEvery10Seconds[1m:20s]))",
+			Start:        time.Unix(120, 0),
+			PeakSamples:  15,
+			TotalSamples: 9,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				120000: 9,
+			},
+			SamplesRead: 9,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				120000: 9,
+			},
+		},
+
+		// Histogram with many inner steps
+		{
+			Query:        "histogram_quantile(0.9, avg_over_time(metricWith1HistogramEvery10Seconds[2m:30s]))",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  118,
+			TotalSamples: 52,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 52,
+			},
+			SamplesRead: 52,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 52,
+			},
+		},
+
+		// Multiple series aggregation with subqueries
+		{
+			Query:        "sum by (a) (rate(metricWith3SampleEvery10Seconds[2m:30s]))[15m:5m]",
+			Start:        time.Unix(900, 0),
+			PeakSamples:  85,
+			TotalSamples: 36,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				900000: 36,
+			},
+			SamplesRead: 72, // subquery SamplesRead merged into outer
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				900000: 72,
+			},
+		},
+
+		// Large window with histogram data
+		{
+			Query:        "histogram_sum(rate(metricWith1HistogramEvery10Seconds[5m:1m]))[30m:10m]",
+			Start:        time.Unix(1800, 0),
+			PeakSamples:  273,
+			TotalSamples: 130,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				1800000: 130,
+			},
+			SamplesRead: 208, // subquery SamplesRead merged into outer
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				1800000: 208,
+			},
+		},
+
+		// ===================================================================================
+		// ADDITIONAL FOCUSED SUBQUERY PATTERNS
+		// ===================================================================================
+
+		// Rate function with subquery
+		{
+			Query:        "rate(sum_over_time(metricWith1SampleEvery10Seconds[30s])[1m:30s])",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  5,
+			TotalSamples: 2,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 2,
+			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 6,
+			},
+		},
+
+		// Subquery with offset modifier
+		{
+			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[20s:10s] offset 1m)",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  5,
+			TotalSamples: 2,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 2,
+			},
+			SamplesRead: 2,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 2,
+			},
+		},
+
+		// Simple range query with subquery
+		{
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[30s:15s])",
+			Start:        time.Unix(201, 0),
+			End:          time.Unix(231, 0),
+			Interval:     15 * time.Second,
+			PeakSamples:  9,
+			TotalSamples: 6,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 2,
+				216000: 2,
+				231000: 2,
+			},
+			SamplesRead: 4,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 2,
+				216000: 1,
+				231000: 1,
+			},
+		},
+
+		// Large time range with subqueries
+		{
+			Query:        "increase(metricWith1SampleEvery10Seconds[5m:1m])[30m:10m]",
+			Start:        time.Unix(1800, 0),
+			PeakSamples:  21,
+			TotalSamples: 10,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				1800000: 10,
+			},
+			SamplesRead: 16, // subquery SamplesRead merged into outer
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				1800000: 16,
+			},
+		},
+
+		// ===================================================================================
+		// PHASE 2: LARGER SCALE TESTING
+		// ===================================================================================
+
+		// Larger subquery with many steps
+		{
+			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[5m:1m])[10m:5m]",
+			Start:        time.Unix(600, 0),
+			PeakSamples:  41,
+			TotalSamples: 30,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				600000: 30,
+			},
+			SamplesRead: 30, // subquery SamplesRead merged into outer
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				600000: 30,
+			},
+		},
+
+		// ===================================================================================
+		// PHASE 3: RANGE QUERY + SUBQUERY COMBINATIONS
+		// ===================================================================================
+
+		// Range query with subquery
+		{
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[1m:20s])",
+			Start:        time.Unix(120, 0),
+			End:          time.Unix(300, 0),
+			Interval:     60 * time.Second,
+			PeakSamples:  19,
+			TotalSamples: 12,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				120000: 3,
+				180000: 3,
+				240000: 3,
+				300000: 3,
+			},
+			SamplesRead: 12,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				120000: 3,
+				180000: 3,
+				240000: 3,
+				300000: 3,
+			},
+		},
+
+		// Range query with histogram subquery
+		{
+			Query:        "avg_over_time(metricWith1HistogramEvery10Seconds[2m:1m])",
+			Start:        time.Unix(120, 0),
+			End:          time.Unix(240, 0),
+			Interval:     60 * time.Second,
+			PeakSamples:  117,
+			TotalSamples: 78,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				120000: 26,
+				180000: 26,
+				240000: 26,
+			},
+			SamplesRead: 52,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				120000: 26,
+				180000: 13,
+				240000: 13,
+			},
+		},
+
+		// Range query with multiple series
+		{
+			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[1m:30s]))",
+			Start:        time.Unix(120, 0),
+			End:          time.Unix(240, 0),
+			Interval:     60 * time.Second,
+			PeakSamples:  29,
+			TotalSamples: 18,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				120000: 6,
+				180000: 6,
+				240000: 6,
+			},
+			SamplesRead: 18,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				120000: 6,
+				180000: 6,
+				240000: 6,
+			},
+		},
+
+		// Range queries with subqueries (multiple series, higher cardinality)
+		{
+			Query:        "max_over_time(metricWith3SampleEvery10Seconds[60s:10s])",
+			Start:        time.Unix(200, 0),
+			End:          time.Unix(400, 0),
+			Interval:     30 * time.Second,
+			PeakSamples:  105,
+			TotalSamples: 126,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				200000: 18,
+				230000: 18,
+				260000: 18,
+				290000: 18,
+				320000: 18,
+				350000: 18,
+				380000: 18,
+			},
+			SamplesRead: 78,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				200000: 18,
+				230000: 9,
+				260000: 9,
+				290000: 9,
+				320000: 9,
+				350000: 9,
+				380000: 15, // steps after last outer → last step
+			},
+		},
+
+		// Range query with histogram subqueries
+		{
+			Query:        "histogram_quantile(0.9, rate(metricWith1HistogramEvery10Seconds[2m:30s]))",
+			Start:        time.Unix(240, 0),
+			End:          time.Unix(600, 0),
+			Interval:     60 * time.Second,
+			PeakSamples:  358,
+			TotalSamples: 364,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 52,
+				300000: 52,
+				360000: 52,
+				420000: 52,
+				480000: 52,
+				540000: 52,
+				600000: 52,
+			},
+			SamplesRead: 208,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 52,
+				300000: 26,
+				360000: 26,
+				420000: 26,
+				480000: 26,
+				540000: 26,
+				600000: 26,
+			},
+		},
+
+		// Range query with multiple series subqueries
+		{
+			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[80s:20s]))",
+			Start:        time.Unix(160, 0),
+			End:          time.Unix(400, 0),
+			Interval:     120 * time.Second,
+			PeakSamples:  61,
+			TotalSamples: 36,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				160000: 12,
+				280000: 12,
+				400000: 12,
+			},
+			SamplesRead: 48,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				160000: 12,
+				280000: 18,
+				400000: 18,
+			},
+		},
+
+		// ===================================================================================
+		// PHASE 4: ADDITIONAL PATTERN TESTS
+		// ===================================================================================
+
+		// Large range with many samples
+		{
+			Query:        "avg_over_time(metricWith1SampleEvery10Seconds[5m:30s])",
+			Start:        time.Unix(300, 0),
+			PeakSamples:  21,
+			TotalSamples: 10,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				300000: 10,
+			},
+			SamplesRead: 10,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				300000: 10,
+			},
+		},
+
+		// Many small steps
+		{
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[2m:20s])",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  13,
+			TotalSamples: 6,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 6,
+			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 6,
+			},
+		},
+
+		// Histogram subquery function
+		{
+			Query:        "histogram_count(avg_over_time(metricWith1HistogramEvery10Seconds[1m:30s]))",
+			Start:        time.Unix(120, 0),
+			PeakSamples:  65,
+			TotalSamples: 26,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				120000: 26,
+			},
+			SamplesRead: 26,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				120000: 26,
+			},
+		},
+
+		// High step count efficiency test - subquery evaluates inner at each step (instant)
+		{
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[300s:10s])",
+			Start:        time.Unix(600, 0),
+			PeakSamples:  61,
+			TotalSamples: 30, // 30 inner steps * 1 sample per step
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				600000: 30,
+			},
+			SamplesRead: 30,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				600000: 30,
+			},
+		},
+
+		// Complex histogram with nested functions
+		{
+			Query:        "rate(histogram_sum(metricWith1HistogramEvery10Seconds)[2m:30s])",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  57,
+			TotalSamples: 4,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 4,
+			},
+			SamplesRead: 52,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 52,
+			},
+		},
+
+		// High step count efficiency test - subquery evaluates inner at each step (instant)
+		{
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[2m:10s])",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  25,
+			TotalSamples: 12, // 12 inner steps * 1 sample per step
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 12,
+			},
+			SamplesRead: 12,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 12,
+			},
+		},
+
+		// Complex histogram function nesting
+		{
+			Query:        "histogram_count(rate(metricWith1HistogramEvery10Seconds[2m:30s]))",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  117,
+			TotalSamples: 52,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 52,
+			},
+			SamplesRead: 52,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 52,
+			},
+		},
+
+		// ===================================================================================
+		// PHASE 5: BOUNDARY CONDITIONS AND EDGE CASES
+		// ===================================================================================
+
+		// Step equals range duration - subquery single inner step
+		{
+			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[60s:60s])",
+			Start:        time.Unix(120, 0),
+			PeakSamples:  3,
+			TotalSamples: 1, // Single inner step, 1 sample
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				120000: 1,
+			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				120000: 1,
+			},
+		},
+
+		// Large step creates sparse sampling - single inner step
+		{
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[30s:2m])",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  3,
+			TotalSamples: 1, // Single inner step
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 1,
+			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 1,
+			},
+		},
+
+		// Offset with subquery - 2 inner steps * 3 series
+		{
+			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[1m:30s] offset 2m)",
+			Start:        time.Unix(300, 0),
+			PeakSamples:  11,
+			TotalSamples: 6, // 2 inner steps * 3 series
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				300000: 6,
+			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				300000: 6,
+			},
+		},
+
+		// Large step size relative to data frequency - single inner step
+		{
+			Query:        "avg_over_time(metricWith1SampleEvery10Seconds[1m:2m])",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  3,
+			TotalSamples: 1, // Single inner step
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 1,
+			},
+			SamplesRead: 1,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 1,
+			},
+		},
+
+		// Subquery with offset and @ modifier combined - 6 inner steps * 3 series
+		{
+			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[1m:10s] @ 200 offset 1m)",
+			Start:        time.Unix(300, 0),
+			PeakSamples:  27,
+			TotalSamples: 18, // 6 inner steps * 3 series
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				300000: 18,
+			},
+			SamplesRead: 18,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				300000: 18,
+			},
 		},
 	}
 
@@ -1293,7 +2379,7 @@ load 10s
 			opts := promql.NewPrometheusQueryOpts(true, 0)
 			engine := promqltest.NewTestEngine(t, true, 0, promqltest.DefaultMaxSamplesPerQuery)
 
-			runQuery := func(expErr error) *stats.Statistics {
+			runQuery := func(engine promql.QueryEngine, opts promql.QueryOpts, expErr error) *stats.Statistics {
 				var err error
 				var qry promql.Query
 				if c.Interval == 0 {
@@ -1309,17 +2395,29 @@ load 10s
 				return qry.Stats()
 			}
 
-			stats := runQuery(nil)
+			stats := runQuery(engine, opts, nil)
 			require.Equal(t, c.TotalSamples, stats.Samples.TotalSamples, "Total samples mismatch")
 			require.Equal(t, &c.TotalSamplesPerStep, stats.Samples.TotalSamplesPerStepMap(), "Total samples per time mismatch")
+			require.Equal(t, c.SamplesRead, stats.Samples.SamplesRead, "Samples read mismatch")
+			require.Equal(t, &c.SamplesReadPerStep, stats.Samples.SamplesReadPerStepMap(), "Samples read per step mismatch")
 			require.Equal(t, c.PeakSamples, stats.Samples.PeakSamples, "Peak samples mismatch")
+
+			// Verify TotalSamples and SamplesRead are correct when per-step stats are disabled.
+			opts = promql.NewPrometheusQueryOpts(false, 0)
+			engine = promqltest.NewTestEngine(t, false, 0, promqltest.DefaultMaxSamplesPerQuery)
+			stats = runQuery(engine, opts, nil)
+			require.Equal(t, c.TotalSamples, stats.Samples.TotalSamples,
+				"TotalSamples should match when per-step stats are disabled")
+			require.Equal(t, c.SamplesRead, stats.Samples.SamplesRead,
+				"SamplesRead should match when per-step stats are disabled")
 
 			// Check that the peak is correct by setting the max to one less.
 			if c.SkipMaxCheck {
 				return
 			}
+			opts = promql.NewPrometheusQueryOpts(true, 0)
 			engine = promqltest.NewTestEngine(t, true, 0, stats.Samples.PeakSamples-1)
-			runQuery(promql.ErrTooManySamples(env))
+			runQuery(engine, opts, promql.ErrTooManySamples(env))
 		})
 	}
 }

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1613,6 +1613,10 @@ load 10s
 		},
 
 		// Range query + subquery, outer step wider than subquery range.
+		// Subquery materialises 9 samples (T=180,190,...,260) but only the
+		// 3 samples in each outer step's window contribute to that step's
+		// output; the 3 samples in the gap (201,231] between outer windows
+		// are not counted.
 		{
 			Query:        "max_over_time(metricWith1SampleEvery10Seconds[30s:10s])",
 			Start:        time.Unix(201, 0),
@@ -1624,10 +1628,10 @@ load 10s
 				201000: 3,
 				261000: 3,
 			},
-			SamplesRead: 9,
+			SamplesRead: 6,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 3,
-				261000: 6,
+				261000: 3,
 			},
 		},
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -998,7 +998,7 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 24,
 			},
-			SamplesRead: 8, // delta: 6 at step 0 + 2 new over 3 steps
+			SamplesRead: 8,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 8,
 			},
@@ -1168,7 +1168,7 @@ load 10s
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
 			},
-			SamplesRead: 12, // all subquery steps attributed (steps before first window → step 0)
+			SamplesRead: 12,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
 			},
@@ -1424,12 +1424,12 @@ load 10s
 				211000: 36,
 				216000: 36,
 			},
-			SamplesRead: 48,
+			SamplesRead: 45,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 36,
 				206000: 3,
 				211000: 3,
-				216000: 6, // steps after last outer → last step
+				216000: 3,
 			},
 		},
 		{
@@ -1445,12 +1445,12 @@ load 10s
 				211000: 12,
 				216000: 12,
 			},
-			SamplesRead: 16,
+			SamplesRead: 15,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
 				206000: 1,
 				211000: 1,
-				216000: 2, // steps after last outer → last step
+				216000: 1,
 			},
 		},
 		{
@@ -1466,12 +1466,12 @@ load 10s
 				211000: 12,
 				216000: 12,
 			},
-			SamplesRead: 16,
+			SamplesRead: 15,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
 				206000: 1,
 				211000: 1,
-				216000: 2, // steps after last outer → last step
+				216000: 1,
 			},
 		},
 		{
@@ -1487,12 +1487,12 @@ load 10s
 				211000: 72,
 				216000: 72,
 			},
-			SamplesRead: 96,
+			SamplesRead: 90,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 72,
 				206000: 6,
 				211000: 6,
-				216000: 12, // steps after last outer → last step
+				216000: 6,
 			},
 		},
 		{
@@ -1508,25 +1508,21 @@ load 10s
 				211000: 48,
 				216000: 48,
 			},
-			SamplesRead: 64,
+			SamplesRead: 60,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				201000: 48,
 				206000: 4,
 				211000: 4,
-				216000: 8, // steps after last outer → last step
+				216000: 4,
 			},
 		},
 
-		// ===================================================================================
-		// ENHANCED SUBQUERY TESTING - Focused on key patterns
-		// ===================================================================================
-
-		// Simple subquery with multiple inner steps - subquery evaluates inner at each step (instant)
+		// Instant subquery: basic SamplesRead merging.
 		{
 			Query:        "max_over_time(metricWith1SampleEvery10Seconds[20s:10s])",
 			Start:        time.Unix(201, 0),
 			PeakSamples:  5,
-			TotalSamples: 2, // 2 inner steps * 1 sample
+			TotalSamples: 2,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 2,
 			},
@@ -1536,7 +1532,7 @@ load 10s
 			},
 		},
 
-		// Single inner step: step equals range so only one subquery evaluation
+		// Boundary: step == range, single inner evaluation.
 		{
 			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[30s:30s])",
 			Start:        time.Unix(90, 0),
@@ -1551,29 +1547,29 @@ load 10s
 			},
 		},
 
-		// Multiple series subquery - 2 inner steps * 3 series
+		// Boundary: step > range, sparse sampling.
 		{
-			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[20s:10s]))",
-			Start:        time.Unix(201, 0),
-			PeakSamples:  11,
-			TotalSamples: 6,
+			Query:        "max_over_time(metricWith1SampleEvery10Seconds[30s:2m])",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  3,
+			TotalSamples: 1,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 6,
+				240000: 1,
 			},
-			SamplesRead: 6,
+			SamplesRead: 1,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				201000: 6,
+				240000: 1,
 			},
 		},
 
-		// Basic range query with subquery - 2 parent steps, 3 inner steps each
+		// Range query + subquery, non-overlapping windows (step >= range).
 		{
 			Query:        "max_over_time(metricWith1SampleEvery10Seconds[30s:10s])",
 			Start:        time.Unix(201, 0),
 			End:          time.Unix(231, 0),
 			Interval:     30 * time.Second,
 			PeakSamples:  11,
-			TotalSamples: 6, // 2 parent steps * 3 inner samples
+			TotalSamples: 6,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 3,
 				231000: 3,
@@ -1585,8 +1581,8 @@ load 10s
 			},
 		},
 
-		// Range query where subquery range (20s) > query step interval (10s):
-		// overlapping windows share inner subquery steps across parent steps.
+		// Range query + subquery, overlapping windows (range > step):
+		// SamplesRead < TotalSamples due to windowed delta attribution.
 		{
 			Query:        "max_over_time(metricWith1SampleEvery10Seconds[20s:10s])",
 			Start:        time.Unix(201, 0),
@@ -1615,150 +1611,7 @@ load 10s
 			},
 		},
 
-		// Subquery range query showing per-step delta attribution
-		{
-			Query:        "max_over_time(metricWith1SampleEvery10Seconds[20s:10s])",
-			Start:        time.Unix(201, 0),
-			End:          time.Unix(231, 0),
-			Interval:     30 * time.Second,
-			PeakSamples:  9,
-			TotalSamples: 4,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 2,
-				231000: 2,
-			},
-			SamplesRead: 5,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				201000: 2,
-				231000: 3,
-			},
-		},
-
-		// Large step size - single inner step
-		{
-			Query:        "avg_over_time(metricWith1SampleEvery10Seconds[60s:2m])",
-			Start:        time.Unix(240, 0),
-			PeakSamples:  3,
-			TotalSamples: 1,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 1,
-			},
-			SamplesRead: 1,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 1,
-			},
-		},
-
-		// High cardinality with multiple steps
-		{
-			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[30s:10s])[2m:1m]",
-			Start:        time.Unix(180, 0),
-			PeakSamples:  36,
-			TotalSamples: 18,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				180000: 18,
-			},
-			SamplesRead: 27, // subquery SamplesRead merged into outer
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				180000: 27,
-			},
-		},
-
-		// Steps larger than inner range
-		{
-			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[30s])[2m:1m]",
-			Start:        time.Unix(120, 0),
-			PeakSamples:  5,
-			TotalSamples: 6,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				120000: 6,
-			},
-			SamplesRead: 6, // subquery SamplesRead merged into outer
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				120000: 6,
-			},
-		},
-
-		// Non-aligned step boundaries
-		{
-			Query:        "avg_over_time(metricWith3SampleEvery10Seconds[73s:17s])[5m:43s]",
-			Start:        time.Unix(300, 0),
-			PeakSamples:  77,
-			TotalSamples: 78,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				300000: 78,
-			},
-			SamplesRead: 54, // all subquery steps attributed (steps before first window → step 0)
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				300000: 54,
-			},
-		},
-
-		// Large step count with reasonable data size
-		{
-			Query:        "avg_over_time(metricWith1SampleEvery10Seconds[30s])[30m:10s]",
-			Start:        time.Unix(1800, 0),
-			PeakSamples:  102,
-			TotalSamples: 302,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				1800000: 302,
-			},
-			SamplesRead: 101, // subquery SamplesRead merged into outer
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				1800000: 101,
-			},
-		},
-
-		// Test with different series cardinality
-		{
-			Query:        "sum(rate(metricWith3SampleEvery10Seconds[120s:40s]))[4m:1m]",
-			Start:        time.Unix(240, 0),
-			PeakSamples:  36,
-			TotalSamples: 33,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 33,
-			},
-			SamplesRead: 21, // subquery SamplesRead merged into outer
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 21,
-			},
-		},
-
-		// ===================================================================================
-		// FOCUSED KEY PATTERNS - Validated Examples
-		// ===================================================================================
-
-		// Histogram function with subquery
-		{
-			Query:        "histogram_count(max_over_time(metricWith1HistogramEvery10Seconds[60s]))",
-			Start:        time.Unix(201, 0),
-			PeakSamples:  66,
-			TotalSamples: 66,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 66,
-			},
-			SamplesRead: 66,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				201000: 66,
-			},
-		},
-
-		// Basic aggregation with existing proven pattern
-		{
-			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[60s]))",
-			Start:        time.Unix(201, 0),
-			PeakSamples:  9,  // Based on existing 3-series pattern
-			TotalSamples: 18, // 3 series * 6 samples from existing [60s] pattern
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 18,
-			},
-			SamplesRead: 18, // Single parent step
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				201000: 18,
-			},
-		},
-
-		// Histogram subquery
+		// Histogram subquery: histogram size counting in subquery path.
 		{
 			Query:        "histogram_count(max_over_time(metricWith1HistogramEvery10Seconds[20s:10s]))",
 			Start:        time.Unix(201, 0),
@@ -1773,298 +1626,7 @@ load 10s
 			},
 		},
 
-		// @ modifier subquery
-		{
-			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[20s:10s] @ 200)",
-			Start:        time.Unix(250, 0),
-			PeakSamples:  11,
-			TotalSamples: 6,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				250000: 6,
-			},
-			SamplesRead: 6,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				250000: 6,
-			},
-		},
-
-		// Mixed functions with histogram subquery
-		{
-			Query:        "histogram_sum(avg_over_time(metricWith1HistogramEvery10Seconds[1m:20s]))",
-			Start:        time.Unix(120, 0),
-			PeakSamples:  91,
-			TotalSamples: 39,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				120000: 39,
-			},
-			SamplesRead: 39,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				120000: 39,
-			},
-		},
-
-		// Subquery with @ modifier
-		{
-			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[60s:20s] @ 200)",
-			Start:        time.Unix(300, 0),
-			PeakSamples:  15,
-			TotalSamples: 9,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				300000: 9,
-			},
-			SamplesRead: 9,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				300000: 9,
-			},
-		},
-
-		// Nested subqueries with @ modifier
-		{
-			Query:        "sum_over_time(max_over_time(metricWith3SampleEvery10Seconds[60s] @ 300)[5m:1m] @ 600)[10m:2m]",
-			Start:        time.Unix(800, 0),
-			PeakSamples:  23,
-			TotalSamples: 75,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				800000: 75,
-			},
-			SamplesRead: 18, // subquery SamplesRead merged into outer
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				800000: 18,
-			},
-		},
-
-		// ===================================================================================
-		// AGGREGATION AND GROUPING WITH SUBQUERIES
-		// ===================================================================================
-
-		// Aggregation with subquery
-		{
-			Query:        "sum by (a) (max_over_time(metricWith3SampleEvery10Seconds[20s:10s]))",
-			Start:        time.Unix(201, 0),
-			PeakSamples:  11,
-			TotalSamples: 6,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 6,
-			},
-			SamplesRead: 6,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				201000: 6,
-			},
-		},
-
-		// Range query with aggregation and subquery
-		{
-			Query:        "sum by (b) (max_over_time(metricWith3SampleEvery10Seconds[20s:10s]))",
-			Start:        time.Unix(201, 0),
-			End:          time.Unix(261, 0),
-			Interval:     30 * time.Second,
-			PeakSamples:  35,
-			TotalSamples: 18,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 6,
-				231000: 6,
-				261000: 6,
-			},
-			SamplesRead: 24,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				201000: 6,
-				231000: 9,
-				261000: 9,
-			},
-		},
-
-		// Histogram quantile with subquery
-		{
-			Query:        "histogram_quantile(0.9, max_over_time(metricWith1HistogramEvery10Seconds[20s:10s]))",
-			Start:        time.Unix(201, 0),
-			PeakSamples:  53,
-			TotalSamples: 26,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 26,
-			},
-			SamplesRead: 26,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				201000: 26,
-			},
-		},
-
-		// Aggregation with subqueries
-		{
-			Query:        "sum by (b) (max_over_time(metricWith3SampleEvery10Seconds[1m:20s]))",
-			Start:        time.Unix(120, 0),
-			PeakSamples:  15,
-			TotalSamples: 9,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				120000: 9,
-			},
-			SamplesRead: 9,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				120000: 9,
-			},
-		},
-
-		// Histogram with many inner steps
-		{
-			Query:        "histogram_quantile(0.9, avg_over_time(metricWith1HistogramEvery10Seconds[2m:30s]))",
-			Start:        time.Unix(240, 0),
-			PeakSamples:  118,
-			TotalSamples: 52,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 52,
-			},
-			SamplesRead: 52,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 52,
-			},
-		},
-
-		// Multiple series aggregation with subqueries
-		{
-			Query:        "sum by (a) (rate(metricWith3SampleEvery10Seconds[2m:30s]))[15m:5m]",
-			Start:        time.Unix(900, 0),
-			PeakSamples:  85,
-			TotalSamples: 36,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				900000: 36,
-			},
-			SamplesRead: 72, // subquery SamplesRead merged into outer
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				900000: 72,
-			},
-		},
-
-		// Large window with histogram data
-		{
-			Query:        "histogram_sum(rate(metricWith1HistogramEvery10Seconds[5m:1m]))[30m:10m]",
-			Start:        time.Unix(1800, 0),
-			PeakSamples:  273,
-			TotalSamples: 130,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				1800000: 130,
-			},
-			SamplesRead: 208, // subquery SamplesRead merged into outer
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				1800000: 208,
-			},
-		},
-
-		// ===================================================================================
-		// ADDITIONAL FOCUSED SUBQUERY PATTERNS
-		// ===================================================================================
-
-		// Rate function with subquery
-		{
-			Query:        "rate(sum_over_time(metricWith1SampleEvery10Seconds[30s])[1m:30s])",
-			Start:        time.Unix(240, 0),
-			PeakSamples:  5,
-			TotalSamples: 2,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 2,
-			},
-			SamplesRead: 6,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 6,
-			},
-		},
-
-		// Subquery with offset modifier
-		{
-			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[20s:10s] offset 1m)",
-			Start:        time.Unix(240, 0),
-			PeakSamples:  5,
-			TotalSamples: 2,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 2,
-			},
-			SamplesRead: 2,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 2,
-			},
-		},
-
-		// Simple range query with subquery
-		{
-			Query:        "max_over_time(metricWith1SampleEvery10Seconds[30s:15s])",
-			Start:        time.Unix(201, 0),
-			End:          time.Unix(231, 0),
-			Interval:     15 * time.Second,
-			PeakSamples:  9,
-			TotalSamples: 6,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 2,
-				216000: 2,
-				231000: 2,
-			},
-			SamplesRead: 4,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				201000: 2,
-				216000: 1,
-				231000: 1,
-			},
-		},
-
-		// Large time range with subqueries
-		{
-			Query:        "increase(metricWith1SampleEvery10Seconds[5m:1m])[30m:10m]",
-			Start:        time.Unix(1800, 0),
-			PeakSamples:  21,
-			TotalSamples: 10,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				1800000: 10,
-			},
-			SamplesRead: 16, // subquery SamplesRead merged into outer
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				1800000: 16,
-			},
-		},
-
-		// ===================================================================================
-		// PHASE 2: LARGER SCALE TESTING
-		// ===================================================================================
-
-		// Larger subquery with many steps
-		{
-			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[5m:1m])[10m:5m]",
-			Start:        time.Unix(600, 0),
-			PeakSamples:  41,
-			TotalSamples: 30,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				600000: 30,
-			},
-			SamplesRead: 30, // subquery SamplesRead merged into outer
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				600000: 30,
-			},
-		},
-
-		// ===================================================================================
-		// PHASE 3: RANGE QUERY + SUBQUERY COMBINATIONS
-		// ===================================================================================
-
-		// Range query with subquery
-		{
-			Query:        "max_over_time(metricWith1SampleEvery10Seconds[1m:20s])",
-			Start:        time.Unix(120, 0),
-			End:          time.Unix(300, 0),
-			Interval:     60 * time.Second,
-			PeakSamples:  19,
-			TotalSamples: 12,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				120000: 3,
-				180000: 3,
-				240000: 3,
-				300000: 3,
-			},
-			SamplesRead: 12,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				120000: 3,
-				180000: 3,
-				240000: 3,
-				300000: 3,
-			},
-		},
-
-		// Range query with histogram subquery
+		// Histogram range query + subquery: histogram delta attribution.
 		{
 			Query:        "avg_over_time(metricWith1HistogramEvery10Seconds[2m:1m])",
 			Start:        time.Unix(120, 0),
@@ -2085,28 +1647,7 @@ load 10s
 			},
 		},
 
-		// Range query with multiple series
-		{
-			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[1m:30s]))",
-			Start:        time.Unix(120, 0),
-			End:          time.Unix(240, 0),
-			Interval:     60 * time.Second,
-			PeakSamples:  29,
-			TotalSamples: 18,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				120000: 6,
-				180000: 6,
-				240000: 6,
-			},
-			SamplesRead: 18,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				120000: 6,
-				180000: 6,
-				240000: 6,
-			},
-		},
-
-		// Range queries with subqueries (multiple series, higher cardinality)
+		// Range query with multiple series + subquery: covers cardinality.
 		{
 			Query:        "max_over_time(metricWith3SampleEvery10Seconds[60s:10s])",
 			Start:        time.Unix(200, 0),
@@ -2123,7 +1664,7 @@ load 10s
 				350000: 18,
 				380000: 18,
 			},
-			SamplesRead: 78,
+			SamplesRead: 72,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				200000: 18,
 				230000: 9,
@@ -2131,245 +1672,83 @@ load 10s
 				290000: 9,
 				320000: 9,
 				350000: 9,
-				380000: 15, // steps after last outer → last step
+				380000: 9,
 			},
 		},
 
-		// Range query with histogram subqueries
+		// Subquery with @ modifier: effectiveRange = 0, windowing disabled.
 		{
-			Query:        "histogram_quantile(0.9, rate(metricWith1HistogramEvery10Seconds[2m:30s]))",
-			Start:        time.Unix(240, 0),
-			End:          time.Unix(600, 0),
-			Interval:     60 * time.Second,
-			PeakSamples:  358,
-			TotalSamples: 364,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 52,
-				300000: 52,
-				360000: 52,
-				420000: 52,
-				480000: 52,
-				540000: 52,
-				600000: 52,
-			},
-			SamplesRead: 208,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 52,
-				300000: 26,
-				360000: 26,
-				420000: 26,
-				480000: 26,
-				540000: 26,
-				600000: 26,
-			},
-		},
-
-		// Range query with multiple series subqueries
-		{
-			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[80s:20s]))",
-			Start:        time.Unix(160, 0),
-			End:          time.Unix(400, 0),
-			Interval:     120 * time.Second,
-			PeakSamples:  61,
-			TotalSamples: 36,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				160000: 12,
-				280000: 12,
-				400000: 12,
-			},
-			SamplesRead: 48,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				160000: 12,
-				280000: 18,
-				400000: 18,
-			},
-		},
-
-		// ===================================================================================
-		// PHASE 4: ADDITIONAL PATTERN TESTS
-		// ===================================================================================
-
-		// Large range with many samples
-		{
-			Query:        "avg_over_time(metricWith1SampleEvery10Seconds[5m:30s])",
-			Start:        time.Unix(300, 0),
-			PeakSamples:  21,
-			TotalSamples: 10,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				300000: 10,
-			},
-			SamplesRead: 10,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				300000: 10,
-			},
-		},
-
-		// Many small steps
-		{
-			Query:        "max_over_time(metricWith1SampleEvery10Seconds[2m:20s])",
-			Start:        time.Unix(240, 0),
-			PeakSamples:  13,
+			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[20s:10s] @ 200)",
+			Start:        time.Unix(250, 0),
+			PeakSamples:  11,
 			TotalSamples: 6,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 6,
+				250000: 6,
 			},
 			SamplesRead: 6,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 6,
+				250000: 6,
 			},
 		},
 
-		// Histogram subquery function
+		// Subquery with offset.
 		{
-			Query:        "histogram_count(avg_over_time(metricWith1HistogramEvery10Seconds[1m:30s]))",
-			Start:        time.Unix(120, 0),
-			PeakSamples:  65,
-			TotalSamples: 26,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				120000: 26,
-			},
-			SamplesRead: 26,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				120000: 26,
-			},
-		},
-
-		// High step count efficiency test - subquery evaluates inner at each step (instant)
-		{
-			Query:        "max_over_time(metricWith1SampleEvery10Seconds[300s:10s])",
-			Start:        time.Unix(600, 0),
-			PeakSamples:  61,
-			TotalSamples: 30, // 30 inner steps * 1 sample per step
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				600000: 30,
-			},
-			SamplesRead: 30,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				600000: 30,
-			},
-		},
-
-		// Complex histogram with nested functions
-		{
-			Query:        "rate(histogram_sum(metricWith1HistogramEvery10Seconds)[2m:30s])",
+			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[20s:10s] offset 1m)",
 			Start:        time.Unix(240, 0),
-			PeakSamples:  57,
-			TotalSamples: 4,
+			PeakSamples:  5,
+			TotalSamples: 2,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 4,
+				240000: 2,
 			},
-			SamplesRead: 52,
+			SamplesRead: 2,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 52,
+				240000: 2,
 			},
 		},
 
-		// High step count efficiency test - subquery evaluates inner at each step (instant)
-		{
-			Query:        "max_over_time(metricWith1SampleEvery10Seconds[2m:10s])",
-			Start:        time.Unix(240, 0),
-			PeakSamples:  25,
-			TotalSamples: 12, // 12 inner steps * 1 sample per step
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 12,
-			},
-			SamplesRead: 12,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 12,
-			},
-		},
-
-		// Complex histogram function nesting
-		{
-			Query:        "histogram_count(rate(metricWith1HistogramEvery10Seconds[2m:30s]))",
-			Start:        time.Unix(240, 0),
-			PeakSamples:  117,
-			TotalSamples: 52,
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 52,
-			},
-			SamplesRead: 52,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 52,
-			},
-		},
-
-		// ===================================================================================
-		// PHASE 5: BOUNDARY CONDITIONS AND EDGE CASES
-		// ===================================================================================
-
-		// Step equals range duration - subquery single inner step
-		{
-			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[60s:60s])",
-			Start:        time.Unix(120, 0),
-			PeakSamples:  3,
-			TotalSamples: 1, // Single inner step, 1 sample
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				120000: 1,
-			},
-			SamplesRead: 1,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				120000: 1,
-			},
-		},
-
-		// Large step creates sparse sampling - single inner step
-		{
-			Query:        "max_over_time(metricWith1SampleEvery10Seconds[30s:2m])",
-			Start:        time.Unix(240, 0),
-			PeakSamples:  3,
-			TotalSamples: 1, // Single inner step
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 1,
-			},
-			SamplesRead: 1,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 1,
-			},
-		},
-
-		// Offset with subquery - 2 inner steps * 3 series
-		{
-			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[1m:30s] offset 2m)",
-			Start:        time.Unix(300, 0),
-			PeakSamples:  11,
-			TotalSamples: 6, // 2 inner steps * 3 series
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				300000: 6,
-			},
-			SamplesRead: 6,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				300000: 6,
-			},
-		},
-
-		// Large step size relative to data frequency - single inner step
-		{
-			Query:        "avg_over_time(metricWith1SampleEvery10Seconds[1m:2m])",
-			Start:        time.Unix(240, 0),
-			PeakSamples:  3,
-			TotalSamples: 1, // Single inner step
-			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 1,
-			},
-			SamplesRead: 1,
-			SamplesReadPerStep: stats.TotalSamplesPerStep{
-				240000: 1,
-			},
-		},
-
-		// Subquery with offset and @ modifier combined - 6 inner steps * 3 series
+		// Subquery with offset + @ modifier combined.
 		{
 			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[1m:10s] @ 200 offset 1m)",
 			Start:        time.Unix(300, 0),
 			PeakSamples:  27,
-			TotalSamples: 18, // 6 inner steps * 3 series
+			TotalSamples: 18,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				300000: 18,
 			},
 			SamplesRead: 18,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
 				300000: 18,
+			},
+		},
+
+		// Nested subquery: recursive merging across two subquery levels.
+		{
+			Query:        "sum_over_time(max_over_time(metricWith3SampleEvery10Seconds[60s] @ 300)[5m:1m] @ 600)[10m:2m]",
+			Start:        time.Unix(800, 0),
+			PeakSamples:  23,
+			TotalSamples: 75,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				800000: 75,
+			},
+			SamplesRead: 18,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				800000: 18,
+			},
+		},
+
+		// Outer subquery wrapping inner range-vector (evalSubquery path):
+		// SamplesRead > TotalSamples because inner subquery reads more data than it surfaces.
+		{
+			Query:        "rate(sum_over_time(metricWith1SampleEvery10Seconds[30s])[1m:30s])",
+			Start:        time.Unix(240, 0),
+			PeakSamples:  5,
+			TotalSamples: 2,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				240000: 2,
+			},
+			SamplesRead: 6,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				240000: 6,
 			},
 		},
 	}

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -782,18 +782,19 @@ load 10s
   metricWith1HistogramEvery10Seconds {{schema:1 count:5 sum:20 buckets:[1 2 1 1]}}+{{schema:1 count:10 sum:5 buckets:[1 2 3 4]}}x100
 `)
 
-	cases := []struct {
+	type testCase struct {
 		Query               string
 		SkipMaxCheck        bool
 		TotalSamples        int64
 		TotalSamplesPerStep stats.TotalSamplesPerStep
-		SamplesRead         int64                     // samples read (delta for range-vector)
-		SamplesReadPerStep  stats.TotalSamplesPerStep // per-step samples read
+		SamplesRead         int64                     // Samples read (delta for range-vector).
+		SamplesReadPerStep  stats.TotalSamplesPerStep // Per-step samples read.
 		PeakSamples         int
 		Start               time.Time
 		End                 time.Time
 		Interval            time.Duration
-	}{
+	}
+	cases := []testCase{
 		{
 			Query:        `"literal string"`,
 			SkipMaxCheck: true, // This can't fail from a max samples limit.
@@ -1779,50 +1780,55 @@ load 10s
 		},
 	}
 
+	runQuery := func(t *testing.T, engine promql.QueryEngine, opts promql.QueryOpts, c testCase, expErr error) *stats.Statistics {
+		t.Helper()
+		var err error
+		var qry promql.Query
+		if c.Interval == 0 {
+			qry, err = engine.NewInstantQuery(context.Background(), storage, opts, c.Query, c.Start)
+		} else {
+			qry, err = engine.NewRangeQuery(context.Background(), storage, opts, c.Query, c.Start, c.End, c.Interval)
+		}
+		require.NoError(t, err)
+
+		res := qry.Exec(context.Background())
+		require.Equal(t, expErr, res.Err)
+
+		return qry.Stats()
+	}
+
 	for _, c := range cases {
 		t.Run(c.Query, func(t *testing.T) {
-			opts := promql.NewPrometheusQueryOpts(true, 0)
-			engine := promqltest.NewTestEngine(t, true, 0, promqltest.DefaultMaxSamplesPerQuery)
+			t.Run("perStepEnabled", func(t *testing.T) {
+				opts := promql.NewPrometheusQueryOpts(true, 0)
+				engine := promqltest.NewTestEngine(t, true, 0, promqltest.DefaultMaxSamplesPerQuery)
 
-			runQuery := func(engine promql.QueryEngine, opts promql.QueryOpts, expErr error) *stats.Statistics {
-				var err error
-				var qry promql.Query
-				if c.Interval == 0 {
-					qry, err = engine.NewInstantQuery(context.Background(), storage, opts, c.Query, c.Start)
-				} else {
-					qry, err = engine.NewRangeQuery(context.Background(), storage, opts, c.Query, c.Start, c.End, c.Interval)
+				stats := runQuery(t, engine, opts, c, nil)
+				require.Equal(t, c.TotalSamples, stats.Samples.TotalSamples, "Total samples mismatch")
+				require.Equal(t, &c.TotalSamplesPerStep, stats.Samples.TotalSamplesPerStepMap(), "Total samples per time mismatch")
+				require.Equal(t, c.SamplesRead, stats.Samples.SamplesRead, "Samples read mismatch")
+				require.Equal(t, &c.SamplesReadPerStep, stats.Samples.SamplesReadPerStepMap(), "Samples read per step mismatch")
+				require.Equal(t, c.PeakSamples, stats.Samples.PeakSamples, "Peak samples mismatch")
+
+				// Re-run with the max set to one less than the observed peak;
+				// confirms the peak is what gates the query.max-samples limit.
+				if c.SkipMaxCheck {
+					return
 				}
-				require.NoError(t, err)
+				engine = promqltest.NewTestEngine(t, true, 0, stats.Samples.PeakSamples-1)
+				runQuery(t, engine, opts, c, promql.ErrTooManySamples(env))
+			})
 
-				res := qry.Exec(context.Background())
-				require.Equal(t, expErr, res.Err)
+			t.Run("perStepDisabled", func(t *testing.T) {
+				opts := promql.NewPrometheusQueryOpts(false, 0)
+				engine := promqltest.NewTestEngine(t, false, 0, promqltest.DefaultMaxSamplesPerQuery)
 
-				return qry.Stats()
-			}
-
-			stats := runQuery(engine, opts, nil)
-			require.Equal(t, c.TotalSamples, stats.Samples.TotalSamples, "Total samples mismatch")
-			require.Equal(t, &c.TotalSamplesPerStep, stats.Samples.TotalSamplesPerStepMap(), "Total samples per time mismatch")
-			require.Equal(t, c.SamplesRead, stats.Samples.SamplesRead, "Samples read mismatch")
-			require.Equal(t, &c.SamplesReadPerStep, stats.Samples.SamplesReadPerStepMap(), "Samples read per step mismatch")
-			require.Equal(t, c.PeakSamples, stats.Samples.PeakSamples, "Peak samples mismatch")
-
-			// Verify TotalSamples and SamplesRead are correct when per-step stats are disabled.
-			opts = promql.NewPrometheusQueryOpts(false, 0)
-			engine = promqltest.NewTestEngine(t, false, 0, promqltest.DefaultMaxSamplesPerQuery)
-			stats = runQuery(engine, opts, nil)
-			require.Equal(t, c.TotalSamples, stats.Samples.TotalSamples,
-				"TotalSamples should match when per-step stats are disabled")
-			require.Equal(t, c.SamplesRead, stats.Samples.SamplesRead,
-				"SamplesRead should match when per-step stats are disabled")
-
-			// Check that the peak is correct by setting the max to one less.
-			if c.SkipMaxCheck {
-				return
-			}
-			opts = promql.NewPrometheusQueryOpts(true, 0)
-			engine = promqltest.NewTestEngine(t, true, 0, stats.Samples.PeakSamples-1)
-			runQuery(engine, opts, promql.ErrTooManySamples(env))
+				stats := runQuery(t, engine, opts, c, nil)
+				require.Equal(t, c.TotalSamples, stats.Samples.TotalSamples,
+					"TotalSamples should match when per-step stats are disabled")
+				require.Equal(t, c.SamplesRead, stats.Samples.SamplesRead,
+					"SamplesRead should match when per-step stats are disabled")
+			})
 		})
 	}
 }

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1676,6 +1676,32 @@ load 10s
 			},
 		},
 
+		// Range query with @ modifier on a matrix selector wrapped in an
+		// at-modifier-unsafe function (predict_linear), so the call is not
+		// hoisted into a step-invariant expression. The @ modifier freezes
+		// the evaluation window, so every parent step consumes the same
+		// matrix. TotalSamples must reflect the full window at every step;
+		// SamplesRead is counted only once (no new I/O after step 0).
+		{
+			Query:        "predict_linear(metricWith1SampleEvery10Seconds[60s] @ 100, 60)",
+			Start:        time.Unix(100, 0),
+			End:          time.Unix(300, 0),
+			Interval:     100 * time.Second,
+			PeakSamples:  12,
+			TotalSamples: 18, // 6 samples per window * 3 steps.
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				100000: 6,
+				200000: 6,
+				300000: 6,
+			},
+			SamplesRead: 6, // @ modifier: single read at step 0; later steps reuse.
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				100000: 6,
+				200000: 0,
+				300000: 0,
+			},
+		},
+
 		// Subquery with @ modifier.
 		{
 			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[20s:10s] @ 200)",

--- a/promql/value.go
+++ b/promql/value.go
@@ -189,6 +189,24 @@ func totalHPointSize(histograms []HPoint) int {
 	return total
 }
 
+// countSamplesAfter returns the number of sample equivalents in floats and histograms
+// with timestamp strictly after cutoff. Float samples count as 1; histogram samples
+// count via HPoint.size. Used for range-vector sample stats to count only new points per step.
+func countSamplesAfter(floats []FPoint, histograms []HPoint, cutoff int64) int64 {
+	var n int64
+	for _, f := range floats {
+		if f.T > cutoff {
+			n++
+		}
+	}
+	for _, h := range histograms {
+		if h.T > cutoff {
+			n += int64(h.size())
+		}
+	}
+	return n
+}
+
 // Sample is a single sample belonging to a metric. It represents either a float
 // sample or a histogram sample. If H is nil, it is a float sample. Otherwise,
 // it is a histogram sample.

--- a/promql/value.go
+++ b/promql/value.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -194,16 +195,17 @@ func totalHPointSize(histograms []HPoint) int {
 // count via HPoint.size. Used for range-vector sample stats to count only new points per step.
 func countSamplesAfter(floats []FPoint, histograms []HPoint, cutoff int64) int64 {
 	var n int64
-	for _, f := range floats {
-		if f.T > cutoff {
-			n++
-		}
+
+	// Both slices are sorted by timestamp; binary-search for the first
+	// element after cutoff then count from there.
+	i := sort.Search(len(floats), func(i int) bool { return floats[i].T > cutoff })
+	n += int64(len(floats) - i)
+
+	j := sort.Search(len(histograms), func(j int) bool { return histograms[j].T > cutoff })
+	for _, h := range histograms[j:] {
+		n += int64(h.size())
 	}
-	for _, h := range histograms {
-		if h.T > cutoff {
-			n += int64(h.size())
-		}
-	}
+
 	return n
 }
 

--- a/promql/value.go
+++ b/promql/value.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -193,19 +192,20 @@ func totalHPointSize(histograms []HPoint) int {
 // countSamplesAfter returns the number of sample equivalents in floats and histograms
 // with timestamp strictly after cutoff. Float samples count as 1; histogram samples
 // count via HPoint.size. Used for range-vector sample stats to count only new points per step.
+//
+// Both slices are sorted by timestamp ascending. We scan backwards from the end
+// because the call site uses cutoff = maxt - interval, which is typically close
+// to the end of the window, so only the last one or two points satisfy the
+// predicate. Backwards linear scan is O(k) for k matches and avoids the closure
+// overhead that sort.Search imposes on these very small slices.
 func countSamplesAfter(floats []FPoint, histograms []HPoint, cutoff int64) int64 {
 	var n int64
-
-	// Both slices are sorted by timestamp; binary-search for the first
-	// element after cutoff then count from there.
-	i := sort.Search(len(floats), func(i int) bool { return floats[i].T > cutoff })
-	n += int64(len(floats) - i)
-
-	j := sort.Search(len(histograms), func(j int) bool { return histograms[j].T > cutoff })
-	for _, h := range histograms[j:] {
-		n += int64(h.size())
+	for i := len(floats) - 1; i >= 0 && floats[i].T > cutoff; i-- {
+		n++
 	}
-
+	for i := len(histograms) - 1; i >= 0 && histograms[i].T > cutoff; i-- {
+		n += int64(histograms[i].size())
+	}
 	return n
 }
 

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -444,6 +444,10 @@ func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples) {
 	if qs.SamplesReadPerStep != nil {
 		numParent = len(qs.SamplesReadPerStep)
 	}
+	if numParent == 0 {
+		qs.SamplesRead += child.SamplesRead
+		return
+	}
 
 	for k := range child.SamplesReadPerStep {
 		n := child.SamplesReadPerStep[k]
@@ -456,14 +460,12 @@ func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples) {
 		if tk > parentStart {
 			outerStep = int((tk - parentStart + parentInterval - 1) / parentInterval)
 		}
-		if numParent > 0 && outerStep >= numParent {
+		if outerStep >= numParent {
 			outerStep = numParent - 1
 		}
 
 		qs.SamplesRead += n
-		if numParent > 0 && outerStep < numParent {
-			qs.SamplesReadPerStep[outerStep] += n
-		}
+		qs.SamplesReadPerStep[outerStep] += n
 	}
 }
 

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -288,10 +288,6 @@ type QuerySamples struct {
 	EnablePerStepStats bool
 	StartTimestamp     int64
 	Interval           int64
-	// numSteps is the number of evaluation steps. Always set by
-	// NewChildWithStepTracking so that MergeSamplesReadFromSubquery
-	// can compute parent windows even when per-step arrays are nil.
-	numSteps int
 }
 
 type Stats struct {
@@ -408,17 +404,11 @@ func (*QuerySamples) NewChild() *QuerySamples {
 }
 
 // NewChildWithStepTracking creates a child QuerySamples and, when
-// enablePerStepStats is true, initializes per-step arrays. The step layout
-// (start, interval, numSteps) is always stored so that
-// MergeSamplesReadFromSubquery can compute parent windows for windowed
-// attribution even when the parent does not track per-step arrays.
+// enablePerStepStats is true, initializes per-step arrays.
 func NewChildWithStepTracking(enablePerStepStats bool, start, end, interval int64) *QuerySamples {
 	qs := NewQuerySamples(enablePerStepStats)
 	qs.StartTimestamp = start
 	qs.Interval = interval
-	if interval > 0 {
-		qs.numSteps = int((end-start)/interval) + 1
-	}
 	if enablePerStepStats {
 		qs.InitStepTracking(start, end, interval)
 	}
@@ -430,18 +420,12 @@ func NewChildWithStepTracking(enablePerStepStats bool, start, end, interval int6
 // not merged, because the outer range-eval loop already counts those when it
 // iterates over the pre-computed matrix.
 //
-// When subqRange > 0, range-windowed attribution is used: only child steps whose
-// timestamp falls within a parent step's [parentTs-subqRange, parentTs] window are
-// counted. Child steps in gaps between parent windows (when the parent interval
-// exceeds subqRange) are not attributed, consistent with range vector selectors
-// where only samples inside the selected range are counted.
-//
-// When subqRange is 0, all child steps are attributed to the nearest parent step.
-//
-// The parent must have StartTimestamp and Interval set (via NewChildWithStepTracking)
-// for windowing to work. Per-step arrays on the parent are optional; when present
-// they receive per-step attribution, otherwise only SamplesRead is updated.
-func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples, subqRange int64) {
+// Each child step is attributed to the earliest parent step whose timestamp is
+// >= the child timestamp. Child steps before the first parent step are attributed
+// to step 0; child steps after the last parent step are attributed to the last
+// step. When the parent has per-step arrays they receive per-step attribution,
+// otherwise only SamplesRead is updated.
+func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples) {
 	if qs == nil || child == nil {
 		return
 	}
@@ -460,8 +444,6 @@ func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples, subqRa
 	if qs.SamplesReadPerStep != nil {
 		numParent = len(qs.SamplesReadPerStep)
 	}
-	numParentForWindow := qs.numSteps
-	numParentForWindow = max(numParentForWindow, numParent)
 
 	for k := range child.SamplesReadPerStep {
 		n := child.SamplesReadPerStep[k]
@@ -474,16 +456,7 @@ func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples, subqRa
 		if tk > parentStart {
 			outerStep = int((tk - parentStart + parentInterval - 1) / parentInterval)
 		}
-
-		if subqRange > 0 {
-			if outerStep >= numParentForWindow {
-				continue
-			}
-			parentTs := parentStart + int64(outerStep)*parentInterval
-			if tk <= parentTs-subqRange {
-				continue
-			}
-		} else if numParent > 0 && outerStep >= numParent {
+		if numParent > 0 && outerStep >= numParent {
 			outerStep = numParent - 1
 		}
 

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -421,21 +421,36 @@ func NewChildWithStepTracking(enablePerStepStats bool, start, end, interval int6
 // not merged, because the outer range-eval loop already counts those when it
 // iterates over the pre-computed matrix. This function ensures the outer query's
 // samples-read stats reflect the subquery's actual storage I/O.
-//
-// Precondition: the child must have been created with NewChildWithStepTracking
-// using the parent evaluator's (start, end, interval), so the child's step
-// indices map 1:1 to the parent's. In evalSubquery, the SubqueryExpr case maps
-// inner subquery steps to the child's (= parent's) step indices via time-based
-// attribution before this function is called, making the 1:1 index merge correct.
 func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples) {
 	if qs == nil || child == nil {
 		return
 	}
 	qs.SamplesRead += child.SamplesRead
-	if qs.SamplesReadPerStep != nil && child.SamplesReadPerStep != nil {
-		for i := 0; i < len(qs.SamplesReadPerStep) && i < len(child.SamplesReadPerStep); i++ {
-			qs.SamplesReadPerStep[i] += child.SamplesReadPerStep[i]
+	if qs.SamplesReadPerStep == nil || child.SamplesReadPerStep == nil {
+		return
+	}
+	if len(qs.SamplesReadPerStep) == 0 || qs.Interval == 0 {
+		return
+	}
+
+	numParent := len(qs.SamplesReadPerStep)
+	parentStart := qs.StartTimestamp
+	parentInterval := qs.Interval
+
+	for k := range child.SamplesReadPerStep {
+		n := child.SamplesReadPerStep[k]
+		if n == 0 {
+			continue
 		}
+		tk := child.StartTimestamp + int64(k)*child.Interval
+		outerStep := 0
+		if tk > parentStart {
+			outerStep = int((tk - parentStart + parentInterval - 1) / parentInterval)
+		}
+		if outerStep >= numParent {
+			outerStep = numParent - 1
+		}
+		qs.SamplesReadPerStep[outerStep] += n
 	}
 }
 

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -406,62 +406,80 @@ func (*QuerySamples) NewChild() *QuerySamples {
 	return NewQuerySamples(false)
 }
 
-// NewChildWithStepTracking creates a child QuerySamples and, when
-// enablePerStepStats is true, initializes per-step arrays via
-// InitStepTracking. When enablePerStepStats is false the timing fields
-// are intentionally left zero; the per-step merge helpers detect this
-// and fall back to a flat SamplesRead accumulation.
-func NewChildWithStepTracking(enablePerStepStats bool, start, end, interval int64) *QuerySamples {
-	qs := NewQuerySamples(enablePerStepStats)
-	if enablePerStepStats {
-		qs.InitStepTracking(start, end, interval)
-	}
+// NewChildWithStepTracking creates a child QuerySamples with per-step tracking
+// enabled and initializes its per-step arrays via InitStepTracking.
+func NewChildWithStepTracking(start, end, interval int64) *QuerySamples {
+	qs := NewQuerySamples(true)
+	qs.InitStepTracking(start, end, interval)
 	return qs
 }
 
 // MergeSamplesReadFromSubquery merges only SamplesRead and SamplesReadPerStep from
 // the child (subquery) into the parent. TotalSamples and TotalSamplesPerStep are
 // not merged, because the outer range-eval loop already counts those when it
-// iterates over the pre-computed matrix.
+// iterates over the pre-computed matrix. The child must have per-step tracking
+// enabled (callers should construct it via NewChildWithStepTracking).
 //
-// Each child step is attributed to the earliest parent step whose timestamp is
-// >= the child timestamp. Child steps before the first parent step are attributed
-// to step 0; child steps after the last parent step are attributed to the last
-// step. When either side lacks per-step arrays we fall back to a flat
-// SamplesRead accumulation.
-func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples) {
+// parentStart, parentInterval and parentNumSteps describe the parent's step
+// grid; they are passed explicitly so that gap filtering still works when the
+// parent has per-step tracking disabled. parentNumSteps <= 1 (instant query)
+// disables step attribution and gap filtering: the child's total is folded into
+// qs.SamplesRead (and qs.SamplesReadPerStep[0] when allocated).
+//
+// The child timestamp tk is shifted forward by outerOffset before being matched
+// against the parent's step grid, so that an offset subquery (whose iterations
+// run earlier than the parent step) is attributed to the parent step that
+// actually consumes its output. Each child step is attributed to the earliest
+// parent step whose timestamp is >= tk+outerOffset; samples before the first
+// parent step are attributed to step 0 and samples after the last clamp to the
+// last step.
+//
+// outerRange is the consumed window width at each parent step (i.e. selRange of
+// the outer call when the subquery is used as a function's matrix argument). When
+// outerRange > 0, child steps whose shifted timestamp falls in a gap between
+// consecutive parent windows (i.e. tk+outerOffset <= parentTs-outerRange) are
+// skipped, so the count reflects only samples that actually contribute to the
+// output. Pass 0 for both outerOffset and outerRange to disable shifting and gap
+// filtering (e.g. for a bare *parser.SubqueryExpr where every child step is part
+// of the parent matrix output).
+func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples, parentStart, parentInterval int64, parentNumSteps int, outerOffset, outerRange int64) {
 	if qs == nil || child == nil {
 		return
 	}
-	// InitStepTracking is the only setter of qs.Interval and it always
-	// allocates SamplesReadPerStep, so qs.Interval == 0 is equivalent to
-	// the parent having no per-step array.
-	if child.SamplesReadPerStep == nil || qs.Interval == 0 {
+	if parentNumSteps <= 1 {
 		qs.SamplesRead += child.SamplesRead
+		if qs.SamplesReadPerStep != nil {
+			qs.SamplesReadPerStep[0] += child.SamplesRead
+		}
 		return
 	}
-
-	parentStart := qs.StartTimestamp
-	parentInterval := qs.Interval
-	numParent := len(qs.SamplesReadPerStep)
 
 	for k := range child.SamplesReadPerStep {
 		n := child.SamplesReadPerStep[k]
 		if n == 0 {
 			continue
 		}
-		tk := child.StartTimestamp + int64(k)*child.Interval
+		tk := child.StartTimestamp + int64(k)*child.Interval + outerOffset
 
 		outerStep := 0
 		if tk > parentStart {
 			outerStep = int((tk - parentStart + parentInterval - 1) / parentInterval)
 		}
-		if outerStep >= numParent {
-			outerStep = numParent - 1
+		if outerStep >= parentNumSteps {
+			outerStep = parentNumSteps - 1
+		}
+
+		if outerRange > 0 {
+			parentTs := parentStart + int64(outerStep)*parentInterval
+			if tk <= parentTs-outerRange {
+				continue
+			}
 		}
 
 		qs.SamplesRead += n
-		qs.SamplesReadPerStep[outerStep] += n
+		if qs.SamplesReadPerStep != nil {
+			qs.SamplesReadPerStep[outerStep] += n
+		}
 	}
 }
 

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -288,6 +288,10 @@ type QuerySamples struct {
 	EnablePerStepStats bool
 	StartTimestamp     int64
 	Interval           int64
+	// numSteps is the number of evaluation steps. Always set by
+	// NewChildWithStepTracking so that MergeSamplesReadFromSubquery
+	// can compute parent windows even when per-step arrays are nil.
+	numSteps int
 }
 
 type Stats struct {
@@ -403,13 +407,18 @@ func (*QuerySamples) NewChild() *QuerySamples {
 	return NewQuerySamples(false)
 }
 
-// NewChildWithStepTracking creates a child QuerySamples that shares the parent's
-// per-step setting and, when enablePerStepStats is true, initializes step tracking
-// with the given outer query step layout (start, end, interval). Used when
-// evaluating a subquery so the child can record SamplesReadPerStep for incremental
-// attribution to outer steps.
+// NewChildWithStepTracking creates a child QuerySamples and, when
+// enablePerStepStats is true, initializes per-step arrays. The step layout
+// (start, interval, numSteps) is always stored so that
+// MergeSamplesReadFromSubquery can compute parent windows for windowed
+// attribution even when the parent does not track per-step arrays.
 func NewChildWithStepTracking(enablePerStepStats bool, start, end, interval int64) *QuerySamples {
 	qs := NewQuerySamples(enablePerStepStats)
+	qs.StartTimestamp = start
+	qs.Interval = interval
+	if interval > 0 {
+		qs.numSteps = int((end-start)/interval) + 1
+	}
 	if enablePerStepStats {
 		qs.InitStepTracking(start, end, interval)
 	}
@@ -419,23 +428,40 @@ func NewChildWithStepTracking(enablePerStepStats bool, start, end, interval int6
 // MergeSamplesReadFromSubquery merges only SamplesRead and SamplesReadPerStep from
 // the child (subquery) into the parent. TotalSamples and TotalSamplesPerStep are
 // not merged, because the outer range-eval loop already counts those when it
-// iterates over the pre-computed matrix. This function ensures the outer query's
-// samples-read stats reflect the subquery's actual storage I/O.
-func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples) {
+// iterates over the pre-computed matrix.
+//
+// When subqRange > 0, range-windowed attribution is used: only child steps whose
+// timestamp falls within a parent step's [parentTs-subqRange, parentTs] window are
+// counted. Child steps in gaps between parent windows (when the parent interval
+// exceeds subqRange) are not attributed, consistent with range vector selectors
+// where only samples inside the selected range are counted.
+//
+// When subqRange is 0, all child steps are attributed to the nearest parent step.
+//
+// The parent must have StartTimestamp and Interval set (via NewChildWithStepTracking)
+// for windowing to work. Per-step arrays on the parent are optional; when present
+// they receive per-step attribution, otherwise only SamplesRead is updated.
+func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples, subqRange int64) {
 	if qs == nil || child == nil {
 		return
 	}
-	qs.SamplesRead += child.SamplesRead
-	if qs.SamplesReadPerStep == nil || child.SamplesReadPerStep == nil {
+	if child.SamplesReadPerStep == nil {
+		qs.SamplesRead += child.SamplesRead
 		return
 	}
-	if len(qs.SamplesReadPerStep) == 0 || qs.Interval == 0 {
+	if qs.Interval == 0 {
+		qs.SamplesRead += child.SamplesRead
 		return
 	}
 
-	numParent := len(qs.SamplesReadPerStep)
 	parentStart := qs.StartTimestamp
 	parentInterval := qs.Interval
+	numParent := 0
+	if qs.SamplesReadPerStep != nil {
+		numParent = len(qs.SamplesReadPerStep)
+	}
+	numParentForWindow := qs.numSteps
+	numParentForWindow = max(numParentForWindow, numParent)
 
 	for k := range child.SamplesReadPerStep {
 		n := child.SamplesReadPerStep[k]
@@ -443,14 +469,28 @@ func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples) {
 			continue
 		}
 		tk := child.StartTimestamp + int64(k)*child.Interval
+
 		outerStep := 0
 		if tk > parentStart {
 			outerStep = int((tk - parentStart + parentInterval - 1) / parentInterval)
 		}
-		if outerStep >= numParent {
+
+		if subqRange > 0 {
+			if outerStep >= numParentForWindow {
+				continue
+			}
+			parentTs := parentStart + int64(outerStep)*parentInterval
+			if tk <= parentTs-subqRange {
+				continue
+			}
+		} else if numParent > 0 && outerStep >= numParent {
 			outerStep = numParent - 1
 		}
-		qs.SamplesReadPerStep[outerStep] += n
+
+		qs.SamplesRead += n
+		if numParent > 0 && outerStep < numParent {
+			qs.SamplesReadPerStep[outerStep] += n
+		}
 	}
 }
 

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -179,7 +179,8 @@ func (qs *QuerySamples) TotalSamplesPerStepMap() *TotalSamplesPerStep {
 	return &ts
 }
 
-// SamplesReadPerStepMap returns the per-step samples read as a map (timestamp -> count), or nil if per-step stats are disabled.
+// SamplesReadPerStepMap returns the per-step samples read as a map
+// (timestamp -> count), or nil if per-step stats are disabled.
 func (qs *QuerySamples) SamplesReadPerStepMap() *TotalSamplesPerStep {
 	if !qs.EnablePerStepStats || qs.SamplesReadPerStep == nil {
 		return nil
@@ -282,7 +283,9 @@ type QuerySamples struct {
 	SamplesRead int64
 
 	// SamplesReadPerStep is the number of samples read per step. For
-	// range-vector functions, step 0 is the full window, later steps only new points.
+	// range-vector functions, step 0 counts the full window and later
+	// steps count only the points not already covered by the previous
+	// step's window.
 	SamplesReadPerStep []int64
 
 	EnablePerStepStats bool
@@ -343,18 +346,20 @@ func (qs *QuerySamples) IncrementSamplesAtTimestamp(t, samples int64) {
 	}
 }
 
-// IncrementSamplesReadAtStep increments the samples-read count. Use this when you know the step index.
+// IncrementSamplesReadAtStep increments the samples-read count.
+// Use this when you know the step index.
 func (qs *QuerySamples) IncrementSamplesReadAtStep(i int, n int64) {
 	if qs == nil {
 		return
 	}
 	qs.SamplesRead += n
-	if qs.SamplesReadPerStep != nil && i < len(qs.SamplesReadPerStep) {
+	if qs.SamplesReadPerStep != nil {
 		qs.SamplesReadPerStep[i] += n
 	}
 }
 
-// IncrementSamplesReadAtTimestamp increments the samples-read count. Use this when you only have the step timestamp.
+// IncrementSamplesReadAtTimestamp increments the samples-read count.
+// Use this when you only have the step timestamp.
 func (qs *QuerySamples) IncrementSamplesReadAtTimestamp(t, n int64) {
 	if qs == nil {
 		return
@@ -362,9 +367,7 @@ func (qs *QuerySamples) IncrementSamplesReadAtTimestamp(t, n int64) {
 	qs.SamplesRead += n
 	if qs.SamplesReadPerStep != nil {
 		i := int((t - qs.StartTimestamp) / qs.Interval)
-		if i >= 0 && i < len(qs.SamplesReadPerStep) {
-			qs.SamplesReadPerStep[i] += n
-		}
+		qs.SamplesReadPerStep[i] += n
 	}
 }
 
@@ -404,11 +407,12 @@ func (*QuerySamples) NewChild() *QuerySamples {
 }
 
 // NewChildWithStepTracking creates a child QuerySamples and, when
-// enablePerStepStats is true, initializes per-step arrays.
+// enablePerStepStats is true, initializes per-step arrays via
+// InitStepTracking. When enablePerStepStats is false the timing fields
+// are intentionally left zero; the per-step merge helpers detect this
+// and fall back to a flat SamplesRead accumulation.
 func NewChildWithStepTracking(enablePerStepStats bool, start, end, interval int64) *QuerySamples {
 	qs := NewQuerySamples(enablePerStepStats)
-	qs.StartTimestamp = start
-	qs.Interval = interval
 	if enablePerStepStats {
 		qs.InitStepTracking(start, end, interval)
 	}
@@ -423,31 +427,23 @@ func NewChildWithStepTracking(enablePerStepStats bool, start, end, interval int6
 // Each child step is attributed to the earliest parent step whose timestamp is
 // >= the child timestamp. Child steps before the first parent step are attributed
 // to step 0; child steps after the last parent step are attributed to the last
-// step. When the parent has per-step arrays they receive per-step attribution,
-// otherwise only SamplesRead is updated.
+// step. When either side lacks per-step arrays we fall back to a flat
+// SamplesRead accumulation.
 func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples) {
 	if qs == nil || child == nil {
 		return
 	}
-	if child.SamplesReadPerStep == nil {
-		qs.SamplesRead += child.SamplesRead
-		return
-	}
-	if qs.Interval == 0 {
+	// InitStepTracking is the only setter of qs.Interval and it always
+	// allocates SamplesReadPerStep, so qs.Interval == 0 is equivalent to
+	// the parent having no per-step array.
+	if child.SamplesReadPerStep == nil || qs.Interval == 0 {
 		qs.SamplesRead += child.SamplesRead
 		return
 	}
 
 	parentStart := qs.StartTimestamp
 	parentInterval := qs.Interval
-	numParent := 0
-	if qs.SamplesReadPerStep != nil {
-		numParent = len(qs.SamplesReadPerStep)
-	}
-	if numParent == 0 {
-		qs.SamplesRead += child.SamplesRead
-		return
-	}
+	numParent := len(qs.SamplesReadPerStep)
 
 	for k := range child.SamplesReadPerStep {
 		n := child.SamplesReadPerStep[k]

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -105,6 +105,8 @@ type queryTimings struct {
 type querySamples struct {
 	TotalQueryableSamplesPerStep []stepStat `json:"totalQueryableSamplesPerStep,omitempty"`
 	TotalQueryableSamples        int64      `json:"totalQueryableSamples"`
+	SamplesReadPerStep           []stepStat `json:"samplesReadPerStep,omitempty"`
+	SamplesRead                  int64      `json:"samplesRead"`
 	PeakSamples                  int        `json:"peakSamples"`
 }
 
@@ -154,9 +156,11 @@ func NewQueryStats(s *Statistics) QueryStats {
 	if sp != nil {
 		samples = &querySamples{
 			TotalQueryableSamples: sp.TotalSamples,
+			SamplesRead:           sp.SamplesRead,
 			PeakSamples:           sp.PeakSamples,
 		}
 		samples.TotalQueryableSamplesPerStep = sp.totalSamplesPerStepPoints()
+		samples.SamplesReadPerStep = sp.samplesReadPerStepPoints()
 	}
 
 	qs := BuiltinStats{Timings: qt, Samples: samples}
@@ -175,6 +179,19 @@ func (qs *QuerySamples) TotalSamplesPerStepMap() *TotalSamplesPerStep {
 	return &ts
 }
 
+// SamplesReadPerStepMap returns the per-step samples read as a map (timestamp -> count), or nil if per-step stats are disabled.
+func (qs *QuerySamples) SamplesReadPerStepMap() *TotalSamplesPerStep {
+	if !qs.EnablePerStepStats || qs.SamplesReadPerStep == nil {
+		return nil
+	}
+
+	ts := TotalSamplesPerStep{}
+	for _, s := range qs.samplesReadPerStepPoints() {
+		ts[s.T] = int(s.V)
+	}
+	return &ts
+}
+
 func (qs *QuerySamples) totalSamplesPerStepPoints() []stepStat {
 	if !qs.EnablePerStepStats {
 		return nil
@@ -182,6 +199,18 @@ func (qs *QuerySamples) totalSamplesPerStepPoints() []stepStat {
 
 	ts := make([]stepStat, len(qs.TotalSamplesPerStep))
 	for i, c := range qs.TotalSamplesPerStep {
+		ts[i] = stepStat{T: qs.StartTimestamp + int64(i)*qs.Interval, V: c}
+	}
+	return ts
+}
+
+func (qs *QuerySamples) samplesReadPerStepPoints() []stepStat {
+	if !qs.EnablePerStepStats || qs.SamplesReadPerStep == nil {
+		return nil
+	}
+
+	ts := make([]stepStat, len(qs.SamplesReadPerStep))
+	for i, c := range qs.SamplesReadPerStep {
 		ts[i] = stepStat{T: qs.StartTimestamp + int64(i)*qs.Interval, V: c}
 	}
 	return ts
@@ -234,8 +263,9 @@ type QuerySamples struct {
 	// configured in the engine.
 	PeakSamples int
 
-	// TotalSamples represents the total number of samples scanned
-	// while evaluating a query.
+	// TotalSamples represents the total number of samples loaded while
+	// evaluating a query. For range-vector functions, each step counts the
+	// full window (points may be counted in multiple steps).
 	TotalSamples int64
 
 	// TotalSamplesPerStep represents the total number of samples scanned
@@ -243,7 +273,17 @@ type QuerySamples struct {
 	// TotalSamples when a step is run as an instant query, which means
 	// we intentionally do not account for optimizations that happen inside the
 	// range query engine that reduce the actual work that happens.
+	// For range-vector functions, each step counts the full window at that step.
 	TotalSamplesPerStep []int64
+
+	// SamplesRead is the number of samples read (I/O). For range-vector functions
+	// in range queries, only new points per step are counted; elsewhere it
+	// equals TotalSamples.
+	SamplesRead int64
+
+	// SamplesReadPerStep is the number of samples read per step. For
+	// range-vector functions, step 0 is the full window, later steps only new points.
+	SamplesReadPerStep []int64
 
 	EnablePerStepStats bool
 	StartTimestamp     int64
@@ -256,14 +296,25 @@ type Stats struct {
 }
 
 func (qs *QuerySamples) InitStepTracking(start, end, interval int64) {
+	if qs == nil {
+		return
+	}
 	if !qs.EnablePerStepStats {
 		return
 	}
 
 	numSteps := int((end-start)/interval) + 1
 	qs.TotalSamplesPerStep = make([]int64, numSteps)
+	qs.SamplesReadPerStep = make([]int64, numSteps)
 	qs.StartTimestamp = start
 	qs.Interval = interval
+}
+
+func (qs *QuerySamples) StepTrackingEnabled() bool {
+	if qs == nil {
+		return false
+	}
+	return qs.EnablePerStepStats
 }
 
 // IncrementSamplesAtStep increments the total samples count. Use this if you know the step index.
@@ -289,6 +340,31 @@ func (qs *QuerySamples) IncrementSamplesAtTimestamp(t, samples int64) {
 	if qs.TotalSamplesPerStep != nil {
 		i := int((t - qs.StartTimestamp) / qs.Interval)
 		qs.TotalSamplesPerStep[i] += samples
+	}
+}
+
+// IncrementSamplesReadAtStep increments the samples-read count. Use this when you know the step index.
+func (qs *QuerySamples) IncrementSamplesReadAtStep(i int, n int64) {
+	if qs == nil {
+		return
+	}
+	qs.SamplesRead += n
+	if qs.SamplesReadPerStep != nil && i < len(qs.SamplesReadPerStep) {
+		qs.SamplesReadPerStep[i] += n
+	}
+}
+
+// IncrementSamplesReadAtTimestamp increments the samples-read count. Use this when you only have the step timestamp.
+func (qs *QuerySamples) IncrementSamplesReadAtTimestamp(t, n int64) {
+	if qs == nil {
+		return
+	}
+	qs.SamplesRead += n
+	if qs.SamplesReadPerStep != nil {
+		i := int((t - qs.StartTimestamp) / qs.Interval)
+		if i >= 0 && i < len(qs.SamplesReadPerStep) {
+			qs.SamplesReadPerStep[i] += n
+		}
 	}
 }
 
@@ -325,6 +401,42 @@ func NewQuerySamples(enablePerStepStats bool) *QuerySamples {
 
 func (*QuerySamples) NewChild() *QuerySamples {
 	return NewQuerySamples(false)
+}
+
+// NewChildWithStepTracking creates a child QuerySamples that shares the parent's
+// per-step setting and, when enablePerStepStats is true, initializes step tracking
+// with the given outer query step layout (start, end, interval). Used when
+// evaluating a subquery so the child can record SamplesReadPerStep for incremental
+// attribution to outer steps.
+func NewChildWithStepTracking(enablePerStepStats bool, start, end, interval int64) *QuerySamples {
+	qs := NewQuerySamples(enablePerStepStats)
+	if enablePerStepStats {
+		qs.InitStepTracking(start, end, interval)
+	}
+	return qs
+}
+
+// MergeSamplesReadFromSubquery merges only SamplesRead and SamplesReadPerStep from
+// the child (subquery) into the parent. TotalSamples and TotalSamplesPerStep are
+// not merged, because the outer range-eval loop already counts those when it
+// iterates over the pre-computed matrix. This function ensures the outer query's
+// samples-read stats reflect the subquery's actual storage I/O.
+//
+// Precondition: the child must have been created with NewChildWithStepTracking
+// using the parent evaluator's (start, end, interval), so the child's step
+// indices map 1:1 to the parent's. In evalSubquery, the SubqueryExpr case maps
+// inner subquery steps to the child's (= parent's) step indices via time-based
+// attribution before this function is called, making the 1:1 index merge correct.
+func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples) {
+	if qs == nil || child == nil {
+		return
+	}
+	qs.SamplesRead += child.SamplesRead
+	if qs.SamplesReadPerStep != nil && child.SamplesReadPerStep != nil {
+		for i := 0; i < len(qs.SamplesReadPerStep) && i < len(child.SamplesReadPerStep); i++ {
+			qs.SamplesReadPerStep[i] += child.SamplesReadPerStep[i]
+		}
+	}
 }
 
 func (qs *QueryTimers) GetSpanTimer(ctx context.Context, qt QueryTiming, observers ...prometheus.Observer) (*SpanTimer, context.Context) {

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -51,6 +51,8 @@ func TestQueryStatsWithTimersAndSamples(t *testing.T) {
 	timer.Stop()
 	qs.IncrementSamplesAtTimestamp(20001000, 5)
 	qs.IncrementSamplesAtTimestamp(25001000, 5)
+	qs.IncrementSamplesReadAtTimestamp(20001000, 5)
+	qs.IncrementSamplesReadAtTimestamp(25001000, 5)
 
 	qstats := NewQueryStats(&Statistics{Timers: qt, Samples: qs})
 	actual, err := json.Marshal(qstats)
@@ -62,6 +64,8 @@ func TestQueryStatsWithTimersAndSamples(t *testing.T) {
 
 	require.Regexpf(t, `[,{]"totalQueryableSamples":10[,}]`, string(actual), "expected totalQueryableSamples")
 	require.Regexpf(t, `[,{]"totalQueryableSamplesPerStep":\[\[20001,5\],\[21001,0\],\[22001,0\],\[23001,0\],\[24001,0\],\[25001,5\]\]`, string(actual), "expected totalQueryableSamplesPerStep")
+	require.Regexpf(t, `[,{]"samplesRead":10[,}]`, string(actual), "expected samplesRead")
+	require.Regexpf(t, `[,{]"samplesReadPerStep":\[\[20001,5\],\[21001,0\],\[22001,0\],\[23001,0\],\[24001,0\],\[25001,5\]\]`, string(actual), "expected samplesReadPerStep")
 }
 
 func TestQueryStatsWithSpanTimers(t *testing.T) {

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -84,6 +84,69 @@ func TestQueryStatsWithSpanTimers(t *testing.T) {
 	require.True(t, match, "Expected timings with one non-zero entry.")
 }
 
+func TestMergeSamplesReadFromSubquery(t *testing.T) {
+	const start, end, interval int64 = 1000, 3000, 1000
+
+	parent := NewQuerySamples(true)
+	parent.InitStepTracking(start, end, interval)
+	parent.SamplesReadPerStep[0] = 1
+	parent.SamplesReadPerStep[1] = 2
+	parent.SamplesReadPerStep[2] = 3
+	parent.SamplesRead = 6
+
+	child := NewChildWithStepTracking(true, start, end, interval)
+	child.SamplesReadPerStep[0] = 10
+	child.SamplesReadPerStep[1] = 20
+	child.SamplesReadPerStep[2] = 30
+	child.SamplesRead = 60
+
+	parent.MergeSamplesReadFromSubquery(child)
+
+	require.Equal(t, int64(66), parent.SamplesRead)
+	require.Equal(t, []int64{11, 22, 33}, parent.SamplesReadPerStep)
+}
+
+func TestMergeSamplesReadFromSubquery_offsetsChildGrid(t *testing.T) {
+	parent := NewQuerySamples(true)
+	parent.InitStepTracking(1000, 3000, 1000)
+	parent.SamplesReadPerStep[1] = 5
+	parent.SamplesRead = 5
+
+	child := NewQuerySamples(true)
+	child.InitStepTracking(2000, 4000, 1000)
+	child.SamplesReadPerStep[1] = 100 // tk=3000 → parent step 2
+	child.SamplesRead = 100
+
+	parent.MergeSamplesReadFromSubquery(child)
+
+	require.Equal(t, int64(105), parent.SamplesRead)
+	require.Equal(t, []int64{0, 5, 100}, parent.SamplesReadPerStep)
+}
+
+func TestMergeSamplesReadFromSubquery_childBeforeAndAfterParentWindow(t *testing.T) {
+	parent := NewQuerySamples(true)
+	parent.InitStepTracking(5000, 7000, 1000)
+	parent.SamplesRead = 0
+
+	child := NewQuerySamples(true)
+	child.InitStepTracking(1000, 9000, 1000)
+	for i := range child.SamplesReadPerStep {
+		child.SamplesReadPerStep[i] = 1
+	}
+	child.SamplesRead = int64(len(child.SamplesReadPerStep))
+
+	parent.MergeSamplesReadFromSubquery(child)
+
+	require.Equal(t, child.SamplesRead, parent.SamplesRead)
+	var sum int64
+	for _, v := range parent.SamplesReadPerStep {
+		sum += v
+	}
+	require.Equal(t, parent.SamplesRead, sum, "per-step sum should match merged SamplesRead")
+	// tk 1000..5000 (k=0..4) → step 0; tk 6000 → step 1; tk 7000 → step 2; tk 8000,9000 → last step.
+	require.Equal(t, []int64{5, 1, 3}, parent.SamplesReadPerStep)
+}
+
 func TestTimerGroup(t *testing.T) {
 	tg := NewTimerGroup()
 	require.Equal(t, "Exec total time: 0s", tg.GetTimer(ExecTotalTime).String())

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -100,7 +100,7 @@ func TestMergeSamplesReadFromSubquery(t *testing.T) {
 	child.SamplesReadPerStep[2] = 30
 	child.SamplesRead = 60
 
-	parent.MergeSamplesReadFromSubquery(child)
+	parent.MergeSamplesReadFromSubquery(child, 0)
 
 	require.Equal(t, int64(66), parent.SamplesRead)
 	require.Equal(t, []int64{11, 22, 33}, parent.SamplesReadPerStep)
@@ -114,10 +114,10 @@ func TestMergeSamplesReadFromSubquery_offsetsChildGrid(t *testing.T) {
 
 	child := NewQuerySamples(true)
 	child.InitStepTracking(2000, 4000, 1000)
-	child.SamplesReadPerStep[1] = 100 // tk=3000 → parent step 2
+	child.SamplesReadPerStep[1] = 100 // tk=3000 -> parent step 2
 	child.SamplesRead = 100
 
-	parent.MergeSamplesReadFromSubquery(child)
+	parent.MergeSamplesReadFromSubquery(child, 0)
 
 	require.Equal(t, int64(105), parent.SamplesRead)
 	require.Equal(t, []int64{0, 5, 100}, parent.SamplesReadPerStep)
@@ -135,7 +135,7 @@ func TestMergeSamplesReadFromSubquery_childBeforeAndAfterParentWindow(t *testing
 	}
 	child.SamplesRead = int64(len(child.SamplesReadPerStep))
 
-	parent.MergeSamplesReadFromSubquery(child)
+	parent.MergeSamplesReadFromSubquery(child, 0)
 
 	require.Equal(t, child.SamplesRead, parent.SamplesRead)
 	var sum int64
@@ -143,8 +143,58 @@ func TestMergeSamplesReadFromSubquery_childBeforeAndAfterParentWindow(t *testing
 		sum += v
 	}
 	require.Equal(t, parent.SamplesRead, sum, "per-step sum should match merged SamplesRead")
-	// tk 1000..5000 (k=0..4) → step 0; tk 6000 → step 1; tk 7000 → step 2; tk 8000,9000 → last step.
+	// tk 1000..5000 (k=0..4) -> step 0; tk 6000 -> step 1; tk 7000 -> step 2; tk 8000,9000 -> last step.
 	require.Equal(t, []int64{5, 1, 3}, parent.SamplesReadPerStep)
+}
+
+func TestMergeSamplesReadFromSubquery_windowed(t *testing.T) {
+	// Parent: step=1000, range=500. Windows: [500,1000], [1500,2000], [2500,3000].
+	// Child steps at 100-unit intervals from 500 to 3000.
+	parent := NewQuerySamples(true)
+	parent.InitStepTracking(1000, 3000, 1000)
+	parent.SamplesRead = 0
+
+	child := NewQuerySamples(true)
+	child.InitStepTracking(500, 3000, 100)
+	for i := range child.SamplesReadPerStep {
+		child.SamplesReadPerStep[i] = 1
+	}
+	child.SamplesRead = int64(len(child.SamplesReadPerStep))
+
+	parent.MergeSamplesReadFromSubquery(child, 500)
+
+	// Step 0 window (500,1000]: tk=600,700,800,900,1000 -> 5.
+	// Step 1 window (1500,2000]: tk=1600,1700,1800,1900,2000 -> 5.
+	// Step 2 window (2500,3000]: tk=2600,2700,2800,2900,3000 -> 5.
+	// Boundary and gap steps are not attributed.
+	require.Equal(t, int64(15), parent.SamplesRead)
+	require.Equal(t, []int64{5, 5, 5}, parent.SamplesReadPerStep)
+}
+
+func TestMergeSamplesReadFromSubquery_windowedNoGaps(t *testing.T) {
+	// When interval <= range, there are no gaps and all child steps are attributed.
+	parent := NewQuerySamples(true)
+	parent.InitStepTracking(1000, 3000, 1000)
+	parent.SamplesRead = 0
+
+	child := NewQuerySamples(true)
+	child.InitStepTracking(0, 3000, 100)
+	for i := range child.SamplesReadPerStep {
+		child.SamplesReadPerStep[i] = 1
+	}
+	child.SamplesRead = int64(len(child.SamplesReadPerStep))
+
+	parent.MergeSamplesReadFromSubquery(child, 1000)
+
+	// range=1000 equals interval=1000, so windows tile perfectly with no gaps.
+	// The first child step (tk=0) falls on the boundary of step 0 and is
+	// excluded: the window is (parentTs-range, parentTs] = (0, 1000].
+	require.Equal(t, child.SamplesRead-1, parent.SamplesRead)
+	var sum int64
+	for _, v := range parent.SamplesReadPerStep {
+		sum += v
+	}
+	require.Equal(t, parent.SamplesRead, sum)
 }
 
 func TestTimerGroup(t *testing.T) {

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -100,7 +100,7 @@ func TestMergeSamplesReadFromSubquery(t *testing.T) {
 	child.SamplesReadPerStep[2] = 30
 	child.SamplesRead = 60
 
-	parent.MergeSamplesReadFromSubquery(child, 0)
+	parent.MergeSamplesReadFromSubquery(child)
 
 	require.Equal(t, int64(66), parent.SamplesRead)
 	require.Equal(t, []int64{11, 22, 33}, parent.SamplesReadPerStep)
@@ -117,7 +117,7 @@ func TestMergeSamplesReadFromSubquery_offsetsChildGrid(t *testing.T) {
 	child.SamplesReadPerStep[1] = 100 // tk=3000 -> parent step 2
 	child.SamplesRead = 100
 
-	parent.MergeSamplesReadFromSubquery(child, 0)
+	parent.MergeSamplesReadFromSubquery(child)
 
 	require.Equal(t, int64(105), parent.SamplesRead)
 	require.Equal(t, []int64{0, 5, 100}, parent.SamplesReadPerStep)
@@ -135,7 +135,7 @@ func TestMergeSamplesReadFromSubquery_childBeforeAndAfterParentWindow(t *testing
 	}
 	child.SamplesRead = int64(len(child.SamplesReadPerStep))
 
-	parent.MergeSamplesReadFromSubquery(child, 0)
+	parent.MergeSamplesReadFromSubquery(child)
 
 	require.Equal(t, child.SamplesRead, parent.SamplesRead)
 	var sum int64
@@ -145,56 +145,6 @@ func TestMergeSamplesReadFromSubquery_childBeforeAndAfterParentWindow(t *testing
 	require.Equal(t, parent.SamplesRead, sum, "per-step sum should match merged SamplesRead")
 	// tk 1000..5000 (k=0..4) -> step 0; tk 6000 -> step 1; tk 7000 -> step 2; tk 8000,9000 -> last step.
 	require.Equal(t, []int64{5, 1, 3}, parent.SamplesReadPerStep)
-}
-
-func TestMergeSamplesReadFromSubquery_windowed(t *testing.T) {
-	// Parent: step=1000, range=500. Windows: [500,1000], [1500,2000], [2500,3000].
-	// Child steps at 100-unit intervals from 500 to 3000.
-	parent := NewQuerySamples(true)
-	parent.InitStepTracking(1000, 3000, 1000)
-	parent.SamplesRead = 0
-
-	child := NewQuerySamples(true)
-	child.InitStepTracking(500, 3000, 100)
-	for i := range child.SamplesReadPerStep {
-		child.SamplesReadPerStep[i] = 1
-	}
-	child.SamplesRead = int64(len(child.SamplesReadPerStep))
-
-	parent.MergeSamplesReadFromSubquery(child, 500)
-
-	// Step 0 window (500,1000]: tk=600,700,800,900,1000 -> 5.
-	// Step 1 window (1500,2000]: tk=1600,1700,1800,1900,2000 -> 5.
-	// Step 2 window (2500,3000]: tk=2600,2700,2800,2900,3000 -> 5.
-	// Boundary and gap steps are not attributed.
-	require.Equal(t, int64(15), parent.SamplesRead)
-	require.Equal(t, []int64{5, 5, 5}, parent.SamplesReadPerStep)
-}
-
-func TestMergeSamplesReadFromSubquery_windowedNoGaps(t *testing.T) {
-	// When interval <= range, there are no gaps and all child steps are attributed.
-	parent := NewQuerySamples(true)
-	parent.InitStepTracking(1000, 3000, 1000)
-	parent.SamplesRead = 0
-
-	child := NewQuerySamples(true)
-	child.InitStepTracking(0, 3000, 100)
-	for i := range child.SamplesReadPerStep {
-		child.SamplesReadPerStep[i] = 1
-	}
-	child.SamplesRead = int64(len(child.SamplesReadPerStep))
-
-	parent.MergeSamplesReadFromSubquery(child, 1000)
-
-	// range=1000 equals interval=1000, so windows tile perfectly with no gaps.
-	// The first child step (tk=0) falls on the boundary of step 0 and is
-	// excluded: the window is (parentTs-range, parentTs] = (0, 1000].
-	require.Equal(t, child.SamplesRead-1, parent.SamplesRead)
-	var sum int64
-	for _, v := range parent.SamplesReadPerStep {
-		sum += v
-	}
-	require.Equal(t, parent.SamplesRead, sum)
 }
 
 func TestTimerGroup(t *testing.T) {

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -93,6 +93,8 @@ func TestMergeSamplesReadFromSubquery(t *testing.T) {
 		name            string
 		parent          stepGrid
 		child           stepGrid
+		outerOffset     int64
+		outerRange      int64
 		wantPerStep     []int64
 		wantSamplesRead int64
 	}{
@@ -120,6 +122,40 @@ func TestMergeSamplesReadFromSubquery(t *testing.T) {
 			wantPerStep:     []int64{5, 1, 3},
 			wantSamplesRead: 9,
 		},
+		{
+			// Parent step 60s, outer range 30s: window per step is (parentTs-30, parentTs].
+			// Child grid at 10s; tk values 10/20/30k -> step 0 window (0,30k];
+			// 70/80/90k -> step 1 window (60k,90k]; 40/50/60k fall in gap (30k,60k].
+			name:            "outerRangeExcludesGapSamples",
+			parent:          stepGrid{30000, 90000, 60000, []int64{0, 0}},
+			child:           stepGrid{10000, 90000, 10000, []int64{1, 1, 1, 1, 1, 1, 1, 1, 1}},
+			outerRange:      30000,
+			wantPerStep:     []int64{3, 3},
+			wantSamplesRead: 6,
+		},
+		{
+			// outerRange=0 disables filtering even when the parent has a wider step
+			// than the child's range; preserves old behaviour for bare-subquery merges.
+			name:            "outerRangeZeroDisablesGapFilter",
+			parent:          stepGrid{30000, 90000, 60000, []int64{0, 0}},
+			child:           stepGrid{10000, 90000, 10000, []int64{1, 1, 1, 1, 1, 1, 1, 1, 1}},
+			wantPerStep:     []int64{3, 6},
+			wantSamplesRead: 9,
+		},
+		{
+			// Offset 60s shifts child tk forward before matching the parent grid.
+			// Parent instant at T=240000 (start=end, interval=1, single step).
+			// Child iterations at tk=170000, 180000 (already shifted earlier by the
+			// subquery's offset); shifted tk+60000 = 230000, 240000 falls inside the
+			// outer window (240000-20000, 240000] = (220000, 240000].
+			name:            "outerOffsetShiftsTkIntoWindow",
+			parent:          stepGrid{240000, 240000, 1, []int64{0}},
+			child:           stepGrid{170000, 180000, 10000, []int64{1, 1}},
+			outerOffset:     60000,
+			outerRange:      20000,
+			wantPerStep:     []int64{2},
+			wantSamplesRead: 2,
+		},
 	}
 
 	for _, tc := range cases {
@@ -131,13 +167,13 @@ func TestMergeSamplesReadFromSubquery(t *testing.T) {
 				parent.SamplesRead += v
 			}
 
-			child := NewChildWithStepTracking(true, tc.child.start, tc.child.end, tc.child.interval)
+			child := NewChildWithStepTracking(tc.child.start, tc.child.end, tc.child.interval)
 			copy(child.SamplesReadPerStep, tc.child.perStep)
 			for _, v := range tc.child.perStep {
 				child.SamplesRead += v
 			}
 
-			parent.MergeSamplesReadFromSubquery(child)
+			parent.MergeSamplesReadFromSubquery(child, tc.parent.start, tc.parent.interval, len(tc.parent.perStep), tc.outerOffset, tc.outerRange)
 
 			require.Equal(t, tc.wantSamplesRead, parent.SamplesRead)
 			require.Equal(t, tc.wantPerStep, parent.SamplesReadPerStep)

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -85,66 +85,64 @@ func TestQueryStatsWithSpanTimers(t *testing.T) {
 }
 
 func TestMergeSamplesReadFromSubquery(t *testing.T) {
-	const start, end, interval int64 = 1000, 3000, 1000
-
-	parent := NewQuerySamples(true)
-	parent.InitStepTracking(start, end, interval)
-	parent.SamplesReadPerStep[0] = 1
-	parent.SamplesReadPerStep[1] = 2
-	parent.SamplesReadPerStep[2] = 3
-	parent.SamplesRead = 6
-
-	child := NewChildWithStepTracking(true, start, end, interval)
-	child.SamplesReadPerStep[0] = 10
-	child.SamplesReadPerStep[1] = 20
-	child.SamplesReadPerStep[2] = 30
-	child.SamplesRead = 60
-
-	parent.MergeSamplesReadFromSubquery(child)
-
-	require.Equal(t, int64(66), parent.SamplesRead)
-	require.Equal(t, []int64{11, 22, 33}, parent.SamplesReadPerStep)
-}
-
-func TestMergeSamplesReadFromSubquery_offsetsChildGrid(t *testing.T) {
-	parent := NewQuerySamples(true)
-	parent.InitStepTracking(1000, 3000, 1000)
-	parent.SamplesReadPerStep[1] = 5
-	parent.SamplesRead = 5
-
-	child := NewQuerySamples(true)
-	child.InitStepTracking(2000, 4000, 1000)
-	child.SamplesReadPerStep[1] = 100 // tk=3000 -> parent step 2
-	child.SamplesRead = 100
-
-	parent.MergeSamplesReadFromSubquery(child)
-
-	require.Equal(t, int64(105), parent.SamplesRead)
-	require.Equal(t, []int64{0, 5, 100}, parent.SamplesReadPerStep)
-}
-
-func TestMergeSamplesReadFromSubquery_childBeforeAndAfterParentWindow(t *testing.T) {
-	parent := NewQuerySamples(true)
-	parent.InitStepTracking(5000, 7000, 1000)
-	parent.SamplesRead = 0
-
-	child := NewQuerySamples(true)
-	child.InitStepTracking(1000, 9000, 1000)
-	for i := range child.SamplesReadPerStep {
-		child.SamplesReadPerStep[i] = 1
+	type stepGrid struct {
+		start, end, interval int64
+		perStep              []int64
 	}
-	child.SamplesRead = int64(len(child.SamplesReadPerStep))
-
-	parent.MergeSamplesReadFromSubquery(child)
-
-	require.Equal(t, child.SamplesRead, parent.SamplesRead)
-	var sum int64
-	for _, v := range parent.SamplesReadPerStep {
-		sum += v
+	cases := []struct {
+		name            string
+		parent          stepGrid
+		child           stepGrid
+		wantPerStep     []int64
+		wantSamplesRead int64
+	}{
+		{
+			name:            "alignedChildGridAddsToParentSteps",
+			parent:          stepGrid{1000, 3000, 1000, []int64{1, 2, 3}},
+			child:           stepGrid{1000, 3000, 1000, []int64{10, 20, 30}},
+			wantPerStep:     []int64{11, 22, 33},
+			wantSamplesRead: 66,
+		},
+		{
+			name:            "offsetChildGridAttributesByTimestamp",
+			parent:          stepGrid{1000, 3000, 1000, []int64{0, 5, 0}},
+			child:           stepGrid{2000, 4000, 1000, []int64{0, 100, 0}}, // tk=3000 -> parent step 2.
+			wantPerStep:     []int64{0, 5, 100},
+			wantSamplesRead: 105,
+		},
+		{
+			// Child spans 1000..9000 (9 steps). Steps with tk <= parentStart=5000
+			// (k=0..4) clamp to parent step 0; tk=6000 -> step 1; tk=7000 -> step 2;
+			// tk=8000,9000 clamp to the last parent step (also 2).
+			name:            "childBeforeAndAfterParentWindowClampsToEndpoints",
+			parent:          stepGrid{5000, 7000, 1000, []int64{0, 0, 0}},
+			child:           stepGrid{1000, 9000, 1000, []int64{1, 1, 1, 1, 1, 1, 1, 1, 1}},
+			wantPerStep:     []int64{5, 1, 3},
+			wantSamplesRead: 9,
+		},
 	}
-	require.Equal(t, parent.SamplesRead, sum, "per-step sum should match merged SamplesRead")
-	// tk 1000..5000 (k=0..4) -> step 0; tk 6000 -> step 1; tk 7000 -> step 2; tk 8000,9000 -> last step.
-	require.Equal(t, []int64{5, 1, 3}, parent.SamplesReadPerStep)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parent := NewQuerySamples(true)
+			parent.InitStepTracking(tc.parent.start, tc.parent.end, tc.parent.interval)
+			copy(parent.SamplesReadPerStep, tc.parent.perStep)
+			for _, v := range tc.parent.perStep {
+				parent.SamplesRead += v
+			}
+
+			child := NewChildWithStepTracking(true, tc.child.start, tc.child.end, tc.child.interval)
+			copy(child.SamplesReadPerStep, tc.child.perStep)
+			for _, v := range tc.child.perStep {
+				child.SamplesRead += v
+			}
+
+			parent.MergeSamplesReadFromSubquery(child)
+
+			require.Equal(t, tc.wantSamplesRead, parent.SamplesRead)
+			require.Equal(t, tc.wantPerStep, parent.SamplesReadPerStep)
+		})
+	}
 }
 
 func TestTimerGroup(t *testing.T) {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -981,6 +981,7 @@ func TestStats(t *testing.T) {
 				require.NotNil(t, qs.Samples)
 				require.NotNil(t, qs.Samples.TotalQueryableSamples)
 				require.Nil(t, qs.Samples.TotalQueryableSamplesPerStep)
+				require.GreaterOrEqual(t, qs.Samples.SamplesRead, int64(0))
 			},
 		},
 		{
@@ -996,6 +997,8 @@ func TestStats(t *testing.T) {
 				require.NotNil(t, qs.Samples)
 				require.NotNil(t, qs.Samples.TotalQueryableSamples)
 				require.NotNil(t, qs.Samples.TotalQueryableSamplesPerStep)
+				require.GreaterOrEqual(t, qs.Samples.SamplesRead, int64(0))
+				require.NotNil(t, qs.Samples.SamplesReadPerStep)
 			},
 		},
 		{

--- a/web/api/v1/openapi_schemas.go
+++ b/web/api/v1/openapi_schemas.go
@@ -593,6 +593,21 @@ func (*OpenAPIBuilder) queryStatsSchema() *base.SchemaProxy {
 			MaxItems:    int64Ptr(2),
 		})},
 	}))
+	samplesProps.Set("samplesRead", base.CreateSchemaProxy(&base.Schema{
+		Type:        []string{"integer"},
+		Description: "Total number of samples read (I/O). For range-vector in range queries, only new points per step.",
+	}))
+	samplesProps.Set("samplesReadPerStep", base.CreateSchemaProxy(&base.Schema{
+		Type:        []string{"array"},
+		Description: "Samples read per step (only included with stats=all when per-step stats enabled).",
+		Items: &base.DynamicValue[*base.SchemaProxy, bool]{A: base.CreateSchemaProxy(&base.Schema{
+			Type:        []string{"array"},
+			Description: "Timestamp and sample count as [timestamp, count].",
+			Items:       &base.DynamicValue[*base.SchemaProxy, bool]{A: base.CreateSchemaProxy(&base.Schema{Type: []string{"number"}})},
+			MinItems:    int64Ptr(2),
+			MaxItems:    int64Ptr(2),
+		})},
+	}))
 
 	// Main stats object.
 	statsProps := orderedmap.New[string, *base.SchemaProxy]()

--- a/web/api/v1/testdata/openapi_3.1_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.1_golden.yaml
@@ -3777,6 +3777,19 @@ components:
                                 minItems: 2
                                 description: Timestamp and sample count as [timestamp, count].
                             description: Total queryable samples per step (only included with stats=all).
+                        samplesRead:
+                            type: integer
+                            description: Total number of samples read (I/O). For range-vector in range queries, only new points per step.
+                        samplesReadPerStep:
+                            type: array
+                            items:
+                                type: array
+                                items:
+                                    type: number
+                                maxItems: 2
+                                minItems: 2
+                                description: Timestamp and sample count as [timestamp, count].
+                            description: Samples read per step (only included with stats=all when per-step stats enabled).
             description: Query execution statistics (included when the stats query parameter is provided).
         FloatSample:
             type: object

--- a/web/api/v1/testdata/openapi_3.2_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.2_golden.yaml
@@ -3815,6 +3815,19 @@ components:
                                 minItems: 2
                                 description: Timestamp and sample count as [timestamp, count].
                             description: Total queryable samples per step (only included with stats=all).
+                        samplesRead:
+                            type: integer
+                            description: Total number of samples read (I/O). For range-vector in range queries, only new points per step.
+                        samplesReadPerStep:
+                            type: array
+                            items:
+                                type: array
+                                items:
+                                    type: number
+                                maxItems: 2
+                                minItems: 2
+                                description: Timestamp and sample count as [timestamp, count].
+                            description: Samples read per step (only included with stats=all when per-step stats enabled).
             description: Query execution statistics (included when the stats query parameter is provided).
         FloatSample:
             type: object


### PR DESCRIPTION
## Summary

This PR adds two optional fields to query statistics so that API consumers can see how many samples were read from storage (I/O) to execute a query: **samplesRead** (total over the whole query) and **samplesReadPerStep** (per evaluation step when per-step stats are enabled).

Prometheus's existing `totalQueryableSamples` counts each sample every time it enters a range-vector window, which inflates the number for queries that reuse the same data across many steps (e.g. `rate(metric[1m])` over a 5-minute range with a 10-second step counts each sample roughly six times). The new `samplesRead` accounting reports unique points read, so operators and capacity planners can tell apart "this query reads a lot of data" from "this query operates over the same data many times".

While wiring this up, three pre-existing accounting bugs surfaced in the same code paths and are fixed in dedicated commits (one of them is also being submitted as #18598).

## Motivation

`totalQueryableSamples` is consumed by:

- The `/api/v1/query{,_range}` stats response (visible in Grafana / explore-style UIs).
- The `prometheus_engine_query_samples_total` engine counter (operators sum this for capacity planning).
- Indirectly informs the `query.max-samples` limit decisions via `peakSamples`.

The key difference from the existing **TotalSamples** / **TotalSamplesPerStep** is how range-vector functions in range queries are counted:

- **TotalSamples** counts the full window at each step (points may be counted in multiple steps).
- **SamplesRead** counts only *new* points per step -- step 0 gets the full window, later steps get only points after `maxt - interval` (the delta). This gives a more useful approximation of actual storage I/O.

For subqueries, each child step's samples-read is attributed to the earliest parent step whose timestamp is >= the child timestamp (`MergeSamplesReadFromSubquery`). This ensures `sum(samplesReadPerStep) == samplesRead`. TotalSamples and TotalSamplesPerStep for subqueries continue to be handled as on main (no change).

For `StepInvariantExpr` (e.g. `@ modifier`), the child's SamplesRead is added to the parent once at step 0 (not per outer step), since the subquery executes only once.

## What this PR adds

### New user-visible API surface

The new counter is exposed in three places:

- **`samplesRead`** in the query stats response, available whenever stats are requested. Equivalent to `totalQueryableSamples` but with delta semantics for range-vector functions.
- **`samplesReadPerStep`** in the query stats response, only populated with `stats=all` and the existing `promql-per-step-stats` feature flag. Mirrors the existing `totalQueryableSamplesPerStep` but with delta semantics.
- **`prometheus_engine_query_samples_read_total`** Prometheus counter, the cumulative samples-read across all queries since process start. Mirrors the existing `prometheus_engine_query_samples_total`.

`docs/feature_flags.md`, `docs/querying/api.md` and the OpenAPI schemas are updated accordingly.

Initial implementation: `5f54d9140 promql: track samples read per query`.

### Subquery merge attribution

For nested subqueries the merge into the parent has to attribute the child's per-step samples to the parent's step grid by timestamp (because the two grids may not align — the subquery has its own `step` and may start before the parent's start due to the `range` look-back). `999daaca1 promql: attribute subquery samples-read by timestamp during merge` generalises `MergeSamplesReadFromSubquery` so callers can pass children with arbitrary bounds: each child step is attributed to the smallest parent step whose timestamp is `>=` the child's timestamp; child steps before the first parent step are clamped to step 0, and child steps past the last are clamped to the last.

### Range-vector inside subquery

`673487dfd promql: count only subquery samples that contribute to output` refines the semantics for range-vector functions over subqueries so the count reflects what the outer call actually consumes from each step's window, not the entire matrix the subquery produced. Adds a `countSamplesAfter` helper for the per-step delta.

## Bug fixes uncovered along the way

### Subquery `endTimestamp` not aligned to the parent's step grid

`5b3223cb2 promql: align subquery end timestamp to parent's step grid` (also submitted as #18598).

When a range query's end timestamp is not aligned to the step grid (i.e. `end != start + N*step`), the parent evaluator's outer loop only iterates up to the last aligned step, but a subquery inside the query was being given `newEv.endTimestamp = ev.endTimestamp - offset`. The inner subquery evaluator therefore iterated past the parent's last actual step, producing a larger intermediate matrix than the parent could ever consume. The extra samples are silently ignored by the outer call/range loop so query results are unchanged, but they:

- Inflate `peakSamples`, which is reported in the stats response **and** is checked against the `query.max-samples` limit (so a query may now hit the limit only because of the unaligned tail).
- Waste storage I/O reading the underlying samples.

Five existing `TestQueryStatistics` cases (`start=201, end=220, step=5`, last aligned step at 216) had `PeakSamples` expectations locking in the inflated values; those are corrected in the same commit.

> If #18598 lands first, drop this commit during rebase. If this PR lands first, #18598 becomes a duplicate.

### `TotalSamples` under-counted for `@`-modifier range-vector queries

`f64c4ec3a promql: count full window per step for @-modifier range-vector functions`.

The earlier samples-read refactor accidentally moved the `fullWindowCount` computation inside the conditional that re-evaluates the matrix selector, which only runs on step 0 when an `@` modifier is set. This left `fullWindowCount = 0` for every subsequent step, so `totalQueryableSamples` silently under-counted `@`-modifier range-vector queries that did not get hoisted into a step-invariant expression — for example `predict_linear(metric[60s] @ T, X)` over a range query (`predict_linear` is in `AtModifierUnsafeFunctions` and so is not wrapped in a `StepInvariantExpr`).

Regression test added: `TestQueryStatistics/predict_linear(metricWith1SampleEvery10Seconds[60s] @ 100, 60)`.

### Duplicated subquery-evaluator construction

`69244eb69 promql: extract runSubquery helper, drop intermediate stats child`.

`evalSubquery` (called from the call/range-vector branch when a function takes a subquery as a matrix argument) and the `*parser.SubqueryExpr` case in `eval()` both build a step-aligned child evaluator for the subquery, with subtly different code. `evalSubquery` additionally allocated an intermediate stats child whose only purpose was to absorb the `IncrementSamplesAtTimestamp` call from the recursion (so it did not double-count the subquery's samples into the parent's `TotalSamples`).

Extracted into a single `runSubquery` helper. Each caller now decides how to merge into the parent: the `*parser.SubqueryExpr` case absorbs `TotalSamples` via `IncrementSamplesAtTimestamp`, while `evalSubquery` skips that step (its caller re-counts from the materialised matrix). The intermediate stats layer is gone.

## Internal cleanups

- `db6b62582 promql: short-circuit subquery merge when parent lacks per-step stats` — fast path for the common case where per-step stats are disabled.
- `c201b703e util/stats: simplify per-step helpers and align bounds-check policy` — drops dead branches in `MergeSamplesReadFromSubquery`, removes redundant writes in `NewChildWithStepTracking`, makes the `IncrementSamplesRead*` bounds-check policy match the existing `IncrementSamples*` helpers (panic on out-of-range, since silently swallowing such writes would mask real step-index bugs).

## Tests

`f96cef11a promql,util/stats: clarify samples-read tests`:

- Each `TestQueryStatistics` case runs under both a `perStepEnabled` and a `perStepDisabled` subtest so failures clearly identify the failing mode. Otherwise reading `expected: 32, actual: 31` from a bare query name leaves the maintainer guessing whether it's the per-step or non-per-step path.
- `TestMergeSamplesReadFromSubquery_*` is consolidated into a single table-driven test covering aligned grids, offset grids, and clamping at the parent window boundaries.

Plus the regression coverage added by the bug-fix commits:

- `predict_linear(metric[60s] @ 100, 60)` for the `@`-modifier case (`f64c4ec3a`).
- Aligned/unaligned counterpart pairs for the subquery-end alignment (`5b3223cb2`).
- The existing inflated-`PeakSamples` cases corrected.

## Performance

`go test -count=6 -benchmem -bench BenchmarkRangeQuery ./promql/...` vs `origin/main`, after the profile-driven optimisations in `eb51671a0 promql: reduce per-step samples-read counting overhead`:

- No statistically significant regression on dense-metric cases (`rate(a_one[1m])`, `rate(a_hundred[1m])`, `changes(a_hundred[1d])`, `absent_over_time(a_hundred[1d])` at all step counts show `~` at p<0.05).
- Sparse-metric cases (`rate(sparse[1m]),steps=10000`, `rate(sparse[1m] smoothed),steps=10000`) retain a ~8% overhead from the additional samples-read accounting in the hot path.

The first benchstat pass (before optimisations) showed `rate(sparse[1m]),steps=10000` at +39.29% and `rate(a_one[1m]),steps=1000` at +15.76%. Profile-driven changes that brought those down to +8.16% and `~` respectively:

- Empty-window early `continue` runs before the new accounting so sparse queries skip it entirely.
- `fullWindowCount` is computed once per step and reused for `samplesReadCount` at step 0 (instead of calling `totalHPointSize` twice).
- `countSamplesAfter` uses a backwards linear scan instead of `sort.Search` with a closure. For the 1-2 new points per step typical of range-vector windows at normal step sizes, linear scan beats binary search by avoiding closure overhead.
- `IncrementSamplesReadAtStep` is skipped when the delta is zero, common on `@`-modifier and step-invariant queries.

The remaining ~8% on sparse cases is inherent to counting samples per step; we can't skip the count when per-step stats are disabled because the engine-level `prometheus_engine_query_samples_read_total` counter is always maintained.

## Commit list

```
eb51671a0 promql: reduce per-step samples-read counting overhead
f96cef11a promql,util/stats: clarify samples-read tests
c201b703e util/stats: simplify per-step helpers and align bounds-check policy
69244eb69 promql: extract runSubquery helper, drop intermediate stats child
f64c4ec3a promql: count full window per step for @-modifier range-vector functions
db6b62582 promql: short-circuit subquery merge when parent lacks per-step stats
5b3223cb2 promql: align subquery end timestamp to parent's step grid
673487dfd promql: count only subquery samples that contribute to output
999daaca1 promql: attribute subquery samples-read by timestamp during merge
5f54d9140 promql: track samples read per query
```

Each commit compiles, passes `go test ./promql/... ./util/stats/...`, and has its own self-contained body explaining the change.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[FEATURE] PromQL: Expose per-query `samplesRead` (and `samplesReadPerStep` with `stats=all` and the `promql-per-step-stats` feature flag) in the query stats response, and add the `prometheus_engine_query_samples_read_total` engine counter. `samplesRead` reflects storage I/O distinct from `totalQueryableSamples`, which counts samples loaded into the evaluator (and so over-counts when a sample is reused across multiple range-vector windows).
[BUGFIX] PromQL: A range query whose `end` was not aligned to `step` caused subqueries inside it to evaluate past the parent's last actual step, inflating `peakSamples` in the query stats and against the `query.max-samples` limit, and wasting storage I/O reading samples that were never used in the result.
[BUGFIX] PromQL: A range query containing an at-modifier-unsafe function over a range-vector with an `@` modifier (e.g. `predict_linear(metric[60s] @ T, X)`) silently under-counted `totalQueryableSamples` for steps after step 0.
```

## Checklist

- [x] Branch from main, rebase if needed.
- [x] Commits are small and signed off (`git commit -s`).
- [x] Tests added/updated (TestQueryStatistics, per-step-disabled parity, stats_test.go).
- [x] TotalSamples/TotalSamplesPerStep expectations match main for existing use-cases.
- [x] API/docs updated for samplesRead and samplesReadPerStep.
- [x] Exported symbols have comments (capital letter, full stop).
- [x] `make test` and `make lint` pass.