### PR TITLE
UI: Fix tooltip Y-offset drift for multiple graph panels

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/uPlotChartHelpers.ts
+++ b/web/ui/mantine-ui/src/pages/query/uPlotChartHelpers.ts
@@ -83,8 +83,6 @@ const formatLabels = (labels: { [key: string]: string }): string => `
 
 const tooltipPlugin = (useLocalTime: boolean, data: AlignedData) => {
   let over: HTMLDivElement;
-  let boundingLeft: number;
-  let boundingTop: number;
   let selectedSeriesIdx: number | null = null;
 
   const overlay = document.createElement("div");
@@ -110,12 +108,6 @@ const tooltipPlugin = (useLocalTime: boolean, data: AlignedData) => {
       // When the chart is destroyed, remove the overlay from the DOM.
       destroy: () => {
         overlay.remove();
-      },
-      // When the chart is resized, store the bounding box of the overlay.
-      setSize: () => {
-        const bbox = over.getBoundingClientRect();
-        boundingLeft = bbox.left;
-        boundingTop = bbox.top;
       },
       // When a series is selected by hovering close to it, store the
       // index of the selected series, so we can update the hover tooltip
@@ -150,8 +142,12 @@ const tooltipPlugin = (useLocalTime: boolean, data: AlignedData) => {
         }
         const color = series.stroke(u, selectedSeriesIdx);
 
-        const x = left + boundingLeft;
-        const y = top + boundingTop;
+        // Get the bounding rect fresh on every cursor move to account for
+        // page scrolling, which would otherwise cause a growing Y offset
+        // for charts further down the page.
+        const bbox = over.getBoundingClientRect();
+        const x = left + bbox.left;
+        const y = top + bbox.top;
 
         overlay.innerHTML = `
             <div class="date">${formatTimestamp(ts, useLocalTime)}</div>


### PR DESCRIPTION
`getBoundingClientRect()` was cached in the `setSize` hook, which only fires on chart creation/resize. The cached viewport-relative coordinates became stale after scrolling, causing the tooltip to appear increasingly offset on charts further down the page.

Fixed by calling `getBoundingClientRect()` (which is really fast) on every `setCursor` invocation to always get accurate viewport-relative coordinates.

See before (left) and after (right):

https://github.com/user-attachments/assets/afacb6d9-7908-4e6b-b44b-dcad0e054b33


<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] UI: Fix tooltip Y-offset drift when using multiple graph panels
```