### PR TITLE
test(cmd/prometheus): use prometheusCommandWithLogging where possible and default to --log.level=debug

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -28,7 +28,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -133,10 +132,16 @@ func TestFailedStartupExitCode(t *testing.T) {
 	}
 	t.Parallel()
 
+	tmpDir := t.TempDir()
 	fakeInputFile := "fake-input-file"
 	expectedExitStatus := 2
 
-	prom := exec.Command(promPath, "-test.main", "--web.listen-address=0.0.0.0:0", "--config.file="+fakeInputFile)
+	prom := prometheusCommandWithLogging(
+		t,
+		fakeInputFile,
+		0,
+		fmt.Sprintf("--storage.tsdb.path=%s", tmpDir),
+	)
 	err := prom.Run()
 	require.Error(t, err)
 
@@ -247,23 +252,7 @@ func TestWALSegmentSizeBounds(t *testing.T) {
 		t.Run(tc.size, func(t *testing.T) {
 			t.Parallel()
 			prom := exec.Command(promPath, "-test.main", "--storage.tsdb.wal-segment-size="+tc.size, "--web.listen-address=0.0.0.0:0", "--config.file="+promConfig, "--storage.tsdb.path="+filepath.Join(t.TempDir(), "data"))
-
-			// Log stderr in case of failure.
-			stderr, err := prom.StderrPipe()
-			require.NoError(t, err)
-
-			// WaitGroup is used to ensure that we don't call t.Log() after the test has finished.
-			var wg sync.WaitGroup
-			wg.Add(1)
-			defer wg.Wait()
-
-			go func() {
-				defer wg.Done()
-				slurp, _ := io.ReadAll(stderr)
-				t.Log(string(slurp))
-			}()
-
-			err = prom.Start()
+			err := prom.Start()
 			require.NoError(t, err)
 
 			if tc.exitCode == 0 {
@@ -311,23 +300,7 @@ func TestMaxBlockChunkSegmentSizeBounds(t *testing.T) {
 		t.Run(tc.size, func(t *testing.T) {
 			t.Parallel()
 			prom := exec.Command(promPath, "-test.main", "--storage.tsdb.max-block-chunk-segment-size="+tc.size, "--web.listen-address=0.0.0.0:0", "--config.file="+promConfig, "--storage.tsdb.path="+filepath.Join(t.TempDir(), "data"))
-
-			// Log stderr in case of failure.
-			stderr, err := prom.StderrPipe()
-			require.NoError(t, err)
-
-			// WaitGroup is used to ensure that we don't call t.Log() after the test has finished.
-			var wg sync.WaitGroup
-			wg.Add(1)
-			defer wg.Wait()
-
-			go func() {
-				defer wg.Done()
-				slurp, _ := io.ReadAll(stderr)
-				t.Log(string(slurp))
-			}()
-
-			err = prom.Start()
+			err := prom.Start()
 			require.NoError(t, err)
 
 			if tc.exitCode == 0 {
@@ -504,8 +477,8 @@ func TestModeSpecificFlags(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("%s mode with option %s", tc.mode, tc.arg), func(t *testing.T) {
 			t.Parallel()
-			args := []string{"-test.main", tc.arg, t.TempDir(), "--web.listen-address=0.0.0.0:0"}
 
+			args := []string{"-test.main", tc.arg, t.TempDir(), "--web.listen-address=0.0.0.0:0"}
 			if tc.mode == "agent" {
 				args = append(args, "--agent", "--config.file="+agentConfig)
 			} else {
@@ -514,22 +487,7 @@ func TestModeSpecificFlags(t *testing.T) {
 
 			prom := exec.Command(promPath, args...)
 
-			// Log stderr in case of failure.
-			stderr, err := prom.StderrPipe()
-			require.NoError(t, err)
-
-			// WaitGroup is used to ensure that we don't call t.Log() after the test has finished.
-			var wg sync.WaitGroup
-			wg.Add(1)
-			defer wg.Wait()
-
-			go func() {
-				defer wg.Done()
-				slurp, _ := io.ReadAll(stderr)
-				t.Log(string(slurp))
-			}()
-
-			err = prom.Start()
+			err := prom.Start()
 			require.NoError(t, err)
 
 			if tc.exitStatus == 0 {
@@ -1014,7 +972,6 @@ remote_write:
 		configFile,
 		port,
 		fmt.Sprintf("--storage.tsdb.path=%s", tmpDir),
-		"--log.level=debug",
 	)
 	require.NoError(t, prom.Start())
 

--- a/cmd/prometheus/main_unix_test.go
+++ b/cmd/prometheus/main_unix_test.go
@@ -36,9 +36,8 @@ func TestStartupInterrupt(t *testing.T) {
 	}
 	t.Parallel()
 
-	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
-
-	prom := exec.Command(promPath, "-test.main", "--config.file="+promConfig, "--storage.tsdb.path="+t.TempDir(), "--web.listen-address=0.0.0.0"+port)
+	port := testutil.RandomUnprivilegedPort(t)
+	prom := exec.Command(promPath, "-test.main", "--config.file="+promConfig, "--storage.tsdb.path="+t.TempDir(), fmt.Sprintf("--web.listen-address=0.0.0.0:%d", port))
 	err := prom.Start()
 	require.NoError(t, err)
 
@@ -50,7 +49,7 @@ func TestStartupInterrupt(t *testing.T) {
 	var startedOk bool
 	var stoppedErr error
 
-	url := "http://localhost" + port + "/graph"
+	url := fmt.Sprintf("http://localhost:%d/graph", port)
 
 Loop:
 	for range 10 {

--- a/cmd/prometheus/reload_test.go
+++ b/cmd/prometheus/reload_test.go
@@ -16,6 +16,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -111,6 +112,7 @@ func runTestSteps(t *testing.T, steps []struct {
 	expectedMetric   float64
 },
 ) {
+	tmpDir := t.TempDir()
 	configDir := t.TempDir()
 	configFilePath := filepath.Join(configDir, "prometheus.yml")
 
@@ -119,7 +121,14 @@ func runTestSteps(t *testing.T, steps []struct {
 	require.NoError(t, os.WriteFile(configFilePath, []byte(steps[0].configText), 0o644), "Failed to write initial config file")
 
 	port := testutil.RandomUnprivilegedPort(t)
-	prom := prometheusCommandWithLogging(t, configFilePath, port, "--enable-feature=auto-reload-config", "--config.auto-reload-interval=1s")
+	prom := prometheusCommandWithLogging(
+		t,
+		configFilePath,
+		port,
+		fmt.Sprintf("--storage.tsdb.path=%s", tmpDir),
+		"--enable-feature=auto-reload-config",
+		"--config.auto-reload-interval=1s",
+	)
 	require.NoError(t, prom.Start())
 
 	baseURL := "http://localhost:" + strconv.Itoa(port)
@@ -209,6 +218,7 @@ func prometheusCommandWithLogging(t *testing.T, configFilePath string, port int,
 		"-test.main",
 		"--config.file=" + configFilePath,
 		"--web.listen-address=0.0.0.0:" + strconv.Itoa(port),
+		"--log.level=debug",
 	}
 	args = append(args, extraArgs...)
 	prom := exec.Command(promPath, args...)


### PR DESCRIPTION
Replace direct Prometheus binary invocations with prometheusCommandWithLogging wherever feasible. Enable --log.level=debug by default to improve visibility when diagnosing flaky - hard to reproduce  tests.

This may increase log verbosity, but we'll evaluate the impact based on gh feedback.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
