### PR TITLE
tsdb: decouple OOO compaction from in-order head compaction

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -684,6 +684,42 @@ func getMetricValue(t *testing.T, body io.Reader, metricType model.MetricType, m
 	return 0, errors.New("cannot get value")
 }
 
+// getMetricValueSum returns the sum of all metrics for a given metric name.
+// This is useful for CounterVec or GaugeVec metrics where we want the total across all label values.
+//
+// Key difference from getMetricValue: This function returns 0 (not an error) when the metric family
+// doesn't exist, which is appropriate for metrics that only appear after being incremented.
+func getMetricValueSum(t *testing.T, body io.Reader, metricType model.MetricType, metricName string) (float64, error) {
+	t.Helper()
+
+	p := expfmt.NewTextParser(model.UTF8Validation)
+	metricFamilies, err := p.TextToMetricFamilies(body)
+	if err != nil {
+		return 0, err
+	}
+	metricFamily, ok := metricFamilies[metricName]
+	if !ok {
+		return 0, nil
+	}
+	metrics := metricFamily.GetMetric()
+	if len(metrics) == 0 {
+		return 0, nil
+	}
+
+	var sum float64
+	for _, metric := range metrics {
+		switch metricType {
+		case model.MetricTypeGauge:
+			sum += metric.GetGauge().GetValue()
+		case model.MetricTypeCounter:
+			sum += metric.GetCounter().GetValue()
+		default:
+			t.Fatalf("metric type %s not supported", metricType)
+		}
+	}
+	return sum, nil
+}
+
 func TestRuntimeGOGCConfig(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -870,7 +906,7 @@ scrape_configs:
 				require.NotZero(t, series)
 
 				// No compaction must have failed
-				failures, err := getMetricValue(t, bytes.NewReader(metrics), model.MetricTypeCounter, "prometheus_tsdb_compactions_failed_total")
+				failures, err := getMetricValueSum(t, bytes.NewReader(metrics), model.MetricTypeCounter, "prometheus_tsdb_compactions_failed_total")
 				require.NoError(t, err)
 				require.Zero(t, failures)
 				return true

--- a/cmd/prometheus/main_upgrade_test.go
+++ b/cmd/prometheus/main_upgrade_test.go
@@ -92,7 +92,7 @@ func fetchLatestLTSRelease(t *testing.T, prefix string) (version, assetURL strin
 	return "", ""
 }
 
-func getPrometheusMetricValue(t *testing.T, port int, metricType model.MetricType, metricName string) (float64, error) {
+func getPrometheusMetricValue(t *testing.T, port int, metricType model.MetricType, metricName string, isVecMetric bool) (float64, error) {
 	t.Helper()
 
 	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/metrics", port))
@@ -102,6 +102,9 @@ func getPrometheusMetricValue(t *testing.T, port int, metricType model.MetricTyp
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return 0, fmt.Errorf("bad status code %d", resp.StatusCode)
+	}
+	if isVecMetric {
+		return getMetricValueSum(t, resp.Body, metricType, metricName)
 	}
 	return getMetricValue(t, resp.Body, metricType, metricName)
 }
@@ -159,59 +162,60 @@ func (c versionChangeTest) ensureHealthyMetrics(t *testing.T) {
 	checkStartTime := time.Now()
 
 	for _, mc := range []struct {
-		mType model.MetricType
-		mName string
-		check func(float64) bool
+		mType       model.MetricType
+		mName       string
+		isVecMetric bool // true if the metric is a vector type (e.g., CounterVec or GaugeVec).
+		check       func(float64) bool
 	}{
-		{model.MetricTypeGauge, "prometheus_ready", func(v float64) bool { return v == 1 }},
-		{model.MetricTypeGauge, "prometheus_config_last_reload_successful", func(v float64) bool { return v == 1 }},
+		{model.MetricTypeGauge, "prometheus_ready", false, func(v float64) bool { return v == 1 }},
+		{model.MetricTypeGauge, "prometheus_config_last_reload_successful", false, func(v float64) bool { return v == 1 }},
 
-		{model.MetricTypeCounter, "prometheus_target_scrape_pools_total", func(v float64) bool { return v == 3 }},
-		{model.MetricTypeCounter, "prometheus_target_scrape_pools_failed_total", func(v float64) bool { return v == 0 }},
-		{model.MetricTypeCounter, "prometheus_target_scrape_pool_reloads_failed_total", func(v float64) bool { return v == 0 }},
+		{model.MetricTypeCounter, "prometheus_target_scrape_pools_total", false, func(v float64) bool { return v == 3 }},
+		{model.MetricTypeCounter, "prometheus_target_scrape_pools_failed_total", false, func(v float64) bool { return v == 0 }},
+		{model.MetricTypeCounter, "prometheus_target_scrape_pool_reloads_failed_total", false, func(v float64) bool { return v == 0 }},
 
-		{model.MetricTypeGauge, "prometheus_remote_storage_highest_timestamp_in_seconds", func(v float64) bool { return v > float64(checkStartTime.Unix()) }},
+		{model.MetricTypeGauge, "prometheus_remote_storage_highest_timestamp_in_seconds", false, func(v float64) bool { return v > float64(checkStartTime.Unix()) }},
 
-		{model.MetricTypeGauge, "prometheus_rule_group_rules", func(v float64) bool { return v == 2 }},
-		{model.MetricTypeCounter, "prometheus_rule_evaluations_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_rule_evaluation_failures_total", func(v float64) bool { return v == 0 }},
+		{model.MetricTypeGauge, "prometheus_rule_group_rules", false, func(v float64) bool { return v == 2 }},
+		{model.MetricTypeCounter, "prometheus_rule_evaluations_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_rule_evaluation_failures_total", false, func(v float64) bool { return v == 0 }},
 
-		{model.MetricTypeCounter, "prometheus_tsdb_compactions_triggered_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_compactions_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_compactions_failed_total", func(v float64) bool { return v == 0 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_compactions_triggered_total", true, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_compactions_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_compactions_failed_total", true, func(v float64) bool { return v == 0 }},
 
-		{model.MetricTypeGauge, "prometheus_tsdb_head_series", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeGauge, "prometheus_tsdb_head_chunks", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeGauge, "prometheus_tsdb_head_chunks_storage_size_bytes", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_head_series_created_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeGauge, "prometheus_tsdb_blocks_loaded", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeGauge, "prometheus_tsdb_storage_blocks_bytes", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_reloads_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_reloads_failures_total", func(v float64) bool { return v == 0 }},
+		{model.MetricTypeGauge, "prometheus_tsdb_head_series", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeGauge, "prometheus_tsdb_head_chunks", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeGauge, "prometheus_tsdb_head_chunks_storage_size_bytes", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_head_series_created_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeGauge, "prometheus_tsdb_blocks_loaded", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeGauge, "prometheus_tsdb_storage_blocks_bytes", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_reloads_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_reloads_failures_total", false, func(v float64) bool { return v == 0 }},
 
-		{model.MetricTypeCounter, "prometheus_tsdb_head_chunks_created_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_head_chunks_removed_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_mmap_chunks_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_mmap_chunk_corruptions_total", func(v float64) bool { return v == 0 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_head_chunks_created_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_head_chunks_removed_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_mmap_chunks_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_mmap_chunk_corruptions_total", false, func(v float64) bool { return v == 0 }},
 
-		{model.MetricTypeCounter, "prometheus_tsdb_checkpoint_creations_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_checkpoint_creations_failed_total", func(v float64) bool { return v == 0 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_checkpoint_deletions_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_checkpoint_deletions_failed_total", func(v float64) bool { return v == 0 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_checkpoint_creations_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_checkpoint_creations_failed_total", false, func(v float64) bool { return v == 0 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_checkpoint_deletions_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_checkpoint_deletions_failed_total", false, func(v float64) bool { return v == 0 }},
 
-		{model.MetricTypeCounter, "prometheus_tsdb_head_truncations_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_head_truncations_failed_total", func(v float64) bool { return v == 0 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_head_truncations_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_head_truncations_failed_total", false, func(v float64) bool { return v == 0 }},
 
-		{model.MetricTypeGauge, "prometheus_tsdb_wal_storage_size_bytes", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_wal_completed_pages_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_wal_page_flushes_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_wal_truncations_total", func(v float64) bool { return v >= 1 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_wal_writes_failed_total", func(v float64) bool { return v == 0 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_wal_corruptions_total", func(v float64) bool { return v == 0 }},
-		{model.MetricTypeCounter, "prometheus_tsdb_wal_truncations_failed_total", func(v float64) bool { return v == 0 }},
+		{model.MetricTypeGauge, "prometheus_tsdb_wal_storage_size_bytes", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_wal_completed_pages_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_wal_page_flushes_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_wal_truncations_total", false, func(v float64) bool { return v >= 1 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_wal_writes_failed_total", false, func(v float64) bool { return v == 0 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_wal_corruptions_total", false, func(v float64) bool { return v == 0 }},
+		{model.MetricTypeCounter, "prometheus_tsdb_wal_truncations_failed_total", false, func(v float64) bool { return v == 0 }},
 	} {
 		require.Eventually(t, func() bool {
-			val, err := getPrometheusMetricValue(t, c.prometheusPort, mc.mType, mc.mName)
+			val, err := getPrometheusMetricValue(t, c.prometheusPort, mc.mType, mc.mName, mc.isVecMetric)
 			if err != nil {
 				return false
 			}

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1340,13 +1340,13 @@ func TestDisableAutoCompactions(t *testing.T) {
 	}
 
 	for range 10 {
-		if prom_testutil.ToFloat64(db.metrics.compactionsSkipped) > 0.0 {
+		if prom_testutil.ToFloat64(db.metrics.compactionsSkipped.WithLabelValues("head")) > 0.0 {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	require.Greater(t, prom_testutil.ToFloat64(db.metrics.compactionsSkipped), 0.0, "No compaction was skipped after the set timeout.")
+	require.Greater(t, prom_testutil.ToFloat64(db.metrics.compactionsSkipped.WithLabelValues("head")), 0.0, "No compaction was skipped after the set timeout.")
 	require.Empty(t, db.blocks)
 
 	// Enable the compaction, trigger it and check that the block is persisted.
@@ -1489,7 +1489,7 @@ func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
 
 			require.Equal(t, 0.0, prom_testutil.ToFloat64(db.metrics.reloadsFailed), "initial 'failed db reloadBlocks' count metrics mismatch")
 			require.Equal(t, 0.0, prom_testutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.Ran), "initial `compactions` count metric mismatch")
-			require.Equal(t, 0.0, prom_testutil.ToFloat64(db.metrics.compactionsFailed), "initial `compactions failed` count metric mismatch")
+			require.Equal(t, 0.0, prom_testutil.ToFloat64(db.metrics.compactionsFailed.WithLabelValues("head")), "initial `compactions failed` count metric mismatch")
 
 			// Do the compaction and check the metrics.
 			// Compaction should succeed, but the reloadBlocks should fail and
@@ -1497,7 +1497,7 @@ func TestDeleteCompactionBlockAfterFailedReload(t *testing.T) {
 			require.Error(t, db.Compact(ctx))
 			require.Equal(t, 1.0, prom_testutil.ToFloat64(db.metrics.reloadsFailed), "'failed db reloadBlocks' count metrics mismatch")
 			require.Equal(t, 1.0, prom_testutil.ToFloat64(db.compactor.(*LeveledCompactor).metrics.Ran), "`compaction` count metric mismatch")
-			require.Equal(t, 1.0, prom_testutil.ToFloat64(db.metrics.compactionsFailed), "`compactions failed` count metric mismatch")
+			require.Equal(t, 1.0, prom_testutil.ToFloat64(db.metrics.compactionsFailed.WithLabelValues("head")), "`compactions failed` count metric mismatch")
 
 			actBlocks, err = blockDirs(db.Dir())
 			require.NoError(t, err)
@@ -2054,7 +2054,7 @@ func TestDelayedCompaction(t *testing.T) {
 			require.Equal(t, 1.0, compactorRanCount(db))
 			// The compaction delay doesn't block or wait on the trigger;
 			// 3 triggers were processed above without blocking.
-			require.GreaterOrEqual(t, prom_testutil.ToFloat64(db.metrics.compactionsTriggered)-prom_testutil.ToFloat64(db.metrics.compactionsSkipped), 3.0)
+			require.GreaterOrEqual(t, prom_testutil.ToFloat64(db.metrics.compactionsTriggered.WithLabelValues("head"))-prom_testutil.ToFloat64(db.metrics.compactionsSkipped.WithLabelValues("head")), 3.0)
 			// The delay doesn't change the head blocks alignment.
 			require.Equal(t, db.compactor.(*LeveledCompactor).ranges[0]+1, db.head.MinTime())
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -57,6 +57,9 @@ const (
 	// DefaultCompactionDelayMaxPercent in percentage.
 	DefaultCompactionDelayMaxPercent = 10
 
+	// DefaultOutOfOrderCompactionInterval is the default interval duration for out-of-order head compaction.
+	DefaultOutOfOrderCompactionInterval = 2 * time.Hour
+
 	// Block dir suffixes to make deletion and creation operations atomic.
 	// We decided to do suffixes instead of creating meta.json as last (or delete as first) one,
 	// because in error case you still can recover meta.json from the block content within local TSDB dir.
@@ -75,26 +78,27 @@ var ErrNotReady = errors.New("TSDB not ready")
 // millisecond precision timestamps.
 func DefaultOptions() *Options {
 	return &Options{
-		WALSegmentSize:              wlog.DefaultSegmentSize,
-		MaxBlockChunkSegmentSize:    chunks.DefaultChunkSegmentSize,
-		RetentionDuration:           int64(15 * 24 * time.Hour / time.Millisecond),
-		MinBlockDuration:            DefaultBlockDuration,
-		MaxBlockDuration:            DefaultBlockDuration,
-		NoLockfile:                  false,
-		SamplesPerChunk:             DefaultSamplesPerChunk,
-		WALCompression:              compression.None,
-		StripeSize:                  DefaultStripeSize,
-		HeadChunksWriteBufferSize:   chunks.DefaultWriteBufferSize,
-		IsolationDisabled:           defaultIsolationDisabled,
-		HeadChunksWriteQueueSize:    chunks.DefaultWriteQueueSize,
-		OutOfOrderCapMax:            DefaultOutOfOrderCapMax,
-		EnableOverlappingCompaction: true,
-		EnableSharding:              false,
-		EnableDelayedCompaction:     false,
-		CompactionDelayMaxPercent:   DefaultCompactionDelayMaxPercent,
-		CompactionDelay:             time.Duration(0),
-		PostingsDecoderFactory:      DefaultPostingsDecoderFactory,
-		BlockReloadInterval:         1 * time.Minute,
+		WALSegmentSize:               wlog.DefaultSegmentSize,
+		MaxBlockChunkSegmentSize:     chunks.DefaultChunkSegmentSize,
+		RetentionDuration:            int64(15 * 24 * time.Hour / time.Millisecond),
+		MinBlockDuration:             DefaultBlockDuration,
+		MaxBlockDuration:             DefaultBlockDuration,
+		NoLockfile:                   false,
+		SamplesPerChunk:              DefaultSamplesPerChunk,
+		WALCompression:               compression.None,
+		StripeSize:                   DefaultStripeSize,
+		HeadChunksWriteBufferSize:    chunks.DefaultWriteBufferSize,
+		IsolationDisabled:            defaultIsolationDisabled,
+		HeadChunksWriteQueueSize:     chunks.DefaultWriteQueueSize,
+		OutOfOrderCapMax:             DefaultOutOfOrderCapMax,
+		OutOfOrderCompactionInterval: DefaultOutOfOrderCompactionInterval,
+		EnableOverlappingCompaction:  true,
+		EnableSharding:               false,
+		EnableDelayedCompaction:      false,
+		CompactionDelayMaxPercent:    DefaultCompactionDelayMaxPercent,
+		CompactionDelay:              time.Duration(0),
+		PostingsDecoderFactory:       DefaultPostingsDecoderFactory,
+		BlockReloadInterval:          1 * time.Minute,
 	}
 }
 
@@ -195,6 +199,11 @@ type Options struct {
 	// OutOfOrderCapMax is maximum capacity for OOO chunks (in samples).
 	// If it is <=0, the default value is assumed.
 	OutOfOrderCapMax int64
+
+	// OutOfOrderCompactionInterval specifies the interval for automatic compaction of
+	// out-of-order head block.
+	// If it is <= 0, the default value is assumed.
+	OutOfOrderCompactionInterval time.Duration
 
 	// Compaction of overlapping blocks are allowed if EnableOverlappingCompaction is true.
 	// This is an optional flag for overlapping blocks.
@@ -356,9 +365,9 @@ type dbMetrics struct {
 	symbolTableSize                 prometheus.GaugeFunc
 	reloads                         prometheus.Counter
 	reloadsFailed                   prometheus.Counter
-	compactionsFailed               prometheus.Counter
-	compactionsTriggered            prometheus.Counter
-	compactionsSkipped              prometheus.Counter
+	compactionsFailed               prometheus.CounterVec
+	compactionsTriggered            prometheus.CounterVec
+	compactionsSkipped              prometheus.CounterVec
 	sizeRetentionCount              prometheus.Counter
 	timeRetentionCount              prometheus.Counter
 	startTime                       prometheus.GaugeFunc
@@ -404,22 +413,22 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 		Name: "prometheus_tsdb_reloads_failures_total",
 		Help: "Number of times the database failed to reloadBlocks block data from disk.",
 	})
-	m.compactionsTriggered = prometheus.NewCounter(prometheus.CounterOpts{
+	m.compactionsTriggered = *prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_compactions_triggered_total",
 		Help: "Total number of triggered compactions for the partition.",
-	})
-	m.compactionsFailed = prometheus.NewCounter(prometheus.CounterOpts{
+	}, []string{"type"})
+	m.compactionsFailed = *prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_compactions_failed_total",
 		Help: "Total number of compactions that failed for the partition.",
-	})
+	}, []string{"type"})
 	m.timeRetentionCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_time_retentions_total",
 		Help: "The number of times that blocks were deleted because the maximum time limit was exceeded.",
 	})
-	m.compactionsSkipped = prometheus.NewCounter(prometheus.CounterOpts{
+	m.compactionsSkipped = *prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_compactions_skipped_total",
 		Help: "Total number of skipped compactions due to disabled auto compaction.",
-	})
+	}, []string{"type"})
 	m.startTime = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "prometheus_tsdb_lowest_timestamp",
 		Help: "Lowest timestamp value stored in the database. The unit is decided by the library consumer.",
@@ -820,7 +829,6 @@ func (db *DBReadOnly) LastBlockID() (string, error) {
 	if lastBlockID == "" {
 		return "", errors.New("no blocks found")
 	}
-
 	return lastBlockID, nil
 }
 
@@ -913,6 +921,9 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
 	}
 	if opts.OutOfOrderTimeWindow < 0 {
 		opts.OutOfOrderTimeWindow = 0
+	}
+	if opts.OutOfOrderCompactionInterval <= 0 {
+		opts.OutOfOrderCompactionInterval = DefaultOutOfOrderCompactionInterval
 	}
 	if opts.BlockReloadInterval < 1*time.Second {
 		opts.BlockReloadInterval = 1 * time.Second
@@ -1185,10 +1196,31 @@ func (db *DB) BlockMetas() []BlockMeta {
 	return metas
 }
 
+// calculateTimeUntilNextOOOCompaction calculates the time until the next out-of-order compaction.
+// We pass nowUnix as a parameter to make it easier to test.
+func calculateTimeUntilNextOOOCompaction(nowUnix int64, oooCompactionInterval time.Duration) time.Duration {
+	intvSec := int64(oooCompactionInterval / time.Second)
+	// For sub-second intervals, skip alignment.
+	if intvSec == 0 {
+		return oooCompactionInterval
+	}
+	// We align the out-of-order compactions to happen with in-order compaction, which happens midway
+	// between aligned intervals of time.
+	nextCompaction := (nowUnix / intvSec) * intvSec
+	nextCompaction += intvSec / 2
+	if nextCompaction < nowUnix {
+		nextCompaction += intvSec
+	}
+	return time.Duration(nextCompaction-nowUnix) * time.Second
+}
+
 func (db *DB) run(ctx context.Context) {
 	defer close(db.donec)
 
 	backoff := time.Duration(0)
+
+	nextOOOCompaction := calculateTimeUntilNextOOOCompaction(time.Now().Unix(), db.opts.OutOfOrderCompactionInterval)
+	oooScheduledCompact := time.NewTimer(nextOOOCompaction)
 
 	for {
 		select {
@@ -1234,8 +1266,24 @@ func (db *DB) run(ctx context.Context) {
 				}
 			}
 
+		case <-oooScheduledCompact.C:
+			db.metrics.compactionsTriggered.WithLabelValues("ooo").Inc()
+
+			db.autoCompactMtx.Lock()
+			if db.autoCompact {
+				if err := db.CompactOOOHead(ctx); err != nil {
+					db.logger.Error("ooo compaction failed", "err", err)
+				}
+			} else {
+				db.metrics.compactionsSkipped.WithLabelValues("ooo").Inc()
+			}
+			db.autoCompactMtx.Unlock()
+
+			// Reset the timer for the next OOO compaction.
+			oooScheduledCompact.Reset(db.opts.OutOfOrderCompactionInterval)
+
 		case <-db.compactc:
-			db.metrics.compactionsTriggered.Inc()
+			db.metrics.compactionsTriggered.WithLabelValues("head").Inc()
 
 			db.autoCompactMtx.Lock()
 			if db.autoCompact {
@@ -1246,7 +1294,7 @@ func (db *DB) run(ctx context.Context) {
 					backoff = 0
 				}
 			} else {
-				db.metrics.compactionsSkipped.Inc()
+				db.metrics.compactionsSkipped.WithLabelValues("head").Inc()
 			}
 			db.autoCompactMtx.Unlock()
 		case <-db.stopc:
@@ -1418,14 +1466,14 @@ func (db *DB) waitingForCompactionDelay() bool {
 // which will also delete the blocks that fall out of the retention window.
 // Old blocks are only deleted on reloadBlocks based on the new block's parent information.
 // See DB.reloadBlocks documentation for further information.
-func (db *DB) Compact(ctx context.Context) (returnErr error) {
+func (db *DB) Compact(_ context.Context) (returnErr error) {
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
 	defer func() {
 		if returnErr != nil && !errors.Is(returnErr, context.Canceled) {
 			// If we got an error because context was canceled then we're most likely
 			// shutting down TSDB and we don't need to report this on metrics
-			db.metrics.compactionsFailed.Inc()
+			db.metrics.compactionsFailed.WithLabelValues("head").Inc()
 		}
 	}()
 
@@ -1502,13 +1550,6 @@ func (db *DB) Compact(ctx context.Context) (returnErr error) {
 		)
 	}
 
-	if lastBlockMaxt != math.MinInt64 {
-		// The head was compacted, so we compact OOO head as well.
-		if err := db.compactOOOHead(ctx); err != nil {
-			return fmt.Errorf("compact ooo head: %w", err)
-		}
-	}
-
 	return db.compactBlocks()
 }
 
@@ -1532,7 +1573,11 @@ func (db *DB) CompactOOOHead(ctx context.Context) error {
 	db.cmtx.Lock()
 	defer db.cmtx.Unlock()
 
-	return db.compactOOOHead(ctx)
+	if err := db.compactOOOHead(ctx); err != nil {
+		db.metrics.compactionsFailed.WithLabelValues("ooo").Inc()
+		return err
+	}
+	return nil
 }
 
 // Callback for testing.

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -4028,6 +4028,7 @@ func testOOOCompactionWithNormalCompactionAppendV2(t *testing.T, scenario sample
 
 	// Compacts normal and OOO head.
 	require.NoError(t, db.Compact(ctx))
+	require.NoError(t, db.CompactOOOHead(ctx))
 
 	// 2 blocks exist now. [0, 120), [250, 360)
 	require.Len(t, db.Blocks(), 2)
@@ -4134,6 +4135,7 @@ func testOOOCompactionWithDisabledWriteLogAppend2(t *testing.T, scenario sampleT
 
 	// Compacts normal and OOO head.
 	require.NoError(t, db.Compact(ctx))
+	require.NoError(t, db.CompactOOOHead(ctx))
 
 	// 2 blocks exist now. [0, 120), [250, 360)
 	require.Len(t, db.Blocks(), 2)
@@ -6921,6 +6923,7 @@ func testNoGapAfterRestartWithOOOAppendV2(t *testing.T, scenario sampleTypeScena
 
 			// We get 2 blocks. 1 from OOO, 1 from in-order.
 			require.NoError(t, db.Compact(ctx))
+			require.NoError(t, db.CompactOOOHead(ctx))
 			verifyBlockRanges := func() {
 				blocks := db.Blocks()
 				require.Len(t, blocks, len(c.blockRanges))

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -5236,24 +5236,24 @@ func testOOOCompaction(t *testing.T, scenario sampleTypeScenario, addExtraSample
 	verifyDBSamples() // Final state. Blocks from normal and OOO head are merged.
 }
 
-// TestOOOCompactionWithNormalCompaction tests if OOO compaction is performed
-// when the normal head's compaction is done.
-func TestOOOCompactionWithNormalCompaction(t *testing.T) {
+// TestOOOScheduledCompaction verifies that OOO compaction is performed at the scheduled interval.
+func TestOOOScheduledCompaction(t *testing.T) {
 	t.Parallel()
 	for name, scenario := range sampleTypeScenarios {
 		t.Run(name, func(t *testing.T) {
-			testOOOCompactionWithNormalCompaction(t, scenario)
+			testOOOScheduledCompaction(t, scenario)
 		})
 	}
 }
 
-func testOOOCompactionWithNormalCompaction(t *testing.T, scenario sampleTypeScenario) {
+func testOOOScheduledCompaction(t *testing.T, scenario sampleTypeScenario) {
 	t.Parallel()
 	ctx := context.Background()
 
 	opts := DefaultOptions()
 	opts.OutOfOrderCapMax = 30
 	opts.OutOfOrderTimeWindow = 300 * time.Minute.Milliseconds()
+	opts.OutOfOrderCompactionInterval = 100 * time.Millisecond // Set a short interval for testing.
 
 	db := newTestDB(t, withOpts(opts))
 	db.DisableCompactions() // We want to manually call it.
@@ -5297,23 +5297,9 @@ func testOOOCompactionWithNormalCompaction(t *testing.T, scenario sampleTypeScen
 	// No blocks before compaction.
 	require.Empty(t, db.Blocks())
 
-	// Compacts normal and OOO head.
+	// Ensure OOO head is not compacted even when in-order head is.
 	require.NoError(t, db.Compact(ctx))
-
-	// 2 blocks exist now. [0, 120), [250, 360)
-	require.Len(t, db.Blocks(), 2)
-	require.Equal(t, int64(0), db.Blocks()[0].MinTime())
-	require.Equal(t, 120*time.Minute.Milliseconds(), db.Blocks()[0].MaxTime())
-	require.Equal(t, 250*time.Minute.Milliseconds(), db.Blocks()[1].MinTime())
-	require.Equal(t, 360*time.Minute.Milliseconds(), db.Blocks()[1].MaxTime())
-
-	// Checking that ooo chunk is empty.
-	for _, lbls := range []labels.Labels{series1, series2} {
-		ms, created, err := db.head.getOrCreate(lbls.Hash(), lbls, false)
-		require.NoError(t, err)
-		require.False(t, created)
-		require.Nil(t, ms.ooo)
-	}
+	require.Len(t, db.Blocks(), 1)
 
 	verifySamples := func(block *Block, fromMins, toMins int64) {
 		series1Samples := make([]chunks.Sample, 0, toMins-fromMins+1)
@@ -5335,9 +5321,38 @@ func testOOOCompactionWithNormalCompaction(t *testing.T, scenario sampleTypeScen
 		requireEqualSeries(t, expRes, actRes, true)
 	}
 
-	// Checking for expected data in the blocks.
-	verifySamples(db.Blocks()[0], 90, 110)
-	verifySamples(db.Blocks()[1], 250, 350)
+	// Now enable auto compaction and expect the OOO head to be compacted at the scheduled interval.
+	db.EnableCompactions()
+	require.Eventually(t, func() bool {
+		if len(db.Blocks()) < 2 {
+			return false
+		}
+
+		// Stop running compactions while getting data for verification to prevent a race condition.
+		db.DisableCompactions()
+
+		// 2 blocks exist now. [0, 120), [250, 360	require.Len(t, db.Blocks(), 2)
+		require.Equal(t, int64(0), db.Blocks()[0].MinTime())
+		require.Equal(t, 120*time.Minute.Milliseconds(), db.Blocks()[0].MaxTime())
+		require.Equal(t, 250*time.Minute.Milliseconds(), db.Blocks()[1].MinTime())
+		require.Equal(t, 360*time.Minute.Milliseconds(), db.Blocks()[1].MaxTime())
+
+		// Checking that ooo chunk is empty.
+		for _, lbls := range []labels.Labels{series1, series2} {
+			ms, created, err := db.head.getOrCreate(lbls.Hash(), lbls, false)
+			require.NoError(t, err)
+			require.False(t, created)
+			require.Nil(t, ms.ooo)
+		}
+
+		// Checking for expected data in the blocks.
+		verifySamples(db.Blocks()[0], 90, 110)
+		verifySamples(db.Blocks()[1], 250, 350)
+
+		return true
+
+		// Sometimes the compaction can be slow; wait 3s to prevent test flakiness.
+	}, 3*time.Second, 100*time.Millisecond, "Expected blocks to be created from OOO compaction")
 }
 
 // TestOOOCompactionWithDisabledWriteLog tests the scenario where the TSDB is
@@ -5405,6 +5420,7 @@ func testOOOCompactionWithDisabledWriteLog(t *testing.T, scenario sampleTypeScen
 
 	// Compacts normal and OOO head.
 	require.NoError(t, db.Compact(ctx))
+	require.NoError(t, db.CompactOOOHead(ctx))
 
 	// 2 blocks exist now. [0, 120), [250, 360)
 	require.Len(t, db.Blocks(), 2)
@@ -7622,6 +7638,92 @@ func testOOOCompactionFailure(t *testing.T, scenario sampleTypeScenario) {
 	verifyMmapFiles("000001")
 }
 
+func TestCalculateTimeUntilNextOOOCompaction(t *testing.T) {
+	tests := []struct {
+		name     string
+		nowUnix  int64
+		interval time.Duration
+		expected time.Duration
+	}{
+		{
+			name:     "2h interval - exact beginning",
+			nowUnix:  1775030400, // Wed Apr 01 2026 08:00:00 UTC
+			interval: 2 * time.Hour,
+			expected: time.Hour, // Wait until midpoint (09:00:00)
+		},
+		{
+			name:     "2h interval - before midpoint",
+			nowUnix:  1775033400, // Wed Apr 01 2026 08:50:00 UTC
+			interval: 2 * time.Hour,
+			expected: 10 * time.Minute, // Wait until midpoint (09:00:00)
+		},
+		{
+			name:     "2h interval - exact midpoint",
+			nowUnix:  1775034000, // Wed Apr 01 2026 09:00:00 UTC
+			interval: 2 * time.Hour,
+			expected: 0, // At midpoint, compaction should trigger immediately
+		},
+		{
+			name:     "2h interval - after midpoint",
+			nowUnix:  1775034600, // Wed Apr 01 2026 09:10:00 UTC
+			interval: 2 * time.Hour,
+			expected: 110 * time.Minute, // Wait until next midpoint (11:00:00)
+		},
+		{
+			name:     "2h interval - exact end",
+			nowUnix:  1775037600, // Wed Apr 01 2026 10:00:00 UTC
+			interval: 2 * time.Hour,
+			expected: time.Hour, // Wait until next midpoint (11:00:00)
+		},
+		{
+			name:     "4h interval - before midpoint",
+			nowUnix:  1775034000, // Wed Apr 01 2026 09:00:00 UTC
+			interval: 4 * time.Hour,
+			expected: time.Hour, // Wait until midpoint (10:00:00)
+		},
+		{
+			name:     "4h interval - after midpoint",
+			nowUnix:  1775041200, // Wed Apr 01 2026 11:00:00 UTC
+			interval: 4 * time.Hour,
+			expected: 3 * time.Hour, // Wait until next midpoint (14:00:00)
+		},
+		{
+			name:     "1 second interval - always trigger immediately",
+			nowUnix:  1775001601, // Wed Apr 01 2026 00:00:01 UTC
+			interval: 1 * time.Second,
+			expected: 0, // At midpoint, compaction should trigger immediately
+		},
+		{
+			name:     "2 second interval - at start",
+			nowUnix:  1775001600, // Wed Apr 01 2026 00:00:00 UTC
+			interval: 2 * time.Second,
+			expected: 1 * time.Second, // Wait until midpoint (1 second)
+		},
+		{
+			name:     "2 second interval - at midpoint",
+			nowUnix:  1775001601, // Wed Apr 01 2026 00:00:01 UTC
+			interval: 2 * time.Second,
+			expected: 0, // At midpoint, compaction should trigger immediately
+		},
+		{
+			name:     "sub-second interval - skip alignment",
+			nowUnix:  1775001600, // Wed Apr 01 2026 00:00:00 UTC
+			interval: 100 * time.Millisecond,
+			expected: 100 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateTimeUntilNextOOOCompaction(tt.nowUnix, tt.interval)
+			require.Equal(t, tt.expected, result,
+				"nowUnix=%d (%s), interval=%v, expected=%v, got=%v",
+				tt.nowUnix, time.Unix(tt.nowUnix, 0).UTC().Format(time.RFC3339),
+				tt.interval, tt.expected, result)
+		})
+	}
+}
+
 func TestWBLCorruption(t *testing.T) {
 	opts := DefaultOptions()
 	opts.OutOfOrderCapMax = 30
@@ -8200,6 +8302,7 @@ func testNoGapAfterRestartWithOOO(t *testing.T, scenario sampleTypeScenario) {
 
 			// We get 2 blocks. 1 from OOO, 1 from in-order.
 			require.NoError(t, db.Compact(ctx))
+			require.NoError(t, db.CompactOOOHead(ctx))
 			verifyBlockRanges := func() {
 				blocks := db.Blocks()
 				require.Len(t, blocks, len(c.blockRanges))
@@ -8429,6 +8532,7 @@ func testDiskFillingUpAfterDisablingOOO(t *testing.T, scenario sampleTypeScenari
 	// See https://github.com/prometheus/prometheus/issues/17941#issuecomment-3846381263
 	require.NotPanics(t, func() {
 		require.NoError(t, db.Compact(ctx))
+		require.NoError(t, db.CompactOOOHead(ctx))
 	})
 
 	checkMmapFileContents([]string{"000002"}, []string{"000001"})
@@ -8444,6 +8548,7 @@ func testDiskFillingUpAfterDisablingOOO(t *testing.T, scenario sampleTypeScenari
 	// See https://github.com/prometheus/prometheus/issues/17941#issuecomment-3846381263
 	require.NotPanics(t, func() {
 		require.NoError(t, db.Compact(ctx))
+		require.NoError(t, db.CompactOOOHead(ctx))
 	})
 	checkMmapFileContents(nil, []string{"000001", "000002", "000003"})
 


### PR DESCRIPTION
Allow OOO head compaction to run independently instead of being triggered after in-order head compaction.

#### Key changes:
- Remove implicit OOO compaction after in-order compaction
- Schedule OOO compaction via a configurable timer (default: 2h)
- Convert compaction metrics to CounterVec to track head vs ooo separately, as suggested by @bwplotka at https://github.com/prometheus/prometheus/pull/11847#issuecomment-1561607309.

Fixes #11834

This PR continues the work started in #11847.


#### Notes for reviewers
Since it changes TSDB compaction metrics, would this be considered a user-facing change? If so, please let me know if I should add or update anything (e.g., documentation). Happy to make any necessary updates. Thanks for your guidance!


#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```
