### PR TITLE
feat(promql): add query_log_min_duration configuration to filter query logs 

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1124,6 +1124,7 @@ func main() {
 					return err
 				}
 				queryEngine.SetQueryLogger(l)
+				queryEngine.SetQueryLogMinDuration(time.Duration(cfg.GlobalConfig.QueryLogMinDuration))
 				return nil
 			},
 		}, {

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1115,7 +1115,7 @@ func main() {
 				}
 
 				if cfg.GlobalConfig.QueryLogFile == "" {
-					queryEngine.SetQueryLogger(nil)
+					queryEngine.SetQueryLogger(nil, 0)
 					return nil
 				}
 
@@ -1123,8 +1123,7 @@ func main() {
 				if err != nil {
 					return err
 				}
-				queryEngine.SetQueryLogger(l)
-				queryEngine.SetQueryLogMinDuration(time.Duration(cfg.GlobalConfig.QueryLogMinDuration))
+				queryEngine.SetQueryLogger(l, time.Duration(cfg.GlobalConfig.QueryLogMinDuration))
 				return nil
 			},
 		}, {

--- a/config/config.go
+++ b/config/config.go
@@ -496,6 +496,8 @@ type GlobalConfig struct {
 	RuleQueryOffset model.Duration `yaml:"rule_query_offset,omitempty"`
 	// File to which PromQL queries are logged.
 	QueryLogFile string `yaml:"query_log_file,omitempty"`
+	// Minimum query execution duration to log.
+	QueryLogMinDuration model.Duration `yaml:"query_log_min_duration,omitempty"`
 	// File to which scrape failures are logged.
 	ScrapeFailureLogFile string `yaml:"scrape_failure_log_file,omitempty"`
 	// The labels to add to any timeseries that this Prometheus instance scrapes.
@@ -711,6 +713,7 @@ func (c *GlobalConfig) isZero() bool {
 		c.EvaluationInterval == 0 &&
 		c.RuleQueryOffset == 0 &&
 		c.QueryLogFile == "" &&
+		c.QueryLogMinDuration == 0 &&
 		c.ScrapeFailureLogFile == "" &&
 		c.ScrapeProtocols == nil &&
 		c.ScrapeNativeHistograms == nil &&

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -93,6 +93,7 @@ var expectedConf = &Config{
 		ScrapeTimeout:        DefaultGlobalConfig.ScrapeTimeout,
 		EvaluationInterval:   model.Duration(30 * time.Second),
 		QueryLogFile:         "testdata/query.log",
+		QueryLogMinDuration:  model.Duration(2 * time.Second),
 		ScrapeFailureLogFile: globScrapeFailureLogFile,
 
 		ExternalLabels: labels.FromStrings("foo", "bar", "monitor", "codelab"),

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -9,6 +9,7 @@ global:
   label_name_length_limit: 200
   label_value_length_limit: 200
   query_log_file: query.log
+  query_log_min_duration: 2s
   scrape_failure_log_file: fail.log
   # scrape_timeout is set to the global default (10s).
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -95,6 +95,9 @@ global:
   # Reloading the configuration will reopen the file.
   [ query_log_file: <string> ]
 
+  # Minimum query execution duration to log.
+  [ query_log_min_duration: <duration> | default = 0s ]
+
   # File to which scrape failures are logged.
   # Reloading the configuration will reopen the file.
   [ scrape_failure_log_file: <string> ]

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -95,7 +95,8 @@ global:
   # Reloading the configuration will reopen the file.
   [ query_log_file: <string> ]
 
-  # Minimum query execution duration to log.
+  # Minimum query execution duration to log. Only queries that take longer than
+  # this duration are logged. If 0s (the default) or not set, all queries are logged.
   [ query_log_min_duration: <duration> | default = 0s ]
 
   # File to which scrape failures are logged.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -699,7 +699,7 @@ func (ng *Engine) exec(ctx context.Context, q *query) (v parser.Value, ws annota
 			return
 		}
 		execDuration := time.Duration(q.stats.GetTimer(stats.ExecTotalTime).Duration() * float64(time.Second))
-		if execDuration < ng.queryLogMinDuration {
+		if err == nil && execDuration < ng.queryLogMinDuration {
 			return
 		}
 		logger := slog.New(l)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -701,7 +701,7 @@ func (ng *Engine) exec(ctx context.Context, q *query) (v parser.Value, ws annota
 	defer func() {
 		ng.queryLoggerLock.RLock()
 		if l := ng.queryLogger; l != nil {
-			execDuration := q.stats.GetTimer(stats.ExecTotalTime).TotalDuration()
+			execDuration := time.Duration(q.stats.GetTimer(stats.ExecTotalTime).Duration() * float64(time.Second))
 			if execDuration >= ng.queryLogMinDuration {
 				logger := slog.New(l)
 				f := make([]slog.Attr, 0, 16) // Probably enough up front to not need to reallocate on append.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -514,12 +514,12 @@ func (ng *Engine) Close() error {
 	return nil
 }
 
-// SetQueryLogger sets the query logger.
-func (ng *Engine) SetQueryLogger(l QueryLogger) {
+// SetQueryLogger sets the query logger and the minimum query duration to be logged.
+func (ng *Engine) SetQueryLogger(l QueryLogger, minDuration time.Duration) {
 	ng.queryLoggerLock.Lock()
 	defer ng.queryLoggerLock.Unlock()
 
-	if ng.queryLogger != nil {
+	if ng.queryLogger != nil && ng.queryLogger != l {
 		// An error closing the old file descriptor should
 		// not make reload fail; only log a warning.
 		err := ng.queryLogger.Close()
@@ -529,20 +529,13 @@ func (ng *Engine) SetQueryLogger(l QueryLogger) {
 	}
 
 	ng.queryLogger = l
+	ng.queryLogMinDuration = minDuration
 
 	if l != nil {
 		ng.metrics.queryLogEnabled.Set(1)
 	} else {
 		ng.metrics.queryLogEnabled.Set(0)
 	}
-}
-
-// SetQueryLogMinDuration sets the minimum query duration to be logged.
-func (ng *Engine) SetQueryLogMinDuration(d time.Duration) {
-	ng.queryLoggerLock.Lock()
-	defer ng.queryLoggerLock.Unlock()
-
-	ng.queryLogMinDuration = d
 }
 
 // NewInstantQuery returns an evaluation query for the given expression at the given time.
@@ -700,44 +693,47 @@ func (ng *Engine) exec(ctx context.Context, q *query) (v parser.Value, ws annota
 
 	defer func() {
 		ng.queryLoggerLock.RLock()
-		if l := ng.queryLogger; l != nil {
-			execDuration := time.Duration(q.stats.GetTimer(stats.ExecTotalTime).Duration() * float64(time.Second))
-			if execDuration >= ng.queryLogMinDuration {
-				logger := slog.New(l)
-				f := make([]slog.Attr, 0, 16) // Probably enough up front to not need to reallocate on append.
+		defer ng.queryLoggerLock.RUnlock()
+		l := ng.queryLogger
+		if l == nil {
+			return
+		}
+		execDuration := time.Duration(q.stats.GetTimer(stats.ExecTotalTime).Duration() * float64(time.Second))
+		if execDuration < ng.queryLogMinDuration {
+			return
+		}
+		logger := slog.New(l)
+		f := make([]slog.Attr, 0, 16) // Probably enough up front to not need to reallocate on append.
 
-				params := make(map[string]any, 4)
-				params["query"] = q.q
-				if eq, ok := q.Statement().(*parser.EvalStmt); ok {
-					params["start"] = formatDate(eq.Start)
-					params["end"] = formatDate(eq.End)
-					// The step provided by the user is in seconds.
-					params["step"] = int64(eq.Interval / (time.Second / time.Nanosecond))
-				}
-				f = append(f, slog.Any("params", params))
-				if err != nil {
-					f = append(f, slog.Any("error", err))
-				}
-				f = append(f, slog.Any("stats", stats.NewQueryStats(q.Stats())))
-				if span := trace.SpanFromContext(ctx); span != nil {
-					spanCtx := span.SpanContext()
-					f = append(f,
-						slog.Any("spanID", spanCtx.SpanID()),
-						slog.Any("traceID", spanCtx.TraceID()),
-					)
-				}
-				if origin := ctx.Value(QueryOrigin{}); origin != nil {
-					for k, v := range origin.(map[string]any) {
-						f = append(f, slog.Any(k, v))
-					}
-				}
-				logger.LogAttrs(context.Background(), slog.LevelInfo, "promql query logged", f...)
-				// TODO: @tjhop -- do we still need this metric/error log if logger doesn't return errors?
-				// ng.metrics.queryLogFailures.Inc()
-				// ng.logger.Error("can't log query", "err", err)
+		params := make(map[string]any, 4)
+		params["query"] = q.q
+		if eq, ok := q.Statement().(*parser.EvalStmt); ok {
+			params["start"] = formatDate(eq.Start)
+			params["end"] = formatDate(eq.End)
+			// The step provided by the user is in seconds.
+			params["step"] = int64(eq.Interval / (time.Second / time.Nanosecond))
+		}
+		f = append(f, slog.Any("params", params))
+		if err != nil {
+			f = append(f, slog.Any("error", err))
+		}
+		f = append(f, slog.Any("stats", stats.NewQueryStats(q.Stats())))
+		if span := trace.SpanFromContext(ctx); span != nil {
+			spanCtx := span.SpanContext()
+			f = append(f,
+				slog.Any("spanID", spanCtx.SpanID()),
+				slog.Any("traceID", spanCtx.TraceID()),
+			)
+		}
+		if origin := ctx.Value(QueryOrigin{}); origin != nil {
+			for k, v := range origin.(map[string]any) {
+				f = append(f, slog.Any(k, v))
 			}
 		}
-		ng.queryLoggerLock.RUnlock()
+		logger.LogAttrs(context.Background(), slog.LevelInfo, "promql query logged", f...)
+		// TODO: @tjhop -- do we still need this metric/error log if logger doesn't return errors?
+		// ng.metrics.queryLogFailures.Inc()
+		// ng.logger.Error("can't log query", "err", err)
 	}()
 
 	execSpanTimer, ctx := q.stats.GetSpanTimer(ctx, stats.ExecTotalTime)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -701,7 +701,7 @@ func (ng *Engine) exec(ctx context.Context, q *query) (v parser.Value, ws annota
 	defer func() {
 		ng.queryLoggerLock.RLock()
 		if l := ng.queryLogger; l != nil {
-			execDuration := time.Duration(q.stats.GetTimer(stats.ExecTotalTime).Duration() * float64(time.Second))
+			execDuration := q.stats.GetTimer(stats.ExecTotalTime).TotalDuration()
 			if execDuration >= ng.queryLogMinDuration {
 				logger := slog.New(l)
 				f := make([]slog.Attr, 0, 16) // Probably enough up front to not need to reallocate on append.

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -302,6 +302,9 @@ type EngineOpts struct {
 	MaxSamples         int
 	Timeout            time.Duration
 	ActiveQueryTracker QueryTracker
+	// QueryLogMinDuration specifies the minimum execution duration a query must
+	// have to be logged.
+	QueryLogMinDuration time.Duration
 	// LookbackDelta determines the time since the last sample after which a time
 	// series is considered stale.
 	LookbackDelta time.Duration
@@ -353,6 +356,7 @@ type Engine struct {
 	activeQueryTracker       QueryTracker
 	queryLogger              QueryLogger
 	queryLoggerLock          sync.RWMutex
+	queryLogMinDuration      time.Duration
 	lookbackDelta            time.Duration
 	noStepSubqueryIntervalFn func(rangeMillis int64) int64
 	enableAtModifier         bool
@@ -483,6 +487,7 @@ func NewEngine(opts EngineOpts) *Engine {
 		metrics:                  metrics,
 		maxSamplesPerQuery:       opts.MaxSamples,
 		activeQueryTracker:       opts.ActiveQueryTracker,
+		queryLogMinDuration:      opts.QueryLogMinDuration,
 		lookbackDelta:            opts.LookbackDelta,
 		noStepSubqueryIntervalFn: opts.NoStepSubqueryIntervalFn,
 		enableAtModifier:         opts.EnableAtModifier,
@@ -530,6 +535,14 @@ func (ng *Engine) SetQueryLogger(l QueryLogger) {
 	} else {
 		ng.metrics.queryLogEnabled.Set(0)
 	}
+}
+
+// SetQueryLogMinDuration sets the minimum query duration to be logged.
+func (ng *Engine) SetQueryLogMinDuration(d time.Duration) {
+	ng.queryLoggerLock.Lock()
+	defer ng.queryLoggerLock.Unlock()
+
+	ng.queryLogMinDuration = d
 }
 
 // NewInstantQuery returns an evaluation query for the given expression at the given time.
@@ -688,38 +701,41 @@ func (ng *Engine) exec(ctx context.Context, q *query) (v parser.Value, ws annota
 	defer func() {
 		ng.queryLoggerLock.RLock()
 		if l := ng.queryLogger; l != nil {
-			logger := slog.New(l)
-			f := make([]slog.Attr, 0, 16) // Probably enough up front to not need to reallocate on append.
+			execDuration := time.Duration(q.stats.GetTimer(stats.ExecTotalTime).Duration() * float64(time.Second))
+			if execDuration >= ng.queryLogMinDuration {
+				logger := slog.New(l)
+				f := make([]slog.Attr, 0, 16) // Probably enough up front to not need to reallocate on append.
 
-			params := make(map[string]any, 4)
-			params["query"] = q.q
-			if eq, ok := q.Statement().(*parser.EvalStmt); ok {
-				params["start"] = formatDate(eq.Start)
-				params["end"] = formatDate(eq.End)
-				// The step provided by the user is in seconds.
-				params["step"] = int64(eq.Interval / (time.Second / time.Nanosecond))
-			}
-			f = append(f, slog.Any("params", params))
-			if err != nil {
-				f = append(f, slog.Any("error", err))
-			}
-			f = append(f, slog.Any("stats", stats.NewQueryStats(q.Stats())))
-			if span := trace.SpanFromContext(ctx); span != nil {
-				spanCtx := span.SpanContext()
-				f = append(f,
-					slog.Any("spanID", spanCtx.SpanID()),
-					slog.Any("traceID", spanCtx.TraceID()),
-				)
-			}
-			if origin := ctx.Value(QueryOrigin{}); origin != nil {
-				for k, v := range origin.(map[string]any) {
-					f = append(f, slog.Any(k, v))
+				params := make(map[string]any, 4)
+				params["query"] = q.q
+				if eq, ok := q.Statement().(*parser.EvalStmt); ok {
+					params["start"] = formatDate(eq.Start)
+					params["end"] = formatDate(eq.End)
+					// The step provided by the user is in seconds.
+					params["step"] = int64(eq.Interval / (time.Second / time.Nanosecond))
 				}
+				f = append(f, slog.Any("params", params))
+				if err != nil {
+					f = append(f, slog.Any("error", err))
+				}
+				f = append(f, slog.Any("stats", stats.NewQueryStats(q.Stats())))
+				if span := trace.SpanFromContext(ctx); span != nil {
+					spanCtx := span.SpanContext()
+					f = append(f,
+						slog.Any("spanID", spanCtx.SpanID()),
+						slog.Any("traceID", spanCtx.TraceID()),
+					)
+				}
+				if origin := ctx.Value(QueryOrigin{}); origin != nil {
+					for k, v := range origin.(map[string]any) {
+						f = append(f, slog.Any(k, v))
+					}
+				}
+				logger.LogAttrs(context.Background(), slog.LevelInfo, "promql query logged", f...)
+				// TODO: @tjhop -- do we still need this metric/error log if logger doesn't return errors?
+				// ng.metrics.queryLogFailures.Inc()
+				// ng.logger.Error("can't log query", "err", err)
 			}
-			logger.LogAttrs(context.Background(), slog.LevelInfo, "promql query logged", f...)
-			// TODO: @tjhop -- do we still need this metric/error log if logger doesn't return errors?
-			// ng.metrics.queryLogFailures.Inc()
-			// ng.logger.Error("can't log query", "err", err)
 		}
 		ng.queryLoggerLock.RUnlock()
 	}()

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -2462,6 +2462,47 @@ func TestQueryLogger_error(t *testing.T) {
 	require.Contains(t, logLines[0], "params", map[string]any{"query": "test statement"})
 }
 
+func TestQueryLogger_minDuration(t *testing.T) {
+	opts := promql.EngineOpts{
+		Logger:     nil,
+		Reg:        nil,
+		MaxSamples: 10,
+		Timeout:    10 * time.Second,
+	}
+	engine := promqltest.NewTestEngineWithOpts(t, opts)
+
+	queryExecWithDelay := func(delay time.Duration) {
+		ctx, cancelCtx := context.WithCancel(context.Background())
+		defer cancelCtx()
+		query := engine.NewTestQuery(func(ctx context.Context) error {
+			time.Sleep(delay)
+			return contextDone(ctx, "test statement execution")
+		})
+		res := query.Exec(ctx)
+		require.NoError(t, res.Err)
+	}
+
+	tmpDir := t.TempDir()
+	qlFile := filepath.Join(tmpDir, "query_duration.log")
+	f, err := logging.NewJSONFileLogger(qlFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	engine.SetQueryLogger(f)
+
+	// Test 1: Log threshold is 50ms, query takes 1ms. Should NOT log.
+	engine.SetQueryLogMinDuration(50 * time.Millisecond)
+	queryExecWithDelay(1 * time.Millisecond)
+	logLines := getLogLines(t, qlFile)
+	require.Len(t, logLines, 0)
+
+	// Test 2: Log threshold is 5ms, query takes 50ms. Should log.
+	engine.SetQueryLogMinDuration(5 * time.Millisecond)
+	queryExecWithDelay(50 * time.Millisecond)
+	logLines = getLogLines(t, qlFile)
+	require.Len(t, logLines, 1)
+}
+
 func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 	startTime := time.Unix(1000, 0)
 	endTime := time.Unix(9999, 0)

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -20,11 +20,13 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 
@@ -2471,14 +2473,27 @@ func TestQueryLogger_minDuration(t *testing.T) {
 	}
 	engine := promqltest.NewTestEngineWithOpts(t, opts)
 
-	queryExecWithDelay := func(delay time.Duration) {
+	queryExec := func(mockDuration time.Duration) {
 		ctx, cancelCtx := context.WithCancel(context.Background())
 		defer cancelCtx()
-		query := engine.NewTestQuery(func(ctx context.Context) error {
-			time.Sleep(delay)
+		var qry promql.Query
+		qry = engine.NewTestQuery(func(ctx context.Context) error {
+			if mockDuration > 0 {
+				val := reflect.ValueOf(qry).Elem()
+				statsField := val.FieldByName("stats")
+				ptrToQueryTimersPtr := unsafe.Pointer(statsField.UnsafeAddr())
+				queryTimers := *(* *stats.QueryTimers)(ptrToQueryTimersPtr)
+				timerGroup := queryTimers.TimerGroup
+
+				timer := timerGroup.GetTimer(stats.ExecTotalTime)
+				timerVal := reflect.ValueOf(timer).Elem()
+				field := timerVal.FieldByName("start")
+				ptr := unsafe.Pointer(field.UnsafeAddr())
+				*(*time.Time)(ptr) = time.Now().Add(-mockDuration)
+			}
 			return contextDone(ctx, "test statement execution")
 		})
-		res := query.Exec(ctx)
+		res := qry.Exec(ctx)
 		require.NoError(t, res.Err)
 	}
 
@@ -2492,13 +2507,13 @@ func TestQueryLogger_minDuration(t *testing.T) {
 
 	// Test 1: Log threshold is 10m, query takes 1ms. Should NOT log.
 	engine.SetQueryLogMinDuration(10 * time.Minute)
-	queryExecWithDelay(1 * time.Millisecond)
+	queryExec(1 * time.Millisecond)
 	logLines := getLogLines(t, qlFile)
 	require.Empty(t, logLines)
 
 	// Test 2: Log threshold is 1ms, query takes 100ms. Should log.
 	engine.SetQueryLogMinDuration(1 * time.Millisecond)
-	queryExecWithDelay(100 * time.Millisecond)
+	queryExec(100 * time.Millisecond)
 	logLines = getLogLines(t, qlFile)
 	require.Len(t, logLines, 1)
 }

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -2502,6 +2502,26 @@ func TestQueryLogger_minDuration(t *testing.T) {
 	queryExec(20 * time.Millisecond)
 	logLines = getLogLines(t, qlFile)
 	require.Len(t, logLines, 1)
+
+	// Test 3: Log threshold is 10m, query takes 1ms, but errors. Should log.
+	engine.SetQueryLogger(f, 10*time.Minute)
+	queryExecError := func(mockDuration time.Duration) {
+		ctx, cancelCtx := context.WithCancel(context.Background())
+		defer cancelCtx()
+		var qry promql.Query
+		qry = engine.NewTestQuery(func(_ context.Context) error {
+			if mockDuration > 0 {
+				qry.Stats().Timers.GetTimer(stats.ExecTotalTime).SetDuration(mockDuration)
+			}
+			return errors.New("query execution error")
+		})
+		res := qry.Exec(ctx)
+		require.Error(t, res.Err)
+	}
+	queryExecError(1 * time.Millisecond)
+	logLines = getLogLines(t, qlFile)
+	require.Len(t, logLines, 2)
+	require.Contains(t, logLines[1], "error", "query execution error")
 }
 
 func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -2494,7 +2494,7 @@ func TestQueryLogger_minDuration(t *testing.T) {
 	engine.SetQueryLogMinDuration(50 * time.Millisecond)
 	queryExecWithDelay(1 * time.Millisecond)
 	logLines := getLogLines(t, qlFile)
-	require.Len(t, logLines, 0)
+	require.Empty(t, logLines)
 
 	// Test 2: Log threshold is 5ms, query takes 50ms. Should log.
 	engine.SetQueryLogMinDuration(5 * time.Millisecond)

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -20,13 +20,11 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 	"sync"
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/stretchr/testify/require"
 
@@ -2360,7 +2358,7 @@ func TestQueryLogger_basic(t *testing.T) {
 	f1, err := logging.NewJSONFileLogger(ql1File)
 	require.NoError(t, err)
 
-	engine.SetQueryLogger(f1)
+	engine.SetQueryLogger(f1, 0)
 	queryExec()
 	logLines := getLogLines(t, ql1File)
 	require.Contains(t, logLines[0], "params", map[string]any{"query": "test statement"})
@@ -2374,7 +2372,7 @@ func TestQueryLogger_basic(t *testing.T) {
 
 	// Test that we close the query logger when unsetting it. The following
 	// attempt to close the file should error.
-	engine.SetQueryLogger(nil)
+	engine.SetQueryLogger(nil, 0)
 	err = f1.Close()
 	require.ErrorContains(t, err, "file already closed", "expected f1 to be closed, got open")
 	queryExec()
@@ -2386,9 +2384,9 @@ func TestQueryLogger_basic(t *testing.T) {
 	ql3File := filepath.Join(tmpDir, "query3.log")
 	f3, err := logging.NewJSONFileLogger(ql3File)
 	require.NoError(t, err)
-	engine.SetQueryLogger(f2)
+	engine.SetQueryLogger(f2, 0)
 	queryExec()
-	engine.SetQueryLogger(f3)
+	engine.SetQueryLogger(f3, 0)
 	err = f2.Close()
 	require.ErrorContains(t, err, "file already closed", "expected f2 to be closed, got open")
 	queryExec()
@@ -2413,7 +2411,7 @@ func TestQueryLogger_fields(t *testing.T) {
 		require.NoError(t, f1.Close())
 	})
 
-	engine.SetQueryLogger(f1)
+	engine.SetQueryLogger(f1, 0)
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	ctx = promql.NewOriginContext(ctx, map[string]any{"foo": "bar"})
@@ -2446,7 +2444,7 @@ func TestQueryLogger_error(t *testing.T) {
 		require.NoError(t, f1.Close())
 	})
 
-	engine.SetQueryLogger(f1)
+	engine.SetQueryLogger(f1, 0)
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	ctx = promql.NewOriginContext(ctx, map[string]any{"foo": "bar"})
@@ -2479,17 +2477,7 @@ func TestQueryLogger_minDuration(t *testing.T) {
 		var qry promql.Query
 		qry = engine.NewTestQuery(func(ctx context.Context) error {
 			if mockDuration > 0 {
-				val := reflect.ValueOf(qry).Elem()
-				statsField := val.FieldByName("stats")
-				ptrToQueryTimersPtr := unsafe.Pointer(statsField.UnsafeAddr())
-				queryTimers := *(* *stats.QueryTimers)(ptrToQueryTimersPtr)
-				timerGroup := queryTimers.TimerGroup
-
-				timer := timerGroup.GetTimer(stats.ExecTotalTime)
-				timerVal := reflect.ValueOf(timer).Elem()
-				field := timerVal.FieldByName("start")
-				ptr := unsafe.Pointer(field.UnsafeAddr())
-				*(*time.Time)(ptr) = time.Now().Add(-mockDuration)
+				qry.Stats().Timers.GetTimer(stats.ExecTotalTime).SetDuration(mockDuration)
 			}
 			return contextDone(ctx, "test statement execution")
 		})
@@ -2503,17 +2491,15 @@ func TestQueryLogger_minDuration(t *testing.T) {
 	require.NoError(t, err)
 	defer f.Close()
 
-	engine.SetQueryLogger(f)
-
 	// Test 1: Log threshold is 10m, query takes 1ms. Should NOT log.
-	engine.SetQueryLogMinDuration(10 * time.Minute)
+	engine.SetQueryLogger(f, 10*time.Minute)
 	queryExec(1 * time.Millisecond)
 	logLines := getLogLines(t, qlFile)
 	require.Empty(t, logLines)
 
-	// Test 2: Log threshold is 1ms, query takes 100ms. Should log.
-	engine.SetQueryLogMinDuration(1 * time.Millisecond)
-	queryExec(100 * time.Millisecond)
+	// Test 2: Log threshold is 1ms, query takes 20ms. Should log.
+	engine.SetQueryLogger(f, 1*time.Millisecond)
+	queryExec(20 * time.Millisecond)
 	logLines = getLogLines(t, qlFile)
 	require.Len(t, logLines, 1)
 }

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -2490,15 +2490,15 @@ func TestQueryLogger_minDuration(t *testing.T) {
 
 	engine.SetQueryLogger(f)
 
-	// Test 1: Log threshold is 50ms, query takes 1ms. Should NOT log.
-	engine.SetQueryLogMinDuration(50 * time.Millisecond)
+	// Test 1: Log threshold is 10m, query takes 1ms. Should NOT log.
+	engine.SetQueryLogMinDuration(10 * time.Minute)
 	queryExecWithDelay(1 * time.Millisecond)
 	logLines := getLogLines(t, qlFile)
 	require.Empty(t, logLines)
 
-	// Test 2: Log threshold is 5ms, query takes 50ms. Should log.
-	engine.SetQueryLogMinDuration(5 * time.Millisecond)
-	queryExecWithDelay(50 * time.Millisecond)
+	// Test 2: Log threshold is 1ms, query takes 100ms. Should log.
+	engine.SetQueryLogMinDuration(1 * time.Millisecond)
+	queryExecWithDelay(100 * time.Millisecond)
 	logLines = getLogLines(t, qlFile)
 	require.Len(t, logLines, 1)
 }

--- a/util/stats/timer.go
+++ b/util/stats/timer.go
@@ -55,7 +55,6 @@ func (t *Timer) SetDuration(d time.Duration) {
 	t.duration = d
 }
 
-
 // Return a string representation of the Timer.
 func (t *Timer) String() string {
 	return fmt.Sprintf("%s: %s", t.name, t.duration)

--- a/util/stats/timer.go
+++ b/util/stats/timer.go
@@ -50,6 +50,11 @@ func (t *Timer) Duration() float64 {
 	return t.duration.Seconds()
 }
 
+// TotalDuration returns the total duration value of the timer.
+func (t *Timer) TotalDuration() time.Duration {
+	return t.duration
+}
+
 // Return a string representation of the Timer.
 func (t *Timer) String() string {
 	return fmt.Sprintf("%s: %s", t.name, t.duration)

--- a/util/stats/timer.go
+++ b/util/stats/timer.go
@@ -50,6 +50,11 @@ func (t *Timer) Duration() float64 {
 	return t.duration.Seconds()
 }
 
+// SetDuration sets the duration of the timer. This is primarily used for testing.
+func (t *Timer) SetDuration(d time.Duration) {
+	t.duration = d
+}
+
 
 // Return a string representation of the Timer.
 func (t *Timer) String() string {

--- a/util/stats/timer.go
+++ b/util/stats/timer.go
@@ -50,10 +50,6 @@ func (t *Timer) Duration() float64 {
 	return t.duration.Seconds()
 }
 
-// TotalDuration returns the total duration value of the timer.
-func (t *Timer) TotalDuration() time.Duration {
-	return t.duration
-}
 
 // Return a string representation of the Timer.
 func (t *Timer) String() string {


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #18920

#### Description of changes
This PR introduces the `query_log_min_duration` configuration under global settings to filter query logs by execution duration.

When configured, only queries that take longer than the specified duration to evaluate will be logged. If not configured (or set to `0s`), all queries will be logged, maintaining backward compatibility.

Key additions:
- Added `QueryLogMinDuration` configuration in `GlobalConfig`.
- Exposed `SetQueryLogMinDuration(time.Duration)` on the PromQL engine.
- Integrated engine configuration updates on reload in `main.go`.
- Added unit test `TestQueryLogger_minDuration` to verify that execution duration thresholds work correctly.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[FEATURE] PromQL: Add query_log_min_duration configuration to filter query logs by execution time.
```
