### PR TITLE
promql: remove unused defaultEpsilon test constant

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -48,7 +48,6 @@ import (
 const (
 	env                  = "query execution"
 	defaultLookbackDelta = 5 * time.Minute
-	defaultEpsilon       = 0.000001 // Relative error allowed for sample values.
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
The `defaultEpsilon` constant in `promql/engine_test.go` was declared but never used. The actively used copy lives in `promql/promqltest/test.go`. This removes the dead declaration.

```release-notes
NONE
```

broken out from #18081 