### PR TITLE
discovery/consul: run tests in parallel

### DIFF
--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -49,6 +49,7 @@ func NewTestMetrics(t *testing.T, conf discovery.Config, reg prometheus.Register
 }
 
 func TestConfiguredService(t *testing.T) {
+	t.Parallel()
 	conf := &SDConfig{
 		Services: []string{"configuredServiceName"},
 	}
@@ -64,6 +65,7 @@ func TestConfiguredService(t *testing.T) {
 }
 
 func TestConfiguredServiceWithTag(t *testing.T) {
+	t.Parallel()
 	conf := &SDConfig{
 		Services:    []string{"configuredServiceName"},
 		ServiceTags: []string{"http"},
@@ -87,6 +89,7 @@ func TestConfiguredServiceWithTag(t *testing.T) {
 }
 
 func TestConfiguredServiceWithTags(t *testing.T) {
+	t.Parallel()
 	type testcase struct {
 		// What we've configured to watch.
 		conf *SDConfig
@@ -174,6 +177,7 @@ func TestConfiguredServiceWithTags(t *testing.T) {
 }
 
 func TestNonConfiguredService(t *testing.T) {
+	t.Parallel()
 	conf := &SDConfig{}
 
 	metrics := NewTestMetrics(t, conf, prometheus.NewRegistry())
@@ -294,6 +298,7 @@ func checkOneTarget(t *testing.T, tg []*targetgroup.Group) {
 
 // Watch all the services in the catalog.
 func TestAllServices(t *testing.T) {
+	t.Parallel()
 	stub, config := newServer(t)
 	t.Cleanup(stub.Close)
 
@@ -313,6 +318,7 @@ func TestAllServices(t *testing.T) {
 
 // targetgroup with no targets is emitted if no services were discovered.
 func TestNoTargets(t *testing.T) {
+	t.Parallel()
 	stub, config := newServer(t)
 	t.Cleanup(stub.Close)
 	config.ServiceTags = []string{"missing"}
@@ -334,6 +340,7 @@ func TestNoTargets(t *testing.T) {
 
 // Watch only the test service.
 func TestOneService(t *testing.T) {
+	t.Parallel()
 	stub, config := newServer(t)
 	t.Cleanup(stub.Close)
 
@@ -349,6 +356,7 @@ func TestOneService(t *testing.T) {
 
 // Watch the test service with a specific tag and node-meta.
 func TestAllOptions(t *testing.T) {
+	t.Parallel()
 	stub, config := newServer(t)
 	t.Cleanup(stub.Close)
 
@@ -374,6 +382,7 @@ func TestAllOptions(t *testing.T) {
 // TestFilterOption verifies that when services and filter are both configured, the Catalog API
 // is still called and receives the filter parameter, while the Health API does not.
 func TestFilterOption(t *testing.T) {
+	t.Parallel()
 	var (
 		catalogCalled bool
 		catalogFilter string
@@ -432,6 +441,7 @@ func TestFilterOption(t *testing.T) {
 // TestHealthFilterOption verifies that health_filter is passed to the Health API and not to
 // the Catalog API.
 func TestHealthFilterOption(t *testing.T) {
+	t.Parallel()
 	var (
 		catalogCalled bool
 		catalogFilter string
@@ -491,6 +501,7 @@ func TestHealthFilterOption(t *testing.T) {
 // TestBothFiltersOption verifies that when both filter and health_filter are configured,
 // each filter is sent exclusively to its respective API endpoint.
 func TestBothFiltersOption(t *testing.T) {
+	t.Parallel()
 	var (
 		catalogCalled bool
 		catalogFilter string
@@ -548,6 +559,7 @@ func TestBothFiltersOption(t *testing.T) {
 }
 
 func TestGetDatacenterShouldReturnError(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		handler    func(http.ResponseWriter, *http.Request)
 		errMessage string
@@ -592,6 +604,7 @@ func TestGetDatacenterShouldReturnError(t *testing.T) {
 }
 
 func TestUnmarshalConfig(t *testing.T) {
+	t.Parallel()
 	unmarshal := func(d []byte) func(any) error {
 		return func(o any) error {
 			return yaml.Unmarshal(d, o)
@@ -663,6 +676,7 @@ oauth2:
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			var config SDConfig
 			err := config.UnmarshalYAML(unmarshal([]byte(test.config)))
 			if err != nil {


### PR DESCRIPTION
Refs #15185

All 13 top-level test functions in `discovery/consul/consul_test.go` create
their own `httptest.Server` and `prometheus.Registry`, so there is no shared
global state between them. Adding `t.Parallel()` to each top-level test and
to the four subtests inside `TestUnmarshalConfig` allows the Go test runner
to overlap them.

No existing PR covers this package (confirmed with `gh pr list --search "discovery/consul"`).

**Testing:** `go test -race -count=1 ./discovery/consul/...` — pass.

```release-notes
NONE
```