### PR TITLE
web/ui: add copy button for rule names in rules and alerts page

### DIFF
--- a/web/ui/mantine-ui/src/components/RuleDefinition.module.css
+++ b/web/ui/mantine-ui/src/components/RuleDefinition.module.css
@@ -10,6 +10,7 @@
   transition: opacity 0.1s ease-in-out;
 }
 
-.codebox:hover .queryButton {
+.codebox:hover .queryButton,
+.codebox:focus-within .queryButton {
   opacity: 1;
 }

--- a/web/ui/mantine-ui/src/pages/AlertsPage.module.css
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.module.css
@@ -1,3 +1,13 @@
 .item {
   background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-5));
 }
+
+.copyAlertNameButton {
+  opacity: 0;
+  transition: opacity 0.1s ease-in-out;
+}
+
+.ruleControl:hover .copyAlertNameButton,
+.ruleControl:focus-within .copyAlertNameButton {
+  opacity: 1;
+}

--- a/web/ui/mantine-ui/src/pages/AlertsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.tsx
@@ -14,6 +14,8 @@ import {
   Pagination,
   rem,
   Divider,
+  CopyButton,
+  ActionIcon,
 } from "@mantine/core";
 import { useSuspenseAPIQuery } from "../api/api";
 import { AlertingRule, AlertingRulesResult } from "../api/responseTypes/rules";
@@ -23,7 +25,7 @@ import RuleDefinition from "../components/RuleDefinition";
 import { humanizeDurationRelative, now } from "../lib/formatTime";
 import { Fragment, useEffect, useMemo } from "react";
 import { StateMultiSelect } from "../components/StateMultiSelect";
-import { IconInfoCircle, IconSearch } from "@tabler/icons-react";
+import { IconCheck, IconCopy, IconInfoCircle, IconSearch } from "@tabler/icons-react";
 import { LabelBadges } from "../components/LabelBadges";
 import { useLocalStorage } from "@mantine/hooks";
 import { useSettings } from "../state/settingsSlice";
@@ -308,7 +310,23 @@ export default function AlertsPage() {
                           styles={{ label: { paddingBlock: rem(10) } }}
                         >
                           <Group wrap="nowrap" justify="space-between" mr="lg">
-                            <Text>{r.rule.name}</Text>
+                            <Group gap="xs" wrap="nowrap">
+                              <Text>{r.rule.name}</Text>
+                              <CopyButton value={r.rule.name}>
+                                {({ copied, copy }) => (
+                                  <ActionIcon
+                                    variant="subtle"
+                                    color={copied ? 'teal' : 'gray'}
+                                    onClick={(e) => {
+                                      e.stopPropagation(); copy();
+                                    }}
+                                    size="xs"
+                                  >
+                                    {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+                                  </ActionIcon>
+                                )}
+                              </CopyButton>
+                            </Group>
                             <Group gap="xs">
                               {r.counts.firing > 0 && (
                                 <Badge className={badgeClasses.healthErr}>

--- a/web/ui/mantine-ui/src/pages/AlertsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.tsx
@@ -307,6 +307,7 @@ export default function AlertsPage() {
                         }
                       >
                         <Accordion.Control
+                          className={classes.ruleControl}
                           styles={{ label: { paddingBlock: rem(10) } }}
                         >
                           <Group wrap="nowrap" justify="space-between" mr="lg">
@@ -315,8 +316,9 @@ export default function AlertsPage() {
                               <CopyButton value={r.rule.name}>
                                 {({ copied, copy }) => (
                                   <ActionIcon
+                                    className={classes.copyAlertNameButton}
                                     variant="subtle"
-                                    color={copied ? 'teal' : 'gray'}
+                                    color="gray"
                                     onClick={(e) => {
                                       e.stopPropagation(); copy();
                                     }}

--- a/web/ui/mantine-ui/src/pages/RulesPage.module.css
+++ b/web/ui/mantine-ui/src/pages/RulesPage.module.css
@@ -1,3 +1,13 @@
 .item {
   background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-5));
 }
+
+.copyRuleNameButton {
+  opacity: 0;
+  transition: opacity 0.1s ease-in-out;
+}
+
+.ruleControl:hover .copyRuleNameButton,
+.ruleControl:focus-within .copyRuleNameButton {
+  opacity: 1;
+}

--- a/web/ui/mantine-ui/src/pages/RulesPage.tsx
+++ b/web/ui/mantine-ui/src/pages/RulesPage.tsx
@@ -1,9 +1,11 @@
 import {
   Accordion,
+  ActionIcon,
   Alert,
   Anchor,
   Badge,
   Card,
+  CopyButton,
   Group,
   Pagination,
   rem,
@@ -20,6 +22,8 @@ import {
 import {
   IconAlertTriangle,
   IconBell,
+  IconCheck,
+  IconCopy,
   IconHourglass,
   IconInfoCircle,
   IconRefresh,
@@ -265,6 +269,20 @@ export default function RulesPage() {
                               </Tooltip>
                             )}
                             <Text>{r.name}</Text>
+                            <CopyButton value={r.name}>
+                              {({ copied, copy }) => (
+                                <ActionIcon
+                                  variant="subtle"
+                                  color={copied ? 'teal' : 'gray'}
+                                  onClick={(e) => {
+                                    e.stopPropagation(); copy();
+                                  }}
+                                  size="xs"
+                                >
+                                  {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+                                </ActionIcon>
+                              )}
+                            </CopyButton>
                           </Group>
                           <Group gap="xs">
                             <Group gap="xs" wrap="wrap">

--- a/web/ui/mantine-ui/src/pages/RulesPage.tsx
+++ b/web/ui/mantine-ui/src/pages/RulesPage.tsx
@@ -251,6 +251,7 @@ export default function RulesPage() {
                       }}
                     >
                       <Accordion.Control
+                        className={classes.ruleControl}
                         styles={{ label: { paddingBlock: rem(10) } }}
                       >
                         <Group justify="space-between" mr="lg">
@@ -272,8 +273,9 @@ export default function RulesPage() {
                             <CopyButton value={r.name}>
                               {({ copied, copy }) => (
                                 <ActionIcon
+                                  className={classes.copyRuleNameButton}
                                   variant="subtle"
-                                  color={copied ? 'teal' : 'gray'}
+                                  color="gray"
                                   onClick={(e) => {
                                     e.stopPropagation(); copy();
                                   }}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #18489

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[ENHANCEMENT] Web UI: Add copy button next to rule names on the Rules and Alerts pages.
```
<img width="1919" height="971" alt="Screenshot 2026-05-17 180758" src="https://github.com/user-attachments/assets/a136bdb7-997a-4e21-905d-00488178a5c3" />

#### Description

The Rule Health page (`/rules`) and Alerts page (`/alerts`) did not allow 
copying rule names. Clicking expanded the accordion, and double-clicking 
collapsed it, making text selection impossible.

This PR adds a small copy button next to each rule name using Mantine's 
`CopyButton` component. `e.stopPropagation()` prevents the accordion from 
toggling when the copy button is clicked. The button shows a checkmark 
briefly after copying for visual feedback.

The fix is applied to both `RulesPage.tsx` and `AlertsPage.tsx` for consistency.