### PR TITLE
deps: consolidate go-yaml v2 to v3

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -44,7 +44,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
@@ -832,7 +832,9 @@ func checkSDFile(filename string) ([]*targetgroup.Group, error) {
 			return nil, err
 		}
 	case ".yml", ".yaml":
-		if err := yaml.UnmarshalStrict(content, &targetGroups); err != nil {
+		dec := yaml.NewDecoder(bytes.NewReader(content))
+		dec.KnownFields(true)
+		if err := dec.Decode(&targetGroups); err != nil {
 			return nil, err
 		}
 	default:

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -33,7 +34,7 @@ import (
 	"github.com/nsf/jsondiff"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -91,7 +92,9 @@ func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, p parser
 	}
 
 	var unitTestInp unitTestFile
-	if err := yaml.UnmarshalStrict(b, &unitTestInp); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(b))
+	dec.KnownFields(true)
+	if err := dec.Decode(&unitTestInp); err != nil {
 		ts.Abort(err)
 		return []error{err}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -14,8 +14,10 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"mime"
 	"net/url"
@@ -34,7 +36,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/otlptranslator"
 	"github.com/prometheus/sigv4"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/model/labels"
@@ -78,8 +80,9 @@ func Load(s string, logger *slog.Logger) (*Config, error) {
 	// point as well.
 	*cfg = DefaultConfig
 
-	err := yaml.UnmarshalStrict([]byte(s), cfg)
-	if err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader([]byte(s)))
+	dec.KnownFields(true)
+	if err := dec.Decode(cfg); err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 
@@ -369,8 +372,9 @@ func (c *Config) GetScrapeConfigs() ([]*ScrapeConfig, error) {
 			if err != nil {
 				return nil, fileErr(filename, err)
 			}
-			err = yaml.UnmarshalStrict(content, &cfg)
-			if err != nil {
+			dec := yaml.NewDecoder(bytes.NewReader(content))
+			dec.KnownFields(true)
+			if err = dec.Decode(&cfg); err != nil {
 				return nil, fileErr(filename, err)
 			}
 			for _, scfg := range cfg.ScrapeConfigs {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2474,7 +2474,7 @@ var expectedErrors = []struct {
 	},
 	{
 		filename: "section_key_dup.bad.yml",
-		errMsg:   "field scrape_configs already set in type config.plain",
+		errMsg:   `mapping key "scrape_configs" already defined at line 1`,
 	},
 	{
 		filename: "azure_client_id_missing.bad.yml",
@@ -2614,7 +2614,7 @@ var expectedErrors = []struct {
 	},
 	{
 		filename: "empty_scrape_config_action.bad.yml",
-		errMsg:   "relabel action cannot be empty",
+		errMsg:   "relabel configuration for replace action requires 'target_label' value",
 	},
 	{
 		filename: "tracing_missing_endpoint.bad.yml",

--- a/config/reload.go
+++ b/config/reload.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 
 	promconfig "github.com/prometheus/common/config"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 type ExternalFilesConfig struct {

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -14,6 +14,7 @@
 package file
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -33,7 +34,7 @@ import (
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -398,7 +399,9 @@ func (d *Discovery) readFile(filename string) ([]*targetgroup.Group, error) {
 			return nil, err
 		}
 	case ".yml", ".yaml":
-		if err := yaml.UnmarshalStrict(content, &targetGroups); err != nil {
+		dec := yaml.NewDecoder(bytes.NewReader(content))
+		dec.KnownFields(true)
+		if err := dec.Decode(&targetGroups); err != nil {
 			return nil, err
 		}
 	default:

--- a/discovery/registry.go
+++ b/discovery/registry.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 )

--- a/notifier/alertmanagerset.go
+++ b/notifier/alertmanagerset.go
@@ -23,7 +23,7 @@ import (
 
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/sigv4"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"go.uber.org/atomic"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -25,7 +25,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"


### PR DESCRIPTION
## Summary

I consolidated the go-yaml library versions from 3 to 2 by migrating
all v2 usage to v3. The v4 dependency remains as it's required by libopenapi.

## Changes

- Replace `yaml.UnmarshalStrict` with `Decoder.KnownFields(true)`
- Handle `io.EOF` for empty documents (v3 behavior)
- Update test expectations for v3 error message format

## Test plan

- [x] `go test ./config/...` - passed
- [x] `go test ./cmd/promtool/...` - passed
- [x] `go test ./discovery/file/...` - passed
- [x] `go test ./notifier/...` - passed
- [x] `go test ./rules/...` - passed
- [x] `go test ./storage/remote/...` - passed

Fixes #18391

```release-notes
NONE
```