### PR TITLE
tsdb: Disable the stale series compaction config until the bug is fixed

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -761,7 +761,6 @@ func main() {
 		cfg.tsdb.BlockReloadInterval = model.Duration(1 * time.Second)
 	}
 	cfg.tsdb.OutOfOrderTimeWindow = cfgFile.StorageConfig.TSDBConfig.OutOfOrderTimeWindow
-	cfg.tsdb.StaleSeriesCompactionThreshold = cfgFile.StorageConfig.TSDBConfig.StaleSeriesCompactionThreshold
 	cfg.tsdb.RetentionDuration = cfgFile.StorageConfig.TSDBConfig.Retention.Time
 	cfg.tsdb.MaxBytes = cfgFile.StorageConfig.TSDBConfig.Retention.Size
 	cfg.tsdb.MaxPercentage = cfgFile.StorageConfig.TSDBConfig.Retention.Percentage
@@ -2080,7 +2079,6 @@ type tsdbOptions struct {
 	EnableSTAsZeroSample           bool
 	EnableSTStorage                bool
 	EnableXOR2Encoding             bool
-	StaleSeriesCompactionThreshold float64
 	EnableFastStartup              bool
 }
 
@@ -2112,7 +2110,6 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		EnableSTAsZeroSample:           opts.EnableSTAsZeroSample,
 		EnableSTStorage:                opts.EnableSTStorage,
 		EnableXOR2Encoding:             opts.EnableXOR2Encoding,
-		StaleSeriesCompactionThreshold: opts.StaleSeriesCompactionThreshold,
 		EnableFastStartup:              opts.EnableFastStartup,
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1143,6 +1143,11 @@ type TSDBConfig struct {
 	// This should not be used directly and must be converted into OutOfOrderTimeWindow.
 	OutOfOrderTimeWindowFlag model.Duration `yaml:"out_of_order_time_window,omitempty"`
 
+	// StaleSeriesCompactionThreshold is currently a no-op. The option is kept
+	// in the config schema so that existing configuration files continue to
+	// parse, but the feature is disabled until the underlying bug is fixed.
+	// See https://github.com/prometheus/prometheus/issues/18379.
+	//
 	// StaleSeriesCompactionThreshold is a number between 0.0-1.0 indicating the % of stale series in
 	// the in-memory Head block. If the % of stale series crosses this threshold, stale series compaction is run immediately.
 	StaleSeriesCompactionThreshold float64 `yaml:"stale_series_compaction_threshold,omitempty"`

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3956,20 +3956,6 @@ with this feature.
 # to the timestamp of the last appended sample for the same series.
 [ out_of_order_time_window: <duration> | default = 0s ]
 
-# Configures the trigger point for compacting the stale series from the memory into persistent blocks
-# and remove those stale series from the memory.
-#
-# The threshold is a number between 0.0 and 1.0. It represents the ratio of stale series in the memory
-# to the total series in the memory. The stale series compaction is triggered when this ratio crosses
-# the configured threshold. It may not trigger the stale series compaction if the usual head compaction
-# is about to happen soon.
-#
-# If set to 0, stale series compaction is disabled.
-#
-# This is an experimental feature, this behaviour could change or be removed in the future.
-[ stale_series_compaction_threshold: <float> | default = 0 ]
-
-
 # Configures data retention settings for TSDB.
 #
 # Note: When retention is changed at runtime, the retention

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1286,7 +1286,6 @@ func (db *DB) ApplyConfig(conf *config.Config) error {
 	oooTimeWindow := int64(0)
 	if conf.StorageConfig.TSDBConfig != nil {
 		oooTimeWindow = conf.StorageConfig.TSDBConfig.OutOfOrderTimeWindow
-		db.opts.staleSeriesCompactionThreshold.Store(conf.StorageConfig.TSDBConfig.StaleSeriesCompactionThreshold)
 		// Update retention configuration if provided.
 		if conf.StorageConfig.TSDBConfig.Retention != nil {
 			db.retentionMtx.Lock()
@@ -1298,8 +1297,6 @@ func (db *DB) ApplyConfig(conf *config.Config) error {
 			db.metrics.maxPercentage.Set(db.opts.MaxPercentage)
 			db.retentionMtx.Unlock()
 		}
-	} else {
-		db.opts.staleSeriesCompactionThreshold.Store(0)
 	}
 	if oooTimeWindow < 0 {
 		oooTimeWindow = 0


### PR DESCRIPTION

#### Which issue(s) does the PR fix:
See https://github.com/prometheus/prometheus/issues/18379

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[CHANGE] tsdb: Make the `stale_series_compaction_threshold` config option a no-op until the bug is fixed.
```
