### PR TITLE
scrape: preserve IPv6 zone identifiers in target URLs

### DIFF
--- a/scrape/target.go
+++ b/scrape/target.go
@@ -230,9 +230,14 @@ func (t *Target) URL() *url.URL {
 		}
 	})
 
+	host := t.labels.Get(model.AddressLabel)
+	if strings.Contains(host, "%25") {
+		host = strings.ReplaceAll(host, "%25", "%")
+	}
+
 	return &url.URL{
 		Scheme:   t.labels.Get(model.SchemeLabel),
-		Host:     t.labels.Get(model.AddressLabel),
+		Host:     host,
 		Path:     t.labels.Get(model.MetricsPathLabel),
 		RawQuery: params.Encode(),
 	}

--- a/scrape/target_test.go
+++ b/scrape/target_test.go
@@ -769,6 +769,12 @@ func TestMaxSchemaAppender(t *testing.T) {
 	}
 }
 
+func TestTargetURLWithIPv6Zone(t *testing.T) {
+	target := newTestTarget("[fe80::1%25ens3]:9100", 0, labels.EmptyLabels())
+
+	require.Equal(t, "http://[fe80::1%25ens3]:9100/metrics", target.URL().String())
+}
+
 // Test sample_limit when a scrape contains Native Histograms.
 func TestAppendWithSampleLimitAndNativeHistogram(t *testing.T) {
 	now := time.Now()


### PR DESCRIPTION
Fixes #18106

This change prevents IPv6 zone identifiers from being double-escaped when constructing scrape target URLs.

Previously, addresses containing `%25` would become `%2525` in the generated scrape URL.

This PR also adds a regression test covering IPv6 link-local addresses with interface zone identifiers.

```release-notes
NONE
```