### PR TITLE
promql: test alignment of subquery end timestamp to parent's step grid

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1922,6 +1922,40 @@ func (ev *evaluator) numSteps() int {
 	return int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
 }
 
+// subqueryTimeRange computes the start, end and step (all in milliseconds) of
+// the child evaluator used to evaluate subquery e within the context of the
+// parent evaluator ev.
+//
+// The parent end timestamp is aligned down to the parent's step grid before the
+// subquery offset is applied. A range query's outer loop only iterates up to
+// its last aligned step (start + N*interval), so when the caller supplies an
+// end timestamp that is not step-aligned the subquery must stop at that aligned
+// step too; otherwise it evaluates points the parent can never consume,
+// inflating PeakSamples and wasting work.
+func (ev *evaluator) subqueryTimeRange(e *parser.SubqueryExpr) (start, end, interval int64) {
+	offsetMillis := durationMilliseconds(e.Offset)
+	rangeMillis := durationMilliseconds(e.Range)
+
+	parentEnd := ev.endTimestamp
+	if ev.interval > 0 {
+		parentEnd = ev.startTimestamp + ((ev.endTimestamp-ev.startTimestamp)/ev.interval)*ev.interval
+	}
+	end = parentEnd - offsetMillis
+
+	if e.Step != 0 {
+		interval = durationMilliseconds(e.Step)
+	} else {
+		interval = ev.noStepSubqueryIntervalFn(rangeMillis)
+	}
+	// Start with the first timestamp after (ev.startTimestamp - offset - range)
+	// that is aligned with the step (multiple of 'interval').
+	start = interval * ((ev.startTimestamp - offsetMillis - rangeMillis) / interval)
+	if start <= (ev.startTimestamp - offsetMillis - rangeMillis) {
+		start += interval
+	}
+	return start, end, interval
+}
+
 // runSubquery evaluates the given SubqueryExpr in a fresh child evaluator
 // aligned to the subquery's own step grid and returns the result along with
 // the child's samples stats. The caller decides how to merge the child stats
@@ -1929,29 +1963,7 @@ func (ev *evaluator) numSteps() int {
 // TotalSamples should only be absorbed when the caller does not later
 // re-count the materialized matrix (e.g. evalSubquery does not absorb it).
 func (ev *evaluator) runSubquery(ctx context.Context, e *parser.SubqueryExpr) (parser.Value, *stats.QuerySamples, annotations.Annotations) {
-	offsetMillis := durationMilliseconds(e.Offset)
-	rangeMillis := durationMilliseconds(e.Range)
-
-	// Align the parent end timestamp down to the parent's step grid before
-	// applying the subquery offset, so the subquery does not evaluate past
-	// the parent's last actual evaluation point when the caller supplied
-	// an end timestamp that is not step-aligned.
-	parentEnd := ev.endTimestamp
-	if ev.interval > 0 {
-		parentEnd = ev.startTimestamp + ((ev.endTimestamp-ev.startTimestamp)/ev.interval)*ev.interval
-	}
-	subqEnd := parentEnd - offsetMillis
-
-	var subqInterval int64
-	if e.Step != 0 {
-		subqInterval = durationMilliseconds(e.Step)
-	} else {
-		subqInterval = ev.noStepSubqueryIntervalFn(rangeMillis)
-	}
-	subqStart := subqInterval * ((ev.startTimestamp - offsetMillis - rangeMillis) / subqInterval)
-	if subqStart <= (ev.startTimestamp - offsetMillis - rangeMillis) {
-		subqStart += subqInterval
-	}
+	subqStart, subqEnd, subqInterval := ev.subqueryTimeRange(e)
 
 	// Subquery children always track per-step samples-read (independent of
 	// the parent's per-step setting) so MergeSamplesReadFromSubquery can

--- a/promql/engine_internal_test.go
+++ b/promql/engine_internal_test.go
@@ -17,14 +17,17 @@ import (
 	"bytes"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/util/annotations"
+	"github.com/prometheus/prometheus/util/stats"
 )
 
 var testParser = parser.NewParser(parser.Options{})
@@ -80,6 +83,115 @@ func TestRecoverEvaluatorErrorWithWarnings(t *testing.T) {
 	defer ev.recover(nil, &ws, &err)
 
 	panic(e)
+}
+
+func TestSubqueryTimeRange(t *testing.T) {
+	// noStepInterval returns the interval the engine uses for a subquery without
+	// an explicit step ([range:]). This is the configured global evaluation
+	// interval (default 1 minute) and does not depend on the subquery range, so
+	// the argument is ignored, matching NoStepSubqueryIntervalFn in production.
+	const noStepEvalInterval = time.Minute
+	noStepInterval := func(int64) int64 { return durationMilliseconds(noStepEvalInterval) }
+
+	const second = 1000
+
+	for _, tc := range []struct {
+		name string
+		// Parent evaluator (the outer range/instant query) time range.
+		parentStart, parentEnd, parentInterval int64
+		query                                  string
+
+		wantStart, wantEnd, wantInterval int64
+	}{
+		{
+			// Instant query: a single evaluation step, no end alignment needed.
+			// Subquery steps span (1000s-60s, 1000s] on the 5s grid: 945s..1000s.
+			name:        "instant query",
+			parentStart: 1000 * second, parentEnd: 1000 * second, parentInterval: 0,
+			query:     "metric[60s:5s]",
+			wantStart: 945 * second, wantEnd: 1000 * second, wantInterval: 5 * second,
+		},
+		{
+			// Range query whose end is already on the 5s step grid
+			// (steps at 201s, 206s, 211s, 216s): subquery ends at the parent end.
+			name:        "range query, end already step-aligned",
+			parentStart: 201 * second, parentEnd: 216 * second, parentInterval: 5 * second,
+			query:     "metric[60s:5s]",
+			wantStart: 145 * second, wantEnd: 216 * second, wantInterval: 5 * second,
+		},
+		{
+			// Same query but end=220s is 4s past the last aligned step (216s).
+			// The subquery must still stop at 216s, matching the aligned case.
+			name:        "range query, end past last step is aligned down",
+			parentStart: 201 * second, parentEnd: 220 * second, parentInterval: 5 * second,
+			query:     "metric[60s:5s]",
+			wantStart: 145 * second, wantEnd: 216 * second, wantInterval: 5 * second,
+		},
+		{
+			// Offset shifts both the subquery start and end back by the offset.
+			name:        "range query with offset, end aligned down",
+			parentStart: 201 * second, parentEnd: 220 * second, parentInterval: 5 * second,
+			query:     "metric[60s:5s] offset 30s",
+			wantStart: 115 * second, wantEnd: 186 * second, wantInterval: 5 * second,
+		},
+		{
+			// Subquery without an explicit step uses noStepSubqueryIntervalFn,
+			// here the 60s default. First aligned start after 201s-100s=101s is
+			// 120s; end is aligned down to 216s as above.
+			name:        "range query, subquery without explicit step",
+			parentStart: 201 * second, parentEnd: 220 * second, parentInterval: 5 * second,
+			query:     "metric[100s:]",
+			wantStart: 120 * second, wantEnd: 216 * second, wantInterval: 60 * second,
+		},
+		{
+			// For a non-negative boundary the truncated-down multiple always
+			// lands on or below the boundary, so the +interval guard fires here
+			// (140s -> 145s) as in every case above. The only way to skip the
+			// guard is a negative boundary, exercised in the next case.
+			name:        "range query with offset, start bumped onto the grid",
+			parentStart: 201 * second, parentEnd: 216 * second, parentInterval: 5 * second,
+			query:     "metric[60s:5s] offset 1s",
+			wantStart: 145 * second, wantEnd: 215 * second, wantInterval: 5 * second,
+		},
+		{
+			// offset+range exceeds the parent start, so the boundary
+			// (30s-61s=-31s) is negative. Integer division truncates toward
+			// zero, yielding -30s, which is already strictly past -31s, so the
+			// +interval guard is NOT taken. Guards the negative-timestamp path.
+			name:        "instant query, negative boundary skips the start bump",
+			parentStart: 30 * second, parentEnd: 30 * second, parentInterval: 0,
+			query:     "metric[61s:5s]",
+			wantStart: -30 * second, wantEnd: 30 * second, wantInterval: 5 * second,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := testParser.ParseExpr(tc.query)
+			require.NoError(t, err)
+			// Mirror the engine's query setup: PreprocessExpr resolves
+			// duration expressions, then setOffsetForAtModifier resolves
+			// OriginalOffset into the Offset the evaluator uses.
+			step := time.Duration(tc.parentInterval) * time.Millisecond
+			expr, err = PreprocessExpr(expr, timestamp.Time(tc.parentStart), timestamp.Time(tc.parentEnd), step)
+			require.NoError(t, err)
+			setOffsetForAtModifier(tc.parentStart, expr)
+			sq, ok := expr.(*parser.SubqueryExpr)
+			require.True(t, ok, "query must parse to a subquery expression")
+
+			ev := &evaluator{
+				startTimestamp:           tc.parentStart,
+				endTimestamp:             tc.parentEnd,
+				interval:                 tc.parentInterval,
+				samplesStats:             stats.NewQuerySamples(false),
+				noStepSubqueryIntervalFn: noStepInterval,
+			}
+
+			start, end, interval := ev.subqueryTimeRange(sq)
+
+			require.Equal(t, tc.wantStart, start, "subquery start timestamp")
+			require.Equal(t, tc.wantEnd, end, "subquery end timestamp")
+			require.Equal(t, tc.wantInterval, interval, "subquery interval")
+		})
+	}
 }
 
 func TestVectorElemBinop_Histograms(t *testing.T) {

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1413,9 +1413,35 @@ load 10s
 			},
 		},
 		{
+			// Aligned counterpart of the unaligned case below: end=216 is the
+			// last actual evaluation step when start=201, step=5. Both cases
+			// should yield identical sample stats; subqueries inside an
+			// unaligned range query must not evaluate past the parent's last
+			// aligned step.
 			Query:        "max_over_time(metricWith3SampleEvery10Seconds[60s:5s])",
 			Start:        time.Unix(201, 0),
-			End:          time.Unix(220, 0),
+			End:          time.Unix(216, 0),
+			Interval:     5 * time.Second,
+			PeakSamples:  69,
+			TotalSamples: 144,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 36,
+				206000: 36,
+				211000: 36,
+				216000: 36,
+			},
+			SamplesRead: 45,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 36,
+				206000: 3,
+				211000: 3,
+				216000: 3,
+			},
+		},
+		{
+			Query:        "max_over_time(metricWith3SampleEvery10Seconds[60s:5s])",
+			Start:        time.Unix(201, 0),
+			End:          time.Unix(220, 0), // 4s past the last aligned step (216).
 			Interval:     5 * time.Second,
 			PeakSamples:  69,
 			TotalSamples: 144, // 3 sample per query * 12 queries (60/5) * 4 steps
@@ -1497,9 +1523,34 @@ load 10s
 			},
 		},
 		{
+			// Aligned counterpart of the unaligned case below (composite
+			// expression with two sibling subqueries). end=216 is the last
+			// aligned step when start=201, step=5. Both cases should yield
+			// identical sample stats.
 			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[60s:5s])) + sum(max_over_time(metricWith1SampleEvery10Seconds[60s:5s]))",
 			Start:        time.Unix(201, 0),
-			End:          time.Unix(220, 0),
+			End:          time.Unix(216, 0),
+			Interval:     5 * time.Second,
+			PeakSamples:  69,
+			TotalSamples: 192,
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 48,
+				206000: 48,
+				211000: 48,
+				216000: 48,
+			},
+			SamplesRead: 60,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 48,
+				206000: 4,
+				211000: 4,
+				216000: 4,
+			},
+		},
+		{
+			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[60s:5s])) + sum(max_over_time(metricWith1SampleEvery10Seconds[60s:5s]))",
+			Start:        time.Unix(201, 0),
+			End:          time.Unix(220, 0), // 4s past the last aligned step (216).
 			Interval:     5 * time.Second,
 			PeakSamples:  69,
 			TotalSamples: 192, // (1 sample per query * 12 queries (60/5) + 3 sample per query * 12 queries (60/5)) * 4 steps


### PR DESCRIPTION
This PR has been rebased and updated to reflect the fact that #18081 landed first and included the subquery alignment fix referred to below. It is now a small refactor and additional tests that verify the correct alignment behavior.

```release-notes
[CHANGE] PromQL: A range query whose `end` was not aligned to `step` caused subqueries inside it to evaluate past the parent's last actual step, inflating `peakSamples` in the query stats and against the `query.max-samples` limit, and wasting storage I/O reading samples that were never used in the result. Add tests to prevent regression of the fix made in #18081
```

### OLD DESCRIPTION BELOW

When a range query's end timestamp is not aligned to the step grid (i.e. `end != start + N*step`), the parent evaluator's outer loop only iterates up to the last aligned step, but a subquery inside the query was being given `newEv.endTimestamp = ev.endTimestamp - offset`. The inner subquery evaluator therefore iterated past the parent's last actual step, producing a larger intermediate matrix than the parent could ever consume.

The extra subquery samples are silently ignored by the outer call/range loop, so query results are unchanged, but they:

- Inflate `peakSamples`, which is reported in the stats response **and** is checked against the `query.max-samples` limit (so a query may now hit the limit only because of the unaligned tail).
- Waste storage I/O reading the underlying samples.

This change aligns the parent end timestamp down to the step grid before applying the subquery offset, so the subquery stops at the parent's last actual evaluation point.

#### Release notes for end users (**ALL** commits must be considered).

```
[BUGFIX] PromQL: A range query whose `end` was not aligned to `step` caused subqueries inside it to evaluate past the parent's last actual step, inflating `peakSamples` in the query stats and against the `query.max-samples` limit, and wasting storage I/O reading samples that were never used in the result.
```

#### Tests

Updates five existing `TestQueryStatistics` cases (`start=201, end=220, step=5` -- last aligned step at 216) whose `PeakSamples` expectations were locking in the inflated values. Adds aligned counterparts (`end=216`) for two of them (one single-subquery, one composite expression) so the equivalence between aligned and unaligned variants is documented in the test data.