### PR TITLE
tsdb: add gauge metric for max head chunks m-mapped per series

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -421,6 +421,7 @@ type headMetrics struct {
 	snapshotReplayErrorTotal  prometheus.Counter // Will be either 0 or 1.
 	oooHistogram              prometheus.Histogram
 	mmapChunksTotal           prometheus.Counter
+	headChunksMaxMmapped      prometheus.Gauge
 	walReplayUnknownRefsTotal *prometheus.CounterVec
 	wblReplayUnknownRefsTotal *prometheus.CounterVec
 }
@@ -560,6 +561,10 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Name: "prometheus_tsdb_mmap_chunks_total",
 			Help: "Total number of chunks that were memory-mapped.",
 		}),
+		headChunksMaxMmapped: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "prometheus_tsdb_head_chunks_max_mmapped",
+			Help: "Maximum number of head chunks memory-mapped for any individual series during the last memory-mapping pass.",
+		}),
 		walReplayUnknownRefsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_wal_replay_unknown_refs_total",
 			Help: "Total number of unknown series references encountered during WAL replay.",
@@ -598,6 +603,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.checkpointCreationTotal,
 			m.oooHistogram,
 			m.mmapChunksTotal,
+			m.headChunksMaxMmapped,
 			m.mmapChunkCorruptionTotal,
 			m.snapshotReplayErrorTotal,
 			// Metrics bound to functions and not needed in tests
@@ -1959,7 +1965,7 @@ func (h *Head) onChunkCreated(series *memSeries, prevHeadChunkCount uint32) {
 // M-mapping is serialised via the per-series lock and done away from the sample append path,
 // since holding the lock during an append could delay the next scrape or cause query timeouts.
 func (h *Head) mmapHeadChunks() {
-	var count int
+	var count, maxMmappedChunks int
 	for i := range h.series.size {
 		if h.series.mmapReady[i].Load() == 0 {
 			continue // No series in this stripe need mmapping.
@@ -1977,10 +1983,14 @@ func (h *Head) mmapHeadChunks() {
 			if n > 0 {
 				count += n
 				h.series.decMmapReady(series.ref)
+				if n > maxMmappedChunks {
+					maxMmappedChunks = n
+				}
 			}
 		}
 		h.series.locks[i].RUnlock()
 	}
+	h.metrics.headChunksMaxMmapped.Set(float64(maxMmappedChunks))
 	h.metrics.mmapChunksTotal.Add(float64(count))
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -8233,12 +8233,14 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		require.Equal(t, uint32(1), getCount(lblsB), "headChunkCount should be 1 after mmap")
 		require.Equal(t, uint32(1), getCount(lblsC), "headChunkCount should be 1 after mmap")
 		require.Equal(t, 0, countReady(), "ready set should be empty after mmapHeadChunks")
+		require.Equal(t, float64(2), prom_testutil.ToFloat64(h.metrics.headChunksMaxMmapped), "max mmapped should be 2 (both series had 3 head chunks, 2 of which got m-mapped)")
 
 		// A second call should be a no-op.
 		beforeMetric := prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
 		h.mmapHeadChunks()
 		afterMetric := prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
 		require.Equal(t, beforeMetric, afterMetric, "second call should mmap 0 chunks")
+		require.Equal(t, float64(0), prom_testutil.ToFloat64(h.metrics.headChunksMaxMmapped), "max mmapped should be 0 when no series needs mmapping")
 
 		// Only newly ready series should be processed.
 		app = h.Appender(t.Context())
@@ -8259,6 +8261,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		afterMetric = prom_testutil.ToFloat64(h.metrics.mmapChunksTotal)
 		require.Greater(t, afterMetric, beforeMetric, "third call should mmap chunks from series B")
 		require.Equal(t, uint32(1), getCount(lblsB), "series B headChunkCount should be 1 after mmap")
+		require.Equal(t, float64(2), prom_testutil.ToFloat64(h.metrics.headChunksMaxMmapped), "max mmapped should be 2 (only series B had 3 head chunks, 2 of which got m-mapped)")
 	})
 
 	t.Run("ooo does not inflate count", func(t *testing.T) {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

N/A

#### Summary

Add `prometheus_tsdb_head_chunks_max_mmapped`, a gauge updated on each `mmapHeadChunks` pass to the maximum number of chunks m-mapped in any individual series during the pass.

The primary motivation is to make it possible to detect pathological chunk creation. For example, when OTLP exponential histograms with cumulative temporality are ingested but the sender resets the counter on every sample, each sample causes a chunk cut, causing head chunks to accumulate faster than they are m-mapped. Without this metric such a condition is invisible.

The gauge value is sourced from the return value of `memSeries.mmapChunks`, i.e. the actual number of chunks moved to m-map storage during the pass. The currently active head chunk is never counted (it is not a candidate for m-mapping), and the count is taken under the per-series lock so it cannot diverge from what was actually written.

When `mmapHeadChunks` is a complete no-op (no series pending), the gauge is set to 0. This also stays correct after the per-stripe `mmapReady` optimisation in #18541, which skips entire stripes where no series needs m-mapping: skipped stripes only contain series with `headChunkCount <= 1`, so they cannot hold the global maximum when any mmap-ready series exists.

The existing `TestHead_mmapHeadChunks` test is extended with assertions at each of the three `mmapHeadChunks` call sites to verify the gauge value.

```release-notes
[FEATURE] TSDB: Add gauge metric `prometheus_tsdb_head_chunks_max_mmapped` tracking the maximum number of head chunks memory-mapped in any individual series during the last memory-mapping pass.
```

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>

Coded with Claude Sonnet 4.6 and Claude Opus 4.7.
