### PR TITLE
discovery/moby: fall back to GlobalIPv6Address for IPv6-only containers

### DIFF
--- a/discovery/moby/docker.go
+++ b/discovery/moby/docker.go
@@ -277,6 +277,8 @@ func (d *DockerDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 				ipAddr := ""
 				if n.IPAddress.IsValid() {
 					ipAddr = n.IPAddress.String()
+				} else if n.GlobalIPv6Address.IsValid() {
+					ipAddr = n.GlobalIPv6Address.String()
 				}
 
 				labels := model.LabelSet{
@@ -312,6 +314,8 @@ func (d *DockerDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, er
 				ipAddr := ""
 				if n.IPAddress.IsValid() {
 					ipAddr = n.IPAddress.String()
+				} else if n.GlobalIPv6Address.IsValid() {
+					ipAddr = n.GlobalIPv6Address.String()
 				}
 
 				labels := model.LabelSet{

--- a/discovery/moby/docker_test.go
+++ b/discovery/moby/docker_test.go
@@ -64,9 +64,25 @@ host: %s
 	tg := tgs[0]
 	require.NotNil(t, tg)
 	require.NotNil(t, tg.Targets)
-	require.Len(t, tg.Targets, 8)
+	require.Len(t, tg.Targets, 9)
 
 	expected := []model.LabelSet{
+		{
+			"__address__":                "[fc00::2]:9100",
+			"__meta_docker_container_id": "a5f3b2c1d4e6f7890abc123def456789012345678901234567890abcdef012345",
+			"__meta_docker_container_label_com_docker_compose_project": "dockersd",
+			"__meta_docker_container_label_com_docker_compose_service": "ipv6_node",
+			"__meta_docker_container_label_com_docker_compose_version": "1.25.0",
+			"__meta_docker_container_name":                             "/dockersd_ipv6_node",
+			"__meta_docker_container_network_mode":                     "dockersd_ipv6",
+			"__meta_docker_network_id":                                 "aabbcc1122334455667788990011aabbcc1122334455667788990011aabbcc11",
+			"__meta_docker_network_ingress":                            "false",
+			"__meta_docker_network_internal":                           "false",
+			"__meta_docker_network_ip":                                 "fc00::2",
+			"__meta_docker_network_name":                               "dockersd_ipv6",
+			"__meta_docker_network_scope":                              "local",
+			"__meta_docker_port_private":                               "9100",
+		},
 		{
 			"__address__":                "172.19.0.2:9100",
 			"__meta_docker_container_id": "c301b928faceb1a18fe379f6bc178727ef920bb30b0f9b8592b32b36255a0eca",
@@ -246,9 +262,25 @@ host: %s
 	tg := tgs[0]
 	require.NotNil(t, tg)
 	require.NotNil(t, tg.Targets)
-	require.Len(t, tg.Targets, 13)
+	require.Len(t, tg.Targets, 14)
 
 	expected := []model.LabelSet{
+		{
+			"__address__":                "[fc00::2]:9100",
+			"__meta_docker_container_id": "a5f3b2c1d4e6f7890abc123def456789012345678901234567890abcdef012345",
+			"__meta_docker_container_label_com_docker_compose_project": "dockersd",
+			"__meta_docker_container_label_com_docker_compose_service": "ipv6_node",
+			"__meta_docker_container_label_com_docker_compose_version": "1.25.0",
+			"__meta_docker_container_name":                             "/dockersd_ipv6_node",
+			"__meta_docker_container_network_mode":                     "dockersd_ipv6",
+			"__meta_docker_network_id":                                 "aabbcc1122334455667788990011aabbcc1122334455667788990011aabbcc11",
+			"__meta_docker_network_ingress":                            "false",
+			"__meta_docker_network_internal":                           "false",
+			"__meta_docker_network_ip":                                 "fc00::2",
+			"__meta_docker_network_name":                               "dockersd_ipv6",
+			"__meta_docker_network_scope":                              "local",
+			"__meta_docker_port_private":                               "9100",
+		},
 		{
 			"__address__":                "172.19.0.2:9100",
 			"__meta_docker_container_id": "c301b928faceb1a18fe379f6bc178727ef920bb30b0f9b8592b32b36255a0eca",

--- a/discovery/moby/testdata/dockerprom/containers/json.json
+++ b/discovery/moby/testdata/dockerprom/containers/json.json
@@ -230,6 +230,52 @@
     "Mounts": []
   },
   {
+    "Id": "a5f3b2c1d4e6f7890abc123def456789012345678901234567890abcdef012345",
+    "Names": [
+      "/dockersd_ipv6_node"
+    ],
+    "Image": "prom/node-exporter:v1.1.2",
+    "ImageID": "sha256:c19ae228f0699185488b6a1c0debb9c6b79672181356ad455c9a7924a41a01bb",
+    "Command": "/bin/node_exporter",
+    "Created": 1616273136,
+    "Ports": [
+      {
+        "PrivatePort": 9100,
+        "Type": "tcp"
+      }
+    ],
+    "Labels": {
+      "com.docker.compose.project": "dockersd",
+      "com.docker.compose.service": "ipv6_node",
+      "com.docker.compose.version": "1.25.0"
+    },
+    "State": "running",
+    "Status": "Up 40 seconds",
+    "HostConfig": {
+      "NetworkMode": "dockersd_ipv6"
+    },
+    "NetworkSettings": {
+      "Networks": {
+        "dockersd_ipv6": {
+          "IPAMConfig": null,
+          "Links": null,
+          "Aliases": null,
+          "NetworkID": "aabbcc1122334455667788990011aabbcc1122334455667788990011aabbcc11",
+          "EndpointID": "1122334455667788990011aabbcc1122334455667788990011aabbcc11223344",
+          "Gateway": "",
+          "IPAddress": "",
+          "IPPrefixLen": 0,
+          "IPv6Gateway": "fc00::1",
+          "GlobalIPv6Address": "fc00::2",
+          "GlobalIPv6PrefixLen": 64,
+          "MacAddress": "02:42:fc:00:00:02",
+          "DriverOpts": null
+        }
+      }
+    },
+    "Mounts": []
+  },
+  {
     "Id": "f84b2a0cfaa58d9e70b0657e2b3c6f44f0e973de4163a871299b4acf127b224f",
     "Names": [
       "/dockersd_multi_networks"

--- a/discovery/moby/testdata/dockerprom/networks.json
+++ b/discovery/moby/testdata/dockerprom/networks.json
@@ -165,5 +165,32 @@
     "Containers": {},
     "Options": {},
     "Labels": {}
+  },
+  {
+    "Name": "dockersd_ipv6",
+    "Id": "aabbcc1122334455667788990011aabbcc1122334455667788990011aabbcc11",
+    "Created": "2021-03-20T21:19:50.639982673+01:00",
+    "Scope": "local",
+    "Driver": "bridge",
+    "EnableIPv6": true,
+    "IPAM": {
+      "Driver": "default",
+      "Options": null,
+      "Config": [
+        {
+          "Subnet": "fc00::/64"
+        }
+      ]
+    },
+    "Internal": false,
+    "Attachable": false,
+    "Ingress": false,
+    "ConfigFrom": {
+      "Network": ""
+    },
+    "ConfigOnly": false,
+    "Containers": {},
+    "Options": {},
+    "Labels": {}
   }
 ]


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18713

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] Docker SD: use GlobalIPv6Address when IPAddress is empty so that IPv6-only containers are discovered correctly.
```

## Summary

When a container runs on an IPv6-only network (created with
`docker network create --ipv6 --ipv4=false`), Docker leaves `IPAddress`
empty and puts the container's address in `GlobalIPv6Address`.
The discovery code only read `n.IPAddress`, so `__address__` was set to
`":80"` (or whatever the port was), causing scrapes to fail immediately.

Fix: in both the per-port loop and the no-ports fallback, fall back to
`n.GlobalIPv6Address` when `n.IPAddress` is not valid.
`net.JoinHostPort` already handles IPv6 bracket formatting, so the
resulting `__address__` is correct (e.g. `[fc00::2]:9100`).

A new container fixture (`dockersd_ipv6_node`) and matching expected
targets are added to both `TestDockerSDRefresh` and
`TestDockerSDRefreshMatchAllNetworks`.