### PR TITLE
tsdb: use deferred unlocking in mmapHeadChunks and mmapOOOSeriesChunk to prevent deadlock

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -8774,8 +8774,7 @@ func testDiskFillingUpAfterDisablingOOO(t *testing.T, scenario sampleTypeScenari
 	checkMmapFileContents([]string{"000001", "000002"}, nil)
 
 	// NOTE: We are investigating flaky errors from this compaction on i386 architecture. Compaction panics due to chunk
-	// mapper fatal error. Recover here to understand the error cause. Leaving panic recovery to test causes deadlock
-	// as t.Cleanup tries to close DB with open locks.
+	// mapper fatal error. mmapHeadChunks now uses deferred unlocking, so panics no longer cause deadlocks during cleanup.
 	// See https://github.com/prometheus/prometheus/issues/17941#issuecomment-3846381263
 	require.NotPanics(t, func() {
 		require.NoError(t, db.Compact(ctx))
@@ -8789,8 +8788,7 @@ func testDiskFillingUpAfterDisablingOOO(t *testing.T, scenario sampleTypeScenari
 	checkMmapFileContents([]string{"000002", "000003"}, []string{"000001"})
 
 	// NOTE: We are investigating flaky errors from this compaction on i386 architecture. Compaction panics due to chunk
-	// mapper fatal error. Recover here to understand the error cause. Leaving panic recovery to test causes deadlock
-	// as t.Cleanup tries to close DB with open locks.
+	// mapper fatal error. mmapHeadChunks now uses deferred unlocking, so panics no longer cause deadlocks during cleanup.
 	// See https://github.com/prometheus/prometheus/issues/17941#issuecomment-3846381263
 	require.NotPanics(t, func() {
 		require.NoError(t, db.Compact(ctx))

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -8774,7 +8774,8 @@ func testDiskFillingUpAfterDisablingOOO(t *testing.T, scenario sampleTypeScenari
 	checkMmapFileContents([]string{"000001", "000002"}, nil)
 
 	// NOTE: We are investigating flaky errors from this compaction on i386 architecture. Compaction panics due to chunk
-	// mapper fatal error. mmapHeadChunks now uses deferred unlocking, so panics no longer cause deadlocks during cleanup.
+	// mapper fatal error. mmapHeadChunks and NewOOOCompactionHead now use deferred unlocking, so panics no longer
+	// cause deadlocks during cleanup.
 	// See https://github.com/prometheus/prometheus/issues/17941#issuecomment-3846381263
 	require.NotPanics(t, func() {
 		require.NoError(t, db.Compact(ctx))
@@ -8788,7 +8789,8 @@ func testDiskFillingUpAfterDisablingOOO(t *testing.T, scenario sampleTypeScenari
 	checkMmapFileContents([]string{"000002", "000003"}, []string{"000001"})
 
 	// NOTE: We are investigating flaky errors from this compaction on i386 architecture. Compaction panics due to chunk
-	// mapper fatal error. mmapHeadChunks now uses deferred unlocking, so panics no longer cause deadlocks during cleanup.
+	// mapper fatal error. mmapHeadChunks and NewOOOCompactionHead now use deferred unlocking, so panics no longer
+	// cause deadlocks during cleanup.
 	// See https://github.com/prometheus/prometheus/issues/17941#issuecomment-3846381263
 	require.NotPanics(t, func() {
 		require.NoError(t, db.Compact(ctx))

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2132,27 +2132,40 @@ func (h *Head) onChunkCreated(series *memSeries, prevHeadChunkCount uint32) {
 func (h *Head) mmapHeadChunks() {
 	var count int
 	for i := range h.series.size {
-		if h.series.mmapReady[i].Load() == 0 {
-			continue // No series in this stripe need mmapping.
-		}
-
-		h.series.locks[i].RLock()
-		for _, series := range h.series.series[i] {
-			if series.headChunkCount.Load() < 2 { // < 2 means 0 or 1 head chunks, nothing to mmap.
-				continue
-			}
-
-			series.Lock()
-			n := series.mmapChunks(h.chunkDiskMapper)
-			series.Unlock()
-			if n > 0 {
-				count += n
-				h.series.decMmapReady(series.ref)
-			}
-		}
-		h.series.locks[i].RUnlock()
+		count += h.mmapHeadChunksInStripe(i)
 	}
 	h.metrics.mmapChunksTotal.Add(float64(count))
+}
+
+// mmapHeadChunksInStripe m-maps chunks for the series in a single stripe that
+// need it. It uses deferred unlocking so that locks are released even if
+// mmapChunks panics (e.g. via handleChunkWriteError), preventing deadlocks
+// during cleanup.
+func (h *Head) mmapHeadChunksInStripe(i int) (count int) {
+	if h.series.mmapReady[i].Load() == 0 {
+		return 0 // No series in this stripe need mmapping.
+	}
+
+	h.series.locks[i].RLock()
+	defer h.series.locks[i].RUnlock()
+
+	for _, series := range h.series.series[i] {
+		if series.headChunkCount.Load() < 2 { // < 2 means 0 or 1 head chunks, nothing to mmap.
+			continue
+		}
+		n := h.mmapSeriesChunks(series)
+		if n > 0 {
+			count += n
+			h.series.decMmapReady(series.ref)
+		}
+	}
+	return count
+}
+
+func (h *Head) mmapSeriesChunks(s *memSeries) int {
+	s.Lock()
+	defer s.Unlock()
+	return s.mmapChunks(h.chunkDiskMapper)
 }
 
 // seriesHashmap lets TSDB find a memSeries by its label set, via a 64-bit hash.

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -9999,6 +10000,56 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		afterMetric = prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
 		require.Greater(t, afterMetric, beforeMetric, "third call should mmap chunks from series B")
 		require.Equal(t, uint32(1), getCount(lblsB), "series B headChunkCount should be 1 after mmap")
+	})
+
+	// Regression test for https://github.com/prometheus/prometheus/issues/17941:
+	// if mmapChunks panics (via handleChunkWriteError) while mmapHeadChunks holds
+	// the stripe and series locks, those locks must still be released. A leaked
+	// lock previously self-deadlocked the subsequent Head.Close() -> mmapHeadChunks().
+	t.Run("panic releases locks", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("forces a chunk-write failure by removing the open chunk directory, which Windows disallows while the ChunkDiskMapper holds the directory handle")
+		}
+
+		h, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
+		require.NoError(t, h.Init(0))
+
+		lbls := labels.FromStrings("__name__", "series")
+		ts := int64(0)
+		var ref storage.SeriesRef
+		app := h.Appender(t.Context())
+		for range chunkCutIterations {
+			var err error
+			ref, err = app.Append(ref, lbls, ts, float64(ts))
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+
+		s := h.series.getByHash(lbls.Hash(), lbls)
+		require.NotNil(t, s)
+		require.GreaterOrEqual(t, s.headChunkCount.Load(), uint32(2), "need >=2 head chunks pending mmap")
+
+		// Removing the chunk directory makes the next segment cut fail, so
+		// handleChunkWriteError panics inside mmapChunks. The chunk-write queue is
+		// synchronous by default, so the panic propagates out of mmapHeadChunks.
+		require.NoError(t, os.RemoveAll(mmappedChunksDir(h.opts.ChunkDirRoot)))
+		// newTestHead's cleanup calls Head.Close() -> mmapHeadChunks(), which would
+		// otherwise re-trigger the panic on the now-missing directory. Closing the
+		// mapper first makes WriteChunk return ErrChunkDiskMapperClosed, which
+		// handleChunkWriteError does not panic on. Cleanups run LIFO, so this runs
+		// before Head.Close().
+		t.Cleanup(func() { _ = h.chunkDiskMapper.Close() })
+
+		require.Panics(t, func() { h.mmapHeadChunks() })
+
+		// The locks held while mmapChunks panicked must have been released.
+		require.True(t, s.TryLock(), "series lock leaked after panic")
+		s.Unlock()
+		for i := range h.series.size {
+			require.Truef(t, h.series.locks[i].TryLock(), "stripe lock %d leaked after panic", i)
+			h.series.locks[i].Unlock()
+		}
 	})
 
 	t.Run("ooo does not inflate count", func(t *testing.T) {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -382,46 +382,53 @@ func NewOOOCompactionHead(ctx context.Context, head *Head) (*OOOCompactionHead, 
 			continue
 		}
 
-		// M-map the in-memory chunk and keep track of the last one.
-		// Also build the block ranges -> series map.
-		// TODO: consider having a lock specifically for ooo data.
-		ms.Lock()
-
-		if ms.ooo == nil {
-			ms.Unlock()
-			continue
-		}
-
-		var lastMmapRef chunks.ChunkDiskMapperRef
-		mmapRefs := ms.mmapCurrentOOOHeadChunk(chunkOpts{chunkDiskMapper: head.chunkDiskMapper, useXOR2: head.opts.UseXOR2FloatEncoding(), useHistogramST: head.opts.EnableHistogramSTEncoding.Load()}, head.logger)
-		if len(mmapRefs) == 0 && len(ms.ooo.oooMmappedChunks) > 0 {
-			// Nothing was m-mapped. So take the mmapRef from the existing slice if it exists.
-			mmapRefs = []chunks.ChunkDiskMapperRef{ms.ooo.oooMmappedChunks[len(ms.ooo.oooMmappedChunks)-1].ref}
-		}
-		if len(mmapRefs) == 0 {
-			lastMmapRef = 0
-		} else {
-			lastMmapRef = mmapRefs[len(mmapRefs)-1]
-		}
-		seq, off := lastMmapRef.Unpack()
-		if seq > lastSeq || (seq == lastSeq && off > lastOff) {
-			ch.lastMmapRef, lastSeq, lastOff = lastMmapRef, seq, off
-		}
-		if len(ms.ooo.oooMmappedChunks) > 0 {
-			ch.postings = append(ch.postings, seriesRef)
-			for _, c := range ms.ooo.oooMmappedChunks {
-				if c.minTime < ch.mint {
-					ch.mint = c.minTime
-				}
-				if c.maxTime > ch.maxt {
-					ch.maxt = c.maxTime
-				}
-			}
-		}
-		ms.Unlock()
+		ch.mmapOOOSeriesChunk(head, ms, seriesRef, &lastSeq, &lastOff)
 	}
 
 	return ch, nil
+}
+
+// mmapOOOSeriesChunk m-maps OOO chunks for a single series during compaction head creation.
+// It uses deferred unlocking so that the series lock is released even if
+// mmapCurrentOOOHeadChunk panics (e.g. via handleChunkWriteError), preventing
+// deadlocks during test cleanup.
+func (ch *OOOCompactionHead) mmapOOOSeriesChunk(head *Head, ms *memSeries, seriesRef storage.SeriesRef, lastSeq, lastOff *int) {
+	// M-map the in-memory chunk and keep track of the last one.
+	// Also build the block ranges -> series map.
+	// TODO: consider having a lock specifically for ooo data.
+	ms.Lock()
+	defer ms.Unlock()
+
+	if ms.ooo == nil {
+		return
+	}
+
+	var lastMmapRef chunks.ChunkDiskMapperRef
+	mmapRefs := ms.mmapCurrentOOOHeadChunk(chunkOpts{chunkDiskMapper: head.chunkDiskMapper, useXOR2: head.opts.UseXOR2FloatEncoding(), useHistogramST: head.opts.EnableHistogramSTEncoding.Load()}, head.logger)
+	if len(mmapRefs) == 0 && len(ms.ooo.oooMmappedChunks) > 0 {
+		// Nothing was m-mapped. So take the mmapRef from the existing slice if it exists.
+		mmapRefs = []chunks.ChunkDiskMapperRef{ms.ooo.oooMmappedChunks[len(ms.ooo.oooMmappedChunks)-1].ref}
+	}
+	if len(mmapRefs) == 0 {
+		lastMmapRef = 0
+	} else {
+		lastMmapRef = mmapRefs[len(mmapRefs)-1]
+	}
+	seq, off := lastMmapRef.Unpack()
+	if seq > *lastSeq || (seq == *lastSeq && off > *lastOff) {
+		ch.lastMmapRef, *lastSeq, *lastOff = lastMmapRef, seq, off
+	}
+	if len(ms.ooo.oooMmappedChunks) > 0 {
+		ch.postings = append(ch.postings, seriesRef)
+		for _, c := range ms.ooo.oooMmappedChunks {
+			if c.minTime < ch.mint {
+				ch.mint = c.minTime
+			}
+			if c.maxTime > ch.maxt {
+				ch.maxt = c.maxTime
+			}
+		}
+	}
 }
 
 func (ch *OOOCompactionHead) Index() (IndexReader, error) {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -382,7 +382,7 @@ func NewOOOCompactionHead(ctx context.Context, head *Head) (*OOOCompactionHead, 
 			continue
 		}
 
-		ch.mmapOOOSeriesChunk(head, ms, seriesRef, &lastSeq, &lastOff)
+		ch.mmapOOOSeriesChunk(ms, seriesRef, &lastSeq, &lastOff)
 	}
 
 	return ch, nil
@@ -392,7 +392,8 @@ func NewOOOCompactionHead(ctx context.Context, head *Head) (*OOOCompactionHead, 
 // It uses deferred unlocking so that the series lock is released even if
 // mmapCurrentOOOHeadChunk panics (e.g. via handleChunkWriteError), preventing
 // deadlocks during test cleanup.
-func (ch *OOOCompactionHead) mmapOOOSeriesChunk(head *Head, ms *memSeries, seriesRef storage.SeriesRef, lastSeq, lastOff *int) {
+func (ch *OOOCompactionHead) mmapOOOSeriesChunk(ms *memSeries, seriesRef storage.SeriesRef, lastSeq, lastOff *int) {
+	head := ch.head
 	// M-map the in-memory chunk and keep track of the last one.
 	// Also build the block ranges -> series map.
 	// TODO: consider having a lock specifically for ooo data.

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
+	"runtime"
 	"slices"
 	"sort"
 	"testing"
@@ -1223,4 +1225,45 @@ func TestHeadAndOOOQuerierSearch(t *testing.T) {
 		require.False(t, rs.Next())
 		require.NoError(t, rs.Close())
 	})
+}
+
+// TestNewOOOCompactionHead_panicReleasesLock is a regression test for
+// https://github.com/prometheus/prometheus/issues/17941: if mmapCurrentOOOHeadChunk
+// panics (via handleChunkWriteError) while NewOOOCompactionHead holds the series
+// lock, that lock must still be released so head shutdown does not deadlock.
+func TestNewOOOCompactionHead_panicReleasesLock(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("forces a chunk-write failure by removing the open chunk directory, which Windows disallows while the ChunkDiskMapper holds the directory handle")
+	}
+
+	h, _ := newTestHead(t, DefaultBlockDuration, compression.None, true /* oooEnabled */)
+	require.NoError(t, h.Init(0))
+
+	lbls := labels.FromStrings("__name__", "series")
+	app := h.Appender(t.Context())
+	inOrderTs := 60 * time.Minute.Milliseconds()
+	_, err := app.Append(0, lbls, inOrderTs, 0)
+	require.NoError(t, err)
+	// An out-of-order sample within the OOO window creates an OOO head chunk.
+	_, err = app.Append(0, lbls, inOrderTs-5*time.Minute.Milliseconds(), 1)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	s := h.series.getByHash(lbls.Hash(), lbls)
+	require.NotNil(t, s)
+	require.NotNil(t, s.ooo, "expected an OOO head chunk")
+
+	// Removing the chunk directory makes mmapCurrentOOOHeadChunk's segment cut
+	// fail, so handleChunkWriteError panics while the series lock is held.
+	require.NoError(t, os.RemoveAll(mmappedChunksDir(h.opts.ChunkDirRoot)))
+	// newTestHead's cleanup calls Head.Close() -> mmapHeadChunks(); closing the
+	// mapper first makes WriteChunk return ErrChunkDiskMapperClosed (which
+	// handleChunkWriteError does not panic on), so shutdown stays clean. Cleanups
+	// run LIFO, so this runs before Head.Close().
+	t.Cleanup(func() { _ = h.chunkDiskMapper.Close() })
+
+	require.Panics(t, func() { _, _ = NewOOOCompactionHead(t.Context(), h) })
+
+	require.True(t, s.TryLock(), "series lock leaked after panic")
+	s.Unlock()
 }


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Part of #17941 (addresses the `TestDiskFillingUpAfterDisablingOOO` deadlock/timeout).
Related: #18150

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```

#### Description

Use deferred lock release in both chunk-mapping paths involved in the i386 CI deadlock: `Head.mmapHeadChunks` and `NewOOOCompactionHead`.

When `handleChunkWriteError` panics during chunk writing, manually paired lock/unlock calls could leave the series lock or stripe read lock held. Although the test recovers the panic through `require.NotPanics`, the leaked lock then caused cleanup to self-deadlock when `db.Close()` → `Head.Close()` → `mmapHeadChunks()` attempted to acquire it again. This manifested as a 10-minute timeout on i386 CI.

The in-order path now delegates stripe and series processing to `mmapHeadChunksInStripe` and `mmapSeriesChunks`, which release their locks with `defer`. The OOO compaction path similarly delegates per-series chunk mapping to `mmapOOOSeriesChunk`, which defers the series unlock. This preserves happy-path behavior while ensuring locks are released when chunk mapping panics.

#### Test plan

- Add deterministic, CPU-architecture-independent regression coverage for both paths by removing the chunk directory to force `handleChunkWriteError` to panic
- Verify `TestHead_mmapHeadChunks/panic releases locks` releases both series and stripe locks
- Verify `TestNewOOOCompactionHead_panicReleasesLock` releases the OOO series lock
- Keep `testDiskFillingUpAfterDisablingOOO` covering the original compaction scenario, with updated comments describing panic-safe cleanup
- Skip the forced-write-failure cases on Windows, where removing the open chunk directory is not allowed
