### PR TITLE
model: cover UTF-8 label validation

### DIFF
--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -346,6 +346,15 @@ func TestLabels_ValidationModes(t *testing.T) {
 		{
 			input: FromStrings(
 				"__name__", "test",
+				"host.name", "localhost",
+				"team/name", "platform",
+			),
+			callMode: model.UTF8Validation,
+			expected: true,
+		},
+		{
+			input: FromStrings(
+				"__name__", "test",
 				"\xc5 bad utf8", "localhost",
 				"job", "check",
 			),


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None.

#### What this PR does:

This PR adds test coverage for `Labels.IsValid` in UTF-8 validation mode.

Existing coverage already checks an extended metric name through `__name__`, but the label names in that case are still legacy-compatible. This test adds coverage for extended label names such as `host.name` and `team/name`, which should be valid under `model.UTF8Validation`.

#### Testing:

- `go test ./model/labels`

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```