### PR TITLE
remote: add gate waiting duration metric

### DIFF
--- a/storage/remote/read_handler.go
+++ b/storage/remote/read_handler.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -40,6 +41,7 @@ type readHandler struct {
 	remoteReadMaxBytesInFrame int
 	remoteReadGate            *gate.Gate
 	queries                   prometheus.Gauge
+	gateWaitDuration          prometheus.Histogram
 	marshalPool               *sync.Pool
 }
 
@@ -61,19 +63,32 @@ func NewReadHandler(logger *slog.Logger, r prometheus.Registerer, queryable stor
 			Name:      "queries",
 			Help:      "The current number of remote read queries that are either in execution or queued on the handler.",
 		}),
+
+		gateWaitDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace:                       namespace,
+			Subsystem:                       "remote_read_handler",
+			Name:                            "gate_wait_duration_seconds",
+			Help:                            "How long the remote read handler is waiting for the concurrency gate to allow the query to execute.",
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
+			Buckets:                         prometheus.DefBuckets,
+		}),
 	}
 	if r != nil {
-		r.MustRegister(h.queries)
+		r.MustRegister(h.queries, h.gateWaitDuration)
 	}
 	return h
 }
 
 func (h *readHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	start := time.Now()
 	if err := h.remoteReadGate.Start(ctx); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	h.gateWaitDuration.Observe(time.Since(start).Seconds())
 	h.queries.Inc()
 
 	defer h.remoteReadGate.Done()

--- a/storage/remote/read_handler_test.go
+++ b/storage/remote/read_handler_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/config"
@@ -461,6 +463,43 @@ func TestStreamReadEndpoint(t *testing.T) {
 			QueryIndex: 2,
 		},
 	}, results)
+}
+
+func TestReadHandlerGateWaitDuration(t *testing.T) {
+	store := promqltest.LoadedStorage(t, `
+		load 1m
+			test_metric1{foo="bar"} 1
+	`)
+	defer store.Close()
+
+	reg := prometheus.NewRegistry()
+	h := NewReadHandler(nil, reg, store, func() config.Config {
+		return config.Config{}
+	}, 1e6, 1, 0)
+
+	matcher, err := labels.NewMatcher(labels.MatchEqual, "__name__", "test_metric1")
+	require.NoError(t, err)
+
+	query, err := ToQuery(0, 1, []*labels.Matcher{matcher}, nil)
+	require.NoError(t, err)
+
+	req := &prompb.ReadRequest{Queries: []*prompb.Query{query}}
+	data, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	compressed := snappy.Encode(nil, data)
+	request, err := http.NewRequest(http.MethodPost, "", bytes.NewBuffer(compressed))
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, request)
+	require.Equal(t, 2, recorder.Code/100)
+
+	rh := h.(*readHandler)
+	m := &dto.Metric{}
+	require.NoError(t, rh.gateWaitDuration.Write(m))
+	require.Equal(t, uint64(1), m.Histogram.GetSampleCount())
+	require.GreaterOrEqual(t, m.Histogram.GetSampleSum(), 0.0)
 }
 
 func addNativeHistogramsToTestSuite(t *testing.T, storage *teststorage.TestStorage, n int) {


### PR DESCRIPTION
## Summary

Add a histogram metric `prometheus_remote_read_handler_gate_wait_duration_seconds` that tracks how long remote read requests wait for the concurrency gate to allow execution.

### Problem

When the remote read concurrency gate is nearly saturated, operators have no visibility into how long requests are queued waiting for a free slot. The existing `prometheus_remote_read_handler_queries` gauge shows current query count but doesn't reveal queuing latency. Without this signal, operators cannot make informed decisions about when to increase the `--storage.remote.read-concurrency-limit`.

### Solution

Record the elapsed time between requesting a gate slot and acquiring it, then observe it in a histogram. The measurement is done at the call site in the read handler (`ServeHTTP`) rather than inside the gate package, keeping the gate as a simple concurrency primitive with no metric dependencies.

The histogram uses both classic buckets (`prometheus.DefBuckets`) and native histogram configuration for forward compatibility.

### How this helps

- **Alerting**: operators can alert when p99 gate wait exceeds a threshold, indicating the concurrency limit needs attention.
- **Dashboarding**: wait duration trends over time reveal whether the system is approaching saturation.
- **Capacity planning**: correlating gate wait with query volume helps size the concurrency limit correctly.

Fixes #11365

```release-notes
[ENHANCEMENT] Remote Read: Add `prometheus_remote_read_handler_gate_wait_duration_seconds` histogram metric to track how long remote read requests wait for a concurrency gate slot.
```