### PR TITLE
tsdb: allow nocopy iteration

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -96,7 +96,7 @@ type IndexReader interface {
 	// Series populates the given builder and chunk metas for the series identified
 	// by the reference.
 	// Returns storage.ErrNotFound if the ref does not resolve to a known series.
-	Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error
+	Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta, params ...index.SeriesParam) error
 
 	// LabelNames returns all the unique label names present in the index in sorted order.
 	LabelNames(ctx context.Context, matchers ...*labels.Matcher) ([]string, error)
@@ -549,8 +549,8 @@ func (r blockIndexReader) ShardedPostings(p index.Postings, shardIndex, shardCou
 	return r.ir.ShardedPostings(p, shardIndex, shardCount)
 }
 
-func (r blockIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
-	if err := r.ir.Series(ref, builder, chks); err != nil {
+func (r blockIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta, params ...index.SeriesParam) error {
+	if err := r.ir.Series(ref, builder, chks, params...); err != nil {
 		return fmt.Errorf("block: %s: %w", r.b.Meta().ULID, err)
 	}
 	return nil

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -848,7 +848,7 @@ func (DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compact
 
 		postings := postingsFunc(ctx, indexr)
 		// Blocks meta is half open: [min, max), so subtract 1 to ensure we don't hold samples with exact meta.MaxTime timestamp.
-		sets = append(sets, NewBlockChunkSeriesSet(b.Meta().ULID, indexr, chunkr, tombsr, postings, meta.MinTime, meta.MaxTime-1, false))
+		sets = append(sets, NewBlockChunkSeriesSet(b.Meta().ULID, indexr, chunkr, tombsr, postings, meta.MinTime, meta.MaxTime-1, false, false))
 		syms := indexr.Symbols()
 		if i == 0 {
 			symbols = syms

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -180,7 +180,7 @@ func (h *headIndexReader) ShardedPostings(p index.Postings, shardIndex, shardCou
 
 // Series returns the series for the given reference.
 // Chunks are skipped if chks is nil.
-func (h *headIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
+func (h *headIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta, _ ...index.SeriesParam) error {
 	s := h.head.series.getByID(chunks.HeadSeriesRef(ref))
 
 	if s == nil {

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -811,7 +811,7 @@ func (w *Writer) writePostingsToTmpFiles() error {
 			// Symbol numbers are in order, so the strings will also be in order.
 			slices.Sort(values)
 			for _, v := range values {
-				value, err := w.symbols.Lookup(v)
+				value, err := w.symbols.Lookup(v, false)
 				if err != nil {
 					return err
 				}
@@ -1190,7 +1190,7 @@ func NewSymbols(bs ByteSlice, version, off int) (*Symbols, error) {
 	return s, nil
 }
 
-func (s Symbols) Lookup(o uint32) (string, error) {
+func (s Symbols) Lookup(o uint32, noCopy bool) (string, error) {
 	d := encoding.Decbuf{
 		B: s.bs.Range(0, s.bs.Len()),
 	}
@@ -1206,6 +1206,14 @@ func (s Symbols) Lookup(o uint32) (string, error) {
 		for i := o - (o / symbolFactor * symbolFactor); i > 0; i-- {
 			d.UvarintBytes()
 		}
+	}
+
+	if noCopy {
+		sym := d.UvarintBytes()
+		if d.Err() != nil {
+			return "", d.Err()
+		}
+		return yoloString(sym), nil
 	}
 	sym := d.UvarintStr()
 	if d.Err() != nil {
@@ -1329,11 +1337,11 @@ func (r *Reader) Close() error {
 	return r.c.Close()
 }
 
-func (r *Reader) lookupSymbol(_ context.Context, o uint32) (string, error) {
+func (r *Reader) lookupSymbol(_ context.Context, o uint32, noCopy bool) (string, error) {
 	if s, ok := r.nameSymbols[o]; ok {
 		return s, nil
 	}
-	return r.symbols.Lookup(o)
+	return r.symbols.Lookup(o, noCopy)
 }
 
 // Symbols returns an iterator over the symbols that exist within the index.
@@ -1445,7 +1453,7 @@ func (r *Reader) LabelNamesFor(ctx context.Context, postings Postings) ([]string
 	// Lookup the unique symbols.
 	names := make([]string, 0, len(offsetsMap))
 	for off := range offsetsMap {
-		name, err := r.lookupSymbol(ctx, off)
+		name, err := r.lookupSymbol(ctx, off, false)
 		if err != nil {
 			return nil, fmt.Errorf("lookup symbol in LabelNamesFor: %w", err)
 		}
@@ -1457,8 +1465,24 @@ func (r *Reader) LabelNamesFor(ctx context.Context, postings Postings) ([]string
 	return names, nil
 }
 
+type seriesParams struct {
+	noCopy bool
+}
+
+type SeriesParam func(p *seriesParams) *seriesParams
+
+func SeriesNoCopy(p *seriesParams) *seriesParams {
+	p.noCopy = true
+	return p
+}
+
 // Series reads the series with the given ID and writes its labels and chunks into builder and chks.
-func (r *Reader) Series(id storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
+func (r *Reader) Series(id storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta, params ...SeriesParam) error {
+	p := &seriesParams{}
+	for _, pr := range params {
+		p = pr(p)
+	}
+
 	offset := id
 	// In version 2 series IDs are no longer exact references but series are 16-byte padded
 	// and the ID is the multiple of 16 of the actual position.
@@ -1471,7 +1495,7 @@ func (r *Reader) Series(id storage.SeriesRef, builder *labels.ScratchBuilder, ch
 	}
 	builder.SetSymbolTable(r.st)
 	builder.Reset()
-	err := r.dec.Series(d.Get(), builder, chks)
+	err := r.dec.Series(d.Get(), builder, chks, p.noCopy)
 	if err != nil {
 		return fmt.Errorf("read series: %w", err)
 	}
@@ -1757,7 +1781,7 @@ func (stringListIter) Err() error   { return nil }
 // It currently does not contain decoding methods for all entry types but can be extended
 // by them if there's demand.
 type Decoder struct {
-	LookupSymbol   func(context.Context, uint32) (string, error)
+	LookupSymbol   func(context.Context, uint32, bool) (string, error)
 	DecodePostings PostingsDecoder
 }
 
@@ -1796,7 +1820,7 @@ func (*Decoder) LabelNamesOffsetsFor(b []byte) ([]uint32, error) {
 // Series decodes a series entry from the given byte slice into builder and chks.
 // Previous contents of builder can be overwritten - make sure you copy before retaining.
 // Skips reading chunks metadata if chks is nil.
-func (dec *Decoder) Series(b []byte, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
+func (dec *Decoder) Series(b []byte, builder *labels.ScratchBuilder, chks *[]chunks.Meta, noCopy bool) error {
 	builder.Reset()
 	if chks != nil {
 		*chks = (*chks)[:0]
@@ -1814,11 +1838,11 @@ func (dec *Decoder) Series(b []byte, builder *labels.ScratchBuilder, chks *[]chu
 			return fmt.Errorf("read series label offsets: %w", d.Err())
 		}
 
-		ln, err := dec.LookupSymbol(context.TODO(), lno)
+		ln, err := dec.LookupSymbol(context.TODO(), lno, noCopy)
 		if err != nil {
 			return fmt.Errorf("lookup label name: %w", err)
 		}
-		lv, err := dec.LookupSymbol(context.TODO(), lvo)
+		lv, err := dec.LookupSymbol(context.TODO(), lvo, noCopy)
 		if err != nil {
 			return fmt.Errorf("lookup label value: %w", err)
 		}

--- a/tsdb/index/index_test.go
+++ b/tsdb/index/index_test.go
@@ -480,11 +480,11 @@ func TestSymbols(t *testing.T) {
 	require.Equal(t, 32, s.Size())
 
 	for i := 99; i >= 0; i-- {
-		s, err := s.Lookup(uint32(i))
+		s, err := s.Lookup(uint32(i), false)
 		require.NoError(t, err)
 		require.Equal(t, string(rune(i)), s)
 	}
-	_, err = s.Lookup(100)
+	_, err = s.Lookup(100, false)
 	require.Error(t, err)
 
 	for i := 99; i >= 0; i-- {

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -59,7 +59,7 @@ func NewHeadAndOOOIndexReader(head *Head, inoMint, mint, maxt int64, lastGarbage
 	return &HeadAndOOOIndexReader{hr, inoMint, lastGarbageCollectedMmapRef}
 }
 
-func (oh *HeadAndOOOIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
+func (oh *HeadAndOOOIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta, _ ...index.SeriesParam) error {
 	s := oh.head.series.getByID(chunks.HeadSeriesRef(ref))
 
 	if s == nil {
@@ -464,7 +464,7 @@ func (ir *OOOCompactionHeadIndexReader) ShardedPostings(p index.Postings, shardI
 	return hr.ShardedPostings(p, shardIndex, shardCount)
 }
 
-func (ir *OOOCompactionHeadIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
+func (ir *OOOCompactionHeadIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta, _ ...index.SeriesParam) error {
 	s := ir.ch.head.series.getByID(chunks.HeadSeriesRef(ref))
 
 	if s == nil {

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -186,7 +186,7 @@ func selectChunkSeriesSet(ctx context.Context, sortSeries bool, hints *storage.S
 	if sortSeries {
 		p = index.SortedPostings(p)
 	}
-	return NewBlockChunkSeriesSet(blockID, index, chunks, tombstones, p, mint, maxt, disableTrimming)
+	return NewBlockChunkSeriesSet(blockID, index, chunks, tombstones, p, mint, maxt, disableTrimming, false)
 }
 
 // PostingsForMatchers assembles a single postings iterator against the index reader
@@ -494,14 +494,15 @@ type blockBaseSeriesSet struct {
 
 	curr seriesData
 
-	bufChks []chunks.Meta
-	builder labels.ScratchBuilder
-	err     error
+	bufChks      []chunks.Meta
+	builder      labels.ScratchBuilder
+	err          error
+	seriesParams []index.SeriesParam
 }
 
 func (b *blockBaseSeriesSet) Next() bool {
 	for b.p.Next() {
-		if err := b.index.Series(b.p.At(), &b.builder, &b.bufChks); err != nil {
+		if err := b.index.Series(b.p.At(), &b.builder, &b.bufChks, b.seriesParams...); err != nil {
 			// Postings may be stale. Skip if no underlying series exists.
 			if errors.Is(err, storage.ErrNotFound) {
 				continue
@@ -1102,7 +1103,12 @@ type blockChunkSeriesSet struct {
 	blockBaseSeriesSet
 }
 
-func NewBlockChunkSeriesSet(id ulid.ULID, i IndexReader, c ChunkReader, t tombstones.Reader, p index.Postings, mint, maxt int64, disableTrimming bool) storage.ChunkSeriesSet {
+func NewBlockChunkSeriesSet(id ulid.ULID, i IndexReader, c ChunkReader, t tombstones.Reader, p index.Postings, mint, maxt int64, disableTrimming, noCopy bool) storage.ChunkSeriesSet {
+	seriesParams := make([]index.SeriesParam, 0, 1)
+	if noCopy {
+		seriesParams = append(seriesParams, index.SeriesNoCopy)
+	}
+
 	return &blockChunkSeriesSet{
 		blockBaseSeriesSet{
 			blockID:         id,
@@ -1113,6 +1119,7 @@ func NewBlockChunkSeriesSet(id ulid.ULID, i IndexReader, c ChunkReader, t tombst
 			mint:            mint,
 			maxt:            maxt,
 			disableTrimming: disableTrimming,
+			seriesParams:    seriesParams,
 		},
 	}
 }

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2578,7 +2578,7 @@ func (m mockIndex) ShardedPostings(p index.Postings, shardIndex, shardCount uint
 	return index.NewListPostings(out)
 }
 
-func (m mockIndex) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta) error {
+func (m mockIndex) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder, chks *[]chunks.Meta, _ ...index.SeriesParam) error {
 	s, ok := m.series[ref]
 	if !ok {
 		return storage.ErrNotFound
@@ -3532,7 +3532,7 @@ func (mockMatcherIndex) ShardedPostings(ps index.Postings, _, _ uint64) index.Po
 	return ps
 }
 
-func (mockMatcherIndex) Series(storage.SeriesRef, *labels.ScratchBuilder, *[]chunks.Meta) error {
+func (m mockMatcherIndex) Series(_ storage.SeriesRef, _ *labels.ScratchBuilder, _ *[]chunks.Meta, _ ...index.SeriesParam) error {
 	return nil
 }
 
@@ -3972,7 +3972,7 @@ func (mockReaderOfLabels) SortedPostings(index.Postings) index.Postings {
 	panic("SortedPostings called")
 }
 
-func (mockReaderOfLabels) Series(storage.SeriesRef, *labels.ScratchBuilder, *[]chunks.Meta) error {
+func (m mockReaderOfLabels) Series(storage.SeriesRef, *labels.ScratchBuilder, *[]chunks.Meta, ...index.SeriesParam) error {
 	panic("Series called")
 }
 


### PR DESCRIPTION
# Add `nocopy` label access

Add a a boolean "nocopy" parameter to `Series.Lookup(...)`. When `true`, the original series label string is returned without copying. The caller is responsible for following all appropriate rules about lifetimes with the `yoloString` result.

Adds variadic parameters to series calls, and a new `SeriesNoCopy` option to propagate the nocopy flag through Series calls.

Needed for Thanos Parquet Gateway to build without a forked Prometheus. This patch was extracted from https://github.com/thanos-io/thanos-prometheus/tree/nocopy_03060rc0 which is used by the parquet gateway in this replace directive https://github.com/thanos-io/thanos-parquet-gateway/blob/b5f6765855ca0f96bc5e023d9e633a676726d452/go.mod#L229 as seen with

```
thanos-prometheus $ git  --no-pager branch --contains a844cabec015
  nocopy_03060rc0
$ 
```

This patch was authored by @GiedriusS , I've just rebased it, fixed a whitespace linter complaint, and updated the commit message.

#### Which issue(s) does the PR fix:

N/A

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```

This is an internal API change, but prom doesn't seem to note those in the release notes.