### PR TITLE
scrape: add dns_refresh_interval to force periodic DNS re-resolution for FQDN targets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -818,6 +818,9 @@ type ScrapeConfig struct {
 	// More than this label value length post metric-relabeling will cause the
 	// scrape to fail. 0 means no limit.
 	LabelValueLengthLimit uint `yaml:"label_value_length_limit,omitempty"`
+	// How often to close idle HTTP connections and force DNS re-resolution for
+	// targets using FQDNs. 0 disables periodic refresh (default).
+	DNSRefreshInterval model.Duration `yaml:"dns_refresh_interval,omitempty"`
 	// If there are more than this many buckets in a native histogram,
 	// buckets will be merged to stay within the limit.
 	NativeHistogramBucketLimit uint `yaml:"native_histogram_bucket_limit,omitempty"`

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -110,9 +110,10 @@ type scrapePool struct {
 	// newLoop injection for testing purposes.
 	injectTestNewLoop func(scrapeLoopOptions) loop
 
-	metrics    *scrapeMetrics
-	buffers    *pool.Pool
-	offsetSeed uint64
+	metrics            *scrapeMetrics
+	buffers            *pool.Pool
+	offsetSeed         uint64
+	dnsRefreshInterval time.Duration
 }
 
 type labelLimits struct {
@@ -185,9 +186,29 @@ func newScrapePool(
 		metrics:              metrics,
 		buffers:              buffers,
 		offsetSeed:           offsetSeed,
+		dnsRefreshInterval:   time.Duration(cfg.DNSRefreshInterval),
 	}
 	sp.metrics.targetScrapePoolTargetLimit.WithLabelValues(sp.config.JobName).Set(float64(sp.config.TargetLimit))
+	if sp.dnsRefreshInterval > 0 {
+		go sp.runDNSRefresh()
+	}
 	return sp, nil
+}
+
+// runDNSRefresh periodically closes idle HTTP connections so that the next
+// scrape re-dials and re-resolves DNS for all targets in this pool.
+// It exits when the pool's context is cancelled (i.e. on stop or reload).
+func (sp *scrapePool) runDNSRefresh() {
+	ticker := time.NewTicker(sp.dnsRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-sp.ctx.Done():
+			return
+		case <-ticker.C:
+			sp.client.CloseIdleConnections()
+		}
+	}
 }
 
 func (sp *scrapePool) newLoop(opts scrapeLoopOptions) loop {
@@ -291,6 +312,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 
 	reuseCache := reusableCache(sp.config, cfg)
 	sp.config = cfg
+	sp.dnsRefreshInterval = time.Duration(cfg.DNSRefreshInterval)
 	oldClient := sp.client
 	sp.client = client
 

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -125,6 +125,50 @@ func testNewScrapePool(t *testing.T, appV2 bool) {
 	require.Nil(t, sp.appendableV2)
 }
 
+func TestScrapePoolDNSRefresh(t *testing.T) {
+	t.Parallel()
+
+	var closeCount atomic.Int32
+	client := &http.Client{Transport: &closeCountingTransport{closed: &closeCount}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sp := &scrapePool{
+		ctx:                context.Background(),
+		cancel:             cancel,
+		client:             client,
+		dnsRefreshInterval: 20 * time.Millisecond,
+		loops:              map[uint64]loop{},
+		activeTargets:      map[uint64]*Target{},
+		config:             &config.ScrapeConfig{},
+		options:            &Options{},
+		logger:             promslog.NewNopLogger(),
+		symbolTable:        labels.NewSymbolTable(),
+		metrics:            newTestScrapeMetrics(t),
+	}
+	sp.ctx = ctx
+
+	go sp.runDNSRefresh()
+
+	// Wait long enough for at least two refresh ticks.
+	time.Sleep(60 * time.Millisecond)
+	cancel()
+
+	require.GreaterOrEqual(t, closeCount.Load(), int32(2), "expected at least 2 CloseIdleConnections calls")
+}
+
+// closeCountingTransport counts CloseIdleConnections calls.
+type closeCountingTransport struct {
+	closed *atomic.Int32
+}
+
+func (ct *closeCountingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("not used")
+}
+
+func (ct *closeCountingTransport) CloseIdleConnections() {
+	ct.closed.Add(1)
+}
+
 func TestStorageHandlesOutOfOrderTimestamps(t *testing.T) {
 	foreachAppendable(t, func(t *testing.T, appV2 bool) {
 		testStorageHandlesOutOfOrderTimestamps(t, appV2)

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -161,7 +161,7 @@ type closeCountingTransport struct {
 	closed *atomic.Int32
 }
 
-func (ct *closeCountingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+func (*closeCountingTransport) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, errors.New("not used")
 }
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18387

```release-notes
[FEATURE] Scrape: add `dns_refresh_interval` to `scrape_config` to periodically close idle HTTP connections and force DNS re-resolution for FQDN targets.
```

## What does this PR do?

Adds a `dns_refresh_interval` field to `ScrapeConfig`. When set, a background goroutine periodically calls `client.CloseIdleConnections()` on the scrape pool's HTTP client, forcing a fresh TCP dial — and therefore DNS re-resolution — on the next scrape cycle.

This fixes the case where a target is addressed by FQDN (e.g. a CNAME that points to a changing A record) and Prometheus continues connecting to a stale IP because `http.Transport` reuses idle TCP connections indefinitely; `DialContext` (and thus the OS resolver) is only invoked when a new connection is opened.

## Why this approach?

Root cause analysis (from the issue thread): the bug is in the scrape layer's connection reuse, not in Consul SD or any other SD mechanism. Any SD that provides an FQDN in `__address__` is affected.

The fix is opt-in: the zero value (default) disables the behaviour and preserves existing connection-reuse semantics. The approach mirrors `discovery/dns`'s `refresh_interval` pattern already present in the codebase.

## Changes

- `config/config.go`: adds `DNSRefreshInterval model.Duration` to `ScrapeConfig`
- `scrape/scrape.go`: adds `dnsRefreshInterval` to `scrapePool`; wires it from config in `newScrapePool` and `reload`; adds `runDNSRefresh()` goroutine
- `scrape/scrape_test.go`: adds `TestScrapePoolDNSRefresh` verifying that `CloseIdleConnections` is called at the configured interval

## Example config

```yaml
scrape_configs:
  - job_name: my-fqdn-targets
    dns_refresh_interval: 30s   # re-resolve DNS every 30 seconds
    consul_sd_configs:
      - server: consul.example.com
```

## Design question for maintainers: periodic flush vs DNS-aware detection

> I want to be upfront about a gap between this implementation and the language used in the issue thread.

@bwplotka's comment on the issue says _"detecting DNS changes"_, which implies the ideal solution would only force reconnection **when the resolved IP actually changes** — DNS-aware detection. This implementation takes a simpler but broader approach: it blindly calls `CloseIdleConnections()` on a fixed timer, which drops **all** idle connections for the scrape pool (not just those whose DNS record changed), regardless of whether the IP is still the same.

**Concretely, the two approaches differ in blast radius:**

| Approach | How it works | Blast radius |
|---|---|---|
| **This PR** (periodic flush) | Timer fires → `CloseIdleConnections()` on all idle connections | All idle connections for the job, even stable IPs |
| **DNS-aware detection** | Before/after each dial, resolve hostname → compare IP → break connection if changed | Only connections whose backing IP actually changed |

The DNS-aware approach would require wrapping the `DialContext` used by the scrape pool's `http.Transport` to cache the last-resolved IP per hostname and force a new dial when it changes. This is more surgical but more complex (and requires storing per-host resolver state).

**Question for reviewers:** Is the periodic `CloseIdleConnections()` approach acceptable here, or would you prefer the DNS-aware `DialContext` wrapper? Happy to implement the more targeted approach if that's the direction — wanted to surface this trade-off before investing further.

## Open questions

1. Should there be a global default in `GlobalConfig` (like `scrape_interval` has), or is zero/disabled the right default?
2. Is `dns_refresh_interval` the right name, or would something like `connection_refresh_interval` be more accurate (since `CloseIdleConnections` affects all idle connections, not just DNS-backed ones)?
3. Any preference on whether the goroutine lives on `scrapePool` (as implemented) vs a ticker inside `scrapeLoop.run()` — the pool approach calls `CloseIdleConnections` once for all loops in a job, which seems preferable.

/cc @bwplotka @mrvarmazyar @roidelapluie