### PR TITLE
discovery/puppetdb: run tests in parallel

### DIFF
--- a/discovery/puppetdb/puppetdb_test.go
+++ b/discovery/puppetdb/puppetdb_test.go
@@ -49,6 +49,7 @@ func mockServer(t *testing.T) *httptest.Server {
 }
 
 func TestPuppetSlashInURL(t *testing.T) {
+	t.Parallel()
 	tests := map[string]string{
 		"https://puppetserver":      "https://puppetserver/pdb/query/v4",
 		"https://puppetserver/":     "https://puppetserver/pdb/query/v4",
@@ -83,6 +84,7 @@ func TestPuppetSlashInURL(t *testing.T) {
 }
 
 func TestPuppetDBRefresh(t *testing.T) {
+	t.Parallel()
 	ts := mockServer(t)
 
 	cfg := SDConfig{
@@ -134,6 +136,7 @@ func TestPuppetDBRefresh(t *testing.T) {
 }
 
 func TestPuppetDBRefreshWithParameters(t *testing.T) {
+	t.Parallel()
 	ts := mockServer(t)
 
 	cfg := SDConfig{
@@ -196,6 +199,7 @@ func TestPuppetDBRefreshWithParameters(t *testing.T) {
 }
 
 func TestPuppetDBInvalidCode(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
@@ -228,6 +232,7 @@ func TestPuppetDBInvalidCode(t *testing.T) {
 }
 
 func TestPuppetDBInvalidFormat(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintln(w, "{}")
 	}))


### PR DESCRIPTION
Following the precedent set by #18703 (aws), #18611 (consul), and #18613 (marathon), this enables parallel test execution for the discovery/puppetdb package.

All 5 test functions create their own HTTP test server and share no global state.

Verified locally:
- \`go test ./discovery/puppetdb/... -race -count=1\`

```release-notes
NONE
```