### PR TITLE
tsdb/record: reuse histogram objects via output-slice capacity

### DIFF
--- a/tsdb/agent/db_test.go
+++ b/tsdb/agent/db_test.go
@@ -1498,7 +1498,7 @@ func readWALSamples(t *testing.T, walDir string) []walSample {
 			for _, h := range histograms {
 				outputSamples = append(outputSamples, walSample{
 					t:    h.T,
-					h:    h.H,
+					h:    h.H.Copy(), // copy: decode buffer is reused across WAL records
 					lbls: lastSeries.Labels.Copy(),
 					ref:  storage.SeriesRef(lastSeries.Ref),
 				})

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"slices"
 	"unsafe"
 
 	"github.com/prometheus/common/model"
@@ -223,6 +224,37 @@ func NewDecoder(_ *labels.SymbolTable, logger *slog.Logger) Decoder { // FIXME r
 	b := labels.NewScratchBuilder(0)
 	b.SetUnsafeAdd(true)
 	return Decoder{builder: b, logger: logger}
+}
+
+// nextHistogram returns the *histogram.Histogram at the next unused capacity
+// slot of out. When the caller later appends to out, the decoder reuses the
+// existing struct and its slice capacity (via DecodeHistogram's slices.Grow
+// pattern), eliminating a per-sample allocation on repeated calls with the
+// same pre-grown slice.
+//
+// Ownership invariant: the H pointers at capacity slots beyond len(out) must
+// not be retained by the caller after passing out (e.g. as out[:0]) to the
+// next HistogramSamples call. Callers that store H pointers across decode
+// calls must copy them first (h.H.Copy()) or use a fresh nil slice each time.
+func nextHistogram(out []RefHistogramSample) *histogram.Histogram {
+	if len(out) < cap(out) {
+		if h := out[:cap(out)][len(out)].H; h != nil {
+			return h
+		}
+	}
+	return new(histogram.Histogram)
+}
+
+// nextFloatHistogram is the FloatHistogram analogue of nextHistogram.
+// The same ownership invariant applies: FH pointers in capacity slots must not
+// be retained after passing the slice back for the next decode.
+func nextFloatHistogram(out []RefFloatHistogramSample) *histogram.FloatHistogram {
+	if len(out) < cap(out) {
+		if fh := out[:cap(out)][len(out)].FH; fh != nil {
+			return fh
+		}
+	}
+	return new(histogram.FloatHistogram)
 }
 
 // Type returns the type of the record.
@@ -555,7 +587,7 @@ func (d *Decoder) histogramSamplesV1(dec *encoding.Decbuf, histograms []RefHisto
 		rh := RefHistogramSample{
 			Ref: chunks.HeadSeriesRef(baseRef + uint64(dref)),
 			T:   baseTime + dtime,
-			H:   &histogram.Histogram{},
+			H:   nextHistogram(histograms),
 		}
 
 		DecodeHistogram(dec, rh.H)
@@ -615,7 +647,7 @@ func (d *Decoder) histogramSamplesV2(dec *encoding.Decbuf, histograms []RefHisto
 			Ref: chunks.HeadSeriesRef(ref),
 			ST:  st,
 			T:   t,
-			H:   &histogram.Histogram{},
+			H:   nextHistogram(histograms),
 		}
 		prev = &rh
 		DecodeHistogram(dec, rh.H)
@@ -644,7 +676,8 @@ func (d *Decoder) histogramSamplesV2(dec *encoding.Decbuf, histograms []RefHisto
 	return histograms, nil
 }
 
-// DecodeHistogram decodes a Histogram from buf.
+// DecodeHistogram decodes a Histogram from buf. h may be a pooled object with
+// existing slice capacity; DecodeHistogram reuses that capacity where possible.
 func DecodeHistogram(buf *encoding.Decbuf, h *histogram.Histogram) {
 	h.CounterResetHint = histogram.CounterResetHint(buf.Byte())
 
@@ -656,47 +689,39 @@ func DecodeHistogram(buf *encoding.Decbuf, h *histogram.Histogram) {
 	h.Sum = math.Float64frombits(buf.Be64())
 
 	l := buf.Uvarint()
-	if l > 0 {
-		h.PositiveSpans = make([]histogram.Span, l)
-	}
+	h.PositiveSpans = slices.Grow(h.PositiveSpans[:0], l)[:l]
 	for i := range h.PositiveSpans {
 		h.PositiveSpans[i].Offset = int32(buf.Varint64())
 		h.PositiveSpans[i].Length = buf.Uvarint32()
 	}
 
 	l = buf.Uvarint()
-	if l > 0 {
-		h.NegativeSpans = make([]histogram.Span, l)
-	}
+	h.NegativeSpans = slices.Grow(h.NegativeSpans[:0], l)[:l]
 	for i := range h.NegativeSpans {
 		h.NegativeSpans[i].Offset = int32(buf.Varint64())
 		h.NegativeSpans[i].Length = buf.Uvarint32()
 	}
 
 	l = buf.Uvarint()
-	if l > 0 {
-		h.PositiveBuckets = make([]int64, l)
-	}
+	h.PositiveBuckets = slices.Grow(h.PositiveBuckets[:0], l)[:l]
 	for i := range h.PositiveBuckets {
 		h.PositiveBuckets[i] = buf.Varint64()
 	}
 
 	l = buf.Uvarint()
-	if l > 0 {
-		h.NegativeBuckets = make([]int64, l)
-	}
+	h.NegativeBuckets = slices.Grow(h.NegativeBuckets[:0], l)[:l]
 	for i := range h.NegativeBuckets {
 		h.NegativeBuckets[i] = buf.Varint64()
 	}
 
 	if histogram.IsCustomBucketsSchema(h.Schema) {
 		l = buf.Uvarint()
-		if l > 0 {
-			h.CustomValues = make([]float64, l)
-		}
+		h.CustomValues = slices.Grow(h.CustomValues[:0], l)[:l]
 		for i := range h.CustomValues {
 			h.CustomValues[i] = buf.Be64Float64()
 		}
+	} else {
+		h.CustomValues = nil
 	}
 }
 
@@ -730,7 +755,7 @@ func (d *Decoder) floatHistogramSamplesV1(dec *encoding.Decbuf, histograms []Ref
 		rh := RefFloatHistogramSample{
 			Ref: chunks.HeadSeriesRef(baseRef + uint64(dref)),
 			T:   baseTime + dtime,
-			FH:  &histogram.FloatHistogram{},
+			FH:  nextFloatHistogram(histograms),
 		}
 
 		DecodeFloatHistogram(dec, rh.FH)
@@ -790,7 +815,7 @@ func (d *Decoder) floatHistogramSamplesV2(dec *encoding.Decbuf, histograms []Ref
 			Ref: chunks.HeadSeriesRef(ref),
 			ST:  st,
 			T:   t,
-			FH:  &histogram.FloatHistogram{},
+			FH:  nextFloatHistogram(histograms),
 		}
 		prev = &rfh
 		DecodeFloatHistogram(dec, rfh.FH)
@@ -820,7 +845,9 @@ func (d *Decoder) floatHistogramSamplesV2(dec *encoding.Decbuf, histograms []Ref
 	return histograms, nil
 }
 
-// DecodeFloatHistogram decodes a FloatHistogram from buf.
+// DecodeFloatHistogram decodes a FloatHistogram from buf. fh may be a pooled
+// object with existing slice capacity; DecodeFloatHistogram reuses that capacity
+// where possible.
 func DecodeFloatHistogram(buf *encoding.Decbuf, fh *histogram.FloatHistogram) {
 	fh.CounterResetHint = histogram.CounterResetHint(buf.Byte())
 
@@ -832,47 +859,39 @@ func DecodeFloatHistogram(buf *encoding.Decbuf, fh *histogram.FloatHistogram) {
 	fh.Sum = buf.Be64Float64()
 
 	l := buf.Uvarint()
-	if l > 0 {
-		fh.PositiveSpans = make([]histogram.Span, l)
-	}
+	fh.PositiveSpans = slices.Grow(fh.PositiveSpans[:0], l)[:l]
 	for i := range fh.PositiveSpans {
 		fh.PositiveSpans[i].Offset = int32(buf.Varint64())
 		fh.PositiveSpans[i].Length = buf.Uvarint32()
 	}
 
 	l = buf.Uvarint()
-	if l > 0 {
-		fh.NegativeSpans = make([]histogram.Span, l)
-	}
+	fh.NegativeSpans = slices.Grow(fh.NegativeSpans[:0], l)[:l]
 	for i := range fh.NegativeSpans {
 		fh.NegativeSpans[i].Offset = int32(buf.Varint64())
 		fh.NegativeSpans[i].Length = buf.Uvarint32()
 	}
 
 	l = buf.Uvarint()
-	if l > 0 {
-		fh.PositiveBuckets = make([]float64, l)
-	}
+	fh.PositiveBuckets = slices.Grow(fh.PositiveBuckets[:0], l)[:l]
 	for i := range fh.PositiveBuckets {
 		fh.PositiveBuckets[i] = buf.Be64Float64()
 	}
 
 	l = buf.Uvarint()
-	if l > 0 {
-		fh.NegativeBuckets = make([]float64, l)
-	}
+	fh.NegativeBuckets = slices.Grow(fh.NegativeBuckets[:0], l)[:l]
 	for i := range fh.NegativeBuckets {
 		fh.NegativeBuckets[i] = buf.Be64Float64()
 	}
 
 	if histogram.IsCustomBucketsSchema(fh.Schema) {
 		l = buf.Uvarint()
-		if l > 0 {
-			fh.CustomValues = make([]float64, l)
-		}
+		fh.CustomValues = slices.Grow(fh.CustomValues[:0], l)[:l]
 		for i := range fh.CustomValues {
 			fh.CustomValues[i] = buf.Be64Float64()
 		}
+	} else {
+		fh.CustomValues = nil
 	}
 }
 

--- a/tsdb/wlog/watcher.go
+++ b/tsdb/wlog/watcher.go
@@ -617,6 +617,12 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			if len(histogramsToSend) > 0 {
 				w.writer.AppendHistograms(histogramsToSend)
 			}
+			// Zero H pointers so the capacity slots are not reused for the
+			// next WAL record's decode: H escapes into the writer queue and
+			// must not be overwritten by a subsequent DecodeHistogram call.
+			for i := range histograms {
+				histograms[i].H = nil
+			}
 
 		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
 			// Skip if "native histograms over remote write" is not enabled.
@@ -646,6 +652,9 @@ func (w *Watcher) readSegment(r *LiveReader, segmentNum int, tail bool) error {
 			}
 			if len(floatHistogramsToSend) > 0 {
 				w.writer.AppendFloatHistograms(floatHistogramsToSend)
+			}
+			for i := range floatHistograms {
+				floatHistograms[i].FH = nil
 			}
 
 		case record.Metadata:


### PR DESCRIPTION
## Summary

`DecodeHistogram` and `DecodeFloatHistogram` allocated one `*histogram.Histogram` plus up to four internal slices (`PositiveSpans`, `NegativeSpans`, `PositiveBuckets`, `NegativeBuckets`) per decoded sample on every call, even when the caller supplied a pre-grown reuse slice.

Two changes eliminate this for callers that decode in a loop with the same slice:

- **`nextHistogram` / `nextFloatHistogram` helpers** look at the capacity slot at index `len(out)` before allocating. When the caller resets the slice with `out[:0]` between records — as `wlog.Checkpoint` does — the struct and its backing arrays from the previous iteration are reused automatically.

- **`slices.Grow` in `DecodeHistogram` / `DecodeFloatHistogram`** replaces every per-field `make([]T, l)` with `slices.Grow(s[:0], l)[:l]`. For a reused histogram whose slice already has `cap >= l`, `Grow` returns the existing backing array without allocating; for a fresh struct it behaves identically to `make`. An explicit `h.CustomValues = nil` branch is added for non-custom-bucket schemas to uphold the invariant documented in `histogram.CopyTo`.

The ownership invariant is documented on `nextHistogram`: H pointers sitting in capacity slots beyond `len(out)` must not be retained by the caller after passing `out[:0]` back for the next decode. Callers that store H pointers across decode calls must copy first (`h.H.Copy()`) or pass `nil` to disable reuse. `readWALSamples` in `db_test.go` is fixed accordingly.

**Beneficiaries:**
- `wlog.Checkpoint`: iterates over all WAL segments in a loop, resetting the slice with `[:0]` at the top of each record; the encoder reads `H` synchronously without retaining the pointer, so the invariant holds.
- Any streaming decoder that calls `dec.HistogramSamples(rec, buf[:0])` in a tight loop without storing H pointers across iterations.

**Not affected:** WAL replay and the remote-write WAL watcher both call `clear()` on the slice before returning it to their pools, which zeros the H pointers and prevents reuse — required because H escapes to `lastHistogramValue` (replay) and the remote-write shard queue (watcher).

## Benchmarks

```
go test -count=6 -benchmem -benchtime=5s -bench BenchmarkCheckpoint/checkpoint=wlog ./tsdb/agent/
benchstat before.txt after.txt
```

```
BenchmarkCheckpoint/checkpoint=wlog (tsdb/agent)
                  │    before     │               after               │
                  │   allocs/op   │  allocs/op    vs base             │
checkpoint=wlog   │ 2928.21k ±17% │  76.31k ± 6%  -97.39% (p=0.002)  │

                  │    before     │              after                │
                  │     B/op      │    B/op       vs base             │
checkpoint=wlog   │ 151.14Mi ±16% │ 11.91Mi ± 2%  -92.12% (p=0.002)  │

                  │    before     │              after                │
                  │    sec/op     │   sec/op      vs base             │
checkpoint=wlog   │  255.4m ±10%  │  224.0m ± 5%  -12.29% (p=0.002)  │
```

```release-notes
[PERF] tsdb/record: Reuse histogram objects across WAL checkpoint decode iterations, reducing allocations by ~97% and heap bytes by ~92% during WAL checkpointing.
```