### PR TITLE
tsdb: add match[] parameter to /api/v1/status/tsdb endpoint

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -2037,6 +2037,21 @@ func (s *readyStorage) Stats(statsByLabelName string, limit int) (*tsdb.Stats, e
 	return nil, tsdb.ErrNotReady
 }
 
+// StatsForMatchers implements the api_v1.TSDBAdminStats interface.
+func (s *readyStorage) StatsForMatchers(ctx context.Context, statsByLabelName string, limit int, matchers []*labels.Matcher) (*tsdb.Stats, error) {
+	if x := s.get(); x != nil {
+		switch db := x.(type) {
+		case *tsdb.DB:
+			return db.Head().StatsForMatchers(ctx, statsByLabelName, limit, matchers)
+		case *agent.DB:
+			return nil, agent.ErrUnsupported
+		default:
+			panic(fmt.Sprintf("unknown storage type %T", db))
+		}
+	}
+	return nil, tsdb.ErrNotReady
+}
+
 // WALReplayStatus implements the api_v1.TSDBStats interface.
 func (s *readyStorage) WALReplayStatus() (tsdb.WALReplayStatus, error) {
 	if x := s.getStats(); x != nil {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1636,6 +1636,36 @@ func (h *Head) Stats(statsByLabelName string, limit int) *Stats {
 	}
 }
 
+// StatsForMatchers computes cardinality statistics for the series matching the given matchers.
+// Unlike Stats, results are not cached because they depend on the provided matchers.
+func (h *Head) StatsForMatchers(ctx context.Context, statsByLabelName string, limit int, matchers []*labels.Matcher) (*Stats, error) {
+	ir := h.indexRange(math.MinInt64, math.MaxInt64)
+
+	var matchedRefs map[storage.SeriesRef]struct{}
+	if len(matchers) > 0 {
+		p, err := PostingsForMatchers(ctx, ir, matchers...)
+		if err != nil {
+			return nil, fmt.Errorf("select series for matchers: %w", err)
+		}
+		refs, err := index.ExpandPostings(p)
+		if err != nil {
+			return nil, fmt.Errorf("expand postings: %w", err)
+		}
+		matchedRefs = make(map[storage.SeriesRef]struct{}, len(refs))
+		for _, ref := range refs {
+			matchedRefs[ref] = struct{}{}
+		}
+	}
+
+	postingsStats := h.postings.StatsForMatchedSeries(statsByLabelName, limit, labels.SizeOfLabels, matchedRefs)
+	return &Stats{
+		NumSeries:         uint64(len(matchedRefs)),
+		MaxTime:           h.MaxTime(),
+		MinTime:           h.MinTime(),
+		IndexPostingStats: postingsStats,
+	}, nil
+}
+
 // RangeHead allows querying Head via an IndexReader, ChunkReader and tombstones.Reader
 // but only within a restricted range.  Used for queries and compactions.
 type RangeHead struct {

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -239,6 +239,66 @@ func (p *MemPostings) Stats(label string, limit int, labelSizeFunc func(string, 
 	}
 }
 
+// StatsForMatchedSeries calculates cardinality statistics from postings,
+// considering only the series whose refs are present in matchedSeries.
+// Caller can pass in a function which computes the space required for n series with a given label.
+func (p *MemPostings) StatsForMatchedSeries(label string, limit int, labelSizeFunc func(string, string, uint64) uint64, matchedSeries map[storage.SeriesRef]struct{}) *PostingsStats {
+	var size uint64
+	p.mtx.RLock()
+
+	metrics := &maxHeap{}
+	lbls := &maxHeap{}
+	labelValueLength := &maxHeap{}
+	labelValuePairs := &maxHeap{}
+	numLabelPairs := 0
+
+	metrics.init(limit)
+	lbls.init(limit)
+	labelValueLength.init(limit)
+	labelValuePairs.init(limit)
+
+	for n, e := range p.m {
+		if n == "" {
+			continue
+		}
+		size = 0
+		labelValueCount := 0
+		for name, values := range e {
+			var filteredCount uint64
+			for _, ref := range values {
+				if _, ok := matchedSeries[ref]; ok {
+					filteredCount++
+				}
+			}
+			if filteredCount == 0 {
+				continue
+			}
+			labelValueCount++
+			numLabelPairs++
+			if n == label {
+				metrics.push(Stat{Name: name, Count: filteredCount})
+			}
+			labelValuePairs.push(Stat{Name: n + "=" + name, Count: filteredCount})
+			size += labelSizeFunc(n, name, filteredCount)
+		}
+		if labelValueCount == 0 {
+			continue
+		}
+		lbls.push(Stat{Name: n, Count: uint64(labelValueCount)})
+		labelValueLength.push(Stat{Name: n, Count: size})
+	}
+
+	p.mtx.RUnlock()
+
+	return &PostingsStats{
+		CardinalityMetricsStats: metrics.get(),
+		CardinalityLabelStats:   lbls.get(),
+		LabelValueStats:         labelValueLength.get(),
+		LabelValuePairsStats:    labelValuePairs.get(),
+		NumLabelPairs:           numLabelPairs,
+	}
+}
+
 // All returns a postings list over all documents ever added.
 func (p *MemPostings) All() Postings {
 	return p.Postings(context.Background(), allPostingsKey.Name, allPostingsKey.Value)

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -196,51 +196,12 @@ type PostingsStats struct {
 // Stats calculates the cardinality statistics from postings.
 // Caller can pass in a function which computes the space required for n series with a given label.
 func (p *MemPostings) Stats(label string, limit int, labelSizeFunc func(string, string, uint64) uint64) *PostingsStats {
-	var size uint64
-	p.mtx.RLock()
-
-	metrics := &maxHeap{}
-	labels := &maxHeap{}
-	labelValueLength := &maxHeap{}
-	labelValuePairs := &maxHeap{}
-	numLabelPairs := 0
-
-	metrics.init(limit)
-	labels.init(limit)
-	labelValueLength.init(limit)
-	labelValuePairs.init(limit)
-
-	for n, e := range p.m {
-		if n == "" {
-			continue
-		}
-		labels.push(Stat{Name: n, Count: uint64(len(e))})
-		numLabelPairs += len(e)
-		size = 0
-		for name, values := range e {
-			if n == label {
-				metrics.push(Stat{Name: name, Count: uint64(len(values))})
-			}
-			seriesCnt := uint64(len(values))
-			labelValuePairs.push(Stat{Name: n + "=" + name, Count: seriesCnt})
-			size += labelSizeFunc(n, name, seriesCnt)
-		}
-		labelValueLength.push(Stat{Name: n, Count: size})
-	}
-
-	p.mtx.RUnlock()
-
-	return &PostingsStats{
-		CardinalityMetricsStats: metrics.get(),
-		CardinalityLabelStats:   labels.get(),
-		LabelValueStats:         labelValueLength.get(),
-		LabelValuePairsStats:    labelValuePairs.get(),
-		NumLabelPairs:           numLabelPairs,
-	}
+	return p.StatsForMatchedSeries(label, limit, labelSizeFunc, nil)
 }
 
 // StatsForMatchedSeries calculates cardinality statistics from postings,
 // considering only the series whose refs are present in matchedSeries.
+// A nil matchedSeries means all series are included (equivalent to Stats).
 // Caller can pass in a function which computes the space required for n series with a given label.
 func (p *MemPostings) StatsForMatchedSeries(label string, limit int, labelSizeFunc func(string, string, uint64) uint64, matchedSeries map[storage.SeriesRef]struct{}) *PostingsStats {
 	var size uint64
@@ -265,9 +226,13 @@ func (p *MemPostings) StatsForMatchedSeries(label string, limit int, labelSizeFu
 		labelValueCount := 0
 		for name, values := range e {
 			var filteredCount uint64
-			for _, ref := range values {
-				if _, ok := matchedSeries[ref]; ok {
-					filteredCount++
+			if matchedSeries == nil {
+				filteredCount = uint64(len(values))
+			} else {
+				for _, ref := range values {
+					if _, ok := matchedSeries[ref]; ok {
+						filteredCount++
+					}
 				}
 			}
 			if filteredCount == 0 {

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -964,6 +964,68 @@ func TestMemPostingsStats(t *testing.T) {
 	require.Equal(t, 3, stats.NumLabelPairs)
 }
 
+func TestStatsForMatchedSeries(t *testing.T) {
+	// Use the same setup as TestMemPostingsStats:
+	//   series 1: label=value1, label=value2, label=value3
+	//   series 2: label=value1
+	p := NewMemPostings()
+	p.Add(1, labels.FromStrings("label", "value1"))
+	p.Add(1, labels.FromStrings("label", "value2"))
+	p.Add(1, labels.FromStrings("label", "value3"))
+	p.Add(2, labels.FromStrings("label", "value1"))
+
+	labelSizeFunc := func(name, value string, n uint64) uint64 { return uint64(len(name)+len(value)) * n }
+
+	t.Run("filter to series 1 only", func(t *testing.T) {
+		filtered := map[storage.SeriesRef]struct{}{1: {}}
+		stats := p.StatsForMatchedSeries("label", 10, labelSizeFunc, filtered)
+
+		// series 1 has value1, value2, value3 — all 3 unique values
+		require.Equal(t, uint64(3), stats.CardinalityLabelStats[0].Count)
+		require.Equal(t, "label", stats.CardinalityLabelStats[0].Name)
+
+		// each label-value pair has exactly 1 series (from ref 1)
+		for _, s := range stats.CardinalityMetricsStats {
+			require.Equal(t, uint64(1), s.Count)
+		}
+		require.Equal(t, 3, stats.NumLabelPairs)
+	})
+
+	t.Run("filter to series 2 only", func(t *testing.T) {
+		filtered := map[storage.SeriesRef]struct{}{2: {}}
+		stats := p.StatsForMatchedSeries("label", 10, labelSizeFunc, filtered)
+
+		// series 2 only has label=value1
+		require.Equal(t, uint64(1), stats.CardinalityLabelStats[0].Count)
+		require.Equal(t, "label", stats.CardinalityLabelStats[0].Name)
+
+		require.Len(t, stats.CardinalityMetricsStats, 1)
+		require.Equal(t, "value1", stats.CardinalityMetricsStats[0].Name)
+		require.Equal(t, uint64(1), stats.CardinalityMetricsStats[0].Count)
+		require.Equal(t, 1, stats.NumLabelPairs)
+	})
+
+	t.Run("filter to both series", func(t *testing.T) {
+		filtered := map[storage.SeriesRef]struct{}{1: {}, 2: {}}
+		stats := p.StatsForMatchedSeries("label", 10, labelSizeFunc, filtered)
+
+		// Same as the unfiltered Stats result
+		require.Equal(t, uint64(3), stats.CardinalityLabelStats[0].Count)
+		require.Equal(t, uint64(2), stats.CardinalityMetricsStats[0].Count)
+		require.Equal(t, "value1", stats.CardinalityMetricsStats[0].Name)
+		require.Equal(t, 3, stats.NumLabelPairs)
+	})
+
+	t.Run("empty filter set", func(t *testing.T) {
+		filtered := map[storage.SeriesRef]struct{}{}
+		stats := p.StatsForMatchedSeries("label", 10, labelSizeFunc, filtered)
+
+		require.Empty(t, stats.CardinalityLabelStats)
+		require.Empty(t, stats.CardinalityMetricsStats)
+		require.Equal(t, 0, stats.NumLabelPairs)
+	})
+}
+
 func TestMemPostings_Delete(t *testing.T) {
 	p := NewMemPostings()
 	p.Add(1, labels.FromStrings("lbl1", "a"))

--- a/web/api/testhelpers/api.go
+++ b/web/api/testhelpers/api.go
@@ -68,6 +68,7 @@ type TSDBAdminStats interface {
 	Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Matcher) error
 	Snapshot(dir string, withHead bool) error
 	Stats(statsByLabelName string, limit int) (*tsdb.Stats, error)
+	StatsForMatchers(ctx context.Context, statsByLabelName string, limit int, matchers []*labels.Matcher) (*tsdb.Stats, error)
 	WALReplayStatus() (tsdb.WALReplayStatus, error)
 	BlockMetas() ([]tsdb.BlockMeta, error)
 }

--- a/web/api/testhelpers/mocks.go
+++ b/web/api/testhelpers/mocks.go
@@ -464,6 +464,10 @@ func (*FakeTSDBAdminStats) Stats(_ string, _ int) (*tsdb.Stats, error) {
 	return &tsdb.Stats{}, nil
 }
 
+func (*FakeTSDBAdminStats) StatsForMatchers(_ context.Context, _ string, _ int, _ []*labels.Matcher) (*tsdb.Stats, error) {
+	return &tsdb.Stats{}, nil
+}
+
 func (*FakeTSDBAdminStats) WALReplayStatus() (tsdb.WALReplayStatus, error) {
 	return tsdb.WALReplayStatus{}, nil
 }

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -211,6 +211,7 @@ type TSDBAdminStats interface {
 	Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Matcher) error
 	Snapshot(dir string, withHead bool) error
 	Stats(statsByLabelName string, limit int) (*tsdb.Stats, error)
+	StatsForMatchers(ctx context.Context, statsByLabelName string, limit int, matchers []*labels.Matcher) (*tsdb.Stats, error)
 	WALReplayStatus() (tsdb.WALReplayStatus, error)
 	BlockMetas() ([]tsdb.BlockMeta, error)
 }
@@ -1940,9 +1941,30 @@ func (api *API) serveTSDBStatus(r *http.Request) apiFuncResult {
 			return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("limit must not exceed %d", maxTSDBLimit)}, nil, nil}
 		}
 	}
-	s, err := api.db.Stats(labels.MetricName, limit)
-	if err != nil {
-		return apiFuncResult{nil, &apiError{errorInternal, err}, nil, nil}
+
+	var s *tsdb.Stats
+	if matcherNames := r.Form["match[]"]; len(matcherNames) > 0 {
+		matcherSets, err := api.parseMatchersParam(matcherNames)
+		if err != nil {
+			return invalidParamError(err, "match[]")
+		}
+		// Flatten multiple match[] selectors into a single matchers list.
+		// Each selector is an independent series selector; we take the union
+		// of all matched series by running StatsForMatchers with all matchers combined.
+		var matchers []*labels.Matcher
+		for _, ms := range matcherSets {
+			matchers = append(matchers, ms...)
+		}
+		s, err = api.db.StatsForMatchers(r.Context(), labels.MetricName, limit, matchers)
+		if err != nil {
+			return apiFuncResult{nil, &apiError{errorInternal, err}, nil, nil}
+		}
+	} else {
+		var err error
+		s, err = api.db.Stats(labels.MetricName, limit)
+		if err != nil {
+			return apiFuncResult{nil, &apiError{errorInternal, err}, nil, nil}
+		}
 	}
 	metrics, err := api.gatherer.Gather()
 	if err != nil {

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -3953,6 +3953,23 @@ func (*fakeDB) Stats(statsByLabelName string, limit int) (_ *tsdb.Stats, retErr 
 	return h.Stats(statsByLabelName, limit), nil
 }
 
+func (*fakeDB) StatsForMatchers(ctx context.Context, statsByLabelName string, limit int, matchers []*labels.Matcher) (_ *tsdb.Stats, retErr error) {
+	dbDir, err := os.MkdirTemp("", "tsdb-api-ready")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err := os.RemoveAll(dbDir)
+		if retErr != nil {
+			retErr = err
+		}
+	}()
+	opts := tsdb.DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	h, _ := tsdb.NewHead(nil, nil, nil, nil, opts, nil)
+	return h.StatsForMatchers(ctx, statsByLabelName, limit, matchers)
+}
+
 func (*fakeDB) WALReplayStatus() (tsdb.WALReplayStatus, error) {
 	return tsdb.WALReplayStatus{}, nil
 }
@@ -4552,9 +4569,28 @@ func TestTSDBStatus(t *testing.T) {
 			values:   map[string][]string{"limit": {"10001"}},
 			errType:  errorBadData,
 		},
+		// Tests for match[] parameter.
+		{
+			db:       tsdb,
+			endpoint: tsdbStatusAPI,
+			values:   map[string][]string{"match[]": {`{job="test"}`}},
+			errType:  errorNone,
+		},
+		{
+			db:       tsdb,
+			endpoint: tsdbStatusAPI,
+			values:   map[string][]string{"match[]": {`{job="test"}`, `{job="other"}`}},
+			errType:  errorNone,
+		},
+		{
+			db:       tsdb,
+			endpoint: tsdbStatusAPI,
+			values:   map[string][]string{"match[]": {`{bad matcher`}},
+			errType:  errorBadData,
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			api := &API{db: tc.db, gatherer: prometheus.DefaultGatherer}
+			api := &API{db: tc.db, gatherer: prometheus.DefaultGatherer, parser: testParser}
 			endpoint := tc.endpoint(api)
 			req, err := http.NewRequest(tc.method, fmt.Sprintf("?%s", tc.values.Encode()), http.NoBody)
 			require.NoError(t, err, "Error when creating test request")

--- a/web/federate_test.go
+++ b/web/federate_test.go
@@ -255,6 +255,10 @@ func (notReadyReadStorage) Stats(string, int) (*tsdb.Stats, error) {
 	return nil, fmt.Errorf("wrap: %w", tsdb.ErrNotReady)
 }
 
+func (notReadyReadStorage) StatsForMatchers(context.Context, string, int, []*labels.Matcher) (*tsdb.Stats, error) {
+	return nil, fmt.Errorf("wrap: %w", tsdb.ErrNotReady)
+}
+
 // Regression test for https://github.com/prometheus/prometheus/issues/7181.
 func TestFederation_NotReady(t *testing.T) {
 	for name, scenario := range scenarios {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
@@ -58,6 +59,10 @@ func (a *dbAdapter) BlockMetas() ([]tsdb.BlockMeta, error) {
 
 func (a *dbAdapter) Stats(statsByLabelName string, limit int) (*tsdb.Stats, error) {
 	return a.Head().Stats(statsByLabelName, limit), nil
+}
+
+func (a *dbAdapter) StatsForMatchers(ctx context.Context, statsByLabelName string, limit int, matchers []*labels.Matcher) (*tsdb.Stats, error) {
+	return a.Head().StatsForMatchers(ctx, statsByLabelName, limit, matchers)
 }
 
 func (*dbAdapter) WALReplayStatus() (tsdb.WALReplayStatus, error) {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #12389

#### Does this PR introduce a user-facing change?

```release-notes
[FEATURE] API: Add `match[]` parameter to `/api/v1/status/tsdb` to filter cardinality statistics by series selectors.
```

## Summary

This PR adds a `match[]` query parameter to the `/api/v1/status/tsdb` endpoint, allowing users to filter cardinality statistics to only the series matching the given selector(s).

### Motivation

Currently `/api/v1/status/tsdb` returns global cardinality stats for all series. If a user wants to investigate the cardinality of a specific job, target, or label set that is not in the top-N list, there is no way to do so. This feature allows scoping the statistics to a specific subset of series.

### Implementation

The filtering works at the TSDB postings level:

1. **`MemPostings.StatsForMatchedSeries`** (`tsdb/index/postings.go`): new method that computes cardinality statistics considering only series whose refs are present in a provided filter set. It skips label-value pairs with no matching series, so all returned counts accurately reflect the filtered subset.

2. **`Head.StatsForMatchers`** (`tsdb/head.go`): uses the existing `PostingsForMatchers` machinery to resolve which series match the given matchers, then delegates to `StatsForMatchedSeries`. Results are not cached (unlike `PostingsCardinalityStats`) because they depend on the provided matchers.

3. **`readyStorage.StatsForMatchers`** (`cmd/prometheus/main.go`): wires `Head.StatsForMatchers` into the `TSDBAdminStats` interface.

4. **`serveTSDBStatus`** (`web/api/v1/api.go`): when `match[]` parameters are present, calls `StatsForMatchers`; otherwise falls back to the existing `Stats` call.

### Behaviour

- Without `match[]`: unchanged behaviour
- With `match[]={job="foo"}`: stats are computed only over series where `job="foo"`
- Multiple `match[]` params are combined (union semantics, matchers are appended)
- Invalid selector syntax returns `400 Bad Data`
- `HeadStats.NumSeries` reflects the count of matched series

### Testing

- Unit tests for `StatsForMatchedSeries` covering: filter to a subset, filter to all, empty filter
- New test cases in `TestTSDBStatus` for valid `match[]`, multiple `match[]`, and invalid selector