### PR TITLE
promql: prevent nil pointer dereference in DurationExpr.PositionRange

### DIFF
--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -487,7 +487,7 @@ func (e *BinaryExpr) PositionRange() posrange.PositionRange {
 }
 
 func (e *DurationExpr) PositionRange() posrange.PositionRange {
-	if e.Op == STEP || e.Op == RANGE {
+	if e.RHS == nil && e.LHS == nil {
 		return posrange.PositionRange{
 			Start: e.StartPos,
 			End:   e.EndPos,
@@ -496,7 +496,7 @@ func (e *DurationExpr) PositionRange() posrange.PositionRange {
 	if e.RHS == nil {
 		return posrange.PositionRange{
 			Start: e.StartPos,
-			End:   e.RHS.PositionRange().End,
+			End:   e.LHS.PositionRange().End,
 		}
 	}
 	if e.LHS == nil {


### PR DESCRIPTION
Fixed a bug in the `PositionRange` method where a panic occurred when `e.RHS` was nil. Previously, the code checked `if e.RHS == nil` but then immediately accessed `e.RHS.PositionRange().End`, causing a runtime error.

This commit updates the logic to correctly use `e.LHS.PositionRange().End` when the RHS is missing.

Fixes: ee7d5158a ("Add step(), min(a,b) and max(a,b) in promql duration expressions") 
Found by PostgresPro with the Svace static analyzer.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
