### PR TITLE
util/gate: add waiting duration histogram metric

### DIFF
--- a/storage/remote/read_handler.go
+++ b/storage/remote/read_handler.go
@@ -51,7 +51,7 @@ func NewReadHandler(logger *slog.Logger, r prometheus.Registerer, queryable stor
 		queryable:                 queryable,
 		config:                    config,
 		remoteReadSampleLimit:     remoteReadSampleLimit,
-		remoteReadGate:            gate.New(remoteReadConcurrencyLimit),
+		remoteReadGate:            gate.NewInstrumented(r, remoteReadConcurrencyLimit),
 		remoteReadMaxBytesInFrame: remoteReadMaxBytesInFrame,
 		marshalPool:               &sync.Pool{},
 

--- a/util/gate/gate.go
+++ b/util/gate/gate.go
@@ -13,23 +13,53 @@
 
 package gate
 
-import "context"
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
 
 // A Gate controls the maximum number of concurrently running and waiting queries.
 type Gate struct {
-	ch chan struct{}
+	ch              chan struct{}
+	waitingDuration prometheus.Observer
 }
 
 // New returns a query gate that limits the number of queries
 // being concurrently executed.
 func New(length int) *Gate {
 	return &Gate{
-		ch: make(chan struct{}, length),
+		ch:              make(chan struct{}, length),
+		waitingDuration: nil,
 	}
+}
+
+// NewInstrumented returns a query gate that limits the number of queries
+// being concurrently executed and records the time spent waiting for the gate.
+func NewInstrumented(reg prometheus.Registerer, length int) *Gate {
+	g := New(length)
+	g.waitingDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name:                            "gate_waiting_seconds",
+		Help:                            "How many seconds it took for queries to wait at the gate.",
+		Buckets:                         prometheus.DefBuckets,
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
+	})
+	return g
 }
 
 // Start blocks until the gate has a free spot or the context is done.
 func (g *Gate) Start(ctx context.Context) error {
+	start := time.Now()
+	defer func() {
+		if g.waitingDuration != nil {
+			g.waitingDuration.Observe(time.Since(start).Seconds())
+		}
+	}()
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/util/gate/gate_test.go
+++ b/util/gate/gate_test.go
@@ -1,0 +1,134 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gate
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGateStart(t *testing.T) {
+	g := New(1)
+
+	ctx := context.Background()
+	require.NoError(t, g.Start(ctx))
+
+	// Gate is full, second Start should block until context timeout.
+	ctx2, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	require.Error(t, g.Start(ctx2))
+
+	g.Done()
+
+	require.NoError(t, g.Start(ctx))
+	g.Done()
+}
+
+func TestGateStartContextCanceled(t *testing.T) {
+	g := New(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.Error(t, g.Start(ctx))
+}
+
+func TestGateDonePanic(t *testing.T) {
+	g := New(1)
+
+	require.Panics(t, func() {
+		g.Done()
+	})
+}
+
+func TestNewInstrumentedRecordsWaitingDuration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	g := NewInstrumented(reg, 1)
+
+	ctx := context.Background()
+	require.NoError(t, g.Start(ctx))
+
+	// Verify the metric was recorded.
+	count := getSampleCount(t, reg, "gate_waiting_seconds")
+	require.Equal(t, uint64(1), count, "expected 1 observation after Start")
+
+	g.Done()
+}
+
+func TestInstrumentedGateWaitingDuration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	// Gate with concurrency 1.
+	g := NewInstrumented(reg, 1)
+
+	ctx := context.Background()
+	require.NoError(t, g.Start(ctx))
+
+	// Now the gate is full. Start a goroutine that will wait.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, g.Start(ctx))
+		g.Done()
+	}()
+
+	// Let the goroutine block for a bit, then release the gate.
+	time.Sleep(100 * time.Millisecond)
+	g.Done()
+	wg.Wait()
+
+	// Should have 2 observations total now.
+	count := getSampleCount(t, reg, "gate_waiting_seconds")
+	require.Equal(t, uint64(2), count, "expected 2 observations total")
+}
+
+func TestNewWithoutInstrumentationDoesNotPanic(t *testing.T) {
+	// Ensure the non-instrumented gate still works fine (no nil pointer panic).
+	g := New(1)
+	ctx := context.Background()
+	require.NoError(t, g.Start(ctx))
+	g.Done()
+}
+
+// getSampleCount gathers metrics from the registry and returns the sample
+// count of the histogram with the given name.
+func getSampleCount(t *testing.T, reg *prometheus.Registry, name string) uint64 {
+	t.Helper()
+
+	metrics, err := reg.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range metrics {
+		if mf.GetName() == name {
+			m := mf.GetMetric()
+			require.NotEmpty(t, m)
+			return getHistogramCount(m[0])
+		}
+	}
+	t.Fatalf("metric %q not found in registry", name)
+	return 0
+}
+
+func getHistogramCount(m *dto.Metric) uint64 {
+	if h := m.GetHistogram(); h != nil {
+		return h.GetSampleCount()
+	}
+	return 0
+}


### PR DESCRIPTION
## What this PR does

Adds a `gate_waiting_seconds` histogram metric to the Gate utility so that operators can detect when the remote read concurrency limit is causing requests to queue.

### Changes

1. **`util/gate/gate.go`**: Added `NewInstrumented(reg prometheus.Registerer, length int)` constructor that wraps the gate with a histogram metric recording how long each `Start()` call waits for a free slot. The existing `New()` constructor is unchanged for backward compatibility.

2. **`util/gate/gate_test.go`**: New test file covering both instrumented and non-instrumented gates, verifying metric observations are recorded correctly.

3. **`storage/remote/read_handler.go`**: Updated `NewReadHandler` to use `gate.NewInstrumented(r, ...)` instead of `gate.New(...)` so that the remote read handler exposes the waiting duration metric.

### How this solves the issue

When Prometheus is close to the `--storage.remote.read-concurrent-limit`, incoming remote read requests queue at the gate. Today there's no way to know this is happening. With this change, the `gate_waiting_seconds` histogram tracks how long each request waited — a spike in wait times or high-percentile values directly indicates gate contention. Operators can alert on `histogram_quantile(0.99, rate(gate_waiting_seconds_bucket[5m]))` to detect when the concurrency limit is becoming a bottleneck.

### Design decisions

- Following the pattern from `util/notifications/notifications.go`, metrics are registered via `prometheus.Registerer` passed at construction time, keeping the util package clean.
- Uses `promauto.With(reg)` for safe registration.
- Native histogram support is enabled for modern Prometheus setups.
- The non-instrumented `New()` constructor remains for backward compatibility (no metrics overhead unless explicitly opted in).

Fixes #11365

```release-notes
[ENHANCEMENT] Remote Read: Add `gate_waiting_seconds` histogram metric to track time spent waiting for the remote read concurrency gate.
```