### PR TITLE
histogram, textparse: fix two panics in compactBuckets for malformed input

### DIFF
--- a/model/histogram/generic.go
+++ b/model/histogram/generic.go
@@ -332,10 +332,18 @@ func compactBuckets[IBC InternalBucketCount](
 	spans = spans[:iSpan]
 	iSpan = 0
 
+	// If all spans were zero-length, no buckets remain valid.
+	if len(spans) == 0 {
+		if compensationBuckets != nil {
+			compensationBuckets = compensationBuckets[:0]
+		}
+		return primaryBuckets[:0], compensationBuckets, spans
+	}
+
 	// Cut out empty buckets from start and end of spans, no matter
 	// what. Also cut out empty buckets from the middle of a span but only
 	// if there are more than maxEmptyBuckets consecutive empty buckets.
-	for iBucket < len(primaryBuckets) {
+	for iBucket < len(primaryBuckets) && iSpan < len(spans) {
 		if deltaBuckets {
 			currentBucketAbsolute += primaryBuckets[iBucket]
 		} else {

--- a/model/histogram/histogram_test.go
+++ b/model/histogram/histogram_test.go
@@ -1339,6 +1339,41 @@ func TestHistogramCompact(t *testing.T) {
 			},
 		},
 		{
+			"all zero-length spans with non-empty buckets",
+			&Histogram{
+				PositiveSpans:   []Span{{0, 0}, {2, 0}},
+				PositiveBuckets: []int64{1, 3},
+				NegativeSpans:   []Span{{1, 0}},
+				NegativeBuckets: []int64{2},
+			},
+			0,
+			&Histogram{
+				PositiveSpans:   []Span{},
+				PositiveBuckets: []int64{},
+				NegativeSpans:   []Span{},
+				NegativeBuckets: []int64{},
+			},
+		},
+		{
+			// The loop guard prevents a panic; extra buckets beyond span
+			// coverage are preserved in the output. Callers must validate
+			// span/bucket consistency before invoking Compact.
+			"more buckets than spans account for",
+			&Histogram{
+				PositiveSpans:   []Span{{0, 1}, {2, 1}},
+				PositiveBuckets: []int64{1, 2, 3, 4},
+				NegativeSpans:   []Span{{0, 1}},
+				NegativeBuckets: []int64{5, 6},
+			},
+			0,
+			&Histogram{
+				PositiveSpans:   []Span{{0, 1}, {2, 1}},
+				PositiveBuckets: []int64{1, 2, 3, 4},
+				NegativeSpans:   []Span{{0, 1}},
+				NegativeBuckets: []int64{5, 6},
+			},
+		},
+		{
 			"eliminate multiple zero length spans with custom buckets",
 			&Histogram{
 				Schema:          CustomBucketsSchema,

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -484,6 +484,9 @@ func (p *ProtobufParser) Next() (Entry, error) {
 				p.fieldPos = -3 // We have not returned anything, let p.Next() increment it to -2.
 				return p.Next()
 			}
+			if err := checkNativeHistogramConsistency(p.dec.GetHistogram()); err != nil {
+				return EntryInvalid, fmt.Errorf("histogram %q: %w", p.dec.GetName(), err)
+			}
 			p.state = EntryHistogram
 		} else {
 			p.state = EntrySeries
@@ -527,6 +530,9 @@ func (p *ProtobufParser) Next() (Entry, error) {
 			// it means we might need to do NHCB conversion.
 			if t == dto.MetricType_HISTOGRAM || t == dto.MetricType_GAUGE_HISTOGRAM {
 				if !isClassicHistogram {
+					if err := checkNativeHistogramConsistency(p.dec.GetHistogram()); err != nil {
+						return EntryInvalid, fmt.Errorf("histogram %q: %w", p.dec.GetName(), err)
+					}
 					p.state = EntryHistogram
 				} else if p.convertClassicHistogramsToNHCB {
 					// We still need to spit out the NHCB.
@@ -747,4 +753,37 @@ func (p *ProtobufParser) convertToNHCB(t dto.MetricType) (*histogram.Histogram, 
 		}
 	}
 	return ch, cfh, nil
+}
+
+// checkNativeHistogramConsistency returns an error if the span bucket counts
+// do not match the number of bucket values in a native histogram protobuf
+// message. It catches malformed input before it reaches compactBuckets, where
+// a mismatch would cause a panic.
+func checkNativeHistogramConsistency(h *dto.Histogram) error {
+	isFloat := h.GetSampleCountFloat() > 0 || h.GetZeroCountFloat() > 0
+	var positiveBuckets, negativeBuckets int
+	if isFloat {
+		positiveBuckets = len(h.GetPositiveCount())
+		negativeBuckets = len(h.GetNegativeCount())
+	} else {
+		positiveBuckets = len(h.GetPositiveDelta())
+		negativeBuckets = len(h.GetNegativeDelta())
+	}
+	if err := checkProtoSpanBucketConsistency("positive", h.GetPositiveSpan(), positiveBuckets); err != nil {
+		return err
+	}
+	return checkProtoSpanBucketConsistency("negative", h.GetNegativeSpan(), negativeBuckets)
+}
+
+// checkProtoSpanBucketConsistency returns an error when the total length
+// described by spans does not match numBuckets.
+func checkProtoSpanBucketConsistency(side string, spans []dto.BucketSpan, numBuckets int) error {
+	var total int
+	for _, s := range spans {
+		total += int(s.GetLength())
+	}
+	if total != numBuckets {
+		return fmt.Errorf("%s side: spans require %d buckets, have %d", side, total, numBuckets)
+	}
+	return nil
 }

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -5937,6 +5937,85 @@ metric: <
 	})
 }
 
+func TestProtobufParseHistogramSpanBucketMismatch(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "all zero-length positive spans with non-empty positive deltas",
+			input: `name: "test_histogram"
+help: "Test."
+type: HISTOGRAM
+metric: <
+  histogram: <
+    sample_count: 2
+    sample_sum: 1.0
+    schema: 1
+    zero_threshold: 0
+    zero_count: 0
+    positive_span: <
+      offset: 0
+      length: 0
+    >
+    positive_span: <
+      offset: 2
+      length: 0
+    >
+    positive_delta: 1
+    positive_delta: 3
+  >
+>
+`,
+		},
+		{
+			name: "more positive deltas than positive spans account for",
+			input: `name: "test_histogram"
+help: "Test."
+type: HISTOGRAM
+metric: <
+  histogram: <
+    sample_count: 10
+    sample_sum: 1.0
+    schema: 1
+    zero_threshold: 0
+    zero_count: 0
+    positive_span: <
+      offset: 0
+      length: 1
+    >
+    positive_span: <
+      offset: 2
+      length: 1
+    >
+    positive_delta: 1
+    positive_delta: 2
+    positive_delta: 3
+    positive_delta: 4
+  >
+>
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := metricFamiliesToProtobuf(t, []string{tc.input})
+			p := NewProtobufParser(buf.Bytes(), false, false, false, false, labels.NewSymbolTable())
+			var gotErr error
+			for {
+				_, err := p.Next()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					gotErr = err
+					break
+				}
+			}
+			require.ErrorContains(t, gotErr, "positive side")
+		})
+	}
+}
+
 func generateString(r *rand.Rand, firstRunes, restRunes []rune) string {
 	result := make([]rune, 1+r.Intn(20))
 	for i := range result {


### PR DESCRIPTION
Two cases in compactBuckets caused a panic when fed malformed histogram data (e.g. via a crafted protobuf message):

1. All spans have zero length: after the zero-length span removal pass, spans becomes empty. The subsequent loop called emptyBucketsHere(), which accessed spans[0] and panicked with index out of range. Fixed by the early return added in the previous commit (already on this branch via the roidelapluie/histogram-compact-zero-spans fix).

2. More buckets than spans describe: iSpan can reach len(spans) before all buckets are consumed, causing emptyBucketsHere() to access spans[iSpan] out of bounds. Fixed by adding iSpan < len(spans) to the loop guard.

Both fixes in compactBuckets are defensive layers. The primary fix is in the protobuf parser: checkNativeHistogramConsistency now validates that span total length matches bucket count before calling Compact(), returning a proper error for malformed input instead of panicking.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Scrape: Fix panic when scraping malformed native histograms.
```
