### PR TITLE
promql: reject NaN/Inf and fix overflow bound in duration expressions

### DIFF
--- a/promql/durations.go
+++ b/promql/durations.go
@@ -87,10 +87,21 @@ func (v *durationVisitor) calculateDuration(expr parser.Expr, allowedNegative bo
 	if err != nil {
 		return 0, err
 	}
+	// Reject NaN and infinities up front. NaN compares false against everything,
+	// so without this guard a NaN duration would slip past the bounds check
+	// below and produce an implementation-defined int64 in the time.Duration
+	// conversion at the end of this function.
+	if math.IsNaN(duration) || math.IsInf(duration, 0) {
+		return 0, fmt.Errorf("%d:%d: duration is NaN or infinite", expr.PositionRange().Start, expr.PositionRange().End)
+	}
 	if duration <= 0 && !allowedNegative {
 		return 0, fmt.Errorf("%d:%d: duration must be greater than 0", expr.PositionRange().Start, expr.PositionRange().End)
 	}
-	if duration > 1<<63-1 || duration < -1<<63 {
+	// duration is in seconds; the conversion below produces nanoseconds in an
+	// int64, so the safe input range is +/- math.MaxInt64 / 1e9 seconds. Match
+	// the bound used by the parser for duration literals (see
+	// offset_duration_expr in generated_parser.y).
+	if duration > 1<<63/1e9 || duration < -(1<<63)/1e9 {
 		return 0, fmt.Errorf("%d:%d: duration is out of range", expr.PositionRange().Start, expr.PositionRange().End)
 	}
 	return time.Duration(duration*1000) * time.Millisecond, nil

--- a/promql/durations_test.go
+++ b/promql/durations_test.go
@@ -266,6 +266,37 @@ func TestCalculateDuration(t *testing.T) {
 			},
 			errorMessage: "modulo by zero",
 		},
+		{
+			name: "NaN from negative base raised to fractional power",
+			expr: &parser.DurationExpr{
+				LHS: &parser.NumberLiteral{Val: -1},
+				RHS: &parser.NumberLiteral{Val: 0.5},
+				Op:  parser.POW,
+			},
+			errorMessage:    "duration is NaN or infinite",
+			allowedNegative: true,
+		},
+		{
+			name: "infinity from huge power",
+			expr: &parser.DurationExpr{
+				LHS: &parser.NumberLiteral{Val: 2},
+				RHS: &parser.NumberLiteral{Val: 1e10},
+				Op:  parser.POW,
+			},
+			errorMessage: "duration is NaN or infinite",
+		},
+		{
+			name:         "duration exceeds time.Duration range",
+			expr:         &parser.NumberLiteral{Val: 1e10},
+			errorMessage: "duration is out of range",
+		},
+		{
+			name: "duration just below the upper bound is accepted",
+			expr: &parser.NumberLiteral{Val: 1e9},
+			// 1e9 seconds is below 1<<63/1e9 seconds (~9.22e9), so it is
+			// representable as a time.Duration. The exact value is preserved.
+			expected: time.Duration(1e9) * time.Second,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

``calculateDuration`` in ``promql/durations.go`` converts a ``float64`` seconds value into a ``time.Duration`` (int64 nanoseconds) via ``time.Duration(duration*1000) * time.Millisecond``. Two related issues let invalid input slip through:

1. **Overflow bound is in the wrong unit.** The check was

   ```go
   if duration > 1<<63-1 || duration < -1<<63 {
   ```

   That compares a value in **seconds** against the **nanosecond** range of int64. The actual safe input range is ``+/- math.MaxInt64 / 1e9`` seconds (about 292 years), roughly 1e9 times tighter. Arithmetic on legal duration literals via DurationExpr (e.g. ``MUL`` / ``POW`` operators) could produce a finite seconds value that passed the check but overflowed during the final ``time.Duration`` conversion, yielding an implementation-defined int64 silently flowing into selector ``Range``, ``OriginalOffset``, and ``Step``. The parser already uses the correct bound for duration **literals** in ``offset_duration_expr`` (``1<<63 / 1e9``); this PR aligns ``calculateDuration`` with it.

2. **NaN bypasses every check.** ``NaN`` compares false against everything, so a NaN duration produced by e.g. ``math.Pow(-1, 0.5)`` (and similar via ``MOD``) bypassed both the negative-value check and the magnitude check, again producing an implementation-defined int64 in the conversion. ``+/-Inf`` on the negative side has the same problem.

## Fix

Reject ``NaN`` and ``+/-Inf`` up front, and align the magnitude bound with ``offset_duration_expr`` in ``generated_parser.y`` (``1<<63 / 1e9``).

```go
if math.IsNaN(duration) || math.IsInf(duration, 0) {
    return 0, fmt.Errorf("...: duration is NaN or infinite")
}
...
if duration > 1<<63/1e9 || duration < -(1<<63)/1e9 {
    return 0, fmt.Errorf("...: duration is out of range")
}
```

## Tests

Added regression cases in ``promql/durations_test.go`` covering:

- NaN from ``(-1) ^ 0.5`` (with ``allowedNegative: true`` so this case isn't trapped earlier).
- ``+Inf`` from ``2 ^ 1e10``.
- ``1e10`` seconds rejected as out of range.
- ``1e9`` seconds (just under the new bound) accepted with the exact expected ``time.Duration`` value.

All four would have failed against the previous code (silently producing a bogus ``time.Duration`` value or accepting a value that overflows the conversion).

## Test plan

- [x] ``go test ./promql/ -run "TestCalculateDuration|TestDurationVisitor"`` (4 new sub-tests, all 16 originals pass)
- [x] ``go test ./promql/ -short``
- [x] ``go vet ./promql/``

```release-notes
[BUGFIX] PromQL: Reject NaN, infinite, and out-of-range duration expressions instead of silently producing an out-of-range time.Duration.
```