### PR TITLE
discovery/azure: fix system managed identity when client_id is empty

### DIFF
--- a/discovery/azure/azure.go
+++ b/discovery/azure/azure.go
@@ -298,7 +298,10 @@ func newCredential(cfg SDConfig, policyClientOptions policy.ClientOptions) (azco
 		}
 		credential = azcore.TokenCredential(workloadIdentityCredential)
 	case authMethodManagedIdentity:
-		options := &azidentity.ManagedIdentityCredentialOptions{ClientOptions: policyClientOptions, ID: azidentity.ClientID(cfg.ClientID)}
+		options := &azidentity.ManagedIdentityCredentialOptions{ClientOptions: policyClientOptions}
+		if cfg.ClientID != "" {
+			options.ID = azidentity.ClientID(cfg.ClientID)
+		}
 		managedIdentityCredential, err := azidentity.NewManagedIdentityCredential(options)
 		if err != nil {
 			return nil, err

--- a/discovery/azure/azure_test.go
+++ b/discovery/azure/azure_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	fake "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5/fake"
@@ -488,6 +489,27 @@ func TestNewAzureResourceFromID(t *testing.T) {
 		require.Equal(t, tc.expected.Name, actual.Name)
 		require.Equal(t, tc.expected.ResourceGroupName, actual.ResourceGroupName)
 	}
+}
+
+func TestNewCredentialManagedIdentity(t *testing.T) {
+	// Test that system-assigned managed identity (empty ClientID) creates
+	// a valid credential. Previously, an empty ClientID was passed as
+	// azidentity.ClientID("") which is not nil and caused Azure SDK to
+	// look up a non-existent user-assigned identity instead of falling
+	// back to system-assigned identity.
+	cfg := SDConfig{
+		AuthenticationMethod: authMethodManagedIdentity,
+		ClientID:             "",
+	}
+	cred, err := newCredential(cfg, policy.ClientOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+
+	// Test that user-assigned managed identity (non-empty ClientID) also works.
+	cfg.ClientID = "00000000-0000-0000-0000-000000000000"
+	cred, err = newCredential(cfg, policy.ClientOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, cred)
 }
 
 func TestAzureRefresh(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #16634

When using `ManagedIdentity` authentication with **system-assigned identity**, the `client_id` field is intentionally left empty. However, the current code unconditionally sets `options.ID = azidentity.ClientID(cfg.ClientID)`, which passes an empty string instead of `nil`. The Azure SDK treats an empty `ClientID` as a request for a user-assigned identity with an empty client ID, rather than falling back to system-assigned identity.

This fix only sets `options.ID` when `cfg.ClientID` is non-empty, matching the pattern already used in `storage/remote/azuread/azuread.go` (lines 330-339).

### Changes
- `discovery/azure/azure.go`: Only set `options.ID` when `cfg.ClientID` is non-empty in the `ManagedIdentity` case of `newCredential()`
- `discovery/azure/azure_test.go`: Add `TestNewCredentialManagedIdentity` covering both system-assigned (empty ClientID) and user-assigned (non-empty ClientID) cases

### Context
This was discussed in #16634 and builds on the Workload Identity pattern merged in #17207. @krajorama invited contribution in the issue thread.

Signed-off-by: Ogulcan Aydogan <ogulcanaydogan@hotmail.com>

```release-notes
[BUGFIX] Azure SD: Fix system-assigned managed identity not working when `client_id` is empty.
```