### PR TITLE
tsdb(wal): st-per-sample for histograms initial code and benchmarks

### DIFF
--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -518,7 +518,7 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 					return
 				}
 				decoded <- samples
-			case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+			case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
 				histograms := db.walReplayHistogramsPool.Get()[:0]
 				histograms, err = dec.HistogramSamples(rec, histograms)
 				if err != nil {
@@ -530,7 +530,7 @@ func (db *DB) loadWAL(r *wlog.Reader, duplicateRefToValidRef map[chunks.HeadSeri
 					return
 				}
 				decoded <- histograms
-			case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+			case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 				floatHistograms := db.walReplayFloatHistogramsPool.Get()[:0]
 				floatHistograms, err = dec.FloatHistogramSamples(rec, floatHistograms)
 				if err != nil {

--- a/tsdb/agent/db_append_v2_test.go
+++ b/tsdb/agent/db_append_v2_test.go
@@ -232,12 +232,36 @@ func TestCommit_AppendV2(t *testing.T) {
 					walSamplesCount += len(samples)
 
 				case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+					if enableSTStorage {
+						t.Errorf("Got V1 Samples when ST enabled")
+					}
+					var histograms []record.RefHistogramSample
+					histograms, err = dec.HistogramSamples(rec, histograms)
+					require.NoError(t, err)
+					walHistogramCount += len(histograms)
+
+				case record.HistogramSamplesV2:
+					if !enableSTStorage {
+						t.Errorf("Got V2 Samples when ST disabled")
+					}
 					var histograms []record.RefHistogramSample
 					histograms, err = dec.HistogramSamples(rec, histograms)
 					require.NoError(t, err)
 					walHistogramCount += len(histograms)
 
 				case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+					if enableSTStorage {
+						t.Errorf("Got V1 Samples when ST enabled")
+					}
+					var floatHistograms []record.RefFloatHistogramSample
+					floatHistograms, err = dec.FloatHistogramSamples(rec, floatHistograms)
+					require.NoError(t, err)
+					walFloatHistogramCount += len(floatHistograms)
+
+				case record.FloatHistogramSamplesV2:
+					if !enableSTStorage {
+						t.Errorf("Got V2 Samples when ST disabled")
+					}
 					var floatHistograms []record.RefFloatHistogramSample
 					floatHistograms, err = dec.FloatHistogramSamples(rec, floatHistograms)
 					require.NoError(t, err)
@@ -375,7 +399,7 @@ func TestRollbackAppendV2(t *testing.T) {
 			case record.Exemplars:
 				t.Errorf("should not have found exemplars")
 
-			case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+			case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.HistogramSamplesV2, record.FloatHistogramSamplesV2:
 				t.Errorf("should not have found histograms")
 
 			default:

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -288,13 +288,13 @@ func TestCommit(t *testing.T) {
 			require.NoError(t, err)
 			walSamplesCount += len(samples)
 
-		case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+		case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
 			var histograms []record.RefHistogramSample
 			histograms, err = dec.HistogramSamples(rec, histograms)
 			require.NoError(t, err)
 			walHistogramCount += len(histograms)
 
-		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 			var floatHistograms []record.RefFloatHistogramSample
 			floatHistograms, err = dec.FloatHistogramSamples(rec, floatHistograms)
 			require.NoError(t, err)
@@ -430,13 +430,13 @@ func TestRollback(t *testing.T) {
 			require.NoError(t, err)
 			walExemplarsCount += len(exemplars)
 
-		case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+		case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
 			var histograms []record.RefHistogramSample
 			histograms, err = dec.HistogramSamples(rec, histograms)
 			require.NoError(t, err)
 			walHistogramCount += len(histograms)
 
-		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 			var floatHistograms []record.RefFloatHistogramSample
 			floatHistograms, err = dec.FloatHistogramSamples(rec, floatHistograms)
 			require.NoError(t, err)

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -205,13 +205,13 @@ func TestDataNotAvailableAfterRollback_AppendV2(t *testing.T) {
 			require.NoError(t, err)
 			walExemplarsCount += len(exemplars)
 
-		case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+		case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
 			var histograms []record.RefHistogramSample
 			histograms, err = dec.HistogramSamples(rec, histograms)
 			require.NoError(t, err)
 			walHistogramCount += len(histograms)
 
-		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 			var floatHistograms []record.RefFloatHistogramSample
 			floatHistograms, err = dec.FloatHistogramSamples(rec, floatHistograms)
 			require.NoError(t, err)

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -407,13 +407,13 @@ func TestDataNotAvailableAfterRollback(t *testing.T) {
 			require.NoError(t, err)
 			walExemplarsCount += len(exemplars)
 
-		case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+		case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
 			var histograms []record.RefHistogramSample
 			histograms, err = dec.HistogramSamples(rec, histograms)
 			require.NoError(t, err)
 			walHistogramCount += len(histograms)
 
-		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 			var floatHistograms []record.RefFloatHistogramSample
 			floatHistograms, err = dec.FloatHistogramSamples(rec, floatHistograms)
 			require.NoError(t, err)
@@ -4567,11 +4567,11 @@ func testOOOWALWrite(t *testing.T,
 				markers, err := dec.MmapMarkers(rec, nil)
 				require.NoError(t, err)
 				records = append(records, markers)
-			case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+			case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
 				histogramSamples, err := dec.HistogramSamples(rec, nil)
 				require.NoError(t, err)
 				records = append(records, histogramSamples)
-			case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+			case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 				floatHistogramSamples, err := dec.FloatHistogramSamples(rec, nil)
 				require.NoError(t, err)
 				records = append(records, floatHistogramSamples)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -164,11 +164,11 @@ func readTestWAL(t testing.TB, dir string) (recs []any) {
 			samples, err := dec.Samples(rec, nil)
 			require.NoError(t, err)
 			recs = append(recs, samples)
-		case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+		case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
 			samples, err := dec.HistogramSamples(rec, nil)
 			require.NoError(t, err)
 			recs = append(recs, samples)
-		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 			samples, err := dec.FloatHistogramSamples(rec, nil)
 			require.NoError(t, err)
 			recs = append(recs, samples)

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -206,7 +206,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 					return
 				}
 				decoded <- exemplars
-			case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+			case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
 				hists := h.wlReplayHistogramsPool.Get()[:0]
 				hists, err = dec.HistogramSamples(r.Record(), hists)
 				if err != nil {
@@ -218,7 +218,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 					return
 				}
 				decoded <- hists
-			case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+			case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 				hists := h.wlReplayFloatHistogramsPool.Get()[:0]
 				hists, err = dec.FloatHistogramSamples(r.Record(), hists)
 				if err != nil {
@@ -838,7 +838,7 @@ func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 					return
 				}
 				decodedCh <- markers
-			case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+			case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
 				hists := h.wlReplayHistogramsPool.Get()[:0]
 				hists, err = dec.HistogramSamples(rec, hists)
 				if err != nil {
@@ -850,7 +850,7 @@ func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 					return
 				}
 				decodedCh <- hists
-			case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+			case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 				hists := h.wlReplayFloatHistogramsPool.Get()[:0]
 				hists, err = dec.FloatHistogramSamples(rec, hists)
 				if err != nil {

--- a/tsdb/record/bench_test.go
+++ b/tsdb/record/bench_test.go
@@ -120,88 +120,335 @@ var (
 		testrecord.WorstCase1000,
 		testrecord.WorstCase1000WithSTSamples,
 	}
-	UseV2 = true
+	versions = []struct {
+		name     string
+		enableST bool
+	}{
+		{"V1", false},
+		{"V2", true},
+	}
 )
 
+//nolint:godot
 /*
-	export bench=encode-v2 && go test ./tsdb/record/... \
+	go test ./tsdb/record/... \
 		-run '^$' -bench '^BenchmarkEncode_Samples' \
 		-benchtime 5s -count 6 -cpu 2 -timeout 999m \
-		| tee ${bench}.txt
+		| tee encode.txt
+
+benchstat -col /version encode.txt
 */
 func BenchmarkEncode_Samples(b *testing.B) {
-	for _, compr := range compressions {
-		for _, data := range dataCases {
-			b.Run(fmt.Sprintf("compr=%v/data=%v", compr, data), func(b *testing.B) {
-				var (
-					samples = testrecord.GenTestRefSamplesCase(b, data)
-					enc     = record.Encoder{EnableSTStorage: UseV2}
-					buf     []byte
-					cBuf    []byte
-				)
+	for _, ver := range versions {
+		for _, compr := range compressions {
+			for _, data := range dataCases {
+				b.Run(fmt.Sprintf("version=%s/compr=%v/data=%v", ver.name, compr, data), func(b *testing.B) {
+					var (
+						samples = testrecord.GenTestRefSamplesCase(b, data)
+						enc     = record.Encoder{EnableSTStorage: ver.enableST}
+						buf     []byte
+						cBuf    []byte
+					)
 
-				cEnc, err := compression.NewEncoder()
-				require.NoError(b, err)
+					cEnc, err := compression.NewEncoder()
+					require.NoError(b, err)
 
-				// Warm up.
-				buf = enc.Samples(samples, buf[:0])
-				cBuf, _, err = cEnc.Encode(compr, buf, cBuf[:0])
-				require.NoError(b, err)
-
-				b.ReportAllocs()
-				b.ResetTimer()
-				for b.Loop() {
+					// Warm up.
 					buf = enc.Samples(samples, buf[:0])
-					b.ReportMetric(float64(len(buf)), "B/rec")
+					cBuf, _, err = cEnc.Encode(compr, buf, cBuf[:0])
+					require.NoError(b, err)
 
-					cBuf, _, _ = cEnc.Encode(compr, buf, cBuf[:0])
-					b.ReportMetric(float64(len(cBuf)), "B/compressed-rec")
-				}
-			})
+					b.ReportAllocs()
+					b.ResetTimer()
+					for b.Loop() {
+						buf = enc.Samples(samples, buf[:0])
+						b.ReportMetric(float64(len(buf)), "B/rec")
+
+						cBuf, _, _ = cEnc.Encode(compr, buf, cBuf[:0])
+						b.ReportMetric(float64(len(cBuf)), "B/compressed-rec")
+					}
+				})
+			}
 		}
 	}
 }
 
+//nolint:godot
 /*
-	export bench=decode-v2 && go test ./tsdb/record/... \
+	go test ./tsdb/record/... \
 		-run '^$' -bench '^BenchmarkDecode_Samples' \
 		-benchtime 5s -count 6 -cpu 2 -timeout 999m \
-		| tee ${bench}.txt
+		| tee decode.txt
+
+benchstat -col /version decode.txt
 */
 func BenchmarkDecode_Samples(b *testing.B) {
-	for _, compr := range compressions {
-		for _, data := range dataCases {
-			b.Run(fmt.Sprintf("compr=%v/data=%v", compr, data), func(b *testing.B) {
-				var (
-					samples    = testrecord.GenTestRefSamplesCase(b, data)
-					enc        = record.Encoder{EnableSTStorage: UseV2}
-					dec        record.Decoder
-					cDec       = compression.NewDecoder()
-					cBuf       []byte
-					samplesBuf []record.RefSample
-				)
+	for _, ver := range versions {
+		for _, compr := range compressions {
+			for _, data := range dataCases {
+				b.Run(fmt.Sprintf("version=%s/compr=%v/data=%v", ver.name, compr, data), func(b *testing.B) {
+					var (
+						samples    = testrecord.GenTestRefSamplesCase(b, data)
+						enc        = record.Encoder{EnableSTStorage: ver.enableST}
+						dec        record.Decoder
+						cDec       = compression.NewDecoder()
+						cBuf       []byte
+						samplesBuf []record.RefSample
+					)
 
-				buf := enc.Samples(samples, nil)
+					buf := enc.Samples(samples, nil)
 
-				cEnc, err := compression.NewEncoder()
-				require.NoError(b, err)
+					cEnc, err := compression.NewEncoder()
+					require.NoError(b, err)
 
-				buf, _, err = cEnc.Encode(compr, buf, nil)
-				require.NoError(b, err)
+					buf, _, err = cEnc.Encode(compr, buf, nil)
+					require.NoError(b, err)
 
-				// Warm up.
-				cBuf, err = cDec.Decode(compr, buf, cBuf[:0])
-				require.NoError(b, err)
-				samplesBuf, err = dec.Samples(cBuf, samplesBuf[:0])
-				require.NoError(b, err)
+					// Warm up.
+					cBuf, err = cDec.Decode(compr, buf, cBuf[:0])
+					require.NoError(b, err)
+					samplesBuf, err = dec.Samples(cBuf, samplesBuf[:0])
+					require.NoError(b, err)
 
-				b.ReportAllocs()
-				b.ResetTimer()
-				for b.Loop() {
-					cBuf, _ = cDec.Decode(compr, buf, cBuf[:0])
-					samplesBuf, _ = dec.Samples(cBuf, samplesBuf[:0])
+					b.ReportAllocs()
+					b.ResetTimer()
+					for b.Loop() {
+						cBuf, _ = cDec.Decode(compr, buf, cBuf[:0])
+						samplesBuf, _ = dec.Samples(cBuf, samplesBuf[:0])
+					}
+				})
+			}
+		}
+	}
+}
+
+var (
+	histDataCases = testrecord.HistDataCases
+	histCounts    = testrecord.HistCounts
+)
+
+//nolint:godot
+/*
+	go test ./tsdb/record/... \
+		-run '^$' -bench '^BenchmarkEncode_Histograms' \
+		-benchtime 5s -count 6 -cpu 2 -timeout 999m \
+		| tee encode-hist.txt
+
+benchstat -col /version encode-hist.txt
+*/
+func BenchmarkEncode_Histograms(b *testing.B) {
+	for _, ver := range versions {
+		for _, compr := range compressions {
+			for _, hcase := range histDataCases {
+				for _, stCase := range testrecord.HistSTCases {
+					for _, count := range histCounts {
+						b.Run(fmt.Sprintf("version=%s/compr=%v/type=%s/st=%s/n=%d", ver.name, compr, hcase.Name, stCase, count), func(b *testing.B) {
+							var (
+								samples = hcase.Gen(count, stCase)
+								enc     = record.Encoder{EnableSTStorage: ver.enableST}
+								buf     []byte
+								cBuf    []byte
+							)
+
+							cEnc, err := compression.NewEncoder()
+							require.NoError(b, err)
+
+							// Warm up.
+							if hcase.Name == "nhcb" {
+								buf = enc.CustomBucketsHistogramSamples(samples, buf[:0])
+							} else {
+								buf, _ = enc.HistogramSamples(samples, buf[:0])
+							}
+							cBuf, _, err = cEnc.Encode(compr, buf, cBuf[:0])
+							require.NoError(b, err)
+
+							b.ReportAllocs()
+							b.ResetTimer()
+							for b.Loop() {
+								if hcase.Name == "nhcb" {
+									buf = enc.CustomBucketsHistogramSamples(samples, buf[:0])
+								} else {
+									buf, _ = enc.HistogramSamples(samples, buf[:0])
+								}
+								b.ReportMetric(float64(len(buf)), "B/rec")
+
+								cBuf, _, _ = cEnc.Encode(compr, buf, cBuf[:0])
+								b.ReportMetric(float64(len(cBuf)), "B/compressed-rec")
+							}
+						})
+					}
 				}
-			})
+			}
+		}
+	}
+}
+
+//nolint:godot
+/*
+	go test ./tsdb/record/... \
+		-run '^$' -bench '^BenchmarkDecode_Histograms' \
+		-benchtime 5s -count 6 -cpu 2 -timeout 999m \
+		| tee decode-hist.txt
+
+benchstat -col /version decode-hist.txt
+*/
+func BenchmarkDecode_Histograms(b *testing.B) {
+	for _, ver := range versions {
+		for _, compr := range compressions {
+			for _, hcase := range histDataCases {
+				for _, stCase := range testrecord.HistSTCases {
+					for _, count := range histCounts {
+						b.Run(fmt.Sprintf("version=%s/compr=%v/type=%s/st=%s/n=%d", ver.name, compr, hcase.Name, stCase, count), func(b *testing.B) {
+							var (
+								samples    = hcase.Gen(count, stCase)
+								enc        = record.Encoder{EnableSTStorage: ver.enableST}
+								dec        record.Decoder
+								cDec       = compression.NewDecoder()
+								cBuf       []byte
+								samplesBuf []record.RefHistogramSample
+							)
+
+							var buf []byte
+							if hcase.Name == "nhcb" {
+								buf = enc.CustomBucketsHistogramSamples(samples, nil)
+							} else {
+								buf, _ = enc.HistogramSamples(samples, nil)
+							}
+
+							cEnc, err := compression.NewEncoder()
+							require.NoError(b, err)
+							buf, _, err = cEnc.Encode(compr, buf, nil)
+							require.NoError(b, err)
+
+							// Warm up.
+							cBuf, err = cDec.Decode(compr, buf, cBuf[:0])
+							require.NoError(b, err)
+							samplesBuf, err = dec.HistogramSamples(cBuf, samplesBuf[:0])
+							require.NoError(b, err)
+
+							b.ReportAllocs()
+							b.ResetTimer()
+							for b.Loop() {
+								cBuf, _ = cDec.Decode(compr, buf, cBuf[:0])
+								samplesBuf, _ = dec.HistogramSamples(cBuf, samplesBuf[:0])
+							}
+						})
+					}
+				}
+			}
+		}
+	}
+}
+
+//nolint:godot
+/*
+	go test ./tsdb/record/... \
+		-run '^$' -bench '^BenchmarkEncode_FloatHistograms' \
+		-benchtime 5s -count 6 -cpu 2 -timeout 999m \
+		| tee encode-fhist.txt
+
+benchstat -col /version encode-fhist.txt
+*/
+func BenchmarkEncode_FloatHistograms(b *testing.B) {
+	for _, ver := range versions {
+		for _, compr := range compressions {
+			for _, hcase := range histDataCases {
+				for _, stCase := range testrecord.HistSTCases {
+					for _, count := range histCounts {
+						b.Run(fmt.Sprintf("version=%s/compr=%v/type=%s/st=%s/n=%d", ver.name, compr, hcase.Name, stCase, count), func(b *testing.B) {
+							var (
+								samples = testrecord.GenFloatHistograms(hcase.Gen(count, stCase))
+								enc     = record.Encoder{EnableSTStorage: ver.enableST}
+								buf     []byte
+								cBuf    []byte
+							)
+
+							cEnc, err := compression.NewEncoder()
+							require.NoError(b, err)
+
+							// Warm up.
+							if hcase.Name == "nhcb" {
+								buf = enc.CustomBucketsFloatHistogramSamples(samples, buf[:0])
+							} else {
+								buf, _ = enc.FloatHistogramSamples(samples, buf[:0])
+							}
+							cBuf, _, err = cEnc.Encode(compr, buf, cBuf[:0])
+							require.NoError(b, err)
+
+							b.ReportAllocs()
+							b.ResetTimer()
+							for b.Loop() {
+								if hcase.Name == "nhcb" {
+									buf = enc.CustomBucketsFloatHistogramSamples(samples, buf[:0])
+								} else {
+									buf, _ = enc.FloatHistogramSamples(samples, buf[:0])
+								}
+								b.ReportMetric(float64(len(buf)), "B/rec")
+
+								cBuf, _, _ = cEnc.Encode(compr, buf, cBuf[:0])
+								b.ReportMetric(float64(len(cBuf)), "B/compressed-rec")
+							}
+						})
+					}
+				}
+			}
+		}
+	}
+}
+
+//nolint:godot
+/*
+	go test ./tsdb/record/... \
+		-run '^$' -bench '^BenchmarkDecode_FloatHistograms' \
+		-benchtime 5s -count 6 -cpu 2 -timeout 999m \
+		| tee decode-fhist.txt
+
+benchstat -col /version decode-fhist.txt
+*/
+func BenchmarkDecode_FloatHistograms(b *testing.B) {
+	for _, ver := range versions {
+		for _, compr := range compressions {
+			for _, hcase := range histDataCases {
+				for _, stCase := range testrecord.HistSTCases {
+					for _, count := range histCounts {
+						b.Run(fmt.Sprintf("version=%s/compr=%v/type=%s/st=%s/n=%d", ver.name, compr, hcase.Name, stCase, count), func(b *testing.B) {
+							var (
+								samples    = testrecord.GenFloatHistograms(hcase.Gen(count, stCase))
+								enc        = record.Encoder{EnableSTStorage: ver.enableST}
+								dec        record.Decoder
+								cDec       = compression.NewDecoder()
+								cBuf       []byte
+								samplesBuf []record.RefFloatHistogramSample
+							)
+
+							var buf []byte
+							if hcase.Name == "nhcb" {
+								buf = enc.CustomBucketsFloatHistogramSamples(samples, nil)
+							} else {
+								buf, _ = enc.FloatHistogramSamples(samples, nil)
+							}
+
+							cEnc, err := compression.NewEncoder()
+							require.NoError(b, err)
+							buf, _, err = cEnc.Encode(compr, buf, nil)
+							require.NoError(b, err)
+
+							// Warm up.
+							cBuf, err = cDec.Decode(compr, buf, cBuf[:0])
+							require.NoError(b, err)
+							samplesBuf, err = dec.FloatHistogramSamples(cBuf, samplesBuf[:0])
+							require.NoError(b, err)
+
+							b.ReportAllocs()
+							b.ResetTimer()
+							for b.Loop() {
+								cBuf, _ = cDec.Decode(compr, buf, cBuf[:0])
+								samplesBuf, _ = dec.FloatHistogramSamples(cBuf, samplesBuf[:0])
+							}
+						})
+					}
+				}
+			}
 		}
 	}
 }

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -60,6 +60,10 @@ const (
 	CustomBucketsFloatHistogramSamples Type = 10
 	// SamplesV2 is an enhanced sample record with an encoding scheme that allows storing float samples with timestamp and an optional ST per sample.
 	SamplesV2 Type = 11
+	// HistogramSamplesV2 is an enhanced histogram record that supports start time per sample.
+	HistogramSamplesV2 Type = 12
+	// FloatHistogramSamplesV2 is an enhanced float histogram record that supports start time per sample.
+	FloatHistogramSamplesV2 Type = 13
 )
 
 func (rt Type) String() string {
@@ -69,7 +73,7 @@ func (rt Type) String() string {
 	case Samples:
 		return "samples"
 	case SamplesV2:
-		return "samples-v2"
+		return "samples_v2"
 	case Tombstones:
 		return "tombstones"
 	case Exemplars:
@@ -82,6 +86,10 @@ func (rt Type) String() string {
 		return "custom_buckets_histogram_samples"
 	case CustomBucketsFloatHistogramSamples:
 		return "custom_buckets_float_histogram_samples"
+	case HistogramSamplesV2:
+		return "histogram_samples_v2"
+	case FloatHistogramSamplesV2:
+		return "float_histogram_samples_v2"
 	case MmapMarkers:
 		return "mmapmarkers"
 	case Metadata:
@@ -186,19 +194,17 @@ type RefExemplar struct {
 }
 
 // RefHistogramSample is a histogram.
-// TODO(owilliams): Add support for ST.
 type RefHistogramSample struct {
-	Ref chunks.HeadSeriesRef
-	T   int64
-	H   *histogram.Histogram
+	Ref   chunks.HeadSeriesRef
+	ST, T int64
+	H     *histogram.Histogram
 }
 
 // RefFloatHistogramSample is a float histogram.
-// TODO(owilliams): Add support for ST.
 type RefFloatHistogramSample struct {
-	Ref chunks.HeadSeriesRef
-	T   int64
-	FH  *histogram.FloatHistogram
+	Ref   chunks.HeadSeriesRef
+	ST, T int64
+	FH    *histogram.FloatHistogram
 }
 
 // RefMmapMarker marks that the all the samples of the given series until now have been m-mapped to disk.
@@ -226,7 +232,9 @@ func (*Decoder) Type(rec []byte) Type {
 		return Unknown
 	}
 	switch t := Type(rec[0]); t {
-	case Series, Samples, SamplesV2, Tombstones, Exemplars, MmapMarkers, Metadata, HistogramSamples, FloatHistogramSamples, CustomBucketsHistogramSamples, CustomBucketsFloatHistogramSamples:
+	case Series, Samples, SamplesV2, Tombstones, Exemplars, MmapMarkers, Metadata,
+		HistogramSamples, FloatHistogramSamples, CustomBucketsHistogramSamples, CustomBucketsFloatHistogramSamples,
+		HistogramSamplesV2, FloatHistogramSamplesV2:
 		return t
 	}
 	return Unknown
@@ -376,33 +384,26 @@ func (*Decoder) samplesV2(dec *encoding.Decbuf, samples []RefSample) ([]RefSampl
 	var firstT, firstST int64
 	for len(dec.B) > 0 && dec.Err() == nil {
 		var prev RefSample
-		var ref, t, ST int64
+		var ref, t, st int64
 		var val uint64
 
 		if len(samples) == 0 {
 			ref = dec.Varint64()
 			firstT = dec.Varint64()
 			t = firstT
-			ST = dec.Varint64()
-			firstST = ST
+			st = dec.Varint64()
+			firstST = st
 		} else {
 			prev = samples[len(samples)-1]
 			ref = int64(prev.Ref) + dec.Varint64()
 			t = firstT + dec.Varint64()
-			stMarker := dec.Byte()
-			switch stMarker {
-			case noST:
-			case sameST:
-				ST = prev.ST
-			default:
-				ST = firstST + dec.Varint64()
-			}
+			st = readSTMarker(dec, prev.ST, firstST)
 		}
 
 		val = dec.Be64()
 		samples = append(samples, RefSample{
 			Ref: chunks.HeadSeriesRef(ref),
-			ST:  ST,
+			ST:  st,
 			T:   t,
 			V:   math.Float64frombits(val),
 		})
@@ -415,6 +416,18 @@ func (*Decoder) samplesV2(dec *encoding.Decbuf, samples []RefSample) ([]RefSampl
 		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return samples, nil
+}
+
+func readSTMarker(buf *encoding.Decbuf, prevST, firstST int64) int64 {
+	stMarker := buf.Byte()
+	switch stMarker {
+	case noST:
+		return 0
+	case sameST:
+		return prevST
+	default:
+		return firstST + buf.Varint64()
+	}
 }
 
 // Tombstones appends tombstones in rec to the given slice.
@@ -441,6 +454,7 @@ func (*Decoder) Tombstones(rec []byte, tstones []tombstones.Stone) ([]tombstones
 	return tstones, nil
 }
 
+// Exemplars appends exemplars in rec to the given slice.
 func (d *Decoder) Exemplars(rec []byte, exemplars []RefExemplar) ([]RefExemplar, error) {
 	dec := encoding.Decbuf{B: rec}
 	t := Type(dec.Byte())
@@ -451,6 +465,7 @@ func (d *Decoder) Exemplars(rec []byte, exemplars []RefExemplar) ([]RefExemplar,
 	return d.ExemplarsFromBuffer(&dec, exemplars)
 }
 
+// ExemplarsFromBuffer appends exemplars in dec to the given slice.
 func (d *Decoder) ExemplarsFromBuffer(dec *encoding.Decbuf, exemplars []RefExemplar) ([]RefExemplar, error) {
 	if dec.Len() == 0 {
 		return exemplars, nil
@@ -482,6 +497,7 @@ func (d *Decoder) ExemplarsFromBuffer(dec *encoding.Decbuf, exemplars []RefExemp
 	return exemplars, nil
 }
 
+// MmapMarkers appends mmap markers in rec to the given slice.
 func (*Decoder) MmapMarkers(rec []byte, markers []RefMmapMarker) ([]RefMmapMarker, error) {
 	dec := encoding.Decbuf{B: rec}
 	t := Type(dec.Byte())
@@ -510,12 +526,21 @@ func (*Decoder) MmapMarkers(rec []byte, markers []RefMmapMarker) ([]RefMmapMarke
 	return markers, nil
 }
 
+// HistogramSamples appends histogram samples in rec to the given slice.
 func (d *Decoder) HistogramSamples(rec []byte, histograms []RefHistogramSample) ([]RefHistogramSample, error) {
 	dec := encoding.Decbuf{B: rec}
-	t := Type(dec.Byte())
-	if t != HistogramSamples && t != CustomBucketsHistogramSamples {
-		return nil, errors.New("invalid record type")
+	switch typ := Type(dec.Byte()); typ {
+	case HistogramSamples, CustomBucketsHistogramSamples:
+		return d.histogramSamplesV1(&dec, histograms)
+	case HistogramSamplesV2:
+		return d.histogramSamplesV2(&dec, histograms)
+	default:
+		return nil, fmt.Errorf("invalid record type %v", typ)
 	}
+}
+
+// histogramSamplesV1 decodes V1 int-histogram records (BE64 baseRef/baseTime, varint deltas).
+func (d *Decoder) histogramSamplesV1(dec *encoding.Decbuf, histograms []RefHistogramSample) ([]RefHistogramSample, error) {
 	if dec.Len() == 0 {
 		return histograms, nil
 	}
@@ -533,7 +558,7 @@ func (d *Decoder) HistogramSamples(rec []byte, histograms []RefHistogramSample) 
 			H:   &histogram.Histogram{},
 		}
 
-		DecodeHistogram(&dec, rh.H)
+		DecodeHistogram(dec, rh.H)
 
 		if !histogram.IsKnownSchema(rh.H.Schema) {
 			d.logger.Warn("skipping histogram with unknown schema in WAL record", "schema", rh.H.Schema, "timestamp", rh.T)
@@ -560,7 +585,66 @@ func (d *Decoder) HistogramSamples(rec []byte, histograms []RefHistogramSample) 
 	return histograms, nil
 }
 
-// DecodeHistogram decodes a Histogram from a byte slice.
+// histogramSamplesV2 decodes V2 int-histogram records.
+func (d *Decoder) histogramSamplesV2(dec *encoding.Decbuf, histograms []RefHistogramSample) ([]RefHistogramSample, error) {
+	if dec.Len() == 0 {
+		return histograms, nil
+	}
+	firstRef := chunks.HeadSeriesRef(dec.Varint64())
+	firstT := dec.Varint64()
+	firstST := dec.Varint64()
+	var prev *RefHistogramSample
+
+	for len(dec.B) > 0 && dec.Err() == nil {
+		var ref, t, st int64
+		if prev == nil {
+			prev = &RefHistogramSample{
+				Ref: firstRef,
+				ST:  firstST,
+			}
+			ref = int64(firstRef)
+			t = firstT
+			st = firstST
+		} else {
+			ref = int64(prev.Ref) + dec.Varint64()
+			t = firstT + dec.Varint64()
+			st = readSTMarker(dec, prev.ST, firstST)
+		}
+
+		rh := RefHistogramSample{
+			Ref: chunks.HeadSeriesRef(ref),
+			ST:  st,
+			T:   t,
+			H:   &histogram.Histogram{},
+		}
+		prev = &rh
+		DecodeHistogram(dec, rh.H)
+
+		if !histogram.IsKnownSchema(rh.H.Schema) {
+			d.logger.Warn("skipping histogram with unknown schema in WAL record", "schema", rh.H.Schema, "timestamp", rh.T)
+			continue
+		}
+		if rh.H.Schema > histogram.ExponentialSchemaMax && rh.H.Schema <= histogram.ExponentialSchemaMaxReserved {
+			// This is a very slow path, but it should only happen if the
+			// record is from a newer Prometheus version that supports higher
+			// resolution.
+			if err := rh.H.ReduceResolution(histogram.ExponentialSchemaMax); err != nil {
+				return nil, fmt.Errorf("error reducing resolution of histogram #%d: %w", len(histograms)+1, err)
+			}
+		}
+		histograms = append(histograms, rh)
+	}
+
+	if dec.Err() != nil {
+		return nil, fmt.Errorf("decode error after %d histograms: %w", len(histograms), dec.Err())
+	}
+	if len(dec.B) > 0 {
+		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
+	}
+	return histograms, nil
+}
+
+// DecodeHistogram decodes a Histogram from buf.
 func DecodeHistogram(buf *encoding.Decbuf, h *histogram.Histogram) {
 	h.CounterResetHint = histogram.CounterResetHint(buf.Byte())
 
@@ -616,12 +700,22 @@ func DecodeHistogram(buf *encoding.Decbuf, h *histogram.Histogram) {
 	}
 }
 
+// FloatHistogramSamples appends float histogram samples in rec to the given
+// slice.
 func (d *Decoder) FloatHistogramSamples(rec []byte, histograms []RefFloatHistogramSample) ([]RefFloatHistogramSample, error) {
 	dec := encoding.Decbuf{B: rec}
-	t := Type(dec.Byte())
-	if t != FloatHistogramSamples && t != CustomBucketsFloatHistogramSamples {
-		return nil, errors.New("invalid record type")
+	switch typ := Type(dec.Byte()); typ {
+	case FloatHistogramSamples, CustomBucketsFloatHistogramSamples:
+		return d.floatHistogramSamplesV1(&dec, histograms)
+	case FloatHistogramSamplesV2:
+		return d.floatHistogramSamplesV2(&dec, histograms)
+	default:
+		return nil, fmt.Errorf("invalid record type %v", typ)
 	}
+}
+
+// floatHistogramSamplesV1 decodes V1 float-histogram records (BE64 baseRef/baseTime, varint deltas).
+func (d *Decoder) floatHistogramSamplesV1(dec *encoding.Decbuf, histograms []RefFloatHistogramSample) ([]RefFloatHistogramSample, error) {
 	if dec.Len() == 0 {
 		return histograms, nil
 	}
@@ -639,7 +733,7 @@ func (d *Decoder) FloatHistogramSamples(rec []byte, histograms []RefFloatHistogr
 			FH:  &histogram.FloatHistogram{},
 		}
 
-		DecodeFloatHistogram(&dec, rh.FH)
+		DecodeFloatHistogram(dec, rh.FH)
 
 		if !histogram.IsKnownSchema(rh.FH.Schema) {
 			d.logger.Warn("skipping histogram with unknown schema in WAL record", "schema", rh.FH.Schema, "timestamp", rh.T)
@@ -666,7 +760,67 @@ func (d *Decoder) FloatHistogramSamples(rec []byte, histograms []RefFloatHistogr
 	return histograms, nil
 }
 
-// DecodeFloatHistogram decodes a Histogram from a byte slice.
+// floatHistogramSamplesV2 decodes V2 float-histogram records.
+func (d *Decoder) floatHistogramSamplesV2(dec *encoding.Decbuf, histograms []RefFloatHistogramSample) ([]RefFloatHistogramSample, error) {
+	if dec.Len() == 0 {
+		return histograms, nil
+	}
+	firstRef := chunks.HeadSeriesRef(dec.Varint64())
+	firstT := dec.Varint64()
+	firstST := dec.Varint64()
+	var prev *RefFloatHistogramSample
+
+	for len(dec.B) > 0 && dec.Err() == nil {
+		var ref, t, st int64
+		if prev == nil {
+			prev = &RefFloatHistogramSample{
+				Ref: firstRef,
+				ST:  firstST,
+			}
+			ref = int64(firstRef)
+			t = firstT
+			st = firstST
+		} else {
+			ref = int64(prev.Ref) + dec.Varint64()
+			t = firstT + dec.Varint64()
+			st = readSTMarker(dec, prev.ST, firstST)
+		}
+
+		rfh := RefFloatHistogramSample{
+			Ref: chunks.HeadSeriesRef(ref),
+			ST:  st,
+			T:   t,
+			FH:  &histogram.FloatHistogram{},
+		}
+		prev = &rfh
+		DecodeFloatHistogram(dec, rfh.FH)
+
+		if !histogram.IsKnownSchema(rfh.FH.Schema) {
+			d.logger.Warn("skipping histogram with unknown schema in WAL record", "schema", rfh.FH.Schema, "timestamp", rfh.T)
+			continue
+		}
+		if rfh.FH.Schema > histogram.ExponentialSchemaMax && rfh.FH.Schema <= histogram.ExponentialSchemaMaxReserved {
+			// This is a very slow path, but it should only happen if the
+			// record is from a newer Prometheus version that supports higher
+			// resolution.
+			if err := rfh.FH.ReduceResolution(histogram.ExponentialSchemaMax); err != nil {
+				return nil, fmt.Errorf("error reducing resolution of histogram #%d: %w", len(histograms)+1, err)
+			}
+		}
+
+		histograms = append(histograms, rfh)
+	}
+
+	if dec.Err() != nil {
+		return nil, fmt.Errorf("decode error after %d histograms: %w", len(histograms), dec.Err())
+	}
+	if len(dec.B) > 0 {
+		return nil, fmt.Errorf("unexpected %d bytes left in entry", len(dec.B))
+	}
+	return histograms, nil
+}
+
+// DecodeFloatHistogram decodes a FloatHistogram from buf.
 func DecodeFloatHistogram(buf *encoding.Decbuf, fh *histogram.FloatHistogram) {
 	fh.CounterResetHint = histogram.CounterResetHint(buf.Byte())
 
@@ -774,7 +928,8 @@ func EncodeLabels(buf *encoding.Encbuf, lbls labels.Labels) {
 }
 
 // Samples appends the encoded samples to b and returns the resulting slice.
-// Depending on the ST existence it either writes Samples or SamplesWithST record.
+// Depending on EnableSTStorage, it writes either a Samples or SamplesV2
+// record.
 func (e *Encoder) Samples(samples []RefSample, b []byte) []byte {
 	if e.EnableSTStorage {
 		return e.samplesV2(samples, b)
@@ -782,7 +937,7 @@ func (e *Encoder) Samples(samples []RefSample, b []byte) []byte {
 	return e.samplesV1(samples, b)
 }
 
-// Samples appends the encoded samples to b and returns the resulting slice.
+// samplesV1 appends the encoded samples to b and returns the resulting slice.
 func (*Encoder) samplesV1(samples []RefSample, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(Samples))
@@ -842,18 +997,22 @@ func (*Encoder) samplesV2(samples []RefSample, b []byte) []byte {
 		buf.PutVarint64(int64(s.Ref) - int64(prev.Ref))
 		buf.PutVarint64(s.T - first.T)
 
-		switch s.ST {
-		case 0:
-			buf.PutByte(noST)
-		case prev.ST:
-			buf.PutByte(sameST)
-		default:
-			buf.PutByte(explicitST)
-			buf.PutVarint64(s.ST - first.ST)
-		}
+		writeSTMarker(&buf, s.ST, first.ST, prev.ST)
 		buf.PutBE64(math.Float64bits(s.V))
 	}
 	return buf.Get()
+}
+
+func writeSTMarker(buf *encoding.Encbuf, st, firstST, prevST int64) {
+	switch st {
+	case 0:
+		buf.PutByte(noST)
+	case prevST:
+		buf.PutByte(sameST)
+	default:
+		buf.PutByte(explicitST)
+		buf.PutVarint64(st - firstST)
+	}
 }
 
 // Tombstones appends the encoded tombstones to b and returns the resulting slice.
@@ -871,6 +1030,8 @@ func (*Encoder) Tombstones(tstones []tombstones.Stone, b []byte) []byte {
 	return buf.Get()
 }
 
+// Exemplars appends the encoded exemplars to b and returns the resulting
+// slice.
 func (e *Encoder) Exemplars(exemplars []RefExemplar, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(Exemplars))
@@ -884,6 +1045,7 @@ func (e *Encoder) Exemplars(exemplars []RefExemplar, b []byte) []byte {
 	return buf.Get()
 }
 
+// EncodeExemplarsIntoBuffer appends the encoded exemplars to buf.
 func (*Encoder) EncodeExemplarsIntoBuffer(exemplars []RefExemplar, buf *encoding.Encbuf) {
 	// Store base timestamp and base reference number of first sample.
 	// All samples encode their timestamp and ref as delta to those.
@@ -900,6 +1062,8 @@ func (*Encoder) EncodeExemplarsIntoBuffer(exemplars []RefExemplar, buf *encoding
 	}
 }
 
+// MmapMarkers appends the encoded mmap markers to b and returns the resulting
+// slice.
 func (*Encoder) MmapMarkers(markers []RefMmapMarker, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(MmapMarkers))
@@ -912,9 +1076,17 @@ func (*Encoder) MmapMarkers(markers []RefMmapMarker, b []byte) []byte {
 	return buf.Get()
 }
 
-// HistogramSamples encode exponential histograms while returning all the excluded custom bucket histograms.
-// Callers can encode the returned custom bucket histograms via CustomBucketsHistogramSamples.
-func (*Encoder) HistogramSamples(histograms []RefHistogramSample, b []byte) ([]byte, []RefHistogramSample) {
+// HistogramSamples encodes exponential histogram samples and returns the custom
+// bucket histogram samples that must be encoded separately via
+// CustomBucketsHistogramSamples.
+func (e *Encoder) HistogramSamples(histograms []RefHistogramSample, b []byte) ([]byte, []RefHistogramSample) {
+	if e.EnableSTStorage {
+		return e.histogramSamplesV2(histograms, b), nil
+	}
+	return e.histogramSamplesV1(histograms, b)
+}
+
+func (*Encoder) histogramSamplesV1(histograms []RefHistogramSample, b []byte) ([]byte, []RefHistogramSample) {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(HistogramSamples))
 
@@ -948,8 +1120,48 @@ func (*Encoder) HistogramSamples(histograms []RefHistogramSample, b []byte) ([]b
 	return buf.Get(), customBucketHistograms
 }
 
-// CustomBucketsHistogramSamples encodes given histograms as custom bucket histograms.
-func (*Encoder) CustomBucketsHistogramSamples(histograms []RefHistogramSample, b []byte) []byte {
+// histogramSamplesV2 encodes the given histogram samples.
+func (*Encoder) histogramSamplesV2(histograms []RefHistogramSample, b []byte) []byte {
+	buf := encoding.Encbuf{B: b}
+	buf.PutByte(byte(HistogramSamplesV2))
+
+	if len(histograms) == 0 {
+		return buf.Get()
+	}
+
+	var first, prev *RefHistogramSample
+	for _, h := range histograms {
+		if first == nil {
+			first = &h
+			buf.PutVarint64(int64(first.Ref))
+			buf.PutVarint64(first.T)
+			buf.PutVarint64(first.ST)
+			prev = first
+			EncodeHistogram(&buf, h.H)
+			continue
+		}
+
+		buf.PutVarint64(int64(h.Ref) - int64(prev.Ref))
+		buf.PutVarint64(h.T - first.T)
+
+		writeSTMarker(&buf, h.ST, first.ST, prev.ST)
+		EncodeHistogram(&buf, h.H)
+		prev = &h
+	}
+
+	return buf.Get()
+}
+
+// CustomBucketsHistogramSamples appends the encoded custom-bucket histogram
+// samples to b and returns the resulting slice.
+func (e *Encoder) CustomBucketsHistogramSamples(histograms []RefHistogramSample, b []byte) []byte {
+	if e.EnableSTStorage {
+		return e.histogramSamplesV2(histograms, b)
+	}
+	return e.customBucketsHistogramSamplesV1(histograms, b)
+}
+
+func (*Encoder) customBucketsHistogramSamplesV1(histograms []RefHistogramSample, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(CustomBucketsHistogramSamples))
 
@@ -973,7 +1185,8 @@ func (*Encoder) CustomBucketsHistogramSamples(histograms []RefHistogramSample, b
 	return buf.Get()
 }
 
-// EncodeHistogram encodes a Histogram into a byte slice.
+// EncodeHistogram encodes a Histogram into a byte slice. Handles both
+// regular and custom bucket histograms.
 func EncodeHistogram(buf *encoding.Encbuf, h *histogram.Histogram) {
 	buf.PutByte(byte(h.CounterResetHint))
 
@@ -1014,9 +1227,15 @@ func EncodeHistogram(buf *encoding.Encbuf, h *histogram.Histogram) {
 	}
 }
 
-// FloatHistogramSamples encode exponential float histograms while returning all the excluded custom bucket float histograms.
-// Callers can encode the returned custom bucket float histograms via CustomBucketsFloatHistogramSamples.
-func (*Encoder) FloatHistogramSamples(histograms []RefFloatHistogramSample, b []byte) ([]byte, []RefFloatHistogramSample) {
+// FloatHistogramSamples encodes exponential float histogram samples.
+func (e *Encoder) FloatHistogramSamples(histograms []RefFloatHistogramSample, b []byte) ([]byte, []RefFloatHistogramSample) {
+	if e.EnableSTStorage {
+		return e.floatHistogramSamplesV2(histograms, b), nil
+	}
+	return e.floatHistogramSamplesV1(histograms, b)
+}
+
+func (*Encoder) floatHistogramSamplesV1(histograms []RefFloatHistogramSample, b []byte) ([]byte, []RefFloatHistogramSample) {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(FloatHistogramSamples))
 
@@ -1051,8 +1270,49 @@ func (*Encoder) FloatHistogramSamples(histograms []RefFloatHistogramSample, b []
 	return buf.Get(), customBucketsFloatHistograms
 }
 
-// CustomBucketsFloatHistogramSamples encodes given float histograms as custom bucket float histograms.
-func (*Encoder) CustomBucketsFloatHistogramSamples(histograms []RefFloatHistogramSample, b []byte) []byte {
+// floatHistogramSamplesV2 encodes exponential float histogram samples and
+// splits off custom-bucket float histogram samples to be encoded later.
+func (*Encoder) floatHistogramSamplesV2(histograms []RefFloatHistogramSample, b []byte) []byte {
+	buf := encoding.Encbuf{B: b}
+	buf.PutByte(byte(FloatHistogramSamplesV2))
+
+	if len(histograms) == 0 {
+		return buf.Get()
+	}
+
+	var first, prev *RefFloatHistogramSample
+	for _, fh := range histograms {
+		if first == nil {
+			first = &fh
+			buf.PutVarint64(int64(first.Ref))
+			buf.PutVarint64(first.T)
+			buf.PutVarint64(first.ST)
+			prev = first
+			EncodeFloatHistogram(&buf, fh.FH)
+			continue
+		}
+
+		buf.PutVarint64(int64(fh.Ref) - int64(prev.Ref))
+		buf.PutVarint64(fh.T - first.T)
+
+		writeSTMarker(&buf, fh.ST, first.ST, prev.ST)
+		EncodeFloatHistogram(&buf, fh.FH)
+		prev = &fh
+	}
+
+	return buf.Get()
+}
+
+// CustomBucketsFloatHistogramSamples appends the encoded custom-bucket float
+// histogram samples to b and returns the resulting slice.
+func (e *Encoder) CustomBucketsFloatHistogramSamples(histograms []RefFloatHistogramSample, b []byte) []byte {
+	if e.EnableSTStorage {
+		return e.floatHistogramSamplesV2(histograms, b)
+	}
+	return e.customBucketsFloatHistogramSamplesV1(histograms, b)
+}
+
+func (*Encoder) customBucketsFloatHistogramSamplesV1(histograms []RefFloatHistogramSample, b []byte) []byte {
 	buf := encoding.Encbuf{B: b}
 	buf.PutByte(byte(CustomBucketsFloatHistogramSamples))
 

--- a/tsdb/record/record_test.go
+++ b/tsdb/record/record_test.go
@@ -245,6 +245,8 @@ func TestRecord_EncodeDecode(t *testing.T) {
 	decFloatHistograms = append(decFloatHistograms, decCustomBucketsFloatHistograms...)
 	require.Equal(t, floatHistograms, decFloatHistograms)
 
+	enc = Encoder{EnableSTStorage: true}
+
 	// Gauge integer histograms.
 	for i := range histograms {
 		histograms[i].H.CounterResetHint = histogram.GaugeType
@@ -272,6 +274,385 @@ func TestRecord_EncodeDecode(t *testing.T) {
 	require.NoError(t, err)
 	decGaugeFloatHistograms = append(decGaugeFloatHistograms, decCustomBucketsGaugeFloatHistograms...)
 	require.Equal(t, floatHistograms, decGaugeFloatHistograms)
+
+	// V2 gauge int-histogram round-trip. V2 does not disentangle regular and custom bucket histograms, so the encoder never returns a slice of leftover items.
+	t.Run("V2 gauge int-histogram", func(t *testing.T) {
+		enc = Encoder{EnableSTStorage: true}
+		gaugeHistsV2 := []RefHistogramSample{
+			{Ref: 56, T: 1234, ST: 1000, H: histograms[0].H},
+			{Ref: 42, T: 5678, ST: 1000, H: histograms[1].H},
+			{Ref: 67, T: 5678, ST: 1000, H: histograms[2].H},
+		}
+		histSamplesV2, leftOver := enc.HistogramSamples(gaugeHistsV2, nil)
+		require.Nil(t, leftOver)
+		decHistsV2, err := dec.HistogramSamples(histSamplesV2, nil)
+		require.NoError(t, err)
+		require.Equal(t, gaugeHistsV2, decHistsV2)
+	})
+
+	// V2 gauge float-histogram round-trip.
+	t.Run("V2 gauge float-histogram", func(t *testing.T) {
+		gaugeHistsV2 := []RefHistogramSample{
+			{Ref: 56, T: 1234, ST: 1000, H: histograms[0].H},
+			{Ref: 42, T: 5678, ST: 1000, H: histograms[1].H},
+			{Ref: 67, T: 5678, ST: 1000, H: histograms[2].H},
+		}
+		gaugeFloatHistsV2 := make([]RefFloatHistogramSample, len(gaugeHistsV2))
+		for i, h := range gaugeHistsV2 {
+			gaugeFloatHistsV2[i] = RefFloatHistogramSample{
+				Ref: h.Ref,
+				T:   h.T,
+				ST:  h.ST,
+				FH:  h.H.ToFloat(nil),
+			}
+		}
+		floatHistSamplesV2, leftOver := enc.FloatHistogramSamples(gaugeFloatHistsV2, nil)
+		require.Nil(t, leftOver)
+		decFloatHistsV2, err := dec.FloatHistogramSamples(floatHistSamplesV2, nil)
+		require.NoError(t, err)
+		require.Equal(t, gaugeFloatHistsV2, decFloatHistsV2)
+	})
+
+	for _, enableSTStorage := range []bool{false, true} {
+		t.Run(fmt.Sprintf("int-histogram empty slice stStorage=%v", enableSTStorage), func(t *testing.T) {
+			enc := Encoder{EnableSTStorage: enableSTStorage}
+			histBuf, customBuckets := enc.HistogramSamples(nil, nil)
+			require.Nil(t, customBuckets)
+
+			decoded, err := dec.HistogramSamples(histBuf, nil)
+			require.NoError(t, err)
+			require.Empty(t, decoded)
+		})
+
+		t.Run(fmt.Sprintf("float-histogram empty slice stStorage=%v", enableSTStorage), func(t *testing.T) {
+			enc := Encoder{EnableSTStorage: enableSTStorage}
+			floatBuf, customBucketsFloat := enc.FloatHistogramSamples(nil, nil)
+			require.Nil(t, customBucketsFloat)
+
+			decoded, err := dec.FloatHistogramSamples(floatBuf, nil)
+			require.NoError(t, err)
+			require.Empty(t, decoded)
+		})
+	}
+
+	// When all histograms are custom-bucket, V1 HistogramSamples must return an
+	// empty buffer (buf.Reset path) and pass every sample through as custom.
+	t.Run("V1 int-histogram all custom bucket", func(t *testing.T) {
+		encV1 := Encoder{}
+		allCustom := []RefHistogramSample{
+			{Ref: 56, T: 1234, H: histograms[2].H},
+			{Ref: 67, T: 5678, H: histograms[2].H},
+		}
+		histBuf, customBuckets := encV1.HistogramSamples(allCustom, nil)
+		require.Empty(t, histBuf, "regular histogram buffer must be empty when all samples are custom bucket")
+		require.Equal(t, allCustom, customBuckets)
+
+		customBuf := encV1.CustomBucketsHistogramSamples(customBuckets, nil)
+		decoded, err := dec.HistogramSamples(customBuf, nil)
+		require.NoError(t, err)
+		require.Equal(t, allCustom, decoded)
+	})
+
+	t.Run("V1 float-histogram all custom bucket", func(t *testing.T) {
+		encV1 := Encoder{}
+		allCustomFloat := []RefFloatHistogramSample{
+			{Ref: 56, T: 1234, FH: histograms[2].H.ToFloat(nil)},
+			{Ref: 67, T: 5678, FH: histograms[2].H.ToFloat(nil)},
+		}
+		floatBuf, customBucketsFloat := encV1.FloatHistogramSamples(allCustomFloat, nil)
+		require.Empty(t, floatBuf, "regular float histogram buffer must be empty when all samples are custom bucket")
+		require.Equal(t, allCustomFloat, customBucketsFloat)
+
+		customFloatBuf := encV1.CustomBucketsFloatHistogramSamples(customBucketsFloat, nil)
+		decoded, err := dec.FloatHistogramSamples(customFloatBuf, nil)
+		require.NoError(t, err)
+		require.Equal(t, allCustomFloat, decoded)
+	})
+
+	// Backward compat: V1-encoded histograms decode with ST=0.
+	t.Run("V1 backward compat int-histogram ST=0", func(t *testing.T) {
+		encV1 := Encoder{}
+		v1HistSamples, v1CustomBucketsHists := encV1.HistogramSamples(histograms, nil)
+		v1CustomBucketsHistSamples := encV1.CustomBucketsHistogramSamples(v1CustomBucketsHists, nil)
+		decV1Hists, err := dec.HistogramSamples(v1HistSamples, nil)
+		require.NoError(t, err)
+		decV1CustomBuckets, err := dec.HistogramSamples(v1CustomBucketsHistSamples, nil)
+		require.NoError(t, err)
+		for _, h := range append(decV1Hists, decV1CustomBuckets...) {
+			require.Equal(t, int64(0), h.ST, "V1 histogram records must decode with ST=0")
+		}
+	})
+
+	// Backward compat: V1-encoded float histograms decode with ST=0.
+	t.Run("V1 backward compat float-histogram ST=0", func(t *testing.T) {
+		encV1 := Encoder{}
+		v1FloatHistSamples, v1CustomBucketsFloatHists := encV1.FloatHistogramSamples(floatHistograms, nil)
+		v1CustomBucketsFloatHistSamples := encV1.CustomBucketsFloatHistogramSamples(v1CustomBucketsFloatHists, nil)
+		decV1FloatHists, err := dec.FloatHistogramSamples(v1FloatHistSamples, nil)
+		require.NoError(t, err)
+		decV1CustomBucketsFloatHists, err := dec.FloatHistogramSamples(v1CustomBucketsFloatHistSamples, nil)
+		require.NoError(t, err)
+		for _, h := range append(decV1FloatHists, decV1CustomBucketsFloatHists...) {
+			require.Equal(t, int64(0), h.ST, "V1 float histogram records must decode with ST=0")
+		}
+	})
+}
+
+// TestRecord_V1MixedRegularAndCustomBucketHistogramPermutations verifies that
+// V1 encoding correctly splits mixed regular and custom-bucket histograms into
+// separate records regardless of input ordering. The split is only meaningful
+// for V1, which keeps the two record types distinct for backwards
+// compatibility. See TestRecord_V2MixedRegularAndCustomBucketHistogram for the
+// V2 behaviour.
+func TestRecord_V1MixedRegularAndCustomBucketHistogramPermutations(t *testing.T) {
+	dec := NewDecoder(labels.NewSymbolTable(), promslog.NewNopLogger())
+
+	regularA := &histogram.Histogram{
+		Count:         5,
+		ZeroCount:     2,
+		ZeroThreshold: 0.001,
+		Sum:           18.4,
+		Schema:        1,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: 2},
+			{Offset: 1, Length: 2},
+		},
+		PositiveBuckets: []int64{1, 1, -1, 0},
+	}
+	regularB := &histogram.Histogram{
+		Count:         11,
+		ZeroCount:     4,
+		ZeroThreshold: 0.001,
+		Sum:           35.5,
+		Schema:        1,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: 2},
+			{Offset: 2, Length: 2},
+		},
+		PositiveBuckets: []int64{1, 1, -1, 0},
+		NegativeSpans: []histogram.Span{
+			{Offset: 0, Length: 1},
+			{Offset: 1, Length: 2},
+		},
+		NegativeBuckets: []int64{1, 2, -1},
+	}
+	custom := &histogram.Histogram{
+		Count:         8,
+		ZeroThreshold: 0.001,
+		Sum:           42.0,
+		Schema:        histogram.CustomBucketsSchema,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: 2},
+			{Offset: 2, Length: 2},
+		},
+		PositiveBuckets: []int64{2, -1, 2, 0},
+		CustomValues:    []float64{0, 2, 4, 6, 8},
+	}
+
+	type tc struct {
+		name  string
+		kinds []string
+	}
+
+	testCases := []tc{
+		{
+			name:  "regular then custom",
+			kinds: []string{"regularA", "custom"},
+		},
+		{
+			name:  "custom then regular",
+			kinds: []string{"custom", "regularA"},
+		},
+		{
+			name:  "regular custom regular",
+			kinds: []string{"regularA", "custom", "regularB"},
+		},
+		{
+			name:  "custom regular custom",
+			kinds: []string{"custom", "regularA", "custom"},
+		},
+	}
+
+	buildIntSamples := func(kinds []string) []RefHistogramSample {
+		samples := make([]RefHistogramSample, 0, len(kinds))
+		for i, kind := range kinds {
+			var h *histogram.Histogram
+			switch kind {
+			case "regularA":
+				h = regularA
+			case "regularB":
+				h = regularB
+			case "custom":
+				h = custom
+			default:
+				t.Fatalf("unknown histogram kind %q", kind)
+			}
+
+			samples = append(samples, RefHistogramSample{
+				Ref: chunks.HeadSeriesRef(100 + i*11),
+				T:   int64(1000 + i*250),
+				H:   h,
+			})
+		}
+		return samples
+	}
+
+	toExpectedIntPartitions := func(samples []RefHistogramSample) ([]RefHistogramSample, []RefHistogramSample) {
+		var regularSamples []RefHistogramSample
+		var customSamples []RefHistogramSample
+		for _, sample := range samples {
+			if sample.H.UsesCustomBuckets() {
+				customSamples = append(customSamples, sample)
+				continue
+			}
+			regularSamples = append(regularSamples, sample)
+		}
+		return regularSamples, customSamples
+	}
+
+	toFloatSamples := func(samples []RefHistogramSample) []RefFloatHistogramSample {
+		floatSamples := make([]RefFloatHistogramSample, 0, len(samples))
+		for _, sample := range samples {
+			floatSamples = append(floatSamples, RefFloatHistogramSample{
+				Ref: sample.Ref,
+				T:   sample.T,
+				FH:  sample.H.ToFloat(nil),
+			})
+		}
+		return floatSamples
+	}
+
+	toExpectedFloatPartitions := func(samples []RefFloatHistogramSample) ([]RefFloatHistogramSample, []RefFloatHistogramSample) {
+		var regularSamples []RefFloatHistogramSample
+		var customSamples []RefFloatHistogramSample
+		for _, sample := range samples {
+			if sample.FH.UsesCustomBuckets() {
+				customSamples = append(customSamples, sample)
+				continue
+			}
+			regularSamples = append(regularSamples, sample)
+		}
+		return regularSamples, customSamples
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := Encoder{}
+
+			intSamples := buildIntSamples(tc.kinds)
+			wantRegularInt, wantCustomInt := toExpectedIntPartitions(intSamples)
+
+			histBuf, customInt := enc.HistogramSamples(intSamples, nil)
+			customBuf := enc.CustomBucketsHistogramSamples(customInt, nil)
+
+			gotRegularInt, err := dec.HistogramSamples(histBuf, nil)
+			require.NoError(t, err)
+			gotCustomInt, err := dec.HistogramSamples(customBuf, nil)
+			require.NoError(t, err)
+
+			require.Equal(t, wantRegularInt, gotRegularInt)
+			require.Equal(t, wantCustomInt, gotCustomInt)
+
+			floatSamples := toFloatSamples(intSamples)
+			wantRegularFloat, wantCustomFloat := toExpectedFloatPartitions(floatSamples)
+
+			floatBuf, customFloat := enc.FloatHistogramSamples(floatSamples, nil)
+			customFloatBuf := enc.CustomBucketsFloatHistogramSamples(customFloat, nil)
+
+			gotRegularFloat, err := dec.FloatHistogramSamples(floatBuf, nil)
+			require.NoError(t, err)
+			gotCustomFloat, err := dec.FloatHistogramSamples(customFloatBuf, nil)
+			require.NoError(t, err)
+
+			require.Equal(t, wantRegularFloat, gotRegularFloat)
+			require.Equal(t, wantCustomFloat, gotCustomFloat)
+		})
+	}
+}
+
+// TestRecord_V2MixedRegularAndCustomBucketHistogram verifies that V2 encodes
+// regular and custom-bucket histograms into a single HistogramSamplesV2 /
+// FloatHistogramSamplesV2 record. V2 drops the V1 split because the on-wire
+// format has no need to preserve backwards compatibility with readers that
+// predate custom buckets.
+func TestRecord_V2HistogramRoundTrip(t *testing.T) {
+	dec := NewDecoder(labels.NewSymbolTable(), promslog.NewNopLogger())
+
+	regularA := &histogram.Histogram{
+		Count:         5,
+		ZeroCount:     2,
+		ZeroThreshold: 0.001,
+		Sum:           18.4,
+		Schema:        1,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: 2},
+			{Offset: 1, Length: 2},
+		},
+		PositiveBuckets: []int64{1, 1, -1, 0},
+	}
+	regularB := &histogram.Histogram{
+		Count:         11,
+		ZeroCount:     4,
+		ZeroThreshold: 0.001,
+		Sum:           35.5,
+		Schema:        1,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: 2},
+			{Offset: 2, Length: 2},
+		},
+		PositiveBuckets: []int64{1, 1, -1, 0},
+		NegativeSpans: []histogram.Span{
+			{Offset: 0, Length: 1},
+			{Offset: 1, Length: 2},
+		},
+		NegativeBuckets: []int64{1, 2, -1},
+	}
+	custom := &histogram.Histogram{
+		Count:         8,
+		ZeroThreshold: 0.001,
+		Sum:           42.0,
+		Schema:        histogram.CustomBucketsSchema,
+		PositiveSpans: []histogram.Span{
+			{Offset: 0, Length: 2},
+			{Offset: 2, Length: 2},
+		},
+		PositiveBuckets: []int64{2, -1, 2, 0},
+		CustomValues:    []float64{0, 2, 4, 6, 8},
+	}
+
+	enc := Encoder{EnableSTStorage: true}
+
+	intSamples := []RefHistogramSample{
+		{Ref: 100, T: 1000, ST: 1000, H: regularA},
+		{Ref: 111, T: 1250, ST: 1000, H: custom},
+		{Ref: 122, T: 1500, ST: 1234, H: regularB},
+	}
+
+	histBuf, leftOver := enc.HistogramSamples(intSamples, nil)
+	require.Nil(t, leftOver, "V2 must not return a separate custom-bucket slice")
+	require.Equal(t, HistogramSamplesV2, dec.Type(histBuf), "V2 must emit a single HistogramSamplesV2 record for mixed inputs")
+
+	gotInt, err := dec.HistogramSamples(histBuf, nil)
+	require.NoError(t, err)
+	require.Equal(t, intSamples, gotInt)
+
+	floatSamples := make([]RefFloatHistogramSample, len(intSamples))
+	for i, s := range intSamples {
+		floatSamples[i] = RefFloatHistogramSample{
+			Ref: s.Ref,
+			T:   s.T,
+			ST:  s.ST,
+			FH:  s.H.ToFloat(nil),
+		}
+	}
+
+	floatBuf, leftOverFloat := enc.FloatHistogramSamples(floatSamples, nil)
+	require.Nil(t, leftOverFloat)
+	require.Equal(t, FloatHistogramSamplesV2, dec.Type(floatBuf), "V2 must emit a single FloatHistogramSamplesV2 record for mixed inputs")
+
+	gotFloat, err := dec.FloatHistogramSamples(floatBuf, nil)
+	require.NoError(t, err)
+	require.Equal(t, floatSamples, gotFloat)
 }
 
 func TestRecord_DecodeInvalidHistogramSchema(t *testing.T) {
@@ -346,6 +727,116 @@ func TestRecord_DecodeInvalidFloatHistogramSchema(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestRecord_DecodeV2UnknownFirstHistogramSchema(t *testing.T) {
+	enc := Encoder{EnableSTStorage: true}
+
+	var output bytes.Buffer
+	logger := promslog.New(&promslog.Config{Writer: &output})
+	dec := NewDecoder(labels.NewSymbolTable(), logger)
+	histograms := []RefHistogramSample{
+		{
+			Ref: 56,
+			ST:  1000,
+			T:   1234,
+			H: &histogram.Histogram{
+				Count:         5,
+				ZeroCount:     2,
+				ZeroThreshold: 0.001,
+				Sum:           18.4,
+				Schema:        -100, // "unknown" schema
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 2},
+					{Offset: 1, Length: 2},
+				},
+				PositiveBuckets: []int64{1, 1, -1, 0},
+			},
+		},
+		{
+			Ref: 42,
+			ST:  1000,
+			T:   5678,
+			H: &histogram.Histogram{
+				Count:         11,
+				ZeroCount:     4,
+				ZeroThreshold: 0.001,
+				Sum:           35.5,
+				Schema:        1,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 2},
+					{Offset: 2, Length: 2},
+				},
+				PositiveBuckets: []int64{1, 1, -1, 0},
+				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 1},
+					{Offset: 1, Length: 2},
+				},
+				NegativeBuckets: []int64{1, 2, -1},
+			},
+		},
+	}
+	histSamples, _ := enc.HistogramSamples(histograms, nil)
+	decHistograms, err := dec.HistogramSamples(histSamples, nil)
+	require.NoError(t, err)
+	require.Equal(t, histograms[1:], decHistograms)
+	// Ensure that the schema ID above is actually unknown. If this fails then
+	// someone started using that value.
+	require.Contains(t, output.String(), "skipping histogram with unknown schema in WAL record")
+}
+
+func TestRecord_DecodeV2UnknownFirstFloatHistogramSchema(t *testing.T) {
+	enc := Encoder{EnableSTStorage: true}
+
+	var output bytes.Buffer
+	logger := promslog.New(&promslog.Config{Writer: &output})
+	dec := NewDecoder(labels.NewSymbolTable(), logger)
+	histograms := []RefFloatHistogramSample{
+		{
+			Ref: 56,
+			ST:  1000,
+			T:   1234,
+			FH: &histogram.FloatHistogram{
+				Count:         5,
+				ZeroCount:     2,
+				ZeroThreshold: 0.001,
+				Sum:           18.4,
+				Schema:        -100,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 2},
+					{Offset: 1, Length: 2},
+				},
+				PositiveBuckets: []float64{1, 1, -1, 0},
+			},
+		},
+		{
+			Ref: 42,
+			ST:  1000,
+			T:   5678,
+			FH: &histogram.FloatHistogram{
+				Count:         11,
+				ZeroCount:     4,
+				ZeroThreshold: 0.001,
+				Sum:           35.5,
+				Schema:        1,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 2},
+					{Offset: 2, Length: 2},
+				},
+				PositiveBuckets: []float64{1, 1, -1, 0},
+				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 1},
+					{Offset: 1, Length: 2},
+				},
+				NegativeBuckets: []float64{1, 2, -1},
+			},
+		},
+	}
+	histSamples, _ := enc.FloatHistogramSamples(histograms, nil)
+	decHistograms, err := dec.FloatHistogramSamples(histSamples, nil)
+	require.NoError(t, err)
+	require.Equal(t, histograms[1:], decHistograms)
+	require.Contains(t, output.String(), "skipping histogram with unknown schema in WAL record")
 }
 
 func TestRecord_DecodeTooHighResolutionHistogramSchema(t *testing.T) {
@@ -597,12 +1088,35 @@ func TestRecord_Type(t *testing.T) {
 			},
 		},
 	}
+	// V1 histogram type recognition (requires EnableSTStorage off).
+	enc = Encoder{}
 	hists, customBucketsHistograms := enc.HistogramSamples(histograms, nil)
 	recordType = dec.Type(hists)
 	require.Equal(t, HistogramSamples, recordType)
 	customBucketsHists := enc.CustomBucketsHistogramSamples(customBucketsHistograms, nil)
 	recordType = dec.Type(customBucketsHists)
 	require.Equal(t, CustomBucketsHistogramSamples, recordType)
+
+	// V2 histogram type recognition.
+	enc = Encoder{EnableSTStorage: true}
+	hists, leftOver := enc.HistogramSamples(histograms, nil)
+	require.Nil(t, leftOver)
+	recordType = dec.Type(hists)
+	require.Equal(t, HistogramSamplesV2, recordType)
+
+	// V2 float-histogram type recognition.
+	floatHistograms := make([]RefFloatHistogramSample, len(histograms))
+	for i, h := range histograms {
+		floatHistograms[i] = RefFloatHistogramSample{
+			Ref: h.Ref,
+			T:   h.T,
+			FH:  h.H.ToFloat(nil),
+		}
+	}
+	floatHists, leftOverFloat := enc.FloatHistogramSamples(floatHistograms, nil)
+	require.Nil(t, leftOverFloat)
+	recordType = dec.Type(floatHists)
+	require.Equal(t, FloatHistogramSamplesV2, recordType)
 
 	recordType = dec.Type(nil)
 	require.Equal(t, Unknown, recordType)

--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -218,7 +218,7 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 			stats.TotalSamples += len(samples)
 			stats.DroppedSamples += len(samples) - len(repl)
 
-		case record.HistogramSamples:
+		case record.HistogramSamples, record.HistogramSamplesV2:
 			histogramSamples, err = dec.HistogramSamples(rec, histogramSamples)
 			if err != nil {
 				return nil, fmt.Errorf("decode histogram samples: %w", err)
@@ -231,7 +231,18 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 				}
 			}
 			if len(repl) > 0 {
-				buf, _ = enc.HistogramSamples(repl, buf)
+				var leftover []record.RefHistogramSample
+				buf, leftover = enc.HistogramSamples(repl, buf)
+				if len(leftover) > 0 {
+					// Flush the exponential-histogram record before
+					// appending the custom-bucket record so they are
+					// written as two separate WAL records.
+					if expEnd := len(buf); expEnd > start {
+						recs = append(recs, buf[start:expEnd])
+						start = expEnd
+					}
+					buf = enc.CustomBucketsHistogramSamples(leftover, buf)
+				}
 			}
 			stats.TotalSamples += len(histogramSamples)
 			stats.DroppedSamples += len(histogramSamples) - len(repl)
@@ -252,7 +263,7 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 			}
 			stats.TotalSamples += len(histogramSamples)
 			stats.DroppedSamples += len(histogramSamples) - len(repl)
-		case record.FloatHistogramSamples:
+		case record.FloatHistogramSamples, record.FloatHistogramSamplesV2:
 			floatHistogramSamples, err = dec.FloatHistogramSamples(rec, floatHistogramSamples)
 			if err != nil {
 				return nil, fmt.Errorf("decode float histogram samples: %w", err)
@@ -265,7 +276,18 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 				}
 			}
 			if len(repl) > 0 {
-				buf, _ = enc.FloatHistogramSamples(repl, buf)
+				var floatLeftover []record.RefFloatHistogramSample
+				buf, floatLeftover = enc.FloatHistogramSamples(repl, buf)
+				if len(floatLeftover) > 0 {
+					// Flush the exponential-float-histogram record before
+					// appending the custom-bucket record so they are
+					// written as two separate WAL records.
+					if expEnd := len(buf); expEnd > start {
+						recs = append(recs, buf[start:expEnd])
+						start = expEnd
+					}
+					buf = enc.CustomBucketsFloatHistogramSamples(floatLeftover, buf)
+				}
 			}
 			stats.TotalSamples += len(floatHistogramSamples)
 			stats.DroppedSamples += len(floatHistogramSamples) - len(repl)

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -332,14 +332,14 @@ func TestCheckpoint(t *testing.T) {
 							require.GreaterOrEqual(t, s.T, last/2, "sample with wrong timestamp")
 						}
 						samplesInCheckpoint += len(samples)
-					case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+					case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
 						histograms, err := dec.HistogramSamples(rec, nil)
 						require.NoError(t, err)
 						for _, h := range histograms {
 							require.GreaterOrEqual(t, h.T, last/2, "histogram with wrong timestamp")
 						}
 						histogramsInCheckpoint += len(histograms)
-					case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+					case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 						floatHistograms, err := dec.FloatHistogramSamples(rec, nil)
 						require.NoError(t, err)
 						for _, h := range floatHistograms {
@@ -382,6 +382,140 @@ func TestCheckpoint(t *testing.T) {
 				require.Equal(t, expectedRefMetadata, metadata)
 			})
 		}
+	}
+}
+
+// TestCheckpointV2HistogramsToV1 verifies that when a WAL contains V2 histogram
+// records (where exponential and custom-bucket histograms are interleaved in a
+// single record) and Checkpoint is asked to re-encode them using the V1 encoder,
+// the custom-bucket histograms returned as leftover by the V1 encoder are not
+// dropped. They must be re-encoded as a separate CustomBuckets(Float)Histogram
+// record in the checkpoint.
+func TestCheckpointV2HistogramsToV1(t *testing.T) {
+	t.Parallel()
+
+	expH := &histogram.Histogram{
+		Count: 5, ZeroCount: 2, ZeroThreshold: 0.001, Sum: 18.4, Schema: 1,
+		PositiveSpans:   []histogram.Span{{Offset: 0, Length: 2}, {Offset: 1, Length: 2}},
+		PositiveBuckets: []int64{1, 1, -1, 0},
+	}
+	cbH := &histogram.Histogram{
+		Count: 5, ZeroCount: 2, ZeroThreshold: 0.001, Sum: 18.4, Schema: histogram.CustomBucketsSchema,
+		PositiveSpans:   []histogram.Span{{Offset: 0, Length: 2}, {Offset: 1, Length: 2}},
+		PositiveBuckets: []int64{1, 1, -1, 0},
+		CustomValues:    []float64{0, 1, 2, 3, 4},
+	}
+
+	dir := t.TempDir()
+
+	encV2 := record.Encoder{EnableSTStorage: true}
+	w, err := NewSize(nil, nil, dir, 128*1024, compression.None)
+	require.NoError(t, err)
+
+	require.NoError(t, w.Log(encV2.Series([]record.RefSeries{
+		{Ref: 0, Labels: labels.FromStrings("a", "b", "c", "exp0")},
+		{Ref: 1, Labels: labels.FromStrings("a", "b", "c", "cb1")},
+		{Ref: 2, Labels: labels.FromStrings("a", "b", "c", "exp2")},
+		{Ref: 3, Labels: labels.FromStrings("a", "b", "c", "cb3")},
+	}, nil)))
+
+	// V2 encoder writes exp and custom-bucket histograms into a single
+	// HistogramSamplesV2 record (interleaved). Verify there is no leftover.
+	histSamples := []record.RefHistogramSample{
+		{Ref: 0, T: 1000, H: expH},
+		{Ref: 1, T: 1000, H: cbH},
+		{Ref: 0, T: 2000, H: expH},
+		{Ref: 1, T: 2000, H: cbH},
+	}
+	histRec, leftover := encV2.HistogramSamples(histSamples, nil)
+	require.Empty(t, leftover, "v2 encoder must not return leftover")
+	require.NoError(t, w.Log(histRec))
+
+	floatHistSamples := make([]record.RefFloatHistogramSample, len(histSamples))
+	for i, h := range histSamples {
+		floatHistSamples[i] = record.RefFloatHistogramSample{
+			Ref: h.Ref + 2, // float series live at refs 2 and 3.
+			T:   h.T,
+			FH:  h.H.ToFloat(nil),
+		}
+	}
+	floatHistRec, floatLeftover := encV2.FloatHistogramSamples(floatHistSamples, nil)
+	require.Empty(t, floatLeftover, "v2 encoder must not return leftover")
+	require.NoError(t, w.Log(floatHistRec))
+
+	require.NoError(t, w.Close())
+
+	_, last, err := Segments(w.Dir())
+	require.NoError(t, err)
+
+	// Re-open so Checkpoint can take a read lock on the directory.
+	w, err = NewSize(nil, nil, dir, 128*1024, compression.None)
+	require.NoError(t, err)
+	t.Cleanup(func() { w.Close() })
+
+	// Run Checkpoint with V1 encoding (enableSTStorage=false) to force the
+	// V1 leftover path in checkpoint.go.
+	stats, err := Checkpoint(promslog.NewNopLogger(), w, 0, last, func(_ chunks.HeadSeriesRef) bool { return true }, 0, false)
+	require.NoError(t, err)
+	require.Equal(t, len(histSamples)+len(floatHistSamples), stats.TotalSamples)
+	require.Zero(t, stats.DroppedSamples, "no histogram samples should be dropped")
+
+	cpDir := CheckpointDir(w.Dir(), last)
+	sr, err := NewSegmentsReader(cpDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { sr.Close() })
+
+	dec := record.NewDecoder(labels.NewSymbolTable(), promslog.NewNopLogger())
+	r := NewReader(sr)
+
+	// For each V1 record type we expect to see exactly 2 samples for a
+	// specific series ref, with the matching UsesCustomBuckets flag.
+	type expectation struct {
+		ref           chunks.HeadSeriesRef
+		usesCB        bool
+		seen, samples int
+	}
+	expects := map[record.Type]*expectation{
+		record.HistogramSamples:                   {ref: 0, usesCB: false},
+		record.CustomBucketsHistogramSamples:      {ref: 1, usesCB: true},
+		record.FloatHistogramSamples:              {ref: 2, usesCB: false},
+		record.CustomBucketsFloatHistogramSamples: {ref: 3, usesCB: true},
+	}
+
+	for r.Next() {
+		rec := r.Record()
+		typ := dec.Type(rec)
+		exp, ok := expects[typ]
+		switch typ {
+		case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+			hs, err := dec.HistogramSamples(rec, nil)
+			require.NoError(t, err)
+			exp.seen++
+			exp.samples += len(hs)
+			for _, h := range hs {
+				require.Equal(t, exp.ref, h.Ref)
+				require.Equal(t, exp.usesCB, h.H.UsesCustomBuckets())
+			}
+		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+			fhs, err := dec.FloatHistogramSamples(rec, nil)
+			require.NoError(t, err)
+			exp.seen++
+			exp.samples += len(fhs)
+			for _, h := range fhs {
+				require.Equal(t, exp.ref, h.Ref)
+				require.Equal(t, exp.usesCB, h.FH.UsesCustomBuckets())
+			}
+		case record.HistogramSamplesV2, record.FloatHistogramSamplesV2:
+			t.Fatalf("unexpected V2 record in V1 checkpoint: %v", typ)
+		default:
+			require.False(t, ok, "unhandled expected type %v", typ)
+		}
+	}
+	require.NoError(t, r.Err())
+
+	for typ, exp := range expects {
+		require.Positive(t, exp.seen, "expected record type %v in checkpoint", typ)
+		require.Equal(t, 2, exp.samples, "expected 2 samples in record type %v", typ)
 	}
 }
 

--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -588,7 +588,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			}
 			w.writer.AppendExemplars(exemplars)
 
-		case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+		case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
 			// Skip if "native histograms over remote write" is not enabled.
 			if !w.sendHistograms {
 				break
@@ -618,7 +618,7 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 				w.writer.AppendHistograms(histogramsToSend)
 			}
 
-		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 			// Skip if "native histograms over remote write" is not enabled.
 			if !w.sendHistograms {
 				break

--- a/util/testrecord/record.go
+++ b/util/testrecord/record.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
 )
@@ -80,6 +81,127 @@ func GenTestRefSamplesCase(t testing.TB, c RefSamplesCase) []record.RefSample {
 	}
 	return ret
 }
+
+// HistSTCase selects the start-time pattern for histogram test data generators.
+type HistSTCase string
+
+const (
+	HistNoST       HistSTCase = "no-st"
+	HistConstST    HistSTCase = "const-st"
+	HistPrevTST    HistSTCase = "prevt-st"
+	HistVariableST HistSTCase = "var-st"
+)
+
+// HistSTCases is the standard set of histogram ST cases for benchmarks.
+var HistSTCases = []HistSTCase{HistNoST, HistConstST, HistPrevTST, HistVariableST}
+
+// applyHistST sets the ST field on histogram samples according to the given case.
+func applyHistST(out []record.RefHistogramSample, stCase HistSTCase) {
+	switch stCase {
+	case HistNoST:
+		// Nothing to do.
+	case HistConstST:
+		for i := range out {
+			out[i].ST = 1709000000
+		}
+	case HistPrevTST:
+		for i := range out {
+			if i == 0 {
+				continue
+			}
+			out[i].ST = out[i-1].T
+		}
+	case HistVariableST:
+		for i := range out {
+			out[i].ST = highVarianceInt(i+1) / 1024
+		}
+	}
+}
+
+// GenExpHistograms generates n standard exponential histograms (schema=1)
+// with incrementing refs, same timestamp, and realistic bucket distributions.
+// The stCase parameter controls how the ST field is populated.
+func GenExpHistograms(n int, stCase HistSTCase) []record.RefHistogramSample {
+	out := make([]record.RefHistogramSample, n)
+	for i := range out {
+		out[i] = record.RefHistogramSample{
+			Ref: chunks.HeadSeriesRef(i),
+			T:   1709000000 + int64(i)*15,
+			H: &histogram.Histogram{
+				Count:         uint64(10 + i%100),
+				ZeroCount:     uint64(1 + i%5),
+				ZeroThreshold: 0.001,
+				Sum:           float64(100+i) * 1.5,
+				Schema:        1,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 4},
+					{Offset: 2, Length: 3},
+				},
+				PositiveBuckets: []int64{1, 2, -1, 0, 3, -2, 1},
+				NegativeSpans: []histogram.Span{
+					{Offset: 0, Length: 2},
+					{Offset: 1, Length: 2},
+				},
+				NegativeBuckets: []int64{1, 1, -1, 0},
+			},
+		}
+	}
+	applyHistST(out, stCase)
+	return out
+}
+
+// GenCustomBucketHistograms generates n custom-bucket (NHCB) histograms (schema=-53)
+// with incrementing refs. The stCase parameter controls how the ST field is populated.
+func GenCustomBucketHistograms(n int, stCase HistSTCase) []record.RefHistogramSample {
+	out := make([]record.RefHistogramSample, n)
+	for i := range out {
+		out[i] = record.RefHistogramSample{
+			Ref: chunks.HeadSeriesRef(i),
+			T:   1709000000 + int64(i)*15,
+			H: &histogram.Histogram{
+				Count:  uint64(10 + i%100),
+				Sum:    float64(100+i) * 1.5,
+				Schema: histogram.CustomBucketsSchema,
+				PositiveSpans: []histogram.Span{
+					{Offset: 0, Length: 8},
+				},
+				PositiveBuckets: []int64{5, -2, 3, -1, 4, 0, -3, 2},
+				CustomValues:    []float64{0.001, 0.01, 0.1, 1, 10, 100, 1000},
+			},
+		}
+	}
+	applyHistST(out, stCase)
+	return out
+}
+
+// GenFloatHistograms converts int histograms to float histograms, preserving ST.
+func GenFloatHistograms(src []record.RefHistogramSample) []record.RefFloatHistogramSample {
+	out := make([]record.RefFloatHistogramSample, len(src))
+	for i, h := range src {
+		out[i] = record.RefFloatHistogramSample{
+			Ref: h.Ref,
+			ST:  h.ST,
+			T:   h.T,
+			FH:  h.H.ToFloat(nil),
+		}
+	}
+	return out
+}
+
+// HistDataCase pairs a name with a histogram generator for benchmark tables.
+type HistDataCase struct {
+	Name string
+	Gen  func(n int, stCase HistSTCase) []record.RefHistogramSample
+}
+
+// HistDataCases is the standard set of histogram data cases for benchmarks.
+var HistDataCases = []HistDataCase{
+	{"exp", GenExpHistograms},
+	{"nhcb", GenCustomBucketHistograms},
+}
+
+// HistCounts is the standard set of histogram counts for benchmarks.
+var HistCounts = []int{10, 100, 1000}
 
 func highVarianceInt(i int) int64 {
 	if i%2 == 0 {


### PR DESCRIPTION
Implements ST for Histograms and Float Histograms (and their custom bucket cousins) in WAL. New tests, new benchmarks. First draft was AI, AI was bad, I rewrote it myself, had AI write the test instead, which found a bug (yay!), fixed it myself. 

Benchmarks:
[encode-hist-benchstat.txt](https://github.com/user-attachments/files/26791684/encode-hist-benchstat.txt)
[decode-hist-benchstat.txt](https://github.com/user-attachments/files/26791682/decode-hist-benchstat.txt)
[encode-fhist-benchstat.txt](https://github.com/user-attachments/files/26791683/encode-fhist-benchstat.txt)
[decode-fhist-benchstat.txt](https://github.com/user-attachments/files/26791681/decode-fhist-benchstat.txt)


Part of https://github.com/prometheus/prometheus/issues/17790 

```release-notes
[CHANGE] Adds Start Time value to all WAL Histogram samples in memory, and therefore may increase memory usage.
```
