### PR TITLE
model/labels: fix FastRegexMatcher capture concat

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -426,6 +426,7 @@ func optimizeAlternatingSimpleContains(r *syntax.Regexp) *syntax.Regexp {
 func optimizeConcatRegex(r *syntax.Regexp) (caseInsensitivePrefix bool, prefix, suffix string, contains []string) {
 	sub := r.Sub
 	clearCapture(sub...)
+	sub = concatAdjacentCaseSensitiveLiterals(sub)
 
 	// We can safely remove begin and end text matchers respectively
 	// at the beginning and end of the regexp.
@@ -460,6 +461,31 @@ func optimizeConcatRegex(r *syntax.Regexp) (caseInsensitivePrefix bool, prefix, 
 	}
 
 	return caseInsensitivePrefix, prefix, suffix, contains
+}
+
+// concatAdjacentCaseSensitiveLiterals preserves the exact literal order when
+// capture removal leaves consecutive literal operations in a concat regexp.
+func concatAdjacentCaseSensitiveLiterals(sub []*syntax.Regexp) []*syntax.Regexp {
+	if len(sub) < 2 {
+		return sub
+	}
+
+	compacted := make([]*syntax.Regexp, 0, len(sub))
+	for _, re := range sub {
+		if len(compacted) > 0 && isCaseSensitiveLiteral(compacted[len(compacted)-1]) && isCaseSensitiveLiteral(re) {
+			compacted[len(compacted)-1].Rune = append(compacted[len(compacted)-1].Rune, re.Rune...)
+			continue
+		}
+
+		if isCaseSensitiveLiteral(re) {
+			reCopy := *re
+			reCopy.Rune = slices.Clone(re.Rune)
+			re = &reCopy
+		}
+		compacted = append(compacted, re)
+	}
+
+	return compacted
 }
 
 // StringMatcher is a matcher that matches a string in place of a regular expression.

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -148,6 +148,27 @@ func TestFastRegexMatcher_MatchString(t *testing.T) {
 	}
 }
 
+func TestFastRegexMatcher_CapturingGroupBetweenLiterals(t *testing.T) {
+	for _, c := range []struct {
+		pattern string
+		value   string
+	}{
+		{`.*\|(foo)\|.*`, "|foo-bar|"},
+		{`.*\|(?:foo)\|.*`, "|foo-bar|"},
+		{`.*\|(foo)\|.*`, "x|foo|y"},
+		{`.*-(ab)-.*`, "x-abc-y"},
+		{`.*-(ab)-.*`, "x-ab-y"},
+	} {
+		t.Run(c.pattern+" on "+c.value, func(t *testing.T) {
+			m, err := NewFastRegexMatcher(c.pattern)
+			require.NoError(t, err)
+
+			re := regexp.MustCompile("^(?s:" + c.pattern + ")$")
+			require.Equal(t, re.MatchString(c.value), m.MatchString(c.value))
+		})
+	}
+}
+
 func readable(s string) string {
 	const maxReadableStringLen = 40
 	if len(s) < maxReadableStringLen {
@@ -186,6 +207,9 @@ func TestOptimizeConcatRegex(t *testing.T) {
 		{regex: "^release.*", prefix: "release", suffix: "", contains: nil},
 		{regex: "^env-[0-9]+laio[1]?[^0-9].*", prefix: "env-", suffix: "", contains: []string{"laio"}},
 		{regex: ".*-.*-.*-.*-.*", prefix: "", suffix: "", contains: []string{"-", "-", "-", "-"}},
+		{regex: `.*\|(foo)\|.*`, prefix: "", suffix: "", contains: []string{"|foo|"}},
+		{regex: `.*-(ab)-.*`, prefix: "", suffix: "", contains: []string{"-ab-"}},
+		{regex: `^foo(bar).*`, prefix: "foobar", suffix: "", contains: nil},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18896

#### What this PR does:

`optimizeConcatRegex` removes capture wrappers before deriving literal prefix/suffix/contains checks. For patterns like `.*\|(foo)\|.*`, that can leave adjacent literal regexp operations (`|`, `foo`, `|`) which were previously treated as independent ordered substrings. This incorrectly allowed arbitrary text between those literals.

This PR compacts adjacent case-sensitive literal operations for concat optimization, preserving the exact contiguous literal that must be present, and adds a regression test against the regexp engine behavior.

cc @bboreham

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] PromQL: Fix label regex matcher false positives for capturing groups between literals.
```
