### PR TITLE
storage/remote: don't run TestReshardPartialBatch in parallel

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -604,7 +604,11 @@ func TestReshardRaceWithStop(t *testing.T) {
 }
 
 func TestReshardPartialBatch(t *testing.T) {
-	t.Parallel()
+	// Intentionally not t.Parallel(): the 2s deadlock-detection deadline below
+	// assumes shards.stop() completes promptly, which is not reliable when the
+	// other reshard tests (TestReshard spawns up to 60 shards, TestReshardRaceWithStop
+	// drives 100 reshards) are running concurrently and starving the scheduler.
+	// See https://github.com/prometheus/prometheus/issues/18078.
 	for _, protoMsg := range []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType} {
 		t.Run(fmt.Sprint(protoMsg), func(t *testing.T) {
 			recs := testwal.GenerateRecords(recCase{


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18078

#### Description

`TestReshardPartialBatch` runs 100 iterations of `shards.stop()` / `shards.start(1)` with a 2-second deadline per iteration, treating any slower completion as a deadlock:

```go
select {
case <-done:
case <-time.After(2 * time.Second):
    t.Error(\"Deadlock between sending and stopping detected\")
    ...
    t.FailNow()
}
```

Under normal conditions one iteration takes ~10–50ms, so the 2s window is plenty. But the stack trace attached to #18078 shows the test timing out while 72 `runShard` goroutines from other parallel tests are active — those are from `TestReshard` (spawns up to 60 shards) and `TestReshardRaceWithStop` (drives 100 reshards back-to-back). Under that kind of scheduler pressure, a legitimate non-deadlocked `stop()` can occasionally cross 2s, and the test misreports it as a deadlock.

`t.Parallel()` was added to `TestReshardPartialBatch` (and most of its neighbours) in bulk in fe1bb5337 as part of a general \"parallelize everything\" pass — the flakiness started from that point. The other reshard tests are less timing-sensitive, but this one explicitly measures shutdown latency, so running it alongside them invalidates the premise.

Dropping `t.Parallel()` here restores the test's original isolation. It still detects a real deadlock (it would never complete), it just stops firing false positives when the CPU is saturated by its siblings. I did 5× runs of `go test -count=20 -run TestReshardPartialBatch` and 5× runs of `go test -count=5 -run TestReshard` (all three reshard tests together) locally and got zero failures.

#### Does this PR introduce a user-facing change?

```release-notes
NONE
```