### PR TITLE
fuzzing: detect parser runtime panics in FuzzParseExpr

### DIFF
--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -337,7 +337,8 @@ func (p *parser) unexpected(context, expected string) {
 	p.addParseErr(p.yyParser.lval.item.PositionRange(), errors.New(errMsg.String()))
 }
 
-var errUnexpected = errors.New("unexpected error")
+// ErrUnexpected is returned when the parser recovers from a runtime panic.
+var ErrUnexpected = errors.New("unexpected error")
 
 // recover is the handler that turns panics into returns from the top level of Parse.
 func (*parser) recover(errp *error) {
@@ -349,7 +350,7 @@ func (*parser) recover(errp *error) {
 		buf = buf[:runtime.Stack(buf, false)]
 
 		fmt.Fprintf(os.Stderr, "parser panic: %v\n%s", e, buf)
-		*errp = errUnexpected
+		*errp = ErrUnexpected
 	case e != nil:
 		*errp = e.(error)
 	}

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -5359,7 +5359,7 @@ func TestParseExpressions(t *testing.T) {
 			expr, err := optsParser.ParseExpr(test.input)
 
 			// Unexpected errors are always caused by a bug.
-			require.NotEqual(t, err, errUnexpected, "unexpected error occurred")
+			require.NotEqual(t, err, ErrUnexpected, "unexpected error occurred")
 
 			if !test.fail {
 				require.NoError(t, err)
@@ -6013,7 +6013,7 @@ func TestParseSeries(t *testing.T) {
 		metric, vals, err := testParser.ParseSeriesDesc(test.input)
 
 		// Unexpected errors are always caused by a bug.
-		require.NotEqual(t, err, errUnexpected, "unexpected error occurred")
+		require.NotEqual(t, err, ErrUnexpected, "unexpected error occurred")
 
 		if !test.fail {
 			require.NoError(t, err)
@@ -6030,7 +6030,7 @@ func TestRecoverParserRuntime(t *testing.T) {
 	var err error
 
 	defer func() {
-		require.Equal(t, errUnexpected, err)
+		require.Equal(t, ErrUnexpected, err)
 	}()
 	defer p.recover(&err)
 	// Cause a runtime panic.

--- a/util/fuzzing/fuzz_test.go
+++ b/util/fuzzing/fuzz_test.go
@@ -372,7 +372,10 @@ func FuzzParseExpr(f *testing.F) {
 			t.Skip()
 		}
 		_, err := p.ParseExpr(in)
-		// We don't care about errors, just that we don't panic.
-		_ = err
+		// The parser recovers from runtime panics and returns ErrUnexpected.
+		// Flag those as test failures since they indicate a real bug.
+		if errors.Is(err, parser.ErrUnexpected) {
+			t.Fatalf("parser panicked on input %q: %v", in, err)
+		}
 	})
 }


### PR DESCRIPTION
Export ErrUnexpected from the parser package so the fuzz test can use errors.Is to detect when the parser's recover() handler caught a runtime panic. Previously these were silently swallowed; now FuzzParseExpr fails on them.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
