### PR TITLE
fix(tsdb): guard CircularExemplarStorage against stale index entries

### DIFF
--- a/tsdb/exemplar.go
+++ b/tsdb/exemplar.go
@@ -167,6 +167,9 @@ func (ce *CircularExemplarStorage) Select(start, end int64, matchers ...[]*label
 
 	// Loop through each index entry, which will point us to first/last exemplar for each series.
 	for _, idx := range ce.index {
+		if idx.oldest == noExemplar || idx.newest == noExemplar {
+			continue
+		}
 		var se exemplar.QueryResult
 		e := ce.exemplars[idx.oldest]
 		if e.exemplar.Ts > end || ce.exemplars[idx.newest].exemplar.Ts < start {
@@ -248,7 +251,8 @@ func (ce *CircularExemplarStorage) validateExemplar(idx *indexEntry, e exemplar.
 		return err
 	}
 
-	if idx == nil {
+	if idx == nil || idx.oldest == noExemplar || idx.newest == noExemplar {
+		// No prior exemplar exists for this series.
 		return nil
 	}
 
@@ -395,6 +399,8 @@ func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemp
 	seriesLabels := l.Bytes(buf[:])
 
 	idx, indexExists := ce.index[string(seriesLabels)]
+	emptyIndex := indexExists && (idx.oldest == noExemplar || idx.newest == noExemplar)
+
 	err := ce.validateExemplar(idx, e, true)
 	if err != nil {
 		if errors.Is(err, storage.ErrDuplicateExemplar) {
@@ -408,7 +414,7 @@ func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemp
 	// index to check for duplicates.
 	var insertionIndex int
 	var outOfOrder bool
-	if indexExists {
+	if indexExists && !emptyIndex {
 		outOfOrder = e.Ts >= ce.exemplars[idx.oldest].exemplar.Ts && e.Ts < ce.exemplars[idx.newest].exemplar.Ts
 		if outOfOrder {
 			insertionIndex = ce.findInsertionIndex(e, idx)
@@ -433,8 +439,8 @@ func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemp
 		prevRef := prev.ref
 		if ce.removeExemplar(prev) {
 			if prevRef == idx {
-				// Do not delete the indexEntry we're inserting to.
-				indexExists = false
+				// All exemplars for this series were just evicted.
+				emptyIndex = true
 			} else {
 				ce.removeIndex(prevRef)
 			}
@@ -451,7 +457,7 @@ func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemp
 	ce.exemplars[ce.nextIndex].ref = idx
 
 	switch {
-	case !indexExists:
+	case !indexExists || emptyIndex:
 		// Add the first and only exemplar to the list.
 		idx.oldest = ce.nextIndex
 		idx.newest = ce.nextIndex

--- a/tsdb/exemplar_test.go
+++ b/tsdb/exemplar_test.go
@@ -941,6 +941,46 @@ func TestIndexOverwrite(t *testing.T) {
 	require.Equal(t, &indexEntry{0, 0, l2}, i)
 }
 
+// TestStaleIndexEntry verifies that Select, ValidateExemplar,
+// and AddExemplar handle a stale indexEntry (oldest == newest == noExemplar)
+// without panicking.
+func TestStaleIndexEntry(t *testing.T) {
+	exs, err := NewCircularExemplarStorage(10, eMetrics, 0)
+	require.NoError(t, err)
+	es := exs.(*CircularExemplarStorage)
+
+	series := labels.FromStrings("service", "a")
+
+	// Add one exemplar so the index entry exists.
+	require.NoError(t, es.AddExemplar(series, exemplar.Exemplar{Value: 1, Ts: 1}))
+
+	// Simulate a stale index entry: exemplars were evicted but the entry
+	// remains in the index map.
+	idx := es.index[string(series.Bytes(nil))]
+	require.NotNil(t, idx)
+	idx.oldest = noExemplar
+	idx.newest = noExemplar
+
+	// Select must not panic and should return an empty slice since there are
+	// no valid exemplars for the series.
+	res, err := es.Select(0, 10, []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "service", "a")})
+	require.NoError(t, err)
+	require.Empty(t, res)
+
+	// ValidateExemplar must not panic; it should treat the stale entry like
+	// a missing one and return nil.
+	require.NoError(t, es.ValidateExemplar(series, exemplar.Exemplar{Value: 2, Ts: 2}))
+
+	// AddExemplar must not panic and should reinitialize the entry.
+	require.NoError(t, es.AddExemplar(series, exemplar.Exemplar{Value: 2, Ts: 2}))
+
+	res, err = es.Select(0, 10, []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "service", "a")})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Len(t, res[0].Exemplars, 1)
+	require.Equal(t, int64(2), res[0].Exemplars[0].Ts)
+}
+
 func TestResize(t *testing.T) {
 	testCases := []struct {
 		name              string


### PR DESCRIPTION
## Summary

`CircularExemplarStorage` panics with `index out of range [-1]` when an `indexEntry` exists in `ce.index` with `oldest` or `newest` set to `noExemplar`. This was observed in production during WAL replay:

```
panic: runtime error: index out of range [-1]

goroutine 123 [running]:
github.com/prometheus/prometheus/tsdb.(*CircularExemplarStorage).validateExemplar(...)
    tsdb/exemplar.go:260
github.com/prometheus/prometheus/tsdb.(*CircularExemplarStorage).AddExemplar(...)
    tsdb/exemplar.go:398
github.com/prometheus/prometheus/tsdb.(*Head).loadWAL.func3(...)
    tsdb/head_wal.go:147
```

Four sites dereference `idx.oldest`/`idx.newest` without checking for the `-1` sentinel: `validateExemplar`, `AddExemplar` (OOO check), `AddExemplar` (linked-list splice), and `Select`.

### Reproduction status

We have not been able to reproduce this through the public API. Coverage-guided fuzz testing with varying buffer sizes, series counts, OOO exemplars, and interleaved Resize calls did not produce a stale index entry — every code path that calls `removeExemplar` correctly handles the return value within the same call. The fix is defensive: it makes the storage resilient to a state that should not occur but did occur in production (the affected tenant consistently replays OOO exemplars from WAL, correlating with the OOO exemplar support added in #17469).

### Changes

- **`Select`**: skip index entries where either pointer is `noExemplar`.
- **`validateExemplar`**: return nil (no prior exemplar) for stale entries.
- **`AddExemplar`**: introduce `emptyIndex` boolean to track entries with no live exemplars. This avoids dereferences of invalid pointers and also replaces the prior overloading of `indexExists` for the eviction same-series path — `indexExists` is now immutable after the initial map lookup.

### Note on `emptyIndex` refactor

The existing code at line 452 (`indexExists = false`) overloaded `indexExists` to mean both "no map entry" and "map entry exists but is empty." The new `emptyIndex` variable separates these concerns, which also avoids a spurious allocation that would otherwise occur at line 441 when encountering a stale entry.

```release-notes
[BUGFIX] TSDB: Fix `CircularExemplarStorage` panic on index out of range [-1] when a stale index entry (oldest/newest == noExemplar) is encountered during WAL replay, exemplar queries, or writes.
```