### PR TITLE
promtool: add --api-path flag to push metrics command

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -233,6 +233,7 @@ func main() {
 	pushMetricsTimeout := pushMetricsCmd.Flag("timeout", "The time to wait for pushing metrics.").Default("30s").Duration()
 	pushMetricsHeaders := pushMetricsCmd.Flag("header", "Prometheus remote write header.").StringMap()
 	pushMetricsProtoMsg := pushMetricsCmd.Flag("protobuf_message", "Protobuf message to use when writing (prometheus.WriteRequest or io.prometheus.write.v2.Request).").Default("prometheus.WriteRequest").String()
+	pushMetricsAPIPath := pushMetricsCmd.Flag("remote-write.api-path", "Override the default remote write API path (/api/v1/write).").Default("").String()
 
 	testCmd := app.Command("test", "Unit testing.")
 	junitOutFile := testCmd.Flag("junit", "File path to store JUnit XML test results.").OpenFile(os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
@@ -393,7 +394,7 @@ func main() {
 		os.Exit(CheckMetrics(*checkMetricsExtended, *checkMetricsLint))
 
 	case pushMetricsCmd.FullCommand():
-		os.Exit(PushMetrics(remoteWriteURL, httpRoundTripper, *pushMetricsHeaders, *pushMetricsTimeout, *pushMetricsProtoMsg, *pushMetricsLabels, *metricFiles...))
+		os.Exit(PushMetrics(remoteWriteURL, httpRoundTripper, *pushMetricsHeaders, *pushMetricsTimeout, *pushMetricsProtoMsg, *pushMetricsLabels, *pushMetricsAPIPath, *metricFiles...))
 
 	case queryInstantCmd.FullCommand():
 		os.Exit(QueryInstant(serverURL, httpRoundTripper, *queryInstantHeaders, *queryInstantExpr, *queryInstantTime, p))

--- a/cmd/promtool/metrics.go
+++ b/cmd/promtool/metrics.go
@@ -29,7 +29,7 @@ import (
 )
 
 // PushMetrics to a prometheus remote write (for testing purpose only).
-func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[string]string, timeout time.Duration, protoMsg string, labels map[string]string, files ...string) int {
+func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[string]string, timeout time.Duration, protoMsg string, labels map[string]string, apiPath string, files ...string) int {
 	addressURL, err := url.Parse(url.String())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -46,7 +46,11 @@ func PushMetrics(url *url.URL, roundTripper http.RoundTripper, headers map[strin
 	}
 
 	// Create remote write API client.
-	writeAPI, err := remoteapi.NewAPI(addressURL.String(), remoteapi.WithAPIHTTPClient(httpClient))
+	apiOpts := []remoteapi.APIOption{remoteapi.WithAPIHTTPClient(httpClient)}
+	if apiPath != "" {
+		apiOpts = append(apiOpts, remoteapi.WithAPIPath(apiPath))
+	}
+	writeAPI, err := remoteapi.NewAPI(addressURL.String(), apiOpts...)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return failureExitCode

--- a/cmd/promtool/metrics_test.go
+++ b/cmd/promtool/metrics_test.go
@@ -102,6 +102,7 @@ test_metric{label="value2"} 43.0
 				30*time.Second,
 				tc.protoMsg,
 				map[string]string{"job": "test"},
+				 "/api/v1/write",
 				tmpFile,
 			)
 
@@ -154,6 +155,7 @@ func TestPushMetricsInvalidProtoMsg(t *testing.T) {
 		30*time.Second,
 		"blablalba", // Invalid protoMsg.
 		map[string]string{"job": "test"},
+		 "/api/v1/write",
 		tmpFile,
 	)
 

--- a/cmd/promtool/metrics_test.go
+++ b/cmd/promtool/metrics_test.go
@@ -102,7 +102,7 @@ test_metric{label="value2"} 43.0
 				30*time.Second,
 				tc.protoMsg,
 				map[string]string{"job": "test"},
-				 "/api/v1/write",
+				"/api/v1/write",
 				tmpFile,
 			)
 
@@ -155,7 +155,7 @@ func TestPushMetricsInvalidProtoMsg(t *testing.T) {
 		30*time.Second,
 		"blablalba", // Invalid protoMsg.
 		map[string]string{"job": "test"},
-		 "/api/v1/write",
+		"/api/v1/write",
 		tmpFile,
 	)
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -435,6 +435,7 @@ Push metrics to a prometheus remote write (for testing purpose only).
 | <code class="text-nowrap">--timeout</code> | The time to wait for pushing metrics. | `30s` |
 | <code class="text-nowrap">--header</code> | Prometheus remote write header. |  |
 | <code class="text-nowrap">--protobuf_message</code> | Protobuf message to use when writing (prometheus.WriteRequest or io.prometheus.write.v2.Request). | `prometheus.WriteRequest` |
+| <code class="text-nowrap">--remote-write.api-path</code> | Override the default remote write API path (/api/v1/write). |  |
 
 
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18358

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*
```release-notes
[ENHANCEMENT] promtool: Add --api-path flag to `push metrics` command to allow overriding the default remote write API path (/api/v1/write). This enables pushing metrics to endpoints that use a different path, such as Mimir's /api/v1/push.
```
Signed-off-by : Varsha  U N <varshaun58@gmail.com>