### PR TITLE
fix: fail early when --enable-feature=use-uncached-io is unsupported

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -77,6 +77,7 @@ import (
 	"github.com/prometheus/prometheus/tracing"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/agent"
+	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/util/compression"
 	"github.com/prometheus/prometheus/util/documentcli"
 	"github.com/prometheus/prometheus/util/features"
@@ -319,6 +320,9 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 				c.web.EnableTypeAndUnitLabels = true
 				logger.Info("Experimental type and unit labels enabled")
 			case "use-uncached-io":
+				if !fileutil.UncachedIOSupported() {
+					return errors.New("experimental Uncached IO is not supported")
+				}
 				c.tsdb.UseUncachedIO = true
 				logger.Info("Experimental Uncached IO is enabled.")
 			default:

--- a/tsdb/fileutil/direct_io_force.go
+++ b/tsdb/fileutil/direct_io_force.go
@@ -26,3 +26,7 @@ func NewDirectIOWriter(f *os.File, size int) (BufWriter, error) {
 func NewBufioWriterWithSize(f *os.File, size int) (BufWriter, error) {
 	return NewDirectIOWriter(f, size)
 }
+
+func UncachedIOSupported() bool {
+	return true
+}

--- a/tsdb/fileutil/direct_io_linux.go
+++ b/tsdb/fileutil/direct_io_linux.go
@@ -27,3 +27,7 @@ func NewBufioWriterWithSize(f *os.File, size int) (BufWriter, error) {
 func NewDirectIOWriter(f *os.File, size int) (BufWriter, error) {
 	return newDirectIOWriter(f, size)
 }
+
+func UncachedIOSupported() bool {
+	return true
+}

--- a/tsdb/fileutil/direct_io_unsupported.go
+++ b/tsdb/fileutil/direct_io_unsupported.go
@@ -27,3 +27,7 @@ func NewBufioWriterWithSize(f *os.File, size int) (BufWriter, error) {
 func NewDirectIOWriter(*os.File, int) (BufWriter, error) {
 	return nil, errDirectIOUnsupported
 }
+
+func UncachedIOSupported() bool {
+	return false
+}


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/prometheus/prometheus/issues/17190

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] TSDB: Fail early when `use-uncached-io` feature flag is set on unsupported environments.
```
