### PR TITLE
promqltest: Add tests to demonstrate detail of smoothed rate calculation

### DIFF
--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -418,3 +418,28 @@ eval instant at 45s withreset smoothed
 
 eval instant at 30s notregular smoothed
     notregular 2
+
+clear
+load 1m
+    metric _ _ _ _ _ _ 1
+
+# smoothed rate with a single point after the range beyond
+# lookback delta returns nothing.
+eval instant at 0m rate(metric[1m] smoothed)
+
+# smoothed rate with a single point after the range within
+# lookback delta is zero.
+# TODO(beorn7): Is this intended? Maybe it should return nothing.
+# See also below.
+eval instant at 3m rate(metric[1m] smoothed)
+    {} 0
+
+# smoothed rate with a single point before the range beyond
+# lookback delta returns nothing.
+eval instant at 15m rate(metric[1m] smoothed)
+
+# smoothed rate with a single point before the range within
+# lookback delta returns nothing.
+# TODO(beorn7): Is this intended? Maybe it should be zero.
+# See also above.
+eval instant at 8m rate(metric[1m] smoothed)


### PR DESCRIPTION
This shows that the smoothed rate with an empty range is calculated to be zero if there is a single sample after the range, but still within the lookback delta.

In contrast, the smoothed rate with an empty range and a single sample before the range, but still within the lookback delta, does not exist.

This is inconsistent. In both cases, the rate should either not exist or be calculated as zero.

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```
