### PR TITLE
fix(tsdb): close file descriptor on json.MarshalIndent failure in writeMetaFile

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -291,7 +291,7 @@ func writeMetaFile(logger *slog.Logger, dir string, meta *BlockMeta) (int64, err
 
 	jsonMeta, err := json.MarshalIndent(meta, "", "\t")
 	if err != nil {
-		return 0, err
+		return 0, errors.Join(err, f.Close())
 	}
 
 	n, err := f.Write(jsonMeta)


### PR DESCRIPTION
Fixes a file descriptor leak in the `writeMetaFile` function in `tsdb/block.go`. When `json.MarshalIndent` failed, the function returned immediately without closing the file descriptor that had been opened by `os.Create`, leaving it open until the process exited or the garbage collector intervened. This change applies the same `errors.Join(err, f.Close())` pattern that all other error paths in the function already use.

#### Which issue(s) does the PR fix:
Fixes #18170 

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```
