### PR TITLE
tsdb/chunks: retry removing empty head chunk file on windows sharing violation

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -443,7 +443,7 @@ func repairLastChunkFile(files map[int]string) (_ map[int]string, returnErr erro
 	// for proper repair mechanism to happen in the Head.
 	if size < MagicChunksSize || binary.BigEndian.Uint32(buf) == 0 {
 		// Corrupt file, hence remove it.
-		if err := os.RemoveAll(files[lastFile]); err != nil {
+		if err := removeChunkFile(files[lastFile]); err != nil {
 			return files, fmt.Errorf("delete corrupted, empty head chunk file during last file repair: %w", err)
 		}
 		delete(files, lastFile)

--- a/tsdb/chunks/head_chunks_other.go
+++ b/tsdb/chunks/head_chunks_other.go
@@ -15,7 +15,16 @@
 
 package chunks
 
+import "os"
+
 // HeadChunkFilePreallocationSize is the size to which the m-map file should be preallocated when a new file is cut.
 // Windows needs pre-allocations while the other OS does not. But we observed that a 0 pre-allocation causes unit tests to flake.
 // This small allocation for non-Windows OSes removes the flake.
 var HeadChunkFilePreallocationSize int64 = MinWriteBufferSize * 2
+
+// removeChunkFile deletes a head chunk file. The Windows build has a retry
+// wrapper around os.Remove to tolerate transient sharing violations caused by
+// antivirus and indexing services; non-Windows platforms need no such retry.
+func removeChunkFile(path string) error {
+	return os.Remove(path)
+}

--- a/tsdb/chunks/head_chunks_windows.go
+++ b/tsdb/chunks/head_chunks_windows.go
@@ -13,6 +13,51 @@
 
 package chunks
 
+import (
+	"errors"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
 // HeadChunkFilePreallocationSize is the size to which the m-map file should be preallocated when a new file is cut.
 // Windows needs pre-allocation to m-map the file.
 var HeadChunkFilePreallocationSize int64 = MaxHeadChunkFileSize
+
+// removeChunkFile deletes a head chunk file, briefly retrying on transient
+// Windows errors caused by antivirus or file-indexing processes that open a
+// freshly created file without granting FILE_SHARE_DELETE. While such a handle
+// is held, os.Remove fails with ERROR_SHARING_VIOLATION (or occasionally
+// ERROR_ACCESS_DENIED for a file already marked for deletion). This mirrors
+// the retry policy used by Go's own testing package; see
+// https://github.com/prometheus/prometheus/issues/16176 and
+// https://go.dev/issue/51442.
+func removeChunkFile(path string) error {
+	const (
+		initialBackoff = 1 * time.Millisecond
+		maxBackoff     = 250 * time.Millisecond
+		deadline       = 2 * time.Second
+	)
+
+	backoff := initialBackoff
+	start := time.Now()
+	for {
+		err := os.Remove(path)
+		if err == nil || !isRetryableRemoveError(err) {
+			return err
+		}
+		if time.Since(start) >= deadline {
+			return err
+		}
+		time.Sleep(backoff)
+		backoff = min(backoff*2, maxBackoff)
+	}
+}
+
+// isRetryableRemoveError reports whether err is a Windows filesystem error that
+// typically clears itself when retried, as used by Go's testing.removeAll.
+func isRetryableRemoveError(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_ACCESS_DENIED)
+}

--- a/tsdb/chunks/head_chunks_windows.go
+++ b/tsdb/chunks/head_chunks_windows.go
@@ -25,6 +25,8 @@ import (
 // Windows needs pre-allocation to m-map the file.
 var HeadChunkFilePreallocationSize int64 = MaxHeadChunkFileSize
 
+var removeOS = os.Remove
+
 // removeChunkFile deletes a head chunk file, briefly retrying on transient
 // Windows errors caused by antivirus or file-indexing processes that open a
 // freshly created file without granting FILE_SHARE_DELETE. While such a handle
@@ -43,7 +45,7 @@ func removeChunkFile(path string) error {
 	backoff := initialBackoff
 	start := time.Now()
 	for {
-		err := os.Remove(path)
+		err := removeOS(path)
 		if err == nil || !isRetryableRemoveError(err) {
 			return err
 		}

--- a/tsdb/chunks/head_chunks_windows_test.go
+++ b/tsdb/chunks/head_chunks_windows_test.go
@@ -1,0 +1,86 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package chunks
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// TestRepairLastChunkFile_RetriesSharingViolation reproduces the Windows-only
+// flake reported in https://github.com/prometheus/prometheus/issues/16176 in a
+// deterministic way: a background goroutine opens the corrupted chunk file
+// with syscall.CreateFile but without FILE_SHARE_DELETE, exactly as an
+// antivirus or file-indexing service would. Under those conditions a plain
+// os.Remove fails with ERROR_SHARING_VIOLATION, so repairLastChunkFile must
+// retry until the blocking handle is released.
+func TestRepairLastChunkFile_RetriesSharingViolation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "000001")
+	require.NoError(t, os.WriteFile(path, nil, 0o666))
+
+	pathp, err := syscall.UTF16PtrFromString(path)
+	require.NoError(t, err)
+	handle, err := syscall.CreateFile(
+		pathp,
+		syscall.GENERIC_READ,
+		// Note the missing FILE_SHARE_DELETE: this is what makes DeleteFile
+		// (and therefore os.Remove) fail with ERROR_SHARING_VIOLATION while
+		// the handle is held.
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE,
+		nil,
+		syscall.OPEN_EXISTING,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	require.NoError(t, err)
+
+	var closeOnce sync.Once
+	closeHandle := func() { closeOnce.Do(func() { _ = syscall.CloseHandle(handle) }) }
+	t.Cleanup(closeHandle)
+
+	// Sanity check: while the handle is held, a plain os.Remove must fail with
+	// the exact errno the retry helper watches for. If this ever changes the
+	// test would pass trivially and no longer exercise the bug, so assert it.
+	require.ErrorIs(t, os.Remove(path), windows.ERROR_SHARING_VIOLATION)
+
+	// Release the blocking handle after a short delay, well below the 2s
+	// retry deadline, so the retry loop observes both the failure and the
+	// subsequent success.
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		time.Sleep(100 * time.Millisecond)
+		closeHandle()
+	}()
+
+	files, err := repairLastChunkFile(map[int]string{1: path})
+	require.NoError(t, err)
+	require.Empty(t, files, "corrupted last chunk file should have been removed from the map")
+
+	<-released
+	_, statErr := os.Stat(path)
+	require.ErrorIs(t, statErr, os.ErrNotExist, "corrupted last chunk file should have been deleted from disk")
+}

--- a/tsdb/chunks/head_chunks_windows_test.go
+++ b/tsdb/chunks/head_chunks_windows_test.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
@@ -66,13 +65,23 @@ func TestRepairLastChunkFile_RetriesSharingViolation(t *testing.T) {
 	// test would pass trivially and no longer exercise the bug, so assert it.
 	require.ErrorIs(t, os.Remove(path), windows.ERROR_SHARING_VIOLATION)
 
-	// Release the blocking handle after a short delay, well below the 2s
-	// retry deadline, so the retry loop observes both the failure and the
-	// subsequent success.
+	trigger := make(chan struct{}, 1)
+	oldRemoveOS := removeOS
+	t.Cleanup(func() { removeOS = oldRemoveOS })
+	removeOS = func(name string) error {
+		select {
+		case trigger <- struct{}{}:
+		default:
+		}
+		return oldRemoveOS(name)
+	}
+
+	// Release the blocking handle as soon as the retry loop attempts its
+	// first deletion, to reliably exercise the retry behavior without timeouts.
 	released := make(chan struct{})
 	go func() {
 		defer close(released)
-		time.Sleep(100 * time.Millisecond)
+		<-trigger
 		closeHandle()
 	}()
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

fixes #16176

the windows ci runner periodically fails `TestDBReadOnly_Querier_NoAlteration/doesn't truncate corrupted chunks` with `ERROR_SHARING_VIOLATION` when `repairLastChunkFile` tries to delete the corrupted head chunk. the repair path closes its own handle before calling `os.Remove`, so the blocker is a different process — typically windows defender or the search indexer briefly opening the newly created file without granting `FILE_SHARE_DELETE`. the CI trace also shows `testing.TempDir` cleanup failing on the same file, which confirms the handle lives outside the go process.

fix is a narrow retry around the remove, windows-only, modeled on go's own `testing.removeAll` (2s deadline, retries `ERROR_SHARING_VIOLATION` and `ERROR_ACCESS_DENIED`). non-windows builds get a trivial wrapper so the package still links.

regression test uses `syscall.CreateFile` without `FILE_SHARE_DELETE` to deterministically reproduce the failure; fails on master, passes with the fix.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] TSDB: Retry deleting an empty head chunk file on Windows when the OS briefly reports a sharing violation.
```