### PR TITLE
scrape: Fix race condition in scrapeFailureLogger access

### DIFF
--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"maps"
 	"math"
 	"net/http"
@@ -6733,4 +6734,55 @@ func testDropsSeriesFromMetricRelabeling(t *testing.T, appV2 bool) {
 	require.Equal(t, 0, seriesAdded)
 
 	require.NoError(t, app.Commit())
+}
+
+// noopFailureLogger is a minimal FailureLogger implementation for testing.
+type noopFailureLogger struct{}
+
+func (noopFailureLogger) Enabled(context.Context, slog.Level) bool  { return true }
+func (noopFailureLogger) Handle(context.Context, slog.Record) error { return nil }
+func (noopFailureLogger) WithAttrs([]slog.Attr) slog.Handler        { return noopFailureLogger{} }
+func (noopFailureLogger) WithGroup(string) slog.Handler             { return noopFailureLogger{} }
+func (noopFailureLogger) Close() error                              { return nil }
+
+// TestScrapePoolSetScrapeFailureLoggerRace is a regression test for concurrent
+// access to scrapeFailureLogger. Both must use targetMtx for synchronization.
+func TestScrapePoolSetScrapeFailureLoggerRace(t *testing.T) {
+	var (
+		app = teststorage.NewAppendable()
+		cfg = &config.ScrapeConfig{
+			JobName:                    "test",
+			ScrapeInterval:             model.Duration(100 * time.Millisecond),
+			ScrapeTimeout:              model.Duration(50 * time.Millisecond),
+			MetricNameValidationScheme: model.UTF8Validation,
+			MetricNameEscapingScheme:   model.AllowUTF8,
+		}
+		sp, err = newScrapePool(cfg, app, nil, 0, nil, nil, &Options{}, newTestScrapeMetrics(t))
+	)
+	require.NoError(t, err)
+	defer sp.stop()
+
+	// Create a target group with a target.
+	tg := &targetgroup.Group{
+		Targets: []model.LabelSet{
+			{model.AddressLabel: "127.0.0.1:9090"},
+		},
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		for range 100 {
+			sp.SetScrapeFailureLogger(noopFailureLogger{})
+			sp.SetScrapeFailureLogger(nil)
+		}
+	})
+
+	wg.Go(func() {
+		for range 100 {
+			sp.Sync([]*targetgroup.Group{tg})
+		}
+	})
+
+	wg.Wait()
 }


### PR DESCRIPTION
Remove the separate scrapeFailureLoggerMtx and use targetMtx instead for synchronizing access to scrapeFailureLogger. This fixes a data race where Sync() would read scrapeFailureLogger while holding targetMtx but SetScrapeFailureLogger() would write to it while holding a different mutex.

Add regression test to catch concurrent access issues.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
