### PR TITLE
textparse: fix panic in protobuf parser for summary with no quantiles

### DIFF
--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -674,6 +674,10 @@ func (p *ProtobufParser) getMagicLabel() (bool, string, string) {
 	switch p.dec.GetType() {
 	case dto.MetricType_SUMMARY:
 		qq := p.dec.GetSummary().GetQuantile()
+		if p.fieldPos >= len(qq) {
+			p.fieldsDone = true
+			return false, "", ""
+		}
 		q := qq[p.fieldPos]
 		p.fieldsDone = p.fieldPos == len(qq)-1
 		return true, model.QuantileLabel, labels.FormatOpenMetricsFloat(q.GetQuantile())

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -5911,6 +5911,32 @@ func generateValidMetricName(r *rand.Rand) string {
 	return generateString(r, validFirstRunes, validMetricNameRunes)
 }
 
+// TestProtobufParseSummaryNoQuantilesNoPanic is a regression test for a panic
+// when Next() is called without Series() on a summary with no quantiles.
+func TestProtobufParseSummaryNoQuantilesNoPanic(t *testing.T) {
+	buf := metricFamiliesToProtobuf(t, []string{`
+name: "no_quantile_summary"
+help: "A summary with no quantile entries."
+type: SUMMARY
+metric: <
+  summary: <
+    sample_count: 10
+    sample_sum: 1.5
+  >
+>
+`})
+
+	p := NewProtobufParser(buf.Bytes(), false, false, false, false, labels.NewSymbolTable())
+	require.NotPanics(t, func() {
+		for {
+			_, err := p.Next()
+			if errors.Is(err, io.EOF) || err != nil {
+				break
+			}
+		}
+	})
+}
+
 func generateString(r *rand.Rand, firstRunes, restRunes []rune) string {
 	result := make([]rune, 1+r.Intn(20))
 	for i := range result {


### PR DESCRIPTION
getMagicLabel had no bounds check on the quantile slice for the Summary case. fieldsDone for an empty-quantile summary is set inside Series(), not getMagicLabel. A caller driving Next() without calling Series() at the _sum step would allow fieldPos to advance to 0 and index into an empty slice.

Add the same out-of-bounds guard that the histogram branch already has, and a regression test that exercises Next()-only iteration over a summary with no quantiles.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Scrape: fix panic when scraping a target exposing a summary with no quantiles via the protobuf format.
```
