### PR TITLE
promql/parser: fix panic on parenthesised number in offset_duration_expr

### DIFF
--- a/promql/parser/generated_parser.y
+++ b/promql/parser/generated_parser.y
@@ -1298,17 +1298,33 @@ offset_duration_expr    : number_duration_literal
                                 }
                         | unary_op LEFT_PAREN duration_expr RIGHT_PAREN %prec MUL
                                 {
-                                de := $3.(*DurationExpr)
-                                de.Wrapped = true
-                                if $1.Typ == SUB {
-                                        $$ = &DurationExpr{
-                                                Op: SUB,
-                                                RHS: de,
-                                                StartPos: $1.Pos,
+                                switch expr := $3.(type) {
+                                case *DurationExpr:
+                                        expr.Wrapped = true
+                                        if $1.Typ == SUB {
+                                                $$ = &DurationExpr{
+                                                        Op:       SUB,
+                                                        RHS:      expr,
+                                                        StartPos: $1.Pos,
+                                                }
+                                                break
                                         }
-                                        break
+                                        $$ = expr
+                                case *NumberLiteral:
+                                        if $1.Typ == SUB {
+                                                expr.Val *= -1
+                                        }
+                                        if expr.Val > 1<<63/1e9 || expr.Val < -(1<<63)/1e9 {
+                                                yylex.(*parser).addParseErrf($1.PositionRange(), "duration out of range")
+                                                $$ = &NumberLiteral{Val: 0}
+                                                break
+                                        }
+                                        expr.PosRange.Start = $1.Pos
+                                        $$ = expr
+                                default:
+                                        yylex.(*parser).addParseErrf($1.PositionRange(), "expected number literal or duration expression")
+                                        $$ = &NumberLiteral{Val: 0}
                                 }
-                                $$ = $3
                                 }
                         | duration_expr
                         ;

--- a/promql/parser/generated_parser.y
+++ b/promql/parser/generated_parser.y
@@ -1198,7 +1198,7 @@ maybe_grouping_labels: /* empty */ { $$ = nil }
 offset_duration_expr    : number_duration_literal
                                 {
                                 nl := $1.(*NumberLiteral)
-                                if nl.Val > 1<<63/1e9 || nl.Val < -(1<<63)/1e9 {
+                                if durationLiteralOutOfRange(nl.Val) {
                                         yylex.(*parser).addParseErrf(nl.PosRange, "duration out of range")
                                         $$ = &NumberLiteral{Val: 0}
                                         break
@@ -1211,7 +1211,7 @@ offset_duration_expr    : number_duration_literal
                                 if $1.Typ == SUB {
                                         nl.Val *= -1
                                 }
-                                if nl.Val > 1<<63/1e9 || nl.Val < -(1<<63)/1e9 {
+                                if durationLiteralOutOfRange(nl.Val) {
                                         yylex.(*parser).addParseErrf($1.PositionRange(), "duration out of range")
                                         $$ = &NumberLiteral{Val: 0}
                                         break
@@ -1298,33 +1298,7 @@ offset_duration_expr    : number_duration_literal
                                 }
                         | unary_op LEFT_PAREN duration_expr RIGHT_PAREN %prec MUL
                                 {
-                                switch expr := $3.(type) {
-                                case *DurationExpr:
-                                        expr.Wrapped = true
-                                        if $1.Typ == SUB {
-                                                $$ = &DurationExpr{
-                                                        Op:       SUB,
-                                                        RHS:      expr,
-                                                        StartPos: $1.Pos,
-                                                }
-                                                break
-                                        }
-                                        $$ = expr
-                                case *NumberLiteral:
-                                        if $1.Typ == SUB {
-                                                expr.Val *= -1
-                                        }
-                                        if expr.Val > 1<<63/1e9 || expr.Val < -(1<<63)/1e9 {
-                                                yylex.(*parser).addParseErrf($1.PositionRange(), "duration out of range")
-                                                $$ = &NumberLiteral{Val: 0}
-                                                break
-                                        }
-                                        expr.PosRange.Start = $1.Pos
-                                        $$ = expr
-                                default:
-                                        yylex.(*parser).addParseErrf($1.PositionRange(), "expected number literal or duration expression")
-                                        $$ = &NumberLiteral{Val: 0}
-                                }
+                                $$ = yylex.(*parser).applyUnaryOpToDurationExpr($1, $3.(Node), true)
                                 }
                         | duration_expr
                         ;
@@ -1334,7 +1308,7 @@ max_of_min_of: MAX_OF | MIN_OF ;
 duration_expr   : number_duration_literal
                         {
                         nl := $1.(*NumberLiteral)
-                        if nl.Val > 1<<63/1e9 || nl.Val < -(1<<63)/1e9 {
+                        if durationLiteralOutOfRange(nl.Val) {
                                 yylex.(*parser).addParseErrf(nl.PosRange, "duration out of range")
                                 $$ = &NumberLiteral{Val: 0}
                                 break
@@ -1343,36 +1317,8 @@ duration_expr   : number_duration_literal
                         }
                 | unary_op duration_expr %prec MUL
                         {
-                        switch expr := $2.(type) {
-                        case *NumberLiteral:
-                                if $1.Typ == SUB {
-                                        expr.Val *= -1
-                                }
-                                if expr.Val > 1<<63/1e9 || expr.Val < -(1<<63)/1e9 {
-                                        yylex.(*parser).addParseErrf($1.PositionRange(), "duration out of range")
-                                        $$ = &NumberLiteral{Val: 0}
-                                        break
-                                }
-                                expr.PosRange.Start = $1.Pos
-                                $$ = expr
-                                break
-                        case *DurationExpr:
-                                if $1.Typ == SUB {
-                                        $$ = &DurationExpr{
-                                                Op: SUB,
-                                                RHS: expr,
-                                                StartPos: $1.Pos,
-                                        }
-                                        break
-                                }
-                                $$ = expr
-                                break
-                        default:
-                                yylex.(*parser).addParseErrf($1.PositionRange(), "expected number literal or duration expression")
-                                $$ = &NumberLiteral{Val: 0}
-                                break
+                        $$ = yylex.(*parser).applyUnaryOpToDurationExpr($1, $2.(Node), false)
                         }
-                }
                 | duration_expr ADD duration_expr
                         {
                         yylex.(*parser).experimentalDurationExpr($1.(Expr))

--- a/promql/parser/generated_parser.y.go
+++ b/promql/parser/generated_parser.y.go
@@ -2438,17 +2438,33 @@ yydefault:
 	case 293:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		{
-			de := yyDollar[3].node.(*DurationExpr)
-			de.Wrapped = true
-			if yyDollar[1].item.Typ == SUB {
-				yyVAL.node = &DurationExpr{
-					Op:       SUB,
-					RHS:      de,
-					StartPos: yyDollar[1].item.Pos,
+			switch expr := yyDollar[3].node.(type) {
+			case *DurationExpr:
+				expr.Wrapped = true
+				if yyDollar[1].item.Typ == SUB {
+					yyVAL.node = &DurationExpr{
+						Op:       SUB,
+						RHS:      expr,
+						StartPos: yyDollar[1].item.Pos,
+					}
+					break
 				}
-				break
+				yyVAL.node = expr
+			case *NumberLiteral:
+				if yyDollar[1].item.Typ == SUB {
+					expr.Val *= -1
+				}
+				if expr.Val > 1<<63/1e9 || expr.Val < -(1<<63)/1e9 {
+					yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "duration out of range")
+					yyVAL.node = &NumberLiteral{Val: 0}
+					break
+				}
+				expr.PosRange.Start = yyDollar[1].item.Pos
+				yyVAL.node = expr
+			default:
+				yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "expected number literal or duration expression")
+				yyVAL.node = &NumberLiteral{Val: 0}
 			}
-			yyVAL.node = yyDollar[3].node
 		}
 	case 297:
 		yyDollar = yyS[yypt-1 : yypt+1]

--- a/promql/parser/generated_parser.y.go
+++ b/promql/parser/generated_parser.y.go
@@ -2330,7 +2330,7 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			nl := yyDollar[1].node.(*NumberLiteral)
-			if nl.Val > 1<<63/1e9 || nl.Val < -(1<<63)/1e9 {
+			if durationLiteralOutOfRange(nl.Val) {
 				yylex.(*parser).addParseErrf(nl.PosRange, "duration out of range")
 				yyVAL.node = &NumberLiteral{Val: 0}
 				break
@@ -2344,7 +2344,7 @@ yydefault:
 			if yyDollar[1].item.Typ == SUB {
 				nl.Val *= -1
 			}
-			if nl.Val > 1<<63/1e9 || nl.Val < -(1<<63)/1e9 {
+			if durationLiteralOutOfRange(nl.Val) {
 				yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "duration out of range")
 				yyVAL.node = &NumberLiteral{Val: 0}
 				break
@@ -2438,39 +2438,13 @@ yydefault:
 	case 293:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		{
-			switch expr := yyDollar[3].node.(type) {
-			case *DurationExpr:
-				expr.Wrapped = true
-				if yyDollar[1].item.Typ == SUB {
-					yyVAL.node = &DurationExpr{
-						Op:       SUB,
-						RHS:      expr,
-						StartPos: yyDollar[1].item.Pos,
-					}
-					break
-				}
-				yyVAL.node = expr
-			case *NumberLiteral:
-				if yyDollar[1].item.Typ == SUB {
-					expr.Val *= -1
-				}
-				if expr.Val > 1<<63/1e9 || expr.Val < -(1<<63)/1e9 {
-					yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "duration out of range")
-					yyVAL.node = &NumberLiteral{Val: 0}
-					break
-				}
-				expr.PosRange.Start = yyDollar[1].item.Pos
-				yyVAL.node = expr
-			default:
-				yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "expected number literal or duration expression")
-				yyVAL.node = &NumberLiteral{Val: 0}
-			}
+			yyVAL.node = yylex.(*parser).applyUnaryOpToDurationExpr(yyDollar[1].item, yyDollar[3].node.(Node), true)
 		}
 	case 297:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			nl := yyDollar[1].node.(*NumberLiteral)
-			if nl.Val > 1<<63/1e9 || nl.Val < -(1<<63)/1e9 {
+			if durationLiteralOutOfRange(nl.Val) {
 				yylex.(*parser).addParseErrf(nl.PosRange, "duration out of range")
 				yyVAL.node = &NumberLiteral{Val: 0}
 				break
@@ -2480,35 +2454,7 @@ yydefault:
 	case 298:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
-			switch expr := yyDollar[2].node.(type) {
-			case *NumberLiteral:
-				if yyDollar[1].item.Typ == SUB {
-					expr.Val *= -1
-				}
-				if expr.Val > 1<<63/1e9 || expr.Val < -(1<<63)/1e9 {
-					yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "duration out of range")
-					yyVAL.node = &NumberLiteral{Val: 0}
-					break
-				}
-				expr.PosRange.Start = yyDollar[1].item.Pos
-				yyVAL.node = expr
-				break
-			case *DurationExpr:
-				if yyDollar[1].item.Typ == SUB {
-					yyVAL.node = &DurationExpr{
-						Op:       SUB,
-						RHS:      expr,
-						StartPos: yyDollar[1].item.Pos,
-					}
-					break
-				}
-				yyVAL.node = expr
-				break
-			default:
-				yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "expected number literal or duration expression")
-				yyVAL.node = &NumberLiteral{Val: 0}
-				break
-			}
+			yyVAL.node = yylex.(*parser).applyUnaryOpToDurationExpr(yyDollar[1].item, yyDollar[2].node.(Node), false)
 		}
 	case 299:
 		yyDollar = yyS[yypt-3 : yypt+1]

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -1201,9 +1201,48 @@ func (p *parser) getAtModifierVars(e Node) (**int64, *ItemType, *posrange.Pos, b
 	return timestampp, preprocp, endPosp, true
 }
 
+// durationLiteralOutOfRange reports whether val, interpreted as seconds, would
+// overflow a time.Duration (int64 nanoseconds).
+func durationLiteralOutOfRange(val float64) bool {
+	return val > 1<<63/1e9 || val < -(1<<63)/1e9
+}
+
 func (p *parser) experimentalDurationExpr(e Expr) {
 	if !p.options.ExperimentalDurationExpr {
 		p.addParseErrf(e.PositionRange(), "experimental duration expression is not enabled")
+	}
+}
+
+// applyUnaryOpToDurationExpr applies a unary operator to a duration expression
+// node, which may be a *DurationExpr or a *NumberLiteral. When wrapped is true
+// (parenthesised form), the Wrapped flag is set on *DurationExpr nodes.
+func (p *parser) applyUnaryOpToDurationExpr(op Item, expr Node, wrapped bool) Node {
+	switch e := expr.(type) {
+	case *DurationExpr:
+		if wrapped {
+			e.Wrapped = true
+		}
+		if op.Typ == SUB {
+			return &DurationExpr{
+				Op:       SUB,
+				RHS:      e,
+				StartPos: op.Pos,
+			}
+		}
+		return e
+	case *NumberLiteral:
+		if op.Typ == SUB {
+			e.Val *= -1
+		}
+		if durationLiteralOutOfRange(e.Val) {
+			p.addParseErrf(op.PositionRange(), "duration out of range")
+			return &NumberLiteral{Val: 0}
+		}
+		e.PosRange.Start = op.Pos
+		return e
+	default:
+		p.addParseErrf(op.PositionRange(), "expected number literal or duration expression")
+		return &NumberLiteral{Val: 0}
 	}
 }
 

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -1714,6 +1714,28 @@ var testExpr = []struct {
 		},
 	},
 	{
+		input: "foo offset +(5)",
+		expected: &VectorSelector{
+			Name:           "foo",
+			OriginalOffset: 5 * time.Second,
+			LabelMatchers: []*labels.Matcher{
+				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+			},
+			PosRange: posrange.PositionRange{Start: 0, End: 15},
+		},
+	},
+	{
+		input: "foo offset -(5)",
+		expected: &VectorSelector{
+			Name:           "foo",
+			OriginalOffset: -5 * time.Second,
+			LabelMatchers: []*labels.Matcher{
+				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
+			},
+			PosRange: posrange.PositionRange{Start: 0, End: 15},
+		},
+	},
+	{
 		input: `http_requests{group="production"} + on(instance) group_left(job,instance) cpu_count{type="smp"}`,
 		fail:  true,
 		errors: ParseErrors{


### PR DESCRIPTION
The `unary_op LEFT_PAREN duration_expr RIGHT_PAREN` production in `offset_duration_expr` unconditionally asserted `$3.(*DurationExpr)`, but `duration_expr` can also reduce to a `*NumberLiteral` (e.g. the literal `0` or `5` inside parentheses).  This caused a runtime panic recoverable only by the top-level recover in parse.go, which surfaced as an opaque "unexpected error".

Replace the hard type-assertion with a type switch matching the same pattern used by the `unary_op duration_expr` production in `duration_expr`: handle `*DurationExpr` (set Wrapped, negate if SUB) and `*NumberLiteral` (negate value if SUB, range-check, update pos), with a fallback parse error for unexpected node types.

Regenerate generated_parser.y.go from the updated grammar.

Add regression tests: `foo offset +(5)` and `foo offset -(5)` now parse correctly as ±5 s offsets.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] PromQL: Fix panic when using a parenthesised plain number as an offset (e.g. `foo offset -(5)`)
```
