### PR TITLE
promql: fix smoothSeries() @ modifier timestamp mismatch

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1712,8 +1712,6 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration)
 	it := storage.NewBuffer(dur + 2*durationMilliseconds(ev.lookbackDelta))
 
 	offMS := offset.Milliseconds()
-	start := ev.startTimestamp - offMS
-	end := ev.endTimestamp - offMS
 	step := ev.interval
 	lb := durationMilliseconds(ev.lookbackDelta)
 
@@ -1729,9 +1727,11 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration)
 		var floats []FPoint
 		var hists []HPoint
 
-		for ts := start; ts <= end; ts += step {
-			matrixStart := ts - lb
-			matrixEnd := ts + lb
+		for evalTS := ev.startTimestamp; evalTS <= ev.endTimestamp; evalTS += step {
+			// Apply offset to get the data timestamp.
+			dataTS := evalTS - offMS
+			matrixStart := dataTS - lb
+			matrixEnd := dataTS + lb
 
 			floats, hists = ev.matrixIterSlice(it, matrixStart, matrixEnd, floats, hists)
 			if len(floats) == 0 && len(hists) == 0 {
@@ -1743,28 +1743,28 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration)
 				ev.errorf("smoothed and anchored modifiers do not work with native histograms")
 			}
 
-			// Binary search for the first index with T >= ts.
-			i := sort.Search(len(floats), func(i int) bool { return floats[i].T >= ts })
+			// Binary search for the first index with T >= dataTS.
+			i := sort.Search(len(floats), func(i int) bool { return floats[i].T >= dataTS })
 
 			switch {
-			case i < len(floats) && floats[i].T == ts:
+			case i < len(floats) && floats[i].T == dataTS:
 				// Exact match.
-				ss.Floats = append(ss.Floats, floats[i])
+				ss.Floats = append(ss.Floats, FPoint{F: floats[i].F, T: evalTS})
 
 			case i > 0 && i < len(floats):
 				// Interpolate between prev and next.
 				// TODO: detect if the sample is a counter, based on __type__ or metadata.
 				prev, next := floats[i-1], floats[i]
-				val := interpolate(prev, next, ts, false)
-				ss.Floats = append(ss.Floats, FPoint{F: val, T: ts})
+				val := interpolate(prev, next, dataTS, false)
+				ss.Floats = append(ss.Floats, FPoint{F: val, T: evalTS})
 
 			case i > 0:
 				// No next point yet; carry forward previous value.
 				prev := floats[i-1]
-				ss.Floats = append(ss.Floats, FPoint{F: prev.F, T: ts})
+				ss.Floats = append(ss.Floats, FPoint{F: prev.F, T: evalTS})
 
 			default:
-				// i == 0 and floats[0].T > ts: there is no previous data yet; skip.
+				// i == 0 and floats[0].T > dataTS: there is no previous data yet; skip.
 			}
 		}
 

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -435,10 +435,25 @@ eval instant at 60s rate(metric[5s] smoothed)
 
 eval instant at 60s increase(metric[5s] smoothed)
 
-# Smoothed vector selector with @ modifier with binary op.
+# Smoothed vector selector with @ and offset modifier and binop
 clear
 load 10s
     metric 0+1x20
 
+eval range from 0s to 60s step 15s metric @ 100
+    metric 10 10 10 10 10
+
+eval range from 0s to 60s step 15s metric @ 100 smoothed
+    metric 10 10 10 10 10
+
 eval range from 0s to 60s step 15s metric @ 100 smoothed + 0
     {} 10 10 10 10 10
+
+eval range from 0s to 60s step 15s metric offset -100
+    metric 10 11 13 14 16
+
+eval range from 0s to 60s step 15s metric offset -100 smoothed
+    metric 10 11.5 13 14.5 16
+
+eval range from 0s to 60s step 15s metric offset -100 smoothed + 0
+    {} 10 11.5 13 14.5 16

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -434,3 +434,11 @@ eval instant at 15s increase(metric[10s] smoothed)
 eval instant at 60s rate(metric[5s] smoothed)
 
 eval instant at 60s increase(metric[5s] smoothed)
+
+# Smoothed vector selector with @ modifier with binary op.
+clear
+load 10s
+    metric 0+1x20
+
+eval range from 0s to 60s step 15s metric @ 100 smoothed + 0
+    {} 10 10 10 10 10


### PR DESCRIPTION
smoothSeries() was stamping output points at offset-adjusted timestamps instead of evaluator timestamps. When the @ modifier is used, this causes gatherVector() to miss the points because it matches by exact timestamp equality against evaluator step timestamps.

Fix by iterating over evaluator timestamps and deriving data timestamps by subtracting the offset, so output points align with what gatherVector() expects.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] PromQL: Fix smoothed vector selector returning no results in binary operations when the `@` modifier is used.
```
