### PR TITLE
[ENHANCEMENT] tsdb/record: NewDecoder now uses the supplied *labels.SymbolTable; under -tags=dedupelabels this preserves symbol sharing across decoder instances as callers already expected.

### DIFF
--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -219,8 +219,20 @@ type Decoder struct {
 	logger  *slog.Logger
 }
 
-func NewDecoder(_ *labels.SymbolTable, logger *slog.Logger) Decoder { // FIXME remove t (or use scratch builder with symbols)
-	b := labels.NewScratchBuilder(0)
+// NewDecoder returns a Decoder that decodes WAL records into typed slices.
+//
+// If t is non-nil, decoded labels are constructed against t — under the
+// dedupelabels build tag this preserves symbol-table sharing across decoder
+// instances, which is required when callers run multiple decoders against
+// the same WAL. If t is nil, the Decoder constructs its own private symbol
+// state (the historical behaviour).
+func NewDecoder(t *labels.SymbolTable, logger *slog.Logger) Decoder {
+	var b labels.ScratchBuilder
+	if t == nil {
+		b = labels.NewScratchBuilder(0)
+	} else {
+		b = labels.NewScratchBuilderWithSymbolTable(t, 0)
+	}
 	b.SetUnsafeAdd(true)
 	return Decoder{builder: b, logger: logger}
 }

--- a/tsdb/record/record_dedupelabels_test.go
+++ b/tsdb/record/record_dedupelabels_test.go
@@ -1,0 +1,73 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dedupelabels
+
+package record
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/promslog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+// TestNewDecoderSharesSymbolTable verifies that a *labels.SymbolTable passed
+// to NewDecoder is actually used as the symbol store for decoded labels.
+// Under the FIXME-ignored implementation the table stayed empty, which
+// caused symbol fragmentation when multiple decoders ran against the same
+// WAL (one private table per decoder). The parallel-WAL-decode path relies
+// on this fix to share one table across the decoder pool.
+func TestNewDecoderSharesSymbolTable(t *testing.T) {
+	syms := labels.NewSymbolTable()
+	require.Equal(t, 0, syms.Len(), "fresh symbol table should be empty")
+
+	enc := Encoder{}
+	rec := enc.Series([]RefSeries{
+		{Ref: chunks.HeadSeriesRef(1), Labels: labels.FromStrings("__name__", "metric_a", "job", "j1")},
+		{Ref: chunks.HeadSeriesRef(2), Labels: labels.FromStrings("__name__", "metric_b", "job", "j1")},
+	}, nil)
+
+	d1 := NewDecoder(syms, promslog.NewNopLogger())
+	out, err := d1.Series(rec, nil)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+
+	afterFirst := syms.Len()
+	require.Positive(t, afterFirst, "decoder should populate the shared symbol table")
+
+	// A second decoder constructed against the same table must reuse the
+	// existing symbols rather than allocate new ones.
+	d2 := NewDecoder(syms, promslog.NewNopLogger())
+	out2, err := d2.Series(rec, nil)
+	require.NoError(t, err)
+	require.Len(t, out2, 2)
+	require.Equal(t, afterFirst, syms.Len(), "second decoder must reuse symbols, not duplicate them")
+}
+
+// TestNewDecoderNilSymbolTable verifies that passing nil still works
+// (callers in tests rely on this fallback path).
+func TestNewDecoderNilSymbolTable(t *testing.T) {
+	enc := Encoder{}
+	rec := enc.Series([]RefSeries{
+		{Ref: chunks.HeadSeriesRef(1), Labels: labels.FromStrings("__name__", "metric_a")},
+	}, nil)
+
+	d := NewDecoder(nil, promslog.NewNopLogger())
+	out, err := d.Series(rec, nil)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+}


### PR DESCRIPTION

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
NewDecoder previously ignored its *labels.SymbolTable argument and built a fresh ScratchBuilder via labels.NewScratchBuilder(0). Under the dedupelabels build tag this means each Decoder constructs its own private SymbolTable, so callers that intend to share symbol state across decoder instances (e.g. tsdb/wlog/watcher.go, which already documents "One table per WAL segment means it won't grow indefinitely") silently get fragmented per-decoder tables instead.

Thread the argument through via labels.NewScratchBuilderWithSymbolTable when non-nil; fall back to the historical behaviour when nil. For the stringlabels and slicelabels build tags this is a no-op since their SymbolTable type is a zero-byte struct. Under dedupelabels the caller-supplied table is now actually used and shared across whatever Decoders the caller constructs against it.

Add a test under -tags=dedupelabels that asserts the passed symbol table is populated by decode and that a second Decoder constructed against the same table reuses existing symbols rather than allocating new ones.

```release-notes
[ENHANCEMENT] tsdb/record: NewDecoder now uses the supplied *labels.SymbolTable; under -tags=dedupelabels this preserves symbol sharing across decoder instances as callers already expected.
```
