### PR TITLE
promtool: add rule test coverage reporting

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -248,6 +248,8 @@ func main() {
 	testRulesDebug := testRulesCmd.Flag("debug", "Enable unit test debugging.").Default("false").Bool()
 	testRulesDiff := testRulesCmd.Flag("diff", "[Experimental] Print colored differential output between expected & received output.").Default("false").Bool()
 	testRulesIgnoreUnknownFields := testRulesCmd.Flag("ignore-unknown-fields", "Ignore unknown fields in the test files. This is useful when you want to extend rule files with custom metadata. Ensure that those fields are removed before loading them into the Prometheus server as it performs strict checks by default.").Default("false").Bool()
+	testRulesCoverage := testRulesCmd.Flag("coverage", "Report rule test coverage to stderr after running tests.").Default("false").Bool()
+	testRulesCoverageThreshold := testRulesCmd.Flag("coverage-threshold", "Fail (exit code 1) if total rule test coverage is below this percentage (0-100). Implies --coverage. 0 disables the check.").Default("0").Float64()
 
 	defaultDBPath := "data/"
 	tsdbCmd := app.Command("tsdb", "Run tsdb commands.")
@@ -435,6 +437,8 @@ func main() {
 			*testRulesDiff,
 			*testRulesDebug,
 			*testRulesIgnoreUnknownFields,
+			*testRulesCoverage,
+			*testRulesCoverageThreshold,
 			*testRulesFiles...),
 		)
 

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -250,6 +250,8 @@ func main() {
 	testRulesDebug := testRulesCmd.Flag("debug", "Enable unit test debugging.").Default("false").Bool()
 	testRulesDiff := testRulesCmd.Flag("diff", "[Experimental] Print colored differential output between expected & received output.").Default("false").Bool()
 	testRulesIgnoreUnknownFields := testRulesCmd.Flag("ignore-unknown-fields", "Ignore unknown fields in the test files. This is useful when you want to extend rule files with custom metadata. Ensure that those fields are removed before loading them into the Prometheus server as it performs strict checks by default.").Default("false").Bool()
+	testRulesCoverage := testRulesCmd.Flag("coverage", "Report rule test coverage to stderr after running tests.").Default("false").Bool()
+	testRulesCoverageThreshold := testRulesCmd.Flag("coverage-threshold", "Fail (exit code 1) if total rule test coverage is below this percentage. Must be between 0 and 100. A positive value implies --coverage; 0 disables the check.").Default("0").Float64()
 
 	defaultDBPath := "data/"
 	tsdbCmd := app.Command("tsdb", "Run tsdb commands.")
@@ -439,6 +441,8 @@ func main() {
 			*testRulesDiff,
 			*testRulesDebug,
 			*testRulesIgnoreUnknownFields,
+			*testRulesCoverage,
+			*testRulesCoverageThreshold,
 			*testRulesFiles...),
 		)
 

--- a/cmd/promtool/rule_coverage.go
+++ b/cmd/promtool/rule_coverage.go
@@ -1,0 +1,1020 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/regexp"
+	"github.com/grafana/regexp/syntax"
+	"github.com/prometheus/common/promslog"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/rules"
+)
+
+// ruleKind distinguishes alerting from recording rules in coverage reports.
+type ruleKind uint8
+
+const (
+	alertingRule ruleKind = iota
+	recordingRule
+)
+
+// String returns the rule kind as it appears in rule files, "alert" or "record".
+func (k ruleKind) String() string {
+	if k == alertingRule {
+		return "alert"
+	}
+	return "record"
+}
+
+// Meta-metrics an alerting rule emits, and the label carrying the alert state.
+const (
+	alertsMetricName         = "ALERTS"
+	alertsForStateMetricName = "ALERTS_FOR_STATE"
+	alertStateLabel          = "alertstate"
+)
+
+// alertMetric is a meta-metric an alerting rule emits, with the labels the engine
+// generates on it. Generated labels override the rule's own, so they are matched
+// against what the engine produces instead of the rule's static labels.
+type alertMetric struct {
+	name      string
+	generated []string
+	// hasState reports whether the engine sets alertstate on this series.
+	hasState bool
+}
+
+// alertMetrics describes both meta-metrics. ALERTS_FOR_STATE gets no generated
+// alertstate, so there alertstate is an ordinary label.
+var alertMetrics = []alertMetric{
+	{
+		name:      alertsMetricName,
+		generated: []string{labels.MetricName, labels.AlertName, alertStateLabel},
+		hasState:  true,
+	},
+	{
+		name:      alertsForStateMetricName,
+		generated: []string{labels.MetricName, labels.AlertName},
+	},
+}
+
+// reachableAlertStates returns the alertstate values an ALERTS series can carry.
+// The state settles before the sample is emitted, so a rule with no hold duration
+// is already firing on its first evaluation and is never observable as pending.
+func reachableAlertStates(holdDuration time.Duration) []string {
+	if holdDuration <= 0 {
+		return []string{"firing"}
+	}
+	return []string{"pending", "firing"}
+}
+
+// recordingRuleGenerated are the labels the engine sets on a recording rule's
+// output. alertname is an ordinary label there.
+var recordingRuleGenerated = []string{labels.MetricName}
+
+// ruleCoverageKey identifies a rule by where it is declared, so the same rule
+// reached from several test files counts once while lookalike declarations stay
+// distinct.
+type ruleCoverageKey struct {
+	file  string // Canonical, symlink-resolved absolute path.
+	group string
+	// ordinal is the rule's index in its group; the loader preserves file order.
+	ordinal int
+}
+
+// ruleCoverageEntry is the reporting metadata and covered state of a rule.
+type ruleCoverageEntry struct {
+	kind   ruleKind
+	name   string
+	labels labels.Labels
+	state  coverageState
+}
+
+// coverageState is what could be established about a rule. Indeterminate is kept
+// apart from uncovered because the analysis is bounded: a rule can have a test
+// whose selector the search could not decide, and calling that untested would be
+// telling the user something it does not know.
+type coverageState uint8
+
+const (
+	coverageUncovered coverageState = iota
+	coverageIndeterminate
+	coverageCovered
+)
+
+// ruleCoverage tracks which rules a test suite exercises. It is populated from
+// rules.Manager.LoadGroups so it stays consistent with how Prometheus loads rules.
+type ruleCoverage struct {
+	parser              parser.Parser
+	ignoreUnknownFields bool
+	manager             *rules.Manager // Loads rule groups; never evaluates them.
+
+	order   []ruleCoverageKey
+	entries map[ruleCoverageKey]*ruleCoverageEntry
+
+	// groups caches groups per canonical path; a nil entry marks a load failure.
+	groups map[string][]*rules.Group
+	// loadFailures holds, per rule file, why it was left out of the totals,
+	// which then understate the suite. failureOrder keeps reporting stable.
+	loadFailures map[string][]error
+	failureOrder []string
+}
+
+// addLoadFailure records that a rule file could not contribute to the totals,
+// either because it failed to load or because nothing matched its pattern.
+func (c *ruleCoverage) addLoadFailure(file string, errs ...error) {
+	if _, ok := c.loadFailures[file]; !ok {
+		c.failureOrder = append(c.failureOrder, file)
+	}
+	c.loadFailures[file] = append(c.loadFailures[file], errs...)
+}
+
+func newRuleCoverage(p parser.Parser, ignoreUnknownFields bool) *ruleCoverage {
+	return &ruleCoverage{
+		parser:              p,
+		ignoreUnknownFields: ignoreUnknownFields,
+		// Pass a logger explicitly, as the unit test path does, so rule file
+		// warnings are discarded instead of interleaved with the report.
+		manager: rules.NewManager(&rules.ManagerOptions{
+			Parser: p,
+			Logger: promslog.NewNopLogger(),
+		}),
+		entries:      map[ruleCoverageKey]*ruleCoverageEntry{},
+		groups:       map[string][]*rules.Group{},
+		loadFailures: map[string][]error{},
+	}
+}
+
+// register counts a rule towards the coverage total. It is idempotent: a rule
+// registered again keeps its covered state.
+func (c *ruleCoverage) register(file, group string, ordinal int, kind ruleKind, name string, ruleLabels labels.Labels) ruleCoverageKey {
+	k := ruleCoverageKey{file: file, group: group, ordinal: ordinal}
+	if _, ok := c.entries[k]; !ok {
+		c.order = append(c.order, k)
+		c.entries[k] = &ruleCoverageEntry{kind: kind, name: name, labels: ruleLabels}
+	}
+	return k
+}
+
+// observe records what a selector established about the rule identified by k,
+// keeping the strongest result seen across every assertion in the suite.
+func (c *ruleCoverage) observe(k ruleCoverageKey, result satisfiability) {
+	e := c.entries[k]
+	switch result {
+	case satisfiable:
+		e.state = coverageCovered
+	case satisfiabilityUnknown:
+		if e.state == coverageUncovered {
+			e.state = coverageIndeterminate
+		}
+	case unsatisfiable:
+	}
+}
+
+// canonicalRuleFilePath resolves file to an absolute, symlink-free path so the
+// same physical file reached by different routes counts once. An unresolvable
+// path falls back to the cleaned input.
+func canonicalRuleFilePath(file string) string {
+	if resolved, err := filepath.EvalSymlinks(file); err == nil {
+		file = resolved
+	}
+	if abs, err := filepath.Abs(file); err == nil {
+		file = abs
+	}
+	return filepath.Clean(file)
+}
+
+// load returns a rule file's canonical path and groups, parsing it on first use.
+// Files are loaded one at a time so a broken file does not drop its valid
+// siblings, and failures go to loadErrs rather than being dropped. interval only
+// sets Group.Interval, which coverage ignores, so the cache is shared across
+// test files that disagree on it.
+func (c *ruleCoverage) load(file string, interval time.Duration) (string, []*rules.Group) {
+	path := canonicalRuleFilePath(file)
+	if groups, ok := c.groups[path]; ok {
+		return path, groups
+	}
+	groupsMap, errs := c.manager.LoadGroups(interval, labels.EmptyLabels(), "", nil, c.ignoreUnknownFields, file)
+	if len(errs) > 0 {
+		// Cache the failure so a shared broken file is reported once.
+		c.groups[path] = nil
+		c.addLoadFailure(path, errs...)
+		return path, nil
+	}
+	// Sort, so registration order does not depend on map iteration order.
+	groups := make([]*rules.Group, 0, len(groupsMap))
+	for _, g := range groupsMap {
+		groups = append(groups, g)
+	}
+	slices.SortFunc(groups, func(a, b *rules.Group) int {
+		return strings.Compare(a.Name(), b.Name())
+	})
+	c.groups[path] = groups
+	return path, groups
+}
+
+// record registers the rules of a unit test file's rule files and marks those its
+// assertions exercise. Rules are attributed through their loaded group rather than
+// by bare name. Only test groups selected by run contribute coverage, so the
+// report reflects what this invocation actually ran.
+func (c *ruleCoverage) record(run *regexp.Regexp, utf *unitTestFile) {
+	// Collect what the test groups that will actually run assert on.
+	testedAlertnames := map[string]struct{}{}
+	var exprSelectors []*compiledSelector
+	for i := range utf.Tests {
+		tg := &utf.Tests[i]
+		if !matchesRun(tg.TestGroupName, run) {
+			continue
+		}
+		for _, a := range tg.AlertRuleTests {
+			testedAlertnames[a.Alertname] = struct{}{}
+		}
+		for _, tc := range tg.PromqlExprTests {
+			expr, err := c.parser.ParseExpr(tc.Expr)
+			if err != nil {
+				continue
+			}
+			for _, matchers := range parser.ExtractSelectors(expr) {
+				exprSelectors = append(exprSelectors, compileSelector(matchers))
+			}
+		}
+	}
+
+	// A rule_files entry that matched nothing never reaches the loader, so the
+	// rules it would have contributed are missing from the totals.
+	for _, pattern := range utf.unmatchedRuleFiles {
+		c.addLoadFailure(canonicalRuleFilePath(pattern),
+			fmt.Errorf("no file matched pattern %q", pattern))
+	}
+
+	for _, rf := range utf.RuleFiles {
+		path, groups := c.load(rf, time.Duration(utf.EvaluationInterval))
+		for _, g := range groups {
+			for i, r := range g.Rules() {
+				switch rule := r.(type) {
+				case *rules.AlertingRule:
+					k := c.register(path, g.Name(), i, alertingRule, rule.Name(), rule.Labels())
+					// Covered by an alert_rule_test naming it, or by a
+					// promql_expr_test selecting its meta-metrics.
+					if _, ok := testedAlertnames[rule.Name()]; ok {
+						c.observe(k, satisfiable)
+						continue
+					}
+					for _, sel := range exprSelectors {
+						result := selectorCoversAlertingRule(rule.Name(), rule.HoldDuration(), rule.Labels(), sel)
+						c.observe(k, result)
+						if result == satisfiable {
+							break
+						}
+					}
+				case *rules.RecordingRule:
+					k := c.register(path, g.Name(), i, recordingRule, rule.Name(), rule.Labels())
+					for _, sel := range exprSelectors {
+						result := selectorCoversRecordingRule(rule.Name(), rule.Labels(), sel)
+						c.observe(k, result)
+						if result == satisfiable {
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// compiledSelector is one selector from a promql_expr_test, together with what
+// has already been established about the matchers on each label. The answer for a
+// label depends only on the matchers, so it is computed once per selector rather
+// than again for every rule the selector is compared against.
+type compiledSelector struct {
+	matchers []*labels.Matcher
+	byLabel  map[string][]*labels.Matcher
+	decided  map[string]satisfiability
+}
+
+func compileSelector(matchers []*labels.Matcher) *compiledSelector {
+	byLabel := make(map[string][]*labels.Matcher, len(matchers))
+	for _, m := range matchers {
+		byLabel[m.Name] = append(byLabel[m.Name], m)
+	}
+	return &compiledSelector{
+		matchers: matchers,
+		byLabel:  byLabel,
+		decided:  make(map[string]satisfiability, len(byLabel)),
+	}
+}
+
+// satisfiabilityOf returns what can be established about the matchers on a label,
+// computing it at most once.
+func (s *compiledSelector) satisfiabilityOf(name string) satisfiability {
+	if result, ok := s.decided[name]; ok {
+		return result
+	}
+	result := matcherSetSatisfiability(s.byLabel[name])
+	s.decided[name] = result
+	return result
+}
+
+// matchersFor returns the matchers constraining name. PromQL allows a label to be
+// constrained repeatedly and requires all such matchers to hold, so callers must
+// satisfy every matcher returned, not just the first.
+func matchersFor(matchers []*labels.Matcher, name string) []*labels.Matcher {
+	var out []*labels.Matcher
+	for _, m := range matchers {
+		if m.Name == name {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// allMatch reports whether value satisfies every matcher in ms. An empty ms
+// constrains nothing and matches.
+func allMatch(ms []*labels.Matcher, value string) bool {
+	for _, m := range ms {
+		if !m.Matches(value) {
+			return false
+		}
+	}
+	return true
+}
+
+// selectorCoversRecordingRule reports whether a promql_expr_test selector reads
+// the named recording rule's output. It is stricter than buildDependencyMap in
+// rules/group.go, which matches on name alone.
+func selectorCoversRecordingRule(name string, ruleLabels labels.Labels, sel *compiledSelector) satisfiability {
+	nameMatchers := sel.byLabel[labels.MetricName]
+	if len(nameMatchers) == 0 {
+		// A wildcard selector cannot be attributed to a specific rule.
+		return unsatisfiable
+	}
+	if !allMatch(nameMatchers, name) {
+		return unsatisfiable
+	}
+	// Recording rule labels are used verbatim, so their values are known exactly.
+	return labelsCompatible(ruleLabels, sel, recordingRuleGenerated, false)
+}
+
+// selectorCoversAlertingRule reports whether a promql_expr_test selector asserts
+// on the named alerting rule through one of its meta-metrics. One meta-metric must
+// satisfy every matcher at once. A selector without an alertname matcher is
+// indeterminate and does not count.
+func selectorCoversAlertingRule(name string, holdDuration time.Duration, ruleLabels labels.Labels, sel *compiledSelector) satisfiability {
+	nameMatchers := sel.byLabel[labels.MetricName]
+	alertnameMatchers := sel.byLabel[labels.AlertName]
+	if len(nameMatchers) == 0 || len(alertnameMatchers) == 0 {
+		return unsatisfiable
+	}
+	// Both meta-metrics carry alertname set to the rule name.
+	if !allMatch(alertnameMatchers, name) {
+		return unsatisfiable
+	}
+
+	best := unsatisfiable
+	for _, am := range alertMetrics {
+		if !allMatch(nameMatchers, am.name) {
+			continue
+		}
+		// The selector must accept at least one reachable alert state.
+		if am.hasState {
+			stateMatchers := sel.byLabel[alertStateLabel]
+			states := reachableAlertStates(holdDuration)
+			if !slices.ContainsFunc(states, func(s string) bool { return allMatch(stateMatchers, s) }) {
+				continue
+			}
+		}
+		switch labelsCompatible(ruleLabels, sel, am.generated, true) {
+		case satisfiable:
+			return satisfiable
+		case satisfiabilityUnknown:
+			best = satisfiabilityUnknown
+		case unsatisfiable:
+		}
+	}
+	return best
+}
+
+// labelsCompatible reports whether a selector can select a rule's output. Labels
+// in generated are checked by the callers and skipped here. A statically set label
+// must satisfy every matcher on it; any other value is produced at evaluation time
+// and treated as unknown, so it is compatible unless the selector contradicts
+// itself. Set expandsTemplates for rules whose labels are templated.
+func labelsCompatible(ruleLabels labels.Labels, sel *compiledSelector, generated []string, expandsTemplates bool) satisfiability {
+	result := satisfiable
+	for name, ms := range sel.byLabel {
+		if slices.Contains(generated, name) {
+			continue
+		}
+		if value, known := staticLabelValue(ruleLabels, name, expandsTemplates); known {
+			if !allMatch(ms, value) {
+				return unsatisfiable
+			}
+			continue
+		}
+		switch sel.satisfiabilityOf(name) {
+		case unsatisfiable:
+			// One impossible label is enough to rule the selector out.
+			return unsatisfiable
+		case satisfiabilityUnknown:
+			result = satisfiabilityUnknown
+		case satisfiable:
+		}
+	}
+	return result
+}
+
+// staticLabelValue returns the value a rule sets for a label and whether that
+// value is known before evaluation. Alerting rules expand their labels per alert
+// instance, so a value carrying template syntax is not known here, which is the
+// same reason AlertingRule.QueryForStateSeries skips those labels. A label the
+// rule sets to the empty string is still known, and constrains the selector.
+func staticLabelValue(ruleLabels labels.Labels, name string, expandsTemplates bool) (string, bool) {
+	if !ruleLabels.Has(name) {
+		return "", false
+	}
+	value := ruleLabels.Get(name)
+	if expandsTemplates && strings.Contains(value, "{{") {
+		return "", false
+	}
+	return value, true
+}
+
+// satisfiabilityProbes are cheap candidate label values, tried before anything is
+// synthesized. The empty string doubles as the value of an absent label; the rest
+// cover distinct character classes.
+var satisfiabilityProbes = []string{"", "a", "A", "0", "-"}
+
+// satisfiability is what the search could establish about a matcher set. The
+// search is bounded, so failing to find a value is not the same as there being
+// none, and the two must not be reported the same way.
+type satisfiability uint8
+
+const (
+	// satisfiabilityUnknown means the search ran out of candidates or budget.
+	satisfiabilityUnknown satisfiability = iota
+	// satisfiable means a value was found and checked against every matcher.
+	satisfiable
+	// unsatisfiable means the matchers confine the label to a finite set of
+	// values, and every one of them was tried and rejected.
+	unsatisfiable
+)
+
+// Limits on the candidate search. regexpCandidateLimit caps how many values are
+// built from one expression, so a nested alternation cannot blow it up;
+// charClassCandidateLimit caps how many are taken from one character class.
+const (
+	regexpCandidateLimit    = 64
+	charClassCandidateLimit = 4
+)
+
+// candidateByteBudget caps the bytes a single matcher set may build while looking
+// for a value. Counted repetition such as [a-z]{1000} expands into a long
+// concatenation, and without a budget the product would allocate megabytes per
+// call, once for every rule the selector is compared against.
+const candidateByteBudget = 1 << 16
+
+// matcherSetSatisfiability reports what can be established about ms. A value is
+// only accepted after allMatch confirms it, so a badly built candidate costs a
+// missed attribution rather than a wrong one.
+//
+// unsatisfiable is only returned when the matchers pin the label to a finite set
+// of values, which makes the enumeration complete. Everything else that fails to
+// find a value is unknown, including a search that exhausted its budget.
+func matcherSetSatisfiability(ms []*labels.Matcher) satisfiability {
+	pinned, exhaustive := pinnedValues(ms)
+	if exhaustive {
+		if slices.ContainsFunc(pinned, func(v string) bool { return allMatch(ms, v) }) {
+			return satisfiable
+		}
+		// The label cannot hold anything outside this set, so nothing satisfies it.
+		return unsatisfiable
+	}
+
+	if slices.ContainsFunc(cheapWitnesses(ms), func(v string) bool { return allMatch(ms, v) }) {
+		return satisfiable
+	}
+	// Building from the required expressions costs a parse, so it is only reached
+	// once the cheap candidates are exhausted.
+	budget := candidateByteBudget
+	for _, m := range ms {
+		if m.Type != labels.MatchRegexp {
+			continue
+		}
+		candidates, spent := regexpCandidates(m.GetRegexString(), budget)
+		budget -= spent
+		if slices.ContainsFunc(candidates, func(v string) bool { return allMatch(ms, v) }) {
+			return satisfiable
+		}
+		if budget <= 0 {
+			break
+		}
+	}
+	return satisfiabilityUnknown
+}
+
+// pinnedValues returns the values the matchers allow the label to take, and
+// whether that list is the complete set. It is complete when some matcher
+// restricts the label to finitely many values: an equality matcher, or a regexp
+// that is an alternation of literals.
+func pinnedValues(ms []*labels.Matcher) ([]string, bool) {
+	var pinned []string
+	exhaustive := false
+	for _, m := range ms {
+		switch m.Type {
+		case labels.MatchEqual:
+			pinned = append(pinned, m.Value)
+			exhaustive = true
+		case labels.MatchRegexp:
+			if set := m.SetMatches(); len(set) > 0 {
+				pinned = append(pinned, set...)
+				exhaustive = true
+			}
+		}
+	}
+	return pinned, exhaustive
+}
+
+// cheapWitnesses returns the candidate values that need no regexp parsing.
+func cheapWitnesses(ms []*labels.Matcher) []string {
+	out := make([]string, 0, len(ms)+len(satisfiabilityProbes)+len(freshWitnessSeeds))
+	for _, m := range ms {
+		if m.Type == labels.MatchRegexp {
+			out = append(out, m.SetMatches()...)
+		}
+	}
+	return append(out, exclusionWitnesses(ms)...)
+}
+
+// regexpCandidates returns values derived from the expression's syntax tree, for
+// a caller to try against the matchers it came from. They are candidates rather
+// than witnesses: a zero-width assertion can make one fail the expression it was
+// built from, as the walk builds "foobar" for foo\bbar, which does not match it.
+// Callers must confirm each value; matchersSatisfiable does.
+//
+// The flags are the ones labels.NewFastRegexMatcher parses with, so a candidate
+// means the same here as it does when the matcher runs.
+func regexpCandidates(expr string, budget int) ([]string, int) {
+	parsed, err := syntax.Parse(expr, syntax.Perl|syntax.DotNL)
+	if err != nil {
+		return nil, 0
+	}
+	b := &candidateBudget{remaining: budget}
+	return regexpCandidatesFor(parsed.Simplify(), b), budget - b.remaining
+}
+
+// candidateBudget tracks how many bytes the search may still build. Running out
+// stops the walk rather than shrinking the values it returns, so a caller never
+// receives a candidate that was silently cut short.
+type candidateBudget struct{ remaining int }
+
+func (b *candidateBudget) spend(n int) bool {
+	b.remaining -= n
+	return b.remaining > 0
+}
+
+// regexpCandidatesFor returns values derived from re, taking every alternation
+// branch and several members of each character class, since a later matcher may
+// exclude the first one that comes to hand. It stops early when the budget runs
+// out, which the caller reads as "unknown" rather than "no value exists".
+func regexpCandidatesFor(re *syntax.Regexp, budget *candidateBudget) []string {
+	if budget.remaining <= 0 {
+		return nil
+	}
+	switch re.Op {
+	case syntax.OpEmptyMatch, syntax.OpBeginLine, syntax.OpEndLine,
+		syntax.OpBeginText, syntax.OpEndText,
+		syntax.OpWordBoundary, syntax.OpNoWordBoundary:
+		// Zero-width assertions add nothing to the value. Whether the assertion
+		// holds where the surrounding parts put it is left to the caller's check.
+		return []string{""}
+	case syntax.OpNoMatch:
+		return nil
+	case syntax.OpLiteral:
+		v := string(re.Rune)
+		if !budget.spend(len(v)) {
+			return nil
+		}
+		return []string{v}
+	case syntax.OpCharClass:
+		return charClassCandidates(re.Rune, budget)
+	case syntax.OpAnyChar:
+		return []string{"a", "b", "\n"}
+	case syntax.OpAnyCharNotNL:
+		return []string{"a", "b", "0"}
+	case syntax.OpCapture:
+		return regexpCandidatesFor(re.Sub[0], budget)
+	case syntax.OpQuest:
+		return dedupeCandidates(append([]string{""}, regexpCandidatesFor(re.Sub[0], budget)...))
+	case syntax.OpStar:
+		return repeatedCandidates(re.Sub[0], 0, 3, budget)
+	case syntax.OpPlus:
+		return repeatedCandidates(re.Sub[0], 1, 3, budget)
+	case syntax.OpRepeat:
+		maxRepeat := re.Min + 1
+		if re.Max >= 0 && re.Max < maxRepeat {
+			maxRepeat = re.Max
+		}
+		return repeatedCandidates(re.Sub[0], re.Min, maxRepeat, budget)
+	case syntax.OpConcat:
+		lists := make([][]string, 0, len(re.Sub))
+		for _, sub := range re.Sub {
+			list := regexpCandidatesFor(sub, budget)
+			if len(list) == 0 {
+				return nil
+			}
+			lists = append(lists, list)
+		}
+		return dedupeCandidates(productCandidates(lists, budget))
+	case syntax.OpAlternate:
+		var out []string
+		for _, sub := range re.Sub {
+			out = append(out, regexpCandidatesFor(sub, budget)...)
+			if len(out) >= regexpCandidateLimit || budget.remaining <= 0 {
+				break
+			}
+		}
+		return dedupeCandidates(out)
+	}
+	return nil
+}
+
+// charClassCandidates returns values from a character class given as range pairs,
+// taking both ends of each range so that a class spanning several ranges is not
+// represented by its first character alone.
+func charClassCandidates(runes []rune, budget *candidateBudget) []string {
+	out := make([]string, 0, charClassCandidateLimit)
+	for i := 0; i+1 < len(runes) && len(out) < charClassCandidateLimit; i += 2 {
+		if !budget.spend(1) {
+			break
+		}
+		out = append(out, string(runes[i]))
+		if runes[i+1] != runes[i] && len(out) < charClassCandidateLimit {
+			out = append(out, string(runes[i+1]))
+		}
+	}
+	return out
+}
+
+// repeatedCandidates returns the values re produces when repeated between
+// minRepeat and maxRepeat times.
+func repeatedCandidates(re *syntax.Regexp, minRepeat, maxRepeat int, budget *candidateBudget) []string {
+	parts := regexpCandidatesFor(re, budget)
+	var out []string
+	for n := minRepeat; n <= maxRepeat; n++ {
+		lists := make([][]string, n)
+		for i := range lists {
+			lists[i] = parts
+		}
+		out = append(out, productCandidates(lists, budget)...)
+		if len(out) >= regexpCandidateLimit || budget.remaining <= 0 {
+			break
+		}
+	}
+	return dedupeCandidates(out)
+}
+
+// productCandidates returns the concatenations of one value from each list. A
+// list with no values makes the whole product empty.
+//
+// The limit caps how wide the product gets at each step, never how many lists are
+// applied: stopping part way would return values built from only the first few
+// sub-expressions, which cannot match the whole thing. Running out of budget
+// abandons the product entirely for the same reason.
+func productCandidates(lists [][]string, budget *candidateBudget) []string {
+	out := []string{""}
+	for _, list := range lists {
+		if len(list) == 0 {
+			return nil
+		}
+		next := make([]string, 0, min(len(out)*len(list), regexpCandidateLimit))
+		for _, prefix := range out {
+			for _, part := range list {
+				if !budget.spend(len(prefix) + len(part)) {
+					return nil
+				}
+				next = append(next, prefix+part)
+				if len(next) >= regexpCandidateLimit {
+					break
+				}
+			}
+			if len(next) >= regexpCandidateLimit {
+				break
+			}
+		}
+		out = next
+	}
+	return out
+}
+
+// dedupeCandidates drops repeats and trims the list to the candidate limit.
+func dedupeCandidates(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, min(len(values), regexpCandidateLimit))
+	for _, v := range values {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+		if len(out) == regexpCandidateLimit {
+			break
+		}
+	}
+	return out
+}
+
+// exclusionWitnesses returns candidate values for a matcher set that only rules
+// values out. Alongside the probes it offers a value stepped outside whatever the
+// equality matchers exclude, so that a set excluding every probe is not mistaken
+// for one that excludes everything.
+func exclusionWitnesses(ms []*labels.Matcher) []string {
+	excluded := make(map[string]struct{}, len(ms))
+	for _, m := range ms {
+		switch m.Type {
+		case labels.MatchNotEqual:
+			excluded[m.Value] = struct{}{}
+		case labels.MatchNotRegexp:
+			// A negated alternation of literals rules out exactly those values.
+			for _, v := range m.SetMatches() {
+				excluded[v] = struct{}{}
+			}
+		}
+	}
+
+	out := slices.Clone(satisfiabilityProbes)
+	// Step outside the excluded set from several starting points, so that one
+	// negative matcher cannot rule out every value this is willing to try.
+	for _, seed := range freshWitnessSeeds {
+		for i := 0; ; i++ {
+			fresh := seed + strconv.Itoa(i)
+			if _, ok := excluded[fresh]; !ok {
+				out = append(out, fresh)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// freshWitnessSeeds are prefixes for values built to sit outside a matcher set's
+// exclusions. They differ in shape rather than in spelling, since a negative
+// regexp that rules out one shape often accepts another.
+var freshWitnessSeeds = []string{"b", "Z", "9", "_", "-", ".", "-b", "b-", "coverage-witness-"}
+
+// coverageStats are the exact rule counts a report is derived from. Thresholds
+// are gated on these, never on the rounded percentage that is displayed.
+type coverageStats struct {
+	Covered int
+	// Indeterminate counts rules the bounded analysis could not decide. They are
+	// neither proven covered nor proven uncovered.
+	Indeterminate int
+	Total         int
+}
+
+// upperBound is the coverage the suite would have if every undecided rule turned
+// out to be covered.
+func (s coverageStats) upperBound() coverageStats {
+	return coverageStats{Covered: s.Covered + s.Indeterminate, Total: s.Total}
+}
+
+// percentage returns covered/total as a percentage, treating an empty set as
+// fully covered. For display only; use belowThreshold to gate.
+func (s coverageStats) percentage() float64 {
+	if s.Total == 0 {
+		return 100
+	}
+	return float64(s.Covered) / float64(s.Total) * 100
+}
+
+// belowThreshold reports whether coverage is below threshold. It cross-multiplies
+// rather than dividing, so one uncovered rule always fails a threshold of 100
+// however large the total. Callers gate an empty set separately.
+func (s coverageStats) belowThreshold(threshold float64) bool {
+	if threshold <= 0 || s.Total == 0 {
+		return false
+	}
+	return float64(s.Covered)*100 < threshold*float64(s.Total)
+}
+
+// reportAndGate writes the coverage summary to w and returns why the coverage
+// gate failed, or the empty string when it passed. A threshold of zero or less
+// only reports. Incomplete data never passes: rule files that never reached the
+// totals, or an empty suite, mean coverage is unknown rather than complete.
+func (c *ruleCoverage) reportAndGate(w io.Writer, threshold float64) string {
+	stats := c.report(w)
+
+	base := reportBaseDir()
+	for _, file := range c.failureOrder {
+		for _, err := range c.loadFailures[file] {
+			fmt.Fprintf(w, "  WARNING: %s excluded from coverage: %s\n", displayRuleFilePath(base, file), err)
+		}
+	}
+
+	if threshold <= 0 {
+		return ""
+	}
+	switch {
+	case len(c.loadFailures) > 0:
+		return fmt.Sprintf("Cannot evaluate the rule coverage threshold: %d rule file(s) were not analysed.", len(c.loadFailures))
+	case stats.Total == 0:
+		return "Cannot evaluate the rule coverage threshold: no rules were loaded."
+	case stats.upperBound().belowThreshold(threshold):
+		// Even crediting every undecided rule leaves the suite short.
+		return fmt.Sprintf("Rule test coverage %d/%d (%s%%) is below the threshold of %s%%.",
+			stats.Covered, stats.Total, formatCoverageAgainstThreshold(stats, threshold), formatThreshold(threshold))
+	case stats.belowThreshold(threshold):
+		// Only the undecided rules stand between the suite and the threshold, so
+		// say that rather than claiming they are untested.
+		return fmt.Sprintf("Rule test coverage is between %d/%d and %d/%d: %d rule(s) could not be attributed either way, so the threshold of %s%% cannot be met with certainty.",
+			stats.Covered, stats.Total, stats.upperBound().Covered, stats.Total, stats.Indeterminate, formatThreshold(threshold))
+	}
+	return ""
+}
+
+// report writes the coverage summary to w and returns the overall statistics.
+// Alerting and recording rules are reported separately.
+func (c *ruleCoverage) report(w io.Writer) coverageStats {
+	var alerting, recording coverageStats
+	for _, k := range c.order {
+		e := c.entries[k]
+		s := &recording
+		if e.kind == alertingRule {
+			s = &alerting
+		}
+		s.Total++
+		switch e.state {
+		case coverageCovered:
+			s.Covered++
+		case coverageIndeterminate:
+			s.Indeterminate++
+		case coverageUncovered:
+		}
+	}
+	total := coverageStats{
+		Covered:       alerting.Covered + recording.Covered,
+		Indeterminate: alerting.Indeterminate + recording.Indeterminate,
+		Total:         alerting.Total + recording.Total,
+	}
+
+	fmt.Fprintln(w, "Rule test coverage:")
+	fmt.Fprintf(w, "  Alerting rules:  %s\n", coverageFraction(alerting))
+	fmt.Fprintf(w, "  Recording rules: %s\n", coverageFraction(recording))
+	fmt.Fprintf(w, "  Total:           %s\n", coverageFraction(total))
+	if total.Indeterminate > 0 {
+		fmt.Fprintf(w, "  Undecided:       %d rule(s) the analysis could not attribute either way\n", total.Indeterminate)
+	}
+	c.reportUncovered(w, total)
+
+	return total
+}
+
+// reportUncovered lists to w the rules no assertion was attributed to, splitting
+// the ones the analysis could not decide from the ones it ruled out, so that a
+// bounded search is never presented as a finding about the tests.
+func (c *ruleCoverage) reportUncovered(w io.Writer, total coverageStats) {
+	c.reportRules(w, "Uncovered rules", coverageUncovered, total.Total-total.Covered-total.Indeterminate)
+	c.reportRules(w, "Rules the analysis could not decide", coverageIndeterminate, total.Indeterminate)
+}
+
+// reportRules lists to w the rules in the given state, grouped by file and group.
+func (c *ruleCoverage) reportRules(w io.Writer, heading string, state coverageState, expected int) {
+	if expected == 0 {
+		return
+	}
+	selected := make([]ruleCoverageKey, 0, expected)
+	for _, k := range c.order {
+		if c.entries[k].state == state {
+			selected = append(selected, k)
+		}
+	}
+	slices.SortFunc(selected, func(a, b ruleCoverageKey) int {
+		if n := strings.Compare(a.file, b.file); n != 0 {
+			return n
+		}
+		if n := strings.Compare(a.group, b.group); n != 0 {
+			return n
+		}
+		return a.ordinal - b.ordinal
+	})
+
+	base := reportBaseDir()
+	fmt.Fprintf(w, "  %s:\n", heading)
+	var lastFile, lastGroup string
+	headerPrinted := false
+	for _, k := range selected {
+		if !headerPrinted || k.file != lastFile || k.group != lastGroup {
+			fmt.Fprintf(w, "    group %q in %s:\n", k.group, displayRuleFilePath(base, k.file))
+			lastFile, lastGroup = k.file, k.group
+			headerPrinted = true
+		}
+		e := c.entries[k]
+		// Labels do not always tell two declarations apart, so give the position
+		// in the group as well; that is what identifies the rule.
+		fmt.Fprintf(w, "      - %s: %s%s (rule #%d)\n", e.kind, e.name, labelSuffix(e.labels), k.ordinal+1)
+	}
+}
+
+// labelSuffix renders static labels as a PromQL-like suffix, empty if there are none.
+func labelSuffix(ls labels.Labels) string {
+	if ls.IsEmpty() {
+		return ""
+	}
+	return ls.String()
+}
+
+// reportBaseDir returns the canonicalized directory rule file paths are reported
+// relative to, or "" if it cannot be determined.
+func reportBaseDir() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(wd); err == nil {
+		return resolved
+	}
+	return wd
+}
+
+// displayRuleFilePath renders file relative to base, or absolute if it lies
+// outside. Enough path is kept for files sharing a base name to stay distinct.
+func displayRuleFilePath(base, file string) string {
+	if base == "" {
+		return file
+	}
+	rel, err := filepath.Rel(base, file)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return file
+	}
+	return rel
+}
+
+// coverageFraction formats a covered/total count together with its percentage.
+// A count with no rules is reported without a percentage.
+func coverageFraction(s coverageStats) string {
+	if s.Total == 0 {
+		return "0/0 covered"
+	}
+	return fmt.Sprintf("%d/%d covered (%s%%)", s.Covered, s.Total, formatCoveragePercentage(s))
+}
+
+// formatCoveragePercentage renders a percentage at one decimal place, adding
+// decimals when that would round an incomplete result up to 100% or a partly
+// covered one down to 0%, contradicting the counts beside it.
+func formatCoveragePercentage(s coverageStats) string {
+	pct := s.percentage()
+	const maxPrec = 6
+	for prec := 1; prec < maxPrec; prec++ {
+		out := strconv.FormatFloat(pct, 'f', prec, 64)
+		rounded, err := strconv.ParseFloat(out, 64)
+		if err != nil {
+			break
+		}
+		if (rounded < 100 || s.Covered == s.Total) && (rounded > 0 || s.Covered == 0) {
+			return out
+		}
+	}
+	return strconv.FormatFloat(pct, 'f', maxPrec, 64)
+}
+
+// formatCoverageAgainstThreshold renders a coverage percentage with enough
+// precision to tell it apart from the threshold it failed, so that a message
+// about 2 rules of 3 does not read as 66.7% being below 66.7%.
+func formatCoverageAgainstThreshold(s coverageStats, threshold float64) string {
+	out := formatCoveragePercentage(s)
+	if out != formatThreshold(threshold) {
+		return out
+	}
+	for prec := 2; prec <= 8; prec++ {
+		if longer := strconv.FormatFloat(s.percentage(), 'f', prec, 64); longer != formatThreshold(threshold) {
+			return longer
+		}
+	}
+	return out
+}
+
+// formatThreshold renders a threshold percentage without trailing zeros, so that
+// a message about a threshold of 60.04 does not report it as 60.0.
+func formatThreshold(threshold float64) string {
+	return strconv.FormatFloat(threshold, 'g', -1, 64)
+}

--- a/cmd/promtool/rule_coverage_test.go
+++ b/cmd/promtool/rule_coverage_test.go
@@ -1,0 +1,1556 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/regexp"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/prometheus/prometheus/util/junitxml"
+)
+
+// recordCoverage builds a ruleCoverage from the given unit test files, mirroring
+// how ruleUnitTest feeds the coverage tracker, so coverage can be asserted in
+// isolation from the test run.
+func recordCoverage(t *testing.T, p parser.Parser, files ...string) *ruleCoverage {
+	t.Helper()
+	return recordCoverageWithRun(t, p, nil, files...)
+}
+
+// recordCoverageWithRun is recordCoverage restricted to the test groups selected
+// by run, mirroring the --run flag.
+func recordCoverageWithRun(t *testing.T, p parser.Parser, run *regexp.Regexp, files ...string) *ruleCoverage {
+	t.Helper()
+	cov := newRuleCoverage(p, false)
+	for _, f := range files {
+		b, err := os.ReadFile(f)
+		require.NoError(t, err)
+		var utf unitTestFile
+		require.NoError(t, yaml.UnmarshalStrict(b, &utf))
+		require.NoError(t, resolveAndGlobFilepaths(filepath.Dir(f), &utf))
+		if utf.EvaluationInterval == 0 {
+			utf.EvaluationInterval = model.Duration(time.Minute)
+		}
+		cov.record(run, &utf)
+	}
+	return cov
+}
+
+// coverageCounts returns the number of covered and total rules tracked.
+func coverageCounts(cov *ruleCoverage) (covered, total int) {
+	total = len(cov.order)
+	for _, k := range cov.order {
+		if cov.entries[k].state == coverageCovered {
+			covered++
+		}
+	}
+	return covered, total
+}
+
+func TestRulesUnitTestCoverage(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+
+	// Tests pass and coverage is informational only: exit code 0.
+	var buf bytes.Buffer
+	require.Equal(t, 0, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, true, 0, "./testdata/coverage_test.yml"))
+
+	// coverage_test.yml exercises 3 of 5 rules (60%). A threshold above it fails,
+	// a threshold at or below it passes. coverage=false with a positive threshold
+	// still enables coverage and gates the exit code.
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 100, "./testdata/coverage_test.yml"))
+	require.Equal(t, 0, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 60, "./testdata/coverage_test.yml"))
+}
+
+func TestRuleCoverageModel(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, "./testdata/coverage_test.yml")
+
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 5, total, "coverage_rules.yml has 3 alerts + 2 recording rules")
+	require.Equal(t, 3, covered)
+
+	var buf bytes.Buffer
+	require.Equal(t, coverageStats{Covered: 3, Total: 5}, cov.report(&buf))
+	out := buf.String()
+	require.Contains(t, out, "Alerting rules:  2/3 covered")
+	require.Contains(t, out, "Recording rules: 1/2 covered")
+	require.Contains(t, out, "Total:           3/5 covered")
+	require.Contains(t, out, "- alert: NeverTested")
+	require.Contains(t, out, "- record: job:up:avg")
+}
+
+// TestRuleCoverageDeduplicatesAcrossFiles covers the bug where a rule file shared
+// by multiple test files was counted once per referencing file, inflating the
+// denominator and listing the same rule as both covered and untested.
+func TestRuleCoverageDeduplicatesAcrossFiles(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, "./testdata/coverage_shared_a_test.yml", "./testdata/coverage_shared_b_test.yml")
+
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 1, total, "the shared rule must be counted exactly once")
+	require.Equal(t, 1, covered, "it is covered because one test file exercises it")
+}
+
+// TestRuleCoverageDistinguishesDuplicateNames covers the bug where rules sharing a
+// name in different groups were conflated. They must be counted as distinct rules
+// and attributed individually: the two same-named alerts are both covered by
+// promtool's union evaluation, while the label-scoped query covers only one of the
+// two same-named recording rules.
+func TestRuleCoverageDistinguishesDuplicateNames(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, "./testdata/coverage_dupname_test.yml")
+
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 4, total, "two same-named alerts and two same-named records are four distinct rules")
+	require.Equal(t, 3, covered, "both alerts plus only the tier=a recording rule")
+
+	var buf bytes.Buffer
+	cov.report(&buf)
+	out := buf.String()
+	require.Contains(t, out, `group "groupB"`)
+	require.Contains(t, out, "- record: dup:metric")
+	require.NotContains(t, out, `group "groupA"`)
+	require.NotContains(t, out, "SameName")
+}
+
+// TestRuleCoverageHonorsRunFilter ensures coverage only counts assertions from
+// test groups selected by --run, so a filtered run cannot report rules as covered
+// that this invocation never exercised.
+func TestRuleCoverageHonorsRunFilter(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverageWithRun(t, p, regexp.MustCompile("NoSuchGroup"), "./testdata/coverage_test.yml")
+
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 5, total, "all rules are still counted in the denominator")
+	require.Equal(t, 0, covered, "no test group ran, so nothing is covered")
+}
+
+// TestRuleCoverageMultiDocumentRuleFile checks that a rule file the loader warns
+// about is still analysed. The coverage manager must supply its own logger, since
+// the loader logs such a warning while loading.
+func TestRuleCoverageMultiDocumentRuleFile(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	require.NotPanics(t, func() {
+		cov := recordCoverage(t, p, "./testdata/coverage_multidoc_test.yml")
+		_, total := coverageCounts(cov)
+		require.Equal(t, 1, total, "the first document's rule is still counted")
+		require.Empty(t, cov.loadFailures)
+	})
+
+	var buf bytes.Buffer
+	require.Equal(t, 0, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, true, 0, "./testdata/coverage_multidoc_test.yml"))
+}
+
+// TestRuleCoverageFailsClosedOnLoadErrors covers the fail-open bug where an
+// unparseable rule file was dropped from the denominator. With no test group to
+// run, nothing else loaded it, so the report became 0/0 and passed a threshold of
+// 100 without analysing the suite at all.
+func TestRuleCoverageFailsClosedOnLoadErrors(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+
+	for _, tc := range []struct {
+		name string
+		file string
+		run  []string
+	}{
+		{name: "no test groups", file: "./testdata/coverage_broken_test.yml"},
+		{name: "no test group selected by --run", file: "./testdata/coverage_broken_run_test.yml", run: []string{"NoSuchGroup"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, tc.run, false, false, false, false, 100, tc.file),
+				"an unanalysable suite must not satisfy a coverage threshold")
+
+			// Report-only mode surfaces incomplete coverage as a warning but keeps
+			// the informational --coverage exit code. Only a positive threshold
+			// turns the same condition into a failure.
+			cov := recordCoverageWithRun(t, p, nil, tc.file)
+			require.Len(t, cov.loadFailures, 1, "one rule file failed, however many errors it produced")
+			var report bytes.Buffer
+			require.Empty(t, cov.reportAndGate(&report, 0))
+			require.Contains(t, report.String(), "excluded from coverage")
+		})
+	}
+}
+
+// TestRuleCoverageDenominatorIsWhatTheSuiteReferences pins the operational limit
+// of the feature: coverage only sees rule files the given test files reach. A
+// rule file nobody wrote a test file for is outside the suite entirely, so it
+// cannot lower the percentage. The documentation says so, because a threshold
+// meant to catch an untested rule would not catch an untested rule file.
+func TestRuleCoverageDenominatorIsWhatTheSuiteReferences(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tested.yml"), []byte(
+		"groups:\n  - name: g\n    rules:\n      - record: r\n        expr: up\n"), 0o600))
+	// Present on disk, referenced by nothing.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "untested.yml"), []byte(
+		"groups:\n  - name: other\n    rules:\n      - alert: NeverSeen\n        expr: up == 0\n"), 0o600))
+
+	testFile := filepath.Join(dir, "test.yml")
+	require.NoError(t, os.WriteFile(testFile, []byte(
+		"rule_files:\n  - tested.yml\n\nevaluation_interval: 1m\n\ntests:\n"+
+			"  - input_series:\n      - series: 'up{job=\"a\"}'\n        values: '1'\n"+
+			"    promql_expr_test:\n      - expr: r\n        eval_time: 0m\n"+
+			"        exp_samples:\n          - labels: 'r{job=\"a\"}'\n            value: 1\n"), 0o600))
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, testFile)
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 1, total, "the unreferenced rule file is not part of the suite")
+	require.Equal(t, 1, covered)
+	require.Empty(t, cov.loadFailures, "an unreferenced file is not a load failure either")
+
+	require.Equal(t, 0, RulesUnitTestResult(io.Discard, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 100, testFile))
+}
+
+// TestRuleCoverageUnmatchedRuleFile covers the fail-open case where a rule_files
+// entry matching nothing was warned about and then dropped. The rules the missing
+// file would have contributed never reach the denominator, so a suite whose
+// remaining files happen to be fully covered used to satisfy a threshold of 100.
+func TestRuleCoverageUnmatchedRuleFile(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	var buf bytes.Buffer
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 100, "./testdata/coverage_missing_test.yml"),
+		"a partially resolved rule_files list must not satisfy a coverage threshold")
+
+	// The rules that were found are still counted, and still fully covered: the
+	// denominator alone cannot reveal the gap.
+	cov := recordCoverage(t, p, "./testdata/coverage_missing_test.yml")
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 1, total)
+	require.Equal(t, 1, covered)
+	require.Len(t, cov.loadFailures, 1)
+	require.Contains(t, cov.reportAndGate(io.Discard, 100), "were not analysed")
+
+	// Report-only mode keeps its exit code.
+	require.Equal(t, 0, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, true, 0, "./testdata/coverage_missing_test.yml"))
+}
+
+// TestRuleCoverageThresholdRejectsUnreachableAlertState covers the fail-open case
+// where every alerting rule was assumed to pass through pending. An alert with no
+// "for" is promoted to firing before its first sample, so an assertion on its
+// pending state passes while observing nothing, and used to satisfy a threshold.
+func TestRuleCoverageThresholdRejectsUnreachableAlertState(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	var buf bytes.Buffer
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 100, "./testdata/coverage_nofor_test.yml"),
+		"an assertion that can never observe the rule must not satisfy a threshold")
+
+	cov := recordCoverage(t, p, "./testdata/coverage_nofor_test.yml")
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 1, total)
+	require.Equal(t, 0, covered)
+}
+
+// TestRuleCoverageThresholdRejectsEmptyStaticLabel covers the false green where
+// rewriting a rule's labels to strip templates also dropped labels set to the
+// empty string, since labels.Builder deletes those. The selector below can never
+// observe the rule, but it looked compatible once severity had gone missing.
+func TestRuleCoverageThresholdRejectsEmptyStaticLabel(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	var buf bytes.Buffer
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 100, "./testdata/coverage_emptylabel_test.yml"),
+		"a selector that contradicts an empty static label must not satisfy a threshold")
+
+	cov := recordCoverage(t, p, "./testdata/coverage_emptylabel_test.yml")
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 1, total)
+	require.Equal(t, 0, covered)
+}
+
+// TestRuleCoverageThresholdRejectsUnsatisfiableSelector is the same check for a
+// selector whose matchers cannot hold at once, which likewise passes as a test
+// while observing nothing.
+func TestRuleCoverageThresholdRejectsUnsatisfiableSelector(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "rules.yml"), []byte(
+		"groups:\n  - name: g\n    rules:\n      - record: r\n        expr: vector(1)\n"), 0o600))
+	testFile := filepath.Join(dir, "test.yml")
+	require.NoError(t, os.WriteFile(testFile, []byte(
+		"rule_files:\n  - rules.yml\n\nevaluation_interval: 1m\n\ntests:\n"+
+			"  - promql_expr_test:\n      - expr: 'r{job=~\"a.*\",job!~\"a.*\"}'\n"+
+			"        eval_time: 0m\n        exp_samples: []\n"), 0o600))
+
+	p := parser.NewParser(parser.Options{})
+	var buf bytes.Buffer
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 100, testFile))
+}
+
+// TestRegexpCandidates checks that a satisfiable expression yields a value it
+// accepts. Individual candidates may fail: a zero-width assertion can contradict
+// the parts around it, which is why callers confirm them.
+func TestRegexpCandidates(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		expr string
+		// usable is false when nothing matches the expression at all, so no
+		// candidate can be expected to either.
+		usable bool
+	}{
+		{expr: "xyz.*", usable: true},
+		{expr: ".*foo", usable: true},
+		{expr: "(staging|prod)-.*", usable: true},
+		{expr: "[a-z]+", usable: true},
+		{expr: ".+", usable: true},
+		{expr: "a|b", usable: true},
+		{expr: ".*prod.*", usable: true},
+		{expr: `job-\d+`, usable: true},
+		{expr: "", usable: true},
+		{expr: ".*", usable: true},
+		{expr: "a.*", usable: true},
+		{expr: "node_.*_total", usable: true},
+		{expr: "(?i)Prod.*", usable: true},
+		{expr: `\d{3}`, usable: true},
+		// \B holds between two word characters, so this one is ordinary.
+		{expr: `foo\Bbar`, usable: true},
+		{expr: `\B`, usable: true},
+		// \b cannot hold between "o" and "b", so nothing matches this.
+		{expr: `foo\bbar`, usable: false},
+		// A high-fanout element before the rest of the expression used to fill
+		// the candidate budget and leave the remaining parts unapplied, so every
+		// candidate came out too short to match.
+		{expr: ".*[0-9][a-z]", usable: true},
+		{expr: ".*.*prod", usable: true},
+		{expr: ".*[a-z].*xyz", usable: true},
+		{expr: ".*prod.*", usable: true},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			t.Parallel()
+			m, err := labels.NewMatcher(labels.MatchRegexp, "job", tc.expr)
+			require.NoError(t, err)
+			require.Equal(t, tc.usable, slices.ContainsFunc(testRegexpCandidates(tc.expr), m.Matches),
+				"candidates for %q", tc.expr)
+		})
+	}
+}
+
+// TestRuleCoverageThresholdAcceptsAlternationSelector is the end-to-end guard for
+// the other direction: a selector whose first alternation branch is excluded can
+// still read the rule, and must not make a legitimate threshold fail.
+func TestRuleCoverageThresholdAcceptsAlternationSelector(t *testing.T) {
+	t.Parallel()
+
+	requireCoveredEndToEnd(t, `r{job=~"(prod|foobar).*",job!~"prod.*"}`)
+}
+
+// TestRuleCoverageThresholdAcceptsNonWordBoundarySelector covers a zero-width
+// assertion that was mistaken for an impossible expression. \B holds between two
+// word characters, so foo\Bbar matches foobar and the assertion reads the rule.
+func TestRuleCoverageThresholdAcceptsNonWordBoundarySelector(t *testing.T) {
+	t.Parallel()
+
+	requireCoveredEndToEnd(t, `r{job=~"foo\\Bbar"}`)
+}
+
+// requireCoveredEndToEnd runs a suite whose single assertion really reads the
+// output of its single rule, and requires a threshold of 100 to pass. Writing it
+// this way keeps the fixture honest: the selector has to observe the rule, not
+// merely be attributable to it.
+func requireCoveredEndToEnd(t *testing.T, selector string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "rules.yml"), []byte(
+		"groups:\n  - name: g\n    rules:\n      - record: r\n        expr: up\n"), 0o600))
+
+	testFile := filepath.Join(dir, "test.yml")
+	require.NoError(t, os.WriteFile(testFile, []byte(
+		"rule_files:\n  - rules.yml\n\nevaluation_interval: 1m\n\ntests:\n"+
+			"  - input_series:\n"+
+			"      - series: 'up{job=\"foobar\"}'\n"+
+			"        values: '1'\n"+
+			"    promql_expr_test:\n"+
+			"      - expr: '"+selector+"'\n"+
+			"        eval_time: 0m\n"+
+			"        exp_samples:\n"+
+			"          - labels: 'r{job=\"foobar\"}'\n"+
+			"            value: 1\n"), 0o600))
+
+	p := parser.NewParser(parser.Options{})
+	require.Equal(t, 0, RulesUnitTestResult(io.Discard, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 100, testFile),
+		"a selector that observes the rule must satisfy the threshold")
+}
+
+// TestMatchersSatisfiableAgainstOracle sweeps pairs of regexp matchers and checks
+// the candidate search against brute force over a small alphabet. Whenever some
+// value in the alphabet satisfies a pair, the search must find one too. This is
+// the completeness half of the property; TestRegexpCandidates covers the rest.
+func TestMatchersSatisfiableAgainstOracle(t *testing.T) {
+	t.Parallel()
+
+	alphabet := []string{
+		"", "a", "b", "c", "A", "B", "0", "1", "-", "_", "\n", "\t", " ",
+		"aa", "ab", "ba", "bb", "abc", "prod", "prod-", "staging", "staging-",
+		"foo", "x", "y", "xy", "yx", "a-b", "z",
+	}
+	exprs := []string{
+		"a.*", "b.*", ".*", ".", "[ab]+", "[a-z]+", "(staging|prod)-.*",
+		"x?y?", "a|b", "xyz.*", "|a|A|0|-|aa", "[^a]+", "a+", "staging-.*",
+		"[^\n]", "(a|b|c)", "a{1,2}", ".+", "prod|staging",
+		`foo\\Bbar`, `\\B`, `\\Bfoo`, `foo\\bbar`,
+	}
+	types := []labels.MatchType{labels.MatchRegexp, labels.MatchNotRegexp}
+
+	// Intersecting two unbounded expressions needs a value neither describes on
+	// its own, which per-expression enumeration cannot reach.
+	knownGaps := map[string]bool{
+		`job=~".*foo",job=~"xyz.*"`: true,
+		`job=~"xyz.*",job=~".*foo"`: true,
+	}
+	exprs = append(exprs, ".*foo")
+
+	for _, first := range exprs {
+		for _, second := range exprs {
+			for _, firstType := range types {
+				for _, secondType := range types {
+					a, err := labels.NewMatcher(firstType, "job", first)
+					require.NoError(t, err)
+					b, err := labels.NewMatcher(secondType, "job", second)
+					require.NoError(t, err)
+					ms := []*labels.Matcher{a, b}
+
+					witness, found := "", false
+					for _, v := range alphabet {
+						if allMatch(ms, v) {
+							witness, found = v, true
+							break
+						}
+					}
+					if !found || knownGaps[a.String()+","+b.String()] {
+						continue
+					}
+					require.True(t, (matcherSetSatisfiability(ms) == satisfiable),
+						"%s and %s are satisfied by %q but the search found nothing", a, b, witness)
+				}
+			}
+		}
+	}
+}
+
+// TestMatcherSetSatisfiabilityStates checks the distinction the whole report
+// rests on: a matcher set the search cannot decide must come back unknown, not
+// unsatisfiable. Only a finite domain that was enumerated in full proves the
+// negative.
+func TestMatcherSetSatisfiabilityStates(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	for _, tc := range []struct {
+		expr string
+		want satisfiability
+	}{
+		{expr: `r{job=~"prom.*"}`, want: satisfiable},
+		{expr: `r{job="a",job=~"a|b"}`, want: satisfiable},
+		// Finite domains, enumerated in full, so the negative is proven.
+		{expr: `r{job="a",job="b"}`, want: unsatisfiable},
+		{expr: `r{job=~"a|b",job!~"a|b"}`, want: unsatisfiable},
+		{expr: `r{job=~"a",job!~"a"}`, want: unsatisfiable},
+		// Satisfiable, but the value is outside what the search builds.
+		{expr: `r{job=~"a+",job!~"a|aa|aaa"}`, want: satisfiabilityUnknown},
+		{expr: `r{job=~"[a-z]{2}",job!~"aa|az|za|zz"}`, want: satisfiabilityUnknown},
+		// Genuinely impossible, but nothing pins the label, so it is not proven.
+		{expr: `r{job!~".*"}`, want: satisfiabilityUnknown},
+		// The budget runs out; that is a limit of the search, not a verdict.
+		{expr: `r{job=~"[a-z]{1000}"}`, want: satisfiabilityUnknown},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, matcherSetSatisfiability(matchersFor(onlySelector(t, p, tc.expr), "job")))
+		})
+	}
+}
+
+// TestRuleCoverageReportsUndecidedSeparately checks that a rule the analysis
+// could not decide is not presented as untested, and that a threshold still
+// fails closed over it.
+func TestRuleCoverageReportsUndecidedSeparately(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "rules.yml"), []byte(
+		"groups:\n  - name: g\n    rules:\n      - record: r\n        expr: up\n"), 0o600))
+	testFile := filepath.Join(dir, "test.yml")
+	require.NoError(t, os.WriteFile(testFile, []byte(
+		"rule_files:\n  - rules.yml\n\nevaluation_interval: 1m\n\ntests:\n"+
+			"  - input_series:\n      - series: 'up{job=\"aaaa\"}'\n        values: '1'\n"+
+			"    promql_expr_test:\n      - expr: 'r{job=~\"a+\",job!~\"a|aa|aaa\"}'\n"+
+			"        eval_time: 0m\n        exp_samples:\n"+
+			"          - labels: 'r{job=\"aaaa\"}'\n            value: 1\n"), 0o600))
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, testFile)
+
+	var buf bytes.Buffer
+	stats := cov.report(&buf)
+	require.Equal(t, 1, stats.Total)
+	require.Equal(t, 0, stats.Covered)
+	require.Equal(t, 1, stats.Indeterminate, "the assertion reads the rule, but the search cannot show it")
+
+	out := buf.String()
+	require.Contains(t, out, "could not decide")
+	require.NotContains(t, out, "Uncovered rules", "an undecided rule must not be called untested")
+
+	// The gate still fails, but says why.
+	reason := cov.reportAndGate(io.Discard, 100)
+	require.Contains(t, reason, "could not be attributed either way")
+	require.Equal(t, 1, RulesUnitTestResult(io.Discard, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 100, testFile))
+}
+
+// BenchmarkMatcherSetSatisfiability covers the shapes that used to be expensive:
+// a counted repetition expands into a long concatenation, and the same selector
+// is compared against every rule whose name matches.
+func BenchmarkMatcherSetSatisfiability(b *testing.B) {
+	p := parser.NewParser(parser.Options{})
+	sel := func(expr string) []*labels.Matcher {
+		parsed, err := p.ParseExpr(expr)
+		require.NoError(b, err)
+		return matchersFor(parser.ExtractSelectors(parsed)[0], "job")
+	}
+	for name, ms := range map[string][]*labels.Matcher{
+		"equality":       sel(`r{job="a"}`),
+		"regexp":         sel(`r{job=~"prom.*"}`),
+		"countedRepeat":  sel(`r{job=~"[a-z]{1000}"}`),
+		"largeExclusion": sel(`r{job!~"a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z"}`),
+	} {
+		b.Run(name, func(b *testing.B) {
+			for b.Loop() {
+				matcherSetSatisfiability(ms)
+			}
+		})
+	}
+}
+
+// BenchmarkCompiledSelectorReuse covers the amplification the compiled selector
+// removes: one expensive matcher set compared against many rules.
+func BenchmarkCompiledSelectorReuse(b *testing.B) {
+	p := parser.NewParser(parser.Options{})
+	parsed, err := p.ParseExpr(`{__name__=~"r.*",job=~"[a-z]{1000}"}`)
+	require.NoError(b, err)
+	matchers := parser.ExtractSelectors(parsed)[0]
+
+	for b.Loop() {
+		sel := compileSelector(matchers)
+		for i := range 200 {
+			selectorCoversRecordingRule("r"+strconv.Itoa(i), labels.EmptyLabels(), sel)
+		}
+	}
+}
+
+// TestMatchersSatisfiableIsSound is the property the coverage gate rests on:
+// matchersSatisfiable must never call a matcher set satisfiable without a value
+// that actually satisfies it, because that is what would let an assertion which
+// can never observe a rule count as covering it.
+//
+// Completeness is not asserted. The search is bounded by design, so the number of
+// satisfiable sets it misses is reported rather than fixed, to keep the test from
+// becoming a tripwire for every regexp the candidate builder cannot reach.
+func TestMatchersSatisfiableIsSound(t *testing.T) {
+	t.Parallel()
+
+	random := rand.New(rand.NewSource(20260820))
+	types := []labels.MatchType{labels.MatchEqual, labels.MatchNotEqual, labels.MatchRegexp, labels.MatchNotRegexp}
+
+	var checked, missed int
+	for range 20000 {
+		matchers := make([]*labels.Matcher, 0, 3)
+		for range 1 + random.Intn(3) {
+			matchType := types[random.Intn(len(types))]
+			value := satisfiabilityFuzzValues[random.Intn(len(satisfiabilityFuzzValues))]
+			if matchType == labels.MatchRegexp || matchType == labels.MatchNotRegexp {
+				value = randomFuzzRegexp(random, 1+random.Intn(2))
+			}
+			// The generator can produce expressions the parser rejects, such as
+			// nested repetition; those are not interesting here.
+			m, err := labels.NewMatcher(matchType, "job", value)
+			if err != nil {
+				matchers = nil
+				break
+			}
+			matchers = append(matchers, m)
+		}
+		if len(matchers) == 0 {
+			continue
+		}
+		checked++
+
+		result := matcherSetSatisfiability(matchers)
+		if result == satisfiable {
+			pinned, _ := pinnedValues(matchers)
+			candidates := append(pinned, cheapWitnesses(matchers)...)
+			candidates = append(candidates, regexpFuzzCandidates(matchers)...)
+			require.True(t, slices.ContainsFunc(candidates, func(v string) bool { return allMatch(matchers, v) }),
+				"%v was called satisfiable with no value that satisfies it", matchers)
+			continue
+		}
+		if result == unsatisfiable {
+			// Claiming impossible requires the enumeration to have been complete.
+			_, exhaustive := pinnedValues(matchers)
+			require.True(t, exhaustive,
+				"%v was called unsatisfiable without a finite domain to enumerate", matchers)
+		}
+		if slices.ContainsFunc(satisfiabilityFuzzValues, func(v string) bool { return allMatch(matchers, v) }) {
+			missed++
+		}
+	}
+	t.Logf("%d matcher sets, no unsupported positives; the bounded search missed %d (%.3f%%)",
+		checked, missed, 100*float64(missed)/float64(checked))
+}
+
+// satisfiabilityFuzzValues stand in for the label values a rule might produce.
+var satisfiabilityFuzzValues = []string{
+	"", "a", "b", "c", "A", "Z", "0", "9", "-", "_", ".", " ", "\n", "aa", "ab",
+	"a-b", "a.b", "foo", "foobar", "prod", "prod-", "-prod", "staging-", "xyz",
+	"xyzfoo", "x", "xy", "node_x_total", "測試", "--", "0x",
+}
+
+// randomFuzzRegexp builds an expression from the shapes that appear in rule test
+// selectors: literals, classes, alternation, repetition and leading wildcards.
+func randomFuzzRegexp(random *rand.Rand, depth int) string {
+	atoms := []string{"a", "b", "foo", "prod", "xyz", "-", "_", "0", ".", "[ab]", "[a-z]", "[0-9]", "[^a]", `\d`, `\w`}
+	if depth <= 0 {
+		return atoms[random.Intn(len(atoms))]
+	}
+	switch random.Intn(7) {
+	case 0:
+		return randomFuzzRegexp(random, depth-1) + randomFuzzRegexp(random, depth-1)
+	case 1:
+		return "(" + randomFuzzRegexp(random, depth-1) + "|" + randomFuzzRegexp(random, depth-1) + ")"
+	case 2:
+		return randomFuzzRegexp(random, depth-1) + "*"
+	case 3:
+		return randomFuzzRegexp(random, depth-1) + "+"
+	case 4:
+		return randomFuzzRegexp(random, depth-1) + "?"
+	case 5:
+		return ".*" + randomFuzzRegexp(random, depth-1)
+	default:
+		return randomFuzzRegexp(random, depth-1) + ".*"
+	}
+}
+
+// regexpFuzzCandidates returns the values the search would build from the
+// required expressions of a matcher set.
+func regexpFuzzCandidates(matchers []*labels.Matcher) []string {
+	var out []string
+	for _, m := range matchers {
+		if m.Type == labels.MatchRegexp {
+			out = append(out, testRegexpCandidates(m.GetRegexString())...)
+		}
+	}
+	return out
+}
+
+// TestMatchersSatisfiableWitness checks the property the attribution relies on:
+// whenever a matcher set is called satisfiable on the strength of a candidate
+// value, some candidate really does satisfy every matcher.
+func TestMatchersSatisfiableWitness(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	for _, expr := range []string{
+		`r{job="a",job=~"a|b"}`,
+		`r{job=~"a|b",job!~"b"}`,
+		`r{job!="a"}`,
+		`r{job!="",job!="a",job!="A",job!="0",job!="-"}`,
+		`r{job!~"a"}`,
+	} {
+		t.Run(expr, func(t *testing.T) {
+			t.Parallel()
+			ms := matchersFor(onlySelector(t, p, expr), "job")
+			require.True(t, (matcherSetSatisfiability(ms) == satisfiable))
+
+			candidates := append(exclusionWitnesses(ms), "a", "b", "aa")
+			for _, m := range ms {
+				if m.Type == labels.MatchEqual {
+					candidates = append(candidates, m.Value)
+				}
+				candidates = append(candidates, m.SetMatches()...)
+			}
+			require.True(t, slices.ContainsFunc(candidates, func(v string) bool { return allMatch(ms, v) }),
+				"a satisfiable matcher set must have a value that satisfies it")
+		})
+	}
+}
+
+// onlySelector parses expr and returns its single selector.
+func onlySelector(t *testing.T, p parser.Parser, expr string) []*labels.Matcher {
+	t.Helper()
+	parsed, err := p.ParseExpr(expr)
+	require.NoError(t, err)
+	selectors := parser.ExtractSelectors(parsed)
+	require.Len(t, selectors, 1)
+	return selectors[0]
+}
+
+// TestRuleCoverageThresholdFailureIsInJUnit checks that a run failing only on
+// coverage is not reported as all green by whatever consumes the JUnit output.
+func TestRuleCoverageThresholdFailureIsInJUnit(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	var buf bytes.Buffer
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 100, "./testdata/coverage_test.yml"))
+
+	var report junitxml.JUnitXML
+	require.NoError(t, xml.Unmarshal(buf.Bytes(), &report))
+	var failures int
+	for _, suite := range report.Suites {
+		failures += suite.FailureCount
+	}
+	require.NotZero(t, failures, "the coverage failure must appear in the JUnit output")
+}
+
+// TestRuleCoverageThresholdRequiresRules checks that a suite loading no rules
+// cannot satisfy a threshold: an empty set is unknown, not fully covered.
+func TestRuleCoverageThresholdRequiresRules(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	var buf bytes.Buffer
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 100, "./testdata/coverage_norules_test.yml"))
+
+	// Without a threshold the empty suite is merely reported.
+	require.Equal(t, 0, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, true, 0, "./testdata/coverage_norules_test.yml"))
+
+	// The gate explains why the threshold could not be evaluated.
+	cov := recordCoverage(t, p, "./testdata/coverage_norules_test.yml")
+	_, total := coverageCounts(cov)
+	require.Equal(t, 0, total)
+	require.Contains(t, cov.reportAndGate(io.Discard, 100), "no rules were loaded")
+	require.Empty(t, cov.reportAndGate(io.Discard, 0))
+}
+
+// TestRuleCoverageDistinguishesRuleDeclarations covers the bug where rules were
+// identified by content, so two declarations differing only in an untracked field
+// such as "for" collapsed into one and the denominator lost a rule.
+func TestRuleCoverageDistinguishesRuleDeclarations(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, "./testdata/coverage_ordinal_test.yml")
+
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 2, total, "two declarations are two rules even when they look alike")
+	require.Equal(t, 0, covered)
+
+	var buf bytes.Buffer
+	cov.report(&buf)
+	out := buf.String()
+	require.Equal(t, 2, strings.Count(out, "- alert: Twin"), "both declarations must be listed")
+	// Their name, expression and labels are identical, so only the position tells
+	// the reader which declaration each line is about.
+	require.Contains(t, out, "(rule #1)")
+	require.Contains(t, out, "(rule #2)")
+}
+
+// TestRuleCoverageReportIdentifiesPartiallyCoveredDeclarations checks the case the
+// ordinal exists for: one of two lookalike declarations is covered, and the report
+// has to say which one still needs a test.
+func TestRuleCoverageReportIdentifiesPartiallyCoveredDeclarations(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, "./testdata/coverage_ordinal_partial_test.yml")
+
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 2, total)
+	require.Equal(t, 1, covered, "only the declaration with a hold duration reaches pending")
+
+	var buf bytes.Buffer
+	cov.report(&buf)
+	out := buf.String()
+	require.Equal(t, 1, strings.Count(out, "- alert: Twin"))
+	require.Contains(t, out, "(rule #1)", "the declaration without a for is the untested one")
+	require.NotContains(t, out, "(rule #2)")
+}
+
+// TestRuleCoverageReportsDistinguishablePaths checks that rule files sharing a
+// base name stay distinguishable in the report, which listed only the base name.
+func TestRuleCoverageReportsDistinguishablePaths(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, "./testdata/coverage_paths_test.yml")
+
+	_, total := coverageCounts(cov)
+	require.Equal(t, 2, total, "same-named rules in different files are distinct")
+
+	var buf bytes.Buffer
+	cov.report(&buf)
+	out := buf.String()
+	require.Contains(t, out, filepath.Join("testdata", "coverage_paths", "a", "rules.yml"))
+	require.Contains(t, out, filepath.Join("testdata", "coverage_paths", "b", "rules.yml"))
+}
+
+// TestRuleCoverageDeduplicatesSymlinkedRuleFile checks that a rule file reached
+// through a symlink is counted once. Making the path absolute is not enough,
+// since both paths are then still distinct.
+func TestRuleCoverageDeduplicatesSymlinkedRuleFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ruleFile := filepath.Join(dir, "rules.yml")
+	require.NoError(t, os.WriteFile(ruleFile, []byte(
+		"groups:\n  - name: g\n    rules:\n      - record: only:metric\n        expr: up\n"), 0o600))
+	if err := os.Symlink(ruleFile, filepath.Join(dir, "link.yml")); err != nil {
+		t.Skipf("symlinks are unavailable here: %v", err)
+	}
+	testFile := filepath.Join(dir, "test.yml")
+	require.NoError(t, os.WriteFile(testFile, []byte(
+		"rule_files:\n  - rules.yml\n  - link.yml\n\ntests: []\n"), 0o600))
+
+	cov := recordCoverage(t, parser.NewParser(parser.Options{}), testFile)
+	_, total := coverageCounts(cov)
+	require.Equal(t, 1, total, "the same rule reached through a symlink is one rule")
+}
+
+// TestRuleCoverageParsesSharedRuleFileOnce checks that a rule file referenced by
+// several test files is loaded once rather than re-parsed per referencing file.
+func TestRuleCoverageParsesSharedRuleFileOnce(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, "./testdata/coverage_shared_a_test.yml", "./testdata/coverage_shared_b_test.yml")
+
+	require.Len(t, cov.groups, 1, "the shared rule file must be parsed once for the suite")
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 1, total)
+	require.Equal(t, 1, covered, "coverage from every test file still applies")
+}
+
+// TestRuleCoverageThresholdValidation rejects thresholds outside [0, 100],
+// including the non-finite values strconv.ParseFloat accepts. NaN compares false
+// against every bound, so unvalidated it would pass the range check and disable
+// the gate it was asked to enforce.
+func TestRuleCoverageThresholdValidation(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	for _, threshold := range []float64{-1, 101, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		t.Run(formatThreshold(threshold), func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, threshold, "./testdata/coverage_test.yml"))
+		})
+	}
+}
+
+// TestRuleCoverageThresholdIsExact checks the gate compares raw counts, not the
+// displayed percentage. Rounding first made it fail open: 1999 of 2000 rules is
+// 99.95%, which displays as 100.0% and used to satisfy a threshold of 100.
+func TestRuleCoverageThresholdIsExact(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := newRuleCoverage(p, false)
+	const total = 2000
+	for i := range total {
+		k := cov.register("/rules.yml", "g", i, recordingRule, fmt.Sprintf("m%d", i), labels.EmptyLabels())
+		if i < total-1 {
+			cov.observe(k, satisfiable)
+		}
+	}
+
+	var buf bytes.Buffer
+	reason := cov.reportAndGate(&buf, 100)
+	require.Equal(t, "Rule test coverage 1999/2000 (99.95%) is below the threshold of 100%.", reason,
+		"one uncovered rule must fail a threshold of 100")
+	// The report must not claim 100% while a rule is uncovered either.
+	require.Contains(t, buf.String(), "1999/2000 covered (99.95%)")
+
+	require.Empty(t, cov.reportAndGate(io.Discard, 99.9), "99.95% clears a threshold of 99.9")
+}
+
+// TestRuleCoverageThresholdEndToEnd exercises the gate through the command entry
+// point: 2/3 is 66.666...%, so it fails a threshold of 66.7 despite displaying
+// as 66.7%.
+func TestRuleCoverageThresholdEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	var buf bytes.Buffer
+	require.Equal(t, 0, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 66.6, "./testdata/coverage_twothirds_test.yml"))
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 66.7, "./testdata/coverage_twothirds_test.yml"))
+}
+
+// TestCoverageStatsBelowThreshold locks the gate to the exact counts.
+func TestCoverageStatsBelowThreshold(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, coverageStats{}.belowThreshold(0), "a zero threshold disables the check")
+	require.False(t, coverageStats{Covered: 1, Total: 2}.belowThreshold(0))
+	require.False(t, coverageStats{}.belowThreshold(100), "an empty set is gated by the caller, not here")
+
+	require.True(t, coverageStats{Covered: 3, Total: 5}.belowThreshold(100))
+	require.False(t, coverageStats{Covered: 3, Total: 5}.belowThreshold(60), "comparison is strictly less-than")
+	require.True(t, coverageStats{Covered: 3, Total: 5}.belowThreshold(60.04), "a threshold need not be a round number")
+	require.False(t, coverageStats{Covered: 3, Total: 5}.belowThreshold(50))
+
+	// A single uncovered rule fails a threshold of 100 whatever the total.
+	require.True(t, coverageStats{Covered: 1999, Total: 2000}.belowThreshold(100))
+	require.True(t, coverageStats{Covered: 999999, Total: 1000000}.belowThreshold(100))
+	require.False(t, coverageStats{Covered: 2000, Total: 2000}.belowThreshold(100))
+}
+
+// TestFormatCoveragePercentage checks the displayed percentage never contradicts
+// the counts printed next to it by rounding to a misleading 100% or 0%.
+func TestFormatCoveragePercentage(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "100.0", formatCoveragePercentage(coverageStats{Covered: 5, Total: 5}))
+	require.Equal(t, "0.0", formatCoveragePercentage(coverageStats{Covered: 0, Total: 5}))
+	require.Equal(t, "66.7", formatCoveragePercentage(coverageStats{Covered: 2, Total: 3}))
+	require.Equal(t, "99.95", formatCoveragePercentage(coverageStats{Covered: 1999, Total: 2000}))
+	require.Equal(t, "0.001", formatCoveragePercentage(coverageStats{Covered: 1, Total: 100000}))
+	require.Equal(t, "100.0", formatCoveragePercentage(coverageStats{}), "an empty set is fully covered")
+
+	// A failure message must not read as a value being below itself: 2/3 is
+	// 66.666...%, which is genuinely below a threshold of 66.7 even though both
+	// render as "66.7" at one decimal place.
+	require.Equal(t, "66.67", formatCoverageAgainstThreshold(coverageStats{Covered: 2, Total: 3}, 66.7))
+	require.Equal(t, "60.0", formatCoverageAgainstThreshold(coverageStats{Covered: 3, Total: 5}, 60.04))
+}
+
+// anySelectorMatches parses expr, extracts its selectors, and reports whether any
+// of them satisfies the given predicate.
+func anySelectorMatches(t *testing.T, p parser.Parser, expr string, pred func([]*labels.Matcher) bool) bool {
+	t.Helper()
+	parsed, err := p.ParseExpr(expr)
+	require.NoError(t, err)
+	return slices.ContainsFunc(parser.ExtractSelectors(parsed), pred)
+}
+
+func TestSelectorCoversRecordingRule(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	tests := []struct {
+		name       string
+		ruleName   string
+		ruleLabels labels.Labels
+		expr       string
+		matches    bool
+	}{
+		{
+			name:     "direct match",
+			ruleName: "job:up:sum",
+			expr:     "job:up:sum",
+			matches:  true,
+		},
+		{
+			name:     "aggregation wrapping",
+			ruleName: "job:up:sum",
+			expr:     `sum by (job)(job:up:sum)`,
+			matches:  true,
+		},
+		{
+			name:     "no match",
+			ruleName: "job:up:sum",
+			expr:     "other_metric",
+			matches:  false,
+		},
+		{
+			name:     "wildcard selector without __name__ is indeterminate",
+			ruleName: "job:up:sum",
+			expr:     `{job="prometheus"}`,
+			matches:  false,
+		},
+		{
+			name:       "compatible static label",
+			ruleName:   "job:up:sum",
+			ruleLabels: labels.FromStrings("team", "infra"),
+			expr:       `job:up:sum{team="infra"}`,
+			matches:    true,
+		},
+		{
+			name:       "incompatible static label",
+			ruleName:   "job:up:sum",
+			ruleLabels: labels.FromStrings("team", "infra"),
+			expr:       `job:up:sum{team="backend"}`,
+			matches:    false,
+		},
+		{
+			name:     "matcher on label absent from static labels is conservatively matched",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job="prometheus"}`,
+			matches:  true,
+		},
+		{
+			name:     "scalar expression has no selectors",
+			ruleName: "job:up:sum",
+			expr:     "vector(1)",
+			matches:  false,
+		},
+		{
+			name:     "ALERTS selector does not cover a recording rule",
+			ruleName: "job:up:sum",
+			expr:     `ALERTS{alertname="job:up:sum"}`,
+			matches:  false,
+		},
+		{
+			// PromQL combines repeated matchers on a label with AND, so the
+			// negative matcher excludes the metric the regex would have selected.
+			name:     "repeated __name__ matchers are combined with AND",
+			ruleName: "job:up:sum",
+			expr:     `{__name__=~"job:up:sum|other",__name__!="job:up:sum"}`,
+			matches:  false,
+		},
+		{
+			name:     "repeated __name__ matchers that all accept the rule match",
+			ruleName: "job:up:sum",
+			expr:     `{__name__=~"job:up:sum|other",__name__!="other"}`,
+			matches:  true,
+		},
+		{
+			// alertname is an ordinary label on a recording rule's output, not a
+			// label the engine generates, so it must be compared like any other.
+			name:       "incompatible static alertname label",
+			ruleName:   "foo",
+			ruleLabels: labels.FromStrings("alertname", "Bar"),
+			expr:       `foo{alertname="Baz"}`,
+			matches:    false,
+		},
+		{
+			name:       "compatible static alertname label",
+			ruleName:   "foo",
+			ruleLabels: labels.FromStrings("alertname", "Bar"),
+			expr:       `foo{alertname="Bar"}`,
+			matches:    true,
+		},
+		{
+			// The value of job comes from the input series and is unknown here,
+			// but no series can carry two different values for it at once.
+			name:     "self-contradictory matchers on a dynamic label",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job="a",job="b"}`,
+			matches:  false,
+		},
+		{
+			name:     "equality and negation of the same value on a dynamic label",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job="a",job!="a"}`,
+			matches:  false,
+		},
+		{
+			name:     "consistent repeated matchers on a dynamic label",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job="a",job=~"a|b"}`,
+			matches:  true,
+		},
+		{
+			// The regexps pin job to "a" and then exclude it, so no series can
+			// satisfy both and the assertion can never observe the rule.
+			name:     "contradictory regexp matchers on a dynamic label",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"a",job!~"a"}`,
+			matches:  false,
+		},
+		{
+			name:     "disjoint regexp matchers on a dynamic label",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"a",job=~"b"}`,
+			matches:  false,
+		},
+		{
+			// Prometheus regexps are fully anchored, so ".*" accepts every value
+			// and its negation accepts none.
+			name:     "negated total regexp on a dynamic label",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job!~".*"}`,
+			matches:  false,
+		},
+		{
+			name:     "regexp alternation with one surviving alternative",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"a|b",job!~"b"}`,
+			matches:  true,
+		},
+		{
+			// An unbounded regexp accepts infinitely many values, so it stays
+			// compatible rather than being rejected for want of a witness.
+			name:     "unbounded regexp on a dynamic label",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"xyz.*"}`,
+			matches:  true,
+		},
+		{
+			name:     "negated equality on a dynamic label leaves other values",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job!="a"}`,
+			matches:  true,
+		},
+		{
+			// The same expression cannot be both required and excluded.
+			name:     "identical unbounded regexp required and excluded",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"a.*",job!~"a.*"}`,
+			matches:  false,
+		},
+		{
+			// No value can start with both "a" and "b".
+			name:     "disjoint unbounded regexps",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"a.*",job=~"b.*"}`,
+			matches:  false,
+		},
+		{
+			name:     "total regexp required and excluded",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~".*",job!~".*"}`,
+			matches:  false,
+		},
+		{
+			// One prefix continues the other, so "ab" satisfies both.
+			name:     "nested unbounded regexp prefixes",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"a.*",job=~"ab.*"}`,
+			matches:  true,
+		},
+		{
+			// A regexp with no literal prefix is still satisfiable, by "foo".
+			name:     "unbounded regexp without a literal prefix",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~".*foo"}`,
+			matches:  true,
+		},
+		{
+			name:     "alternation followed by an unbounded regexp",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"(staging|prod)-.*"}`,
+			matches:  true,
+		},
+		{
+			name:     "character class regexp",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"[a-z]+"}`,
+			matches:  true,
+		},
+		{
+			// "a" satisfies both: it matches a.* and does not match ab.*.
+			name:     "unbounded regexps that only look contradictory",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"a.*",job!~"ab.*"}`,
+			matches:  true,
+		},
+		{
+			// The shortest value a.* allows is excluded, but "aa" is not.
+			name:     "unbounded regexp with its shortest value excluded",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"a.*",job!="a"}`,
+			matches:  true,
+		},
+		{
+			// The first alternation branch is excluded, the second is not.
+			name:     "alternation branch excluded by a later matcher",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"(staging|prod)-.*",job!~"staging-.*"}`,
+			matches:  true,
+		},
+		{
+			// "b" satisfies both, but only if the class is not read as "a" alone.
+			name:     "character class member excluded by a later matcher",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"[ab]+",job!~"a+"}`,
+			matches:  true,
+		},
+		{
+			// Needs one optional taken and the other left out.
+			name:     "independent optional branches",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"x?y?",job!~"|xy"}`,
+			matches:  true,
+		},
+		{
+			// A negated alternation of literals rules out exactly those values,
+			// which happen to be every fixed probe.
+			name:     "negated alternation excluding every probe",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job!~"|a|A|0|-|aa"}`,
+			matches:  true,
+		},
+		{
+			// \B holds between two word characters, so this matches "foobar".
+			// It used to be treated as an impossible expression.
+			name:     "non-word-boundary assertion",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"foo\\Bbar"}`,
+			matches:  true,
+		},
+		{
+			// \b cannot hold between "o" and "b", so nothing matches this.
+			name:     "word-boundary assertion that cannot hold",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"foo\\bbar"}`,
+			matches:  false,
+		},
+		{
+			// Label regexps are parsed dot-all, so "." accepts a newline and the
+			// negated class does not.
+			name:     "newline is a valid label value",
+			ruleName: "job:up:sum",
+			expr:     "job:up:sum{job=~\".\",job!~\"[^\\n]\"}",
+			matches:  true,
+		},
+		{
+			// Every fixed probe is excluded, but "aa" still satisfies the set.
+			name:     "negative equalities excluding every probe",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job!="",job!="a",job!="A",job!="0",job!="-"}`,
+			matches:  true,
+		},
+		{
+			// One negative regexp excludes every probe and another the values
+			// built to step outside it, but "b" satisfies both.
+			name:     "negative regexps excluding the probes and one fresh family",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job!~"|a|A|0|-",job!~"coverage-witness-.*"}`,
+			matches:  true,
+		},
+		{
+			// The one- and two-fold values are excluded, so the search has to
+			// build a longer one.
+			name:     "repetition with its shortest values excluded",
+			ruleName: "job:up:sum",
+			expr:     `job:up:sum{job=~"a+",job!~"a|aa"}`,
+			matches:  true,
+		},
+		{
+			// A recording rule's labels are used verbatim, so template syntax in a
+			// value is a literal string rather than something expanded later.
+			name:       "template syntax in a recording rule label is literal",
+			ruleName:   "foo",
+			ruleLabels: labels.FromStrings("cluster", "{{ $externalLabels.cluster }}"),
+			expr:       `foo{cluster="prod"}`,
+			matches:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ruleLabels := tc.ruleLabels
+			if ruleLabels.IsEmpty() {
+				ruleLabels = labels.EmptyLabels()
+			}
+			require.Equal(t, tc.matches, anySelectorMatches(t, p, tc.expr, func(ms []*labels.Matcher) bool {
+				return selectorCoversRecordingRule(tc.ruleName, ruleLabels, compileSelector(ms)) == satisfiable
+			}))
+		})
+	}
+}
+
+func TestSelectorCoversAlertingRule(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	tests := []struct {
+		name string
+		// holdDuration is the rule's "for"; zero unless the case is about the
+		// alert states a selector can observe.
+		holdDuration time.Duration
+		alertName    string
+		ruleLabels   labels.Labels
+		expr         string
+		matches      bool
+	}{
+		{
+			name:       "ALERTS with matching alertname",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `count(ALERTS{alertname="InstanceDown"})`,
+			matches:    true,
+		},
+		{
+			name:       "ALERTS_FOR_STATE with matching alertname",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `ALERTS_FOR_STATE{alertname="InstanceDown"}`,
+			matches:    true,
+		},
+		{
+			name:       "ALERTS with wrong alertname",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `count(ALERTS{alertname="OtherAlert"})`,
+			matches:    false,
+		},
+		{
+			name:       "ALERTS without alertname is indeterminate",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `count(ALERTS)`,
+			matches:    false,
+		},
+		{
+			name:       "ALERTS with compatible static label",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("severity", "page"),
+			expr:       `ALERTS{alertname="InstanceDown", severity="page"}`,
+			matches:    true,
+		},
+		{
+			name:       "ALERTS with incompatible static label",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("severity", "page"),
+			expr:       `ALERTS{alertname="InstanceDown", severity="critical"}`,
+			matches:    false,
+		},
+		{
+			name:       "direct alert name does not cover an alerting rule",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `InstanceDown`,
+			matches:    false,
+		},
+		{
+			name:       "recording-style selector does not cover an alerting rule",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `job:up:sum`,
+			matches:    false,
+		},
+		{
+			// PromQL combines repeated matchers on a label with AND, so this
+			// selector can never select the InstanceDown alert.
+			name:       "repeated alertname matchers are combined with AND",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `ALERTS{alertname=~"InstanceDown|Other",alertname!="InstanceDown"}`,
+			matches:    false,
+		},
+		{
+			name:       "repeated alertname matchers that all accept the rule match",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `ALERTS{alertname=~"InstanceDown|Other",alertname!="Other"}`,
+			matches:    true,
+		},
+		{
+			name:       "repeated __name__ matchers exclude both meta-metrics",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `{__name__=~"ALERTS.*",__name__!="ALERTS",__name__!="ALERTS_FOR_STATE",alertname="InstanceDown"}`,
+			matches:    false,
+		},
+		{
+			// The engine sets alertstate on every ALERTS series, and an alert is
+			// only sampled while it is pending or firing.
+			name:       "impossible alertstate value",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `ALERTS{alertname="InstanceDown",alertstate="bogus"}`,
+			matches:    false,
+		},
+		{
+			name:       "firing alertstate value",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `ALERTS{alertname="InstanceDown",alertstate="firing"}`,
+			matches:    true,
+		},
+		{
+			// An alert is only observable as pending while it is held down.
+			name:         "pending alertstate value with a hold duration",
+			holdDuration: 5 * time.Minute,
+			alertName:    "InstanceDown",
+			ruleLabels:   labels.EmptyLabels(),
+			expr:         `ALERTS{alertname="InstanceDown",alertstate="pending"}`,
+			matches:      true,
+		},
+		{
+			// Without "for" the alert is promoted to firing before the first
+			// sample, so it never appears as pending.
+			name:       "pending alertstate value without a hold duration",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `ALERTS{alertname="InstanceDown",alertstate="pending"}`,
+			matches:    false,
+		},
+		{
+			name:         "firing alertstate value with a hold duration",
+			holdDuration: 5 * time.Minute,
+			alertName:    "InstanceDown",
+			ruleLabels:   labels.EmptyLabels(),
+			expr:         `ALERTS{alertname="InstanceDown",alertstate="firing"}`,
+			matches:      true,
+		},
+		{
+			// ALERTS_FOR_STATE carries no generated alertstate, so the hold
+			// duration does not constrain it.
+			name:       "ALERTS_FOR_STATE is unaffected by the hold duration",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `ALERTS_FOR_STATE{alertname="InstanceDown"}`,
+			matches:    true,
+		},
+		{
+			// A static alertstate label cannot survive on an ALERTS series because
+			// the engine overwrites it, but ALERTS_FOR_STATE carries no generated
+			// alertstate, so there it is an ordinary label.
+			name:       "ALERTS_FOR_STATE treats alertstate as an ordinary label",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("alertstate", "custom"),
+			expr:       `ALERTS_FOR_STATE{alertname="InstanceDown",alertstate="custom"}`,
+			matches:    true,
+		},
+		{
+			name:       "ALERTS ignores a static alertstate label the engine overwrites",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("alertstate", "custom"),
+			expr:       `ALERTS{alertname="InstanceDown",alertstate="firing"}`,
+			matches:    true,
+		},
+		{
+			// The engine applies the rule's own labels last, so an empty value
+			// deletes the label from the output and nothing can be non-empty.
+			name:       "non-empty matcher against an empty static label",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("dynamic", "{{ $value }}", "fixed", ""),
+			expr:       `ALERTS{alertname="InstanceDown",fixed!=""}`,
+			matches:    false,
+		},
+		{
+			// The same value the rule produces, expressed as a negated regexp.
+			name:       "negated regexp that accepts the empty static label",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("dynamic", "{{ $value }}", "fixed", ""),
+			expr:       `ALERTS{alertname="InstanceDown",fixed!~".+"}`,
+			matches:    true,
+		},
+		{
+			// A label the rule sets to the empty string still constrains the
+			// selector, including when another label is templated. Rewriting the
+			// label set to strip templates used to drop this one as well.
+			name:       "empty static label alongside a templated one",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("severity", "", "cluster", "{{ $externalLabels.cluster }}"),
+			expr:       `ALERTS{alertname="InstanceDown",severity="page"}`,
+			matches:    false,
+		},
+		{
+			name:       "empty static label on its own",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("severity", ""),
+			expr:       `ALERTS{alertname="InstanceDown",severity="page"}`,
+			matches:    false,
+		},
+		{
+			// Matching the empty value is what the rule actually produces.
+			name:       "selector asking for the empty value",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("severity", "", "cluster", "{{ $externalLabels.cluster }}"),
+			expr:       `ALERTS{alertname="InstanceDown",severity=""}`,
+			matches:    true,
+		},
+		{
+			// Alert labels are expanded per alert instance, so the literal value
+			// says nothing about what the series will carry.
+			name:       "templated alert label is not compared literally",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("cluster", "{{ $externalLabels.cluster }}"),
+			expr:       `ALERTS{alertname="InstanceDown",cluster="prod"}`,
+			matches:    true,
+		},
+		{
+			name:       "non-templated labels are still compared when another label is templated",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("cluster", "{{ $externalLabels.cluster }}", "severity", "page"),
+			expr:       `ALERTS{alertname="InstanceDown",cluster="prod",severity="critical"}`,
+			matches:    false,
+		},
+		{
+			name:       "self-contradictory matchers on a dynamic label",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `ALERTS{alertname="InstanceDown",instance="a",instance="b"}`,
+			matches:    false,
+		},
+		{
+			name:       "contradictory regexp matchers on a dynamic label",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `ALERTS{alertname="InstanceDown",instance=~"a",instance!~"a"}`,
+			matches:    false,
+		},
+		{
+			name:       "negated total regexp on a dynamic label",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `ALERTS_FOR_STATE{alertname="InstanceDown",instance!~".*"}`,
+			matches:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.matches, anySelectorMatches(t, p, tc.expr, func(ms []*labels.Matcher) bool {
+				return selectorCoversAlertingRule(tc.alertName, tc.holdDuration, tc.ruleLabels, compileSelector(ms)) == satisfiable
+			}))
+		})
+	}
+}
+
+// testRegexpCandidates runs the candidate walk with a generous budget, so tests
+// exercise the search rather than the budget.
+func testRegexpCandidates(expr string) []string {
+	candidates, _ := regexpCandidates(expr, candidateByteBudget)
+	return candidates
+}

--- a/cmd/promtool/testdata/coverage_broken_rules.yml
+++ b/cmd/promtool/testdata/coverage_broken_rules.yml
@@ -1,0 +1,6 @@
+# Deliberately unparseable: the expression is not valid PromQL.
+groups:
+  - name: broken
+    rules:
+      - record: broken_metric
+        expr: "("

--- a/cmd/promtool/testdata/coverage_broken_run_test.yml
+++ b/cmd/promtool/testdata/coverage_broken_run_test.yml
@@ -1,0 +1,13 @@
+# Has a test group, so the broken rule file is only skipped when --run selects no
+# group. Coverage must still refuse to report the suite as fully covered.
+rule_files:
+  - coverage_broken_rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - name: unselected
+    interval: 1m
+    input_series:
+      - series: 'up{job="prometheus"}'
+        values: "1x5"

--- a/cmd/promtool/testdata/coverage_broken_test.yml
+++ b/cmd/promtool/testdata/coverage_broken_test.yml
@@ -1,0 +1,6 @@
+# Declares no test groups, so nothing else loads the broken rule file. Coverage
+# must not silently report 0/0 as fully covered.
+rule_files:
+  - coverage_broken_rules.yml
+
+tests: []

--- a/cmd/promtool/testdata/coverage_dupname_rules.yml
+++ b/cmd/promtool/testdata/coverage_dupname_rules.yml
@@ -1,0 +1,19 @@
+# Two groups define rules that share a name. The alerting rules are identical in
+# name; the recording rules share a name but carry distinguishing static labels.
+groups:
+  - name: groupA
+    rules:
+      - alert: SameName
+        expr: up == 0
+      - record: dup:metric
+        expr: up
+        labels:
+          tier: a
+  - name: groupB
+    rules:
+      - alert: SameName
+        expr: up == 2
+      - record: dup:metric
+        expr: up
+        labels:
+          tier: b

--- a/cmd/promtool/testdata/coverage_dupname_test.yml
+++ b/cmd/promtool/testdata/coverage_dupname_test.yml
@@ -1,0 +1,23 @@
+# Asserts on the SameName alert once (covers both same-named alerting rules,
+# which promtool evaluates together) and on dup:metric scoped to tier="a" (covers
+# only groupA's recording rule, not groupB's).
+rule_files:
+  - coverage_dupname_rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'up{job="prometheus"}'
+        values: "1x5"
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: SameName
+        exp_alerts: []
+    promql_expr_test:
+      - expr: dup:metric{tier="a"}
+        eval_time: 1m
+        exp_samples:
+          - value: 1
+            labels: 'dup:metric{job="prometheus",tier="a"}'

--- a/cmd/promtool/testdata/coverage_emptylabel_rules.yml
+++ b/cmd/promtool/testdata/coverage_emptylabel_rules.yml
@@ -1,0 +1,11 @@
+# severity is set to the empty string, and cluster is templated. The empty value
+# is still a value the rule always produces, so a selector asking for anything
+# else can never observe this rule.
+groups:
+  - name: g
+    rules:
+      - alert: EmptyLabel
+        expr: vector(1)
+        labels:
+          severity: ""
+          cluster: '{{ $externalLabels.cluster }}'

--- a/cmd/promtool/testdata/coverage_emptylabel_test.yml
+++ b/cmd/promtool/testdata/coverage_emptylabel_test.yml
@@ -1,0 +1,10 @@
+rule_files:
+  - coverage_emptylabel_rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - promql_expr_test:
+      - expr: 'ALERTS{alertname="EmptyLabel",severity="page"}'
+        eval_time: 0m
+        exp_samples: []

--- a/cmd/promtool/testdata/coverage_missing_rules.yml
+++ b/cmd/promtool/testdata/coverage_missing_rules.yml
@@ -1,0 +1,7 @@
+# Referenced alongside a missing rule file, to check that a partially resolved
+# rule_files list cannot satisfy a coverage threshold.
+groups:
+  - name: g
+    rules:
+      - record: covered:metric
+        expr: vector(1)

--- a/cmd/promtool/testdata/coverage_missing_test.yml
+++ b/cmd/promtool/testdata/coverage_missing_test.yml
@@ -1,0 +1,15 @@
+# The second entry matches no file. The first is fully covered, so the totals
+# look complete unless the unmatched pattern is tracked.
+rule_files:
+  - coverage_missing_rules.yml
+  - coverage_no_such_file.yml
+
+evaluation_interval: 1m
+
+tests:
+  - promql_expr_test:
+      - expr: covered:metric
+        eval_time: 0m
+        exp_samples:
+          - labels: covered:metric
+            value: 1

--- a/cmd/promtool/testdata/coverage_multidoc_rules.yml
+++ b/cmd/promtool/testdata/coverage_multidoc_rules.yml
@@ -1,0 +1,9 @@
+# A rule file with a second YAML document. The rule loader warns about it, which
+# used to panic the coverage loader through its nil logger.
+groups:
+  - name: multidoc
+    rules:
+      - record: multidoc:metric
+        expr: vector(1)
+---
+groups: []

--- a/cmd/promtool/testdata/coverage_multidoc_test.yml
+++ b/cmd/promtool/testdata/coverage_multidoc_test.yml
@@ -1,0 +1,5 @@
+# Has no test groups, so only the coverage loader reads the rule file.
+rule_files:
+  - coverage_multidoc_rules.yml
+
+tests: []

--- a/cmd/promtool/testdata/coverage_nofor_rules.yml
+++ b/cmd/promtool/testdata/coverage_nofor_rules.yml
@@ -1,0 +1,7 @@
+# An alert with no "for" is promoted to firing before its first sample, so it can
+# never be observed as pending.
+groups:
+  - name: g
+    rules:
+      - alert: NoFor
+        expr: vector(1)

--- a/cmd/promtool/testdata/coverage_nofor_test.yml
+++ b/cmd/promtool/testdata/coverage_nofor_test.yml
@@ -1,0 +1,13 @@
+# The assertion can never observe NoFor, so it must not count as coverage. It
+# passes as a test, because the selector genuinely returns nothing.
+rule_files:
+  - coverage_nofor_rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - name: impossible-pending
+    promql_expr_test:
+      - expr: 'ALERTS{alertname="NoFor",alertstate="pending"}'
+        eval_time: 0m
+        exp_samples: []

--- a/cmd/promtool/testdata/coverage_norules_rules.yml
+++ b/cmd/promtool/testdata/coverage_norules_rules.yml
@@ -1,0 +1,2 @@
+# A valid rule file that declares no rules at all.
+groups: []

--- a/cmd/promtool/testdata/coverage_norules_test.yml
+++ b/cmd/promtool/testdata/coverage_norules_test.yml
@@ -1,0 +1,4 @@
+rule_files:
+  - coverage_norules_rules.yml
+
+tests: []

--- a/cmd/promtool/testdata/coverage_ordinal_partial_rules.yml
+++ b/cmd/promtool/testdata/coverage_ordinal_partial_rules.yml
@@ -1,0 +1,10 @@
+# Two declarations that differ only in "for". A selector on the pending state can
+# only observe the second one, so the report has to say which is untested.
+groups:
+  - name: partial
+    rules:
+      - alert: Twin
+        expr: up == 0
+      - alert: Twin
+        expr: up == 0
+        for: 5m

--- a/cmd/promtool/testdata/coverage_ordinal_partial_test.yml
+++ b/cmd/promtool/testdata/coverage_ordinal_partial_test.yml
@@ -1,0 +1,15 @@
+rule_files:
+  - coverage_ordinal_partial_rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - input_series:
+      - series: 'up{job="prometheus"}'
+        values: "0x5"
+    promql_expr_test:
+      - expr: 'ALERTS{alertname="Twin",alertstate="pending"}'
+        eval_time: 1m
+        exp_samples:
+          - labels: 'ALERTS{alertname="Twin",alertstate="pending",job="prometheus"}'
+            value: 1

--- a/cmd/promtool/testdata/coverage_ordinal_rules.yml
+++ b/cmd/promtool/testdata/coverage_ordinal_rules.yml
@@ -1,0 +1,15 @@
+# Two declarations in the same group that share a name, expression and labels and
+# differ only in "for". They are two distinct rules and must be counted twice.
+groups:
+  - name: ordinal
+    rules:
+      - alert: Twin
+        expr: up == 0
+        for: 5m
+        labels:
+          severity: page
+      - alert: Twin
+        expr: up == 0
+        for: 30m
+        labels:
+          severity: page

--- a/cmd/promtool/testdata/coverage_ordinal_test.yml
+++ b/cmd/promtool/testdata/coverage_ordinal_test.yml
@@ -1,0 +1,5 @@
+# Exercises neither declaration, so both must be counted and listed as untested.
+rule_files:
+  - coverage_ordinal_rules.yml
+
+tests: []

--- a/cmd/promtool/testdata/coverage_paths/a/rules.yml
+++ b/cmd/promtool/testdata/coverage_paths/a/rules.yml
@@ -1,0 +1,5 @@
+groups:
+  - name: samegroup
+    rules:
+      - record: same:metric
+        expr: up

--- a/cmd/promtool/testdata/coverage_paths/b/rules.yml
+++ b/cmd/promtool/testdata/coverage_paths/b/rules.yml
@@ -1,0 +1,5 @@
+groups:
+  - name: samegroup
+    rules:
+      - record: same:metric
+        expr: up

--- a/cmd/promtool/testdata/coverage_paths_test.yml
+++ b/cmd/promtool/testdata/coverage_paths_test.yml
@@ -1,0 +1,7 @@
+# Two rule files that share a base name, group name and rule name. Coverage must
+# count them separately and report them with distinguishable paths.
+rule_files:
+  - coverage_paths/a/rules.yml
+  - coverage_paths/b/rules.yml
+
+tests: []

--- a/cmd/promtool/testdata/coverage_rules.yml
+++ b/cmd/promtool/testdata/coverage_rules.yml
@@ -1,0 +1,22 @@
+groups:
+  - name: alerts
+    rules:
+      - alert: InstanceDown
+        expr: up == 0
+        for: 5m
+        labels:
+          severity: page
+      - alert: AlwaysFiring
+        expr: 1
+      - alert: NeverTested
+        expr: up == 0
+        for: 10m
+        labels:
+          severity: warning
+
+  - name: recording
+    rules:
+      - record: job:up:sum
+        expr: sum by (job)(up)
+      - record: job:up:avg
+        expr: avg by (job)(up)

--- a/cmd/promtool/testdata/coverage_shared_a_test.yml
+++ b/cmd/promtool/testdata/coverage_shared_a_test.yml
@@ -1,0 +1,17 @@
+# Tests the shared recording rule only:metric.
+rule_files:
+  - coverage_shared_rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'up{job="prometheus"}'
+        values: "1x5"
+    promql_expr_test:
+      - expr: only:metric
+        eval_time: 1m
+        exp_samples:
+          - value: 1
+            labels: 'only:metric{job="prometheus"}'

--- a/cmd/promtool/testdata/coverage_shared_b_test.yml
+++ b/cmd/promtool/testdata/coverage_shared_b_test.yml
@@ -1,0 +1,18 @@
+# References the same shared rule file as coverage_shared_a_test.yml but does
+# not test only:metric. The rule must still be counted once for the suite.
+rule_files:
+  - coverage_shared_rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'up{job="prometheus"}'
+        values: "1x5"
+    promql_expr_test:
+      - expr: up
+        eval_time: 1m
+        exp_samples:
+          - value: 1
+            labels: 'up{job="prometheus"}'

--- a/cmd/promtool/testdata/coverage_shared_rules.yml
+++ b/cmd/promtool/testdata/coverage_shared_rules.yml
@@ -1,0 +1,7 @@
+# Shared rule file referenced by two test files, to exercise coverage
+# de-duplication across a suite (see TestRuleCoverageDeduplicatesAcrossFiles).
+groups:
+  - name: shared
+    rules:
+      - record: only:metric
+        expr: up

--- a/cmd/promtool/testdata/coverage_test.yml
+++ b/cmd/promtool/testdata/coverage_test.yml
@@ -1,0 +1,34 @@
+rule_files:
+  - coverage_rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'up{job="prometheus", instance="localhost:9090"}'
+        values: "0+0x1440"
+
+    # Tests for alerting rules: covers InstanceDown and AlwaysFiring.
+    # NeverTested is intentionally NOT tested.
+    alert_rule_test:
+      - eval_time: 1d
+        alertname: AlwaysFiring
+        exp_alerts:
+          - {}
+      - eval_time: 1d
+        alertname: InstanceDown
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              instance: localhost:9090
+              job: prometheus
+
+    # Tests for recording rules: covers job:up:sum.
+    # job:up:avg is intentionally NOT tested.
+    promql_expr_test:
+      - expr: job:up:sum
+        eval_time: 1m
+        exp_samples:
+          - value: 0
+            labels: 'job:up:sum{job="prometheus"}'

--- a/cmd/promtool/testdata/coverage_twothirds_rules.yml
+++ b/cmd/promtool/testdata/coverage_twothirds_rules.yml
@@ -1,0 +1,11 @@
+# Three recording rules of which two are tested, yielding 2/3 (66.7%) coverage,
+# used to exercise the coverage-threshold rounding behaviour.
+groups:
+  - name: g
+    rules:
+      - record: a:metric
+        expr: up
+      - record: b:metric
+        expr: up
+      - record: c:metric
+        expr: up

--- a/cmd/promtool/testdata/coverage_twothirds_test.yml
+++ b/cmd/promtool/testdata/coverage_twothirds_test.yml
@@ -1,0 +1,21 @@
+rule_files:
+  - coverage_twothirds_rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'up{job="prometheus"}'
+        values: "1x5"
+    promql_expr_test:
+      - expr: a:metric
+        eval_time: 1m
+        exp_samples:
+          - value: 1
+            labels: 'a:metric{job="prometheus"}'
+      - expr: b:metric
+        eval_time: 1m
+        exp_samples:
+          - value: 1
+            labels: 'b:metric{job="prometheus"}'

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -48,10 +48,19 @@ import (
 // RulesUnitTest does unit testing of rules based on the unit testing files provided.
 // More info about the file format can be found in the docs.
 func RulesUnitTest(queryOpts promqltest.LazyLoaderOpts, p parser.Parser, runStrings []string, diffFlag, debug, ignoreUnknownFields bool, files ...string) int {
-	return RulesUnitTestResult(io.Discard, queryOpts, p, runStrings, diffFlag, debug, ignoreUnknownFields, files...)
+	return RulesUnitTestResult(io.Discard, queryOpts, p, runStrings, diffFlag, debug, ignoreUnknownFields, false, 0, files...)
 }
 
-func RulesUnitTestResult(results io.Writer, queryOpts promqltest.LazyLoaderOpts, p parser.Parser, runStrings []string, diffFlag, debug, ignoreUnknownFields bool, files ...string) int {
+// RulesUnitTestResult runs unit tests for rules and writes JUnit XML results to the
+// provided writer. If coverage is true, it reports to stderr which rules are
+// exercised by the test assertions. If coverageThreshold is greater than zero, it
+// also enables coverage reporting and returns a non-zero exit code when the total
+// coverage percentage is below the threshold.
+func RulesUnitTestResult(results io.Writer, queryOpts promqltest.LazyLoaderOpts, p parser.Parser, runStrings []string, diffFlag, debug, ignoreUnknownFields, coverage bool, coverageThreshold float64, files ...string) int {
+	if coverageThreshold < 0 || coverageThreshold > 100 {
+		fmt.Fprintf(os.Stderr, "invalid --coverage-threshold %.1f: must be between 0 and 100\n", coverageThreshold)
+		return failureExitCode
+	}
 	failed := false
 	junit := &junitxml.JUnitXML{}
 
@@ -60,8 +69,13 @@ func RulesUnitTestResult(results io.Writer, queryOpts promqltest.LazyLoaderOpts,
 		run = regexp.MustCompile(strings.Join(runStrings, "|"))
 	}
 
+	var cov *ruleCoverage
+	if coverage || coverageThreshold > 0 {
+		cov = newRuleCoverage()
+	}
+
 	for _, f := range files {
-		if errs := ruleUnitTest(f, queryOpts, p, run, diffFlag, debug, ignoreUnknownFields, junit.Suite(f)); errs != nil {
+		if errs := ruleUnitTest(f, queryOpts, p, run, diffFlag, debug, ignoreUnknownFields, junit.Suite(f), cov); errs != nil {
 			fmt.Fprintln(os.Stderr, "  FAILED:")
 			for _, e := range errs {
 				fmt.Fprintln(os.Stderr, e.Error())
@@ -77,13 +91,20 @@ func RulesUnitTestResult(results io.Writer, queryOpts promqltest.LazyLoaderOpts,
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to write JUnit XML: %s\n", err)
 	}
+	if cov != nil {
+		pct := cov.report(os.Stderr)
+		if belowThreshold(pct, coverageThreshold) {
+			fmt.Fprintf(os.Stderr, "Rule test coverage %.1f%% is below the threshold of %.1f%%.\n", pct, coverageThreshold)
+			failed = true
+		}
+	}
 	if failed {
 		return failureExitCode
 	}
 	return successExitCode
 }
 
-func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, p parser.Parser, run *regexp.Regexp, diffFlag, debug, ignoreUnknownFields bool, ts *junitxml.TestSuite) []error {
+func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, p parser.Parser, run *regexp.Regexp, diffFlag, debug, ignoreUnknownFields bool, ts *junitxml.TestSuite, cov *ruleCoverage) []error {
 	b, err := os.ReadFile(filename)
 	if err != nil {
 		ts.Abort(err)
@@ -102,6 +123,12 @@ func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, p parser
 
 	if unitTestInp.EvaluationInterval == 0 {
 		unitTestInp.EvaluationInterval = model.Duration(1 * time.Minute)
+	}
+
+	// Record rule coverage for the suite before running the tests, so rules in
+	// files whose tests fail (or that have no tests at all) are still counted.
+	if cov != nil {
+		cov.record(p, run, ignoreUnknownFields, &unitTestInp)
 	}
 
 	evalInterval := time.Duration(unitTestInp.EvaluationInterval)
@@ -735,4 +762,322 @@ func (ps *parsedSample) String() string {
 		return ps.Labels.String() + " " + ps.Histogram
 	}
 	return ps.Labels.String() + " " + strconv.FormatFloat(ps.Value, 'E', -1, 64)
+}
+
+// ruleKind identifies whether a rule is an alerting or a recording rule, used
+// for coverage reporting.
+type ruleKind uint8
+
+const (
+	alertingRule ruleKind = iota
+	recordingRule
+)
+
+// String returns the rule kind as it appears in rule files, "alert" or "record".
+func (k ruleKind) String() string {
+	if k == alertingRule {
+		return "alert"
+	}
+	return "record"
+}
+
+// Meta-metric names emitted by alerting rules. A promql_expr_test selecting one
+// of these with an "alertname" matcher exercises the corresponding alerting rule.
+const (
+	alertsMetricName         = "ALERTS"
+	alertsForStateMetricName = "ALERTS_FOR_STATE"
+)
+
+// ruleCoverageKey uniquely identifies a rule within a test suite. Keying on
+// file, group, name, kind, labels and query ensures that the same physical rule
+// referenced by multiple test files is counted exactly once, while distinct
+// rules that merely share a name (in different groups, or with different labels
+// or expressions) are counted separately.
+type ruleCoverageKey struct {
+	file   string
+	group  string
+	name   string
+	labels string
+	query  string
+	kind   ruleKind
+}
+
+// ruleCoverage tracks which rules of a test suite are exercised by unit test
+// assertions. It is populated from the output of rules.Manager.LoadGroups so it
+// stays consistent with how Prometheus itself loads rules.
+type ruleCoverage struct {
+	order   []ruleCoverageKey
+	covered map[ruleCoverageKey]bool
+}
+
+func newRuleCoverage() *ruleCoverage {
+	return &ruleCoverage{covered: map[ruleCoverageKey]bool{}}
+}
+
+// register records a rule so that it is counted towards the coverage total. It
+// is idempotent: registering the same rule again returns the existing key and
+// preserves its covered state.
+func (c *ruleCoverage) register(g *rules.Group, r rules.Rule, kind ruleKind) ruleCoverageKey {
+	// Canonicalize the file path so the same physical rule file reached through
+	// different relative paths from different test files is counted once.
+	file := g.File()
+	if abs, err := filepath.Abs(file); err == nil {
+		file = abs
+	}
+	k := ruleCoverageKey{
+		file:   file,
+		group:  g.Name(),
+		name:   r.Name(),
+		labels: r.Labels().String(),
+		query:  r.Query().String(),
+		kind:   kind,
+	}
+	if _, ok := c.covered[k]; !ok {
+		c.order = append(c.order, k)
+		c.covered[k] = false
+	}
+	return k
+}
+
+// mark flags the rule identified by k as covered by a test assertion.
+func (c *ruleCoverage) mark(k ruleCoverageKey) {
+	c.covered[k] = true
+}
+
+// record loads the rule files referenced by a single unit test file through
+// rules.Manager.LoadGroups, registers every alerting and recording rule, and
+// marks those exercised by the file's test assertions as covered. Because rules
+// are attributed via their loaded group rather than by bare name, coverage is
+// counted precisely across files and groups. Only test groups selected by run
+// contribute coverage, so the report reflects what this invocation actually ran.
+func (c *ruleCoverage) record(p parser.Parser, run *regexp.Regexp, ignoreUnknownFields bool, utf *unitTestFile) {
+	// Collect the alert names and PromQL selectors asserted by the test groups
+	// that will actually run.
+	testedAlertnames := map[string]struct{}{}
+	var exprSelectors [][]*labels.Matcher
+	for i := range utf.Tests {
+		tg := &utf.Tests[i]
+		if !matchesRun(tg.TestGroupName, run) {
+			continue
+		}
+		for _, a := range tg.AlertRuleTests {
+			testedAlertnames[a.Alertname] = struct{}{}
+		}
+		for _, tc := range tg.PromqlExprTests {
+			expr, err := p.ParseExpr(tc.Expr)
+			if err != nil {
+				continue
+			}
+			exprSelectors = append(exprSelectors, parser.ExtractSelectors(expr)...)
+		}
+	}
+
+	// Load each rule file independently so that one unparseable file does not
+	// drop the rules of its valid siblings from the coverage total. Files that
+	// fail to load are reported by the test run itself.
+	m := rules.NewManager(&rules.ManagerOptions{Parser: p})
+	for _, rf := range utf.RuleFiles {
+		groupsMap, errs := m.LoadGroups(time.Duration(utf.EvaluationInterval), labels.EmptyLabels(), "", nil, ignoreUnknownFields, rf)
+		if len(errs) > 0 {
+			continue
+		}
+		for _, g := range groupsMap {
+			for _, r := range g.Rules() {
+				switch rule := r.(type) {
+				case *rules.AlertingRule:
+					k := c.register(g, rule, alertingRule)
+					// An alerting rule is covered by an alert_rule_test naming its
+					// alertname, or by a promql_expr_test selecting its ALERTS series.
+					if _, ok := testedAlertnames[rule.Name()]; ok {
+						c.mark(k)
+						continue
+					}
+					for _, matchers := range exprSelectors {
+						if selectorCoversAlertingRule(rule.Name(), rule.Labels(), matchers) {
+							c.mark(k)
+							break
+						}
+					}
+				case *rules.RecordingRule:
+					k := c.register(g, rule, recordingRule)
+					for _, matchers := range exprSelectors {
+						if selectorCoversRecordingRule(rule, matchers) {
+							c.mark(k)
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// metricNameMatcher returns the matcher on the __name__ label from a selector,
+// or nil for a wildcard selector that has no __name__ matcher.
+func metricNameMatcher(matchers []*labels.Matcher) *labels.Matcher {
+	for _, m := range matchers {
+		if m.Name == labels.MetricName {
+			return m
+		}
+	}
+	return nil
+}
+
+// selectorCoversRecordingRule reports whether a promql_expr_test selector reads
+// the output of the given recording rule: its __name__ must match the rule's
+// output metric and any other matchers must be compatible with the rule's
+// (merged group and rule) static labels. It is inspired by, but stricter than,
+// the selector matching in buildDependencyMap in rules/group.go, which matches on
+// name only.
+func selectorCoversRecordingRule(rule *rules.RecordingRule, matchers []*labels.Matcher) bool {
+	nameMatcher := metricNameMatcher(matchers)
+	if nameMatcher == nil {
+		// Wildcard selector: it cannot be attributed to a specific rule.
+		return false
+	}
+	if !nameMatcher.Matches(rule.Name()) {
+		return false
+	}
+	return labelsCompatible(rule.Labels(), matchers)
+}
+
+// selectorCoversAlertingRule reports whether a promql_expr_test selector asserts
+// on the alerting rule with the given name and static labels via its ALERTS or
+// ALERTS_FOR_STATE meta-metric. A selector without an "alertname" matcher is
+// treated as indeterminate and does not count as coverage. Any remaining
+// matchers must be compatible with the rule's static labels.
+func selectorCoversAlertingRule(name string, ruleLabels labels.Labels, matchers []*labels.Matcher) bool {
+	nameMatcher := metricNameMatcher(matchers)
+	if nameMatcher == nil {
+		return false
+	}
+	if !nameMatcher.Matches(alertsMetricName) && !nameMatcher.Matches(alertsForStateMetricName) {
+		return false
+	}
+	alertnameMatched := false
+	for _, m := range matchers {
+		if m.Name == labels.AlertName {
+			if !m.Matches(name) {
+				return false
+			}
+			alertnameMatched = true
+			break
+		}
+	}
+	if !alertnameMatched {
+		return false
+	}
+	return labelsCompatible(ruleLabels, matchers)
+}
+
+// labelsCompatible reports whether the non-name matchers of a selector are
+// compatible with the rule's known static labels. The __name__ and alertname
+// matchers are handled by the callers and skipped here. A matcher on a label the
+// rule does not statically set is treated as compatible, because the value may be
+// produced from the input series at evaluation time.
+func labelsCompatible(ruleLabels labels.Labels, matchers []*labels.Matcher) bool {
+	for _, m := range matchers {
+		if m.Name == labels.MetricName || m.Name == labels.AlertName {
+			continue
+		}
+		if ruleLabels.Has(m.Name) && !m.Matches(ruleLabels.Get(m.Name)) {
+			return false
+		}
+	}
+	return true
+}
+
+// report writes the coverage summary to w and returns the overall coverage
+// percentage in the range [0, 100]. Alerting and recording rules are reported
+// separately. A suite with no rules is reported as fully covered.
+func (c *ruleCoverage) report(w io.Writer) float64 {
+	var alertTotal, alertCovered, recordTotal, recordCovered int
+	for _, k := range c.order {
+		switch k.kind {
+		case alertingRule:
+			alertTotal++
+			if c.covered[k] {
+				alertCovered++
+			}
+		case recordingRule:
+			recordTotal++
+			if c.covered[k] {
+				recordCovered++
+			}
+		}
+	}
+	total := alertTotal + recordTotal
+	covered := alertCovered + recordCovered
+
+	fmt.Fprintln(w, "Rule test coverage:")
+	fmt.Fprintf(w, "  Alerting rules:  %s\n", coverageFraction(alertCovered, alertTotal))
+	fmt.Fprintf(w, "  Recording rules: %s\n", coverageFraction(recordCovered, recordTotal))
+	fmt.Fprintf(w, "  Total:           %s\n", coverageFraction(covered, total))
+
+	if covered < total {
+		fmt.Fprintln(w, "  Untested rules:")
+		uncovered := make([]ruleCoverageKey, 0, total-covered)
+		for _, k := range c.order {
+			if !c.covered[k] {
+				uncovered = append(uncovered, k)
+			}
+		}
+		slices.SortFunc(uncovered, func(a, b ruleCoverageKey) int {
+			if n := strings.Compare(a.file, b.file); n != 0 {
+				return n
+			}
+			if n := strings.Compare(a.group, b.group); n != 0 {
+				return n
+			}
+			if a.kind != b.kind {
+				return int(a.kind) - int(b.kind)
+			}
+			if n := strings.Compare(a.name, b.name); n != 0 {
+				return n
+			}
+			return strings.Compare(a.labels, b.labels)
+		})
+		var lastFile, lastGroup string
+		headerPrinted := false
+		for _, k := range uncovered {
+			if !headerPrinted || k.file != lastFile || k.group != lastGroup {
+				fmt.Fprintf(w, "    group %q in %s:\n", k.group, filepath.Base(k.file))
+				lastFile, lastGroup = k.file, k.group
+				headerPrinted = true
+			}
+			fmt.Fprintf(w, "      - %s: %s\n", k.kind, k.name)
+		}
+	}
+
+	return coveragePercentage(covered, total)
+}
+
+// coverageFraction formats a covered/total count together with its percentage.
+// A count with no rules is reported without a percentage.
+func coverageFraction(covered, total int) string {
+	if total == 0 {
+		return "0/0 covered"
+	}
+	return fmt.Sprintf("%d/%d covered (%.1f%%)", covered, total, coveragePercentage(covered, total))
+}
+
+// coveragePercentage returns covered/total as a percentage, treating an empty
+// set as fully covered.
+func coveragePercentage(covered, total int) float64 {
+	if total == 0 {
+		return 100
+	}
+	return float64(covered) / float64(total) * 100
+}
+
+// belowThreshold reports whether the coverage percentage pct is below threshold.
+// A threshold of zero or less disables the check. The comparison uses pct exactly
+// as it is displayed (one decimal place) so the exit code never contradicts the
+// reported number, even at rounding ties.
+func belowThreshold(pct, threshold float64) bool {
+	if threshold <= 0 {
+		return false
+	}
+	displayed, _ := strconv.ParseFloat(fmt.Sprintf("%.1f", pct), 64)
+	return displayed < threshold
 }

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -48,10 +48,20 @@ import (
 // RulesUnitTest does unit testing of rules based on the unit testing files provided.
 // More info about the file format can be found in the docs.
 func RulesUnitTest(queryOpts promqltest.LazyLoaderOpts, p parser.Parser, runStrings []string, diffFlag, debug, ignoreUnknownFields bool, files ...string) int {
-	return RulesUnitTestResult(io.Discard, queryOpts, p, runStrings, diffFlag, debug, ignoreUnknownFields, files...)
+	return RulesUnitTestResult(io.Discard, queryOpts, p, runStrings, diffFlag, debug, ignoreUnknownFields, false, 0, files...)
 }
 
-func RulesUnitTestResult(results io.Writer, queryOpts promqltest.LazyLoaderOpts, p parser.Parser, runStrings []string, diffFlag, debug, ignoreUnknownFields bool, files ...string) int {
+// RulesUnitTestResult runs unit tests for rules and writes JUnit XML results to
+// results. coverage reports to stderr which rules the assertions exercise. A
+// coverageThreshold above zero also enables that report and fails the run when
+// coverage is below it or could not be determined.
+func RulesUnitTestResult(results io.Writer, queryOpts promqltest.LazyLoaderOpts, p parser.Parser, runStrings []string, diffFlag, debug, ignoreUnknownFields, coverage bool, coverageThreshold float64, files ...string) int {
+	// Reject non-finite values explicitly: NaN compares false against both bounds,
+	// so it would pass the range check and then disable the gate it was asked for.
+	if math.IsNaN(coverageThreshold) || math.IsInf(coverageThreshold, 0) || coverageThreshold < 0 || coverageThreshold > 100 {
+		fmt.Fprintf(os.Stderr, "invalid --coverage-threshold %s: must be a number between 0 and 100\n", formatThreshold(coverageThreshold))
+		return failureExitCode
+	}
 	failed := false
 	junit := &junitxml.JUnitXML{}
 
@@ -60,8 +70,15 @@ func RulesUnitTestResult(results io.Writer, queryOpts promqltest.LazyLoaderOpts,
 		run = regexp.MustCompile(strings.Join(runStrings, "|"))
 	}
 
+	// A positive threshold implies reporting; gating without naming the untested
+	// rules would not be actionable.
+	var cov *ruleCoverage
+	if coverage || coverageThreshold > 0 {
+		cov = newRuleCoverage(p, ignoreUnknownFields)
+	}
+
 	for _, f := range files {
-		if errs := ruleUnitTest(f, queryOpts, p, run, diffFlag, debug, ignoreUnknownFields, junit.Suite(f)); errs != nil {
+		if errs := ruleUnitTest(f, queryOpts, p, run, diffFlag, debug, ignoreUnknownFields, junit.Suite(f), cov); errs != nil {
 			fmt.Fprintln(os.Stderr, "  FAILED:")
 			for _, e := range errs {
 				fmt.Fprintln(os.Stderr, e.Error())
@@ -73,6 +90,17 @@ func RulesUnitTestResult(results io.Writer, queryOpts promqltest.LazyLoaderOpts,
 		}
 		fmt.Println()
 	}
+	// Gate before writing the XML, so that a run failing only on coverage is not
+	// reported as all green by whatever consumes the JUnit output.
+	if cov != nil {
+		if reason := cov.reportAndGate(os.Stderr, coverageThreshold); reason != "" {
+			fmt.Fprintln(os.Stderr, reason)
+			suite := junit.Suite("rule coverage")
+			suite.Settime(time.Now().Format("2006-01-02T15:04:05"))
+			suite.Case("coverage threshold").Fail(reason)
+			failed = true
+		}
+	}
 	err := junit.WriteXML(results)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to write JUnit XML: %s\n", err)
@@ -83,7 +111,7 @@ func RulesUnitTestResult(results io.Writer, queryOpts promqltest.LazyLoaderOpts,
 	return successExitCode
 }
 
-func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, p parser.Parser, run *regexp.Regexp, diffFlag, debug, ignoreUnknownFields bool, ts *junitxml.TestSuite) []error {
+func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, p parser.Parser, run *regexp.Regexp, diffFlag, debug, ignoreUnknownFields bool, ts *junitxml.TestSuite, cov *ruleCoverage) []error {
 	b, err := os.ReadFile(filename)
 	if err != nil {
 		ts.Abort(err)
@@ -102,6 +130,12 @@ func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, p parser
 
 	if unitTestInp.EvaluationInterval == 0 {
 		unitTestInp.EvaluationInterval = model.Duration(1 * time.Minute)
+	}
+
+	// Record rule coverage for the suite before running the tests, so rules in
+	// files whose tests fail (or that have no tests at all) are still counted.
+	if cov != nil {
+		cov.record(run, &unitTestInp)
 	}
 
 	evalInterval := time.Duration(unitTestInp.EvaluationInterval)
@@ -163,6 +197,11 @@ type unitTestFile struct {
 	GroupEvalOrder     []string       `yaml:"group_eval_order"`
 	Tests              []testGroup    `yaml:"tests"`
 	FuzzyCompare       bool           `yaml:"fuzzy_compare,omitempty"`
+
+	// unmatchedRuleFiles are the rule_files entries that matched nothing. They
+	// are dropped from RuleFiles, so coverage records them separately to avoid
+	// mistaking a rule file it never saw for one with no untested rules.
+	unmatchedRuleFiles []string `yaml:"-"`
 }
 
 // resolveAndGlobFilepaths joins all relative paths in a configuration
@@ -182,6 +221,7 @@ func resolveAndGlobFilepaths(baseDir string, utf *unitTestFile) error {
 		}
 		if len(m) == 0 {
 			fmt.Fprintln(os.Stderr, "  WARNING: no file match pattern", rf)
+			utf.unmatchedRuleFiles = append(utf.unmatchedRuleFiles, rf)
 		}
 		globbedFiles = append(globbedFiles, m...)
 	}

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -17,12 +17,21 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
 	"testing"
+	"time"
 
+	"github.com/grafana/regexp"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/util/junitxml"
 )
 
@@ -162,7 +171,7 @@ func TestRulesUnitTest(t *testing.T) {
 	t.Run("Junit xml output ", func(t *testing.T) {
 		t.Parallel()
 		var buf bytes.Buffer
-		if got := RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, parser.NewParser(parser.Options{}), nil, false, false, false, reuseFiles...); got != 1 {
+		if got := RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, parser.NewParser(parser.Options{}), nil, false, false, false, false, 0, reuseFiles...); got != 1 {
 			t.Errorf("RulesUnitTestResults() = %v, want 1", got)
 		}
 		var test junitxml.JUnitXML
@@ -196,6 +205,338 @@ func TestRulesUnitTest(t *testing.T) {
 			t.Errorf("JUnit output had %d suites without test cases\n", total-cases)
 		}
 	})
+}
+
+// recordCoverage builds a ruleCoverage from the given unit test files, mirroring
+// how ruleUnitTest feeds the coverage tracker, so coverage can be asserted in
+// isolation from the test run.
+func recordCoverage(t *testing.T, p parser.Parser, files ...string) *ruleCoverage {
+	t.Helper()
+	cov := newRuleCoverage()
+	for _, f := range files {
+		b, err := os.ReadFile(f)
+		require.NoError(t, err)
+		var utf unitTestFile
+		require.NoError(t, yaml.UnmarshalStrict(b, &utf))
+		require.NoError(t, resolveAndGlobFilepaths(filepath.Dir(f), &utf))
+		if utf.EvaluationInterval == 0 {
+			utf.EvaluationInterval = model.Duration(time.Minute)
+		}
+		cov.record(p, nil, false, &utf)
+	}
+	return cov
+}
+
+// coverageCounts returns the number of covered and total rules tracked.
+func coverageCounts(cov *ruleCoverage) (covered, total int) {
+	total = len(cov.order)
+	for _, k := range cov.order {
+		if cov.covered[k] {
+			covered++
+		}
+	}
+	return covered, total
+}
+
+func TestRulesUnitTestCoverage(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+
+	// Tests pass and coverage is informational only: exit code 0.
+	var buf bytes.Buffer
+	require.Equal(t, 0, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, true, 0, "./testdata/coverage_test.yml"))
+
+	// coverage_test.yml exercises 3 of 5 rules (60%). A threshold above it fails,
+	// a threshold at or below it passes. coverage=false with a positive threshold
+	// still enables coverage and gates the exit code.
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 100, "./testdata/coverage_test.yml"))
+	require.Equal(t, 0, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 60, "./testdata/coverage_test.yml"))
+}
+
+func TestRuleCoverageModel(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, "./testdata/coverage_test.yml")
+
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 5, total, "coverage_rules.yml has 3 alerts + 2 recording rules")
+	require.Equal(t, 3, covered)
+
+	var buf bytes.Buffer
+	require.InEpsilon(t, 60.0, cov.report(&buf), 0.0001)
+	out := buf.String()
+	require.Contains(t, out, "Alerting rules:  2/3 covered")
+	require.Contains(t, out, "Recording rules: 1/2 covered")
+	require.Contains(t, out, "Total:           3/5 covered")
+	require.Contains(t, out, "- alert: NeverTested")
+	require.Contains(t, out, "- record: job:up:avg")
+}
+
+// TestRuleCoverageDeduplicatesAcrossFiles covers the bug where a rule file shared
+// by multiple test files was counted once per referencing file, inflating the
+// denominator and listing the same rule as both covered and untested.
+func TestRuleCoverageDeduplicatesAcrossFiles(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, "./testdata/coverage_shared_a_test.yml", "./testdata/coverage_shared_b_test.yml")
+
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 1, total, "the shared rule must be counted exactly once")
+	require.Equal(t, 1, covered, "it is covered because one test file exercises it")
+}
+
+// TestRuleCoverageDistinguishesDuplicateNames covers the bug where rules sharing a
+// name in different groups were conflated. They must be counted as distinct rules
+// and attributed individually: the two same-named alerts are both covered by
+// promtool's union evaluation, while the label-scoped query covers only one of the
+// two same-named recording rules.
+func TestRuleCoverageDistinguishesDuplicateNames(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	cov := recordCoverage(t, p, "./testdata/coverage_dupname_test.yml")
+
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 4, total, "two same-named alerts and two same-named records are four distinct rules")
+	require.Equal(t, 3, covered, "both alerts plus only the tier=a recording rule")
+
+	var buf bytes.Buffer
+	cov.report(&buf)
+	out := buf.String()
+	require.Contains(t, out, `group "groupB"`)
+	require.Contains(t, out, "- record: dup:metric")
+	require.NotContains(t, out, `group "groupA"`)
+	require.NotContains(t, out, "SameName")
+}
+
+// TestRuleCoverageHonorsRunFilter ensures coverage only counts assertions from
+// test groups selected by --run, so a filtered run cannot report rules as covered
+// that this invocation never exercised.
+func TestRuleCoverageHonorsRunFilter(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	b, err := os.ReadFile("./testdata/coverage_test.yml")
+	require.NoError(t, err)
+	var utf unitTestFile
+	require.NoError(t, yaml.UnmarshalStrict(b, &utf))
+	require.NoError(t, resolveAndGlobFilepaths("./testdata", &utf))
+
+	cov := newRuleCoverage()
+	cov.record(p, regexp.MustCompile("NoSuchGroup"), false, &utf)
+
+	covered, total := coverageCounts(cov)
+	require.Equal(t, 5, total, "all rules are still counted in the denominator")
+	require.Equal(t, 0, covered, "no test group ran, so nothing is covered")
+}
+
+// TestRuleCoverageThresholdValidation rejects out-of-range thresholds.
+func TestRuleCoverageThresholdValidation(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	var buf bytes.Buffer
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, -1, "./testdata/coverage_test.yml"))
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 101, "./testdata/coverage_test.yml"))
+}
+
+// TestRuleCoverageThresholdRounding checks the gate compares the displayed
+// (one-decimal) percentage, so a threshold equal to the reported value passes.
+func TestRuleCoverageThresholdRounding(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	var buf bytes.Buffer
+	// 2/3 displays as 66.7%; a threshold equal to it passes, just above it fails.
+	require.Equal(t, 0, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 66.7, "./testdata/coverage_twothirds_test.yml"))
+	require.Equal(t, 1, RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, p, nil, false, false, false, false, 66.8, "./testdata/coverage_twothirds_test.yml"))
+}
+
+// TestBelowThreshold locks the gate to the displayed (one-decimal) percentage,
+// including half-even rounding ties where naive rounding would disagree with the
+// printed value. For example 6.25 prints as "6.2", so it is below 6.3.
+func TestBelowThreshold(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, belowThreshold(0, 0), "a zero threshold disables the check")
+	require.False(t, belowThreshold(50, 0))
+	require.True(t, belowThreshold(60, 100))
+	require.False(t, belowThreshold(60, 60), "comparison is strictly less-than")
+	require.False(t, belowThreshold(60, 50))
+
+	// 6.25 displays as 6.2 (round half to even); the gate must match the display.
+	require.True(t, belowThreshold(6.25, 6.3))
+	require.False(t, belowThreshold(6.25, 6.2))
+	// 31.25 displays as 31.2.
+	require.True(t, belowThreshold(31.25, 31.3))
+	require.False(t, belowThreshold(31.25, 31.2))
+}
+
+// anySelectorMatches parses expr, extracts its selectors, and reports whether any
+// of them satisfies the given predicate.
+func anySelectorMatches(t *testing.T, p parser.Parser, expr string, pred func([]*labels.Matcher) bool) bool {
+	t.Helper()
+	parsed, err := p.ParseExpr(expr)
+	require.NoError(t, err)
+	return slices.ContainsFunc(parser.ExtractSelectors(parsed), pred)
+}
+
+func TestSelectorCoversRecordingRule(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	tests := []struct {
+		name    string
+		rule    *rules.RecordingRule
+		expr    string
+		matches bool
+	}{
+		{
+			name:    "direct match",
+			rule:    rules.NewRecordingRule("job:up:sum", nil, labels.EmptyLabels()),
+			expr:    "job:up:sum",
+			matches: true,
+		},
+		{
+			name:    "aggregation wrapping",
+			rule:    rules.NewRecordingRule("job:up:sum", nil, labels.EmptyLabels()),
+			expr:    `sum by (job)(job:up:sum)`,
+			matches: true,
+		},
+		{
+			name:    "no match",
+			rule:    rules.NewRecordingRule("job:up:sum", nil, labels.EmptyLabels()),
+			expr:    "other_metric",
+			matches: false,
+		},
+		{
+			name:    "wildcard selector without __name__ is indeterminate",
+			rule:    rules.NewRecordingRule("job:up:sum", nil, labels.EmptyLabels()),
+			expr:    `{job="prometheus"}`,
+			matches: false,
+		},
+		{
+			name:    "compatible static label",
+			rule:    rules.NewRecordingRule("job:up:sum", nil, labels.FromStrings("team", "infra")),
+			expr:    `job:up:sum{team="infra"}`,
+			matches: true,
+		},
+		{
+			name:    "incompatible static label",
+			rule:    rules.NewRecordingRule("job:up:sum", nil, labels.FromStrings("team", "infra")),
+			expr:    `job:up:sum{team="backend"}`,
+			matches: false,
+		},
+		{
+			name:    "matcher on label absent from static labels is conservatively matched",
+			rule:    rules.NewRecordingRule("job:up:sum", nil, labels.EmptyLabels()),
+			expr:    `job:up:sum{job="prometheus"}`,
+			matches: true,
+		},
+		{
+			name:    "scalar expression has no selectors",
+			rule:    rules.NewRecordingRule("job:up:sum", nil, labels.EmptyLabels()),
+			expr:    "vector(1)",
+			matches: false,
+		},
+		{
+			name:    "ALERTS selector does not cover a recording rule",
+			rule:    rules.NewRecordingRule("job:up:sum", nil, labels.EmptyLabels()),
+			expr:    `ALERTS{alertname="job:up:sum"}`,
+			matches: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.matches, anySelectorMatches(t, p, tc.expr, func(ms []*labels.Matcher) bool {
+				return selectorCoversRecordingRule(tc.rule, ms)
+			}))
+		})
+	}
+}
+
+func TestSelectorCoversAlertingRule(t *testing.T) {
+	t.Parallel()
+
+	p := parser.NewParser(parser.Options{})
+	tests := []struct {
+		name       string
+		alertName  string
+		ruleLabels labels.Labels
+		expr       string
+		matches    bool
+	}{
+		{
+			name:       "ALERTS with matching alertname",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `count(ALERTS{alertname="InstanceDown"})`,
+			matches:    true,
+		},
+		{
+			name:       "ALERTS_FOR_STATE with matching alertname",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `ALERTS_FOR_STATE{alertname="InstanceDown"}`,
+			matches:    true,
+		},
+		{
+			name:       "ALERTS with wrong alertname",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `count(ALERTS{alertname="OtherAlert"})`,
+			matches:    false,
+		},
+		{
+			name:       "ALERTS without alertname is indeterminate",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `count(ALERTS)`,
+			matches:    false,
+		},
+		{
+			name:       "ALERTS with compatible static label",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("severity", "page"),
+			expr:       `ALERTS{alertname="InstanceDown", severity="page"}`,
+			matches:    true,
+		},
+		{
+			name:       "ALERTS with incompatible static label",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.FromStrings("severity", "page"),
+			expr:       `ALERTS{alertname="InstanceDown", severity="critical"}`,
+			matches:    false,
+		},
+		{
+			name:       "direct alert name does not cover an alerting rule",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `InstanceDown`,
+			matches:    false,
+		},
+		{
+			name:       "recording-style selector does not cover an alerting rule",
+			alertName:  "InstanceDown",
+			ruleLabels: labels.EmptyLabels(),
+			expr:       `job:up:sum`,
+			matches:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.matches, anySelectorMatches(t, p, tc.expr, func(ms []*labels.Matcher) bool {
+				return selectorCoversAlertingRule(tc.alertName, tc.ruleLabels, ms)
+			}))
+		})
+	}
 }
 
 func TestRulesUnitTestRun(t *testing.T) {

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -162,7 +162,7 @@ func TestRulesUnitTest(t *testing.T) {
 	t.Run("Junit xml output ", func(t *testing.T) {
 		t.Parallel()
 		var buf bytes.Buffer
-		if got := RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, parser.NewParser(parser.Options{}), nil, false, false, false, reuseFiles...); got != 1 {
+		if got := RulesUnitTestResult(&buf, promqltest.LazyLoaderOpts{}, parser.NewParser(parser.Options{}), nil, false, false, false, false, 0, reuseFiles...); got != 1 {
 			t.Errorf("RulesUnitTestResults() = %v, want 1", got)
 		}
 		var test junitxml.JUnitXML

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -479,6 +479,8 @@ Unit tests for rules.
 | <code class="text-nowrap">--debug</code> | Enable unit test debugging. | `false` |
 | <code class="text-nowrap">--diff</code> | [Experimental] Print colored differential output between expected & received output. | `false` |
 | <code class="text-nowrap">--ignore-unknown-fields</code> | Ignore unknown fields in the test files. This is useful when you want to extend rule files with custom metadata. Ensure that those fields are removed before loading them into the Prometheus server as it performs strict checks by default. | `false` |
+| <code class="text-nowrap">--coverage</code> | Report rule test coverage to stderr after running tests. | `false` |
+| <code class="text-nowrap">--coverage-threshold</code> | Fail (exit code 1) if total rule test coverage is below this percentage (0-100). Implies --coverage. 0 disables the check. | `0` |
 
 
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -479,6 +479,8 @@ Unit tests for rules.
 | <code class="text-nowrap">--debug</code> | Enable unit test debugging. | `false` |
 | <code class="text-nowrap">--diff</code> | [Experimental] Print colored differential output between expected & received output. | `false` |
 | <code class="text-nowrap">--ignore-unknown-fields</code> | Ignore unknown fields in the test files. This is useful when you want to extend rule files with custom metadata. Ensure that those fields are removed before loading them into the Prometheus server as it performs strict checks by default. | `false` |
+| <code class="text-nowrap">--coverage</code> | Report rule test coverage to stderr after running tests. | `false` |
+| <code class="text-nowrap">--coverage-threshold</code> | Fail (exit code 1) if total rule test coverage is below this percentage. Must be between 0 and 100. A positive value implies --coverage; 0 disables the check. | `0` |
 
 
 

--- a/docs/configuration/unit_testing_rules.md
+++ b/docs/configuration/unit_testing_rules.md
@@ -310,3 +310,135 @@ When you set `start_timestamp`:
 - All `input_series` samples will be timestamped starting from `start_timestamp`
 - The `eval_time` field in test cases is interpreted as a duration relative to `start_timestamp`
 - The `time()` function will return `start_timestamp + eval_time`
+
+## Rule test coverage
+
+`promtool test rules --coverage` reports to stderr which alerting and recording
+rules of the loaded rule files are exercised by the test assertions. All test
+files given on the command line form a single suite, so a rule file shared by
+several of them is counted once.
+
+```shell
+promtool test rules --coverage test.yml
+```
+
+`--coverage-threshold` additionally fails the command with exit code 1 when total
+coverage is below the given percentage, which is intended for CI gating. A
+positive value implies `--coverage`; `0` disables the check.
+
+```shell
+promtool test rules --coverage-threshold=80 test.yml
+```
+
+Rules no assertion could be attributed to are listed by rule file and group, with
+their position in the group, since two declarations in one group can otherwise
+look identical:
+
+```
+  Uncovered rules:
+    group "partial" in rules.yml:
+      - alert: Twin (rule #1)
+```
+
+### What counts as covered
+
+Coverage is *assertion presence*, not expression branch coverage: it answers
+"does any test assert on this rule's output?", not "does every branch of its
+expression get evaluated?". A rule is covered when:
+
+- an `alert_rule_test` names it in `alertname`, or
+- a `promql_expr_test` expression contains a selector that could read its output.
+
+A failing assertion still counts as covered, because the rule is being tested.
+The test failure fails the command on its own.
+
+Because several alerting rules can share an `alertname`, and promtool evaluates
+same-named alerts together, an `alert_rule_test` covers every rule with that name.
+Only the test groups selected by `--run` contribute coverage; the denominator
+always stays the full set of rules the suite declares.
+
+### Selector attribution
+
+A `promql_expr_test` covers a recording rule when every `__name__` matcher of one
+of its selectors accepts the rule's output metric, and covers an alerting rule
+when a selector reads its `ALERTS` or `ALERTS_FOR_STATE` series with a matching
+`alertname`. Repeated matchers on a label are combined, as in PromQL.
+
+The generated `alertstate` label is matched against the states the rule can
+actually reach. A rule with no `for` is promoted to firing before its first
+sample, so a selector asking for its `pending` state observes nothing and does not
+cover it.
+
+Attribution is a static analysis of the selectors, so it may both under-report and
+over-report:
+
+- A selector with no `__name__` matcher, or an alert selector with no `alertname`
+  matcher, is indeterminate and covers nothing. This under-reports.
+- A matcher on a label the rule does not set is compatible when some value could
+  satisfy every matcher on it, whether or not the rule ever produces that value.
+  `job:up:sum{job="prod"}` therefore counts even if the rule only ever emits
+  `job="staging"`, which over-reports.
+- A matcher set that no value can satisfy does not count. That value is looked
+  for rather than proven, and the search is bounded, so there are three outcomes
+  rather than two. A value is found, and the rule is covered. The matchers confine
+  the label to a finite set, every member is tried, and none works, which rules
+  the selector out. Or the search runs out of candidates or budget, and the result
+  is undecided.
+
+Undecided rules are reported separately from uncovered ones, because the analysis
+does not know whether they have a test. `{job=~"a+",job!~"a|aa|aaa"}` is satisfied
+by `aaaa` and `{job=~".*foo",job=~"xyz.*"}` by `xyzfoo`, but neither value is one
+the search builds. A threshold still fails over undecided rules, so the gate stays
+closed; the report says the coverage lies between two bounds rather than claiming
+the rules are untested.
+- Alert labels containing template syntax are expanded per alert instance, so
+  their value is treated as unknown rather than compared literally. A selector
+  that would not have matched the expanded value still counts, which
+  over-reports.
+
+Attribution also matches on the selectors alone, and deliberately does not
+establish where the samples an assertion sees come from or when they exist:
+
+- The rule the selector names is credited even when every matching sample came
+  from `input_series` rather than from the rule. A test may supply `ALERTS` or a
+  recorded metric directly and still count as covering the rule of that name.
+- `eval_time`, `offset` and `@` are not taken into account, so an assertion
+  reading a time at which the rule produced nothing still counts.
+- A selector inside an expression counts even when it does not affect the result,
+  as in `r or vector(1)`.
+
+### What the denominator contains
+
+Coverage counts the rules of the rule files the given test files reach through
+their `rule_files`, and nothing else. A rule file that no test file references is
+not part of the suite: it produces no warning, adds nothing to the total, and
+cannot lower the percentage.
+
+That matters when the threshold is used to catch a rule added without a test,
+because a whole rule file added without a test file would pass. Point `rule_files`
+at the production rule tree with a glob, or generate the test files from the same
+manifest the rules are deployed from, so that a new rule file is always reached.
+
+### Reliability of the threshold
+
+The threshold is compared against the exact covered and total counts, never the
+rounded percentage in the report, so a threshold of 100 requires every rule to be
+covered *as this analysis counts coverage*.
+
+Two different guarantees are worth keeping apart. Deciding which rules exist fails
+closed: if a rule file fails to load or matches nothing, or the suite declares no
+rules at all, the command reports the problem and exits 1 rather than treating the
+unknown as fully covered. Deciding which rules an assertion covers is the
+analysis described above. It reasons about what a selector *could* read, not what
+it did read, so it can over-report. A passing threshold therefore means every rule
+was attributed an assertion by this model, not that every rule was proven to be
+observed by one.
+
+Reporting without a threshold keeps its exit code: `--coverage` on its own warns
+about rule files it could not analyse but still exits 0, since the test run
+reports rule file errors of its own. Only a positive threshold turns incomplete
+coverage into a failure.
+
+A threshold failure is also written to the JUnit XML output as a failing
+`coverage threshold` test case, so a run that fails only on coverage does not
+appear green to whatever consumes that file.


### PR DESCRIPTION
This patch adds `--coverage` and `--coverage-threshold` to `promtool test rules`. `--coverage` reports which alerting and recording rules of the loaded rule files are exercised by unit test assertions, and `--coverage-threshold` fails the command when total coverage is below a percentage, so a CI pipeline can refuse a rule that arrived without a test.

In a GitOps repository nothing but code review notices a rule landing untested, and code review is exactly what gets skipped when an alert is urgent. This is the coverage half of #11848; the JUnit half was already resolved by #14506.

```console
$ promtool test rules --coverage coverage_test.yml
  SUCCESS

Rule test coverage:
  Alerting rules:  2/3 covered (66.7%)
  Recording rules: 1/2 covered (50.0%)
  Total:           3/5 covered (60.0%)
  Uncovered rules:
    group "alerts" in coverage_rules.yml:
      - alert: NeverTested{severity="warning"} (rule #3)
    group "recording" in coverage_rules.yml:
      - record: job:up:avg (rule #2)
```

```console
$ promtool test rules --coverage-threshold=80 coverage_test.yml
...
Rule test coverage 3/5 (60.0%) is below the threshold of 80%.
$ echo $?
1
```

## What counts as covered

Coverage here is assertion presence, not expression branch coverage. It answers "does any test assert on this rule's output?", not "does every branch of its expression get evaluated". A rule is covered when an `alert_rule_test` names it in `alertname`, or a `promql_expr_test` contains a selector that could read its output.

A failing assertion still counts as covered, because the rule is under test; the failure fails the command on its own and does not need to be counted twice. Because promtool evaluates same-named alerts together and compares against their unioned output, an `alert_rule_test` covers every rule with that `alertname` — that is a property of the assertion, not an approximation on my side.

All the test files on the command line form one suite, so a rule file shared by several of them is counted once rather than once per referencing file.

This is deliberately narrower than the input-feeding model sketched in #8131, where a rule is covered if the test's `input_series` supply its inputs. Asking about the output puts the question closer to what a test is for than asking whether the rule ran, though neither model establishes that the assertion observed this rule's output; the limits section below says what this one does not check. I would rather ship the narrower thing and let #8131 stay open for the dependency-graph work.

## How rules are identified

Rules come out of `rules.Manager.LoadGroups` rather than a hand-rolled `rulefmt` walk, so group and rule labels are merged exactly the way Prometheus merges them.

Each rule is keyed by its rule file, its group, and its position within that group. Position rather than content matters here: two declarations in one group can share a name, an expression and a set of labels and still be two rules, differing only in something coverage does not track such as `for`. Keying on content would silently merge them and quietly shrink the denominator. Rule file paths are resolved through symlinks first, so the same physical file reached by two routes is still one file, and the report prints enough of each path to tell apart rule files that share a base name.

## Selector attribution

For recording rules the selector's `__name__` matchers have to accept the rule's output metric; for alerting rules the selector has to be able to read the rule's `ALERTS` or `ALERTS_FOR_STATE` series with a matching `alertname`.

The matching follows what the querying documentation promises:

> Multiple matchers can be used for the same label name; they all must pass for a result to be returned.

and

> Label matchers can also be applied to metric names by matching against the internal `__name__` label.

so `{__name__=~"job:up:sum|other",__name__!="job:up:sum"}` is not attributed to `job:up:sum`, and neither is `ALERTS{alertname=~"A|B",alertname!="A"}` attributed to `A`. Labels the rule engine generates are compared against what the engine actually produces rather than against the rule's own labels: `alertname` is always the rule name, and on `ALERTS_FOR_STATE` there is no generated `alertstate` at all, so there it is an ordinary label. `alertname` is likewise ordinary on a recording rule's output and is compared like any other label.

`alertstate` is matched against the states the rule can reach rather than against both of them. An alert is only sampled once its state has settled for the evaluation, and a rule with no `for` is promoted to firing before its first sample, so `ALERTS{alertname="X",alertstate="pending"}` observes nothing for such a rule and does not cover it.

Alert labels are expanded per alert instance, so a value containing template syntax is treated as unknown instead of compared literally. `AlertingRule.QueryForStateSeries` already skips those labels when it builds matchers, and it seemed wrong for coverage to be stricter about them than the rule engine is.

## Making the threshold safe to gate on

Two guarantees are worth keeping apart, because only one of them is sound.

Deciding which rules exist fails closed, and the threshold arithmetic is exact. It is compared against the raw covered and total counts and never against the percentage as it is rendered; rounding first is not hypothetical, since 1999 of 2000 rules is 99.95%, prints as `100.0%`, and would clear a threshold of 100 with a rule still untested.

Deciding which rules an assertion covers is the heuristic above, and can over-report. A passing threshold means every rule was attributed an assertion by this model, not that every rule was proven to be observed by one. The documentation says so in those words rather than promising more.

One limit is worth stating before the rest, because it decides whether the gate does the job #11848 asks of it. The denominator holds the rules of the rule files the given test files reach through their `rule_files`, and nothing else. A rule file nobody wrote a test file for is not in the suite: no warning, no total, no effect on the percentage. A rule added without a test is caught; a rule *file* added without a test file is not, unless `rule_files` globs the production tree or the test files are generated from the same manifest. The documentation says this where someone setting up the gate will read it.

Coverage that could not be determined does not pass either, and there are three ways to not determine it. A rule file that fails to load never reaches the denominator, and with no test group to run nothing else would load it, so the report would come out `0/0` and be read as fully covered. A `rule_files` entry that matches nothing is worse, because it disappears quietly: the files that do exist can be fully covered and the total is not even zero. A suite with no rules at all is the same question with no data. All three fail a positive threshold with the reason printed.

Report-only mode keeps its exit code and only warns, since `--coverage` has always been informational and the test run reports rule file errors of its own. A threshold failure is also recorded in the JUnit XML as a failing `coverage threshold` test case, so a run that fails only on coverage does not read as green to whatever consumes that file.

Non-finite thresholds are rejected up front. `strconv.ParseFloat` accepts `NaN`, every comparison against `NaN` is false, and an unvalidated `NaN` would sail through the range check and then quietly disable the very gate it was asked to enforce.

## Where it is imprecise

Attribution is a static analysis of the selectors, so it misses in both directions and the documentation says so rather than promising one.

It under-reports when a selector has no concrete `__name__`, or when an alert selector has no `alertname`: neither can be attributed to a particular rule, so a test that genuinely exercises one that way is not counted. #8131 notes the same limitation.

It over-reports because it reasons about what a selector *could* read rather than what it did. A matcher on a label the rule does not set counts when some value could satisfy every matcher on it, whether or not the rule ever emits that value: `job:up:sum{job="prod"}` counts even for a rule that only ever emits `job="staging"`. Templated alert labels are likewise treated as unknown rather than expanded.

What it does reject is a matcher set that no value can satisfy, and it rejects those by finding a value rather than by pattern-matching the contradiction. Candidates come from the matchers themselves, from the literal alternations `SetMatches` exposes, and from strings built by walking the parsed expression: every alternation branch, a bounded set of representative character-class endpoints, and a bounded product across concatenations and repetitions, capped so a nested alternation cannot blow the search up. Parsing uses the flags `labels.NewFastRegexMatcher` uses, so `.` means the same thing here as it does when the matcher runs.

`{job=~"a.*",job!~"a.*"}` and `{job=~"a.*",job=~"b.*"}` have no satisfying value and do not count. `{job=~"(staging|prod)-.*",job!~"staging-.*"}` and `{job=~"[ab]+",job!~"a+"}` do, via `prod-` and `b`, which is why the search has to try more than the first branch it finds.

There are three outcomes, not two. A value is found and the rule counts. The matchers confine the label to a finite set, every member is tried, and none works, which rules the selector out. Or the search runs out of candidates or budget, and the answer is that it does not know. That last case used to be reported as uncovered, which told the user something the analysis had not established: `{job=~"a+",job!~"a|aa|aaa"}` reads a rule through `aaaa`, and the search never builds that value. Undecided rules are now listed separately, and the gate says the coverage lies between two bounds rather than naming them untested. It still fails, so nothing opens up.

These really are candidates rather than witnesses. A zero-width assertion can contradict the parts around it, so the walk builds `foobar` for `foo\bbar` even though that expression matches nothing. Every candidate is confirmed against the real matchers before it counts, which is what keeps a badly built one costing a missed attribution rather than a wrong one.

The search being bounded is where the under-reporting lives: intersecting two unbounded expressions needs a value neither describes on its own, as in `{job=~".*foo",job=~"xyz.*"}`, which `xyzfoo` satisfies. A brute-force test over a small alphabet sweeps pairs of regexp matchers and asserts the search finds a value whenever one exists. That pair is the only gap in that table, which is a finite table rather than a proof: a matcher set whose solutions all sit outside the candidates the search builds will still be missed.

It also matches on selectors alone, and deliberately establishes neither where the samples an assertion sees come from nor when they exist. `input_series` supplying `ALERTS` or a recorded metric directly counts as covering the rule of that name; `eval_time`, `offset` and `@` are not considered; and a selector that does not affect the result, as in `r or vector(1)`, still counts. Sample provenance and rule dependencies are the broader problem #8131 describes, and are out of scope here.

## Note on this revision

The branch is rebased onto current `main` and force-pushed. It is still a single commit.

Since the last review, three more ways the gate could pass without observing a rule are closed. `alertstate` was assumed to reach `pending` for every alerting rule, so an assertion on the pending state of a rule with no `for` counted as coverage while observing nothing. An unbounded regexp made the whole matcher set compatible, so `{job=~"a.*",job!~"a.*"}` counted too. In the other direction, a matcher set that only excluded values was decided against a handful of fixed probes, so `{job!="",job!="a",job!="A",job!="0",job!="-"}` was wrongly called unsatisfiable although `aa` satisfies it.

Both threshold regressions for the first two go through `RulesUnitTestResult` rather than the helpers, since that is where the fail-open showed.

Attribution on dynamic labels is witness-based: a positive result always has a concrete value that satisfies every matcher. The search enumerates rather than taking the first path through the expression, since a selector like `{job=~"(staging|prod)-.*",job!~"staging-.*"}` is perfectly ordinary and its only witness is in the second branch.

The solver reports three outcomes rather than two, and the candidate search is bounded and cached per selector; the sections above describe both. Before this, an exhausted search was indistinguishable from a proven contradiction, and a legal `[a-z]{1000}` matcher allocated 33.6 MiB for every rule it was compared against.

One false green is closed. Stripping templated labels rewrote the rule's label set through `labels.Builder`, which deletes labels whose value is the empty string, so a rule setting `severity: ""` alongside a templated label lost the `severity` constraint entirely and `ALERTS{alertname="X",severity="page"}` counted as covering it. Nothing is rewritten now; whether a value is known is decided where it is compared.

Three things changed in the round before. Two bounded-search misses are closed: a negative-only matcher set was decided against the probes and a single fresh-value family, so `{job!~"|a|A|0|-",job!~"coverage-witness-.*"}` was called unsatisfiable although `b` satisfies it, and repetitions were only built one and two deep, so `{job=~"a+",job!~"a|aa"}` missed `aaa`. Neither is a completeness proof, only a wider net; the wording above says so now.

Also, `\B` was grouped with the impossible-node case, so `{job=~"foo\Bbar"}` was read as unsatisfiable although it matches `foobar`; it is an ordinary zero-width assertion and is treated like the others now. The uncovered list also prints each rule's position in its group, because two declarations differing only in `for` produced two identical lines and no way to tell which one needed the test:

```
  Uncovered rules:
    group "partial" in rules.yml:
      - alert: Twin (rule #1)
```

The two end-to-end threshold tests for this now assert on a real sample rather than an empty result, so they show the selector reading the rule rather than only being attributable to it.

The coverage code and its tests have moved to `rule_coverage.go` and `rule_coverage_test.go`. Nothing changed with them; `unittest.go` is down to the flag plumbing and one call, which should make the rest of this easier to read.

On cost, the walk is bounded by a byte budget and each selector keeps its own answers, since the answer for a label depends on the matchers rather than on the rule being compared. Both were needed: `[a-z]{1000}` is a legal matcher that expands into a thousand-element concatenation, and it allocated 33.6 MiB per call, once per rule the selector was compared against. It is 0.23 MiB now, and a selector compared against 200 rules solves once, so those 200 rules cost 376µs in total rather than 200 times 325µs. An equality matcher is 92ns. A suite of 200 rules against 20 such selectors runs in 0.09s.

Earlier in this revision, two ways the gate could pass without complete coverage were closed. A `rule_files` entry that matched nothing used to warn and then vanish, so a suite whose remaining files were fully covered satisfied a threshold of 100 while part of it had never been analysed; unmatched patterns are now carried through and counted as unanalysed. Separately, satisfiability of a dynamic label was only checked when an equality matcher pinned it, so regexp-only contradictions such as `{job=~"a",job!~"a"}` and `{job!~".*"}` were accepted and an assertion that can never observe a rule marked it covered.

For the unmatched-pattern part I deliberately did not reintroduce `--warn-as-error`: #16932 showed that turning warnings into an API contract wants a design covering query-engine warnings, warning types and exit codes. This only lets the coverage gate see what it was not given, and leaves the broader question in #12499 open.

Also in this revision: the documentation no longer claims attribution can only under-report, which was not true of templated labels and is not true of the regexp cases either; failed rule files are counted per file rather than per error; and a threshold failure now appears in the JUnit XML.

The coverage-only rule manager passes a logger explicitly. Without one it inherited a nil logger from `NewManager` and panicked on any rule file the loader warns about, which is a bug in the rule manager rather than in this feature; it is filed as #19432 with a fix in #19433, and this PR does not depend on that one.

## Testing

`go test ./cmd/promtool/...` passes, including with `-race`, under `GOARCH=386`, and with `-race` under each of the `stringlabels`, `dedupelabels` and `slicelabels` build tags; `golangci-lint run cmd/promtool/...` is clean and the CLI documentation is regenerated. 122 coverage and selector tests and subtests pass in total.

One note on CI: `slicelabels` runs over `./cmd/prometheus ./model/textparse ./prompb/...` rather than `./...`, so this package is not covered by that job. I ran it locally instead and left the workflow alone here. #19447 adds `./cmd/promtool/...` to that line on its own, and this PR does not depend on it.

The regression tests cover the behaviour this revision changes: an alert with and without `for` against a `pending` selector, an unbounded regexp required and excluded, two required regexps with disjoint literal prefixes, nested prefixes and a regexp without one that both have to stay compatible, and a negative-only matcher set excluding every fixed probe. Two of these go end to end through `RulesUnitTestResult` with a threshold rather than through the helpers. Earlier ones cover a valid fully covered rule file alongside one that matches nothing, contradictory finite regexp matchers, a negated total regexp, a threshold failure appearing in the JUnit output, and a rule file the loader warns about, an unloadable rule file with no test group and with `--run` selecting none, a suite with no rules, `NaN` and the infinities, 1999 of 2000 rules against a threshold of 100, repeated `__name__` and `alertname` matchers, a static `alertname` on a recording rule, a templated alert label, an impossible `alertstate`, two lookalike declarations in one group, rule files sharing a base name, a rule file reached through a symlink, and a rule file shared by two test files.

Where a test guards a fix rather than a feature I checked that it fails without the fix.

#### Which issue(s) does the PR fix:

Fixes #11848

Related to #8131 — this covers the output-assertion part of it, not the input and dependency analysis discussed there.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[FEATURE] promtool: Add `--coverage` and `--coverage-threshold` flags to `promtool test rules` to report which alerting and recording rules are exercised by unit test assertions and optionally fail when coverage is below a threshold.
```

