### PR TITLE
tsdb: capture chunk-boundary samples in CompactStaleHead

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1691,7 +1691,7 @@ func (db *DB) CompactStaleHead() (err error) {
 	meta := &BlockMeta{}
 	meta.Compaction.SetStaleSeries()
 	mint, maxt := db.head.opts.ChunkRange*(db.head.MinTime()/db.head.opts.ChunkRange), db.head.MaxTime()
-	for ; mint < maxt; mint += db.head.chunkRange.Load() {
+	for ; mint <= maxt; mint += db.head.chunkRange.Load() {
 		staleHead := NewStaleHead(db.Head(), mint, mint+db.head.chunkRange.Load()-1, staleSeriesRefs)
 
 		uids, err := db.compactor.Write(db.dir, staleHead, staleHead.MinTime(), staleHead.BlockMaxTime(), meta)

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9721,6 +9721,63 @@ func TestCompactStaleHead_EvictedSeriesRecordKeptInCheckpoint(t *testing.T) {
 			"still holds sample records referencing this ref")
 }
 
+// TestCompactStaleHead_ChunkBoundarySampleNotLost verifies that CompactStaleHead
+// preserves a sample whose timestamp lands exactly on a chunk-range boundary.
+//
+// CompactStaleHead walks the head's time range one fixed-width slice
+// (chunkRange) at a time, writes one on-disk block per slice for the stale
+// series, then removes those series from memory. A sample sitting exactly on
+// the upper boundary must still be captured by a block before the in-memory
+// copy is removed.
+//
+// The test plants a stale series with samples at t=500 (regular value) and at
+// t=chunkRange (=1000, stale-NaN marker). The stale-NaN at the boundary is
+// what makes sel stale and a candidate for CompactStaleHead; the earlier
+// regular sample keeps the head's lower bound below the boundary so the
+// removal step runs end to end and the boundary slice is exercised. After
+// CompactStaleHead completes, both samples must still be queryable.
+func TestCompactStaleHead_ChunkBoundarySampleNotLost(t *testing.T) {
+	const chunkRange = 1000
+	opts := DefaultOptions()
+	opts.MinBlockDuration = chunkRange
+	opts.MaxBlockDuration = chunkRange
+	db := newTestDB(t, withOpts(opts))
+	db.DisableCompactions()
+
+	staleV := math.Float64frombits(value.StaleNaN)
+
+	sel := labels.FromStrings("name", "selected")
+	app := db.Appender(context.Background())
+	selRef, err := app.Append(0, sel, 500, 1.0)
+	require.NoError(t, err)
+	_, err = app.Append(selRef, sel, chunkRange, staleV) // T == chunkRange, marks sel stale
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	require.Equal(t, int64(500), db.Head().MinTime(), "test precondition")
+	require.Equal(t, int64(chunkRange), db.Head().MaxTime(), "test precondition")
+	require.Equal(t, uint64(1), db.Head().NumStaleSeries(),
+		"sel must be the only stale series")
+
+	require.NoError(t, db.CompactStaleHead())
+
+	q, err := db.Querier(0, 2*chunkRange)
+	require.NoError(t, err)
+	// Use the no-replacement variant so the stale-NaN bit pattern survives into the result.
+	seriesSet := queryWithoutReplacingNaNs(t, q, labels.MustNewMatcher(labels.MatchEqual, "name", "selected"))
+	actual := seriesSet[`{name="selected"}`]
+
+	require.Len(t, actual, 2,
+		"both samples must remain queryable; if the boundary sample is missing the "+
+			"loop in compactHeadViewLocked exited one iteration too early and the slice "+
+			"covering [chunkRange, 2*chunkRange-1] was never produced as a block")
+	require.Equal(t, int64(500), actual[0].T(), "first sample timestamp")
+	require.Equal(t, 1.0, actual[0].F(), "first sample value")
+	require.Equal(t, int64(chunkRange), actual[1].T(), "boundary sample timestamp")
+	require.True(t, value.IsStaleNaN(actual[1].F()),
+		"boundary sample must remain the stale-NaN marker")
+}
+
 func TestBeyondSizeRetentionWithPercentage(t *testing.T) {
 	const maxBlock = 100
 	const numBytesChunks = 1024


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

#### Summary
`CompactStaleSeries` writes stale series from the head into blocks and then evicts them from memory. A boundary condition in its block-generation loop can cause data loss when the latest sample of a series falls exactly on a block boundary.

The loop currently stops when the next block’s start time is not strictly less than the head’s maximum timestamp (`mint < maxt`). As a result, a sample at exactly the boundary timestamp is not included in any generated block.

The problem becomes visible when the series also contains at least one older sample. In that case, the older sample is written to a block, the series is considered safe to evict, and the boundary sample is removed from the head even though it was never written to disk. The sample is then lost permanently.

  #### What changed
 The fix changes the loop condition in `CompactStaleSeries` (`tsdb/db.go`) from:
```go
min < maxt
```
to
```go
min <= maxt
```
This ensures that a sample exactly on a block boundary is included in the final block before the series is evicted.

A regression test, `TestCompactStaleSeries_ChunkBoundarySampleNotLost`, reproduces the issue with a series containing one sample before the boundary (`t=500`) and one exactly on the boundary (`t=chunkRange=1000`). The test verifies that both samples remain queryable after compaction. It fails on the old code and passes with the fix.

Release Notes:
```release-notes
[BUGFIX] tsdb: prevent loss of samples at the chunk-range boundary when CompactSelectedSeries (and CompactStaleHead) evict the series — the per-slice compaction loop now runs one more iteration so the boundary timestamp is captured in a block before the in-memory copy is removed.
```
