### PR TITLE
ui: add optional refresh interval to alerts page

### DIFF
--- a/web/ui/mantine-ui/src/api/api.ts
+++ b/web/ui/mantine-ui/src/api/api.ts
@@ -118,13 +118,14 @@ export const useAPIQuery = <T>({
   });
 };
 
-export const useSuspenseAPIQuery = <T>({ key, path, params }: QueryOptions) => {
+export const useSuspenseAPIQuery = <T>({ key, path, params, refetchInterval }: QueryOptions) => {
   const { pathPrefix } = useSettings();
 
   return useSuspenseQuery<SuccessAPIResponse<T>>({
     queryKey: key !== undefined ? key : [path, params],
     retry: false,
     refetchOnWindowFocus: false,
+    refetchInterval,
     staleTime: Infinity, // Required for suspense queries since the component is briefly unmounted when loading the data, which together with a gcTime of 0 will cause the data to be garbage collected before it can be used.
     gcTime: 0,
     queryFn: createQueryFn({ pathPrefix, path, params }),

--- a/web/ui/mantine-ui/src/pages/AlertsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.tsx
@@ -14,6 +14,7 @@ import {
   Pagination,
   rem,
   Divider,
+  Select,
 } from "@mantine/core";
 import { useSuspenseAPIQuery } from "../api/api";
 import { AlertingRule, AlertingRulesResult } from "../api/responseTypes/rules";
@@ -152,13 +153,26 @@ const buildAlertsPageData = (
 // computations to re-run as long as no state filter is selected.
 const emptyStateFilter: string[] = [];
 
+const refreshIntervals: Record<string, false | number> = {
+  "": false,
+  "30s": 30_000,
+  "1m": 60_000,
+  "5m": 5 * 60_000,
+};
+
 export default function AlertsPage() {
+  const [refreshInterval, setRefreshInterval] = useQueryParam(
+    "refresh",
+    withDefault(StringParam, "")
+  );
+
   // Fetch the alerting rules data.
   const { data } = useSuspenseAPIQuery<AlertingRulesResult>({
     path: `/rules`,
     params: {
       type: "alert",
     },
+    refetchInterval: refreshIntervals[refreshInterval || ""] ?? false,
   });
 
   const { showAnnotations } = useSettings();
@@ -454,6 +468,19 @@ export default function AlertsPage() {
             setSearchFilter(event.currentTarget.value || null)
           }
         ></TextInput>
+        <Select
+          w={240}
+          label={null}
+          aria-label="Refresh interval"
+          data={[
+            { value: "", label: "Refresh: Never" },
+            { value: "30s", label: "Refresh: 30s" },
+            { value: "1m", label: "Refresh: 1m" },
+            { value: "5m", label: "Refresh: 5m" },
+          ]}
+          value={refreshInterval || ""}
+          onChange={(value) => setRefreshInterval(value || null)}
+        />
       </Group>
       {alertsPageData.groups.length === 0 ? (
         <Alert title="No rules found" icon={<IconInfoCircle />}>


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #4440

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[ENHANCEMENT] UI: Add an optional refresh interval dropdown to the alerts page.
```

#### Additional information

This PR adds an optional refresh interval dropdown to the Alerts page.

The dropdown defaults to `Never`, and users can select an interval such as `30s`, `1m`, or `5m`. The selected value is stored in the URL, so it survives a page reload and can be shared as part of the link.

The implementation only refetches the alerts data query instead of reloading the entire page.

#### Testing

- `npm test`
- `npm run lint`