### PR TITLE
Add kgeckhart as agent maintainer and codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,6 +17,7 @@
 /storage/remote                 @prometheus/default-maintainers @cstyan @bwplotka @tomwilkie @alexgreenbank
 /storage/remote/otlptranslator  @prometheus/default-maintainers @aknuds1 @jesusvazquez @ArthurSens
 /tsdb                           @prometheus/default-maintainers @jesusvazquez @codesome @bwplotka @krajorama
+/tsdb/agent                     @prometheus/default-maintainers @jesusvazquez @codesome @bwplotka @krajorama @kgeckhart
 
 # Service discovery.
 /discovery/kubernetes           @prometheus/default-maintainers @brancz @rexagod

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -25,6 +25,7 @@ Maintainers for specific parts of the codebase:
   * `remote`: Callum Styan (<callumstyan@gmail.com> / @cstyan), Tom Wilkie (tom.wilkie@gmail.com / @tomwilkie), Alex Greenbank (<alexgreenbank@yahoo.com> / @alexgreenbank)
     * `otlptranslator`: Arthur Silva Sens (<arthursens2005@gmail.com> / @ArthurSens, Jesús Vázquez (<jesus.vazquez@grafana.com> / @jesusvazquez)
 * `tsdb`: Ganesh Vernekar (<ganesh@grafana.com> / @codesome), Jesús Vázquez (<jesus.vazquez@grafana.com> / @jesusvazquez)
+    * `agent`: Kyle Eckhart (<kyle.eckhart@grafana.com> / @kgeckhart)
 * `web`
   * `ui`: Julius Volz (<julius.volz@gmail.com> / @juliusv)
     * `module`: Augustin Husson (<husson.augustin@gmail.com> / @nexucis)


### PR DESCRIPTION
I am volunteering to take ownership of the prometheus agent code.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```
