### PR TITLE
tsdb(perf): filter label values before appending

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -70,6 +70,9 @@ type IndexReader interface {
 	// LabelValues returns possible label values which may not be sorted.
 	LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error)
 
+	// LabelValuesFiltered returns values for which the filter function returns true.
+	LabelValuesFiltered(ctx context.Context, name string, hints *storage.LabelHints, filter func(string) bool) ([]string, error)
+
 	// Postings returns the postings list iterator for the label pairs.
 	// The Postings here contain the offsets to the series inside the index.
 	// Found IDs are not strictly required to point to a valid Series, e.g.
@@ -515,6 +518,11 @@ func (r blockIndexReader) LabelValues(ctx context.Context, name string, hints *s
 	}
 
 	return labelValuesWithMatchers(ctx, r.ir, name, hints, matchers...)
+}
+
+// LabelValuesFiltered returns values for which the filter function returns true.
+func (r blockIndexReader) LabelValuesFiltered(ctx context.Context, name string, hints *storage.LabelHints, filter func(string) bool) ([]string, error) {
+	return r.ir.LabelValuesFiltered(ctx, name, hints, filter)
 }
 
 func (r blockIndexReader) LabelNames(ctx context.Context, matchers ...*labels.Matcher) ([]string, error) {

--- a/tsdb/block_test.go
+++ b/tsdb/block_test.go
@@ -453,14 +453,28 @@ func BenchmarkLabelValuesWithMatchers(b *testing.B) {
 	require.NoError(b, err)
 	defer func() { require.NoError(b, indexReader.Close()) }()
 
-	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "c_ninety", "value0")}
+	cases := []struct {
+		label    string
+		matchers []*labels.Matcher
+		expected int
+	}{
+		{"a_unique", nil, 1000000},
+		{"a_unique", []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a_unique", ".*000")}, 999},
+		{"b_tens", []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "c_ninety", "value0")}, 9},
+		{"b_tens", []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "c_ninety", "value0")}, 1},
+		{"b_tens", []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "c_ninety", ".*0")}, 9},
+		{"a_unique", []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a_unique", ".*000"), labels.MustNewMatcher(labels.MatchRegexp, "b_tens", "value0")}, 99},
+		{"b_tens", []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a_unique", ".*000"), labels.MustNewMatcher(labels.MatchRegexp, "b_tens", "value0")}, 1},
+	}
 
-	b.ReportAllocs()
-
-	for b.Loop() {
-		actualValues, err := indexReader.LabelValues(ctx, "b_tens", nil, matchers...)
-		require.NoError(b, err)
-		require.Len(b, actualValues, 9)
+	for _, c := range cases {
+		b.Run(fmt.Sprintf("%s;%s", c.label, c.matchers), func(b *testing.B) {
+			for b.Loop() {
+				actualValues, err := indexReader.LabelValues(ctx, c.label, nil, c.matchers...)
+				require.NoError(b, err)
+				require.Len(b, actualValues, c.expected)
+			}
+		})
 	}
 }
 

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -96,6 +96,15 @@ func (h *headIndexReader) LabelValues(ctx context.Context, name string, hints *s
 	return labelValuesWithMatchers(ctx, h, name, hints, matchers...)
 }
 
+// LabelValuesFiltered returns values for which the filter function returns true.
+func (h *headIndexReader) LabelValuesFiltered(ctx context.Context, name string, hints *storage.LabelHints, filter func(string) bool) ([]string, error) {
+	if h.maxt < h.head.MinTime() || h.mint > h.head.MaxTime() {
+		return nil, nil
+	}
+
+	return h.head.postings.LabelValuesFiltered(ctx, name, hints, filter)
+}
+
 // LabelNames returns all the unique label names present in the head
 // that are within the time range mint to maxt.
 func (h *headIndexReader) LabelNames(ctx context.Context, matchers ...*labels.Matcher) ([]string, error) {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -3887,14 +3887,30 @@ func BenchmarkHeadLabelValuesWithMatchers(b *testing.B) {
 	require.NoError(b, app.Commit())
 
 	headIdxReader := head.indexRange(0, 200)
-	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "c_ninety", "value0")}
-
 	b.ReportAllocs()
 
-	for b.Loop() {
-		actualValues, err := headIdxReader.LabelValues(ctx, "b_tens", nil, matchers...)
-		require.NoError(b, err)
-		require.Len(b, actualValues, 9)
+	cases := []struct {
+		label    string
+		matchers []*labels.Matcher
+		expected int
+	}{
+		{"a_unique", nil, 1000000},
+		{"a_unique", []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a_unique", ".*000")}, 999},
+		{"b_tens", []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "c_ninety", "value0")}, 9},
+		{"b_tens", []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "c_ninety", "value0")}, 1},
+		{"b_tens", []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "c_ninety", ".*0")}, 9},
+		{"a_unique", []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a_unique", ".*000"), labels.MustNewMatcher(labels.MatchRegexp, "b_tens", "value0")}, 99},
+		{"b_tens", []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "a_unique", ".*000"), labels.MustNewMatcher(labels.MatchRegexp, "b_tens", "value0")}, 1},
+	}
+
+	for _, c := range cases {
+		b.Run(fmt.Sprintf("%s;%s", c.label, c.matchers), func(b *testing.B) {
+			for b.Loop() {
+				actualValues, err := headIdxReader.LabelValues(ctx, c.label, nil, c.matchers...)
+				require.NoError(b, err)
+				require.Len(b, actualValues, c.expected)
+			}
+		})
 	}
 }
 

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1365,7 +1365,12 @@ func (r *Reader) LabelValues(ctx context.Context, name string, hints *storage.La
 	if len(matchers) > 0 {
 		return nil, fmt.Errorf("matchers parameter is not implemented: %+v", matchers)
 	}
+	return r.LabelValuesFiltered(ctx, name, hints, nil)
+}
 
+// LabelValuesFiltered returns label values for which the filter function returns true.
+// Accepts filter==nil meaning all values, to avoid repeating all the code for LabelValues().
+func (r *Reader) LabelValuesFiltered(ctx context.Context, name string, hints *storage.LabelHints, filter func(string) bool) ([]string, error) {
 	if r.version == FormatV1 {
 		e, ok := r.postingsV1[name]
 		if !ok {
@@ -1373,10 +1378,12 @@ func (r *Reader) LabelValues(ctx context.Context, name string, hints *storage.La
 		}
 		values := make([]string, 0, len(e))
 		for k := range e {
-			if hints != nil && hints.Limit > 0 && len(values) >= hints.Limit {
-				break
+			if filter(k) {
+				if hints != nil && hints.Limit > 0 && len(values) >= hints.Limit {
+					break
+				}
+				values = append(values, k)
 			}
-			values = append(values, k)
 		}
 		return values, nil
 	}
@@ -1389,6 +1396,9 @@ func (r *Reader) LabelValues(ctx context.Context, name string, hints *storage.La
 	}
 
 	valuesLength := len(e) * symbolFactor
+	if filter != nil {
+		valuesLength = 0 // Don't know what proportion of values will match.
+	}
 	if hints != nil && hints.Limit > 0 && valuesLength > hints.Limit {
 		valuesLength = hints.Limit
 	}
@@ -1398,7 +1408,9 @@ func (r *Reader) LabelValues(ctx context.Context, name string, hints *storage.La
 		if hints != nil && hints.Limit > 0 && len(values) >= hints.Limit {
 			return false, nil
 		}
-		values = append(values, val)
+		if filter == nil || filter(val) {
+			values = append(values, val)
+		}
 		return val != lastVal, nil
 	})
 	return values, err

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -184,6 +184,29 @@ func (p *MemPostings) LabelValues(_ context.Context, name string, hints *storage
 	return slices.Clone(values)
 }
 
+// LabelValuesFiltered returns values for which the filter function returns true.
+func (p *MemPostings) LabelValuesFiltered(ctx context.Context, name string, hints *storage.LabelHints, filter func(string) bool) ([]string, error) {
+	p.mtx.RLock()
+	allValues := p.lvs[name]
+	p.mtx.RUnlock()
+
+	var values []string // Not preallocated because we don't know what proportion of values will match.
+	count := 1
+	for _, v := range allValues {
+		if count%checkContextEveryNIterations == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		count++
+		if filter(v) {
+			values = append(values, v)
+			if hints != nil && hints.Limit > 0 && len(values) > hints.Limit {
+				break
+			}
+		}
+	}
+	return values, nil
+}
+
 // PostingsStats contains cardinality based statistics for postings.
 type PostingsStats struct {
 	CardinalityMetricsStats []Stat

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1519,3 +1519,19 @@ func TestMemPostings_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	require.Error(t, p.Err())
 	require.Equal(t, failAfter+1, ctx.Count()) // Plus one for the Err() call that puts the error in the result.
 }
+
+func TestMemPostings_LabelValuesFilteredHonorsContextCancel(t *testing.T) {
+	memP := NewMemPostings()
+	seriesCount := 10 * checkContextEveryNIterations
+	for i := 1; i <= seriesCount; i++ {
+		memP.Add(storage.SeriesRef(i), labels.FromStrings("__name__", fmt.Sprintf("%4d", i)))
+	}
+
+	failAfter := uint64(seriesCount / 2 / checkContextEveryNIterations)
+	ctx := &testutil.MockContextErrAfter{FailAfter: failAfter}
+
+	_, err := memP.LabelValuesFiltered(ctx, "__name__", nil, func(string) bool { return true })
+
+	require.Error(t, err)
+	require.Equal(t, failAfter+1, ctx.Count()) // Plus one for the Err() call that puts the error in the result.
+}

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -193,6 +193,15 @@ func (oh *HeadAndOOOIndexReader) LabelValues(ctx context.Context, name string, h
 	return labelValuesWithMatchers(ctx, oh, name, hints, matchers...)
 }
 
+// LabelValuesFiltered returns values for which the filter function returns true.
+func (oh *HeadAndOOOIndexReader) LabelValuesFiltered(ctx context.Context, name string, hints *storage.LabelHints, filter func(string) bool) ([]string, error) {
+	if oh.maxt < oh.head.MinTime() && oh.maxt < oh.head.MinOOOTime() || oh.mint > oh.head.MaxTime() && oh.mint > oh.head.MaxOOOTime() {
+		return nil, nil
+	}
+
+	return oh.head.postings.LabelValuesFiltered(ctx, name, hints, filter)
+}
+
 func lessByMinTimeAndMinRef(a, b chunks.Meta) int {
 	switch {
 	case a.MinTime < b.MinTime:
@@ -534,6 +543,10 @@ func (*OOOCompactionHeadIndexReader) SortedLabelValues(_ context.Context, _ stri
 }
 
 func (*OOOCompactionHeadIndexReader) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*OOOCompactionHeadIndexReader) LabelValuesFiltered(context.Context, string, *storage.LabelHints, func(string) bool) ([]string, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -462,36 +462,36 @@ func inversePostingsForMatcher(ctx context.Context, ix IndexReader, m *labels.Ma
 }
 
 func labelValuesWithMatchers(ctx context.Context, r IndexReader, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
-	// Limit is applied at the end, after filtering.
-	allValues, err := r.LabelValues(ctx, name, nil)
-	if err != nil {
-		return nil, fmt.Errorf("fetching values of label %s: %w", name, err)
-	}
-
 	// If we have a matcher for the label name, we can filter out values that don't match
 	// before we fetch postings. This is especially useful for labels with many values.
 	// e.g. __name__ with a selector like {__name__="xyz"}
 	hasMatchersForOtherLabels := false
+	// Construct a single function which chains all matchers on the label name.
+	var filter func(_ string) bool
 	for _, m := range matchers {
 		if m.Name != name {
 			hasMatchersForOtherLabels = true
 			continue
 		}
-
-		// re-use the allValues slice to avoid allocations
-		// this is safe because the iteration is always ahead of the append
-		filteredValues := allValues[:0]
-		count := 1
-		for _, v := range allValues {
-			if count%checkContextEveryNIterations == 0 && ctx.Err() != nil {
-				return nil, ctx.Err()
-			}
-			count++
-			if m.Matches(v) {
-				filteredValues = append(filteredValues, v)
+		if filter == nil {
+			filter = m.Matches
+		} else {
+			prevFilter := filter
+			filter = func(s string) bool {
+				return prevFilter(s) && m.Matches(s)
 			}
 		}
-		allValues = filteredValues
+	}
+
+	var allValues []string
+	var err error
+	if filter == nil {
+		allValues, err = r.LabelValues(ctx, name, hints)
+	} else {
+		allValues, err = r.LabelValuesFiltered(ctx, name, hints, filter)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: fetching values of label %s", err, name)
 	}
 
 	if len(allValues) == 0 {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2534,6 +2534,25 @@ func (m mockIndex) LabelValues(_ context.Context, name string, hints *storage.La
 	return values, nil
 }
 
+func (m mockIndex) LabelValueFor(_ context.Context, id storage.SeriesRef, label string) (string, error) {
+	return m.series[id].l.Get(label), nil
+}
+
+func (m mockIndex) LabelValuesFiltered(_ context.Context, name string, hints *storage.LabelHints, filter func(string) bool) ([]string, error) {
+	var values []string
+
+	for l := range m.postings {
+		if l.Name == name && filter(l.Value) {
+			values = append(values, l.Value)
+			if hints != nil && hints.Limit > 0 && len(values) >= hints.Limit {
+				break
+			}
+		}
+	}
+
+	return values, nil
+}
+
 func (m mockIndex) LabelNamesFor(_ context.Context, postings index.Postings) ([]string, error) {
 	namesMap := make(map[string]bool)
 	for postings.Next() {
@@ -3555,6 +3574,10 @@ func (mockMatcherIndex) LabelNamesFor(context.Context, index.Postings) ([]string
 	return nil, errors.New("label names for called")
 }
 
+func (mockMatcherIndex) LabelValuesFiltered(context.Context, string, *storage.LabelHints, func(string) bool) ([]string, error) {
+	return []string{}, errors.New("label values filtered called")
+}
+
 func (mockMatcherIndex) Postings(context.Context, string, ...string) (index.Postings, error) {
 	return index.EmptyPostings(), nil
 }
@@ -4116,6 +4139,10 @@ func (mockReaderOfLabels) LabelNames(context.Context, ...*labels.Matcher) ([]str
 
 func (mockReaderOfLabels) LabelNamesFor(context.Context, index.Postings) ([]string, error) {
 	panic("LabelNamesFor called")
+}
+
+func (m mockReaderOfLabels) LabelValuesFiltered(_ context.Context, name string, hints *storage.LabelHints, filter func(string) bool) ([]string, error) {
+	return make([]string, mockReaderOfLabelsSeriesCount), nil
 }
 
 func (mockReaderOfLabels) PostingsForLabelMatching(context.Context, string, func(string) bool) index.Postings {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/util/annotations"
-	"github.com/prometheus/prometheus/util/testutil"
 )
 
 // TODO(bwplotka): Replace those mocks with remote.concreteSeriesSet.
@@ -4104,73 +4103,6 @@ func testChunkQuerierOverlappingInOrderAndOOOChunks(t *testing.T, valType chunke
 	require.Equal(t, 1, seriesCount)
 	require.Greater(t, chunkCount, 1)
 	require.Equal(t, lastIndex-firstIndex+1, sampleCount)
-}
-
-func TestReader_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
-	ir := mockReaderOfLabels{}
-
-	failAfter := uint64(mockReaderOfLabelsSeriesCount / 2 / checkContextEveryNIterations)
-	ctx := &testutil.MockContextErrAfter{FailAfter: failAfter}
-	_, err := labelValuesWithMatchers(ctx, ir, "__name__", nil, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".+"))
-
-	require.Error(t, err)
-	require.Equal(t, failAfter+1, ctx.Count()) // Plus one for the Err() call that puts the error in the result.
-}
-
-type mockReaderOfLabels struct{}
-
-const mockReaderOfLabelsSeriesCount = checkContextEveryNIterations * 10
-
-func (mockReaderOfLabels) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
-	return make([]string, mockReaderOfLabelsSeriesCount), nil
-}
-
-func (mockReaderOfLabels) SortedLabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, error) {
-	panic("SortedLabelValues called")
-}
-
-func (mockReaderOfLabels) Close() error {
-	return nil
-}
-
-func (mockReaderOfLabels) LabelNames(context.Context, ...*labels.Matcher) ([]string, error) {
-	panic("LabelNames called")
-}
-
-func (mockReaderOfLabels) LabelNamesFor(context.Context, index.Postings) ([]string, error) {
-	panic("LabelNamesFor called")
-}
-
-func (m mockReaderOfLabels) LabelValuesFiltered(_ context.Context, name string, hints *storage.LabelHints, filter func(string) bool) ([]string, error) {
-	return make([]string, mockReaderOfLabelsSeriesCount), nil
-}
-
-func (mockReaderOfLabels) PostingsForLabelMatching(context.Context, string, func(string) bool) index.Postings {
-	panic("PostingsForLabelMatching called")
-}
-
-func (mockReaderOfLabels) PostingsForAllLabelValues(context.Context, string) index.Postings {
-	panic("PostingsForAllLabelValues called")
-}
-
-func (mockReaderOfLabels) Postings(context.Context, string, ...string) (index.Postings, error) {
-	panic("Postings called")
-}
-
-func (mockReaderOfLabels) ShardedPostings(index.Postings, uint64, uint64) index.Postings {
-	panic("Postings called")
-}
-
-func (mockReaderOfLabels) SortedPostings(index.Postings) index.Postings {
-	panic("SortedPostings called")
-}
-
-func (mockReaderOfLabels) Series(storage.SeriesRef, *labels.ScratchBuilder, *[]chunks.Meta) error {
-	panic("Series called")
-}
-
-func (mockReaderOfLabels) Symbols() index.StringIter {
-	panic("Series called")
 }
 
 // TestMergeQuerierConcurrentSelectMatchers reproduces the data race bug from


### PR DESCRIPTION
Re-opening #12865, simpler than before now we have `lvs`.

This saves a lot of memory in cases where there are a lot of possible values but the matcher discards most of them.
I see this pattern for instance in filtering on pod names.

Extending the `IndexReader` interface is a drawback.
I suspect `SortedLabelValues` could be removed, since #7448 speaks about the same underlying issue.

I extended the benchmarks too.

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Core(TM) i7-14700K
                                                                             │    before     │                after                │
                                                                             │    sec/op     │    sec/op     vs base               │
LabelValuesWithMatchers/a_unique;[]-28                                          11.40m ±  1%   11.05m ±  3%   -3.09% (p=0.002 n=6)
LabelValuesWithMatchers/a_unique;[a_unique=~".*000"]-28                         17.81m ±  1%   17.08m ±  1%   -4.10% (p=0.002 n=6)
LabelValuesWithMatchers/b_tens;[c_ninety="value0"]-28                           542.7µ ±  1%   541.0µ ±  1%        ~ (p=0.132 n=6)
LabelValuesWithMatchers/b_tens;[c_ninety!="value0"]-28                          17.12m ±  3%   16.52m ±  2%   -3.50% (p=0.002 n=6)
LabelValuesWithMatchers/b_tens;[c_ninety=~".*0"]-28                             544.9µ ±  1%   536.7µ ±  1%   -1.51% (p=0.002 n=6)
LabelValuesWithMatchers/a_unique;[a_unique=~".*000"_b_tens=~"value0"]-28        35.72m ±  1%   34.44m ±  1%   -3.59% (p=0.002 n=6)
LabelValuesWithMatchers/b_tens;[a_unique=~".*000"_b_tens=~"value0"]-28          17.06m ±  0%   16.70m ±  0%   -2.05% (p=0.002 n=6)
HeadLabelValuesWithMatchers/a_unique;[]-28                                      2.823m ±  8%   2.958m ±  8%        ~ (p=0.132 n=6)
HeadLabelValuesWithMatchers/a_unique;[a_unique=~".*000"]-28                    10.904m ±  6%   8.113m ±  2%  -25.60% (p=0.002 n=6)
HeadLabelValuesWithMatchers/b_tens;[c_ninety="value0"]-28                       1.860µ ±  5%   1.839µ ± 12%        ~ (p=0.394 n=6)
HeadLabelValuesWithMatchers/b_tens;[c_ninety!="value0"]-28                      5.569m ±  0%   5.535m ±  0%   -0.59% (p=0.009 n=6)
HeadLabelValuesWithMatchers/b_tens;[c_ninety=~".*0"]-28                         1.978µ ± 10%   1.904µ ±  8%   -3.74% (p=0.041 n=6)
HeadLabelValuesWithMatchers/a_unique;[a_unique=~".*000"_b_tens=~"value0"]-28    20.30m ±  4%   17.26m ±  2%  -14.97% (p=0.002 n=6)
HeadLabelValuesWithMatchers/b_tens;[a_unique=~".*000"_b_tens=~"value0"]-28      9.418m ±  6%   9.608m ±  5%        ~ (p=0.240 n=6)
geomean                                                                         2.231m         2.132m         -4.41%

                                                                             │     before      │                 after                 │
                                                                             │      B/op       │     B/op      vs base                 │
LabelValuesWithMatchers/a_unique;[]-28                                            15.27Mi ± 0%   15.27Mi ± 0%        ~ (p=0.193 n=6)
LabelValuesWithMatchers/a_unique;[a_unique=~".*000"]-28                        15632.03Ki ± 0%   34.40Ki ± 0%  -99.78% (p=0.002 n=6)
LabelValuesWithMatchers/b_tens;[c_ninety="value0"]-28                             2.727Ki ± 0%   2.727Ki ± 0%        ~ (p=1.000 n=6) ¹
LabelValuesWithMatchers/b_tens;[c_ninety!="value0"]-28                            2.494Ki ± 0%   2.494Ki ± 0%        ~ (p=1.000 n=6)
LabelValuesWithMatchers/b_tens;[c_ninety=~".*0"]-28                               2.727Ki ± 0%   2.727Ki ± 0%        ~ (p=1.000 n=6) ¹
LabelValuesWithMatchers/a_unique;[a_unique=~".*000"_b_tens=~"value0"]-28        15876.1Ki ± 0%   278.4Ki ± 0%  -98.25% (p=0.002 n=6)
LabelValuesWithMatchers/b_tens;[a_unique=~".*000"_b_tens=~"value0"]-28            131.1Ki ± 0%   130.0Ki ± 0%   -0.83% (p=0.002 n=6)
HeadLabelValuesWithMatchers/a_unique;[]-28                                        15.27Mi ± 0%   15.27Mi ± 0%        ~ (p=1.000 n=6)
HeadLabelValuesWithMatchers/a_unique;[a_unique=~".*000"]-28                    15632.03Ki ± 0%   34.35Ki ± 0%  -99.78% (p=0.002 n=6)
HeadLabelValuesWithMatchers/b_tens;[c_ninety="value0"]-28                         1.672Ki ± 0%   1.672Ki ± 0%        ~ (p=1.000 n=6) ¹
HeadLabelValuesWithMatchers/b_tens;[c_ninety!="value0"]-28                        1.430Ki ± 0%   1.430Ki ± 0%        ~ (p=1.000 n=6)
HeadLabelValuesWithMatchers/b_tens;[c_ninety=~".*0"]-28                           1.672Ki ± 0%   1.672Ki ± 0%        ~ (p=1.000 n=6) ¹
HeadLabelValuesWithMatchers/a_unique;[a_unique=~".*000"_b_tens=~"value0"]-28      30.72Mi ± 0%   15.49Mi ± 0%  -49.58% (p=0.002 n=6)
HeadLabelValuesWithMatchers/b_tens;[a_unique=~".*000"_b_tens=~"value0"]-28        15.35Mi ± 0%   15.35Mi ± 0%   -0.00% (p=0.002 n=6)
geomean                                                                           253.6Ki        75.43Ki       -70.26%
¹ all samples are equal

                                                                             │   before    │                 after                 │
                                                                             │  allocs/op  │  allocs/op   vs base                  │
LabelValuesWithMatchers/a_unique;[]-28                                          2.000 ± 0%    2.000 ± 0%         ~ (p=1.000 n=6) ¹
LabelValuesWithMatchers/a_unique;[a_unique=~".*000"]-28                         2.000 ± 0%   13.000 ± 0%  +550.00% (p=0.002 n=6)
LabelValuesWithMatchers/b_tens;[c_ninety="value0"]-28                           45.00 ± 0%    45.00 ± 0%         ~ (p=1.000 n=6) ¹
LabelValuesWithMatchers/b_tens;[c_ninety!="value0"]-28                          46.00 ± 0%    46.00 ± 0%         ~ (p=1.000 n=6) ¹
LabelValuesWithMatchers/b_tens;[c_ninety=~".*0"]-28                             45.00 ± 0%    45.00 ± 0%         ~ (p=1.000 n=6) ¹
LabelValuesWithMatchers/a_unique;[a_unique=~".*000"_b_tens=~"value0"]-28       4.031k ± 0%   4.042k ± 0%    +0.27% (p=0.002 n=6)
LabelValuesWithMatchers/b_tens;[a_unique=~".*000"_b_tens=~"value0"]-28         1.029k ± 0%   1.030k ± 0%    +0.10% (p=0.002 n=6)
HeadLabelValuesWithMatchers/a_unique;[]-28                                      2.000 ± 0%    2.000 ± 0%         ~ (p=1.000 n=6) ¹
HeadLabelValuesWithMatchers/a_unique;[a_unique=~".*000"]-28                     2.000 ± 0%   11.000 ± 0%  +450.00% (p=0.002 n=6)
HeadLabelValuesWithMatchers/b_tens;[c_ninety="value0"]-28                       45.00 ± 0%    45.00 ± 0%         ~ (p=1.000 n=6) ¹
HeadLabelValuesWithMatchers/b_tens;[c_ninety!="value0"]-28                      46.00 ± 0%    46.00 ± 0%         ~ (p=1.000 n=6) ¹
HeadLabelValuesWithMatchers/b_tens;[c_ninety=~".*0"]-28                         45.00 ± 0%    45.00 ± 0%         ~ (p=1.000 n=6) ¹
HeadLabelValuesWithMatchers/a_unique;[a_unique=~".*000"_b_tens=~"value0"]-28   3.024k ± 0%   3.033k ± 0%    +0.30% (p=0.002 n=6)
HeadLabelValuesWithMatchers/b_tens;[a_unique=~".*000"_b_tens=~"value0"]-28      22.00 ± 0%    23.00 ± 0%    +4.55% (p=0.002 n=6)
geomean                                                                         41.03         53.17        +29.58%
¹ all samples are equal
```

#### Release notes for end users (**ALL** commits must be considered).
```release-notes
[PERF] TSDB: Speed up label-values calls with matcher(s) on the label requested.
```
