### PR TITLE
perf(remote): replace per-series maps with seriesStorage, reducing Append lookup cost

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -869,7 +869,7 @@ func main() {
 	var (
 		localStorage  = &readyStorage{stats: tsdb.NewDBStats()}
 		scraper       = &readyScrapeManager{}
-		remoteStorage = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, cfg.scrape.EnableTypeAndUnitLabels)
+		remoteStorage = remote.NewStorage(logger.With("component", "remote"), prometheus.DefaultRegisterer, localStorage.StartTime, localStoragePath, time.Duration(cfg.RemoteFlushDeadline), scraper, cfg.scrape.EnableTypeAndUnitLabels, cfg.scrape.AppendMetadata)
 		fanoutStorage = storage.NewFanout(logger, localStorage, remoteStorage)
 	)
 

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -66,6 +66,120 @@ const (
 	reasonNHCBNotSupported           = "nhcb_in_rw1_not_supported"
 )
 
+// seriesEntry holds the labels and metadata for a single active (non-dropped) series.
+type seriesEntry struct {
+	labels labels.Labels
+	meta   *metadata.Metadata
+}
+
+// seriesStorage holds per-series label and metadata maps, selecting its internal
+// layout at construction time based on whether metadata WAL records are in use:
+//
+//   - withMeta=false (RWv1, or RWv2 without metadata-wal-records): only labels is
+//     populated. Each Append lookup requires only a single map access.
+//   - withMeta=true (RWv2 with metadata-wal-records enabled): only entries is
+//     populated. Each Append lookup retrieves both labels and metadata in a single
+//     map access, avoiding the two separate lookups the old layout required.
+//
+// The hot-path method lookup acquires and releases mu internally.
+// Callers that must hold both series.mu and seriesSegmentMtx must take series.mu first.
+type seriesStorage struct {
+	mu sync.Mutex
+	// withMeta is set once in NewQueueManager and never modified; it is safe to
+	// read without holding mu.
+	withMeta bool
+
+	// withMeta=false: labels is used; entries is nil.
+	labels map[chunks.HeadSeriesRef]labels.Labels
+	// withMeta=true: entries is used; labels is nil.
+	entries map[chunks.HeadSeriesRef]seriesEntry
+
+	dropped map[chunks.HeadSeriesRef]struct{}
+}
+
+func (s *seriesStorage) lock()   { s.mu.Lock() }
+func (s *seriesStorage) unlock() { s.mu.Unlock() }
+
+// lookup returns the labels and metadata for ref, taking and releasing mu internally.
+// active is true when the series is known and not dropped.
+// dropped is only meaningful when active=false: true means the series was explicitly
+// filtered by relabelling, false means it was never seen.
+func (s *seriesStorage) lookup(ref chunks.HeadSeriesRef) (lbls labels.Labels, meta *metadata.Metadata, active, dropped bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.withMeta {
+		e, ok := s.entries[ref]
+		if !ok {
+			_, d := s.dropped[ref]
+			return labels.EmptyLabels(), nil, false, d
+		}
+		return e.labels, e.meta, true, false
+	}
+	l, ok := s.labels[ref]
+	if !ok {
+		_, d := s.dropped[ref]
+		return labels.EmptyLabels(), nil, false, d
+	}
+	return l, nil, true, false
+}
+
+// storeLocked records ref as an active series with the given labels, preserving any
+// existing metadata. Must be called with mu held.
+func (s *seriesStorage) storeLocked(ref chunks.HeadSeriesRef, lbls labels.Labels) {
+	delete(s.dropped, ref)
+	if s.withMeta {
+		existing := s.entries[ref]
+		s.entries[ref] = seriesEntry{labels: lbls, meta: existing.meta}
+	} else {
+		s.labels[ref] = lbls
+	}
+}
+
+// dropLocked marks ref as an explicitly-dropped series and removes it from the active
+// map. Must be called with mu held.
+func (s *seriesStorage) dropLocked(ref chunks.HeadSeriesRef) {
+	if s.withMeta {
+		delete(s.entries, ref)
+	} else {
+		delete(s.labels, ref)
+	}
+	s.dropped[ref] = struct{}{}
+}
+
+// activeLen returns the number of active (non-dropped) series. Must be called with mu held.
+func (s *seriesStorage) activeLen() int {
+	if s.withMeta {
+		return len(s.entries)
+	}
+	return len(s.labels)
+}
+
+// deleteLocked removes ref from all maps. Must be called with mu held.
+func (s *seriesStorage) deleteLocked(ref chunks.HeadSeriesRef) {
+	if s.withMeta {
+		delete(s.entries, ref)
+	} else {
+		delete(s.labels, ref)
+	}
+	delete(s.dropped, ref)
+}
+
+// storeMetadataLocked updates the metadata for ref if it is an active series.
+// Must be called with mu held. No-op when withMeta is false.
+func (s *seriesStorage) storeMetadataLocked(ref chunks.HeadSeriesRef, m record.RefMetadata) {
+	if !s.withMeta {
+		return
+	}
+	if e, ok := s.entries[ref]; ok {
+		e.meta = &metadata.Metadata{
+			Type: record.ToMetricType(m.Type),
+			Unit: m.Unit,
+			Help: m.Help,
+		}
+		s.entries[ref] = e
+	}
+}
+
 type queueManagerMetrics struct {
 	reg prometheus.Registerer
 
@@ -441,13 +555,10 @@ type QueueManager struct {
 	protoMsg    remoteapi.WriteMessageType
 	compr       compression.Type
 
-	seriesMtx      sync.Mutex // Covers seriesLabels, seriesMetadata, droppedSeries and builder.
-	seriesLabels   map[chunks.HeadSeriesRef]labels.Labels
-	seriesMetadata map[chunks.HeadSeriesRef]*metadata.Metadata
-	droppedSeries  map[chunks.HeadSeriesRef]struct{}
-	builder        *labels.Builder
+	series  seriesStorage
+	builder *labels.Builder // Accessed under series.mu during StoreSeries.
 
-	seriesSegmentMtx     sync.Mutex // Covers seriesSegmentIndexes - if you also lock seriesMtx, take seriesMtx first.
+	seriesSegmentMtx     sync.Mutex // Covers seriesSegmentIndexes - if you also lock series.mu, take series.mu first.
 	seriesSegmentIndexes map[chunks.HeadSeriesRef]int
 
 	shards      *shards
@@ -487,6 +598,7 @@ func NewQueueManager(
 	enableExemplarRemoteWrite bool,
 	enableNativeHistogramRemoteWrite bool,
 	enableTypeAndUnitLabels bool,
+	enableMetadataWALRecords bool,
 	protoMsg remoteapi.WriteMessageType,
 	recordBuf *record.BuffersPool,
 ) *QueueManager {
@@ -499,6 +611,8 @@ func NewQueueManager(
 	externalLabels.Range(func(l labels.Label) {
 		extLabelsSlice = append(extLabelsSlice, l)
 	})
+
+	walMetadata := protoMsg != remoteapi.WriteV1MessageType && enableMetadataWALRecords
 
 	logger = logger.With(remoteName, client.Name(), endpoint, client.Endpoint())
 	t := &QueueManager{
@@ -513,10 +627,7 @@ func NewQueueManager(
 		sendNativeHistograms:    enableNativeHistogramRemoteWrite,
 		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
 
-		seriesLabels:         make(map[chunks.HeadSeriesRef]labels.Labels),
-		seriesMetadata:       make(map[chunks.HeadSeriesRef]*metadata.Metadata),
 		seriesSegmentIndexes: make(map[chunks.HeadSeriesRef]int),
-		droppedSeries:        make(map[chunks.HeadSeriesRef]struct{}),
 		builder:              labels.NewBuilder(labels.EmptyLabels()),
 
 		numShards:   cfg.MinShards,
@@ -536,7 +647,13 @@ func NewQueueManager(
 		compr:    compression.Snappy, // Hardcoded for now, but scaffolding exists for likely future use.
 	}
 
-	walMetadata := t.protoMsg != remoteapi.WriteV1MessageType
+	t.series.withMeta = walMetadata
+	t.series.dropped = make(map[chunks.HeadSeriesRef]struct{})
+	if walMetadata {
+		t.series.entries = make(map[chunks.HeadSeriesRef]seriesEntry)
+	} else {
+		t.series.labels = make(map[chunks.HeadSeriesRef]labels.Labels)
+	}
 
 	t.watcher = wlog.NewWatcher(watcherMetrics, readerMetrics, logger, client.Name(), t, dir, enableExemplarRemoteWrite, enableNativeHistogramRemoteWrite, walMetadata, recordBuf)
 
@@ -732,23 +849,19 @@ outer:
 			t.metrics.droppedSamplesTotal.WithLabelValues(reasonTooOld).Inc()
 			continue
 		}
-		t.seriesMtx.Lock()
-		lbls, ok := t.seriesLabels[s.Ref]
+		lbls, meta, ok, dropped := t.series.lookup(s.Ref)
 		if !ok {
 			t.dataDropped.incr(1)
-			if _, ok := t.droppedSeries[s.Ref]; !ok {
+			if dropped {
+				t.metrics.droppedSamplesTotal.WithLabelValues(reasonDroppedSeries).Inc()
+			} else {
 				t.logger.Info("Dropped sample for series that was not explicitly dropped via relabelling", "ref", s.Ref)
 				t.metrics.droppedSamplesTotal.WithLabelValues(reasonUnintentionalDroppedSeries).Inc()
-			} else {
-				t.metrics.droppedSamplesTotal.WithLabelValues(reasonDroppedSeries).Inc()
 			}
-			t.seriesMtx.Unlock()
 			continue
 		}
 		// TODO(cstyan): Handle or at least log an error if no metadata is found.
 		// See https://github.com/prometheus/prometheus/issues/14405
-		meta := t.seriesMetadata[s.Ref]
-		t.seriesMtx.Unlock()
 		// Start with a very small backoff. This should not be t.cfg.MinBackoff
 		// as it can happen without errors, and we want to pickup work after
 		// filling a queue/resharding as quickly as possible.
@@ -795,22 +908,18 @@ outer:
 			t.metrics.droppedExemplarsTotal.WithLabelValues(reasonTooOld).Inc()
 			continue
 		}
-		t.seriesMtx.Lock()
-		lbls, ok := t.seriesLabels[e.Ref]
+		lbls, meta, ok, dropped := t.series.lookup(e.Ref)
 		if !ok {
 			// Track dropped exemplars in the same EWMA for sharding calc.
 			t.dataDropped.incr(1)
-			if _, ok := t.droppedSeries[e.Ref]; !ok {
+			if dropped {
+				t.metrics.droppedExemplarsTotal.WithLabelValues(reasonDroppedSeries).Inc()
+			} else {
 				t.logger.Info("Dropped exemplar for series that was not explicitly dropped via relabelling", "ref", e.Ref)
 				t.metrics.droppedExemplarsTotal.WithLabelValues(reasonUnintentionalDroppedSeries).Inc()
-			} else {
-				t.metrics.droppedExemplarsTotal.WithLabelValues(reasonDroppedSeries).Inc()
 			}
-			t.seriesMtx.Unlock()
 			continue
 		}
-		meta := t.seriesMetadata[e.Ref]
-		t.seriesMtx.Unlock()
 		// This will only loop if the queues are being resharded.
 		backoff := t.cfg.MinBackoff
 		for {
@@ -858,21 +967,17 @@ outer:
 			t.logger.Warn("Dropped native histogram with custom buckets (NHCB) as remote write v1 does not support itB", "ref", h.Ref)
 			continue
 		}
-		t.seriesMtx.Lock()
-		lbls, ok := t.seriesLabels[h.Ref]
+		lbls, meta, ok, dropped := t.series.lookup(h.Ref)
 		if !ok {
 			t.dataDropped.incr(1)
-			if _, ok := t.droppedSeries[h.Ref]; !ok {
+			if dropped {
+				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonDroppedSeries).Inc()
+			} else {
 				t.logger.Info("Dropped histogram for series that was not explicitly dropped via relabelling", "ref", h.Ref)
 				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonUnintentionalDroppedSeries).Inc()
-			} else {
-				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonDroppedSeries).Inc()
 			}
-			t.seriesMtx.Unlock()
 			continue
 		}
-		meta := t.seriesMetadata[h.Ref]
-		t.seriesMtx.Unlock()
 
 		backoff := model.Duration(5 * time.Millisecond)
 		for {
@@ -920,21 +1025,17 @@ outer:
 			t.logger.Warn("Dropped float native histogram with custom buckets (NHCB) as remote write v1 does not support itB", "ref", h.Ref)
 			continue
 		}
-		t.seriesMtx.Lock()
-		lbls, ok := t.seriesLabels[h.Ref]
+		lbls, meta, ok, dropped := t.series.lookup(h.Ref)
 		if !ok {
 			t.dataDropped.incr(1)
-			if _, ok := t.droppedSeries[h.Ref]; !ok {
+			if dropped {
+				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonDroppedSeries).Inc()
+			} else {
 				t.logger.Info("Dropped histogram for series that was not explicitly dropped via relabelling", "ref", h.Ref)
 				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonUnintentionalDroppedSeries).Inc()
-			} else {
-				t.metrics.droppedHistogramsTotal.WithLabelValues(reasonDroppedSeries).Inc()
 			}
-			t.seriesMtx.Unlock()
 			continue
 		}
-		meta := t.seriesMetadata[h.Ref]
-		t.seriesMtx.Unlock()
 
 		backoff := model.Duration(5 * time.Millisecond)
 		for {
@@ -1008,8 +1109,8 @@ func (t *QueueManager) Stop() {
 
 // StoreSeries keeps track of which series we know about for lookups when sending samples to remote.
 func (t *QueueManager) StoreSeries(series []record.RefSeries, index int) {
-	t.seriesMtx.Lock()
-	defer t.seriesMtx.Unlock()
+	t.series.lock()
+	defer t.series.unlock()
 	t.seriesSegmentMtx.Lock()
 	defer t.seriesSegmentMtx.Unlock()
 	for _, s := range series {
@@ -1020,28 +1121,23 @@ func (t *QueueManager) StoreSeries(series []record.RefSeries, index int) {
 		processExternalLabels(t.builder, t.externalLabels)
 		keep := relabel.ProcessBuilder(t.builder, t.relabelConfigs...)
 		if !keep {
-			t.droppedSeries[s.Ref] = struct{}{}
+			t.series.dropLocked(s.Ref)
 			continue
 		}
-		lbls := t.builder.Labels()
-		t.seriesLabels[s.Ref] = lbls
+		t.series.storeLocked(s.Ref, t.builder.Labels())
 	}
 }
 
 // StoreMetadata keeps track of known series' metadata for lookups when sending samples to remote.
 func (t *QueueManager) StoreMetadata(meta []record.RefMetadata) {
-	if t.protoMsg == remoteapi.WriteV1MessageType {
+	if !t.series.withMeta {
 		return
 	}
 
-	t.seriesMtx.Lock()
-	defer t.seriesMtx.Unlock()
+	t.series.lock()
+	defer t.series.unlock()
 	for _, m := range meta {
-		t.seriesMetadata[m.Ref] = &metadata.Metadata{
-			Type: record.ToMetricType(m.Type),
-			Unit: m.Unit,
-			Help: m.Help,
-		}
+		t.series.storeMetadataLocked(m.Ref, m)
 	}
 }
 
@@ -1059,8 +1155,8 @@ func (t *QueueManager) UpdateSeriesSegment(series []record.RefSeries, index int)
 // stored series records with the checkpoints index number, so we can now
 // delete any ref ID's lower than that # from the two maps.
 func (t *QueueManager) SeriesReset(index int) {
-	t.seriesMtx.Lock()
-	defer t.seriesMtx.Unlock()
+	t.series.lock()
+	defer t.series.unlock()
 	t.seriesSegmentMtx.Lock()
 	defer t.seriesSegmentMtx.Unlock()
 	// Check for series that are in segments older than the checkpoint
@@ -1068,9 +1164,7 @@ func (t *QueueManager) SeriesReset(index int) {
 	for k, v := range t.seriesSegmentIndexes {
 		if v < index {
 			delete(t.seriesSegmentIndexes, k)
-			delete(t.seriesLabels, k)
-			delete(t.seriesMetadata, k)
-			delete(t.droppedSeries, k)
+			t.series.deleteLocked(k)
 		}
 	}
 }

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"runtime"
 	"runtime/pprof"
 	"strconv"
 	"strings"
@@ -140,7 +141,8 @@ func TestBasicContentNegotiation(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+			enableMetadataWALRecords := tc.senderProtoMsg == remoteapi.WriteV2MessageType
+			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, enableMetadataWALRecords)
 			defer s.Close()
 
 			recs := testwal.GenerateRecords(recCase{
@@ -225,7 +227,8 @@ func TestSampleDelivery(t *testing.T) {
 		} {
 			t.Run(fmt.Sprintf("proto=%s/case=%s", protoMsg, rc.Name), func(t *testing.T) {
 				dir := t.TempDir()
-				s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+				enableMetadataWALRecords := protoMsg == remoteapi.WriteV2MessageType
+				s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, enableMetadataWALRecords)
 				defer s.Close()
 
 				rc.NoST = protoMsg == remoteapi.WriteV1MessageType // RW1 does not support ST.
@@ -300,13 +303,13 @@ func newTestClientAndQueueManager(t testing.TB, flushDeadline time.Duration, pro
 	c := NewTestWriteClient(protoMsg)
 	cfg := config.DefaultQueueConfig
 	mcfg := config.DefaultMetadataConfig
-	return c, newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg)
+	return c, newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 }
 
-func newTestQueueManager(t testing.TB, cfg config.QueueConfig, mcfg config.MetadataConfig, deadline time.Duration, c WriteClient, protoMsg remoteapi.WriteMessageType) *QueueManager {
+func newTestQueueManager(t testing.TB, cfg config.QueueConfig, mcfg config.MetadataConfig, deadline time.Duration, c WriteClient, protoMsg remoteapi.WriteMessageType, enableMetadataWALRecords bool) *QueueManager {
 	dir := t.TempDir()
 	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, protoMsg, record.NewBuffersPool())
+	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, enableMetadataWALRecords, protoMsg, record.NewBuffersPool())
 
 	return m
 }
@@ -347,7 +350,7 @@ func TestMetadataDelivery(t *testing.T) {
 
 func TestWALMetadataDelivery(t *testing.T) {
 	dir := t.TempDir()
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, true)
 	defer s.Close()
 
 	cfg := config.DefaultQueueConfig
@@ -379,8 +382,9 @@ func TestWALMetadataDelivery(t *testing.T) {
 	qm.StoreSeries(recs.Series, 0)
 	qm.StoreMetadata(recs.Metadata)
 
-	require.Len(t, qm.seriesLabels, n)
-	require.Len(t, qm.seriesMetadata, n)
+	qm.series.lock()
+	require.Equal(t, n, qm.series.activeLen())
+	qm.series.unlock()
 
 	c.expectSamples(recs.Samples, recs.Series)
 	c.expectMetadataForBatch(recs.Metadata, recs.Series, recs.Samples, nil, nil, nil)
@@ -401,7 +405,7 @@ func TestSampleDeliveryTimeout(t *testing.T) {
 			cfg.MaxShards = 1
 
 			c := NewTestWriteClient(protoMsg)
-			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			m.StoreSeries(recs.Series, 0)
 			m.Start()
 			defer m.Stop()
@@ -453,7 +457,7 @@ func TestShutdown(t *testing.T) {
 				cfg := config.DefaultQueueConfig
 				mcfg := config.DefaultMetadataConfig
 
-				m := newTestQueueManager(t, cfg, mcfg, deadline, c, protoMsg)
+				m := newTestQueueManager(t, cfg, mcfg, deadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 				// Send 2x batch size, so we know it will need at least two sends.
 				n := 2 * config.DefaultQueueConfig.MaxSamplesPerSend
 				recs := testwal.GenerateRecords(recCase{
@@ -481,6 +485,160 @@ func TestShutdown(t *testing.T) {
 	}
 }
 
+func TestSeriesStorage(t *testing.T) {
+	ref1 := chunks.HeadSeriesRef(1)
+	ref2 := chunks.HeadSeriesRef(2)
+	ref3 := chunks.HeadSeriesRef(3)
+	lbls1 := labels.FromStrings("__name__", "metric_one")
+	lbls1Updated := labels.FromStrings("__name__", "metric_one_v2")
+
+	t.Run("withMeta=false", func(t *testing.T) {
+		s := &seriesStorage{
+			withMeta: false,
+			labels:   make(map[chunks.HeadSeriesRef]labels.Labels),
+			dropped:  make(map[chunks.HeadSeriesRef]struct{}),
+		}
+
+		// Never-seen ref: not active, not dropped.
+		lbls, meta, active, dropped := s.lookup(ref1)
+		require.Equal(t, labels.EmptyLabels(), lbls)
+		require.Nil(t, meta)
+		require.False(t, active)
+		require.False(t, dropped)
+
+		// Store and look up an active series.
+		s.lock()
+		s.storeLocked(ref1, lbls1)
+		require.Equal(t, 1, s.activeLen())
+		s.unlock()
+
+		lbls, meta, active, dropped = s.lookup(ref1)
+		require.Equal(t, lbls1, lbls)
+		require.Nil(t, meta) // metadata always nil when withMeta=false
+		require.True(t, active)
+		require.False(t, dropped)
+
+		// storeMetadataLocked is a no-op for withMeta=false.
+		s.lock()
+		s.storeMetadataLocked(ref1, record.RefMetadata{Ref: ref1, Type: 1, Unit: "bytes", Help: "help"})
+		s.unlock()
+		_, meta, _, _ = s.lookup(ref1)
+		require.Nil(t, meta)
+
+		// Drop the series: active=false, dropped=true.
+		s.lock()
+		s.dropLocked(ref1)
+		require.Equal(t, 0, s.activeLen())
+		s.unlock()
+
+		lbls, meta, active, dropped = s.lookup(ref1)
+		require.Equal(t, labels.EmptyLabels(), lbls)
+		require.Nil(t, meta)
+		require.False(t, active)
+		require.True(t, dropped)
+
+		// deleteLocked removes all traces: subsequent lookup is never-seen.
+		s.lock()
+		s.deleteLocked(ref1)
+		s.unlock()
+
+		_, _, active, dropped = s.lookup(ref1)
+		require.False(t, active)
+		require.False(t, dropped)
+	})
+
+	t.Run("withMeta=true", func(t *testing.T) {
+		s := &seriesStorage{
+			withMeta: true,
+			entries:  make(map[chunks.HeadSeriesRef]seriesEntry),
+			dropped:  make(map[chunks.HeadSeriesRef]struct{}),
+		}
+
+		// Never-seen ref: not active, not dropped.
+		lbls, meta, active, dropped := s.lookup(ref1)
+		require.Equal(t, labels.EmptyLabels(), lbls)
+		require.Nil(t, meta)
+		require.False(t, active)
+		require.False(t, dropped)
+
+		// Store series; metadata is nil until explicitly set.
+		s.lock()
+		s.storeLocked(ref1, lbls1)
+		require.Equal(t, 1, s.activeLen())
+		s.unlock()
+
+		lbls, meta, active, dropped = s.lookup(ref1)
+		require.Equal(t, lbls1, lbls)
+		require.Nil(t, meta)
+		require.True(t, active)
+		require.False(t, dropped)
+
+		// Store metadata; labels must be unchanged.
+		s.lock()
+		s.storeMetadataLocked(ref1, record.RefMetadata{Ref: ref1, Type: 1, Unit: "bytes", Help: "help"})
+		s.unlock()
+
+		lbls, meta, active, _ = s.lookup(ref1)
+		require.Equal(t, lbls1, lbls)
+		require.NotNil(t, meta)
+		require.Equal(t, "bytes", meta.Unit)
+		require.True(t, active)
+
+		// Update labels via storeLocked; existing metadata must be preserved.
+		s.lock()
+		s.storeLocked(ref1, lbls1Updated)
+		s.unlock()
+
+		lbls, meta, active, _ = s.lookup(ref1)
+		require.Equal(t, lbls1Updated, lbls)
+		require.NotNil(t, meta, "storeLocked must preserve existing metadata")
+		require.Equal(t, "bytes", meta.Unit)
+		require.True(t, active)
+
+		// storeMetadataLocked must not create an entry for a never-seen series.
+		s.lock()
+		s.storeMetadataLocked(ref3, record.RefMetadata{Ref: ref3, Type: 1, Unit: "u", Help: "h"})
+		require.Equal(t, 1, s.activeLen())
+		s.unlock()
+		_, _, active, _ = s.lookup(ref3)
+		require.False(t, active)
+
+		// Drop the series: labels and metadata no longer accessible.
+		s.lock()
+		s.dropLocked(ref1)
+		require.Equal(t, 0, s.activeLen())
+		s.unlock()
+
+		lbls, meta, active, dropped = s.lookup(ref1)
+		require.Equal(t, labels.EmptyLabels(), lbls)
+		require.Nil(t, meta)
+		require.False(t, active)
+		require.True(t, dropped)
+
+		// storeLocked on a previously-dropped ref restores it as active.
+		s.lock()
+		s.storeLocked(ref1, lbls1)
+		s.unlock()
+
+		_, _, active, dropped = s.lookup(ref1)
+		require.True(t, active)
+		require.False(t, dropped)
+
+		// deleteLocked removes both the active entry and the dropped flag.
+		s.lock()
+		s.storeLocked(ref2, labels.FromStrings("__name__", "metric_two"))
+		s.dropLocked(ref1) // move ref1 back to dropped before deleting
+		s.deleteLocked(ref1)
+		s.deleteLocked(ref2)
+		require.Equal(t, 0, s.activeLen())
+		s.unlock()
+
+		_, _, active, dropped = s.lookup(ref1)
+		require.False(t, active)
+		require.False(t, dropped)
+	})
+}
+
 func TestSeriesReset(t *testing.T) {
 	for _, protoMsg := range []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType} {
 		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
@@ -491,7 +649,7 @@ func TestSeriesReset(t *testing.T) {
 
 			cfg := config.DefaultQueueConfig
 			mcfg := config.DefaultMetadataConfig
-			m := newTestQueueManager(t, cfg, mcfg, deadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, deadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			for i := range numSegments {
 				series := []record.RefSeries{}
 				metadata := []record.RefMetadata{}
@@ -503,19 +661,14 @@ func TestSeriesReset(t *testing.T) {
 				m.StoreSeries(series, i)
 				m.StoreMetadata(metadata)
 			}
-			require.Len(t, m.seriesLabels, numSegments*numSeries)
-			// V2 stores metadata in seriesMetadata map for inline sending.
-			// V1 sends metadata separately via MetadataWatcher, so seriesMetadata is not populated.
-			if protoMsg == remoteapi.WriteV2MessageType {
-				require.Len(t, m.seriesMetadata, numSegments*numSeries)
-			}
+			m.series.lock()
+			require.Equal(t, numSegments*numSeries, m.series.activeLen())
+			m.series.unlock()
 
 			m.SeriesReset(2)
-			require.Len(t, m.seriesLabels, numSegments*numSeries/2)
-			// Verify metadata is also reset for V2
-			if protoMsg == remoteapi.WriteV2MessageType {
-				require.Len(t, m.seriesMetadata, numSegments*numSeries/2)
-			}
+			m.series.lock()
+			require.Equal(t, numSegments*numSeries/2, m.series.activeLen())
+			m.series.unlock()
 		})
 	}
 }
@@ -538,7 +691,7 @@ func TestReshard(t *testing.T) {
 			cfg.MaxShards = 1
 
 			c := NewTestWriteClient(protoMsg)
-			m := newTestQueueManager(t, cfg, config.DefaultMetadataConfig, defaultFlushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, config.DefaultMetadataConfig, defaultFlushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			c.expectSamples(recs.Samples, recs.Series)
 			m.StoreSeries(recs.Series, 0)
 
@@ -578,7 +731,7 @@ func TestReshardRaceWithStop(t *testing.T) {
 			exitCh := make(chan struct{})
 			go func() {
 				for {
-					m = newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg)
+					m = newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 
 					m.Start()
 					h.Unlock()
@@ -621,7 +774,7 @@ func TestReshardPartialBatch(t *testing.T) {
 			flushDeadline := 10 * time.Millisecond
 			cfg.BatchSendDeadline = model.Duration(batchSendDeadline)
 
-			m := newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			m.StoreSeries(recs.Series, 0)
 
 			m.Start()
@@ -671,7 +824,7 @@ func TestQueueFilledDeadlock(t *testing.T) {
 			batchSendDeadline := time.Millisecond
 			cfg.BatchSendDeadline = model.Duration(batchSendDeadline)
 
-			m := newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, flushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			m.StoreSeries(recs.Series, 0)
 			m.Start()
 			defer m.Stop()
@@ -792,7 +945,7 @@ func TestDisableReshardOnRetry(t *testing.T) {
 		}
 	)
 
-	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, nil)
+	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, false, false, remoteapi.WriteV1MessageType, nil)
 	m.StoreSeries(recs.Series, 0)
 
 	// Attempt to samples while the manager is running. We immediately stop the
@@ -1302,6 +1455,265 @@ var extraLabels []labels.Label = []labels.Label{
 	{Name: "pod_name", Value: "some-other-name-5j8s8"},
 }
 
+// BenchmarkSeriesLookup isolates the per-sample map lookup cost in the Append hot
+// path, measuring only the lock+lookup section without shard or network overhead.
+//
+// layout=old:    3-map layout from before this change (seriesLabels + seriesMetadata +
+//
+//	droppedSeries); always 2 lookups per non-dropped sample.
+//
+// layout=new-v1: labels-only map (withMeta=false, used for RWv1 or RWv2 without
+//
+//	metadata-wal-records); 1 lookup per non-dropped sample.
+//
+// layout=new-v2: entries map (withMeta=true, used for RWv2 with metadata-wal-records);
+//
+//	1 lookup per non-dropped sample, retrieving labels and metadata together.
+//
+// To run:
+//
+//	go test -bench=BenchmarkSeriesLookup -benchtime=5s -count=6 ./storage/remote/ | tee bench_lookup.txt
+//	benchstat -col /layout bench_lookup.txt
+func BenchmarkSeriesLookup(b *testing.B) {
+	const (
+		numRefsPerIter  = 10_000
+		sampleDropRate  = 0.10 // fraction of refs that hit dropped series
+		droppedFraction = 0.15
+	)
+
+	type sizeCase struct {
+		label   string
+		total   int
+		dropped int
+	}
+
+	sizes := []sizeCase{
+		{"n=1M/drop=0", 1_000_000, 0},
+		{"n=1M/drop=150k", 1_000_000, int(1_000_000 * droppedFraction)},
+		{"n=20M/drop=0", 20_000_000, 0},
+		{"n=20M/drop=3000k", 20_000_000, int(20_000_000 * droppedFraction)},
+	}
+
+	for _, sz := range sizes {
+		numKept := sz.total - sz.dropped
+
+		// Build ref batch: sampleDropRate fraction hit dropped series.
+		numDroppedRefs := 0
+		if sz.dropped > 0 {
+			numDroppedRefs = int(numRefsPerIter * sampleDropRate)
+		}
+		numKeptRefs := numRefsPerIter - numDroppedRefs
+		refs := make([]chunks.HeadSeriesRef, numRefsPerIter)
+		for i := range numKeptRefs {
+			refs[i] = chunks.HeadSeriesRef(i % numKept)
+		}
+		for i := range numDroppedRefs {
+			refs[numKeptRefs+i] = chunks.HeadSeriesRef(numKept + (i % sz.dropped))
+		}
+
+		b.Run(sz.label+"/layout=old", func(b *testing.B) {
+			if testing.Short() && sz.total >= 1_000_000 {
+				b.Skip("skipping large-scale benchmark in short mode")
+			}
+
+			// Old layout: three separate maps.
+			seriesLabels := make(map[chunks.HeadSeriesRef]labels.Labels, numKept)
+			seriesMetadata := make(map[chunks.HeadSeriesRef]*metadata.Metadata, numKept)
+			droppedSeries := make(map[chunks.HeadSeriesRef]struct{}, sz.dropped)
+			var mu sync.Mutex
+
+			for i := range numKept {
+				ref := chunks.HeadSeriesRef(i)
+				seriesLabels[ref] = labels.FromStrings("__name__", fmt.Sprintf("metric_%d", i))
+				seriesMetadata[ref] = &metadata.Metadata{Type: "gauge", Unit: "bytes"}
+			}
+			for i := range sz.dropped {
+				droppedSeries[chunks.HeadSeriesRef(numKept+i)] = struct{}{}
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				for _, ref := range refs {
+					mu.Lock()
+					lbls, ok := seriesLabels[ref]
+					if !ok {
+						_ = droppedSeries[ref]
+						mu.Unlock()
+						continue
+					}
+					_ = seriesMetadata[ref]
+					mu.Unlock()
+					_ = lbls
+				}
+			}
+		})
+
+		b.Run(sz.label+"/layout=new-v1", func(b *testing.B) {
+			if testing.Short() && sz.total >= 1_000_000 {
+				b.Skip("skipping large-scale benchmark in short mode")
+			}
+
+			seriesLabels := make(map[chunks.HeadSeriesRef]labels.Labels, numKept)
+			droppedSeries := make(map[chunks.HeadSeriesRef]struct{}, sz.dropped)
+			var mu sync.Mutex
+
+			for i := range numKept {
+				ref := chunks.HeadSeriesRef(i)
+				seriesLabels[ref] = labels.FromStrings("__name__", fmt.Sprintf("metric_%d", i))
+			}
+			for i := range sz.dropped {
+				droppedSeries[chunks.HeadSeriesRef(numKept+i)] = struct{}{}
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				for _, ref := range refs {
+					mu.Lock()
+					lbls, ok := seriesLabels[ref]
+					if !ok {
+						_ = droppedSeries[ref]
+						mu.Unlock()
+						continue
+					}
+					mu.Unlock()
+					_ = lbls
+				}
+			}
+		})
+
+		b.Run(sz.label+"/layout=new-v2", func(b *testing.B) {
+			if testing.Short() && sz.total >= 1_000_000 {
+				b.Skip("skipping large-scale benchmark in short mode")
+			}
+
+			series := make(map[chunks.HeadSeriesRef]seriesEntry, numKept)
+			droppedSeries := make(map[chunks.HeadSeriesRef]struct{}, sz.dropped)
+			var mu sync.Mutex
+
+			for i := range numKept {
+				ref := chunks.HeadSeriesRef(i)
+				series[ref] = seriesEntry{
+					labels: labels.FromStrings("__name__", fmt.Sprintf("metric_%d", i)),
+					meta:   &metadata.Metadata{Type: "gauge", Unit: "bytes"},
+				}
+			}
+			for i := range sz.dropped {
+				droppedSeries[chunks.HeadSeriesRef(numKept+i)] = struct{}{}
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				for _, ref := range refs {
+					mu.Lock()
+					entry, ok := series[ref]
+					if !ok {
+						_ = droppedSeries[ref]
+						mu.Unlock()
+						continue
+					}
+					mu.Unlock()
+					_ = entry
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkAppend measures full-pipeline Append throughput across a matrix of:
+//   - total series count (100k / 1M)
+//   - metadata presence (no meta / with meta, V2 only)
+//   - wire format (RW1 / RW2)
+//
+// Each iteration calls Append with 10 000 samples spread across all series.
+// For isolating the lookup cost see BenchmarkSeriesLookup.
+//
+// To run:
+//
+//	go test -bench=BenchmarkAppend -benchtime=5s -count=6 -benchmem ./storage/remote/ | tee bench_append.txt
+//	benchstat bench_append.txt
+func BenchmarkAppend(b *testing.B) {
+	const numSamplesPerIter = 10_000
+
+	type sizeCase struct {
+		label string
+		total int
+	}
+
+	sizes := []sizeCase{
+		{"n=100k", 100_000},
+		{"n=1M", 1_000_000},
+	}
+
+	type formatCase struct {
+		label    string
+		format   remoteapi.WriteMessageType
+		withMeta bool
+	}
+	formats := []formatCase{
+		{"proto=v1/meta=false", remoteapi.WriteV1MessageType, false},
+		{"proto=v2/meta=false", remoteapi.WriteV2MessageType, false},
+		{"proto=v2/meta=true", remoteapi.WriteV2MessageType, true},
+	}
+
+	for _, sz := range sizes {
+		for _, fc := range formats {
+			b.Run(fmt.Sprintf("%s/%s", sz.label, fc.label), func(b *testing.B) {
+				if testing.Short() && sz.total >= 1_000_000 {
+					b.Skip("skipping large-scale benchmark in short mode")
+				}
+
+				cfg := testDefaultQueueConfig()
+				mcfg := config.DefaultMetadataConfig
+				dir := b.TempDir()
+				metrics := newQueueManagerMetrics(nil, "", "")
+				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, NewNopWriteClient(), defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, fc.withMeta, fc.format, record.NewBuffersPool())
+
+				series := make([]record.RefSeries, sz.total)
+				for i := range sz.total {
+					series[i] = record.RefSeries{
+						Ref:    chunks.HeadSeriesRef(i),
+						Labels: labels.FromStrings("__name__", fmt.Sprintf("metric_%d", i)),
+					}
+				}
+				m.StoreSeries(series, 0)
+
+				if fc.withMeta {
+					meta := make([]record.RefMetadata, sz.total)
+					for i := range sz.total {
+						meta[i] = record.RefMetadata{
+							Ref:  chunks.HeadSeriesRef(i),
+							Type: 1,
+							Unit: "bytes",
+							Help: fmt.Sprintf("help text for metric_%d", i),
+						}
+					}
+					m.StoreMetadata(meta)
+				}
+
+				samples := make([]record.RefSample, numSamplesPerIter)
+				for i := range numSamplesPerIter {
+					samples[i] = record.RefSample{Ref: chunks.HeadSeriesRef(i % sz.total), T: 0, V: float64(i)}
+				}
+
+				m.Start()
+				defer m.Stop()
+
+				runtime.GC()
+				var mem runtime.MemStats
+				runtime.ReadMemStats(&mem)
+				heapMB := float64(mem.HeapInuse) / 1e6
+
+				b.ReportAllocs()
+				for b.Loop() {
+					m.Append(samples)
+				}
+				b.StopTimer()
+				b.ReportMetric(heapMB, "heapMB")
+			})
+		}
+	}
+}
+
 // Recommended CLI invocation(s):
 /*
 	export bench=sampleSend && go test ./storage/remote/... \
@@ -1327,7 +1739,7 @@ func BenchmarkSampleSend(b *testing.B) {
 	// todo: test with new proto type(s)
 	for _, format := range []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType} {
 		b.Run(string(format), func(b *testing.B) {
-			m := newTestQueueManager(b, cfg, mcfg, defaultFlushDeadline, c, format)
+			m := newTestQueueManager(b, cfg, mcfg, defaultFlushDeadline, c, format, format != remoteapi.WriteV1MessageType)
 			m.StoreSeries(recs.Series, 0)
 
 			// These should be received by the client.
@@ -1390,7 +1802,7 @@ func BenchmarkStoreSeries(b *testing.B) {
 				mcfg := config.DefaultMetadataConfig
 				metrics := newQueueManagerMetrics(nil, "", "")
 
-				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, record.NewBuffersPool())
+				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, false, remoteapi.WriteV1MessageType, record.NewBuffersPool())
 				m.externalLabels = tc.externalLabels
 				m.relabelConfigs = tc.relabelConfigs
 
@@ -1948,7 +2360,7 @@ func TestDropOldTimeSeries(t *testing.T) {
 			mcfg := config.DefaultMetadataConfig
 			cfg.MaxShards = 1
 			cfg.SampleAgeLimit = model.Duration(60 * time.Second)
-			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			m.StoreSeries(series, 0)
 
 			m.Start()
@@ -1992,7 +2404,7 @@ func TestSendSamplesWithBackoffWithSampleAgeLimit(t *testing.T) {
 			metadataCfg.SendInterval = model.Duration(time.Second * 60)
 			metadataCfg.MaxSamplesPerSend = maxSamplesPerSend
 			c := NewTestWriteClient(protoMsg)
-			m := newTestQueueManager(t, cfg, metadataCfg, time.Second, c, protoMsg)
+			m := newTestQueueManager(t, cfg, metadataCfg, time.Second, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 
 			m.Start()
 
@@ -2584,7 +2996,7 @@ func TestAppendHistogramSchemaValidation(t *testing.T) {
 			mcfg := config.DefaultMetadataConfig
 			cfg.MaxShards = 1
 
-			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg)
+			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg, protoMsg != remoteapi.WriteV1MessageType)
 			m.sendNativeHistograms = true
 
 			// Create series for the histograms

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -93,7 +93,7 @@ func TestNoDuplicateReadConfigs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
-			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+			s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, false)
 			conf := &config.Config{
 				GlobalConfig:      config.DefaultGlobalConfig,
 				RemoteReadConfigs: tc.cfgs,

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -66,7 +66,7 @@ type Storage struct {
 var _ storage.Storage = &Storage{}
 
 // NewStorage returns a remote.Storage.
-func NewStorage(l *slog.Logger, reg prometheus.Registerer, stCallback startTimeCallback, walDir string, flushDeadline time.Duration, sm ReadyScrapeManager, enableTypeAndUnitLabels bool) *Storage {
+func NewStorage(l *slog.Logger, reg prometheus.Registerer, stCallback startTimeCallback, walDir string, flushDeadline time.Duration, sm ReadyScrapeManager, enableTypeAndUnitLabels, enableMetadataWALRecords bool) *Storage {
 	if l == nil {
 		l = promslog.NewNopLogger()
 	}
@@ -78,7 +78,7 @@ func NewStorage(l *slog.Logger, reg prometheus.Registerer, stCallback startTimeC
 		deduper:                deduper,
 		localStartTimeCallback: stCallback,
 	}
-	s.rws = NewWriteStorage(s.logger, reg, walDir, flushDeadline, sm, enableTypeAndUnitLabels)
+	s.rws = NewWriteStorage(s.logger, reg, walDir, flushDeadline, sm, enableTypeAndUnitLabels, enableMetadataWALRecords)
 	return s
 }
 

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -29,7 +29,7 @@ import (
 func TestStorageLifecycle(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, false)
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -56,7 +56,7 @@ func TestStorageLifecycle(t *testing.T) {
 func TestUpdateRemoteReadConfigs(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, false)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
@@ -77,7 +77,7 @@ func TestUpdateRemoteReadConfigs(t *testing.T) {
 func TestFilterExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, false)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{
@@ -102,7 +102,7 @@ func TestFilterExternalLabels(t *testing.T) {
 func TestIgnoreExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewStorage(nil, nil, nil, dir, defaultFlushDeadline, nil, false, false)
 
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{
@@ -159,7 +159,7 @@ func baseRemoteReadConfig(host string) *config.RemoteReadConfig {
 // ApplyConfig runs concurrently with Notify
 // See https://github.com/prometheus/prometheus/issues/12747
 func TestWriteStorageApplyConfigsDuringCommit(t *testing.T) {
-	s := NewStorage(nil, nil, nil, t.TempDir(), defaultFlushDeadline, nil, false)
+	s := NewStorage(nil, nil, nil, t.TempDir(), defaultFlushDeadline, nil, false, false)
 
 	var wg sync.WaitGroup
 	wg.Add(2000)

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -76,12 +76,13 @@ type WriteStorage struct {
 	recordBuf *record.BuffersPool
 
 	// For timestampTracker.
-	highestTimestamp        *maxTimestamp
-	enableTypeAndUnitLabels bool
+	highestTimestamp         *maxTimestamp
+	enableTypeAndUnitLabels  bool
+	enableMetadataWALRecords bool
 }
 
 // NewWriteStorage creates and runs a WriteStorage.
-func NewWriteStorage(logger *slog.Logger, reg prometheus.Registerer, dir string, flushDeadline time.Duration, sm ReadyScrapeManager, enableTypeAndUnitLabels bool) *WriteStorage {
+func NewWriteStorage(logger *slog.Logger, reg prometheus.Registerer, dir string, flushDeadline time.Duration, sm ReadyScrapeManager, enableTypeAndUnitLabels, enableMetadataWALRecords bool) *WriteStorage {
 	if logger == nil {
 		logger = promslog.NewNopLogger()
 	}
@@ -105,8 +106,9 @@ func NewWriteStorage(logger *slog.Logger, reg prometheus.Registerer, dir string,
 				Help:      "Highest timestamp that has come into the remote storage via the Appender interface, in seconds since epoch. Initialized to 0 when no data has been received yet. Deprecated, check prometheus_remote_storage_queue_highest_timestamp_seconds which is more accurate.",
 			}),
 		},
-		recordBuf:               record.NewBuffersPool(),
-		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
+		recordBuf:                record.NewBuffersPool(),
+		enableTypeAndUnitLabels:  enableTypeAndUnitLabels,
+		enableMetadataWALRecords: enableMetadataWALRecords,
 	}
 	if reg != nil {
 		reg.MustRegister(rws.highestTimestamp)
@@ -218,6 +220,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			rwConf.SendExemplars,
 			rwConf.SendNativeHistograms,
 			rws.enableTypeAndUnitLabels,
+			rws.enableMetadataWALRecords,
 			rwConf.ProtobufMessage,
 			rws.recordBuf,
 		)

--- a/storage/remote/write_test.go
+++ b/storage/remote/write_test.go
@@ -100,7 +100,7 @@ func TestWriteStorageApplyConfig_NoDuplicateWriteConfigs(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false)
+			s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false, false)
 			conf := &config.Config{
 				GlobalConfig:       config.DefaultGlobalConfig,
 				RemoteWriteConfigs: tc.cfgs,
@@ -126,7 +126,7 @@ func TestWriteStorageApplyConfig_RestartOnNameChange(t *testing.T) {
 	hash, err := toHash(cfg)
 	require.NoError(t, err)
 
-	s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false)
+	s := NewWriteStorage(nil, nil, dir, time.Millisecond, nil, false, false)
 
 	conf := &config.Config{
 		GlobalConfig:       config.DefaultGlobalConfig,
@@ -148,7 +148,7 @@ func TestWriteStorageApplyConfig_RestartOnNameChange(t *testing.T) {
 func TestWriteStorageApplyConfig_UpdateWithRegisterer(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Millisecond, nil, false)
+	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Millisecond, nil, false, false)
 	c1 := &config.RemoteWriteConfig{
 		Name: "named",
 		URL: &common_config.URL{
@@ -189,7 +189,7 @@ func TestWriteStorageApplyConfig_UpdateWithRegisterer(t *testing.T) {
 func TestWriteStorageApplyConfig_Lifecycle(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false, false)
 	conf := &config.Config{
 		GlobalConfig: config.DefaultGlobalConfig,
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -205,7 +205,7 @@ func TestWriteStorageApplyConfig_Lifecycle(t *testing.T) {
 func TestWriteStorageApplyConfig_UpdateExternalLabels(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Second, nil, false)
+	s := NewWriteStorage(nil, prometheus.NewRegistry(), dir, time.Second, nil, false, false)
 
 	externalLabels := labels.FromStrings("external", "true")
 	conf := &config.Config{
@@ -233,7 +233,7 @@ func TestWriteStorageApplyConfig_UpdateExternalLabels(t *testing.T) {
 func TestWriteStorageApplyConfig_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false, false)
 	conf := &config.Config{
 		GlobalConfig: config.GlobalConfig{},
 		RemoteWriteConfigs: []*config.RemoteWriteConfig{
@@ -257,7 +257,7 @@ func TestWriteStorageApplyConfig_Idempotent(t *testing.T) {
 func TestWriteStorageApplyConfig_PartialUpdate(t *testing.T) {
 	dir := t.TempDir()
 
-	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false)
+	s := NewWriteStorage(nil, nil, dir, defaultFlushDeadline, nil, false, false)
 
 	c0 := &config.RemoteWriteConfig{
 		RemoteTimeout: model.Duration(10 * time.Second),
@@ -369,7 +369,7 @@ func TestWriteStorage_CanRegisterMetricsAfterClosing(t *testing.T) {
 	dir := t.TempDir()
 	reg := prometheus.NewPedanticRegistry()
 
-	s := NewWriteStorage(nil, reg, dir, time.Millisecond, nil, false)
+	s := NewWriteStorage(nil, reg, dir, time.Millisecond, nil, false, false)
 	require.NoError(t, s.Close())
-	require.NotPanics(t, func() { NewWriteStorage(nil, reg, dir, time.Millisecond, nil, false) })
+	require.NotPanics(t, func() { NewWriteStorage(nil, reg, dir, time.Millisecond, nil, false, false) })
 }

--- a/tsdb/agent/db_append_v2_test.go
+++ b/tsdb/agent/db_append_v2_test.go
@@ -729,7 +729,7 @@ func TestWALReplay_AppendV2(t *testing.T) {
 
 func Test_ExistingWAL_NextRef_AppendV2(t *testing.T) {
 	dbDir := t.TempDir()
-	rs := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false)
+	rs := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false, false)
 	defer func() {
 		require.NoError(t, rs.Close())
 	}()

--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -94,7 +94,7 @@ func createTestAgentDB(t testing.TB, reg prometheus.Registerer, opts *Options) *
 
 	dbDir := t.TempDir()
 
-	rs := remote.NewStorage(promslog.NewNopLogger(), reg, startTime, dbDir, time.Second*30, nil, false)
+	rs := remote.NewStorage(promslog.NewNopLogger(), reg, startTime, dbDir, time.Second*30, nil, false, false)
 	t.Cleanup(func() {
 		require.NoError(t, rs.Close())
 	})
@@ -798,7 +798,7 @@ func TestLockfile(t *testing.T) {
 	tsdbutil.TestDirLockerUsage(t, func(t *testing.T, data string, createLock bool) (*tsdbutil.DirLocker, testutil.Closer) {
 		logger := promslog.NewNopLogger()
 		reg := prometheus.NewRegistry()
-		rs := remote.NewStorage(logger, reg, startTime, data, time.Second*30, nil, false)
+		rs := remote.NewStorage(logger, reg, startTime, data, time.Second*30, nil, false, false)
 		t.Cleanup(func() {
 			require.NoError(t, rs.Close())
 		})
@@ -818,7 +818,7 @@ func TestLockfile(t *testing.T) {
 
 func Test_ExistingWAL_NextRef(t *testing.T) {
 	dbDir := t.TempDir()
-	rs := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false)
+	rs := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false, false)
 	defer func() {
 		require.NoError(t, rs.Close())
 	}()
@@ -1377,7 +1377,7 @@ func TestDBStartTimestampSamplesIngestion(t *testing.T) {
 func TestDuplicateSeriesRefsByHash(t *testing.T) {
 	dbDir := t.TempDir()
 	opts := DefaultOptions()
-	rs1 := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false)
+	rs1 := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false, false)
 	db, err := Open(promslog.NewNopLogger(), nil, rs1, dbDir, opts)
 	require.NoError(t, err)
 
@@ -1435,7 +1435,7 @@ func TestDuplicateSeriesRefsByHash(t *testing.T) {
 	require.NoError(t, db.Close())
 	require.NoError(t, rs1.Close())
 
-	rs2 := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false)
+	rs2 := remote.NewStorage(promslog.NewNopLogger(), nil, startTime, dbDir, time.Second*30, nil, false, false)
 	t.Cleanup(func() { require.NoError(t, rs2.Close()) })
 	db, err = Open(promslog.NewNopLogger(), nil, rs2, dbDir, opts)
 	require.NoError(t, err)

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -539,7 +539,7 @@ func TestEndpoints(t *testing.T) {
 
 		remote := remote.NewStorage(promslog.New(&promslogConfig), prometheus.DefaultRegisterer, func() (int64, error) {
 			return 0, nil
-		}, dbDir, 1*time.Second, nil, false)
+		}, dbDir, 1*time.Second, nil, false, false)
 		t.Cleanup(func() { _ = remote.Close() })
 
 		err = remote.ApplyConfig(&config.Config{


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Related to #17277, I have a feeling it could solves it but can't confirm easily.

Every sample in `QueueManager.Append` required two map lookups under `seriesMtx` (`seriesLabels` + either `droppedSeries` or `seriesMetadata`). This replaces the three maps with a single `seriesStorage` struct that selects its layout at construction time:

- **`withMeta=false`** (RWv1, or RWv2 without `metadata-wal-records`): labels-only map, one lookup per Append.
- **`withMeta=true`** (RWv2 + `metadata-wal-records`): combined labels+metadata map, one lookup per Append.

`StoreMetadata` short-circuits before acquiring the lock when `!series.withMeta`. `walMetadata` is now gated on both proto type and `enableMetadataWALRecords` to avoid allocating the entries map when metadata WAL records won't arrive.

**Note:** metadata is no longer stored for dropped series. Previously `StoreMetadata` wrote to `seriesMetadata` unconditionally, including for refs already in `droppedSeries`. `storeMetadataLocked` now skips refs with no active entry. `Append` already discarded dropped series before reading metadata, so this has no effect on what gets sent.

### Benchmarks

`BenchmarkSeriesLookup`:

```
                                 │     old      │              new-v1               │              new-v2               │
                                 │    sec/op    │   sec/op     vs base              │   sec/op     vs base              │
SeriesLookup/n=1M/drop=0-11        183.17µ ± 1%   98.33µ ± 3%  -46.32% (p=0.002 n=6)  104.87µ ± 1%  -42.75% (p=0.002 n=6)
SeriesLookup/n=1M/drop=150k-11      179.7µ ± 3%  112.5µ  ± 3%  -37.42% (p=0.002 n=6)   113.0µ ± 1%  -37.13% (p=0.002 n=6)
SeriesLookup/n=20M/drop=0-11        233.7µ ± 5%  139.3µ  ± 3%  -40.38% (p=0.002 n=6)   138.9µ ± 3%  -40.56% (p=0.002 n=6)
SeriesLookup/n=20M/drop=3000k-11    241.4µ ± 4%  149.4µ  ± 4%  -38.12% (p=0.002 n=6)   149.5µ ± 1%  -38.05% (p=0.002 n=6)
geomean                             207.6µ        123.2µ        -40.67%                  125.3µ        -39.66%
```

`BenchmarkAppend` 

```
                                     │    main    │              branch               │
                                     │   sec/op   │   sec/op     vs base              │
Append/n=100k/proto=v1/meta=false-11   1.958m ± 4%   1.949m ± 2%        ~ (p=0.589 n=6)
Append/n=100k/proto=v2/meta=false-11   3.806m ± 4%   3.860m ± 4%        ~ (p=0.240 n=6)
Append/n=100k/proto=v2/meta=true-11    4.520m ± 1%   4.497m ± 2%        ~ (p=0.589 n=6)
Append/n=1M/proto=v1/meta=false-11     1.251m ± 5%   1.100m ± 2%  -12.07% (p=0.002 n=6)
Append/n=1M/proto=v2/meta=false-11     3.893m ± 7%   3.209m ± 6%  -17.57% (p=0.002 n=6)
Append/n=1M/proto=v2/meta=true-11      4.627m ± 4%   4.285m ± 2%   -7.38% (p=0.002 n=6)
geomean                                3.020m        2.828m         -6.36%
```

No regressions. At n=1M throughput improves 7–18%; n=100k is neutral (bottleneck is elsewhere at small scale).

<details>
<summary>BenchmarkAppend — heapMB, B/op, allocs/op</summary>

```
                                     │   main    │             branch              │
                                     │  heapMB   │   heapMB    vs base             │
Append/n=100k/proto=v1/meta=false-11   30.38 ± 1%   30.79 ±  1%  +1.37% (p=0.013 n=6)
Append/n=100k/proto=v2/meta=false-11   30.67 ± 2%   31.09 ±  2%       ~ (p=0.102 n=6)
Append/n=100k/proto=v2/meta=true-11    39.59 ± 1%   38.60 ±  1%  -2.50% (p=0.002 n=6)
Append/n=1M/proto=v1/meta=false-11      146.8 ± 7%   156.2 ± 10%       ~ (p=0.240 n=6)
Append/n=1M/proto=v2/meta=false-11      145.1 ± 8%   147.2 ±  4%       ~ (p=0.961 n=6)
Append/n=1M/proto=v2/meta=true-11       273.5 ± 5%   250.3 ±  1%  -8.47% (p=0.002 n=6)
geomean                                77.39         77.26        -0.17%

                                     │    main     │            branch             │
                                     │    B/op     │    B/op     vs base           │
Append/n=100k/proto=v1/meta=false-11   3.901Ki ± 2%   3.851Ki ± 1%  -1.29% (p=0.006 n=6)
Append/n=100k/proto=v2/meta=false-11   9.530Ki ± 1%   9.561Ki ± 0%       ~ (p=0.004 n=6)
Append/n=100k/proto=v2/meta=true-11    10.21Ki ± 0%   10.21Ki ± 1%       ~ (p=0.970 n=6)
Append/n=1M/proto=v1/meta=false-11     3.706Ki ± 0%   3.676Ki ± 0%  -0.79% (p=0.002 n=6)
Append/n=1M/proto=v2/meta=false-11     9.572Ki ± 1%   9.395Ki ± 1%  -1.85% (p=0.002 n=6)
Append/n=1M/proto=v2/meta=true-11      10.26Ki ± 1%   10.12Ki ± 3%       ~ (p=0.093 n=6)
geomean                                7.190Ki        7.130Ki       -0.84%

                                     │   main    │  branch   │
                                     │ allocs/op │ allocs/op │
Append/n=100k/proto=v1/meta=false-11    35 ± 0%    35 ± 0%
Append/n=100k/proto=v2/meta=false-11   116 ± 0%   116 ± 0%
Append/n=100k/proto=v2/meta=true-11    116 ± 0%   116 ± 0%
Append/n=1M/proto=v1/meta=false-11      35 ± 0%    35 ± 0%
Append/n=1M/proto=v2/meta=false-11     116 ± 0%   116 ± 0%
Append/n=1M/proto=v2/meta=true-11      116 ± 0%   116 ± 0%
```

heapMB is measured after `StoreSeries`/`StoreMetadata` and before the Append loop — it reflects steady-state map footprint, not per-Append allocation. Allocations are unchanged across all cases.

</details>

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[PERF] remote: replace three per-series maps with a layout-selected `seriesStorage`, reducing `Append` lookup cost ~40% at scale.
```