### PR TITLE
tsdb/chunkenc: inline hot path in XOR2 appender for unchanged values

### DIFF
--- a/tsdb/chunkenc/xor2.go
+++ b/tsdb/chunkenc/xor2.go
@@ -257,11 +257,28 @@ func (a *xor2Appender) Append(st, t int64, v float64) {
 
 		// Fast path: no ST involvement at all.
 		if st == 0 && a.numTotal != maxFirstSTChangeOn && a.firstSTChangeOn == 0 && !a.firstSTKnown {
-			a.encodeJoint(dod, v)
-			a.t = t
-			if !value.IsStaleNaN(v) {
-				a.v = v
+			vbits := math.Float64bits(v)
+			isStale := vbits == value.StaleNaN
+			if !isStale && vbits == math.Float64bits(a.v) {
+				// Value unchanged: inline the common timestamp encodings to avoid
+				// two function calls (encodeJoint + writeVDelta) for hot paths.
+				if dod == 0 {
+					a.b.writeBit(zero)
+				} else if dod >= -(1<<12) && dod <= (1<<12)-1 {
+					a.b.writeByte(0b110_00000 | byte(uint64(dod)>>8)&0x1F)
+					a.b.writeByte(byte(uint64(dod)))
+					a.b.writeBit(zero) // value unchanged.
+				} else {
+					a.encodeJoint(dod, v)
+				}
+				// a.v is not updated since v == a.v.
+			} else {
+				a.encodeJoint(dod, v)
+				if !isStale {
+					a.v = v
+				}
 			}
+			a.t = t
 			a.tDelta = tDelta
 			a.numTotal++
 			binary.BigEndian.PutUint16(a.b.bytes(), a.numTotal)


### PR DESCRIPTION
In the ST-free fast path, inline the two most common encoding cases when the value is unchanged, avoiding calls to encodeJoint and writeVDelta per sample.

- dod=0, value unchanged: write 1 bit inline
- 13-bit dod, value unchanged: write 2 bytes + 1 bit inline

Also compute math.Float64bits(v) once and reuse it for both the isStale check and the value comparison, replacing two separate IsStaleNaN calls that previously happened across encodeJoint and writeVDelta.

When v == a.v the a.v update is skipped since it is a no-op.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
