### PR TITLE
UI: Skip recomputing stacked chart data on hover

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/uPlotStackHelpers.ts
+++ b/web/ui/mantine-ui/src/pages/query/uPlotStackHelpers.ts
@@ -85,14 +85,16 @@ export function setStackedOpts(opts: uPlot.Options, data: uPlot.AlignedData) {
     },
   };
 
-  // restack on toggle
+  // restack on toggle (but not on focus/hover)
   opts.hooks = opts.hooks || {};
   opts.hooks.setSeries = opts.hooks.setSeries || [];
-  opts.hooks.setSeries.push((u, _i) => {
-    const stacked = stack(data, (i) => !u.series[i].show);
-    u.delBand(null);
-    stacked.bands.forEach((b) => u.addBand(b));
-    u.setData(stacked.data);
+  opts.hooks.setSeries.push((u, _i, opts) => {
+    if (opts.show != null) {
+      const stacked = stack(data, (i) => !u.series[i].show);
+      u.delBand(null);
+      stacked.bands.forEach((b) => u.addBand(b));
+      u.setData(stacked.data);
+    }
   });
 
   return { opts, data: stacked.data };


### PR DESCRIPTION
See https://github.com/leeoniya/uPlot/issues/988

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[PERF] UI: Skip restacking on hover in stacked series charts
```