### PR TITLE
chore: Use make target for protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,8 @@ jobs:
       - run: go test --tags=slicelabels -race ./cmd/prometheus ./model/textparse ./prompb/...
       - run: go test --tags=forcedirectio -race ./tsdb/
       - run: GOARCH=386 go test ./...
-      - run: |
-          VERSION="3.15.8"
-          env
-          set -x
-          curl -s -L https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-linux-x86_64.zip > /tmp/protoc.zip
-          unzip -d /tmp /tmp/protoc.zip
-          chmod +x /tmp/bin/protoc
-          export PATH=/tmp/bin:$PATH
-          make proto
+      - run: make protoc
+      - run: make proto
       - run: git diff --exit-code
 
   test_go_oldest:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,15 @@ GOYACC_VERSION ?= v0.6.0
 
 include Makefile.common
 
+ifeq (arm, $(GOHOSTARCH))
+	PROTOC_ARCH ?= aarch_64
+else
+	PROTOC_ARCH ?= x86_64
+endif
+
+PROTOC_VERSION ?= 3.15.8
+PROTOC_URL     ?= https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/protoc-$(PROTOC_VERSION)-linux-$(PROTOC_ARCH).zip
+
 DOCKER_IMAGE_NAME       ?= prometheus
 
 # Only build UI if PREBUILT_ASSETS_STATIC_DIR is not set
@@ -128,6 +137,15 @@ assets-compress: assets
 assets-tarball: assets
 	@echo '>> packaging assets'
 	scripts/package_assets.sh
+
+.PHONY: protoc
+protoc:
+	@echo ">> Installing protoc"
+	$(eval PROTOC_TMP := $(shell mktemp))
+	curl -s -o $(PROTOC_TMP) -L $(PROTOC_URL) 
+	unzip -u $(PROTOC_TMP) bin/protoc -d $(FIRST_GOPATH)
+	chmod +x $(FIRST_GOPATH)/bin/protoc
+	rm -v $(PROTOC_TMP)
 
 .PHONY: parser
 parser:


### PR DESCRIPTION
Migrate the CI scripting of installing protoc to a Makefile target.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
