### PR TITLE
promql: make duplicate series error message deterministic

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3104,9 +3104,13 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 				oneSide = "left"
 			}
 			matchedLabels := rs.Metric.MatchLabels(matching.On, matching.MatchingLabels...)
-			// Many-to-many matching not allowed.
+			// Make the error message consistent between runs by ordering the reported series.
+			dupl1, dupl2 := rs.Metric.String(), duplSample.Metric.String()
+			if dupl1 > dupl2 {
+				dupl1, dupl2 = dupl2, dupl1
+			}
 			ev.errorf("found duplicate series for the match group %s on the %s hand-side of the operation: [%s, %s]"+
-				";many-to-many matching not allowed: matching labels must be unique on one side", matchedLabels.String(), oneSide, rs.Metric.String(), duplSample.Metric.String())
+				";many-to-many matching not allowed: matching labels must be unique on one side", matchedLabels.String(), oneSide, dupl1, dupl2)
 		}
 		rightSigs[sigOrd] = rs
 		rightSigsPresent[sigOrd] = true

--- a/promql/promqltest/testdata/operators.test
+++ b/promql/promqltest/testdata/operators.test
@@ -1017,3 +1017,14 @@ eval range from 0 to 20m step 10m -metric_a or -metric_b
     {} -1  -4
 
 clear
+
+# The two duplicate series reported in a many-to-many error must come out in a stable, sorted order.
+load 5m
+  dup_metric{label="alpha"} 1
+  dup_metric{label="beta"}  2
+  scalar_metric{} 3
+
+eval instant at 0m scalar_metric > on() dup_metric
+  expect fail msg: found duplicate series for the match group {} on the right hand-side of the operation: [{__name__="dup_metric", label="alpha"}, {__name__="dup_metric", label="beta"}];many-to-many matching not allowed: matching labels must be unique on one side
+
+clear


### PR DESCRIPTION
## What

This makes the PromQL many-to-many duplicate-series error deterministic:

`found duplicate series for the match group ... [X, Y] ...`

`VectorBinop` now sorts the two duplicate series label strings before formatting the error. The error text and semantics are otherwise unchanged.

## Why this site, not the map iteration upstream

The two series strings were previously rendered from `rs.Metric.String()` and `duplSample.Metric.String()` in whichever order the duplicate pair arrived from `rightSigs`. That order can be influenced by Go map iteration randomization upstream (the RHS Matrix is assembled by iterating `seriess map[uint64]seriesAndTimestamp` in `rangeEval` / `rangeEvalAgg`), even though normal `Matrix` result order is already sorted by `sortMatrixResult` before being returned to clients. The only place the non-determinism leaks out is this error path, so the smallest fix is to sort the two rendered label strings immediately before formatting the error.

Full reproducer and root-cause walk in #18809.

The error string itself was last touched on 2021-11-17 in commit 5d4db805 and has otherwise stayed stable for years, so this keeps the existing message format intact.

## Test

Added a `.test` regression case in `promql/promqltest/testdata/operators.test` that asserts the many-to-many error renders the duplicate pair in sorted order.

Added `TestManyToManyErrorDeterministic` in `promql/engine_test.go`, which repeatedly evaluates the offending query and asserts every rendered error message is byte-identical, pinning the stable `(A, B)` output regardless of whether the underlying duplicate pair is encountered as `(A, B)` or `(B, A)`. Verified by temporarily reverting the sort: both tests FAIL with the unsorted ordering; restoring the patch makes them PASS.

## Which issue(s) does the PR fix:

Fixes #18809. Also unblocks cortexproject/cortex#7546 (a flaky test in Cortex caused by this exact non-determinism — tactical downstream workaround in cortexproject/cortex#7550 can be removed once this lands and is vendored).

## Does this PR introduce a user-facing change?

No behavior change. The error message content is unchanged; only the ordering of the two label strings inside the existing `[X, Y]` brackets is now stable.

```release-notes
[BUGFIX] PromQL: Make the "found duplicate series for the match group" many-to-many matching error message deterministic by sorting the two duplicate labels.
```