### PR TITLE
[WIP] promtool: Add support for OpenMetrics to check metrics

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -84,6 +84,8 @@ const (
 	lintOptionDuplicateRules        = "duplicate-rules"
 	lintOptionTooLongScrapeInterval = "too-long-scrape-interval"
 	lintOptionNone                  = "none"
+	metricsFormatPrometheus         = "prometheus"
+	metricsFormatOpenMetrics        = "openmetrics"
 	checkHealth                     = "/-/healthy"
 	checkReadiness                  = "/-/ready"
 )
@@ -91,7 +93,8 @@ const (
 var (
 	lintRulesOptions = []string{lintOptionAll, lintOptionDuplicateRules, lintOptionNone}
 	// Same as lintRulesOptions, but including scrape config linting options as well.
-	lintConfigOptions = append(append([]string{}, lintRulesOptions...), lintOptionTooLongScrapeInterval)
+	lintConfigOptions   = append(append([]string{}, lintRulesOptions...), lintOptionTooLongScrapeInterval)
+	checkMetricsFormats = []string{metricsFormatPrometheus, metricsFormatOpenMetrics}
 )
 
 const httpConfigFileDescription = "HTTP client configuration file, see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool"
@@ -168,6 +171,7 @@ func main() {
 
 	checkMetricsCmd := checkCmd.Command("metrics", checkMetricsUsage)
 	checkMetricsExtended := checkMetricsCmd.Flag("extended", "Print extended information related to the cardinality of the metrics.").Bool()
+	checkMetricsFormat := checkMetricsCmd.Flag("format", "Metrics format to expect in standard input.").Default(metricsFormatPrometheus).Enum(checkMetricsFormats...)
 	checkMetricsLint := checkMetricsCmd.Flag(
 		"lint",
 		"Linting checks to apply for metrics. Available options are: all, none. Use --lint=none to disable metrics linting.",
@@ -390,7 +394,7 @@ func main() {
 		os.Exit(CheckRules(newRulesLintConfig(*checkRulesLint, *checkRulesLintFatal, *checkRulesIgnoreUnknownFields, model.UTF8Validation), promtoolParser, *ruleFiles...))
 
 	case checkMetricsCmd.FullCommand():
-		os.Exit(CheckMetrics(*checkMetricsExtended, *checkMetricsLint))
+		os.Exit(CheckMetrics(*checkMetricsFormat, *checkMetricsExtended, *checkMetricsLint))
 
 	case pushMetricsCmd.FullCommand():
 		os.Exit(PushMetrics(remoteWriteURL, httpRoundTripper, *pushMetricsHeaders, *pushMetricsTimeout, *pushMetricsProtoMsg, *pushMetricsLabels, *metricFiles...))
@@ -1040,13 +1044,15 @@ examples:
 
 $ cat metrics.prom | promtool check metrics
 
+$ cat metrics.om | promtool check metrics --format=openmetrics
+
 $ curl -s http://localhost:9090/metrics | promtool check metrics --extended
 
 $ curl -s http://localhost:9100/metrics | promtool check metrics --extended --lint=none
 `)
 
 // CheckMetrics performs a linting pass on input metrics.
-func CheckMetrics(extended bool, lint string) int {
+func CheckMetrics(format string, extended bool, lint string) int {
 	// Validate that at least one feature is enabled.
 	if !extended && lint == lintOptionNone {
 		fmt.Fprintln(os.Stderr, "error: at least one of --extended or linting must be enabled")
@@ -1054,16 +1060,15 @@ func CheckMetrics(extended bool, lint string) int {
 		return failureExitCode
 	}
 
-	var buf bytes.Buffer
-	var (
-		problems []promlint.Problem
-		reader   io.Reader
-		err      error
-	)
+	metricFamilies, err := parseMetricFamilies(os.Stdin, format)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error while parsing metrics:", err)
+		return failureExitCode
+	}
 
+	var problems []promlint.Problem
 	if lint != lintOptionNone {
-		tee := io.TeeReader(os.Stdin, &buf)
-		l := promlint.New(tee)
+		l := promlint.NewWithMetricFamilies(metricFamilies)
 		problems, err = l.Lint()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "error while linting:", err)
@@ -1072,15 +1077,12 @@ func CheckMetrics(extended bool, lint string) int {
 		for _, p := range problems {
 			fmt.Fprintln(os.Stderr, p.Metric, p.Text)
 		}
-		reader = &buf
-	} else {
-		reader = os.Stdin
 	}
 
 	hasLintProblems := len(problems) > 0
 
 	if extended {
-		stats, total, err := checkMetricsExtended(reader)
+		stats, total, err := checkMetricsExtended(metricFamilies)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return failureExitCode
@@ -1107,16 +1109,37 @@ type metricStat struct {
 	percentage  float64
 }
 
-func checkMetricsExtended(r io.Reader) ([]metricStat, int, error) {
-	// Lacking information about what the intended validation scheme is, use the
-	// deprecated library bool.
-	//nolint:staticcheck
-	p := expfmt.NewTextParser(model.NameValidationScheme)
-	metricFamilies, err := p.TextToMetricFamilies(r)
-	if err != nil {
-		return nil, 0, fmt.Errorf("error while parsing text to metric families: %w", err)
+func parseMetricFamilies(r io.Reader, format string) ([]*dto.MetricFamily, error) {
+	var decoder expfmt.Decoder
+	switch format {
+	case metricsFormatPrometheus:
+		decoder = expfmt.NewDecoder(r, expfmt.NewFormat(expfmt.TypeTextPlain))
+	case metricsFormatOpenMetrics:
+		decoder = expfmt.NewDecoder(r, expfmt.NewFormat(expfmt.TypeOpenMetrics))
+	default:
+		return nil, fmt.Errorf("unsupported metrics format %q", format)
 	}
 
+	metricFamilies := make([]*dto.MetricFamily, 0)
+	for {
+		mf := &dto.MetricFamily{}
+		if err := decoder.Decode(mf); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		metricFamilies = append(metricFamilies, mf)
+	}
+
+	sort.SliceStable(metricFamilies, func(i, j int) bool {
+		return metricFamilies[i].GetName() < metricFamilies[j].GetName()
+	})
+
+	return metricFamilies, nil
+}
+
+func checkMetricsExtended(metricFamilies []*dto.MetricFamily) ([]metricStat, int, error) {
 	var total int
 	stats := make([]metricStat, 0, len(metricFamilies))
 	for _, mf := range metricFamilies {
@@ -1124,7 +1147,7 @@ func checkMetricsExtended(r io.Reader) ([]metricStat, int, error) {
 		switch mf.GetType() {
 		case dto.MetricType_COUNTER, dto.MetricType_GAUGE, dto.MetricType_UNTYPED:
 			cardinality = len(mf.Metric)
-		case dto.MetricType_HISTOGRAM:
+		case dto.MetricType_HISTOGRAM, dto.MetricType_GAUGE_HISTOGRAM:
 			// Histogram metrics includes sum, count, buckets.
 			buckets := len(mf.Metric[0].Histogram.Bucket)
 			cardinality = len(mf.Metric) * (2 + buckets)

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -1068,8 +1068,7 @@ func CheckMetrics(format string, extended bool, lint string) int {
 
 	var problems []promlint.Problem
 	if lint != lintOptionNone {
-		l := promlint.NewWithMetricFamilies(metricFamilies)
-		problems, err = l.Lint()
+		problems, err = lintMetricFamilies(metricFamilies, format)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "error while linting:", err)
 			return failureExitCode
@@ -1101,6 +1100,46 @@ func CheckMetrics(format string, extended bool, lint string) int {
 	}
 
 	return successExitCode
+}
+
+func lintMetricFamilies(metricFamilies []*dto.MetricFamily, format string) ([]promlint.Problem, error) {
+	l := promlint.NewWithMetricFamilies(metricFamilies)
+	problems, err := l.Lint()
+	if err != nil {
+		return nil, err
+	}
+
+	if format == metricsFormatOpenMetrics {
+		problems = filterOpenMetricsLintProblems(metricFamilies, problems)
+	}
+
+	return problems, nil
+}
+
+func filterOpenMetricsLintProblems(metricFamilies []*dto.MetricFamily, problems []promlint.Problem) []promlint.Problem {
+	if len(problems) == 0 {
+		return problems
+	}
+
+	counterFamilies := make(map[string]struct{}, len(metricFamilies))
+	for _, metricFamily := range metricFamilies {
+		if metricFamily.GetType() == dto.MetricType_COUNTER {
+			counterFamilies[metricFamily.GetName()] = struct{}{}
+		}
+	}
+
+	filteredProblems := problems[:0]
+	for _, problem := range problems {
+		if problem.Text == `counter metrics should have "_total" suffix` {
+			if _, ok := counterFamilies[problem.Metric]; ok {
+				continue
+			}
+		}
+
+		filteredProblems = append(filteredProblems, problem)
+	}
+
+	return filteredProblems
 }
 
 type metricStat struct {

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -491,6 +491,72 @@ latency_seconds_count 2
 	}, stats)
 }
 
+func TestParseMetricFamiliesOpenMetricsInfoFamilyUsesBaseName(t *testing.T) {
+	t.Parallel()
+
+	const input = `# TYPE target info
+# HELP target Target metadata.
+target_info{service_name="service"} 1
+# EOF
+`
+
+	metricFamilies, err := parseMetricFamilies(strings.NewReader(input), metricsFormatOpenMetrics)
+	require.NoError(t, err)
+	require.Len(t, metricFamilies, 1)
+	require.Equal(t, "target", metricFamilies[0].GetName())
+	require.Equal(t, "Target metadata.", metricFamilies[0].GetHelp())
+	require.Equal(t, dto.MetricType_UNTYPED, metricFamilies[0].GetType())
+	require.Len(t, metricFamilies[0].Metric, 1)
+	require.Len(t, metricFamilies[0].Metric[0].GetLabel(), 1)
+	require.Equal(t, "service_name", metricFamilies[0].Metric[0].GetLabel()[0].GetName())
+}
+
+func TestCheckMetricsOpenMetricsNoFalsePositives(t *testing.T) {
+	const input = `# TYPE target info
+# HELP target Target metadata.
+target_info{service_name="service"} 1
+# HELP requests Number of requests.
+# TYPE requests counter
+requests_total 2
+# EOF
+`
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	_, err = w.WriteString(input)
+	require.NoError(t, err)
+	w.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	rOut, wOut, err := os.Pipe()
+	require.NoError(t, err)
+	rErr, wErr, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	code := CheckMetrics(metricsFormatOpenMetrics, false, lintOptionAll)
+
+	wOut.Close()
+	wErr.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	var outBuf, errBuf bytes.Buffer
+	_, _ = io.Copy(&outBuf, rOut)
+	_, _ = io.Copy(&errBuf, rErr)
+
+	require.Equal(t, successExitCode, code)
+	require.Empty(t, outBuf.String())
+	require.NotContains(t, errBuf.String(), `counter metrics should have "_total" suffix`)
+	require.NotContains(t, errBuf.String(), "no help text")
+}
+
 func TestCheckMetricsLintOptions(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on windows")

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
@@ -394,7 +395,10 @@ func TestCheckMetricsExtended(t *testing.T) {
 	require.NoError(t, err)
 	defer f.Close()
 
-	stats, total, err := checkMetricsExtended(f)
+	metricFamilies, err := parseMetricFamilies(f, metricsFormatPrometheus)
+	require.NoError(t, err)
+
+	stats, total, err := checkMetricsExtended(metricFamilies)
 	require.NoError(t, err)
 	require.Equal(t, 27, total)
 	require.Equal(t, []metricStat{
@@ -421,6 +425,72 @@ func TestCheckMetricsExtended(t *testing.T) {
 	}, stats)
 }
 
+func TestParseMetricFamiliesOpenMetrics(t *testing.T) {
+	t.Parallel()
+
+	const input = `# HELP requests Number of requests.
+# TYPE requests counter
+requests_total{code="200"} 2 123456
+requests_created{code="200"} 100.123
+# TYPE latency_seconds histogram
+latency_seconds_bucket{le="0.5"} 1
+latency_seconds_bucket{le="+Inf"} 2
+latency_seconds_sum 0.75
+latency_seconds_count 2
+# EOF
+`
+
+	metricFamilies, err := parseMetricFamilies(strings.NewReader(input), metricsFormatOpenMetrics)
+	require.NoError(t, err)
+	require.Len(t, metricFamilies, 2)
+
+	require.Equal(t, "latency_seconds", metricFamilies[0].GetName())
+	require.Equal(t, dto.MetricType_HISTOGRAM, metricFamilies[0].GetType())
+	require.Len(t, metricFamilies[0].Metric, 1)
+	require.Len(t, metricFamilies[0].Metric[0].GetHistogram().GetBucket(), 2)
+
+	require.Equal(t, "requests", metricFamilies[1].GetName())
+	require.Equal(t, dto.MetricType_COUNTER, metricFamilies[1].GetType())
+	require.Len(t, metricFamilies[1].Metric, 1)
+	require.EqualValues(t, 123456, metricFamilies[1].Metric[0].GetTimestampMs())
+	require.NotNil(t, metricFamilies[1].Metric[0].GetCounter().GetCreatedTimestamp())
+	require.EqualValues(t, 100123, metricFamilies[1].Metric[0].GetCounter().GetCreatedTimestamp().AsTime().UnixMilli())
+}
+
+func TestCheckMetricsExtendedOpenMetrics(t *testing.T) {
+	t.Parallel()
+
+	const input = `# HELP requests Number of requests.
+# TYPE requests counter
+requests_total{code="200"} 2
+# TYPE latency_seconds histogram
+latency_seconds_bucket{le="0.5"} 1
+latency_seconds_bucket{le="+Inf"} 2
+latency_seconds_sum 0.75
+latency_seconds_count 2
+# EOF
+`
+
+	metricFamilies, err := parseMetricFamilies(strings.NewReader(input), metricsFormatOpenMetrics)
+	require.NoError(t, err)
+
+	stats, total, err := checkMetricsExtended(metricFamilies)
+	require.NoError(t, err)
+	require.Equal(t, 5, total)
+	require.Equal(t, []metricStat{
+		{
+			name:        "latency_seconds",
+			cardinality: 4,
+			percentage:  float64(4) / float64(5),
+		},
+		{
+			name:        "requests",
+			cardinality: 1,
+			percentage:  float64(1) / float64(5),
+		},
+	}, stats)
+}
+
 func TestCheckMetricsLintOptions(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on windows")
@@ -432,8 +502,17 @@ func TestCheckMetricsLintOptions(t *testing.T) {
 testMetric_CamelCase{label="value1"} 1
 `
 
+	const testOpenMetrics = `
+# HELP testMetric_CamelCase A test metric with camelCase
+# TYPE testMetric_CamelCase gauge
+testMetric_CamelCase{label="value1"} 1
+# EOF
+`
+
 	tests := []struct {
 		name        string
+		format      string
+		input       string
 		lint        string
 		extended    bool
 		wantErrCode int
@@ -442,6 +521,8 @@ testMetric_CamelCase{label="value1"} 1
 	}{
 		{
 			name:        "default_all_with_extended",
+			format:      metricsFormatPrometheus,
+			input:       testMetrics,
 			lint:        lintOptionAll,
 			extended:    true,
 			wantErrCode: lintErrExitCode,
@@ -450,6 +531,8 @@ testMetric_CamelCase{label="value1"} 1
 		},
 		{
 			name:        "lint_none_with_extended",
+			format:      metricsFormatPrometheus,
+			input:       testMetrics,
 			lint:        lintOptionNone,
 			extended:    true,
 			wantErrCode: successExitCode,
@@ -458,11 +541,23 @@ testMetric_CamelCase{label="value1"} 1
 		},
 		{
 			name:        "both_disabled_fails",
+			format:      metricsFormatPrometheus,
+			input:       testMetrics,
 			lint:        lintOptionNone,
 			extended:    false,
 			wantErrCode: failureExitCode,
 			wantLint:    false,
 			wantCard:    false,
+		},
+		{
+			name:        "openmetrics_with_extended",
+			format:      metricsFormatOpenMetrics,
+			input:       testOpenMetrics,
+			lint:        lintOptionAll,
+			extended:    true,
+			wantErrCode: lintErrExitCode,
+			wantLint:    true,
+			wantCard:    true,
 		},
 	}
 
@@ -470,7 +565,7 @@ testMetric_CamelCase{label="value1"} 1
 		t.Run(tt.name, func(t *testing.T) {
 			r, w, err := os.Pipe()
 			require.NoError(t, err)
-			_, err = w.WriteString(testMetrics)
+			_, err = w.WriteString(tt.input)
 			require.NoError(t, err)
 			w.Close()
 
@@ -487,7 +582,7 @@ testMetric_CamelCase{label="value1"} 1
 			os.Stdout = wOut
 			os.Stderr = wErr
 
-			code := CheckMetrics(tt.extended, tt.lint)
+			code := CheckMetrics(tt.format, tt.extended, tt.lint)
 
 			wOut.Close()
 			wErr.Close()
@@ -512,6 +607,33 @@ testMetric_CamelCase{label="value1"} 1
 			}
 		})
 	}
+}
+
+func TestCheckMetricsOpenMetricsFlag(t *testing.T) {
+	t.Parallel()
+
+	const testOpenMetrics = `
+# HELP testMetric_CamelCase A test metric with camelCase
+# TYPE testMetric_CamelCase gauge
+testMetric_CamelCase{label="value1"} 1
+# EOF
+`
+
+	cmd := exec.Command(promtoolPath, "-test.main", "check", "metrics", "--format=openmetrics", "--extended")
+	cmd.Stdin = strings.NewReader(testOpenMetrics)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	require.Error(t, err)
+
+	var exitError *exec.ExitError
+	require.ErrorAs(t, err, &exitError)
+	require.Equal(t, lintErrExitCode, exitError.ExitCode())
+	require.Contains(t, stdout.String(), "Cardinality")
+	require.Contains(t, stderr.String(), "testMetric_CamelCase")
 }
 
 func TestExitCodes(t *testing.T) {

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -197,6 +197,8 @@ examples:
 
 $ cat metrics.prom | promtool check metrics
 
+$ cat metrics.om | promtool check metrics `--format`=openmetrics
+
 $ curl -s http://localhost:9090/metrics | promtool check metrics `--extended`
 
 $ curl -s http://localhost:9100/metrics | promtool check metrics `--extended` `--lint`=none
@@ -208,6 +210,7 @@ $ curl -s http://localhost:9100/metrics | promtool check metrics `--extended` `-
 | Flag | Description | Default |
 | --- | --- | --- |
 | <code class="text-nowrap">--extended</code> | Print extended information related to the cardinality of the metrics. |  |
+| <code class="text-nowrap">--format</code> | Metrics format to expect in standard input. | `prometheus` |
 | <code class="text-nowrap">--lint</code> | Linting checks to apply for metrics. Available options are: all, none. Use --lint=none to disable metrics linting. | `all` |
 
 

--- a/go.mod
+++ b/go.mod
@@ -139,7 +139,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
 
-replace github.com/prometheus/common => github.com/martincostello/common v0.0.0-20260503195019-ed3033948166
+replace github.com/prometheus/common => github.com/martincostello/common v0.0.0-20260503213144-a6754a1811aa
 
 require (
 	cloud.google.com/go/auth v0.18.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
 
+replace github.com/prometheus/common => github.com/martincostello/common v0.0.0-20260503195019-ed3033948166
+
 require (
 	cloud.google.com/go/auth v0.18.2 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect


### PR DESCRIPTION
Add support for OpenMetrics to `promtool check metrics` with new `--format=openmetrics` option.

Depends on https://github.com/prometheus/common/pull/904.

For now, not intended for merge, I've pointed prometheus/common to my PR branch, which breaks unrelated things due to other changes there compared to the version currently in main.

#### Which issue(s) does the PR fix:

#8932

#### Release notes for end users

```release-notes
[FEATURE] promtool: Add support for OpenMetrics to check metrics.
```
