### PR TITLE
convertnhcb: reject NaN bucket upper bounds in SetBucketCount

### DIFF
--- a/util/convertnhcb/convertnhcb.go
+++ b/util/convertnhcb/convertnhcb.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	errNegativeBucketCount = errors.New("bucket count must be non-negative")
+	errNaNBucket           = errors.New("bucket boundary must not be NaN")
 	errNegativeCount       = errors.New("count must be non-negative")
 	errCountMismatch       = errors.New("count mismatch")
 	errCountNotCumulative  = errors.New("count is not cumulative")
@@ -69,6 +70,10 @@ func (h *TempHistogram) Reset() {
 
 func (h *TempHistogram) SetBucketCount(boundary, count float64) error {
 	if h.err != nil {
+		return h.err
+	}
+	if math.IsNaN(boundary) {
+		h.err = errNaNBucket
 		return h.err
 	}
 	if count < 0 {

--- a/util/convertnhcb/convertnhcb_test.go
+++ b/util/convertnhcb/convertnhcb_test.go
@@ -147,6 +147,19 @@ func TestNHCBConvert(t *testing.T) {
 			},
 			expectedErr: errNegativeCount,
 		},
+		"NaN bucket upper bound": {
+			setup: func() *TempHistogram {
+				h := NewTempHistogram()
+				// Add a real bucket first so that the NaN call reaches the
+				// default branch of the switch in SetBucketCount; without an
+				// existing bucket, len(h.buckets)==0 and the NaN is silently
+				// appended without triggering the panic.
+				h.SetBucketCount(1.0, 5)
+				h.SetBucketCount(math.NaN(), 10)
+				return &h
+			},
+			expectedErr: errNaNBucket,
+		},
 		"mixed order": {
 			setup: func() *TempHistogram {
 				h := NewTempHistogram()


### PR DESCRIPTION
A NaN upper bound causes all three switch cases in SetBucketCount to evaluate to false (NaN comparisons always return false), falling through to the default branch. There, sort.Search returns len(h.buckets) because the predicate h.buckets[i].le >= NaN is always false, and the subsequent h.buckets[i] access panics with an index out of range.

Fix by checking for NaN at the entry of SetBucketCount and storing an error, consistent with the existing handling of negative counts.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
