### PR TITLE
web/api: remove deprecated DELETE /api/v1/series endpoint

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -443,7 +443,6 @@ func (api *API) Register(r *route.Router) {
 
 	r.Get("/series", wrapAgent(api.series))
 	r.Post("/series", wrapAgent(api.series))
-	r.Del("/series", wrapAgent(api.dropSeries))
 
 	r.Get("/scrape_pools", wrap(api.scrapePools))
 	r.Get("/targets", wrap(api.targets))
@@ -1045,10 +1044,6 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 	}
 
 	return apiFuncResult{metrics, nil, warnings, closer}
-}
-
-func (*API) dropSeries(*http.Request) apiFuncResult {
-	return apiFuncResult{nil, &apiError{errorInternal, errors.New("not implemented")}, nil, nil}
 }
 
 // Target has the information for one target.

--- a/web/api/v1/openapi_examples.go
+++ b/web/api/v1/openapi_examples.go
@@ -914,20 +914,6 @@ func cleanTombstonesResponseExamples() *orderedmap.Map[string, *base.Example] {
 	return examples
 }
 
-// seriesDeleteResponseExamples returns examples for DELETE /series response.
-func seriesDeleteResponseExamples() *orderedmap.Map[string, *base.Example] {
-	examples := orderedmap.New[string, *base.Example]()
-
-	examples.Set("seriesDeleted", &base.Example{
-		Summary: "Series marked for deletion",
-		Value: createYAMLNode(map[string]any{
-			"status": "success",
-		}),
-	})
-
-	return examples
-}
-
 // snapshotResponseExamples returns examples for /admin/tsdb/snapshot response.
 func snapshotResponseExamples() *orderedmap.Map[string, *base.Example] {
 	examples := orderedmap.New[string, *base.Example]()

--- a/web/api/v1/openapi_paths.go
+++ b/web/api/v1/openapi_paths.go
@@ -224,13 +224,6 @@ func (*OpenAPIBuilder) seriesPath() *v3.PathItem {
 			RequestBody: formRequestBodyWithExamples("SeriesPostInputBody", seriesPostExamples(), "Submit a series query. This endpoint accepts the same parameters as the GET version."),
 			Responses:   responsesWithErrorExamples("SeriesOutputBody", seriesResponseExamples(), errorResponseExamples(), "Series returned matching the provided label matchers via POST.", "Error retrieving series via POST."),
 		},
-		Delete: &v3.Operation{
-			OperationId: "delete-series",
-			Summary:     "Delete series",
-			Description: "Delete series matching selectors. Note: This is deprecated, use POST /admin/tsdb/delete_series instead.",
-			Tags:        []string{"series"},
-			Responses:   responsesWithErrorExamples("SeriesDeleteOutputBody", seriesDeleteResponseExamples(), errorResponseExamples(), "Series marked for deletion.", "Error deleting series."),
-		},
 	}
 }
 

--- a/web/api/v1/openapi_schemas.go
+++ b/web/api/v1/openapi_schemas.go
@@ -58,7 +58,6 @@ func (b *OpenAPIBuilder) buildComponents() *v3.Components {
 	// Series schemas.
 	schemas.Set("SeriesOutputBody", b.labelsArrayResponseBodySchema())
 	schemas.Set("SeriesPostInputBody", b.seriesPostInputBodySchema())
-	schemas.Set("SeriesDeleteOutputBody", b.simpleResponseBodySchema())
 
 	// Metadata schemas.
 	schemas.Set("Metadata", b.metadataSchema())

--- a/web/api/v1/testdata/openapi_3.1_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.1_golden.yaml
@@ -1182,37 +1182,6 @@ paths:
                                         error: TSDB not ready
                                         errorType: internal
                                         status: error
-        delete:
-            tags:
-                - series
-            summary: Delete series
-            description: 'Delete series matching selectors. Note: This is deprecated, use POST /admin/tsdb/delete_series instead.'
-            operationId: delete-series
-            responses:
-                "200":
-                    description: Series marked for deletion.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/SeriesDeleteOutputBody'
-                            examples:
-                                seriesDeleted:
-                                    summary: Series marked for deletion
-                                    value:
-                                        status: success
-                default:
-                    description: Error deleting series.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Error'
-                            examples:
-                                tsdbNotReady:
-                                    summary: TSDB not ready
-                                    value:
-                                        error: TSDB not ready
-                                        errorType: internal
-                                        status: error
     /metadata:
         get:
             tags:
@@ -3224,35 +3193,6 @@ components:
                 - match[]
             additionalProperties: false
             description: POST request body for series query.
-        SeriesDeleteOutputBody:
-            type: object
-            properties:
-                status:
-                    type: string
-                    enum:
-                        - success
-                        - error
-                    description: Response status.
-                    example: success
-                data:
-                    description: Response data (structure varies by endpoint).
-                    example:
-                        result: ok
-                warnings:
-                    type: array
-                    items:
-                        type: string
-                    description: Only set if there were warnings while executing the request. There will still be data in the data field.
-                infos:
-                    type: array
-                    items:
-                        type: string
-                    description: Only set if there were info-level annotations while executing the request.
-            required:
-                - status
-                - data
-            additionalProperties: false
-            description: Generic response body.
         Metadata:
             type: object
             properties:

--- a/web/api/v1/testdata/openapi_3.2_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.2_golden.yaml
@@ -1182,37 +1182,6 @@ paths:
                                         error: TSDB not ready
                                         errorType: internal
                                         status: error
-        delete:
-            tags:
-                - series
-            summary: Delete series
-            description: 'Delete series matching selectors. Note: This is deprecated, use POST /admin/tsdb/delete_series instead.'
-            operationId: delete-series
-            responses:
-                "200":
-                    description: Series marked for deletion.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/SeriesDeleteOutputBody'
-                            examples:
-                                seriesDeleted:
-                                    summary: Series marked for deletion
-                                    value:
-                                        status: success
-                default:
-                    description: Error deleting series.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Error'
-                            examples:
-                                tsdbNotReady:
-                                    summary: TSDB not ready
-                                    value:
-                                        error: TSDB not ready
-                                        errorType: internal
-                                        status: error
     /metadata:
         get:
             tags:
@@ -3262,35 +3231,6 @@ components:
                 - match[]
             additionalProperties: false
             description: POST request body for series query.
-        SeriesDeleteOutputBody:
-            type: object
-            properties:
-                status:
-                    type: string
-                    enum:
-                        - success
-                        - error
-                    description: Response status.
-                    example: success
-                data:
-                    description: Response data (structure varies by endpoint).
-                    example:
-                        result: ok
-                warnings:
-                    type: array
-                    items:
-                        type: string
-                    description: Only set if there were warnings while executing the request. There will still be data in the data field.
-                infos:
-                    type: array
-                    items:
-                        type: string
-                    description: Only set if there were info-level annotations while executing the request.
-            required:
-                - status
-                - data
-            additionalProperties: false
-            description: Generic response body.
         Metadata:
             type: object
             properties:

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -587,7 +587,7 @@ func TestAgentAPIEndPoints(t *testing.T) {
 	for path, methods := range map[string][]string{
 		"/labels":                      {http.MethodGet, http.MethodPost},
 		"/label/:name/values":          {http.MethodGet},
-		"/series":                      {http.MethodGet, http.MethodPost, http.MethodDelete},
+		"/series":                      {http.MethodGet, http.MethodPost},
 		"/alertmanagers":               {http.MethodGet},
 		"/query":                       {http.MethodGet, http.MethodPost},
 		"/query_range":                 {http.MethodGet, http.MethodPost},


### PR DESCRIPTION
## Summary

Remove the deprecated and non-functional `DELETE /api/v1/series` endpoint. This endpoint has been returning "not implemented" since Prometheus v2.0.0 (November 2017) and provides no value to users.

## Changes

- Removed route registration `r.Del("/series", ...)` from api.go
- Removed unused `dropSeries` function
- Removed corresponding test case
- Removed OpenAPI specification for this endpoint

## Fixes

Fixes #17955

```release-notes
NONE
```