### PR TITLE
model/labels: Add case-insensitive prefix matching optimization

### DIFF
--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -168,3 +168,10 @@ func (m *Matcher) IsRegexOptimized() bool {
 	}
 	return m.re.IsOptimized()
 }
+
+func (m *Matcher) HasCaseInsensitivePrefix() bool {
+	if m.re == nil {
+		return false
+	}
+	return m.re.caseInsensitivePrefix
+}

--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -168,10 +168,3 @@ func (m *Matcher) IsRegexOptimized() bool {
 	}
 	return m.re.IsOptimized()
 }
-
-func (m *Matcher) HasCaseInsensitivePrefix() bool {
-	if m.re == nil {
-		return false
-	}
-	return m.re.caseInsensitivePrefix
-}

--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -137,8 +137,9 @@ func TestInverse(t *testing.T) {
 
 func TestPrefix(t *testing.T) {
 	for i, tc := range []struct {
-		matcher *Matcher
-		prefix  string
+		matcher               *Matcher
+		prefix                string
+		caseInsensitivePrefix bool
 	}{
 		{
 			matcher: mustNewMatcher(t, MatchEqual, "abc"),
@@ -180,9 +181,15 @@ func TestPrefix(t *testing.T) {
 			matcher: mustNewMatcher(t, MatchRegexp, ".+def"),
 			prefix:  "",
 		},
+		{
+			matcher:               mustNewMatcher(t, MatchNotRegexp, "(?i)abc.+"),
+			prefix:                "ABC",
+			caseInsensitivePrefix: true,
+		},
 	} {
 		t.Run(fmt.Sprintf("%d: %s", i, tc.matcher), func(t *testing.T) {
 			require.Equal(t, tc.prefix, tc.matcher.Prefix())
+			require.Equal(t, tc.caseInsensitivePrefix, tc.matcher.HasCaseInsensitivePrefix())
 		})
 	}
 }

--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -27,6 +27,13 @@ func mustNewMatcher(t *testing.T, mType MatchType, value string) *Matcher {
 	return m
 }
 
+func (m *Matcher) hasCaseInsensitivePrefix() bool {
+	if m.re == nil {
+		return false
+	}
+	return m.re.caseInsensitivePrefix
+}
+
 func TestMatcher(t *testing.T) {
 	tests := []struct {
 		matcher *Matcher
@@ -189,7 +196,7 @@ func TestPrefix(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%d: %s", i, tc.matcher), func(t *testing.T) {
 			require.Equal(t, tc.prefix, tc.matcher.Prefix())
-			require.Equal(t, tc.caseInsensitivePrefix, tc.matcher.HasCaseInsensitivePrefix())
+			require.Equal(t, tc.caseInsensitivePrefix, tc.matcher.hasCaseInsensitivePrefix())
 		})
 	}
 }

--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -46,6 +46,9 @@ type FastRegexMatcher struct {
 	suffix        string
 	contains      []string
 
+	// caseInsensitivePrefix is true if prefix exists and should be matched case-insensitively
+	caseInsensitivePrefix bool
+
 	// matchString is the "compiled" function to run by MatchString().
 	matchString func(string) bool
 }
@@ -79,7 +82,7 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 		clearCapture(parsed)
 
 		if parsed.Op == syntax.OpConcat {
-			m.prefix, m.suffix, m.contains = optimizeConcatRegex(parsed)
+			m.caseInsensitivePrefix, m.prefix, m.suffix, m.contains = optimizeConcatRegex(parsed)
 		}
 		if matches, caseSensitive := findSetMatches(parsed); caseSensitive {
 			m.setMatches = matches
@@ -107,6 +110,15 @@ func (m *FastRegexMatcher) compileMatchStringFunction() func(string) bool {
 	// If the only optimization available is the string matcher, then we can just run it.
 	if len(m.setMatches) == 0 && m.prefix == "" && m.suffix == "" && len(m.contains) == 0 && m.stringMatcher != nil {
 		return m.stringMatcher.Matches
+	}
+
+	if m.caseInsensitivePrefix && m.prefix != "" {
+		return func(s string) bool {
+			if !hasPrefixCaseInsensitive(s, m.prefix) {
+				return false
+			}
+			return m.re.MatchString(s)
+		}
 	}
 
 	return func(s string) bool {
@@ -411,7 +423,7 @@ func optimizeAlternatingSimpleContains(r *syntax.Regexp) *syntax.Regexp {
 
 // optimizeConcatRegex returns literal prefix/suffix text that can be safely
 // checked against the label value before running the regexp matcher.
-func optimizeConcatRegex(r *syntax.Regexp) (prefix, suffix string, contains []string) {
+func optimizeConcatRegex(r *syntax.Regexp) (caseInsensitivePrefix bool, prefix, suffix string, contains []string) {
 	sub := r.Sub
 	clearCapture(sub...)
 
@@ -425,14 +437,15 @@ func optimizeConcatRegex(r *syntax.Regexp) (prefix, suffix string, contains []st
 	}
 
 	if len(sub) == 0 {
-		return prefix, suffix, contains
+		return caseInsensitivePrefix, prefix, suffix, contains
 	}
 
 	// Given Prometheus regex matchers are always anchored to the begin/end
 	// of the text, if the first/last operations are literals, we can safely
 	// treat them as prefix/suffix.
-	if sub[0].Op == syntax.OpLiteral && (sub[0].Flags&syntax.FoldCase) == 0 {
+	if sub[0].Op == syntax.OpLiteral {
 		prefix = string(sub[0].Rune)
+		caseInsensitivePrefix = (sub[0].Flags & syntax.FoldCase) != 0
 	}
 	if last := len(sub) - 1; sub[last].Op == syntax.OpLiteral && (sub[last].Flags&syntax.FoldCase) == 0 {
 		suffix = string(sub[last].Rune)
@@ -446,7 +459,7 @@ func optimizeConcatRegex(r *syntax.Regexp) (prefix, suffix string, contains []st
 		}
 	}
 
-	return prefix, suffix, contains
+	return caseInsensitivePrefix, prefix, suffix, contains
 }
 
 // StringMatcher is a matcher that matches a string in place of a regular expression.

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -47,6 +47,7 @@ var (
 		".*foo.*",
 		".+foo.+",
 		".*foo.*|",
+		"(?i).*foo.*",
 		".*foo.*|bar.*",
 		"foo.*|.*bar.*",
 		".*foo.*|.*bar.*",
@@ -67,6 +68,8 @@ var (
 		"10\\.0\\.(1|2)\\.+",
 		"10\\.0\\.(1|2).+",
 		"((fo(bar))|.+foo)",
+		"(?i)report.scheduled.job_runscheduledreports",
+		"report.scheduled.job_runscheduledreports",
 		// A long case sensitive alternation.
 		"zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKMimS|IecrXtPa|seTckYqt|NxnyHkgB|fIDlOgKb|UhlWIygH|OtNoJxHG|cUTkFVIV|mTgFIHjr|jQkoIDtE|PPMKxRXl|AwMfwVkQ|CQyMrTQJ|BzrqxVSi|nTpcWuhF|PertdywG|ZZDgCtXN|WWdDPyyE|uVtNQsKk|BdeCHvPZ|wshRnFlH|aOUIitIp|RxZeCdXT|CFZMslCj|AVBZRDxl|IzIGCnhw|ythYuWiz|oztXVXhl|VbLkwqQx|qvaUgyVC|VawUjPWC|ecloYJuj|boCLTdSU|uPrKeAZx|hrMWLWBq|JOnUNHRM|rYnujkPq|dDEdZhIj|DRrfvugG|yEGfDxVV|YMYdJWuP|PHUQZNWM|AmKNrLis|zTxndVfn|FPsHoJnc|EIulZTua|KlAPhdzg|ScHJJCLt|NtTfMzME|eMCwuFdo|SEpJVJbR|cdhXZeCx|sAVtBwRh|kVFEVcMI|jzJrxraA|tGLHTell|NNWoeSaw|DcOKSetX|UXZAJyka|THpMphDP|rizheevl|kDCBRidd|pCZZRqyu|pSygkitl|SwZGkAaW|wILOrfNX|QkwVOerj|kHOMxPDr|EwOVycJv|AJvtzQFS|yEOjKYYB|LizIINLL|JBRSsfcG|YPiUqqNl|IsdEbvee|MjEpGcBm|OxXZVgEQ|xClXGuxa|UzRCGFEb|buJbvfvA|IPZQxRet|oFYShsMc|oBHffuHO|bzzKrcBR|KAjzrGCl|IPUsAVls|OGMUMbIU|gyDccHuR|bjlalnDd|ZLWjeMna|fdsuIlxQ|dVXtiomV|XxedTjNg|XWMHlNoA|nnyqArQX|opfkWGhb|wYtnhdYb",
 		// An extremely long case sensitive alternation. This is a special
@@ -108,6 +111,7 @@ var (
 		"foo", " foo bar", "bar", "buzz\nbar", "bar foo", "bfoo", "\n", "\nfoo", "foo\n", "hello foo world", "hello foo\n world", "",
 		"FOO", "Foo", "fOo", "foO", "OO", "Oo", "\nfoo\n", strings.Repeat("f", 20), "prometheus", "prometheus_api_v1", "prometheus_api_v1_foo",
 		"10.0.1.20", "10.0.2.10", "10.0.3.30", "10.0.4.40",
+		"report.scheduled.job_runscheduledreports", "Report.Scheduled.JobRunScheduledReports", "Report.Scheduled.Job_RunScheduledReports",
 		"foofoo0", "foofoo", "😀foo0", "ſſs", "ſſS", "AAAAAAAAAAAAAAAAAAAAAAAA", "BBBBBBBBBBBBBBBBBBBBBBBB", "cccccccccccccccccccccccC", "ſſſſſſſſſſſſſſſſſſſſſſſſS", "SSSSSSSSSSSSSSSSSSSSSSSSſ",
 		"a-b-c-d-e",
 		"aaaaaa-bbbbbb-cccccc-dddddd-eeeeee",
@@ -154,10 +158,11 @@ func readable(s string) string {
 
 func TestOptimizeConcatRegex(t *testing.T) {
 	cases := []struct {
-		regex    string
-		prefix   string
-		suffix   string
-		contains []string
+		regex                   string
+		prefix                  string
+		isCaseInsensitivePrefix bool
+		suffix                  string
+		contains                []string
 	}{
 		{regex: "foo(hello|bar)", prefix: "foo", suffix: "", contains: nil},
 		{regex: "foo(hello|bar)world", prefix: "foo", suffix: "world", contains: nil},
@@ -171,12 +176,12 @@ func TestOptimizeConcatRegex(t *testing.T) {
 		{regex: ".*[abc].*", prefix: "", suffix: "", contains: nil},
 		{regex: ".*((?i)abc).*", prefix: "", suffix: "", contains: nil},
 		{regex: ".*(?i:abc).*", prefix: "", suffix: "", contains: nil},
-		{regex: "(?i:abc).*", prefix: "", suffix: "", contains: nil},
+		{regex: "(?i:abc).*", prefix: "ABC", isCaseInsensitivePrefix: true, suffix: "", contains: nil},
 		{regex: ".*(?i:abc)", prefix: "", suffix: "", contains: nil},
 		{regex: ".*(?i:abc)def.*", prefix: "", suffix: "", contains: []string{"def"}},
 		{regex: "(?i).*(?-i:abc)def", prefix: "", suffix: "", contains: []string{"abc"}},
 		{regex: ".*(?msU:abc).*", prefix: "", suffix: "", contains: []string{"abc"}},
-		{regex: "[aA]bc.*", prefix: "", suffix: "", contains: []string{"bc"}},
+		{regex: "[aA]bc.*", prefix: "A", isCaseInsensitivePrefix: true, suffix: "", contains: []string{"bc"}},
 		{regex: "^5..$", prefix: "5", suffix: "", contains: nil},
 		{regex: "^release.*", prefix: "release", suffix: "", contains: nil},
 		{regex: "^env-[0-9]+laio[1]?[^0-9].*", prefix: "env-", suffix: "", contains: []string{"laio"}},
@@ -184,13 +189,16 @@ func TestOptimizeConcatRegex(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		parsed, err := syntax.Parse(c.regex, syntax.Perl|syntax.DotNL)
-		require.NoError(t, err)
+		t.Run(c.regex, func(t *testing.T) {
+			parsed, err := syntax.Parse(c.regex, syntax.Perl|syntax.DotNL)
+			require.NoError(t, err)
 
-		prefix, suffix, contains := optimizeConcatRegex(parsed)
-		require.Equal(t, c.prefix, prefix)
-		require.Equal(t, c.suffix, suffix)
-		require.Equal(t, c.contains, contains)
+			caseInsensitivePrefix, prefix, suffix, contains := optimizeConcatRegex(parsed)
+			require.Equal(t, c.prefix, prefix)
+			require.Equal(t, c.isCaseInsensitivePrefix, caseInsensitivePrefix)
+			require.Equal(t, c.suffix, suffix)
+			require.Equal(t, c.contains, contains)
+		})
 	}
 }
 
@@ -432,6 +440,8 @@ func TestNewFastRegexMatcher(t *testing.T) {
 		{"foo.?", &literalPrefixSensitiveStringMatcher{prefix: "foo", right: &zeroOrOneCharacterStringMatcher{matchNL: true}}},
 		{"f.?o", nil},
 		{".*foo.*|.*bar.*|.*baz.*", &containsStringMatcher{left: trueMatcher{}, substrings: []string{"foo", "bar", "baz"}, right: trueMatcher{}}},
+		{"(?i)report.scheduled.job_runscheduledreports", nil},
+		{"report.scheduled.job_runscheduledreports", nil},
 	} {
 		t.Run(c.pattern, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

This change adds support for case-insensitive prefix matching, with the goal of especially improving performance when evaluating long case-insensitive regexes, without degrading performance particularly in other cases.

Note the benchmark results for `report.scheduled.job_runscheduledreports` vs `(?i)report.scheduled.job_runscheduledreports`. The case-insensitive regular expression takes ~twice as long to evaulate in the original case, and introducing this change brings them much closer together in performance.

<details><summary>BenchmarkFastRegexMatcher results</summary>

```
% benchstat original.txt case_insensitive_prefix.txt   
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Apple M2 Pro
                                                        │ original.txt  │      case_insensitive_prefix.txt      │
                                                        │    sec/op     │    sec/op      vs base                │
FastRegexMatcher/#00-10                                    54.71n ±  0%    56.28n ±  4%   +2.88% (p=0.000 n=10)
FastRegexMatcher/foo-10                                    57.67n ±  0%    59.57n ±  7%   +3.31% (p=0.000 n=10)
FastRegexMatcher/^foo-10                                   66.55n ±  0%    67.36n ±  3%   +1.21% (p=0.000 n=10)
FastRegexMatcher/(foo|bar)-10                              81.71n ±  1%    82.45n ±  2%   +0.91% (p=0.000 n=10)
FastRegexMatcher/foo.*-10                                  95.87n ±  1%    98.80n ±  2%   +3.05% (p=0.001 n=10)
FastRegexMatcher/.*foo-10                                  112.0n ±  0%    113.7n ±  2%        ~ (p=0.100 n=10)
FastRegexMatcher/^.*foo$-10                                111.9n ±  1%    113.4n ±  2%        ~ (p=0.159 n=10)
FastRegexMatcher/^.+foo$-10                                112.5n ±  1%    112.4n ± 10%        ~ (p=0.957 n=10)
FastRegexMatcher/.?-10                                     78.31n ±  0%    78.85n ±  3%   +0.69% (p=0.000 n=10)
FastRegexMatcher/.*-10                                     53.75n ±  0%    54.69n ±  2%   +1.75% (p=0.000 n=10)
FastRegexMatcher/.+-10                                     56.03n ±  0%    57.16n ±  8%   +2.01% (p=0.002 n=10)
FastRegexMatcher/foo.+-10                                  96.27n ±  0%    97.41n ±  1%   +1.18% (p=0.000 n=10)
FastRegexMatcher/.+foo-10                                  113.4n ±  1%    111.8n ±  7%        ~ (p=0.137 n=10)
FastRegexMatcher/foo_.+-10                                 87.00n ±  0%    88.52n ±  2%   +1.74% (p=0.000 n=10)
FastRegexMatcher/foo_.*-10                                 87.03n ±  0%    88.17n ±  0%   +1.32% (p=0.000 n=10)
FastRegexMatcher/.*foo.*-10                                172.8n ±  0%    169.1n ±  1%   -2.11% (p=0.000 n=10)
FastRegexMatcher/.+foo.+-10                                205.2n ±  3%    201.1n ±  7%        ~ (p=0.105 n=10)
FastRegexMatcher/.*foo.*|-10                               244.3n ±  1%    246.2n ±  1%   +0.80% (p=0.000 n=10)
FastRegexMatcher/.*foo.*|bar.*-10                          281.9n ±  0%    287.1n ±  5%   +1.84% (p=0.000 n=10)
FastRegexMatcher/foo.*|.*bar.*-10                          280.2n ±  0%    284.3n ±  3%   +1.46% (p=0.000 n=10)
FastRegexMatcher/.*foo.*|.*bar.*-10                        297.3n ±  0%    298.3n ±  2%   +0.34% (p=0.030 n=10)
FastRegexMatcher/.*foo.*bar.*|.*hello.*-10                 13.77µ ±  0%    13.79µ ±  1%        ~ (p=0.516 n=10)
FastRegexMatcher/.*foo.*|.*bar.*|.*hello.*-10              486.6n ±  8%    490.9n ±  3%        ~ (p=0.564 n=10)
FastRegexMatcher/.+.*foo.*|.*bar.*-10                      16.06µ ±  1%    16.19µ ±  1%   +0.81% (p=0.009 n=10)
FastRegexMatcher/(?s:.*)-10                                53.60n ±  1%    54.44n ±  0%   +1.56% (p=0.000 n=10)
FastRegexMatcher/(?s:.+)-10                                56.15n ±  1%    56.81n ±  5%        ~ (p=0.393 n=10)
FastRegexMatcher/(?s:^.*foo$)-10                           113.5n ±  1%    111.6n ±  1%   -1.67% (p=0.001 n=10)
FastRegexMatcher/(?i:foo)-10                               81.41n ±  0%    82.18n ±  2%   +0.95% (p=0.001 n=10)
FastRegexMatcher/(?i:(foo|bar))-10                         169.6n ±  1%    170.4n ± 11%   +0.44% (p=0.019 n=10)
FastRegexMatcher/(?i:(foo1|foo2|bar))-10                   299.0n ±  1%    302.8n ±  2%   +1.25% (p=0.000 n=10)
FastRegexMatcher/^(?i:foo|oo)|(bar)$-10                    743.0n ± 14%    743.1n ±  6%        ~ (p=0.529 n=10)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-10       632.8n ±  4%    612.1n ±  5%   -3.26% (p=0.034 n=10)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-10            469.5n ±  9%    462.4n ±  1%   -1.50% (p=0.007 n=10)
FastRegexMatcher/^$-10                                     54.77n ±  2%    54.93n ±  1%        ~ (p=0.306 n=10)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-10        173.3n ±  0%    174.2n ±  6%        ~ (p=0.066 n=10)
FastRegexMatcher/10\.0\.(1|2)\.+-10                        87.20n ±  1%    87.57n ±  0%   +0.42% (p=0.029 n=10)
FastRegexMatcher/10\.0\.(1|2).+-10                         87.53n ±  3%    88.56n ±  3%   +1.17% (p=0.015 n=10)
FastRegexMatcher/((fo(bar))|.+foo)-10                      211.9n ±  0%    205.5n ±  2%   -3.04% (p=0.001 n=10)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-10       186.8n ± 15%    179.7n ± 10%        ~ (p=0.143 n=10)
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-10       188.8n ±  9%    184.2n ± 11%        ~ (p=0.616 n=10)
FastRegexMatcher/.*zQPbMkNO.*|.*NNSPdvMi.*|.*iWuu-10       11.86µ ±  1%    11.89µ ±  4%        ~ (p=0.143 n=10)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-10       621.4n ±  4%    610.2n ±  2%        ~ (p=0.137 n=10)
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-10       374.6n ±  0%    383.8n ±  8%   +2.47% (p=0.045 n=10)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-10       269.5n ±  0%    269.4n ±  1%        ~ (p=0.809 n=10)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-10    445.2n ±  1%    452.0n ±  2%   +1.52% (p=0.003 n=10)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-10       7.513µ ±  1%    7.544µ ±  3%   +0.41% (p=0.030 n=10)
FastRegexMatcher/fo.?-10                                   97.56n ±  0%    99.16n ±  4%   +1.64% (p=0.000 n=10)
FastRegexMatcher/foo.?-10                                  97.60n ±  0%   101.75n ±  4%   +4.25% (p=0.000 n=10)
FastRegexMatcher/f.?o-10                                   81.08n ±  1%    81.95n ±  1%   +1.09% (p=0.043 n=10)
FastRegexMatcher/.*foo.?-10                                202.5n ±  0%    221.0n ± 18%   +9.16% (p=0.021 n=10)
FastRegexMatcher/.?foo.+-10                                196.5n ±  0%    198.6n ±  3%        ~ (p=0.313 n=10)
FastRegexMatcher/foo.?|bar-10                              159.1n ±  4%    154.8n ±  1%   -2.64% (p=0.000 n=10)
FastRegexMatcher/ſſs-10                                    57.97n ±  0%    58.80n ±  3%   +1.44% (p=0.000 n=10)
FastRegexMatcher/.*-.*-.*-.*-.*-10                         200.3n ±  1%    186.8n ±  4%   -6.76% (p=0.000 n=10)
FastRegexMatcher/.+-.*-.*-.*-.+-10                         199.6n ±  1%    184.8n ±  4%   -7.39% (p=0.000 n=10)
FastRegexMatcher/-.*-.*-.*-.*-10                           98.13n ±  1%   102.85n ±  9%   +4.81% (p=0.023 n=10)
FastRegexMatcher/.*-.*-.*-.*--10                           115.1n ±  0%    122.2n ± 21%   +6.13% (p=0.004 n=10)
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-10               199.5n ±  2%    187.7n ± 11%        ~ (p=0.118 n=10)
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-10       4.335µ ±  0%    4.572µ ± 23%   +5.47% (p=0.000 n=10)
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-10       3.548µ ±  0%    3.694µ ± 12%   +4.11% (p=0.000 n=10)
FastRegexMatcher/(.*0.*)-10                                131.0n ±  1%    117.0n ±  1%  -10.68% (p=0.000 n=10)
FastRegexMatcher/(?i).*foo.*-10                            7.654µ ±  0%    7.732µ ±  2%   +1.01% (p=0.003 n=10)
FastRegexMatcher/(?i)report.scheduled.job_runsche-10      168.85n ±  0%    78.73n ±  2%  -53.37% (p=0.000 n=10)
FastRegexMatcher/report.scheduled.job_runschedule-10       87.39n ±  0%    87.81n ±  1%   +0.49% (p=0.003 n=10)
FastRegexMatcher/(?i).*zQPbMkNO.*|.*NNSPdvMi.*|.*-10       1.154m ±  0%    1.155m ±  5%        ~ (p=0.529 n=10)
FastRegexMatcher/(?i).*/label/.*|.*/labels.*|.*/s-10       19.23µ ±  1%    19.18µ ±  4%        ~ (p=0.271 n=10)
FastRegexMatcher/.*/label/.*|.*/labels.*|.*/serie-10       386.8n ±  5%    375.3n ±  3%        ~ (p=0.109 n=10)
geomean                                                    273.9n          271.6n         -0.84%
```

</details>

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
