### PR TITLE
tsdb/chunkenc: take a generic Appender as the prev parameter

### DIFF
--- a/tsdb/chunkenc/appendable.go
+++ b/tsdb/chunkenc/appendable.go
@@ -1,0 +1,42 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunkenc
+
+import "github.com/prometheus/prometheus/model/histogram"
+
+// histogramAppendable is the subset of an integer-histogram appender's API
+// that AppendHistogram needs from a previous chunk's appender in order to
+// detect counter resets across chunks. It is satisfied by *HistogramAppender
+// and any type that embeds it (e.g. *HistogramSTAppender). The Appender
+// interface itself stays a single type so callers can hand off whichever
+// concrete appender they happen to have without first type-asserting it.
+type histogramAppendable interface {
+	appendable(*histogram.Histogram) (
+		positiveInserts, negativeInserts,
+		backwardPositiveInserts, backwardNegativeInserts []Insert,
+		okToAppend bool, counterResetHint CounterResetHeader,
+	)
+}
+
+// floatHistogramAppendable is the float-histogram counterpart of
+// histogramAppendable. Note the asymmetry with the integer version: float
+// histograms surface a bool counter-reset flag rather than the richer
+// CounterResetHeader value used for integer histograms.
+type floatHistogramAppendable interface {
+	appendable(*histogram.FloatHistogram) (
+		positiveInserts, negativeInserts,
+		backwardPositiveInserts, backwardNegativeInserts []Insert,
+		okToAppend, counterReset bool,
+	)
+}

--- a/tsdb/chunkenc/chunk.go
+++ b/tsdb/chunkenc/chunk.go
@@ -119,6 +119,9 @@ type Appender interface {
 	// Appending a histogram may require creating a completely new chunk or recoding (changing) the current chunk.
 	// The Appender prev is used to determine if there is a counter reset between the previous Appender and the current Appender.
 	// The Appender prev is optional and only taken into account when the first sample is being appended.
+	// It is typed as the generic Appender interface so callers can pass whichever concrete appender they
+	// currently hold without first type-asserting; each implementation performs the type check itself,
+	// and only on the code path that actually needs the previous appender's state.
 	// The bool appendOnly governs what happens when a sample cannot be appended to the current chunk. If appendOnly is true, then
 	// in such case an error is returned without modifying the chunk. If appendOnly is false, then a new chunk is created or the
 	// current chunk is recoded to accommodate the sample.
@@ -126,8 +129,8 @@ type Appender interface {
 	// The returned bool isRecoded can be used to distinguish between the new Chunk c being a completely new Chunk
 	// or the current Chunk recoded to a new Chunk.
 	// The Appender app that can be used for the next append is always returned.
-	AppendHistogram(prev *HistogramAppender, st, t int64, h *histogram.Histogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
-	AppendFloatHistogram(prev *FloatHistogramAppender, st, t int64, h *histogram.FloatHistogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
+	AppendHistogram(prev Appender, st, t int64, h *histogram.Histogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
+	AppendFloatHistogram(prev Appender, st, t int64, h *histogram.FloatHistogram, appendOnly bool) (c Chunk, isRecoded bool, app Appender, err error)
 }
 
 // Iterator is a simple iterator that can only get the next value.

--- a/tsdb/chunkenc/float_histogram.go
+++ b/tsdb/chunkenc/float_histogram.go
@@ -682,11 +682,11 @@ func (*FloatHistogramAppender) recodeHistogram(
 	}
 }
 
-func (*FloatHistogramAppender) AppendHistogram(*HistogramAppender, int64, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
+func (*FloatHistogramAppender) AppendHistogram(Appender, int64, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a histogram sample to a float histogram chunk")
 }
 
-func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppender, _, t int64, h *histogram.FloatHistogram, appendOnly bool) (Chunk, bool, Appender, error) {
+func (a *FloatHistogramAppender) AppendFloatHistogram(prev Appender, _, t int64, h *histogram.FloatHistogram, appendOnly bool) (Chunk, bool, Appender, error) {
 	numSamples := a.NumSamples()
 
 	if numSamples == math.MaxUint16 {
@@ -705,12 +705,21 @@ func (a *FloatHistogramAppender) AppendFloatHistogram(prev *FloatHistogramAppend
 			// Always honor the explicit counter reset hint.
 			a.setCounterResetHeader(CounterReset)
 		case prev != nil:
-			// This is a new chunk, but continued from a previous one. We need to calculate the reset header unless already set.
-			_, _, _, _, _, counterReset := prev.appendable(h)
-			if counterReset {
-				a.setCounterResetHeader(CounterReset)
-			} else {
-				a.setCounterResetHeader(NotCounterReset)
+			// This is a new chunk, but continued from a previous one. We need
+			// to calculate the reset header unless already set. We only need
+			// the prev appender's appendable() method, so we type-assert here
+			// rather than at the interface boundary; this lets callers pass
+			// any Appender (xor, xor2, histogram, floatHistogramST, ...) and
+			// we silently ignore prev when it isn't a float-histogram appender
+			// (e.g. a transition from an integer histogram chunk, where the
+			// counter-reset relationship is not defined here).
+			if p, ok := prev.(floatHistogramAppendable); ok {
+				_, _, _, _, _, counterReset := p.appendable(h)
+				if counterReset {
+					a.setCounterResetHeader(CounterReset)
+				} else {
+					a.setCounterResetHeader(NotCounterReset)
+				}
 			}
 		}
 		return nil, false, a, nil

--- a/tsdb/chunkenc/histogram.go
+++ b/tsdb/chunkenc/histogram.go
@@ -734,11 +734,11 @@ func (a *HistogramAppender) writeSumDelta(v float64) {
 	xorWrite(a.b, v, a.sum, &a.leading, &a.trailing)
 }
 
-func (*HistogramAppender) AppendFloatHistogram(*FloatHistogramAppender, int64, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
+func (*HistogramAppender) AppendFloatHistogram(Appender, int64, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a float histogram sample to a histogram chunk")
 }
 
-func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, _, t int64, h *histogram.Histogram, appendOnly bool) (Chunk, bool, Appender, error) {
+func (a *HistogramAppender) AppendHistogram(prev Appender, _, t int64, h *histogram.Histogram, appendOnly bool) (Chunk, bool, Appender, error) {
 	numSamples := a.NumSamples()
 
 	if numSamples == math.MaxUint16 {
@@ -757,9 +757,18 @@ func (a *HistogramAppender) AppendHistogram(prev *HistogramAppender, _, t int64,
 			// Always honor the explicit counter reset hint.
 			a.setCounterResetHeader(CounterReset)
 		case prev != nil:
-			// This is a new chunk, but continued from a previous one. We need to calculate the reset header unless already set.
-			_, _, _, _, _, counterReset := prev.appendable(h)
-			a.setCounterResetHeader(counterReset)
+			// This is a new chunk, but continued from a previous one. We need
+			// to calculate the reset header unless already set. We only need
+			// the prev appender's appendable() method, so we type-assert here
+			// rather than at the interface boundary; this lets callers pass
+			// any Appender (xor, xor2, histogram, histogramST, ...) and we
+			// silently ignore prev when it isn't an integer-histogram appender
+			// (e.g. a transition from a float chunk, where there is no counter
+			// to reset against).
+			if p, ok := prev.(histogramAppendable); ok {
+				_, _, _, _, _, counterReset := p.appendable(h)
+				a.setCounterResetHeader(counterReset)
+			}
 		}
 		return nil, false, a, nil
 	}

--- a/tsdb/chunkenc/xor.go
+++ b/tsdb/chunkenc/xor.go
@@ -227,11 +227,11 @@ func (a *xorAppender) writeVDelta(v float64) {
 	xorWrite(a.b, v, a.v, &a.leading, &a.trailing)
 }
 
-func (*xorAppender) AppendHistogram(*HistogramAppender, int64, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
+func (*xorAppender) AppendHistogram(Appender, int64, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a histogram sample to a float chunk")
 }
 
-func (*xorAppender) AppendFloatHistogram(*FloatHistogramAppender, int64, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
+func (*xorAppender) AppendFloatHistogram(Appender, int64, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a float histogram sample to a float chunk")
 }
 

--- a/tsdb/chunkenc/xor2.go
+++ b/tsdb/chunkenc/xor2.go
@@ -503,11 +503,11 @@ func (a *xor2Appender) writeVDeltaKnownNonZero(delta uint64) {
 	a.b.writeBitsFast(delta>>newTrailing, int(sigbits))
 }
 
-func (*xor2Appender) AppendHistogram(*HistogramAppender, int64, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
+func (*xor2Appender) AppendHistogram(Appender, int64, int64, *histogram.Histogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a histogram sample to a float chunk")
 }
 
-func (*xor2Appender) AppendFloatHistogram(*FloatHistogramAppender, int64, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
+func (*xor2Appender) AppendFloatHistogram(Appender, int64, int64, *histogram.FloatHistogram, bool) (Chunk, bool, Appender, error) {
 	panic("appended a float histogram sample to a float chunk")
 }
 

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1877,8 +1877,7 @@ func (s *memSeries) appendHistogram(st, t int64, h *histogram.Histogram, appendI
 	// Head controls the execution of recoding, so that we own the proper
 	// chunk reference afterwards and mmap used up chunks.
 
-	// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
-	prevApp, _ := s.app.(*chunkenc.HistogramAppender)
+	prevApp := s.app
 
 	c, sampleInOrder, chunkCreated := s.histogramsAppendPreprocessor(t, chunkenc.ValHistogram.ChunkEncoding(o.useXOR2), o)
 	if !sampleInOrder {
@@ -1935,8 +1934,7 @@ func (s *memSeries) appendFloatHistogram(st, t int64, fh *histogram.FloatHistogr
 	// Head controls the execution of recoding, so that we own the proper
 	// chunk reference afterwards and mmap used up chunks.
 
-	// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
-	prevApp, _ := s.app.(*chunkenc.FloatHistogramAppender)
+	prevApp := s.app
 
 	c, sampleInOrder, chunkCreated := s.histogramsAppendPreprocessor(t, chunkenc.ValFloatHistogram.ChunkEncoding(o.useXOR2), o)
 	if !sampleInOrder {

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -127,13 +127,11 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 			app.Append(s.st, s.t, s.f)
 		case chunkenc.EncHistogram:
 			// TODO(krajorama,ywwg): handle ST capable histogram chunk.
-			// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
-			prevHApp, _ := prevApp.(*chunkenc.HistogramAppender)
 			var (
 				newChunk chunkenc.Chunk
 				recoded  bool
 			)
-			newChunk, recoded, app, _ = app.AppendHistogram(prevHApp, s.st, s.t, s.h, false)
+			newChunk, recoded, app, _ = app.AppendHistogram(prevApp, s.st, s.t, s.h, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
 					chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})
@@ -143,13 +141,11 @@ func (o *OOOChunk) ToEncodedChunks(mint, maxt int64, useXOR2 bool) (chks []memCh
 			}
 		case chunkenc.EncFloatHistogram:
 			// TODO(krajorama,ywwg): handle ST capable float histogram chunk.
-			// Ignoring ok is ok, since we don't want to compare to the wrong previous appender anyway.
-			prevHApp, _ := prevApp.(*chunkenc.FloatHistogramAppender)
 			var (
 				newChunk chunkenc.Chunk
 				recoded  bool
 			)
-			newChunk, recoded, app, _ = app.AppendFloatHistogram(prevHApp, s.st, s.t, s.fh, false)
+			newChunk, recoded, app, _ = app.AppendFloatHistogram(prevApp, s.st, s.t, s.fh, false)
 			if newChunk != nil { // A new chunk was allocated.
 				if !recoded {
 					chks = append(chks, memChunk{chunk, cmint, cmaxt, nil})


### PR DESCRIPTION
## Summary

Today the `chunkenc.Appender` interface's `AppendHistogram` and `AppendFloatHistogram` methods take a typed previous appender (`*HistogramAppender` / `*FloatHistogramAppender`). Callers must type-assert `s.app` to that concrete type before every call, and **silently discard the cross-chunk counter-reset signal whenever the running chunk happens to be a different concrete histogram-appender type**.

This PR changes the parameter to the generic `chunkenc.Appender` interface and moves the concrete type check inside each implementation, onto the code path that actually needs the previous appender's state (the new-chunk branch in `setCounterResetHeader`). The type check goes through two new private interfaces (`histogramAppendable`, `floatHistogramAppendable`); any appender that exposes the right `appendable()` method satisfies them, and any appender that doesn't is silently ignored.

The cost of the type assertion is paid only on the new-chunk branch — i.e. once per chunk boundary, not per sample.

### Motivation

Preparation for [#18609](https://github.com/prometheus/prometheus/pull/18609), which introduces `*HistogramSTAppender` and `*FloatHistogramSTAppender`. Both embed their non-ST counterparts, so they automatically satisfy the new internal interfaces and can be handed off as `prev` without any caller-side knowledge of the ST variant.

It also removes a small foot-gun: the current `prev, _ := s.app.(*chunkenc.HistogramAppender)` discards the cross-chunk reset signal whenever `s.app` is *any* other concrete type (e.g. an xor chunk that's about to be followed by a histogram chunk, or — once #18609 lands — a `*HistogramSTAppender`).

### Diff shape

- `tsdb/chunkenc/appendable.go` (new): `histogramAppendable` / `floatHistogramAppendable` interfaces.
- `tsdb/chunkenc/chunk.go`: `Appender.AppendHistogram` / `AppendFloatHistogram` take `prev Appender`.
- `tsdb/chunkenc/{histogram,float_histogram}.go`: the new-chunk branch type-asserts to the appropriate appendable interface.
- `tsdb/chunkenc/{xor,xor2,histogram,float_histogram}.go`: panic stubs for cross-kind appends updated to the new signature.
- `tsdb/{head_append,ooo_head}.go`: drop the pre-call type assertion; pass `s.app` (or `prevApp`) through as `chunkenc.Appender`.

`storage/series.go` and `tsdb/querier.go` already pass `nil` for `prev` and are unaffected.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./tsdb/...`
- [x] `go test ./tsdb/...` — all packages green (full suite, no `-short`).
- [ ] Rebase [#18609](https://github.com/prometheus/prometheus/pull/18609) on top of this and remove the now-unneeded TODOs in `tsdb/ooo_head.go` for the ST chunk types (follow-up).

```release-notes
NONE
```

Coded with Claude Opus 4.7.