### PR TITLE
build: add option to choose which UI to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ DOCKERFILE_ARCH_EXCLUSIONS ?= Dockerfile.distroless:riscv64
 DOCKER_REGISTRY_ARCH_EXCLUSIONS ?= quay.io:riscv64
 
 UI_PATH = web/ui
+BUILD_UI ?= all
 UI_NODE_MODULES_PATH = $(UI_PATH)/node_modules
 REACT_APP_NPM_LICENSES_TARBALL = "npm_licenses.tar.bz2"
 
@@ -63,7 +64,11 @@ ui-install:
 
 .PHONY: ui-build
 ui-build:
+ifeq ($(BUILD_UI),mantine)
+	cd $(UI_PATH) && CI="" npm run build:mantine-ui
+else
 	cd $(UI_PATH) && CI="" npm run build
+endif
 
 .PHONY: ui-build-module
 ui-build-module:

--- a/web/ui/build_ui.sh
+++ b/web/ui/build_ui.sh
@@ -58,5 +58,10 @@ for i in "$@"; do
     buildModule
     shift
     ;;
+  --mantine-ui)
+    buildModule
+    buildMantineUI
+    shift
+    ;;
   esac
 done

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "bash build_ui.sh --all",
+    "build:mantine-ui": "bash build_ui.sh --mantine-ui",
     "build:module": "bash build_ui.sh --build-module",
     "start": "npm run start -w mantine-ui",
     "test": "npm run test --workspaces",


### PR DESCRIPTION
This adds a switch to `web/ui/build_ui.sh` that allows customizing which UI gets build and add plumbing to expose this through the Makefile. It defaults too `--all` so the current build process still provides both UIs.

If build with one UI but run requesting the other (e.g. build with `BUILD_UI=mantine` but run with `--enable-features=old-ui`) the users gets a 404.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
