### PR TITLE
textparse: fix parseLVals to only treat quoted strings as metric names

### DIFF
--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -634,11 +634,13 @@ func (p *OpenMetricsParser) parseLVals(offsets []int, isExemplar bool) ([]int, e
 	for {
 		curTStart := p.l.start
 		curTI := p.l.i
+		var isQString bool
 		switch t {
 		case tBraceClose:
 			return offsets, nil
 		case tLName:
 		case tQString:
+			isQString = true
 		default:
 			return nil, p.parseError("expected label name", t)
 		}
@@ -647,7 +649,7 @@ func (p *OpenMetricsParser) parseLVals(offsets []int, isExemplar bool) ([]int, e
 		// A quoted string followed by a comma or brace is a metric name. Set the
 		// offsets and continue processing. If this is an exemplar, this format
 		// is not allowed.
-		if t == tComma || t == tBraceClose {
+		if isQString && (t == tComma || t == tBraceClose) {
 			if isExemplar {
 				return nil, p.parseError("expected label name", t)
 			}

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -942,6 +942,10 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 			err:   "expected label name, got \"=\\\"\" (\"EQUAL\") while parsing: \"empty_label_name{=\\\"\"",
 		},
 		{
+			input: "{A}0\n# EOF\n",
+			err:   "expected equal, got \"}0\" (\"BCLOSE\") while parsing: \"{A}0\"",
+		},
+		{
 			input: "foo 1_2\n\n# EOF\n",
 			err:   "unsupported character in float while parsing: \"foo 1_2\"",
 		},
@@ -971,11 +975,11 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 		},
 		{
 			input: `custom_metric_total 1 # {bb}`,
-			err:   "expected label name, got \"}\" (\"BCLOSE\") while parsing: \"custom_metric_total 1 # {bb}\"",
+			err:   "expected equal, got \"}\" (\"BCLOSE\") while parsing: \"custom_metric_total 1 # {bb}\"",
 		},
 		{
 			input: `custom_metric_total 1 # {bb, a="dd"}`,
-			err:   "expected label name, got \", \" (\"COMMA\") while parsing: \"custom_metric_total 1 # {bb, \"",
+			err:   "expected equal, got \", \" (\"COMMA\") while parsing: \"custom_metric_total 1 # {bb, \"",
 		},
 		{
 			input: `custom_metric_total 1 # {aa="bb",,cc="dd"} 1`,
@@ -1035,6 +1039,22 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 		}
 		require.Equal(t, c.err, err.Error(), "test %d: %s", i, c.input)
 	}
+}
+
+func TestOpenMetricsParseBareIdentifierInBraces(t *testing.T) {
+	require.NotPanics(t, func() {
+		p := NewOpenMetricsParser([]byte("{A} 0\n# EOF\n"), labels.NewSymbolTable(), WithOMParserSTSeriesSkipped())
+		for {
+			et, err := p.Next()
+			if err != nil {
+				break
+			}
+			if et == EntrySeries {
+				var lset labels.Labels
+				p.Labels(&lset)
+			}
+		}
+	})
 }
 
 func TestOMNullByteHandling(t *testing.T) {

--- a/model/textparse/promparse.go
+++ b/model/textparse/promparse.go
@@ -408,11 +408,13 @@ func (p *PromParser) parseLVals() error {
 	for {
 		curTStart := p.l.start
 		curTI := p.l.i
+		var isQString bool
 		switch t {
 		case tBraceClose:
 			return nil
 		case tLName:
 		case tQString:
+			isQString = true
 		default:
 			return p.parseError("expected label name", t)
 		}
@@ -420,7 +422,7 @@ func (p *PromParser) parseLVals() error {
 		t = p.nextToken()
 		// A quoted string followed by a comma or brace is a metric name. Set the
 		// offsets and continue processing.
-		if t == tComma || t == tBraceClose {
+		if isQString && (t == tComma || t == tBraceClose) {
 			if p.offsets[0] != -1 || p.offsets[1] != -1 {
 				return fmt.Errorf("metric name already set while parsing: %q", p.l.b[p.start:p.l.i])
 			}

--- a/model/textparse/promparse_test.go
+++ b/model/textparse/promparse_test.go
@@ -511,6 +511,10 @@ func TestPromParseErrors(t *testing.T) {
 			err:   "expected label name, got \"=\\\"\" (\"EQUAL\") while parsing: \"empty_label_name{=\\\"\"",
 		},
 		{
+			input: "{A}0",
+			err:   "expected equal, got \"}0\" (\"BCLOSE\") while parsing: \"{A}0\"",
+		},
+		{
 			input: "foo 1_2\n",
 			err:   "unsupported character in float while parsing: \"foo 1_2\"",
 		},
@@ -548,6 +552,22 @@ func TestPromParseErrors(t *testing.T) {
 		}
 		require.EqualError(t, err, c.err, "test %d", i)
 	}
+}
+
+func TestPromParseBareIdentifierInBraces(t *testing.T) {
+	require.NotPanics(t, func() {
+		p := NewPromParser([]byte("{A} 0\n"), labels.NewSymbolTable(), false)
+		for {
+			et, err := p.Next()
+			if err != nil {
+				break
+			}
+			if et == EntrySeries {
+				var lset labels.Labels
+				p.Labels(&lset)
+			}
+		}
+	})
 }
 
 func TestPromNullByteHandling(t *testing.T) {


### PR DESCRIPTION
When a label-name position is followed by comma or brace-close, only treat it as a metric name shorthand if the token was a double-quoted string (tQString). Bare identifiers must be followed by an equal sign.

Add tests for bare identifier inputs that previously could panic.

Fixes #18225 

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] scrape: Fix panic when parsing bare label names without an equal sign in brace-only metric notation.
```
