### PR TITLE
test: add TestClientTLSCertRotationWithoutCAFile as a regresion test for cert rotation not breaking scraping

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -16,6 +16,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -42,6 +43,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/notifier"
@@ -1233,4 +1235,96 @@ func TestFeatureFlagsDocumented(t *testing.T) {
 	require.NotEmpty(t, docFlags)
 	require.True(t, slices.IsSorted(helpFlags))
 	require.ElementsMatch(t, helpFlags, docFlags)
+}
+
+func cpFile(t *testing.T, dst, src string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dst, data, 0o644))
+}
+
+// TestClientTLSCertRotationWithoutCAFile checks that scrapes keep working after
+// a client cert rotation when no ca_file is configured (cert_file + key_file only).
+// Regression test for: https://github.com/prometheus/prometheus/issues/16622.
+func TestClientTLSCertRotationWithoutCAFile(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// The target starts serving an extra metric after client cert rotation.
+	// If the scrape recovers, the new series should get ingested.
+	var clientCertRotated atomic.Bool
+	target := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, "test_up 1")
+		if clientCertRotated.Load() {
+			fmt.Fprintln(w, "test_after_rotation 1")
+		}
+	}))
+	target.TLS = &tls.Config{
+		ClientAuth: tls.RequireAnyClientCert,
+	}
+	target.StartTLS()
+	defer target.Close()
+
+	clientCertFile := filepath.Join(tmpDir, "client.cer")
+	clientKeyFile := filepath.Join(tmpDir, "client.key")
+	cpFile(t, clientCertFile, filepath.Join("..", "..", "scrape", "testdata", "client.cer"))
+	cpFile(t, clientKeyFile, filepath.Join("..", "..", "scrape", "testdata", "client.key"))
+
+	port := testutil.RandomUnprivilegedPort(t)
+	configFile := filepath.Join(tmpDir, "prometheus.yml")
+	require.NoError(t, os.WriteFile(configFile, fmt.Appendf(nil, `
+scrape_configs:
+  - job_name: target
+    scrape_interval: 1s
+    scheme: https
+    static_configs:
+      - targets: ['%s']
+    tls_config:
+      cert_file: %s
+      key_file: %s
+      insecure_skip_verify: true
+`, target.Listener.Addr().String(), clientCertFile, clientKeyFile), 0o644))
+
+	prom := prometheusCommandWithLogging(t, configFile, port,
+		"--storage.tsdb.path="+filepath.Join(tmpDir, "data"))
+	require.NoError(t, prom.Start())
+
+	promURL := "http://localhost:" + strconv.Itoa(port)
+	const headSeriesCreated = "prometheus_tsdb_head_series_created_total"
+
+	getHeadSeriesCreated := func() (float64, error) {
+		r, err := http.Get(promURL + "/metrics")
+		if err != nil {
+			return 0, err
+		}
+		defer r.Body.Close()
+		b, _ := io.ReadAll(r.Body)
+		return getMetricValue(t, bytes.NewReader(b), model.MetricTypeCounter, headSeriesCreated)
+	}
+
+	// Wait for at least one scrape to ingest series.
+	var seriesCreatedBeforeRotation float64
+	require.Eventually(t, func() bool {
+		v, err := getHeadSeriesCreated()
+		if err != nil {
+			return false
+		}
+		seriesCreatedBeforeRotation = v
+		return seriesCreatedBeforeRotation > 0
+	}, startupTime, 500*time.Millisecond)
+
+	// Overwrite client cert files (content doesn't matter) to trigger a
+	// transport rebuild.
+	cpFile(t, clientCertFile, filepath.Join("..", "..", "scrape", "testdata", "server.cer"))
+	cpFile(t, clientKeyFile, filepath.Join("..", "..", "scrape", "testdata", "server.key"))
+	clientCertRotated.Store(true)
+
+	require.Eventually(t, func() bool {
+		v, err := getHeadSeriesCreated()
+		if err != nil {
+			return false
+		}
+		return v > seriesCreatedBeforeRotation
+	}, 5*time.Second, 1*time.Second, "scrape should keep working after cert rotation")
 }


### PR DESCRIPTION
Add a regression test for client TLS cert rotation when no ca_file is configured (cert_file + key_file only). After rotation, scraping permanently fails instead of rebuilding the transport with the new certs. The test also catches the SIGSEGV (prometheus/prometheus#16622).


the test is passing now as Prometheus starts using https://github.com/prometheus/common/pull/908.


<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
