### PR TITLE
Scrape: add string interning to scrape cache

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unique"
 	"unsafe"
 
 	"github.com/klauspost/compress/gzip"
@@ -903,11 +904,11 @@ type scrapeCache struct {
 
 	// Parsed string to an entry with information about the actual label set
 	// and its storage reference.
-	series map[string]*cacheEntry
+	series map[unique.Handle[string]]*cacheEntry
 
 	// Cache of dropped metric strings and their iteration. The iteration must
 	// be a pointer so we can update it.
-	droppedSeries map[string]*uint64
+	droppedSeries map[unique.Handle[string]]*uint64
 
 	// Series that were seen in the current and previous scrape, for staleness detection.
 	seriesCur  map[storage.SeriesRef]*cacheEntry
@@ -915,8 +916,8 @@ type scrapeCache struct {
 
 	// TODO(bwplotka): Consider moving metadata caching to head. See
 	// https://github.com/prometheus/prometheus/issues/17619.
-	metaMtx  sync.Mutex            // Mutex is needed due to api touching it when metadata is queried.
-	metadata map[string]*metaEntry // metadata by metric family name.
+	metaMtx  sync.Mutex                           // Mutex is needed due to api touching it when metadata is queried.
+	metadata map[unique.Handle[string]]*metaEntry // metadata by metric family name.
 
 	metrics *scrapeMetrics
 }
@@ -924,6 +925,9 @@ type scrapeCache struct {
 // metaEntry holds meta information about a metric.
 type metaEntry struct {
 	metadata.Metadata
+
+	help unique.Handle[string]
+	unit unique.Handle[string]
 
 	lastIter       uint64 // Last scrape iteration the entry was observed at.
 	lastIterChange uint64 // Last scrape iteration the entry was changed at.
@@ -936,11 +940,11 @@ func (m *metaEntry) size() int {
 
 func newScrapeCache(metrics *scrapeMetrics) *scrapeCache {
 	return &scrapeCache{
-		series:        map[string]*cacheEntry{},
-		droppedSeries: map[string]*uint64{},
+		series:        map[unique.Handle[string]]*cacheEntry{},
+		droppedSeries: map[unique.Handle[string]]*uint64{},
 		seriesCur:     map[storage.SeriesRef]*cacheEntry{},
 		seriesPrev:    map[storage.SeriesRef]*cacheEntry{},
-		metadata:      map[string]*metaEntry{},
+		metadata:      map[unique.Handle[string]]*metaEntry{},
 		metrics:       metrics,
 	}
 }
@@ -995,7 +999,7 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 }
 
 func (c *scrapeCache) get(met []byte) (*cacheEntry, bool, bool) {
-	e, ok := c.series[string(met)]
+	e, ok := c.series[unique.Make(string(met))]
 	if !ok {
 		return nil, false, false
 	}
@@ -1009,17 +1013,17 @@ func (c *scrapeCache) addRef(met []byte, ref storage.SeriesRef, lset labels.Labe
 		return nil
 	}
 	ce = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
-	c.series[string(met)] = ce
+	c.series[unique.Make(string(met))] = ce
 	return ce
 }
 
 func (c *scrapeCache) addDropped(met []byte) {
 	iter := c.iter
-	c.droppedSeries[string(met)] = &iter
+	c.droppedSeries[unique.Make(string(met))] = &iter
 }
 
 func (c *scrapeCache) getDropped(met []byte) bool {
-	iterp, ok := c.droppedSeries[string(met)]
+	iterp, ok := c.droppedSeries[unique.Make(string(met))]
 	if ok {
 		*iterp = c.iter
 	}
@@ -1045,13 +1049,15 @@ func yoloString(b []byte) string {
 }
 
 func (c *scrapeCache) setType(mfName []byte, t model.MetricType) ([]byte, *metaEntry) {
+	key := unique.Make(string(mfName))
+
 	c.metaMtx.Lock()
 	defer c.metaMtx.Unlock()
 
-	e, ok := c.metadata[string(mfName)]
+	e, ok := c.metadata[key]
 	if !ok {
 		e = &metaEntry{Metadata: metadata.Metadata{Type: model.MetricTypeUnknown}}
-		c.metadata[string(mfName)] = e
+		c.metadata[key] = e
 	}
 	if e.Type != t {
 		e.Type = t
@@ -1062,16 +1068,19 @@ func (c *scrapeCache) setType(mfName []byte, t model.MetricType) ([]byte, *metaE
 }
 
 func (c *scrapeCache) setHelp(mfName, help []byte) ([]byte, *metaEntry) {
+	key := unique.Make(string(mfName))
+
 	c.metaMtx.Lock()
 	defer c.metaMtx.Unlock()
 
-	e, ok := c.metadata[string(mfName)]
+	e, ok := c.metadata[key]
 	if !ok {
 		e = &metaEntry{Metadata: metadata.Metadata{Type: model.MetricTypeUnknown}}
-		c.metadata[string(mfName)] = e
+		c.metadata[key] = e
 	}
 	if e.Help != string(help) {
-		e.Help = string(help)
+		e.help = unique.Make(string(help))
+		e.Help = e.help.Value()
 		e.lastIterChange = c.iter
 	}
 	e.lastIter = c.iter
@@ -1079,16 +1088,19 @@ func (c *scrapeCache) setHelp(mfName, help []byte) ([]byte, *metaEntry) {
 }
 
 func (c *scrapeCache) setUnit(mfName, unit []byte) ([]byte, *metaEntry) {
+	key := unique.Make(string(mfName))
+
 	c.metaMtx.Lock()
 	defer c.metaMtx.Unlock()
 
-	e, ok := c.metadata[string(mfName)]
+	e, ok := c.metadata[key]
 	if !ok {
 		e = &metaEntry{Metadata: metadata.Metadata{Type: model.MetricTypeUnknown}}
-		c.metadata[string(mfName)] = e
+		c.metadata[key] = e
 	}
 	if e.Unit != string(unit) {
-		e.Unit = string(unit)
+		e.unit = unique.Make(string(unit))
+		e.Unit = e.unit.Value()
 		e.lastIterChange = c.iter
 	}
 	e.lastIter = c.iter
@@ -1097,10 +1109,12 @@ func (c *scrapeCache) setUnit(mfName, unit []byte) ([]byte, *metaEntry) {
 
 // GetMetadata returns metadata given the metric family name.
 func (c *scrapeCache) GetMetadata(mfName string) (MetricMetadata, bool) {
+	key := unique.Make(mfName)
+
 	c.metaMtx.Lock()
 	defer c.metaMtx.Unlock()
 
-	m, ok := c.metadata[mfName]
+	m, ok := c.metadata[key]
 	if !ok {
 		return MetricMetadata{}, false
 	}
@@ -1121,7 +1135,7 @@ func (c *scrapeCache) ListMetadata() []MetricMetadata {
 
 	for m, e := range c.metadata {
 		res = append(res, MetricMetadata{
-			MetricFamily: m,
+			MetricFamily: m.Value(),
 			Type:         e.Type,
 			Help:         e.Help,
 			Unit:         e.Unit,

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unique"
 	"unsafe"
 
 	"github.com/klauspost/compress/gzip"
@@ -900,6 +901,16 @@ type scrapeLoop struct {
 // storage references. Additionally, it tracks staleness of series between
 // scrapes.
 // Cache is meant to be used per a single target.
+// Since there's a lot of series that share the same parsed string, especially
+// for metrics with no labels other than the __name__, we use unique package
+// to de-duplicate these for us in the cache, so we only store each raw string once,
+// and then keep a reference to that raw string here.
+// This saves us memory because unique.Handle needs 8 bytes, while the average series
+// would need a lot more than 8 bytes.
+// All scrapeCache functions take arguments as unique.Handle, rather than a raw string
+// that require unique.Make() call to get the handle value, because unique.Make is
+// a relatively expensive, so we want to call it once and then pass the results of
+// it around.
 type scrapeCache struct {
 	iter uint64 // Current scrape iteration.
 
@@ -908,11 +919,11 @@ type scrapeCache struct {
 
 	// Parsed string to an entry with information about the actual label set
 	// and its storage reference.
-	series map[string]*cacheEntry
+	series map[unique.Handle[string]]*cacheEntry
 
 	// Cache of dropped metric strings and their iteration. The iteration must
 	// be a pointer so we can update it.
-	droppedSeries map[string]*uint64
+	droppedSeries map[unique.Handle[string]]*uint64
 
 	// Series that were seen in the current and previous scrape, for staleness detection.
 	seriesCur  map[storage.SeriesRef]*cacheEntry
@@ -920,8 +931,8 @@ type scrapeCache struct {
 
 	// TODO(bwplotka): Consider moving metadata caching to head. See
 	// https://github.com/prometheus/prometheus/issues/17619.
-	metaMtx  sync.Mutex            // Mutex is needed due to api touching it when metadata is queried.
-	metadata map[string]*metaEntry // metadata by metric family name.
+	metaMtx  sync.Mutex                           // Mutex is needed due to api touching it when metadata is queried.
+	metadata map[unique.Handle[string]]*metaEntry // metadata by metric family name.
 
 	metrics *scrapeMetrics
 }
@@ -929,6 +940,9 @@ type scrapeCache struct {
 // metaEntry holds meta information about a metric.
 type metaEntry struct {
 	metadata.Metadata
+
+	help unique.Handle[string]
+	unit unique.Handle[string]
 
 	lastIter       uint64 // Last scrape iteration the entry was observed at.
 	lastIterChange uint64 // Last scrape iteration the entry was changed at.
@@ -941,11 +955,11 @@ func (m *metaEntry) size() int {
 
 func newScrapeCache(metrics *scrapeMetrics) *scrapeCache {
 	return &scrapeCache{
-		series:        map[string]*cacheEntry{},
-		droppedSeries: map[string]*uint64{},
+		series:        map[unique.Handle[string]]*cacheEntry{},
+		droppedSeries: map[unique.Handle[string]]*uint64{},
 		seriesCur:     map[storage.SeriesRef]*cacheEntry{},
 		seriesPrev:    map[storage.SeriesRef]*cacheEntry{},
-		metadata:      map[string]*metaEntry{},
+		metadata:      map[unique.Handle[string]]*metaEntry{},
 		metrics:       metrics,
 	}
 }
@@ -999,8 +1013,8 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 	c.iter++
 }
 
-func (c *scrapeCache) get(met []byte) (*cacheEntry, bool, bool) {
-	e, ok := c.series[string(met)]
+func (c *scrapeCache) get(met unique.Handle[string]) (*cacheEntry, bool, bool) {
+	e, ok := c.series[met]
 	if !ok {
 		return nil, false, false
 	}
@@ -1009,19 +1023,19 @@ func (c *scrapeCache) get(met []byte) (*cacheEntry, bool, bool) {
 	return e, true, alreadyScraped
 }
 
-func (c *scrapeCache) addRef(met []byte, ref storage.SeriesRef, lset labels.Labels, hash uint64) (ce *cacheEntry) {
+func (c *scrapeCache) addRef(met unique.Handle[string], ref storage.SeriesRef, lset labels.Labels, hash uint64) (ce *cacheEntry) {
 	ce = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
-	c.series[string(met)] = ce
+	c.series[met] = ce
 	return ce
 }
 
-func (c *scrapeCache) addDropped(met []byte) {
+func (c *scrapeCache) addDropped(met unique.Handle[string]) {
 	iter := c.iter
-	c.droppedSeries[string(met)] = &iter
+	c.droppedSeries[met] = &iter
 }
 
-func (c *scrapeCache) getDropped(met []byte) bool {
-	iterp, ok := c.droppedSeries[string(met)]
+func (c *scrapeCache) getDropped(met unique.Handle[string]) bool {
+	iterp, ok := c.droppedSeries[met]
 	if ok {
 		*iterp = c.iter
 	}
@@ -1047,13 +1061,15 @@ func yoloString(b []byte) string {
 }
 
 func (c *scrapeCache) setType(mfName []byte, t model.MetricType) ([]byte, *metaEntry) {
+	key := unique.Make(string(mfName))
+
 	c.metaMtx.Lock()
 	defer c.metaMtx.Unlock()
 
-	e, ok := c.metadata[string(mfName)]
+	e, ok := c.metadata[key]
 	if !ok {
 		e = &metaEntry{Metadata: metadata.Metadata{Type: model.MetricTypeUnknown}}
-		c.metadata[string(mfName)] = e
+		c.metadata[key] = e
 	}
 	if e.Type != t {
 		e.Type = t
@@ -1064,16 +1080,19 @@ func (c *scrapeCache) setType(mfName []byte, t model.MetricType) ([]byte, *metaE
 }
 
 func (c *scrapeCache) setHelp(mfName, help []byte) ([]byte, *metaEntry) {
+	key := unique.Make(string(mfName))
+
 	c.metaMtx.Lock()
 	defer c.metaMtx.Unlock()
 
-	e, ok := c.metadata[string(mfName)]
+	e, ok := c.metadata[key]
 	if !ok {
 		e = &metaEntry{Metadata: metadata.Metadata{Type: model.MetricTypeUnknown}}
-		c.metadata[string(mfName)] = e
+		c.metadata[key] = e
 	}
 	if e.Help != string(help) {
-		e.Help = string(help)
+		e.help = unique.Make(string(help))
+		e.Help = e.help.Value()
 		e.lastIterChange = c.iter
 	}
 	e.lastIter = c.iter
@@ -1081,16 +1100,19 @@ func (c *scrapeCache) setHelp(mfName, help []byte) ([]byte, *metaEntry) {
 }
 
 func (c *scrapeCache) setUnit(mfName, unit []byte) ([]byte, *metaEntry) {
+	key := unique.Make(string(mfName))
+
 	c.metaMtx.Lock()
 	defer c.metaMtx.Unlock()
 
-	e, ok := c.metadata[string(mfName)]
+	e, ok := c.metadata[key]
 	if !ok {
 		e = &metaEntry{Metadata: metadata.Metadata{Type: model.MetricTypeUnknown}}
-		c.metadata[string(mfName)] = e
+		c.metadata[key] = e
 	}
 	if e.Unit != string(unit) {
-		e.Unit = string(unit)
+		e.unit = unique.Make(string(unit))
+		e.Unit = e.unit.Value()
 		e.lastIterChange = c.iter
 	}
 	e.lastIter = c.iter
@@ -1099,10 +1121,12 @@ func (c *scrapeCache) setUnit(mfName, unit []byte) ([]byte, *metaEntry) {
 
 // GetMetadata returns metadata given the metric family name.
 func (c *scrapeCache) GetMetadata(mfName string) (MetricMetadata, bool) {
+	key := unique.Make(mfName)
+
 	c.metaMtx.Lock()
 	defer c.metaMtx.Unlock()
 
-	m, ok := c.metadata[mfName]
+	m, ok := c.metadata[key]
 	if !ok {
 		return MetricMetadata{}, false
 	}
@@ -1123,7 +1147,7 @@ func (c *scrapeCache) ListMetadata() []MetricMetadata {
 
 	for m, e := range c.metadata {
 		res = append(res, MetricMetadata{
-			MetricFamily: m,
+			MetricFamily: m.Value(),
 			Type:         e.Type,
 			Help:         e.Help,
 			Unit:         e.Unit,
@@ -1656,6 +1680,7 @@ loop:
 			et                       textparse.Entry
 			sampleAdded, isHistogram bool
 			met                      []byte
+			metHandle                unique.Handle[string]
 			parsedTimestamp          *int64
 			val                      float64
 			h                        *histogram.Histogram
@@ -1695,6 +1720,7 @@ loop:
 		} else {
 			met, parsedTimestamp, val = p.Series()
 		}
+		metHandle = unique.Make(string(met))
 		if !sl.honorTimestamps {
 			parsedTimestamp = nil
 		}
@@ -1702,10 +1728,10 @@ loop:
 			t = *parsedTimestamp
 		}
 
-		if sl.cache.getDropped(met) {
+		if sl.cache.getDropped(metHandle) {
 			continue
 		}
-		ce, seriesCached, seriesAlreadyScraped := sl.cache.get(met)
+		ce, seriesCached, seriesAlreadyScraped := sl.cache.get(metHandle)
 		var (
 			ref  storage.SeriesRef
 			hash uint64
@@ -1725,7 +1751,7 @@ loop:
 
 			// The label set may be set to empty to indicate dropping.
 			if lset.IsEmpty() {
-				sl.cache.addDropped(met)
+				sl.cache.addDropped(metHandle)
 				continue
 			}
 
@@ -1797,7 +1823,7 @@ loop:
 		// If a series was new but we didn't append it due to sample_limit or other errors then we don't need
 		// it in the scrape cache because we don't need to emit StaleNaNs for it when it disappears.
 		if !seriesCached && sampleAdded {
-			ce = sl.cache.addRef(met, ref, lset, hash)
+			ce = sl.cache.addRef(metHandle, ref, lset, hash)
 			if ce != nil && ce.ref != 0 && (parsedTimestamp == nil || sl.trackTimestampsStaleness) {
 				// Bypass staleness logic if there is an explicit timestamp.
 				// But make sure we only do this if we have a cache entry (ce) for our series.
@@ -2181,7 +2207,8 @@ func (sl *scrapeLoop) reportStale(app scrapeLoopAppendAdapter, start time.Time) 
 }
 
 func (sl *scrapeLoopAppender) addReportSample(s reportSample, t int64, v float64, b *labels.Builder, rejectOOO bool) (err error) {
-	ce, ok, _ := sl.cache.get(s.name)
+	handle := unique.Make(string(s.name))
+	ce, ok, _ := sl.cache.get(handle)
 	var ref storage.SeriesRef
 	var lset labels.Labels
 	if ok {
@@ -2208,7 +2235,7 @@ func (sl *scrapeLoopAppender) addReportSample(s reportSample, t int64, v float64
 	switch {
 	case err == nil:
 		if !ok {
-			sl.cache.addRef(s.name, ref, lset, lset.Hash())
+			sl.cache.addRef(handle, ref, lset, lset.Hash())
 			// We only need to add metadata once a scrape target appears.
 			if sl.appendMetadataToWAL {
 				if _, merr := sl.UpdateMetadata(ref, lset, s.Metadata); merr != nil {

--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"slices"
 	"time"
+	"unique"
 
 	"github.com/prometheus/common/model"
 
@@ -152,6 +153,7 @@ loop:
 			sampleAdded, isHistogram bool
 			st                       int64
 			met                      []byte
+			metHandle                unique.Handle[string]
 			parsedTimestamp          *int64
 			val                      float64
 			h                        *histogram.Histogram
@@ -193,6 +195,7 @@ loop:
 		} else {
 			met, parsedTimestamp, val = p.Series()
 		}
+		metHandle = unique.Make(string(met))
 		if !sl.honorTimestamps {
 			parsedTimestamp = nil
 		}
@@ -200,10 +203,10 @@ loop:
 			t = *parsedTimestamp
 		}
 
-		if sl.cache.getDropped(met) {
+		if sl.cache.getDropped(metHandle) {
 			continue
 		}
-		ce, seriesCached, seriesAlreadyScraped := sl.cache.get(met)
+		ce, seriesCached, seriesAlreadyScraped := sl.cache.get(metHandle)
 		var (
 			ref  storage.SeriesRef
 			hash uint64
@@ -223,7 +226,7 @@ loop:
 
 			// The label set may be set to empty to indicate dropping.
 			if lset.IsEmpty() {
-				sl.cache.addDropped(met)
+				sl.cache.addDropped(metHandle)
 				continue
 			}
 
@@ -348,7 +351,7 @@ loop:
 		// If a series was new, but we didn't append it due to sample_limit or other errors then we don't need
 		// it in the scrape cache because we don't need to emit StaleNaNs for it when it disappears.
 		if !seriesCached && sampleAdded {
-			ce = sl.cache.addRef(met, ref, lset, hash)
+			ce = sl.cache.addRef(metHandle, ref, lset, hash)
 
 			if sampleLimitErr == nil && bucketLimitErr == nil {
 				seriesAdded++
@@ -414,7 +417,8 @@ loop:
 }
 
 func (sl *scrapeLoopAppenderV2) addReportSample(s reportSample, t int64, v float64, b *labels.Builder, rejectOOO bool) (err error) {
-	ce, ok, _ := sl.cache.get(s.name)
+	handle := unique.Make(string(s.name))
+	ce, ok, _ := sl.cache.get(handle)
 	var ref storage.SeriesRef
 	var lset labels.Labels
 	if ok {
@@ -437,7 +441,7 @@ func (sl *scrapeLoopAppenderV2) addReportSample(s reportSample, t int64, v float
 	switch {
 	case err == nil:
 		if !ok {
-			sl.cache.addRef(s.name, ref, lset, lset.Hash())
+			sl.cache.addRef(handle, ref, lset, lset.Hash())
 		}
 		return nil
 	case errors.Is(err, storage.ErrOutOfOrderSample), errors.Is(err, storage.ErrDuplicateSampleForTimestamp):

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -37,6 +37,7 @@ import (
 	"testing/synctest"
 	"text/template"
 	"time"
+	"unique"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/regexp"
@@ -2239,14 +2240,14 @@ func testScrapeLoopCache(t *testing.T, appV2 bool) {
 	scraper.scrapeFunc = func(_ context.Context, w io.Writer) error {
 		switch numScrapes {
 		case 1, 2:
-			_, ok := sl.cache.series["metric_a"]
+			_, ok := sl.cache.series[unique.Make("metric_a")]
 			require.True(t, ok, "metric_a missing from cache after scrape %d", numScrapes)
-			_, ok = sl.cache.series["metric_b"]
+			_, ok = sl.cache.series[unique.Make("metric_b")]
 			require.True(t, ok, "metric_b missing from cache after scrape %d", numScrapes)
 		case 3:
-			_, ok := sl.cache.series["metric_a"]
+			_, ok := sl.cache.series[unique.Make("metric_a")]
 			require.True(t, ok, "metric_a missing from cache after scrape %d", numScrapes)
-			_, ok = sl.cache.series["metric_b"]
+			_, ok = sl.cache.series[unique.Make("metric_b")]
 			require.False(t, ok, "metric_b present in cache after scrape %d", numScrapes)
 		}
 

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -37,6 +37,7 @@ import (
 	"testing/synctest"
 	"text/template"
 	"time"
+	"unique"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/regexp"
@@ -2878,14 +2879,14 @@ func testScrapeLoopCache(t *testing.T, appV2 bool) {
 	scraper.scrapeFunc = func(_ context.Context, w io.Writer) error {
 		switch numScrapes {
 		case 1, 2:
-			_, ok := sl.cache.series["metric_a"]
+			_, ok := sl.cache.series[unique.Make("metric_a")]
 			require.True(t, ok, "metric_a missing from cache after scrape %d", numScrapes)
-			_, ok = sl.cache.series["metric_b"]
+			_, ok = sl.cache.series[unique.Make("metric_b")]
 			require.True(t, ok, "metric_b missing from cache after scrape %d", numScrapes)
 		case 3:
-			_, ok := sl.cache.series["metric_a"]
+			_, ok := sl.cache.series[unique.Make("metric_a")]
 			require.True(t, ok, "metric_a missing from cache after scrape %d", numScrapes)
-			_, ok = sl.cache.series["metric_b"]
+			_, ok = sl.cache.series[unique.Make("metric_b")]
 			require.False(t, ok, "metric_b present in cache after scrape %d", numScrapes)
 		}
 
@@ -3153,7 +3154,7 @@ func testScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T, appV2 bool) {
 	hash := lset.Hash()
 
 	// Create a fake entry in the cache
-	sl.cache.addRef(metric, fakeRef, lset, hash)
+	sl.cache.addRef(unique.Make(string(metric)), fakeRef, lset, hash)
 	now := time.Now()
 
 	app := sl.appender()


### PR DESCRIPTION
A lot of memory is used by scrape cache:

```
(pprof) list addRef
Total: 99.23GB
ROUTINE ======================== github.com/prometheus/prometheus/scrape.(*scrapeCache).addRef in scrape/scrape.go
    6.78GB     6.78GB (flat, cum)  6.83% of Total
         .          .   1085:func (c *scrapeCache) addRef(met []byte, ref storage.SeriesRef, lset labels.Labels, hash uint64) (ce *cacheEntry) {
         .          .   1086:   if ref == 0 {
         .          .   1087:           return nil
         .          .   1088:   }
    1.73GB     1.73GB   1089:   ce = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
    5.04GB     5.04GB   1090:   c.series[string(met)] = ce
         .          .   1091:   return ce
         .          .   1092:}
         .          .   1093:
         .          .   1094:func (c *scrapeCache) addDropped(met []byte) {
         .          .   1095:   iter := c.iter
```

Here `met` is a timeseries identity as it comes from the scrape, so it is very much shared between instances. Instead of storing 255 instances of this coming from every target:

```
edgeworker_request_internalExceptions{isActor="true",exceptionType="overloaded",stableId="cloudflare/cf_imgresize",plan="ss",cordon="paid"}
```

One can store 255 u64 pointers, which sounds a lot more compact.

I built a vanilla prometheus binary and a patched binary and let them both scrape the same targets in a datacenter with sum(scrape_samples_scraped) of about 10 million.

After running for not a very long period of time in parallel:

* Control:

```
(pprof) top30
Showing nodes accounting for 33.55GB, 94.28% of 35.58GB total
Dropped 702 nodes (cum <= 0.18GB)
Showing top 30 nodes out of 95
      flat  flat%   sum%        cum   cum%
    4.84GB 13.60% 13.60%     4.84GB 13.60%  github.com/prometheus/prometheus/model/labels.(*Builder).Labels
    4.10GB 11.53% 25.14%     4.10GB 11.53%  github.com/prometheus/prometheus/scrape.(*scrapeCache).addRef
    3.90GB 10.96% 36.09%     4.58GB 12.88%  github.com/prometheus/prometheus/tsdb.newMemSeries (inline)
    3.56GB  9.99% 46.09%     3.56GB  9.99%  github.com/prometheus/prometheus/tsdb/chunkenc.NewXORChunk (inline)
    2.99GB  8.40% 54.49%     2.99GB  8.40%  github.com/prometheus/prometheus/tsdb/index.appendWithExponentialGrowth[go.shape.uint64] (inline)
    2.41GB  6.78% 61.27%     2.41GB  6.78%  github.com/prometheus/prometheus/tsdb.(*txRing).add
    1.37GB  3.84% 65.11%     1.37GB  3.84%  github.com/prometheus/prometheus/scrape.(*scrapeCache).trackStaleness
    1.31GB  3.68% 68.79%     1.31GB  3.68%  github.com/prometheus/prometheus/scrape.(*scrapeCache).addDropped
    1.22GB  3.44% 72.23%     1.22GB  3.44%  github.com/prometheus/prometheus/scrape.NewManager.func1
    1.10GB  3.08% 75.31%     1.10GB  3.08%  github.com/prometheus/prometheus/tsdb/chunkenc.(*XORChunk).Appender
    1.08GB  3.05% 78.36%     5.76GB 16.19%  github.com/prometheus/prometheus/tsdb.(*memSeries).cutNewHeadChunk
    0.91GB  2.56% 80.93%     0.92GB  2.58%  github.com/prometheus/prometheus/tsdb.(*memSeries).mmapChunks
    0.70GB  1.97% 82.90%     0.70GB  1.97%  github.com/prometheus/prometheus/scrape.(*scrapeCache).setHelp
    0.68GB  1.92% 84.82%     0.68GB  1.92%  github.com/prometheus/prometheus/tsdb.newTxRing (inline)
    0.56GB  1.59% 86.41%     0.56GB  1.59%  github.com/prometheus/prometheus/tsdb.(*seriesHashmap).set
    0.55GB  1.55% 87.95%     5.70GB 16.02%  github.com/prometheus/prometheus/tsdb.(*stripeSeries).getOrSet
    0.35GB  0.99% 88.94%     0.36GB  1.01%  golang.org/x/net/trace.NewEventLog
    0.28GB  0.78% 89.73%     0.28GB  0.78%  github.com/prometheus/prometheus/tsdb.NewCircularExemplarStorage
    0.26GB  0.72% 90.45%     0.26GB  0.72%  github.com/prometheus/prometheus/model/labels.(*ScratchBuilder).Labels
    0.25GB  0.71% 91.16%     0.25GB  0.71%  bufio.NewReaderSize (inline)
    0.23GB  0.66% 91.81%     0.23GB  0.66%  bufio.NewWriterSize (inline)
    0.20GB  0.57% 92.39%     0.20GB  0.57%  github.com/prometheus/prometheus/tsdb.(*blockSeriesSet).At
    0.18GB  0.51% 92.89%     0.90GB  2.52%  github.com/prometheus/prometheus/promql.(*evaluator).rangeEval
    0.12GB  0.34% 93.23%     0.47GB  1.33%  github.com/prometheus/prometheus/promql.expandSeriesSet
    0.11GB   0.3% 93.53%     8.67GB 24.38%  github.com/prometheus/prometheus/tsdb.(*headAppender).Append
    0.10GB  0.29% 93.82%     1.88GB  5.28%  github.com/prometheus/prometheus/rules.(*Group).Eval.func1
    0.05GB  0.15% 93.97%     1.38GB  3.89%  github.com/prometheus/prometheus/promql.(*evaluator).eval
    0.05GB  0.15% 94.12%     0.92GB  2.59%  net/http.(*Transport).dialConn
    0.04GB  0.11% 94.22%     8.57GB 24.10%  github.com/prometheus/prometheus/tsdb.(*headAppender).getOrCreate
    0.02GB 0.059% 94.28%     0.18GB  0.52%  github.com/prometheus/prometheus/promql.(*evaluator).VectorBinop
```

* Test:

```
(pprof) top30
Showing nodes accounting for 28.31GB, 94.43% of 29.98GB total
Dropped 684 nodes (cum <= 0.15GB)
Showing top 30 nodes out of 96
      flat  flat%   sum%        cum   cum%
    4.41GB 14.72% 14.72%     4.41GB 14.72%  github.com/prometheus/prometheus/model/labels.(*Builder).Labels
    3.74GB 12.46% 27.18%     4.38GB 14.63%  github.com/prometheus/prometheus/tsdb.newMemSeries (inline)
    3.15GB 10.51% 37.69%     3.15GB 10.51%  github.com/prometheus/prometheus/tsdb/chunkenc.NewXORChunk (inline)
    2.98GB  9.93% 47.61%     2.98GB  9.93%  github.com/prometheus/prometheus/tsdb/index.appendWithExponentialGrowth[go.shape.uint64] (inline)
    1.93GB  6.42% 54.03%     1.93GB  6.42%  github.com/prometheus/prometheus/tsdb.(*txRing).add
    1.88GB  6.28% 60.31%     1.88GB  6.28%  bytes.growSlice
    1.63GB  5.45% 65.76%     1.64GB  5.46%  github.com/prometheus/prometheus/scrape.(*scrapeCache).addRef
    1.17GB  3.90% 69.66%     1.17GB  3.90%  github.com/prometheus/prometheus/scrape.(*scrapeCache).trackStaleness
    0.97GB  3.23% 72.89%     5.03GB 16.78%  github.com/prometheus/prometheus/tsdb.(*memSeries).cutNewHeadChunk
    0.89GB  2.95% 75.84%     0.89GB  2.95%  github.com/prometheus/prometheus/tsdb/chunkenc.(*XORChunk).Appender
    0.68GB  2.28% 78.12%     0.71GB  2.36%  github.com/prometheus/prometheus/tsdb.(*memSeries).mmapChunks
    0.65GB  2.17% 80.29%     0.65GB  2.17%  github.com/prometheus/prometheus/tsdb.newTxRing (inline)
    0.56GB  1.88% 82.17%     5.50GB 18.35%  github.com/prometheus/prometheus/tsdb.(*stripeSeries).getOrSet
    0.55GB  1.84% 84.02%     0.55GB  1.84%  github.com/prometheus/prometheus/tsdb.(*seriesHashmap).set
    0.42GB  1.40% 85.42%     0.42GB  1.40%  github.com/prometheus/prometheus/scrape.NewManager.func1
    0.36GB  1.20% 86.61%     0.36GB  1.21%  github.com/prometheus/prometheus/scrape.(*scrapeCache).setHelp
    0.33GB  1.09% 87.70%     0.34GB  1.13%  golang.org/x/net/trace.NewEventLog
    0.28GB  0.92% 88.62%     0.28GB  0.92%  github.com/prometheus/prometheus/tsdb.NewCircularExemplarStorage
    0.26GB  0.88% 89.50%     0.26GB  0.88%  github.com/prometheus/prometheus/scrape.(*scrapeCache).addDropped
    0.24GB   0.8% 90.30%     0.24GB   0.8%  bufio.NewReaderSize (inline)
    0.24GB  0.79% 91.09%     0.24GB  0.79%  bufio.NewWriterSize (inline)
    0.20GB  0.68% 91.77%     8.95GB 29.86%  github.com/prometheus/prometheus/tsdb.(*headAppender).Append
    0.19GB  0.63% 92.40%     0.19GB  0.63%  internal/stringslite.Clone
    0.18GB  0.59% 92.99%     8.69GB 28.97%  github.com/prometheus/prometheus/tsdb.(*headAppender).getOrCreate
    0.17GB  0.58% 93.57%     0.17GB  0.58%  github.com/prometheus/prometheus/tsdb/encoding.(*Encbuf).PutString
    0.10GB  0.33% 93.90%     0.26GB  0.86%  unique.(*canonMap[go.shape.string]).LoadOrStore
    0.06GB  0.22% 94.11%     0.91GB  3.05%  net/http.(*Transport).dialConn
    0.04GB  0.13% 94.24%     0.38GB  1.27%  github.com/prometheus/prometheus/promql.(*evaluator).eval
    0.04GB  0.12% 94.37%     0.18GB  0.59%  github.com/prometheus/prometheus/promql.expandSeriesSet
    0.02GB  0.06% 94.43%     0.52GB  1.72%  github.com/prometheus/prometheus/rules.(*Group).Eval.func1
```

Key changes:

* `addRef`: 4.10GB -> 1.63GB
* `addDropped`: 1.31GB -> 0.26GB
* `setHelp`: 0.70GB -> 0.36GB

Given that Go GC requires quite significant overhead, these numbers need to be multiplied by 1.5-2x to get the actual amount of memory saved as visible from the OS perspective.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[PERF] Scrape: optimize memory usage for scrape cache.
```
