### PR TITLE
api: use SHA-256 for rule group pagination tokens

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -15,7 +15,7 @@ package v1
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -1794,7 +1794,7 @@ func parseListRulesPaginationRequest(r *http.Request) (int64, string, *apiFuncRe
 }
 
 func getRuleGroupNextToken(file, group string) string {
-	h := sha1.New()
+	h := sha256.New()
 	h.Write([]byte(file + ";" + group))
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -15,6 +15,8 @@ package v1
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -5014,4 +5016,16 @@ func TestDeleteSeriesEndpointRemoved(t *testing.T) {
 	// so we must not get the old 500 error.
 	require.NotEqual(t, http.StatusInternalServerError, recorder.Code,
 		"DELETE /api/v1/series should no longer return 500; the endpoint has been removed")
+}
+
+func TestGetRuleGroupNextToken(t *testing.T) {
+	// The token is a SHA-256 hex digest, so it must be deterministic and 64
+	// characters long.
+	token := getRuleGroupNextToken("/path/to/file", "group")
+	require.Len(t, token, hex.EncodedLen(sha256.Size))
+	require.Equal(t, token, getRuleGroupNextToken("/path/to/file", "group"))
+
+	// Distinct file and group inputs must produce distinct tokens.
+	require.NotEqual(t, token, getRuleGroupNextToken("/path/to/file", "other"))
+	require.NotEqual(t, token, getRuleGroupNextToken("/other/file", "group"))
 }


### PR DESCRIPTION
The `getRuleGroupNextToken` function in `web/api/v1/api.go` generates rule group pagination tokens with the deprecated SHA-1 algorithm. The token is opaque and only compared server-side, so switching to SHA-256 does not change the API contract: a token from a previous version simply will not match, which is already handled the same way as when rule groups change. This avoids SHA-1 in environments with FIPS or security-compliance constraints.

Added `TestGetRuleGroupNextToken` covering the token length, determinism, and uniqueness across inputs.

Test command and result:

    GOPROXY=direct GOSUMDB=off go test ./web/api/v1/ -count=1
    ok  github.com/prometheus/prometheus/web/api/v1

Fixes #18841

```release-notes
[CHANGE] API: Use SHA-256 instead of SHA-1 to generate rule group pagination tokens.
```