### PR TITLE
test(TestRemoteWrite_ReshardingWithoutDeadlock): remove t.Skip() added by mistake

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -977,7 +977,6 @@ remote_write:
 // | dataPending         | 0             | 1228.8              |
 // | desiredShards       | 0.6           | 369.2               |.
 func TestRemoteWrite_ReshardingWithoutDeadlock(t *testing.T) {
-	t.Skip("flaky test, see https://github.com/prometheus/prometheus/issues/17489")
 	t.Parallel()
 
 	tmpDir := t.TempDir()


### PR DESCRIPTION
during release-3.8->main sync https://github.com/prometheus/prometheus/pull/17634

see https://github.com/prometheus/prometheus/pull/17634
```
I'm afraid this merged 26f8c92de8b5ddec530a53c74a6f50ac28f65388 which skipped again TestRemoteWrite_ReshardingWithoutDeadlock on main, but that test was already fixed from https://github.com/prometheus/prometheus/pull/17490/changes

that commit comes from https://github.com/prometheus/prometheus/pull/17543 where the test was skipped on 3.8 because the fix wasn't read yet.

I tried to start a discussion about this “merge release to main” step. It’s really error-prone. I think we should always merge fixes into main first, then backport them to the release branches. We should only sync the changelog and perform version bumps at the end. All other commits on release branches should be left there...
```

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
