### PR TITLE
DO NOT REVIEW perf(PromQL): improve floatHistogram.KahanAdd perf with batch Kahan sum

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -1619,6 +1619,34 @@ func kahanAddBuckets(
 					// Bucket is in current span.
 					iBucket += int(deltaIndex)
 					iInSpan += deltaIndex
+
+					// Batch-add contiguous buckets from B that fall within the same span of A.
+					// Within a span of B, bucket indices are consecutive, and if they also
+					// fall within the current span of A, they map to consecutive positions in bucketsA.
+					// Processing them in a single IncSlice call amortizes the noinline function call overhead.
+					batchSize := min(int(spansA[iSpan].Length)-int(iInSpan), int(spanB.Length)-j)
+					if batchSize > 1 && !negative {
+						kahansum.IncSlice(
+							bucketsB[bIdxB:bIdxB+batchSize],
+							bucketsA[iBucket:iBucket+batchSize],
+							compensationBucketsA[iBucket:iBucket+batchSize],
+						)
+						if compensationBucketsB != nil {
+							kahansum.IncSlice(
+								compensationBucketsB[bIdxB:bIdxB+batchSize],
+								bucketsA[iBucket:iBucket+batchSize],
+								compensationBucketsA[iBucket:iBucket+batchSize],
+							)
+						}
+						advance := batchSize - 1
+						iBucket += advance
+						iInSpan += int32(advance)
+						j += advance
+						bIdxB += advance
+						indexB += int32(advance)
+						break
+					}
+
 					bucketsA[iBucket], compensationBucketsA[iBucket] = kahansum.Inc(bucketB, bucketsA[iBucket], compensationBucketsA[iBucket])
 					if compensationBucketB != 0 {
 						bucketsA[iBucket], compensationBucketsA[iBucket] = kahansum.Inc(compensationBucketB, bucketsA[iBucket], compensationBucketsA[iBucket])

--- a/util/kahansum/kahansum.go
+++ b/util/kahansum/kahansum.go
@@ -37,3 +37,23 @@ func Inc(inc, sum, c float64) (newSum, newC float64) {
 func Dec(dec, sum, c float64) (newSum, newC float64) {
 	return Inc(-dec, sum, c)
 }
+
+// IncSlice is the slice version of Inc. It element-wise adds inc into sum using
+// the Kahan summation algorithm, with c holding the compensation values.
+// inc, sum, and c must have the same length.
+func IncSlice(inc, sum, c []float64) {
+	for i, v := range inc {
+		t := sum[i] + v
+		switch {
+		case math.IsInf(t, 0):
+			c[i] = 0
+
+			// Using Neumaier improvement, swap if next term larger than sum.
+		case math.Abs(sum[i]) >= math.Abs(v):
+			c[i] += (sum[i] - t) + v
+		default:
+			c[i] += (v - t) + sum[i]
+		}
+		sum[i] = t
+	}
+}


### PR DESCRIPTION
When there are matching, consecutive bucket ranges in histograms being added, this change utilizes the new `kahan.IncSlice` function to do Kahan summation in batches, avoiding the overhead of noninlineable `kahan.Inc` calls.
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/histogram
cpu: Apple M1 Pro
                              │ before.txt  │              after.txt              │
                              │   sec/op    │   sec/op     vs base                │
FloatHistogramAdd/KahanAdd-10   36.68µ ± 1%   28.26µ ± 4%  -22.95% (p=0.000 n=10)

                              │ before.txt │           after.txt            │
                              │    B/op    │    B/op     vs base            │
FloatHistogramAdd/KahanAdd-10   800.0 ± 0%   800.0 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                              │ before.txt │           after.txt            │
                              │ allocs/op  │ allocs/op   vs base            │
FloatHistogramAdd/KahanAdd-10   3.000 ± 0%   3.000 ± 0%  ~ (p=1.000 n=10) ¹
```

Shrinking the performance gap between `KahanAdd` and plain `Add` further:
```
BenchmarkFloatHistogramAdd/Add
BenchmarkFloatHistogramAdd/Add-10         	   57644	     20615 ns/op	       0 B/op	       0 allocs/op
BenchmarkFloatHistogramAdd/KahanAdd
BenchmarkFloatHistogramAdd/KahanAdd-10    	   39862	     29028 ns/op	     800 B/op	       3 allocs/op
```

@beorn7 @krajorama @crush-on-anechka 

#### Which issue(s) does the PR fix:
Further addresses https://github.com/prometheus/prometheus/issues/18249

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```