### PR TITLE
storage/remote: add OTLP request body read limit

### DIFF
--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -1000,7 +1000,7 @@ func DecodeOTLPWriteRequest(r *http.Request) (pmetricotlp.ExportRequest, error) 
 		return pmetricotlp.NewExportRequest(), fmt.Errorf("unsupported compression: %s. Only \"gzip\" or no compression supported", r.Header.Get("Content-Encoding"))
 	}
 
-	body, err := io.ReadAll(reader)
+	body, err := io.ReadAll(io.LimitReader(reader, decodeReadLimit))
 	if err != nil {
 		r.Body.Close()
 		return pmetricotlp.NewExportRequest(), err

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -15,9 +15,12 @@ package remote
 
 import (
 	"bytes"
+	"compress/gzip"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -25,6 +28,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -727,6 +732,37 @@ func TestMergeLabels(t *testing.T) {
 	} {
 		require.Equal(t, tc.expected, MergeLabels(tc.primary, tc.secondary))
 	}
+}
+
+func TestDecodeOTLPWriteRequestGzipSizeLimit(t *testing.T) {
+	// Build a valid OTLP request whose serialized protobuf exceeds decodeReadLimit.
+	// A metric description filled with repeated characters compresses very
+	// efficiently, so the gzip payload is small while the decompressed form is
+	// larger than the 32 MiB limit.
+	d := pmetric.NewMetrics()
+	m := d.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("test_metric")
+	m.SetDescription(strings.Repeat("a", decodeReadLimit+1))
+	m.SetEmptyGauge()
+
+	proto, err := pmetricotlp.NewExportRequestFromMetrics(d).MarshalProto()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err = gz.Write(proto)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	req, err := http.NewRequest(http.MethodPost, "/", &buf)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", pbContentType)
+	req.Header.Set("Content-Encoding", "gzip")
+
+	// The decompressed payload exceeds decodeReadLimit and is truncated, so the
+	// protobuf cannot be parsed into a valid ExportRequest.
+	_, err = DecodeOTLPWriteRequest(req)
+	require.Error(t, err)
 }
 
 func TestDecodeWriteRequest(t *testing.T) {


### PR DESCRIPTION
Apply the same io.LimitReader guard (decodeReadLimit = 32 MiB) to the OTLP write decoder that remote write and remote read already use, so that a gzip-encoded request body cannot decompress to unbounded memory.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] OTLP: limit decompressed body size for gzip-encoded OTLP write requests.
```
