### PR TITLE
histograms: BenchmarkFloatHistogramAdd

### DIFF
--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -4420,13 +4420,10 @@ func BenchmarkFloatHistogramDetectReset(b *testing.B) {
 
 func BenchmarkFloatHistogramAdd(b *testing.B) {
 	var (
-		rng = rand.New(rand.NewSource(0))
-
+		rng           = rand.New(rand.NewSource(0))
 		numHistograms = 120
-
-		err error
-
-		fhs = make([]*FloatHistogram, 0, numHistograms)
+		err           error
+		fhs           = make([]*FloatHistogram, 0, numHistograms)
 	)
 
 	for range numHistograms {


### PR DESCRIPTION
Mainly for demonstrating the difference between `FloatHistogram.Add` and `FloatHistogram.KahanAdd`.
```
BenchmarkFloatHistogramAdd/Add
BenchmarkFloatHistogramAdd/Add-10         	   64574	     18312 ns/op	       0 B/op	       0 allocs/op
BenchmarkFloatHistogramAdd/KahanAdd
BenchmarkFloatHistogramAdd/KahanAdd-10    	   30944	     38313 ns/op	     800 B/op	       3 allocs/op
```

```release-notes
NONE
```
