### PR TITLE
tsdb: fix pendingCommit condition for V1 histogram append

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -843,7 +843,7 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 		// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 		// to skip that sample from the WAL and write only in the WBL.
 		_, delta, err := s.appendableHistogram(t, h, a.headMaxt, a.minValidTime, a.oooTimeWindow)
-		if err != nil {
+		if err == nil {
 			s.pendingCommit = true
 		}
 		s.Unlock()


### PR DESCRIPTION
`AppendHistogram` set `pendingCommit` when `appendableHistogram` returned an error, while the float histogram branch sets it only on success (`err == nil`). This change aligns the integer histogram path with the float histogram path for consistency.

Per review: the mistaken branch is effectively unreachable in normal operation (the error path returns before effects that would make `pendingCommit` observable), so this is an internal consistency fix rather than a user-visible bugfix.

```release-notes
NONE
```