### PR TITLE
fix: update Go version to 1.25.7 to address security vulnerabilities

### DIFF
--- a/compliance/go.mod
+++ b/compliance/go.mod
@@ -1,6 +1,6 @@
 module compliance
 
-go 1.25.5
+go 1.25.7
 
 require github.com/prometheus/compliance/remotewrite v0.0.0-20260220101514-bccaa3a70275
 

--- a/documentation/examples/remote_storage/go.mod
+++ b/documentation/examples/remote_storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/prometheus/documentation/examples/remote_storage
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/prometheus
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/prometheus/internal/tools
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/bufbuild/buf v1.65.0

--- a/web/ui/mantine-ui/src/promql/tools/go.mod
+++ b/web/ui/mantine-ui/src/promql/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/prometheus/web/ui/mantine-ui/src/promql/tools
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853


### PR DESCRIPTION
## Summary

This updates the Go version from 1.25.5 to 1.25.7, which fixes the following security vulnerabilities in the Go standard library:

### Vulnerabilities Fixed

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2025-68121 | **CRITICAL** | crypto/tls: Unexpected session resumption in crypto/tls |
| CVE-2025-61726 | HIGH | net/url: Memory exhaustion in query parameter parsing |
| CVE-2025-61728 | HIGH | archive/zip: Excessive CPU consumption when building archive index |
| CVE-2025-61730 | HIGH | TLS 1.3 handshake vulnerability |

### Changes Made
- Updated `go 1.25.5` to `go 1.25.7` in all go.mod files
- Ran `go mod tidy` to ensure go.sum is consistent

### Verification
- Trivy image scan of `quay.io/prometheus/prometheus:v3.9.1` detected these vulnerabilities
- Go 1.25.7 contains the fixes for all listed CVEs

### References
- https://avd.aquasec.com/nvd/cve-2025-68121
- https://avd.aquasec.com/nvd/cve-2025-61726
- https://avd.aquasec.com/nvd/cve-2025-61728
- https://avd.aquasec.com/nvd/cve-2025-61730

This is a minimal, low-risk change that addresses critical security vulnerabilities affecting all Prometheus deployments.