### PR TITLE
perf(PromQL): allow inlining kahansum.Inc

### DIFF
--- a/util/kahansum/kahansum.go
+++ b/util/kahansum/kahansum.go
@@ -18,7 +18,7 @@ import "math"
 // Inc performs addition of two floating-point numbers using the Kahan summation algorithm.
 func Inc(inc, sum, c float64) (newSum, newC float64) {
 	// We've seen Kahan summation return less accurate results when Inc function is
-	// allowed to beinlined (see https://github.com/prometheus/prometheus/pull/16895).
+	// allowed to be inlined (see https://github.com/prometheus/prometheus/pull/16895).
 	// Go permits fusing float operations (e.g. using fused multiply-add, which allows
 	// calculating a*b+c without rounding the result of a*b to precision available in float64),
 	// and Kahan sum is sensitive to float rounding behavior. Instead of forbidding inlining


### PR DESCRIPTION
This is an alternative to https://github.com/prometheus/prometheus/pull/18317 - it achieves the same performance improvement without adding new code, but by allowing inlining of `kahansum.Inc` in existing code.

Go permits float operations to be fused, which affects rounding behavior. Whether fusion is used or not depends on other optimizations - whether compiler decides to unroll loops or not, inline functions, etc. This is the only optimization that I'm aware of that go compiler does which can affect float results. Go spec actually doesn't explicitly say whether more elaborate optimizations are allowed (e.g. optimizing with assumption that floats are associative), but it does call out the rather simple operation fusion as the optimization that compiler is allowed to apply (and nondeterministically at that, which is why mathematical operation results are allowed to change when changing optimization settings or changing hardware). The original change to disable inlining (https://github.com/prometheus/prometheus/pull/16895) does impede fusion optimization, but we can also achieve that without eating the performance impact of non-inlined function calls. Note that neither this PR nor `//go:noinline` would prevent an associativity based optimization, because the relevant operations are entirely within `kahansum.Inc`.

I tried to investigate bigzero evaluation test (which was reported in https://github.com/prometheus/prometheus/issues/16714), and my best guess is that [these multiplications](https://github.com/prometheus/prometheus/blob/fc1c60d9eb4367d74cf18adb658475560adae306/promql/engine.go#L3588-L3589) fuse with additions inside `kahansum.Inc`, which we can prevent by either `//go:noinline` or casts that forbid fusion. Digging further turned out to be difficult because attempting to simplify the test case changes what compiler manages to optimize, making the issue appear and disappear when making seemingly innocuous changes. Therefore I don't have a good explanation _why_ we need to perform summation one way or another, but I believe that this PR has better motivation than a blanket `//go:noinline`. 

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/histogram
cpu: Apple M1 Pro
                              │ bench-before.txt │           bench-after.txt           │
                              │      sec/op      │   sec/op     vs base                │
FloatHistogramAdd/KahanAdd-10        36.02µ ± 1%   27.40µ ± 6%  -23.95% (p=0.000 n=10)

                              │ bench-before.txt │        bench-after.txt         │
                              │       B/op       │    B/op     vs base            │
FloatHistogramAdd/KahanAdd-10         800.0 ± 0%   800.0 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                              │ bench-before.txt │        bench-after.txt         │
                              │    allocs/op     │ allocs/op   vs base            │
FloatHistogramAdd/KahanAdd-10         3.000 ± 0%   3.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:

Partially addresses #18249

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
