### PR TITLE
scrape: reset ticker to align target scrape times with offset and intervals

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -149,9 +149,8 @@ type Options struct {
 	// because of an early startup scrape.
 	InitialScrapeOffset time.Duration
 
-	// private options for testability.
+	// private option for testability.
 	skipJitterOffsetting bool
-	offsetSeed           uint64
 }
 
 // Manager maintains a set of scrape pools and manages start/stop cycles
@@ -270,11 +269,6 @@ func (m *Manager) reload() {
 
 // setOffsetSeed calculates a global offsetSeed per server relying on extra label set.
 func (m *Manager) setOffsetSeed(labels labels.Labels) error {
-	if m.opts.offsetSeed != 0 {
-		m.offsetSeed = m.opts.offsetSeed
-		return nil
-	}
-
 	h := fnv.New64a()
 	hostname, err := osutil.GetFQDN()
 	if err != nil {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1253,9 +1253,8 @@ func (sl *scrapeLoop) getScrapeOffset() time.Duration {
 
 func (sl *scrapeLoop) run(errc chan<- error) {
 	var (
-		last              time.Time
-		alignedScrapeTime = time.Now().Round(0)
-		ticker            = time.NewTicker(sl.interval)
+		last   time.Time
+		ticker = time.NewTicker(sl.interval)
 	)
 	defer func() {
 		if sl.scrapeOnShutdown {
@@ -1284,6 +1283,7 @@ func (sl *scrapeLoop) run(errc chan<- error) {
 
 	// Reset the ticker so target scrape times are aligned to the offset+intervals.
 	ticker.Reset(sl.interval)
+	alignedScrapeTime := time.Now().Round(0)
 
 	for {
 		select {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -6823,7 +6823,6 @@ func TestScrapeOffsetDistribution(t *testing.T) {
 
 		app := teststorage.NewAppendable()
 		opts := &Options{
-			offsetSeed: 1,
 			HTTPClientOptions: []config_util.HTTPClientOption{
 				config_util.WithDialContextFunc(func(ctx context.Context, _, _ string) (net.Conn, error) {
 					srvConn, cliConn := net.Pipe()
@@ -6839,6 +6838,7 @@ func TestScrapeOffsetDistribution(t *testing.T) {
 			},
 		}
 		scrapeManager, err := NewManager(opts, promslog.NewNopLogger(), nil, app, nil, prometheus.NewRegistry())
+		scrapeManager.offsetSeed = 1 // Set a fixed offset seed for deterministic testing.
 		require.NoError(t, err)
 
 		var targets []model.LabelSet


### PR DESCRIPTION
Follow up to https://github.com/prometheus/prometheus/pull/18067

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Rationale
Thinking about the `InitialScrapeOffset`, I'm not sure if we would find it useful for serverless settings yet. As long as we can guarantee a single scrape (which we get as a result of the shutdown scrape in https://github.com/prometheus/prometheus/pull/18067, we should be good to go). I propose removing this option until we have a defined use case.

I also noticed that the jitter only applies to the first scrape and not every scrape. It didn't seem intentional and can cause CPU spikes every interval after the first scrape. Correct me if I'm wrong pls :)

cc @bwplotka @avilevy18 

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes https://github.com/prometheus/prometheus/issues/15359

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
