### PR TITLE
Fix typos in comments and metric help strings

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -325,7 +325,7 @@ func newQueueManagerMetrics(r prometheus.Registerer, rn, e string) *queueManager
 		Namespace:   namespace,
 		Subsystem:   subsystem,
 		Name:        "max_samples_per_send",
-		Help:        "The maximum number of samples to be sent, in a single request, to the remote storage. Note that, when sending of exemplars over remote write is enabled, exemplars count towards this limt.",
+		Help:        "The maximum number of samples to be sent, in a single request, to the remote storage. Note that, when sending of exemplars over remote write is enabled, exemplars count towards this limit.",
 		ConstLabels: constLabels,
 	})
 

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -171,7 +171,7 @@ type LeveledCompactorOptions struct {
 	// MergeFunc is used for merging series together in vertical compaction. By default storage.NewCompactingChunkSeriesMerger(storage.ChainedSeriesMerge) is used.
 	MergeFunc storage.VerticalChunkSeriesMergeFunc
 
-	// BlockExcludeFilter is used to decide which blocks are exluded from compactions.
+	// BlockExcludeFilter is used to decide which blocks are excluded from compactions.
 	BlockExcludeFilter BlockExcludeFilterFunc
 
 	// EnableOverlappingCompaction enables compaction of overlapping blocks. In Prometheus it is always enabled.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -757,7 +757,7 @@ func (h *Head) Init(minValidTime int64) error {
 			snapIdx, snapOffset = -1, 0
 
 			// If this fails, data will be recovered from WAL.
-			// Hence we wont lose any data (given WAL is not corrupt).
+			// Hence we won't lose any data (given WAL is not corrupt).
 			mmappedChunks, oooMmappedChunks, lastMmapRef, err = h.removeCorruptedMmappedChunks(err)
 			if err != nil {
 				return err


### PR DESCRIPTION
Fix spelling mistakes found by [codespell](https://github.com/codespell-project/codespell):

- `limt` → `limit` in metric help text (storage/remote/queue_manager.go)
- `exluded` → `excluded` in comment (tsdb/compact.go)
- `wont` → `won't` in comment (tsdb/head.go)

```release-notes
NONE
```