### PR TITLE
tsdb: optimize head chunk access paths

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -943,9 +943,7 @@ func (DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compact
 		closers = append(closers, chunkr)
 
 		// Enable the head-chunk cache for compaction.
-		if enabler, ok := chunkr.(chunkCacheEnabler); ok {
-			enabler.EnableChunkCache()
-		}
+		enableChunkCache(chunkr)
 
 		tombsr, err := b.Tombstones()
 		if err != nil {

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -942,6 +942,11 @@ func (DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compact
 		}
 		closers = append(closers, chunkr)
 
+		// Enable the head-chunk cache for compaction.
+		if toggler, ok := chunkr.(chunkCacheToggler); ok {
+			toggler.EnableChunkCache()
+		}
+
 		tombsr, err := b.Tombstones()
 		if err != nil {
 			return fmt.Errorf("open tombstone reader for block %+v: %w", b.Meta(), err)

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -943,8 +943,8 @@ func (DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compact
 		closers = append(closers, chunkr)
 
 		// Enable the head-chunk cache for compaction.
-		if toggler, ok := chunkr.(chunkCacheToggler); ok {
-			toggler.EnableChunkCache()
+		if enabler, ok := chunkr.(chunkCacheEnabler); ok {
+			enabler.EnableChunkCache()
 		}
 
 		tombsr, err := b.Tombstones()

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1370,8 +1370,7 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 				lbls := labels.FromStrings("__name__", "bench", "series", strconv.Itoa(i))
 				for j := range nChunks {
 					// Counter reset on every histogram forces a new head chunk per sample.
-					hist := tsdbutil.GenerateTestHistogram(int64(j))
-					hist.CounterResetHint = histogram.CounterReset
+					hist := tsdbutil.GenerateTestHistogramWithHint(j, histogram.CounterReset)
 					_, err := app.AppendHistogram(0, lbls, int64(j)*1000, hist, nil)
 					require.NoError(b, err)
 				}
@@ -1396,65 +1395,67 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 	}
 }
 
-// TestCompactionFromHeadWithMultipleHeadChunks verifies that compaction from
-// a Head with multiple head chunks per series produces correct blocks. This
-// exercises the chunkCacheEnabler path in PopulateBlock, which enables the
-// head-chunk cache during compaction for O(1) chunk lookups.
-func TestCompactionFromHeadWithMultipleHeadChunks(t *testing.T) {
-	opts := DefaultHeadOptions()
-	opts.ChunkRange = 100
-	opts.ChunkDirRoot = t.TempDir()
-	h, err := NewHead(nil, nil, nil, nil, opts, nil)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, h.Close()) })
-
-	// Append enough samples to create multiple head chunks.
-	// With ChunkRange=100 and DefaultSamplesPerChunk=120, each chunk holds
-	// ~20 samples (range/step = 100/5). 200 samples → ~10 head chunks.
-	lbls := labels.FromStrings("__name__", "test")
-	var expSamples []sample
-	app := h.Appender(t.Context())
-	for i := int64(0); i < 1000; i += 5 {
-		_, err := app.Append(0, lbls, i, float64(i))
+func TestCompactionFromHead(t *testing.T) {
+	t.Run("multiple head chunks", func(t *testing.T) {
+		// Verify compaction from a Head with multiple head chunks per series
+		// produces correct blocks. This exercises the chunkCacheEnabler path
+		// in PopulateBlock, which enables the head-chunk cache during
+		// compaction for O(1) chunk lookups.
+		opts := DefaultHeadOptions()
+		opts.ChunkRange = 100
+		opts.ChunkDirRoot = t.TempDir()
+		h, err := NewHead(nil, nil, nil, nil, opts, nil)
 		require.NoError(t, err)
-		expSamples = append(expSamples, sample{t: i, f: float64(i)})
-	}
-	require.NoError(t, app.Commit())
+		t.Cleanup(func() { require.NoError(t, h.Close()) })
 
-	// Verify we have multiple head chunks.
-	s := h.series.getByID(1)
-	require.NotNil(t, s)
-	s.Lock()
-	headChunks := int(s.headChunkCount.Load())
-	s.Unlock()
-	require.Greater(t, headChunks, 1, "need multiple head chunks for this test")
+		// Append enough samples to create multiple head chunks.
+		// With ChunkRange=100 and DefaultSamplesPerChunk=120, each chunk holds
+		// ~20 samples (range/step = 100/5). 200 samples → ~10 head chunks.
+		lbls := labels.FromStrings("__name__", "test")
+		var expSamples []sample
+		app := h.Appender(t.Context())
+		for i := int64(0); i < 1000; i += 5 {
+			_, err := app.Append(0, lbls, i, float64(i))
+			require.NoError(t, err)
+			expSamples = append(expSamples, sample{t: i, f: float64(i)})
+		}
+		require.NoError(t, app.Commit())
 
-	// Compact from head.
-	blockDir := createBlockFromHead(t, t.TempDir(), h)
+		// Verify we have multiple head chunks.
+		s := h.series.getByID(1)
+		require.NotNil(t, s)
+		s.Lock()
+		headChunks := int(s.headChunkCount.Load())
+		s.Unlock()
+		require.Greater(t, headChunks, 1, "need multiple head chunks for this test")
 
-	// Re-read the block and verify all samples survived.
-	block, err := OpenBlock(promslog.NewNopLogger(), blockDir, nil, nil)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, block.Close()) })
+		// Compact from head.
+		blockDir := createBlockFromHead(t, t.TempDir(), h)
 
-	q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
-	require.NoError(t, err)
-	defer q.Close()
+		// Re-read the block and verify all samples survived.
+		block, err := OpenBlock(promslog.NewNopLogger(), blockDir, nil, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, block.Close()) })
 
-	ss := q.Select(t.Context(), false, nil, labels.MustNewMatcher(labels.MatchEqual, "__name__", "test"))
-	require.True(t, ss.Next(), "expected a series")
+		q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+		require.NoError(t, err)
+		defer q.Close()
 
-	var actSamples []sample
-	it := ss.At().Iterator(nil)
-	for it.Next() == chunkenc.ValFloat {
-		ts, v := it.At()
-		actSamples = append(actSamples, sample{t: ts, f: v})
-	}
-	require.NoError(t, it.Err())
-	require.False(t, ss.Next(), "expected only one series")
-	require.NoError(t, ss.Err())
+		ss := q.Select(t.Context(), false, nil, labels.MustNewMatcher(labels.MatchEqual, "__name__", "test"))
+		require.True(t, ss.Next(), "expected a series")
 
-	require.Equal(t, expSamples, actSamples, "compacted block should contain all samples")
+		var actSamples []sample
+		it := ss.At().Iterator(nil)
+		for it.Next() == chunkenc.ValFloat {
+			ts, v := it.At()
+			actSamples = append(actSamples, sample{t: ts, f: v})
+		}
+		require.NoError(t, it.Err())
+		require.False(t, ss.Next(), "expected only one series")
+		require.NoError(t, ss.Err())
+
+		require.Equal(t, expSamples, actSamples, "compacted block should contain all samples")
+	})
 }
 
 func BenchmarkCompactionFromOOOHead(b *testing.B) {

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1344,6 +1344,109 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 			h.Close()
 		})
 	}
+
+	// Sub-benchmark with multiple head chunks per series, as can happen with
+	// native histograms that trigger a counter reset on every sample. This
+	// stresses the linked-list traversal in s.chunk() and exercises the
+	// head-chunk cache.
+	for _, tc := range []struct{ series, chunks int }{
+		{100000, 1},  // Baseline: cache skipped (prev==nil).
+		{100000, 10}, // Realistic: cache active, but improvement negligible vs total compaction cost.
+		{10, 100},    // Moderate pathological case.
+		{10, 1000},   // Heavy pathological case.
+	} {
+		nSeries, nChunks := tc.series, tc.chunks
+		b.Run(fmt.Sprintf("many head chunks/series=%d,chunks=%d", nSeries, nChunks), func(b *testing.B) {
+			dir := b.TempDir()
+			chunkDir := b.TempDir()
+			opts := DefaultHeadOptions()
+			opts.ChunkRange = int64(nChunks+1) * 1000 // Wide enough so nothing gets mmapped.
+			opts.ChunkDirRoot = chunkDir
+			h, err := NewHead(nil, nil, nil, nil, opts, nil)
+			require.NoError(b, err)
+
+			app := h.Appender(b.Context())
+			for i := range nSeries {
+				lbls := labels.FromStrings("__name__", "bench", "series", strconv.Itoa(i))
+				for j := range nChunks {
+					// Counter reset on every histogram forces a new head chunk per sample.
+					hist := tsdbutil.GenerateTestHistogram(int64(j))
+					hist.CounterResetHint = histogram.CounterReset
+					_, err := app.AppendHistogram(0, lbls, int64(j)*1000, hist, nil)
+					require.NoError(b, err)
+				}
+			}
+			require.NoError(b, app.Commit())
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; b.Loop(); i++ {
+				createBlockFromHead(b, filepath.Join(dir, strconv.Itoa(i)), h)
+			}
+			h.Close()
+		})
+	}
+}
+
+// TestCompactionFromHeadWithMultipleHeadChunks verifies that compaction from
+// a Head with multiple head chunks per series produces correct blocks. This
+// exercises the chunkCacheToggler path in PopulateBlock, which enables the
+// head-chunk cache during compaction for O(1) chunk lookups.
+func TestCompactionFromHeadWithMultipleHeadChunks(t *testing.T) {
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 100
+	opts.ChunkDirRoot = t.TempDir()
+	h, err := NewHead(nil, nil, nil, nil, opts, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, h.Close()) })
+
+	// Append enough samples to create multiple head chunks.
+	// With ChunkRange=100 and DefaultSamplesPerChunk=120, each chunk holds
+	// ~20 samples (range/step = 100/5). 200 samples → ~10 head chunks.
+	lbls := labels.FromStrings("__name__", "test")
+	var expSamples []sample
+	app := h.Appender(t.Context())
+	for i := int64(0); i < 1000; i += 5 {
+		_, err := app.Append(0, lbls, i, float64(i))
+		require.NoError(t, err)
+		expSamples = append(expSamples, sample{t: i, f: float64(i)})
+	}
+	require.NoError(t, app.Commit())
+
+	// Verify we have multiple head chunks.
+	s := h.series.getByID(1)
+	require.NotNil(t, s)
+	s.Lock()
+	headChunks := int(s.headChunkCount.Load())
+	s.Unlock()
+	require.Greater(t, headChunks, 1, "need multiple head chunks for this test")
+
+	// Compact from head.
+	blockDir := createBlockFromHead(t, t.TempDir(), h)
+
+	// Re-read the block and verify all samples survived.
+	block, err := OpenBlock(promslog.NewNopLogger(), blockDir, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, block.Close()) })
+
+	q, err := NewBlockQuerier(block, math.MinInt64, math.MaxInt64)
+	require.NoError(t, err)
+	defer q.Close()
+
+	ss := q.Select(t.Context(), false, nil, labels.MustNewMatcher(labels.MatchEqual, "__name__", "test"))
+	require.True(t, ss.Next(), "expected a series")
+
+	var actSamples []sample
+	it := ss.At().Iterator(nil)
+	for it.Next() == chunkenc.ValFloat {
+		ts, v := it.At()
+		actSamples = append(actSamples, sample{t: ts, f: v})
+	}
+	require.NoError(t, it.Err())
+	require.False(t, ss.Next(), "expected only one series")
+	require.NoError(t, ss.Err())
+
+	require.Equal(t, expSamples, actSamples, "compacted block should contain all samples")
 }
 
 func BenchmarkCompactionFromOOOHead(b *testing.B) {

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1398,7 +1398,7 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 
 // TestCompactionFromHeadWithMultipleHeadChunks verifies that compaction from
 // a Head with multiple head chunks per series produces correct blocks. This
-// exercises the chunkCacheToggler path in PopulateBlock, which enables the
+// exercises the chunkCacheEnabler path in PopulateBlock, which enables the
 // head-chunk cache during compaction for O(1) chunk lookups.
 func TestCompactionFromHeadWithMultipleHeadChunks(t *testing.T) {
 	opts := DefaultHeadOptions()

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1378,6 +1378,14 @@ func BenchmarkCompactionFromHead(b *testing.B) {
 			}
 			require.NoError(b, app.Commit())
 
+			// Verify we actually have the expected number of head chunks.
+			for i := range nSeries {
+				lbls := labels.FromStrings("__name__", "bench", "series", strconv.Itoa(i))
+				s := h.series.getByHash(lbls.Hash(), lbls)
+				require.NotNil(b, s, "series %d not found", i)
+				require.Equal(b, uint32(nChunks), s.headChunkCount.Load(), "series %d: unexpected head chunk count", i)
+			}
+
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; b.Loop(); i++ {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2385,9 +2385,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		}
 
 		chunksRemoved += len(series.mmappedChunks)
-		if series.headChunks != nil {
-			chunksRemoved += series.headChunks.len()
-		}
+		chunksRemoved += int(series.headChunkCount.Load())
 		if series.headChunkCount.Load() >= 2 {
 			h.series.decMmapReady(series.ref)
 		}
@@ -2452,9 +2450,7 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 			return
 		}
 
-		if series.headChunks != nil {
-			rmChunks += series.headChunks.len()
-		}
+		rmChunks += int(series.headChunkCount.Load())
 		rmChunks += len(series.mmappedChunks)
 
 		// The series is gone entirely. We need to keep the series lock
@@ -2756,13 +2752,12 @@ func (s *memSeries) setHeadChunks(head *memChunk, count uint32) {
 func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) int {
 	var removedInOrder int
 	if s.headChunks != nil {
-		var i uint32
+		var i int
 		var nextChk *memChunk
 		chk := s.headChunks
 		for chk != nil {
 			if chk.maxTime < mint {
-				// If any head chunk is truncated, we can truncate all mmapped chunks.
-				removedInOrder = chk.len() + len(s.mmappedChunks)
+				removedInOrder = int(s.headChunkCount.Load()) - i + len(s.mmappedChunks)
 				s.firstChunkID += chunks.HeadChunkID(removedInOrder)
 				if i == 0 {
 					// This is the first chunk on the list so we need to remove the entire list.
@@ -2840,9 +2835,7 @@ func (mc *memChunk) len() (count int) {
 
 // collectHeadChunks walks the headChunks linked list once and returns a slice
 // in oldest-first order (matching mmappedChunks ordering).
-// buf must have length 0 but may have non-zero capacity for reuse; the
-// returned slice's tail beyond its length is zeroed, so a reused, shrinking
-// buffer does not pin chunks from a previous, longer collection.
+// buf must have length 0 but may have non-zero capacity for reuse.
 func collectHeadChunks(head *memChunk, buf []*memChunk) []*memChunk {
 	// Single walk: append newest-to-oldest (following prev pointers), then
 	// reverse to oldest-to-newest. Pointer-chasing the linked list is the
@@ -2866,30 +2859,6 @@ func (mc *memChunk) oldest() (elem *memChunk) {
 	elem = mc
 	for elem.prev != nil {
 		elem = elem.prev
-	}
-	return elem
-}
-
-// atOffset returns a memChunk that's Nth element on the linked list.
-func (mc *memChunk) atOffset(offset int) (elem *memChunk) {
-	if offset == 0 {
-		return mc
-	}
-	if offset == 1 {
-		return mc.prev
-	}
-	if offset < 0 {
-		return nil
-	}
-
-	var i int
-	elem = mc
-	for i < offset {
-		i++
-		elem = elem.prev
-		if elem == nil {
-			break
-		}
 	}
 	return elem
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2384,9 +2384,10 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 			staleSeriesDeleted++
 		}
 
+		headChunkCount := series.headChunkCount.Load()
 		chunksRemoved += len(series.mmappedChunks)
-		chunksRemoved += int(series.headChunkCount.Load())
-		if series.headChunkCount.Load() >= 2 {
+		chunksRemoved += int(headChunkCount)
+		if headChunkCount >= 2 {
 			h.series.decMmapReady(series.ref)
 		}
 		// Clear to prevent a double-subtraction from the chunksRemoved gauge if
@@ -2450,7 +2451,8 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 			return
 		}
 
-		rmChunks += int(series.headChunkCount.Load())
+		headChunkCount := series.headChunkCount.Load()
+		rmChunks += int(headChunkCount)
 		rmChunks += len(series.mmappedChunks)
 
 		// The series is gone entirely. We need to keep the series lock
@@ -2459,7 +2461,7 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 		// If we don't hold them all, there's a very small chance that a series receives
 		// samples again while we are half-way into deleting it.
 		stripe := s.refStripe(series.ref)
-		if series.headChunkCount.Load() >= 2 {
+		if headChunkCount >= 2 {
 			s.decMmapReady(series.ref)
 		}
 		if hashShard != stripe {
@@ -2752,13 +2754,13 @@ func (s *memSeries) setHeadChunks(head *memChunk, count uint32) {
 func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) int {
 	var removedInOrder int
 	if s.headChunks != nil {
-		var i int
+		var i uint32
 		var nextChk *memChunk
 		chk := s.headChunks
 		for chk != nil {
 			if chk.maxTime < mint {
 				// If any head chunk is truncated, we can truncate all mmapped chunks.
-				removedInOrder = int(s.headChunkCount.Load()) - i + len(s.mmappedChunks)
+				removedInOrder = chk.len() + len(s.mmappedChunks)
 				s.firstChunkID += chunks.HeadChunkID(removedInOrder)
 				if i == 0 {
 					// This is the first chunk on the list so we need to remove the entire list.
@@ -2837,7 +2839,9 @@ func (mc *memChunk) len() (count int) {
 // collectHeadChunks walks the headChunks linked list once and returns a slice
 // in oldest-first order (matching mmappedChunks ordering).
 // For example, given head{t4} -> t3 -> t2 -> t1 -> t0, it returns [t0, t1, t2, t3, t4].
-// buf must have length 0 but may have non-zero capacity for reuse.
+// buf must have length 0 but may have non-zero capacity for reuse; the
+// returned slice's tail beyond its length is zeroed, so a reused, shrinking
+// buffer does not pin chunks from a previous, longer collection.
 func collectHeadChunks(head *memChunk, buf []*memChunk) []*memChunk {
 	// Single walk: append newest-to-oldest (following prev pointers), then
 	// reverse to oldest-to-newest. Pointer-chasing the linked list is the

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2834,13 +2834,9 @@ func (mc *memChunk) len() (count int) {
 	return count
 }
 
-// collectHeadChunksBufSize is the stack-allocated buffer size for collectHeadChunks.
-// Most series have ≤16 head chunks between mmap cycles, so this avoids heap allocation
-// in the common case.
-const collectHeadChunksBufSize = 16
-
 // collectHeadChunks walks the headChunks linked list once and returns a slice
 // in oldest-first order (matching mmappedChunks ordering).
+// For example, given head{t4} -> t3 -> t2 -> t1 -> t0, it returns [t0, t1, t2, t3, t4].
 // buf must have length 0 but may have non-zero capacity for reuse.
 func collectHeadChunks(head *memChunk, buf []*memChunk) []*memChunk {
 	// Single walk: append newest-to-oldest (following prev pointers), then

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2757,6 +2757,7 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 		chk := s.headChunks
 		for chk != nil {
 			if chk.maxTime < mint {
+				// If any head chunk is truncated, we can truncate all mmapped chunks.
 				removedInOrder = int(s.headChunkCount.Load()) - i + len(s.mmappedChunks)
 				s.firstChunkID += chunks.HeadChunkID(removedInOrder)
 				if i == 0 {
@@ -2832,6 +2833,11 @@ func (mc *memChunk) len() (count int) {
 	}
 	return count
 }
+
+// collectHeadChunksBufSize is the stack-allocated buffer size for collectHeadChunks.
+// Most series have ≤16 head chunks between mmap cycles, so this avoids heap allocation
+// in the common case.
+const collectHeadChunksBufSize = 16
 
 // collectHeadChunks walks the headChunks linked list once and returns a slice
 // in oldest-first order (matching mmappedChunks ordering).

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -2201,7 +2201,7 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 	// Collect head chunks in oldest-first order.
 	// If we have this chain: s.headChunks{t4} -> t3 -> t2 -> t1 -> t0
 	// then hc = [t0, t1, t2, t3, t4] and we write all except the newest (t4).
-	var buf [16]*memChunk
+	var buf [collectHeadChunksBufSize]*memChunk
 	hc := collectHeadChunks(s.headChunks, buf[:0])
 	for _, chk := range hc[:len(hc)-1] {
 		chunkRef := chunkDiskMapper.WriteChunk(s.ref, chk.minTime, chk.maxTime, chk.chunk, false, handleChunkWriteError)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -2198,11 +2198,8 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 		return count
 	}
 
-	// Collect head chunks in oldest-first order.
-	// If we have this chain: s.headChunks{t4} -> t3 -> t2 -> t1 -> t0
-	// then hc = [t0, t1, t2, t3, t4] and we write all except the newest (t4).
-	var buf [collectHeadChunksBufSize]*memChunk
-	hc := collectHeadChunks(s.headChunks, buf[:0])
+	// Collect head chunks in oldest-first order, then write all except the newest.
+	hc := collectHeadChunks(s.headChunks, make([]*memChunk, 0, s.headChunkCount.Load()))
 	for _, chk := range hc[:len(hc)-1] {
 		chunkRef := chunkDiskMapper.WriteChunk(s.ref, chk.minTime, chk.maxTime, chk.chunk, false, handleChunkWriteError)
 		s.mmappedChunks = append(s.mmappedChunks, &mmappedChunk{

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -2198,7 +2198,7 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 		return count
 	}
 
-	// Collect head chunks in oldest-first order (O(n) instead of O(n²)).
+	// Collect head chunks in oldest-first order.
 	// If we have this chain: s.headChunks{t4} -> t3 -> t2 -> t1 -> t0
 	// then hc = [t0, t1, t2, t3, t4] and we write all except the newest (t4).
 	var buf [16]*memChunk

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -2198,11 +2198,12 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 		return count
 	}
 
-	// Write chunks starting from the oldest one and stop before we get to current s.headChunks.
+	// Collect head chunks in oldest-first order (O(n) instead of O(n²)).
 	// If we have this chain: s.headChunks{t4} -> t3 -> t2 -> t1 -> t0
-	// then we need to write chunks t0 to t3, but skip s.headChunks.
-	for i := s.headChunks.len() - 1; i > 0; i-- {
-		chk := s.headChunks.atOffset(i)
+	// then hc = [t0, t1, t2, t3, t4] and we write all except the newest (t4).
+	var buf [16]*memChunk
+	hc := collectHeadChunks(s.headChunks, buf[:0])
+	for _, chk := range hc[:len(hc)-1] {
 		chunkRef := chunkDiskMapper.WriteChunk(s.ref, chk.minTime, chk.maxTime, chk.chunk, false, handleChunkWriteError)
 		s.mmappedChunks = append(s.mmappedChunks, &mmappedChunk{
 			ref:        chunkRef,

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -28,9 +28,9 @@ import (
 	"github.com/prometheus/prometheus/tsdb/index"
 )
 
-// headChunksBufMaxCap is the maximum capacity for the reusable headChunksBuf
-// slice. If the buffer grows beyond this, it is released to avoid holding
-// oversized backing arrays across many series iterations.
+// headChunksBufMaxCap is the maximum capacity retained for reusable []*memChunk
+// buffers. If a buffer grows beyond this, it is released to avoid holding
+// oversized backing arrays across series iterations.
 const headChunksBufMaxCap = 256
 
 func (h *Head) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
@@ -525,11 +525,19 @@ func (h *headChunkReader) Close() error {
 	return nil
 }
 
-// EnableChunkCache enables the head-chunk cache for sequential chunk access patterns.
+// EnableChunkCache enables the head-chunk cache for sequential chunk access
+// patterns (range queries, compaction), which look up every chunk of a series.
+// The cache is invalidated whenever the series' chunk layout changes (a
+// parallel append, mmapping, or truncation), falling back to O(n) for that
+// lookup.
 func (h *headChunkReader) EnableChunkCache() {
 	h.enableCache = true
 }
 
+// getOrCollectHeadChunks returns the cached head-chunk slice for s, collecting
+// it first if the cache does not match the series' current chunk layout.
+// The series lock must be held; the fingerprint comparison is only consistent
+// against concurrent appends, mmapping, and truncation under that lock.
 func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 	// Skip if the cache is disabled (instant queries) or there are no head chunks or there's only one.
 	if !h.enableCache || s.headChunks == nil || s.headChunks.prev == nil {
@@ -693,10 +701,15 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 	offset := headChunksLen - ix - 1
 	elem := s.headChunks
 	for range offset {
-		if elem.prev == nil {
-			return nil, false, false, storage.ErrNotFound
+		if elem == nil {
+			break
 		}
 		elem = elem.prev
+	}
+	if elem == nil {
+		// Defensive: headChunkCount disagreed with the actual list length.
+		// This only catches walks that run off the end of the list.
+		return nil, false, false, storage.ErrNotFound
 	}
 	return elem, true, offset == 0, nil
 }

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -765,7 +765,7 @@ func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *
 
 		ix -= len(s.mmappedChunks)
 		if s.headChunks != nil {
-			// Iterate all head chunks from the oldest to the newest (O(n) instead of O(n²)).
+			// Iterate all head chunks from the oldest to the newest.
 			var buf [16]*memChunk
 			hc := collectHeadChunks(s.headChunks, buf[:0])
 			for j, chk := range hc {

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -766,7 +766,7 @@ func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *
 		ix -= len(s.mmappedChunks)
 		if s.headChunks != nil {
 			// Iterate all head chunks from the oldest to the newest.
-			var buf [16]*memChunk
+			var buf [collectHeadChunksBufSize]*memChunk
 			hc := collectHeadChunks(s.headChunks, buf[:0])
 			for j, chk := range hc {
 				chkSamples := chk.chunk.NumSamples()

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -656,9 +656,19 @@ func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool,
 // (and not the chunkenc.Chunk inside it) can be garbage collected after its usage.
 // if isOpen is true, it means that the returned *memChunk is used for appends.
 func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDiskMapper, memChunkPool *sync.Pool, headChunks []*memChunk) (chunk *memChunk, headChunk, isOpen bool, err error) {
-	// ix is the chunk's position in the logical sequence: mmappedChunks first
-	// (oldest at index 0), then headChunks (oldest first). Values 0..len(mmappedChunks)-1
-	// refer to mmapped chunks; values >= len(mmappedChunks) refer to head chunks.
+	// ix is the chunk's oldest-first position in the logical sequence. Chunk IDs
+	// increase by one when a chunk is created, so id-firstChunkID yields that position.
+	// s.mmappedChunks is stored oldest-first, while the s.headChunks linked list is
+	// stored newest-first:
+	//
+	// memSeries {
+	//   mmappedChunks: [t0, t1, t2]
+	//   headChunks:    {t5}->{t4}->{t3}
+	// }
+	//
+	// Values below len(s.mmappedChunks) index the slice directly. Remaining values
+	// index head chunks oldest-first; the pre-collected headChunks slice already uses
+	// this order, while the linked-list fallback reverses the index.
 	ix := int(id) - int(s.firstChunkID)
 	if ix < 0 {
 		return nil, false, false, storage.ErrNotFound

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -648,18 +648,9 @@ func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool,
 // (and not the chunkenc.Chunk inside it) can be garbage collected after its usage.
 // if isOpen is true, it means that the returned *memChunk is used for appends.
 func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDiskMapper, memChunkPool *sync.Pool, headChunks []*memChunk) (chunk *memChunk, headChunk, isOpen bool, err error) {
-	// ix represents the index of chunk in the s.mmappedChunks slice. The chunk id's are
-	// incremented by 1 when new chunk is created, hence (id - firstChunkID) gives the slice index.
-	// The max index for the s.mmappedChunks slice can be len(s.mmappedChunks)-1, hence if the ix
-	// is >= len(s.mmappedChunks), it represents one of the chunks on s.headChunks linked list.
-	// The order of elements is different for slice and linked list.
-	// For s.mmappedChunks slice newer chunks are appended to it.
-	// For s.headChunks list newer chunks are prepended to it.
-	//
-	// memSeries {
-	//   mmappedChunks: [t0, t1, t2]
-	//   headChunk:     {t5}->{t4}->{t3}
-	// }
+	// ix is the chunk's position in the logical sequence: mmappedChunks first
+	// (oldest at index 0), then headChunks (oldest first). Values 0..len(mmappedChunks)-1
+	// refer to mmapped chunks; values >= len(mmappedChunks) refer to head chunks.
 	ix := int(id) - int(s.firstChunkID)
 	if ix < 0 {
 		return nil, false, false, storage.ErrNotFound
@@ -681,7 +672,7 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 		return mc, false, false, nil
 	}
 
-	// Head chunk lookup — walk directly (no collect+reverse needed).
+	// Head chunk lookup.
 	ix -= len(s.mmappedChunks)
 
 	// Fast path: use pre-collected slice for O(1) indexed lookup.
@@ -696,10 +687,6 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 	headChunksLen := int(s.headChunkCount.Load())
 	if ix >= headChunksLen {
 		return nil, false, false, storage.ErrNotFound
-	}
-	// Fast path: single head chunk (the common case).
-	if headChunksLen == 1 {
-		return s.headChunks, true, true, nil
 	}
 	// Walk from newest (offset 0) to target. The list is newest-first,
 	// but ix is oldest-first, so reverse the offset.
@@ -766,8 +753,7 @@ func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *
 		ix -= len(s.mmappedChunks)
 		if s.headChunks != nil {
 			// Iterate all head chunks from the oldest to the newest.
-			var buf [collectHeadChunksBufSize]*memChunk
-			hc := collectHeadChunks(s.headChunks, buf[:0])
+			hc := collectHeadChunks(s.headChunks, make([]*memChunk, 0, s.headChunkCount.Load()))
 			for j, chk := range hc {
 				chkSamples := chk.chunk.NumSamples()
 				totalSamples += chkSamples

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -525,18 +525,11 @@ func (h *headChunkReader) Close() error {
 	return nil
 }
 
-// EnableChunkCache enables the head-chunk cache for sequential chunk access
-// patterns (range queries), which look up every chunk of a series. The cache
-// is invalidated whenever the series' chunk layout changes (a parallel append,
-// mmapping, or truncation), falling back to O(n) for that lookup.
+// EnableChunkCache enables the head-chunk cache for sequential chunk access patterns.
 func (h *headChunkReader) EnableChunkCache() {
 	h.enableCache = true
 }
 
-// getOrCollectHeadChunks returns the cached head-chunk slice for s, collecting
-// it first if the cache does not match the series' current chunk layout.
-// The series lock must be held; the fingerprint comparison is only consistent
-// against concurrent appends, mmapping, and truncation under that lock.
 func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 	// Skip if the cache is disabled (instant queries) or there are no head chunks or there's only one.
 	if !h.enableCache || s.headChunks == nil || s.headChunks.prev == nil {

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -691,7 +691,7 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 		return headChunks[ix], true, ix == len(headChunks)-1, nil
 	}
 
-	// Fallback: walk the linked list using cached length.
+	// Fallback: walk the linked list.
 	headChunksLen := int(s.headChunkCount.Load())
 	if ix >= headChunksLen {
 		return nil, false, false, storage.ErrNotFound

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -668,15 +668,7 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 	//   headChunk:     {t5}->{t4}->{t3}
 	// }
 	ix := int(id) - int(s.firstChunkID)
-
-	var headChunksLen int
-	if headChunks != nil {
-		headChunksLen = len(headChunks)
-	} else if s.headChunks != nil {
-		headChunksLen = s.headChunks.len()
-	}
-
-	if ix < 0 || ix > len(s.mmappedChunks)+headChunksLen-1 {
+	if ix < 0 {
 		return nil, false, false, storage.ErrNotFound
 	}
 
@@ -696,7 +688,7 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 		return mc, false, false, nil
 	}
 
-	// Head chunk lookup.
+	// Head chunk lookup — walk directly (no collect+reverse needed).
 	ix -= len(s.mmappedChunks)
 
 	// Fast path: use pre-collected slice for O(1) indexed lookup.
@@ -707,18 +699,24 @@ func (s *memSeries) chunk(id chunks.HeadChunkID, chunkDiskMapper *chunks.ChunkDi
 		return headChunks[ix], true, ix == len(headChunks)-1, nil
 	}
 
-	// Fallback: walk the linked list.
-
-	offset := headChunksLen - ix - 1
-	// headChunks is a linked list where first element is the most recent one and the last one is the oldest.
-	// This order is reversed when compared with mmappedChunks, since mmappedChunks[0] is the oldest chunk,
-	// while headChunk.atOffset(0) would give us the most recent chunk.
-	// So when calling headChunk.atOffset() we need to reverse the value of ix.
-	elem := s.headChunks.atOffset(offset)
-	if elem == nil {
-		// This should never really happen and would mean that headChunksLen value is NOT equal
-		// to the length of the headChunks list.
+	// Fallback: walk the linked list using cached length.
+	headChunksLen := int(s.headChunkCount.Load())
+	if ix >= headChunksLen {
 		return nil, false, false, storage.ErrNotFound
+	}
+	// Fast path: single head chunk (the common case).
+	if headChunksLen == 1 {
+		return s.headChunks, true, true, nil
+	}
+	// Walk from newest (offset 0) to target. The list is newest-first,
+	// but ix is oldest-first, so reverse the offset.
+	offset := headChunksLen - ix - 1
+	elem := s.headChunks
+	for range offset {
+		if elem.prev == nil {
+			return nil, false, false, storage.ErrNotFound
+		}
+		elem = elem.prev
 	}
 	return elem, true, offset == 0, nil
 }
@@ -774,16 +772,13 @@ func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *
 
 		ix -= len(s.mmappedChunks)
 		if s.headChunks != nil {
-			// Iterate all head chunks from the oldest to the newest.
-			headChunksLen := s.headChunks.len()
-			for j := headChunksLen - 1; j >= 0; j-- {
-				chk := s.headChunks.atOffset(j)
+			// Iterate all head chunks from the oldest to the newest (O(n) instead of O(n²)).
+			var buf [16]*memChunk
+			hc := collectHeadChunks(s.headChunks, buf[:0])
+			for j, chk := range hc {
 				chkSamples := chk.chunk.NumSamples()
 				totalSamples += chkSamples
-				// Chunk ID is len(s.mmappedChunks) + $(headChunks list position).
-				// Where $(headChunks list position) is zero for the oldest chunk and $(s.headChunks.len() - 1)
-				// for the newest (open) chunk.
-				if headChunksLen-1-j < ix {
+				if j < ix {
 					previousSamples += chkSamples
 				}
 			}

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -731,7 +731,7 @@ func (c *safeHeadChunk) Iterator(reuseIter chunkenc.Iterator) chunkenc.Iterator 
 	return it
 }
 
-// iterator returns a chunk iterator for the requested chunkID, or a NopIterator if the requested ID is out of range.
+// iterator returns a chunk iterator for the requested chunk ID, or a NopIterator if it is out of range.
 // It is unsafe to call this concurrently with s.append(...) without holding the series lock.
 func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *isolationState, it chunkenc.Iterator) chunkenc.Iterator {
 	ix := int(id) - int(s.firstChunkID)
@@ -750,16 +750,20 @@ func (s *memSeries) iterator(id chunks.HeadChunkID, c chunkenc.Chunk, isoState *
 			}
 		}
 
-		ix -= len(s.mmappedChunks)
 		if s.headChunks != nil {
-			// Iterate all head chunks from the oldest to the newest.
-			hc := collectHeadChunks(s.headChunks, make([]*memChunk, 0, s.headChunkCount.Load()))
-			for j, chk := range hc {
-				chkSamples := chk.chunk.NumSamples()
+			// Reset ix, so its base is 0 (oldest non-mmapped head chunk).
+			ix -= len(s.mmappedChunks)
+
+			// Head chunks are indexed oldest-first, matching chunk ID order, but the list is walked newest-first,
+			// so j starts at the highest (newest) index and counts down.
+			j := int(s.headChunkCount.Load()) - 1
+			for elem := s.headChunks; elem != nil; elem = elem.prev {
+				chkSamples := elem.chunk.NumSamples()
 				totalSamples += chkSamples
 				if j < ix {
 					previousSamples += chkSamples
 				}
+				j--
 			}
 		}
 

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -15,6 +15,7 @@ package tsdb
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -168,6 +169,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
 				s.headChunks = nil
+				s.headChunkCount.Store(0)
 			},
 			inputID:  0,
 			expected: outMmappedChunk,
@@ -182,6 +184,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
 				s.headChunks = nil
+				s.headChunkCount.Store(0)
 			},
 			inputID:  2,
 			expected: outMmappedChunk,
@@ -196,6 +199,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
 				s.headChunks = nil
+				s.headChunkCount.Store(0)
 			},
 			inputID:  3,
 			expected: outErr,
@@ -815,7 +819,8 @@ func TestHeadChunkReaderCache(t *testing.T) {
 	})
 }
 
-var benchSink *memChunk
+// benchSink prevents the compiler from eliding benchmark calls.
+var benchSink any
 
 // BenchmarkSeriesChunkIteration measures iterating all N head chunks of a series
 // oldest-to-newest (the real query pattern) using the cached head-chunks slice.
@@ -827,6 +832,7 @@ func BenchmarkSeriesChunkIteration(b *testing.B) {
 				firstChunkID: 0,
 				headChunks:   buildHeadChunksLight(n),
 			}
+			s.headChunkCount.Store(uint32(n))
 			hc := collectHeadChunks(s.headChunks, nil)
 			b.ReportAllocs()
 			for b.Loop() {
@@ -836,6 +842,20 @@ func BenchmarkSeriesChunkIteration(b *testing.B) {
 			}
 		})
 	}
+}
+
+// buildHeadChunks creates a linked list of N head chunks with non-overlapping time ranges.
+func buildHeadChunks(n int) *memChunk {
+	var head *memChunk
+	for i := range n {
+		head = &memChunk{
+			chunk:   chunkenc.NewXORChunk(),
+			minTime: int64(i) * 1000,
+			maxTime: int64(i)*1000 + 999,
+			prev:    head,
+		}
+	}
+	return head
 }
 
 // buildHeadChunksLight creates a memChunk linked list without allocating chunk
@@ -851,4 +871,134 @@ func buildHeadChunksLight(n int) *memChunk {
 		}
 	}
 	return head
+}
+
+func BenchmarkAppendSeriesChunks(b *testing.B) {
+	for _, numHeadChunks := range []int{1, 4, 16, 64, 256} {
+		b.Run(fmt.Sprintf("headOnly/%d", numHeadChunks), func(b *testing.B) {
+			s := &memSeries{
+				ref:        1,
+				headChunks: buildHeadChunksLight(numHeadChunks),
+			}
+			mint := int64(0)
+			maxt := int64(numHeadChunks) * 1000
+			chks := make([]chunks.Meta, 0, numHeadChunks)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				chks, _ = appendSeriesChunks(s, mint, maxt, chks[:0], nil)
+			}
+			benchSink = chks
+		})
+
+		b.Run(fmt.Sprintf("withMmapped/%d", numHeadChunks), func(b *testing.B) {
+			// Same number of mmapped chunks as head chunks.
+			mmapped := make([]*mmappedChunk, numHeadChunks)
+			for i := range numHeadChunks {
+				mmapped[i] = &mmappedChunk{
+					minTime: int64(i) * 1000,
+					maxTime: int64(i)*1000 + 999,
+				}
+			}
+			s := &memSeries{
+				ref:           1,
+				headChunks:    buildHeadChunksLight(numHeadChunks),
+				mmappedChunks: mmapped,
+			}
+			totalChunks := numHeadChunks * 2
+			mint := int64(0)
+			maxt := int64(totalChunks) * 1000
+			chks := make([]chunks.Meta, 0, totalChunks)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				chks, _ = appendSeriesChunks(s, mint, maxt, chks[:0], nil)
+			}
+			benchSink = chks
+		})
+	}
+}
+
+func BenchmarkCollectHeadChunks(b *testing.B) {
+	for _, n := range []int{1, 4, 16, 64, 256} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			head := buildHeadChunks(n)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				var buf [16]*memChunk
+				benchSink = collectHeadChunks(head, buf[:0])
+			}
+		})
+	}
+}
+
+func BenchmarkSeriesChunk(b *testing.B) {
+	for _, n := range []int{1, 4, 16, 64, 256} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			s := &memSeries{
+				ref:          1,
+				firstChunkID: 0,
+				headChunks:   buildHeadChunksLight(n),
+			}
+			s.headChunkCount.Store(uint32(n))
+			// Request the oldest head chunk (HeadChunkID 0) — worst case.
+			id := chunks.HeadChunkID(0)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				c, _, _, err := s.chunk(id, nil, nil, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink = c
+			}
+		})
+	}
+}
+
+func BenchmarkChunkLookup(b *testing.B) {
+	for _, n := range []int{1, 4, 16, 64, 256} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			s := &memSeries{
+				ref:          1,
+				firstChunkID: 0,
+				headChunks:   buildHeadChunksLight(n),
+			}
+			s.headChunkCount.Store(uint32(n))
+			// Request a mid-position chunk (complements BenchmarkSeriesChunk which does worst-case oldest).
+			id := chunks.HeadChunkID(n / 2)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				c, _, _, err := s.chunk(id, nil, nil, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink = c
+			}
+		})
+	}
+}
+
+func BenchmarkTruncateChunksBefore(b *testing.B) {
+	for _, n := range []int{1, 4, 16, 64, 256} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			// mint truncates the oldest half of head chunks.
+			mint := int64(n/2) * 1000
+
+			b.ReportAllocs()
+			for b.Loop() {
+				// Rebuild each iteration since truncate is destructive.
+				// Use lightweight chunks (nil chunk field) since truncation
+				// only reads maxTime and follows prev pointers.
+				s := &memSeries{
+					firstChunkID: 0,
+					headChunks:   buildHeadChunksLight(n),
+				}
+				s.headChunkCount.Store(uint32(n))
+				s.truncateChunksBefore(mint, 0)
+			}
+		})
+	}
 }

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -820,7 +820,11 @@ func TestHeadChunkReaderCache(t *testing.T) {
 }
 
 // benchSink prevents the compiler from eliding benchmark calls.
-var benchSink any
+var (
+	benchSinkChunk  *memChunk
+	benchSinkChunks []*memChunk
+	benchSinkMeta   []chunks.Meta
+)
 
 // BenchmarkSeriesChunkIteration measures iterating all N head chunks of a series
 // oldest-to-newest (the real query pattern) using the cached head-chunks slice.
@@ -837,7 +841,7 @@ func BenchmarkSeriesChunkIteration(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
 				for i := range n {
-					benchSink, _, _, _ = s.chunk(chunks.HeadChunkID(i), nil, nil, hc)
+					benchSinkChunk, _, _, _ = s.chunk(chunks.HeadChunkID(i), nil, nil, hc)
 				}
 			}
 		})
@@ -888,7 +892,7 @@ func BenchmarkAppendSeriesChunks(b *testing.B) {
 			for b.Loop() {
 				chks, _ = appendSeriesChunks(s, mint, maxt, chks[:0], nil)
 			}
-			benchSink = chks
+			benchSinkMeta = chks
 		})
 
 		b.Run(fmt.Sprintf("withMmapped/%d", numHeadChunks), func(b *testing.B) {
@@ -914,7 +918,7 @@ func BenchmarkAppendSeriesChunks(b *testing.B) {
 			for b.Loop() {
 				chks, _ = appendSeriesChunks(s, mint, maxt, chks[:0], nil)
 			}
-			benchSink = chks
+			benchSinkMeta = chks
 		})
 	}
 }
@@ -926,8 +930,7 @@ func BenchmarkCollectHeadChunks(b *testing.B) {
 
 			b.ReportAllocs()
 			for b.Loop() {
-				var buf [collectHeadChunksBufSize]*memChunk
-				benchSink = collectHeadChunks(head, buf[:0])
+				benchSinkChunks = collectHeadChunks(head, make([]*memChunk, 0, n))
 			}
 		})
 	}
@@ -951,7 +954,7 @@ func BenchmarkSeriesChunk(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				benchSink = c
+				benchSinkChunk = c
 			}
 		})
 	}
@@ -975,7 +978,7 @@ func BenchmarkChunkLookup(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				benchSink = c
+				benchSinkChunk = c
 			}
 		})
 	}

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -495,6 +495,10 @@ func TestMemSeries_chunk_FastPath(t *testing.T) {
 			require.Same(t, chkLL, chkFP, "ix=%d: head chunk pointer mismatch", ix)
 		}
 	}
+
+	// Out-of-range ID via the fast path must return ErrNotFound.
+	_, _, _, err = series.chunk(chunks.HeadChunkID(totalChunks), chunkDiskMapper, memChunkPool, hc)
+	require.ErrorIs(t, err, storage.ErrNotFound)
 }
 
 func TestHeadIndexReader_PostingsForLabelMatching(t *testing.T) {

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -926,7 +926,7 @@ func BenchmarkCollectHeadChunks(b *testing.B) {
 
 			b.ReportAllocs()
 			for b.Loop() {
-				var buf [16]*memChunk
+				var buf [collectHeadChunksBufSize]*memChunk
 				benchSink = collectHeadChunks(head, buf[:0])
 			}
 		})
@@ -989,6 +989,7 @@ func BenchmarkTruncateChunksBefore(b *testing.B) {
 
 			b.ReportAllocs()
 			for b.Loop() {
+				b.StopTimer()
 				// Rebuild each iteration since truncate is destructive.
 				// Use lightweight chunks (nil chunk field) since truncation
 				// only reads maxTime and follows prev pointers.
@@ -997,6 +998,7 @@ func BenchmarkTruncateChunksBefore(b *testing.B) {
 					headChunks:   buildHeadChunksLight(n),
 				}
 				s.headChunkCount.Store(uint32(n))
+				b.StartTimer()
 				s.truncateChunksBefore(mint, 0)
 			}
 		})

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/util/compression"
@@ -168,8 +169,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.headChunks = nil
-				s.headChunkCount.Store(0)
+				s.setHeadChunks(nil, 0)
 			},
 			inputID:  0,
 			expected: outMmappedChunk,
@@ -183,8 +183,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.headChunks = nil
-				s.headChunkCount.Store(0)
+				s.setHeadChunks(nil, 0)
 			},
 			inputID:  2,
 			expected: outMmappedChunk,
@@ -198,8 +197,7 @@ func TestMemSeries_chunk(t *testing.T) {
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.headChunks = nil
-				s.headChunkCount.Store(0)
+				s.setHeadChunks(nil, 0)
 			},
 			inputID:  3,
 			expected: outErr,
@@ -413,6 +411,25 @@ func TestMemSeries_chunk(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("head chunk count mismatch", func(t *testing.T) {
+		// A drifted headChunkCount (larger than the actual list length) must
+		// yield ErrNotFound, not a panic or a nil chunk with a nil error.
+		s := &memSeries{ref: 1}
+		s.headChunkCount.Store(2) // Drifted: the list is empty.
+
+		// ix == count-1: the walk is skipped entirely (offset 0).
+		c, headChunk, isOpen, err := s.chunk(1, nil, nil, nil)
+		require.ErrorIs(t, err, storage.ErrNotFound)
+		require.Nil(t, c)
+		require.False(t, headChunk)
+		require.False(t, isOpen)
+
+		// ix < count-1: the walk runs off the end of the shorter list.
+		c, _, _, err = s.chunk(0, nil, nil, nil)
+		require.ErrorIs(t, err, storage.ErrNotFound)
+		require.Nil(t, c)
+	})
 }
 
 // TestMemSeries_chunk_FastPath verifies that the O(1) indexed lookup via a
@@ -819,11 +836,12 @@ func TestHeadChunkReaderCache(t *testing.T) {
 	})
 }
 
-// benchSink prevents the compiler from eliding benchmark calls.
+// Benchmark sinks prevent the compiler from eliding the measured calls.
 var (
 	benchSinkChunk  *memChunk
 	benchSinkChunks []*memChunk
 	benchSinkMeta   []chunks.Meta
+	benchSinkInt    int
 )
 
 // BenchmarkSeriesChunkIteration measures iterating all N head chunks of a series
@@ -836,7 +854,7 @@ func BenchmarkSeriesChunkIteration(b *testing.B) {
 				firstChunkID: 0,
 				headChunks:   buildHeadChunksLight(n),
 			}
-			s.headChunkCount.Store(uint32(n))
+			s.setHeadChunks(s.headChunks, uint32(n))
 			hc := collectHeadChunks(s.headChunks, nil)
 			b.ReportAllocs()
 			for b.Loop() {
@@ -846,20 +864,6 @@ func BenchmarkSeriesChunkIteration(b *testing.B) {
 			}
 		})
 	}
-}
-
-// buildHeadChunks creates a linked list of N head chunks with non-overlapping time ranges.
-func buildHeadChunks(n int) *memChunk {
-	var head *memChunk
-	for i := range n {
-		head = &memChunk{
-			chunk:   chunkenc.NewXORChunk(),
-			minTime: int64(i) * 1000,
-			maxTime: int64(i)*1000 + 999,
-			prev:    head,
-		}
-	}
-	return head
 }
 
 // buildHeadChunksLight creates a memChunk linked list without allocating chunk
@@ -879,7 +883,7 @@ func buildHeadChunksLight(n int) *memChunk {
 
 func BenchmarkAppendSeriesChunks(b *testing.B) {
 	for _, numHeadChunks := range []int{1, 4, 16, 64, 256} {
-		b.Run(fmt.Sprintf("headOnly/%d", numHeadChunks), func(b *testing.B) {
+		b.Run(fmt.Sprintf("head only/%d", numHeadChunks), func(b *testing.B) {
 			s := &memSeries{
 				ref:        1,
 				headChunks: buildHeadChunksLight(numHeadChunks),
@@ -895,13 +899,14 @@ func BenchmarkAppendSeriesChunks(b *testing.B) {
 			benchSinkMeta = chks
 		})
 
-		b.Run(fmt.Sprintf("withMmapped/%d", numHeadChunks), func(b *testing.B) {
-			// Same number of mmapped chunks as head chunks.
+		b.Run(fmt.Sprintf("with mmapped/%d", numHeadChunks), func(b *testing.B) {
+			// Same number of mmapped chunks as head chunks. Mmapped chunks are
+			// strictly older than all head chunks, as in a real series.
 			mmapped := make([]*mmappedChunk, numHeadChunks)
 			for i := range numHeadChunks {
 				mmapped[i] = &mmappedChunk{
-					minTime: int64(i) * 1000,
-					maxTime: int64(i)*1000 + 999,
+					minTime: int64(i-numHeadChunks) * 1000,
+					maxTime: int64(i-numHeadChunks)*1000 + 999,
 				}
 			}
 			s := &memSeries{
@@ -909,10 +914,9 @@ func BenchmarkAppendSeriesChunks(b *testing.B) {
 				headChunks:    buildHeadChunksLight(numHeadChunks),
 				mmappedChunks: mmapped,
 			}
-			totalChunks := numHeadChunks * 2
-			mint := int64(0)
-			maxt := int64(totalChunks) * 1000
-			chks := make([]chunks.Meta, 0, totalChunks)
+			mint := int64(-numHeadChunks) * 1000
+			maxt := int64(numHeadChunks) * 1000
+			chks := make([]chunks.Meta, 0, numHeadChunks*2)
 
 			b.ReportAllocs()
 			for b.Loop() {
@@ -926,7 +930,7 @@ func BenchmarkAppendSeriesChunks(b *testing.B) {
 func BenchmarkCollectHeadChunks(b *testing.B) {
 	for _, n := range []int{1, 4, 16, 64, 256} {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
-			head := buildHeadChunks(n)
+			head := buildHeadChunksLight(n)
 
 			b.ReportAllocs()
 			for b.Loop() {
@@ -938,49 +942,35 @@ func BenchmarkCollectHeadChunks(b *testing.B) {
 
 func BenchmarkSeriesChunk(b *testing.B) {
 	for _, n := range []int{1, 4, 16, 64, 256} {
-		b.Run(strconv.Itoa(n), func(b *testing.B) {
-			s := &memSeries{
-				ref:          1,
-				firstChunkID: 0,
-				headChunks:   buildHeadChunksLight(n),
+		for _, pos := range []struct {
+			name string
+			id   chunks.HeadChunkID
+		}{
+			{name: "oldest", id: 0}, // Worst case: the full list walk.
+			{name: "middle", id: chunks.HeadChunkID(n / 2)},
+		} {
+			if n < 2 && pos.name == "middle" {
+				// With a single chunk, "middle" is the same lookup as "oldest".
+				continue
 			}
-			s.headChunkCount.Store(uint32(n))
-			// Request the oldest head chunk (HeadChunkID 0) — worst case.
-			id := chunks.HeadChunkID(0)
-
-			b.ReportAllocs()
-			for b.Loop() {
-				c, _, _, err := s.chunk(id, nil, nil, nil)
-				if err != nil {
-					b.Fatal(err)
+			b.Run(fmt.Sprintf("%d/%s", n, pos.name), func(b *testing.B) {
+				s := &memSeries{
+					ref:          1,
+					firstChunkID: 0,
+					headChunks:   buildHeadChunksLight(n),
 				}
-				benchSinkChunk = c
-			}
-		})
-	}
-}
+				s.setHeadChunks(s.headChunks, uint32(n))
 
-func BenchmarkChunkLookup(b *testing.B) {
-	for _, n := range []int{1, 4, 16, 64, 256} {
-		b.Run(strconv.Itoa(n), func(b *testing.B) {
-			s := &memSeries{
-				ref:          1,
-				firstChunkID: 0,
-				headChunks:   buildHeadChunksLight(n),
-			}
-			s.headChunkCount.Store(uint32(n))
-			// Request a mid-position chunk (complements BenchmarkSeriesChunk which does worst-case oldest).
-			id := chunks.HeadChunkID(n / 2)
-
-			b.ReportAllocs()
-			for b.Loop() {
-				c, _, _, err := s.chunk(id, nil, nil, nil)
-				if err != nil {
-					b.Fatal(err)
+				b.ReportAllocs()
+				for b.Loop() {
+					c, _, _, err := s.chunk(pos.id, nil, nil, nil)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchSinkChunk = c
 				}
-				benchSinkChunk = c
-			}
-		})
+			})
+		}
 	}
 }
 
@@ -989,20 +979,25 @@ func BenchmarkTruncateChunksBefore(b *testing.B) {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			// mint truncates the oldest half of head chunks.
 			mint := int64(n/2) * 1000
+			head := buildHeadChunksLight(n)
+			headChunks := collectHeadChunks(head, nil)
+			removedHeadChunks := n / 2
+			var boundary, removedTail *memChunk
+			if removedHeadChunks > 0 {
+				boundary = headChunks[removedHeadChunks]
+				removedTail = headChunks[removedHeadChunks-1]
+			}
+			s := &memSeries{firstChunkID: 0}
 
 			b.ReportAllocs()
 			for b.Loop() {
-				b.StopTimer()
-				// Rebuild each iteration since truncate is destructive.
-				// Use lightweight chunks (nil chunk field) since truncation
-				// only reads maxTime and follows prev pointers.
-				s := &memSeries{
-					firstChunkID: 0,
-					headChunks:   buildHeadChunksLight(n),
+				if boundary != nil {
+					boundary.prev = removedTail
 				}
-				s.headChunkCount.Store(uint32(n))
-				b.StartTimer()
-				s.truncateChunksBefore(mint, 0)
+				s.firstChunkID = 0
+				s.mmappedChunks = nil
+				s.setHeadChunks(head, uint32(n))
+				benchSinkInt = s.truncateChunksBefore(mint, 0)
 			}
 		})
 	}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1802,6 +1802,7 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 
 			if tc.headChunks == 0 {
 				series.headChunks = nil
+				series.headChunkCount.Store(0)
 			} else {
 				for i := headStart; i < chunkRange*(tc.mmappedChunks+tc.headChunks); i += chunkStep {
 					ok, _ := series.append(0, int64(i), float64(i), 0, cOpts)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1801,8 +1801,7 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 			}
 
 			if tc.headChunks == 0 {
-				series.headChunks = nil
-				series.headChunkCount.Store(0)
+				series.setHeadChunks(nil, 0)
 			} else {
 				for i := headStart; i < chunkRange*(tc.mmappedChunks+tc.headChunks); i += chunkStep {
 					ok, _ := series.append(0, int64(i), float64(i), 0, cOpts)
@@ -1844,6 +1843,22 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 			require.Equal(t, tc.expectedFirstChunkID, series.firstChunkID, "wrong firstChunkID after truncation")
 		})
 	}
+
+	t.Run("head chunk count mismatch", func(t *testing.T) {
+		// truncateChunksBefore must advance firstChunkID by the actual number of
+		// removed chunks, measured from the list itself, even if headChunkCount
+		// drifted from the real list length.
+		s := &memSeries{ref: 1}
+		s.setHeadChunks(buildHeadChunksLight(5), 5)
+		s.headChunkCount.Store(7) // Drifted: the list has 5 chunks.
+
+		// Chunks span [0,999]..[4000,4999]; mint=2000 drops the two oldest.
+		removed := s.truncateChunksBefore(2000, 0)
+		require.Equal(t, 2, removed)
+		require.Equal(t, chunks.HeadChunkID(2), s.firstChunkID)
+		require.Equal(t, 3, s.headChunks.len())
+		require.Equal(t, uint32(3), s.headChunkCount.Load(), "truncation re-syncs the counter from the walk")
+	})
 }
 
 func TestHeadDeleteSeriesWithoutSamples(t *testing.T) {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -311,8 +311,10 @@ func (cr *HeadAndOOOChunkReader) collectOrGetHeadChunks(s *memSeries) []*memChun
 	return hc
 }
 
-// EnableChunkCache enables the head-chunk cache on the underlying
-// headChunkReader; see its documentation for the caching semantics.
+// EnableChunkCache enables the head-chunk cache on the underlying headChunkReader.
+// This should be called for sequential chunk access patterns (range queries,
+// compaction) where the cache provides O(1) lookups across multiple chunk
+// accesses for the same series.
 func (cr *HeadAndOOOChunkReader) EnableChunkCache() {
 	if cr.cr != nil {
 		cr.cr.EnableChunkCache()

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -314,7 +314,8 @@ func (cr *HeadAndOOOChunkReader) collectOrGetHeadChunks(s *memSeries) []*memChun
 // EnableChunkCache enables the head-chunk cache on the underlying headChunkReader.
 // This should be called for sequential chunk access patterns (range queries,
 // compaction) where the cache provides O(1) lookups across multiple chunk
-// accesses for the same series.
+// accesses for the same series. The cache is invalidated when a new chunk
+// appears due to a parallel append, falling back to O(n) for that lookup.
 func (cr *HeadAndOOOChunkReader) EnableChunkCache() {
 	if cr.cr != nil {
 		cr.cr.EnableChunkCache()

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -311,11 +311,8 @@ func (cr *HeadAndOOOChunkReader) collectOrGetHeadChunks(s *memSeries) []*memChun
 	return hc
 }
 
-// EnableChunkCache enables the head-chunk cache on the underlying headChunkReader.
-// This should be called for sequential chunk access patterns (range queries,
-// compaction) where the cache provides O(1) lookups across multiple chunk
-// accesses for the same series. The cache is invalidated when a new chunk
-// appears due to a parallel append, falling back to O(n) for that lookup.
+// EnableChunkCache enables the head-chunk cache on the underlying
+// headChunkReader; see its documentation for the caching semantics.
 func (cr *HeadAndOOOChunkReader) EnableChunkCache() {
 	if cr.cr != nil {
 		cr.cr.EnableChunkCache()

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -171,8 +171,8 @@ func (q *blockQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 }
 
 // chunkCacheToggler is an optional interface implemented by chunk readers that
-// support an in-memory head-chunk cache. The cache is only beneficial for range
-// queries (Step > 0) where every chunk of a series is accessed.
+// support an in-memory head-chunk cache. The cache is beneficial when every
+// chunk of a series is accessed sequentially, such as range queries and compaction.
 type chunkCacheToggler interface {
 	EnableChunkCache()
 }

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -170,10 +170,10 @@ func (q *blockQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 	return selectSeriesSet(ctx, sortSeries, hints, ms, q.index, q.chunks, q.tombstones, q.mint, q.maxt)
 }
 
-// chunkCacheToggler is an optional interface implemented by chunk readers that
+// chunkCacheEnabler is an optional interface implemented by chunk readers that
 // support an in-memory head-chunk cache. The cache is beneficial when every
 // chunk of a series is accessed sequentially, such as range queries and compaction.
-type chunkCacheToggler interface {
+type chunkCacheEnabler interface {
 	EnableChunkCache()
 }
 
@@ -184,8 +184,8 @@ func selectSeriesSet(ctx context.Context, sortSeries bool, hints *storage.Select
 	sharded := hints != nil && hints.ShardCount > 0
 
 	if hints != nil && hints.Step > 0 {
-		if toggler, ok := chunks.(chunkCacheToggler); ok {
-			toggler.EnableChunkCache()
+		if enabler, ok := chunks.(chunkCacheEnabler); ok {
+			enabler.EnableChunkCache()
 		}
 	}
 
@@ -238,8 +238,8 @@ func selectChunkSeriesSet(ctx context.Context, sortSeries bool, hints *storage.S
 	sharded := hints != nil && hints.ShardCount > 0
 
 	if hints != nil && hints.Step > 0 {
-		if toggler, ok := chunks.(chunkCacheToggler); ok {
-			toggler.EnableChunkCache()
+		if enabler, ok := chunks.(chunkCacheEnabler); ok {
+			enabler.EnableChunkCache()
 		}
 	}
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -177,6 +177,13 @@ type chunkCacheEnabler interface {
 	EnableChunkCache()
 }
 
+// enableChunkCache enables the head-chunk cache on cr if it supports one.
+func enableChunkCache(cr ChunkReader) {
+	if enabler, ok := cr.(chunkCacheEnabler); ok {
+		enabler.EnableChunkCache()
+	}
+}
+
 func selectSeriesSet(ctx context.Context, sortSeries bool, hints *storage.SelectHints, ms []*labels.Matcher,
 	index IndexReader, chunks ChunkReader, tombstones tombstones.Reader, mint, maxt int64,
 ) storage.SeriesSet {
@@ -184,9 +191,7 @@ func selectSeriesSet(ctx context.Context, sortSeries bool, hints *storage.Select
 	sharded := hints != nil && hints.ShardCount > 0
 
 	if hints != nil && hints.Step > 0 {
-		if enabler, ok := chunks.(chunkCacheEnabler); ok {
-			enabler.EnableChunkCache()
-		}
+		enableChunkCache(chunks)
 	}
 
 	p, err := PostingsForMatchers(ctx, index, ms...)
@@ -238,9 +243,7 @@ func selectChunkSeriesSet(ctx context.Context, sortSeries bool, hints *storage.S
 	sharded := hints != nil && hints.ShardCount > 0
 
 	if hints != nil && hints.Step > 0 {
-		if enabler, ok := chunks.(chunkCacheEnabler); ok {
-			enabler.EnableChunkCache()
-		}
+		enableChunkCache(chunks)
 	}
 
 	if hints != nil {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Follow-up to #18302.

The TSDB head stores in-memory chunks as a newest-first linked list, while chunk IDs address chunks in oldest-first logical order after any m-mapped chunks. Several hot paths repeatedly walked that linked list to resolve chunk offsets or count chunks, turning series with many head chunks into O(n²) work. I found this while profiling Grafana Mimir ingesters in the cloud after spotting containers with extreme CPU utilization.

#### Changes

This PR optimizes head chunk access paths by collecting head chunks once in oldest-first order for paths that need to iterate or index all of them, instead of repeatedly walking the linked list. It applies that shape to mmap, series chunk metadata construction, iterator isolation accounting, and chunk lookup paths.

It also uses the tracked `headChunkCount` for O(1) count reads where callers only need the list length, and adds small helper methods so `headChunks` and `headChunkCount` stay synchronized when chunks are pushed, truncated, loaded, reset, or m-mapped.

For direct `memSeries.chunk()` lookups, the PR keeps the existing mmapped-chunk lookup behavior, adds a fast path for pre-collected head chunks, and uses the tracked count for the linked-list fallback. The common single-head-chunk case avoids the extra collection/cache path.

Compaction now enables the same head-chunk cache used by range-query chunk readers, so compaction from Head can resolve sequential chunk accesses without re-walking the list for each chunk.

The PR adds focused tests for chunk lookup, head chunk count/list synchronization, truncation behavior, cache invalidation, mmap-ready state, and compaction from Head with multiple head chunks. It also adds benchmarks covering chunk lookup, head chunk collection, metadata construction, truncation, mmap, and compaction scenarios.

#### Benchmarks

<details>
<summary>benchstat results</summary>

```console
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz
                                                      │   main.txt    │         optimizations.txt          │
                                                      │    sec/op     │   sec/op     vs base               │
MmapHeadChunks/series=1000/ready=10-16                   402.8µ ±  2%   396.8µ ± 0%        ~ (p=0.065 n=6)
MmapHeadChunks/series=1000/ready=100-16                  481.1µ ±  2%   476.9µ ± 2%        ~ (p=0.394 n=6)
MmapHeadChunks/series=1000/ready=1000-16                 1.154m ±  2%   1.170m ± 3%        ~ (p=0.394 n=6)
MmapHeadChunks/series=10000/ready=100-16                 937.0µ ±  3%   883.2µ ± 2%   -5.74% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=1000-16                1.983m ±  2%   1.940m ± 5%        ~ (p=0.310 n=6)
MmapHeadChunks/series=10000/ready=10000-16               11.37m ±  1%   11.52m ± 2%   +1.27% (p=0.002 n=6)
MmapHeadChunks/series=100000/ready=1000-16               6.737m ±  9%   6.730m ± 8%        ~ (p=0.699 n=6)
MmapHeadChunks/series=100000/ready=10000-16              18.08m ±  1%   18.20m ± 4%        ~ (p=0.485 n=6)
MmapHeadChunks/series=100000/ready=100000-16             114.8m ±  2%   115.7m ± 4%        ~ (p=0.937 n=6)
SeriesChunkIteration/1-16                                4.825n ±  4%   4.274n ± 1%  -11.41% (p=0.002 n=6)
SeriesChunkIteration/4-16                                16.82n ±  2%   15.31n ± 1%   -8.95% (p=0.002 n=6)
SeriesChunkIteration/16-16                               64.45n ±  1%   59.29n ± 2%   -8.00% (p=0.002 n=6)
SeriesChunkIteration/64-16                               263.0n ±  5%   244.6n ± 1%   -7.00% (p=0.002 n=6)
SeriesChunkIteration/256-16                             1025.0n ±  1%   953.7n ± 1%   -6.96% (p=0.002 n=6)
AppendSeriesChunks/headOnly/1-16                         11.34n ±  1%   11.46n ± 1%   +1.15% (p=0.039 n=6)
AppendSeriesChunks/withMmapped/1-16                      19.54n ±  1%   19.47n ± 2%        ~ (p=0.485 n=6)
AppendSeriesChunks/headOnly/4-16                         152.5n ±  1%   151.8n ± 2%        ~ (p=0.732 n=6)
AppendSeriesChunks/withMmapped/4-16                      185.6n ±  0%   186.3n ± 1%        ~ (p=0.472 n=6)
AppendSeriesChunks/headOnly/16-16                        423.7n ±  2%   425.5n ± 1%        ~ (p=0.589 n=6)
AppendSeriesChunks/withMmapped/16-16                     568.2n ±  1%   562.0n ± 1%        ~ (p=0.093 n=6)
AppendSeriesChunks/headOnly/64-16                        1.353µ ±  2%   1.367µ ± 1%        ~ (p=0.180 n=6)
AppendSeriesChunks/withMmapped/64-16                     1.931µ ±  1%   1.942µ ± 1%        ~ (p=0.310 n=6)
AppendSeriesChunks/headOnly/256-16                       5.485µ ±  1%   5.513µ ± 3%        ~ (p=0.132 n=6)
AppendSeriesChunks/withMmapped/256-16                    8.062µ ±  1%   8.061µ ± 1%        ~ (p=1.000 n=6)
CollectHeadChunks/1-16                                   113.1n ±  2%   116.5n ± 2%   +2.96% (p=0.004 n=6)
CollectHeadChunks/4-16                                   119.7n ±  1%   124.0n ± 3%   +3.59% (p=0.002 n=6)
CollectHeadChunks/16-16                                  135.1n ±  1%   139.1n ± 1%   +2.96% (p=0.002 n=6)
CollectHeadChunks/64-16                                  630.9n ±  2%   646.7n ± 1%   +2.50% (p=0.009 n=6)
CollectHeadChunks/256-16                                 2.866µ ± 15%   2.885µ ± 3%        ~ (p=0.368 n=6)
SeriesChunk/1-16                                         4.852n ±  2%   3.959n ± 1%  -18.39% (p=0.002 n=6)
SeriesChunk/4-16                                         9.850n ±  1%   5.960n ± 2%  -39.49% (p=0.002 n=6)
SeriesChunk/16-16                                        18.25n ±  1%   11.04n ± 2%  -39.50% (p=0.002 n=6)
SeriesChunk/64-16                                        94.13n ±  2%   48.79n ± 2%  -48.17% (p=0.002 n=6)
SeriesChunk/256-16                                       574.0n ±  2%   272.6n ± 1%  -52.51% (p=0.002 n=6)
ChunkLookup/1-16                                         4.839n ±  4%   3.968n ± 2%  -18.00% (p=0.002 n=6)
ChunkLookup/4-16                                         7.924n ±  0%   4.876n ± 1%  -38.48% (p=0.002 n=6)
ChunkLookup/16-16                                       15.245n ±  1%   6.569n ± 7%  -56.91% (p=0.002 n=6)
ChunkLookup/64-16                                        81.95n ±  2%   24.45n ± 2%  -70.16% (p=0.002 n=6)
ChunkLookup/256-16                                       430.1n ±  2%   128.7n ± 2%  -70.07% (p=0.002 n=6)
TruncateChunksBefore/1-16                                55.68n ±  1%   55.90n ± 1%        ~ (p=0.331 n=6)
TruncateChunksBefore/4-16                                201.3n ±  1%   202.7n ± 2%        ~ (p=0.071 n=6)
TruncateChunksBefore/16-16                               751.9n ±  1%   740.6n ± 1%   -1.49% (p=0.009 n=6)
TruncateChunksBefore/64-16                               2.913µ ±  1%   2.913µ ± 1%        ~ (p=0.853 n=6)
TruncateChunksBefore/256-16                              11.67µ ±  2%   11.63µ ± 1%        ~ (p=0.310 n=6)
geomean                                                  4.782µ         4.151µ       -13.21%

                                                      │    main.txt     │          optimizations.txt           │
                                                      │      B/op       │     B/op      vs base                │
CompactionFromHead/labelnames=1,labelvalues=100000-16   105.0Mi ±  0%     105.1Mi ± 0%  +0.13% (p=0.041 n=6)
CompactionFromHead/labelnames=10,labelvalues=10000-16   108.7Mi ±  0%     108.8Mi ± 0%       ~ (p=0.132 n=6)
CompactionFromHead/labelnames=100,labelvalues=1000-16   112.0Mi ±  0%     111.8Mi ± 0%       ~ (p=0.240 n=6)
CompactionFromHead/labelnames=1000,labelvalues=100-16   105.9Mi ±  0%     105.8Mi ± 0%       ~ (p=0.589 n=6)
CompactionFromHead/labelnames=10000,labelvalues=10-16   111.0Mi ±  1%     110.9Mi ± 0%       ~ (p=0.589 n=6)
MmapHeadChunks/series=1000/ready=10-16                  2.717Ki ±  3%     2.681Ki ± 4%       ~ (p=0.394 n=6)
MmapHeadChunks/series=1000/ready=100-16                 16.42Ki ±  3%     16.66Ki ± 3%       ~ (p=0.699 n=6)
MmapHeadChunks/series=1000/ready=1000-16                145.5Ki ±  1%     145.3Ki ± 6%       ~ (p=0.818 n=6)
MmapHeadChunks/series=10000/ready=100-16                17.74Ki ±  4%     16.76Ki ± 3%  -5.50% (p=0.009 n=6)
MmapHeadChunks/series=10000/ready=1000-16               150.9Ki ±  8%     139.2Ki ± 8%  -7.73% (p=0.026 n=6)
MmapHeadChunks/series=10000/ready=10000-16              1.345Mi ±  0%     1.345Mi ± 2%       ~ (p=0.450 n=6)
MmapHeadChunks/series=100000/ready=1000-16              165.4Ki ±  3%     164.4Ki ± 3%       ~ (p=0.981 n=6)
MmapHeadChunks/series=100000/ready=10000-16             1.474Mi ± 10%     1.473Mi ± 2%       ~ (p=0.900 n=6)
MmapHeadChunks/series=100000/ready=100000-16            13.64Mi ±  3%     13.64Mi ± 3%       ~ (p=1.000 n=6)
SeriesChunkIteration/1-16                                 0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunkIteration/4-16                                 0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunkIteration/16-16                                0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunkIteration/64-16                                0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunkIteration/256-16                               0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/headOnly/1-16                          0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/withMmapped/1-16                       0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/headOnly/4-16                          56.00 ±  0%       56.00 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/withMmapped/4-16                       56.00 ±  0%       56.00 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/headOnly/16-16                         248.0 ±  0%       248.0 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/withMmapped/16-16                      248.0 ±  0%       248.0 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/headOnly/64-16                        1016.0 ±  0%      1016.0 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/withMmapped/64-16                     1016.0 ±  0%      1016.0 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/headOnly/256-16                      4.367Ki ±  0%     4.367Ki ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/withMmapped/256-16                   4.367Ki ±  0%     4.367Ki ± 0%       ~ (p=1.000 n=6) ¹
CollectHeadChunks/1-16                                    152.0 ±  0%       152.0 ± 0%       ~ (p=1.000 n=6) ¹
CollectHeadChunks/4-16                                    152.0 ±  0%       152.0 ± 0%       ~ (p=1.000 n=6) ¹
CollectHeadChunks/16-16                                   152.0 ±  0%       152.0 ± 0%       ~ (p=1.000 n=6) ¹
CollectHeadChunks/64-16                                   920.0 ±  0%       920.0 ± 0%       ~ (p=1.000 n=6) ¹
CollectHeadChunks/256-16                                4.273Ki ±  0%     4.273Ki ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunk/1-16                                          0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunk/4-16                                          0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunk/16-16                                         0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunk/64-16                                         0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunk/256-16                                        0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
ChunkLookup/1-16                                          0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
ChunkLookup/4-16                                          0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
ChunkLookup/16-16                                         0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
ChunkLookup/64-16                                         0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
ChunkLookup/256-16                                        0.000 ±  0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
TruncateChunksBefore/1-16                                 48.00 ±  0%       48.00 ± 0%       ~ (p=1.000 n=6) ¹
TruncateChunksBefore/4-16                                 192.0 ±  0%       192.0 ± 0%       ~ (p=1.000 n=6) ¹
TruncateChunksBefore/16-16                                768.0 ±  0%       768.0 ± 0%       ~ (p=1.000 n=6) ¹
TruncateChunksBefore/64-16                              3.000Ki ±  0%     3.000Ki ± 0%       ~ (p=1.000 n=6) ¹
TruncateChunksBefore/256-16                             12.00Ki ±  0%     12.00Ki ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                               ²                 -0.30%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                      │   main.txt    │          optimizations.txt          │
                                                      │   allocs/op   │  allocs/op   vs base                │
CompactionFromHead/labelnames=1,labelvalues=100000-16   918.1k ± 0%     918.2k ± 0%       ~ (p=0.065 n=6)
CompactionFromHead/labelnames=10,labelvalues=10000-16   983.6k ± 0%     983.6k ± 0%       ~ (p=0.390 n=6)
CompactionFromHead/labelnames=100,labelvalues=1000-16   999.4k ± 0%     999.4k ± 0%       ~ (p=0.799 n=6)
CompactionFromHead/labelnames=1000,labelvalues=100-16   1.010M ± 0%     1.010M ± 0%       ~ (p=0.623 n=6)
CompactionFromHead/labelnames=10000,labelvalues=10-16   1.059M ± 0%     1.059M ± 0%       ~ (p=0.509 n=6)
MmapHeadChunks/series=1000/ready=10-16                   11.00 ± 0%      11.00 ± 0%       ~ (p=1.000 n=6) ¹
MmapHeadChunks/series=1000/ready=100-16                  105.5 ± 0%      105.0 ± 1%       ~ (p=1.000 n=6)
MmapHeadChunks/series=1000/ready=1000-16                1.037k ± 0%     1.037k ± 0%       ~ (p=1.000 n=6)
MmapHeadChunks/series=10000/ready=100-16                 107.0 ± 0%      107.0 ± 0%       ~ (p=1.000 n=6) ¹
MmapHeadChunks/series=10000/ready=1000-16               1.046k ± 0%     1.046k ± 0%       ~ (p=0.545 n=6)
MmapHeadChunks/series=10000/ready=10000-16              11.05k ± 0%     11.05k ± 0%       ~ (p=1.000 n=6)
MmapHeadChunks/series=100000/ready=1000-16              1.087k ± 0%     1.087k ± 0%       ~ (p=0.602 n=6)
MmapHeadChunks/series=100000/ready=10000-16             11.43k ± 1%     11.40k ± 1%       ~ (p=0.779 n=6)
MmapHeadChunks/series=100000/ready=100000-16            151.3k ± 6%     151.3k ± 6%       ~ (p=1.000 n=6)
SeriesChunkIteration/1-16                                0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunkIteration/4-16                                0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunkIteration/16-16                               0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunkIteration/64-16                               0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunkIteration/256-16                              0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/headOnly/1-16                         0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/withMmapped/1-16                      0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/headOnly/4-16                         3.000 ± 0%      3.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/withMmapped/4-16                      3.000 ± 0%      3.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/headOnly/16-16                        5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/withMmapped/16-16                     5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/headOnly/64-16                        7.000 ± 0%      7.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/withMmapped/64-16                     7.000 ± 0%      7.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/headOnly/256-16                       9.000 ± 0%      9.000 ± 0%       ~ (p=1.000 n=6) ¹
AppendSeriesChunks/withMmapped/256-16                    9.000 ± 0%      9.000 ± 0%       ~ (p=1.000 n=6) ¹
CollectHeadChunks/1-16                                   2.000 ± 0%      2.000 ± 0%       ~ (p=1.000 n=6) ¹
CollectHeadChunks/4-16                                   2.000 ± 0%      2.000 ± 0%       ~ (p=1.000 n=6) ¹
CollectHeadChunks/16-16                                  2.000 ± 0%      2.000 ± 0%       ~ (p=1.000 n=6) ¹
CollectHeadChunks/64-16                                  4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=6) ¹
CollectHeadChunks/256-16                                 6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunk/1-16                                         0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunk/4-16                                         0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunk/16-16                                        0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunk/64-16                                        0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
SeriesChunk/256-16                                       0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
ChunkLookup/1-16                                         0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
ChunkLookup/4-16                                         0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
ChunkLookup/16-16                                        0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
ChunkLookup/64-16                                        0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
ChunkLookup/256-16                                       0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
TruncateChunksBefore/1-16                                1.000 ± 0%      1.000 ± 0%       ~ (p=1.000 n=6) ¹
TruncateChunksBefore/4-16                                4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=6) ¹
TruncateChunksBefore/16-16                               16.00 ± 0%      16.00 ± 0%       ~ (p=1.000 n=6) ¹
TruncateChunksBefore/64-16                               64.00 ± 0%      64.00 ± 0%       ~ (p=1.000 n=6) ¹
TruncateChunksBefore/256-16                              256.0 ± 0%      256.0 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                             ²                -0.01%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

</details>

<details>
<summary>benchstat results: compaction</summary>

```console
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz
                                                               │ main-compaction.txt │    optimizations-compaction.txt    │
                                                               │       sec/op        │   sec/op     vs base               │
CompactionFromHead/labelnames=1,labelvalues=100000-16                    658.0m ± 1%   668.6m ± 1%   +1.60% (p=0.009 n=6)
CompactionFromHead/labelnames=10,labelvalues=10000-16                    663.5m ± 1%   681.1m ± 2%   +2.66% (p=0.002 n=6)
CompactionFromHead/labelnames=100,labelvalues=1000-16                    667.2m ± 1%   675.6m ± 1%   +1.27% (p=0.009 n=6)
CompactionFromHead/labelnames=1000,labelvalues=100-16                    658.9m ± 0%   669.1m ± 1%   +1.55% (p=0.002 n=6)
CompactionFromHead/labelnames=10000,labelvalues=10-16                    693.8m ± 3%   702.1m ± 1%        ~ (p=0.132 n=6)
CompactionFromHead/many_head_chunks/series=100000,chunks=1-16            852.6m ± 1%   851.9m ± 2%        ~ (p=0.818 n=6)
CompactionFromHead/many_head_chunks/series=100000,chunks=10-16            1.371 ± 2%    1.389 ± 3%        ~ (p=0.180 n=6)
CompactionFromHead/many_head_chunks/series=10,chunks=100-16              230.3m ± 2%   231.2m ± 3%        ~ (p=0.394 n=6)
CompactionFromHead/many_head_chunks/series=10,chunks=1000-16             271.7m ± 1%   238.1m ± 2%  -12.37% (p=0.002 n=6)
geomean                                                                  597.8m        595.5m        -0.38%

                                                               │ main-compaction.txt │    optimizations-compaction.txt    │
                                                               │        B/op         │     B/op      vs base              │
CompactionFromHead/labelnames=1,labelvalues=100000-16                   105.1Mi ± 0%   105.1Mi ± 0%       ~ (p=0.937 n=6)
CompactionFromHead/labelnames=10,labelvalues=10000-16                   108.7Mi ± 0%   108.8Mi ± 0%       ~ (p=0.589 n=6)
CompactionFromHead/labelnames=100,labelvalues=1000-16                   111.9Mi ± 1%   111.8Mi ± 0%       ~ (p=0.310 n=6)
CompactionFromHead/labelnames=1000,labelvalues=100-16                   106.0Mi ± 0%   105.9Mi ± 0%       ~ (p=0.818 n=6)
CompactionFromHead/labelnames=10000,labelvalues=10-16                   111.1Mi ± 1%   111.0Mi ± 1%       ~ (p=0.699 n=6)
CompactionFromHead/many_head_chunks/series=100000,chunks=1-16           163.3Mi ± 0%   163.3Mi ± 0%       ~ (p=0.937 n=6)
CompactionFromHead/many_head_chunks/series=100000,chunks=10-16          239.0Mi ± 0%   239.0Mi ± 0%       ~ (p=0.177 n=6)
CompactionFromHead/many_head_chunks/series=10,chunks=100-16             32.59Mi ± 0%   32.61Mi ± 0%  +0.06% (p=0.002 n=6)
CompactionFromHead/many_head_chunks/series=10,chunks=1000-16            33.67Mi ± 0%   33.85Mi ± 0%  +0.54% (p=0.002 n=6)
geomean                                                                 95.25Mi        95.28Mi       +0.04%

                                                               │ main-compaction.txt │   optimizations-compaction.txt    │
                                                               │      allocs/op      │  allocs/op   vs base              │
CompactionFromHead/labelnames=1,labelvalues=100000-16                    918.2k ± 0%   918.2k ± 0%       ~ (p=0.937 n=6)
CompactionFromHead/labelnames=10,labelvalues=10000-16                    983.6k ± 0%   983.6k ± 0%       ~ (p=0.485 n=6)
CompactionFromHead/labelnames=100,labelvalues=1000-16                    999.3k ± 0%   999.3k ± 0%       ~ (p=0.608 n=6)
CompactionFromHead/labelnames=1000,labelvalues=100-16                    1.010M ± 0%   1.010M ± 0%       ~ (p=0.619 n=6)
CompactionFromHead/labelnames=10000,labelvalues=10-16                    1.059M ± 0%   1.059M ± 0%       ~ (p=0.589 n=6)
CompactionFromHead/many_head_chunks/series=100000,chunks=1-16            2.102M ± 0%   2.102M ± 0%       ~ (p=0.734 n=6)
CompactionFromHead/many_head_chunks/series=100000,chunks=10-16           3.002M ± 0%   3.002M ± 0%  +0.00% (p=0.015 n=6)
CompactionFromHead/many_head_chunks/series=10,chunks=100-16              1.864k ± 0%   1.902k ± 0%  +2.04% (p=0.002 n=6)
CompactionFromHead/many_head_chunks/series=10,chunks=1000-16             10.97k ± 0%   11.04k ± 0%  +0.63% (p=0.002 n=6)
geomean                                                                  368.3k        369.3k       +0.29%
```

</details>

#### Does this PR introduce a user-facing change?
```release-notes
[PERF] TSDB: Fix O(n²) head chunk iteration and optimize chunk lookups using tracked head chunk counts and pre-collected head chunks
```
