### PR TITLE
web/api: remove deprecated DELETE /api/v1/series endpoint

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -443,7 +443,6 @@ func (api *API) Register(r *route.Router) {
 
 	r.Get("/series", wrapAgent(api.series))
 	r.Post("/series", wrapAgent(api.series))
-	r.Del("/series", wrapAgent(api.dropSeries))
 
 	r.Get("/scrape_pools", wrap(api.scrapePools))
 	r.Get("/targets", wrap(api.targets))
@@ -1045,10 +1044,6 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 	}
 
 	return apiFuncResult{metrics, nil, warnings, closer}
-}
-
-func (*API) dropSeries(*http.Request) apiFuncResult {
-	return apiFuncResult{nil, &apiError{errorInternal, errors.New("not implemented")}, nil, nil}
 }
 
 // Target has the information for one target.

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1769,10 +1769,6 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 			errType:  errorBadData,
 		},
 		{
-			endpoint: api.dropSeries,
-			errType:  errorInternal,
-		},
-		{
 			endpoint: api.targets,
 			response: &TargetDiscovery{
 				ActiveTargets: []*Target{

--- a/web/api/v1/openapi_examples.go
+++ b/web/api/v1/openapi_examples.go
@@ -914,20 +914,6 @@ func cleanTombstonesResponseExamples() *orderedmap.Map[string, *base.Example] {
 	return examples
 }
 
-// seriesDeleteResponseExamples returns examples for DELETE /series response.
-func seriesDeleteResponseExamples() *orderedmap.Map[string, *base.Example] {
-	examples := orderedmap.New[string, *base.Example]()
-
-	examples.Set("seriesDeleted", &base.Example{
-		Summary: "Series marked for deletion",
-		Value: createYAMLNode(map[string]any{
-			"status": "success",
-		}),
-	})
-
-	return examples
-}
-
 // snapshotResponseExamples returns examples for /admin/tsdb/snapshot response.
 func snapshotResponseExamples() *orderedmap.Map[string, *base.Example] {
 	examples := orderedmap.New[string, *base.Example]()

--- a/web/api/v1/openapi_paths.go
+++ b/web/api/v1/openapi_paths.go
@@ -224,13 +224,6 @@ func (*OpenAPIBuilder) seriesPath() *v3.PathItem {
 			RequestBody: formRequestBodyWithExamples("SeriesPostInputBody", seriesPostExamples(), "Submit a series query. This endpoint accepts the same parameters as the GET version."),
 			Responses:   responsesWithErrorExamples("SeriesOutputBody", seriesResponseExamples(), errorResponseExamples(), "Series returned matching the provided label matchers via POST.", "Error retrieving series via POST."),
 		},
-		Delete: &v3.Operation{
-			OperationId: "delete-series",
-			Summary:     "Delete series",
-			Description: "Delete series matching selectors. Note: This is deprecated, use POST /admin/tsdb/delete_series instead.",
-			Tags:        []string{"series"},
-			Responses:   responsesWithErrorExamples("SeriesDeleteOutputBody", seriesDeleteResponseExamples(), errorResponseExamples(), "Series marked for deletion.", "Error deleting series."),
-		},
 	}
 }
 

--- a/web/api/v1/testdata/openapi_3.1_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.1_golden.yaml
@@ -1182,37 +1182,6 @@ paths:
                                         error: TSDB not ready
                                         errorType: internal
                                         status: error
-        delete:
-            tags:
-                - series
-            summary: Delete series
-            description: 'Delete series matching selectors. Note: This is deprecated, use POST /admin/tsdb/delete_series instead.'
-            operationId: delete-series
-            responses:
-                "200":
-                    description: Series marked for deletion.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/SeriesDeleteOutputBody'
-                            examples:
-                                seriesDeleted:
-                                    summary: Series marked for deletion
-                                    value:
-                                        status: success
-                default:
-                    description: Error deleting series.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Error'
-                            examples:
-                                tsdbNotReady:
-                                    summary: TSDB not ready
-                                    value:
-                                        error: TSDB not ready
-                                        errorType: internal
-                                        status: error
     /metadata:
         get:
             tags:

--- a/web/api/v1/testdata/openapi_3.2_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.2_golden.yaml
@@ -1182,37 +1182,6 @@ paths:
                                         error: TSDB not ready
                                         errorType: internal
                                         status: error
-        delete:
-            tags:
-                - series
-            summary: Delete series
-            description: 'Delete series matching selectors. Note: This is deprecated, use POST /admin/tsdb/delete_series instead.'
-            operationId: delete-series
-            responses:
-                "200":
-                    description: Series marked for deletion.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/SeriesDeleteOutputBody'
-                            examples:
-                                seriesDeleted:
-                                    summary: Series marked for deletion
-                                    value:
-                                        status: success
-                default:
-                    description: Error deleting series.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Error'
-                            examples:
-                                tsdbNotReady:
-                                    summary: TSDB not ready
-                                    value:
-                                        error: TSDB not ready
-                                        errorType: internal
-                                        status: error
     /metadata:
         get:
             tags:


### PR DESCRIPTION
## Summary

Remove the deprecated and non-functional `DELETE /api/v1/series` endpoint. This endpoint has been returning "not implemented" since Prometheus v2.0.0 (November 2017) and provides no value to users.

## Changes

- Removed route registration `r.Del("/series", ...)` from api.go
- Removed unused `dropSeries` function
- Removed corresponding test case
- Removed OpenAPI specification for this endpoint

## Fixes

Fixes #17955

## Release notes

NONE