### PR TITLE
promql: set Schema in HistogramStatsIterator to detect schema mix

### DIFF
--- a/promql/histogram_stats_iterator.go
+++ b/promql/histogram_stats_iterator.go
@@ -86,10 +86,14 @@ func (*HistogramStatsIterator) AtHistogram(*histogram.Histogram) (int64, *histog
 // performs a counter reset detection on the fly. It will return an explicit
 // hint (not UnknownCounterReset) if the previous sample has been accessed with
 // the same iterator.
+//
+// The returned histogram contains only Count, Sum, CounterResetHint, and Schema.
+// Bucket data is intentionally omitted.
 func (hsi *HistogramStatsIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
 	populateFH := func(src *histogram.FloatHistogram, detectReset bool) {
 		h := histogram.FloatHistogram{
 			CounterResetHint: src.CounterResetHint,
+			Schema:           src.Schema,
 			Count:            src.Count,
 			Sum:              src.Sum,
 		}

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1118,6 +1118,13 @@ eval instant at 1m30s rate(some_metric[1m30s])
     expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "some_metric"
     # Should produce no results.
 
+# histogram_count(rate()) must also warn when the schema mix falls inside the stats-only
+# path (HistogramStatsIterator). Without Schema being set in that iterator, all histograms
+# appear as Schema=0 and the custom-bucket mismatch is silently missed.
+eval instant at 1m histogram_count(rate(some_metric[1m30s]))
+    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "some_metric"
+    # Should produce no results.
+
 # Start with custom, end with exponential. Return the exponential histogram divided by 48.
 # (The 1st sample is the NHCB with count:1. It is mostly ignored with the exception of the
 # count, which means the rate calculation extrapolates until the count hits 0.)


### PR DESCRIPTION
Without Schema being propagated in HistogramStatsIterator, histograms served through the stats-only path (e.g. histogram_count(rate(...))) all appear as Schema=0, causing the exponential/custom-bucket mismatch detection to be silently skipped.

Add a test that exercises histogram_count(rate()) over a series with mixed exponential and custom bucket schemas to verify the warning is emitted.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] PromQL: Fix missing warning when mixing exponential and custom-bucket histograms in stats queries.
```
