### PR TITLE
discovery: Introduce `prometheus_sd_last_update_timestamp_seconds`

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -475,6 +475,7 @@ func (m *Manager) allGroups() map[string][]*targetgroup.Group {
 
 	for setName, v := range n {
 		m.metrics.DiscoveredTargets.WithLabelValues(setName).Set(float64(v))
+		m.metrics.LastUpdated.WithLabelValues(setName).SetToCurrentTime()
 	}
 
 	return tSets

--- a/discovery/metrics.go
+++ b/discovery/metrics.go
@@ -26,6 +26,7 @@ type Metrics struct {
 	ReceivedUpdates   prometheus.Counter
 	DelayedUpdates    prometheus.Counter
 	SentUpdates       prometheus.Counter
+	LastUpdated       *prometheus.GaugeVec
 }
 
 func NewManagerMetrics(registerer prometheus.Registerer, sdManagerName string) (*Metrics, error) {
@@ -72,12 +73,22 @@ func NewManagerMetrics(registerer prometheus.Registerer, sdManagerName string) (
 		},
 	)
 
+	m.LastUpdated = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:        "prometheus_sd_last_update_timestamp_seconds",
+			Help:        "Timestamp of the last update sent to the SD consumers.",
+			ConstLabels: prometheus.Labels{"name": sdManagerName},
+		},
+		[]string{"config"},
+	)
+
 	metrics := []prometheus.Collector{
 		m.FailedConfigs,
 		m.DiscoveredTargets,
 		m.ReceivedUpdates,
 		m.DelayedUpdates,
 		m.SentUpdates,
+		m.LastUpdated,
 	}
 
 	for _, collector := range metrics {
@@ -97,4 +108,5 @@ func (m *Metrics) Unregister(registerer prometheus.Registerer) {
 	registerer.Unregister(m.ReceivedUpdates)
 	registerer.Unregister(m.DelayedUpdates)
 	registerer.Unregister(m.SentUpdates)
+	registerer.Unregister(m.LastUpdated)
 }


### PR DESCRIPTION
The metric tracks the last update sent to SD consumers, and includes the manager name. This allows for monitoring SD state based on far ago its last heartbeat was.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix: #11726
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
