### PR TITLE
chore(reposync): use fork actual name and new API version in sync_repo_files

### DIFF
--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -19,4 +19,4 @@ jobs:
           persist-credentials: false
       - run: ./scripts/sync_repo_files.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.PROMBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PROMBOT_REPOSYNC_TOKEN }}

--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -85,14 +85,15 @@ fetch_repos() {
 # Fork ${1} into ${fork_org}. The forks API is idempotent: it returns the
 # existing fork if one already exists. The fork name is prefixed with the
 # upstream org to avoid collisions between orgs (e.g. prometheus_node_exporter).
+# Returns the full_name of the fork (which may differ from the requested name
+# when a fork already exists under a different name).
 fork_repo() {
   local org_repo="$1"
   local fork_name="${org_repo//\//_}"
   github_api "repos/${org_repo}/forks" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    --data "{\"organization\":\"${fork_org}\",\"name\":\"${fork_name}\"}" \
-    > /dev/null || return 1
-  echo "${fork_org}/${fork_name}"
+    -H "X-GitHub-Api-Version: 2026-03-10" \
+    --data "{\"organization\":\"${fork_org}\",\"name\":\"${fork_name}\"}" |
+    jq -r '.full_name' || return 1
 }
 
 push_branch() {
@@ -117,8 +118,8 @@ post_pull_request() {
   local repo="$1"
   local default_branch="$2"
   local fork_owner="$3"
-  local fork_name="${repo//\//_}"
-  local checkout_hint="To check out this branch locally and push changes back:\\n\`\`\`\\ngit remote add ${fork_owner} https://github.com/${fork_owner}/${fork_name}.git\\ngit fetch ${fork_owner} ${branch}\\ngit checkout -b ${branch} ${fork_owner}/${branch}\\n\`\`\`"
+  local fork_org_repo="$4"
+  local checkout_hint="To check out this branch locally and push changes back:\\n\`\`\`\\ngit remote add ${fork_owner} https://github.com/${fork_org_repo}.git\\ngit fetch ${fork_owner} ${branch}\\ngit checkout -b ${branch} ${fork_owner}/${branch}\\n\`\`\`"
   local post_json
   post_json="$(printf '{"title":"%s","base":"%s","head":"%s:%s","body":"%s"}' "${pr_title}" "${default_branch}" "${fork_owner}" "${branch}" "${pr_msg}\\n\\n${checkout_hint}")"
   echo "Posting PR to ${default_branch} on ${repo}"
@@ -248,7 +249,7 @@ process_repo() {
     local fork_org_repo
     fork_org_repo="$(fork_repo "${org_repo}")" || { repo_log_red "Forking ${org_repo} failed"; return 1; }
     if push_branch "${fork_org_repo}"; then
-      if ! post_pull_request "${org_repo}" "${default_branch}" "${fork_org}"; then
+      if ! post_pull_request "${org_repo}" "${default_branch}" "${fork_org}" "${fork_org_repo}"; then
         repo_log_red "Posting PR failed"
         return 1
       fi


### PR DESCRIPTION
Read the fork's actual full_name from the fork API response instead of constructing it.  Pass the fork full_name to post_pull_request so the checkout hint uses the correct repo name.

Use newly-created scoped PROMBOT_REPOSYNC_TOKEN in the workflow.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
