### PR TITLE
codemirror: fix autocomplete edgecase for functions

### DIFF
--- a/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
@@ -75,6 +75,31 @@ describe('analyzeCompletion test', () => {
       ],
     },
     {
+      title: 'autocomplete AggregateOpModifier or BinOp after closing aggregation',
+      expr: 'sum()',
+      pos: 5, // cursor is after the closing bracket
+      expectedContext: [{ kind: ContextKind.AggregateOpModifier }, { kind: ContextKind.BinOp }],
+    },
+    {
+      title: 'metric/function/aggregation autocompletion in incomplete function',
+      expr: 'sum(',
+      pos: 4,
+      expectedContext: [
+        {
+          kind: ContextKind.MetricName,
+          metricName: '',
+        },
+        { kind: ContextKind.Function },
+        { kind: ContextKind.Aggregation },
+      ],
+    },
+    {
+      title: 'autocomplete binOp after closing function',
+      expr: 'rate(foo[5m])',
+      pos: 13, // cursor is after the closing bracket
+      expectedContext: [{ kind: ContextKind.BinOp }],
+    },
+    {
       title: 'metric/function/aggregation autocompletion 2',
       expr: 'sum(rat)',
       pos: 7,
@@ -99,6 +124,18 @@ describe('analyzeCompletion test', () => {
         { kind: ContextKind.Function },
         { kind: ContextKind.Aggregation },
       ],
+    },
+    {
+      title: 'autocomplete AggregateOpModifier or BinOp after closing nested aggregation',
+      expr: 'sum(rate(foo[5m]))',
+      pos: 18, // cursor is after the closing bracket
+      expectedContext: [{ kind: ContextKind.AggregateOpModifier }, { kind: ContextKind.BinOp }],
+    },
+    {
+      title: 'autocomplete binOp after closing aggregation with existing modifier',
+      expr: 'sum by(job)(rate(foo[5m]))',
+      pos: 26, // cursor is after the closing bracket
+      expectedContext: [{ kind: ContextKind.BinOp }],
     },
     {
       title: 'metric/function/aggregation autocompletion 4',
@@ -718,6 +755,18 @@ describe('computeStartCompletePosition test', () => {
       expectedStart: 9,
     },
     {
+      title: 'start should be equal to the pos after closing function',
+      expr: 'rate(foo[5m])',
+      pos: 13, // cursor is after the closing bracket
+      expectedStart: 13,
+    },
+    {
+      title: 'start should be equal to the pos after closing aggregation',
+      expr: 'sum(rate(foo[5m]))',
+      pos: 18, // cursor is after the closing bracket
+      expectedStart: 18,
+    },
+    {
       title: 'bracket containing a substring',
       expr: '{myL}',
       pos: 4, // cursor is between the bracket
@@ -994,12 +1043,24 @@ describe('computeEndCompletePosition test', () => {
       pos: 13, // cursor at '!' (error node)
       expectedEnd: 13, // error node returns pos
     },
+    {
+      title: 'end should be equal to the pos after closing function',
+      expr: 'rate(foo[5m])',
+      pos: 13, // cursor is after the closing bracket
+      expectedEnd: 13,
+    },
+    {
+      title: 'end should be equal to the pos after closing aggregation',
+      expr: 'sum(rate(foo[5m]))',
+      pos: 18, // cursor is after the closing bracket
+      expectedEnd: 18,
+    },
   ];
   testCases.forEach((value) => {
     it(value.title, () => {
       const state = createEditorState(value.expr);
       const node = syntaxTree(state).resolve(value.pos, -1);
-      const result = computeEndCompletePosition(node, value.pos);
+      const result = computeEndCompletePosition(state, node, value.pos);
       expect(result).toEqual(value.expectedEnd);
     });
   });
@@ -1044,6 +1105,28 @@ describe('autocomplete promQL test', () => {
       },
     },
     {
+      title: 'offline autocomplete aggregate operation modifier or binary operator after closing aggregation',
+      expr: 'sum()',
+      pos: 5, // cursor is after the closing bracket
+      expectedResult: {
+        options: ([] as Completion[]).concat(aggregateOpModifierTerms, binOpTerms),
+        from: 5,
+        to: 5,
+        validFor: /^[a-zA-Z0-9_:]+$/,
+      },
+    },
+    {
+      title: 'offline autocomplete binary operator after closing function',
+      expr: 'rate(foo[5m])',
+      pos: 13, // cursor is after the closing bracket
+      expectedResult: {
+        options: binOpTerms,
+        from: 13,
+        to: 13,
+        validFor: /^[a-zA-Z0-9_:]+$/,
+      },
+    },
+    {
       title: 'offline function/aggregation autocompletion in aggregation 2',
       expr: 'sum(ra)',
       pos: 6,
@@ -1084,6 +1167,17 @@ describe('autocomplete promQL test', () => {
         options: ([] as Completion[]).concat(functionIdentifierTerms, aggregateOpTerms, snippets),
         from: 9,
         to: 9,
+        validFor: /^[a-zA-Z0-9_:]+$/,
+      },
+    },
+    {
+      title: 'offline autocomplete aggregate operation modifier or binary operator after closing nested aggregation',
+      expr: 'sum(rate(foo[5m]))',
+      pos: 18, // cursor is after the closing bracket
+      expectedResult: {
+        options: ([] as Completion[]).concat(aggregateOpModifierTerms, binOpTerms),
+        from: 18,
+        to: 18,
         validFor: /^[a-zA-Z0-9_:]+$/,
       },
     },

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -17,6 +17,7 @@ import { PrometheusClient } from '../client';
 import {
   Add,
   AggregateExpr,
+  AggregateModifier,
   And,
   BinaryExpr,
   BoolModifier,
@@ -175,13 +176,21 @@ function escapePromQLString(str: string): string {
   return str.replace(/([\\"])/g, '\\$1');
 }
 
+function isAfterClosedFunctionCallBody(state: EditorState, node: SyntaxNode, pos: number): boolean {
+  return node.type.id === FunctionCallBody && pos >= node.to && node.from < node.to && state.sliceDoc(node.to - 1, node.to) === ')';
+}
+
 // computeEndCompletePosition calculates the end position for autocompletion replacement.
 // When the cursor is in the middle of a token, this ensures the entire token is replaced,
 // not just the portion before the cursor. This fixes issue #15839.
 // Note: this method is exported only for testing purpose.
-export function computeEndCompletePosition(node: SyntaxNode, pos: number): number {
+export function computeEndCompletePosition(state: EditorState, node: SyntaxNode, pos: number): number {
   // For error nodes, use the cursor position as the end position
   if (node.type.id === 0) {
+    return pos;
+  }
+
+  if (isAfterClosedFunctionCallBody(state, node, pos)) {
     return pos;
   }
 
@@ -240,7 +249,9 @@ function computeStartCompleteLabelPositionInLabelMatcherOrInGroupingLabel(node: 
 export function computeStartCompletePosition(state: EditorState, node: SyntaxNode, pos: number): number {
   const currentText = state.doc.slice(node.from, pos).toString();
   let start = node.from;
-  if (node.type.id === LabelMatchers || node.type.id === GroupingLabels) {
+  if (isAfterClosedFunctionCallBody(state, node, pos)) {
+    start = pos;
+  } else if (node.type.id === LabelMatchers || node.type.id === GroupingLabels) {
     start = computeStartCompleteLabelPositionInLabelMatcherOrInGroupingLabel(node, pos);
   } else if (
     (node.type.id === FunctionCallBody && node.firstChild === null) ||
@@ -545,6 +556,13 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode, pos: num
       result.push({ kind: ContextKind.Duration });
       break;
     case FunctionCallBody:
+      if (isAfterClosedFunctionCallBody(state, node, pos)) {
+        if (node.parent?.type.id === AggregateExpr && !containsAtLeastOneChild(node.parent, AggregateModifier)) {
+          result.push({ kind: ContextKind.AggregateOpModifier });
+        }
+        result.push({ kind: ContextKind.BinOp });
+        break;
+      }
       // For aggregation function such as Topk, the first parameter is a number.
       // The second one is an expression.
       // When moving to the second parameter, the node is an error node.
@@ -711,7 +729,7 @@ export class HybridComplete implements CompleteStrategy {
       return arrayToCompletionResult(
         result,
         computeStartCompletePosition(state, tree, pos),
-        computeEndCompletePosition(tree, pos),
+        computeEndCompletePosition(state, tree, pos),
         completeSnippet,
         span
       );


### PR DESCRIPTION
We want to stop suggesting metric names on closing function brackets. Instead we suggest syntactically valid constructs like binary operators or aggregation modifiers.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->

```release-notes
[ENHANCEMENT] UI: improve autocompletion after closing a function bracket
```
