### PR TITLE
util: add t.Parallel() to speed up tests

### DIFF
--- a/util/almost/almost_test.go
+++ b/util/almost/almost_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestEqual(t *testing.T) {
+	t.Parallel()
 	staleNaN := math.Float64frombits(value.StaleNaN)
 	tests := []struct {
 		a       float64

--- a/util/annotations/annotations_test.go
+++ b/util/annotations/annotations_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestAnnotations_AsStrings(t *testing.T) {
+	t.Parallel()
 	var annos Annotations
 	pos := posrange.PositionRange{Start: 3, End: 8}
 

--- a/util/compression/compression_test.go
+++ b/util/compression/compression_test.go
@@ -41,6 +41,7 @@ ddddddddddsfpgjsdoadjgfpajdspfgjasfjapddddddddddaaaaaaaa145
 `
 
 func TestEncodeDecode(t *testing.T) {
+	t.Parallel()
 	for _, tcase := range []struct {
 		name string
 

--- a/util/convertnhcb/convertnhcb_test.go
+++ b/util/convertnhcb/convertnhcb_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestNHCBConvert(t *testing.T) {
+	t.Parallel()
 	tests := map[string]struct {
 		setup       func() *TempHistogram
 		expectedErr error

--- a/util/fmtutil/format_test.go
+++ b/util/fmtutil/format_test.go
@@ -177,6 +177,7 @@ var writeRequestFixture = &prompb.WriteRequest{
 }
 
 func TestParseAndPushMetricsTextAndFormat(t *testing.T) {
+	t.Parallel()
 	input := bytes.NewReader([]byte(`
 	# HELP http_request_duration_seconds A histogram of the request duration.
 	# TYPE http_request_duration_seconds histogram
@@ -211,6 +212,7 @@ func TestParseAndPushMetricsTextAndFormat(t *testing.T) {
 }
 
 func TestMetricTextToWriteRequestErrorParsingFloatValue(t *testing.T) {
+	t.Parallel()
 	input := bytes.NewReader([]byte(`
 	# HELP http_requests_total The total number of HTTP requests.
 	# TYPE http_requests_total counter
@@ -224,6 +226,7 @@ func TestMetricTextToWriteRequestErrorParsingFloatValue(t *testing.T) {
 }
 
 func TestMetricTextToWriteRequestErrorParsingMetricType(t *testing.T) {
+	t.Parallel()
 	input := bytes.NewReader([]byte(`
 	# HELP node_info node info summary.
 	# TYPE node_info info
@@ -236,6 +239,7 @@ func TestMetricTextToWriteRequestErrorParsingMetricType(t *testing.T) {
 }
 
 func TestMakeTimeseries_HistogramInfBucket(t *testing.T) {
+	t.Parallel()
 	tests := map[string]*dto.Histogram{
 		"Histogram missing +Inf bucket": {
 			Bucket: []*dto.Bucket{

--- a/util/httputil/cors_test.go
+++ b/util/httputil/cors_test.go
@@ -31,6 +31,7 @@ func getCORSHandlerFunc() http.Handler {
 }
 
 func TestCORSHandler(t *testing.T) {
+	t.Parallel()
 	tearDown := setup()
 	defer tearDown()
 	client := &http.Client{}

--- a/util/junitxml/junitxml_test.go
+++ b/util/junitxml/junitxml_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestJunitOutput(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var test JUnitXML
 	x := FakeTestSuites()

--- a/util/kahansum/kahansum_test.go
+++ b/util/kahansum/kahansum_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestIsInf(t *testing.T) {
+	t.Parallel()
 	for _, f := range []float64{
 		math.Inf(1),
 		math.Inf(-1),

--- a/util/logging/dedupe_test.go
+++ b/util/logging/dedupe_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestDedupe(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	d := Dedupe(promslog.New(&promslog.Config{Writer: &buf}), 100*time.Millisecond)
 	dlog := slog.New(d)
@@ -60,6 +61,7 @@ func TestDedupe(t *testing.T) {
 }
 
 func TestDedupeConcurrent(t *testing.T) {
+	t.Parallel()
 	d := Dedupe(promslog.New(&promslog.Config{}), 250*time.Millisecond)
 	dlog := slog.New(d)
 	defer d.Stop()
@@ -92,6 +94,7 @@ func (fl *fakeWarningLogger) HandleWarningHeaderWithContext(_ context.Context, _
 }
 
 func TestDedupeDeprecationWarningLogger(t *testing.T) {
+	t.Parallel()
 	wl := DedupDeprecationWarningLogger{
 		logger: &fakeWarningLogger{},
 		logged: make(map[string]struct{}),

--- a/util/logging/file_test.go
+++ b/util/logging/file_test.go
@@ -37,6 +37,7 @@ func getLogLines(t *testing.T, name string) []string {
 }
 
 func TestJSONFileLogger_basic(t *testing.T) {
+	t.Parallel()
 	f, err := os.CreateTemp("", "logging")
 	require.NoError(t, err)
 	defer func() {
@@ -66,6 +67,7 @@ func TestJSONFileLogger_basic(t *testing.T) {
 }
 
 func TestJSONFileLogger_parallel(t *testing.T) {
+	t.Parallel()
 	f, err := os.CreateTemp("", "logging")
 	require.NoError(t, err)
 	defer func() {

--- a/util/namevalidationutil/namevalidationutil_test.go
+++ b/util/namevalidationutil/namevalidationutil_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestCheckNameValidationScheme(t *testing.T) {
+	t.Parallel()
 	require.NoError(t, CheckNameValidationScheme(model.UTF8Validation))
 	require.NoError(t, CheckNameValidationScheme(model.LegacyValidation))
 	require.EqualError(t, CheckNameValidationScheme(model.UnsetValidation), "unset nameValidationScheme")

--- a/util/netconnlimit/netconnlimit_test.go
+++ b/util/netconnlimit/netconnlimit_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestSharedLimitListenerConcurrency(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name        string
 		semCapacity int
@@ -106,6 +107,7 @@ func TestSharedLimitListenerConcurrency(t *testing.T) {
 }
 
 func TestSharedLimitListenerClose(t *testing.T) {
+	t.Parallel()
 	sem := NewSharedSemaphore(2)
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err, "failed to create listener")

--- a/util/notifications/notifications_test.go
+++ b/util/notifications/notifications_test.go
@@ -23,6 +23,7 @@ import (
 
 // TestNotificationLifecycle tests adding, modifying, and deleting notifications.
 func TestNotificationLifecycle(t *testing.T) {
+	t.Parallel()
 	notifs := NewNotifications(10, nil)
 
 	// Add a notification.
@@ -47,6 +48,7 @@ func TestNotificationLifecycle(t *testing.T) {
 
 // TestSubscriberReceivesNotifications tests that a subscriber receives notifications, including modifications and deletions.
 func TestSubscriberReceivesNotifications(t *testing.T) {
+	t.Parallel()
 	notifs := NewNotifications(10, nil)
 
 	// Subscribe to notifications.
@@ -104,6 +106,7 @@ func TestSubscriberReceivesNotifications(t *testing.T) {
 
 // TestMultipleSubscribers tests that multiple subscribers receive notifications independently.
 func TestMultipleSubscribers(t *testing.T) {
+	t.Parallel()
 	notifs := NewNotifications(10, nil)
 
 	// Subscribe two subscribers to notifications.
@@ -160,6 +163,7 @@ func TestMultipleSubscribers(t *testing.T) {
 
 // TestUnsubscribe tests that unsubscribing prevents further notifications from being received.
 func TestUnsubscribe(t *testing.T) {
+	t.Parallel()
 	notifs := NewNotifications(10, nil)
 
 	// Subscribe to notifications.
@@ -197,6 +201,7 @@ func TestUnsubscribe(t *testing.T) {
 
 // TestMaxSubscribers tests that exceeding the max subscribers limit prevents additional subscriptions.
 func TestMaxSubscribers(t *testing.T) {
+	t.Parallel()
 	maxSubscribers := 2
 	notifs := NewNotifications(maxSubscribers, nil)
 

--- a/util/pool/pool_test.go
+++ b/util/pool/pool_test.go
@@ -24,6 +24,7 @@ func makeFunc(size int) any {
 }
 
 func TestPool(t *testing.T) {
+	t.Parallel()
 	testPool := New(1, 8, 2, makeFunc)
 	cases := []struct {
 		size        int

--- a/util/runtime/statfs_unix_test.go
+++ b/util/runtime/statfs_unix_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestFsType(t *testing.T) {
+	t.Parallel()
 	var fsType string
 
 	path, err := os.Getwd()
@@ -40,6 +41,7 @@ func TestFsType(t *testing.T) {
 }
 
 func TestFsSize(t *testing.T) {
+	t.Parallel()
 	var size uint64
 
 	path, err := os.Getwd()

--- a/util/runtime/statfs_windows_test.go
+++ b/util/runtime/statfs_windows_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestFsType(t *testing.T) {
+	t.Parallel()
 	var fsType string
 
 	path, err := os.Getwd()
@@ -36,6 +37,7 @@ func TestFsType(t *testing.T) {
 }
 
 func TestFsSize(t *testing.T) {
+	t.Parallel()
 	var size uint64
 
 	size = FsSize("C:\\")

--- a/util/stats/stats_test.go
+++ b/util/stats/stats_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestTimerGroupNewTimer(t *testing.T) {
+	t.Parallel()
 	tg := NewTimerGroup()
 	timer := tg.GetTimer(ExecTotalTime)
 	duration := timer.Duration()
@@ -42,6 +43,7 @@ func TestTimerGroupNewTimer(t *testing.T) {
 }
 
 func TestQueryStatsWithTimersAndSamples(t *testing.T) {
+	t.Parallel()
 	qt := NewQueryTimers()
 	qs := NewQuerySamples(true)
 	qs.InitStepTracking(20001000, 25001000, 1000000)
@@ -65,6 +67,7 @@ func TestQueryStatsWithTimersAndSamples(t *testing.T) {
 }
 
 func TestQueryStatsWithSpanTimers(t *testing.T) {
+	t.Parallel()
 	qt := NewQueryTimers()
 	qs := NewQuerySamples(false)
 	ctx := &testutil.MockContext{DoneCh: make(chan struct{})}
@@ -81,6 +84,7 @@ func TestQueryStatsWithSpanTimers(t *testing.T) {
 }
 
 func TestTimerGroup(t *testing.T) {
+	t.Parallel()
 	tg := NewTimerGroup()
 	require.Equal(t, "Exec total time: 0s", tg.GetTimer(ExecTotalTime).String())
 

--- a/util/strutil/jarowinkler_test.go
+++ b/util/strutil/jarowinkler_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestJaroWinklerMatcher(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		s1, s2 string
 		min    float64

--- a/util/strutil/quote_test.go
+++ b/util/strutil/quote_test.go
@@ -144,6 +144,7 @@ var misquoted = []string{
 }
 
 func TestUnquote(t *testing.T) {
+	t.Parallel()
 	for _, tt := range unquotetests {
 		out, err := Unquote(tt.in)
 		if err != nil {

--- a/util/strutil/strconv_test.go
+++ b/util/strutil/strconv_test.go
@@ -59,6 +59,7 @@ var linkTests = []linkTest{
 }
 
 func TestLink(t *testing.T) {
+	t.Parallel()
 	for _, tt := range linkTests {
 		graphLink := GraphLinkForExpression(tt.expression)
 		require.Equal(t, tt.expectedGraphLink, graphLink,
@@ -71,6 +72,7 @@ func TestLink(t *testing.T) {
 }
 
 func TestSanitizeLabelName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -137,6 +139,7 @@ func TestSanitizeLabelName(t *testing.T) {
 }
 
 func TestSanitizeFullLabelName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string

--- a/util/strutil/subsequence_test.go
+++ b/util/strutil/subsequence_test.go
@@ -106,6 +106,7 @@ func BenchmarkSubsequenceScoreRunes(b *testing.B) {
 }
 
 func TestSubsequenceScore(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		pattern   string
@@ -276,6 +277,7 @@ func TestSubsequenceScore(t *testing.T) {
 }
 
 func TestSubsequenceScoreProperties(t *testing.T) {
+	t.Parallel()
 	// Prefix match scores below 1.0; only exact match scores 1.0.
 	// "pro" in "prometheus": intervals [0,2], trailing=7. raw = 9 - 7/20, normalized by 9.
 	require.InDelta(t, 173.0/180.0*0.999, NewSubsequenceMatcher("pro").Score("prometheus"), 1e-9)

--- a/util/teststorage/appender_test.go
+++ b/util/teststorage/appender_test.go
@@ -129,12 +129,14 @@ func testAppendableV2(t *testing.T, appTest *Appendable, a storage.AppendableV2)
 }
 
 func TestAppendable(t *testing.T) {
+	t.Parallel()
 	appTest := NewAppendable()
 	testAppendableV1(t, appTest, appTest)
 	testAppendableV2(t, appTest, appTest)
 }
 
 func TestAppendable_Then(t *testing.T) {
+	t.Parallel()
 	nextAppTest := NewAppendable()
 	app := NewAppendable().Then(nextAppTest)
 
@@ -146,6 +148,7 @@ func TestAppendable_Then(t *testing.T) {
 
 // TestSample_RequireEqual.
 func TestSample_RequireEqual(t *testing.T) {
+	t.Parallel()
 	a := []Sample{
 		{},
 		{L: labels.FromStrings(model.MetricNameLabel, "test_metric_total"), M: metadata.Metadata{Type: "counter", Unit: "metric", Help: "some help text"}},
@@ -232,6 +235,7 @@ func TestSample_RequireEqual(t *testing.T) {
 }
 
 func TestConcurrentAppender_ReturnsErrAppender(t *testing.T) {
+	t.Parallel()
 	a := NewAppendable()
 
 	// Non-concurrent multiple use if fine.
@@ -271,6 +275,7 @@ func TestConcurrentAppender_ReturnsErrAppender(t *testing.T) {
 }
 
 func TestConcurrentAppenderV2_ReturnsErrAppender(t *testing.T) {
+	t.Parallel()
 	a := NewAppendable()
 
 	// Non-concurrent multiple use if fine.
@@ -308,6 +313,7 @@ func TestConcurrentAppenderV2_ReturnsErrAppender(t *testing.T) {
 }
 
 func TestReorderExpectedForStaleness(t *testing.T) {
+	t.Parallel()
 	testcases := []struct {
 		name       string
 		inExpected []Sample
@@ -394,6 +400,7 @@ func TestReorderExpectedForStaleness(t *testing.T) {
 }
 
 func TestSampleIsStale(t *testing.T) {
+	t.Parallel()
 	s1 := Sample{V: 1}
 	require.False(t, s1.IsStale())
 	s2 := Sample{V: math.Float64frombits(value.StaleNaN)}


### PR DESCRIPTION
Adds `t.Parallel()` to 47 top-level test functions across the `util/` sub-packages.

Each test uses only local state with no shared mutable package-level variables.

Excluded from parallelization:
- `util/httputil/compression_test.go`: uses package-level mux and server variables
- `util/zeropool/pool_test.go`: uses `testing.AllocsPerRun` sensitive to GC pressure

Part of #15185 (`util/` was unchecked in the tracking list).

```release-notes
NONE
```