### PR TITLE
testutil: fix port-bind flake in subprocess tests

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -138,7 +138,8 @@ func TestFailedStartupExitCode(t *testing.T) {
 	fakeInputFile := "fake-input-file"
 	expectedExitStatus := 2
 
-	prom := exec.Command(promPath, "-test.main", "--web.listen-address=0.0.0.0:0", "--config.file="+fakeInputFile)
+	port := testutil.RandomUnprivilegedPort(t)
+	prom := exec.Command(promPath, "-test.main", fmt.Sprintf("--web.listen-address=0.0.0.0:%d", port), "--config.file="+fakeInputFile)
 	err := prom.Run()
 	require.Error(t, err)
 
@@ -248,7 +249,8 @@ func TestWALSegmentSizeBounds(t *testing.T) {
 	} {
 		t.Run(tc.size, func(t *testing.T) {
 			t.Parallel()
-			prom := exec.Command(promPath, "-test.main", "--storage.tsdb.wal-segment-size="+tc.size, "--web.listen-address=0.0.0.0:0", "--config.file="+promConfig, "--storage.tsdb.path="+filepath.Join(t.TempDir(), "data"))
+			port := testutil.RandomUnprivilegedPort(t)
+			prom := exec.Command(promPath, "-test.main", "--storage.tsdb.wal-segment-size="+tc.size, fmt.Sprintf("--web.listen-address=0.0.0.0:%d", port), "--config.file="+promConfig, "--storage.tsdb.path="+filepath.Join(t.TempDir(), "data"))
 
 			// Log stderr in case of failure.
 			stderr, err := prom.StderrPipe()
@@ -312,7 +314,8 @@ func TestMaxBlockChunkSegmentSizeBounds(t *testing.T) {
 	} {
 		t.Run(tc.size, func(t *testing.T) {
 			t.Parallel()
-			prom := exec.Command(promPath, "-test.main", "--storage.tsdb.max-block-chunk-segment-size="+tc.size, "--web.listen-address=0.0.0.0:0", "--config.file="+promConfig, "--storage.tsdb.path="+filepath.Join(t.TempDir(), "data"))
+			port := testutil.RandomUnprivilegedPort(t)
+			prom := exec.Command(promPath, "-test.main", "--storage.tsdb.max-block-chunk-segment-size="+tc.size, fmt.Sprintf("--web.listen-address=0.0.0.0:%d", port), "--config.file="+promConfig, "--storage.tsdb.path="+filepath.Join(t.TempDir(), "data"))
 
 			// Log stderr in case of failure.
 			stderr, err := prom.StderrPipe()
@@ -420,7 +423,8 @@ func getCurrentGaugeValuesFor(t *testing.T, reg prometheus.Gatherer, metricNames
 func TestAgentSuccessfulStartup(t *testing.T) {
 	t.Parallel()
 
-	prom := exec.Command(promPath, "-test.main", "--agent", "--web.listen-address=0.0.0.0:0", "--config.file="+agentConfig)
+	port := testutil.RandomUnprivilegedPort(t)
+	prom := exec.Command(promPath, "-test.main", "--agent", fmt.Sprintf("--web.listen-address=0.0.0.0:%d", port), "--config.file="+agentConfig)
 	require.NoError(t, prom.Start())
 
 	actualExitStatus := 0
@@ -440,7 +444,8 @@ func TestAgentSuccessfulStartup(t *testing.T) {
 func TestAgentFailedStartupWithServerFlag(t *testing.T) {
 	t.Parallel()
 
-	prom := exec.Command(promPath, "-test.main", "--agent", "--storage.tsdb.path=.", "--web.listen-address=0.0.0.0:0", "--config.file="+promConfig)
+	port := testutil.RandomUnprivilegedPort(t)
+	prom := exec.Command(promPath, "-test.main", "--agent", "--storage.tsdb.path=.", fmt.Sprintf("--web.listen-address=0.0.0.0:%d", port), "--config.file="+promConfig)
 
 	output := bytes.Buffer{}
 	prom.Stderr = &output
@@ -469,7 +474,8 @@ func TestAgentFailedStartupWithServerFlag(t *testing.T) {
 func TestAgentFailedStartupWithInvalidConfig(t *testing.T) {
 	t.Parallel()
 
-	prom := exec.Command(promPath, "-test.main", "--agent", "--web.listen-address=0.0.0.0:0", "--config.file="+promConfig)
+	port := testutil.RandomUnprivilegedPort(t)
+	prom := exec.Command(promPath, "-test.main", "--agent", fmt.Sprintf("--web.listen-address=0.0.0.0:%d", port), "--config.file="+promConfig)
 	require.NoError(t, prom.Start())
 
 	actualExitStatus := 0
@@ -506,7 +512,8 @@ func TestModeSpecificFlags(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("%s mode with option %s", tc.mode, tc.arg), func(t *testing.T) {
 			t.Parallel()
-			args := []string{"-test.main", tc.arg, t.TempDir(), "--web.listen-address=0.0.0.0:0"}
+			port := testutil.RandomUnprivilegedPort(t)
+			args := []string{"-test.main", tc.arg, t.TempDir(), fmt.Sprintf("--web.listen-address=0.0.0.0:%d", port)}
 
 			if tc.mode == "agent" {
 				args = append(args, "--agent", "--config.file="+agentConfig)

--- a/util/testutil/port.go
+++ b/util/testutil/port.go
@@ -14,6 +14,8 @@
 package testutil
 
 import (
+	"fmt"
+	"math/rand/v2"
 	"net"
 	"slices"
 	"sync"
@@ -25,26 +27,34 @@ var (
 	usedPorts []int
 )
 
-// RandomUnprivilegedPort returns valid unprivileged random port number which can be used for testing.
+// Port range used by getPort. Chosen to live entirely below Linux's
+// default ephemeral allocation range (32768–60999), so a concurrent
+// net.Listen(":0") elsewhere on the host will never be assigned a port
+// from here. Adjust if the runtime host has a non-default
+// /proc/sys/net/ipv4/ip_local_port_range.
+const (
+	testPortLo = 20000
+	testPortHi = 30000
+)
+
+// RandomUnprivilegedPort returns a random TCP port number that is currently
+// free, drawn from a range outside the kernel's ephemeral allocation range.
+//
+// Drawing from a non-ephemeral range eliminates the dominant
+// "bind: address already in use" race in subprocess tests: the kernel will
+// not hand a port from this range to anyone calling net.Listen(":0"), so
+// other tests that pass --web.listen-address=0.0.0.0:0 cannot grab the
+// port between this helper's Close and the caller's subprocess bind.
 func RandomUnprivilegedPort(t *testing.T) int {
 	t.Helper()
 	mu.Lock()
 	defer mu.Unlock()
 
-	port, err := getPort()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	port := getPort()
 	for portWasUsed(port) {
-		port, err = getPort()
-		if err != nil {
-			t.Fatal(err)
-		}
+		port = getPort()
 	}
-
 	usedPorts = append(usedPorts, port)
-
 	return port
 }
 
@@ -52,15 +62,14 @@ func portWasUsed(port int) bool {
 	return slices.Contains(usedPorts, port)
 }
 
-func getPort() (int, error) {
-	listener, err := net.Listen("tcp", ":0")
-	if err != nil {
-		return 0, err
+func getPort() int {
+	for {
+		port := testPortLo + rand.IntN(testPortHi-testPortLo)
+		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		if err != nil {
+			continue
+		}
+		listener.Close()
+		return port
 	}
-
-	if err := listener.Close(); err != nil {
-		return 0, err
-	}
-
-	return listener.Addr().(*net.TCPAddr).Port, nil
 }

--- a/util/testutil/port.go
+++ b/util/testutil/port.go
@@ -30,21 +30,13 @@ var (
 // Port range used by getPort. Chosen to live entirely below Linux's
 // default ephemeral allocation range (32768–60999), so a concurrent
 // net.Listen(":0") elsewhere on the host will never be assigned a port
-// from here. Adjust if the runtime host has a non-default
-// /proc/sys/net/ipv4/ip_local_port_range.
+// from here.
 const (
 	testPortLo = 20000
 	testPortHi = 30000
 )
 
-// RandomUnprivilegedPort returns a random TCP port number that is currently
-// free, drawn from a range outside the kernel's ephemeral allocation range.
-//
-// Drawing from a non-ephemeral range eliminates the dominant
-// "bind: address already in use" race in subprocess tests: the kernel will
-// not hand a port from this range to anyone calling net.Listen(":0"), so
-// other tests that pass --web.listen-address=0.0.0.0:0 cannot grab the
-// port between this helper's Close and the caller's subprocess bind.
+// RandomUnprivilegedPort returns valid unprivileged random port number which can be used for testing.
 func RandomUnprivilegedPort(t *testing.T) int {
 	t.Helper()
 	mu.Lock()

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/tsdb"
-	"github.com/prometheus/prometheus/util/testutil"
 )
 
 func TestMain(m *testing.M) {
@@ -64,6 +63,20 @@ func (*dbAdapter) WALReplayStatus() (tsdb.WALReplayStatus, error) {
 	return tsdb.WALReplayStatus{}, nil
 }
 
+// loopbackListener opens a TCP listener on 127.0.0.1:0 and returns it
+// alongside the bound ":port" string. The listener stays open until t
+// cleans up (or until the caller hands it to webHandler.Run, which closes
+// it on shutdown). Holding the listener across the whole test rather than
+// pre-allocating a port via testutil.RandomUnprivilegedPort eliminates
+// the close-then-bind window: the kernel reservation is continuous.
+func loopbackListener(t *testing.T) (ln net.Listener, port string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+	return ln, ":" + strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+}
+
 func TestReadyAndHealthy(t *testing.T) {
 	t.Parallel()
 
@@ -74,7 +87,7 @@ func TestReadyAndHealthy(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())
 	})
-	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
+	ln, port := loopbackListener(t)
 
 	opts := &Options{
 		ListenAddresses: []string{port},
@@ -105,14 +118,10 @@ func TestReadyAndHealthy(t *testing.T) {
 
 	webHandler.config = &config.Config{}
 	webHandler.notifier = &notifier.Manager{}
-	l, err := webHandler.Listeners()
-	if err != nil {
-		panic(fmt.Sprintf("Unable to start web listeners: %s", err))
-	}
 
 	ctx := t.Context()
 	go func() {
-		err := webHandler.Run(ctx, l, "")
+		err := webHandler.Run(ctx, []net.Listener{ln}, "")
 		if err != nil {
 			panic(fmt.Sprintf("Can't start web handler:%s", err))
 		}
@@ -217,7 +226,7 @@ func TestRoutePrefix(t *testing.T) {
 		require.NoError(t, db.Close())
 	})
 
-	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
+	ln, port := loopbackListener(t)
 
 	opts := &Options{
 		ListenAddresses: []string{port},
@@ -242,13 +251,9 @@ func TestRoutePrefix(t *testing.T) {
 	opts.Flags = map[string]string{}
 
 	webHandler := New(nil, opts)
-	l, err := webHandler.Listeners()
-	if err != nil {
-		panic(fmt.Sprintf("Unable to start web listeners: %s", err))
-	}
 	ctx := t.Context()
 	go func() {
-		err := webHandler.Run(ctx, l, "")
+		err := webHandler.Run(ctx, []net.Listener{ln}, "")
 		if err != nil {
 			panic(fmt.Sprintf("Can't start web handler:%s", err))
 		}
@@ -399,7 +404,7 @@ func TestShutdownWithStaleConnection(t *testing.T) {
 	})
 	timeout := 10 * time.Second
 
-	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
+	ln, port := loopbackListener(t)
 
 	opts := &Options{
 		ListenAddresses: []string{port},
@@ -429,16 +434,12 @@ func TestShutdownWithStaleConnection(t *testing.T) {
 
 	webHandler.config = &config.Config{}
 	webHandler.notifier = &notifier.Manager{}
-	l, err := webHandler.Listeners()
-	if err != nil {
-		panic(fmt.Sprintf("Unable to start web listeners: %s", err))
-	}
 
 	closed := make(chan struct{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		err := webHandler.Run(ctx, l, "")
+		err := webHandler.Run(ctx, []net.Listener{ln}, "")
 		if err != nil {
 			panic(fmt.Sprintf("Can't start web handler:%s", err))
 		}
@@ -466,7 +467,7 @@ func TestShutdownWithStaleConnection(t *testing.T) {
 }
 
 func TestHandleMultipleQuitRequests(t *testing.T) {
-	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
+	ln, port := loopbackListener(t)
 
 	opts := &Options{
 		ListenAddresses: []string{port},
@@ -482,14 +483,10 @@ func TestHandleMultipleQuitRequests(t *testing.T) {
 	webHandler := New(nil, opts)
 	webHandler.config = &config.Config{}
 	webHandler.notifier = &notifier.Manager{}
-	l, err := webHandler.Listeners()
-	if err != nil {
-		panic(fmt.Sprintf("Unable to start web listeners: %s", err))
-	}
 	ctx, cancel := context.WithCancel(context.Background())
 	closed := make(chan struct{})
 	go func() {
-		err := webHandler.Run(ctx, l, "")
+		err := webHandler.Run(ctx, []net.Listener{ln}, "")
 		if err != nil {
 			panic(fmt.Sprintf("Can't start web handler:%s", err))
 		}
@@ -527,7 +524,7 @@ func TestHandleMultipleQuitRequests(t *testing.T) {
 func TestAgentAPIEndPoints(t *testing.T) {
 	t.Parallel()
 
-	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
+	ln, port := loopbackListener(t)
 
 	opts := &Options{
 		ListenAddresses: []string{port},
@@ -557,14 +554,10 @@ func TestAgentAPIEndPoints(t *testing.T) {
 	webHandler.SetReady(Ready)
 	webHandler.config = &config.Config{}
 	webHandler.notifier = &notifier.Manager{}
-	l, err := webHandler.Listeners()
-	if err != nil {
-		panic(fmt.Sprintf("Unable to start web listeners: %s", err))
-	}
 
 	ctx := t.Context()
 	go func() {
-		err := webHandler.Run(ctx, l, "")
+		err := webHandler.Run(ctx, []net.Listener{ln}, "")
 		if err != nil {
 			panic(fmt.Sprintf("Can't start web handler:%s", err))
 		}
@@ -656,9 +649,9 @@ func TestMultipleListenAddresses(t *testing.T) {
 		require.NoError(t, db.Close())
 	})
 
-	// Create multiple ports for testing multiple ListenAddresses
-	port1 := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
-	port2 := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
+	// Create multiple listeners for testing multiple ListenAddresses.
+	ln1, port1 := loopbackListener(t)
+	ln2, port2 := loopbackListener(t)
 
 	opts := &Options{
 		ListenAddresses: []string{port1, port2},
@@ -689,14 +682,10 @@ func TestMultipleListenAddresses(t *testing.T) {
 
 	webHandler.config = &config.Config{}
 	webHandler.notifier = &notifier.Manager{}
-	l, err := webHandler.Listeners()
-	if err != nil {
-		panic(fmt.Sprintf("Unable to start web listener: %s", err))
-	}
 
 	ctx := t.Context()
 	go func() {
-		err := webHandler.Run(ctx, l, "")
+		err := webHandler.Run(ctx, []net.Listener{ln1, ln2}, "")
 		if err != nil {
 			panic(fmt.Sprintf("Can't start web handler:%s", err))
 		}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #16843

`testutil.RandomUnprivilegedPort` opens `net.Listen(":0")`, closes it, returns the port, then the caller hands it to a Prometheus subprocess. The kernel sees the port as free between Close and the subprocess's bind, so any concurrent listener — typically another test using `--web.listen-address=0.0.0.0:0` — can grab it, producing intermittent `bind: address already in use`. The helper's `usedPorts` slice only dedupes within one Go process; the kernel doesn't consult it when picking the next ephemeral port for anyone else.

Fix by drawing test ports from a fixed range (`20000–30000`) below Linux's default ephemeral allocation range (`32768–60999`). The kernel will not assign a port from this range to anyone calling `net.Listen(":0")`

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```
