### PR TITLE
promql: fix smoothed rate returning zero for data only after range

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -142,6 +142,9 @@ func extendedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper, isC
 	if f[lastSampleIndex].T <= rangeStart {
 		return enh.Out, annos
 	}
+	if smoothed && f[firstSampleIndex].T > rangeEnd {
+		return enh.Out, annos
+	}
 
 	left := pickOrInterpolateLeft(f, firstSampleIndex, rangeStart, smoothed, isCounter)
 	right := pickOrInterpolateRight(f, lastSampleIndex, rangeEnd, smoothed, isCounter)

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -418,3 +418,19 @@ eval instant at 45s withreset smoothed
 
 eval instant at 30s notregular smoothed
     notregular 2
+
+# Smoothed rate returns empty when data is only before or only after the range.
+clear
+load 10s
+    metric _ 5+1x4
+
+eval instant at 5s rate(metric[5s] smoothed)
+
+eval instant at 5s increase(metric[5s] smoothed)
+
+eval instant at 15s increase(metric[10s] smoothed)
+    {} 0.5
+
+eval instant at 60s rate(metric[5s] smoothed)
+
+eval instant at 60s increase(metric[5s] smoothed)


### PR DESCRIPTION
For smoothed rate/increase, a result should only be returned when there is data available to interpolate across the range. If the range has a single data point only on one side, the result is meaningless and should be empty.

The "data only before" case was already handled: if the last fetched sample is at or before rangeStart, extendedRate returns nothing.

Add the symmetric guard for the "data only after" case: if the first fetched sample is strictly after rangeEnd, return nothing as well.

This mirrors the behaviour described in prometheus/prometheus#18295, where a smoothed rate that has no data before the range should not return zero.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] PromQL: Fix `smoothed` rate/increase returning zero instead of no result when all data falls strictly after the query range.
```
