### PR TITLE
perf(labels): check length bitmask (bloom filter) in FastRegexMatcher

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -81,19 +81,30 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 		if parsed.Op == syntax.OpConcat {
 			m.prefix, m.suffix, m.contains = optimizeConcatRegex(parsed)
 		}
-		if matches, caseSensitive := findSetMatches(parsed); caseSensitive {
-			m.setMatches = matches
+		if matches, caseSensitive := findSetMatches(parsed); len(matches) > 0 {
+			if caseSensitive {
+				m.setMatches = matches
+			}
+			if len(matches) > 1 {
+				emsm := newEqualMultiStringMatcher(caseSensitive, len(matches), 0, 0)
+				for _, match := range matches {
+					emsm.add(match)
+				}
+				m.stringMatcher = emsm
+			}
 		}
 
-		// Check if we have a pattern like .*-.*-.*.
-		// If so, then we can rely on the containsInOrder check in compileMatchStringFunction,
-		// so no further inspection of the string is required.
-		// We can't do this in stringMatcherFromRegexpInternal as we only want to apply this
-		// if the top-level pattern satisfies this requirement.
-		if isSimpleConcatenationPattern(parsed) {
-			m.stringMatcher = trueMatcher{}
-		} else {
-			m.stringMatcher = stringMatcherFromRegexp(parsed)
+		if m.stringMatcher == nil {
+			// Check if we have a pattern like .*-.*-.*.
+			// If so, then we can rely on the containsInOrder check in compileMatchStringFunction,
+			// so no further inspection of the string is required.
+			// We can't do this in stringMatcherFromRegexpInternal as we only want to apply this
+			// if the top-level pattern satisfies this requirement.
+			if isSimpleConcatenationPattern(parsed) {
+				m.stringMatcher = trueMatcher{}
+			} else {
+				m.stringMatcher = stringMatcherFromRegexp(parsed)
+			}
 		}
 
 		m.matchString = m.compileMatchStringFunction()
@@ -104,15 +115,17 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 
 // compileMatchStringFunction returns the function to run by MatchString().
 func (m *FastRegexMatcher) compileMatchStringFunction() func(string) bool {
+	// Special case for a single element matcher (equality).
+	if len(m.setMatches) == 1 {
+		return func(s string) bool { return s == m.setMatches[0] }
+	}
+
 	// If the only optimization available is the string matcher, then we can just run it.
-	if len(m.setMatches) == 0 && m.prefix == "" && m.suffix == "" && len(m.contains) == 0 && m.stringMatcher != nil {
+	if m.prefix == "" && m.suffix == "" && len(m.contains) == 0 && m.stringMatcher != nil {
 		return m.stringMatcher.Matches
 	}
 
 	return func(s string) bool {
-		if len(m.setMatches) != 0 {
-			return slices.Contains(m.setMatches, s)
-		}
 		if m.prefix != "" && !strings.HasPrefix(s, m.prefix) {
 			return false
 		}
@@ -835,12 +848,20 @@ func newEqualMultiStringMatcher(caseSensitive bool, estimatedSize, estimatedPref
 // equalMultiStringSliceMatcher matches a string exactly against a slice of valid values.
 type equalMultiStringSliceMatcher struct {
 	values []string
+	// lengthsMask is a bitmask of the lengths of the strings in values.
+	// If the bit at position i is set, it means that there's at least one string of length i in values.
+	// It's like a bloom filter but we don't hash, we just take the values.
+	// Bit 64 means there are strings longer than 63 characters.
+	// This can be used to filter case-sensitive values.
+	// Case-insensitive Unicode strings can have different lengths when case folded.
+	lengthsMask uint64
 
 	caseSensitive bool
 }
 
 func (m *equalMultiStringSliceMatcher) add(s string) {
 	m.values = append(m.values, s)
+	m.lengthsMask |= lengthMask(s)
 }
 
 func (*equalMultiStringSliceMatcher) addPrefix(string, bool, StringMatcher) {
@@ -853,7 +874,7 @@ func (m *equalMultiStringSliceMatcher) setMatches() []string {
 
 func (m *equalMultiStringSliceMatcher) Matches(s string) bool {
 	if m.caseSensitive {
-		return slices.Contains(m.values, s)
+		return m.lengthsMask&lengthMask(s) > 0 && slices.Contains(m.values, s)
 	}
 	for _, v := range m.values {
 		if strings.EqualFold(s, v) {
@@ -869,6 +890,13 @@ type equalMultiStringMapMatcher struct {
 	// values contains values to match a string against. If the matching is case insensitive,
 	// the values here must be lowercase.
 	values map[string]struct{}
+	// lengthsMask is a bitmask of the lengths of the strings in values.
+	// If the bit at position i is set, it means that there's at least one string of length i in values.
+	// It's like a bloom filter but we don't hash, we just take the values.
+	// Bit 64 means there are strings longer than 63 characters.
+	// This can be used to filter case-sensitive values.
+	// Case-insensitive Unicode strings can have different lengths when case folded.
+	lengthsMask uint64
 	// prefixes maps strings, all of length minPrefixLen, to sets of matchers to check the rest of the string.
 	// If the matching is case insensitive, prefixes are all lowercase.
 	prefixes map[string][]StringMatcher
@@ -880,6 +908,8 @@ type equalMultiStringMapMatcher struct {
 func (m *equalMultiStringMapMatcher) add(s string) {
 	if !m.caseSensitive {
 		s = toNormalisedLower(s, nil) // Don't pass a stack buffer here - it will always escape to heap.
+	} else {
+		m.lengthsMask |= lengthMask(s)
 	}
 
 	m.values[s] = struct{}{}
@@ -918,6 +948,9 @@ func (m *equalMultiStringMapMatcher) setMatches() []string {
 
 func (m *equalMultiStringMapMatcher) Matches(s string) bool {
 	if len(m.values) > 0 {
+		if m.minPrefixLen == 0 && m.caseSensitive && m.lengthsMask&lengthMask(s) == 0 {
+			return false
+		}
 		sNorm := s
 		var a [32]byte
 		if !m.caseSensitive {
@@ -1184,4 +1217,10 @@ func containsInOrderMulti(s string, contains []string) bool {
 	}
 
 	return true
+}
+
+// lengthMask returns a bitmask with the bit at position len(s) set to 1, and all other bits set to 0.
+// If len(s) is greater than 63, it returns a bitmask with only the bit at position 63 set to 1.
+func lengthMask(s string) uint64 {
+	return 1 << min(len(s), 63)
 }

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -379,10 +379,10 @@ func TestNewFastRegexMatcher(t *testing.T) {
 		{"^foo$", &equalStringMatcher{s: "foo", caseSensitive: true}},
 		{"^(?i:foo)$", &equalStringMatcher{s: "FOO", caseSensitive: false}},
 		{"^((?i:foo)|(bar))$", orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO", caseSensitive: false}, &equalStringMatcher{s: "bar", caseSensitive: true}})},
-		{`(?i:((foo|bar)))`, orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO", caseSensitive: false}, &equalStringMatcher{s: "BAR", caseSensitive: false}})},
-		{`(?i:((foo1|foo2|bar)))`, orStringMatcher([]StringMatcher{orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO1", caseSensitive: false}, &equalStringMatcher{s: "FOO2", caseSensitive: false}}), &equalStringMatcher{s: "BAR", caseSensitive: false}})},
+		{`(?i:((foo|bar)))`, &equalMultiStringSliceMatcher{values: []string{"FOO", "BAR"}, lengthsMask: 0b1000, caseSensitive: false}},
+		{`(?i:((foo1|foo2|bar)))`, &equalMultiStringSliceMatcher{values: []string{"FOO1", "FOO2", "BAR"}, lengthsMask: 0b11000, caseSensitive: false}},
 		{"^((?i:foo|oo)|(bar))$", orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO", caseSensitive: false}, &equalStringMatcher{s: "OO", caseSensitive: false}, &equalStringMatcher{s: "bar", caseSensitive: true}})},
-		{"(?i:(foo1|foo2|bar))", orStringMatcher([]StringMatcher{orStringMatcher([]StringMatcher{&equalStringMatcher{s: "FOO1", caseSensitive: false}, &equalStringMatcher{s: "FOO2", caseSensitive: false}}), &equalStringMatcher{s: "BAR", caseSensitive: false}})},
+		{"(?i:(foo1|foo2|bar))", &equalMultiStringSliceMatcher{values: []string{"FOO1", "FOO2", "BAR"}, lengthsMask: 0b11000, caseSensitive: false}},
 		{".*foo.*", trueMatcher{}},     // The containsInOrder check done in the function returned by compileMatchStringFunction is sufficient.
 		{"(.*)foo.*", trueMatcher{}},   // The containsInOrder check done in the function returned by compileMatchStringFunction is sufficient.
 		{"(.*)foo(.*)", trueMatcher{}}, // The containsInOrder check done in the function returned by compileMatchStringFunction is sufficient.
@@ -406,7 +406,7 @@ func TestNewFastRegexMatcher(t *testing.T) {
 		{"^(.*)((?i)foo|foobar)(.*)$", nil},
 		{"(api|rpc)_(v1|prom)_((?i)push|query)", nil},
 		{"[a-z][a-z]", nil},
-		{"[1^3]", nil},
+		{"[1^3]", &equalMultiStringSliceMatcher{values: []string{"1", "3", "^"}, lengthsMask: 0b10, caseSensitive: true}},
 		{".*foo.*bar.*", trueMatcher{}}, // The containsInOrder check done in the function returned by compileMatchStringFunction is sufficient.
 		{`\d*`, nil},
 		{".", nil},


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:

This replaces the ad-hoc usage of `setMatches` in `compileMatchStringFunction` by existing well-optimized logic from `newEqualMultiStringMatcher`: it works better with a high number of values, and also (didn't check why, but benchmarks say so) works better for case insensitive alternations.

I've left the 1-setmatches case-sensitive value as a special case, trying to avoid an extra allocation there.

Then, I've added an optimization to `newEqualMultiStringMatcher`'s implementations: as we add values, we compute a bitmask with lengths of matched values. Then we can do the quick check of the incoming matched string against that label and quickly discard the value if none of the matched values have that length, we basically use this bitmask as a bloom filter of lengths. Of course this won't help matching things like UUIDs that all have the same lengths, but there are plenty of labels in the wild (routes, etc.) that do have different lengths.

I've benchmarked both things separately, first the reuse of `newEqualMultiStringMatcher` (this is `stringmatcher` in the bench) and then the full change.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/model/labels
cpu: Apple M3 Pro
                                                        │     main      │             stringmatcher             │              lengthmask              │
                                                        │    sec/op     │    sec/op      vs base                │    sec/op     vs base                │
FastRegexMatcher/#00-12                                    35.62n ±  4%    36.22n ±  5%        ~ (p=0.811 n=10)   33.39n ±  6%   -6.27% (p=0.003 n=10)
FastRegexMatcher/foo-12                                    39.27n ±  3%    38.24n ±  5%   -2.61% (p=0.000 n=10)   38.29n ±  3%   -2.47% (p=0.003 n=10)
FastRegexMatcher/^foo-12                                   56.50n ±  3%    31.24n ±  8%  -44.70% (p=0.000 n=10)   30.78n ± 15%  -45.53% (p=0.000 n=10)
FastRegexMatcher/(foo|bar)-12                              72.34n ±  3%    68.28n ± 10%   -5.61% (p=0.043 n=10)   53.19n ±  3%  -26.47% (p=0.000 n=10)
FastRegexMatcher/foo.*-12                                  87.88n ±  5%    83.68n ±  3%        ~ (p=0.123 n=10)   88.03n ±  2%        ~ (p=0.739 n=10)
FastRegexMatcher/.*foo-12                                  103.5n ±  2%    103.5n ±  5%        ~ (p=0.869 n=10)   103.3n ±  4%        ~ (p=0.955 n=10)
FastRegexMatcher/^.*foo$-12                                103.6n ±  3%    101.3n ±  4%        ~ (p=0.190 n=10)   101.3n ±  2%        ~ (p=0.143 n=10)
FastRegexMatcher/^.+foo$-12                                101.9n ±  2%    101.8n ±  7%        ~ (p=0.810 n=10)   102.0n ±  2%        ~ (p=0.782 n=10)
FastRegexMatcher/.?-12                                     45.41n ±  4%    45.69n ±  6%        ~ (p=0.481 n=10)   45.80n ±  3%        ~ (p=0.289 n=10)
FastRegexMatcher/.*-12                                     34.73n ±  3%    34.09n ±  5%        ~ (p=0.436 n=10)   33.91n ±  2%   -2.35% (p=0.045 n=10)
FastRegexMatcher/.+-12                                     36.51n ±  6%    36.32n ±  3%        ~ (p=0.579 n=10)   36.77n ±  3%        ~ (p=0.447 n=10)
FastRegexMatcher/foo.+-12                                  85.35n ±  2%    83.62n ±  3%        ~ (p=0.063 n=10)   84.67n ±  3%        ~ (p=0.684 n=10)
FastRegexMatcher/.+foo-12                                  104.1n ±  4%    101.1n ±  8%        ~ (p=0.289 n=10)   103.2n ±  6%        ~ (p=0.754 n=10)
FastRegexMatcher/foo_.+-12                                 73.22n ±  3%    72.34n ±  2%        ~ (p=0.247 n=10)   72.56n ±  3%        ~ (p=0.280 n=10)
FastRegexMatcher/foo_.*-12                                 72.74n ±  2%    72.77n ±  8%        ~ (p=0.739 n=10)   73.91n ±  8%   +1.60% (p=0.043 n=10)
FastRegexMatcher/.*foo.*-12                                164.5n ±  4%    165.0n ±  5%        ~ (p=1.000 n=10)   161.9n ±  3%        ~ (p=0.256 n=10)
FastRegexMatcher/.+foo.+-12                                198.6n ±  2%    199.7n ±  2%        ~ (p=0.985 n=10)   197.7n ±  5%        ~ (p=0.271 n=10)
FastRegexMatcher/.*foo.*|-12                               236.1n ±  2%    236.6n ±  5%        ~ (p=0.927 n=10)   236.1n ±  4%        ~ (p=0.838 n=10)
FastRegexMatcher/.*foo.*|bar.*-12                          285.2n ±  4%    283.1n ±  4%        ~ (p=0.644 n=10)   286.4n ±  5%        ~ (p=0.617 n=10)
FastRegexMatcher/foo.*|.*bar.*-12                          277.7n ±  3%    278.9n ±  3%        ~ (p=0.796 n=10)   278.8n ±  3%        ~ (p=0.699 n=10)
FastRegexMatcher/.*foo.*|.*bar.*-12                        321.5n ±  4%    307.9n ±  4%        ~ (p=0.075 n=10)   323.9n ±  4%        ~ (p=0.305 n=10)
FastRegexMatcher/.*foo.*bar.*|.*hello.*-12                 12.38µ ±  7%    13.05µ ±  2%   +5.44% (p=0.019 n=10)   13.66µ ±  4%  +10.32% (p=0.000 n=10)
FastRegexMatcher/.*foo.*|.*bar.*|.*hello.*-12              471.0n ±  8%    478.6n ±  4%        ~ (p=0.353 n=10)   484.9n ±  4%        ~ (p=0.105 n=10)
FastRegexMatcher/.+.*foo.*|.*bar.*-12                      15.33µ ±  4%    15.32µ ±  4%        ~ (p=0.684 n=10)   14.94µ ±  5%   -2.54% (p=0.029 n=10)
FastRegexMatcher/(?s:.*)-12                                34.56n ±  5%    34.82n ±  6%        ~ (p=0.684 n=10)   32.41n ±  5%   -6.22% (p=0.002 n=10)
FastRegexMatcher/(?s:.+)-12                                36.62n ±  5%    37.86n ± 35%        ~ (p=0.119 n=10)   36.42n ±  2%        ~ (p=0.424 n=10)
FastRegexMatcher/(?s:^.*foo$)-12                           102.2n ±  4%    101.8n ±  6%        ~ (p=0.796 n=10)   104.8n ±  7%        ~ (p=0.123 n=10)
FastRegexMatcher/(?i:foo)-12                               75.08n ±  3%    75.23n ±  5%        ~ (p=0.725 n=10)   78.44n ±  6%   +4.46% (p=0.011 n=10)
FastRegexMatcher/(?i:(foo|bar))-12                         170.4n ±  6%    138.8n ±  4%  -18.54% (p=0.000 n=10)   148.0n ±  4%  -13.14% (p=0.000 n=10)
FastRegexMatcher/(?i:(foo1|foo2|bar))-12                   302.1n ± 13%    170.4n ±  6%  -43.59% (p=0.000 n=10)   175.7n ±  5%  -41.86% (p=0.000 n=10)
FastRegexMatcher/^(?i:foo|oo)|(bar)$-12                    767.3n ±  4%    730.6n ±  2%   -4.78% (p=0.003 n=10)   741.3n ±  3%        ~ (p=0.075 n=10)
FastRegexMatcher/(?i:(foo1|foo2|aaa|bbb|ccc|ddd|e-12       710.6n ±  8%    677.4n ±  7%        ~ (p=0.089 n=10)   701.9n ±  8%        ~ (p=0.529 n=10)
FastRegexMatcher/((.*)(bar|b|buzz)(.+)|foo)$-12            494.0n ±  6%    469.8n ±  3%   -4.91% (p=0.009 n=10)   495.2n ±  4%        ~ (p=0.754 n=10)
FastRegexMatcher/^$-12                                     35.80n ±  4%    35.57n ± 10%        ~ (p=0.955 n=10)   36.24n ±  3%        ~ (p=0.492 n=10)
FastRegexMatcher/(prometheus|api_prom)_api_v1_.+-12        169.7n ± 11%    162.5n ±  5%   -4.27% (p=0.046 n=10)   168.1n ±  5%        ~ (p=0.404 n=10)
FastRegexMatcher/10\.0\.(1|2)\.+-12                        73.83n ± 14%    72.08n ±  5%        ~ (p=0.165 n=10)   73.16n ±  5%        ~ (p=0.353 n=10)
FastRegexMatcher/10\.0\.(1|2).+-12                         73.48n ±  5%    71.77n ±  2%        ~ (p=0.123 n=10)   72.30n ±  4%        ~ (p=0.481 n=10)
FastRegexMatcher/((fo(bar))|.+foo)-12                      195.9n ±  9%    195.2n ±  4%        ~ (p=0.565 n=10)   192.5n ±  5%   -1.76% (p=0.030 n=10)
FastRegexMatcher/zQPbMkNO|NNSPdvMi|iWuuSoAl|qbvKM-12      173.65n ± 15%   176.20n ± 11%        ~ (p=0.631 n=10)   46.90n ±  2%  -72.99% (p=0.000 n=10)
FastRegexMatcher/jyyfj00j0061|jyyfj00j0062|jyyfj9-12       178.9n ± 19%    186.6n ± 12%        ~ (p=0.869 n=10)   110.1n ± 15%  -38.47% (p=0.000 n=10)
FastRegexMatcher/.*zQPbMkNO.*|.*NNSPdvMi.*|.*iWuu-12       12.33µ ±  6%    12.80µ ±  8%        ~ (p=0.315 n=10)   12.12µ ±  7%        ~ (p=0.739 n=10)
FastRegexMatcher/(?i:(zQPbMkNO|NNSPdvMi|iWuuSoAl|-12       694.3n ±  9%    737.6n ±  7%        ~ (p=0.218 n=10)   690.9n ±  5%        ~ (p=0.363 n=10)
FastRegexMatcher/(?i:(AAAAAAAAAAAAAAAAAAAAAAAA|BB-12       395.6n ±  5%    190.5n ±  4%  -51.85% (p=0.000 n=10)   189.9n ±  6%  -52.00% (p=0.000 n=10)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS-12       288.3n ± 18%    235.6n ± 13%  -18.30% (p=0.025 n=10)   234.9n ±  5%  -18.52% (p=0.010 n=10)
FastRegexMatcher/(?i:(zQPbMkNO.*|NNSPdvMi.*|iWuuS#01-12    480.3n ±  6%    443.0n ± 13%   -7.78% (p=0.015 n=10)   440.4n ±  3%   -8.32% (p=0.000 n=10)
FastRegexMatcher/(?i:(.*zQPbMkNO|.*NNSPdvMi|.*iWu-12       7.442µ ± 12%    7.042µ ±  9%        ~ (p=0.075 n=10)   6.850µ ±  5%   -7.95% (p=0.003 n=10)
FastRegexMatcher/fo.?-12                                   89.08n ±  2%    90.92n ±  4%        ~ (p=0.218 n=10)   88.88n ±  4%        ~ (p=0.971 n=10)
FastRegexMatcher/foo.?-12                                  84.82n ±  3%    90.22n ±  6%   +6.37% (p=0.004 n=10)   86.88n ±  4%   +2.43% (p=0.019 n=10)
FastRegexMatcher/f.?o-12                                   73.99n ±  4%    71.80n ±  9%        ~ (p=0.971 n=10)   75.06n ±  5%        ~ (p=0.393 n=10)
FastRegexMatcher/.*foo.?-12                                194.3n ±  3%    198.8n ±  9%        ~ (p=0.190 n=10)   199.5n ±  2%   +2.65% (p=0.007 n=10)
FastRegexMatcher/.?foo.+-12                                190.1n ±  2%    199.6n ±  5%   +5.00% (p=0.005 n=10)   194.7n ±  8%        ~ (p=0.138 n=10)
FastRegexMatcher/foo.?|bar-12                              137.2n ±  4%    143.1n ±  7%   +4.30% (p=0.046 n=10)   139.8n ±  5%        ~ (p=0.315 n=10)
FastRegexMatcher/ſſs-12                                    38.07n ±  3%    39.63n ±  2%   +4.12% (p=0.002 n=10)   40.74n ± 29%   +7.03% (p=0.002 n=10)
FastRegexMatcher/.*-.*-.*-.*-.*-12                         191.3n ±  4%    193.3n ± 17%        ~ (p=0.383 n=10)   200.1n ± 36%        ~ (p=0.190 n=10)
FastRegexMatcher/.+-.*-.*-.*-.+-12                         188.3n ±  5%    193.2n ±  1%   +2.55% (p=0.018 n=10)   191.0n ±  3%        ~ (p=0.165 n=10)
FastRegexMatcher/-.*-.*-.*-.*-12                           78.78n ±  3%    79.91n ±  2%        ~ (p=0.315 n=10)   78.02n ±  4%        ~ (p=0.912 n=10)
FastRegexMatcher/.*-.*-.*-.*--12                           95.30n ±  2%    97.57n ±  7%        ~ (p=0.093 n=10)   97.72n ±  5%   +2.53% (p=0.016 n=10)
FastRegexMatcher/(.+)-(.+)-(.+)-(.+)-(.+)-12               193.2n ±  3%    199.7n ±  3%   +3.37% (p=0.030 n=10)   192.1n ±  7%        ~ (p=0.684 n=10)
FastRegexMatcher/((.*))(?i:f)((.*))o((.*))o((.*))-12       4.295µ ±  3%    4.516µ ±  4%   +5.16% (p=0.001 n=10)   4.326µ ±  4%        ~ (p=0.912 n=10)
FastRegexMatcher/((.*))f((.*))(?i:o)((.*))o((.*))-12       3.580µ ± 12%    3.572µ ± 11%        ~ (p=0.739 n=10)   3.494µ ±  4%        ~ (p=0.052 n=10)
FastRegexMatcher/(.*0.*)-12                                112.6n ±  4%    115.0n ±  5%        ~ (p=0.363 n=10)   113.1n ±  1%        ~ (p=0.670 n=10)
FastRegexMatcher_ConcatenatedPattern-12                    124.2n ±  8%    116.2n ±  9%        ~ (p=0.209 n=10)   119.7n ± 11%        ~ (p=0.753 n=10)
geomean                                                    191.4n          184.2n         -3.74%                  178.1n         -6.92%
```

<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[PERF] Improved the performance of label matchers for regular expressions matching a set of values.
```
