### PR TITLE
util/fuzzing: fix changed field name CreatedTimestamp in protobuf corpus

### DIFF
--- a/util/fuzzing/corpus_protobuf.go
+++ b/util/fuzzing/corpus_protobuf.go
@@ -316,7 +316,7 @@ func getRawProtobufCorpus() ([][]byte, error) {
 		return nil, err
 	}
 
-	// Counter: with created_timestamp.
+	// Counter: with start_timestamp.
 	if result, err = appendSerializedProtobufSeed(result, dto.MetricFamily{
 		Name: "process_cpu_seconds_total",
 		Help: "Total user and system CPU time spent.",
@@ -324,8 +324,8 @@ func getRawProtobufCorpus() ([][]byte, error) {
 		Metric: []dto.Metric{
 			{
 				Counter: &dto.Counter{
-					Value:            12.5,
-					CreatedTimestamp: &types.Timestamp{Seconds: 1625000000},
+					Value:          12.5,
+					StartTimestamp: &types.Timestamp{Seconds: 1625000000},
 				},
 			},
 		},
@@ -400,17 +400,17 @@ func getRawProtobufCorpus() ([][]byte, error) {
 		return nil, err
 	}
 
-	// Summary: with created_timestamp.
+	// Summary: with start_timestamp.
 	if result, err = appendSerializedProtobufSeed(result, dto.MetricFamily{
 		Name: "summary_with_ct",
-		Help: "Summary with created timestamp.",
+		Help: "Summary with start timestamp.",
 		Type: dto.MetricType_SUMMARY,
 		Metric: []dto.Metric{
 			{
 				Summary: &dto.Summary{
-					SampleCount:      200,
-					SampleSum:        1000,
-					CreatedTimestamp: &types.Timestamp{Seconds: 1625000000},
+					SampleCount:    200,
+					SampleSum:      1000,
+					StartTimestamp: &types.Timestamp{Seconds: 1625000000},
 					Quantile: []dto.Quantile{
 						{Quantile: 0.5, Value: 5},
 						{Quantile: 0.99, Value: 10},
@@ -1251,36 +1251,36 @@ metric: <
   >
 >
 `,
-		// Summary with created_timestamp.
+		// Summary with start_timestamp.
 		`name: "test_summary_with_createdtimestamp"
-help: "A summary with a created timestamp."
+help: "A summary with a start timestamp."
 type: SUMMARY
 metric: <
   summary: <
     sample_count: 42
     sample_sum: 1.234
-    created_timestamp: < seconds: 1625851153 nanos: 146848499 >
+    start_timestamp: < seconds: 1625851153 nanos: 146848499 >
   >
 >
 `,
-		// Native histogram with created_timestamp.
+		// Native histogram with start_timestamp.
 		`name: "test_histogram_with_createdtimestamp"
-help: "A histogram with a created timestamp."
+help: "A histogram with a start timestamp."
 type: HISTOGRAM
 metric: <
   histogram: <
-    created_timestamp: < seconds: 1625851153 nanos: 146848499 >
+    start_timestamp: < seconds: 1625851153 nanos: 146848499 >
     positive_span: < offset: 0 length: 0 >
   >
 >
 `,
-		// Gauge histogram with created_timestamp.
+		// Gauge histogram with start_timestamp.
 		`name: "test_gaugehistogram_with_createdtimestamp"
-help: "A gauge histogram with a created timestamp."
+help: "A gauge histogram with a start timestamp."
 type: GAUGE_HISTOGRAM
 metric: <
   histogram: <
-    created_timestamp: < seconds: 1625851153 nanos: 146848499 >
+    start_timestamp: < seconds: 1625851153 nanos: 146848499 >
     positive_span: < offset: 0 length: 0 >
   >
 >


### PR DESCRIPTION
Fixes main.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
