### PR TITLE
tsdb: Find the last series ID on startup from the last series id file and WAL scan

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -815,7 +815,7 @@ func (h *Head) Init(minValidTime int64) error {
 				h.lastSeriesID.Store(state.LastSeriesID)
 				h.logger.Info("Fast startup: clean shutdown detected, restored last series ID", "last_series_id", state.LastSeriesID)
 			} else {
-				h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", endAt, "to_segment", state.LastWALSegment)
+				h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", state.LastWALSegment, "to_segment", endAt)
 				id, scanErr := h.findLastSeriesID(state, endAt)
 				if scanErr != nil {
 					h.logger.Error("Fast startup: WAL scan failed, skipping fast startup", "err", scanErr)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -7989,4 +7989,12 @@ func TestHead_FindLastSeriesID(t *testing.T) {
 	id, err = head.findLastSeriesID(mockState, last)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), id, "Should find ID 2 after new series was created in segment 2")
+
+	// Simulate state file knowing about latest segment.
+	mockState.LastWALSegment = last
+
+	// Should return 2 as it should scan the last file and find series B.
+	id, err = head.findLastSeriesID(mockState, last)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), id, "Should find ID 2 even when state file's last segment is the newest segment")
 }

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1919,7 +1919,7 @@ func (h *Head) findLastSeriesID(state SeriesLifecycleState, endSegment int) (uin
 		var highestID chunks.HeadSeriesRef
 		var found bool
 
-		// Read the segment forwards
+		// Read the segment forwards.
 		for r.Next() {
 			rec := r.Record()
 			// We only care about Series records.


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

- This PR builds directly on top of the state file created and maintained as in PR [#18303](https://github.com/prometheus/prometheus/pull/18303)
- Now on startup, the Head.Init (...) method checks for this file,reads it, and if the shutdown is clean, trusts the last series ID value in it. If it is an unclean shutdown, we scan the WAL segments backwards, up until the last WAL segment as told by the file. 
- Added unit tests for this. 

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
NA

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
