### PR TITLE
chore(ci) install libsnmp-dev for snmp_exporter govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Run govulncheck
     steps:
+      - name: Install snmp_exporter/generator dependencies
+        id: snmp-deps
+        run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
+        if: github.repository == 'prometheus/snmp_exporter'
       - id: govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         env:


### PR DESCRIPTION
snmp_exporter has a generator/ subpackage that uses CGo and requires libsnmp-dev to compile. Without it, govulncheck ./... fails with fatal error: net-snmp/net-snmp-config.h: No such file or directory.

Fixes: prometheus/snmp_exporter#1618

```release-notes
NONE
```