### PR TITLE
promtool: add tests for parser feature flag propagation across subcommands

### DIFF
--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -662,6 +662,45 @@ func TestCheckRulesWithFeatureFlag(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCheckConfigWithFeatureFlag(t *testing.T) {
+	// Similar to TestCheckRulesWithFeatureFlag but for "check config".
+	// The config references rule files that use experimental syntax,
+	// so feature flags must be propagated to the parser.
+	args := []string{"-test.main", "--enable-feature=promql-experimental-functions", "--enable-feature=promql-duration-expr", "--enable-feature=promql-extended-range-selectors", "check", "config", "testdata/config_with_features.yml"}
+	tool := exec.Command(promtoolPath, args...)
+	require.NoError(t, tool.Run())
+}
+
+func TestTestRulesWithFeatureFlag(t *testing.T) {
+	// Similar to TestCheckRulesWithFeatureFlag but for "test rules".
+	// The test file references rule files that use experimental syntax,
+	// so feature flags must be propagated to the rules manager's parser.
+	args := []string{"-test.main", "--enable-feature=promql-experimental-functions", "--enable-feature=promql-duration-expr", "--enable-feature=promql-extended-range-selectors", "test", "rules", "testdata/features-test.yml"}
+	tool := exec.Command(promtoolPath, args...)
+	require.NoError(t, tool.Run())
+}
+
+func TestFormatPromQLWithFeatureFlag(t *testing.T) {
+	// Ensure "promql format" respects --enable-feature flags.
+	args := []string{"-test.main", "--experimental", "--enable-feature=promql-experimental-functions", "promql", "format", `sort_by_label(up, "instance")`}
+	tool := exec.Command(promtoolPath, args...)
+	require.NoError(t, tool.Run())
+}
+
+func TestLabelsSetPromQLWithFeatureFlag(t *testing.T) {
+	// Ensure "promql labels set" respects --enable-feature flags.
+	args := []string{"-test.main", "--experimental", "--enable-feature=promql-experimental-functions", "promql", "label-matchers", "set", `sort_by_label(up, "instance")`, "job", "prometheus"}
+	tool := exec.Command(promtoolPath, args...)
+	require.NoError(t, tool.Run())
+}
+
+func TestLabelsDeletePromQLWithFeatureFlag(t *testing.T) {
+	// Ensure "promql label-matchers delete" respects --enable-feature flags.
+	args := []string{"-test.main", "--experimental", "--enable-feature=promql-experimental-functions", "promql", "label-matchers", "delete", `sort_by_label(up, "instance")`, "job"}
+	tool := exec.Command(promtoolPath, args...)
+	require.NoError(t, tool.Run())
+}
+
 func TestCheckRulesWithRuleFiles(t *testing.T) {
 	t.Run("rules-good", func(t *testing.T) {
 		t.Parallel()

--- a/cmd/promtool/testdata/config_with_features.yml
+++ b/cmd/promtool/testdata/config_with_features.yml
@@ -1,0 +1,2 @@
+rule_files:
+  - features.yml

--- a/cmd/promtool/testdata/features-test.yml
+++ b/cmd/promtool/testdata/features-test.yml
@@ -1,0 +1,6 @@
+rule_files:
+  - features.yml
+
+evaluation_interval: 1m
+
+tests: []


### PR DESCRIPTION
This is a follow-up from #18097
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Improves test coverage so #18092 and #18093 don't happen again as suggested in https://github.com/prometheus/prometheus/pull/18097#issuecomment-3911392578.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
