### PR TITLE
tsdb: skip entire stripes in mmapHeadChunks via per-stripe ready count

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1028,6 +1028,9 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 			// The head chunk was completed and was m-mapped after taking the snapshot.
 			// Hence remove this chunk.
 			ms.nextAt = 0
+			if ms.headChunkCount.Load() >= 2 {
+				h.series.mmapReady[h.series.refStripe(ms.ref)].Add(-1)
+			}
 			ms.headChunks = nil
 			ms.headChunkCount.Store(0)
 			ms.app = nil
@@ -1946,6 +1949,10 @@ func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, l
 func (h *Head) mmapHeadChunks() {
 	var count int
 	for i := range h.series.size {
+		if h.series.mmapReady[i].Load() == 0 {
+			continue // No series in this stripe need mmapping.
+		}
+
 		h.series.locks[i].RLock()
 		for _, series := range h.series.series[i] {
 			if series.headChunkCount.Load() < 2 { // < 2 means 0 or 1 head chunks, nothing to mmap.
@@ -1953,8 +1960,12 @@ func (h *Head) mmapHeadChunks() {
 			}
 
 			series.Lock()
-			count += series.mmapChunks(h.chunkDiskMapper)
+			n := series.mmapChunks(h.chunkDiskMapper)
 			series.Unlock()
+			if n > 0 {
+				count += n
+				h.series.mmapReady[i].Add(-1)
+			}
 		}
 		h.series.locks[i].RUnlock()
 	}
@@ -2048,6 +2059,7 @@ type stripeSeries struct {
 	series                  []map[chunks.HeadSeriesRef]*memSeries // Sharded by ref. A series ref is the value of `size` when the series was being newly added.
 	hashes                  []seriesHashmap                       // Sharded by label hash.
 	locks                   []stripeLock                          // Sharded by ref for series access, by label hash for hashes access.
+	mmapReady               []paddedAtomicInt32                   // Per-stripe count of series with headChunkCount >= 2 (ready for mmapping).
 	seriesLifecycleCallback SeriesLifecycleCallback
 }
 
@@ -2057,12 +2069,20 @@ type stripeLock struct {
 	_ [40]byte
 }
 
+// paddedAtomicInt32 is an atomic int32 padded to 64 bytes to avoid false sharing.
+type paddedAtomicInt32 struct {
+	stdatomic.Int32
+	// Padding to avoid multiple counters being on the same cache line.
+	_ [60]byte
+}
+
 func newStripeSeries(stripeSize int, seriesCallback SeriesLifecycleCallback) *stripeSeries {
 	s := &stripeSeries{
 		size:                    stripeSize,
 		series:                  make([]map[chunks.HeadSeriesRef]*memSeries, stripeSize),
 		hashes:                  make([]seriesHashmap, stripeSize),
 		locks:                   make([]stripeLock, stripeSize),
+		mmapReady:               make([]paddedAtomicInt32, stripeSize),
 		seriesLifecycleCallback: seriesCallback,
 	}
 
@@ -2100,7 +2120,11 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		series.Lock()
 		defer series.Unlock()
 
+		wasMmapReady := series.headChunkCount.Load() >= 2
 		rmChunks += series.truncateChunksBefore(mint, minOOOMmapRef)
+		if wasMmapReady && series.headChunkCount.Load() < 2 {
+			s.mmapReady[s.refStripe(series.ref)].Add(-1)
+		}
 
 		if len(series.mmappedChunks) > 0 {
 			seq, _ := series.mmappedChunks[0].ref.Unpack()
@@ -2244,6 +2268,9 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		if series.headChunks != nil {
 			chunksRemoved += series.headChunks.len()
 		}
+		if series.headChunkCount.Load() >= 2 {
+			h.series.mmapReady[refShard].Add(-1)
+		}
 		// Clear to prevent a double-subtraction from the chunksRemoved gauge if
 		// resetSeriesWithMMappedChunks is queued on the same WAL-replay processor
 		// after this deletion (it would otherwise subtract len(mmappedChunks) again).
@@ -2313,6 +2340,9 @@ func (s *stripeSeries) gcStaleSeries(seriesRefs []storage.SeriesRef, maxt int64)
 		// If we don't hold them all, there's a very small chance that a series receives
 		// samples again while we are half-way into deleting it.
 		refShard := s.refStripe(series.ref)
+		if series.headChunkCount.Load() >= 2 {
+			s.mmapReady[refShard].Add(-1)
+		}
 		if hashShard != refShard {
 			s.locks[refShard].Lock()
 			defer s.locks[refShard].Unlock()

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2137,7 +2137,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		// series alike.
 		// If we don't hold them all, there's a very small chance that a series receives
 		// samples again while we are half-way into deleting it.
-		refShard := int(series.ref) & (s.size - 1)
+		refShard := s.refStripe(series.ref)
 		if hashShard != refShard {
 			s.locks[refShard].Lock()
 			defer s.locks[refShard].Unlock()
@@ -2217,7 +2217,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 	for _, ref := range refs {
 		// Delete the reference from the series map.
 		// Copying getByID here to avoid locking and unlocking twice.
-		refShard := int(ref) & (h.series.size - 1)
+		refShard := h.series.refStripe(ref)
 		h.series.locks[refShard].Lock()
 		series := h.series.series[refShard][ref]
 		if series == nil {
@@ -2312,7 +2312,7 @@ func (s *stripeSeries) gcStaleSeries(seriesRefs []storage.SeriesRef, maxt int64)
 		// series alike.
 		// If we don't hold them all, there's a very small chance that a series receives
 		// samples again while we are half-way into deleting it.
-		refShard := int(series.ref) & (s.size - 1)
+		refShard := s.refStripe(series.ref)
 		if hashShard != refShard {
 			s.locks[refShard].Lock()
 			defer s.locks[refShard].Unlock()
@@ -2359,8 +2359,13 @@ func (s *stripeSeries) iterForDeletion(checkDeletedFunc func(int, uint64, *memSe
 	return totalDeletedSeries
 }
 
+// refStripe returns the stripe index for the given series ref.
+func (s *stripeSeries) refStripe(ref chunks.HeadSeriesRef) int {
+	return int(uint64(ref) & uint64(s.size-1))
+}
+
 func (s *stripeSeries) getByID(id chunks.HeadSeriesRef) *memSeries {
-	i := uint64(id) & uint64(s.size-1)
+	i := s.refStripe(id)
 
 	s.locks[i].RLock()
 	series := s.series[i][id]
@@ -2389,11 +2394,11 @@ func (s *stripeSeries) setUnlessAlreadySet(hash uint64, lset labels.Labels, seri
 	s.hashes[i].set(hash, series)
 	s.locks[i].Unlock()
 
-	i = uint64(series.ref) & uint64(s.size-1)
+	refShard := s.refStripe(series.ref)
 
-	s.locks[i].Lock()
-	s.series[i][series.ref] = series
-	s.locks[i].Unlock()
+	s.locks[refShard].Lock()
+	s.series[refShard][series.ref] = series
+	s.locks[refShard].Unlock()
 
 	return series, true
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1029,7 +1029,7 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 			// Hence remove this chunk.
 			ms.nextAt = 0
 			if ms.headChunkCount.Load() >= 2 {
-				h.series.mmapReady[h.series.refStripe(ms.ref)].Add(-1)
+				h.series.decMmapReady(ms.ref)
 			}
 			ms.headChunks = nil
 			ms.headChunkCount.Store(0)
@@ -1964,7 +1964,7 @@ func (h *Head) mmapHeadChunks() {
 			series.Unlock()
 			if n > 0 {
 				count += n
-				h.series.mmapReady[i].Add(-1)
+				h.series.decMmapReady(series.ref)
 			}
 		}
 		h.series.locks[i].RUnlock()
@@ -2123,7 +2123,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		wasMmapReady := series.headChunkCount.Load() >= 2
 		rmChunks += series.truncateChunksBefore(mint, minOOOMmapRef)
 		if wasMmapReady && series.headChunkCount.Load() < 2 {
-			s.mmapReady[s.refStripe(series.ref)].Add(-1)
+			s.decMmapReady(series.ref)
 		}
 
 		if len(series.mmappedChunks) > 0 {
@@ -2161,10 +2161,10 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		// series alike.
 		// If we don't hold them all, there's a very small chance that a series receives
 		// samples again while we are half-way into deleting it.
-		refShard := s.refStripe(series.ref)
-		if hashShard != refShard {
-			s.locks[refShard].Lock()
-			defer s.locks[refShard].Unlock()
+		stripe := s.refStripe(series.ref)
+		if hashShard != stripe {
+			s.locks[stripe].Lock()
+			defer s.locks[stripe].Unlock()
 		}
 
 		if value.IsStaleNaN(series.lastValue) ||
@@ -2176,7 +2176,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
 		s.hashes[hashShard].del(hash, series.ref)
-		delete(s.series[refShard], series.ref)
+		delete(s.series[stripe], series.ref)
 		deletedForCallback[series.ref] = series.lset // OK to access lset; series is locked at the top of this function.
 	}
 
@@ -2241,22 +2241,22 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 	for _, ref := range refs {
 		// Delete the reference from the series map.
 		// Copying getByID here to avoid locking and unlocking twice.
-		refShard := h.series.refStripe(ref)
-		h.series.locks[refShard].Lock()
-		series := h.series.series[refShard][ref]
+		stripe := h.series.refStripe(ref)
+		h.series.locks[stripe].Lock()
+		series := h.series.series[stripe][ref]
 		if series == nil {
-			h.series.locks[refShard].Unlock()
+			h.series.locks[stripe].Unlock()
 			continue
 		}
-		delete(h.series.series[refShard], series.ref)
-		h.series.locks[refShard].Unlock()
+		delete(h.series.series[stripe], series.ref)
+		h.series.locks[stripe].Unlock()
 
 		// Delete the reference from the hash.
 		hash := series.lset.Hash()
-		hashShard := int(hash) & (h.series.size - 1)
-		h.series.locks[hashShard].Lock()
-		h.series.hashes[hashShard].del(hash, series.ref)
-		h.series.locks[hashShard].Unlock()
+		hashStripe := int(hash) & (h.series.size - 1)
+		h.series.locks[hashStripe].Lock()
+		h.series.hashes[hashStripe].del(hash, series.ref)
+		h.series.locks[hashStripe].Unlock()
 
 		if value.IsStaleNaN(series.lastValue) ||
 			(series.lastHistogramValue != nil && value.IsStaleNaN(series.lastHistogramValue.Sum)) ||
@@ -2269,7 +2269,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 			chunksRemoved += series.headChunks.len()
 		}
 		if series.headChunkCount.Load() >= 2 {
-			h.series.mmapReady[refShard].Add(-1)
+			h.series.decMmapReady(series.ref)
 		}
 		// Clear to prevent a double-subtraction from the chunksRemoved gauge if
 		// resetSeriesWithMMappedChunks is queued on the same WAL-replay processor
@@ -2339,19 +2339,19 @@ func (s *stripeSeries) gcStaleSeries(seriesRefs []storage.SeriesRef, maxt int64)
 		// series alike.
 		// If we don't hold them all, there's a very small chance that a series receives
 		// samples again while we are half-way into deleting it.
-		refShard := s.refStripe(series.ref)
+		stripe := s.refStripe(series.ref)
 		if series.headChunkCount.Load() >= 2 {
-			s.mmapReady[refShard].Add(-1)
+			s.decMmapReady(series.ref)
 		}
-		if hashShard != refShard {
-			s.locks[refShard].Lock()
-			defer s.locks[refShard].Unlock()
+		if hashShard != stripe {
+			s.locks[stripe].Lock()
+			defer s.locks[stripe].Unlock()
 		}
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
 		s.hashes[hashShard].del(hash, series.ref)
-		delete(s.series[refShard], series.ref)
+		delete(s.series[stripe], series.ref)
 		deletedForCallback[series.ref] = series.lset // OK to access lset; series is locked at the top of this function.
 	}
 
@@ -2394,6 +2394,16 @@ func (s *stripeSeries) refStripe(ref chunks.HeadSeriesRef) int {
 	return int(uint64(ref) & uint64(s.size-1))
 }
 
+// incMmapReady increments the per-stripe mmap-ready counter for the given series.
+func (s *stripeSeries) incMmapReady(ref chunks.HeadSeriesRef) {
+	s.mmapReady[s.refStripe(ref)].Add(1)
+}
+
+// decMmapReady decrements the per-stripe mmap-ready counter for the given series.
+func (s *stripeSeries) decMmapReady(ref chunks.HeadSeriesRef) {
+	s.mmapReady[s.refStripe(ref)].Add(-1)
+}
+
 func (s *stripeSeries) getByID(id chunks.HeadSeriesRef) *memSeries {
 	i := s.refStripe(id)
 
@@ -2424,11 +2434,11 @@ func (s *stripeSeries) setUnlessAlreadySet(hash uint64, lset labels.Labels, seri
 	s.hashes[i].set(hash, series)
 	s.locks[i].Unlock()
 
-	refShard := s.refStripe(series.ref)
+	stripe := s.refStripe(series.ref)
 
-	s.locks[refShard].Lock()
-	s.series[refShard][series.ref] = series
-	s.locks[refShard].Unlock()
+	s.locks[stripe].Lock()
+	s.series[stripe][series.ref] = series
+	s.locks[stripe].Unlock()
 
 	return series, true
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1937,13 +1937,13 @@ func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, l
 	return s, true, nil
 }
 
-// onChunkCreated records the side-effects of creating a new head chunk for
-// the given series: it bumps the chunk metrics and, when the chunk brings
-// the series to two head chunks, marks the series as ready for mmapping.
-func (h *Head) onChunkCreated(series *memSeries) {
+// onChunkCreated bumps the head chunk metrics for any newly created chunk, in-order or OOO.
+// If prevHeadChunkCount < 2 and series.headChunkCount == 2, the corresponding
+// stripe's count of mmap ready series is incremented.
+func (h *Head) onChunkCreated(series *memSeries, prevHeadChunkCount uint32) {
 	h.metrics.chunks.Inc()
 	h.metrics.chunksCreated.Inc()
-	if series.headChunkCount.Load() == 2 {
+	if prevHeadChunkCount < 2 && series.headChunkCount.Load() == 2 {
 		h.series.incMmapReady(series.ref)
 	}
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1025,8 +1025,9 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 		})
 		h.updateMinMaxTime(mint, maxt)
 		if ms.headChunks != nil && maxt >= ms.headChunks.minTime {
-			// The head chunk was completed and was m-mapped after taking the snapshot.
-			// Hence remove this chunk.
+			// The most recent head chunk was completed and m-mapped after the snapshot
+			// was taken, so its samples are now covered by the mmapped chunk we just
+			// loaded. Drop the in-memory head chunk chain.
 			ms.nextAt = 0
 			if ms.headChunkCount.Load() >= 2 {
 				h.series.decMmapReady(ms.ref)
@@ -1934,6 +1935,17 @@ func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, l
 	h.series.postCreation(lset)
 
 	return s, true, nil
+}
+
+// onChunkCreated records the side-effects of creating a new head chunk for
+// the given series: it bumps the chunk metrics and, when the chunk brings
+// the series to two head chunks, marks the series as ready for mmapping.
+func (h *Head) onChunkCreated(series *memSeries) {
+	h.metrics.chunks.Inc()
+	h.metrics.chunksCreated.Inc()
+	if series.headChunkCount.Load() == 2 {
+		h.series.incMmapReady(series.ref)
+	}
 }
 
 // mmapHeadChunks iterates all memSeries stored on Head ready for m-mapping and calls

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1459,7 +1459,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			a.head.metrics.chunks.Inc()
 			a.head.metrics.chunksCreated.Inc()
 			if series.headChunkCount.Load() == 2 {
-				a.head.series.mmapReady[a.head.series.refStripe(series.ref)].Add(1)
+				a.head.series.incMmapReady(series.ref)
 			}
 		}
 
@@ -1573,7 +1573,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 			a.head.metrics.chunks.Inc()
 			a.head.metrics.chunksCreated.Inc()
 			if series.headChunkCount.Load() == 2 {
-				a.head.series.mmapReady[a.head.series.refStripe(series.ref)].Add(1)
+				a.head.series.incMmapReady(series.ref)
 			}
 		}
 
@@ -1687,7 +1687,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 			a.head.metrics.chunks.Inc()
 			a.head.metrics.chunksCreated.Inc()
 			if series.headChunkCount.Load() == 2 {
-				a.head.series.mmapReady[a.head.series.refStripe(series.ref)].Add(1)
+				a.head.series.incMmapReady(series.ref)
 			}
 		}
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1458,6 +1458,9 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		if chunkCreated {
 			a.head.metrics.chunks.Inc()
 			a.head.metrics.chunksCreated.Inc()
+			if series.headChunkCount.Load() == 2 {
+				a.head.series.mmapReady[a.head.series.refStripe(series.ref)].Add(1)
+			}
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1569,6 +1572,9 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 		if chunkCreated {
 			a.head.metrics.chunks.Inc()
 			a.head.metrics.chunksCreated.Inc()
+			if series.headChunkCount.Load() == 2 {
+				a.head.series.mmapReady[a.head.series.refStripe(series.ref)].Add(1)
+			}
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1680,6 +1686,9 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 		if chunkCreated {
 			a.head.metrics.chunks.Inc()
 			a.head.metrics.chunksCreated.Inc()
+			if series.headChunkCount.Load() == 2 {
+				a.head.series.mmapReady[a.head.series.refStripe(series.ref)].Add(1)
+			}
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1384,6 +1384,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			handleAppendableError(err, &acc.floatsAppended, &acc.floatOOORejected, &acc.floatOOBRejected, &acc.floatTooOldRejected)
 		}
 
+		prevHeadChunkCount := series.headChunkCount.Load()
 		switch {
 		case err != nil:
 			// Do nothing here.
@@ -1456,7 +1457,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		}
 
 		if chunkCreated {
-			a.head.onChunkCreated(series)
+			a.head.onChunkCreated(series, prevHeadChunkCount)
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1488,6 +1489,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
 		}
 
+		prevHeadChunkCount := series.headChunkCount.Load()
 		switch {
 		case err != nil:
 			// Do nothing here.
@@ -1566,7 +1568,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 		}
 
 		if chunkCreated {
-			a.head.onChunkCreated(series)
+			a.head.onChunkCreated(series, prevHeadChunkCount)
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1598,6 +1600,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
 		}
 
+		prevHeadChunkCount := series.headChunkCount.Load()
 		switch {
 		case err != nil:
 			// Do nothing here.
@@ -1676,7 +1679,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 		}
 
 		if chunkCreated {
-			a.head.onChunkCreated(series)
+			a.head.onChunkCreated(series, prevHeadChunkCount)
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1456,11 +1456,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		}
 
 		if chunkCreated {
-			a.head.metrics.chunks.Inc()
-			a.head.metrics.chunksCreated.Inc()
-			if series.headChunkCount.Load() == 2 {
-				a.head.series.incMmapReady(series.ref)
-			}
+			a.head.onChunkCreated(series)
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1570,11 +1566,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 		}
 
 		if chunkCreated {
-			a.head.metrics.chunks.Inc()
-			a.head.metrics.chunksCreated.Inc()
-			if series.headChunkCount.Load() == 2 {
-				a.head.series.incMmapReady(series.ref)
-			}
+			a.head.onChunkCreated(series)
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1684,11 +1676,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 		}
 
 		if chunkCreated {
-			a.head.metrics.chunks.Inc()
-			a.head.metrics.chunksCreated.Inc()
-			if series.headChunkCount.Load() == 2 {
-				a.head.series.incMmapReady(series.ref)
-			}
+			a.head.onChunkCreated(series)
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -8154,143 +8154,327 @@ func TestHead_FindLastSeriesID(t *testing.T) {
 }
 
 func TestHead_mmapHeadChunks(t *testing.T) {
-	h, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
-	require.NoError(t, h.Init(0))
+	// Interval such that one chunk's worth of samples (DefaultSamplesPerChunk) spans DefaultBlockDuration/4.
+	interval := DefaultBlockDuration / (4 * DefaultSamplesPerChunk)
+	// Enough samples to cross the nextAt boundary multiple times, producing 3 head chunks per series.
+	const chunkCutIterations = 2*DefaultSamplesPerChunk + 10
 
-	interval := DefaultBlockDuration / (4 * 120) // Same interval as other mmap tests.
+	t.Run("basic", func(t *testing.T) {
+		h, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
+		require.NoError(t, h.Init(0))
 
-	countReady := func() int {
-		n := 0
-		for i := range h.series.size {
-			h.series.locks[i].RLock()
-			for _, s := range h.series.series[i] {
-				if s.headChunkCount.Load() >= 2 {
-					n++
+		countReady := func() int {
+			n := 0
+			for i := range h.series.size {
+				h.series.locks[i].RLock()
+				for _, s := range h.series.series[i] {
+					if s.headChunkCount.Load() >= 2 {
+						n++
+					}
 				}
+				h.series.locks[i].RUnlock()
 			}
-			h.series.locks[i].RUnlock()
+			return n
 		}
-		return n
-	}
 
-	getCount := func(lbls labels.Labels) uint32 {
+		getCount := func(lbls labels.Labels) uint32 {
+			s := h.series.getByHash(lbls.Hash(), lbls)
+			require.NotNil(t, s, "series %s not found", lbls)
+			return s.headChunkCount.Load()
+		}
+
+		lblsA := labels.FromStrings("__name__", "seriesA")
+		lblsB := labels.FromStrings("__name__", "seriesB")
+		lblsC := labels.FromStrings("__name__", "seriesC")
+
+		ts := int64(0)
+
+		// First chunk creation should set headChunkCount to 1.
+		app := h.Appender(t.Context())
+		_, err := app.Append(0, lblsA, ts, 1.0)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+		ts += interval
+
+		require.Equal(t, uint32(1), getCount(lblsA), "first chunk should set headChunkCount to 1")
+		require.Equal(t, 0, countReady(), "series with only a first chunk should not be ready")
+
+		// Appending enough samples to trigger chunk cuts should update headChunkCount.
+		var refB, refC storage.SeriesRef
+		app = h.Appender(t.Context())
+		for range chunkCutIterations {
+			var err error
+			refB, err = app.Append(refB, lblsB, ts, float64(ts))
+			require.NoError(t, err)
+			refC, err = app.Append(refC, lblsC, ts, float64(ts))
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+
+		require.Equal(t, 2, countReady(), "expected both series to be marked ready")
+		// With ~2*DefaultSamplesPerChunk samples, we expect 3 head chunks (the count tracks total head chunks).
+		require.Equal(t, uint32(3), getCount(lblsB), "series B headChunkCount should reflect actual head chunk count")
+		require.Equal(t, uint32(3), getCount(lblsC), "series C headChunkCount should reflect actual head chunk count")
+
+		// mmapHeadChunks should reset headChunkCount to 1 (one head chunk remains).
+		h.mmapHeadChunks()
+
+		for _, lbls := range []labels.Labels{lblsB, lblsC} {
+			s := h.series.getByHash(lbls.Hash(), lbls)
+			require.NotNil(t, s, "series %s not found", lbls)
+			s.Lock()
+			require.NotNil(t, s.headChunks, "series %s should have head chunks", lbls)
+			require.Nil(t, s.headChunks.prev, "series %s should not have prev mmapped", lbls)
+			require.NotEmpty(t, s.mmappedChunks, "series %s should have mmapped chunks", lbls)
+			s.Unlock()
+		}
+
+		require.Equal(t, uint32(1), getCount(lblsB), "headChunkCount should be 1 after mmap")
+		require.Equal(t, uint32(1), getCount(lblsC), "headChunkCount should be 1 after mmap")
+		require.Equal(t, 0, countReady(), "ready set should be empty after mmapHeadChunks")
+
+		// A second call should be a no-op.
+		beforeMetric := prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
+		h.mmapHeadChunks()
+		afterMetric := prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
+		require.Equal(t, beforeMetric, afterMetric, "second call should mmap 0 chunks")
+
+		// Only newly ready series should be processed.
+		app = h.Appender(t.Context())
+		for range chunkCutIterations {
+			var err error
+			refB, err = app.Append(refB, lblsB, ts, float64(ts))
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+
+		require.Equal(t, 1, countReady(), "only series B should be ready")
+		require.Equal(t, uint32(3), getCount(lblsB), "series B headChunkCount should reflect new chunks")
+		require.Equal(t, uint32(1), getCount(lblsC), "series C headChunkCount should be unchanged")
+
+		beforeMetric = prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
+		h.mmapHeadChunks()
+		afterMetric = prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
+		require.Greater(t, afterMetric, beforeMetric, "third call should mmap chunks from series B")
+		require.Equal(t, uint32(1), getCount(lblsB), "series B headChunkCount should be 1 after mmap")
+	})
+
+	t.Run("ooo does not inflate count", func(t *testing.T) {
+		h, _ := newTestHead(t, DefaultBlockDuration, compression.None, true /* oooEnabled */)
+		require.NoError(t, h.Init(0))
+
+		lbls := labels.FromStrings("__name__", "test")
+		ts := int64(0)
+
+		// Create enough in-order samples to get headChunkCount >= 2.
+		var ref storage.SeriesRef
+		app := h.Appender(t.Context())
+		for range chunkCutIterations {
+			var err error
+			ref, err = app.Append(ref, lbls, ts, float64(ts))
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+
 		s := h.series.getByHash(lbls.Hash(), lbls)
-		require.NotNil(t, s, "series %s not found", lbls)
-		return s.headChunkCount.Load()
-	}
+		require.NotNil(t, s)
+		countBefore := s.headChunkCount.Load()
+		require.GreaterOrEqual(t, countBefore, uint32(2), "need multiple head chunks for this test")
 
-	lblsA := labels.FromStrings("__name__", "seriesA")
-	lblsB := labels.FromStrings("__name__", "seriesB")
-	lblsC := labels.FromStrings("__name__", "seriesC")
-
-	ts := int64(0)
-
-	// First chunk creation should set headChunkCount to 1.
-	app := h.Appender(t.Context())
-	_, err := app.Append(0, lblsA, ts, 1.0)
-	require.NoError(t, err)
-	require.NoError(t, app.Commit())
-	ts += interval
-
-	require.Equal(t, uint32(1), getCount(lblsA), "first chunk should set headChunkCount to 1")
-	require.Equal(t, 0, countReady(), "series with only a first chunk should not be ready")
-
-	const chunkCutIterations = 2*DefaultSamplesPerChunk + 10
-
-	// Appending enough samples to trigger chunk cuts should update headChunkCount.
-	var refB, refC storage.SeriesRef
-	app = h.Appender(t.Context())
-	for range chunkCutIterations {
-		var err error
-		refB, err = app.Append(refB, lblsB, ts, float64(ts))
+		// Append an OOO sample that creates an OOO chunk.
+		oooTs := ts - 5*time.Minute.Milliseconds() // Within the 10m OOO window.
+		app = h.Appender(t.Context())
+		_, err := app.Append(0, lbls, oooTs, 999.0)
 		require.NoError(t, err)
-		refC, err = app.Append(refC, lblsC, ts, float64(ts))
+		require.NoError(t, app.Commit())
+
+		// headChunkCount must not change from an OOO insert.
+		require.Equal(t, countBefore, s.headChunkCount.Load(), "OOO insert should not inflate headChunkCount")
+	})
+
+	// Verify the mmapReady per-stripe counter stays in sync with the actual
+	// number of series that have headChunkCount >= 2, across append, mmap,
+	// GC, and stale-series deletion.
+	t.Run("counter consistency", func(t *testing.T) {
+		h, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
+		require.NoError(t, h.Init(0))
+
+		// mmapReadyCounter returns the sum of mmapReady[i] across all stripes.
+		mmapReadyCounter := func() int32 {
+			var n int32
+			for i := range h.series.size {
+				n += h.series.mmapReady[i].Load()
+			}
+			return n
+		}
+		requireCounterConsistent := func(msg string) {
+			t.Helper()
+
+			var actual int32
+			for i := range h.series.size {
+				h.series.locks[i].RLock()
+				for _, s := range h.series.series[i] {
+					if s.headChunkCount.Load() >= 2 {
+						actual++
+					}
+				}
+				h.series.locks[i].RUnlock()
+			}
+			counter := mmapReadyCounter()
+			require.Equal(t, actual, counter, "%s: mmapReady counter (%d) != actual ready count (%d)", msg, counter, actual)
+		}
+
+		lblsA := labels.FromStrings("__name__", "seriesA")
+		lblsB := labels.FromStrings("__name__", "seriesB")
+		lblsC := labels.FromStrings("__name__", "seriesC")
+		lblsHist := labels.FromStrings("__name__", "seriesHist")
+		lblsFHist := labels.FromStrings("__name__", "seriesFHist")
+
+		// Phase 1: Append enough samples to create multiple head chunks.
+		// Include histogram and float-histogram series to cover commitHistograms
+		// and commitFloatHistograms increment paths.
+		ts := int64(0)
+		var refA, refB, refC, refHist, refFHist storage.SeriesRef
+		histograms := tsdbutil.GenerateTestHistograms(chunkCutIterations)
+		floatHistograms := tsdbutil.GenerateTestFloatHistograms(chunkCutIterations)
+		app := h.Appender(t.Context())
+		for i := range chunkCutIterations {
+			var err error
+			refA, err = app.Append(refA, lblsA, ts, float64(ts))
+			require.NoError(t, err)
+			refB, err = app.Append(refB, lblsB, ts, float64(ts))
+			require.NoError(t, err)
+			refC, err = app.Append(refC, lblsC, ts, float64(ts))
+			require.NoError(t, err)
+			refHist, err = app.AppendHistogram(refHist, lblsHist, ts, histograms[i], nil)
+			require.NoError(t, err)
+			refFHist, err = app.AppendHistogram(refFHist, lblsFHist, ts, nil, floatHistograms[i])
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+		requireCounterConsistent("after initial appends with chunk cuts")
+		require.Equal(t, int32(5), mmapReadyCounter(), "all five series should be ready")
+
+		// Phase 2: mmapHeadChunks should bring counter to 0.
+		h.mmapHeadChunks()
+		requireCounterConsistent("after mmapHeadChunks")
+		require.Equal(t, int32(0), mmapReadyCounter(), "counter should be 0 after mmap")
+
+		// Phase 3: Make only seriesA ready again, then GC with a mint that
+		// truncates its head chunks back to 1.
+		app = h.Appender(t.Context())
+		for range chunkCutIterations {
+			var err error
+			refA, err = app.Append(refA, lblsA, ts, float64(ts))
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+		requireCounterConsistent("after making seriesA ready again")
+		require.Equal(t, int32(1), mmapReadyCounter(), "only seriesA should be ready")
+
+		// Mmap to bring seriesA back to headChunkCount == 1, then append
+		// again so the next GC can test the counter decrement path.
+		h.mmapHeadChunks()
+		requireCounterConsistent("after second mmap")
+		require.Equal(t, int32(0), mmapReadyCounter())
+
+		// Make seriesA ready a third time, then GC at a time that truncates
+		// the mmapped chunks but not the new head chunks.
+		app = h.Appender(t.Context())
+		for range chunkCutIterations {
+			var err error
+			refA, err = app.Append(refA, lblsA, ts, float64(ts))
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+		requireCounterConsistent("after third round of appends")
+		require.Equal(t, int32(1), mmapReadyCounter())
+
+		// Set minTime to current ts so GC truncates old chunks. Since seriesA
+		// still has recent head chunks (headChunkCount >= 2), GC's
+		// truncateChunksBefore may or may not reduce headChunkCount depending
+		// on timestamps. Regardless, the counter must stay consistent.
+		h.minTime.Store(ts)
+		h.gc()
+		requireCounterConsistent("after GC truncation")
+
+		// Phase 4: Stale-series deletion via truncateStaleSeries (gcStaleSeries path).
+		// Build seriesB up to headChunkCount >= 2, then mark stale and truncate.
+		app = h.Appender(t.Context())
+		for range chunkCutIterations {
+			var err error
+			refB, err = app.Append(refB, lblsB, ts, float64(ts))
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+
+		// Mark seriesB stale so truncateStaleSeries will remove it.
+		app = h.Appender(t.Context())
+		_, err := app.Append(refB, lblsB, ts, math.Float64frombits(value.StaleNaN))
 		require.NoError(t, err)
+		require.NoError(t, app.Commit())
 		ts += interval
-	}
-	require.NoError(t, app.Commit())
 
-	require.Equal(t, 2, countReady(), "expected both series to be marked ready")
-	// With ~2*DefaultSamplesPerChunk samples, we expect 3 head chunks (the count tracks total head chunks).
-	require.Equal(t, uint32(3), getCount(lblsB), "series B headChunkCount should reflect actual head chunk count")
-	require.Equal(t, uint32(3), getCount(lblsC), "series C headChunkCount should reflect actual head chunk count")
+		sB := h.series.getByHash(lblsB.Hash(), lblsB)
+		require.NotNil(t, sB)
+		require.GreaterOrEqual(t, sB.headChunkCount.Load(), uint32(2),
+			"seriesB must be mmap-ready at deletion time for this test to be meaningful")
+		requireCounterConsistent("before stale series deletion")
+		readyBefore := mmapReadyCounter()
 
-	// mmapHeadChunks should reset headChunkCount to 1 (one head chunk remains).
-	h.mmapHeadChunks()
+		// Use truncateStaleSeries which calls gcStaleSeries internally.
+		require.NoError(t, h.truncateStaleSeries(
+			[]storage.SeriesRef{storage.SeriesRef(sB.ref)}, ts,
+		))
+		requireCounterConsistent("after truncateStaleSeries")
+		require.Less(t, mmapReadyCounter(), readyBefore,
+			"counter should have decreased after deleting a ready series")
 
-	for _, lbls := range []labels.Labels{lblsB, lblsC} {
-		s := h.series.getByHash(lbls.Hash(), lbls)
-		require.NotNil(t, s, "series %s not found", lbls)
-		s.Lock()
-		require.NotNil(t, s.headChunks, "series %s should have head chunks", lbls)
-		require.Nil(t, s.headChunks.prev, "series %s should not have prev mmapped", lbls)
-		require.NotEmpty(t, s.mmappedChunks, "series %s should have mmapped chunks", lbls)
-		s.Unlock()
-	}
-
-	require.Equal(t, uint32(1), getCount(lblsB), "headChunkCount should be 1 after mmap")
-	require.Equal(t, uint32(1), getCount(lblsC), "headChunkCount should be 1 after mmap")
-	require.Equal(t, 0, countReady(), "ready set should be empty after mmapHeadChunks")
-
-	// A second call should be a no-op.
-	beforeMetric := prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
-	h.mmapHeadChunks()
-	afterMetric := prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
-	require.Equal(t, beforeMetric, afterMetric, "second call should mmap 0 chunks")
-
-	// Only newly ready series should be processed.
-	app = h.Appender(t.Context())
-	for range chunkCutIterations {
-		var err error
-		refB, err = app.Append(refB, lblsB, ts, float64(ts))
+		// Phase 5: Verify mmapHeadChunks does not decrement when mmapChunks
+		// returns 0. This simulates the race where a series passes the
+		// headChunkCount >= 2 filter but by the time the series lock is
+		// acquired, another goroutine (GC) has already reduced the count.
+		//
+		// We create a fresh series with 1 head chunk, then artificially set
+		// headChunkCount to 2 and mmapReady to 1. mmapChunks will see
+		// headChunks.prev == nil and return 0. Without the n > 0 guard,
+		// the counter would be decremented to 0 even though the "real"
+		// decrement never happened (simulating a double-decrement).
+		lblsD := labels.FromStrings("__name__", "seriesD")
+		app = h.Appender(t.Context())
+		_, err = app.Append(0, lblsD, ts, float64(ts))
 		require.NoError(t, err)
-		ts += interval
-	}
-	require.NoError(t, app.Commit())
+		require.NoError(t, app.Commit())
 
-	require.Equal(t, 1, countReady(), "only series B should be ready")
-	require.Equal(t, uint32(3), getCount(lblsB), "series B headChunkCount should reflect new chunks")
-	require.Equal(t, uint32(1), getCount(lblsC), "series C headChunkCount should be unchanged")
+		sD := h.series.getByHash(lblsD.Hash(), lblsD)
+		require.NotNil(t, sD)
+		require.Equal(t, uint32(1), sD.headChunkCount.Load())
+		require.Nil(t, sD.headChunks.prev, "only one head chunk, prev must be nil")
+		stripeD := h.series.refStripe(sD.ref)
 
-	beforeMetric = prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
-	h.mmapHeadChunks()
-	afterMetric = prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
-	require.Greater(t, afterMetric, beforeMetric, "third call should mmap chunks from series B")
-	require.Equal(t, uint32(1), getCount(lblsB), "series B headChunkCount should be 1 after mmap")
-}
+		// Simulate the race: inflate headChunkCount so the series passes the
+		// >= 2 filter, and set mmapReady to 1 (as the increment site would).
+		sD.headChunkCount.Store(2)
+		h.series.mmapReady[stripeD].Add(1)
 
-func TestHead_mmapHeadChunks_oooDoesNotInflateCount(t *testing.T) {
-	h, _ := newTestHead(t, DefaultBlockDuration, compression.None, true /* oooEnabled */)
-	require.NoError(t, h.Init(0))
+		h.mmapHeadChunks()
 
-	interval := DefaultBlockDuration / (4 * 120)
-	lbls := labels.FromStrings("__name__", "test")
-	ts := int64(0)
+		// mmapChunks returned 0 (headChunks.prev is nil). With the n > 0
+		// guard, the counter stays at 1. Without the guard, it would drop
+		// to 0 — an incorrect extra decrement.
+		require.Equal(t, int32(1), h.series.mmapReady[stripeD].Load(),
+			"mmapHeadChunks must not decrement when mmapChunks returns 0")
 
-	// Create enough in-order samples to get headChunkCount >= 2.
-	const chunkCutIterations = 2*DefaultSamplesPerChunk + 10
-	var ref storage.SeriesRef
-	app := h.Appender(t.Context())
-	for range chunkCutIterations {
-		var err error
-		ref, err = app.Append(ref, lbls, ts, float64(ts))
-		require.NoError(t, err)
-		ts += interval
-	}
-	require.NoError(t, app.Commit())
-
-	s := h.series.getByHash(lbls.Hash(), lbls)
-	require.NotNil(t, s)
-	countBefore := s.headChunkCount.Load()
-	require.GreaterOrEqual(t, countBefore, uint32(2), "need multiple head chunks for this test")
-
-	// Append an OOO sample that creates an OOO chunk.
-	oooTs := ts - 5*time.Minute.Milliseconds() // Within the 10m OOO window.
-	app = h.Appender(t.Context())
-	_, err := app.Append(0, lbls, oooTs, 999.0)
-	require.NoError(t, err)
-	require.NoError(t, app.Commit())
-
-	// headChunkCount must not change from an OOO insert.
-	require.Equal(t, countBefore, s.headChunkCount.Load(), "OOO insert should not inflate headChunkCount")
+		// Clean up: restore the real state.
+		sD.headChunkCount.Store(1)
+		h.series.mmapReady[stripeD].Add(-1)
+		requireCounterConsistent("final state")
+	})
 }

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -8368,6 +8368,103 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		}
 	})
 
+	// Verify the WAL-replay path's eager mmap (appendChunkAndMmap) keeps
+	// mmapReady consistent when a series enters the path with
+	// headChunkCount >= 2 (typical after loadChunkSnapshot restores a
+	// series that had multiple head chunks at shutdown).
+	t.Run("wal replay does not leak mmap ready", func(t *testing.T) {
+		// Pre-generate varied histograms; reusing the same histogram every
+		// iteration compresses too well to trigger chunk cuts.
+		histograms := tsdbutil.GenerateTestHistograms(chunkCutIterations)
+		floatHistograms := tsdbutil.GenerateTestFloatHistograms(chunkCutIterations)
+
+		type testCase struct {
+			appendOnce     func(app storage.Appender, lbls labels.Labels, ts int64, i int) error
+			appendInternal func(ms *memSeries, t int64, opts chunkOpts) bool
+		}
+		testCases := map[string]testCase{
+			"floats": {
+				appendOnce: func(app storage.Appender, lbls labels.Labels, ts int64, _ int) error {
+					_, err := app.Append(0, lbls, ts, float64(ts))
+					return err
+				},
+				appendInternal: func(ms *memSeries, t int64, opts chunkOpts) bool {
+					_, chunkCreated := ms.append(0, t, 0, 0, opts)
+					return chunkCreated
+				},
+			},
+			"histograms": {
+				appendOnce: func(app storage.Appender, lbls labels.Labels, ts int64, i int) error {
+					_, err := app.AppendHistogram(0, lbls, ts, histograms[i], nil)
+					return err
+				},
+				appendInternal: func(ms *memSeries, t int64, opts chunkOpts) bool {
+					_, chunkCreated := ms.appendHistogram(0, t, histograms[0], 0, opts)
+					return chunkCreated
+				},
+			},
+			"float histograms": {
+				appendOnce: func(app storage.Appender, lbls labels.Labels, ts int64, i int) error {
+					_, err := app.AppendHistogram(0, lbls, ts, nil, floatHistograms[i])
+					return err
+				},
+				appendInternal: func(ms *memSeries, t int64, opts chunkOpts) bool {
+					_, chunkCreated := ms.appendFloatHistogram(0, t, floatHistograms[0], 0, opts)
+					return chunkCreated
+				},
+			},
+		}
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				h, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
+				require.NoError(t, h.Init(0))
+
+				mmapReadyTotal := func() int32 {
+					var n int32
+					for i := range h.series.size {
+						n += h.series.mmapReady[i].Load()
+					}
+					return n
+				}
+
+				// Build a series naturally to headChunkCount >= 2 via the normal
+				// appender path. This sets mmapReady to 1.
+				lbls := labels.FromStrings("__name__", "test")
+				ts := int64(0)
+				app := h.Appender(t.Context())
+				for i := range chunkCutIterations {
+					require.NoError(t, tc.appendOnce(app, lbls, ts, i))
+					ts += interval
+				}
+				require.NoError(t, app.Commit())
+
+				s := h.series.getByHash(lbls.Hash(), lbls)
+				require.NotNil(t, s)
+				require.GreaterOrEqual(t, s.headChunkCount.Load(), uint32(2))
+				require.Equal(t, int32(1), mmapReadyTotal())
+
+				// Invoke the WAL-replay-style helper with a sample timestamped
+				// past the next chunk boundary to force a chunk cut.
+				s.Lock()
+				chunkCreated := h.appendChunkAndMmap(s, func() bool {
+					return tc.appendInternal(s, ts+h.chunkRange.Load(), chunkOpts{
+						chunkDiskMapper: h.chunkDiskMapper,
+						chunkRange:      h.chunkRange.Load(),
+						samplesPerChunk: h.opts.SamplesPerChunk,
+					})
+				})
+				s.Unlock()
+				require.True(t, chunkCreated, "test needs a chunk cut to be meaningful")
+
+				// After the chunk cut + mmap, headChunkCount == 1 (mmapChunks
+				// always sets it to 1 when it does work). The series is no
+				// longer mmap-ready, so mmapReady must be 0.
+				require.Equal(t, int32(0), mmapReadyTotal(),
+					"WAL-replay-style chunk cut must decrement mmapReady when prev >= 2")
+			})
+		}
+	})
+
 	// Verify the mmapReady per-stripe counter stays in sync with the actual
 	// number of series that have headChunkCount >= 2, across append, mmap,
 	// GC, and stale-series deletion.

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -8295,6 +8295,79 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		require.Equal(t, countBefore, s.headChunkCount.Load(), "OOO insert should not inflate headChunkCount")
 	})
 
+	// Verify OOO chunk creation does not spuriously increment mmapReady when the
+	// series happens to be at headChunkCount == 2. This simulates the natural
+	// window where a series has just become mmap-ready and an OOO sample arrives.
+	// Covers all three commit paths: floats, histograms, and float histograms.
+	t.Run("ooo insert does not increment mmap ready", func(t *testing.T) {
+		type testCase struct {
+			appendSample func(app storage.Appender, lbls labels.Labels, ts int64) error
+		}
+		testCases := map[string]testCase{
+			"floats": {
+				appendSample: func(app storage.Appender, lbls labels.Labels, ts int64) error {
+					_, err := app.Append(0, lbls, ts, float64(ts))
+					return err
+				},
+			},
+			"histograms": {
+				appendSample: func(app storage.Appender, lbls labels.Labels, ts int64) error {
+					_, err := app.AppendHistogram(0, lbls, ts, tsdbutil.GenerateTestHistograms(1)[0], nil)
+					return err
+				},
+			},
+			"float histograms": {
+				appendSample: func(app storage.Appender, lbls labels.Labels, ts int64) error {
+					_, err := app.AppendHistogram(0, lbls, ts, nil, tsdbutil.GenerateTestFloatHistograms(1)[0])
+					return err
+				},
+			},
+		}
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				h, _ := newTestHead(t, DefaultBlockDuration, compression.None, true /* oooEnabled */)
+				require.NoError(t, h.Init(0))
+
+				mmapReadyTotal := func() int32 {
+					var n int32
+					for i := range h.series.size {
+						n += h.series.mmapReady[i].Load()
+					}
+					return n
+				}
+
+				// Create a series with one in-order sample.
+				lbls := labels.FromStrings("__name__", "test")
+				ts := int64(0)
+				app := h.Appender(t.Context())
+				require.NoError(t, tc.appendSample(app, lbls, ts))
+				require.NoError(t, app.Commit())
+				ts += interval
+
+				s := h.series.getByHash(lbls.Hash(), lbls)
+				require.NotNil(t, s)
+
+				// Force the exact state required to trigger the bug: series at
+				// headChunkCount == 2 (mmap-ready) with mmapReady already incremented.
+				s.Lock()
+				s.headChunkCount.Store(2)
+				s.Unlock()
+				h.series.incMmapReady(s.ref)
+				require.Equal(t, int32(1), mmapReadyTotal())
+
+				// Append an OOO sample. This creates an OOO chunk (not a regular
+				// head chunk), so mmapReady must stay at 1.
+				oooTs := ts - 5*time.Minute.Milliseconds()
+				app = h.Appender(t.Context())
+				require.NoError(t, tc.appendSample(app, lbls, oooTs))
+				require.NoError(t, app.Commit())
+
+				require.Equal(t, int32(1), mmapReadyTotal(),
+					"OOO chunk creation must not increment mmapReady")
+			})
+		}
+	})
+
 	// Verify the mmapReady per-stripe counter stays in sync with the actual
 	// number of series that have headChunkCount >= 2, across append, mmap,
 	// GC, and stale-series deletion.

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -579,7 +579,7 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 	// Any samples replayed till now would already be compacted. Resetting the head chunk.
 	mSeries.nextAt = 0
 	if mSeries.headChunkCount.Load() >= 2 {
-		h.series.mmapReady[h.series.refStripe(mSeries.ref)].Add(-1)
+		h.series.decMmapReady(mSeries.ref)
 	}
 	mSeries.headChunks = nil
 	mSeries.headChunkCount.Store(0)
@@ -1667,7 +1667,7 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 				chunkCount := uint32(csr.mc.len())
 				series.headChunkCount.Store(chunkCount)
 				if chunkCount >= 2 {
-					h.series.mmapReady[h.series.refStripe(series.ref)].Add(1)
+					h.series.incMmapReady(series.ref)
 				}
 				series.lastValue = csr.lastValue
 				series.lastHistogramValue = csr.lastHistogramValue

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -578,6 +578,9 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 
 	// Any samples replayed till now would already be compacted. Resetting the head chunk.
 	mSeries.nextAt = 0
+	if mSeries.headChunkCount.Load() >= 2 {
+		h.series.mmapReady[h.series.refStripe(mSeries.ref)].Add(-1)
+	}
 	mSeries.headChunks = nil
 	mSeries.headChunkCount.Store(0)
 	mSeries.app = nil
@@ -1661,7 +1664,11 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 				}
 				series.nextAt = csr.mc.maxTime // This will create a new chunk on append.
 				series.headChunks = csr.mc
-				series.headChunkCount.Store(uint32(csr.mc.len()))
+				chunkCount := uint32(csr.mc.len())
+				series.headChunkCount.Store(chunkCount)
+				if chunkCount >= 2 {
+					h.series.mmapReady[h.series.refStripe(series.ref)].Add(1)
+				}
 				series.lastValue = csr.lastValue
 				series.lastHistogramValue = csr.lastHistogramValue
 				series.lastFloatHistogramValue = csr.lastFloatHistogramValue

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -635,6 +635,29 @@ func (wp *walSubsetProcessor) reuseHistogramBuf() []histogramRecord {
 	return nil
 }
 
+// appendChunkAndMmap appends a sample to ms via appendFn and, if a new head
+// chunk was created, immediately mmaps the now-completed predecessors. Used
+// by WAL replay paths to keep memory bounded by mmapping eagerly rather than
+// waiting for the periodic mmapHeadChunks pass.
+//
+// If the chunk cut + mmap reduces headChunkCount from >= 2 to < 2 (which
+// happens whenever prev >= 2, since mmapChunks always sets the count to 1
+// when it does work), the per-stripe mmap-ready counter is decremented to
+// maintain its invariant.
+func (h *Head) appendChunkAndMmap(ms *memSeries, appendFn func() bool) bool {
+	prev := ms.headChunkCount.Load()
+	chunkCreated := appendFn()
+	if chunkCreated {
+		h.metrics.chunksCreated.Inc()
+		h.metrics.chunks.Inc()
+		_ = ms.mmapChunks(h.chunkDiskMapper)
+		if prev >= 2 {
+			h.series.decMmapReady(ms.ref)
+		}
+	}
+	return chunkCreated
+}
+
 // processWALSamples adds the samples it receives to the head and passes
 // the buffer received to an output channel for reuse.
 // Samples before the minValidTime timestamp are discarded.
@@ -682,11 +705,10 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				h.numStaleSeries.Dec()
 			}
 
-			if _, chunkCreated := ms.append(s.ST, s.T, s.V, 0, appendChunkOpts); chunkCreated {
-				h.metrics.chunksCreated.Inc()
-				h.metrics.chunks.Inc()
-				_ = ms.mmapChunks(h.chunkDiskMapper)
-			}
+			h.appendChunkAndMmap(ms, func() bool {
+				_, chunkCreated := ms.append(s.ST, s.T, s.V, 0, appendChunkOpts)
+				return chunkCreated
+			})
 			if s.T > maxt {
 				maxt = s.T
 			}
@@ -712,7 +734,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if s.t <= ms.mmMaxTime {
 				continue
 			}
-			var chunkCreated, newlyStale, staleToNonStale bool
+			var newlyStale, staleToNonStale bool
 			if s.h != nil {
 				newlyStale = value.IsStaleNaN(s.h.Sum)
 				if ms.lastHistogramValue != nil {
@@ -720,7 +742,10 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 					staleToNonStale = value.IsStaleNaN(ms.lastHistogramValue.Sum) && !value.IsStaleNaN(s.h.Sum)
 				}
 				// TODO(krajorama,ywwg): Pass ST when available in WBL.
-				_, chunkCreated = ms.appendHistogram(0, s.t, s.h, 0, appendChunkOpts)
+				h.appendChunkAndMmap(ms, func() bool {
+					_, chunkCreated := ms.appendHistogram(0, s.t, s.h, 0, appendChunkOpts)
+					return chunkCreated
+				})
 			} else {
 				newlyStale = value.IsStaleNaN(s.fh.Sum)
 				if ms.lastFloatHistogramValue != nil {
@@ -728,18 +753,16 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 					staleToNonStale = value.IsStaleNaN(ms.lastFloatHistogramValue.Sum) && !value.IsStaleNaN(s.fh.Sum)
 				}
 				// TODO(krajorama,ywwg): Pass ST when available in WBL.
-				_, chunkCreated = ms.appendFloatHistogram(0, s.t, s.fh, 0, appendChunkOpts)
+				h.appendChunkAndMmap(ms, func() bool {
+					_, chunkCreated := ms.appendFloatHistogram(0, s.t, s.fh, 0, appendChunkOpts)
+					return chunkCreated
+				})
 			}
 			if newlyStale {
 				h.numStaleSeries.Inc()
 			}
 			if staleToNonStale {
 				h.numStaleSeries.Dec()
-			}
-			if chunkCreated {
-				h.metrics.chunksCreated.Inc()
-				h.metrics.chunks.Inc()
-				_ = ms.mmapChunks(h.chunkDiskMapper)
 			}
 			if s.t > maxt {
 				maxt = s.t


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

<!--
N/A — this is a performance optimization, not a bug fix.
-->

#### Summary

Follow-up to #18272, optimizing also the outer loop (skipping entire TSDB stripes without series in need of mmapping).

**Commit 1 — `tsdb: extract stripeSeries.refStripe helper`**

Extract the repeated ref-to-stripe-index calculation into a `refStripe` method on `stripeSeries`, replacing four inline copies that used two different casting styles (`int` and `uint64`).

**Commit 2 — `tsdb: skip entire stripes in mmapHeadChunks via per-stripe ready count`**

Add a per-stripe `mmapReady` counter to `stripeSeries` that tracks how many series in each stripe have `headChunkCount >= 2` (i.e., are ready for mmapping). `mmapHeadChunks` skips stripes where the counter is zero, avoiding the RLock and map iteration entirely.

The counter is maintained at all sites that modify `headChunkCount`:
- Incremented in commit paths when a chunk cut brings count to 2
- Decremented when `mmapChunks` brings count back to 1
- Decremented in `gc`/`truncateChunksBefore` and series deletion
- Maintained during WAL replay and chunk snapshot loading

Guard the decrement in `mmapHeadChunks` on `mmapChunks` returning > 0 to prevent a double-decrement race: between the lockless `headChunkCount` filter and acquiring the series lock, GC/deletion can concurrently reduce `headChunkCount` and decrement `mmapReady`, so an unconditional decrement would drive the counter negative.

Pad `mmapReady` counters to 64-byte cache lines (`paddedAtomicInt32`) to avoid false sharing under concurrent appends across stripes, following the existing `stripeLock` padding convention.

#### Testing

I've tested the optimization on a Grafana Mimir instance with millions of series, and AFAICT ingester CPU utilization was reduced by about 15%, because time is no longer wasted locking each TSDB stripe unless a stripe actually has mmappable series.

<details>
<summary>Benchmark results (Intel Xeon Platinum 8280, 16 CPUs)</summary>

```console
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz
                                             │   main.txt   │            optimized.txt            │
                                             │    sec/op    │    sec/op     vs base               │
MmapHeadChunks/series=1000/ready=10-16         399.36µ ± 3%   44.62µ ± 46%  -88.83% (p=0.002 n=6)
MmapHeadChunks/series=1000/ready=100-16         477.8µ ± 1%   121.5µ ±  5%  -74.57% (p=0.002 n=6)
MmapHeadChunks/series=1000/ready=1000-16       1103.9µ ± 1%   780.5µ ±  4%  -29.29% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=100-16        895.9µ ± 4%   122.3µ ±  6%  -86.35% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=1000-16      1716.9µ ± 4%   930.8µ ±  2%  -45.79% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=10000-16      10.18m ± 3%   10.25m ±  3%        ~ (p=0.394 n=6)
MmapHeadChunks/series=100000/ready=1000-16      5.819m ± 4%   1.081m ±  4%  -81.43% (p=0.002 n=6)
MmapHeadChunks/series=100000/ready=10000-16     16.90m ± 3%   13.83m ±  6%  -18.14% (p=0.002 n=6)
MmapHeadChunks/series=100000/ready=100000-16    111.0m ± 3%   109.0m ±  3%        ~ (p=0.394 n=6)
geomean                                         3.208m        1.261m        -60.71%

                                             │   main.txt   │            optimized.txt            │
                                             │     B/op     │     B/op      vs base               │
MmapHeadChunks/series=1000/ready=10-16         2.723Ki ± 4%   1.705Ki ± 2%  -37.39% (p=0.002 n=6)
MmapHeadChunks/series=1000/ready=100-16        16.58Ki ± 4%   15.48Ki ± 3%   -6.62% (p=0.002 n=6)
MmapHeadChunks/series=1000/ready=1000-16       145.3Ki ± 1%   137.9Ki ± 5%   -5.11% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=100-16       16.91Ki ± 4%   15.33Ki ± 2%   -9.31% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=1000-16      146.2Ki ± 2%   140.0Ki ± 2%   -4.26% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=10000-16     1.327Mi ± 1%   1.345Mi ± 3%        ~ (p=0.171 n=6)
MmapHeadChunks/series=100000/ready=1000-16     158.4Ki ± 3%   144.2Ki ± 1%   -8.96% (p=0.002 n=6)
MmapHeadChunks/series=100000/ready=10000-16    1.463Mi ± 8%   1.389Mi ± 5%        ~ (p=0.132 n=6)
MmapHeadChunks/series=100000/ready=100000-16   13.24Mi ± 3%   13.44Mi ± 2%        ~ (p=0.803 n=6)
geomean                                        160.6Ki        146.1Ki        -8.99%

                                             │  main.txt   │            optimized.txt             │
                                             │  allocs/op  │  allocs/op    vs base                │
MmapHeadChunks/series=1000/ready=10-16          11.00 ± 9%    10.00 ± 10%       ~ (p=0.242 n=6)
MmapHeadChunks/series=1000/ready=100-16         105.5 ± 0%    106.0 ±  1%       ~ (p=0.545 n=6)
MmapHeadChunks/series=1000/ready=1000-16       1.037k ± 0%   1.033k ±  0%  -0.39% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=100-16        107.0 ± 0%    107.0 ±  0%       ~ (p=1.000 n=6) ¹
MmapHeadChunks/series=10000/ready=1000-16      1.043k ± 0%   1.035k ±  0%  -0.77% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=10000-16     10.98k ± 1%   11.05k ±  1%       ~ (p=0.545 n=6)
MmapHeadChunks/series=100000/ready=1000-16     1.077k ± 0%   1.036k ±  0%  -3.81% (p=0.002 n=6)
MmapHeadChunks/series=100000/ready=10000-16    11.35k ± 1%   11.14k ±  2%  -1.85% (p=0.017 n=6)
MmapHeadChunks/series=100000/ready=100000-16   142.9k ± 6%   147.1k ±  3%       ~ (p=0.628 n=6)
geomean                                        1.111k        1.096k        -1.38%
¹ all samples are equal
```

</details>

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[PERF] TSDB: Skip entire stripes in mmapHeadChunks when no series need mmapping, reducing CPU utilization significantly at production-relevant scales.
```