### PR TITLE
discovery/aws: add filter support for RDS role

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -801,7 +801,7 @@ var expectedConf = &Config{
 					Profile:         "profile",
 					RefreshInterval: model.Duration(60 * time.Second),
 					Port:            80,
-					Filters: []*aws.EC2Filter{
+					Filters: []*aws.Filter{
 						{
 							Name:   "tag:environment",
 							Values: []string{"prod"},

--- a/discovery/aws/aws.go
+++ b/discovery/aws/aws.go
@@ -68,6 +68,12 @@ func (c Role) String() string {
 	return string(c)
 }
 
+// Filter is the configuration for filtering AWS resources.
+type Filter struct {
+	Name   string   `yaml:"name"`
+	Values []string `yaml:"values"`
+}
+
 // SDConfig is the configuration for AWS service discovery.
 type SDConfig struct {
 	Role             Role                    `yaml:"role"`
@@ -82,8 +88,8 @@ type SDConfig struct {
 	Port             int                     `yaml:"port,omitempty"`
 	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 
-	// ec2 specific
-	Filters []*EC2Filter `yaml:"filters,omitempty"`
+	// ec2, rds specific
+	Filters []*Filter `yaml:"filters,omitempty"`
 
 	// ecs, msk specific
 	Clusters []string `yaml:"clusters,omitempty"`
@@ -312,6 +318,9 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		if c.RefreshInterval != 0 {
 			c.RDSSDConfig.RefreshInterval = c.RefreshInterval
+		}
+		if c.Filters != nil {
+			c.RDSSDConfig.Filters = c.Filters
 		}
 		if c.Clusters != nil {
 			c.RDSSDConfig.Clusters = c.Clusters

--- a/discovery/aws/aws_test.go
+++ b/discovery/aws/aws_test.go
@@ -178,6 +178,24 @@ port: 9300`,
 				require.Equal(t, 9300, cfg.LightsailSDConfig.Port)
 			},
 		},
+		{
+			name: "RDSWithFlatFields",
+			yaml: `role: rds
+region: us-east-1
+port: 9400
+filters:
+  - name: engine
+    values: [aurora-postgresql]`,
+			validateFunc: func(t *testing.T, cfg *SDConfig) {
+				require.Equal(t, RoleRDS, cfg.Role)
+				require.NotNil(t, cfg.RDSSDConfig)
+				require.Equal(t, "us-east-1", cfg.RDSSDConfig.Region)
+				require.Equal(t, 9400, cfg.RDSSDConfig.Port)
+				require.Len(t, cfg.RDSSDConfig.Filters, 1)
+				require.Equal(t, "engine", cfg.RDSSDConfig.Filters[0].Name)
+				require.Equal(t, []string{"aurora-postgresql"}, cfg.RDSSDConfig.Filters[0].Values)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -80,12 +80,6 @@ func init() {
 	discovery.RegisterConfig(&EC2SDConfig{})
 }
 
-// EC2Filter is the configuration for filtering EC2 instances.
-type EC2Filter struct {
-	Name   string   `yaml:"name"`
-	Values []string `yaml:"values"`
-}
-
 // EC2SDConfig is the configuration for EC2 based service discovery.
 type EC2SDConfig struct {
 	Endpoint        string         `yaml:"endpoint"`
@@ -97,7 +91,7 @@ type EC2SDConfig struct {
 	ExternalID      string         `yaml:"external_id,omitempty"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
 	Port            int            `yaml:"port"`
-	Filters         []*EC2Filter   `yaml:"filters"`
+	Filters         []*Filter      `yaml:"filters"`
 
 	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 }

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -107,6 +107,7 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
 		ec2Data  *ec2DataStore
+		filters  []*Filter
 		expected []*targetgroup.Group
 	}{
 		{
@@ -428,6 +429,82 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "FiltersMatchSingleInstance",
+			ec2Data: &ec2DataStore{
+				region: "region-filter-match",
+				azToAZID: map[string]string{
+					"azname-a": "azid-1",
+				},
+				instances: []ec2Types.Instance{
+					{
+						ImageId:          strptr("ami-filter-1"),
+						InstanceId:       strptr("instance-filter-1"),
+						InstanceType:     "instance-type-filter",
+						Placement:        &ec2Types.Placement{AvailabilityZone: strptr("azname-a")},
+						PrivateIpAddress: strptr("10.0.0.1"),
+						State:            &ec2Types.InstanceState{Name: "running"},
+					},
+					{
+						ImageId:          strptr("ami-filter-2"),
+						InstanceId:       strptr("instance-filter-2"),
+						InstanceType:     "instance-type-filter",
+						Placement:        &ec2Types.Placement{AvailabilityZone: strptr("azname-a")},
+						PrivateIpAddress: strptr("10.0.0.2"),
+						State:            &ec2Types.InstanceState{Name: "stopped"},
+					},
+				},
+			},
+			filters: []*Filter{{Name: "instance-state-name", Values: []string{"running"}}},
+			expected: []*targetgroup.Group{
+				{
+					Source: "region-filter-match",
+					Targets: []model.LabelSet{
+						{
+							"__address__":                     model.LabelValue("10.0.0.1:4242"),
+							"__meta_ec2_ami":                  model.LabelValue("ami-filter-1"),
+							"__meta_ec2_availability_zone":    model.LabelValue("azname-a"),
+							"__meta_ec2_availability_zone_id": model.LabelValue("azid-1"),
+							"__meta_ec2_instance_id":          model.LabelValue("instance-filter-1"),
+							"__meta_ec2_instance_state":       model.LabelValue("running"),
+							"__meta_ec2_instance_type":        model.LabelValue("instance-type-filter"),
+							"__meta_ec2_owner_id":             model.LabelValue(""),
+							"__meta_ec2_private_ip":           model.LabelValue("10.0.0.1"),
+							"__meta_ec2_region":               model.LabelValue("region-filter-match"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "FiltersMatchNoInstances",
+			ec2Data: &ec2DataStore{
+				region: "region-filter-none",
+				azToAZID: map[string]string{
+					"azname-a": "azid-1",
+				},
+				instances: []ec2Types.Instance{
+					{
+						ImageId:          strptr("ami-filter-1"),
+						InstanceId:       strptr("instance-filter-1"),
+						InstanceType:     "instance-type-filter",
+						Placement:        &ec2Types.Placement{AvailabilityZone: strptr("azname-a")},
+						PrivateIpAddress: strptr("10.0.1.1"),
+						State:            &ec2Types.InstanceState{Name: "running"},
+					},
+					{
+						ImageId:          strptr("ami-filter-2"),
+						InstanceId:       strptr("instance-filter-2"),
+						InstanceType:     "instance-type-filter",
+						Placement:        &ec2Types.Placement{AvailabilityZone: strptr("azname-a")},
+						PrivateIpAddress: strptr("10.0.1.2"),
+						State:            &ec2Types.InstanceState{Name: "stopped"},
+					},
+				},
+			},
+			filters:  []*Filter{{Name: "instance-state-name", Values: []string{"terminated"}}},
+			expected: []*targetgroup.Group{{Source: "region-filter-none"}},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			client := newMockEC2Client(tt.ec2Data)
@@ -435,8 +512,9 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 			d := &EC2Discovery{
 				ec2: client,
 				cfg: &EC2SDConfig{
-					Port:   4242,
-					Region: client.ec2Data.region,
+					Port:    4242,
+					Region:  client.ec2Data.region,
+					Filters: tt.filters,
 				},
 			}
 
@@ -480,9 +558,31 @@ func (m *mockEC2Client) DescribeAvailabilityZones(context.Context, *ec2.Describe
 	}, nil
 }
 
-func (m *mockEC2Client) DescribeInstances(_ context.Context, _ *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+func (m *mockEC2Client) DescribeInstances(_ context.Context, input *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	allowedStates := map[string]struct{}{}
+	hasStateFilter := false
+	for _, f := range input.Filters {
+		if f.Name == nil || *f.Name != "instance-state-name" {
+			continue
+		}
+		hasStateFilter = true
+		for _, v := range f.Values {
+			allowedStates[v] = struct{}{}
+		}
+	}
+
 	r := ec2Types.Reservation{}
-	r.Instances = append(r.Instances, m.ec2Data.instances...)
+	for _, inst := range m.ec2Data.instances {
+		if hasStateFilter {
+			if inst.State == nil {
+				continue
+			}
+			if _, ok := allowedStates[string(inst.State.Name)]; !ok {
+				continue
+			}
+		}
+		r.Instances = append(r.Instances, inst)
+	}
 	r.OwnerId = aws.String(m.ec2Data.ownerID)
 
 	o := ec2.DescribeInstancesOutput{}

--- a/discovery/aws/rds.go
+++ b/discovery/aws/rds.go
@@ -229,6 +229,7 @@ type RDSSDConfig struct {
 	Clusters        []string       `yaml:"clusters,omitempty"`
 	Port            int            `yaml:"port"`
 	RefreshInterval model.Duration `yaml:"refresh_interval,omitempty"`
+	Filters         []*Filter      `yaml:"filters"`
 
 	RequestConcurrency int                     `yaml:"request_concurrency,omitempty"`
 	HTTPClientConfig   config.HTTPClientConfig `yaml:",inline"`
@@ -467,19 +468,26 @@ func (d *RDSDiscovery) describeDBClusters(ctx context.Context, dbClusterARNS []s
 }
 
 func (d *RDSDiscovery) describeDBInstances(ctx context.Context, dbClusterARN string) ([]types.DBInstance, error) {
-	mu := &sync.Mutex{}
-	errg, ectx := errgroup.WithContext(ctx)
-	errg.SetLimit(d.cfg.RequestConcurrency)
 	dbInstances := []types.DBInstance{}
 	var nextToken *string
+
+	filters := []types.Filter{
+		{
+			Name:   aws.String("db-cluster-id"),
+			Values: []string{dbClusterARN},
+		},
+	}
+
+	for _, f := range d.cfg.Filters {
+		filters = append(filters, types.Filter{
+			Name:   aws.String(f.Name),
+			Values: f.Values,
+		})
+	}
+
 	for {
-		output, err := d.rds.DescribeDBInstances(ectx, &rds.DescribeDBInstancesInput{
-			Filters: []types.Filter{
-				{
-					Name:   aws.String("db-cluster-id"),
-					Values: []string{dbClusterARN},
-				},
-			},
+		output, err := d.rds.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{
+			Filters:    filters,
 			Marker:     nextToken,
 			MaxRecords: aws.Int32(100),
 		})
@@ -487,17 +495,14 @@ func (d *RDSDiscovery) describeDBInstances(ctx context.Context, dbClusterARN str
 			return nil, fmt.Errorf("failed to describe DB instances for cluster ARN %s: %w", dbClusterARN, err)
 		}
 
-		for _, dbInstance := range output.DBInstances {
-			mu.Lock()
-			dbInstances = append(dbInstances, dbInstance)
-			mu.Unlock()
-		}
+		dbInstances = append(dbInstances, output.DBInstances...)
+
 		if output.Marker == nil {
 			break
 		}
 		nextToken = output.Marker
 	}
-	return dbInstances, errg.Wait()
+	return dbInstances, nil
 }
 
 func (d *RDSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {

--- a/discovery/aws/rds_test.go
+++ b/discovery/aws/rds_test.go
@@ -16,6 +16,7 @@ package aws
 import (
 	"context"
 	"net"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -76,6 +77,23 @@ func (m *mockRDSClient) DescribeDBInstances(_ context.Context, input *rds.Descri
 		}
 	}
 
+	for _, filter := range input.Filters {
+		if filter.Name == nil || *filter.Name != "engine" {
+			continue
+		}
+
+		var filtered []types.DBInstance
+		for _, inst := range instances {
+			if inst.Engine == nil {
+				continue
+			}
+			if slices.Contains(filter.Values, *inst.Engine) {
+				filtered = append(filtered, inst)
+			}
+		}
+		instances = filtered
+	}
+
 	return &rds.DescribeDBInstancesOutput{
 		DBInstances: instances,
 	}, nil
@@ -89,6 +107,7 @@ func TestRDSDiscoveryRefresh(t *testing.T) {
 		name           string
 		clusters       map[string]types.DBCluster
 		instances      map[string][]types.DBInstance
+		filters        []*Filter
 		expectedLabels []model.LabelSet
 	}{
 		{
@@ -265,6 +284,78 @@ func TestRDSDiscoveryRefresh(t *testing.T) {
 			instances:      map[string][]types.DBInstance{},
 			expectedLabels: []model.LabelSet{},
 		},
+		{
+			name: "FiltersMatchSingleInstance",
+			clusters: map[string]types.DBCluster{
+				"arn:aws:rds:us-east-1:123456789012:cluster:filter-cluster": {
+					DBClusterArn:        aws.String("arn:aws:rds:us-east-1:123456789012:cluster:filter-cluster"),
+					DBClusterIdentifier: aws.String("filter-cluster"),
+					Engine:              aws.String("aurora-postgresql"),
+					Status:              aws.String("available"),
+					DBClusterMembers: []types.DBClusterMember{
+						{DBInstanceIdentifier: aws.String("filter-instance-1"), IsClusterWriter: aws.Bool(true)},
+						{DBInstanceIdentifier: aws.String("filter-instance-2"), IsClusterWriter: aws.Bool(false)},
+					},
+				},
+			},
+			instances: map[string][]types.DBInstance{
+				"arn:aws:rds:us-east-1:123456789012:cluster:filter-cluster": {
+					{
+						DBInstanceArn:        aws.String("arn:aws:rds:us-east-1:123456789012:db:filter-instance-1"),
+						DBInstanceIdentifier: aws.String("filter-instance-1"),
+						DBInstanceClass:      aws.String("db.r6g.large"),
+						DBInstanceStatus:     aws.String("available"),
+						Engine:               aws.String("aurora-postgresql"),
+						Endpoint:             &types.Endpoint{Address: aws.String("filter-instance-1.rds.amazonaws.com"), Port: aws.Int32(5432)},
+					},
+					{
+						DBInstanceArn:        aws.String("arn:aws:rds:us-east-1:123456789012:db:filter-instance-2"),
+						DBInstanceIdentifier: aws.String("filter-instance-2"),
+						DBInstanceClass:      aws.String("db.r6g.large"),
+						DBInstanceStatus:     aws.String("available"),
+						Engine:               aws.String("mysql"),
+						Endpoint:             &types.Endpoint{Address: aws.String("filter-instance-2.rds.amazonaws.com"), Port: aws.Int32(3306)},
+					},
+				},
+			},
+			filters: []*Filter{{Name: "engine", Values: []string{"aurora-postgresql"}}},
+			expectedLabels: []model.LabelSet{
+				{
+					model.AddressLabel:                   model.LabelValue("filter-instance-1.rds.amazonaws.com:5432"),
+					rdsLabelClusterDBClusterArn:          model.LabelValue("arn:aws:rds:us-east-1:123456789012:cluster:filter-cluster"),
+					rdsLabelClusterDBClusterIdentifier:   model.LabelValue("filter-cluster"),
+					rdsLabelClusterEngine:                model.LabelValue("aurora-postgresql"),
+					rdsLabelClusterStatus:                model.LabelValue("available"),
+					rdsLabelInstanceDBInstanceArn:        model.LabelValue("arn:aws:rds:us-east-1:123456789012:db:filter-instance-1"),
+					rdsLabelInstanceDBInstanceIdentifier: model.LabelValue("filter-instance-1"),
+					rdsLabelInstanceIsClusterWriter:      model.LabelValue("true"),
+					rdsLabelInstanceDBInstanceClass:      model.LabelValue("db.r6g.large"),
+					rdsLabelInstanceDBInstanceStatus:     model.LabelValue("available"),
+					rdsLabelInstanceEngine:               model.LabelValue("aurora-postgresql"),
+					rdsLabelInstanceEndpointAddress:      model.LabelValue("filter-instance-1.rds.amazonaws.com"),
+					rdsLabelInstanceEndpointPort:         model.LabelValue("5432"),
+				},
+			},
+		},
+		{
+			name: "FiltersMatchNoInstances",
+			clusters: map[string]types.DBCluster{
+				"arn:aws:rds:us-east-1:123456789012:cluster:filter-cluster": {
+					DBClusterArn:        aws.String("arn:aws:rds:us-east-1:123456789012:cluster:filter-cluster"),
+					DBClusterIdentifier: aws.String("filter-cluster"),
+					Engine:              aws.String("aurora-postgresql"),
+					Status:              aws.String("available"),
+				},
+			},
+			instances: map[string][]types.DBInstance{
+				"arn:aws:rds:us-east-1:123456789012:cluster:filter-cluster": {
+					{DBInstanceIdentifier: aws.String("filter-instance-1"), Engine: aws.String("aurora-postgresql")},
+					{DBInstanceIdentifier: aws.String("filter-instance-2"), Engine: aws.String("mysql")},
+				},
+			},
+			filters:        []*Filter{{Name: "engine", Values: []string{"sqlserver-ee"}}},
+			expectedLabels: []model.LabelSet{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -279,6 +370,7 @@ func TestRDSDiscoveryRefresh(t *testing.T) {
 				cfg: &RDSSDConfig{
 					Region:             "us-east-1",
 					RequestConcurrency: 10,
+					Filters:            tt.filters,
 				},
 			}
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1341,10 +1341,14 @@ role: <string>
 # instead be specified in the relabeling rule.
 [ port: <int> | default = 80 ]
 
-# Filters can be used optionally to filter the instance list by other criteria (ec2 role only).
+# Filters can be used optionally to filter the instance list by other criteria (ec2 & rds role only).
 # Available filter criteria can be found here:
-# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
-# Filter API documentation: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html
+# EC2:
+#  - https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
+#  - Filter API documentation: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Filter.html
+# RDS:
+#  - https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html
+#  - Filter API documentation: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Filter.html
 filters:
   [ - name: <string>
       values: <string>, [...] ]


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
On the back of https://github.com/prometheus/prometheus/pull/18845 it was discussed to make the filter component in the config generic so we can use it on other roles aside from just ec2 if the relevant API supports it. Currently the ec2 and rds apis support filtering so this change updates the rds role so that it uses the filter, and updates the ec2/rds tests to add some basic filter tests.

This will allow users to filter the RDS instances to only certain engines for specific exporters. Previously you would have to get all the instances and then drop then in relabelling.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[FEATURE] Discovery/AWS: Add ability to filter RDS instances #18859
```
