### PR TITLE
storage/remote/otlptranslator/prometheusremotewrite: add t.Parallel()

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/context_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/context_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestEveryNTimes(t *testing.T) {
+	t.Parallel()
 	const n = 128
 	ctx, cancel := context.WithCancel(context.Background())
 	e := &everyNTimes{

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
@@ -42,6 +42,7 @@ import (
 type sample = teststorage.Sample
 
 func TestPrometheusConverter_createAttributes(t *testing.T) {
+	t.Parallel()
 	resourceAttrs := map[string]string{
 		"service.name":        "service name",
 		"service.instance.id": "service ID",
@@ -544,6 +545,7 @@ func TestPrometheusConverter_createAttributes(t *testing.T) {
 }
 
 func Test_convertTimeStamp(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		arg  pcommon.Timestamp
@@ -562,6 +564,7 @@ func Test_convertTimeStamp(t *testing.T) {
 }
 
 func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
+	t.Parallel()
 	scopeAttrs := pcommon.NewMap()
 	scopeAttrs.FromRaw(map[string]any{
 		"attr1": "value1",
@@ -790,6 +793,7 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 }
 
 func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
+	t.Parallel()
 	scopeAttrs := pcommon.NewMap()
 	scopeAttrs.FromRaw(map[string]any{
 		"attr1": "value1",
@@ -960,6 +964,7 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 // exemplars from a previous data point don't leak into _sum/_count of the
 // next data point. Regression test for stale exemplar leak.
 func TestAddHistogramDataPoints_ExemplarLeakAcrossDataPoints(t *testing.T) {
+	t.Parallel()
 	ts := pcommon.Timestamp(time.Now().UnixNano())
 	exTs := pcommon.Timestamp(time.Now().Add(time.Second).UnixNano())
 
@@ -1072,6 +1077,7 @@ func TestAddHistogramDataPoints_ExemplarLeakAcrossDataPoints(t *testing.T) {
 }
 
 func TestGetPromExemplars(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	c := NewPrometheusConverter(teststorage.NewAppendable().AppenderV2(t.Context()))
 
@@ -1107,6 +1113,7 @@ func TestGetPromExemplars(t *testing.T) {
 }
 
 func TestAddTypeAndUnitLabels(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name           string
 		inputLabels    []prompb.Label

--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms_test.go
@@ -42,6 +42,7 @@ type expectedBucketLayout struct {
 }
 
 func TestConvertBucketsLayout(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		buckets    func() pmetric.ExponentialHistogramDataPointBuckets
@@ -420,6 +421,7 @@ func BenchmarkConvertBucketLayout(b *testing.B) {
 }
 
 func TestExponentialToNativeHistogram(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		exponentialHist func() pmetric.ExponentialHistogramDataPoint
@@ -619,6 +621,7 @@ func validateNativeHistogramCount(t *testing.T, h *histogram.Histogram) {
 }
 
 func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
+	t.Parallel()
 	scopeAttrs := pcommon.NewMap()
 	scopeAttrs.FromRaw(map[string]any{
 		"attr1": "value1",
@@ -892,6 +895,7 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 }
 
 func TestConvertExplicitHistogramBucketsToNHCBLayout(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		buckets    []uint64
@@ -1026,6 +1030,7 @@ func BenchmarkConvertHistogramBucketsToNHCBLayout(b *testing.B) {
 }
 
 func TestHistogramToCustomBucketsHistogram(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		hist           func() pmetric.HistogramDataPoint
@@ -1097,6 +1102,7 @@ func TestHistogramToCustomBucketsHistogram(t *testing.T) {
 }
 
 func TestPrometheusConverter_addCustomBucketsHistogramDataPoints(t *testing.T) {
+	t.Parallel()
 	scopeAttrs := pcommon.NewMap()
 	scopeAttrs.FromRaw(map[string]any{
 		"attr1": "value1",

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 func TestFromMetrics(t *testing.T) {
+	t.Parallel()
 	t.Run("Successful", func(t *testing.T) {
 		for _, tc := range []struct {
 			name        string
@@ -711,6 +712,7 @@ func TestFromMetrics(t *testing.T) {
 }
 
 func TestTemporality(t *testing.T) {
+	t.Parallel()
 	ts := time.Unix(100, 0)
 
 	tests := []struct {
@@ -1149,6 +1151,7 @@ func createOtelEmptyType(name string) pmetric.Metric {
 }
 
 func TestTranslatorMetricFromOtelMetric(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		inputMetric    pmetric.Metric

--- a/storage/remote/otlptranslator/prometheusremotewrite/number_data_points_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/number_data_points_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestPrometheusConverter_addGaugeNumberDataPoints(t *testing.T) {
+	t.Parallel()
 	scopeAttrs := pcommon.NewMap()
 	scopeAttrs.FromRaw(map[string]any{
 		"attr1": "value1",
@@ -141,6 +142,7 @@ func TestPrometheusConverter_addGaugeNumberDataPoints(t *testing.T) {
 }
 
 func TestPrometheusConverter_addSumNumberDataPoints(t *testing.T) {
+	t.Parallel()
 	scopeAttrs := pcommon.NewMap()
 	scopeAttrs.FromRaw(map[string]any{
 		"attr1": "value1",


### PR DESCRIPTION
Adds `t.Parallel()` to the 19 top-level test functions in the `prometheusremotewrite` translation package.

These tests exercise pure translation logic with locally-scoped state (contexts, structs, appenders) and no shared mutable package-level variables.

Verified locally with `go test -race -count=1 ./...` — passes with no data races.

Part of #15185 (this sub-package was not yet covered by the in-flight storage/remote PRs, which target client_test.go and codec_test.go).

```release-notes
NONE
```

_AI assistance disclosure: this change was prepared with AI assistance and verified locally with the race detector before submission._