### PR TITLE
tsdb: replace handleChunkWriteError panic with error callback

### DIFF
--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -539,6 +539,7 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 					Segment: r.Segment(),
 					Offset:  r.Offset(),
 				}
+				return
 			}
 		}
 	}()
@@ -558,15 +559,14 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 				series, created := db.series.GetOrSet(series.lset.Hash(), series)
 
 				if !created {
-					// We don't need to check if entry.Ref exists / if the value is not series.ref because GetOrSet
-					// enforces that the same labels will always get the same Ref. If we did not create a new ref
-					// the only possible ref it should ever be in the WAL is series.ref.
-					duplicateRefToValidRef[entry.Ref] = series.ref
+					if entry.Ref != series.ref {
+						duplicateRefToValidRef[entry.Ref] = series.ref
 
-					// We want to track the largest segment where we encountered the duplicate ref, so we can ensure
-					// it remains in the checkpoint until we get past that segment.
-					if db.deleted[entry.Ref] <= currentSegmentOrCheckpoint {
-						db.deleted[entry.Ref] = currentSegmentOrCheckpoint
+						// We want to track the largest segment where we encountered the duplicate ref, so we can ensure
+						// it remains in the checkpoint until we get past that segment.
+						if db.deleted[entry.Ref] <= currentSegmentOrCheckpoint {
+							db.deleted[entry.Ref] = currentSegmentOrCheckpoint
+						}
 					}
 				} else {
 					db.metrics.numActiveSeries.Inc()

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -226,7 +226,9 @@ type ChunkDiskMapper struct {
 	// This is done after iterating through all the chunks in those files using the IterateAllChunks method.
 	fileMaxtSet bool
 
-	writeQueue *chunkWriteQueue
+	writeQueue  *chunkWriteQueue
+	writeErrMtx sync.RWMutex
+	writeErr    error // Set only when mapper recovery fails and the mapper must stay failed.
 
 	closed bool
 }
@@ -458,18 +460,144 @@ func (cdm *ChunkDiskMapper) WriteChunk(seriesRef HeadSeriesRef, mint, maxt int64
 	// cdm.evtlPosMtx must be held to serialize the calls to cdm.evtlPos.getNextChunkRef() and the writing of the chunk (either with or without queue).
 	cdm.evtlPosMtx.Lock()
 	defer cdm.evtlPosMtx.Unlock()
+	if err := cdm.getWriteError(); err != nil {
+		if callback != nil {
+			callback(err)
+		}
+		return 0
+	}
+	prevPos := cdm.evtlPos
 	ref, cutFile := cdm.evtlPos.getNextChunkRef(chk)
 
 	if cdm.writeQueue != nil {
-		return cdm.writeChunkViaQueue(ref, isOOO, cutFile, seriesRef, mint, maxt, chk, callback)
+		chkRef = cdm.writeChunkViaQueue(ref, isOOO, cutFile, seriesRef, mint, maxt, chk, callback)
+		if chkRef == 0 {
+			cdm.evtlPos = prevPos
+		}
+		return chkRef
 	}
 
 	err := cdm.writeChunk(seriesRef, mint, maxt, chk, ref, isOOO, cutFile)
+	if err != nil {
+		if repairErr := cdm.recoverWriteError(prevPos); repairErr != nil {
+			err = errors.Join(err, repairErr)
+		}
+	}
 	if callback != nil {
 		callback(err)
 	}
+	if err != nil {
+		return 0
+	}
 
 	return ref
+}
+
+// WriteChunkSync writes the chunk to disk synchronously, flushes pending writes, and returns an
+// error if the write fails. When the async write queue is enabled, this still preserves queue
+// order by enqueueing the write and waiting for completion before returning.
+func (cdm *ChunkDiskMapper) WriteChunkSync(seriesRef HeadSeriesRef, mint, maxt int64, chk chunkenc.Chunk, isOOO bool) (chkRef ChunkDiskMapperRef, err error) {
+	ref, _, err := cdm.WriteChunkSyncNoFlush(seriesRef, mint, maxt, chk, isOOO)
+	if err != nil {
+		return 0, err
+	}
+	if err = cdm.FlushWrites(); err != nil {
+		return 0, err
+	}
+	return ref, nil
+}
+
+// WriteChunkSyncNoFlush writes the chunk to disk synchronously but does not flush buffered writes.
+// The caller must call FlushWrites to ensure data is persisted. When the async write queue is
+// enabled, this still preserves queue order by enqueueing the write and waiting for completion.
+//
+// On error, lastValidRef is the post-recovery write position captured under the lock.
+// Callers can use it to filter stale refs without a separate LastWrittenRef() call,
+// avoiding a TOCTOU race where a concurrent writer advances the position between calls.
+func (cdm *ChunkDiskMapper) WriteChunkSyncNoFlush(seriesRef HeadSeriesRef, mint, maxt int64, chk chunkenc.Chunk, isOOO bool) (chkRef, lastValidRef ChunkDiskMapperRef, err error) {
+	cdm.evtlPosMtx.Lock()
+	defer cdm.evtlPosMtx.Unlock()
+	if err = cdm.getWriteError(); err != nil {
+		return 0, 0, err
+	}
+
+	prevPos := cdm.evtlPos
+	ref, cutFile := cdm.evtlPos.getNextChunkRef(chk)
+	if cdm.writeQueue != nil {
+		done := make(chan error, 1)
+		if err = cdm.writeQueue.addJob(chunkWriteJob{
+			cutFile:   cutFile,
+			seriesRef: seriesRef,
+			mint:      mint,
+			maxt:      maxt,
+			chk:       chk,
+			ref:       ref,
+			isOOO:     isOOO,
+			callback: func(err error) {
+				done <- err
+			},
+		}); err != nil {
+			cdm.evtlPos = prevPos
+			return 0, 0, err
+		}
+		// Hold the lock while waiting. Even though getNextChunkRef reserved our ref,
+		// releasing the lock would allow a concurrent writer to enqueue after us;
+		// if our write fails and recoverWriteError truncates, it would destroy
+		// the concurrent writer's valid data.
+		err = <-done
+		if err != nil {
+			if repairErr := cdm.recoverWriteError(prevPos); repairErr != nil {
+				err = errors.Join(err, repairErr)
+			}
+			return 0, newChunkDiskMapperRef(cdm.evtlPos.seq, cdm.evtlPos.offset), err
+		}
+		return ref, 0, nil
+	}
+
+	if err = cdm.writeChunk(seriesRef, mint, maxt, chk, ref, isOOO, cutFile); err != nil {
+		if repairErr := cdm.recoverWriteError(prevPos); repairErr != nil {
+			err = errors.Join(err, repairErr)
+		}
+		return 0, newChunkDiskMapperRef(cdm.evtlPos.seq, cdm.evtlPos.offset), err
+	}
+
+	return ref, 0, nil
+}
+
+// FlushWrites flushes any buffered chunk writes to disk. It should be called after one or more
+// WriteChunkSyncNoFlush calls to ensure data is persisted.
+func (cdm *ChunkDiskMapper) FlushWrites() error {
+	cdm.evtlPosMtx.Lock()
+	defer cdm.evtlPosMtx.Unlock()
+	if err := cdm.getWriteError(); err != nil {
+		return err
+	}
+	prevPos := cdm.evtlPos
+	if err := cdm.flushPendingWrites(); err != nil {
+		if repairErr := cdm.recoverWriteError(prevPos); repairErr != nil {
+			err = errors.Join(err, repairErr)
+		}
+		return err
+	}
+	return nil
+}
+
+func (cdm *ChunkDiskMapper) WriteQueueEnabled() bool {
+	return cdm.writeQueue != nil
+}
+
+// SetWriteChunkFuncForTesting replaces the write queue's writeChunk function with f and returns
+// the previous function. Panics if the write queue is not enabled.
+// Must be called before any writes are enqueued or after the queue is drained.
+func (cdm *ChunkDiskMapper) SetWriteChunkFuncForTesting(
+	f func(HeadSeriesRef, int64, int64, chunkenc.Chunk, ChunkDiskMapperRef, bool, bool) error,
+) func(HeadSeriesRef, int64, int64, chunkenc.Chunk, ChunkDiskMapperRef, bool, bool) error {
+	if cdm.writeQueue == nil {
+		panic("SetWriteChunkFuncForTesting requires write queue")
+	}
+	prev := cdm.writeQueue.writeChunk
+	cdm.writeQueue.writeChunk = f
+	return prev
 }
 
 func (cdm *ChunkDiskMapper) writeChunkViaQueue(ref ChunkDiskMapperRef, isOOO, cutFile bool, seriesRef HeadSeriesRef, mint, maxt int64, chk chunkenc.Chunk, callback func(err error)) (chkRef ChunkDiskMapperRef) {
@@ -492,6 +620,9 @@ func (cdm *ChunkDiskMapper) writeChunkViaQueue(ref ChunkDiskMapperRef, isOOO, cu
 		isOOO:     isOOO,
 		callback:  callback,
 	})
+	if err != nil {
+		return 0
+	}
 
 	return ref
 }
@@ -502,6 +633,9 @@ func (cdm *ChunkDiskMapper) writeChunk(seriesRef HeadSeriesRef, mint, maxt int64
 
 	if cdm.closed {
 		return ErrChunkDiskMapperClosed
+	}
+	if err := cdm.getWriteError(); err != nil {
+		return err
 	}
 
 	if cutFile {
@@ -562,6 +696,23 @@ func (cdm *ChunkDiskMapper) writeChunk(seriesRef HeadSeriesRef, mint, maxt int64
 	}
 
 	return nil
+}
+
+func (cdm *ChunkDiskMapper) getWriteError() error {
+	cdm.writeErrMtx.RLock()
+	defer cdm.writeErrMtx.RUnlock()
+
+	return cdm.writeErr
+}
+
+func (cdm *ChunkDiskMapper) setWriteError(err error) error {
+	cdm.writeErrMtx.Lock()
+	defer cdm.writeErrMtx.Unlock()
+
+	if cdm.writeErr == nil {
+		cdm.writeErr = err
+	}
+	return cdm.writeErr
 }
 
 // CutNewFile makes that a new file will be created the next time a chunk is written.
@@ -643,7 +794,7 @@ func (cdm *ChunkDiskMapper) cut() (seq, offset int, returnErr error) {
 	cdm.mmappedChunkFiles[cdm.curFileSequence] = &mmappedChunkFile{byteSlice: realByteSlice(mmapFile.Bytes())}
 	cdm.readPathMtx.Unlock()
 
-	cdm.curFileMaxt = 0
+	cdm.curFileMaxt = math.MinInt64
 
 	return seq, offset, nil
 }
@@ -692,6 +843,164 @@ func (cdm *ChunkDiskMapper) flushBuffer() error {
 	}
 	cdm.chunkBuffer.clear()
 	return nil
+}
+
+func (cdm *ChunkDiskMapper) flushPendingWrites() error {
+	cdm.writePathMtx.Lock()
+	defer cdm.writePathMtx.Unlock()
+
+	if cdm.closed || cdm.chkWriter == nil || cdm.chkWriter.Buffered() == 0 {
+		return nil
+	}
+	return cdm.flushBuffer()
+}
+
+func (cdm *ChunkDiskMapper) recoverWriteError(prevPos chunkPos) error {
+	if err := cdm.getWriteError(); err != nil {
+		return err
+	}
+
+	cdm.writePathMtx.Lock()
+	defer cdm.writePathMtx.Unlock()
+
+	if cdm.closed {
+		return ErrChunkDiskMapperClosed
+	}
+
+	// Best-effort flush: write buffered data to disk so that lastValidChunkEnd can
+	// see any complete chunks that were successfully written before the error.
+	// We ignore flush errors here because recovery will truncate to the last valid
+	// chunk boundary anyway.
+	if cdm.chkWriter != nil {
+		_ = cdm.chkWriter.Flush()
+		cdm.chkWriter.Reset(io.Discard)
+	}
+	cdm.chunkBuffer.clear()
+
+	seq := cdm.curFileSequence
+	if seq == 0 {
+		cdm.evtlPos = prevPos
+		return nil
+	}
+
+	lastValidOffset, maxt, err := cdm.lastValidChunkEnd(seq, int(cdm.curFileSize()))
+	if err != nil {
+		return cdm.setWriteError(err)
+	}
+
+	if cdm.curFile != nil {
+		if closeErr := cdm.curFile.Close(); closeErr != nil {
+			return cdm.setWriteError(closeErr)
+		}
+		cdm.curFile = nil
+	}
+
+	f, err := os.OpenFile(segmentFile(cdm.dir.Name(), seq), os.O_RDWR, 0o666)
+	if err != nil {
+		return cdm.setWriteError(err)
+	}
+	if _, err := f.Seek(int64(lastValidOffset), io.SeekStart); err != nil {
+		_ = f.Close()
+		return cdm.setWriteError(err)
+	}
+	if err := f.Truncate(int64(lastValidOffset)); err != nil {
+		_ = f.Close()
+		return cdm.setWriteError(err)
+	}
+
+	cdm.curFile = f
+	cdm.curFileOffset.Store(uint64(lastValidOffset))
+	cdm.curFileMaxt = maxt
+	if cdm.chkWriter != nil {
+		cdm.chkWriter.Reset(f)
+	} else {
+		cdm.chkWriter = bufio.NewWriterSize(f, cdm.writeBufferSize)
+	}
+	cdm.evtlPos = chunkPos{
+		seq:    uint64(seq),
+		offset: uint64(lastValidOffset),
+	}
+
+	cdm.readPathMtx.Lock()
+	if mmapped := cdm.mmappedChunkFiles[seq]; mmapped != nil {
+		mmapped.maxt = maxt
+	}
+	cdm.readPathMtx.Unlock()
+	return nil
+}
+
+func (cdm *ChunkDiskMapper) lastValidChunkEnd(seq, fileEnd int) (lastValidOffset int, maxt int64, err error) {
+	cdm.readPathMtx.RLock()
+	mmapFile := cdm.mmappedChunkFiles[seq]
+	cdm.readPathMtx.RUnlock()
+	if mmapFile == nil {
+		return 0, math.MinInt64, fmt.Errorf("head chunk file %d not mapped", seq)
+	}
+
+	lastValidOffset = HeadChunkFileHeaderSize
+	if fileEnd < lastValidOffset {
+		return 0, math.MinInt64, fmt.Errorf("head chunk file %d too small: %d", seq, fileEnd)
+	}
+
+	seenChunk := false
+	idx := HeadChunkFileHeaderSize
+	for idx < fileEnd {
+		if fileEnd-idx < MaxHeadChunkMetaSize {
+			if zeroFilled(mmapFile.byteSlice.Range(idx, fileEnd)) {
+				break
+			}
+			return lastValidOffset, maxt, nil
+		}
+
+		startIdx := idx
+		seriesRef := HeadSeriesRef(binary.BigEndian.Uint64(mmapFile.byteSlice.Range(idx, idx+SeriesRefSize)))
+		idx += SeriesRefSize
+		mint := int64(binary.BigEndian.Uint64(mmapFile.byteSlice.Range(idx, idx+MintMaxtSize)))
+		idx += MintMaxtSize
+		chunkMaxt := int64(binary.BigEndian.Uint64(mmapFile.byteSlice.Range(idx, idx+MintMaxtSize)))
+		idx += MintMaxtSize
+
+		if seriesRef == 0 && mint == 0 && chunkMaxt == 0 {
+			break
+		}
+
+		idx += ChunkEncodingSize
+		dataLen, n := binary.Uvarint(mmapFile.byteSlice.Range(idx, idx+MaxChunkLengthFieldSize))
+		if n <= 0 {
+			return lastValidOffset, maxt, nil
+		}
+		idx += n
+		if dataLen > uint64(fileEnd-idx) {
+			return lastValidOffset, maxt, nil
+		}
+		idx += int(dataLen)
+		if idx+CRCSize > fileEnd {
+			return lastValidOffset, maxt, nil
+		}
+		if err := checkCRC32(mmapFile.byteSlice.Range(startIdx, idx), mmapFile.byteSlice.Range(idx, idx+CRCSize)); err != nil {
+			return lastValidOffset, maxt, nil
+		}
+		idx += CRCSize
+		lastValidOffset = idx
+		if !seenChunk || chunkMaxt > maxt {
+			maxt = chunkMaxt
+		}
+		seenChunk = true
+	}
+
+	if !seenChunk {
+		maxt = math.MinInt64
+	}
+	return lastValidOffset, maxt, nil
+}
+
+func zeroFilled(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // Chunk returns a chunk from a given reference.

--- a/tsdb/chunks/head_chunks_test.go
+++ b/tsdb/chunks/head_chunks_test.go
@@ -412,6 +412,112 @@ func TestChunkDiskMapper_Truncate_WriteQueueRaceCondition(t *testing.T) {
 	wg.Wait()
 }
 
+func TestChunkDiskMapper_WriteChunkSync_PreservesQueueOrder(t *testing.T) {
+	t.Parallel()
+	hrw := createChunkDiskMapper(t, "")
+	t.Cleanup(func() {
+		require.NoError(t, hrw.Close())
+	})
+
+	if hrw.writeQueue == nil {
+		t.Skip("This test should only run when the queue is enabled")
+	}
+
+	var (
+		mu          sync.Mutex
+		writtenRefs []ChunkDiskMapperRef
+		firstRef    ChunkDiskMapperRef
+	)
+	firstWriteStarted := make(chan struct{})
+	allowFirstWrite := make(chan struct{})
+
+	origWriteChunk := hrw.writeQueue.writeChunk
+	hrw.writeQueue.writeChunk = func(seriesRef HeadSeriesRef, mint, maxt int64, chk chunkenc.Chunk, ref ChunkDiskMapperRef, isOOO, cutFile bool) error {
+		mu.Lock()
+		writtenRefs = append(writtenRefs, ref)
+		mu.Unlock()
+		if ref == firstRef {
+			close(firstWriteStarted)
+			<-allowFirstWrite
+		}
+		return origWriteChunk(seriesRef, mint, maxt, chk, ref, isOOO, cutFile)
+	}
+
+	firstWriteDone := make(chan error, 1)
+	firstRef = hrw.WriteChunk(1, 0, 10, randomChunk(t), false, func(err error) {
+		firstWriteDone <- err
+	})
+
+	<-firstWriteStarted
+
+	var (
+		secondRef ChunkDiskMapperRef
+		syncErr   error
+	)
+	secondWriteDone := make(chan struct{})
+	go func() {
+		secondRef, syncErr = hrw.WriteChunkSync(1, 11, 20, randomChunk(t), false)
+		close(secondWriteDone)
+	}()
+
+	select {
+	case <-secondWriteDone:
+		t.Fatal("WriteChunkSync returned before the earlier queued write completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(allowFirstWrite)
+
+	require.NoError(t, <-firstWriteDone)
+	<-secondWriteDone
+	require.NoError(t, syncErr)
+
+	mu.Lock()
+	require.Equal(t, []ChunkDiskMapperRef{firstRef, secondRef}, writtenRefs)
+	mu.Unlock()
+}
+
+func TestChunkDiskMapper_WriteChunkSync_RecoversAfterWriteError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	hrw, err := NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), DefaultWriteBufferSize, 1)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, hrw.Close())
+	})
+
+	injectedErr := errors.New("injected chunk write failure")
+	var calls int
+	origWriteChunk := hrw.writeQueue.writeChunk
+	hrw.writeQueue.writeChunk = func(seriesRef HeadSeriesRef, mint, maxt int64, chk chunkenc.Chunk, ref ChunkDiskMapperRef, isOOO, cutFile bool) error {
+		calls++
+		if calls == 1 {
+			return injectedErr
+		}
+		return origWriteChunk(seriesRef, mint, maxt, chk, ref, isOOO, cutFile)
+	}
+
+	firstRef, err := hrw.WriteChunkSync(1, 0, 10, randomChunk(t), false)
+	require.Zero(t, firstRef)
+	require.ErrorIs(t, err, injectedErr)
+
+	secondRef, err := hrw.WriteChunkSync(1, 11, 20, randomChunk(t), false)
+	require.NoError(t, err)
+	require.Equal(t, newChunkDiskMapperRef(1, HeadChunkFileHeaderSize), secondRef)
+
+	thirdRef, err := hrw.WriteChunkSync(1, 21, 30, randomChunk(t), false)
+	require.NoError(t, err)
+	require.Greater(t, thirdRef, secondRef)
+
+	var written int
+	require.NoError(t, hrw.IterateAllChunks(func(HeadSeriesRef, ChunkDiskMapperRef, int64, int64, uint16, chunkenc.Encoding, bool) error {
+		written++
+		return nil
+	}))
+	require.Equal(t, 2, written)
+}
+
 // TestHeadReadWriter_TruncateAfterFailedIterateChunks tests for
 // https://github.com/prometheus/prometheus/issues/7753
 func TestHeadReadWriter_TruncateAfterFailedIterateChunks(t *testing.T) {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1210,7 +1210,7 @@ func (db *DB) run(ctx context.Context) {
 			default:
 			}
 			// We attempt mmapping of head chunks regularly.
-			db.head.mmapHeadChunks()
+			db.head.mmapHeadChunks(false)
 
 			numStaleSeries, numSeries := db.Head().NumStaleSeries(), db.Head().NumSeries()
 			if db.autoCompact && numSeries > 0 && db.opts.staleSeriesCompactionThreshold.Load() > 0 {
@@ -2270,7 +2270,7 @@ func (db *DB) generateCompactionDelay() time.Duration {
 
 // ForceHeadMMap is intended for use only in tests and benchmarks.
 func (db *DB) ForceHeadMMap() {
-	db.head.mmapHeadChunks()
+	db.head.mmapHeadChunks(true)
 }
 
 // Snapshot writes the current data to the directory. If withHead is set to true it

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -1218,7 +1218,7 @@ func TestSizeRetention_AppendV2(t *testing.T) {
 				}
 			}
 			require.NoError(t, headApp.Commit())
-			db.Head().mmapHeadChunks()
+			db.Head().mmapHeadChunks(true)
 
 			require.Eventually(t, func() bool {
 				return db.Head().chunkDiskMapper.IsQueueEmpty()
@@ -4242,8 +4242,8 @@ func testOOOQueryAfterRestartWithSnapshotAndRemovedWBLAppendV2(t *testing.T, sce
 		ms, created, err := db.head.getOrCreate(lbls.Hash(), lbls, false)
 		require.NoError(t, err)
 		require.False(t, created)
-		require.Len(t, ms.ooo.oooMmappedChunks, 2)
-		require.Equal(t, 109*time.Minute.Milliseconds(), ms.ooo.oooMmappedChunks[1].maxTime)
+		require.Len(t, ms.ooo.oooMmappedChunks, 3)
+		require.Equal(t, 110*time.Minute.Milliseconds(), ms.ooo.oooMmappedChunks[2].maxTime)
 		require.Nil(t, ms.ooo.oooHeadChunk) // Because of missing wbl.
 	}
 
@@ -4268,7 +4268,7 @@ func testOOOQueryAfterRestartWithSnapshotAndRemovedWBLAppendV2(t *testing.T, sce
 	}
 
 	// Checking for expected ooo data from mmap chunks.
-	verifySamples(90, 109)
+	verifySamples(90, 110)
 
 	// Compaction should also work fine.
 	require.Empty(t, db.Blocks())
@@ -4285,7 +4285,7 @@ func testOOOQueryAfterRestartWithSnapshotAndRemovedWBLAppendV2(t *testing.T, sce
 		require.Nil(t, ms.ooo)
 	}
 
-	verifySamples(90, 109)
+	verifySamples(90, 110)
 }
 
 func TestQuerierOOOQuery_AppendV2(t *testing.T) {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1592,7 +1592,7 @@ func TestSizeRetention(t *testing.T) {
 				}
 			}
 			require.NoError(t, headApp.Commit())
-			db.Head().mmapHeadChunks()
+			db.Head().mmapHeadChunks(true)
 
 			require.Eventually(t, func() bool {
 				return db.Head().chunkDiskMapper.IsQueueEmpty()
@@ -2748,7 +2748,7 @@ func TestDBReadOnly_Querier_NoAlteration(t *testing.T) {
 
 		// The RW Head should have no problem cutting its own chunk,
 		// this also proves that a chunk needed to be cut.
-		require.NotPanics(t, func() { db.ForceHeadMMap() })
+		db.ForceHeadMMap()
 		require.Equal(t, 1, countChunks(db.Dir()))
 	})
 
@@ -5446,6 +5446,228 @@ func testOOOCompactionWithDisabledWriteLog(t *testing.T, scenario sampleTypeScen
 	verifySamples(db.Blocks()[1], 250, 350)
 }
 
+func TestOOOQueueEnabledRolloverPersistsAcrossRestartAndCompaction(t *testing.T) {
+	opts := DefaultOptions()
+	opts.OutOfOrderCapMax = 1
+	opts.OutOfOrderTimeWindow = 60 * time.Minute.Milliseconds()
+	opts.HeadChunksWriteQueueSize = 1
+
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+
+	series := labels.FromStrings("foo", "bar")
+	app := db.Appender(context.Background())
+	_, err := app.Append(0, series, 300, 300)
+	require.NoError(t, err)
+	_, err = app.Append(0, series, 250, 250)
+	require.NoError(t, err)
+	_, err = app.Append(0, series, 240, 240)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	expSamples := map[string][]chunks.Sample{
+		series.String(): {
+			sample{t: 240, f: 240},
+			sample{t: 250, f: 250},
+			sample{t: 300, f: 300},
+		},
+	}
+	verifyQuery := func() {
+		q, err := db.Querier(0, 400)
+		require.NoError(t, err)
+		requireEqualSeries(t, expSamples, query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")), true)
+	}
+	verifySeriesState := func(mmapped, closed int, headChunk bool) {
+		ms, created, err := db.head.getOrCreate(series.Hash(), series, false)
+		require.NoError(t, err)
+		require.False(t, created)
+		require.NotNil(t, ms.ooo)
+		require.Len(t, ms.ooo.oooMmappedChunks, mmapped)
+		require.Len(t, ms.ooo.oooClosedChunks, closed)
+		if headChunk {
+			require.NotNil(t, ms.ooo.oooHeadChunk)
+		} else {
+			require.Nil(t, ms.ooo.oooHeadChunk)
+		}
+	}
+
+	verifyQuery()
+	verifySeriesState(0, 1, true)
+
+	dbDir := db.Dir()
+	require.NoError(t, db.Close())
+
+	db = newTestDB(t, withDir(dbDir), withOpts(opts))
+	db.DisableCompactions()
+	verifyQuery()
+	verifySeriesState(2, 0, false)
+
+	_, err = NewOOOCompactionHead(context.Background(), db.head)
+	require.NoError(t, err)
+	verifyQuery()
+	verifySeriesState(2, 0, false)
+
+	require.NoError(t, db.Close())
+
+	db = newTestDB(t, withDir(dbDir), withOpts(opts))
+	db.DisableCompactions()
+	verifyQuery()
+	verifySeriesState(2, 0, false)
+}
+
+func TestOOOReplayDropsUnmarkedMmappedChunks(t *testing.T) {
+	opts := DefaultOptions()
+	opts.OutOfOrderCapMax = 1
+	opts.OutOfOrderTimeWindow = 60 * time.Minute.Milliseconds()
+	opts.HeadChunksWriteQueueSize = 1
+
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+
+	series := labels.FromStrings("foo", "bar")
+	app := db.Appender(context.Background())
+	_, err := app.Append(0, series, 300, 300)
+	require.NoError(t, err)
+	_, err = app.Append(0, series, 250, 250)
+	require.NoError(t, err)
+	_, err = app.Append(0, series, 240, 240)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	ms, created, err := db.head.getOrCreate(series.Hash(), series, false)
+	require.NoError(t, err)
+	require.False(t, created)
+
+	orphan := chunkenc.NewXORChunk()
+	appender, err := orphan.Appender()
+	require.NoError(t, err)
+	appender.Append(0, 230, 230)
+	_, err = db.head.chunkDiskMapper.WriteChunkSync(ms.ref, 230, 230, orphan, true)
+	require.NoError(t, err)
+
+	dbDir := db.Dir()
+	require.NoError(t, db.Close())
+
+	db = newTestDB(t, withDir(dbDir), withOpts(opts))
+	db.DisableCompactions()
+
+	q, err := db.Querier(0, 400)
+	require.NoError(t, err)
+	requireEqualSeries(t, map[string][]chunks.Sample{
+		series.String(): {
+			sample{t: 240, f: 240},
+			sample{t: 250, f: 250},
+			sample{t: 300, f: 300},
+		},
+	}, query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")), true)
+}
+
+func TestOOOQueueEnabledBackgroundMmapFlushesAndReplays(t *testing.T) {
+	opts := DefaultOptions()
+	opts.OutOfOrderCapMax = 1
+	opts.OutOfOrderTimeWindow = 60 * time.Minute.Milliseconds()
+	opts.HeadChunksWriteQueueSize = 1
+
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+
+	series := labels.FromStrings("foo", "bar")
+	app := db.Appender(context.Background())
+	_, err := app.Append(0, series, 300, 300)
+	require.NoError(t, err)
+	_, err = app.Append(0, series, 250, 250)
+	require.NoError(t, err)
+	_, err = app.Append(0, series, 240, 240)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	db.head.mmapHeadChunks(false)
+
+	ms, created, err := db.head.getOrCreate(series.Hash(), series, false)
+	require.NoError(t, err)
+	require.False(t, created)
+	require.NotNil(t, ms.ooo)
+	require.Len(t, ms.ooo.oooMmappedChunks, 1)
+	require.Empty(t, ms.ooo.oooClosedChunks)
+	require.NotNil(t, ms.ooo.oooHeadChunk)
+
+	dbDir := db.Dir()
+	require.NoError(t, db.Close())
+
+	db = newTestDB(t, withDir(dbDir), withOpts(opts))
+	db.DisableCompactions()
+
+	ms, created, err = db.head.getOrCreate(series.Hash(), series, false)
+	require.NoError(t, err)
+	require.False(t, created)
+	require.NotNil(t, ms.ooo)
+	require.Len(t, ms.ooo.oooMmappedChunks, 2)
+	require.Empty(t, ms.ooo.oooClosedChunks)
+	require.Nil(t, ms.ooo.oooHeadChunk)
+
+	q, err := db.Querier(0, 400)
+	require.NoError(t, err)
+	requireEqualSeries(t, map[string][]chunks.Sample{
+		series.String(): {
+			sample{t: 240, f: 240},
+			sample{t: 250, f: 250},
+			sample{t: 300, f: 300},
+		},
+	}, query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")), true)
+}
+
+func TestOOOPartialBackgroundMmapFailureKeepsMarkedPrefixAfterRestart(t *testing.T) {
+	opts := DefaultOptions()
+	opts.OutOfOrderCapMax = 1
+	opts.OutOfOrderTimeWindow = 60 * time.Minute.Milliseconds()
+	opts.HeadChunksWriteQueueSize = 1
+
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+
+	series := labels.FromStrings("foo", "bar")
+	app := db.Appender(context.Background())
+	_, err := app.Append(0, series, 300, 300)
+	require.NoError(t, err)
+	_, err = app.Append(0, series, 250, 250)
+	require.NoError(t, err)
+	_, err = app.Append(0, series, 240, 240)
+	require.NoError(t, err)
+	_, err = app.Append(0, series, 230, 230)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	injectedErr := errors.New("injected chunk write failure")
+	failNthChunkWrite(t, db.head.chunkDiskMapper, 2, injectedErr)
+
+	db.head.mmapHeadChunks(false)
+
+	ms, created, err := db.head.getOrCreate(series.Hash(), series, false)
+	require.NoError(t, err)
+	require.False(t, created)
+	require.NotNil(t, ms.ooo)
+	require.Len(t, ms.ooo.oooMmappedChunks, 1)
+	require.Len(t, ms.ooo.oooClosedChunks, 1)
+	require.NotNil(t, ms.ooo.oooHeadChunk)
+
+	dbDir := db.Dir()
+	require.NoError(t, db.Close())
+
+	db = newTestDB(t, withDir(dbDir), withOpts(opts))
+	db.DisableCompactions()
+
+	q, err := db.Querier(0, 400)
+	require.NoError(t, err)
+	requireEqualSeries(t, map[string][]chunks.Sample{
+		series.String(): {
+			sample{t: 230, f: 230},
+			sample{t: 240, f: 240},
+			sample{t: 250, f: 250},
+			sample{t: 300, f: 300},
+		},
+	}, query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")), true)
+}
+
 // TestOOOQueryAfterRestartWithSnapshotAndRemovedWBL tests the scenario where the WBL goes
 // missing after a restart while snapshot was enabled, but the query still returns the right
 // data from the mmap chunks.
@@ -5513,8 +5735,8 @@ func testOOOQueryAfterRestartWithSnapshotAndRemovedWBL(t *testing.T, scenario sa
 		ms, created, err := db.head.getOrCreate(lbls.Hash(), lbls, false)
 		require.NoError(t, err)
 		require.False(t, created)
-		require.Len(t, ms.ooo.oooMmappedChunks, 2)
-		require.Equal(t, 109*time.Minute.Milliseconds(), ms.ooo.oooMmappedChunks[1].maxTime)
+		require.Len(t, ms.ooo.oooMmappedChunks, 3)
+		require.Equal(t, 110*time.Minute.Milliseconds(), ms.ooo.oooMmappedChunks[2].maxTime)
 		require.Nil(t, ms.ooo.oooHeadChunk) // Because of missing wbl.
 	}
 
@@ -5539,7 +5761,7 @@ func testOOOQueryAfterRestartWithSnapshotAndRemovedWBL(t *testing.T, scenario sa
 	}
 
 	// Checking for expected ooo data from mmap chunks.
-	verifySamples(90, 109)
+	verifySamples(90, 110)
 
 	// Compaction should also work fine.
 	require.Empty(t, db.Blocks())
@@ -5556,7 +5778,7 @@ func testOOOQueryAfterRestartWithSnapshotAndRemovedWBL(t *testing.T, scenario sa
 		require.Nil(t, ms.ooo)
 	}
 
-	verifySamples(90, 109)
+	verifySamples(90, 110)
 }
 
 func TestQuerierOOOQuery(t *testing.T) {
@@ -8420,31 +8642,19 @@ func testDiskFillingUpAfterDisablingOOO(t *testing.T, scenario sampleTypeScenari
 
 	// Check that m-map files gets deleted properly after compactions.
 
-	db.head.mmapHeadChunks()
+	db.head.mmapHeadChunks(true)
 	checkMmapFileContents([]string{"000001", "000002"}, nil)
 
-	// NOTE: We are investigating flaky errors from this compaction on i386 architecture. Compaction panics due to chunk
-	// mapper fatal error. Recover here to understand the error cause. Leaving panic recovery to test causes deadlock
-	// as t.Cleanup tries to close DB with open locks.
-	// See https://github.com/prometheus/prometheus/issues/17941#issuecomment-3846381263
-	require.NotPanics(t, func() {
-		require.NoError(t, db.Compact(ctx))
-	})
+	require.NoError(t, db.Compact(ctx))
 
 	checkMmapFileContents([]string{"000002"}, []string{"000001"})
 	require.Nil(t, ms.ooo, "OOO mmap chunk was not compacted")
 
 	addSamples(501, 650)
-	db.head.mmapHeadChunks()
+	db.head.mmapHeadChunks(true)
 	checkMmapFileContents([]string{"000002", "000003"}, []string{"000001"})
 
-	// NOTE: We are investigating flaky errors from this compaction on i386 architecture. Compaction panics due to chunk
-	// mapper fatal error. Recover here to understand the error cause. Leaving panic recovery to test causes deadlock
-	// as t.Cleanup tries to close DB with open locks.
-	// See https://github.com/prometheus/prometheus/issues/17941#issuecomment-3846381263
-	require.NotPanics(t, func() {
-		require.NoError(t, db.Compact(ctx))
-	})
+	require.NoError(t, db.Compact(ctx))
 	checkMmapFileContents(nil, []string{"000001", "000002", "000003"})
 
 	// Verify that WBL is empty.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -420,6 +420,7 @@ type headMetrics struct {
 	mmapChunksTotal           prometheus.Counter
 	walReplayUnknownRefsTotal *prometheus.CounterVec
 	wblReplayUnknownRefsTotal *prometheus.CounterVec
+	chunkWriteErrorsTotal     prometheus.Counter
 }
 
 const (
@@ -565,6 +566,10 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Name: "prometheus_tsdb_wbl_replay_unknown_refs_total",
 			Help: "Total number of unknown series references encountered during WBL replay.",
 		}, []string{"type"}),
+		chunkWriteErrorsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "prometheus_tsdb_chunk_write_errors_total",
+			Help: "Total number of errors that occurred while writing chunks to disk.",
+		}),
 	}
 
 	if r != nil {
@@ -597,6 +602,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.mmapChunksTotal,
 			m.mmapChunkCorruptionTotal,
 			m.snapshotReplayErrorTotal,
+			m.chunkWriteErrorsTotal,
 			// Metrics bound to functions and not needed in tests
 			// can be created and registered on the spot.
 			prometheus.NewGaugeFunc(prometheus.GaugeOpts{
@@ -961,6 +967,7 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 				maxTime:    maxt,
 				numSamples: numSamples,
 			})
+			ms.observeOOOMinTime(mint)
 
 			h.updateMinOOOMaxOOOTime(mint, maxt)
 			return nil
@@ -1843,7 +1850,7 @@ func (h *Head) Close() error {
 
 	// mmap all but last chunk in case we're performing snapshot since that only
 	// takes samples from most recent head chunk.
-	h.mmapHeadChunks()
+	h.mmapHeadChunks(false)
 
 	errs := h.chunkDiskMapper.Close()
 	if h.wal != nil {
@@ -1907,13 +1914,12 @@ func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, l
 	return s, true, nil
 }
 
-// mmapHeadChunks will iterate all memSeries stored on Head and call mmapHeadChunks() on each of them.
+// mmapHeadChunks will iterate all memSeries stored on Head and call mmapChunks() on each of them.
 //
 // There are two types of chunks that store samples for each memSeries:
 // A) Head chunk - stored on Go heap, when new samples are appended they go there.
 // B) M-mapped chunks - memory mapped chunks, kernel manages the memory for us on-demand, these chunks
-//
-//	are read-only.
+// are read-only.
 //
 // Calling mmapHeadChunks() will iterate all memSeries and m-mmap all chunks that should be m-mapped.
 // The m-mapping operation is needs to be serialised and so it goes via central lock.
@@ -1922,18 +1928,91 @@ func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, l
 // To minimise the effect of locking on TSDB operations m-mapping is serialised and done away from
 // sample append path, since waiting on a lock inside an append would lock the entire memSeries for
 // (potentially) a long time, since that could eventually delay next scrape and/or cause query timeouts.
-func (h *Head) mmapHeadChunks() {
+func (h *Head) mmapHeadChunks(includeOOOHead bool) {
 	var count int
-	for i := 0; i < h.series.size; i++ {
+	for i := range h.series.size {
 		h.series.locks[i].RLock()
 		for _, series := range h.series.series[i] {
 			series.Lock()
-			count += series.mmapChunks(h.chunkDiskMapper)
+			n, err := series.mmapChunks(h.chunkDiskMapper)
+			oooRefs, oooErr := h.mmapOOOChunks(series, includeOOOHead)
 			series.Unlock()
+			if err != nil {
+				h.chunkWriteErrorCallback(err)
+			}
+			if oooErr != nil {
+				h.chunkWriteErrorCallback(oooErr)
+			}
+			count += n
+			count += len(oooRefs)
 		}
 		h.series.locks[i].RUnlock()
 	}
 	h.metrics.mmapChunksTotal.Add(float64(count))
+}
+
+func (h *Head) chunkWriteErrorCallback(err error) {
+	if err != nil && !errors.Is(err, chunks.ErrChunkDiskMapperClosed) {
+		h.logger.Error("Error writing chunk", "err", err)
+		h.metrics.chunkWriteErrorsTotal.Inc()
+	}
+}
+
+func (h *Head) mmapOOOChunks(series *memSeries, includeOOOHead bool) ([]chunks.ChunkDiskMapperRef, error) {
+	if series.ooo == nil {
+		return nil, nil
+	}
+
+	o := chunkOpts{
+		chunkDiskMapper: h.chunkDiskMapper,
+		chunkRange:      h.chunkRange.Load(),
+		samplesPerChunk: h.opts.SamplesPerChunk,
+		useXOR2:         h.opts.EnableXOR2Encoding.Load(),
+	}
+
+	var (
+		mmapRefs []chunks.ChunkDiskMapperRef
+		err      error
+	)
+	if includeOOOHead {
+		mmapRefs, err = series.mmapCurrentOOOHeadChunk(o, h.logger)
+	} else {
+		mmapRefs, err = series.mmapOOOClosedChunks(o, h.logger)
+	}
+	if markerErr := h.logOOOMmapMarkers(series.ref, mmapRefs); markerErr != nil {
+		if err != nil {
+			return mmapRefs, errors.Join(err, markerErr)
+		}
+		return mmapRefs, markerErr
+	}
+	if err != nil {
+		return mmapRefs, err
+	}
+	return mmapRefs, nil
+}
+
+func (h *Head) logOOOMmapMarkers(seriesRef chunks.HeadSeriesRef, mmapRefs []chunks.ChunkDiskMapperRef) error {
+	if h.wbl == nil || len(mmapRefs) == 0 {
+		return nil
+	}
+
+	markers := make([]record.RefMmapMarker, 0, len(mmapRefs))
+	for _, mmapRef := range mmapRefs {
+		markers = append(markers, record.RefMmapMarker{
+			Ref:     seriesRef,
+			MmapRef: mmapRef,
+		})
+	}
+
+	var enc record.Encoder
+	buf := h.getBytesBuffer()
+	rec := enc.MmapMarkers(markers, buf)
+	defer h.putBytesBuffer(rec[:0])
+
+	if err := h.wbl.Log(rec); err != nil {
+		return fmt.Errorf("log OOO mmap markers for series %d: %w", seriesRef, err)
+	}
+	return nil
 }
 
 // seriesHashmap lets TSDB find a memSeries by its label set, via a 64-bit hash.
@@ -2088,19 +2167,17 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 			if seq < minMmapFile {
 				minMmapFile = seq
 			}
-			for _, ch := range series.ooo.oooMmappedChunks {
-				if ch.minTime < minOOOTime {
-					minOOOTime = ch.minTime
-				}
-			}
 		}
-		if series.ooo != nil && series.ooo.oooHeadChunk != nil {
-			if series.ooo.oooHeadChunk.minTime < minOOOTime {
-				minOOOTime = series.ooo.oooHeadChunk.minTime
+		if series.ooo != nil {
+			if !series.ooo.minTimeSet && series.ooo.hasData() {
+				series.recomputeOOOMinTime()
+			}
+			if series.ooo.minTimeSet && series.ooo.minTime < minOOOTime {
+				minOOOTime = series.ooo.minTime
 			}
 		}
 		if len(series.mmappedChunks) > 0 || series.headChunks != nil || series.pendingCommit ||
-			(series.ooo != nil && (len(series.ooo.oooMmappedChunks) > 0 || series.ooo.oooHeadChunk != nil)) {
+			(series.ooo != nil && (len(series.ooo.oooMmappedChunks) > 0 || len(series.ooo.oooClosedChunks) > 0 || series.ooo.oooHeadChunk != nil)) {
 			seriesMint := series.minTime()
 			if seriesMint < actualMint {
 				actualMint = seriesMint
@@ -2474,8 +2551,11 @@ type memSeries struct {
 // to handle out-of-order data.
 type memSeriesOOOFields struct {
 	oooMmappedChunks []*mmappedChunk    // Immutable chunks on disk containing OOO samples.
+	oooClosedChunks  []*oooHeadChunk    // Immutable in-memory OOO chunks waiting to be mmapped.
 	oooHeadChunk     *oooHeadChunk      // Most recent chunk for ooo samples in memory that's still being built.
 	firstOOOChunkID  chunks.HeadChunkID // HeadOOOChunkID for oooMmappedChunks[0].
+	minTime          int64
+	minTimeSet       bool
 }
 
 func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, shardHash uint64, isolationDisabled, pendingCommit bool) *memSeries {
@@ -2493,13 +2573,67 @@ func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, shardHash uint64,
 }
 
 func (s *memSeries) minTime() int64 {
-	if len(s.mmappedChunks) > 0 {
-		return s.mmappedChunks[0].minTime
+	mint := int64(math.MaxInt64)
+	if len(s.mmappedChunks) > 0 && s.mmappedChunks[0].minTime < mint {
+		mint = s.mmappedChunks[0].minTime
 	}
-	if s.headChunks != nil {
-		return s.headChunks.oldest().minTime
+	if s.headChunks != nil && s.headChunks.oldest().minTime < mint {
+		mint = s.headChunks.oldest().minTime
 	}
-	return math.MinInt64
+	if s.ooo != nil {
+		if !s.ooo.minTimeSet && s.ooo.hasData() {
+			s.recomputeOOOMinTime()
+		}
+		if s.ooo.minTimeSet && s.ooo.minTime < mint {
+			mint = s.ooo.minTime
+		}
+	}
+	if mint == math.MaxInt64 {
+		return math.MinInt64
+	}
+	return mint
+}
+
+func (ooo *memSeriesOOOFields) hasData() bool {
+	return len(ooo.oooMmappedChunks) > 0 || len(ooo.oooClosedChunks) > 0 || ooo.oooHeadChunk != nil
+}
+
+func (s *memSeries) observeOOOMinTime(t int64) {
+	if s.ooo == nil {
+		return
+	}
+	if !s.ooo.minTimeSet || t < s.ooo.minTime {
+		s.ooo.minTime = t
+		s.ooo.minTimeSet = true
+	}
+}
+
+func (s *memSeries) recomputeOOOMinTime() {
+	if s.ooo == nil {
+		return
+	}
+
+	mint := int64(math.MaxInt64)
+	for _, c := range s.ooo.oooMmappedChunks {
+		if c.minTime < mint {
+			mint = c.minTime
+		}
+	}
+	for _, c := range s.ooo.oooClosedChunks {
+		if c.minTime < mint {
+			mint = c.minTime
+		}
+	}
+	if s.ooo.oooHeadChunk != nil && s.ooo.oooHeadChunk.minTime < mint {
+		mint = s.ooo.oooHeadChunk.minTime
+	}
+	if mint == math.MaxInt64 {
+		s.ooo.minTime = 0
+		s.ooo.minTimeSet = false
+		return
+	}
+	s.ooo.minTime = mint
+	s.ooo.minTimeSet = true
 }
 
 func (s *memSeries) maxTime() int64 {
@@ -2564,8 +2698,10 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks[:0], s.ooo.oooMmappedChunks[removedOOO:]...)
 		s.ooo.firstOOOChunkID += chunks.HeadChunkID(removedOOO)
 
-		if len(s.ooo.oooMmappedChunks) == 0 && s.ooo.oooHeadChunk == nil {
+		if len(s.ooo.oooMmappedChunks) == 0 && len(s.ooo.oooClosedChunks) == 0 && s.ooo.oooHeadChunk == nil {
 			s.ooo = nil
+		} else if removedOOO > 0 {
+			s.recomputeOOOMinTime()
 		}
 	}
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"sort"
 	"time"
 
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -1386,13 +1387,16 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 
 		switch {
 		case err != nil:
-			// Do nothing here.
+		// Do nothing here.
 		case oooSample:
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
-			var mmapRefs []chunks.ChunkDiskMapperRef
-			ok, chunkCreated, mmapRefs = series.insert(s.ST, s.T, s.V, nil, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
-			if chunkCreated {
+			res := series.insert(s.ST, s.T, s.V, nil, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
+			ok, chunkCreated = res.inserted, res.chunkCreated
+			if res.deferredErr != nil {
+				a.head.chunkWriteErrorCallback(res.deferredErr)
+			}
+			if chunkCreated && res.trackMmap {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
 					// !ok means there are no markers collected for these samples yet. So we first flush the samples
@@ -1407,9 +1411,9 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 				if acc.oooMmapMarkers == nil {
 					acc.oooMmapMarkers = make(map[chunks.HeadSeriesRef][]chunks.ChunkDiskMapperRef)
 				}
-				if len(mmapRefs) > 0 {
-					acc.oooMmapMarkers[series.ref] = mmapRefs
-					acc.oooMmapMarkersCount += len(mmapRefs)
+				if len(res.mmapRefs) > 0 {
+					acc.oooMmapMarkers[series.ref] = res.mmapRefs
+					acc.oooMmapMarkersCount += len(res.mmapRefs)
 				} else {
 					// No chunk was written to disk, so we need to set an initial marker for this series.
 					acc.oooMmapMarkers[series.ref] = []chunks.ChunkDiskMapperRef{0}
@@ -1491,14 +1495,17 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 
 		switch {
 		case err != nil:
-			// Do nothing here.
+		// Do nothing here.
 		case oooSample:
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
-			var mmapRefs []chunks.ChunkDiskMapperRef
 			// TODO(krajorama,ywwg): Pass ST when available in WAL.
-			ok, chunkCreated, mmapRefs = series.insert(0, s.T, 0, s.H, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
-			if chunkCreated {
+			res := series.insert(0, s.T, 0, s.H, nil, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
+			ok, chunkCreated = res.inserted, res.chunkCreated
+			if res.deferredErr != nil {
+				a.head.chunkWriteErrorCallback(res.deferredErr)
+			}
+			if chunkCreated && res.trackMmap {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
 					// !ok means there are no markers collected for these samples yet. So we first flush the samples
@@ -1513,9 +1520,9 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 				if acc.oooMmapMarkers == nil {
 					acc.oooMmapMarkers = make(map[chunks.HeadSeriesRef][]chunks.ChunkDiskMapperRef)
 				}
-				if len(mmapRefs) > 0 {
-					acc.oooMmapMarkers[series.ref] = mmapRefs
-					acc.oooMmapMarkersCount += len(mmapRefs)
+				if len(res.mmapRefs) > 0 {
+					acc.oooMmapMarkers[series.ref] = res.mmapRefs
+					acc.oooMmapMarkersCount += len(res.mmapRefs)
 				} else {
 					// No chunk was written to disk, so we need to set an initial marker for this series.
 					acc.oooMmapMarkers[series.ref] = []chunks.ChunkDiskMapperRef{0}
@@ -1602,14 +1609,17 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 
 		switch {
 		case err != nil:
-			// Do nothing here.
+		// Do nothing here.
 		case oooSample:
 			// Sample is OOO and OOO handling is enabled
 			// and the delta is within the OOO tolerance.
-			var mmapRefs []chunks.ChunkDiskMapperRef
 			// TODO(krajorama,ywwg): Pass ST when available in WAL.
-			ok, chunkCreated, mmapRefs = series.insert(0, s.T, 0, nil, s.FH, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
-			if chunkCreated {
+			res := series.insert(0, s.T, 0, nil, s.FH, acc.appendChunkOpts, acc.oooCapMax, a.head.logger)
+			ok, chunkCreated = res.inserted, res.chunkCreated
+			if res.deferredErr != nil {
+				a.head.chunkWriteErrorCallback(res.deferredErr)
+			}
+			if chunkCreated && res.trackMmap {
 				r, ok := acc.oooMmapMarkers[series.ref]
 				if !ok || r != nil {
 					// !ok means there are no markers collected for these samples yet. So we first flush the samples
@@ -1624,9 +1634,9 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 				if acc.oooMmapMarkers == nil {
 					acc.oooMmapMarkers = make(map[chunks.HeadSeriesRef][]chunks.ChunkDiskMapperRef)
 				}
-				if len(mmapRefs) > 0 {
-					acc.oooMmapMarkers[series.ref] = mmapRefs
-					acc.oooMmapMarkersCount += len(mmapRefs)
+				if len(res.mmapRefs) > 0 {
+					acc.oooMmapMarkers[series.ref] = res.mmapRefs
+					acc.oooMmapMarkersCount += len(res.mmapRefs)
 				} else {
 					// No chunk was written to disk, so we need to set an initial marker for this series.
 					acc.oooMmapMarkers[series.ref] = []chunks.ChunkDiskMapperRef{0}
@@ -1807,28 +1817,76 @@ func (a *headAppenderBase) Commit() (err error) {
 	return nil
 }
 
+type insertResult struct {
+	inserted     bool
+	chunkCreated bool
+	mmapRefs     []chunks.ChunkDiskMapperRef
+	trackMmap    bool
+	deferredErr  error
+}
+
 // insert is like append, except it inserts. Used for OOO samples.
-func (s *memSeries) insert(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, o chunkOpts, oooCapMax int64, logger *slog.Logger) (inserted, chunkCreated bool, mmapRefs []chunks.ChunkDiskMapperRef) {
+func (s *memSeries) insert(st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, o chunkOpts, oooCapMax int64, logger *slog.Logger) insertResult {
 	if s.ooo == nil {
 		s.ooo = &memSeriesOOOFields{}
 	}
 	c := s.ooo.oooHeadChunk
-	if c == nil || c.chunk.NumSamples() == int(oooCapMax) {
-		// Note: If no new samples come in then we rely on compaction to clean up stale in-memory OOO chunks.
-		c, mmapRefs = s.cutNewOOOHeadChunk(t, o, logger)
-		chunkCreated = true
+	var res insertResult
+	if c == nil {
+		c = s.newOOOHeadChunk(t)
+		res.chunkCreated = true
+		res.trackMmap = !o.chunkDiskMapper.WriteQueueEnabled()
+	} else if c.chunk.NumSamples() >= int(oooCapMax) {
+		if o.chunkDiskMapper.WriteQueueEnabled() {
+			// Keep rollover off the append path when chunk writes are queued: seal the full chunk in memory
+			// and let background/compaction paths persist it later.
+			s.ooo.oooClosedChunks = append(s.ooo.oooClosedChunks, c)
+			c = s.newOOOHeadChunk(t)
+			res.chunkCreated = true
+		} else {
+			// Note: If no new samples come in then we rely on compaction to clean up stale in-memory OOO chunks.
+			// If the rollover write fails, keep appending to the current in-memory chunk and retry on a later sample
+			// instead of dropping the current sample.
+			var err error
+			c, res.mmapRefs, err = s.cutNewOOOHeadChunk(t, o, logger)
+			if err != nil {
+				res.deferredErr = err
+				c = s.ooo.oooHeadChunk
+				if c == nil {
+					// All samples from the old head were already written to disk
+					// in prior sub-chunks. Create a fresh head for the new sample.
+					c = s.newOOOHeadChunk(t)
+					res.chunkCreated = true
+				}
+				res.mmapRefs = nil
+			} else {
+				res.chunkCreated = true
+				res.trackMmap = true
+			}
+		}
 	}
 
-	ok := c.chunk.Insert(st, t, v, h, fh)
-	if ok {
-		if chunkCreated || t < c.minTime {
+	res.inserted = c.chunk.Insert(st, t, v, h, fh)
+	if res.inserted {
+		if res.chunkCreated || t < c.minTime {
 			c.minTime = t
 		}
-		if chunkCreated || t > c.maxTime {
+		if res.chunkCreated || t > c.maxTime {
 			c.maxTime = t
 		}
+		s.observeOOOMinTime(c.minTime)
 	}
-	return ok, chunkCreated, mmapRefs
+	return res
+}
+
+func (s *memSeries) newOOOHeadChunk(mint int64) *oooHeadChunk {
+	s.ooo.oooHeadChunk = &oooHeadChunk{
+		chunk:   NewOOOChunk(),
+		minTime: mint,
+		maxTime: math.MinInt64,
+	}
+	s.observeOOOMinTime(mint)
+	return s.ooo.oooHeadChunk
 }
 
 // chunkOpts are chunk-level options that are passed when appending to a memSeries.
@@ -2171,83 +2229,373 @@ func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange 
 
 // cutNewOOOHeadChunk cuts a new OOO chunk and m-maps the old chunk.
 // The caller must ensure that s is locked and s.ooo is not nil.
-func (s *memSeries) cutNewOOOHeadChunk(mint int64, o chunkOpts, logger *slog.Logger) (*oooHeadChunk, []chunks.ChunkDiskMapperRef) {
-	ref := s.mmapCurrentOOOHeadChunk(o, logger)
-
-	s.ooo.oooHeadChunk = &oooHeadChunk{
-		chunk:   NewOOOChunk(),
-		minTime: mint,
-		maxTime: math.MinInt64,
+func (s *memSeries) cutNewOOOHeadChunk(mint int64, o chunkOpts, logger *slog.Logger) (*oooHeadChunk, []chunks.ChunkDiskMapperRef, error) {
+	ref, err := s.mmapCurrentOOOHeadChunk(o, logger)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return s.ooo.oooHeadChunk, ref
+	if s.ooo.oooHeadChunk != nil {
+		// mmapCurrentOOOHeadChunk already installed a new head via
+		// too-many-chunks recovery. Don't clobber it.
+		return s.ooo.oooHeadChunk, ref, nil
+	}
+	return s.newOOOHeadChunk(mint), ref, nil
+}
+
+func (s *memSeries) setOOOStateFromChunks(chunksInMemory []*oooHeadChunk, headIndex int) {
+	if s.ooo == nil {
+		return
+	}
+	if len(chunksInMemory) == 0 {
+		if len(s.ooo.oooMmappedChunks) == 0 {
+			s.ooo = nil
+			return
+		}
+		s.ooo.oooClosedChunks = nil
+		s.ooo.oooHeadChunk = nil
+		s.recomputeOOOMinTime()
+		return
+	}
+
+	if headIndex >= 0 {
+		s.ooo.oooClosedChunks = append(s.ooo.oooClosedChunks[:0], chunksInMemory[:headIndex]...)
+		s.ooo.oooHeadChunk = chunksInMemory[headIndex]
+		s.recomputeOOOMinTime()
+		return
+	}
+
+	s.ooo.oooClosedChunks = append(s.ooo.oooClosedChunks[:0], chunksInMemory...)
+	s.ooo.oooHeadChunk = nil
+	s.recomputeOOOMinTime()
+}
+
+func oooHeadChunkFromSamples(samples []sample) *oooHeadChunk {
+	if len(samples) == 0 {
+		return nil
+	}
+
+	chunk := NewOOOChunk()
+	chunk.samples = append(chunk.samples[:0], samples...)
+	return &oooHeadChunk{
+		chunk:   chunk,
+		minTime: samples[0].t,
+		maxTime: samples[len(samples)-1].t,
+	}
+}
+
+func (s *memSeries) mmapOOOClosedChunks(o chunkOpts, logger *slog.Logger) ([]chunks.ChunkDiskMapperRef, error) {
+	return s.mmapOOOChunks(o, logger, false)
 }
 
 // s must be locked when calling.
-func (s *memSeries) mmapCurrentOOOHeadChunk(o chunkOpts, logger *slog.Logger) []chunks.ChunkDiskMapperRef {
-	if s.ooo == nil || s.ooo.oooHeadChunk == nil {
-		// OOO is not enabled or there is no head chunk, so nothing to m-map here.
-		return nil
+func (s *memSeries) mmapCurrentOOOHeadChunk(o chunkOpts, logger *slog.Logger) ([]chunks.ChunkDiskMapperRef, error) {
+	return s.mmapOOOChunks(o, logger, true)
+}
+
+// s must be locked when calling.
+func (s *memSeries) mmapOOOChunks(o chunkOpts, logger *slog.Logger, includeHead bool) ([]chunks.ChunkDiskMapperRef, error) {
+	if s.ooo == nil || len(s.ooo.oooClosedChunks) == 0 && (!includeHead || s.ooo.oooHeadChunk == nil) {
+		// OOO is not enabled or there are no eligible chunks to m-map here.
+		return nil, nil
 	}
-	chks, err := s.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, o.useXOR2)
-	if err != nil {
-		handleChunkWriteError(err)
-		return nil
+
+	existingHead := s.ooo.oooHeadChunk
+	capExtra := 0
+	if includeHead && s.ooo.oooHeadChunk != nil {
+		capExtra = 1
 	}
-	chunkRefs := make([]chunks.ChunkDiskMapperRef, 0, len(chks))
-	for _, memchunk := range chks {
-		if len(s.ooo.oooMmappedChunks) >= (oooChunkIDMask - 1) {
-			logger.Error("Too many OOO chunks, dropping data", "series", s.lset.String())
+	inMemoryOOOChunks := append(make([]*oooHeadChunk, 0, len(s.ooo.oooClosedChunks)+capExtra), s.ooo.oooClosedChunks...)
+	headIndex := -1
+	if includeHead && s.ooo.oooHeadChunk != nil {
+		inMemoryOOOChunks = append(inMemoryOOOChunks, s.ooo.oooHeadChunk)
+		headIndex = len(inMemoryOOOChunks) - 1
+	}
+
+	type pendingMmap struct {
+		chunk *mmappedChunk
+	}
+
+	var chunkRefs []chunks.ChunkDiskMapperRef
+	var pendingChunks []pendingMmap
+	existingMmapCount := len(s.ooo.oooMmappedChunks)
+
+	// Phase 1: Write all chunks without flushing, collecting refs for deferred state update.
+	var writeErr error
+	var writeErrLastValid chunks.ChunkDiskMapperRef
+	var writeErrI, writeErrJ int
+	var writeErrChks []memChunk
+	for i, c := range inMemoryOOOChunks {
+		chks, encErr := c.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, o.useXOR2)
+		if encErr != nil {
+			// Commit any already-written prefix chunks before returning.
+			if len(pendingChunks) > 0 {
+				if flushErr := o.chunkDiskMapper.FlushWrites(); flushErr != nil {
+					// Flush failed: restore all original chunks.
+					remainingChunks := inMemoryOOOChunks
+					restoreHeadIdx := headIndex
+					if !includeHead && existingHead != nil {
+						remainingChunks = append(append(make([]*oooHeadChunk, 0, len(remainingChunks)+1), remainingChunks...), existingHead)
+						restoreHeadIdx = len(remainingChunks) - 1
+					}
+					s.setOOOStateFromChunks(remainingChunks, restoreHeadIdx)
+					return nil, errors.Join(encErr, flushErr)
+				}
+				for _, p := range pendingChunks {
+					s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks, p.chunk)
+					s.observeOOOMinTime(p.chunk.minTime)
+				}
+			}
+			remaining := inMemoryOOOChunks[i:]
+			newHeadIdx := max(headIndex-i, -1)
+			if !includeHead && existingHead != nil {
+				remaining = append(append(make([]*oooHeadChunk, 0, len(remaining)+1), remaining...), existingHead)
+				newHeadIdx = len(remaining) - 1
+			}
+			s.setOOOStateFromChunks(remaining, newHeadIdx)
+			return chunkRefs, encErr
+		}
+		if chunkRefs == nil {
+			chunkRefs = make([]chunks.ChunkDiskMapperRef, 0, len(chks))
+		}
+		for j, memchunk := range chks {
+			if existingMmapCount+len(pendingChunks) >= (oooChunkIDMask - 1) {
+				logger.Error("Too many OOO chunks, dropping data", "series", s.lset.String())
+				// Flush buffered writes before committing to in-memory state.
+				if len(pendingChunks) > 0 {
+					if flushErr := o.chunkDiskMapper.FlushWrites(); flushErr != nil {
+						// Flush failed: restore all original chunks.
+						remainingChunks := inMemoryOOOChunks
+						restoreHeadIdx := headIndex
+						if !includeHead && existingHead != nil {
+							remainingChunks = append(append(make([]*oooHeadChunk, 0, len(remainingChunks)+1), remainingChunks...), existingHead)
+							restoreHeadIdx = len(remainingChunks) - 1
+						}
+						s.setOOOStateFromChunks(remainingChunks, restoreHeadIdx)
+						return nil, flushErr
+					}
+				}
+				// Commit already-written chunks, then set remaining state.
+				for _, p := range pendingChunks {
+					s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks, p.chunk)
+					s.observeOOOMinTime(p.chunk.minTime)
+				}
+				var suffix *oooHeadChunk
+				remainingChunks := make([]*oooHeadChunk, 0, len(inMemoryOOOChunks)-i)
+				if j == 0 {
+					remainingChunks = append(remainingChunks, c)
+				} else {
+					suffix = oooHeadChunkFromSamples(c.chunk.samples[sort.Search(len(c.chunk.samples), func(k int) bool {
+						return c.chunk.samples[k].t > chks[j-1].maxTime
+					}):])
+					if suffix != nil {
+						remainingChunks = append(remainingChunks, suffix)
+					}
+				}
+				remainingChunks = append(remainingChunks, inMemoryOOOChunks[i+1:]...)
+				newHeadIdx := -1
+				switch {
+				case headIndex == i && (j == 0 || suffix != nil):
+					newHeadIdx = 0
+				case headIndex > i:
+					newHeadIdx = headIndex - i
+					if j > 0 && suffix == nil {
+						newHeadIdx--
+					}
+				}
+				if !includeHead && existingHead != nil {
+					remainingChunks = append(remainingChunks, existingHead)
+					newHeadIdx = len(remainingChunks) - 1
+				}
+				s.setOOOStateFromChunks(remainingChunks, newHeadIdx)
+				return chunkRefs, nil
+			}
+			chunkRef, writeLastValid, err := o.chunkDiskMapper.WriteChunkSyncNoFlush(s.ref, memchunk.minTime, memchunk.maxTime, memchunk.chunk, true)
+			if err != nil {
+				writeErr = err
+				writeErrLastValid = writeLastValid
+				writeErrI = i
+				writeErrJ = j
+				writeErrChks = chks
+				break
+			}
+
+			chunkRefs = append(chunkRefs, chunkRef)
+			pendingChunks = append(pendingChunks, pendingMmap{
+				chunk: &mmappedChunk{
+					ref:        chunkRef,
+					numSamples: uint16(memchunk.chunk.NumSamples()),
+					minTime:    memchunk.minTime,
+					maxTime:    memchunk.maxTime,
+				},
+			})
+		}
+		if writeErr != nil {
 			break
 		}
-		chunkRef := o.chunkDiskMapper.WriteChunk(s.ref, memchunk.minTime, memchunk.maxTime, memchunk.chunk, true, handleChunkWriteError)
-		chunkRefs = append(chunkRefs, chunkRef)
-		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks, &mmappedChunk{
-			ref:        chunkRef,
-			numSamples: uint16(memchunk.chunk.NumSamples()),
-			minTime:    memchunk.minTime,
-			maxTime:    memchunk.maxTime,
-		})
 	}
-	s.ooo.oooHeadChunk = nil
-	return chunkRefs
+
+	// Handle write error mid-loop: commit already-written prefix, set remaining state.
+	// Note: recoverWriteError (called inside WriteChunkSyncNoFlush) flushes buffered data
+	// before recovery, so any successfully written prefix chunks are already persisted to disk.
+	if writeErr != nil {
+		// Filter pending to only include refs at or before the last valid position,
+		// since recovery may have truncated some successfully queued writes.
+		if len(pendingChunks) > 0 {
+			valid := pendingChunks[:0]
+			for _, p := range pendingChunks {
+				if !p.chunk.ref.GreaterThan(writeErrLastValid) {
+					valid = append(valid, p)
+				}
+			}
+			pendingChunks = valid
+
+			// Rebuild chunkRefs from filtered pendingChunks to avoid returning stale refs
+			// that would be written to WBL mmap markers.
+			chunkRefs = chunkRefs[:0]
+			for _, p := range pendingChunks {
+				chunkRefs = append(chunkRefs, p.chunk.ref)
+			}
+		}
+		for _, p := range pendingChunks {
+			s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks, p.chunk)
+			s.observeOOOMinTime(p.chunk.minTime)
+		}
+		i, j, c := writeErrI, writeErrJ, inMemoryOOOChunks[writeErrI]
+		var suffix *oooHeadChunk
+		remainingChunks := make([]*oooHeadChunk, 0, len(inMemoryOOOChunks)-i)
+		if j == 0 {
+			remainingChunks = append(remainingChunks, c)
+		} else {
+			suffix = oooHeadChunkFromSamples(c.chunk.samples[sort.Search(len(c.chunk.samples), func(k int) bool {
+				return c.chunk.samples[k].t > writeErrChks[j-1].maxTime
+			}):])
+			if suffix != nil {
+				remainingChunks = append(remainingChunks, suffix)
+			}
+		}
+		remainingChunks = append(remainingChunks, inMemoryOOOChunks[i+1:]...)
+		newHeadIndex := -1
+		switch {
+		case headIndex == i && (j == 0 || suffix != nil):
+			newHeadIndex = 0
+		case headIndex > i:
+			newHeadIndex = headIndex - i
+			if j > 0 && suffix == nil {
+				newHeadIndex--
+			}
+		}
+		if !includeHead && existingHead != nil {
+			remainingChunks = append(remainingChunks, existingHead)
+			newHeadIndex = len(remainingChunks) - 1
+		}
+		s.setOOOStateFromChunks(remainingChunks, newHeadIndex)
+		return chunkRefs, writeErr
+	}
+
+	// Phase 2: Single batch flush.
+	if err := o.chunkDiskMapper.FlushWrites(); err != nil {
+		// Flush failed: no in-memory state was modified, so restore all chunks as remaining.
+		remainingChunks := inMemoryOOOChunks
+		flushHeadIndex := headIndex
+		if !includeHead && existingHead != nil {
+			remainingChunks = append(append(make([]*oooHeadChunk, 0, len(remainingChunks)+1), remainingChunks...), existingHead)
+			flushHeadIndex = len(remainingChunks) - 1
+		}
+		s.setOOOStateFromChunks(remainingChunks, flushHeadIndex)
+		return nil, err
+	}
+
+	// Phase 3: Success — commit all pending state updates.
+	for _, p := range pendingChunks {
+		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks, p.chunk)
+		s.observeOOOMinTime(p.chunk.minTime)
+	}
+	// Preserve the existing head chunk when it wasn't included in the mmap set.
+	var finalRemaining []*oooHeadChunk
+	finalHeadIndex := -1
+	if !includeHead && existingHead != nil {
+		finalRemaining = []*oooHeadChunk{existingHead}
+		finalHeadIndex = 0
+	}
+	s.setOOOStateFromChunks(finalRemaining, finalHeadIndex)
+	return chunkRefs, nil
 }
 
 // mmapChunks will m-map all but first chunk on s.headChunks list.
-func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count int) {
+func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count int, err error) {
 	if s.headChunks == nil || s.headChunks.prev == nil {
 		// There is none or only one head chunk, so nothing to m-map here.
-		return count
+		return count, nil
+	}
+
+	type pendingMmapChunk struct {
+		chunk *mmappedChunk
 	}
 
 	// Write chunks starting from the oldest one and stop before we get to current s.headChunks.
 	// If we have this chain: s.headChunks{t4} -> t3 -> t2 -> t1 -> t0
 	// then we need to write chunks t0 to t3, but skip s.headChunks.
-	for i := s.headChunks.len() - 1; i > 0; i-- {
+	chunksToWrite := s.headChunks.len() - 1
+
+	// Phase 1: Write all chunks without flushing, collecting refs for deferred state update.
+	var pending []pendingMmapChunk
+	for i := chunksToWrite; i > 0; i-- {
 		chk := s.headChunks.atOffset(i)
-		chunkRef := chunkDiskMapper.WriteChunk(s.ref, chk.minTime, chk.maxTime, chk.chunk, false, handleChunkWriteError)
-		s.mmappedChunks = append(s.mmappedChunks, &mmappedChunk{
-			ref:        chunkRef,
-			numSamples: uint16(chk.chunk.NumSamples()),
-			minTime:    chk.minTime,
-			maxTime:    chk.maxTime,
+		chunkRef, lastValidRef, err := chunkDiskMapper.WriteChunkSyncNoFlush(s.ref, chk.minTime, chk.maxTime, chk.chunk, false)
+		if err != nil {
+			// Write error mid-loop: commit already-written prefix to in-memory state.
+			// Note: recoverWriteError (called inside WriteChunkSyncNoFlush) flushes buffered
+			// data before recovery, so any successfully written prefix chunks are persisted.
+			// Filter pending to only include refs at or before the last valid position,
+			// since recovery may have truncated some successfully queued writes.
+			if len(pending) > 0 {
+				valid := pending[:0]
+				for _, p := range pending {
+					if !p.chunk.ref.GreaterThan(lastValidRef) {
+						valid = append(valid, p)
+					}
+				}
+				pending = valid
+			}
+			if len(pending) > 0 {
+				for _, p := range pending {
+					s.mmappedChunks = append(s.mmappedChunks, p.chunk)
+				}
+				keepOldChunks := chunksToWrite - len(pending)
+				if keepOldChunks == 0 {
+					s.headChunks.prev = nil
+				} else {
+					s.headChunks.atOffset(keepOldChunks).prev = nil
+				}
+			}
+			return len(pending), err
+		}
+
+		pending = append(pending, pendingMmapChunk{
+			chunk: &mmappedChunk{
+				ref:        chunkRef,
+				numSamples: uint16(chk.chunk.NumSamples()),
+				minTime:    chk.minTime,
+				maxTime:    chk.maxTime,
+			},
 		})
-		count++
 	}
 
+	// Phase 2: Single batch flush.
+	if err := chunkDiskMapper.FlushWrites(); err != nil {
+		// Flush failed: no in-memory state was modified, return error.
+		return 0, err
+	}
+
+	// Phase 3: Success — commit all pending state updates.
+	for _, p := range pending {
+		s.mmappedChunks = append(s.mmappedChunks, p.chunk)
+	}
 	// Once we've written out all chunks except s.headChunks we need to unlink these from s.headChunk.
 	s.headChunks.prev = nil
 
-	return count
-}
-
-// TODO(bwplotka): Propagate errors correctly, even when they are async. Panicking here do occurs from time to time
-// and cause flaky tests with hidden root cause (unlocked mutexes when deferred closing).
-// We didn't have evidences of prod impact though, yet.
-func handleChunkWriteError(err error) {
-	if err != nil && !errors.Is(err, chunks.ErrChunkDiskMapperClosed) {
-		panic(err)
-	}
+	return len(pending), nil
 }
 
 // Rollback removes the samples and exemplars from headAppender and writes any series to WAL.

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -840,7 +840,7 @@ func TestHeadAppenderV2_MemSeriesIsolation(t *testing.T) {
 			_, err := app.Append(0, labels.FromStrings("foo", "bar"), 0, int64(i), float64(i), nil, nil, storage.AOptions{})
 			require.NoError(t, err)
 			require.NoError(t, app.Commit())
-			h.mmapHeadChunks()
+			h.mmapHeadChunks(true)
 		}
 		return i
 	}
@@ -1740,7 +1740,7 @@ func TestHistogramInWALAndMmapChunk_AppenderV2(t *testing.T) {
 			}
 		}
 		require.NoError(t, app.Commit())
-		head.mmapHeadChunks()
+		head.mmapHeadChunks(true)
 	}
 
 	// There should be 20 mmap chunks in s1.
@@ -2463,7 +2463,7 @@ func testHeadAppenderV2AppendStaleHistogram(t *testing.T, floatHistogram bool) {
 		expHistograms = append(expHistograms, timedHistogram{t: 100*int64(len(expHistograms)) + 1, h: &histogram.Histogram{Sum: math.Float64frombits(value.StaleNaN)}})
 	}
 	require.NoError(t, app.Commit())
-	head.mmapHeadChunks()
+	head.mmapHeadChunks(true)
 
 	// Total 2 chunks, 1 m-mapped.
 	s = head.series.getByHash(l.Hash(), l)
@@ -2504,7 +2504,7 @@ func TestHeadAppenderV2_Append_CounterResetHeader(t *testing.T) {
 
 				ms, _, err := head.getOrCreate(l.Hash(), l, false)
 				require.NoError(t, err)
-				ms.mmapChunks(head.chunkDiskMapper)
+				mustMmapChunks(t, ms, head.chunkDiskMapper)
 				require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
 
 				for i, mmapChunk := range ms.mmappedChunks {
@@ -2949,29 +2949,27 @@ func testWBLReplayAppenderV2(t *testing.T, scenario sampleTypeScenario, enableST
 	require.NoError(t, err)
 	require.NoError(t, h.Init(0))
 
-	var expOOOSamples []chunks.Sample
+	var expAllSamples []chunks.Sample
 	l := labels.FromStrings("foo", "bar")
-	appendSample := func(mins int64, _ float64, isOOO bool) {
+	appendSample := func(mins int64) {
 		app := h.AppenderV2(context.Background())
 		_, s, err := scenario.appendFunc(storage.AppenderV2AsLimitedV1(app), l, mins*time.Minute.Milliseconds(), mins)
 		require.NoError(t, err)
 		require.NoError(t, app.Commit())
 
-		if isOOO {
-			expOOOSamples = append(expOOOSamples, s)
-		}
+		expAllSamples = append(expAllSamples, s)
 	}
 
 	// In-order sample.
-	appendSample(60, 60, false)
+	appendSample(60)
 
 	// Out of order samples.
-	appendSample(40, 40, true)
-	appendSample(35, 35, true)
-	appendSample(50, 50, true)
-	appendSample(55, 55, true)
-	appendSample(59, 59, true)
-	appendSample(31, 31, true)
+	appendSample(40)
+	appendSample(35)
+	appendSample(50)
+	appendSample(55)
+	appendSample(59)
+	appendSample(31)
 
 	// Check that Head's time ranges are set properly.
 	require.Equal(t, 60*time.Minute.Milliseconds(), h.MinTime())
@@ -2989,29 +2987,50 @@ func testWBLReplayAppenderV2(t *testing.T, scenario sampleTypeScenario, enableST
 	require.NoError(t, err)
 	require.NoError(t, h.Init(0)) // Replay happens here.
 
-	// Get the ooo samples from the Head.
+	// After restart, OOO head chunk may have been mmapped during Close.
+	// Collect OOO samples from both mmapped chunks and in-memory head chunk.
 	ms, ok, err := h.getOrCreate(l.Hash(), l, false)
 	require.NoError(t, err)
 	require.False(t, ok)
 	require.NotNil(t, ms)
 
-	chks, err := ms.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, h.opts.EnableXOR2Encoding.Load())
-	require.NoError(t, err)
-	require.Len(t, chks, 1)
+	var actOOOSamples []chunks.Sample
+	for _, m := range ms.ooo.oooMmappedChunks {
+		chk, err := h.chunkDiskMapper.Chunk(m.ref)
+		require.NoError(t, err)
+		it := chk.Iterator(nil)
+		samples, err := storage.ExpandSamples(it, nil)
+		require.NoError(t, err)
+		actOOOSamples = append(actOOOSamples, samples...)
+	}
+	if ms.ooo.oooHeadChunk != nil {
+		chks, err := ms.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, h.opts.EnableXOR2Encoding.Load())
+		require.NoError(t, err)
+		for _, c := range chks {
+			it := c.chunk.Iterator(nil)
+			samples, err := storage.ExpandSamples(it, nil)
+			require.NoError(t, err)
+			actOOOSamples = append(actOOOSamples, samples...)
+		}
+	}
 
-	it := chks[0].chunk.Iterator(nil)
-	actOOOSamples, err := storage.ExpandSamples(it, nil)
-	require.NoError(t, err)
-
-	// OOO chunk will be sorted. Hence sort the expected samples.
-	sort.Slice(expOOOSamples, func(i, j int) bool {
-		return expOOOSamples[i].T() < expOOOSamples[j].T()
+	// Sort expected OOO samples by time.
+	sort.Slice(expAllSamples, func(i, j int) bool {
+		return expAllSamples[i].T() < expAllSamples[j].T()
 	})
+
+	// Remove the in-order sample from expectations (it's not in OOO chunks).
+	var expOOOOnly []chunks.Sample
+	for _, s := range expAllSamples {
+		if s.T() != 60*time.Minute.Milliseconds() {
+			expOOOOnly = append(expOOOOnly, s)
+		}
+	}
 
 	// Passing in true for the 'ignoreCounterResets' parameter prevents differences in counter reset headers
 	// from being factored in to the sample comparison
 	// TODO(fionaliao): understand counter reset behaviour, might want to modify this later
-	requireEqualSamples(t, l.String(), expOOOSamples, actOOOSamples, requireEqualSamplesIgnoreCounterResets)
+	requireEqualSamples(t, l.String(), expOOOOnly, actOOOSamples, requireEqualSamplesIgnoreCounterResets)
 
 	require.NoError(t, h.Close())
 }
@@ -3071,10 +3090,17 @@ func testOOOMmapReplayAppenderV2(t *testing.T, scenario sampleTypeScenario) {
 		require.Equal(t, int(m.numSamples), chk.NumSamples())
 	}
 
-	expMmapChunks := make([]*mmappedChunk, 3)
-	copy(expMmapChunks, ms.ooo.oooMmappedChunks)
+	// Count total samples across mmapped and in-memory OOO chunks.
+	var expTotalSamples int
+	for _, m := range ms.ooo.oooMmappedChunks {
+		expTotalSamples += int(m.numSamples)
+	}
+	if ms.ooo.oooHeadChunk != nil {
+		expTotalSamples += ms.ooo.oooHeadChunk.chunk.NumSamples()
+	}
 
-	// Restart head.
+	// Restart head. Close mmaps all OOO chunks including the head chunk,
+	// so after restart there will be one more mmapped chunk than before.
 	require.NoError(t, h.Close())
 
 	wal, err = wlog.NewSize(nil, nil, filepath.Join(dir, "wal"), 32768, compression.Snappy)
@@ -3091,18 +3117,17 @@ func testOOOMmapReplayAppenderV2(t *testing.T, scenario sampleTypeScenario) {
 	require.False(t, ok)
 	require.NotNil(t, ms)
 
-	require.Len(t, ms.ooo.oooMmappedChunks, len(expMmapChunks))
-	// Verify that we can access the chunks without error.
+	// Verify that we can access the chunks without error and that the total
+	// sample count matches (the chunk count may differ from before due to
+	// the head chunk being mmapped during Close).
+	var actTotalSamples int
 	for _, m := range ms.ooo.oooMmappedChunks {
 		chk, err := h.chunkDiskMapper.Chunk(m.ref)
 		require.NoError(t, err)
 		require.Equal(t, int(m.numSamples), chk.NumSamples())
+		actTotalSamples += int(m.numSamples)
 	}
-
-	actMmapChunks := make([]*mmappedChunk, len(expMmapChunks))
-	copy(actMmapChunks, ms.ooo.oooMmappedChunks)
-
-	require.Equal(t, expMmapChunks, actMmapChunks)
+	require.Equal(t, expTotalSamples, actTotalSamples)
 
 	require.NoError(t, h.Close())
 }
@@ -3146,7 +3171,7 @@ func TestHead_Init_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
 
-	series.mmapChunks(h.chunkDiskMapper)
+	mustMmapChunks(t, series, h.chunkDiskMapper)
 	expChunks := make([]*mmappedChunk, len(series.mmappedChunks))
 	copy(expChunks, series.mmappedChunks)
 
@@ -3286,7 +3311,7 @@ func TestReplayAfterMmapReplayError_AppenderV2(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	openHead()
-	h.mmapHeadChunks()
+	h.mmapHeadChunks(true)
 
 	// There should be less m-map files due to corruption.
 	files, err = os.ReadDir(filepath.Join(dir, "chunks_head"))
@@ -3473,7 +3498,7 @@ func TestGaugeHistogramWALAndChunkHeader_AppenderV2(t *testing.T) {
 	appendHistogram(hists[4])
 
 	checkHeaders := func() {
-		head.mmapHeadChunks()
+		head.mmapHeadChunks(true)
 		ms, _, err := head.getOrCreate(l.Hash(), l, false)
 		require.NoError(t, err)
 		require.Len(t, ms.mmappedChunks, 3)
@@ -3551,7 +3576,7 @@ func TestGaugeFloatHistogramWALAndChunkHeader_AppenderV2(t *testing.T) {
 	checkHeaders := func() {
 		ms, _, err := head.getOrCreate(l.Hash(), l, false)
 		require.NoError(t, err)
-		head.mmapHeadChunks()
+		head.mmapHeadChunks(true)
 		require.Len(t, ms.mmappedChunks, 3)
 		expHeaders := []chunkenc.CounterResetHeader{
 			chunkenc.UnknownCounterReset,

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -357,7 +357,8 @@ const oooChunkIDMask = 1 << 23
 // oooHeadChunkID returns the HeadChunkID referred to by the given position.
 // Only the bottom 24 bits are used. Bit 23 is always 1 for an OOO chunk; for the rest:
 // * 0 <= pos < len(s.oooMmappedChunks) refer to s.oooMmappedChunks[pos]
-// * pos == len(s.oooMmappedChunks) refers to s.oooHeadChunk
+// * the next len(s.ooo.oooClosedChunks) positions refer to sealed in-memory OOO chunks
+// * the last position refers to s.oooHeadChunk
 // The caller must ensure that s.ooo is not nil.
 func (s *memSeries) oooHeadChunkID(pos int) chunks.HeadChunkID {
 	return (chunks.HeadChunkID(pos) + s.ooo.firstOOOChunkID) | oooChunkIDMask

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -121,7 +121,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -134,7 +134,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=1 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -147,7 +147,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -160,7 +160,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -174,7 +174,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=2 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -188,7 +188,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -202,7 +202,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=1 on memSeries with 3 mmapped chunks and closed ChunkDiskMapper",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -216,7 +216,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks and closed ChunkDiskMapper",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -266,7 +266,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -283,7 +283,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=2 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -300,7 +300,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -317,7 +317,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=5 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -334,7 +334,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=6 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -352,7 +352,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=10 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				mustMmapChunks(t, s, cdm)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -16,6 +16,7 @@ package tsdb
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -99,6 +100,31 @@ func newTestHeadWithOptions(t testing.TB, compressWAL compression.Type, opts *He
 	}))
 
 	return h, wal
+}
+
+func mustMmapChunks(t testing.TB, s *memSeries, chunkDiskMapper *chunks.ChunkDiskMapper) {
+	t.Helper()
+
+	_, err := s.mmapChunks(chunkDiskMapper)
+	require.NoError(t, err)
+}
+
+func failNthChunkWrite(t testing.TB, chunkDiskMapper *chunks.ChunkDiskMapper, failAt int, injErr error) {
+	t.Helper()
+
+	var (
+		calls          int
+		origWriteChunk func(chunks.HeadSeriesRef, int64, int64, chunkenc.Chunk, chunks.ChunkDiskMapperRef, bool, bool) error
+	)
+	origWriteChunk = chunkDiskMapper.SetWriteChunkFuncForTesting(
+		func(seriesRef chunks.HeadSeriesRef, mint, maxt int64, chk chunkenc.Chunk, ref chunks.ChunkDiskMapperRef, isOOO, cutFile bool) error {
+			calls++
+			if calls == failAt {
+				return injErr
+			}
+			return origWriteChunk(seriesRef, mint, maxt, chk, ref, isOOO, cutFile)
+		},
+	)
 }
 
 func BenchmarkCreateSeries(b *testing.B) {
@@ -355,7 +381,7 @@ func BenchmarkLoadWLs(b *testing.B) {
 									// ignores the latest chunk, so we need to cut a new head chunk to guarantee the chunk with
 									// the sample at c.mmappedChunkT is mmapped.
 									s.cutNewHeadChunk(c.mmappedChunkT, chunkenc.EncXOR, c.mmappedChunkT)
-									s.mmapChunks(chunkDiskMapper)
+									mustMmapChunks(b, s, chunkDiskMapper)
 								}
 								require.NoError(b, chunkDiskMapper.Close())
 							}
@@ -1496,7 +1522,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 		ok, _ := s.append(0, int64(i), float64(i), 0, cOpts)
 		require.True(t, ok, "sample append failed")
 	}
-	s.mmapChunks(chunkDiskMapper)
+	mustMmapChunks(t, s, chunkDiskMapper)
 
 	// Check that truncate removes half of the chunks and afterwards
 	// that the ID of the last chunk still gives us the same chunk afterwards.
@@ -1646,7 +1672,7 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 					ok, _ := series.append(0, int64(i), float64(i), 0, cOpts)
 					require.True(t, ok, "sample append failed")
 				}
-				series.mmapChunks(chunkDiskMapper)
+				mustMmapChunks(t, series, chunkDiskMapper)
 			}
 
 			if tc.headChunks == 0 {
@@ -2251,7 +2277,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 	ok, chunkCreated = s.append(stFunc(999), 999, 2, 0, cOpts)
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
-	s.mmapChunks(chunkDiskMapper)
+	mustMmapChunks(t, s, chunkDiskMapper)
 
 	ok, chunkCreated = s.append(stFunc(1000), 1000, 3, 0, cOpts)
 	require.True(t, ok, "append failed")
@@ -2261,7 +2287,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	mustMmapChunks(t, s, chunkDiskMapper)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -2275,7 +2301,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 		ok, _ := s.append(stFunc(ts), ts, float64(i), 0, cOpts)
 		require.True(t, ok, "append failed")
 	}
-	s.mmapChunks(chunkDiskMapper)
+	mustMmapChunks(t, s, chunkDiskMapper)
 
 	require.Greater(t, len(s.mmappedChunks)+1, 7, "expected intermediate chunks")
 
@@ -2285,6 +2311,287 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 		require.NoError(t, err)
 		require.Greater(t, chk.NumSamples(), 100, "unexpected small chunk %d of length %d", i, chk.NumSamples())
 	}
+}
+
+func TestMemSeries_mmapChunksKeepsHeadChunksOnWriteError(t *testing.T) {
+	dir := t.TempDir()
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+	require.NoError(t, err)
+
+	cOpts := chunkOpts{
+		chunkDiskMapper: chunkDiskMapper,
+		chunkRange:      500,
+		samplesPerChunk: DefaultSamplesPerChunk,
+	}
+
+	s := newMemSeries(labels.Labels{}, 1, 0, defaultIsolationDisabled, false)
+
+	ok, chunkCreated := s.append(0, 998, 1, 0, cOpts)
+	require.True(t, ok)
+	require.True(t, chunkCreated)
+
+	ok, chunkCreated = s.append(0, 999, 2, 0, cOpts)
+	require.True(t, ok)
+	require.False(t, chunkCreated)
+
+	ok, chunkCreated = s.append(0, 1000, 3, 0, cOpts)
+	require.True(t, ok)
+	require.True(t, chunkCreated)
+
+	ok, chunkCreated = s.append(0, 1001, 4, 0, cOpts)
+	require.True(t, ok)
+	require.False(t, chunkCreated)
+
+	require.Empty(t, s.mmappedChunks)
+	require.Equal(t, 2, s.headChunks.len())
+
+	oldestHeadChunk := s.headChunks.prev
+	require.NotNil(t, oldestHeadChunk)
+
+	require.NoError(t, chunkDiskMapper.Close())
+
+	count, err := s.mmapChunks(chunkDiskMapper)
+	require.ErrorIs(t, err, chunks.ErrChunkDiskMapperClosed)
+	require.Zero(t, count)
+	require.Empty(t, s.mmappedChunks)
+	require.Equal(t, 2, s.headChunks.len())
+	require.Same(t, oldestHeadChunk, s.headChunks.prev)
+	require.Equal(t, int64(998), s.headChunks.prev.minTime)
+	require.Equal(t, int64(999), s.headChunks.prev.maxTime)
+	require.Equal(t, int64(1000), s.headChunks.minTime)
+	require.Equal(t, int64(1001), s.headChunks.maxTime)
+}
+
+func TestMemSeries_mmapChunksCommitsSuccessfulPrefixOnWriteError(t *testing.T) {
+	dir := t.TempDir()
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, 1)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = chunkDiskMapper.Close() })
+	injectedErr := errors.New("injected chunk write failure")
+	failNthChunkWrite(t, chunkDiskMapper, 2, injectedErr)
+
+	cOpts := chunkOpts{
+		chunkDiskMapper: chunkDiskMapper,
+		chunkRange:      1,
+		samplesPerChunk: DefaultSamplesPerChunk,
+	}
+
+	s := newMemSeries(labels.Labels{}, 1, 0, defaultIsolationDisabled, false)
+	for i := range int64(32) {
+		ok, _ := s.append(0, 1000+i, float64(i), 0, cOpts)
+		require.True(t, ok)
+	}
+
+	totalHeadChunks := s.headChunks.len()
+	count, err := s.mmapChunks(chunkDiskMapper)
+	require.ErrorIs(t, err, injectedErr)
+	require.Positive(t, count)
+	require.Less(t, count, totalHeadChunks-1)
+	require.Len(t, s.mmappedChunks, count)
+	require.Equal(t, totalHeadChunks-count, s.headChunks.len())
+
+	lastMmapped := s.mmappedChunks[len(s.mmappedChunks)-1]
+	require.Equal(t, lastMmapped.maxTime, s.headChunks.oldest().minTime-1)
+}
+
+func TestMemSeries_insertObservesOOOHeadChunkWriteError(t *testing.T) {
+	dir := t.TempDir()
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+	require.NoError(t, err)
+	cOpts := chunkOpts{chunkDiskMapper: chunkDiskMapper}
+
+	s := newMemSeries(labels.Labels{}, 1, 0, defaultIsolationDisabled, false)
+
+	res := s.insert(0, 100, 1, nil, nil, cOpts, 1, promslog.NewNopLogger())
+	require.True(t, res.inserted)
+	require.True(t, res.chunkCreated)
+	require.Empty(t, res.mmapRefs)
+	require.NoError(t, res.deferredErr)
+
+	require.NoError(t, chunkDiskMapper.Close())
+
+	res = s.insert(0, 101, 2, nil, nil, cOpts, 1, promslog.NewNopLogger())
+	require.True(t, res.inserted)
+	require.False(t, res.chunkCreated)
+	require.Nil(t, res.mmapRefs)
+	require.ErrorIs(t, res.deferredErr, chunks.ErrChunkDiskMapperClosed)
+}
+
+func TestMemSeries_insertKeepsOOOHeadChunkOnWriteError(t *testing.T) {
+	dir := t.TempDir()
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, chunks.DefaultWriteQueueSize)
+	require.NoError(t, err)
+	cOpts := chunkOpts{chunkDiskMapper: chunkDiskMapper}
+
+	s := newMemSeries(labels.Labels{}, 1, 0, defaultIsolationDisabled, false)
+
+	res := s.insert(0, 100, 1, nil, nil, cOpts, 1, promslog.NewNopLogger())
+	require.True(t, res.inserted)
+	require.True(t, res.chunkCreated)
+	require.Empty(t, res.mmapRefs)
+	require.NoError(t, res.deferredErr)
+	require.NotNil(t, s.ooo)
+	require.NotNil(t, s.ooo.oooHeadChunk)
+
+	oldOOOHeadChunk := s.ooo.oooHeadChunk
+
+	require.NoError(t, chunkDiskMapper.Close())
+
+	res = s.insert(0, 101, 2, nil, nil, cOpts, 1, promslog.NewNopLogger())
+	require.True(t, res.inserted)
+	require.False(t, res.chunkCreated)
+	require.Nil(t, res.mmapRefs)
+	require.ErrorIs(t, res.deferredErr, chunks.ErrChunkDiskMapperClosed)
+	require.Same(t, oldOOOHeadChunk, s.ooo.oooHeadChunk)
+	require.Empty(t, s.ooo.oooMmappedChunks)
+	require.Equal(t, 2, s.ooo.oooHeadChunk.chunk.NumSamples())
+	require.Equal(t, int64(100), s.ooo.oooHeadChunk.minTime)
+	require.Equal(t, int64(101), s.ooo.oooHeadChunk.maxTime)
+}
+
+func TestMemSeries_insertKeepsQueueEnabledOOORolloverInMemory(t *testing.T) {
+	dir := t.TempDir()
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, 1)
+	require.NoError(t, err)
+	cOpts := chunkOpts{chunkDiskMapper: chunkDiskMapper}
+	defer func() {
+		require.NoError(t, chunkDiskMapper.Close())
+	}()
+
+	s := newMemSeries(labels.Labels{}, 1, 0, defaultIsolationDisabled, false)
+
+	res := s.insert(0, 100, 1, nil, nil, cOpts, 1, promslog.NewNopLogger())
+	require.True(t, res.inserted)
+	require.True(t, res.chunkCreated)
+	require.Empty(t, res.mmapRefs)
+	require.NoError(t, res.deferredErr)
+
+	res = s.insert(0, 101, 2, nil, nil, cOpts, 1, promslog.NewNopLogger())
+	require.True(t, res.inserted)
+	require.True(t, res.chunkCreated)
+	require.Empty(t, res.mmapRefs)
+	require.NoError(t, res.deferredErr)
+
+	require.NotNil(t, s.ooo)
+	require.Empty(t, s.ooo.oooMmappedChunks)
+	require.Len(t, s.ooo.oooClosedChunks, 1)
+	require.NotNil(t, s.ooo.oooHeadChunk)
+	require.Equal(t, 1, s.ooo.oooClosedChunks[0].chunk.NumSamples())
+	require.Equal(t, int64(100), s.ooo.oooClosedChunks[0].minTime)
+	require.Equal(t, int64(100), s.ooo.oooClosedChunks[0].maxTime)
+	require.Equal(t, 1, s.ooo.oooHeadChunk.chunk.NumSamples())
+	require.Equal(t, int64(101), s.ooo.oooHeadChunk.minTime)
+	require.Equal(t, int64(101), s.ooo.oooHeadChunk.maxTime)
+}
+
+func TestMemSeries_mmapCurrentOOOHeadChunkCommitsSuccessfulPrefixOnWriteError(t *testing.T) {
+	dir := t.TempDir()
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, 1)
+	require.NoError(t, err)
+	cOpts := chunkOpts{chunkDiskMapper: chunkDiskMapper}
+	t.Cleanup(func() { _ = chunkDiskMapper.Close() })
+	injectedErr := errors.New("injected chunk write failure")
+	failNthChunkWrite(t, chunkDiskMapper, 2, injectedErr)
+
+	s := newMemSeries(labels.Labels{}, 1, 0, defaultIsolationDisabled, false)
+	for i := range int64(32) {
+		res := s.insert(0, 1000-i, float64(i), nil, nil, cOpts, 1, promslog.NewNopLogger())
+		require.True(t, res.inserted)
+	}
+	require.NotNil(t, s.ooo)
+	totalInMemoryChunks := len(s.ooo.oooClosedChunks) + 1
+
+	refs, err := s.mmapCurrentOOOHeadChunk(cOpts, promslog.NewNopLogger())
+	require.ErrorIs(t, err, injectedErr)
+	require.NotEmpty(t, refs)
+	require.Len(t, s.ooo.oooMmappedChunks, len(refs))
+	require.NotNil(t, s.ooo)
+	require.Less(t, len(s.ooo.oooClosedChunks)+btoi(s.ooo.oooHeadChunk != nil), totalInMemoryChunks)
+	require.Positive(t, len(s.ooo.oooClosedChunks)+btoi(s.ooo.oooHeadChunk != nil))
+}
+
+func TestMemSeries_oooMinTimeTracksFlushAndTruncate(t *testing.T) {
+	dir := t.TempDir()
+	chunkDiskMapper, err := chunks.NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), chunks.DefaultWriteBufferSize, 1)
+	require.NoError(t, err)
+	cOpts := chunkOpts{chunkDiskMapper: chunkDiskMapper}
+	t.Cleanup(func() { require.NoError(t, chunkDiskMapper.Close()) })
+
+	s := newMemSeries(labels.Labels{}, 1, 0, defaultIsolationDisabled, false)
+
+	res := s.insert(0, 100, 1, nil, nil, cOpts, 1, promslog.NewNopLogger())
+	require.True(t, res.inserted)
+	res = s.insert(0, 101, 2, nil, nil, cOpts, 1, promslog.NewNopLogger())
+	require.True(t, res.inserted)
+
+	require.NotNil(t, s.ooo)
+	require.True(t, s.ooo.minTimeSet)
+	require.Equal(t, int64(100), s.ooo.minTime)
+	require.Equal(t, int64(100), s.minTime())
+
+	refs, err := s.mmapCurrentOOOHeadChunk(cOpts, promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+	require.NotNil(t, s.ooo)
+	require.True(t, s.ooo.minTimeSet)
+	require.Equal(t, int64(100), s.ooo.minTime)
+	require.Equal(t, int64(100), s.minTime())
+
+	removed := s.truncateChunksBefore(math.MinInt64, refs[0])
+	require.Equal(t, 1, removed)
+	require.NotNil(t, s.ooo)
+	require.True(t, s.ooo.minTimeSet)
+	require.Equal(t, int64(101), s.ooo.minTime)
+	require.Equal(t, int64(101), s.minTime())
+
+	removed = s.truncateChunksBefore(math.MinInt64, refs[1])
+	require.Equal(t, 1, removed)
+	require.Nil(t, s.ooo)
+	require.Equal(t, int64(math.MinInt64), s.minTime())
+}
+
+func btoi(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+func TestWBLSubsetProcessorPreservesOOOSampleOnRolloverWriteError(t *testing.T) {
+	h, _ := newTestHead(t, 1000, compression.None, true)
+	h.opts.OutOfOrderCapMax.Store(1)
+	require.NoError(t, h.Init(0))
+
+	ms, _, err := h.getOrCreate(labels.FromStrings("a", "b").Hash(), labels.FromStrings("a", "b"), false)
+	require.NoError(t, err)
+
+	ms.ooo = &memSeriesOOOFields{
+		oooHeadChunk: &oooHeadChunk{
+			chunk:   NewOOOChunk(),
+			minTime: 100,
+			maxTime: 100,
+		},
+	}
+	require.True(t, ms.ooo.oooHeadChunk.chunk.Insert(0, 100, 1, nil, nil))
+
+	require.NoError(t, h.chunkDiskMapper.Close())
+
+	var wp wblSubsetProcessor
+	wp.setup()
+	wp.input <- wblSubsetProcessorInputItem{
+		samples: []record.RefSample{{Ref: ms.ref, T: 101, V: 2}},
+	}
+	close(wp.input)
+
+	missingSeries, unknownSampleRefs, unknownHistogramRefs := wp.processWBLSamples(h)
+	require.Empty(t, missingSeries)
+	require.Zero(t, unknownSampleRefs)
+	require.Zero(t, unknownHistogramRefs)
+	require.NotNil(t, ms.ooo.oooHeadChunk)
+	require.Empty(t, ms.ooo.oooMmappedChunks)
+	require.Equal(t, 2, ms.ooo.oooHeadChunk.chunk.NumSamples())
+	require.Equal(t, int64(100), ms.ooo.oooHeadChunk.minTime)
+	require.Equal(t, int64(101), ms.ooo.oooHeadChunk.maxTime)
 }
 
 // TestMemSeries_appendHistogram tests histogram appending with various useXOR2/st combinations.
@@ -2370,7 +2677,7 @@ func testMemSeriesAppendHistogram(t *testing.T, useXOR2 bool, stFunc func(ts int
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	mustMmapChunks(t, s, chunkDiskMapper)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -2381,7 +2688,7 @@ func testMemSeriesAppendHistogram(t *testing.T, useXOR2 bool, stFunc func(ts int
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "third sample should trigger a re-encoded chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	mustMmapChunks(t, s, chunkDiskMapper)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -2430,7 +2737,7 @@ func TestMemSeries_append_atVariableRate(t *testing.T) {
 	require.True(t, ok, "new chunk sample was not appended")
 	require.True(t, chunkCreated, "sample at block duration timestamp should create a new chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	mustMmapChunks(t, s, chunkDiskMapper)
 	var totalSamplesInChunks int
 	for i, c := range s.mmappedChunks {
 		totalSamplesInChunks += int(c.numSamples)
@@ -2866,7 +3173,7 @@ func TestHeadReadWriterRepair(t *testing.T) {
 			require.True(t, ok, "series append failed")
 			require.False(t, chunkCreated, "chunk was created")
 			h.chunkDiskMapper.CutNewFile()
-			s.mmapChunks(h.chunkDiskMapper)
+			mustMmapChunks(t, s, h.chunkDiskMapper)
 		}
 		require.NoError(t, h.Close())
 
@@ -3004,7 +3311,7 @@ func TestMemSeriesIsolation(t *testing.T) {
 			_, err := app.Append(0, labels.FromStrings("foo", "bar"), int64(i), float64(i))
 			require.NoError(t, err)
 			require.NoError(t, app.Commit())
-			h.mmapHeadChunks()
+			h.mmapHeadChunks(true)
 		}
 		return i
 	}
@@ -4331,7 +4638,7 @@ func TestHistogramInWALAndMmapChunk(t *testing.T) {
 			}
 		}
 		require.NoError(t, app.Commit())
-		head.mmapHeadChunks()
+		head.mmapHeadChunks(true)
 	}
 
 	// There should be 20 mmap chunks in s1.
@@ -5047,7 +5354,7 @@ func testHistogramStaleSampleHelper(t *testing.T, floatHistogram bool) {
 		expHistograms = append(expHistograms, timedHistogram{t: 100*int64(len(expHistograms)) + 1, h: &histogram.Histogram{Sum: math.Float64frombits(value.StaleNaN)}})
 	}
 	require.NoError(t, app.Commit())
-	head.mmapHeadChunks()
+	head.mmapHeadChunks(true)
 
 	// Total 2 chunks, 1 m-mapped.
 	s = head.series.getByHash(l.Hash(), l)
@@ -5088,7 +5395,7 @@ func TestHistogramCounterResetHeader(t *testing.T) {
 
 				ms, _, err := head.getOrCreate(l.Hash(), l, false)
 				require.NoError(t, err)
-				ms.mmapChunks(head.chunkDiskMapper)
+				mustMmapChunks(t, ms, head.chunkDiskMapper)
 				require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
 
 				for i, mmapChunk := range ms.mmappedChunks {
@@ -5601,29 +5908,27 @@ func testWBLReplay(t *testing.T, scenario sampleTypeScenario) {
 	require.NoError(t, err)
 	require.NoError(t, h.Init(0))
 
-	var expOOOSamples []chunks.Sample
+	var expAllSamples []chunks.Sample
 	l := labels.FromStrings("foo", "bar")
-	appendSample := func(mins int64, _ float64, isOOO bool) {
+	appendSample := func(mins int64) {
 		app := h.Appender(context.Background())
 		_, s, err := scenario.appendFunc(app, l, mins*time.Minute.Milliseconds(), mins)
 		require.NoError(t, err)
 		require.NoError(t, app.Commit())
 
-		if isOOO {
-			expOOOSamples = append(expOOOSamples, s)
-		}
+		expAllSamples = append(expAllSamples, s)
 	}
 
 	// In-order sample.
-	appendSample(60, 60, false)
+	appendSample(60)
 
 	// Out of order samples.
-	appendSample(40, 40, true)
-	appendSample(35, 35, true)
-	appendSample(50, 50, true)
-	appendSample(55, 55, true)
-	appendSample(59, 59, true)
-	appendSample(31, 31, true)
+	appendSample(40)
+	appendSample(35)
+	appendSample(50)
+	appendSample(55)
+	appendSample(59)
+	appendSample(31)
 
 	// Check that Head's time ranges are set properly.
 	require.Equal(t, 60*time.Minute.Milliseconds(), h.MinTime())
@@ -5641,29 +5946,50 @@ func testWBLReplay(t *testing.T, scenario sampleTypeScenario) {
 	require.NoError(t, err)
 	require.NoError(t, h.Init(0)) // Replay happens here.
 
-	// Get the ooo samples from the Head.
+	// After restart, OOO head chunk may have been mmapped during Close.
+	// Collect OOO samples from both mmapped chunks and in-memory head chunk.
 	ms, ok, err := h.getOrCreate(l.Hash(), l, false)
 	require.NoError(t, err)
 	require.False(t, ok)
 	require.NotNil(t, ms)
 
-	chks, err := ms.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, false)
-	require.NoError(t, err)
-	require.Len(t, chks, 1)
+	var actOOOSamples []chunks.Sample
+	for _, m := range ms.ooo.oooMmappedChunks {
+		chk, err := h.chunkDiskMapper.Chunk(m.ref)
+		require.NoError(t, err)
+		it := chk.Iterator(nil)
+		samples, err := storage.ExpandSamples(it, nil)
+		require.NoError(t, err)
+		actOOOSamples = append(actOOOSamples, samples...)
+	}
+	if ms.ooo.oooHeadChunk != nil {
+		chks, err := ms.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, false)
+		require.NoError(t, err)
+		for _, c := range chks {
+			it := c.chunk.Iterator(nil)
+			samples, err := storage.ExpandSamples(it, nil)
+			require.NoError(t, err)
+			actOOOSamples = append(actOOOSamples, samples...)
+		}
+	}
 
-	it := chks[0].chunk.Iterator(nil)
-	actOOOSamples, err := storage.ExpandSamples(it, nil)
-	require.NoError(t, err)
-
-	// OOO chunk will be sorted. Hence sort the expected samples.
-	sort.Slice(expOOOSamples, func(i, j int) bool {
-		return expOOOSamples[i].T() < expOOOSamples[j].T()
+	// Sort expected OOO samples by time.
+	sort.Slice(expAllSamples, func(i, j int) bool {
+		return expAllSamples[i].T() < expAllSamples[j].T()
 	})
+
+	// Remove the in-order sample from expectations (it's not in OOO chunks).
+	var expOOOOnly []chunks.Sample
+	for _, s := range expAllSamples {
+		if s.T() != 60*time.Minute.Milliseconds() {
+			expOOOOnly = append(expOOOOnly, s)
+		}
+	}
 
 	// Passing in true for the 'ignoreCounterResets' parameter prevents differences in counter reset headers
 	// from being factored in to the sample comparison
 	// TODO(fionaliao): understand counter reset behaviour, might want to modify this later
-	requireEqualSamples(t, l.String(), expOOOSamples, actOOOSamples, requireEqualSamplesIgnoreCounterResets)
+	requireEqualSamples(t, l.String(), expOOOOnly, actOOOSamples, requireEqualSamplesIgnoreCounterResets)
 
 	require.NoError(t, h.Close())
 }
@@ -5723,10 +6049,17 @@ func testOOOMmapReplay(t *testing.T, scenario sampleTypeScenario) {
 		require.Equal(t, int(m.numSamples), chk.NumSamples())
 	}
 
-	expMmapChunks := make([]*mmappedChunk, 3)
-	copy(expMmapChunks, ms.ooo.oooMmappedChunks)
+	// Count total samples across mmapped and in-memory OOO chunks.
+	var expTotalSamples int
+	for _, m := range ms.ooo.oooMmappedChunks {
+		expTotalSamples += int(m.numSamples)
+	}
+	if ms.ooo.oooHeadChunk != nil {
+		expTotalSamples += ms.ooo.oooHeadChunk.chunk.NumSamples()
+	}
 
-	// Restart head.
+	// Restart head. Close mmaps all OOO chunks including the head chunk,
+	// so after restart there will be one more mmapped chunk than before.
 	require.NoError(t, h.Close())
 
 	wal, err = wlog.NewSize(nil, nil, filepath.Join(dir, "wal"), 32768, compression.Snappy)
@@ -5743,18 +6076,17 @@ func testOOOMmapReplay(t *testing.T, scenario sampleTypeScenario) {
 	require.False(t, ok)
 	require.NotNil(t, ms)
 
-	require.Len(t, ms.ooo.oooMmappedChunks, len(expMmapChunks))
-	// Verify that we can access the chunks without error.
+	// Verify that we can access the chunks without error and that the total
+	// sample count matches (the chunk count may differ from before due to
+	// the head chunk being mmapped during Close).
+	var actTotalSamples int
 	for _, m := range ms.ooo.oooMmappedChunks {
 		chk, err := h.chunkDiskMapper.Chunk(m.ref)
 		require.NoError(t, err)
 		require.Equal(t, int(m.numSamples), chk.NumSamples())
+		actTotalSamples += int(m.numSamples)
 	}
-
-	actMmapChunks := make([]*mmappedChunk, len(expMmapChunks))
-	copy(actMmapChunks, ms.ooo.oooMmappedChunks)
-
-	require.Equal(t, expMmapChunks, actMmapChunks)
+	require.Equal(t, expTotalSamples, actTotalSamples)
 
 	require.NoError(t, h.Close())
 }
@@ -5882,7 +6214,7 @@ func TestHeadInit_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
 
-	series.mmapChunks(h.chunkDiskMapper)
+	mustMmapChunks(t, series, h.chunkDiskMapper)
 	expChunks := make([]*mmappedChunk, len(series.mmappedChunks))
 	copy(expChunks, series.mmappedChunks)
 
@@ -6043,7 +6375,7 @@ func TestReplayAfterMmapReplayError(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	openHead()
-	h.mmapHeadChunks()
+	h.mmapHeadChunks(true)
 
 	// There should be less m-map files due to corruption.
 	files, err = os.ReadDir(filepath.Join(dir, "chunks_head"))
@@ -6230,7 +6562,7 @@ func TestGaugeHistogramWALAndChunkHeader(t *testing.T) {
 	appendHistogram(hists[4])
 
 	checkHeaders := func() {
-		head.mmapHeadChunks()
+		head.mmapHeadChunks(true)
 		ms, _, err := head.getOrCreate(l.Hash(), l, false)
 		require.NoError(t, err)
 		require.Len(t, ms.mmappedChunks, 3)
@@ -6308,7 +6640,7 @@ func TestGaugeFloatHistogramWALAndChunkHeader(t *testing.T) {
 	checkHeaders := func() {
 		ms, _, err := head.getOrCreate(l.Hash(), l, false)
 		require.NoError(t, err)
-		head.mmapHeadChunks()
+		head.mmapHeadChunks(true)
 		require.Len(t, ms.mmappedChunks, 3)
 		expHeaders := []chunkenc.CounterResetHeader{
 			chunkenc.UnknownCounterReset,

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -554,6 +554,7 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 			mSeries.ooo = &memSeriesOOOFields{}
 		}
 		*mSeries.ooo = memSeriesOOOFields{oooMmappedChunks: oooMmc}
+		mSeries.recomputeOOOMinTime()
 	}
 	// Cache the last mmapped chunk time, so we can skip calling append() for samples it will reject.
 	if len(mmc) == 0 {
@@ -681,7 +682,9 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if _, chunkCreated := ms.append(s.ST, s.T, s.V, 0, appendChunkOpts); chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()
-				_ = ms.mmapChunks(h.chunkDiskMapper)
+				if _, err := ms.mmapChunks(h.chunkDiskMapper); err != nil {
+					h.chunkWriteErrorCallback(err)
+				}
 			}
 			if s.T > maxt {
 				maxt = s.T
@@ -735,7 +738,9 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()
-				_ = ms.mmapChunks(h.chunkDiskMapper)
+				if _, err := ms.mmapChunks(h.chunkDiskMapper); err != nil {
+					h.chunkWriteErrorCallback(err)
+				}
 			}
 			if s.t > maxt {
 				maxt = s.t
@@ -759,6 +764,80 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 	return missingSeries, unknownSampleRefs, unknownHistogramRefs, mmapOverlappingChunks
 }
 
+func (h *Head) dropUnmarkedOOOMmapChunks(markedRefs map[chunks.HeadSeriesRef]map[chunks.ChunkDiskMapperRef]struct{}, lastMmapRef chunks.ChunkDiskMapperRef) {
+	lastSeq, lastOff := lastMmapRef.Unpack()
+	for i := range h.series.size {
+		h.series.locks[i].RLock()
+		for _, series := range h.series.series[i] {
+			series.Lock()
+			if series.ooo == nil || len(series.ooo.oooMmappedChunks) == 0 {
+				series.Unlock()
+				continue
+			}
+
+			refsForSeries, ok := markedRefs[series.ref]
+			if !ok {
+				// No markers at all for this series — all chunks predate this
+				// WBL session (their markers may have been truncated by a prior
+				// compaction cycle). Keep everything.
+				series.Unlock()
+				continue
+			}
+
+			// Find minimum real (non-zero) marker ref as session boundary.
+			// Chunks written before this ref predate the current WBL session
+			// and should be kept — their markers may have been truncated by
+			// a prior compaction cycle.
+			var minMarkerRef chunks.ChunkDiskMapperRef
+			for ref := range refsForSeries {
+				if ref != 0 && (minMarkerRef == 0 || !ref.GreaterThanOrEqualTo(minMarkerRef)) {
+					minMarkerRef = ref
+				}
+			}
+
+			kept := series.ooo.oooMmappedChunks[:0]
+			for _, mmc := range series.ooo.oooMmappedChunks {
+				seq, off := mmc.ref.Unpack()
+				createdDuringReplay := seq > lastSeq || (seq == lastSeq && off > lastOff)
+				if createdDuringReplay {
+					// Chunks created during WBL replay have no markers; always keep them.
+					kept = append(kept, mmc)
+				} else if minMarkerRef == 0 || minMarkerRef.GreaterThan(mmc.ref) {
+					// No real markers (only {0} initial marker), or chunk predates the
+					// first real marker — from a prior session. Keep.
+					kept = append(kept, mmc)
+				} else if _, ok := refsForSeries[mmc.ref]; ok {
+					kept = append(kept, mmc)
+				}
+			}
+
+			if len(kept) == len(series.ooo.oooMmappedChunks) {
+				series.Unlock()
+				continue
+			}
+
+			removed := len(series.ooo.oooMmappedChunks) - len(kept)
+			h.metrics.chunksRemoved.Add(float64(removed))
+			h.metrics.chunks.Sub(float64(removed))
+			if len(kept) == 0 {
+				series.ooo.oooMmappedChunks = nil
+				series.ooo.firstOOOChunkID = 0
+				if len(series.ooo.oooClosedChunks) == 0 && series.ooo.oooHeadChunk == nil {
+					series.ooo = nil
+				} else {
+					series.recomputeOOOMinTime()
+				}
+			} else {
+				series.ooo.oooMmappedChunks = kept
+				series.ooo.firstOOOChunkID = 0
+				series.recomputeOOOMinTime()
+			}
+			series.Unlock()
+		}
+		h.series.locks[i].RUnlock()
+	}
+}
+
 func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, lastMmapRef chunks.ChunkDiskMapperRef) (err error) {
 	// Track number of missing series records that were referenced by other records.
 	unknownSeriesRefs := &seriesRefSet{refs: make(map[chunks.HeadSeriesRef]struct{}), mtx: sync.Mutex{}}
@@ -769,9 +848,10 @@ func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 	lastSeq, lastOff := lastMmapRef.Unpack()
 	// Start workers that each process samples for a partition of the series ID space.
 	var (
-		wg          sync.WaitGroup
-		concurrency = h.opts.WALReplayConcurrency
-		processors  = make([]wblSubsetProcessor, concurrency)
+		wg                sync.WaitGroup
+		concurrency       = h.opts.WALReplayConcurrency
+		processors        = make([]wblSubsetProcessor, concurrency)
+		markedOOOMmapRefs = make(map[chunks.HeadSeriesRef]map[chunks.ChunkDiskMapperRef]struct{})
 
 		shards          = make([][]record.RefSample, concurrency)
 		histogramShards = make([][]histogramRecord, concurrency)
@@ -914,6 +994,10 @@ func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				if r, ok := multiRef[rm.Ref]; ok {
 					rm.Ref = r
 				}
+				if _, ok := markedOOOMmapRefs[rm.Ref]; !ok {
+					markedOOOMmapRefs[rm.Ref] = make(map[chunks.ChunkDiskMapperRef]struct{}, 1)
+				}
+				markedOOOMmapRefs[rm.Ref][rm.MmapRef] = struct{}{}
 
 				ms := h.series.getByID(rm.Ref)
 				if ms == nil {
@@ -999,6 +1083,8 @@ func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		processors[i].closeAndDrain()
 	}
 	wg.Wait()
+
+	h.dropUnmarkedOOOMmapChunks(markedOOOMmapRefs, lastMmapRef)
 
 	if err := r.Err(); err != nil {
 		return fmt.Errorf("read records: %w", err)
@@ -1104,12 +1190,12 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (map[chunks.HeadSeriesR
 	mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)
 	for in := range wp.input {
 		if in.mmappedSeries != nil && in.mmappedSeries.ooo != nil {
-			// All samples till now have been m-mapped. Hence clear out the headChunk.
-			// In case some samples slipped through and went into m-map chunks because of changed
-			// chunk size parameters, we are not taking care of that here.
-			// TODO(codesome): see if there is a way to avoid duplicate m-map chunks if
-			// the size of ooo chunk was reduced between restart.
-			in.mmappedSeries.ooo.oooHeadChunk = nil
+			// The marker tells us that all preceding samples were m-mapped in
+			// the original run. Clear closed chunks (replay duplicates), but
+			// keep oooHeadChunk: it may hold samples inserted after the last
+			// m-map that have no marker yet and would otherwise be lost.
+			in.mmappedSeries.ooo.oooClosedChunks = nil
+			in.mmappedSeries.recomputeOOOMinTime()
 			continue
 		}
 		for _, s := range in.samples {
@@ -1119,12 +1205,15 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (map[chunks.HeadSeriesR
 				missingSeries[s.Ref] = struct{}{}
 				continue
 			}
-			ok, chunkCreated, _ := ms.insert(s.ST, s.T, s.V, nil, nil, appendChunkOpts, oooCapMax, h.logger)
-			if chunkCreated {
+			res := ms.insert(s.ST, s.T, s.V, nil, nil, appendChunkOpts, oooCapMax, h.logger)
+			if res.deferredErr != nil {
+				h.chunkWriteErrorCallback(res.deferredErr)
+			}
+			if res.chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()
 			}
-			if ok {
+			if res.inserted {
 				if s.T < mint {
 					mint = s.T
 				}
@@ -1144,20 +1233,22 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (map[chunks.HeadSeriesR
 				missingSeries[s.ref] = struct{}{}
 				continue
 			}
-			var chunkCreated bool
-			var ok bool
+			var res insertResult
 			if s.h != nil {
 				// TODO(krajorama,ywwg): Pass ST when available in WBL.
-				ok, chunkCreated, _ = ms.insert(0, s.t, 0, s.h, nil, appendChunkOpts, oooCapMax, h.logger)
+				res = ms.insert(0, s.t, 0, s.h, nil, appendChunkOpts, oooCapMax, h.logger)
 			} else {
 				// TODO(krajorama,ywwg): Pass ST when available in WBL.
-				ok, chunkCreated, _ = ms.insert(0, s.t, 0, nil, s.fh, appendChunkOpts, oooCapMax, h.logger)
+				res = ms.insert(0, s.t, 0, nil, s.fh, appendChunkOpts, oooCapMax, h.logger)
 			}
-			if chunkCreated {
+			if res.deferredErr != nil {
+				h.chunkWriteErrorCallback(res.deferredErr)
+			}
+			if res.chunkCreated {
 				h.metrics.chunksCreated.Inc()
 				h.metrics.chunks.Inc()
 			}
-			if ok {
+			if res.inserted {
 				if s.t > maxt {
 					maxt = s.t
 				}

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -87,9 +87,9 @@ func (oh *HeadAndOOOIndexReader) Series(ref storage.SeriesRef, builder *labels.S
 // any chunk at or before this ref will not be considered. 0 disables this check.
 //
 // maxMmapRef tells upto what max m-map chunk that we can consider. If it is non-0, then
-// the oooHeadChunk will not be considered.
+// in-memory OOO chunks will not be considered.
 func getOOOSeriesChunks(s *memSeries, useXOR2 bool, mint, maxt int64, lastGarbageCollectedMmapRef, maxMmapRef chunks.ChunkDiskMapperRef, includeInOrder bool, inoMint int64, chks *[]chunks.Meta) error {
-	tmpChks := make([]chunks.Meta, 0, len(s.ooo.oooMmappedChunks))
+	tmpChks := make([]chunks.Meta, 0, len(s.ooo.oooMmappedChunks)+len(s.ooo.oooClosedChunks)+1)
 
 	addChunk := func(minT, maxT int64, ref chunks.ChunkRef, chunk chunkenc.Chunk) {
 		tmpChks = append(tmpChks, chunks.Meta{
@@ -101,15 +101,32 @@ func getOOOSeriesChunks(s *memSeries, useXOR2 bool, mint, maxt int64, lastGarbag
 	}
 
 	// Collect all chunks that overlap the query range.
+	for i, c := range s.ooo.oooClosedChunks {
+		if !c.OverlapsClosedInterval(mint, maxt) || maxMmapRef != 0 {
+			continue
+		}
+		ref := chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.oooHeadChunkID(len(s.ooo.oooMmappedChunks)+i)))
+		if len(c.chunk.samples) > 0 { // Empty samples happens in tests, at least.
+			chks, err := c.chunk.ToEncodedChunks(c.minTime, c.maxTime, useXOR2)
+			if err != nil {
+				return fmt.Errorf("encoding sealed OOO chunk for reading: %w", err)
+			}
+			for _, chk := range chks {
+				addChunk(chk.minTime, chk.maxTime, ref, chk.chunk)
+			}
+		} else {
+			var emptyChunk chunkenc.Chunk
+			addChunk(c.minTime, c.maxTime, ref, emptyChunk)
+		}
+	}
 	if s.ooo.oooHeadChunk != nil {
 		c := s.ooo.oooHeadChunk
 		if c.OverlapsClosedInterval(mint, maxt) && maxMmapRef == 0 {
-			ref := chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.oooHeadChunkID(len(s.ooo.oooMmappedChunks))))
+			ref := chunks.ChunkRef(chunks.NewHeadChunkRef(s.ref, s.oooHeadChunkID(len(s.ooo.oooMmappedChunks)+len(s.ooo.oooClosedChunks))))
 			if len(c.chunk.samples) > 0 { // Empty samples happens in tests, at least.
 				chks, err := s.ooo.oooHeadChunk.chunk.ToEncodedChunks(c.minTime, c.maxTime, useXOR2)
 				if err != nil {
-					handleChunkWriteError(err)
-					return nil
+					return fmt.Errorf("encoding OOO head chunk for reading: %w", err)
 				}
 				for _, chk := range chks {
 					addChunk(chk.minTime, chk.maxTime, ref, chk.chunk)
@@ -336,46 +353,67 @@ func NewOOOCompactionHead(ctx context.Context, head *Head) (*OOOCompactionHead, 
 			continue
 		}
 
-		// M-map the in-memory chunk and keep track of the last one.
-		// Also build the block ranges -> series map.
-		// TODO: consider having a lock specifically for ooo data.
-		ms.Lock()
-
-		if ms.ooo == nil {
-			ms.Unlock()
-			continue
+		if err := ch.mmapOOOSeriesChunk(head, ms, seriesRef, &lastSeq, &lastOff); err != nil {
+			return nil, err
 		}
-
-		var lastMmapRef chunks.ChunkDiskMapperRef
-		mmapRefs := ms.mmapCurrentOOOHeadChunk(chunkOpts{chunkDiskMapper: head.chunkDiskMapper, useXOR2: head.opts.EnableXOR2Encoding.Load()}, head.logger)
-		if len(mmapRefs) == 0 && len(ms.ooo.oooMmappedChunks) > 0 {
-			// Nothing was m-mapped. So take the mmapRef from the existing slice if it exists.
-			mmapRefs = []chunks.ChunkDiskMapperRef{ms.ooo.oooMmappedChunks[len(ms.ooo.oooMmappedChunks)-1].ref}
-		}
-		if len(mmapRefs) == 0 {
-			lastMmapRef = 0
-		} else {
-			lastMmapRef = mmapRefs[len(mmapRefs)-1]
-		}
-		seq, off := lastMmapRef.Unpack()
-		if seq > lastSeq || (seq == lastSeq && off > lastOff) {
-			ch.lastMmapRef, lastSeq, lastOff = lastMmapRef, seq, off
-		}
-		if len(ms.ooo.oooMmappedChunks) > 0 {
-			ch.postings = append(ch.postings, seriesRef)
-			for _, c := range ms.ooo.oooMmappedChunks {
-				if c.minTime < ch.mint {
-					ch.mint = c.minTime
-				}
-				if c.maxTime > ch.maxt {
-					ch.maxt = c.maxTime
-				}
-			}
-		}
-		ms.Unlock()
 	}
 
 	return ch, nil
+}
+
+// mmapOOOSeriesChunk m-maps OOO chunks for a single series during compaction head creation.
+// It uses deferred unlocking so the series lock is released even if chunk
+// mapping panics unexpectedly during compaction head creation.
+func (ch *OOOCompactionHead) mmapOOOSeriesChunk(head *Head, ms *memSeries, seriesRef storage.SeriesRef, lastSeq, lastOff *int) error {
+	// M-map the in-memory chunk and keep track of the last one.
+	// Also build the block ranges -> series map.
+	// TODO: consider having a lock specifically for ooo data.
+	ms.Lock()
+	defer ms.Unlock()
+
+	if ms.ooo == nil {
+		return nil
+	}
+
+	var lastMmapRef chunks.ChunkDiskMapperRef
+	// Use mmapOOOChunks directly (not head.mmapOOOChunks) to avoid writing
+	// WBL markers during compaction — the data is being persisted to blocks.
+	o := chunkOpts{
+		chunkDiskMapper: head.chunkDiskMapper,
+		chunkRange:      head.chunkRange.Load(),
+		samplesPerChunk: head.opts.SamplesPerChunk,
+		useXOR2:         head.opts.EnableXOR2Encoding.Load(),
+	}
+	mmapRefs, err := ms.mmapOOOChunks(o, head.logger, true)
+	if err != nil {
+		return fmt.Errorf("mmap OOO chunks for series %d: %w", seriesRef, err)
+	}
+	if len(mmapRefs) == 0 && len(ms.ooo.oooMmappedChunks) > 0 {
+		// Nothing was m-mapped. So take the mmapRef from the existing slice if it exists.
+		mmapRefs = []chunks.ChunkDiskMapperRef{ms.ooo.oooMmappedChunks[len(ms.ooo.oooMmappedChunks)-1].ref}
+	}
+	if len(mmapRefs) == 0 {
+		lastMmapRef = 0
+	} else {
+		lastMmapRef = mmapRefs[len(mmapRefs)-1]
+	}
+	seq, off := lastMmapRef.Unpack()
+	if seq > *lastSeq || (seq == *lastSeq && off > *lastOff) {
+		ch.lastMmapRef, *lastSeq, *lastOff = lastMmapRef, seq, off
+	}
+	if len(ms.ooo.oooMmappedChunks) > 0 {
+		ch.postings = append(ch.postings, seriesRef)
+		for _, c := range ms.ooo.oooMmappedChunks {
+			if c.minTime < ch.mint {
+				ch.mint = c.minTime
+			}
+			if c.maxTime > ch.maxt {
+				ch.maxt = c.maxTime
+			}
+		}
+	}
+
+	return nil
 }
 
 func (ch *OOOCompactionHead) Index() (IndexReader, error) {

--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -679,13 +679,14 @@ func (w *Watcher) readSegmentForGC(r *LiveReader, segmentNum int, _ bool) error 
 	defer w.recordBuf.PutRefSeries(series)
 
 	dec := record.NewDecoder(labels.NewSymbolTable(), w.logger) // Needed for decoding; labels do not outlive this function.
+	var err error
 	for r.Next() && !isClosed(w.quit) {
 		rec := r.Record()
 		w.recordsReadMetric.WithLabelValues(dec.Type(rec).String()).Inc()
 
 		switch dec.Type(rec) {
 		case record.Series:
-			series, err := dec.Series(rec, series[:0])
+			series, err = dec.Series(rec, series[:0])
 			if err != nil {
 				w.recordDecodeFailsMetric.Inc()
 				return err


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18150

#### Does this PR introduce a user-facing change?

```release-notes
[ENHANCEMENT] TSDB: Replace panic in chunk write error handling with logging and a new `prometheus_tsdb_chunk_write_errors_total` metric.
```

#### Description

Replace the panicking `handleChunkWriteError` function with an error callback that logs the error and increments a counter metric: `prometheus_tsdb_chunk_write_errors_total`. This prevents process crashes and flaky test failures when chunk disk mapper errors occur during writing.

The `handleChunkWriteError` function had a TODO from @bwplotka acknowledging that it panics from time to time and causes flaky tests with hidden root causes (unlocked mutexes when deferred closing).

**Changes:**
- Add `chunkWriteErrorCallback` method to `Head` that logs and increments `prometheus_tsdb_chunk_write_errors_total` (skipping `ErrChunkDiskMapperClosed`)
- Thread a `callback func(error)` parameter through `mmapChunks`, `mmapCurrentOOOHeadChunk`, `cutNewOOOHeadChunk`, and `insert`
- On the read path (`getOOOSeriesChunks`), return the error directly since the function already returns `error`
- Remove `handleChunkWriteError` and its TODO comment
- Clean up `require.NotPanics` wrappers and investigation comments in tests

#### Test plan

- `go build ./tsdb/...` passes
- `go test ./tsdb/...` passes
- `go test -run TestDiskFillingUpAfterDisablingOOO ./tsdb/...` passes (previously flaky)
- Verified no remaining references to `handleChunkWriteError`