### PR TITLE
promql/parser: recognize range in duration expressions

### DIFF
--- a/promql/parser/lex.go
+++ b/promql/parser/lex.go
@@ -499,15 +499,15 @@ func lexStatements(l *Lexer) stateFn {
 			l.backup()
 			return lexKeywordOrIdentifier
 		}
-		switch r {
-		case ':':
+		switch {
+		case r == ':':
 			if l.gotColon {
 				return l.errorf("unexpected colon %q", r)
 			}
 			l.emit(COLON)
 			l.gotColon = true
 			return lexStatements
-		case 's', 'S', 'm', 'M', 'r', 'R':
+		case isDurationKeywordStartChar(r):
 			if l.scanDurationKeyword() {
 				return lexStatements
 			}
@@ -935,6 +935,32 @@ func lexNumber(l *Lexer) stateFn {
 	return lexStatements
 }
 
+// durationKeywordTokens maps lowercase duration keyword names to their token types.
+var durationKeywordTokens = map[string]ItemType{
+	"step":  STEP,
+	"range": RANGE,
+	"min":   MIN,
+	"max":   MAX,
+}
+
+// durationKeywordStartChars is the set of lowercase runes that can start a duration keyword,
+// derived from durationKeywordTokens.
+var durationKeywordStartChars = makeDurationKeywordStartChars()
+
+func makeDurationKeywordStartChars() map[rune]struct{} {
+	m := make(map[rune]struct{}, len(durationKeywordTokens))
+	for kw := range durationKeywordTokens {
+		m[rune(kw[0])] = struct{}{}
+	}
+	return m
+}
+
+// isDurationKeywordStartChar reports whether r can be the first character of a duration keyword.
+func isDurationKeywordStartChar(r rune) bool {
+	_, ok := durationKeywordStartChars[unicode.ToLower(r)]
+	return ok
+}
+
 func (l *Lexer) scanDurationKeyword() bool {
 	for {
 		switch r := l.next(); {
@@ -942,24 +968,12 @@ func (l *Lexer) scanDurationKeyword() bool {
 			// absorb.
 		default:
 			l.backup()
-			word := l.input[l.start:l.pos]
-			kw := strings.ToLower(word)
-			switch kw {
-			case "step":
-				l.emit(STEP)
+			word := strings.ToLower(l.input[l.start:l.pos])
+			if tok, ok := durationKeywordTokens[word]; ok {
+				l.emit(tok)
 				return true
-			case "range":
-				l.emit(RANGE)
-				return true
-			case "min":
-				l.emit(MIN)
-				return true
-			case "max":
-				l.emit(MAX)
-				return true
-			default:
-				return false
 			}
+			return false
 		}
 	}
 }
@@ -1239,7 +1253,7 @@ func lexDurationExpr(l *Lexer) stateFn {
 	case r == ',':
 		l.emit(COMMA)
 		return lexDurationExpr
-	case r == 's' || r == 'S' || r == 'm' || r == 'M' || r == 'r' || r == 'R':
+	case isDurationKeywordStartChar(r):
 		if l.scanDurationKeyword() {
 			return lexDurationExpr
 		}

--- a/promql/parser/lex.go
+++ b/promql/parser/lex.go
@@ -507,7 +507,7 @@ func lexStatements(l *Lexer) stateFn {
 			l.emit(COLON)
 			l.gotColon = true
 			return lexStatements
-		case 's', 'S', 'm', 'M':
+		case 's', 'S', 'm', 'M', 'r', 'R':
 			if l.scanDurationKeyword() {
 				return lexStatements
 			}

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -4719,6 +4719,32 @@ var testExpr = []struct {
 		},
 	},
 	{
+		input: `foo[2m/range()]`,
+		expected: &MatrixSelector{
+			VectorSelector: &VectorSelector{
+				Name: "foo",
+				LabelMatchers: []*labels.Matcher{
+					MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+				},
+				PosRange: posrange.PositionRange{Start: 0, End: 3},
+			},
+			RangeExpr: &DurationExpr{
+				Op: DIV,
+				LHS: &NumberLiteral{
+					Val:      120,
+					Duration: true,
+					PosRange: posrange.PositionRange{Start: 4, End: 6},
+				},
+				RHS: &DurationExpr{
+					Op:       RANGE,
+					StartPos: 7,
+					EndPos:   14,
+				},
+			},
+			EndPos: 15,
+		},
+	},
+	{
 		input: `foo[-range()]`,
 		expected: &MatrixSelector{
 			VectorSelector: &VectorSelector{


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] PromQL: Fix parsing of `range()` keyword in duration expressions such as `foo[5m+range()]`.
```
