### PR TITLE
PromQL: Fix for panic in smoothed series handling

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1830,7 +1830,9 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration,
 			}
 		}
 
-		mat = append(mat, ss)
+		if len(ss.Floats)+len(ss.Histograms) > 0 {
+			mat = append(mat, ss)
+		}
 	}
 
 	return mat, annos

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -692,6 +692,9 @@ clear
 load 30s
   mixed_types 1 2 {{schema:0 sum:3 count:3 buckets:[3]}} {{schema:0 sum:4 count:4 buckets:[4]}}
 
+eval instant at 45s mixed_types smoothed
+    expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "mixed_types"
+
 eval instant at 45s sort(mixed_types smoothed)
     expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "mixed_types"
 


### PR DESCRIPTION
This PR introduces a fix for a panic which can occur in the handling of a smoothed series. 

Previously this test case would result in a panic;

```
load 1s
  mixed 0 {{schema:0 sum:5 count:4 buckets:[1 2 1]}} 2 {{schema:0 sum:5 count:4 buckets:[1 2 1]}} 4 {{schema:0 sum:5 count:4 buckets:[1 2 1]}} 6 {{schema:0 sum:5 count:4 buckets:[1 2 1]}}

eval instant at 1s mixed smoothed
  mixed {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
```

`smoothSeries` (promql/engine.go) unconditionally appended each Series to the output matrix at the end of its per-series loop — even when no points were collected. A series collects no points whenever every lookback window is skipped, e.g. when the window mixes floats and histograms (mixed-types warning → continue), or when the only available sample lies after the requested timestamp.
  
For an instant query whose top-level expression is a bare vector selector (mixed smoothed), execEvalStmt converts the resulting matrix to a vector at engine.go:853:

```
  if len(s.Histograms) > 0 {
      vector[i] = Sample{..., H: s.Histograms[0].H, ...}
  } else {
      vector[i] = Sample{..., F: s.Floats[0].F, ...}   // panics: index out of range [0] with length 0
  }
```

With both Floats and Histograms empty, s.Floats[0] panicked. The existing testdata case used sort(mixed_types smoothed), whose function evaluator consumes the matrix and never hits this conversion — which is why it masked the panic.

#### Which issue(s) does the PR fix:


#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] PromQL: Fix panic when a `smoothed` instant vector selector produces no samples for a series.
```
