### PR TITLE
promql: fix spurious reset when prevST is invalid in isStartTimestampReset

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -447,6 +447,12 @@ func isStartTimestampReset(prevStartTimestamp, prevTimestamp, currStartTimestamp
 	// This should be treated as a reset for deltas, but it is not a reset for cumulative series
 	// with unknown start timestamp. Thus we have to check whether the start timestamp
 	// of the previous datapoint is known.
+	//
+	// A previous start timestamp greater than the previous sample timestamp is invalid; treat it
+	// as unknown to avoid a spurious reset.
+	if prevStartTimestamp > prevTimestamp {
+		return false
+	}
 	return prevStartTimestamp != 0
 }
 

--- a/promql/promqltest/testdata/start_timestamps.test
+++ b/promql/promqltest/testdata/start_timestamps.test
@@ -94,17 +94,21 @@ clear
 
 # Test for cumulative with unknow start timestamp, which is described in OTel spec. It is easy to incorrectly treat
 # second datapoint in such timeseries as delta, producing incorrect result. These can be distinguished by:
-#   * ST_curr == T_prev && ST_prev == 0 -> cumulative with unknown start, no reset
-#   * ST_curr == T_prev && ST_prev != 0 -> delta datapoint, treat as a reset
+#   * ST_curr == T_prev && ST_prev == 0  -> cumulative with unknown start, no reset
+#   * ST_curr == T_prev && ST_prev != 0  -> delta datapoint, treat as a reset
+#   * ST_curr == T_prev && ST_prev > T_prev (invalid) -> must not be mistaken for the delta case above
 load 1m
-    series{type="otel_cumulative_unknown_start"}@st  _ _   _ -1m
-    series{type="otel_cumulative_unknown_start"}     _ _   1   1
-    series{type="otel_delta"}@st                     _ _ -1m -1m
-    series{type="otel_delta"}                        _ _   1   1
+    series{type="otel_cumulative_unknown_start"}@st  _ _    _ -1m
+    series{type="otel_cumulative_unknown_start"}     _ _    1   1
+    series{type="otel_delta"}@st                     _ _ -1m  -1m
+    series{type="otel_delta"}                        _ _    1    1
+    series{type="invalid_prev_st"}@st                _ _ +1m  -1m
+    series{type="invalid_prev_st"}                   _ _    1    1
 
 eval instant at 3m round(increase(series[1m1ms]))
     {type="otel_cumulative_unknown_start"}  0
     {type="otel_delta"}                     1
+    {type="invalid_prev_st"}                0
 
 clear
 


### PR DESCRIPTION

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
