### PR TITLE
refactor: use UnixMilli instead of dividing

### DIFF
--- a/util/fmtutil/format.go
+++ b/util/fmtutil/format.go
@@ -108,7 +108,7 @@ func makeTimeseries(wr *prompb.WriteRequest, labels map[string]string, m *dto.Me
 
 	timestamp := m.GetTimestampMs()
 	if timestamp == 0 {
-		timestamp = time.Now().UnixNano() / int64(time.Millisecond)
+		timestamp = time.Now().UnixMilli()
 	}
 
 	switch {


### PR DESCRIPTION
Description:
`time.Millisecond` is `time.Duration(1000000)` nanoseconds, and `UnixMilli()` is defined by the standard
  library as `t.UnixNano() / 1e6`, so the two are identical.
> https://pkg.go.dev/time#Time.UnixMilli

 ```go
  package main

  import (
        "fmt"
        "time"
  )

  func main() {
        t := time.Now()
        old := t.UnixNano() / int64(time.Millisecond)
        new := t.UnixMilli()
        fmt.Println("old:", old)
        fmt.Println("new:", new)
        fmt.Println("equal:", old == new)
  }
 ```
 
Output:
old: __1746273600123__
new: __1746273600123__
equal: true

#### Which issue(s) does the PR fix:
None

#### Release notes for end users (**ALL** commits must be considered).
```release-notes
NONE
```

Based on contrib md i tag @roidelapluie to CR

