### PR TITLE
perf(PromQL): make floatHistogram.KahanAdd inlineable on Go 1.26

### DIFF
--- a/util/kahansum/kahansum.go
+++ b/util/kahansum/kahansum.go
@@ -15,6 +15,12 @@ package kahansum
 
 import "math"
 
+// isInf reports whether f is positive or negative infinity.
+// It avoids math.IsInf to prevent inflating Inc's inlining cost.
+func isInf(f float64) bool {
+	return f > math.MaxFloat64 || f < -math.MaxFloat64
+}
+
 // Inc performs addition of two floating-point numbers using the Kahan summation algorithm.
 func Inc(inc, sum, c float64) (newSum, newC float64) {
 	// We've seen Kahan summation return less accurate results when Inc function is
@@ -33,7 +39,7 @@ func Inc(inc, sum, c float64) (newSum, newC float64) {
 
 	t := sum + inc
 	switch {
-	case math.IsInf(t, 0):
+	case isInf(t):
 		c = 0
 
 		// Using Neumaier improvement, swap if next term larger than sum.

--- a/util/kahansum/kahansum_test.go
+++ b/util/kahansum/kahansum_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/util/kahansum/kahansum_test.go
+++ b/util/kahansum/kahansum_test.go
@@ -21,20 +21,16 @@ import (
 )
 
 func TestIsInf(t *testing.T) {
-	for _, tc := range []struct {
-		f    float64
-		want bool
-	}{
-		{math.Inf(1), true},
-		{math.Inf(-1), true},
-		{math.MaxFloat64, false},
-		{-math.MaxFloat64, false},
-		{1.0, false},
-		{-1.0, false},
-		{0, false},
-		{math.NaN(), false},
+	for _, f := range []float64{
+		math.Inf(1),
+		math.Inf(-1),
+		math.MaxFloat64,
+		-math.MaxFloat64,
+		1.0,
+		-1.0,
+		0,
+		math.NaN(),
 	} {
-		got := isInf(tc.f)
-		require.Equal(t, tc.want, got, "%e", tc.f)
+		require.Equal(t, math.IsInf(f, 0), isInf(f), "%e", f)
 	}
 }

--- a/util/kahansum/kahansum_test.go
+++ b/util/kahansum/kahansum_test.go
@@ -1,0 +1,40 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kahansum
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsInf(t *testing.T) {
+	for _, tc := range []struct {
+		f    float64
+		want bool
+	}{
+		{math.Inf(1), true},
+		{math.Inf(-1), true},
+		{math.MaxFloat64, false},
+		{-math.MaxFloat64, false},
+		{1.0, false},
+		{-1.0, false},
+		{0, false},
+		{math.NaN(), false},
+	} {
+		got := isInf(tc.f)
+		require.Equal(t, tc.want, got, "%e", tc.f)
+	}
+}


### PR DESCRIPTION
Related to #18249.

On Go 1.26, `kahansum.Inc` has become non-inlineable again, which affected performance of `FloatHistogram.KahanAdd`. Apparently the reason for this was the change of `math.IsInf` implementation in the standard library: https://github.com/golang/go/commit/4e05a070c4f88ebf43f0873e144c62d02d56060b. This increased the cost of `math.IsInf` (which is inlined into `kahansum.Inc`), and that was enough to slightly exceed the inlining budget.
We do not need the extra flexibility of `math.IsInf`. A simple `f > math.MaxFloat64 || f < -math.MaxFloat64` check suffices, and is enough to make `kahansum.Inc` inlineable again.

Benchmark results:
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/histogram
cpu: Apple M4 Pro
                              │   before    │                after                │
                              │   sec/op    │   sec/op     vs base                │
FloatHistogramAdd/KahanAdd-14   19.36µ ± 2%   14.21µ ± 1%  -26.61% (p=0.000 n=10)

                              │   before   │             after              │
                              │    B/op    │    B/op     vs base            │
FloatHistogramAdd/KahanAdd-14   800.0 ± 0%   800.0 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                              │   before   │             after              │
                              │ allocs/op  │ allocs/op   vs base            │
FloatHistogramAdd/KahanAdd-14   3.000 ± 0%   3.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[PERF] PromQL: Address FloatHistogram.KahanAdd performance regression on Go 1.26.
```
