### PR TITLE
chore(scripts/check_release_notes): also validate component name in entries

### DIFF
--- a/scripts/check_release_notes.sh
+++ b/scripts/check_release_notes.sh
@@ -16,13 +16,55 @@ if [[ "$content" == "NONE" ]]; then
     exit 0
 fi
 
-prefixes='FEATURE|ENHANCEMENT|PERF|BUGFIX|SECURITY|CHANGE'
+types=(
+    FEATURE
+    ENHANCEMENT
+    PERF
+    BUGFIX
+    SECURITY
+    CHANGE
+)
+
+components=(
+    PromQL
+    TSDB
+
+    Scraping
+    OTLP
+    Relabeling
+
+    "Remote-write"
+    Federation
+
+    Alerting
+    Rules
+
+    Discovery
+
+    Config
+    Tracing
+    Dockerfile
+
+    API
+    UI
+    Templates
+
+    Promtool
+    Mixin
+)
+
+types_re=$(IFS='|'; printf '%s' "${types[*]}")
+components_re=$(IFS='|'; printf '%s' "${components[*]}")
+
+# Expected format: [TYPE] Component: description
+pattern="^\[($types_re)\] ($components_re): .+"
 
 while IFS= read -r line; do
-  if [[ ! $line =~ ^\[($prefixes)\] ]]; then
-    echo "Error: Invalid prefix in '$line'"
-    # Convert pipes to brackets
-    echo "Content should be NONE or entries should start with one of: [${prefixes//|/] [}]"
+  if [[ ! $line =~ $pattern ]]; then
+    echo "Error: '$line' does not match the expected format."
+    echo "Expected: NONE or [TYPE] Component: description"
+    echo "Valid types: [${types_re//|/] [}]"
+    echo "Valid components: ${components_re//|/, }"
     exit 1
   fi
 done <<<"$content"

--- a/scripts/check_release_notes.sh
+++ b/scripts/check_release_notes.sh
@@ -17,42 +17,35 @@ if [[ "$content" == "NONE" ]]; then
 fi
 
 types=(
-    FEATURE
-    ENHANCEMENT
-    PERF
     BUGFIX
-    SECURITY
     CHANGE
+    ENHANCEMENT
+    FEATURE
+    PERF
+    SECURITY
 )
 
 components=(
-    PromQL
-    TSDB
-
-    Scraping
-    OTLP
-    Relabeling
-
-    "Remote-write"
-    "Remote-read"
-    Federation
-
-    Alerting
-    Rules
-
-    Discovery
-
-    Config
-    Tracing
-    Dockerfile
     Agent
-
+    Alerting
     API
-    UI
-    Templates
-
-    Promtool
+    Config
+    Discovery
+    Dockerfile
+    Federation
     Mixin
+    OTLP
+    PromQL
+    Promtool
+    Relabeling
+    "Remote-read"
+    "Remote-write"
+    Rules
+    Scraping
+    Templates
+    Tracing
+    TSDB
+    UI
 )
 
 types_re=$(IFS='|'; printf '%s' "${types[*]}")
@@ -64,7 +57,7 @@ pattern="^\[($types_re)\] ($components_re): .+"
 while IFS= read -r line; do
   if [[ ! $line =~ $pattern ]]; then
     echo "Error: '$line' does not match the expected format."
-    echo "Expected: NONE or [TYPE] Component: description"
+    echo "Expected: NONE or [TYPE] Component: Description"
     echo "Valid types: [${types_re//|/] [}]"
     echo "Valid components: ${components_re//|/, }"
     exit 1

--- a/scripts/check_release_notes.sh
+++ b/scripts/check_release_notes.sh
@@ -34,6 +34,7 @@ components=(
     Relabeling
 
     "Remote-write"
+    "Remote-read"
     Federation
 
     Alerting
@@ -44,6 +45,7 @@ components=(
     Config
     Tracing
     Dockerfile
+    Agent
 
     API
     UI

--- a/scripts/check_release_notes.sh
+++ b/scripts/check_release_notes.sh
@@ -38,8 +38,8 @@ components=(
     PromQL
     Promtool
     Relabeling
-    "Remote-read"
-    "Remote-write"
+    "Remote-Read"
+    "Remote-Write"
     Rules
     Scraping
     Templates


### PR DESCRIPTION


Previously only the type ([BUGFIX], [FEATURE], ...) was validated. Now the component (TSDB, PromQL, ...) must also match a canonical list derived from v3.x CHANGELOG entries, normalising the many inconsistent variants found there. The list can be extended if needed.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
