### PR TITLE
chunkenc: reduce chunkAllocationSize from 128 to 32 to avoid multi-GB heap waste

### DIFF
--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -53,7 +53,7 @@ import (
 
 const (
 	chunkHeaderSize               = 2
-	chunkAllocationSize           = 128
+	chunkAllocationSize           = 32
 	chunkCompactCapacityThreshold = 32
 )
 


### PR DESCRIPTION
## Problem

`NewXORChunk`, `NewXOR2Chunk`, `NewHistogramChunk`, and `NewFloatHistogramChunk` pre-allocate a 128-byte backing slice but the header size is only 2–3 bytes. In large Prometheus instances this causes multi-GB wasted heap — pprof showed ~2.79 GB net savings from reducing it.

## Root Cause

The `chunkAllocationSize` constant was set to 128 in the original implementation. While `chunkCompactCapacityThreshold` handles shrinking post-use, the initial allocation was unnecessarily large.

## Fix

Reduce `chunkAllocationSize` from 128 to 32, as discussed in the issue thread. This gives a middle ground: the first sample fits without any realloc, per-chunk waste drops from ~126 bytes to ~15 bytes (~88% reduction), and allocator pressure is unchanged vs the original value.

## Validation

- All existing tests in `tsdb/chunkenc/...` pass
- Single-constant change, zero behavioral impact on encoding/decoding

## Related

- Closes #18529
- Referenced in #18502

## DCO

Signed-off-by: Lohit Kolluri <lohitkolluri@gmail.com>