### PR TITLE
web/ui: fix lezer-promql module build on Windows

### DIFF
--- a/web/ui/module/lezer-promql/rollup.config.js
+++ b/web/ui/module/lezer-promql/rollup.config.js
@@ -1,3 +1,4 @@
+import path from "node:path"
 import { nodeResolve } from "@rollup/plugin-node-resolve"
 
 export default {
@@ -9,7 +10,7 @@ export default {
     format: "es",
     file: "./dist/index.es.js"
   }],
-  external(id) { return !/^[.\/]/.test(id) },
+  external(id) { return !/^[.\/]/.test(id) && !path.isAbsolute(id) },
   plugins: [
     nodeResolve()
   ]


### PR DESCRIPTION
On Windows, Rollup can resolve the generated lezer parser entry to an absolute path. The existing `external` predicate only treated relative paths and POSIX-style absolute paths as internal, so Windows absolute paths could be treated as external and fail the module build.

This updates the predicate to also keep absolute local paths internal using `path.isAbsolute`, while leaving bare package imports external.

Fixes #18694

#### Release notes for end users

```release-notes
NONE
```

Tests:

```text
npm.cmd run build:module
```