### PR TITLE
rules: skip template labels when querying ALERTS_FOR_STATE for restore

### DIFF
--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -282,6 +282,11 @@ func (r *AlertingRule) QueryForStateSeries(ctx context.Context, q storage.Querie
 	smpl := r.forStateSample(nil, time.Now(), 0)
 	var matchers []*labels.Matcher
 	smpl.Metric.Range(func(l labels.Label) {
+		// Skip labels with template syntax: their values are expanded per alert
+		// instance and would not match the stored series.
+		if strings.Contains(l.Value, "{{") {
+			return
+		}
 		mt, err := labels.NewMatcher(labels.MatchEqual, l.Name, l.Value)
 		if err != nil {
 			panic(err)

--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -741,6 +741,45 @@ func TestQueryForStateSeries(t *testing.T) {
 	}
 }
 
+// TestQueryForStateSeriesTemplateLabels verifies that labels containing Go
+// template syntax are excluded from the matchers used to query ALERTS_FOR_STATE,
+// so that per-instance expanded values stored in the series can still be found.
+func TestQueryForStateSeriesTemplateLabels(t *testing.T) {
+	var gotMatchers []*labels.Matcher
+	querier := &storage.MockQuerier{
+		SelectMockFunction: func(_ bool, _ *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+			gotMatchers = matchers
+			return storage.EmptySeriesSet()
+		},
+	}
+
+	rule := NewAlertingRule(
+		"TestRule",
+		nil,
+		time.Minute,
+		0,
+		labels.FromStrings("severity", "critical", "instance_ext", "instance_{{ $labels.instance }}"),
+		labels.EmptyLabels(), labels.EmptyLabels(), "", true, nil,
+	)
+
+	_, err := rule.QueryForStateSeries(context.Background(), querier)
+	require.NoError(t, err)
+
+	for _, m := range gotMatchers {
+		require.NotContains(t, m.Value, "{{", "template label %q must not appear in Select matchers", m.Name)
+	}
+
+	// The static label must still be present.
+	found := false
+	for _, m := range gotMatchers {
+		if m.Name == "severity" && m.Value == "critical" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "static label severity=critical must be present in Select matchers")
+}
+
 // TestSendAlertsDontAffectActiveAlerts tests a fix for https://github.com/prometheus/prometheus/issues/11424.
 func TestSendAlertsDontAffectActiveAlerts(t *testing.T) {
 	rule := NewAlertingRule(


### PR DESCRIPTION
QueryForStateSeries built Select matchers from the raw rule labels, which can contain Go template expressions such as
`instance_{{ $labels.instance }}`. The stored ALERTS_FOR_STATE series carry the per-instance evaluated values (e.g. `instance_0`), so the unevaluated template string never matched, leaving seriesByLabels empty and silently skipping restoration for every active alert.

Fix by omitting any label whose value contains `{{` from the matcher list. Static labels (including `__name__` and `alertname`) are never templated and continue to scope the query to the correct rule. The in-memory lookup against evaluated alert labels that follows is unaffected, so the single-query-per-rule optimisation introduced in #13980 is fully preserved.

Fixes #16883
Ref #13980
Ref #18364

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Rules: Fix alert state restoration when rule labels contain Go template expressions
```
