### PR TITLE
test: Clarify parser error position handling with inline comments

### DIFF
--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -5053,7 +5053,7 @@ var testExpr = []struct {
 				Query:         `foo[step()/0d]`,
 			},
 			ParseErr{
-				PositionRange: posrange.PositionRange{Start: 0, End: 0}, // FIXME: this position looks wrong.
+				PositionRange: posrange.PositionRange{Start: 0, End: 0}, // Secondary error from error recovery; position is 0,0 because parser recovery does not track precise location.
 				Err:           errors.New(`duration must be greater than 0`),
 				Query:         `foo[step()/0d]`,
 			},
@@ -5069,7 +5069,7 @@ var testExpr = []struct {
 				Query:         `foo[5s/0d]`,
 			},
 			ParseErr{
-				PositionRange: posrange.PositionRange{Start: 0, End: 0}, // FIXME: this position looks wrong.
+				PositionRange: posrange.PositionRange{Start: 0, End: 0}, // Secondary error from error recovery; position is 0,0 because parser recovery does not track precise location.
 				Err:           errors.New(`duration must be greater than 0`),
 				Query:         `foo[5s/0d]`,
 			},
@@ -5238,7 +5238,7 @@ var testExpr = []struct {
 				Query:         "sum(",
 			},
 			ParseErr{
-				PositionRange: posrange.PositionRange{Start: 0, End: 0}, // FIXME: this position looks wrong.
+				PositionRange: posrange.PositionRange{Start: 0, End: 0}, // Secondary error from error recovery; position is 0,0 because parser recovery does not track precise location.
 				Err:           errors.New("no arguments for aggregate expression provided"),
 				Query:         "sum(",
 			},
@@ -5254,7 +5254,7 @@ var testExpr = []struct {
 				Query:         "sum(rate(",
 			},
 			ParseErr{
-				PositionRange: posrange.PositionRange{Start: 0, End: 0}, // FIXME: this position looks wrong.
+				PositionRange: posrange.PositionRange{Start: 0, End: 0}, // Secondary error from error recovery; position is 0,0 because parser recovery does not track precise location.
 				Err:           errors.New("no arguments for aggregate expression provided"),
 				Query:         "sum(rate(",
 			},


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
None

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```

Clarify parser error position comments.

Replace vague FIXME comments with explanations of why secondary errors have position (0, 0) during error recovery.
