### PR TITLE
test: prometheusCommandWithLogging util: graceful shutdown and run prometheus at debug level

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -1014,7 +1014,6 @@ remote_write:
 		configFile,
 		port,
 		fmt.Sprintf("--storage.tsdb.path=%s", tmpDir),
-		"--log.level=debug",
 	)
 	require.NoError(t, prom.Start())
 

--- a/cmd/prometheus/reload_test.go
+++ b/cmd/prometheus/reload_test.go
@@ -21,9 +21,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -223,10 +225,17 @@ func commandWithLogging(t *testing.T, logProcessor func(*testing.T, io.Reader), 
 	}()
 
 	t.Cleanup(func() {
-		cmd.Process.Kill()
-		cmd.Wait()
-		stdoutWriter.Close()
-		stderrWriter.Close()
+		// Terminate the process gracefully, as that's the expected shutdown path.
+		// Prometheus must handle this signal cleanly.
+		if runtime.GOOS != "windows" {
+			require.NoError(t, cmd.Process.Signal(syscall.SIGTERM))
+			require.NoError(t, cmd.Wait())
+		} else {
+			require.NoError(t, cmd.Process.Kill())
+			cmd.Wait()
+		}
+		require.NoError(t, stdoutWriter.Close())
+		require.NoError(t, stderrWriter.Close())
 		wg.Wait()
 	})
 	return cmd
@@ -237,6 +246,7 @@ func prometheusCommandWithLogging(t *testing.T, configFilePath string, port int,
 		"-test.main",
 		"--config.file=" + configFilePath,
 		"--web.listen-address=0.0.0.0:" + strconv.Itoa(port),
+		"--log.level=debug",
 	}
 	args = append(args, extraArgs...)
 	return commandWithLogging(t, nil, promPath, args...)


### PR DESCRIPTION
Replace SIGKILL with SIGTERM in test cleanup to allow Prometheus to shut down gracefully, matching real-world behavior and avoiding false negatives from forceful process termination. Add --log.level=debug to surface detailed output when tests fail, especially when it's not easy to reproduce the failure

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
