### PR TITLE
PromQL: Fix for resets/changes in anchored

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -2214,21 +2214,44 @@ func funcHistogramQuantiles(vectorVals []Vector, _ Matrix, args parser.Expressio
 	return enh.Out, annos
 }
 
-// pickFirstSampleIndex returns the index of the last sample before
-// or at the range start, or 0 if none exist before the range start.
-// If the vector selector is not anchored, it always returns 0, true.
-// The second return value is false if there are no samples in range (for anchored selectors).
-func pickFirstSampleIndex(floats []FPoint, args parser.Expressions, enh *EvalNodeHelper) (int, bool) {
+// pickFirstSampleIndices returns the start indices into the floats and
+// histograms slices for anchored range processing. The anchor is the single
+// most recent sample at or before the range start, regardless of type; it is
+// retained as the baseline together with every sample after the range start,
+// while earlier samples of either type are skipped.
+// If the vector selector is not anchored, it always returns 0, 0, true.
+// found is false when no sample lies strictly after the range start, in which
+// case there is nothing to measure.
+func pickFirstSampleIndices(floats []FPoint, histograms []HPoint, args parser.Expressions, enh *EvalNodeHelper) (firstFloat, firstHistogram int, found bool) {
 	ms := args[0].(*parser.MatrixSelector)
 	vs := ms.VectorSelector.(*parser.VectorSelector)
 	if !vs.Anchored {
-		return 0, true
+		return 0, 0, true
 	}
 	rangeStart := enh.Ts - durationMilliseconds(ms.Range+vs.Offset)
-	if len(floats) == 0 || floats[len(floats)-1].T <= rangeStart {
-		return 0, false
+
+	// Index of the last float / histogram at or before the range start, or -1.
+	lastFloatLE := sort.Search(len(floats), func(i int) bool { return floats[i].T > rangeStart }) - 1
+	lastHistLE := sort.Search(len(histograms), func(i int) bool { return histograms[i].T > rangeStart }) - 1
+
+	// Without a sample strictly after the range start there is nothing to measure.
+	if lastFloatLE+1 >= len(floats) && lastHistLE+1 >= len(histograms) {
+		return 0, 0, false
 	}
-	return max(0, sort.Search(len(floats)-1, func(i int) bool { return floats[i].T > rangeStart })-1), true
+
+	switch {
+	case lastFloatLE < 0 && lastHistLE < 0:
+		// No anchor; every sample is after the range start, so include all.
+		return 0, 0, true
+	case lastHistLE < 0 || (lastFloatLE >= 0 && floats[lastFloatLE].T >= histograms[lastHistLE].T):
+		// The anchor is a float; histograms at or before the range start precede
+		// it and are skipped.
+		return lastFloatLE, lastHistLE + 1, true
+	default:
+		// The anchor is a histogram; floats at or before the range start precede
+		// it and are skipped.
+		return lastFloatLE + 1, lastHistLE, true
+	}
 }
 
 // === resets(Matrix parser.ValueTypeMatrix) (Vector, Annotations) ===
@@ -2252,11 +2275,11 @@ func funcResets(_ []Vector, matrixVal Matrix, args parser.Expressions, enh *Eval
 		floatSTs = sts.Floats
 		histogramSTs = sts.Histograms
 	}
-	firstSampleIndex, found := pickFirstSampleIndex(floats, args, enh)
+	firstFloat, firstHistogram, found := pickFirstSampleIndices(floats, histograms, args, enh)
 	if !found {
 		return enh.Out, nil
 	}
-	for iFloat, iHistogram := firstSampleIndex, 0; iFloat < len(floats) || iHistogram < len(histograms); {
+	for iFloat, iHistogram := firstFloat, firstHistogram; iFloat < len(floats) || iHistogram < len(histograms); {
 		var curST int64
 		switch {
 		// Process a float sample if no histogram sample remains or its timestamp is earlier.
@@ -2278,7 +2301,7 @@ func funcResets(_ []Vector, matrixVal Matrix, args parser.Expressions, enh *Eval
 			iHistogram++
 		}
 		// Skip the comparison for the first sample, just initialize prevSample.
-		if iFloat+iHistogram == 1+firstSampleIndex {
+		if iFloat+iHistogram == 1+firstFloat+firstHistogram {
 			prevSample = curSample
 			prevST = curST
 			continue
@@ -2316,11 +2339,11 @@ func funcChanges(_ []Vector, matrixVal Matrix, args parser.Expressions, enh *Eva
 	}
 
 	var prevSample, curSample Sample
-	firstSampleIndex, found := pickFirstSampleIndex(floats, args, enh)
+	firstFloat, firstHistogram, found := pickFirstSampleIndices(floats, histograms, args, enh)
 	if !found {
 		return enh.Out, nil
 	}
-	for iFloat, iHistogram := firstSampleIndex, 0; iFloat < len(floats) || iHistogram < len(histograms); {
+	for iFloat, iHistogram := firstFloat, firstHistogram; iFloat < len(floats) || iHistogram < len(histograms); {
 		switch {
 		// Process a float sample if no histogram sample remains or its timestamp is earlier.
 		// Process a histogram sample if no float sample remains or its timestamp is earlier.
@@ -2333,7 +2356,7 @@ func funcChanges(_ []Vector, matrixVal Matrix, args parser.Expressions, enh *Eva
 			iHistogram++
 		}
 		// Skip the comparison for the first sample, just initialize prevSample.
-		if iFloat+iHistogram == 1+firstSampleIndex {
+		if iFloat+iHistogram == 1+firstFloat+firstHistogram {
 			prevSample = curSample
 			continue
 		}

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -724,6 +724,9 @@ clear
 #   floats:         all floats
 #   histograms:     all histograms
 #   honlywithreset: all histograms, with a counter reset hint
+#   hhffmixed:      histograms before a float anchor; the pre-anchor histograms
+#                   at t=0 and t=1m must be skipped, so only the t=2m -> t=3m
+#                   float transition is counted.
 load 1m
   ftohmixed 1 2 3 {{schema:0 sum:5 count:4 buckets:[1 2 1]}} 4 5 6 7+1x60
   htofmixed {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:0 sum:2 count:2 buckets:[2]}} {{schema:0 sum:3 count:3 buckets:[3]}} 5

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -750,6 +750,9 @@ eval instant at 3m resets(htofmixed[1m] anchored)
 eval instant at 3m resets(honlywithreset[1m] anchored)
     {} 1
 
+eval instant at 3m resets(hhffmixed[1m] anchored)
+    {} 1
+
 eval instant at 3m changes(ftohmixed[1m] anchored)
     {} 1
 

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -767,3 +767,6 @@ eval instant at 3m changes(htofmixed[1m] anchored)
 
 eval instant at 3m changes(honlywithreset[1m] anchored)
     {} 1
+
+eval instant at 3m changes(hhffmixed[1m] anchored)
+    {} 1

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -711,3 +711,53 @@ load 10s
 
 eval instant at 15s histogram_count(rate(right_boundary_reset[10s] smoothed))
     {} 0.4
+
+clear
+
+# These tests explore an anchored window of (2m, 3m].
+# We have a point at t=3m. The anchor (last sample at or before rangeStart=2m)
+# is selected to be the t=2m sample. The test verifies that the all-float,
+# all-histogram, and mixed cases are handled the same: the anchor is prepended
+# and the t=2m -> t=3m transition counts as one reset/change. Per-series shape:
+#   ftohmixed:      float -> histogram
+#   htofmixed:      histogram -> float
+#   floats:         all floats
+#   histograms:     all histograms
+#   honlywithreset: all histograms, with a counter reset hint
+load 1m
+  ftohmixed 1 2 3 {{schema:0 sum:5 count:4 buckets:[1 2 1]}} 4 5 6 7+1x60
+  htofmixed {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:0 sum:2 count:2 buckets:[2]}} {{schema:0 sum:3 count:3 buckets:[3]}} 5
+  floats 2 1 2 1 2 1
+  histograms {{schema:0 sum:5 count:2}} {{schema:0 sum:5 count:1}} {{schema:0 sum:5 count:2}} {{schema:0 sum:5 count:1}} {{schema:0 sum:5 count:2}}
+  honlywithreset {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:0 sum:2 count:2 buckets:[2]}} {{schema:0 sum:3 count:3 buckets:[3]}} {{schema:0 sum:1 count:1 buckets:[1] counter_reset_hint:reset}}
+
+
+eval instant at 3m resets(ftohmixed[1m] anchored)
+    {} 1
+
+eval instant at 3m resets(floats[1m] anchored)
+    {} 1
+
+eval instant at 3m resets(histograms[1m] anchored)
+    {} 1
+
+eval instant at 3m resets(htofmixed[1m] anchored)
+    {} 1
+
+eval instant at 3m resets(honlywithreset[1m] anchored)
+    {} 1
+
+eval instant at 3m changes(ftohmixed[1m] anchored)
+    {} 1
+
+eval instant at 3m changes(floats[1m] anchored)
+    {} 1
+
+eval instant at 3m changes(histograms[1m] anchored)
+    {} 1
+
+eval instant at 3m changes(htofmixed[1m] anchored)
+    {} 1
+
+eval instant at 3m changes(honlywithreset[1m] anchored)
+    {} 1

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -733,6 +733,7 @@ load 1m
   floats 2 1 2 1 2 1
   histograms {{schema:0 sum:5 count:2}} {{schema:0 sum:5 count:1}} {{schema:0 sum:5 count:2}} {{schema:0 sum:5 count:1}} {{schema:0 sum:5 count:2}}
   honlywithreset {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:0 sum:2 count:2 buckets:[2]}} {{schema:0 sum:3 count:3 buckets:[3]}} {{schema:0 sum:1 count:1 buckets:[1] counter_reset_hint:reset}}
+  hhffmixed {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:0 sum:2 count:2 buckets:[2]}} 5 2 3
 
 
 eval instant at 3m resets(ftohmixed[1m] anchored)
@@ -752,6 +753,9 @@ eval instant at 3m resets(honlywithreset[1m] anchored)
 
 eval instant at 3m resets(hhffmixed[1m] anchored)
     {} 1
+
+eval instant at 4m resets(hhffmixed[1m] anchored)
+    {} 0
 
 eval instant at 3m changes(ftohmixed[1m] anchored)
     {} 1


### PR DESCRIPTION
This PR fixes an issue with the recently added handling of histograms in anchored range extensions.

The issue was with the handling of anchored for `resets()`/`changes()` over series that contain native histograms.
  
Anchored selection picks the anchor (last sample with `T <= rangeStart`) from a window extended below `rangeStart`, then counts resets/changes from that anchor through the samples in `(rangeStart, rangeEnd]`. 

Two issues in `pickFirstSampleIndex` broke this when histograms were involved:

1. **Empty result.** The "are there samples in range" check inspected only the float slice, so a window whose post-`rangeStart` samples were histograms reported "not found" and returned nothing.

2. **Over-counting.** The merge loop always started the histogram cursor at index 0, so histograms *before* the anchor were counted too.

Consider this test case which illustrates the expected result. Previously this mixed case would have returned no result.

```
load 1m
  mixed 1 2 3 {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
  same 2 1 2 1
  
  eval instant at 3m resets(mixed[1m] anchored)
     {} 1

  eval instant at 3m resets(same[1m] anchored)
     {} 1
```


The window range should be (2m, 3m] - with the anchor point being selected from points with T <= 2m.

This should select the float point at T=2m. At which point the range for the resets() should be the T=2m float and T=3m histogram.

The fix replaces `pickFirstSampleIndex` with `pickFirstSampleIndices`, which selects the anchor across both floats and histograms and returns the start index for each; `funcResets`/`funcChanges` now begin the histogram cursor at the anchor. 

Float-only behaviour is unchanged. 

#### Which issue(s) does the PR fix:

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] PromQL: Fix for resets() and changes() in anchored range extenders with histograms.
```
