### PR TITLE
promql: fix currentSamples accounting for native histograms in matrixIterSlice

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2845,6 +2845,7 @@ func (ev *evaluator) matrixIterSlice(
 		var drop int
 		for drop = 0; histograms[drop].T <= mint; drop++ {
 		}
+		droppedSize := totalHPointSize(histograms[:drop])
 		// Rotate the buffer around the drop index so that points before mint can be
 		// reused to store new histograms.
 		tail := make([]HPoint, drop)
@@ -2852,7 +2853,7 @@ func (ev *evaluator) matrixIterSlice(
 		copy(histograms, histograms[drop:])
 		copy(histograms[len(histograms)-drop:], tail)
 		histograms = histograms[:len(histograms)-drop]
-		ev.currentSamples -= totalHPointSize(histograms)
+		ev.currentSamples -= droppedSize
 		// Only append points with timestamps after the last timestamp we have.
 		mintHistograms = histograms[len(histograms)-1].T
 

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1330,6 +1330,7 @@ load 10s
   metric 1+1x100
   bigmetric{a="1"} 1+1x100
   bigmetric{a="2"} 1+1x100
+  metricWith1HistogramEvery10Seconds {{schema:1 count:5 sum:20 buckets:[1 2 1 1]}}+{{schema:1 count:10 sum:5 buckets:[1 2 3 4]}}x100
 `)
 
 	// These test cases should be touching the limit exactly (hence no exceeding).
@@ -1465,6 +1466,11 @@ load 10s
 			Query:      `rate(rate(bigmetric[10s:1s] @ 10)[100s:25s] @ 1000)[17s:1s] @ 2000`,
 			MaxSamples: 34,
 			Start:      time.Unix(10, 0),
+		},
+		{
+			Query:      "max_over_time(metricWith1HistogramEvery10Seconds[61s])[20s:5s]",
+			MaxSamples: 91,
+			Start:      time.Unix(201, 0),
 		},
 	}
 


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
No tracked issue — found via code review. Fixes incorrect `ev.currentSamples`
accounting for native histograms in `matrixIterSlice`.
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] PromQL: Fix histogram sample accounting for overlapping range evaluation when enforcing --query.max-samples.
```
Summary
matrixIterSlice reuses point buffers across overlapping range evaluations, dropping stale points from the front before appending new ones.

The float path subtracts the number of dropped samples from ev.currentSamples:
```
ev.currentSamples -= drop
```
The histogram path, however, called totalHPointSize after the slice had already been truncated to the surviving points, so it subtracted the size of the retained histograms instead of the dropped ones:
```
histograms = histograms[:len(histograms)-drop] // retained only
ev.currentSamples -= totalHPointSize(histograms) // wrong: retained, not dropped
```
Because histogram samples contribute a variable weight via HPoint.size() ((H.Size()+8)/16), this makes ev.currentSamples inaccurate during overlapping range evaluation. ev.currentSamples backs --query.max-samples, so incorrect accounting can lead to incorrect sample-limit enforcement for native histogram queries.

This change computes the size of the dropped histogram prefix before rotating and truncating the buffer, and subtracts that value instead — mirroring the float path.

Testing
Added a regression test to TestMaxQuerySamples: max_over_time(metricWith1HistogramEvery10Seconds[61s])[20s:5s] with MaxSamples: 91.

Without the fix: peak sample accounting reports 78 instead of 91, causing the test to fail.
With the fix: peak sample accounting reports 91 and the test passes.
The test also verifies ErrTooManySamples behaviour at the limit boundary (rejected at a limit of 90).
```
go test ./promql/ -count=1 passes.
```
