### PR TITLE
tsdb: Make sure WAL replay data goes to different map, and then merge it with scrape data. 

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1920,6 +1920,9 @@ func (s *readyStorage) Close() error {
 
 // CleanTombstones implements the api_v1.TSDBAdminStats and api_v2.TSDBAdmin interfaces.
 func (s *readyStorage) CleanTombstones() error {
+	if !s.queryReady.Load() {
+		return tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:
@@ -1935,6 +1938,9 @@ func (s *readyStorage) CleanTombstones() error {
 
 // BlockMetas implements the api_v1.TSDBAdminStats and api_v2.TSDBAdmin interfaces.
 func (s *readyStorage) BlockMetas() ([]tsdb.BlockMeta, error) {
+	if !s.queryReady.Load() {
+		return nil, tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:
@@ -1950,6 +1956,9 @@ func (s *readyStorage) BlockMetas() ([]tsdb.BlockMeta, error) {
 
 // Delete implements the api_v1.TSDBAdminStats and api_v2.TSDBAdmin interfaces.
 func (s *readyStorage) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Matcher) error {
+	if !s.queryReady.Load() {
+		return tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:
@@ -1965,6 +1974,9 @@ func (s *readyStorage) Delete(ctx context.Context, mint, maxt int64, ms ...*labe
 
 // Snapshot implements the api_v1.TSDBAdminStats and api_v2.TSDBAdmin interfaces.
 func (s *readyStorage) Snapshot(dir string, withHead bool) error {
+	if !s.queryReady.Load() {
+		return tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:
@@ -1980,6 +1992,9 @@ func (s *readyStorage) Snapshot(dir string, withHead bool) error {
 
 // Stats implements the api_v1.TSDBAdminStats interface.
 func (s *readyStorage) Stats(statsByLabelName string, limit int) (*tsdb.Stats, error) {
+	if !s.queryReady.Load() {
+		return nil, tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1752,7 +1752,7 @@ type readyStorage struct {
 	db              storage.Storage
 	startTimeMargin int64
 	stats           *tsdb.DBStats
-	queryReady atomic.Bool
+	queryReady      atomic.Bool
 }
 
 func (s *readyStorage) ApplyConfig(conf *config.Config) error {
@@ -1815,7 +1815,7 @@ func (s *readyStorage) StartTime() (int64, error) {
 
 // Querier implements the Storage interface.
 func (s *readyStorage) Querier(mint, maxt int64) (storage.Querier, error) {
-	if (!s.queryReady.Load()) {
+	if !s.queryReady.Load() {
 		return nil, tsdb.ErrNotReady
 	}
 	if x := s.get(); x != nil {
@@ -1826,7 +1826,7 @@ func (s *readyStorage) Querier(mint, maxt int64) (storage.Querier, error) {
 
 // ChunkQuerier implements the Storage interface.
 func (s *readyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
-	if (!s.queryReady.Load()) {
+	if !s.queryReady.Load() {
 		return nil, tsdb.ErrNotReady
 	}
 	if x := s.get(); x != nil {
@@ -1836,7 +1836,7 @@ func (s *readyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, err
 }
 
 func (s *readyStorage) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
-	if (!s.queryReady.Load()) {
+	if !s.queryReady.Load() {
 		return nil, tsdb.ErrNotReady
 	}
 	if x := s.get(); x != nil {

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1449,6 +1449,18 @@ func main() {
 				startTimeMargin := int64(2 * time.Duration(cfg.tsdb.MinBlockDuration).Seconds() * 1000)
 				localStorage.Set(db, startTimeMargin)
 				db.SetWriteNotified(remoteStorage)
+
+				if cfg.tsdb.EnableFastStartup {
+					go func() {
+						// Wait for queries to become enabled.
+						<-db.Head().WaitForWALReplay()
+						localStorage.SetQueryReady()
+						logger.Info("WAL replay finished. Queries are now enabled.")
+					}()
+				} else {
+					localStorage.SetQueryReady()
+				}
+
 				close(dbOpen)
 				<-cancel
 				logger.Info("TSDB stopped")
@@ -1507,6 +1519,7 @@ func main() {
 				)
 
 				localStorage.Set(db, 0)
+				localStorage.SetQueryReady()
 				db.SetWriteNotified(remoteStorage)
 				close(dbOpen)
 				<-cancel
@@ -1739,6 +1752,7 @@ type readyStorage struct {
 	db              storage.Storage
 	startTimeMargin int64
 	stats           *tsdb.DBStats
+	queryReady atomic.Bool
 }
 
 func (s *readyStorage) ApplyConfig(conf *config.Config) error {
@@ -1772,6 +1786,10 @@ func (s *readyStorage) getStats() *tsdb.DBStats {
 	return x
 }
 
+func (s *readyStorage) SetQueryReady() {
+	s.queryReady.Store(true)
+}
+
 // StartTime implements the Storage interface.
 func (s *readyStorage) StartTime() (int64, error) {
 	if x := s.get(); x != nil {
@@ -1797,6 +1815,9 @@ func (s *readyStorage) StartTime() (int64, error) {
 
 // Querier implements the Storage interface.
 func (s *readyStorage) Querier(mint, maxt int64) (storage.Querier, error) {
+	if (!s.queryReady.Load()) {
+		return nil, tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		return x.Querier(mint, maxt)
 	}
@@ -1805,6 +1826,9 @@ func (s *readyStorage) Querier(mint, maxt int64) (storage.Querier, error) {
 
 // ChunkQuerier implements the Storage interface.
 func (s *readyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
+	if (!s.queryReady.Load()) {
+		return nil, tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		return x.ChunkQuerier(mint, maxt)
 	}
@@ -1812,6 +1836,9 @@ func (s *readyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, err
 }
 
 func (s *readyStorage) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
+	if (!s.queryReady.Load()) {
+		return nil, tsdb.ErrNotReady
+	}
 	if x := s.get(); x != nil {
 		switch db := x.(type) {
 		case *tsdb.DB:

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1127,7 +1127,14 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 		minValidTime = inOrderMaxTime
 	}
 
-	if initErr := db.head.Init(minValidTime); initErr != nil {
+	var initErr error
+	if headOpts.EnableFastStartup {
+		initErr = db.head.Init(minValidTime)
+	} else {
+		initErr = db.head.InitFastStartup(minValidTime)
+	}
+
+	if initErr != nil {
 		db.head.metrics.walCorruptionsTotal.Inc()
 		var e *errLoadWbl
 		if errors.As(initErr, &e) {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -112,6 +112,10 @@ type Head struct {
 	// All series addressable by their ID or hash.
 	series *stripeSeries
 
+	// A temporary map used exclusively during WAL replay.
+	// It is merged into 'series' at the end of the replay.
+	walSeries *stripeSeries
+
 	walExpiriesMtx sync.Mutex
 	walExpiries    map[chunks.HeadSeriesRef]int64 // Series no longer in the head, and what time they must be kept until.
 
@@ -368,6 +372,11 @@ func (h *Head) resetInMemoryState() error {
 	}
 
 	h.series = newStripeSeries(h.opts.StripeSize, h.opts.SeriesCallback)
+
+	if h.opts.EnableFastStartup {
+		h.walSeries = newStripeSeries(h.opts.StripeSize, h.opts.SeriesCallback)
+	}
+
 	h.iso = newIsolation(h.opts.IsolationDisabled)
 	h.oooIso = newOOOIsolation()
 	h.numSeries.Store(0)
@@ -702,6 +711,11 @@ func (h *Head) replayDiskChunksAndWAL() error {
 	h.logger.Info("Replaying on-disk memory mappable chunks if any")
 	start := time.Now()
 
+	targetStripeMap := h.series
+	if h.opts.EnableFastStartup {
+		targetStripeMap = h.walSeries
+	}
+
 	snapIdx, snapOffset := -1, 0
 	refSeries := make(map[chunks.HeadSeriesRef]*memSeries)
 
@@ -825,7 +839,7 @@ func (h *Head) replayDiskChunksAndWAL() error {
 
 		// A corrupted checkpoint is a hard error for now and requires user
 		// intervention. There's likely little data that can be recovered anyway.
-		if err := h.loadWAL(wlog.NewReader(sr), syms, multiRef, mmappedChunks, oooMmappedChunks); err != nil {
+		if err := h.loadWAL(wlog.NewReader(sr), syms, multiRef, mmappedChunks, oooMmappedChunks, targetStripeMap); err != nil {
 			return fmt.Errorf("backfill checkpoint: %w", err)
 		}
 		h.updateWALReplayStatusRead(startFrom)
@@ -859,7 +873,7 @@ func (h *Head) replayDiskChunksAndWAL() error {
 		if err != nil {
 			return fmt.Errorf("segment reader (offset=%d): %w", offset, err)
 		}
-		err = h.loadWAL(wlog.NewReader(sr), syms, multiRef, mmappedChunks, oooMmappedChunks)
+		err = h.loadWAL(wlog.NewReader(sr), syms, multiRef, mmappedChunks, oooMmappedChunks, targetStripeMap)
 		if err := sr.Close(); err != nil {
 			h.logger.Warn("Error while closing the wal segments reader", "err", err)
 		}
@@ -1936,8 +1950,14 @@ func (h *Head) getOrCreate(hash uint64, lset labels.Labels, pendingCommit bool) 
 }
 
 // If id is zero, one will be allocated.
+// It always writes to the live h.series map.
 func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, lset labels.Labels, pendingCommit bool) (*memSeries, bool, error) {
-	if preCreationErr := h.series.seriesLifecycleCallback.PreCreation(lset); preCreationErr != nil {
+	return h.getOrCreateInStripe(h.series, id, hash, lset, pendingCommit)
+}
+
+// getOrCreateInStripe allows injecting a specific stripe map like walSeries for background replay.
+func (h *Head) getOrCreateInStripe(stripeMap *stripeSeries, id chunks.HeadSeriesRef, hash uint64, lset labels.Labels, pendingCommit bool) (*memSeries, bool, error) {
+	if preCreationErr := stripeMap.seriesLifecycleCallback.PreCreation(lset); preCreationErr != nil {
 		return nil, false, preCreationErr
 	}
 	if id == 0 {
@@ -1951,7 +1971,7 @@ func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, l
 	}
 	optimisticallyCreatedSeries := newMemSeries(lset, id, shardHash, h.opts.IsolationDisabled, pendingCommit)
 
-	s, created := h.series.setUnlessAlreadySet(hash, lset, optimisticallyCreatedSeries)
+	s, created := stripeMap.setUnlessAlreadySet(hash, lset, optimisticallyCreatedSeries)
 	if !created {
 		return s, false, nil
 	}
@@ -1963,7 +1983,7 @@ func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, l
 
 	// Adding the series in the postings marks the creation of series
 	// as any further calls to this and the read methods would return that series.
-	h.series.postCreation(lset)
+	stripeMap.postCreation(lset)
 
 	return s, true, nil
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -287,6 +287,12 @@ func NewHead(r prometheus.Registerer, l *slog.Logger, wal, wbl *wlog.WL, opts *H
 		return nil, fmt.Errorf("OOOCapMax of %d is invalid. must be > 0 and <= 255", capMax)
 	}
 
+	if opts.EnableFastStartup {
+		if opts.OutOfOrderTimeWindow.Load() > 0 {
+			return nil, fmt.Errorf("Fast startup is disabled because Out-Of-Order time window is enabled.")
+		}
+	}
+
 	if opts.ChunkRange < 1 {
 		return nil, fmt.Errorf("invalid chunk range %d", opts.ChunkRange)
 	}
@@ -935,6 +941,13 @@ func (h *Head) replayDiskChunksAndWAL() error {
 // limits the ingested samples to the head min valid time.
 func (h *Head) Init(minValidTime int64) error {
 	h.minValidTime.Store(minValidTime)
+	err := h.replayDiskChunksAndWAL()
+	close(h.walReplayDone)
+	return err
+}
+
+func (h *Head) InitFastStartup(minValidTime int64) error {
+	h.minValidTime.Store(minValidTime)
 
 	// TODO(RushabhMehta2005): Remove this 'if' block and always run the series state ticker when the feature is fully implemented.
 	if h.opts.EnableFastStartup {
@@ -980,10 +993,7 @@ func (h *Head) Init(minValidTime int64) error {
 		return nil
 	}
 
-	// When feature is not enabled, blocking call.
-	err := h.replayDiskChunksAndWAL()
-	close(h.walReplayDone)
-	return err
+	return nil
 }
 
 // WaitForWALReplay returns a channel that is closed when the WAL replay has finished.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -311,7 +311,7 @@ func NewHead(r prometheus.Registerer, l *slog.Logger, wal, wbl *wlog.WL, opts *H
 		stats:           stats,
 		reg:             r,
 		seriesStateQuit: make(chan struct{}),
-		walReplayDone: make(chan struct{}),
+		walReplayDone:   make(chan struct{}),
 	}
 	if err := h.resetInMemoryState(); err != nil {
 		return nil, err
@@ -970,7 +970,7 @@ func (h *Head) Init(minValidTime int64) error {
 	return err
 }
 
-// WaitForWALReplay returns a channel that is closed when the WAL replay has finished. 
+// WaitForWALReplay returns a channel that is closed when the WAL replay has finished.
 func (h *Head) WaitForWALReplay() <-chan struct{} {
 	return h.walReplayDone
 }

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -949,49 +949,45 @@ func (h *Head) Init(minValidTime int64) error {
 func (h *Head) InitFastStartup(minValidTime int64) error {
 	h.minValidTime.Store(minValidTime)
 
-	// TODO(RushabhMehta2005): Remove this 'if' block and always run the series state ticker when the feature is fully implemented.
-	if h.opts.EnableFastStartup {
-		if h.wal != nil {
-			// Find the last WAL segment.
-			_, endAt, e := wlog.Segments(h.wal.Dir())
-			if e != nil {
-				return fmt.Errorf("finding WAL segments: %w", e)
-			}
+	if h.wal != nil {
+		// Find the last WAL segment.
+		_, endAt, e := wlog.Segments(h.wal.Dir())
+		if e != nil {
+			return fmt.Errorf("finding WAL segments: %w", e)
+		}
 
-			state, err := h.readSeriesStateFile()
-			if err != nil && !os.IsNotExist(err) {
-				h.logger.Warn("Failed to read series state file, skipping the fast startup", "err", err)
-			}
-			if err == nil {
-				if state.CleanShutdown {
-					h.lastSeriesID.Store(state.LastSeriesID)
-					h.logger.Info("Fast startup: clean shutdown detected, restored last series ID", "last_series_id", state.LastSeriesID)
+		state, err := h.readSeriesStateFile()
+		if err != nil && !os.IsNotExist(err) {
+			h.logger.Warn("Failed to read series state file, skipping the fast startup", "err", err)
+		}
+		if err == nil {
+			if state.CleanShutdown {
+				h.lastSeriesID.Store(state.LastSeriesID)
+				h.logger.Info("Fast startup: clean shutdown detected, restored last series ID", "last_series_id", state.LastSeriesID)
+			} else {
+				h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", state.LastWALSegment, "to_segment", endAt)
+				id, scanErr := h.findLastSeriesID(state, endAt)
+				if scanErr != nil {
+					h.logger.Error("Fast startup: WAL scan failed, skipping fast startup", "err", scanErr)
 				} else {
-					h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", state.LastWALSegment, "to_segment", endAt)
-					id, scanErr := h.findLastSeriesID(state, endAt)
-					if scanErr != nil {
-						h.logger.Error("Fast startup: WAL scan failed, skipping fast startup", "err", scanErr)
-					} else {
-						h.lastSeriesID.Store(id)
-						h.logger.Info("Fast startup: WAL scan completed", "last_series_id", id)
-					}
+					h.lastSeriesID.Store(id)
+					h.logger.Info("Fast startup: WAL scan completed", "last_series_id", id)
 				}
 			}
 		}
-
-		// Start the background goroutine that writes to series_state.json.
-		h.seriesStateWg.Add(1)
-		go h.runSeriesStateTicker()
-
-		h.walReplayWg.Go(func() {
-			defer close(h.walReplayDone)
-			if err := h.replayDiskChunksAndWAL(); err != nil {
-				h.logger.Error("Fast startup: Background WAL replay failed", "err", err)
-			}
-		})
-
-		return nil
 	}
+
+	// Start the background goroutine that writes to series_state.json.
+	h.seriesStateWg.Add(1)
+	go h.runSeriesStateTicker()
+
+	h.walReplayWg.Go(func() {
+		defer close(h.walReplayDone)
+		if err := h.replayDiskChunksAndWAL(); err != nil {
+			h.logger.Error("Fast startup: Background WAL replay failed", "err", err)
+		}
+		h.mergeWALSeries()
+	})
 
 	return nil
 }
@@ -1912,6 +1908,7 @@ func (h *Head) compactable() bool {
 func (h *Head) Close() error {
 	// Wait for background WAL replay to finish before shutdown.
 	h.walReplayWg.Wait()
+	h.mergeWALSeries() // TODO: Is this needed here? Not sure. 
 
 	h.closedMtx.Lock()
 	defer h.closedMtx.Unlock()

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -141,6 +141,9 @@ type Head struct {
 	seriesStateQuit chan struct{}
 	seriesStateWg   sync.WaitGroup
 
+	// For running the background WAL replay.
+	walReplayWg sync.WaitGroup
+
 	stats *HeadStats
 	reg   prometheus.Registerer
 
@@ -678,11 +681,7 @@ func (s *WALReplayStatus) GetWALReplayStatus() WALReplayStatus {
 
 const cardinalityCacheExpirationTime = time.Duration(30) * time.Second
 
-// Init loads data from the write ahead log and prepares the head for writes.
-// It should be called before using an appender so that it
-// limits the ingested samples to the head min valid time.
-func (h *Head) Init(minValidTime int64) error {
-	h.minValidTime.Store(minValidTime)
+func (h *Head) replayDiskChunksAndWAL() error {
 	defer h.resetWLReplayResources()
 	defer func() {
 		h.postings.EnsureOrder(h.opts.WALReplayConcurrency)
@@ -698,6 +697,9 @@ func (h *Head) Init(minValidTime int64) error {
 
 	h.logger.Info("Replaying on-disk memory mappable chunks if any")
 	start := time.Now()
+
+	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
+	var multiRefMtx sync.Mutex
 
 	snapIdx, snapOffset := -1, 0
 	refSeries := make(map[chunks.HeadSeriesRef]*memSeries)
@@ -731,7 +733,7 @@ func (h *Head) Init(minValidTime int64) error {
 		}
 		if loadSnapshot {
 			var err error
-			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot()
+			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot(multiRef, &multiRefMtx)
 			if err == nil {
 				snapshotLoaded = true
 				chunkSnapshotLoadDuration = time.Since(start)
@@ -775,7 +777,7 @@ func (h *Head) Init(minValidTime int64) error {
 			snapIdx, snapOffset = -1, 0
 
 			// If this fails, data will be recovered from WAL.
-			// Hence we won't lose any data (given WAL is not corrupt).
+			// Hence we wont lose any data (given WAL is not corrupt).
 			mmappedChunks, oooMmappedChunks, lastMmapRef, err = h.removeCorruptedMmappedChunks(err)
 			if err != nil {
 				return err
@@ -805,32 +807,9 @@ func (h *Head) Init(minValidTime int64) error {
 		return fmt.Errorf("finding WAL segments: %w", e)
 	}
 
-	if h.opts.EnableFastStartup {
-		state, err := h.readSeriesStateFile()
-		if err != nil && !os.IsNotExist(err) {
-			h.logger.Warn("Failed to read series state file, skipping the fast startup", "err", err)
-		}
-		if err == nil {
-			if state.CleanShutdown {
-				h.lastSeriesID.Store(state.LastSeriesID)
-				h.logger.Info("Fast startup: clean shutdown detected, restored last series ID", "last_series_id", state.LastSeriesID)
-			} else {
-				h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", state.LastWALSegment, "to_segment", endAt)
-				id, scanErr := h.findLastSeriesID(state, endAt)
-				if scanErr != nil {
-					h.logger.Error("Fast startup: WAL scan failed, skipping fast startup", "err", scanErr)
-				} else {
-					h.lastSeriesID.Store(id)
-					h.logger.Info("Fast startup: WAL scan completed", "last_series_id", id)
-				}
-			}
-		}
-	}
-
 	h.startWALReplayStatus(startFrom, endAt)
 
 	syms := labels.NewSymbolTable() // One table for the whole WAL.
-	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
 	if err == nil && startFrom >= snapIdx {
 		sr, err := wlog.NewSegmentsReader(dir)
 		if err != nil {
@@ -932,14 +911,60 @@ func (h *Head) Init(minValidTime int64) error {
 		"total_replay_duration", totalReplayDuration.String(),
 	)
 
+	return nil
+}
+
+// Init loads data from the write ahead log and prepares the head for writes.
+// It should be called before using an appender so that it
+// limits the ingested samples to the head min valid time.
+func (h *Head) Init(minValidTime int64) error {
+	h.minValidTime.Store(minValidTime)
+
+	// Find the last WAL segment.
+	_, endAt, e := wlog.Segments(h.wal.Dir())
+	if e != nil {
+		return fmt.Errorf("finding WAL segments: %w", e)
+	}
+
 	// TODO(RushabhMehta2005): Remove this 'if' block and always run the series state ticker when the feature is fully implemented.
 	if h.opts.EnableFastStartup {
+		state, err := h.readSeriesStateFile()
+		if err != nil && !os.IsNotExist(err) {
+			h.logger.Warn("Failed to read series state file, skipping the fast startup", "err", err)
+		}
+		if err == nil {
+			if state.CleanShutdown {
+				h.lastSeriesID.Store(state.LastSeriesID)
+				h.logger.Info("Fast startup: clean shutdown detected, restored last series ID", "last_series_id", state.LastSeriesID)
+			} else {
+				h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", state.LastWALSegment, "to_segment", endAt)
+				id, scanErr := h.findLastSeriesID(state, endAt)
+				if scanErr != nil {
+					h.logger.Error("Fast startup: WAL scan failed, skipping fast startup", "err", scanErr)
+				} else {
+					h.lastSeriesID.Store(id)
+					h.logger.Info("Fast startup: WAL scan completed", "last_series_id", id)
+				}
+			}
+		}
+
 		// Start the background goroutine that writes to series_state.json.
 		h.seriesStateWg.Add(1)
 		go h.runSeriesStateTicker()
+
+		h.walReplayWg.Add(1)
+		go func() {
+			defer h.walReplayWg.Done()
+			if err := h.replayDiskChunksAndWAL(); err != nil {
+				h.logger.Error("Fast startup: Background WAL replay failed", "err", err)
+			}
+		}()
+
+		return nil
 	}
 
-	return nil
+	// When feature is not enabled, blocking call.
+	return h.replayDiskChunksAndWAL()
 }
 
 func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) (map[chunks.HeadSeriesRef][]*mmappedChunk, map[chunks.HeadSeriesRef][]*mmappedChunk, chunks.ChunkDiskMapperRef, error) {
@@ -1851,6 +1876,9 @@ func (h *Head) compactable() bool {
 // Close flushes the WAL and closes the head.
 // It also takes a snapshot of in-memory chunks if enabled.
 func (h *Head) Close() error {
+	// Wait for background WAL replay to finish before shutdown.
+	h.walReplayWg.Wait()
+
 	h.closedMtx.Lock()
 	defer h.closedMtx.Unlock()
 	h.closed = true

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -922,30 +922,32 @@ func (h *Head) replayDiskChunksAndWAL() error {
 func (h *Head) Init(minValidTime int64) error {
 	h.minValidTime.Store(minValidTime)
 
-	// Find the last WAL segment.
-	_, endAt, e := wlog.Segments(h.wal.Dir())
-	if e != nil {
-		return fmt.Errorf("finding WAL segments: %w", e)
-	}
-
 	// TODO(RushabhMehta2005): Remove this 'if' block and always run the series state ticker when the feature is fully implemented.
 	if h.opts.EnableFastStartup {
-		state, err := h.readSeriesStateFile()
-		if err != nil && !os.IsNotExist(err) {
-			h.logger.Warn("Failed to read series state file, skipping the fast startup", "err", err)
-		}
-		if err == nil {
-			if state.CleanShutdown {
-				h.lastSeriesID.Store(state.LastSeriesID)
-				h.logger.Info("Fast startup: clean shutdown detected, restored last series ID", "last_series_id", state.LastSeriesID)
-			} else {
-				h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", state.LastWALSegment, "to_segment", endAt)
-				id, scanErr := h.findLastSeriesID(state, endAt)
-				if scanErr != nil {
-					h.logger.Error("Fast startup: WAL scan failed, skipping fast startup", "err", scanErr)
+		if h.wal != nil {
+			// Find the last WAL segment.
+			_, endAt, e := wlog.Segments(h.wal.Dir())
+			if e != nil {
+				return fmt.Errorf("finding WAL segments: %w", e)
+			}
+
+			state, err := h.readSeriesStateFile()
+			if err != nil && !os.IsNotExist(err) {
+				h.logger.Warn("Failed to read series state file, skipping the fast startup", "err", err)
+			}
+			if err == nil {
+				if state.CleanShutdown {
+					h.lastSeriesID.Store(state.LastSeriesID)
+					h.logger.Info("Fast startup: clean shutdown detected, restored last series ID", "last_series_id", state.LastSeriesID)
 				} else {
-					h.lastSeriesID.Store(id)
-					h.logger.Info("Fast startup: WAL scan completed", "last_series_id", id)
+					h.logger.Info("Fast startup: unclean shutdown detected, performing WAL scan", "from_segment", state.LastWALSegment, "to_segment", endAt)
+					id, scanErr := h.findLastSeriesID(state, endAt)
+					if scanErr != nil {
+						h.logger.Error("Fast startup: WAL scan failed, skipping fast startup", "err", scanErr)
+					} else {
+						h.lastSeriesID.Store(id)
+						h.logger.Info("Fast startup: WAL scan completed", "last_series_id", id)
+					}
 				}
 			}
 		}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -289,7 +289,7 @@ func NewHead(r prometheus.Registerer, l *slog.Logger, wal, wbl *wlog.WL, opts *H
 
 	if opts.EnableFastStartup {
 		if opts.OutOfOrderTimeWindow.Load() > 0 {
-			return nil, fmt.Errorf("Fast startup is disabled because Out-Of-Order time window is enabled.")
+			return nil, errors.New("fast startup is disabled because OOO time window is enabled")
 		}
 	}
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -777,7 +777,7 @@ func (h *Head) replayDiskChunksAndWAL() error {
 			snapIdx, snapOffset = -1, 0
 
 			// If this fails, data will be recovered from WAL.
-			// Hence we wont lose any data (given WAL is not corrupt).
+			// Hence we won't lose any data (given WAL is not corrupt).
 			mmappedChunks, oooMmappedChunks, lastMmapRef, err = h.removeCorruptedMmappedChunks(err)
 			if err != nil {
 				return err
@@ -952,13 +952,11 @@ func (h *Head) Init(minValidTime int64) error {
 		h.seriesStateWg.Add(1)
 		go h.runSeriesStateTicker()
 
-		h.walReplayWg.Add(1)
-		go func() {
-			defer h.walReplayWg.Done()
+		h.walReplayWg.Go(func() {
 			if err := h.replayDiskChunksAndWAL(); err != nil {
 				h.logger.Error("Fast startup: Background WAL replay failed", "err", err)
 			}
-		}()
+		})
 
 		return nil
 	}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -144,6 +144,9 @@ type Head struct {
 	// For running the background WAL replay.
 	walReplayWg sync.WaitGroup
 
+	// For signalling when the background WAL replay finishes.
+	walReplayDone chan struct{}
+
 	stats *HeadStats
 	reg   prometheus.Registerer
 
@@ -308,6 +311,7 @@ func NewHead(r prometheus.Registerer, l *slog.Logger, wal, wbl *wlog.WL, opts *H
 		stats:           stats,
 		reg:             r,
 		seriesStateQuit: make(chan struct{}),
+		walReplayDone: make(chan struct{}),
 	}
 	if err := h.resetInMemoryState(); err != nil {
 		return nil, err
@@ -698,9 +702,6 @@ func (h *Head) replayDiskChunksAndWAL() error {
 	h.logger.Info("Replaying on-disk memory mappable chunks if any")
 	start := time.Now()
 
-	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
-	var multiRefMtx sync.Mutex
-
 	snapIdx, snapOffset := -1, 0
 	refSeries := make(map[chunks.HeadSeriesRef]*memSeries)
 
@@ -733,7 +734,7 @@ func (h *Head) replayDiskChunksAndWAL() error {
 		}
 		if loadSnapshot {
 			var err error
-			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot(multiRef, &multiRefMtx)
+			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot()
 			if err == nil {
 				snapshotLoaded = true
 				chunkSnapshotLoadDuration = time.Since(start)
@@ -810,6 +811,7 @@ func (h *Head) replayDiskChunksAndWAL() error {
 	h.startWALReplayStatus(startFrom, endAt)
 
 	syms := labels.NewSymbolTable() // One table for the whole WAL.
+	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
 	if err == nil && startFrom >= snapIdx {
 		sr, err := wlog.NewSegmentsReader(dir)
 		if err != nil {
@@ -953,6 +955,7 @@ func (h *Head) Init(minValidTime int64) error {
 		go h.runSeriesStateTicker()
 
 		h.walReplayWg.Go(func() {
+			defer close(h.walReplayDone)
 			if err := h.replayDiskChunksAndWAL(); err != nil {
 				h.logger.Error("Fast startup: Background WAL replay failed", "err", err)
 			}
@@ -962,7 +965,14 @@ func (h *Head) Init(minValidTime int64) error {
 	}
 
 	// When feature is not enabled, blocking call.
-	return h.replayDiskChunksAndWAL()
+	err := h.replayDiskChunksAndWAL()
+	close(h.walReplayDone)
+	return err
+}
+
+// WaitForWALReplay returns a channel that is closed when the WAL replay has finished. 
+func (h *Head) WaitForWALReplay() <-chan struct{} {
+	return h.walReplayDone
 }
 
 func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) (map[chunks.HeadSeriesRef][]*mmappedChunk, map[chunks.HeadSeriesRef][]*mmappedChunk, chunks.ChunkDiskMapperRef, error) {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -748,7 +748,7 @@ func (h *Head) replayDiskChunksAndWAL() error {
 		}
 		if loadSnapshot {
 			var err error
-			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot()
+			snapIdx, snapOffset, refSeries, err = h.loadChunkSnapshot(targetStripeMap)
 			if err == nil {
 				snapshotLoaded = true
 				chunkSnapshotLoadDuration = time.Since(start)

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1592,7 +1592,7 @@ func DeleteChunkSnapshots(dir string, maxIndex, maxOffset int) error {
 
 // loadChunkSnapshot replays the chunk snapshot and restores the Head state from it. If there was any error returned,
 // it is the responsibility of the caller to clear the contents of the Head.
-func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {
+func (h *Head) loadChunkSnapshot(multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, multiRefMtx *sync.Mutex) (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {
 	dir, snapIdx, snapOffset, err := LastChunkSnapshot(h.opts.ChunkDirRoot)
 	if err != nil {
 		if errors.Is(err, record.ErrNotFound) {
@@ -1641,11 +1641,19 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 			localRefSeries := shardedRefSeries[idx]
 
 			for csr := range rc {
-				series, _, err := h.getOrCreateWithOptionalID(csr.ref, csr.lset.Hash(), csr.lset, false)
+				series, created, err := h.getOrCreateWithOptionalID(csr.ref, csr.lset.Hash(), csr.lset, false)
 				if err != nil {
 					errChan <- err
 					return
 				}
+
+				if h.opts.EnableFastStartup && !created {
+					// This is not a newly created series, update the multiRef.
+					multiRefMtx.Lock()
+					multiRef[csr.ref] = series.ref
+					multiRefMtx.Unlock()
+				}
+
 				localRefSeries[csr.ref] = series
 				for {
 					seriesID := uint64(series.ref)

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -76,7 +76,7 @@ func counterAddNonZero(v *prometheus.CounterVec, value float64, lvs ...string) {
 	}
 }
 
-func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, mmappedChunks, oooMmappedChunks map[chunks.HeadSeriesRef][]*mmappedChunk) (err error) {
+func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, mmappedChunks, oooMmappedChunks map[chunks.HeadSeriesRef][]*mmappedChunk, targetStripeMap *stripeSeries) (err error) {
 	// Track number of missing series records that were referenced by other records.
 	unknownSeriesRefs := &seriesRefSet{refs: make(map[chunks.HeadSeriesRef]struct{}), mtx: sync.Mutex{}}
 	// Track number of different records that referenced a series we don't know about
@@ -136,7 +136,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		var err error
 		defer wg.Done()
 		for e := range input {
-			ms := h.series.getByID(e.Ref)
+			ms := targetStripeMap.getByID(e.Ref)
 			if ms == nil {
 				unknownExemplarRefs.Inc()
 				missingSeries[e.Ref] = struct{}{}
@@ -255,7 +255,7 @@ Outer:
 		switch v := d.(type) {
 		case []record.RefSeries:
 			for _, walSeries := range v {
-				mSeries, created, err := h.getOrCreateWithOptionalID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels, false)
+				mSeries, created, err := h.getOrCreateInStripe(targetStripeMap, walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels, false)
 				if err != nil {
 					seriesCreationErr = err
 					break Outer
@@ -335,7 +335,7 @@ Outer:
 						h.updateWALExpiry(chunks.HeadSeriesRef(s.Ref), itv.Maxt)
 						s.Ref = storage.SeriesRef(r)
 					}
-					if m := h.series.getByID(chunks.HeadSeriesRef(s.Ref)); m == nil {
+					if m := targetStripeMap.getByID(chunks.HeadSeriesRef(s.Ref)); m == nil {
 						unknownTombstoneRefs.Inc()
 						missingSeries[chunks.HeadSeriesRef(s.Ref)] = struct{}{}
 						continue
@@ -446,7 +446,7 @@ Outer:
 				if r, ok := multiRef[m.Ref]; ok {
 					m.Ref = r
 				}
-				s := h.series.getByID(m.Ref)
+				s := targetStripeMap.getByID(m.Ref)
 				if s == nil {
 					unknownMetadataRefs.Inc()
 					missingSeries[m.Ref] = struct{}{}

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1592,7 +1592,7 @@ func DeleteChunkSnapshots(dir string, maxIndex, maxOffset int) error {
 
 // loadChunkSnapshot replays the chunk snapshot and restores the Head state from it. If there was any error returned,
 // it is the responsibility of the caller to clear the contents of the Head.
-func (h *Head) loadChunkSnapshot(multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, multiRefMtx *sync.Mutex) (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {
+func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {
 	dir, snapIdx, snapOffset, err := LastChunkSnapshot(h.opts.ChunkDirRoot)
 	if err != nil {
 		if errors.Is(err, record.ErrNotFound) {
@@ -1641,17 +1641,10 @@ func (h *Head) loadChunkSnapshot(multiRef map[chunks.HeadSeriesRef]chunks.HeadSe
 			localRefSeries := shardedRefSeries[idx]
 
 			for csr := range rc {
-				series, created, err := h.getOrCreateWithOptionalID(csr.ref, csr.lset.Hash(), csr.lset, false)
+				series, _, err := h.getOrCreateWithOptionalID(csr.ref, csr.lset.Hash(), csr.lset, false)
 				if err != nil {
 					errChan <- err
 					return
-				}
-
-				if h.opts.EnableFastStartup && !created {
-					// This is not a newly created series, update the multiRef.
-					multiRefMtx.Lock()
-					multiRef[csr.ref] = series.ref
-					multiRefMtx.Unlock()
 				}
 
 				localRefSeries[csr.ref] = series

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1954,3 +1954,54 @@ func (h *Head) findLastSeriesID(state SeriesLifecycleState, endSegment int) (uin
 	// the ID from our state file has to be used.
 	return state.LastSeriesID, nil
 }
+
+// mergeWALSeries is called once the WAL replay is done, and merges the data in the WAL map, into the live scraper map.
+func (h *Head) mergeWALSeries() {
+	h.logger.Info("Starting to merge WAL series into live series")
+	start := time.Now()
+
+	for i := 0; i < h.walSeries.size; i++ {
+		addedSeries := make([]labels.Labels, 0)
+
+		h.series.locks[i].Lock()
+
+		// Helper function to process a single series. 
+		processWALSeries := func(hash uint64, walS *memSeries) {
+			liveS, exists := h.series.series[i][walS.ref]
+
+			if !exists {
+				// First case: The scraper hasn't seen this series yet.
+				// Move it over to the live maps.
+				h.series.series[i][walS.ref] = walS
+				h.series.hashes[i].set(hash, walS) 				
+				addedSeries = append(addedSeries, walS.lset)
+				return
+			}
+
+			// Other case: overlap
+			// liveS.Lock()
+			// walS.Lock()
+			
+			// TODO: Implement this: h.mergeOverlappingSeries(walS, liveS)
+			
+			// walS.Unlock()
+			// liveS.Unlock()
+		}
+
+		// Iterate conflicts first
+		for hash, all := range h.walSeries.hashes[i].conflicts {
+			for _, walS := range all {
+				processWALSeries(hash, walS)
+			}
+		}
+
+		// Iterate uniques 
+		for hash, walS := range h.walSeries.hashes[i].unique {
+			processWALSeries(hash, walS)
+		}
+
+		h.series.locks[i].Unlock()
+	}
+
+	h.logger.Info("WAL series merge completed", "duration", time.Since(start).String())
+}

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -120,7 +120,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		processors[i].setup()
 
 		go func(wp *walSubsetProcessor) {
-			missingSeries, unknownSamples, unknownHistograms, overlapping := wp.processWALSamples(h, mmappedChunks, oooMmappedChunks)
+			missingSeries, unknownSamples, unknownHistograms, overlapping := wp.processWALSamples(h, mmappedChunks, oooMmappedChunks, targetStripeMap)
 			unknownSeriesRefs.merge(missingSeries)
 			unknownSampleRefs.Add(unknownSamples)
 			mmapOverlappingChunks.Add(overlapping)
@@ -634,7 +634,7 @@ func (wp *walSubsetProcessor) reuseHistogramBuf() []histogramRecord {
 // processWALSamples adds the samples it receives to the head and passes
 // the buffer received to an output channel for reuse.
 // Samples before the minValidTime timestamp are discarded.
-func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmappedChunks map[chunks.HeadSeriesRef][]*mmappedChunk) (map[chunks.HeadSeriesRef]struct{}, uint64, uint64, uint64) {
+func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmappedChunks map[chunks.HeadSeriesRef][]*mmappedChunk, targetStripeMap *stripeSeries) (map[chunks.HeadSeriesRef]struct{}, uint64, uint64, uint64) {
 	defer close(wp.output)
 	defer close(wp.histogramsOutput)
 
@@ -661,7 +661,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 		}
 
 		for _, s := range in.samples {
-			ms := h.series.getByID(s.Ref)
+			ms := targetStripeMap.getByID(s.Ref)
 			if ms == nil {
 				unknownSampleRefs++
 				missingSeries[s.Ref] = struct{}{}
@@ -699,7 +699,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if s.t < minValidTime {
 				continue
 			}
-			ms := h.series.getByID(s.ref)
+			ms := targetStripeMap.getByID(s.ref)
 			if ms == nil {
 				unknownHistogramRefs++
 				missingSeries[s.ref] = struct{}{}
@@ -1592,7 +1592,7 @@ func DeleteChunkSnapshots(dir string, maxIndex, maxOffset int) error {
 
 // loadChunkSnapshot replays the chunk snapshot and restores the Head state from it. If there was any error returned,
 // it is the responsibility of the caller to clear the contents of the Head.
-func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {
+func (h *Head) loadChunkSnapshot(targetStripeMap *stripeSeries) (int, int, map[chunks.HeadSeriesRef]*memSeries, error) {
 	dir, snapIdx, snapOffset, err := LastChunkSnapshot(h.opts.ChunkDirRoot)
 	if err != nil {
 		if errors.Is(err, record.ErrNotFound) {
@@ -1641,7 +1641,7 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 			localRefSeries := shardedRefSeries[idx]
 
 			for csr := range rc {
-				series, _, err := h.getOrCreateWithOptionalID(csr.ref, csr.lset.Hash(), csr.lset, false)
+				series, _, err := h.getOrCreateInStripe(targetStripeMap, csr.ref, csr.lset.Hash(), csr.lset, false)
 				if err != nil {
 					errChan <- err
 					return


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
NONE
#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```


- This is PR 4, which currently has the commits of [PR 3](https://github.com/prometheus/prometheus/pull/18442) along with it. 
- This PR has the following needs to be met:
- - Make sure that when the WAL replay is happening in the background, the WAL data goes to a seperate map (not `h.series`)
- - Once the WAL replay is finished, merge the wal data with the scraping data
- - this is only enabled when OOO samples are not a possibility
