### PR TITLE
feat: add scrapes_failed extra scrape metric

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -17,11 +17,14 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"math"
+	"net"
 	"net/http"
 	"net/http/httptrace"
 	"reflect"
@@ -29,6 +32,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -131,7 +135,7 @@ type scrapeLoopAppendAdapter interface {
 	Commit() error
 	Rollback() error
 
-	addReportSample(s reportSample, t int64, v float64, b *labels.Builder, rejectOOO bool) error
+	addReportSample(s reportSample, t int64, v float64, b *labels.Builder, rejectOOO bool, extraLabels labels.Labels) error
 	append(b []byte, contentType string, ts time.Time) (total, added, seriesAdded int, err error)
 }
 
@@ -705,6 +709,15 @@ type targetScraper struct {
 
 var errBodySizeLimit = errors.New("body size limit exceeded")
 
+type httpStatusError struct {
+	StatusCode int
+	Status     string
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("server returned HTTP status %s", e.Status)
+}
+
 // acceptHeader transforms preference from the options into specific header values as
 // https://www.rfc-editor.org/rfc/rfc9110.html#name-accept defines.
 // No validation is here, we expect scrape protocols to be validated already.
@@ -761,7 +774,7 @@ func (s *targetScraper) readResponse(_ context.Context, resp *http.Response, w i
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("server returned HTTP status %s", resp.Status)
+		return "", &httpStatusError{StatusCode: resp.StatusCode, Status: resp.Status}
 	}
 
 	if s.bodySizeLimit <= 0 {
@@ -834,9 +847,10 @@ type scrapeLoop struct {
 	parentCtx context.Context
 	// appenderCtx is a parentCtx with some extra context for appender
 	// implementations. Potentially remove-able with removal of AppenderV1.
-	appenderCtx context.Context
-	l           *slog.Logger
-	cache       *scrapeCache
+	appenderCtx          context.Context
+	l                    *slog.Logger
+	cache                *scrapeCache
+	lastScrapeFailedArea string
 
 	interval            time.Duration
 	timeout             time.Duration
@@ -2101,6 +2115,14 @@ var (
 			Unit: "bytes",
 		},
 	}
+	scrapeFailedMetric = reportSample{
+		name: []byte("scrapes_failed" + "\xff"),
+		Metadata: metadata.Metadata{
+			Type: model.MetricTypeGauge,
+			Help: "The failure reason for the last scrape. The 'area' label indicates the failure reason.",
+			Unit: "",
+		},
+	}
 )
 
 func (sl *scrapeLoop) report(app scrapeLoopAppendAdapter, start time.Time, duration time.Duration, scraped, added, seriesAdded, bytes int, scrapeErr error) (err error) {
@@ -2114,31 +2136,47 @@ func (sl *scrapeLoop) report(app scrapeLoopAppendAdapter, start time.Time, durat
 	}
 	b := labels.NewBuilderWithSymbolTable(sl.symbolTable)
 
-	if err = app.addReportSample(scrapeHealthMetric, ts, health, b, false); err != nil {
+	if err = app.addReportSample(scrapeHealthMetric, ts, health, b, false, labels.EmptyLabels()); err != nil {
 		return err
 	}
-	if err = app.addReportSample(scrapeDurationMetric, ts, duration.Seconds(), b, false); err != nil {
+	if err = app.addReportSample(scrapeDurationMetric, ts, duration.Seconds(), b, false, labels.EmptyLabels()); err != nil {
 		return err
 	}
-	if err = app.addReportSample(scrapeSamplesMetric, ts, float64(scraped), b, false); err != nil {
+	if err = app.addReportSample(scrapeSamplesMetric, ts, float64(scraped), b, false, labels.EmptyLabels()); err != nil {
 		return err
 	}
-	if err = app.addReportSample(samplesPostRelabelMetric, ts, float64(added), b, false); err != nil {
+	if err = app.addReportSample(samplesPostRelabelMetric, ts, float64(added), b, false, labels.EmptyLabels()); err != nil {
 		return err
 	}
-	if err = app.addReportSample(scrapeSeriesAddedMetric, ts, float64(seriesAdded), b, false); err != nil {
+	if err = app.addReportSample(scrapeSeriesAddedMetric, ts, float64(seriesAdded), b, false, labels.EmptyLabels()); err != nil {
 		return err
 	}
 	if sl.reportExtraMetrics {
-		if err = app.addReportSample(scrapeTimeoutMetric, ts, sl.timeout.Seconds(), b, false); err != nil {
+		if err = app.addReportSample(scrapeTimeoutMetric, ts, sl.timeout.Seconds(), b, false, labels.EmptyLabels()); err != nil {
 			return err
 		}
-		if err = app.addReportSample(scrapeSampleLimitMetric, ts, float64(sl.sampleLimit), b, false); err != nil {
+		if err = app.addReportSample(scrapeSampleLimitMetric, ts, float64(sl.sampleLimit), b, false, labels.EmptyLabels()); err != nil {
 			return err
 		}
-		if err = app.addReportSample(scrapeBodySizeBytesMetric, ts, float64(bytes), b, false); err != nil {
+		if err = app.addReportSample(scrapeBodySizeBytesMetric, ts, float64(bytes), b, false, labels.EmptyLabels()); err != nil {
 			return err
 		}
+		var activeArea string
+		if scrapeErr != nil {
+			activeArea = classifyScrapeError(scrapeErr)
+			err = app.addReportSample(scrapeFailedMetric, ts, 1.0, b, false, labels.FromStrings("area", activeArea))
+			if err != nil {
+				return err
+			}
+		}
+
+		if sl.lastScrapeFailedArea != "" && sl.lastScrapeFailedArea != activeArea {
+			err = app.addReportSample(scrapeFailedMetric, ts, math.Float64frombits(value.StaleNaN), b, true, labels.FromStrings("area", sl.lastScrapeFailedArea))
+			if err != nil {
+				return err
+			}
+		}
+		sl.lastScrapeFailedArea = activeArea
 	}
 	return err
 }
@@ -2148,37 +2186,104 @@ func (sl *scrapeLoop) reportStale(app scrapeLoopAppendAdapter, start time.Time) 
 	stale := math.Float64frombits(value.StaleNaN)
 	b := labels.NewBuilder(labels.EmptyLabels())
 
-	if err = app.addReportSample(scrapeHealthMetric, ts, stale, b, true); err != nil {
+	if err = app.addReportSample(scrapeHealthMetric, ts, stale, b, true, labels.EmptyLabels()); err != nil {
 		return err
 	}
-	if err = app.addReportSample(scrapeDurationMetric, ts, stale, b, true); err != nil {
+	if err = app.addReportSample(scrapeDurationMetric, ts, stale, b, true, labels.EmptyLabels()); err != nil {
 		return err
 	}
-	if err = app.addReportSample(scrapeSamplesMetric, ts, stale, b, true); err != nil {
+	if err = app.addReportSample(scrapeSamplesMetric, ts, stale, b, true, labels.EmptyLabels()); err != nil {
 		return err
 	}
-	if err = app.addReportSample(samplesPostRelabelMetric, ts, stale, b, true); err != nil {
+	if err = app.addReportSample(samplesPostRelabelMetric, ts, stale, b, true, labels.EmptyLabels()); err != nil {
 		return err
 	}
-	if err = app.addReportSample(scrapeSeriesAddedMetric, ts, stale, b, true); err != nil {
+	if err = app.addReportSample(scrapeSeriesAddedMetric, ts, stale, b, true, labels.EmptyLabels()); err != nil {
 		return err
 	}
 	if sl.reportExtraMetrics {
-		if err = app.addReportSample(scrapeTimeoutMetric, ts, stale, b, true); err != nil {
+		if err = app.addReportSample(scrapeTimeoutMetric, ts, stale, b, true, labels.EmptyLabels()); err != nil {
 			return err
 		}
-		if err = app.addReportSample(scrapeSampleLimitMetric, ts, stale, b, true); err != nil {
+		if err = app.addReportSample(scrapeSampleLimitMetric, ts, stale, b, true, labels.EmptyLabels()); err != nil {
 			return err
 		}
-		if err = app.addReportSample(scrapeBodySizeBytesMetric, ts, stale, b, true); err != nil {
+		if err = app.addReportSample(scrapeBodySizeBytesMetric, ts, stale, b, true, labels.EmptyLabels()); err != nil {
 			return err
+		}
+		if sl.lastScrapeFailedArea != "" {
+			if err = app.addReportSample(scrapeFailedMetric, ts, stale, b, true, labels.FromStrings("area", sl.lastScrapeFailedArea)); err != nil {
+				return err
+			}
 		}
 	}
 	return err
 }
 
-func (sl *scrapeLoopAppender) addReportSample(s reportSample, t int64, v float64, b *labels.Builder, rejectOOO bool) (err error) {
-	ce, ok, _ := sl.cache.get(s.name)
+func classifyScrapeError(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, errBodySizeLimit) {
+		return "body_size_limit"
+	}
+	var httpErr *httpStatusError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode >= 400 && httpErr.StatusCode < 500 {
+			return "client_http_error"
+		}
+		if httpErr.StatusCode >= 500 {
+			return "server_http_error"
+		}
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return "dns_error"
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return "connection_refused"
+	}
+	var netOpErr *net.OpError
+	if errors.As(err, &netOpErr) {
+		return "network_error"
+	}
+	// Check for TLS errors.
+	var (
+		tlsAlertErr tls.AlertError
+		tlsRecErr   *tls.RecordHeaderError
+		tlsCertErr  *tls.CertificateVerificationError
+		x509CertErr x509.CertificateInvalidError
+		x509HostErr x509.HostnameError
+		x509AuthErr x509.UnknownAuthorityError
+		x509RootErr x509.SystemRootsError
+		x509ConsErr x509.ConstraintViolationError
+		x509AlgoErr x509.InsecureAlgorithmError
+	)
+	if errors.As(err, &tlsAlertErr) ||
+		errors.As(err, &tlsRecErr) ||
+		errors.As(err, &tlsCertErr) ||
+		errors.As(err, &x509CertErr) ||
+		errors.As(err, &x509HostErr) ||
+		errors.As(err, &x509AuthErr) ||
+		errors.As(err, &x509RootErr) ||
+		errors.As(err, &x509ConsErr) ||
+		errors.As(err, &x509AlgoErr) {
+		return "tls_error"
+	}
+
+	return "other"
+}
+
+func (sl *scrapeLoopAppender) addReportSample(s reportSample, t int64, v float64, b *labels.Builder, rejectOOO bool, extraLabels labels.Labels) (err error) {
+	var cacheKey []byte
+	if extraLabels.IsEmpty() {
+		cacheKey = s.name
+	} else {
+		// Combine name (without \xff) and extra labels, and append \xff to avoid collisions.
+		cacheKey = []byte(string(s.name[:len(s.name)-1]) + "_" + extraLabels.String() + "\xff")
+	}
+
+	ce, ok, _ := sl.cache.get(cacheKey)
 	var ref storage.SeriesRef
 	var lset labels.Labels
 	if ok {
@@ -2190,6 +2295,9 @@ func (sl *scrapeLoopAppender) addReportSample(s reportSample, t int64, v float64
 		// We have to drop it when building the actual metric.
 		b.Reset(labels.EmptyLabels())
 		b.Set(model.MetricNameLabel, string(s.name[:len(s.name)-1]))
+		extraLabels.Range(func(l labels.Label) {
+			b.Set(l.Name, l.Value)
+		})
 		lset = sl.reportSampleMutator(b.Labels())
 	}
 
@@ -2205,7 +2313,7 @@ func (sl *scrapeLoopAppender) addReportSample(s reportSample, t int64, v float64
 	switch {
 	case err == nil:
 		if !ok {
-			sl.cache.addRef(s.name, ref, lset, lset.Hash())
+			sl.cache.addRef(cacheKey, ref, lset, lset.Hash())
 			// We only need to add metadata once a scrape target appears.
 			if sl.appendMetadataToWAL {
 				if _, merr := sl.UpdateMetadata(ref, lset, s.Metadata); merr != nil {

--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -379,8 +379,16 @@ loop:
 	return total, added, seriesAdded, err
 }
 
-func (sl *scrapeLoopAppenderV2) addReportSample(s reportSample, t int64, v float64, b *labels.Builder, rejectOOO bool) (err error) {
-	ce, ok, _ := sl.cache.get(s.name)
+func (sl *scrapeLoopAppenderV2) addReportSample(s reportSample, t int64, v float64, b *labels.Builder, rejectOOO bool, extraLabels labels.Labels) (err error) {
+	var cacheKey []byte
+	if extraLabels.IsEmpty() {
+		cacheKey = s.name
+	} else {
+		// Combine name (without \xff) and extra labels, and append \xff to avoid collisions.
+		cacheKey = []byte(string(s.name[:len(s.name)-1]) + "_" + extraLabels.String() + "\xff")
+	}
+
+	ce, ok, _ := sl.cache.get(cacheKey)
 	var ref storage.SeriesRef
 	var lset labels.Labels
 	if ok {
@@ -392,6 +400,9 @@ func (sl *scrapeLoopAppenderV2) addReportSample(s reportSample, t int64, v float
 		// We have to drop it when building the actual metric.
 		b.Reset(labels.EmptyLabels())
 		b.Set(model.MetricNameLabel, string(s.name[:len(s.name)-1]))
+		extraLabels.Range(func(l labels.Label) {
+			b.Set(l.Name, l.Value)
+		})
 		lset = sl.reportSampleMutator(b.Labels())
 	}
 
@@ -403,7 +414,7 @@ func (sl *scrapeLoopAppenderV2) addReportSample(s reportSample, t int64, v float
 	switch {
 	case err == nil:
 		if !ok {
-			sl.cache.addRef(s.name, ref, lset, lset.Hash())
+			sl.cache.addRef(cacheKey, ref, lset, lset.Hash())
 		}
 		return nil
 	case errors.Is(err, storage.ErrOutOfOrderSample), errors.Is(err, storage.ErrDuplicateSampleForTimestamp):

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -17,6 +17,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -33,6 +35,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"testing/synctest"
 	"text/template"
@@ -1938,6 +1941,175 @@ func BenchmarkScrapeLoopScrapeAndReport(b *testing.B) {
 			}
 		})
 	}
+}
+
+func TestScrapeLoopFailedScrapes(t *testing.T) {
+	foreachAppendable(t, func(t *testing.T, appV2 bool) {
+		testScrapeLoopFailedScrapes(t, appV2)
+	})
+}
+
+func testScrapeLoopFailedScrapes(t *testing.T, appV2 bool) {
+	tests := []struct {
+		name         string
+		scrapeErr    error
+		expectedArea string
+	}{
+		{
+			name:         "timeout",
+			scrapeErr:    context.DeadlineExceeded,
+			expectedArea: "timeout",
+		},
+		{
+			name:         "body_size_limit",
+			scrapeErr:    errBodySizeLimit,
+			expectedArea: "body_size_limit",
+		},
+		{
+			name:         "client_http_error",
+			scrapeErr:    &httpStatusError{StatusCode: 404, Status: "Not Found"},
+			expectedArea: "client_http_error",
+		},
+		{
+			name:         "server_http_error",
+			scrapeErr:    &httpStatusError{StatusCode: 500, Status: "Internal Server Error"},
+			expectedArea: "server_http_error",
+		},
+		{
+			name:         "dns_error",
+			scrapeErr:    &net.DNSError{Err: "no such host"},
+			expectedArea: "dns_error",
+		},
+		{
+			name:         "connection_refused",
+			scrapeErr:    syscall.ECONNREFUSED,
+			expectedArea: "connection_refused",
+		},
+		{
+			name:         "network_error",
+			scrapeErr:    &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("generic network error")},
+			expectedArea: "network_error",
+		},
+		{
+			name:         "tls_error",
+			scrapeErr:    &tls.RecordHeaderError{Msg: "oversized record received"},
+			expectedArea: "tls_error",
+		},
+		{
+			name:         "tls_hostname_error",
+			scrapeErr:    x509.HostnameError{Host: "badhost"},
+			expectedArea: "tls_error",
+		},
+		{
+			name:         "network_other",
+			scrapeErr:    errors.New("some other network error"),
+			expectedArea: "other",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			appTest := teststorage.NewAppendable()
+			sl, scraper := newTestScrapeLoop(t, withAppendable(appTest, appV2), func(sl *scrapeLoop) {
+				sl.reportExtraMetrics = true
+			})
+			scraper.scrapeFunc = func(context.Context, io.Writer) error {
+				return tc.scrapeErr
+			}
+
+			sl.scrapeAndReport(time.Time{}, time.Now(), nil)
+
+			samples := appTest.ResultSamples()
+
+			var found bool
+			for _, s := range samples {
+				if s.L.Get("__name__") == "scrapes_failed" {
+					found = true
+					require.Equal(t, tc.expectedArea, s.L.Get("area"), "bad area label")
+					require.Equal(t, 1.0, s.V, "bad value")
+				}
+			}
+			require.True(t, found, "scrapes_failed metric not found")
+		})
+	}
+}
+
+func TestScrapeLoopFailedScrapesStaleness(t *testing.T) {
+	foreachAppendable(t, func(t *testing.T, appV2 bool) {
+		testScrapeLoopFailedScrapesStaleness(t, appV2)
+	})
+}
+
+func testScrapeLoopFailedScrapesStaleness(t *testing.T, appV2 bool) {
+	appTest := teststorage.NewAppendable()
+	sl, scraper := newTestScrapeLoop(t, withAppendable(appTest, appV2), func(sl *scrapeLoop) {
+		sl.reportExtraMetrics = true
+	})
+
+	// 1. First scrape fails.
+	scraper.scrapeFunc = func(context.Context, io.Writer) error {
+		return context.DeadlineExceeded
+	}
+
+	sl.scrapeAndReport(time.Time{}, time.Now(), nil)
+
+	samples := appTest.ResultSamples()
+	var found bool
+	for _, s := range samples {
+		if s.L.Get("__name__") == "scrapes_failed" && s.L.Get("area") == "timeout" {
+			found = true
+			require.Equal(t, 1.0, s.V, "bad value")
+		}
+	}
+	require.True(t, found, "scrapes_failed metric not found in first scrape")
+
+	// Reset results for the next scrape.
+	appTest.ResultReset()
+
+	// 2. Second scrape fails with a different error (connection_refused).
+	scraper.scrapeFunc = func(context.Context, io.Writer) error {
+		return syscall.ECONNREFUSED
+	}
+
+	sl.scrapeAndReport(time.Time{}, time.Now(), nil)
+
+	samples = appTest.ResultSamples()
+	found = false
+	var timeoutStale bool
+	for _, s := range samples {
+		if s.L.Get("__name__") == "scrapes_failed" {
+			if s.L.Get("area") == "connection_refused" {
+				found = true
+				require.Equal(t, 1.0, s.V, "bad value for connection_refused")
+			}
+			if s.L.Get("area") == "timeout" {
+				timeoutStale = true
+				require.True(t, value.IsStaleNaN(s.V), "Wanted: stale NaN for timeout Got: %x", math.Float64bits(s.V))
+			}
+		}
+	}
+	require.True(t, found, "scrapes_failed metric with area=connection_refused not found")
+	require.True(t, timeoutStale, "stale marker for timeout not found")
+
+	// Reset results for the next scrape.
+	appTest.ResultReset()
+
+	// 3. Third scrape succeeds.
+	scraper.scrapeFunc = func(context.Context, io.Writer) error {
+		return nil
+	}
+
+	sl.scrapeAndReport(time.Time{}, time.Now(), nil)
+
+	samples = appTest.ResultSamples()
+	found = false
+	for _, s := range samples {
+		if s.L.Get("__name__") == "scrapes_failed" && s.L.Get("area") == "connection_refused" {
+			found = true
+			require.True(t, value.IsStaleNaN(s.V), "Wanted: stale NaN for connection_refused Got: %x", math.Float64bits(s.V))
+		}
+	}
+	require.True(t, found, "stale marker for connection_refused not found")
 }
 
 func TestSetOptionsHandlingStaleness(t *testing.T) {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes: #18284

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[FEATURE] Add scrapes_failed metric, which provides more detail about why scrapes did not succeed. It is enabled by extra_scrape_metrics, and is only reported when up=0.
```
