### PR TITLE
chore(ci): Add registry-specific architecture exclusions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 # Needs to be defined before including Makefile.common to auto-generate targets
 DOCKER_ARCHS ?= amd64 armv7 arm64 ppc64le riscv64 s390x
 DOCKERFILE_ARCH_EXCLUSIONS ?= Dockerfile.distroless:riscv64
+DOCKER_REGISTRY_ARCH_EXCLUSIONS ?= quay.io:riscv64
 
 UI_PATH = web/ui
 UI_NODE_MODULES_PATH = $(UI_PATH)/node_modules

--- a/Makefile.common
+++ b/Makefile.common
@@ -117,6 +117,16 @@ case " $(DOCKERFILE_ARCH_EXCLUSIONS) " in \
 esac
 endef
 
+# Shell helper to check whether a registry/arch pair is excluded.
+# Extracts registry from DOCKER_REPO (e.g., quay.io/prometheus -> quay.io)
+define registry_arch_is_excluded
+registry=$$(echo "$(DOCKER_REPO)" | cut -d'/' -f1); \
+case " $(DOCKER_REGISTRY_ARCH_EXCLUSIONS) " in \
+	*" $$registry:$(1) "*) true ;; \
+	*) false ;; \
+esac
+endef
+
 BUILD_DOCKER_ARCHS = $(addprefix common-docker-,$(DOCKER_ARCHS))
 PUBLISH_DOCKER_ARCHS = $(addprefix common-docker-publish-,$(DOCKER_ARCHS))
 TAG_DOCKER_ARCHS = $(addprefix common-docker-tag-latest-,$(DOCKER_ARCHS))
@@ -300,6 +310,10 @@ $(PUBLISH_DOCKER_ARCHS): common-docker-publish-%:
 			echo "Skipping push for $$variant_name variant on linux-$* (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
 			continue; \
 		fi; \
+		if $(call registry_arch_is_excluded,$*); then \
+			echo "Skipping push for $$variant_name variant on linux-$* to $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
+			continue; \
+		fi; \
 		if [ "$$dockerfile" != "Dockerfile" ] || [ "$$variant_name" != "default" ]; then \
 			echo "Pushing $$variant_name variant for linux-$*"; \
 			docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name"; \
@@ -331,6 +345,10 @@ $(TAG_DOCKER_ARCHS): common-docker-tag-latest-%:
 			echo "Skipping tag for $$variant_name variant on linux-$* (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
 			continue; \
 		fi; \
+		if $(call registry_arch_is_excluded,$*); then \
+			echo "Skipping tag for $$variant_name variant on linux-$* for $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
+			continue; \
+		fi; \
 		if [ "$$dockerfile" != "Dockerfile" ] || [ "$$variant_name" != "default" ]; then \
 			echo "Tagging $$variant_name variant for linux-$* as latest"; \
 			docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:latest-$$variant_name"; \
@@ -353,6 +371,11 @@ common-docker-manifest:
 			refs=""; \
 			for arch in $(DOCKER_ARCHS); do \
 				if $(call dockerfile_arch_is_excluded,$$arch); then \
+					echo "  Skipping $$arch for $$variant_name (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
+					continue; \
+				fi; \
+				if $(call registry_arch_is_excluded,$$arch); then \
+					echo "  Skipping $$arch for $$variant_name on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
 					continue; \
 				fi; \
 				refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name"; \
@@ -369,6 +392,11 @@ common-docker-manifest:
 			refs=""; \
 			for arch in $(DOCKER_ARCHS); do \
 				if $(call dockerfile_arch_is_excluded,$$arch); then \
+					echo "  Skipping $$arch for default variant (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
+					continue; \
+				fi; \
+				if $(call registry_arch_is_excluded,$$arch); then \
+					echo "  Skipping $$arch for default variant on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
 					continue; \
 				fi; \
 				refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:$(SANITIZED_DOCKER_IMAGE_TAG)"; \
@@ -386,6 +414,11 @@ common-docker-manifest:
 				refs=""; \
 				for arch in $(DOCKER_ARCHS); do \
 					if $(call dockerfile_arch_is_excluded,$$arch); then \
+						echo "  Skipping $$arch for $$variant_name version tag (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
+						continue; \
+					fi; \
+					if $(call registry_arch_is_excluded,$$arch); then \
+						echo "  Skipping $$arch for $$variant_name version tag on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
 						continue; \
 					fi; \
 					refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:v$(DOCKER_MAJOR_VERSION_TAG)-$$variant_name"; \
@@ -402,6 +435,11 @@ common-docker-manifest:
 				refs=""; \
 				for arch in $(DOCKER_ARCHS); do \
 					if $(call dockerfile_arch_is_excluded,$$arch); then \
+						echo "  Skipping $$arch for default variant version tag (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
+						continue; \
+					fi; \
+					if $(call registry_arch_is_excluded,$$arch); then \
+						echo "  Skipping $$arch for default variant version tag on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
 						continue; \
 					fi; \
 					refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:v$(DOCKER_MAJOR_VERSION_TAG)"; \


### PR DESCRIPTION
Fixes #18123

Introduces DOCKER_REGISTRY_ARCH_EXCLUSIONS to exclude specific architectures from specific registries. This allows riscv64 to be excluded from quay.io (which returns unauthorized) while still supporting it on docker.io.

The new registry_arch_is_excluded function extracts the registry from DOCKER_REPO and checks if registry:arch is in the exclusion list. This is applied during push, tag, and manifest creation steps.

This fix ensures s390x and other architectures are included in quay.io manifests even when riscv64 fails to push.

**NOTE**: riskv64 is NEW in 3.10.


Build logs:

```
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:27.4538937Z The push refers to repository [quay.io/prometheus/prometheus-linux-riscv64]
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:27.6333916Z 7ac317945e9d: Preparing
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:27.6334330Z a030688b1e26: Preparing
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:27.6334633Z 7ac317945e9d: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:28.5214235Z 4bd9d25b163b: Preparing
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:28.5214638Z a030688b1e26: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.0885580Z e63b52d7e24c: Preparing
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.2531743Z 4bd9d25b163b: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.2532135Z af4bcd508a2a: Preparing
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.2532499Z e63b52d7e24c: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.2532793Z 38f46c5f185d: Preparing
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.2533254Z c17fb38494a3: Preparing
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.2533692Z 087f4c11c9ac: Preparing
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.2533974Z 087f4c11c9ac: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.2534392Z af4bcd508a2a: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.2534770Z 38f46c5f185d: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.2535053Z c17fb38494a3: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.4477264Z 638267266792: Preparing
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.4477669Z 638267266792: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:29.4477957Z 087f4c11c9ac: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:30.6056101Z 615dbd7b7395: Preparing
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:30.6056628Z 615dbd7b7395: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:30.6057116Z 638267266792: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:30.7542416Z 615dbd7b7395: Waiting
Publish release artefacts       UNKNOWN STEP    2026-02-20T00:48:30.7543209Z unauthorized: access to the requested resource is not authorized
```
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
