### PR TITLE
promql: fix inconsistent labelset collision error for range vector functions

### DIFF
--- a/promql/bench_test.go
+++ b/promql/bench_test.go
@@ -827,3 +827,112 @@ func BenchmarkParser(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkRangeVectorLabelsetMerge measures the overhead introduced by
+// mergeSeriesWithSameLabelset compared to the previous ContainsSameLabelset check.
+// In the no-collision path (common case), mergeSeriesWithSameLabelset calls
+// ContainsSameLabelset as a fast path and returns early, so the added cost is
+// one extra function call.
+func BenchmarkRangeVectorLabelsetMerge(b *testing.B) {
+	const (
+		intervalSec  = 60
+		numIntervals = 120
+	)
+
+	engineOpts := promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 50_000_000,
+		Timeout:    100 * time.Second,
+	}
+
+	appendSeries := func(b *testing.B, stor *teststorage.TestStorage, metrics []labels.Labels, stepRange [2]int) {
+		b.Helper()
+		ctx := context.Background()
+		refs := make([]storage.SeriesRef, len(metrics))
+		for s := stepRange[0]; s < stepRange[1]; s++ {
+			a := stor.Appender(ctx)
+			ts := int64(s) * intervalSec * 1000
+			for i, m := range metrics {
+				var err error
+				refs[i], err = a.Append(refs[i], m, ts, float64(s))
+				require.NoError(b, err)
+			}
+			require.NoError(b, a.Commit())
+		}
+		stor.ForceHeadMMap()
+	}
+
+	// NoCollision: each series has a unique id label so labelsets remain distinct
+	// after __name__ removal. This exercises the fast path in mergeSeriesWithSameLabelset.
+	for _, n := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("NoCollision/series=%d", n), func(b *testing.B) {
+			stor := teststorage.New(b)
+			stor.DisableCompactions()
+
+			metrics := make([]labels.Labels, n)
+			for i := range n {
+				metrics[i] = labels.FromStrings("__name__", fmt.Sprintf("bench_noc_%d", i), "id", strconv.Itoa(i))
+			}
+			appendSeries(b, stor, metrics, [2]int{0, numIntervals})
+
+			engine := promqltest.NewTestEngineWithOpts(b, engineOpts)
+			ctx := context.Background()
+			expr := `max_over_time({__name__=~"bench_noc_.*"}[5m])`
+			start := time.Unix(int64(numIntervals/2)*intervalSec, 0)
+			end := time.Unix(int64(numIntervals)*intervalSec, 0)
+			step := time.Duration(intervalSec) * time.Second
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				qry, err := engine.NewRangeQuery(ctx, stor, nil, expr, start, end, step)
+				require.NoError(b, err)
+				res := qry.Exec(ctx)
+				require.NoError(b, res.Err)
+				qry.Close()
+			}
+		})
+	}
+
+	// WithCollision: pairs of series share the same id after __name__ removal, but
+	// have data in non-overlapping time windows (>5m gap). mergeSeriesWithSameLabelset
+	// detects the collision, merges the samples, and confirms no timestamp conflicts.
+	// The old code would have errored here, so this case can only run after the fix.
+	for _, n := range []int{10, 100} {
+		b.Run(fmt.Sprintf("WithCollision/pairs=%d", n), func(b *testing.B) {
+			stor := teststorage.New(b)
+			stor.DisableCompactions()
+
+			metricsA := make([]labels.Labels, n)
+			metricsB := make([]labels.Labels, n)
+			for i := range n {
+				metricsA[i] = labels.FromStrings("__name__", "bench_col_a", "id", strconv.Itoa(i))
+				metricsB[i] = labels.FromStrings("__name__", "bench_col_b", "id", strconv.Itoa(i))
+			}
+			// bench_col_a: steps 0..49, bench_col_b: steps 70..119.
+			// The 20-step (20m) gap is larger than the 5m query window, so no timestamp
+			// overlap occurs between the two series at any query step.
+			appendSeries(b, stor, metricsA, [2]int{0, 50})
+			appendSeries(b, stor, metricsB, [2]int{70, numIntervals})
+
+			engine := promqltest.NewTestEngineWithOpts(b, engineOpts)
+			ctx := context.Background()
+			expr := `max_over_time({__name__=~"bench_col_.*"}[5m])`
+			// Start at step 70 so the window [65m..70m] only sees bench_col_b.
+			start := time.Unix(70*intervalSec, 0)
+			end := time.Unix(int64(numIntervals)*intervalSec, 0)
+			step := time.Duration(intervalSec) * time.Second
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				qry, err := engine.NewRangeQuery(ctx, stor, nil, expr, start, end, step)
+				require.NoError(b, err)
+				res := qry.Exec(ctx)
+				require.NoError(b, res.Err)
+				qry.Close()
+			}
+		})
+	}
+}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2291,8 +2291,8 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 			}, warnings
 		}
 
-		if !ev.enableDelayedNameRemoval && mat.ContainsSameLabelset() {
-			ev.errorf("vector cannot contain metrics with the same labelset")
+		if !ev.enableDelayedNameRemoval {
+			mat = ev.mergeSeriesWithSameLabelset(mat)
 		}
 		return mat, warnings
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -4051,6 +4051,26 @@ load 10m
 eval range from 0 to 20m step 10m -metric_a or -metric_b
     {} -1  -4
 
+# Test range vector functions with non-overlapping series that have the same labelset
+# after __name__ removal. This verifies the fix for issue #14695.
+# When evaluated as a range query, at each step only one series has data in the
+# window, so the results should merge correctly without collision.
+clear
+load 6m
+  metric_1{common="label"} 0 1 _ _ 4
+  metric_2{common="label"} _ _ 2 3 _
+
+eval range from 0 to 24m step 6m max_over_time({__name__=~"metric_.*"}[5m])
+  {common="label"} 0 1 2 3 4
+
+# Range vector function should fail when both series have data within the same window.
+clear
+load 6m
+  metric_1{common="label"} 0 1 2
+  metric_2{common="label"} 3 4 5
+
+eval_fail instant at 12m max_over_time({__name__=~"metric_.*"}[30m])
+
 `, engine)
 }
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix

Fixes #14695

#### Does this PR introduce a user-facing change?

```release-notes
[BUGFIX] PromQL: Range vector functions no longer raise a spurious "vector cannot contain metrics with the same labelset" error when series have different metric names but the same remaining labels, as long as their timestamps do not overlap within the evaluated range window
```

## What was happening

When querying with a range vector function such as `max_over_time()` or `rate()` using a selector that matched multiple metric names (for example `{__name__=~"metric_.*"}`), Prometheus would sometimes return an error saying the vector contained duplicate labelsets, even though the two series never had data at the same timestamp.

A simple reproduction:

```
load 6m
  metric_1{env="prod"} 0 1 _ _ 4
  metric_2{env="prod"} _ _ 2 3 _

eval range from 0 to 24m step 6m max_over_time({__name__=~"metric_.*"}[5m])
```

At each evaluation step only one of the two series had a sample inside the range window, so there was no real conflict. Yet Prometheus rejected the query entirely.

## Why it was inconsistent

Instant vector functions like `ceil()` already handled this correctly. They call `mergeSeriesWithSameLabelset()`, which groups series by their labelset, merges their samples, and only returns an error if two samples share the exact same timestamp after merging.

Range vector functions were using a different, simpler check: if the resulting matrix contained any two series with the same labelset at all, they immediately raised the error, without checking whether the timestamps actually overlapped.

## What this change does

The fix replaces the unconditional `ContainsSameLabelset()` check in the `parser.Call` branch of `evaluator.eval()` with a call to the existing `mergeSeriesWithSameLabelset()` function, making range vector functions consistent with instant vector functions.

Non-overlapping series are now merged into a single output series. Series that do share a timestamp within the same range window still produce an error, which is the correct and expected behavior.

## Testing

Two test cases were added to `TestEvaluationWithDelayedNameRemovalDisabled`, which evaluates with `EnableDelayedNameRemoval: false` and therefore exercises the exact code path changed here:

The first case verifies that two series with non-overlapping timestamps are merged and return the expected values.

The second case verifies that two series with overlapping timestamps within the same range window still fail as expected.

All existing PromQL tests continue to pass.