### PR TITLE
discovery/consul: add health_filter for Health API filtering

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -116,9 +116,12 @@ type SDConfig struct {
 	ServiceTags []string `yaml:"tags,omitempty"`
 	// Desired node metadata. As of Consul 1.14, consider `filter` instead.
 	NodeMeta map[string]string `yaml:"node_meta,omitempty"`
-	// Consul filter string
-	// See https://www.consul.io/api-docs/catalog#filtering-1, for syntax
+	// Filter expression for the Catalog API.
+	// See https://developer.hashicorp.com/consul/api-docs/catalog#filtering for syntax.
 	Filter string `yaml:"filter,omitempty"`
+	// Filter expression for the Health API.
+	// See https://developer.hashicorp.com/consul/api-docs/health#filtering for syntax.
+	HealthFilter string `yaml:"health_filter,omitempty"`
 
 	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 }
@@ -170,20 +173,21 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 // Discovery retrieves target information from a Consul server
 // and updates them via watches.
 type Discovery struct {
-	client           *consul.Client
-	clientDatacenter string
-	clientNamespace  string
-	clientPartition  string
-	tagSeparator     string
-	watchedServices  []string // Set of services which will be discovered.
-	watchedTags      []string // Tags used to filter instances of a service.
-	watchedNodeMeta  map[string]string
-	watchedFilter    string
-	allowStale       bool
-	refreshInterval  time.Duration
-	finalizer        func()
-	logger           *slog.Logger
-	metrics          *consulMetrics
+	client              *consul.Client
+	clientDatacenter    string
+	clientNamespace     string
+	clientPartition     string
+	tagSeparator        string
+	watchedServices     []string // Set of services which will be discovered.
+	watchedTags         []string // Tags used to filter instances of a service.
+	watchedNodeMeta     map[string]string
+	watchedFilter       string
+	watchedHealthFilter string
+	allowStale          bool
+	refreshInterval     time.Duration
+	finalizer           func()
+	logger              *slog.Logger
+	metrics             *consulMetrics
 }
 
 // NewDiscovery returns a new Discovery for the given config.
@@ -218,20 +222,21 @@ func NewDiscovery(conf *SDConfig, logger *slog.Logger, metrics discovery.Discove
 		return nil, err
 	}
 	cd := &Discovery{
-		client:           client,
-		tagSeparator:     conf.TagSeparator,
-		watchedServices:  conf.Services,
-		watchedTags:      conf.ServiceTags,
-		watchedNodeMeta:  conf.NodeMeta,
-		watchedFilter:    conf.Filter,
-		allowStale:       conf.AllowStale,
-		refreshInterval:  time.Duration(conf.RefreshInterval),
-		clientDatacenter: conf.Datacenter,
-		clientNamespace:  conf.Namespace,
-		clientPartition:  conf.Partition,
-		finalizer:        wrapper.CloseIdleConnections,
-		logger:           logger,
-		metrics:          m,
+		client:              client,
+		tagSeparator:        conf.TagSeparator,
+		watchedServices:     conf.Services,
+		watchedTags:         conf.ServiceTags,
+		watchedNodeMeta:     conf.NodeMeta,
+		watchedFilter:       conf.Filter,
+		watchedHealthFilter: conf.HealthFilter,
+		allowStale:          conf.AllowStale,
+		refreshInterval:     time.Duration(conf.RefreshInterval),
+		clientDatacenter:    conf.Datacenter,
+		clientNamespace:     conf.Namespace,
+		clientPartition:     conf.Partition,
+		finalizer:           wrapper.CloseIdleConnections,
+		logger:              logger,
+		metrics:             m,
 	}
 
 	return cd, nil
@@ -499,7 +504,7 @@ func (srv *consulService) watch(ctx context.Context, ch chan<- []*targetgroup.Gr
 		WaitTime:   watchTimeout,
 		AllowStale: srv.discovery.allowStale,
 		NodeMeta:   srv.discovery.watchedNodeMeta,
-		Filter:     srv.discovery.watchedFilter,
+		Filter:     srv.discovery.watchedHealthFilter,
 	}
 
 	t0 := time.Now()

--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -335,7 +335,7 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 	}
 	d.initialize(ctx)
 
-	if len(d.watchedServices) == 0 || len(d.watchedTags) != 0 {
+	if len(d.watchedServices) == 0 || len(d.watchedTags) != 0 || d.watchedFilter != "" {
 		// We need to watch the catalog.
 		ticker := time.NewTicker(d.refreshInterval)
 

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -295,7 +295,7 @@ func checkOneTarget(t *testing.T, tg []*targetgroup.Group) {
 // Watch all the services in the catalog.
 func TestAllServices(t *testing.T) {
 	stub, config := newServer(t)
-	defer stub.Close()
+	t.Cleanup(stub.Close)
 
 	d := newDiscovery(t, config)
 
@@ -314,7 +314,7 @@ func TestAllServices(t *testing.T) {
 // targetgroup with no targets is emitted if no services were discovered.
 func TestNoTargets(t *testing.T) {
 	stub, config := newServer(t)
-	defer stub.Close()
+	t.Cleanup(stub.Close)
 	config.ServiceTags = []string{"missing"}
 
 	d := newDiscovery(t, config)
@@ -335,7 +335,7 @@ func TestNoTargets(t *testing.T) {
 // Watch only the test service.
 func TestOneService(t *testing.T) {
 	stub, config := newServer(t)
-	defer stub.Close()
+	t.Cleanup(stub.Close)
 
 	config.Services = []string{"test"}
 	d := newDiscovery(t, config)
@@ -350,7 +350,7 @@ func TestOneService(t *testing.T) {
 // Watch the test service with a specific tag and node-meta.
 func TestAllOptions(t *testing.T) {
 	stub, config := newServer(t)
-	defer stub.Close()
+	t.Cleanup(stub.Close)
 
 	config.Services = []string{"test"}
 	config.NodeMeta = map[string]string{"rack_name": "2304"}
@@ -371,68 +371,46 @@ func TestAllOptions(t *testing.T) {
 	<-ch
 }
 
-// Watch the test service with a specific tag and node-meta via Filter parameter.
+// TestFilterOption verifies that when services and filter are both configured, the Catalog API
+// is still called and receives the filter parameter, while the Health API does not.
 func TestFilterOption(t *testing.T) {
-	stub, config := newServer(t)
-	defer stub.Close()
+	var (
+		catalogCalled bool
+		catalogFilter string
+		healthCalled  bool
+		healthFilter  string
+	)
 
-	config.Services = []string{"test"}
-	config.Filter = `NodeMeta.rack_name == "2304"`
-	config.Token = "fake-token"
-
-	d := newDiscovery(t, config)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	ch := make(chan []*targetgroup.Group)
-	go func() {
-		d.Run(ctx, ch)
-		close(ch)
-	}()
-	checkOneTarget(t, <-ch)
-	cancel()
-}
-
-// TestHealthFilterOption verifies that health_filter is passed to the health service endpoint
-// and not to the catalog endpoint.
-func TestHealthFilterOption(t *testing.T) {
-	catalogFilterReceived := false
-	healthFilterReceived := false
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := ""
+		w.Header().Add("X-Consul-Index", "1")
 		switch r.URL.Path {
 		case "/v1/agent/self":
-			response = AgentAnswer
-		case "/v1/health/service/test":
-			filter := r.URL.Query().Get("filter")
-			if filter == `Service.Tags contains "canary"` {
-				healthFilterReceived = true
-			}
-			response = ServiceTestAnswer
+			w.Write([]byte(AgentAnswer))
 		case "/v1/catalog/services":
-			filter := r.URL.Query().Get("filter")
-			if filter != "" {
-				catalogFilterReceived = true
-			}
-			response = ServicesTestAnswer
+			catalogCalled = true
+			catalogFilter = r.URL.Query().Get("filter")
+			w.Write([]byte(`{"test": []}`))
+		case "/v1/health/service/test":
+			healthCalled = true
+			healthFilter = r.URL.Query().Get("filter")
+			w.Write([]byte(ServiceTestAnswer))
 		default:
 			t.Errorf("Unhandled consul call: %s", r.URL)
 		}
-		w.Header().Add("X-Consul-Index", "1")
-		w.Write([]byte(response))
 	}))
-	defer stub.Close()
+	t.Cleanup(stub.Close)
 
 	stuburl, err := url.Parse(stub.URL)
 	require.NoError(t, err)
 
-	config := &SDConfig{
+	cfg := &SDConfig{
 		Server:          stuburl.Host,
 		Services:        []string{"test"},
-		HealthFilter:    `Service.Tags contains "canary"`,
+		Filter:          `NodeMeta.rack_name == "2304"`,
 		RefreshInterval: model.Duration(1 * time.Second),
 	}
 
-	d := newDiscovery(t, config)
+	d := newDiscovery(t, cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ch := make(chan []*targetgroup.Group)
@@ -441,10 +419,132 @@ func TestHealthFilterOption(t *testing.T) {
 		close(ch)
 	}()
 	checkOneTarget(t, <-ch)
+	// All handler writes happened-before the channel receive above.
+	require.True(t, catalogCalled, "Catalog endpoint should be called when filter is set alongside services.")
+	require.Equal(t, `NodeMeta.rack_name == "2304"`, catalogFilter, "Catalog should receive the filter parameter.")
+	require.True(t, healthCalled, "Health endpoint should be called.")
+	require.Empty(t, healthFilter, "Health endpoint should not receive the catalog filter.")
 	cancel()
+	for range ch {
+	}
+}
 
-	require.True(t, healthFilterReceived, "health_filter should be sent to the health service endpoint.")
-	require.False(t, catalogFilterReceived, "health_filter should not be sent to the catalog endpoint.")
+// TestHealthFilterOption verifies that health_filter is passed to the Health API and not to
+// the Catalog API.
+func TestHealthFilterOption(t *testing.T) {
+	var (
+		catalogCalled bool
+		catalogFilter string
+		healthCalled  bool
+		healthFilter  string
+	)
+
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("X-Consul-Index", "1")
+		switch r.URL.Path {
+		case "/v1/agent/self":
+			w.Write([]byte(AgentAnswer))
+		case "/v1/catalog/services":
+			catalogCalled = true
+			catalogFilter = r.URL.Query().Get("filter")
+			w.Write([]byte(`{"test": []}`))
+		case "/v1/health/service/test":
+			healthCalled = true
+			healthFilter = r.URL.Query().Get("filter")
+			w.Write([]byte(ServiceTestAnswer))
+		default:
+			t.Errorf("Unhandled consul call: %s", r.URL)
+		}
+	}))
+	t.Cleanup(stub.Close)
+
+	stuburl, err := url.Parse(stub.URL)
+	require.NoError(t, err)
+
+	// No services configured: catalog path is always used, allowing us to assert
+	// that health_filter is not forwarded to the Catalog API.
+	cfg := &SDConfig{
+		Server:          stuburl.Host,
+		HealthFilter:    `Service.Tags contains "canary"`,
+		RefreshInterval: model.Duration(1 * time.Second),
+	}
+
+	d := newDiscovery(t, cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan []*targetgroup.Group)
+	go func() {
+		d.Run(ctx, ch)
+		close(ch)
+	}()
+	checkOneTarget(t, <-ch)
+	// All handler writes happened-before the channel receive above.
+	require.True(t, catalogCalled, "Catalog endpoint should be called.")
+	require.Empty(t, catalogFilter, "Catalog should not receive the health_filter parameter.")
+	require.True(t, healthCalled, "Health endpoint should be called.")
+	require.Equal(t, `Service.Tags contains "canary"`, healthFilter, "Health endpoint should receive the health_filter parameter.")
+	cancel()
+	for range ch {
+	}
+}
+
+// TestBothFiltersOption verifies that when both filter and health_filter are configured,
+// each filter is sent exclusively to its respective API endpoint.
+func TestBothFiltersOption(t *testing.T) {
+	var (
+		catalogCalled bool
+		catalogFilter string
+		healthCalled  bool
+		healthFilter  string
+	)
+
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("X-Consul-Index", "1")
+		switch r.URL.Path {
+		case "/v1/agent/self":
+			w.Write([]byte(AgentAnswer))
+		case "/v1/catalog/services":
+			catalogCalled = true
+			catalogFilter = r.URL.Query().Get("filter")
+			w.Write([]byte(`{"test": []}`))
+		case "/v1/health/service/test":
+			healthCalled = true
+			healthFilter = r.URL.Query().Get("filter")
+			w.Write([]byte(ServiceTestAnswer))
+		default:
+			t.Errorf("Unhandled consul call: %s", r.URL)
+		}
+	}))
+	t.Cleanup(stub.Close)
+
+	stuburl, err := url.Parse(stub.URL)
+	require.NoError(t, err)
+
+	cfg := &SDConfig{
+		Server:          stuburl.Host,
+		Services:        []string{"test"},
+		Filter:          `NodeMeta.rack_name == "2304"`,
+		HealthFilter:    `Service.Tags contains "canary"`,
+		RefreshInterval: model.Duration(1 * time.Second),
+	}
+
+	d := newDiscovery(t, cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan []*targetgroup.Group)
+	go func() {
+		d.Run(ctx, ch)
+		close(ch)
+	}()
+	checkOneTarget(t, <-ch)
+	// All handler writes happened-before the channel receive above.
+	require.True(t, catalogCalled, "Catalog endpoint should be called when filter is set.")
+	require.Equal(t, `NodeMeta.rack_name == "2304"`, catalogFilter, "Catalog should receive only the catalog filter.")
+	require.True(t, healthCalled, "Health endpoint should be called.")
+	require.Equal(t, `Service.Tags contains "canary"`, healthFilter, "Health endpoint should receive only the health_filter.")
+	cancel()
+	for range ch {
+	}
 }
 
 func TestGetDatacenterShouldReturnError(t *testing.T) {
@@ -476,7 +576,7 @@ func TestGetDatacenterShouldReturnError(t *testing.T) {
 			Token:           "fake-token",
 			RefreshInterval: model.Duration(1 * time.Second),
 		}
-		defer stub.Close()
+		t.Cleanup(stub.Close)
 		d := newDiscovery(t, config)
 
 		// Should be empty if not initialized.

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -240,8 +240,6 @@ func newServer(t *testing.T) (*httptest.Server, *SDConfig) {
 			response = ServiceTestAnswer
 		case "/v1/health/service/test?wait=120000ms":
 			response = ServiceTestAnswer
-		case "/v1/health/service/test?filter=NodeMeta.rack_name+%3D%3D+%222304%22&wait=120000ms":
-			response = ServiceTestAnswer
 		case "/v1/health/service/other?wait=120000ms":
 			response = `[]`
 		case "/v1/catalog/services?node-meta=rack_name%3A2304&stale=&wait=120000ms":
@@ -394,21 +392,28 @@ func TestFilterOption(t *testing.T) {
 	cancel()
 }
 
-// TestFilterOnHealthEndpoint verifies that filter is passed to health service endpoint.
-func TestFilterOnHealthEndpoint(t *testing.T) {
-	filterReceived := false
+// TestHealthFilterOption verifies that health_filter is passed to the health service endpoint
+// and not to the catalog endpoint.
+func TestHealthFilterOption(t *testing.T) {
+	catalogFilterReceived := false
+	healthFilterReceived := false
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := ""
 		switch r.URL.Path {
 		case "/v1/agent/self":
 			response = AgentAnswer
 		case "/v1/health/service/test":
-			// Verify filter parameter is present in the query
 			filter := r.URL.Query().Get("filter")
-			if filter == `Node.Meta.rack_name == "2304"` {
-				filterReceived = true
+			if filter == `Service.Tags contains "canary"` {
+				healthFilterReceived = true
 			}
 			response = ServiceTestAnswer
+		case "/v1/catalog/services":
+			filter := r.URL.Query().Get("filter")
+			if filter != "" {
+				catalogFilterReceived = true
+			}
+			response = ServicesTestAnswer
 		default:
 			t.Errorf("Unhandled consul call: %s", r.URL)
 		}
@@ -423,7 +428,7 @@ func TestFilterOnHealthEndpoint(t *testing.T) {
 	config := &SDConfig{
 		Server:          stuburl.Host,
 		Services:        []string{"test"},
-		Filter:          `Node.Meta.rack_name == "2304"`,
+		HealthFilter:    `Service.Tags contains "canary"`,
 		RefreshInterval: model.Duration(1 * time.Second),
 	}
 
@@ -438,8 +443,8 @@ func TestFilterOnHealthEndpoint(t *testing.T) {
 	checkOneTarget(t, <-ch)
 	cancel()
 
-	// Verify the filter was actually sent to the health endpoint
-	require.True(t, filterReceived, "Filter parameter should be sent to health service endpoint")
+	require.True(t, healthFilterReceived, "health_filter should be sent to the health service endpoint.")
+	require.False(t, catalogFilterReceived, "health_filter should not be sent to the catalog endpoint.")
 }
 
 func TestGetDatacenterShouldReturnError(t *testing.T) {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1478,7 +1478,7 @@ services:
 tags:
   [ - <string> ]
 
-# Node metadata key/value pairs to filter nodes for a given service. As of Consul 1.14, consider `health_filter` instead.
+# Node metadata key/value pairs to filter nodes for a given service. As of Consul 1.14, consider `filter` or `health_filter` instead.
 [ node_meta:
   [ <string>: <string> ... ] ]
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1417,7 +1417,17 @@ subscription_id: <string>
 ### `<consul_sd_config>`
 
 Consul SD configurations allow retrieving scrape targets from [Consul's](https://www.consul.io)
-Catalog API.
+service catalog. Discovery uses two Consul API endpoints:
+
+1. The [Catalog API](https://developer.hashicorp.com/consul/api-docs/catalog) to list services
+   (used when `services` is empty, or when `tags` or `filter` are set).
+2. The [Health API](https://developer.hashicorp.com/consul/api-docs/health) to retrieve service
+   instances and their health status.
+
+Because these two APIs have different filtering field schemas, Prometheus exposes separate filter
+options for each: `filter` applies to the Catalog API and `health_filter` applies to the Health API.
+For example, tags are exposed as `ServiceTags` in the Catalog API but as `Service.Tags` in the
+Health API.
 
 The following meta labels are available on targets during [relabeling](#relabel_config):
 
@@ -1457,17 +1467,18 @@ The following meta labels are available on targets during [relabeling](#relabel_
 services:
   [ - <string> ]
 
-# A Consul Filter expression used to filter the catalog results
-# See https://www.consul.io/api-docs/catalog#list-services to know more
-# about the filter expressions that can be used.
+# Filter expression for the Catalog API. See https://developer.hashicorp.com/consul/api-docs/catalog#filtering for syntax.
 [ filter: <string> ]
 
-# The `tags` and `node_meta` fields are deprecated in Consul in favor of `filter`.
+# Filter expression for the Health API. See https://developer.hashicorp.com/consul/api-docs/health#filtering for syntax.
+[ health_filter: <string> ]
+
+# The `tags` and `node_meta` fields are deprecated in favor of `filter` and `health_filter`.
 # An optional list of tags used to filter nodes for a given service. Services must contain all tags in the list.
 tags:
   [ - <string> ]
 
-# Node metadata key/value pairs to filter nodes for a given service. As of Consul 1.14, consider `filter` instead.
+# Node metadata key/value pairs to filter nodes for a given service. As of Consul 1.14, consider `health_filter` instead.
 [ node_meta:
   [ <string>: <string> ... ] ]
 


### PR DESCRIPTION
The filter field was documented as targeting the Catalog API but since PR #17349 it was also passed to the Health API. This broke existing configs using Catalog-only fields like ServiceTags, which the Health API rejects (it uses Service.Tags instead).

Introduce a separate health_filter field that is passed exclusively to the Health API, while filter remains catalog-only. Update the docs to explain the two-phase discovery (Catalog for service listing, Health for instances) and the field name differences between the two APIs.

Fixes #18479

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Discovery/Consul: Add `health_filter` for Health API filtering, fixing breakage when using Catalog-only fields like `ServiceTags` in `filter`. #18479
```
