### PR TITLE
build: remove DOCKER_REGISTRY_ARCH_EXCLUSIONS and DOCKERFILE_ARCH_EXCLUSIONS logic

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -92,7 +92,6 @@ endif
 
 DOCKER_ARCHS ?= amd64 arm64 armv7 ppc64le riscv64 s390x
 DOCKERFILE_ARCH_EXCLUSIONS ?=
-DOCKER_REGISTRY_ARCH_EXCLUSIONS ?=
 DOCKERFILE_VARIANTS     ?= $(wildcard Dockerfile Dockerfile.*)
 
 # Function to extract variant from Dockerfile label.
@@ -115,16 +114,6 @@ DOCKERFILE_VARIANTS_WITH_NAMES := $(foreach df,$(DOCKERFILE_VARIANTS),$(call doc
 define dockerfile_arch_is_excluded
 case " $(DOCKERFILE_ARCH_EXCLUSIONS) " in \
 	*" $$dockerfile:$(1) "*) true ;; \
-	*) false ;; \
-esac
-endef
-
-# Shell helper to check whether a registry/arch pair is excluded.
-# Extracts registry from DOCKER_REPO (e.g., quay.io/prometheus -> quay.io)
-define registry_arch_is_excluded
-registry=$$(echo "$(DOCKER_REPO)" | cut -d'/' -f1); \
-case " $(DOCKER_REGISTRY_ARCH_EXCLUSIONS) " in \
-	*" $$registry:$(1) "*) true ;; \
 	*) false ;; \
 esac
 endef
@@ -312,10 +301,6 @@ $(PUBLISH_DOCKER_ARCHS): common-docker-publish-%:
 			echo "Skipping push for $$variant_name variant on linux-$* (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
 			continue; \
 		fi; \
-		if $(call registry_arch_is_excluded,$*); then \
-			echo "Skipping push for $$variant_name variant on linux-$* to $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
-			continue; \
-		fi; \
 		if [ "$$dockerfile" != "Dockerfile" ] || [ "$$variant_name" != "default" ]; then \
 			echo "Pushing $$variant_name variant for linux-$*"; \
 			docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name"; \
@@ -347,10 +332,6 @@ $(TAG_DOCKER_ARCHS): common-docker-tag-latest-%:
 			echo "Skipping tag for $$variant_name variant on linux-$* (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
 			continue; \
 		fi; \
-		if $(call registry_arch_is_excluded,$*); then \
-			echo "Skipping tag for $$variant_name variant on linux-$* for $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
-			continue; \
-		fi; \
 		if [ "$$dockerfile" != "Dockerfile" ] || [ "$$variant_name" != "default" ]; then \
 			echo "Tagging $$variant_name variant for linux-$* as latest"; \
 			docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:latest-$$variant_name"; \
@@ -376,10 +357,6 @@ common-docker-manifest:
 					echo "  Skipping $$arch for $$variant_name (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
 					continue; \
 				fi; \
-				if $(call registry_arch_is_excluded,$$arch); then \
-					echo "  Skipping $$arch for $$variant_name on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
-					continue; \
-				fi; \
 				refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name"; \
 			done; \
 			if [ -z "$$refs" ]; then \
@@ -395,10 +372,6 @@ common-docker-manifest:
 			for arch in $(DOCKER_ARCHS); do \
 				if $(call dockerfile_arch_is_excluded,$$arch); then \
 					echo "  Skipping $$arch for default variant (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
-					continue; \
-				fi; \
-				if $(call registry_arch_is_excluded,$$arch); then \
-					echo "  Skipping $$arch for default variant on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
 					continue; \
 				fi; \
 				refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:$(SANITIZED_DOCKER_IMAGE_TAG)"; \
@@ -419,10 +392,6 @@ common-docker-manifest:
 						echo "  Skipping $$arch for $$variant_name version tag (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
 						continue; \
 					fi; \
-					if $(call registry_arch_is_excluded,$$arch); then \
-						echo "  Skipping $$arch for $$variant_name version tag on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
-						continue; \
-					fi; \
 					refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:v$(DOCKER_MAJOR_VERSION_TAG)-$$variant_name"; \
 				done; \
 				if [ -z "$$refs" ]; then \
@@ -438,10 +407,6 @@ common-docker-manifest:
 				for arch in $(DOCKER_ARCHS); do \
 					if $(call dockerfile_arch_is_excluded,$$arch); then \
 						echo "  Skipping $$arch for default variant version tag (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
-						continue; \
-					fi; \
-					if $(call registry_arch_is_excluded,$$arch); then \
-						echo "  Skipping $$arch for default variant version tag on $(DOCKER_REPO) (excluded by DOCKER_REGISTRY_ARCH_EXCLUSIONS)"; \
 						continue; \
 					fi; \
 					refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:v$(DOCKER_MAJOR_VERSION_TAG)"; \

--- a/Makefile.common
+++ b/Makefile.common
@@ -91,7 +91,6 @@ $(error DOCKERFILE_PATH is deprecated. Use DOCKERFILE_VARIANTS ?= $(DOCKERFILE_P
 endif
 
 DOCKER_ARCHS ?= amd64 arm64 armv7 ppc64le riscv64 s390x
-DOCKERFILE_ARCH_EXCLUSIONS ?=
 DOCKERFILE_VARIANTS     ?= $(wildcard Dockerfile Dockerfile.*)
 
 # Function to extract variant from Dockerfile label.
@@ -109,14 +108,6 @@ endif
 
 # Build variant:dockerfile pairs for shell iteration.
 DOCKERFILE_VARIANTS_WITH_NAMES := $(foreach df,$(DOCKERFILE_VARIANTS),$(call dockerfile_variant,$(df)):$(df))
-
-# Shell helper to check whether a dockerfile/arch pair is excluded.
-define dockerfile_arch_is_excluded
-case " $(DOCKERFILE_ARCH_EXCLUSIONS) " in \
-	*" $$dockerfile:$(1) "*) true ;; \
-	*) false ;; \
-esac
-endef
 
 BUILD_DOCKER_ARCHS = $(addprefix common-docker-,$(DOCKER_ARCHS))
 PUBLISH_DOCKER_ARCHS = $(addprefix common-docker-publish-,$(DOCKER_ARCHS))
@@ -259,10 +250,6 @@ $(BUILD_DOCKER_ARCHS): common-docker-%:
 	@for variant in $(DOCKERFILE_VARIANTS_WITH_NAMES); do \
 		dockerfile=$${variant#*:}; \
 		variant_name=$${variant%%:*}; \
-		if $(call dockerfile_arch_is_excluded,$*); then \
-			echo "Skipping $$variant_name variant for linux-$* (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
-			continue; \
-		fi; \
 		distroless_arch="$*"; \
 		if [ "$*" = "armv7" ]; then \
 			distroless_arch="arm"; \
@@ -297,10 +284,6 @@ $(PUBLISH_DOCKER_ARCHS): common-docker-publish-%:
 	@for variant in $(DOCKERFILE_VARIANTS_WITH_NAMES); do \
 		dockerfile=$${variant#*:}; \
 		variant_name=$${variant%%:*}; \
-		if $(call dockerfile_arch_is_excluded,$*); then \
-			echo "Skipping push for $$variant_name variant on linux-$* (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
-			continue; \
-		fi; \
 		if [ "$$dockerfile" != "Dockerfile" ] || [ "$$variant_name" != "default" ]; then \
 			echo "Pushing $$variant_name variant for linux-$*"; \
 			docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name"; \
@@ -328,10 +311,6 @@ $(TAG_DOCKER_ARCHS): common-docker-tag-latest-%:
 	@for variant in $(DOCKERFILE_VARIANTS_WITH_NAMES); do \
 		dockerfile=$${variant#*:}; \
 		variant_name=$${variant%%:*}; \
-		if $(call dockerfile_arch_is_excluded,$*); then \
-			echo "Skipping tag for $$variant_name variant on linux-$* (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
-			continue; \
-		fi; \
 		if [ "$$dockerfile" != "Dockerfile" ] || [ "$$variant_name" != "default" ]; then \
 			echo "Tagging $$variant_name variant for linux-$* as latest"; \
 			docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:latest-$$variant_name"; \
@@ -353,10 +332,6 @@ common-docker-manifest:
 			echo "Creating manifest for $$variant_name variant"; \
 			refs=""; \
 			for arch in $(DOCKER_ARCHS); do \
-				if $(call dockerfile_arch_is_excluded,$$arch); then \
-					echo "  Skipping $$arch for $$variant_name (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
-					continue; \
-				fi; \
 				refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:$(SANITIZED_DOCKER_IMAGE_TAG)-$$variant_name"; \
 			done; \
 			if [ -z "$$refs" ]; then \
@@ -370,10 +345,6 @@ common-docker-manifest:
 			echo "Creating default variant ($$variant_name) manifest"; \
 			refs=""; \
 			for arch in $(DOCKER_ARCHS); do \
-				if $(call dockerfile_arch_is_excluded,$$arch); then \
-					echo "  Skipping $$arch for default variant (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
-					continue; \
-				fi; \
 				refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:$(SANITIZED_DOCKER_IMAGE_TAG)"; \
 			done; \
 			if [ -z "$$refs" ]; then \
@@ -388,10 +359,6 @@ common-docker-manifest:
 				echo "Creating manifest for $$variant_name variant version tag"; \
 				refs=""; \
 				for arch in $(DOCKER_ARCHS); do \
-					if $(call dockerfile_arch_is_excluded,$$arch); then \
-						echo "  Skipping $$arch for $$variant_name version tag (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
-						continue; \
-					fi; \
 					refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:v$(DOCKER_MAJOR_VERSION_TAG)-$$variant_name"; \
 				done; \
 				if [ -z "$$refs" ]; then \
@@ -405,10 +372,6 @@ common-docker-manifest:
 				echo "Creating default variant version tag manifest"; \
 				refs=""; \
 				for arch in $(DOCKER_ARCHS); do \
-					if $(call dockerfile_arch_is_excluded,$$arch); then \
-						echo "  Skipping $$arch for default variant version tag (excluded by DOCKERFILE_ARCH_EXCLUSIONS)"; \
-						continue; \
-					fi; \
 					refs="$$refs $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$$arch:v$(DOCKER_MAJOR_VERSION_TAG)"; \
 				done; \
 				if [ -z "$$refs" ]; then \


### PR DESCRIPTION
This mechanism was introduced to skip pushing riscv64 images to registries that were misconfigured to not accept that architecture. The misconfiguration has now been fixed across all repositories, so this workaround is no longer needed.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
