### PR TITLE
config: add consul health_filter fixture coverage

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -481,6 +481,7 @@ var expectedConf = &Config{
 					PathPrefix:      "/consul",
 					Token:           "mysecret",
 					Services:        []string{"nginx", "cache", "mysql"},
+					HealthFilter:    `Service.Tags contains "canary"`,
 					ServiceTags:     []string{"canary", "v1"},
 					NodeMeta:        map[string]string{"rack": "123"},
 					TagSeparator:    consul.DefaultSDConfig.TagSeparator,

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -182,6 +182,7 @@ scrape_configs:
         token: mysecret
         path_prefix: /consul
         services: ["nginx", "cache", "mysql"]
+        health_filter: 'Service.Tags contains "canary"'
         tags: ["canary", "v1"]
         node_meta:
           rack: "123"

--- a/config/testdata/roundtrip.good.yml
+++ b/config/testdata/roundtrip.good.yml
@@ -41,6 +41,7 @@ scrape_configs:
       - server: localhost:1234
         token: <secret>
         services: [nginx, cache, mysql]
+        health_filter: 'Service.Tags contains "canary"'
         tags: [canary, v1]
         node_meta:
           rack: "123"


### PR DESCRIPTION
Follow-up to #18499.

Adds `health_filter` coverage to the config fixtures and round-trip config tests.

```release-notes
NONE
```