### PR TITLE
promql: Add range query tests for experimental max_of/min_of

### DIFF
--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -2239,3 +2239,17 @@ eval instant at 0s max_of(NaN, 3)
 
 eval instant at 0s max_of(3, NaN)
   NaN
+
+# Range queries with literals
+eval range from 0 to 4m step 1m max_of(4, 4)
+  {} 4 4 4 4 4
+
+eval range from 0 to 4m step 1m min_of(0, 1)
+  {} 0 0 0 0 0
+
+# Range queries with scalar functions
+eval range from 0 to 4m step 1m max_of(time(), 90)
+  {} 90 90 120 180 240
+
+eval range from 0 to 4m step 1m min_of(90, time())
+  {} 0 60 90 90 90


### PR DESCRIPTION
This change adds range query tests for the experimental `max_of`/`min_of` functions introduced in https://github.com/prometheus/prometheus/pull/18687

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:

Follow up to https://github.com/prometheus/prometheus/pull/18687

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
