### PR TITLE
promqltest: use AppenderV2 in load command

### DIFF
--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -1446,7 +1446,7 @@ func (t *test) exec(tc testCommand, engine promql.QueryEngine) error {
 	case *loadCmd:
 		app := t.storage.AppenderV2(t.context)
 		if err := cmd.append(app); err != nil {
-			app.Rollback()
+			_ = app.Rollback()
 			return err
 		}
 


### PR DESCRIPTION
Prereq for #18258

Switch the PromQL test framework's load command from `storage.Appender` to `storage.AppenderV2` in `appendSample`, `appendCustomHistogram` and `appendTill`. ST is set to 0 (unknown) for now; a follow-up will add per-sample ST specification in load statements.

## Why AppenderV2 and not passing all fields at once

`AppenderV2.Append` has a unified signature that carries `st`, `v`, `h`, and `fh` in one call. One might ask whether we could simply always pass `s.H` as the float histogram alongside `s.F` and let the implementation detect the type. The answer is no: the interface contract explicitly states:

> Callers MUST only provide one of the sample types (either v, h or fh).

So the `if s.H != nil` branch in `appendSample` is required by contract, not just a defensive check. With that constraint the helper function is kept as-is since it gives a name to the pattern and hides the zero-valued unused parameters.

```release-notes
NONE
```

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>
Coded with Claude Sonnet 4.6.