### PR TITLE
tsdb: fix WAL replay dropping samples for series re-created after stale deletion

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2326,14 +2326,7 @@ func (h *Head) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict 
 // deleteSeriesByID deletes the series with the given reference.
 // Only used for WAL replay.
 func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
-	var (
-		deleted            = map[storage.SeriesRef]struct{}{}
-		deletedForCallback = map[chunks.HeadSeriesRef]labels.Labels{}
-		affected           = map[labels.Label]struct{}{}
-		staleSeriesDeleted = 0
-		chunksRemoved      = 0
-	)
-
+	detached := make([]*memSeries, 0, len(refs))
 	for _, ref := range refs {
 		// Delete the reference from the series map.
 		// Copying getByID here to avoid locking and unlocking twice.
@@ -2354,6 +2347,28 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		h.series.hashes[hashStripe].del(hash, series.ref)
 		h.series.locks[hashStripe].Unlock()
 
+		detached = append(detached, series)
+	}
+
+	h.accountDeletedSeries(detached)
+}
+
+// accountDeletedSeries updates head metrics, counters, postings, and
+// tombstones for deleted series, and neutralizes the series objects against
+// late accesses through stale references. The series must already have been
+// removed from the head's lookup maps.
+// Only used for WAL replay; must run on the replay processor that owns the
+// series, after any in-flight appends to them.
+func (h *Head) accountDeletedSeries(detached []*memSeries) {
+	var (
+		deleted            = map[storage.SeriesRef]struct{}{}
+		deletedForCallback = map[chunks.HeadSeriesRef]labels.Labels{}
+		affected           = map[labels.Label]struct{}{}
+		staleSeriesDeleted = 0
+		chunksRemoved      = 0
+	)
+
+	for _, series := range detached {
 		if value.IsStaleNaN(series.lastValue) ||
 			(series.lastHistogramValue != nil && value.IsStaleNaN(series.lastHistogramValue.Sum)) ||
 			(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2386,6 +2386,12 @@ func (h *Head) accountDeletedSeries(detached []*memSeries) {
 		// resetSeriesWithMMappedChunks is queued on the same WAL-replay processor
 		// after this deletion (it would otherwise subtract len(mmappedChunks) again).
 		series.mmappedChunks = nil
+		// Release the chunk data, so that references retained past this
+		// point (such as the pending-deletion tracking during WAL replay)
+		// do not pin it in memory.
+		series.headChunks = nil
+		series.app = nil
+		series.ooo = nil
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		deletedForCallback[series.ref] = series.lset
@@ -2558,6 +2564,29 @@ func (s *stripeSeries) setUnlessAlreadySet(hash uint64, lset labels.Labels, seri
 	s.locks[stripe].Unlock()
 
 	return series, true
+}
+
+// displaceIfUnchanged removes the given series from the lookup maps, provided
+// it is still the object registered under its reference, and reports whether
+// it did. If the series has already been removed, or replaced by another
+// object under the same reference, the maps are left untouched.
+// Only used for WAL replay.
+func (s *stripeSeries) displaceIfUnchanged(series *memSeries, hash uint64) bool {
+	stripe := s.refStripe(series.ref)
+	s.locks[stripe].Lock()
+	if s.series[stripe][series.ref] != series {
+		s.locks[stripe].Unlock()
+		return false
+	}
+	delete(s.series[stripe], series.ref)
+	s.locks[stripe].Unlock()
+
+	hashStripe := hash & uint64(s.size-1)
+	s.locks[hashStripe].Lock()
+	s.hashes[hashStripe].del(hash, series.ref)
+	s.locks[hashStripe].Unlock()
+
+	return true
 }
 
 func (s *stripeSeries) postCreation(lset labels.Labels) {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1048,6 +1048,236 @@ func TestHead_WALMultiRef_StaleDeletion_ChunkGaugeNotNegative(t *testing.T) {
 	require.GreaterOrEqual(t, chunksGauge, 0.0, "prometheus_tsdb_head_chunks gauge must not be negative after WAL replay")
 }
 
+// TestHead_WALReplay verifies WAL replay handling of full-deletion tombstones
+// interleaved with series records re-creating the deleted series.
+func TestHead_WALReplay(t *testing.T) {
+	// Verify that a series re-created after stale-series deletion keeps its
+	// new samples across a WAL replay.
+	//
+	// truncateStaleSeries writes a [MinInt64, MaxInt64] tombstone for the
+	// deleted series; re-creating the series under the same labels produces a
+	// new WAL ref. During replay, deletions are applied asynchronously on the
+	// sharded replay processors, while series records are resolved on the
+	// dispatch goroutine. If the dispatch goroutine reads the re-created
+	// series' record while the deletion is still queued, it used to map the
+	// new ref to the doomed series object, and every subsequent record for
+	// the new ref was then dropped as an unknown ref once the deletion
+	// landed: the resurrected series lost all its WAL data for that replay.
+	t.Run("stale series resurrection", func(t *testing.T) {
+		head, w := newTestHead(t, 1000, compression.None, false)
+		require.NoError(t, head.Init(0))
+
+		lset := labels.FromStrings("foo", "bar")
+
+		// Queue plenty of sample records for the first incarnation so its
+		// replay processor is still busy appending when the dispatch
+		// goroutine reads the re-created series' record. This biases the
+		// replay towards the race being tested; it cannot turn the test
+		// flaky, since with the fix the outcome is the same in either
+		// interleaving.
+		var ref1 storage.SeriesRef
+		ts := int64(0)
+		for range 5 {
+			app := head.Appender(context.Background())
+			for range 1000 {
+				ref, err := app.Append(0, lset, ts, float64(ts))
+				require.NoError(t, err)
+				ref1 = ref
+				ts++
+			}
+			require.NoError(t, app.Commit())
+		}
+
+		// Mark the series stale and delete it; this writes the full-range
+		// tombstone record to the WAL.
+		app := head.Appender(context.Background())
+		_, err := app.Append(0, lset, ts, math.Float64frombits(value.StaleNaN))
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+		require.NoError(t, head.truncateStaleSeries([]storage.SeriesRef{ref1}, ts, math.MaxUint64))
+
+		// Re-create the series under the same labels (new ref) with new samples.
+		app = head.Appender(context.Background())
+		ref2, err := app.Append(0, lset, 6000, 1)
+		require.NoError(t, err)
+		_, err = app.Append(0, lset, 6100, 2)
+		require.NoError(t, err)
+		_, err = app.Append(0, lset, 6200, 3)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+		require.NotEqual(t, ref1, ref2, "refs must differ after stale truncation and recreation")
+
+		require.NoError(t, head.Close())
+
+		// Reopen the head to trigger WAL replay. The WAL contains (in order):
+		//   series(ref1) → samples(ref1) → tombstone(ref1) → series(ref2) → samples(ref2)
+		w, err = wlog.New(nil, nil, w.Dir(), compression.None)
+		require.NoError(t, err)
+		opts := DefaultHeadOptions()
+		opts.ChunkRange = 1000
+		opts.ChunkDirRoot = head.opts.ChunkDirRoot
+		head, err = NewHead(nil, nil, w, nil, opts, nil)
+		require.NoError(t, err)
+		require.NoError(t, head.Init(0))
+		defer func() {
+			require.NoError(t, head.Close())
+		}()
+
+		require.Equal(t, 1, int(head.NumSeries()), "the re-created series must survive WAL replay")
+
+		q, err := NewBlockQuerier(head, 5500, 7000)
+		require.NoError(t, err)
+		series := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+		require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: {
+			sample{0, 6000, 1, nil, nil},
+			sample{0, 6100, 2, nil, nil},
+			sample{0, 6200, 3, nil, nil},
+		}}, series)
+
+		// The deleted incarnation's chunks must be fully accounted for in
+		// both interleavings, leaving exactly the re-created series' head
+		// chunk.
+		chunksGauge := prom_testutil.ToFloat64(head.metrics.chunks)
+		require.Equal(t, 1.0, chunksGauge, "prometheus_tsdb_head_chunks gauge must count only the re-created series' chunk after WAL replay")
+	})
+
+	// Replay raw WALs that interleave full-deletion tombstones with duplicate
+	// series records around a series deleted and re-created under the same
+	// labels, and verify that exactly the re-created incarnation with its
+	// samples survives the replay.
+	t.Run("stale series deletion variants", func(t *testing.T) {
+		lset := labels.FromStrings("foo", "bar")
+		fullTombstone := func(ref storage.SeriesRef) []tombstones.Stone {
+			return []tombstones.Stone{{Ref: ref, Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}}}
+		}
+		cases := []struct {
+			name string
+			recs []any
+		}{
+			{
+				// The re-created series gets a duplicate series record of its
+				// own; its samples must resolve to the re-created series.
+				name: "duplicate series record after resurrection",
+				recs: []any{
+					[]record.RefSeries{{Ref: 1, Labels: lset}},
+					[]record.RefSample{{Ref: 1, T: 10, V: 1}, {Ref: 1, T: 20, V: 2}},
+					fullTombstone(1),
+					[]record.RefSeries{{Ref: 2, Labels: lset}},
+					[]record.RefSeries{{Ref: 3, Labels: lset}},
+					[]record.RefSample{{Ref: 3, T: 30, V: 3}},
+				},
+			},
+			{
+				// The tombstone references a duplicate of the deleted series;
+				// the deletion must follow the mapping to the actual object.
+				name: "tombstone for a duplicate series record",
+				recs: []any{
+					[]record.RefSeries{{Ref: 1, Labels: lset}},
+					[]record.RefSeries{{Ref: 2, Labels: lset}},
+					[]record.RefSample{{Ref: 2, T: 10, V: 1}},
+					fullTombstone(2),
+					[]record.RefSeries{{Ref: 3, Labels: lset}},
+					[]record.RefSample{{Ref: 3, T: 30, V: 3}},
+				},
+			},
+			{
+				name: "repeated full-deletion tombstones",
+				recs: []any{
+					[]record.RefSeries{{Ref: 1, Labels: lset}},
+					[]record.RefSample{{Ref: 1, T: 10, V: 1}},
+					fullTombstone(1),
+					fullTombstone(1),
+					[]record.RefSeries{{Ref: 2, Labels: lset}},
+					[]record.RefSample{{Ref: 2, T: 30, V: 3}},
+				},
+			},
+		}
+		concurrencies := []struct {
+			name string
+			n    int
+		}{
+			{name: "default concurrency", n: 0},
+			{name: "concurrency 1", n: 1},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				for _, conc := range concurrencies {
+					t.Run(conc.name, func(t *testing.T) {
+						dir := t.TempDir()
+						w, err := wlog.New(nil, nil, filepath.Join(dir, "wal"), compression.None)
+						require.NoError(t, err)
+						populateTestWL(t, w, c.recs, nil, false)
+
+						opts := DefaultHeadOptions()
+						opts.ChunkRange = 1000
+						opts.ChunkDirRoot = dir
+						if conc.n > 0 {
+							opts.WALReplayConcurrency = conc.n
+						}
+						head, err := NewHead(nil, nil, w, nil, opts, nil)
+						require.NoError(t, err)
+						defer func() {
+							require.NoError(t, head.Close())
+						}()
+						require.NoError(t, head.Init(0))
+
+						require.Equal(t, 1, int(head.NumSeries()), "exactly the re-created series must survive replay")
+						q, err := NewBlockQuerier(head, 0, 100)
+						require.NoError(t, err)
+						series := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+						require.Equal(t, map[string][]chunks.Sample{`{foo="bar"}`: {
+							sample{0, 30, 3, nil, nil},
+						}}, series)
+					})
+				}
+			})
+		}
+	})
+}
+
+// TestStripeSeries_DisplaceIfUnchanged verifies that displaceIfUnchanged
+// removes a series from the lookup maps only while it is still the object
+// registered under its reference.
+func TestStripeSeries_DisplaceIfUnchanged(t *testing.T) {
+	h, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
+	require.NoError(t, h.Init(0))
+
+	lset := labels.FromStrings("foo", "bar")
+	hash := lset.Hash()
+	s1, created, err := h.getOrCreateWithOptionalID(0, hash, lset, false)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	// Displacing a registered series removes it from both lookup maps.
+	require.True(t, h.series.displaceIfUnchanged(s1, hash))
+	require.Nil(t, h.series.getByID(s1.ref))
+	require.Nil(t, h.series.getByHash(hash, lset))
+
+	// Displacing an already removed series is a no-op.
+	require.False(t, h.series.displaceIfUnchanged(s1, hash))
+
+	// A series re-created under the same labels is a different object; the
+	// stale one must not displace it.
+	s2, created, err := h.getOrCreateWithOptionalID(0, hash, lset, false)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NotSame(t, s1, s2)
+	require.False(t, h.series.displaceIfUnchanged(s1, hash))
+	require.Same(t, s2, h.series.getByHash(hash, lset))
+
+	// Even with the stale object's reference slot re-occupied by another
+	// object, pointer identity prevents displacement.
+	stripe := h.series.refStripe(s1.ref)
+	h.series.locks[stripe].Lock()
+	h.series.series[stripe][s1.ref] = s2
+	h.series.locks[stripe].Unlock()
+	require.False(t, h.series.displaceIfUnchanged(s1, hash))
+	require.Same(t, s2, h.series.getByID(s1.ref))
+	h.series.locks[stripe].Lock()
+	delete(h.series.series[stripe], s1.ref)
+	h.series.locks[stripe].Unlock()
+}
+
 func TestHead_WALCheckpointMultiRef(t *testing.T) {
 	cases := []struct {
 		name               string

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -251,22 +251,65 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 
 	// The records are always replayed from the oldest to the newest.
 	missingSeries := make(map[chunks.HeadSeriesRef]struct{})
+	// Series objects whose deletion has been dispatched to a processor but may
+	// not have been applied yet, keyed by their reference.
+	pendingDeletes := make(map[chunks.HeadSeriesRef]*memSeries)
 Outer:
 	for d := range decoded {
 		switch v := d.(type) {
 		case []record.RefSeries:
 			for _, walSeries := range v {
-				mSeries, created, err := h.getOrCreateWithOptionalID(walSeries.Ref, walSeries.Labels.Hash(), walSeries.Labels, false)
-				if err != nil {
-					seriesCreationErr = err
-					break Outer
+				hash := walSeries.Labels.Hash()
+				var (
+					mSeries *memSeries
+					created bool
+					err     error
+				)
+				for {
+					mSeries, created, err = h.getOrCreateWithOptionalID(walSeries.Ref, hash, walSeries.Labels, false)
+					if err != nil {
+						seriesCreationErr = err
+						break Outer
+					}
+					if created {
+						break
+					}
+					if pendingDeletes[mSeries.ref] != mSeries {
+						// A live series with these labels exists, so this
+						// record is a duplicate of it.
+						multiRef[walSeries.Ref] = mSeries.ref
+						break
+					}
+					// The series found by labels has a deletion queued behind
+					// earlier records of its replay processor. This record
+					// must re-create the series rather than become a
+					// duplicate of the doomed object (its samples would be
+					// dropped once the deletion is applied). Displace the
+					// object from the lookup maps and retry; its accounting
+					// is settled on the owning processor, after any of its
+					// appends still in flight. Samples of the displaced
+					// series still queued on that processor can no longer
+					// resolve it and are counted as unknown references; the
+					// series is deleted either way, so no data that should
+					// survive is lost.
+					if h.series.displaceIfUnchanged(mSeries, hash) {
+						processors[uint64(mSeries.ref)%uint64(concurrency)].input <- walSubsetProcessorInputItem{deletedSeries: mSeries}
+						delete(pendingDeletes, mSeries.ref)
+					} else if cur := h.series.getByID(mSeries.ref); cur != nil && cur != mSeries {
+						// The reference has been re-occupied by a different
+						// series object, which only a corrupt WAL can
+						// produce (references are not reused). Drop the
+						// stale pending entry so the retry settles on the
+						// duplicate path instead of spinning.
+						delete(pendingDeletes, mSeries.ref)
+					}
+					// Otherwise the owning processor is concurrently
+					// applying the deletion; retry until the lookup maps
+					// converge.
 				}
 
 				if chunks.HeadSeriesRef(h.lastSeriesID.Load()) < walSeries.Ref {
 					h.lastSeriesID.Store(uint64(walSeries.Ref))
-				}
-				if !created {
-					multiRef[walSeries.Ref] = mSeries.ref
 				}
 
 				idx := uint64(mSeries.ref) % uint64(concurrency)
@@ -317,11 +360,21 @@ Outer:
 			for _, s := range v {
 				if len(s.Intervals) == 1 && s.Intervals[0].Mint == math.MinInt64 && s.Intervals[0].Maxt == math.MaxInt64 {
 					// This series was fully deleted at this point. This record is only done for stale series at the moment.
+					// Remember the doomed series object: if a series record
+					// with the same labels arrives before the deletion has
+					// been applied, the series must be re-created rather
+					// than treated as a duplicate of the deleted one.
+					if obj := h.series.getByID(chunks.HeadSeriesRef(s.Ref)); obj != nil {
+						pendingDeletes[chunks.HeadSeriesRef(s.Ref)] = obj
+					}
 					mod := uint64(s.Ref) % uint64(concurrency)
 					deleteSeriesShards[mod] = append(deleteSeriesShards[mod], chunks.HeadSeriesRef(s.Ref))
 
 					// If the series is with a different reference, try deleting that.
 					if r, ok := multiRef[chunks.HeadSeriesRef(s.Ref)]; ok {
+						if obj := h.series.getByID(r); obj != nil {
+							pendingDeletes[r] = obj
+						}
 						mod := uint64(r) % uint64(concurrency)
 						deleteSeriesShards[mod] = append(deleteSeriesShards[mod], r)
 					}
@@ -599,6 +652,9 @@ type walSubsetProcessorInputItem struct {
 	existingSeries    *memSeries
 	walSeriesRef      chunks.HeadSeriesRef
 	deletedSeriesRefs []chunks.HeadSeriesRef
+	// deletedSeries is a series object already removed from the head's lookup
+	// maps, awaiting accounting on the processor that owns its reference.
+	deletedSeries *memSeries
 }
 
 func (wp *walSubsetProcessor) setup() {
@@ -690,6 +746,11 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if h.resetSeriesWithMMappedChunks(in.existingSeries, mmc, oooMmc, in.walSeriesRef) {
 				mmapOverlappingChunks++
 			}
+			continue
+		}
+
+		if in.deletedSeries != nil {
+			h.accountDeletedSeries([]*memSeries{in.deletedSeries})
 			continue
 		}
 


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Series deletions are applied asynchronously on the sharded replay processors, while series records are resolved on the dispatch goroutine. When a full-deletion tombstone was closely followed by a series record re-creating the series under the same labels, the dispatch goroutine could resolve the new record as a duplicate of the doomed series object and map the new ref to it. Once the deletion was applied, every subsequent record for the new ref was dropped as an unknown ref: the re-created series lost all its WAL and WBL data for that replay.

Track series objects with dispatched deletions on the dispatch goroutine. When a series record resolves to such an object, displace it from the lookup maps (guarded by pointer identity against the owning processor applying the deletion concurrently) and re-create the series under the record's own ref instead of mapping to the doomed object. The displaced object's accounting is settled on its owning processor, behind any of its in-flight appends.

Samples of the displaced series still queued on its processor are dropped and counted as unknown references rather than appended and then deleted; the resulting head state is identical, but the unknown-refs counter can be elevated for replays that hit the race.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] TSDB: Fix WAL replay dropping all samples of a series re-created after stale series compaction deleted it
```
