### PR TITLE
rulefmt: error on multi-document YAML rule files

### DIFF
--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -355,6 +355,14 @@ func Parse(content []byte, ignoreUnknownFields bool, nameValidationScheme model.
 	if err != nil && !errors.Is(err, io.EOF) {
 		errs = append(errs, err)
 	}
+
+	// Check for additional YAML documents. Multi-document YAML rule files are not supported
+	// as extra documents would be silently ignored, which can lead to confusion.
+	var extra any
+	if err = decoder.Decode(&extra); err == nil && extra != nil {
+		errs = append(errs, errors.New("rule file must not contain multiple YAML documents"))
+	}
+
 	err = yaml.Unmarshal(content, &node)
 	if err != nil {
 		errs = append(errs, err)

--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -118,6 +118,10 @@ func TestParseFileFailure(t *testing.T) {
 			nameValidationScheme: model.LegacyValidation,
 			errMsg:               "invalid annotation name: ins-tance",
 		},
+		{
+			filename: "multi_doc.bad.yaml",
+			errMsg:   "rule file must not contain multiple YAML documents",
+		},
 	} {
 		t.Run(c.filename, func(t *testing.T) {
 			if c.nameValidationScheme == model.UnsetValidation {

--- a/model/rulefmt/testdata/multi_doc.bad.yaml
+++ b/model/rulefmt/testdata/multi_doc.bad.yaml
@@ -1,0 +1,13 @@
+groups:
+  - name: first-group
+    rules:
+      - alert: TestAlert
+        expr: up == 0
+        for: 5m
+---
+groups:
+  - name: second-group
+    rules:
+      - alert: TestAlert2
+        expr: up == 1
+        for: 5m


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #15834

#### Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] rulefmt: Error when a rule file contains multiple YAML documents instead of silently ignoring documents beyond the first.
```

## What this PR does / why we need it

The `Parse` function in `model/rulefmt/rulefmt.go` previously silently ignored any YAML documents beyond the first when a rule file contained multiple documents separated by `---`. This silent-ignore behavior was confusing — users could write multi-document rule files and believe all rules were loaded, when only the first document was.

This PR adds a check: after decoding the first YAML document, a second decode is attempted using the same decoder. If a second non-empty document is found, an error is returned:

```
rule file must not contain multiple YAML documents
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/prometheus/prometheus/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally with my changes