### PR TITLE
fix: accept empty HELP text without trailing space in OpenMetrics parser

### DIFF
--- a/model/textparse/openmetricslex.l
+++ b/model/textparse/openmetricslex.l
@@ -52,6 +52,7 @@ S     [ ]
 <sComment>"EOF"\n?                    l.state = sInit; return tEOFWord
 <sMeta1>\"(\\.|[^\\"])*\"             l.state = sMeta2; return tMName
 <sMeta1>{M}({M}|{D})*                 l.state = sMeta2; return tMName
+<sMeta2>\n                              l.state = sInit; return tText
 <sMeta2>{S}{C}*\n                     l.state = sInit; return tText
 
 {M}({M}|{D})*                         l.state = sValue; return tMName

--- a/model/textparse/openmetricslex.l.go
+++ b/model/textparse/openmetricslex.l.go
@@ -43,19 +43,19 @@ yystate0:
 	case 3: // start condition: sMeta2
 		goto yystart31
 	case 4: // start condition: sLabels
-		goto yystart34
+		goto yystart35
 	case 5: // start condition: sLValue
-		goto yystart42
+		goto yystart43
 	case 6: // start condition: sValue
-		goto yystart46
+		goto yystart47
 	case 7: // start condition: sTimestamp
-		goto yystart50
+		goto yystart51
 	case 8: // start condition: sExemplar
-		goto yystart57
+		goto yystart58
 	case 9: // start condition: sEValue
-		goto yystart65
+		goto yystart66
 	case 10: // start condition: sETimestamp
-		goto yystart71
+		goto yystart72
 	}
 
 yystate1:
@@ -74,10 +74,10 @@ yystart1:
 
 yystate2:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate3
 	}
 
@@ -89,55 +89,55 @@ yystate4:
 	c = l.next()
 	switch {
 	default:
-		goto yyrule9
+		goto yyrule10
 	case c >= '0' && c <= ':' || c >= 'A' && c <= 'Z' || c == '_' || c >= 'a' && c <= 'z':
 		goto yystate4
 	}
 
 yystate5:
 	c = l.next()
-	goto yyrule11
+	goto yyrule12
 
 yystate6:
 	c = l.next()
 yystart6:
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'E':
+	case c == 'E':
 		goto yystate7
-	case 'H':
+	case c == 'H':
 		goto yystate11
-	case 'T':
+	case c == 'T':
 		goto yystate16
-	case 'U':
+	case c == 'U':
 		goto yystate21
 	}
 
 yystate7:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'O':
+	case c == 'O':
 		goto yystate8
 	}
 
 yystate8:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'F':
+	case c == 'F':
 		goto yystate9
 	}
 
 yystate9:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyrule5
-	case '\n':
+	case c == '\n':
 		goto yystate10
 	}
 
@@ -147,37 +147,37 @@ yystate10:
 
 yystate11:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'E':
+	case c == 'E':
 		goto yystate12
 	}
 
 yystate12:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'L':
+	case c == 'L':
 		goto yystate13
 	}
 
 yystate13:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'P':
+	case c == 'P':
 		goto yystate14
 	}
 
 yystate14:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate15
 	}
 
@@ -187,37 +187,37 @@ yystate15:
 
 yystate16:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'Y':
+	case c == 'Y':
 		goto yystate17
 	}
 
 yystate17:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'P':
+	case c == 'P':
 		goto yystate18
 	}
 
 yystate18:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'E':
+	case c == 'E':
 		goto yystate19
 	}
 
 yystate19:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate20
 	}
 
@@ -227,37 +227,37 @@ yystate20:
 
 yystate21:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'N':
+	case c == 'N':
 		goto yystate22
 	}
 
 yystate22:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'I':
+	case c == 'I':
 		goto yystate23
 	}
 
 yystate23:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case 'T':
+	case c == 'T':
 		goto yystate24
 	}
 
 yystate24:
 	c = l.next()
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
 		goto yystate25
 	}
 
@@ -315,376 +315,382 @@ yystate30:
 yystate31:
 	c = l.next()
 yystart31:
-	switch c {
+	switch {
 	default:
 		goto yyabort
-	case ' ':
+	case c == ' ':
+		goto yystate33
+	case c == '\n':
 		goto yystate32
 	}
 
 yystate32:
 	c = l.next()
+	goto yyrule8
+
+yystate33:
+	c = l.next()
 	switch {
 	default:
 		goto yyabort
 	case c == '\n':
-		goto yystate33
+		goto yystate34
 	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= 'ÿ':
-		goto yystate32
+		goto yystate33
 	}
-
-yystate33:
-	c = l.next()
-	goto yyrule8
 
 yystate34:
 	c = l.next()
-yystart34:
-	switch {
-	default:
-		goto yyabort
-	case c == '"':
-		goto yystate35
-	case c == ',':
-		goto yystate38
-	case c == '=':
-		goto yystate39
-	case c == '}':
-		goto yystate41
-	case c >= 'A' && c <= 'Z' || c == '_' || c >= 'a' && c <= 'z':
-		goto yystate40
-	}
+	goto yyrule9
 
 yystate35:
 	c = l.next()
+yystart35:
 	switch {
 	default:
 		goto yyabort
 	case c == '"':
 		goto yystate36
-	case c == '\\':
-		goto yystate37
-	case c >= '\x01' && c <= '!' || c >= '#' && c <= '[' || c >= ']' && c <= 'ÿ':
-		goto yystate35
+	case c == ',':
+		goto yystate39
+	case c == '=':
+		goto yystate40
+	case c == '}':
+		goto yystate42
+	case c >= 'A' && c <= 'Z' || c == '_' || c >= 'a' && c <= 'z':
+		goto yystate41
 	}
 
 yystate36:
-	c = l.next()
-	goto yyrule13
-
-yystate37:
-	c = l.next()
-	switch {
-	default:
-		goto yyabort
-	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= 'ÿ':
-		goto yystate35
-	}
-
-yystate38:
-	c = l.next()
-	goto yyrule16
-
-yystate39:
-	c = l.next()
-	goto yyrule15
-
-yystate40:
-	c = l.next()
-	switch {
-	default:
-		goto yyrule12
-	case c >= '0' && c <= '9' || c >= 'A' && c <= 'Z' || c == '_' || c >= 'a' && c <= 'z':
-		goto yystate40
-	}
-
-yystate41:
-	c = l.next()
-	goto yyrule14
-
-yystate42:
-	c = l.next()
-yystart42:
-	switch c {
-	default:
-		goto yyabort
-	case '"':
-		goto yystate43
-	}
-
-yystate43:
 	c = l.next()
 	switch {
 	default:
 		goto yyabort
 	case c == '"':
-		goto yystate44
+		goto yystate37
 	case c == '\\':
-		goto yystate45
-	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '!' || c >= '#' && c <= '[' || c >= ']' && c <= 'ÿ':
-		goto yystate43
+		goto yystate38
+	case c >= '\x01' && c <= '!' || c >= '#' && c <= '[' || c >= ']' && c <= 'ÿ':
+		goto yystate36
 	}
 
-yystate44:
+yystate37:
 	c = l.next()
-	goto yyrule17
+	goto yyrule14
 
-yystate45:
+yystate38:
 	c = l.next()
 	switch {
 	default:
 		goto yyabort
 	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= 'ÿ':
-		goto yystate43
+		goto yystate36
 	}
 
-yystate46:
+yystate39:
 	c = l.next()
-yystart46:
-	switch c {
+	goto yyrule17
+
+yystate40:
+	c = l.next()
+	goto yyrule16
+
+yystate41:
+	c = l.next()
+	switch {
+	default:
+		goto yyrule13
+	case c >= '0' && c <= '9' || c >= 'A' && c <= 'Z' || c == '_' || c >= 'a' && c <= 'z':
+		goto yystate41
+	}
+
+yystate42:
+	c = l.next()
+	goto yyrule15
+
+yystate43:
+	c = l.next()
+yystart43:
+	switch {
 	default:
 		goto yyabort
-	case ' ':
-		goto yystate47
-	case '{':
-		goto yystate49
+	case c == '"':
+		goto yystate44
 	}
 
-yystate47:
+yystate44:
 	c = l.next()
 	switch {
 	default:
 		goto yyabort
-	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
+	case c == '"':
+		goto yystate45
+	case c == '\\':
+		goto yystate46
+	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '!' || c >= '#' && c <= '[' || c >= ']' && c <= 'ÿ':
+		goto yystate44
+	}
+
+yystate45:
+	c = l.next()
+	goto yyrule18
+
+yystate46:
+	c = l.next()
+	switch {
+	default:
+		goto yyabort
+	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= 'ÿ':
+		goto yystate44
+	}
+
+yystate47:
+	c = l.next()
+yystart47:
+	switch {
+	default:
+		goto yyabort
+	case c == ' ':
 		goto yystate48
+	case c == '{':
+		goto yystate50
 	}
 
 yystate48:
 	c = l.next()
 	switch {
 	default:
-		goto yyrule18
+		goto yyabort
 	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
-		goto yystate48
+		goto yystate49
 	}
 
 yystate49:
-	c = l.next()
-	goto yyrule10
-
-yystate50:
-	c = l.next()
-yystart50:
-	switch c {
-	default:
-		goto yyabort
-	case ' ':
-		goto yystate52
-	case '\n':
-		goto yystate51
-	}
-
-yystate51:
-	c = l.next()
-	goto yyrule20
-
-yystate52:
-	c = l.next()
-	switch {
-	default:
-		goto yyabort
-	case c == '#':
-		goto yystate54
-	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c == '!' || c == '"' || c >= '$' && c <= 'ÿ':
-		goto yystate53
-	}
-
-yystate53:
 	c = l.next()
 	switch {
 	default:
 		goto yyrule19
 	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
+		goto yystate49
+	}
+
+yystate50:
+	c = l.next()
+	goto yyrule11
+
+yystate51:
+	c = l.next()
+yystart51:
+	switch {
+	default:
+		goto yyabort
+	case c == ' ':
 		goto yystate53
+	case c == '\n':
+		goto yystate52
+	}
+
+yystate52:
+	c = l.next()
+	goto yyrule21
+
+yystate53:
+	c = l.next()
+	switch {
+	default:
+		goto yyabort
+	case c == '#':
+		goto yystate55
+	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c == '!' || c == '"' || c >= '$' && c <= 'ÿ':
+		goto yystate54
 	}
 
 yystate54:
 	c = l.next()
 	switch {
 	default:
-		goto yyrule19
-	case c == ' ':
-		goto yystate55
+		goto yyrule20
 	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
-		goto yystate53
+		goto yystate54
 	}
 
 yystate55:
 	c = l.next()
-	switch c {
+	switch {
 	default:
-		goto yyabort
-	case '{':
+		goto yyrule20
+	case c == ' ':
 		goto yystate56
+	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
+		goto yystate54
 	}
 
 yystate56:
 	c = l.next()
-	goto yyrule21
-
-yystate57:
-	c = l.next()
-yystart57:
 	switch {
 	default:
 		goto yyabort
-	case c == '"':
-		goto yystate58
-	case c == ',':
-		goto yystate61
-	case c == '=':
-		goto yystate62
-	case c == '}':
-		goto yystate64
-	case c >= 'A' && c <= 'Z' || c == '_' || c >= 'a' && c <= 'z':
-		goto yystate63
+	case c == '{':
+		goto yystate57
 	}
+
+yystate57:
+	c = l.next()
+	goto yyrule22
 
 yystate58:
 	c = l.next()
+yystart58:
 	switch {
 	default:
 		goto yyabort
 	case c == '"':
 		goto yystate59
-	case c == '\\':
-		goto yystate60
-	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '!' || c >= '#' && c <= '[' || c >= ']' && c <= 'ÿ':
-		goto yystate58
+	case c == ',':
+		goto yystate62
+	case c == '=':
+		goto yystate63
+	case c == '}':
+		goto yystate65
+	case c >= 'A' && c <= 'Z' || c == '_' || c >= 'a' && c <= 'z':
+		goto yystate64
 	}
 
 yystate59:
 	c = l.next()
-	goto yyrule23
+	switch {
+	default:
+		goto yyabort
+	case c == '"':
+		goto yystate60
+	case c == '\\':
+		goto yystate61
+	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '!' || c >= '#' && c <= '[' || c >= ']' && c <= 'ÿ':
+		goto yystate59
+	}
 
 yystate60:
+	c = l.next()
+	goto yyrule24
+
+yystate61:
 	c = l.next()
 	switch {
 	default:
 		goto yyabort
 	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= 'ÿ':
-		goto yystate58
+		goto yystate59
 	}
-
-yystate61:
-	c = l.next()
-	goto yyrule27
 
 yystate62:
 	c = l.next()
-	goto yyrule25
+	goto yyrule28
 
 yystate63:
 	c = l.next()
-	switch {
-	default:
-		goto yyrule22
-	case c >= '0' && c <= '9' || c >= 'A' && c <= 'Z' || c == '_' || c >= 'a' && c <= 'z':
-		goto yystate63
-	}
+	goto yyrule26
 
 yystate64:
 	c = l.next()
-	goto yyrule24
+	switch {
+	default:
+		goto yyrule23
+	case c >= '0' && c <= '9' || c >= 'A' && c <= 'Z' || c == '_' || c >= 'a' && c <= 'z':
+		goto yystate64
+	}
 
 yystate65:
 	c = l.next()
-yystart65:
-	switch c {
-	default:
-		goto yyabort
-	case ' ':
-		goto yystate66
-	case '"':
-		goto yystate68
-	}
+	goto yyrule25
 
 yystate66:
 	c = l.next()
+yystart66:
 	switch {
 	default:
 		goto yyabort
-	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
+	case c == ' ':
 		goto yystate67
+	case c == '"':
+		goto yystate69
 	}
 
 yystate67:
 	c = l.next()
 	switch {
 	default:
-		goto yyrule28
+		goto yyabort
 	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
-		goto yystate67
+		goto yystate68
 	}
 
 yystate68:
 	c = l.next()
 	switch {
 	default:
-		goto yyabort
-	case c == '"':
-		goto yystate69
-	case c == '\\':
-		goto yystate70
-	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '!' || c >= '#' && c <= '[' || c >= ']' && c <= 'ÿ':
+		goto yyrule29
+	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
 		goto yystate68
 	}
 
 yystate69:
 	c = l.next()
-	goto yyrule26
+	switch {
+	default:
+		goto yyabort
+	case c == '"':
+		goto yystate70
+	case c == '\\':
+		goto yystate71
+	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '!' || c >= '#' && c <= '[' || c >= ']' && c <= 'ÿ':
+		goto yystate69
+	}
 
 yystate70:
+	c = l.next()
+	goto yyrule27
+
+yystate71:
 	c = l.next()
 	switch {
 	default:
 		goto yyabort
 	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= 'ÿ':
-		goto yystate68
-	}
-
-yystate71:
-	c = l.next()
-yystart71:
-	switch c {
-	default:
-		goto yyabort
-	case ' ':
-		goto yystate73
-	case '\n':
-		goto yystate72
+		goto yystate69
 	}
 
 yystate72:
 	c = l.next()
-	goto yyrule30
-
-yystate73:
-	c = l.next()
+yystart72:
 	switch {
 	default:
 		goto yyabort
-	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
+	case c == ' ':
 		goto yystate74
+	case c == '\n':
+		goto yystate73
 	}
+
+yystate73:
+	c = l.next()
+	goto yyrule31
 
 yystate74:
 	c = l.next()
 	switch {
 	default:
-		goto yyrule29
+		goto yyabort
 	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
-		goto yystate74
+		goto yystate75
+	}
+
+yystate75:
+	c = l.next()
+	switch {
+	default:
+		goto yyrule30
+	case c >= '\x01' && c <= '\t' || c >= '\v' && c <= '\x1f' || c >= '!' && c <= 'ÿ':
+		goto yystate75
 	}
 
 yyrule1: // #{S}
@@ -696,163 +702,169 @@ yyrule2: // HELP{S}
 	{
 		l.state = sMeta1
 		return tHelp
-
+		goto yystate0
 	}
 yyrule3: // TYPE{S}
 	{
 		l.state = sMeta1
 		return tType
-
+		goto yystate0
 	}
 yyrule4: // UNIT{S}
 	{
 		l.state = sMeta1
 		return tUnit
-
+		goto yystate0
 	}
 yyrule5: // "EOF"\n?
 	{
 		l.state = sInit
 		return tEOFWord
-
+		goto yystate0
 	}
 yyrule6: // \"(\\.|[^\\"])*\"
 	{
 		l.state = sMeta2
 		return tMName
-
+		goto yystate0
 	}
 yyrule7: // {M}({M}|{D})*
 	{
 		l.state = sMeta2
 		return tMName
-
+		goto yystate0
 	}
-yyrule8: // {S}{C}*\n
+yyrule8: // \n
 	{
 		l.state = sInit
 		return tText
-
+		goto yystate0
 	}
-yyrule9: // {M}({M}|{D})*
+yyrule9: // {S}{C}*\n
+	{
+		l.state = sInit
+		return tText
+		goto yystate0
+	}
+yyrule10: // {M}({M}|{D})*
 	{
 		l.state = sValue
 		return tMName
-
-	}
-yyrule10: // \{
-	{
-		l.state = sLabels
-		return tBraceOpen
-
+		goto yystate0
 	}
 yyrule11: // \{
 	{
 		l.state = sLabels
 		return tBraceOpen
-
+		goto yystate0
 	}
-yyrule12: // {L}({L}|{D})*
+yyrule12: // \{
+	{
+		l.state = sLabels
+		return tBraceOpen
+		goto yystate0
+	}
+yyrule13: // {L}({L}|{D})*
 	{
 		return tLName
 	}
-yyrule13: // \"(\\.|[^\\"])*\"
+yyrule14: // \"(\\.|[^\\"])*\"
 	{
 		l.state = sLabels
 		return tQString
-
+		goto yystate0
 	}
-yyrule14: // \}
+yyrule15: // \}
 	{
 		l.state = sValue
 		return tBraceClose
-
+		goto yystate0
 	}
-yyrule15: // =
+yyrule16: // =
 	{
 		l.state = sLValue
 		return tEqual
-
+		goto yystate0
 	}
-yyrule16: // ,
+yyrule17: // ,
 	{
 		return tComma
 	}
-yyrule17: // \"(\\.|[^\\"\n])*\"
+yyrule18: // \"(\\.|[^\\"\n])*\"
 	{
 		l.state = sLabels
 		return tLValue
-
-	}
-yyrule18: // {S}[^ \n]+
-	{
-		l.state = sTimestamp
-		return tValue
-
+		goto yystate0
 	}
 yyrule19: // {S}[^ \n]+
 	{
+		l.state = sTimestamp
+		return tValue
+		goto yystate0
+	}
+yyrule20: // {S}[^ \n]+
+	{
 		return tTimestamp
 	}
-yyrule20: // \n
+yyrule21: // \n
 	{
 		l.state = sInit
 		return tLinebreak
-
+		goto yystate0
 	}
-yyrule21: // {S}#{S}\{
+yyrule22: // {S}#{S}\{
 	{
 		l.state = sExemplar
 		return tComment
-
+		goto yystate0
 	}
-yyrule22: // {L}({L}|{D})*
+yyrule23: // {L}({L}|{D})*
 	{
 		return tLName
 	}
-yyrule23: // \"(\\.|[^\\"\n])*\"
+yyrule24: // \"(\\.|[^\\"\n])*\"
 	{
 		l.state = sExemplar
 		return tQString
-
+		goto yystate0
 	}
-yyrule24: // \}
+yyrule25: // \}
 	{
 		l.state = sEValue
 		return tBraceClose
-
+		goto yystate0
 	}
-yyrule25: // =
+yyrule26: // =
 	{
 		l.state = sEValue
 		return tEqual
-
+		goto yystate0
 	}
-yyrule26: // \"(\\.|[^\\"\n])*\"
+yyrule27: // \"(\\.|[^\\"\n])*\"
 	{
 		l.state = sExemplar
 		return tLValue
-
+		goto yystate0
 	}
-yyrule27: // ,
+yyrule28: // ,
 	{
 		return tComma
 	}
-yyrule28: // {S}[^ \n]+
+yyrule29: // {S}[^ \n]+
 	{
 		l.state = sETimestamp
 		return tValue
-
+		goto yystate0
 	}
-yyrule29: // {S}[^ \n]+
+yyrule30: // {S}[^ \n]+
 	{
 		return tTimestamp
 	}
-yyrule30: // \n
+yyrule31: // \n
 	if true { // avoid go vet determining the below panic will not be reached
 		l.state = sInit
 		return tLinebreak
-
+		goto yystate0
 	}
 	panic("unreachable")
 
@@ -878,25 +890,25 @@ yyabort: // no lexem recognized
 			goto yystate31
 		}
 		if false {
-			goto yystate34
+			goto yystate35
 		}
 		if false {
-			goto yystate42
+			goto yystate43
 		}
 		if false {
-			goto yystate46
+			goto yystate47
 		}
 		if false {
-			goto yystate50
+			goto yystate51
 		}
 		if false {
-			goto yystate57
+			goto yystate58
 		}
 		if false {
-			goto yystate65
+			goto yystate66
 		}
 		if false {
-			goto yystate71
+			goto yystate72
 		}
 	}
 

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -35,6 +35,7 @@ go_gc_duration_seconds{quantile="0"} 4.9351e-05
 go_gc_duration_seconds{quantile="0.25"} 7.424100000000001e-05
 go_gc_duration_seconds{quantile="0.5",a="b"} 8.3835e-05
 # HELP nohelp1 
+# HELP nohelp2
 # HELP help2 escape \ \n \\ \" \x chars
 # UNIT nounit 
 go_gc_duration_seconds{quantile="1.0",a="b"} 8.3835e-05
@@ -157,6 +158,9 @@ foobar{quantile="0.99"} 150.1`
 					),
 				}, {
 					m:    "nohelp1",
+					help: "",
+				}, {
+					m:    "nohelp2",
 					help: "",
 				}, {
 					m:    "help2",
@@ -811,7 +815,7 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 		},
 		{
 			input: "# TYPE m\n#EOF\n",
-			err:   "expected text in TYPE",
+			err:   `invalid metric type ""`,
 		},
 		{
 			input: "# UNIT metric suffix\n#EOF\n",
@@ -831,7 +835,7 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 		},
 		{
 			input: "# UNIT m\n#EOF\n",
-			err:   "expected text in UNIT",
+			err:   `expected a valid start token, got "#E" ("INVALID") while parsing: "#E"`,
 		},
 		{
 			input: "# HELP \n#EOF\n",
@@ -839,7 +843,7 @@ func TestOpenMetricsParseErrors(t *testing.T) {
 		},
 		{
 			input: "# HELP m\n#EOF\n",
-			err:   "expected text in HELP",
+			err:   `expected a valid start token, got "#E" ("INVALID") while parsing: "#E"`,
 		},
 		{
 			input: "a\t1\n#EOF\n",


### PR DESCRIPTION
The OpenMetrics lexer rejects valid `# HELP metric_name` lines when there's no trailing space after the metric name. The `sMeta2` state only has a rule requiring at least one space character before the newline, so a bare newline causes a parse error.

The OpenMetrics spec says HELP text "SHOULD be non-empty" (not MUST), so empty HELP metadata is valid.

Adds a new lexer rule to handle the bare newline case in `sMeta2`, plus a test case.

Related: #12202