### PR TITLE
scripts: fix LICENSE check using stale target_file in sync_repo_files

### DIFF
--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -186,10 +186,6 @@ process_repo() {
         continue
       fi
     fi
-    if [[ "${source_file}" == 'LICENSE' ]] && ! check_license "${target_file}" ; then
-      repo_log "LICENSE in ${org_repo} is not apache, skipping."
-      continue
-    fi
     target_filename="${source_file}"
     if [[ "${source_file}" == 'scripts/golangci-lint.yml' ]] ; then
       target_filename=".github/workflows/golangci-lint.yml"
@@ -203,6 +199,10 @@ process_repo() {
           needs_update+=("${source_file}")
           ;;
       esac
+      continue
+    fi
+    if [[ "${source_file}" == 'LICENSE' ]] && ! check_license "${target_file}" ; then
+      repo_log "LICENSE in ${org_repo} is not apache, skipping."
       continue
     fi
     target_checksum="$(echo "${target_file}" | sha256sum | cut -d' ' -f1)"


### PR DESCRIPTION
The check_license guard ran before target_file was fetched, so it always tested the previous iteration's file content (CODE_OF_CONDUCT.md) instead of the target repo's LICENSE. This caused the LICENSE file to be silently skipped on every run regardless of the actual license.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
