### PR TITLE
histogram: fix panic in compactBuckets when all spans have zero length

### DIFF
--- a/model/histogram/generic.go
+++ b/model/histogram/generic.go
@@ -332,6 +332,10 @@ func compactBuckets[IBC InternalBucketCount](
 	spans = spans[:iSpan]
 	iSpan = 0
 
+	if len(spans) == 0 {
+		return primaryBuckets[:0], compensationBuckets[:0], spans
+	}
+
 	// Cut out empty buckets from start and end of spans, no matter
 	// what. Also cut out empty buckets from the middle of a span but only
 	// if there are more than maxEmptyBuckets consecutive empty buckets.

--- a/model/histogram/histogram_test.go
+++ b/model/histogram/histogram_test.go
@@ -1339,6 +1339,22 @@ func TestHistogramCompact(t *testing.T) {
 			},
 		},
 		{
+			"all zero-length spans with non-empty buckets",
+			&Histogram{
+				PositiveSpans:   []Span{{0, 0}, {2, 0}},
+				PositiveBuckets: []int64{1, 3},
+				NegativeSpans:   []Span{{1, 0}},
+				NegativeBuckets: []int64{2},
+			},
+			0,
+			&Histogram{
+				PositiveSpans:   []Span{},
+				PositiveBuckets: []int64{},
+				NegativeSpans:   []Span{},
+				NegativeBuckets: []int64{},
+			},
+		},
+		{
 			"eliminate multiple zero length spans with custom buckets",
 			&Histogram{
 				Schema:          CustomBucketsSchema,


### PR DESCRIPTION
When all spans have zero length, the zero-length span removal loop produces an empty spans slice. The subsequent loop over primaryBuckets then calls emptyBucketsHere(), which accesses spans[iSpan] and panics with an index out of range.

Fix by returning early when spans is empty after the zero-length span removal pass.

```    === RUN   TestHistogramCompact
    === RUN   TestHistogramCompact/all_zero-length_spans_with_non-empty_buckets
    --- FAIL: TestHistogramCompact (0.00s)
        --- FAIL: TestHistogramCompact/all_zero-length_spans_with_non-empty_buckets (0.00s)
    panic: runtime error: index out of range [0] with length 0 [recovered, repanicked]

    goroutine 9 [running]:
    testing.tRunner.func1.2({0x8d3c00, 0x3ad7e4be8b28})
            /nix/store/.../go-1.26.1/share/go/src/testing/testing.go:1974 +0x232
    testing.tRunner.func1()
            /nix/store/.../go-1.26.1/share/go/src/testing/testing.go:1977 +0x349
    panic({0x8d3c00?, 0x3ad7e4be8b28?})
            /nix/store/.../go-1.26.1/share/go/src/runtime/panic.go:860 +0x13a
    github.com/prometheus/prometheus/model/histogram.compactBuckets[...].func1(...)
            model/histogram/generic.go:290
    github.com/prometheus/prometheus/model/histogram.compactBuckets[...]
            model/histogram/generic.go:344 +0x11fe
    github.com/prometheus/prometheus/model/histogram.(*Histogram).Compact(...)
            model/histogram/histogram.go:352 +0x65
    FAIL    github.com/prometheus/prometheus/model/histogram        0.008s

```

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Scrape: Fix panic when all spans from a native histogram have zero length.
```
