### PR TITLE
storage/remote: reject oversized remote write label strings

### DIFF
--- a/prompb/codec.go
+++ b/prompb/codec.go
@@ -14,6 +14,7 @@
 package prompb
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/common/model"
@@ -28,6 +29,48 @@ import (
 // ToLabels return model labels.Labels from timeseries' remote labels.
 func (m TimeSeries) ToLabels(b *labels.ScratchBuilder, _ []string) labels.Labels {
 	return labelProtosToLabels(b, m.GetLabels())
+}
+
+// ErrLabelValueTooLong is returned when a label value exceeds the maximum allowed length.
+type ErrLabelValueTooLong struct {
+	LabelName   string
+	ValueLength int
+	Limit       int
+}
+
+func (e ErrLabelValueTooLong) Error() string {
+	return "label value exceeds maximum length: label " + e.LabelName + " has length " + strconv.Itoa(e.ValueLength) + ", limit " + strconv.Itoa(e.Limit)
+}
+
+// ErrLabelNameTooLong is returned when a label name exceeds the maximum allowed length.
+type ErrLabelNameTooLong struct {
+	NameLength int
+	Limit      int
+}
+
+func (e ErrLabelNameTooLong) Error() string {
+	return "label name exceeds maximum length: length " + strconv.Itoa(e.NameLength) + ", limit " + strconv.Itoa(e.Limit)
+}
+
+// ToLabelsWithLimits returns model labels.Labels from timeseries' remote labels,
+// with validation of label name and value length.
+func (m TimeSeries) ToLabelsWithLimits(b *labels.ScratchBuilder, _ []string, maxLabelValueLength int) (labels.Labels, error) {
+	for _, l := range m.GetLabels() {
+		if len(l.Name) > maxLabelValueLength {
+			return labels.EmptyLabels(), ErrLabelNameTooLong{
+				NameLength: len(l.Name),
+				Limit:      maxLabelValueLength,
+			}
+		}
+		if len(l.Value) > maxLabelValueLength {
+			return labels.EmptyLabels(), ErrLabelValueTooLong{
+				LabelName:   l.Name,
+				ValueLength: len(l.Value),
+				Limit:       maxLabelValueLength,
+			}
+		}
+	}
+	return labelProtosToLabels(b, m.GetLabels()), nil
 }
 
 // ToLabels return model labels.Labels from timeseries' remote labels.
@@ -203,4 +246,25 @@ func (m Exemplar) ToExemplar(b *labels.ScratchBuilder, _ []string) exemplar.Exem
 		Ts:     timestamp,
 		HasTs:  timestamp != 0,
 	}
+}
+
+// ToExemplarWithLimits converts remote exemplar to model exemplar,
+// with validation of label name and value length.
+func (m Exemplar) ToExemplarWithLimits(b *labels.ScratchBuilder, _ []string, maxLabelValueLength int) (exemplar.Exemplar, error) {
+	for _, l := range m.GetLabels() {
+		if len(l.Name) > maxLabelValueLength {
+			return exemplar.Exemplar{}, ErrLabelNameTooLong{
+				NameLength: len(l.Name),
+				Limit:      maxLabelValueLength,
+			}
+		}
+		if len(l.Value) > maxLabelValueLength {
+			return exemplar.Exemplar{}, ErrLabelValueTooLong{
+				LabelName:   l.Name,
+				ValueLength: len(l.Value),
+				Limit:       maxLabelValueLength,
+			}
+		}
+	}
+	return m.ToExemplar(b, nil), nil
 }

--- a/prompb/io/prometheus/write/v2/codec.go
+++ b/prompb/io/prometheus/write/v2/codec.go
@@ -31,6 +31,12 @@ func (m TimeSeries) ToLabels(b *labels.ScratchBuilder, symbols []string) (labels
 	return desymbolizeLabels(b, m.GetLabelsRefs(), symbols)
 }
 
+// ToLabelsWithLimits returns model labels.Labels from timeseries' remote labels,
+// with validation of label name and value length.
+func (m TimeSeries) ToLabelsWithLimits(b *labels.ScratchBuilder, symbols []string, maxLabelValueLength int) (labels.Labels, error) {
+	return desymbolizeLabelsWithLimits(b, m.GetLabelsRefs(), symbols, maxLabelValueLength)
+}
+
 // ToMetadata returns model metadata from timeseries' remote metadata.
 func (m TimeSeries) ToMetadata(symbols []string) (metadata.Metadata, error) {
 	typ := model.MetricTypeUnknown
@@ -219,6 +225,24 @@ func (m Exemplar) ToExemplar(b *labels.ScratchBuilder, symbols []string) (exempl
 	timestamp := m.Timestamp
 
 	lbls, err := desymbolizeLabels(b, m.LabelsRefs, symbols)
+	if err != nil {
+		return exemplar.Exemplar{}, err
+	}
+
+	return exemplar.Exemplar{
+		Labels: lbls,
+		Value:  m.Value,
+		Ts:     timestamp,
+		HasTs:  timestamp != 0,
+	}, nil
+}
+
+// ToExemplarWithLimits converts remote exemplar to model exemplar,
+// with validation of label name and value length.
+func (m Exemplar) ToExemplarWithLimits(b *labels.ScratchBuilder, symbols []string, maxLabelValueLength int) (exemplar.Exemplar, error) {
+	timestamp := m.Timestamp
+
+	lbls, err := desymbolizeLabelsWithLimits(b, m.LabelsRefs, symbols, maxLabelValueLength)
 	if err != nil {
 		return exemplar.Exemplar{}, err
 	}

--- a/prompb/io/prometheus/write/v2/symbols.go
+++ b/prompb/io/prometheus/write/v2/symbols.go
@@ -96,3 +96,61 @@ func desymbolizeLabels(b *labels.ScratchBuilder, labelRefs []uint32, symbols []s
 	b.Sort()
 	return b.Labels(), nil
 }
+
+// ErrLabelValueTooLong is returned when a label value exceeds the maximum allowed length.
+type ErrLabelValueTooLong struct {
+	LabelName   string
+	ValueLength int
+	Limit       int
+}
+
+func (e ErrLabelValueTooLong) Error() string {
+	return fmt.Sprintf("label value exceeds maximum length: label %s has length %d, limit %d", e.LabelName, e.ValueLength, e.Limit)
+}
+
+// ErrLabelNameTooLong is returned when a label name exceeds the maximum allowed length.
+type ErrLabelNameTooLong struct {
+	NameLength int
+	Limit      int
+}
+
+func (e ErrLabelNameTooLong) Error() string {
+	return fmt.Sprintf("label name exceeds maximum length: length %d, limit %d", e.NameLength, e.Limit)
+}
+
+// desymbolizeLabelsWithLimits decodes label references, with given symbols to labels,
+// while validating that no label name or value exceeds maxLabelValueLength.
+// This function requires labelRefs to have an even number of elements (name-value pairs) and
+// all references must be valid indices within the symbols table. It will return an error if
+// these invariants are violated or if any label name or value exceeds the limit.
+func desymbolizeLabelsWithLimits(b *labels.ScratchBuilder, labelRefs []uint32, symbols []string, maxLabelValueLength int) (labels.Labels, error) {
+	if len(labelRefs)%2 != 0 {
+		return labels.EmptyLabels(), fmt.Errorf("invalid labelRefs length %d", len(labelRefs))
+	}
+
+	b.Reset()
+	for i := 0; i < len(labelRefs); i += 2 {
+		nameRef, valueRef := labelRefs[i], labelRefs[i+1]
+		if int(nameRef) >= len(symbols) || int(valueRef) >= len(symbols) {
+			return labels.EmptyLabels(), fmt.Errorf("labelRefs %d (name) = %d (value) outside of symbols table (size %d)", nameRef, valueRef, len(symbols))
+		}
+		name := symbols[nameRef]
+		if len(name) > maxLabelValueLength {
+			return labels.EmptyLabels(), ErrLabelNameTooLong{
+				NameLength: len(name),
+				Limit:      maxLabelValueLength,
+			}
+		}
+		value := symbols[valueRef]
+		if len(value) > maxLabelValueLength {
+			return labels.EmptyLabels(), ErrLabelValueTooLong{
+				LabelName:   name,
+				ValueLength: len(value),
+				Limit:       maxLabelValueLength,
+			}
+		}
+		b.Add(name, value)
+	}
+	b.Sort()
+	return b.Labels(), nil
+}

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -48,9 +48,18 @@ type writeHandler struct {
 	ingestSTZeroSample      bool
 	enableTypeAndUnitLabels bool
 	appendMetadata          bool
+
+	// maxLabelValueLength is the maximum allowed length for a label value in bytes.
+	// This prevents memory issues and potential crashes from oversized label values.
+	maxLabelValueLength int
 }
 
 const maxAheadTime = 10 * time.Minute
+
+// DefaultMaxLabelValueLength is the maximum allowed length for a label value in bytes.
+// This stays below the 24-bit label string length boundary.
+// TODO(#16525): Make this configurable via GlobalConfig.LabelValueLengthLimit.
+const DefaultMaxLabelValueLength = (1 << 24) - 1
 
 // NewWriteHandler creates a http.Handler that accepts remote write requests with
 // the given message in acceptedMsgs and writes them to the provided appendable.
@@ -58,6 +67,16 @@ const maxAheadTime = 10 * time.Minute
 // NOTE(bwplotka): When accepting v2 proto and spec, partial writes are possible
 // as per https://prometheus.io/docs/specs/remote_write_spec_2_0/#partial-write.
 func NewWriteHandler(logger *slog.Logger, reg prometheus.Registerer, appendable storage.Appendable, acceptedMsgs remoteapi.MessageTypes, ingestSTZeroSample, enableTypeAndUnitLabels, appendMetadata bool) http.Handler {
+	return NewWriteHandlerWithConfig(logger, reg, appendable, acceptedMsgs, ingestSTZeroSample, enableTypeAndUnitLabels, appendMetadata, DefaultMaxLabelValueLength)
+}
+
+// NewWriteHandlerWithConfig creates a http.Handler that accepts remote write requests with
+// the given message in acceptedMsgs and writes them to the provided appendable.
+// This variant allows specifying maxLabelValueLength for testing or custom configurations.
+//
+// NOTE(bwplotka): When accepting v2 proto and spec, partial writes are possible
+// as per https://prometheus.io/docs/specs/remote_write_spec_2_0/#partial-write.
+func NewWriteHandlerWithConfig(logger *slog.Logger, reg prometheus.Registerer, appendable storage.Appendable, acceptedMsgs remoteapi.MessageTypes, ingestSTZeroSample, enableTypeAndUnitLabels, appendMetadata bool, maxLabelValueLength int) http.Handler {
 	h := &writeHandler{
 		logger:     logger,
 		appendable: appendable,
@@ -77,6 +96,7 @@ func NewWriteHandler(logger *slog.Logger, reg prometheus.Registerer, appendable 
 		ingestSTZeroSample:      ingestSTZeroSample,
 		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
 		appendMetadata:          appendMetadata,
+		maxLabelValueLength:     maxLabelValueLength,
 	}
 	return remoteapi.NewWriteHandler(h, acceptedMsgs, remoteapi.WithWriteHandlerLogger(logger))
 }
@@ -169,7 +189,12 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 
 	b := labels.NewScratchBuilder(0)
 	for _, ts := range req.Timeseries {
-		ls := ts.ToLabels(&b, nil)
+		ls, err := ts.ToLabelsWithLimits(&b, nil, h.maxLabelValueLength)
+		if err != nil {
+			h.logger.Warn("Label value exceeds maximum length", "err", err)
+			samplesWithInvalidLabels++
+			continue
+		}
 
 		// TODO(bwplotka): Even as per 1.0 spec, this should be a 400 error, while other samples are
 		// potentially written. Perhaps unify with fixed writeV2 implementation a bit.
@@ -189,7 +214,11 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 		samplesAppended += len(ts.Samples)
 
 		for _, ep := range ts.Exemplars {
-			e := ep.ToExemplar(&b, nil)
+			e, err := ep.ToExemplarWithLimits(&b, nil, h.maxLabelValueLength)
+			if err != nil {
+				h.logger.Debug("Invalid exemplar labels", "series", ls.String(), "err", err)
+				continue
+			}
 			if _, err := app.AppendExemplar(0, ls, e); err != nil {
 				switch {
 				case errors.Is(err, storage.ErrOutOfOrderExemplar):
@@ -312,7 +341,7 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 		b = labels.NewScratchBuilder(0)
 	)
 	for _, ts := range req.Timeseries {
-		ls, err := ts.ToLabels(&b, req.Symbols)
+		ls, err := ts.ToLabelsWithLimits(&b, req.Symbols, h.maxLabelValueLength)
 		if err != nil {
 			badRequestErrs = append(badRequestErrs, fmt.Errorf("parsing labels for series %v: %w", ts.LabelsRefs, err))
 			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)
@@ -325,6 +354,16 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 			continue
 		}
 		if h.enableTypeAndUnitLabels && (m.Type != model.MetricTypeUnknown || m.Unit != "") {
+			if len(m.Unit) > h.maxLabelValueLength {
+				badRequestErrs = append(badRequestErrs, fmt.Errorf("metadata unit label for series %v: %w", ts.LabelsRefs, writev2.ErrLabelValueTooLong{
+					LabelName:   model.MetricUnitLabel,
+					ValueLength: len(m.Unit),
+					Limit:       h.maxLabelValueLength,
+				}))
+				samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)
+				continue
+			}
+
 			slb := labels.NewScratchBuilder(ls.Len() + 2) // +2 for __type__ and __unit__
 			ls.Range(func(l labels.Label) {
 				// Skip __type__ and __unit__ labels if they exist in the incoming labels.
@@ -432,7 +471,7 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 
 		// Exemplars.
 		for _, ep := range ts.Exemplars {
-			e, err := ep.ToExemplar(&b, req.Symbols)
+			e, err := ep.ToExemplarWithLimits(&b, req.Symbols, h.maxLabelValueLength)
 			if err != nil {
 				badRequestErrs = append(badRequestErrs, fmt.Errorf("parsing exemplar for series %v: %w", ls.String(), err))
 				continue

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -1711,3 +1711,250 @@ func TestRemoteWriteHandler_ResponseStats(t *testing.T) {
 		})
 	}
 }
+
+// TestWriteHandler_LabelValueLengthLimit tests that label values exceeding the configured
+// maximum length are rejected with appropriate error messages.
+// Regression test for https://github.com/prometheus/prometheus/issues/16525
+func TestWriteHandler_LabelValueLengthLimit(t *testing.T) {
+	const testLimit = 100 // Small limit for testing
+
+	require.Less(t, DefaultMaxLabelValueLength, 1<<24)
+
+	// Create a label value that exceeds the limit.
+	longValue := strings.Repeat("a", testLimit+1)
+	longName := strings.Repeat("b", testLimit+1)
+
+	for _, tc := range []struct {
+		name                    string
+		msgType                 remoteapi.WriteMessageType
+		buildPayload            func() ([]byte, error)
+		expectedCode            int
+		expectedErr             string
+		enableTypeAndUnitLabels bool
+		expectedSamples         int
+		expectedExemplars       int
+	}{
+		{
+			name:    "V1 message with label value exceeding limit",
+			msgType: remoteapi.WriteV1MessageType,
+			buildPayload: func() ([]byte, error) {
+				ts := []prompb.TimeSeries{{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "test_metric"}, {Name: "foo", Value: longValue}},
+					Samples: []prompb.Sample{{Value: 1, Timestamp: 1}},
+				}}
+				buf, _, _, err := buildWriteRequest(nil, ts, nil, nil, nil, nil, "snappy")
+				return buf, err
+			},
+			expectedCode: http.StatusNoContent, // V1 logs warning but continues (partial write behavior)
+		},
+		{
+			name:    "V1 message with label name exceeding limit",
+			msgType: remoteapi.WriteV1MessageType,
+			buildPayload: func() ([]byte, error) {
+				ts := []prompb.TimeSeries{{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "test_metric"}, {Name: longName, Value: "short"}},
+					Samples: []prompb.Sample{{Value: 1, Timestamp: 1}},
+				}}
+				buf, _, _, err := buildWriteRequest(nil, ts, nil, nil, nil, nil, "snappy")
+				return buf, err
+			},
+			expectedCode: http.StatusNoContent,
+		},
+		{
+			name:    "V1 message with exemplar label value exceeding limit",
+			msgType: remoteapi.WriteV1MessageType,
+			buildPayload: func() ([]byte, error) {
+				ts := []prompb.TimeSeries{{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "test_metric"}},
+					Samples: []prompb.Sample{{Value: 1, Timestamp: 1}},
+					Exemplars: []prompb.Exemplar{{
+						Labels:    []prompb.Label{{Name: "traceID", Value: longValue}},
+						Value:     1,
+						Timestamp: 1,
+					}},
+				}}
+				buf, _, _, err := buildWriteRequest(nil, ts, nil, nil, nil, nil, "snappy")
+				return buf, err
+			},
+			expectedCode:    http.StatusNoContent,
+			expectedSamples: 1,
+		},
+		{
+			name:    "V1 message with exemplar label name exceeding limit",
+			msgType: remoteapi.WriteV1MessageType,
+			buildPayload: func() ([]byte, error) {
+				ts := []prompb.TimeSeries{{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "test_metric"}},
+					Samples: []prompb.Sample{{Value: 1, Timestamp: 1}},
+					Exemplars: []prompb.Exemplar{{
+						Labels:    []prompb.Label{{Name: longName, Value: "short"}},
+						Value:     1,
+						Timestamp: 1,
+					}},
+				}}
+				buf, _, _, err := buildWriteRequest(nil, ts, nil, nil, nil, nil, "snappy")
+				return buf, err
+			},
+			expectedCode:    http.StatusNoContent,
+			expectedSamples: 1,
+		},
+		{
+			name:    "V2 message with label value exceeding limit",
+			msgType: remoteapi.WriteV2MessageType,
+			buildPayload: func() ([]byte, error) {
+				st := writev2.NewSymbolTable()
+				labelRefs := st.SymbolizeLabels(labels.FromStrings("__name__", "test_metric", "foo", longValue), nil)
+				ts := []writev2.TimeSeries{{
+					LabelsRefs: labelRefs,
+					Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+				}}
+				buf, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), ts, st.Symbols(), nil, nil, nil, "snappy")
+				return buf, err
+			},
+			expectedCode: http.StatusBadRequest,
+			expectedErr:  "label value exceeds maximum length",
+		},
+		{
+			name:    "V2 message with label name exceeding limit",
+			msgType: remoteapi.WriteV2MessageType,
+			buildPayload: func() ([]byte, error) {
+				st := writev2.NewSymbolTable()
+				labelRefs := st.SymbolizeLabels(labels.FromStrings("__name__", "test_metric", longName, "short"), nil)
+				ts := []writev2.TimeSeries{{
+					LabelsRefs: labelRefs,
+					Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+				}}
+				buf, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), ts, st.Symbols(), nil, nil, nil, "snappy")
+				return buf, err
+			},
+			expectedCode: http.StatusBadRequest,
+			expectedErr:  "label name exceeds maximum length",
+		},
+		{
+			name:    "V2 message with exemplar label value exceeding limit",
+			msgType: remoteapi.WriteV2MessageType,
+			buildPayload: func() ([]byte, error) {
+				st := writev2.NewSymbolTable()
+				labelRefs := st.SymbolizeLabels(labels.FromStrings("__name__", "test_metric"), nil)
+				exemplarRefs := st.SymbolizeLabels(labels.FromStrings("traceID", longValue), nil)
+				ts := []writev2.TimeSeries{{
+					LabelsRefs: labelRefs,
+					Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+					Exemplars: []writev2.Exemplar{{
+						LabelsRefs: exemplarRefs,
+						Value:      1,
+						Timestamp:  1,
+					}},
+				}}
+				buf, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), ts, st.Symbols(), nil, nil, nil, "snappy")
+				return buf, err
+			},
+			expectedCode:    http.StatusBadRequest,
+			expectedErr:     "label value exceeds maximum length",
+			expectedSamples: 1,
+		},
+		{
+			name:    "V2 message with exemplar label name exceeding limit",
+			msgType: remoteapi.WriteV2MessageType,
+			buildPayload: func() ([]byte, error) {
+				st := writev2.NewSymbolTable()
+				labelRefs := st.SymbolizeLabels(labels.FromStrings("__name__", "test_metric"), nil)
+				exemplarRefs := st.SymbolizeLabels(labels.FromStrings(longName, "short"), nil)
+				ts := []writev2.TimeSeries{{
+					LabelsRefs: labelRefs,
+					Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+					Exemplars: []writev2.Exemplar{{
+						LabelsRefs: exemplarRefs,
+						Value:      1,
+						Timestamp:  1,
+					}},
+				}}
+				buf, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), ts, st.Symbols(), nil, nil, nil, "snappy")
+				return buf, err
+			},
+			expectedCode:    http.StatusBadRequest,
+			expectedErr:     "label name exceeds maximum length",
+			expectedSamples: 1,
+		},
+		{
+			name:    "V2 message with metadata unit label value exceeding limit",
+			msgType: remoteapi.WriteV2MessageType,
+			buildPayload: func() ([]byte, error) {
+				st := writev2.NewSymbolTable()
+				labelRefs := st.SymbolizeLabels(labels.FromStrings("__name__", "test_metric"), nil)
+				unitRef := st.Symbolize(longValue)
+				ts := []writev2.TimeSeries{{
+					LabelsRefs: labelRefs,
+					Metadata: writev2.Metadata{
+						Type:    writev2.Metadata_METRIC_TYPE_COUNTER,
+						UnitRef: unitRef,
+					},
+					Samples: []writev2.Sample{{Value: 1, Timestamp: 1}},
+				}}
+				buf, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), ts, st.Symbols(), nil, nil, nil, "snappy")
+				return buf, err
+			},
+			expectedCode:            http.StatusBadRequest,
+			expectedErr:             "label value exceeds maximum length",
+			enableTypeAndUnitLabels: true,
+		},
+		{
+			name:    "V1 message with label value within limit",
+			msgType: remoteapi.WriteV1MessageType,
+			buildPayload: func() ([]byte, error) {
+				ts := []prompb.TimeSeries{{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "test_metric"}, {Name: "foo", Value: "short"}},
+					Samples: []prompb.Sample{{Value: 1, Timestamp: 1}},
+				}}
+				buf, _, _, err := buildWriteRequest(nil, ts, nil, nil, nil, nil, "snappy")
+				return buf, err
+			},
+			expectedCode:    http.StatusNoContent,
+			expectedSamples: 1,
+		},
+		{
+			name:    "V2 message with label value within limit",
+			msgType: remoteapi.WriteV2MessageType,
+			buildPayload: func() ([]byte, error) {
+				st := writev2.NewSymbolTable()
+				labelRefs := st.SymbolizeLabels(labels.FromStrings("__name__", "test_metric", "foo", "short"), nil)
+				ts := []writev2.TimeSeries{{
+					LabelsRefs: labelRefs,
+					Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+				}}
+				buf, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), ts, st.Symbols(), nil, nil, nil, "snappy")
+				return buf, err
+			},
+			expectedCode:    http.StatusNoContent,
+			expectedSamples: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, err := tc.buildPayload()
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(payload))
+			require.NoError(t, err)
+
+			req.Header.Set("Content-Type", remoteWriteContentTypeHeaders[tc.msgType])
+			req.Header.Set("Content-Encoding", compression.Snappy)
+
+			appendable := &mockAppendable{}
+			handler := NewWriteHandlerWithConfig(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{tc.msgType}, false, tc.enableTypeAndUnitLabels, false, testLimit)
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+
+			resp := recorder.Result()
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedCode, resp.StatusCode, "unexpected status code: %s", string(body))
+
+			if tc.expectedErr != "" {
+				require.Contains(t, string(body), tc.expectedErr)
+			}
+			require.Len(t, appendable.samples, tc.expectedSamples)
+			require.Len(t, appendable.exemplars, tc.expectedExemplars)
+		})
+	}
+}


### PR DESCRIPTION
This picks up #17309 after @beorn7 suggested a follow-up PR because the original branch had stalled. The core shape comes from @fancive's work; I rebased it onto current `main` and tightened the crash guard around the remaining label-construction paths.

What changed:

- Validate remote-write v1 label names and values before calling `ToLabels`.
- Validate remote-write v1 exemplar label names and values before calling `ToExemplar`.
- Validate remote-write v2 symbolized label names and values before constructing `labels.Labels`.
- Reject oversized v2 metadata-derived `__unit__` labels before type/unit labels are injected.
- Keep v1 best-effort behavior and v2 bad-request handling consistent with the surrounding receiver code.

Local verification:

Using repo-local Go temp/module/build caches:

```bash
go test ./storage/remote -run TestWriteHandler_LabelValueLengthLimit -count=1
go test ./prompb/... ./storage/remote
git diff origin/main..HEAD --check
```

I also ran a fresh uncommitted-change review pass against the full diff after rebasing onto current `origin/main`; it did not find a discrete regression.

#### Which issue(s) does the PR fix:

Contributes to #16525.

Follow-up to #17309; this PR does not close the broader tracking issue by itself.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] Remote write: Reject oversized label names and values before constructing labels.
```
