### PR TITLE
discovery/oci: add native Oracle Cloud Infrastructure service discovery

### DIFF
--- a/cmd/prometheus/testdata/features.json
+++ b/cmd/prometheus/testdata/features.json
@@ -212,6 +212,7 @@
     "msk": true,
     "nerve": true,
     "nomad": true,
+    "oci": true,
     "openstack": true,
     "outscale": true,
     "ovhcloud": true,
@@ -262,8 +263,8 @@
     "isolation": true,
     "native_histograms": true,
     "st_storage": false,
-    "xor2_encoding": false,
-    "use_uncached_io": false
+    "use_uncached_io": false,
+    "xor2_encoding": false
   },
   "ui": {
     "ui_v2": false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2567,7 +2567,7 @@ var expectedErrors = []struct {
 	},
 	{
 		filename: "oci_authentication_method.bad.yml",
-		errMsg:   `OCI SD unknown auth method "invalid", expected "api_key" or "instance_principal"`,
+		errMsg:   `oci_sd: unknown auth method "invalid", expected "api_key" or "instance_principal"`,
 	},
 	{
 		filename: "azure_bearertoken_basicauth.bad.yml",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/marathon"
 	"github.com/prometheus/prometheus/discovery/moby"
 	"github.com/prometheus/prometheus/discovery/nomad"
+	"github.com/prometheus/prometheus/discovery/oci"
 	"github.com/prometheus/prometheus/discovery/openstack"
 	"github.com/prometheus/prometheus/discovery/outscale"
 	"github.com/prometheus/prometheus/discovery/ovhcloud"
@@ -1227,6 +1228,48 @@ var expectedConf = &Config{
 					Host:             "http://127.0.0.1:2375",
 					Role:             "nodes",
 					Port:             80,
+					RefreshInterval:  model.Duration(60 * time.Second),
+					HTTPClientConfig: config.DefaultHTTPClientConfig,
+				},
+			},
+		},
+		{
+			JobName: "service-oci",
+
+			HonorTimestamps:                true,
+			ScrapeInterval:                 model.Duration(15 * time.Second),
+			ScrapeTimeout:                  DefaultGlobalConfig.ScrapeTimeout,
+			EnableCompression:              true,
+			BodySizeLimit:                  globBodySizeLimit,
+			SampleLimit:                    globSampleLimit,
+			TargetLimit:                    globTargetLimit,
+			LabelLimit:                     globLabelLimit,
+			LabelNameLengthLimit:           globLabelNameLengthLimit,
+			LabelValueLengthLimit:          globLabelValueLengthLimit,
+			ScrapeProtocols:                DefaultScrapeProtocols,
+			ScrapeFailureLogFile:           globScrapeFailureLogFile,
+			MetricNameValidationScheme:     DefaultGlobalConfig.MetricNameValidationScheme,
+			MetricNameEscapingScheme:       DefaultGlobalConfig.MetricNameEscapingScheme,
+			ScrapeNativeHistograms:         boolPtr(false),
+			AlwaysScrapeClassicHistograms:  boolPtr(false),
+			ConvertClassicHistogramsToNHCB: boolPtr(false),
+			ExtraScrapeMetrics:             boolPtr(false),
+
+			MetricsPath:      DefaultScrapeConfig.MetricsPath,
+			Scheme:           DefaultScrapeConfig.Scheme,
+			HTTPClientConfig: config.DefaultHTTPClientConfig,
+
+			ServiceDiscoveryConfigs: discovery.Configs{
+				&oci.SDConfig{
+					Auth:             "api_key",
+					Region:           "us-ashburn-1",
+					Tenancy:          "ocid1.tenancy.oc1..tenancy001",
+					User:             "ocid1.user.oc1..user001",
+					Fingerprint:      "aa:bb:cc:dd:ee:ff",
+					KeyFile:          "testdata/valid_key_file",
+					Compartments:     []string{"ocid1.compartment.oc1..comp001"},
+					TagFilterAction:  "include",
+					Port:             9100,
 					RefreshInterval:  model.Duration(60 * time.Second),
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1271,6 +1271,7 @@ var expectedConf = &Config{
 					Compartments:     []string{"ocid1.compartment.oc1..comp001"},
 					Port:             9100,
 					RefreshInterval:  model.Duration(60 * time.Second),
+					RateLimitRPS:     500,
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1271,7 +1271,6 @@ var expectedConf = &Config{
 					Compartments:     []string{"ocid1.compartment.oc1..comp001"},
 					Port:             9100,
 					RefreshInterval:  model.Duration(60 * time.Second),
-					RateLimitRPS:     500,
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
 				},
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1267,8 +1267,8 @@ var expectedConf = &Config{
 					User:             "ocid1.user.oc1..user001",
 					Fingerprint:      "aa:bb:cc:dd:ee:ff",
 					KeyFile:          "testdata/valid_key_file",
+					KeyPassphrase:    "mysecret",
 					Compartments:     []string{"ocid1.compartment.oc1..comp001"},
-					TagFilterAction:  "include",
 					Port:             9100,
 					RefreshInterval:  model.Duration(60 * time.Second),
 					HTTPClientConfig: config.DefaultHTTPClientConfig,
@@ -2202,7 +2202,7 @@ func TestElideSecrets(t *testing.T) {
 	yamlConfig := string(config)
 
 	matches := secretRe.FindAllStringIndex(yamlConfig, -1)
-	require.Len(t, matches, 28, "wrong number of secret matches found")
+	require.Len(t, matches, 29, "wrong number of secret matches found")
 	require.NotContains(t, yamlConfig, "mysecret",
 		"yaml marshal reveals authentication credentials.")
 }
@@ -2564,6 +2564,10 @@ var expectedErrors = []struct {
 	{
 		filename: "azure_authentication_method.bad.yml",
 		errMsg:   "unknown authentication_type \"invalid\". Supported types are \"OAuth\", \"ManagedIdentity\", \"SDK\" or \"WorkloadIdentity\"",
+	},
+	{
+		filename: "oci_authentication_method.bad.yml",
+		errMsg:   `OCI SD unknown auth method "invalid", expected "api_key" or "instance_principal"`,
 	},
 	{
 		filename: "azure_bearertoken_basicauth.bad.yml",

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -346,6 +346,18 @@ scrape_configs:
       - host: http://127.0.0.1:2375
         role: nodes
 
+  - job_name: service-oci
+    oci_sd_configs:
+      - region: us-ashburn-1
+        tenancy: ocid1.tenancy.oc1..tenancy001
+        user: ocid1.user.oc1..user001
+        fingerprint: aa:bb:cc:dd:ee:ff
+        key_file: valid_key_file
+        compartments:
+          - ocid1.compartment.oc1..comp001
+        port: 9100
+        refresh_interval: 1m
+
   - job_name: service-openstack
     openstack_sd_configs:
       - role: instance

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -353,6 +353,7 @@ scrape_configs:
         user: ocid1.user.oc1..user001
         fingerprint: aa:bb:cc:dd:ee:ff
         key_file: valid_key_file
+        key_passphrase: mysecret
         compartments:
           - ocid1.compartment.oc1..comp001
         port: 9100

--- a/config/testdata/oci_authentication_method.bad.yml
+++ b/config/testdata/oci_authentication_method.bad.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - oci_sd_configs:
+      - auth: invalid
+        region: us-ashburn-1

--- a/discovery/install/install.go
+++ b/discovery/install/install.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/prometheus/prometheus/discovery/marathon"     // register marathon
 	_ "github.com/prometheus/prometheus/discovery/moby"         // register moby
 	_ "github.com/prometheus/prometheus/discovery/nomad"        // register nomad
+	_ "github.com/prometheus/prometheus/discovery/oci"          // register oci
 	_ "github.com/prometheus/prometheus/discovery/openstack"    // register openstack
 	_ "github.com/prometheus/prometheus/discovery/outscale"     // register outscale
 	_ "github.com/prometheus/prometheus/discovery/ovhcloud"     // register ovhcloud

--- a/discovery/oci/metrics.go
+++ b/discovery/oci/metrics.go
@@ -1,0 +1,30 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"github.com/prometheus/prometheus/discovery"
+)
+
+var _ discovery.DiscovererMetrics = (*ociMetrics)(nil)
+
+type ociMetrics struct {
+	refreshMetrics discovery.RefreshMetricsInstantiator
+}
+
+// Register implements discovery.DiscovererMetrics.
+func (*ociMetrics) Register() error { return nil }
+
+// Unregister implements discovery.DiscovererMetrics.
+func (*ociMetrics) Unregister() {}

--- a/discovery/oci/oci.go
+++ b/discovery/oci/oci.go
@@ -74,21 +74,20 @@ const (
 	authAPIKey            = "api_key"
 	authInstancePrincipal = "instance_principal"
 
-	// defaultRateLimitRPS is the default cap on OCI API calls per second
-	// across all operations (ListCompartments, ListInstances,
-	// ListVnicAttachments, GetVnic). The OCI Go SDK's DefaultRetryPolicy
-	// already backs off on 429 (TooManyRequests) and 5xx responses, so the
-	// client cap is intentionally generous: discovery of a tenancy with a
-	// few thousand instances issues two paginated calls per VNIC plus one
-	// list call per compartment, and the 60s default refresh interval gives
-	// little headroom at low rates. Operators can lower this through the
-	// rate_limit_rps configuration field if their tenancy enforces a
-	// stricter quota.
-	defaultRateLimitRPS = 500.0
+	// rateLimitRPS caps OCI API calls per second across all operations
+	// (ListCompartments, ListInstances, ListVnicAttachments, GetVnic).
+	// The OCI Go SDK's DefaultRetryPolicy already backs off on 429
+	// (TooManyRequests) and 5xx responses, so this is mainly a safety net
+	// against runaway refreshes rather than a quota guard. Discovering a
+	// tenancy with a few thousand instances issues two paginated calls per
+	// VNIC plus one list call per compartment, and the 60s default refresh
+	// interval gives little headroom at low rates, so the value is set
+	// well above what any healthy tenancy needs.
+	rateLimitRPS = 500.0
 
 	// rateLimitBurst caps how many requests can be released back-to-back
 	// before the limiter throttles. Kept small so a cold refresh does not
-	// fire defaultRateLimitRPS requests at once.
+	// fire rateLimitRPS requests at once.
 	rateLimitBurst = 50
 )
 
@@ -97,7 +96,6 @@ var DefaultSDConfig = SDConfig{
 	Port:             80,
 	RefreshInterval:  model.Duration(60 * time.Second),
 	Auth:             authAPIKey,
-	RateLimitRPS:     defaultRateLimitRPS,
 	HTTPClientConfig: config.DefaultHTTPClientConfig,
 }
 
@@ -134,12 +132,6 @@ type SDConfig struct {
 	// all active compartments reachable from the tenancy root are discovered
 	// automatically via the OCI Identity API.
 	Compartments []string `yaml:"compartments,omitempty"`
-
-	// RateLimitRPS caps OCI API calls per second across all operations
-	// (ListCompartments, ListInstances, ListVnicAttachments, GetVnic). The
-	// SDK's default retry policy already backs off on 429 and 5xx responses,
-	// so this is primarily useful for tenancies enforcing a stricter quota.
-	RateLimitRPS float64 `yaml:"rate_limit_rps,omitempty"`
 
 	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 
@@ -219,10 +211,6 @@ func (c *SDConfig) validate() error {
 		return fmt.Errorf("OCI SD refresh_interval must be positive, got %s", c.RefreshInterval)
 	}
 
-	if c.RateLimitRPS <= 0 {
-		return fmt.Errorf("OCI SD rate_limit_rps must be positive, got %v", c.RateLimitRPS)
-	}
-
 	return c.HTTPClientConfig.Validate()
 }
 
@@ -286,11 +274,7 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 	// Rate limiter and retry policy are shared across all closures so every OCI
 	// API call counts against the same budget. The burst is kept small so a
 	// cold refresh does not fire a full second's worth of calls at once.
-	burst := rateLimitBurst
-	if rps := int(conf.RateLimitRPS); rps > 0 && rps < burst {
-		burst = rps
-	}
-	limiter := rate.NewLimiter(rate.Limit(conf.RateLimitRPS), burst)
+	limiter := rate.NewLimiter(rate.Limit(rateLimitRPS), rateLimitBurst)
 	retryPolicy := common.DefaultRetryPolicy()
 
 	compLister, err := newCompartmentLister(provider, httpClient, tenancy, conf.Compartments, limiter, &retryPolicy, opts.Logger)

--- a/discovery/oci/oci.go
+++ b/discovery/oci/oci.go
@@ -1,0 +1,638 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package oci provides service discovery for Oracle Cloud Infrastructure compute instances.
+package oci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/common/auth"
+	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/oracle/oci-go-sdk/v65/identity"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"golang.org/x/time/rate"
+
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/refresh"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+const (
+	ociLabel                   = model.MetaLabelPrefix + "oci_"
+	ociLabelInstanceID         = ociLabel + "instance_id"
+	ociLabelInstanceName       = ociLabel + "instance_name"
+	ociLabelInstanceState      = ociLabel + "instance_state"
+	ociLabelInstanceShape      = ociLabel + "instance_shape"
+	ociLabelAvailabilityDomain = ociLabel + "availability_domain"
+	ociLabelFaultDomain        = ociLabel + "fault_domain"
+	ociLabelRegion             = ociLabel + "region"
+	ociLabelTenancyID          = ociLabel + "tenancy_id"
+	ociLabelCompartmentID      = ociLabel + "compartment_id"
+	ociLabelImageID            = ociLabel + "image_id"
+	ociLabelPrivateIP          = ociLabel + "private_ip"
+	ociLabelPublicIP           = ociLabel + "public_ip"
+	ociLabelFreeformTagPrefix  = ociLabel + "tag_"
+	ociLabelDefinedTagPrefix   = ociLabel + "defined_tag_"
+)
+
+const (
+	authAPIKey            = "api_key"
+	authInstancePrincipal = "instance_principal"
+
+	tagFilterActionInclude = "include"
+	tagFilterActionExclude = "exclude"
+)
+
+// DefaultSDConfig is the default OCI service discovery configuration.
+var DefaultSDConfig = SDConfig{
+	Port:            80,
+	RefreshInterval: model.Duration(60 * time.Second),
+	Auth:            authAPIKey,
+	TagFilterAction: tagFilterActionInclude,
+	RateLimitRPS:    10.0,
+}
+
+func init() {
+	discovery.RegisterConfig(&SDConfig{})
+}
+
+// SDConfig is the configuration for OCI service discovery.
+type SDConfig struct {
+	// Auth selects the authentication method. Valid values: "api_key" (default),
+	// "instance_principal".
+	Auth string `yaml:"auth,omitempty"`
+
+	// API key auth fields. Required when Auth is "api_key".
+	Tenancy       string        `yaml:"tenancy,omitempty"`
+	User          string        `yaml:"user,omitempty"`
+	Fingerprint   string        `yaml:"fingerprint,omitempty"`
+	KeyFile       string        `yaml:"key_file,omitempty"`
+	KeyPassphrase config.Secret `yaml:"key_passphrase,omitempty"`
+
+	// Region is required for all auth methods.
+	Region string `yaml:"region"`
+
+	// Compartments is an explicit list of compartment OCIDs to scan. When empty,
+	// all active compartments reachable from the tenancy root are discovered
+	// automatically via the OCI Identity API.
+	Compartments []string `yaml:"compartments,omitempty"`
+
+	// Filter is an optional OCI display-name substring filter for ListInstances.
+	Filter string `yaml:"filter,omitempty"`
+
+	// TagFilterKey and TagFilterValue together select instances by a freeform or
+	// defined tag. TagFilterAction controls whether matching instances are included
+	// (default: "include") or excluded ("exclude"). When TagFilterKey is empty all
+	// instances are returned regardless of TagFilterValue and TagFilterAction.
+	TagFilterKey    string `yaml:"tag_filter_key,omitempty"`
+	TagFilterValue  string `yaml:"tag_filter_value,omitempty"`
+	TagFilterAction string `yaml:"tag_filter_action,omitempty"`
+
+	// RateLimitRPS caps the number of OCI API calls per second to avoid hitting
+	// per-tenancy service limits. Defaults to 10.
+	RateLimitRPS float64 `yaml:"rate_limit_rps,omitempty"`
+
+	Port            int            `yaml:"port"`
+	RefreshInterval model.Duration `yaml:"refresh_interval"`
+}
+
+// NewDiscovererMetrics implements discovery.Config.
+func (*SDConfig) NewDiscovererMetrics(_ prometheus.Registerer, rmi discovery.RefreshMetricsInstantiator) discovery.DiscovererMetrics {
+	return &ociMetrics{refreshMetrics: rmi}
+}
+
+// Name returns the name of the OCI service discovery config.
+func (*SDConfig) Name() string { return "oci" }
+
+// NewDiscoverer returns a Discoverer for the Config.
+func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Discoverer, error) {
+	return NewDiscovery(c, opts)
+}
+
+// SetDirectory joins any relative file paths with dir.
+func (c *SDConfig) SetDirectory(dir string) {
+	if c.KeyFile != "" && !strings.HasPrefix(c.KeyFile, "/") {
+		c.KeyFile = dir + "/" + c.KeyFile
+	}
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	*c = DefaultSDConfig
+	type plain SDConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	return c.validate()
+}
+
+// validate checks all SDConfig fields for consistency. It is called from
+// UnmarshalYAML and is also used directly in tests.
+func (c *SDConfig) validate() error {
+	if c.Region == "" {
+		return errors.New("OCI SD configuration requires a region")
+	}
+
+	switch c.Auth {
+	case authAPIKey:
+		if c.Tenancy == "" {
+			return errors.New("OCI SD api_key auth requires tenancy")
+		}
+		if c.User == "" {
+			return errors.New("OCI SD api_key auth requires user")
+		}
+		if c.Fingerprint == "" {
+			return errors.New("OCI SD api_key auth requires fingerprint")
+		}
+		if c.KeyFile == "" {
+			return errors.New("OCI SD api_key auth requires key_file")
+		}
+	case authInstancePrincipal:
+		if c.Tenancy != "" || c.User != "" || c.Fingerprint != "" || c.KeyFile != "" {
+			return errors.New("OCI SD instance_principal auth must not have tenancy, user, fingerprint, or key_file set")
+		}
+	default:
+		return fmt.Errorf("OCI SD unknown auth method %q, expected %q or %q", c.Auth, authAPIKey, authInstancePrincipal)
+	}
+
+	for i, cid := range c.Compartments {
+		if cid == "" {
+			return fmt.Errorf("OCI SD compartments[%d] must not be empty", i)
+		}
+	}
+
+	if c.TagFilterKey != "" {
+		if c.TagFilterValue == "" {
+			return errors.New("OCI SD tag_filter_key requires tag_filter_value")
+		}
+		switch c.TagFilterAction {
+		case tagFilterActionInclude, tagFilterActionExclude:
+		default:
+			return fmt.Errorf("OCI SD tag_filter_action must be %q or %q, got %q", tagFilterActionInclude, tagFilterActionExclude, c.TagFilterAction)
+		}
+	}
+
+	if c.RateLimitRPS <= 0 {
+		return errors.New("OCI SD rate_limit_rps must be positive")
+	}
+
+	return nil
+}
+
+// compartmentLister returns the ordered list of compartment OCIDs to scan.
+// When compartments are configured explicitly it returns them directly; when
+// auto-discovering it recursively lists all active compartments from the
+// tenancy root via the OCI Identity API.
+type compartmentLister func(ctx context.Context) ([]string, error)
+
+// instancesLister lists RUNNING compute instances in a compartment, handling
+// pagination internally. The concrete ComputeClient is captured in the closure
+// so it is not reachable through reflection on the interface-boxed Discovery
+// struct, keeping dead-code elimination effective and the binary small.
+type instancesLister func(ctx context.Context, compartmentID string) ([]core.Instance, error)
+
+// vnicAttachmentLister lists VNIC attachments for an instance in a compartment.
+type vnicAttachmentLister func(ctx context.Context, compartmentID, instanceID string) ([]core.VnicAttachment, error)
+
+// vnicFetcher fetches the details of a single VNIC by its ID.
+type vnicFetcher func(ctx context.Context, vnicID string) (*core.Vnic, error)
+
+// Discovery periodically performs OCI compute instance discovery. It implements
+// the Discoverer interface.
+type Discovery struct {
+	*refresh.Discovery
+	listCompartments    compartmentLister
+	listInstances       instancesLister
+	listVnicAttachments vnicAttachmentLister
+	getVnic             vnicFetcher
+	tenancy             string
+	tagFilterKey        string
+	tagFilterValue      string
+	tagFilterAction     string
+	port                int
+	logger              *slog.Logger
+}
+
+// NewDiscovery returns a new Discovery which periodically refreshes its targets.
+func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery, error) {
+	m, ok := opts.Metrics.(*ociMetrics)
+	if !ok {
+		return nil, errors.New("invalid discovery metrics type")
+	}
+
+	provider, err := newConfigurationProvider(conf)
+	if err != nil {
+		return nil, fmt.Errorf("OCI SD failed to build configuration provider: %w", err)
+	}
+
+	tenancy, err := provider.TenancyOCID()
+	if err != nil {
+		return nil, fmt.Errorf("OCI SD failed to determine tenancy OCID: %w", err)
+	}
+
+	// Rate limiter and retry policy are shared across all closures so every OCI
+	// API call counts against the same budget.
+	limiter := rate.NewLimiter(rate.Limit(conf.RateLimitRPS), max(1, int(conf.RateLimitRPS)))
+	retryPolicy := common.DefaultRetryPolicy()
+
+	compLister, err := newCompartmentLister(provider, tenancy, conf.Compartments, limiter, &retryPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("OCI SD failed to create compartment lister: %w", err)
+	}
+
+	lister, attachmentLister, fetcher, err := newOCIClients(provider, conf.Filter, limiter, &retryPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("OCI SD failed to create clients: %w", err)
+	}
+
+	d := &Discovery{
+		listCompartments:    compLister,
+		listInstances:       lister,
+		listVnicAttachments: attachmentLister,
+		getVnic:             fetcher,
+		tenancy:             tenancy,
+		tagFilterKey:        conf.TagFilterKey,
+		tagFilterValue:      conf.TagFilterValue,
+		tagFilterAction:     conf.TagFilterAction,
+		port:                conf.Port,
+		logger:              opts.Logger,
+	}
+
+	d.Discovery = refresh.NewDiscovery(refresh.Options{
+		Logger:              opts.Logger,
+		Mech:                "oci",
+		SetName:             opts.SetName,
+		Interval:            time.Duration(conf.RefreshInterval),
+		RefreshF:            d.refresh,
+		MetricsInstantiator: m.refreshMetrics,
+	})
+
+	return d, nil
+}
+
+// newConfigurationProvider builds an OCI ConfigurationProvider for the given SDConfig.
+func newConfigurationProvider(conf *SDConfig) (common.ConfigurationProvider, error) {
+	switch conf.Auth {
+	case authInstancePrincipal:
+		return auth.InstancePrincipalConfigurationProvider()
+	default: // authAPIKey
+		keyPEM, err := os.ReadFile(conf.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading OCI key file %q: %w", conf.KeyFile, err)
+		}
+		passphrase := string(conf.KeyPassphrase)
+		var passphrasePtr *string
+		if passphrase != "" {
+			passphrasePtr = &passphrase
+		}
+		return common.NewRawConfigurationProvider(
+			conf.Tenancy, conf.User, conf.Region,
+			conf.Fingerprint, string(keyPEM), passphrasePtr,
+		), nil
+	}
+}
+
+// newCompartmentLister returns a compartmentLister that either returns the
+// explicit list from the config directly, or auto-discovers all active
+// compartments under the tenancy root via the OCI Identity API.
+//
+// When compartments are explicitly configured no Identity client is created,
+// so the identity package methods are dropped by dead-code elimination.
+func newCompartmentLister(provider common.ConfigurationProvider, tenancy string, compartments []string, limiter *rate.Limiter, retryPolicy *common.RetryPolicy) (compartmentLister, error) {
+	if len(compartments) > 0 {
+		ids := make([]string, len(compartments))
+		copy(ids, compartments)
+		return func(_ context.Context) ([]string, error) {
+			return ids, nil
+		}, nil
+	}
+
+	// Auto-discovery: the Identity client lives only in the closure context so
+	// reflection cannot traverse it through the Discovery struct.
+	idClient, err := identity.NewIdentityClientWithConfigurationProvider(provider)
+	if err != nil {
+		return nil, fmt.Errorf("creating OCI identity client: %w", err)
+	}
+
+	return func(ctx context.Context) ([]string, error) {
+		return listAllCompartments(ctx, &idClient, tenancy, limiter, retryPolicy)
+	}, nil
+}
+
+// listAllCompartments recursively discovers all active compartments reachable
+// from root using a BFS queue, including root itself. Child compartments that
+// fail to list are skipped so a single permission gap does not abort the walk.
+func listAllCompartments(ctx context.Context, idClient *identity.IdentityClient, root string, limiter *rate.Limiter, retryPolicy *common.RetryPolicy) ([]string, error) {
+	var all []string
+	visited := make(map[string]bool)
+	queue := []string{root}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if visited[current] {
+			continue
+		}
+		visited[current] = true
+		all = append(all, current)
+
+		var page *string
+		for {
+			if err := limiter.Wait(ctx); err != nil {
+				return nil, err
+			}
+			resp, err := idClient.ListCompartments(ctx, identity.ListCompartmentsRequest{
+				CompartmentId:          common.String(current),
+				AccessLevel:            identity.ListCompartmentsAccessLevelAccessible,
+				CompartmentIdInSubtree: common.Bool(false), // direct children only
+				Limit:                  common.Int(100),
+				Page:                   page,
+				RequestMetadata:        common.RequestMetadata{RetryPolicy: retryPolicy},
+			})
+			if err != nil {
+				// Permission gap on this compartment - skip its children.
+				break
+			}
+			for _, comp := range resp.Items {
+				if comp.Id != nil && comp.LifecycleState == identity.CompartmentLifecycleStateActive && !visited[*comp.Id] {
+					queue = append(queue, *comp.Id)
+				}
+			}
+			if resp.OpcNextPage == nil {
+				break
+			}
+			page = resp.OpcNextPage
+		}
+	}
+	return all, nil
+}
+
+// newOCIClients constructs the three closure functions that wrap the OCI SDK
+// clients. The concrete client values live only in the closure context so
+// reflection cannot reach them through the interface-boxed Discovery struct,
+// allowing the linker to drop unused SDK operations and keep the binary small.
+func newOCIClients(provider common.ConfigurationProvider, filter string, limiter *rate.Limiter, retryPolicy *common.RetryPolicy) (instancesLister, vnicAttachmentLister, vnicFetcher, error) {
+	computeClient, err := core.NewComputeClientWithConfigurationProvider(provider)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("creating OCI compute client: %w", err)
+	}
+
+	vnetClient, err := core.NewVirtualNetworkClientWithConfigurationProvider(provider)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("creating OCI virtual network client: %w", err)
+	}
+
+	lister := func(ctx context.Context, compartmentID string) ([]core.Instance, error) {
+		var instances []core.Instance
+		req := core.ListInstancesRequest{
+			CompartmentId:   common.String(compartmentID),
+			LifecycleState:  core.InstanceLifecycleStateRunning,
+			Limit:           common.Int(100),
+			RequestMetadata: common.RequestMetadata{RetryPolicy: retryPolicy},
+		}
+		if filter != "" {
+			req.DisplayName = common.String(filter)
+		}
+		for {
+			if err := limiter.Wait(ctx); err != nil {
+				return nil, err
+			}
+			resp, err := computeClient.ListInstances(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			instances = append(instances, resp.Items...)
+			if resp.OpcNextPage == nil {
+				break
+			}
+			req.Page = resp.OpcNextPage
+		}
+		return instances, nil
+	}
+
+	attachmentLister := func(ctx context.Context, compartmentID, instanceID string) ([]core.VnicAttachment, error) {
+		var attachments []core.VnicAttachment
+		req := core.ListVnicAttachmentsRequest{
+			CompartmentId:   common.String(compartmentID),
+			InstanceId:      common.String(instanceID),
+			Limit:           common.Int(100),
+			RequestMetadata: common.RequestMetadata{RetryPolicy: retryPolicy},
+		}
+		for {
+			if err := limiter.Wait(ctx); err != nil {
+				return nil, err
+			}
+			resp, err := computeClient.ListVnicAttachments(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			attachments = append(attachments, resp.Items...)
+			if resp.OpcNextPage == nil {
+				break
+			}
+			req.Page = resp.OpcNextPage
+		}
+		return attachments, nil
+	}
+
+	fetcher := func(ctx context.Context, vnicID string) (*core.Vnic, error) {
+		if err := limiter.Wait(ctx); err != nil {
+			return nil, err
+		}
+		resp, err := vnetClient.GetVnic(ctx, core.GetVnicRequest{
+			VnicId:          common.String(vnicID),
+			RequestMetadata: common.RequestMetadata{RetryPolicy: retryPolicy},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &resp.Vnic, nil
+	}
+
+	return lister, attachmentLister, fetcher, nil
+}
+
+func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
+	compartments, err := d.listCompartments(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("OCI SD failed to list compartments: %w", err)
+	}
+
+	var tgs []*targetgroup.Group
+
+	for _, compartmentID := range compartments {
+		tg := &targetgroup.Group{Source: "OCI_" + compartmentID}
+
+		instances, err := d.listInstances(ctx, compartmentID)
+		if err != nil {
+			d.logger.Warn("OCI SD failed to list instances, skipping compartment",
+				"compartment_id", compartmentID, "err", err)
+			continue
+		}
+
+		for i := range instances {
+			inst := &instances[i]
+
+			// Tag filter is applied before VNIC resolution to avoid unnecessary API
+			// calls for instances that will be dropped anyway.
+			if d.tagFilterKey != "" {
+				match := hasTag(inst, d.tagFilterKey, d.tagFilterValue)
+				if d.tagFilterAction == tagFilterActionInclude && !match {
+					continue
+				}
+				if d.tagFilterAction == tagFilterActionExclude && match {
+					continue
+				}
+			}
+
+			privateIP, publicIP, err := d.primaryVnicIPs(ctx, inst)
+			if err != nil {
+				d.logger.Warn("OCI SD failed to resolve VNIC IPs, skipping instance",
+					"instance_id", stringVal(inst.Id), "err", err)
+				continue
+			}
+
+			tg.Targets = append(tg.Targets, instanceLabels(inst, privateIP, publicIP, d.tenancy, d.port))
+		}
+
+		tgs = append(tgs, tg)
+	}
+
+	return tgs, nil
+}
+
+// primaryVnicIPs returns the private and public IP of the primary VNIC for inst.
+// publicIP may be empty if no public IP is assigned.
+func (d *Discovery) primaryVnicIPs(ctx context.Context, inst *core.Instance) (privateIP, publicIP string, err error) {
+	attachments, err := d.listVnicAttachments(ctx, *inst.CompartmentId, *inst.Id)
+	if err != nil {
+		return "", "", fmt.Errorf("listing VNIC attachments for instance %s: %w", *inst.Id, err)
+	}
+
+	for _, att := range attachments {
+		if att.VnicId == nil || att.LifecycleState != core.VnicAttachmentLifecycleStateAttached {
+			continue
+		}
+		vnic, err := d.getVnic(ctx, *att.VnicId)
+		if err != nil {
+			return "", "", fmt.Errorf("fetching VNIC %s: %w", *att.VnicId, err)
+		}
+		if vnic.IsPrimary == nil || !*vnic.IsPrimary {
+			continue
+		}
+		if vnic.PrivateIp != nil {
+			privateIP = *vnic.PrivateIp
+		}
+		if vnic.PublicIp != nil {
+			publicIP = *vnic.PublicIp
+		}
+		return privateIP, publicIP, nil
+	}
+
+	return "", "", nil
+}
+
+// hasTag reports whether inst carries a freeform or defined tag with the given
+// key and value. Freeform tags are checked first; defined tags are checked
+// across all namespaces. Only string-typed defined tag values are compared.
+func hasTag(inst *core.Instance, key, value string) bool {
+	if v, ok := inst.FreeformTags[key]; ok && v == value {
+		return true
+	}
+	for _, nsMap := range inst.DefinedTags {
+		if v, ok := nsMap[key]; ok {
+			if s, ok := v.(string); ok && s == value {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// instanceLabels builds the label set for one OCI compute instance.
+func instanceLabels(inst *core.Instance, privateIP, publicIP, tenancy string, port int) model.LabelSet {
+	addr := privateIP
+	if addr == "" {
+		addr = publicIP
+	}
+
+	labels := model.LabelSet{
+		model.AddressLabel:         model.LabelValue(net.JoinHostPort(addr, strconv.Itoa(port))),
+		ociLabelInstanceID:         model.LabelValue(stringVal(inst.Id)),
+		ociLabelInstanceName:       model.LabelValue(stringVal(inst.DisplayName)),
+		ociLabelInstanceState:      model.LabelValue(string(inst.LifecycleState)),
+		ociLabelInstanceShape:      model.LabelValue(stringVal(inst.Shape)),
+		ociLabelAvailabilityDomain: model.LabelValue(stringVal(inst.AvailabilityDomain)),
+		ociLabelFaultDomain:        model.LabelValue(stringVal(inst.FaultDomain)),
+		ociLabelRegion:             model.LabelValue(stringVal(inst.Region)),
+		ociLabelTenancyID:          model.LabelValue(tenancy),
+		ociLabelCompartmentID:      model.LabelValue(stringVal(inst.CompartmentId)),
+		ociLabelImageID:            model.LabelValue(stringVal(inst.ImageId)),
+		ociLabelPrivateIP:          model.LabelValue(privateIP),
+		ociLabelPublicIP:           model.LabelValue(publicIP),
+	}
+
+	for k, v := range inst.FreeformTags {
+		labels[model.LabelName(ociLabelFreeformTagPrefix+sanitizeLabelName(k))] = model.LabelValue(v)
+	}
+
+	// Only string-typed defined tag values are emitted; numeric and boolean
+	// values from OCI's typed tag system are skipped to avoid label churn.
+	for ns, tags := range inst.DefinedTags {
+		for k, v := range tags {
+			s, ok := v.(string)
+			if !ok {
+				continue
+			}
+			name := ociLabelDefinedTagPrefix + sanitizeLabelName(ns) + "_" + sanitizeLabelName(k)
+			labels[model.LabelName(name)] = model.LabelValue(s)
+		}
+	}
+
+	return labels
+}
+
+// sanitizeLabelName replaces characters that are invalid in Prometheus label
+// names with underscores and lowercases the result.
+func sanitizeLabelName(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// stringVal dereferences a *string, returning "" if nil.
+func stringVal(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/discovery/oci/oci.go
+++ b/discovery/oci/oci.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -45,29 +44,22 @@ import (
 )
 
 const (
-	ociLabel                    = model.MetaLabelPrefix + "oci_"
-	ociLabelInstanceID          = ociLabel + "instance_id"
-	ociLabelInstanceName        = ociLabel + "instance_name"
-	ociLabelInstanceState       = ociLabel + "instance_state"
-	ociLabelInstanceShape       = ociLabel + "instance_shape"
-	ociLabelAvailabilityDomain  = ociLabel + "availability_domain"
-	ociLabelFaultDomain         = ociLabel + "fault_domain"
-	ociLabelRegion              = ociLabel + "region"
-	ociLabelTenancyID           = ociLabel + "tenancy_id"
-	ociLabelCompartmentID       = ociLabel + "compartment_id"
-	ociLabelImageID             = ociLabel + "image_id"
-	ociLabelVnicID              = ociLabel + "vnic_id"
-	ociLabelPrivateIP           = ociLabel + "private_ip"
-	ociLabelPublicIP            = ociLabel + "public_ip"
-	ociLabelSecondaryPrivateIPs = ociLabel + "secondary_private_ips"
-	ociLabelSecondaryPublicIPs  = ociLabel + "secondary_public_ips"
-	ociLabelFreeformTagPrefix   = ociLabel + "tag_"
-	ociLabelDefinedTagPrefix    = ociLabel + "defined_tag_"
-
-	// ociLabelSeparator surrounds and separates values in list-valued labels
-	// (e.g. ociLabelSecondaryPrivateIPs) so users can match individual values
-	// with anchored relabel regexes without ambiguity at the boundaries.
-	ociLabelSeparator = ","
+	ociLabel                   = model.MetaLabelPrefix + "oci_"
+	ociLabelInstanceID         = ociLabel + "instance_id"
+	ociLabelInstanceName       = ociLabel + "instance_name"
+	ociLabelInstanceState      = ociLabel + "instance_state"
+	ociLabelInstanceShape      = ociLabel + "instance_shape"
+	ociLabelAvailabilityDomain = ociLabel + "availability_domain"
+	ociLabelFaultDomain        = ociLabel + "fault_domain"
+	ociLabelRegion             = ociLabel + "region"
+	ociLabelTenancyID          = ociLabel + "tenancy_id"
+	ociLabelCompartmentID      = ociLabel + "compartment_id"
+	ociLabelImageID            = ociLabel + "image_id"
+	ociLabelVnicID             = ociLabel + "vnic_id"
+	ociLabelPrivateIP          = ociLabel + "private_ip"
+	ociLabelPublicIP           = ociLabel + "public_ip"
+	ociLabelFreeformTagPrefix  = ociLabel + "tag_"
+	ociLabelDefinedTagPrefix   = ociLabel + "defined_tag_"
 )
 
 const (
@@ -75,19 +67,17 @@ const (
 	authInstancePrincipal = "instance_principal"
 
 	// rateLimitRPS caps OCI API calls per second across all operations
-	// (ListCompartments, ListInstances, ListVnicAttachments, GetVnic).
-	// The OCI Go SDK's DefaultRetryPolicy already backs off on 429
-	// (TooManyRequests) and 5xx responses, so this is mainly a safety net
-	// against runaway refreshes rather than a quota guard. Discovering a
-	// tenancy with a few thousand instances issues two paginated calls per
-	// VNIC plus one list call per compartment, and the 60s default refresh
-	// interval gives little headroom at low rates, so the value is set
-	// well above what any healthy tenancy needs.
-	rateLimitRPS = 500.0
+	// (ListCompartments, ListInstances, ListVnicAttachments, GetVnic). OCI
+	// throttles IAM read/list operations at 20/s on a free domain, and
+	// ListCompartments is an IAM call, so the cap is kept below that ceiling
+	// to avoid 429s. The OCI Go SDK's DefaultRetryPolicy already backs off on
+	// 429 (TooManyRequests) and 5xx responses, so this is mainly a safety net
+	// against runaway refreshes rather than a quota guard.
+	// See https://docs.oracle.com/en-us/iaas/Content/Identity/sku/api-rate-limiting.htm.
+	rateLimitRPS = 10.0
 
-	// rateLimitBurst caps how many requests can be released back-to-back
-	// before the limiter throttles. Kept small so a cold refresh does not
-	// fire rateLimitRPS requests at once.
+	// rateLimitBurst is the token-bucket burst size: the limiter releases up
+	// to this many requests back-to-back before throttling to rateLimitRPS.
 	rateLimitBurst = 50
 )
 
@@ -173,42 +163,42 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 // UnmarshalYAML and is also used directly in tests.
 func (c *SDConfig) validate() error {
 	if c.Region == "" {
-		return errors.New("OCI SD configuration requires a region")
+		return errors.New("oci_sd: region is required")
 	}
 
 	switch c.Auth {
 	case authAPIKey:
 		if c.Tenancy == "" {
-			return errors.New("OCI SD api_key auth requires tenancy")
+			return errors.New("oci_sd: api_key auth requires tenancy")
 		}
 		if c.User == "" {
-			return errors.New("OCI SD api_key auth requires user")
+			return errors.New("oci_sd: api_key auth requires user")
 		}
 		if c.Fingerprint == "" {
-			return errors.New("OCI SD api_key auth requires fingerprint")
+			return errors.New("oci_sd: api_key auth requires fingerprint")
 		}
 		if c.KeyFile == "" {
-			return errors.New("OCI SD api_key auth requires key_file")
+			return errors.New("oci_sd: api_key auth requires key_file")
 		}
 		if c.KeyPassphrase != "" && c.KeyPassphraseFile != "" {
-			return errors.New("OCI SD at most one of key_passphrase and key_passphrase_file must be configured")
+			return errors.New("oci_sd: at most one of key_passphrase and key_passphrase_file must be configured")
 		}
 	case authInstancePrincipal:
 		if c.Tenancy != "" || c.User != "" || c.Fingerprint != "" || c.KeyFile != "" || c.KeyPassphrase != "" || c.KeyPassphraseFile != "" {
-			return errors.New("OCI SD instance_principal auth must not have tenancy, user, fingerprint, key_file, key_passphrase, or key_passphrase_file set")
+			return errors.New("oci_sd: instance_principal auth must not have tenancy, user, fingerprint, key_file, key_passphrase, or key_passphrase_file set")
 		}
 	default:
-		return fmt.Errorf("OCI SD unknown auth method %q, expected %q or %q", c.Auth, authAPIKey, authInstancePrincipal)
+		return fmt.Errorf("oci_sd: unknown auth method %q, expected %q or %q", c.Auth, authAPIKey, authInstancePrincipal)
 	}
 
 	for i, cid := range c.Compartments {
 		if cid == "" {
-			return fmt.Errorf("OCI SD compartments[%d] must not be empty", i)
+			return fmt.Errorf("oci_sd: compartments[%d] must not be empty", i)
 		}
 	}
 
 	if c.RefreshInterval <= 0 {
-		return fmt.Errorf("OCI SD refresh_interval must be positive, got %s", c.RefreshInterval)
+		return fmt.Errorf("oci_sd: refresh_interval must be positive, got %s", c.RefreshInterval)
 	}
 
 	return c.HTTPClientConfig.Validate()
@@ -258,17 +248,17 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 
 	httpClient, err := config.NewClientFromConfig(conf.HTTPClientConfig, "oci_sd")
 	if err != nil {
-		return nil, fmt.Errorf("OCI SD failed to build HTTP client: %w", err)
+		return nil, fmt.Errorf("oci_sd: failed to build HTTP client: %w", err)
 	}
 
 	provider, err := newConfigurationProvider(conf, httpClient)
 	if err != nil {
-		return nil, fmt.Errorf("OCI SD failed to build configuration provider: %w", err)
+		return nil, fmt.Errorf("oci_sd: failed to build configuration provider: %w", err)
 	}
 
 	tenancy, err := provider.TenancyOCID()
 	if err != nil {
-		return nil, fmt.Errorf("OCI SD failed to determine tenancy OCID: %w", err)
+		return nil, fmt.Errorf("oci_sd: failed to determine tenancy OCID: %w", err)
 	}
 
 	// Rate limiter and retry policy are shared across all closures so every OCI
@@ -279,12 +269,12 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 
 	compLister, err := newCompartmentLister(provider, httpClient, tenancy, conf.Compartments, limiter, &retryPolicy, opts.Logger)
 	if err != nil {
-		return nil, fmt.Errorf("OCI SD failed to create compartment lister: %w", err)
+		return nil, fmt.Errorf("oci_sd: failed to create compartment lister: %w", err)
 	}
 
 	lister, attachmentLister, fetcher, err := newOCIClients(provider, httpClient, limiter, &retryPolicy)
 	if err != nil {
-		return nil, fmt.Errorf("OCI SD failed to create clients: %w", err)
+		return nil, fmt.Errorf("oci_sd: failed to create clients: %w", err)
 	}
 
 	d := &Discovery{
@@ -540,7 +530,7 @@ func newOCIClients(provider common.ConfigurationProvider, httpClient *http.Clien
 func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	compartments, err := d.listCompartments(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("OCI SD failed to list compartments: %w", err)
+		return nil, fmt.Errorf("oci_sd: failed to list compartments: %w", err)
 	}
 
 	var tgs []*targetgroup.Group
@@ -595,19 +585,16 @@ type vnicInfo struct {
 	publicIP  string
 }
 
-// instanceVnics holds the resolved VNICs for one compute instance: the
-// primary VNIC supplies the scrape address and the indexed primary labels,
-// and any additional attached VNICs are emitted as secondary IP lists for
-// relabeling.
+// instanceVnics holds the primary VNIC resolved for one compute instance. The
+// primary VNIC supplies the scrape address and the VNIC meta labels.
 type instanceVnics struct {
-	primary    vnicInfo
-	secondary  []vnicInfo
-	hasPrimary bool
+	primary vnicInfo
 }
 
-// resolveVnics returns all attached VNICs for inst, with the primary VNIC
-// (if any) singled out. Caller must guarantee inst.Id and inst.CompartmentId
-// are non-nil.
+// resolveVnics returns the primary VNIC for inst. Each attachment costs one
+// GetVnic call and OCI offers no batch VNIC fetch, so the walk stops as soon
+// as the primary VNIC is found rather than fanning out a call per attachment.
+// Caller must guarantee inst.Id and inst.CompartmentId are non-nil.
 func (d *Discovery) resolveVnics(ctx context.Context, inst *core.Instance) (instanceVnics, error) {
 	attachments, err := d.listVnicAttachments(ctx, stringVal(inst.CompartmentId), stringVal(inst.Id))
 	if err != nil {
@@ -626,17 +613,14 @@ func (d *Discovery) resolveVnics(ctx context.Context, inst *core.Instance) (inst
 		if vnic == nil {
 			continue
 		}
-		info := vnicInfo{
-			id:        stringVal(vnic.Id),
-			privateIP: stringVal(vnic.PrivateIp),
-			publicIP:  stringVal(vnic.PublicIp),
+		if vnic.IsPrimary != nil && *vnic.IsPrimary {
+			out.primary = vnicInfo{
+				id:        stringVal(vnic.Id),
+				privateIP: stringVal(vnic.PrivateIp),
+				publicIP:  stringVal(vnic.PublicIp),
+			}
+			break
 		}
-		if vnic.IsPrimary != nil && *vnic.IsPrimary && !out.hasPrimary {
-			out.primary = info
-			out.hasPrimary = true
-			continue
-		}
-		out.secondary = append(out.secondary, info)
 	}
 
 	return out, nil
@@ -664,29 +648,6 @@ func instanceLabels(inst *core.Instance, vnics instanceVnics, tenancy string, po
 		ociLabelVnicID:             model.LabelValue(vnics.primary.id),
 		ociLabelPrivateIP:          model.LabelValue(vnics.primary.privateIP),
 		ociLabelPublicIP:           model.LabelValue(vnics.primary.publicIP),
-	}
-
-	if len(vnics.secondary) > 0 {
-		var privates, publics []string
-		for _, v := range vnics.secondary {
-			if v.privateIP != "" {
-				privates = append(privates, v.privateIP)
-			}
-			if v.publicIP != "" {
-				publics = append(publics, v.publicIP)
-			}
-		}
-		// OCI does not guarantee a stable attachment order across
-		// ListVnicAttachments calls, so sort to keep the joined label
-		// value deterministic between refreshes.
-		slices.Sort(privates)
-		slices.Sort(publics)
-		if len(privates) > 0 {
-			labels[ociLabelSecondaryPrivateIPs] = model.LabelValue(joinList(privates))
-		}
-		if len(publics) > 0 {
-			labels[ociLabelSecondaryPublicIPs] = model.LabelValue(joinList(publics))
-		}
 	}
 
 	for k, v := range inst.FreeformTags {
@@ -738,13 +699,6 @@ func stringifyDefinedTag(v any) (string, bool) {
 	default:
 		return "", false
 	}
-}
-
-// joinList renders values as a separator-wrapped list (",a,b,c,") so users can
-// match individual elements with anchored relabel regexes. Matches the EC2 SD
-// subnet_id convention.
-func joinList(values []string) string {
-	return ociLabelSeparator + strings.Join(values, ociLabelSeparator) + ociLabelSeparator
 }
 
 // stringVal dereferences a *string, returning "" if nil.

--- a/discovery/oci/oci.go
+++ b/discovery/oci/oci.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -73,10 +74,22 @@ const (
 	authAPIKey            = "api_key"
 	authInstancePrincipal = "instance_principal"
 
-	// rateLimitRPS caps OCI API calls per second across all operations
-	// (ListCompartments, ListInstances, ListVnicAttachments, GetVnic) to stay
-	// well below per-tenancy service limits.
-	rateLimitRPS = 10.0
+	// defaultRateLimitRPS is the default cap on OCI API calls per second
+	// across all operations (ListCompartments, ListInstances,
+	// ListVnicAttachments, GetVnic). The OCI Go SDK's DefaultRetryPolicy
+	// already backs off on 429 (TooManyRequests) and 5xx responses, so the
+	// client cap is intentionally generous: discovery of a tenancy with a
+	// few thousand instances issues two paginated calls per VNIC plus one
+	// list call per compartment, and the 60s default refresh interval gives
+	// little headroom at low rates. Operators can lower this through the
+	// rate_limit_rps configuration field if their tenancy enforces a
+	// stricter quota.
+	defaultRateLimitRPS = 500.0
+
+	// rateLimitBurst caps how many requests can be released back-to-back
+	// before the limiter throttles. Kept small so a cold refresh does not
+	// fire defaultRateLimitRPS requests at once.
+	rateLimitBurst = 50
 )
 
 // DefaultSDConfig is the default OCI service discovery configuration.
@@ -84,6 +97,7 @@ var DefaultSDConfig = SDConfig{
 	Port:             80,
 	RefreshInterval:  model.Duration(60 * time.Second),
 	Auth:             authAPIKey,
+	RateLimitRPS:     defaultRateLimitRPS,
 	HTTPClientConfig: config.DefaultHTTPClientConfig,
 }
 
@@ -121,8 +135,11 @@ type SDConfig struct {
 	// automatically via the OCI Identity API.
 	Compartments []string `yaml:"compartments,omitempty"`
 
-	// Filter is an optional OCI display-name substring filter for ListInstances.
-	Filter string `yaml:"filter,omitempty"`
+	// RateLimitRPS caps OCI API calls per second across all operations
+	// (ListCompartments, ListInstances, ListVnicAttachments, GetVnic). The
+	// SDK's default retry policy already backs off on 429 and 5xx responses,
+	// so this is primarily useful for tenancies enforcing a stricter quota.
+	RateLimitRPS float64 `yaml:"rate_limit_rps,omitempty"`
 
 	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 
@@ -202,6 +219,10 @@ func (c *SDConfig) validate() error {
 		return fmt.Errorf("OCI SD refresh_interval must be positive, got %s", c.RefreshInterval)
 	}
 
+	if c.RateLimitRPS <= 0 {
+		return fmt.Errorf("OCI SD rate_limit_rps must be positive, got %v", c.RateLimitRPS)
+	}
+
 	return c.HTTPClientConfig.Validate()
 }
 
@@ -263,8 +284,13 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 	}
 
 	// Rate limiter and retry policy are shared across all closures so every OCI
-	// API call counts against the same budget.
-	limiter := rate.NewLimiter(rate.Limit(rateLimitRPS), max(1, int(rateLimitRPS)))
+	// API call counts against the same budget. The burst is kept small so a
+	// cold refresh does not fire a full second's worth of calls at once.
+	burst := rateLimitBurst
+	if rps := int(conf.RateLimitRPS); rps > 0 && rps < burst {
+		burst = rps
+	}
+	limiter := rate.NewLimiter(rate.Limit(conf.RateLimitRPS), burst)
 	retryPolicy := common.DefaultRetryPolicy()
 
 	compLister, err := newCompartmentLister(provider, httpClient, tenancy, conf.Compartments, limiter, &retryPolicy, opts.Logger)
@@ -272,7 +298,7 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 		return nil, fmt.Errorf("OCI SD failed to create compartment lister: %w", err)
 	}
 
-	lister, attachmentLister, fetcher, err := newOCIClients(provider, httpClient, conf.Filter, limiter, &retryPolicy)
+	lister, attachmentLister, fetcher, err := newOCIClients(provider, httpClient, limiter, &retryPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("OCI SD failed to create clients: %w", err)
 	}
@@ -446,7 +472,7 @@ func listAllCompartments(ctx context.Context, paginate compartmentPaginator, roo
 // clients. The concrete client values live only in the closure context so
 // reflection cannot reach them through the interface-boxed Discovery struct,
 // allowing the linker to drop unused SDK operations and keep the binary small.
-func newOCIClients(provider common.ConfigurationProvider, httpClient *http.Client, filter string, limiter *rate.Limiter, retryPolicy *common.RetryPolicy) (instancesLister, vnicAttachmentLister, vnicFetcher, error) {
+func newOCIClients(provider common.ConfigurationProvider, httpClient *http.Client, limiter *rate.Limiter, retryPolicy *common.RetryPolicy) (instancesLister, vnicAttachmentLister, vnicFetcher, error) {
 	computeClient, err := core.NewComputeClientWithConfigurationProvider(provider)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("creating OCI compute client: %w", err)
@@ -467,9 +493,6 @@ func newOCIClients(provider common.ConfigurationProvider, httpClient *http.Clien
 			CompartmentId:   common.String(compartmentID),
 			Limit:           common.Int(100),
 			RequestMetadata: common.RequestMetadata{RetryPolicy: retryPolicy},
-		}
-		if filter != "" {
-			req.DisplayName = common.String(filter)
 		}
 		for {
 			if err := limiter.Wait(ctx); err != nil {
@@ -543,12 +566,10 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 		instances, err := d.listInstances(ctx, compartmentID)
 		if err != nil {
-			d.logger.Warn("OCI SD failed to list instances, clearing compartment targets",
-				"compartment_id", compartmentID, "err", err)
-			// Emit the empty group so the discovery manager prunes any
-			// stale targets it still has for this compartment.
-			tgs = append(tgs, tg)
-			continue
+			// Return the error rather than emitting an empty group: the
+			// refresh framework will keep the last known good targets for
+			// this source, avoiding a flap on a transient OCI API failure.
+			return nil, fmt.Errorf("listing OCI instances in compartment %s: %w", compartmentID, err)
 		}
 
 		for i := range instances {
@@ -671,6 +692,11 @@ func instanceLabels(inst *core.Instance, vnics instanceVnics, tenancy string, po
 				publics = append(publics, v.publicIP)
 			}
 		}
+		// OCI does not guarantee a stable attachment order across
+		// ListVnicAttachments calls, so sort to keep the joined label
+		// value deterministic between refreshes.
+		slices.Sort(privates)
+		slices.Sort(publics)
 		if len(privates) > 0 {
 			labels[ociLabelSecondaryPrivateIPs] = model.LabelValue(joinList(privates))
 		}
@@ -683,11 +709,14 @@ func instanceLabels(inst *core.Instance, vnics instanceVnics, tenancy string, po
 		labels[model.LabelName(ociLabelFreeformTagPrefix+strutil.SanitizeLabelName(k))] = model.LabelValue(v)
 	}
 
-	// Only string-typed defined tag values are emitted; numeric and boolean
-	// values from OCI's typed tag system are skipped to avoid label churn.
+	// OCI's typed tag system allows string, integer, and boolean values for
+	// defined tags. Stringify scalar values so a keep/drop relabel on a
+	// numeric or boolean tag does not silently match nothing. Non-scalar
+	// values (slices, maps) cannot be safely represented as a single label
+	// value and are skipped.
 	for ns, tags := range inst.DefinedTags {
 		for k, v := range tags {
-			s, ok := v.(string)
+			s, ok := stringifyDefinedTag(v)
 			if !ok {
 				continue
 			}
@@ -697,6 +726,34 @@ func instanceLabels(inst *core.Instance, vnics instanceVnics, tenancy string, po
 	}
 
 	return labels
+}
+
+// stringifyDefinedTag converts a scalar OCI defined-tag value to a string.
+// The SDK decodes defined tags as map[string]any: JSON numbers arrive as
+// float64, booleans as bool, and strings as string. Integer fields are kept
+// (some callers may construct DefinedTags in Go directly). Non-scalar
+// values cannot be safely flattened to a label and are reported as not OK.
+func stringifyDefinedTag(v any) (string, bool) {
+	switch t := v.(type) {
+	case nil:
+		return "", false
+	case string:
+		return t, true
+	case bool:
+		return strconv.FormatBool(t), true
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64), true
+	case float32:
+		return strconv.FormatFloat(float64(t), 'f', -1, 32), true
+	case int:
+		return strconv.FormatInt(int64(t), 10), true
+	case int64:
+		return strconv.FormatInt(t, 10), true
+	case int32:
+		return strconv.FormatInt(int64(t), 10), true
+	default:
+		return "", false
+	}
 }
 
 // joinList renders values as a separator-wrapped list (",a,b,c,") so users can

--- a/discovery/oci/oci.go
+++ b/discovery/oci/oci.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -32,6 +33,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
+	"github.com/prometheus/common/version"
 	"golang.org/x/time/rate"
 
 	"github.com/prometheus/prometheus/discovery"
@@ -41,29 +44,34 @@ import (
 )
 
 const (
-	ociLabel                   = model.MetaLabelPrefix + "oci_"
-	ociLabelInstanceID         = ociLabel + "instance_id"
-	ociLabelInstanceName       = ociLabel + "instance_name"
-	ociLabelInstanceState      = ociLabel + "instance_state"
-	ociLabelInstanceShape      = ociLabel + "instance_shape"
-	ociLabelAvailabilityDomain = ociLabel + "availability_domain"
-	ociLabelFaultDomain        = ociLabel + "fault_domain"
-	ociLabelRegion             = ociLabel + "region"
-	ociLabelTenancyID          = ociLabel + "tenancy_id"
-	ociLabelCompartmentID      = ociLabel + "compartment_id"
-	ociLabelImageID            = ociLabel + "image_id"
-	ociLabelPrivateIP          = ociLabel + "private_ip"
-	ociLabelPublicIP           = ociLabel + "public_ip"
-	ociLabelFreeformTagPrefix  = ociLabel + "tag_"
-	ociLabelDefinedTagPrefix   = ociLabel + "defined_tag_"
+	ociLabel                    = model.MetaLabelPrefix + "oci_"
+	ociLabelInstanceID          = ociLabel + "instance_id"
+	ociLabelInstanceName        = ociLabel + "instance_name"
+	ociLabelInstanceState       = ociLabel + "instance_state"
+	ociLabelInstanceShape       = ociLabel + "instance_shape"
+	ociLabelAvailabilityDomain  = ociLabel + "availability_domain"
+	ociLabelFaultDomain         = ociLabel + "fault_domain"
+	ociLabelRegion              = ociLabel + "region"
+	ociLabelTenancyID           = ociLabel + "tenancy_id"
+	ociLabelCompartmentID       = ociLabel + "compartment_id"
+	ociLabelImageID             = ociLabel + "image_id"
+	ociLabelVnicID              = ociLabel + "vnic_id"
+	ociLabelPrivateIP           = ociLabel + "private_ip"
+	ociLabelPublicIP            = ociLabel + "public_ip"
+	ociLabelSecondaryPrivateIPs = ociLabel + "secondary_private_ips"
+	ociLabelSecondaryPublicIPs  = ociLabel + "secondary_public_ips"
+	ociLabelFreeformTagPrefix   = ociLabel + "tag_"
+	ociLabelDefinedTagPrefix    = ociLabel + "defined_tag_"
+
+	// ociLabelSeparator surrounds and separates values in list-valued labels
+	// (e.g. ociLabelSecondaryPrivateIPs) so users can match individual values
+	// with anchored relabel regexes without ambiguity at the boundaries.
+	ociLabelSeparator = ","
 )
 
 const (
 	authAPIKey            = "api_key"
 	authInstancePrincipal = "instance_principal"
-
-	tagFilterActionInclude = "include"
-	tagFilterActionExclude = "exclude"
 
 	// rateLimitRPS caps OCI API calls per second across all operations
 	// (ListCompartments, ListInstances, ListVnicAttachments, GetVnic) to stay
@@ -76,7 +84,6 @@ var DefaultSDConfig = SDConfig{
 	Port:             80,
 	RefreshInterval:  model.Duration(60 * time.Second),
 	Auth:             authAPIKey,
-	TagFilterAction:  tagFilterActionInclude,
 	HTTPClientConfig: config.DefaultHTTPClientConfig,
 }
 
@@ -91,11 +98,20 @@ type SDConfig struct {
 	Auth string `yaml:"auth,omitempty"`
 
 	// API key auth fields. Required when Auth is "api_key".
-	Tenancy       string        `yaml:"tenancy,omitempty"`
-	User          string        `yaml:"user,omitempty"`
-	Fingerprint   string        `yaml:"fingerprint,omitempty"`
-	KeyFile       string        `yaml:"key_file,omitempty"`
+	Tenancy     string `yaml:"tenancy,omitempty"`
+	User        string `yaml:"user,omitempty"`
+	Fingerprint string `yaml:"fingerprint,omitempty"`
+	KeyFile     string `yaml:"key_file,omitempty"`
+	// KeyPassphrase is the passphrase used to decrypt KeyFile, if any.
+	// Mutually exclusive with KeyPassphraseFile.
 	KeyPassphrase config.Secret `yaml:"key_passphrase,omitempty"`
+	// KeyPassphraseFile is a path to a file containing the passphrase used to
+	// decrypt KeyFile. Mutually exclusive with KeyPassphrase.
+	//
+	// TODO: read this lazily via a custom common.ConfigurationProvider so
+	// rotating the passphrase on disk takes effect without restarting
+	// Prometheus, matching the runtime-reloadable semantics of password_file.
+	KeyPassphraseFile string `yaml:"key_passphrase_file,omitempty"`
 
 	// Region is required for all auth methods.
 	Region string `yaml:"region"`
@@ -107,14 +123,6 @@ type SDConfig struct {
 
 	// Filter is an optional OCI display-name substring filter for ListInstances.
 	Filter string `yaml:"filter,omitempty"`
-
-	// TagFilterKey and TagFilterValue together select instances by a freeform or
-	// defined tag. TagFilterAction controls whether matching instances are included
-	// (default: "include") or excluded ("exclude"). When TagFilterKey is empty all
-	// instances are returned regardless of TagFilterValue and TagFilterAction.
-	TagFilterKey    string `yaml:"tag_filter_key,omitempty"`
-	TagFilterValue  string `yaml:"tag_filter_value,omitempty"`
-	TagFilterAction string `yaml:"tag_filter_action,omitempty"`
 
 	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 
@@ -139,6 +147,7 @@ func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Di
 func (c *SDConfig) SetDirectory(dir string) {
 	c.HTTPClientConfig.SetDirectory(dir)
 	c.KeyFile = config.JoinDir(dir, c.KeyFile)
+	c.KeyPassphraseFile = config.JoinDir(dir, c.KeyPassphraseFile)
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -172,9 +181,12 @@ func (c *SDConfig) validate() error {
 		if c.KeyFile == "" {
 			return errors.New("OCI SD api_key auth requires key_file")
 		}
+		if c.KeyPassphrase != "" && c.KeyPassphraseFile != "" {
+			return errors.New("OCI SD at most one of key_passphrase and key_passphrase_file must be configured")
+		}
 	case authInstancePrincipal:
-		if c.Tenancy != "" || c.User != "" || c.Fingerprint != "" || c.KeyFile != "" {
-			return errors.New("OCI SD instance_principal auth must not have tenancy, user, fingerprint, or key_file set")
+		if c.Tenancy != "" || c.User != "" || c.Fingerprint != "" || c.KeyFile != "" || c.KeyPassphrase != "" || c.KeyPassphraseFile != "" {
+			return errors.New("OCI SD instance_principal auth must not have tenancy, user, fingerprint, key_file, key_passphrase, or key_passphrase_file set")
 		}
 	default:
 		return fmt.Errorf("OCI SD unknown auth method %q, expected %q or %q", c.Auth, authAPIKey, authInstancePrincipal)
@@ -183,17 +195,6 @@ func (c *SDConfig) validate() error {
 	for i, cid := range c.Compartments {
 		if cid == "" {
 			return fmt.Errorf("OCI SD compartments[%d] must not be empty", i)
-		}
-	}
-
-	if c.TagFilterKey != "" {
-		if c.TagFilterValue == "" {
-			return errors.New("OCI SD tag_filter_key requires tag_filter_value")
-		}
-		switch c.TagFilterAction {
-		case tagFilterActionInclude, tagFilterActionExclude:
-		default:
-			return fmt.Errorf("OCI SD tag_filter_action must be %q or %q, got %q", tagFilterActionInclude, tagFilterActionExclude, c.TagFilterAction)
 		}
 	}
 
@@ -231,9 +232,6 @@ type Discovery struct {
 	listVnicAttachments vnicAttachmentLister
 	getVnic             vnicFetcher
 	tenancy             string
-	tagFilterKey        string
-	tagFilterValue      string
-	tagFilterAction     string
 	port                int
 	logger              *slog.Logger
 }
@@ -243,6 +241,10 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 	m, ok := opts.Metrics.(*ociMetrics)
 	if !ok {
 		return nil, errors.New("invalid discovery metrics type")
+	}
+
+	if opts.Logger == nil {
+		opts.Logger = promslog.NewNopLogger()
 	}
 
 	httpClient, err := config.NewClientFromConfig(conf.HTTPClientConfig, "oci_sd")
@@ -265,7 +267,7 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 	limiter := rate.NewLimiter(rate.Limit(rateLimitRPS), max(1, int(rateLimitRPS)))
 	retryPolicy := common.DefaultRetryPolicy()
 
-	compLister, err := newCompartmentLister(provider, httpClient, tenancy, conf.Compartments, limiter, &retryPolicy)
+	compLister, err := newCompartmentLister(provider, httpClient, tenancy, conf.Compartments, limiter, &retryPolicy, opts.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("OCI SD failed to create compartment lister: %w", err)
 	}
@@ -281,9 +283,6 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 		listVnicAttachments: attachmentLister,
 		getVnic:             fetcher,
 		tenancy:             tenancy,
-		tagFilterKey:        conf.TagFilterKey,
-		tagFilterValue:      conf.TagFilterValue,
-		tagFilterAction:     conf.TagFilterAction,
 		port:                conf.Port,
 		logger:              opts.Logger,
 	}
@@ -318,7 +317,10 @@ func newConfigurationProvider(conf *SDConfig, httpClient *http.Client) (common.C
 		if err != nil {
 			return nil, fmt.Errorf("reading OCI key file %q: %w", conf.KeyFile, err)
 		}
-		passphrase := string(conf.KeyPassphrase)
+		passphrase, err := resolveKeyPassphrase(conf)
+		if err != nil {
+			return nil, err
+		}
 		var passphrasePtr *string
 		if passphrase != "" {
 			passphrasePtr = &passphrase
@@ -330,13 +332,32 @@ func newConfigurationProvider(conf *SDConfig, httpClient *http.Client) (common.C
 	}
 }
 
+// resolveKeyPassphrase reads the inline KeyPassphrase or the contents of
+// KeyPassphraseFile. The file is read eagerly at construction time; rotation
+// at runtime is not yet supported (see TODO on SDConfig.KeyPassphraseFile).
+func resolveKeyPassphrase(conf *SDConfig) (string, error) {
+	if conf.KeyPassphraseFile != "" {
+		b, err := os.ReadFile(conf.KeyPassphraseFile)
+		if err != nil {
+			return "", fmt.Errorf("reading OCI key passphrase file %q: %w", conf.KeyPassphraseFile, err)
+		}
+		return strings.TrimRight(string(b), "\r\n"), nil
+	}
+	return string(conf.KeyPassphrase), nil
+}
+
+// compartmentPaginator lists the direct child compartments of parentID one
+// page at a time. It is the smallest surface listAllCompartments needs from
+// the OCI Identity API, which keeps the walk easy to test with a fake.
+type compartmentPaginator func(ctx context.Context, parentID string, page *string) ([]identity.Compartment, *string, error)
+
 // newCompartmentLister returns a compartmentLister that either returns the
 // explicit list from the config directly, or auto-discovers all active
 // compartments under the tenancy root via the OCI Identity API.
 //
 // When compartments are explicitly configured no Identity client is created,
 // so the identity package methods are dropped by dead-code elimination.
-func newCompartmentLister(provider common.ConfigurationProvider, httpClient *http.Client, tenancy string, compartments []string, limiter *rate.Limiter, retryPolicy *common.RetryPolicy) (compartmentLister, error) {
+func newCompartmentLister(provider common.ConfigurationProvider, httpClient *http.Client, tenancy string, compartments []string, limiter *rate.Limiter, retryPolicy *common.RetryPolicy, logger *slog.Logger) (compartmentLister, error) {
 	if len(compartments) > 0 {
 		ids := make([]string, len(compartments))
 		copy(ids, compartments)
@@ -352,16 +373,37 @@ func newCompartmentLister(provider common.ConfigurationProvider, httpClient *htt
 		return nil, fmt.Errorf("creating OCI identity client: %w", err)
 	}
 	idClient.HTTPClient = httpClient
+	idClient.UserAgent = version.PrometheusUserAgent()
+
+	paginate := func(ctx context.Context, parentID string, page *string) ([]identity.Compartment, *string, error) {
+		if err := limiter.Wait(ctx); err != nil {
+			return nil, nil, err
+		}
+		resp, err := idClient.ListCompartments(ctx, identity.ListCompartmentsRequest{
+			CompartmentId:          common.String(parentID),
+			AccessLevel:            identity.ListCompartmentsAccessLevelAccessible,
+			CompartmentIdInSubtree: common.Bool(false), // Direct children only.
+			Limit:                  common.Int(100),
+			Page:                   page,
+			RequestMetadata:        common.RequestMetadata{RetryPolicy: retryPolicy},
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.OpcNextPage, nil
+	}
 
 	return func(ctx context.Context) ([]string, error) {
-		return listAllCompartments(ctx, &idClient, tenancy, limiter, retryPolicy)
+		return listAllCompartments(ctx, paginate, tenancy, logger)
 	}, nil
 }
 
 // listAllCompartments recursively discovers all active compartments reachable
 // from root using a BFS queue, including root itself. Child compartments that
-// fail to list are skipped so a single permission gap does not abort the walk.
-func listAllCompartments(ctx context.Context, idClient *identity.IdentityClient, root string, limiter *rate.Limiter, retryPolicy *common.RetryPolicy) ([]string, error) {
+// fail to list (typically a permission gap) are logged and skipped so a single
+// gap does not abort the walk. Context cancellation aborts the walk immediately
+// rather than being treated as a permission gap.
+func listAllCompartments(ctx context.Context, paginate compartmentPaginator, root string, logger *slog.Logger) ([]string, error) {
 	var all []string
 	visited := make(map[string]bool)
 	queue := []string{root}
@@ -377,30 +419,24 @@ func listAllCompartments(ctx context.Context, idClient *identity.IdentityClient,
 
 		var page *string
 		for {
-			if err := limiter.Wait(ctx); err != nil {
-				return nil, err
-			}
-			resp, err := idClient.ListCompartments(ctx, identity.ListCompartmentsRequest{
-				CompartmentId:          common.String(current),
-				AccessLevel:            identity.ListCompartmentsAccessLevelAccessible,
-				CompartmentIdInSubtree: common.Bool(false), // direct children only
-				Limit:                  common.Int(100),
-				Page:                   page,
-				RequestMetadata:        common.RequestMetadata{RetryPolicy: retryPolicy},
-			})
+			items, next, err := paginate(ctx, current, page)
 			if err != nil {
-				// Permission gap on this compartment - skip its children.
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+				logger.Warn("OCI SD failed to list child compartments, skipping subtree",
+					"compartment_id", current, "err", err)
 				break
 			}
-			for _, comp := range resp.Items {
+			for _, comp := range items {
 				if comp.Id != nil && comp.LifecycleState == identity.CompartmentLifecycleStateActive && !visited[*comp.Id] {
 					queue = append(queue, *comp.Id)
 				}
 			}
-			if resp.OpcNextPage == nil {
+			if next == nil {
 				break
 			}
-			page = resp.OpcNextPage
+			page = next
 		}
 	}
 	return all, nil
@@ -416,12 +452,14 @@ func newOCIClients(provider common.ConfigurationProvider, httpClient *http.Clien
 		return nil, nil, nil, fmt.Errorf("creating OCI compute client: %w", err)
 	}
 	computeClient.HTTPClient = httpClient
+	computeClient.UserAgent = version.PrometheusUserAgent()
 
 	vnetClient, err := core.NewVirtualNetworkClientWithConfigurationProvider(provider)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("creating OCI virtual network client: %w", err)
 	}
 	vnetClient.HTTPClient = httpClient
+	vnetClient.UserAgent = version.PrometheusUserAgent()
 
 	lister := func(ctx context.Context, compartmentID string) ([]core.Instance, error) {
 		var instances []core.Instance
@@ -522,32 +560,20 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 				continue
 			}
 
-			// Tag filter is applied before VNIC resolution to avoid unnecessary API
-			// calls for instances that will be dropped anyway.
-			if d.tagFilterKey != "" {
-				match := hasTag(inst, d.tagFilterKey, d.tagFilterValue)
-				if d.tagFilterAction == tagFilterActionInclude && !match {
-					continue
-				}
-				if d.tagFilterAction == tagFilterActionExclude && match {
-					continue
-				}
-			}
-
-			privateIP, publicIP, err := d.primaryVnicIPs(ctx, inst)
+			vnics, err := d.resolveVnics(ctx, inst)
 			if err != nil {
 				d.logger.Warn("OCI SD failed to resolve VNIC IPs, skipping instance",
 					"instance_id", *inst.Id, "err", err)
 				continue
 			}
 
-			if privateIP == "" && publicIP == "" {
+			if vnics.primary.privateIP == "" && vnics.primary.publicIP == "" {
 				d.logger.Debug("OCI SD skipping instance with no usable IP address",
 					"instance_id", *inst.Id)
 				continue
 			}
 
-			tg.Targets = append(tg.Targets, instanceLabels(inst, privateIP, publicIP, d.tenancy, d.port))
+			tg.Targets = append(tg.Targets, instanceLabels(inst, vnics, d.tenancy, d.port))
 		}
 
 		tgs = append(tgs, tg)
@@ -556,60 +582,66 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	return tgs, nil
 }
 
-// primaryVnicIPs returns the private and public IP of the primary VNIC for inst.
-// publicIP may be empty if no public IP is assigned. Caller must guarantee
-// inst.Id and inst.CompartmentId are non-nil.
-func (d *Discovery) primaryVnicIPs(ctx context.Context, inst *core.Instance) (privateIP, publicIP string, err error) {
+// vnicInfo is the subset of a single OCI VNIC that the SD exposes through
+// meta labels.
+type vnicInfo struct {
+	id        string
+	privateIP string
+	publicIP  string
+}
+
+// instanceVnics holds the resolved VNICs for one compute instance: the
+// primary VNIC supplies the scrape address and the indexed primary labels,
+// and any additional attached VNICs are emitted as secondary IP lists for
+// relabeling.
+type instanceVnics struct {
+	primary    vnicInfo
+	secondary  []vnicInfo
+	hasPrimary bool
+}
+
+// resolveVnics returns all attached VNICs for inst, with the primary VNIC
+// (if any) singled out. Caller must guarantee inst.Id and inst.CompartmentId
+// are non-nil.
+func (d *Discovery) resolveVnics(ctx context.Context, inst *core.Instance) (instanceVnics, error) {
 	attachments, err := d.listVnicAttachments(ctx, stringVal(inst.CompartmentId), stringVal(inst.Id))
 	if err != nil {
-		return "", "", fmt.Errorf("listing VNIC attachments for instance %s: %w", stringVal(inst.Id), err)
+		return instanceVnics{}, fmt.Errorf("listing VNIC attachments for instance %s: %w", stringVal(inst.Id), err)
 	}
 
+	var out instanceVnics
 	for _, att := range attachments {
 		if att.VnicId == nil || att.LifecycleState != core.VnicAttachmentLifecycleStateAttached {
 			continue
 		}
 		vnic, err := d.getVnic(ctx, *att.VnicId)
 		if err != nil {
-			return "", "", fmt.Errorf("fetching VNIC %s: %w", *att.VnicId, err)
+			return instanceVnics{}, fmt.Errorf("fetching VNIC %s: %w", *att.VnicId, err)
 		}
-		if vnic == nil || vnic.IsPrimary == nil || !*vnic.IsPrimary {
+		if vnic == nil {
 			continue
 		}
-		if vnic.PrivateIp != nil {
-			privateIP = *vnic.PrivateIp
+		info := vnicInfo{
+			id:        stringVal(vnic.Id),
+			privateIP: stringVal(vnic.PrivateIp),
+			publicIP:  stringVal(vnic.PublicIp),
 		}
-		if vnic.PublicIp != nil {
-			publicIP = *vnic.PublicIp
+		if vnic.IsPrimary != nil && *vnic.IsPrimary && !out.hasPrimary {
+			out.primary = info
+			out.hasPrimary = true
+			continue
 		}
-		return privateIP, publicIP, nil
+		out.secondary = append(out.secondary, info)
 	}
 
-	return "", "", nil
-}
-
-// hasTag reports whether inst carries a freeform or defined tag with the given
-// key and value. Freeform tags are checked first; defined tags are checked
-// across all namespaces. Only string-typed defined tag values are compared.
-func hasTag(inst *core.Instance, key, value string) bool {
-	if v, ok := inst.FreeformTags[key]; ok && v == value {
-		return true
-	}
-	for _, nsMap := range inst.DefinedTags {
-		if v, ok := nsMap[key]; ok {
-			if s, ok := v.(string); ok && s == value {
-				return true
-			}
-		}
-	}
-	return false
+	return out, nil
 }
 
 // instanceLabels builds the label set for one OCI compute instance.
-func instanceLabels(inst *core.Instance, privateIP, publicIP, tenancy string, port int) model.LabelSet {
-	addr := privateIP
+func instanceLabels(inst *core.Instance, vnics instanceVnics, tenancy string, port int) model.LabelSet {
+	addr := vnics.primary.privateIP
 	if addr == "" {
-		addr = publicIP
+		addr = vnics.primary.publicIP
 	}
 
 	labels := model.LabelSet{
@@ -624,8 +656,27 @@ func instanceLabels(inst *core.Instance, privateIP, publicIP, tenancy string, po
 		ociLabelTenancyID:          model.LabelValue(tenancy),
 		ociLabelCompartmentID:      model.LabelValue(stringVal(inst.CompartmentId)),
 		ociLabelImageID:            model.LabelValue(stringVal(inst.ImageId)),
-		ociLabelPrivateIP:          model.LabelValue(privateIP),
-		ociLabelPublicIP:           model.LabelValue(publicIP),
+		ociLabelVnicID:             model.LabelValue(vnics.primary.id),
+		ociLabelPrivateIP:          model.LabelValue(vnics.primary.privateIP),
+		ociLabelPublicIP:           model.LabelValue(vnics.primary.publicIP),
+	}
+
+	if len(vnics.secondary) > 0 {
+		var privates, publics []string
+		for _, v := range vnics.secondary {
+			if v.privateIP != "" {
+				privates = append(privates, v.privateIP)
+			}
+			if v.publicIP != "" {
+				publics = append(publics, v.publicIP)
+			}
+		}
+		if len(privates) > 0 {
+			labels[ociLabelSecondaryPrivateIPs] = model.LabelValue(joinList(privates))
+		}
+		if len(publics) > 0 {
+			labels[ociLabelSecondaryPublicIPs] = model.LabelValue(joinList(publics))
+		}
 	}
 
 	for k, v := range inst.FreeformTags {
@@ -646,6 +697,13 @@ func instanceLabels(inst *core.Instance, privateIP, publicIP, tenancy string, po
 	}
 
 	return labels
+}
+
+// joinList renders values as a separator-wrapped list (",a,b,c,") so users can
+// match individual elements with anchored relabel regexes. Matches the EC2 SD
+// subnet_id convention.
+func joinList(values []string) string {
+	return ociLabelSeparator + strings.Join(values, ociLabelSeparator) + ociLabelSeparator
 }
 
 // stringVal dereferences a *string, returning "" if nil.

--- a/discovery/oci/oci.go
+++ b/discovery/oci/oci.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -37,6 +37,7 @@ import (
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/refresh"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/util/strutil"
 )
 
 const (
@@ -63,15 +64,20 @@ const (
 
 	tagFilterActionInclude = "include"
 	tagFilterActionExclude = "exclude"
+
+	// rateLimitRPS caps OCI API calls per second across all operations
+	// (ListCompartments, ListInstances, ListVnicAttachments, GetVnic) to stay
+	// well below per-tenancy service limits.
+	rateLimitRPS = 10.0
 )
 
 // DefaultSDConfig is the default OCI service discovery configuration.
 var DefaultSDConfig = SDConfig{
-	Port:            80,
-	RefreshInterval: model.Duration(60 * time.Second),
-	Auth:            authAPIKey,
-	TagFilterAction: tagFilterActionInclude,
-	RateLimitRPS:    10.0,
+	Port:             80,
+	RefreshInterval:  model.Duration(60 * time.Second),
+	Auth:             authAPIKey,
+	TagFilterAction:  tagFilterActionInclude,
+	HTTPClientConfig: config.DefaultHTTPClientConfig,
 }
 
 func init() {
@@ -110,9 +116,7 @@ type SDConfig struct {
 	TagFilterValue  string `yaml:"tag_filter_value,omitempty"`
 	TagFilterAction string `yaml:"tag_filter_action,omitempty"`
 
-	// RateLimitRPS caps the number of OCI API calls per second to avoid hitting
-	// per-tenancy service limits. Defaults to 10.
-	RateLimitRPS float64 `yaml:"rate_limit_rps,omitempty"`
+	HTTPClientConfig config.HTTPClientConfig `yaml:",inline"`
 
 	Port            int            `yaml:"port"`
 	RefreshInterval model.Duration `yaml:"refresh_interval"`
@@ -133,9 +137,8 @@ func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Di
 
 // SetDirectory joins any relative file paths with dir.
 func (c *SDConfig) SetDirectory(dir string) {
-	if c.KeyFile != "" && !strings.HasPrefix(c.KeyFile, "/") {
-		c.KeyFile = dir + "/" + c.KeyFile
-	}
+	c.HTTPClientConfig.SetDirectory(dir)
+	c.KeyFile = config.JoinDir(dir, c.KeyFile)
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -194,11 +197,11 @@ func (c *SDConfig) validate() error {
 		}
 	}
 
-	if c.RateLimitRPS <= 0 {
-		return errors.New("OCI SD rate_limit_rps must be positive")
+	if c.RefreshInterval <= 0 {
+		return fmt.Errorf("OCI SD refresh_interval must be positive, got %s", c.RefreshInterval)
 	}
 
-	return nil
+	return c.HTTPClientConfig.Validate()
 }
 
 // compartmentLister returns the ordered list of compartment OCIDs to scan.
@@ -207,10 +210,10 @@ func (c *SDConfig) validate() error {
 // tenancy root via the OCI Identity API.
 type compartmentLister func(ctx context.Context) ([]string, error)
 
-// instancesLister lists RUNNING compute instances in a compartment, handling
-// pagination internally. The concrete ComputeClient is captured in the closure
-// so it is not reachable through reflection on the interface-boxed Discovery
-// struct, keeping dead-code elimination effective and the binary small.
+// instancesLister lists compute instances in a compartment, handling pagination
+// internally. The concrete ComputeClient is captured in the closure so it is
+// not reachable through reflection on the interface-boxed Discovery struct,
+// keeping dead-code elimination effective and the binary small.
 type instancesLister func(ctx context.Context, compartmentID string) ([]core.Instance, error)
 
 // vnicAttachmentLister lists VNIC attachments for an instance in a compartment.
@@ -242,7 +245,12 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 		return nil, errors.New("invalid discovery metrics type")
 	}
 
-	provider, err := newConfigurationProvider(conf)
+	httpClient, err := config.NewClientFromConfig(conf.HTTPClientConfig, "oci_sd")
+	if err != nil {
+		return nil, fmt.Errorf("OCI SD failed to build HTTP client: %w", err)
+	}
+
+	provider, err := newConfigurationProvider(conf, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("OCI SD failed to build configuration provider: %w", err)
 	}
@@ -254,15 +262,15 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 
 	// Rate limiter and retry policy are shared across all closures so every OCI
 	// API call counts against the same budget.
-	limiter := rate.NewLimiter(rate.Limit(conf.RateLimitRPS), max(1, int(conf.RateLimitRPS)))
+	limiter := rate.NewLimiter(rate.Limit(rateLimitRPS), max(1, int(rateLimitRPS)))
 	retryPolicy := common.DefaultRetryPolicy()
 
-	compLister, err := newCompartmentLister(provider, tenancy, conf.Compartments, limiter, &retryPolicy)
+	compLister, err := newCompartmentLister(provider, httpClient, tenancy, conf.Compartments, limiter, &retryPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("OCI SD failed to create compartment lister: %w", err)
 	}
 
-	lister, attachmentLister, fetcher, err := newOCIClients(provider, conf.Filter, limiter, &retryPolicy)
+	lister, attachmentLister, fetcher, err := newOCIClients(provider, httpClient, conf.Filter, limiter, &retryPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("OCI SD failed to create clients: %w", err)
 	}
@@ -293,10 +301,18 @@ func NewDiscovery(conf *SDConfig, opts discovery.DiscovererOptions) (*Discovery,
 }
 
 // newConfigurationProvider builds an OCI ConfigurationProvider for the given SDConfig.
-func newConfigurationProvider(conf *SDConfig) (common.ConfigurationProvider, error) {
+// httpClient is used by the instance-principal key provider so that the IMDS
+// metadata call honours the user-supplied Prometheus HTTP knobs (proxy, TLS,
+// custom CA). For API key auth the provider is purely local so the HTTP client
+// is unused here.
+func newConfigurationProvider(conf *SDConfig, httpClient *http.Client) (common.ConfigurationProvider, error) {
 	switch conf.Auth {
 	case authInstancePrincipal:
-		return auth.InstancePrincipalConfigurationProvider()
+		return auth.InstancePrincipalConfigurationProviderWithCustomClient(
+			func(common.HTTPRequestDispatcher) (common.HTTPRequestDispatcher, error) {
+				return httpClient, nil
+			},
+		)
 	default: // authAPIKey
 		keyPEM, err := os.ReadFile(conf.KeyFile)
 		if err != nil {
@@ -320,7 +336,7 @@ func newConfigurationProvider(conf *SDConfig) (common.ConfigurationProvider, err
 //
 // When compartments are explicitly configured no Identity client is created,
 // so the identity package methods are dropped by dead-code elimination.
-func newCompartmentLister(provider common.ConfigurationProvider, tenancy string, compartments []string, limiter *rate.Limiter, retryPolicy *common.RetryPolicy) (compartmentLister, error) {
+func newCompartmentLister(provider common.ConfigurationProvider, httpClient *http.Client, tenancy string, compartments []string, limiter *rate.Limiter, retryPolicy *common.RetryPolicy) (compartmentLister, error) {
 	if len(compartments) > 0 {
 		ids := make([]string, len(compartments))
 		copy(ids, compartments)
@@ -335,6 +351,7 @@ func newCompartmentLister(provider common.ConfigurationProvider, tenancy string,
 	if err != nil {
 		return nil, fmt.Errorf("creating OCI identity client: %w", err)
 	}
+	idClient.HTTPClient = httpClient
 
 	return func(ctx context.Context) ([]string, error) {
 		return listAllCompartments(ctx, &idClient, tenancy, limiter, retryPolicy)
@@ -393,22 +410,23 @@ func listAllCompartments(ctx context.Context, idClient *identity.IdentityClient,
 // clients. The concrete client values live only in the closure context so
 // reflection cannot reach them through the interface-boxed Discovery struct,
 // allowing the linker to drop unused SDK operations and keep the binary small.
-func newOCIClients(provider common.ConfigurationProvider, filter string, limiter *rate.Limiter, retryPolicy *common.RetryPolicy) (instancesLister, vnicAttachmentLister, vnicFetcher, error) {
+func newOCIClients(provider common.ConfigurationProvider, httpClient *http.Client, filter string, limiter *rate.Limiter, retryPolicy *common.RetryPolicy) (instancesLister, vnicAttachmentLister, vnicFetcher, error) {
 	computeClient, err := core.NewComputeClientWithConfigurationProvider(provider)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("creating OCI compute client: %w", err)
 	}
+	computeClient.HTTPClient = httpClient
 
 	vnetClient, err := core.NewVirtualNetworkClientWithConfigurationProvider(provider)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("creating OCI virtual network client: %w", err)
 	}
+	vnetClient.HTTPClient = httpClient
 
 	lister := func(ctx context.Context, compartmentID string) ([]core.Instance, error) {
 		var instances []core.Instance
 		req := core.ListInstancesRequest{
 			CompartmentId:   common.String(compartmentID),
-			LifecycleState:  core.InstanceLifecycleStateRunning,
 			Limit:           common.Int(100),
 			RequestMetadata: common.RequestMetadata{RetryPolicy: retryPolicy},
 		}
@@ -487,13 +505,22 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 		instances, err := d.listInstances(ctx, compartmentID)
 		if err != nil {
-			d.logger.Warn("OCI SD failed to list instances, skipping compartment",
+			d.logger.Warn("OCI SD failed to list instances, clearing compartment targets",
 				"compartment_id", compartmentID, "err", err)
+			// Emit the empty group so the discovery manager prunes any
+			// stale targets it still has for this compartment.
+			tgs = append(tgs, tg)
 			continue
 		}
 
 		for i := range instances {
 			inst := &instances[i]
+
+			if inst.Id == nil || inst.CompartmentId == nil {
+				d.logger.Warn("OCI SD skipping instance with missing OCID fields",
+					"compartment_id", compartmentID)
+				continue
+			}
 
 			// Tag filter is applied before VNIC resolution to avoid unnecessary API
 			// calls for instances that will be dropped anyway.
@@ -510,7 +537,13 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 			privateIP, publicIP, err := d.primaryVnicIPs(ctx, inst)
 			if err != nil {
 				d.logger.Warn("OCI SD failed to resolve VNIC IPs, skipping instance",
-					"instance_id", stringVal(inst.Id), "err", err)
+					"instance_id", *inst.Id, "err", err)
+				continue
+			}
+
+			if privateIP == "" && publicIP == "" {
+				d.logger.Debug("OCI SD skipping instance with no usable IP address",
+					"instance_id", *inst.Id)
 				continue
 			}
 
@@ -524,11 +557,12 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 }
 
 // primaryVnicIPs returns the private and public IP of the primary VNIC for inst.
-// publicIP may be empty if no public IP is assigned.
+// publicIP may be empty if no public IP is assigned. Caller must guarantee
+// inst.Id and inst.CompartmentId are non-nil.
 func (d *Discovery) primaryVnicIPs(ctx context.Context, inst *core.Instance) (privateIP, publicIP string, err error) {
-	attachments, err := d.listVnicAttachments(ctx, *inst.CompartmentId, *inst.Id)
+	attachments, err := d.listVnicAttachments(ctx, stringVal(inst.CompartmentId), stringVal(inst.Id))
 	if err != nil {
-		return "", "", fmt.Errorf("listing VNIC attachments for instance %s: %w", *inst.Id, err)
+		return "", "", fmt.Errorf("listing VNIC attachments for instance %s: %w", stringVal(inst.Id), err)
 	}
 
 	for _, att := range attachments {
@@ -539,7 +573,7 @@ func (d *Discovery) primaryVnicIPs(ctx context.Context, inst *core.Instance) (pr
 		if err != nil {
 			return "", "", fmt.Errorf("fetching VNIC %s: %w", *att.VnicId, err)
 		}
-		if vnic.IsPrimary == nil || !*vnic.IsPrimary {
+		if vnic == nil || vnic.IsPrimary == nil || !*vnic.IsPrimary {
 			continue
 		}
 		if vnic.PrivateIp != nil {
@@ -595,7 +629,7 @@ func instanceLabels(inst *core.Instance, privateIP, publicIP, tenancy string, po
 	}
 
 	for k, v := range inst.FreeformTags {
-		labels[model.LabelName(ociLabelFreeformTagPrefix+sanitizeLabelName(k))] = model.LabelValue(v)
+		labels[model.LabelName(ociLabelFreeformTagPrefix+strutil.SanitizeLabelName(k))] = model.LabelValue(v)
 	}
 
 	// Only string-typed defined tag values are emitted; numeric and boolean
@@ -606,27 +640,12 @@ func instanceLabels(inst *core.Instance, privateIP, publicIP, tenancy string, po
 			if !ok {
 				continue
 			}
-			name := ociLabelDefinedTagPrefix + sanitizeLabelName(ns) + "_" + sanitizeLabelName(k)
+			name := ociLabelDefinedTagPrefix + strutil.SanitizeLabelName(ns) + "_" + strutil.SanitizeLabelName(k)
 			labels[model.LabelName(name)] = model.LabelValue(s)
 		}
 	}
 
 	return labels
-}
-
-// sanitizeLabelName replaces characters that are invalid in Prometheus label
-// names with underscores and lowercases the result.
-func sanitizeLabelName(s string) string {
-	s = strings.ToLower(s)
-	var b strings.Builder
-	for _, r := range s {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
-			b.WriteRune(r)
-		} else {
-			b.WriteRune('_')
-		}
-	}
-	return b.String()
 }
 
 // stringVal dereferences a *string, returning "" if nil.

--- a/discovery/oci/oci_test.go
+++ b/discovery/oci/oci_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -842,15 +843,17 @@ func TestSDConfig_ValidExcludeFilter(t *testing.T) {
 // ---- SetDirectory -----------------------------------------------------------
 
 func TestSDConfig_SetDirectory_RelativePath(t *testing.T) {
-	cfg := SDConfig{KeyFile: "keys/oci.pem"}
-	cfg.SetDirectory("/etc/prometheus")
-	require.Equal(t, "/etc/prometheus/keys/oci.pem", cfg.KeyFile)
+	dir := filepath.FromSlash("/etc/prometheus")
+	cfg := SDConfig{KeyFile: filepath.FromSlash("keys/oci.pem")}
+	cfg.SetDirectory(dir)
+	require.Equal(t, filepath.Join(dir, "keys", "oci.pem"), cfg.KeyFile)
 }
 
 func TestSDConfig_SetDirectory_AbsolutePathUnchanged(t *testing.T) {
-	cfg := SDConfig{KeyFile: "/absolute/path/oci.pem"}
-	cfg.SetDirectory("/etc/prometheus")
-	require.Equal(t, "/absolute/path/oci.pem", cfg.KeyFile)
+	abs := filepath.Join(t.TempDir(), "oci.pem")
+	cfg := SDConfig{KeyFile: abs}
+	cfg.SetDirectory(filepath.FromSlash("/etc/prometheus"))
+	require.Equal(t, abs, cfg.KeyFile)
 }
 
 func TestSDConfig_SetDirectory_EmptyKeyFile(t *testing.T) {

--- a/discovery/oci/oci_test.go
+++ b/discovery/oci/oci_test.go
@@ -737,7 +737,6 @@ func TestSDConfig_Validation(t *testing.T) {
 		Fingerprint:      "aa:bb:cc",
 		KeyFile:          "/etc/oci/key.pem",
 		RefreshInterval:  model.Duration(60 * time.Second),
-		RateLimitRPS:     defaultRateLimitRPS,
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 
@@ -821,16 +820,6 @@ func TestSDConfig_Validation(t *testing.T) {
 			mutate:  func(c *SDConfig) { c.RefreshInterval = model.Duration(-1 * time.Second) },
 			wantErr: "refresh_interval must be positive",
 		},
-		{
-			name:    "rate_limit_rps zero",
-			mutate:  func(c *SDConfig) { c.RateLimitRPS = 0 },
-			wantErr: "rate_limit_rps must be positive",
-		},
-		{
-			name:    "rate_limit_rps negative",
-			mutate:  func(c *SDConfig) { c.RateLimitRPS = -1 },
-			wantErr: "rate_limit_rps must be positive",
-		},
 	}
 
 	for _, tc := range cases {
@@ -849,7 +838,6 @@ func TestSDConfig_ValidInstancePrincipal(t *testing.T) {
 		Auth:             authInstancePrincipal,
 		Region:           "us-ashburn-1",
 		RefreshInterval:  model.Duration(60 * time.Second),
-		RateLimitRPS:     defaultRateLimitRPS,
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
@@ -865,7 +853,6 @@ func TestSDConfig_ValidWithExplicitCompartments(t *testing.T) {
 		KeyFile:          "/etc/oci/key.pem",
 		Compartments:     []string{"ocid1.compartment.oc1..c001", "ocid1.compartment.oc1..c002"},
 		RefreshInterval:  model.Duration(60 * time.Second),
-		RateLimitRPS:     defaultRateLimitRPS,
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
@@ -881,7 +868,6 @@ func TestSDConfig_ValidAutoDiscovery(t *testing.T) {
 		Fingerprint:      "aa:bb:cc",
 		KeyFile:          "/etc/oci/key.pem",
 		RefreshInterval:  model.Duration(60 * time.Second),
-		RateLimitRPS:     defaultRateLimitRPS,
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
@@ -897,7 +883,6 @@ func TestSDConfig_ValidWithKeyPassphraseFile(t *testing.T) {
 		KeyFile:           "/etc/oci/key.pem",
 		KeyPassphraseFile: "/etc/oci/passphrase",
 		RefreshInterval:   model.Duration(60 * time.Second),
-		RateLimitRPS:      defaultRateLimitRPS,
 		HTTPClientConfig:  config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())

--- a/discovery/oci/oci_test.go
+++ b/discovery/oci/oci_test.go
@@ -43,7 +43,7 @@ func makeInstance(opts ...func(*core.Instance)) core.Instance {
 		CompartmentId:      strPtr("ocid1.compartment.oc1..comp001"),
 		LifecycleState:     core.InstanceLifecycleStateRunning,
 		FreeformTags:       map[string]string{},
-		DefinedTags:        map[string]map[string]interface{}{},
+		DefinedTags:        map[string]map[string]any{},
 	}
 	for _, o := range opts {
 		o(&inst)
@@ -74,8 +74,10 @@ func makeAttachment(instanceID, vnicID string) core.VnicAttachment {
 	}
 }
 
-const testCompartment = "ocid1.compartment.oc1..comp001"
-const testTenancy = "ocid1.tenancy.oc1..test001"
+const (
+	testCompartment = "ocid1.compartment.oc1..comp001"
+	testTenancy     = "ocid1.tenancy.oc1..test001"
+)
 
 // baseDiscovery returns a Discovery with no-op closure stubs.
 // Tests override specific closures. d.refresh() is called directly so
@@ -172,7 +174,7 @@ func TestHasTag(t *testing.T) {
 		{
 			name: "defined tag match",
 			inst: makeInstance(func(i *core.Instance) {
-				i.DefinedTags = map[string]map[string]interface{}{
+				i.DefinedTags = map[string]map[string]any{
 					"ops-ns": {"monitoring": "enabled"},
 				}
 			}),
@@ -181,7 +183,7 @@ func TestHasTag(t *testing.T) {
 		{
 			name: "defined tag value mismatch",
 			inst: makeInstance(func(i *core.Instance) {
-				i.DefinedTags = map[string]map[string]interface{}{
+				i.DefinedTags = map[string]map[string]any{
 					"ops-ns": {"monitoring": "disabled"},
 				}
 			}),
@@ -190,7 +192,7 @@ func TestHasTag(t *testing.T) {
 		{
 			name: "defined tag non-string value not matched",
 			inst: makeInstance(func(i *core.Instance) {
-				i.DefinedTags = map[string]map[string]interface{}{
+				i.DefinedTags = map[string]map[string]any{
 					"ops-ns": {"monitoring": 42},
 				}
 			}),
@@ -199,7 +201,7 @@ func TestHasTag(t *testing.T) {
 		{
 			name: "defined tag found in second namespace",
 			inst: makeInstance(func(i *core.Instance) {
-				i.DefinedTags = map[string]map[string]interface{}{
+				i.DefinedTags = map[string]map[string]any{
 					"ns1": {"other": "x"},
 					"ns2": {"monitoring": "enabled"},
 				}
@@ -210,7 +212,7 @@ func TestHasTag(t *testing.T) {
 			name: "freeform matches even when defined tag disagrees",
 			inst: makeInstance(func(i *core.Instance) {
 				i.FreeformTags = map[string]string{"monitoring": "enabled"}
-				i.DefinedTags = map[string]map[string]interface{}{
+				i.DefinedTags = map[string]map[string]any{
 					"ns": {"monitoring": "disabled"},
 				}
 			}),
@@ -288,7 +290,7 @@ func TestInstanceLabels_FreeformTagsSanitized(t *testing.T) {
 
 func TestInstanceLabels_DefinedTagsStringOnly(t *testing.T) {
 	inst := makeInstance(func(i *core.Instance) {
-		i.DefinedTags = map[string]map[string]interface{}{
+		i.DefinedTags = map[string]map[string]any{
 			"Oracle-Tags": {
 				"CreatedBy":  "user@example.com",
 				"CostCenter": "42",
@@ -313,7 +315,7 @@ func TestInstanceLabels_NilOptionalFields(t *testing.T) {
 	inst := core.Instance{
 		LifecycleState: core.InstanceLifecycleStateRunning,
 		FreeformTags:   map[string]string{},
-		DefinedTags:    map[string]map[string]interface{}{},
+		DefinedTags:    map[string]map[string]any{},
 	}
 	labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", 80)
 
@@ -326,7 +328,8 @@ func TestInstanceLabels_PortInAddress(t *testing.T) {
 	inst := makeInstance()
 	for _, port := range []int{80, 9100, 9182, 443} {
 		labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", port)
-		require.Equal(t,
+		require.Equal(
+			t,
 			model.LabelValue("10.0.0.1:"+strconv.Itoa(port)),
 			labels[model.AddressLabel],
 			"port %d", port,
@@ -596,7 +599,7 @@ func TestRefresh_NoTagFilter_AllInstancesReturned(t *testing.T) {
 func TestRefresh_DefinedTagFilterInclude(t *testing.T) {
 	tagged := makeInstance(func(i *core.Instance) {
 		i.Id = strPtr("ocid1.instance.oc1..tagged")
-		i.DefinedTags = map[string]map[string]interface{}{
+		i.DefinedTags = map[string]map[string]any{
 			"ops-ns": {"monitoring": "enabled"},
 		}
 	})
@@ -839,5 +842,5 @@ func TestSDConfig_SetDirectory_AbsolutePathUnchanged(t *testing.T) {
 func TestSDConfig_SetDirectory_EmptyKeyFile(t *testing.T) {
 	cfg := SDConfig{}
 	cfg.SetDirectory("/etc/prometheus")
-	require.Equal(t, "", cfg.KeyFile)
+	require.Empty(t, cfg.KeyFile)
 }

--- a/discovery/oci/oci_test.go
+++ b/discovery/oci/oci_test.go
@@ -19,8 +19,10 @@ import (
 	"log/slog"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
@@ -111,35 +113,6 @@ func singleInstanceDiscovery(inst core.Instance, vnic *core.Vnic) *Discovery {
 		return vnic, nil
 	}
 	return d
-}
-
-// ---- sanitizeLabelName ------------------------------------------------------
-
-func TestSanitizeLabelName(t *testing.T) {
-	cases := []struct {
-		input string
-		want  string
-	}{
-		{"monitoring", "monitoring"},
-		{"Monitoring", "monitoring"},
-		{"my-tag", "my_tag"},
-		{"my.tag.key", "my_tag_key"},
-		{"My-Tag.Key", "my_tag_key"},
-		{"tag with spaces", "tag_with_spaces"},
-		{"tag123", "tag123"},
-		{"123numeric", "123numeric"},
-		{"", ""},
-		{"CamelCase", "camelcase"},
-		{"mixed-UPPER_lower.dot", "mixed_upper_lower_dot"},
-		{"Oracle-Tags", "oracle_tags"},
-		{"__reserved__", "__reserved__"},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
-			require.Equal(t, tc.want, sanitizeLabelName(tc.input))
-		})
-	}
 }
 
 // ---- hasTag -----------------------------------------------------------------
@@ -274,18 +247,24 @@ func TestInstanceLabels_AddressFallsBackToPublicIP(t *testing.T) {
 }
 
 func TestInstanceLabels_FreeformTagsSanitized(t *testing.T) {
+	// Sanitization replaces invalid characters with underscores but preserves
+	// case so that case-sensitive OCI tag keys do not collide (e.g. Env vs env).
 	inst := makeInstance(func(i *core.Instance) {
 		i.FreeformTags = map[string]string{
 			"environment": "production",
 			"My-Tag.Key":  "value",
 			"123numeric":  "v",
+			"Env":         "upper",
+			"env":         "lower",
 		}
 	})
 	labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", 80)
 
 	require.Equal(t, model.LabelValue("production"), labels[ociLabelFreeformTagPrefix+"environment"])
-	require.Equal(t, model.LabelValue("value"), labels[ociLabelFreeformTagPrefix+"my_tag_key"])
+	require.Equal(t, model.LabelValue("value"), labels[ociLabelFreeformTagPrefix+"My_Tag_Key"])
 	require.Equal(t, model.LabelValue("v"), labels[ociLabelFreeformTagPrefix+"123numeric"])
+	require.Equal(t, model.LabelValue("upper"), labels[ociLabelFreeformTagPrefix+"Env"])
+	require.Equal(t, model.LabelValue("lower"), labels[ociLabelFreeformTagPrefix+"env"])
 }
 
 func TestInstanceLabels_DefinedTagsStringOnly(t *testing.T) {
@@ -301,13 +280,13 @@ func TestInstanceLabels_DefinedTagsStringOnly(t *testing.T) {
 	})
 	labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", 80)
 
-	require.Equal(t, model.LabelValue("user@example.com"), labels[ociLabelDefinedTagPrefix+"oracle_tags_createdby"])
-	require.Equal(t, model.LabelValue("42"), labels[ociLabelDefinedTagPrefix+"oracle_tags_costcenter"])
+	require.Equal(t, model.LabelValue("user@example.com"), labels[ociLabelDefinedTagPrefix+"Oracle_Tags_CreatedBy"])
+	require.Equal(t, model.LabelValue("42"), labels[ociLabelDefinedTagPrefix+"Oracle_Tags_CostCenter"])
 
-	_, hasInt := labels[ociLabelDefinedTagPrefix+"oracle_tags_intvalue"]
+	_, hasInt := labels[ociLabelDefinedTagPrefix+"Oracle_Tags_IntValue"]
 	require.False(t, hasInt, "integer defined tag must not be emitted")
 
-	_, hasBool := labels[ociLabelDefinedTagPrefix+"oracle_tags_boolvalue"]
+	_, hasBool := labels[ociLabelDefinedTagPrefix+"Oracle_Tags_BoolValue"]
 	require.False(t, hasBool, "boolean defined tag must not be emitted")
 }
 
@@ -417,8 +396,10 @@ func TestRefresh_CompartmentListError_Propagates(t *testing.T) {
 	require.ErrorIs(t, err, sentinel)
 }
 
-func TestRefresh_ListInstancesError_CompartmentSkipped(t *testing.T) {
-	// listInstances error → compartment is logged and skipped, no target group returned.
+func TestRefresh_ListInstancesError_EmptyGroupReturned(t *testing.T) {
+	// listInstances error → compartment is logged and an empty group is
+	// returned so the discovery manager prunes any stale targets it still
+	// has for this source.
 	sentinel := errors.New("OCI API unavailable")
 	d := baseDiscovery()
 	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
@@ -427,7 +408,9 @@ func TestRefresh_ListInstancesError_CompartmentSkipped(t *testing.T) {
 
 	tgs, err := d.refresh(context.Background())
 	require.NoError(t, err)
-	require.Empty(t, tgs, "failed compartment should be skipped, not returned")
+	require.Len(t, tgs, 1, "failed compartment must still return an (empty) group")
+	require.Equal(t, "OCI_"+testCompartment, tgs[0].Source)
+	require.Empty(t, tgs[0].Targets)
 }
 
 func TestRefresh_EmptyCompartment(t *testing.T) {
@@ -628,7 +611,9 @@ func TestRefresh_DefinedTagFilterInclude(t *testing.T) {
 	require.Equal(t, model.LabelValue("ocid1.instance.oc1..tagged"), tgs[0].Targets[0][ociLabelInstanceID])
 }
 
-func TestRefresh_NoPrimaryVnic_EmptyIPs(t *testing.T) {
+func TestRefresh_NoPrimaryVnic_InstanceDropped(t *testing.T) {
+	// An instance with no resolvable primary VNIC has no usable IP, so the
+	// SD drops it rather than emit an unscrapeable :port target.
 	inst := makeInstance()
 	nonPrimary := &core.Vnic{
 		Id:        strPtr("ocid1.vnic.oc1..v001"),
@@ -648,8 +633,32 @@ func TestRefresh_NoPrimaryVnic_EmptyIPs(t *testing.T) {
 
 	tgs, err := d.refresh(context.Background())
 	require.NoError(t, err)
-	require.Len(t, tgs[0].Targets, 1)
-	require.Equal(t, model.LabelValue(""), tgs[0].Targets[0][ociLabelPrivateIP])
+	require.Len(t, tgs, 1)
+	require.Empty(t, tgs[0].Targets, "instance with no usable IP must be dropped")
+}
+
+func TestRefresh_InstanceWithNilIDDropped(t *testing.T) {
+	// Defensive: an instance with a nil OCID would panic on dereference;
+	// it must be skipped with a warning.
+	inst := makeInstance(func(i *core.Instance) {
+		i.Id = nil
+	})
+
+	vnicCalls := 0
+	d := baseDiscovery()
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return []core.Instance{inst}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
+		vnicCalls++
+		return nil, nil
+	}
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Empty(t, tgs[0].Targets)
+	require.Zero(t, vnicCalls, "instance with nil Id must not reach VNIC lookup")
 }
 
 func TestRefresh_ContextCanceled(t *testing.T) {
@@ -669,14 +678,15 @@ func TestRefresh_ContextCanceled(t *testing.T) {
 
 func TestSDConfig_Validation(t *testing.T) {
 	validAPIKey := SDConfig{
-		Auth:            authAPIKey,
-		Region:          "us-ashburn-1",
-		Tenancy:         "ocid1.tenancy.oc1..t001",
-		User:            "ocid1.user.oc1..u001",
-		Fingerprint:     "aa:bb:cc",
-		KeyFile:         "/etc/oci/key.pem",
-		TagFilterAction: tagFilterActionInclude,
-		RateLimitRPS:    10,
+		Auth:             authAPIKey,
+		Region:           "us-ashburn-1",
+		Tenancy:          "ocid1.tenancy.oc1..t001",
+		User:             "ocid1.user.oc1..u001",
+		Fingerprint:      "aa:bb:cc",
+		KeyFile:          "/etc/oci/key.pem",
+		TagFilterAction:  tagFilterActionInclude,
+		RefreshInterval:  model.Duration(60 * time.Second),
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 
 	cases := []struct {
@@ -747,14 +757,14 @@ func TestSDConfig_Validation(t *testing.T) {
 			wantErr: "tag_filter_action must be",
 		},
 		{
-			name:    "rate_limit_rps zero",
-			mutate:  func(c *SDConfig) { c.RateLimitRPS = 0 },
-			wantErr: "rate_limit_rps must be positive",
+			name:    "refresh_interval zero",
+			mutate:  func(c *SDConfig) { c.RefreshInterval = 0 },
+			wantErr: "refresh_interval must be positive",
 		},
 		{
-			name:    "rate_limit_rps negative",
-			mutate:  func(c *SDConfig) { c.RateLimitRPS = -1 },
-			wantErr: "rate_limit_rps must be positive",
+			name:    "refresh_interval negative",
+			mutate:  func(c *SDConfig) { c.RefreshInterval = model.Duration(-1 * time.Second) },
+			wantErr: "refresh_interval must be positive",
 		},
 	}
 
@@ -771,25 +781,27 @@ func TestSDConfig_Validation(t *testing.T) {
 
 func TestSDConfig_ValidInstancePrincipal(t *testing.T) {
 	cfg := SDConfig{
-		Auth:            authInstancePrincipal,
-		Region:          "us-ashburn-1",
-		RateLimitRPS:    10,
-		TagFilterAction: tagFilterActionInclude,
+		Auth:             authInstancePrincipal,
+		Region:           "us-ashburn-1",
+		TagFilterAction:  tagFilterActionInclude,
+		RefreshInterval:  model.Duration(60 * time.Second),
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
 }
 
 func TestSDConfig_ValidWithExplicitCompartments(t *testing.T) {
 	cfg := SDConfig{
-		Auth:            authAPIKey,
-		Region:          "us-ashburn-1",
-		Tenancy:         "ocid1.tenancy.oc1..t001",
-		User:            "ocid1.user.oc1..u001",
-		Fingerprint:     "aa:bb:cc",
-		KeyFile:         "/etc/oci/key.pem",
-		Compartments:    []string{"ocid1.compartment.oc1..c001", "ocid1.compartment.oc1..c002"},
-		TagFilterAction: tagFilterActionInclude,
-		RateLimitRPS:    10,
+		Auth:             authAPIKey,
+		Region:           "us-ashburn-1",
+		Tenancy:          "ocid1.tenancy.oc1..t001",
+		User:             "ocid1.user.oc1..u001",
+		Fingerprint:      "aa:bb:cc",
+		KeyFile:          "/etc/oci/key.pem",
+		Compartments:     []string{"ocid1.compartment.oc1..c001", "ocid1.compartment.oc1..c002"},
+		TagFilterAction:  tagFilterActionInclude,
+		RefreshInterval:  model.Duration(60 * time.Second),
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
 }
@@ -797,30 +809,32 @@ func TestSDConfig_ValidWithExplicitCompartments(t *testing.T) {
 func TestSDConfig_ValidAutoDiscovery(t *testing.T) {
 	// Compartments empty → auto-discover. Should be valid.
 	cfg := SDConfig{
-		Auth:            authAPIKey,
-		Region:          "us-ashburn-1",
-		Tenancy:         "ocid1.tenancy.oc1..t001",
-		User:            "ocid1.user.oc1..u001",
-		Fingerprint:     "aa:bb:cc",
-		KeyFile:         "/etc/oci/key.pem",
-		TagFilterAction: tagFilterActionInclude,
-		RateLimitRPS:    10,
+		Auth:             authAPIKey,
+		Region:           "us-ashburn-1",
+		Tenancy:          "ocid1.tenancy.oc1..t001",
+		User:             "ocid1.user.oc1..u001",
+		Fingerprint:      "aa:bb:cc",
+		KeyFile:          "/etc/oci/key.pem",
+		TagFilterAction:  tagFilterActionInclude,
+		RefreshInterval:  model.Duration(60 * time.Second),
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
 }
 
 func TestSDConfig_ValidExcludeFilter(t *testing.T) {
 	cfg := SDConfig{
-		Auth:            authAPIKey,
-		Region:          "us-ashburn-1",
-		Tenancy:         "ocid1.tenancy.oc1..t001",
-		User:            "ocid1.user.oc1..u001",
-		Fingerprint:     "aa:bb:cc",
-		KeyFile:         "/etc/oci/key.pem",
-		TagFilterKey:    "monitoring",
-		TagFilterValue:  "disabled",
-		TagFilterAction: tagFilterActionExclude,
-		RateLimitRPS:    10,
+		Auth:             authAPIKey,
+		Region:           "us-ashburn-1",
+		Tenancy:          "ocid1.tenancy.oc1..t001",
+		User:             "ocid1.user.oc1..u001",
+		Fingerprint:      "aa:bb:cc",
+		KeyFile:          "/etc/oci/key.pem",
+		TagFilterKey:     "monitoring",
+		TagFilterValue:   "disabled",
+		TagFilterAction:  tagFilterActionExclude,
+		RefreshInterval:  model.Duration(60 * time.Second),
+		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
 }

--- a/discovery/oci/oci_test.go
+++ b/discovery/oci/oci_test.go
@@ -87,8 +87,7 @@ func makeAttachment(instanceID, vnicID string) core.VnicAttachment {
 // primaryOnly is a convenience for tests that only care about the primary VNIC.
 func primaryOnly(id, privateIP, publicIP string) instanceVnics {
 	return instanceVnics{
-		primary:    vnicInfo{id: id, privateIP: privateIP, publicIP: publicIP},
-		hasPrimary: true,
+		primary: vnicInfo{id: id, privateIP: privateIP, publicIP: publicIP},
 	}
 }
 
@@ -167,53 +166,6 @@ func TestInstanceLabels_AddressFallsBackToPublicIP(t *testing.T) {
 	inst := makeInstance()
 	labels := instanceLabels(&inst, primaryOnly("v", "", "203.0.113.1"), "tenancy", 80)
 	require.Equal(t, model.LabelValue("203.0.113.1:80"), labels[model.AddressLabel])
-}
-
-func TestInstanceLabels_SecondaryVnicIPsExposed(t *testing.T) {
-	inst := makeInstance()
-	vnics := instanceVnics{
-		primary:    vnicInfo{id: "ocid1.vnic.oc1..p", privateIP: "10.0.0.1", publicIP: ""},
-		hasPrimary: true,
-		secondary: []vnicInfo{
-			{id: "ocid1.vnic.oc1..s1", privateIP: "10.0.0.2", publicIP: "203.0.113.2"},
-			{id: "ocid1.vnic.oc1..s2", privateIP: "10.0.0.3"},
-		},
-	}
-	labels := instanceLabels(&inst, vnics, "tenancy", 80)
-
-	require.Equal(t, model.LabelValue(",10.0.0.2,10.0.0.3,"), labels[ociLabelSecondaryPrivateIPs])
-	require.Equal(t, model.LabelValue(",203.0.113.2,"), labels[ociLabelSecondaryPublicIPs])
-}
-
-func TestInstanceLabels_SecondaryVnicIPsSortedDeterministically(t *testing.T) {
-	// OCI does not guarantee a stable attachment order between calls. The
-	// joined label value must be sorted so secondary IPs do not churn
-	// between refreshes when ListVnicAttachments returns the same IPs in a
-	// different order.
-	inst := makeInstance()
-	vnics := instanceVnics{
-		primary:    vnicInfo{id: "ocid1.vnic.oc1..p", privateIP: "10.0.0.1"},
-		hasPrimary: true,
-		secondary: []vnicInfo{
-			{id: "s3", privateIP: "10.0.0.30", publicIP: "203.0.113.30"},
-			{id: "s1", privateIP: "10.0.0.10", publicIP: "203.0.113.10"},
-			{id: "s2", privateIP: "10.0.0.20"},
-		},
-	}
-	labels := instanceLabels(&inst, vnics, "tenancy", 80)
-
-	require.Equal(t, model.LabelValue(",10.0.0.10,10.0.0.20,10.0.0.30,"), labels[ociLabelSecondaryPrivateIPs])
-	require.Equal(t, model.LabelValue(",203.0.113.10,203.0.113.30,"), labels[ociLabelSecondaryPublicIPs])
-}
-
-func TestInstanceLabels_NoSecondaryVnicLabelsWhenAbsent(t *testing.T) {
-	inst := makeInstance()
-	labels := instanceLabels(&inst, primaryOnly("v", "10.0.0.1", ""), "tenancy", 80)
-
-	_, hasPrivates := labels[ociLabelSecondaryPrivateIPs]
-	require.False(t, hasPrivates, "secondary private IPs label must not be set when there are no secondaries")
-	_, hasPublics := labels[ociLabelSecondaryPublicIPs]
-	require.False(t, hasPublics, "secondary public IPs label must not be set when there are no secondaries")
 }
 
 func TestInstanceLabels_FreeformTagsSanitized(t *testing.T) {
@@ -349,12 +301,17 @@ func TestRefresh_SingleInstance(t *testing.T) {
 	require.Equal(t, model.LabelValue(testTenancy), labels[ociLabelTenancyID])
 }
 
-func TestRefresh_SecondaryVnicsExposedAsListLabels(t *testing.T) {
+func TestRefresh_ResolvesPrimaryVnicAndStops(t *testing.T) {
+	// Only the primary VNIC is resolved: once it is found the walk stops so a
+	// multi-VNIC instance does not fan out a GetVnic call per attachment. The
+	// primary supplies the address and the VNIC labels; the secondary is never
+	// fetched.
 	inst := makeInstance()
 	primary := &core.Vnic{
 		Id:        strPtr("ocid1.vnic.oc1..p"),
 		IsPrimary: boolPtr(true),
 		PrivateIp: strPtr("10.0.0.1"),
+		PublicIp:  strPtr("203.0.113.1"),
 	}
 	secondary := &core.Vnic{
 		Id:        strPtr("ocid1.vnic.oc1..s"),
@@ -363,6 +320,7 @@ func TestRefresh_SecondaryVnicsExposedAsListLabels(t *testing.T) {
 		PublicIp:  strPtr("203.0.113.2"),
 	}
 
+	getVnicCalls := 0
 	d := baseDiscovery()
 	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
 		return []core.Instance{inst}, nil
@@ -374,6 +332,7 @@ func TestRefresh_SecondaryVnicsExposedAsListLabels(t *testing.T) {
 		}, nil
 	}
 	d.getVnic = func(_ context.Context, vnicID string) (*core.Vnic, error) {
+		getVnicCalls++
 		switch vnicID {
 		case stringVal(primary.Id):
 			return primary, nil
@@ -389,9 +348,11 @@ func TestRefresh_SecondaryVnicsExposedAsListLabels(t *testing.T) {
 	require.Len(t, tgs[0].Targets, 1)
 
 	labels := tgs[0].Targets[0]
+	require.Equal(t, model.LabelValue("10.0.0.1:9100"), labels[model.AddressLabel])
 	require.Equal(t, model.LabelValue("ocid1.vnic.oc1..p"), labels[ociLabelVnicID])
-	require.Equal(t, model.LabelValue(",10.0.0.2,"), labels[ociLabelSecondaryPrivateIPs])
-	require.Equal(t, model.LabelValue(",203.0.113.2,"), labels[ociLabelSecondaryPublicIPs])
+	require.Equal(t, model.LabelValue("10.0.0.1"), labels[ociLabelPrivateIP])
+	require.Equal(t, model.LabelValue("203.0.113.1"), labels[ociLabelPublicIP])
+	require.Equal(t, 1, getVnicCalls, "must stop after resolving the primary VNIC")
 }
 
 func TestRefresh_MultipleCompartments(t *testing.T) {
@@ -748,7 +709,7 @@ func TestSDConfig_Validation(t *testing.T) {
 		{
 			name:    "missing region",
 			mutate:  func(c *SDConfig) { c.Region = "" },
-			wantErr: "requires a region",
+			wantErr: "region is required",
 		},
 		{
 			name:    "api_key missing tenancy",

--- a/discovery/oci/oci_test.go
+++ b/discovery/oci/oci_test.go
@@ -17,16 +17,23 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/oracle/oci-go-sdk/v65/identity"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 )
+
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}
 
 // ---- test helpers -----------------------------------------------------------
 
@@ -77,6 +84,14 @@ func makeAttachment(instanceID, vnicID string) core.VnicAttachment {
 	}
 }
 
+// primaryOnly is a convenience for tests that only care about the primary VNIC.
+func primaryOnly(id, privateIP, publicIP string) instanceVnics {
+	return instanceVnics{
+		primary:    vnicInfo{id: id, privateIP: privateIP, publicIP: publicIP},
+		hasPrimary: true,
+	}
+}
+
 const (
 	testCompartment = "ocid1.compartment.oc1..comp001"
 	testTenancy     = "ocid1.tenancy.oc1..test001"
@@ -87,10 +102,9 @@ const (
 // d.Discovery (the refresh framework) is left nil.
 func baseDiscovery() *Discovery {
 	return &Discovery{
-		tenancy:         testTenancy,
-		tagFilterAction: tagFilterActionInclude,
-		port:            9100,
-		logger:          slog.Default(),
+		tenancy: testTenancy,
+		port:    9100,
+		logger:  slog.Default(),
 		listCompartments: func(_ context.Context) ([]string, error) {
 			return []string{testCompartment}, nil
 		},
@@ -116,104 +130,11 @@ func singleInstanceDiscovery(inst core.Instance, vnic *core.Vnic) *Discovery {
 	return d
 }
 
-// ---- hasTag -----------------------------------------------------------------
-
-func TestHasTag(t *testing.T) {
-	cases := []struct {
-		name  string
-		inst  core.Instance
-		key   string
-		value string
-		want  bool
-	}{
-		{
-			name: "freeform match",
-			inst: makeInstance(func(i *core.Instance) {
-				i.FreeformTags = map[string]string{"monitoring": "enabled"}
-			}),
-			key: "monitoring", value: "enabled", want: true,
-		},
-		{
-			name: "freeform value mismatch",
-			inst: makeInstance(func(i *core.Instance) {
-				i.FreeformTags = map[string]string{"monitoring": "disabled"}
-			}),
-			key: "monitoring", value: "enabled", want: false,
-		},
-		{
-			name: "freeform key absent",
-			inst: makeInstance(),
-			key:  "monitoring", value: "enabled", want: false,
-		},
-		{
-			name: "defined tag match",
-			inst: makeInstance(func(i *core.Instance) {
-				i.DefinedTags = map[string]map[string]any{
-					"ops-ns": {"monitoring": "enabled"},
-				}
-			}),
-			key: "monitoring", value: "enabled", want: true,
-		},
-		{
-			name: "defined tag value mismatch",
-			inst: makeInstance(func(i *core.Instance) {
-				i.DefinedTags = map[string]map[string]any{
-					"ops-ns": {"monitoring": "disabled"},
-				}
-			}),
-			key: "monitoring", value: "enabled", want: false,
-		},
-		{
-			name: "defined tag non-string value not matched",
-			inst: makeInstance(func(i *core.Instance) {
-				i.DefinedTags = map[string]map[string]any{
-					"ops-ns": {"monitoring": 42},
-				}
-			}),
-			key: "monitoring", value: "42", want: false,
-		},
-		{
-			name: "defined tag found in second namespace",
-			inst: makeInstance(func(i *core.Instance) {
-				i.DefinedTags = map[string]map[string]any{
-					"ns1": {"other": "x"},
-					"ns2": {"monitoring": "enabled"},
-				}
-			}),
-			key: "monitoring", value: "enabled", want: true,
-		},
-		{
-			name: "freeform matches even when defined tag disagrees",
-			inst: makeInstance(func(i *core.Instance) {
-				i.FreeformTags = map[string]string{"monitoring": "enabled"}
-				i.DefinedTags = map[string]map[string]any{
-					"ns": {"monitoring": "disabled"},
-				}
-			}),
-			key: "monitoring", value: "enabled", want: true,
-		},
-		{
-			name: "nil freeform and nil defined - no panic",
-			inst: makeInstance(func(i *core.Instance) {
-				i.FreeformTags = nil
-				i.DefinedTags = nil
-			}),
-			key: "monitoring", value: "enabled", want: false,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, hasTag(&tc.inst, tc.key, tc.value))
-		})
-	}
-}
-
 // ---- instanceLabels ---------------------------------------------------------
 
 func TestInstanceLabels_CoreLabels(t *testing.T) {
 	inst := makeInstance()
-	labels := instanceLabels(&inst, "10.0.0.5", "203.0.113.1", testTenancy, 9100)
+	labels := instanceLabels(&inst, primaryOnly("ocid1.vnic.oc1..v001", "10.0.0.5", "203.0.113.1"), testTenancy, 9100)
 
 	expected := model.LabelSet{
 		model.AddressLabel:         "10.0.0.5:9100",
@@ -227,6 +148,7 @@ func TestInstanceLabels_CoreLabels(t *testing.T) {
 		ociLabelTenancyID:          testTenancy,
 		ociLabelCompartmentID:      "ocid1.compartment.oc1..comp001",
 		ociLabelImageID:            "ocid1.image.oc1.iad.img001",
+		ociLabelVnicID:             "ocid1.vnic.oc1..v001",
 		ociLabelPrivateIP:          "10.0.0.5",
 		ociLabelPublicIP:           "203.0.113.1",
 	}
@@ -237,14 +159,40 @@ func TestInstanceLabels_CoreLabels(t *testing.T) {
 
 func TestInstanceLabels_AddressIsPrivateIPWhenBothPresent(t *testing.T) {
 	inst := makeInstance()
-	labels := instanceLabels(&inst, "10.0.0.5", "203.0.113.1", "tenancy", 80)
+	labels := instanceLabels(&inst, primaryOnly("v", "10.0.0.5", "203.0.113.1"), "tenancy", 80)
 	require.Equal(t, model.LabelValue("10.0.0.5:80"), labels[model.AddressLabel])
 }
 
 func TestInstanceLabels_AddressFallsBackToPublicIP(t *testing.T) {
 	inst := makeInstance()
-	labels := instanceLabels(&inst, "", "203.0.113.1", "tenancy", 80)
+	labels := instanceLabels(&inst, primaryOnly("v", "", "203.0.113.1"), "tenancy", 80)
 	require.Equal(t, model.LabelValue("203.0.113.1:80"), labels[model.AddressLabel])
+}
+
+func TestInstanceLabels_SecondaryVnicIPsExposed(t *testing.T) {
+	inst := makeInstance()
+	vnics := instanceVnics{
+		primary:    vnicInfo{id: "ocid1.vnic.oc1..p", privateIP: "10.0.0.1", publicIP: ""},
+		hasPrimary: true,
+		secondary: []vnicInfo{
+			{id: "ocid1.vnic.oc1..s1", privateIP: "10.0.0.2", publicIP: "203.0.113.2"},
+			{id: "ocid1.vnic.oc1..s2", privateIP: "10.0.0.3"},
+		},
+	}
+	labels := instanceLabels(&inst, vnics, "tenancy", 80)
+
+	require.Equal(t, model.LabelValue(",10.0.0.2,10.0.0.3,"), labels[ociLabelSecondaryPrivateIPs])
+	require.Equal(t, model.LabelValue(",203.0.113.2,"), labels[ociLabelSecondaryPublicIPs])
+}
+
+func TestInstanceLabels_NoSecondaryVnicLabelsWhenAbsent(t *testing.T) {
+	inst := makeInstance()
+	labels := instanceLabels(&inst, primaryOnly("v", "10.0.0.1", ""), "tenancy", 80)
+
+	_, hasPrivates := labels[ociLabelSecondaryPrivateIPs]
+	require.False(t, hasPrivates, "secondary private IPs label must not be set when there are no secondaries")
+	_, hasPublics := labels[ociLabelSecondaryPublicIPs]
+	require.False(t, hasPublics, "secondary public IPs label must not be set when there are no secondaries")
 }
 
 func TestInstanceLabels_FreeformTagsSanitized(t *testing.T) {
@@ -259,7 +207,7 @@ func TestInstanceLabels_FreeformTagsSanitized(t *testing.T) {
 			"env":         "lower",
 		}
 	})
-	labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", 80)
+	labels := instanceLabels(&inst, primaryOnly("v", "10.0.0.1", ""), "tenancy", 80)
 
 	require.Equal(t, model.LabelValue("production"), labels[ociLabelFreeformTagPrefix+"environment"])
 	require.Equal(t, model.LabelValue("value"), labels[ociLabelFreeformTagPrefix+"My_Tag_Key"])
@@ -274,12 +222,12 @@ func TestInstanceLabels_DefinedTagsStringOnly(t *testing.T) {
 			"Oracle-Tags": {
 				"CreatedBy":  "user@example.com",
 				"CostCenter": "42",
-				"IntValue":   100,  // must be skipped
-				"BoolValue":  true, // must be skipped
+				"IntValue":   100,  // Must be skipped.
+				"BoolValue":  true, // Must be skipped.
 			},
 		}
 	})
-	labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", 80)
+	labels := instanceLabels(&inst, primaryOnly("v", "10.0.0.1", ""), "tenancy", 80)
 
 	require.Equal(t, model.LabelValue("user@example.com"), labels[ociLabelDefinedTagPrefix+"Oracle_Tags_CreatedBy"])
 	require.Equal(t, model.LabelValue("42"), labels[ociLabelDefinedTagPrefix+"Oracle_Tags_CostCenter"])
@@ -297,7 +245,7 @@ func TestInstanceLabels_NilOptionalFields(t *testing.T) {
 		FreeformTags:   map[string]string{},
 		DefinedTags:    map[string]map[string]any{},
 	}
-	labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", 80)
+	labels := instanceLabels(&inst, primaryOnly("", "10.0.0.1", ""), "tenancy", 80)
 
 	require.Equal(t, model.LabelValue("10.0.0.1:80"), labels[model.AddressLabel])
 	require.Equal(t, model.LabelValue(""), labels[ociLabelInstanceID])
@@ -307,7 +255,7 @@ func TestInstanceLabels_NilOptionalFields(t *testing.T) {
 func TestInstanceLabels_PortInAddress(t *testing.T) {
 	inst := makeInstance()
 	for _, port := range []int{80, 9100, 9182, 443} {
-		labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", port)
+		labels := instanceLabels(&inst, primaryOnly("v", "10.0.0.1", ""), "tenancy", port)
 		require.Equal(
 			t,
 			model.LabelValue("10.0.0.1:"+strconv.Itoa(port)),
@@ -333,9 +281,55 @@ func TestRefresh_SingleInstance(t *testing.T) {
 	labels := tgs[0].Targets[0]
 	require.Equal(t, model.LabelValue("10.0.0.5:9100"), labels[model.AddressLabel])
 	require.Equal(t, model.LabelValue("ocid1.instance.oc1.iad.aaa001"), labels[ociLabelInstanceID])
+	require.Equal(t, model.LabelValue("ocid1.vnic.oc1..v001"), labels[ociLabelVnicID])
 	require.Equal(t, model.LabelValue("10.0.0.5"), labels[ociLabelPrivateIP])
 	require.Equal(t, model.LabelValue("203.0.113.10"), labels[ociLabelPublicIP])
 	require.Equal(t, model.LabelValue(testTenancy), labels[ociLabelTenancyID])
+}
+
+func TestRefresh_SecondaryVnicsExposedAsListLabels(t *testing.T) {
+	inst := makeInstance()
+	primary := &core.Vnic{
+		Id:        strPtr("ocid1.vnic.oc1..p"),
+		IsPrimary: boolPtr(true),
+		PrivateIp: strPtr("10.0.0.1"),
+	}
+	secondary := &core.Vnic{
+		Id:        strPtr("ocid1.vnic.oc1..s"),
+		IsPrimary: boolPtr(false),
+		PrivateIp: strPtr("10.0.0.2"),
+		PublicIp:  strPtr("203.0.113.2"),
+	}
+
+	d := baseDiscovery()
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return []core.Instance{inst}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{
+			makeAttachment(stringVal(inst.Id), stringVal(primary.Id)),
+			makeAttachment(stringVal(inst.Id), stringVal(secondary.Id)),
+		}, nil
+	}
+	d.getVnic = func(_ context.Context, vnicID string) (*core.Vnic, error) {
+		switch vnicID {
+		case stringVal(primary.Id):
+			return primary, nil
+		case stringVal(secondary.Id):
+			return secondary, nil
+		}
+		return nil, errors.New("unexpected VNIC ID")
+	}
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Len(t, tgs[0].Targets, 1)
+
+	labels := tgs[0].Targets[0]
+	require.Equal(t, model.LabelValue("ocid1.vnic.oc1..p"), labels[ociLabelVnicID])
+	require.Equal(t, model.LabelValue(",10.0.0.2,"), labels[ociLabelSecondaryPrivateIPs])
+	require.Equal(t, model.LabelValue(",203.0.113.2,"), labels[ociLabelSecondaryPublicIPs])
 }
 
 func TestRefresh_MultipleCompartments(t *testing.T) {
@@ -398,7 +392,7 @@ func TestRefresh_CompartmentListError_Propagates(t *testing.T) {
 }
 
 func TestRefresh_ListInstancesError_EmptyGroupReturned(t *testing.T) {
-	// listInstances error → compartment is logged and an empty group is
+	// listInstances error -> compartment is logged and an empty group is
 	// returned so the discovery manager prunes any stale targets it still
 	// has for this source.
 	sentinel := errors.New("OCI API unavailable")
@@ -464,154 +458,6 @@ func TestRefresh_GetVnicError_InstanceSkipped(t *testing.T) {
 	require.Empty(t, tgs[0].Targets)
 }
 
-func TestRefresh_TagFilterInclude_OnlyTaggedInstanceReturned(t *testing.T) {
-	tagged := makeInstance(func(i *core.Instance) {
-		i.Id = strPtr("ocid1.instance.oc1..tagged")
-		i.FreeformTags = map[string]string{"monitoring": "enabled"}
-	})
-	untagged := makeInstance(func(i *core.Instance) {
-		i.Id = strPtr("ocid1.instance.oc1..untagged")
-	})
-
-	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.1", "")
-	att := makeAttachment("ocid1.instance.oc1..tagged", stringVal(vnic.Id))
-
-	d := baseDiscovery()
-	d.tagFilterKey = "monitoring"
-	d.tagFilterValue = "enabled"
-	d.tagFilterAction = tagFilterActionInclude
-	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
-		return []core.Instance{tagged, untagged}, nil
-	}
-	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
-		return []core.VnicAttachment{att}, nil
-	}
-	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
-
-	tgs, err := d.refresh(context.Background())
-	require.NoError(t, err)
-	require.Len(t, tgs[0].Targets, 1)
-	require.Equal(t, model.LabelValue("ocid1.instance.oc1..tagged"), tgs[0].Targets[0][ociLabelInstanceID])
-}
-
-func TestRefresh_TagFilterExclude_TaggedInstanceDropped(t *testing.T) {
-	disabled := makeInstance(func(i *core.Instance) {
-		i.Id = strPtr("ocid1.instance.oc1..disabled")
-		i.FreeformTags = map[string]string{"monitoring": "disabled"}
-	})
-	active := makeInstance(func(i *core.Instance) {
-		i.Id = strPtr("ocid1.instance.oc1..active")
-	})
-
-	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.2", "")
-	att := makeAttachment("ocid1.instance.oc1..active", stringVal(vnic.Id))
-
-	d := baseDiscovery()
-	d.tagFilterKey = "monitoring"
-	d.tagFilterValue = "disabled"
-	d.tagFilterAction = tagFilterActionExclude
-	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
-		return []core.Instance{disabled, active}, nil
-	}
-	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
-		return []core.VnicAttachment{att}, nil
-	}
-	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
-
-	tgs, err := d.refresh(context.Background())
-	require.NoError(t, err)
-	require.Len(t, tgs[0].Targets, 1)
-	require.Equal(t, model.LabelValue("ocid1.instance.oc1..active"), tgs[0].Targets[0][ociLabelInstanceID])
-}
-
-func TestRefresh_TagFilter_VnicNotCalledForFilteredInstances(t *testing.T) {
-	inst1 := makeInstance(func(i *core.Instance) {
-		i.Id = strPtr("ocid1.instance.oc1..inst1")
-		i.FreeformTags = map[string]string{"monitoring": "disabled"}
-	})
-	inst2 := makeInstance(func(i *core.Instance) {
-		i.Id = strPtr("ocid1.instance.oc1..inst2")
-		i.FreeformTags = map[string]string{"monitoring": "disabled"}
-	})
-
-	vnicCalls := 0
-	d := baseDiscovery()
-	d.tagFilterKey = "monitoring"
-	d.tagFilterValue = "disabled"
-	d.tagFilterAction = tagFilterActionExclude
-	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
-		return []core.Instance{inst1, inst2}, nil
-	}
-	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
-		vnicCalls++
-		return nil, nil
-	}
-	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) {
-		vnicCalls++
-		return nil, nil
-	}
-
-	tgs, err := d.refresh(context.Background())
-	require.NoError(t, err)
-	require.Empty(t, tgs[0].Targets)
-	require.Zero(t, vnicCalls, "VNIC API must not be called for filtered-out instances")
-}
-
-func TestRefresh_NoTagFilter_AllInstancesReturned(t *testing.T) {
-	instances := []core.Instance{
-		makeInstance(func(i *core.Instance) { i.Id = strPtr("ocid1.instance.oc1..i1") }),
-		makeInstance(func(i *core.Instance) { i.Id = strPtr("ocid1.instance.oc1..i2") }),
-		makeInstance(func(i *core.Instance) { i.Id = strPtr("ocid1.instance.oc1..i3") }),
-	}
-	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.1", "")
-	att := makeAttachment("", stringVal(vnic.Id))
-
-	d := baseDiscovery()
-	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
-		return instances, nil
-	}
-	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
-		return []core.VnicAttachment{att}, nil
-	}
-	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
-
-	tgs, err := d.refresh(context.Background())
-	require.NoError(t, err)
-	require.Len(t, tgs[0].Targets, 3)
-}
-
-func TestRefresh_DefinedTagFilterInclude(t *testing.T) {
-	tagged := makeInstance(func(i *core.Instance) {
-		i.Id = strPtr("ocid1.instance.oc1..tagged")
-		i.DefinedTags = map[string]map[string]any{
-			"ops-ns": {"monitoring": "enabled"},
-		}
-	})
-	untagged := makeInstance(func(i *core.Instance) {
-		i.Id = strPtr("ocid1.instance.oc1..untagged")
-	})
-
-	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.5", "")
-	att := makeAttachment("ocid1.instance.oc1..tagged", stringVal(vnic.Id))
-
-	d := baseDiscovery()
-	d.tagFilterKey = "monitoring"
-	d.tagFilterValue = "enabled"
-	d.tagFilterAction = tagFilterActionInclude
-	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
-		return []core.Instance{tagged, untagged}, nil
-	}
-	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
-		return []core.VnicAttachment{att}, nil
-	}
-	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
-
-	tgs, err := d.refresh(context.Background())
-	require.NoError(t, err)
-	require.Len(t, tgs[0].Targets, 1)
-	require.Equal(t, model.LabelValue("ocid1.instance.oc1..tagged"), tgs[0].Targets[0][ociLabelInstanceID])
-}
-
 func TestRefresh_NoPrimaryVnic_InstanceDropped(t *testing.T) {
 	// An instance with no resolvable primary VNIC has no usable IP, so the
 	// SD drops it rather than emit an unscrapeable :port target.
@@ -675,6 +521,151 @@ func TestRefresh_ContextCanceled(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+// ---- listAllCompartments ----------------------------------------------------
+
+// fakeCompartmentTree drives listAllCompartments via a compartmentPaginator
+// stub. Each node has a list of pages, each page a list of (id, active,
+// hasNext) tuples. Setting failChildrenOf to a node ID makes paginate return
+// an error when that node is queried, simulating a permission gap.
+type fakeCompartmentTree struct {
+	// children maps parent compartment ID -> ordered direct children.
+	children map[string][]identity.Compartment
+	// pageSize bins children into pages of this size to exercise pagination.
+	pageSize int
+	// permissionDenied is the set of parent IDs whose list call should fail.
+	permissionDenied map[string]bool
+	// errOnce records first call so cancelled-context tests can observe it.
+	calls map[string]int
+}
+
+func (f *fakeCompartmentTree) paginate(ctx context.Context, parentID string, page *string) ([]identity.Compartment, *string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	if f.calls == nil {
+		f.calls = map[string]int{}
+	}
+	f.calls[parentID]++
+
+	if f.permissionDenied[parentID] {
+		return nil, nil, errors.New("permission denied")
+	}
+
+	all := f.children[parentID]
+	if f.pageSize <= 0 || f.pageSize >= len(all) {
+		return all, nil, nil
+	}
+
+	start := 0
+	if page != nil {
+		// Page tokens are 1-based indices into the slice.
+		idx, err := strconv.Atoi(*page)
+		if err != nil {
+			return nil, nil, err
+		}
+		start = idx
+	}
+	end := start + f.pageSize
+	if end >= len(all) {
+		return all[start:], nil, nil
+	}
+	next := strconv.Itoa(end)
+	return all[start:end], &next, nil
+}
+
+func activeComp(id string) identity.Compartment {
+	return identity.Compartment{Id: strPtr(id), LifecycleState: identity.CompartmentLifecycleStateActive}
+}
+
+func inactiveComp(id string) identity.Compartment {
+	return identity.Compartment{Id: strPtr(id), LifecycleState: identity.CompartmentLifecycleStateInactive}
+}
+
+func TestListAllCompartments_BFSIncludesRoot(t *testing.T) {
+	tree := &fakeCompartmentTree{
+		children: map[string][]identity.Compartment{
+			"root": {activeComp("c1"), activeComp("c2")},
+			"c1":   {activeComp("c1a")},
+		},
+	}
+
+	got, err := listAllCompartments(context.Background(), tree.paginate, "root", promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"root", "c1", "c2", "c1a"}, got)
+}
+
+func TestListAllCompartments_PagedResults(t *testing.T) {
+	tree := &fakeCompartmentTree{
+		children: map[string][]identity.Compartment{
+			"root": {activeComp("c1"), activeComp("c2"), activeComp("c3"), activeComp("c4"), activeComp("c5")},
+		},
+		pageSize: 2,
+	}
+
+	got, err := listAllCompartments(context.Background(), tree.paginate, "root", promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"root", "c1", "c2", "c3", "c4", "c5"}, got)
+	require.Equal(t, 3, tree.calls["root"], "5 children with page size 2 must take 3 calls")
+}
+
+func TestListAllCompartments_InactiveCompartmentSkipped(t *testing.T) {
+	tree := &fakeCompartmentTree{
+		children: map[string][]identity.Compartment{
+			"root": {activeComp("c1"), inactiveComp("c2-dead"), activeComp("c3")},
+		},
+	}
+
+	got, err := listAllCompartments(context.Background(), tree.paginate, "root", promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"root", "c1", "c3"}, got)
+}
+
+func TestListAllCompartments_CycleVisitedOnce(t *testing.T) {
+	// A child that references back to root must not cause an infinite loop.
+	tree := &fakeCompartmentTree{
+		children: map[string][]identity.Compartment{
+			"root": {activeComp("c1")},
+			"c1":   {activeComp("root")}, // Cycle.
+		},
+	}
+
+	got, err := listAllCompartments(context.Background(), tree.paginate, "root", promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"root", "c1"}, got)
+	require.Equal(t, 1, tree.calls["root"], "root must be listed only once even when referenced as a child")
+}
+
+func TestListAllCompartments_PermissionErrorSkipsSubtree(t *testing.T) {
+	tree := &fakeCompartmentTree{
+		children: map[string][]identity.Compartment{
+			"root": {activeComp("c1"), activeComp("c2")},
+			"c1":   {activeComp("c1a")},
+			// c2 denied; its subtree must not abort the walk.
+		},
+		permissionDenied: map[string]bool{"c2": true},
+	}
+
+	got, err := listAllCompartments(context.Background(), tree.paginate, "root", promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"root", "c1", "c2", "c1a"}, got)
+}
+
+func TestListAllCompartments_CanceledContextAborts(t *testing.T) {
+	// A cancelled context must abort the walk immediately rather than be
+	// silently treated as a permission gap.
+	tree := &fakeCompartmentTree{
+		children: map[string][]identity.Compartment{
+			"root": {activeComp("c1")},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := listAllCompartments(ctx, tree.paginate, "root", promslog.NewNopLogger())
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 // ---- SDConfig validation ----------------------------------------------------
 
 func TestSDConfig_Validation(t *testing.T) {
@@ -685,7 +676,6 @@ func TestSDConfig_Validation(t *testing.T) {
 		User:             "ocid1.user.oc1..u001",
 		Fingerprint:      "aa:bb:cc",
 		KeyFile:          "/etc/oci/key.pem",
-		TagFilterAction:  tagFilterActionInclude,
 		RefreshInterval:  model.Duration(60 * time.Second),
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
@@ -721,12 +711,32 @@ func TestSDConfig_Validation(t *testing.T) {
 			wantErr: "requires key_file",
 		},
 		{
+			name: "api_key with both key_passphrase and key_passphrase_file",
+			mutate: func(c *SDConfig) {
+				c.KeyPassphrase = "secret"
+				c.KeyPassphraseFile = "/etc/oci/passphrase"
+			},
+			wantErr: "at most one of key_passphrase and key_passphrase_file",
+		},
+		{
 			name: "instance_principal with api_key fields",
 			mutate: func(c *SDConfig) {
 				c.Auth = authInstancePrincipal
 				// Tenancy still set from validAPIKey.
 			},
 			wantErr: "must not have tenancy",
+		},
+		{
+			name: "instance_principal with key_passphrase_file",
+			mutate: func(c *SDConfig) {
+				c.Auth = authInstancePrincipal
+				c.Tenancy = ""
+				c.User = ""
+				c.Fingerprint = ""
+				c.KeyFile = ""
+				c.KeyPassphraseFile = "/etc/oci/passphrase"
+			},
+			wantErr: "must not have",
 		},
 		{
 			name:    "unknown auth method",
@@ -739,23 +749,6 @@ func TestSDConfig_Validation(t *testing.T) {
 				c.Compartments = []string{"ocid1.compartment.oc1..good", ""}
 			},
 			wantErr: "compartments[1] must not be empty",
-		},
-		{
-			name: "tag_filter_key without tag_filter_value",
-			mutate: func(c *SDConfig) {
-				c.TagFilterKey = "monitoring"
-				c.TagFilterValue = ""
-			},
-			wantErr: "requires tag_filter_value",
-		},
-		{
-			name: "tag_filter_action invalid",
-			mutate: func(c *SDConfig) {
-				c.TagFilterKey = "k"
-				c.TagFilterValue = "v"
-				c.TagFilterAction = "allowlist"
-			},
-			wantErr: "tag_filter_action must be",
 		},
 		{
 			name:    "refresh_interval zero",
@@ -784,7 +777,6 @@ func TestSDConfig_ValidInstancePrincipal(t *testing.T) {
 	cfg := SDConfig{
 		Auth:             authInstancePrincipal,
 		Region:           "us-ashburn-1",
-		TagFilterAction:  tagFilterActionInclude,
 		RefreshInterval:  model.Duration(60 * time.Second),
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
@@ -800,7 +792,6 @@ func TestSDConfig_ValidWithExplicitCompartments(t *testing.T) {
 		Fingerprint:      "aa:bb:cc",
 		KeyFile:          "/etc/oci/key.pem",
 		Compartments:     []string{"ocid1.compartment.oc1..c001", "ocid1.compartment.oc1..c002"},
-		TagFilterAction:  tagFilterActionInclude,
 		RefreshInterval:  model.Duration(60 * time.Second),
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
@@ -808,7 +799,7 @@ func TestSDConfig_ValidWithExplicitCompartments(t *testing.T) {
 }
 
 func TestSDConfig_ValidAutoDiscovery(t *testing.T) {
-	// Compartments empty → auto-discover. Should be valid.
+	// Compartments empty -> auto-discover. Should be valid.
 	cfg := SDConfig{
 		Auth:             authAPIKey,
 		Region:           "us-ashburn-1",
@@ -816,28 +807,47 @@ func TestSDConfig_ValidAutoDiscovery(t *testing.T) {
 		User:             "ocid1.user.oc1..u001",
 		Fingerprint:      "aa:bb:cc",
 		KeyFile:          "/etc/oci/key.pem",
-		TagFilterAction:  tagFilterActionInclude,
 		RefreshInterval:  model.Duration(60 * time.Second),
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
 }
 
-func TestSDConfig_ValidExcludeFilter(t *testing.T) {
+func TestSDConfig_ValidWithKeyPassphraseFile(t *testing.T) {
 	cfg := SDConfig{
-		Auth:             authAPIKey,
-		Region:           "us-ashburn-1",
-		Tenancy:          "ocid1.tenancy.oc1..t001",
-		User:             "ocid1.user.oc1..u001",
-		Fingerprint:      "aa:bb:cc",
-		KeyFile:          "/etc/oci/key.pem",
-		TagFilterKey:     "monitoring",
-		TagFilterValue:   "disabled",
-		TagFilterAction:  tagFilterActionExclude,
-		RefreshInterval:  model.Duration(60 * time.Second),
-		HTTPClientConfig: config.DefaultHTTPClientConfig,
+		Auth:              authAPIKey,
+		Region:            "us-ashburn-1",
+		Tenancy:           "ocid1.tenancy.oc1..t001",
+		User:              "ocid1.user.oc1..u001",
+		Fingerprint:       "aa:bb:cc",
+		KeyFile:           "/etc/oci/key.pem",
+		KeyPassphraseFile: "/etc/oci/passphrase",
+		RefreshInterval:   model.Duration(60 * time.Second),
+		HTTPClientConfig:  config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
+}
+
+// ---- resolveKeyPassphrase ---------------------------------------------------
+
+func TestResolveKeyPassphrase_InlinePreferredWhenSetAlone(t *testing.T) {
+	got, err := resolveKeyPassphrase(&SDConfig{KeyPassphrase: "topsecret"})
+	require.NoError(t, err)
+	require.Equal(t, "topsecret", got)
+}
+
+func TestResolveKeyPassphrase_FileTrimsTrailingNewline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pass")
+	require.NoError(t, writeFile(path, "topsecret\n"))
+
+	got, err := resolveKeyPassphrase(&SDConfig{KeyPassphraseFile: path})
+	require.NoError(t, err)
+	require.Equal(t, "topsecret", got)
+}
+
+func TestResolveKeyPassphrase_FileMissing(t *testing.T) {
+	_, err := resolveKeyPassphrase(&SDConfig{KeyPassphraseFile: filepath.Join(t.TempDir(), "nope")})
+	require.Error(t, err)
 }
 
 // ---- SetDirectory -----------------------------------------------------------
@@ -860,4 +870,11 @@ func TestSDConfig_SetDirectory_EmptyKeyFile(t *testing.T) {
 	cfg := SDConfig{}
 	cfg.SetDirectory("/etc/prometheus")
 	require.Empty(t, cfg.KeyFile)
+}
+
+func TestSDConfig_SetDirectory_KeyPassphraseFileJoined(t *testing.T) {
+	dir := filepath.FromSlash("/etc/prometheus")
+	cfg := SDConfig{KeyPassphraseFile: filepath.FromSlash("keys/oci.pass")}
+	cfg.SetDirectory(dir)
+	require.Equal(t, filepath.Join(dir, "keys", "oci.pass"), cfg.KeyPassphraseFile)
 }

--- a/discovery/oci/oci_test.go
+++ b/discovery/oci/oci_test.go
@@ -1,0 +1,843 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strconv"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- test helpers -----------------------------------------------------------
+
+func strPtr(s string) *string { return &s }
+func boolPtr(b bool) *bool    { return &b }
+
+// makeInstance builds a core.Instance with sensible defaults.
+func makeInstance(opts ...func(*core.Instance)) core.Instance {
+	inst := core.Instance{
+		Id:                 strPtr("ocid1.instance.oc1.iad.aaa001"),
+		DisplayName:        strPtr("test-instance-1"),
+		Shape:              strPtr("VM.Standard.E4.Flex"),
+		AvailabilityDomain: strPtr("US-ASHBURN-AD-1"),
+		FaultDomain:        strPtr("FAULT-DOMAIN-1"),
+		ImageId:            strPtr("ocid1.image.oc1.iad.img001"),
+		Region:             strPtr("us-ashburn-1"),
+		CompartmentId:      strPtr("ocid1.compartment.oc1..comp001"),
+		LifecycleState:     core.InstanceLifecycleStateRunning,
+		FreeformTags:       map[string]string{},
+		DefinedTags:        map[string]map[string]interface{}{},
+	}
+	for _, o := range opts {
+		o(&inst)
+	}
+	return inst
+}
+
+// makeVnic builds a primary VNIC. publicIP may be empty.
+func makeVnic(id, privateIP, publicIP string) *core.Vnic {
+	v := &core.Vnic{
+		Id:        strPtr(id),
+		IsPrimary: boolPtr(true),
+		PrivateIp: strPtr(privateIP),
+	}
+	if publicIP != "" {
+		v.PublicIp = strPtr(publicIP)
+	}
+	return v
+}
+
+// makeAttachment returns a single ATTACHED VnicAttachment.
+func makeAttachment(instanceID, vnicID string) core.VnicAttachment {
+	return core.VnicAttachment{
+		Id:             strPtr("ocid1.vnicattachment.oc1..att001"),
+		InstanceId:     strPtr(instanceID),
+		VnicId:         strPtr(vnicID),
+		LifecycleState: core.VnicAttachmentLifecycleStateAttached,
+	}
+}
+
+const testCompartment = "ocid1.compartment.oc1..comp001"
+const testTenancy = "ocid1.tenancy.oc1..test001"
+
+// baseDiscovery returns a Discovery with no-op closure stubs.
+// Tests override specific closures. d.refresh() is called directly so
+// d.Discovery (the refresh framework) is left nil.
+func baseDiscovery() *Discovery {
+	return &Discovery{
+		tenancy:         testTenancy,
+		tagFilterAction: tagFilterActionInclude,
+		port:            9100,
+		logger:          slog.Default(),
+		listCompartments: func(_ context.Context) ([]string, error) {
+			return []string{testCompartment}, nil
+		},
+		listInstances:       func(_ context.Context, _ string) ([]core.Instance, error) { return nil, nil },
+		listVnicAttachments: func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) { return nil, nil },
+		getVnic:             func(_ context.Context, _ string) (*core.Vnic, error) { return nil, nil },
+	}
+}
+
+// singleInstanceDiscovery wires closures to serve exactly one instance/VNIC.
+func singleInstanceDiscovery(inst core.Instance, vnic *core.Vnic) *Discovery {
+	att := makeAttachment(stringVal(inst.Id), stringVal(vnic.Id))
+	d := baseDiscovery()
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return []core.Instance{inst}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{att}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) {
+		return vnic, nil
+	}
+	return d
+}
+
+// ---- sanitizeLabelName ------------------------------------------------------
+
+func TestSanitizeLabelName(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"monitoring", "monitoring"},
+		{"Monitoring", "monitoring"},
+		{"my-tag", "my_tag"},
+		{"my.tag.key", "my_tag_key"},
+		{"My-Tag.Key", "my_tag_key"},
+		{"tag with spaces", "tag_with_spaces"},
+		{"tag123", "tag123"},
+		{"123numeric", "123numeric"},
+		{"", ""},
+		{"CamelCase", "camelcase"},
+		{"mixed-UPPER_lower.dot", "mixed_upper_lower_dot"},
+		{"Oracle-Tags", "oracle_tags"},
+		{"__reserved__", "__reserved__"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.want, sanitizeLabelName(tc.input))
+		})
+	}
+}
+
+// ---- hasTag -----------------------------------------------------------------
+
+func TestHasTag(t *testing.T) {
+	cases := []struct {
+		name  string
+		inst  core.Instance
+		key   string
+		value string
+		want  bool
+	}{
+		{
+			name: "freeform match",
+			inst: makeInstance(func(i *core.Instance) {
+				i.FreeformTags = map[string]string{"monitoring": "enabled"}
+			}),
+			key: "monitoring", value: "enabled", want: true,
+		},
+		{
+			name: "freeform value mismatch",
+			inst: makeInstance(func(i *core.Instance) {
+				i.FreeformTags = map[string]string{"monitoring": "disabled"}
+			}),
+			key: "monitoring", value: "enabled", want: false,
+		},
+		{
+			name: "freeform key absent",
+			inst: makeInstance(),
+			key:  "monitoring", value: "enabled", want: false,
+		},
+		{
+			name: "defined tag match",
+			inst: makeInstance(func(i *core.Instance) {
+				i.DefinedTags = map[string]map[string]interface{}{
+					"ops-ns": {"monitoring": "enabled"},
+				}
+			}),
+			key: "monitoring", value: "enabled", want: true,
+		},
+		{
+			name: "defined tag value mismatch",
+			inst: makeInstance(func(i *core.Instance) {
+				i.DefinedTags = map[string]map[string]interface{}{
+					"ops-ns": {"monitoring": "disabled"},
+				}
+			}),
+			key: "monitoring", value: "enabled", want: false,
+		},
+		{
+			name: "defined tag non-string value not matched",
+			inst: makeInstance(func(i *core.Instance) {
+				i.DefinedTags = map[string]map[string]interface{}{
+					"ops-ns": {"monitoring": 42},
+				}
+			}),
+			key: "monitoring", value: "42", want: false,
+		},
+		{
+			name: "defined tag found in second namespace",
+			inst: makeInstance(func(i *core.Instance) {
+				i.DefinedTags = map[string]map[string]interface{}{
+					"ns1": {"other": "x"},
+					"ns2": {"monitoring": "enabled"},
+				}
+			}),
+			key: "monitoring", value: "enabled", want: true,
+		},
+		{
+			name: "freeform matches even when defined tag disagrees",
+			inst: makeInstance(func(i *core.Instance) {
+				i.FreeformTags = map[string]string{"monitoring": "enabled"}
+				i.DefinedTags = map[string]map[string]interface{}{
+					"ns": {"monitoring": "disabled"},
+				}
+			}),
+			key: "monitoring", value: "enabled", want: true,
+		},
+		{
+			name: "nil freeform and nil defined - no panic",
+			inst: makeInstance(func(i *core.Instance) {
+				i.FreeformTags = nil
+				i.DefinedTags = nil
+			}),
+			key: "monitoring", value: "enabled", want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, hasTag(&tc.inst, tc.key, tc.value))
+		})
+	}
+}
+
+// ---- instanceLabels ---------------------------------------------------------
+
+func TestInstanceLabels_CoreLabels(t *testing.T) {
+	inst := makeInstance()
+	labels := instanceLabels(&inst, "10.0.0.5", "203.0.113.1", testTenancy, 9100)
+
+	expected := model.LabelSet{
+		model.AddressLabel:         "10.0.0.5:9100",
+		ociLabelInstanceID:         "ocid1.instance.oc1.iad.aaa001",
+		ociLabelInstanceName:       "test-instance-1",
+		ociLabelInstanceState:      "RUNNING",
+		ociLabelInstanceShape:      "VM.Standard.E4.Flex",
+		ociLabelAvailabilityDomain: "US-ASHBURN-AD-1",
+		ociLabelFaultDomain:        "FAULT-DOMAIN-1",
+		ociLabelRegion:             "us-ashburn-1",
+		ociLabelTenancyID:          testTenancy,
+		ociLabelCompartmentID:      "ocid1.compartment.oc1..comp001",
+		ociLabelImageID:            "ocid1.image.oc1.iad.img001",
+		ociLabelPrivateIP:          "10.0.0.5",
+		ociLabelPublicIP:           "203.0.113.1",
+	}
+	for k, want := range expected {
+		require.Equal(t, want, labels[k], "label %s", k)
+	}
+}
+
+func TestInstanceLabels_AddressIsPrivateIPWhenBothPresent(t *testing.T) {
+	inst := makeInstance()
+	labels := instanceLabels(&inst, "10.0.0.5", "203.0.113.1", "tenancy", 80)
+	require.Equal(t, model.LabelValue("10.0.0.5:80"), labels[model.AddressLabel])
+}
+
+func TestInstanceLabels_AddressFallsBackToPublicIP(t *testing.T) {
+	inst := makeInstance()
+	labels := instanceLabels(&inst, "", "203.0.113.1", "tenancy", 80)
+	require.Equal(t, model.LabelValue("203.0.113.1:80"), labels[model.AddressLabel])
+}
+
+func TestInstanceLabels_FreeformTagsSanitized(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.FreeformTags = map[string]string{
+			"environment": "production",
+			"My-Tag.Key":  "value",
+			"123numeric":  "v",
+		}
+	})
+	labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", 80)
+
+	require.Equal(t, model.LabelValue("production"), labels[ociLabelFreeformTagPrefix+"environment"])
+	require.Equal(t, model.LabelValue("value"), labels[ociLabelFreeformTagPrefix+"my_tag_key"])
+	require.Equal(t, model.LabelValue("v"), labels[ociLabelFreeformTagPrefix+"123numeric"])
+}
+
+func TestInstanceLabels_DefinedTagsStringOnly(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.DefinedTags = map[string]map[string]interface{}{
+			"Oracle-Tags": {
+				"CreatedBy":  "user@example.com",
+				"CostCenter": "42",
+				"IntValue":   100,  // must be skipped
+				"BoolValue":  true, // must be skipped
+			},
+		}
+	})
+	labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", 80)
+
+	require.Equal(t, model.LabelValue("user@example.com"), labels[ociLabelDefinedTagPrefix+"oracle_tags_createdby"])
+	require.Equal(t, model.LabelValue("42"), labels[ociLabelDefinedTagPrefix+"oracle_tags_costcenter"])
+
+	_, hasInt := labels[ociLabelDefinedTagPrefix+"oracle_tags_intvalue"]
+	require.False(t, hasInt, "integer defined tag must not be emitted")
+
+	_, hasBool := labels[ociLabelDefinedTagPrefix+"oracle_tags_boolvalue"]
+	require.False(t, hasBool, "boolean defined tag must not be emitted")
+}
+
+func TestInstanceLabels_NilOptionalFields(t *testing.T) {
+	inst := core.Instance{
+		LifecycleState: core.InstanceLifecycleStateRunning,
+		FreeformTags:   map[string]string{},
+		DefinedTags:    map[string]map[string]interface{}{},
+	}
+	labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", 80)
+
+	require.Equal(t, model.LabelValue("10.0.0.1:80"), labels[model.AddressLabel])
+	require.Equal(t, model.LabelValue(""), labels[ociLabelInstanceID])
+	require.Equal(t, model.LabelValue(""), labels[ociLabelImageID])
+}
+
+func TestInstanceLabels_PortInAddress(t *testing.T) {
+	inst := makeInstance()
+	for _, port := range []int{80, 9100, 9182, 443} {
+		labels := instanceLabels(&inst, "10.0.0.1", "", "tenancy", port)
+		require.Equal(t,
+			model.LabelValue("10.0.0.1:"+strconv.Itoa(port)),
+			labels[model.AddressLabel],
+			"port %d", port,
+		)
+	}
+}
+
+// ---- refresh ----------------------------------------------------------------
+
+func TestRefresh_SingleInstance(t *testing.T) {
+	inst := makeInstance()
+	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.5", "203.0.113.10")
+	d := singleInstanceDiscovery(inst, vnic)
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Equal(t, "OCI_"+testCompartment, tgs[0].Source)
+	require.Len(t, tgs[0].Targets, 1)
+
+	labels := tgs[0].Targets[0]
+	require.Equal(t, model.LabelValue("10.0.0.5:9100"), labels[model.AddressLabel])
+	require.Equal(t, model.LabelValue("ocid1.instance.oc1.iad.aaa001"), labels[ociLabelInstanceID])
+	require.Equal(t, model.LabelValue("10.0.0.5"), labels[ociLabelPrivateIP])
+	require.Equal(t, model.LabelValue("203.0.113.10"), labels[ociLabelPublicIP])
+	require.Equal(t, model.LabelValue(testTenancy), labels[ociLabelTenancyID])
+}
+
+func TestRefresh_MultipleCompartments(t *testing.T) {
+	comp1 := "ocid1.compartment.oc1..c001"
+	comp2 := "ocid1.compartment.oc1..c002"
+	comp3 := "ocid1.compartment.oc1..c003"
+
+	inst1 := makeInstance(func(i *core.Instance) {
+		i.Id = strPtr("ocid1.instance.oc1..i001")
+		i.CompartmentId = strPtr(comp1)
+	})
+	inst2 := makeInstance(func(i *core.Instance) {
+		i.Id = strPtr("ocid1.instance.oc1..i002")
+		i.CompartmentId = strPtr(comp2)
+	})
+	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.1", "")
+
+	d := baseDiscovery()
+	d.listCompartments = func(_ context.Context) ([]string, error) {
+		return []string{comp1, comp2, comp3}, nil
+	}
+	d.listInstances = func(_ context.Context, compartmentID string) ([]core.Instance, error) {
+		switch compartmentID {
+		case comp1:
+			return []core.Instance{inst1}, nil
+		case comp2:
+			return []core.Instance{inst2}, nil
+		default:
+			return nil, nil // comp3 is empty
+		}
+	}
+	d.listVnicAttachments = func(_ context.Context, _, instanceID string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{makeAttachment(instanceID, stringVal(vnic.Id))}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) {
+		return vnic, nil
+	}
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	// One group per compartment, including the empty one.
+	require.Len(t, tgs, 3)
+	require.Equal(t, "OCI_"+comp1, tgs[0].Source)
+	require.Len(t, tgs[0].Targets, 1)
+	require.Equal(t, "OCI_"+comp2, tgs[1].Source)
+	require.Len(t, tgs[1].Targets, 1)
+	require.Equal(t, "OCI_"+comp3, tgs[2].Source)
+	require.Empty(t, tgs[2].Targets)
+}
+
+func TestRefresh_CompartmentListError_Propagates(t *testing.T) {
+	sentinel := errors.New("identity API unavailable")
+	d := baseDiscovery()
+	d.listCompartments = func(_ context.Context) ([]string, error) {
+		return nil, sentinel
+	}
+
+	_, err := d.refresh(context.Background())
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestRefresh_ListInstancesError_CompartmentSkipped(t *testing.T) {
+	// listInstances error → compartment is logged and skipped, no target group returned.
+	sentinel := errors.New("OCI API unavailable")
+	d := baseDiscovery()
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return nil, sentinel
+	}
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, tgs, "failed compartment should be skipped, not returned")
+}
+
+func TestRefresh_EmptyCompartment(t *testing.T) {
+	d := baseDiscovery()
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Empty(t, tgs[0].Targets)
+}
+
+func TestRefresh_VnicAttachmentError_InstanceSkipped(t *testing.T) {
+	inst := makeInstance()
+	sentinel := errors.New("VNIC list failed")
+
+	d := baseDiscovery()
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return []core.Instance{inst}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
+		return nil, sentinel
+	}
+
+	// Instance is skipped, compartment group is still returned (empty targets).
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Empty(t, tgs[0].Targets)
+}
+
+func TestRefresh_GetVnicError_InstanceSkipped(t *testing.T) {
+	inst := makeInstance()
+	att := makeAttachment(stringVal(inst.Id), "ocid1.vnic.oc1..v001")
+	sentinel := errors.New("GetVnic failed")
+
+	d := baseDiscovery()
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return []core.Instance{inst}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{att}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) {
+		return nil, sentinel
+	}
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Empty(t, tgs[0].Targets)
+}
+
+func TestRefresh_TagFilterInclude_OnlyTaggedInstanceReturned(t *testing.T) {
+	tagged := makeInstance(func(i *core.Instance) {
+		i.Id = strPtr("ocid1.instance.oc1..tagged")
+		i.FreeformTags = map[string]string{"monitoring": "enabled"}
+	})
+	untagged := makeInstance(func(i *core.Instance) {
+		i.Id = strPtr("ocid1.instance.oc1..untagged")
+	})
+
+	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.1", "")
+	att := makeAttachment("ocid1.instance.oc1..tagged", stringVal(vnic.Id))
+
+	d := baseDiscovery()
+	d.tagFilterKey = "monitoring"
+	d.tagFilterValue = "enabled"
+	d.tagFilterAction = tagFilterActionInclude
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return []core.Instance{tagged, untagged}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{att}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs[0].Targets, 1)
+	require.Equal(t, model.LabelValue("ocid1.instance.oc1..tagged"), tgs[0].Targets[0][ociLabelInstanceID])
+}
+
+func TestRefresh_TagFilterExclude_TaggedInstanceDropped(t *testing.T) {
+	disabled := makeInstance(func(i *core.Instance) {
+		i.Id = strPtr("ocid1.instance.oc1..disabled")
+		i.FreeformTags = map[string]string{"monitoring": "disabled"}
+	})
+	active := makeInstance(func(i *core.Instance) {
+		i.Id = strPtr("ocid1.instance.oc1..active")
+	})
+
+	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.2", "")
+	att := makeAttachment("ocid1.instance.oc1..active", stringVal(vnic.Id))
+
+	d := baseDiscovery()
+	d.tagFilterKey = "monitoring"
+	d.tagFilterValue = "disabled"
+	d.tagFilterAction = tagFilterActionExclude
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return []core.Instance{disabled, active}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{att}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs[0].Targets, 1)
+	require.Equal(t, model.LabelValue("ocid1.instance.oc1..active"), tgs[0].Targets[0][ociLabelInstanceID])
+}
+
+func TestRefresh_TagFilter_VnicNotCalledForFilteredInstances(t *testing.T) {
+	inst1 := makeInstance(func(i *core.Instance) {
+		i.Id = strPtr("ocid1.instance.oc1..inst1")
+		i.FreeformTags = map[string]string{"monitoring": "disabled"}
+	})
+	inst2 := makeInstance(func(i *core.Instance) {
+		i.Id = strPtr("ocid1.instance.oc1..inst2")
+		i.FreeformTags = map[string]string{"monitoring": "disabled"}
+	})
+
+	vnicCalls := 0
+	d := baseDiscovery()
+	d.tagFilterKey = "monitoring"
+	d.tagFilterValue = "disabled"
+	d.tagFilterAction = tagFilterActionExclude
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return []core.Instance{inst1, inst2}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
+		vnicCalls++
+		return nil, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) {
+		vnicCalls++
+		return nil, nil
+	}
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, tgs[0].Targets)
+	require.Zero(t, vnicCalls, "VNIC API must not be called for filtered-out instances")
+}
+
+func TestRefresh_NoTagFilter_AllInstancesReturned(t *testing.T) {
+	instances := []core.Instance{
+		makeInstance(func(i *core.Instance) { i.Id = strPtr("ocid1.instance.oc1..i1") }),
+		makeInstance(func(i *core.Instance) { i.Id = strPtr("ocid1.instance.oc1..i2") }),
+		makeInstance(func(i *core.Instance) { i.Id = strPtr("ocid1.instance.oc1..i3") }),
+	}
+	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.1", "")
+	att := makeAttachment("", stringVal(vnic.Id))
+
+	d := baseDiscovery()
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return instances, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{att}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs[0].Targets, 3)
+}
+
+func TestRefresh_DefinedTagFilterInclude(t *testing.T) {
+	tagged := makeInstance(func(i *core.Instance) {
+		i.Id = strPtr("ocid1.instance.oc1..tagged")
+		i.DefinedTags = map[string]map[string]interface{}{
+			"ops-ns": {"monitoring": "enabled"},
+		}
+	})
+	untagged := makeInstance(func(i *core.Instance) {
+		i.Id = strPtr("ocid1.instance.oc1..untagged")
+	})
+
+	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.5", "")
+	att := makeAttachment("ocid1.instance.oc1..tagged", stringVal(vnic.Id))
+
+	d := baseDiscovery()
+	d.tagFilterKey = "monitoring"
+	d.tagFilterValue = "enabled"
+	d.tagFilterAction = tagFilterActionInclude
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return []core.Instance{tagged, untagged}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{att}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs[0].Targets, 1)
+	require.Equal(t, model.LabelValue("ocid1.instance.oc1..tagged"), tgs[0].Targets[0][ociLabelInstanceID])
+}
+
+func TestRefresh_NoPrimaryVnic_EmptyIPs(t *testing.T) {
+	inst := makeInstance()
+	nonPrimary := &core.Vnic{
+		Id:        strPtr("ocid1.vnic.oc1..v001"),
+		IsPrimary: boolPtr(false),
+		PrivateIp: strPtr("10.0.0.5"),
+	}
+	att := makeAttachment(stringVal(inst.Id), stringVal(nonPrimary.Id))
+
+	d := baseDiscovery()
+	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
+		return []core.Instance{inst}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, _ string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{att}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return nonPrimary, nil }
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs[0].Targets, 1)
+	require.Equal(t, model.LabelValue(""), tgs[0].Targets[0][ociLabelPrivateIP])
+}
+
+func TestRefresh_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	d := baseDiscovery()
+	d.listCompartments = func(ctx context.Context) ([]string, error) {
+		return nil, ctx.Err()
+	}
+
+	_, err := d.refresh(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// ---- SDConfig validation ----------------------------------------------------
+
+func TestSDConfig_Validation(t *testing.T) {
+	validAPIKey := SDConfig{
+		Auth:            authAPIKey,
+		Region:          "us-ashburn-1",
+		Tenancy:         "ocid1.tenancy.oc1..t001",
+		User:            "ocid1.user.oc1..u001",
+		Fingerprint:     "aa:bb:cc",
+		KeyFile:         "/etc/oci/key.pem",
+		TagFilterAction: tagFilterActionInclude,
+		RateLimitRPS:    10,
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(*SDConfig)
+		wantErr string
+	}{
+		{
+			name:    "missing region",
+			mutate:  func(c *SDConfig) { c.Region = "" },
+			wantErr: "requires a region",
+		},
+		{
+			name:    "api_key missing tenancy",
+			mutate:  func(c *SDConfig) { c.Tenancy = "" },
+			wantErr: "requires tenancy",
+		},
+		{
+			name:    "api_key missing user",
+			mutate:  func(c *SDConfig) { c.User = "" },
+			wantErr: "requires user",
+		},
+		{
+			name:    "api_key missing fingerprint",
+			mutate:  func(c *SDConfig) { c.Fingerprint = "" },
+			wantErr: "requires fingerprint",
+		},
+		{
+			name:    "api_key missing key_file",
+			mutate:  func(c *SDConfig) { c.KeyFile = "" },
+			wantErr: "requires key_file",
+		},
+		{
+			name: "instance_principal with api_key fields",
+			mutate: func(c *SDConfig) {
+				c.Auth = authInstancePrincipal
+				// Tenancy still set from validAPIKey.
+			},
+			wantErr: "must not have tenancy",
+		},
+		{
+			name:    "unknown auth method",
+			mutate:  func(c *SDConfig) { c.Auth = "magic"; c.Tenancy = "" },
+			wantErr: "unknown auth method",
+		},
+		{
+			name: "empty string in compartments list",
+			mutate: func(c *SDConfig) {
+				c.Compartments = []string{"ocid1.compartment.oc1..good", ""}
+			},
+			wantErr: "compartments[1] must not be empty",
+		},
+		{
+			name: "tag_filter_key without tag_filter_value",
+			mutate: func(c *SDConfig) {
+				c.TagFilterKey = "monitoring"
+				c.TagFilterValue = ""
+			},
+			wantErr: "requires tag_filter_value",
+		},
+		{
+			name: "tag_filter_action invalid",
+			mutate: func(c *SDConfig) {
+				c.TagFilterKey = "k"
+				c.TagFilterValue = "v"
+				c.TagFilterAction = "allowlist"
+			},
+			wantErr: "tag_filter_action must be",
+		},
+		{
+			name:    "rate_limit_rps zero",
+			mutate:  func(c *SDConfig) { c.RateLimitRPS = 0 },
+			wantErr: "rate_limit_rps must be positive",
+		},
+		{
+			name:    "rate_limit_rps negative",
+			mutate:  func(c *SDConfig) { c.RateLimitRPS = -1 },
+			wantErr: "rate_limit_rps must be positive",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validAPIKey
+			tc.mutate(&cfg)
+			err := cfg.validate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestSDConfig_ValidInstancePrincipal(t *testing.T) {
+	cfg := SDConfig{
+		Auth:            authInstancePrincipal,
+		Region:          "us-ashburn-1",
+		RateLimitRPS:    10,
+		TagFilterAction: tagFilterActionInclude,
+	}
+	require.NoError(t, cfg.validate())
+}
+
+func TestSDConfig_ValidWithExplicitCompartments(t *testing.T) {
+	cfg := SDConfig{
+		Auth:            authAPIKey,
+		Region:          "us-ashburn-1",
+		Tenancy:         "ocid1.tenancy.oc1..t001",
+		User:            "ocid1.user.oc1..u001",
+		Fingerprint:     "aa:bb:cc",
+		KeyFile:         "/etc/oci/key.pem",
+		Compartments:    []string{"ocid1.compartment.oc1..c001", "ocid1.compartment.oc1..c002"},
+		TagFilterAction: tagFilterActionInclude,
+		RateLimitRPS:    10,
+	}
+	require.NoError(t, cfg.validate())
+}
+
+func TestSDConfig_ValidAutoDiscovery(t *testing.T) {
+	// Compartments empty → auto-discover. Should be valid.
+	cfg := SDConfig{
+		Auth:            authAPIKey,
+		Region:          "us-ashburn-1",
+		Tenancy:         "ocid1.tenancy.oc1..t001",
+		User:            "ocid1.user.oc1..u001",
+		Fingerprint:     "aa:bb:cc",
+		KeyFile:         "/etc/oci/key.pem",
+		TagFilterAction: tagFilterActionInclude,
+		RateLimitRPS:    10,
+	}
+	require.NoError(t, cfg.validate())
+}
+
+func TestSDConfig_ValidExcludeFilter(t *testing.T) {
+	cfg := SDConfig{
+		Auth:            authAPIKey,
+		Region:          "us-ashburn-1",
+		Tenancy:         "ocid1.tenancy.oc1..t001",
+		User:            "ocid1.user.oc1..u001",
+		Fingerprint:     "aa:bb:cc",
+		KeyFile:         "/etc/oci/key.pem",
+		TagFilterKey:    "monitoring",
+		TagFilterValue:  "disabled",
+		TagFilterAction: tagFilterActionExclude,
+		RateLimitRPS:    10,
+	}
+	require.NoError(t, cfg.validate())
+}
+
+// ---- SetDirectory -----------------------------------------------------------
+
+func TestSDConfig_SetDirectory_RelativePath(t *testing.T) {
+	cfg := SDConfig{KeyFile: "keys/oci.pem"}
+	cfg.SetDirectory("/etc/prometheus")
+	require.Equal(t, "/etc/prometheus/keys/oci.pem", cfg.KeyFile)
+}
+
+func TestSDConfig_SetDirectory_AbsolutePathUnchanged(t *testing.T) {
+	cfg := SDConfig{KeyFile: "/absolute/path/oci.pem"}
+	cfg.SetDirectory("/etc/prometheus")
+	require.Equal(t, "/absolute/path/oci.pem", cfg.KeyFile)
+}
+
+func TestSDConfig_SetDirectory_EmptyKeyFile(t *testing.T) {
+	cfg := SDConfig{}
+	cfg.SetDirectory("/etc/prometheus")
+	require.Equal(t, "", cfg.KeyFile)
+}

--- a/discovery/oci/oci_test.go
+++ b/discovery/oci/oci_test.go
@@ -185,6 +185,27 @@ func TestInstanceLabels_SecondaryVnicIPsExposed(t *testing.T) {
 	require.Equal(t, model.LabelValue(",203.0.113.2,"), labels[ociLabelSecondaryPublicIPs])
 }
 
+func TestInstanceLabels_SecondaryVnicIPsSortedDeterministically(t *testing.T) {
+	// OCI does not guarantee a stable attachment order between calls. The
+	// joined label value must be sorted so secondary IPs do not churn
+	// between refreshes when ListVnicAttachments returns the same IPs in a
+	// different order.
+	inst := makeInstance()
+	vnics := instanceVnics{
+		primary:    vnicInfo{id: "ocid1.vnic.oc1..p", privateIP: "10.0.0.1"},
+		hasPrimary: true,
+		secondary: []vnicInfo{
+			{id: "s3", privateIP: "10.0.0.30", publicIP: "203.0.113.30"},
+			{id: "s1", privateIP: "10.0.0.10", publicIP: "203.0.113.10"},
+			{id: "s2", privateIP: "10.0.0.20"},
+		},
+	}
+	labels := instanceLabels(&inst, vnics, "tenancy", 80)
+
+	require.Equal(t, model.LabelValue(",10.0.0.10,10.0.0.20,10.0.0.30,"), labels[ociLabelSecondaryPrivateIPs])
+	require.Equal(t, model.LabelValue(",203.0.113.10,203.0.113.30,"), labels[ociLabelSecondaryPublicIPs])
+}
+
 func TestInstanceLabels_NoSecondaryVnicLabelsWhenAbsent(t *testing.T) {
 	inst := makeInstance()
 	labels := instanceLabels(&inst, primaryOnly("v", "10.0.0.1", ""), "tenancy", 80)
@@ -216,14 +237,21 @@ func TestInstanceLabels_FreeformTagsSanitized(t *testing.T) {
 	require.Equal(t, model.LabelValue("lower"), labels[ociLabelFreeformTagPrefix+"env"])
 }
 
-func TestInstanceLabels_DefinedTagsStringOnly(t *testing.T) {
+func TestInstanceLabels_DefinedTagsStringifyScalars(t *testing.T) {
+	// OCI defined tag values may be strings, numbers, or booleans. The SDK
+	// decodes JSON numbers as float64. All scalars are stringified so that
+	// keep/drop relabel rules on numeric or boolean tags match correctly.
 	inst := makeInstance(func(i *core.Instance) {
 		i.DefinedTags = map[string]map[string]any{
 			"Oracle-Tags": {
-				"CreatedBy":  "user@example.com",
-				"CostCenter": "42",
-				"IntValue":   100,  // Must be skipped.
-				"BoolValue":  true, // Must be skipped.
+				"CreatedBy":   "user@example.com",
+				"CostCenter":  "42",
+				"FloatValue":  float64(100),
+				"DecimalRate": float64(0.5),
+				"BoolValue":   true,
+				"IntValue":    int(7),
+				"NilValue":    nil,
+				"SliceValue":  []any{"a"},
 			},
 		}
 	})
@@ -231,12 +259,46 @@ func TestInstanceLabels_DefinedTagsStringOnly(t *testing.T) {
 
 	require.Equal(t, model.LabelValue("user@example.com"), labels[ociLabelDefinedTagPrefix+"Oracle_Tags_CreatedBy"])
 	require.Equal(t, model.LabelValue("42"), labels[ociLabelDefinedTagPrefix+"Oracle_Tags_CostCenter"])
+	require.Equal(t, model.LabelValue("100"), labels[ociLabelDefinedTagPrefix+"Oracle_Tags_FloatValue"])
+	require.Equal(t, model.LabelValue("0.5"), labels[ociLabelDefinedTagPrefix+"Oracle_Tags_DecimalRate"])
+	require.Equal(t, model.LabelValue("true"), labels[ociLabelDefinedTagPrefix+"Oracle_Tags_BoolValue"])
+	require.Equal(t, model.LabelValue("7"), labels[ociLabelDefinedTagPrefix+"Oracle_Tags_IntValue"])
 
-	_, hasInt := labels[ociLabelDefinedTagPrefix+"Oracle_Tags_IntValue"]
-	require.False(t, hasInt, "integer defined tag must not be emitted")
+	_, hasNil := labels[ociLabelDefinedTagPrefix+"Oracle_Tags_NilValue"]
+	require.False(t, hasNil, "nil defined tag must not be emitted")
 
-	_, hasBool := labels[ociLabelDefinedTagPrefix+"Oracle_Tags_BoolValue"]
-	require.False(t, hasBool, "boolean defined tag must not be emitted")
+	_, hasSlice := labels[ociLabelDefinedTagPrefix+"Oracle_Tags_SliceValue"]
+	require.False(t, hasSlice, "non-scalar defined tag must not be emitted")
+}
+
+func TestStringifyDefinedTag(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+		ok   bool
+	}{
+		{"string", "abc", "abc", true},
+		{"empty string", "", "", true},
+		{"bool true", true, "true", true},
+		{"bool false", false, "false", true},
+		{"float64 whole", float64(42), "42", true},
+		{"float64 fraction", float64(3.14), "3.14", true},
+		{"float32", float32(1.5), "1.5", true},
+		{"int", int(7), "7", true},
+		{"int64", int64(-9), "-9", true},
+		{"int32", int32(3), "3", true},
+		{"nil", nil, "", false},
+		{"slice", []any{"a"}, "", false},
+		{"map", map[string]any{"a": 1}, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := stringifyDefinedTag(tc.in)
+			require.Equal(t, tc.ok, ok)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func TestInstanceLabels_NilOptionalFields(t *testing.T) {
@@ -391,10 +453,10 @@ func TestRefresh_CompartmentListError_Propagates(t *testing.T) {
 	require.ErrorIs(t, err, sentinel)
 }
 
-func TestRefresh_ListInstancesError_EmptyGroupReturned(t *testing.T) {
-	// listInstances error -> compartment is logged and an empty group is
-	// returned so the discovery manager prunes any stale targets it still
-	// has for this source.
+func TestRefresh_ListInstancesError_PropagatesError(t *testing.T) {
+	// listInstances error -> the refresh fails as a whole so the refresh
+	// framework keeps the last known good targets rather than flapping the
+	// compartment's targets down for a cycle.
 	sentinel := errors.New("OCI API unavailable")
 	d := baseDiscovery()
 	d.listInstances = func(_ context.Context, _ string) ([]core.Instance, error) {
@@ -402,10 +464,8 @@ func TestRefresh_ListInstancesError_EmptyGroupReturned(t *testing.T) {
 	}
 
 	tgs, err := d.refresh(context.Background())
-	require.NoError(t, err)
-	require.Len(t, tgs, 1, "failed compartment must still return an (empty) group")
-	require.Equal(t, "OCI_"+testCompartment, tgs[0].Source)
-	require.Empty(t, tgs[0].Targets)
+	require.ErrorIs(t, err, sentinel)
+	require.Nil(t, tgs, "no target groups must be returned when listInstances fails")
 }
 
 func TestRefresh_EmptyCompartment(t *testing.T) {
@@ -677,6 +737,7 @@ func TestSDConfig_Validation(t *testing.T) {
 		Fingerprint:      "aa:bb:cc",
 		KeyFile:          "/etc/oci/key.pem",
 		RefreshInterval:  model.Duration(60 * time.Second),
+		RateLimitRPS:     defaultRateLimitRPS,
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 
@@ -760,6 +821,16 @@ func TestSDConfig_Validation(t *testing.T) {
 			mutate:  func(c *SDConfig) { c.RefreshInterval = model.Duration(-1 * time.Second) },
 			wantErr: "refresh_interval must be positive",
 		},
+		{
+			name:    "rate_limit_rps zero",
+			mutate:  func(c *SDConfig) { c.RateLimitRPS = 0 },
+			wantErr: "rate_limit_rps must be positive",
+		},
+		{
+			name:    "rate_limit_rps negative",
+			mutate:  func(c *SDConfig) { c.RateLimitRPS = -1 },
+			wantErr: "rate_limit_rps must be positive",
+		},
 	}
 
 	for _, tc := range cases {
@@ -778,6 +849,7 @@ func TestSDConfig_ValidInstancePrincipal(t *testing.T) {
 		Auth:             authInstancePrincipal,
 		Region:           "us-ashburn-1",
 		RefreshInterval:  model.Duration(60 * time.Second),
+		RateLimitRPS:     defaultRateLimitRPS,
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
@@ -793,6 +865,7 @@ func TestSDConfig_ValidWithExplicitCompartments(t *testing.T) {
 		KeyFile:          "/etc/oci/key.pem",
 		Compartments:     []string{"ocid1.compartment.oc1..c001", "ocid1.compartment.oc1..c002"},
 		RefreshInterval:  model.Duration(60 * time.Second),
+		RateLimitRPS:     defaultRateLimitRPS,
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
@@ -808,6 +881,7 @@ func TestSDConfig_ValidAutoDiscovery(t *testing.T) {
 		Fingerprint:      "aa:bb:cc",
 		KeyFile:          "/etc/oci/key.pem",
 		RefreshInterval:  model.Duration(60 * time.Second),
+		RateLimitRPS:     defaultRateLimitRPS,
 		HTTPClientConfig: config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())
@@ -823,6 +897,7 @@ func TestSDConfig_ValidWithKeyPassphraseFile(t *testing.T) {
 		KeyFile:           "/etc/oci/key.pem",
 		KeyPassphraseFile: "/etc/oci/passphrase",
 		RefreshInterval:   model.Duration(60 * time.Second),
+		RateLimitRPS:      defaultRateLimitRPS,
 		HTTPClientConfig:  config.DefaultHTTPClientConfig,
 	}
 	require.NoError(t, cfg.validate())

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -486,6 +486,10 @@ nerve_sd_configs:
 nomad_sd_configs:
   [ - <nomad_sd_config> ... ]
 
+# List of OCI service discovery configurations.
+oci_sd_configs:
+  [ - <oci_sd_config> ... ]
+
 # List of OpenStack service discovery configurations.
 openstack_sd_configs:
   [ - <openstack_sd_config> ... ]
@@ -2936,6 +2940,98 @@ The following meta labels are available on targets during [relabeling](#relabel_
 [ <http_config> ]
 ```
 
+### `<oci_sd_config>`
+
+OCI SD configurations allow retrieving scrape targets from Oracle Cloud Infrastructure (OCI)
+compute instances. The private IP of the primary VNIC is used as the default address.
+Where no private IP is present (bare-metal instances without secondary VNIC assignment),
+the public IP is used instead.
+
+The following OCI IAM policies are required. For API key authentication (user credentials):
+
+```text
+Allow group <group-name> to read instances in tenancy
+Allow group <group-name> to read compartments in tenancy
+Allow group <group-name> to read vnic-attachments in tenancy
+Allow group <group-name> to read vnics in tenancy
+Allow group <group-name> to read tag-namespaces in tenancy
+```
+
+For instance principal authentication (Prometheus running on OCI compute):
+
+```text
+Allow dynamic-group <dynamic-group-name> to read instances in tenancy
+Allow dynamic-group <dynamic-group-name> to read compartments in tenancy
+Allow dynamic-group <dynamic-group-name> to read vnic-attachments in tenancy
+Allow dynamic-group <dynamic-group-name> to read vnics in tenancy
+Allow dynamic-group <dynamic-group-name> to read tag-namespaces in tenancy
+```
+
+The following meta labels are available on all targets during
+[relabeling](#relabel_config):
+
+* `__meta_oci_availability_domain`: the availability domain of the instance (e.g. `US-ASHBURN-AD-1`)
+* `__meta_oci_compartment_id`: the OCID of the compartment the instance belongs to
+* `__meta_oci_defined_tag_<namespace>_<key>`: each defined tag of the instance; string-typed values only
+* `__meta_oci_fault_domain`: the fault domain of the instance (e.g. `FAULT-DOMAIN-1`)
+* `__meta_oci_image_id`: the OCID of the image the instance was launched from
+* `__meta_oci_instance_id`: the OCID of the instance
+* `__meta_oci_instance_name`: the display name of the instance
+* `__meta_oci_instance_shape`: the shape of the instance (e.g. `VM.Standard.E4.Flex`)
+* `__meta_oci_instance_state`: the lifecycle state of the instance (always `RUNNING`)
+* `__meta_oci_private_ip`: the private IP address of the primary VNIC
+* `__meta_oci_public_ip`: the public IP address of the primary VNIC, if assigned
+* `__meta_oci_region`: the OCI region identifier (e.g. `us-ashburn-1`)
+* `__meta_oci_tag_<key>`: each freeform tag of the instance
+* `__meta_oci_tenancy_id`: the OCID of the tenancy the instance belongs to
+
+```yaml
+# Authentication method. Supported values: "api_key" (default), "instance_principal".
+# "instance_principal" uses IMDS-based credentials and requires no credential fields;
+# it is the recommended method when Prometheus runs on OCI compute.
+[ auth: <string> | default = "api_key" ]
+
+# API key auth fields. Required when auth is "api_key".
+[ tenancy: <string> ]
+[ user: <string> ]
+[ fingerprint: <string> ]
+[ key_file: <string> ]
+[ key_passphrase: <secret> ]
+
+# OCI region identifier. Required.
+region: <string>
+
+# Explicit list of compartment OCIDs to scan. When empty, all active
+# compartments reachable from the tenancy root are discovered automatically
+# via the OCI Identity API using a breadth-first walk. Compartments that
+# cannot be listed due to missing permissions are silently skipped.
+[ compartments:
+  [ - <string> ... ] ]
+
+# Optional display-name substring filter passed to the OCI ListInstances API.
+[ filter: <string> ]
+
+# Tag-based filtering. When tag_filter_key is set, only instances carrying
+# (include) or lacking (exclude) the given freeform or defined tag key=value
+# pair are returned. Freeform tags are checked before defined tags.
+# The filter is applied before VNIC resolution to avoid unnecessary API calls.
+[ tag_filter_key: <string> ]
+[ tag_filter_value: <string> ]
+# Controls whether matching instances are included or excluded.
+# Valid values: "include" (default), "exclude".
+[ tag_filter_action: <string> | default = "include" ]
+
+# Maximum number of OCI API calls per second across all operations
+# (ListCompartments, ListInstances, ListVnicAttachments, GetVnic).
+[ rate_limit_rps: <float> | default = 10.0 ]
+
+# The port to scrape metrics from.
+[ port: <int> | default = 80 ]
+
+# The time after which the instances are refreshed.
+[ refresh_interval: <duration> | default = 60s ]
+```
+
 ### `<serverset_sd_config>`
 
 Serverset SD configurations allow retrieving scrape targets from [Serversets](https://github.com/twitter/finagle/tree/develop/finagle-serversets) which are
@@ -3677,6 +3773,10 @@ nerve_sd_configs:
 # List of Nomad service discovery configurations.
 nomad_sd_configs:
   [ - <nomad_sd_config> ... ]
+
+# List of OCI service discovery configurations.
+oci_sd_configs:
+  [ - <oci_sd_config> ... ]
 
 # List of OpenStack service discovery configurations.
 openstack_sd_configs:

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2972,7 +2972,7 @@ The following meta labels are available on all targets during
 
 * `__meta_oci_availability_domain`: the availability domain of the instance (e.g. `US-ASHBURN-AD-1`)
 * `__meta_oci_compartment_id`: the OCID of the compartment the instance belongs to
-* `__meta_oci_defined_tag_<namespace>_<key>`: each defined tag of the instance; string-typed values only
+* `__meta_oci_defined_tag_<namespace>_<key>`: each defined tag of the instance. Scalar values (strings, numbers, booleans) are stringified; non-scalar values are dropped
 * `__meta_oci_fault_domain`: the fault domain of the instance (e.g. `FAULT-DOMAIN-1`)
 * `__meta_oci_image_id`: the OCID of the image the instance was launched from
 * `__meta_oci_instance_id`: the OCID of the instance
@@ -2982,8 +2982,8 @@ The following meta labels are available on all targets during
 * `__meta_oci_private_ip`: the private IP address of the primary VNIC
 * `__meta_oci_public_ip`: the public IP address of the primary VNIC, if assigned
 * `__meta_oci_region`: the OCI region identifier (e.g. `us-ashburn-1`)
-* `__meta_oci_secondary_private_ips`: comma-separated list (surrounded by commas) of private IPs assigned to any attached non-primary VNICs
-* `__meta_oci_secondary_public_ips`: comma-separated list (surrounded by commas) of public IPs assigned to any attached non-primary VNICs
+* `__meta_oci_secondary_private_ips`: sorted comma-separated list (surrounded by commas) of private IPs assigned to any attached non-primary VNICs
+* `__meta_oci_secondary_public_ips`: sorted comma-separated list (surrounded by commas) of public IPs assigned to any attached non-primary VNICs
 * `__meta_oci_tag_<key>`: each freeform tag of the instance
 * `__meta_oci_tenancy_id`: the OCID of the tenancy the instance belongs to
 * `__meta_oci_vnic_id`: the OCID of the primary VNIC
@@ -3032,8 +3032,12 @@ region: <string>
 [ compartments:
   [ - <string> ... ] ]
 
-# Optional display-name substring filter passed to the OCI ListInstances API.
-[ filter: <string> ]
+# Cap on OCI API calls per second across all SD operations
+# (ListCompartments, ListInstances, ListVnicAttachments, GetVnic). The OCI
+# Go SDK's default retry policy already backs off on 429 (TooManyRequests)
+# and 5xx responses, so this is primarily useful for tenancies that enforce
+# a stricter quota. Must be positive.
+[ rate_limit_rps: <float> | default = 500 ]
 
 # Authentication information used to authenticate to the API server.
 # Note that `basic_auth`, `authorization`, and `oauth2` options are

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2944,8 +2944,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 
 OCI SD configurations allow retrieving scrape targets from Oracle Cloud Infrastructure (OCI)
 compute instances. The private IP of the primary VNIC is used as the default address.
-Where no private IP is present (bare-metal instances without secondary VNIC assignment),
-the public IP is used instead.
+Where no private IP is present, the public IP is used instead.
 
 The following OCI IAM policies are required. For API key authentication (user credentials):
 
@@ -2954,7 +2953,6 @@ Allow group <group-name> to read instances in tenancy
 Allow group <group-name> to read compartments in tenancy
 Allow group <group-name> to read vnic-attachments in tenancy
 Allow group <group-name> to read vnics in tenancy
-Allow group <group-name> to read tag-namespaces in tenancy
 ```
 
 For instance principal authentication (Prometheus running on OCI compute):
@@ -2964,7 +2962,6 @@ Allow dynamic-group <dynamic-group-name> to read instances in tenancy
 Allow dynamic-group <dynamic-group-name> to read compartments in tenancy
 Allow dynamic-group <dynamic-group-name> to read vnic-attachments in tenancy
 Allow dynamic-group <dynamic-group-name> to read vnics in tenancy
-Allow dynamic-group <dynamic-group-name> to read tag-namespaces in tenancy
 ```
 
 The following meta labels are available on all targets during
@@ -2982,8 +2979,6 @@ The following meta labels are available on all targets during
 * `__meta_oci_private_ip`: the private IP address of the primary VNIC
 * `__meta_oci_public_ip`: the public IP address of the primary VNIC, if assigned
 * `__meta_oci_region`: the OCI region identifier (e.g. `us-ashburn-1`)
-* `__meta_oci_secondary_private_ips`: sorted comma-separated list (surrounded by commas) of private IPs assigned to any attached non-primary VNICs
-* `__meta_oci_secondary_public_ips`: sorted comma-separated list (surrounded by commas) of public IPs assigned to any attached non-primary VNICs
 * `__meta_oci_tag_<key>`: each freeform tag of the instance
 * `__meta_oci_tenancy_id`: the OCID of the tenancy the instance belongs to
 * `__meta_oci_vnic_id`: the OCID of the primary VNIC

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3032,13 +3032,6 @@ region: <string>
 [ compartments:
   [ - <string> ... ] ]
 
-# Cap on OCI API calls per second across all SD operations
-# (ListCompartments, ListInstances, ListVnicAttachments, GetVnic). The OCI
-# Go SDK's default retry policy already backs off on 429 (TooManyRequests)
-# and 5xx responses, so this is primarily useful for tenancies that enforce
-# a stricter quota. Must be positive.
-[ rate_limit_rps: <float> | default = 500 ]
-
 # Authentication information used to authenticate to the API server.
 # Note that `basic_auth`, `authorization`, and `oauth2` options are
 # mutually exclusive. `password` and `password_file` are mutually exclusive.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2982,8 +2982,11 @@ The following meta labels are available on all targets during
 * `__meta_oci_private_ip`: the private IP address of the primary VNIC
 * `__meta_oci_public_ip`: the public IP address of the primary VNIC, if assigned
 * `__meta_oci_region`: the OCI region identifier (e.g. `us-ashburn-1`)
+* `__meta_oci_secondary_private_ips`: comma-separated list (surrounded by commas) of private IPs assigned to any attached non-primary VNICs
+* `__meta_oci_secondary_public_ips`: comma-separated list (surrounded by commas) of public IPs assigned to any attached non-primary VNICs
 * `__meta_oci_tag_<key>`: each freeform tag of the instance
 * `__meta_oci_tenancy_id`: the OCID of the tenancy the instance belongs to
+* `__meta_oci_vnic_id`: the OCID of the primary VNIC
 
 In tag and namespace names, any character outside `[a-zA-Z0-9_]` is replaced
 with an underscore; case is preserved. For example, a freeform tag named
@@ -2991,6 +2994,10 @@ with an underscore; case is preserved. For example, a freeform tag named
 namespace `Operations` with key `Cost Center` is exposed as
 `__meta_oci_defined_tag_Operations_Cost_Center`. Because case is preserved,
 tag keys that differ only in case (`Env` and `env`) produce distinct labels.
+
+To restrict targets to instances carrying a specific tag, use
+[`relabel_configs`](#relabel_config) with `keep` or `drop` actions matching the
+relevant `__meta_oci_tag_*` or `__meta_oci_defined_tag_*` label.
 
 Targets with no resolvable primary-VNIC IP (neither private nor public) are
 dropped to avoid emitting unscrapeable `:<port>` addresses. The address used
@@ -3007,7 +3014,12 @@ is the private IP when available, falling back to the public IP.
 [ user: <string> ]
 [ fingerprint: <string> ]
 [ key_file: <string> ]
+# Passphrase for the private key. Mutually exclusive with key_passphrase_file.
 [ key_passphrase: <secret> ]
+# Path to a file containing the passphrase for the private key. Mutually
+# exclusive with key_passphrase. The file is read at configuration load
+# time; rotating the file requires reloading Prometheus.
+[ key_passphrase_file: <string> ]
 
 # OCI region identifier. Required.
 region: <string>
@@ -3015,22 +3027,13 @@ region: <string>
 # Explicit list of compartment OCIDs to scan. When empty, all active
 # compartments reachable from the tenancy root are discovered automatically
 # via the OCI Identity API using a breadth-first walk. Compartments that
-# cannot be listed due to missing permissions are silently skipped.
+# cannot be listed due to missing permissions are skipped with a warning so
+# that a single permission gap does not abort the walk.
 [ compartments:
   [ - <string> ... ] ]
 
 # Optional display-name substring filter passed to the OCI ListInstances API.
 [ filter: <string> ]
-
-# Tag-based filtering. When tag_filter_key is set, only instances carrying
-# (include) or lacking (exclude) the given freeform or defined tag key=value
-# pair are returned. Freeform tags are checked before defined tags.
-# The filter is applied before VNIC resolution to avoid unnecessary API calls.
-[ tag_filter_key: <string> ]
-[ tag_filter_value: <string> ]
-# Controls whether matching instances are included or excluded.
-# Valid values: "include" (default), "exclude".
-[ tag_filter_action: <string> | default = "include" ]
 
 # Authentication information used to authenticate to the API server.
 # Note that `basic_auth`, `authorization`, and `oauth2` options are

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2978,12 +2978,23 @@ The following meta labels are available on all targets during
 * `__meta_oci_instance_id`: the OCID of the instance
 * `__meta_oci_instance_name`: the display name of the instance
 * `__meta_oci_instance_shape`: the shape of the instance (e.g. `VM.Standard.E4.Flex`)
-* `__meta_oci_instance_state`: the lifecycle state of the instance (always `RUNNING`)
+* `__meta_oci_instance_state`: the lifecycle state of the instance (e.g. `RUNNING`, `STOPPED`, `TERMINATED`). Use relabeling to restrict scraping to states you care about.
 * `__meta_oci_private_ip`: the private IP address of the primary VNIC
 * `__meta_oci_public_ip`: the public IP address of the primary VNIC, if assigned
 * `__meta_oci_region`: the OCI region identifier (e.g. `us-ashburn-1`)
 * `__meta_oci_tag_<key>`: each freeform tag of the instance
 * `__meta_oci_tenancy_id`: the OCID of the tenancy the instance belongs to
+
+In tag and namespace names, any character outside `[a-zA-Z0-9_]` is replaced
+with an underscore; case is preserved. For example, a freeform tag named
+`appOwner` is exposed as `__meta_oci_tag_appOwner`, and a defined tag in
+namespace `Operations` with key `Cost Center` is exposed as
+`__meta_oci_defined_tag_Operations_Cost_Center`. Because case is preserved,
+tag keys that differ only in case (`Env` and `env`) produce distinct labels.
+
+Targets with no resolvable primary-VNIC IP (neither private nor public) are
+dropped to avoid emitting unscrapeable `:<port>` addresses. The address used
+is the private IP when available, falling back to the public IP.
 
 ```yaml
 # Authentication method. Supported values: "api_key" (default), "instance_principal".
@@ -3021,9 +3032,40 @@ region: <string>
 # Valid values: "include" (default), "exclude".
 [ tag_filter_action: <string> | default = "include" ]
 
-# Maximum number of OCI API calls per second across all operations
-# (ListCompartments, ListInstances, ListVnicAttachments, GetVnic).
-[ rate_limit_rps: <float> | default = 10.0 ]
+# Authentication information used to authenticate to the API server.
+# Note that `basic_auth`, `authorization`, and `oauth2` options are
+# mutually exclusive. `password` and `password_file` are mutually exclusive.
+# It is mostly useful to configure `proxy_url`, `tls_config`, and the
+# underlying HTTP transport when targeting OCI through a corporate proxy
+# or with a custom CA bundle.
+# Optional HTTP basic authentication information, currently not supported by OCI.
+[ basic_auth: <basic_auth> ]
+# Optional `Authorization` header configuration, currently not supported by OCI.
+[ authorization: <authorization> ]
+# Optional OAuth 2.0 configuration, currently not supported by OCI.
+[ oauth2: <oauth2> ]
+
+# Optional proxy URL.
+[ proxy_url: <string> ]
+# Comma-separated string that can contain IPs, CIDR notation, domain names
+# that should be excluded from proxying. IP and domain names can
+# contain port numbers.
+[ no_proxy: <string> ]
+# Use proxy URL indicated by environment variables (HTTP_PROXY, https_proxy, HTTPs_PROXY, https_proxy, and no_proxy)
+[ proxy_from_environment: <boolean> | default: false ]
+# Specifies headers to send to proxies during CONNECT requests.
+[ proxy_connect_header:
+  [ <string>: [<secret>, ...] ] ]
+
+# Configure whether HTTP requests follow HTTP 3xx redirects.
+[ follow_redirects: <boolean> | default = true ]
+
+# Whether to enable HTTP2.
+[ enable_http2: <boolean> | default: true ]
+
+# Configures the TLS settings.
+tls_config:
+  [ <tls_config> ]
 
 # The port to scrape metrics from.
 [ port: <int> | default = 80 ]

--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,7 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.25.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/oracle/oci-go-sdk/v65 v65.117.1 // indirect
 	github.com/pb33f/jsonpath v0.8.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/puzpuzpuz/xsync/v4 v4.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -110,6 +110,12 @@ require (
 )
 
 require (
+	github.com/gofrs/flock v0.10.0 // indirect
+	github.com/sony/gobreaker/v2 v2.4.0 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+)
+
+require (
 	github.com/aws/aws-sdk-go v1.55.8 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.1.4 // indirect
@@ -245,7 +251,7 @@ require (
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/time v0.15.0
 	golang.org/x/tools v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.25.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/oracle/oci-go-sdk/v65 v65.117.1 // indirect
+	github.com/oracle/oci-go-sdk/v65 v65.117.1
 	github.com/pb33f/jsonpath v0.8.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/puzpuzpuz/xsync/v4 v4.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
+github.com/gofrs/flock v0.10.0 h1:SHMXenfaB03KbroETaCMtbBg3Yn29v4w1r+tgy4ff4k=
+github.com/gofrs/flock v0.10.0/go.mod h1:FirDy1Ing0mI2+kB6wk+vyyAH+e6xiE+EYA0jnzV9jc=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -541,6 +543,8 @@ github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c h1:aqg5Vm5dwtvL+Yg
 github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c/go.mod h1:owqhoLW1qZoYLZzLnBw+QkPP9WZnjlSWihhxAJC1+/M=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stackitcloud/stackit-sdk-go/core v0.26.0 h1:jQEb9gkehfp6VCP6TcYk7BI10cz4l0KM2L6hqYBH2QA=
@@ -569,6 +573,8 @@ github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
+github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
+github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -457,6 +457,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/oracle/oci-go-sdk/v65 v65.117.1 h1:DurEtbj8xEuF2B6K73uifNqWJ4dh6CJPADVmNzclrGU=
+github.com/oracle/oci-go-sdk/v65 v65.117.1/go.mod h1:oo33NDf2XPqx3/N6oLG4jFlrqJ0xu4Rlt9SfuAbtDFs=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=

--- a/plugins/plugin_oci.go
+++ b/plugins/plugin_oci.go
@@ -1,0 +1,20 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !remove_all_sd || enable_oci_sd
+
+package plugins
+
+import (
+	_ "github.com/prometheus/prometheus/discovery/oci" // Register oci plugin.
+)


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #18707

---

This adds native service discovery for Oracle Cloud Infrastructure (OCI) compute instances, following the same patterns as existing cloud SD integrations.

The prior attempt (#10226, 2022) was closed over binary size concerns. This implementation addresses that upfront by keeping the concrete SDK clients out of the interface-boxed `Discovery` struct, using closure-based adapters so the linker can drop unused SDK operations. The pattern follows what was done in #18819 (GCE), #18821 (Kubernetes), and #18824 (Azure).

**Authentication**

Two methods supported:

- `api_key` (default): user OCID, fingerprint, RSA key file. Works anywhere Prometheus runs.
- `instance_principal`: uses OCI IMDS. No credentials needed when Prometheus runs on OCI compute.

**Compartment discovery**

OCI organizes resources into compartments (similar to AWS accounts within an organization). Two modes:

- Leave `compartments` unset: the SD walks the tenancy root recursively via the Identity API and discovers all active compartments automatically.
- Set `compartments` to an explicit list: only those compartments are scanned. The Identity client is not created in this case.

**Tag-based filtering**

OCI instances carry freeform tags (key/value strings) and defined tags (namespace/key/value). The SD supports three filtering modes via `tag_filter_key`, `tag_filter_value`, and `tag_filter_action`:

- `include`: only return instances that have the tag
- `exclude`: return all instances except those with the tag
- omit `tag_filter_key`: no filtering, return everything

The filter runs before VNIC resolution, so filtered instances do not trigger additional API calls.

**Rate limiting and retries**

A `rate_limit_rps` field (default 10) caps API calls per second using `golang.org/x/time/rate`. The OCI SDK default retry policy handles transient 429 and 503 responses. Both are shared across all closure-captured clients for the SD instance.

**Error handling**

Compartment-level `ListInstances` failures are logged as warnings and the compartment is skipped, so a single permission gap does not abort the refresh. VNIC resolution failures per instance are also logged and skipped. Compartment listing failures (Identity API) propagate as a refresh error.

**Labels**

```
__meta_oci_instance_id
__meta_oci_instance_name
__meta_oci_instance_state
__meta_oci_instance_shape
__meta_oci_availability_domain
__meta_oci_fault_domain
__meta_oci_region
__meta_oci_tenancy_id
__meta_oci_compartment_id
__meta_oci_image_id
__meta_oci_private_ip
__meta_oci_public_ip
__meta_oci_tag_<key>
__meta_oci_defined_tag_<namespace>_<key>
```

Freeform tag keys and defined tag namespace/key names are lowercased with non-alphanumeric characters replaced by underscores. Only string-typed defined tag values are emitted.

**Required IAM policies**

For API key auth:
```
Allow group <group-name> to read instances in tenancy
Allow group <group-name> to read compartments in tenancy
Allow group <group-name> to read vnic-attachments in tenancy
Allow group <group-name> to read vnics in tenancy
Allow group <group-name> to read tag-namespaces in tenancy
```

For instance principal, replace `group <group-name>` with `dynamic-group <dynamic-group-name>`.

**Testing**

Unit tests use function-type stubs injected directly into the `Discovery` struct. No OCI credentials or network access needed. Tests cover: label building, tag filter all three modes, multi-compartment refresh, per-compartment error skipping, VNIC resolution failures, context cancellation, config validation for both auth methods, and `SetDirectory` for relative key file paths.

---

```release-notes
[FEATURE] OCI: Add native Oracle Cloud Infrastructure compute service discovery.
```