### PR TITLE
docs: state the anchored additivity invariant

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -353,6 +353,16 @@ Example query:
 
 **Note**: When using the anchored modifier with the increase function, the results returned are integers.
 
+**Composability (additive property)**: With `anchored`, `increase`, `rate`, and `delta` are *additive* over adjacent ranges. For any series `m` and timestamps `T₀ < T₁ < T₂` with `r₁ = T₁ − T₀` (≤ lookback delta) and `r₂ = T₂ − T₁`:
+
+```
+  increase(m[r₁]      anchored)  @ T₁
++ increase(m[r₂]      anchored)  @ T₂
+= increase(m[r₁ + r₂] anchored)  @ T₂
+```
+
+This invariant is what makes anchored `increase` composable: splitting a wider range into adjacent sub-ranges and summing the results gives the same answer as asking for the wider range directly — and it does this for any possible sub-ranges. See [#18679](https://github.com/prometheus/prometheus/issues/18679) for the precise statement and proposed invariant tests.
+
 ### `smoothed`
 
 In range selectors, linearly interpolates values at the range boundaries, using the sample values before and after the boundaries for an improved estimation that is robust against irregular scrapes and missing samples. However, it requires a sample after the evaluation interval to work properly, see note below.


### PR DESCRIPTION
## What this changes

`docs/feature_flags.md`, inside the `### anchored` subsection: appends a short callout that states the additive property of `anchored`-mode `increase` / `rate` / `delta`. The callout links to #18679 for the precise statement and the proposed invariant tests.

## Why

- The proposal already lists "Improved composability across range boundaries" as a use case (proposal 0052, line 222), but neither the proposal nor the user-facing docs say what *exactly* "composable" means.
- We've run `yincrease` / `yrate` / `ydelta` in production for ~3 years and the additive property is *the* reason it stays predictable and explainable under irregular scrapes, with no partition-boundary surprises. Putting it in writing here in feature-flag doc makes the guarantee easily discoverable.

Refs: #18679
