### PR TITLE
promql/parser: preserve wrapped duration literals

### DIFF
--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -110,7 +110,7 @@ type BinaryExpr struct {
 	ReturnBool bool
 }
 
-// DurationExpr represents a binary expression between two duration expressions.
+// DurationExpr represents an arithmetic duration expression.
 type DurationExpr struct {
 	Op       ItemType // The operation of the expression.
 	LHS, RHS Expr     // The operands on the respective sides of the operator.

--- a/promql/parser/generated_parser.y
+++ b/promql/parser/generated_parser.y
@@ -1397,12 +1397,7 @@ duration_expr   : number_duration_literal
 paren_duration_expr : LEFT_PAREN duration_expr RIGHT_PAREN
                         {
                             yylex.(*parser).experimentalDurationExpr($2.(Expr))
-                            if durationExpr, ok := $2.(*DurationExpr); ok {
-                                durationExpr.Wrapped = true
-                                $$ = durationExpr
-                                break
-                            }
-                            $$ = $2
+                            $$ = yylex.(*parser).wrapDurationExpr($2.(Node), $1.PositionRange().Start)
                         }
                 ;
 

--- a/promql/parser/generated_parser.y.go
+++ b/promql/parser/generated_parser.y.go
@@ -2541,12 +2541,7 @@ yydefault:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yylex.(*parser).experimentalDurationExpr(yyDollar[2].node.(Expr))
-			if durationExpr, ok := yyDollar[2].node.(*DurationExpr); ok {
-				durationExpr.Wrapped = true
-				yyVAL.node = durationExpr
-				break
-			}
-			yyVAL.node = yyDollar[2].node
+			yyVAL.node = yylex.(*parser).wrapDurationExpr(yyDollar[2].node.(Node), yyDollar[1].item.PositionRange().Start)
 		}
 	}
 	goto yystack /* stack new state and value */

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -1214,15 +1214,36 @@ func (p *parser) experimentalDurationExpr(e Expr) {
 	}
 }
 
-// applyUnaryOpToDurationExpr applies a unary operator to a duration expression
-// node, which may be a *DurationExpr or a *NumberLiteral. When wrapped is true
-// (parenthesised form), the Wrapped flag is set on *DurationExpr nodes.
+func (p *parser) wrapDurationExpr(expr Node, start posrange.Pos) Node {
+	durationExpr, ok := expr.(*DurationExpr)
+	if ok {
+		durationExpr.Wrapped = true
+		return durationExpr
+	}
+	durationOperand, ok := expr.(Expr)
+	if !ok {
+		p.addParseErrf(expr.PositionRange(), "expected duration expression")
+		return &NumberLiteral{Val: 0}
+	}
+	return &DurationExpr{
+		Op:       ADD,
+		RHS:      durationOperand,
+		Wrapped:  true,
+		StartPos: start,
+	}
+}
+
+// ApplyUnaryOpToDurationExpr applies a unary operator to a duration expression node.
+//
+// The node may be a *DurationExpr or a *NumberLiteral.
+// Parenthesised expressions are converted to or marked as a wrapped DurationExpr node.
 func (p *parser) applyUnaryOpToDurationExpr(op Item, expr Node, wrapped bool) Node {
+	if wrapped {
+		expr = p.wrapDurationExpr(expr, expr.PositionRange().Start)
+	}
+
 	switch e := expr.(type) {
 	case *DurationExpr:
-		if wrapped {
-			e.Wrapped = true
-		}
 		if op.Typ == SUB {
 			return &DurationExpr{
 				Op:       SUB,

--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -1716,8 +1716,16 @@ var testExpr = []struct {
 	{
 		input: "foo offset +(5)",
 		expected: &VectorSelector{
-			Name:           "foo",
-			OriginalOffset: 5 * time.Second,
+			Name: "foo",
+			OriginalOffsetExpr: &DurationExpr{
+				Op: ADD,
+				RHS: &NumberLiteral{
+					Val:      5,
+					PosRange: posrange.PositionRange{Start: 13, End: 14},
+				},
+				Wrapped:  true,
+				StartPos: 13,
+			},
 			LabelMatchers: []*labels.Matcher{
 				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
 			},
@@ -1727,8 +1735,20 @@ var testExpr = []struct {
 	{
 		input: "foo offset -(5)",
 		expected: &VectorSelector{
-			Name:           "foo",
-			OriginalOffset: -5 * time.Second,
+			Name: "foo",
+			OriginalOffsetExpr: &DurationExpr{
+				Op: SUB,
+				RHS: &DurationExpr{
+					Op: ADD,
+					RHS: &NumberLiteral{
+						Val:      5,
+						PosRange: posrange.PositionRange{Start: 13, End: 14},
+					},
+					Wrapped:  true,
+					StartPos: 13,
+				},
+				StartPos: 11,
+			},
 			LabelMatchers: []*labels.Matcher{
 				MustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "foo"),
 			},

--- a/promql/parser/prettier.go
+++ b/promql/parser/prettier.go
@@ -83,7 +83,11 @@ func (e *DurationExpr) Pretty(int) string {
 	var s string
 	if e.LHS == nil {
 		// This is a unary duration expression.
-		s = fmt.Sprintf("%s%s", e.Op, e.RHS.Pretty(0))
+		if e.Op == ADD {
+			s = e.RHS.Pretty(0)
+		} else {
+			s = fmt.Sprintf("%s%s", e.Op, e.RHS.Pretty(0))
+		}
 	} else {
 		s = fmt.Sprintf("%s %s %s", e.LHS.Pretty(0), e.Op, e.RHS.Pretty(0))
 	}

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -266,6 +266,22 @@ func TestExprString(t *testing.T) {
 			in: "foo offset -(step())",
 		},
 		{
+			in: "foo offset (5)",
+		},
+		{
+			in:  "foo offset +(5)",
+			out: "foo offset (5)",
+		},
+		{
+			in: "foo offset -(5)",
+		},
+		{
+			in: "foo offset (5m)",
+		},
+		{
+			in: "foo[(5s)]",
+		},
+		{
 			in:  "foo offset +(5*2)",
 			out: "foo offset (5 * 2)",
 		},


### PR DESCRIPTION
Fixes #18770

This keeps parenthesized plain duration literals as wrapped duration expressions in range and offset expression contexts, matching the existing behavior for multi-term duration expressions. It also keeps unary minus outside the wrapped literal so `foo offset -(5)` stringifies as `foo offset -(5)`.

```release-notes
[BUGFIX] PromQL: Preserve parentheses around plain duration literals in range and offset duration expressions when printing queries.
```