### PR TITLE
promql: add info() test cases and remove stale XXX comment

### DIFF
--- a/promql/promqltest/testdata/info.test
+++ b/promql/promqltest/testdata/info.test
@@ -22,6 +22,10 @@ eval range from 0m to 10m step 5m info(metric_not_matching_target_info)
 eval range from 0m to 10m step 5m info(metric_not_matching_target_info, {data=~".*"})
     metric_not_matching_target_info{instance="a", job="2", label="value"} 0 1 2
 
+# Non-matching identifying labels with a data label matcher that doesn't match empty string.
+# The series should be dropped since no info series matches and the matcher requires a non-empty value.
+eval range from 0m to 10m step 5m info(metric_not_matching_target_info, {data=~".+"})
+
 # Try including a certain info metric data label with a non-matching matcher not accepting empty labels.
 # Metric is ignored, due there being a data label matcher not matching empty labels,
 # and there being no info series matches.


### PR DESCRIPTION
This PR adds test cases for `info()` covering edge cases around non-matching identifying labels and empty-accepting data matchers, and removes a stale XXX comment.

**Commit 1:** Add a test for `info()` where identifying labels don't match any info series, but the data label matcher accepts empty strings (`{data=~".*"}`). The base series should be returned unchanged.

**Commit 2:** Remove the outdated XXX comment about vector selectors requiring at least one non-empty matcher, since the info function's second argument now bypasses this check via `BypassEmptyMatcherCheck`. Replace the workaround test (`{data=~".+", non_existent=~".*"}`) with a simpler test using only an empty-accepting matcher (`{non_existent=~".*"}`).

**Commit 3:** Add a test for `info()` where identifying labels don't match and the data matcher doesn't accept empty strings (`{data=~".+"}`). The series should be dropped since no info series matches and the matcher requires a non-empty value.

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```