### PR TITLE
storage/remote: validate label value lengths to prevent crashes (#16525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [BUGFIX] Remote write receiver: Validate label value lengths before deserialization to prevent crashes on values ≥16 MB. Respects `global.label_value_length_limit`; defaults to 16 MB safety cap when not configured. #16525
+
 ## 3.11.3 / 2026-04-27
 
 This release fixes mutiple security issues.

--- a/prompb/codec.go
+++ b/prompb/codec.go
@@ -14,6 +14,7 @@
 package prompb
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/common/model"
@@ -28,6 +29,34 @@ import (
 // ToLabels return model labels.Labels from timeseries' remote labels.
 func (m TimeSeries) ToLabels(b *labels.ScratchBuilder, _ []string) labels.Labels {
 	return labelProtosToLabels(b, m.GetLabels())
+}
+
+// ErrLabelValueTooLong is returned when a label value exceeds the configured limit.
+type ErrLabelValueTooLong struct {
+	LabelName   string
+	ValueLength int
+	Limit       int
+}
+
+func (e ErrLabelValueTooLong) Error() string {
+	return "label value too long: label " + e.LabelName +
+		" has value length " + strconv.Itoa(e.ValueLength) +
+		", limit " + strconv.Itoa(e.Limit)
+}
+
+// ToLabelsWithLimits returns labels from this TimeSeries, validating that no label value
+// exceeds maxLabelValueLength bytes. Returns ErrLabelValueTooLong on violation.
+func (m TimeSeries) ToLabelsWithLimits(b *labels.ScratchBuilder, _ []string, maxLabelValueLength int) (labels.Labels, error) {
+	for _, l := range m.GetLabels() {
+		if len(l.Value) > maxLabelValueLength {
+			return labels.EmptyLabels(), ErrLabelValueTooLong{
+				LabelName:   l.Name,
+				ValueLength: len(l.Value),
+				Limit:       maxLabelValueLength,
+			}
+		}
+	}
+	return labelProtosToLabels(b, m.GetLabels()), nil
 }
 
 // ToLabels return model labels.Labels from timeseries' remote labels.

--- a/prompb/io/prometheus/write/v2/codec.go
+++ b/prompb/io/prometheus/write/v2/codec.go
@@ -31,6 +31,12 @@ func (m TimeSeries) ToLabels(b *labels.ScratchBuilder, symbols []string) (labels
 	return desymbolizeLabels(b, m.GetLabelsRefs(), symbols)
 }
 
+// ToLabelsWithLimits returns labels from this TimeSeries, validating that no label value
+// exceeds maxLabelValueLength bytes. Returns ErrLabelValueTooLong on violation.
+func (m TimeSeries) ToLabelsWithLimits(b *labels.ScratchBuilder, symbols []string, maxLabelValueLength int) (labels.Labels, error) {
+	return desymbolizeLabelsWithLimits(b, m.GetLabelsRefs(), symbols, maxLabelValueLength)
+}
+
 // ToMetadata returns model metadata from timeseries' remote metadata.
 func (m TimeSeries) ToMetadata(symbols []string) (metadata.Metadata, error) {
 	typ := model.MetricTypeUnknown

--- a/prompb/io/prometheus/write/v2/symbols.go
+++ b/prompb/io/prometheus/write/v2/symbols.go
@@ -96,3 +96,42 @@ func desymbolizeLabels(b *labels.ScratchBuilder, labelRefs []uint32, symbols []s
 	b.Sort()
 	return b.Labels(), nil
 }
+
+// ErrLabelValueTooLong is returned when a label value exceeds the configured limit.
+type ErrLabelValueTooLong struct {
+	LabelName   string
+	ValueLength int
+	Limit       int
+}
+
+func (e ErrLabelValueTooLong) Error() string {
+	return fmt.Sprintf("label value too long: label %q has value length %d, limit %d",
+		e.LabelName, e.ValueLength, e.Limit)
+}
+
+// desymbolizeLabelsWithLimits decodes label references from the symbol table,
+// validating that no label value exceeds maxLabelValueLength bytes.
+func desymbolizeLabelsWithLimits(b *labels.ScratchBuilder, labelRefs []uint32, symbols []string, maxLabelValueLength int) (labels.Labels, error) {
+	if len(labelRefs)%2 != 0 {
+		return labels.EmptyLabels(), fmt.Errorf("invalid labelRefs length %d", len(labelRefs))
+	}
+	b.Reset()
+	for i := 0; i < len(labelRefs); i += 2 {
+		nameRef, valueRef := labelRefs[i], labelRefs[i+1]
+		if int(nameRef) >= len(symbols) || int(valueRef) >= len(symbols) {
+			return labels.EmptyLabels(), fmt.Errorf("labelRefs %d (name) = %d (value) outside of symbols table (size %d)",
+				nameRef, valueRef, len(symbols))
+		}
+		value := symbols[valueRef]
+		if len(value) > maxLabelValueLength {
+			return labels.EmptyLabels(), ErrLabelValueTooLong{
+				LabelName:   symbols[nameRef],
+				ValueLength: len(value),
+				Limit:       maxLabelValueLength,
+			}
+		}
+		b.Add(symbols[nameRef], value)
+	}
+	b.Sort()
+	return b.Labels(), nil
+}

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -48,6 +49,28 @@ type writeHandler struct {
 	ingestSTZeroSample      bool
 	enableTypeAndUnitLabels bool
 	appendMetadata          bool
+
+	// configFunc returns the current Prometheus configuration.
+	// Used to read GlobalConfig.LabelValueLengthLimit dynamically.
+	configFunc func() config.Config
+}
+
+// DefaultMaxLabelValueLength is the safety cap applied to the remote write receiver
+// when no explicit GlobalConfig.LabelValueLengthLimit is configured.
+// This prevents panics caused by label values exceeding the 16 MB internal cap.
+const DefaultMaxLabelValueLength = 16 * 1024 * 1024 // 16 MB
+
+// effectiveLabelValueLengthLimit returns the label value length limit to enforce
+// for remote write. It reads GlobalConfig.LabelValueLengthLimit from the current
+// configuration; if that is 0 (no explicit limit), it falls back to
+// DefaultMaxLabelValueLength to prevent crashes from oversized values.
+func (h *writeHandler) effectiveLabelValueLengthLimit() int {
+	if h.configFunc != nil {
+		if limit := int(h.configFunc().GlobalConfig.LabelValueLengthLimit); limit > 0 {
+			return limit
+		}
+	}
+	return DefaultMaxLabelValueLength
 }
 
 const maxAheadTime = 10 * time.Minute
@@ -57,7 +80,7 @@ const maxAheadTime = 10 * time.Minute
 //
 // NOTE(bwplotka): When accepting v2 proto and spec, partial writes are possible
 // as per https://prometheus.io/docs/specs/remote_write_spec_2_0/#partial-write.
-func NewWriteHandler(logger *slog.Logger, reg prometheus.Registerer, appendable storage.Appendable, acceptedMsgs remoteapi.MessageTypes, ingestSTZeroSample, enableTypeAndUnitLabels, appendMetadata bool) http.Handler {
+func NewWriteHandler(logger *slog.Logger, reg prometheus.Registerer, appendable storage.Appendable, acceptedMsgs remoteapi.MessageTypes, ingestSTZeroSample, enableTypeAndUnitLabels, appendMetadata bool, configFunc func() config.Config) http.Handler {
 	h := &writeHandler{
 		logger:     logger,
 		appendable: appendable,
@@ -77,6 +100,7 @@ func NewWriteHandler(logger *slog.Logger, reg prometheus.Registerer, appendable 
 		ingestSTZeroSample:      ingestSTZeroSample,
 		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
 		appendMetadata:          appendMetadata,
+		configFunc:              configFunc,
 	}
 	return remoteapi.NewWriteHandler(h, acceptedMsgs, remoteapi.WithWriteHandlerLogger(logger))
 }
@@ -168,8 +192,14 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 	}()
 
 	b := labels.NewScratchBuilder(0)
+	limit := h.effectiveLabelValueLengthLimit()
 	for _, ts := range req.Timeseries {
-		ls := ts.ToLabels(&b, nil)
+		ls, err := ts.ToLabelsWithLimits(&b, nil, limit)
+		if err != nil {
+			h.logger.Warn("Label value exceeds configured limit, dropping series", "err", err)
+			samplesWithInvalidLabels++
+			continue
+		}
 
 		// TODO(bwplotka): Even as per 1.0 spec, this should be a 400 error, while other samples are
 		// potentially written. Perhaps unify with fixed writeV2 implementation a bit.
@@ -311,8 +341,9 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 
 		b = labels.NewScratchBuilder(0)
 	)
+	limit := h.effectiveLabelValueLengthLimit()
 	for _, ts := range req.Timeseries {
-		ls, err := ts.ToLabels(&b, req.Symbols)
+		ls, err := ts.ToLabelsWithLimits(&b, req.Symbols, limit)
 		if err != nil {
 			badRequestErrs = append(badRequestErrs, fmt.Errorf("parsing labels for series %v: %w", ts.LabelsRefs, err))
 			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -130,7 +131,7 @@ func TestRemoteWriteHandlerHeadersHandling_V1Message(t *testing.T) {
 			}
 
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false, nil)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -237,7 +238,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 			}
 
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false, nil)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -272,7 +273,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 		}
 
 		appendable := &mockAppendable{}
-		handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
+		handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false, nil)
 
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, req)
@@ -301,7 +302,7 @@ func TestRemoteWriteHandler_V1Message(t *testing.T) {
 	// in Prometheus, so keeping like this to not break existing 1.0 clients.
 
 	appendable := &mockAppendable{}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false, nil)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -736,7 +737,7 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 				appendExemplarErr:     tc.appendExemplarErr,
 				updateMetadataErr:     tc.updateMetadataErr,
 			}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, tc.ingestSTZeroSample, tc.enableTypeAndUnitLabels, tc.appendMetadata)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, tc.ingestSTZeroSample, tc.enableTypeAndUnitLabels, tc.appendMetadata, nil)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -911,7 +912,7 @@ func TestRemoteWriteHandler_V2Message_NoDuplicateTypeAndUnitLabels(t *testing.T)
 			req.Header.Set(RemoteWriteVersionHeader, RemoteWriteVersion20HeaderValue)
 
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, true, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, true, false, nil)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -960,7 +961,7 @@ func TestOutOfOrderSample_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false, nil)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -1002,7 +1003,7 @@ func TestOutOfOrderExemplar_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false, nil)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -1040,7 +1041,7 @@ func TestOutOfOrderHistogram_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false, nil)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -1090,7 +1091,7 @@ func BenchmarkRemoteWriteHandler(b *testing.B) {
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{tc.protoFormat}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{tc.protoFormat}, false, false, false, nil)
 			b.ResetTimer()
 			for b.Loop() {
 				b.StopTimer()
@@ -1115,7 +1116,7 @@ func TestCommitErr_V1Message(t *testing.T) {
 	require.NoError(t, err)
 
 	appendable := &mockAppendable{commitErr: errors.New("commit error")}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false, nil)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -1181,7 +1182,7 @@ func TestHistogramValidationErrorHandling(t *testing.T) {
 				require.NoError(t, err)
 				t.Cleanup(func() { require.NoError(t, db.Close()) })
 
-				handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []remoteapi.WriteMessageType{protoMsg}, false, false, false)
+				handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []remoteapi.WriteMessageType{protoMsg}, false, false, false, nil)
 				recorder := httptest.NewRecorder()
 
 				var buf []byte
@@ -1226,7 +1227,7 @@ func TestCommitErr_V2Message(t *testing.T) {
 	req.Header.Set(RemoteWriteVersionHeader, RemoteWriteVersion20HeaderValue)
 
 	appendable := &mockAppendable{commitErr: errors.New("commit error")}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false, nil)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -1253,7 +1254,7 @@ func BenchmarkRemoteWriteOOOSamples(b *testing.B) {
 		require.NoError(b, db.Close())
 	})
 	// TODO: test with other proto format(s)
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false, nil)
 
 	buf, _, _, err := buildWriteRequest(nil, genSeriesWithSample(1000, 200*time.Minute.Milliseconds()), nil, nil, nil, nil, "snappy")
 	require.NoError(b, err)
@@ -1585,7 +1586,7 @@ func TestHistogramsReduction(t *testing.T) {
 	for _, protoMsg := range []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType} {
 		t.Run(string(protoMsg), func(t *testing.T) {
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{protoMsg}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{protoMsg}, false, false, false, nil)
 
 			var (
 				err     error
@@ -1681,6 +1682,7 @@ func TestRemoteWriteHandler_ResponseStats(t *testing.T) {
 				false,
 				false,
 				false,
+				nil,
 			)
 
 			if tt.forceInjectHeaders {
@@ -1710,4 +1712,174 @@ func TestRemoteWriteHandler_ResponseStats(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWriteHandler_LabelValueLengthLimit(t *testing.T) {
+	const testLimit = 100
+
+	longValue := strings.Repeat("x", testLimit+1)
+	shortValue := "short"
+
+	t.Run("v1_long_value_dropped", func(t *testing.T) {
+		ts := []prompb.TimeSeries{{
+			Labels:  []prompb.Label{{Name: "__name__", Value: "test"}, {Name: "foo", Value: longValue}},
+			Samples: []prompb.Sample{{Value: 1, Timestamp: 1}},
+		}}
+		buf, _, _, err := buildWriteRequest(nil, ts, nil, nil, nil, nil, "snappy")
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(buf))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", remoteWriteContentTypeHeaders[remoteapi.WriteV1MessageType])
+		req.Header.Set("Content-Encoding", compression.Snappy)
+
+		appendable := &mockAppendable{}
+		cfgFunc := func() config.Config {
+			return config.Config{
+				GlobalConfig: config.GlobalConfig{
+					LabelValueLengthLimit: uint(testLimit),
+				},
+			}
+		}
+		handler := NewWriteHandler(
+			promslog.NewNopLogger(), nil, appendable,
+			[]remoteapi.WriteMessageType{remoteapi.WriteV1MessageType},
+			false, false, false, cfgFunc,
+		)
+
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+		// V1: series with oversized label is dropped (best-effort), request succeeds.
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+	})
+
+	t.Run("v1_short_value_accepted", func(t *testing.T) {
+		ts := []prompb.TimeSeries{{
+			Labels:  []prompb.Label{{Name: "__name__", Value: "test"}, {Name: "foo", Value: shortValue}},
+			Samples: []prompb.Sample{{Value: 1, Timestamp: 1}},
+		}}
+		buf, _, _, err := buildWriteRequest(nil, ts, nil, nil, nil, nil, "snappy")
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(buf))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", remoteWriteContentTypeHeaders[remoteapi.WriteV1MessageType])
+		req.Header.Set("Content-Encoding", compression.Snappy)
+
+		appendable := &mockAppendable{}
+		cfgFunc := func() config.Config {
+			return config.Config{
+				GlobalConfig: config.GlobalConfig{
+					LabelValueLengthLimit: uint(testLimit),
+				},
+			}
+		}
+		handler := NewWriteHandler(
+			promslog.NewNopLogger(), nil, appendable,
+			[]remoteapi.WriteMessageType{remoteapi.WriteV1MessageType},
+			false, false, false, cfgFunc,
+		)
+
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+		require.Len(t, appendable.samples, 1)
+	})
+
+	t.Run("v2_long_value_rejected", func(t *testing.T) {
+		st := writev2.NewSymbolTable()
+		labelRefs := st.SymbolizeLabels(labels.FromStrings("__name__", "test", "foo", longValue), nil)
+		ts := []writev2.TimeSeries{{
+			LabelsRefs: labelRefs,
+			Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+		}}
+		buf, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), ts, st.Symbols(), nil, nil, nil, "snappy")
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(buf))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", remoteWriteContentTypeHeaders[remoteapi.WriteV2MessageType])
+		req.Header.Set("Content-Encoding", compression.Snappy)
+
+		appendable := &mockAppendable{}
+		cfgFunc := func() config.Config {
+			return config.Config{
+				GlobalConfig: config.GlobalConfig{
+					LabelValueLengthLimit: uint(testLimit),
+				},
+			}
+		}
+		handler := NewWriteHandler(
+			promslog.NewNopLogger(), nil, appendable,
+			[]remoteapi.WriteMessageType{remoteapi.WriteV2MessageType},
+			false, false, false, cfgFunc,
+		)
+
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+		// V2: label value too long → 400 Bad Request.
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+		require.Contains(t, recorder.Body.String(), "label value")
+	})
+
+	t.Run("v2_short_value_accepted", func(t *testing.T) {
+		st := writev2.NewSymbolTable()
+		labelRefs := st.SymbolizeLabels(labels.FromStrings("__name__", "test", "foo", shortValue), nil)
+		ts := []writev2.TimeSeries{{
+			LabelsRefs: labelRefs,
+			Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+		}}
+		buf, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), ts, st.Symbols(), nil, nil, nil, "snappy")
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(buf))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", remoteWriteContentTypeHeaders[remoteapi.WriteV2MessageType])
+		req.Header.Set("Content-Encoding", compression.Snappy)
+
+		appendable := &mockAppendable{}
+		cfgFunc := func() config.Config {
+			return config.Config{
+				GlobalConfig: config.GlobalConfig{
+					LabelValueLengthLimit: uint(testLimit),
+				},
+			}
+		}
+		handler := NewWriteHandler(
+			promslog.NewNopLogger(), nil, appendable,
+			[]remoteapi.WriteMessageType{remoteapi.WriteV2MessageType},
+			false, false, false, cfgFunc,
+		)
+
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+		require.Len(t, appendable.samples, 1)
+	})
+
+	// Test effectiveLabelValueLengthLimit helper directly.
+	t.Run("fallback_to_default_max", func(t *testing.T) {
+		h := &writeHandler{
+			configFunc: func() config.Config {
+				return config.Config{} // LabelValueLengthLimit == 0
+			},
+		}
+		require.Equal(t, DefaultMaxLabelValueLength, h.effectiveLabelValueLengthLimit())
+	})
+
+	t.Run("globalconfig_limit_used_when_set", func(t *testing.T) {
+		h := &writeHandler{
+			configFunc: func() config.Config {
+				return config.Config{
+					GlobalConfig: config.GlobalConfig{LabelValueLengthLimit: 512},
+				}
+			},
+		}
+		require.Equal(t, 512, h.effectiveLabelValueLengthLimit())
+	})
+
+	t.Run("nil_configfunc_uses_default", func(t *testing.T) {
+		h := &writeHandler{configFunc: nil}
+		require.Equal(t, DefaultMaxLabelValueLength, h.effectiveLabelValueLengthLimit())
+	})
 }

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -356,7 +356,7 @@ func NewAPI(
 	}
 
 	if rwEnabled {
-		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, acceptRemoteWriteProtoMsgs, stZeroIngestionEnabled, enableTypeAndUnitLabels, appendMetadata)
+		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, acceptRemoteWriteProtoMsgs, stZeroIngestionEnabled, enableTypeAndUnitLabels, appendMetadata, configFunc)
 	}
 	if otlpEnabled {
 		a.otlpWriteHandler = remote.NewOTLPWriteHandler(logger, registerer, apV2, configFunc, remote.OTLPOptions{


### PR DESCRIPTION
## Summary

Adds label value length validation to the remote write receiver to prevent Prometheus from crashing on label values ≥16 MB (the internal cap introduced in #16069).

Closes #16525

## Problem

After #16069, Prometheus panics when the remote write handler receives label values ≥16 MB. There was no validation before `ToLabels()` deserialization to prevent this. Additionally, the existing `GlobalConfig.LabelValueLengthLimit` was never applied to the remote write path.

## Changes

### Core codec changes
- `prompb/codec.go`: Add `ToLabelsWithLimits(b, symbols, maxLabelValueLength)` and `ErrLabelValueTooLong` to V1 `TimeSeries`
- `prompb/io/prometheus/write/v2/codec.go`: Add `ToLabelsWithLimits(b, symbols, maxLabelValueLength)` to V2 `TimeSeries`
- `prompb/io/prometheus/write/v2/symbols.go`: Add `desymbolizeLabelsWithLimits()` helper and `ErrLabelValueTooLong`

### Remote write handler
- Add `configFunc func() config.Config` field to `writeHandler` for dynamic config lookup
- Add `DefaultMaxLabelValueLength` constant (16 MB safety cap)
- Add `effectiveLabelValueLengthLimit()` helper: returns `GlobalConfig.LabelValueLengthLimit` when set, falls back to `DefaultMaxLabelValueLength` (16 MB) when 0
- Update `NewWriteHandler()` to accept `configFunc`
- V1 write path: drop oversized series with a warning log (best-effort, consistent with existing duplicate-label handling)
- V2 write path: return HTTP 400 Bad Request with details (per RW 2.0 spec)

### Wiring
- `web/api/v1/api.go`: Pass `configFunc` to `NewWriteHandler` so the limit is dynamically read on each request batch

## Behavior

| GlobalConfig.LabelValueLengthLimit | Effective limit for remote write |
|------------------------------------|----------------------------------|
| 0 (not set, default)               | 16 MB (safety cap)               |
| > 0                                | Configured value                 |

## Testing

New test `TestWriteHandler_LabelValueLengthLimit` covers:
- V1: oversized label values are dropped with a warning (best-effort)
- V1: normal label values are accepted
- V2: oversized label values return HTTP 400
- V2: normal label values are accepted
- `effectiveLabelValueLengthLimit()` fallback and override behavior

```
go test ./storage/remote/... -v -run TestWriteHandler_LabelValueLengthLimit
go test ./storage/remote/... -count=1
go test ./prompb/... -count=1
go test ./web/api/v1/... -count=1
```

---
*This fix was contributed with AI assistance by SwarmFix (sulphur-swarm).*