### PR TITLE
fix: handle ErrTooOldSample as 400 in OTLP and v2 histogram write paths

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -225,7 +225,8 @@ func (h *writeHandler) appendV1Samples(app storage.Appender, ss []prompb.Sample,
 		if err != nil {
 			if errors.Is(err, storage.ErrOutOfOrderSample) ||
 				errors.Is(err, storage.ErrOutOfBounds) ||
-				errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+				errors.Is(err, storage.ErrDuplicateSampleForTimestamp) ||
+				errors.Is(err, storage.ErrTooOldSample) {
 				h.logger.Error("Out of order sample from remote write", "err", err.Error(), "series", labels.String(), "timestamp", s.Timestamp)
 			}
 			return err
@@ -247,7 +248,8 @@ func (h *writeHandler) appendV1Histograms(app storage.Appender, hh []prompb.Hist
 			// a note indicating its inclusion in the future.
 			if errors.Is(err, storage.ErrOutOfOrderSample) ||
 				errors.Is(err, storage.ErrOutOfBounds) ||
-				errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+				errors.Is(err, storage.ErrDuplicateSampleForTimestamp) ||
+				errors.Is(err, storage.ErrTooOldSample) {
 				h.logger.Error("Out of order histogram from remote write", "err", err.Error(), "series", labels.String(), "timestamp", hp.Timestamp)
 			}
 			return err
@@ -409,7 +411,8 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 			// a note indicating its inclusion in the future.
 			if errors.Is(err, storage.ErrOutOfOrderSample) ||
 				errors.Is(err, storage.ErrOutOfBounds) ||
-				errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+				errors.Is(err, storage.ErrDuplicateSampleForTimestamp) ||
+				errors.Is(err, storage.ErrTooOldSample) {
 				// TODO(bwplotka): Not too spammy log?
 				h.logger.Error("Out of order histogram from remote write", "err", err.Error(), "series", ls.String(), "timestamp", hp.Timestamp)
 				badRequestErrs = append(badRequestErrs, fmt.Errorf("%w for series %v", err, ls.String()))

--- a/storage/remote/write_otlp_handler.go
+++ b/storage/remote/write_otlp_handler.go
@@ -176,7 +176,7 @@ func (h *otlpWriteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case err == nil:
-	case errors.Is(err, storage.ErrOutOfOrderSample), errors.Is(err, storage.ErrOutOfBounds), errors.Is(err, storage.ErrDuplicateSampleForTimestamp):
+	case errors.Is(err, storage.ErrOutOfOrderSample), errors.Is(err, storage.ErrOutOfBounds), errors.Is(err, storage.ErrDuplicateSampleForTimestamp), errors.Is(err, storage.ErrTooOldSample):
 		// Indicated an out of order sample is a bad request to prevent retries.
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return


### PR DESCRIPTION
The OTLP write handler and the PRW v2 histogram append path were missing
`storage.ErrTooOldSample` from their error type checks. When this error
occurred, it fell through to the default case and returned HTTP 500
Internal Server Error instead of 400 Bad Request.

This matters because OTLP clients (like the Python SDK) retry on 5xx
errors, so a "too old sample" rejection caused an infinite retry loop
instead of being treated as a non-retryable bad request.

### What changed

- `write_otlp_handler.go`: Added `ErrTooOldSample` to the error switch
  in `ServeHTTP`, matching the existing handling of `ErrOutOfOrderSample`,
  `ErrOutOfBounds`, and `ErrDuplicateSampleForTimestamp`.

- `write_handler.go`: Added `ErrTooOldSample` to the v2 histogram error
  check (the v2 sample path already had it at line 377). Also added it
  to the v1 sample/histogram log checks for consistent logging.

The PRW v1 top-level handler (line 115) already correctly maps
`ErrTooOldSample` to 400 - this just brings the remaining code paths
in line.

Fixes #16645

```release-notes
[BUGFIX] Fix ErrTooOldSample being returned as HTTP 500 instead of 400 in OTLP and PRW v2 histogram write paths, preventing infinite client retry loops.
```

Signed-off-by: Varun Chawla <varun_6april@hotmail.com>