### PR TITLE
ui: add configuration assistant prototype

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1048,6 +1048,7 @@ func main() {
 	}
 
 	cfg.web.Flags = map[string]string{}
+	cfg.web.ConfigFile = cfg.configFile
 
 	// Exclude kingpin default flags to expose only Prometheus ones.
 	boilerplateFlags := kingpin.New("", "").Version("")

--- a/web/ui/mantine-ui/src/App.tsx
+++ b/web/ui/mantine-ui/src/App.tsx
@@ -36,6 +36,7 @@ import {
   IconSearch,
   IconServer,
   IconServerCog,
+  IconSettingsAutomation,
 } from "@tabler/icons-react";
 import {
   BrowserRouter,
@@ -55,6 +56,7 @@ import StatusPage from "./pages/StatusPage";
 import TSDBStatusPage from "./pages/TSDBStatusPage";
 import FlagsPage from "./pages/FlagsPage";
 import ConfigPage from "./pages/ConfigPage";
+import ConfigurationAssistantPage from "./pages/ConfigurationAssistantPage";
 import AgentPage from "./pages/AgentPage";
 import { Suspense } from "react";
 import ErrorBoundary from "./components/ErrorBoundary";
@@ -153,6 +155,13 @@ const serverStatusPages = [
     path: "/config",
     icon: <IconServerCog style={navIconStyle} />,
     element: <ConfigPage />,
+    inAgentMode: true,
+  },
+  {
+    title: "Configuration assistant",
+    path: "/configuration-assistant",
+    icon: <IconSettingsAutomation style={navIconStyle} />,
+    element: <ConfigurationAssistantPage />,
     inAgentMode: true,
   },
   {

--- a/web/ui/mantine-ui/src/pages/ConfigurationAssistantPage.tsx
+++ b/web/ui/mantine-ui/src/pages/ConfigurationAssistantPage.tsx
@@ -1,0 +1,343 @@
+import { useMemo, useState } from "react";
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Group,
+  List,
+  Stack,
+  Table,
+  Text,
+  Textarea,
+  Title,
+} from "@mantine/core";
+import { IconAlertTriangle, IconCheck } from "@tabler/icons-react";
+import { useSettings } from "../state/settingsSlice";
+
+type ScrapeJobPreview = {
+  jobName: string;
+  scrapeInterval: string;
+  metricsPath: string;
+  targets: string[];
+};
+
+type LocalAnalysisResult = {
+  errors: string[];
+  warnings: string[];
+  suggestions: string[];
+  jobs: ScrapeJobPreview[];
+};
+
+type ApplyResponse = {
+  status: string;
+  message: string;
+  backupFile?: string;
+  suggestions?: string[];
+};
+
+const sampleConfig = `global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]`;
+
+function extractValue(line: string): string {
+  return line.split(":").slice(1).join(":").trim().replace(/^["']|["']$/g, "");
+}
+
+function extractTargets(line: string): string[] {
+  const match = line.match(/\[(.*)\]/);
+  if (!match) {
+    return [];
+  }
+
+  return match[1]
+    .split(",")
+    .map((target) => target.trim().replace(/^["']|["']$/g, ""))
+    .filter(Boolean);
+}
+
+function analyzePrometheusConfig(configText: string): LocalAnalysisResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const suggestions: string[] = [];
+  const jobs: ScrapeJobPreview[] = [];
+
+  const trimmedConfig = configText.trim();
+
+  if (!trimmedConfig) {
+    errors.push("Configuration is empty.");
+    suggestions.push("Paste a prometheus.yml configuration before applying changes.");
+    return { errors, warnings, suggestions, jobs };
+  }
+
+  if (!trimmedConfig.includes("scrape_configs:")) {
+    errors.push("Missing required scrape_configs section.");
+    suggestions.push("Add a scrape_configs section to define scrape jobs.");
+  }
+
+  const lines = trimmedConfig.split("\n");
+  let currentJob: ScrapeJobPreview | null = null;
+  let globalScrapeInterval = "default";
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+
+    if (trimmedLine.startsWith("scrape_interval:") && !currentJob) {
+      globalScrapeInterval = extractValue(trimmedLine);
+    }
+
+    if (trimmedLine.startsWith("- job_name:")) {
+      if (currentJob) {
+        jobs.push(currentJob);
+      }
+
+      currentJob = {
+        jobName: extractValue(trimmedLine),
+        scrapeInterval: globalScrapeInterval,
+        metricsPath: "/metrics",
+        targets: [],
+      };
+    }
+
+    if (currentJob && trimmedLine.startsWith("scrape_interval:")) {
+      currentJob.scrapeInterval = extractValue(trimmedLine);
+    }
+
+    if (currentJob && trimmedLine.startsWith("metrics_path:")) {
+      currentJob.metricsPath = extractValue(trimmedLine);
+    }
+
+    if (currentJob && trimmedLine.startsWith("- targets:")) {
+      currentJob.targets = extractTargets(trimmedLine);
+    }
+  }
+
+  if (currentJob) {
+    jobs.push(currentJob);
+  }
+
+  if (trimmedConfig.includes("scrape_configs:") && jobs.length === 0) {
+    warnings.push("scrape_configs exists, but no job_name was detected.");
+    suggestions.push("Add at least one scrape job with job_name.");
+  }
+
+  for (const job of jobs) {
+    if (job.targets.length === 0) {
+      warnings.push(`Job "${job.jobName || "unknown"}" does not define targets.`);
+      suggestions.push("Add static_configs with targets for each scrape job.");
+    }
+  }
+
+  if (errors.length === 0 && warnings.length === 0) {
+    suggestions.push("Local preview did not detect common configuration issues.");
+  }
+
+  return { errors, warnings, suggestions, jobs };
+}
+
+export default function ConfigurationAssistantPage() {
+  const { pathPrefix } = useSettings();
+
+  const [configText, setConfigText] = useState(sampleConfig);
+  const [hasValidated, setHasValidated] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
+  const [applyResponse, setApplyResponse] = useState<ApplyResponse | null>(null);
+
+  const localResult = useMemo(
+    () => analyzePrometheusConfig(configText),
+    [configText]
+  );
+
+  const hasLocalIssues =
+    localResult.errors.length > 0 || localResult.warnings.length > 0;
+
+  async function applyAndReload() {
+    setIsApplying(true);
+    setApplyResponse(null);
+
+    try {
+      const response = await fetch(`${pathPrefix}/-/config-assistant/apply`, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ yaml: configText }),
+      });
+
+      const contentType = response.headers.get("content-type");
+      const data = contentType?.includes("application/json")
+        ? ((await response.json()) as ApplyResponse)
+        : ({
+            status: response.ok ? "success" : "error",
+            message: await response.text(),
+          } satisfies ApplyResponse);
+
+      setApplyResponse(data);
+    } catch (error) {
+      setApplyResponse({
+        status: "error",
+        message: `Failed to apply configuration: ${String(error)}`,
+      });
+    } finally {
+      setIsApplying(false);
+    }
+  }
+
+  return (
+    <Stack maw={1000} mx="auto" gap="md">
+      <div>
+        <Title order={2}>Configuration Assistant</Title>
+        <Text c="dimmed">
+          Validate, preview, and apply Prometheus configuration changes.
+        </Text>
+      </div>
+
+      <Alert color="yellow" icon={<IconAlertTriangle />} title="Local prototype">
+        This assistant writes to the Prometheus configuration file used by the
+        running server and then triggers a reload. It requires the lifecycle API
+        to be enabled.
+      </Alert>
+
+      <Textarea
+        label="Prometheus configuration"
+        description="Edit prometheus.yml content here."
+        autosize
+        minRows={14}
+        value={configText}
+        onChange={(event) => {
+          setConfigText(event.currentTarget.value);
+          setHasValidated(false);
+          setApplyResponse(null);
+        }}
+      />
+
+      <Group>
+        <Button variant="default" onClick={() => setHasValidated(true)}>
+          Validate locally
+        </Button>
+        <Button
+          onClick={applyAndReload}
+          loading={isApplying}
+          disabled={hasLocalIssues}
+        >
+          Apply and reload
+        </Button>
+      </Group>
+
+      {hasValidated && (
+        <Card withBorder>
+          <Title order={3}>Local validation</Title>
+
+          {hasLocalIssues ? (
+            <Stack mt="sm">
+              {localResult.errors.length > 0 && (
+                <div>
+                  <Badge color="red">Errors</Badge>
+                  <List mt="xs">
+                    {localResult.errors.map((error) => (
+                      <List.Item key={error}>{error}</List.Item>
+                    ))}
+                  </List>
+                </div>
+              )}
+
+              {localResult.warnings.length > 0 && (
+                <div>
+                  <Badge color="yellow">Warnings</Badge>
+                  <List mt="xs">
+                    {localResult.warnings.map((warning) => (
+                      <List.Item key={warning}>{warning}</List.Item>
+                    ))}
+                  </List>
+                </div>
+              )}
+            </Stack>
+          ) : (
+            <Text mt="sm">No common local issues detected.</Text>
+          )}
+        </Card>
+      )}
+
+      <Card withBorder>
+        <Title order={3}>Configuration preview</Title>
+
+        {localResult.jobs.length === 0 ? (
+          <Text mt="sm" c="dimmed">
+            No scrape jobs could be previewed.
+          </Text>
+        ) : (
+          <Table mt="sm" striped withTableBorder>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Job name</Table.Th>
+                <Table.Th>Targets</Table.Th>
+                <Table.Th>Scrape interval</Table.Th>
+                <Table.Th>Metrics path</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {localResult.jobs.map((job) => (
+                <Table.Tr key={job.jobName}>
+                  <Table.Td>{job.jobName}</Table.Td>
+                  <Table.Td>
+                    {job.targets.length > 0
+                      ? job.targets.join(", ")
+                      : "No targets detected"}
+                  </Table.Td>
+                  <Table.Td>{job.scrapeInterval}</Table.Td>
+                  <Table.Td>{job.metricsPath}</Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        )}
+      </Card>
+
+      <Card withBorder>
+        <Title order={3}>Suggestions</Title>
+        <List mt="sm">
+          {localResult.suggestions.map((suggestion) => (
+            <List.Item key={suggestion}>{suggestion}</List.Item>
+          ))}
+        </List>
+      </Card>
+
+      {applyResponse && (
+        <Alert
+          color={applyResponse.status === "success" ? "green" : "red"}
+          icon={
+            applyResponse.status === "success" ? (
+              <IconCheck />
+            ) : (
+              <IconAlertTriangle />
+            )
+          }
+          title={
+            applyResponse.status === "success"
+              ? "Configuration applied"
+              : "Apply failed"
+          }
+        >
+          <Stack gap="xs">
+            <Text>{applyResponse.message}</Text>
+            {applyResponse.backupFile && (
+              <Text size="sm">Backup file: {applyResponse.backupFile}</Text>
+            )}
+            {applyResponse.suggestions && applyResponse.suggestions.length > 0 && (
+              <List>
+                {applyResponse.suggestions.map((suggestion) => (
+                  <List.Item key={suggestion}>{suggestion}</List.Item>
+                ))}
+              </List>
+            )}
+          </Stack>
+        </Alert>
+      )}
+    </Stack>
+  );
+}

--- a/web/ui/mantine-ui/src/state/settingsSlice.ts
+++ b/web/ui/mantine-ui/src/state/settingsSlice.ts
@@ -57,6 +57,7 @@ const getPathPrefix = (path: string) => {
     "/tsdb-status",
     "/flags",
     "/config",
+    "/configuration-assistant",
     "/alertmanager-discovery",
     "/agent",
   ];

--- a/web/web.go
+++ b/web/web.go
@@ -284,6 +284,7 @@ type Options struct {
 	NotificationsGetter   func() []notifications.Notification
 	NotificationsSub      func() (<-chan notifications.Notification, func(), bool)
 	Flags                 map[string]string
+	ConfigFile            string
 
 	ListenAddresses            []string
 	CORSOrigin                 *regexp.Regexp
@@ -583,6 +584,7 @@ func New(logger *slog.Logger, o *Options) *Handler {
 		router.Put("/-/quit", h.quit)
 		router.Post("/-/reload", h.reload)
 		router.Put("/-/reload", h.reload)
+		router.Post("/-/config-assistant/apply", h.configAssistantApply)
 	} else {
 		forbiddenAPINotEnabled := func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusForbidden)
@@ -592,6 +594,7 @@ func New(logger *slog.Logger, o *Options) *Handler {
 		router.Put("/-/quit", forbiddenAPINotEnabled)
 		router.Post("/-/reload", forbiddenAPINotEnabled)
 		router.Put("/-/reload", forbiddenAPINotEnabled)
+		router.Post("/-/config-assistant/apply", forbiddenAPINotEnabled)
 	}
 	router.Get("/-/quit", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -964,6 +967,123 @@ func (h *Handler) reload(w http.ResponseWriter, _ *http.Request) {
 	h.reloadCh <- rc
 	if err := <-rc; err != nil {
 		http.Error(w, fmt.Sprintf("failed to reload config: %s", err), http.StatusInternalServerError)
+	}
+}
+
+type configAssistantRequest struct {
+	YAML string `json:"yaml"`
+}
+
+type configAssistantResponse struct {
+	Status      string   `json:"status"`
+	Message     string   `json:"message"`
+	BackupFile  string   `json:"backupFile,omitempty"`
+	Suggestions []string `json:"suggestions,omitempty"`
+}
+
+func (h *Handler) configAssistantApply(w http.ResponseWriter, r *http.Request) {
+	var req configAssistantRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid request body: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	if strings.TrimSpace(req.YAML) == "" {
+		writeConfigAssistantJSON(w, http.StatusBadRequest, configAssistantResponse{
+			Status:  "error",
+			Message: "Configuration is empty.",
+			Suggestions: []string{
+				"Paste a prometheus.yml configuration before applying changes.",
+			},
+		})
+		return
+	}
+
+	if h.options.ConfigFile == "" {
+		writeConfigAssistantJSON(w, http.StatusInternalServerError, configAssistantResponse{
+			Status:  "error",
+			Message: "Prometheus config file path is not available.",
+		})
+		return
+	}
+
+	if _, err := config.Load(req.YAML, h.logger); err != nil {
+		writeConfigAssistantJSON(w, http.StatusBadRequest, configAssistantResponse{
+			Status:  "error",
+			Message: fmt.Sprintf("Configuration validation failed: %s", err),
+			Suggestions: []string{
+				"Check YAML syntax, indentation, and Prometheus configuration field names.",
+			},
+		})
+		return
+	}
+
+	backupFile := h.options.ConfigFile + ".bak"
+
+	previousConfig, err := os.ReadFile(h.options.ConfigFile)
+	if err != nil {
+		writeConfigAssistantJSON(w, http.StatusInternalServerError, configAssistantResponse{
+			Status:  "error",
+			Message: fmt.Sprintf("Failed to read current configuration file: %s", err),
+		})
+		return
+	}
+
+	if err := os.WriteFile(backupFile, previousConfig, 0o644); err != nil {
+		writeConfigAssistantJSON(w, http.StatusInternalServerError, configAssistantResponse{
+			Status:  "error",
+			Message: fmt.Sprintf("Failed to create configuration backup: %s", err),
+		})
+		return
+	}
+
+	tempFile := h.options.ConfigFile + ".tmp"
+	if err := os.WriteFile(tempFile, []byte(req.YAML), 0o644); err != nil {
+		writeConfigAssistantJSON(w, http.StatusInternalServerError, configAssistantResponse{
+			Status:  "error",
+			Message: fmt.Sprintf("Failed to write temporary configuration file: %s", err),
+		})
+		return
+	}
+
+	if err := os.Rename(tempFile, h.options.ConfigFile); err != nil {
+		writeConfigAssistantJSON(w, http.StatusInternalServerError, configAssistantResponse{
+			Status:  "error",
+			Message: fmt.Sprintf("Failed to replace configuration file: %s", err),
+		})
+		return
+	}
+
+	rc := make(chan error)
+	h.reloadCh <- rc
+	if err := <-rc; err != nil {
+		_ = os.WriteFile(h.options.ConfigFile, previousConfig, 0o644)
+
+		writeConfigAssistantJSON(w, http.StatusInternalServerError, configAssistantResponse{
+			Status:     "error",
+			Message:    fmt.Sprintf("Configuration was written but reload failed. Previous configuration was restored: %s", err),
+			BackupFile: backupFile,
+			Suggestions: []string{
+				"Review the error message and try applying the configuration again.",
+			},
+		})
+		return
+	}
+
+	writeConfigAssistantJSON(w, http.StatusOK, configAssistantResponse{
+		Status:     "success",
+		Message:    "Configuration applied and reloaded successfully.",
+		BackupFile: backupFile,
+	})
+}
+
+func writeConfigAssistantJSON(w http.ResponseWriter, statusCode int, resp configAssistantResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, fmt.Sprintf("failed to encode response: %s", err), http.StatusInternalServerError)
 	}
 }
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -741,4 +742,111 @@ func waitForServerReady(t *testing.T, baseURL string, timeout time.Duration) {
 		time.Sleep(interval)
 	}
 	t.Fatalf("Server did not become ready within %v", timeout)
+}
+
+func TestConfigAssistantApplySuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "prometheus.yml")
+
+	originalConfig := `global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+`
+
+	err := os.WriteFile(configFile, []byte(originalConfig), 0o644)
+	require.NoError(t, err)
+
+	h := &Handler{
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		options:  &Options{ConfigFile: configFile},
+		reloadCh: make(chan chan error),
+	}
+
+	go func() {
+		rc := <-h.reloadCh
+		rc <- nil
+	}()
+
+	newConfig := `global:
+  scrape_interval: 30s
+
+scrape_configs:
+  - job_name: "prometheus-updated"
+    static_configs:
+      - targets: ["localhost:9090"]
+`
+
+	reqBody := strings.NewReader(fmt.Sprintf(`{"yaml": %q}`, newConfig))
+	req := httptest.NewRequest(http.MethodPost, "/-/config-assistant/apply", reqBody)
+	resp := httptest.NewRecorder()
+
+	h.configAssistantApply(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var applyResp configAssistantResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &applyResp))
+	require.Equal(t, "success", applyResp.Status)
+	require.Equal(t, configFile+".bak", applyResp.BackupFile)
+
+	writtenConfig, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+	require.Equal(t, newConfig, string(writtenConfig))
+
+	backupConfig, err := os.ReadFile(configFile + ".bak")
+	require.NoError(t, err)
+	require.Equal(t, originalConfig, string(backupConfig))
+}
+
+func TestConfigAssistantApplyRejectsInvalidConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "prometheus.yml")
+
+	originalConfig := `global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+`
+
+	err := os.WriteFile(configFile, []byte(originalConfig), 0o644)
+	require.NoError(t, err)
+
+	h := &Handler{
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		options:  &Options{ConfigFile: configFile},
+		reloadCh: make(chan chan error),
+	}
+
+	badConfig := `global:
+  scrape_interval: bad-duration
+
+scrape_configs:
+  - job_name: "broken"
+    static_configs:
+      - targets: ["localhost:9090"]
+`
+
+	reqBody := strings.NewReader(fmt.Sprintf(`{"yaml": %q}`, badConfig))
+	req := httptest.NewRequest(http.MethodPost, "/-/config-assistant/apply", reqBody)
+	resp := httptest.NewRecorder()
+
+	h.configAssistantApply(resp, req)
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+
+	var applyResp configAssistantResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &applyResp))
+	require.Equal(t, "error", applyResp.Status)
+	require.Contains(t, applyResp.Message, "Configuration validation failed")
+
+	writtenConfig, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+	require.Equal(t, originalConfig, string(writtenConfig))
 }

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -761,7 +761,7 @@ scrape_configs:
 	require.NoError(t, err)
 
 	h := &Handler{
-		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		logger:   slog.New(slog.DiscardHandler),
 		options:  &Options{ConfigFile: configFile},
 		reloadCh: make(chan chan error),
 	}
@@ -819,7 +819,7 @@ scrape_configs:
 	require.NoError(t, err)
 
 	h := &Handler{
-		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		logger:   slog.New(slog.DiscardHandler),
 		options:  &Options{ConfigFile: configFile},
 		reloadCh: make(chan chan error),
 	}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None. This is a prototype PR for discussion.

#### What does this PR do?

This PR adds a prototype Configuration Assistant to the Prometheus UI.

The assistant provides a small YAML editing workflow that allows users to:

* edit a Prometheus configuration snippet
* run lightweight local validation
* preview scrape jobs, targets, scrape intervals, and metrics paths
* apply the configuration through a lifecycle-gated backend endpoint
* trigger a configuration reload after applying the change
* create a backup of the previous configuration before overwriting it
* restore the previous configuration if reload fails

The backend endpoint validates the submitted YAML using Prometheus's existing configuration loader before writing it to the configured `--config.file`.

#### Motivation

Editing `prometheus.yml` manually can be difficult for newer users because YAML syntax, indentation, and Prometheus-specific configuration structure must all be correct before reload. This prototype explores whether the Prometheus UI can provide a safer configuration workflow with validation, preview, and reload feedback.

This does not aim to replace the existing YAML workflow. It is intended as a small UI-assisted workflow around the existing configuration model.

#### Design notes

This is intentionally an MVP prototype:

* The assistant starts from a sample configuration.
* The local preview supports common `scrape_configs` patterns.
* Applying configuration changes is only available when `--web.enable-lifecycle` is enabled.
* The backend creates a `.bak` file before overwriting the current configuration.
* If reload fails, the previous configuration is restored.

The lifecycle gate is used because writing the configuration file and triggering reload is a sensitive operation.

#### Testing

Manually tested:

* started Prometheus with `--web.enable-lifecycle`
* applied a valid configuration through the UI
* verified that the configuration file was updated
* verified that a backup file was created
* applied an invalid configuration and confirmed that it was rejected
* verified that the endpoint returns `403` when lifecycle API is not enabled

Automated / build checks:

```bash
go test ./web -run ConfigAssistant
go test ./web
cd web/ui
npm run build:mantine-ui
```

#### Release notes for end users (**ALL** commits must be considered).

*Reviewers should verify clarity and quality.*

```release-notes
[FEATURE] UI: Add a prototype configuration assistant for validating, previewing, applying, and reloading Prometheus configuration.
```
