### PR TITLE
[#18632] Make TestCancelCompactions deterministic and non-racy

### DIFF
--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
@@ -1370,37 +1371,27 @@ func TestDisableAutoCompactions(t *testing.T) {
 func TestCancelCompactions(t *testing.T) {
 	t.Parallel()
 
-	db := newTestDB(t)
-
 	compactionStarted := make(chan struct{})
 	compactionCanceled := make(chan struct{})
-	ctx, cancel := context.WithCancel(context.Background())
-	originalCancel := db.compactCancel
-	db.compactCancel = func() {
-		cancel()
-		originalCancel()
-	}
 
-	var startedOnce sync.Once
-	var canceledOnce sync.Once
-	db.compactor = &mockCompactorFn{
-		planFn: func() ([]string, error) {
-			return []string{"block-a", "block-b"}, nil
-		},
-		compactFn: func() ([]ulid.ULID, error) {
-			startedOnce.Do(func() {
+	opts := DefaultOptions()
+	opts.NewCompactorFunc = func(ctx context.Context, _ prometheus.Registerer, _ *slog.Logger, _ []int64, _ chunkenc.Pool, _ *Options) (Compactor, error) {
+		return &mockCompactorFn{
+			planFn: func() ([]string, error) {
+				return []string{"block-a", "block-b"}, nil
+			},
+			compactFn: func() ([]ulid.ULID, error) {
 				close(compactionStarted)
-			})
-			<-ctx.Done()
-			canceledOnce.Do(func() {
+				<-ctx.Done()
 				close(compactionCanceled)
-			})
-			return nil, ctx.Err()
-		},
-		writeFn: func() ([]ulid.ULID, error) {
-			return nil, nil
-		},
+				return nil, ctx.Err()
+			},
+			writeFn: func() ([]ulid.ULID, error) {
+				return nil, nil
+			},
+		}, nil
 	}
+	db := newTestDB(t, withOpts(opts))
 
 	select {
 	case db.compactc <- struct{}{}:
@@ -1420,11 +1411,21 @@ func TestCancelCompactions(t *testing.T) {
 
 	select {
 	case <-compactionCanceled:
-	case <-time.After(30 * time.Second):
+	case <-time.After(time.Second):
 		t.Fatal("compaction was not canceled")
 	}
 }
 
+type blockPopulatorFunc func(context.Context, *CompactorMetrics, *slog.Logger, chunkenc.Pool, storage.VerticalChunkSeriesMergeFunc, []BlockReader, *BlockMeta, IndexWriter, ChunkWriter, IndexReaderPostingsFunc) error
+
+func (f blockPopulatorFunc) PopulateBlock(ctx context.Context, metrics *CompactorMetrics, logger *slog.Logger, chunkPool chunkenc.Pool, mergeFunc storage.VerticalChunkSeriesMergeFunc, blocks []BlockReader, meta *BlockMeta, indexw IndexWriter, chunkw ChunkWriter, postingsFunc IndexReaderPostingsFunc) error {
+	return f(ctx, metrics, logger, chunkPool, mergeFunc, blocks, meta, indexw, chunkw, postingsFunc)
+}
+
+// TestCanceledCompactionDoesNotMarkBlocksFailed ensures that a compaction
+// aborted via context cancellation does not mark its source blocks as
+// Compaction.Failed. The context.Canceled error must be detected with
+// errors.Is so wrapped values are still recognized at every level.
 func TestCanceledCompactionDoesNotMarkBlocksFailed(t *testing.T) {
 	t.Parallel()
 
@@ -1439,7 +1440,7 @@ func TestCanceledCompactionDoesNotMarkBlocksFailed(t *testing.T) {
 
 	_, err = compactor.CompactWithBlockPopulator(tmpdir, blockDirs, nil, blockPopulatorFunc(
 		func(context.Context, *CompactorMetrics, *slog.Logger, chunkenc.Pool, storage.VerticalChunkSeriesMergeFunc, []BlockReader, *BlockMeta, IndexWriter, ChunkWriter, IndexReaderPostingsFunc) error {
-			return fmt.Errorf("populate block: %w", context.Canceled)
+			return context.Canceled
 		},
 	))
 	require.ErrorIs(t, err, context.Canceled)
@@ -1449,12 +1450,6 @@ func TestCanceledCompactionDoesNotMarkBlocksFailed(t *testing.T) {
 		require.NoError(t, err)
 		require.Falsef(t, meta.Compaction.Failed, "block %s should not be marked as compaction failed", meta.ULID)
 	}
-}
-
-type blockPopulatorFunc func(context.Context, *CompactorMetrics, *slog.Logger, chunkenc.Pool, storage.VerticalChunkSeriesMergeFunc, []BlockReader, *BlockMeta, IndexWriter, ChunkWriter, IndexReaderPostingsFunc) error
-
-func (f blockPopulatorFunc) PopulateBlock(ctx context.Context, metrics *CompactorMetrics, logger *slog.Logger, chunkPool chunkenc.Pool, mergeFunc storage.VerticalChunkSeriesMergeFunc, blocks []BlockReader, meta *BlockMeta, indexw IndexWriter, chunkw ChunkWriter, postingsFunc IndexReaderPostingsFunc) error {
-	return f(ctx, metrics, logger, chunkPool, mergeFunc, blocks, meta, indexw, chunkw, postingsFunc)
 }
 
 // TestDeleteCompactionBlockAfterFailedReload ensures that a failed reloadBlocks immediately after a compaction

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1369,51 +1369,41 @@ func TestDisableAutoCompactions(t *testing.T) {
 // TestCancelCompactions ensures that when the db is closed
 // any running compaction is cancelled to unblock closing the db.
 func TestCancelCompactions(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		compactionStarted := make(chan struct{})
+		compactionCanceled := make(chan struct{})
 
-	compactionStarted := make(chan struct{})
-	compactionCanceled := make(chan struct{})
+		opts := DefaultOptions()
+		opts.NewCompactorFunc = func(ctx context.Context, _ prometheus.Registerer, _ *slog.Logger, _ []int64, _ chunkenc.Pool, _ *Options) (Compactor, error) {
+			return &mockCompactorFn{
+				planFn: func() ([]string, error) {
+					return []string{"block-a", "block-b"}, nil
+				},
+				compactFn: func() ([]ulid.ULID, error) {
+					close(compactionStarted)
+					<-ctx.Done()
+					close(compactionCanceled)
+					return nil, ctx.Err()
+				},
+				// writeFn is unused: this test never reaches the head, OOO,
+				// or stale-series compaction paths that would call Write.
+				writeFn: func() ([]ulid.ULID, error) {
+					return nil, nil
+				},
+			}, nil
+		}
+		db := newTestDB(t, withOpts(opts))
 
-	opts := DefaultOptions()
-	opts.NewCompactorFunc = func(ctx context.Context, _ prometheus.Registerer, _ *slog.Logger, _ []int64, _ chunkenc.Pool, _ *Options) (Compactor, error) {
-		return &mockCompactorFn{
-			planFn: func() ([]string, error) {
-				return []string{"block-a", "block-b"}, nil
-			},
-			compactFn: func() ([]ulid.ULID, error) {
-				close(compactionStarted)
-				<-ctx.Done()
-				close(compactionCanceled)
-				return nil, ctx.Err()
-			},
-			writeFn: func() ([]ulid.ULID, error) {
-				return nil, nil
-			},
-		}, nil
-	}
-	db := newTestDB(t, withOpts(opts))
+		db.compactc <- struct{}{}
+		<-compactionStarted
 
-	select {
-	case db.compactc <- struct{}{}:
-	case <-time.After(time.Second):
-		t.Fatal("triggering compaction timed out")
-	}
+		require.NoError(t, db.Close())
+		<-compactionCanceled
 
-	select {
-	case <-compactionStarted:
-	case <-time.After(time.Second):
-		t.Fatal("compaction did not start")
-	}
-
-	start := time.Now()
-	require.NoError(t, db.Close())
-	require.Less(t, time.Since(start), time.Second)
-
-	select {
-	case <-compactionCanceled:
-	case <-time.After(time.Second):
-		t.Fatal("compaction was not canceled")
-	}
+		// Wrapped context.Canceled must not be counted as a real compaction
+		// failure (verifies errors.Is at every level of the chain).
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(db.metrics.compactionsFailed))
+	})
 }
 
 type blockPopulatorFunc func(context.Context, *CompactorMetrics, *slog.Logger, chunkenc.Pool, storage.VerticalChunkSeriesMergeFunc, []BlockReader, *BlockMeta, IndexWriter, ChunkWriter, IndexReaderPostingsFunc) error

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -1425,7 +1425,7 @@ func TestCanceledCompactionDoesNotMarkBlocksFailed(t *testing.T) {
 		createBlock(t, tmpdir, genSeries(1, 1, 100, 200)),
 	}
 
-	compactor, err := NewLeveledCompactor(context.Background(), nil, promslog.NewNopLogger(), []int64{200}, nil, nil)
+	compactor, err := NewLeveledCompactor(t.Context(), nil, promslog.NewNopLogger(), []int64{200}, nil, nil)
 	require.NoError(t, err)
 
 	_, err = compactor.CompactWithBlockPopulator(tmpdir, blockDirs, nil, blockPopulatorFunc(


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Suggested improvements to #18632.

## Commit 1: address review feedback

- Inject the mock through `opts.NewCompactorFunc` instead of swapping `db.compactor` and wrapping `db.compactCancel` after `Open()`. The post-`Open` swap races the `db.run` goroutine on its `BlockReloadInterval` select arm. Same injection pattern as `TestNewCompactorFunc`.
- Restore the `errors.Is` rationale comment on `TestCanceledCompactionDoesNotMarkBlocksFailed` (it was on the original test, dropped in the rewrite). Drop the `sync.Once` guards — `compactFn` is invoked exactly once in this flow.
- Tighten the 30s `compactionCanceled` timeout to 1s. `db.Close` orders the mock close via `<-db.donec`, so by the time the receive runs the channel is already closed; 30s would only fire on a deadlock. Move `blockPopulatorFunc` above its only caller.
- Simplify the stub populator from `fmt.Errorf("populate block: %w", context.Canceled)` to plain `return context.Canceled` — `c.write` already wraps with `%w`.

## Commit 2: run under `synctest`

- Wrap `TestCancelCompactions` in `synctest.Test`. All goroutines (including `db.run`) live in the bubble; channel ordering is deterministic and a real hang surfaces as a `synctest` deadlock report. Same pattern as `compact_test.go:2039`, `head_test.go:4080`, `head_append_v2_test.go:1447`.
- Drop the three `time.After(time.Second)` timeouts and the `require.Less(t, time.Since(start), time.Second)` assertion — fake time wouldn't advance during `Close` anyway, and the deadlock detector is sharper.
- **Add `require.Equal(t, 0.0, prom_testutil.ToFloat64(db.metrics.compactionsFailed))`.** This is the main coverage recovery: it exercises the full wrapping chain — mock returns `context.Canceled` → `db.compactBlocks` wraps with `%w` → `db.Compact`'s defer unwraps via `errors.Is` to decide whether to bump the metric. A regression at any link flips the metric and fails the test.
- Reword the `TestCanceledCompactionDoesNotMarkBlocksFailed` doc to describe observable behavior instead of an internal control-flow path.

## What's still narrower than `main`

The `LeveledCompactor`-internal ctx checks at `compact.go:498-503` (pre-block-open loop) and `compact.go:710-714` (post-populator `<-c.ctx.Done()`) are still not exercised. Both are simple `select` statements — shallow regression targets. To cover them, `TestCanceledCompactionDoesNotMarkBlocksFailed` can be extended through canceling a context from inside the populator.


#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes

```
