### PR TITLE
tsdb: log all errors during exemplar WAL replay

### DIFF
--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -142,10 +142,8 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 				missingSeries[e.Ref] = struct{}{}
 				continue
 			}
-			// At the moment the only possible error here is out of order exemplars, which we shouldn't see when
-			// replaying the WAL, so lets just log the error if it's not that type.
 			err = h.exemplars.AddExemplar(ms.labels(), exemplar.Exemplar{Ts: e.T, Value: e.V, Labels: e.Labels})
-			if err != nil && errors.Is(err, storage.ErrOutOfOrderExemplar) {
+			if err != nil {
 				h.logger.Warn("Unexpected error when replaying WAL on exemplar record", "err", err)
 			}
 		}


### PR DESCRIPTION
## Summary

The condition introduced years ago for logging exemplar errors during WAL replay was inverted relative to its own comment.

```go
// At the moment the only possible error here is out of order exemplars, which we shouldn't see when
// replaying the WAL, so lets just log the error if it's not that type.
err = h.exemplars.AddExemplar(...)
if err != nil && errors.Is(err, storage.ErrOutOfOrderExemplar) {
    h.logger.Warn("Unexpected error when replaying WAL on exemplar record", "err", err)
}
```

The comment says "log if it's not that type" but the code logs only when the error **is** ``ErrOutOfOrderExemplar`` and silently drops every other error class.

``CircularExemplarStorage.AddExemplar`` can in fact return ``ErrExemplarsDisabled``, label-length errors via ``validateExemplar``, and ``ErrOutOfOrderExemplar`` (it does not return ``ErrDuplicateExemplar`` because that case is filtered to ``nil``). None of these are expected during WAL replay, so log every non-nil error and rewrite the comment to match.

Also fixes a small typo in the doc comment for ``storage.ErrOutOfOrderST`` in the same area (``the then`` -> ``than the``).

## Test plan

- [x] ``go build ./tsdb/ ./storage/``
- [x] ``go test ./tsdb/ -run "TestWAL|TestHead.*Replay|TestHead.*Exemplar|TestExemplar"``
- [x] No behavioural change for the OOO case (still logged, same message); previously-silent error classes will now produce a warning.

```release-notes
[BUGFIX] tsdb: Surface all errors during exemplar WAL replay; previously only out-of-order errors were logged.
```