### PR TITLE
tsdb: Implement `headStaleIndexReader` methods properly

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1684,7 +1684,7 @@ func (db *DB) CompactStaleHead() (err error) {
 
 	// We get the stale series reference first because this list can change during the compaction below.
 	// It is more efficient and easier to provide an index interface for the stale series when we have a static list.
-	staleSeriesRefs, err := db.head.SortedStaleSeriesRefsNoOOOData(context.Background())
+	staleSeriesRefs, err := db.head.sortedStaleSeriesRefsNoOOOData(context.Background())
 	if err != nil {
 		return err
 	}

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1712,14 +1712,14 @@ func (db *DB) CompactStaleHead() (err error) {
 		}
 	}
 
-	if err := db.head.truncateStaleSeries(staleSeriesRefs, maxt); err != nil {
+	if err := db.head.truncateStaleSeries(staleSeriesRefs.sortedByRef, maxt); err != nil {
 		return fmt.Errorf("head truncate: %w", err)
 	}
 	db.head.RebuildSymbolTable(db.logger)
 
 	elapsed := time.Since(start)
 	db.metrics.staleSeriesCompactionDuration.Observe(elapsed.Seconds())
-	db.logger.Info("Ending stale series compaction", "num_series", len(staleSeriesRefs), "duration", elapsed)
+	db.logger.Info("Ending stale series compaction", "num_series", len(staleSeriesRefs.sortedByRef), "duration", elapsed)
 	return nil
 }
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1684,7 +1684,7 @@ func (db *DB) CompactStaleHead() (err error) {
 
 	// We get the stale series reference first because this list can change during the compaction below.
 	// It is more efficient and easier to provide an index interface for the stale series when we have a static list.
-	staleSeriesRefs, err := db.head.sortedStaleSeriesRefsNoOOOData(context.Background())
+	staleSeriesRefs, err := db.head.staleSeriesRefsNoOOOData(context.Background())
 	if err != nil {
 		return err
 	}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1646,11 +1646,11 @@ func (h *RangeHead) String() string {
 // Used only for compactions.
 type StaleHead struct {
 	RangeHead
-	staleSeriesRefs []storage.SeriesRef
+	staleSeriesRefs staleSeriesRefs
 }
 
 // NewStaleHead returns a *StaleHead.
-func NewStaleHead(head *Head, mint, maxt int64, staleSeriesRefs []storage.SeriesRef) *StaleHead {
+func NewStaleHead(head *Head, mint, maxt int64, staleSeriesRefs staleSeriesRefs) *StaleHead {
 	return &StaleHead{
 		RangeHead: RangeHead{
 			head: head,

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -334,8 +334,8 @@ func (h *headStaleIndexReader) SortedPostings(p index.Postings) index.Postings {
 	}
 }
 
-// SortedStaleSeriesRefsNoOOOData returns all the series refs of the stale series that do not have any out-of-order data.
-func (h *Head) SortedStaleSeriesRefsNoOOOData(ctx context.Context) (staleSeriesRefs, error) {
+// sortedStaleSeriesRefsNoOOOData returns all the series refs of the stale series that do not have any out-of-order data.
+func (h *Head) sortedStaleSeriesRefsNoOOOData(ctx context.Context) (staleSeriesRefs, error) {
 	k, v := index.AllPostingsKey()
 	return h.filterStaleSeriesAndSortPostings(h.postings.Postings(ctx, k, v))
 }

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -273,9 +273,24 @@ type staleSeriesRefs struct {
 	sortedByLabels []storage.SeriesRef
 }
 
-// filterStaleSeriesAndSortPostings returns the stale series references from the given postings
-// that also do not have any out-of-order data.
-func (h *Head) filterStaleSeriesAndSortPostings(p index.Postings) (staleSeriesRefs, error) {
+// SortedPostings returns the provided postings sorted by labels.
+// This implementation expects the input postings to be the one returned by headStaleIndexReader.Postings() with AllPostingsKey, and will return the pre-sorted postings by labels in that case.
+func (h *headStaleIndexReader) SortedPostings(p index.Postings) index.Postings {
+	switch p.(type) {
+	case allStaleSeriesPostings:
+		// This is the marker we expect.
+		return index.NewListPostings(h.staleSeriesRefs.sortedByLabels)
+	default:
+		// This is not expected, but implementing it is easy: just delegate to headIndexReader's logic.
+		return h.headIndexReader.SortedPostings(p)
+	}
+}
+
+// staleSeriesRefsNoOOOData returns all the series refs of the stale series that do not have any out-of-order data.
+func (h *Head) staleSeriesRefsNoOOOData(ctx context.Context) (staleSeriesRefs, error) {
+	k, v := index.AllPostingsKey()
+	p := h.postings.Postings(ctx, k, v)
+
 	sortedByRef := make([]storage.SeriesRef, 0, 1024)
 	series := make([]*memSeries, 0, 1024)
 
@@ -319,25 +334,6 @@ func (h *Head) filterStaleSeriesAndSortPostings(p index.Postings) (staleSeriesRe
 		sortedByLabels = append(sortedByLabels, storage.SeriesRef(p.ref))
 	}
 	return staleSeriesRefs{sortedByRef: sortedByRef, sortedByLabels: sortedByLabels}, nil
-}
-
-// SortedPostings returns the provided postings sorted by labels.
-// This implementation expects the input postings to be the one returned by headStaleIndexReader.Postings() with AllPostingsKey, and will return the pre-sorted postings by labels in that case.
-func (h *headStaleIndexReader) SortedPostings(p index.Postings) index.Postings {
-	switch p.(type) {
-	case allStaleSeriesPostings:
-		// This is the marker we expect.
-		return index.NewListPostings(h.staleSeriesRefs.sortedByLabels)
-	default:
-		// This is not expected, but implementing it is easy: just delegate to headIndexReader's logic.
-		return h.headIndexReader.SortedPostings(p)
-	}
-}
-
-// sortedStaleSeriesRefsNoOOOData returns all the series refs of the stale series that do not have any out-of-order data.
-func (h *Head) sortedStaleSeriesRefsNoOOOData(ctx context.Context) (staleSeriesRefs, error) {
-	k, v := index.AllPostingsKey()
-	return h.filterStaleSeriesAndSortPostings(h.postings.Postings(ctx, k, v))
 }
 
 // appendSeriesChunks appends chunk metadata for s to chks.

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -215,7 +215,7 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchB
 	return nil
 }
 
-func (h *Head) staleIndex(mint, maxt int64, staleSeriesRefs []storage.SeriesRef) (*headStaleIndexReader, error) {
+func (h *Head) staleIndex(mint, maxt int64, staleSeriesRefs staleSeriesRefs) (*headStaleIndexReader, error) {
 	return &headStaleIndexReader{
 		headIndexReader: h.indexRange(mint, maxt),
 		staleSeriesRefs: staleSeriesRefs,
@@ -228,43 +228,55 @@ func (h *Head) staleIndex(mint, maxt int64, staleSeriesRefs []storage.SeriesRef)
 // pre-calculated list of stale series refs that can be returned without re-reading the Head.
 type headStaleIndexReader struct {
 	*headIndexReader
-	staleSeriesRefs []storage.SeriesRef
+	staleSeriesRefs staleSeriesRefs
 }
 
+type allStaleSeriesPostings struct{ index.Postings }
+
 func (h *headStaleIndexReader) Postings(ctx context.Context, name string, values ...string) (index.Postings, error) {
-	// If all postings are requested, return the precalculated list.
-	k, v := index.AllPostingsKey()
-	if len(h.staleSeriesRefs) > 0 && name == k && len(values) == 1 && values[0] == v {
-		return index.NewListPostings(h.staleSeriesRefs), nil
+	if len(h.staleSeriesRefs.sortedByRef) == 0 {
+		return index.EmptyPostings(), nil
 	}
-	seriesRefs, err := h.head.filterStaleSeriesAndSortPostings(h.head.postings.Postings(ctx, name, values...))
-	if err != nil {
-		return index.ErrPostings(err), err
+
+	staleSeriesPostings := index.NewListPostings(h.staleSeriesRefs.sortedByRef)
+	// This method is only expected to be called during compaction from the AllSortedPostings, with AllPostingsKey.
+	// The result of this method will be passed to SortedPostings().
+	// In order to avoid sorting head twice, but still return the correct results, we return a postings type with a marker here.
+	// This marker will be used by SortedPostings to swap the full postings by the ones sorted by labels.
+	// However, the results is still valid to be used as normal postings as well.
+	if k, v := index.AllPostingsKey(); name == k && len(values) == 1 && values[0] == v {
+		return allStaleSeriesPostings{staleSeriesPostings}, nil
 	}
-	return index.NewListPostings(seriesRefs), nil
+
+	// This is not expected to be used, as headStaleIndexReader is only expected to be used during compaction.
+	return index.Intersect(staleSeriesPostings, h.head.postings.Postings(ctx, name, values...)), nil
 }
 
 func (h *headStaleIndexReader) PostingsForLabelMatching(ctx context.Context, name string, match func(string) bool) index.Postings {
-	// Unused for compaction, so we don't need to optimise.
-	seriesRefs, err := h.head.filterStaleSeriesAndSortPostings(h.head.postings.PostingsForLabelMatching(ctx, name, match))
-	if err != nil {
-		return index.ErrPostings(err)
-	}
-	return index.NewListPostings(seriesRefs)
+	// This is not expected to be used, as headStaleIndexReader is only expected to be used during compaction.
+	return index.Intersect(
+		index.NewListPostings(h.staleSeriesRefs.sortedByRef),
+		h.head.postings.PostingsForLabelMatching(ctx, name, match),
+	)
 }
 
 func (h *headStaleIndexReader) PostingsForAllLabelValues(ctx context.Context, name string) index.Postings {
-	// Unused for compaction, so we don't need to optimise.
-	seriesRefs, err := h.head.filterStaleSeriesAndSortPostings(h.head.postings.PostingsForAllLabelValues(ctx, name))
-	if err != nil {
-		return index.ErrPostings(err)
-	}
-	return index.NewListPostings(seriesRefs)
+	// This is not expected to be used, as headStaleIndexReader is only expected to be used during compaction.
+	return index.Intersect(
+		index.NewListPostings(h.staleSeriesRefs.sortedByRef),
+		h.head.postings.PostingsForAllLabelValues(ctx, name),
+	)
+}
+
+type staleSeriesRefs struct {
+	sortedByRef    []storage.SeriesRef
+	sortedByLabels []storage.SeriesRef
 }
 
 // filterStaleSeriesAndSortPostings returns the stale series references from the given postings
 // that also do not have any out-of-order data.
-func (h *Head) filterStaleSeriesAndSortPostings(p index.Postings) ([]storage.SeriesRef, error) {
+func (h *Head) filterStaleSeriesAndSortPostings(p index.Postings) (staleSeriesRefs, error) {
+	sortedByRef := make([]storage.SeriesRef, 0, 1024)
 	series := make([]*memSeries, 0, 1024)
 
 	notFoundSeriesCount := 0
@@ -286,6 +298,7 @@ func (h *Head) filterStaleSeriesAndSortPostings(p index.Postings) ([]storage.Ser
 		if value.IsStaleNaN(s.lastValue) ||
 			(s.lastHistogramValue != nil && value.IsStaleNaN(s.lastHistogramValue.Sum)) ||
 			(s.lastFloatHistogramValue != nil && value.IsStaleNaN(s.lastFloatHistogramValue.Sum)) {
+			sortedByRef = append(sortedByRef, p.At())
 			series = append(series, s)
 		}
 		s.Unlock()
@@ -294,29 +307,35 @@ func (h *Head) filterStaleSeriesAndSortPostings(p index.Postings) ([]storage.Ser
 		h.logger.Debug("Looked up stale series not found", "count", notFoundSeriesCount)
 	}
 	if err := p.Err(); err != nil {
-		return nil, fmt.Errorf("expand postings: %w", err)
+		return staleSeriesRefs{}, fmt.Errorf("expand postings: %w", err)
 	}
 
 	slices.SortFunc(series, func(a, b *memSeries) int {
 		return labels.Compare(a.labels(), b.labels())
 	})
 
-	refs := make([]storage.SeriesRef, 0, len(series))
+	sortedByLabels := make([]storage.SeriesRef, 0, len(series))
 	for _, p := range series {
-		refs = append(refs, storage.SeriesRef(p.ref))
+		sortedByLabels = append(sortedByLabels, storage.SeriesRef(p.ref))
 	}
-	return refs, nil
+	return staleSeriesRefs{sortedByRef: sortedByRef, sortedByLabels: sortedByLabels}, nil
 }
 
-// SortedPostings returns the postings as it is because we expect any postings obtained via
-// headStaleIndexReader to be already sorted.
-func (*headStaleIndexReader) SortedPostings(p index.Postings) index.Postings {
-	// All the postings function above already give the sorted list of postings.
-	return p
+// SortedPostings returns the provided postings sorted by labels.
+// This implementation expects the input postings to be the one returned by headStaleIndexReader.Postings() with AllPostingsKey, and will return the pre-sorted postings by labels in that case.
+func (h *headStaleIndexReader) SortedPostings(p index.Postings) index.Postings {
+	switch p.(type) {
+	case allStaleSeriesPostings:
+		// This is the marker we expect.
+		return index.NewListPostings(h.staleSeriesRefs.sortedByLabels)
+	default:
+		// This is not expected, but implementing it is easy: just delegate to headIndexReader's logic.
+		return h.headIndexReader.SortedPostings(p)
+	}
 }
 
 // SortedStaleSeriesRefsNoOOOData returns all the series refs of the stale series that do not have any out-of-order data.
-func (h *Head) SortedStaleSeriesRefsNoOOOData(ctx context.Context) ([]storage.SeriesRef, error) {
+func (h *Head) SortedStaleSeriesRefsNoOOOData(ctx context.Context) (staleSeriesRefs, error) {
 	k, v := index.AllPostingsKey()
 	return h.filterStaleSeriesAndSortPostings(h.postings.Postings(ctx, k, v))
 }


### PR DESCRIPTION
While building a new feature, we realized that `headStaleIndexReader`'s implementation of `Postings`, `PostingsForLabelMatching`, `PostingsForAllLabelValues` and `SortedPostings` methods was incorrect and/or incomplete.

The existing implementation relied on the fact that this interface would only be used by `AllSortedPostings` function, which will do `SortedPostings(Postings(index.AllPostingKey))`, that works, but it's a very long shot: the line between this and writing untyped javascript is very thin.

The reason for that is probably the proliferation of "let's use this interface again" decisions in Prometheus' codebase, in this particular case caused by:
- `SortedPostings()` contract is to return `index.Postings` _but sorted by labels so please don't use the Seek method_
    - We think that `SortedPostings()` should return `index.SortedPostings()` interface, which is like `index.Postings` but without the `Seek()` method.
-  The compaction mechanism, in particular `BlockPopulator` should not need the entire `IndexReader` interface, that has been growing with methods like `PostingsForAllLabelValues` or `LabelNamesFor`: there should be a more constrained `IndexReaderForCompaction` interface, requiring only the basic set of tools needed for compaction.

These two changes, especially the second one, would require agreement from multiple downstream projects importing Prometheus, so we don't want to open that can of worms today, or not in this PR at least.

So, **in the current implementation** there are two issues:
- `headStaleIndexReader.Postings()` returns `index.Postings` but sorted by labels: those break the contract of `index.Postings` and are useless for anything that's not `headStaleIndexReader.SortedPostings()`. Even though the comment said "we don't need to optimise", it's not a matter of optimization, it's a matter of correctness.
- `headStaleIndexReader.SortedPostings()` just blindly assumes that it's being called by the result of `headStaleIndexReader.Postings(index.AllPostingsKey)`. If it's called with something else, it's result is not correct.

This is anb **issue** for the feature we're building because we're trying to extend this implementation and what previously has been a tiny hack somewhere, now is becoming a huge hack with dependency injection to make the hack more hacky and robust. We don't want to grow the hack.

I was tempted to just return `index.ErrPostings` in all cases that are incomplete, but I felt I was not contributing to make this codebase better.

I was tempted to change `filterStaleSeriesAndSortPostings` to return postings sorted by refs, and then remove the `SortedPostings()` override from `headStaleIndexReader`: that is the cleanest solution in the code, but it would have a performance impact because `headIndexReader.SortedPostings()` would have to retrieve each `memSeries` again one by one. Probably not a too large impact, but I didn't want this PR to have a noticeable impact.

So *what this PR does* is:
- In the `filterStaleSeriesAndSortPostings` we store both the series refs sorted by refs and labels.
  - We don't expect series refs sorted by refs to be used anywhere, that's just for the sake of completeness of the implementation of this index reader, but also its cost is negligible since we already have them.
- `headStaleIndexReader.Postings(index.AllPostingsKey)` now returns postings wrapped by a marker type `allStaleSeriesPostings`
- `headStaleIndexReader.SortedPostings` checks the presence of that marker and returns the postings sorted by label that we pre-calculated before.
- For the rest of the cases, which are not expected to be called, we rely on the `index.Intersect` using the correct `index.ListPostings` with series refs sorted by ref.
- I unexported `sortedStaleSeriesRefsNoOOOData` after checking with GitHub search that is not used anywhere outside of the Prometheus project: I don't want to export the `staleSeriesRefs` type right now.

Release notes:
```release-notes
[BUGFIX] internal tsdb: implement missing headStaleIndexReader methods
```