### PR TITLE
scrape: fix race between SetScrapeFailureLogger and restartLoops

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -391,22 +391,23 @@ func (m *Manager) ApplyConfig(cfg *config.Config) error {
 				wg.Done()
 				<-canReload
 			}()
-			switch {
-			case !ok:
+			if !ok {
 				sp.stop()
 				toDelete.Store(name, struct{}{})
-			case !reflect.DeepEqual(sp.config, cfg):
+				return
+			}
+			// Update the scrape failure logger before reloading so that
+			// restartLoops captures the new logger when starting new loops.
+			if l, ok := m.scrapeFailureLoggers[cfg.ScrapeFailureLogFile]; ok {
+				sp.SetScrapeFailureLogger(l)
+			} else {
+				sp.logger.Error("No logger found. This is a bug in Prometheus that should be reported upstream.", "scrape_pool", name)
+			}
+			if !reflect.DeepEqual(sp.config, cfg) {
 				err := sp.reload(cfg)
 				if err != nil {
 					m.logger.Error("error reloading scrape pool", "err", err, "scrape_pool", name)
 					failed.Store(true)
-				}
-				fallthrough
-			case ok:
-				if l, ok := m.scrapeFailureLoggers[cfg.ScrapeFailureLogFile]; ok {
-					sp.SetScrapeFailureLogger(l)
-				} else {
-					sp.logger.Error("No logger found. This is a bug in Prometheus that should be reported upstream.", "scrape_pool", name)
 				}
 			}
 		}(poolName, pool, cfg, ok)


### PR DESCRIPTION
Noticed a flaky e2e test in CI: https://github.com/prometheus/prometheus/actions/runs/23854401749/job/69543210918

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Scrape: fix scrape failure log file occasionally not applied after a configuration reload.
```
