### PR TITLE
cmd/prometheus: add --auto-gomemlimit.refresh-interval flag

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -206,9 +206,10 @@ type flagConfig struct {
 	enableAutoReload   bool
 	autoReloadInterval model.Duration
 
-	maxprocsEnable bool
-	memlimitEnable bool
-	memlimitRatio  float64
+	maxprocsEnable          bool
+	memlimitEnable          bool
+	memlimitRatio           float64
+	memlimitRefreshInterval model.Duration
 
 	featureList []string
 	// These options are extracted from featureList
@@ -424,6 +425,8 @@ func main() {
 		Default("true").BoolVar(&cfg.memlimitEnable)
 	a.Flag("auto-gomemlimit.ratio", "The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory").
 		Default("0.9").FloatVar(&cfg.memlimitRatio)
+	a.Flag("auto-gomemlimit.refresh-interval", "Interval at which to re-detect the container or system memory limit and update GOMEMLIMIT accordingly. Useful when the limit can change at runtime, e.g. with a Vertical Pod Autoscaler. Set to 0 to detect the limit only once at startup. Note that a downward change in the limit can cause a temporary increase in garbage collection activity. Only used when --auto-gomemlimit is set.").
+		Default("0s").SetValue(&cfg.memlimitRefreshInterval)
 
 	webConfig := a.Flag(
 		"web.config.file",
@@ -796,6 +799,7 @@ func main() {
 	if cfg.memlimitEnable {
 		if _, err := memlimit.SetGoMemLimitWithOpts(
 			memlimit.WithRatio(cfg.memlimitRatio),
+			memlimit.WithRefreshInterval(time.Duration(cfg.memlimitRefreshInterval)),
 			memlimit.WithProvider(
 				memlimit.ApplyFallback(
 					memlimit.FromCgroup,

--- a/docs/command-line/prometheus.md
+++ b/docs/command-line/prometheus.md
@@ -18,6 +18,7 @@ The Prometheus monitoring server
 | <code class="text-nowrap">--auto-gomaxprocs</code> | Automatically set GOMAXPROCS to match Linux container CPU quota | `true` |
 | <code class="text-nowrap">--auto-gomemlimit</code> | Automatically set GOMEMLIMIT to match Linux container or system memory limit | `true` |
 | <code class="text-nowrap">--auto-gomemlimit.ratio</code> | The ratio of reserved GOMEMLIMIT memory to the detected maximum container or system memory | `0.9` |
+| <code class="text-nowrap">--auto-gomemlimit.refresh-interval</code> | Interval at which to re-detect the container or system memory limit and update GOMEMLIMIT accordingly. Useful when the limit can change at runtime, e.g. with a Vertical Pod Autoscaler. Set to 0 to detect the limit only once at startup. Note that a downward change in the limit can cause a temporary increase in garbage collection activity. Only used when --auto-gomemlimit is set. | `0s` |
 | <code class="text-nowrap">--web.config.file</code> | [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication. |  |
 | <code class="text-nowrap">--web.read-timeout</code> | Maximum duration before timing out read of the request, and closing idle connections. | `5m` |
 | <code class="text-nowrap">--web.max-connections</code> | Maximum number of simultaneous connections across all listeners. | `512` |


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18712

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[FEATURE] Prometheus: Add `--auto-gomemlimit.refresh-interval` flag to periodically re-detect the container or system memory limit and update `GOMEMLIMIT` at runtime.
```

---

## What this does

The auto-GOMEMLIMIT feature (`--auto-gomemlimit`) detects the cgroup or system memory limit **only once at startup**, via a single call to `memlimit.SetGoMemLimitWithOpts`. If the limit changes while Prometheus is running — for example, a Vertical Pod Autoscaler (VPA) adjusting a container's memory — `GOMEMLIMIT` keeps the value computed at startup until the process restarts.

This PR adds an optional `--auto-gomemlimit.refresh-interval` flag that wires the `automemlimit` library's existing `WithRefreshInterval` option. When set to a non-zero duration, the limit is periodically re-detected and `GOMEMLIMIT` is reapplied if it changed.

- Default is `0s`, which preserves the current behaviour exactly (detect once at startup, no background refresh — `WithRefreshInterval(0)` is a no-op in the library).
- The flag is only used when `--auto-gomemlimit` is enabled, consistent with `--auto-gomemlimit.ratio`.
- Negative durations are rejected at flag-parse time by `model.Duration`, so the library's ticker can never receive an invalid interval.

## Notes

- As discussed in the issue, the polling cost is negligible at typical intervals (≥30–60s) — it reads a single value from cgroup memory. The flag defaults to disabled so there is no behaviour change unless opted in.
- The help text calls out that a downward change in the limit (e.g. a VPA scale-down) can cause a temporary increase in GC activity, so operators aren't surprised.

## Changes

- `cmd/prometheus/main.go`: new flag + config field, passed through as `memlimit.WithRefreshInterval`.
- `docs/command-line/prometheus.md`: regenerated via `make cli-documentation`.

I have signed the DCO.