### PR TITLE
ui: cover PromQL URL-sensitive characters in URL state test

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/urlStateEncoding.test.ts
+++ b/web/ui/mantine-ui/src/pages/query/urlStateEncoding.test.ts
@@ -573,6 +573,18 @@ describe("encode and decode roundtrip", () => {
     expect(decoded[0].showTree).toBe(original.showTree);
   });
 
+  test("roundtrip preserves PromQL expressions with URL-sensitive characters", () => {
+    const expr =
+      'sum by (job) (rate(http_requests_total{status!="500",handler=~"/api/v1/.+"}[5m]))';
+
+    const original = createPanel({ expr });
+    const encoded = encodePanelOptionsToURLParams([original]);
+    const decoded = decodePanelOptionsFromURLParams(encoded.toString());
+
+    expect(decoded).toHaveLength(1);
+    expect(decoded[0].expr).toBe(expr);
+  });
+
   test("roundtrip preserves visualizer settings", () => {
     const original = createPanel({
       visualizer: {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None.

#### What this PR does:

This PR adds test coverage for the query page URL state roundtrip when a PromQL expression contains URL-sensitive characters.

There is already coverage for a basic expression roundtrip, but this test uses a more realistic PromQL expression containing label matchers, quotes, braces, a regex matcher, slashes, and a literal plus sign.

This helps verify that Prometheus preserves the expression exactly when query panel state is encoded into URL parameters and decoded back into panel state.

#### Testing:

- `make ui-test`

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```