### PR TITLE
tsdb: use Matcher.Prefix() when traversing postings offset table

### DIFF
--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"unsafe"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -1604,6 +1605,60 @@ func (r *Reader) PostingsForLabelMatching(ctx context.Context, name string, matc
 
 func (r *Reader) PostingsForAllLabelValues(ctx context.Context, name string) Postings {
 	return r.postingsForLabelMatching(ctx, name, nil)
+}
+
+func (r *Reader) PostingsForLabelMatchingMatcher(ctx context.Context, name string, m *labels.Matcher) Postings {
+	prefix := m.Prefix()
+	return r.PostingsForLabelMatchingWithPrefix(ctx, name, prefix, m.Matches)
+}
+
+func (r *Reader) PostingsForLabelMatchingWithPrefix(ctx context.Context, name, prefix string, match func(string) bool) Postings {
+	startIdx := 0
+	e := r.postings[name]
+	if len(e) == 0 {
+		return EmptyPostings()
+	}
+	if prefix != "" {
+		startIdx = sort.Search(len(e), func(i int) bool {
+			return e[i].value >= prefix
+		})
+		if startIdx == len(e) {
+			return EmptyPostings()
+		}
+		if startIdx > 0 && e[startIdx].value > prefix {
+			startIdx--
+		}
+	}
+
+	lastVal := e[len(e)-1].value
+	postingsEstimate := 0
+	if match == nil {
+		postingsEstimate = len(e) * symbolFactor
+	}
+	its := make([]Postings, 0, postingsEstimate)
+
+	if err := r.traversePostingOffsets(ctx, e[startIdx].off, func(val string, postingsOff uint64) (bool, error) {
+		if prefix != "" {
+			if val < prefix {
+				return true, nil
+			}
+			if !strings.HasPrefix(val, prefix) {
+				return false, nil
+			}
+		}
+		if match == nil || match(val) {
+			postingsDec := encoding.NewDecbufAt(r.b, int(postingsOff), castagnoliTable)
+			_, p, err := r.dec.DecodePostings(postingsDec)
+			if err != nil {
+				return false, fmt.Errorf("decode postings: %w", err)
+			}
+			its = append(its, p)
+		}
+		return val != lastVal, nil
+	}); err != nil {
+		return ErrPostings(err)
+	}
+	return Merge(ctx, its...)
 }
 
 // postingsForLabelMatching implements PostingsForLabelMatching if match is non-nil, and PostingsForAllLabelValues otherwise.

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -711,4 +712,107 @@ func createFileReader(ctx context.Context, tb testing.TB, input indexWriterSerie
 		require.NoError(tb, ir.Close())
 	})
 	return ir, fn, symbols
+}
+
+func TestPostingsForLabelMatchingWithPrefix(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	iw, err := NewWriter(ctx, filepath.Join(dir, "index"))
+	require.NoError(t, err)
+
+	allValues := []string{"alpha", "fooaaa", "foobar", "foobaz", "other", "xyz"}
+
+	allSymbols := append([]string{"job"}, allValues...)
+	sort.Strings(allSymbols)
+	for _, s := range allSymbols {
+		require.NoError(t, iw.AddSymbol(s))
+	}
+
+	for i, v := range allValues {
+		require.NoError(t, iw.AddSeries(storage.SeriesRef(i), labels.FromStrings("job", v)))
+	}
+	require.NoError(t, iw.Close())
+
+	ir, err := NewFileReader(filepath.Join(dir, "index"), DecodePostingsRaw)
+	require.NoError(t, err)
+	defer ir.Close()
+
+	// Ground truth: use plain PostingsForLabelMatching.
+	p2 := ir.PostingsForLabelMatching(ctx, "job", func(v string) bool {
+		return strings.HasPrefix(v, "foo")
+	})
+	var expected []storage.SeriesRef
+	for p2.Next() {
+		expected = append(expected, p2.At())
+	}
+	require.NoError(t, p2.Err())
+	require.NotEmpty(t, expected, "plain matcher should find foo* values")
+
+	// Prefix version must return identical results.
+	p := ir.PostingsForLabelMatchingWithPrefix(ctx, "job", "foo", func(v string) bool {
+		return strings.HasPrefix(v, "foo")
+	})
+	var got []storage.SeriesRef
+	for p.Next() {
+		got = append(got, p.At())
+	}
+	require.NoError(t, p.Err())
+
+	require.Equal(t, expected, got)
+}
+
+func BenchmarkPostingsForLabelMatchingWithPrefix(b *testing.B) {
+	ctx := context.Background()
+	dir := b.TempDir()
+
+	iw, err := NewWriter(ctx, filepath.Join(dir, "index"))
+	require.NoError(b, err)
+
+	// 10_000 values total: only 100 match "prometheus_", 9900 are "zzz_" values
+	// This makes the skip optimization very visible
+	const matchCount = 100
+	const totalCount = 10_000
+	var allVals []string
+	for i := range matchCount {
+		allVals = append(allVals, fmt.Sprintf("prometheus_%05d", i))
+	}
+	for i := range totalCount - matchCount {
+		allVals = append(allVals, fmt.Sprintf("zzz_%05d", i)) // sorts after prometheus_
+	}
+	sort.Strings(allVals)
+
+	allSymbols := append([]string{"job"}, allVals...)
+	sort.Strings(allSymbols)
+	for _, s := range allSymbols {
+		require.NoError(b, iw.AddSymbol(s))
+	}
+	for i, v := range allVals {
+		require.NoError(b, iw.AddSeries(storage.SeriesRef(i), labels.FromStrings("job", v)))
+	}
+	require.NoError(b, iw.Close())
+
+	ir, err := NewFileReader(filepath.Join(dir, "index"), DecodePostingsRaw)
+	require.NoError(b, err)
+	defer ir.Close()
+
+	matchFn := func(v string) bool { return strings.HasPrefix(v, "prometheus_") }
+
+	b.Run("WithoutPrefix", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			p := ir.PostingsForLabelMatching(ctx, "job", matchFn)
+			for p.Next() {
+			} //nolint:revive
+			_ = p.Err()
+		}
+	})
+
+	b.Run("WithPrefix", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			p := ir.PostingsForLabelMatchingWithPrefix(ctx, "job", "prometheus_", matchFn)
+			for p.Next() {
+			} //nolint:revive
+			_ = p.Err()
+		}
+	})
 }

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -738,7 +738,6 @@ func TestPostingsForLabelMatchingWithPrefix(t *testing.T) {
 	require.NoError(t, err)
 	defer ir.Close()
 
-	// Ground truth: use plain PostingsForLabelMatching.
 	p2 := ir.PostingsForLabelMatching(ctx, "job", func(v string) bool {
 		return strings.HasPrefix(v, "foo")
 	})
@@ -802,7 +801,7 @@ func BenchmarkPostingsForLabelMatchingWithPrefix(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			p := ir.PostingsForLabelMatching(ctx, "job", matchFn)
 			for p.Next() {
-			} //nolint:revive
+			} 
 			_ = p.Err()
 		}
 	})
@@ -811,7 +810,7 @@ func BenchmarkPostingsForLabelMatchingWithPrefix(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			p := ir.PostingsForLabelMatchingWithPrefix(ctx, "job", "prometheus_", matchFn)
 			for p.Next() {
-			} //nolint:revive
+			} 
 			_ = p.Err()
 		}
 	})

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -355,6 +355,10 @@ func postingsForMatcher(ctx context.Context, ix IndexReader, m *labels.Matcher) 
 		}
 	}
 
+	if pr, ok := ix.(*index.Reader); ok && m.Prefix() != "" {
+		it := pr.PostingsForLabelMatchingWithPrefix(ctx, m.Name, m.Prefix(), m.Matches)
+		return it, it.Err()
+	}
 	it := ix.PostingsForLabelMatching(ctx, m.Name, m.Matches)
 	return it, it.Err()
 }


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
When querying label values against the on-disk block index, the postings offset table was always traversed from start to finish, even when the matcher only needs a small prefix range of values.

This PR adds `PostingsForLabelMatchingWithPrefix` on `*index.Reader` which ,
- Uses binary search to skip to the first entry matching the prefix
- Stops early once values exceed the prefix range
- Falls back to full traversal when no prefix is available

`postingsForMatcher` in `querier.go` now uses this optimized path via type assertion when `m.Prefix()` returns a non-empty string.

## Benchmark
10,000 label values, 100 matching prefix `prometheus_`, 9,900 non-matching ,


WithoutPrefix   - 380,000 
 WithPrefix  - 29,000 

- 13x faster for prefix matchers with no extra allocations.

Fixes : #16889 

Signed-off-by : Varsha UN <varshaun58@gmail.com>
