### PR TITLE
promql/parser: fix panic in setAnchored/setSmoothed for non-selector ranges

### DIFF
--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -1086,8 +1086,12 @@ func (p *parser) setAnchored(e Node) {
 			p.addParseErrf(e.PositionRange(), "anchored and smoothed modifiers cannot be used together")
 		}
 	case *MatrixSelector:
-		s.VectorSelector.(*VectorSelector).Anchored = true
-		if s.VectorSelector.(*VectorSelector).Smoothed {
+		vs, ok := s.VectorSelector.(*VectorSelector)
+		if !ok {
+			return
+		}
+		vs.Anchored = true
+		if vs.Smoothed {
 			p.addParseErrf(e.PositionRange(), "anchored and smoothed modifiers cannot be used together")
 		}
 	case *SubqueryExpr:
@@ -1109,8 +1113,12 @@ func (p *parser) setSmoothed(e Node) {
 			p.addParseErrf(e.PositionRange(), "anchored and smoothed modifiers cannot be used together")
 		}
 	case *MatrixSelector:
-		s.VectorSelector.(*VectorSelector).Smoothed = true
-		if s.VectorSelector.(*VectorSelector).Anchored {
+		vs, ok := s.VectorSelector.(*VectorSelector)
+		if !ok {
+			return
+		}
+		vs.Smoothed = true
+		if vs.Anchored {
 			p.addParseErrf(e.PositionRange(), "anchored and smoothed modifiers cannot be used together")
 		}
 	case *SubqueryExpr:

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -5308,6 +5308,29 @@ var testExpr = []struct {
 			},
 		},
 	},
+	// Anchored/smoothed on non-selector range must not panic.
+	{
+		input: "1[5m] smoothed",
+		fail:  true,
+		errors: ParseErrors{
+			{
+				PositionRange: posrange.PositionRange{Start: 1, End: 5},
+				Err:           errors.New("ranges only allowed for vector selectors"),
+				Query:         "1[5m] smoothed",
+			},
+		},
+	},
+	{
+		input: "1[5m] anchored",
+		fail:  true,
+		errors: ParseErrors{
+			{
+				PositionRange: posrange.PositionRange{Start: 1, End: 5},
+				Err:           errors.New("ranges only allowed for vector selectors"),
+				Query:         "1[5m] anchored",
+			},
+		},
+	},
 }
 
 func makeInt64Pointer(val int64) *int64 {
@@ -5326,8 +5349,9 @@ func readable(s string) string {
 
 func TestParseExpressions(t *testing.T) {
 	optsParser := NewParser(Options{
-		EnableExperimentalFunctions: true,
-		ExperimentalDurationExpr:    true,
+		EnableExperimentalFunctions:  true,
+		ExperimentalDurationExpr:     true,
+		EnableExtendedRangeSelectors: true,
 	})
 
 	for _, test := range testExpr {


### PR DESCRIPTION
When a MatrixSelector wraps a non-VectorSelector expression (e.g. `1[5m]`), the grammar records a parse error but continues. The unchecked type assertions in setAnchored and setSmoothed then panic. Use safe assertions and emit a parse error instead.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] PromQL: Fix panic on `1[5m] smoothed` and similar expressions when extended range selectors are enabled.
```
