### PR TITLE
promql: fix empty results when @ subquery is matrix arg with step-varying scalars (#18610)

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -4431,9 +4431,14 @@ func preprocessExprHelper(expr parser.Expr, start, end time.Time) (isStepInvaria
 		}
 
 		for i, isi := range shouldWrap {
-			if isi {
-				n.Args[i] = newStepInvariantExpr(n.Args[i])
+			if !isi {
+				continue
 			}
+			
+			if _, ok := n.Args[i].(*parser.SubqueryExpr); ok {
+				continue
+			}
+			n.Args[i] = newStepInvariantExpr(n.Args[i])
 		}
 		return false, false
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -4434,7 +4434,7 @@ func preprocessExprHelper(expr parser.Expr, start, end time.Time) (isStepInvaria
 			if !isi {
 				continue
 			}
-			
+
 			if _, ok := n.Args[i].(*parser.SubqueryExpr); ok {
 				continue
 			}

--- a/promql/promqltest/testdata/at_modifier.test
+++ b/promql/promqltest/testdata/at_modifier.test
@@ -308,3 +308,16 @@ eval range from 0 to 60s step 10s timestamp(abs(metric_missing @ 11))
  {} 0 10 20 30 40 50 60
 
 clear
+
+# Step-invariant subquery as matrix argument of a non-step-invariant call (#18610).
+load 30s
+  arg 0 0.5 1 0.75
+  metric 1 2 3 4 5
+
+eval range from 0 to 1m30s step 30s quantile_over_time(scalar(arg), metric[2m1s:30s] @ 2m)
+  {} 1 3 5 4
+
+eval instant at 0 quantile_over_time(scalar(arg), metric[2m1s:30s] @ 2m)
+  {} 1
+
+clear


### PR DESCRIPTION

#### Which issue(s) does the PR fix:

Fixes #18610

**Cause:**

When a step-invariant subquery (for example metric[2m1s:30s] @ 2m) was passed as the matrix argument to a function whose other arguments were not step-invariant (for example quantile_over_time(scalar(arg), ...)), preprocessExprHelper wrapped the subquery in StepInvariantExpr. 

The Call evaluator only recognizes MatrixSelector and SubqueryExpr for matrix arguments, so it never found the matrix argument and returned an empty result.

**Fix:**

Skip wrapping *parser.SubqueryExpr arguments in StepInvariantExpr in the *parser.Call branch of preprocessExprHelper. Subqueries with @ already use offset adjustment and the matrix iteration path that reuses the evaluated window when VectorSelector.Timestamp is set.

Add regression tests from the issue report to at_modifier.test.

```release-notes
[BUGFIX] PromQL: Fix empty results when a step-invariant subquery with `@` is used as the matrix argument of a call that is not step-invariant (for example `quantile_over_time(scalar(x), metric[...:...] @ T)`).
```
