### PR TITLE
relabel: fix JSON and YAML serialization with empty separator or replacement

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -228,10 +228,10 @@ func (re *Regexp) UnmarshalYAML(unmarshal func(any) error) error {
 
 // MarshalYAML implements the yaml.Marshaler interface.
 func (re Regexp) MarshalYAML() (any, error) {
-	if re.String() != "" {
-		return re.String(), nil
+	if re.Regexp == nil {
+		return nil, nil
 	}
-	return nil, nil
+	return re.String(), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -88,7 +88,7 @@ type Config struct {
 	// with the configured separator in order.
 	SourceLabels model.LabelNames `yaml:"source_labels,flow,omitempty" json:"source_labels,omitempty"`
 	// Separator is the string between concatenated values from the source labels.
-	Separator string `yaml:"separator" json:"separator,omitempty"`
+	Separator string `yaml:"separator" json:"separator"`
 	// Regex against which the concatenation is matched.
 	Regex Regexp `yaml:"regex,omitempty" json:"regex,omitempty"`
 	// Modulus to take of the hash of concatenated values from the source labels.
@@ -97,7 +97,7 @@ type Config struct {
 	// Regexp interpolation is allowed for the replace action.
 	TargetLabel string `yaml:"target_label,omitempty" json:"target_label,omitempty"`
 	// Replacement is the regex replacement pattern to be used.
-	Replacement string `yaml:"replacement" json:"replacement,omitempty"`
+	Replacement string `yaml:"replacement" json:"replacement"`
 	// Action is the action to be performed for the relabeling.
 	Action Action `yaml:"action,omitempty" json:"action,omitempty"`
 	// NameValidationScheme to use when validating labels.

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -88,7 +88,7 @@ type Config struct {
 	// with the configured separator in order.
 	SourceLabels model.LabelNames `yaml:"source_labels,flow,omitempty" json:"source_labels,omitempty"`
 	// Separator is the string between concatenated values from the source labels.
-	Separator string `yaml:"separator,omitempty" json:"separator,omitempty"`
+	Separator string `yaml:"separator" json:"separator,omitempty"`
 	// Regex against which the concatenation is matched.
 	Regex Regexp `yaml:"regex,omitempty" json:"regex,omitempty"`
 	// Modulus to take of the hash of concatenated values from the source labels.
@@ -97,7 +97,7 @@ type Config struct {
 	// Regexp interpolation is allowed for the replace action.
 	TargetLabel string `yaml:"target_label,omitempty" json:"target_label,omitempty"`
 	// Replacement is the regex replacement pattern to be used.
-	Replacement string `yaml:"replacement,omitempty" json:"replacement,omitempty"`
+	Replacement string `yaml:"replacement" json:"replacement,omitempty"`
 	// Action is the action to be performed for the relabeling.
 	Action Action `yaml:"action,omitempty" json:"action,omitempty"`
 	// NameValidationScheme to use when validating labels.

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -1157,15 +1157,15 @@ func TestRegexp_JSONUnmarshalThenMarshal(t *testing.T) {
 	}{
 		{
 			name:  "Empty regex",
-			input: `{"regex":""}`,
+			input: `{"separator":"","regex":"","replacement":""}`,
 		},
 		{
 			name:  "string literal",
-			input: `{"regex":"foo"}`,
+			input: `{"separator":"","regex":"foo","replacement":""}`,
 		},
 		{
 			name:  "regex",
-			input: `{"regex":".*foo.*"}`,
+			input: `{"separator":"","regex":".*foo.*","replacement":""}`,
 		},
 	}
 	for _, test := range tests {

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -1109,6 +1109,19 @@ replacement: $1
 action: replace
 `,
 		},
+		{
+			// https://github.com/prometheus/prometheus/issues/18652:
+			// explicit empty separator/replacement must survive a YAML round-trip
+			// because they are distinct from the defaults (";" and "$1").
+			name: "Explicit empty separator and replacement",
+			inputYaml: `source_labels: [namespace, k8s_app]
+separator: ""
+regex: kube-systemcilium
+target_label: target_cluster
+replacement: ""
+action: replace
+`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -1111,12 +1111,12 @@ action: replace
 		},
 		{
 			// https://github.com/prometheus/prometheus/issues/18652:
-			// explicit empty separator/replacement must survive a YAML round-trip
-			// because they are distinct from the defaults (";" and "$1").
+			// explicit empty separator/replacement/regex must survive a YAML round-trip
+			// because they are distinct from the defaults (";", "$1", "(.*)").
 			name: "Explicit empty separator and replacement",
 			inputYaml: `source_labels: [namespace, k8s_app]
 separator: ""
-regex: kube-systemcilium
+regex: ""
 target_label: target_cluster
 replacement: ""
 action: replace


### PR DESCRIPTION
`UnmarshalYAML` seeds `DefaultRelabelConfig` (`;` / `$1`, both non-empty).   
An empty `Separator`/`Replacement` in memory only happens when the user explicitly set them so.  
`omitempty` is a wrong intent for these fields.

#### Which issue(s) does the PR fix:
Fixes #18652 

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[CHANGE] Relabel: config now serializes to JSON and YAML an empty `separator` or `replacement` value as `""`
```

#### Notes
- Better solution would be changing field types from `string` to `*string`. But it is a public package used by external code, and a SemVer-major break - every external caller reading `cfg.Separator` or constructing `Config{...}` literals breaks at compile time.
- ~I do not fix the same issue for JSON, because it has no `UnmarshalJSON` with defaults.~ Which is tested:
https://github.com/prometheus/prometheus/blob/6a1ca18ec82aa0b67716f1e3eb26fc7b25871e04/model/relabel/relabel_test.go#L1160
i.e. `{"regex":""}` unmarshal from JSON does not lead to struct with default `separator: ;`, but with go-type-defaults (`separator: ""`)
- Another possible improvement here is to drop default values on serialization. That would make own prometheus web-UI `/config` view much shorter and cleaner. Would also touch `TestConfig_UnmarshalThenMarshal` cases. Before:
  ```yaml
  source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
  separator: ;
  regex: \\d+
  target_label: __meta_kubernetes_pod_container_port_number
  replacement: $1
  action: replace
  ```
  After:
  ```yaml
  source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
  regex: \\d+
  target_label: __meta_kubernetes_pod_container_port_number
  ```
  I can add it to this PR if you also find it useful.