### PR TITLE
perf(tsdb): inline oversize-chunk check in populateChunksFromIterable

### DIFF
--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -1058,19 +1058,25 @@ func (p *populateWithDelChunkSeriesIterator) populateChunksFromIterable() bool {
 		// not capable.
 		st = p.currDelIter.AtST()
 		needTS := st != 0
-		overSizeChunk := func() bool {
+		// Decide whether to cut a new chunk. The size check inside `if !cutNewChunk`
+		// is reachable only when currentValueType == prevValueType, which excludes
+		// the first iteration (prevValueType == ValNone forces cutNewChunk true),
+		// so currentChunk is non-nil there.
+		cutNewChunk := currentValueType != prevValueType || (!hasTS && needTS)
+		if !cutNewChunk {
+			chunkBytes := len(currentChunk.Bytes())
 			switch currentValueType {
 			case chunkenc.ValFloat:
 				// In the TSDB head we also take into account the number of samples, but here we want to keep it
 				// simple and consistent with histograms. Also the size limit is checked before sample limit in
 				// the head as well.
-				return len(currentChunk.Bytes()) > chunkenc.MaxBytesPerXORChunkBeforeAppend
+				cutNewChunk = chunkBytes > chunkenc.MaxBytesPerXORChunkBeforeAppend
 			case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
-				return len(currentChunk.Bytes()) > chunkenc.TargetBytesPerHistogramChunk && currentChunk.NumSamples() > chunkenc.MinSamplesPerHistogramChunk
+				cutNewChunk = chunkBytes > chunkenc.TargetBytesPerHistogramChunk &&
+					currentChunk.NumSamples() > chunkenc.MinSamplesPerHistogramChunk
 			}
-			return false
 		}
-		if currentValueType != prevValueType || !hasTS && needTS || overSizeChunk() {
+		if cutNewChunk {
 			if prevValueType != chunkenc.ValNone {
 				p.chunksFromIterable = append(p.chunksFromIterable, chunks.Meta{Chunk: currentChunk, MinTime: cmint, MaxTime: cmaxt})
 			}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

The oversize-chunk trigger introduced in #18692 was implemented as a closure defined inside the per-sample loop in
populateChunksFromIterable and invoked once at the `if` condition. Replace it with a plain conditional and hoist
`len(currentChunk.Bytes())` out of the switch so the two encoding cases don't repeat the same expression. The new shape preserves the original `||` short-circuit: the size check is only evaluated when neither the encoding nor the start-timestamp capability forces a new chunk, which also keeps `currentChunk` non-nil at the point of read.

`gcflags=-m=2` reports the closure body inlined and the symbol table shows no separate `func1` symbol, yet benchstat shows a measurable speedup. The most likely explanation: the closure body inlines, but the `funcval` struct (capturing `currentChunk` and `currentValueType`) is still stack-constructed each iteration — invisible to escape analysis, but a real per-iteration cost in a hot loop.

Benchmark, `go test -count=6 -benchmem -bench=BenchmarkQuerierSelectWithOutOfOrder -benchtime=5s -run=^$ ./tsdb/`, Intel Xeon Platinum 8280 @ 2.70 GHz (linux/amd64), 1M-series head, query selectivity varies:

```console
                                          │   main      │           optimized                │
                                          │   sec/op    │    sec/op    vs base               │
Head/1of1000000-16                          301.5m ± 4%   257.0m ±  4%  -14.74% (p=0.002 n=6)
Head/10of1000000-16                         305.6m ± 3%   260.4m ±  2%  -14.80% (p=0.002 n=6)
Head/100of1000000-16                        303.9m ± 2%   259.7m ±  2%  -14.54% (p=0.002 n=6)
Head/1000of1000000-16                       303.8m ± 2%   267.0m ±  2%  -12.13% (p=0.002 n=6)
Head/10000of1000000-16                      318.1m ± 1%   278.9m ±  8%  -12.33% (p=0.002 n=6)
Head/100000of1000000-16                     364.1m ± 7%   352.8m ±  4%        ~ (p=0.065 n=6)
Head/1000000of1000000-16                     1.115 ± 2%    1.089 ± 26%        ~ (p=0.394 n=6)
geomean                                     377.8m        337.3m        -10.71%
```

allocs/op and B/op unchanged. The two largest-selectivity cases trend faster but are dominated by the per-sample append cost so the relative delta is smaller and lost in variance.

`TestChunkQuerier_OverlappingInOrderAndOOOChunks` continues to exercise the overflow path.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```