### PR TITLE
promql: support native histograms with smoothed/anchored rate

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1738,6 +1738,7 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration,
 
 		var floats []FPoint
 		var hists []HPoint
+		metricName := s.Labels().Get(labels.MetricName)
 
 		for evalTS := ev.startTimestamp; evalTS <= ev.endTimestamp; evalTS += step {
 			// Apply offset to get the data timestamp.
@@ -1751,7 +1752,7 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration,
 			}
 
 			if len(hists) > 0 && len(floats) > 0 {
-				annos.Add(annotations.NewMixedFloatsHistogramsWarning(s.Labels().Get(labels.MetricName), pos))
+				annos.Add(annotations.NewMixedFloatsHistogramsWarning(metricName, pos))
 				continue
 			}
 
@@ -1770,21 +1771,25 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration,
 					// unless both samples explicitly carry the gauge hint.
 					prev, next := hists[i-1], hists[i]
 					if prev.H.UsesCustomBuckets() != next.H.UsesCustomBuckets() {
-						annos.Add(annotations.NewMixedExponentialCustomHistogramsWarning(s.Labels().Get(labels.MetricName), pos))
+						annos.Add(annotations.NewMixedExponentialCustomHistogramsWarning(metricName, pos))
 						continue
 					}
 					isCounter := prev.H.CounterResetHint != histogram.GaugeType || next.H.CounterResetHint != histogram.GaugeType
 					h, err := interpolateHistograms(prev.H, prev.T, next.H, next.T, dataTS, isCounter, &annos, pos)
 					if err != nil {
-						annos = annosFromInterpolationError(annos, err, s.Labels().Get(labels.MetricName), pos)
+						annosFromInterpolationError(&annos, err, metricName, pos)
 						continue
 					}
 					ss.Histograms = append(ss.Histograms, HPoint{H: h, T: evalTS})
 
 				case i > 0:
 					// No next point yet; carry forward previous value.
+					// CounterResetHint is reset to UnknownCounterReset because the hint
+					// describes the relationship between consecutive samples, not the value.
 					prev := hists[i-1]
-					ss.Histograms = append(ss.Histograms, HPoint{H: prev.H.Copy(), T: evalTS})
+					h := prev.H.Copy()
+					h.CounterResetHint = histogram.UnknownCounterReset
+					ss.Histograms = append(ss.Histograms, HPoint{H: h, T: evalTS})
 
 				default:
 					// i == 0 and hists[0].T > dataTS: there is no previous data yet; skip.
@@ -2754,7 +2759,7 @@ func (ev *evaluator) matrixSelector(ctx context.Context, node *parser.MatrixSele
 			ss.Floats = extendFloats(ss.Floats, matrixMint, matrixMaxt, false)
 		case vs.Smoothed:
 			if ss.Histograms != nil {
-				ev.errorf("anchored modifier is not supported with histograms")
+				ev.errorf("smoothed modifier is not supported with histograms")
 			}
 			ss.Floats = extendFloats(ss.Floats, matrixMint, matrixMaxt, true)
 		}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1717,7 +1717,7 @@ func (ev *evaluator) rangeEvalAgg(ctx context.Context, aggExpr *parser.Aggregate
 
 // smoothSeries is a helper function that smooths the series by interpolating the values
 // based on values before and after the timestamp.
-func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration) Matrix {
+func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration, pos posrange.PositionRange) (Matrix, annotations.Annotations) {
 	dur := ev.endTimestamp - ev.startTimestamp
 
 	it := storage.NewBuffer(dur + 2*durationMilliseconds(ev.lookbackDelta))
@@ -1728,6 +1728,7 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration)
 
 	var chkIter chunkenc.Iterator
 	mat := make(Matrix, 0, len(series))
+	var annos annotations.Annotations
 
 	for _, s := range series {
 		ss := Series{Metric: s.Labels()}
@@ -1749,40 +1750,76 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration)
 				continue
 			}
 
-			if len(hists) > 0 {
-				// TODO: support native histograms.
-				ev.errorf("smoothed and anchored modifiers do not work with native histograms")
+			if len(hists) > 0 && len(floats) > 0 {
+				annos.Add(annotations.NewMixedFloatsHistogramsWarning(s.Labels().Get(labels.MetricName), pos))
+				continue
 			}
 
-			// Binary search for the first index with T >= dataTS.
-			i := sort.Search(len(floats), func(i int) bool { return floats[i].T >= dataTS })
+			if len(hists) > 0 {
+				// Binary search for the first histogram index with T >= dataTS.
+				i := sort.Search(len(hists), func(i int) bool { return hists[i].T >= dataTS })
 
-			switch {
-			case i < len(floats) && floats[i].T == dataTS:
-				// Exact match.
-				ss.Floats = append(ss.Floats, FPoint{F: floats[i].F, T: evalTS})
+				switch {
+				case i < len(hists) && hists[i].T == dataTS:
+					// Exact match.
+					ss.Histograms = append(ss.Histograms, HPoint{H: hists[i].H.Copy(), T: evalTS})
 
-			case i > 0 && i < len(floats):
-				// Interpolate between prev and next.
-				// TODO: detect if the sample is a counter, based on __type__ or metadata.
-				prev, next := floats[i-1], floats[i]
-				val := interpolate(prev, next, dataTS, false)
-				ss.Floats = append(ss.Floats, FPoint{F: val, T: evalTS})
+				case i > 0 && i < len(hists):
+					// Interpolate between prev and next.
+					// Use CounterResetHint to determine counter vs gauge: treat as counter
+					// unless both samples explicitly carry the gauge hint.
+					prev, next := hists[i-1], hists[i]
+					if prev.H.UsesCustomBuckets() != next.H.UsesCustomBuckets() {
+						annos.Add(annotations.NewMixedExponentialCustomHistogramsWarning(s.Labels().Get(labels.MetricName), pos))
+						continue
+					}
+					isCounter := prev.H.CounterResetHint != histogram.GaugeType || next.H.CounterResetHint != histogram.GaugeType
+					h, err := interpolateHistograms(prev.H, prev.T, next.H, next.T, dataTS, isCounter, &annos, pos)
+					if err != nil {
+						annos = annosFromInterpolationError(annos, err, s.Labels().Get(labels.MetricName), pos)
+						continue
+					}
+					ss.Histograms = append(ss.Histograms, HPoint{H: h, T: evalTS})
 
-			case i > 0:
-				// No next point yet; carry forward previous value.
-				prev := floats[i-1]
-				ss.Floats = append(ss.Floats, FPoint{F: prev.F, T: evalTS})
+				case i > 0:
+					// No next point yet; carry forward previous value.
+					prev := hists[i-1]
+					ss.Histograms = append(ss.Histograms, HPoint{H: prev.H.Copy(), T: evalTS})
 
-			default:
-				// i == 0 and floats[0].T > dataTS: there is no previous data yet; skip.
+				default:
+					// i == 0 and hists[0].T > dataTS: there is no previous data yet; skip.
+				}
+			} else {
+				// Binary search for the first index with T >= dataTS.
+				i := sort.Search(len(floats), func(i int) bool { return floats[i].T >= dataTS })
+
+				switch {
+				case i < len(floats) && floats[i].T == dataTS:
+					// Exact match.
+					ss.Floats = append(ss.Floats, FPoint{F: floats[i].F, T: evalTS})
+
+				case i > 0 && i < len(floats):
+					// Interpolate between prev and next.
+					// TODO: detect if the sample is a counter, based on __type__ or metadata.
+					prev, next := floats[i-1], floats[i]
+					val := interpolate(prev, next, dataTS, false)
+					ss.Floats = append(ss.Floats, FPoint{F: val, T: evalTS})
+
+				case i > 0:
+					// No next point yet; carry forward previous value.
+					prev := floats[i-1]
+					ss.Floats = append(ss.Floats, FPoint{F: prev.F, T: evalTS})
+
+				default:
+					// i == 0 and floats[0].T > dataTS: there is no previous data yet; skip.
+				}
 			}
 		}
 
 		mat = append(mat, ss)
 	}
 
-	return mat
+	return mat, annos
 }
 
 // evalSeries generates a Matrix between ev.startTimestamp and ev.endTimestamp (inclusive), each point spaced ev.interval apart, from series given offset.
@@ -2178,12 +2215,6 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 				if len(floats)+len(histograms) == 0 {
 					continue
 				}
-				if selVS.Anchored || selVS.Smoothed {
-					if len(histograms) > 0 {
-						// TODO: support native histograms.
-						ev.errorf("smoothed and anchored modifiers do not work with native histograms")
-					}
-				}
 				inMatrix[0].Floats = floats
 				inMatrix[0].Histograms = histograms
 				enh.Ts = ts
@@ -2378,7 +2409,8 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 			ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), ws})
 		}
 		if e.Smoothed {
-			mat := ev.smoothSeries(e.Series, e.Offset)
+			mat, smoothAnnos := ev.smoothSeries(e.Series, e.Offset, e.PositionRange())
+			ws.Merge(smoothAnnos)
 			return mat, ws
 		}
 		mat := ev.evalSeries(ctx, e.Series, e.Offset, false)

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -247,32 +247,38 @@ func validateHistogramRange(h []HPoint, isCounter bool, annos *annotations.Annot
 	return true
 }
 
-// innerHistogramBounds returns the (first, last) indices for the inner slice
-// passed to correctForCounterResetsHistogram. firstSampleIndex is always
-// excluded because it is already represented by left (directly or via
-// interpolation). When the left-boundary interpolation itself spanned a reset
-// (smoothed mode, first sample before rangeStart, DetectReset true), the reset
-// between firstSampleIndex and firstSampleIndex+1 is already accounted for, so
-// firstSampleIndex+1 is also excluded. lastSampleIndex is excluded when its
-// timestamp is at or after rangeEnd, mirroring the float version.
-func innerHistogramBounds(h []HPoint, firstSampleIndex, lastSampleIndex int, rangeStart, rangeEnd int64, smoothed bool) (int, int) {
+// correctForCounterResetsHistogram calculates the histogram correction for
+// counter resets between firstSampleIndex and lastSampleIndex in h, using
+// left and right as the boundary values. It mirrors correctForCounterResets
+// for float samples. It returns the accumulated correction (nil if none),
+// any annotations, and false if combining histograms failed.
+func correctForCounterResetsHistogram(h []HPoint, firstSampleIndex, lastSampleIndex int, left, right *histogram.FloatHistogram, rangeStart int64, smoothed bool, metricName string, pos posrange.PositionRange) (*histogram.FloatHistogram, annotations.Annotations, bool) {
+	// firstSampleIndex is represented by left, so the loop starts one beyond.
 	first := firstSampleIndex + 1
+	prev := left
 	if smoothed && h[firstSampleIndex].T < rangeStart && h[firstSampleIndex+1].H.DetectReset(h[firstSampleIndex].H) {
+		// The left interpolation spanned the reset between h[firstSampleIndex]
+		// and h[firstSampleIndex+1]. That reset is already accounted for, so
+		// skip h[firstSampleIndex+1] from the loop and use it as the comparison
+		// anchor for any reset that immediately follows.
+		prev = h[firstSampleIndex+1].H
 		first++
 	}
-	last := lastSampleIndex
-	if h[last].T >= rangeEnd {
-		last--
-	}
-	return first, last
-}
+	// lastSampleIndex is always excluded: right is either a direct copy of
+	// h[lastSampleIndex] or an interpolation that inherits its CounterResetHint.
+	// Including h[lastSampleIndex] in the loop would make right.DetectReset
+	// self-detect on the same hint. The final right.DetectReset(prev) below
+	// handles the right-boundary reset safely once h[lastSampleIndex] is not prev.
+	last := lastSampleIndex - 1
 
-// correctForCounterResetsHistogram calculates the histogram correction for
-// counter resets in points, using left and right as the boundary samples.
-// It is only used by extendedHistogramRate. It returns the accumulated
-// correction (nil if no resets were detected), any annotations produced, and
-// false if combining histograms failed.
-func correctForCounterResetsHistogram(left, right *histogram.FloatHistogram, points []HPoint, metricName string, pos posrange.PositionRange) (*histogram.FloatHistogram, annotations.Annotations, bool) {
+	// first > last+1 only when leftInterpolationHandledReset is true and there
+	// is only one sample interval (lastSampleIndex == firstSampleIndex+1).
+	// Both left and right were interpolated from the same reset segment, so
+	// there is nothing more to correct.
+	if first > last+1 {
+		return nil, nil, true
+	}
+
 	var (
 		correction *histogram.FloatHistogram
 		annos      annotations.Annotations
@@ -286,8 +292,7 @@ func correctForCounterResetsHistogram(left, right *histogram.FloatHistogram, poi
 		return addHistogramWithAnnotations(correction, h, &annos, metricName, pos)
 	}
 
-	prev := left
-	for _, p := range points {
+	for _, p := range h[first : last+1] {
 		if p.H.DetectReset(prev) {
 			if !addCorrection(prev) {
 				return nil, annos, false
@@ -411,16 +416,13 @@ func extendedHistogramRate(vals Matrix, args parser.Expressions, enh *EvalNodeHe
 	}
 
 	if isCounter {
-		first, last := innerHistogramBounds(h, firstSampleIndex, lastSampleIndex, rangeStart, rangeEnd, smoothed)
-		if first <= last {
-			correction, newAnnos, ok := correctForCounterResetsHistogram(left, right, h[first:last+1], metricName, pos)
-			annos.Merge(newAnnos)
-			if !ok {
-				return enh.Out, annos
-			}
-			if correction != nil && !addHistogramWithAnnotations(resultHistogram, correction, &annos, metricName, pos) {
-				return enh.Out, annos
-			}
+		correction, newAnnos, ok := correctForCounterResetsHistogram(h, firstSampleIndex, lastSampleIndex, left, right, rangeStart, smoothed, metricName, pos)
+		annos.Merge(newAnnos)
+		if !ok {
+			return enh.Out, annos
+		}
+		if correction != nil && !addHistogramWithAnnotations(resultHistogram, correction, &annos, metricName, pos) {
+			return enh.Out, annos
 		}
 	}
 	if isRate {

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -107,6 +107,66 @@ func interpolate(p1, p2 FPoint, t int64, isCounter bool) float64 {
 	return y1 + (y2-y1)*float64(t-p1.T)/float64(p2.T-p1.T)
 }
 
+// interpolateHistograms performs linear interpolation between two histogram points.
+// If isCounter is true and there is a counter reset, it models the counter
+// as starting from 0 (post-reset) by returning h2 scaled by the fraction.
+// It returns an error if the histograms are incompatible (e.g. mixing
+// exponential and custom-bucket schemas). NHCB bucket-bounds reconciliation
+// warnings are collected into annos.
+func interpolateHistograms(h1 *histogram.FloatHistogram, t1 int64, h2 *histogram.FloatHistogram, t2, t int64, isCounter bool, annos *annotations.Annotations, pos posrange.PositionRange) (*histogram.FloatHistogram, error) {
+	if t == t1 {
+		return h1.Copy(), nil
+	}
+	if t == t2 {
+		return h2.Copy(), nil
+	}
+	fraction := float64(t-t1) / float64(t2-t1)
+
+	if isCounter && h2.DetectReset(h1) {
+		// Counter reset: model as starting from zero.
+		return h2.Copy().Mul(fraction), nil
+	}
+
+	// Result = H1 + (H2 - H1) * fraction.
+	delta := h2.Copy()
+	_, _, nhcbReconciled, err := delta.Sub(h1)
+	if err != nil {
+		return nil, err
+	}
+	if nhcbReconciled {
+		annos.Add(annotations.NewMismatchedCustomBucketsHistogramsInfo(pos, annotations.HistogramSub))
+	}
+	delta.Mul(fraction)
+	_, _, nhcbReconciled, err = delta.Add(h1)
+	if err != nil {
+		return nil, err
+	}
+	if nhcbReconciled {
+		annos.Add(annotations.NewMismatchedCustomBucketsHistogramsInfo(pos, annotations.HistogramAdd))
+	}
+	return delta, nil
+}
+
+// pickOrInterpolateLeftHistogram returns the histogram at the left boundary of the range.
+// If interpolation is needed (when smoothed is true and the first sample is before the range start),
+// it returns the interpolated histogram at the left boundary; otherwise, it returns a copy of the first sample's histogram.
+func pickOrInterpolateLeftHistogram(hists []HPoint, first int, rangeStart int64, smoothed, isCounter bool, annos *annotations.Annotations, pos posrange.PositionRange) (*histogram.FloatHistogram, error) {
+	if smoothed && hists[first].T < rangeStart {
+		return interpolateHistograms(hists[first].H, hists[first].T, hists[first+1].H, hists[first+1].T, rangeStart, isCounter, annos, pos)
+	}
+	return hists[first].H.Copy(), nil
+}
+
+// pickOrInterpolateRightHistogram returns the histogram at the right boundary of the range.
+// If interpolation is needed (when smoothed is true and the last sample is after the range end),
+// it returns the interpolated histogram at the right boundary; otherwise, it returns a copy of the last sample's histogram.
+func pickOrInterpolateRightHistogram(hists []HPoint, last int, rangeEnd int64, smoothed, isCounter bool, annos *annotations.Annotations, pos posrange.PositionRange) (*histogram.FloatHistogram, error) {
+	if smoothed && last > 0 && hists[last].T > rangeEnd {
+		return interpolateHistograms(hists[last-1].H, hists[last-1].T, hists[last].H, hists[last].T, rangeEnd, isCounter, annos, pos)
+	}
+	return hists[last].H.Copy(), nil
+}
+
 // correctForCounterResets calculates the correction for counter resets.
 // This function is only used for extendedRate functions with smoothed or anchored rates.
 func correctForCounterResets(left, right float64, points []FPoint) float64 {
@@ -122,6 +182,86 @@ func correctForCounterResets(left, right float64, points []FPoint) float64 {
 		correction += prev
 	}
 	return correction
+}
+
+// annosFromInterpolationError classifies an error returned by
+// interpolateHistograms (via pickOrInterpolate*Histogram) into the appropriate
+// annotation. If the error is not recognised, annos is returned unchanged.
+func annosFromInterpolationError(annos annotations.Annotations, err error, metricName string, pos posrange.PositionRange) annotations.Annotations {
+	if errors.Is(err, histogram.ErrHistogramsIncompatibleSchema) {
+		return annos.Add(annotations.NewMixedExponentialCustomHistogramsWarning(metricName, pos))
+	}
+	return annos
+}
+
+// addHistogramWithAnnotations adds other into base in place, translating
+// histogram errors and bucket-bounds reconciliations into annotations.
+// It returns false if the operation failed.
+func addHistogramWithAnnotations(base, other *histogram.FloatHistogram, annos *annotations.Annotations, metricName string, pos posrange.PositionRange) bool {
+	_, _, nhcbBoundsReconciled, err := base.Add(other)
+	if err != nil {
+		if errors.Is(err, histogram.ErrHistogramsIncompatibleSchema) {
+			annos.Add(annotations.NewMixedExponentialCustomHistogramsWarning(metricName, pos))
+		}
+		return false
+	}
+	if nhcbBoundsReconciled {
+		annos.Add(annotations.NewMismatchedCustomBucketsHistogramsInfo(pos, annotations.HistogramAdd))
+	}
+	return true
+}
+
+// subHistogramWithAnnotations subtracts other from base in place, translating
+// histogram errors and bucket-bounds reconciliations into annotations.
+// It returns false if the operation failed.
+func subHistogramWithAnnotations(base, other *histogram.FloatHistogram, annos *annotations.Annotations, metricName string, pos posrange.PositionRange) bool {
+	_, _, nhcbBoundsReconciled, err := base.Sub(other)
+	if err != nil {
+		if errors.Is(err, histogram.ErrHistogramsIncompatibleSchema) {
+			annos.Add(annotations.NewMixedExponentialCustomHistogramsWarning(metricName, pos))
+		}
+		return false
+	}
+	if nhcbBoundsReconciled {
+		annos.Add(annotations.NewMismatchedCustomBucketsHistogramsInfo(pos, annotations.HistogramSub))
+	}
+	return true
+}
+
+// correctForCounterResetsHistogram calculates the histogram correction for
+// counter resets in points, using left and right as the boundary samples.
+// It is only used by extendedHistogramRate. It returns the accumulated
+// correction (nil if no resets were detected), any annotations produced, and
+// false if combining histograms failed.
+func correctForCounterResetsHistogram(left, right *histogram.FloatHistogram, points []HPoint, metricName string, pos posrange.PositionRange) (*histogram.FloatHistogram, annotations.Annotations, bool) {
+	var (
+		correction *histogram.FloatHistogram
+		annos      annotations.Annotations
+	)
+
+	addCorrection := func(h *histogram.FloatHistogram) bool {
+		if correction == nil {
+			correction = h.Copy()
+			return true
+		}
+		return addHistogramWithAnnotations(correction, h, &annos, metricName, pos)
+	}
+
+	prev := left
+	for _, p := range points {
+		if p.H.DetectReset(prev) {
+			if !addCorrection(prev) {
+				return nil, annos, false
+			}
+		}
+		prev = p.H
+	}
+	if right.DetectReset(prev) {
+		if !addCorrection(prev) {
+			return nil, annos, false
+		}
+	}
+	return correction, annos, true
 }
 
 // extendedRate is a utility function for anchored/smoothed rate/increase/delta.
@@ -178,18 +318,129 @@ func extendedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper, isC
 	return append(enh.Out, Sample{F: resultFloat}), annos
 }
 
+// extendedHistogramRate is a utility function for anchored/smoothed rate/increase/delta
+// with native histograms. It calculates the rate (allowing for counter resets if
+// isCounter is true), interpolates at the range boundaries if needed, and returns
+// the result as either per-second (if isRate is true) or overall.
+func extendedHistogramRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper, isCounter, isRate bool) (Vector, annotations.Annotations) {
+	var (
+		ms              = args[0].(*parser.MatrixSelector)
+		vs              = ms.VectorSelector.(*parser.VectorSelector)
+		samples         = vals[0]
+		h               = samples.Histograms
+		lastSampleIndex = len(h) - 1
+		rangeStart      = enh.Ts - durationMilliseconds(ms.Range+vs.Offset)
+		rangeEnd        = enh.Ts - durationMilliseconds(vs.Offset)
+		annos           annotations.Annotations
+		metricName      = getMetricName(samples.Metric)
+		pos             = args[0].PositionRange()
+		smoothed        = vs.Smoothed
+	)
+
+	firstSampleIndex := max(0, sort.Search(lastSampleIndex, func(i int) bool { return h[i].T > rangeStart })-1)
+	if smoothed {
+		lastSampleIndex = sort.Search(lastSampleIndex, func(i int) bool { return h[i].T >= rangeEnd })
+	}
+
+	if h[lastSampleIndex].T <= rangeStart {
+		return enh.Out, annos
+	}
+	if smoothed && h[firstSampleIndex].T > rangeEnd {
+		return enh.Out, annos
+	}
+
+	usingCustomBuckets := h[firstSampleIndex].H.UsesCustomBuckets()
+	for _, p := range h[firstSampleIndex : lastSampleIndex+1] {
+		if p.H.UsesCustomBuckets() != usingCustomBuckets {
+			return enh.Out, annos.Add(annotations.NewMixedExponentialCustomHistogramsWarning(metricName, pos))
+		}
+		if isCounter && p.H.CounterResetHint == histogram.GaugeType {
+			annos.Add(annotations.NewNativeHistogramNotCounterWarning(metricName, pos))
+		}
+	}
+
+	left, err := pickOrInterpolateLeftHistogram(h, firstSampleIndex, rangeStart, smoothed, isCounter, &annos, pos)
+	if err != nil {
+		return enh.Out, annosFromInterpolationError(annos, err, metricName, pos)
+	}
+	right, err := pickOrInterpolateRightHistogram(h, lastSampleIndex, rangeEnd, smoothed, isCounter, &annos, pos)
+	if err != nil {
+		return enh.Out, annosFromInterpolationError(annos, err, metricName, pos)
+	}
+
+	if !isCounter && (left.CounterResetHint != histogram.GaugeType || right.CounterResetHint != histogram.GaugeType) {
+		annos.Add(annotations.NewNativeHistogramNotGaugeWarning(metricName, pos))
+	}
+
+	// Compute result = right - left.
+	resultHistogram := right.Copy()
+	if !subHistogramWithAnnotations(resultHistogram, left, &annos, metricName, pos) {
+		return enh.Out, annos
+	}
+
+	if isCounter {
+		leftInterpolationHandledReset := smoothed && h[firstSampleIndex].T < rangeStart && h[firstSampleIndex+1].H.DetectReset(h[firstSampleIndex].H)
+
+		// Always skip firstSampleIndex: it is either already represented by
+		// left (when h[firstSampleIndex].T >= rangeStart) or by the
+		// interpolation between h[firstSampleIndex] and h[firstSampleIndex+1]
+		// (when smoothed). Including it in the correction slice would
+		// double-count via DetectReset's CounterReset shortcut when
+		// h[firstSampleIndex].CounterResetHint == CounterReset.
+		first := firstSampleIndex + 1
+		if leftInterpolationHandledReset {
+			// The reset between h[firstSampleIndex] and h[firstSampleIndex+1]
+			// is already accounted for by the left boundary interpolation.
+			first++
+		}
+		last := lastSampleIndex
+		if h[last].T >= rangeEnd {
+			last--
+		}
+
+		if first <= last {
+			correction, newAnnos, ok := correctForCounterResetsHistogram(left, right, h[first:last+1], metricName, pos)
+			annos.Merge(newAnnos)
+			if !ok {
+				return enh.Out, annos
+			}
+			if correction != nil && !addHistogramWithAnnotations(resultHistogram, correction, &annos, metricName, pos) {
+				return enh.Out, annos
+			}
+		}
+	}
+	if isRate {
+		resultHistogram.Div(ms.Range.Seconds())
+	}
+
+	resultHistogram.CounterResetHint = histogram.GaugeType
+	return append(enh.Out, Sample{H: resultHistogram.Compact(0)}), annos
+}
+
 // extrapolatedRate is a utility function for rate/increase/delta.
 // It calculates the rate (allowing for counter resets if isCounter is true),
 // extrapolates if the first/last sample is close to the boundary, and returns
 // the result as either per-second (if isRate is true) or overall.
 //
 // Note: If the vector selector is smoothed or anchored, it will use the
-// extendedRate function instead.
+// extendedRate or extendedHistogramRate function instead.
 func extrapolatedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper, isCounter, isRate bool) (Vector, annotations.Annotations) {
 	ms := args[0].(*parser.MatrixSelector)
 	vs := ms.VectorSelector.(*parser.VectorSelector)
 	if vs.Anchored || vs.Smoothed {
-		return extendedRate(vals, args, enh, isCounter, isRate)
+		samples := vals[0]
+		if len(samples.Histograms) > 0 && len(samples.Floats) > 0 {
+			var annos annotations.Annotations
+			return enh.Out, annos.Add(annotations.NewMixedFloatsHistogramsWarning(getMetricName(samples.Metric), args[0].PositionRange()))
+		}
+		if len(samples.Histograms) > 0 {
+			return extendedHistogramRate(vals, args, enh, isCounter, isRate)
+		}
+		if len(samples.Floats) > 0 {
+			return extendedRate(vals, args, enh, isCounter, isRate)
+		}
+		// Not enough samples.
+		return enh.Out, nil
 	}
 
 	var (

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -228,6 +228,45 @@ func subHistogramWithAnnotations(base, other *histogram.FloatHistogram, annos *a
 	return true
 }
 
+// validateHistogramRange checks all histogram samples in h for schema
+// consistency and counter-type hints. It returns false (and adds an annotation
+// to annos) when exponential and custom buckets are mixed. It adds a
+// NativeHistogramNotCounterWarning for any sample carrying a gauge hint while
+// isCounter is true.
+func validateHistogramRange(h []HPoint, isCounter bool, annos *annotations.Annotations, metricName string, pos posrange.PositionRange) bool {
+	usingCustomBuckets := h[0].H.UsesCustomBuckets()
+	for _, p := range h {
+		if p.H.UsesCustomBuckets() != usingCustomBuckets {
+			annos.Add(annotations.NewMixedExponentialCustomHistogramsWarning(metricName, pos))
+			return false
+		}
+		if isCounter && p.H.CounterResetHint == histogram.GaugeType {
+			annos.Add(annotations.NewNativeHistogramNotCounterWarning(metricName, pos))
+		}
+	}
+	return true
+}
+
+// innerHistogramBounds returns the (first, last) indices for the inner slice
+// passed to correctForCounterResetsHistogram. firstSampleIndex is always
+// excluded because it is already represented by left (directly or via
+// interpolation). When the left-boundary interpolation itself spanned a reset
+// (smoothed mode, first sample before rangeStart, DetectReset true), the reset
+// between firstSampleIndex and firstSampleIndex+1 is already accounted for, so
+// firstSampleIndex+1 is also excluded. lastSampleIndex is excluded when its
+// timestamp is at or after rangeEnd, mirroring the float version.
+func innerHistogramBounds(h []HPoint, firstSampleIndex, lastSampleIndex int, rangeStart, rangeEnd int64, smoothed bool) (int, int) {
+	first := firstSampleIndex + 1
+	if smoothed && h[firstSampleIndex].T < rangeStart && h[firstSampleIndex+1].H.DetectReset(h[firstSampleIndex].H) {
+		first++
+	}
+	last := lastSampleIndex
+	if h[last].T >= rangeEnd {
+		last--
+	}
+	return first, last
+}
+
 // correctForCounterResetsHistogram calculates the histogram correction for
 // counter resets in points, using left and right as the boundary samples.
 // It is only used by extendedHistogramRate. It returns the accumulated
@@ -349,14 +388,8 @@ func extendedHistogramRate(vals Matrix, args parser.Expressions, enh *EvalNodeHe
 		return enh.Out, annos
 	}
 
-	usingCustomBuckets := h[firstSampleIndex].H.UsesCustomBuckets()
-	for _, p := range h[firstSampleIndex : lastSampleIndex+1] {
-		if p.H.UsesCustomBuckets() != usingCustomBuckets {
-			return enh.Out, annos.Add(annotations.NewMixedExponentialCustomHistogramsWarning(metricName, pos))
-		}
-		if isCounter && p.H.CounterResetHint == histogram.GaugeType {
-			annos.Add(annotations.NewNativeHistogramNotCounterWarning(metricName, pos))
-		}
+	if !validateHistogramRange(h[firstSampleIndex:lastSampleIndex+1], isCounter, &annos, metricName, pos) {
+		return enh.Out, annos
 	}
 
 	left, err := pickOrInterpolateLeftHistogram(h, firstSampleIndex, rangeStart, smoothed, isCounter, &annos, pos)
@@ -372,32 +405,13 @@ func extendedHistogramRate(vals Matrix, args parser.Expressions, enh *EvalNodeHe
 		annos.Add(annotations.NewNativeHistogramNotGaugeWarning(metricName, pos))
 	}
 
-	// Compute result = right - left.
 	resultHistogram := right.Copy()
 	if !subHistogramWithAnnotations(resultHistogram, left, &annos, metricName, pos) {
 		return enh.Out, annos
 	}
 
 	if isCounter {
-		leftInterpolationHandledReset := smoothed && h[firstSampleIndex].T < rangeStart && h[firstSampleIndex+1].H.DetectReset(h[firstSampleIndex].H)
-
-		// Always skip firstSampleIndex: it is either already represented by
-		// left (when h[firstSampleIndex].T >= rangeStart) or by the
-		// interpolation between h[firstSampleIndex] and h[firstSampleIndex+1]
-		// (when smoothed). Including it in the correction slice would
-		// double-count via DetectReset's CounterReset shortcut when
-		// h[firstSampleIndex].CounterResetHint == CounterReset.
-		first := firstSampleIndex + 1
-		if leftInterpolationHandledReset {
-			// The reset between h[firstSampleIndex] and h[firstSampleIndex+1]
-			// is already accounted for by the left boundary interpolation.
-			first++
-		}
-		last := lastSampleIndex
-		if h[last].T >= rangeEnd {
-			last--
-		}
-
+		first, last := innerHistogramBounds(h, firstSampleIndex, lastSampleIndex, rangeStart, rangeEnd, smoothed)
 		if first <= last {
 			correction, newAnnos, ok := correctForCounterResetsHistogram(left, right, h[first:last+1], metricName, pos)
 			annos.Merge(newAnnos)

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -128,23 +128,23 @@ func interpolateHistograms(h1 *histogram.FloatHistogram, t1 int64, h2 *histogram
 	}
 
 	// Result = H1 + (H2 - H1) * fraction.
-	delta := h2.Copy()
-	_, _, nhcbReconciled, err := delta.Sub(h1)
+	result := h2.Copy()
+	_, _, nhcbReconciled, err := result.Sub(h1)
 	if err != nil {
 		return nil, err
 	}
 	if nhcbReconciled {
 		annos.Add(annotations.NewMismatchedCustomBucketsHistogramsInfo(pos, annotations.HistogramSub))
 	}
-	delta.Mul(fraction)
-	_, _, nhcbReconciled, err = delta.Add(h1)
+	result.Mul(fraction)
+	_, _, nhcbReconciled, err = result.Add(h1)
 	if err != nil {
 		return nil, err
 	}
 	if nhcbReconciled {
 		annos.Add(annotations.NewMismatchedCustomBucketsHistogramsInfo(pos, annotations.HistogramAdd))
 	}
-	return delta, nil
+	return result, nil
 }
 
 // pickOrInterpolateLeftHistogram returns the histogram at the left boundary of the range.
@@ -186,12 +186,11 @@ func correctForCounterResets(left, right float64, points []FPoint) float64 {
 
 // annosFromInterpolationError classifies an error returned by
 // interpolateHistograms (via pickOrInterpolate*Histogram) into the appropriate
-// annotation. If the error is not recognised, annos is returned unchanged.
-func annosFromInterpolationError(annos annotations.Annotations, err error, metricName string, pos posrange.PositionRange) annotations.Annotations {
+// annotation. If the error is not recognised, annos is left unchanged.
+func annosFromInterpolationError(annos *annotations.Annotations, err error, metricName string, pos posrange.PositionRange) {
 	if errors.Is(err, histogram.ErrHistogramsIncompatibleSchema) {
-		return annos.Add(annotations.NewMixedExponentialCustomHistogramsWarning(metricName, pos))
+		annos.Add(annotations.NewMixedExponentialCustomHistogramsWarning(metricName, pos))
 	}
-	return annos
 }
 
 // addHistogramWithAnnotations adds other into base in place, translating
@@ -271,10 +270,12 @@ func correctForCounterResetsHistogram(h []HPoint, firstSampleIndex, lastSampleIn
 	// handles the right-boundary reset safely once h[lastSampleIndex] is not prev.
 	last := lastSampleIndex - 1
 
-	// first > last+1 only when leftInterpolationHandledReset is true and there
-	// is only one sample interval (lastSampleIndex == firstSampleIndex+1).
-	// Both left and right were interpolated from the same reset segment, so
-	// there is nothing more to correct.
+	// first > last+1 when there is nothing between the two boundary samples to
+	// check. This happens when firstSampleIndex == lastSampleIndex (single-sample
+	// window), or when the smoothed left interpolation already spanned the only
+	// reset interval (lastSampleIndex == firstSampleIndex+1 and first was
+	// incremented above). Both boundaries were interpolated from the same reset
+	// segment, so there is nothing more to correct.
 	if first > last+1 {
 		return nil, nil, true
 	}
@@ -310,7 +311,7 @@ func correctForCounterResetsHistogram(h []HPoint, firstSampleIndex, lastSampleIn
 
 // extendedRate is a utility function for anchored/smoothed rate/increase/delta.
 // It calculates the rate (allowing for counter resets if isCounter is true),
-// extrapolates if the first/last sample if needed, and returns
+// interpolates at the first/last sample boundary if needed, and returns
 // the result as either per-second (if isRate is true) or overall.
 func extendedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper, isCounter, isRate bool) (Vector, annotations.Annotations) {
 	var (
@@ -399,17 +400,21 @@ func extendedHistogramRate(vals Matrix, args parser.Expressions, enh *EvalNodeHe
 
 	left, err := pickOrInterpolateLeftHistogram(h, firstSampleIndex, rangeStart, smoothed, isCounter, &annos, pos)
 	if err != nil {
-		return enh.Out, annosFromInterpolationError(annos, err, metricName, pos)
+		annosFromInterpolationError(&annos, err, metricName, pos)
+		return enh.Out, annos
 	}
 	right, err := pickOrInterpolateRightHistogram(h, lastSampleIndex, rangeEnd, smoothed, isCounter, &annos, pos)
 	if err != nil {
-		return enh.Out, annosFromInterpolationError(annos, err, metricName, pos)
+		annosFromInterpolationError(&annos, err, metricName, pos)
+		return enh.Out, annos
 	}
 
 	if !isCounter && (left.CounterResetHint != histogram.GaugeType || right.CounterResetHint != histogram.GaugeType) {
 		annos.Add(annotations.NewNativeHistogramNotGaugeWarning(metricName, pos))
 	}
 
+	// Copy right so that correctForCounterResetsHistogram can still call
+	// right.DetectReset without observing mutations from subHistogramWithAnnotations.
 	resultHistogram := right.Copy()
 	if !subHistogramWithAnnotations(resultHistogram, left, &annos, metricName, pos) {
 		return enh.Out, annos

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -367,6 +367,17 @@ func extendedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper, isC
 // with native histograms. It calculates the rate (allowing for counter resets if
 // isCounter is true), interpolates at the range boundaries if needed, and returns
 // the result as either per-second (if isRate is true) or overall.
+//
+// TODO: histogramRate pre-computes the minimum exponential schema across all
+// samples and reduces every sample to that schema before doing arithmetic, so
+// the schema is reduced at most once. extendedHistogramRate reduces schema on
+// the fly during pairwise Sub/Add operations. In the common constant-schema
+// case both produce identical results. In mixed-schema cases the final schema
+// is also the same (global minimum wins either way), but intermediate values
+// may briefly sit at a higher resolution before being pulled down when the
+// correction is added. Aligning the two approaches requires a min-schema
+// pre-scan followed by CopyToSchema on the interpolated boundaries, which is
+// a non-trivial change and warrants its own PR.
 func extendedHistogramRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper, isCounter, isRate bool) (Vector, annotations.Annotations) {
 	var (
 		ms              = args[0].(*parser.MatrixSelector)

--- a/promql/functions_internal_test.go
+++ b/promql/functions_internal_test.go
@@ -136,33 +136,33 @@ func TestInterpolateHistograms(t *testing.T) {
 	}{
 		{
 			name: "exact match t1",
-			h1: h1, h2: h2, t1: 0, t2: 20, t: 0,
+			h1:   h1, h2: h2, t1: 0, t2: 20, t: 0,
 			isCounter: false, wantCount: 1,
 		},
 		{
 			name: "exact match t2",
-			h1: h1, h2: h2, t1: 0, t2: 20, t: 20,
+			h1:   h1, h2: h2, t1: 0, t2: 20, t: 20,
 			isCounter: false, wantCount: 3,
 		},
 		{
 			name: "midpoint no reset",
-			h1: h1, h2: h2, t1: 0, t2: 20, t: 10,
+			h1:   h1, h2: h2, t1: 0, t2: 20, t: 10,
 			isCounter: false, wantCount: 2,
 		},
 		{
 			name: "counter midpoint no reset",
-			h1: h1, h2: h2, t1: 0, t2: 20, t: 10,
+			h1:   h1, h2: h2, t1: 0, t2: 20, t: 10,
 			isCounter: true, wantCount: 2,
 		},
 		{
 			name: "counter midpoint with reset: scale from zero",
-			h1: h1, h2: h2Reset, t1: 0, t2: 20, t: 10,
+			h1:   h1, h2: h2Reset, t1: 0, t2: 20, t: 10,
 			// h2Reset * (10/20) = count:1 * 0.5 = 0.5.
 			isCounter: true, wantCount: 0.5,
 		},
 		{
 			name: "quarter point",
-			h1: h1, h2: h2, t1: 0, t2: 20, t: 5,
+			h1:   h1, h2: h2, t1: 0, t2: 20, t: 5,
 			// h1 + (h2-h1)*0.25 = 1 + 2*0.25 = 1.5.
 			isCounter: false, wantCount: 1.5,
 		},

--- a/promql/functions_internal_test.go
+++ b/promql/functions_internal_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/prometheus/prometheus/util/kahansum"
 )
 
@@ -117,5 +118,61 @@ func TestInterpolate(t *testing.T) {
 	for _, test := range tests {
 		result := interpolate(test.p1, test.p2, test.t, test.isCounter)
 		require.Equal(t, test.expected, result)
+	}
+}
+
+func TestInterpolateHistograms(t *testing.T) {
+	h1 := &histogram.FloatHistogram{Count: 1, Sum: 1, CounterResetHint: histogram.UnknownCounterReset}
+	h2 := &histogram.FloatHistogram{Count: 3, Sum: 3, CounterResetHint: histogram.UnknownCounterReset}
+	h2Reset := &histogram.FloatHistogram{Count: 1, Sum: 1, CounterResetHint: histogram.CounterReset}
+	pos := posrange.PositionRange{}
+
+	tests := []struct {
+		name      string
+		h1, h2    *histogram.FloatHistogram
+		t1, t2, t int64
+		isCounter bool
+		wantCount float64
+	}{
+		{
+			name: "exact match t1",
+			h1: h1, h2: h2, t1: 0, t2: 20, t: 0,
+			isCounter: false, wantCount: 1,
+		},
+		{
+			name: "exact match t2",
+			h1: h1, h2: h2, t1: 0, t2: 20, t: 20,
+			isCounter: false, wantCount: 3,
+		},
+		{
+			name: "midpoint no reset",
+			h1: h1, h2: h2, t1: 0, t2: 20, t: 10,
+			isCounter: false, wantCount: 2,
+		},
+		{
+			name: "counter midpoint no reset",
+			h1: h1, h2: h2, t1: 0, t2: 20, t: 10,
+			isCounter: true, wantCount: 2,
+		},
+		{
+			name: "counter midpoint with reset: scale from zero",
+			h1: h1, h2: h2Reset, t1: 0, t2: 20, t: 10,
+			// h2Reset * (10/20) = count:1 * 0.5 = 0.5.
+			isCounter: true, wantCount: 0.5,
+		},
+		{
+			name: "quarter point",
+			h1: h1, h2: h2, t1: 0, t2: 20, t: 5,
+			// h1 + (h2-h1)*0.25 = 1 + 2*0.25 = 1.5.
+			isCounter: false, wantCount: 1.5,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var annos annotations.Annotations
+			result, err := interpolateHistograms(tc.h1, tc.t1, tc.h2, tc.t2, tc.t, tc.isCounter, &annos, pos)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantCount, result.Count)
+		})
 	}
 }

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -506,8 +506,20 @@ eval instant at 5s histogram_sum(increase(hist_counter[1m] anchored))
 
 # Smoothed delta (non-counter) at 50s: same values as smoothed increase
 # for a monotonic series (no counter reset correction needed).
+# hist_counter samples have no GaugeType hint so a not-a-gauge warning is emitted.
 eval instant at 50s histogram_count(delta(hist_counter[1m] smoothed))
+    expect warn msg: PromQL warning: this native histogram metric is not a gauge: "hist_counter"
     {} 3.333333333333333
+
+# Anchored rate at 50s: left=count:1 (t=0), right=count:4 (t=45), rate=3/60.
+eval instant at 50s histogram_count(rate(hist_counter[1m] anchored))
+    {} 0.05
+
+# Anchored delta (non-counter) at 50s: same result as anchored increase but
+# hist_counter samples have no GaugeType hint so a not-a-gauge warning is emitted.
+eval instant at 50s histogram_count(delta(hist_counter[1m] anchored))
+    expect warn msg: PromQL warning: this native histogram metric is not a gauge: "hist_counter"
+    {} 3
 
 # Smoothed vector selector interpolation for native histograms.
 # At t=7s, interpolate between t=0 (count:1) and t=15 (count:2), fraction=7/15.
@@ -517,6 +529,21 @@ eval instant at 7s histogram_count(hist_counter smoothed)
 # At t=15s, exact match: count:2.
 eval instant at 15s histogram_count(hist_counter smoothed)
     {} 2
+
+# At t=110s, no next sample; carry forward the last value (count:8 at t=105).
+eval instant at 110s histogram_count(hist_counter smoothed)
+    {} 8
+
+# Range eval for smoothed rate: verify per-step boundary handling.
+# hist_counter increments count:1 and sum:1 every 15s starting at t=0.
+# rate(hist_counter[1m] smoothed) at each step computes increase/60.
+# t=0:  left=right=count:1, increase=0, rate=0.
+# t=15: left=count:1, right=count:2 (exact), increase=1, rate=1/60.
+# t=30: left=count:1, right=count:3 (exact), increase=2, rate=2/60.
+# t=45: left=count:1, right=count:4 (exact), increase=3, rate=3/60.
+# t=60: left=count:1, right=count:5 (exact), increase=4, rate=4/60.
+eval range from 0s to 60s step 15s histogram_count(rate(hist_counter[1m] smoothed))
+    {} 0 0.016666666666666666 0.03333333333333333 0.05 0.06666666666666667
 
 # Anchored and smoothed native histogram modifiers with custom buckets.
 clear
@@ -640,8 +667,8 @@ eval instant at 15s histogram_count(increase(smoothed_double_reset[14s] smoothed
 # Two-sample smoothed window where both left and right are interpolated from the
 # same reset. The left interpolation already accounts for the reset, so no
 # correction should be applied. Float reference: right-left = h[1].Mul(0.75) -
-# h[1].Mul(0.25) = h[1].Mul(0.5) = count 2.5. (prev initialPrev path must not
-# fire here, since first > last+1 for this two-sample case.)
+# h[1].Mul(0.25) = h[1].Mul(0.5) = count 2.5. The first > last+1 early-return
+# in correctForCounterResetsHistogram prevents double-counting this case.
 clear
 load 20s
   smoothed_two_sample_both_interp {{schema:0 sum:10 count:10 buckets:[10]}} {{schema:0 sum:5 count:5 buckets:[5] counter_reset_hint:reset}}
@@ -667,3 +694,20 @@ load 30s
 
 eval instant at 45s sort(mixed_types smoothed)
     expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "mixed_types"
+
+# Smoothed rate where the RIGHT boundary interpolation crosses a counter reset.
+# Samples: t=0 count:5, t=10 count:10, t=20 count:3 (reset).
+# At t=15s, range=10s: rangeStart=5s, rangeEnd=15s.
+# left: interpolate(t=0 count:5, t=10 count:10, t=5s) = count:5+(count:5*0.5) = count:7.5.
+# right: interpolate(t=10 count:10, t=20 count:3 reset, t=15s) → reset path →
+#   count:3 * 0.5 = count:1.5 (CounterResetHint=reset inherited).
+# Inner samples: h[t=10 count:10]. h[10].DetectReset(left=7.5)? no (10>7.5).
+# right.DetectReset(prev=count:10)? yes (reset hint). correction=count:10.
+# increase = count:1.5 - count:7.5 + count:10 = count:4.
+# rate = count:4/10 = 0.4.
+clear
+load 10s
+  right_boundary_reset {{schema:0 sum:5 count:5 buckets:[5]}} {{schema:0 sum:10 count:10 buckets:[10]}} {{schema:0 sum:3 count:3 buckets:[3] counter_reset_hint:reset}}
+
+eval instant at 15s histogram_count(rate(right_boundary_reset[10s] smoothed))
+    {} 0.4

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -604,6 +604,51 @@ load 10s
 eval instant at 20s500ms histogram_count(rate(reset_boundary[1s] smoothed))
     {} 9.7
 
+# Anchored increase with reset at last sample (T < rangeEnd): the reset hint on
+# h[2] must not self-detect when right is a direct copy of h[2].
+# Float reference (5 10 3): increase = 10 - 5 + 10 - 3? No: right - left + correction.
+# left=5 right=3 correction=h[1]=10 → 8. Bug returns 11 (adds h[2]=3 twice).
+clear
+load 30s
+  anchored_reset_at_end {{schema:0 sum:5 count:5 buckets:[5]}} {{schema:0 sum:10 count:10 buckets:[10]}} {{schema:0 sum:3 count:3 buckets:[3] counter_reset_hint:reset}}
+
+eval instant at 70s histogram_count(increase(anchored_reset_at_end[70s] anchored))
+    {} 8
+
+# Anchored increase with only two samples, second is a reset at rangeEnd.
+# The two-sample case must still apply the reset correction even though the
+# inner slice is empty after excluding both boundary samples.
+# Float reference: right - left + correction = 3 - 5 + 5 = 3.
+clear
+load 30s
+  anchored_two_sample_reset {{schema:0 sum:5 count:5 buckets:[5]}} {{schema:0 sum:3 count:3 buckets:[3] counter_reset_hint:reset}}
+
+eval instant at 30s histogram_count(increase(anchored_two_sample_reset[30s] anchored))
+    {} 3
+
+# Smoothed increase where the left interpolation crosses the first reset and a
+# second reset immediately follows the skipped sample. The correction must be
+# taken against h[firstSampleIndex+1] (count=5), not the interpolated left
+# (count=0.5). Float reference: 5.5.
+clear
+load 10s
+  smoothed_double_reset {{schema:0 sum:10 count:10 buckets:[10]}} {{schema:0 sum:5 count:5 buckets:[5] counter_reset_hint:reset}} {{schema:0 sum:2 count:2 buckets:[2] counter_reset_hint:reset}} {{schema:0 sum:4 count:4 buckets:[4]}}
+
+eval instant at 15s histogram_count(increase(smoothed_double_reset[14s] smoothed))
+    {} 5.5
+
+# Two-sample smoothed window where both left and right are interpolated from the
+# same reset. The left interpolation already accounts for the reset, so no
+# correction should be applied. Float reference: right-left = h[1].Mul(0.75) -
+# h[1].Mul(0.25) = h[1].Mul(0.5) = count 2.5. (prev initialPrev path must not
+# fire here, since first > last+1 for this two-sample case.)
+clear
+load 20s
+  smoothed_two_sample_both_interp {{schema:0 sum:10 count:10 buckets:[10]}} {{schema:0 sum:5 count:5 buckets:[5] counter_reset_hint:reset}}
+
+eval instant at 15s histogram_count(increase(smoothed_two_sample_both_interp[10s] smoothed))
+    {} 2.5
+
 # Smoothed vector selector emits MixedExponentialCustomHistogramsWarning and
 # produces no result when interpolating between exponential and custom-bucket
 # histograms. At t=45s: prev=t=30 (custom), next=t=60 (exp) → skip + warn.

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -457,3 +457,168 @@ eval range from 0s to 60s step 15s metric offset -100 smoothed
 
 eval range from 0s to 60s step 15s metric offset -100 smoothed + 0
     {} 10 11.5 13 14.5 16
+
+# Native histogram tests for smoothed/anchored modifiers.
+# Simple histogram counter incrementing by count:1, sum:1, buckets:[1] every 15s.
+clear
+load 15s
+  hist_counter {{schema:0 count:1 sum:1 buckets:[1] offset:1}}+{{count:1 sum:1 buckets:[1] offset:1}}x7
+
+# Standard (non-smoothed/anchored) rate and increase at 50s for reference.
+eval instant at 50s histogram_count(rate(hist_counter[1m]))
+    {} 0.06666666666666667
+
+eval instant at 50s histogram_count(increase(hist_counter[1m]))
+    {} 4
+
+# Anchored increase at 50s: left=count:1 (t=0), right=count:4 (t=45), increase=3.
+eval instant at 50s histogram_count(increase(hist_counter[1m] anchored))
+    {} 3
+
+eval instant at 50s histogram_sum(increase(hist_counter[1m] anchored))
+    {} 3
+
+# Smoothed increase at 50s: left=count:1 (t=0), right interpolated at t=50
+# between count:4 (t=45) and count:5 (t=60), fraction=1/3, right=count:4.333...,
+# increase=3.333...
+eval instant at 50s histogram_count(increase(hist_counter[1m] smoothed))
+    {} 3.333333333333333
+
+eval instant at 50s histogram_sum(increase(hist_counter[1m] smoothed))
+    {} 3.333333333333333
+
+# Smoothed increase at 5s: left=count:1 (t=0, not before rangeStart=-55s),
+# right interpolated at t=5 between count:1 (t=0) and count:2 (t=15),
+# fraction=1/3, right=count:1.333..., increase=0.333...
+eval instant at 5s histogram_count(increase(hist_counter[1m] smoothed))
+    {} 0.3333333333333333
+
+# Smoothed rate at 50s: increase / 60s.
+eval instant at 50s histogram_count(rate(hist_counter[1m] smoothed))
+    {} 0.05555555555555555
+
+# Anchored increase at 5s: only one sample (t=0) in range, increase from itself is 0.
+eval instant at 5s histogram_count(increase(hist_counter[1m] anchored))
+    {} 0
+
+eval instant at 5s histogram_sum(increase(hist_counter[1m] anchored))
+    {} 0
+
+# Smoothed delta (non-counter) at 50s: same values as smoothed increase
+# for a monotonic series (no counter reset correction needed).
+eval instant at 50s histogram_count(delta(hist_counter[1m] smoothed))
+    {} 3.333333333333333
+
+# Smoothed vector selector interpolation for native histograms.
+# At t=7s, interpolate between t=0 (count:1) and t=15 (count:2), fraction=7/15.
+eval instant at 7s histogram_count(hist_counter smoothed)
+    {} 1.4666666666666668
+
+# At t=15s, exact match: count:2.
+eval instant at 15s histogram_count(hist_counter smoothed)
+    {} 2
+
+# Anchored and smoothed native histogram modifiers with custom buckets.
+clear
+load 30s
+  mixed_hist {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+
+# Anchored rate should warn and return no result when the range mixes exponential
+# and custom buckets at the boundaries.
+eval instant at 1m rate(mixed_hist[1m] anchored)
+    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "mixed_hist"
+    # Should produce no results.
+
+# Smoothed rate should warn and return no result when interpolation would cross
+# exponential and custom buckets.
+eval instant at 45s rate(mixed_hist[1m] smoothed)
+    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "mixed_hist"
+    # Should produce no results.
+
+# Anchored increase should still account for resets for custom-bucket histograms.
+clear
+load 30s
+  reset_custom_hist {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:-53 sum:4 count:4 custom_values:[5 10] buckets:[4]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1] counter_reset_hint:reset}} {{schema:-53 sum:3 count:3 custom_values:[5 10] buckets:[3]}}
+
+eval instant at 90s histogram_count(increase(reset_custom_hist[90s]))
+    {} 4.5
+
+eval instant at 90s histogram_sum(increase(reset_custom_hist[90s]))
+    {} 4.5
+
+eval instant at 90s histogram_count(increase(reset_custom_hist[90s] anchored))
+    {} 6
+
+eval instant at 90s histogram_sum(increase(reset_custom_hist[90s] anchored))
+    {} 6
+
+# A gauge-hint on a middle (non-boundary) sample must trigger the "not a counter"
+# warning for rate/increase, matching the behaviour of the non-extended path.
+clear
+load 30s
+  mid_gauge_hist {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:0 sum:2 count:2 buckets:[2] counter_reset_hint:gauge}} {{schema:0 sum:3 count:3 buckets:[3]}}
+
+eval instant at 90s histogram_count(rate(mid_gauge_hist[90s] anchored))
+    expect warn msg: PromQL warning: this native histogram metric is not a counter: "mid_gauge_hist"
+    {} 0.022222222222222223
+
+eval instant at 90s histogram_count(increase(mid_gauge_hist[90s] smoothed))
+    expect warn msg: PromQL warning: this native histogram metric is not a counter: "mid_gauge_hist"
+    {} 2
+
+# Gauge op on a counter-typed series must warn when a boundary sample lacks the
+# gauge hint.
+eval instant at 90s histogram_count(delta(mid_gauge_hist[90s] anchored))
+    expect warn msg: PromQL warning: this native histogram metric is not a gauge: "mid_gauge_hist"
+    {} 2
+
+# Smoothed rate on a custom-bucket-only series interpolates cleanly.
+clear
+load 15s
+  custom_only {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}+{{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}x7
+
+eval instant at 50s histogram_count(increase(custom_only[1m] smoothed))
+    {} 3.333333333333333
+
+eval instant at 50s histogram_sum(increase(custom_only[1m] smoothed))
+    {} 3.333333333333333
+
+# Smoothed vector-selector interpolation for a histogram counter crossing a
+# reset. isCounter=true (CounterResetHint != GaugeType), so the reset between
+# h[1]=count:10 and h[2]=count:2 (counter_reset_hint:reset) is detected and
+# the interpolation models the counter as restarting from zero:
+# h[2].Mul(fraction) = count:2 * (5/15) = 0.666...
+clear
+load 15s
+  reset_middle {{schema:0 sum:5 count:5 buckets:[5]}} {{schema:0 sum:10 count:10 buckets:[10]}} {{schema:0 sum:2 count:2 buckets:[2] counter_reset_hint:reset}} {{schema:0 sum:6 count:6 buckets:[6]}}
+
+eval instant at 20s histogram_count(reset_middle smoothed)
+    {} 0.6666666666666666
+
+# Smoothed histogram rate must not double-count the first post-reset sample when
+# the left range boundary is interpolated across the reset.
+clear
+load 10s
+  reset_boundary _ {{schema:0 sum:396 count:396 buckets:[396] counter_reset_hint:not_reset}} {{schema:0 sum:110 count:110 buckets:[110] counter_reset_hint:reset}} {{schema:0 sum:194 count:194 buckets:[194] counter_reset_hint:not_reset}}
+
+eval instant at 20s500ms histogram_count(rate(reset_boundary[1s] smoothed))
+    {} 9.7
+
+# Smoothed vector selector emits MixedExponentialCustomHistogramsWarning and
+# produces no result when interpolating between exponential and custom-bucket
+# histograms. At t=45s: prev=t=30 (custom), next=t=60 (exp) → skip + warn.
+clear
+load 30s
+  smoothed_mix {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
+
+eval instant at 45s histogram_count(smoothed_mix smoothed)
+    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "smoothed_mix"
+
+# Smoothed vector selector must emit a warning and produce no result when the
+# lookback window mixes floats and histograms.
+clear
+load 30s
+  mixed_types 1 2 {{schema:0 sum:3 count:3 buckets:[3]}} {{schema:0 sum:4 count:4 buckets:[4]}}
+
+eval instant at 45s sort(mixed_types smoothed)
+    expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "mixed_types"


### PR DESCRIPTION
Add native histogram support for the smoothed and anchored rate modifiers (rate, increase, delta). Previously these modifiers only worked with float samples and errored on native histograms.

The implementation adds histogram interpolation helpers that mirror the float versions, and a dedicated extendedHistogramRate() function parallel to extendedRate(). The smoothSeries() function for smoothed vector selectors now also handles histogram interpolation.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[FEATURE] PromQL: Add support for smoothed/anchored rate with native histograms.
```
