### PR TITLE
perf(model/labels): separate closure for setMatches in FastRegexMatcher

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -104,15 +104,18 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 
 // compileMatchStringFunction returns the function to run by MatchString().
 func (m *FastRegexMatcher) compileMatchStringFunction() func(string) bool {
+	if len(m.setMatches) != 0 {
+		return func(s string) bool {
+			return slices.Contains(m.setMatches, s)
+		}
+	}
+
 	// If the only optimization available is the string matcher, then we can just run it.
-	if len(m.setMatches) == 0 && m.prefix == "" && m.suffix == "" && len(m.contains) == 0 && m.stringMatcher != nil {
+	if m.prefix == "" && m.suffix == "" && len(m.contains) == 0 && m.stringMatcher != nil {
 		return m.stringMatcher.Matches
 	}
 
 	return func(s string) bool {
-		if len(m.setMatches) != 0 {
-			return slices.Contains(m.setMatches, s)
-		}
 		if m.prefix != "" && !strings.HasPrefix(s, m.prefix) {
 			return false
 		}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

I saw this on the profiling:

```
 Total:   38.2 mins  1.57 hours  (self, total)
   146            .           . 	// If the only optimization available is the string matcher, then we can just run it.
   147            .           . 	if len(m.setMatches) == 0 && m.prefix == "" && m.suffix == "" && len(m.contains) == 0 && m.stringMatcher != nil {
   148            .           . 		return m.stringMatcher.Matches
   149            .           . 	}
   150            .           .
   151    8.43 mins   8.46 mins 	return func(s string) bool {
   152    23.7 mins   23.8 mins 		if len(m.setMatches) != 0 {
   153    1.70 mins   26.3 mins 			return slices.Contains(m.setMatches, s)
   154            .           . 		}
   155    2.79 mins   21.4 mins 		if m.prefix != "" && !strings.HasPrefix(s, m.prefix) {
   156    1.04 mins   1.04 mins 			return false
   157            .           . 		}
   158       11.7 s   1.79 mins 		if m.suffix != "" && !strings.HasSuffix(s, m.suffix) {
   159       2.89 s      2.90 s 			return false
   160            .           . 		}
   161       7.04 s   9.47 mins 		if len(m.contains) > 0 && !containsInOrder(s, m.contains) {
   162       2.21 s      2.22 s 			return false
   163            .           . 		}
   164       1.38 s      1.38 s 		if m.stringMatcher != nil {
   165       5.75 s      58.3 s 			return m.stringMatcher.Matches(s)
   166            .           . 		}
   167        60 ms      36.5 s 		return m.re.MatchString(s)
   168            .           . 	}
   169            .           . }
   170            .           .
   171            .           . // IsOptimized returns true if any fast-path optimization is applied to the
   172            .           . // regex matcher.
```

We seem to spend too much time checking whether `setMatches` is non empty, but that decision is static once the matcher has been compiled.

This PR modifies FastRegexMatcher.compileMatchStringFunction to build a separate closure when setMatches is not empty: it's not necessary to check it on every matcher call.

I ran the benchmark suite but couldn't see any difference tbh. 

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[PERF] Improve performance of FastRegexpMatcher's pre-compiled matching function.
```
