### PR TITLE
fix: improve promtool health check documentation for authentication (#18807)

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -94,7 +94,7 @@ var (
 	lintConfigOptions = append(append([]string{}, lintRulesOptions...), lintOptionTooLongScrapeInterval)
 )
 
-const httpConfigFileDescription = "HTTP client configuration file, see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool"
+const httpConfigFileDescription = "HTTP client configuration file (supports TLS, basic auth, OAuth2, etc.), see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool"
 
 func main() {
 	var (
@@ -144,11 +144,11 @@ func main() {
 		"The config files to check.",
 	).Required().ExistingFiles()
 
-	checkServerHealthCmd := checkCmd.Command("healthy", "Check if the Prometheus server is healthy.")
+	checkServerHealthCmd := checkCmd.Command("healthy", "Check if the Prometheus server is healthy. Use --http.config.file flag to pass authentication credentials.")
 	checkServerHealthCmd.Flag("http.config.file", httpConfigFileDescription).PlaceHolder("<filename>").ExistingFileVar(&httpConfigFilePath)
 	checkServerHealthCmd.Flag("url", "The URL for the Prometheus server.").Default("http://localhost:9090").URLVar(&serverURL)
 
-	checkServerReadyCmd := checkCmd.Command("ready", "Check if the Prometheus server is ready.")
+	checkServerReadyCmd := checkCmd.Command("ready", "Check if the Prometheus server is ready. Use --http.config.file flag to pass authentication credentials.")
 	checkServerReadyCmd.Flag("http.config.file", httpConfigFileDescription).PlaceHolder("<filename>").ExistingFileVar(&httpConfigFilePath)
 	checkServerReadyCmd.Flag("url", "The URL for the Prometheus server.").Default("http://localhost:9090").URLVar(&serverURL)
 

--- a/cmd/promtool/main_healthcheck_test.go
+++ b/cmd/promtool/main_healthcheck_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	promconfig "github.com/prometheus/common/config"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCheckServerStatusWithBasicAuth verifies health check works with basic auth

--- a/cmd/promtool/main_healthcheck_test.go
+++ b/cmd/promtool/main_healthcheck_test.go
@@ -1,3 +1,16 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -12,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCheckServerStatusWithBasicAuth verifies health check works with basic auth
+// TestCheckServerStatusWithBasicAuth verifies health check works with basic auth.
 func TestCheckServerStatusWithBasicAuth(t *testing.T) {
 	// Create a test HTTP server that requires basic auth
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -32,7 +45,7 @@ func TestCheckServerStatusWithBasicAuth(t *testing.T) {
   password: secret
 `
 	configFile := filepath.Join(t.TempDir(), "http-config.yml")
-	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0o644))
 
 	// Load HTTP config
 	httpConfig, _, err := promconfig.LoadHTTPConfigFile(configFile)
@@ -51,7 +64,7 @@ func TestCheckServerStatusWithBasicAuth(t *testing.T) {
 	require.NoError(t, err, "health check should succeed with correct basic auth")
 }
 
-// TestCheckServerStatusWithoutAuth verifies health check fails without auth
+// TestCheckServerStatusWithoutAuth verifies health check fails without auth.
 func TestCheckServerStatusWithoutAuth(t *testing.T) {
 	// Create a test HTTP server that requires basic auth
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/promtool/main_healthcheck_test.go
+++ b/cmd/promtool/main_healthcheck_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	promconfig "github.com/prometheus/common/config"
+)
+
+// TestCheckServerStatusWithBasicAuth verifies health check works with basic auth
+func TestCheckServerStatusWithBasicAuth(t *testing.T) {
+	// Create a test HTTP server that requires basic auth
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "alice" || password != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
+	defer server.Close()
+
+	// Create HTTP config file with basic auth
+	configContent := `basic_auth:
+  username: alice
+  password: secret
+`
+	configFile := filepath.Join(t.TempDir(), "http-config.yml")
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	// Load HTTP config
+	httpConfig, _, err := promconfig.LoadHTTPConfigFile(configFile)
+	require.NoError(t, err)
+
+	// Create round tripper from config
+	httpRoundTripper, err := promconfig.NewRoundTripperFromConfig(*httpConfig, "promtool", promconfig.WithUserAgent("test"))
+	require.NoError(t, err)
+
+	// Parse server URL
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	// Check server status with auth
+	err = CheckServerStatus(serverURL, "/-/healthy", httpRoundTripper)
+	require.NoError(t, err, "health check should succeed with correct basic auth")
+}
+
+// TestCheckServerStatusWithoutAuth verifies health check fails without auth
+func TestCheckServerStatusWithoutAuth(t *testing.T) {
+	// Create a test HTTP server that requires basic auth
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "alice" || password != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Parse server URL
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	// Check server status without auth
+	err = CheckServerStatus(serverURL, "/-/healthy", http.DefaultClient.Transport)
+	require.Error(t, err, "health check should fail without auth")
+	require.ErrorContains(t, err, "status=401")
+}

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -133,7 +133,7 @@ Check if the web config files are valid or not.
 
 ##### `promtool check healthy`
 
-Check if the Prometheus server is healthy.
+Check if the Prometheus server is healthy. Use `--http`.config.file flag to pass authentication credentials.
 
 
 
@@ -141,7 +141,7 @@ Check if the Prometheus server is healthy.
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file, see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool |  |
+| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file (supports TLS, basic auth, OAuth2, etc.), see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool |  |
 | <code class="text-nowrap">--url</code> | The URL for the Prometheus server. | `http://localhost:9090` |
 
 
@@ -149,7 +149,7 @@ Check if the Prometheus server is healthy.
 
 ##### `promtool check ready`
 
-Check if the Prometheus server is ready.
+Check if the Prometheus server is ready. Use `--http`.config.file flag to pass authentication credentials.
 
 
 
@@ -157,7 +157,7 @@ Check if the Prometheus server is ready.
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file, see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool |  |
+| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file (supports TLS, basic auth, OAuth2, etc.), see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool |  |
 | <code class="text-nowrap">--url</code> | The URL for the Prometheus server. | `http://localhost:9090` |
 
 
@@ -224,7 +224,7 @@ Run query against a Prometheus server.
 | Flag | Description | Default |
 | --- | --- | --- |
 | <code class="text-nowrap">-o</code>, <code class="text-nowrap">--format</code> | Output format of the query. | `promql` |
-| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file, see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool |  |
+| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file (supports TLS, basic auth, OAuth2, etc.), see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool |  |
 
 
 
@@ -416,7 +416,7 @@ Push to a Prometheus server.
 
 | Flag | Description |
 | --- | --- |
-| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file, see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool |
+| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file (supports TLS, basic auth, OAuth2, etc.), see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool |
 
 
 
@@ -686,7 +686,7 @@ Create blocks of data for new recording rules.
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file, see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool |  |
+| <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file (supports TLS, basic auth, OAuth2, etc.), see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool |  |
 | <code class="text-nowrap">--url</code> | The URL for the Prometheus API with the data where the rule will be backfilled from. | `http://localhost:9090` |
 | <code class="text-nowrap">--start</code> | The time to start backfilling the new rule from. Must be a RFC3339 formatted date or Unix timestamp. Required. |  |
 | <code class="text-nowrap">--end</code> | If an end time is provided, all recording rules in the rule files provided will be backfilled to the end time. Default will backfill up to 3 hours ago. Must be a RFC3339 formatted date or Unix timestamp. |  |

--- a/documentation/examples/promtool-healthcheck-with-auth.md
+++ b/documentation/examples/promtool-healthcheck-with-auth.md
@@ -1,0 +1,91 @@
+# Using Promtool Health Check with Authentication
+
+When your Prometheus server requires authentication (basic auth, TLS, etc.), you can use the `--http.config.file` flag to pass the necessary credentials to `promtool check healthy` and `promtool check ready` commands.
+
+## Basic Authentication Example
+
+### 1. Create an HTTP config file with basic auth
+
+Create a file named `promtool-auth.yml`:
+
+```yaml
+basic_auth:
+  username: alice
+  password: verylongpassword
+```
+
+### 2. Use it with promtool health check
+
+```bash
+promtool check healthy --http.config.file=promtool-auth.yml --url=https://prometheus.example.com:9090
+```
+
+## TLS and Basic Authentication Example
+
+If your Prometheus server requires both TLS and basic authentication:
+
+```yaml
+basic_auth:
+  username: alice
+  password: verylongpassword
+
+tls_config:
+  ca_file: /path/to/ca.crt
+  cert_file: /path/to/client.crt
+  key_file: /path/to/client.key
+  insecure_skip_verify: false
+```
+
+## Docker Usage
+
+When running Prometheus in Docker with health checks that require authentication:
+
+```yaml
+# docker-compose.yml
+prometheus:
+  image: prom/prometheus:latest
+  ports:
+    - "9090:9090"
+  healthcheck:
+    test: ["CMD", "promtool", "check", "healthy", "--http.config.file=/etc/prometheus/promtool-auth.yml", "--url=http://localhost:9090"]
+    interval: 10s
+    timeout: 5s
+    retries: 3
+  volumes:
+    - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    - ./promtool-auth.yml:/etc/prometheus/promtool-auth.yml
+    - ./web-config.yml:/etc/prometheus/web-config.yml
+```
+
+With `web-config.yml` requiring authentication:
+
+```yaml
+basic_auth_users:
+  alice: $2y$10$...  # bcrypt hashed password
+```
+
+## Security Considerations
+
+- **Plaintext Passwords**: The HTTP config file contains plaintext passwords. Ensure proper file permissions (e.g., `chmod 600 promtool-auth.yml`).
+- **Password Files**: Consider using `password_file` or `password_ref` instead of inline plaintext passwords:
+
+```yaml
+basic_auth:
+  username: alice
+  password_file: /etc/prometheus/prometheus-password.txt
+```
+
+## Troubleshooting
+
+If you get a 401 Unauthorized error:
+
+1. Verify credentials in your config file match those configured in Prometheus
+2. Check the HTTP config file path is correct and readable
+3. Ensure the `--url` matches the Prometheus server address
+
+Example debugging:
+
+```bash
+# Enable verbose output to see what's happening
+promtool check healthy --http.config.file=promtool-auth.yml --url=https://prometheus.example.com:9090 -v
+```


### PR DESCRIPTION
## Summary
Improves promtool health check documentation to clarify authentication support and adds comprehensive test cases.

## Changes

### Documentation & Help Text
- Enhanced `httpConfigFileDescription` to explicitly mention authentication support
- Updated `healthy` command help to mention `--http.config.file` flag for authentication
- Updated `ready` command help to mention `--http.config.file` flag for authentication
- Added comprehensive documentation with examples for:
  - Basic authentication
  - TLS and basic authentication combined
  - Docker usage with health checks
  - Security considerations
  - Troubleshooting guide

### Test Coverage
Added test cases verifying:
- Health checks work correctly with basic auth credentials via HTTP config file
- Health checks properly fail (401) when credentials are missing

```release-notes
[ENHANCEMENT] Improves promtool health check documentation to clarify that --http.config.file flag supports authentication (basic auth, TLS, OAuth2). Adds test cases verifying basic auth functionality works correctly.
```

## Fixes
Fixes #18807