### PR TITLE
promql/parser: support wrapped number literals as matrix range duration

### DIFF
--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -133,9 +133,9 @@ type MatrixSelector struct {
 	// It is safe to assume that this is an VectorSelector
 	// if the parser hasn't returned an error.
 	VectorSelector Expr
-	Range          time.Duration
-	RangeExpr      *DurationExpr
-	EndPos         posrange.Pos
+	Range     time.Duration
+	RangeExpr Expr
+	EndPos    posrange.Pos
 }
 
 // SubqueryExpr represents a subquery.
@@ -164,6 +164,7 @@ type NumberLiteral struct {
 	Val float64
 
 	Duration bool // Used to format the number as a duration.
+	Wrapped  bool // Set when the duration literal is wrapped in parentheses.
 	PosRange posrange.PositionRange
 }
 

--- a/promql/parser/generated_parser.y
+++ b/promql/parser/generated_parser.y
@@ -662,10 +662,17 @@ matrix_selector : expr LEFT_BRACKET positive_duration_expr RIGHT_BRACKET
                         }
 
                         var rangeNl time.Duration
-                        if numLit, ok := $3.(*NumberLiteral); ok {
-                                rangeNl = time.Duration(math.Round(numLit.Val*float64(time.Second)))
+                        var rangeExpr Expr
+                        switch e := $3.(type) {
+                        case *NumberLiteral:
+                                if e.Wrapped {
+                                        rangeExpr = e
+                                } else {
+                                        rangeNl = time.Duration(math.Round(e.Val*float64(time.Second)))
+                                }
+                        case *DurationExpr:
+                                rangeExpr = e
                         }
-                        rangeExpr, _ := $3.(*DurationExpr)
                         $$ = &MatrixSelector{
                                 VectorSelector: $1.(Expr),
                                 Range: rangeNl,
@@ -1397,12 +1404,16 @@ duration_expr   : number_duration_literal
 paren_duration_expr : LEFT_PAREN duration_expr RIGHT_PAREN
                         {
                             yylex.(*parser).experimentalDurationExpr($2.(Expr))
-                            if durationExpr, ok := $2.(*DurationExpr); ok {
-                                durationExpr.Wrapped = true
-                                $$ = durationExpr
-                                break
+                            switch expr := $2.(type) {
+                            case *DurationExpr:
+                                expr.Wrapped = true
+                                $$ = expr
+                            case *NumberLiteral:
+                                expr.Wrapped = true
+                                $$ = expr
+                            default:
+                                $$ = $2
                             }
-                            $$ = $2
                         }
                 ;
 

--- a/promql/parser/generated_parser.y.go
+++ b/promql/parser/generated_parser.y.go
@@ -1723,10 +1723,17 @@ yydefault:
 			}
 
 			var rangeNl time.Duration
-			if numLit, ok := yyDollar[3].node.(*NumberLiteral); ok {
-				rangeNl = time.Duration(math.Round(numLit.Val * float64(time.Second)))
+			var rangeExpr Expr
+			switch e := yyDollar[3].node.(type) {
+			case *NumberLiteral:
+				if e.Wrapped {
+					rangeExpr = e
+				} else {
+					rangeNl = time.Duration(math.Round(e.Val * float64(time.Second)))
+				}
+			case *DurationExpr:
+				rangeExpr = e
 			}
-			rangeExpr, _ := yyDollar[3].node.(*DurationExpr)
 			yyVAL.node = &MatrixSelector{
 				VectorSelector: yyDollar[1].node.(Expr),
 				Range:          rangeNl,
@@ -2541,12 +2548,16 @@ yydefault:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yylex.(*parser).experimentalDurationExpr(yyDollar[2].node.(Expr))
-			if durationExpr, ok := yyDollar[2].node.(*DurationExpr); ok {
-				durationExpr.Wrapped = true
-				yyVAL.node = durationExpr
-				break
+			switch expr := yyDollar[2].node.(type) {
+			case *DurationExpr:
+				expr.Wrapped = true
+				yyVAL.node = expr
+			case *NumberLiteral:
+				expr.Wrapped = true
+				yyVAL.node = expr
+			default:
+				yyVAL.node = yyDollar[2].node
 			}
-			yyVAL.node = yyDollar[2].node
 		}
 	}
 	goto yystack /* stack new state and value */

--- a/promql/parser/printer.go
+++ b/promql/parser/printer.go
@@ -356,13 +356,20 @@ func (node *SubqueryExpr) getSubqueryTimeSuffix() string {
 }
 
 func (node *NumberLiteral) String() string {
+	var s string
 	if node.Duration {
 		if node.Val < 0 {
-			return fmt.Sprintf("-%s", model.Duration(-node.Val*1e9).String())
+			s = fmt.Sprintf("-%s", model.Duration(-node.Val*1e9).String())
+		} else {
+			s = model.Duration(node.Val * 1e9).String()
 		}
-		return model.Duration(node.Val * 1e9).String()
+	} else {
+		s = strconv.FormatFloat(node.Val, 'f', -1, 64)
 	}
-	return strconv.FormatFloat(node.Val, 'f', -1, 64)
+	if node.Wrapped {
+		return "(" + s + ")"
+	}
+	return s
 }
 
 func (node *ParenExpr) String() string {

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -147,6 +147,13 @@ func TestExprString(t *testing.T) {
 			in: `a{c="d"}[5m] offset 1m`,
 		},
 		{
+			in: `a[(5m)]`,
+		},
+		{
+			in:  `a[0+(5m)]`,
+			out: `a[0 + (5m)]`,
+		},
+		{
 			in: `a[5m] offset 1m`,
 		},
 		{


### PR DESCRIPTION
Extend MatrixSelector.RangeExpr to type Expr (was *DurationExpr) so it can hold a wrapped NumberLiteral such as metric[(5)]. Add a Wrapped bool to NumberLiteral and update the printer to emit parentheses when set.

When a NumberLiteral is wrapped, set only RangeExpr and leave Range at zero, letting the durationVisitor compute Range consistently with the DurationExpr path. Previously both Range and RangeExpr were set, which was redundant and inconsistent.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[ENHANCEMENT] PromQL: Support number literals with parentheses formatting as matrix range duration.
```
