### PR TITLE
promql: sort scientific notation label values numerically

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -726,11 +727,7 @@ func funcSortByLabel(vectorVals []Vector, _ Matrix, args parser.Expressions, _ *
 				continue
 			}
 
-			if natsort.Compare(lv1, lv2) {
-				return -1
-			}
-
-			return +1
+			return naturalLabelCompare(lv1, lv2)
 		}
 
 		// If all labels provided as arguments were equal, sort by the full label set. This ensures a consistent ordering.
@@ -752,11 +749,7 @@ func funcSortByLabelDesc(vectorVals []Vector, _ Matrix, args parser.Expressions,
 				continue
 			}
 
-			if natsort.Compare(lv1, lv2) {
-				return +1
-			}
-
-			return -1
+			return -naturalLabelCompare(lv1, lv2)
 		}
 
 		// If all labels provided as arguments were equal, sort by the full label set. This ensures a consistent ordering.
@@ -764,6 +757,32 @@ func funcSortByLabelDesc(vectorVals []Vector, _ Matrix, args parser.Expressions,
 	})
 
 	return vectorVals[0], nil
+}
+
+func naturalLabelCompare(a, b string) int {
+	if af, aok := parseFiniteLabelFloat(a); aok {
+		if bf, bok := parseFiniteLabelFloat(b); bok {
+			if af < bf {
+				return -1
+			}
+			if af > bf {
+				return 1
+			}
+		}
+	}
+
+	if natsort.Compare(a, b) {
+		return -1
+	}
+	return 1
+}
+
+func parseFiniteLabelFloat(s string) (float64, bool) {
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil || math.IsInf(f, 0) || math.IsNaN(f) {
+		return 0, false
+	}
+	return f, true
 }
 
 func clamp(vec Vector, minVal, maxVal float64, enh *EvalNodeHelper) (Vector, annotations.Annotations) {

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -750,6 +750,19 @@ load 5m
 	node_uname_info{job="node_exporter", instance="4m600", release="1.2.3"} 0+10x10
 	node_uname_info{job="node_exporter", instance="4m5", release="1.11.3"} 0+10x10
 	node_uname_info{job="node_exporter", instance="4m1000", release="1.111.3"} 0+10x10
+	response_size_bucket{le="+Inf"} 0+1x10
+	response_size_bucket{le="100"} 0+1x10
+	response_size_bucket{le="100.0"} 0+1x10
+	response_size_bucket{le="1000"} 0+1x10
+	response_size_bucket{le="1000.0"} 0+1x10
+	response_size_bucket{le="10000"} 0+1x10
+	response_size_bucket{le="10000.0"} 0+1x10
+	response_size_bucket{le="100000"} 0+1x10
+	response_size_bucket{le="100000.0"} 0+1x10
+	response_size_bucket{le="1e+06"} 0+1x10
+	response_size_bucket{le="1e+07"} 0+1x10
+	response_size_bucket{le="1e+08"} 0+1x10
+	response_size_bucket{le="1e+09"} 0+1x10
 
 eval instant at 50m sort_by_label(http_requests, "instance")
 	expect ordered
@@ -879,6 +892,37 @@ eval instant at 50m sort_by_label(node_uname_info, "release")
 	node_uname_info{job="node_exporter", instance="4m600", release="1.2.3"} 100
 	node_uname_info{job="node_exporter", instance="4m5", release="1.11.3"} 100
 	node_uname_info{job="node_exporter", instance="4m1000", release="1.111.3"} 100
+
+eval instant at 50m sort_by_label(response_size_bucket, "le")
+	expect ordered
+	response_size_bucket{le="+Inf"} 10
+	response_size_bucket{le="100"} 10
+	response_size_bucket{le="100.0"} 10
+	response_size_bucket{le="1000"} 10
+	response_size_bucket{le="1000.0"} 10
+	response_size_bucket{le="10000"} 10
+	response_size_bucket{le="10000.0"} 10
+	response_size_bucket{le="100000"} 10
+	response_size_bucket{le="100000.0"} 10
+	response_size_bucket{le="1e+06"} 10
+	response_size_bucket{le="1e+07"} 10
+	response_size_bucket{le="1e+08"} 10
+	response_size_bucket{le="1e+09"} 10
+
+eval instant at 50m sort_by_label_desc(response_size_bucket{le!="+Inf"}, "le")
+	expect ordered
+	response_size_bucket{le="1e+09"} 10
+	response_size_bucket{le="1e+08"} 10
+	response_size_bucket{le="1e+07"} 10
+	response_size_bucket{le="1e+06"} 10
+	response_size_bucket{le="100000.0"} 10
+	response_size_bucket{le="100000"} 10
+	response_size_bucket{le="10000.0"} 10
+	response_size_bucket{le="10000"} 10
+	response_size_bucket{le="1000.0"} 10
+	response_size_bucket{le="1000"} 10
+	response_size_bucket{le="100.0"} 10
+	response_size_bucket{le="100"} 10
 
 # Tests for double_exponential_smoothing
 clear


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #17799

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] PromQL: Sort numeric label values in scientific notation correctly in sort_by_label and sort_by_label_desc.
```
