### PR TITLE
config: validate remote_write queue_config fields

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1474,6 +1474,10 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
+	if err := c.QueueConfig.Validate(); err != nil {
+		return err
+	}
+
 	return validateAuthConfigs(c)
 }
 
@@ -1564,6 +1568,29 @@ type QueueConfig struct {
 
 	// Samples older than the limit will be dropped.
 	SampleAgeLimit model.Duration `yaml:"sample_age_limit,omitempty"`
+}
+
+// Validate checks QueueConfig fields for invalid values.
+func (c *QueueConfig) Validate() error {
+	if c.MaxShards <= 0 {
+		return errors.New("remote write queue max_shards must be positive")
+	}
+	if c.MinShards <= 0 {
+		return errors.New("remote write queue min_shards must be positive")
+	}
+	if c.MinShards > c.MaxShards {
+		return errors.New("remote write queue min_shards must not be greater than max_shards")
+	}
+	if c.MaxSamplesPerSend <= 0 {
+		return errors.New("remote write queue max_samples_per_send must be positive")
+	}
+	if c.Capacity <= 0 {
+		return errors.New("remote write queue capacity must be positive")
+	}
+	if c.MaxBackoff < c.MinBackoff {
+		return errors.New("remote write queue max_backoff must not be less than min_backoff")
+	}
+	return nil
 }
 
 // MetadataConfig is the configuration for sending metadata to remote

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2415,6 +2415,18 @@ var expectedErrors = []struct {
 		errMsg:   `found multiple remote write configs with job name "queue1"`,
 	},
 	{
+		filename: "remote_write_queue_max_samples_per_send_zero.bad.yml",
+		errMsg:   `remote write queue max_samples_per_send must be positive`,
+	},
+	{
+		filename: "remote_write_queue_min_shards_greater_than_max.bad.yml",
+		errMsg:   `remote write queue min_shards must not be greater than max_shards`,
+	},
+	{
+		filename: "remote_write_queue_max_backoff_less_than_min.bad.yml",
+		errMsg:   `remote write queue max_backoff must not be less than min_backoff`,
+	},
+	{
 		filename: "remote_read_dup.bad.yml",
 		errMsg:   `found multiple remote read configs with job name "queue1"`,
 	},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2419,6 +2419,18 @@ var expectedErrors = []struct {
 		errMsg:   `remote write queue max_samples_per_send must be positive`,
 	},
 	{
+		filename: "remote_write_queue_max_shards_zero.bad.yml",
+		errMsg:   `remote write queue max_shards must be positive`,
+	},
+	{
+		filename: "remote_write_queue_min_shards_zero.bad.yml",
+		errMsg:   `remote write queue min_shards must be positive`,
+	},
+	{
+		filename: "remote_write_queue_capacity_zero.bad.yml",
+		errMsg:   `remote write queue capacity must be positive`,
+	},
+	{
 		filename: "remote_write_queue_min_shards_greater_than_max.bad.yml",
 		errMsg:   `remote write queue min_shards must not be greater than max_shards`,
 	},

--- a/config/testdata/remote_write_queue_capacity_zero.bad.yml
+++ b/config/testdata/remote_write_queue_capacity_zero.bad.yml
@@ -1,0 +1,4 @@
+remote_write:
+  - url: http://localhost:9090/api/v1/write
+    queue_config:
+      capacity: 0

--- a/config/testdata/remote_write_queue_max_backoff_less_than_min.bad.yml
+++ b/config/testdata/remote_write_queue_max_backoff_less_than_min.bad.yml
@@ -1,0 +1,5 @@
+remote_write:
+  - url: http://localhost:9090/api/v1/write
+    queue_config:
+      min_backoff: 10s
+      max_backoff: 1s

--- a/config/testdata/remote_write_queue_max_samples_per_send_zero.bad.yml
+++ b/config/testdata/remote_write_queue_max_samples_per_send_zero.bad.yml
@@ -1,0 +1,4 @@
+remote_write:
+  - url: http://localhost:9090/api/v1/write
+    queue_config:
+      max_samples_per_send: 0

--- a/config/testdata/remote_write_queue_max_shards_zero.bad.yml
+++ b/config/testdata/remote_write_queue_max_shards_zero.bad.yml
@@ -1,0 +1,4 @@
+remote_write:
+  - url: http://localhost:9090/api/v1/write
+    queue_config:
+      max_shards: 0

--- a/config/testdata/remote_write_queue_min_shards_greater_than_max.bad.yml
+++ b/config/testdata/remote_write_queue_min_shards_greater_than_max.bad.yml
@@ -1,0 +1,5 @@
+remote_write:
+  - url: http://localhost:9090/api/v1/write
+    queue_config:
+      min_shards: 100
+      max_shards: 10

--- a/config/testdata/remote_write_queue_min_shards_zero.bad.yml
+++ b/config/testdata/remote_write_queue_min_shards_zero.bad.yml
@@ -1,0 +1,4 @@
+remote_write:
+  - url: http://localhost:9090/api/v1/write
+    queue_config:
+      min_shards: 0


### PR DESCRIPTION
## Summary

While working with remote write configurations, I noticed that `queue_config` parameters had zero validation. This meant users could accidentally set `max_samples_per_send: 0` (or other invalid combinations) and Prometheus would accept the config silently—only to panic at runtime with an integer divide-by-zero error when the queue manager started.

The panic happens in `newQueue()` when calculating `capacity / batchSize` with `batchSize=0`. Beyond the crash, other misconfigurations like `min_shards > max_shards` or `max_backoff < min_backoff` were also silently accepted, leading to undefined runtime behavior.

This PR adds proper validation to catch these issues at config load time.

---

## Fix

Added `QueueConfig.Validate()` method in `config/config.go` that checks:
- All numeric fields are positive (`max_shards`, `min_shards`, `max_samples_per_send`, `capacity`)
- `min_shards` ≤ `max_shards`
- `max_backoff` ≥ `min_backoff`

The validation is called from `RemoteWriteConfig.UnmarshalYAML()` so invalid configs fail fast during startup.

**Key changes:**

`config/config.go` — Added validation method (~20 LOC):
```go
func (c *QueueConfig) Validate() error {
    if c.MaxSamplesPerSend <= 0 {
        return errors.New("remote write queue max_samples_per_send must be positive")
    }
    if c.Capacity <= 0 {
        return errors.New("remote write queue capacity must be positive")
    }
    // ... additional checks for shards and backoff
    if c.MinShards > c.MaxShards {
        return errors.New("remote write queue min_shards must not be greater than max_shards")
    }
    return nil
}
```

Also added 3 test cases in `config/config_test.go` and corresponding bad config YAML files in `config/testdata/` covering each validation path.

---
 #### Does this PR introduce a user-facing change?

  ```release-notes
[BUGFIX] Config: Validate remote_write queue_config fields at load time to prevent runtime panic and silent misconfiguration.
```
