### PR TITLE
fix: [flaky tests] TestReshardPartialBatch

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -628,9 +628,15 @@ func TestReshardPartialBatch(t *testing.T) {
 
 			for range 100 {
 				done := make(chan struct{})
+				prevCalls := c.NumCalls()
 				go func() {
 					m.Append(recs.Samples)
-					time.Sleep(batchSendDeadline)
+					// Wait until the shard goroutine has entered Store (i.e. a
+					// send is actually in progress) before stopping, so we
+					// reliably test that stop() can interrupt an in-flight send.
+					for c.NumCalls() == prevCalls {
+						time.Sleep(time.Millisecond)
+					}
 					m.shards.stop()
 					m.shards.start(1)
 					done <- struct{}{}


### PR DESCRIPTION
## Summary

`TestReshardPartialBatch` used `time.Sleep(batchSendDeadline)` (1 ms) to wait for the shard goroutine's batch-send timer to fire before calling `shards.stop()`.


## Root cause

`TestReshardPartialBatch` used `time.Sleep(batchSendDeadline)` (1 ms) to
wait for the shard goroutine's batch-send timer to fire before calling
`shards.stop()`. The timer inside `runShard` also uses that same 1 ms
deadline, so the sleep raced with the timer on every iteration.

When the sleep won the race, `stop()` was called before the goroutine
reached `sendBatch`/`Store`. The goroutine was still sitting in the `select`
loop waiting for work. `stop()` would close `batchQueue` via
`FlushAndShutdown`, the goroutine would exit its select immediately, and
`s.done` would close. That path is fine, but on a loaded CI the goroutine
could also be in the middle of starting `Store` while `stop()` had already
returned, leaving a half-started send. Over 100 iterations the accumulated
scheduling jitter occasionally pushed the test past the 2-second per-
iteration timeout.

The test's intent is to verify that `stop()` can interrupt an in-flight
send (a goroutine blocked inside `TestBlockingWriteClient.Store`). The race
meant that was only sometimes the case.


## What changed

`storage/remote/queue_manager_test.go` - `TestReshardPartialBatch`

Replaced:
```go
m.Append(recs.Samples)
time.Sleep(batchSendDeadline)
m.shards.stop()
m.shards.start(1)
```

With:
```go
prevCalls := c.NumCalls()
m.Append(recs.Samples)
// Wait until the shard goroutine has entered Store (i.e. a
// send is actually in progress) before stopping, so we
// reliably test that stop() can interrupt an in-flight send.
for c.NumCalls() == prevCalls {
 time.Sleep(time.Millisecond)
}
m.shards.stop()
m.shards.start(1)
```

`TestBlockingWriteClient.Store` increments `numCalls` before blocking on
`<-ctx.Done()`. Polling until `c.NumCalls()` increases guarantees the
goroutine is actually inside `Store` when `stop()` is called, regardless
of CPU load or scheduling delays.


## Issue

Fixes #18078

Issue: https://github.com/prometheus/prometheus/issues/18078


## Diffstat

```
storage/remote/queue_manager_test.go | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.