### PR TITLE
ci: add support for configuring stale action via repository variables

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,15 +17,15 @@ jobs:
           # opt out of defaults to avoid marking issues as stale and closing them
           # https://github.com/actions/stale#days-before-close
           # https://github.com/actions/stale#days-before-stale
-          days-before-stale: -1
-          days-before-close: -1
+          days-before-stale: ${{ vars.GHA_STALE_DAYS_BEFORE_STALE || -1 }}
+          days-before-close: ${{ vars.GHA_STALE_DAYS_BEFORE_CLOSE || -1 }}
           # Setting it to empty string to skip comments.
           # https://github.com/actions/stale#stale-pr-message
           # https://github.com/actions/stale#stale-issue-message
-          stale-pr-message: ''
-          stale-issue-message: ''
-          operations-per-run: 30
+          stale-pr-message: ${{ vars.GHA_STALE_PR_MESSAGE || '' }}
+          stale-issue-message: ${{ vars.GHA_STALE_ISSUE_MESSAGE || '' }}
+          operations-per-run: ${{ vars.GHA_STALE_OPERATIONS_PER_RUN || 30 }}
           # override days-before-stale, for only marking the pull requests as stale
-          days-before-pr-stale: 60
-          stale-pr-label: stale
-          exempt-pr-labels: keepalive
+          days-before-pr-stale: ${{ vars.GHA_STALE_DAYS_BEFORE_PR_STALE || 60 }}
+          stale-pr-label: ${{ vars.GHA_STALE_PR_LABEL || 'stale' }}
+          exempt-pr-labels: ${{ vars.GHA_EXEMPT_PR_LABELS || 'keepalive' }}


### PR DESCRIPTION

The stale GHA is mirrorred to other projects (e.g. alertmanager). This change allows us to configure the stale action via repository variables.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
