### PR TITLE
ui: include group and file names in rules page search filter

### DIFF
--- a/web/ui/mantine-ui/src/pages/RulesPage.tsx
+++ b/web/ui/mantine-ui/src/pages/RulesPage.tsx
@@ -56,6 +56,14 @@ type RulesPageData = {
   groups: (RuleGroup & { prefilterRulesCount: number })[];
 };
 
+const groupMatchesSearch = (group: RuleGroup, search: string): boolean => {
+  const lowerSearch = search.toLowerCase();
+  return (
+    group.name.toLowerCase().includes(lowerSearch) ||
+    group.file.toLowerCase().includes(lowerSearch)
+  );
+};
+
 const buildRulesPageData = (
   data: RulesResult,
   search: string,
@@ -66,7 +74,9 @@ const buildRulesPageData = (
     prefilterRulesCount: group.rules.length,
     rules: (search === ""
       ? group.rules
-      : kvSearch.filter(search, group.rules).map((value) => value.original)
+      : groupMatchesSearch(group, search)
+        ? group.rules
+        : kvSearch.filter(search, group.rules).map((value) => value.original)
     ).filter(
       (r) => healthFilter.length === 0 || healthFilter.includes(r.health)
     ),
@@ -351,7 +361,7 @@ export default function RulesPage() {
         <TextInput
           flex={1}
           leftSection={<IconSearch style={inputIconStyle} />}
-          placeholder="Filter by rule name or labels"
+          placeholder="Filter by rule name, labels, group, or file"
           value={searchFilter || ""}
           onChange={(event) =>
             setSearchFilter(event.currentTarget.value || null)


### PR DESCRIPTION
## Summary

The search box on the Rule health page (⁠ `/rules` ⁠) previously only matched against individual rule names and labels. Typing a group name like ⁠ `alerting.rules ` or a file path like ⁠ `test.rules.yml ⁠` returned no results, even when matching groups existed.

## How

In ⁠` buildRulesPageData` ⁠, before running the per-rule `⁠ KVSearch ⁠`, check whether the search term is a case-insensitive substring of the group's ⁠ `name` ⁠ or `file ⁠`. If it matches at the group level, all rules in that group are shown. If not, the existing rule-level name/label search runs unchanged.

Updated the search input placeholder from "Filter by rule name or labels" to "Filter by rule name, labels, group, or file" so users can discover the new capability.

Fixes #18490

```release-notes
[ENHANCEMENT] UI: Rule health page search now also filters by group name and file name, not only by rule name and labels.
```
