### PR TITLE
tsdb: add chunk_encoding config field for runtime encoding selection

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -78,6 +78,7 @@ import (
 	"github.com/prometheus/prometheus/tracing"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/agent"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/util/compression"
 	"github.com/prometheus/prometheus/util/documentcli"
@@ -280,7 +281,7 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 				config.DefaultGlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols
 				logger.Info("Experimental start timestamp zero ingestion enabled. OpenMetrics 1.0 parsing will parse <metric>_created metrics as ST instead of normal sample. Changed default scrape_protocols to prefer PrometheusProto format.", "global.scrape_protocols", fmt.Sprintf("%v", config.DefaultGlobalConfig.ScrapeProtocols))
 			case "xor2-encoding":
-				c.tsdb.EnableXOR2Encoding = true
+				c.tsdb.FloatChunkEncoding = chunkenc.EncXOR2
 				logger.Info("Experimental XOR2 chunk encoding enabled.")
 			case "st-synthesis":
 				// TODO(ridwanmsharif): Move this to scrape configuration once stable.
@@ -392,6 +393,10 @@ func main() {
 		promslogConfig: promslog.Config{},
 		scrape: scrape.Options{
 			FeatureRegistry: features.DefaultRegistry,
+		},
+		tsdb: tsdbOptions{
+			// Default to XOR encoding; xor2-encoding feature flag overrides this to EncXOR2.
+			FloatChunkEncoding: chunkenc.EncXOR,
 		},
 	}
 
@@ -2090,9 +2095,9 @@ type tsdbOptions struct {
 	BlockReloadInterval            model.Duration
 	EnableSTAsZeroSample           bool
 	EnableSTStorage                bool
-	EnableXOR2Encoding             bool
 	StaleSeriesCompactionThreshold float64
 	EnableFastStartup              bool
+	FloatChunkEncoding             chunkenc.Encoding
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -2122,9 +2127,9 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		FeatureRegistry:                features.DefaultRegistry,
 		EnableSTAsZeroSample:           opts.EnableSTAsZeroSample,
 		EnableSTStorage:                opts.EnableSTStorage,
-		EnableXOR2Encoding:             opts.EnableXOR2Encoding,
 		StaleSeriesCompactionThreshold: opts.StaleSeriesCompactionThreshold,
 		EnableFastStartup:              opts.EnableFastStartup,
+		FloatChunkEncoding:             opts.FloatChunkEncoding,
 	}
 }
 

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -396,6 +396,108 @@ func TestMaxBlockChunkSegmentSizeBounds(t *testing.T) {
 	}
 }
 
+func TestChunkEncodingStartupValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		config   string
+		features string
+		exitCode int
+	}{
+		{
+			name: "xor2 without xor2-encoding feature",
+			config: `
+storage:
+  tsdb:
+    chunk_encoding:
+      floats: xor2`,
+			features: "",
+			exitCode: 1,
+		},
+		{
+			name: "xor2 with xor2-encoding feature",
+			config: `
+storage:
+  tsdb:
+    chunk_encoding:
+      floats: xor2`,
+			features: "xor2-encoding",
+			exitCode: 0,
+		},
+		{
+			name: "xor with st-storage and xor2-encoding features",
+			config: `
+storage:
+  tsdb:
+    chunk_encoding:
+      floats: xor`,
+			features: "st-storage,xor2-encoding",
+			exitCode: 1,
+		},
+		{
+			name: "xor without st-storage feature",
+			config: `
+storage:
+  tsdb:
+    chunk_encoding:
+      floats: xor`,
+			features: "",
+			exitCode: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+			configFile := filepath.Join(tmpDir, "prometheus.yml")
+			require.NoError(t, os.WriteFile(configFile, []byte(tc.config), 0o777))
+
+			args := []string{"-test.main", "--web.listen-address=0.0.0.0:0", "--config.file=" + configFile, "--storage.tsdb.path=" + filepath.Join(tmpDir, "data")}
+			if tc.features != "" {
+				args = append(args, "--enable-feature="+tc.features)
+			}
+			prom := exec.Command(promPath, args...)
+
+			stderr, err := prom.StderrPipe()
+			require.NoError(t, err)
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			defer wg.Wait()
+			go func() {
+				defer wg.Done()
+				slurp, _ := io.ReadAll(stderr)
+				t.Log(string(slurp))
+			}()
+
+			require.NoError(t, prom.Start())
+
+			if tc.exitCode == 0 {
+				done := make(chan error, 1)
+				go func() { done <- prom.Wait() }()
+				select {
+				case err := <-done:
+					t.Fatalf("prometheus should be still running: %v", err)
+				case <-time.After(startupTime):
+					prom.Process.Kill()
+					<-done
+				}
+				return
+			}
+
+			err = prom.Wait()
+			require.Error(t, err)
+			var exitError *exec.ExitError
+			require.ErrorAs(t, err, &exitError)
+			status := exitError.Sys().(syscall.WaitStatus)
+			require.Equal(t, tc.exitCode, status.ExitStatus())
+		})
+	}
+}
+
 func TestTimeMetrics(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/compliance/remote_write_sender_test.go
+++ b/compliance/remote_write_sender_test.go
@@ -80,12 +80,15 @@ func (p internalPrometheus) Run(ctx context.Context, opts sender.Options) error 
 		"run", ".",
 		"--web.listen-address=0.0.0.0:0",
 		fmt.Sprintf("--config.file=%s", configFile),
-		// Set important flags for the full remote write compliance:
-		"--enable-feature=st-storage",
 	}
 	if p.agentMode {
+		// Agent mode: st-storage only (agent WAL does not use XOR2 chunks).
+		args = append(args, "--enable-feature=st-storage")
 		args = append(args, fmt.Sprintf("--storage.agent.path=%v", dir), "--agent")
 	} else {
+		// Server mode: st-storage requires XOR2 chunk encoding so that start
+		// timestamps can be stored in float chunks.
+		args = append(args, "--enable-feature=st-storage,xor2-encoding")
 		args = append(args, fmt.Sprintf("--storage.tsdb.path=%v", dir))
 	}
 	return sender.RunCommand(ctx, "../cmd/prometheus", nil, "go", args...)

--- a/config/config.go
+++ b/config/config.go
@@ -1130,6 +1130,21 @@ func (t *TSDBRetentionConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
+const (
+	// FloatChunkEncodingXOR selects standard XOR encoding for float chunks.
+	FloatChunkEncodingXOR = "xor"
+	// FloatChunkEncodingXOR2 selects XOR2 encoding for float chunks; requires --enable-feature=xor2-encoding.
+	FloatChunkEncodingXOR2 = "xor2"
+)
+
+// ChunkEncodingConfig configures per-chunk-type encoding overrides.
+type ChunkEncodingConfig struct {
+	// Floats selects the encoding used for float chunks.
+	// Valid values are "xor", "xor2", and "" (empty/absent). When empty, the encoding
+	// follows the --enable-feature=xor2-encoding flag. Setting "xor2" requires the flag to be enabled.
+	Floats string `yaml:"floats,omitempty"`
+}
+
 // TSDBConfig configures runtime reloadable configuration options.
 type TSDBConfig struct {
 	// OutOfOrderTimeWindow sets how long back in time an out-of-order sample can be inserted
@@ -1147,6 +1162,9 @@ type TSDBConfig struct {
 	// the in-memory Head block. If the % of stale series crosses this threshold, stale series compaction is run immediately.
 	StaleSeriesCompactionThreshold float64 `yaml:"stale_series_compaction_threshold,omitempty"`
 
+	// ChunkEncoding configures per-chunk-type encoding overrides.
+	ChunkEncoding ChunkEncodingConfig `yaml:"chunk_encoding,omitempty"`
+
 	Retention *TSDBRetentionConfig `yaml:"retention,omitempty"`
 }
 
@@ -1159,6 +1177,13 @@ func (t *TSDBConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 
 	t.OutOfOrderTimeWindow = time.Duration(t.OutOfOrderTimeWindowFlag).Milliseconds()
+
+	switch t.ChunkEncoding.Floats {
+	case "", FloatChunkEncodingXOR, FloatChunkEncodingXOR2:
+		// Valid; no action required.
+	default:
+		return fmt.Errorf("'storage.tsdb.chunk_encoding.floats' must be 'xor' or 'xor2', or the field must be omitted entirely, got %q", t.ChunkEncoding.Floats)
+	}
 
 	if t.Retention == nil {
 		retention := DefaultTSDBRetentionConfig

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2722,6 +2722,18 @@ var expectedErrors = []struct {
 		filename: "tsdb_retention_percentage_negative.bad.yml",
 		errMsg:   "'storage.tsdb.retention.percentage' must be in the range [0, 100]",
 	},
+	{
+		filename: "tsdb_chunk_encoding_floats.bad.yml",
+		errMsg:   `'storage.tsdb.chunk_encoding.floats' must be 'xor' or 'xor2', or the field must be omitted entirely, got "xor3"`,
+	},
+	{
+		filename: "tsdb_chunk_encoding_floats_wrong_case.bad.yml",
+		errMsg:   `'storage.tsdb.chunk_encoding.floats' must be 'xor' or 'xor2', or the field must be omitted entirely, got "XOR"`,
+	},
+	{
+		filename: "tsdb_chunk_encoding_floats_wrong_case_xor2.bad.yml",
+		errMsg:   `'storage.tsdb.chunk_encoding.floats' must be 'xor' or 'xor2', or the field must be omitted entirely, got "XOR2"`,
+	},
 }
 
 func TestBadConfigs(t *testing.T) {
@@ -2736,6 +2748,27 @@ func TestTSDBRetentionPercentageFloat(t *testing.T) {
 	c, err := LoadFile("testdata/tsdb_retention_percentage_float.good.yml", false, promslog.NewNopLogger())
 	require.NoError(t, err)
 	require.Equal(t, 0.5, c.StorageConfig.TSDBConfig.Retention.Percentage)
+}
+
+func TestTSDBChunkEncoding(t *testing.T) {
+	for _, tc := range []struct {
+		filename string
+		encoding string
+	}{
+		{filename: "tsdb_chunk_encoding_floats_xor.good.yml", encoding: FloatChunkEncodingXOR},
+		{filename: "tsdb_chunk_encoding_floats_xor2.good.yml", encoding: FloatChunkEncodingXOR2},
+	} {
+		t.Run(tc.encoding, func(t *testing.T) {
+			c, err := LoadFile("testdata/"+tc.filename, false, promslog.NewNopLogger())
+			require.NoError(t, err)
+			require.Equal(t, tc.encoding, c.StorageConfig.TSDBConfig.ChunkEncoding.Floats)
+		})
+	}
+
+	// Empty/absent value is also valid.
+	c, err := Load("", promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.Empty(t, c.StorageConfig.TSDBConfig.ChunkEncoding.Floats)
 }
 
 func TestBadStaticConfigsYML(t *testing.T) {

--- a/config/testdata/tsdb_chunk_encoding_floats.bad.yml
+++ b/config/testdata/tsdb_chunk_encoding_floats.bad.yml
@@ -1,0 +1,4 @@
+storage:
+  tsdb:
+    chunk_encoding:
+      floats: xor3

--- a/config/testdata/tsdb_chunk_encoding_floats_wrong_case.bad.yml
+++ b/config/testdata/tsdb_chunk_encoding_floats_wrong_case.bad.yml
@@ -1,0 +1,4 @@
+storage:
+  tsdb:
+    chunk_encoding:
+      floats: XOR

--- a/config/testdata/tsdb_chunk_encoding_floats_wrong_case_xor2.bad.yml
+++ b/config/testdata/tsdb_chunk_encoding_floats_wrong_case_xor2.bad.yml
@@ -1,0 +1,4 @@
+storage:
+  tsdb:
+    chunk_encoding:
+      floats: XOR2

--- a/config/testdata/tsdb_chunk_encoding_floats_xor.good.yml
+++ b/config/testdata/tsdb_chunk_encoding_floats_xor.good.yml
@@ -1,0 +1,4 @@
+storage:
+  tsdb:
+    chunk_encoding:
+      floats: xor

--- a/config/testdata/tsdb_chunk_encoding_floats_xor2.good.yml
+++ b/config/testdata/tsdb_chunk_encoding_floats_xor2.good.yml
@@ -1,0 +1,4 @@
+storage:
+  tsdb:
+    chunk_encoding:
+      floats: xor2

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3977,6 +3977,25 @@ with this feature.
 # This is an experimental feature, this behaviour could change or be removed in the future.
 [ stale_series_compaction_threshold: <float> | default = 0 ]
 
+# Configures the float chunk encoding to use for new chunks.
+# Valid values are 'xor' and 'xor2'. When absent, the encoding follows the
+# --enable-feature=xor2-encoding flag: 'xor2' if the flag is set, 'xor' otherwise.
+# Setting 'xor' forces standard XOR encoding even when --enable-feature=xor2-encoding is set.
+# Setting 'xor2' is only valid when --enable-feature=xor2-encoding is set;
+# Prometheus will refuse to reload if 'xor2' is set without the feature flag.
+# Setting 'xor' is incompatible with --enable-feature=st-storage (XOR chunks do not store
+# start timestamps); Prometheus will refuse to reload in that case too.
+# Omitting 'floats' (or the entire 'chunk_encoding' field) is equivalent; the encoding
+# follows the --enable-feature=xor2-encoding flag.
+# This field is runtime-reloadable.
+# When --enable-feature=st-storage is disabled, XOR and XOR2 are compatible
+# encodings and in-progress chunks are not cut on an encoding change; the new
+# encoding takes effect when the current chunk is next cut for any reason (size, time range, or sample count).
+# When --enable-feature=st-storage is enabled, XOR and XOR2 are not compatible
+# (XOR chunks do not store start timestamps), so an in-progress chunk is cut
+# on the next append after the encoding changes.
+[ chunk_encoding:
+  [ floats: <string> ] ]
 
 # Configures data retention settings for TSDB.
 #

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -97,8 +97,9 @@ Besides enabling this feature in Prometheus, start timestamps need to be exposed
 > NOTE: This is an experimental feature with known limitations until fully implemented.
 > * It introduces new WAL record type (SamplesV2) that can only be replayed with Prometheus 3.11 or later versions.
 > * For persistent storage support (TSDB blocks), you need to manually opt-in for XOR2 chunk format ([`xor2-encoding` flag](#xor2-chunk-encoding)).
->   Without `--enable-feature=xor2-encoding`, Prometheus will emit a startup warning but continue running; start timestamps will not be stored in persistent TSDB blocks.
->   Explicitly setting `chunk_encoding.floats: xor` in the config file while `st-storage` is active is rejected at config reload.
+>   The float chunk encoding must resolve to XOR2 when `st-storage` is active, because XOR chunks do not store start timestamps.
+>   If the resolved encoding is XOR (that is, `--enable-feature=xor2-encoding` is not set and `chunk_encoding.floats: xor2` is not configured), Prometheus refuses to start and fails the configuration validation with an error rather than continuing to run.
+>   Likewise, explicitly setting `chunk_encoding.floats: xor` in the config file while `st-storage` is active is rejected at config reload.
 >   This might change later once we finish experimentation phase with XOR2.
 > * ST for native histograms and NHCBs are not yet implemented (see [#18315](https://github.com/prometheus/prometheus/issues/18315)).
 > * PromQL use of ST is out of scope of this feature.

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -96,8 +96,10 @@ Besides enabling this feature in Prometheus, start timestamps need to be exposed
 
 > NOTE: This is an experimental feature with known limitations until fully implemented.
 > * It introduces new WAL record type (SamplesV2) that can only be replayed with Prometheus 3.11 or later versions.
-> * For persistent storage support (TSDB blocks), you need to manually opt-in for XOR2 chunk format ([`xor2-encoding` flag](#xor2-chunk-encoding)). 
-> This might change later once we finish experimentation phase with XOR2.
+> * For persistent storage support (TSDB blocks), you need to manually opt-in for XOR2 chunk format ([`xor2-encoding` flag](#xor2-chunk-encoding)).
+>   Without `--enable-feature=xor2-encoding`, Prometheus will emit a startup warning but continue running; start timestamps will not be stored in persistent TSDB blocks.
+>   Explicitly setting `chunk_encoding.floats: xor` in the config file while `st-storage` is active is rejected at config reload.
+>   This might change later once we finish experimentation phase with XOR2.
 > * ST for native histograms and NHCBs are not yet implemented (see [#18315](https://github.com/prometheus/prometheus/issues/18315)).
 > * PromQL use of ST is out of scope of this feature.
 
@@ -346,9 +348,17 @@ For more details, see the [proposal](https://github.com/prometheus/proposals/pul
 > WARNING: This is highly experimental and risky setting:
 > * Chunks encoded with XOR2 **cannot be read by older Prometheus versions** that do not support the encoding. Once enabled and data is written, you need to **manually delete blocks from the disk**, otherwise Prometheus will return error on all queries.
 > * We are still experimenting on the final encoding. As of now this encoding can change in any Prometheus version. All your persistent block data will be lost between versions.
-> * This is encoding is new, meaning downstream tools and LTS systems might now support it yet (e.g. Thanos sidecar uploaded blocks).
+> * This encoding is new, meaning downstream tools and LTS systems might not support it yet (e.g. Thanos sidecar uploaded blocks).
 
-This setting enables the new XOR2 chunk encoding for float samples, which provides better disk compression than the default XOR encoding for typical Prometheus workloads. This format also allow storing Start Timestamp (ST).
+This setting enables the new XOR2 chunk encoding for float samples, which provides better disk compression than the default XOR encoding for typical Prometheus workloads. This format also allows storing Start Timestamp (ST).
+
+The encoding can also be controlled at each configuration reload via the `chunk_encoding.floats` field in the `storage.tsdb` section of the configuration file. Setting `chunk_encoding.floats: xor` forces standard XOR encoding even when `--enable-feature=xor2-encoding` is set; setting `chunk_encoding.floats: xor2` requires `--enable-feature=xor2-encoding` to be enabled.
+
+Without [`st-storage`](#start-timestamp-st-native-storage), XOR and XOR2 are compatible encodings, so an encoding change via `chunk_encoding.floats` does not cut the current chunk; the new encoding takes effect when the current chunk is next cut for any reason (size, time range, or sample count). When `st-storage` is also enabled, XOR and XOR2 are not compatible because XOR chunks do not store start timestamps, so the in-progress chunk is cut on the next append after the encoding changes.
+
+Note that `--enable-feature=st-storage` does not automatically enable XOR2 encoding.
+However, setting `chunk_encoding.floats: xor` while `st-storage` is active is rejected at
+config reload, because XOR chunks do not store start timestamps.
 
 ## Extended Range Selectors
 

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/almost"
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/prometheus/prometheus/util/convertnhcb"
@@ -161,7 +162,7 @@ func RunBuiltinTests(t TBRun, engine promql.QueryEngine) {
 	RunBuiltinTestsWithStorage(t, engine, func(t testing.TB) storage.Storage {
 		return teststorage.New(t, func(opt *tsdb.Options) {
 			opt.EnableSTStorage = true
-			opt.EnableXOR2Encoding = true
+			opt.FloatChunkEncoding = chunkenc.EncXOR2
 		})
 	})
 }

--- a/promql/promqltest/test_test.go
+++ b/promql/promqltest/test_test.go
@@ -33,7 +33,7 @@ func init() {
 	testStorageOptions = []teststorage.Option{
 		func(opts *tsdb.Options) {
 			opts.EnableSTStorage = true
-			opts.EnableXOR2Encoding = true
+			opts.FloatChunkEncoding = chunkenc.EncXOR2
 		},
 	}
 }

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1921,7 +1921,7 @@ func TestScrapeLoopAppend_StartTimeSynthesis_WithSTStorage(t *testing.T) {
 
 	s := teststorage.New(t, func(opt *tsdb.Options) {
 		opt.EnableSTStorage = true
-		opt.EnableXOR2Encoding = true
+		opt.FloatChunkEncoding = chunkenc.EncXOR2
 	})
 
 	appTest := teststorage.NewAppendable().Then(s)

--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -212,10 +212,6 @@ process_repo() {
       target_filename=".github/workflows/golangci-lint.yml"
     fi
     target_file="$(curl -sL --fail "https://raw.githubusercontent.com/${org_repo}/${default_branch}/${target_filename}")"
-    if [[ "${source_file}" == 'LICENSE' ]] && ! check_license "${target_file}" ; then
-      repo_log "LICENSE in ${org_repo} is not apache, skipping."
-      continue
-    fi
     if [[ -z "${target_file}" ]]; then
       repo_log "${target_filename} doesn't exist in ${org_repo}"
       case "${source_file}" in

--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -212,6 +212,10 @@ process_repo() {
       target_filename=".github/workflows/golangci-lint.yml"
     fi
     target_file="$(curl -sL --fail "https://raw.githubusercontent.com/${org_repo}/${default_branch}/${target_filename}")"
+    if [[ "${source_file}" == 'LICENSE' ]] && ! check_license "${target_file}" ; then
+      repo_log "LICENSE in ${org_repo} is not apache, skipping."
+      continue
+    fi
     if [[ -z "${target_file}" ]]; then
       repo_log "${target_filename} doesn't exist in ${org_repo}"
       case "${source_file}" in

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -219,6 +219,22 @@ func (v ValueType) NewChunk(useXOR2 bool) (Chunk, error) {
 	return NewEmptyChunk(v.ChunkEncoding(useXOR2))
 }
 
+// Compatible reports whether two encodings are mutually compatible, meaning a chunk
+// opened with one encoding can continue to receive appends even when the desired
+// encoding changes to the other, without requiring a new chunk to be started.
+// Data written into the existing chunk continues to use the chunk's original encoding;
+// the new encoding takes effect only when a new chunk is created.
+// The EncXOR family (EncXOR and EncXOR2) is mutually compatible; all other encoding
+// pairs, including same-histogram-type pairs, are not compatible.
+func Compatible(a, b Encoding) bool {
+	return isFloatXOREncoding(a) && isFloatXOREncoding(b)
+}
+
+// isFloatXOREncoding reports whether the encoding e belongs to the XOR float family (EncXOR or EncXOR2).
+func isFloatXOREncoding(e Encoding) bool {
+	return e == EncXOR || e == EncXOR2
+}
+
 // MockSeriesIterator returns an iterator for a mock series with custom
 // start timestamp, timestamps, and values.
 // Start timestamps is optional, pass nil or empty slice to indicate no start

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -219,14 +219,17 @@ func (v ValueType) NewChunk(useXOR2 bool) (Chunk, error) {
 	return NewEmptyChunk(v.ChunkEncoding(useXOR2))
 }
 
-// Compatible reports whether two encodings are mutually compatible, meaning a chunk
-// opened with one encoding can continue to receive appends even when the desired
-// encoding changes to the other, without requiring a new chunk to be started.
+// CompatibleValues reports whether two encodings are mutually compatible with
+// respect to sample-value encoding, meaning a chunk opened with one encoding can
+// continue to receive appends even when the desired encoding changes to the other,
+// without requiring a new chunk to be started.
 // Data written into the existing chunk continues to use the chunk's original encoding;
 // the new encoding takes effect only when a new chunk is created.
 // The EncXOR family (EncXOR and EncXOR2) is mutually compatible; all other encoding
 // pairs, including same-histogram-type pairs, are not compatible.
-func Compatible(a, b Encoding) bool {
+// This concerns only the sample-value encoding. Start timestamp (ST) compatibility
+// is a separate concern that the caller must check itself.
+func CompatibleValues(a, b Encoding) bool {
 	return isFloatXOREncoding(a) && isFloatXOREncoding(b)
 }
 

--- a/tsdb/chunkenc/chunk_test.go
+++ b/tsdb/chunkenc/chunk_test.go
@@ -240,3 +240,40 @@ func testChunkOverFlowPanics(t *testing.T, e Encoding, vt ValueType) {
 		}
 	})
 }
+
+func TestCompatible(t *testing.T) {
+	// Compatible is about whether a chunk can continue to receive appends for a
+	// different encoding without being cut. Only the XOR float family (EncXOR and
+	// EncXOR2) is mutually compatible. All other pairs — including same-type
+	// histogram pairs — return false because histogram encodings are not part of the
+	// XOR family and no cross-family compatibility is defined.
+	cases := []struct {
+		a, b Encoding
+		want bool
+	}{
+		{EncXOR, EncXOR, true},
+		{EncXOR2, EncXOR2, true},
+		{EncXOR, EncXOR2, true},
+		{EncXOR2, EncXOR, true},
+		{EncHistogram, EncHistogram, false},
+		{EncHistogram, EncFloatHistogram, false},
+		{EncFloatHistogram, EncHistogram, false},
+		{EncFloatHistogram, EncFloatHistogram, false},
+		{EncXOR, EncHistogram, false},
+		{EncXOR2, EncHistogram, false},
+		{EncXOR, EncFloatHistogram, false},
+		{EncXOR2, EncFloatHistogram, false},
+		{EncHistogram, EncXOR, false},
+		{EncHistogram, EncXOR2, false},
+		{EncFloatHistogram, EncXOR, false},
+		{EncFloatHistogram, EncXOR2, false},
+		{EncNone, EncXOR, false},
+		{EncNone, EncXOR2, false},
+		{EncXOR, EncNone, false},
+		{EncXOR2, EncNone, false},
+		{EncNone, EncNone, false},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, Compatible(tc.a, tc.b), "Compatible(%v, %v)", tc.a, tc.b)
+	}
+}

--- a/tsdb/chunkenc/chunk_test.go
+++ b/tsdb/chunkenc/chunk_test.go
@@ -241,8 +241,8 @@ func testChunkOverFlowPanics(t *testing.T, e Encoding, vt ValueType) {
 	})
 }
 
-func TestCompatible(t *testing.T) {
-	// Compatible is about whether a chunk can continue to receive appends for a
+func TestCompatibleValues(t *testing.T) {
+	// CompatibleValues is about whether a chunk can continue to receive appends for a
 	// different encoding without being cut. Only the XOR float family (EncXOR and
 	// EncXOR2) is mutually compatible. All other pairs — including same-type
 	// histogram pairs — return false because histogram encodings are not part of the
@@ -274,6 +274,6 @@ func TestCompatible(t *testing.T) {
 		{EncNone, EncNone, false},
 	}
 	for _, tc := range cases {
-		require.Equal(t, tc.want, Compatible(tc.a, tc.b), "Compatible(%v, %v)", tc.a, tc.b)
+		require.Equal(t, tc.want, CompatibleValues(tc.a, tc.b), "CompatibleValues(%v, %v)", tc.a, tc.b)
 	}
 }

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -898,10 +898,10 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64, error) {
 		opts.FloatChunkEncoding = chunkenc.EncXOR
 	}
 	if opts.FloatChunkEncoding != chunkenc.EncXOR && opts.FloatChunkEncoding != chunkenc.EncXOR2 {
-		return nil, nil, fmt.Errorf("unsupported FloatChunkEncoding %v; valid values are EncXOR and EncXOR2", opts.FloatChunkEncoding)
+		return nil, nil, fmt.Errorf("unsupported float chunk encoding %q; valid values are %q and %q", strings.ToLower(opts.FloatChunkEncoding.String()), config.FloatChunkEncodingXOR, config.FloatChunkEncodingXOR2)
 	}
 	if opts.EnableSTStorage && opts.FloatChunkEncoding == chunkenc.EncXOR {
-		return nil, nil, errors.New("FloatChunkEncoding EncXOR is incompatible with EnableSTStorage; XOR chunks do not store start timestamps, use EncXOR2")
+		return nil, nil, fmt.Errorf("float chunk encoding %q is incompatible with start-timestamp storage; XOR chunks do not store start timestamps, use %q", config.FloatChunkEncodingXOR, config.FloatChunkEncodingXOR2)
 	}
 	if opts.StripeSize <= 0 {
 		opts.StripeSize = DefaultStripeSize

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -91,6 +91,7 @@ func DefaultOptions() *Options {
 		EnableOverlappingCompaction: true,
 		EnableSharding:              false,
 		EnableDelayedCompaction:     false,
+		FloatChunkEncoding:          chunkenc.EncXOR,
 		CompactionDelayMaxPercent:   DefaultCompactionDelayMaxPercent,
 		CompactionDelay:             time.Duration(0),
 		PostingsDecoderFactory:      DefaultPostingsDecoderFactory,
@@ -240,11 +241,6 @@ type Options struct {
 	// is implemented.
 	EnableSTAsZeroSample bool
 
-	// EnableXOR2Encoding enables the XOR2 chunk encoding for float samples.
-	// XOR2 provides better compression than XOR, especially for stale markers.
-	// Automatically set to true when EnableSTStorage is true.
-	EnableXOR2Encoding bool
-
 	// EnableSTStorage determines whether TSDB should write a Start Timestamp (ST)
 	// per sample to WAL.
 	// TODO(bwplotka): Implement this option as per PROM-60, currently it's noop.
@@ -261,6 +257,14 @@ type Options struct {
 
 	// BlockReloadInterval is the interval at which blocks are reloaded.
 	BlockReloadInterval time.Duration
+
+	// FloatChunkEncoding is the encoding used for new float chunks when
+	// chunk_encoding.floats is absent from the configuration file.
+	// Defaults to EncXOR. Set to EncXOR2 to enable XOR2 encoding.
+	// Always use DefaultOptions() rather than a bare Options literal; the zero value
+	// of this field is EncNone, not EncXOR. This field is independent of EnableSTStorage:
+	// st-storage does not automatically select EncXOR2.
+	FloatChunkEncoding chunkenc.Encoding
 
 	// FeatureRegistry is used to register TSDB features.
 	FeatureRegistry features.Collector
@@ -867,7 +871,10 @@ func (db *DBReadOnly) Close() error {
 // Open returns a new DB in the given directory. If options are empty, DefaultOptions will be used.
 func Open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, stats *DBStats) (db *DB, err error) {
 	var rngs []int64
-	opts, rngs = validateOpts(opts, nil)
+	opts, rngs, err = validateOpts(opts, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	// Register TSDB features if a registry is provided.
 	if opts.FeatureRegistry != nil {
@@ -877,15 +884,24 @@ func Open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, st
 		opts.FeatureRegistry.Set(features.TSDB, "use_uncached_io", opts.UseUncachedIO)
 		opts.FeatureRegistry.Enable(features.TSDB, "native_histograms")
 		opts.FeatureRegistry.Set(features.TSDB, "st_storage", opts.EnableSTStorage)
-		opts.FeatureRegistry.Set(features.TSDB, "xor2_encoding", opts.EnableXOR2Encoding)
+		opts.FeatureRegistry.Set(features.TSDB, "xor2_encoding", opts.FloatChunkEncoding == chunkenc.EncXOR2)
 	}
 
 	return open(dir, l, r, opts, rngs, stats)
 }
 
-func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
+func validateOpts(opts *Options, rngs []int64) (*Options, []int64, error) {
 	if opts == nil {
 		opts = DefaultOptions()
+	}
+	if opts.FloatChunkEncoding == chunkenc.EncNone {
+		opts.FloatChunkEncoding = chunkenc.EncXOR
+	}
+	if opts.FloatChunkEncoding != chunkenc.EncXOR && opts.FloatChunkEncoding != chunkenc.EncXOR2 {
+		return nil, nil, fmt.Errorf("unsupported FloatChunkEncoding %v; valid values are EncXOR and EncXOR2", opts.FloatChunkEncoding)
+	}
+	if opts.EnableSTStorage && opts.FloatChunkEncoding == chunkenc.EncXOR {
+		return nil, nil, errors.New("FloatChunkEncoding EncXOR is incompatible with EnableSTStorage; XOR chunks do not store start timestamps, use EncXOR2")
 	}
 	if opts.StripeSize <= 0 {
 		opts.StripeSize = DefaultStripeSize
@@ -925,7 +941,7 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64) {
 	}
 
 	opts.staleSeriesCompactionThreshold.Store(opts.StaleSeriesCompactionThreshold)
-	return opts, rngs
+	return opts, rngs, nil
 }
 
 // open returns a new DB in the given directory.
@@ -1085,7 +1101,7 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 	headOpts.EnableSharding = opts.EnableSharding
 	headOpts.EnableSTAsZeroSample = opts.EnableSTAsZeroSample
 	headOpts.EnableSTStorage.Store(opts.EnableSTStorage)
-	headOpts.EnableXOR2Encoding.Store(opts.EnableXOR2Encoding)
+	headOpts.FloatChunkEncoding.Store(uint32(opts.FloatChunkEncoding))
 	headOpts.EnableMetadataWALRecords = opts.EnableMetadataWALRecords
 	headOpts.EnableFastStartup = opts.EnableFastStartup
 	if opts.WALReplayConcurrency > 0 {
@@ -1285,6 +1301,15 @@ func (db *DB) AppenderV2(ctx context.Context) storage.AppenderV2 {
 func (db *DB) ApplyConfig(conf *config.Config) error {
 	oooTimeWindow := int64(0)
 	if conf.StorageConfig.TSDBConfig != nil {
+		// Validate encoding config before updating the head encoding so that
+		// an invalid encoding in the config does not change the active encoding.
+		if conf.StorageConfig.TSDBConfig.ChunkEncoding.Floats == config.FloatChunkEncodingXOR2 && db.opts.FloatChunkEncoding != chunkenc.EncXOR2 {
+			return errors.New("'storage.tsdb.chunk_encoding.floats: xor2' requires the xor2-encoding feature flag to be enabled at startup")
+		}
+		// db.opts.EnableSTStorage is set once at startup and never mutated.
+		if conf.StorageConfig.TSDBConfig.ChunkEncoding.Floats == config.FloatChunkEncodingXOR && db.opts.EnableSTStorage {
+			return errors.New("'storage.tsdb.chunk_encoding.floats: xor' is incompatible with st-storage; XOR chunks do not store start timestamps")
+		}
 		oooTimeWindow = conf.StorageConfig.TSDBConfig.OutOfOrderTimeWindow
 		db.opts.staleSeriesCompactionThreshold.Store(conf.StorageConfig.TSDBConfig.StaleSeriesCompactionThreshold)
 		// Update retention configuration if provided.
@@ -1298,8 +1323,18 @@ func (db *DB) ApplyConfig(conf *config.Config) error {
 			db.metrics.maxPercentage.Set(db.opts.MaxPercentage)
 			db.retentionMtx.Unlock()
 		}
+		// Default to the startup encoding; overridden by an explicit value below.
+		effectiveEncoding := db.opts.FloatChunkEncoding
+		switch conf.StorageConfig.TSDBConfig.ChunkEncoding.Floats {
+		case config.FloatChunkEncodingXOR:
+			effectiveEncoding = chunkenc.EncXOR
+		case config.FloatChunkEncodingXOR2:
+			effectiveEncoding = chunkenc.EncXOR2
+		}
+		db.head.opts.FloatChunkEncoding.Store(uint32(effectiveEncoding))
 	} else {
 		db.opts.staleSeriesCompactionThreshold.Store(0)
+		db.head.opts.FloatChunkEncoding.Store(uint32(db.opts.FloatChunkEncoding))
 	}
 	if oooTimeWindow < 0 {
 		oooTimeWindow = 0

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -7510,14 +7510,14 @@ func TestCompactHeadWithSTStorage_AppendV2(t *testing.T) {
 	t.Parallel()
 
 	opts := &Options{
-		RetentionDuration:  int64(time.Hour * 24 * 15 / time.Millisecond),
-		NoLockfile:         true,
-		MinBlockDuration:   int64(time.Hour * 2 / time.Millisecond),
-		MaxBlockDuration:   int64(time.Hour * 2 / time.Millisecond),
-		WALCompression:     compression.Snappy,
-		EnableSTStorage:    true,
-		EnableXOR2Encoding: true,
+		RetentionDuration: int64(time.Hour * 24 * 15 / time.Millisecond),
+		NoLockfile:        true,
+		MinBlockDuration:  int64(time.Hour * 2 / time.Millisecond),
+		MaxBlockDuration:  int64(time.Hour * 2 / time.Millisecond),
+		WALCompression:    compression.Snappy,
+		EnableSTStorage:   true,
 	}
+	opts.FloatChunkEncoding = chunkenc.EncXOR2
 	db := newTestDB(t, withOpts(opts))
 	ctx := context.Background()
 	app := db.AppenderV2(ctx)
@@ -7655,7 +7655,7 @@ func TestDBAppenderV2_STStorage_OutOfOrder(t *testing.T) {
 			opts := DefaultOptions()
 			opts.OutOfOrderTimeWindow = 300 * time.Minute.Milliseconds()
 			opts.EnableSTStorage = true
-			opts.EnableXOR2Encoding = true
+			opts.FloatChunkEncoding = chunkenc.EncXOR2
 			db := newTestDB(t, withOpts(opts))
 			db.DisableCompactions()
 

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1907,7 +1907,7 @@ func TestValidateOptsInvalidFloatChunkEncoding(t *testing.T) {
 	opts := DefaultOptions()
 	opts.FloatChunkEncoding = chunkenc.EncHistogram
 	_, _, err := validateOpts(opts, nil)
-	require.ErrorContains(t, err, "unsupported FloatChunkEncoding")
+	require.ErrorContains(t, err, "unsupported float chunk encoding")
 }
 
 func TestValidateOptsSTStorageRequiresXOR2(t *testing.T) {
@@ -1916,7 +1916,7 @@ func TestValidateOptsSTStorageRequiresXOR2(t *testing.T) {
 	opts.EnableSTStorage = true
 	// Default encoding is EncXOR; combining it with EnableSTStorage must be rejected.
 	_, _, err := validateOpts(opts, nil)
-	require.ErrorContains(t, err, "incompatible with EnableSTStorage")
+	require.ErrorContains(t, err, "is incompatible with start-timestamp storage")
 
 	// EncXOR2 + st-storage must be accepted.
 	opts.FloatChunkEncoding = chunkenc.EncXOR2

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -119,12 +119,9 @@ func newTestDB(t testing.TB, opts ...testDBOpt) (db *DB) {
 	}
 
 	var err error
-	if len(o.rngs) == 0 {
-		db, err = Open(o.dir, nil, nil, o.opts, nil)
-	} else {
-		o.opts, o.rngs = validateOpts(o.opts, o.rngs)
-		db, err = open(o.dir, nil, nil, o.opts, o.rngs, nil)
-	}
+	o.opts, o.rngs, err = validateOpts(o.opts, o.rngs)
+	require.NoError(t, err)
+	db, err = open(o.dir, nil, nil, o.opts, o.rngs, nil)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -1800,6 +1797,131 @@ func TestApplyConfigRetentionDurationMetricUnit(t *testing.T) {
 	gotSeconds := prom_testutil.ToFloat64(db.metrics.retentionDuration)
 	wantSeconds := time.Hour.Seconds()
 	require.Equal(t, wantSeconds, gotSeconds)
+}
+
+// TestDBApplyConfigChunkEncoding verifies that ApplyConfig correctly
+// handles the chunk_encoding setting.
+func TestDBApplyConfigChunkEncoding(t *testing.T) {
+	xorCfg := func(floats string) *config.Config {
+		return &config.Config{StorageConfig: config.StorageConfig{
+			TSDBConfig: &config.TSDBConfig{ChunkEncoding: config.ChunkEncodingConfig{Floats: floats}},
+		}}
+	}
+
+	t.Run("xor2_without_option_returns_error", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.FloatChunkEncoding = chunkenc.EncXOR
+		db := newTestDB(t, withOpts(opts))
+		require.ErrorContains(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR2)),
+			"'storage.tsdb.chunk_encoding.floats: xor2' requires the xor2-encoding feature flag")
+	})
+
+	t.Run("explicit_xor_overrides_xor2_option", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.FloatChunkEncoding = chunkenc.EncXOR2
+		db := newTestDB(t, withOpts(opts))
+		require.NoError(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR)))
+		require.False(t, db.head.opts.UseXOR2FloatEncoding())
+		require.Equal(t, chunkenc.EncXOR2, db.opts.FloatChunkEncoding, "startup option must not be mutated")
+	})
+
+	t.Run("xor2_with_option_succeeds", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.FloatChunkEncoding = chunkenc.EncXOR2
+		db := newTestDB(t, withOpts(opts))
+		require.NoError(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR2)))
+		require.True(t, db.head.opts.UseXOR2FloatEncoding())
+	})
+
+	t.Run("empty_encoding_uses_startup_option", func(t *testing.T) {
+		for _, enc := range []chunkenc.Encoding{chunkenc.EncXOR2, chunkenc.EncXOR} {
+			t.Run(enc.String(), func(t *testing.T) {
+				opts := DefaultOptions()
+				opts.FloatChunkEncoding = enc
+				db := newTestDB(t, withOpts(opts))
+				require.NoError(t, db.ApplyConfig(xorCfg("")))
+				require.Equal(t, enc == chunkenc.EncXOR2, db.head.opts.UseXOR2FloatEncoding())
+			})
+		}
+	})
+
+	t.Run("sequential_reload_reverts_to_startup_option", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.FloatChunkEncoding = chunkenc.EncXOR2
+		db := newTestDB(t, withOpts(opts))
+
+		require.NoError(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR)))
+		require.False(t, db.head.opts.UseXOR2FloatEncoding())
+
+		require.NoError(t, db.ApplyConfig(xorCfg("")))
+		require.True(t, db.head.opts.UseXOR2FloatEncoding(), "empty encoding must revert to startup option")
+	})
+
+	t.Run("nil_TSDBConfig_resets_to_startup_option", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.FloatChunkEncoding = chunkenc.EncXOR2
+		db := newTestDB(t, withOpts(opts))
+
+		require.NoError(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR)))
+		require.False(t, db.head.opts.UseXOR2FloatEncoding())
+
+		require.NoError(t, db.ApplyConfig(&config.Config{}))
+		require.True(t, db.head.opts.UseXOR2FloatEncoding(), "nil TSDBConfig must revert to startup option")
+	})
+
+	t.Run("xor_with_st_storage_returns_error", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.FloatChunkEncoding = chunkenc.EncXOR2
+		opts.EnableSTStorage = true
+		db := newTestDB(t, withOpts(opts))
+		require.ErrorContains(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR)),
+			"incompatible with st-storage")
+	})
+}
+
+func TestHeadOptionsUseXOR2FloatEncoding(t *testing.T) {
+	t.Parallel()
+
+	opts := DefaultHeadOptions()
+	require.False(t, opts.UseXOR2FloatEncoding(), "default must be XOR, not XOR2")
+
+	opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+	require.True(t, opts.UseXOR2FloatEncoding())
+
+	opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
+	require.False(t, opts.UseXOR2FloatEncoding())
+
+	// EncNone (zero value) must not be treated as XOR2.
+	opts.FloatChunkEncoding.Store(uint32(chunkenc.EncNone))
+	require.False(t, opts.UseXOR2FloatEncoding(), "EncNone must not be treated as XOR2")
+}
+
+func TestDefaultOptionsFloatChunkEncoding(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, chunkenc.EncXOR, DefaultOptions().FloatChunkEncoding,
+		"DefaultOptions must use EncXOR as the float chunk encoding")
+}
+
+func TestValidateOptsInvalidFloatChunkEncoding(t *testing.T) {
+	t.Parallel()
+	opts := DefaultOptions()
+	opts.FloatChunkEncoding = chunkenc.EncHistogram
+	_, _, err := validateOpts(opts, nil)
+	require.ErrorContains(t, err, "unsupported FloatChunkEncoding")
+}
+
+func TestValidateOptsSTStorageRequiresXOR2(t *testing.T) {
+	t.Parallel()
+	opts := DefaultOptions()
+	opts.EnableSTStorage = true
+	// Default encoding is EncXOR; combining it with EnableSTStorage must be rejected.
+	_, _, err := validateOpts(opts, nil)
+	require.ErrorContains(t, err, "incompatible with EnableSTStorage")
+
+	// EncXOR2 + st-storage must be accepted.
+	opts.FloatChunkEncoding = chunkenc.EncXOR2
+	_, _, err = validateOpts(opts, nil)
+	require.NoError(t, err)
 }
 
 func TestNotMatcherSelectsLabelsUnsetSeries(t *testing.T) {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -173,9 +173,11 @@ type HeadOptions struct {
 	// Represents 'st-storage' feature flag.
 	EnableSTStorage atomic.Bool
 
-	// EnableXOR2Encoding enables XOR2 chunk encoding for float samples.
-	// Represents 'xor2-encoding' feature flag.
-	EnableXOR2Encoding atomic.Bool
+	// FloatChunkEncoding is the encoding applied to new float chunks.
+	// Updated atomically on config reload. Always initialise via DefaultHeadOptions();
+	// the zero value (EncNone) is not a valid sentinel.
+	// Store and load using uint32(chunkenc.Encoding) / chunkenc.Encoding(Load()).
+	FloatChunkEncoding atomic.Uint32
 
 	ChunkRange int64
 	// ChunkDirRoot is the parent directory of the chunks directory.
@@ -243,7 +245,13 @@ func DefaultHeadOptions() *HeadOptions {
 		WALReplayConcurrency: defaultWALReplayConcurrency,
 	}
 	ho.OutOfOrderCapMax.Store(DefaultOutOfOrderCapMax)
+	ho.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
 	return ho
+}
+
+// UseXOR2FloatEncoding reports whether new float chunks should use XOR2 encoding.
+func (o *HeadOptions) UseXOR2FloatEncoding() bool {
+	return chunkenc.Encoding(o.FloatChunkEncoding.Load()) == chunkenc.EncXOR2
 }
 
 // SeriesLifecycleCallback specifies a list of callbacks that will be called during a lifecycle of a series.

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -2018,8 +2018,8 @@ func (s *memSeries) appendPreprocessor(t int64, e chunkenc.Encoding, o chunkOpts
 	// switching between them does not require cutting the current chunk. When ST
 	// storage is enabled the two encodings differ in their start-timestamp support
 	// and must not be mixed within a single chunk; the o.storeST override forces
-	// an immediate cut that Compatible would otherwise allow to skip.
-	if c.chunk.Encoding() != e && (!chunkenc.Compatible(c.chunk.Encoding(), e) || o.storeST) {
+	// an immediate cut that CompatibleValues would otherwise allow to skip.
+	if c.chunk.Encoding() != e && (!chunkenc.CompatibleValues(c.chunk.Encoding(), e) || o.storeST) {
 		c = s.cutNewHeadChunk(t, e, o.chunkRange)
 		chunkCreated = true
 	}

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -191,7 +191,7 @@ func (h *Head) appender() *headAppender {
 			appendID:              appendID,
 			cleanupAppendIDsBelow: cleanupAppendIDsBelow,
 			storeST:               h.opts.EnableSTStorage.Load(),
-			useXOR2:               h.opts.EnableXOR2Encoding.Load(),
+			useXOR2:               h.opts.UseXOR2FloatEncoding(),
 		},
 	}
 }
@@ -419,8 +419,8 @@ type headAppenderBase struct {
 
 	appendID, cleanupAppendIDsBelow uint64
 	closed                          bool
-	storeST                         bool
-	useXOR2                         bool
+	storeST                         bool // Whether start-timestamp storage is enabled for this append.
+	useXOR2                         bool // Whether XOR2 encoding is used for float chunks in this append.
 }
 type headAppender struct {
 	headAppenderBase
@@ -1755,6 +1755,7 @@ func (a *headAppenderBase) Commit() (err error) {
 			chunkRange:      h.chunkRange.Load(),
 			samplesPerChunk: h.opts.SamplesPerChunk,
 			useXOR2:         a.useXOR2,
+			storeST:         a.storeST,
 		},
 		oooEnc: record.Encoder{
 			EnableSTStorage: a.storeST,
@@ -1842,6 +1843,7 @@ type chunkOpts struct {
 	chunkRange      int64
 	samplesPerChunk int
 	useXOR2         bool // Selects XOR2 encoding for float chunks.
+	storeST         bool // Whether start-timestamp storage is enabled.
 }
 
 // append adds the sample (t, v) to the series. The caller also has to provide
@@ -2012,9 +2014,12 @@ func (s *memSeries) appendPreprocessor(t int64, e chunkenc.Encoding, o chunkOpts
 		chunkCreated = true
 	}
 
-	if c.chunk.Encoding() != e {
-		// The chunk encoding expected by this append is different than the head chunk's
-		// encoding. So we cut a new chunk with the expected encoding.
+	// XOR and XOR2 are compatible float encodings when ST storage is disabled:
+	// switching between them does not require cutting the current chunk. When ST
+	// storage is enabled the two encodings differ in their start-timestamp support
+	// and must not be mixed within a single chunk; the o.storeST override forces
+	// an immediate cut that Compatible would otherwise allow to skip.
+	if c.chunk.Encoding() != e && (!chunkenc.Compatible(c.chunk.Encoding(), e) || o.storeST) {
 		c = s.cutNewHeadChunk(t, e, o.chunkRange)
 		chunkCreated = true
 	}

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -96,7 +96,7 @@ func (h *Head) appenderV2() *headAppenderV2 {
 			appendID:              appendID,
 			cleanupAppendIDsBelow: cleanupAppendIDsBelow,
 			storeST:               h.opts.EnableSTStorage.Load(),
-			useXOR2:               h.opts.EnableXOR2Encoding.Load(),
+			useXOR2:               h.opts.UseXOR2FloatEncoding(),
 		},
 	}
 }

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -3007,7 +3007,11 @@ func testWBLReplayAppenderV2(t *testing.T, scenario sampleTypeScenario, enableST
 	opts.ChunkDirRoot = dir
 	opts.OutOfOrderTimeWindow.Store(30 * time.Minute.Milliseconds())
 	opts.EnableSTStorage.Store(enableSTstorage)
-	opts.EnableXOR2Encoding.Store(enableSTstorage)
+	if enableSTstorage {
+		opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+	} else {
+		opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
+	}
 
 	h, err := NewHead(nil, nil, wal, oooWlog, opts, nil)
 	require.NoError(t, err)
@@ -3059,7 +3063,7 @@ func testWBLReplayAppenderV2(t *testing.T, scenario sampleTypeScenario, enableST
 	require.False(t, ok)
 	require.NotNil(t, ms)
 
-	chks, err := ms.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, h.opts.EnableXOR2Encoding.Load())
+	chks, err := ms.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, h.opts.UseXOR2FloatEncoding())
 	require.NoError(t, err)
 	require.Len(t, chks, 1)
 
@@ -4981,7 +4985,7 @@ func TestHeadAppenderV2_STStorage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
 			opts.EnableSTStorage.Store(true)
-			opts.EnableXOR2Encoding.Store(true)
+			opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
 			h, _ := newTestHeadWithOptions(t, compression.None, opts)
 
 			lbls := labels.FromStrings("foo", "bar")

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -7823,7 +7823,11 @@ func TestHeadAppender_WALEncoder_EnableSTStorage(t *testing.T) {
 		t.Run(fmt.Sprintf("enableSTStorage=%v", enableST), func(t *testing.T) {
 			opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
 			opts.EnableSTStorage.Store(enableST)
-			opts.EnableXOR2Encoding.Store(enableST)
+			if enableST {
+				opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+			} else {
+				opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
+			}
 			h, w := newTestHeadWithOptions(t, compression.None, opts)
 
 			lbls := labels.FromStrings("foo", "bar")
@@ -7879,7 +7883,11 @@ func TestHeadAppender_WBLEncoder_EnableSTStorage(t *testing.T) {
 			opts.ChunkDirRoot = dir
 			opts.OutOfOrderTimeWindow.Store(60 * time.Minute.Milliseconds())
 			opts.EnableSTStorage.Store(enableST)
-			opts.EnableXOR2Encoding.Store(enableST)
+			if enableST {
+				opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+			} else {
+				opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
+			}
 
 			h, err := NewHead(nil, nil, wal, wbl, opts, nil)
 			require.NoError(t, err)
@@ -7998,7 +8006,7 @@ func TestHeadAppender_STStorage_Disabled(t *testing.T) {
 func TestHeadAppender_STStorage_WALReplay(t *testing.T) {
 	opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
 	opts.EnableSTStorage.Store(true)
-	opts.EnableXOR2Encoding.Store(true)
+	opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
 	h, w := newTestHeadWithOptions(t, compression.None, opts)
 
 	lbls := labels.FromStrings("foo", "bar")
@@ -8033,6 +8041,59 @@ func TestHeadAppender_STStorage_WALReplay(t *testing.T) {
 	require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: expected}, got)
 }
 
+// TestWALReplayStoreSTPassed is a regression test verifying that processWALSamples
+// passes storeST to chunkOpts. Without storeST, a WAL written with EncXOR would be
+// replayed into an EncXOR2+STStorage head without cutting the in-progress XOR chunk
+// (Compatible returns true for the XOR family), silently continuing a chunk that
+// cannot hold start timestamps. With storeST set, the encoding mismatch forces an
+// immediate chunk cut.
+func TestWALReplayStoreSTPassed(t *testing.T) {
+	// Phase 1: write a WAL with EncXOR and no ST storage.
+	opts1 := newTestHeadDefaultOptions(DefaultBlockDuration, false)
+	opts1.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
+	h, w := newTestHeadWithOptions(t, compression.None, opts1)
+
+	lbls := labels.FromStrings("foo", "bar")
+
+	app := h.Appender(context.Background())
+	for ts := int64(1); ts <= 5; ts++ {
+		_, err := app.Append(0, lbls, ts, float64(ts))
+		require.NoError(t, err)
+	}
+	require.NoError(t, app.Commit())
+	require.NoError(t, h.Close())
+
+	// Phase 2: replay the WAL with EncXOR2 + ST storage enabled. If storeST were
+	// not passed during WAL replay, the XOR chunk loaded from the chunk snapshot
+	// would be continued with EncXOR2 appends (Compatible = true, no cut), which
+	// would produce a chunk that cannot store start timestamps.
+	opts2 := newTestHeadDefaultOptions(DefaultBlockDuration, false)
+	opts2.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+	opts2.EnableSTStorage.Store(true)
+	opts2.ChunkDirRoot = h.opts.ChunkDirRoot
+
+	w2, err := wlog.New(nil, nil, w.Dir(), compression.None)
+	require.NoError(t, err)
+	h2, err := NewHead(nil, nil, w2, nil, opts2, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h2.Close() })
+	require.NoError(t, h2.Init(0))
+
+	// Append one post-replay sample with a start timestamp to confirm the active
+	// chunk is EncXOR2 (which can store ST).
+	app2 := h2.Appender(context.Background())
+	_, err = app2.Append(0, lbls, 10, 10.0)
+	require.NoError(t, err)
+	require.NoError(t, app2.Commit())
+
+	ms, created, err := h2.getOrCreate(lbls.Hash(), lbls, false)
+	require.NoError(t, err)
+	require.False(t, created)
+	require.NotNil(t, ms.headChunks)
+	require.Equal(t, chunkenc.EncXOR2, ms.headChunks.chunk.Encoding(),
+		"active chunk after WAL replay into EncXOR2+STStorage head must use EncXOR2")
+}
+
 // TestHeadAppender_STStorage_WBLReplay verifies that ST values are preserved
 // across a WBL replay for out-of-order samples when EnableSTStorage is true.
 // The bug was that collectOOORecords() hardcoded EnableSTStorage=false in the
@@ -8050,7 +8111,7 @@ func TestHeadAppender_STStorage_WBLReplay(t *testing.T) {
 	opts.ChunkDirRoot = dir
 	opts.OutOfOrderTimeWindow.Store(60 * time.Minute.Milliseconds())
 	opts.EnableSTStorage.Store(true)
-	opts.EnableXOR2Encoding.Store(true)
+	opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
 
 	h, err := NewHead(nil, nil, wal, wbl, opts, nil)
 	require.NoError(t, err)
@@ -8113,6 +8174,60 @@ func TestHeadAppender_STStorage_WBLReplay(t *testing.T) {
 	require.Equal(t, expected, got)
 }
 
+// TestHeadAppender_STStorage_WALReplay_CrossEncoding verifies that WAL replay
+// correctly handles a cross-encoding migration: samples written with EncXOR and
+// no ST storage are replayed with EncXOR2+STStorage enabled. Since the original
+// WAL records are V1 (no ST), the replayed samples have ST=0. The in-memory
+// chunks must use EncXOR2 (the replay-time encoding).
+func TestHeadAppender_STStorage_WALReplay_CrossEncoding(t *testing.T) {
+	// Phase 1: write with EncXOR, no ST storage.
+	opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
+	opts.EnableSTStorage.Store(false)
+	opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
+	h, w := newTestHeadWithOptions(t, compression.None, opts)
+
+	lbls := labels.FromStrings("foo", "bar")
+
+	a := h.Appender(context.Background())
+	for ts := int64(100); ts < 110; ts++ {
+		_, err := a.Append(0, lbls, ts, float64(ts))
+		require.NoError(t, err)
+	}
+	require.NoError(t, a.Commit())
+	require.NoError(t, h.Close())
+
+	// Phase 2: reopen with EncXOR2+STStorage=true (migration to ST storage).
+	w, err := wlog.New(nil, nil, w.Dir(), compression.None)
+	require.NoError(t, err)
+	opts.ChunkDirRoot = h.opts.ChunkDirRoot
+	opts.EnableSTStorage.Store(true)
+	opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+	h2, err := NewHead(nil, nil, w, nil, opts, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h2.Close() })
+	require.NoError(t, h2.Init(0))
+
+	// Data must survive the replay; ST values are 0 because the WAL records
+	// were written without ST storage (V1 records carry no ST).
+	q, err := NewBlockQuerier(h2, 100, 109)
+	require.NoError(t, err)
+	got := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+
+	var expected []chunks.Sample
+	for ts := int64(100); ts < 110; ts++ {
+		expected = append(expected, sample{0, ts, float64(ts), nil, nil})
+	}
+	require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: expected}, got)
+
+	// Verify the in-memory head chunk uses EncXOR2 (replay-time encoding).
+	ms, created, err := h2.getOrCreate(lbls.Hash(), lbls, false)
+	require.NoError(t, err)
+	require.False(t, created)
+	require.NotNil(t, ms.headChunks)
+	require.Equal(t, chunkenc.EncXOR2, ms.headChunks.chunk.Encoding(),
+		"chunks after replay into EncXOR2+STStorage head must use EncXOR2")
+}
+
 // TestHeadAppender_STStorage_ChunkEncoding verifies that the correct chunk encoding
 // is used based on EnableSTStorage setting.
 func TestHeadAppender_STStorage_ChunkEncoding(t *testing.T) {
@@ -8129,7 +8244,11 @@ func TestHeadAppender_STStorage_ChunkEncoding(t *testing.T) {
 		t.Run(fmt.Sprintf("EnableSTStorage=%t", enableST), func(t *testing.T) {
 			opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
 			opts.EnableSTStorage.Store(enableST)
-			opts.EnableXOR2Encoding.Store(enableST) // ST storage implies XOR2 encoding.
+			if enableST {
+				opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+			} else {
+				opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
+			}
 			h, _ := newTestHeadWithOptions(t, compression.None, opts)
 
 			lbls := labels.FromStrings("foo", "bar")
@@ -8178,6 +8297,204 @@ func TestHeadAppender_STStorage_ChunkEncoding(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFloatChunkEncodingSwitchWaitsForNextChunk validates the chunk-cut behaviour when
+// the float chunk encoding changes between XOR and XOR2. When ST storage is disabled
+// the two encodings are compatible and in-progress chunks are not cut; the new encoding
+// takes effect only when the current chunk fills up naturally. When ST storage is enabled
+// the encodings are not compatible (XOR cannot store start timestamps) and an encoding
+// switch — in either direction (XOR2→XOR or XOR→XOR2) — must cut the current chunk
+// immediately.
+func TestFloatChunkEncodingSwitchWaitsForNextChunk(t *testing.T) {
+	t.Run("without_st_storage", func(t *testing.T) {
+		opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
+		opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+		h, _ := newTestHeadWithOptions(t, compression.None, opts)
+		require.NoError(t, h.Init(0))
+
+		lbls := labels.FromStrings("foo", "bar")
+
+		// Phase 1: Start appending while XOR2 is enabled.
+		app1 := h.Appender(context.Background())
+		for ts := int64(1); ts <= 5; ts++ {
+			_, err := app1.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app1.Commit())
+
+		// Simulate a config reload that switches encoding to XOR.
+		h.opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
+
+		// A new appender picks up useXOR2=false, but the existing XOR2 chunk must
+		// not be cut — XOR and XOR2 are compatible when ST is disabled.
+		app2 := h.Appender(context.Background())
+		for ts := int64(6); ts <= 10; ts++ {
+			_, err := app2.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app2.Commit())
+
+		// The head chunk must still be XOR2: encoding change does not cut chunks.
+		ms, created, err := h.getOrCreate(lbls.Hash(), lbls, false)
+		require.NoError(t, err)
+		require.False(t, created)
+		require.NotNil(t, ms.headChunks)
+		require.Nil(t, ms.headChunks.prev, "chunk must not have been cut; only one chunk must exist after encoding switch without ST storage")
+		require.Equal(t, chunkenc.EncXOR2, ms.headChunks.chunk.Encoding(),
+			"in-progress chunk must keep XOR2 encoding after encoding switch")
+
+		// Phase 2: Fill the current chunk past its natural size limit so that a new
+		// chunk is started. The new chunk must use the updated XOR encoding.
+		// We append enough samples to guarantee at least one natural chunk cut.
+		app3 := h.Appender(context.Background())
+		for ts := int64(11); ts <= int64(DefaultSamplesPerChunk*3); ts++ {
+			_, err := app3.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app3.Commit())
+
+		ms, _, err = h.getOrCreate(lbls.Hash(), lbls, false)
+		require.NoError(t, err)
+		require.NotNil(t, ms.headChunks)
+		require.NotNil(t, ms.headChunks.prev, "at least one chunk cut must have occurred during phase 2")
+		require.Equal(t, chunkenc.EncXOR, ms.headChunks.chunk.Encoding(),
+			"new chunk after natural boundary must use XOR encoding")
+	})
+
+	t.Run("with_st_storage", func(t *testing.T) {
+		opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
+		opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+		opts.EnableSTStorage.Store(true)
+		h, _ := newTestHeadWithOptions(t, compression.None, opts)
+		require.NoError(t, h.Init(0))
+
+		lbls := labels.FromStrings("foo", "bar")
+
+		// Phase 1: Start appending while XOR2 is enabled.
+		app1 := h.Appender(context.Background())
+		for ts := int64(1); ts <= 5; ts++ {
+			_, err := app1.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app1.Commit())
+
+		// Verify the in-progress chunk is XOR2.
+		ms, created, err := h.getOrCreate(lbls.Hash(), lbls, false)
+		require.NoError(t, err)
+		require.False(t, created)
+		require.Equal(t, chunkenc.EncXOR2, ms.headChunks.chunk.Encoding(),
+			"chunk must be XOR2 before encoding switch")
+
+		// Simulate a config reload that switches encoding to XOR.
+		h.opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
+
+		// With ST storage enabled, XOR and XOR2 are NOT compatible. The first
+		// append after the encoding switch must cut the current XOR2 chunk and
+		// start a new XOR chunk.
+		app2 := h.Appender(context.Background())
+		_, err = app2.Append(0, lbls, 6, 6)
+		require.NoError(t, err)
+		require.NoError(t, app2.Commit())
+
+		ms, _, err = h.getOrCreate(lbls.Hash(), lbls, false)
+		require.NoError(t, err)
+		require.NotNil(t, ms.headChunks)
+		require.Equal(t, chunkenc.EncXOR, ms.headChunks.chunk.Encoding(),
+			"encoding switch with ST storage must cut chunk immediately")
+		require.NotNil(t, ms.headChunks.prev,
+			"the old XOR2 chunk must exist as a previous chunk after the cut")
+		require.Equal(t, chunkenc.EncXOR2, ms.headChunks.prev.chunk.Encoding(),
+			"the evicted chunk must retain its original XOR2 encoding")
+	})
+
+	t.Run("with_st_storage_xor_to_xor2", func(t *testing.T) {
+		// Start with XOR encoding and then switch to XOR2 while ST storage is
+		// enabled. The encoding switch must cut the current XOR chunk immediately
+		// because XOR does not store start timestamps.
+		opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
+		opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
+		opts.EnableSTStorage.Store(true)
+		h, _ := newTestHeadWithOptions(t, compression.None, opts)
+		require.NoError(t, h.Init(0))
+
+		lbls := labels.FromStrings("foo", "bar")
+
+		// Phase 1: Start appending while XOR is active.
+		app1 := h.Appender(context.Background())
+		for ts := int64(1); ts <= 5; ts++ {
+			_, err := app1.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app1.Commit())
+
+		// Verify the in-progress chunk is XOR.
+		ms, created, err := h.getOrCreate(lbls.Hash(), lbls, false)
+		require.NoError(t, err)
+		require.False(t, created)
+		require.Equal(t, chunkenc.EncXOR, ms.headChunks.chunk.Encoding(),
+			"chunk must be XOR before encoding switch")
+
+		// Simulate a config reload that switches encoding to XOR2.
+		h.opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+
+		// With ST storage enabled, the first append must cut the XOR chunk and
+		// start a new XOR2 chunk.
+		app2 := h.Appender(context.Background())
+		_, err = app2.Append(0, lbls, 6, 6)
+		require.NoError(t, err)
+		require.NoError(t, app2.Commit())
+
+		ms, _, err = h.getOrCreate(lbls.Hash(), lbls, false)
+		require.NoError(t, err)
+		require.NotNil(t, ms.headChunks)
+		require.Equal(t, chunkenc.EncXOR2, ms.headChunks.chunk.Encoding(),
+			"encoding switch with ST storage must cut chunk immediately")
+		require.NotNil(t, ms.headChunks.prev,
+			"the old XOR chunk must exist as a previous chunk after the cut")
+		require.Equal(t, chunkenc.EncXOR, ms.headChunks.prev.chunk.Encoding(),
+			"the evicted chunk must retain its original XOR encoding")
+	})
+
+	t.Run("without_st_storage_xor_to_xor2", func(t *testing.T) {
+		// Start with XOR encoding and switch to XOR2 while ST storage is disabled.
+		// The existing XOR chunk must not be cut — XOR and XOR2 are compatible
+		// when ST is disabled.
+		opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
+		opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR))
+		opts.EnableSTStorage.Store(false)
+		h, _ := newTestHeadWithOptions(t, compression.None, opts)
+		require.NoError(t, h.Init(0))
+
+		lbls := labels.FromStrings("foo", "bar")
+
+		app1 := h.Appender(context.Background())
+		for ts := int64(1); ts <= 5; ts++ {
+			_, err := app1.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app1.Commit())
+
+		// Switch to XOR2.
+		h.opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+
+		app2 := h.Appender(context.Background())
+		for ts := int64(6); ts <= 10; ts++ {
+			_, err := app2.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app2.Commit())
+
+		// The head chunk must still be XOR: encoding change does not cut chunks
+		// when ST storage is disabled.
+		ms, created, err := h.getOrCreate(lbls.Hash(), lbls, false)
+		require.NoError(t, err)
+		require.False(t, created)
+		require.NotNil(t, ms.headChunks)
+		require.Nil(t, ms.headChunks.prev, "chunk must not have been cut; only one chunk must exist after encoding switch without ST storage")
+		require.Equal(t, chunkenc.EncXOR, ms.headChunks.chunk.Encoding(),
+			"in-progress chunk must keep XOR encoding after encoding switch")
+	})
 }
 
 // TestWALReplayRaceWithStaleSeriesCompaction verifies that deleteSeriesByID correctly locks the

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -8044,7 +8044,7 @@ func TestHeadAppender_STStorage_WALReplay(t *testing.T) {
 // TestWALReplayStoreSTPassed is a regression test verifying that processWALSamples
 // passes storeST to chunkOpts. Without storeST, a WAL written with EncXOR would be
 // replayed into an EncXOR2+STStorage head without cutting the in-progress XOR chunk
-// (Compatible returns true for the XOR family), silently continuing a chunk that
+// (CompatibleValues returns true for the XOR family), silently continuing a chunk that
 // cannot hold start timestamps. With storeST set, the encoding mismatch forces an
 // immediate chunk cut.
 func TestWALReplayStoreSTPassed(t *testing.T) {
@@ -8065,7 +8065,7 @@ func TestWALReplayStoreSTPassed(t *testing.T) {
 
 	// Phase 2: replay the WAL with EncXOR2 + ST storage enabled. If storeST were
 	// not passed during WAL replay, the XOR chunk loaded from the chunk snapshot
-	// would be continued with EncXOR2 appends (Compatible = true, no cut), which
+	// would be continued with EncXOR2 appends (CompatibleValues = true, no cut), which
 	// would produce a chunk that cannot store start timestamps.
 	opts2 := newTestHeadDefaultOptions(DefaultBlockDuration, false)
 	opts2.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -673,11 +673,16 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 
 	minValidTime := h.minValidTime.Load()
 	mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)
+	// storeST must be passed here so that appendPreprocessor cuts an in-progress
+	// XOR chunk immediately when replaying into a head with ST storage enabled.
+	// XOR chunks cannot store start timestamps and must not be continued with
+	// XOR2 appends when ST storage is active.
 	appendChunkOpts := chunkOpts{
 		chunkDiskMapper: h.chunkDiskMapper,
 		chunkRange:      h.chunkRange.Load(),
 		samplesPerChunk: h.opts.SamplesPerChunk,
-		useXOR2:         h.opts.EnableXOR2Encoding.Load(),
+		useXOR2:         h.opts.UseXOR2FloatEncoding(),
+		storeST:         h.opts.EnableSTStorage.Load(),
 	}
 
 	for in := range wp.input {
@@ -1126,11 +1131,15 @@ func (wp *wblSubsetProcessor) processWBLSamples(h *Head) (map[chunks.HeadSeriesR
 	var unknownSampleRefs, unknownHistogramRefs uint64
 
 	oooCapMax := h.opts.OutOfOrderCapMax.Load()
+	// storeST must be passed here for the same reason as in processWALSamples: so
+	// that appendPreprocessor forces an immediate chunk cut when an XOR chunk is
+	// encountered during replay into a head with ST storage enabled.
 	appendChunkOpts := chunkOpts{
 		chunkDiskMapper: h.chunkDiskMapper,
 		chunkRange:      h.chunkRange.Load(),
 		samplesPerChunk: h.opts.SamplesPerChunk,
-		useXOR2:         h.opts.EnableXOR2Encoding.Load(),
+		useXOR2:         h.opts.UseXOR2FloatEncoding(),
+		storeST:         h.opts.EnableSTStorage.Load(),
 	}
 	// We don't check for minValidTime for ooo samples.
 	mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -77,7 +77,7 @@ func (oh *HeadAndOOOIndexReader) Series(ref storage.SeriesRef, builder *labels.S
 	*chks = (*chks)[:0]
 
 	if s.ooo != nil {
-		oh.headChunksBuf = getOOOSeriesChunks(s, oh.head.opts.EnableXOR2Encoding.Load(), oh.mint, oh.maxt, oh.lastGarbageCollectedMmapRef, 0, true, oh.inoMint, chks, oh.headChunksBuf)
+		oh.headChunksBuf = getOOOSeriesChunks(s, oh.head.opts.UseXOR2FloatEncoding(), oh.mint, oh.maxt, oh.lastGarbageCollectedMmapRef, 0, true, oh.inoMint, chks, oh.headChunksBuf)
 	} else {
 		*chks, oh.headChunksBuf = appendSeriesChunks(s, oh.inoMint, oh.maxt, *chks, oh.headChunksBuf)
 	}
@@ -391,7 +391,7 @@ func NewOOOCompactionHead(ctx context.Context, head *Head) (*OOOCompactionHead, 
 		}
 
 		var lastMmapRef chunks.ChunkDiskMapperRef
-		mmapRefs := ms.mmapCurrentOOOHeadChunk(chunkOpts{chunkDiskMapper: head.chunkDiskMapper, useXOR2: head.opts.EnableXOR2Encoding.Load()}, head.logger)
+		mmapRefs := ms.mmapCurrentOOOHeadChunk(chunkOpts{chunkDiskMapper: head.chunkDiskMapper, useXOR2: head.opts.UseXOR2FloatEncoding()}, head.logger)
 		if len(mmapRefs) == 0 && len(ms.ooo.oooMmappedChunks) > 0 {
 			// Nothing was m-mapped. So take the mmapRef from the existing slice if it exists.
 			mmapRefs = []chunks.ChunkDiskMapperRef{ms.ooo.oooMmappedChunks[len(ms.ooo.oooMmappedChunks)-1].ref}
@@ -525,7 +525,7 @@ func (ir *OOOCompactionHeadIndexReader) Series(ref storage.SeriesRef, builder *l
 		return nil
 	}
 
-	getOOOSeriesChunks(s, ir.ch.head.opts.EnableXOR2Encoding.Load(), ir.ch.mint, ir.ch.maxt, 0, ir.ch.lastMmapRef, false, 0, chks, nil)
+	getOOOSeriesChunks(s, ir.ch.head.opts.UseXOR2FloatEncoding(), ir.ch.mint, ir.ch.maxt, 0, ir.ch.lastMmapRef, false, 0, chks, nil)
 	return nil
 }
 

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3990,6 +3990,9 @@ func testChunkQuerierOverlappingInOrderAndOOOChunks(t *testing.T, valType chunke
 	opts.OutOfOrderCapMax = oooCapMax
 	opts.OutOfOrderTimeWindow = 24 * time.Hour.Milliseconds()
 	opts.EnableSTStorage = storeST
+	if storeST {
+		opts.FloatChunkEncoding = chunkenc.EncXOR2
+	}
 	db := newTestDB(t, withOpts(opts))
 	db.DisableCompactions()
 


### PR DESCRIPTION
Add a new `storage.tsdb.chunk_encoding.floats` configuration field that allows operators to select the float chunk encoding (`xor` or `xor2`) independently of the `--enable-feature=xor2-encoding` startup flag.

When the field is absent the encoding follows the feature flag as before. Setting `xor` forces standard XOR encoding even when the feature flag is set. Setting `xor2` is only valid when the feature flag is set, and Prometheus will refuse to reload the config otherwise. The field is runtime-reloadable.

Add `chunkenc.Compatible(a, b Encoding)` to express that `EncXOR` and `EncXOR2` are interchangeable at append time when ST (start-timestamp) storage is disabled. The `appendPreprocessor` in `head_append.go` uses this to avoid cutting an in-progress chunk on an encoding change; the new encoding takes effect at the next natural chunk boundary. When ST storage is enabled, the two encodings are not compatible because XOR chunks do not store start timestamps, so the chunk is cut immediately on the next append.

Propagate `storeST` through `chunkOpts` so that both WAL and WBL replay paths correctly apply the ST-storage compatibility rule when restoring chunks.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[FEATURE] TSDB: Add `storage.tsdb.chunk_encoding.floats` configuration field to select float chunk encoding (`xor` or `xor2`) at runtime, independently of the `--enable-feature=xor2-encoding` flag.
```