### PR TITLE
util/strutil: Fix duplicate isASCII declaration

### DIFF
--- a/util/strutil/jarowinkler.go
+++ b/util/strutil/jarowinkler.go
@@ -52,16 +52,6 @@ func (m *JaroWinklerMatcher) Score(s string) float64 {
 	return jaroWinklerRunes(m.termRunes, []rune(s))
 }
 
-// isASCII reports whether s contains only ASCII characters.
-func isASCII(s string) bool {
-	for i := range len(s) {
-		if s[i] >= 0x80 {
-			return false
-		}
-	}
-	return true
-}
-
 // jaroWinklerString implements the Jaro-Winkler algorithm directly on ASCII
 // strings, avoiding any []rune conversion.
 func jaroWinklerString(s1, s2 string) float64 {


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:

PRs #18402 and #18405 both introduced the same `isASCII` function. `main` build is broken.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
