### PR TITLE
promtool: fix check healthy/ready failing with a trailing slash in the URL

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -569,8 +569,11 @@ func CheckServerStatus(serverURL *url.URL, checkEndpoint string, roundTripper ht
 		serverURL.Scheme = "http"
 	}
 
+	// Join the endpoint onto the server URL path so that a trailing slash in
+	// the user-provided URL does not result in a doubled slash (e.g.
+	// "//-/healthy"), which the Prometheus router does not match.
 	config := api.Config{
-		Address:      serverURL.String() + checkEndpoint,
+		Address:      serverURL.JoinPath(checkEndpoint).String(),
 		RoundTripper: roundTripper,
 	}
 

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -120,6 +120,35 @@ func TestQueryInstantHeaders(t *testing.T) {
 	require.Equal(t, "value", getRequest().Header.Get("X-Custom"))
 }
 
+func TestCheckServerStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		urlSuffix string
+	}{
+		{name: "no trailing slash", urlSuffix: ""},
+		{name: "trailing slash", urlSuffix: "/"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s, getRequest := mockServer(200, "Prometheus is Healthy.\n")
+			defer s.Close()
+
+			urlObject, err := url.Parse(s.URL + tc.urlSuffix)
+			require.NoError(t, err)
+
+			err = CheckServerStatus(urlObject, checkHealth, http.DefaultTransport)
+			require.NoError(t, err)
+			// The endpoint path must be requested verbatim regardless of a
+			// trailing slash in the user-provided URL. A naive string
+			// concatenation would request "//-/healthy" here, which the
+			// Prometheus router does not match.
+			require.Equal(t, checkHealth, getRequest().URL.Path)
+		})
+	}
+}
+
 func mockServer(code int, body string) (*httptest.Server, func() *http.Request) {
 	var req *http.Request
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] Promtool: Fix `check healthy` and `check ready` when `--url` ends with a trailing slash.
```

`promtool check healthy` and `promtool check ready` build the request URL by concatenating the server URL with the endpoint path:

```go
Address: serverURL.String() + checkEndpoint, // checkEndpoint = "/-/healthy"
```

If the `--url` value ends with a slash (e.g. `--url=http://localhost:9090/`), this produces a doubled slash: `http://localhost:9090//-/healthy`. The router registers `/-/healthy` and `/-/ready` verbatim and does not collapse repeated slashes, so the request 404s and the command reports `check failed: ... status=404` even though the server is healthy. A trailing slash is easy to end up with in scripts and container HEALTHCHECKs.

Fix is to append the endpoint with `url.JoinPath` instead of string concatenation. It normalises the slash and also keeps working when the server is served under a route prefix (e.g. `http://host:9090/prometheus/` -> `/prometheus/-/healthy`). `JoinPath` returns a new URL, so the original is untouched and the error message at the bottom of the function still prints the URL the user passed.

Added `TestCheckServerStatus` covering both the plain and trailing-slash forms; it asserts the requested path is `/-/healthy` in both cases. The test fails before the change (`//-/healthy`) and passes after.