### PR TITLE
tsdb: guard chunk length overflow in IterateAllChunks

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -892,10 +892,32 @@ func (cdm *ChunkDiskMapper) IterateAllChunks(f func(seriesRef HeadSeriesRef, chu
 			chkEnc := chunkenc.Encoding(mmapFile.byteSlice.Range(idx, idx+ChunkEncodingSize)[0])
 			idx += ChunkEncodingSize
 			dataLen, n := binary.Uvarint(mmapFile.byteSlice.Range(idx, idx+MaxChunkLengthFieldSize))
+			if n <= 0 {
+				return &CorruptionErr{
+					Dir:       cdm.dir.Name(),
+					FileIndex: segID,
+					Err:       fmt.Errorf("reading chunk length failed with %d", n),
+				}
+			}
+			if dataLen > uint64(math.MaxInt) {
+				return &CorruptionErr{
+					Dir:       cdm.dir.Name(),
+					FileIndex: segID,
+					Err:       fmt.Errorf("chunk length %d exceeds supported size", dataLen),
+				}
+			}
+			dataLenInt := int(dataLen)
 			idx += n
 
 			numSamples := binary.BigEndian.Uint16(mmapFile.byteSlice.Range(idx, idx+2))
-			idx += int(dataLen) // Skip the data.
+			if idx > math.MaxInt-dataLenInt {
+				return &CorruptionErr{
+					Dir:       cdm.dir.Name(),
+					FileIndex: segID,
+					Err:       fmt.Errorf("chunk data end overflows supported size (idx=%d, len=%d)", idx, dataLenInt),
+				}
+			}
+			idx += dataLenInt // Skip the data.
 
 			// In the beginning we only checked for the chunk meta size.
 			// Now that we have added the chunk data length, we check for sufficient bytes again.

--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -910,18 +910,20 @@ func (cdm *ChunkDiskMapper) IterateAllChunks(f func(seriesRef HeadSeriesRef, chu
 			idx += n
 
 			numSamples := binary.BigEndian.Uint16(mmapFile.byteSlice.Range(idx, idx+2))
-			if idx > math.MaxInt-dataLenInt {
+			// We know idx <= fileEnd, so comparing against fileEnd-dataLenInt
+			// instead of idx+dataLenInt avoids any overflow of idx.
+			if idx > fileEnd-dataLenInt {
 				return &CorruptionErr{
 					Dir:       cdm.dir.Name(),
 					FileIndex: segID,
-					Err:       fmt.Errorf("chunk data end overflows supported size (idx=%d, len=%d)", idx, dataLenInt),
+					Err:       fmt.Errorf("head chunk file doesn't include enough bytes to read the chunk data - idx:%v, data length:%v, available:%v, file:%d", idx, dataLenInt, fileEnd, segID),
 				}
 			}
 			idx += dataLenInt // Skip the data.
 
 			// In the beginning we only checked for the chunk meta size.
 			// Now that we have added the chunk data length, we check for sufficient bytes again.
-			if idx+CRCSize > fileEnd {
+			if CRCSize > fileEnd-idx {
 				return &CorruptionErr{
 					Dir:       cdm.dir.Name(),
 					FileIndex: segID,

--- a/tsdb/chunks/head_chunks_test.go
+++ b/tsdb/chunks/head_chunks_test.go
@@ -14,8 +14,10 @@
 package chunks
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
+	"math"
 	"math/rand"
 	"os"
 	"strconv"
@@ -444,6 +446,77 @@ func TestHeadReadWriter_TruncateAfterFailedIterateChunks(t *testing.T) {
 
 	// Truncation call should not return error after IterateAllChunks fails.
 	require.NoError(t, hrw.Truncate(2000))
+}
+
+// TestHeadReadWriter_IterateChunksCorruptLength checks that IterateAllChunks
+// reports corruption, rather than panicking, when a chunk's length field on
+// disk is malformed.
+func TestHeadReadWriter_IterateChunksCorruptLength(t *testing.T) {
+	t.Parallel()
+
+	// dataLenOffset is the byte offset of the chunk length field of the first
+	// chunk in a freshly cut head chunk file.
+	dataLenOffset := int64(HeadChunkFileHeaderSize + SeriesRefSize + 2*MintMaxtSize + ChunkEncodingSize)
+
+	// largeLen encodes a chunk length that points well past the end of the file.
+	largeLen := make([]byte, MaxChunkLengthFieldSize)
+	binary.PutUvarint(largeLen, math.MaxUint32)
+
+	for _, tc := range []struct {
+		name string
+		// corrupt is written over the chunk length field on disk.
+		corrupt []byte
+	}{
+		{
+			// A length field made entirely of continuation bytes cannot be
+			// decoded as a uvarint.
+			name:    "unreadable length",
+			corrupt: bytes.Repeat([]byte{0x80}, MaxChunkLengthFieldSize),
+		},
+		{
+			name:    "length past file end",
+			corrupt: largeLen,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			hrw := createChunkDiskMapper(t, "")
+
+			var err error
+			awaitCb := make(chan struct{})
+			hrw.WriteChunk(1, 0, 1000, randomChunk(t), false, func(cbErr error) {
+				err = cbErr
+				close(awaitCb)
+			})
+			<-awaitCb
+			require.NoError(t, err)
+
+			dir := hrw.dir.Name()
+			require.NoError(t, hrw.Close())
+
+			// Corrupt the length field of the chunk we just wrote.
+			f, err := os.OpenFile(segmentFile(dir, 1), os.O_WRONLY, 0o666)
+			require.NoError(t, err)
+			_, err = f.WriteAt(tc.corrupt, dataLenOffset)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+
+			// Reopen directly (createChunkDiskMapper would fail iterating the
+			// corrupt file) and check that iteration reports corruption.
+			hrw, err = NewChunkDiskMapper(nil, dir, chunkenc.NewPool(), DefaultWriteBufferSize, writeQueueSize)
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, hrw.Close())
+			}()
+
+			err = hrw.IterateAllChunks(func(HeadSeriesRef, ChunkDiskMapperRef, int64, int64, uint16, chunkenc.Encoding, bool) error {
+				return nil
+			})
+			var corruptErr *CorruptionErr
+			require.ErrorAs(t, err, &corruptErr)
+		})
+	}
 }
 
 func TestHeadReadWriter_ReadRepairOnEmptyLastFile(t *testing.T) {


### PR DESCRIPTION
## Summary

PR #17533 (commit ae00fd45a) added overflow guards to `ChunkDiskMapper.Chunk()` when reading a chunk's per-chunk length uvarint from the mmapped head chunk segment. The same on-disk format is parsed a second time by `IterateAllChunks` (called during DB open, via `Head.Init`), but those guards were not mirrored there.

Without them, a corrupt or maliciously crafted head chunk segment can produce a varuint chunk-length that, when cast via `int(dataLen)`, wraps to a negative value on 32-bit platforms; the subsequent ``idx + CRCSize > fileEnd`` check then evaluates false (negative < non-negative) and the next ``byteSlice.Range`` call panics with ``slice bounds out of range`` during startup, before the existing CRC-and-bounds checks fire.

This PR applies the same three guards used by ``Chunk()``:

- Reject ``n <= 0`` from ``binary.Uvarint`` as a corruption error.
- Reject ``dataLen > math.MaxInt`` before casting to int.
- Check ``idx + dataLenInt`` for overflow before incrementing.

The guards convert what would have been a panic into a ``CorruptionErr``, matching how every other corruption path in this file behaves and making the two parsing sites consistent.

No new test was added: PR #17533 made the same change in the sibling code path without adding a regression test (the test surface for these guards requires hand-crafting bytes inside a head chunk file). Mirroring that precedent here.

## Test plan

- [x] ``go build ./tsdb/chunks/``
- [x] ``go test ./tsdb/chunks/`` (passes; existing corruption tests unaffected)
- [x] ``go vet ./tsdb/chunks/``

```release-notes
[BUGFIX] tsdb: Guard chunk length overflow in IterateAllChunks during head chunk replay, mirroring the equivalent guards in Chunk().
```