### PR TITLE
[ENHANCEMENT] AWS SD: Add optional external_id field

### DIFF
--- a/discovery/aws/aws.go
+++ b/discovery/aws/aws.go
@@ -77,6 +77,7 @@ type SDConfig struct {
 	SecretKey        config.Secret           `yaml:"secret_key,omitempty"`
 	Profile          string                  `yaml:"profile,omitempty"`
 	RoleARN          string                  `yaml:"role_arn,omitempty"`
+	ExternalID       string                  `yaml:"external_id,omitempty"`
 	RefreshInterval  model.Duration          `yaml:"refresh_interval,omitempty"`
 	Port             int                     `yaml:"port,omitempty"`
 	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
@@ -136,6 +137,9 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		if c.RoleARN != "" {
 			c.EC2SDConfig.RoleARN = c.RoleARN
 		}
+		if c.ExternalID != "" {
+			c.EC2SDConfig.ExternalID = c.ExternalID
+		}
 		if c.Port != 0 {
 			c.EC2SDConfig.Port = c.Port
 		}
@@ -166,6 +170,9 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		if c.RoleARN != "" {
 			c.ECSSDConfig.RoleARN = c.RoleARN
+		}
+		if c.ExternalID != "" {
+			c.ECSSDConfig.ExternalID = c.ExternalID
 		}
 		if c.Port != 0 {
 			c.ECSSDConfig.Port = c.Port
@@ -198,6 +205,9 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		if c.RoleARN != "" {
 			c.ElasticacheSDConfig.RoleARN = c.RoleARN
 		}
+		if c.ExternalID != "" {
+			c.ElasticacheSDConfig.ExternalID = c.ExternalID
+		}
 		if c.Port != 0 {
 			c.ElasticacheSDConfig.Port = c.Port
 		}
@@ -229,6 +239,9 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		if c.RoleARN != "" {
 			c.LightsailSDConfig.RoleARN = c.RoleARN
 		}
+		if c.ExternalID != "" {
+			c.LightsailSDConfig.ExternalID = c.ExternalID
+		}
 		if c.Port != 0 {
 			c.LightsailSDConfig.Port = c.Port
 		}
@@ -256,6 +269,9 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		if c.RoleARN != "" {
 			c.MSKSDConfig.RoleARN = c.RoleARN
+		}
+		if c.ExternalID != "" {
+			c.MSKSDConfig.ExternalID = c.ExternalID
 		}
 		if c.Port != 0 {
 			c.MSKSDConfig.Port = c.Port
@@ -287,6 +303,9 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		if c.RoleARN != "" {
 			c.RDSSDConfig.RoleARN = c.RoleARN
+		}
+		if c.ExternalID != "" {
+			c.RDSSDConfig.ExternalID = c.ExternalID
 		}
 		if c.Port != 0 {
 			c.RDSSDConfig.Port = c.Port

--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -99,6 +99,7 @@ type ECSSDConfig struct {
 	SecretKey       config.Secret  `yaml:"secret_key,omitempty"`
 	Profile         string         `yaml:"profile,omitempty"`
 	RoleARN         string         `yaml:"role_arn,omitempty"`
+	ExternalID      string         `yaml:"external_id,omitempty"`
 	Clusters        []string       `yaml:"clusters,omitempty"`
 	Port            int            `yaml:"port"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
@@ -241,7 +242,11 @@ func (d *ECSDiscovery) initEcsClient(ctx context.Context) error {
 
 	// If the role ARN is set, assume the role to get credentials and set the credentials provider in the config.
 	if d.cfg.RoleARN != "" {
-		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN)
+		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN, func(o *stscreds.AssumeRoleOptions) {
+			if d.cfg.ExternalID != "" {
+				o.ExternalID = aws.String(d.cfg.ExternalID)
+			}
+		})
 		cfg.Credentials = aws.NewCredentialsCache(assumeProvider)
 	}
 

--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -192,6 +192,7 @@ type ElasticacheSDConfig struct {
 	SecretKey       config.Secret  `yaml:"secret_key,omitempty"`
 	Profile         string         `yaml:"profile,omitempty"`
 	RoleARN         string         `yaml:"role_arn,omitempty"`
+	ExternalID      string         `yaml:"external_id,omitempty"`
 	Clusters        []string       `yaml:"clusters,omitempty"`
 	Port            int            `yaml:"port"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
@@ -319,7 +320,11 @@ func (d *ElasticacheDiscovery) initElasticacheClient(ctx context.Context) error 
 
 	// If the role ARN is set, assume the role to get credentials and set the credentials provider in the config.
 	if d.cfg.RoleARN != "" {
-		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN)
+		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN, func(o *stscreds.AssumeRoleOptions) {
+			if d.cfg.ExternalID != "" {
+				o.ExternalID = aws.String(d.cfg.ExternalID)
+			}
+		})
 		cfg.Credentials = aws.NewCredentialsCache(assumeProvider)
 	}
 

--- a/discovery/aws/msk.go
+++ b/discovery/aws/msk.go
@@ -106,6 +106,7 @@ type MSKSDConfig struct {
 	SecretKey       config.Secret  `yaml:"secret_key,omitempty"`
 	Profile         string         `yaml:"profile,omitempty"`
 	RoleARN         string         `yaml:"role_arn,omitempty"`
+	ExternalID      string         `yaml:"external_id,omitempty"`
 	Clusters        []string       `yaml:"clusters,omitempty"`
 	Port            int            `yaml:"port"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
@@ -231,7 +232,11 @@ func (d *MSKDiscovery) initMskClient(ctx context.Context) error {
 
 	// If the role ARN is set, assume the role to get credentials and set the credentials provider in the config.
 	if d.cfg.RoleARN != "" {
-		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN)
+		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN, func(o *stscreds.AssumeRoleOptions) {
+			if d.cfg.ExternalID != "" {
+				o.ExternalID = aws.String(d.cfg.ExternalID)
+			}
+		})
 		cfg.Credentials = aws.NewCredentialsCache(assumeProvider)
 	}
 

--- a/discovery/aws/rds.go
+++ b/discovery/aws/rds.go
@@ -225,6 +225,7 @@ type RDSSDConfig struct {
 	SecretKey       config.Secret  `yaml:"secret_key,omitempty"`
 	Profile         string         `yaml:"profile,omitempty"`
 	RoleARN         string         `yaml:"role_arn,omitempty"`
+	ExternalID      string         `yaml:"external_id,omitempty"`
 	Clusters        []string       `yaml:"clusters,omitempty"`
 	Port            int            `yaml:"port"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
@@ -349,7 +350,11 @@ func (d *RDSDiscovery) initRdsClient(ctx context.Context) error {
 
 	// If the role ARN is set, assume the role to get credentials and set the credentials provider in the config.
 	if d.cfg.RoleARN != "" {
-		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN)
+		assumeProvider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), d.cfg.RoleARN, func(o *stscreds.AssumeRoleOptions) {
+			if d.cfg.ExternalID != "" {
+				o.ExternalID = aws.String(d.cfg.ExternalID)
+			}
+		})
 		cfg.Credentials = aws.NewCredentialsCache(assumeProvider)
 	}
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1330,6 +1330,9 @@ role: <string>
 # AWS Role ARN, an alternative to using AWS API keys.
 [ role_arn: <string> ]
 
+# Optional External ID that can go along with role_arn.
+[ external_id: <string> ]
+
 # Refresh interval to re-read the targets list.
 [ refresh_interval: <duration> | default = 60s ]
 


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
AWS recommends that roles use an external ID to avoid accidentally granting access to the wrong account. 

On the back of https://github.com/prometheus/prometheus/pull/17171 this adds the external id to ECS/MSK/RDS/Elasticache.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes https://github.com/prometheus/prometheus/issues/16314

#### Release notes for end users (**ALL** commits must be considered).

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[ENHANCEMENT] AWS Service Discovery: Add optional `external_id` field to ECS/MSK/RDS/Elasticache.
```
