### PR TITLE
remote: limit expanded label size in write v2 receiver

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -50,7 +50,16 @@ type writeHandler struct {
 	appendMetadata          bool
 }
 
-const maxAheadTime = 10 * time.Minute
+const (
+	maxAheadTime = 10 * time.Minute
+
+	// Keep the expanded labels accepted from a symbolized remote write 2.0
+	// request within the same envelope as the decoded request body accepted by
+	// the remote API.
+	maxRemoteWriteV2ExpandedLabelsBytes = 32 * 1024 * 1024
+
+	maxRemoteWriteErrMsgBytes = 4 * 1024
+)
 
 // NewWriteHandler creates a http.Handler that accepts remote write requests with
 // the given message in acceptedMsgs and writes them to the provided appendable.
@@ -308,13 +317,27 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 	var (
 		badRequestErrs                                   []error
 		outOfOrderExemplarErrs, samplesWithInvalidLabels int
+		expandedLabelsBytes                              uint64
+		expandedLabelsLimitReached                       bool
 
 		b = labels.NewScratchBuilder(0)
 	)
 	for _, ts := range req.Timeseries {
+		if expandedLabelsLimitReached {
+			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)
+			continue
+		}
+
 		ls, err := ts.ToLabels(&b, req.Symbols)
 		if err != nil {
 			badRequestErrs = append(badRequestErrs, fmt.Errorf("parsing labels for series %v: %w", ts.LabelsRefs, err))
+			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)
+			continue
+		}
+		seriesLabelsBytes := labelsByteSize(ls)
+		if total, ok := addExpandedLabelsBytes(&expandedLabelsBytes, seriesLabelsBytes); !ok {
+			badRequestErrs = append(badRequestErrs, expandedLabelsLimitError(total))
+			expandedLabelsLimitReached = true
 			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)
 			continue
 		}
@@ -474,8 +497,46 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 	if len(badRequestErrs) == 0 {
 		return samplesWithoutMetadata, 0, nil
 	}
-	// TODO(bwplotka): Better concat formatting? Perhaps add size limit?
-	return samplesWithoutMetadata, http.StatusBadRequest, errors.Join(badRequestErrs...)
+	return samplesWithoutMetadata, http.StatusBadRequest, joinErrorsWithLimit(badRequestErrs)
+}
+
+func addExpandedLabelsBytes(used *uint64, size uint64) (uint64, bool) {
+	if size > maxRemoteWriteV2ExpandedLabelsBytes {
+		return size, false
+	}
+	// The size check above keeps this subtraction from underflowing.
+	if *used > maxRemoteWriteV2ExpandedLabelsBytes-size {
+		return *used + size, false
+	}
+	*used += size
+	return *used, true
+}
+
+func labelsByteSize(ls labels.Labels) uint64 {
+	var size uint64
+	ls.Range(func(l labels.Label) {
+		size += uint64(len(l.Name) + len(l.Value))
+	})
+	return size
+}
+
+func expandedLabelsLimitError(total uint64) error {
+	return fmt.Errorf("expanded labels size exceeds remote write limit: total %d bytes, limit %d bytes", total, maxRemoteWriteV2ExpandedLabelsBytes)
+}
+
+func joinErrorsWithLimit(errs []error) error {
+	err := errors.Join(errs...)
+	if err == nil {
+		return nil
+	}
+
+	msg := err.Error()
+	if len(msg) <= maxRemoteWriteErrMsgBytes {
+		return err
+	}
+
+	const truncated = "\n... remote write error response truncated"
+	return errors.New(msg[:maxRemoteWriteErrMsgBytes-len(truncated)] + truncated)
 }
 
 // handleHistogramZeroSample appends ST as a zero-value sample with st value as the sample timestamp.

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -934,6 +934,132 @@ func TestRemoteWriteHandler_V2Message_NoDuplicateTypeAndUnitLabels(t *testing.T)
 	}
 }
 
+func TestRemoteWriteHandler_V2Message_RejectsExpandedLabelsOverLimit(t *testing.T) {
+	st := writev2.NewSymbolTable()
+	nameRef := st.Symbolize(labels.MetricName)
+	metricRef := st.Symbolize("test_metric")
+	largeValueRef := st.Symbolize(strings.Repeat("x", 32*1024))
+
+	labelRefs := []uint32{nameRef, metricRef}
+	for i := range 2048 {
+		labelRefs = append(labelRefs, st.Symbolize(fmt.Sprintf("x_%04d", i)), largeValueRef)
+	}
+
+	recorder, appendable := serveV2WriteRequest(t, []writev2.TimeSeries{{
+		LabelsRefs: labelRefs,
+		Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+	}}, st.Symbols())
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "expanded labels size exceeds remote write limit")
+	require.Empty(t, appendable.samples)
+}
+
+func TestRemoteWriteHandler_V2Message_RejectsCumulativeExpandedLabelsOverLimit(t *testing.T) {
+	st := writev2.NewSymbolTable()
+	nameRef := st.Symbolize(labels.MetricName)
+	largeValueRef := st.Symbolize(strings.Repeat("x", 32*1024))
+
+	buildRefs := func(metric string) []uint32 {
+		labelRefs := []uint32{nameRef, st.Symbolize(metric)}
+		for i := range 600 {
+			labelRefs = append(labelRefs, st.Symbolize(fmt.Sprintf("x_%04d", i)), largeValueRef)
+		}
+		return labelRefs
+	}
+
+	recorder, appendable := serveV2WriteRequest(t, []writev2.TimeSeries{
+		{
+			LabelsRefs: buildRefs("test_metric_1"),
+			Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+		},
+		{
+			LabelsRefs: buildRefs("test_metric_2"),
+			Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+		},
+		{
+			LabelsRefs: []uint32{nameRef, st.Symbolize("test_metric_3")},
+			Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+		},
+	}, st.Symbols())
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "expanded labels size exceeds remote write limit")
+	require.Len(t, appendable.samples, 1)
+	require.Equal(t, "test_metric_1", appendable.samples[0].l.Get(labels.MetricName))
+}
+
+func TestRemoteWriteHandler_V2Message_CountsInvalidSeriesTowardExpandedLabelsLimit(t *testing.T) {
+	st := writev2.NewSymbolTable()
+	largeValueRef := st.Symbolize(strings.Repeat("x", 32*1024))
+
+	buildRefs := func(metric string) []uint32 {
+		labelRefs := []uint32{}
+		if metric != "" {
+			labelRefs = append(labelRefs, st.Symbolize(labels.MetricName), st.Symbolize(metric))
+		}
+		for i := range 600 {
+			labelRefs = append(labelRefs, st.Symbolize(fmt.Sprintf("%s_%04d", metric, i)), largeValueRef)
+		}
+		return labelRefs
+	}
+
+	recorder, appendable := serveV2WriteRequest(t, []writev2.TimeSeries{
+		{
+			LabelsRefs: buildRefs(""),
+			Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+		},
+		{
+			LabelsRefs: buildRefs("test_metric"),
+			Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+		},
+	}, st.Symbols())
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "invalid metric name or labels")
+	require.Empty(t, appendable.samples)
+}
+
+func TestRemoteWriteHandler_V2Message_BoundsBadRequestErrorResponse(t *testing.T) {
+	st := writev2.NewSymbolTable()
+	labelRefs := []uint32{
+		st.Symbolize(labels.MetricName), st.Symbolize("test_metric"),
+		st.Symbolize("duplicate"), st.Symbolize(strings.Repeat("x", maxRemoteWriteErrMsgBytes*2)),
+		st.Symbolize("duplicate"), st.Symbolize("value"),
+	}
+
+	recorder, appendable := serveV2WriteRequest(t, []writev2.TimeSeries{{
+		LabelsRefs: labelRefs,
+		Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+	}}, st.Symbols())
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "invalid labels for series")
+	require.Contains(t, recorder.Body.String(), "remote write error response truncated")
+	// http.Error appends a trailing newline to the error message.
+	require.LessOrEqual(t, recorder.Body.Len(), maxRemoteWriteErrMsgBytes+len("\n"))
+	require.Empty(t, appendable.samples)
+}
+
+func serveV2WriteRequest(t *testing.T, timeSeries []writev2.TimeSeries, symbols []string) (*httptest.ResponseRecorder, *mockAppendable) {
+	t.Helper()
+
+	payload, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), timeSeries, symbols, nil, nil, nil, "snappy")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/write", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", remoteWriteContentTypeHeaders[remoteapi.WriteV2MessageType])
+	req.Header.Set("Content-Encoding", compression.Snappy)
+	req.Header.Set(RemoteWriteVersionHeader, RemoteWriteVersion20HeaderValue)
+
+	appendable := &mockAppendable{}
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	return recorder, appendable
+}
+
 // NOTE: V2 Message is tested in TestRemoteWriteHandler_V2Message.
 func TestOutOfOrderSample_V1Message(t *testing.T) {
 	for _, tc := range []struct {


### PR DESCRIPTION
## Summary
The remote write v2 symbol table allows a small decoded request to expand into a much larger set of materialized labels. A single string defined once in `Request.Symbols` can be referenced by many labels. The existing 32 MiB decoded request limit does not cover this post-expansion size.

This adds a per-request budget for expanded label bytes, using the same 32 MiB envelope as the decoded request limit. After symbol references are resolved, each series' label byte size is charged against the budget. Series that fail validation (e.g. missing metric name) still count, since the labels were already materialized. Once exceeded, remaining series are skipped without further symbol expansion. Partial-write behavior is preserved: series accepted before the limit are committed.

Bad-request error responses are also capped to 4 KiB. The existing error formatting embeds full expanded labelsets via `ls.String()`, which could produce responses proportional to the expanded label size. This addresses the existing TODO on error concatenation.

#### Which issue(s) does the PR fix:
None.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[ENHANCEMENT] Remote-Write: Limit total expanded remote write v2 labels to the existing 32 MiB request envelope. Cap bad-request error responses to 4 KiB.
```
