### PR TITLE
docs: document external_labels behavior with remote read

### DIFF
--- a/docs/querying/remote_read_api.md
+++ b/docs/querying/remote_read_api.md
@@ -14,6 +14,15 @@ Request are made to the following endpoint.
 /api/v1/read
 ```
 
+## External labels and remote read
+
+The `external_labels` setting in `global` affects remote read on both sides:
+
+- **Exposing remote read:** Prometheus appends `external_labels` to every time series returned via `/api/v1/read`. The labels are not stored in TSDB; they are added at response time. Incoming equality matchers that match an external label are rewritten to match the empty string so that TSDB can satisfy the query.
+- **Using remote read:** The querying Prometheus sends its own `external_labels` as additional equality matchers in the request, then strips them from the response.
+
+If the querying Prometheus has `external_labels` that differ from or are absent on the remote server, queries may return no results because the matchers will not match. Ensure that any `external_labels` on the querying side are consistent with the labels present on the remote side.
+
 ## Samples
 
 This returns a message that includes a list of raw samples matching the


### PR DESCRIPTION
## Summary
- Documents how `external_labels` interacts with the remote read API on both server and client sides
- Server side: Prometheus appends external labels to responses at query time and rewrites incoming matchers
- Client side: The querying Prometheus sends its external labels as matchers and strips them from results
- Notes the common pitfall when external labels differ between querying and remote Prometheus instances

Verified against `storage/remote/read_handler.go` (server: `filterExtLabelsFromMatchers`, `MergeLabels`) and `storage/remote/read.go` (client: `addExternalLabels`, `seriesSetFilter`).

Fixes #7192
Continues the work from #17377 (addresses @bboreham's feedback to be more concise, and corrects a factual error in the original PR about external labels not being added to responses)

```release-notes
NONE
```