### PR TITLE
Add Consul SD maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,7 @@
 /discovery/kubernetes           @prometheus/default-maintainers @brancz
 /discovery/stackit              @prometheus/default-maintainers @jkroepke
 /discovery/aws/                 @prometheus/default-maintainers @matt-gp @sysadmind
+/discovery/consul               @prometheus/default-maintainers @mrvarmazyar
 # Pending
 # https://github.com/prometheus/prometheus/pull/15212#issuecomment-3575225179
 # /discovery/aliyun               @prometheus/default-maintainers @KeyOfSpectator

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,6 +14,7 @@ Maintainers for specific parts of the codebase:
 * `discovery`
   * `k8s`: Frederic Branczyk (<fbranczyk@gmail.com> / @brancz)
   * `stackit`: Jan-Otto Kröpke (<mail@jkroepke.de> / @jkroepke)
+  * `consul`: Mohammad Varmazyar (<mrvarmazyar@gmail.com> / @mrvarmazyar)
 * `documentation`
   * `prometheus-mixin`: Matthias Loibl (<mail@matthiasloibl.com> / @metalmatze)
 * `storage`


### PR DESCRIPTION
## Summary

Following the discussion in #17349, adding myself as maintainer for Consul service discovery.

## Changes

- Added `/discovery/consul` to CODEOWNERS with @prometheus/default-maintainers and @mrvarmazyar
- Added `consul` entry to MAINTAINERS.md

## Context

In #17349, @krajorama invited me to become the Consul SD maintainer. This PR formalizes that by updating the ownership files as requested.

cc @krajorama @gouthamve

---

#### Which issue(s) does the PR fix:
Follows up on #17349

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```