### PR TITLE
relabel: fastpath for common regular expressions

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2087,6 +2087,7 @@ func TestLoadConfig(t *testing.T) {
 		cmpopts.IgnoreUnexported(ionos.SDConfig{}),
 		cmpopts.IgnoreUnexported(stackit.SDConfig{}),
 		cmpopts.IgnoreUnexported(regexp.Regexp{}),
+		cmpopts.IgnoreUnexported(relabel.Regexp{}),
 		cmpopts.IgnoreUnexported(hetzner.SDConfig{}),
 		cmpopts.IgnoreUnexported(Config{}),
 	})

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -194,13 +194,23 @@ func (c *Config) Validate(nameValidationScheme model.ValidationScheme) error {
 // Regexp encapsulates a regexp.Regexp and makes it YAML marshalable.
 type Regexp struct {
 	*regexp.Regexp
+	// literal is non-empty when the pattern contains no regex
+	// metacharacters, enabling simple string equality matching.
+	literal string
 }
 
 // NewRegexp creates a new anchored Regexp and returns an error if the
 // passed-in regular expression does not compile.
 func NewRegexp(s string) (Regexp, error) {
 	regex, err := regexp.Compile("^(?s:" + s + ")$")
-	return Regexp{Regexp: regex}, err
+	if err != nil {
+		return Regexp{}, err
+	}
+	re := Regexp{Regexp: regex}
+	if regexp.QuoteMeta(s) == s {
+		re.literal = s
+	}
+	return re, nil
 }
 
 // MustNewRegexp works like NewRegexp, but panics if the regular expression does not compile.
@@ -256,6 +266,15 @@ func (re Regexp) MarshalJSON() ([]byte, error) {
 // IsZero implements the yaml.IsZeroer interface.
 func (re Regexp) IsZero() bool {
 	return re.Regexp == DefaultRelabelConfig.Regex.Regexp
+}
+
+// MatchString returns whether s matches the regular expression.
+// For literal patterns it uses simple string comparison.
+func (re Regexp) MatchString(s string) bool {
+	if re.literal != "" {
+		return s == re.literal
+	}
+	return re.Regexp.MatchString(s)
 }
 
 // String returns the original string used to compile the regular expression.
@@ -324,9 +343,38 @@ func relabel(cfg *Config, lb *labels.Builder) (keep bool) {
 			return false
 		}
 	case Replace:
-		// Fast path to add or delete label pair.
-		if val == "" && cfg.Regex == DefaultRelabelConfig.Regex &&
+		// Fast path for the default regex (.*): it always matches and
+		// $0/$1 equal val, so we can expand templates without the regex engine.
+		if cfg.Regex.Regexp == DefaultRelabelConfig.Regex.Regexp {
+			target, targetOK := resolveDefaultExpand(cfg.TargetLabel, val)
+			replacement, replacementOK := resolveDefaultExpand(cfg.Replacement, val)
+			if targetOK && replacementOK {
+				if !cfg.NameValidationScheme.IsValidLabelName(target) {
+					break
+				}
+				if replacement == "" {
+					lb.Del(target)
+					break
+				}
+				lb.Set(target, replacement)
+				break
+			}
+		}
+
+		// Fast path for literal regex with no template variables:
+		// the regex is just a guard and templates are used verbatim.
+		if cfg.Regex.literal != "" &&
 			!varInRegexTemplate(cfg.TargetLabel) && !varInRegexTemplate(cfg.Replacement) {
+			if val != cfg.Regex.literal {
+				break
+			}
+			if !cfg.NameValidationScheme.IsValidLabelName(cfg.TargetLabel) {
+				break
+			}
+			if cfg.Replacement == "" {
+				lb.Del(cfg.TargetLabel)
+				break
+			}
 			lb.Set(cfg.TargetLabel, cfg.Replacement)
 			break
 		}
@@ -383,4 +431,19 @@ func relabel(cfg *Config, lb *labels.Builder) (keep bool) {
 
 func varInRegexTemplate(template string) bool {
 	return strings.Contains(template, "$")
+}
+
+// resolveDefaultExpand resolves a template for the default regex (.*),
+// where $0 and $1 both equal val. It handles the common cases of plain
+// strings and bare $0/$1/${0}/${1} references. For anything more complex
+// it returns ok=false to signal the caller to fall back to the general path.
+func resolveDefaultExpand(template, val string) (string, bool) {
+	if !strings.Contains(template, "$") {
+		return template, true
+	}
+	switch template {
+	case "$0", "${0}", "$1", "${1}":
+		return val, true
+	}
+	return "", false
 }

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -3828,6 +3828,7 @@ func assertAPIResponse(t *testing.T, got, exp any) {
 
 	testutil.RequireEqualWithOptions(t, exp, got, []cmp.Option{
 		cmpopts.IgnoreUnexported(regexp.Regexp{}),
+		cmpopts.IgnoreUnexported(relabel.Regexp{}),
 	})
 }
 


### PR DESCRIPTION
This optimizes the common case of the default regex or a literal string. Benchmark results look pretty ok:
```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/relabel cpu: 13th Gen Intel(R) Core(TM) i7-13800H
                             │ /tmp/main.bench │           /tmp/pr.bench            │
                             │     sec/op      │   sec/op     vs base               │
Relabel/example-20                1.747µ ±  8%   1.381µ ± 9%  -20.96% (p=0.002 n=6)
Relabel/kubernetes-20             7.239µ ±  5%   4.300µ ± 5%  -40.60% (p=0.002 n=6)
Relabel/static_label_pair-20     1276.5n ± 15%   869.8n ± 8%  -31.86% (p=0.002 n=6)
geomean                           2.527µ         1.728µ       -31.61%
                             │ /tmp/main.bench │           /tmp/pr.bench           │
                             │      B/op       │    B/op     vs base               │
Relabel/example-20                  460.0 ± 0%   395.0 ± 0%  -14.13% (p=0.002 n=6)
Relabel/kubernetes-20              1364.0 ± 0%   702.0 ± 0%  -48.53% (p=0.002 n=6)
Relabel/static_label_pair-20        576.0 ± 0%   496.0 ± 0%  -13.89% (p=0.002 n=6)
geomean                             712.3        516.2       -27.53%
                             │ /tmp/main.bench │           /tmp/pr.bench           │
                             │    allocs/op    │ allocs/op   vs base               │
Relabel/example-20                 14.000 ± 0%   9.000 ± 0%  -35.71% (p=0.002 n=6)
Relabel/kubernetes-20              31.000 ± 0%   6.000 ± 0%  -80.65% (p=0.002 n=6)
Relabel/static_label_pair-20        7.000 ± 0%   3.000 ± 0%  -57.14% (p=0.002 n=6)
geomean                             14.48        5.451       -62.36%
```
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[PERF] relabel: fastpath for common regular expressions #18327
```
