### PR TITLE
tsdb/index: add Close to Postings

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -17,6 +17,7 @@ import (
 	"container/heap"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"maps"
 	"math"
@@ -536,6 +537,9 @@ func (p *MemPostings) PostingsForAllLabelValues(ctx context.Context, name string
 
 // ExpandPostings returns the postings expanded as a slice.
 func ExpandPostings(p Postings) (res []storage.SeriesRef, err error) {
+	defer func() {
+		err = errors.Join(err, p.Close())
+	}()
 	for p.Next() {
 		res = append(res, p.At())
 	}
@@ -557,6 +561,9 @@ type Postings interface {
 
 	// Err returns the last error of the iterator.
 	Err() error
+
+	// Close releases resources retained by the iterator.
+	Close() error
 }
 
 // errPostings is an empty iterator that always errors.
@@ -568,6 +575,7 @@ func (errPostings) Next() bool                  { return false }
 func (errPostings) Seek(storage.SeriesRef) bool { return false }
 func (errPostings) At() storage.SeriesRef       { return 0 }
 func (e errPostings) Err() error                { return e.err }
+func (errPostings) Close() error                { return nil }
 
 var emptyPostings = errPostings{}
 
@@ -609,6 +617,7 @@ func Intersect(its ...Postings) Postings {
 type intersectPostings struct {
 	postings []Postings        // These are the postings we will be intersecting.
 	current  storage.SeriesRef // The current intersection, if Seek() or Next() has returned true.
+	closed   bool
 }
 
 func newIntersectPostings(its ...Postings) *intersectPostings {
@@ -675,6 +684,16 @@ func (it *intersectPostings) Err() error {
 	return nil
 }
 
+func (it *intersectPostings) Close() error {
+	if it.closed {
+		return nil
+	}
+	it.closed = true
+	err := closePostings(it.postings...)
+	it.postings = nil
+	return err
+}
+
 // Merge returns a new iterator over the union of the input iterators.
 func Merge[T Postings](_ context.Context, its ...T) Postings {
 	if len(its) == 0 {
@@ -692,9 +711,10 @@ func Merge[T Postings](_ context.Context, its ...T) Postings {
 }
 
 type mergedPostings[T Postings] struct {
-	p   []T
-	h   *loser.Tree[storage.SeriesRef, T]
-	cur storage.SeriesRef
+	p      []T
+	h      *loser.Tree[storage.SeriesRef, T]
+	cur    storage.SeriesRef
+	closed bool
 }
 
 func newMergedPostings[T Postings](p []T) (m *mergedPostings[T], nonEmpty bool) {
@@ -742,6 +762,23 @@ func (it mergedPostings[T]) Err() error {
 	return nil
 }
 
+func (it *mergedPostings[T]) Close() error {
+	if it.closed {
+		return nil
+	}
+	it.closed = true
+
+	errs := make([]error, 0, len(it.p))
+	for _, p := range it.p {
+		if err := p.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	it.p = nil
+	it.h = nil
+	return errors.Join(errs...)
+}
+
 // Without returns a new postings list that contains all elements from the full list that
 // are not in the drop list.
 func Without(full, drop Postings) Postings {
@@ -762,6 +799,7 @@ type removedPostings struct {
 
 	initialized bool
 	fok, rok    bool
+	closed      bool
 }
 
 func newRemovedPostings(full, remove Postings) *removedPostings {
@@ -827,16 +865,37 @@ func (rp *removedPostings) Err() error {
 	return rp.remove.Err()
 }
 
+func (rp *removedPostings) Close() error {
+	if rp.closed {
+		return nil
+	}
+	rp.closed = true
+	err := closePostings(rp.full, rp.remove)
+	rp.full = nil
+	rp.remove = nil
+	return err
+}
+
 // listPostings implements the Postings interface over a plain list.
 type listPostings struct {
-	list []storage.SeriesRef
-	cur  storage.SeriesRef
+	list   []storage.SeriesRef
+	cur    storage.SeriesRef
+	closed bool
+	pooled bool
+}
+
+var listPostingsPool = sync.Pool{
+	New: func() any {
+		return &listPostings{}
+	},
 }
 
 // NewListPostings creates a Postings from the supplied SeriesRefs, which must be in order.
 // The list slice passed in is retained.
 func NewListPostings(list []storage.SeriesRef) Postings {
-	return &listPostings{list: list}
+	it := listPostingsPool.Get().(*listPostings)
+	*it = listPostings{list: list, pooled: true}
+	return it
 }
 
 func (it *listPostings) At() storage.SeriesRef {
@@ -879,6 +938,19 @@ func (*listPostings) Err() error {
 	return nil
 }
 
+func (it *listPostings) Close() error {
+	if it.closed {
+		return nil
+	}
+	it.list = nil
+	it.cur = 0
+	it.closed = true
+	if it.pooled {
+		listPostingsPool.Put(it)
+	}
+	return nil
+}
+
 // Len returns the remaining number of postings in the list.
 func (it *listPostings) Len() int {
 	return len(it.list)
@@ -889,6 +961,8 @@ func (it *listPostings) Len() int {
 type bigEndianPostings struct {
 	list []byte
 	cur  uint32
+	// closed makes Close idempotent.
+	closed bool
 }
 
 func newBigEndianPostings(list []byte) *bigEndianPostings {
@@ -930,6 +1004,29 @@ func (it *bigEndianPostings) Seek(x storage.SeriesRef) bool {
 
 func (*bigEndianPostings) Err() error {
 	return nil
+}
+
+func (it *bigEndianPostings) Close() error {
+	if it.closed {
+		return nil
+	}
+	it.list = nil
+	it.cur = 0
+	it.closed = true
+	return nil
+}
+
+func closePostings(postings ...Postings) error {
+	errs := make([]error, 0, len(postings))
+	for _, p := range postings {
+		if p == nil {
+			continue
+		}
+		if err := p.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // FindIntersectingPostings checks the intersection of p and candidates[i] for each i in candidates,

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -562,7 +562,9 @@ type Postings interface {
 	// Err returns the last error of the iterator.
 	Err() error
 
-	// Close releases resources retained by the iterator.
+	// Close releases resources retained by the iterator. It must be called
+	// exactly once when the iterator is no longer needed. The iterator must not
+	// be used after Close returns, including any further Close calls.
 	Close() error
 }
 
@@ -878,9 +880,9 @@ func (rp *removedPostings) Close() error {
 
 // listPostings implements the Postings interface over a plain list.
 type listPostings struct {
-	list   []storage.SeriesRef
-	cur    storage.SeriesRef
-	closed bool
+	list []storage.SeriesRef
+	cur  storage.SeriesRef
+
 	pooled bool
 }
 
@@ -939,12 +941,8 @@ func (*listPostings) Err() error {
 }
 
 func (it *listPostings) Close() error {
-	if it.closed {
-		return nil
-	}
 	it.list = nil
 	it.cur = 0
-	it.closed = true
 	if it.pooled {
 		listPostingsPool.Put(it)
 	}

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -619,7 +619,6 @@ func Intersect(its ...Postings) Postings {
 type intersectPostings struct {
 	postings []Postings        // These are the postings we will be intersecting.
 	current  storage.SeriesRef // The current intersection, if Seek() or Next() has returned true.
-	closed   bool
 }
 
 func newIntersectPostings(its ...Postings) *intersectPostings {
@@ -687,10 +686,6 @@ func (it *intersectPostings) Err() error {
 }
 
 func (it *intersectPostings) Close() error {
-	if it.closed {
-		return nil
-	}
-	it.closed = true
 	err := closePostings(it.postings...)
 	it.postings = nil
 	return err
@@ -713,10 +708,9 @@ func Merge[T Postings](_ context.Context, its ...T) Postings {
 }
 
 type mergedPostings[T Postings] struct {
-	p      []T
-	h      *loser.Tree[storage.SeriesRef, T]
-	cur    storage.SeriesRef
-	closed bool
+	p   []T
+	h   *loser.Tree[storage.SeriesRef, T]
+	cur storage.SeriesRef
 }
 
 func newMergedPostings[T Postings](p []T) (m *mergedPostings[T], nonEmpty bool) {
@@ -765,11 +759,6 @@ func (it mergedPostings[T]) Err() error {
 }
 
 func (it *mergedPostings[T]) Close() error {
-	if it.closed {
-		return nil
-	}
-	it.closed = true
-
 	errs := make([]error, 0, len(it.p))
 	for _, p := range it.p {
 		if err := p.Close(); err != nil {
@@ -801,7 +790,6 @@ type removedPostings struct {
 
 	initialized bool
 	fok, rok    bool
-	closed      bool
 }
 
 func newRemovedPostings(full, remove Postings) *removedPostings {
@@ -868,10 +856,6 @@ func (rp *removedPostings) Err() error {
 }
 
 func (rp *removedPostings) Close() error {
-	if rp.closed {
-		return nil
-	}
-	rp.closed = true
 	err := closePostings(rp.full, rp.remove)
 	rp.full = nil
 	rp.remove = nil
@@ -959,8 +943,6 @@ func (it *listPostings) Len() int {
 type bigEndianPostings struct {
 	list []byte
 	cur  uint32
-	// closed makes Close idempotent.
-	closed bool
 }
 
 func newBigEndianPostings(list []byte) *bigEndianPostings {
@@ -1005,12 +987,8 @@ func (*bigEndianPostings) Err() error {
 }
 
 func (it *bigEndianPostings) Close() error {
-	if it.closed {
-		return nil
-	}
 	it.list = nil
 	it.cur = 0
-	it.closed = true
 	return nil
 }
 

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -891,10 +891,6 @@ func TestCompositePostingsCloseClosesInputs(t *testing.T) {
 			require.NoError(t, p.Close())
 			require.Equal(t, 1, a.closes)
 			require.Equal(t, 1, b.closes)
-
-			require.NoError(t, p.Close())
-			require.Equal(t, 1, a.closes)
-			require.Equal(t, 1, b.closes)
 		})
 	}
 }

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -879,10 +879,8 @@ func TestCompositePostingsCloseClosesInputs(t *testing.T) {
 			},
 		},
 		{
-			name: "without",
-			build: func(a, b Postings) Postings {
-				return Without(a, b)
-			},
+			name:  "without",
+			build: Without,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -919,10 +917,8 @@ func TestCompositePostingsCloseJoinsErrors(t *testing.T) {
 			},
 		},
 		{
-			name: "without",
-			build: func(a, b Postings) Postings {
-				return Without(a, b)
-			},
+			name:  "without",
+			build: Without,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -291,6 +291,17 @@ func newListPostings(list ...storage.SeriesRef) *listPostings {
 	return &listPostings{list: list}
 }
 
+type closeTrackingPostings struct {
+	Postings
+	closeErr error
+	closes   int
+}
+
+func (p *closeTrackingPostings) Close() error {
+	p.closes++
+	return errors.Join(p.closeErr, p.Postings.Close())
+}
+
 // Create ListPostings for a benchmark, collecting the original sets of references
 // so they can be reset without additional memory allocations.
 func createPostings(lps *[]*listPostings, refs *[][]storage.SeriesRef, params ...storage.SeriesRef) {
@@ -809,6 +820,124 @@ func TestBigEndian(t *testing.T) {
 			require.NoError(t, bep.Err())
 		}
 	})
+}
+
+func TestPostingsCloseReleasesIterators(t *testing.T) {
+	t.Run("list postings", func(t *testing.T) {
+		p := NewListPostings([]storage.SeriesRef{10, 20}).(*listPostings)
+
+		require.True(t, p.Next())
+		require.NoError(t, p.Close())
+		require.Nil(t, p.list)
+		require.Zero(t, p.cur)
+	})
+
+	t.Run("big endian postings", func(t *testing.T) {
+		p := newBigEndianPostings([]byte{0, 0, 0, 10})
+
+		require.True(t, p.Next())
+		require.NoError(t, p.Close())
+		require.Nil(t, p.list)
+		require.Zero(t, p.cur)
+	})
+}
+
+func TestExpandPostingsClosesInput(t *testing.T) {
+	p := &closeTrackingPostings{Postings: newListPostings(1, 2)}
+
+	refs, err := ExpandPostings(p)
+	require.NoError(t, err)
+	require.Equal(t, []storage.SeriesRef{1, 2}, refs)
+	require.Equal(t, 1, p.closes)
+}
+
+func TestExpandPostingsReturnsCloseError(t *testing.T) {
+	closeErr := errors.New("close failed")
+	p := &closeTrackingPostings{Postings: newListPostings(1, 2), closeErr: closeErr}
+
+	refs, err := ExpandPostings(p)
+	require.ErrorIs(t, err, closeErr)
+	require.Equal(t, []storage.SeriesRef{1, 2}, refs)
+	require.Equal(t, 1, p.closes)
+}
+
+func TestCompositePostingsCloseClosesInputs(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		build func(a, b Postings) Postings
+	}{
+		{
+			name: "intersect",
+			build: func(a, b Postings) Postings {
+				return Intersect(a, b)
+			},
+		},
+		{
+			name: "merge",
+			build: func(a, b Postings) Postings {
+				return Merge(context.Background(), a, b)
+			},
+		},
+		{
+			name: "without",
+			build: func(a, b Postings) Postings {
+				return Without(a, b)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &closeTrackingPostings{Postings: newListPostings(1, 2)}
+			b := &closeTrackingPostings{Postings: newListPostings(2, 3)}
+			p := tc.build(a, b)
+
+			require.NoError(t, p.Close())
+			require.Equal(t, 1, a.closes)
+			require.Equal(t, 1, b.closes)
+
+			require.NoError(t, p.Close())
+			require.Equal(t, 1, a.closes)
+			require.Equal(t, 1, b.closes)
+		})
+	}
+}
+
+func TestCompositePostingsCloseJoinsErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		build func(a, b Postings) Postings
+	}{
+		{
+			name: "intersect",
+			build: func(a, b Postings) Postings {
+				return Intersect(a, b)
+			},
+		},
+		{
+			name: "merge",
+			build: func(a, b Postings) Postings {
+				return Merge(context.Background(), a, b)
+			},
+		},
+		{
+			name: "without",
+			build: func(a, b Postings) Postings {
+				return Without(a, b)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errA := errors.New("close a")
+			errB := errors.New("close b")
+			a := &closeTrackingPostings{Postings: newListPostings(1, 2), closeErr: errA}
+			b := &closeTrackingPostings{Postings: newListPostings(2, 3), closeErr: errB}
+
+			err := tc.build(a, b).Close()
+			require.ErrorIs(t, err, errA)
+			require.ErrorIs(t, err, errB)
+			require.Equal(t, 1, a.closes)
+			require.Equal(t, 1, b.closes)
+		})
+	}
 }
 
 func TestIntersectWithMerge(t *testing.T) {


### PR DESCRIPTION
Refs #15160.

<!--
```release-notes
[CHANGE] TSDB: Add `Close` to the `index.Postings` interface.
```
-->

## Summary

- Add `Close()` to `index.Postings` so postings iterators can release retained resources after use.
- Recycle pooled `NewListPostings` iterators on close and release retained refs from list and big-endian postings.
- Propagate close through `Intersect`, `Merge`, `Without`, and `ExpandPostings`, joining close errors with iterator errors where needed.

## Tests

- `go test ./tsdb/index`
- `go test -run '^$' ./tsdb/...`
- `go test -run '^$' ./cmd/promtool`
- `git diff --check -- tsdb/index/postings.go tsdb/index/postings_test.go`
