### PR TITLE
tsdb: store maxt timestamp in walExpiries on stale series eviction

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9653,6 +9653,74 @@ func TestStaleSeriesCompactionWithZeroSeries(t *testing.T) {
 	require.Empty(t, db.Blocks())
 }
 
+// TestCompactStaleHead_EvictedSeriesRecordKeptInCheckpoint verifies that after
+// CompactStaleHead evicts a stale series, the series's label record is retained
+// in the next WAL checkpoint while the WAL still holds sample records
+// referencing its ref. The test forces a checkpoint via truncateWAL with a
+// mint between head.MinTime and head.MaxTime, then reads the checkpoint and
+// asserts that the evicted series's record is present.
+func TestCompactStaleHead_EvictedSeriesRecordKeptInCheckpoint(t *testing.T) {
+	const chunkRange = 1000
+	opts := DefaultOptions()
+	opts.MinBlockDuration = chunkRange
+	opts.MaxBlockDuration = chunkRange
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+
+	staleV := math.Float64frombits(value.StaleNaN)
+
+	sel := labels.FromStrings("name", "selected")
+	app := db.Appender(context.Background())
+	selRef, err := app.Append(0, sel, 100, 1.0)
+	require.NoError(t, err)
+	_, err = app.Append(selRef, sel, 200, staleV) // marks sel as stale
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+	require.Equal(t, uint64(1), db.Head().NumStaleSeries(),
+		"sel must be the only stale series")
+
+	// Evict sel via gcStaleSeries → sets walExpiries[selRef] = head.MaxTime() (200).
+	require.NoError(t, db.CompactStaleHead())
+	_, ok := db.Head().getWALExpiry(chunks.HeadSeriesRef(selRef))
+	require.True(t, ok, "walExpiry must be recorded for the evicted ref")
+
+	// truncateMint sits between the two head bounds: > head.MinTime so the
+	// checkpoint can run, and <= head.MaxTime so the walExpiry (200) is
+	// considered still in effect and the series record must be kept.
+	truncateMint := int64(150)
+
+	// Each truncateWAL call rolls to a new WAL segment; truncateWAL is a no-op
+	// until there are enough segments to checkpoint, so loop until a checkpoint
+	// is actually produced.
+	for range 10 {
+		db.head.lastWALTruncationTime.Store(0) // force re-truncation each iteration
+		require.NoError(t, db.head.truncateWAL(truncateMint))
+		if _, _, err := wlog.LastCheckpoint(db.head.wal.Dir()); err == nil {
+			break
+		}
+	}
+
+	checkpointDir, _, err := wlog.LastCheckpoint(db.head.wal.Dir())
+	require.NoError(t, err, "a checkpoint must have been produced")
+
+	records := readTestWAL(t, checkpointDir)
+	selRefPresent := false
+	for _, rec := range records {
+		seriesRecs, ok := rec.([]record.RefSeries)
+		if !ok {
+			continue
+		}
+		for _, s := range seriesRecs {
+			if storage.SeriesRef(s.Ref) == selRef {
+				selRefPresent = true
+			}
+		}
+	}
+	require.True(t, selRefPresent,
+		"the evicted stale series's record must remain in the checkpoint while the WAL "+
+			"still holds sample records referencing this ref")
+}
+
 func TestBeyondSizeRetentionWithPercentage(t *testing.T) {
 	const maxBlock = 100
 	const numBytesChunks = 1024

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2226,16 +2226,17 @@ func (h *Head) gcStaleSeries(seriesRefs []storage.SeriesRef, maxt int64) map[sto
 	h.tombstones.DeleteTombstones(deleted)
 
 	if h.wal != nil {
-		_, last, _ := wlog.Segments(h.wal.Dir())
 		h.walExpiriesMtx.Lock()
-		// Keep series records until we're past segment 'last'
-		// because the WAL will still have samples records with
-		// this ref ID. If we didn't keep these series records then
-		// on start up when we replay the WAL, or any other code
-		// that reads the WAL, wouldn't be able to use those
-		// samples since we would have no labels for that ref ID.
+		// Keep series records until we're past timestamp 'maxt' because
+		// the WAL will still have samples records with this ref ID. The
+		// value must be a timestamp (not e.g. a WAL segment number)
+		// because the reader and the cleaner both compare it against a
+		// timestamp. If we didn't keep these series records then on start
+		// up when we replay the WAL, or any other code that reads the
+		// WAL, wouldn't be able to use those samples since we would have
+		// no labels for that ref ID.
 		for ref := range deleted {
-			h.walExpiries[chunks.HeadSeriesRef(ref)] = int64(last)
+			h.walExpiries[chunks.HeadSeriesRef(ref)] = maxt
 		}
 		h.walExpiriesMtx.Unlock()
 	}

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2227,14 +2227,12 @@ func (h *Head) gcStaleSeries(seriesRefs []storage.SeriesRef, maxt int64) map[sto
 
 	if h.wal != nil {
 		h.walExpiriesMtx.Lock()
-		// Keep series records until we're past timestamp 'maxt' because
-		// the WAL will still have samples records with this ref ID. The
-		// value must be a timestamp (not e.g. a WAL segment number)
-		// because the reader and the cleaner both compare it against a
-		// timestamp. If we didn't keep these series records then on start
-		// up when we replay the WAL, or any other code that reads the
-		// WAL, wouldn't be able to use those samples since we would have
-		// no labels for that ref ID.
+		// Keep series records until we're past timestamp maxt
+		// because the WAL will still have samples records with
+		// this ref ID. If we didn't keep these series records then
+		// on start up when we replay the WAL, or any other code
+		// that reads the WAL, wouldn't be able to use those
+		// samples since we would have no labels for that ref ID.
 		for ref := range deleted {
 			h.walExpiries[chunks.HeadSeriesRef(ref)] = maxt
 		}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

Prometheus keeps a small bookkeeping table — `walExpiries` — that, for each series the system has recently dropped from the head, remembers a value meaning *"keep this series's label record around until at least this point in time."* The reason it has to remember anything is that even after a series has been dropped from active memory, older WAL segments on disk may still contain sample records that point back at it. If those samples are read later (for example, on a restart), the system needs the series's label record to make sense of them.

  There are two places in the code that add entries to this table. One — the regular head GC — writes a moment in time (a millisecond timestamp) into the value. The other — `gcStaleSeries`, used by `CompactStaleHead` — was writing a WAL segment number (a small counter — 0, 1, 2, …) into the same field.

  Later, two other places read this table to decide what to throw away — one when compressing old WAL segments into a checkpoint, the other when cleaning up the bookkeeping table itself. Both treat the value as a moment in time and compare it against a millisecond timestamp. A WAL segment number, being a tiny integer, will always look like a moment in the very distant past compared to any real timestamp. So the comparison always says *"the deadline has already passed, throw this entry away."*

  The result is that entries created by the buggy path were discarded immediately on the next cleanup, even when they should have been kept. The series's label record then disappeared from the checkpoint, and any sample records that still referenced that series — sitting in WAL segments that hadn't been truncated yet — became orphans: the system can no longer match them to a series the next time it reads the log.

  In practice this does **not** lose user-visible data, because at the moment the bookkeeping entry is created the system has just safely written the affected series's samples to a permanent on-disk block. So the samples are still there if you query them. What the bug does cause is internal inconsistency: orphaned records in the WAL, `prometheus_tsdb_wal_replay_unknown_refs_total` counters ticking up on restart, and warnings in the logs that look like data corruption to anyone reading them. It also breaks an invariant the code is plainly trying to maintain: that the label record outlives the samples that point at it.

  #### What changed
  
  `gcStaleSeries` now stores `maxt` — the millisecond timestamp it already receives as an argument — in `walExpiries`, matching the unit used by the regular head GC and expected by both readers. The change is two lines in `tsdb/head.go`: drop the `wlog.Segments` lookup, replace `int64(last)` with `maxt`, and update the surrounding comment to spell out that the value must be a timestamp.

  A regression test, `TestCompactStaleSeries_EvictedSeriesRecordKeptInCheckpoint` in `tsdb/db_test.go`, exercises the pipeline end-to-end: it triggers `CompactStaleSeries`, forces a WAL checkpoint via repeated `truncateWAL` calls, then reads the resulting checkpoint and asserts that the evicted series's `RefSeries` record is present. The test fails on the old code (the unit-mismatched value is treated as expired and the series record is dropped from the checkpoint) and passes on the fixed code.

Release Notes:
```release-notes
[BUGFIX] tsdb: store a millisecond timestamp (not a WAL segment number) in walExpiries when a series is evicted via CompactStaleHead/CompactSelectedSeries, so the series's label record is correctly retained in the next WAL checkpoint and replays cleanly.
```
