### PR TITLE
Allow periodic heap pprof collection during Head Init

### DIFF
--- a/cmd/prometheus/features_test.go
+++ b/cmd/prometheus/features_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -53,15 +52,7 @@ func TestFeaturesAPI(t *testing.T) {
 
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 
-	// Wait for Prometheus to be ready.
-	require.Eventually(t, func() bool {
-		resp, err := http.Get(baseURL + "/-/ready")
-		if err != nil {
-			return false
-		}
-		defer resp.Body.Close()
-		return resp.StatusCode == http.StatusOK
-	}, 10*time.Second, 100*time.Millisecond, "Prometheus didn't become ready in time")
+	ensurePrometheusIsReady(t, baseURL)
 
 	// Fetch features from the API.
 	resp, err := http.Get(baseURL + "/api/v1/features")

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -613,6 +613,9 @@ func main() {
 
 	a.Flag("agent", "Run Prometheus in 'Agent mode'.").BoolVar(&agentMode)
 
+	serverOnlyFlag(a, "debug.pprof-collector.path", "Base path to write periodic heap pprof snapshots to during startup. Disabled when empty.").
+		Default("").Hidden().StringVar(&cfg.tsdb.HeapPprofPath)
+
 	promslogflag.AddFlags(a, &cfg.promslogConfig)
 
 	a.Flag("write-documentation", "Generate command line documentation. Internal use.").Hidden().Action(func(*kingpin.ParseContext) error {
@@ -659,6 +662,13 @@ func main() {
 	if cfg.memlimitRatio <= 0.0 || cfg.memlimitRatio > 1.0 {
 		fmt.Fprintf(os.Stderr, "--auto-gomemlimit.ratio must be greater than 0 and less than or equal to 1.")
 		os.Exit(1)
+	}
+
+	if cfg.tsdb.HeapPprofPath != "" {
+		if _, err := os.Stat(cfg.tsdb.HeapPprofPath); err != nil {
+			fmt.Fprintf(os.Stderr, "Invalid --debug.pprof-collector.path: %s\n", err)
+			os.Exit(1)
+		}
 	}
 
 	localStoragePath := cfg.serverStoragePath
@@ -2033,6 +2043,7 @@ type tsdbOptions struct {
 	EnableXOR2Encoding             bool
 	StaleSeriesCompactionThreshold float64
 	EnableFastStartup              bool
+	HeapPprofPath                  string
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -2065,6 +2076,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		EnableXOR2Encoding:             opts.EnableXOR2Encoding,
 		StaleSeriesCompactionThreshold: opts.StaleSeriesCompactionThreshold,
 		EnableFastStartup:              opts.EnableFastStartup,
+		HeapPprofPath:                  opts.HeapPprofPath,
 	}
 }
 

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -55,6 +55,18 @@ func init() {
 
 const startupTime = 10 * time.Second
 
+func ensurePrometheusIsReady(t *testing.T, baseURL string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(baseURL + "/-/ready")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, startupTime, 100*time.Millisecond, "Prometheus didn't become ready in time")
+}
+
 var (
 	promPath    = os.Args[0]
 	promConfig  = filepath.Join("..", "..", "documentation", "examples", "prometheus.yml")
@@ -1062,4 +1074,32 @@ remote_write:
 		return true
 		// 3*shardUpdateDuration to allow for the resharding logic to run.
 	}, 30*time.Second, time.Second)
+}
+
+func TestHeadInitHeapPprofCollector(t *testing.T) {
+	t.Parallel()
+	t.Run("happy path", func(t *testing.T) {
+		pprofDir := t.TempDir()
+		port := testutil.RandomUnprivilegedPort(t)
+		prom := prometheusCommandWithLogging(t, promConfig, port,
+			"--storage.tsdb.path="+t.TempDir(),
+			"--debug.pprof-collector.path="+pprofDir,
+		)
+		require.NoError(t, prom.Start())
+
+		baseURL := fmt.Sprintf("http://localhost:%d", port)
+		ensurePrometheusIsReady(t, baseURL)
+
+		matches, _ := filepath.Glob(filepath.Join(pprofDir, "*head_init*", "*heap.pprof*"))
+		require.Len(t, matches, 1, "expected exactly one head_init*/heap.pprof under %s", pprofDir)
+	})
+
+	t.Run("bad path", func(t *testing.T) {
+		prom := prometheusCommandWithLogging(t, promConfig, testutil.RandomUnprivilegedPort(t),
+			"--debug.pprof-collector.path=/no/such/dir",
+		)
+		err := prom.Run()
+		require.Error(t, err)
+		require.Equal(t, 1, prom.ProcessState.ExitCode())
+	})
 }

--- a/cmd/prometheus/reload_test.go
+++ b/cmd/prometheus/reload_test.go
@@ -123,14 +123,7 @@ func runTestSteps(t *testing.T, steps []struct {
 	require.NoError(t, prom.Start())
 
 	baseURL := "http://localhost:" + strconv.Itoa(port)
-	require.Eventually(t, func() bool {
-		resp, err := http.Get(baseURL + "/-/ready")
-		if err != nil {
-			return false
-		}
-		defer resp.Body.Close()
-		return resp.StatusCode == http.StatusOK
-	}, 5*time.Second, 100*time.Millisecond, "Prometheus didn't become ready in time")
+	ensurePrometheusIsReady(t, baseURL)
 
 	for i, step := range steps {
 		t.Logf("Step %d", i)

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -274,6 +274,9 @@ type Options struct {
 
 	// EnableFastStartup enables scraping in parallel with WAL replay but with queries still disabled.
 	EnableFastStartup bool
+
+	// HeapPprofPath is the base directory for periodic heap pprof snapshots.
+	HeapPprofPath string
 }
 
 type NewCompactorFunc func(ctx context.Context, r prometheus.Registerer, l *slog.Logger, ranges []int64, pool chunkenc.Pool, opts *Options) (Compactor, error)
@@ -1088,6 +1091,7 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 	headOpts.EnableXOR2Encoding.Store(opts.EnableXOR2Encoding)
 	headOpts.EnableMetadataWALRecords = opts.EnableMetadataWALRecords
 	headOpts.EnableFastStartup = opts.EnableFastStartup
+	headOpts.HeapPprofPath = opts.HeapPprofPath
 	if opts.WALReplayConcurrency > 0 {
 		headOpts.WALReplayConcurrency = opts.WALReplayConcurrency
 	}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -44,6 +44,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/record"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/tsdb/wlog"
+	"github.com/prometheus/prometheus/util/pprofutil"
 	"github.com/prometheus/prometheus/util/zeropool"
 )
 
@@ -217,6 +218,9 @@ type HeadOptions struct {
 
 	// EnableFastStartup enables scraping in parallel with WAL replay but with queries still disabled.
 	EnableFastStartup bool
+
+	// HeapPprofPath is the base directory for periodic heap pprof snapshots.
+	HeapPprofPath string
 }
 
 const (
@@ -681,6 +685,14 @@ const cardinalityCacheExpirationTime = time.Duration(30) * time.Second
 // It should be called before using an appender so that it
 // limits the ingested samples to the head min valid time.
 func (h *Head) Init(minValidTime int64) error {
+	if h.opts.HeapPprofPath != "" {
+		stop, err := startHeapPprofCollector(h.opts.HeapPprofPath, "head_init", h.logger)
+		if err != nil {
+			return err
+		}
+		defer stop()
+	}
+
 	h.minValidTime.Store(minValidTime)
 	defer h.resetWLReplayResources()
 	defer func() {
@@ -694,7 +706,6 @@ func (h *Head) Init(minValidTime int64) error {
 			h.minTime.Store(h.minValidTime.Load())
 		}
 	}()
-
 	h.logger.Info("Replaying on-disk memory mappable chunks if any")
 	start := time.Now()
 
@@ -2704,4 +2715,18 @@ func (h *Head) updateWALReplayStatusRead(current int) {
 	defer h.stats.WALReplayStatus.Unlock()
 
 	h.stats.WALReplayStatus.Current = current
+}
+
+func startHeapPprofCollector(path, name string, logger *slog.Logger) (func(), error) {
+	collector, err := pprofutil.NewHeapPprofCollector(path, name, logger)
+	if err != nil {
+		return nil, fmt.Errorf("initialize %s pprof collector: %w", name, err)
+	}
+	old := runtime.MemProfileRate
+	runtime.MemProfileRate = 1
+	collector.Start()
+	return func() {
+		collector.Stop()
+		runtime.MemProfileRate = old
+	}, nil
 }

--- a/util/pprofutil/pprofutil.go
+++ b/util/pprofutil/pprofutil.go
@@ -1,0 +1,116 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pprofutil
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"time"
+)
+
+const (
+	collectionInterval = 3 * time.Second
+	heapPprofFilename  = "heap.pprof"
+)
+
+type HeapPprofCollector struct {
+	dir    string
+	logger *slog.Logger
+	stopc  chan struct{}
+	donec  chan struct{}
+}
+
+func NewHeapPprofCollector(basePath, name string, logger *slog.Logger) (*HeapPprofCollector, error) {
+	dir, err := os.MkdirTemp(basePath, name)
+	if err != nil {
+		return nil, fmt.Errorf("create pprof output directory under %s: %w", basePath, err)
+	}
+	return &HeapPprofCollector{
+		dir:    dir,
+		logger: logger.With("name", name, "dir", dir),
+		stopc:  make(chan struct{}),
+		donec:  make(chan struct{}),
+	}, nil
+}
+
+func (d *HeapPprofCollector) Start() {
+	go d.run()
+	d.logger.Info("Heap pprof collector started")
+}
+
+func (d *HeapPprofCollector) Stop() {
+	close(d.stopc)
+	<-d.donec
+	d.logger.Info("Heap pprof collector stopped")
+}
+
+func (d *HeapPprofCollector) run() {
+	defer close(d.donec)
+
+	// get up-to-date GC statistics.
+	runtime.GC()
+	if err := d.collect(); err != nil {
+		d.logger.Warn("Failed to write heap pprof", "err", err)
+	}
+
+	timer := time.NewTimer(collectionInterval)
+	defer timer.Stop()
+
+	// Periodically overwrite the heap profile to ensure a recent snapshot
+	// is available in case of OOM.
+	for {
+		select {
+		case <-d.stopc:
+			// Take a final snapshot.
+			runtime.GC()
+			if err := d.collect(); err != nil {
+				d.logger.Warn("Failed to write heap pprof", "err", err)
+			}
+			return
+		case <-timer.C:
+			if err := d.collect(); err != nil {
+				d.logger.Warn("Failed to write heap pprof", "err", err)
+			}
+			timer.Reset(collectionInterval)
+		}
+	}
+}
+
+func (d *HeapPprofCollector) collect() error {
+	tmpName := filepath.Join(d.dir, heapPprofFilename+".tmp")
+	tmp, err := os.Create(tmpName)
+	if err != nil {
+		return fmt.Errorf("create temp pprof file: %w", err)
+	}
+
+	writeErr := pprof.WriteHeapProfile(tmp)
+	closeErr := tmp.Close()
+
+	if writeErr != nil {
+		return fmt.Errorf("write heap pprof: %w", writeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close temp pprof file: %w", closeErr)
+	}
+
+	dest := filepath.Join(d.dir, heapPprofFilename)
+	if err := os.Rename(tmpName, dest); err != nil {
+		return fmt.Errorf("rename pprof file to %s: %w", dest, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Relates to #6934 and #16942. 

In some cases, WAL replay (or Head Init in general) is known to spike memory above steady-state usage, sometimes causing OOM crashloops from which Prometheus cannot recover.   

This PR introduces a built-in/easy to use profiling mechanism for this window. All the user needs to do is run:
```
prometheus --debug.pprof-collector.path=/path/to/dir
```
and Prometheus will periodically capture heap snapshots during Head Init, maximizing the chance of preserving a profile before an OOM kill.   

The user can then share the profile with us for analysis and debugging.
This is simpler and more precise than setting up scripts to poll /debug/pprof. 
The added utils can also be used to precisely profile other parts of the codebase when/if needed.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
