### PR TITLE
ui: improve alert group label contrast

### DIFF
--- a/web/ui/mantine-ui/src/pages/AlertsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.tsx
@@ -230,7 +230,11 @@ export default function AlertsPage() {
         <Card shadow="xs" withBorder p="md" key={`${g.file}-${g.name}`}>
           <Group mb="sm" justify="space-between">
             <Group align="baseline">
-              <Text fz="xl" fw={600} c="var(--mantine-primary-color-filled)">
+              <Text
+                fz="xl"
+                fw={600}
+                c="light-dark(var(--mantine-primary-color-filled), var(--mantine-color-blue-3))"
+              >
                 {g.name}
               </Text>
               <Text fz="sm" c="gray.6">


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18776.

This updates the Alerts page rule group label color in dark theme to use a lighter Mantine blue token while preserving the existing filled primary color in light theme.

The previous dark-theme color reported in the issue had a contrast ratio of 2.70:1 against the rule group card background. The new dark-theme color has a contrast ratio of 6.91:1 against the same background, satisfying WCAG AA for normal text.

Validation:

- `npm run lint -w @prometheus-io/mantine-ui`
- `npm run build:module`
- `npm run build -w @prometheus-io/mantine-ui`

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] UI: Improve Alerts page rule group label contrast in dark theme.
```
