### PR TITLE
feat(promtool): print test filename during promtool tests

### DIFF
--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -61,6 +61,7 @@ func RulesUnitTestResult(results io.Writer, queryOpts promqltest.LazyLoaderOpts,
 	}
 
 	for _, f := range files {
+		fmt.Printf("Processing test file: %s\n", f)
 		if errs := ruleUnitTest(f, queryOpts, p, run, diffFlag, debug, ignoreUnknownFields, junit.Suite(f)); errs != nil {
 			fmt.Fprintln(os.Stderr, "  FAILED:")
 			for _, e := range errs {


### PR DESCRIPTION
The current behaviour of `promtool tests` when tests pass is just to print 'SUCCESS' to the terminal for each input file or if a test fails a bit more output around the failure.

However, in the case of running something like:`promtool test rules tests/**/*.yaml` this isn't very helpful or useful
output.

Instead print the test file that is being executed in the file loop.

#### Which issue(s) does the PR fix:

N/A

#### Does this PR introduce a user-facing change?

```release-notes
[FEATURE] Promtool: print test filename during promtool tests
```
