### PR TITLE
rules: add goroutine dump and increase timeout in template test

### DIFF
--- a/rules/alerting_test.go
+++ b/rules/alerting_test.go
@@ -16,6 +16,7 @@ package rules
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -538,8 +539,11 @@ instance: {{ $v.Labels.instance }}, value: {{ printf "%.0f" $v.Value }};
 			close(startQueryCh)
 			select {
 			case <-getDoneCh:
-			case <-time.After(time.Millisecond * 10):
+			case <-time.After(20 * time.Millisecond):
 				// Assert no blocking when template expanding.
+				buf := make([]byte, 1<<20)
+				n := runtime.Stack(buf, true)
+				t.Logf("goroutine dump:\n%s", buf[:n])
 				require.Fail(t, "unexpected blocking when template expanding.")
 			}
 		}


### PR DESCRIPTION
Increase the blocking detection timeout from 10ms to 20ms to reduce flakiness, and add a goroutine dump on timeout to aid debugging.

Flaky in https://github.com/prometheus/prometheus/actions/runs/23805345266/job/69377075148?pr=18414
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
