### PR TITLE
storage/remote: add wait duration histogram for the remote read gate

### DIFF
--- a/storage/remote/read_handler.go
+++ b/storage/remote/read_handler.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -40,6 +41,7 @@ type readHandler struct {
 	remoteReadMaxBytesInFrame int
 	remoteReadGate            *gate.Gate
 	queries                   prometheus.Gauge
+	gateWaitDuration          prometheus.Histogram
 	marshalPool               *sync.Pool
 }
 
@@ -61,16 +63,30 @@ func NewReadHandler(logger *slog.Logger, r prometheus.Registerer, queryable stor
 			Name:      "queries",
 			Help:      "The current number of remote read queries that are either in execution or queued on the handler.",
 		}),
+		gateWaitDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace:                       namespace,
+			Subsystem:                       "remote_read_handler",
+			Name:                            "gate_wait_duration_seconds",
+			Help:                            "How long a remote read request spent waiting for the concurrency gate to open before proceeding.",
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
+		}),
 	}
 	if r != nil {
-		r.MustRegister(h.queries)
+		r.MustRegister(h.queries, h.gateWaitDuration)
 	}
 	return h
 }
 
 func (h *readHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if err := h.remoteReadGate.Start(ctx); err != nil {
+	gateStart := time.Now()
+	err := h.remoteReadGate.Start(ctx)
+	// Observe before checking the error so requests that are canceled while waiting on the gate
+	// are recorded too.
+	h.gateWaitDuration.Observe(time.Since(gateStart).Seconds())
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/storage/remote/read_handler_test.go
+++ b/storage/remote/read_handler_test.go
@@ -15,6 +15,7 @@ package remote
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/config"
@@ -479,4 +481,68 @@ func addNativeHistogramsToTestSuite(t *testing.T, storage *teststorage.TestStora
 	}
 
 	require.NoError(t, app.Commit())
+}
+
+func TestRemoteReadGateWaitDurationObserved(t *testing.T) {
+	store := promqltest.LoadedStorage(t, `
+		load 1m
+			test_metric1{foo="bar"} 1
+	`)
+	defer store.Close()
+
+	newRequest := func(t *testing.T) *http.Request {
+		matcher, err := labels.NewMatcher(labels.MatchEqual, "__name__", "test_metric1")
+		require.NoError(t, err)
+		query, err := ToQuery(0, 1, []*labels.Matcher{matcher}, &storage.SelectHints{Step: 0, Func: "avg"})
+		require.NoError(t, err)
+		data, err := proto.Marshal(&prompb.ReadRequest{Queries: []*prompb.Query{query}})
+		require.NoError(t, err)
+		request, err := http.NewRequest(http.MethodPost, "", bytes.NewBuffer(snappy.Encode(nil, data)))
+		require.NoError(t, err)
+		return request
+	}
+
+	gateWaitSampleCount := func(t *testing.T, reg *prometheus.Registry) uint64 {
+		mfs, err := reg.Gather()
+		require.NoError(t, err)
+		for _, mf := range mfs {
+			if mf.GetName() == "prometheus_remote_read_handler_gate_wait_duration_seconds" {
+				return mf.GetMetric()[0].GetHistogram().GetSampleCount()
+			}
+		}
+		t.Fatal("expected gate wait duration histogram to be registered")
+		return 0
+	}
+
+	t.Run("successful acquisition", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		h := NewReadHandler(nil, reg, store, func() config.Config {
+			return config.Config{}
+		}, 1e6, 1, 0)
+
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, newRequest(t))
+		require.Equal(t, 2, recorder.Code/100)
+
+		require.Equal(t, uint64(1), gateWaitSampleCount(t, reg))
+	})
+
+	t.Run("canceled acquisition", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		// A concurrency limit of zero means the gate never opens, so a canceled context
+		// deterministically loses the race in Gate.Start and returns an error.
+		h := NewReadHandler(nil, reg, store, func() config.Config {
+			return config.Config{}
+		}, 1e6, 0, 0)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		recorder := httptest.NewRecorder()
+		h.ServeHTTP(recorder, newRequest(t).WithContext(ctx))
+		require.Equal(t, http.StatusInternalServerError, recorder.Code)
+
+		// The wait is still observed even though the request was canceled at the gate.
+		require.Equal(t, uint64(1), gateWaitSampleCount(t, reg))
+	})
 }


### PR DESCRIPTION
## What

Add a `prometheus_remote_read_handler_gate_wait_duration_seconds` histogram that records how long each remote read request waits for the concurrency gate before it can proceed.

## Why, how this solves #11365

The issue asks for visibility into whether requests are being held up at the remote read gate, and for how long.

This metric answers that directly:

- If `rate(prometheus_remote_read_handler_gate_wait_duration_seconds_count[5m])` is close to the incoming request rate, most requests are waiting.
- If `histogram_quantile(0.99, ...)` is high, the concurrency limit needs increasing.
- If the histogram stays near zero, the limit is adequate.

This is the "waiting duration" subset that @bboreham approved as a valid scope in the discussion.

## Changes

- `storage/remote/read_handler.go`: record the wait around `remoteReadGate.Start()` in the remote read handler and register the histogram alongside the existing handler metrics. The wait is observed before the error is checked, so requests that are canceled while waiting on the gate are recorded too.
- `storage/remote/read_handler_test.go`: sub-tests for a successful acquisition and a canceled acquisition.

`util/gate` is left unchanged; the metric lives on the read handler per review feedback. It is a native histogram (bucket factor 1.1), so there are no fixed bucket boundaries.

```release-notes
[ENHANCEMENT] Remote Read: Add prometheus_remote_read_handler_gate_wait_duration_seconds histogram to track how long requests wait for the concurrency gate.
```

Fixes #11365
