### PR TITLE
discovery/ovhcloud: run tests in parallel

### DIFF
--- a/discovery/ovhcloud/ovhcloud_test.go
+++ b/discovery/ovhcloud/ovhcloud_test.go
@@ -57,6 +57,7 @@ func getMockConfFromString(confString string) (SDConfig, error) {
 }
 
 func TestErrorInitClient(t *testing.T) {
+	t.Parallel()
 	confString := fmt.Sprintf(`
 endpoint: %s
 
@@ -70,6 +71,7 @@ endpoint: %s
 }
 
 func TestParseIPs(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name  string
 		input []string
@@ -120,6 +122,7 @@ func TestParseIPs(t *testing.T) {
 }
 
 func TestDiscoverer(t *testing.T) {
+	t.Parallel()
 	conf, _ := getMockConf("vps")
 	logger := promslog.NewNopLogger()
 


### PR DESCRIPTION
Adds `t.Parallel()` to the top-level tests in `discovery/ovhcloud`, matching the other discovery providers. Tests pass with the race detector enabled (`go test -race ./discovery/ovhcloud/`).

Part of #15185.

```release-notes
NONE
```