### PR TITLE
discovery: add t.Parallel() to linode, eureka, digitalocean, openstack, moby tests

### DIFF
--- a/discovery/digitalocean/digitalocean_db_test.go
+++ b/discovery/digitalocean/digitalocean_db_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestDigitalOceanDBRefresh(t *testing.T) {
+	t.Parallel()
 	mock := NewSDMock(t)
 	mock.Setup()
 	defer mock.ShutdownServer()
@@ -94,6 +95,7 @@ func TestDigitalOceanDBRefresh(t *testing.T) {
 }
 
 func TestDigitalOceanDBRefreshPagination(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		page := r.URL.Query().Get("page")
 		switch page {

--- a/discovery/digitalocean/digitalocean_test.go
+++ b/discovery/digitalocean/digitalocean_test.go
@@ -42,6 +42,7 @@ func (s *DigitalOceanSDTestSuite) SetupTest(t *testing.T) {
 }
 
 func TestDigitalOceanSDRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := &DigitalOceanSDTestSuite{}
 	sdmock.SetupTest(t)
 	t.Cleanup(sdmock.TearDownSuite)

--- a/discovery/eureka/eureka_test.go
+++ b/discovery/eureka/eureka_test.go
@@ -60,6 +60,7 @@ func testUpdateServices(respHandler http.HandlerFunc) ([]*targetgroup.Group, err
 }
 
 func TestEurekaSDHandleError(t *testing.T) {
+	t.Parallel()
 	var (
 		errTesting  = "non 2xx status '500' response during eureka service discovery"
 		respHandler = func(w http.ResponseWriter, _ *http.Request) {
@@ -75,6 +76,7 @@ func TestEurekaSDHandleError(t *testing.T) {
 }
 
 func TestEurekaSDEmptyList(t *testing.T) {
+	t.Parallel()
 	var (
 		appsXML = `<applications>
 <versions__delta>1</versions__delta>
@@ -92,6 +94,7 @@ func TestEurekaSDEmptyList(t *testing.T) {
 }
 
 func TestEurekaSDSendGroup(t *testing.T) {
+	t.Parallel()
 	var (
 		appsXML = `<applications>
   <versions__delta>1</versions__delta>

--- a/discovery/linode/linode_test.go
+++ b/discovery/linode/linode_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestLinodeSDRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t)
 	sdmock.Setup()
 

--- a/discovery/moby/docker_test.go
+++ b/discovery/moby/docker_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestDockerSDRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "dockerprom")
 	sdmock.Setup()
 
@@ -211,6 +212,7 @@ host: %s
 }
 
 func TestDockerSDRefreshMatchAllNetworks(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "dockerprom")
 	sdmock.Setup()
 

--- a/discovery/moby/nodes_test.go
+++ b/discovery/moby/nodes_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestDockerSwarmNodesSDRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 

--- a/discovery/moby/services_test.go
+++ b/discovery/moby/services_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestDockerSwarmSDServicesRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 
@@ -330,6 +331,7 @@ host: %s
 }
 
 func TestDockerSwarmSDServicesRefreshWithFilters(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 

--- a/discovery/moby/tasks_test.go
+++ b/discovery/moby/tasks_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestDockerSwarmTasksSDRefresh(t *testing.T) {
+	t.Parallel()
 	sdmock := NewSDMock(t, "swarmprom")
 	sdmock.Setup()
 

--- a/discovery/openstack/hypervisor_test.go
+++ b/discovery/openstack/hypervisor_test.go
@@ -47,6 +47,7 @@ func (s *OpenstackSDHypervisorTestSuite) openstackAuthSuccess() (refresher, erro
 }
 
 func TestOpenstackSDHypervisorRefresh(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 
@@ -86,6 +87,7 @@ func TestOpenstackSDHypervisorRefresh(t *testing.T) {
 }
 
 func TestOpenstackSDHypervisorRefreshWithDoneContext(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 

--- a/discovery/openstack/instance_test.go
+++ b/discovery/openstack/instance_test.go
@@ -52,6 +52,7 @@ func (s *OpenstackSDInstanceTestSuite) openstackAuthSuccess() (refresher, error)
 }
 
 func TestOpenstackSDInstanceRefresh(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDInstanceTestSuite{}
 	mock.SetupTest(t)
 
@@ -153,6 +154,7 @@ func TestOpenstackSDInstanceRefresh(t *testing.T) {
 }
 
 func TestOpenstackSDInstanceRefreshWithDoneContext(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDHypervisorTestSuite{}
 	mock.SetupTest(t)
 

--- a/discovery/openstack/loadbalancer_test.go
+++ b/discovery/openstack/loadbalancer_test.go
@@ -51,6 +51,7 @@ func (s *OpenstackSDLoadBalancerTestSuite) openstackAuthSuccess() (refresher, er
 }
 
 func TestOpenstackSDLoadBalancerRefresh(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDLoadBalancerTestSuite{}
 	mock.SetupTest(t)
 
@@ -126,6 +127,7 @@ func TestOpenstackSDLoadBalancerRefresh(t *testing.T) {
 }
 
 func TestOpenstackSDLoadBalancerRefreshWithDoneContext(t *testing.T) {
+	t.Parallel()
 	mock := &OpenstackSDLoadBalancerTestSuite{}
 	mock.SetupTest(t)
 


### PR DESCRIPTION
Adds `t.Parallel()` to 19 test functions across 5 discovery sub-packages: linode, eureka, digitalocean, openstack, and moby.

Each test creates its own mock HTTP server and SD config with no shared mutable package-level state.

Part of #15185 (discovery sub-packages not yet covered).

```release-notes
NONE
```