### PR TITLE
Support multi-document YAML rule files

### DIFF
--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -339,6 +339,7 @@ func testTemplateParsing(rl *Rule) (errs []error) {
 }
 
 // Parse parses and validates a set of rules.
+// It supports multi-document YAML files where documents are separated by "---".
 func Parse(content []byte, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme, p parser.Parser) (*RuleGroups, []error) {
 	var (
 		groups RuleGroups
@@ -346,18 +347,37 @@ func Parse(content []byte, ignoreUnknownFields bool, nameValidationScheme model.
 		errs   []error
 	)
 
+	// Decode typed rule groups from all YAML documents.
 	decoder := yaml.NewDecoder(bytes.NewReader(content))
 	if !ignoreUnknownFields {
 		decoder.KnownFields(true)
 	}
-	err := decoder.Decode(&groups)
-	// Ignore io.EOF which happens with empty input.
-	if err != nil && !errors.Is(err, io.EOF) {
-		errs = append(errs, err)
+	for {
+		var doc RuleGroups
+		err := decoder.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			errs = append(errs, err)
+			break
+		}
+		groups.Groups = append(groups.Groups, doc.Groups...)
 	}
-	err = yaml.Unmarshal(content, &node)
-	if err != nil {
-		errs = append(errs, err)
+
+	// Decode node-based rule groups from all YAML documents.
+	nodeDecoder := yaml.NewDecoder(bytes.NewReader(content))
+	for {
+		var doc ruleGroups
+		err := nodeDecoder.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			errs = append(errs, err)
+			break
+		}
+		node.Groups = append(node.Groups, doc.Groups...)
 	}
 
 	if len(errs) > 0 {

--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -40,6 +40,40 @@ func TestParseFileSuccess(t *testing.T) {
 	require.Empty(t, errs, "unexpected errors parsing file")
 }
 
+func TestParseFileSuccessMultiDocument(t *testing.T) {
+	rgs, errs := ParseFile("testdata/multi_doc.good.yaml", false, model.UTF8Validation, testParser)
+	require.Empty(t, errs, "unexpected errors parsing file")
+	require.Len(t, rgs.Groups, 2)
+	require.Equal(t, "my-group-name", rgs.Groups[0].Name)
+	require.Equal(t, "my-second-group", rgs.Groups[1].Name)
+	require.Len(t, rgs.Groups[0].Rules, 1)
+	require.Equal(t, "HighErrors", rgs.Groups[0].Rules[0].Alert)
+	require.Len(t, rgs.Groups[1].Rules, 1)
+	require.Equal(t, "new_metric", rgs.Groups[1].Rules[0].Record)
+}
+
+func TestParseMultiDocumentInline(t *testing.T) {
+	content := []byte(`groups:
+  - name: group-one
+    rules:
+      - record: metric_one
+        expr: up
+---
+groups:
+  - name: group-two
+    rules:
+      - record: metric_two
+        expr: up
+`)
+	rgs, errs := Parse(content, false, model.UTF8Validation, testParser)
+	require.Empty(t, errs, "unexpected errors parsing multi-document YAML")
+	require.Len(t, rgs.Groups, 2)
+	require.Equal(t, "group-one", rgs.Groups[0].Name)
+	require.Equal(t, "group-two", rgs.Groups[1].Name)
+	require.Equal(t, "metric_one", rgs.Groups[0].Rules[0].Record)
+	require.Equal(t, "metric_two", rgs.Groups[1].Rules[0].Record)
+}
+
 func TestParseFileSuccessWithAliases(t *testing.T) {
 	exprString := `sum without(instance) (rate(errors_total[5m]))
 /

--- a/model/rulefmt/testdata/multi_doc.good.yaml
+++ b/model/rulefmt/testdata/multi_doc.good.yaml
@@ -1,0 +1,20 @@
+groups:
+  - name: my-group-name
+    rules:
+      - alert: HighErrors
+        expr: |
+          sum without(instance) (rate(errors_total[5m]))
+          /
+          sum without(instance) (rate(requests_total[5m]))
+        for: 5m
+        labels:
+          severity: critical
+---
+groups:
+  - name: my-second-group
+    rules:
+      - record: new_metric
+        expr: |
+          sum without(instance) (rate(errors_total[5m]))
+          /
+          sum without(instance) (rate(requests_total[5m]))


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #15834

#### Does this PR introduce a user-facing change?
```release-notes
[BUGFIX] Rules: Support multi-document YAML files in rule file parsing, allowing rule groups separated by `---` in a single file.
```

### Summary
- Modified `Parse` function to iterate over all YAML documents using `yaml.NewDecoder` loop
- Both typed and node-based decoders now loop until EOF, accumulating rule groups
- Added tests for multi-document parsing

### Test plan
- Existing tests pass
- New tests verify multi-document YAML parsing works