### PR TITLE
fix(discovery): apply EC2 SD endpoint and guard refreshAZIDs nils

### DIFF
--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -188,7 +188,12 @@ func (d *LightsailDiscovery) lightsailClient(ctx context.Context) (*lightsail.Cl
 		cfg.Credentials = aws.NewCredentialsCache(assumeProvider)
 	}
 
-	d.lightsail = lightsail.NewFromConfig(cfg)
+	d.lightsail = lightsail.NewFromConfig(cfg, func(options *lightsail.Options) {
+		if d.cfg.Endpoint != "" {
+			options.BaseEndpoint = &d.cfg.Endpoint
+		}
+		options.HTTPClient = httpClient
+	})
 
 	return d.lightsail, nil
 }


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
N/A

#### Context (regression)

The `endpoint` option for EC2 SD stopped being applied after the [AWS SDK v2 migration](https://github.com/prometheus/prometheus/commit/eab9b696f2901cd8e446cfc230ba31dee5d5aeab). The v1 code passed `Endpoint` into the session config; the v2 code builds the client with `LoadDefaultConfig` but never passes the configured endpoint, so the field was effectively dropped.

The [configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#ec2_sd_config) still documents `endpoint` for `ec2_sd_config`. Custom endpoints are needed for AWS-compatible APIs (e.g. [Outscale](https://outscale.com/), LocalStack, or other EC2-compatible endpoints) so users can point EC2 SD at a custom API URL.

This PR restores endpoint handling by calling `awsConfig.WithBaseEndpoint(d.cfg.Endpoint)` when `endpoint` is set, and adds nil-safety in `refreshAZIDs`: the AWS SDK v2 `DescribeAvailabilityZones` response can have `AvailabilityZones == nil` or entries with nil `ZoneName`/`ZoneId`, which would panic when building the `azToAZID` map. We now guard against nil and skip invalid entries.

#### Does this PR introduce a user-facing change?
Yes. The documented `endpoint` option in `ec2_sd_config` is applied again when building the EC2 client, and availability zone handling no longer panics on nil responses.

```release-notes
[BUGFIX] discovery: EC2 SD now respects the configured `endpoint` option when building the AWS client (regression from AWS SDK v2 migration). Also adds nil-safety in availability zone handling to avoid panics when DescribeAvailabilityZones returns nil or nil ZoneName/ZoneId.
```
