### PR TITLE
discovery/marathon: run tests in parallel

### DIFF
--- a/discovery/marathon/marathon_test.go
+++ b/discovery/marathon/marathon_test.go
@@ -66,6 +66,7 @@ func testUpdateServices(client appListClient) ([]*targetgroup.Group, error) {
 }
 
 func TestMarathonSDHandleError(t *testing.T) {
+	t.Parallel()
 	var (
 		errTesting = errors.New("testing failure")
 		client     = func(context.Context, *http.Client, string) (*appList, error) {
@@ -78,6 +79,7 @@ func TestMarathonSDHandleError(t *testing.T) {
 }
 
 func TestMarathonSDEmptyList(t *testing.T) {
+	t.Parallel()
 	client := func(context.Context, *http.Client, string) (*appList, error) { return &appList{}, nil }
 	tgs, err := testUpdateServices(client)
 	require.NoError(t, err)
@@ -111,6 +113,7 @@ func marathonTestAppList(labels map[string]string, runningTasks int) *appList {
 }
 
 func TestMarathonSDSendGroup(t *testing.T) {
+	t.Parallel()
 	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppList(marathonValidLabel, 1), nil
 	}
@@ -128,6 +131,7 @@ func TestMarathonSDSendGroup(t *testing.T) {
 }
 
 func TestMarathonSDRemoveApp(t *testing.T) {
+	t.Parallel()
 	cfg := testConfig()
 	reg := prometheus.NewRegistry()
 	refreshMetrics := discovery.NewRefreshMetrics(reg)
@@ -192,6 +196,7 @@ func marathonTestAppListWithMultiplePorts(labels map[string]string, runningTasks
 }
 
 func TestMarathonSDSendGroupWithMultiplePort(t *testing.T) {
+	t.Parallel()
 	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithMultiplePorts(marathonValidLabel, 1), nil
 	}
@@ -237,6 +242,7 @@ func marathonTestZeroTaskPortAppList(labels map[string]string, runningTasks int)
 }
 
 func TestMarathonZeroTaskPorts(t *testing.T) {
+	t.Parallel()
 	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestZeroTaskPortAppList(marathonValidLabel, 1), nil
 	}
@@ -250,6 +256,7 @@ func TestMarathonZeroTaskPorts(t *testing.T) {
 }
 
 func Test500ErrorHttpResponseWithValidJSONBody(t *testing.T) {
+	t.Parallel()
 	// Simulate 500 error with a valid JSON response.
 	respHandler := func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -295,6 +302,7 @@ func marathonTestAppListWithPortDefinitions(labels map[string]string, runningTas
 }
 
 func TestMarathonSDSendGroupWithPortDefinitions(t *testing.T) {
+	t.Parallel()
 	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithPortDefinitions(marathonValidLabel, 1), nil
 	}
@@ -349,6 +357,7 @@ func marathonTestAppListWithPortDefinitionsRequirePorts(labels map[string]string
 }
 
 func TestMarathonSDSendGroupWithPortDefinitionsRequirePorts(t *testing.T) {
+	t.Parallel()
 	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithPortDefinitionsRequirePorts(marathonValidLabel, 1), nil
 	}
@@ -396,6 +405,7 @@ func marathonTestAppListWithPorts(labels map[string]string, runningTasks int) *a
 }
 
 func TestMarathonSDSendGroupWithPorts(t *testing.T) {
+	t.Parallel()
 	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithPorts(marathonValidLabel, 1), nil
 	}
@@ -452,6 +462,7 @@ func marathonTestAppListWithContainerPortMappings(labels map[string]string, runn
 }
 
 func TestMarathonSDSendGroupWithContainerPortMappings(t *testing.T) {
+	t.Parallel()
 	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithContainerPortMappings(marathonValidLabel, 1), nil
 	}
@@ -508,6 +519,7 @@ func marathonTestAppListWithDockerContainerPortMappings(labels map[string]string
 }
 
 func TestMarathonSDSendGroupWithDockerContainerPortMappings(t *testing.T) {
+	t.Parallel()
 	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithDockerContainerPortMappings(marathonValidLabel, 1), nil
 	}
@@ -568,6 +580,7 @@ func marathonTestAppListWithContainerNetworkAndPortMappings(labels map[string]st
 }
 
 func TestMarathonSDSendGroupWithContainerNetworkAndPortMapping(t *testing.T) {
+	t.Parallel()
 	client := func(context.Context, *http.Client, string) (*appList, error) {
 		return marathonTestAppListWithContainerNetworkAndPortMappings(marathonValidLabel, 1), nil
 	}


### PR DESCRIPTION
Add `t.Parallel()` to the 13 top-level test functions in
`discovery/marathon/marathon_test.go`.

Each test creates its own registry, metrics, and `SDConfig` — there is
no shared mutable state — so parallelisation is safe. This follows the
same pattern already applied to other discovery packages (e.g. azure,
consul, eureka) and matches the ask in #15185.

Refs #15185

```release-notes
NONE
```