### PR TITLE
tsdb/chunkenc: prepare histogram appenders for reuse

### DIFF
--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -193,6 +193,11 @@ func (a *FloatHistogramAppender) NumSamples() int {
 	return int(binary.BigEndian.Uint16(a.b.bytes()))
 }
 
+// setNumSamples writes the float histogram sample count into the chunk header.
+func (a *FloatHistogramAppender) setNumSamples(num int) {
+	binary.BigEndian.PutUint16(a.b.bytes(), uint16(num))
+}
+
 // Append implements Appender. This implementation panics because normal float
 // samples must never be appended to a histogram chunk.
 func (*FloatHistogramAppender) Append(int64, int64, float64) {
@@ -509,9 +514,12 @@ func (a *FloatHistogramAppender) appendableGauge(h *histogram.FloatHistogram) (
 // the histogram is properly structured, e.g. the number of buckets used
 // corresponds to the number conveyed by the span structures. First call
 // Appendable() and act accordingly!
-func (a *FloatHistogramAppender) appendFloatHistogram(t int64, h *histogram.FloatHistogram) {
+//
+// num is the current sample count in the chunk (as returned by NumSamples).
+// appendFloatHistogram does not update the chunk header itself; it returns the
+// new sample count (num+1), which the caller must persist via setNumSamples.
+func (a *FloatHistogramAppender) appendFloatHistogram(num int, t int64, h *histogram.FloatHistogram) int {
 	var tDelta int64
-	num := binary.BigEndian.Uint16(a.b.bytes())
 
 	if value.IsStaleNaN(h.Sum) {
 		// Emptying out other fields to write no buckets, and an empty
@@ -602,10 +610,10 @@ func (a *FloatHistogramAppender) appendFloatHistogram(t int64, h *histogram.Floa
 		}
 	}
 
-	binary.BigEndian.PutUint16(a.b.bytes(), num+1)
-
 	a.t = t
 	a.tDelta = tDelta
+
+	return num + 1
 }
 
 func (a *FloatHistogramAppender) writeXorValue(old *xorValue, v float64) {
@@ -636,6 +644,7 @@ func (a *FloatHistogramAppender) recode(
 	happ := app.(*FloatHistogramAppender)
 	numPositiveBuckets, numNegativeBuckets := countSpans(positiveSpans), countSpans(negativeSpans)
 
+	num := happ.NumSamples()
 	for it.Next() == ValFloatHistogram {
 		tOld, hOld := it.AtFloatHistogram(nil)
 
@@ -659,8 +668,9 @@ func (a *FloatHistogramAppender) recode(
 		if len(negativeInserts) > 0 {
 			hOld.NegativeBuckets = insert(hOld.NegativeBuckets, negativeBuckets, negativeInserts, false)
 		}
-		happ.appendFloatHistogram(tOld, hOld)
+		num = happ.appendFloatHistogram(num, tOld, hOld)
 	}
+	happ.setNumSamples(num)
 
 	happ.setCounterResetHeader(CounterResetHeader(byts[histogramFlagPos] & CounterResetHeaderMask))
 	return hc, app
@@ -694,7 +704,7 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 	}
 
 	if numSamples == 0 {
-		a.appendFloatHistogram(t, h)
+		a.setNumSamples(a.appendFloatHistogram(numSamples, t, h))
 		if h.CounterResetHint == histogram.GaugeType {
 			a.setCounterResetHeader(GaugeType)
 			return nil, false, a, nil
@@ -735,7 +745,7 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			if counterReset {
 				happ.setCounterResetHeader(CounterReset)
 			}
-			happ.appendFloatHistogram(t, h)
+			happ.setNumSamples(happ.appendFloatHistogram(0, t, h))
 			return newChunk, false, app, nil
 		}
 		if len(pBackwardInserts) > 0 || len(nBackwardInserts) > 0 {
@@ -763,10 +773,11 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 				pForwardInserts, nForwardInserts,
 				h.PositiveSpans, h.NegativeSpans,
 			)
-			app.(*FloatHistogramAppender).appendFloatHistogram(t, h)
+			happ := app.(*FloatHistogramAppender)
+			happ.setNumSamples(happ.appendFloatHistogram(happ.NumSamples(), t, h))
 			return chk, true, app, nil
 		}
-		a.appendFloatHistogram(t, h)
+		a.setNumSamples(a.appendFloatHistogram(numSamples, t, h))
 		return nil, false, a, nil
 	}
 	// Adding gauge histogram.
@@ -782,7 +793,7 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 		}
 		happ := app.(*FloatHistogramAppender)
 		happ.setCounterResetHeader(GaugeType)
-		happ.appendFloatHistogram(t, h)
+		happ.setNumSamples(happ.appendFloatHistogram(0, t, h))
 		return newChunk, false, app, nil
 	}
 
@@ -803,11 +814,12 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			pForwardInserts, nForwardInserts,
 			h.PositiveSpans, h.NegativeSpans,
 		)
-		app.(*FloatHistogramAppender).appendFloatHistogram(t, h)
+		happ := app.(*FloatHistogramAppender)
+		happ.setNumSamples(happ.appendFloatHistogram(happ.NumSamples(), t, h))
 		return chk, true, app, nil
 	}
 
-	a.appendFloatHistogram(t, h)
+	a.setNumSamples(a.appendFloatHistogram(numSamples, t, h))
 	return nil, false, a, nil
 }
 

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -629,7 +629,7 @@ func (a *FloatHistogramAppender) writeXorValue(old *xorValue, v float64) {
 func (a *FloatHistogramAppender) recode(
 	positiveInserts, negativeInserts []Insert,
 	positiveSpans, negativeSpans []histogram.Span,
-) (Chunk, Appender) {
+) (Chunk, *FloatHistogramAppender) {
 	// TODO(beorn7): This currently just decodes everything and then encodes
 	// it again with the new span layout. This can probably be done in-place
 	// by editing the chunk. But let's first see how expensive it is in the
@@ -673,7 +673,7 @@ func (a *FloatHistogramAppender) recode(
 	happ.setNumSamples(num)
 
 	happ.setCounterResetHeader(CounterResetHeader(byts[histogramFlagPos] & CounterResetHeaderMask))
-	return hc, app
+	return hc, happ
 }
 
 // recodeHistogram converts the current histogram (in-place) to accommodate an expansion of the set of
@@ -769,13 +769,12 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			if appendOnly {
 				return nil, false, a, fmt.Errorf("float histogram layout change with %d positive and %d negative forwards inserts", len(pForwardInserts), len(nForwardInserts))
 			}
-			chk, app := a.recode(
+			chk, happ := a.recode(
 				pForwardInserts, nForwardInserts,
 				h.PositiveSpans, h.NegativeSpans,
 			)
-			happ := app.(*FloatHistogramAppender)
 			happ.setNumSamples(happ.appendFloatHistogram(happ.NumSamples(), t, h))
-			return chk, true, app, nil
+			return chk, true, happ, nil
 		}
 		a.setNumSamples(a.appendFloatHistogram(numSamples, t, h))
 		return nil, false, a, nil
@@ -810,13 +809,12 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 		if appendOnly {
 			return nil, false, a, fmt.Errorf("float gauge histogram layout change with %d positive and %d negative forwards inserts", len(pForwardInserts), len(nForwardInserts))
 		}
-		chk, app := a.recode(
+		chk, happ := a.recode(
 			pForwardInserts, nForwardInserts,
 			h.PositiveSpans, h.NegativeSpans,
 		)
-		happ := app.(*FloatHistogramAppender)
 		happ.setNumSamples(happ.appendFloatHistogram(happ.NumSamples(), t, h))
-		return chk, true, app, nil
+		return chk, true, happ, nil
 	}
 
 	a.setNumSamples(a.appendFloatHistogram(numSamples, t, h))

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -677,7 +677,7 @@ func (a *HistogramAppender) appendHistogram(num int, t int64, h *histogram.Histo
 func (a *HistogramAppender) recode(
 	positiveInserts, negativeInserts []Insert,
 	positiveSpans, negativeSpans []histogram.Span,
-) (Chunk, Appender) {
+) (Chunk, *HistogramAppender) {
 	// TODO(beorn7): This currently just decodes everything and then encodes
 	// it again with the new span layout. This can probably be done in-place
 	// by editing the chunk. But let's first see how expensive it is in the
@@ -721,7 +721,7 @@ func (a *HistogramAppender) recode(
 	happ.setNumSamples(num)
 
 	happ.setCounterResetHeader(CounterResetHeader(byts[histogramFlagPos] & CounterResetHeaderMask))
-	return hc, app
+	return hc, happ
 }
 
 // recodeHistogram converts the current histogram (in-place) to accommodate an
@@ -815,13 +815,12 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, _, t int64,
 			if appendOnly {
 				return nil, false, a, fmt.Errorf("histogram layout change with %d positive and %d negative forwards inserts", len(pForwardInserts), len(nForwardInserts))
 			}
-			chk, app := a.recode(
+			chk, happ := a.recode(
 				pForwardInserts, nForwardInserts,
 				h.PositiveSpans, h.NegativeSpans,
 			)
-			happ := app.(*HistogramAppender)
 			happ.setNumSamples(happ.appendHistogram(happ.NumSamples(), t, h))
-			return chk, true, app, nil
+			return chk, true, happ, nil
 		}
 		a.setNumSamples(a.appendHistogram(numSamples, t, h))
 		return nil, false, a, nil
@@ -856,13 +855,12 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, _, t int64,
 		if appendOnly {
 			return nil, false, a, fmt.Errorf("gauge histogram layout change with %d positive and %d negative forwards inserts", len(pForwardInserts), len(nForwardInserts))
 		}
-		chk, app := a.recode(
+		chk, happ := a.recode(
 			pForwardInserts, nForwardInserts,
 			h.PositiveSpans, h.NegativeSpans,
 		)
-		happ := app.(*HistogramAppender)
 		happ.setNumSamples(happ.appendHistogram(happ.NumSamples(), t, h))
-		return chk, true, app, nil
+		return chk, true, happ, nil
 	}
 
 	a.setNumSamples(a.appendHistogram(numSamples, t, h))

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -217,6 +217,11 @@ func (a *HistogramAppender) NumSamples() int {
 	return int(binary.BigEndian.Uint16(a.b.bytes()))
 }
 
+// setNumSamples writes the histogram sample count into the chunk header.
+func (a *HistogramAppender) setNumSamples(num int) {
+	binary.BigEndian.PutUint16(a.b.bytes(), uint16(num))
+}
+
 // Append implements Appender. This implementation panics because normal float
 // samples must never be appended to a histogram chunk.
 func (*HistogramAppender) Append(int64, int64, float64) {
@@ -546,9 +551,12 @@ func (a *HistogramAppender) appendableGauge(h *histogram.Histogram) (
 // the histogram is properly structured, e.g. the number of buckets used
 // corresponds to the number conveyed by the span structures. First call
 // Appendable() and act accordingly!
-func (a *HistogramAppender) appendHistogram(t int64, h *histogram.Histogram) {
+//
+// num is the current sample count in the chunk (as returned by NumSamples).
+// appendHistogram does not update the chunk header itself; it returns the new
+// sample count (num+1), which the caller must persist via setNumSamples.
+func (a *HistogramAppender) appendHistogram(num int, t int64, h *histogram.Histogram) int {
 	var tDelta, cntDelta, zCntDelta int64
-	num := binary.BigEndian.Uint16(a.b.bytes())
 
 	if value.IsStaleNaN(h.Sum) {
 		// Emptying out other fields to write no buckets, and an empty
@@ -646,8 +654,6 @@ func (a *HistogramAppender) appendHistogram(t int64, h *histogram.Histogram) {
 		}
 	}
 
-	binary.BigEndian.PutUint16(a.b.bytes(), num+1)
-
 	a.t = t
 	a.cnt = h.Count
 	a.zCnt = h.ZeroCount
@@ -659,6 +665,8 @@ func (a *HistogramAppender) appendHistogram(t int64, h *histogram.Histogram) {
 	copy(a.nBuckets, h.NegativeBuckets)
 	// Note that the bucket deltas were already updated above.
 	a.sum = h.Sum
+
+	return num + 1
 }
 
 // recode converts the current chunk to accommodate an expansion of the set of
@@ -684,6 +692,7 @@ func (a *HistogramAppender) recode(
 	happ := app.(*HistogramAppender)
 	numPositiveBuckets, numNegativeBuckets := countSpans(positiveSpans), countSpans(negativeSpans)
 
+	num := happ.NumSamples()
 	for it.Next() == ValHistogram {
 		tOld, hOld := it.AtHistogram(nil)
 
@@ -707,8 +716,9 @@ func (a *HistogramAppender) recode(
 		if len(negativeInserts) > 0 {
 			hOld.NegativeBuckets = insert(hOld.NegativeBuckets, negativeBuckets, negativeInserts, true)
 		}
-		happ.appendHistogram(tOld, hOld)
+		num = happ.appendHistogram(num, tOld, hOld)
 	}
+	happ.setNumSamples(num)
 
 	happ.setCounterResetHeader(CounterResetHeader(byts[histogramFlagPos] & CounterResetHeaderMask))
 	return hc, app
@@ -746,7 +756,7 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, _, t int64,
 	}
 
 	if numSamples == 0 {
-		a.appendHistogram(t, h)
+		a.setNumSamples(a.appendHistogram(numSamples, t, h))
 		if h.CounterResetHint == histogram.GaugeType {
 			a.setCounterResetHeader(GaugeType)
 			return nil, false, a, nil
@@ -781,7 +791,7 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, _, t int64,
 			}
 			happ := app.(*HistogramAppender)
 			happ.setCounterResetHeader(counterResetHint)
-			happ.appendHistogram(t, h)
+			happ.setNumSamples(happ.appendHistogram(0, t, h))
 			return newChunk, false, app, nil
 		}
 		if len(pBackwardInserts) > 0 || len(nBackwardInserts) > 0 {
@@ -809,10 +819,11 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, _, t int64,
 				pForwardInserts, nForwardInserts,
 				h.PositiveSpans, h.NegativeSpans,
 			)
-			app.(*HistogramAppender).appendHistogram(t, h)
+			happ := app.(*HistogramAppender)
+			happ.setNumSamples(happ.appendHistogram(happ.NumSamples(), t, h))
 			return chk, true, app, nil
 		}
-		a.appendHistogram(t, h)
+		a.setNumSamples(a.appendHistogram(numSamples, t, h))
 		return nil, false, a, nil
 	}
 	// Adding gauge histogram.
@@ -828,7 +839,7 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, _, t int64,
 		}
 		happ := app.(*HistogramAppender)
 		happ.setCounterResetHeader(GaugeType)
-		happ.appendHistogram(t, h)
+		happ.setNumSamples(happ.appendHistogram(0, t, h))
 		return newChunk, false, app, nil
 	}
 
@@ -849,11 +860,12 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, _, t int64,
 			pForwardInserts, nForwardInserts,
 			h.PositiveSpans, h.NegativeSpans,
 		)
-		app.(*HistogramAppender).appendHistogram(t, h)
+		happ := app.(*HistogramAppender)
+		happ.setNumSamples(happ.appendHistogram(happ.NumSamples(), t, h))
 		return chk, true, app, nil
 	}
 
-	a.appendHistogram(t, h)
+	a.setNumSamples(a.appendHistogram(numSamples, t, h))
 	return nil, false, a, nil
 }
 


### PR DESCRIPTION
## Summary

Refactor `(Float)HistogramAppender.appendHistogram` so that the sample
count (`num`) is taken as an input parameter and the new value
(`num+1`) is returned, rather than reading/writing the chunk header
directly inside the function. Callers read via the existing
`NumSamples()` and write via the new `setNumSamples` helper. This
prepares the chunkenc layer for reuse from #18609.

Additionally tighten the return type of `recode` from `Appender` to
the concrete `*HistogramAppender` / `*FloatHistogramAppender`,
dropping the redundant type assertions at both call sites.

The commit series mirrors the same two changes for `HistogramAppender`
and `FloatHistogramAppender` separately so each commit stays small.

## Benchmark

`BenchmarkCuttingHeadHistogramChunks` exercises
`HistogramAppender.AppendHistogram` heavily, including the
chunk-cut / recode paths. No regression observed (10 samples per
side, `benchstat`):

```
                             │ main          │ refactor                        │
                             │ sec/op        │ sec/op        vs base           │
CuttingHeadHistogramChunks-8    21.92m ± 72%    20.86m ± 23%  ~ (p=0.481 n=10)

                             │ main          │ refactor                        │
                             │ B/op          │ B/op          vs base           │
CuttingHeadHistogramChunks-8    9.659Mi ± 0%    9.659Mi ± 0%  ~ (p=0.796 n=10)

                             │ main          │ refactor                        │
                             │ allocs/op     │ allocs/op     vs base           │
CuttingHeadHistogramChunks-8       77.00 ± 3%      77.00 ± 4%  ~ (p=0.703 n=10)
```

Memory and allocations are byte-identical; time is within noise (the
`main` side had two outliers around 38 ms, explaining the wide
variance).

## Test plan

- [x] `go test ./tsdb/chunkenc/...` passes
- [x] `go test ./tsdb/...` passes (all subpackages)
- [x] Benchmark above shows no regression vs `main`

```release-notes
NONE
```

Coded with Claude Opus 4.7.