### PR TITLE
feat(promql): add option to preserve parser comments

### DIFF
--- a/promql/parser/ast.go
+++ b/promql/parser/ast.go
@@ -84,6 +84,26 @@ type Expr interface {
 	PromQLExpr()
 }
 
+// Comment contains a PromQL line comment preserved by the parser.
+type Comment struct {
+	// Text is the original comment text, including the leading "#".
+	Text string
+	// PosRange is the byte position range of the comment in the parsed input.
+	PosRange posrange.PositionRange
+}
+
+// CommentedExpr wraps an expression with comments collected during parsing.
+//
+// CommentedExpr is only returned when Options.PreserveComments is enabled.
+// Comments are rendered in a stable canonical form and are not semantic PromQL
+// nodes.
+type CommentedExpr struct {
+	// Expr is the parsed PromQL expression.
+	Expr Expr
+	// Comments are the preserved comments in source order.
+	Comments []Comment
+}
+
 // Expressions is a list of expression nodes that implements Node.
 type Expressions []Expr
 
@@ -198,6 +218,8 @@ type StepInvariantExpr struct {
 
 func (e *StepInvariantExpr) String() string { return e.Expr.String() }
 
+func (e *CommentedExpr) String() string { return renderWithComments(e.Expr, e.Comments) }
+
 func (e *StepInvariantExpr) PositionRange() posrange.PositionRange {
 	return e.Expr.PositionRange()
 }
@@ -248,15 +270,16 @@ func (TestStmt) PositionRange() posrange.PositionRange {
 		End:   -1,
 	}
 }
-func (*AggregateExpr) Type() ValueType  { return ValueTypeVector }
-func (e *Call) Type() ValueType         { return e.Func.ReturnType }
-func (*MatrixSelector) Type() ValueType { return ValueTypeMatrix }
-func (*SubqueryExpr) Type() ValueType   { return ValueTypeMatrix }
-func (*NumberLiteral) Type() ValueType  { return ValueTypeScalar }
-func (e *ParenExpr) Type() ValueType    { return e.Expr.Type() }
-func (*StringLiteral) Type() ValueType  { return ValueTypeString }
-func (e *UnaryExpr) Type() ValueType    { return e.Expr.Type() }
-func (*VectorSelector) Type() ValueType { return ValueTypeVector }
+func (*AggregateExpr) Type() ValueType   { return ValueTypeVector }
+func (e *Call) Type() ValueType          { return e.Func.ReturnType }
+func (e *CommentedExpr) Type() ValueType { return e.Expr.Type() }
+func (*MatrixSelector) Type() ValueType  { return ValueTypeMatrix }
+func (*SubqueryExpr) Type() ValueType    { return ValueTypeMatrix }
+func (*NumberLiteral) Type() ValueType   { return ValueTypeScalar }
+func (e *ParenExpr) Type() ValueType     { return e.Expr.Type() }
+func (*StringLiteral) Type() ValueType   { return ValueTypeString }
+func (e *UnaryExpr) Type() ValueType     { return e.Expr.Type() }
+func (*VectorSelector) Type() ValueType  { return ValueTypeVector }
 func (e *BinaryExpr) Type() ValueType {
 	if e.LHS.Type() == ValueTypeScalar && e.RHS.Type() == ValueTypeScalar {
 		return ValueTypeScalar
@@ -269,6 +292,7 @@ func (*DurationExpr) Type() ValueType        { return ValueTypeScalar }
 func (*AggregateExpr) PromQLExpr()     {}
 func (*BinaryExpr) PromQLExpr()        {}
 func (*Call) PromQLExpr()              {}
+func (*CommentedExpr) PromQLExpr()     {}
 func (*MatrixSelector) PromQLExpr()    {}
 func (*SubqueryExpr) PromQLExpr()      {}
 func (*NumberLiteral) PromQLExpr()     {}
@@ -431,6 +455,8 @@ func ChildrenIter(node Node) func(func(Node) bool) {
 					return
 				}
 			}
+		case *CommentedExpr:
+			yield(n.Expr)
 		case *SubqueryExpr:
 			yield(n.Expr)
 		case *ParenExpr:
@@ -510,6 +536,20 @@ func (e *DurationExpr) PositionRange() posrange.PositionRange {
 
 func (e *Call) PositionRange() posrange.PositionRange {
 	return e.PosRange
+}
+
+func (e *CommentedExpr) PositionRange() posrange.PositionRange {
+	if len(e.Comments) == 0 {
+		return e.Expr.PositionRange()
+	}
+	rng := e.Expr.PositionRange()
+	if e.Comments[0].PosRange.Start < rng.Start {
+		rng.Start = e.Comments[0].PosRange.Start
+	}
+	if e.Comments[len(e.Comments)-1].PosRange.End > rng.End {
+		rng.End = e.Comments[len(e.Comments)-1].PosRange.End
+	}
+	return rng
 }
 
 func (e *EvalStmt) PositionRange() posrange.PositionRange {

--- a/promql/parser/comments.go
+++ b/promql/parser/comments.go
@@ -1,0 +1,136 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+)
+
+func (e *CommentedExpr) Pretty(int) string {
+	return e.String()
+}
+
+func renderWithComments(expr Expr, comments []Comment) string {
+	if len(comments) == 0 {
+		return expr.String()
+	}
+	r := commentRenderer{
+		comments: append([]Comment(nil), comments...),
+	}
+	sort.SliceStable(r.comments, func(i, j int) bool {
+		return r.comments[i].PosRange.Start < r.comments[j].PosRange.Start
+	})
+	r.renderExpr(expr)
+	r.flushRemaining()
+	return strings.TrimRight(r.b.String(), "\n")
+}
+
+type commentRenderer struct {
+	comments []Comment
+	next     int
+	b        strings.Builder
+}
+
+func (r *commentRenderer) renderExpr(expr Expr) {
+	if expr == nil {
+		return
+	}
+	pos := expr.PositionRange()
+	r.flushBefore(pos.Start)
+	if !r.hasCommentBefore(pos.End) {
+		r.b.WriteString(expr.String())
+		return
+	}
+
+	switch e := expr.(type) {
+	case *CommentedExpr:
+		r.renderExpr(e.Expr)
+	case *AggregateExpr:
+		var b bytes.Buffer
+		e.writeAggOpStr(&b)
+		r.b.Write(b.Bytes())
+		r.b.WriteByte('(')
+		if e.Op.IsAggregatorWithParam() {
+			r.renderExpr(e.Param)
+			r.b.WriteString(", ")
+		}
+		r.renderExpr(e.Expr)
+		r.flushBefore(pos.End)
+		r.b.WriteByte(')')
+	case *BinaryExpr:
+		r.renderExpr(e.LHS)
+		r.b.WriteByte(' ')
+		r.b.WriteString(e.Op.String())
+		r.b.WriteString(e.returnBool())
+		r.b.WriteString(e.getMatchingStr())
+		r.b.WriteByte(' ')
+		r.renderExpr(e.RHS)
+	case *Call:
+		r.b.WriteString(e.Func.Name)
+		r.b.WriteByte('(')
+		r.renderExpressions(e.Args)
+		r.flushBefore(pos.End)
+		r.b.WriteByte(')')
+	case *ParenExpr:
+		r.b.WriteByte('(')
+		r.renderExpr(e.Expr)
+		r.flushBefore(pos.End)
+		r.b.WriteByte(')')
+	case *UnaryExpr:
+		r.b.WriteString(e.Op.String())
+		r.renderExpr(e.Expr)
+	default:
+		r.flushBefore(pos.End)
+		r.b.WriteString(expr.String())
+	}
+}
+
+func (r *commentRenderer) renderExpressions(exprs Expressions) {
+	for i, expr := range exprs {
+		if i > 0 {
+			r.b.WriteString(", ")
+		}
+		r.renderExpr(expr)
+	}
+}
+
+func (r *commentRenderer) hasCommentBefore(end posrange.Pos) bool {
+	return r.next < len(r.comments) && r.comments[r.next].PosRange.Start < end
+}
+
+func (r *commentRenderer) flushBefore(pos posrange.Pos) {
+	for r.next < len(r.comments) && r.comments[r.next].PosRange.Start < pos {
+		r.writeComment(r.comments[r.next])
+		r.next++
+	}
+}
+
+func (r *commentRenderer) flushRemaining() {
+	for r.next < len(r.comments) {
+		r.writeComment(r.comments[r.next])
+		r.next++
+	}
+}
+
+func (r *commentRenderer) writeComment(comment Comment) {
+	if r.b.Len() != 0 && !strings.HasSuffix(r.b.String(), "\n") {
+		r.b.WriteByte(' ')
+	}
+	r.b.WriteString(comment.Text)
+	r.b.WriteByte('\n')
+}

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -46,6 +46,9 @@ type Options struct {
 	ExperimentalDurationExpr     bool
 	EnableExtendedRangeSelectors bool
 	EnableBinopFillModifiers     bool
+	// PreserveComments keeps comments in the parsed expression for String rendering.
+	// The default parser behavior remains to discard comments.
+	PreserveComments bool
 }
 
 // Parser provides PromQL parsing methods. Create one with NewParser.
@@ -157,6 +160,7 @@ type parser struct {
 
 	generatedParserResult any
 	parseErrors           ParseErrors
+	comments              []Comment
 
 	// lastHistogramCounterResetHintSet is set to true when the most recently
 	// built histogram had a counter_reset_hint explicitly specified.
@@ -174,6 +178,7 @@ func newParser(input string, opts Options) *parser {
 	p.injecting = false
 	p.parseErrors = nil
 	p.generatedParserResult = nil
+	p.comments = nil
 	p.lastClosing = posrange.Pos(0)
 	p.options = opts
 
@@ -209,6 +214,12 @@ func (p *parser) parseExpr() (expr Expr, err error) {
 
 	if len(p.parseErrors) != 0 {
 		err = p.parseErrors
+	}
+	if err == nil && expr != nil && p.options.PreserveComments && len(p.comments) != 0 {
+		expr = &CommentedExpr{
+			Expr:     expr,
+			Comments: append([]Comment(nil), p.comments...),
+		}
 	}
 
 	return expr, err
@@ -376,6 +387,12 @@ func (p *parser) Lex(lval *yySymType) int {
 	for {
 		p.lex.NextItem(&lval.item)
 		typ = lval.item.Typ
+		if typ == COMMENT && p.options.PreserveComments {
+			p.comments = append(p.comments, Comment{
+				Text:     lval.item.Val,
+				PosRange: lval.item.PositionRange(),
+			})
+		}
 		if typ != COMMENT {
 			break
 		}

--- a/promql/parser/printer_test.go
+++ b/promql/parser/printer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 )
 
 func TestExprString(t *testing.T) {
@@ -330,6 +331,100 @@ func TestExprString(t *testing.T) {
 			}
 
 			require.Equal(t, exp, expr.String())
+		})
+	}
+}
+
+func TestExprStringPreserveComments(t *testing.T) {
+	commentParser := NewParser(Options{PreserveComments: true})
+
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "leading comment",
+			input:    "# trace_id=abc123\nup",
+			expected: "# trace_id=abc123\nup",
+		},
+		{
+			name:     "trailing comment",
+			input:    "up # trace_id=abc123",
+			expected: "up # trace_id=abc123",
+		},
+		{
+			name:     "nested comment",
+			input:    "sum(\n  # rate comment\n  rate(http_requests_total[5m])\n)",
+			expected: "sum( # rate comment\nrate(http_requests_total[5m]))",
+		},
+		{
+			name:     "multiple comments",
+			input:    "# first\nup # second\n# third",
+			expected: "# first\nup # second\n# third",
+		},
+		{
+			name:     "no comments",
+			input:    "sum(rate(http_requests_total[5m]))",
+			expected: "sum(rate(http_requests_total[5m]))",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := commentParser.ParseExpr(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, expr.String())
+		})
+	}
+}
+
+func TestPreserveCommentsExposesCommentPositions(t *testing.T) {
+	expr, err := NewParser(Options{PreserveComments: true}).ParseExpr("# first\nup # second")
+	require.NoError(t, err)
+
+	commented, ok := expr.(*CommentedExpr)
+	require.True(t, ok)
+	require.Equal(t, []Comment{
+		{
+			Text:     "# first",
+			PosRange: posrange.PositionRange{Start: 0, End: 7},
+		},
+		{
+			Text:     "# second",
+			PosRange: posrange.PositionRange{Start: 11, End: 19},
+		},
+	}, commented.Comments)
+}
+
+func TestPreserveCommentsSurviveASTMutation(t *testing.T) {
+	expr, err := NewParser(Options{PreserveComments: true}).ParseExpr("# trace\n1 + 2")
+	require.NoError(t, err)
+
+	commented := expr.(*CommentedExpr)
+	commented.Expr.(*BinaryExpr).RHS.(*NumberLiteral).Val = 3
+	require.Equal(t, "# trace\n1 + 3", commented.String())
+}
+
+func TestExprStringStripsCommentsByDefault(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "leading comment",
+			input:    "# trace_id=abc123\nup",
+			expected: "up",
+		},
+		{
+			name:     "trailing comment",
+			input:    "up # trace_id=abc123",
+			expected: "up",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := testParser.ParseExpr(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, expr.String())
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in PromQL parser mode for preserving comments through parsing and rendering, while keeping the default parser behavior unchanged.

### Motivation

Fixes #15871.

### More

- Keeps comment preservation opt-in through `Options.PreserveComments`.
- Preserves existing parser behavior by default.
- Collects existing lexer comment tokens while continuing to skip them for yacc parsing, so comments remain non-semantic.
- Adds regression coverage for comment preservation, exposed comment positions, default stripping behavior, and AST mutation followed by rendering.
- Keeps the change scoped to the PromQL parser.

### Additional Notes

Chosen API shape: `Options.PreserveComments` returns a `*parser.CommentedExpr` wrapper from `ParseExpr` when comments are present. The wrapper delegates expression type/AST traversal to the parsed expression and carries preserved `Comment` metadata with source positions.

Comment rendering is canonical rather than exact original whitespace preservation. Leading and trailing comments are kept in source order, and comments inside supported expression subtrees are emitted at deterministic positions while normal expression rendering continues to use existing `String()` formatting.

#### Does this PR introduce a user-facing change?

```release-notes
[FEATURE] PromQL: Add opt-in parser option to preserve comments when rendering parsed expressions.
```

### Tests

- `go test ./promql/parser/...` with `GOPROXY=https://proxy.golang.org,direct` - passed
- `go test ./promql/...` with default Go proxy configuration - failed before compiling non-parser packages because the configured mirror `https://mirror-go.runflare.com` returned `402 Payment Required`
- `go test ./promql/...` with `GOPROXY=https://proxy.golang.org,direct` - failed before compiling non-parser packages because `proxy.golang.org` returned `403 Forbidden` for some dependency zip downloads
- `go test ./promql/...` with `GOPROXY=direct` - failed before compiling non-parser packages because `google.golang.org` could not be resolved in this environment