### PR TITLE
remote write: reject unsorted labels in receiver

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -52,6 +52,8 @@ type writeHandler struct {
 
 const maxAheadTime = 10 * time.Minute
 
+var errLabelsNotSorted = errors.New("labels are not sorted")
+
 // NewWriteHandler creates a http.Handler that accepts remote write requests with
 // the given message in acceptedMsgs and writes them to the provided appendable.
 //
@@ -112,6 +114,9 @@ func (h *writeHandler) Store(r *http.Request, msgType remoteapi.WriteMessageType
 		}
 		if err = h.write(r.Context(), &req); err != nil {
 			switch {
+			case errors.Is(err, errLabelsNotSorted):
+				wr.SetStatusCode(http.StatusBadRequest)
+				return wr, err
 			case errors.Is(err, storage.ErrOutOfOrderSample), errors.Is(err, storage.ErrOutOfBounds), errors.Is(err, storage.ErrDuplicateSampleForTimestamp), errors.Is(err, storage.ErrTooOldSample):
 				// Indicated an out-of-order sample is a bad request to prevent retries.
 				wr.SetStatusCode(http.StatusBadRequest)
@@ -169,6 +174,12 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 
 	b := labels.NewScratchBuilder(0)
 	for _, ts := range req.Timeseries {
+		if !labelProtosNamesSorted(ts.Labels) {
+			h.logger.Warn("Invalid labels for series.", "labels", ts.Labels, "err", errLabelsNotSorted)
+			h.samplesWithInvalidLabelsTotal.Inc()
+			return fmt.Errorf("%w for series %v", errLabelsNotSorted, ts.Labels)
+		}
+
 		ls := ts.ToLabels(&b, nil)
 
 		// TODO(bwplotka): Even as per 1.0 spec, this should be a 400 error, while other samples are
@@ -312,6 +323,12 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 		b = labels.NewScratchBuilder(0)
 	)
 	for _, ts := range req.Timeseries {
+		if !labelRefsNamesSorted(ts.LabelsRefs, req.Symbols) {
+			badRequestErrs = append(badRequestErrs, fmt.Errorf("labels for series %v are not sorted", ts.LabelsRefs))
+			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)
+			continue
+		}
+
 		ls, err := ts.ToLabels(&b, req.Symbols)
 		if err != nil {
 			badRequestErrs = append(badRequestErrs, fmt.Errorf("parsing labels for series %v: %w", ts.LabelsRefs, err))
@@ -476,6 +493,34 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 	}
 	// TODO(bwplotka): Better concat formatting? Perhaps add size limit?
 	return samplesWithoutMetadata, http.StatusBadRequest, errors.Join(badRequestErrs...)
+}
+
+func labelProtosNamesSorted(labelPairs []prompb.Label) bool {
+	for i := 1; i < len(labelPairs); i++ {
+		if labelPairs[i-1].Name > labelPairs[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+func labelRefsNamesSorted(labelRefs []uint32, symbols []string) bool {
+	if len(labelRefs)%2 != 0 {
+		return true
+	}
+	var previousName string
+	for i := 0; i < len(labelRefs); i += 2 {
+		nameRef, valueRef := labelRefs[i], labelRefs[i+1]
+		if uint64(nameRef) >= uint64(len(symbols)) || uint64(valueRef) >= uint64(len(symbols)) {
+			return true
+		}
+		name := symbols[nameRef]
+		if i > 0 && previousName > name {
+			return false
+		}
+		previousName = name
+	}
+	return true
 }
 
 // handleHistogramZeroSample appends ST as a zero-value sample with st value as the sample timestamp.

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -338,6 +338,33 @@ func TestRemoteWriteHandler_V1Message(t *testing.T) {
 	}
 }
 
+func TestRemoteWriteHandler_V1Message_RejectsUnsortedLabels(t *testing.T) {
+	payload, _, _, err := buildWriteRequest(nil, []prompb.TimeSeries{{
+		Labels: []prompb.Label{
+			{Name: "foo", Value: "bar"},
+			{Name: "__name__", Value: "test_metric"},
+		},
+		Samples: []prompb.Sample{{Value: 1, Timestamp: 1}},
+	}}, nil, nil, nil, nil, "snappy")
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(payload))
+	require.NoError(t, err)
+
+	appendable := &mockAppendable{}
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	resp := recorder.Result()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Contains(t, string(body), "labels are not sorted")
+	require.Empty(t, appendable.samples)
+}
+
 func expectHeaderValue(t testing.TB, expected int, got string) {
 	t.Helper()
 
@@ -405,6 +432,15 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 				writeV2RequestFixture.Timeseries...),
 			expectedCode:     http.StatusBadRequest,
 			expectedRespBody: "invalid labels for series, labels {__name__=\"test_metric1\", test_metric1=\"test_metric1\", test_metric1=\"test_metric1\"}, duplicated label test_metric1\n",
+		},
+		{
+			desc: "Partial write; first series with unsorted labels",
+			input: append(
+				// Series with foo="bar",__name__="test_metric1" labels.
+				[]writev2.TimeSeries{{LabelsRefs: []uint32{9, 10, 1, 2}, Samples: []writev2.Sample{{Value: 1, Timestamp: 1}}}},
+				writeV2RequestFixture.Timeseries...),
+			expectedCode:     http.StatusBadRequest,
+			expectedRespBody: "labels for series [9 10 1 2] are not sorted\n",
 		},
 		{
 			desc: "Partial write; first series with odd number of label refs",


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #11505.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] Remote write: Reject incoming series with unsorted label names.
```

This validates that incoming remote write label names are sorted before converting them to `labels.Labels`. Previously the conversion path sorted the labels, so malformed remote write input could be accepted instead of rejected.

For remote write 1.0, unsorted labels return HTTP 400. For remote write 2.0, unsorted time series are handled as partial-write bad requests, consistent with the existing non-retriable label validation behavior. Existing parsing errors for odd or out-of-bounds label refs are preserved.

Tests:
- `go test ./storage/remote -run TestRemoteWriteHandler_V1Message_RejectsUnsortedLabels|TestRemoteWriteHandler_V2Message`
- `go test ./storage/remote`