### PR TITLE
tsdb: fix goroutine leaks when Open() fails on corrupt data

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -274,7 +274,13 @@ func NewChunkDiskMapper(reg prometheus.Registerer, dir string, pool chunkenc.Poo
 		m.pool = chunkenc.NewPool()
 	}
 
-	return m, m.openMMapFiles()
+	if err := m.openMMapFiles(); err != nil {
+		if m.writeQueue != nil {
+			m.writeQueue.stop()
+		}
+		return nil, err
+	}
+	return m, nil
 }
 
 // Chunk encodings for out-of-order chunks.

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -278,6 +278,7 @@ func NewChunkDiskMapper(reg prometheus.Registerer, dir string, pool chunkenc.Poo
 		if m.writeQueue != nil {
 			m.writeQueue.stop()
 		}
+		err = errors.Join(err, m.dir.Close())
 		return nil, err
 	}
 	return m, nil

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -989,6 +989,12 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 			}
 		}
 
+		// db.Close() short-circuits once db.donec is closed below, so release
+		// the lockfile here to ensure it is always released on error.
+		if db.locker != nil {
+			returnedErr = errors.Join(returnedErr, db.locker.Release())
+		}
+
 		close(db.donec) // DB is never run if it was an error, so close this channel here.
 		if err := db.Close(); err != nil {
 			returnedErr = errors.Join(returnedErr, fmt.Errorf("close DB after failed startup: %w", err))

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -958,6 +958,8 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 		}
 	}
 
+	var wal, wbl *wlog.WL
+
 	db := &DB{
 		dir:            dir,
 		logger:         l,
@@ -974,6 +976,17 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 		// Close files if startup fails somewhere.
 		if returnedErr == nil {
 			return
+		}
+
+		// If head was never initialized, WAL/WBL goroutines need explicit
+		// cleanup since db.Close() -> head.Close() won't reach them.
+		if db.head == nil {
+			if wal != nil {
+				returnedErr = errors.Join(returnedErr, wal.Close())
+			}
+			if wbl != nil {
+				returnedErr = errors.Join(returnedErr, wbl.Close())
+			}
 		}
 
 		close(db.donec) // DB is never run if it was an error, so close this channel here.
@@ -1033,7 +1046,6 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 		db.fsSizeFunc = opts.FsSizeFunc
 	}
 
-	var wal, wbl *wlog.WL
 	segmentSize := wlog.DefaultSegmentSize
 	// Wal is enabled.
 	if opts.WALSegmentSize >= 0 {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3488,13 +3488,7 @@ func TestNoGoroutineLeakOnTSDBOpenError(t *testing.T) {
 	// Verify that no goroutines were leaked. Without proper cleanup,
 	// wlog.(*WL).run and chunks.(*chunkWriteQueue).start.func1 goroutines
 	// would remain running after the failed Open().
-	goleak.VerifyNone(t,
-		goleak.IgnoreTopFunction("github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func1"),
-		goleak.IgnoreTopFunction("github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func2"),
-		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
-		goleak.IgnoreTopFunction("testing.(*T).Run"),
-		goleak.IgnoreTopFunction("testing.tRunner"),
-	)
+	goleak.VerifyNone(t)
 }
 
 func TestLockfile(t *testing.T) {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3461,6 +3461,42 @@ func TestNoPanicOnTSDBOpenError(t *testing.T) {
 	require.NoError(t, l.Release())
 }
 
+func TestNoGoroutineLeakOnTSDBOpenError(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a WAL directory with a valid segment so that wlog.NewSize() succeeds
+	// and starts its run() goroutine.
+	walDir := filepath.Join(dir, "wal")
+	require.NoError(t, os.MkdirAll(walDir, 0o777))
+	w, err := wlog.NewSize(nil, nil, walDir, 32768, compression.None)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	// Create a corrupt chunks_head file with an invalid magic number.
+	// This will cause NewChunkDiskMapper.openMMapFiles() to fail,
+	// which in turn causes NewHead() to fail.
+	chunksDir := filepath.Join(dir, "chunks_head")
+	require.NoError(t, os.MkdirAll(chunksDir, 0o777))
+	require.NoError(t, os.WriteFile(filepath.Join(chunksDir, "000001"), []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x00, 0x00, 0x00}, 0o666))
+
+	opts := DefaultOptions()
+	opts.HeadChunksWriteQueueSize = 1000
+
+	_, err = Open(dir, nil, nil, opts, nil)
+	require.Error(t, err)
+
+	// Verify that no goroutines were leaked. Without proper cleanup,
+	// wlog.(*WL).run and chunks.(*chunkWriteQueue).start.func1 goroutines
+	// would remain running after the failed Open().
+	goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func1"),
+		goleak.IgnoreTopFunction("github.com/prometheus/prometheus/tsdb.(*SegmentWAL).cut.func2"),
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreTopFunction("testing.(*T).Run"),
+		goleak.IgnoreTopFunction("testing.tRunner"),
+	)
+}
+
 func TestLockfile(t *testing.T) {
 	tsdbutil.TestDirLockerUsage(t, func(t *testing.T, data string, createLock bool) (*tsdbutil.DirLocker, testutil.Closer) {
 		opts := DefaultOptions()


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Reported by https://github.com/grafana/mimir/pull/14672.

#### Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] TSDB: Fix goroutine and file handle leaks when `tsdb.Open()` fails on corrupt `chunks_head` data.
```

When `tsdb.Open()` fails due to corrupt `chunks_head` files, several resources started before the failure were never cleaned up:

- `NewChunkDiskMapper` starts a `writeQueue` goroutine and opens the `chunks_head` directory handle. If `openMMapFiles()` fails, the mapper is discarded by `NewHead`; the goroutine keeps running and the directory handle stays open (on Windows this prevents directory removal).
- WAL/WBL goroutines are started before `NewHead`. When `NewHead` fails, `db.head` is nil, so `db.Close()` skips `head.Close()` and the WAL goroutines are never stopped.
- The lockfile is acquired before `NewHead`. On the error path, `db.donec` is closed before `db.Close()` runs, so `db.Close()` short-circuits and `db.locker.Release()` is never called, leaking the flock handle and leaving the `lock` file behind.

Fix by:
- Stopping the `writeQueue` and closing the directory handle in `NewChunkDiskMapper` when `openMMapFiles` fails.
- Closing WAL/WBL explicitly in the error defer when `db.head` was never initialized.
- Releasing the locker explicitly in the error defer.
