### PR TITLE
feat(discovery): add Outscale VM service discovery

### DIFF
--- a/cmd/prometheus/testdata/features.json
+++ b/cmd/prometheus/testdata/features.json
@@ -204,6 +204,7 @@
     "nerve": true,
     "nomad": true,
     "openstack": true,
+    "outscale": true,
     "ovhcloud": true,
     "puppetdb": true,
     "rds": true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/moby"
 	"github.com/prometheus/prometheus/discovery/nomad"
 	"github.com/prometheus/prometheus/discovery/openstack"
+	"github.com/prometheus/prometheus/discovery/outscale"
 	"github.com/prometheus/prometheus/discovery/ovhcloud"
 	"github.com/prometheus/prometheus/discovery/puppetdb"
 	"github.com/prometheus/prometheus/discovery/scaleway"
@@ -1708,6 +1709,44 @@ var expectedConf = &Config{
 				},
 			},
 		},
+		{
+			JobName: "outscale",
+
+			HonorTimestamps:                true,
+			ScrapeInterval:                 model.Duration(15 * time.Second),
+			ScrapeTimeout:                  DefaultGlobalConfig.ScrapeTimeout,
+			EnableCompression:              true,
+			BodySizeLimit:                  globBodySizeLimit,
+			SampleLimit:                    globSampleLimit,
+			TargetLimit:                    globTargetLimit,
+			LabelLimit:                     globLabelLimit,
+			LabelNameLengthLimit:           globLabelNameLengthLimit,
+			LabelValueLengthLimit:          globLabelValueLengthLimit,
+			ScrapeProtocols:                DefaultScrapeProtocols,
+			ScrapeFailureLogFile:           globScrapeFailureLogFile,
+			MetricNameValidationScheme:     DefaultGlobalConfig.MetricNameValidationScheme,
+			MetricNameEscapingScheme:       DefaultGlobalConfig.MetricNameEscapingScheme,
+			ScrapeNativeHistograms:         boolPtr(false),
+			AlwaysScrapeClassicHistograms:  boolPtr(false),
+			ConvertClassicHistogramsToNHCB: boolPtr(false),
+			ExtraScrapeMetrics:             boolPtr(false),
+
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
+
+			ServiceDiscoveryConfigs: discovery.Configs{
+				&outscale.SDConfig{
+					Endpoint:         "https://api.eu-west-2.outscale.com/api/v1",
+					Region:           "eu-west-2",
+					AccessKey:        "A1B2C3D4E5F6G7H8I9J0",
+					SecretKey:        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+					Port:             80,
+					RefreshInterval:  model.Duration(60 * time.Second),
+					HTTPClientConfig: config.DefaultHTTPClientConfig,
+				},
+			},
+		},
 	},
 	AlertingConfig: AlertingConfig{
 		AlertmanagerConfigs: []*AlertmanagerConfig{
@@ -2087,6 +2126,7 @@ func TestLoadConfig(t *testing.T) {
 	testutil.RequireEqualWithOptions(t, expectedConf, c, []cmp.Option{
 		cmpopts.IgnoreUnexported(config.ProxyConfig{}),
 		cmpopts.IgnoreUnexported(ionos.SDConfig{}),
+		cmpopts.IgnoreUnexported(outscale.SDConfig{}),
 		cmpopts.IgnoreUnexported(stackit.SDConfig{}),
 		cmpopts.IgnoreUnexported(regexp.Regexp{}),
 		cmpopts.IgnoreUnexported(hetzner.SDConfig{}),
@@ -2115,7 +2155,7 @@ func TestElideSecrets(t *testing.T) {
 	yamlConfig := string(config)
 
 	matches := secretRe.FindAllStringIndex(yamlConfig, -1)
-	require.Len(t, matches, 25, "wrong number of secret matches found")
+	require.Len(t, matches, 26, "wrong number of secret matches found")
 	require.NotContains(t, yamlConfig, "mysecret",
 		"yaml marshal reveals authentication credentials.")
 }
@@ -2536,6 +2576,18 @@ var expectedErrors = []struct {
 	},
 	{
 		filename: "scaleway_two_secrets.bad.yml",
+		errMsg:   "at most one of secret_key & secret_key_file must be configured",
+	},
+	{
+		filename: "outscale_no_region.bad.yml",
+		errMsg:   "outscale SD configuration requires a region",
+	},
+	{
+		filename: "outscale_no_secret.bad.yml",
+		errMsg:   "one of secret_key & secret_key_file must be configured",
+	},
+	{
+		filename: "outscale_two_secrets.bad.yml",
 		errMsg:   "at most one of secret_key & secret_key_file must be configured",
 	},
 	{

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -441,6 +441,12 @@ scrape_configs:
       - authorization:
           credentials: abcdef
 
+  - job_name: outscale
+    outscale_sd_configs:
+      - region: eu-west-2
+        access_key: A1B2C3D4E5F6G7H8I9J0
+        secret_key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
 alerting:
   alertmanagers:
     - scheme: https

--- a/config/testdata/outscale_no_region.bad.yml
+++ b/config/testdata/outscale_no_region.bad.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: outscale
+    outscale_sd_configs:
+      - region: ""
+        access_key: A1B2C3D4E5F6G7H8I9J0
+        secret_key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/config/testdata/outscale_no_secret.bad.yml
+++ b/config/testdata/outscale_no_secret.bad.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: prometheus
+    outscale_sd_configs:
+      - region: eu-west-2
+        access_key: A1B2C3D4E5F6G7H8I9J0

--- a/config/testdata/outscale_two_secrets.bad.yml
+++ b/config/testdata/outscale_two_secrets.bad.yml
@@ -1,0 +1,7 @@
+scrape_configs:
+  - job_name: outscale
+    outscale_sd_configs:
+      - region: eu-west-2
+        access_key: A1B2C3D4E5F6G7H8I9J0
+        secret_key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        secret_key_file: /tmp/outscale-secret-key

--- a/discovery/install/install.go
+++ b/discovery/install/install.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/prometheus/prometheus/discovery/moby"         // register moby
 	_ "github.com/prometheus/prometheus/discovery/nomad"        // register nomad
 	_ "github.com/prometheus/prometheus/discovery/openstack"    // register openstack
+	_ "github.com/prometheus/prometheus/discovery/outscale"     // register outscale
 	_ "github.com/prometheus/prometheus/discovery/ovhcloud"     // register ovhcloud
 	_ "github.com/prometheus/prometheus/discovery/puppetdb"     // register puppetdb
 	_ "github.com/prometheus/prometheus/discovery/scaleway"     // register scaleway

--- a/discovery/outscale/metrics.go
+++ b/discovery/outscale/metrics.go
@@ -1,0 +1,32 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outscale
+
+import (
+	"github.com/prometheus/prometheus/discovery"
+)
+
+var _ discovery.DiscovererMetrics = (*outscaleMetrics)(nil)
+
+type outscaleMetrics struct {
+	refreshMetrics discovery.RefreshMetricsInstantiator
+}
+
+// Register implements discovery.DiscovererMetrics.
+func (*outscaleMetrics) Register() error {
+	return nil
+}
+
+// Unregister implements discovery.DiscovererMetrics.
+func (*outscaleMetrics) Unregister() {}

--- a/discovery/outscale/outscale.go
+++ b/discovery/outscale/outscale.go
@@ -1,0 +1,171 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outscale
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	osc "github.com/outscale/osc-sdk-go/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/version"
+
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/refresh"
+)
+
+const (
+	metaLabelPrefix = model.MetaLabelPrefix + "outscale_"
+)
+
+// DefaultSDConfig is the default Outscale Service Discovery configuration.
+var DefaultSDConfig = SDConfig{
+	Port:             80,
+	RefreshInterval:  model.Duration(60 * time.Second),
+	HTTPClientConfig: config.DefaultHTTPClientConfig,
+	Region:           "eu-west-2",
+}
+
+// SDConfig is the configuration for Outscale VM-based service discovery
+// using the OUTSCALE API (OAPI).
+type SDConfig struct {
+	Endpoint         string                  `yaml:"endpoint,omitempty"`
+	Region           string                  `yaml:"region"`
+	AccessKey        string                  `yaml:"access_key"`
+	SecretKey        config.Secret           `yaml:"secret_key"`
+	SecretKeyFile    string                  `yaml:"secret_key_file"`
+	RefreshInterval  model.Duration          `yaml:"refresh_interval,omitempty"`
+	Port             int                     `yaml:"port"`
+	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
+}
+
+// NewDiscovererMetrics implements discovery.Config.
+func (*SDConfig) NewDiscovererMetrics(_ prometheus.Registerer, rmi discovery.RefreshMetricsInstantiator) discovery.DiscovererMetrics {
+	return &outscaleMetrics{
+		refreshMetrics: rmi,
+	}
+}
+
+// Name returns the name of the discovery mechanism.
+func (SDConfig) Name() string {
+	return "outscale"
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	*c = DefaultSDConfig
+	type plain SDConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	if c.Region == "" {
+		return errors.New("outscale SD configuration requires a region")
+	}
+	if c.AccessKey == "" {
+		return errors.New("outscale SD configuration requires access_key")
+	}
+	if c.SecretKey == "" && c.SecretKeyFile == "" {
+		return errors.New("one of secret_key & secret_key_file must be configured")
+	}
+	if c.SecretKey != "" && c.SecretKeyFile != "" {
+		return errors.New("at most one of secret_key & secret_key_file must be configured")
+	}
+	if c.Endpoint == "" {
+		c.Endpoint = "https://api." + c.Region + ".outscale.com/api/v1"
+	}
+	return c.HTTPClientConfig.Validate()
+}
+
+// SetDirectory joins any relative file paths with dir.
+func (c *SDConfig) SetDirectory(dir string) {
+	c.SecretKeyFile = config.JoinDir(dir, c.SecretKeyFile)
+	c.HTTPClientConfig.SetDirectory(dir)
+}
+
+func (c *SDConfig) SecretKeyValue() (config.Secret, error) {
+	if c.SecretKeyFile == "" {
+		return c.SecretKey, nil
+	}
+	secret, err := os.ReadFile(c.SecretKeyFile)
+	if err != nil {
+		return "", fmt.Errorf("unable to read outscale secret key file %s: %w", c.SecretKeyFile, err)
+	}
+	return config.Secret(strings.TrimSpace(string(secret))), nil
+}
+
+// NewDiscoverer returns a Discoverer for the Config.
+func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Discoverer, error) {
+	return NewDiscovery(c, opts)
+}
+
+func init() {
+	discovery.RegisterConfig(&SDConfig{})
+}
+
+// Discovery periodically performs Outscale API requests.
+type Discovery struct{}
+
+// NewDiscovery returns a new Discovery which periodically refreshes its targets.
+func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*refresh.Discovery, error) {
+	m, ok := opts.Metrics.(*outscaleMetrics)
+	if !ok {
+		return nil, errors.New("invalid discovery metrics type")
+	}
+
+	d, err := newVMDiscovery(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return refresh.NewDiscovery(
+		refresh.Options{
+			Logger:              opts.Logger,
+			Mech:                "outscale",
+			SetName:             opts.SetName,
+			Interval:            time.Duration(conf.RefreshInterval),
+			RefreshF:            d.refresh,
+			MetricsInstantiator: m.refreshMetrics,
+		},
+	), nil
+}
+
+// loadClient builds an Outscale API client from SDConfig using the official osc-sdk-go (OAPI).
+func loadClient(conf *SDConfig) (*osc.APIClient, error) {
+	rt, err := config.NewRoundTripperFromConfig(conf.HTTPClientConfig, "outscale_sd")
+	if err != nil {
+		return nil, fmt.Errorf("outscale SD client config: %w", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: rt,
+		Timeout:   time.Duration(conf.RefreshInterval),
+	}
+
+	cfg := osc.NewConfiguration()
+	cfg.HTTPClient = httpClient
+	cfg.UserAgent = version.PrometheusUserAgent()
+	// Use a single server URL (custom endpoint or default per-region).
+	cfg.Servers = osc.ServerConfigurations{
+		osc.ServerConfiguration{URL: conf.Endpoint, Description: "Outscale API"},
+	}
+
+	client := osc.NewAPIClient(cfg)
+	return client, nil
+}

--- a/discovery/outscale/vm.go
+++ b/discovery/outscale/vm.go
@@ -1,0 +1,144 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outscale
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	osc "github.com/outscale/osc-sdk-go/v2"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+const (
+	vmLabelPrefix     = metaLabelPrefix + "vm_"
+	vmLabelInstanceID = vmLabelPrefix + "instance_id"
+	vmLabelRegion     = vmLabelPrefix + "region"
+	vmLabelSubregion  = vmLabelPrefix + "subregion"
+	vmLabelState      = vmLabelPrefix + "state"
+	vmLabelPrivateIP  = vmLabelPrefix + "private_ip"
+	vmLabelPublicIP   = vmLabelPrefix + "public_ip"
+	vmLabelTag        = vmLabelPrefix + "tag_"
+)
+
+type vmDiscovery struct {
+	client *osc.APIClient
+	cfg    *SDConfig
+}
+
+func newVMDiscovery(conf *SDConfig) (*vmDiscovery, error) {
+	client, err := loadClient(conf)
+	if err != nil {
+		return nil, err
+	}
+	return &vmDiscovery{
+		client: client,
+		cfg:    conf,
+	}, nil
+}
+
+func (d *vmDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	secretKey, err := d.cfg.SecretKeyValue()
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge request context with auth context so the SDK signs requests.
+	ctx = context.WithValue(ctx, osc.ContextAWSv4, osc.AWSv4{
+		AccessKey: d.cfg.AccessKey,
+		SecretKey: string(secretKey),
+	})
+
+	tg := &targetgroup.Group{Source: d.cfg.Region}
+
+	var allVms []osc.Vm
+	req := d.client.VmApi.ReadVms(ctx).ReadVmsRequest(osc.ReadVmsRequest{})
+
+	for {
+		resp, _, err := req.Execute()
+		if err != nil {
+			return nil, fmt.Errorf("outscale ReadVms: %w", err)
+		}
+		if resp.Vms != nil {
+			allVms = append(allVms, *resp.Vms...)
+		}
+		if resp.NextPageToken == nil || *resp.NextPageToken == "" {
+			break
+		}
+		req = d.client.VmApi.ReadVms(ctx).ReadVmsRequest(osc.ReadVmsRequest{NextPageToken: resp.NextPageToken})
+	}
+
+	tg.Targets = vmsToLabelSets(allVms, d.cfg)
+	return []*targetgroup.Group{tg}, nil
+}
+
+// vmsToLabelSets converts Outscale VMs into target label sets.
+func vmsToLabelSets(vms []osc.Vm, cfg *SDConfig) []model.LabelSet {
+	var out []model.LabelSet
+	for _, vm := range vms {
+		var addr string
+		switch {
+		case vm.PrivateIp != nil && *vm.PrivateIp != "":
+			addr = net.JoinHostPort(*vm.PrivateIp, strconv.Itoa(cfg.Port))
+		case vm.PublicIp != nil && *vm.PublicIp != "":
+			addr = net.JoinHostPort(*vm.PublicIp, strconv.Itoa(cfg.Port))
+		default:
+			continue
+		}
+
+		vmID := ""
+		if vm.VmId != nil {
+			vmID = *vm.VmId
+		}
+		state := ""
+		if vm.State != nil {
+			state = *vm.State
+		}
+
+		labels := model.LabelSet{
+			model.AddressLabel: model.LabelValue(addr),
+			vmLabelInstanceID:  model.LabelValue(vmID),
+			vmLabelRegion:      model.LabelValue(cfg.Region),
+			vmLabelState:       model.LabelValue(state),
+		}
+
+		if vm.Placement != nil && vm.Placement.SubregionName != nil {
+			labels[vmLabelSubregion] = model.LabelValue(*vm.Placement.SubregionName)
+		}
+		if vm.PrivateIp != nil {
+			labels[vmLabelPrivateIP] = model.LabelValue(*vm.PrivateIp)
+		}
+		if vm.PublicIp != nil {
+			labels[vmLabelPublicIP] = model.LabelValue(*vm.PublicIp)
+		}
+
+		if vm.Tags != nil {
+			for _, t := range *vm.Tags {
+				if t.Key == "" || t.Value == "" {
+					continue
+				}
+				name := strutil.SanitizeLabelName(t.Key)
+				labels[vmLabelTag+model.LabelName(name)] = model.LabelValue(t.Value)
+			}
+		}
+
+		out = append(out, labels)
+	}
+	return out
+}

--- a/discovery/outscale/vm_test.go
+++ b/discovery/outscale/vm_test.go
@@ -1,0 +1,123 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outscale
+
+import (
+	"testing"
+
+	osc "github.com/outscale/osc-sdk-go/v2"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func strptr(s string) *string { return &s }
+
+func TestVmsToLabelSets(t *testing.T) {
+	cfg := &SDConfig{
+		Region: "eu-west-2",
+		Port:   9090,
+	}
+
+	t.Run("empty", func(t *testing.T) {
+		out := vmsToLabelSets(nil, cfg)
+		require.Empty(t, out)
+		out = vmsToLabelSets([]osc.Vm{}, cfg)
+		require.Empty(t, out)
+	})
+
+	t.Run("skip_no_ip", func(t *testing.T) {
+		vms := []osc.Vm{
+			{VmId: strptr("i-1"), State: strptr("running")}, // no PrivateIp nor PublicIp
+		}
+		out := vmsToLabelSets(vms, cfg)
+		require.Empty(t, out)
+	})
+
+	t.Run("private_ip_preferred", func(t *testing.T) {
+		vms := []osc.Vm{
+			{
+				VmId:      strptr("i-abc"),
+				State:     strptr("running"),
+				PrivateIp: strptr("10.1.2.3"),
+				PublicIp:  strptr("1.2.3.4"),
+			},
+		}
+		out := vmsToLabelSets(vms, cfg)
+		require.Len(t, out, 1)
+		require.Equal(t, model.LabelValue("10.1.2.3:9090"), out[0][model.AddressLabel])
+		require.Equal(t, model.LabelValue("i-abc"), out[0][vmLabelInstanceID])
+		require.Equal(t, model.LabelValue("eu-west-2"), out[0][vmLabelRegion])
+		require.Equal(t, model.LabelValue("running"), out[0][vmLabelState])
+		require.Equal(t, model.LabelValue("10.1.2.3"), out[0][vmLabelPrivateIP])
+		require.Equal(t, model.LabelValue("1.2.3.4"), out[0][vmLabelPublicIP])
+	})
+
+	t.Run("public_ip_fallback", func(t *testing.T) {
+		vms := []osc.Vm{
+			{
+				VmId:     strptr("i-pub"),
+				State:    strptr("running"),
+				PublicIp: strptr("203.0.113.10"),
+			},
+		}
+		out := vmsToLabelSets(vms, cfg)
+		require.Len(t, out, 1)
+		require.Equal(t, model.LabelValue("203.0.113.10:9090"), out[0][model.AddressLabel])
+		require.Equal(t, model.LabelValue("203.0.113.10"), out[0][vmLabelPublicIP])
+		_, hasPrivate := out[0][vmLabelPrivateIP]
+		require.False(t, hasPrivate)
+	})
+
+	t.Run("subregion_and_tags", func(t *testing.T) {
+		subregion := "eu-west-2a"
+		vms := []osc.Vm{
+			{
+				VmId:      strptr("i-tagged"),
+				State:     strptr("stopped"),
+				PrivateIp: strptr("10.0.0.5"),
+				Placement: &osc.Placement{SubregionName: &subregion},
+				Tags: &[]osc.ResourceTag{
+					{Key: "Name", Value: "my-vm"},
+					{Key: "env", Value: "prod"},
+				},
+			},
+		}
+		out := vmsToLabelSets(vms, cfg)
+		require.Len(t, out, 1)
+		require.Equal(t, model.LabelValue("eu-west-2a"), out[0][vmLabelSubregion])
+		require.Equal(t, model.LabelValue("my-vm"), out[0][vmLabelTag+model.LabelName("Name")])
+		require.Equal(t, model.LabelValue("prod"), out[0][vmLabelTag+model.LabelName("env")])
+	})
+
+	t.Run("skips_empty_tag_key_or_value", func(t *testing.T) {
+		vms := []osc.Vm{
+			{
+				VmId:      strptr("i-tags"),
+				PrivateIp: strptr("10.0.0.1"),
+				Tags: &[]osc.ResourceTag{
+					{Key: "Good", Value: "yes"},
+					{Key: "", Value: "skip"},
+					{Key: "EmptyVal", Value: ""},
+				},
+			},
+		}
+		out := vmsToLabelSets(vms, cfg)
+		require.Len(t, out, 1)
+		require.Equal(t, model.LabelValue("yes"), out[0][vmLabelTag+model.LabelName("Good")])
+		_, hasBad := out[0][vmLabelTag+model.LabelName("")]
+		require.False(t, hasBad)
+		_, hasEmptyVal := out[0][vmLabelTag+model.LabelName("EmptyVal")]
+		require.False(t, hasEmptyVal)
+	})
+}

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -490,6 +490,10 @@ nomad_sd_configs:
 openstack_sd_configs:
   [ - <openstack_sd_config> ... ]
 
+# List of Outscale service discovery configurations.
+outscale_sd_configs:
+  [ - <outscale_sd_config> ... ]
+
 # List of OVHcloud service discovery configurations.
 ovhcloud_sd_configs:
   [ - <ovhcloud_sd_config> ... ]
@@ -3297,6 +3301,49 @@ The following meta labels are available on targets during [relabeling](#relabel_
 [ <http_config> ]
 ```
 
+### `<outscale_sd_config>`
+
+Outscale SD configurations allow retrieving scrape targets from [Outscale Cloud](https://outscale.com/) VMs via the Outscale API (OAPI).
+
+The following meta labels are available on targets during [relabeling](#relabel_config):
+
+* `__meta_outscale_vm_instance_id`: the ID of the VM
+* `__meta_outscale_vm_region`: the region of the VM
+* `__meta_outscale_vm_subregion`: the subregion of the VM
+* `__meta_outscale_vm_state`: the state of the VM
+* `__meta_outscale_vm_private_ip`: the private IP address of the VM
+* `__meta_outscale_vm_public_ip`: the public IP address of the VM
+* `__meta_outscale_vm_tag_<key>`: each tag value; the tag key is sanitized and appended (e.g. tag key `Name` → `__meta_outscale_vm_tag_Name`)
+
+Targets use the first address found: private IP, then public IP. This can be changed with relabeling, as demonstrated in [the Prometheus outscale-sd configuration file](/documentation/examples/prometheus-outscale.yml).
+
+See below for the configuration options for Outscale discovery:
+
+```yaml
+# Region to use.
+[ region: <string> | default = "eu-west-2" ]
+
+# Access key (20 alphanumeric characters). See https://docs.outscale.com/en/userguide/Creating-an-Access-Key.html
+access_key: <string>
+
+# Secret key (40 characters). Use one of `secret_key` or `secret_key_file`.
+[ secret_key: <secret> ]
+
+# Secret key file.
+[ secret_key_file: <filename> ]
+
+# API endpoint URL. Defaults to https://api.<region>.outscale.com/api/v1 if empty.
+[ endpoint: <string> ]
+
+# The port to scrape metrics from.
+[ port: <int> | default = 80 ]
+
+# Refresh interval to re-read the targets list.
+[ refresh_interval: <duration> | default = 60s ]
+
+# HTTP client settings.
+[ <http_config> ]
+```
 
 ### `<static_config>`
 
@@ -3572,6 +3619,10 @@ nomad_sd_configs:
 # List of OpenStack service discovery configurations.
 openstack_sd_configs:
   [ - <openstack_sd_config> ... ]
+
+# List of Outscale service discovery configurations.
+outscale_sd_configs:
+  [ - <outscale_sd_config> ... ]
 
 # List of OVHcloud service discovery configurations.
 ovhcloud_sd_configs:

--- a/documentation/examples/prometheus-outscale.yml
+++ b/documentation/examples/prometheus-outscale.yml
@@ -1,0 +1,35 @@
+# An example scrape configuration for running Prometheus with Outscale.
+# API credentials: access key (20 alphanumeric chars) and secret key (40 chars).
+# See https://docs.outscale.com/en/userguide/Creating-an-Access-Key.html
+scrape_configs:
+  - job_name: 'prometheus'
+    outscale_sd_configs:
+      - # region defaults to eu-west-2 if omitted.
+        region: eu-west-2
+        access_key: A1B2C3D4E5F6G7H8I9J0
+        secret_key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    relabel_configs:
+      # Only scrape targets whose Name tag value contains 'prometheus'.
+      - source_labels: [__meta_outscale_vm_tag_Name]
+        regex: '.*prometheus.*'
+        action: keep
+      # Use the public IP and port 9090 to scrape the target.
+      - source_labels: [__meta_outscale_vm_public_ip]
+        target_label: __address__
+        replacement: '$1:9090'
+      # Add the region as label.
+      - source_labels: [__meta_outscale_vm_region]
+        target_label: outscale_region
+
+  - job_name: 'node'
+    outscale_sd_configs:
+      - region: eu-west-2
+        port: 9100
+        access_key: A1B2C3D4E5F6G7H8I9J0
+        # Configure one of secret_key or secret_key_file.
+        secret_key_file: /etc/prometheus/outscale_secret_key
+    relabel_configs:
+      # Use private IP and node exporter port by default.
+      - source_labels: [__meta_outscale_vm_private_ip]
+        target_label: __address__
+        replacement: '$1:9100'

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/oklog/run v1.2.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.148.0
+	github.com/outscale/osc-sdk-go/v2 v2.32.0
 	github.com/ovh/go-ovh v1.9.0
 	github.com/pb33f/libopenapi v0.34.3
 	github.com/pb33f/libopenapi-validator v0.13.3
@@ -108,6 +109,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go v1.55.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad // indirect
@@ -123,6 +125,7 @@ require (
 	github.com/go-openapi/swag/stringutils v0.25.4 // indirect
 	github.com/go-openapi/swag/typeutils v0.25.4 // indirect
 	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pb33f/jsonpath v0.8.1 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJ
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
+github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
 github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/config v1.32.12 h1:O3csC7HUGn2895eNrLytOJQdoL2xyJy0iYXhoZ1OmP0=
@@ -344,6 +346,10 @@ github.com/ionos-cloud/sdk-go/v6 v6.3.6 h1:l/TtKgdQ1wUH3DDe2SfFD78AW+TJWdEbDpQhH
 github.com/ionos-cloud/sdk-go/v6 v6.3.6/go.mod h1:nUGHP4kZHAZngCVr4v6C8nuargFrtvt7GrzH/hqn7c4=
 github.com/jarcoal/httpmock v1.4.1 h1:0Ju+VCFuARfFlhVXFc2HxlcQkfB+Xq12/EotHko+x2A=
 github.com/jarcoal/httpmock v1.4.1/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -462,6 +468,8 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
+github.com/outscale/osc-sdk-go/v2 v2.32.0 h1:twcX7/YF32aowN0khwK3fPKXGujRi7oOCLLzWcLTX+M=
+github.com/outscale/osc-sdk-go/v2 v2.32.0/go.mod h1:fl+1NvnHptNVE0N57dkDa+H4fyBhlrFaRA+lYiUT44s=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=
 github.com/ovh/go-ovh v1.9.0/go.mod h1:cTVDnl94z4tl8pP1uZ/8jlVxntjSIf09bNcQ5TJSC7c=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -797,6 +805,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/plugins/plugin_outscale.go
+++ b/plugins/plugin_outscale.go
@@ -1,0 +1,20 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !remove_all_sd || enable_outscale_sd
+
+package plugins
+
+import (
+	_ "github.com/prometheus/prometheus/discovery/outscale" // Register outscale plugin.
+)


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

**Title:** `discovery: add Outscale VM service discovery`

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
N/A (new feature).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] Discovery: Add Outscale VM service discovery (`outscale_sd_configs`) for discovering scrape targets from the Outscale Cloud API.
```

---

## Description

This PR adds **Outscale VM service discovery** (`outscale_sd_configs`) so Prometheus can discover scrape targets from the [Outscale Cloud](https://outscale.com/) API (OAPI). It uses the official [Outscale OSC SDK for Go](https://github.com/outscale/osc-sdk-go) and follows the same pattern as other cloud SDs (e.g. Scaleway, EC2).

## Context

- **Issue:** N/A (new feature).
- Outscale provides an AWS-compatible API; this discovery uses the ReadVms API to list VMs and exposes meta labels for relabeling (instance_id, region, private_ip, public_ip, tags, etc.).
- Config requires `region`, `access_key`, and `secret_key`; optional `endpoint` for custom API URL (e.g. for different regions/endpoints).

## Configuration

- **Config reference:** `outscale_sd_configs` under [scrape_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
- **Example:** [documentation/examples/prometheus-outscale.yml](documentation/examples/prometheus-outscale.yml).

Example minimal config:

```yaml
scrape_configs:
  - job_name: outscale
    outscale_sd_configs:
      - region: eu-west-2
        access_key: YOUR_ACCESS_KEY
        secret_key: YOUR_SECRET_KEY
```

With custom endpoint (e.g. Outscale EU):

```yaml
  - job_name: outscale
    outscale_sd_configs:
      - region: eu-west-2
        endpoint: https://api.eu-west-2.outscale.com/api/v1
        access_key: YOUR_ACCESS_KEY
        secret_key: YOUR_SECRET_KEY
```
