### PR TITLE
annotations: add warning for ineffective sort in range queries

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2010,7 +2010,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 			return ev.evalInfo(ctx, e.Args)
 		}
 
-		// Emit a warning when sort is used for range queries
+		// Emit a warning when sort is used for range queries.
 		if (e.Func.Name == "sort" || e.Func.Name == "sort_desc" || e.Func.Name == "sort_by_label" || e.Func.Name == "sort_by_label_desc") && ev.startTimestamp != ev.endTimestamp {
 			warnings.Add(annotations.NewSortInRangeQueryWarning(e.PositionRange()))
 		}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2010,6 +2010,11 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 			return ev.evalInfo(ctx, e.Args)
 		}
 
+		// Emit a warning when sort is used for range queries
+		if (e.Func.Name == "sort" || e.Func.Name == "sort_desc" || e.Func.Name == "sort_by_label" || e.Func.Name == "sort_by_label_desc") && ev.startTimestamp != ev.endTimestamp {
+			warnings.Add(annotations.NewSortInRangeQueryWarning(e.PositionRange()))
+		}
+
 		if !matrixArg {
 			// Does not have a matrix argument.
 			return ev.rangeEval(ctx, nil, func(v []Vector, _ Matrix, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, annotations.Annotations) {

--- a/promql/promqltest/testdata/histograms.test
+++ b/promql/promqltest/testdata/histograms.test
@@ -1169,3 +1169,68 @@ eval instant at 0 histogram_fraction(-Inf, 1, series)
   expect no_info
   expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
   # Should return no results.
+
+clear
+
+# Test histogram_quantile(s) and histogram_fraction warns about missing "le"
+load 1m
+  series{ale="0.1"}   2
+
+eval instant at 0 histogram_quantile(0.8, series)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
+	# Should return no results.
+
+eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
+	# Should return no results.
+
+eval instant at 0 histogram_fraction(-Inf, 1, series)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
+	# Should return no results.
+
+clear
+
+# Test histogram_quantile(s) and histogram_fraction warns about malformated "le"
+load 1m
+  series{le="Hello World"}   2
+
+eval instant at 0 histogram_quantile(0.8, series)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
+	# Should return no results.
+
+eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
+	# Should return no results.
+
+eval instant at 0 histogram_fraction(-Inf, 1, series)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
+	# Should return no results.
+
+clear
+
+# Test histogram_quantile(s) and histogram_fraction warns about mixed classic and native histogram
+load 1m
+  series{le="0.1"}   1
+  series{le="1"}     2
+  series{}           {{schema:0 count:10 sum:50 buckets:[1 2 3]}}
+
+eval instant at 0 histogram_quantile(0.8, series)
+	expect no_info
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+	# Should return no results.
+
+eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
+	expect no_info
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+	# Should return no results.
+
+eval instant at 0 histogram_fraction(-Inf, 1, series)
+	expect no_info
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+	# Should return no results.

--- a/promql/promqltest/testdata/range_queries.test
+++ b/promql/promqltest/testdata/range_queries.test
@@ -105,3 +105,18 @@ eval instant at 1m some_nonexistent_metric[1m]
 
 eval instant at 10m some_metric[1m]
     expect range vector from 9m10s to 10m step 1m
+
+eval range from 1m to 2m step 1m sort(series)
+  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels
+
+eval range from 1m to 2m step 1m sort_desc(series)
+  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels
+
+eval range from 1m to 2m step 1m sort_by_label(series)
+  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels
+
+eval range from 1m to 2m step 1m sort_by_label_desc(series)
+  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels
+
+eval range from 1m to 2m step 1m sum(sort(series))
+  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -156,6 +156,7 @@ var (
 	NativeHistogramNotGaugeWarning          = fmt.Errorf("%w: this native histogram metric is not a gauge:", PromQLWarning)
 	MixedExponentialCustomHistogramsWarning = fmt.Errorf("%w: vector contains a mix of histograms with exponential and custom buckets schemas for metric name", PromQLWarning)
 	IncompatibleBucketLayoutInBinOpWarning  = fmt.Errorf("%w: incompatible bucket layout encountered for binary operator", PromQLWarning)
+	SortInRangeQueryWarning                 = fmt.Errorf("%w: sort is ineffective for range queries since results are always ordered by labels", PromQLWarning)
 
 	PossibleNonCounterInfo                  = fmt.Errorf("%w: metric might not be a counter, name does not end in _total/_sum/_count/_bucket:", PromQLInfo)
 	PossibleNonCounterLabelInfo             = fmt.Errorf("%w: metric might not be a counter, __type__ label is not set to %q or %q", PromQLInfo, model.MetricTypeCounter, model.MetricTypeHistogram)
@@ -421,6 +422,15 @@ func NewIncompatibleBucketLayoutInBinOpWarning(operator string, pos posrange.Pos
 	return &annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %s", IncompatibleBucketLayoutInBinOpWarning, operator),
+	}
+}
+
+// NewSortInRangeQueryWarning is used when sort or sort_desc functions are used
+// in range queries where they have no effect since results are always ordered by labels.
+func NewSortInRangeQueryWarning(pos posrange.PositionRange) error {
+	return &annoErr{
+		PositionRange: pos,
+		Err:           SortInRangeQueryWarning,
 	}
 }
 


### PR DESCRIPTION
We add to revert https://github.com/prometheus/prometheus/pull/16628, because it failed the CI after merging (the CI on the PR were quite old at the time of the merge), so we @krajorama and I wanted to fix that up to get the feature back in the main branch.

In addition, the tests were moved to the ".test" files that didn't exist when the PR was initially created.

#### Which issue(s) does the PR fix:
Fixes https://github.com/prometheus/prometheus/issues/14115

#### Release notes for end users (**ALL** commits must be considered).
```release-notes
[FEATURE] Emit a warning when `sort`, `sort_by_label` or `sort_by_label_desc` is used within range (matrix) queries, as these functions do not have effect in that context.
```
