### PR TITLE
promql: detect and warn on overlapping start timestamps

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3085,7 +3085,6 @@ loop:
 	return floats, histograms, startTimestamps
 }
 
-
 func (*evaluator) VectorAnd(lhs, rhs Vector, matching *parser.VectorMatching, lhsh, rhsh []EvalSeriesHelper, enh *EvalNodeHelper) Vector {
 	if matching.Card != parser.CardManyToMany {
 		panic("set operations must only use many-to-many matching")

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3085,6 +3085,7 @@ loop:
 	return floats, histograms, startTimestamps
 }
 
+
 func (*evaluator) VectorAnd(lhs, rhs Vector, matching *parser.VectorMatching, lhsh, rhsh []EvalSeriesHelper, enh *EvalNodeHelper) Vector {
 	if matching.Card != parser.CardManyToMany {
 		panic("set operations must only use many-to-many matching")

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -521,7 +521,7 @@ func extrapolatedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper,
 			prevPoint := samples.Floats[i]
 			// Check for start timestamp overlap once.
 			if i+1 < len(startTimestamps) {
-				if overlap := checkStartTimeOverlap(startTimestamps[i], prevPoint.T, startTimestamps[i+1]); overlap {
+				if checkStartTimeOverlap(startTimestamps[i], prevPoint.T, startTimestamps[i+1]) {
 					// Extract metric name only when needed.
 					annos.Add(annotations.NewStartTimeOverlapWarning(getMetricName(samples.Metric), args[0].PositionRange()))
 					break
@@ -725,7 +725,7 @@ func histogramRate(
 			curr := currPoint.H
 			// Check for start timestamp overlap once.
 			if i+1 < len(startTimestamps) {
-				if overlap := checkStartTimeOverlap(startTimestamps[i], points[i].T, startTimestamps[i+1]); overlap {
+				if checkStartTimeOverlap(startTimestamps[i], points[i].T, startTimestamps[i+1]) {
 					// Extract metric name only when needed.
 					annos.Add(annotations.NewStartTimeOverlapWarning(getMetricName(labels), pos))
 					break

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -765,7 +765,7 @@ func histogramRate(
 //   - Valid deltas: currST = prevT (no overlap detected)
 //   - Valid cumulative: currST = prevST (no overlap detected)
 //   - Invalid overlap: currST < prevT && currST != prevST (overlap detected)
-func checkStartTimeOverlap(prevStartTimestamp, prevTimestamp, currStartTimestamp, currTimestamp int64) bool {
+func checkStartTimeOverlap(prevStartTimestamp, prevTimestamp, currStartTimestamp, _ int64) bool {
 	return currStartTimestamp != 0 && currStartTimestamp < prevTimestamp && currStartTimestamp != prevStartTimestamp
 }
 

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -517,8 +517,17 @@ func extrapolatedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper,
 		if enh.StartTimestamps != nil {
 			startTimestamps = enh.StartTimestamps.Floats
 		}
+		var overlapDetected bool
 		for i, currPoint := range samples.Floats[1:] {
 			prevPoint := samples.Floats[i]
+			// Check for start timestamp overlap once.
+			if !overlapDetected && i+1 < len(startTimestamps) {
+				if overlap := checkStartTimeOverlap(startTimestamps[i], prevPoint.T, startTimestamps[i+1], currPoint.T); overlap {
+					// Extract metric name only when needed.
+					annos.Add(annotations.NewStartTimeOverlapWarning(getMetricName(samples.Metric), args[0].PositionRange()))
+					overlapDetected = true
+				}
+			}
 			if currPoint.F < prevPoint.F || (i+1 < len(startTimestamps) && isStartTimestampReset(startTimestamps[i], prevPoint.T, startTimestamps[i+1], currPoint.T)) {
 				resultFloat += prevPoint.F
 			}
@@ -713,8 +722,17 @@ func histogramRate(
 
 	if isCounter {
 		// Second iteration to deal with counter resets.
+		var overlapDetected bool
 		for i, currPoint := range points[1:] {
 			curr := currPoint.H
+			// Check for start timestamp overlap once.
+			if !overlapDetected && i+1 < len(startTimestamps) {
+				if overlap := checkStartTimeOverlap(startTimestamps[i], points[i].T, startTimestamps[i+1], currPoint.T); overlap {
+					// Extract metric name only when needed.
+					annos.Add(annotations.NewStartTimeOverlapWarning(getMetricName(labels), pos))
+					overlapDetected = true
+				}
+			}
 			// Check start timestamps first since it's potentially cheaper.
 			if i+1 < len(startTimestamps) && isStartTimestampReset(startTimestamps[i], points[i].T, startTimestamps[i+1], currPoint.T) || curr.DetectReset(prev) {
 				// Counter reset conflict ignored here for the same reason as above.
@@ -736,6 +754,19 @@ func histogramRate(
 
 	h.CounterResetHint = histogram.GaugeType
 	return h.Compact(0), annos
+}
+
+// checkStartTimeOverlap detects when a sample's start timestamp overlaps with a
+// previous sample's timestamp, indicating potential data quality issues.
+// Works for both delta and cumulative counter metrics.
+//
+// Returns true when: currST != 0 && currST < prevT && currST != prevST
+// This correctly handles:
+//   - Valid deltas: currST = prevT (no overlap detected)
+//   - Valid cumulative: currST = prevST (no overlap detected)
+//   - Invalid overlap: currST < prevT && currST != prevST (overlap detected)
+func checkStartTimeOverlap(prevStartTimestamp, prevTimestamp, currStartTimestamp, currTimestamp int64) bool {
+	return currStartTimestamp != 0 && currStartTimestamp < prevTimestamp && currStartTimestamp != prevStartTimestamp
 }
 
 // isStartTimestampReset tells whether there was a counter reset by checking the start timestamp value.

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -517,14 +517,15 @@ func extrapolatedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper,
 		if enh.StartTimestamps != nil {
 			startTimestamps = enh.StartTimestamps.Floats
 		}
+		var overlapDetected bool
 		for i, currPoint := range samples.Floats[1:] {
 			prevPoint := samples.Floats[i]
-			// Check for start timestamp overlap once.
-			if i+1 < len(startTimestamps) {
+			// Warn once per series if start timestamp overlap detected.
+			if !overlapDetected && i+1 < len(startTimestamps) {
 				if checkStartTimeOverlap(startTimestamps[i], prevPoint.T, startTimestamps[i+1]) {
 					// Extract metric name only when needed.
 					annos.Add(annotations.NewStartTimeOverlapWarning(getMetricName(samples.Metric), args[0].PositionRange()))
-					break
+					overlapDetected = true
 				}
 			}
 			if currPoint.F < prevPoint.F || (i+1 < len(startTimestamps) && isStartTimestampReset(startTimestamps[i], prevPoint.T, startTimestamps[i+1], currPoint.T)) {
@@ -721,14 +722,15 @@ func histogramRate(
 
 	if isCounter {
 		// Second iteration to deal with counter resets.
+		var overlapDetected bool
 		for i, currPoint := range points[1:] {
 			curr := currPoint.H
-			// Check for start timestamp overlap once.
-			if i+1 < len(startTimestamps) {
+			// Warn once per series if start timestamp overlap detected.
+			if !overlapDetected && i+1 < len(startTimestamps) {
 				if checkStartTimeOverlap(startTimestamps[i], points[i].T, startTimestamps[i+1]) {
 					// Extract metric name only when needed.
 					annos.Add(annotations.NewStartTimeOverlapWarning(getMetricName(labels), pos))
-					break
+					overlapDetected = true
 				}
 			}
 			// Check start timestamps first since it's potentially cheaper.

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -517,15 +517,14 @@ func extrapolatedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper,
 		if enh.StartTimestamps != nil {
 			startTimestamps = enh.StartTimestamps.Floats
 		}
-		var overlapDetected bool
 		for i, currPoint := range samples.Floats[1:] {
 			prevPoint := samples.Floats[i]
 			// Check for start timestamp overlap once.
-			if !overlapDetected && i+1 < len(startTimestamps) {
-				if overlap := checkStartTimeOverlap(startTimestamps[i], prevPoint.T, startTimestamps[i+1], currPoint.T); overlap {
+			if i+1 < len(startTimestamps) {
+				if overlap := checkStartTimeOverlap(startTimestamps[i], prevPoint.T, startTimestamps[i+1]); overlap {
 					// Extract metric name only when needed.
 					annos.Add(annotations.NewStartTimeOverlapWarning(getMetricName(samples.Metric), args[0].PositionRange()))
-					overlapDetected = true
+					break
 				}
 			}
 			if currPoint.F < prevPoint.F || (i+1 < len(startTimestamps) && isStartTimestampReset(startTimestamps[i], prevPoint.T, startTimestamps[i+1], currPoint.T)) {
@@ -722,15 +721,14 @@ func histogramRate(
 
 	if isCounter {
 		// Second iteration to deal with counter resets.
-		var overlapDetected bool
 		for i, currPoint := range points[1:] {
 			curr := currPoint.H
 			// Check for start timestamp overlap once.
-			if !overlapDetected && i+1 < len(startTimestamps) {
-				if overlap := checkStartTimeOverlap(startTimestamps[i], points[i].T, startTimestamps[i+1], currPoint.T); overlap {
+			if i+1 < len(startTimestamps) {
+				if overlap := checkStartTimeOverlap(startTimestamps[i], points[i].T, startTimestamps[i+1]); overlap {
 					// Extract metric name only when needed.
 					annos.Add(annotations.NewStartTimeOverlapWarning(getMetricName(labels), pos))
-					overlapDetected = true
+					break
 				}
 			}
 			// Check start timestamps first since it's potentially cheaper.
@@ -754,19 +752,6 @@ func histogramRate(
 
 	h.CounterResetHint = histogram.GaugeType
 	return h.Compact(0), annos
-}
-
-// checkStartTimeOverlap detects when a sample's start timestamp overlaps with a
-// previous sample's timestamp, indicating potential data quality issues.
-// Works for both delta and cumulative counter metrics.
-//
-// Returns true when: currST != 0 && currST < prevT && currST != prevST
-// This correctly handles:
-//   - Valid deltas: currST = prevT (no overlap detected)
-//   - Valid cumulative: currST = prevST (no overlap detected)
-//   - Invalid overlap: currST < prevT && currST != prevST (overlap detected)
-func checkStartTimeOverlap(prevStartTimestamp, prevTimestamp, currStartTimestamp, _ int64) bool {
-	return currStartTimestamp != 0 && currStartTimestamp < prevTimestamp && currStartTimestamp != prevStartTimestamp
 }
 
 // isStartTimestampReset tells whether there was a counter reset by checking the start timestamp value.
@@ -800,6 +785,19 @@ func isStartTimestampReset(prevStartTimestamp, prevTimestamp, currStartTimestamp
 		return false
 	}
 	return prevStartTimestamp != 0 && prevStartTimestamp != prevTimestamp
+}
+
+// checkStartTimeOverlap detects when a sample's start timestamp overlaps with a
+// previous sample's timestamp, indicating potential data quality issues.
+// Works for both delta and cumulative counter metrics.
+//
+// Returns true when: currST != 0 && currST < prevT && currST != prevST
+// This correctly handles:
+//   - Valid deltas: currST = prevT (no overlap detected)
+//   - Valid cumulative: currST = prevST (no overlap detected)
+//   - Invalid overlap: currST < prevT && currST != prevST (overlap detected)
+func checkStartTimeOverlap(prevStartTimestamp, prevTimestamp, currStartTimestamp int64) bool {
+	return currStartTimestamp != 0 && currStartTimestamp < prevTimestamp && currStartTimestamp != prevStartTimestamp
 }
 
 // === delta(Matrix parser.ValueTypeMatrix) (Vector, Annotations) ===

--- a/promql/promqltest/testdata/start_timestamps.test
+++ b/promql/promqltest/testdata/start_timestamps.test
@@ -266,13 +266,53 @@ clear
 
 # Tests for start timestamp overlap warnings.
 # Overlaps occur when: currST != 0 && currST < prevT && currST != prevST
-# At T=3m: ST=90s, prevT=120s, prevST=0s → 90s < 120s AND 90s != 0s → overlap detected!
-load 1m
-    overlap_float_total@st      _ _ -2m -90000ms -105000ms
-    overlap_float_total         _ _  60  120      180
 
-eval instant at 4m rate(overlap_float_total[5m])
-    {} 0.5
-    expect warn msg: PromQL warning: sample has start time that overlaps with previous sample timestamp for metric "overlap_float_total"
+# Test 1: Valid delta timeseries (OTel style) - no warning expected
+# Delta pattern: ST_curr = T_prev
+load 1m
+    valid_delta_total@st        _ _ -1m -1m -1m
+    valid_delta_total           _ _  60  60  60
+
+eval instant at 4m rate(valid_delta_total[3m])
+    {} 1
+    expect no_info
+    expect no_warn
+
+clear
+
+# Test 2: Valid cumulative timeseries - no warning expected  
+# Cumulative pattern: ST stays constant (use 0 to keep ST=0 for all samples)
+load 1m
+    valid_cumulative_total@st   _ _ 0 0 0
+    valid_cumulative_total      _ _ 60 120 180
+
+eval instant at 4m rate(valid_cumulative_total[3m])
+    {} 2
+    expect no_info
+    expect no_warn
+
+clear
+
+# Test 3: Samples without start timestamps - no warning expected
+load 1m
+    no_st_counter_total         _ _ 60 120 180
+
+eval instant at 4m rate(no_st_counter_total[3m])
+    {} 1
+    expect no_info
+    expect no_warn
+
+clear
+
+# Test 4: Invalid overlap detected - warning expected
+# ST goes backward creating overlap: T=2m/ST=0m, T=3m/ST=1m, T=4m/ST=2m
+# At T=4m: currST=2m < prevT=3m AND currST!=prevST(1m) → overlap!
+load 1m
+    overlap_counter_total@st    _ _ -2m -2m -2m
+    overlap_counter_total       _ _  60 120 180
+
+eval instant at 4m rate(overlap_counter_total[3m])
+    {} 1
+    expect warn msg: PromQL warning: sample has start time that overlaps with previous sample timestamp for metric "overlap_counter_total"
 
 clear

--- a/promql/promqltest/testdata/start_timestamps.test
+++ b/promql/promqltest/testdata/start_timestamps.test
@@ -251,7 +251,6 @@ eval range from 10m to 15m step 1m irate(delta[5m])
 
 clear
 
-
 # Tests for histogram rate where rate extrapolation is substituted with assuming 0 sample at start timestamps.
 #
 # TODO: this doesn't yet produce expected results, because tsdb doesn't yet support start timestamps
@@ -262,5 +261,52 @@ load 1m
 
 eval instant at 3m rate(series[5m])
     # No series, since single sample can only produce a rate when there's a valid and suitable ST.
+
+clear
+
+# Tests for start timestamp overlap warnings.
+# Overlaps occur when: currST != 0 && currST < prevT && currST != prevST
+load 1m
+    valid_delta@st          _ _ -1mx5
+    valid_delta             _ _  60x5
+    valid_cumulative@st     _ _ -5m-5mx5
+    valid_cumulative        _ _  60+60x5
+    invalid_overlap@st      _ _ -2m-1mx5
+    invalid_overlap         _ _  60x5
+
+# Valid delta: currST = prevT, no warning expected.
+eval instant at 5m rate(valid_delta[5m])
+    {} 1
+
+# Valid cumulative: currST = prevST, no warning expected.
+eval instant at 5m rate(valid_cumulative[5m])
+    {} 1
+
+# Invalid overlap: currST < prevT && currST != prevST, should warn.
+eval instant at 5m rate(invalid_overlap[5m])
+    {} 1
+    expect warn msg: sample has start time that overlaps with previous sample timestamp
+
+clear
+
+# Test overlap warning for histogram samples.
+load 1m
+    histogram_overlap@st    _ _ -2m-1mx5
+    histogram_overlap       _ _ {{schema:0 sum:60 count:60}}x5
+
+eval instant at 5m rate(histogram_overlap[5m])
+    {} {{schema:0 sum:1 count:1}}
+    expect warn msg: sample has start time that overlaps with previous sample timestamp
+
+clear
+
+# Test that increase() also produces overlap warnings.
+load 1m
+    counter_overlap@st      _ _ -2m-1mx5
+    counter_overlap         _ _ 60x5
+
+eval instant at 5m increase(counter_overlap[5m])
+    {} 300
+    expect warn msg: sample has start time that overlaps with previous sample timestamp
 
 clear

--- a/promql/promqltest/testdata/start_timestamps.test
+++ b/promql/promqltest/testdata/start_timestamps.test
@@ -266,53 +266,34 @@ clear
 
 # Tests for start timestamp overlap warnings.
 # Overlaps occur when: currST != 0 && currST < prevT && currST != prevST
-
-# Test 1: Valid delta timeseries (OTel style) - no warning expected
-# Delta pattern: ST_curr = T_prev
 load 1m
-    valid_delta_total@st        _ _ -1m -1m -1m
-    valid_delta_total           _ _  60  60  60
+    counter_total{type="delta"}@st       _ _ -1m -1m -1m
+    counter_total{type="delta"}          _ _  60  60  60
+    counter_total{type="cumulative"}@st  _ _ -30s -90s -150s
+    counter_total{type="cumulative"}     _ _ 60 120 180
+    counter_total{type="no_st"}          _ _ 60 120 180
+    counter_total{type="overlap"}@st     _ _ -2m -2m -2m
+    counter_total{type="overlap"}        _ _  60 120 180
 
-eval instant at 4m rate(valid_delta_total[3m])
-    {} 1
+# Test valid cases: delta, cumulative, and no start timestamps - no warnings
+eval instant at 4m rate(counter_total{type!="overlap"}[3m])
+    {type="delta"} 1
+    {type="cumulative"} 1
+    {type="no_st"} 1
     expect no_info
     expect no_warn
 
-clear
+# Test overlapping start timestamps - warning expected
+eval instant at 4m rate(counter_total{type="overlap"}[3m])
+    {type="overlap"} 1
+    expect warn msg: PromQL warning: sample has start time that overlaps with previous sample timestamp for metric "counter_total"
 
-# Test 2: Valid cumulative timeseries - no warning expected  
-# Cumulative pattern: ST stays constant (use 0 to keep ST=0 for all samples)
-load 1m
-    valid_cumulative_total@st   _ _ 0 0 0
-    valid_cumulative_total      _ _ 60 120 180
-
-eval instant at 4m rate(valid_cumulative_total[3m])
-    {} 2
-    expect no_info
-    expect no_warn
-
-clear
-
-# Test 3: Samples without start timestamps - no warning expected
-load 1m
-    no_st_counter_total         _ _ 60 120 180
-
-eval instant at 4m rate(no_st_counter_total[3m])
-    {} 1
-    expect no_info
-    expect no_warn
-
-clear
-
-# Test 4: Invalid overlap detected - warning expected
-# ST goes backward creating overlap: T=2m/ST=0m, T=3m/ST=1m, T=4m/ST=2m
-# At T=4m: currST=2m < prevT=3m AND currST!=prevST(1m) → overlap!
-load 1m
-    overlap_counter_total@st    _ _ -2m -2m -2m
-    overlap_counter_total       _ _  60 120 180
-
-eval instant at 4m rate(overlap_counter_total[3m])
-    {} 1
-    expect warn msg: PromQL warning: sample has start time that overlaps with previous sample timestamp for metric "overlap_counter_total"
+# Test querying all series - should only warn for overlap case
+eval instant at 4m rate(counter_total[3m])
+    {type="delta"} 1
+    {type="cumulative"} 1
+    {type="no_st"} 1
+    {type="overlap"} 1
+    expect warn msg: PromQL warning: sample has start time that overlaps with previous sample timestamp for metric "counter_total"
 
 clear

--- a/promql/promqltest/testdata/start_timestamps.test
+++ b/promql/promqltest/testdata/start_timestamps.test
@@ -266,47 +266,13 @@ clear
 
 # Tests for start timestamp overlap warnings.
 # Overlaps occur when: currST != 0 && currST < prevT && currST != prevST
+# At T=3m: ST=90s, prevT=120s, prevST=0s → 90s < 120s AND 90s != 0s → overlap detected!
 load 1m
-    valid_delta@st          _ _ -1mx5
-    valid_delta             _ _  60x5
-    valid_cumulative@st     _ _ -5m-5mx5
-    valid_cumulative        _ _  60+60x5
-    invalid_overlap@st      _ _ -2m-1mx5
-    invalid_overlap         _ _  60x5
+    overlap_float_total@st      _ _ -2m -90000ms -105000ms
+    overlap_float_total         _ _  60  120      180
 
-# Valid delta: currST = prevT, no warning expected.
-eval instant at 5m rate(valid_delta[5m])
-    {} 1
-
-# Valid cumulative: currST = prevST, no warning expected.
-eval instant at 5m rate(valid_cumulative[5m])
-    {} 1
-
-# Invalid overlap: currST < prevT && currST != prevST, should warn.
-eval instant at 5m rate(invalid_overlap[5m])
-    {} 1
-    expect warn msg: sample has start time that overlaps with previous sample timestamp
-
-clear
-
-# Test overlap warning for histogram samples.
-load 1m
-    histogram_overlap@st    _ _ -2m-1mx5
-    histogram_overlap       _ _ {{schema:0 sum:60 count:60}}x5
-
-eval instant at 5m rate(histogram_overlap[5m])
-    {} {{schema:0 sum:1 count:1}}
-    expect warn msg: sample has start time that overlaps with previous sample timestamp
-
-clear
-
-# Test that increase() also produces overlap warnings.
-load 1m
-    counter_overlap@st      _ _ -2m-1mx5
-    counter_overlap         _ _ 60x5
-
-eval instant at 5m increase(counter_overlap[5m])
-    {} 300
-    expect warn msg: sample has start time that overlaps with previous sample timestamp
+eval instant at 4m rate(overlap_float_total[5m])
+    {} 0.5
+    expect warn msg: PromQL warning: sample has start time that overlaps with previous sample timestamp for metric "overlap_float_total"
 
 clear

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -169,6 +169,7 @@ var (
 	NativeHistogramFractionNaNsInfo         = fmt.Errorf("%w: input to histogram_fraction has NaN observations, which are excluded from all fractions", PromQLInfo)
 	HistogramCounterResetCollisionWarning   = fmt.Errorf("%w: conflicting counter resets during histogram", PromQLWarning)
 	MismatchedCustomBucketsHistogramsInfo   = fmt.Errorf("%w: mismatched custom buckets were reconciled during", PromQLInfo)
+	StartTimeOverlapWarning                 = fmt.Errorf("%w: sample has start time that overlaps with previous sample timestamp", PromQLWarning)
 )
 
 // annoError extends the standard error interface to provide additional functionality
@@ -487,5 +488,56 @@ func NewMismatchedCustomBucketsHistogramsInfo(pos posrange.PositionRange, operat
 	return &annoErr{
 		PositionRange: pos,
 		Err:           fmt.Errorf("%w %s", MismatchedCustomBucketsHistogramsInfo, operation.String()),
+	}
+}
+
+type startTimeOverlapErr struct {
+	PositionRange posrange.PositionRange
+	Err           error
+	Query         string
+	metricName    string
+	count         int
+}
+
+func (e *startTimeOverlapErr) Error() string {
+	if e.Query == "" {
+		// Don't include count when query is empty to allow proper deduplication.
+		return fmt.Sprintf("%s for metric %q", e.Err, e.metricName)
+	}
+	if e.count > 0 {
+		return fmt.Sprintf("%s for metric %q (%d occurrences) (%s)", e.Err, e.metricName, e.count+1, e.PositionRange.StartPosInput(e.Query, 0))
+	}
+	return fmt.Sprintf("%s for metric %q (%s)", e.Err, e.metricName, e.PositionRange.StartPosInput(e.Query, 0))
+}
+
+func (e *startTimeOverlapErr) Unwrap() error {
+	return e.Err
+}
+
+func (e *startTimeOverlapErr) SetQuery(query string) {
+	e.Query = query
+}
+
+func (e *startTimeOverlapErr) Merge(other error) error {
+	o := &startTimeOverlapErr{}
+	ok := errors.As(other, &o)
+	if !ok {
+		return e
+	}
+	if e.Err.Error() != o.Err.Error() || e.metricName != o.metricName {
+		return e
+	}
+	o.count += e.count + 1
+	return o
+}
+
+// NewStartTimeOverlapWarning is used when a sample's start time overlaps with a
+// previous sample's timestamp, indicating potential data quality issues.
+// This applies to both delta and cumulative counter metrics.
+func NewStartTimeOverlapWarning(metricName string, pos posrange.PositionRange) error {
+	return &startTimeOverlapErr{
+		PositionRange: pos,
+		Err:           StartTimeOverlapWarning,
+		metricName:    metricName,
 	}
 }

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -504,8 +504,8 @@ func (e *startTimeOverlapErr) Error() string {
 		// Don't include count when query is empty to allow proper deduplication.
 		return fmt.Sprintf("%s for metric %q", e.Err, e.metricName)
 	}
-	if e.count > 0 {
-		return fmt.Sprintf("%s for metric %q (%d occurrences) (%s)", e.Err, e.metricName, e.count+1, e.PositionRange.StartPosInput(e.Query, 0))
+	if e.count > 1 {
+		return fmt.Sprintf("%s for metric %q (%d occurrences) (%s)", e.Err, e.metricName, e.count, e.PositionRange.StartPosInput(e.Query, 0))
 	}
 	return fmt.Sprintf("%s for metric %q (%s)", e.Err, e.metricName, e.PositionRange.StartPosInput(e.Query, 0))
 }
@@ -527,7 +527,7 @@ func (e *startTimeOverlapErr) Merge(other error) error {
 	if e.Err.Error() != o.Err.Error() || e.metricName != o.metricName {
 		return e
 	}
-	o.count += e.count + 1
+	o.count += e.count
 	return o
 }
 
@@ -539,5 +539,6 @@ func NewStartTimeOverlapWarning(metricName string, pos posrange.PositionRange) e
 		PositionRange: pos,
 		Err:           StartTimeOverlapWarning,
 		metricName:    metricName,
+		count:         1,
 	}
 }

--- a/util/annotations/annotations.go
+++ b/util/annotations/annotations.go
@@ -519,7 +519,7 @@ func (e *startTimeOverlapErr) SetQuery(query string) {
 }
 
 func (e *startTimeOverlapErr) Merge(other error) error {
-	o := &startTimeOverlapErr{}
+	var o *startTimeOverlapErr
 	ok := errors.As(other, &o)
 	if !ok {
 		return e

--- a/util/annotations/annotations_test.go
+++ b/util/annotations/annotations_test.go
@@ -133,7 +133,7 @@ func TestStartTimeOverlapWarning(t *testing.T) {
 	require.Len(t, warnings, 1)
 	require.Contains(t, warnings[0], "sample has start time that overlaps with previous sample timestamp")
 	require.Contains(t, warnings[0], "test_metric")
-	// Count increases by 1 each time we merge: first occurrence has count=0, after 2 merges count=2, displayed as 3 occurrences.
+	// Each warning starts with count=1. After merging 3 warnings: 1+1+1=3 occurrences.
 	require.Contains(t, warnings[0], "3 occurrences")
 }
 

--- a/util/annotations/annotations_test.go
+++ b/util/annotations/annotations_test.go
@@ -16,6 +16,7 @@ package annotations
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -111,4 +112,55 @@ func newTestCustomWarning(q float64, pos posrange.PositionRange, smallest, large
 		Min:           []float64{smallest},
 		Max:           []float64{largest},
 	}
+}
+
+func TestStartTimeOverlapWarning(t *testing.T) {
+	pos := posrange.PositionRange{Start: 5, End: 10}
+
+	// Test single warning.
+	warning := NewStartTimeOverlapWarning("test_metric", pos)
+	require.Error(t, warning)
+	require.ErrorIs(t, warning, StartTimeOverlapWarning)
+	require.ErrorIs(t, warning, PromQLWarning)
+
+	// Test merging of warnings.
+	var annos Annotations
+	annos.Add(NewStartTimeOverlapWarning("test_metric", pos))
+	annos.Add(NewStartTimeOverlapWarning("test_metric", pos))
+	annos.Add(NewStartTimeOverlapWarning("test_metric", pos))
+
+	warnings, _ := annos.AsStrings("test query", 0, 0)
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], "sample has start time that overlaps with previous sample timestamp")
+	require.Contains(t, warnings[0], "test_metric")
+	// Count increases by 1 each time we merge: first occurrence has count=0, after 2 merges count=2, displayed as 3 occurrences.
+	require.Contains(t, warnings[0], "3 occurrences")
+}
+
+func TestStartTimeOverlapWarning_DifferentMetrics(t *testing.T) {
+	pos := posrange.PositionRange{Start: 5, End: 10}
+
+	var annos Annotations
+	annos.Add(NewStartTimeOverlapWarning("metric_a", pos))
+	annos.Add(NewStartTimeOverlapWarning("metric_b", pos))
+	annos.Add(NewStartTimeOverlapWarning("metric_a", pos))
+
+	warnings, _ := annos.AsStrings("test query", 0, 0)
+	require.Len(t, warnings, 2)
+
+	// Check that we have warnings for both metrics.
+	hasMetricA := false
+	hasMetricB := false
+	for _, w := range warnings {
+		if strings.Contains(w, "metric_a") {
+			hasMetricA = true
+			require.Contains(t, w, "2 occurrences")
+		}
+		if strings.Contains(w, "metric_b") {
+			hasMetricB = true
+			require.NotContains(t, w, "occurrences")
+		}
+	}
+	require.True(t, hasMetricA)
+	require.True(t, hasMetricB)
 }


### PR DESCRIPTION
### Which issue(s) does the PR fix:

Fixes #18534

### Description

This PR implements query-time detection of overlapping start timestamp windows for both delta and cumulative counter metrics.

**Problem:**
Metrics with start timestamps can have overlapping time spans when a sample's start timestamp (ST) is earlier than the previous sample's timestamp (T). This indicates potential data quality issues such as:

- Clock skew or time synchronization problems
- Out-of-order sample ingestion
- Misconfigured exporters
- Application restarts with incorrect state

Some monitoring systems reject these samples outright, but Prometheus currently accepts them silently, which can lead to incorrect query results.

**Solution:**
This PR adds query-time warnings using Prometheus's annotation mechanism to alert users when overlapping start timestamp spans are detected during rate(), increase(), and related calculations.

**Implementation:**

- Adds StartTimeOverlapWarning annotation type with intelligent merging (counts occurrences per metric)
- Implements checkStartTimeOverlap() helper function with overlap detection logic that works for both delta temporality (OTel-style) and cumulative counters
- Detects overlaps in extrapolatedRate() and histogramRate() functions for float and histogram samples
- Emits warning once per series to avoid spam
- Handles nil/zero start timestamps gracefully (no false positives)
- Optimized: only extracts metric names when warnings are needed

**Overlap Detection Condition:**
An overlap is detected when: currST != 0 AND currST < prevT AND currST != prevST

This condition correctly identifies overlaps for:
- **Delta counters**: where ST should equal previous T (e.g., OTel delta temporality)
- **Cumulative counters**: where ST should remain constant across samples

**Testing:**

- Unit tests for annotation creation, merging, and deduplication (util/annotations)
- Comprehensive integration tests using promqltest with multiple scenarios:
  - Valid delta timeseries (no warning)
  - Valid cumulative counters (no warning)
  - Samples without start timestamps (no warning)
  - Invalid overlapping start timestamps (warning expected)
  - Mixed queries with label selectors

**Dependencies:**
This PR builds on the start timestamp infrastructure from #18344 (merged), which propagates StartTimestamps through the query evaluation path.

### Release notes for end users (**ALL** commits must be considered).

```release-notes
[FEATURE] PromQL: Add query-time warning when samples have overlapping start timestamps (applicable to both delta and cumulative counters).