### PR TITLE
Fix(discovery/aws): Added SetDirectory method to AWS SD

### DIFF
--- a/discovery/aws/aws.go
+++ b/discovery/aws/aws.go
@@ -342,6 +342,36 @@ func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Di
 	}
 }
 
+// SetDirectory joins any relative file paths with dir.
+func (c *SDConfig) SetDirectory(dir string) {
+	switch c.Role {
+	case RoleEC2:
+		if c.EC2SDConfig != nil {
+			c.EC2SDConfig.SetDirectory(dir)
+		}
+	case RoleECS:
+		if c.ECSSDConfig != nil {
+			c.ECSSDConfig.SetDirectory(dir)
+		}
+	case RoleElasticache:
+		if c.ElasticacheSDConfig != nil {
+			c.ElasticacheSDConfig.SetDirectory(dir)
+		}
+	case RoleLightsail:
+		if c.LightsailSDConfig != nil {
+			c.LightsailSDConfig.SetDirectory(dir)
+		}
+	case RoleMSK:
+		if c.MSKSDConfig != nil {
+			c.MSKSDConfig.SetDirectory(dir)
+		}
+	case RoleRDS:
+		if c.RDSSDConfig != nil {
+			c.RDSSDConfig.SetDirectory(dir)
+		}
+	}
+}
+
 // loadRegion finds the region in order: AWS config/env vars ->IMDS.
 func loadRegion(ctx context.Context, specifiedRegion string) (string, error) {
 	if specifiedRegion != "" {

--- a/discovery/aws/aws_test.go
+++ b/discovery/aws/aws_test.go
@@ -487,3 +487,89 @@ region = ` + randomRegion + `
 		require.Contains(t, err.Error(), "failed to get region from IMDS")
 	})
 }
+
+func TestSDConfigSetDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	tests := []struct {
+		name string
+		yaml string
+		role Role
+	}{
+		{
+			name: "EC2",
+			yaml: `
+role: ec2
+region: us-east-1
+`,
+			role: RoleEC2,
+		},
+		{
+			name: "ECS",
+			yaml: `
+role: ecs
+region: us-west-2
+clusters: [test-cluster]
+`,
+			role: RoleECS,
+		},
+		{
+			name: "Elasticache",
+			yaml: `
+role: elasticache
+region: eu-west-1
+`,
+			role: RoleElasticache,
+		},
+		{
+			name: "Lightsail",
+			yaml: `
+role: lightsail
+region: ap-south-1
+`,
+			role: RoleLightsail,
+		},
+		{
+			name: "MSK",
+			yaml: `
+role: msk
+region: us-east-2
+`,
+			role: RoleMSK,
+		},
+		{
+			name: "RDS",
+			yaml: `
+role: rds
+region: us-west-1
+`,
+			role: RoleRDS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg SDConfig
+			err := yaml.Unmarshal([]byte(tt.yaml), &cfg)
+			require.NoError(t, err)
+			require.Equal(t, tt.role, cfg.Role)
+
+			// Call SetDirectory - should not panic
+			require.NotPanics(t, func() {
+				cfg.SetDirectory(tmpDir)
+			})
+		})
+	}
+
+	t.Run("SetDirectoryWithNilConfigs", func(t *testing.T) {
+		// Test that SetDirectory doesn't panic when called on an SDConfig
+		// where the role-specific config might be nil (this was the original bug)
+		cfg := SDConfig{
+			Role: RoleEC2,
+			// EC2SDConfig is nil - this would have caused a panic before the fix
+		}
+		// This should not panic
+		require.NotPanics(t, func() {
+			cfg.SetDirectory(tmpDir)
+		})
+	})
+}

--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -129,6 +129,11 @@ func (c *ECSSDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery
 	return NewECSDiscovery(c, opts)
 }
 
+// SetDirectory joins any relative file paths with dir.
+func (c *ECSSDConfig) SetDirectory(dir string) {
+	c.HTTPClientConfig.SetDirectory(dir)
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the ECS Config.
 func (c *ECSSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultECSSDConfig

--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -217,6 +217,11 @@ func (c *ElasticacheSDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (d
 	return NewElasticacheDiscovery(c, opts)
 }
 
+// SetDirectory joins any relative file paths with dir.
+func (c *ElasticacheSDConfig) SetDirectory(dir string) {
+	c.HTTPClientConfig.SetDirectory(dir)
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the Elasticache Config.
 func (c *ElasticacheSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultElasticacheSDConfig

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -97,6 +97,11 @@ func (c *LightsailSDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (dis
 	return NewLightsailDiscovery(c, opts)
 }
 
+// SetDirectory joins any relative file paths with dir.
+func (c *LightsailSDConfig) SetDirectory(dir string) {
+	c.HTTPClientConfig.SetDirectory(dir)
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the Lightsail Config.
 func (c *LightsailSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultLightsailSDConfig

--- a/discovery/aws/msk.go
+++ b/discovery/aws/msk.go
@@ -129,6 +129,11 @@ func (c *MSKSDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery
 	return NewMSKDiscovery(c, opts)
 }
 
+// SetDirectory joins any relative file paths with dir.
+func (c *MSKSDConfig) SetDirectory(dir string) {
+	c.HTTPClientConfig.SetDirectory(dir)
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the MSK Config.
 func (c *MSKSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultMSKSDConfig

--- a/discovery/aws/rds.go
+++ b/discovery/aws/rds.go
@@ -248,6 +248,11 @@ func (c *RDSSDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery
 	return NewRDSDiscovery(c, opts)
 }
 
+// SetDirectory joins any relative file paths with dir.
+func (c *RDSSDConfig) SetDirectory(dir string) {
+	c.HTTPClientConfig.SetDirectory(dir)
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the RDS Config.
 func (c *RDSSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultRDSSDConfig


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
https://github.com/prometheus/prometheus/pull/17685 introduced a `SetDirectory` method for the EC2 SD, but because this was only implemented for EC2, it broke the unified AWS Discovery Method as the it wasn't implemented for the other roles. This change adds this same method to the rest of the roles and adds the logic to the main AWS SD.
#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
