### PR TITLE
util/gate: add wait duration histogram metric

### DIFF
--- a/storage/remote/read_handler.go
+++ b/storage/remote/read_handler.go
@@ -47,11 +47,15 @@ type readHandler struct {
 // writes them to the provided queryable.
 func NewReadHandler(logger *slog.Logger, r prometheus.Registerer, queryable storage.SampleAndChunkQueryable, config func() config.Config, remoteReadSampleLimit, remoteReadConcurrencyLimit, remoteReadMaxBytesInFrame int) http.Handler {
 	h := &readHandler{
-		logger:                    logger,
-		queryable:                 queryable,
-		config:                    config,
-		remoteReadSampleLimit:     remoteReadSampleLimit,
-		remoteReadGate:            gate.New(remoteReadConcurrencyLimit),
+		logger:                logger,
+		queryable:             queryable,
+		config:                config,
+		remoteReadSampleLimit: remoteReadSampleLimit,
+		remoteReadGate: gate.New(
+			remoteReadConcurrencyLimit,
+			r,
+			"prometheus_remote_read_handler",
+		),
 		remoteReadMaxBytesInFrame: remoteReadMaxBytesInFrame,
 		marshalPool:               &sync.Pool{},
 

--- a/util/gate/gate.go
+++ b/util/gate/gate.go
@@ -13,27 +13,49 @@
 
 package gate
 
-import "context"
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // A Gate controls the maximum number of concurrently running and waiting queries.
 type Gate struct {
-	ch chan struct{}
+	ch        chan struct{}
+	histogram prometheus.Histogram
 }
 
-// New returns a query gate that limits the number of queries
-// being concurrently executed.
-func New(length int) *Gate {
+// New returns a gate that limits the number of concurrent operations.
+// If registerer is not nil, a histogram metric tracking wait duration will be registered.
+// The metric name will be "{metricPrefix}_gate_wait_duration_seconds".
+func New(length int, registerer prometheus.Registerer, metricPrefix string) *Gate {
+	histogram := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: metricPrefix + "_gate_wait_duration_seconds",
+		Help: "Time spent waiting for the gate in seconds.",
+	})
+
+	if registerer != nil {
+		registerer.MustRegister(histogram)
+	}
+
 	return &Gate{
-		ch: make(chan struct{}, length),
+		ch:        make(chan struct{}, length),
+		histogram: histogram,
 	}
 }
 
 // Start blocks until the gate has a free spot or the context is done.
+// It records the duration spent waiting in the histogram metric.
 func (g *Gate) Start(ctx context.Context) error {
+	startTime := time.Now()
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case g.ch <- struct{}{}:
+		// Successfully acquired the gate, record the wait time
+		g.histogram.Observe(time.Since(startTime).Seconds())
 		return nil
 	}
 }

--- a/util/gate/gate_test.go
+++ b/util/gate/gate_test.go
@@ -1,0 +1,75 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGateWaitDurationMetricObserved(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	gate := New(1, registry, "test")
+
+	ctx := context.Background()
+	err := gate.Start(ctx)
+	require.NoError(t, err)
+	gate.Done()
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	require.Len(t, families, 1)
+
+	metric := families[0]
+	require.Equal(t, "test_gate_wait_duration_seconds", *metric.Name)
+	require.Len(t, metric.Metric, 1)
+
+	histogram := metric.Metric[0].Histogram
+	require.NotNil(t, histogram)
+	require.Greater(t, *histogram.SampleCount, uint64(0))
+}
+
+func TestGateWithNilRegisterer(t *testing.T) {
+	gate := New(1, nil, "test")
+
+	ctx := context.Background()
+	err := gate.Start(ctx)
+	require.NoError(t, err)
+	gate.Done()
+}
+
+func TestGateCancellationNoMetricRecorded(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	gate := New(1, registry, "test")
+
+	ctx := context.Background()
+	err := gate.Start(ctx)
+	require.NoError(t, err)
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = gate.Start(cancelledCtx)
+	require.Error(t, err)
+
+	gate.Done()
+
+	families, _ := registry.Gather()
+	require.Len(t, families, 1)
+	histogram := families[0].Metric[0].Histogram
+	require.Equal(t, uint64(1), *histogram.SampleCount)
+}


### PR DESCRIPTION
## What this PR does

Adds prometheus.Histogram to Gate to track how long operations wait for a gate slot. This allows operators to identify whether the gate is becoming a bottleneck.

### Design

- Gate accepts prometheus.Registerer for flexible metric registration
- Caller provides metric name prefix (e.g., prometheus_remote_read_handler)
- Histogram observed after successful gate acquisition
- Optional registration: if registerer is nil, no metric recorded

### Implementation

- Gate.New() now accepts (length, registerer, metricPrefix) parameters
- Metric name: "{metricPrefix}_gate_wait_duration_seconds"
- Time measured from Start() call to gate slot acquisition
- Follows prometheus pattern used in util/notifications

### Testing

- Tests verify metric observation for normal operation
- Tests verify nil registerer (optional registration) works correctly
- Tests verify cancelled contexts don't record metrics
- All tests pass: 3/3 ✅

---

## Which issue(s) does the PR fix:

Fixes #11365

---

## Release notes for end users

[ENHANCEMENT] util/gate: Add `gate_wait_duration_seconds` histogram metric to track how long requests wait for gate availability. Callers control metric naming via the Registerer pattern, enabling both `prometheus_remote_read_handler_gate_wait_duration_seconds` and component-specific variants.