### PR TITLE
ui: escape label values in PromQL autocomplete

### DIFF
--- a/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
@@ -1569,11 +1569,13 @@ describe('autocomplete promQL test', () => {
             type: 'text',
           },
           {
-            label: '\\\\x2d',
+            label: '\\x2d',
+            apply: '\\\\x2d',
             type: 'text',
           },
           {
-            label: 'quoted\\"value',
+            label: 'quoted"value',
+            apply: 'quoted\\"value',
             type: 'text',
           },
         ],

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
@@ -1566,6 +1566,7 @@ describe('autocomplete promQL test', () => {
         options: [
           {
             label: 'demo',
+            apply: 'demo',
             type: 'text',
           },
           {

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
@@ -1568,6 +1568,14 @@ describe('autocomplete promQL test', () => {
             label: 'demo',
             type: 'text',
           },
+          {
+            label: '\\\\x2d',
+            type: 'text',
+          },
+          {
+            label: 'quoted\\"value',
+            type: 'text',
+          },
         ],
         from: 25,
         to: 25,

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -168,6 +168,10 @@ function arrayToCompletionResult(data: Completion[], from: number, to: number, i
   } as CompletionResult;
 }
 
+function escapePromQLString(str: string): string {
+  return str.replace(/([\\"])/g, '\\$1');
+}
+
 // computeEndCompletePosition calculates the end position for autocompletion replacement.
 // When the cursor is in the middle of a token, this ensures the entire token is replaced,
 // not just the portion before the cursor. This fixes issue #15839.
@@ -794,7 +798,7 @@ export class HybridComplete implements CompleteStrategy {
       return result;
     }
     return this.prometheusClient.labelValues(context.labelName, context.metricName, context.matchers).then((labelValues: string[]) => {
-      return result.concat(labelValues.map((value) => ({ label: value, type: 'text' })));
+      return result.concat(labelValues.map((value) => ({ label: escapePromQLString(value), type: 'text' })));
     });
   }
 }

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -169,6 +169,9 @@ function arrayToCompletionResult(data: Completion[], from: number, to: number, i
 }
 
 function escapePromQLString(str: string): string {
+  // PromQL only evaluates escape sequences in single- and double-quoted strings.
+  // Backtick-quoted string completions are not handled separately today, so keep
+  // the inserted value escaped unconditionally.
   return str.replace(/([\\"])/g, '\\$1');
 }
 
@@ -798,7 +801,7 @@ export class HybridComplete implements CompleteStrategy {
       return result;
     }
     return this.prometheusClient.labelValues(context.labelName, context.metricName, context.matchers).then((labelValues: string[]) => {
-      return result.concat(labelValues.map((value) => ({ label: escapePromQLString(value), type: 'text' })));
+      return result.concat(labelValues.map((value) => ({ label: value, apply: escapePromQLString(value), type: 'text' })));
     });
   }
 }

--- a/web/ui/module/codemirror-promql/src/test/label_env_values.json
+++ b/web/ui/module/codemirror-promql/src/test/label_env_values.json
@@ -1,6 +1,8 @@
 {
   "status": "success",
   "data": [
-    "demo"
+    "demo",
+    "\\x2d",
+    "quoted\"value"
   ]
 }


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #11629

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] UI: Escape label values offered by PromQL autocomplete.
```