### PR TITLE
discovery: do not close static discovery update channel

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -166,8 +166,6 @@ func (StaticConfig) NewDiscovererMetrics(prometheus.Registerer, RefreshMetricsIn
 type staticDiscoverer []*targetgroup.Group
 
 func (c staticDiscoverer) Run(ctx context.Context, up chan<- []*targetgroup.Group) {
-	// TODO: existing implementation closes up chan, but documentation explicitly forbids it...?
-	defer close(up)
 	select {
 	case <-ctx.Done():
 	case up <- c:

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -14,8 +14,11 @@
 package discovery
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v2"
 )
@@ -33,4 +36,30 @@ func TestConfigsCustomUnMarshalMarshal(t *testing.T) {
 	output, err := yaml.Marshal(cfg)
 	require.NoError(t, err)
 	require.Equal(t, input, string(output))
+}
+
+func TestStaticDiscovererDoesNotCloseUpdates(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	up := make(chan []*targetgroup.Group, 1)
+	done := make(chan struct{})
+	go func() {
+		staticDiscoverer{{Source: "0"}}.Run(ctx, up)
+		close(done)
+	}()
+
+	require.Equal(t, []*targetgroup.Group{{Source: "0"}}, <-up)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("static discoverer did not return after sending targets")
+	}
+
+	select {
+	case _, ok := <-up:
+		require.True(t, ok, "static discoverer closed the update channel")
+	default:
+	}
 }

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -1256,8 +1256,6 @@ func (s lockStaticConfig) NewDiscoverer(DiscovererOptions) (Discoverer, error) {
 type lockStaticDiscoverer lockStaticConfig
 
 func (s lockStaticDiscoverer) Run(ctx context.Context, up chan<- []*targetgroup.Group) {
-	// TODO: existing implementation closes up chan, but documentation explicitly forbids it...?
-	defer close(up)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	select {


### PR DESCRIPTION
Static discovery closed the update channel when `Run` returned, even though the `Discoverer` interface documents that discoverers should not close the update channel.

This removes the channel close from static discovery and updates the matching test helper to follow the same contract. It also adds a regression test to verify that static discovery sends its target groups without closing the caller-owned channel.

```release-notes
NONE
```

Tests:

```text
go test -tags remove_all_sd ./discovery
```
