### PR TITLE
fix: alert state is not restored when Prometheus restarts

### DIFF
--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
@@ -488,6 +490,237 @@ func TestForStateRestore(t *testing.T) {
 					newGroup.Eval(context.TODO(), restoreTime)
 					// Restore happens here.
 					newGroup.RestoreForState(restoreTime)
+
+					got := newRule.ActiveAlerts()
+					for _, aa := range got {
+						require.Empty(t, aa.Labels.Get(model.MetricNameLabel), "%s label set on active alert: %s", model.MetricNameLabel, aa.Labels)
+					}
+					sort.Slice(got, func(i, j int) bool {
+						return labels.Compare(got[i].Labels, got[j].Labels) < 0
+					})
+
+					// In all cases, we expect the restoration process to have completed.
+					require.Truef(t, newRule.Restored(), "expected the rule restoration process to have completed")
+
+					// Checking if we have restored it correctly.
+					switch {
+					case tt.noRestore:
+						require.Len(t, got, tt.num)
+						for _, e := range got {
+							require.Equal(t, e.ActiveAt, restoreTime)
+						}
+					case tt.gracePeriod:
+
+						require.Len(t, got, tt.num)
+						for _, e := range got {
+							require.Equal(t, opts.ForGracePeriod, e.ActiveAt.Add(alertForDuration).Sub(restoreTime))
+						}
+					default:
+						exp := tt.expectedAlerts
+						require.Len(t, got, len(exp))
+						sortAlerts(exp)
+						sortAlerts(got)
+						for i, e := range exp {
+							require.Equal(t, e.Labels, got[i].Labels)
+
+							// Difference in time should be within 1e6 ns, i.e. 1ms
+							// (due to conversion between ns & ms, float64 & int64).
+							activeAtDiff := queryOffset.Seconds() + float64(e.ActiveAt.Unix()+int64(tt.downDuration/time.Second)-got[i].ActiveAt.Unix())
+							require.Equal(t, 0.0, math.Abs(activeAtDiff), "'for' state restored time is wrong")
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestForStateRestoreWithTemplate(t *testing.T) {
+	alertLabels := labels.FromStrings(
+		"severity",
+		"critical",
+		"instance_ext",
+		"instance_{{ $labels.instance }}", // Using a template label to test restoration in this particular case
+	)
+
+	for _, queryOffset := range []time.Duration{0, time.Minute} {
+		t.Run(fmt.Sprintf("queryOffset %s", queryOffset.String()), func(t *testing.T) {
+			st := promqltest.LoadedStorage(t, `
+		load 5m
+		http_requests{job="app-server", instance="0", group="canary", severity="overwrite-me"}	75  85 50 0 0 25 0 0 40 0 120
+		http_requests{job="app-server", instance="1", group="canary", severity="overwrite-me"}	125 90 60 0 0 25 0 0 40 0 130
+	`)
+			t.Cleanup(func() { st.Close() })
+
+			expr, err := parser.ParseExpr(`http_requests{group="canary", job="app-server"} < 100`)
+			require.NoError(t, err)
+
+			ng := testEngine(t)
+			crq := storage.NewCallRecorderQueryable(st)
+			opts := &ManagerOptions{
+				QueryFunc:       EngineQueryFunc(ng, st),
+				Appendable:      st,
+				Queryable:       crq,
+				Context:         context.Background(),
+				Logger:          promslog.NewNopLogger(),
+				NotifyFunc:      func(_ context.Context, _ string, _ ...*Alert) {},
+				OutageTolerance: 30 * time.Minute,
+				ForGracePeriod:  10 * time.Minute,
+			}
+
+			alertForDuration := 25 * time.Minute
+			// Initial run before prometheus goes down.
+			rule := NewAlertingRule(
+				"HTTPRequestRateLow",
+				expr,
+				alertForDuration,
+				0,
+				alertLabels,
+				labels.EmptyLabels(), labels.EmptyLabels(), "", true, nil,
+			)
+
+			group := NewGroup(GroupOptions{
+				Name:          "default",
+				Interval:      time.Second,
+				Rules:         []Rule{rule},
+				ShouldRestore: true,
+				Opts:          opts,
+			})
+			groups := make(map[string]*Group)
+			groups["default;"] = group
+
+			initialRuns := []time.Duration{0, 5 * time.Minute}
+
+			baseTime := time.Unix(0, 0)
+			for _, duration := range initialRuns {
+				evalTime := baseTime.Add(duration)
+				group.Eval(context.TODO(), evalTime)
+			}
+
+			// Prometheus goes down here. We create new rules and groups.
+			type testInput struct {
+				name            string
+				restoreDuration time.Duration
+				expectedAlerts  []*Alert
+
+				num          int
+				noRestore    bool
+				gracePeriod  bool
+				downDuration time.Duration
+				before       func()
+			}
+
+			tests := []testInput{
+				{
+					name:            "normal restore (alerts were not firing)",
+					restoreDuration: 15 * time.Minute,
+					expectedAlerts:  rule.ActiveAlerts(),
+					downDuration:    10 * time.Minute,
+				},
+				{
+					name:            "outage tolerance",
+					restoreDuration: 40 * time.Minute,
+					noRestore:       true,
+					num:             2,
+				},
+				{
+					name:            "no active alerts",
+					restoreDuration: 50 * time.Minute,
+					expectedAlerts:  []*Alert{},
+				},
+				{
+					name:            "test the grace period",
+					restoreDuration: 25 * time.Minute,
+					expectedAlerts:  []*Alert{},
+					gracePeriod:     true,
+					before: func() {
+						for _, duration := range []time.Duration{10 * time.Minute, 15 * time.Minute, 20 * time.Minute} {
+							evalTime := baseTime.Add(duration)
+							group.Eval(context.TODO(), evalTime)
+						}
+					},
+					num: 2,
+				},
+			}
+
+			for i, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					if tt.before != nil {
+						tt.before()
+					}
+
+					newRule := NewAlertingRule(
+						"HTTPRequestRateLow",
+						expr,
+						alertForDuration,
+						0,
+						alertLabels,
+						labels.EmptyLabels(),
+						labels.EmptyLabels(),
+						"",
+						false,
+						nil,
+					)
+					newGroup := NewGroup(GroupOptions{
+						Name:          "default",
+						Interval:      time.Second,
+						Rules:         []Rule{newRule},
+						ShouldRestore: true,
+						Opts:          opts,
+						QueryOffset:   &queryOffset,
+					})
+
+					// Check the storage to see if we have ALERTS_FOR_STATE
+					afs, err := opts.QueryFunc(t.Context(), "ALERTS_FOR_STATE", baseTime)
+					if err != nil {
+						t.Fatalf("failed to query storage for ALERTS_FOR_STATE: %v", err)
+					}
+					t.Log(afs.String())
+
+					newGroups := make(map[string]*Group)
+					newGroups["default;"] = newGroup
+
+					restoreTime := baseTime.Add(tt.restoreDuration).Add(queryOffset)
+					// First eval before restoration.
+					newGroup.Eval(t.Context(), restoreTime)
+					require.Len(t, crq.Queriers(), i)
+
+					// Restore happens here.
+					newGroup.RestoreForState(restoreTime)
+
+					queriers := crq.Queriers()
+					require.Len(t, queriers, i+1, "expected one querier to be created during restoration")
+
+					wantCalls := []storage.SelectCall{
+						{
+							Matchers: []*labels.Matcher{
+								{
+									Name:  "__name__",
+									Value: alertForStateMetricName,
+									Type:  labels.MatchEqual,
+								},
+								{
+									Name:  "alertname",
+									Value: "HTTPRequestRateLow",
+									Type:  labels.MatchEqual,
+								},
+								{
+									Name:  "instance_ext",
+									Value: "instance_0",
+									Type:  labels.MatchEqual,
+								},
+								{
+									Name:  "severity",
+									Value: "critical",
+									Type:  labels.MatchEqual,
+								},
+							},
+						},
+					}
+					gotCalls := queriers[i].SelectCalls()
+					if diff := cmp.Diff(wantCalls, gotCalls, cmpopts.IgnoreUnexported(labels.Matcher{})); diff != "" {
+						t.Errorf("unexpected Select calls (-want +got):\n%s", diff)
+					}
 
 					got := newRule.ActiveAlerts()
 					for _, aa := range got {

--- a/storage/call_recorder.go
+++ b/storage/call_recorder.go
@@ -1,0 +1,138 @@
+package storage
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+// CallRecorderQueryable is used to record the queries made to the storage layer during tests.
+type CallRecorderQueryable struct {
+	q Queryable
+
+	mtx      sync.Mutex
+	queriers []*CallRecorderQuerier
+}
+
+func (c *CallRecorderQueryable) Queriers() []*CallRecorderQuerier {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	queriers := make([]*CallRecorderQuerier, 0, len(c.queriers))
+	for _, q := range c.queriers {
+		queriers = append(queriers, q)
+	}
+	return queriers
+}
+
+// CallRecorderQuerier is used to record the queries made to the storage layer during tests.
+type CallRecorderQuerier struct {
+	q Querier
+
+	mtx             sync.RWMutex
+	labelValuesCall []labelValuesCall
+	labelNamesCall  []labelNamesCall
+	selectCall      []SelectCall
+}
+
+func (c *CallRecorderQuerier) LabelValuesCalls() []labelValuesCall {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return append([]labelValuesCall(nil), c.labelValuesCall...)
+}
+
+func (c *CallRecorderQuerier) LabelNamesCalls() []labelNamesCall {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return append([]labelNamesCall(nil), c.labelNamesCall...)
+}
+
+func (c *CallRecorderQuerier) SelectCalls() []SelectCall {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	return append([]SelectCall(nil), c.selectCall...)
+}
+
+type labelValuesCall struct {
+	name     string
+	hints    *LabelHints
+	matchers []*labels.Matcher
+}
+
+type labelNamesCall struct {
+	hints    *LabelHints
+	matchers []*labels.Matcher
+}
+
+type SelectCall struct {
+	SortSeries bool
+	Hints      *SelectHints
+	Matchers   []*labels.Matcher
+}
+
+// NewCallRecorderQueryable creates a new CallRecorderQueryable that wraps the provided Queryable.
+func NewCallRecorderQueryable(q Queryable) *CallRecorderQueryable {
+	return &CallRecorderQueryable{
+		q: q,
+	}
+}
+
+// NewCallRecorderQuerier creates a new CallRecorderQuerier that wraps the provided Querier.
+func NewCallRecorderQuerier(q Querier) *CallRecorderQuerier {
+	return &CallRecorderQuerier{
+		q: q,
+	}
+}
+
+// Querier returns a Querier that records the calls made to it.
+func (c *CallRecorderQueryable) Querier(mint, maxt int64) (Querier, error) {
+	q, err := c.q.Querier(mint, maxt)
+	if err != nil {
+		return nil, err
+	}
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	crQuerier := NewCallRecorderQuerier(q)
+	c.queriers = append(c.queriers, crQuerier)
+	return crQuerier, nil
+}
+
+func (c *CallRecorderQuerier) LabelValues(ctx context.Context, name string, hints *LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.labelValuesCall = append(c.labelValuesCall, labelValuesCall{
+		name:     name,
+		hints:    hints,
+		matchers: matchers,
+	})
+	return c.q.LabelValues(ctx, name, hints, matchers...)
+}
+
+func (c *CallRecorderQuerier) LabelNames(ctx context.Context, hints *LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.labelNamesCall = append(c.labelNamesCall, labelNamesCall{
+		hints:    hints,
+		matchers: matchers,
+	})
+	return c.q.LabelNames(ctx, hints, matchers...)
+}
+
+func (c *CallRecorderQuerier) Close() error {
+	return c.q.Close()
+}
+
+func (c *CallRecorderQuerier) Select(ctx context.Context, sortSeries bool, hints *SelectHints, matchers ...*labels.Matcher) SeriesSet {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.selectCall = append(c.selectCall, SelectCall{
+		SortSeries: sortSeries,
+		Hints:      hints,
+		Matchers:   matchers,
+	})
+	return c.q.Select(ctx, sortSeries, hints, matchers...)
+}
+
+var _ Queryable = (*CallRecorderQueryable)(nil)
+var _ Querier = (*CallRecorderQuerier)(nil)


### PR DESCRIPTION
In #13980 an optimization in the `ALERTS_FOR_STATE` logic caused the alert restoration to fail when template variables are used.

This PR intentionally doesn't solve this (yet) because the fix might cause performance issues that the problematic PR tried to address.

I strongly believe, as shown from the test here, that the performance fix never really worked - and this bug got unnoticed for a long time.

This investigation is the result of multiple months of debugging this behavior at a previous company I worked at together with @verejoel - and it's one of the reasons why he gave [this talk at PromCon 2025](https://promcon.io/2025-munich/talks/alertmanager-has-amnesia--should-we-fix-it/) (although he didn't mention this issue there).

The intent of this PR is to get acknowledgment on the problem, and understand together what is the best way forward to solve it. Ideally a revert of the problematic PR would be enough, but that would solve the performance issues that @gotjosh tried to solve in #13980.

This PR will be used to fix #16883

cc/ @bwplotka