### PR TITLE
docs: add names for hetzner maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,7 +14,7 @@ Maintainers for specific parts of the codebase:
 * `cmd`
   * `promtool`: David Leadbeater (<dgl@dgl.cx> / @dgl)
 * `discovery`
-  * `hetzner`: (@jooola) (@apricote)
+  * `hetzner`: Jonas L. (@jooola), Julian Tölle (@apricote)
   * `k8s`: Frederic Branczyk (<fbranczyk@gmail.com> / @brancz), Pranshu Srivastava (<rexagod@gmail.com> / @rexagod)
   * `stackit`: Jan-Otto Kröpke (<mail@jkroepke.de> / @jkroepke)
   * `consul`: Mohammad Varmazyar (<mrvarmazyar@gmail.com> / @mrvarmazyar)


### PR DESCRIPTION
## Summary

This PR updates the Hetzner entry in `MAINTAINERS.md` by adding the maintainer names alongside the existing GitHub handles.

Changes:

* Added `Jonas L.` for `@jooola`
* Added `Julian Tölle` for `@apricote`

This improves readability and keeps the maintainer information consistent with other entries in the file.

Fixes #18704
