### PR TITLE
fix(UI): autocomplete for first_over_time and ts_of_first_over_time

### DIFF
--- a/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
+++ b/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
@@ -318,9 +318,15 @@ export const functionIdentifierTerms = [
     type: 'function',
   },
   {
+    label: 'first_over_time',
+    detail: 'function',
+    info: 'Return the value of the oldest sample in the specified interval',
+    type: 'function',
+  },
+  {
     label: 'last_over_time',
     detail: 'function',
-    info: 'The most recent point value in specified interval.',
+    info: 'Return the value of the most recent sample in the specified interval',
     type: 'function',
   },
   {
@@ -369,6 +375,12 @@ export const functionIdentifierTerms = [
     label: 'ts_of_min_over_time',
     detail: 'function',
     info: 'Return the timestamp of the minimum value over time for input series',
+    type: 'function',
+  },
+  {
+    label: 'ts_of_first_over_time',
+    detail: 'function',
+    info: 'Return the timestamp of the first value over time for input series',
     type: 'function',
   },
   {


### PR DESCRIPTION
Apparently this was missed in https://github.com/prometheus/prometheus/pull/17021.

#### Does this PR introduce a user-facing change?
```release-notes
[ENHANCEMENT] Autocomplete support for experimental first_over_time and ts_of_first_over_time PromQL functions.
```
