### PR TITLE
remote: validate snappy decoded length before allocation in write endpoint

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
 	deltatocumulative "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -58,7 +59,11 @@ type writeHandler struct {
 	ingestCTZeroSample bool
 }
 
-const maxAheadTime = 10 * time.Minute
+const (
+	maxAheadTime = 10 * time.Minute
+	// decodeWriteLimit is the maximum decoded size of a remote write request body in bytes.
+	decodeWriteLimit = 32 * 1024 * 1024
+)
 
 // NewWriteHandler creates a http.Handler that accepts remote write requests with
 // the given message in acceptedProtoMsgs and writes them to the provided appendable.
@@ -158,6 +163,19 @@ func (h *writeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Read the request body.
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		h.logger.Error("Error decoding remote write request", "err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	decodedLen, err := snappy.DecodedLen(body)
+	if err != nil {
+		h.logger.Error("Error decoding remote write request", "err", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if decodedLen > decodeWriteLimit {
+		err := fmt.Errorf("snappy: decoded length %d exceeds limit %d", decodedLen, decodeWriteLimit)
 		h.logger.Error("Error decoding remote write request", "err", err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -245,6 +245,22 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 	}
 }
 
+func TestRemoteWriteHandlerTooLarge(t *testing.T) {
+	// 5-byte snappy stream whose header claims 256 MiB decoded length,
+	// well above decodeWriteLimit (32 MiB).
+	bomb := []byte{0x80, 0x80, 0x80, 0x80, 0x01}
+	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(bomb))
+	require.NoError(t, err)
+
+	appendable := &mockAppendable{}
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []config.RemoteWriteProtoMsg{config.RemoteWriteProtoMsgV1}, false)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "exceeds limit")
+}
+
 func TestRemoteWriteHandler_V1Message(t *testing.T) {
 	payload, _, _, err := buildWriteRequest(nil, writeRequestFixture.Timeseries, nil, nil, nil, nil, "snappy")
 	require.NoError(t, err)


### PR DESCRIPTION

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[SECURITY] Remote-Write: Reject snappy-compressed requests whose declared decoded length exceeds the decode limit
```
