### PR TITLE
fix: correctly document supported formats for duration query request parameters in OpenAPI spec

### DIFF
--- a/web/api/v1/openapi_helpers.go
+++ b/web/api/v1/openapi_helpers.go
@@ -174,15 +174,15 @@ func durationSchema() *base.SchemaProxy {
 			base.CreateSchemaProxy(&base.Schema{
 				Type:        []string{"string"},
 				Format:      "duration",
-				Description: "Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.",
+				Description: "Human-readable form such as 15s or 2m30s. Supported units are ms (milliseconds), s (seconds), m (minutes), h (hours), d (days), w (weeks) and y (years).",
 			}),
 			base.CreateSchemaProxy(&base.Schema{
 				Type:        []string{"number"},
 				Format:      "float",
-				Description: "Fractional number of seconds, such as 2 or 4.5.",
+				Description: "Fractional number of seconds.",
 			}),
 		},
-		Description: "Duration in humand-readable or numeric format.",
+		Description: "Duration in human-readable or numeric format.",
 	})
 }
 

--- a/web/api/v1/openapi_helpers.go
+++ b/web/api/v1/openapi_helpers.go
@@ -168,6 +168,24 @@ func timestampSchema() *base.SchemaProxy {
 	})
 }
 
+func durationSchema() *base.SchemaProxy {
+	return base.CreateSchemaProxy(&base.Schema{
+		OneOf: []*base.SchemaProxy{
+			base.CreateSchemaProxy(&base.Schema{
+				Type:        []string{"string"},
+				Format:      "duration",
+				Description: "Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.",
+			}),
+			base.CreateSchemaProxy(&base.Schema{
+				Type:        []string{"number"},
+				Format:      "float",
+				Description: "Fractional number of seconds, such as 2 or 4.5.",
+			}),
+		},
+		Description: "Duration in humand-readable or numeric format.",
+	})
+}
+
 func stringSchemaWithConstValue(value string) *base.SchemaProxy {
 	node := &yaml.Node{Kind: yaml.ScalarNode, Value: value}
 	return base.CreateSchemaProxy(&base.Schema{

--- a/web/api/v1/openapi_paths.go
+++ b/web/api/v1/openapi_paths.go
@@ -30,8 +30,8 @@ func (*OpenAPIBuilder) queryPath() *v3.PathItem {
 		queryParamWithExample("limit", "The maximum number of metrics to return.", false, integerSchema(), []example{{"example", 100}}),
 		queryParamWithExample("time", "The evaluation timestamp (optional, defaults to current time).", false, timestampSchema(), timestampExamples(exampleTime)),
 		queryParamWithExample("query", "The PromQL query to execute.", true, stringSchema(), []example{{"example", "up"}}),
-		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, stringSchema(), []example{{"example", "30s"}}),
-		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, stringSchema(), []example{{"example", "5m"}}),
+		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, durationSchema(), []example{{"example", "30s"}}),
+		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, durationSchema(), []example{{"example", "5m"}}),
 		queryParamWithExample("stats", "When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.", false, stringSchema(), []example{{"example", "all"}}),
 	}
 	return &v3.PathItem{
@@ -57,10 +57,10 @@ func (*OpenAPIBuilder) queryRangePath() *v3.PathItem {
 		queryParamWithExample("limit", "The maximum number of metrics to return.", false, integerSchema(), []example{{"example", 100}}),
 		queryParamWithExample("start", "The start time of the query.", true, timestampSchema(), timestampExamples(exampleTime.Add(-1*time.Hour))),
 		queryParamWithExample("end", "The end time of the query.", true, timestampSchema(), timestampExamples(exampleTime)),
-		queryParamWithExample("step", "The step size of the query.", true, stringSchema(), []example{{"example", "15s"}}),
+		queryParamWithExample("step", "The step size of the query.", true, durationSchema(), []example{{"example", "15s"}}),
 		queryParamWithExample("query", "The query to execute.", true, stringSchema(), []example{{"example", "rate(prometheus_http_requests_total{handler=\"/api/v1/query\"}[5m])"}}),
-		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, stringSchema(), []example{{"example", "30s"}}),
-		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, stringSchema(), []example{{"example", "5m"}}),
+		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, durationSchema(), []example{{"example", "30s"}}),
+		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, durationSchema(), []example{{"example", "5m"}}),
 		queryParamWithExample("stats", "When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.", false, stringSchema(), []example{{"example", "all"}}),
 	}
 	return &v3.PathItem{

--- a/web/api/v1/openapi_paths.go
+++ b/web/api/v1/openapi_paths.go
@@ -30,8 +30,8 @@ func (*OpenAPIBuilder) queryPath() *v3.PathItem {
 		queryParamWithExample("limit", "The maximum number of metrics to return.", false, integerSchema(), []example{{"example", 100}}),
 		queryParamWithExample("time", "The evaluation timestamp (optional, defaults to current time).", false, timestampSchema(), timestampExamples(exampleTime)),
 		queryParamWithExample("query", "The PromQL query to execute.", true, stringSchema(), []example{{"example", "up"}}),
-		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, durationSchema(), []example{{"example", "30s"}}),
-		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, durationSchema(), []example{{"example", "5m"}}),
+		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, durationSchema(), []example{{"duration", "1m30s"}, {"number", "90"}}),
+		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, durationSchema(), []example{{"duration", "5m"}, {"number", "300"}}),
 		queryParamWithExample("stats", "When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.", false, stringSchema(), []example{{"example", "all"}}),
 	}
 	return &v3.PathItem{
@@ -57,10 +57,10 @@ func (*OpenAPIBuilder) queryRangePath() *v3.PathItem {
 		queryParamWithExample("limit", "The maximum number of metrics to return.", false, integerSchema(), []example{{"example", 100}}),
 		queryParamWithExample("start", "The start time of the query.", true, timestampSchema(), timestampExamples(exampleTime.Add(-1*time.Hour))),
 		queryParamWithExample("end", "The end time of the query.", true, timestampSchema(), timestampExamples(exampleTime)),
-		queryParamWithExample("step", "The step size of the query.", true, durationSchema(), []example{{"example", "15s"}}),
+		queryParamWithExample("step", "The step size of the query.", true, durationSchema(), []example{{"duration", "15s"}, {"number", "15"}}),
 		queryParamWithExample("query", "The query to execute.", true, stringSchema(), []example{{"example", "rate(prometheus_http_requests_total{handler=\"/api/v1/query\"}[5m])"}}),
-		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, durationSchema(), []example{{"example", "30s"}}),
-		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, durationSchema(), []example{{"example", "5m"}}),
+		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, durationSchema(), []example{{"duration", "1m30s"}, {"number", "90"}}),
+		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, durationSchema(), []example{{"duration", "5m"}, {"number", "300"}}),
 		queryParamWithExample("stats", "When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.", false, stringSchema(), []example{{"example", "all"}}),
 	}
 	return &v3.PathItem{

--- a/web/api/v1/testdata/openapi_3.1_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.1_golden.yaml
@@ -62,7 +62,14 @@ paths:
                   required: false
                   explode: false
                   schema:
-                    type: string
+                    oneOf:
+                        - type: string
+                          format: duration
+                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                        - type: number
+                          format: float
+                          description: Fractional number of seconds, such as 2 or 4.5.
+                    description: Duration in humand-readable or numeric format.
                   examples:
                     example:
                         value: 30s
@@ -72,7 +79,14 @@ paths:
                   required: false
                   explode: false
                   schema:
-                    type: string
+                    oneOf:
+                        - type: string
+                          format: duration
+                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                        - type: number
+                          format: float
+                          description: Fractional number of seconds, such as 2 or 4.5.
+                    description: Duration in humand-readable or numeric format.
                   examples:
                     example:
                         value: 5m
@@ -248,7 +262,14 @@ paths:
                   required: true
                   explode: false
                   schema:
-                    type: string
+                    oneOf:
+                        - type: string
+                          format: duration
+                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                        - type: number
+                          format: float
+                          description: Fractional number of seconds, such as 2 or 4.5.
+                    description: Duration in humand-readable or numeric format.
                   examples:
                     example:
                         value: 15s
@@ -268,7 +289,14 @@ paths:
                   required: false
                   explode: false
                   schema:
-                    type: string
+                    oneOf:
+                        - type: string
+                          format: duration
+                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                        - type: number
+                          format: float
+                          description: Fractional number of seconds, such as 2 or 4.5.
+                    description: Duration in humand-readable or numeric format.
                   examples:
                     example:
                         value: 30s
@@ -278,7 +306,14 @@ paths:
                   required: false
                   explode: false
                   schema:
-                    type: string
+                    oneOf:
+                        - type: string
+                          format: duration
+                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                        - type: number
+                          format: float
+                          description: Fractional number of seconds, such as 2 or 4.5.
+                    description: Duration in humand-readable or numeric format.
                   examples:
                     example:
                         value: 5m

--- a/web/api/v1/testdata/openapi_3.1_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.1_golden.yaml
@@ -65,14 +65,16 @@ paths:
                     oneOf:
                         - type: string
                           format: duration
-                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                          description: Human-readable form such as 15s or 2m30s. Supported units are ms (milliseconds), s (seconds), m (minutes), h (hours), d (days), w (weeks) and y (years).
                         - type: number
                           format: float
-                          description: Fractional number of seconds, such as 2 or 4.5.
-                    description: Duration in humand-readable or numeric format.
+                          description: Fractional number of seconds.
+                    description: Duration in human-readable or numeric format.
                   examples:
-                    example:
-                        value: 30s
+                    duration:
+                        value: 1m30s
+                    number:
+                        value: "90"
                 - name: lookback_delta
                   in: query
                   description: Override the lookback period for this query. Optional.
@@ -82,14 +84,16 @@ paths:
                     oneOf:
                         - type: string
                           format: duration
-                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                          description: Human-readable form such as 15s or 2m30s. Supported units are ms (milliseconds), s (seconds), m (minutes), h (hours), d (days), w (weeks) and y (years).
                         - type: number
                           format: float
-                          description: Fractional number of seconds, such as 2 or 4.5.
-                    description: Duration in humand-readable or numeric format.
+                          description: Fractional number of seconds.
+                    description: Duration in human-readable or numeric format.
                   examples:
-                    example:
+                    duration:
                         value: 5m
+                    number:
+                        value: "300"
                 - name: stats
                   in: query
                   description: When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.
@@ -265,14 +269,16 @@ paths:
                     oneOf:
                         - type: string
                           format: duration
-                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                          description: Human-readable form such as 15s or 2m30s. Supported units are ms (milliseconds), s (seconds), m (minutes), h (hours), d (days), w (weeks) and y (years).
                         - type: number
                           format: float
-                          description: Fractional number of seconds, such as 2 or 4.5.
-                    description: Duration in humand-readable or numeric format.
+                          description: Fractional number of seconds.
+                    description: Duration in human-readable or numeric format.
                   examples:
-                    example:
+                    duration:
                         value: 15s
+                    number:
+                        value: "15"
                 - name: query
                   in: query
                   description: The query to execute.
@@ -292,14 +298,16 @@ paths:
                     oneOf:
                         - type: string
                           format: duration
-                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                          description: Human-readable form such as 15s or 2m30s. Supported units are ms (milliseconds), s (seconds), m (minutes), h (hours), d (days), w (weeks) and y (years).
                         - type: number
                           format: float
-                          description: Fractional number of seconds, such as 2 or 4.5.
-                    description: Duration in humand-readable or numeric format.
+                          description: Fractional number of seconds.
+                    description: Duration in human-readable or numeric format.
                   examples:
-                    example:
-                        value: 30s
+                    duration:
+                        value: 1m30s
+                    number:
+                        value: "90"
                 - name: lookback_delta
                   in: query
                   description: Override the lookback period for this query. Optional.
@@ -309,14 +317,16 @@ paths:
                     oneOf:
                         - type: string
                           format: duration
-                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                          description: Human-readable form such as 15s or 2m30s. Supported units are ms (milliseconds), s (seconds), m (minutes), h (hours), d (days), w (weeks) and y (years).
                         - type: number
                           format: float
-                          description: Fractional number of seconds, such as 2 or 4.5.
-                    description: Duration in humand-readable or numeric format.
+                          description: Fractional number of seconds.
+                    description: Duration in human-readable or numeric format.
                   examples:
-                    example:
+                    duration:
                         value: 5m
+                    number:
+                        value: "300"
                 - name: stats
                   in: query
                   description: When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.

--- a/web/api/v1/testdata/openapi_3.2_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.2_golden.yaml
@@ -62,7 +62,14 @@ paths:
                   required: false
                   explode: false
                   schema:
-                    type: string
+                    oneOf:
+                        - type: string
+                          format: duration
+                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                        - type: number
+                          format: float
+                          description: Fractional number of seconds, such as 2 or 4.5.
+                    description: Duration in humand-readable or numeric format.
                   examples:
                     example:
                         value: 30s
@@ -72,7 +79,14 @@ paths:
                   required: false
                   explode: false
                   schema:
-                    type: string
+                    oneOf:
+                        - type: string
+                          format: duration
+                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                        - type: number
+                          format: float
+                          description: Fractional number of seconds, such as 2 or 4.5.
+                    description: Duration in humand-readable or numeric format.
                   examples:
                     example:
                         value: 5m
@@ -248,7 +262,14 @@ paths:
                   required: true
                   explode: false
                   schema:
-                    type: string
+                    oneOf:
+                        - type: string
+                          format: duration
+                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                        - type: number
+                          format: float
+                          description: Fractional number of seconds, such as 2 or 4.5.
+                    description: Duration in humand-readable or numeric format.
                   examples:
                     example:
                         value: 15s
@@ -268,7 +289,14 @@ paths:
                   required: false
                   explode: false
                   schema:
-                    type: string
+                    oneOf:
+                        - type: string
+                          format: duration
+                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                        - type: number
+                          format: float
+                          description: Fractional number of seconds, such as 2 or 4.5.
+                    description: Duration in humand-readable or numeric format.
                   examples:
                     example:
                         value: 30s
@@ -278,7 +306,14 @@ paths:
                   required: false
                   explode: false
                   schema:
-                    type: string
+                    oneOf:
+                        - type: string
+                          format: duration
+                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                        - type: number
+                          format: float
+                          description: Fractional number of seconds, such as 2 or 4.5.
+                    description: Duration in humand-readable or numeric format.
                   examples:
                     example:
                         value: 5m

--- a/web/api/v1/testdata/openapi_3.2_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.2_golden.yaml
@@ -65,14 +65,16 @@ paths:
                     oneOf:
                         - type: string
                           format: duration
-                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                          description: Human-readable form such as 15s or 2m30s. Supported units are ms (milliseconds), s (seconds), m (minutes), h (hours), d (days), w (weeks) and y (years).
                         - type: number
                           format: float
-                          description: Fractional number of seconds, such as 2 or 4.5.
-                    description: Duration in humand-readable or numeric format.
+                          description: Fractional number of seconds.
+                    description: Duration in human-readable or numeric format.
                   examples:
-                    example:
-                        value: 30s
+                    duration:
+                        value: 1m30s
+                    number:
+                        value: "90"
                 - name: lookback_delta
                   in: query
                   description: Override the lookback period for this query. Optional.
@@ -82,14 +84,16 @@ paths:
                     oneOf:
                         - type: string
                           format: duration
-                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                          description: Human-readable form such as 15s or 2m30s. Supported units are ms (milliseconds), s (seconds), m (minutes), h (hours), d (days), w (weeks) and y (years).
                         - type: number
                           format: float
-                          description: Fractional number of seconds, such as 2 or 4.5.
-                    description: Duration in humand-readable or numeric format.
+                          description: Fractional number of seconds.
+                    description: Duration in human-readable or numeric format.
                   examples:
-                    example:
+                    duration:
                         value: 5m
+                    number:
+                        value: "300"
                 - name: stats
                   in: query
                   description: When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.
@@ -265,14 +269,16 @@ paths:
                     oneOf:
                         - type: string
                           format: duration
-                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                          description: Human-readable form such as 15s or 2m30s. Supported units are ms (milliseconds), s (seconds), m (minutes), h (hours), d (days), w (weeks) and y (years).
                         - type: number
                           format: float
-                          description: Fractional number of seconds, such as 2 or 4.5.
-                    description: Duration in humand-readable or numeric format.
+                          description: Fractional number of seconds.
+                    description: Duration in human-readable or numeric format.
                   examples:
-                    example:
+                    duration:
                         value: 15s
+                    number:
+                        value: "15"
                 - name: query
                   in: query
                   description: The query to execute.
@@ -292,14 +298,16 @@ paths:
                     oneOf:
                         - type: string
                           format: duration
-                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                          description: Human-readable form such as 15s or 2m30s. Supported units are ms (milliseconds), s (seconds), m (minutes), h (hours), d (days), w (weeks) and y (years).
                         - type: number
                           format: float
-                          description: Fractional number of seconds, such as 2 or 4.5.
-                    description: Duration in humand-readable or numeric format.
+                          description: Fractional number of seconds.
+                    description: Duration in human-readable or numeric format.
                   examples:
-                    example:
-                        value: 30s
+                    duration:
+                        value: 1m30s
+                    number:
+                        value: "90"
                 - name: lookback_delta
                   in: query
                   description: Override the lookback period for this query. Optional.
@@ -309,14 +317,16 @@ paths:
                     oneOf:
                         - type: string
                           format: duration
-                          description: Human-readable form accepted by Go's time.Duration.ParseDuration(), such as 15s or 2m30s.
+                          description: Human-readable form such as 15s or 2m30s. Supported units are ms (milliseconds), s (seconds), m (minutes), h (hours), d (days), w (weeks) and y (years).
                         - type: number
                           format: float
-                          description: Fractional number of seconds, such as 2 or 4.5.
-                    description: Duration in humand-readable or numeric format.
+                          description: Fractional number of seconds.
+                    description: Duration in human-readable or numeric format.
                   examples:
-                    example:
+                    duration:
                         value: 5m
+                    number:
+                        value: "300"
                 - name: stats
                   in: query
                   description: When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.


### PR DESCRIPTION
This PR is a follow up to https://github.com/prometheus/prometheus/pull/18245#issuecomment-4010541782. 

It updates the OpenAPI spec accessible at `/api/v1/openapi.yaml` with the supported formats for duration parameters (step, timeout and lookback delta).

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

(none)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] API: correctly document formats accepted for duration query request parameters (step, timeout and lookback delta) in OpenAPI spec
```
