### PR TITLE
tsdb: reduce chunk segment size in TestDiskFillingUpAfterDisablingOOO

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -8361,6 +8361,10 @@ func testDiskFillingUpAfterDisablingOOO(t *testing.T, scenario sampleTypeScenari
 	// (important for slow CI like i386 which can be 60x+ slower).
 	opts.SamplesPerChunk = 15
 	opts.OutOfOrderCapMax = 5
+	// Reduce the chunk segment size from the 512MB default: the test only writes
+	// ~80 samples so 1MB is sufficient and avoids large file pre-allocations
+	// during compaction on slow or constrained CI environments.
+	opts.MaxBlockChunkSegmentSize = 1024 * 1024
 
 	db := newTestDB(t, withOpts(opts))
 	db.DisableCompactions()


### PR DESCRIPTION
The test only writes ~80 samples, so the default 512MB chunk segment pre-allocation during compaction is unnecessary. Use 1MB instead to avoid large file allocations on constrained CI environments.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
