### PR TITLE
Small doc fixes

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -159,12 +159,6 @@ global:
   # native histogram with custom buckets.
   [ always_scrape_classic_histograms: <boolean> | default = false ]
 
-  # When enabled, Prometheus stores additional time series for each scrape:
-  # scrape_timeout_seconds, scrape_sample_limit, and scrape_body_size_bytes.
-  # These metrics help monitor how close targets are to their configured limits.
-  # This option can be overridden per scrape config.
-  [ extra_scrape_metrics: <boolean> | default = false ]
-
   # The following explains the various combinations of the last three options
   # in various exposition cases.
   #
@@ -200,6 +194,12 @@ global:
   # convert_classic_histograms_to_nhcb is set to (it would collide with the
   # actual native histogram). However, there will be a classic histogram if (and
   # only if) always_scrape_classic_histograms is set to true.
+
+  # When enabled, Prometheus stores additional time series for each scrape:
+  # scrape_timeout_seconds, scrape_sample_limit, and scrape_body_size_bytes.
+  # These metrics help monitor how close targets are to their configured limits.
+  # This option can be overridden per scrape config.
+  [ extra_scrape_metrics: <boolean> | default = false ]
 
 runtime:
   # Configure the Go garbage collector GOGC parameter
@@ -653,14 +653,14 @@ metric_relabel_configs:
 # native histogram with custom buckets.
 [ always_scrape_classic_histograms: <boolean> | default = <global.always_scrape_classic_histograms> ]
 
+# See global configuration above for further explanations of how the last three
+# options combine their effects.
+
 # When enabled, Prometheus stores additional time series for this scrape job:
 # scrape_timeout_seconds, scrape_sample_limit, and scrape_body_size_bytes.
 # These metrics help monitor how close targets are to their configured limits.
 # If not set, inherits the value from the global configuration.
 [ extra_scrape_metrics: <boolean> | default = <global.extra_scrape_metrics> ]
-
-# See global configuration above for further explanations of how the last three
-# options combine their effects.
 
 ```
 

--- a/documentation/examples/prometheus.yml
+++ b/documentation/examples/prometheus.yml
@@ -30,3 +30,4 @@ scrape_configs:
        # The label name is added as a label `label_name=<label_value>` to any timeseries scraped from this config.
         labels:
           app: "prometheus"
+    scrape_native_histograms: true


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
In https://github.com/prometheus/prometheus/pull/17606/changes#diff-17f1012e0c2fbd9bcd8dff3c23b18ff4b6676eef3beca the docs for `extra_scrape_metrics` was added in between `always_scrape_classic_histograms` and the following more expansive documentation about three histogram scraping configs. This PR just moves `always_scrape_classic_histograms` to after the histogram related configs and doc.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
