### PR TITLE
fix(tsdb): cap head chunk file size on 32-bit architectures

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -54,8 +54,6 @@ const (
 	SeriesRefSize = 8
 	// HeadChunkFileHeaderSize is the total size of the header for a head chunk file.
 	HeadChunkFileHeaderSize = SegmentHeaderSize
-	// MaxHeadChunkFileSize is the max size of a head chunk file.
-	MaxHeadChunkFileSize = 128 * 1024 * 1024 // 128 MiB.
 	// CRCSize is the size of crc32 sum on disk.
 	CRCSize = 4
 	// MaxHeadChunkMetaSize is the max size of an mmapped chunks minus the chunks data.

--- a/tsdb/chunks/head_chunks_386.go
+++ b/tsdb/chunks/head_chunks_386.go
@@ -11,10 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build 386 && !windows
+
 package chunks
 
 // HeadChunkFilePreallocationSize is the size to which the m-map file should be preallocated when a new file is cut.
-// Windows needs pre-allocation to m-map the file.
-var HeadChunkFilePreallocationSize int64 = MaxHeadChunkFileSize
+var HeadChunkFilePreallocationSize int64 = MinWriteBufferSize * 2
 
-const MaxHeadChunkFileSize = 128 * 1024 * 1024
+// MaxHeadChunkFileSize is reduced on 32-bit systems to avoid exhausting the 2GiB virtual
+// address space when multiple ChunkDiskMapper instances hold concurrent mmap reservations.
+const MaxHeadChunkFileSize = 16 * 1024 * 1024 // 16MiB

--- a/tsdb/chunks/head_chunks_other.go
+++ b/tsdb/chunks/head_chunks_other.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
+//go:build !windows && !386
 
 package chunks
 
@@ -19,3 +19,6 @@ package chunks
 // Windows needs pre-allocations while the other OS does not. But we observed that a 0 pre-allocation causes unit tests to flake.
 // This small allocation for non-Windows OSes removes the flake.
 var HeadChunkFilePreallocationSize int64 = MinWriteBufferSize * 2
+
+// MaxHeadChunkFileSize is the max size of a head chunk file.
+const MaxHeadChunkFileSize = 128 * 1024 * 1024 // 128MiB


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Part of [#17941](https://github.com/prometheus/prometheus/issues/17941#issuecomment-4396028435)
#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] tsdb: Fix flaky test failures caused by virtual address space exhaustion on 32-bit (i386) Linux.
```

#### Description

On 32-bit (i386) Linux, `ChunkDiskMapper.cut()` reserves 128 MiB of virtual address space via `mmap(2)` per head chunk file. With 14 parallel subtests each holding 2–3 files open during compaction, peak reservations can reach 5.25 GiB against the 2 GiB i386 limit. When `mmap()` returns `ENOMEM`, `cut()` errors, `handleChunkWriteError` panics, and `require.NotPanics` fails the test.

`MaxHeadChunkFileSize` is moved from the shared const block into build-tagged files, following the pattern established by `HeadChunkFilePreallocationSize` in [#7306](https://github.com/prometheus/prometheus/pull/7306). On 32-bit systems the value is reduced to 16 MiB, reducing both the mmap window in `cut()` and the rollover threshold in `shouldCutNewFile()`.

Peak reservation on i386 drops to 14 × 3 × 16 = 672 MiB.