### PR TITLE
textparse: fix NaN canonicalization check in OpenMetrics getFloatValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [BUGFIX] Remote write: Fix `prometheus_remote_storage_sent_batch_duration_seconds` measuring before the request was sent. #18214
 - [BUGFIX] Rules: Fix alert state restoration when rule labels contain Go template expressions. #18375
 - [BUGFIX] Scrape: Fix panic when parsing bare label names without an equal sign in brace-only metric notation. #18229
+- [BUGFIX] Textparse: Canonicalize NaN in OpenMetrics metric sample values when parsing the value token. #18399
 - [BUGFIX] TSDB: Fail early when `use-uncached-io` feature flag is set on unsupported environments. #18219
 - [BUGFIX] TSDB: Fall back to CLI flag values when retention is removed from config file. #18200
 - [BUGFIX] TSDB: Fix memory leaks in buffer pools by clearing reference fields before returning buffers to pools. #17895

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@
 - [BUGFIX] Remote write: Fix `prometheus_remote_storage_sent_batch_duration_seconds` measuring before the request was sent. #18214
 - [BUGFIX] Rules: Fix alert state restoration when rule labels contain Go template expressions. #18375
 - [BUGFIX] Scrape: Fix panic when parsing bare label names without an equal sign in brace-only metric notation. #18229
-- [BUGFIX] Textparse: Canonicalize NaN in OpenMetrics metric sample values when parsing the value token. #18399
 - [BUGFIX] TSDB: Fail early when `use-uncached-io` feature flag is set on unsupported environments. #18219
 - [BUGFIX] TSDB: Fall back to CLI flag values when retention is removed from config file. #18200
 - [BUGFIX] TSDB: Fix memory leaks in buffer pools by clearing reference fields before returning buffers to pools. #17895

--- a/model/textparse/interface_test.go
+++ b/model/textparse/interface_test.go
@@ -222,6 +222,7 @@ func requireEntries(t *testing.T, exp, got []parsedEntry) {
 			_, yIsLabels := y.(labels.Labels)
 			return !xIsLabels && !yIsLabels
 		}, cmpopts.EquateEmpty()),
+		cmpopts.EquateNaNs(),
 		cmp.AllowUnexported(parsedEntry{}),
 	})
 }

--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -763,7 +763,7 @@ func (p *OpenMetricsParser) getFloatValue(t token, after string) (float64, error
 		return 0, fmt.Errorf("%w while parsing: %q", err, p.l.b[p.start:p.l.i])
 	}
 	// Ensure canonical NaN value.
-	if math.IsNaN(p.exemplarVal) {
+	if math.IsNaN(val) {
 		val = math.Float64frombits(value.NormalNaN)
 	}
 	return val, nil

--- a/model/textparse/openmetricsparse_test.go
+++ b/model/textparse/openmetricsparse_test.go
@@ -16,6 +16,7 @@ package textparse
 import (
 	"fmt"
 	"io"
+	"math"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 )
 
 func int64p(x int64) *int64 { return &x }
@@ -113,7 +115,13 @@ foobar_count 21
 foobar_created 1520430004
 foobar_sum 324789.6
 foobar{quantile="0.95"} 123.8
-foobar{quantile="0.99"} 150.1`
+foobar{quantile="0.99"} 150.1
+# HELP nansum Summary with NaN value
+# TYPE nansum summary
+nansum_count 0
+nansum_sum 0.0
+nansum{quantile="0.95"} nan
+nansum{quantile="0.99"} NaN`
 
 	input += "\n# HELP metric foo\x00bar"
 	input += "\nnull_byte_metric{a=\"abc\x00\"} 1"
@@ -631,6 +639,42 @@ foobar{quantile="0.99"} 150.1`
 						labels.FromStrings("__name__", "foobar", "quantile", "0.99"),
 					),
 					st: 1520430004000,
+				}, {
+					m:    "nansum",
+					help: "Summary with NaN value",
+				}, {
+					m:   "nansum",
+					typ: model.MetricTypeSummary,
+				}, {
+					m: "nansum_count",
+					lset: typeAndUnitLabels(
+						typeAndUnitEnabled,
+						labels.FromStrings("__name__", "nansum_count", "__type__", string(model.MetricTypeSummary)),
+						labels.FromStrings("__name__", "nansum_count"),
+					),
+				}, {
+					m: "nansum_sum",
+					lset: typeAndUnitLabels(
+						typeAndUnitEnabled,
+						labels.FromStrings("__name__", "nansum_sum", "__type__", string(model.MetricTypeSummary)),
+						labels.FromStrings("__name__", "nansum_sum"),
+					),
+				}, {
+					m: `nansum{quantile="0.95"}`,
+					v: math.Float64frombits(value.NormalNaN),
+					lset: typeAndUnitLabels(
+						typeAndUnitEnabled,
+						labels.FromStrings("__name__", "nansum", "__type__", string(model.MetricTypeSummary), "quantile", "0.95"),
+						labels.FromStrings("__name__", "nansum", "quantile", "0.95"),
+					),
+				}, {
+					m: `nansum{quantile="0.99"}`,
+					v: math.Float64frombits(value.NormalNaN),
+					lset: typeAndUnitLabels(
+						typeAndUnitEnabled,
+						labels.FromStrings("__name__", "nansum", "__type__", string(model.MetricTypeSummary), "quantile", "0.99"),
+						labels.FromStrings("__name__", "nansum", "quantile", "0.99"),
+					),
 				}, {
 					m:    "metric",
 					help: "foo\x00bar",


### PR DESCRIPTION
getFloatValue was testing `p.exemplarVal` instead of the parsed float when normalizing NaN to the canonical representation, so OpenMetrics metric sample values that were NaN were not normalized correctly.

```release-notes
NONE
```