### PR TITLE
docs: recommend testing/synctest for concurrent and time-dependent tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,37 @@ Example:
 
 ---
 
+## Concurrency and Time in Tests
+
+Tests that exercise goroutines or time should use the standard library
+[`testing/synctest`](https://pkg.go.dev/testing/synctest) package rather
+than relying on wall-clock timing. The project requires Go ≥ 1.25, so
+`testing/synctest` is always available — there is no build tag or shim to
+worry about.
+
+- Prefer `synctest.Test(t, func(t *testing.T) { ... })` over `time.Sleep`
+  polling, ad-hoc `time.After` timeouts, or `require.Eventually` when the goal
+  is to wait for goroutines to reach a known state.
+- Inside a synctest bubble, time advances virtually: once every bubbled
+  goroutine is durably blocked, the clock jumps forward, so `time.Sleep`
+  returns, timers fire, and tickers tick without slowing the test down. Use
+  `synctest.Wait()` to synchronise with background work instead of sleeps or
+  polling.
+- Start every goroutine the test needs to observe inside the
+  `synctest.Test` callback so it joins the bubble. Goroutines started from
+  `init`, package-level singletons, or before the bubble opens are not
+  controlled by it.
+- When fixing a flaky timing-dependent test, prefer migrating it to
+  `synctest` over adding sleeps, retries, or larger timeouts. Existing
+  examples to copy from: `TestHangingNotifier`, `TestStop_DrainingEnabled`,
+  `TestCancelCompactions`, `TestDelayedCompaction`.
+- `synctest` does not model real I/O. Network round-trips, disk fsync, and
+  OS scheduling do not register as "durably blocked", so virtual time cannot
+  advance while such operations are in flight. Keep deterministic fakes at
+  the boundary and use `synctest` for the in-process portion only.
+
+---
+
 ## Performance Work
 
 Maintainers take performance seriously. For any PERF PR:


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Add a "Concurrency and Time in Tests" section to AGENTS.md pointing contributors at the standard library `testing/synctest` package for tests involving goroutines or time. The project already requires Go >= 1.25 and several merged PRs have migrated previously flaky timing-dependent tests to `synctest`, so capturing the preference up front should reduce review-time churn on new contributions.

Example of a past PR migrating timing dependent tests to `synctest`: #17985.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```