### PR TITLE
cmd/prometheus: fix flaky TestQueryLog console test

### DIFF
--- a/cmd/prometheus/query_log_test.go
+++ b/cmd/prometheus/query_log_test.go
@@ -68,16 +68,16 @@ func (p *queryLogTest) skip(t *testing.T) {
 }
 
 // waitForPrometheus waits for Prometheus to be ready.
-func (p *queryLogTest) waitForPrometheus() error {
-	var err error
-	for range 20 {
-		var r *http.Response
-		if r, err = http.Get(fmt.Sprintf("http://%s:%d%s/-/ready", p.host, p.port, p.prefix)); err == nil && r.StatusCode == http.StatusOK {
-			break
+func (p *queryLogTest) waitForPrometheus(t *testing.T) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		r, err := http.Get(fmt.Sprintf("http://%s:%d%s/-/ready", p.host, p.port, p.prefix))
+		if err != nil {
+			return false
 		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	return err
+		r.Body.Close()
+		return r.StatusCode == http.StatusOK
+	}, 20*time.Second, 500*time.Millisecond, "prometheus at %s:%d did not become ready in time", p.host, p.port)
 }
 
 // setQueryLog alters the configuration file to enable or disable the query log,
@@ -250,7 +250,7 @@ func (p *queryLogTest) params() []string {
 		s = append(s, "--web.route-prefix="+p.prefix)
 	}
 	if p.origin == consoleOrigin {
-		s = append(s, "--web.console.templates="+filepath.Join("testdata", "consoles"))
+		s = append(s, "--web.console.templates="+filepath.Join(p.cwd, "testdata", "consoles"))
 	}
 	return s
 }
@@ -323,7 +323,7 @@ func (p *queryLogTest) run(t *testing.T) {
 		prom.Process.Kill()
 		prom.Wait()
 	}()
-	require.NoError(t, p.waitForPrometheus())
+	p.waitForPrometheus(t)
 
 	if !p.enabledAtStart {
 		p.query(t)


### PR DESCRIPTION
- Use an absolute path for the console templates directory to align with rules.
- Rewrite waitForPrometheus using require.Eventually for cleaner error reporting and to fix a bug where the function could return nil even when the server never became ready.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
