### PR TITLE
ui: cover Prometheus duration parsing

### DIFF
--- a/web/ui/mantine-ui/src/lib/formatTime.test.ts
+++ b/web/ui/mantine-ui/src/lib/formatTime.test.ts
@@ -1,4 +1,30 @@
-import { humanizeDuration, formatPrometheusDuration } from "./formatTime";
+import {
+  humanizeDuration,
+  formatPrometheusDuration,
+  parsePrometheusDuration,
+} from "./formatTime";
+
+describe("parsePrometheusDuration", () => {
+  test("parses Prometheus duration strings", () => {
+    expect(parsePrometheusDuration("0")).toBe(0);
+    expect(parsePrometheusDuration("5m")).toBe(5 * 60 * 1000);
+    expect(parsePrometheusDuration("1h30m")).toBe(90 * 60 * 1000);
+    expect(parsePrometheusDuration("2d3h4m5s6ms")).toBe(
+      2 * 24 * 60 * 60 * 1000 +
+        3 * 60 * 60 * 1000 +
+        4 * 60 * 1000 +
+        5 * 1000 +
+        6
+    );
+  });
+
+  test("returns null for empty or invalid durations", () => {
+    expect(parsePrometheusDuration("")).toBeNull();
+    expect(parsePrometheusDuration("1.5h")).toBeNull();
+    expect(parsePrometheusDuration("5m1h")).toBeNull();
+    expect(parsePrometheusDuration("10q")).toBeNull();
+  });
+});
 
 describe("formatPrometheusDuration", () => {
   test('returns "0s" for 0 milliseconds', () => {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None.

#### What this PR does:

This PR adds test coverage for `parsePrometheusDuration`.

The test covers valid Prometheus duration strings, including combined durations such as `1h30m`, as well as empty and invalid duration strings that should return `null`.

#### Testing:

- `make ui-test`

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```