### PR TITLE
fix: Consolidate (and update) go-yaml versions

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -44,7 +44,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/exporter-toolkit/web"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
@@ -67,6 +67,12 @@ var (
 	promtoolParserOpts             parser.Options
 	logger                         = promslog.New(&promslog.Config{})
 )
+
+func unmarshalYAMLStrict(data []byte, v interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(v)
+}
 
 func init() {
 	// This can be removed when the legacy global mode is fully deprecated.
@@ -832,7 +838,7 @@ func checkSDFile(filename string) ([]*targetgroup.Group, error) {
 			return nil, err
 		}
 	case ".yml", ".yaml":
-		if err := yaml.UnmarshalStrict(content, &targetGroups); err != nil {
+		if err := unmarshalYAMLStrict(content, &targetGroups); err != nil {
 			return nil, err
 		}
 	default:

--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -33,7 +33,7 @@ import (
 	"github.com/nsf/jsondiff"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -91,7 +91,7 @@ func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, p parser
 	}
 
 	var unitTestInp unitTestFile
-	if err := yaml.UnmarshalStrict(b, &unitTestInp); err != nil {
+	if err := unmarshalYAMLStrict(b, &unitTestInp); err != nil {
 		ts.Abort(err)
 		return []error{err}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -34,7 +35,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/otlptranslator"
 	"github.com/prometheus/sigv4"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/model/labels"
@@ -71,6 +72,12 @@ var (
 )
 
 // Load parses the YAML input s into a Config.
+func unmarshalYAMLStrict(data []byte, v interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(v)
+}
+
 func Load(s string, logger *slog.Logger) (*Config, error) {
 	cfg := &Config{}
 	// If the entire config body is empty the UnmarshalYAML method is
@@ -78,7 +85,7 @@ func Load(s string, logger *slog.Logger) (*Config, error) {
 	// point as well.
 	*cfg = DefaultConfig
 
-	err := yaml.UnmarshalStrict([]byte(s), cfg)
+	err := unmarshalYAMLStrict([]byte(s), cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +376,7 @@ func (c *Config) GetScrapeConfigs() ([]*ScrapeConfig, error) {
 			if err != nil {
 				return nil, fileErr(filename, err)
 			}
-			err = yaml.UnmarshalStrict(content, &cfg)
+			err = unmarshalYAMLStrict(content, &cfg)
 			if err != nil {
 				return nil, fileErr(filename, err)
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/otlptranslator"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/aws"
@@ -1841,7 +1841,7 @@ func TestOTLPSanitizeResourceAttributes(t *testing.T) {
 		out, err := yaml.Marshal(want)
 		require.NoError(t, err)
 		var got Config
-		require.NoError(t, yaml.UnmarshalStrict(out, &got))
+		require.NoError(t, unmarshalYAMLStrict(out, &got))
 
 		require.False(t, got.OTLPConfig.PromoteAllResourceAttributes)
 		require.Empty(t, got.OTLPConfig.IgnoreResourceAttributes)
@@ -1855,7 +1855,7 @@ func TestOTLPSanitizeResourceAttributes(t *testing.T) {
 		out, err := yaml.Marshal(want)
 		require.NoError(t, err)
 		var got Config
-		require.NoError(t, yaml.UnmarshalStrict(out, &got))
+		require.NoError(t, unmarshalYAMLStrict(out, &got))
 
 		require.False(t, got.OTLPConfig.PromoteAllResourceAttributes)
 		require.Empty(t, got.OTLPConfig.IgnoreResourceAttributes)
@@ -1876,7 +1876,7 @@ func TestOTLPSanitizeResourceAttributes(t *testing.T) {
 		out, err := yaml.Marshal(want)
 		require.NoError(t, err)
 		var got Config
-		require.NoError(t, yaml.UnmarshalStrict(out, &got))
+		require.NoError(t, unmarshalYAMLStrict(out, &got))
 		require.True(t, got.OTLPConfig.PromoteAllResourceAttributes)
 		require.Empty(t, got.OTLPConfig.PromoteResourceAttributes)
 		require.Empty(t, got.OTLPConfig.IgnoreResourceAttributes)
@@ -1889,7 +1889,7 @@ func TestOTLPSanitizeResourceAttributes(t *testing.T) {
 		out, err := yaml.Marshal(want)
 		require.NoError(t, err)
 		var got Config
-		require.NoError(t, yaml.UnmarshalStrict(out, &got))
+		require.NoError(t, unmarshalYAMLStrict(out, &got))
 		require.True(t, got.OTLPConfig.PromoteAllResourceAttributes)
 		require.Empty(t, got.OTLPConfig.PromoteResourceAttributes)
 		require.Equal(t, []string{"k8s.cluster.name", "k8s.job.name", "k8s.namespace.name"}, got.OTLPConfig.IgnoreResourceAttributes)
@@ -1921,7 +1921,7 @@ func TestOTLPAllowServiceNameInTargetInfo(t *testing.T) {
 		out, err := yaml.Marshal(want)
 		require.NoError(t, err)
 		var got Config
-		require.NoError(t, yaml.UnmarshalStrict(out, &got))
+		require.NoError(t, unmarshalYAMLStrict(out, &got))
 
 		require.True(t, got.OTLPConfig.KeepIdentifyingResourceAttributes)
 	})
@@ -1935,7 +1935,7 @@ func TestOTLPConvertHistogramsToNHCB(t *testing.T) {
 		out, err := yaml.Marshal(want)
 		require.NoError(t, err)
 		var got Config
-		require.NoError(t, yaml.UnmarshalStrict(out, &got))
+		require.NoError(t, unmarshalYAMLStrict(out, &got))
 
 		require.True(t, got.OTLPConfig.ConvertHistogramsToNHCB)
 	})
@@ -1949,7 +1949,7 @@ func TestOTLPPromoteScopeMetadata(t *testing.T) {
 		out, err := yaml.Marshal(want)
 		require.NoError(t, err)
 		var got Config
-		require.NoError(t, yaml.UnmarshalStrict(out, &got))
+		require.NoError(t, unmarshalYAMLStrict(out, &got))
 
 		require.True(t, got.OTLPConfig.PromoteScopeMetadata)
 	})
@@ -1972,7 +1972,7 @@ func TestOTLPLabelUnderscoreSanitization(t *testing.T) {
 		out, err := yaml.Marshal(conf)
 		require.NoError(t, err)
 		var got Config
-		require.NoError(t, yaml.UnmarshalStrict(out, &got))
+		require.NoError(t, unmarshalYAMLStrict(out, &got))
 
 		require.True(t, got.OTLPConfig.LabelNameUnderscoreSanitization)
 		require.True(t, got.OTLPConfig.LabelNamePreserveMultipleUnderscores)
@@ -2742,7 +2742,7 @@ func TestBadStaticConfigsYML(t *testing.T) {
 	content, err := os.ReadFile("testdata/static_config.bad.yml")
 	require.NoError(t, err)
 	var tg targetgroup.Group
-	err = yaml.UnmarshalStrict(content, &tg)
+	err = unmarshalYAMLStrict(content, &tg)
 	require.Error(t, err)
 }
 
@@ -3306,7 +3306,7 @@ func TestScrapeConfigDisableCompression(t *testing.T) {
 
 	require.NoError(t, err)
 	got := &Config{}
-	require.NoError(t, yaml.UnmarshalStrict(out, got))
+	require.NoError(t, unmarshalYAMLStrict(out, got))
 
 	require.False(t, got.ScrapeConfigs[0].EnableCompression)
 }
@@ -3359,7 +3359,7 @@ func TestScrapeConfigNameValidationSettings(t *testing.T) {
 
 			require.NoError(t, err)
 			got := &Config{}
-			require.NoError(t, yaml.UnmarshalStrict(out, got))
+			require.NoError(t, unmarshalYAMLStrict(out, got))
 
 			require.Equal(t, tc.expectScheme, got.ScrapeConfigs[0].MetricNameValidationScheme)
 
@@ -3412,7 +3412,7 @@ func TestScrapeConfigNameEscapingSettings(t *testing.T) {
 
 			require.NoError(t, err)
 			got := &Config{}
-			require.NoError(t, yaml.UnmarshalStrict(out, got))
+			require.NoError(t, unmarshalYAMLStrict(out, got))
 
 			require.Equal(t, tc.expectValidationScheme, got.ScrapeConfigs[0].MetricNameValidationScheme)
 			require.Equal(t, tc.expectEscapingScheme, got.ScrapeConfigs[0].MetricNameEscapingScheme)

--- a/config/reload.go
+++ b/config/reload.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 
 	promconfig "github.com/prometheus/common/config"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 type ExternalFilesConfig struct {

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -14,11 +14,18 @@
 package discovery
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
+
+func unmarshalYAMLStrict(data []byte, v interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(v)
+}
 
 func TestConfigsCustomUnMarshalMarshal(t *testing.T) {
 	input := `static_configs:
@@ -27,7 +34,7 @@ func TestConfigsCustomUnMarshalMarshal(t *testing.T) {
   - bar:4321
 `
 	cfg := &Configs{}
-	err := yaml.UnmarshalStrict([]byte(input), cfg)
+	err := unmarshalYAMLStrict([]byte(input), cfg)
 	require.NoError(t, err)
 
 	output, err := yaml.Marshal(cfg)

--- a/discovery/dns/dns_test.go
+++ b/discovery/dns/dns_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"

--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -14,6 +14,7 @@
 package file
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -33,7 +34,7 @@ import (
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -50,6 +51,12 @@ var (
 
 func init() {
 	discovery.RegisterConfig(&SDConfig{})
+}
+
+func unmarshalYAMLStrict(data []byte, v interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(v)
 }
 
 // SDConfig is the configuration for file based discovery.
@@ -398,7 +405,7 @@ func (d *Discovery) readFile(filename string) ([]*targetgroup.Group, error) {
 			return nil, err
 		}
 	case ".yml", ".yaml":
-		if err := yaml.UnmarshalStrict(content, &targetGroups); err != nil {
+		if err := unmarshalYAMLStrict(content, &targetGroups); err != nil {
 			return nil, err
 		}
 	default:

--- a/discovery/moby/docker_test.go
+++ b/discovery/moby/docker_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 )

--- a/discovery/moby/mock_test.go
+++ b/discovery/moby/mock_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/util/strutil"
 )

--- a/discovery/moby/nodes_test.go
+++ b/discovery/moby/nodes_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 )

--- a/discovery/moby/services_test.go
+++ b/discovery/moby/services_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 )

--- a/discovery/moby/tasks_test.go
+++ b/discovery/moby/tasks_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 )

--- a/discovery/ovhcloud/dedicated_server_test.go
+++ b/discovery/ovhcloud/dedicated_server_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestOvhcloudDedicatedServerRefresh(t *testing.T) {
@@ -40,7 +40,7 @@ application_key: %s
 application_secret: %s
 consumer_key: %s`, mock.URL, ovhcloudApplicationKeyTest, ovhcloudApplicationSecretTest, ovhcloudConsumerKeyTest)
 
-	require.NoError(t, yaml.UnmarshalStrict([]byte(cfgString), &cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(cfgString), &cfg))
 	d, err := newRefresher(&cfg, promslog.NewNopLogger())
 	require.NoError(t, err)
 	ctx := context.Background()

--- a/discovery/ovhcloud/ovhcloud_test.go
+++ b/discovery/ovhcloud/ovhcloud_test.go
@@ -14,6 +14,7 @@
 package ovhcloud
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"testing"
@@ -22,7 +23,7 @@ import (
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 )
@@ -36,6 +37,12 @@ var (
 const (
 	mockURL = "https://localhost:1234"
 )
+
+func unmarshalYAMLStrict(data []byte, v interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(v)
+}
 
 func getMockConf(service string) (SDConfig, error) {
 	confString := fmt.Sprintf(`
@@ -52,7 +59,7 @@ service: %s
 
 func getMockConfFromString(confString string) (SDConfig, error) {
 	var conf SDConfig
-	err := yaml.UnmarshalStrict([]byte(confString), &conf)
+	err := unmarshalYAMLStrict([]byte(confString), &conf)
 	return conf, err
 }
 

--- a/discovery/ovhcloud/vps_test.go
+++ b/discovery/ovhcloud/vps_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	yaml "go.yaml.in/yaml/v2"
+	yaml "go.yaml.in/yaml/v3"
 )
 
 func TestOvhCloudVpsRefresh(t *testing.T) {
@@ -40,7 +40,7 @@ application_key: %s
 application_secret: %s
 consumer_key: %s`, mock.URL, ovhcloudApplicationKeyTest, ovhcloudApplicationSecretTest, ovhcloudConsumerKeyTest)
 
-	require.NoError(t, yaml.UnmarshalStrict([]byte(cfgString), &cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(cfgString), &cfg))
 
 	d, err := newRefresher(&cfg, promslog.NewNopLogger())
 	require.NoError(t, err)

--- a/discovery/registry.go
+++ b/discovery/registry.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 )

--- a/discovery/scaleway/instance_test.go
+++ b/discovery/scaleway/instance_test.go
@@ -14,6 +14,7 @@
 package scaleway
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -23,7 +24,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 var (
@@ -32,6 +33,12 @@ var (
 	testSecretKey     = "6d6579e5-a5b9-49fc-a35f-b4feb9b87301"
 	testAccessKey     = "SCW0W8NG6024YHRJ7723"
 )
+
+func unmarshalYAMLStrict(data []byte, v interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(v)
+}
 
 func TestScalewayInstanceRefresh(t *testing.T) {
 	mock := httptest.NewServer(http.HandlerFunc(mockScalewayInstance))
@@ -46,7 +53,7 @@ access_key: %s
 api_url: %s
 `, testProjectID, testSecretKey, testAccessKey, mock.URL)
 	var cfg SDConfig
-	require.NoError(t, yaml.UnmarshalStrict([]byte(cfgString), &cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(cfgString), &cfg))
 
 	d, err := newRefresher(&cfg)
 	require.NoError(t, err)
@@ -262,7 +269,7 @@ access_key: %s
 api_url: %s
 `, testProjectID, testSecretKey, testAccessKey, mock.URL)
 	var cfg SDConfig
-	require.NoError(t, yaml.UnmarshalStrict([]byte(cfgString), &cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(cfgString), &cfg))
 
 	d, err := newRefresher(&cfg)
 	require.NoError(t, err)
@@ -289,7 +296,7 @@ access_key: %s
 api_url: %s
 `, testProjectID, testSecretKeyFile, testAccessKey, mock.URL)
 	var cfg SDConfig
-	require.NoError(t, yaml.UnmarshalStrict([]byte(cfgString), &cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(cfgString), &cfg))
 
 	d, err := newRefresher(&cfg)
 	require.NoError(t, err)

--- a/discovery/targetgroup/targetgroup_test.go
+++ b/discovery/targetgroup/targetgroup_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestTargetGroupStrictJSONUnmarshal(t *testing.T) {

--- a/discovery/xds/kuma_test.go
+++ b/discovery/xds/kuma_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,6 @@ require (
 	go.uber.org/atomic v1.11.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/goleak v1.3.0
-	go.yaml.in/yaml/v2 v2.4.4
 	go.yaml.in/yaml/v3 v3.0.4
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/oauth2 v0.36.0

--- a/model/labels/labels_test.go
+++ b/model/labels/labels_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 var (

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -14,17 +14,24 @@
 package relabel
 
 import (
+	"bytes"
 	"encoding/json"
 	"strconv"
 	"testing"
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/util/testutil"
 )
+
+func unmarshalYAMLStrict(data []byte, v interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(v)
+}
 
 func TestRelabel(t *testing.T) {
 	tests := []struct {
@@ -1061,7 +1068,7 @@ func BenchmarkRelabel(b *testing.B) {
 		},
 	}
 	for i := range tests {
-		err := yaml.UnmarshalStrict([]byte(tests[i].config), &tests[i].cfgs)
+		err := unmarshalYAMLStrict([]byte(tests[i].config), &tests[i].cfgs)
 		require.NoError(b, err)
 	}
 	for _, tt := range tests {

--- a/notifier/alertmanagerset.go
+++ b/notifier/alertmanagerset.go
@@ -23,7 +23,7 @@ import (
 
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/sigv4"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"

--- a/notifier/manager_test.go
+++ b/notifier/manager_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
@@ -45,6 +45,12 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 )
+
+func unmarshalYAMLStrict(data []byte, v interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(v)
+}
 
 func alertsEqual(a, b []*Alert) error {
 	if len(a) != len(b) {
@@ -608,7 +614,7 @@ alerting:
   alertmanagers:
   - static_configs:
 `
-	err := yaml.UnmarshalStrict([]byte(s), cfg)
+	err := unmarshalYAMLStrict([]byte(s), cfg)
 	require.NoError(t, err, "Unable to load YAML config.")
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 1)
 
@@ -659,7 +665,7 @@ alerting:
         regex: 'alertmanager:9093'
         action: drop
 `
-	err := yaml.UnmarshalStrict([]byte(s), cfg)
+	err := unmarshalYAMLStrict([]byte(s), cfg)
 	require.NoError(t, err, "Unable to load YAML config.")
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 1)
 
@@ -1044,7 +1050,7 @@ alerting:
       - foo.json
 `
 	// 1. Ensure known alertmanagers are not dropped during ApplyConfig.
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(s), cfg))
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 1)
 
 	// First, apply the config and reload.
@@ -1070,7 +1076,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(s), cfg))
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 2)
 
 	require.NoError(t, n.ApplyConfig(cfg))
@@ -1093,7 +1099,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(s), cfg))
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 2)
 
 	require.NoError(t, n.ApplyConfig(cfg))
@@ -1120,7 +1126,7 @@ alerting:
       regex: 'doesntmatter:1234'
       action: drop
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(s), cfg))
 	require.Len(t, cfg.AlertingConfig.AlertmanagerConfigs, 2)
 
 	require.NoError(t, n.ApplyConfig(cfg))
@@ -1328,7 +1334,7 @@ alerting:
     - files:
       - bar.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	// Reload with target groups to discover alertmanagers.
@@ -1379,7 +1385,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	// CRITICAL CHECK: After ApplyConfig but BEFORE reload, the sendLoops should
@@ -1435,7 +1441,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	targetGroup := &targetgroup.Group{
@@ -1460,7 +1466,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	// Reload with target groups for both configs - same alertmanager URL for both.
@@ -1508,7 +1514,7 @@ alerting:
     - files:
       - foo.json
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	targetGroup := &targetgroup.Group{
@@ -1536,7 +1542,7 @@ alerting:
       - foo.json
     path_prefix: /changed
 `
-	require.NoError(t, yaml.UnmarshalStrict([]byte(s), cfg))
+	require.NoError(t, unmarshalYAMLStrict([]byte(s), cfg))
 	require.NoError(t, n.ApplyConfig(cfg))
 
 	// The old sendLoop should have been stopped since hash changed.

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"go.uber.org/atomic"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"

--- a/rules/recording.go
+++ b/rules/recording.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"

--- a/scrape/helpers_test.go
+++ b/scrape/helpers_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/prometheus/prometheus/config"
@@ -58,6 +58,12 @@ import (
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func unmarshalYAMLStrict(data []byte, v interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(v)
 }
 
 func TestPopulateLabels(t *testing.T) {
@@ -736,7 +742,7 @@ global:
 `
 
 		cfg := &config.Config{}
-		err := yaml.UnmarshalStrict([]byte(cfgText), cfg)
+		err := unmarshalYAMLStrict([]byte(cfgText), cfg)
 		require.NoError(t, err, "Unable to load YAML config cfgYaml.")
 
 		return cfg

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -53,7 +53,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.uber.org/atomic"
 	"go.uber.org/goleak"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"

--- a/storage/remote/azuread/azuread_test.go
+++ b/storage/remote/azuread/azuread_test.go
@@ -14,6 +14,7 @@
 package azuread
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"os"
@@ -29,7 +30,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 const (
@@ -137,13 +138,19 @@ func (ad *AzureAdTestSuite) TestAzureAdRoundTripper() {
 	}
 }
 
+func unmarshalYAMLStrict(data []byte, v interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(v)
+}
+
 func loadAzureAdConfig(filename string) (*AzureADConfig, error) {
 	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 	cfg := AzureADConfig{}
-	if err = yaml.UnmarshalStrict(content, &cfg); err != nil {
+	if err = unmarshalYAMLStrict(content, &cfg); err != nil {
 		return nil, err
 	}
 	return &cfg, nil

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -25,7 +25,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"

--- a/web/api/v1/openapi_test.go
+++ b/web/api/v1/openapi_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 )
 
 // TestOpenAPIHTTPHandler verifies that the OpenAPI endpoint serves a valid specification


### PR DESCRIPTION
## Summary

The Prometheus binary was compiled with three versions of `go.yaml.in/yaml` (v2, v3, v4) because Prometheus source files used v2 for the majority of YAML work, `model/rulefmt` had already been migrated to v3, and `web/api/v1/openapi_helpers.go` uses v4 because `github.com/pb33f/libopenapi` requires it.


## Root cause

The Prometheus binary was compiled with three versions of `go.yaml.in/yaml` (v2, v3, v4) because Prometheus source files used v2 for the majority of YAML work, `model/rulefmt` had already been migrated to v3, and `web/api/v1/openapi_helpers.go` uses v4 because `github.com/pb33f/libopenapi` requires it.

The key blocker for consolidating v2 into v3 was `yaml.UnmarshalStrict`, a v2-only convenience function. In v3, the equivalent requires a decoder object.


## What changed

Migrated all 35 Go source files that imported `go.yaml.in/yaml/v2` to use `go.yaml.in/yaml/v3` instead, reducing the distinct yaml versions from 3 (v2+v3+v4) to 2 (v3+v4).

**Import changes:** Updated `"go.yaml.in/yaml/v2"` to `"go.yaml.in/yaml/v3"` in all affected files.

**`yaml.UnmarshalStrict` replacements:** Added a package-local `unmarshalYAMLStrict(data []byte, v interface{}) error` helper in each package that needed it:
- `config.unmarshalYAMLStrict` (config/config.go)
- `main.unmarshalYAMLStrict` (cmd/promtool/main.go)
- `file.unmarshalYAMLStrict` (discovery/file/file.go)
- `discovery.unmarshalYAMLStrict`, `ovhcloud.unmarshalYAMLStrict`, `scaleway.unmarshalYAMLStrict`, `relabel.unmarshalYAMLStrict`, `notifier.unmarshalYAMLStrict`, `scrape.unmarshalYAMLStrict`, `azuread.unmarshalYAMLStrict` (test helpers)

Each helper wraps the v3 decoder pattern:
```go
func unmarshalYAMLStrict(data []byte, v interface{}) error {
 dec := yaml.NewDecoder(bytes.NewReader(data))
 dec.KnownFields(true)
 return dec.Decode(v)
}
```

**`UnmarshalYAML` method signatures unchanged:** Existing methods implementing the v2 `UnmarshalYAML(unmarshal func(interface{}) error) error` signature work unchanged with v3, which has built-in backward compatibility for the old signature via its internal `obsoleteUnmarshaler` interface.

**go.mod:** Removed `go.yaml.in/yaml/v2 v2.4.4` from direct dependencies.

**Not changed:** `web/api/v1/openapi_helpers.go` (v4 stays because libopenapi requires it), `model/rulefmt/rulefmt.go` (already on v3), `web/api/v1/openapi_golden_test.go` and `discovery/aws/aws_test.go` (already on v3).


## Issue

Fixes #18391

Issue: https://github.com/prometheus/prometheus/issues/18391


## Diffstat

```
cmd/promtool/main.go | 10 +++++++--
 cmd/promtool/unittest.go | 4 ++--
 config/config.go | 13 +++++++++---
 config/config_test.go | 26 +++++++++++------------
 config/reload.go | 2 +-
 discovery/consul/consul_test.go | 2 +-
 discovery/discovery_test.go | 11 ++++++++--
 discovery/dns/dns_test.go | 2 +-
 discovery/file/file.go | 11 ++++++++--
 discovery/moby/docker_test.go | 2 +-
 discovery/moby/mock_test.go | 2 +-
 discovery/moby/nodes_test.go | 2 +-
 discovery/moby/services_test.go | 2 +-
 discovery/moby/tasks_test.go | 2 +-
 discovery/ovhcloud/dedicated_server_test.go | 4 ++--
 discovery/ovhcloud/ovhcloud_test.go | 11 ++++++++--
 discovery/ovhcloud/vps_test.go | 4 ++--
 discovery/registry.go | 2 +-
 discovery/scaleway/instance_test.go | 15 ++++++++++----
 discovery/targetgroup/targetgroup_test.go | 2 +-
 discovery/xds/kuma_test.go | 2 +-
 go.mod | 1 -
 model/labels/labels_test.go | 2 +-
 model/relabel/relabel_test.go | 11 ++++++++--
 notifier/alertmanagerset.go | 2 +-
 notifier/manager_test.go | 32 +++++++++++++++++------------
 rules/alerting.go | 2 +-
 rules/manager_test.go | 2 +-
 rules/recording.go | 2 +-
 scrape/helpers_test.go | 2 +-
 scrape/manager_test.go | 10 +++++++--
 scrape/scrape_test.go | 2 +-
 storage/remote/azuread/azuread_test.go | 11 ++++++++--
 storage/remote/storage.go | 2 +-
 web/api/v1/openapi_test.go | 2 +-
 35 files changed, 140 insertions(+), 74 deletions(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.