### PR TITLE
discovery/aws: run tests in parallel

### DIFF
--- a/discovery/aws/aws_test.go
+++ b/discovery/aws/aws_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestRoleUnmarshalYAML(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -84,6 +85,7 @@ func TestRoleUnmarshalYAML(t *testing.T) {
 }
 
 func TestRoleString(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		role     Role
@@ -114,16 +116,19 @@ func TestRoleString(t *testing.T) {
 }
 
 func TestSDConfigName(t *testing.T) {
+	t.Parallel()
 	cfg := &SDConfig{}
 	require.Equal(t, "aws", cfg.Name())
 }
 
 func TestDefaultSDConfig(t *testing.T) {
+	t.Parallel()
 	require.Equal(t, Role(""), DefaultSDConfig.Role)
 	require.Equal(t, model.Duration(60*time.Second), DefaultSDConfig.RefreshInterval)
 }
 
 func TestSDConfigUnmarshalYAML(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		yaml         string
@@ -189,6 +194,7 @@ port: 9300`,
 // all configs pointed to the same global default, causing port and other
 // settings from one job to overwrite settings in another job.
 func TestMultipleSDConfigsDoNotShareState(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		yaml         string
@@ -489,6 +495,7 @@ region = ` + randomRegion + `
 }
 
 func TestSDConfigSetDirectory(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	tests := []struct {
 		name string

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -55,6 +55,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestEC2DiscoveryRefreshAZIDs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// iterate through the test cases
@@ -99,6 +100,7 @@ func TestEC2DiscoveryRefreshAZIDs(t *testing.T) {
 }
 
 func TestEC2DiscoveryRefresh(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// iterate through the test cases

--- a/discovery/aws/ecs_test.go
+++ b/discovery/aws/ecs_test.go
@@ -40,6 +40,7 @@ type ecsDataStore struct {
 }
 
 func TestECSDiscoveryListClusterARNs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// iterate through the test cases
@@ -114,6 +115,7 @@ func TestECSDiscoveryListClusterARNs(t *testing.T) {
 }
 
 func TestECSDiscoveryDescribeClusters(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// iterate through the test cases
@@ -212,6 +214,7 @@ func TestECSDiscoveryDescribeClusters(t *testing.T) {
 }
 
 func TestECSDiscoveryListServiceARNs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -310,6 +313,7 @@ func TestECSDiscoveryListServiceARNs(t *testing.T) {
 }
 
 func TestECSDiscoveryDescribeServices(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -402,6 +406,7 @@ func TestECSDiscoveryDescribeServices(t *testing.T) {
 }
 
 func TestECSDiscoveryDescribeContainerInstances(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -506,6 +511,7 @@ func TestECSDiscoveryDescribeContainerInstances(t *testing.T) {
 }
 
 func TestECSDiscoveryDescribeEC2Instances(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -619,6 +625,7 @@ func TestECSDiscoveryDescribeEC2Instances(t *testing.T) {
 }
 
 func TestECSDiscoveryDescribeNetworkInterfaces(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -760,6 +767,7 @@ func TestECSDiscoveryDescribeNetworkInterfaces(t *testing.T) {
 }
 
 func TestECSDiscoveryListTaskARNs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// iterate through the test cases
@@ -834,6 +842,7 @@ func TestECSDiscoveryListTaskARNs(t *testing.T) {
 }
 
 func TestECSDiscoveryDescribeTasks(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// iterate through the test cases
@@ -923,6 +932,7 @@ func TestECSDiscoveryDescribeTasks(t *testing.T) {
 }
 
 func TestECSDiscoveryRefresh(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	tests := []struct {
@@ -1712,6 +1722,7 @@ func (m *mockECSEC2Client) DescribeNetworkInterfaces(_ context.Context, input *e
 }
 
 func TestIsStandaloneTask(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		task     ecsTypes.Task
@@ -1763,6 +1774,7 @@ func TestIsStandaloneTask(t *testing.T) {
 }
 
 func TestGetServiceNameFromTaskGroup(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		task     ecsTypes.Task

--- a/discovery/aws/elasticache_test.go
+++ b/discovery/aws/elasticache_test.go
@@ -36,6 +36,7 @@ type elasticacheDataStore struct {
 }
 
 func TestElasticacheDiscoveryDescribeServerlessCaches(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -125,6 +126,7 @@ func TestElasticacheDiscoveryDescribeServerlessCaches(t *testing.T) {
 }
 
 func TestElasticacheDiscoveryDescribeCacheClusters(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -184,6 +186,7 @@ func TestElasticacheDiscoveryDescribeCacheClusters(t *testing.T) {
 }
 
 func TestAddServerlessCacheTargets(t *testing.T) {
+	t.Parallel()
 	testTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
@@ -269,6 +272,7 @@ func TestAddServerlessCacheTargets(t *testing.T) {
 }
 
 func TestAddCacheClusterTargets(t *testing.T) {
+	t.Parallel()
 	testTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
@@ -532,6 +536,7 @@ func (m *mockElasticacheClient) ListTagsForResource(_ context.Context, input *el
 }
 
 func TestSplitCacheDeploymentOptions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                       string
 		caches                     []string

--- a/discovery/aws/msk_test.go
+++ b/discovery/aws/msk_test.go
@@ -36,6 +36,7 @@ type mskDataStore struct {
 }
 
 func TestMSKDiscoveryListClusters(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -126,6 +127,7 @@ func TestMSKDiscoveryListClusters(t *testing.T) {
 }
 
 func TestMSKDiscoveryDescribeClusters(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -240,6 +242,7 @@ func TestMSKDiscoveryDescribeClusters(t *testing.T) {
 }
 
 func TestMSKDiscoveryListNodes(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	for _, tt := range []struct {
@@ -406,6 +409,7 @@ func TestMSKDiscoveryListNodes(t *testing.T) {
 }
 
 func TestMSKDiscoveryRefresh(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	tests := []struct {
@@ -1031,6 +1035,7 @@ func TestMSKDiscoveryRefresh(t *testing.T) {
 }
 
 func TestNodeType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		node     types.NodeInfo

--- a/discovery/aws/rds_test.go
+++ b/discovery/aws/rds_test.go
@@ -82,6 +82,7 @@ func (m *mockRDSClient) DescribeDBInstances(_ context.Context, input *rds.Descri
 }
 
 func TestRDSDiscoveryRefresh(t *testing.T) {
+	t.Parallel()
 	testTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
@@ -421,6 +422,7 @@ func TestRDSDiscoveryRefresh(t *testing.T) {
 }
 
 func TestDescribeAllDBClusters(t *testing.T) {
+	t.Parallel()
 	mockClient := &mockRDSClient{
 		clusters: map[string]types.DBCluster{
 			"arn:aws:rds:us-east-1:123456789012:cluster:cluster-1": {


### PR DESCRIPTION
Each test function in the `discovery/aws` package creates its own mock
AWS client and operates on independent in-memory data stores, so there
is no shared global state between top-level test functions.

Adding `t.Parallel()` to the 33 top-level test functions across the
six test files (`aws`, `ec2`, `ecs`, `elasticache`, `msk`, `rds`)
allows the Go test runner to overlap their execution, reducing
wall-clock time.

`TestLoadRegion` is excluded: its subtests call `t.Setenv`, which
panics when a parallel ancestor is present (Go 1.25+).

Refs: #15185

```release-notes
NONE
```