### PR TITLE
Document default values of min/max retention time for agent mode (#18233)

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -537,11 +537,11 @@ func main() {
 
 	agentOnlyFlag(a, "storage.agent.retention.min-time",
 		"Minimum age samples may be before being considered for deletion when the WAL is truncated").
-		SetValue(&cfg.agent.MinWALTime)
+		Default("5min").SetValue(&cfg.agent.MinWALTime)
 
 	agentOnlyFlag(a, "storage.agent.retention.max-time",
 		"Maximum age samples may be before being forcibly deleted when the WAL is truncated").
-		SetValue(&cfg.agent.MaxWALTime)
+		Default("4hours").SetValue(&cfg.agent.MaxWALTime)
 
 	agentOnlyFlag(a, "storage.agent.no-lockfile", "Do not create lockfile in data directory.").
 		Default("false").BoolVar(&cfg.agent.NoLockfile)


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

**Description:**
This PR documents the default values for `storage.agent.retention.min-time` and `storage.agent.retention.max-time` by adding `.Default()` configurations to the Kingpin flags in [cmd/prometheus/main.go]
Previously, these flags had underlying defaults defined in [tsdb/agent/db.go], but they were not visible to the user when running `prometheus --help`.

#### Which issue(s) does the PR fix:
Fixes #18233

#### Does this PR introduce a user-facing change?
```release-notes
[BUGFIX] agent: Ensure default values for `storage.agent.retention.min-time` and `storage.agent.retention.max-time` flags are documented in the CLI help output
