### PR TITLE
codemirror: prefer query execution when no autocomplete item is selected

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/ExpressionInput.tsx
+++ b/web/ui/mantine-ui/src/pages/query/ExpressionInput.tsx
@@ -38,10 +38,13 @@ import {
 } from "@codemirror/language";
 import classes from "./ExpressionInput.module.css";
 import {
+  acceptCompletion,
   autocompletion,
   closeBrackets,
   closeBracketsKeymap,
   completionKeymap,
+  completionStatus,
+  selectedCompletion,
 } from "@codemirror/autocomplete";
 import {
   defaultKeymap,
@@ -240,7 +243,7 @@ const ExpressionInput: FC<ExpressionInputProps> = ({
           indentOnInput(),
           bracketMatching(),
           closeBrackets(),
-          autocompletion(),
+          autocompletion({ selectOnOpen: false }),
           highlightSelectionMatches(),
           EditorView.lineWrapping,
           keymap.of([
@@ -271,7 +274,13 @@ const ExpressionInput: FC<ExpressionInputProps> = ({
             keymap.of([
               {
                 key: "Enter",
-                run: (): boolean => {
+                run: (view: EditorView): boolean => {
+                  if (
+                    completionStatus(view.state) === "active" &&
+                    selectedCompletion(view.state) !== null
+                  ) {
+                    return acceptCompletion(view);
+                  }
                   executeQuery(expr);
                   return true;
                 },


### PR DESCRIPTION
Autocomplete will hijack query execution when there is an autocomplete item selected. There is always one selected when the window opens. This leads to bad UX when the user does not want to accept the autocomplete suggestion and just submit the query.
We fix it by opening the autocomplete window without selection initially and prefering query execution when no autocomplete item is selected.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[CHANGE] Make auto-complete explicitly require a selection and not hijack query execution request #18900
```
