### PR TITLE
rules: treat indeterminate rules as depending on all prior rules

### DIFF
--- a/rules/fixtures/rules_indeterminates_first_and_last.yaml
+++ b/rules/fixtures/rules_indeterminates_first_and_last.yaml
@@ -1,8 +1,10 @@
 groups:
-  - name: indeterminate
+  - name: indeterminate_first_and_last
     rules:
-      # The open matcher rule depends on all prior rules, but the prior
-      # independent rules can still run in parallel with each other.
+      # First rule is indeterminate (no __name__ matcher).
+      - record: indeterminate_first
+        expr: count({job=~".+"})
+      # Four independent rules in the middle.
       - record: job:http_requests:rate1m
         expr: sum by (job)(rate(http_requests_total[1m]))
       - record: job:http_requests:rate5m
@@ -11,9 +13,6 @@ groups:
         expr: sum by (job)(rate(http_requests_total[15m]))
       - record: job:http_requests:rate30m
         expr: sum by (job)(rate(http_requests_total[30m]))
-      - record: job:http_requests:rate1h
-        expr: sum by (job)(rate(http_requests_total[1h]))
-      - record: job:http_requests:rate2h
-        expr: sum by (job)(rate(http_requests_total[2h]))
-      - record: matcher
-        expr: '{job="job1"}'
+      # Last rule is also indeterminate (no __name__ matcher).
+      - alert: IndeterminateLast
+        expr: max({job=~".+"}) > 1e15

--- a/rules/group.go
+++ b/rules/group.go
@@ -1121,6 +1121,9 @@ func (m dependencyMap) isIndependent(r Rule) bool {
 // inferred, or concurrent evaluation of rules depending on these series would produce undefined/unexpected behaviour:
 //   - wildcard queriers like {cluster="prod1"} which would match every series with that label selector
 //
+// When a rule is indeterminate, it is conservatively treated as depending on all prior rules in the group.
+// Other rules in the group that are not indeterminate can still be analysed normally and may run concurrently.
+//
 // Rules which are independent can run concurrently with no side-effects.
 func buildDependencyMap(rules []Rule) dependencyMap {
 	dependencies := make(dependencyMap)
@@ -1130,15 +1133,15 @@ func buildDependencyMap(rules []Rule) dependencyMap {
 		return dependencies
 	}
 
-	var indeterminate bool
-
-	for _, rule := range rules {
-		if indeterminate {
-			break
-		}
+	for i, rule := range rules {
+		var ruleIsIndeterminate bool
 
 		parser.Inspect(rule.Query(), func(node parser.Node, _ []parser.Node) error {
 			if n, ok := node.(*parser.VectorSelector); ok {
+				if ruleIsIndeterminate {
+					return nil
+				}
+
 				// Find the name matcher for the rule.
 				var nameMatcher *labels.Matcher
 				if n.Name != "" {
@@ -1152,10 +1155,13 @@ func buildDependencyMap(rules []Rule) dependencyMap {
 					}
 				}
 
-				// A wildcard metric expression means we cannot reliably determine if this rule depends on any other,
-				// which means we cannot safely run any rules concurrently.
+				// A wildcard metric expression means we cannot reliably determine if this rule depends on
+				// any other. Conservatively treat it as depending on every prior rule in the group.
 				if nameMatcher == nil {
-					indeterminate = true
+					ruleIsIndeterminate = true
+					for _, other := range rules[:i] {
+						dependencies[other] = append(dependencies[other], rule)
+					}
 					return nil
 				}
 
@@ -1173,15 +1179,7 @@ func buildDependencyMap(rules []Rule) dependencyMap {
 				}
 
 				// Find the other rules that this rule depends on.
-				for _, other := range rules {
-					// Rules are defined in order in a rule group. Once we find our rule we can stop searching
-					// because next rules can't be considered dependencies of this rule by specification, given
-					// they are defined later in the group. The next rules can still query this rule, but they're
-					// just not strict dependencies to honor.
-					if other == rule {
-						break
-					}
-
+				for _, other := range rules[:i] {
 					otherName := other.Name()
 
 					// If this rule vector selector matches the other rule name, then it's a dependency.
@@ -1201,10 +1199,6 @@ func buildDependencyMap(rules []Rule) dependencyMap {
 			}
 			return nil
 		})
-	}
-
-	if indeterminate {
-		return nil
 	}
 
 	return dependencies

--- a/rules/manager.go
+++ b/rules/manager.go
@@ -510,10 +510,6 @@ type ruleDependencyController struct{}
 func (ruleDependencyController) AnalyseRules(rules []Rule) {
 	depMap := buildDependencyMap(rules)
 
-	if depMap == nil {
-		return
-	}
-
 	for _, r := range rules {
 		r.SetDependentRules(depMap.dependents(r))
 		r.SetDependencyRules(depMap.dependencies(r))

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -1948,6 +1948,55 @@ func TestDependentRulesWithNonMetricExpression(t *testing.T) {
 	require.True(t, depMap.isIndependent(rule3))
 }
 
+func TestIndeterminateRuleDependencyEdges(t *testing.T) {
+	ctx := context.Background()
+	opts := &ManagerOptions{
+		Context: ctx,
+		Logger:  promslog.NewNopLogger(),
+	}
+
+	independentExprs := []string{
+		"sum by (job)(rate(http_requests_total[1m]))",
+		"sum by (job)(rate(http_requests_total[5m]))",
+		"sum by (job)(rate(http_requests_total[15m]))",
+		"sum by (job)(rate(http_requests_total[30m]))",
+		"sum by (job)(rate(http_requests_total[1h]))",
+		"sum by (job)(rate(http_requests_total[2h]))",
+	}
+
+	var rules []Rule
+	for i, e := range independentExprs {
+		expr, err := testParser.ParseExpr(e)
+		require.NoError(t, err)
+		rules = append(rules, NewRecordingRule(fmt.Sprintf("rule_%d", i), expr, labels.Labels{}))
+	}
+
+	poisonExpr, err := testParser.ParseExpr(
+		`max({job=~".+"}) > 10000000000000`,
+	)
+	require.NoError(t, err)
+	poisonRule := NewAlertingRule("HighDiskUsage", poisonExpr, 0, 0, labels.Labels{}, labels.Labels{}, labels.EmptyLabels(), "", true, promslog.NewNopLogger())
+	rules = append(rules, poisonRule)
+
+	group := NewGroup(GroupOptions{
+		Name:     "rule_group",
+		Interval: time.Second,
+		Rules:    rules,
+		Opts:     opts,
+	})
+
+	depMap := buildDependencyMap(group.rules)
+	require.NotNil(t, depMap)
+
+	for _, r := range rules[:6] {
+		require.Equal(t, []Rule{poisonRule}, depMap.dependents(r), "rule %s: expected poison rule as only dependent", r.Name())
+		require.Empty(t, depMap.dependencies(r), "rule %s: expected no dependencies", r.Name())
+	}
+
+	require.Len(t, depMap.dependencies(poisonRule), 6)
+	require.Empty(t, depMap.dependents(poisonRule))
+}
+
 func TestDependencyMapUpdatesOnGroupUpdate(t *testing.T) {
 	storage := teststorage.New(t)
 	engine := testEngine(t)
@@ -2190,7 +2239,7 @@ func TestAsyncRuleEvaluation(t *testing.T) {
 		})
 	})
 
-	t.Run("asynchronous evaluation of independent rules, with indeterminate. Should be synchronous", func(t *testing.T) {
+	t.Run("asynchronous evaluation with indeterminate rule depending on all prior", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			storage := teststorage.New(t)
 
@@ -2219,11 +2268,11 @@ func TestAsyncRuleEvaluation(t *testing.T) {
 
 				group.Eval(ctx, start)
 
-				// Never expect more than 1 inflight query at a time.
-				require.EqualValues(t, 1, maxInflight.Load())
-				// Each rule should take at least 1 second to execute sequentially.
-				require.GreaterOrEqual(t, time.Since(start).Seconds(), (time.Duration(ruleCount) * artificialDelay).Seconds())
-				// Each rule produces one vector.
+				// The indeterminate rule depends on all prior rules, but the 6
+				// independent rules can still run concurrently.
+				require.Greater(t, maxInflight.Load(), int32(1), "expected concurrent evaluation for independent rules")
+				require.Less(t, time.Since(start).Seconds(), (time.Duration(ruleCount) * artificialDelay).Seconds(),
+					"expected faster than fully sequential evaluation")
 				require.EqualValues(t, ruleCount, testutil.ToFloat64(group.metrics.GroupSamples))
 			}
 		})
@@ -2697,30 +2746,60 @@ func TestRuleDependencyController_AnalyseRules(t *testing.T) {
 			expected: map[string]expectedDependencies{
 				"job:http_requests:rate1m": {
 					noDependentRules:  false,
-					noDependencyRules: false,
+					noDependencyRules: true,
 				},
 				"job:http_requests:rate5m": {
 					noDependentRules:  false,
-					noDependencyRules: false,
+					noDependencyRules: true,
 				},
 				"job:http_requests:rate15m": {
 					noDependentRules:  false,
-					noDependencyRules: false,
+					noDependencyRules: true,
 				},
 				"job:http_requests:rate30m": {
 					noDependentRules:  false,
-					noDependencyRules: false,
+					noDependencyRules: true,
 				},
 				"job:http_requests:rate1h": {
 					noDependentRules:  false,
-					noDependencyRules: false,
+					noDependencyRules: true,
 				},
 				"job:http_requests:rate2h": {
 					noDependentRules:  false,
-					noDependencyRules: false,
+					noDependencyRules: true,
 				},
 				"matcher": {
+					noDependentRules:  true,
+					noDependencyRules: false,
+				},
+			},
+		},
+		{
+			name:     "indeterminate rules first and last",
+			ruleFile: "fixtures/rules_indeterminates_first_and_last.yaml",
+			expected: map[string]expectedDependencies{
+				"indeterminate_first": {
 					noDependentRules:  false,
+					noDependencyRules: true,
+				},
+				"job:http_requests:rate1m": {
+					noDependentRules:  false,
+					noDependencyRules: true,
+				},
+				"job:http_requests:rate5m": {
+					noDependentRules:  false,
+					noDependencyRules: true,
+				},
+				"job:http_requests:rate15m": {
+					noDependentRules:  false,
+					noDependencyRules: true,
+				},
+				"job:http_requests:rate30m": {
+					noDependentRules:  false,
+					noDependencyRules: true,
+				},
+				"IndeterminateLast": {
+					noDependentRules:  true,
 					noDependencyRules: false,
 				},
 			},


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18616

#### Description

Previously, `buildDependencyMap` returned `nil` when any rule in a group had a `VectorSelector` without a `__name__` matcher, forcing the entire group into sequential evaluation. This was overly conservative: one indeterminate rule disabled concurrency for all other rules, even those that are independent of each other.

Instead, treat the indeterminate rule as depending on all prior rules in the group and continue building the dependency map for the remaining rules. This allows independent rules to still be batched concurrently while the indeterminate rule correctly waits for all prior rules to complete.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] Rules: A rule with no `__name__` matcher no longer disables concurrent evaluation for the entire group.
```