### PR TITLE
WIP: tsdb: centralize headChunkCount/mmapReady invariant on memSeries

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -150,6 +150,8 @@ type Head struct {
 
 	memTruncationInProcess atomic.Bool
 	memTruncationCallBack  func() // For testing purposes.
+
+	walReplayExemplarDrainHook func(<-chan struct{}) // For testing purposes.
 }
 
 type ExemplarStorage interface {
@@ -262,6 +264,8 @@ func (o *HeadOptions) UseXOR2FloatEncoding() bool {
 // SeriesLifecycleCallback specifies a list of callbacks that will be called during a lifecycle of a series.
 // It is always a no-op in Prometheus and mainly meant for external users who import TSDB.
 // All the callbacks should be safe to be called concurrently.
+// During WAL replay, callbacks for a label set are invoked in lifecycle order.
+// Callbacks must not wait for a later WAL replay lifecycle callback.
 // It is up to the user to implement soft or hard consistency by making the callbacks
 // atomic or non-atomic. Atomic callbacks can cause degradation performance.
 type SeriesLifecycleCallback interface {
@@ -2323,9 +2327,11 @@ func (h *Head) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict 
 	return deleted
 }
 
-// deleteSeriesByID deletes the series with the given reference.
+// deleteSeriesByID deletes the series with the given reference and returns the
+// payload for the lifecycle callback. The caller must invoke PostDeletion before
+// completing the associated replay-deletion barrier.
 // Only used for WAL replay.
-func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
+func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) map[chunks.HeadSeriesRef]labels.Labels {
 	var (
 		deleted            = map[storage.SeriesRef]struct{}{}
 		deletedForCallback = map[chunks.HeadSeriesRef]labels.Labels{}
@@ -2406,9 +2412,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 	// Remove tombstones referring to the deleted series.
 	h.tombstones.DeleteTombstones(deleted)
 
-	if len(deletedForCallback) > 0 {
-		h.series.seriesLifecycleCallback.PostDeletion(deletedForCallback)
-	}
+	return deletedForCallback
 }
 
 // gcSeries walks all series and removes those whose ref is in seriesRefs, whose maxTime is

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1045,11 +1045,10 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 			// The most recent head chunk was completed and m-mapped after the snapshot
 			// was taken, so its samples are now covered by the mmapped chunk we just
 			// loaded. Drop the in-memory head chunk chain.
+			// No series.Lock: loadMmappedChunks runs at startup before any
+			// appender goroutine can reach this series.
 			ms.nextAt = 0
-			if ms.headChunkCount.Load() >= 2 {
-				h.series.decMmapReady(ms.ref)
-			}
-			ms.setHeadChunks(nil, 0)
+			ms.setHeadChunks(nil, 0, h.series)
 			ms.app = nil
 		}
 		return nil
@@ -2022,15 +2021,13 @@ func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, l
 	return s, true, nil
 }
 
-// onChunkCreated bumps the head chunk metrics for any newly created chunk, in-order or OOO.
-// If prevHeadChunkCount < 2 and series.headChunkCount == 2, the corresponding
-// stripe's count of mmap ready series is incremented.
-func (h *Head) onChunkCreated(series *memSeries, prevHeadChunkCount uint32) {
+// onChunkCreatedMetrics bumps the head chunk metrics for any newly created
+// chunk, in-order or OOO. The mmap-ready bookkeeping is owned by the
+// memSeries setters and runs at the actual headChunkCount mutation site
+// (e.g. cutNewHeadChunk via incHeadChunkCount).
+func (h *Head) onChunkCreatedMetrics() {
 	h.metrics.chunks.Inc()
 	h.metrics.chunksCreated.Inc()
-	if prevHeadChunkCount < 2 && series.headChunkCount.Load() == 2 {
-		h.series.incMmapReady(series.ref)
-	}
 }
 
 // mmapHeadChunks iterates all memSeries stored on Head ready for m-mapping and calls
@@ -2057,12 +2054,8 @@ func (h *Head) mmapHeadChunks() {
 			}
 
 			series.Lock()
-			n := series.mmapChunks(h.chunkDiskMapper)
+			count += series.mmapChunks(h.chunkDiskMapper, h.series)
 			series.Unlock()
-			if n > 0 {
-				count += n
-				h.series.decMmapReady(series.ref)
-			}
 		}
 		h.series.locks[i].RUnlock()
 	}
@@ -2217,11 +2210,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		series.Lock()
 		defer series.Unlock()
 
-		wasMmapReady := series.headChunkCount.Load() >= 2
-		rmChunks += series.truncateChunksBefore(mint, minOOOMmapRef)
-		if wasMmapReady && series.headChunkCount.Load() < 2 {
-			s.decMmapReady(series.ref)
-		}
+		rmChunks += series.truncateChunksBefore(mint, minOOOMmapRef, s)
 
 		if len(series.mmappedChunks) > 0 {
 			seq, _ := series.mmappedChunks[0].ref.Unpack()
@@ -2384,14 +2373,14 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) map[chunks.HeadSeri
 				chunksRemoved++
 			}
 		}
-		if series.headChunkCount.Load() >= 2 {
-			h.series.decMmapReady(series.ref)
-		}
+		// No series.Lock: deleteSeriesByID is only invoked during WAL replay,
+		// where walSubsetProcessor partitions inputs by series ref so this
+		// series has no concurrent writer.
 		// Release all chunk data and keep the head-chunk list and count in sync.
 		// A stale reference may remain queued on this WAL-replay processor after
 		// the series has been removed from the lookup maps.
 		series.mmappedChunks = nil
-		series.setHeadChunks(nil, 0)
+		series.setHeadChunks(nil, 0, h.series)
 		series.app = nil
 		series.ooo = nil
 
@@ -2460,9 +2449,7 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 		// If we don't hold them all, there's a very small chance that a series receives
 		// samples again while we are half-way into deleting it.
 		stripe := s.refStripe(series.ref)
-		if series.headChunkCount.Load() >= 2 {
-			s.decMmapReady(series.ref)
-		}
+		series.setHeadChunks(nil, 0, s)
 		if hashShard != stripe {
 			s.locks[stripe].Lock()
 			defer s.locks[stripe].Unlock()
@@ -2517,14 +2504,10 @@ func (s *stripeSeries) refStripe(ref chunks.HeadSeriesRef) int {
 	return int(uint64(ref) & uint64(s.size-1))
 }
 
-// incMmapReady increments the per-stripe mmap-ready counter for the given series.
-func (s *stripeSeries) incMmapReady(ref chunks.HeadSeriesRef) {
-	s.mmapReady[s.refStripe(ref)].Add(1)
-}
-
-// decMmapReady decrements the per-stripe mmap-ready counter for the given series.
-func (s *stripeSeries) decMmapReady(ref chunks.HeadSeriesRef) {
-	s.mmapReady[s.refStripe(ref)].Add(-1)
+// mmapReadyFor returns the per-stripe mmap-ready counter for the stripe that
+// the given series ref belongs to.
+func (s *stripeSeries) mmapReadyFor(ref chunks.HeadSeriesRef) *paddedAtomicInt32 {
+	return &s.mmapReady[s.refStripe(ref)]
 }
 
 func (s *stripeSeries) getByID(id chunks.HeadSeriesRef) *memSeries {
@@ -2662,11 +2645,12 @@ type memSeries struct {
 	histogramChunkHasComputedEndTime bool  // True if nextAt has been predicted for the current histograms chunk; false otherwise.
 	pendingCommit                    bool  // Whether there are samples waiting to be committed to this series.
 	// headChunkCount tracks the number of head chunks. All mutations of the
-	// headChunks/headChunkCount pair go through pushHeadChunk and setHeadChunks.
+	// headChunks/headChunkCount pair go through pushHeadChunk and setHeadChunks,
+	// which also keep the owning stripe's mmapReady counter in sync.
 	// Chunk counts are bounded by the 3-byte field in HeadChunkRef, so cannot overflow uint32.
-	// Explicitly uses sync/atomic.Uint32 (4 bytes) to fit in the existing padding
+	// The underlying sync/atomic.Uint32 (4 bytes) fits in the existing padding
 	// between two bools and a float64.
-	headChunkCount stdatomic.Uint32
+	headChunkCount headChunkCounter
 
 	// We keep the last value here (in addition to appending it to the chunk) so we can check for duplicates.
 	lastValue float64
@@ -2706,6 +2690,50 @@ func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, shardHash uint64,
 	return s
 }
 
+// headChunkCounter wraps the head chunk count so it can only be mutated via
+// the memSeries setters, which keep the stripe's mmapReady counter in sync.
+type headChunkCounter struct {
+	n stdatomic.Uint32
+}
+
+// Load returns the current head chunk count.
+func (c *headChunkCounter) Load() uint32 { return c.n.Load() }
+
+// incHeadChunkCount atomically increments the head chunk count and bumps the
+// stripe's mmap-ready counter on the 1 -> 2 edge.
+//
+// Callers MUST either hold series.Lock or otherwise guarantee single-writer
+// ownership of this series (e.g. WAL replay's per-ref partitioning). Two
+// concurrent setters on the same series can race the threshold check
+// against the mmapReady update and leave mmapReady transiently out of sync
+// with headChunkCount.
+//
+// stripes is nil only for memSeries that are not registered in a
+// stripeSeries (test paths constructing a memSeries directly via
+// newMemSeries); the stripe accounting is simply skipped in that case.
+func (s *memSeries) incHeadChunkCount(stripes *stripeSeries) {
+	if s.headChunkCount.n.Add(1) == 2 && stripes != nil {
+		stripes.mmapReadyFor(s.ref).Add(1)
+	}
+}
+
+// setHeadChunkCount atomically stores the head chunk count and adjusts the
+// stripe's mmap-ready counter if the >= 2 threshold is crossed in either
+// direction. Same single-writer and nil-stripes semantics as
+// incHeadChunkCount.
+func (s *memSeries) setHeadChunkCount(n uint32, stripes *stripeSeries) {
+	prev := s.headChunkCount.n.Swap(n)
+	if stripes == nil {
+		return
+	}
+	switch {
+	case prev < 2 && n >= 2:
+		stripes.mmapReadyFor(s.ref).Add(1)
+	case prev >= 2 && n < 2:
+		stripes.mmapReadyFor(s.ref).Add(-1)
+	}
+}
+
 func (s *memSeries) minTime() int64 {
 	if len(s.mmappedChunks) > 0 {
 		return s.mmappedChunks[0].minTime
@@ -2732,25 +2760,25 @@ func (s *memSeries) maxTime() int64 {
 // list length whenever the series lock is released; direct prev unlinks
 // (mmapChunks, truncateChunksBefore) must be immediately paired with a
 // setHeadChunks call.
-func (s *memSeries) pushHeadChunk(chk *memChunk) *memChunk {
+func (s *memSeries) pushHeadChunk(chk *memChunk, stripes *stripeSeries) *memChunk {
 	chk.prev = s.headChunks
 	s.headChunks = chk
-	s.headChunkCount.Add(1)
+	s.incHeadChunkCount(stripes)
 	return chk
 }
 
 // setHeadChunks replaces the head-chunk list with head, which must be a list
 // of count chunks, keeping headChunkCount in sync with the list length. See
 // pushHeadChunk for the invariant.
-func (s *memSeries) setHeadChunks(head *memChunk, count uint32) {
+func (s *memSeries) setHeadChunks(head *memChunk, count uint32, stripes *stripeSeries) {
 	s.headChunks = head
-	s.headChunkCount.Store(count)
+	s.setHeadChunkCount(count, stripes)
 }
 
 // truncateChunksBefore removes all chunks from the series that
 // have no timestamp at or after mint.
 // Chunk IDs remain unchanged.
-func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) int {
+func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef, stripes *stripeSeries) int {
 	var removedInOrder int
 	if s.headChunks != nil {
 		var i uint32
@@ -2763,11 +2791,11 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 				s.firstChunkID += chunks.HeadChunkID(removedInOrder)
 				if i == 0 {
 					// This is the first chunk on the list so we need to remove the entire list.
-					s.setHeadChunks(nil, 0)
+					s.setHeadChunks(nil, 0, stripes)
 				} else {
 					// This is NOT the first chunk, unlink it from parent.
 					nextChk.prev = nil
-					s.setHeadChunks(s.headChunks, i)
+					s.setHeadChunks(s.headChunks, i, stripes)
 				}
 				s.mmappedChunks = nil
 				break

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2372,13 +2372,22 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		if series.headChunks != nil {
 			chunksRemoved += series.headChunks.len()
 		}
+		if series.ooo != nil {
+			chunksRemoved += len(series.ooo.oooMmappedChunks)
+			if series.ooo.oooHeadChunk != nil {
+				chunksRemoved++
+			}
+		}
 		if series.headChunkCount.Load() >= 2 {
 			h.series.decMmapReady(series.ref)
 		}
-		// Clear to prevent a double-subtraction from the chunksRemoved gauge if
-		// resetSeriesWithMMappedChunks is queued on the same WAL-replay processor
-		// after this deletion (it would otherwise subtract len(mmappedChunks) again).
+		// Release all chunk data and keep the head-chunk list and count in sync.
+		// A stale reference may remain queued on this WAL-replay processor after
+		// the series has been removed from the lookup maps.
 		series.mmappedChunks = nil
+		series.setHeadChunks(nil, 0)
+		series.app = nil
+		series.ooo = nil
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		deletedForCallback[series.ref] = series.lset

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -159,6 +159,8 @@ type Head struct {
 	// testAfterSeriesLookup is invoked after getByID in appenders, before the
 	// series is locked. Tests use it to race GC against a resolved pointer.
 	testAfterSeriesLookup func(*memSeries)
+
+	walReplayExemplarDrainHook func(<-chan struct{}) // For testing purposes.
 }
 
 type ExemplarStorage interface {
@@ -271,6 +273,8 @@ func (o *HeadOptions) UseXOR2FloatEncoding() bool {
 // SeriesLifecycleCallback specifies a list of callbacks that will be called during a lifecycle of a series.
 // It is always a no-op in Prometheus and mainly meant for external users who import TSDB.
 // All the callbacks should be safe to be called concurrently.
+// During WAL replay, callbacks for a label set are invoked in lifecycle order.
+// Callbacks must not wait for a later WAL replay lifecycle callback.
 // It is up to the user to implement soft or hard consistency by making the callbacks
 // atomic or non-atomic. Atomic callbacks can cause degradation performance.
 type SeriesLifecycleCallback interface {
@@ -2447,9 +2451,11 @@ func (h *Head) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict 
 	return deleted
 }
 
-// deleteSeriesByID deletes the series with the given reference.
+// deleteSeriesByID deletes the series with the given reference and returns the
+// payload for the lifecycle callback. The caller must invoke PostDeletion before
+// completing the associated replay-deletion barrier.
 // Only used for WAL replay.
-func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
+func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) map[chunks.HeadSeriesRef]labels.Labels {
 	var (
 		deleted                 = map[storage.SeriesRef]struct{}{}
 		deletedForCallback      = map[chunks.HeadSeriesRef]labels.Labels{}
@@ -2536,9 +2542,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 	// Remove tombstones referring to the deleted series.
 	h.tombstones.DeleteTombstones(deleted)
 
-	if len(deletedForCallback) > 0 {
-		h.series.seriesLifecycleCallback.PostDeletion(deletedForCallback)
-	}
+	return deletedForCallback
 }
 
 // gcSeries walks all series and removes those whose ref is in seriesRefs, whose maxTime is

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1087,11 +1087,10 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 			// The most recent head chunk was completed and m-mapped after the snapshot
 			// was taken, so its samples are now covered by the mmapped chunk we just
 			// loaded. Drop the in-memory head chunk chain.
+			// No series.Lock: loadMmappedChunks runs at startup before any
+			// appender goroutine can reach this series.
 			ms.nextAt = 0
-			if ms.headChunkCount.Load() >= 2 {
-				h.series.decMmapReady(ms.ref)
-			}
-			ms.setHeadChunks(nil, 0)
+			ms.setHeadChunks(nil, 0, h.series)
 			ms.app = nil
 		}
 		return nil
@@ -2125,15 +2124,11 @@ func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, l
 	return s, true, nil
 }
 
-// onChunkCreated bumps the head chunk metrics for any newly created chunk, in-order or OOO.
-// If prevHeadChunkCount < 2 and series.headChunkCount == 2, the corresponding
-// stripe's count of mmap ready series is incremented.
-func (h *Head) onChunkCreated(series *memSeries, prevHeadChunkCount uint32) {
+// onChunkCreatedMetrics bumps metrics for a newly created in-order or OOO
+// chunk. The memSeries setters own mmap-ready accounting.
+func (h *Head) onChunkCreatedMetrics() {
 	h.metrics.chunks.Inc()
 	h.metrics.chunksCreated.Inc()
-	if prevHeadChunkCount < 2 && series.headChunkCount.Load() == 2 {
-		h.series.incMmapReady(series.ref)
-	}
 }
 
 // mmapHeadChunks iterates all memSeries stored on Head ready for m-mapping and calls
@@ -2173,7 +2168,6 @@ func (h *Head) mmapHeadChunksInStripe(i int) (count int) {
 		n := h.mmapSeriesChunks(series)
 		if n > 0 {
 			count += n
-			h.series.decMmapReady(series.ref)
 		}
 	}
 	return count
@@ -2182,7 +2176,7 @@ func (h *Head) mmapHeadChunksInStripe(i int) (count int) {
 func (h *Head) mmapSeriesChunks(s *memSeries) int {
 	s.Lock()
 	defer s.Unlock()
-	return s.mmapChunks(h.chunkDiskMapper)
+	return s.mmapChunks(h.chunkDiskMapper, h.series)
 }
 
 // seriesHashmap lets TSDB find a memSeries by its label set, via a 64-bit hash.
@@ -2335,11 +2329,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		series.Lock()
 		defer series.Unlock()
 
-		wasMmapReady := series.headChunkCount.Load() >= 2
-		rmChunks += series.truncateChunksBefore(mint, minOOOMmapRef)
-		if wasMmapReady && series.headChunkCount.Load() < 2 {
-			s.decMmapReady(series.ref)
-		}
+		rmChunks += series.truncateChunksBefore(mint, minOOOMmapRef, s)
 
 		if len(series.mmappedChunks) > 0 {
 			seq, _ := series.mmappedChunks[0].ref.Unpack()
@@ -2512,14 +2502,14 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) map[chunks.HeadSeri
 				chunksRemoved++
 			}
 		}
-		if headChunkCount >= 2 {
-			h.series.decMmapReady(series.ref)
-		}
+		// No series.Lock: deleteSeriesByID is only invoked during WAL replay,
+		// where walSubsetProcessor partitions inputs by series ref so this
+		// series has no concurrent writer.
 		// Release all chunk data and keep the head-chunk list and count in sync.
 		// A stale reference may remain queued on this WAL-replay processor after
 		// the series has been removed from the lookup maps.
 		series.mmappedChunks = nil
-		series.setHeadChunks(nil, 0)
+		series.setHeadChunks(nil, 0, h.series)
 		series.app = nil
 		series.ooo = nil
 
@@ -2591,9 +2581,7 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 		// If we don't hold them all, there's a very small chance that a series receives
 		// samples again while we are half-way into deleting it.
 		stripe := s.refStripe(series.ref)
-		if headChunkCount >= 2 {
-			s.decMmapReady(series.ref)
-		}
+		series.setHeadChunks(nil, 0, s)
 		if hashShard != stripe {
 			s.locks[stripe].Lock()
 			defer s.locks[stripe].Unlock()
@@ -2654,14 +2642,10 @@ func (s *stripeSeries) refStripe(ref chunks.HeadSeriesRef) int {
 	return int(uint64(ref) & uint64(s.size-1))
 }
 
-// incMmapReady increments the per-stripe mmap-ready counter for the given series.
-func (s *stripeSeries) incMmapReady(ref chunks.HeadSeriesRef) {
-	s.mmapReady[s.refStripe(ref)].Add(1)
-}
-
-// decMmapReady decrements the per-stripe mmap-ready counter for the given series.
-func (s *stripeSeries) decMmapReady(ref chunks.HeadSeriesRef) {
-	s.mmapReady[s.refStripe(ref)].Add(-1)
+// mmapReadyFor returns the per-stripe mmap-ready counter for the stripe that
+// the given series ref belongs to.
+func (s *stripeSeries) mmapReadyFor(ref chunks.HeadSeriesRef) *paddedAtomicInt32 {
+	return &s.mmapReady[s.refStripe(ref)]
 }
 
 func (s *stripeSeries) getByID(id chunks.HeadSeriesRef) *memSeries {
@@ -2799,11 +2783,12 @@ type memSeries struct {
 	// The state packs the pending-sample count and infrequent flags to avoid increasing memSeries size.
 	state uint32
 	// headChunkCount tracks the number of head chunks. All mutations of the
-	// headChunks/headChunkCount pair go through pushHeadChunk and setHeadChunks.
+	// headChunks/headChunkCount pair go through pushHeadChunk and setHeadChunks,
+	// which also keep the owning stripe's mmapReady counter in sync.
 	// Chunk counts are bounded by the 3-byte field in HeadChunkRef, so cannot overflow uint32.
-	// Explicitly uses sync/atomic.Uint32 (4 bytes) so state and the chunk count
-	// occupy one 8-byte word before lastValue.
-	headChunkCount stdatomic.Uint32
+	// The wrapped sync/atomic.Uint32 remains 4 bytes, so state and the chunk
+	// count occupy one 8-byte word before lastValue.
+	headChunkCount headChunkCounter
 
 	// We keep the last value here (in addition to appending it to the chunk) so we can check for duplicates.
 	lastValue float64
@@ -2915,6 +2900,38 @@ func newMemSeries(lset labels.Labels, id chunks.HeadSeriesRef, shardHash uint64,
 	return s
 }
 
+// headChunkCounter exposes reads while reserving mutations for memSeries setters.
+type headChunkCounter struct {
+	n stdatomic.Uint32
+}
+
+// Load returns the current head chunk count.
+func (c *headChunkCounter) Load() uint32 { return c.n.Load() }
+
+// incHeadChunkCount increments the count and records the 1 -> 2 readiness edge.
+// The caller must serialize setters with the series lock or exclusive write
+// ownership. A nil stripes denotes an unregistered standalone series.
+func (s *memSeries) incHeadChunkCount(stripes *stripeSeries) {
+	if s.headChunkCount.n.Add(1) == 2 && stripes != nil {
+		stripes.mmapReadyFor(s.ref).Add(1)
+	}
+}
+
+// setHeadChunkCount sets the count and records readiness threshold crossings.
+// It has the same serialization and nil-stripes contract as incHeadChunkCount.
+func (s *memSeries) setHeadChunkCount(n uint32, stripes *stripeSeries) {
+	prev := s.headChunkCount.n.Swap(n)
+	if stripes == nil {
+		return
+	}
+	switch {
+	case prev < 2 && n >= 2:
+		stripes.mmapReadyFor(s.ref).Add(1)
+	case prev >= 2 && n < 2:
+		stripes.mmapReadyFor(s.ref).Add(-1)
+	}
+}
+
 func (s *memSeries) minTime() int64 {
 	if len(s.mmappedChunks) > 0 {
 		return s.mmappedChunks[0].minTime
@@ -2941,7 +2958,7 @@ func (s *memSeries) maxTime() int64 {
 // list length whenever the series lock is released; direct prev unlinks
 // (mmapChunks, truncateChunksBefore) must be immediately paired with a
 // setHeadChunks call.
-func (s *memSeries) pushHeadChunk(chk *memChunk) *memChunk {
+func (s *memSeries) pushHeadChunk(chk *memChunk, stripes *stripeSeries) *memChunk {
 	// Chunk IDs can only be 23 bits, so a series cannot hold more than 2^23 chunks
 	// without two of them sharing an ID. This is not reachable in practice (head
 	// compaction keeps the live set tiny); panic rather than serve an ambiguous ID.
@@ -2951,22 +2968,22 @@ func (s *memSeries) pushHeadChunk(chk *memChunk) *memChunk {
 
 	chk.prev = s.headChunks
 	s.headChunks = chk
-	s.headChunkCount.Add(1)
+	s.incHeadChunkCount(stripes)
 	return chk
 }
 
 // setHeadChunks replaces the head-chunk list with head, which must be a list
 // of count chunks, keeping headChunkCount in sync with the list length. See
 // pushHeadChunk for the invariant.
-func (s *memSeries) setHeadChunks(head *memChunk, count uint32) {
+func (s *memSeries) setHeadChunks(head *memChunk, count uint32, stripes *stripeSeries) {
 	s.headChunks = head
-	s.headChunkCount.Store(count)
+	s.setHeadChunkCount(count, stripes)
 }
 
 // truncateChunksBefore removes all chunks from the series that
 // have no timestamp at or after mint.
 // Chunk IDs remain unchanged.
-func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) int {
+func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef, stripes *stripeSeries) int {
 	var removedInOrder int
 	if s.headChunks != nil {
 		var i uint32
@@ -2979,11 +2996,11 @@ func (s *memSeries) truncateChunksBefore(mint int64, minOOOMmapRef chunks.ChunkD
 				s.firstChunkID = wrapChunkID(s.firstChunkID + chunks.HeadChunkID(removedInOrder))
 				if i == 0 {
 					// This is the first chunk on the list so we need to remove the entire list.
-					s.setHeadChunks(nil, 0)
+					s.setHeadChunks(nil, 0, stripes)
 				} else {
 					// This is NOT the first chunk, unlink it from parent.
 					nextChk.prev = nil
-					s.setHeadChunks(s.headChunks, i)
+					s.setHeadChunks(s.headChunks, i, stripes)
 				}
 				s.mmappedChunks = nil
 				break

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2500,13 +2500,22 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		headChunkCount := series.headChunkCount.Load()
 		chunksRemoved += len(series.mmappedChunks)
 		chunksRemoved += int(headChunkCount)
+		if series.ooo != nil {
+			chunksRemoved += len(series.ooo.oooMmappedChunks)
+			if series.ooo.oooHeadChunk != nil {
+				chunksRemoved++
+			}
+		}
 		if headChunkCount >= 2 {
 			h.series.decMmapReady(series.ref)
 		}
-		// Clear to prevent a double-subtraction from the chunksRemoved gauge if
-		// resetSeriesWithMMappedChunks is queued on the same WAL-replay processor
-		// after this deletion (it would otherwise subtract len(mmappedChunks) again).
+		// Release all chunk data and keep the head-chunk list and count in sync.
+		// A stale reference may remain queued on this WAL-replay processor after
+		// the series has been removed from the lookup maps.
 		series.mmappedChunks = nil
+		series.setHeadChunks(nil, 0)
+		series.app = nil
+		series.ooo = nil
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		deletedForCallback[series.ref] = series.lset

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1391,7 +1391,6 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			handleAppendableError(err, &acc.floatsAppended, &acc.floatOOORejected, &acc.floatOOBRejected, &acc.floatTooOldRejected)
 		}
 
-		prevHeadChunkCount := series.headChunkCount.Load()
 		switch {
 		case err != nil:
 			// Do nothing here.
@@ -1464,7 +1463,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		}
 
 		if chunkCreated {
-			a.head.onChunkCreated(series, prevHeadChunkCount)
+			a.head.onChunkCreatedMetrics()
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1496,7 +1495,6 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
 		}
 
-		prevHeadChunkCount := series.headChunkCount.Load()
 		switch {
 		case err != nil:
 			// Do nothing here.
@@ -1573,7 +1571,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 		}
 
 		if chunkCreated {
-			a.head.onChunkCreated(series, prevHeadChunkCount)
+			a.head.onChunkCreatedMetrics()
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1605,7 +1603,6 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
 		}
 
-		prevHeadChunkCount := series.headChunkCount.Load()
 		switch {
 		case err != nil:
 			// Do nothing here.
@@ -1682,7 +1679,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 		}
 
 		if chunkCreated {
-			a.head.onChunkCreated(series, prevHeadChunkCount)
+			a.head.onChunkCreatedMetrics()
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1755,6 +1752,7 @@ func (a *headAppenderBase) Commit() (err error) {
 			useXOR2:         a.useXOR2,
 			useHistogramST:  a.useHistogramST,
 			storeST:         a.storeST,
+			stripes:         h.series,
 		},
 		oooEnc: record.Encoder{
 			EnableSTStorage: a.storeST,
@@ -1844,6 +1842,14 @@ type chunkOpts struct {
 	useXOR2         bool // Selects XOR2 encoding for float chunks.
 	useHistogramST  bool // Selects ST-capable encoding for integer and float histogram chunks.
 	storeST         bool // Whether start-timestamp storage is enabled.
+
+	// stripes is the stripeSeries the appended-to series is registered in, so
+	// the headChunkCount setters can maintain the per-stripe mmapReady
+	// counters. It is shared across all series in a batch, so it can only
+	// carry the container, never a per-series counter. nil in tests that
+	// exercise a standalone memSeries and in OOO-only paths, where the
+	// stripe accounting is skipped.
+	stripes *stripeSeries
 }
 
 // append adds the sample (t, v) to the series. The caller also has to provide
@@ -1920,7 +1926,7 @@ func (s *memSeries) appendHistogram(st, t int64, h *histogram.Histogram, appendI
 		chunk:   newChunk,
 		minTime: t,
 		maxTime: t,
-	})
+	}, o.stripes)
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
 }
@@ -1975,7 +1981,7 @@ func (s *memSeries) appendFloatHistogram(st, t int64, fh *histogram.FloatHistogr
 		chunk:   newChunk,
 		minTime: t,
 		maxTime: t,
-	})
+	}, o.stripes)
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
 }
@@ -1993,7 +1999,7 @@ func (s *memSeries) appendPreprocessor(t int64, e chunkenc.Encoding, o chunkOpts
 			return c, false, false
 		}
 		// There is no head chunk in this series yet, create the first chunk for the sample.
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2004,7 +2010,7 @@ func (s *memSeries) appendPreprocessor(t int64, e chunkenc.Encoding, o chunkOpts
 
 	// Check the chunk size, unless we just created it and if the chunk is too large, cut a new one.
 	if !chunkCreated && len(c.chunk.Bytes()) > chunkenc.MaxBytesPerXORChunkBeforeAppend {
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2014,7 +2020,7 @@ func (s *memSeries) appendPreprocessor(t int64, e chunkenc.Encoding, o chunkOpts
 	// and must not be mixed within a single chunk; the o.storeST override forces
 	// an immediate cut that CompatibleValues would otherwise allow to skip.
 	if c.chunk.Encoding() != e && (!chunkenc.CompatibleValues(c.chunk.Encoding(), e) || o.storeST) {
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2039,7 +2045,7 @@ func (s *memSeries) appendPreprocessor(t int64, e chunkenc.Encoding, o chunkOpts
 	// as we expect more chunks to come.
 	// Note that next chunk will have its nextAt recalculated for the new rate.
 	if t >= s.nextAt || numSamples >= o.samplesPerChunk*2 {
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2059,7 +2065,7 @@ func (s *memSeries) histogramsAppendPreprocessor(t int64, e chunkenc.Encoding, o
 			return c, false, false
 		}
 		// There is no head chunk in this series yet, create the first chunk for the sample.
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2071,7 +2077,7 @@ func (s *memSeries) histogramsAppendPreprocessor(t int64, e chunkenc.Encoding, o
 	if c.chunk.Encoding() != e {
 		// The chunk encoding expected by this append is different than the head chunk's
 		// encoding. So we cut a new chunk with the expected encoding.
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2112,7 +2118,7 @@ func (s *memSeries) histogramsAppendPreprocessor(t int64, e chunkenc.Encoding, o
 	// increased or if the bucket/span count has increased.
 	// Note that next chunk will have its nextAt recalculated for the new rate.
 	if (t >= s.nextAt || numBytes >= targetBytes*2) && (numSamples >= chunkenc.MinSamplesPerHistogramChunk || t >= nextChunkRangeStart) {
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2137,7 +2143,7 @@ func computeChunkEndTime(start, cur, maxT int64, ratioToFull float64) int64 {
 	return int64(float64(start) + float64(maxT-start)/math.Floor(n))
 }
 
-func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange int64) *memChunk {
+func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, o chunkOpts) *memChunk {
 	// When cutting a new head chunk we create a new memChunk instance with .prev
 	// pointing at the current .headChunks, so it forms a linked list.
 	// All but first headChunks list elements will be m-mapped as soon as possible
@@ -2145,7 +2151,7 @@ func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange 
 	chk := s.pushHeadChunk(&memChunk{
 		minTime: mint,
 		maxTime: math.MinInt64,
-	})
+	}, o.stripes)
 
 	if chunkenc.IsValidEncoding(e) {
 		var err error
@@ -2159,7 +2165,7 @@ func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange 
 
 	// Set upper bound on when the next chunk must be started. An earlier timestamp
 	// may be chosen dynamically at a later point.
-	s.nextAt = rangeForTimestamp(mint, chunkRange)
+	s.nextAt = rangeForTimestamp(mint, o.chunkRange)
 
 	app, err := chk.chunk.Appender()
 	if err != nil {
@@ -2214,7 +2220,7 @@ func (s *memSeries) mmapCurrentOOOHeadChunk(o chunkOpts, logger *slog.Logger) []
 }
 
 // mmapChunks will m-map all but first chunk on s.headChunks list and update headChunkCount.
-func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count int) {
+func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper, stripes *stripeSeries) (count int) {
 	if s.headChunks == nil || s.headChunks.prev == nil {
 		// There is none or only one head chunk, so nothing to m-map here.
 		return count
@@ -2237,7 +2243,7 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 
 	// Remove the tail of the list, leaving only the most recent head chunk.
 	s.headChunks.prev = nil
-	s.setHeadChunks(s.headChunks, 1)
+	s.setHeadChunks(s.headChunks, 1, stripes)
 
 	return count
 }

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1439,7 +1439,6 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			handleAppendableError(err, &acc.floatsAppended, &acc.floatOOORejected, &acc.floatOOBRejected, &acc.floatTooOldRejected)
 		}
 
-		prevHeadChunkCount := series.headChunkCount.Load()
 		switch {
 		case err != nil:
 			// Do nothing here.
@@ -1510,7 +1509,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		}
 
 		if chunkCreated {
-			a.head.onChunkCreated(series, prevHeadChunkCount)
+			a.head.onChunkCreatedMetrics()
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1542,7 +1541,6 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
 		}
 
-		prevHeadChunkCount := series.headChunkCount.Load()
 		switch {
 		case err != nil:
 			// Do nothing here.
@@ -1612,7 +1610,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 		}
 
 		if chunkCreated {
-			a.head.onChunkCreated(series, prevHeadChunkCount)
+			a.head.onChunkCreatedMetrics()
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1644,7 +1642,6 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
 		}
 
-		prevHeadChunkCount := series.headChunkCount.Load()
 		switch {
 		case err != nil:
 			// Do nothing here.
@@ -1714,7 +1711,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 		}
 
 		if chunkCreated {
-			a.head.onChunkCreated(series, prevHeadChunkCount)
+			a.head.onChunkCreatedMetrics()
 		}
 
 		series.cleanupAppendIDsBelow(a.cleanupAppendIDsBelow)
@@ -1800,6 +1797,7 @@ func (a *headAppenderBase) Commit() (err error) {
 			useXOR2:         a.useXOR2,
 			useHistogramST:  a.useHistogramST,
 			storeST:         a.storeST,
+			stripes:         h.series,
 		},
 		oooEnc: record.Encoder{
 			EnableSTStorage: a.storeST,
@@ -1889,6 +1887,10 @@ type chunkOpts struct {
 	useXOR2         bool // Selects XOR2 encoding for float chunks.
 	useHistogramST  bool // Selects ST-capable encoding for integer and float histogram chunks.
 	storeST         bool // Whether start-timestamp storage is enabled.
+
+	// stripes owns mmap-ready accounting for registered in-order series.
+	// It is nil for standalone test series and OOO-only paths.
+	stripes *stripeSeries
 }
 
 // append adds the sample (t, v) to the series. The caller also has to provide
@@ -1965,7 +1967,7 @@ func (s *memSeries) appendHistogram(st, t int64, h *histogram.Histogram, appendI
 		chunk:   newChunk,
 		minTime: t,
 		maxTime: t,
-	})
+	}, o.stripes)
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
 }
@@ -2020,7 +2022,7 @@ func (s *memSeries) appendFloatHistogram(st, t int64, fh *histogram.FloatHistogr
 		chunk:   newChunk,
 		minTime: t,
 		maxTime: t,
-	})
+	}, o.stripes)
 	s.nextAt = rangeForTimestamp(t, o.chunkRange)
 	return true, true
 }
@@ -2038,7 +2040,7 @@ func (s *memSeries) appendPreprocessor(t int64, e chunkenc.Encoding, o chunkOpts
 			return c, false, false
 		}
 		// There is no head chunk in this series yet, create the first chunk for the sample.
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2049,7 +2051,7 @@ func (s *memSeries) appendPreprocessor(t int64, e chunkenc.Encoding, o chunkOpts
 
 	// Check the chunk size, unless we just created it and if the chunk is too large, cut a new one.
 	if !chunkCreated && len(c.chunk.Bytes()) > chunkenc.MaxBytesPerXORChunkBeforeAppend {
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2059,7 +2061,7 @@ func (s *memSeries) appendPreprocessor(t int64, e chunkenc.Encoding, o chunkOpts
 	// and must not be mixed within a single chunk; the o.storeST override forces
 	// an immediate cut that CompatibleValues would otherwise allow to skip.
 	if c.chunk.Encoding() != e && (!chunkenc.CompatibleValues(c.chunk.Encoding(), e) || o.storeST) {
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2084,7 +2086,7 @@ func (s *memSeries) appendPreprocessor(t int64, e chunkenc.Encoding, o chunkOpts
 	// as we expect more chunks to come.
 	// Note that next chunk will have its nextAt recalculated for the new rate.
 	if t >= s.nextAt || numSamples >= o.samplesPerChunk*2 {
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2104,7 +2106,7 @@ func (s *memSeries) histogramsAppendPreprocessor(t int64, e chunkenc.Encoding, o
 			return c, false, false
 		}
 		// There is no head chunk in this series yet, create the first chunk for the sample.
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2116,7 +2118,7 @@ func (s *memSeries) histogramsAppendPreprocessor(t int64, e chunkenc.Encoding, o
 	if c.chunk.Encoding() != e {
 		// The chunk encoding expected by this append is different than the head chunk's
 		// encoding. So we cut a new chunk with the expected encoding.
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2157,7 +2159,7 @@ func (s *memSeries) histogramsAppendPreprocessor(t int64, e chunkenc.Encoding, o
 	// increased or if the bucket/span count has increased.
 	// Note that next chunk will have its nextAt recalculated for the new rate.
 	if (t >= s.nextAt || numBytes >= targetBytes*2) && (numSamples >= chunkenc.MinSamplesPerHistogramChunk || t >= nextChunkRangeStart) {
-		c = s.cutNewHeadChunk(t, e, o.chunkRange)
+		c = s.cutNewHeadChunk(t, e, o)
 		chunkCreated = true
 	}
 
@@ -2182,7 +2184,7 @@ func computeChunkEndTime(start, cur, maxT int64, ratioToFull float64) int64 {
 	return int64(float64(start) + float64(maxT-start)/math.Floor(n))
 }
 
-func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange int64) *memChunk {
+func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, o chunkOpts) *memChunk {
 	// When cutting a new head chunk we create a new memChunk instance with .prev
 	// pointing at the current .headChunks, so it forms a linked list.
 	// All but first headChunks list elements will be m-mapped as soon as possible
@@ -2190,7 +2192,7 @@ func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange 
 	chk := s.pushHeadChunk(&memChunk{
 		minTime: mint,
 		maxTime: math.MinInt64,
-	})
+	}, o.stripes)
 
 	if chunkenc.IsValidEncoding(e) {
 		var err error
@@ -2204,7 +2206,7 @@ func (s *memSeries) cutNewHeadChunk(mint int64, e chunkenc.Encoding, chunkRange 
 
 	// Set upper bound on when the next chunk must be started. An earlier timestamp
 	// may be chosen dynamically at a later point.
-	s.nextAt = rangeForTimestamp(mint, chunkRange)
+	s.nextAt = rangeForTimestamp(mint, o.chunkRange)
 
 	app, err := chk.chunk.Appender()
 	if err != nil {
@@ -2260,7 +2262,7 @@ func (s *memSeries) mmapCurrentOOOHeadChunk(o chunkOpts, logger *slog.Logger) []
 }
 
 // mmapChunks will m-map all but first chunk on s.headChunks list and update headChunkCount.
-func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count int) {
+func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper, stripes *stripeSeries) (count int) {
 	if s.headChunks == nil || s.headChunks.prev == nil {
 		// There is none or only one head chunk, so nothing to m-map here.
 		return count
@@ -2282,7 +2284,7 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 
 	// Remove the tail of the list, leaving only the most recent head chunk.
 	s.headChunks.prev = nil
-	s.setHeadChunks(s.headChunks, 1)
+	s.setHeadChunks(s.headChunks, 1, stripes)
 
 	return count
 }

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -2566,7 +2566,7 @@ func TestHeadAppenderV2_Append_CounterResetHeader(t *testing.T) {
 
 				ms, _, err := head.getOrCreate(l.Hash(), l, false)
 				require.NoError(t, err)
-				ms.mmapChunks(head.chunkDiskMapper)
+				ms.mmapChunks(head.chunkDiskMapper, head.series)
 				require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
 
 				for i, mmapChunk := range ms.mmappedChunks {
@@ -3220,7 +3220,7 @@ func TestHead_Init_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
 
-	series.mmapChunks(h.chunkDiskMapper)
+	series.mmapChunks(h.chunkDiskMapper, h.series)
 	expChunks := make([]*mmappedChunk, len(series.mmappedChunks))
 	copy(expChunks, series.mmappedChunks)
 

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -2571,7 +2571,7 @@ func TestHeadAppenderV2_Append_CounterResetHeader(t *testing.T) {
 
 				ms, _, err := head.getOrCreate(l.Hash(), l, false)
 				require.NoError(t, err)
-				ms.mmapChunks(head.chunkDiskMapper)
+				ms.mmapChunks(head.chunkDiskMapper, head.series)
 				require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
 
 				for i, mmapChunk := range ms.mmappedChunks {
@@ -3225,7 +3225,7 @@ func TestHead_Init_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
 
-	series.mmapChunks(h.chunkDiskMapper)
+	series.mmapChunks(h.chunkDiskMapper, h.series)
 	expChunks := make([]*mmappedChunk, len(series.mmappedChunks))
 	copy(expChunks, series.mmappedChunks)
 

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -123,7 +123,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -136,7 +136,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=1 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -149,7 +149,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -162,7 +162,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -176,7 +176,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=2 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -190,7 +190,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -204,7 +204,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=1 on memSeries with 3 mmapped chunks and closed ChunkDiskMapper",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -218,7 +218,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks and closed ChunkDiskMapper",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -268,7 +268,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -285,7 +285,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=2 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -302,7 +302,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -319,7 +319,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=5 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -336,7 +336,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=6 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -354,7 +354,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=10 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -441,7 +441,7 @@ func TestMemSeries_chunk_FastPath(t *testing.T) {
 
 	// Build 3 mmapped + 3 head chunks.
 	appendSamples(t, series, 0, chunkRange*4, chunkDiskMapper)
-	series.mmapChunks(chunkDiskMapper)
+	series.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, series.mmappedChunks, 3)
 	require.Equal(t, 1, series.headChunks.len())
 	appendSamples(t, series, chunkRange*4, chunkRange*6, chunkDiskMapper)
@@ -594,7 +594,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		// require under the series lock would deadlock the cleanup's Close).
 		s.Lock()
 		headPtrBefore := s.headChunks
-		s.mmapChunks(h.chunkDiskMapper)
+		s.mmapChunks(h.chunkDiskMapper, h.series)
 		headChunksLenAfter := s.headChunks.len()
 		headPtrAfter := s.headChunks
 		newestMinTimeAfter := s.headChunks.minTime
@@ -655,7 +655,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		s.Lock()
 		headPtrBefore := s.headChunks
 		oldestMaxTime := s.headChunks.oldest().maxTime
-		s.truncateChunksBefore(oldestMaxTime+1, 0)
+		s.truncateChunksBefore(oldestMaxTime+1, 0, h.series)
 		headPtrAfter := s.headChunks
 		mmappedLenAfter := len(s.mmappedChunks)
 		firstChunkIDAfter := s.firstChunkID

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -125,7 +125,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -138,7 +138,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=1 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -151,7 +151,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -164,12 +164,12 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.setHeadChunks(nil, 0)
+				s.setHeadChunks(nil, 0, nil)
 			},
 			inputID:  0,
 			expected: outMmappedChunk,
@@ -178,12 +178,12 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=2 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.setHeadChunks(nil, 0)
+				s.setHeadChunks(nil, 0, nil)
 			},
 			inputID:  2,
 			expected: outMmappedChunk,
@@ -192,12 +192,12 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
 				require.Equal(t, (chunkRange*4)-chunkStep, s.headChunks.maxTime, "wrong maxTime on first headChunks element")
-				s.setHeadChunks(nil, 0)
+				s.setHeadChunks(nil, 0, nil)
 			},
 			inputID:  3,
 			expected: outErr,
@@ -206,7 +206,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=1 on memSeries with 3 mmapped chunks and closed ChunkDiskMapper",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -220,7 +220,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks and closed ChunkDiskMapper",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -270,7 +270,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -287,7 +287,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=2 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -304,7 +304,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -321,7 +321,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=5 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -338,7 +338,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=6 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -356,7 +356,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=10 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -416,7 +416,7 @@ func TestMemSeries_chunk(t *testing.T) {
 		// A drifted headChunkCount (larger than the actual list length) must
 		// yield ErrNotFound, not a panic or a nil chunk with a nil error.
 		s := &memSeries{ref: 1}
-		s.headChunkCount.Store(2) // Drifted: the list is empty.
+		s.headChunkCount.n.Store(2) // Drifted: the list is empty.
 
 		// ix == count-1: the walk is skipped entirely (offset 0).
 		c, headChunk, isOpen, err := s.chunk(1, nil, nil, nil)
@@ -462,7 +462,7 @@ func TestMemSeries_chunk_FastPath(t *testing.T) {
 
 	// Build 3 mmapped + 3 head chunks.
 	appendSamples(t, series, 0, chunkRange*4, chunkDiskMapper)
-	series.mmapChunks(chunkDiskMapper)
+	series.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, series.mmappedChunks, 3)
 	require.Equal(t, 1, series.headChunks.len())
 	appendSamples(t, series, chunkRange*4, chunkRange*6, chunkDiskMapper)
@@ -527,7 +527,7 @@ func TestMemSeries_chunk_ResolveAfterWrap(t *testing.T) {
 		})
 		require.True(t, ok, "sample append failed")
 	}
-	series.mmapChunks(chunkDiskMapper)
+	series.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, series.mmappedChunks, numChunks-1, "wrong number of mmapped chunks")
 	require.Equal(t, 1, series.headChunks.len(), "wrong number of head chunks")
 
@@ -558,13 +558,13 @@ func TestMemSeries_chunk_ResolveAfterWrap(t *testing.T) {
 
 	// Truncate positions 0-3. firstChunkID stays near the top of the space, so
 	// the surviving wrapped IDs (positions 10+) are numerically below it.
-	removed := series.truncateChunksBefore(chunkRange*4, 0)
+	removed := series.truncateChunksBefore(chunkRange*4, 0, nil)
 	require.Equal(t, 4, removed)
 	require.Equal(t, chunks.HeadChunkID(oooChunkIDMask-6), series.firstChunkID)
 	requireResolves(t, 4)
 
 	// Truncate positions 4-11, which carries firstChunkID itself past 0.
-	removed = series.truncateChunksBefore(chunkRange*12, 0)
+	removed = series.truncateChunksBefore(chunkRange*12, 0, nil)
 	require.Equal(t, 8, removed)
 	require.Equal(t, chunks.HeadChunkID(2), series.firstChunkID)
 	requireResolves(t, 12)
@@ -688,7 +688,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		// require under the series lock would deadlock the cleanup's Close).
 		s.Lock()
 		headPtrBefore := s.headChunks
-		s.mmapChunks(h.chunkDiskMapper)
+		s.mmapChunks(h.chunkDiskMapper, h.series)
 		headChunksLenAfter := s.headChunks.len()
 		headPtrAfter := s.headChunks
 		newestMinTimeAfter := s.headChunks.minTime
@@ -749,7 +749,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		s.Lock()
 		headPtrBefore := s.headChunks
 		oldestMaxTime := s.headChunks.oldest().maxTime
-		s.truncateChunksBefore(oldestMaxTime+1, 0)
+		s.truncateChunksBefore(oldestMaxTime+1, 0, h.series)
 		headPtrAfter := s.headChunks
 		mmappedLenAfter := len(s.mmappedChunks)
 		firstChunkIDAfter := s.firstChunkID
@@ -927,7 +927,7 @@ func BenchmarkSeriesChunkIteration(b *testing.B) {
 				firstChunkID: 0,
 				headChunks:   buildHeadChunksLight(n),
 			}
-			s.setHeadChunks(s.headChunks, uint32(n))
+			s.setHeadChunks(s.headChunks, uint32(n), nil)
 			hc := collectHeadChunks(s.headChunks, nil)
 			b.ReportAllocs()
 			for b.Loop() {
@@ -1032,7 +1032,7 @@ func BenchmarkSeriesChunk(b *testing.B) {
 					firstChunkID: 0,
 					headChunks:   buildHeadChunksLight(n),
 				}
-				s.setHeadChunks(s.headChunks, uint32(n))
+				s.setHeadChunks(s.headChunks, uint32(n), nil)
 
 				b.ReportAllocs()
 				for b.Loop() {
@@ -1069,8 +1069,8 @@ func BenchmarkTruncateChunksBefore(b *testing.B) {
 				}
 				s.firstChunkID = 0
 				s.mmappedChunks = nil
-				s.setHeadChunks(head, uint32(n))
-				benchSinkInt = s.truncateChunksBefore(mint, 0)
+				s.setHeadChunks(head, uint32(n), nil)
+				benchSinkInt = s.truncateChunksBefore(mint, 0, nil)
 			}
 		})
 	}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -102,6 +102,28 @@ func newTestHeadWithOptions(t testing.TB, compressWAL compression.Type, opts *He
 	return h, wal
 }
 
+// requireMmapReadyConsistent asserts that, for every stripe, the mmapReady
+// atomic equals the number of registered series with headChunkCount >= 2 in
+// that stripe. Used by tests that exercise the setters across real WAL
+// replay paths to lock in the invariant end-to-end.
+// Callers must ensure the head is quiesced (no concurrent appends): the
+// counts are read without holding each series lock.
+func requireMmapReadyConsistent(t testing.TB, h *Head, msg string) {
+	t.Helper()
+	for i := range h.series.size {
+		var expected int32
+		h.series.locks[i].RLock()
+		for _, s := range h.series.series[i] {
+			if s.headChunkCount.Load() >= 2 {
+				expected++
+			}
+		}
+		h.series.locks[i].RUnlock()
+		require.Equal(t, expected, h.series.mmapReady[i].Load(),
+			"%s: stripe %d mmapReady out of sync", msg, i)
+	}
+}
+
 func BenchmarkCreateSeries(b *testing.B) {
 	series := genSeries(b.N, 10, 0, 0)
 	h, _ := newTestHead(b, 10000, compression.None, false)
@@ -437,8 +459,8 @@ func BenchmarkLoadWLs(b *testing.B) {
 									// There's only one head chunk because only a single sample is appended. mmapChunks()
 									// ignores the latest chunk, so we need to cut a new head chunk to guarantee the chunk with
 									// the sample at c.mmappedChunkT is mmapped.
-									s.cutNewHeadChunk(c.mmappedChunkT, chunkenc.EncXOR, c.mmappedChunkT)
-									s.mmapChunks(chunkDiskMapper)
+									s.cutNewHeadChunk(c.mmappedChunkT, chunkenc.EncXOR, cOpts)
+									s.mmapChunks(chunkDiskMapper, nil)
 								}
 								require.NoError(b, chunkDiskMapper.Close())
 							}
@@ -2302,7 +2324,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 		ok, _ := s.append(0, int64(i), float64(i), 0, cOpts)
 		require.True(t, ok, "sample append failed")
 	}
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	// Check that truncate removes half of the chunks and afterwards
 	// that the ID of the last chunk still gives us the same chunk afterwards.
@@ -2316,7 +2338,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 	require.NotNil(t, chk)
 	require.NoError(t, err)
 
-	s.truncateChunksBefore(2000, 0)
+	s.truncateChunksBefore(2000, 0, nil)
 
 	require.Equal(t, int64(2000), s.mmappedChunks[0].minTime)
 	_, _, _, err = s.chunk(0, chunkDiskMapper, &memChunkPool, nil)
@@ -2452,7 +2474,7 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 					ok, _ := series.append(0, int64(i), float64(i), 0, cOpts)
 					require.True(t, ok, "sample append failed")
 				}
-				series.mmapChunks(chunkDiskMapper)
+				series.mmapChunks(chunkDiskMapper, nil)
 			}
 
 			if tc.headChunks == 0 {
@@ -2472,10 +2494,9 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 			}
 			require.Len(t, series.mmappedChunks, tc.mmappedChunks, "wrong number of mmapped chunks")
 
-			// Set headChunkCount before truncation (series.append bypasses observeChunkCreated).
-			series.headChunkCount.Store(uint32(tc.headChunks))
+			series.setHeadChunkCount(uint32(tc.headChunks), nil)
 
-			truncated := series.truncateChunksBefore(tc.truncateBefore, 0)
+			truncated := series.truncateChunksBefore(tc.truncateBefore, 0, nil)
 			require.Equal(t, tc.expectedTruncated, truncated, "wrong number of truncated chunks returned")
 			require.Equal(t, uint32(tc.expectedHead), series.headChunkCount.Load(), "wrong headChunkCount after truncation")
 
@@ -3061,7 +3082,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 	ok, chunkCreated = s.append(stFunc(999), 999, 2, 0, cOpts)
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	ok, chunkCreated = s.append(stFunc(1000), 1000, 3, 0, cOpts)
 	require.True(t, ok, "append failed")
@@ -3071,7 +3092,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -3085,7 +3106,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 		ok, _ := s.append(stFunc(ts), ts, float64(i), 0, cOpts)
 		require.True(t, ok, "append failed")
 	}
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	require.Greater(t, len(s.mmappedChunks)+1, 7, "expected intermediate chunks")
 
@@ -3180,7 +3201,7 @@ func testMemSeriesAppendHistogram(t *testing.T, useXOR2 bool, stFunc func(ts int
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -3191,7 +3212,7 @@ func testMemSeriesAppendHistogram(t *testing.T, useXOR2 bool, stFunc func(ts int
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "third sample should trigger a re-encoded chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -3240,7 +3261,7 @@ func TestMemSeries_append_atVariableRate(t *testing.T) {
 	require.True(t, ok, "new chunk sample was not appended")
 	require.True(t, chunkCreated, "sample at block duration timestamp should create a new chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	var totalSamplesInChunks int
 	for i, c := range s.mmappedChunks {
 		totalSamplesInChunks += int(c.numSamples)
@@ -3663,6 +3684,7 @@ func TestHeadReadWriterRepair(t *testing.T) {
 			chunkDiskMapper: h.chunkDiskMapper,
 			chunkRange:      chunkRange,
 			samplesPerChunk: DefaultSamplesPerChunk,
+			stripes:         h.series,
 		}
 
 		s, created, _ := h.getOrCreate(1, labels.FromStrings("a", "1"), false)
@@ -3676,8 +3698,9 @@ func TestHeadReadWriterRepair(t *testing.T) {
 			require.True(t, ok, "series append failed")
 			require.False(t, chunkCreated, "chunk was created")
 			h.chunkDiskMapper.CutNewFile()
-			s.mmapChunks(h.chunkDiskMapper)
+			s.mmapChunks(h.chunkDiskMapper, h.series)
 		}
+		requireMmapReadyConsistent(t, h, "after append+mmap cycles")
 		require.NoError(t, h.Close())
 
 		// Verify that there are 6 segment files.
@@ -5485,6 +5508,7 @@ func TestChunkSnapshot(t *testing.T) {
 				checkFloatHistograms()
 				checkTombstones()
 				checkExemplars()
+				requireMmapReadyConsistent(t, head, "after WAL replay")
 			}
 
 			{ // Initial data that goes into snapshot.
@@ -6096,7 +6120,7 @@ func TestHistogramCounterResetHeader(t *testing.T) {
 
 				ms, _, err := head.getOrCreate(l.Hash(), l, false)
 				require.NoError(t, err)
-				ms.mmapChunks(head.chunkDiskMapper)
+				ms.mmapChunks(head.chunkDiskMapper, head.series)
 				require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
 
 				for i, mmapChunk := range ms.mmappedChunks {
@@ -7007,7 +7031,7 @@ func TestHeadInit_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
 
-	series.mmapChunks(h.chunkDiskMapper)
+	series.mmapChunks(h.chunkDiskMapper, h.series)
 	expChunks := make([]*mmappedChunk, len(series.mmappedChunks))
 	copy(expChunks, series.mmappedChunks)
 
@@ -10133,9 +10157,8 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 				// Force the exact state required to trigger the bug: series at
 				// headChunkCount == 2 (mmap-ready) with mmapReady already incremented.
 				s.Lock()
-				s.headChunkCount.Store(2)
+				s.setHeadChunkCount(2, h.series)
 				s.Unlock()
-				h.series.incMmapReady(s.ref)
 				require.Equal(t, int32(1), mmapReadyTotal())
 
 				// Append an OOO sample. This creates an OOO chunk (not a regular
@@ -10234,6 +10257,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 						chunkDiskMapper: h.chunkDiskMapper,
 						chunkRange:      h.chunkRange.Load(),
 						samplesPerChunk: h.opts.SamplesPerChunk,
+						stripes:         h.series,
 					})
 				})
 				s.Unlock()
@@ -10314,6 +10338,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		require.Equal(t, int32(0), mmapReadyTotal())
 		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.chunks))
 		require.Equal(t, removedBefore+float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunksRemoved))
+		requireMmapReadyConsistent(t, h, "after WAL replay deletion")
 	})
 
 	// Verify the mmapReady per-stripe counter stays in sync with the actual
@@ -10333,19 +10358,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		}
 		requireCounterConsistent := func(msg string) {
 			t.Helper()
-
-			var actual int32
-			for i := range h.series.size {
-				h.series.locks[i].RLock()
-				for _, s := range h.series.series[i] {
-					if s.headChunkCount.Load() >= 2 {
-						actual++
-					}
-				}
-				h.series.locks[i].RUnlock()
-			}
-			counter := mmapReadyCounter()
-			require.Equal(t, actual, counter, "%s: mmapReady counter (%d) != actual ready count (%d)", msg, counter, actual)
+			requireMmapReadyConsistent(t, h, msg)
 		}
 
 		lblsA := labels.FromStrings("__name__", "seriesA")
@@ -10464,10 +10477,10 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		// acquired, another goroutine (GC) has already reduced the count.
 		//
 		// We create a fresh series with 1 head chunk, then artificially set
-		// headChunkCount to 2 and mmapReady to 1. mmapChunks will see
-		// headChunks.prev == nil and return 0. Without the n > 0 guard,
-		// the counter would be decremented to 0 even though the "real"
-		// decrement never happened (simulating a double-decrement).
+		// headChunkCount to 2 and mmapReady to 1 (reaching into the wrapper's
+		// inner field to simulate the racy state). mmapChunks will see
+		// headChunks.prev == nil and return 0 without crossing the >= 2
+		// threshold, so mmapReady must stay at 1.
 		lblsD := labels.FromStrings("__name__", "seriesD")
 		app = h.Appender(t.Context())
 		_, err = app.Append(0, lblsD, ts, float64(ts))
@@ -10482,19 +10495,18 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 
 		// Simulate the race: inflate headChunkCount so the series passes the
 		// >= 2 filter, and set mmapReady to 1 (as the increment site would).
-		sD.headChunkCount.Store(2)
+		sD.headChunkCount.n.Store(2)
 		h.series.mmapReady[stripeD].Add(1)
 
 		h.mmapHeadChunks()
 
-		// mmapChunks returned 0 (headChunks.prev is nil). With the n > 0
-		// guard, the counter stays at 1. Without the guard, it would drop
-		// to 0 — an incorrect extra decrement.
+		// mmapChunks returned 0 (headChunks.prev is nil). Its setter only
+		// runs after that early-return guard, so the counter stays at 1.
 		require.Equal(t, int32(1), h.series.mmapReady[stripeD].Load(),
 			"mmapHeadChunks must not decrement when mmapChunks returns 0")
 
 		// Clean up: restore the real state.
-		sD.headChunkCount.Store(1)
+		sD.headChunkCount.n.Store(1)
 		h.series.mmapReady[stripeD].Add(-1)
 		requireCounterConsistent("final state")
 	})

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -980,8 +980,8 @@ func TestHead_WALMultiRef(t *testing.T) {
 	}}, series)
 }
 
-// TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative is a regression test
-// for https://github.com/prometheus/prometheus/issues/10884.
+// TestHead_WALMultiRef_StaleDeletion_RecreatedSeriesSurvives is a regression
+// test for https://github.com/prometheus/prometheus/issues/10884.
 //
 // When a stale series is deleted via truncateStaleSeries (which writes a
 // [MinInt64, MaxInt64] tombstone to the WAL) and then re-created under the same
@@ -992,11 +992,10 @@ func TestHead_WALMultiRef(t *testing.T) {
 //	deleteSeriesByID(oldRef)           ← removes chunks from gauge
 //	reset(mSeries, newRef_chunks, newRef) ← was double-subtracting old chunks
 //
-// Without the fix, deleteSeriesByID removes M chunks from the gauge but leaves
-// series.mmappedChunks non-nil. The subsequent reset then subtracts those M
-// chunks a second time, driving prometheus_tsdb_head_chunks negative when M
-// exceeds the new series' chunk count.
-func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
+// Without deletion ordering, the new series record can resolve to the old
+// object before its queued deletion is applied. The deletion then removes the
+// object, drops the new series' samples, and corrupts chunk accounting.
+func TestHead_WALMultiRef_StaleDeletion_RecreatedSeriesSurvives(t *testing.T) {
 	head, w := newTestHead(t, 1000, compression.None, false)
 	require.NoError(t, head.Init(0))
 
@@ -1022,16 +1021,24 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 	// [MinInt64, MaxInt64] tombstone record to the WAL.
 	require.NoError(t, head.truncateStaleSeries([]storage.SeriesRef{ref1}, 3500, math.MaxUint64))
 
-	// Append a single sample with the same labels to create ref2.
-	// Ref2 has 0 m-mapped chunks, fewer than ref1's 3.
+	// Re-create the series and produce both m-mapped and active head chunks.
 	ref2 := appendSample(5000, 5)
+	appendSample(6200, 6)
+	appendSample(7300, 7)
+	appendSample(8400, 8)
 	require.NotEqual(t, ref1, ref2, "refs must differ after stale truncation and recreation")
+	head.mmapHeadChunks()
+	ref2Series := head.series.getByID(chunks.HeadSeriesRef(ref2))
+	require.NotNil(t, ref2Series)
+	require.Len(t, ref2Series.mmappedChunks, 3, "test needs real m-mapped chunks on the re-created series")
+	require.NotNil(t, ref2Series.headChunks)
 
 	require.NoError(t, head.Close())
 
 	// Reopen the head to trigger WAL replay. The WAL contains (in order):
-	//   series(ref1) → tombstone(ref1, [MinInt64,MaxInt64]) → series(ref2) → sample(ref2)
-	// Without the fix, replay drives prometheus_tsdb_head_chunks negative.
+	//   series(ref1) → tombstone(ref1, [MinInt64,MaxInt64]) → series(ref2) → samples(ref2)
+	// The deletion must complete before ref2 is resolved so its samples and
+	// m-mapped chunks are attached to a live series object.
 	w, err := wlog.New(nil, nil, w.Dir(), compression.None)
 	require.NoError(t, err)
 	opts := DefaultHeadOptions()
@@ -1044,8 +1051,656 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 		require.NoError(t, head.Close())
 	}()
 
-	chunksGauge := prom_testutil.ToFloat64(head.metrics.chunks)
-	require.GreaterOrEqual(t, chunksGauge, 0.0, "prometheus_tsdb_head_chunks gauge must not be negative after WAL replay")
+	require.Equal(t, 1, int(head.NumSeries()))
+	q, err := NewBlockQuerier(head, 5000, 8400)
+	require.NoError(t, err)
+	series := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+	require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: {
+		sample{0, 5000, 5, nil, nil},
+		sample{0, 6200, 6, nil, nil},
+		sample{0, 7300, 7, nil, nil},
+		sample{0, 8400, 8, nil, nil},
+	}}, series)
+	require.Equal(t, 4.0, prom_testutil.ToFloat64(head.metrics.chunks),
+		"the chunk gauge must count only the re-created series' three m-mapped chunks and active head chunk")
+}
+
+func TestHead_WALReplayFullDeletionOrdering(t *testing.T) {
+	fullTombstone := func(ref storage.SeriesRef) tombstones.Stone {
+		return tombstones.Stone{Ref: ref, Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}}
+	}
+
+	type testCase struct {
+		name     string
+		records  []any
+		expected map[string][]chunks.Sample
+	}
+	testCases := []testCase{
+		{
+			name: "duplicate series record after recreation",
+			records: []any{
+				[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 1, T: 10, V: 1}, {Ref: 1, T: 20, V: 2}},
+				[]tombstones.Stone{fullTombstone(1)},
+				[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSeries{{Ref: 3, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 3, T: 30, V: 3}},
+			},
+			expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+		},
+		{
+			name: "tombstone for duplicate series reference",
+			records: []any{
+				[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 2, T: 10, V: 1}},
+				[]tombstones.Stone{fullTombstone(2)},
+				[]record.RefSeries{{Ref: 3, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 3, T: 30, V: 3}},
+			},
+			expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+		},
+		{
+			name: "repeated and absent tombstones",
+			records: []any{
+				[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 1, T: 10, V: 1}},
+				[]tombstones.Stone{fullTombstone(1)},
+				[]tombstones.Stone{fullTombstone(1), fullTombstone(99)},
+				[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 2, T: 30, V: 3}},
+			},
+			expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+		},
+		{
+			name: "deletions across processor shards",
+			records: []any{
+				[]record.RefSeries{
+					{Ref: 1, Labels: labels.FromStrings("foo", "a")},
+					{Ref: 2, Labels: labels.FromStrings("foo", "b")},
+				},
+				[]record.RefSample{{Ref: 1, T: 10, V: 1}, {Ref: 2, T: 10, V: 2}},
+				[]tombstones.Stone{fullTombstone(1), fullTombstone(2)},
+				[]record.RefSeries{
+					{Ref: 3, Labels: labels.FromStrings("foo", "a")},
+					{Ref: 4, Labels: labels.FromStrings("foo", "b")},
+				},
+				[]record.RefSample{{Ref: 3, T: 30, V: 3}, {Ref: 4, T: 30, V: 4}},
+			},
+			expected: map[string][]chunks.Sample{
+				`{foo="a"}`: {sample{0, 30, 3, nil, nil}},
+				`{foo="b"}`: {sample{0, 30, 4, nil, nil}},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, concurrency := range []int{1, defaultWALReplayConcurrency} {
+				t.Run(fmt.Sprintf("concurrency=%d", concurrency), func(t *testing.T) {
+					dir := t.TempDir()
+					wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+					require.NoError(t, err)
+					populateTestWL(t, wal, tc.records, nil, false)
+
+					opts := DefaultHeadOptions()
+					opts.ChunkRange = 1000
+					opts.ChunkDirRoot = dir
+					opts.WALReplayConcurrency = concurrency
+					head, err := NewHead(nil, nil, wal, nil, opts, nil)
+					require.NoError(t, err)
+					require.NoError(t, head.Init(0))
+
+					require.Equal(t, len(tc.expected), int(head.NumSeries()))
+					q, err := NewBlockQuerier(head, 0, 100)
+					require.NoError(t, err)
+					actual := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", ".+"))
+					require.Equal(t, tc.expected, actual)
+					for _, recordType := range []string{"series", "samples", "exemplars", "histograms", "metadata", "tombstones"} {
+						require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.walReplayUnknownRefsTotal.WithLabelValues(recordType)),
+							"valid replay must not report unknown %s references", recordType)
+					}
+					require.NoError(t, head.Close())
+				})
+			}
+		})
+	}
+}
+
+type coordinatedReplayLifecycleCallback struct {
+	mtx          sync.Mutex
+	preCreations int
+	creations    int
+	deletions    int
+	preCreation  func(labels.Labels, int)
+	postCreation func(labels.Labels, int)
+	postDeletion func(map[chunks.HeadSeriesRef]labels.Labels)
+}
+
+func (c *coordinatedReplayLifecycleCallback) PreCreation(lset labels.Labels) error {
+	c.mtx.Lock()
+	c.preCreations++
+	preCreations := c.preCreations
+	preCreation := c.preCreation
+	c.mtx.Unlock()
+	if preCreation != nil {
+		preCreation(lset, preCreations)
+	}
+	return nil
+}
+
+func (c *coordinatedReplayLifecycleCallback) PostCreation(lset labels.Labels) {
+	c.mtx.Lock()
+	c.creations++
+	creations := c.creations
+	postCreation := c.postCreation
+	c.mtx.Unlock()
+	if postCreation != nil {
+		postCreation(lset, creations)
+	}
+}
+
+func (c *coordinatedReplayLifecycleCallback) PostDeletion(deleted map[chunks.HeadSeriesRef]labels.Labels) {
+	if len(deleted) == 0 {
+		return
+	}
+	c.mtx.Lock()
+	c.deletions++
+	postDeletion := c.postDeletion
+	c.mtx.Unlock()
+	if postDeletion != nil {
+		postDeletion(deleted)
+	}
+}
+
+func (c *coordinatedReplayLifecycleCallback) counts() (int, int, int) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.preCreations, c.creations, c.deletions
+}
+
+func TestWALReplayPendingDeletions(t *testing.T) {
+	registry := newWALReplayPendingDeletions()
+	firstLabels := labels.FromStrings("series", "first")
+	secondLabels := labels.FromStrings("series", "second")
+	const collidingHash = 1
+
+	firstBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	secondBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	registry.add(collidingHash, firstLabels, firstBarrier)
+	registry.add(collidingHash, secondLabels, secondBarrier)
+
+	firstBarrier.complete()
+	registry.wait(collidingHash, firstLabels)
+	registry.mtx.Lock()
+	bucket := registry.byHash[collidingHash]
+	registry.mtx.Unlock()
+	require.Equal(t, walReplayPendingDeletion{lset: secondLabels, barrier: secondBarrier}, bucket.entry)
+	require.Empty(t, bucket.collisions)
+
+	replacementBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	registry.add(collidingHash, secondLabels, replacementBarrier)
+	secondBarrier.complete()
+	registry.mtx.Lock()
+	bucket = registry.byHash[collidingHash]
+	registry.mtx.Unlock()
+	require.Equal(t, walReplayPendingDeletion{lset: secondLabels, barrier: replacementBarrier}, bucket.entry,
+		"completing an older barrier must not remove its replacement")
+	require.Empty(t, bucket.collisions)
+
+	replacementBarrier.complete()
+	registry.wait(collidingHash, secondLabels)
+	registry.mtx.Lock()
+	require.Empty(t, registry.byHash)
+	registry.mtx.Unlock()
+}
+
+type gatedReplayExemplarStorage struct {
+	ExemplarStorage
+	timestamp int64
+	entered   chan struct{}
+	release   chan struct{}
+	once      sync.Once
+}
+
+func (s *gatedReplayExemplarStorage) AddExemplar(lset labels.Labels, e exemplar.Exemplar) error {
+	if e.Ts == s.timestamp {
+		s.once.Do(func() { close(s.entered) })
+		<-s.release
+	}
+	return s.ExemplarStorage.AddExemplar(lset, e)
+}
+
+func TestHead_WALReplayFullDeletionDrainsEarlierExemplars(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+	require.NoError(t, err)
+	lset := labels.FromStrings("foo", "bar")
+	populateTestWL(t, wal, []any{
+		[]record.RefSeries{{Ref: 1, Labels: lset}},
+		[]record.RefExemplar{{Ref: 1, T: 10, V: 1, Labels: labels.FromStrings("trace_id", "old")}},
+		[]tombstones.Stone{{Ref: 1, Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}}},
+		[]record.RefSeries{{Ref: 2, Labels: lset}},
+		[]record.RefExemplar{{Ref: 2, T: 20, V: 2, Labels: labels.FromStrings("trace_id", "new")}},
+	}, nil, false)
+
+	callback := &coordinatedReplayLifecycleCallback{}
+	deletionStarted := make(chan struct{})
+	var signalDeletion sync.Once
+	callback.postDeletion = func(map[chunks.HeadSeriesRef]labels.Labels) {
+		signalDeletion.Do(func() { close(deletionStarted) })
+	}
+	opts := DefaultHeadOptions()
+	opts.ChunkDirRoot = dir
+	opts.WALReplayConcurrency = 1
+	opts.EnableExemplarStorage = true
+	opts.MaxExemplars.Store(config.DefaultExemplarsConfig.MaxExemplars)
+	opts.SeriesCallback = callback
+	head, err := NewHead(nil, nil, wal, nil, opts, nil)
+	require.NoError(t, err)
+
+	exemplarEntered := make(chan struct{})
+	allowExemplar := make(chan struct{})
+	var releaseExemplar sync.Once
+	release := func() { releaseExemplar.Do(func() { close(allowExemplar) }) }
+	t.Cleanup(release)
+	head.exemplars = &gatedReplayExemplarStorage{
+		ExemplarStorage: head.exemplars,
+		timestamp:       10,
+		entered:         exemplarEntered,
+		release:         allowExemplar,
+	}
+	drainHookEntered := make(chan (<-chan struct{}), 1)
+	allowDrainHook := make(chan struct{})
+	var releaseDrainHook sync.Once
+	releaseHook := func() { releaseDrainHook.Do(func() { close(allowDrainHook) }) }
+	t.Cleanup(releaseHook)
+	head.walReplayExemplarDrainHook = func(done <-chan struct{}) {
+		drainHookEntered <- done
+		<-allowDrainHook
+	}
+
+	initDone := make(chan error, 1)
+	go func() {
+		initDone <- head.Init(0)
+	}()
+
+	select {
+	case <-exemplarEntered:
+	case <-time.After(10 * time.Second):
+		releaseHook()
+		release()
+		initErr := <-initDone
+		require.NoError(t, initErr)
+		require.NoError(t, head.Close())
+		require.FailNow(t, "timed out waiting for the earlier exemplar")
+	}
+	var exemplarDrainDone <-chan struct{}
+	select {
+	case exemplarDrainDone = <-drainHookEntered:
+	case <-time.After(10 * time.Second):
+		releaseHook()
+		release()
+		initErr := <-initDone
+		require.NoError(t, initErr)
+		require.NoError(t, head.Close())
+		require.FailNow(t, "timed out waiting for the exemplar drain marker")
+	}
+	select {
+	case <-exemplarDrainDone:
+		require.Fail(t, "the drain marker completed before the earlier exemplar")
+	default:
+	}
+	select {
+	case <-deletionStarted:
+		require.Fail(t, "deletion started before the earlier exemplar was drained")
+	default:
+	}
+
+	releaseHook()
+	release()
+	require.NoError(t, <-initDone)
+	var exemplarTimestamps []int64
+	require.NoError(t, head.exemplars.IterateExemplars(func(_ labels.Labels, e exemplar.Exemplar) error {
+		exemplarTimestamps = append(exemplarTimestamps, e.Ts)
+		return nil
+	}))
+	require.Equal(t, []int64{10, 20}, exemplarTimestamps)
+	require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.walReplayUnknownRefsTotal.WithLabelValues("exemplars")))
+	require.NoError(t, head.Close())
+}
+
+func TestHead_WALReplayFullDeletionWaitsOnlyForMatchingSeries(t *testing.T) {
+	const stripeSize = 32
+	for _, blockedRef := range []chunks.HeadSeriesRef{1, 2} {
+		t.Run(fmt.Sprintf("blocked_ref=%d", blockedRef), func(t *testing.T) {
+			refStripe := int(blockedRef) & (stripeSize - 1)
+			labelOutsideStripe := func(value string, stripe int) labels.Labels {
+				for i := 0; ; i++ {
+					lset := labels.FromStrings("series", fmt.Sprintf("%s-%d", value, i))
+					if int(lset.Hash()&uint64(stripeSize-1)) != stripe {
+						return lset
+					}
+				}
+			}
+
+			dir := t.TempDir()
+			wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+			require.NoError(t, err)
+			oldLabels := labelOutsideStripe("old", refStripe)
+			blockedHashStripe := int(oldLabels.Hash() & uint64(stripeSize-1))
+			unrelatedLabels := labelOutsideStripe("unrelated", blockedHashStripe)
+			unrelatedRef := chunks.HeadSeriesRef(3)
+			for int(unrelatedRef)&(stripeSize-1) == blockedHashStripe || unrelatedRef == blockedRef {
+				unrelatedRef++
+			}
+			replacementRef := unrelatedRef + 1
+			for replacementRef == blockedRef {
+				replacementRef++
+			}
+			populateTestWL(t, wal, []any{
+				[]record.RefSeries{{Ref: blockedRef, Labels: oldLabels}},
+				[]record.RefSample{{Ref: blockedRef, T: 10, V: 1}},
+				[]tombstones.Stone{{Ref: storage.SeriesRef(blockedRef), Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}}},
+				[]record.RefSeries{{Ref: unrelatedRef, Labels: unrelatedLabels}},
+				[]record.RefSeries{{Ref: replacementRef, Labels: oldLabels}},
+				[]record.RefSample{{Ref: unrelatedRef, T: 20, V: 2}, {Ref: replacementRef, T: 30, V: 3}},
+			}, nil, false)
+
+			callback := &coordinatedReplayLifecycleCallback{}
+			initialSeriesCreated := make(chan struct{})
+			allowReplay := make(chan struct{})
+			unrelatedPreCreation := make(chan struct{})
+			unrelatedPostCreation := make(chan struct{})
+			replacementPreCreation := make(chan struct{})
+			replacementPostCreation := make(chan struct{})
+			deletionStarted := make(chan struct{})
+			allowDeletion := make(chan struct{})
+			var signalInitialCreation, releaseCreation, signalUnrelatedPre, signalUnrelatedPost sync.Once
+			var signalReplacementPre, signalReplacementPost, signalDeletion, releaseDeletion sync.Once
+			releaseReplay := func() { releaseCreation.Do(func() { close(allowReplay) }) }
+			releaseDeletionCallback := func() { releaseDeletion.Do(func() { close(allowDeletion) }) }
+			t.Cleanup(func() {
+				releaseReplay()
+				releaseDeletionCallback()
+			})
+			oldPreCreations := 0
+			callback.preCreation = func(lset labels.Labels, _ int) {
+				switch {
+				case labels.Equal(lset, oldLabels):
+					oldPreCreations++
+					if oldPreCreations == 2 {
+						signalReplacementPre.Do(func() { close(replacementPreCreation) })
+					}
+				case labels.Equal(lset, unrelatedLabels):
+					signalUnrelatedPre.Do(func() { close(unrelatedPreCreation) })
+				}
+			}
+			oldPostCreations := 0
+			callback.postCreation = func(lset labels.Labels, _ int) {
+				switch {
+				case labels.Equal(lset, oldLabels):
+					oldPostCreations++
+					if oldPostCreations == 1 {
+						signalInitialCreation.Do(func() { close(initialSeriesCreated) })
+						<-allowReplay
+					} else {
+						signalReplacementPost.Do(func() { close(replacementPostCreation) })
+					}
+				case labels.Equal(lset, unrelatedLabels):
+					signalUnrelatedPost.Do(func() { close(unrelatedPostCreation) })
+				}
+			}
+			callback.postDeletion = func(deleted map[chunks.HeadSeriesRef]labels.Labels) {
+				if _, ok := deleted[blockedRef]; ok {
+					signalDeletion.Do(func() { close(deletionStarted) })
+					<-allowDeletion
+				}
+			}
+
+			opts := DefaultHeadOptions()
+			opts.ChunkDirRoot = dir
+			opts.StripeSize = stripeSize
+			opts.WALReplayConcurrency = 2
+			opts.SeriesCallback = callback
+			head, err := NewHead(nil, nil, wal, nil, opts, nil)
+			require.NoError(t, err)
+
+			initDone := make(chan error, 1)
+			go func() {
+				initDone <- head.Init(0)
+			}()
+
+			select {
+			case <-initialSeriesCreated:
+			case <-time.After(10 * time.Second):
+				releaseReplay()
+				releaseDeletionCallback()
+				initErr := <-initDone
+				require.NoError(t, initErr)
+				require.NoError(t, head.Close())
+				require.FailNow(t, "timed out waiting for the initial series")
+			}
+
+			releaseReplay()
+
+			select {
+			case <-unrelatedPreCreation:
+			case <-time.After(10 * time.Second):
+				releaseDeletionCallback()
+				initErr := <-initDone
+				require.NoError(t, initErr)
+				require.NoError(t, head.Close())
+				require.FailNow(t, "timed out waiting for unrelated PreCreation")
+			}
+			select {
+			case <-unrelatedPostCreation:
+			case <-time.After(10 * time.Second):
+				releaseDeletionCallback()
+				initErr := <-initDone
+				require.NoError(t, initErr)
+				require.NoError(t, head.Close())
+				require.FailNow(t, "timed out waiting for unrelated PostCreation")
+			}
+			select {
+			case <-replacementPreCreation:
+				require.Fail(t, "replacement PreCreation ran before the matching deletion")
+			default:
+			}
+			select {
+			case <-replacementPostCreation:
+				require.Fail(t, "replacement PostCreation ran before the matching deletion")
+			default:
+			}
+
+			select {
+			case <-deletionStarted:
+			case <-time.After(10 * time.Second):
+				releaseDeletionCallback()
+				initErr := <-initDone
+				require.NoError(t, initErr)
+				require.NoError(t, head.Close())
+				require.FailNow(t, "timed out waiting for PostDeletion")
+			}
+			select {
+			case <-replacementPreCreation:
+				require.Fail(t, "replacement PreCreation ran before PostDeletion returned")
+			default:
+			}
+			select {
+			case <-replacementPostCreation:
+				require.Fail(t, "replacement PostCreation ran before PostDeletion returned")
+			default:
+			}
+
+			releaseDeletionCallback()
+			require.NoError(t, <-initDone)
+			preCreations, creations, deletions := callback.counts()
+			require.Equal(t, 3, preCreations)
+			require.Equal(t, 3, creations)
+			require.Equal(t, 1, deletions)
+			require.Equal(t, uint64(2), head.NumSeries())
+			q, err := NewBlockQuerier(head, 0, 100)
+			require.NoError(t, err)
+			actual := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "series", ".+"))
+			require.Equal(t, map[string][]chunks.Sample{
+				oldLabels.String():       {sample{0, 30, 3, nil, nil}},
+				unrelatedLabels.String(): {sample{0, 20, 2, nil, nil}},
+			}, actual)
+			require.NoError(t, head.Close())
+		})
+	}
+}
+
+func TestHead_WALReplayFullDeletionPreservesWBLData(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+	require.NoError(t, err)
+	wbl, err := wlog.New(nil, nil, filepath.Join(dir, wlog.WblDirName), compression.None)
+	require.NoError(t, err)
+	lset := labels.FromStrings("foo", "bar")
+	populateTestWL(t, wal, []any{
+		[]record.RefSeries{{Ref: 1, Labels: lset}},
+		[]record.RefSample{{Ref: 1, T: 10, V: 1}},
+		[]tombstones.Stone{{Ref: 1, Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}}},
+		[]record.RefSeries{{Ref: 2, Labels: lset}},
+		[]record.RefSample{{Ref: 2, T: 100, V: 2}},
+	}, nil, false)
+	populateTestWL(t, wbl, []any{
+		[]record.RefSample{{Ref: 2, T: 50, V: 3}},
+	}, nil, false)
+	require.NoError(t, wal.Close())
+	require.NoError(t, wbl.Close())
+	wal, err = wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+	require.NoError(t, err)
+	wbl, err = wlog.New(nil, nil, filepath.Join(dir, wlog.WblDirName), compression.None)
+	require.NoError(t, err)
+
+	opts := DefaultHeadOptions()
+	opts.ChunkDirRoot = dir
+	opts.OutOfOrderTimeWindow.Store(10 * time.Minute.Milliseconds())
+	head, err := NewHead(nil, nil, wal, wbl, opts, nil)
+	require.NoError(t, err)
+	require.NoError(t, head.Init(0))
+
+	q, err := NewBlockQuerier(head, 0, 200)
+	require.NoError(t, err)
+	actual := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+	require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: {
+		sample{0, 100, 2, nil, nil},
+	}}, actual)
+
+	ms := head.series.getByID(2)
+	require.NotNil(t, ms)
+	require.NotNil(t, ms.ooo)
+	require.NotNil(t, ms.ooo.oooHeadChunk)
+	oooChunks, err := ms.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, false, false)
+	require.NoError(t, err)
+	require.Len(t, oooChunks, 1)
+	oooSamples, err := storage.ExpandSamples(oooChunks[0].chunk.Iterator(nil), nil)
+	require.NoError(t, err)
+	requireEqualSamples(t, lset.String(), []chunks.Sample{sample{0, 50, 3, nil, nil}}, oooSamples)
+	require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.wblReplayUnknownRefsTotal.WithLabelValues("samples")))
+	require.NoError(t, head.Close())
+}
+
+func BenchmarkHeadWALReplayFullDeletion(b *testing.B) {
+	const (
+		generations         = 6
+		seriesPerGeneration = 1000
+	)
+	cases := []struct {
+		name                string
+		fullDeletionRecords int
+		recreate            bool
+	}{
+		{name: "none"},
+		{name: "unrelated/one", fullDeletionRecords: 1},
+		{name: "unrelated/repeated", fullDeletionRecords: 5},
+		{name: "recreated/one", fullDeletionRecords: 1, recreate: true},
+		{name: "recreated/repeated", fullDeletionRecords: 5, recreate: true},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			walDir := b.TempDir()
+			wal, err := wlog.New(nil, nil, walDir, compression.None)
+			require.NoError(b, err)
+
+			var buf []byte
+			for generation := range generations {
+				series := make([]record.RefSeries, 0, seriesPerGeneration)
+				samples := make([]record.RefSample, 0, seriesPerGeneration)
+				tombstonesForGeneration := make([]tombstones.Stone, 0, seriesPerGeneration)
+				for i := range seriesPerGeneration {
+					ref := chunks.HeadSeriesRef(generation*seriesPerGeneration + i + 1)
+					lset := labels.FromStrings(
+						"__name__", "wal_replay_benchmark",
+						"series", strconv.Itoa(i),
+					)
+					if !tc.recreate {
+						lset = labels.FromStrings(
+							"__name__", "wal_replay_benchmark",
+							"generation", strconv.Itoa(generation),
+							"series", strconv.Itoa(i),
+						)
+					}
+					series = append(series, record.RefSeries{
+						Ref:    ref,
+						Labels: lset,
+					})
+					samples = append(samples, record.RefSample{Ref: ref, T: int64(generation), V: float64(generation)})
+					tombstonesForGeneration = append(tombstonesForGeneration, tombstones.Stone{
+						Ref: storage.SeriesRef(ref),
+						Intervals: tombstones.Intervals{{
+							Mint: math.MinInt64,
+							Maxt: math.MaxInt64,
+						}},
+					})
+				}
+				buf = populateTestWL(b, wal, []any{series, samples}, buf, false)
+				if generation < tc.fullDeletionRecords {
+					buf = populateTestWL(b, wal, []any{tombstonesForGeneration}, buf, false)
+				}
+			}
+			require.NoError(b, wal.Close())
+
+			for _, concurrency := range []int{1, defaultWALReplayConcurrency} {
+				b.Run(fmt.Sprintf("concurrency=%d", concurrency), func(b *testing.B) {
+					chunkDirRoot := b.TempDir()
+					b.ReportAllocs()
+					for b.Loop() {
+						b.StopTimer()
+						segmentsReader, err := wlog.NewSegmentsReader(walDir)
+						require.NoError(b, err)
+						opts := DefaultHeadOptions()
+						opts.ChunkDirRoot = chunkDirRoot
+						opts.WALReplayConcurrency = concurrency
+						head, err := NewHead(nil, nil, nil, nil, opts, nil)
+						require.NoError(b, err)
+
+						b.StartTimer()
+						err = head.loadWAL(
+							wlog.NewReader(segmentsReader),
+							labels.NewSymbolTable(),
+							map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{},
+							nil,
+							nil,
+						)
+						b.StopTimer()
+						require.NoError(b, err)
+						expectedSeries := uint64((generations - tc.fullDeletionRecords) * seriesPerGeneration)
+						if tc.recreate {
+							expectedSeries = seriesPerGeneration
+						}
+						require.Equal(b, expectedSeries, head.NumSeries())
+						require.NoError(b, segmentsReader.Close())
+						require.NoError(b, head.Close())
+						b.StartTimer()
+					}
+				})
+			}
+		})
+	}
 }
 
 func TestHead_WALCheckpointMultiRef(t *testing.T) {
@@ -8905,15 +9560,12 @@ func TestFloatChunkEncodingSwitchWaitsForNextChunk(t *testing.T) {
 	})
 }
 
-// TestWALReplayRaceWithStaleSeriesCompaction verifies that deleteSeriesByID correctly locks the
-// hash shard (not only the ref shard) when deleting from the hashes map.
-// The race only occurs when Prometheus restarts after having done a stale series compaction because
-// deleteSeriesByID is not used otherwise.
-func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
+// TestWALReplayFullDeletionBeforeLaterSeriesCreation verifies that replayed
+// full deletions complete before later series records and samples are handled.
+func TestWALReplayFullDeletionBeforeLaterSeriesCreation(t *testing.T) {
 	opts := newTestHeadDefaultOptions(1000, false)
-	// A small stripe size ensures many series share hash shards, increasing
-	// the likelihood that deleteSeriesByID and getOrCreateWithOptionalID
-	// contend on the same shard during WAL replay.
+	// A small stripe size makes the test cover many ref and hash shard
+	// collisions while replaying a large deletion batch.
 	opts.StripeSize = 32
 	head, _ := newTestHeadWithOptions(t, compression.None, opts)
 	require.NoError(t, head.Init(0))
@@ -8949,12 +9601,9 @@ func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
 	require.Equal(t, uint64(0), head.NumStaleSeries())
 	require.Equal(t, uint64(0), head.NumSeries())
 
-	// Step 3: Add new series AFTER the truncation. In the WAL, these series
-	// records appear after the tombstone records. During replay, the main
-	// goroutine will create these series (via getOrCreateWithOptionalID, which
-	// accesses hashes[hashShard] under locks[hashShard]) concurrently with
-	// the walSubsetProcessor goroutines deleting the stale series (via
-	// deleteSeriesByID, which must also lock the correct hashShard).
+	// Step 3: Add new series after the truncation. In the WAL, these series
+	// records and samples appear after the tombstone records and must not be
+	// overtaken by the queued full deletions.
 	const numNewSeries = 500
 	for i := range numNewSeries {
 		lbl := labels.FromStrings("__name__", "new_metric", "i", strconv.Itoa(i))
@@ -8963,19 +9612,24 @@ func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
 	require.Equal(t, uint64(numNewSeries), head.NumSeries())
 
 	// Step 4: Close and re-open the Head to trigger WAL replay.
-	// With the buggy locking, the race detector should catch the data race
-	// between the main goroutine (creating series) and worker goroutines
-	// (deleting stale series) during replay.
 	require.NoError(t, head.Close())
 
 	wal, err := wlog.NewSize(nil, nil, filepath.Join(head.opts.ChunkDirRoot, "wal"), 32768, compression.None)
 	require.NoError(t, err)
 	head, err = NewHead(nil, nil, wal, nil, head.opts, nil)
 	require.NoError(t, err)
-	require.NoError(t, head.Init(0)) // Should not cause a race here.
+	require.NoError(t, head.Init(0))
 
 	require.Equal(t, uint64(0), head.NumStaleSeries())
 	require.Equal(t, uint64(numNewSeries), head.NumSeries())
+	q, err := NewBlockQuerier(head, 0, 500)
+	require.NoError(t, err)
+	series := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".+"))
+	require.Len(t, series, numNewSeries)
+	for _, samples := range series {
+		require.Len(t, samples, 1)
+		require.Equal(t, int64(300), samples[0].T())
+	}
 	require.NoError(t, head.Close())
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -9594,6 +9594,74 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		}
 	})
 
+	t.Run("wal replay deletion clears all chunk state", func(t *testing.T) {
+		opts := newTestHeadDefaultOptions(DefaultBlockDuration, true)
+		opts.OutOfOrderCapMax.Store(1)
+		h, _ := newTestHeadWithOptions(t, compression.None, opts)
+		require.NoError(t, h.Init(0))
+
+		mmapReadyTotal := func() int32 {
+			var n int32
+			for i := range h.series.size {
+				n += h.series.mmapReady[i].Load()
+			}
+			return n
+		}
+
+		lbls := labels.FromStrings("__name__", "seriesToDelete")
+		ts := int64(0)
+		app := h.Appender(t.Context())
+		for range chunkCutIterations {
+			_, err := app.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+
+		// With an OOO chunk capacity of one, the second OOO sample m-maps the
+		// first OOO head chunk and creates a replacement head chunk.
+		oooTs := ts - 5*time.Minute.Milliseconds()
+		app = h.Appender(t.Context())
+		_, err := app.Append(0, lbls, oooTs, 1)
+		require.NoError(t, err)
+		_, err = app.Append(0, lbls, oooTs+1, 2)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		s := h.series.getByHash(lbls.Hash(), lbls)
+		require.NotNil(t, s)
+		require.GreaterOrEqual(t, s.headChunkCount.Load(), uint32(2))
+		require.NotNil(t, s.ooo)
+		require.NotEmpty(t, s.ooo.oooMmappedChunks)
+		require.NotNil(t, s.ooo.oooHeadChunk)
+		require.Equal(t, int32(1), mmapReadyTotal())
+
+		expectedRemoved := len(s.mmappedChunks) + s.headChunks.len() + len(s.ooo.oooMmappedChunks) + 1
+		require.Equal(t, float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunks))
+		removedBefore := prom_testutil.ToFloat64(h.metrics.chunksRemoved)
+
+		h.deleteSeriesByID([]chunks.HeadSeriesRef{s.ref})
+
+		require.Nil(t, h.series.getByID(s.ref))
+		require.Nil(t, h.series.getByHash(lbls.Hash(), lbls))
+		require.Zero(t, h.NumSeries())
+		require.Equal(t, int32(0), mmapReadyTotal())
+		require.Zero(t, s.headChunkCount.Load())
+		require.Nil(t, s.headChunks)
+		require.Nil(t, s.app)
+		require.Nil(t, s.mmappedChunks)
+		require.Nil(t, s.ooo)
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.chunks))
+		require.Equal(t, removedBefore+float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunksRemoved))
+
+		// A stale reset with no chunks must not release mmap readiness or chunk
+		// accounting a second time.
+		h.resetSeriesWithMMappedChunks(s, nil, nil, s.ref+1)
+		require.Equal(t, int32(0), mmapReadyTotal())
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.chunks))
+		require.Equal(t, removedBefore+float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunksRemoved))
+	})
+
 	// Verify the mmapReady per-stripe counter stays in sync with the actual
 	// number of series that have headChunkCount >= 2, across append, mmap,
 	// GC, and stale-series deletion.

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -980,8 +980,8 @@ func TestHead_WALMultiRef(t *testing.T) {
 	}}, series)
 }
 
-// TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative is a regression test
-// for https://github.com/prometheus/prometheus/issues/10884.
+// TestHead_WALMultiRef_StaleDeletion_RecreatedSeriesSurvives is a regression
+// test for https://github.com/prometheus/prometheus/issues/10884.
 //
 // When a stale series is deleted via truncateStaleSeries (which writes a
 // [MinInt64, MaxInt64] tombstone to the WAL) and then re-created under the same
@@ -992,11 +992,10 @@ func TestHead_WALMultiRef(t *testing.T) {
 //	deleteSeriesByID(oldRef)           ← removes chunks from gauge
 //	reset(mSeries, newRef_chunks, newRef) ← was double-subtracting old chunks
 //
-// Without the fix, deleteSeriesByID removes M chunks from the gauge but leaves
-// series.mmappedChunks non-nil. The subsequent reset then subtracts those M
-// chunks a second time, driving prometheus_tsdb_head_chunks negative when M
-// exceeds the new series' chunk count.
-func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
+// Without deletion ordering, the new series record can resolve to the old
+// object before its queued deletion is applied. The deletion then removes the
+// object, drops the new series' samples, and corrupts chunk accounting.
+func TestHead_WALMultiRef_StaleDeletion_RecreatedSeriesSurvives(t *testing.T) {
 	head, w := newTestHead(t, 1000, compression.None, false)
 	require.NoError(t, head.Init(0))
 
@@ -1022,16 +1021,24 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 	// [MinInt64, MaxInt64] tombstone record to the WAL.
 	require.NoError(t, head.truncateStaleSeries([]storage.SeriesRef{ref1}, 3500, math.MaxUint64))
 
-	// Append a single sample with the same labels to create ref2.
-	// Ref2 has 0 m-mapped chunks, fewer than ref1's 3.
+	// Re-create the series and produce both m-mapped and active head chunks.
 	ref2 := appendSample(5000, 5)
+	appendSample(6200, 6)
+	appendSample(7300, 7)
+	appendSample(8400, 8)
 	require.NotEqual(t, ref1, ref2, "refs must differ after stale truncation and recreation")
+	head.mmapHeadChunks()
+	ref2Series := head.series.getByID(chunks.HeadSeriesRef(ref2))
+	require.NotNil(t, ref2Series)
+	require.Len(t, ref2Series.mmappedChunks, 3, "test needs real m-mapped chunks on the re-created series")
+	require.NotNil(t, ref2Series.headChunks)
 
 	require.NoError(t, head.Close())
 
 	// Reopen the head to trigger WAL replay. The WAL contains (in order):
-	//   series(ref1) → tombstone(ref1, [MinInt64,MaxInt64]) → series(ref2) → sample(ref2)
-	// Without the fix, replay drives prometheus_tsdb_head_chunks negative.
+	//   series(ref1) → tombstone(ref1, [MinInt64,MaxInt64]) → series(ref2) → samples(ref2)
+	// The deletion must complete before ref2 is resolved so its samples and
+	// m-mapped chunks are attached to a live series object.
 	w, err := wlog.New(nil, nil, w.Dir(), compression.None)
 	require.NoError(t, err)
 	opts := DefaultHeadOptions()
@@ -1044,8 +1051,729 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 		require.NoError(t, head.Close())
 	}()
 
-	chunksGauge := prom_testutil.ToFloat64(head.metrics.chunks)
-	require.GreaterOrEqual(t, chunksGauge, 0.0, "prometheus_tsdb_head_chunks gauge must not be negative after WAL replay")
+	require.Equal(t, 1, int(head.NumSeries()))
+	q, err := NewBlockQuerier(head, 5000, 8400)
+	require.NoError(t, err)
+	series := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+	require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: {
+		sample{0, 5000, 5, nil, nil},
+		sample{0, 6200, 6, nil, nil},
+		sample{0, 7300, 7, nil, nil},
+		sample{0, 8400, 8, nil, nil},
+	}}, series)
+	require.Equal(t, 4.0, prom_testutil.ToFloat64(head.metrics.chunks),
+		"the chunk gauge must count only the re-created series' three m-mapped chunks and active head chunk")
+}
+
+type coordinatedReplayLifecycleCallback struct {
+	mtx          sync.Mutex
+	preCreations int
+	creations    int
+	deletions    int
+	preCreation  func(labels.Labels, int)
+	postCreation func(labels.Labels, int)
+	postDeletion func(map[chunks.HeadSeriesRef]labels.Labels)
+}
+
+func (c *coordinatedReplayLifecycleCallback) PreCreation(lset labels.Labels) error {
+	c.mtx.Lock()
+	c.preCreations++
+	preCreations := c.preCreations
+	preCreation := c.preCreation
+	c.mtx.Unlock()
+	if preCreation != nil {
+		preCreation(lset, preCreations)
+	}
+	return nil
+}
+
+func (c *coordinatedReplayLifecycleCallback) PostCreation(lset labels.Labels) {
+	c.mtx.Lock()
+	c.creations++
+	creations := c.creations
+	postCreation := c.postCreation
+	c.mtx.Unlock()
+	if postCreation != nil {
+		postCreation(lset, creations)
+	}
+}
+
+func (c *coordinatedReplayLifecycleCallback) PostDeletion(deleted map[chunks.HeadSeriesRef]labels.Labels) {
+	if len(deleted) == 0 {
+		return
+	}
+	c.mtx.Lock()
+	c.deletions++
+	postDeletion := c.postDeletion
+	c.mtx.Unlock()
+	if postDeletion != nil {
+		postDeletion(deleted)
+	}
+}
+
+func (c *coordinatedReplayLifecycleCallback) counts() (int, int, int) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.preCreations, c.creations, c.deletions
+}
+
+func TestWALReplayPendingDeletions(t *testing.T) {
+	registry := newWALReplayPendingDeletions()
+	firstLabels := labels.FromStrings("series", "first")
+	secondLabels := labels.FromStrings("series", "second")
+	const collidingHash = 1
+
+	firstBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	secondBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	registry.add(collidingHash, firstLabels, firstBarrier)
+	registry.add(collidingHash, secondLabels, secondBarrier)
+
+	firstBarrier.complete()
+	registry.wait(collidingHash, firstLabels)
+	registry.mtx.Lock()
+	bucket := registry.byHash[collidingHash]
+	registry.mtx.Unlock()
+	require.Equal(t, walReplayPendingDeletion{lset: secondLabels, barrier: secondBarrier}, bucket.entry)
+	require.Empty(t, bucket.collisions)
+
+	replacementBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	registry.add(collidingHash, secondLabels, replacementBarrier)
+	secondBarrier.complete()
+	registry.mtx.Lock()
+	bucket = registry.byHash[collidingHash]
+	registry.mtx.Unlock()
+	require.Equal(t, walReplayPendingDeletion{lset: secondLabels, barrier: replacementBarrier}, bucket.entry,
+		"completing an older barrier must not remove its replacement")
+	require.Empty(t, bucket.collisions)
+
+	replacementBarrier.complete()
+	registry.wait(collidingHash, secondLabels)
+	registry.mtx.Lock()
+	require.Empty(t, registry.byHash)
+	registry.mtx.Unlock()
+}
+
+type gatedReplayExemplarStorage struct {
+	ExemplarStorage
+	timestamp int64
+	entered   chan struct{}
+	release   chan struct{}
+	once      sync.Once
+}
+
+func (s *gatedReplayExemplarStorage) AddExemplar(lset labels.Labels, e exemplar.Exemplar) error {
+	if e.Ts == s.timestamp {
+		s.once.Do(func() { close(s.entered) })
+		<-s.release
+	}
+	return s.ExemplarStorage.AddExemplar(lset, e)
+}
+
+func TestHead_WALReplayFullDeletion(t *testing.T) {
+	fullTombstone := func(ref storage.SeriesRef) tombstones.Stone {
+		return tombstones.Stone{Ref: ref, Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}}
+	}
+	closeOnce := func(ch chan struct{}) func() {
+		var once sync.Once
+		return func() { once.Do(func() { close(ch) }) }
+	}
+	newReplayHead := func(t *testing.T, records []any, opts *HeadOptions) *Head {
+		t.Helper()
+		dir := t.TempDir()
+		wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+		require.NoError(t, err)
+		populateTestWL(t, wal, records, nil, false)
+		opts.ChunkDirRoot = dir
+		head, err := NewHead(nil, nil, wal, nil, opts, nil)
+		require.NoError(t, err)
+		return head
+	}
+
+	t.Run("ordering", func(t *testing.T) {
+		type testCase struct {
+			name     string
+			records  []any
+			expected map[string][]chunks.Sample
+		}
+		testCases := []testCase{
+			{
+				name: "duplicate series record after recreation",
+				records: []any{
+					[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 1, T: 10, V: 1}, {Ref: 1, T: 20, V: 2}},
+					[]tombstones.Stone{fullTombstone(1)},
+					[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSeries{{Ref: 3, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 3, T: 30, V: 3}},
+				},
+				expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+			},
+			{
+				name: "tombstone for duplicate series reference",
+				records: []any{
+					[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 2, T: 10, V: 1}},
+					[]tombstones.Stone{fullTombstone(2)},
+					[]record.RefSeries{{Ref: 3, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 3, T: 30, V: 3}},
+				},
+				expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+			},
+			{
+				name: "repeated and absent tombstones",
+				records: []any{
+					[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 1, T: 10, V: 1}},
+					[]tombstones.Stone{fullTombstone(1)},
+					[]tombstones.Stone{fullTombstone(1), fullTombstone(99)},
+					[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 2, T: 30, V: 3}},
+				},
+				expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+			},
+			{
+				name: "deletions across processor shards",
+				records: []any{
+					[]record.RefSeries{
+						{Ref: 1, Labels: labels.FromStrings("foo", "a")},
+						{Ref: 2, Labels: labels.FromStrings("foo", "b")},
+					},
+					[]record.RefSample{{Ref: 1, T: 10, V: 1}, {Ref: 2, T: 10, V: 2}},
+					[]tombstones.Stone{fullTombstone(1), fullTombstone(2)},
+					[]record.RefSeries{
+						{Ref: 3, Labels: labels.FromStrings("foo", "a")},
+						{Ref: 4, Labels: labels.FromStrings("foo", "b")},
+					},
+					[]record.RefSample{{Ref: 3, T: 30, V: 3}, {Ref: 4, T: 30, V: 4}},
+				},
+				expected: map[string][]chunks.Sample{
+					`{foo="a"}`: {sample{0, 30, 3, nil, nil}},
+					`{foo="b"}`: {sample{0, 30, 4, nil, nil}},
+				},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				for _, concurrency := range []int{1, defaultWALReplayConcurrency} {
+					t.Run(fmt.Sprintf("concurrency=%d", concurrency), func(t *testing.T) {
+						opts := DefaultHeadOptions()
+						opts.ChunkRange = 1000
+						opts.WALReplayConcurrency = concurrency
+						head := newReplayHead(t, tc.records, opts)
+						require.NoError(t, head.Init(0))
+
+						require.Equal(t, len(tc.expected), int(head.NumSeries()))
+						q, err := NewBlockQuerier(head, 0, 100)
+						require.NoError(t, err)
+						actual := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", ".+"))
+						require.Equal(t, tc.expected, actual)
+						for _, recordType := range []string{"series", "samples", "exemplars", "histograms", "metadata", "tombstones"} {
+							require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.walReplayUnknownRefsTotal.WithLabelValues(recordType)),
+								"valid replay must not report unknown %s references", recordType)
+						}
+						require.NoError(t, head.Close())
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("drains earlier exemplars", func(t *testing.T) {
+		lset := labels.FromStrings("foo", "bar")
+		records := []any{
+			[]record.RefSeries{{Ref: 1, Labels: lset}},
+			[]record.RefExemplar{{Ref: 1, T: 10, V: 1, Labels: labels.FromStrings("trace_id", "old")}},
+			[]tombstones.Stone{fullTombstone(1)},
+			[]record.RefSeries{{Ref: 2, Labels: lset}},
+			[]record.RefExemplar{{Ref: 2, T: 20, V: 2, Labels: labels.FromStrings("trace_id", "new")}},
+		}
+
+		callback := &coordinatedReplayLifecycleCallback{}
+		deletionStarted := make(chan struct{})
+		signalDeletion := closeOnce(deletionStarted)
+		callback.postDeletion = func(map[chunks.HeadSeriesRef]labels.Labels) {
+			signalDeletion()
+		}
+		opts := DefaultHeadOptions()
+		opts.WALReplayConcurrency = 1
+		opts.EnableExemplarStorage = true
+		opts.MaxExemplars.Store(config.DefaultExemplarsConfig.MaxExemplars)
+		opts.SeriesCallback = callback
+		head := newReplayHead(t, records, opts)
+
+		exemplarEntered := make(chan struct{})
+		allowExemplar := make(chan struct{})
+		release := closeOnce(allowExemplar)
+		t.Cleanup(release)
+		head.exemplars = &gatedReplayExemplarStorage{
+			ExemplarStorage: head.exemplars,
+			timestamp:       10,
+			entered:         exemplarEntered,
+			release:         allowExemplar,
+		}
+		drainHookEntered := make(chan (<-chan struct{}), 1)
+		allowDrainHook := make(chan struct{})
+		releaseHook := closeOnce(allowDrainHook)
+		t.Cleanup(releaseHook)
+		head.walReplayExemplarDrainHook = func(done <-chan struct{}) {
+			drainHookEntered <- done
+			<-allowDrainHook
+		}
+
+		initDone := make(chan error, 1)
+		go func() {
+			initDone <- head.Init(0)
+		}()
+
+		select {
+		case <-exemplarEntered:
+		case <-time.After(10 * time.Second):
+			releaseHook()
+			release()
+			initErr := <-initDone
+			require.NoError(t, initErr)
+			require.NoError(t, head.Close())
+			require.FailNow(t, "timed out waiting for the earlier exemplar")
+		}
+		var exemplarDrainDone <-chan struct{}
+		select {
+		case exemplarDrainDone = <-drainHookEntered:
+		case <-time.After(10 * time.Second):
+			releaseHook()
+			release()
+			initErr := <-initDone
+			require.NoError(t, initErr)
+			require.NoError(t, head.Close())
+			require.FailNow(t, "timed out waiting for the exemplar drain marker")
+		}
+		select {
+		case <-exemplarDrainDone:
+			require.Fail(t, "the drain marker completed before the earlier exemplar")
+		default:
+		}
+		select {
+		case <-deletionStarted:
+			require.Fail(t, "deletion started before the earlier exemplar was drained")
+		default:
+		}
+
+		releaseHook()
+		release()
+		require.NoError(t, <-initDone)
+		var exemplarTimestamps []int64
+		require.NoError(t, head.exemplars.IterateExemplars(func(_ labels.Labels, e exemplar.Exemplar) error {
+			exemplarTimestamps = append(exemplarTimestamps, e.Ts)
+			return nil
+		}))
+		require.Equal(t, []int64{10, 20}, exemplarTimestamps)
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.walReplayUnknownRefsTotal.WithLabelValues("exemplars")))
+		require.NoError(t, head.Close())
+	})
+
+	t.Run("waits only for matching series", func(t *testing.T) {
+		const stripeSize = 32
+		for _, blockedRef := range []chunks.HeadSeriesRef{1, 2} {
+			t.Run(fmt.Sprintf("blocked_ref=%d", blockedRef), func(t *testing.T) {
+				refStripe := int(blockedRef) & (stripeSize - 1)
+				labelOutsideStripe := func(value string, stripe int) labels.Labels {
+					for i := 0; ; i++ {
+						lset := labels.FromStrings("series", fmt.Sprintf("%s-%d", value, i))
+						if int(lset.Hash()&uint64(stripeSize-1)) != stripe {
+							return lset
+						}
+					}
+				}
+
+				oldLabels := labelOutsideStripe("old", refStripe)
+				blockedHashStripe := int(oldLabels.Hash() & uint64(stripeSize-1))
+				unrelatedLabels := labelOutsideStripe("unrelated", blockedHashStripe)
+				unrelatedRef := chunks.HeadSeriesRef(3)
+				for int(unrelatedRef)&(stripeSize-1) == blockedHashStripe || unrelatedRef == blockedRef {
+					unrelatedRef++
+				}
+				replacementRef := unrelatedRef + 1
+				for replacementRef == blockedRef {
+					replacementRef++
+				}
+				records := []any{
+					[]record.RefSeries{{Ref: blockedRef, Labels: oldLabels}},
+					[]record.RefSample{{Ref: blockedRef, T: 10, V: 1}},
+					[]tombstones.Stone{fullTombstone(storage.SeriesRef(blockedRef))},
+					[]record.RefSeries{{Ref: unrelatedRef, Labels: unrelatedLabels}},
+					[]record.RefSeries{{Ref: replacementRef, Labels: oldLabels}},
+					[]record.RefSample{{Ref: unrelatedRef, T: 20, V: 2}, {Ref: replacementRef, T: 30, V: 3}},
+				}
+
+				callback := &coordinatedReplayLifecycleCallback{}
+				initialSeriesCreated := make(chan struct{})
+				allowReplay := make(chan struct{})
+				unrelatedPreCreation := make(chan struct{})
+				unrelatedPostCreation := make(chan struct{})
+				replacementPreCreation := make(chan struct{})
+				replacementPostCreation := make(chan struct{})
+				deletionStarted := make(chan struct{})
+				allowDeletion := make(chan struct{})
+				signalInitialCreation := closeOnce(initialSeriesCreated)
+				releaseReplay := closeOnce(allowReplay)
+				signalUnrelatedPre := closeOnce(unrelatedPreCreation)
+				signalUnrelatedPost := closeOnce(unrelatedPostCreation)
+				signalReplacementPre := closeOnce(replacementPreCreation)
+				signalReplacementPost := closeOnce(replacementPostCreation)
+				signalDeletion := closeOnce(deletionStarted)
+				releaseDeletionCallback := closeOnce(allowDeletion)
+				t.Cleanup(func() {
+					releaseReplay()
+					releaseDeletionCallback()
+				})
+				oldPreCreations := 0
+				callback.preCreation = func(lset labels.Labels, _ int) {
+					switch {
+					case labels.Equal(lset, oldLabels):
+						oldPreCreations++
+						if oldPreCreations == 2 {
+							signalReplacementPre()
+						}
+					case labels.Equal(lset, unrelatedLabels):
+						signalUnrelatedPre()
+					}
+				}
+				oldPostCreations := 0
+				callback.postCreation = func(lset labels.Labels, _ int) {
+					switch {
+					case labels.Equal(lset, oldLabels):
+						oldPostCreations++
+						if oldPostCreations == 1 {
+							signalInitialCreation()
+							<-allowReplay
+						} else {
+							signalReplacementPost()
+						}
+					case labels.Equal(lset, unrelatedLabels):
+						signalUnrelatedPost()
+					}
+				}
+				callback.postDeletion = func(deleted map[chunks.HeadSeriesRef]labels.Labels) {
+					if _, ok := deleted[blockedRef]; ok {
+						signalDeletion()
+						<-allowDeletion
+					}
+				}
+
+				opts := DefaultHeadOptions()
+				opts.StripeSize = stripeSize
+				opts.WALReplayConcurrency = 2
+				opts.SeriesCallback = callback
+				head := newReplayHead(t, records, opts)
+
+				initDone := make(chan error, 1)
+				go func() {
+					initDone <- head.Init(0)
+				}()
+
+				select {
+				case <-initialSeriesCreated:
+				case <-time.After(10 * time.Second):
+					releaseReplay()
+					releaseDeletionCallback()
+					initErr := <-initDone
+					require.NoError(t, initErr)
+					require.NoError(t, head.Close())
+					require.FailNow(t, "timed out waiting for the initial series")
+				}
+
+				releaseReplay()
+
+				select {
+				case <-unrelatedPreCreation:
+				case <-time.After(10 * time.Second):
+					releaseDeletionCallback()
+					initErr := <-initDone
+					require.NoError(t, initErr)
+					require.NoError(t, head.Close())
+					require.FailNow(t, "timed out waiting for unrelated PreCreation")
+				}
+				select {
+				case <-unrelatedPostCreation:
+				case <-time.After(10 * time.Second):
+					releaseDeletionCallback()
+					initErr := <-initDone
+					require.NoError(t, initErr)
+					require.NoError(t, head.Close())
+					require.FailNow(t, "timed out waiting for unrelated PostCreation")
+				}
+				select {
+				case <-replacementPreCreation:
+					require.Fail(t, "replacement PreCreation ran before the matching deletion")
+				default:
+				}
+				select {
+				case <-replacementPostCreation:
+					require.Fail(t, "replacement PostCreation ran before the matching deletion")
+				default:
+				}
+
+				select {
+				case <-deletionStarted:
+				case <-time.After(10 * time.Second):
+					releaseDeletionCallback()
+					initErr := <-initDone
+					require.NoError(t, initErr)
+					require.NoError(t, head.Close())
+					require.FailNow(t, "timed out waiting for PostDeletion")
+				}
+				select {
+				case <-replacementPreCreation:
+					require.Fail(t, "replacement PreCreation ran before PostDeletion returned")
+				default:
+				}
+				select {
+				case <-replacementPostCreation:
+					require.Fail(t, "replacement PostCreation ran before PostDeletion returned")
+				default:
+				}
+
+				releaseDeletionCallback()
+				require.NoError(t, <-initDone)
+				preCreations, creations, deletions := callback.counts()
+				require.Equal(t, 3, preCreations)
+				require.Equal(t, 3, creations)
+				require.Equal(t, 1, deletions)
+				require.Equal(t, uint64(2), head.NumSeries())
+				q, err := NewBlockQuerier(head, 0, 100)
+				require.NoError(t, err)
+				actual := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "series", ".+"))
+				require.Equal(t, map[string][]chunks.Sample{
+					oldLabels.String():       {sample{0, 30, 3, nil, nil}},
+					unrelatedLabels.String(): {sample{0, 20, 2, nil, nil}},
+				}, actual)
+				require.NoError(t, head.Close())
+			})
+		}
+	})
+
+	t.Run("preserves WBL data", func(t *testing.T) {
+		dir := t.TempDir()
+		wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+		require.NoError(t, err)
+		wbl, err := wlog.New(nil, nil, filepath.Join(dir, wlog.WblDirName), compression.None)
+		require.NoError(t, err)
+		lset := labels.FromStrings("foo", "bar")
+		populateTestWL(t, wal, []any{
+			[]record.RefSeries{{Ref: 1, Labels: lset}},
+			[]record.RefSample{{Ref: 1, T: 10, V: 1}},
+			[]tombstones.Stone{fullTombstone(1)},
+			[]record.RefSeries{{Ref: 2, Labels: lset}},
+			[]record.RefSample{{Ref: 2, T: 100, V: 2}},
+		}, nil, false)
+		populateTestWL(t, wbl, []any{
+			[]record.RefSample{{Ref: 2, T: 50, V: 3}},
+		}, nil, false)
+		require.NoError(t, wal.Close())
+		require.NoError(t, wbl.Close())
+		wal, err = wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+		require.NoError(t, err)
+		wbl, err = wlog.New(nil, nil, filepath.Join(dir, wlog.WblDirName), compression.None)
+		require.NoError(t, err)
+
+		opts := DefaultHeadOptions()
+		opts.ChunkDirRoot = dir
+		opts.OutOfOrderTimeWindow.Store(10 * time.Minute.Milliseconds())
+		head, err := NewHead(nil, nil, wal, wbl, opts, nil)
+		require.NoError(t, err)
+		require.NoError(t, head.Init(0))
+
+		q, err := NewBlockQuerier(head, 0, 200)
+		require.NoError(t, err)
+		actual := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: {
+			sample{0, 100, 2, nil, nil},
+		}}, actual)
+
+		ms := head.series.getByID(2)
+		require.NotNil(t, ms)
+		require.NotNil(t, ms.ooo)
+		require.NotNil(t, ms.ooo.oooHeadChunk)
+		oooChunks, err := ms.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, false, false)
+		require.NoError(t, err)
+		require.Len(t, oooChunks, 1)
+		oooSamples, err := storage.ExpandSamples(oooChunks[0].chunk.Iterator(nil), nil)
+		require.NoError(t, err)
+		requireEqualSamples(t, lset.String(), []chunks.Sample{sample{0, 50, 3, nil, nil}}, oooSamples)
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.wblReplayUnknownRefsTotal.WithLabelValues("samples")))
+		require.NoError(t, head.Close())
+	})
+
+	t.Run("stale series truncation followed by unrelated series", func(t *testing.T) {
+		// Exercise replay of the WAL shape produced by stale-series truncation followed by unrelated series creation.
+		opts := newTestHeadDefaultOptions(1000, false)
+		// A small stripe size makes the test cover many ref and hash shard
+		// collisions while replaying a large deletion batch.
+		opts.StripeSize = 32
+		head, _ := newTestHeadWithOptions(t, compression.None, opts)
+		require.NoError(t, head.Init(0))
+
+		appendSample := func(lbls labels.Labels, ts int64, val float64) {
+			app := head.Appender(context.Background())
+			_, err := app.Append(0, lbls, ts, val)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+		}
+
+		// Step 1: Create a batch of series and make them stale.
+		const numStaleSeries = 500
+		staleLbls := make([]labels.Labels, numStaleSeries)
+		for i := range numStaleSeries {
+			staleLbls[i] = labels.FromStrings("__name__", "stale_metric", "i", strconv.Itoa(i))
+			appendSample(staleLbls[i], 100, float64(i))
+		}
+		for _, lbl := range staleLbls {
+			appendSample(lbl, 200, math.Float64frombits(value.StaleNaN))
+		}
+		require.Equal(t, uint64(numStaleSeries), head.NumStaleSeries())
+
+		// Step 2: Truncate stale series. This removes them from the Head and
+		// writes tombstone records (with Mint=MinInt64, Maxt=MaxInt64) to the WAL.
+		staleRefs := make([]storage.SeriesRef, 0, numStaleSeries)
+		for i := range numStaleSeries {
+			ms := head.series.getByHash(staleLbls[i].Hash(), staleLbls[i])
+			require.NotNil(t, ms)
+			staleRefs = append(staleRefs, storage.SeriesRef(ms.ref))
+		}
+		require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64))
+		require.Equal(t, uint64(0), head.NumStaleSeries())
+		require.Equal(t, uint64(0), head.NumSeries())
+
+		// Step 3: Add unrelated series after the truncation. Their WAL records
+		// follow the full-deletion tombstones, allowing creation and asynchronous
+		// deletion to overlap during replay.
+		const numNewSeries = 500
+		for i := range numNewSeries {
+			lbl := labels.FromStrings("__name__", "new_metric", "i", strconv.Itoa(i))
+			appendSample(lbl, 300, float64(i))
+		}
+		require.Equal(t, uint64(numNewSeries), head.NumSeries())
+
+		// Step 4: Close and re-open the Head to trigger WAL replay.
+		require.NoError(t, head.Close())
+
+		wal, err := wlog.NewSize(nil, nil, filepath.Join(head.opts.ChunkDirRoot, "wal"), 32768, compression.None)
+		require.NoError(t, err)
+		head, err = NewHead(nil, nil, wal, nil, head.opts, nil)
+		require.NoError(t, err)
+		require.NoError(t, head.Init(0))
+
+		require.Equal(t, uint64(0), head.NumStaleSeries())
+		require.Equal(t, uint64(numNewSeries), head.NumSeries())
+		q, err := NewBlockQuerier(head, 0, 500)
+		require.NoError(t, err)
+		series := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".+"))
+		require.Len(t, series, numNewSeries)
+		for _, samples := range series {
+			require.Len(t, samples, 1)
+			require.Equal(t, int64(300), samples[0].T())
+		}
+		require.NoError(t, head.Close())
+	})
+}
+
+func BenchmarkHeadWALReplayFullDeletion(b *testing.B) {
+	const (
+		generations         = 6
+		seriesPerGeneration = 1000
+	)
+	cases := []struct {
+		name                string
+		fullDeletionRecords int
+		recreate            bool
+	}{
+		{name: "none"},
+		{name: "unrelated/one", fullDeletionRecords: 1},
+		{name: "unrelated/repeated", fullDeletionRecords: 5},
+		{name: "recreated/one", fullDeletionRecords: 1, recreate: true},
+		{name: "recreated/repeated", fullDeletionRecords: 5, recreate: true},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			walDir := b.TempDir()
+			wal, err := wlog.New(nil, nil, walDir, compression.None)
+			require.NoError(b, err)
+
+			var buf []byte
+			for generation := range generations {
+				series := make([]record.RefSeries, 0, seriesPerGeneration)
+				samples := make([]record.RefSample, 0, seriesPerGeneration)
+				tombstonesForGeneration := make([]tombstones.Stone, 0, seriesPerGeneration)
+				for i := range seriesPerGeneration {
+					ref := chunks.HeadSeriesRef(generation*seriesPerGeneration + i + 1)
+					lset := labels.FromStrings(
+						"__name__", "wal_replay_benchmark",
+						"series", strconv.Itoa(i),
+					)
+					if !tc.recreate {
+						lset = labels.FromStrings(
+							"__name__", "wal_replay_benchmark",
+							"generation", strconv.Itoa(generation),
+							"series", strconv.Itoa(i),
+						)
+					}
+					series = append(series, record.RefSeries{
+						Ref:    ref,
+						Labels: lset,
+					})
+					samples = append(samples, record.RefSample{Ref: ref, T: int64(generation), V: float64(generation)})
+					tombstonesForGeneration = append(tombstonesForGeneration, tombstones.Stone{
+						Ref: storage.SeriesRef(ref),
+						Intervals: tombstones.Intervals{{
+							Mint: math.MinInt64,
+							Maxt: math.MaxInt64,
+						}},
+					})
+				}
+				buf = populateTestWL(b, wal, []any{series, samples}, buf, false)
+				if generation < tc.fullDeletionRecords {
+					buf = populateTestWL(b, wal, []any{tombstonesForGeneration}, buf, false)
+				}
+			}
+			require.NoError(b, wal.Close())
+
+			for _, concurrency := range []int{1, defaultWALReplayConcurrency} {
+				b.Run(fmt.Sprintf("concurrency=%d", concurrency), func(b *testing.B) {
+					chunkDirRoot := b.TempDir()
+					b.ReportAllocs()
+					for b.Loop() {
+						b.StopTimer()
+						segmentsReader, err := wlog.NewSegmentsReader(walDir)
+						require.NoError(b, err)
+						opts := DefaultHeadOptions()
+						opts.ChunkDirRoot = chunkDirRoot
+						opts.WALReplayConcurrency = concurrency
+						head, err := NewHead(nil, nil, nil, nil, opts, nil)
+						require.NoError(b, err)
+
+						b.StartTimer()
+						err = head.loadWAL(
+							wlog.NewReader(segmentsReader),
+							labels.NewSymbolTable(),
+							map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{},
+							nil,
+							nil,
+						)
+						b.StopTimer()
+						require.NoError(b, err)
+						expectedSeries := uint64((generations - tc.fullDeletionRecords) * seriesPerGeneration)
+						if tc.recreate {
+							expectedSeries = seriesPerGeneration
+						}
+						require.Equal(b, expectedSeries, head.NumSeries())
+						require.NoError(b, segmentsReader.Close())
+						require.NoError(b, head.Close())
+						b.StartTimer()
+					}
+				})
+			}
+		})
+	}
 }
 
 func TestHead_WALCheckpointMultiRef(t *testing.T) {
@@ -9823,80 +10551,6 @@ func TestFloatChunkEncodingSwitchWaitsForNextChunk(t *testing.T) {
 		require.Equal(t, chunkenc.EncXOR, ms.headChunks.chunk.Encoding(),
 			"in-progress chunk must keep XOR encoding after encoding switch")
 	})
-}
-
-// TestWALReplayRaceWithStaleSeriesCompaction verifies that deleteSeriesByID correctly locks the
-// hash shard (not only the ref shard) when deleting from the hashes map.
-// The race only occurs when Prometheus restarts after having done a stale series compaction because
-// deleteSeriesByID is not used otherwise.
-func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
-	opts := newTestHeadDefaultOptions(1000, false)
-	// A small stripe size ensures many series share hash shards, increasing
-	// the likelihood that deleteSeriesByID and getOrCreateWithOptionalID
-	// contend on the same shard during WAL replay.
-	opts.StripeSize = 32
-	head, _ := newTestHeadWithOptions(t, compression.None, opts)
-	require.NoError(t, head.Init(0))
-
-	appendSample := func(lbls labels.Labels, ts int64, val float64) {
-		app := head.Appender(context.Background())
-		_, err := app.Append(0, lbls, ts, val)
-		require.NoError(t, err)
-		require.NoError(t, app.Commit())
-	}
-
-	// Step 1: Create a batch of series and make them stale.
-	const numStaleSeries = 500
-	staleLbls := make([]labels.Labels, numStaleSeries)
-	for i := range numStaleSeries {
-		staleLbls[i] = labels.FromStrings("__name__", "stale_metric", "i", strconv.Itoa(i))
-		appendSample(staleLbls[i], 100, float64(i))
-	}
-	for _, lbl := range staleLbls {
-		appendSample(lbl, 200, math.Float64frombits(value.StaleNaN))
-	}
-	require.Equal(t, uint64(numStaleSeries), head.NumStaleSeries())
-
-	// Step 2: Truncate stale series. This removes them from the Head and
-	// writes tombstone records (with Mint=MinInt64, Maxt=MaxInt64) to the WAL.
-	staleRefs := make([]storage.SeriesRef, 0, numStaleSeries)
-	for i := range numStaleSeries {
-		ms := head.series.getByHash(staleLbls[i].Hash(), staleLbls[i])
-		require.NotNil(t, ms)
-		staleRefs = append(staleRefs, storage.SeriesRef(ms.ref))
-	}
-	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64))
-	require.Equal(t, uint64(0), head.NumStaleSeries())
-	require.Equal(t, uint64(0), head.NumSeries())
-
-	// Step 3: Add new series AFTER the truncation. In the WAL, these series
-	// records appear after the tombstone records. During replay, the main
-	// goroutine will create these series (via getOrCreateWithOptionalID, which
-	// accesses hashes[hashShard] under locks[hashShard]) concurrently with
-	// the walSubsetProcessor goroutines deleting the stale series (via
-	// deleteSeriesByID, which must also lock the correct hashShard).
-	const numNewSeries = 500
-	for i := range numNewSeries {
-		lbl := labels.FromStrings("__name__", "new_metric", "i", strconv.Itoa(i))
-		appendSample(lbl, 300, float64(i))
-	}
-	require.Equal(t, uint64(numNewSeries), head.NumSeries())
-
-	// Step 4: Close and re-open the Head to trigger WAL replay.
-	// With the buggy locking, the race detector should catch the data race
-	// between the main goroutine (creating series) and worker goroutines
-	// (deleting stale series) during replay.
-	require.NoError(t, head.Close())
-
-	wal, err := wlog.NewSize(nil, nil, filepath.Join(head.opts.ChunkDirRoot, "wal"), 32768, compression.None)
-	require.NoError(t, err)
-	head, err = NewHead(nil, nil, wal, nil, head.opts, nil)
-	require.NoError(t, err)
-	require.NoError(t, head.Init(0)) // Should not cause a race here.
-
-	require.Equal(t, uint64(0), head.NumStaleSeries())
-	require.Equal(t, uint64(numNewSeries), head.NumSeries())
-	require.NoError(t, head.Close())
 }
 
 // TestHead_ReadWAL_TombstonesAdvanceLastSeriesID verifies that replay advances

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -102,6 +102,24 @@ func newTestHeadWithOptions(t testing.TB, compressWAL compression.Type, opts *He
 	return h, wal
 }
 
+// requireMmapReadyConsistent checks the per-stripe readiness invariant.
+// The head must be quiescent because series counts are read without series locks.
+func requireMmapReadyConsistent(t testing.TB, h *Head, msg string) {
+	t.Helper()
+	for i := range h.series.size {
+		var expected int32
+		h.series.locks[i].RLock()
+		for _, s := range h.series.series[i] {
+			if s.headChunkCount.Load() >= 2 {
+				expected++
+			}
+		}
+		h.series.locks[i].RUnlock()
+		require.Equal(t, expected, h.series.mmapReady[i].Load(),
+			"%s: stripe %d mmapReady out of sync", msg, i)
+	}
+}
+
 func BenchmarkCreateSeries(b *testing.B) {
 	series := genSeries(b.N, 10, 0, 0)
 	h, _ := newTestHead(b, 10000, compression.None, false)
@@ -437,8 +455,8 @@ func BenchmarkLoadWLs(b *testing.B) {
 									// There's only one head chunk because only a single sample is appended. mmapChunks()
 									// ignores the latest chunk, so we need to cut a new head chunk to guarantee the chunk with
 									// the sample at c.mmappedChunkT is mmapped.
-									s.cutNewHeadChunk(c.mmappedChunkT, chunkenc.EncXOR, c.mmappedChunkT)
-									s.mmapChunks(chunkDiskMapper)
+									s.cutNewHeadChunk(c.mmappedChunkT, chunkenc.EncXOR, cOpts)
+									s.mmapChunks(chunkDiskMapper, nil)
 								}
 								require.NoError(b, chunkDiskMapper.Close())
 							}
@@ -2471,7 +2489,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 		ok, _ := s.append(0, int64(i), float64(i), 0, cOpts)
 		require.True(t, ok, "sample append failed")
 	}
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	// Check that truncate removes half of the chunks and afterwards
 	// that the ID of the last chunk still gives us the same chunk afterwards.
@@ -2485,7 +2503,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 	require.NotNil(t, chk)
 	require.NoError(t, err)
 
-	s.truncateChunksBefore(2000, 0)
+	s.truncateChunksBefore(2000, 0, nil)
 
 	require.Equal(t, int64(2000), s.mmappedChunks[0].minTime)
 	_, _, _, err = s.chunk(0, chunkDiskMapper, &memChunkPool, nil)
@@ -2621,11 +2639,11 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 					ok, _ := series.append(0, int64(i), float64(i), 0, cOpts)
 					require.True(t, ok, "sample append failed")
 				}
-				series.mmapChunks(chunkDiskMapper)
+				series.mmapChunks(chunkDiskMapper, nil)
 			}
 
 			if tc.headChunks == 0 {
-				series.setHeadChunks(nil, 0)
+				series.setHeadChunks(nil, 0, nil)
 			} else {
 				for i := headStart; i < chunkRange*(tc.mmappedChunks+tc.headChunks); i += chunkStep {
 					ok, _ := series.append(0, int64(i), float64(i), 0, cOpts)
@@ -2641,10 +2659,9 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 			}
 			require.Len(t, series.mmappedChunks, tc.mmappedChunks, "wrong number of mmapped chunks")
 
-			// Set headChunkCount before truncation (series.append bypasses observeChunkCreated).
-			series.headChunkCount.Store(uint32(tc.headChunks))
+			series.setHeadChunkCount(uint32(tc.headChunks), nil)
 
-			truncated := series.truncateChunksBefore(tc.truncateBefore, 0)
+			truncated := series.truncateChunksBefore(tc.truncateBefore, 0, nil)
 			require.Equal(t, tc.expectedTruncated, truncated, "wrong number of truncated chunks returned")
 			require.Equal(t, uint32(tc.expectedHead), series.headChunkCount.Load(), "wrong headChunkCount after truncation")
 
@@ -2673,11 +2690,11 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 		// removed chunks, measured from the list itself, even if headChunkCount
 		// drifted from the real list length.
 		s := &memSeries{ref: 1}
-		s.setHeadChunks(buildHeadChunksLight(5), 5)
-		s.headChunkCount.Store(7) // Drifted: the list has 5 chunks.
+		s.setHeadChunks(buildHeadChunksLight(5), 5, nil)
+		s.headChunkCount.n.Store(7) // Drifted: the list has 5 chunks.
 
 		// Chunks span [0,999]..[4000,4999]; mint=2000 drops the two oldest.
-		removed := s.truncateChunksBefore(2000, 0)
+		removed := s.truncateChunksBefore(2000, 0, nil)
 		require.Equal(t, 2, removed)
 		require.Equal(t, chunks.HeadChunkID(2), s.firstChunkID)
 		require.Equal(t, 3, s.headChunks.len())
@@ -2750,7 +2767,7 @@ func TestOOOTruncateChunksBefore_Wrap(t *testing.T) {
 			}
 
 			minOOOMmapRef := refs[tc.truncateN-1]
-			series.truncateChunksBefore(0, minOOOMmapRef)
+			series.truncateChunksBefore(0, minOOOMmapRef, nil)
 
 			if tc.expOOONil {
 				require.Nil(t, series.ooo, "ooo should be nil after truncating all chunks")
@@ -2765,14 +2782,14 @@ func TestOOOTruncateChunksBefore_Wrap(t *testing.T) {
 
 func TestPushHeadChunk_PanicsAtIDSpaceBound(t *testing.T) {
 	s := newMemSeries(labels.FromStrings("a", "b"), 1, 0, true, false)
-	s.headChunkCount.Store(oooChunkIDMask - 1)
+	s.headChunkCount.n.Store(oooChunkIDMask - 1)
 
 	require.Panics(t, func() {
 		s.pushHeadChunk(&memChunk{
 			chunk:   chunkenc.NewXORChunk(),
 			minTime: 0,
 			maxTime: 0,
-		})
+		}, nil)
 	})
 }
 
@@ -2789,7 +2806,7 @@ func TestAppendHistogramLayoutChange_PanicsAtIDSpaceBound(t *testing.T) {
 	ms, _, err := head.getOrCreate(l.Hash(), l, false)
 	require.NoError(t, err)
 	ms.Lock()
-	ms.headChunkCount.Store(oooChunkIDMask - 1)
+	ms.headChunkCount.n.Store(oooChunkIDMask - 1)
 	ms.Unlock()
 
 	h2 := h.Copy()
@@ -3362,7 +3379,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 	ok, chunkCreated = s.append(stFunc(999), 999, 2, 0, cOpts)
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	ok, chunkCreated = s.append(stFunc(1000), 1000, 3, 0, cOpts)
 	require.True(t, ok, "append failed")
@@ -3372,7 +3389,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -3386,7 +3403,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 		ok, _ := s.append(stFunc(ts), ts, float64(i), 0, cOpts)
 		require.True(t, ok, "append failed")
 	}
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	require.Greater(t, len(s.mmappedChunks)+1, 7, "expected intermediate chunks")
 
@@ -3481,7 +3498,7 @@ func testMemSeriesAppendHistogram(t *testing.T, useXOR2 bool, stFunc func(ts int
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -3492,7 +3509,7 @@ func testMemSeriesAppendHistogram(t *testing.T, useXOR2 bool, stFunc func(ts int
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "third sample should trigger a re-encoded chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -3541,7 +3558,7 @@ func TestMemSeries_append_atVariableRate(t *testing.T) {
 	require.True(t, ok, "new chunk sample was not appended")
 	require.True(t, chunkCreated, "sample at block duration timestamp should create a new chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	var totalSamplesInChunks int
 	for i, c := range s.mmappedChunks {
 		totalSamplesInChunks += int(c.numSamples)
@@ -3559,6 +3576,7 @@ func TestGCChunkAccess(t *testing.T) {
 		chunkDiskMapper: h.chunkDiskMapper,
 		chunkRange:      chunkRange,
 		samplesPerChunk: DefaultSamplesPerChunk,
+		stripes:         h.series,
 	}
 
 	h.initTime(0)
@@ -3615,6 +3633,7 @@ func TestGCSeriesAccess(t *testing.T) {
 		chunkDiskMapper: h.chunkDiskMapper,
 		chunkRange:      chunkRange,
 		samplesPerChunk: DefaultSamplesPerChunk,
+		stripes:         h.series,
 	}
 
 	h.initTime(0)
@@ -3964,6 +3983,7 @@ func TestHeadReadWriterRepair(t *testing.T) {
 			chunkDiskMapper: h.chunkDiskMapper,
 			chunkRange:      chunkRange,
 			samplesPerChunk: DefaultSamplesPerChunk,
+			stripes:         h.series,
 		}
 
 		s, created, _ := h.getOrCreate(1, labels.FromStrings("a", "1"), false)
@@ -3977,8 +3997,9 @@ func TestHeadReadWriterRepair(t *testing.T) {
 			require.True(t, ok, "series append failed")
 			require.False(t, chunkCreated, "chunk was created")
 			h.chunkDiskMapper.CutNewFile()
-			s.mmapChunks(h.chunkDiskMapper)
+			s.mmapChunks(h.chunkDiskMapper, h.series)
 		}
+		requireMmapReadyConsistent(t, h, "after append+mmap cycles")
 		require.NoError(t, h.Close())
 
 		// Verify that there are 6 segment files.
@@ -4309,6 +4330,7 @@ func TestIsolationAppendIDZeroIsNoop(t *testing.T) {
 		chunkDiskMapper: h.chunkDiskMapper,
 		chunkRange:      h.chunkRange.Load(),
 		samplesPerChunk: DefaultSamplesPerChunk,
+		stripes:         h.series,
 	}
 
 	s, _, _ := h.getOrCreate(1, labels.FromStrings("a", "1"), false)
@@ -5786,6 +5808,7 @@ func TestChunkSnapshot(t *testing.T) {
 				checkFloatHistograms()
 				checkTombstones()
 				checkExemplars()
+				requireMmapReadyConsistent(t, head, "after WAL replay")
 			}
 
 			{ // Initial data that goes into snapshot.
@@ -6397,7 +6420,7 @@ func TestHistogramCounterResetHeader(t *testing.T) {
 
 				ms, _, err := head.getOrCreate(l.Hash(), l, false)
 				require.NoError(t, err)
-				ms.mmapChunks(head.chunkDiskMapper)
+				ms.mmapChunks(head.chunkDiskMapper, head.series)
 				require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
 
 				for i, mmapChunk := range ms.mmappedChunks {
@@ -7308,7 +7331,7 @@ func TestHeadInit_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
 
-	series.mmapChunks(h.chunkDiskMapper)
+	series.mmapChunks(h.chunkDiskMapper, h.series)
 	expChunks := make([]*mmappedChunk, len(series.mmappedChunks))
 	copy(expChunks, series.mmappedChunks)
 
@@ -11107,9 +11130,8 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 				// Force the exact state required to trigger the bug: series at
 				// headChunkCount == 2 (mmap-ready) with mmapReady already incremented.
 				s.Lock()
-				s.headChunkCount.Store(2)
+				s.setHeadChunkCount(2, h.series)
 				s.Unlock()
-				h.series.incMmapReady(s.ref)
 				require.Equal(t, int32(1), mmapReadyTotal())
 
 				// Append an OOO sample. This creates an OOO chunk (not a regular
@@ -11205,6 +11227,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 						chunkDiskMapper: h.chunkDiskMapper,
 						chunkRange:      h.chunkRange.Load(),
 						samplesPerChunk: h.opts.SamplesPerChunk,
+						stripes:         h.series,
 					})
 				})
 				s.Unlock()
@@ -11285,6 +11308,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		require.Equal(t, int32(0), mmapReadyTotal())
 		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.chunks))
 		require.Equal(t, removedBefore+float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunksRemoved))
+		requireMmapReadyConsistent(t, h, "after WAL replay deletion")
 	})
 
 	// Verify the mmapReady per-stripe counter stays in sync with the actual
@@ -11304,19 +11328,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		}
 		requireCounterConsistent := func(msg string) {
 			t.Helper()
-
-			var actual int32
-			for i := range h.series.size {
-				h.series.locks[i].RLock()
-				for _, s := range h.series.series[i] {
-					if s.headChunkCount.Load() >= 2 {
-						actual++
-					}
-				}
-				h.series.locks[i].RUnlock()
-			}
-			counter := mmapReadyCounter()
-			require.Equal(t, actual, counter, "%s: mmapReady counter (%d) != actual ready count (%d)", msg, counter, actual)
+			requireMmapReadyConsistent(t, h, msg)
 		}
 
 		lblsA := labels.FromStrings("__name__", "seriesA")
@@ -11435,10 +11447,10 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		// acquired, another goroutine (GC) has already reduced the count.
 		//
 		// We create a fresh series with 1 head chunk, then artificially set
-		// headChunkCount to 2 and mmapReady to 1. mmapChunks will see
-		// headChunks.prev == nil and return 0. Without the n > 0 guard,
-		// the counter would be decremented to 0 even though the "real"
-		// decrement never happened (simulating a double-decrement).
+		// headChunkCount to 2 and mmapReady to 1 (reaching into the wrapper's
+		// inner field to simulate the racy state). mmapChunks will see
+		// headChunks.prev == nil and return 0 without crossing the >= 2
+		// threshold, so mmapReady must stay at 1.
 		lblsD := labels.FromStrings("__name__", "seriesD")
 		app = h.Appender(t.Context())
 		_, err = app.Append(0, lblsD, ts, float64(ts))
@@ -11453,19 +11465,18 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 
 		// Simulate the race: inflate headChunkCount so the series passes the
 		// >= 2 filter, and set mmapReady to 1 (as the increment site would).
-		sD.headChunkCount.Store(2)
+		sD.headChunkCount.n.Store(2)
 		h.series.mmapReady[stripeD].Add(1)
 
 		h.mmapHeadChunks()
 
-		// mmapChunks returned 0 (headChunks.prev is nil). With the n > 0
-		// guard, the counter stays at 1. Without the guard, it would drop
-		// to 0 — an incorrect extra decrement.
+		// mmapChunks returned 0 (headChunks.prev is nil). Its setter only
+		// runs after that early-return guard, so the counter stays at 1.
 		require.Equal(t, int32(1), h.series.mmapReady[stripeD].Load(),
 			"mmapHeadChunks must not decrement when mmapChunks returns 0")
 
 		// Clean up: restore the real state.
-		sD.headChunkCount.Store(1)
+		sD.headChunkCount.n.Store(1)
 		h.series.mmapReady[stripeD].Add(-1)
 		requireCounterConsistent("final state")
 	})

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -10565,6 +10565,74 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		}
 	})
 
+	t.Run("wal replay deletion clears all chunk state", func(t *testing.T) {
+		opts := newTestHeadDefaultOptions(DefaultBlockDuration, true)
+		opts.OutOfOrderCapMax.Store(1)
+		h, _ := newTestHeadWithOptions(t, compression.None, opts)
+		require.NoError(t, h.Init(0))
+
+		mmapReadyTotal := func() int32 {
+			var n int32
+			for i := range h.series.size {
+				n += h.series.mmapReady[i].Load()
+			}
+			return n
+		}
+
+		lbls := labels.FromStrings("__name__", "seriesToDelete")
+		ts := int64(0)
+		app := h.Appender(t.Context())
+		for range chunkCutIterations {
+			_, err := app.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+
+		// With an OOO chunk capacity of one, the second OOO sample m-maps the
+		// first OOO head chunk and creates a replacement head chunk.
+		oooTs := ts - 5*time.Minute.Milliseconds()
+		app = h.Appender(t.Context())
+		_, err := app.Append(0, lbls, oooTs, 1)
+		require.NoError(t, err)
+		_, err = app.Append(0, lbls, oooTs+1, 2)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		s := h.series.getByHash(lbls.Hash(), lbls)
+		require.NotNil(t, s)
+		require.GreaterOrEqual(t, s.headChunkCount.Load(), uint32(2))
+		require.NotNil(t, s.ooo)
+		require.NotEmpty(t, s.ooo.oooMmappedChunks)
+		require.NotNil(t, s.ooo.oooHeadChunk)
+		require.Equal(t, int32(1), mmapReadyTotal())
+
+		expectedRemoved := len(s.mmappedChunks) + s.headChunks.len() + len(s.ooo.oooMmappedChunks) + 1
+		require.Equal(t, float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunks))
+		removedBefore := prom_testutil.ToFloat64(h.metrics.chunksRemoved)
+
+		h.deleteSeriesByID([]chunks.HeadSeriesRef{s.ref})
+
+		require.Nil(t, h.series.getByID(s.ref))
+		require.Nil(t, h.series.getByHash(lbls.Hash(), lbls))
+		require.Zero(t, h.NumSeries())
+		require.Equal(t, int32(0), mmapReadyTotal())
+		require.Zero(t, s.headChunkCount.Load())
+		require.Nil(t, s.headChunks)
+		require.Nil(t, s.app)
+		require.Nil(t, s.mmappedChunks)
+		require.Nil(t, s.ooo)
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.chunks))
+		require.Equal(t, removedBefore+float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunksRemoved))
+
+		// A stale reset with no chunks must not release mmap readiness or chunk
+		// accounting a second time.
+		h.resetSeriesWithMMappedChunks(s, nil, nil, s.ref+1)
+		require.Equal(t, int32(0), mmapReadyTotal())
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.chunks))
+		require.Equal(t, removedBefore+float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunksRemoved))
+	})
+
 	// Verify the mmapReady per-stripe counter stays in sync with the actual
 	// number of series that have headChunkCount >= 2, across append, mmap,
 	// GC, and stale-series deletion.

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -59,6 +59,172 @@ type seriesRefSet struct {
 	mtx  sync.Mutex
 }
 
+type walReplayDeletionBarrierEntry struct {
+	hash uint64
+	lset labels.Labels
+}
+
+type walReplayDeletionBarrier struct {
+	done     chan struct{}
+	entries  []walReplayDeletionBarrierEntry
+	registry *walReplayPendingDeletions
+}
+
+type walReplayPendingDeletion struct {
+	lset    labels.Labels
+	barrier *walReplayDeletionBarrier
+}
+
+type walReplayPendingDeletionBucket struct {
+	entry      walReplayPendingDeletion
+	collisions []walReplayPendingDeletion
+}
+
+// walReplayPendingDeletions prevents a series record from re-creating a label
+// set until an earlier full deletion and its lifecycle callback have completed.
+type walReplayPendingDeletions struct {
+	// Keep the 64-bit atomic first to guarantee alignment on 32-bit systems.
+	count  atomic.Int64
+	mtx    sync.Mutex
+	byHash map[uint64]walReplayPendingDeletionBucket
+}
+
+func newWALReplayPendingDeletions() *walReplayPendingDeletions {
+	return &walReplayPendingDeletions{byHash: map[uint64]walReplayPendingDeletionBucket{}}
+}
+
+func (p *walReplayPendingDeletions) add(hash uint64, lset labels.Labels, barrier *walReplayDeletionBarrier) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.addLocked(hash, lset, barrier)
+}
+
+func (p *walReplayPendingDeletions) addLocked(hash uint64, lset labels.Labels, barrier *walReplayDeletionBarrier) {
+	bucket, ok := p.byHash[hash]
+	if !ok {
+		p.byHash[hash] = walReplayPendingDeletionBucket{
+			entry: walReplayPendingDeletion{lset: lset, barrier: barrier},
+		}
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		p.count.Inc()
+		return
+	}
+
+	if labels.Equal(bucket.entry.lset, lset) {
+		if bucket.entry.barrier == barrier {
+			return
+		}
+		bucket.entry.barrier = barrier
+		p.byHash[hash] = bucket
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		return
+	}
+
+	for i := range bucket.collisions {
+		if !labels.Equal(bucket.collisions[i].lset, lset) {
+			continue
+		}
+		if bucket.collisions[i].barrier == barrier {
+			return
+		}
+		bucket.collisions[i].barrier = barrier
+		p.byHash[hash] = bucket
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		return
+	}
+
+	bucket.collisions = append(bucket.collisions, walReplayPendingDeletion{lset: lset, barrier: barrier})
+	p.byHash[hash] = bucket
+	barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+	p.count.Inc()
+}
+
+func (p *walReplayPendingDeletions) newBarrier(lsets []labels.Labels) *walReplayDeletionBarrier {
+	barrier := &walReplayDeletionBarrier{
+		done:     make(chan struct{}),
+		registry: p,
+	}
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	for _, lset := range lsets {
+		p.addLocked(lset.Hash(), lset, barrier)
+	}
+	return barrier
+}
+
+func (p *walReplayPendingDeletions) wait(hash uint64, lset labels.Labels) {
+	for {
+		if p.count.Load() == 0 {
+			return
+		}
+		p.mtx.Lock()
+		var done <-chan struct{}
+		if bucket, ok := p.byHash[hash]; ok {
+			if labels.Equal(bucket.entry.lset, lset) {
+				done = bucket.entry.barrier.done
+			} else {
+				for _, entry := range bucket.collisions {
+					if labels.Equal(entry.lset, lset) {
+						done = entry.barrier.done
+						break
+					}
+				}
+			}
+		}
+		p.mtx.Unlock()
+
+		if done == nil {
+			return
+		}
+		<-done
+	}
+}
+
+func (p *walReplayPendingDeletions) complete(barrier *walReplayDeletionBarrier) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	close(barrier.done)
+	for _, completed := range barrier.entries {
+		bucket, ok := p.byHash[completed.hash]
+		if !ok {
+			continue
+		}
+
+		if bucket.entry.barrier == barrier && labels.Equal(bucket.entry.lset, completed.lset) {
+			p.count.Dec()
+			if len(bucket.collisions) == 0 {
+				delete(p.byHash, completed.hash)
+			} else {
+				last := len(bucket.collisions) - 1
+				bucket.entry = bucket.collisions[last]
+				bucket.collisions = bucket.collisions[:last]
+				p.byHash[completed.hash] = bucket
+			}
+			continue
+		}
+
+		for i := range bucket.collisions {
+			entry := bucket.collisions[i]
+			if entry.barrier != barrier || !labels.Equal(entry.lset, completed.lset) {
+				continue
+			}
+			last := len(bucket.collisions) - 1
+			bucket.collisions[i] = bucket.collisions[last]
+			bucket.collisions = bucket.collisions[:last]
+			p.byHash[completed.hash] = bucket
+			p.count.Dec()
+			break
+		}
+	}
+}
+
+func (b *walReplayDeletionBarrier) complete() {
+	if b != nil {
+		b.registry.complete(b)
+	}
+}
+
 func (s *seriesRefSet) merge(other map[chunks.HeadSeriesRef]struct{}) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
@@ -95,7 +261,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		wg             sync.WaitGroup
 		concurrency    = h.opts.WALReplayConcurrency
 		processors     = make([]walSubsetProcessor, concurrency)
-		exemplarsInput chan record.RefExemplar
+		exemplarsInput chan walReplayExemplarInput
 
 		shards          = make([][]record.RefSample, concurrency)
 		histogramShards = make([][]histogramRecord, concurrency)
@@ -103,6 +269,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		decoded                      = make(chan any, 10)
 		decodeErr, seriesCreationErr error
 	)
+	pendingDeletions := newWALReplayPendingDeletions()
 
 	defer func() {
 		// For CorruptionErr ensure to terminate all workers before exiting.
@@ -131,12 +298,17 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 	}
 
 	wg.Add(1)
-	exemplarsInput = make(chan record.RefExemplar, 300)
-	go func(input <-chan record.RefExemplar) {
+	exemplarsInput = make(chan walReplayExemplarInput, 300)
+	go func(input <-chan walReplayExemplarInput) {
 		missingSeries := make(map[chunks.HeadSeriesRef]struct{})
 		var err error
 		defer wg.Done()
-		for e := range input {
+		for in := range input {
+			if in.done != nil {
+				close(in.done)
+				continue
+			}
+			e := in.exemplar
 			ms := h.series.getByID(e.Ref)
 			if ms == nil {
 				unknownExemplarRefs.Inc()
@@ -251,12 +423,15 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 
 	// The records are always replayed from the oldest to the newest.
 	missingSeries := make(map[chunks.HeadSeriesRef]struct{})
+	exemplarsPending := false
 Outer:
 	for d := range decoded {
 		switch v := d.(type) {
 		case []record.RefSeries:
 			for _, walSeries := range v {
-				mSeries, created, err := h.getOrCreateWithOptionalID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels, false)
+				hash := walSeries.Labels.Hash()
+				pendingDeletions.wait(hash, walSeries.Labels)
+				mSeries, created, err := h.getOrCreateWithOptionalID(walSeries.Ref, hash, walSeries.Labels, false)
 				if err != nil {
 					seriesCreationErr = err
 					break Outer
@@ -314,6 +489,20 @@ Outer:
 		case []tombstones.Stone:
 			// Tombstone records will be fairly rare, so not trying to optimise the allocations here.
 			deleteSeriesShards := make([][]chunks.HeadSeriesRef, concurrency)
+			deleteSeriesLabelShards := make([][]labels.Labels, concurrency)
+			queueFullDeletion := func(ref chunks.HeadSeriesRef) {
+				series := h.series.getByID(ref)
+				if series == nil {
+					return
+				}
+				// Remove the series from the hash index so a later series record with
+				// the same labels creates a fresh series. The by-ref entry remains until
+				// the queued deletion applies, so earlier records can still resolve it.
+				h.series.unlinkHash(series.lset.Hash(), ref)
+				mod := uint64(ref) % uint64(concurrency)
+				deleteSeriesShards[mod] = append(deleteSeriesShards[mod], ref)
+				deleteSeriesLabelShards[mod] = append(deleteSeriesLabelShards[mod], series.labels())
+			}
 			for _, s := range v {
 				// A tombstone means this ref was previously allocated, even if its series record is no
 				// longer in the WAL. Advance lastSeriesID so the ref is not reissued.
@@ -327,15 +516,7 @@ Outer:
 					if r, ok := multiRef[ref]; ok {
 						ref = r
 					}
-					if series := h.series.getByID(ref); series != nil {
-						// Remove the series from the hash index so that a later series
-						// record with the same labels creates a fresh series instead of
-						// mapping onto this one. It stays in the by-ref map so
-						// already-queued samples still resolve until the deletion applies.
-						h.series.unlinkHash(series.lset.Hash(), ref)
-						mod := uint64(ref) % uint64(concurrency)
-						deleteSeriesShards[mod] = append(deleteSeriesShards[mod], ref)
-					}
+					queueFullDeletion(ref)
 					continue
 				}
 				for _, itv := range s.Intervals {
@@ -356,10 +537,36 @@ Outer:
 				}
 			}
 
+			hasLiveFullDeletions := false
+			for i := range concurrency {
+				if len(deleteSeriesLabelShards[i]) > 0 {
+					hasLiveFullDeletions = true
+					break
+				}
+			}
+
+			// Drain separately processed exemplars before dispatching a live
+			// deletion so it cannot overtake an earlier exemplar for the series.
+			if hasLiveFullDeletions && exemplarsPending {
+				done := make(chan struct{})
+				exemplarsInput <- walReplayExemplarInput{done: done}
+				if h.walReplayExemplarDrainHook != nil {
+					h.walReplayExemplarDrainHook(done)
+				}
+				<-done
+				exemplarsPending = false
+			}
+
 			for i := range concurrency {
 				if len(deleteSeriesShards[i]) > 0 {
-					processors[i].input <- walSubsetProcessorInputItem{deletedSeriesRefs: deleteSeriesShards[i]}
-					deleteSeriesShards[i] = nil
+					var barrier *walReplayDeletionBarrier
+					if len(deleteSeriesLabelShards[i]) > 0 {
+						barrier = pendingDeletions.newBarrier(deleteSeriesLabelShards[i])
+					}
+					processors[i].input <- walSubsetProcessorInputItem{
+						deletedSeriesRefs: deleteSeriesShards[i],
+						deletionBarrier:   barrier,
+					}
 				}
 			}
 
@@ -375,7 +582,8 @@ Outer:
 					h.updateWALExpiry(e.Ref, e.T)
 					e.Ref = r
 				}
-				exemplarsInput <- e
+				exemplarsInput <- walReplayExemplarInput{exemplar: e}
+				exemplarsPending = true
 			}
 			for i := range v { // Zero out to avoid retaining label data.
 				v[i].Labels = labels.EmptyLabels()
@@ -604,12 +812,18 @@ type walSubsetProcessor struct {
 	histogramsOutput chan []histogramRecord
 }
 
+type walReplayExemplarInput struct {
+	exemplar record.RefExemplar
+	done     chan struct{}
+}
+
 type walSubsetProcessorInputItem struct {
 	samples           []record.RefSample
 	histogramSamples  []histogramRecord
 	existingSeries    *memSeries
 	walSeriesRef      chunks.HeadSeriesRef
 	deletedSeriesRefs []chunks.HeadSeriesRef
+	deletionBarrier   *walReplayDeletionBarrier
 }
 
 func (wp *walSubsetProcessor) setup() {
@@ -792,9 +1006,14 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 		default:
 		}
 
+		var deletedForCallback map[chunks.HeadSeriesRef]labels.Labels
 		if len(in.deletedSeriesRefs) > 0 {
-			h.deleteSeriesByID(in.deletedSeriesRefs)
+			deletedForCallback = h.deleteSeriesByID(in.deletedSeriesRefs)
 		}
+		if len(deletedForCallback) > 0 {
+			h.series.seriesLifecycleCallback.PostDeletion(deletedForCallback)
+		}
+		in.deletionBarrier.complete()
 	}
 	h.updateMinMaxTime(mint, maxt)
 

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -797,11 +797,10 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 	}
 
 	// Any samples replayed till now would already be compacted. Resetting the head chunk.
+	// No series.Lock: walSubsetProcessor partitions inputs by series ref, so
+	// this series has no concurrent writer during WAL replay.
 	mSeries.nextAt = 0
-	if mSeries.headChunkCount.Load() >= 2 {
-		h.series.decMmapReady(mSeries.ref)
-	}
-	mSeries.setHeadChunks(nil, 0)
+	mSeries.setHeadChunks(nil, 0, h.series)
 	mSeries.app = nil
 	return overlapped
 }
@@ -865,20 +864,15 @@ func (wp *walSubsetProcessor) reuseHistogramBuf() []histogramRecord {
 // by WAL replay paths to keep memory bounded by mmapping eagerly rather than
 // waiting for the periodic mmapHeadChunks pass.
 //
-// If the chunk cut + mmap reduces headChunkCount from >= 2 to < 2 (which
-// happens whenever prev >= 2, since mmapChunks always sets the count to 1
-// when it does work), the per-stripe mmap-ready counter is decremented to
-// maintain its invariant.
+// The mmap-ready bookkeeping is handled inside memSeries' setters
+// (incHeadChunkCount in the append path, setHeadChunkCount(1) in mmapChunks).
+// No series.Lock is taken: walSubsetProcessor partitions inputs by series ref,
+// so ms has no concurrent writer.
 func (h *Head) appendChunkAndMmap(ms *memSeries, appendFn func() bool) bool {
-	prev := ms.headChunkCount.Load()
 	chunkCreated := appendFn()
 	if chunkCreated {
-		h.metrics.chunksCreated.Inc()
-		h.metrics.chunks.Inc()
-		_ = ms.mmapChunks(h.chunkDiskMapper)
-		if prev >= 2 {
-			h.series.decMmapReady(ms.ref)
-		}
+		h.onChunkCreatedMetrics()
+		_ = ms.mmapChunks(h.chunkDiskMapper, h.series)
 	}
 	return chunkCreated
 }
@@ -906,6 +900,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 		useXOR2:         h.opts.UseXOR2FloatEncoding(),
 		useHistogramST:  h.opts.EnableHistogramSTEncoding.Load(),
 		storeST:         h.opts.EnableSTStorage.Load(),
+		stripes:         h.series,
 	}
 
 	for in := range wp.input {
@@ -1929,10 +1924,10 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 				}
 				series.nextAt = csr.mc.maxTime // This will create a new chunk on append.
 				chunkCount := uint32(csr.mc.len())
-				series.setHeadChunks(csr.mc, chunkCount)
-				if chunkCount >= 2 {
-					h.series.incMmapReady(series.ref)
-				}
+				// No series.Lock: snapshot loading runs before Head.Appender
+				// returns a real appender, and each csr.ref appears in the
+				// snapshot at most once, so this series has no concurrent writer.
+				series.setHeadChunks(csr.mc, chunkCount, h.series)
 				series.lastValue = csr.lastValue
 				series.lastHistogramValue = csr.lastHistogramValue
 				series.lastFloatHistogramValue = csr.lastFloatHistogramValue

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -799,11 +799,10 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 	}
 
 	// Any samples replayed till now would already be compacted. Resetting the head chunk.
+	// No series.Lock: walSubsetProcessor partitions inputs by series ref, so
+	// this series has no concurrent writer during WAL replay.
 	mSeries.nextAt = 0
-	if mSeries.headChunkCount.Load() >= 2 {
-		h.series.decMmapReady(mSeries.ref)
-	}
-	mSeries.setHeadChunks(nil, 0)
+	mSeries.setHeadChunks(nil, 0, h.series)
 	mSeries.app = nil
 	return overlapped
 }
@@ -862,28 +861,15 @@ func (wp *walSubsetProcessor) reuseHistogramBuf() []histogramRecord {
 	return nil
 }
 
-// appendChunkAndMmap appends a sample to ms via appendFn and, if a new head
-// chunk was created, immediately mmaps the now-completed predecessors. Used
-// by WAL replay paths to keep memory bounded by mmapping eagerly rather than
-// waiting for the periodic mmapHeadChunks pass. appendFn returns whether the
-// sample was accepted as in-order and whether it cut a new chunk, and those
-// values are returned to the caller so it can skip metric updates for samples
-// that were rejected (e.g. an older sample appearing later in the WAL).
-//
-// If the chunk cut + mmap reduces headChunkCount from >= 2 to < 2 (which
-// happens whenever prev >= 2, since mmapChunks always sets the count to 1
-// when it does work), the per-stripe mmap-ready counter is decremented to
-// maintain its invariant.
+// appendChunkAndMmap appends through appendFn and eagerly m-maps completed
+// predecessors after a chunk cut. It returns appendFn's acceptance and chunk
+// creation results. WAL replay partitions work by series reference, giving the
+// caller exclusive write ownership without taking series.Lock.
 func (h *Head) appendChunkAndMmap(ms *memSeries, appendFn func() (sampleInOrder, chunkCreated bool)) (sampleInOrder, chunkCreated bool) {
-	prev := ms.headChunkCount.Load()
 	sampleInOrder, chunkCreated = appendFn()
 	if chunkCreated {
-		h.metrics.chunksCreated.Inc()
-		h.metrics.chunks.Inc()
-		_ = ms.mmapChunks(h.chunkDiskMapper)
-		if prev >= 2 {
-			h.series.decMmapReady(ms.ref)
-		}
+		h.onChunkCreatedMetrics()
+		_ = ms.mmapChunks(h.chunkDiskMapper, h.series)
 	}
 	return sampleInOrder, chunkCreated
 }
@@ -1007,6 +993,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 		useXOR2:         h.opts.UseXOR2FloatEncoding(),
 		useHistogramST:  h.opts.EnableHistogramSTEncoding.Load(),
 		storeST:         h.opts.EnableSTStorage.Load(),
+		stripes:         h.series,
 	}
 
 	for in := range wp.input {
@@ -1993,10 +1980,10 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 				}
 				series.nextAt = csr.mc.maxTime // This will create a new chunk on append.
 				chunkCount := uint32(csr.mc.len())
-				series.setHeadChunks(csr.mc, chunkCount)
-				if chunkCount >= 2 {
-					h.series.incMmapReady(series.ref)
-				}
+				// No series.Lock: snapshot loading runs before Head.Appender
+				// returns a real appender, and each csr.ref appears in the
+				// snapshot at most once, so this series has no concurrent writer.
+				series.setHeadChunks(csr.mc, chunkCount, h.series)
 				series.lastValue = csr.lastValue
 				series.lastHistogramValue = csr.lastHistogramValue
 				series.lastFloatHistogramValue = csr.lastFloatHistogramValue

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -60,6 +60,172 @@ type seriesRefSet struct {
 	mtx  sync.Mutex
 }
 
+type walReplayDeletionBarrierEntry struct {
+	hash uint64
+	lset labels.Labels
+}
+
+type walReplayDeletionBarrier struct {
+	done     chan struct{}
+	entries  []walReplayDeletionBarrierEntry
+	registry *walReplayPendingDeletions
+}
+
+type walReplayPendingDeletion struct {
+	lset    labels.Labels
+	barrier *walReplayDeletionBarrier
+}
+
+type walReplayPendingDeletionBucket struct {
+	entry      walReplayPendingDeletion
+	collisions []walReplayPendingDeletion
+}
+
+// walReplayPendingDeletions prevents a series record from re-creating a label
+// set until an earlier full deletion and its lifecycle callback have completed.
+type walReplayPendingDeletions struct {
+	// Keep the 64-bit atomic first to guarantee alignment on 32-bit systems.
+	count  atomic.Int64
+	mtx    sync.Mutex
+	byHash map[uint64]walReplayPendingDeletionBucket
+}
+
+func newWALReplayPendingDeletions() *walReplayPendingDeletions {
+	return &walReplayPendingDeletions{byHash: map[uint64]walReplayPendingDeletionBucket{}}
+}
+
+func (p *walReplayPendingDeletions) add(hash uint64, lset labels.Labels, barrier *walReplayDeletionBarrier) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.addLocked(hash, lset, barrier)
+}
+
+func (p *walReplayPendingDeletions) addLocked(hash uint64, lset labels.Labels, barrier *walReplayDeletionBarrier) {
+	bucket, ok := p.byHash[hash]
+	if !ok {
+		p.byHash[hash] = walReplayPendingDeletionBucket{
+			entry: walReplayPendingDeletion{lset: lset, barrier: barrier},
+		}
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		p.count.Inc()
+		return
+	}
+
+	if labels.Equal(bucket.entry.lset, lset) {
+		if bucket.entry.barrier == barrier {
+			return
+		}
+		bucket.entry.barrier = barrier
+		p.byHash[hash] = bucket
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		return
+	}
+
+	for i := range bucket.collisions {
+		if !labels.Equal(bucket.collisions[i].lset, lset) {
+			continue
+		}
+		if bucket.collisions[i].barrier == barrier {
+			return
+		}
+		bucket.collisions[i].barrier = barrier
+		p.byHash[hash] = bucket
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		return
+	}
+
+	bucket.collisions = append(bucket.collisions, walReplayPendingDeletion{lset: lset, barrier: barrier})
+	p.byHash[hash] = bucket
+	barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+	p.count.Inc()
+}
+
+func (p *walReplayPendingDeletions) newBarrier(lsets []labels.Labels) *walReplayDeletionBarrier {
+	barrier := &walReplayDeletionBarrier{
+		done:     make(chan struct{}),
+		registry: p,
+	}
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	for _, lset := range lsets {
+		p.addLocked(lset.Hash(), lset, barrier)
+	}
+	return barrier
+}
+
+func (p *walReplayPendingDeletions) wait(hash uint64, lset labels.Labels) {
+	for {
+		if p.count.Load() == 0 {
+			return
+		}
+		p.mtx.Lock()
+		var done <-chan struct{}
+		if bucket, ok := p.byHash[hash]; ok {
+			if labels.Equal(bucket.entry.lset, lset) {
+				done = bucket.entry.barrier.done
+			} else {
+				for _, entry := range bucket.collisions {
+					if labels.Equal(entry.lset, lset) {
+						done = entry.barrier.done
+						break
+					}
+				}
+			}
+		}
+		p.mtx.Unlock()
+
+		if done == nil {
+			return
+		}
+		<-done
+	}
+}
+
+func (p *walReplayPendingDeletions) complete(barrier *walReplayDeletionBarrier) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	close(barrier.done)
+	for _, completed := range barrier.entries {
+		bucket, ok := p.byHash[completed.hash]
+		if !ok {
+			continue
+		}
+
+		if bucket.entry.barrier == barrier && labels.Equal(bucket.entry.lset, completed.lset) {
+			p.count.Dec()
+			if len(bucket.collisions) == 0 {
+				delete(p.byHash, completed.hash)
+			} else {
+				last := len(bucket.collisions) - 1
+				bucket.entry = bucket.collisions[last]
+				bucket.collisions = bucket.collisions[:last]
+				p.byHash[completed.hash] = bucket
+			}
+			continue
+		}
+
+		for i := range bucket.collisions {
+			entry := bucket.collisions[i]
+			if entry.barrier != barrier || !labels.Equal(entry.lset, completed.lset) {
+				continue
+			}
+			last := len(bucket.collisions) - 1
+			bucket.collisions[i] = bucket.collisions[last]
+			bucket.collisions = bucket.collisions[:last]
+			p.byHash[completed.hash] = bucket
+			p.count.Dec()
+			break
+		}
+	}
+}
+
+func (b *walReplayDeletionBarrier) complete() {
+	if b != nil {
+		b.registry.complete(b)
+	}
+}
+
 func (s *seriesRefSet) merge(other map[chunks.HeadSeriesRef]struct{}) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
@@ -96,13 +262,14 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		wg             sync.WaitGroup
 		concurrency    = h.opts.WALReplayConcurrency
 		processors     = make([]walSubsetProcessor, concurrency)
-		exemplarsInput chan record.RefExemplar
+		exemplarsInput chan walReplayExemplarInput
 
 		shards          = make([][]record.RefSample, concurrency)
 		histogramShards = make([][]histogramRecord, concurrency)
 
 		decoded                      = make(chan any, 10)
 		decodeErr, seriesCreationErr error
+		pendingDeletions             *walReplayPendingDeletions
 	)
 
 	defer func() {
@@ -132,12 +299,18 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 	}
 
 	wg.Add(1)
-	exemplarsInput = make(chan record.RefExemplar, 300)
-	go func(input <-chan record.RefExemplar) {
+	exemplarsInput = make(chan walReplayExemplarInput, 300)
+	go func(input <-chan walReplayExemplarInput) {
 		missingSeries := make(map[chunks.HeadSeriesRef]struct{})
 		var err error
 		defer wg.Done()
-		for e := range input {
+		for in := range input {
+			if in.done != nil {
+				// Channel ordering makes this a barrier: closing done acknowledges that all preceding exemplars have been replayed.
+				close(in.done)
+				continue
+			}
+			e := in.exemplar
 			ms := h.series.getByID(e.Ref)
 			if ms == nil {
 				unknownExemplarRefs.Inc()
@@ -252,12 +425,17 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 
 	// The records are always replayed from the oldest to the newest.
 	missingSeries := make(map[chunks.HeadSeriesRef]struct{})
+	exemplarsPending := false
 Outer:
 	for d := range decoded {
 		switch v := d.(type) {
 		case []record.RefSeries:
 			for _, walSeries := range v {
-				mSeries, created, err := h.getOrCreateWithOptionalID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels, false)
+				hash := walSeries.Labels.Hash()
+				if pendingDeletions != nil {
+					pendingDeletions.wait(hash, walSeries.Labels)
+				}
+				mSeries, created, err := h.getOrCreateWithOptionalID(walSeries.Ref, hash, walSeries.Labels, false)
 				if err != nil {
 					seriesCreationErr = err
 					break Outer
@@ -315,6 +493,7 @@ Outer:
 		case []tombstones.Stone:
 			// Tombstone records will be fairly rare, so not trying to optimise the allocations here.
 			deleteSeriesShards := make([][]chunks.HeadSeriesRef, concurrency)
+			deleteSeriesLabelShards := make([][]labels.Labels, concurrency)
 			for _, s := range v {
 				// A tombstone means this ref was previously allocated, even if its series record is no
 				// longer in the WAL. Advance lastSeriesID so the ref is not reissued.
@@ -329,13 +508,13 @@ Outer:
 						ref = r
 					}
 					if series := h.series.getByID(ref); series != nil {
-						// Remove the series from the hash index so that a later series
-						// record with the same labels creates a fresh series instead of
-						// mapping onto this one. It stays in the by-ref map so
-						// already-queued samples still resolve until the deletion applies.
+						// Remove the series from the hash index so a later series record with
+						// the same labels creates a fresh series. The by-ref entry remains until
+						// the queued deletion applies, so earlier records can still resolve it.
 						h.series.unlinkHash(series.lset.Hash(), ref)
 						mod := uint64(ref) % uint64(concurrency)
 						deleteSeriesShards[mod] = append(deleteSeriesShards[mod], ref)
+						deleteSeriesLabelShards[mod] = append(deleteSeriesLabelShards[mod], series.labels())
 					}
 					continue
 				}
@@ -357,10 +536,39 @@ Outer:
 				}
 			}
 
+			hasLiveFullDeletions := false
+			for i := range concurrency {
+				if len(deleteSeriesLabelShards[i]) > 0 {
+					hasLiveFullDeletions = true
+					break
+				}
+			}
+			if hasLiveFullDeletions && pendingDeletions == nil {
+				pendingDeletions = newWALReplayPendingDeletions()
+			}
+
+			// Drain separately processed exemplars before dispatching a live
+			// deletion so it cannot overtake an earlier exemplar for the series.
+			if hasLiveFullDeletions && exemplarsPending {
+				done := make(chan struct{})
+				exemplarsInput <- walReplayExemplarInput{done: done}
+				if h.walReplayExemplarDrainHook != nil {
+					h.walReplayExemplarDrainHook(done)
+				}
+				<-done
+				exemplarsPending = false
+			}
+
 			for i := range concurrency {
 				if len(deleteSeriesShards[i]) > 0 {
-					processors[i].input <- walSubsetProcessorInputItem{deletedSeriesRefs: deleteSeriesShards[i]}
-					deleteSeriesShards[i] = nil
+					var barrier *walReplayDeletionBarrier
+					if len(deleteSeriesLabelShards[i]) > 0 {
+						barrier = pendingDeletions.newBarrier(deleteSeriesLabelShards[i])
+					}
+					processors[i].input <- walSubsetProcessorInputItem{
+						deletedSeriesRefs: deleteSeriesShards[i],
+						deletionBarrier:   barrier,
+					}
 				}
 			}
 
@@ -376,7 +584,8 @@ Outer:
 					h.updateWALExpiry(e.Ref, e.T)
 					e.Ref = r
 				}
-				exemplarsInput <- e
+				exemplarsInput <- walReplayExemplarInput{exemplar: e}
+				exemplarsPending = true
 			}
 			for i := range v { // Zero out to avoid retaining label data.
 				v[i].Labels = labels.EmptyLabels()
@@ -605,12 +814,18 @@ type walSubsetProcessor struct {
 	histogramsOutput chan []histogramRecord
 }
 
+type walReplayExemplarInput struct {
+	exemplar record.RefExemplar
+	done     chan struct{}
+}
+
 type walSubsetProcessorInputItem struct {
 	samples           []record.RefSample
 	histogramSamples  []histogramRecord
 	existingSeries    *memSeries
 	walSeriesRef      chunks.HeadSeriesRef
 	deletedSeriesRefs []chunks.HeadSeriesRef
+	deletionBarrier   *walReplayDeletionBarrier
 }
 
 func (wp *walSubsetProcessor) setup() {
@@ -859,9 +1074,14 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 		default:
 		}
 
+		var deletedForCallback map[chunks.HeadSeriesRef]labels.Labels
 		if len(in.deletedSeriesRefs) > 0 {
-			h.deleteSeriesByID(in.deletedSeriesRefs)
+			deletedForCallback = h.deleteSeriesByID(in.deletedSeriesRefs)
 		}
+		if len(deletedForCallback) > 0 {
+			h.series.seriesLifecycleCallback.PostDeletion(deletedForCallback)
+		}
+		in.deletionBarrier.complete()
 	}
 	h.updateMinMaxTime(mint, maxt)
 


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Depends on #18907.

This PR centralizes the invariant between `memSeries.headChunkCount` and the owning stripe's `mmapReady` counter. Mutations now flow through `incHeadChunkCount` and `setHeadChunkCount`, called by `pushHeadChunk` and `setHeadChunks`. The setters update `mmapReady` whenever a series crosses the `headChunkCount >= 2` threshold, so append, mmap, GC and truncation, startup loading, WAL replay, snapshot loading, and stale-series deletion through `truncateStaleSeries` and `gcSeries` use the same accounting.

`headChunkCount` is wrapped in `headChunkCounter`: ordinary callers use `Load`, previous direct `Add` and `Store` calls no longer compile, and tests that deliberately construct inconsistent state access the inner atomic explicitly. For the WAL replay deletion covered by #18907, `setHeadChunks(nil, 0, h.series)` now clears the list and count while performing the matching `mmapReady` transition. `requireMmapReadyConsistent` adds regression coverage for the per-stripe invariant.

The three appender commit paths no longer load the previous head chunk count solely for readiness accounting. Chunk creation now calls `onChunkCreatedMetrics`, which only updates chunk metrics, and the obsolete `stripeSeries.incMmapReady` and `decMmapReady` helpers are removed.

#### Benchmarks

Hardware: `Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz`, `-count=6`.

```
go test -count=6 -benchmem -run='^$' \
  -bench='^(BenchmarkHeadAppender_AppendCommit|BenchmarkMmapHeadChunks|BenchmarkHeadStripeSeriesCreate|BenchmarkHeadStripeSeriesCreateParallel|BenchmarkCreateSeries|BenchmarkCuttingHeadHistogramChunks|BenchmarkHead_Truncate)$' \
  ./tsdb/
```

Historical pre-rebase results: **geomean -1.02% sec/op, +0.23% B/op, +0.02% allocs/op**. These measurements were collected before the latest rebase onto #18907 and have not been rerun against current HEAD. The command and raw benchstat output are retained for context; they are not current-base performance evidence.

<details>
<summary>Full benchstat output</summary>

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz
                                                                                                          │    main.txt    │             refactor.txt             │
                                                                                                          │     sec/op     │     sec/op      vs base              │
HeadAppender_AppendCommit/appender=v1/case=floats/series=10/samples_per_append=1-16                           8.907µ ±  1%     8.385µ ±  2%  -5.86% (p=0.002 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=10/samples_per_append=5-16                           23.89µ ±  2%     22.04µ ±  3%  -7.74% (p=0.002 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=10/samples_per_append=100-16                         357.7µ ±  4%     335.4µ ±  5%  -6.24% (p=0.004 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=1-16                          58.04µ ±  3%     55.13µ ±  1%  -5.01% (p=0.002 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=5-16                          206.8µ ±  3%     194.4µ ±  2%  -6.00% (p=0.002 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=100-16                        3.620m ±  2%     3.295m ±  2%  -8.98% (p=0.002 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=10/samples_per_append=1-16                           9.034µ ±  1%     8.488µ ±  3%  -6.04% (p=0.002 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=10/samples_per_append=5-16                           23.61µ ±  4%     22.81µ ±  3%  -3.41% (p=0.002 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=10/samples_per_append=100-16                         359.2µ ±  1%     342.5µ ±  2%  -4.65% (p=0.002 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=1-16                          57.70µ ±  3%     55.79µ ±  1%  -3.31% (p=0.002 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=5-16                          202.0µ ±  2%     204.5µ ±  1%       ~ (p=0.180 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=100-16                        3.431m ±  2%     3.465m ±  2%       ~ (p=0.180 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=10/samples_per_append=1-16        32.51µ ±  3%     33.36µ ±  2%  +2.60% (p=0.041 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=10/samples_per_append=5-16        126.7µ ±  2%     126.6µ ±  5%       ~ (p=0.818 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=10/samples_per_append=100-16      2.237m ±  6%     2.187m ±  5%       ~ (p=0.132 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=1-16       271.5µ ±  2%     274.8µ ±  2%       ~ (p=0.180 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=5-16       1.232m ±  3%     1.229m ±  4%       ~ (p=0.937 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=100-16     21.24m ±  2%     21.57m ±  2%  +1.54% (p=0.015 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=10/samples_per_append=1-16        27.73µ ±  2%     27.69µ ±  2%       ~ (p=0.485 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=10/samples_per_append=5-16        98.55µ ±  1%    100.31µ ±  3%  +1.79% (p=0.026 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=10/samples_per_append=100-16      1.694m ±  1%     1.701m ±  1%       ~ (p=0.485 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=1-16       228.0µ ±  2%     227.0µ ±  4%       ~ (p=1.000 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=5-16       1.009m ±  3%     1.017m ±  2%       ~ (p=0.394 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=100-16     16.53m ±  1%     16.74m ±  1%  +1.32% (p=0.002 n=6)
HeadStripeSeriesCreate-16                                                                                     1.814µ ±  3%     1.853µ ±  1%  +2.12% (p=0.002 n=6)
HeadStripeSeriesCreateParallel-16                                                                             1.765µ ±  2%     1.794µ ±  4%       ~ (p=0.589 n=6)
MmapHeadChunks/series=1000/ready=10-16                                                                        22.25µ ± 73%     23.38µ ± 59%       ~ (p=0.240 n=6)
MmapHeadChunks/series=1000/ready=100-16                                                                       113.2µ ±  3%     111.2µ ±  3%       ~ (p=0.310 n=6)
MmapHeadChunks/series=1000/ready=1000-16                                                                      756.2µ ±  7%     764.2µ ±  5%       ~ (p=0.937 n=6)
MmapHeadChunks/series=10000/ready=100-16                                                                      117.9µ ±  4%     112.7µ ± 18%  -4.39% (p=0.026 n=6)
MmapHeadChunks/series=10000/ready=1000-16                                                                     883.2µ ±  3%     888.8µ ±  4%       ~ (p=0.589 n=6)
MmapHeadChunks/series=10000/ready=10000-16                                                                    9.562m ±  3%    10.053m ±  6%       ~ (p=0.093 n=6)
MmapHeadChunks/series=100000/ready=1000-16                                                                    1.048m ±  3%     1.039m ±  1%       ~ (p=0.818 n=6)
MmapHeadChunks/series=100000/ready=10000-16                                                                   12.74m ±  5%     12.35m ±  3%  -3.01% (p=0.002 n=6)
MmapHeadChunks/series=100000/ready=100000-16                                                                  107.8m ±  2%     107.4m ±  5%       ~ (p=1.000 n=6)
CreateSeries-16                                                                                               2.882µ ±  1%     2.980µ ±  5%       ~ (p=0.132 n=6)
Head_Truncate/churn=10-16                                                                                     446.2m ±  5%     444.2m ±  8%       ~ (p=1.000 n=6)
Head_Truncate/churn=100-16                                                                                    512.0m ±  4%     514.6m ±  5%       ~ (p=1.000 n=6)
Head_Truncate/churn=1000-16                                                                                   482.8m ±  1%     484.3m ±  4%       ~ (p=1.000 n=6)
CuttingHeadHistogramChunks-16                                                                               0.02793n ± 51%   0.02812n ±  3%       ~ (p=0.937 n=6)
geomean                                                                                                       297.8µ           294.7µ        -1.02%

                                                                                                          │    main.txt     │             refactor.txt              │
                                                                                                          │      B/op       │     B/op       vs base                │
HeadAppender_AppendCommit/appender=v1/case=floats/series=10/samples_per_append=1-16                           660.0 ±  1%       661.0 ±  0%       ~ (p=0.297 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=10/samples_per_append=5-16                           861.0 ±  0%       867.0 ±  0%  +0.70% (p=0.002 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=10/samples_per_append=100-16                       5.705Ki ±  1%     5.695Ki ±  1%       ~ (p=0.981 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=1-16                        2.921Ki ±  0%     2.923Ki ±  0%       ~ (p=0.669 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=5-16                        4.921Ki ±  2%     4.785Ki ±  2%  -2.78% (p=0.009 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=100-16                      55.10Ki ±  3%     52.07Ki ±  5%  -5.50% (p=0.004 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=10/samples_per_append=1-16                           659.5 ±  0%       660.0 ±  0%       ~ (p=0.316 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=10/samples_per_append=5-16                           861.0 ±  0%       863.5 ±  1%       ~ (p=0.093 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=10/samples_per_append=100-16                       5.711Ki ±  1%     5.723Ki ±  1%       ~ (p=0.818 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=1-16                        2.921Ki ±  0%     2.919Ki ±  0%       ~ (p=0.517 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=5-16                        4.869Ki ±  4%     4.968Ki ±  4%       ~ (p=0.310 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=100-16                      54.95Ki ±  5%     53.53Ki ±  7%       ~ (p=0.699 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=10/samples_per_append=1-16      3.906Ki ±  0%     3.909Ki ±  0%       ~ (p=0.411 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=10/samples_per_append=5-16      16.25Ki ±  0%     16.26Ki ±  0%       ~ (p=0.970 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=10/samples_per_append=100-16    315.6Ki ±  2%     315.9Ki ±  1%       ~ (p=0.818 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=1-16     34.42Ki ±  0%     34.40Ki ±  0%       ~ (p=0.725 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=5-16     160.4Ki ±  1%     160.4Ki ±  1%       ~ (p=0.937 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=100-16   3.367Mi ±  8%     3.394Mi ± 11%       ~ (p=1.000 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=10/samples_per_append=1-16      4.034Ki ±  0%     4.035Ki ±  0%       ~ (p=1.000 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=10/samples_per_append=5-16      16.32Ki ±  0%     16.31Ki ±  0%       ~ (p=0.240 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=10/samples_per_append=100-16    313.7Ki ±  1%     314.1Ki ±  1%       ~ (p=0.310 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=1-16     34.53Ki ±  0%     34.53Ki ±  0%       ~ (p=0.937 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=5-16     159.6Ki ±  1%     159.5Ki ±  1%       ~ (p=0.818 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=100-16   3.045Mi ± 21%     3.329Mi ±  8%       ~ (p=0.240 n=6)
HeadStripeSeriesCreate-16                                                                                     641.0 ±  0%       641.0 ±  0%       ~ (p=1.000 n=6) ¹
HeadStripeSeriesCreateParallel-16                                                                             523.5 ± 12%       531.0 ±  3%       ~ (p=0.234 n=6)
MmapHeadChunks/series=1000/ready=10-16                                                                      1.668Ki ±  5%     1.668Ki ±  3%       ~ (p=0.561 n=6)
MmapHeadChunks/series=1000/ready=100-16                                                                     15.19Ki ±  0%     15.16Ki ±  2%       ~ (p=0.394 n=6)
MmapHeadChunks/series=1000/ready=1000-16                                                                    141.1Ki ±  4%     146.4Ki ±  1%       ~ (p=0.093 n=6)
MmapHeadChunks/series=10000/ready=100-16                                                                    15.29Ki ±  2%     15.30Ki ±  1%       ~ (p=0.786 n=6)
MmapHeadChunks/series=10000/ready=1000-16                                                                   139.3Ki ±  1%     138.1Ki ±  1%       ~ (p=0.394 n=6)
MmapHeadChunks/series=10000/ready=10000-16                                                                  1.304Mi ±  0%     1.345Mi ±  3%  +3.10% (p=0.002 n=6)
MmapHeadChunks/series=100000/ready=1000-16                                                                  143.1Ki ±  1%     143.1Ki ±  1%       ~ (p=0.937 n=6)
MmapHeadChunks/series=100000/ready=10000-16                                                                 1.359Mi ±  2%     1.359Mi ±  5%       ~ (p=0.838 n=6)
MmapHeadChunks/series=100000/ready=100000-16                                                                13.24Mi ±  0%     13.24Mi ±  0%       ~ (p=0.905 n=6)
CreateSeries-16                                                                                               867.0 ±  9%       865.5 ±  7%       ~ (p=0.818 n=6)
Head_Truncate/churn=10-16                                                                                   34.74Mi ±  0%     34.74Mi ±  0%       ~ (p=0.615 n=6)
Head_Truncate/churn=100-16                                                                                  65.06Mi ±  0%     65.06Mi ±  0%       ~ (p=1.000 n=6)
Head_Truncate/churn=1000-16                                                                                 91.18Mi ±  0%     91.18Mi ±  0%       ~ (p=0.669 n=6)
CuttingHeadHistogramChunks-16                                                                                 0.000 ±  0%       0.000 ±  0%       ~ (p=1.000 n=6) ¹
geomean                                                                                                                   ²                  +0.23%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                                                                          │   main.txt    │            refactor.txt             │
                                                                                                          │   allocs/op   │  allocs/op   vs base                │
HeadAppender_AppendCommit/appender=v1/case=floats/series=10/samples_per_append=1-16                          8.000 ± 0%      8.000 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v1/case=floats/series=10/samples_per_append=5-16                          8.000 ± 0%      8.000 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v1/case=floats/series=10/samples_per_append=100-16                        56.00 ± 0%      56.00 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=1-16                         44.00 ± 0%      44.00 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=5-16                         52.50 ± 1%      52.00 ± 0%       ~ (p=0.182 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=100-16                       512.0 ± 0%      512.0 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floats/series=10/samples_per_append=1-16                          8.000 ± 0%      8.000 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floats/series=10/samples_per_append=5-16                          8.000 ± 0%      8.000 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floats/series=10/samples_per_append=100-16                        56.00 ± 2%      56.00 ± 2%       ~ (p=1.000 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=1-16                         44.00 ± 0%      44.00 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=5-16                         52.00 ± 2%      52.50 ± 1%       ~ (p=1.000 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=100-16                       512.0 ± 0%      512.0 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=10/samples_per_append=1-16       66.00 ± 0%      66.00 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=10/samples_per_append=5-16       307.0 ± 0%      307.0 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=10/samples_per_append=100-16    6.046k ± 0%     6.047k ± 0%       ~ (p=0.545 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=1-16      615.0 ± 0%      615.0 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=5-16     3.035k ± 0%     3.035k ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=100-16   60.27k ± 0%     60.27k ± 0%       ~ (p=0.898 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=10/samples_per_append=1-16       67.00 ± 0%      67.00 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=10/samples_per_append=5-16       308.0 ± 0%      308.0 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=10/samples_per_append=100-16    6.025k ± 0%     6.025k ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=1-16      616.0 ± 0%      616.0 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=5-16     3.031k ± 0%     3.031k ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=100-16   60.04k ± 0%     60.04k ± 0%       ~ (p=0.413 n=6)
HeadStripeSeriesCreate-16                                                                                    5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=6) ¹
HeadStripeSeriesCreateParallel-16                                                                            5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=6) ¹
MmapHeadChunks/series=1000/ready=10-16                                                                       10.00 ± 0%      10.00 ± 0%       ~ (p=1.000 n=6) ¹
MmapHeadChunks/series=1000/ready=100-16                                                                      105.0 ± 1%      105.0 ± 1%       ~ (p=0.636 n=6)
MmapHeadChunks/series=1000/ready=1000-16                                                                    1.033k ± 0%     1.033k ± 0%       ~ (p=0.455 n=6)
MmapHeadChunks/series=10000/ready=100-16                                                                     106.5 ± 0%      106.0 ± 1%       ~ (p=0.675 n=6)
MmapHeadChunks/series=10000/ready=1000-16                                                                   1.034k ± 0%     1.034k ± 0%       ~ (p=0.636 n=6)
MmapHeadChunks/series=10000/ready=10000-16                                                                  10.91k ± 0%     11.05k ± 1%  +1.32% (p=0.006 n=6)
MmapHeadChunks/series=100000/ready=1000-16                                                                  1.036k ± 0%     1.036k ± 0%       ~ (p=0.545 n=6)
MmapHeadChunks/series=100000/ready=10000-16                                                                 11.07k ± 1%     11.07k ± 2%       ~ (p=0.831 n=6)
MmapHeadChunks/series=100000/ready=100000-16                                                                142.9k ± 0%     142.9k ± 0%       ~ (p=1.000 n=6)
CreateSeries-16                                                                                              3.000 ± 0%      3.000 ± 0%       ~ (p=1.000 n=6) ¹
Head_Truncate/churn=10-16                                                                                   16.53k ± 0%     16.53k ± 0%       ~ (p=1.000 n=6)
Head_Truncate/churn=100-16                                                                                  17.00k ± 0%     17.00k ± 0%       ~ (p=1.000 n=6)
Head_Truncate/churn=1000-16                                                                                 20.58k ± 0%     20.58k ± 0%       ~ (p=1.000 n=6)
CuttingHeadHistogramChunks-16                                                                                0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                                                                                 ²                +0.02%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

</details>

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```

