### PR TITLE
discovery/file: restore atomic file writes in tests

### DIFF
--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -69,25 +69,55 @@ func (t *testRunner) copyFile(src string) string {
 	return t.copyFileTo(src, filepath.Base(src))
 }
 
-// copyFileTo copies a file with a different name to the runner's directory.
+// copyFileTo atomically copies a file with a different name to the runner's directory.
 func (t *testRunner) copyFileTo(src, name string) string {
 	t.Helper()
 
-	newf, err := os.ReadFile(src)
+	content, err := os.ReadFile(src)
 	require.NoError(t, err)
 
 	dst := filepath.Join(t.dir, name)
-	// Use os.WriteFile to avoid an os.Rename race condition on Windows.
-	require.NoError(t, os.WriteFile(dst, newf, 0o644))
+	t.atomicWrite(dst, content)
 
 	return dst
 }
 
-// writeString writes a string to a file.
+// writeString atomically writes a string to a file.
 func (t *testRunner) writeString(file, data string) {
 	t.Helper()
-	// Use os.WriteFile to avoid an os.Rename race condition on Windows.
-	require.NoError(t, os.WriteFile(file, []byte(data), 0o644))
+	t.atomicWrite(file, []byte(data))
+}
+
+// atomicWrite writes data to dst atomically by writing to a temporary file
+// and renaming it. The temp file is created outside the watched directory to
+// avoid triggering spurious fsnotify events that could cause readFile to hold
+// an open handle on dst (which would make os.Rename fail on Windows).
+func (t *testRunner) atomicWrite(dst string, data []byte) {
+	t.Helper()
+
+	// Create the temp file via t.TempDir() rather than in t.dir (the watched
+	// directory). t.TempDir() returns a fresh directory on the same filesystem
+	// as t.dir, so os.Rename works, and cleanup is handled by the test framework.
+	tmp, err := os.CreateTemp(t.TempDir(), ".sd-test-*")
+	require.NoError(t, err)
+
+	_, err = tmp.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	// On Windows, os.Rename fails if another process holds an open handle
+	// on dst. This can happen if a previous refresh cycle's readFile call
+	// hasn't released the file yet. Retry a few times to handle this;
+	// on Linux/macOS os.Rename always succeeds regardless, so the retry
+	// never triggers.
+	for retries := 0; ; retries++ {
+		err = os.Rename(tmp.Name(), dst)
+		if err == nil || retries >= 5 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NoError(t, err)
 }
 
 // appendString appends a string to a file.


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18237

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```

---

**Root cause:**

PR #17269 replaced atomic `os.Rename`-based file writes in the test helpers with `os.WriteFile` to fix a Windows flake. However, `os.WriteFile` is not atomic (it truncates then writes), and `fsnotify` can fire between the truncate and write, causing the watcher to read an empty file. Since `yaml.UnmarshalStrict` returns no error for empty content, `readFile()` succeeds with 0 target groups, and `refresh()` sends empty target groups that replace the previously valid ones.

This matches the CI failure output exactly: `[{"targets":[]},{"targets":[]}]`.

**Fix:**

Restore atomic file writes in the test helpers using temp file + `os.Rename`. The temp file is created in `os.TempDir()` (outside the watched directory) to avoid triggering spurious `fsnotify` events that could cause `readFile` to hold an open handle on the destination file (which would make `os.Rename` fail on Windows). A small retry loop on `os.Rename` is included as a safety net for the rare case where a previous refresh cycle hasn't released the file handle yet. On Linux/macOS, `os.Rename` succeeds regardless of open handles, so the retry never triggers.