### PR TITLE
tsdb: Make postings ctx aware in selectSeriesSet and selectChunkSeriesSet

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -128,10 +128,10 @@ func selectSeriesSet(ctx context.Context, sortSeries bool, hints *storage.Select
 		return storage.ErrSeriesSet(err)
 	}
 	if sharded {
-		p = index.ShardedPostings(p, hints.ShardIndex, hints.ShardCount)
+		p = index.ShardedPostings(&contextAwarePostings{ctx: ctx, p: p}, hints.ShardIndex, hints.ShardCount)
 	}
 	if sortSeries {
-		p = index.SortedPostings(p)
+		p = index.SortedPostings(&contextAwarePostings{ctx: ctx, p: p})
 	}
 
 	if hints != nil {
@@ -181,10 +181,10 @@ func selectChunkSeriesSet(ctx context.Context, sortSeries bool, hints *storage.S
 		return storage.ErrChunkSeriesSet(err)
 	}
 	if sharded {
-		p = index.ShardedPostings(p, hints.ShardIndex, hints.ShardCount)
+		p = index.ShardedPostings(&contextAwarePostings{ctx: ctx, p: p}, hints.ShardIndex, hints.ShardCount)
 	}
 	if sortSeries {
-		p = index.SortedPostings(p)
+		p = index.SortedPostings(&contextAwarePostings{ctx: ctx, p: p})
 	}
 	return NewBlockChunkSeriesSet(blockID, index, chunks, tombstones, p, mint, maxt, disableTrimming)
 }
@@ -1273,3 +1273,45 @@ func (cr nopChunkReader) ChunkOrIterable(chunks.Meta) (chunkenc.Chunk, chunkenc.
 }
 
 func (nopChunkReader) Close() error { return nil }
+
+// contextAwarePostings wraps a Postings iterator to check for context cancellation.
+type contextAwarePostings struct {
+	ctx context.Context
+	p   index.Postings
+	err error
+	i   int
+}
+
+func (c *contextAwarePostings) Next() bool {
+	if c.err != nil {
+		return false
+	}
+	c.i++
+	if c.i%checkContextEveryNIterations == 0 {
+		if err := c.ctx.Err(); err != nil {
+			c.err = err
+			return false
+		}
+	}
+	return c.p.Next()
+}
+
+func (c *contextAwarePostings) Seek(v storage.SeriesRef) bool {
+	if c.err != nil {
+		return false
+	}
+	if err := c.ctx.Err(); err != nil {
+		c.err = err
+		return false
+	}
+	return c.p.Seek(v)
+}
+
+func (c *contextAwarePostings) At() storage.SeriesRef { return c.p.At() }
+
+func (c *contextAwarePostings) Err() error {
+	if c.err != nil {
+		return c.err
+	}
+	return c.p.Err()
+}


### PR DESCRIPTION
This wraps the `ShardedPostings` implementation with context aware methods, that check for context cancel on every iteration to exit if the request has been already cancelled by the client. This will help stop heavy queries from running after the client request has already timed out.

I tested this in a fork. You can see below the before and after in CPU usage between a deploy using this version (red, blue) and one without it (green, yellow)

<img width="2912" height="770" alt="image" src="https://github.com/user-attachments/assets/97c6c1ae-9877-458a-9b4b-bd3964e15982" />

<img width="2912" height="770" alt="image" src="https://github.com/user-attachments/assets/3aad0664-2b0f-4733-aba6-669f922f3aa3" />

---

**NOTE**: Other methods like `LabelNames` in the `LabelQuerier` interface already had a context added, for example in [this PR](https://github.com/prometheus/prometheus/pull/12666). I'm using a wrapper here to keep the PR small, but let me know if you prefer changing the interface and I can do that here instead.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[ENHANCEMENT] TSDB: Make postings context-aware to allow cancellation of queries during long postings iterations.
```
