### PR TITLE
util/gate, storage/remote: add wait duration metric

### DIFF
--- a/util/gate/gate.go
+++ b/util/gate/gate.go
@@ -13,23 +13,63 @@
 
 package gate
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// Observer is the minimal interface for recording metrics.
+type Observer interface {
+	Observe(float64)
+}
 
 // A Gate controls the maximum number of concurrently running and waiting queries.
 type Gate struct {
-	ch chan struct{}
+	ch           chan struct{}
+	waitDuration Observer // Optional: nil if not tracking
 }
 
 // New returns a query gate that limits the number of queries
 // being concurrently executed.
 func New(length int) *Gate {
+	return NewWithMetric(length, nil)
+}
+
+// NewWithMetric returns a gate that optionally tracks wait duration.
+// If waitDuration is non-nil, it observes the duration spent waiting
+// to acquire a slot in the gate.
+func NewWithMetric(length int, waitDuration Observer) *Gate {
 	return &Gate{
-		ch: make(chan struct{}, length),
+		ch:           make(chan struct{}, length),
+		waitDuration: waitDuration,
 	}
 }
 
 // Start blocks until the gate has a free spot or the context is done.
 func (g *Gate) Start(ctx context.Context) error {
+	if g.waitDuration != nil {
+		// Try non-blocking send first to avoid timing overhead when no wait is needed.
+		select {
+		case g.ch <- struct{}{}:
+			// Acquired immediately, no wait time.
+			g.waitDuration.Observe(0)
+			return nil
+		default:
+			// Channel is full, will need to wait.
+		}
+
+		// Start timing the actual wait.
+		start := time.Now()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case g.ch <- struct{}{}:
+			g.waitDuration.Observe(time.Since(start).Seconds())
+			return nil
+		}
+	}
+
+	// No metric tracking, use simple select.
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/util/gate/gate_test.go
+++ b/util/gate/gate_test.go
@@ -1,0 +1,178 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gate
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockObserver implements the Observer interface for testing.
+type mockObserver struct {
+	mu           sync.Mutex
+	observations []float64
+}
+
+func (m *mockObserver) Observe(v float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.observations = append(m.observations, v)
+}
+
+func (m *mockObserver) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.observations)
+}
+
+func (m *mockObserver) lastObservation() float64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.observations) == 0 {
+		return 0
+	}
+	return m.observations[len(m.observations)-1]
+}
+
+func TestNew(t *testing.T) {
+	g := New(1)
+	require.NotNil(t, g)
+	require.NotNil(t, g.ch)
+	require.Nil(t, g.waitDuration)
+}
+
+func TestNewWithMetric(t *testing.T) {
+	observer := &mockObserver{}
+	g := NewWithMetric(1, observer)
+	require.NotNil(t, g)
+	require.NotNil(t, g.ch)
+	require.NotNil(t, g.waitDuration)
+}
+
+func TestGate_StartWithoutMetric(t *testing.T) {
+	g := New(1)
+	err := g.Start(context.Background())
+	require.NoError(t, err)
+	g.Done()
+}
+
+func TestGate_StartWithMetric(t *testing.T) {
+	observer := &mockObserver{}
+	g := NewWithMetric(1, observer)
+
+	err := g.Start(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, observer.count())
+
+	// The observation should be very small (near 0) since there's no blocking
+	lastObs := observer.lastObservation()
+	require.GreaterOrEqual(t, lastObs, 0.0)
+	require.Less(t, lastObs, 0.1) // Should be much less than 100ms
+
+	g.Done()
+}
+
+func TestGate_WaitDuration(t *testing.T) {
+	observer := &mockObserver{}
+	g := NewWithMetric(1, observer)
+
+	// Fill the gate
+	err := g.Start(context.Background())
+	require.NoError(t, err)
+
+	// Start a goroutine that will block
+	done := make(chan struct{})
+	go func() {
+		err := g.Start(context.Background())
+		require.NoError(t, err)
+		close(done)
+		g.Done()
+	}()
+
+	// Let the goroutine block for a bit
+	time.Sleep(50 * time.Millisecond)
+
+	// Release the gate
+	g.Done()
+
+	// Wait for the goroutine to finish
+	<-done
+
+	// We should have 2 observations
+	require.Equal(t, 2, observer.count())
+
+	// The second observation should reflect the wait time (at least 50ms)
+	lastObs := observer.lastObservation()
+	require.GreaterOrEqual(t, lastObs, 0.05) // At least 50ms
+}
+
+func TestGate_ContextCancellation(t *testing.T) {
+	observer := &mockObserver{}
+	g := NewWithMetric(1, observer)
+
+	// Fill the gate
+	err := g.Start(context.Background())
+	require.NoError(t, err)
+
+	// Try to start with a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = g.Start(ctx)
+	require.Error(t, err)
+	require.Equal(t, context.Canceled, err)
+
+	// Should only have 1 observation (from the first Start)
+	require.Equal(t, 1, observer.count())
+
+	g.Done()
+}
+
+func TestGate_DonePanic(t *testing.T) {
+	g := New(1)
+
+	// Done without Start should panic
+	require.Panics(t, func() {
+		g.Done()
+	})
+}
+
+func TestGate_Concurrency(t *testing.T) {
+	observer := &mockObserver{}
+	const concurrency = 3
+	g := NewWithMetric(concurrency, observer)
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for range numGoroutines {
+		go func() {
+			defer wg.Done()
+			err := g.Start(context.Background())
+			require.NoError(t, err)
+			time.Sleep(10 * time.Millisecond)
+			g.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	// All goroutines should have completed
+	require.Equal(t, numGoroutines, observer.count())
+}


### PR DESCRIPTION
Add optional wait duration tracking to gate via Observer interface. The remote read handler records time spent waiting for concurrency slots in prometheus_remote_read_handler_wait_duration_seconds histogram.

This helps operators identify when remote read queries are being throttled due to concurrency limits, providing visibility into queue wait times.

#### Which issue(s) does the PR fix:
Fixes #11365

#### Does this PR introduce a user-facing change?
```release-notes
[ENHANCEMENT] Remote-read: Add `prometheus_remote_read_handler_wait_duration_seconds` histogram metric tracking time spent waiting for concurrency slots.
```