### PR TITLE
[codex] deps: consolidate direct yaml usage

### DIFF
--- a/discovery/aws/aws_test.go
+++ b/discovery/aws/aws_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestRoleUnmarshalYAML(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,6 @@ require (
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/goleak v1.3.0
 	go.yaml.in/yaml/v2 v2.4.4
-	go.yaml.in/yaml/v3 v3.0.4
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
@@ -134,6 +133,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.148.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect

--- a/model/rulefmt/rulefmt.go
+++ b/model/rulefmt/rulefmt.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"

--- a/model/rulefmt/rulefmt_test.go
+++ b/model/rulefmt/rulefmt_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/promql/parser"
 )

--- a/web/api/v1/openapi_golden_test.go
+++ b/web/api/v1/openapi_golden_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/prometheus/prometheus/web/api/testhelpers"
 )


### PR DESCRIPTION
## Summary
- switch the remaining direct `go.yaml.in/yaml/v3` imports in the root module to `go.yaml.in/yaml/v4`
- let `go mod tidy` drop `yaml/v3` from the root module's direct requirements while keeping it indirect for `internal/tools`
- avoid a broader `yaml/v2` migration, since Prometheus still has many legacy `UnmarshalYAML(func(any) error)` implementations that are not compatible with `yaml/v4`

## Why
`#18391` asks for consolidation and cleanup of the mixed Go YAML dependencies. This change removes the last direct `yaml/v3` usages from the root module and narrows the direct dependency surface to `yaml/v2` and `yaml/v4`.

Fixes #18391

## Testing
- `go test ./model/rulefmt -run TestParseFileSuccess -count=1`
- `go test ./web/api/v1 -run 'TestOpenAPIGolden_3_1|TestOpenAPIGolden_3_2' -count=1`
- `go test ./discovery/aws -run 'TestRoleUnmarshalYAML|TestSDConfigUnmarshalYAML' -count=1`

## Release notes
```release-notes
NONE
```
