### PR TITLE
tsdb: fix pendingCommit condition for classic histogram append

### DIFF
--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -848,7 +848,7 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 		// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 		// to skip that sample from the WAL and write only in the WBL.
 		_, delta, err := s.appendableHistogram(t, h, a.headMaxt, a.minValidTime, a.oooTimeWindow)
-		if err != nil {
+		if err == nil {
 			s.pendingCommit = true
 		}
 		s.Unlock()

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -1155,6 +1155,53 @@ func testHeadAppenderV2OutOfOrderSamplesMetric(t *testing.T, scenario sampleType
 	require.NoError(t, app.Commit())
 }
 
+// TestHeadAppenderV2_HistogramErrorDoesNotSetPendingCommit is the V2
+// counterpart of TestAppendHistogramErrorDoesNotSetPendingCommit. The V2
+// histogram paths in head_append_v2.go already set pendingCommit only on
+// success, so this test is here to lock that property in.
+func TestHeadAppenderV2_HistogramErrorDoesNotSetPendingCommit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		h    *histogram.Histogram
+		fh   *histogram.FloatHistogram
+	}{
+		{name: "integer", h: tsdbutil.GenerateTestHistogram(0)},
+		{name: "float", fh: tsdbutil.GenerateTestFloatHistogram(0)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			head, _ := newTestHead(t, 1000, compression.None, false)
+			require.NoError(t, head.Init(0))
+
+			lbls := labels.FromStrings("a", "b")
+			ctx := context.Background()
+
+			app := head.AppenderV2(ctx)
+			_, err := app.Append(0, lbls, 0, 200, 0, tc.h, tc.fh, storage.AOptions{})
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			ms, _, err := head.getOrCreate(lbls.Hash(), lbls, false)
+			require.NoError(t, err)
+			require.NotNil(t, ms)
+			ms.Lock()
+			pc := ms.pendingCommit
+			ms.Unlock()
+			require.False(t, pc, "pendingCommit should be cleared after a successful commit")
+
+			// Out-of-order append for the same series, OOO window disabled.
+			app = head.AppenderV2(ctx)
+			_, err = app.Append(0, lbls, 0, 100, 0, tc.h, tc.fh, storage.AOptions{})
+			require.ErrorIs(t, err, storage.ErrOutOfOrderSample)
+			require.NoError(t, app.Rollback())
+
+			ms.Lock()
+			pc = ms.pendingCommit
+			ms.Unlock()
+			require.False(t, pc, "pendingCommit should remain false after a failed AppenderV2.Append")
+		})
+	}
+}
+
 func TestHeadLabelNamesValuesWithMinMaxRange_AppenderV2(t *testing.T) {
 	head, _ := newTestHead(t, 1000, compression.None, false)
 	defer func() {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -5708,6 +5708,58 @@ func TestAppendingDifferentEncodingToSameSeries(t *testing.T) {
 	require.Equal(t, map[string][]chunks.Sample{lbls.String(): expResult}, series)
 }
 
+// TestAppendHistogramErrorDoesNotSetPendingCommit verifies that when
+// AppendHistogram fails with a sample-validation error (e.g. out-of-order),
+// the existing memSeries's pendingCommit flag is not left set to true.
+// A stuck pendingCommit flag keeps the series alive across head GC even
+// though no samples are pending for it.
+func TestAppendHistogramErrorDoesNotSetPendingCommit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		h    *histogram.Histogram
+		fh   *histogram.FloatHistogram
+	}{
+		{name: "integer", h: tsdbutil.GenerateTestHistogram(0)},
+		{name: "float", fh: tsdbutil.GenerateTestFloatHistogram(0)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			head, _ := newTestHead(t, 1000, compression.None, false)
+			require.NoError(t, head.Init(0))
+
+			lbls := labels.FromStrings("a", "b")
+
+			// Seed an in-order sample so the series exists with maxTime=200.
+			app := head.Appender(context.Background())
+			_, err := app.AppendHistogram(0, lbls, 200, tc.h, tc.fh)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			ms, _, err := head.getOrCreate(lbls.Hash(), lbls, false)
+			require.NoError(t, err)
+			require.NotNil(t, ms)
+			ms.Lock()
+			pc := ms.pendingCommit
+			ms.Unlock()
+			require.False(t, pc, "pendingCommit should be cleared after a successful commit")
+
+			// Attempt an out-of-order append: same series, earlier timestamp,
+			// OOO time window disabled. appendableHistogram returns
+			// ErrOutOfOrderSample, so the sample is never recorded in the
+			// appender's batch and Commit/Rollback never clears pendingCommit
+			// for this series.
+			app = head.Appender(context.Background())
+			_, err = app.AppendHistogram(0, lbls, 100, tc.h, tc.fh)
+			require.ErrorIs(t, err, storage.ErrOutOfOrderSample)
+			require.NoError(t, app.Rollback())
+
+			ms.Lock()
+			pc = ms.pendingCommit
+			ms.Unlock()
+			require.False(t, pc, "pendingCommit should remain false after a failed AppendHistogram")
+		})
+	}
+}
+
 // Tests https://github.com/prometheus/prometheus/issues/9725.
 func TestChunkSnapshotReplayBug(t *testing.T) {
 	for _, enableSTStorage := range []bool{false, true} {


### PR DESCRIPTION
Picks the fix from #18400 by @cuiweixie (preserving authorship and sign-off) and adds the regression test that @bboreham asked for in review.

## Why

`headAppender.AppendHistogram` set `s.pendingCommit = true` when `appendableHistogram` returned a *non-nil* error, while every other site in `tsdb/head_append.go` (`Append`, `AppendSTZeroSample`, the float histogram branch, `AppendHistogramSTZeroSample`, and all V2 paths in `tsdb/head_append_v2.go`) sets it only when `err == nil`. The integer histogram branch was the lone outlier.

When the check fails (e.g. `ErrOutOfOrderSample`, `ErrTooOldSample`), the function returns without adding the series to the appender's batch, so `Commit`/`Rollback` never clears `pendingCommit` for that series. Head GC at `tsdb/head.go` treats `series.pendingCommit == true` as part of the "still in use" condition and won't remove the series — a small leak that can persist until the next successful append on it.

## What's in this PR

- The original one-line fix from #18400, with @cuiweixie's authorship and sign-off preserved.
- `TestAppendHistogramErrorDoesNotSetPendingCommit` covering both the integer and float histogram branches in V1. The integer subtest fails on `main` without the fix; both pass with it.
- `TestHeadAppenderV2_HistogramErrorDoesNotSetPendingCommit` covering the same property for V2. V2 already had the correct condition; the test is a lock-in and was confirmed to fail when the V2 integer condition is inverted locally.

Supersedes #18400 — happy to close that one once this lands, or for the maintainers to prefer the test be pushed onto @cuiweixie's branch instead, whichever path is easier.

```release-notes
[BUGFIX] TSDB: Do not leak head series when an integer histogram append is rejected (e.g. out-of-order).
```