### PR TITLE
ui: cover PromQL label name quoting

### DIFF
--- a/web/ui/mantine-ui/src/promql/utils.test.ts
+++ b/web/ui/mantine-ui/src/promql/utils.test.ts
@@ -3,6 +3,7 @@ import {
   getNonParenNodeType,
   containsPlaceholders,
   nodeValueType,
+  maybeQuoteLabelName,
 } from "./utils";
 import { nodeType, valueType, binaryOperatorType } from "./ast";
 
@@ -157,5 +158,18 @@ describe("nodeValueType", () => {
         bool: false,
       })
     ).toBe(valueType.vector);
+  });
+});
+
+describe("maybeQuoteLabelName", () => {
+  it("does not quote valid PromQL label names", () => {
+    expect(maybeQuoteLabelName("job")).toBe("job");
+    expect(maybeQuoteLabelName("status_code")).toBe("status_code");
+  });
+
+  it("quotes and escapes label names with extended characters", () => {
+    expect(maybeQuoteLabelName("service.version")).toBe('"service.version"');
+    expect(maybeQuoteLabelName("team/name")).toBe('"team/name"');
+    expect(maybeQuoteLabelName('team"name')).toBe('"team\\"name"');
   });
 });


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None.

#### What this PR does:

This PR adds test coverage for `maybeQuoteLabelName`.

The test covers valid PromQL label names that should remain unquoted, as well as label names with extended characters that should be quoted and escaped. This includes a label name containing a double quote to verify escaping behavior.

#### Testing:

- `make ui-test`

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```