### PR TITLE
feat: Add waiting duration metric to query gate

### DIFF
--- a/util/gate/gate.go
+++ b/util/gate/gate.go
@@ -13,7 +13,21 @@
 
 package gate
 
-import "context"
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var gateWaitingDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+	Namespace: "prometheus",
+	Subsystem: "query",
+	Name:      "gate_waiting_duration_seconds",
+	Help:      "Histogram of request waiting time at the query gate in seconds.",
+	Buckets:   prometheus.DefBuckets,
+})
 
 // A Gate controls the maximum number of concurrently running and waiting queries.
 type Gate struct {
@@ -30,10 +44,12 @@ func New(length int) *Gate {
 
 // Start blocks until the gate has a free spot or the context is done.
 func (g *Gate) Start(ctx context.Context) error {
+	startTime := time.Now()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case g.ch <- struct{}{}:
+		gateWaitingDuration.Observe(time.Since(startTime).Seconds())
 		return nil
 	}
 }

--- a/util/gate/gate_test.go
+++ b/util/gate/gate_test.go
@@ -1,0 +1,110 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gate
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestGateStart(t *testing.T) {
+	g := New(1)
+
+	ctx := context.Background()
+	if err := g.Start(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	g.Done()
+}
+
+func TestGateStartContextDone(t *testing.T) {
+	g := New(1)
+
+	// Fill the gate
+	ctx := context.Background()
+	if err := g.Start(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Try to start with a cancelled context
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := g.Start(cancelledCtx); err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+
+	g.Done()
+}
+
+func TestGateDone(t *testing.T) {
+	g := New(2)
+
+	ctx := context.Background()
+	if err := g.Start(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := g.Start(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	g.Done()
+	g.Done()
+}
+
+func TestGateDonePanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic from Done() without Start()")
+		}
+	}()
+
+	g := New(1)
+	g.Done()
+}
+
+func TestGateWaitingDuration(t *testing.T) {
+	g := New(1)
+	ctx := context.Background()
+
+	// Start first request to fill the gate
+	if err := g.Start(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Start a goroutine that will wait
+	done := make(chan error, 1)
+	go func() {
+		startTime := time.Now()
+		err := g.Start(ctx)
+		waitTime := time.Since(startTime)
+		if waitTime < 50*time.Millisecond {
+			t.Logf("wait time was %v (expected at least ~100ms delay)", waitTime)
+		}
+		done <- err
+	}()
+
+	// Give the goroutine time to block
+	time.Sleep(100 * time.Millisecond)
+
+	// Release the gate so the waiting goroutine can proceed
+	g.Done()
+
+	if err := <-done; err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	g.Done()
+}


### PR DESCRIPTION
Fixes #11365

The query gate limits concurrent requests but we had no visibility into how long requests wait when the limit is hit.

This adds a histogram metric to track waiting duration, so operators can see if the gate is becoming a bottleneck and whether they need to increase the concurrency limit.

The metric is named 'prometheus_query_gate_waiting_duration_seconds' and uses standard histogram buckets. Waiting time is measured from when Start() is called until the request acquires a gate slot.

This includes comprehensive tests covering normal operation, context cancellation, and metric recording.