### PR TITLE
fix: FastRegexMatcher: false-positive match for .*<lit>(group)<lit>.* with a capturing group

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -78,8 +78,10 @@ func NewFastRegexMatcher(v string) (*FastRegexMatcher, error) {
 			return nil, err
 		}
 
-		// Remove any capture operations before trying to optimize the remaining operations.
-		clearCapture(parsed)
+		// Remove any capture operations and merge the adjacent literals they
+		// expose before trying to optimize the remaining operations. This is
+		// done after compiling m.re above so the fallback regexp is unaffected.
+		normalizeRegexp(parsed)
 
 		if parsed.Op == syntax.OpConcat {
 			m.caseInsensitivePrefix, m.prefix, m.suffix, m.contains = optimizeConcatRegex(parsed)
@@ -278,6 +280,50 @@ func clearCapture(regs ...*syntax.Regexp) {
 			*r = *r.Sub[0]
 		}
 	}
+}
+
+// normalizeRegexp removes capture operations throughout re and merges any
+// adjacent literals exposed as a result. The Go regexp parser never emits two
+// consecutive literals in a concat, but stripping a capture group can break
+// that invariant: `\|(foo)\|` parses as the literals `|`, `foo`, `|` separated
+// by the capture and, once the capture is removed by clearCapture, those three
+// literals are left adjacent. Downstream optimizations (optimizeConcatRegex,
+// isSimpleConcatenationPattern) would then treat them as independent substrings
+// that may be separated by arbitrary text, producing false-positive matches.
+// Merging restores the invariant so the contiguous literal `|foo|` is matched
+// as a unit.
+func normalizeRegexp(re *syntax.Regexp) {
+	clearCapture(re)
+	for _, sub := range re.Sub {
+		normalizeRegexp(sub)
+	}
+	if re.Op == syntax.OpConcat {
+		re.Sub = mergeAdjacentLiterals(re.Sub)
+	}
+}
+
+// mergeAdjacentLiterals merges consecutive literal sub-expressions of a concat
+// into a single literal. Only literals with matching case-sensitivity are
+// merged, so case-sensitive and case-insensitive literals are kept distinct.
+func mergeAdjacentLiterals(sub []*syntax.Regexp) []*syntax.Regexp {
+	if len(sub) < 2 {
+		return sub
+	}
+	merged := make([]*syntax.Regexp, 0, len(sub))
+	for _, r := range sub {
+		if n := len(merged); n > 0 && r.Op == syntax.OpLiteral {
+			if prev := merged[n-1]; prev.Op == syntax.OpLiteral &&
+				(prev.Flags&syntax.FoldCase) == (r.Flags&syntax.FoldCase) {
+				combined := make([]rune, 0, len(prev.Rune)+len(r.Rune))
+				combined = append(combined, prev.Rune...)
+				combined = append(combined, r.Rune...)
+				merged[n-1] = &syntax.Regexp{Op: syntax.OpLiteral, Rune: combined, Flags: prev.Flags}
+				continue
+			}
+		}
+		merged = append(merged, r)
+	}
+	return merged
 }
 
 // clearBeginEndText removes the begin and end text from the regexp. Prometheus regexp are anchored to the beginning and end of the string.

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -148,6 +148,43 @@ func TestFastRegexMatcher_MatchString(t *testing.T) {
 	}
 }
 
+// TestFastRegexMatcher_CapturingGroupBetweenLiterals is a regression test for a
+// false-positive match in patterns of the shape `.*<lit1>(group)<lit2>.*`. When
+// the group is a capturing group it is stripped before the concat fast path runs
+// (added in #17828), which loses the surrounding delimiter literals and degrades
+// to a substring-style check on the inner literal. The equivalent non-capturing
+// pattern takes a different path and stays correct. In every case the result must
+// agree with Go's stdlib RE2.
+func TestFastRegexMatcher_CapturingGroupBetweenLiterals(t *testing.T) {
+	cases := []struct {
+		pattern string
+		value   string
+	}{
+		// The captured literal is a prefix of a longer token in the input, so
+		// the delimiter `|` does not follow it: `|foo|` is absent from
+		// `|foo-bar|` and the correct answer is false.
+		{`.*\|(foo)\|.*`, "|foo-bar|"},
+		// Control: the same pattern with a non-capturing group, which must
+		// also be false.
+		{`.*\|(?:foo)\|.*`, "|foo-bar|"},
+		// A genuine match must still be reported for the capturing-group form.
+		{`.*\|(foo)\|.*`, "x|foo|y"},
+		// Other delimiters and prefix-overlap shapes.
+		{`.*-(ab)-.*`, "x-abc-y"},
+		{`.*-(ab)-.*`, "x-ab-y"},
+	}
+
+	for _, c := range cases {
+		t.Run(readable(c.pattern)+` on "`+readable(c.value)+`"`, func(t *testing.T) {
+			m, err := NewFastRegexMatcher(c.pattern)
+			require.NoError(t, err)
+			want := regexp.MustCompile("^(?s:" + c.pattern + ")$").MatchString(c.value)
+			require.Equal(t, want, m.MatchString(c.value),
+				"FastRegexMatcher disagrees with stdlib RE2 for pattern %q on %q", c.pattern, c.value)
+		})
+	}
+}
+
 func readable(s string) string {
 	const maxReadableStringLen = 40
 	if len(s) < maxReadableStringLen {
@@ -406,7 +443,7 @@ func TestNewFastRegexMatcher(t *testing.T) {
 		{"foo-.*$", &literalPrefixSensitiveStringMatcher{prefix: "foo-", right: trueMatcher{}}},
 		{"(prometheus|api_prom)_api_v1_.+", &containsStringMatcher{substrings: []string{"prometheus_api_v1_", "api_prom_api_v1_"}, left: nil, right: &anyNonEmptyStringMatcher{matchNL: true}}},
 		{"^((.*)(bar|b|buzz)(.+)|foo)$", orStringMatcher([]StringMatcher{&containsStringMatcher{substrings: []string{"bar", "b", "buzz"}, left: trueMatcher{}, right: &anyNonEmptyStringMatcher{matchNL: true}}, &equalStringMatcher{s: "foo", caseSensitive: true}})},
-		{"((fo(bar))|.+foo)", orStringMatcher([]StringMatcher{orStringMatcher([]StringMatcher{&equalStringMatcher{s: "fobar", caseSensitive: true}}), &literalSuffixStringMatcher{suffix: "foo", suffixCaseSensitive: true, left: &anyNonEmptyStringMatcher{matchNL: true}}})},
+		{"((fo(bar))|.+foo)", orStringMatcher([]StringMatcher{&equalStringMatcher{s: "fobar", caseSensitive: true}, &literalSuffixStringMatcher{suffix: "foo", suffixCaseSensitive: true, left: &anyNonEmptyStringMatcher{matchNL: true}}})},
 		{"(.+)/(gateway|cortex-gw|cortex-gw-internal)", &containsStringMatcher{substrings: []string{"/gateway", "/cortex-gw", "/cortex-gw-internal"}, left: &anyNonEmptyStringMatcher{matchNL: true}, right: nil}},
 		// we don't support case insensitive matching for contains.
 		// This is because there's no strings.IndexOfFold function.


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

https://github.com/prometheus/prometheus/issues/18896

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
BUGFIX: FastRegexMatcher produced a result that disagreed with Go's stdlib RE2 for
patterns of the shape .*<lit1>(capturing group)<lit2>.*.

At the PromQL/label level this surfaced as a selector like
{label=~".*\|(foo)\|.*"} incorrectly matching a series whose label value is
|foo-bar|.
```
