### PR TITLE
chore: enable staticcheck linter and update golangci-lint to 2.10.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,12 @@ jobs:
         with:
           args: --verbose --build-tags=dedupelabels
           version: ${{ steps.golangci-lint-version.outputs.version }}
+      - name: Lint in documentation/examples/remote_storage
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          args: --verbose
+          working-directory: documentation/examples/remote_storage
+          version: ${{ steps.golangci-lint-version.outputs.version }}
   fuzzing:
     uses: ./.github/workflows/fuzzing.yml
     if: github.event_name == 'pull_request'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,7 @@ linters:
     - predeclared
     - revive
     - sloglint
+    - staticcheck
     - testifylint
     - unconvert
     - unused

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_FMT_OPTS ?=
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -948,11 +948,11 @@ func checkRuleGroups(rgs *rulefmt.RuleGroups, lintSettings rulesLintConfig) (int
 		dRules := checkDuplicates(rgs.Groups)
 		if len(dRules) != 0 {
 			var errMessage strings.Builder
-			errMessage.WriteString(fmt.Sprintf("%d duplicate rule(s) found.\n", len(dRules)))
+			fmt.Fprintf(&errMessage, "%d duplicate rule(s) found.\n", len(dRules))
 			for _, n := range dRules {
-				errMessage.WriteString(fmt.Sprintf("Metric: %s\nLabel(s):\n", n.metric))
+				fmt.Fprintf(&errMessage, "Metric: %s\nLabel(s):\n", n.metric)
 				n.label.Range(func(l labels.Label) {
-					errMessage.WriteString(fmt.Sprintf("\t%s: %s\n", l.Name, l.Value))
+					fmt.Fprintf(&errMessage, "\t%s: %s\n", l.Name, l.Value)
 				})
 			}
 			errMessage.WriteString("Might cause inconsistency while recording expressions")

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -561,9 +561,9 @@ Outer:
 // seriesLoadingString returns the input series in PromQL notation.
 func (tg *testGroup) seriesLoadingString() string {
 	var result strings.Builder
-	result.WriteString(fmt.Sprintf("load %v\n", shortDuration(tg.Interval)))
+	fmt.Fprintf(&result, "load %v\n", shortDuration(tg.Interval))
 	for _, is := range tg.InputSeries {
-		result.WriteString(fmt.Sprintf("  %v %v\n", is.Series, is.Values))
+		fmt.Fprintf(&result, "  %v %v\n", is.Series, is.Values)
 	}
 	return result.String()
 }

--- a/documentation/examples/remote_storage/remote_storage_adapter/graphite/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/graphite/client.go
@@ -73,8 +73,7 @@ func pathFromMetric(m model.Metric, prefix string) string {
 		// Since we use '.' instead of '=' to separate label and values
 		// it means that we can't have an '.' in the metric name. Fortunately
 		// this is prohibited in prometheus metrics.
-		buffer.WriteString(fmt.Sprintf(
-			".%s.%s", string(l), escape(v)))
+		fmt.Fprintf(&buffer, ".%s.%s", string(l), escape(v))
 	}
 	return buffer.String()
 }

--- a/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
@@ -166,9 +166,9 @@ func (c *Client) buildCommand(q *prompb.Query) (string, error) {
 		if m.Name == model.MetricNameLabel {
 			switch m.Type {
 			case prompb.LabelMatcher_EQ:
-				measurement.WriteString(fmt.Sprintf(" == \"%s\"", m.Value))
+				fmt.Fprintf(&measurement, " == \"%s\"", m.Value)
 			case prompb.LabelMatcher_RE:
-				measurement.WriteString(fmt.Sprintf(" =~ /%s/", escapeSlashes(m.Value)))
+				fmt.Fprintf(&measurement, " =~ /%s/", escapeSlashes(m.Value))
 			default:
 				// TODO: Figure out how to support these efficiently.
 				return "", errors.New("non-equal or regex-non-equal matchers are not supported on the metric name yet")

--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -38,7 +38,7 @@ func tree(node Node, level string) string {
 	typs := strings.Split(fmt.Sprintf("%T", node), ".")[1]
 
 	var t strings.Builder
-	t.WriteString(fmt.Sprintf("%s |---- %s :: %s\n", level, typs, node))
+	fmt.Fprintf(&t, "%s |---- %s :: %s\n", level, typs, node)
 
 	level += " · · ·"
 

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -1267,10 +1267,8 @@ func debugCircularBuffer(ce *CircularExemplarStorage) string {
 		if e.ref == nil {
 			continue
 		}
-		sb.WriteString(fmt.Sprintf(
-			"i: %d, ts: %d, next: %d, prev: %d",
-			i, e.exemplar.Ts, e.next, e.prev,
-		))
+		fmt.Fprintf(&sb, "i: %d, ts: %d, next: %d, prev: %d",
+			i, e.exemplar.Ts, e.next, e.prev)
 		for _, idx := range ce.index {
 			if i == idx.newest {
 				sb.WriteString(" <- newest " + idx.seriesLabels.String())
@@ -1281,6 +1279,6 @@ func debugCircularBuffer(ce *CircularExemplarStorage) string {
 		}
 		sb.WriteString("\n")
 	}
-	sb.WriteString(fmt.Sprintf("Next index: %d\n", ce.nextIndex))
+	fmt.Fprintf(&sb, "Next index: %d\n", ce.nextIndex)
 	return sb.String()
 }

--- a/util/teststorage/appender.go
+++ b/util/teststorage/appender.go
@@ -76,9 +76,9 @@ func (s Sample) String() string {
 	if s.FH != nil {
 		fh = " " + s.FH.String()
 	}
-	b.WriteString(fmt.Sprintf("%s %v%v%v st@%v t@%v", s.L.String(), s.V, h, fh, s.ST, s.T))
+	fmt.Fprintf(&b, "%s %v%v%v st@%v t@%v", s.L.String(), s.V, h, fh, s.ST, s.T)
 	if len(s.ES) > 0 {
-		b.WriteString(fmt.Sprintf(" %v", s.ES))
+		fmt.Fprintf(&b, " %v", s.ES)
 	}
 	b.WriteString("\n")
 	return b.String()


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

enables and fixes staticcheck linter issues

```release-notes
[ENHANCEMENT]: enable staticcheck linter and update golangci-lint to 2.10.1
```
