### PR TITLE
promql: ignore metadata labels in default vector matching

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1458,6 +1458,9 @@ func (ev *evaluator) rangeEval(ctx context.Context, matching *parser.VectorMatch
 			}
 		} else { // "without"
 			names = append([]string{labels.MetricName}, names...)
+			if ev.enableTypeAndUnitLabels {
+				names = append(names, model.MetricTypeLabel, model.MetricUnitLabel)
+			}
 			slices.Sort(names)
 			sigf = func(lset labels.Labels) string {
 				return string(lset.BytesWithoutLabels(buf, names...))

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3563,6 +3563,36 @@ histogram {{sum:4 count:4 buckets:[2 2]}} {{sum:6 count:6 buckets:[3 3]}} {{sum:
 	})
 }
 
+func TestTypeAndUnitLabelsBinaryVectorMatching(t *testing.T) {
+	input := `
+load 1m
+	metric_a{job="api-server", __type__="counter", __unit__="request"} 10
+	metric_b{job="api-server", __type__="counter", __unit__="request"} 4
+
+eval instant at 1m (metric_a - metric_b) / metric_a
+	{job="api-server"} 0.6
+`
+
+	for _, delayedNameRemoval := range []bool{false, true} {
+		t.Run(fmt.Sprintf("delayed_name_removal=%t", delayedNameRemoval), func(t *testing.T) {
+			engine := promqltest.NewTestEngineWithOpts(t, promql.EngineOpts{
+				Logger:                   nil,
+				Reg:                      nil,
+				MaxSamples:               promqltest.DefaultMaxSamplesPerQuery,
+				Timeout:                  100 * time.Second,
+				NoStepSubqueryIntervalFn: func(int64) int64 { return int64((1 * time.Minute / time.Millisecond / time.Nanosecond)) },
+				EnableAtModifier:         true,
+				EnableNegativeOffset:     true,
+				EnableDelayedNameRemoval: delayedNameRemoval,
+				EnableTypeAndUnitLabels:  true,
+				Parser:                   parser.NewParser(promqltest.TestParserOpts),
+			})
+
+			promqltest.RunTest(t, input, engine)
+		})
+	}
+}
+
 func TestRateAnnotations(t *testing.T) {
 	testCases := map[string]struct {
 		data                       string


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18635

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] PromQL: Fix binary operations returning no data when the `type-and-unit-labels` feature flag adds metadata labels to one side of a vector match.
```

This treats `__type__` and `__unit__` like `__name__` when building default binary vector matching signatures while `type-and-unit-labels` is enabled.

I added a regression test for `(metric_a - metric_b) / metric_a`, where the arithmetic intermediate drops metadata labels but the denominator still has them.

Tests:

- `/usr/local/go/bin/go test ./promql -run TestTypeAndUnitLabelsBinaryVectorMatching -count=1`
- `/usr/local/go/bin/go test ./promql -run 'TestTypeAndUnitLabelsBinaryVectorMatching|TestRateAnnotations' -count=1`
- `/usr/local/go/bin/go test ./promql -count=1`