### PR TITLE
discovery/aws: handle rds clusters without instances

### DIFF
--- a/discovery/aws/rds.go
+++ b/discovery/aws/rds.go
@@ -486,9 +486,6 @@ func (d *RDSDiscovery) describeDBInstances(ctx context.Context, dbClusterARN str
 		if err != nil {
 			return nil, fmt.Errorf("failed to describe DB instances for cluster ARN %s: %w", dbClusterARN, err)
 		}
-		if len(output.DBInstances) == 0 {
-			return nil, fmt.Errorf("no DB instances found for cluster ARN %s", dbClusterARN)
-		}
 
 		for _, dbInstance := range output.DBInstances {
 			mu.Lock()

--- a/discovery/aws/rds_test.go
+++ b/discovery/aws/rds_test.go
@@ -250,6 +250,21 @@ func TestRDSDiscoveryRefresh(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "NoInstancesInCluster",
+			clusters: map[string]types.DBCluster{
+				"arn:aws:rds:us-west-2:123456789012:cluster:prod-cluster": {
+					DBClusterArn:        aws.String("arn:aws:rds:us-west-2:123456789012:cluster:prod-cluster"),
+					DBClusterIdentifier: aws.String("prod-cluster"),
+					Engine:              aws.String("aurora-mysql"),
+					EngineVersion:       aws.String("8.0.mysql_aurora.3.04.0"),
+					Status:              aws.String("available"),
+					DBClusterMembers:    []types.DBClusterMember{},
+				},
+			},
+			instances:      map[string][]types.DBInstance{},
+			expectedLabels: []model.LabelSet{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR updates the AWS SD RDS role so that it no longer returns an error when processing an empty cluster (i.e. a cluster without instances).

In my opinion, the cluster should be ignored, no target should be generated, and no error should be reported.

I've also added the corresponding test.

Let me know what you think cc @matt-gp

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Discovery/AWS: Fix failure when processing an AWS RDS cluster without instances #18845
```