### PR TITLE
promql: drop __type__ and __unit__ in default vector matching

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1457,7 +1457,7 @@ func (ev *evaluator) rangeEval(ctx context.Context, matching *parser.VectorMatch
 				return string(lset.BytesWithLabels(buf, names...))
 			}
 		} else { // "without"
-			names = append([]string{labels.MetricName}, names...)
+		    names = append([]string{labels.MetricName, model.MetricTypeLabel, model.MetricUnitLabel}, names...)
 			slices.Sort(names)
 			sigf = func(lset labels.Labels) string {
 				return string(lset.BytesWithoutLabels(buf, names...))

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1457,7 +1457,7 @@ func (ev *evaluator) rangeEval(ctx context.Context, matching *parser.VectorMatch
 				return string(lset.BytesWithLabels(buf, names...))
 			}
 		} else { // "without"
-			names = append([]string{labels.MetricName, model.MetricTypeLabel, model.MetricUnitLabel}, names...)
+			names = append([]string{model.MetricNameLabel, model.MetricTypeLabel, model.MetricUnitLabel}, names...)
 			slices.Sort(names)
 			sigf = func(lset labels.Labels) string {
 				return string(lset.BytesWithoutLabels(buf, names...))

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1457,7 +1457,7 @@ func (ev *evaluator) rangeEval(ctx context.Context, matching *parser.VectorMatch
 				return string(lset.BytesWithLabels(buf, names...))
 			}
 		} else { // "without"
-		    names = append([]string{labels.MetricName, model.MetricTypeLabel, model.MetricUnitLabel}, names...)
+			names = append([]string{labels.MetricName, model.MetricTypeLabel, model.MetricUnitLabel}, names...)
 			slices.Sort(names)
 			sigf = func(lset labels.Labels) string {
 				return string(lset.BytesWithoutLabels(buf, names...))

--- a/promql/promqltest/testdata/type_and_unit.test
+++ b/promql/promqltest/testdata/type_and_unit.test
@@ -262,7 +262,13 @@ eval instant at 50m http_requests_total{group="canary"} unless ignoring(group) h
 	http_requests_total{__type__="counter", __unit__="not-request", group="canary", instance="1", job="api-server"} 400
 	http_requests_total{group="canary", instance="1", job="app-server"} 800
 
+# Default vector matching is now transparent to __type__ / __unit__,
+# so different type/unit combos on lhs and rhs should still match.
 eval instant at 50m http_requests_total{group="canary"} / ignoring(group) http_requests_total{group="production"}
+	{instance="0", job="api-server"} 3
+	{instance="0", job="app-server"} 1.4
+	{instance="1", job="api-server"} 2
+	{instance="1", job="app-server"} 1.3333333333333333
 
 # Comparisons.
 eval instant at 50m SUM(http_requests_total) BY (job) > 1000
@@ -278,3 +284,22 @@ eval instant at 50m SUM(http_requests_total) BY (job) != bool SUM(http_requests_
 
 eval instant at 50m http_requests_total{job="api-server", instance="0", group="production"} == bool 100
 	{job="api-server", instance="0", group="production"} 1
+
+clear
+
+# B. Binary operations should be transparent to __type__ and __unit__ labels.
+# Verifies that (metric_a - metric_b) / metric_a works correctly and __type__/__unit__
+# do not cause label set mismatches in chained binary operations.
+
+load 5m
+  kubelet_volume_stats_capacity_bytes{__type__="gauge", __unit__="bytes", namespace="test", persistentvolumeclaim="data-0"} 100
+  kubelet_volume_stats_available_bytes{__type__="gauge", __unit__="bytes", namespace="test", persistentvolumeclaim="data-0"} 40
+
+# Subtraction should drop __type__ and __unit__ from result (like __name__)
+eval instant at 0m kubelet_volume_stats_capacity_bytes - kubelet_volume_stats_available_bytes
+  {namespace="test", persistentvolumeclaim="data-0"} 60
+
+# Division of binary op result by raw metric should work (not return empty)
+# This was broken before the fix - __type__ mismatch caused no data
+eval instant at 0m (kubelet_volume_stats_capacity_bytes - kubelet_volume_stats_available_bytes) / kubelet_volume_stats_capacity_bytes * 100
+  {namespace="test", persistentvolumeclaim="data-0"} 60

--- a/promql/promqltest/testdata/type_and_unit.test
+++ b/promql/promqltest/testdata/type_and_unit.test
@@ -262,8 +262,6 @@ eval instant at 50m http_requests_total{group="canary"} unless ignoring(group) h
 	http_requests_total{__type__="counter", __unit__="not-request", group="canary", instance="1", job="api-server"} 400
 	http_requests_total{group="canary", instance="1", job="app-server"} 800
 
-# Default vector matching is now transparent to __type__ / __unit__,
-# so different type/unit combos on lhs and rhs should still match.
 eval instant at 50m http_requests_total{group="canary"} / ignoring(group) http_requests_total{group="production"}
 	{instance="0", job="api-server"} 3
 	{instance="0", job="app-server"} 1.4
@@ -300,6 +298,6 @@ eval instant at 0m kubelet_volume_stats_capacity_bytes - kubelet_volume_stats_av
   {namespace="test", persistentvolumeclaim="data-0"} 60
 
 # Division of binary op result by raw metric should work (not return empty)
-# This was broken before the fix - __type__ mismatch caused no data
 eval instant at 0m (kubelet_volume_stats_capacity_bytes - kubelet_volume_stats_available_bytes) / kubelet_volume_stats_capacity_bytes * 100
   {namespace="test", persistentvolumeclaim="data-0"} 60
+


### PR DESCRIPTION
## Summary

When the `type-and-unit-labels` feature flag is enabled, chained binary
operations like `(metric_a - metric_b) / metric_a * 100` silently returned
no data because:
- Subtraction drops `__type__` from the result
- The denominator still carries `__type__="gauge"`
- Label sets no longer match → division returns nothing

This fix drops `__type__` and `__unit__` in binary operations similar to
how `__name__` is already handled. Since these are reserved labels that
users cannot set, this is a no-op when the feature flag is off.

Related discussion: prometheus/proposals#39, https://cloud-native.slack.com/archives/C167KFM6C/p1777882106059969

#### Which issue(s) does the PR fix:
Fixes #18635

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] PromQL: Drop __type__ and __unit__ in binary operations so they are transparent to users, similar to how __name__ is handled.
```
<img width="1104" height="154" alt="pic1" src="https://github.com/user-attachments/assets/80765f40-4d6d-4500-9a8b-b60749eacae7" />
<img width="1280" height="720" alt="WhatsApp Image 2026-05-12 at 1 34 57 PM" src="https://github.com/user-attachments/assets/d9035d19-374a-413b-bdfd-16c404837cc8" />
