### PR TITLE
tsdb [PERF]: move lastHistogramValue/lastFloatHistogramValue from memSeries to appenders

### DIFF
--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -121,6 +121,16 @@ type Appender interface {
 	// The Appender app that can be used for the next append is always returned.
 	AppendHistogram(prev *HistogramAppender, st, t int64, h *histogram.Histogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
 	AppendFloatHistogram(prev *FloatHistogramAppender, st, t int64, h *histogram.FloatHistogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
+
+	// IsStaleLastValue reports whether the most recently appended sample is a
+	// stale marker, regardless of sample type.
+	IsStaleLastValue() bool
+
+	// IsEqual reports whether the given sample would be an exact duplicate of
+	// the most recently appended sample. Pass only the field that matches the
+	// sample type being checked; the other fields should be zero (0 for float64,
+	// nil for pointers). Returns false whenever the types differ or the values differ.
+	IsEqual(v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool
 }
 
 // Iterator is a simple iterator that can only get the next value.

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -122,15 +122,12 @@ type Appender interface {
 	AppendHistogram(prev *HistogramAppender, st, t int64, h *histogram.Histogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
 	AppendFloatHistogram(prev *FloatHistogramAppender, st, t int64, h *histogram.FloatHistogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
 
-	// IsStaleLastValue reports whether the most recently appended sample is a
-	// stale marker, regardless of sample type.
-	IsStaleLastValue() bool
-
-	// IsEqual reports whether the given sample would be an exact duplicate of
-	// the most recently appended sample. Pass only the field that matches the
-	// sample type being checked; the other fields should be zero (0 for float64,
-	// nil for pointers). Returns false whenever the types differ or the values differ.
-	IsEqual(v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool
+	// LastValue returns the most recently appended sample value.
+	// For float samples, v is set and h, fh are nil.
+	// For integer histogram samples, h is set and v, fh are zero/nil.
+	// For float histogram samples, fh is set and v, h are zero/nil.
+	// If no sample has been appended yet, all return values are zero/nil.
+	LastValue() (v float64, h *histogram.Histogram, fh *histogram.FloatHistogram)
 }
 
 // Iterator is a simple iterator that can only get the next value.

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -179,10 +179,26 @@ type FloatHistogramAppender struct {
 	t, tDelta          int64
 	sum, cnt, zCnt     xorValue
 	pBuckets, nBuckets []xorValue
+
+	// lastValue is the most recently appended float histogram, retained for
+	// duplicate detection and stale-marker tracking.
+	lastValue *histogram.FloatHistogram
 }
 
 func (a *FloatHistogramAppender) GetCounterResetHeader() CounterResetHeader {
 	return CounterResetHeader(a.b.bytes()[histogramFlagPos] & CounterResetHeaderMask)
+}
+
+// LastFloatHistogram returns the most recently appended float histogram, or nil
+// if none has been appended yet.
+func (a *FloatHistogramAppender) LastFloatHistogram() *histogram.FloatHistogram {
+	return a.lastValue
+}
+
+// SetLastFloatHistogram sets the last float histogram value. Used to restore
+// state after loading the appender from a snapshot.
+func (a *FloatHistogramAppender) SetLastFloatHistogram(fh *histogram.FloatHistogram) {
+	a.lastValue = fh
 }
 
 func (a *FloatHistogramAppender) setCounterResetHeader(cr CounterResetHeader) {
@@ -606,6 +622,7 @@ func (a *FloatHistogramAppender) appendFloatHistogram(t int64, h *histogram.Floa
 
 	a.t = t
 	a.tDelta = tDelta
+	a.lastValue = h
 }
 
 func (a *FloatHistogramAppender) writeXorValue(old *xorValue, v float64) {

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -201,6 +201,14 @@ func (a *FloatHistogramAppender) SetLastFloatHistogram(fh *histogram.FloatHistog
 	a.lastValue = fh
 }
 
+func (a *FloatHistogramAppender) IsStaleLastValue() bool {
+	return a.lastValue != nil && value.IsStaleNaN(a.lastValue.Sum)
+}
+
+func (a *FloatHistogramAppender) IsEqual(_ float64, _ *histogram.Histogram, fh *histogram.FloatHistogram) bool {
+	return fh != nil && fh.Equals(a.lastValue)
+}
+
 func (a *FloatHistogramAppender) setCounterResetHeader(cr CounterResetHeader) {
 	a.b.bytes()[histogramFlagPos] = (a.b.bytes()[histogramFlagPos] & (^CounterResetHeaderMask)) | (byte(cr) & CounterResetHeaderMask)
 }

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -201,12 +201,8 @@ func (a *FloatHistogramAppender) SetLastFloatHistogram(fh *histogram.FloatHistog
 	a.lastValue = fh
 }
 
-func (a *FloatHistogramAppender) IsStaleLastValue() bool {
-	return a.lastValue != nil && value.IsStaleNaN(a.lastValue.Sum)
-}
-
-func (a *FloatHistogramAppender) IsEqual(_ float64, _ *histogram.Histogram, fh *histogram.FloatHistogram) bool {
-	return fh != nil && fh.Equals(a.lastValue)
+func (a *FloatHistogramAppender) LastValue() (float64, *histogram.Histogram, *histogram.FloatHistogram) {
+	return 0, nil, a.lastValue
 }
 
 func (a *FloatHistogramAppender) setCounterResetHeader(cr CounterResetHeader) {

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -203,10 +203,26 @@ type HistogramAppender struct {
 	sum      float64
 	leading  uint8
 	trailing uint8
+
+	// lastValue is the most recently appended histogram, retained for
+	// duplicate detection and stale-marker tracking.
+	lastValue *histogram.Histogram
 }
 
 func (a *HistogramAppender) GetCounterResetHeader() CounterResetHeader {
 	return CounterResetHeader(a.b.bytes()[histogramFlagPos] & CounterResetHeaderMask)
+}
+
+// LastHistogram returns the most recently appended histogram, or nil if none
+// has been appended yet.
+func (a *HistogramAppender) LastHistogram() *histogram.Histogram {
+	return a.lastValue
+}
+
+// SetLastHistogram sets the last histogram value. Used to restore state after
+// loading the appender from a snapshot.
+func (a *HistogramAppender) SetLastHistogram(h *histogram.Histogram) {
+	a.lastValue = h
 }
 
 func (a *HistogramAppender) setCounterResetHeader(cr CounterResetHeader) {
@@ -659,6 +675,7 @@ func (a *HistogramAppender) appendHistogram(t int64, h *histogram.Histogram) {
 	copy(a.nBuckets, h.NegativeBuckets)
 	// Note that the bucket deltas were already updated above.
 	a.sum = h.Sum
+	a.lastValue = h
 }
 
 // recode converts the current chunk to accommodate an expansion of the set of

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -225,6 +225,14 @@ func (a *HistogramAppender) SetLastHistogram(h *histogram.Histogram) {
 	a.lastValue = h
 }
 
+func (a *HistogramAppender) IsStaleLastValue() bool {
+	return a.lastValue != nil && value.IsStaleNaN(a.lastValue.Sum)
+}
+
+func (a *HistogramAppender) IsEqual(_ float64, h *histogram.Histogram, _ *histogram.FloatHistogram) bool {
+	return h != nil && h.Equals(a.lastValue)
+}
+
 func (a *HistogramAppender) setCounterResetHeader(cr CounterResetHeader) {
 	a.b.bytes()[histogramFlagPos] = (a.b.bytes()[histogramFlagPos] & (^CounterResetHeaderMask)) | (byte(cr) & CounterResetHeaderMask)
 }

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -225,12 +225,8 @@ func (a *HistogramAppender) SetLastHistogram(h *histogram.Histogram) {
 	a.lastValue = h
 }
 
-func (a *HistogramAppender) IsStaleLastValue() bool {
-	return a.lastValue != nil && value.IsStaleNaN(a.lastValue.Sum)
-}
-
-func (a *HistogramAppender) IsEqual(_ float64, h *histogram.Histogram, _ *histogram.FloatHistogram) bool {
-	return h != nil && h.Equals(a.lastValue)
+func (a *HistogramAppender) LastValue() (float64, *histogram.Histogram, *histogram.FloatHistogram) {
+	return 0, a.lastValue, nil
 }
 
 func (a *HistogramAppender) setCounterResetHeader(cr CounterResetHeader) {

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -49,6 +49,7 @@ import (
 	"math/bits"
 
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/value"
 )
 
 const (
@@ -231,6 +232,14 @@ func (*xorAppender) AppendHistogram(*HistogramAppender, int64, int64, *histogram
 
 func (*xorAppender) AppendFloatHistogram(*FloatHistogramAppender, int64, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a float histogram sample to a float chunk")
+}
+
+func (a *xorAppender) IsStaleLastValue() bool {
+	return value.IsStaleNaN(a.v)
+}
+
+func (a *xorAppender) IsEqual(v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool {
+	return h == nil && fh == nil && math.Float64bits(a.v) == math.Float64bits(v)
 }
 
 type xorIterator struct {

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -49,7 +49,6 @@ import (
 	"math/bits"
 
 	"github.com/prometheus/prometheus/model/histogram"
-	"github.com/prometheus/prometheus/model/value"
 )
 
 const (
@@ -234,12 +233,8 @@ func (*xorAppender) AppendFloatHistogram(*FloatHistogramAppender, int64, int64, 
 	panic("appended a float histogram sample to a float chunk")
 }
 
-func (a *xorAppender) IsStaleLastValue() bool {
-	return value.IsStaleNaN(a.v)
-}
-
-func (a *xorAppender) IsEqual(v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool {
-	return h == nil && fh == nil && math.Float64bits(a.v) == math.Float64bits(v)
+func (a *xorAppender) LastValue() (float64, *histogram.Histogram, *histogram.FloatHistogram) {
+	return a.v, nil, nil
 }
 
 type xorIterator struct {

--- a/tsdb/chunkenc/xor2.go
+++ b/tsdb/chunkenc/xor2.go
@@ -508,6 +508,14 @@ func (*xor2Appender) AppendFloatHistogram(*FloatHistogramAppender, int64, int64,
 	panic("appended a float histogram sample to a float chunk")
 }
 
+func (a *xor2Appender) IsStaleLastValue() bool {
+	return value.IsStaleNaN(a.v)
+}
+
+func (a *xor2Appender) IsEqual(v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool {
+	return h == nil && fh == nil && math.Float64bits(a.v) == math.Float64bits(v)
+}
+
 // xor2Iterator decodes XOR2 chunks.
 type xor2Iterator struct {
 	br       bstreamReader

--- a/tsdb/chunkenc/xor2.go
+++ b/tsdb/chunkenc/xor2.go
@@ -508,12 +508,8 @@ func (*xor2Appender) AppendFloatHistogram(*FloatHistogramAppender, int64, int64,
 	panic("appended a float histogram sample to a float chunk")
 }
 
-func (a *xor2Appender) IsStaleLastValue() bool {
-	return value.IsStaleNaN(a.v)
-}
-
-func (a *xor2Appender) IsEqual(v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) bool {
-	return h == nil && fh == nil && math.Float64bits(a.v) == math.Float64bits(v)
+func (a *xor2Appender) LastValue() (float64, *histogram.Histogram, *histogram.FloatHistogram) {
+	return a.v, nil, nil
 }
 
 // xor2Iterator decodes XOR2 chunks.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2141,9 +2141,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 			defer s.locks[refShard].Unlock()
 		}
 
-		if value.IsStaleNaN(series.lastValue) ||
-			(series.lastHistogramValue != nil && value.IsStaleNaN(series.lastHistogramValue.Sum)) ||
-			(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
+		if value.IsStaleNaN(series.lastValue) || series.isHistogramStale() {
 			staleSeriesDeleted++
 		}
 
@@ -2232,9 +2230,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		h.series.hashes[hashShard].del(hash, series.ref)
 		h.series.locks[hashShard].Unlock()
 
-		if value.IsStaleNaN(series.lastValue) ||
-			(series.lastHistogramValue != nil && value.IsStaleNaN(series.lastHistogramValue.Sum)) ||
-			(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
+		if value.IsStaleNaN(series.lastValue) || series.isHistogramStale() {
 			staleSeriesDeleted++
 		}
 
@@ -2292,9 +2288,7 @@ func (s *stripeSeries) gcStaleSeries(seriesRefs []storage.SeriesRef, maxt int64)
 		}
 
 		// Check if the series is still stale.
-		isStale := value.IsStaleNaN(series.lastValue) ||
-			(series.lastHistogramValue != nil && value.IsStaleNaN(series.lastHistogramValue.Sum)) ||
-			(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum))
+		isStale := value.IsStaleNaN(series.lastValue) || series.isHistogramStale()
 
 		if !isStale {
 			return
@@ -2484,10 +2478,6 @@ type memSeries struct {
 	// We keep the last value here (in addition to appending it to the chunk) so we can check for duplicates.
 	lastValue float64
 
-	// We keep the last histogram value here (in addition to appending it to the chunk) so we can check for duplicates.
-	lastHistogramValue      *histogram.Histogram
-	lastFloatHistogramValue *histogram.FloatHistogram
-
 	// Current appender for the head chunk. Set when a new head chunk is cut.
 	// It is nil only if headChunks is nil. E.g. if there was an appender that created a new series, but rolled back the commit
 	// (the first sample would create a headChunk, hence appender, but rollback skipped it while the Append() call would create a series).
@@ -2495,6 +2485,18 @@ type memSeries struct {
 
 	// txs is nil if isolation is disabled.
 	txs *txRing
+}
+
+// isHistogramStale reports whether the most recently appended histogram or float
+// histogram sample is a stale marker. The series lock must be held.
+func (s *memSeries) isHistogramStale() bool {
+	if app, ok := s.app.(*chunkenc.HistogramAppender); ok && app.LastHistogram() != nil {
+		return value.IsStaleNaN(app.LastHistogram().Sum)
+	}
+	if app, ok := s.app.(*chunkenc.FloatHistogramAppender); ok && app.LastFloatHistogram() != nil {
+		return value.IsStaleNaN(app.LastFloatHistogram().Sum)
+	}
+	return false
 }
 
 // memSeriesOOOFields contains the fields required by memSeries

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -37,6 +37,7 @@ import (
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -2474,9 +2475,6 @@ type memSeries struct {
 	histogramChunkHasComputedEndTime bool  // True if nextAt has been predicted for the current histograms chunk; false otherwise.
 	pendingCommit                    bool  // Whether there are samples waiting to be committed to this series.
 
-	// We keep the last value here (in addition to appending it to the chunk) so we can check for duplicates.
-	lastValue float64
-
 	// Current appender for the head chunk. Set when a new head chunk is cut.
 	// It is nil only if headChunks is nil. E.g. if there was an appender that created a new series, but rolled back the commit
 	// (the first sample would create a headChunk, hence appender, but rollback skipped it while the Append() call would create a series).
@@ -2489,7 +2487,11 @@ type memSeries struct {
 // isStaleLastValue reports whether the most recently appended sample (of any
 // type) is a stale marker. The series lock must be held.
 func (s *memSeries) isStaleLastValue() bool {
-	return s.app != nil && s.app.IsStaleLastValue()
+	if s.app == nil {
+		return false
+	}
+	v, h, fh := s.app.LastValue()
+	return value.IsStaleNaN(v) || (h != nil && value.IsStaleNaN(h.Sum)) || (fh != nil && value.IsStaleNaN(fh.Sum))
 }
 
 // memSeriesOOOFields contains the fields required by memSeries

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -37,7 +37,6 @@ import (
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
-	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -2141,7 +2140,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 			defer s.locks[refShard].Unlock()
 		}
 
-		if value.IsStaleNaN(series.lastValue) || series.isHistogramStale() {
+		if series.isStaleLastValue() {
 			staleSeriesDeleted++
 		}
 
@@ -2230,7 +2229,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		h.series.hashes[hashShard].del(hash, series.ref)
 		h.series.locks[hashShard].Unlock()
 
-		if value.IsStaleNaN(series.lastValue) || series.isHistogramStale() {
+		if series.isStaleLastValue() {
 			staleSeriesDeleted++
 		}
 
@@ -2288,7 +2287,7 @@ func (s *stripeSeries) gcStaleSeries(seriesRefs []storage.SeriesRef, maxt int64)
 		}
 
 		// Check if the series is still stale.
-		isStale := value.IsStaleNaN(series.lastValue) || series.isHistogramStale()
+		isStale := series.isStaleLastValue()
 
 		if !isStale {
 			return
@@ -2487,16 +2486,10 @@ type memSeries struct {
 	txs *txRing
 }
 
-// isHistogramStale reports whether the most recently appended histogram or float
-// histogram sample is a stale marker. The series lock must be held.
-func (s *memSeries) isHistogramStale() bool {
-	if app, ok := s.app.(*chunkenc.HistogramAppender); ok && app.LastHistogram() != nil {
-		return value.IsStaleNaN(app.LastHistogram().Sum)
-	}
-	if app, ok := s.app.(*chunkenc.FloatHistogramAppender); ok && app.LastFloatHistogram() != nil {
-		return value.IsStaleNaN(app.LastFloatHistogram().Sum)
-	}
-	return false
+// isStaleLastValue reports whether the most recently appended sample (of any
+// type) is a stale marker. The series lock must be held.
+func (s *memSeries) isStaleLastValue() bool {
+	return s.app != nil && s.app.IsStaleLastValue()
 }
 
 // memSeriesOOOFields contains the fields required by memSeries

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -660,7 +660,8 @@ func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime, oooTi
 			// like federation and erroring out at that time would be extremely noisy.
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
-			if s.lastHistogramValue != nil || s.lastFloatHistogramValue != nil {
+			switch s.app.(type) {
+			case *chunkenc.HistogramAppender, *chunkenc.FloatHistogramAppender:
 				return false, 0, storage.NewDuplicateHistogramToFloatErr(t, v)
 			}
 			if math.Float64bits(s.lastValue) != math.Float64bits(v) {
@@ -705,7 +706,8 @@ func (s *memSeries) appendableHistogram(t int64, h *histogram.Histogram, headMax
 			// like federation and erroring out at that time would be extremely noisy.
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
-			if !h.Equals(s.lastHistogramValue) {
+			app, ok := s.app.(*chunkenc.HistogramAppender)
+			if !ok || !h.Equals(app.LastHistogram()) {
 				return false, 0, storage.ErrDuplicateSampleForTimestamp
 			}
 			// Sample is identical (ts + value) with most current (highest ts) sample in sampleBuf.
@@ -747,7 +749,8 @@ func (s *memSeries) appendableFloatHistogram(t int64, fh *histogram.FloatHistogr
 			// like federation and erroring out at that time would be extremely noisy.
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
-			if !fh.Equals(s.lastFloatHistogramValue) {
+			app, ok := s.app.(*chunkenc.FloatHistogramAppender)
+			if !ok || !fh.Equals(app.LastFloatHistogram()) {
 				return false, 0, storage.ErrDuplicateSampleForTimestamp
 			}
 			// Sample is identical (ts + value) with most current (highest ts) sample in sampleBuf.
@@ -1352,8 +1355,8 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			// sample for this same series in this same batch
 			// (because any such sample would have triggered a new
 			// batch).
-			switch {
-			case series.lastHistogramValue != nil:
+			switch series.app.(type) {
+			case *chunkenc.HistogramAppender:
 				b.histograms = append(b.histograms, record.RefHistogramSample{
 					Ref: series.ref,
 					T:   s.T,
@@ -1365,7 +1368,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 				acc.histogramsAppended++
 				series.Unlock()
 				continue
-			case series.lastFloatHistogramValue != nil:
+			case *chunkenc.FloatHistogramAppender:
 				b.floatHistograms = append(b.floatHistograms, record.RefFloatHistogramSample{
 					Ref: series.ref,
 					T:   s.T,
@@ -1541,9 +1544,10 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 		default:
 			newlyStale := value.IsStaleNaN(s.H.Sum)
 			staleToNonStale := false
-			if series.lastHistogramValue != nil {
-				newlyStale = newlyStale && !value.IsStaleNaN(series.lastHistogramValue.Sum)
-				staleToNonStale = value.IsStaleNaN(series.lastHistogramValue.Sum) && !value.IsStaleNaN(s.H.Sum)
+			if app, ok2 := series.app.(*chunkenc.HistogramAppender); ok2 && app.LastHistogram() != nil {
+				prevSum := app.LastHistogram().Sum
+				newlyStale = newlyStale && !value.IsStaleNaN(prevSum)
+				staleToNonStale = value.IsStaleNaN(prevSum) && !value.IsStaleNaN(s.H.Sum)
 			}
 			// TODO(krajorama,ywwg): pass ST when available in WAL.
 			ok, chunkCreated = series.appendHistogram(0, s.T, s.H, a.appendID, acc.appendChunkOpts)
@@ -1652,9 +1656,10 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 		default:
 			newlyStale := value.IsStaleNaN(s.FH.Sum)
 			staleToNonStale := false
-			if series.lastFloatHistogramValue != nil {
-				newlyStale = newlyStale && !value.IsStaleNaN(series.lastFloatHistogramValue.Sum)
-				staleToNonStale = value.IsStaleNaN(series.lastFloatHistogramValue.Sum) && !value.IsStaleNaN(s.FH.Sum)
+			if app, ok2 := series.app.(*chunkenc.FloatHistogramAppender); ok2 && app.LastFloatHistogram() != nil {
+				prevSum := app.LastFloatHistogram().Sum
+				newlyStale = newlyStale && !value.IsStaleNaN(prevSum)
+				staleToNonStale = value.IsStaleNaN(prevSum) && !value.IsStaleNaN(s.FH.Sum)
 			}
 			// TODO(krajorama,ywwg): pass ST when available in WAL.
 			ok, chunkCreated = series.appendFloatHistogram(0, s.T, s.FH, a.appendID, acc.appendChunkOpts)
@@ -1853,8 +1858,6 @@ func (s *memSeries) append(st, t int64, v float64, appendID uint64, o chunkOpts)
 	c.maxTime = t
 
 	s.lastValue = v
-	s.lastHistogramValue = nil
-	s.lastFloatHistogramValue = nil
 
 	if appendID > 0 {
 		s.txs.add(appendID)
@@ -1891,9 +1894,6 @@ func (s *memSeries) appendHistogram(st, t int64, h *histogram.Histogram, appendI
 	}
 
 	newChunk, recoded, s.app, _ = s.app.AppendHistogram(prevApp, st, t, h, false) // false=request a new chunk if needed
-
-	s.lastHistogramValue = h
-	s.lastFloatHistogramValue = nil
 
 	if appendID > 0 {
 		s.txs.add(appendID)
@@ -1948,9 +1948,6 @@ func (s *memSeries) appendFloatHistogram(st, t int64, fh *histogram.FloatHistogr
 	}
 
 	newChunk, recoded, s.app, _ = s.app.AppendFloatHistogram(prevApp, st, t, fh, false) // False means request a new chunk if needed.
-
-	s.lastHistogramValue = nil
-	s.lastFloatHistogramValue = fh
 
 	if appendID > 0 {
 		s.txs.add(appendID)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -660,15 +660,15 @@ func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime, oooTi
 			// like federation and erroring out at that time would be extremely noisy.
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
+			if s.app.IsEqual(v, nil, nil) {
+				// Sample is identical (ts + value) with most current (highest ts) sample in sampleBuf.
+				return false, 0, nil
+			}
 			switch s.app.(type) {
 			case *chunkenc.HistogramAppender, *chunkenc.FloatHistogramAppender:
 				return false, 0, storage.NewDuplicateHistogramToFloatErr(t, v)
 			}
-			if math.Float64bits(s.lastValue) != math.Float64bits(v) {
-				return false, 0, storage.NewDuplicateFloatErr(t, s.lastValue, v)
-			}
-			// Sample is identical (ts + value) with most current (highest ts) sample in sampleBuf.
-			return false, 0, nil
+			return false, 0, storage.NewDuplicateFloatErr(t, s.lastValue, v)
 		}
 	}
 
@@ -706,8 +706,7 @@ func (s *memSeries) appendableHistogram(t int64, h *histogram.Histogram, headMax
 			// like federation and erroring out at that time would be extremely noisy.
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
-			app, ok := s.app.(*chunkenc.HistogramAppender)
-			if !ok || !h.Equals(app.LastHistogram()) {
+			if !s.app.IsEqual(0, h, nil) {
 				return false, 0, storage.ErrDuplicateSampleForTimestamp
 			}
 			// Sample is identical (ts + value) with most current (highest ts) sample in sampleBuf.
@@ -749,8 +748,7 @@ func (s *memSeries) appendableFloatHistogram(t int64, fh *histogram.FloatHistogr
 			// like federation and erroring out at that time would be extremely noisy.
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
-			app, ok := s.app.(*chunkenc.FloatHistogramAppender)
-			if !ok || !fh.Equals(app.LastFloatHistogram()) {
+			if !s.app.IsEqual(0, nil, fh) {
 				return false, 0, storage.ErrDuplicateSampleForTimestamp
 			}
 			// Sample is identical (ts + value) with most current (highest ts) sample in sampleBuf.
@@ -1436,8 +1434,9 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 				acc.floatsAppended--
 			}
 		default:
-			newlyStale := !value.IsStaleNaN(series.lastValue) && value.IsStaleNaN(s.V)
-			staleToNonStale := value.IsStaleNaN(series.lastValue) && !value.IsStaleNaN(s.V)
+			isLastStale := series.isStaleLastValue()
+			newlyStale := !isLastStale && value.IsStaleNaN(s.V)
+			staleToNonStale := isLastStale && !value.IsStaleNaN(s.V)
 			ok, chunkCreated = series.append(s.ST, s.T, s.V, a.appendID, acc.appendChunkOpts)
 			if ok {
 				if s.T < acc.inOrderMint {
@@ -1544,10 +1543,10 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 		default:
 			newlyStale := value.IsStaleNaN(s.H.Sum)
 			staleToNonStale := false
-			if app, ok2 := series.app.(*chunkenc.HistogramAppender); ok2 && app.LastHistogram() != nil {
-				prevSum := app.LastHistogram().Sum
-				newlyStale = newlyStale && !value.IsStaleNaN(prevSum)
-				staleToNonStale = value.IsStaleNaN(prevSum) && !value.IsStaleNaN(s.H.Sum)
+			if _, ok2 := series.app.(*chunkenc.HistogramAppender); ok2 {
+				isLastStale := series.app.IsStaleLastValue()
+				newlyStale = newlyStale && !isLastStale
+				staleToNonStale = isLastStale && !value.IsStaleNaN(s.H.Sum)
 			}
 			// TODO(krajorama,ywwg): pass ST when available in WAL.
 			ok, chunkCreated = series.appendHistogram(0, s.T, s.H, a.appendID, acc.appendChunkOpts)
@@ -1656,10 +1655,10 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 		default:
 			newlyStale := value.IsStaleNaN(s.FH.Sum)
 			staleToNonStale := false
-			if app, ok2 := series.app.(*chunkenc.FloatHistogramAppender); ok2 && app.LastFloatHistogram() != nil {
-				prevSum := app.LastFloatHistogram().Sum
-				newlyStale = newlyStale && !value.IsStaleNaN(prevSum)
-				staleToNonStale = value.IsStaleNaN(prevSum) && !value.IsStaleNaN(s.FH.Sum)
+			if _, ok2 := series.app.(*chunkenc.FloatHistogramAppender); ok2 {
+				isLastStale := series.app.IsStaleLastValue()
+				newlyStale = newlyStale && !isLastStale
+				staleToNonStale = isLastStale && !value.IsStaleNaN(s.FH.Sum)
 			}
 			// TODO(krajorama,ywwg): pass ST when available in WAL.
 			ok, chunkCreated = series.appendFloatHistogram(0, s.T, s.FH, a.appendID, acc.appendChunkOpts)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -660,15 +660,15 @@ func (s *memSeries) appendable(t int64, v float64, headMaxt, minValidTime, oooTi
 			// like federation and erroring out at that time would be extremely noisy.
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
-			if s.app.IsEqual(v, nil, nil) {
+			prevV, prevH, prevFH := s.app.LastValue()
+			if prevH == nil && prevFH == nil && math.Float64bits(prevV) == math.Float64bits(v) {
 				// Sample is identical (ts + value) with most current (highest ts) sample in sampleBuf.
 				return false, 0, nil
 			}
-			switch s.app.(type) {
-			case *chunkenc.HistogramAppender, *chunkenc.FloatHistogramAppender:
+			if prevH != nil || prevFH != nil {
 				return false, 0, storage.NewDuplicateHistogramToFloatErr(t, v)
 			}
-			return false, 0, storage.NewDuplicateFloatErr(t, s.lastValue, v)
+			return false, 0, storage.NewDuplicateFloatErr(t, prevV, v)
 		}
 	}
 
@@ -706,7 +706,8 @@ func (s *memSeries) appendableHistogram(t int64, h *histogram.Histogram, headMax
 			// like federation and erroring out at that time would be extremely noisy.
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
-			if !s.app.IsEqual(0, h, nil) {
+			_, prevH, _ := s.app.LastValue()
+			if !h.Equals(prevH) {
 				return false, 0, storage.ErrDuplicateSampleForTimestamp
 			}
 			// Sample is identical (ts + value) with most current (highest ts) sample in sampleBuf.
@@ -748,7 +749,8 @@ func (s *memSeries) appendableFloatHistogram(t int64, fh *histogram.FloatHistogr
 			// like federation and erroring out at that time would be extremely noisy.
 			// This only checks against the latest in-order sample.
 			// The OOO headchunk has its own method to detect these duplicates.
-			if !s.app.IsEqual(0, nil, fh) {
+			_, _, prevFH := s.app.LastValue()
+			if !fh.Equals(prevFH) {
 				return false, 0, storage.ErrDuplicateSampleForTimestamp
 			}
 			// Sample is identical (ts + value) with most current (highest ts) sample in sampleBuf.
@@ -1543,10 +1545,12 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 		default:
 			newlyStale := value.IsStaleNaN(s.H.Sum)
 			staleToNonStale := false
-			if _, ok2 := series.app.(*chunkenc.HistogramAppender); ok2 {
-				isLastStale := series.app.IsStaleLastValue()
-				newlyStale = newlyStale && !isLastStale
-				staleToNonStale = isLastStale && !value.IsStaleNaN(s.H.Sum)
+			if series.app != nil {
+				if _, prevH, _ := series.app.LastValue(); prevH != nil {
+					isLastStale := value.IsStaleNaN(prevH.Sum)
+					newlyStale = newlyStale && !isLastStale
+					staleToNonStale = isLastStale && !value.IsStaleNaN(s.H.Sum)
+				}
 			}
 			// TODO(krajorama,ywwg): pass ST when available in WAL.
 			ok, chunkCreated = series.appendHistogram(0, s.T, s.H, a.appendID, acc.appendChunkOpts)
@@ -1655,10 +1659,12 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 		default:
 			newlyStale := value.IsStaleNaN(s.FH.Sum)
 			staleToNonStale := false
-			if _, ok2 := series.app.(*chunkenc.FloatHistogramAppender); ok2 {
-				isLastStale := series.app.IsStaleLastValue()
-				newlyStale = newlyStale && !isLastStale
-				staleToNonStale = isLastStale && !value.IsStaleNaN(s.FH.Sum)
+			if series.app != nil {
+				if _, _, prevFH := series.app.LastValue(); prevFH != nil {
+					isLastStale := value.IsStaleNaN(prevFH.Sum)
+					newlyStale = newlyStale && !isLastStale
+					staleToNonStale = isLastStale && !value.IsStaleNaN(s.FH.Sum)
+				}
 			}
 			// TODO(krajorama,ywwg): pass ST when available in WAL.
 			ok, chunkCreated = series.appendFloatHistogram(0, s.T, s.FH, a.appendID, acc.appendChunkOpts)
@@ -1855,8 +1861,6 @@ func (s *memSeries) append(st, t int64, v float64, appendID uint64, o chunkOpts)
 	s.app.Append(st, t, v)
 
 	c.maxTime = t
-
-	s.lastValue = v
 
 	if appendID > 0 {
 		s.txs.add(appendID)

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -270,9 +270,7 @@ func (h *Head) filterStaleSeriesAndSortPostings(p index.Postings) ([]storage.Ser
 			continue
 		}
 
-		if value.IsStaleNaN(s.lastValue) ||
-			(s.lastHistogramValue != nil && value.IsStaleNaN(s.lastHistogramValue.Sum)) ||
-			(s.lastFloatHistogramValue != nil && value.IsStaleNaN(s.lastFloatHistogramValue.Sum)) {
+		if value.IsStaleNaN(s.lastValue) || s.isHistogramStale() {
 			series = append(series, s)
 		}
 		s.Unlock()

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -270,7 +269,7 @@ func (h *Head) filterStaleSeriesAndSortPostings(p index.Postings) ([]storage.Ser
 			continue
 		}
 
-		if value.IsStaleNaN(s.lastValue) || s.isHistogramStale() {
+		if s.isStaleLastValue() {
 			series = append(series, s)
 		}
 		s.Unlock()

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -711,17 +711,19 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			var chunkCreated, newlyStale, staleToNonStale bool
 			if s.h != nil {
 				newlyStale = value.IsStaleNaN(s.h.Sum)
-				if ms.lastHistogramValue != nil {
-					newlyStale = newlyStale && !value.IsStaleNaN(ms.lastHistogramValue.Sum)
-					staleToNonStale = value.IsStaleNaN(ms.lastHistogramValue.Sum) && !value.IsStaleNaN(s.h.Sum)
+				if app, ok := ms.app.(*chunkenc.HistogramAppender); ok && app.LastHistogram() != nil {
+					prevSum := app.LastHistogram().Sum
+					newlyStale = newlyStale && !value.IsStaleNaN(prevSum)
+					staleToNonStale = value.IsStaleNaN(prevSum) && !value.IsStaleNaN(s.h.Sum)
 				}
 				// TODO(krajorama,ywwg): Pass ST when available in WBL.
 				_, chunkCreated = ms.appendHistogram(0, s.t, s.h, 0, appendChunkOpts)
 			} else {
 				newlyStale = value.IsStaleNaN(s.fh.Sum)
-				if ms.lastFloatHistogramValue != nil {
-					newlyStale = newlyStale && !value.IsStaleNaN(ms.lastFloatHistogramValue.Sum)
-					staleToNonStale = value.IsStaleNaN(ms.lastFloatHistogramValue.Sum) && !value.IsStaleNaN(s.fh.Sum)
+				if app, ok := ms.app.(*chunkenc.FloatHistogramAppender); ok && app.LastFloatHistogram() != nil {
+					prevSum := app.LastFloatHistogram().Sum
+					newlyStale = newlyStale && !value.IsStaleNaN(prevSum)
+					staleToNonStale = value.IsStaleNaN(prevSum) && !value.IsStaleNaN(s.fh.Sum)
 				}
 				// TODO(krajorama,ywwg): Pass ST when available in WBL.
 				_, chunkCreated = ms.appendFloatHistogram(0, s.t, s.fh, 0, appendChunkOpts)
@@ -1221,9 +1223,17 @@ func (s *memSeries) encodeToSnapshotRecord(b []byte) []byte {
 			buf.PutBE64int64(0)
 			buf.PutBEFloat64(s.lastValue)
 		case chunkenc.EncHistogram:
-			record.EncodeHistogram(&buf, s.lastHistogramValue)
+			var lastH *histogram.Histogram
+			if app, ok := s.app.(*chunkenc.HistogramAppender); ok {
+				lastH = app.LastHistogram()
+			}
+			record.EncodeHistogram(&buf, lastH)
 		default: // chunkenc.FloatHistogram.
-			record.EncodeFloatHistogram(&buf, s.lastFloatHistogramValue)
+			var lastFH *histogram.FloatHistogram
+			if app, ok := s.app.(*chunkenc.FloatHistogramAppender); ok {
+				lastFH = app.LastFloatHistogram()
+			}
+			record.EncodeFloatHistogram(&buf, lastFH)
 		}
 	}
 	s.Unlock()
@@ -1661,14 +1671,6 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 				series.nextAt = csr.mc.maxTime // This will create a new chunk on append.
 				series.headChunks = csr.mc
 				series.lastValue = csr.lastValue
-				series.lastHistogramValue = csr.lastHistogramValue
-				series.lastFloatHistogramValue = csr.lastFloatHistogramValue
-
-				if value.IsStaleNaN(series.lastValue) ||
-					(series.lastHistogramValue != nil && value.IsStaleNaN(series.lastHistogramValue.Sum)) ||
-					(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
-					h.numStaleSeries.Inc()
-				}
 
 				app, err := series.headChunks.chunk.Appender()
 				if err != nil {
@@ -1676,6 +1678,22 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 					return
 				}
 				series.app = app
+
+				// Restore the last histogram pointer so that duplicate detection
+				// and stale-marker tracking work after snapshot load.
+				if csr.lastHistogramValue != nil {
+					if histApp, ok := app.(*chunkenc.HistogramAppender); ok {
+						histApp.SetLastHistogram(csr.lastHistogramValue)
+					}
+				} else if csr.lastFloatHistogramValue != nil {
+					if fhApp, ok := app.(*chunkenc.FloatHistogramAppender); ok {
+						fhApp.SetLastFloatHistogram(csr.lastFloatHistogramValue)
+					}
+				}
+
+				if value.IsStaleNaN(series.lastValue) || series.isHistogramStale() {
+					h.numStaleSeries.Inc()
+				}
 
 				h.updateMinMaxTime(csr.mc.minTime, csr.mc.maxTime)
 			}

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -712,19 +712,23 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			var chunkCreated, newlyStale, staleToNonStale bool
 			if s.h != nil {
 				newlyStale = value.IsStaleNaN(s.h.Sum)
-				if _, ok := ms.app.(*chunkenc.HistogramAppender); ok {
-					isLastStale := ms.app.IsStaleLastValue()
-					newlyStale = newlyStale && !isLastStale
-					staleToNonStale = isLastStale && !value.IsStaleNaN(s.h.Sum)
+				if ms.app != nil {
+					if _, prevH, _ := ms.app.LastValue(); prevH != nil {
+						isLastStale := value.IsStaleNaN(prevH.Sum)
+						newlyStale = newlyStale && !isLastStale
+						staleToNonStale = isLastStale && !value.IsStaleNaN(s.h.Sum)
+					}
 				}
 				// TODO(krajorama,ywwg): Pass ST when available in WBL.
 				_, chunkCreated = ms.appendHistogram(0, s.t, s.h, 0, appendChunkOpts)
 			} else {
 				newlyStale = value.IsStaleNaN(s.fh.Sum)
-				if _, ok := ms.app.(*chunkenc.FloatHistogramAppender); ok {
-					isLastStale := ms.app.IsStaleLastValue()
-					newlyStale = newlyStale && !isLastStale
-					staleToNonStale = isLastStale && !value.IsStaleNaN(s.fh.Sum)
+				if ms.app != nil {
+					if _, _, prevFH := ms.app.LastValue(); prevFH != nil {
+						isLastStale := value.IsStaleNaN(prevFH.Sum)
+						newlyStale = newlyStale && !isLastStale
+						staleToNonStale = isLastStale && !value.IsStaleNaN(s.fh.Sum)
+					}
 				}
 				// TODO(krajorama,ywwg): Pass ST when available in WBL.
 				_, chunkCreated = ms.appendFloatHistogram(0, s.t, s.fh, 0, appendChunkOpts)
@@ -1222,18 +1226,13 @@ func (s *memSeries) encodeToSnapshotRecord(b []byte) []byte {
 				buf.PutBEFloat64(0)
 			}
 			buf.PutBE64int64(0)
-			buf.PutBEFloat64(s.lastValue)
+			lastV, _, _ := s.app.LastValue()
+			buf.PutBEFloat64(lastV)
 		case chunkenc.EncHistogram:
-			var lastH *histogram.Histogram
-			if app, ok := s.app.(*chunkenc.HistogramAppender); ok {
-				lastH = app.LastHistogram()
-			}
+			_, lastH, _ := s.app.LastValue()
 			record.EncodeHistogram(&buf, lastH)
 		default: // chunkenc.FloatHistogram.
-			var lastFH *histogram.FloatHistogram
-			if app, ok := s.app.(*chunkenc.FloatHistogramAppender); ok {
-				lastFH = app.LastFloatHistogram()
-			}
+			_, _, lastFH := s.app.LastValue()
 			record.EncodeFloatHistogram(&buf, lastFH)
 		}
 	}
@@ -1671,7 +1670,6 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 				}
 				series.nextAt = csr.mc.maxTime // This will create a new chunk on append.
 				series.headChunks = csr.mc
-				series.lastValue = csr.lastValue
 
 				app, err := series.headChunks.chunk.Appender()
 				if err != nil {

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -671,10 +671,11 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				continue
 			}
 
-			if !value.IsStaleNaN(ms.lastValue) && value.IsStaleNaN(s.V) {
+			isLastStale := ms.isStaleLastValue()
+			if !isLastStale && value.IsStaleNaN(s.V) {
 				h.numStaleSeries.Inc()
 			}
-			if value.IsStaleNaN(ms.lastValue) && !value.IsStaleNaN(s.V) {
+			if isLastStale && !value.IsStaleNaN(s.V) {
 				h.numStaleSeries.Dec()
 			}
 
@@ -711,19 +712,19 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			var chunkCreated, newlyStale, staleToNonStale bool
 			if s.h != nil {
 				newlyStale = value.IsStaleNaN(s.h.Sum)
-				if app, ok := ms.app.(*chunkenc.HistogramAppender); ok && app.LastHistogram() != nil {
-					prevSum := app.LastHistogram().Sum
-					newlyStale = newlyStale && !value.IsStaleNaN(prevSum)
-					staleToNonStale = value.IsStaleNaN(prevSum) && !value.IsStaleNaN(s.h.Sum)
+				if _, ok := ms.app.(*chunkenc.HistogramAppender); ok {
+					isLastStale := ms.app.IsStaleLastValue()
+					newlyStale = newlyStale && !isLastStale
+					staleToNonStale = isLastStale && !value.IsStaleNaN(s.h.Sum)
 				}
 				// TODO(krajorama,ywwg): Pass ST when available in WBL.
 				_, chunkCreated = ms.appendHistogram(0, s.t, s.h, 0, appendChunkOpts)
 			} else {
 				newlyStale = value.IsStaleNaN(s.fh.Sum)
-				if app, ok := ms.app.(*chunkenc.FloatHistogramAppender); ok && app.LastFloatHistogram() != nil {
-					prevSum := app.LastFloatHistogram().Sum
-					newlyStale = newlyStale && !value.IsStaleNaN(prevSum)
-					staleToNonStale = value.IsStaleNaN(prevSum) && !value.IsStaleNaN(s.fh.Sum)
+				if _, ok := ms.app.(*chunkenc.FloatHistogramAppender); ok {
+					isLastStale := ms.app.IsStaleLastValue()
+					newlyStale = newlyStale && !isLastStale
+					staleToNonStale = isLastStale && !value.IsStaleNaN(s.fh.Sum)
 				}
 				// TODO(krajorama,ywwg): Pass ST when available in WBL.
 				_, chunkCreated = ms.appendFloatHistogram(0, s.t, s.fh, 0, appendChunkOpts)
@@ -1691,7 +1692,7 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 					}
 				}
 
-				if value.IsStaleNaN(series.lastValue) || series.isHistogramStale() {
+				if series.isStaleLastValue() {
 					h.numStaleSeries.Inc()
 				}
 


### PR DESCRIPTION
## Summary

- Remove `lastHistogramValue *histogram.Histogram` and `lastFloatHistogramValue *histogram.FloatHistogram` from `memSeries`, reducing its size by two pointer fields (16 bytes on 64-bit).
- Add `lastValue` to `HistogramAppender` and `FloatHistogramAppender` (set on every `appendHistogram`/`appendFloatHistogram` call), with `LastHistogram()`/`SetLastHistogram()` and `LastFloatHistogram()`/`SetLastFloatHistogram()` accessors.
- All call sites updated to type-assert on `series.app`; a new `isHistogramStale()` helper on `memSeries` de-duplicates the four stale-check locations.
- The `chunkSnapshotRecord` WAL format is unchanged; snapshot load now restores appender state via the new setters.

```release-notes
[PERF] tsdb: reduce memSeries size by moving histogram last-value pointers into the chunk appenders.
```

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>
Coded with Claude Sonnet 4.6.