### PR TITLE
discovery/openstack: run tests in parallel

### DIFF
--- a/discovery/openstack/hypervisor_test.go
+++ b/discovery/openstack/hypervisor_test.go
@@ -47,6 +47,7 @@ func (s *OpenstackSDHypervisorTestSuite) openstackAuthSuccess() (refresher, erro
 }
 
 func TestOpenstackSDHypervisorRefresh(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 
@@ -86,6 +87,7 @@ func TestOpenstackSDHypervisorRefresh(t *testing.T) {
 }
 
 func TestOpenstackSDHypervisorRefreshWithDoneContext(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 

--- a/discovery/openstack/instance_test.go
+++ b/discovery/openstack/instance_test.go
@@ -52,6 +52,7 @@ func (s *OpenstackSDInstanceTestSuite) openstackAuthSuccess() (refresher, error)
 }
 
 func TestOpenstackSDInstanceRefresh(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDInstanceTestSuite{}
 	mock.SetupTest(t)
 
@@ -153,6 +154,7 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 }
 
 func TestOpenstackSDInstanceRefreshWithDoneContext(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 

--- a/discovery/openstack/loadbalancer_test.go
+++ b/discovery/openstack/loadbalancer_test.go
@@ -51,6 +51,7 @@ func (s *OpenstackSDLoadBalancerTestSuite) openstackAuthSuccess() (refresher, er
 }
 
 func TestOpenstackSDLoadBalancerRefresh(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDLoadBalancerTestSuite{}
 	mock.SetupTest(t)
 
@@ -126,6 +127,7 @@ func TestOpenstackSDLoadBalancerRefresh(t *testing.T) {
 }
 
 func TestOpenstackSDLoadBalancerRefreshWithDoneContext(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDLoadBalancerTestSuite{}
 	mock.SetupTest(t)
 


### PR DESCRIPTION
Following the precedent set by #18703 (aws), #18611 (consul), and #18613 (marathon), this enables parallel test execution for the discovery/openstack package.

All 6 test functions create their own mock server via \`NewSDMock(t)\` and share no global state.

Verified locally:
- \`go test ./discovery/openstack/... -race -count=1\`

```release-notes
NONE
```