### PR TITLE
tsdb: preserve WAL replay accounting and ordering after full deletion

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -150,6 +150,8 @@ type Head struct {
 
 	memTruncationInProcess atomic.Bool
 	memTruncationCallBack  func() // For testing purposes.
+
+	walReplayExemplarDrainHook func(<-chan struct{}) // For testing purposes.
 }
 
 type ExemplarStorage interface {
@@ -262,6 +264,8 @@ func (o *HeadOptions) UseXOR2FloatEncoding() bool {
 // SeriesLifecycleCallback specifies a list of callbacks that will be called during a lifecycle of a series.
 // It is always a no-op in Prometheus and mainly meant for external users who import TSDB.
 // All the callbacks should be safe to be called concurrently.
+// During WAL replay, callbacks for a label set are invoked in lifecycle order.
+// Callbacks must not wait for a later WAL replay lifecycle callback.
 // It is up to the user to implement soft or hard consistency by making the callbacks
 // atomic or non-atomic. Atomic callbacks can cause degradation performance.
 type SeriesLifecycleCallback interface {
@@ -2323,9 +2327,11 @@ func (h *Head) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict 
 	return deleted
 }
 
-// deleteSeriesByID deletes the series with the given reference.
+// deleteSeriesByID deletes the series with the given reference and returns the
+// payload for the lifecycle callback. The caller must invoke PostDeletion before
+// completing the associated replay-deletion barrier.
 // Only used for WAL replay.
-func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
+func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) map[chunks.HeadSeriesRef]labels.Labels {
 	var (
 		deleted            = map[storage.SeriesRef]struct{}{}
 		deletedForCallback = map[chunks.HeadSeriesRef]labels.Labels{}
@@ -2406,9 +2412,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 	// Remove tombstones referring to the deleted series.
 	h.tombstones.DeleteTombstones(deleted)
 
-	if len(deletedForCallback) > 0 {
-		h.series.seriesLifecycleCallback.PostDeletion(deletedForCallback)
-	}
+	return deletedForCallback
 }
 
 // gcSeries walks all series and removes those whose ref is in seriesRefs, whose maxTime is

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2372,13 +2372,22 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		if series.headChunks != nil {
 			chunksRemoved += series.headChunks.len()
 		}
+		if series.ooo != nil {
+			chunksRemoved += len(series.ooo.oooMmappedChunks)
+			if series.ooo.oooHeadChunk != nil {
+				chunksRemoved++
+			}
+		}
 		if series.headChunkCount.Load() >= 2 {
 			h.series.decMmapReady(series.ref)
 		}
-		// Clear to prevent a double-subtraction from the chunksRemoved gauge if
-		// resetSeriesWithMMappedChunks is queued on the same WAL-replay processor
-		// after this deletion (it would otherwise subtract len(mmappedChunks) again).
+		// Release all chunk data and keep the head-chunk list and count in sync.
+		// A stale reference may remain queued on this WAL-replay processor after
+		// the series has been removed from the lookup maps.
 		series.mmappedChunks = nil
+		series.setHeadChunks(nil, 0)
+		series.app = nil
+		series.ooo = nil
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		deletedForCallback[series.ref] = series.lset

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -159,6 +159,8 @@ type Head struct {
 	// testAfterSeriesLookup is invoked after getByID in appenders, before the
 	// series is locked. Tests use it to race GC against a resolved pointer.
 	testAfterSeriesLookup func(*memSeries)
+
+	walReplayExemplarDrainHook func(<-chan struct{}) // For testing purposes.
 }
 
 type ExemplarStorage interface {
@@ -271,6 +273,8 @@ func (o *HeadOptions) UseXOR2FloatEncoding() bool {
 // SeriesLifecycleCallback specifies a list of callbacks that will be called during a lifecycle of a series.
 // It is always a no-op in Prometheus and mainly meant for external users who import TSDB.
 // All the callbacks should be safe to be called concurrently.
+// During WAL replay, callbacks for a label set are invoked in lifecycle order.
+// Callbacks must not wait for a later WAL replay lifecycle callback.
 // It is up to the user to implement soft or hard consistency by making the callbacks
 // atomic or non-atomic. Atomic callbacks can cause degradation performance.
 type SeriesLifecycleCallback interface {
@@ -2447,9 +2451,11 @@ func (h *Head) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict 
 	return deleted
 }
 
-// deleteSeriesByID deletes the series with the given reference.
+// deleteSeriesByID deletes the series with the given reference and returns the
+// payload for the lifecycle callback. The caller must invoke PostDeletion before
+// completing the associated replay-deletion barrier.
 // Only used for WAL replay.
-func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
+func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) map[chunks.HeadSeriesRef]labels.Labels {
 	var (
 		deleted                 = map[storage.SeriesRef]struct{}{}
 		deletedForCallback      = map[chunks.HeadSeriesRef]labels.Labels{}
@@ -2536,9 +2542,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 	// Remove tombstones referring to the deleted series.
 	h.tombstones.DeleteTombstones(deleted)
 
-	if len(deletedForCallback) > 0 {
-		h.series.seriesLifecycleCallback.PostDeletion(deletedForCallback)
-	}
+	return deletedForCallback
 }
 
 // gcSeries walks all series and removes those whose ref is in seriesRefs, whose maxTime is

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2500,13 +2500,22 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		headChunkCount := series.headChunkCount.Load()
 		chunksRemoved += len(series.mmappedChunks)
 		chunksRemoved += int(headChunkCount)
+		if series.ooo != nil {
+			chunksRemoved += len(series.ooo.oooMmappedChunks)
+			if series.ooo.oooHeadChunk != nil {
+				chunksRemoved++
+			}
+		}
 		if headChunkCount >= 2 {
 			h.series.decMmapReady(series.ref)
 		}
-		// Clear to prevent a double-subtraction from the chunksRemoved gauge if
-		// resetSeriesWithMMappedChunks is queued on the same WAL-replay processor
-		// after this deletion (it would otherwise subtract len(mmappedChunks) again).
+		// Release all chunk data and keep the head-chunk list and count in sync.
+		// A stale reference may remain queued on this WAL-replay processor after
+		// the series has been removed from the lookup maps.
 		series.mmappedChunks = nil
+		series.setHeadChunks(nil, 0)
+		series.app = nil
+		series.ooo = nil
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		deletedForCallback[series.ref] = series.lset

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -980,8 +980,8 @@ func TestHead_WALMultiRef(t *testing.T) {
 	}}, series)
 }
 
-// TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative is a regression test
-// for https://github.com/prometheus/prometheus/issues/10884.
+// TestHead_WALMultiRef_StaleDeletion_RecreatedSeriesSurvives is a regression
+// test for https://github.com/prometheus/prometheus/issues/10884.
 //
 // When a stale series is deleted via truncateStaleSeries (which writes a
 // [MinInt64, MaxInt64] tombstone to the WAL) and then re-created under the same
@@ -992,11 +992,10 @@ func TestHead_WALMultiRef(t *testing.T) {
 //	deleteSeriesByID(oldRef)           ← removes chunks from gauge
 //	reset(mSeries, newRef_chunks, newRef) ← was double-subtracting old chunks
 //
-// Without the fix, deleteSeriesByID removes M chunks from the gauge but leaves
-// series.mmappedChunks non-nil. The subsequent reset then subtracts those M
-// chunks a second time, driving prometheus_tsdb_head_chunks negative when M
-// exceeds the new series' chunk count.
-func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
+// Without deletion ordering, the new series record can resolve to the old
+// object before its queued deletion is applied. The deletion then removes the
+// object, drops the new series' samples, and corrupts chunk accounting.
+func TestHead_WALMultiRef_StaleDeletion_RecreatedSeriesSurvives(t *testing.T) {
 	head, w := newTestHead(t, 1000, compression.None, false)
 	require.NoError(t, head.Init(0))
 
@@ -1022,16 +1021,24 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 	// [MinInt64, MaxInt64] tombstone record to the WAL.
 	require.NoError(t, head.truncateStaleSeries([]storage.SeriesRef{ref1}, 3500, math.MaxUint64))
 
-	// Append a single sample with the same labels to create ref2.
-	// Ref2 has 0 m-mapped chunks, fewer than ref1's 3.
+	// Re-create the series and produce both m-mapped and active head chunks.
 	ref2 := appendSample(5000, 5)
+	appendSample(6200, 6)
+	appendSample(7300, 7)
+	appendSample(8400, 8)
 	require.NotEqual(t, ref1, ref2, "refs must differ after stale truncation and recreation")
+	head.mmapHeadChunks()
+	ref2Series := head.series.getByID(chunks.HeadSeriesRef(ref2))
+	require.NotNil(t, ref2Series)
+	require.Len(t, ref2Series.mmappedChunks, 3, "test needs real m-mapped chunks on the re-created series")
+	require.NotNil(t, ref2Series.headChunks)
 
 	require.NoError(t, head.Close())
 
 	// Reopen the head to trigger WAL replay. The WAL contains (in order):
-	//   series(ref1) → tombstone(ref1, [MinInt64,MaxInt64]) → series(ref2) → sample(ref2)
-	// Without the fix, replay drives prometheus_tsdb_head_chunks negative.
+	//   series(ref1) → tombstone(ref1, [MinInt64,MaxInt64]) → series(ref2) → samples(ref2)
+	// The deletion must complete before ref2 is resolved so its samples and
+	// m-mapped chunks are attached to a live series object.
 	w, err := wlog.New(nil, nil, w.Dir(), compression.None)
 	require.NoError(t, err)
 	opts := DefaultHeadOptions()
@@ -1044,8 +1051,656 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 		require.NoError(t, head.Close())
 	}()
 
-	chunksGauge := prom_testutil.ToFloat64(head.metrics.chunks)
-	require.GreaterOrEqual(t, chunksGauge, 0.0, "prometheus_tsdb_head_chunks gauge must not be negative after WAL replay")
+	require.Equal(t, 1, int(head.NumSeries()))
+	q, err := NewBlockQuerier(head, 5000, 8400)
+	require.NoError(t, err)
+	series := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+	require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: {
+		sample{0, 5000, 5, nil, nil},
+		sample{0, 6200, 6, nil, nil},
+		sample{0, 7300, 7, nil, nil},
+		sample{0, 8400, 8, nil, nil},
+	}}, series)
+	require.Equal(t, 4.0, prom_testutil.ToFloat64(head.metrics.chunks),
+		"the chunk gauge must count only the re-created series' three m-mapped chunks and active head chunk")
+}
+
+func TestHead_WALReplayFullDeletionOrdering(t *testing.T) {
+	fullTombstone := func(ref storage.SeriesRef) tombstones.Stone {
+		return tombstones.Stone{Ref: ref, Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}}
+	}
+
+	type testCase struct {
+		name     string
+		records  []any
+		expected map[string][]chunks.Sample
+	}
+	testCases := []testCase{
+		{
+			name: "duplicate series record after recreation",
+			records: []any{
+				[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 1, T: 10, V: 1}, {Ref: 1, T: 20, V: 2}},
+				[]tombstones.Stone{fullTombstone(1)},
+				[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSeries{{Ref: 3, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 3, T: 30, V: 3}},
+			},
+			expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+		},
+		{
+			name: "tombstone for duplicate series reference",
+			records: []any{
+				[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 2, T: 10, V: 1}},
+				[]tombstones.Stone{fullTombstone(2)},
+				[]record.RefSeries{{Ref: 3, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 3, T: 30, V: 3}},
+			},
+			expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+		},
+		{
+			name: "repeated and absent tombstones",
+			records: []any{
+				[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 1, T: 10, V: 1}},
+				[]tombstones.Stone{fullTombstone(1)},
+				[]tombstones.Stone{fullTombstone(1), fullTombstone(99)},
+				[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+				[]record.RefSample{{Ref: 2, T: 30, V: 3}},
+			},
+			expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+		},
+		{
+			name: "deletions across processor shards",
+			records: []any{
+				[]record.RefSeries{
+					{Ref: 1, Labels: labels.FromStrings("foo", "a")},
+					{Ref: 2, Labels: labels.FromStrings("foo", "b")},
+				},
+				[]record.RefSample{{Ref: 1, T: 10, V: 1}, {Ref: 2, T: 10, V: 2}},
+				[]tombstones.Stone{fullTombstone(1), fullTombstone(2)},
+				[]record.RefSeries{
+					{Ref: 3, Labels: labels.FromStrings("foo", "a")},
+					{Ref: 4, Labels: labels.FromStrings("foo", "b")},
+				},
+				[]record.RefSample{{Ref: 3, T: 30, V: 3}, {Ref: 4, T: 30, V: 4}},
+			},
+			expected: map[string][]chunks.Sample{
+				`{foo="a"}`: {sample{0, 30, 3, nil, nil}},
+				`{foo="b"}`: {sample{0, 30, 4, nil, nil}},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, concurrency := range []int{1, defaultWALReplayConcurrency} {
+				t.Run(fmt.Sprintf("concurrency=%d", concurrency), func(t *testing.T) {
+					dir := t.TempDir()
+					wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+					require.NoError(t, err)
+					populateTestWL(t, wal, tc.records, nil, false)
+
+					opts := DefaultHeadOptions()
+					opts.ChunkRange = 1000
+					opts.ChunkDirRoot = dir
+					opts.WALReplayConcurrency = concurrency
+					head, err := NewHead(nil, nil, wal, nil, opts, nil)
+					require.NoError(t, err)
+					require.NoError(t, head.Init(0))
+
+					require.Equal(t, len(tc.expected), int(head.NumSeries()))
+					q, err := NewBlockQuerier(head, 0, 100)
+					require.NoError(t, err)
+					actual := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", ".+"))
+					require.Equal(t, tc.expected, actual)
+					for _, recordType := range []string{"series", "samples", "exemplars", "histograms", "metadata", "tombstones"} {
+						require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.walReplayUnknownRefsTotal.WithLabelValues(recordType)),
+							"valid replay must not report unknown %s references", recordType)
+					}
+					require.NoError(t, head.Close())
+				})
+			}
+		})
+	}
+}
+
+type coordinatedReplayLifecycleCallback struct {
+	mtx          sync.Mutex
+	preCreations int
+	creations    int
+	deletions    int
+	preCreation  func(labels.Labels, int)
+	postCreation func(labels.Labels, int)
+	postDeletion func(map[chunks.HeadSeriesRef]labels.Labels)
+}
+
+func (c *coordinatedReplayLifecycleCallback) PreCreation(lset labels.Labels) error {
+	c.mtx.Lock()
+	c.preCreations++
+	preCreations := c.preCreations
+	preCreation := c.preCreation
+	c.mtx.Unlock()
+	if preCreation != nil {
+		preCreation(lset, preCreations)
+	}
+	return nil
+}
+
+func (c *coordinatedReplayLifecycleCallback) PostCreation(lset labels.Labels) {
+	c.mtx.Lock()
+	c.creations++
+	creations := c.creations
+	postCreation := c.postCreation
+	c.mtx.Unlock()
+	if postCreation != nil {
+		postCreation(lset, creations)
+	}
+}
+
+func (c *coordinatedReplayLifecycleCallback) PostDeletion(deleted map[chunks.HeadSeriesRef]labels.Labels) {
+	if len(deleted) == 0 {
+		return
+	}
+	c.mtx.Lock()
+	c.deletions++
+	postDeletion := c.postDeletion
+	c.mtx.Unlock()
+	if postDeletion != nil {
+		postDeletion(deleted)
+	}
+}
+
+func (c *coordinatedReplayLifecycleCallback) counts() (int, int, int) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.preCreations, c.creations, c.deletions
+}
+
+func TestWALReplayPendingDeletions(t *testing.T) {
+	registry := newWALReplayPendingDeletions()
+	firstLabels := labels.FromStrings("series", "first")
+	secondLabels := labels.FromStrings("series", "second")
+	const collidingHash = 1
+
+	firstBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	secondBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	registry.add(collidingHash, firstLabels, firstBarrier)
+	registry.add(collidingHash, secondLabels, secondBarrier)
+
+	firstBarrier.complete()
+	registry.wait(collidingHash, firstLabels)
+	registry.mtx.Lock()
+	bucket := registry.byHash[collidingHash]
+	registry.mtx.Unlock()
+	require.Equal(t, walReplayPendingDeletion{lset: secondLabels, barrier: secondBarrier}, bucket.entry)
+	require.Empty(t, bucket.collisions)
+
+	replacementBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	registry.add(collidingHash, secondLabels, replacementBarrier)
+	secondBarrier.complete()
+	registry.mtx.Lock()
+	bucket = registry.byHash[collidingHash]
+	registry.mtx.Unlock()
+	require.Equal(t, walReplayPendingDeletion{lset: secondLabels, barrier: replacementBarrier}, bucket.entry,
+		"completing an older barrier must not remove its replacement")
+	require.Empty(t, bucket.collisions)
+
+	replacementBarrier.complete()
+	registry.wait(collidingHash, secondLabels)
+	registry.mtx.Lock()
+	require.Empty(t, registry.byHash)
+	registry.mtx.Unlock()
+}
+
+type gatedReplayExemplarStorage struct {
+	ExemplarStorage
+	timestamp int64
+	entered   chan struct{}
+	release   chan struct{}
+	once      sync.Once
+}
+
+func (s *gatedReplayExemplarStorage) AddExemplar(lset labels.Labels, e exemplar.Exemplar) error {
+	if e.Ts == s.timestamp {
+		s.once.Do(func() { close(s.entered) })
+		<-s.release
+	}
+	return s.ExemplarStorage.AddExemplar(lset, e)
+}
+
+func TestHead_WALReplayFullDeletionDrainsEarlierExemplars(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+	require.NoError(t, err)
+	lset := labels.FromStrings("foo", "bar")
+	populateTestWL(t, wal, []any{
+		[]record.RefSeries{{Ref: 1, Labels: lset}},
+		[]record.RefExemplar{{Ref: 1, T: 10, V: 1, Labels: labels.FromStrings("trace_id", "old")}},
+		[]tombstones.Stone{{Ref: 1, Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}}},
+		[]record.RefSeries{{Ref: 2, Labels: lset}},
+		[]record.RefExemplar{{Ref: 2, T: 20, V: 2, Labels: labels.FromStrings("trace_id", "new")}},
+	}, nil, false)
+
+	callback := &coordinatedReplayLifecycleCallback{}
+	deletionStarted := make(chan struct{})
+	var signalDeletion sync.Once
+	callback.postDeletion = func(map[chunks.HeadSeriesRef]labels.Labels) {
+		signalDeletion.Do(func() { close(deletionStarted) })
+	}
+	opts := DefaultHeadOptions()
+	opts.ChunkDirRoot = dir
+	opts.WALReplayConcurrency = 1
+	opts.EnableExemplarStorage = true
+	opts.MaxExemplars.Store(config.DefaultExemplarsConfig.MaxExemplars)
+	opts.SeriesCallback = callback
+	head, err := NewHead(nil, nil, wal, nil, opts, nil)
+	require.NoError(t, err)
+
+	exemplarEntered := make(chan struct{})
+	allowExemplar := make(chan struct{})
+	var releaseExemplar sync.Once
+	release := func() { releaseExemplar.Do(func() { close(allowExemplar) }) }
+	t.Cleanup(release)
+	head.exemplars = &gatedReplayExemplarStorage{
+		ExemplarStorage: head.exemplars,
+		timestamp:       10,
+		entered:         exemplarEntered,
+		release:         allowExemplar,
+	}
+	drainHookEntered := make(chan (<-chan struct{}), 1)
+	allowDrainHook := make(chan struct{})
+	var releaseDrainHook sync.Once
+	releaseHook := func() { releaseDrainHook.Do(func() { close(allowDrainHook) }) }
+	t.Cleanup(releaseHook)
+	head.walReplayExemplarDrainHook = func(done <-chan struct{}) {
+		drainHookEntered <- done
+		<-allowDrainHook
+	}
+
+	initDone := make(chan error, 1)
+	go func() {
+		initDone <- head.Init(0)
+	}()
+
+	select {
+	case <-exemplarEntered:
+	case <-time.After(10 * time.Second):
+		releaseHook()
+		release()
+		initErr := <-initDone
+		require.NoError(t, initErr)
+		require.NoError(t, head.Close())
+		require.FailNow(t, "timed out waiting for the earlier exemplar")
+	}
+	var exemplarDrainDone <-chan struct{}
+	select {
+	case exemplarDrainDone = <-drainHookEntered:
+	case <-time.After(10 * time.Second):
+		releaseHook()
+		release()
+		initErr := <-initDone
+		require.NoError(t, initErr)
+		require.NoError(t, head.Close())
+		require.FailNow(t, "timed out waiting for the exemplar drain marker")
+	}
+	select {
+	case <-exemplarDrainDone:
+		require.Fail(t, "the drain marker completed before the earlier exemplar")
+	default:
+	}
+	select {
+	case <-deletionStarted:
+		require.Fail(t, "deletion started before the earlier exemplar was drained")
+	default:
+	}
+
+	releaseHook()
+	release()
+	require.NoError(t, <-initDone)
+	var exemplarTimestamps []int64
+	require.NoError(t, head.exemplars.IterateExemplars(func(_ labels.Labels, e exemplar.Exemplar) error {
+		exemplarTimestamps = append(exemplarTimestamps, e.Ts)
+		return nil
+	}))
+	require.Equal(t, []int64{10, 20}, exemplarTimestamps)
+	require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.walReplayUnknownRefsTotal.WithLabelValues("exemplars")))
+	require.NoError(t, head.Close())
+}
+
+func TestHead_WALReplayFullDeletionWaitsOnlyForMatchingSeries(t *testing.T) {
+	const stripeSize = 32
+	for _, blockedRef := range []chunks.HeadSeriesRef{1, 2} {
+		t.Run(fmt.Sprintf("blocked_ref=%d", blockedRef), func(t *testing.T) {
+			refStripe := int(blockedRef) & (stripeSize - 1)
+			labelOutsideStripe := func(value string, stripe int) labels.Labels {
+				for i := 0; ; i++ {
+					lset := labels.FromStrings("series", fmt.Sprintf("%s-%d", value, i))
+					if int(lset.Hash()&uint64(stripeSize-1)) != stripe {
+						return lset
+					}
+				}
+			}
+
+			dir := t.TempDir()
+			wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+			require.NoError(t, err)
+			oldLabels := labelOutsideStripe("old", refStripe)
+			blockedHashStripe := int(oldLabels.Hash() & uint64(stripeSize-1))
+			unrelatedLabels := labelOutsideStripe("unrelated", blockedHashStripe)
+			unrelatedRef := chunks.HeadSeriesRef(3)
+			for int(unrelatedRef)&(stripeSize-1) == blockedHashStripe || unrelatedRef == blockedRef {
+				unrelatedRef++
+			}
+			replacementRef := unrelatedRef + 1
+			for replacementRef == blockedRef {
+				replacementRef++
+			}
+			populateTestWL(t, wal, []any{
+				[]record.RefSeries{{Ref: blockedRef, Labels: oldLabels}},
+				[]record.RefSample{{Ref: blockedRef, T: 10, V: 1}},
+				[]tombstones.Stone{{Ref: storage.SeriesRef(blockedRef), Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}}},
+				[]record.RefSeries{{Ref: unrelatedRef, Labels: unrelatedLabels}},
+				[]record.RefSeries{{Ref: replacementRef, Labels: oldLabels}},
+				[]record.RefSample{{Ref: unrelatedRef, T: 20, V: 2}, {Ref: replacementRef, T: 30, V: 3}},
+			}, nil, false)
+
+			callback := &coordinatedReplayLifecycleCallback{}
+			initialSeriesCreated := make(chan struct{})
+			allowReplay := make(chan struct{})
+			unrelatedPreCreation := make(chan struct{})
+			unrelatedPostCreation := make(chan struct{})
+			replacementPreCreation := make(chan struct{})
+			replacementPostCreation := make(chan struct{})
+			deletionStarted := make(chan struct{})
+			allowDeletion := make(chan struct{})
+			var signalInitialCreation, releaseCreation, signalUnrelatedPre, signalUnrelatedPost sync.Once
+			var signalReplacementPre, signalReplacementPost, signalDeletion, releaseDeletion sync.Once
+			releaseReplay := func() { releaseCreation.Do(func() { close(allowReplay) }) }
+			releaseDeletionCallback := func() { releaseDeletion.Do(func() { close(allowDeletion) }) }
+			t.Cleanup(func() {
+				releaseReplay()
+				releaseDeletionCallback()
+			})
+			oldPreCreations := 0
+			callback.preCreation = func(lset labels.Labels, _ int) {
+				switch {
+				case labels.Equal(lset, oldLabels):
+					oldPreCreations++
+					if oldPreCreations == 2 {
+						signalReplacementPre.Do(func() { close(replacementPreCreation) })
+					}
+				case labels.Equal(lset, unrelatedLabels):
+					signalUnrelatedPre.Do(func() { close(unrelatedPreCreation) })
+				}
+			}
+			oldPostCreations := 0
+			callback.postCreation = func(lset labels.Labels, _ int) {
+				switch {
+				case labels.Equal(lset, oldLabels):
+					oldPostCreations++
+					if oldPostCreations == 1 {
+						signalInitialCreation.Do(func() { close(initialSeriesCreated) })
+						<-allowReplay
+					} else {
+						signalReplacementPost.Do(func() { close(replacementPostCreation) })
+					}
+				case labels.Equal(lset, unrelatedLabels):
+					signalUnrelatedPost.Do(func() { close(unrelatedPostCreation) })
+				}
+			}
+			callback.postDeletion = func(deleted map[chunks.HeadSeriesRef]labels.Labels) {
+				if _, ok := deleted[blockedRef]; ok {
+					signalDeletion.Do(func() { close(deletionStarted) })
+					<-allowDeletion
+				}
+			}
+
+			opts := DefaultHeadOptions()
+			opts.ChunkDirRoot = dir
+			opts.StripeSize = stripeSize
+			opts.WALReplayConcurrency = 2
+			opts.SeriesCallback = callback
+			head, err := NewHead(nil, nil, wal, nil, opts, nil)
+			require.NoError(t, err)
+
+			initDone := make(chan error, 1)
+			go func() {
+				initDone <- head.Init(0)
+			}()
+
+			select {
+			case <-initialSeriesCreated:
+			case <-time.After(10 * time.Second):
+				releaseReplay()
+				releaseDeletionCallback()
+				initErr := <-initDone
+				require.NoError(t, initErr)
+				require.NoError(t, head.Close())
+				require.FailNow(t, "timed out waiting for the initial series")
+			}
+
+			releaseReplay()
+
+			select {
+			case <-unrelatedPreCreation:
+			case <-time.After(10 * time.Second):
+				releaseDeletionCallback()
+				initErr := <-initDone
+				require.NoError(t, initErr)
+				require.NoError(t, head.Close())
+				require.FailNow(t, "timed out waiting for unrelated PreCreation")
+			}
+			select {
+			case <-unrelatedPostCreation:
+			case <-time.After(10 * time.Second):
+				releaseDeletionCallback()
+				initErr := <-initDone
+				require.NoError(t, initErr)
+				require.NoError(t, head.Close())
+				require.FailNow(t, "timed out waiting for unrelated PostCreation")
+			}
+			select {
+			case <-replacementPreCreation:
+				require.Fail(t, "replacement PreCreation ran before the matching deletion")
+			default:
+			}
+			select {
+			case <-replacementPostCreation:
+				require.Fail(t, "replacement PostCreation ran before the matching deletion")
+			default:
+			}
+
+			select {
+			case <-deletionStarted:
+			case <-time.After(10 * time.Second):
+				releaseDeletionCallback()
+				initErr := <-initDone
+				require.NoError(t, initErr)
+				require.NoError(t, head.Close())
+				require.FailNow(t, "timed out waiting for PostDeletion")
+			}
+			select {
+			case <-replacementPreCreation:
+				require.Fail(t, "replacement PreCreation ran before PostDeletion returned")
+			default:
+			}
+			select {
+			case <-replacementPostCreation:
+				require.Fail(t, "replacement PostCreation ran before PostDeletion returned")
+			default:
+			}
+
+			releaseDeletionCallback()
+			require.NoError(t, <-initDone)
+			preCreations, creations, deletions := callback.counts()
+			require.Equal(t, 3, preCreations)
+			require.Equal(t, 3, creations)
+			require.Equal(t, 1, deletions)
+			require.Equal(t, uint64(2), head.NumSeries())
+			q, err := NewBlockQuerier(head, 0, 100)
+			require.NoError(t, err)
+			actual := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "series", ".+"))
+			require.Equal(t, map[string][]chunks.Sample{
+				oldLabels.String():       {sample{0, 30, 3, nil, nil}},
+				unrelatedLabels.String(): {sample{0, 20, 2, nil, nil}},
+			}, actual)
+			require.NoError(t, head.Close())
+		})
+	}
+}
+
+func TestHead_WALReplayFullDeletionPreservesWBLData(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+	require.NoError(t, err)
+	wbl, err := wlog.New(nil, nil, filepath.Join(dir, wlog.WblDirName), compression.None)
+	require.NoError(t, err)
+	lset := labels.FromStrings("foo", "bar")
+	populateTestWL(t, wal, []any{
+		[]record.RefSeries{{Ref: 1, Labels: lset}},
+		[]record.RefSample{{Ref: 1, T: 10, V: 1}},
+		[]tombstones.Stone{{Ref: 1, Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}}},
+		[]record.RefSeries{{Ref: 2, Labels: lset}},
+		[]record.RefSample{{Ref: 2, T: 100, V: 2}},
+	}, nil, false)
+	populateTestWL(t, wbl, []any{
+		[]record.RefSample{{Ref: 2, T: 50, V: 3}},
+	}, nil, false)
+	require.NoError(t, wal.Close())
+	require.NoError(t, wbl.Close())
+	wal, err = wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+	require.NoError(t, err)
+	wbl, err = wlog.New(nil, nil, filepath.Join(dir, wlog.WblDirName), compression.None)
+	require.NoError(t, err)
+
+	opts := DefaultHeadOptions()
+	opts.ChunkDirRoot = dir
+	opts.OutOfOrderTimeWindow.Store(10 * time.Minute.Milliseconds())
+	head, err := NewHead(nil, nil, wal, wbl, opts, nil)
+	require.NoError(t, err)
+	require.NoError(t, head.Init(0))
+
+	q, err := NewBlockQuerier(head, 0, 200)
+	require.NoError(t, err)
+	actual := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+	require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: {
+		sample{0, 100, 2, nil, nil},
+	}}, actual)
+
+	ms := head.series.getByID(2)
+	require.NotNil(t, ms)
+	require.NotNil(t, ms.ooo)
+	require.NotNil(t, ms.ooo.oooHeadChunk)
+	oooChunks, err := ms.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, false, false)
+	require.NoError(t, err)
+	require.Len(t, oooChunks, 1)
+	oooSamples, err := storage.ExpandSamples(oooChunks[0].chunk.Iterator(nil), nil)
+	require.NoError(t, err)
+	requireEqualSamples(t, lset.String(), []chunks.Sample{sample{0, 50, 3, nil, nil}}, oooSamples)
+	require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.wblReplayUnknownRefsTotal.WithLabelValues("samples")))
+	require.NoError(t, head.Close())
+}
+
+func BenchmarkHeadWALReplayFullDeletion(b *testing.B) {
+	const (
+		generations         = 6
+		seriesPerGeneration = 1000
+	)
+	cases := []struct {
+		name                string
+		fullDeletionRecords int
+		recreate            bool
+	}{
+		{name: "none"},
+		{name: "unrelated/one", fullDeletionRecords: 1},
+		{name: "unrelated/repeated", fullDeletionRecords: 5},
+		{name: "recreated/one", fullDeletionRecords: 1, recreate: true},
+		{name: "recreated/repeated", fullDeletionRecords: 5, recreate: true},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			walDir := b.TempDir()
+			wal, err := wlog.New(nil, nil, walDir, compression.None)
+			require.NoError(b, err)
+
+			var buf []byte
+			for generation := range generations {
+				series := make([]record.RefSeries, 0, seriesPerGeneration)
+				samples := make([]record.RefSample, 0, seriesPerGeneration)
+				tombstonesForGeneration := make([]tombstones.Stone, 0, seriesPerGeneration)
+				for i := range seriesPerGeneration {
+					ref := chunks.HeadSeriesRef(generation*seriesPerGeneration + i + 1)
+					lset := labels.FromStrings(
+						"__name__", "wal_replay_benchmark",
+						"series", strconv.Itoa(i),
+					)
+					if !tc.recreate {
+						lset = labels.FromStrings(
+							"__name__", "wal_replay_benchmark",
+							"generation", strconv.Itoa(generation),
+							"series", strconv.Itoa(i),
+						)
+					}
+					series = append(series, record.RefSeries{
+						Ref:    ref,
+						Labels: lset,
+					})
+					samples = append(samples, record.RefSample{Ref: ref, T: int64(generation), V: float64(generation)})
+					tombstonesForGeneration = append(tombstonesForGeneration, tombstones.Stone{
+						Ref: storage.SeriesRef(ref),
+						Intervals: tombstones.Intervals{{
+							Mint: math.MinInt64,
+							Maxt: math.MaxInt64,
+						}},
+					})
+				}
+				buf = populateTestWL(b, wal, []any{series, samples}, buf, false)
+				if generation < tc.fullDeletionRecords {
+					buf = populateTestWL(b, wal, []any{tombstonesForGeneration}, buf, false)
+				}
+			}
+			require.NoError(b, wal.Close())
+
+			for _, concurrency := range []int{1, defaultWALReplayConcurrency} {
+				b.Run(fmt.Sprintf("concurrency=%d", concurrency), func(b *testing.B) {
+					chunkDirRoot := b.TempDir()
+					b.ReportAllocs()
+					for b.Loop() {
+						b.StopTimer()
+						segmentsReader, err := wlog.NewSegmentsReader(walDir)
+						require.NoError(b, err)
+						opts := DefaultHeadOptions()
+						opts.ChunkDirRoot = chunkDirRoot
+						opts.WALReplayConcurrency = concurrency
+						head, err := NewHead(nil, nil, nil, nil, opts, nil)
+						require.NoError(b, err)
+
+						b.StartTimer()
+						err = head.loadWAL(
+							wlog.NewReader(segmentsReader),
+							labels.NewSymbolTable(),
+							map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{},
+							nil,
+							nil,
+						)
+						b.StopTimer()
+						require.NoError(b, err)
+						expectedSeries := uint64((generations - tc.fullDeletionRecords) * seriesPerGeneration)
+						if tc.recreate {
+							expectedSeries = seriesPerGeneration
+						}
+						require.Equal(b, expectedSeries, head.NumSeries())
+						require.NoError(b, segmentsReader.Close())
+						require.NoError(b, head.Close())
+						b.StartTimer()
+					}
+				})
+			}
+		})
+	}
 }
 
 func TestHead_WALCheckpointMultiRef(t *testing.T) {
@@ -8905,15 +9560,12 @@ func TestFloatChunkEncodingSwitchWaitsForNextChunk(t *testing.T) {
 	})
 }
 
-// TestWALReplayRaceWithStaleSeriesCompaction verifies that deleteSeriesByID correctly locks the
-// hash shard (not only the ref shard) when deleting from the hashes map.
-// The race only occurs when Prometheus restarts after having done a stale series compaction because
-// deleteSeriesByID is not used otherwise.
-func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
+// TestWALReplayFullDeletionBeforeLaterSeriesCreation verifies that replayed
+// full deletions complete before later series records and samples are handled.
+func TestWALReplayFullDeletionBeforeLaterSeriesCreation(t *testing.T) {
 	opts := newTestHeadDefaultOptions(1000, false)
-	// A small stripe size ensures many series share hash shards, increasing
-	// the likelihood that deleteSeriesByID and getOrCreateWithOptionalID
-	// contend on the same shard during WAL replay.
+	// A small stripe size makes the test cover many ref and hash shard
+	// collisions while replaying a large deletion batch.
 	opts.StripeSize = 32
 	head, _ := newTestHeadWithOptions(t, compression.None, opts)
 	require.NoError(t, head.Init(0))
@@ -8949,12 +9601,9 @@ func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
 	require.Equal(t, uint64(0), head.NumStaleSeries())
 	require.Equal(t, uint64(0), head.NumSeries())
 
-	// Step 3: Add new series AFTER the truncation. In the WAL, these series
-	// records appear after the tombstone records. During replay, the main
-	// goroutine will create these series (via getOrCreateWithOptionalID, which
-	// accesses hashes[hashShard] under locks[hashShard]) concurrently with
-	// the walSubsetProcessor goroutines deleting the stale series (via
-	// deleteSeriesByID, which must also lock the correct hashShard).
+	// Step 3: Add new series after the truncation. In the WAL, these series
+	// records and samples appear after the tombstone records and must not be
+	// overtaken by the queued full deletions.
 	const numNewSeries = 500
 	for i := range numNewSeries {
 		lbl := labels.FromStrings("__name__", "new_metric", "i", strconv.Itoa(i))
@@ -8963,19 +9612,24 @@ func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
 	require.Equal(t, uint64(numNewSeries), head.NumSeries())
 
 	// Step 4: Close and re-open the Head to trigger WAL replay.
-	// With the buggy locking, the race detector should catch the data race
-	// between the main goroutine (creating series) and worker goroutines
-	// (deleting stale series) during replay.
 	require.NoError(t, head.Close())
 
 	wal, err := wlog.NewSize(nil, nil, filepath.Join(head.opts.ChunkDirRoot, "wal"), 32768, compression.None)
 	require.NoError(t, err)
 	head, err = NewHead(nil, nil, wal, nil, head.opts, nil)
 	require.NoError(t, err)
-	require.NoError(t, head.Init(0)) // Should not cause a race here.
+	require.NoError(t, head.Init(0))
 
 	require.Equal(t, uint64(0), head.NumStaleSeries())
 	require.Equal(t, uint64(numNewSeries), head.NumSeries())
+	q, err := NewBlockQuerier(head, 0, 500)
+	require.NoError(t, err)
+	series := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".+"))
+	require.Len(t, series, numNewSeries)
+	for _, samples := range series {
+		require.Len(t, samples, 1)
+		require.Equal(t, int64(300), samples[0].T())
+	}
 	require.NoError(t, head.Close())
 }
 

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -9594,6 +9594,74 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		}
 	})
 
+	t.Run("wal replay deletion clears all chunk state", func(t *testing.T) {
+		opts := newTestHeadDefaultOptions(DefaultBlockDuration, true)
+		opts.OutOfOrderCapMax.Store(1)
+		h, _ := newTestHeadWithOptions(t, compression.None, opts)
+		require.NoError(t, h.Init(0))
+
+		mmapReadyTotal := func() int32 {
+			var n int32
+			for i := range h.series.size {
+				n += h.series.mmapReady[i].Load()
+			}
+			return n
+		}
+
+		lbls := labels.FromStrings("__name__", "seriesToDelete")
+		ts := int64(0)
+		app := h.Appender(t.Context())
+		for range chunkCutIterations {
+			_, err := app.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+
+		// With an OOO chunk capacity of one, the second OOO sample m-maps the
+		// first OOO head chunk and creates a replacement head chunk.
+		oooTs := ts - 5*time.Minute.Milliseconds()
+		app = h.Appender(t.Context())
+		_, err := app.Append(0, lbls, oooTs, 1)
+		require.NoError(t, err)
+		_, err = app.Append(0, lbls, oooTs+1, 2)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		s := h.series.getByHash(lbls.Hash(), lbls)
+		require.NotNil(t, s)
+		require.GreaterOrEqual(t, s.headChunkCount.Load(), uint32(2))
+		require.NotNil(t, s.ooo)
+		require.NotEmpty(t, s.ooo.oooMmappedChunks)
+		require.NotNil(t, s.ooo.oooHeadChunk)
+		require.Equal(t, int32(1), mmapReadyTotal())
+
+		expectedRemoved := len(s.mmappedChunks) + s.headChunks.len() + len(s.ooo.oooMmappedChunks) + 1
+		require.Equal(t, float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunks))
+		removedBefore := prom_testutil.ToFloat64(h.metrics.chunksRemoved)
+
+		h.deleteSeriesByID([]chunks.HeadSeriesRef{s.ref})
+
+		require.Nil(t, h.series.getByID(s.ref))
+		require.Nil(t, h.series.getByHash(lbls.Hash(), lbls))
+		require.Zero(t, h.NumSeries())
+		require.Equal(t, int32(0), mmapReadyTotal())
+		require.Zero(t, s.headChunkCount.Load())
+		require.Nil(t, s.headChunks)
+		require.Nil(t, s.app)
+		require.Nil(t, s.mmappedChunks)
+		require.Nil(t, s.ooo)
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.chunks))
+		require.Equal(t, removedBefore+float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunksRemoved))
+
+		// A stale reset with no chunks must not release mmap readiness or chunk
+		// accounting a second time.
+		h.resetSeriesWithMMappedChunks(s, nil, nil, s.ref+1)
+		require.Equal(t, int32(0), mmapReadyTotal())
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.chunks))
+		require.Equal(t, removedBefore+float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunksRemoved))
+	})
+
 	// Verify the mmapReady per-stripe counter stays in sync with the actual
 	// number of series that have headChunkCount >= 2, across append, mmap,
 	// GC, and stale-series deletion.

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -980,8 +980,8 @@ func TestHead_WALMultiRef(t *testing.T) {
 	}}, series)
 }
 
-// TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative is a regression test
-// for https://github.com/prometheus/prometheus/issues/10884.
+// TestHead_WALMultiRef_StaleDeletion_RecreatedSeriesSurvives is a regression
+// test for https://github.com/prometheus/prometheus/issues/10884.
 //
 // When a stale series is deleted via truncateStaleSeries (which writes a
 // [MinInt64, MaxInt64] tombstone to the WAL) and then re-created under the same
@@ -992,11 +992,10 @@ func TestHead_WALMultiRef(t *testing.T) {
 //	deleteSeriesByID(oldRef)           ← removes chunks from gauge
 //	reset(mSeries, newRef_chunks, newRef) ← was double-subtracting old chunks
 //
-// Without the fix, deleteSeriesByID removes M chunks from the gauge but leaves
-// series.mmappedChunks non-nil. The subsequent reset then subtracts those M
-// chunks a second time, driving prometheus_tsdb_head_chunks negative when M
-// exceeds the new series' chunk count.
-func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
+// Without deletion ordering, the new series record can resolve to the old
+// object before its queued deletion is applied. The deletion then removes the
+// object, drops the new series' samples, and corrupts chunk accounting.
+func TestHead_WALMultiRef_StaleDeletion_RecreatedSeriesSurvives(t *testing.T) {
 	head, w := newTestHead(t, 1000, compression.None, false)
 	require.NoError(t, head.Init(0))
 
@@ -1022,16 +1021,24 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 	// [MinInt64, MaxInt64] tombstone record to the WAL.
 	require.NoError(t, head.truncateStaleSeries([]storage.SeriesRef{ref1}, 3500, math.MaxUint64))
 
-	// Append a single sample with the same labels to create ref2.
-	// Ref2 has 0 m-mapped chunks, fewer than ref1's 3.
+	// Re-create the series and produce both m-mapped and active head chunks.
 	ref2 := appendSample(5000, 5)
+	appendSample(6200, 6)
+	appendSample(7300, 7)
+	appendSample(8400, 8)
 	require.NotEqual(t, ref1, ref2, "refs must differ after stale truncation and recreation")
+	head.mmapHeadChunks()
+	ref2Series := head.series.getByID(chunks.HeadSeriesRef(ref2))
+	require.NotNil(t, ref2Series)
+	require.Len(t, ref2Series.mmappedChunks, 3, "test needs real m-mapped chunks on the re-created series")
+	require.NotNil(t, ref2Series.headChunks)
 
 	require.NoError(t, head.Close())
 
 	// Reopen the head to trigger WAL replay. The WAL contains (in order):
-	//   series(ref1) → tombstone(ref1, [MinInt64,MaxInt64]) → series(ref2) → sample(ref2)
-	// Without the fix, replay drives prometheus_tsdb_head_chunks negative.
+	//   series(ref1) → tombstone(ref1, [MinInt64,MaxInt64]) → series(ref2) → samples(ref2)
+	// The deletion must complete before ref2 is resolved so its samples and
+	// m-mapped chunks are attached to a live series object.
 	w, err := wlog.New(nil, nil, w.Dir(), compression.None)
 	require.NoError(t, err)
 	opts := DefaultHeadOptions()
@@ -1044,8 +1051,729 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 		require.NoError(t, head.Close())
 	}()
 
-	chunksGauge := prom_testutil.ToFloat64(head.metrics.chunks)
-	require.GreaterOrEqual(t, chunksGauge, 0.0, "prometheus_tsdb_head_chunks gauge must not be negative after WAL replay")
+	require.Equal(t, 1, int(head.NumSeries()))
+	q, err := NewBlockQuerier(head, 5000, 8400)
+	require.NoError(t, err)
+	series := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+	require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: {
+		sample{0, 5000, 5, nil, nil},
+		sample{0, 6200, 6, nil, nil},
+		sample{0, 7300, 7, nil, nil},
+		sample{0, 8400, 8, nil, nil},
+	}}, series)
+	require.Equal(t, 4.0, prom_testutil.ToFloat64(head.metrics.chunks),
+		"the chunk gauge must count only the re-created series' three m-mapped chunks and active head chunk")
+}
+
+type coordinatedReplayLifecycleCallback struct {
+	mtx          sync.Mutex
+	preCreations int
+	creations    int
+	deletions    int
+	preCreation  func(labels.Labels, int)
+	postCreation func(labels.Labels, int)
+	postDeletion func(map[chunks.HeadSeriesRef]labels.Labels)
+}
+
+func (c *coordinatedReplayLifecycleCallback) PreCreation(lset labels.Labels) error {
+	c.mtx.Lock()
+	c.preCreations++
+	preCreations := c.preCreations
+	preCreation := c.preCreation
+	c.mtx.Unlock()
+	if preCreation != nil {
+		preCreation(lset, preCreations)
+	}
+	return nil
+}
+
+func (c *coordinatedReplayLifecycleCallback) PostCreation(lset labels.Labels) {
+	c.mtx.Lock()
+	c.creations++
+	creations := c.creations
+	postCreation := c.postCreation
+	c.mtx.Unlock()
+	if postCreation != nil {
+		postCreation(lset, creations)
+	}
+}
+
+func (c *coordinatedReplayLifecycleCallback) PostDeletion(deleted map[chunks.HeadSeriesRef]labels.Labels) {
+	if len(deleted) == 0 {
+		return
+	}
+	c.mtx.Lock()
+	c.deletions++
+	postDeletion := c.postDeletion
+	c.mtx.Unlock()
+	if postDeletion != nil {
+		postDeletion(deleted)
+	}
+}
+
+func (c *coordinatedReplayLifecycleCallback) counts() (int, int, int) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.preCreations, c.creations, c.deletions
+}
+
+func TestWALReplayPendingDeletions(t *testing.T) {
+	registry := newWALReplayPendingDeletions()
+	firstLabels := labels.FromStrings("series", "first")
+	secondLabels := labels.FromStrings("series", "second")
+	const collidingHash = 1
+
+	firstBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	secondBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	registry.add(collidingHash, firstLabels, firstBarrier)
+	registry.add(collidingHash, secondLabels, secondBarrier)
+
+	firstBarrier.complete()
+	registry.wait(collidingHash, firstLabels)
+	registry.mtx.Lock()
+	bucket := registry.byHash[collidingHash]
+	registry.mtx.Unlock()
+	require.Equal(t, walReplayPendingDeletion{lset: secondLabels, barrier: secondBarrier}, bucket.entry)
+	require.Empty(t, bucket.collisions)
+
+	replacementBarrier := &walReplayDeletionBarrier{done: make(chan struct{}), registry: registry}
+	registry.add(collidingHash, secondLabels, replacementBarrier)
+	secondBarrier.complete()
+	registry.mtx.Lock()
+	bucket = registry.byHash[collidingHash]
+	registry.mtx.Unlock()
+	require.Equal(t, walReplayPendingDeletion{lset: secondLabels, barrier: replacementBarrier}, bucket.entry,
+		"completing an older barrier must not remove its replacement")
+	require.Empty(t, bucket.collisions)
+
+	replacementBarrier.complete()
+	registry.wait(collidingHash, secondLabels)
+	registry.mtx.Lock()
+	require.Empty(t, registry.byHash)
+	registry.mtx.Unlock()
+}
+
+type gatedReplayExemplarStorage struct {
+	ExemplarStorage
+	timestamp int64
+	entered   chan struct{}
+	release   chan struct{}
+	once      sync.Once
+}
+
+func (s *gatedReplayExemplarStorage) AddExemplar(lset labels.Labels, e exemplar.Exemplar) error {
+	if e.Ts == s.timestamp {
+		s.once.Do(func() { close(s.entered) })
+		<-s.release
+	}
+	return s.ExemplarStorage.AddExemplar(lset, e)
+}
+
+func TestHead_WALReplayFullDeletion(t *testing.T) {
+	fullTombstone := func(ref storage.SeriesRef) tombstones.Stone {
+		return tombstones.Stone{Ref: ref, Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}}
+	}
+	closeOnce := func(ch chan struct{}) func() {
+		var once sync.Once
+		return func() { once.Do(func() { close(ch) }) }
+	}
+	newReplayHead := func(t *testing.T, records []any, opts *HeadOptions) *Head {
+		t.Helper()
+		dir := t.TempDir()
+		wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+		require.NoError(t, err)
+		populateTestWL(t, wal, records, nil, false)
+		opts.ChunkDirRoot = dir
+		head, err := NewHead(nil, nil, wal, nil, opts, nil)
+		require.NoError(t, err)
+		return head
+	}
+
+	t.Run("ordering", func(t *testing.T) {
+		type testCase struct {
+			name     string
+			records  []any
+			expected map[string][]chunks.Sample
+		}
+		testCases := []testCase{
+			{
+				name: "duplicate series record after recreation",
+				records: []any{
+					[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 1, T: 10, V: 1}, {Ref: 1, T: 20, V: 2}},
+					[]tombstones.Stone{fullTombstone(1)},
+					[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSeries{{Ref: 3, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 3, T: 30, V: 3}},
+				},
+				expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+			},
+			{
+				name: "tombstone for duplicate series reference",
+				records: []any{
+					[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 2, T: 10, V: 1}},
+					[]tombstones.Stone{fullTombstone(2)},
+					[]record.RefSeries{{Ref: 3, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 3, T: 30, V: 3}},
+				},
+				expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+			},
+			{
+				name: "repeated and absent tombstones",
+				records: []any{
+					[]record.RefSeries{{Ref: 1, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 1, T: 10, V: 1}},
+					[]tombstones.Stone{fullTombstone(1)},
+					[]tombstones.Stone{fullTombstone(1), fullTombstone(99)},
+					[]record.RefSeries{{Ref: 2, Labels: labels.FromStrings("foo", "bar")}},
+					[]record.RefSample{{Ref: 2, T: 30, V: 3}},
+				},
+				expected: map[string][]chunks.Sample{`{foo="bar"}`: {sample{0, 30, 3, nil, nil}}},
+			},
+			{
+				name: "deletions across processor shards",
+				records: []any{
+					[]record.RefSeries{
+						{Ref: 1, Labels: labels.FromStrings("foo", "a")},
+						{Ref: 2, Labels: labels.FromStrings("foo", "b")},
+					},
+					[]record.RefSample{{Ref: 1, T: 10, V: 1}, {Ref: 2, T: 10, V: 2}},
+					[]tombstones.Stone{fullTombstone(1), fullTombstone(2)},
+					[]record.RefSeries{
+						{Ref: 3, Labels: labels.FromStrings("foo", "a")},
+						{Ref: 4, Labels: labels.FromStrings("foo", "b")},
+					},
+					[]record.RefSample{{Ref: 3, T: 30, V: 3}, {Ref: 4, T: 30, V: 4}},
+				},
+				expected: map[string][]chunks.Sample{
+					`{foo="a"}`: {sample{0, 30, 3, nil, nil}},
+					`{foo="b"}`: {sample{0, 30, 4, nil, nil}},
+				},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				for _, concurrency := range []int{1, defaultWALReplayConcurrency} {
+					t.Run(fmt.Sprintf("concurrency=%d", concurrency), func(t *testing.T) {
+						opts := DefaultHeadOptions()
+						opts.ChunkRange = 1000
+						opts.WALReplayConcurrency = concurrency
+						head := newReplayHead(t, tc.records, opts)
+						require.NoError(t, head.Init(0))
+
+						require.Equal(t, len(tc.expected), int(head.NumSeries()))
+						q, err := NewBlockQuerier(head, 0, 100)
+						require.NoError(t, err)
+						actual := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", ".+"))
+						require.Equal(t, tc.expected, actual)
+						for _, recordType := range []string{"series", "samples", "exemplars", "histograms", "metadata", "tombstones"} {
+							require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.walReplayUnknownRefsTotal.WithLabelValues(recordType)),
+								"valid replay must not report unknown %s references", recordType)
+						}
+						require.NoError(t, head.Close())
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("drains earlier exemplars", func(t *testing.T) {
+		lset := labels.FromStrings("foo", "bar")
+		records := []any{
+			[]record.RefSeries{{Ref: 1, Labels: lset}},
+			[]record.RefExemplar{{Ref: 1, T: 10, V: 1, Labels: labels.FromStrings("trace_id", "old")}},
+			[]tombstones.Stone{fullTombstone(1)},
+			[]record.RefSeries{{Ref: 2, Labels: lset}},
+			[]record.RefExemplar{{Ref: 2, T: 20, V: 2, Labels: labels.FromStrings("trace_id", "new")}},
+		}
+
+		callback := &coordinatedReplayLifecycleCallback{}
+		deletionStarted := make(chan struct{})
+		signalDeletion := closeOnce(deletionStarted)
+		callback.postDeletion = func(map[chunks.HeadSeriesRef]labels.Labels) {
+			signalDeletion()
+		}
+		opts := DefaultHeadOptions()
+		opts.WALReplayConcurrency = 1
+		opts.EnableExemplarStorage = true
+		opts.MaxExemplars.Store(config.DefaultExemplarsConfig.MaxExemplars)
+		opts.SeriesCallback = callback
+		head := newReplayHead(t, records, opts)
+
+		exemplarEntered := make(chan struct{})
+		allowExemplar := make(chan struct{})
+		release := closeOnce(allowExemplar)
+		t.Cleanup(release)
+		head.exemplars = &gatedReplayExemplarStorage{
+			ExemplarStorage: head.exemplars,
+			timestamp:       10,
+			entered:         exemplarEntered,
+			release:         allowExemplar,
+		}
+		drainHookEntered := make(chan (<-chan struct{}), 1)
+		allowDrainHook := make(chan struct{})
+		releaseHook := closeOnce(allowDrainHook)
+		t.Cleanup(releaseHook)
+		head.walReplayExemplarDrainHook = func(done <-chan struct{}) {
+			drainHookEntered <- done
+			<-allowDrainHook
+		}
+
+		initDone := make(chan error, 1)
+		go func() {
+			initDone <- head.Init(0)
+		}()
+
+		select {
+		case <-exemplarEntered:
+		case <-time.After(10 * time.Second):
+			releaseHook()
+			release()
+			initErr := <-initDone
+			require.NoError(t, initErr)
+			require.NoError(t, head.Close())
+			require.FailNow(t, "timed out waiting for the earlier exemplar")
+		}
+		var exemplarDrainDone <-chan struct{}
+		select {
+		case exemplarDrainDone = <-drainHookEntered:
+		case <-time.After(10 * time.Second):
+			releaseHook()
+			release()
+			initErr := <-initDone
+			require.NoError(t, initErr)
+			require.NoError(t, head.Close())
+			require.FailNow(t, "timed out waiting for the exemplar drain marker")
+		}
+		select {
+		case <-exemplarDrainDone:
+			require.Fail(t, "the drain marker completed before the earlier exemplar")
+		default:
+		}
+		select {
+		case <-deletionStarted:
+			require.Fail(t, "deletion started before the earlier exemplar was drained")
+		default:
+		}
+
+		releaseHook()
+		release()
+		require.NoError(t, <-initDone)
+		var exemplarTimestamps []int64
+		require.NoError(t, head.exemplars.IterateExemplars(func(_ labels.Labels, e exemplar.Exemplar) error {
+			exemplarTimestamps = append(exemplarTimestamps, e.Ts)
+			return nil
+		}))
+		require.Equal(t, []int64{10, 20}, exemplarTimestamps)
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.walReplayUnknownRefsTotal.WithLabelValues("exemplars")))
+		require.NoError(t, head.Close())
+	})
+
+	t.Run("waits only for matching series", func(t *testing.T) {
+		const stripeSize = 32
+		for _, blockedRef := range []chunks.HeadSeriesRef{1, 2} {
+			t.Run(fmt.Sprintf("blocked_ref=%d", blockedRef), func(t *testing.T) {
+				refStripe := int(blockedRef) & (stripeSize - 1)
+				labelOutsideStripe := func(value string, stripe int) labels.Labels {
+					for i := 0; ; i++ {
+						lset := labels.FromStrings("series", fmt.Sprintf("%s-%d", value, i))
+						if int(lset.Hash()&uint64(stripeSize-1)) != stripe {
+							return lset
+						}
+					}
+				}
+
+				oldLabels := labelOutsideStripe("old", refStripe)
+				blockedHashStripe := int(oldLabels.Hash() & uint64(stripeSize-1))
+				unrelatedLabels := labelOutsideStripe("unrelated", blockedHashStripe)
+				unrelatedRef := chunks.HeadSeriesRef(3)
+				for int(unrelatedRef)&(stripeSize-1) == blockedHashStripe || unrelatedRef == blockedRef {
+					unrelatedRef++
+				}
+				replacementRef := unrelatedRef + 1
+				for replacementRef == blockedRef {
+					replacementRef++
+				}
+				records := []any{
+					[]record.RefSeries{{Ref: blockedRef, Labels: oldLabels}},
+					[]record.RefSample{{Ref: blockedRef, T: 10, V: 1}},
+					[]tombstones.Stone{fullTombstone(storage.SeriesRef(blockedRef))},
+					[]record.RefSeries{{Ref: unrelatedRef, Labels: unrelatedLabels}},
+					[]record.RefSeries{{Ref: replacementRef, Labels: oldLabels}},
+					[]record.RefSample{{Ref: unrelatedRef, T: 20, V: 2}, {Ref: replacementRef, T: 30, V: 3}},
+				}
+
+				callback := &coordinatedReplayLifecycleCallback{}
+				initialSeriesCreated := make(chan struct{})
+				allowReplay := make(chan struct{})
+				unrelatedPreCreation := make(chan struct{})
+				unrelatedPostCreation := make(chan struct{})
+				replacementPreCreation := make(chan struct{})
+				replacementPostCreation := make(chan struct{})
+				deletionStarted := make(chan struct{})
+				allowDeletion := make(chan struct{})
+				signalInitialCreation := closeOnce(initialSeriesCreated)
+				releaseReplay := closeOnce(allowReplay)
+				signalUnrelatedPre := closeOnce(unrelatedPreCreation)
+				signalUnrelatedPost := closeOnce(unrelatedPostCreation)
+				signalReplacementPre := closeOnce(replacementPreCreation)
+				signalReplacementPost := closeOnce(replacementPostCreation)
+				signalDeletion := closeOnce(deletionStarted)
+				releaseDeletionCallback := closeOnce(allowDeletion)
+				t.Cleanup(func() {
+					releaseReplay()
+					releaseDeletionCallback()
+				})
+				oldPreCreations := 0
+				callback.preCreation = func(lset labels.Labels, _ int) {
+					switch {
+					case labels.Equal(lset, oldLabels):
+						oldPreCreations++
+						if oldPreCreations == 2 {
+							signalReplacementPre()
+						}
+					case labels.Equal(lset, unrelatedLabels):
+						signalUnrelatedPre()
+					}
+				}
+				oldPostCreations := 0
+				callback.postCreation = func(lset labels.Labels, _ int) {
+					switch {
+					case labels.Equal(lset, oldLabels):
+						oldPostCreations++
+						if oldPostCreations == 1 {
+							signalInitialCreation()
+							<-allowReplay
+						} else {
+							signalReplacementPost()
+						}
+					case labels.Equal(lset, unrelatedLabels):
+						signalUnrelatedPost()
+					}
+				}
+				callback.postDeletion = func(deleted map[chunks.HeadSeriesRef]labels.Labels) {
+					if _, ok := deleted[blockedRef]; ok {
+						signalDeletion()
+						<-allowDeletion
+					}
+				}
+
+				opts := DefaultHeadOptions()
+				opts.StripeSize = stripeSize
+				opts.WALReplayConcurrency = 2
+				opts.SeriesCallback = callback
+				head := newReplayHead(t, records, opts)
+
+				initDone := make(chan error, 1)
+				go func() {
+					initDone <- head.Init(0)
+				}()
+
+				select {
+				case <-initialSeriesCreated:
+				case <-time.After(10 * time.Second):
+					releaseReplay()
+					releaseDeletionCallback()
+					initErr := <-initDone
+					require.NoError(t, initErr)
+					require.NoError(t, head.Close())
+					require.FailNow(t, "timed out waiting for the initial series")
+				}
+
+				releaseReplay()
+
+				select {
+				case <-unrelatedPreCreation:
+				case <-time.After(10 * time.Second):
+					releaseDeletionCallback()
+					initErr := <-initDone
+					require.NoError(t, initErr)
+					require.NoError(t, head.Close())
+					require.FailNow(t, "timed out waiting for unrelated PreCreation")
+				}
+				select {
+				case <-unrelatedPostCreation:
+				case <-time.After(10 * time.Second):
+					releaseDeletionCallback()
+					initErr := <-initDone
+					require.NoError(t, initErr)
+					require.NoError(t, head.Close())
+					require.FailNow(t, "timed out waiting for unrelated PostCreation")
+				}
+				select {
+				case <-replacementPreCreation:
+					require.Fail(t, "replacement PreCreation ran before the matching deletion")
+				default:
+				}
+				select {
+				case <-replacementPostCreation:
+					require.Fail(t, "replacement PostCreation ran before the matching deletion")
+				default:
+				}
+
+				select {
+				case <-deletionStarted:
+				case <-time.After(10 * time.Second):
+					releaseDeletionCallback()
+					initErr := <-initDone
+					require.NoError(t, initErr)
+					require.NoError(t, head.Close())
+					require.FailNow(t, "timed out waiting for PostDeletion")
+				}
+				select {
+				case <-replacementPreCreation:
+					require.Fail(t, "replacement PreCreation ran before PostDeletion returned")
+				default:
+				}
+				select {
+				case <-replacementPostCreation:
+					require.Fail(t, "replacement PostCreation ran before PostDeletion returned")
+				default:
+				}
+
+				releaseDeletionCallback()
+				require.NoError(t, <-initDone)
+				preCreations, creations, deletions := callback.counts()
+				require.Equal(t, 3, preCreations)
+				require.Equal(t, 3, creations)
+				require.Equal(t, 1, deletions)
+				require.Equal(t, uint64(2), head.NumSeries())
+				q, err := NewBlockQuerier(head, 0, 100)
+				require.NoError(t, err)
+				actual := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "series", ".+"))
+				require.Equal(t, map[string][]chunks.Sample{
+					oldLabels.String():       {sample{0, 30, 3, nil, nil}},
+					unrelatedLabels.String(): {sample{0, 20, 2, nil, nil}},
+				}, actual)
+				require.NoError(t, head.Close())
+			})
+		}
+	})
+
+	t.Run("preserves WBL data", func(t *testing.T) {
+		dir := t.TempDir()
+		wal, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+		require.NoError(t, err)
+		wbl, err := wlog.New(nil, nil, filepath.Join(dir, wlog.WblDirName), compression.None)
+		require.NoError(t, err)
+		lset := labels.FromStrings("foo", "bar")
+		populateTestWL(t, wal, []any{
+			[]record.RefSeries{{Ref: 1, Labels: lset}},
+			[]record.RefSample{{Ref: 1, T: 10, V: 1}},
+			[]tombstones.Stone{fullTombstone(1)},
+			[]record.RefSeries{{Ref: 2, Labels: lset}},
+			[]record.RefSample{{Ref: 2, T: 100, V: 2}},
+		}, nil, false)
+		populateTestWL(t, wbl, []any{
+			[]record.RefSample{{Ref: 2, T: 50, V: 3}},
+		}, nil, false)
+		require.NoError(t, wal.Close())
+		require.NoError(t, wbl.Close())
+		wal, err = wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+		require.NoError(t, err)
+		wbl, err = wlog.New(nil, nil, filepath.Join(dir, wlog.WblDirName), compression.None)
+		require.NoError(t, err)
+
+		opts := DefaultHeadOptions()
+		opts.ChunkDirRoot = dir
+		opts.OutOfOrderTimeWindow.Store(10 * time.Minute.Milliseconds())
+		head, err := NewHead(nil, nil, wal, wbl, opts, nil)
+		require.NoError(t, err)
+		require.NoError(t, head.Init(0))
+
+		q, err := NewBlockQuerier(head, 0, 200)
+		require.NoError(t, err)
+		actual := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: {
+			sample{0, 100, 2, nil, nil},
+		}}, actual)
+
+		ms := head.series.getByID(2)
+		require.NotNil(t, ms)
+		require.NotNil(t, ms.ooo)
+		require.NotNil(t, ms.ooo.oooHeadChunk)
+		oooChunks, err := ms.ooo.oooHeadChunk.chunk.ToEncodedChunks(math.MinInt64, math.MaxInt64, false, false)
+		require.NoError(t, err)
+		require.Len(t, oooChunks, 1)
+		oooSamples, err := storage.ExpandSamples(oooChunks[0].chunk.Iterator(nil), nil)
+		require.NoError(t, err)
+		requireEqualSamples(t, lset.String(), []chunks.Sample{sample{0, 50, 3, nil, nil}}, oooSamples)
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.wblReplayUnknownRefsTotal.WithLabelValues("samples")))
+		require.NoError(t, head.Close())
+	})
+
+	t.Run("stale series truncation followed by unrelated series", func(t *testing.T) {
+		// Exercise replay of the WAL shape produced by stale-series truncation followed by unrelated series creation.
+		opts := newTestHeadDefaultOptions(1000, false)
+		// A small stripe size makes the test cover many ref and hash shard
+		// collisions while replaying a large deletion batch.
+		opts.StripeSize = 32
+		head, _ := newTestHeadWithOptions(t, compression.None, opts)
+		require.NoError(t, head.Init(0))
+
+		appendSample := func(lbls labels.Labels, ts int64, val float64) {
+			app := head.Appender(context.Background())
+			_, err := app.Append(0, lbls, ts, val)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+		}
+
+		// Step 1: Create a batch of series and make them stale.
+		const numStaleSeries = 500
+		staleLbls := make([]labels.Labels, numStaleSeries)
+		for i := range numStaleSeries {
+			staleLbls[i] = labels.FromStrings("__name__", "stale_metric", "i", strconv.Itoa(i))
+			appendSample(staleLbls[i], 100, float64(i))
+		}
+		for _, lbl := range staleLbls {
+			appendSample(lbl, 200, math.Float64frombits(value.StaleNaN))
+		}
+		require.Equal(t, uint64(numStaleSeries), head.NumStaleSeries())
+
+		// Step 2: Truncate stale series. This removes them from the Head and
+		// writes tombstone records (with Mint=MinInt64, Maxt=MaxInt64) to the WAL.
+		staleRefs := make([]storage.SeriesRef, 0, numStaleSeries)
+		for i := range numStaleSeries {
+			ms := head.series.getByHash(staleLbls[i].Hash(), staleLbls[i])
+			require.NotNil(t, ms)
+			staleRefs = append(staleRefs, storage.SeriesRef(ms.ref))
+		}
+		require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64))
+		require.Equal(t, uint64(0), head.NumStaleSeries())
+		require.Equal(t, uint64(0), head.NumSeries())
+
+		// Step 3: Add unrelated series after the truncation. Their WAL records
+		// follow the full-deletion tombstones, allowing creation and asynchronous
+		// deletion to overlap during replay.
+		const numNewSeries = 500
+		for i := range numNewSeries {
+			lbl := labels.FromStrings("__name__", "new_metric", "i", strconv.Itoa(i))
+			appendSample(lbl, 300, float64(i))
+		}
+		require.Equal(t, uint64(numNewSeries), head.NumSeries())
+
+		// Step 4: Close and re-open the Head to trigger WAL replay.
+		require.NoError(t, head.Close())
+
+		wal, err := wlog.NewSize(nil, nil, filepath.Join(head.opts.ChunkDirRoot, "wal"), 32768, compression.None)
+		require.NoError(t, err)
+		head, err = NewHead(nil, nil, wal, nil, head.opts, nil)
+		require.NoError(t, err)
+		require.NoError(t, head.Init(0))
+
+		require.Equal(t, uint64(0), head.NumStaleSeries())
+		require.Equal(t, uint64(numNewSeries), head.NumSeries())
+		q, err := NewBlockQuerier(head, 0, 500)
+		require.NoError(t, err)
+		series := query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".+"))
+		require.Len(t, series, numNewSeries)
+		for _, samples := range series {
+			require.Len(t, samples, 1)
+			require.Equal(t, int64(300), samples[0].T())
+		}
+		require.NoError(t, head.Close())
+	})
+}
+
+func BenchmarkHeadWALReplayFullDeletion(b *testing.B) {
+	const (
+		generations         = 6
+		seriesPerGeneration = 1000
+	)
+	cases := []struct {
+		name                string
+		fullDeletionRecords int
+		recreate            bool
+	}{
+		{name: "none"},
+		{name: "unrelated/one", fullDeletionRecords: 1},
+		{name: "unrelated/repeated", fullDeletionRecords: 5},
+		{name: "recreated/one", fullDeletionRecords: 1, recreate: true},
+		{name: "recreated/repeated", fullDeletionRecords: 5, recreate: true},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			walDir := b.TempDir()
+			wal, err := wlog.New(nil, nil, walDir, compression.None)
+			require.NoError(b, err)
+
+			var buf []byte
+			for generation := range generations {
+				series := make([]record.RefSeries, 0, seriesPerGeneration)
+				samples := make([]record.RefSample, 0, seriesPerGeneration)
+				tombstonesForGeneration := make([]tombstones.Stone, 0, seriesPerGeneration)
+				for i := range seriesPerGeneration {
+					ref := chunks.HeadSeriesRef(generation*seriesPerGeneration + i + 1)
+					lset := labels.FromStrings(
+						"__name__", "wal_replay_benchmark",
+						"series", strconv.Itoa(i),
+					)
+					if !tc.recreate {
+						lset = labels.FromStrings(
+							"__name__", "wal_replay_benchmark",
+							"generation", strconv.Itoa(generation),
+							"series", strconv.Itoa(i),
+						)
+					}
+					series = append(series, record.RefSeries{
+						Ref:    ref,
+						Labels: lset,
+					})
+					samples = append(samples, record.RefSample{Ref: ref, T: int64(generation), V: float64(generation)})
+					tombstonesForGeneration = append(tombstonesForGeneration, tombstones.Stone{
+						Ref: storage.SeriesRef(ref),
+						Intervals: tombstones.Intervals{{
+							Mint: math.MinInt64,
+							Maxt: math.MaxInt64,
+						}},
+					})
+				}
+				buf = populateTestWL(b, wal, []any{series, samples}, buf, false)
+				if generation < tc.fullDeletionRecords {
+					buf = populateTestWL(b, wal, []any{tombstonesForGeneration}, buf, false)
+				}
+			}
+			require.NoError(b, wal.Close())
+
+			for _, concurrency := range []int{1, defaultWALReplayConcurrency} {
+				b.Run(fmt.Sprintf("concurrency=%d", concurrency), func(b *testing.B) {
+					chunkDirRoot := b.TempDir()
+					b.ReportAllocs()
+					for b.Loop() {
+						b.StopTimer()
+						segmentsReader, err := wlog.NewSegmentsReader(walDir)
+						require.NoError(b, err)
+						opts := DefaultHeadOptions()
+						opts.ChunkDirRoot = chunkDirRoot
+						opts.WALReplayConcurrency = concurrency
+						head, err := NewHead(nil, nil, nil, nil, opts, nil)
+						require.NoError(b, err)
+
+						b.StartTimer()
+						err = head.loadWAL(
+							wlog.NewReader(segmentsReader),
+							labels.NewSymbolTable(),
+							map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{},
+							nil,
+							nil,
+						)
+						b.StopTimer()
+						require.NoError(b, err)
+						expectedSeries := uint64((generations - tc.fullDeletionRecords) * seriesPerGeneration)
+						if tc.recreate {
+							expectedSeries = seriesPerGeneration
+						}
+						require.Equal(b, expectedSeries, head.NumSeries())
+						require.NoError(b, segmentsReader.Close())
+						require.NoError(b, head.Close())
+						b.StartTimer()
+					}
+				})
+			}
+		})
+	}
 }
 
 func TestHead_WALCheckpointMultiRef(t *testing.T) {
@@ -9823,80 +10551,6 @@ func TestFloatChunkEncodingSwitchWaitsForNextChunk(t *testing.T) {
 		require.Equal(t, chunkenc.EncXOR, ms.headChunks.chunk.Encoding(),
 			"in-progress chunk must keep XOR encoding after encoding switch")
 	})
-}
-
-// TestWALReplayRaceWithStaleSeriesCompaction verifies that deleteSeriesByID correctly locks the
-// hash shard (not only the ref shard) when deleting from the hashes map.
-// The race only occurs when Prometheus restarts after having done a stale series compaction because
-// deleteSeriesByID is not used otherwise.
-func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
-	opts := newTestHeadDefaultOptions(1000, false)
-	// A small stripe size ensures many series share hash shards, increasing
-	// the likelihood that deleteSeriesByID and getOrCreateWithOptionalID
-	// contend on the same shard during WAL replay.
-	opts.StripeSize = 32
-	head, _ := newTestHeadWithOptions(t, compression.None, opts)
-	require.NoError(t, head.Init(0))
-
-	appendSample := func(lbls labels.Labels, ts int64, val float64) {
-		app := head.Appender(context.Background())
-		_, err := app.Append(0, lbls, ts, val)
-		require.NoError(t, err)
-		require.NoError(t, app.Commit())
-	}
-
-	// Step 1: Create a batch of series and make them stale.
-	const numStaleSeries = 500
-	staleLbls := make([]labels.Labels, numStaleSeries)
-	for i := range numStaleSeries {
-		staleLbls[i] = labels.FromStrings("__name__", "stale_metric", "i", strconv.Itoa(i))
-		appendSample(staleLbls[i], 100, float64(i))
-	}
-	for _, lbl := range staleLbls {
-		appendSample(lbl, 200, math.Float64frombits(value.StaleNaN))
-	}
-	require.Equal(t, uint64(numStaleSeries), head.NumStaleSeries())
-
-	// Step 2: Truncate stale series. This removes them from the Head and
-	// writes tombstone records (with Mint=MinInt64, Maxt=MaxInt64) to the WAL.
-	staleRefs := make([]storage.SeriesRef, 0, numStaleSeries)
-	for i := range numStaleSeries {
-		ms := head.series.getByHash(staleLbls[i].Hash(), staleLbls[i])
-		require.NotNil(t, ms)
-		staleRefs = append(staleRefs, storage.SeriesRef(ms.ref))
-	}
-	require.NoError(t, head.truncateStaleSeries(staleRefs, 300, math.MaxUint64))
-	require.Equal(t, uint64(0), head.NumStaleSeries())
-	require.Equal(t, uint64(0), head.NumSeries())
-
-	// Step 3: Add new series AFTER the truncation. In the WAL, these series
-	// records appear after the tombstone records. During replay, the main
-	// goroutine will create these series (via getOrCreateWithOptionalID, which
-	// accesses hashes[hashShard] under locks[hashShard]) concurrently with
-	// the walSubsetProcessor goroutines deleting the stale series (via
-	// deleteSeriesByID, which must also lock the correct hashShard).
-	const numNewSeries = 500
-	for i := range numNewSeries {
-		lbl := labels.FromStrings("__name__", "new_metric", "i", strconv.Itoa(i))
-		appendSample(lbl, 300, float64(i))
-	}
-	require.Equal(t, uint64(numNewSeries), head.NumSeries())
-
-	// Step 4: Close and re-open the Head to trigger WAL replay.
-	// With the buggy locking, the race detector should catch the data race
-	// between the main goroutine (creating series) and worker goroutines
-	// (deleting stale series) during replay.
-	require.NoError(t, head.Close())
-
-	wal, err := wlog.NewSize(nil, nil, filepath.Join(head.opts.ChunkDirRoot, "wal"), 32768, compression.None)
-	require.NoError(t, err)
-	head, err = NewHead(nil, nil, wal, nil, head.opts, nil)
-	require.NoError(t, err)
-	require.NoError(t, head.Init(0)) // Should not cause a race here.
-
-	require.Equal(t, uint64(0), head.NumStaleSeries())
-	require.Equal(t, uint64(numNewSeries), head.NumSeries())
-	require.NoError(t, head.Close())
 }
 
 // TestHead_ReadWAL_TombstonesAdvanceLastSeriesID verifies that replay advances

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -10565,6 +10565,74 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		}
 	})
 
+	t.Run("wal replay deletion clears all chunk state", func(t *testing.T) {
+		opts := newTestHeadDefaultOptions(DefaultBlockDuration, true)
+		opts.OutOfOrderCapMax.Store(1)
+		h, _ := newTestHeadWithOptions(t, compression.None, opts)
+		require.NoError(t, h.Init(0))
+
+		mmapReadyTotal := func() int32 {
+			var n int32
+			for i := range h.series.size {
+				n += h.series.mmapReady[i].Load()
+			}
+			return n
+		}
+
+		lbls := labels.FromStrings("__name__", "seriesToDelete")
+		ts := int64(0)
+		app := h.Appender(t.Context())
+		for range chunkCutIterations {
+			_, err := app.Append(0, lbls, ts, float64(ts))
+			require.NoError(t, err)
+			ts += interval
+		}
+		require.NoError(t, app.Commit())
+
+		// With an OOO chunk capacity of one, the second OOO sample m-maps the
+		// first OOO head chunk and creates a replacement head chunk.
+		oooTs := ts - 5*time.Minute.Milliseconds()
+		app = h.Appender(t.Context())
+		_, err := app.Append(0, lbls, oooTs, 1)
+		require.NoError(t, err)
+		_, err = app.Append(0, lbls, oooTs+1, 2)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+
+		s := h.series.getByHash(lbls.Hash(), lbls)
+		require.NotNil(t, s)
+		require.GreaterOrEqual(t, s.headChunkCount.Load(), uint32(2))
+		require.NotNil(t, s.ooo)
+		require.NotEmpty(t, s.ooo.oooMmappedChunks)
+		require.NotNil(t, s.ooo.oooHeadChunk)
+		require.Equal(t, int32(1), mmapReadyTotal())
+
+		expectedRemoved := len(s.mmappedChunks) + s.headChunks.len() + len(s.ooo.oooMmappedChunks) + 1
+		require.Equal(t, float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunks))
+		removedBefore := prom_testutil.ToFloat64(h.metrics.chunksRemoved)
+
+		h.deleteSeriesByID([]chunks.HeadSeriesRef{s.ref})
+
+		require.Nil(t, h.series.getByID(s.ref))
+		require.Nil(t, h.series.getByHash(lbls.Hash(), lbls))
+		require.Zero(t, h.NumSeries())
+		require.Equal(t, int32(0), mmapReadyTotal())
+		require.Zero(t, s.headChunkCount.Load())
+		require.Nil(t, s.headChunks)
+		require.Nil(t, s.app)
+		require.Nil(t, s.mmappedChunks)
+		require.Nil(t, s.ooo)
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.chunks))
+		require.Equal(t, removedBefore+float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunksRemoved))
+
+		// A stale reset with no chunks must not release mmap readiness or chunk
+		// accounting a second time.
+		h.resetSeriesWithMMappedChunks(s, nil, nil, s.ref+1)
+		require.Equal(t, int32(0), mmapReadyTotal())
+		require.Equal(t, 0.0, prom_testutil.ToFloat64(h.metrics.chunks))
+		require.Equal(t, removedBefore+float64(expectedRemoved), prom_testutil.ToFloat64(h.metrics.chunksRemoved))
+	})
+
 	// Verify the mmapReady per-stripe counter stays in sync with the actual
 	// number of series that have headChunkCount >= 2, across append, mmap,
 	// GC, and stale-series deletion.

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -59,6 +59,172 @@ type seriesRefSet struct {
 	mtx  sync.Mutex
 }
 
+type walReplayDeletionBarrierEntry struct {
+	hash uint64
+	lset labels.Labels
+}
+
+type walReplayDeletionBarrier struct {
+	done     chan struct{}
+	entries  []walReplayDeletionBarrierEntry
+	registry *walReplayPendingDeletions
+}
+
+type walReplayPendingDeletion struct {
+	lset    labels.Labels
+	barrier *walReplayDeletionBarrier
+}
+
+type walReplayPendingDeletionBucket struct {
+	entry      walReplayPendingDeletion
+	collisions []walReplayPendingDeletion
+}
+
+// walReplayPendingDeletions prevents a series record from re-creating a label
+// set until an earlier full deletion and its lifecycle callback have completed.
+type walReplayPendingDeletions struct {
+	// Keep the 64-bit atomic first to guarantee alignment on 32-bit systems.
+	count  atomic.Int64
+	mtx    sync.Mutex
+	byHash map[uint64]walReplayPendingDeletionBucket
+}
+
+func newWALReplayPendingDeletions() *walReplayPendingDeletions {
+	return &walReplayPendingDeletions{byHash: map[uint64]walReplayPendingDeletionBucket{}}
+}
+
+func (p *walReplayPendingDeletions) add(hash uint64, lset labels.Labels, barrier *walReplayDeletionBarrier) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.addLocked(hash, lset, barrier)
+}
+
+func (p *walReplayPendingDeletions) addLocked(hash uint64, lset labels.Labels, barrier *walReplayDeletionBarrier) {
+	bucket, ok := p.byHash[hash]
+	if !ok {
+		p.byHash[hash] = walReplayPendingDeletionBucket{
+			entry: walReplayPendingDeletion{lset: lset, barrier: barrier},
+		}
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		p.count.Inc()
+		return
+	}
+
+	if labels.Equal(bucket.entry.lset, lset) {
+		if bucket.entry.barrier == barrier {
+			return
+		}
+		bucket.entry.barrier = barrier
+		p.byHash[hash] = bucket
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		return
+	}
+
+	for i := range bucket.collisions {
+		if !labels.Equal(bucket.collisions[i].lset, lset) {
+			continue
+		}
+		if bucket.collisions[i].barrier == barrier {
+			return
+		}
+		bucket.collisions[i].barrier = barrier
+		p.byHash[hash] = bucket
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		return
+	}
+
+	bucket.collisions = append(bucket.collisions, walReplayPendingDeletion{lset: lset, barrier: barrier})
+	p.byHash[hash] = bucket
+	barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+	p.count.Inc()
+}
+
+func (p *walReplayPendingDeletions) newBarrier(lsets []labels.Labels) *walReplayDeletionBarrier {
+	barrier := &walReplayDeletionBarrier{
+		done:     make(chan struct{}),
+		registry: p,
+	}
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	for _, lset := range lsets {
+		p.addLocked(lset.Hash(), lset, barrier)
+	}
+	return barrier
+}
+
+func (p *walReplayPendingDeletions) wait(hash uint64, lset labels.Labels) {
+	for {
+		if p.count.Load() == 0 {
+			return
+		}
+		p.mtx.Lock()
+		var done <-chan struct{}
+		if bucket, ok := p.byHash[hash]; ok {
+			if labels.Equal(bucket.entry.lset, lset) {
+				done = bucket.entry.barrier.done
+			} else {
+				for _, entry := range bucket.collisions {
+					if labels.Equal(entry.lset, lset) {
+						done = entry.barrier.done
+						break
+					}
+				}
+			}
+		}
+		p.mtx.Unlock()
+
+		if done == nil {
+			return
+		}
+		<-done
+	}
+}
+
+func (p *walReplayPendingDeletions) complete(barrier *walReplayDeletionBarrier) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	close(barrier.done)
+	for _, completed := range barrier.entries {
+		bucket, ok := p.byHash[completed.hash]
+		if !ok {
+			continue
+		}
+
+		if bucket.entry.barrier == barrier && labels.Equal(bucket.entry.lset, completed.lset) {
+			p.count.Dec()
+			if len(bucket.collisions) == 0 {
+				delete(p.byHash, completed.hash)
+			} else {
+				last := len(bucket.collisions) - 1
+				bucket.entry = bucket.collisions[last]
+				bucket.collisions = bucket.collisions[:last]
+				p.byHash[completed.hash] = bucket
+			}
+			continue
+		}
+
+		for i := range bucket.collisions {
+			entry := bucket.collisions[i]
+			if entry.barrier != barrier || !labels.Equal(entry.lset, completed.lset) {
+				continue
+			}
+			last := len(bucket.collisions) - 1
+			bucket.collisions[i] = bucket.collisions[last]
+			bucket.collisions = bucket.collisions[:last]
+			p.byHash[completed.hash] = bucket
+			p.count.Dec()
+			break
+		}
+	}
+}
+
+func (b *walReplayDeletionBarrier) complete() {
+	if b != nil {
+		b.registry.complete(b)
+	}
+}
+
 func (s *seriesRefSet) merge(other map[chunks.HeadSeriesRef]struct{}) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
@@ -95,7 +261,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		wg             sync.WaitGroup
 		concurrency    = h.opts.WALReplayConcurrency
 		processors     = make([]walSubsetProcessor, concurrency)
-		exemplarsInput chan record.RefExemplar
+		exemplarsInput chan walReplayExemplarInput
 
 		shards          = make([][]record.RefSample, concurrency)
 		histogramShards = make([][]histogramRecord, concurrency)
@@ -103,6 +269,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		decoded                      = make(chan any, 10)
 		decodeErr, seriesCreationErr error
 	)
+	pendingDeletions := newWALReplayPendingDeletions()
 
 	defer func() {
 		// For CorruptionErr ensure to terminate all workers before exiting.
@@ -131,12 +298,17 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 	}
 
 	wg.Add(1)
-	exemplarsInput = make(chan record.RefExemplar, 300)
-	go func(input <-chan record.RefExemplar) {
+	exemplarsInput = make(chan walReplayExemplarInput, 300)
+	go func(input <-chan walReplayExemplarInput) {
 		missingSeries := make(map[chunks.HeadSeriesRef]struct{})
 		var err error
 		defer wg.Done()
-		for e := range input {
+		for in := range input {
+			if in.done != nil {
+				close(in.done)
+				continue
+			}
+			e := in.exemplar
 			ms := h.series.getByID(e.Ref)
 			if ms == nil {
 				unknownExemplarRefs.Inc()
@@ -251,12 +423,15 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 
 	// The records are always replayed from the oldest to the newest.
 	missingSeries := make(map[chunks.HeadSeriesRef]struct{})
+	exemplarsPending := false
 Outer:
 	for d := range decoded {
 		switch v := d.(type) {
 		case []record.RefSeries:
 			for _, walSeries := range v {
-				mSeries, created, err := h.getOrCreateWithOptionalID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels, false)
+				hash := walSeries.Labels.Hash()
+				pendingDeletions.wait(hash, walSeries.Labels)
+				mSeries, created, err := h.getOrCreateWithOptionalID(walSeries.Ref, hash, walSeries.Labels, false)
 				if err != nil {
 					seriesCreationErr = err
 					break Outer
@@ -314,6 +489,20 @@ Outer:
 		case []tombstones.Stone:
 			// Tombstone records will be fairly rare, so not trying to optimise the allocations here.
 			deleteSeriesShards := make([][]chunks.HeadSeriesRef, concurrency)
+			deleteSeriesLabelShards := make([][]labels.Labels, concurrency)
+			queueFullDeletion := func(ref chunks.HeadSeriesRef) {
+				series := h.series.getByID(ref)
+				if series == nil {
+					return
+				}
+				// Remove the series from the hash index so a later series record with
+				// the same labels creates a fresh series. The by-ref entry remains until
+				// the queued deletion applies, so earlier records can still resolve it.
+				h.series.unlinkHash(series.lset.Hash(), ref)
+				mod := uint64(ref) % uint64(concurrency)
+				deleteSeriesShards[mod] = append(deleteSeriesShards[mod], ref)
+				deleteSeriesLabelShards[mod] = append(deleteSeriesLabelShards[mod], series.labels())
+			}
 			for _, s := range v {
 				// A tombstone means this ref was previously allocated, even if its series record is no
 				// longer in the WAL. Advance lastSeriesID so the ref is not reissued.
@@ -327,15 +516,7 @@ Outer:
 					if r, ok := multiRef[ref]; ok {
 						ref = r
 					}
-					if series := h.series.getByID(ref); series != nil {
-						// Remove the series from the hash index so that a later series
-						// record with the same labels creates a fresh series instead of
-						// mapping onto this one. It stays in the by-ref map so
-						// already-queued samples still resolve until the deletion applies.
-						h.series.unlinkHash(series.lset.Hash(), ref)
-						mod := uint64(ref) % uint64(concurrency)
-						deleteSeriesShards[mod] = append(deleteSeriesShards[mod], ref)
-					}
+					queueFullDeletion(ref)
 					continue
 				}
 				for _, itv := range s.Intervals {
@@ -356,10 +537,36 @@ Outer:
 				}
 			}
 
+			hasLiveFullDeletions := false
+			for i := range concurrency {
+				if len(deleteSeriesLabelShards[i]) > 0 {
+					hasLiveFullDeletions = true
+					break
+				}
+			}
+
+			// Drain separately processed exemplars before dispatching a live
+			// deletion so it cannot overtake an earlier exemplar for the series.
+			if hasLiveFullDeletions && exemplarsPending {
+				done := make(chan struct{})
+				exemplarsInput <- walReplayExemplarInput{done: done}
+				if h.walReplayExemplarDrainHook != nil {
+					h.walReplayExemplarDrainHook(done)
+				}
+				<-done
+				exemplarsPending = false
+			}
+
 			for i := range concurrency {
 				if len(deleteSeriesShards[i]) > 0 {
-					processors[i].input <- walSubsetProcessorInputItem{deletedSeriesRefs: deleteSeriesShards[i]}
-					deleteSeriesShards[i] = nil
+					var barrier *walReplayDeletionBarrier
+					if len(deleteSeriesLabelShards[i]) > 0 {
+						barrier = pendingDeletions.newBarrier(deleteSeriesLabelShards[i])
+					}
+					processors[i].input <- walSubsetProcessorInputItem{
+						deletedSeriesRefs: deleteSeriesShards[i],
+						deletionBarrier:   barrier,
+					}
 				}
 			}
 
@@ -375,7 +582,8 @@ Outer:
 					h.updateWALExpiry(e.Ref, e.T)
 					e.Ref = r
 				}
-				exemplarsInput <- e
+				exemplarsInput <- walReplayExemplarInput{exemplar: e}
+				exemplarsPending = true
 			}
 			for i := range v { // Zero out to avoid retaining label data.
 				v[i].Labels = labels.EmptyLabels()
@@ -604,12 +812,18 @@ type walSubsetProcessor struct {
 	histogramsOutput chan []histogramRecord
 }
 
+type walReplayExemplarInput struct {
+	exemplar record.RefExemplar
+	done     chan struct{}
+}
+
 type walSubsetProcessorInputItem struct {
 	samples           []record.RefSample
 	histogramSamples  []histogramRecord
 	existingSeries    *memSeries
 	walSeriesRef      chunks.HeadSeriesRef
 	deletedSeriesRefs []chunks.HeadSeriesRef
+	deletionBarrier   *walReplayDeletionBarrier
 }
 
 func (wp *walSubsetProcessor) setup() {
@@ -792,9 +1006,14 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 		default:
 		}
 
+		var deletedForCallback map[chunks.HeadSeriesRef]labels.Labels
 		if len(in.deletedSeriesRefs) > 0 {
-			h.deleteSeriesByID(in.deletedSeriesRefs)
+			deletedForCallback = h.deleteSeriesByID(in.deletedSeriesRefs)
 		}
+		if len(deletedForCallback) > 0 {
+			h.series.seriesLifecycleCallback.PostDeletion(deletedForCallback)
+		}
+		in.deletionBarrier.complete()
 	}
 	h.updateMinMaxTime(mint, maxt)
 

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -60,6 +60,172 @@ type seriesRefSet struct {
 	mtx  sync.Mutex
 }
 
+type walReplayDeletionBarrierEntry struct {
+	hash uint64
+	lset labels.Labels
+}
+
+type walReplayDeletionBarrier struct {
+	done     chan struct{}
+	entries  []walReplayDeletionBarrierEntry
+	registry *walReplayPendingDeletions
+}
+
+type walReplayPendingDeletion struct {
+	lset    labels.Labels
+	barrier *walReplayDeletionBarrier
+}
+
+type walReplayPendingDeletionBucket struct {
+	entry      walReplayPendingDeletion
+	collisions []walReplayPendingDeletion
+}
+
+// walReplayPendingDeletions prevents a series record from re-creating a label
+// set until an earlier full deletion and its lifecycle callback have completed.
+type walReplayPendingDeletions struct {
+	// Keep the 64-bit atomic first to guarantee alignment on 32-bit systems.
+	count  atomic.Int64
+	mtx    sync.Mutex
+	byHash map[uint64]walReplayPendingDeletionBucket
+}
+
+func newWALReplayPendingDeletions() *walReplayPendingDeletions {
+	return &walReplayPendingDeletions{byHash: map[uint64]walReplayPendingDeletionBucket{}}
+}
+
+func (p *walReplayPendingDeletions) add(hash uint64, lset labels.Labels, barrier *walReplayDeletionBarrier) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.addLocked(hash, lset, barrier)
+}
+
+func (p *walReplayPendingDeletions) addLocked(hash uint64, lset labels.Labels, barrier *walReplayDeletionBarrier) {
+	bucket, ok := p.byHash[hash]
+	if !ok {
+		p.byHash[hash] = walReplayPendingDeletionBucket{
+			entry: walReplayPendingDeletion{lset: lset, barrier: barrier},
+		}
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		p.count.Inc()
+		return
+	}
+
+	if labels.Equal(bucket.entry.lset, lset) {
+		if bucket.entry.barrier == barrier {
+			return
+		}
+		bucket.entry.barrier = barrier
+		p.byHash[hash] = bucket
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		return
+	}
+
+	for i := range bucket.collisions {
+		if !labels.Equal(bucket.collisions[i].lset, lset) {
+			continue
+		}
+		if bucket.collisions[i].barrier == barrier {
+			return
+		}
+		bucket.collisions[i].barrier = barrier
+		p.byHash[hash] = bucket
+		barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+		return
+	}
+
+	bucket.collisions = append(bucket.collisions, walReplayPendingDeletion{lset: lset, barrier: barrier})
+	p.byHash[hash] = bucket
+	barrier.entries = append(barrier.entries, walReplayDeletionBarrierEntry{hash: hash, lset: lset})
+	p.count.Inc()
+}
+
+func (p *walReplayPendingDeletions) newBarrier(lsets []labels.Labels) *walReplayDeletionBarrier {
+	barrier := &walReplayDeletionBarrier{
+		done:     make(chan struct{}),
+		registry: p,
+	}
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	for _, lset := range lsets {
+		p.addLocked(lset.Hash(), lset, barrier)
+	}
+	return barrier
+}
+
+func (p *walReplayPendingDeletions) wait(hash uint64, lset labels.Labels) {
+	for {
+		if p.count.Load() == 0 {
+			return
+		}
+		p.mtx.Lock()
+		var done <-chan struct{}
+		if bucket, ok := p.byHash[hash]; ok {
+			if labels.Equal(bucket.entry.lset, lset) {
+				done = bucket.entry.barrier.done
+			} else {
+				for _, entry := range bucket.collisions {
+					if labels.Equal(entry.lset, lset) {
+						done = entry.barrier.done
+						break
+					}
+				}
+			}
+		}
+		p.mtx.Unlock()
+
+		if done == nil {
+			return
+		}
+		<-done
+	}
+}
+
+func (p *walReplayPendingDeletions) complete(barrier *walReplayDeletionBarrier) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	close(barrier.done)
+	for _, completed := range barrier.entries {
+		bucket, ok := p.byHash[completed.hash]
+		if !ok {
+			continue
+		}
+
+		if bucket.entry.barrier == barrier && labels.Equal(bucket.entry.lset, completed.lset) {
+			p.count.Dec()
+			if len(bucket.collisions) == 0 {
+				delete(p.byHash, completed.hash)
+			} else {
+				last := len(bucket.collisions) - 1
+				bucket.entry = bucket.collisions[last]
+				bucket.collisions = bucket.collisions[:last]
+				p.byHash[completed.hash] = bucket
+			}
+			continue
+		}
+
+		for i := range bucket.collisions {
+			entry := bucket.collisions[i]
+			if entry.barrier != barrier || !labels.Equal(entry.lset, completed.lset) {
+				continue
+			}
+			last := len(bucket.collisions) - 1
+			bucket.collisions[i] = bucket.collisions[last]
+			bucket.collisions = bucket.collisions[:last]
+			p.byHash[completed.hash] = bucket
+			p.count.Dec()
+			break
+		}
+	}
+}
+
+func (b *walReplayDeletionBarrier) complete() {
+	if b != nil {
+		b.registry.complete(b)
+	}
+}
+
 func (s *seriesRefSet) merge(other map[chunks.HeadSeriesRef]struct{}) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
@@ -96,13 +262,14 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		wg             sync.WaitGroup
 		concurrency    = h.opts.WALReplayConcurrency
 		processors     = make([]walSubsetProcessor, concurrency)
-		exemplarsInput chan record.RefExemplar
+		exemplarsInput chan walReplayExemplarInput
 
 		shards          = make([][]record.RefSample, concurrency)
 		histogramShards = make([][]histogramRecord, concurrency)
 
 		decoded                      = make(chan any, 10)
 		decodeErr, seriesCreationErr error
+		pendingDeletions             *walReplayPendingDeletions
 	)
 
 	defer func() {
@@ -132,12 +299,18 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 	}
 
 	wg.Add(1)
-	exemplarsInput = make(chan record.RefExemplar, 300)
-	go func(input <-chan record.RefExemplar) {
+	exemplarsInput = make(chan walReplayExemplarInput, 300)
+	go func(input <-chan walReplayExemplarInput) {
 		missingSeries := make(map[chunks.HeadSeriesRef]struct{})
 		var err error
 		defer wg.Done()
-		for e := range input {
+		for in := range input {
+			if in.done != nil {
+				// Channel ordering makes this a barrier: closing done acknowledges that all preceding exemplars have been replayed.
+				close(in.done)
+				continue
+			}
+			e := in.exemplar
 			ms := h.series.getByID(e.Ref)
 			if ms == nil {
 				unknownExemplarRefs.Inc()
@@ -252,12 +425,17 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 
 	// The records are always replayed from the oldest to the newest.
 	missingSeries := make(map[chunks.HeadSeriesRef]struct{})
+	exemplarsPending := false
 Outer:
 	for d := range decoded {
 		switch v := d.(type) {
 		case []record.RefSeries:
 			for _, walSeries := range v {
-				mSeries, created, err := h.getOrCreateWithOptionalID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels, false)
+				hash := walSeries.Labels.Hash()
+				if pendingDeletions != nil {
+					pendingDeletions.wait(hash, walSeries.Labels)
+				}
+				mSeries, created, err := h.getOrCreateWithOptionalID(walSeries.Ref, hash, walSeries.Labels, false)
 				if err != nil {
 					seriesCreationErr = err
 					break Outer
@@ -315,6 +493,7 @@ Outer:
 		case []tombstones.Stone:
 			// Tombstone records will be fairly rare, so not trying to optimise the allocations here.
 			deleteSeriesShards := make([][]chunks.HeadSeriesRef, concurrency)
+			deleteSeriesLabelShards := make([][]labels.Labels, concurrency)
 			for _, s := range v {
 				// A tombstone means this ref was previously allocated, even if its series record is no
 				// longer in the WAL. Advance lastSeriesID so the ref is not reissued.
@@ -329,13 +508,13 @@ Outer:
 						ref = r
 					}
 					if series := h.series.getByID(ref); series != nil {
-						// Remove the series from the hash index so that a later series
-						// record with the same labels creates a fresh series instead of
-						// mapping onto this one. It stays in the by-ref map so
-						// already-queued samples still resolve until the deletion applies.
+						// Remove the series from the hash index so a later series record with
+						// the same labels creates a fresh series. The by-ref entry remains until
+						// the queued deletion applies, so earlier records can still resolve it.
 						h.series.unlinkHash(series.lset.Hash(), ref)
 						mod := uint64(ref) % uint64(concurrency)
 						deleteSeriesShards[mod] = append(deleteSeriesShards[mod], ref)
+						deleteSeriesLabelShards[mod] = append(deleteSeriesLabelShards[mod], series.labels())
 					}
 					continue
 				}
@@ -357,10 +536,39 @@ Outer:
 				}
 			}
 
+			hasLiveFullDeletions := false
+			for i := range concurrency {
+				if len(deleteSeriesLabelShards[i]) > 0 {
+					hasLiveFullDeletions = true
+					break
+				}
+			}
+			if hasLiveFullDeletions && pendingDeletions == nil {
+				pendingDeletions = newWALReplayPendingDeletions()
+			}
+
+			// Drain separately processed exemplars before dispatching a live
+			// deletion so it cannot overtake an earlier exemplar for the series.
+			if hasLiveFullDeletions && exemplarsPending {
+				done := make(chan struct{})
+				exemplarsInput <- walReplayExemplarInput{done: done}
+				if h.walReplayExemplarDrainHook != nil {
+					h.walReplayExemplarDrainHook(done)
+				}
+				<-done
+				exemplarsPending = false
+			}
+
 			for i := range concurrency {
 				if len(deleteSeriesShards[i]) > 0 {
-					processors[i].input <- walSubsetProcessorInputItem{deletedSeriesRefs: deleteSeriesShards[i]}
-					deleteSeriesShards[i] = nil
+					var barrier *walReplayDeletionBarrier
+					if len(deleteSeriesLabelShards[i]) > 0 {
+						barrier = pendingDeletions.newBarrier(deleteSeriesLabelShards[i])
+					}
+					processors[i].input <- walSubsetProcessorInputItem{
+						deletedSeriesRefs: deleteSeriesShards[i],
+						deletionBarrier:   barrier,
+					}
 				}
 			}
 
@@ -376,7 +584,8 @@ Outer:
 					h.updateWALExpiry(e.Ref, e.T)
 					e.Ref = r
 				}
-				exemplarsInput <- e
+				exemplarsInput <- walReplayExemplarInput{exemplar: e}
+				exemplarsPending = true
 			}
 			for i := range v { // Zero out to avoid retaining label data.
 				v[i].Labels = labels.EmptyLabels()
@@ -605,12 +814,18 @@ type walSubsetProcessor struct {
 	histogramsOutput chan []histogramRecord
 }
 
+type walReplayExemplarInput struct {
+	exemplar record.RefExemplar
+	done     chan struct{}
+}
+
 type walSubsetProcessorInputItem struct {
 	samples           []record.RefSample
 	histogramSamples  []histogramRecord
 	existingSeries    *memSeries
 	walSeriesRef      chunks.HeadSeriesRef
 	deletedSeriesRefs []chunks.HeadSeriesRef
+	deletionBarrier   *walReplayDeletionBarrier
 }
 
 func (wp *walSubsetProcessor) setup() {
@@ -859,9 +1074,14 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 		default:
 		}
 
+		var deletedForCallback map[chunks.HeadSeriesRef]labels.Labels
 		if len(in.deletedSeriesRefs) > 0 {
-			h.deleteSeriesByID(in.deletedSeriesRefs)
+			deletedForCallback = h.deleteSeriesByID(in.deletedSeriesRefs)
 		}
+		if len(deletedForCallback) > 0 {
+			h.series.seriesLifecycleCallback.PostDeletion(deletedForCallback)
+		}
+		in.deletionBarrier.complete()
 	}
 	h.updateMinMaxTime(mint, maxt)
 


### PR DESCRIPTION
When WAL replay applies a full-series deletion, it must remove every retained chunk from the Head accounting and keep asynchronous replay work in WAL order. This PR fixes two remaining consistency gaps:

- Account for all in-order and out-of-order m-mapped and head chunks when replay deletes a series, then clear the retained chunk state and reset the head-chunk list/count together. This keeps the `Head` chunk metrics and `mmapReady` invariant consistent.
- Drain earlier exemplars before dispatching a live deletion. Track in-flight full deletions by exact label set so `PostDeletion` completes before later lifecycle callbacks for the same labels, while unrelated labels remain pipelined.

Regression coverage includes real m-mapped chunks, raw and duplicate-reference tombstones, callback ordering, deterministic exemplar draining, both replay shards, WBL data, repeated/absent deletions, and a 500-series stress case.

### Performance

Benchmarks compared `prometheus/main` at `9e5466380279441ea2a869cc5e871e338f8e9022` with this PR at `7a33b17d6fc89b799ac3f8f2ed8c589348a3aba2` on an Apple M4 Pro using Go 1.27.0 and `GOMAXPROCS=14`:

```sh
GOMAXPROCS=14 go test ./tsdb -run '^$' -bench '^BenchmarkHeadWALReplayFullDeletion$' -benchmem -count=6
```

```text
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Apple M4 Pro
                                                               │ /private/tmp/pr18907-main-9e546638-bench.txt │ /private/tmp/pr18907-optimized-bench.txt │
                                                               │                    sec/op                    │      sec/op        vs base               │
HeadWALReplayFullDeletion/none/concurrency=1-14                                                  3.315m ±  3%         3.174m ± 2%   -4.24% (p=0.002 n=6)
HeadWALReplayFullDeletion/none/concurrency=14-14                                                 4.343m ±  5%         3.938m ± 1%   -9.33% (p=0.002 n=6)
HeadWALReplayFullDeletion/unrelated/one/concurrency=1-14                                         5.255m ±  6%         4.837m ± 1%   -7.94% (p=0.002 n=6)
HeadWALReplayFullDeletion/unrelated/one/concurrency=14-14                                        5.312m ± 12%         4.720m ± 1%  -11.14% (p=0.002 n=6)
HeadWALReplayFullDeletion/unrelated/repeated/concurrency=1-14                                    11.57m ±  1%         11.96m ± 2%   +3.36% (p=0.002 n=6)
HeadWALReplayFullDeletion/unrelated/repeated/concurrency=14-14                                   7.666m ±  3%         7.874m ± 1%   +2.71% (p=0.002 n=6)
HeadWALReplayFullDeletion/recreated/one/concurrency=1-14                                         4.232m ±  2%         4.323m ± 1%   +2.15% (p=0.041 n=6)
HeadWALReplayFullDeletion/recreated/one/concurrency=14-14                                        4.102m ±  3%         4.238m ± 0%   +3.31% (p=0.002 n=6)
HeadWALReplayFullDeletion/recreated/repeated/concurrency=1-14                                    11.20m ±  4%         12.17m ± 1%   +8.67% (p=0.002 n=6)
HeadWALReplayFullDeletion/recreated/repeated/concurrency=14-14                                   7.205m ±  7%         7.469m ± 1%        ~ (p=0.394 n=6)
geomean                                                                                          5.886m               5.822m        -1.09%

                                                               │ /private/tmp/pr18907-main-9e546638-bench.txt │ /private/tmp/pr18907-optimized-bench.txt │
                                                               │                     B/op                     │       B/op         vs base               │
HeadWALReplayFullDeletion/none/concurrency=1-14                                                  6.060Mi ± 0%        6.069Mi ± 0%   +0.15% (p=0.002 n=6)
HeadWALReplayFullDeletion/none/concurrency=14-14                                                 6.621Mi ± 0%        6.699Mi ± 0%   +1.17% (p=0.002 n=6)
HeadWALReplayFullDeletion/unrelated/one/concurrency=1-14                                         6.640Mi ± 0%        6.990Mi ± 0%   +5.27% (p=0.002 n=6)
HeadWALReplayFullDeletion/unrelated/one/concurrency=14-14                                        7.675Mi ± 0%        8.026Mi ± 0%   +4.57% (p=0.002 n=6)
HeadWALReplayFullDeletion/unrelated/repeated/concurrency=1-14                                    8.620Mi ± 0%        9.313Mi ± 0%   +8.04% (p=0.002 n=6)
HeadWALReplayFullDeletion/unrelated/repeated/concurrency=14-14                                   11.22Mi ± 0%        11.83Mi ± 0%   +5.42% (p=0.002 n=6)
HeadWALReplayFullDeletion/recreated/one/concurrency=1-14                                         5.684Mi ± 0%        6.208Mi ± 0%   +9.21% (p=0.002 n=6)
HeadWALReplayFullDeletion/recreated/one/concurrency=14-14                                        6.667Mi ± 0%        7.073Mi ± 0%   +6.09% (p=0.002 n=6)
HeadWALReplayFullDeletion/recreated/repeated/concurrency=1-14                                    7.815Mi ± 0%        9.526Mi ± 0%  +21.89% (p=0.002 n=6)
HeadWALReplayFullDeletion/recreated/repeated/concurrency=14-14                                   10.26Mi ± 0%        10.94Mi ± 0%   +6.70% (p=0.002 n=6)
geomean                                                                                          7.549Mi             8.055Mi        +6.71%

                                                               │ /private/tmp/pr18907-main-9e546638-bench.txt │ /private/tmp/pr18907-optimized-bench.txt │
                                                               │                  allocs/op                   │     allocs/op       vs base              │
HeadWALReplayFullDeletion/none/concurrency=1-14                                                   56.35k ± 0%          56.35k ± 0%       ~ (p=0.455 n=6)
HeadWALReplayFullDeletion/none/concurrency=14-14                                                  56.57k ± 0%          56.57k ± 0%       ~ (p=0.924 n=6)
HeadWALReplayFullDeletion/unrelated/one/concurrency=1-14                                          59.15k ± 0%          59.20k ± 0%  +0.08% (p=0.002 n=6)
HeadWALReplayFullDeletion/unrelated/one/concurrency=14-14                                         60.17k ± 0%          60.51k ± 0%  +0.58% (p=0.002 n=6)
HeadWALReplayFullDeletion/unrelated/repeated/concurrency=1-14                                     68.63k ± 0%          68.77k ± 0%  +0.21% (p=0.002 n=6)
HeadWALReplayFullDeletion/unrelated/repeated/concurrency=14-14                                    72.46k ± 0%          73.89k ± 0%  +1.97% (p=0.002 n=6)
HeadWALReplayFullDeletion/recreated/one/concurrency=1-14                                          49.37k ± 0%          49.48k ± 0%  +0.20% (p=0.002 n=6)
HeadWALReplayFullDeletion/recreated/one/concurrency=14-14                                         50.23k ± 0%          50.53k ± 0%  +0.60% (p=0.002 n=6)
HeadWALReplayFullDeletion/recreated/repeated/concurrency=1-14                                     64.45k ± 0%          66.07k ± 0%  +2.51% (p=0.002 n=6)
HeadWALReplayFullDeletion/recreated/repeated/concurrency=14-14                                    68.07k ± 0%          69.82k ± 0%  +2.56% (p=0.002 n=6)
geomean                                                                                           60.09k               60.61k       +0.87%
```

#### Which issue(s) does the PR fix:

None.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] TSDB: Preserve chunk accounting, exemplars, and series lifecycle callback ordering when WAL replay applies full-series deletions
```

