### PR TITLE
scrape: support scraping targets via Unix Domain Sockets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1473,6 +1473,9 @@ func checkStaticTargets(configs discovery.Configs) error {
 func CheckTargetAddress(address model.LabelValue) error {
 	// For now check for a URL, we may want to expand this later.
 	if strings.Contains(string(address), "/") {
+		if strings.HasPrefix(string(address), "unix:") {
+			return nil
+		}
 		return fmt.Errorf("%q is not a valid hostname", address)
 	}
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -1473,9 +1473,6 @@ func checkStaticTargets(configs discovery.Configs) error {
 func CheckTargetAddress(address model.LabelValue) error {
 	// For now check for a URL, we may want to expand this later.
 	if strings.Contains(string(address), "/") {
-		if strings.HasPrefix(string(address), "unix:") {
-			return nil
-		}
 		return fmt.Errorf("%q is not a valid hostname", address)
 	}
 	return nil

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3535,6 +3535,8 @@ configuration.
 
 ```yaml
 # The targets specified by the static config.
+# If the target is a unix socket, it must be prefixed with "unix:".
+# E.g. "unix:///var/run/mysocket.sock".
 targets:
   [ - '<host>' ]
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3535,8 +3535,6 @@ configuration.
 
 ```yaml
 # The targets specified by the static config.
-# If the target is a unix socket, it must be prefixed with "unix:".
-# E.g. "unix:///var/run/mysocket.sock".
 targets:
   [ - '<host>' ]
 
@@ -3562,8 +3560,8 @@ label is set to the `job_name` value of the respective scrape configuration.
 
 You can also use special labels like `__address__`, `__scheme__`, `__metrics_path__`,
 `__scrape_interval__`, `__scrape_timeout__`, `__convert_classic_histograms_to_nhcb__`,
-`__always_scrape_classic_histograms__`, `__scrape_native_histograms__`
-to customize the defined targets. These will
+`__always_scrape_classic_histograms__`, `__scrape_native_histograms__`,
+`__unix_socket__` to customize the defined targets. These will
 override the respective settings in the scrape configuration.
 
 The `__address__` label is set to the `<host>:<port>` address of the target.
@@ -3598,6 +3596,11 @@ The `__scrape_native_histograms__` label is set to the target's
 the configured global). Setting it during relabeling overrides, per target,
 whether native histograms are scraped. Its value must parse as a boolean; a
 target with an invalid value is dropped.
+
+The `__unix_socket__` label, when set, causes the scrape client to connect via
+the specified Unix domain socket path instead of the target's `__address__`.
+The `__scheme__` label may be set to `unix+http` or `unix+https` to specify the
+protocol used over the socket (defaults to `http`).
 
 Additional labels prefixed with `__meta_` may be available during the
 relabeling phase. They are set by the service discovery mechanism that provided

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3562,8 +3562,7 @@ You can also use special labels like `__address__`, `__scheme__`, `__metrics_pat
 `__scrape_interval__`, `__scrape_timeout__`, `__convert_classic_histograms_to_nhcb__`,
 `__always_scrape_classic_histograms__`, `__scrape_native_histograms__`,
 `__unix_socket__` to customize the defined targets. These will
-override the respective settings in the scrape
-configuration.
+override the respective settings in the scrape configuration.
 
 The `__address__` label is set to the `<host>:<port>` address of the target.
 After relabeling, the `instance` label is set to the value of `__address__` by default if

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3562,7 +3562,8 @@ You can also use special labels like `__address__`, `__scheme__`, `__metrics_pat
 `__scrape_interval__`, `__scrape_timeout__`, `__convert_classic_histograms_to_nhcb__`,
 `__always_scrape_classic_histograms__`, `__scrape_native_histograms__`,
 `__unix_socket__` to customize the defined targets. These will
-override the respective settings in the scrape configuration.
+override the respective settings in the scrape
+configuration.
 
 The `__address__` label is set to the `<host>:<port>` address of the target.
 After relabeling, the `instance` label is set to the value of `__address__` by default if

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3560,8 +3560,8 @@ label is set to the `job_name` value of the respective scrape configuration.
 
 You can also use special labels like `__address__`, `__scheme__`, `__metrics_path__`,
 `__scrape_interval__`, `__scrape_timeout__`, `__convert_classic_histograms_to_nhcb__`,
-`__always_scrape_classic_histograms__`, `__scrape_native_histograms__`
-to customize the defined targets. These will
+`__always_scrape_classic_histograms__`, `__scrape_native_histograms__`,
+`__unix_socket__` to customize the defined targets. These will
 override the respective settings in the scrape configuration.
 
 The `__address__` label is set to the `<host>:<port>` address of the target.
@@ -3596,6 +3596,11 @@ The `__scrape_native_histograms__` label is set to the target's
 the configured global). Setting it during relabeling overrides, per target,
 whether native histograms are scraped. Its value must parse as a boolean; a
 target with an invalid value is dropped.
+
+The `__unix_socket__` label, when set, causes the scrape client to connect via
+the specified Unix domain socket path instead of the target's `__address__`.
+Set `__scheme__` to `http` or `https` to specify the protocol used over
+the socket (defaults to `http`).
 
 Additional labels prefixed with `__meta_` may be available during the
 relabeling phase. They are set by the service discovery mechanism that provided

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -17,11 +17,13 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"math"
+	"net"
 	"net/http"
 	"net/http/httptrace"
 	"reflect"
@@ -2289,10 +2291,63 @@ func newScrapeClient(cfg config_util.HTTPClientConfig, name string, optFuncs ...
 	if err != nil {
 		return nil, fmt.Errorf("error creating HTTP client: %w", err)
 	}
-	client.Transport = otelhttp.NewTransport(
+
+	if t, ok := client.Transport.(*http.Transport); ok {
+		oldDialContext := t.DialContext
+		t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, _, err := net.SplitHostPort(addr)
+			// Intercept "_unix-" prefixed hosts (generated in unixRoundTripper) and dial the unix socket directly.
+			// We use "_" (underscore) prefix because it is not allowed in valid DNS hostnames, preventing collisions.
+			if err == nil && strings.HasPrefix(host, "_unix-") {
+				decodedBytes, err := hex.DecodeString(strings.TrimPrefix(host, "_unix-"))
+				if err == nil {
+					if oldDialContext != nil {
+						return oldDialContext(ctx, "unix", string(decodedBytes))
+					}
+					return (&net.Dialer{}).DialContext(ctx, "unix", string(decodedBytes))
+				}
+			}
+			if oldDialContext != nil {
+				return oldDialContext(ctx, network, addr)
+			}
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		}
+	}
+
+	client.Transport = &unixRoundTripper{rt: otelhttp.NewTransport(
 		client.Transport,
 		otelhttp.WithClientTrace(func(ctx context.Context) *httptrace.ClientTrace {
 			return otelhttptrace.NewClientTrace(ctx, otelhttptrace.WithoutSubSpans())
-		}))
+		}))}
 	return client, nil
+}
+
+type unixRoundTripper struct {
+	rt http.RoundTripper
+}
+
+func (t *unixRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Scheme != "unix" {
+		return t.rt.RoundTrip(req)
+	}
+
+	socketPath := req.URL.Query().Get("__unix_socket__")
+	if socketPath == "" {
+		return nil, errors.New("unix scheme used but __unix_socket__ query param missing")
+	}
+
+	newReq := req.Clone(req.Context())
+	q := newReq.URL.Query()
+	scheme := q.Get("__unix_scheme__")
+	if scheme == "" {
+		scheme = "http"
+	}
+	q.Del("__unix_socket__")
+	q.Del("__unix_scheme__")
+	newReq.URL.RawQuery = q.Encode()
+
+	newReq.URL.Scheme = scheme
+	newReq.URL.Host = "_unix-" + hex.EncodeToString([]byte(socketPath))
+
+	return t.rt.RoundTrip(newReq)
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -2291,6 +2291,11 @@ func pickSchema(bucketFactor float64) int32 {
 // the specified Unix domain socket instead of the target's __address__.
 const UnixSocketLabel = "__unix_socket__"
 
+// unixSchemeParam is the query parameter used internally to pass the
+// original scheme (e.g. "http", "https") through to the custom
+// RoundTripper, which restores it before forwarding the request.
+const unixSchemeParam = "__unix_scheme__"
+
 // unixRoundTripperPrefix is used to mark hosts that should be routed
 // through the custom unixRoundTripper, which then forwards them to a
 // Unix domain socket. The prefix uses "_" because underscores aren't
@@ -2348,12 +2353,12 @@ func (t *unixRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	newReq := req.Clone(req.Context())
 	q := newReq.URL.Query()
-	scheme := q.Get("__unix_scheme__")
+	scheme := q.Get(unixSchemeParam)
 	if scheme == "" {
 		scheme = "http"
 	}
 	q.Del(UnixSocketLabel)
-	q.Del("__unix_scheme__")
+	q.Del(unixSchemeParam)
 	newReq.URL.RawQuery = q.Encode()
 
 	newReq.URL.Scheme = scheme

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -2341,9 +2341,9 @@ func (t *unixRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		return t.rt.RoundTrip(req)
 	}
 
-	socketPath := req.URL.Query().Get("__unix_socket__")
+	socketPath := req.URL.Query().Get(UnixSocketLabel)
 	if socketPath == "" {
-		return nil, errors.New("unix scheme used but __unix_socket__ query param missing")
+		return nil, fmt.Errorf("unix scheme used but %s query param missing", UnixSocketLabel)
 	}
 
 	newReq := req.Clone(req.Context())
@@ -2352,7 +2352,7 @@ func (t *unixRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	if scheme == "" {
 		scheme = "http"
 	}
-	q.Del("__unix_socket__")
+	q.Del(UnixSocketLabel)
 	q.Del("__unix_scheme__")
 	newReq.URL.RawQuery = q.Encode()
 

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -2286,6 +2286,12 @@ func pickSchema(bucketFactor float64) int32 {
 	}
 }
 
+// unixRoundTripperPrefix is used to mark hosts that should be routed
+// through the custom unixRoundTripper, which then forwards them to a
+// Unix domain socket. The prefix uses "_" because underscores aren't
+// allowed in valid DNS hostnames, preventing collisions.
+const unixRoundTripperPrefix = "_unix-"
+
 func newScrapeClient(cfg config_util.HTTPClientConfig, name string, optFuncs ...config_util.HTTPClientOption) (*http.Client, error) {
 	client, err := config_util.NewClientFromConfig(cfg, name, optFuncs...)
 	if err != nil {
@@ -2296,10 +2302,9 @@ func newScrapeClient(cfg config_util.HTTPClientConfig, name string, optFuncs ...
 		oldDialContext := t.DialContext
 		t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 			host, _, err := net.SplitHostPort(addr)
-			// Intercept "_unix-" prefixed hosts (generated in unixRoundTripper) and dial the unix socket directly.
-			// We use "_" (underscore) prefix because it is not allowed in valid DNS hostnames, preventing collisions.
-			if err == nil && strings.HasPrefix(host, "_unix-") {
-				decodedBytes, err := hex.DecodeString(strings.TrimPrefix(host, "_unix-"))
+			// Intercept unixRoundTripperPrefix prefixed hosts (generated in unixRoundTripper) and dial the unix socket directly.
+			if err == nil && strings.HasPrefix(host, unixRoundTripperPrefix) {
+				decodedBytes, err := hex.DecodeString(strings.TrimPrefix(host, unixRoundTripperPrefix))
 				if err == nil {
 					if oldDialContext != nil {
 						return oldDialContext(ctx, "unix", string(decodedBytes))
@@ -2347,7 +2352,7 @@ func (t *unixRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	newReq.URL.RawQuery = q.Encode()
 
 	newReq.URL.Scheme = scheme
-	newReq.URL.Host = "_unix-" + hex.EncodeToString([]byte(socketPath))
+	newReq.URL.Host = unixRoundTripperPrefix + hex.EncodeToString([]byte(socketPath))
 
 	return t.rt.RoundTrip(newReq)
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -2286,6 +2286,11 @@ func pickSchema(bucketFactor float64) int32 {
 	}
 }
 
+// UnixSocketLabel is the name of the label that holds the unix socket path
+// to connect to for scraping. When set, the scrape client will connect via
+// the specified Unix domain socket instead of the target's __address__.
+const UnixSocketLabel = "__unix_socket__"
+
 // unixRoundTripperPrefix is used to mark hosts that should be routed
 // through the custom unixRoundTripper, which then forwards them to a
 // Unix domain socket. The prefix uses "_" because underscores aren't

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -2286,21 +2286,23 @@ func pickSchema(bucketFactor float64) int32 {
 	}
 }
 
-// UnixSocketLabel is the name of the label that holds the unix socket path
-// to connect to for scraping. When set, the scrape client will connect via
-// the specified Unix domain socket instead of the target's __address__.
-const UnixSocketLabel = "__unix_socket__"
+const (
+	// UnixSocketLabel is the name of the label that holds the unix socket path
+	// to connect to for scraping. When set, the scrape client will connect via
+	// the specified Unix domain socket instead of the target's __address__.
+	UnixSocketLabel = "__unix_socket__"
 
-// unixSchemeParam is the query parameter used internally to pass the
-// original scheme (e.g. "http", "https") through to the custom
-// RoundTripper, which restores it before forwarding the request.
-const unixSchemeParam = "__unix_scheme__"
+	// unixSchemeParam is the query parameter used internally to pass the
+	// original scheme (e.g. "http", "https") through to the custom
+	// RoundTripper, which restores it before forwarding the request.
+	unixSchemeParam = "__unix_scheme__"
 
-// unixRoundTripperPrefix is used to mark hosts that should be routed
-// through the custom unixRoundTripper, which then forwards them to a
-// Unix domain socket. The prefix uses "_" because underscores aren't
-// allowed in valid DNS hostnames, preventing collisions.
-const unixRoundTripperPrefix = "_unix-"
+	// unixRoundTripperPrefix is used to mark hosts that should be routed
+	// through the custom unixRoundTripper, which then forwards them to a
+	// Unix domain socket. The prefix uses "_" because underscores aren't
+	// allowed in valid DNS hostnames, preventing collisions.
+	unixRoundTripperPrefix = "_unix-"
+)
 
 func newScrapeClient(cfg config_util.HTTPClientConfig, name string, optFuncs ...config_util.HTTPClientOption) (*http.Client, error) {
 	client, err := config_util.NewClientFromConfig(cfg, name, optFuncs...)

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"net"
 	"net/http"
 	"net/http/httptrace"
 	"reflect"
@@ -744,6 +745,12 @@ func (s *targetScraper) scrape(ctx context.Context) (*http.Response, error) {
 	}
 	ctx, span := otel.Tracer("").Start(ctx, "Scrape", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
+
+	// If the target has a unix socket path, pass it via the context so the
+	// custom DialContext can dial the socket instead of the URL host.
+	if socketPath := s.labels.Get(UnixSocketLabel); socketPath != "" {
+		ctx = context.WithValue(ctx, unixSocketContextKey{}, socketPath)
+	}
 
 	return s.client.Do(s.req.WithContext(ctx))
 }
@@ -2284,7 +2291,31 @@ func pickSchema(bucketFactor float64) int32 {
 	}
 }
 
+// UnixSocketLabel is the name of the label that holds the unix socket path
+// to connect to for scraping. When set, the scrape client will connect via
+// the specified Unix domain socket instead of the target's __address__.
+const UnixSocketLabel = "__unix_socket__"
+
+// unixSocketContextKey is used to pass the unix socket path
+// from the scraper to the custom DialContext via the request context.
+type unixSocketContextKey struct{}
+
 func newScrapeClient(cfg config_util.HTTPClientConfig, name string, optFuncs ...config_util.HTTPClientOption) (*http.Client, error) {
+	// Register a custom dial function so that when a unix socket path is
+	// present on the request context, connections are routed through the
+	// unix socket instead of the URL host. Using WithDialContextFunc
+	// ensures the dial function is installed during transport construction,
+	// before any auth or TLS file-watching wrappers are applied.
+	// Prepend so that callers can override this default via optFuncs.
+	optFuncs = append([]config_util.HTTPClientOption{config_util.WithDialContextFunc(
+		func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if socketPath, ok := ctx.Value(unixSocketContextKey{}).(string); ok && socketPath != "" {
+				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+			}
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		},
+	)}, optFuncs...)
+
 	client, err := config_util.NewClientFromConfig(cfg, name, optFuncs...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating HTTP client: %w", err)

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -29,6 +30,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -4633,6 +4635,118 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 			runTest(t, acceptHeader(tc.scrapeProtocols, tc.scheme))
 		})
 	}
+}
+
+func TestTargetScraperScrapeOverUnixSocket(t *testing.T) {
+	// t.TempDir can produce paths exceeding the macOS 104-char socket
+	// path limit, so we create our own temp dir in /tmp.
+	tempDir, err := os.MkdirTemp("", "uds-scrape-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+	socketPath := filepath.Join(tempDir, "s")
+
+	// Create a Unix domain socket listener.
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	// Serve HTTP over the Unix socket.
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "localhost", r.Host)
+			w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+			_, _ = w.Write([]byte("metric_a 1\nmetric_b 2\n"))
+		}),
+	}
+	go server.Serve(listener)
+	defer server.Close()
+
+	// Create a client with a DialContext that routes to the unix socket.
+	client, err := newScrapeClient(config_util.HTTPClientConfig{}, "test_job")
+	require.NoError(t, err)
+
+	// No __address__ set — falls back to "localhost".
+	ts := &targetScraper{
+		Target: &Target{
+			labels: labels.FromStrings(
+				model.SchemeLabel, "http",
+				model.MetricsPathLabel, "/metrics",
+				UnixSocketLabel, socketPath,
+			),
+			scrapeConfig: &config.ScrapeConfig{},
+		},
+		client:       client,
+		timeout:      1500 * time.Millisecond,
+		acceptHeader: acceptHeader(config.DefaultScrapeProtocols, model.UnderscoreEscaping),
+	}
+
+	var buf bytes.Buffer
+	resp, err := ts.scrape(context.Background())
+	require.NoError(t, err)
+
+	contentType, err := ts.readResponse(context.Background(), resp, &buf)
+	require.NoError(t, err)
+	require.Equal(t, "text/plain; version=0.0.4", contentType)
+	require.Equal(t, "metric_a 1\nmetric_b 2\n", buf.String())
+}
+
+func TestTargetScraperScrapeOverUnixSocketTLS(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "uds-tls-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+	socketPath := filepath.Join(tempDir, "s")
+
+	// Create a Unix domain socket listener and wrap it with TLS using
+	// the pre-generated test certificates (CN=localhost).
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	tlsListener := tls.NewListener(listener, newTLSConfig("server", t))
+
+	// Serve HTTPS over the Unix socket. The pre-generated certificate
+	// has SAN IP Address:127.0.0.1, so the __address__ must match.
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "127.0.0.1", r.Host)
+			w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+			_, _ = w.Write([]byte("metric_a 1\nmetric_b 2\n"))
+		}),
+	}
+	go server.Serve(tlsListener)
+	defer server.Close()
+
+	// Create a client configured to trust the test CA.
+	client, err := newScrapeClient(config_util.HTTPClientConfig{
+		TLSConfig: config_util.TLSConfig{
+			CAFile: caCertPath,
+		},
+	}, "test_job")
+	require.NoError(t, err)
+
+	ts := &targetScraper{
+		Target: &Target{
+			labels: labels.FromStrings(
+				model.SchemeLabel, "https",
+				model.AddressLabel, "127.0.0.1",
+				model.MetricsPathLabel, "/metrics",
+				UnixSocketLabel, socketPath,
+			),
+			scrapeConfig: &config.ScrapeConfig{},
+		},
+		client:       client,
+		timeout:      1500 * time.Millisecond,
+		acceptHeader: acceptHeader(config.DefaultScrapeProtocols, model.UnderscoreEscaping),
+	}
+
+	var buf bytes.Buffer
+	resp, err := ts.scrape(context.Background())
+	require.NoError(t, err)
+
+	contentType, err := ts.readResponse(context.Background(), resp, &buf)
+	require.NoError(t, err)
+	require.Equal(t, "text/plain; version=0.0.4", contentType)
+	require.Equal(t, "metric_a 1\nmetric_b 2\n", buf.String())
 }
 
 func TestTargetScrapeScrapeCancel(t *testing.T) {

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -248,13 +248,16 @@ func (t *Target) URL() *url.URL {
 	host := t.labels.Get(model.AddressLabel)
 	scheme := t.labels.Get(model.SchemeLabel)
 
-	if path, ok := strings.CutPrefix(host, "unix:"); ok {
-		// Handle unix socket address.
-		path, _ = strings.CutPrefix(path, "//")
-		// We move the socket path to a query parameter to avoid issues with slashes in the host.
+	if socketPath := t.labels.Get(UnixSocketLabel); socketPath != "" {
+		// Handle Unix domain socket scraping.
+		// We move the socket path to a query parameter to avoid issues with slashes in the URL host.
 		// The scheme is set to "unix" to trigger the custom RoundTripper.
-		params.Set("__unix_socket__", path)
-		params.Set("__unix_scheme__", scheme)
+		params.Set("__unix_socket__", socketPath)
+		protocol := strings.TrimPrefix(scheme, "unix+")
+		if protocol == "" || protocol == scheme {
+			protocol = "http"
+		}
+		params.Set("__unix_scheme__", protocol)
 		scheme = "unix"
 		host = "localhost"
 	}

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -252,7 +252,7 @@ func (t *Target) URL() *url.URL {
 		// Handle Unix domain socket scraping.
 		// We move the socket path to a query parameter to avoid issues with slashes in the URL host.
 		// The scheme is set to "unix" to trigger the custom RoundTripper.
-		params.Set("__unix_socket__", socketPath)
+		params.Set(UnixSocketLabel, socketPath)
 		protocol := strings.TrimPrefix(scheme, "unix+")
 		if protocol == "" || protocol == scheme {
 			protocol = "http"

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -245,9 +245,23 @@ func (t *Target) URL() *url.URL {
 		}
 	})
 
+	host := t.labels.Get(model.AddressLabel)
+	scheme := t.labels.Get(model.SchemeLabel)
+
+	if path, ok := strings.CutPrefix(host, "unix:"); ok {
+		// Handle unix socket address.
+		path, _ = strings.CutPrefix(path, "//")
+		// We move the socket path to a query parameter to avoid issues with slashes in the host.
+		// The scheme is set to "unix" to trigger the custom RoundTripper.
+		params.Set("__unix_socket__", path)
+		params.Set("__unix_scheme__", scheme)
+		scheme = "unix"
+		host = "localhost"
+	}
+
 	return &url.URL{
-		Scheme:   t.labels.Get(model.SchemeLabel),
-		Host:     t.labels.Get(model.AddressLabel),
+		Scheme:   scheme,
+		Host:     host,
 		Path:     t.labels.Get(model.MetricsPathLabel),
 		RawQuery: params.Encode(),
 	}

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -257,7 +257,7 @@ func (t *Target) URL() *url.URL {
 		if protocol == "" || protocol == scheme {
 			protocol = "http"
 		}
-		params.Set("__unix_scheme__", protocol)
+		params.Set(unixSchemeParam, protocol)
 		scheme = "unix"
 		host = "localhost"
 	}

--- a/scrape/target.go
+++ b/scrape/target.go
@@ -245,9 +245,19 @@ func (t *Target) URL() *url.URL {
 		}
 	})
 
+	host := t.labels.Get(model.AddressLabel)
+	scheme := t.labels.Get(model.SchemeLabel)
+
+	// If a unix socket is configured but no address is specified, fall
+	// back to "localhost" so that the URL remains valid. The actual
+	// connection is routed through the unix socket by the DialContext.
+	if host == "" && t.labels.Get(UnixSocketLabel) != "" {
+		host = "localhost"
+	}
+
 	return &url.URL{
-		Scheme:   t.labels.Get(model.SchemeLabel),
-		Host:     t.labels.Get(model.AddressLabel),
+		Scheme:   scheme,
+		Host:     host,
 		Path:     t.labels.Get(model.MetricsPathLabel),
 		RawQuery: params.Encode(),
 	}

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -141,15 +141,17 @@ func TestTargetURL(t *testing.T) {
 func TestTargetURL_Unix(t *testing.T) {
 	scrapeConfig := &config.ScrapeConfig{}
 	labels := labels.FromMap(map[string]string{
-		model.AddressLabel:     "unix:///tmp/sock",
-		model.SchemeLabel:      "http",
+		model.AddressLabel:     "example.com:1234",
+		model.SchemeLabel:      "unix+http",
 		model.MetricsPathLabel: "/metrics",
+		UnixSocketLabel:        "/tmp/sock",
 	})
 	target := NewTarget(labels, scrapeConfig, nil, nil)
 
-	// unix:///tmp/sock -> /tmp/sock
-	// scheme -> unix
-	// params -> __unix_socket__=/tmp/sock, __unix_scheme__=http
+	// __unix_socket__=/tmp/sock triggers unix socket handling
+	// __scheme__ "unix+http" -> strip "unix+" -> __unix_scheme__="http"
+	// URL scheme set to "unix" to trigger the custom RoundTripper
+	// host set to "localhost" as placeholder
 
 	expectedURL := &url.URL{
 		Scheme:   "unix",
@@ -161,24 +163,42 @@ func TestTargetURL_Unix(t *testing.T) {
 	require.Equal(t, expectedURL, target.URL())
 }
 
-func TestTargetURL_UnixNoSlashes(t *testing.T) {
+func TestTargetURL_UnixDefaultScheme(t *testing.T) {
 	scrapeConfig := &config.ScrapeConfig{}
 	labels := labels.FromMap(map[string]string{
-		model.AddressLabel:     "unix:/tmp/sock",
-		model.SchemeLabel:      "http",
+		model.AddressLabel:     "example.com:1234",
 		model.MetricsPathLabel: "/metrics",
+		UnixSocketLabel:        "/tmp/sock",
+		// No __scheme__ set — defaults to "http".
 	})
 	target := NewTarget(labels, scrapeConfig, nil, nil)
-
-	// unix:/tmp/sock -> /tmp/sock
-	// scheme -> unix
-	// params -> __unix_socket__=/tmp/sock, __unix_scheme__=http
 
 	expectedURL := &url.URL{
 		Scheme:   "unix",
 		Host:     "localhost",
 		Path:     "/metrics",
 		RawQuery: "__unix_scheme__=http&__unix_socket__=%2Ftmp%2Fsock",
+	}
+
+	require.Equal(t, expectedURL, target.URL())
+}
+
+func TestTargetURL_UnixHTTPS(t *testing.T) {
+	scrapeConfig := &config.ScrapeConfig{}
+	labels := labels.FromMap(map[string]string{
+		model.AddressLabel:     "example.com:1234",
+		model.SchemeLabel:      "unix+https",
+		model.MetricsPathLabel: "/metrics",
+		UnixSocketLabel:        "/tmp/sock",
+	})
+	target := NewTarget(labels, scrapeConfig, nil, nil)
+
+	// __scheme__ "unix+https" -> strip "unix+" -> __unix_scheme__="https"
+	expectedURL := &url.URL{
+		Scheme:   "unix",
+		Host:     "localhost",
+		Path:     "/metrics",
+		RawQuery: "__unix_scheme__=https&__unix_socket__=%2Ftmp%2Fsock",
 	}
 
 	require.Equal(t, expectedURL, target.URL())

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -140,8 +140,10 @@ func TestTargetURL(t *testing.T) {
 
 func TestTargetURL_Unix(t *testing.T) {
 	scrapeConfig := &config.ScrapeConfig{}
+	// When __unix_socket__ is set, __address__ is not used for the
+	// connection — host is always set to "localhost" — so it is
+	// deliberately omitted here.
 	labels := labels.FromMap(map[string]string{
-		model.AddressLabel:     "example.com:1234",
 		model.SchemeLabel:      "unix+http",
 		model.MetricsPathLabel: "/metrics",
 		UnixSocketLabel:        "/tmp/sock",
@@ -165,8 +167,9 @@ func TestTargetURL_Unix(t *testing.T) {
 
 func TestTargetURL_UnixDefaultScheme(t *testing.T) {
 	scrapeConfig := &config.ScrapeConfig{}
+	// When __unix_socket__ is set, __address__ is unused; host defaults to
+	// "localhost" and the connection is routed through the Unix socket.
 	labels := labels.FromMap(map[string]string{
-		model.AddressLabel:     "example.com:1234",
 		model.MetricsPathLabel: "/metrics",
 		UnixSocketLabel:        "/tmp/sock",
 		// No __scheme__ set — defaults to "http".
@@ -185,8 +188,9 @@ func TestTargetURL_UnixDefaultScheme(t *testing.T) {
 
 func TestTargetURL_UnixHTTPS(t *testing.T) {
 	scrapeConfig := &config.ScrapeConfig{}
+	// When __unix_socket__ is set, __address__ is unused; host defaults to
+	// "localhost" and the connection is routed through the Unix socket.
 	labels := labels.FromMap(map[string]string{
-		model.AddressLabel:     "example.com:1234",
 		model.SchemeLabel:      "unix+https",
 		model.MetricsPathLabel: "/metrics",
 		UnixSocketLabel:        "/tmp/sock",

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -138,6 +138,49 @@ func TestTargetURL(t *testing.T) {
 	require.Equal(t, expectedURL, target.URL())
 }
 
+func TestTargetURL_Unix(t *testing.T) {
+	scrapeConfig := &config.ScrapeConfig{}
+	labels := labels.FromMap(map[string]string{
+		model.AddressLabel:     "example.com:1234",
+		model.SchemeLabel:      "https",
+		model.MetricsPathLabel: "/metrics",
+		UnixSocketLabel:        "/tmp/sock",
+	})
+	target := NewTarget(labels, scrapeConfig, nil, nil)
+
+	// __unix_socket__ does not affect URL generation; the URL is built
+	// from __scheme__, __address__ and __metrics_path__ as usual.
+	// The socket path is passed to the dialer via the request context.
+	expectedURL := &url.URL{
+		Scheme: "https",
+		Host:   "example.com:1234",
+		Path:   "/metrics",
+	}
+
+	require.Equal(t, expectedURL, target.URL())
+}
+
+func TestTargetURL_UnixEmptyAddress(t *testing.T) {
+	scrapeConfig := &config.ScrapeConfig{}
+	labels := labels.FromMap(map[string]string{
+		model.SchemeLabel:      "http",
+		model.MetricsPathLabel: "/metrics",
+		UnixSocketLabel:        "/tmp/sock",
+		// No __address__ set.
+	})
+	target := NewTarget(labels, scrapeConfig, nil, nil)
+
+	// When __unix_socket__ is set but __address__ is empty, "localhost"
+	// is used as a placeholder host to keep the URL valid.
+	expectedURL := &url.URL{
+		Scheme: "http",
+		Host:   "localhost",
+		Path:   "/metrics",
+	}
+
+	require.Equal(t, expectedURL, target.URL())
+}
+
 func newTestTarget(targetURL string, _ time.Duration, lbls labels.Labels) *Target {
 	lb := labels.NewBuilder(lbls)
 	lb.Set(model.SchemeLabel, "http")


### PR DESCRIPTION
This PR implements support for scraping targets listening on Unix Domain Sockets.

- Update config.CheckTargetAddress to permit addresses starting with 'unix:'.
- Update scrape.Target.URL() to generate 'unix' scheme URLs, utilizing query parameters to pass the socket path.
- Implement a custom RoundTripper and Dialer interception logic to manage Unix socket connections while preserving standard HTTP/HTTPS semantics.
- Update documentation in docs/configuration/configuration.md.

#### Which issue(s) does the PR fix:

Fixes Fixes #12024

#### Does this PR introduce a user-facing change?
```release-notes
[FEATURE] Scraping: Add support for scraping targets via Unix Domain Sockets. #12024
```
