### PR TITLE
promtool: skip duplicate samples at appender batch boundaries

### DIFF
--- a/cmd/promtool/backfill.go
+++ b/cmd/promtool/backfill.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/textparse"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 )
 
@@ -170,6 +171,9 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				lbls := lb.Labels()
 
 				if _, err := app.Append(0, lbls, *ts, v); err != nil {
+					if errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+						continue
+					}
 					return fmt.Errorf("add sample: %w", err)
 				}
 

--- a/cmd/promtool/backfill_test.go
+++ b/cmd/promtool/backfill_test.go
@@ -682,6 +682,46 @@ http_requests_total{code="200"} 3 1629863088.000
 			},
 		},
 		{
+			// Regression test for https://github.com/prometheus/prometheus/issues/12531.
+			// Duplicate samples (same series + timestamp, different value) that cross an
+			// appender batch boundary must be silently skipped, matching the within-batch
+			// behaviour where the TSDB commit already drops them without error.
+			ToParse: `# HELP http_requests_total The total number of HTTP requests.
+# TYPE http_requests_total counter
+http_requests_total{code="200"} 1 1565133713.989
+http_requests_total{code="200"} 2 1565133713.989
+http_requests_total{code="200"} 3 1565133714.989
+# EOF
+`,
+			IsOk:                 true,
+			Description:          "Duplicate samples across appender batch boundary are skipped, not fatal.",
+			MaxSamplesInAppender: 1,
+			Expected: struct {
+				MinTime       int64
+				MaxTime       int64
+				NumBlocks     int
+				BlockDuration int64
+				Samples       []backfillSample
+			}{
+				MinTime:       1565133713989,
+				MaxTime:       1565133714989,
+				NumBlocks:     1,
+				BlockDuration: tsdb.DefaultBlockDuration,
+				Samples: []backfillSample{
+					{
+						Timestamp: 1565133713989,
+						Value:     1,
+						Labels:    labels.FromStrings("__name__", "http_requests_total", "code", "200"),
+					},
+					{
+						Timestamp: 1565133714989,
+						Value:     3,
+						Labels:    labels.FromStrings("__name__", "http_requests_total", "code", "200"),
+					},
+				},
+			},
+		},
+		{
 			ToParse: `# HELP rpc_duration_seconds A summary of the RPC duration in seconds.
 # TYPE rpc_duration_seconds summary
 rpc_duration_seconds{quantile="0.01"} 3102


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #12531

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] promtool: Fix backfill aborting on duplicate samples that straddle appender batch boundaries.
```

## Summary

Fixes the inconsistent behaviour when backfilling OpenMetrics data that contains duplicate samples (same series + timestamp, different value).

### Root cause

`createBlocks` flushes the appender every `maxSamplesInAppender` (default 5000) samples. The TSDB handles duplicates differently depending on *when* they are seen:

- **Within-batch**: `app.Commit()` silently drops the duplicate and returns `nil`.
- **Cross-batch**: the first copy commits and advances the series `msMaxt`; the second copy hits `storage.ErrDuplicateSampleForTimestamp` inside `app.Append()`, which was returned as a fatal error and aborted the entire backfill.

The same pair of duplicate lines would succeed or fail depending on where they happened to fall relative to the 5000-sample boundary — a position that varies with input size.

### Fix

Check for `storage.ErrDuplicateSampleForTimestamp` immediately after `app.Append()` and `continue` to the next sample, making cross-batch behaviour identical to within-batch behaviour.

### Test

Added a regression test with `MaxSamplesInAppender: 1` so every sample causes a batch flush, guaranteeing any duplicate exercises the cross-batch path. The test verifies the backfill succeeds and only the first value for the duplicate timestamp is stored.