### PR TITLE
chore: use sync/atomic instead of go.uber.org/atomic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,8 +85,6 @@ linters:
       rules:
         main:
           deny:
-            - pkg: "sync/atomic"
-              desc: "Use go.uber.org/atomic instead of sync/atomic"
             - pkg: "github.com/stretchr/testify/assert"
               desc: "Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert"
             - pkg: "github.com/go-kit/kit/log"
@@ -101,6 +99,8 @@ linters:
               desc: "Use github.com/klauspost/compress instead of gzip"
             - pkg: "zlib"
               desc: "Use github.com/klauspost/compress instead of zlib"
+            - pkg: "go.uber.org/atomic"
+              desc: "Use sync/atomic instead of go.uber.org/atomic"
             - pkg: "golang.org/x/exp/slices"
               desc: "Use 'slices' instead."
             - pkg: "gopkg.in/yaml.v2"

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -35,6 +35,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -53,7 +54,6 @@ import (
 	promslogflag "github.com/prometheus/common/promslog/flag"
 	"github.com/prometheus/common/version"
 	toolkit_web "github.com/prometheus/exporter-toolkit/web"
-	"go.uber.org/atomic"
 	"go.uber.org/automaxprocs/maxprocs"
 	"k8s.io/klog"
 	klogv2 "k8s.io/klog/v2"

--- a/cmd/prometheus/scrape_failure_log_test.go
+++ b/cmd/prometheus/scrape_failure_log_test.go
@@ -22,11 +22,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/util/testutil"
 )
@@ -165,7 +165,7 @@ scrape_configs:
 // for all requests. It also increments the request count each time it's hit.
 func startGarbageServer(t *testing.T, requestCount *atomic.Int32) string {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requestCount.Inc()
+		requestCount.Add(1)
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	t.Cleanup(server.Close)

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -30,12 +30,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"text/tabwriter"
 	"time"
 
 	"github.com/alecthomas/units"
 	"github.com/prometheus/common/promslog"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"

--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -349,7 +349,7 @@ func newAzureResourceFromID(id string, logger *slog.Logger) (*arm.ResourceID, er
 func (d *Discovery) refreshAzureClient(ctx context.Context, client client) ([]*targetgroup.Group, error) {
 	machines, err := client.getVMs(ctx, d.cfg.ResourceGroup)
 	if err != nil {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, fmt.Errorf("could not get virtual machines: %w", err)
 	}
 
@@ -358,14 +358,14 @@ func (d *Discovery) refreshAzureClient(ctx context.Context, client client) ([]*t
 	// Load the vms managed by scale sets.
 	scaleSets, err := client.getScaleSets(ctx, d.cfg.ResourceGroup)
 	if err != nil {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, fmt.Errorf("could not get virtual machine scale sets: %w", err)
 	}
 
 	for _, scaleSet := range scaleSets {
 		scaleSetVms, err := client.getScaleSetVMs(ctx, scaleSet)
 		if err != nil {
-			d.metrics.failuresCount.Inc()
+			d.metrics.failuresCount.Add(1)
 			return nil, fmt.Errorf("could not get virtual machine scale set vms: %w", err)
 		}
 		machines = append(machines, scaleSetVms...)
@@ -395,7 +395,7 @@ func (d *Discovery) refreshAzureClient(ctx context.Context, client client) ([]*t
 	var tg targetgroup.Group
 	for tgt := range ch {
 		if tgt.err != nil {
-			d.metrics.failuresCount.Inc()
+			d.metrics.failuresCount.Add(1)
 			return nil, fmt.Errorf("unable to complete Azure service discovery: %w", tgt.err)
 		}
 		if tgt.labelSet != nil {
@@ -411,7 +411,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 	client, err := d.createAzureClient()
 	if err != nil {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, fmt.Errorf("could not create Azure client: %w", err)
 	}
 

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -284,7 +284,7 @@ func (d *Discovery) getDatacenter() error {
 	info, err := d.client.Agent().Self()
 	if err != nil {
 		d.logger.Error("Error retrieving datacenter name", "err", err)
-		d.metrics.rpcFailuresCount.Inc()
+		d.metrics.rpcFailuresCount.Add(1)
 		return err
 	}
 
@@ -385,7 +385,7 @@ func (d *Discovery) watchServices(ctx context.Context, ch chan<- []*targetgroup.
 
 	if err != nil {
 		d.logger.Error("Error refreshing service list", "err", err)
-		d.metrics.rpcFailuresCount.Inc()
+		d.metrics.rpcFailuresCount.Add(1)
 		time.Sleep(retryInterval)
 		return
 	}
@@ -516,7 +516,7 @@ func (srv *consulService) watch(ctx context.Context, ch chan<- []*targetgroup.Gr
 
 	if err != nil {
 		srv.logger.Error("Error refreshing service", "service", srv.name, "tags", strings.Join(srv.tags, ","), "err", err)
-		srv.rpcFailuresCount.Inc()
+		srv.rpcFailuresCount.Add(1)
 		time.Sleep(retryInterval)
 		return
 	}

--- a/discovery/dns/dns.go
+++ b/discovery/dns/dns.go
@@ -194,9 +194,9 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 func (d *Discovery) refreshOne(ctx context.Context, name string, ch chan<- *targetgroup.Group) error {
 	response, err := d.lookupFn(name, d.qtype, d.logger)
-	d.metrics.dnsSDLookupsCount.Inc()
+	d.metrics.dnsSDLookupsCount.Add(1)
 	if err != nil {
-		d.metrics.dnsSDLookupFailuresCount.Inc()
+		d.metrics.dnsSDLookupFailuresCount.Add(1)
 		return err
 	}
 

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -240,7 +240,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		d.logger.Error("Error adding file watcher", "err", err)
-		d.metrics.fileWatcherErrorsCount.Inc()
+		d.metrics.fileWatcherErrorsCount.Add(1)
 		return
 	}
 	d.watcher = watcher
@@ -336,7 +336,7 @@ func (d *Discovery) refresh(ctx context.Context, ch chan<- []*targetgroup.Group)
 	for _, p := range d.listFiles() {
 		tgroups, err := d.readFile(p)
 		if err != nil {
-			d.metrics.fileSDReadErrorsCount.Inc()
+			d.metrics.fileSDReadErrorsCount.Add(1)
 
 			d.logger.Error("Error reading file", "path", p, "err", err)
 			// Prevent deletion down below.

--- a/discovery/http/http.go
+++ b/discovery/http/http.go
@@ -161,7 +161,7 @@ func (d *Discovery) Refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 	resp, err := d.client.Do(req.WithContext(ctx))
 	if err != nil {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, err
 	}
 	defer func() {
@@ -170,31 +170,31 @@ func (d *Discovery) Refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, fmt.Errorf("server returned HTTP status %s", resp.Status)
 	}
 
 	if !matchContentType.MatchString(strings.TrimSpace(resp.Header.Get("Content-Type"))) {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, fmt.Errorf("unsupported content type %q", resp.Header.Get("Content-Type"))
 	}
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, err
 	}
 
 	var targetGroups []*targetgroup.Group
 
 	if err := json.Unmarshal(b, &targetGroups); err != nil {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, err
 	}
 
 	for i, tg := range targetGroups {
 		if tg == nil {
-			d.metrics.failuresCount.Inc()
+			d.metrics.failuresCount.Add(1)
 			err = errors.New("nil target group item found")
 			return nil, err
 		}

--- a/discovery/kubernetes/endpoints.go
+++ b/discovery/kubernetes/endpoints.go
@@ -89,15 +89,15 @@ func NewEndpoints(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, node,
 
 	_, err := e.endpointsInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o any) {
-			epAddCount.Inc()
+			epAddCount.Add(1)
 			e.enqueue(o)
 		},
 		UpdateFunc: func(_, o any) {
-			epUpdateCount.Inc()
+			epUpdateCount.Add(1)
 			e.enqueue(o)
 		},
 		DeleteFunc: func(o any) {
-			epDeleteCount.Inc()
+			epDeleteCount.Add(1)
 			e.enqueue(o)
 		},
 	})
@@ -125,15 +125,15 @@ func NewEndpoints(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, node,
 		// TODO(fabxc): potentially remove add and delete event handlers. Those should
 		// be triggered via the endpoint handlers already.
 		AddFunc: func(o any) {
-			svcAddCount.Inc()
+			svcAddCount.Add(1)
 			serviceUpdate(o)
 		},
 		UpdateFunc: func(_, o any) {
-			svcUpdateCount.Inc()
+			svcUpdateCount.Add(1)
 			serviceUpdate(o)
 		},
 		DeleteFunc: func(o any) {
-			svcDeleteCount.Inc()
+			svcDeleteCount.Add(1)
 			serviceUpdate(o)
 		},
 	})
@@ -142,7 +142,7 @@ func NewEndpoints(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, node,
 	}
 	_, err = e.podInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, cur any) {
-			podUpdateCount.Inc()
+			podUpdateCount.Add(1)
 			oldPod, ok := old.(*apiv1.Pod)
 			if !ok {
 				return

--- a/discovery/kubernetes/endpointslice.go
+++ b/discovery/kubernetes/endpointslice.go
@@ -86,15 +86,15 @@ func NewEndpointSlice(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, n
 
 	_, err := e.endpointSliceInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o any) {
-			epslAddCount.Inc()
+			epslAddCount.Add(1)
 			e.enqueue(o)
 		},
 		UpdateFunc: func(_, o any) {
-			epslUpdateCount.Inc()
+			epslUpdateCount.Add(1)
 			e.enqueue(o)
 		},
 		DeleteFunc: func(o any) {
-			epslDeleteCount.Inc()
+			epslDeleteCount.Add(1)
 			e.enqueue(o)
 		},
 	})
@@ -121,15 +121,15 @@ func NewEndpointSlice(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, n
 	}
 	_, err = e.serviceInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o any) {
-			svcAddCount.Inc()
+			svcAddCount.Add(1)
 			serviceUpdate(o)
 		},
 		UpdateFunc: func(_, o any) {
-			svcUpdateCount.Inc()
+			svcUpdateCount.Add(1)
 			serviceUpdate(o)
 		},
 		DeleteFunc: func(o any) {
-			svcDeleteCount.Inc()
+			svcDeleteCount.Add(1)
 			serviceUpdate(o)
 		},
 	})

--- a/discovery/kubernetes/ingress.go
+++ b/discovery/kubernetes/ingress.go
@@ -59,15 +59,15 @@ func NewIngress(l *slog.Logger, inf cache.SharedIndexInformer, namespace cache.S
 
 	_, err := s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o any) {
-			ingressAddCount.Inc()
+			ingressAddCount.Add(1)
 			s.enqueue(o)
 		},
 		DeleteFunc: func(o any) {
-			ingressDeleteCount.Inc()
+			ingressDeleteCount.Add(1)
 			s.enqueue(o)
 		},
 		UpdateFunc: func(_, o any) {
-			ingressUpdateCount.Inc()
+			ingressUpdateCount.Add(1)
 			s.enqueue(o)
 		},
 	})

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -833,7 +833,7 @@ func (d *Discovery) newIndexedIngressesInformer(ilw *cache.ListWatch) cache.Shar
 }
 
 func (d *Discovery) informerWatchErrorHandler(ctx context.Context, r *cache.Reflector, err error) {
-	d.metrics.failuresCount.Inc()
+	d.metrics.failuresCount.Add(1)
 	cache.DefaultWatchErrorHandler(ctx, r, err)
 }
 

--- a/discovery/kubernetes/node.go
+++ b/discovery/kubernetes/node.go
@@ -65,15 +65,15 @@ func NewNode(l *slog.Logger, inf cache.SharedInformer, eventCount *prometheus.Co
 
 	_, err := n.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o any) {
-			nodeAddCount.Inc()
+			nodeAddCount.Add(1)
 			n.enqueue(o)
 		},
 		DeleteFunc: func(o any) {
-			nodeDeleteCount.Inc()
+			nodeDeleteCount.Add(1)
 			n.enqueue(o)
 		},
 		UpdateFunc: func(_, o any) {
-			nodeUpdateCount.Inc()
+			nodeUpdateCount.Add(1)
 			n.enqueue(o)
 		},
 	})

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -74,15 +74,15 @@ func NewPod(l *slog.Logger, pods cache.SharedIndexInformer, nodes, namespace cac
 	}
 	_, err := p.podInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o any) {
-			podAddCount.Inc()
+			podAddCount.Add(1)
 			p.enqueue(o)
 		},
 		DeleteFunc: func(o any) {
-			podDeleteCount.Inc()
+			podDeleteCount.Add(1)
 			p.enqueue(o)
 		},
 		UpdateFunc: func(_, o any) {
-			podUpdateCount.Inc()
+			podUpdateCount.Add(1)
 			p.enqueue(o)
 		},
 	})

--- a/discovery/kubernetes/service.go
+++ b/discovery/kubernetes/service.go
@@ -64,15 +64,15 @@ func NewService(l *slog.Logger, inf cache.SharedIndexInformer, namespace cache.S
 
 	_, err := s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(o any) {
-			svcAddCount.Inc()
+			svcAddCount.Add(1)
 			s.enqueue(o)
 		},
 		DeleteFunc: func(o any) {
-			svcDeleteCount.Inc()
+			svcDeleteCount.Add(1)
 			s.enqueue(o)
 		},
 		UpdateFunc: func(_, o any) {
-			svcUpdateCount.Inc()
+			svcUpdateCount.Add(1)
 			s.enqueue(o)
 		},
 	})

--- a/discovery/linode/linode.go
+++ b/discovery/linode/linode.go
@@ -252,21 +252,21 @@ func (d *Discovery) refreshData(ctx context.Context) ([]*targetgroup.Group, erro
 	// Gather all linode instances.
 	instances, err := d.client.ListInstances(ctx, &listInstancesOpts)
 	if err != nil {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, err
 	}
 
 	// Gather detailed IP address info for all IPs on all linode instances.
 	detailedIPs, err := d.client.ListIPAddresses(ctx, &listIPAddressesOpts)
 	if err != nil {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, err
 	}
 
 	// Gather detailed IPv6 Range info for all linode instances.
 	ipv6RangeList, err := d.client.ListIPv6Ranges(ctx, &listIPv6RangesOpts)
 	if err != nil {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, err
 	}
 

--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -360,7 +360,7 @@ func (m *Manager) updater(ctx context.Context, p *Provider, updates chan []*targ
 		case <-ctx.Done():
 			return
 		case tgs, ok := <-updates:
-			m.metrics.ReceivedUpdates.Inc()
+			m.metrics.ReceivedUpdates.Add(1)
 			if !ok {
 				m.logger.Debug("Discoverer channel closed", "provider", p.name)
 				// Wait for provider cancellation to ensure targets are cleaned up when expected.
@@ -395,11 +395,11 @@ func (m *Manager) sender() {
 		case <-ticker.C: // Some discoverers send updates too often, so we throttle these with the ticker.
 			select {
 			case <-m.triggerSend:
-				m.metrics.SentUpdates.Inc()
+				m.metrics.SentUpdates.Add(1)
 				select {
 				case m.syncCh <- m.allGroups():
 				default:
-					m.metrics.DelayedUpdates.Inc()
+					m.metrics.DelayedUpdates.Add(1)
 					m.logger.Debug("Discovery receiver's channel was full so will retry the next cycle")
 					select {
 					case m.triggerSend <- struct{}{}:

--- a/discovery/metrics_k8s_client.go
+++ b/discovery/metrics_k8s_client.go
@@ -162,7 +162,7 @@ func (f *clientGoRequestMetricAdapter) RegisterWithK8sGoClient() {
 }
 
 func (clientGoRequestMetricAdapter) Increment(_ context.Context, code, _, _ string) {
-	clientGoRequestResultMetricVec.WithLabelValues(code).Inc()
+	clientGoRequestResultMetricVec.WithLabelValues(code).Add(1)
 }
 
 func (clientGoRequestMetricAdapter) Observe(_ context.Context, _ string, u url.URL, latency time.Duration) {

--- a/discovery/nomad/nomad.go
+++ b/discovery/nomad/nomad.go
@@ -173,7 +173,7 @@ func (d *Discovery) refresh(context.Context) ([]*targetgroup.Group, error) {
 	}
 	stubs, _, err := d.client.Services().List(opts)
 	if err != nil {
-		d.metrics.failuresCount.Inc()
+		d.metrics.failuresCount.Add(1)
 		return nil, err
 	}
 
@@ -185,7 +185,7 @@ func (d *Discovery) refresh(context.Context) ([]*targetgroup.Group, error) {
 		for _, service := range stub.Services {
 			instances, _, err := d.client.Services().Get(service.ServiceName, opts)
 			if err != nil {
-				d.metrics.failuresCount.Inc()
+				d.metrics.failuresCount.Add(1)
 				return nil, fmt.Errorf("failed to fetch services: %w", err)
 			}
 

--- a/discovery/refresh/refresh.go
+++ b/discovery/refresh/refresh.go
@@ -113,7 +113,7 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 	tgs, err := d.refreshf(ctx)
 	if err != nil {
-		d.metrics.Failures.Inc()
+		d.metrics.Failures.Add(1)
 	}
 	return tgs, err
 }

--- a/discovery/xds/xds.go
+++ b/discovery/xds/xds.go
@@ -140,20 +140,20 @@ func (d *fetchDiscovery) poll(ctx context.Context, ch chan<- []*targetgroup.Grou
 
 	if err != nil {
 		d.logger.Error("error parsing resources", "err", err)
-		d.metrics.fetchFailuresCount.Inc()
+		d.metrics.fetchFailuresCount.Add(1)
 		return
 	}
 
 	if response == nil {
 		// No update needed.
-		d.metrics.fetchSkipUpdateCount.Inc()
+		d.metrics.fetchSkipUpdateCount.Add(1)
 		return
 	}
 
 	parsedTargets, err := d.parseResources(response.Resources, response.TypeUrl)
 	if err != nil {
 		d.logger.Error("error parsing resources", "err", err)
-		d.metrics.fetchFailuresCount.Inc()
+		d.metrics.fetchFailuresCount.Add(1)
 		return
 	}
 

--- a/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
+++ b/documentation/examples/remote_storage/remote_storage_adapter/influxdb/client.go
@@ -90,7 +90,7 @@ func (c *Client) Write(samples model.Samples) error {
 		v := float64(s.Value)
 		if math.IsNaN(v) || math.IsInf(v, 0) {
 			c.logger.Debug("Cannot send to InfluxDB, skipping sample", "value", v, "sample", s)
-			c.ignoredSamples.Inc()
+			c.ignoredSamples.Add(1)
 			continue
 		}
 		p := influx.NewPoint(

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.9
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.9
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.290.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.72.0
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.51.9
@@ -66,6 +67,7 @@ require (
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/common/assets v0.2.0
 	github.com/prometheus/exporter-toolkit v0.15.1
+	github.com/prometheus/otlptranslator v1.0.0
 	github.com/prometheus/sigv4 v0.4.1
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36
 	github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c
@@ -85,7 +87,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
-	go.uber.org/atomic v1.11.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/goleak v1.3.0
 	go.yaml.in/yaml/v2 v2.4.3
@@ -107,33 +108,6 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
-	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/go-openapi/swag/cmdutils v0.25.4 // indirect
-	github.com/go-openapi/swag/conv v0.25.4 // indirect
-	github.com/go-openapi/swag/fileutils v0.25.4 // indirect
-	github.com/go-openapi/swag/jsonname v0.25.4 // indirect
-	github.com/go-openapi/swag/jsonutils v0.25.4 // indirect
-	github.com/go-openapi/swag/loading v0.25.4 // indirect
-	github.com/go-openapi/swag/mangling v0.25.4 // indirect
-	github.com/go-openapi/swag/netutils v0.25.4 // indirect
-	github.com/go-openapi/swag/stringutils v0.25.4 // indirect
-	github.com/go-openapi/swag/typeutils v0.25.4 // indirect
-	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
-	github.com/pb33f/jsonpath v0.7.1 // indirect
-	github.com/pb33f/ordered-map/v2 v2.3.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
-	github.com/sirupsen/logrus v1.9.4 // indirect
-	go.opentelemetry.io/collector/internal/componentalias v0.145.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
-)
-
-require (
 	cloud.google.com/go/auth v0.18.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
@@ -141,15 +115,18 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.14 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20251110193048-8bfbf64dc13e // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
@@ -173,6 +150,17 @@ require (
 	github.com/go-openapi/loads v0.23.2 // indirect
 	github.com/go-openapi/spec v0.22.3 // indirect
 	github.com/go-openapi/swag v0.25.4 // indirect
+	github.com/go-openapi/swag/cmdutils v0.25.4 // indirect
+	github.com/go-openapi/swag/conv v0.25.4 // indirect
+	github.com/go-openapi/swag/fileutils v0.25.4 // indirect
+	github.com/go-openapi/swag/jsonname v0.25.4 // indirect
+	github.com/go-openapi/swag/jsonutils v0.25.4 // indirect
+	github.com/go-openapi/swag/loading v0.25.4 // indirect
+	github.com/go-openapi/swag/mangling v0.25.4 // indirect
+	github.com/go-openapi/swag/netutils v0.25.4 // indirect
+	github.com/go-openapi/swag/stringutils v0.25.4 // indirect
+	github.com/go-openapi/swag/typeutils v0.25.4 // indirect
+	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
 	github.com/go-openapi/validate v0.25.1 // indirect
 	github.com/go-resty/resty/v2 v2.17.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
@@ -220,14 +208,17 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.145.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pb33f/jsonpath v0.7.1 // indirect
+	github.com/pb33f/ordered-map/v2 v2.3.0 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/otlptranslator v1.0.0
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -237,8 +228,10 @@ require (
 	go.opentelemetry.io/collector/confmap v1.51.0 // indirect
 	go.opentelemetry.io/collector/confmap/xconfmap v0.145.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.51.0 // indirect
+	go.opentelemetry.io/collector/internal/componentalias v0.145.0 // indirect
 	go.opentelemetry.io/collector/pipeline v1.51.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
@@ -251,11 +244,14 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -640,8 +640,6 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.2.0 h1:o
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.2.0/go.mod h1:Gyb6Xe7FTi/6xBHwMmngGoHqL0w29Y4eW8TGFzpefGA=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.2.0 h1:EiUYvtwu6PMrMHVjcPfnsG3v+ajPkbUeH+IL93+QYyk=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.2.0/go.mod h1:mUUHKFiN2SST3AhJ8XhJxEoeVW12oqfXog0Bo8W3Ec4=
-go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
-go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
 go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/notifier/manager_test.go
+++ b/notifier/manager_test.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,7 +35,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/config"
@@ -835,7 +835,8 @@ func TestStop_DrainingDisabled(t *testing.T) {
 		const alertmanagerURL = "http://alertmanager:9093/api/v2/alerts"
 
 		handlerStarted := make(chan struct{})
-		alertsReceived := atomic.NewInt64(0)
+		alertsReceived := atomic.Int64{}
+		alertsReceived.Store(int64(0))
 
 		// Fake Do function that simulates a hanging alertmanager that times out.
 		fakeDo := func(ctx context.Context, _ *http.Client, req *http.Request) (*http.Response, error) {
@@ -906,7 +907,8 @@ func TestStop_DrainingEnabled(t *testing.T) {
 		const alertmanagerURL = "http://alertmanager:9093/api/v2/alerts"
 
 		handlerStarted := make(chan struct{}, 1)
-		alertsReceived := atomic.NewInt64(0)
+		alertsReceived := atomic.Int64{}
+		alertsReceived.Store(0)
 
 		// Fake Do function that simulates alertmanager responding slowly but successfully.
 		fakeDo := func(_ context.Context, _ *http.Client, req *http.Request) (*http.Response, error) {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -671,9 +671,9 @@ func (ng *Engine) NewTestQuery(f func(context.Context) error) Query {
 // At this point per query only one EvalStmt is evaluated. Alert and record
 // statements are not handled by the Engine.
 func (ng *Engine) exec(ctx context.Context, q *query) (v parser.Value, ws annotations.Annotations, err error) {
-	ng.metrics.currentQueries.Inc()
+	ng.metrics.currentQueries.Add(1)
 	defer func() {
-		ng.metrics.currentQueries.Dec()
+		ng.metrics.currentQueries.Add(-1)
 		ng.metrics.querySamples.Add(float64(q.sampleStats.TotalSamples))
 	}()
 
@@ -709,7 +709,7 @@ func (ng *Engine) exec(ctx context.Context, q *query) (v parser.Value, ws annota
 			}
 			logger.LogAttrs(context.Background(), slog.LevelInfo, "promql query logged", f...)
 			// TODO: @tjhop -- do we still need this metric/error log if logger doesn't return errors?
-			// ng.metrics.queryLogFailures.Inc()
+			// ng.metrics.queryLogFailures.Add(1)
 			// ng.logger.Error("can't log query", "err", err)
 		}
 		ng.queryLoggerLock.RUnlock()

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -79,7 +79,7 @@ func EngineQueryFunc(engine promql.QueryEngine, q storage.Queryable) QueryFunc {
 // to invoke this function as well, to ensure correct Group state and metrics
 // are maintained.
 func DefaultEvalIterationFunc(ctx context.Context, g *Group, evalTimestamp time.Time) {
-	g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Inc()
+	g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Add(1)
 
 	start := time.Now()
 	g.Eval(ctx, evalTimestamp)

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -21,13 +21,13 @@ import (
 	"reflect"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -218,10 +218,10 @@ func (m *Manager) reload() {
 				m.logger.Error("error reloading target set", "err", "invalid config id:"+setName)
 				continue
 			}
-			m.metrics.targetScrapePools.Inc()
+			m.metrics.targetScrapePools.Add(1)
 			sp, err := newScrapePool(scrapeConfig, m.appendable, m.appendableV2, m.offsetSeed, m.logger.With("scrape_pool", setName), m.buffers, m.opts, m.metrics)
 			if err != nil {
-				m.metrics.targetScrapePoolsFailed.Inc()
+				m.metrics.targetScrapePoolsFailed.Add(1)
 				m.logger.Error("error creating new scrape pool", "err", err, "scrape_pool", setName)
 				continue
 			}

--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -235,7 +235,7 @@ loop:
 
 			// If any label limits is exceeded the scrape should fail.
 			if err = verifyLabelLimits(lset, sl.labelLimits); err != nil {
-				sl.metrics.targetScrapePoolExceededLabelLimits.Inc()
+				sl.metrics.targetScrapePoolExceededLabelLimits.Add(1)
 				break loop
 			}
 		}
@@ -352,14 +352,14 @@ loop:
 			err = sampleLimitErr
 		}
 		// We only want to increment this once per scrape, so this is Inc'd outside the loop.
-		sl.metrics.targetScrapeSampleLimit.Inc()
+		sl.metrics.targetScrapeSampleLimit.Add(1)
 	}
 	if bucketLimitErr != nil {
 		if err == nil {
 			err = bucketLimitErr // If sample limit is hit, that error takes precedence.
 		}
 		// We only want to increment this once per scrape, so this is Inc'd outside the loop.
-		sl.metrics.targetScrapeNativeHistogramBucketLimit.Inc()
+		sl.metrics.targetScrapeNativeHistogramBucketLimit.Add(1)
 	}
 	if appErrs.numOutOfOrder > 0 {
 		sl.l.Warn("Error on ingesting out-of-order samples", "num_dropped", appErrs.numOutOfOrder)

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"text/template"
 	"time"
@@ -48,7 +49,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.uber.org/atomic"
 	"go.uber.org/goleak"
 
 	"github.com/prometheus/prometheus/config"
@@ -6525,7 +6525,8 @@ func TestScrapeLoopDisableStalenessMarkerInjection(t *testing.T) {
 }
 
 func testScrapeLoopDisableStalenessMarkerInjection(t *testing.T, appV2 bool) {
-	loopDone := atomic.NewBool(false)
+	loopDone := atomic.Bool{}
+	loopDone.Store(false)
 
 	appTest := teststorage.NewAppendable()
 	sl, scraper := newTestScrapeLoop(t, withAppendable(appTest, appV2))

--- a/storage/remote/ewma.go
+++ b/storage/remote/ewma.go
@@ -15,9 +15,8 @@ package remote
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
-
-	"go.uber.org/atomic"
 )
 
 // ewmaRate tracks an exponentially weighted moving average of a per-second rate.

--- a/storage/remote/intern.go
+++ b/storage/remote/intern.go
@@ -20,10 +20,10 @@ package remote
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/atomic"
 )
 
 var noReferenceReleases = promauto.NewCounter(prometheus.CounterOpts{
@@ -64,7 +64,7 @@ func (p *pool) intern(s string) string {
 	if ok {
 		// Increase the reference count while we're still holding the read lock,
 		// This will prevent the release() from deleting the entry while we're increasing its ref count.
-		interned.refs.Inc()
+		interned.refs.Add(1)
 		p.mtx.RUnlock()
 		return interned.s
 	}
@@ -73,7 +73,7 @@ func (p *pool) intern(s string) string {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	if interned, ok := p.pool[s]; ok {
-		interned.refs.Inc()
+		interned.refs.Add(1)
 		return interned.s
 	}
 
@@ -88,11 +88,11 @@ func (p *pool) release(s string) {
 	p.mtx.RUnlock()
 
 	if !ok {
-		noReferenceReleases.Inc()
+		noReferenceReleases.Add(1)
 		return
 	}
 
-	refs := interned.refs.Dec()
+	refs := interned.refs.Add(-1)
 	if refs > 0 {
 		return
 	}

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,7 +35,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -1356,7 +1356,7 @@ func NewTestBlockedWriteClient() *TestBlockingWriteClient {
 }
 
 func (c *TestBlockingWriteClient) Store(ctx context.Context, _ []byte, _ int) (WriteResponseStats, error) {
-	c.numCalls.Inc()
+	c.numCalls.Add(1)
 	<-ctx.Done()
 	return WriteResponseStats{}, nil
 }

--- a/storage/remote/read_handler.go
+++ b/storage/remote/read_handler.go
@@ -74,10 +74,10 @@ func (h *readHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	h.queries.Inc()
+	h.queries.Add(1)
 
 	defer h.remoteReadGate.Done()
-	defer h.queries.Dec()
+	defer h.queries.Add(-1)
 
 	req, err := DecodeReadRequest(r)
 	if err != nil {

--- a/storage/remote/write_otlp_handler.go
+++ b/storage/remote/write_otlp_handler.go
@@ -270,7 +270,7 @@ func (app *otlpInstrumentedAppender) Append(ref storage.SeriesRef, ls labels.Lab
 		// Hide the partial error as otlp converter does not handle it.
 	}
 	if opts.Metadata.IsEmpty() {
-		app.samplesAppendedWithoutMetadata.Inc()
+		app.samplesAppendedWithoutMetadata.Add(1)
 	}
 	return ref, nil
 }

--- a/template/template.go
+++ b/template/template.go
@@ -335,11 +335,11 @@ func (te Expander) Expand() (result string, resultErr error) {
 			}
 		}
 		if resultErr != nil {
-			templateTextExpansionFailures.Inc()
+			templateTextExpansionFailures.Add(1)
 		}
 	}()
 
-	templateTextExpansionTotal.Inc()
+	templateTextExpansionTotal.Add(1)
 
 	tmpl := text_template.New(te.name).Funcs(te.funcMap)
 	tmpl.Option(te.options...)

--- a/tsdb/agent/db_append_v2.go
+++ b/tsdb/agent/db_append_v2.go
@@ -78,7 +78,7 @@ func (a *appenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t int64
 	}
 
 	if t <= a.minValidTime(lastTS) {
-		a.metrics.totalOutOfOrderSamples.Inc()
+		a.metrics.totalOutOfOrderSamples.Add(1)
 		return 0, storage.ErrOutOfOrderSample
 	}
 
@@ -112,7 +112,7 @@ func (a *appenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t int64
 		})
 		a.sampleSeries = append(a.sampleSeries, s)
 	}
-	a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricType).Inc()
+	a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricType).Add(1)
 	if isStale {
 		// For stale values we never attempt to process metadata/exemplars, claim the success.
 		return storage.SeriesRef(s.ref), nil
@@ -162,7 +162,7 @@ func (a *appenderV2) appendExemplars(s *memSeries, exemplar []exemplar.Exemplar)
 			V:      e.Value,
 			Labels: e.Labels,
 		})
-		a.metrics.totalAppendedExemplars.Inc()
+		a.metrics.totalAppendedExemplars.Add(1)
 	}
 	if len(errs) > 0 {
 		return &storage.AppendPartialError{ExemplarErrors: errs}
@@ -197,7 +197,7 @@ func (a *appenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.Labels
 		}
 		a.pendingFloatHistograms = append(a.pendingFloatHistograms, record.RefFloatHistogramSample{Ref: s.ref, T: st, FH: zeroFloatHistogram})
 		a.floatHistogramSeries = append(a.floatHistogramSeries, s)
-		a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
+		a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricTypeHistogram).Add(1)
 	case h != nil:
 		zeroHistogram := &histogram.Histogram{
 			// The STZeroSample represents a counter reset by definition.
@@ -209,10 +209,10 @@ func (a *appenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.Labels
 		}
 		a.pendingHistograms = append(a.pendingHistograms, record.RefHistogramSample{Ref: s.ref, T: st, H: zeroHistogram})
 		a.histogramSeries = append(a.histogramSeries, s)
-		a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
+		a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricTypeHistogram).Add(1)
 	default:
 		a.pendingSamples = append(a.pendingSamples, record.RefSample{Ref: s.ref, T: st, V: 0})
 		a.sampleSeries = append(a.sampleSeries, s)
-		a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
+		a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricTypeFloat).Add(1)
 	}
 }

--- a/tsdb/chunks/chunk_write_queue.go
+++ b/tsdb/chunks/chunk_write_queue.go
@@ -138,7 +138,7 @@ func (c *chunkWriteQueue) processJob(job chunkWriteJob) {
 
 	delete(c.chunkRefMap, job.ref)
 
-	c.completed.Inc()
+	c.completed.Add(1)
 
 	c.shrinkChunkRefMap()
 }
@@ -174,13 +174,13 @@ func (c *chunkWriteQueue) shrinkChunkRefMap() {
 
 	c.chunkRefMapPeakSize = 0
 	c.chunkRefMapLastShrink = now
-	c.shrink.Inc()
+	c.shrink.Add(1)
 }
 
 func (c *chunkWriteQueue) addJob(job chunkWriteJob) (err error) {
 	defer func() {
 		if err == nil {
-			c.adds.Inc()
+			c.adds.Add(1)
 		}
 	}()
 
@@ -217,7 +217,7 @@ func (c *chunkWriteQueue) get(ref ChunkDiskMapperRef) chunkenc.Chunk {
 
 	chk, ok := c.chunkRefMap[ref]
 	if ok {
-		c.gets.Inc()
+		c.gets.Add(1)
 	}
 
 	return chk

--- a/tsdb/chunks/chunk_write_queue_test.go
+++ b/tsdb/chunks/chunk_write_queue_test.go
@@ -17,11 +17,11 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
@@ -149,7 +149,8 @@ func TestChunkWriteQueue_WrappingAroundSizeLimit(t *testing.T) {
 	require.True(t, q.queueIsFull())
 
 	// Adding another job should block as long as no job from the queue gets consumed.
-	addedJob := atomic.NewBool(false)
+	addedJob := atomic.Bool{}
+	addedJob.Store(false)
 	go func() {
 		addChunk()
 		addedJob.Store(true)

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -26,10 +26,10 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
 	"github.com/dennwc/varint"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/fileutil"

--- a/tsdb/chunks/queue_test.go
+++ b/tsdb/chunks/queue_test.go
@@ -16,11 +16,11 @@ package chunks
 import (
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 func (q *writeJobQueue) assertInvariants(t *testing.T) {
@@ -284,7 +284,7 @@ func TestQueuePushPopManyGoroutines(t *testing.T) {
 	for range writeGoroutines {
 		writersWG.Go(func() {
 			for range writes {
-				ref := id.Inc()
+				ref := id.Add(1)
 
 				require.True(t, queue.push(chunkWriteJob{seriesRef: HeadSeriesRef(ref)}))
 			}

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -666,7 +666,7 @@ func (c *LeveledCompactor) write(dest string, meta *BlockMeta, blockPopulator Bl
 		if err := os.RemoveAll(tmp); err != nil {
 			c.logger.Error("removed tmp folder after failed compaction", "err", err.Error())
 		}
-		c.metrics.Ran.Inc()
+		c.metrics.Ran.Add(1)
 		c.metrics.Duration.Observe(time.Since(t).Seconds())
 	}(time.Now())
 
@@ -819,7 +819,7 @@ func (DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compact
 
 		if !overlapping {
 			if i > 0 && b.Meta().MinTime < globalMaxt {
-				metrics.OverlappingBlocks.Inc()
+				metrics.OverlappingBlocks.Add(1)
 				overlapping = true
 				logger.Info("Found overlapping blocks during compaction", "ulid", meta.ULID)
 			}

--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -271,7 +271,7 @@ func (ce *CircularExemplarStorage) validateExemplar(idx *indexEntry, e exemplar.
 		(e.Ts == newestExemplar.Ts && e.Value < newestExemplar.Value) ||
 		(e.Ts == newestExemplar.Ts && e.Value == newestExemplar.Value && e.Labels.Hash() < newestExemplar.Labels.Hash()) {
 		if appended {
-			ce.metrics.outOfOrderExemplars.Inc()
+			ce.metrics.outOfOrderExemplars.Add(1)
 		}
 		return storage.ErrOutOfOrderExemplar
 	}
@@ -483,7 +483,7 @@ func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemp
 
 	ce.nextIndex = (ce.nextIndex + 1) % len(ce.exemplars)
 
-	ce.metrics.exemplarsAppended.Inc()
+	ce.metrics.exemplarsAppended.Add(1)
 	ce.computeMetrics()
 	return nil
 }

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,7 +37,6 @@ import (
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -166,7 +166,8 @@ func TestHeadAppenderV2_RaceBetweenSeriesCreationAndGC(t *testing.T) {
 	for i := range totalSeries {
 		series[i] = labels.FromStrings("foo", strconv.Itoa(i))
 	}
-	done := atomic.NewBool(false)
+	done := atomic.Bool{}
+	done.Store(false)
 
 	go func() {
 		defer done.Store(true)

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -281,7 +281,7 @@ func BenchmarkHeadStripeSeriesCreateParallel(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			i := count.Inc()
+			i := count.Add(1)
 			h.getOrCreate(uint64(i), labels.FromStrings("a", strconv.Itoa(int(i))), false)
 		}
 	})

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -184,7 +184,7 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchB
 	s := h.head.series.getByID(chunks.HeadSeriesRef(ref))
 
 	if s == nil {
-		h.head.metrics.seriesNotFound.Inc()
+		h.head.metrics.seriesNotFound.Add(1)
 		return storage.ErrNotFound
 	}
 	builder.Assign(s.labels())

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -37,7 +38,6 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/prometheus/prometheus/config"
@@ -1231,7 +1231,8 @@ func TestHead_RaceBetweenSeriesCreationAndGC(t *testing.T) {
 	for i := range totalSeries {
 		series[i] = labels.FromStrings("foo", strconv.Itoa(i))
 	}
-	done := atomic.NewBool(false)
+	done := atomic.Bool{}
+	done.Store(false)
 
 	go func() {
 		defer done.Store(true)
@@ -6947,7 +6948,7 @@ type countSeriesLifecycleCallback struct {
 }
 
 func (*countSeriesLifecycleCallback) PreCreation(labels.Labels) error { return nil }
-func (c *countSeriesLifecycleCallback) PostCreation(labels.Labels)    { c.created.Inc() }
+func (c *countSeriesLifecycleCallback) PostCreation(labels.Labels)    { c.created.Add(1) }
 func (c *countSeriesLifecycleCallback) PostDeletion(s map[chunks.HeadSeriesRef]labels.Labels) {
 	c.deleted.Add(int64(len(s)))
 }

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -63,7 +63,7 @@ func (oh *HeadAndOOOIndexReader) Series(ref storage.SeriesRef, builder *labels.S
 	s := oh.head.series.getByID(chunks.HeadSeriesRef(ref))
 
 	if s == nil {
-		oh.head.metrics.seriesNotFound.Inc()
+		oh.head.metrics.seriesNotFound.Add(1)
 		return storage.ErrNotFound
 	}
 	builder.Assign(s.labels())
@@ -468,7 +468,7 @@ func (ir *OOOCompactionHeadIndexReader) Series(ref storage.SeriesRef, builder *l
 	s := ir.ch.head.series.getByID(chunks.HeadSeriesRef(ref))
 
 	if s == nil {
-		ir.ch.head.metrics.seriesNotFound.Inc()
+		ir.ch.head.metrics.seriesNotFound.Add(1)
 		return storage.ErrNotFound
 	}
 	builder.Assign(s.labels())

--- a/tsdb/wlog/live_reader.go
+++ b/tsdb/wlog/live_reader.go
@@ -308,7 +308,7 @@ func (r *LiveReader) readRecord() ([]byte, int, error) {
 		if !r.permissive {
 			return nil, 0, fmt.Errorf("record would overflow current page: %d > %d", r.readIndex+recordHeaderSize+length, pageSize)
 		}
-		r.metrics.readerCorruptionErrors.WithLabelValues("record_span_page").Inc()
+		r.metrics.readerCorruptionErrors.WithLabelValues("record_span_page").Add(1)
 		r.logger.Warn("Record spans page boundaries", "start", r.readIndex, "end", recordHeaderSize+length, "pageSize", pageSize)
 	}
 	if recordHeaderSize+length > pageSize {

--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -217,7 +217,7 @@ func (w *Watcher) Notify() {
 	default: // default so we can exit
 		// we don't need a buffered channel or any buffering since
 		// for each notification it recv's the watcher will read until EOF
-		w.notificationsSkipped.Inc()
+		w.notificationsSkipped.Add(1)
 	}
 }
 
@@ -508,13 +508,13 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 	for r.Next() && !isClosed(w.quit) {
 		var err error
 		rec := r.Record()
-		w.recordsReadMetric.WithLabelValues(dec.Type(rec).String()).Inc()
+		w.recordsReadMetric.WithLabelValues(dec.Type(rec).String()).Add(1)
 
 		switch dec.Type(rec) {
 		case record.Series:
 			series, err = dec.Series(rec, series[:0])
 			if err != nil {
-				w.recordDecodeFailsMetric.Inc()
+				w.recordDecodeFailsMetric.Add(1)
 				return err
 			}
 			w.writer.StoreSeries(series, segmentNum)
@@ -527,7 +527,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			}
 			samples, err = dec.Samples(rec, samples[:0])
 			if err != nil {
-				w.recordDecodeFailsMetric.Inc()
+				w.recordDecodeFailsMetric.Add(1)
 				return err
 			}
 			for _, s := range samples {
@@ -557,7 +557,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			}
 			exemplars, err = dec.Exemplars(rec, exemplars[:0])
 			if err != nil {
-				w.recordDecodeFailsMetric.Inc()
+				w.recordDecodeFailsMetric.Add(1)
 				return err
 			}
 			w.writer.AppendExemplars(exemplars)
@@ -572,7 +572,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			}
 			histograms, err = dec.HistogramSamples(rec, histograms[:0])
 			if err != nil {
-				w.recordDecodeFailsMetric.Inc()
+				w.recordDecodeFailsMetric.Add(1)
 				return err
 			}
 			for _, h := range histograms {
@@ -600,7 +600,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			}
 			floatHistograms, err = dec.FloatHistogramSamples(rec, floatHistograms[:0])
 			if err != nil {
-				w.recordDecodeFailsMetric.Inc()
+				w.recordDecodeFailsMetric.Add(1)
 				return err
 			}
 			for _, fh := range floatHistograms {
@@ -624,14 +624,14 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			}
 			metadata, err = dec.Metadata(rec, metadata[:0])
 			if err != nil {
-				w.recordDecodeFailsMetric.Inc()
+				w.recordDecodeFailsMetric.Add(1)
 				return err
 			}
 			w.writer.StoreMetadata(metadata)
 
 		case record.Unknown:
 			// Could be corruption, or reading from a WAL from a newer Prometheus.
-			w.recordDecodeFailsMetric.Inc()
+			w.recordDecodeFailsMetric.Add(1)
 
 		default:
 			// We're not interested in other types of records.
@@ -652,20 +652,20 @@ func (w *Watcher) readSegmentForGC(r *LiveReader, segmentNum int, _ bool) error 
 	)
 	for r.Next() && !isClosed(w.quit) {
 		rec := r.Record()
-		w.recordsReadMetric.WithLabelValues(dec.Type(rec).String()).Inc()
+		w.recordsReadMetric.WithLabelValues(dec.Type(rec).String()).Add(1)
 
 		switch dec.Type(rec) {
 		case record.Series:
 			series, err := dec.Series(rec, series[:0])
 			if err != nil {
-				w.recordDecodeFailsMetric.Inc()
+				w.recordDecodeFailsMetric.Add(1)
 				return err
 			}
 			w.writer.UpdateSeriesSegment(series, segmentNum)
 
 		case record.Unknown:
 			// Could be corruption, or reading from a WAL from a newer Prometheus.
-			w.recordDecodeFailsMetric.Inc()
+			w.recordDecodeFailsMetric.Add(1)
 
 		default:
 			// We're only interested in series.

--- a/tsdb/wlog/wlog.go
+++ b/tsdb/wlog/wlog.go
@@ -581,7 +581,7 @@ func (w *WL) setSegment(segment *Segment) error {
 // the page, the remaining bytes will be set to zero and a new page will be started.
 // If forceClear is true, this is enforced regardless of how many bytes are left in the page.
 func (w *WL) flushPage(forceClear bool) error {
-	w.metrics.pageFlushes.Inc()
+	w.metrics.pageFlushes.Add(1)
 
 	p := w.page
 	shouldClear := forceClear || p.full()
@@ -603,7 +603,7 @@ func (w *WL) flushPage(forceClear bool) error {
 	if shouldClear {
 		p.reset()
 		w.donePages++
-		w.metrics.pageCompletions.Inc()
+		w.metrics.pageCompletions.Add(1)
 	}
 	return nil
 }
@@ -661,7 +661,7 @@ func (w *WL) Log(recs ...[]byte) error {
 	// a bit of extra logic here frees them from that overhead.
 	for i, r := range recs {
 		if err := w.log(r, i == len(recs)-1); err != nil {
-			w.metrics.writesFailed.Inc()
+			w.metrics.writesFailed.Add(1)
 			return err
 		}
 	}
@@ -756,7 +756,7 @@ func (w *WL) log(rec []byte, final bool) error {
 		copy(buf[recordHeaderSize:], part)
 		p.alloc += len(part) + recordHeaderSize
 
-		w.metrics.recordPartWrites.Inc()
+		w.metrics.recordPartWrites.Add(1)
 		w.metrics.recordPartBytes.Add(float64(len(part) + recordHeaderSize))
 
 		if w.page.full() {
@@ -798,10 +798,10 @@ func (w *WL) LastSegmentAndOffset() (seg, offset int, err error) {
 
 // Truncate drops all segments before i.
 func (w *WL) Truncate(i int) (err error) {
-	w.metrics.truncateTotal.Inc()
+	w.metrics.truncateTotal.Add(1)
 	defer func() {
 		if err != nil {
-			w.metrics.truncateFail.Inc()
+			w.metrics.truncateFail.Add(1)
 		}
 	}()
 	refs, err := listSegments(w.Dir())

--- a/util/notifications/notifications.go
+++ b/util/notifications/notifications.go
@@ -106,13 +106,13 @@ func (n *Notifications) AddNotification(text string) {
 func (n *Notifications) notifySubscribers(notification Notification) {
 	for sub := range n.subscribers {
 		// Non-blocking send to avoid subscriber blocking issues.
-		n.notificationsSent.Inc()
+		n.notificationsSent.Add(1)
 		select {
 		case sub <- notification:
 			// Notification sent to the subscriber.
 		default:
 			// Drop the notification if the subscriber's channel is full.
-			n.notificationsDropped.Inc()
+			n.notificationsDropped.Add(1)
 		}
 	}
 }

--- a/util/testutil/context.go
+++ b/util/testutil/context.go
@@ -15,9 +15,8 @@ package testutil
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
-
-	"go.uber.org/atomic"
 )
 
 // A MockContext provides a simple stub implementation of a Context.
@@ -55,7 +54,7 @@ type MockContextErrAfter struct {
 }
 
 func (c *MockContextErrAfter) Err() error {
-	c.count.Inc()
+	c.count.Add(1)
 	if c.count.Load() >= c.FailAfter {
 		return context.Canceled
 	}

--- a/util/treecache/treecache.go
+++ b/util/treecache/treecache.go
@@ -134,7 +134,7 @@ func (tc *ZookeeperTreeCache) loop(path string) {
 	retryChan := make(chan struct{})
 
 	failure := func() {
-		failureCounter.Inc()
+		failureCounter.Add(1)
 		failureMode = true
 		time.AfterFunc(time.Second*10, func() {
 			retryChan <- struct{}{}
@@ -266,7 +266,7 @@ func (tc *ZookeeperTreeCache) recursiveNodeUpdate(path string, node *zookeeperTr
 	}
 
 	tc.wg.Go(func() {
-		numWatchers.Inc()
+		numWatchers.Add(1)
 		// Pass up zookeeper events, until the node is deleted.
 		select {
 		case event := <-dataWatcher:
@@ -275,7 +275,7 @@ func (tc *ZookeeperTreeCache) recursiveNodeUpdate(path string, node *zookeeperTr
 			node.events <- event
 		case <-node.done:
 		}
-		numWatchers.Dec()
+		numWatchers.Add(-1)
 	})
 	return nil
 }

--- a/util/zeropool/pool_test.go
+++ b/util/zeropool/pool_test.go
@@ -16,10 +16,10 @@ package zeropool_test
 import (
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/util/zeropool"
 )

--- a/web/federate.go
+++ b/web/federate.go
@@ -79,7 +79,7 @@ func (h *Handler) federation(w http.ResponseWriter, req *http.Request) {
 
 	q, err := h.localStorage.Querier(mint, maxt)
 	if err != nil {
-		federationErrors.Inc()
+		federationErrors.Add(1)
 		if errors.Is(err, tsdb.ErrNotReady) {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			return
@@ -159,7 +159,7 @@ Loop:
 		federationWarnings.Add(float64(len(ws)))
 	}
 	if set.Err() != nil {
-		federationErrors.Inc()
+		federationErrors.Add(1)
 		http.Error(w, set.Err().Error(), http.StatusInternalServerError)
 		return
 	}
@@ -265,7 +265,7 @@ Loop:
 			return nil
 		})
 		if err != nil {
-			federationErrors.Inc()
+			federationErrors.Add(1)
 			h.logger.Error("federation failed", "err", err)
 			return
 		}
@@ -304,7 +304,7 @@ Loop:
 	// Still have to ship off the last MetricDescriptor, if any.
 	if protMetricFam != nil {
 		if err := enc.Encode(protMetricFam); err != nil {
-			federationErrors.Inc()
+			federationErrors.Add(1)
 			h.logger.Error("federation failed", "err", err)
 		}
 	}

--- a/web/web.go
+++ b/web/web.go
@@ -33,6 +33,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/alecthomas/units"
@@ -49,7 +50,6 @@ import (
 	"github.com/prometheus/common/server"
 	toolkit_web "github.com/prometheus/exporter-toolkit/web"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/notifier"


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

use sync/atomic instead of go.uber.org/atomic as this doing the same job while dropping a dependency. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
