### PR TITLE
perf(PromQL): improve performance of FloatHistogram.KahanAdd

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -465,16 +465,14 @@ func (h *FloatHistogram) KahanAdd(other, c *FloatHistogram) (updatedC *FloatHist
 		return c, counterResetCollision, nhcbBoundsReconciled, nil
 	}
 
-	otherC := other.newCompensationHistogram()
-
 	var (
 		hNegativeSpans        = h.NegativeSpans
 		hNegativeBuckets      = h.NegativeBuckets
 		otherNegativeSpans    = other.NegativeSpans
 		otherNegativeBuckets  = other.NegativeBuckets
 		cNegativeBuckets      = c.NegativeBuckets
-		otherCPositiveBuckets = otherC.PositiveBuckets
-		otherCNegativeBuckets = otherC.NegativeBuckets
+		otherCPositiveBuckets []float64
+		otherCNegativeBuckets []float64
 	)
 
 	switch {
@@ -492,16 +490,22 @@ func (h *FloatHistogram) KahanAdd(other, c *FloatHistogram) (updatedC *FloatHist
 		h.Schema = other.Schema
 
 	case other.Schema > h.Schema:
-		otherPositiveSpans, otherPositiveBuckets, otherCPositiveBuckets = kahanReduceResolution(
-			otherPositiveSpans, otherPositiveBuckets, otherCPositiveBuckets,
-			other.Schema, h.Schema,
-			false,
-		)
-		otherNegativeSpans, otherNegativeBuckets, otherCNegativeBuckets = kahanReduceResolution(
-			otherNegativeSpans, otherNegativeBuckets, otherCNegativeBuckets,
-			other.Schema, h.Schema,
-			false,
-		)
+		if len(otherPositiveBuckets) > 0 {
+			otherCPositiveBuckets = make([]float64, len(otherPositiveBuckets))
+			otherPositiveSpans, otherPositiveBuckets, otherCPositiveBuckets = kahanReduceResolution(
+				otherPositiveSpans, otherPositiveBuckets, otherCPositiveBuckets,
+				other.Schema, h.Schema,
+				false,
+			)
+		}
+		if len(otherNegativeBuckets) > 0 {
+			otherCNegativeBuckets = make([]float64, len(otherNegativeBuckets))
+			otherNegativeSpans, otherNegativeBuckets, otherCNegativeBuckets = kahanReduceResolution(
+				otherNegativeSpans, otherNegativeBuckets, otherCNegativeBuckets,
+				other.Schema, h.Schema,
+				false,
+			)
+		}
 	}
 
 	h.PositiveSpans, h.PositiveBuckets, c.PositiveBuckets = kahanAddBuckets(
@@ -1600,7 +1604,9 @@ func kahanAddBuckets(
 				} else if spansA[0].Offset == indexB {
 					// Just add to first bucket.
 					bucketsA[0], compensationBucketsA[0] = kahansum.Inc(bucketB, bucketsA[0], compensationBucketsA[0])
-					bucketsA[0], compensationBucketsA[0] = kahansum.Inc(compensationBucketB, bucketsA[0], compensationBucketsA[0])
+					if compensationBucketB != 0 {
+						bucketsA[0], compensationBucketsA[0] = kahansum.Inc(compensationBucketB, bucketsA[0], compensationBucketsA[0])
+					}
 					goto nextLoop
 				}
 				iSpan, iBucket, iInSpan = 0, 0, 0
@@ -1614,7 +1620,9 @@ func kahanAddBuckets(
 					iBucket += int(deltaIndex)
 					iInSpan += deltaIndex
 					bucketsA[iBucket], compensationBucketsA[iBucket] = kahansum.Inc(bucketB, bucketsA[iBucket], compensationBucketsA[iBucket])
-					bucketsA[iBucket], compensationBucketsA[iBucket] = kahansum.Inc(compensationBucketB, bucketsA[iBucket], compensationBucketsA[iBucket])
+					if compensationBucketB != 0 {
+						bucketsA[iBucket], compensationBucketsA[iBucket] = kahansum.Inc(compensationBucketB, bucketsA[iBucket], compensationBucketsA[iBucket])
+					}
 					break
 				}
 				deltaIndex -= remainingInSpan


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #18249 (partially)

This line allocates a new histogram (with new bucket slices) on every `KahanAdd` invocation:
https://github.com/prometheus/prometheus/blob/7cb405bad4edb51584f01c50d9a1a7fa1f2cbc39/model/histogram/float_histogram.go#L468

However, the bucket values in this histogram are initialized to 0:
https://github.com/prometheus/prometheus/blob/7cb405bad4edb51584f01c50d9a1a7fa1f2cbc39/model/histogram/float_histogram.go#L2038

And they are never set to non-zero values, except (potentially) when reducing the resolution of `other` histogram:
https://github.com/prometheus/prometheus/blob/7cb405bad4edb51584f01c50d9a1a7fa1f2cbc39/model/histogram/float_histogram.go#L495-L504

Therefore, we can avoid allocating `otherC` histogram, and only allocate `otherCPositiveBuckets` and/or `otherCNegativeBuckets` in case `other` histogram gets its resolution reduced (which is what this PR does).

Benchmark (using https://github.com/prometheus/prometheus/pull/18248) results:
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/histogram
cpu: Apple M1 Pro
                              │ before.txt  │              after.txt              │
                              │   sec/op    │   sec/op     vs base                │
FloatHistogramAdd/KahanAdd-10   46.67µ ± 1%   36.10µ ± 2%  -22.65% (p=0.000 n=10)

                              │  before.txt  │             after.txt              │
                              │     B/op     │    B/op     vs base                │
FloatHistogramAdd/KahanAdd-10   29904.0 ± 0%   800.0 ± 0%  -97.32% (p=0.000 n=10)

                              │  before.txt  │             after.txt              │
                              │  allocs/op   │ allocs/op   vs base                │
FloatHistogramAdd/KahanAdd-10   241.000 ± 0%   3.000 ± 0%  -98.76% (p=0.000 n=10)
```
Note that with this change `KahanAdd` is still ~2 times slower than a plain `Add`. I believe this could be optimized more aggressively by only doing a local Kahan compensation in `kahanReduceResolution` for `other` histogram. This would allow simplifying `kahanAddBuckets` (dropping `compensationBucketsB` argument and related code). But, as that might involve some precision tradeoffs, I would leave it for a separate change.

#### Does this PR introduce a user-facing change?

```release-notes
[PERF] PromQL: partially address performance regression in native histogram aggregations due to using `KahanAdd`.
```
