### PR TITLE
kubernetes_sd: support daemonset metadata enrichment

### DIFF
--- a/discovery/kubernetes/endpoints.go
+++ b/discovery/kubernetes/endpoints.go
@@ -46,6 +46,7 @@ type Endpoints struct {
 	withNamespaceMetadata  bool
 	replicaSetInf          cache.SharedInformer
 	withDeploymentMetadata bool
+	withDaemonSetMetadata  bool
 	jobInf                 cache.SharedInformer
 	withJobMetadata        bool
 	withCronJobMetadata    bool
@@ -60,7 +61,7 @@ type Endpoints struct {
 // NewEndpoints returns a new endpoints discovery.
 //
 // Deprecated: The Endpoints API is deprecated starting in K8s v1.33+. Use NewEndpointSlice.
-func NewEndpoints(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, node, namespace, rs, job cache.SharedInformer, withDeploymentMetadata, withJobMetadata, withCronJobMetadata bool, eventCount *prometheus.CounterVec) *Endpoints {
+func NewEndpoints(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, node, namespace, rs, job cache.SharedInformer, withDeploymentMetadata, withDaemonSetMetadata, withJobMetadata, withCronJobMetadata bool, eventCount *prometheus.CounterVec) *Endpoints {
 	if l == nil {
 		l = promslog.NewNopLogger()
 	}
@@ -89,6 +90,7 @@ func NewEndpoints(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, node,
 		withNamespaceMetadata:  namespace != nil,
 		replicaSetInf:          rs,
 		withDeploymentMetadata: withDeploymentMetadata,
+		withDaemonSetMetadata:  withDaemonSetMetadata,
 		jobInf:                 job,
 		withJobMetadata:        withJobMetadata,
 		withCronJobMetadata:    withCronJobMetadata,
@@ -410,7 +412,7 @@ func (e *Endpoints) buildEndpoints(eps *apiv1.Endpoints) *targetgroup.Group {
 		}
 
 		// Attach standard pod labels.
-		target = target.Merge(podLabels(pod, e.replicaSetInf, e.jobInf, e.withDeploymentMetadata, e.withJobMetadata, e.withCronJobMetadata))
+		target = target.Merge(podLabels(pod, e.replicaSetInf, e.jobInf, e.withDeploymentMetadata, e.withDaemonSetMetadata, e.withJobMetadata, e.withCronJobMetadata))
 
 		// Attach potential container port labels matching the endpoint port.
 		containers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
@@ -494,7 +496,7 @@ func (e *Endpoints) buildEndpoints(eps *apiv1.Endpoints) *targetgroup.Group {
 					podContainerPortProtocolLabel: lv(string(cport.Protocol)),
 					podContainerIsInit:            lv(strconv.FormatBool(isInit)),
 				}
-				tg.Targets = append(tg.Targets, target.Merge(podLabels(pe.pod, e.replicaSetInf, e.jobInf, e.withDeploymentMetadata, e.withJobMetadata, e.withCronJobMetadata)))
+				tg.Targets = append(tg.Targets, target.Merge(podLabels(pe.pod, e.replicaSetInf, e.jobInf, e.withDeploymentMetadata, e.withDaemonSetMetadata, e.withJobMetadata, e.withCronJobMetadata)))
 			}
 		}
 	}

--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -278,6 +278,84 @@ func TestEndpointsDiscoveryAdd(t *testing.T) {
 	}.Run(t)
 }
 
+func TestEndpointsDiscoveryWithDaemonSet(t *testing.T) {
+	t.Parallel()
+
+	daemonSet := makeDaemonSet("testdaemonset", "default")
+	pod := makeDaemonSetOwnedPod("default", daemonSet.Name, daemonSet.UID)
+	endpoints := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testendpoints",
+			Namespace: "default",
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: []v1.EndpointAddress{
+					{
+						IP: pod.Status.PodIP,
+						TargetRef: &v1.ObjectReference{
+							Kind:      "Pod",
+							Name:      pod.Name,
+							Namespace: pod.Namespace,
+						},
+					},
+				},
+				Ports: []v1.EndpointPort{
+					{
+						Name:     "testport",
+						Port:     9000,
+						Protocol: v1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}
+
+	n, _ := makeDiscoveryWithMetadata(RoleEndpoint, NamespaceDiscovery{}, AttachMetadataConfig{
+		PodMetadataConfig: PodMetadataConfig{DaemonSet: true},
+	}, daemonSet, pod, endpoints)
+
+	k8sDiscoveryTest{
+		discovery:        n,
+		expectedMaxItems: 1,
+		expectedRes: map[string]*targetgroup.Group{
+			"endpoints/default/testendpoints": {
+				Targets: []model.LabelSet{
+					{
+						"__address__": "1.2.3.4:9000",
+						"__meta_kubernetes_endpoint_address_target_kind": "Pod",
+						"__meta_kubernetes_endpoint_address_target_name": "testpod",
+						"__meta_kubernetes_endpoint_port_name":           "testport",
+						"__meta_kubernetes_endpoint_port_protocol":       "TCP",
+						"__meta_kubernetes_endpoint_ready":               "true",
+						"__meta_kubernetes_pod_container_image":          "testcontainer:latest",
+						"__meta_kubernetes_pod_container_init":           "false",
+						"__meta_kubernetes_pod_container_name":           "testcontainer",
+						"__meta_kubernetes_pod_container_port_name":      "testport",
+						"__meta_kubernetes_pod_container_port_number":    "9000",
+						"__meta_kubernetes_pod_container_port_protocol":  "TCP",
+						"__meta_kubernetes_pod_controller_kind":          "DaemonSet",
+						"__meta_kubernetes_pod_controller_name":          "testdaemonset",
+						"__meta_kubernetes_pod_daemonset_name":           "testdaemonset",
+						"__meta_kubernetes_pod_host_ip":                  "2.3.4.5",
+						"__meta_kubernetes_pod_ip":                       "1.2.3.4",
+						"__meta_kubernetes_pod_name":                     "testpod",
+						"__meta_kubernetes_pod_node_name":                "testnode",
+						"__meta_kubernetes_pod_phase":                    "Running",
+						"__meta_kubernetes_pod_ready":                    "true",
+						"__meta_kubernetes_pod_uid":                      "pod123",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_endpoints_name": "testendpoints",
+					"__meta_kubernetes_namespace":      "default",
+				},
+				Source: "endpoints/default/testendpoints",
+			},
+		},
+	}.Run(t)
+}
+
 func TestEndpointsDiscoveryDelete(t *testing.T) {
 	t.Parallel()
 	n, c := makeDiscovery(RoleEndpoint, NamespaceDiscovery{}, makeEndpoints("default"))

--- a/discovery/kubernetes/endpointslice.go
+++ b/discovery/kubernetes/endpointslice.go
@@ -47,6 +47,7 @@ type EndpointSlice struct {
 	withNamespaceMetadata  bool
 	replicaSetInf          cache.SharedInformer
 	withDeploymentMetadata bool
+	withDaemonSetMetadata  bool
 	jobInf                 cache.SharedInformer
 	withJobMetadata        bool
 	withCronJobMetadata    bool
@@ -59,7 +60,7 @@ type EndpointSlice struct {
 }
 
 // NewEndpointSlice returns a new endpointslice discovery.
-func NewEndpointSlice(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, node, namespace, rs, job cache.SharedInformer, withDeploymentMetadata, withJobMetadata, withCronJobMetadata bool, eventCount *prometheus.CounterVec) *EndpointSlice {
+func NewEndpointSlice(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, node, namespace, rs, job cache.SharedInformer, withDeploymentMetadata, withDaemonSetMetadata, withJobMetadata, withCronJobMetadata bool, eventCount *prometheus.CounterVec) *EndpointSlice {
 	if l == nil {
 		l = promslog.NewNopLogger()
 	}
@@ -86,6 +87,7 @@ func NewEndpointSlice(l *slog.Logger, eps cache.SharedIndexInformer, svc, pod, n
 		withNamespaceMetadata:  namespace != nil,
 		replicaSetInf:          rs,
 		withDeploymentMetadata: withDeploymentMetadata,
+		withDaemonSetMetadata:  withDaemonSetMetadata,
 		jobInf:                 job,
 		withJobMetadata:        withJobMetadata,
 		withCronJobMetadata:    withCronJobMetadata,
@@ -416,7 +418,7 @@ func (e *EndpointSlice) buildEndpointSlice(eps v1.EndpointSlice) *targetgroup.Gr
 		}
 
 		// Attach standard pod labels.
-		target = target.Merge(podLabels(pod, e.replicaSetInf, e.jobInf, e.withDeploymentMetadata, e.withJobMetadata, e.withCronJobMetadata))
+		target = target.Merge(podLabels(pod, e.replicaSetInf, e.jobInf, e.withDeploymentMetadata, e.withDaemonSetMetadata, e.withJobMetadata, e.withCronJobMetadata))
 
 		// Attach potential container port labels matching the endpoint port.
 		containers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
@@ -494,7 +496,7 @@ func (e *EndpointSlice) buildEndpointSlice(eps v1.EndpointSlice) *targetgroup.Gr
 					podContainerPortProtocolLabel: lv(string(cport.Protocol)),
 					podContainerIsInit:            lv(strconv.FormatBool(isInit)),
 				}
-				tg.Targets = append(tg.Targets, target.Merge(podLabels(pe.pod, e.replicaSetInf, e.jobInf, e.withDeploymentMetadata, e.withJobMetadata, e.withCronJobMetadata)))
+				tg.Targets = append(tg.Targets, target.Merge(podLabels(pe.pod, e.replicaSetInf, e.jobInf, e.withDeploymentMetadata, e.withDaemonSetMetadata, e.withJobMetadata, e.withCronJobMetadata)))
 			}
 		}
 	}

--- a/discovery/kubernetes/endpointslice_test.go
+++ b/discovery/kubernetes/endpointslice_test.go
@@ -334,6 +334,86 @@ func TestEndpointSliceDiscoveryAdd(t *testing.T) {
 	}.Run(t)
 }
 
+func TestEndpointSliceDiscoveryWithDaemonSet(t *testing.T) {
+	t.Parallel()
+
+	daemonSet := makeDaemonSet("testdaemonset", "default")
+	pod := makeDaemonSetOwnedPod("default", daemonSet.Name, daemonSet.UID)
+	endpointSlice := &v1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testendpoints",
+			Namespace: "default",
+		},
+		AddressType: v1.AddressTypeIPv4,
+		Ports: []v1.EndpointPort{
+			{
+				Name:     strptr("testport"),
+				Port:     int32ptr(9000),
+				Protocol: protocolptr(corev1.ProtocolTCP),
+			},
+		},
+		Endpoints: []v1.Endpoint{
+			{
+				Addresses: []string{pod.Status.PodIP},
+				Conditions: v1.EndpointConditions{
+					Ready: boolptr(true),
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+				},
+			},
+		},
+	}
+
+	n, _ := makeDiscoveryWithMetadata(RoleEndpointSlice, NamespaceDiscovery{}, AttachMetadataConfig{
+		PodMetadataConfig: PodMetadataConfig{DaemonSet: true},
+	}, daemonSet, pod, endpointSlice)
+
+	k8sDiscoveryTest{
+		discovery:        n,
+		expectedMaxItems: 1,
+		expectedRes: map[string]*targetgroup.Group{
+			"endpointslice/default/testendpoints": {
+				Targets: []model.LabelSet{
+					{
+						"__address__": "1.2.3.4:9000",
+						"__meta_kubernetes_endpointslice_address_target_kind":       "Pod",
+						"__meta_kubernetes_endpointslice_address_target_name":       "testpod",
+						"__meta_kubernetes_endpointslice_endpoint_conditions_ready": "true",
+						"__meta_kubernetes_endpointslice_port":                      "9000",
+						"__meta_kubernetes_endpointslice_port_name":                 "testport",
+						"__meta_kubernetes_endpointslice_port_protocol":             "TCP",
+						"__meta_kubernetes_pod_container_image":                     "testcontainer:latest",
+						"__meta_kubernetes_pod_container_init":                      "false",
+						"__meta_kubernetes_pod_container_name":                      "testcontainer",
+						"__meta_kubernetes_pod_container_port_name":                 "testport",
+						"__meta_kubernetes_pod_container_port_number":               "9000",
+						"__meta_kubernetes_pod_container_port_protocol":             "TCP",
+						"__meta_kubernetes_pod_controller_kind":                     "DaemonSet",
+						"__meta_kubernetes_pod_controller_name":                     "testdaemonset",
+						"__meta_kubernetes_pod_daemonset_name":                      "testdaemonset",
+						"__meta_kubernetes_pod_host_ip":                             "2.3.4.5",
+						"__meta_kubernetes_pod_ip":                                  "1.2.3.4",
+						"__meta_kubernetes_pod_name":                                "testpod",
+						"__meta_kubernetes_pod_node_name":                           "testnode",
+						"__meta_kubernetes_pod_phase":                               "Running",
+						"__meta_kubernetes_pod_ready":                               "true",
+						"__meta_kubernetes_pod_uid":                                 "pod123",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_endpointslice_address_type": "IPv4",
+					"__meta_kubernetes_endpointslice_name":         "testendpoints",
+					"__meta_kubernetes_namespace":                  "default",
+				},
+				Source: "endpointslice/default/testendpoints",
+			},
+		},
+	}.Run(t)
+}
+
 func TestEndpointSliceDiscoveryDelete(t *testing.T) {
 	t.Parallel()
 	n, c := makeDiscovery(RoleEndpointSlice, NamespaceDiscovery{Names: []string{"default"}}, makeEndpointSliceV1("default"))

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -165,6 +165,7 @@ type AttachMetadataConfig struct {
 // PodMetadataConfig allows configuring which pod-related metadata to attach.
 type PodMetadataConfig struct {
 	Deployment bool `yaml:"deployment"`
+	DaemonSet  bool `yaml:"daemonset"`
 	Job        bool `yaml:"job"`
 	CronJob    bool `yaml:"cronjob"`
 }
@@ -465,6 +466,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 				replicaSetInf,
 				jobInformer,
 				d.attachMetadata.Deployment,
+				d.attachMetadata.DaemonSet,
 				d.attachMetadata.Job,
 				d.attachMetadata.CronJob,
 				d.metrics.eventCount,
@@ -546,6 +548,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 				replicaSetInf,
 				jobInformer,
 				d.attachMetadata.Deployment,
+				d.attachMetadata.DaemonSet,
 				d.attachMetadata.Job,
 				d.attachMetadata.CronJob,
 				d.metrics.eventCount,
@@ -598,6 +601,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 				replicaSetInformer,
 				jobInformer,
 				d.attachMetadata.Deployment,
+				d.attachMetadata.DaemonSet,
 				d.attachMetadata.Job,
 				d.attachMetadata.CronJob,
 				d.metrics.eventCount,

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -162,7 +162,7 @@ type AttachMetadataConfig struct {
 	PodMetadataConfig `yaml:",inline"`
 }
 
-// PodMetadataConfig allows configuring which pod-related metadata to attach.
+// PodMetadataConfig allows configuring which pod-related metadata to attach. The fields below may be used through `AttachMetadataConfig` above in non-pod discoveries.
 type PodMetadataConfig struct {
 	Deployment bool `yaml:"deployment"`
 	DaemonSet  bool `yaml:"daemonset"`

--- a/discovery/kubernetes/pod.go
+++ b/discovery/kubernetes/pod.go
@@ -51,6 +51,7 @@ type Pod struct {
 	withNamespaceMetadata  bool
 	replicaSetInf          cache.SharedInformer
 	withDeploymentMetadata bool
+	withDaemonSetMetadata  bool
 	jobInf                 cache.SharedInformer
 	withJobMetadata        bool
 	withCronJobMetadata    bool
@@ -60,7 +61,7 @@ type Pod struct {
 }
 
 // NewPod creates a new pod discovery.
-func NewPod(l *slog.Logger, pods cache.SharedIndexInformer, nodes, namespace, replicaSets, jobs cache.SharedInformer, withDeploymentMetadata, withJobMetadata, withCronJobMetadata bool, eventCount *prometheus.CounterVec) *Pod {
+func NewPod(l *slog.Logger, pods cache.SharedIndexInformer, nodes, namespace, replicaSets, jobs cache.SharedInformer, withDeploymentMetadata, withDaemonSetMetadata, withJobMetadata, withCronJobMetadata bool, eventCount *prometheus.CounterVec) *Pod {
 	if l == nil {
 		l = promslog.NewNopLogger()
 	}
@@ -77,6 +78,7 @@ func NewPod(l *slog.Logger, pods cache.SharedIndexInformer, nodes, namespace, re
 		withNamespaceMetadata:  namespace != nil,
 		replicaSetInf:          replicaSets,
 		withDeploymentMetadata: withDeploymentMetadata,
+		withDaemonSetMetadata:  withDaemonSetMetadata,
 		jobInf:                 jobs,
 		withJobMetadata:        withJobMetadata,
 		withCronJobMetadata:    withCronJobMetadata,
@@ -267,6 +269,7 @@ const (
 	podContainerPortProtocolLabel = metaLabelPrefix + "pod_container_port_protocol"
 	podContainerIsInit            = metaLabelPrefix + "pod_container_init"
 	podCronJobNameLabel           = metaLabelPrefix + "pod_cronjob_name"
+	podDaemonSetNameLabel         = metaLabelPrefix + "pod_daemonset_name"
 	podDeploymentNameLabel        = metaLabelPrefix + "pod_deployment_name"
 	podJobNameLabel               = metaLabelPrefix + "pod_job_name"
 	podReadyLabel                 = metaLabelPrefix + "pod_ready"
@@ -289,7 +292,7 @@ func GetControllerOf(controllee metav1.Object) *metav1.OwnerReference {
 	return nil
 }
 
-func podLabels(pod *apiv1.Pod, replicaSetInf, jobInf cache.SharedInformer, withDeploymentMetadata, withJobMetadata, withCronJobMetadata bool) model.LabelSet {
+func podLabels(pod *apiv1.Pod, replicaSetInf, jobInf cache.SharedInformer, withDeploymentMetadata, withDaemonSetMetadata, withJobMetadata, withCronJobMetadata bool) model.LabelSet {
 	ls := model.LabelSet{
 		podIPLabel:       lv(pod.Status.PodIP),
 		podReadyLabel:    podReady(pod),
@@ -322,6 +325,10 @@ func podLabels(pod *apiv1.Pod, replicaSetInf, jobInf cache.SharedInformer, withD
 						}
 					}
 				}
+			}
+		case "DaemonSet":
+			if withDaemonSetMetadata {
+				ls[podDaemonSetNameLabel] = lv(createdBy.Name)
 			}
 		case "Job":
 			if withJobMetadata {
@@ -385,7 +392,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
 		}
 	}
 
-	tg.Labels = podLabels(pod, p.replicaSetInf, p.jobInf, p.withDeploymentMetadata, p.withJobMetadata, p.withCronJobMetadata)
+	tg.Labels = podLabels(pod, p.replicaSetInf, p.jobInf, p.withDeploymentMetadata, p.withDaemonSetMetadata, p.withJobMetadata, p.withCronJobMetadata)
 	tg.Labels[namespaceLabel] = lv(pod.Namespace)
 	if p.withNodeMetadata {
 		tg.Labels = addNodeLabels(tg.Labels, p.nodeInf, p.logger, &pod.Spec.NodeName)

--- a/discovery/kubernetes/pod_test.go
+++ b/discovery/kubernetes/pod_test.go
@@ -729,6 +729,16 @@ func makeDeployment(name, namespace string) *appsv1.Deployment {
 	}
 }
 
+func makeDaemonSet(name, namespace string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID("daemonset123"),
+		},
+	}
+}
+
 func makeJob(name, namespace, cronJobName string, cronJobUID types.UID) *batchv1.Job {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -864,6 +874,57 @@ func makeJobOwnedPod(namespace, jobName string, jobUID types.UID) *v1.Pod {
 	}
 }
 
+func makeDaemonSetOwnedPod(namespace, daemonSetName string, daemonSetUID types.UID) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpod",
+			Namespace: namespace,
+			UID:       types.UID("pod123"),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "DaemonSet",
+					Name:       daemonSetName,
+					UID:        daemonSetUID,
+					Controller: makeOptionalBool(true),
+				},
+			},
+		},
+		Spec: v1.PodSpec{
+			NodeName: "testnode",
+			Containers: []v1.Container{
+				{
+					Name:  "testcontainer",
+					Image: "testcontainer:latest",
+					Ports: []v1.ContainerPort{
+						{
+							Name:          "testport",
+							Protocol:      v1.ProtocolTCP,
+							ContainerPort: int32(9000),
+						},
+					},
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			PodIP:  "1.2.3.4",
+			HostIP: "2.3.4.5",
+			Phase:  "Running",
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodReady,
+					Status: v1.ConditionTrue,
+				},
+			},
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:        "testcontainer",
+					ContainerID: "docker://a1b2c3d4e5f6",
+				},
+			},
+		},
+	}
+}
+
 func TestPodDiscoveryWithDeployment(t *testing.T) {
 	t.Parallel()
 
@@ -904,6 +965,52 @@ func TestPodDiscoveryWithDeployment(t *testing.T) {
 					"__meta_kubernetes_pod_controller_kind": "ReplicaSet",
 					"__meta_kubernetes_pod_controller_name": "testdeployment-rs-abc",
 					"__meta_kubernetes_pod_deployment_name": "testdeployment",
+				},
+				Source: "pod/default/testpod",
+			},
+		},
+	}.Run(t)
+}
+
+func TestPodDiscoveryWithDaemonSet(t *testing.T) {
+	t.Parallel()
+
+	daemonSet := makeDaemonSet("testdaemonset", "default")
+	pod := makeDaemonSetOwnedPod("default", daemonSet.Name, daemonSet.UID)
+
+	n, _ := makeDiscoveryWithMetadata(RolePod, NamespaceDiscovery{}, AttachMetadataConfig{
+		PodMetadataConfig: PodMetadataConfig{DaemonSet: true},
+	}, pod, daemonSet)
+
+	k8sDiscoveryTest{
+		discovery:        n,
+		expectedMaxItems: 1,
+		expectedRes: map[string]*targetgroup.Group{
+			"pod/default/testpod": {
+				Targets: []model.LabelSet{
+					{
+						"__address__":                                   "1.2.3.4:9000",
+						"__meta_kubernetes_pod_container_name":          "testcontainer",
+						"__meta_kubernetes_pod_container_image":         "testcontainer:latest",
+						"__meta_kubernetes_pod_container_port_name":     "testport",
+						"__meta_kubernetes_pod_container_port_number":   "9000",
+						"__meta_kubernetes_pod_container_port_protocol": "TCP",
+						"__meta_kubernetes_pod_container_init":          "false",
+						"__meta_kubernetes_pod_container_id":            "docker://a1b2c3d4e5f6",
+					},
+				},
+				Labels: model.LabelSet{
+					"__meta_kubernetes_pod_name":            "testpod",
+					"__meta_kubernetes_namespace":           "default",
+					"__meta_kubernetes_pod_node_name":       "testnode",
+					"__meta_kubernetes_pod_ip":              "1.2.3.4",
+					"__meta_kubernetes_pod_host_ip":         "2.3.4.5",
+					"__meta_kubernetes_pod_ready":           "true",
+					"__meta_kubernetes_pod_phase":           "Running",
+					"__meta_kubernetes_pod_uid":             "pod123",
+					"__meta_kubernetes_pod_controller_kind": "DaemonSet",
+					"__meta_kubernetes_pod_controller_name": "testdaemonset",
+					"__meta_kubernetes_pod_daemonset_name":  "testdaemonset",
 				},
 				Source: "pod/default/testpod",
 			},

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2493,6 +2493,7 @@ Available meta labels:
 * `__meta_kubernetes_pod_controller_kind`: Object kind of the pod controller.
 * `__meta_kubernetes_pod_controller_name`: Name of the pod controller.
 * `__meta_kubernetes_pod_deployment_name`: Name of the deployment the pod belongs to. Requires `attach_metadata: {deployment: true}`.
+* `__meta_kubernetes_pod_daemonset_name`: Name of the daemonset the pod belongs to. Requires `attach_metadata: {daemonset: true}`.
 * `__meta_kubernetes_pod_cronjob_name`: Name of the cronjob the pod belongs to. Requires `attach_metadata: {cronjob: true}`.
 * `__meta_kubernetes_pod_job_name`: Name of the job the pod belongs to. Requires `attach_metadata: {job: true}`.
 
@@ -2635,6 +2636,9 @@ attach_metadata:
 # When set to true, Prometheus must have permissions to list/watch ReplicaSets.
 # Enables the __meta_kubernetes_pod_deployment_name label.
   [ deployment: <boolean> | default = false ]
+# Attaches daemonset metadata to discovered pod targets. Valid for role: pod.
+# Enables the __meta_kubernetes_pod_daemonset_name label.
+  [ daemonset: <boolean> | default = false ]
 # Attaches job metadata to discovered pod targets. Valid for role: pod.
 # When set to true, Prometheus must have permissions to list/watch Jobs.
 # Enables the __meta_kubernetes_pod_job_name label.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2636,7 +2636,7 @@ attach_metadata:
 # When set to true, Prometheus must have permissions to list/watch ReplicaSets.
 # Enables the __meta_kubernetes_pod_deployment_name label.
   [ deployment: <boolean> | default = false ]
-# Attaches daemonset metadata to discovered pod targets. Valid for role: pod.
+# Attaches daemonset metadata to discovered pod targets. Valid for role: pod, endpoints, endpointslices.
 # Enables the __meta_kubernetes_pod_daemonset_name label.
   [ daemonset: <boolean> | default = false ]
 # Attaches job metadata to discovered pod targets. Valid for role: pod.


### PR DESCRIPTION
#### The PR is related to https://github.com/prometheus/prometheus/issues/16747 and extends https://github.com/prometheus/prometheus/pull/17774

This PR is just a small improvement of what @rexagod did in [his PR](https://github.com/prometheus/prometheus/pull/17774).
In the original PR was added ability to add name metadata for deployments, cronjobs and jobs.
It would be nice to also add name for daemosets as well.

Note: this PR has been written with help of LLMs, but I've thoroughly checked everything before submitting it (including using it in our k8s clusters).

#### Release notes for end users.
```release-notes
[FEATURE] Introduce pod-based label for daemonset names: __meta_kubernetes_pod_daemonset_name.
```

<img width="1440" height="121" alt="image" src="https://github.com/user-attachments/assets/74b88d2e-8c66-4941-993e-21dd6339c2ee" />
