### PR TITLE
Enable govulncheck in CI

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,21 @@
+---
+name: govulncheck
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  schedule:
+    - cron: '33 2 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    name: Run govulncheck
+    steps:
+      - id: govulncheck
+        uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd # v1.0.4-unreleased

--- a/Makefile.common
+++ b/Makefile.common
@@ -425,9 +425,3 @@ $(1)_precheck:
 		exit 1; \
 	fi
 endef
-
-govulncheck: install-govulncheck
-	govulncheck ./...
-
-install-govulncheck:
-	command -v govulncheck > /dev/null || go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ examples and guides.</p>
 [![Docker Pulls](https://img.shields.io/docker/pulls/prom/prometheus.svg?maxAge=604800)][hub]
 [![Go Report Card](https://goreportcard.com/badge/github.com/prometheus/prometheus)](https://goreportcard.com/report/github.com/prometheus/prometheus)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/486/badge)](https://bestpractices.coreinfrastructure.org/projects/486)
+[![govluncheck](https://github.com/prometheus/prometheus/actions/workflows/govluncheck.yml/badge.svg?event=schedule)](https://github.com/prometheus/prometheus/actions/workflows/govluncheck.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/prometheus/prometheus/badge)](https://securityscorecards.dev/viewer/?uri=github.com/prometheus/prometheus)
 [![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/prometheus/badge)](https://clomonitor.io/projects/cncf/prometheus)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/prometheus.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:prometheus)

--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -53,7 +53,7 @@ if [ -z "${GITHUB_TOKEN}" ]; then
 fi
 
 # List of files that should be synced.
-SYNC_FILES="CODE_OF_CONDUCT.md LICENSE Makefile.common SECURITY.md .dockerignore .yamllint scripts/golangci-lint.yml .github/workflows/scorecards.yml .github/workflows/container_description.yml .github/workflows/stale.yml"
+SYNC_FILES="CODE_OF_CONDUCT.md LICENSE Makefile.common SECURITY.md .dockerignore .yamllint scripts/golangci-lint.yml .github/workflows/govulncheck.yml .github/workflows/scorecards.yml .github/workflows/container_description.yml .github/workflows/stale.yml"
 
 # Go to the root of the repo
 cd "$(git rev-parse --show-cdup)" || exit 1
@@ -128,7 +128,7 @@ process_repo() {
   local org_repo
   local default_branch
   org_repo="$1"
-  repo_log_green "Analyzing '${org_repo}'"
+  repo_log "Analyzing '${org_repo}'"
 
   default_branch="$(get_default_branch "${org_repo}")"
   if [[ -z "${default_branch}" ]]; then
@@ -140,9 +140,15 @@ process_repo() {
   local needs_update=()
   for source_file in ${SYNC_FILES}; do
     source_checksum="$(sha256sum "${source_dir}/${source_file}" | cut -d' ' -f1)"
-    if [[ "${source_file}" == 'scripts/golangci-lint.yml' ]] && ! check_go "${org_repo}" "${default_branch}" ; then
-      repo_log "${org_repo} is not Go, skipping golangci-lint.yml."
-      continue
+    if ! check_go "${org_repo}" "${default_branch}" ; then
+      if [[ "${source_file}" == 'scripts/golangci-lint.yml' ]] ; then
+        repo_log "${org_repo} is not Go, skipping golangci-lint.yml."
+        continue
+      fi
+      if [[ "${source_file}" == '.github/workflows/govulncheck.yml' ]] ; then
+        repo_log "${org_repo} is not Go, skipping govulncheck.yml."
+        continue
+      fi
     fi
     if ! check_docker "${org_repo}" "${default_branch}" ; then
       if [[ "${source_file}" == '.dockerignore' ]] ; then
@@ -166,7 +172,7 @@ process_repo() {
     if [[ -z "${target_file}" ]]; then
       repo_log "${target_filename} doesn't exist in ${org_repo}"
       case "${source_file}" in
-        CODE_OF_CONDUCT.md | SECURITY.md | .dockerignore | .github/workflows/container_description.yml)
+        CODE_OF_CONDUCT.md | SECURITY.md | .dockerignore | .github/workflows/container_description.yml | .github/workflows/govulncheck.yml)
           repo_log_yellow "${source_file} missing in ${org_repo}, force updating."
           needs_update+=("${source_file}")
           ;;
@@ -175,7 +181,7 @@ process_repo() {
     fi
     target_checksum="$(echo "${target_file}" | sha256sum | cut -d' ' -f1)"
     if [ "${source_checksum}" == "${target_checksum}" ]; then
-      repo_log_green "${source_file} is already in sync."
+      repo_log "${source_file} is already in sync."
       continue
     fi
     repo_log_yellow "${source_file} needs updating."


### PR DESCRIPTION
Add a CI job to run govulncheck.
* Run daily.
* Run when touching go.{mod,sum}.on PRs and merge to the default branch.
* Cleanup unused / broken govulncheck in Makefile.common.
* Add status badge.
* Add to repo sync for all Go projects.
* Reduce green lines in sync script to make it easier to read the log.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
