### PR TITLE
api: expose scrape timeout usage in target API

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -1079,6 +1079,7 @@ type Target struct {
 	LastScrape         time.Time           `json:"lastScrape"`
 	LastScrapeDuration float64             `json:"lastScrapeDuration"`
 	Health             scrape.TargetHealth `json:"health"`
+	ScrapeTimeoutUsage float64             `json:"scrapeTimeoutUsage"`
 
 	ScrapeInterval string `json:"scrapeInterval"`
 	ScrapeTimeout  string `json:"scrapeTimeout"`
@@ -1169,6 +1170,14 @@ func getGlobalURL(u *url.URL, opts GlobalURLOptions) (*url.URL, error) {
 	return u, nil
 }
 
+func scrapeTimeoutUsage(lastScrapeDuration time.Duration, scrapeTimeout string) float64 {
+	timeout, err := parseDuration(scrapeTimeout)
+	if err != nil || timeout <= 0 {
+		return 0
+	}
+	return lastScrapeDuration.Seconds() / timeout.Seconds()
+}
+
 func (api *API) scrapePools(r *http.Request) apiFuncResult {
 	names := api.scrapePoolsRetriever(r.Context()).ScrapePools()
 	sort.Strings(names)
@@ -1213,6 +1222,7 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 
 				globalURL, err := getGlobalURL(target.URL(), api.globalURLOptions)
 
+				scrapeTimeout := target.GetValue(model.ScrapeTimeoutLabel)
 				res.ActiveTargets = append(res.ActiveTargets, &Target{
 					DiscoveredLabels: target.DiscoveredLabels(builder),
 					Labels:           target.Labels(builder),
@@ -1233,7 +1243,8 @@ func (api *API) targets(r *http.Request) apiFuncResult {
 					LastScrapeDuration: target.LastScrapeDuration().Seconds(),
 					Health:             target.Health(),
 					ScrapeInterval:     target.GetValue(model.ScrapeIntervalLabel),
-					ScrapeTimeout:      target.GetValue(model.ScrapeTimeoutLabel),
+					ScrapeTimeout:      scrapeTimeout,
+					ScrapeTimeoutUsage: scrapeTimeoutUsage(target.LastScrapeDuration(), scrapeTimeout),
 				})
 			}
 		}

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -1785,6 +1785,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 						LastScrapeDuration: 0.1,
 						ScrapeInterval:     "20s",
 						ScrapeTimeout:      "10s",
+						ScrapeTimeoutUsage: 0.01,
 					},
 					{
 						DiscoveredLabels:   labels.FromStrings("__convert_classic_histograms_to_nhcb__", "false", "__scrape_interval__", "0s", "__scrape_timeout__", "0s"),
@@ -1798,6 +1799,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 						LastScrapeDuration: 0.07,
 						ScrapeInterval:     "15s",
 						ScrapeTimeout:      "5s",
+						ScrapeTimeoutUsage: 0.014000000000000002,
 					},
 				},
 				DroppedTargets: []*DroppedTarget{
@@ -1836,6 +1838,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 						LastScrapeDuration: 0.1,
 						ScrapeInterval:     "20s",
 						ScrapeTimeout:      "10s",
+						ScrapeTimeoutUsage: 0.01,
 					},
 					{
 						DiscoveredLabels:   labels.FromStrings("__convert_classic_histograms_to_nhcb__", "false", "__scrape_interval__", "0s", "__scrape_timeout__", "0s"),
@@ -1849,6 +1852,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 						LastScrapeDuration: 0.07,
 						ScrapeInterval:     "15s",
 						ScrapeTimeout:      "5s",
+						ScrapeTimeoutUsage: 0.014000000000000002,
 					},
 				},
 				DroppedTargets: []*DroppedTarget{
@@ -1887,6 +1891,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 						LastScrapeDuration: 0.1,
 						ScrapeInterval:     "20s",
 						ScrapeTimeout:      "10s",
+						ScrapeTimeoutUsage: 0.01,
 					},
 					{
 						DiscoveredLabels:   labels.FromStrings("__convert_classic_histograms_to_nhcb__", "false", "__scrape_interval__", "0s", "__scrape_timeout__", "0s"),
@@ -1900,6 +1905,7 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, testLabelAPI
 						LastScrapeDuration: 0.07,
 						ScrapeInterval:     "15s",
 						ScrapeTimeout:      "5s",
+						ScrapeTimeoutUsage: 0.014000000000000002,
 					},
 				},
 				DroppedTargets: []*DroppedTarget{},
@@ -4480,6 +4486,46 @@ func TestParseDuration(t *testing.T) {
 			continue
 		}
 		require.Error(t, err, "Expected error for %q but got none", test.input)
+	}
+}
+
+func TestScrapeTimeoutUsage(t *testing.T) {
+	tests := []struct {
+		name               string
+		lastScrapeDuration time.Duration
+		scrapeTimeout      string
+		expected           float64
+	}{
+		{
+			name:               "normal usage",
+			lastScrapeDuration: 100 * time.Millisecond,
+			scrapeTimeout:      "10s",
+			expected:           0.01,
+		},
+		{
+			name:               "different timeout",
+			lastScrapeDuration: 70 * time.Millisecond,
+			scrapeTimeout:      "5s",
+			expected:           0.014,
+		},
+		{
+			name:               "invalid timeout",
+			lastScrapeDuration: 100 * time.Millisecond,
+			scrapeTimeout:      "invalid",
+			expected:           0,
+		},
+		{
+			name:               "zero timeout",
+			lastScrapeDuration: 100 * time.Millisecond,
+			scrapeTimeout:      "0s",
+			expected:           0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.InDelta(t, tt.expected, scrapeTimeoutUsage(tt.lastScrapeDuration, tt.scrapeTimeout), 1e-9)
+		})
 	}
 }
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[ENHANCEMENT] API: Add scrape timeout usage to target discovery response.
```

#### Summary

This PR adds a `scrapeTimeoutUsage` field to the `/api/v1/targets` active target response.

The value is calculated as:

`lastScrapeDuration / scrapeTimeout`

This provides a direct indication of how much of the configured scrape timeout window was used by the most recent scrape. It can help users and external tools identify slow scrape targets that are close to timing out, even if they are still currently healthy.

#### Testing

- `go test ./web/api/v1 -run TestScrapeTimeoutUsage`
- `go test ./web/api/v1 -run TestEndpoints`
- `go test ./web/api/v1 -run TestOpenAPIGolden`