### PR TITLE
docs: Fix typos and improve comments

### DIFF
--- a/storage/remote/write_otlp_handler_test.go
+++ b/storage/remote/write_otlp_handler_test.go
@@ -224,7 +224,7 @@ func TestOTLPWriteHandler(t *testing.T) {
 				TranslationStrategy: otlptranslator.NoUTF8EscapingWithSuffixes,
 			},
 			expectedLabelsAndMFs: []sample{
-				// TODO: Counter MF name looks likea bug. Uncovered in unrelated refactor. fix it.
+				// TODO: Counter MF name looks like a bug. Uncovered in unrelated refactor. fix it.
 				{MF: "test.counter_bytes_total", L: labels.FromStrings(model.MetricNameLabel, "test.counter_bytes_total", "foo.bar", "baz", "instance", "test-instance", "job", "test-service")},
 				{MF: "test.gauge_bytes", L: labels.FromStrings(model.MetricNameLabel, "test.gauge_bytes", "foo.bar", "baz", "instance", "test-instance", "job", "test-service")},
 				{MF: "test.histogram_bytes", L: labels.FromStrings(model.MetricNameLabel, "test.histogram_bytes_sum", "foo.bar", "baz", "instance", "test-instance", "job", "test-service")},

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -887,7 +887,7 @@ func (it *floatHistogramIterator) AtFloatHistogram(fh *histogram.FloatHistogram)
 			if err := fh.ReduceResolution(histogram.ExponentialSchemaMax); err != nil {
 				// With the checks above, this can only happen
 				// with invalid data in a chunk. As this is a
-				// rare edge case of a rare edge case, we'd
+				// rare edge case nested within a rare edge case, we'd
 				// rather not create all the plumbing to handle
 				// this error gracefully.
 				panic(err)

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -942,7 +942,7 @@ func (it *histogramIterator) AtHistogram(h *histogram.Histogram) (int64, *histog
 			if err := h.ReduceResolution(histogram.ExponentialSchemaMax); err != nil {
 				// With the checks above, this can only happen
 				// with invalid data in a chunk. As this is a
-				// rare edge case of a rare edge case, we'd
+				// rare edge case nested within a rare edge case, we'd
 				// rather not create all the plumbing to handle
 				// this error gracefully.
 				panic(err)
@@ -1016,7 +1016,7 @@ func (it *histogramIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int
 			if err := fh.ReduceResolution(histogram.ExponentialSchemaMax); err != nil {
 				// With the checks above, this can only happen
 				// with invalid data in a chunk. As this is a
-				// rare edge case of a rare edge case, we'd
+				// rare edge case nested within a rare edge case, we'd
 				// rather not create all the plumbing to handle
 				// this error gracefully.
 				panic(err)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -2231,7 +2231,7 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 	return count
 }
 
-// TODO(bwplotka): Propagate errors correctly, even when they are async. Panicking here do occurs from time to time
+// TODO(bwplotka): Propagate errors correctly, even when they are async. Panicking here does occur from time to time
 // and cause flaky tests with hidden root cause (unlocked mutexes when deferred closing).
 // We didn't have evidences of prod impact though, yet.
 func handleChunkWriteError(err error) {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
None

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```

Fix typos in comments and error messages:
- `looks likea` → `looks like a` 
- `do occurs` → `does occur`
- Improve phrasing in histogram chunk tests
