### PR TITLE
chore: fix typos in comments

### DIFF
--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -295,7 +295,7 @@ loop:
 				appOpts.Exemplars = exemplars
 			}
 
-			// Metadata path mimicks the scrape appender V1 flow. Once we remove v2
+			// Metadata path mimics the scrape appender V1 flow. Once we remove v2
 			// flow we should rename "appendMetadataToWAL" flag to "passMetadata" because for v2 flow
 			// the metadata storage detail is behind the appendableV2 contract. V2 also means we always pass the metadata,
 			// we don't check if it changed (that code can be removed).

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -1852,7 +1852,7 @@ Outer:
 // Name of the file used to store the state.
 const seriesStateFilename = "series_state.json"
 
-// SeriesLifecycleState descibes the information we record in the series_state.json file.
+// SeriesLifecycleState describes the information we record in the series_state.json file.
 type SeriesLifecycleState struct {
 	LastSeriesID   uint64 `json:"last_series_id"`
 	LastWALSegment int    `json:"last_wal_segment"`

--- a/web/ui/module/codemirror-promql/src/parser/parser.ts
+++ b/web/ui/module/codemirror-promql/src/parser/parser.ts
@@ -162,7 +162,7 @@ export class Parser {
         // Specially the one checking if the timestamp after the `@` is ok: https://github.com/prometheus/prometheus/blob/ad5ed416ba635834370bfa06139258b31f8c33f9/promql/parser/parse.go#L722-L725
         // Since Javascript is managing the number as a float64 and so on 53 bits, we cannot validate that the maxInt64 number is a valid value.
         // So, to manage properly this issue, we would need to use the BigInt which is possible or by using ES2020.BigInt, or by using the lib: https://github.com/GoogleChromeLabs/jsbi.
-        //   * Introducing a lib just for theses checks is quite overkilled
+        //   * Introducing a lib just for these checks is quite overkilled
         //   * Using ES2020 would be the way to go. Unfortunately moving to ES2020 is breaking the build of the lib.
         //     So far I didn't find the way to fix it. I think it's likely due to the fact we are building an ESM package which is now something stable in nodeJS/javascript but still experimental in typescript.
         // For the above reason, we decided to drop these checks.


### PR DESCRIPTION
﻿Fixes three minor typos in source code comments. No functional changes.

- `scrape/scrape_append_v2.go`: ``mimicks`` -> ``mimics``
- `tsdb/head_wal.go`: ``descibes`` -> ``describes``
- `web/ui/module/codemirror-promql/src/parser/parser.ts`: ``theses`` -> ``these``

```release-notes
NONE
```