### PR TITLE
tsdb: Refactor `Head.Init(...)` for fast startup

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1920,6 +1920,9 @@ func (s *readyStorage) Close() error {
 
 // CleanTombstones implements the api_v1.TSDBAdminStats and api_v2.TSDBAdmin interfaces.
 func (s *readyStorage) CleanTombstones() error {
+	if !s.queryReady.Load() {
+		return tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:
@@ -1935,6 +1938,9 @@ func (s *readyStorage) CleanTombstones() error {
 
 // BlockMetas implements the api_v1.TSDBAdminStats and api_v2.TSDBAdmin interfaces.
 func (s *readyStorage) BlockMetas() ([]tsdb.BlockMeta, error) {
+	if !s.queryReady.Load() {
+		return nil, tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:
@@ -1950,6 +1956,9 @@ func (s *readyStorage) BlockMetas() ([]tsdb.BlockMeta, error) {
 
 // Delete implements the api_v1.TSDBAdminStats and api_v2.TSDBAdmin interfaces.
 func (s *readyStorage) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Matcher) error {
+	if !s.queryReady.Load() {
+		return tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:
@@ -1965,6 +1974,9 @@ func (s *readyStorage) Delete(ctx context.Context, mint, maxt int64, ms ...*labe
 
 // Snapshot implements the api_v1.TSDBAdminStats and api_v2.TSDBAdmin interfaces.
 func (s *readyStorage) Snapshot(dir string, withHead bool) error {
+	if !s.queryReady.Load() {
+		return tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:
@@ -1980,6 +1992,9 @@ func (s *readyStorage) Snapshot(dir string, withHead bool) error {
 
 // Stats implements the api_v1.TSDBAdminStats interface.
 func (s *readyStorage) Stats(statsByLabelName string, limit int) (*tsdb.Stats, error) {
+	if !s.queryReady.Load() {
+		return nil, tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1752,7 +1752,7 @@ type readyStorage struct {
 	db              storage.Storage
 	startTimeMargin int64
 	stats           *tsdb.DBStats
-	queryReady atomic.Bool
+	queryReady      atomic.Bool
 }
 
 func (s *readyStorage) ApplyConfig(conf *config.Config) error {
@@ -1815,7 +1815,7 @@ func (s *readyStorage) StartTime() (int64, error) {
 
 // Querier implements the Storage interface.
 func (s *readyStorage) Querier(mint, maxt int64) (storage.Querier, error) {
-	if (!s.queryReady.Load()) {
+	if !s.queryReady.Load() {
 		return nil, tsdb.ErrNotReady
 	}
 	if x := s.get(); x != nil {
@@ -1826,7 +1826,7 @@ func (s *readyStorage) Querier(mint, maxt int64) (storage.Querier, error) {
 
 // ChunkQuerier implements the Storage interface.
 func (s *readyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
-	if (!s.queryReady.Load()) {
+	if !s.queryReady.Load() {
 		return nil, tsdb.ErrNotReady
 	}
 	if x := s.get(); x != nil {
@@ -1836,7 +1836,7 @@ func (s *readyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, err
 }
 
 func (s *readyStorage) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
-	if (!s.queryReady.Load()) {
+	if !s.queryReady.Load() {
 		return nil, tsdb.ErrNotReady
 	}
 	if x := s.get(); x != nil {

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1449,6 +1449,18 @@ func main() {
 				startTimeMargin := int64(2 * time.Duration(cfg.tsdb.MinBlockDuration).Seconds() * 1000)
 				localStorage.Set(db, startTimeMargin)
 				db.SetWriteNotified(remoteStorage)
+
+				if cfg.tsdb.EnableFastStartup {
+					go func() {
+						// Wait for queries to become enabled.
+						<-db.Head().WaitForWALReplay()
+						localStorage.SetQueryReady()
+						logger.Info("WAL replay finished. Queries are now enabled.")
+					}()
+				} else {
+					localStorage.SetQueryReady()
+				}
+
 				close(dbOpen)
 				<-cancel
 				logger.Info("TSDB stopped")
@@ -1507,6 +1519,7 @@ func main() {
 				)
 
 				localStorage.Set(db, 0)
+				localStorage.SetQueryReady()
 				db.SetWriteNotified(remoteStorage)
 				close(dbOpen)
 				<-cancel
@@ -1739,6 +1752,7 @@ type readyStorage struct {
 	db              storage.Storage
 	startTimeMargin int64
 	stats           *tsdb.DBStats
+	queryReady atomic.Bool
 }
 
 func (s *readyStorage) ApplyConfig(conf *config.Config) error {
@@ -1772,6 +1786,10 @@ func (s *readyStorage) getStats() *tsdb.DBStats {
 	return x
 }
 
+func (s *readyStorage) SetQueryReady() {
+	s.queryReady.Store(true)
+}
+
 // StartTime implements the Storage interface.
 func (s *readyStorage) StartTime() (int64, error) {
 	if x := s.get(); x != nil {
@@ -1797,6 +1815,9 @@ func (s *readyStorage) StartTime() (int64, error) {
 
 // Querier implements the Storage interface.
 func (s *readyStorage) Querier(mint, maxt int64) (storage.Querier, error) {
+	if (!s.queryReady.Load()) {
+		return nil, tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		return x.Querier(mint, maxt)
 	}
@@ -1805,6 +1826,9 @@ func (s *readyStorage) Querier(mint, maxt int64) (storage.Querier, error) {
 
 // ChunkQuerier implements the Storage interface.
 func (s *readyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
+	if (!s.queryReady.Load()) {
+		return nil, tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		return x.ChunkQuerier(mint, maxt)
 	}
@@ -1812,6 +1836,9 @@ func (s *readyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, err
 }
 
 func (s *readyStorage) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
+	if (!s.queryReady.Load()) {
+		return nil, tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -311,7 +311,7 @@ func NewHead(r prometheus.Registerer, l *slog.Logger, wal, wbl *wlog.WL, opts *H
 		stats:           stats,
 		reg:             r,
 		seriesStateQuit: make(chan struct{}),
-		walReplayDone: make(chan struct{}),
+		walReplayDone:   make(chan struct{}),
 	}
 	if err := h.resetInMemoryState(); err != nil {
 		return nil, err
@@ -970,7 +970,7 @@ func (h *Head) Init(minValidTime int64) error {
 	return err
 }
 
-// WaitForWALReplay returns a channel that is closed when the WAL replay has finished. 
+// WaitForWALReplay returns a channel that is closed when the WAL replay has finished.
 func (h *Head) WaitForWALReplay() <-chan struct{} {
 	return h.walReplayDone
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -141,6 +141,9 @@ type Head struct {
 	seriesStateQuit chan struct{}
 	seriesStateWg   sync.WaitGroup
 
+	// For running the background WAL replay.
+	walReplayWg sync.WaitGroup
+
 	stats *HeadStats
 	reg   prometheus.Registerer
 
@@ -678,11 +681,7 @@ func (s *WALReplayStatus) GetWALReplayStatus() WALReplayStatus {
 
 const cardinalityCacheExpirationTime = time.Duration(30) * time.Second
 
-// Init loads data from the write ahead log and prepares the head for writes.
-// It should be called before using an appender so that it
-// limits the ingested samples to the head min valid time.
-func (h *Head) Init(minValidTime int64) error {
-	h.minValidTime.Store(minValidTime)
+func (h *Head) replayDiskChunksAndWAL() error {
 	defer h.resetWLReplayResources()
 	defer func() {
 		h.postings.EnsureOrder(h.opts.WALReplayConcurrency)
@@ -698,6 +697,9 @@ func (h *Head) Init(minValidTime int64) error {
 
 	h.logger.Info("Replaying on-disk memory mappable chunks if any")
 	start := time.Now()
+
+	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
+	var multiRefMtx sync.Mutex
 
 	snapIdx, snapOffset := -1, 0
 	refSeries := make(map[chunks.HeadSeriesRef]*memSeries)
@@ -731,7 +733,7 @@ func (h *Head) Init(minValidTime int64) error {
 		}
 		if loadSnapshot {
 			var err error
-			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot()
+			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot(multiRef, &multiRefMtx)
 			if err == nil {
 				snapshotLoaded = true
 				chunkSnapshotLoadDuration = time.Since(start)
@@ -775,7 +777,7 @@ func (h *Head) Init(minValidTime int64) error {
 			snapIdx, snapOffset = -1, 0
 
 			// If this fails, data will be recovered from WAL.
-			// Hence we won't lose any data (given WAL is not corrupt).
+			// Hence we wont lose any data (given WAL is not corrupt).
 			mmappedChunks, oooMmappedChunks, lastMmapRef, err = h.removeCorruptedMmappedChunks(err)
 			if err != nil {
 				return err
@@ -805,32 +807,9 @@ func (h *Head) Init(minValidTime int64) error {
 		return fmt.Errorf("finding WAL segments: %w", e)
 	}
 
-	if h.opts.EnableFastStartup {
-		state, err := h.readSeriesStateFile()
-		if err != nil && !os.IsNotExist(err) {
-			h.logger.Warn("Failed to read series state file, skipping the fast startup", "err", err)
-		}
-		if err == nil {
-			if state.CleanShutdown {
-				h.lastSeriesID.Store(state.LastSeriesID)
-				h.logger.Info("Fast startup: clean shutdown detected, restored last series ID", "last_series_id", state.LastSeriesID)
-			} else {
-				h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", state.LastWALSegment, "to_segment", endAt)
-				id, scanErr := h.findLastSeriesID(state, endAt)
-				if scanErr != nil {
-					h.logger.Error("Fast startup: WAL scan failed, skipping fast startup", "err", scanErr)
-				} else {
-					h.lastSeriesID.Store(id)
-					h.logger.Info("Fast startup: WAL scan completed", "last_series_id", id)
-				}
-			}
-		}
-	}
-
 	h.startWALReplayStatus(startFrom, endAt)
 
 	syms := labels.NewSymbolTable() // One table for the whole WAL.
-	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
 	if err == nil && startFrom >= snapIdx {
 		sr, err := wlog.NewSegmentsReader(dir)
 		if err != nil {
@@ -932,14 +911,60 @@ func (h *Head) Init(minValidTime int64) error {
 		"total_replay_duration", totalReplayDuration.String(),
 	)
 
+	return nil
+}
+
+// Init loads data from the write ahead log and prepares the head for writes.
+// It should be called before using an appender so that it
+// limits the ingested samples to the head min valid time.
+func (h *Head) Init(minValidTime int64) error {
+	h.minValidTime.Store(minValidTime)
+
+	// Find the last WAL segment.
+	_, endAt, e := wlog.Segments(h.wal.Dir())
+	if e != nil {
+		return fmt.Errorf("finding WAL segments: %w", e)
+	}
+
 	// TODO(RushabhMehta2005): Remove this 'if' block and always run the series state ticker when the feature is fully implemented.
 	if h.opts.EnableFastStartup {
+		state, err := h.readSeriesStateFile()
+		if err != nil && !os.IsNotExist(err) {
+			h.logger.Warn("Failed to read series state file, skipping the fast startup", "err", err)
+		}
+		if err == nil {
+			if state.CleanShutdown {
+				h.lastSeriesID.Store(state.LastSeriesID)
+				h.logger.Info("Fast startup: clean shutdown detected, restored last series ID", "last_series_id", state.LastSeriesID)
+			} else {
+				h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", state.LastWALSegment, "to_segment", endAt)
+				id, scanErr := h.findLastSeriesID(state, endAt)
+				if scanErr != nil {
+					h.logger.Error("Fast startup: WAL scan failed, skipping fast startup", "err", scanErr)
+				} else {
+					h.lastSeriesID.Store(id)
+					h.logger.Info("Fast startup: WAL scan completed", "last_series_id", id)
+				}
+			}
+		}
+
 		// Start the background goroutine that writes to series_state.json.
 		h.seriesStateWg.Add(1)
 		go h.runSeriesStateTicker()
+
+		h.walReplayWg.Add(1)
+		go func() {
+			defer h.walReplayWg.Done()
+			if err := h.replayDiskChunksAndWAL(); err != nil {
+				h.logger.Error("Fast startup: Background WAL replay failed", "err", err)
+			}
+		}()
+
+		return nil
 	}
 
-	return nil
+	// When feature is not enabled, blocking call.
+	return h.replayDiskChunksAndWAL()
 }
 
 func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) (map[chunks.HeadSeriesRef][]*mmappedChunk, map[chunks.HeadSeriesRef][]*mmappedChunk, chunks.ChunkDiskMapperRef, error) {
@@ -1851,6 +1876,9 @@ func (h *Head) compactable() bool {
 // Close flushes the WAL and closes the head.
 // It also takes a snapshot of in-memory chunks if enabled.
 func (h *Head) Close() error {
+	// Wait for background WAL replay to finish before shutdown.
+	h.walReplayWg.Wait()
+
 	h.closedMtx.Lock()
 	defer h.closedMtx.Unlock()
 	h.closed = true

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -922,30 +922,32 @@ func (h *Head) replayDiskChunksAndWAL() error {
 func (h *Head) Init(minValidTime int64) error {
 	h.minValidTime.Store(minValidTime)
 
-	// Find the last WAL segment.
-	_, endAt, e := wlog.Segments(h.wal.Dir())
-	if e != nil {
-		return fmt.Errorf("finding WAL segments: %w", e)
-	}
-
 	// TODO(RushabhMehta2005): Remove this 'if' block and always run the series state ticker when the feature is fully implemented.
 	if h.opts.EnableFastStartup {
-		state, err := h.readSeriesStateFile()
-		if err != nil && !os.IsNotExist(err) {
-			h.logger.Warn("Failed to read series state file, skipping the fast startup", "err", err)
-		}
-		if err == nil {
-			if state.CleanShutdown {
-				h.lastSeriesID.Store(state.LastSeriesID)
-				h.logger.Info("Fast startup: clean shutdown detected, restored last series ID", "last_series_id", state.LastSeriesID)
-			} else {
-				h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", state.LastWALSegment, "to_segment", endAt)
-				id, scanErr := h.findLastSeriesID(state, endAt)
-				if scanErr != nil {
-					h.logger.Error("Fast startup: WAL scan failed, skipping fast startup", "err", scanErr)
+		if h.wal != nil {
+			// Find the last WAL segment.
+			_, endAt, e := wlog.Segments(h.wal.Dir())
+			if e != nil {
+				return fmt.Errorf("finding WAL segments: %w", e)
+			}
+
+			state, err := h.readSeriesStateFile()
+			if err != nil && !os.IsNotExist(err) {
+				h.logger.Warn("Failed to read series state file, skipping the fast startup", "err", err)
+			}
+			if err == nil {
+				if state.CleanShutdown {
+					h.lastSeriesID.Store(state.LastSeriesID)
+					h.logger.Info("Fast startup: clean shutdown detected, restored last series ID", "last_series_id", state.LastSeriesID)
 				} else {
-					h.lastSeriesID.Store(id)
-					h.logger.Info("Fast startup: WAL scan completed", "last_series_id", id)
+					h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", state.LastWALSegment, "to_segment", endAt)
+					id, scanErr := h.findLastSeriesID(state, endAt)
+					if scanErr != nil {
+						h.logger.Error("Fast startup: WAL scan failed, skipping fast startup", "err", scanErr)
+					} else {
+						h.lastSeriesID.Store(id)
+						h.logger.Info("Fast startup: WAL scan completed", "last_series_id", id)
+					}
 				}
 			}
 		}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -777,7 +777,7 @@ func (h *Head) replayDiskChunksAndWAL() error {
 			snapIdx, snapOffset = -1, 0
 
 			// If this fails, data will be recovered from WAL.
-			// Hence we wont lose any data (given WAL is not corrupt).
+			// Hence we won't lose any data (given WAL is not corrupt).
 			mmappedChunks, oooMmappedChunks, lastMmapRef, err = h.removeCorruptedMmappedChunks(err)
 			if err != nil {
 				return err
@@ -952,13 +952,11 @@ func (h *Head) Init(minValidTime int64) error {
 		h.seriesStateWg.Add(1)
 		go h.runSeriesStateTicker()
 
-		h.walReplayWg.Add(1)
-		go func() {
-			defer h.walReplayWg.Done()
+		h.walReplayWg.Go(func() {
 			if err := h.replayDiskChunksAndWAL(); err != nil {
 				h.logger.Error("Fast startup: Background WAL replay failed", "err", err)
 			}
-		}()
+		})
 
 		return nil
 	}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -144,6 +144,9 @@ type Head struct {
 	// For running the background WAL replay.
 	walReplayWg sync.WaitGroup
 
+	// For signalling when the background WAL replay finishes.
+	walReplayDone chan struct{}
+
 	stats *HeadStats
 	reg   prometheus.Registerer
 
@@ -308,6 +311,7 @@ func NewHead(r prometheus.Registerer, l *slog.Logger, wal, wbl *wlog.WL, opts *H
 		stats:           stats,
 		reg:             r,
 		seriesStateQuit: make(chan struct{}),
+		walReplayDone: make(chan struct{}),
 	}
 	if err := h.resetInMemoryState(); err != nil {
 		return nil, err
@@ -698,9 +702,6 @@ func (h *Head) replayDiskChunksAndWAL() error {
 	h.logger.Info("Replaying on-disk memory mappable chunks if any")
 	start := time.Now()
 
-	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
-	var multiRefMtx sync.Mutex
-
 	snapIdx, snapOffset := -1, 0
 	refSeries := make(map[chunks.HeadSeriesRef]*memSeries)
 
@@ -733,7 +734,7 @@ func (h *Head) replayDiskChunksAndWAL() error {
 		}
 		if loadSnapshot {
 			var err error
-			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot(multiRef, &multiRefMtx)
+			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot()
 			if err == nil {
 				snapshotLoaded = true
 				chunkSnapshotLoadDuration = time.Since(start)
@@ -810,6 +811,7 @@ func (h *Head) replayDiskChunksAndWAL() error {
 	h.startWALReplayStatus(startFrom, endAt)
 
 	syms := labels.NewSymbolTable() // One table for the whole WAL.
+	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
 	if err == nil && startFrom >= snapIdx {
 		sr, err := wlog.NewSegmentsReader(dir)
 		if err != nil {
@@ -953,6 +955,7 @@ func (h *Head) Init(minValidTime int64) error {
 		go h.runSeriesStateTicker()
 
 		h.walReplayWg.Go(func() {
+			defer close(h.walReplayDone)
 			if err := h.replayDiskChunksAndWAL(); err != nil {
 				h.logger.Error("Fast startup: Background WAL replay failed", "err", err)
 			}
@@ -962,7 +965,14 @@ func (h *Head) Init(minValidTime int64) error {
 	}
 
 	// When feature is not enabled, blocking call.
-	return h.replayDiskChunksAndWAL()
+	err := h.replayDiskChunksAndWAL()
+	close(h.walReplayDone)
+	return err
+}
+
+// WaitForWALReplay returns a channel that is closed when the WAL replay has finished. 
+func (h *Head) WaitForWALReplay() <-chan struct{} {
+	return h.walReplayDone
 }
 
 func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) (map[chunks.HeadSeriesRef][]*mmappedChunk, map[chunks.HeadSeriesRef][]*mmappedChunk, chunks.ChunkDiskMapperRef, error) {

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1592,7 +1592,7 @@ func DeleteChunkSnapshots(dir string, maxIndex, maxOffset int) error {
 
 // loadChunkSnapshot replays the chunk snapshot and restores the Head state from it. If there was any error returned,
 // it is the responsibility of the caller to clear the contents of the Head.
-func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {
+func (h *Head) loadChunkSnapshot(multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, multiRefMtx *sync.Mutex) (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {
 	dir, snapIdx, snapOffset, err := LastChunkSnapshot(h.opts.ChunkDirRoot)
 	if err != nil {
 		if errors.Is(err, record.ErrNotFound) {
@@ -1641,11 +1641,19 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 			localRefSeries := shardedRefSeries[idx]
 
 			for csr := range rc {
-				series, _, err := h.getOrCreateWithOptionalID(csr.ref, csr.lset.Hash(), csr.lset, false)
+				series, created, err := h.getOrCreateWithOptionalID(csr.ref, csr.lset.Hash(), csr.lset, false)
 				if err != nil {
 					errChan <- err
 					return
 				}
+
+				if h.opts.EnableFastStartup && !created {
+					// This is not a newly created series, update the multiRef.
+					multiRefMtx.Lock()
+					multiRef[csr.ref] = series.ref
+					multiRefMtx.Unlock()
+				}
+
 				localRefSeries[csr.ref] = series
 				for {
 					seriesID := uint64(series.ref)

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1592,7 +1592,7 @@ func DeleteChunkSnapshots(dir string, maxIndex, maxOffset int) error {
 
 // loadChunkSnapshot replays the chunk snapshot and restores the Head state from it. If there was any error returned,
 // it is the responsibility of the caller to clear the contents of the Head.
-func (h *Head) loadChunkSnapshot(multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, multiRefMtx *sync.Mutex) (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {
+func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {
 	dir, snapIdx, snapOffset, err := LastChunkSnapshot(h.opts.ChunkDirRoot)
 	if err != nil {
 		if errors.Is(err, record.ErrNotFound) {
@@ -1641,17 +1641,10 @@ func (h *Head) loadChunkSnapshot(multiRef map[chunks.HeadSeriesRef]chunks.HeadSe
 			localRefSeries := shardedRefSeries[idx]
 
 			for csr := range rc {
-				series, created, err := h.getOrCreateWithOptionalID(csr.ref, csr.lset.Hash(), csr.lset, false)
+				series, _, err := h.getOrCreateWithOptionalID(csr.ref, csr.lset.Hash(), csr.lset, false)
 				if err != nil {
 					errChan <- err
 					return
-				}
-
-				if h.opts.EnableFastStartup && !created {
-					// This is not a newly created series, update the multiRef.
-					multiRefMtx.Lock()
-					multiRef[csr.ref] = series.ref
-					multiRefMtx.Unlock()
 				}
 
 				localRefSeries[csr.ref] = series


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
- This PR builds on top of the 2 previous PRs: [Adding the series_state.json file](https://github.com/prometheus/prometheus/pull/18303), [Implementing the fast startup algorithm](https://github.com/prometheus/prometheus/pull/18333). 
- `Head.Init(...)` has to be refactored to make sure it does not block on `Head.loadWAL(...)`. The latter is launched in its own goroutine, there is a check added in `Head.Close(...)` as well, which makes sure the WAL loading is finished before attempting a graceful shutdown, if it hasn't, we wait for it. This makes the WAL replay run *in parallel* with scraping.
-  Until the WAL replay is done, we have to block queries as we have incomplete data.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
NA
#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
