### PR TITLE
relabel, notifier, remote: migrate internal MD5 usage to SHA-256 and add hashmod_sha256

### DIFF
--- a/cmd/prometheus/main_upgrade_test.go
+++ b/cmd/prometheus/main_upgrade_test.go
@@ -54,9 +54,9 @@ func fetchLTSPrefix(t *testing.T) string {
 
 	// Extracts "X.Y" from the ltsVersions block:
 	//   ltsVersions: {
-	//     prometheus: ["X.Y"],
+	//     prometheus: ["X.Y", ...],
 	//   },
-	matches := regexp.MustCompile(`ltsVersions:\s*{\s*prometheus:\s*\["(\d+\.\d+)"]`).FindSubmatch(body)
+	matches := regexp.MustCompile(`ltsVersions:\s*{\s*prometheus:\s*\[\s*"(\d+\.\d+)"`).FindSubmatch(body)
 	require.NotEmpty(t, matches)
 	return string(matches[1])
 }

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -15,6 +15,7 @@ package relabel
 
 import (
 	"crypto/md5"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -56,6 +57,8 @@ const (
 	DropEqual Action = "dropequal"
 	// HashMod sets a label to the modulus of a hash of labels.
 	HashMod Action = "hashmod"
+	// HashModSHA256 sets a label to the modulus of a SHA-256 hash of labels.
+	HashModSHA256 Action = "hashmod_sha256"
 	// LabelMap copies labels to other labelnames based on a regex.
 	LabelMap Action = "labelmap"
 	// LabelDrop drops any label matching the regex.
@@ -75,7 +78,7 @@ func (a *Action) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 	switch act := Action(strings.ToLower(s)); act {
-	case Replace, Keep, Drop, HashMod, LabelMap, LabelDrop, LabelKeep, Lowercase, Uppercase, KeepEqual, DropEqual:
+	case Replace, Keep, Drop, HashMod, HashModSHA256, LabelMap, LabelDrop, LabelKeep, Lowercase, Uppercase, KeepEqual, DropEqual:
 		*a = act
 		return nil
 	}
@@ -121,10 +124,10 @@ func (c *Config) Validate(nameValidationScheme model.ValidationScheme) error {
 	if c.Action == "" {
 		return errors.New("relabel action cannot be empty")
 	}
-	if c.Modulus == 0 && c.Action == HashMod {
+	if c.Modulus == 0 && (c.Action == HashMod || c.Action == HashModSHA256) {
 		return errors.New("relabel configuration for hashmod requires non-zero modulus")
 	}
-	if (c.Action == Replace || c.Action == HashMod || c.Action == Lowercase || c.Action == Uppercase || c.Action == KeepEqual || c.Action == DropEqual) && c.TargetLabel == "" {
+	if (c.Action == Replace || c.Action == HashMod || c.Action == HashModSHA256 || c.Action == Lowercase || c.Action == Uppercase || c.Action == KeepEqual || c.Action == DropEqual) && c.TargetLabel == "" {
 		return fmt.Errorf("relabel configuration for %s action requires 'target_label' value", c.Action)
 	}
 
@@ -165,7 +168,7 @@ func (c *Config) Validate(nameValidationScheme model.ValidationScheme) error {
 	if c.Action == LabelMap && !isValidLabelNameWithRegexVarFn(c.Replacement) {
 		return fmt.Errorf("%q is invalid 'replacement' for %s action", c.Replacement, c.Action)
 	}
-	if c.Action == HashMod && !c.NameValidationScheme.IsValidLabelName(c.TargetLabel) {
+	if (c.Action == HashMod || c.Action == HashModSHA256) && !c.NameValidationScheme.IsValidLabelName(c.TargetLabel) {
 		return fmt.Errorf("%q is invalid 'target_label' for %s action", c.TargetLabel, c.Action)
 	}
 
@@ -340,6 +343,11 @@ func relabel(cfg *Config, lb *labels.Builder) (keep bool) {
 		hash := md5.Sum([]byte(val))
 		// Use only the last 8 bytes of the hash to give the same result as earlier versions of this code.
 		mod := binary.BigEndian.Uint64(hash[8:]) % cfg.Modulus
+		lb.Set(cfg.TargetLabel, strconv.FormatUint(mod, 10))
+	case HashModSHA256:
+		hash := sha256.Sum256([]byte(val))
+		// Use the first 8 bytes of the SHA-256 hash.
+		mod := binary.BigEndian.Uint64(hash[:8]) % cfg.Modulus
 		lb.Set(cfg.TargetLabel, strconv.FormatUint(mod, 10))
 	case LabelMap:
 		lb.Range(func(l labels.Label) {

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -277,6 +277,28 @@ func TestRelabel(t *testing.T) {
 		},
 		{
 			input: labels.FromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+			}),
+			relabel: []*Config{
+				{
+					SourceLabels: model.LabelNames{"c"},
+					TargetLabel:  "d",
+					Separator:    ";",
+					Action:       HashModSHA256,
+					Modulus:      1000,
+				},
+			},
+			output: labels.FromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+				"d": "307",
+			}),
+		},
+		{
+			input: labels.FromMap(map[string]string{
 				"a":  "foo",
 				"b1": "bar",
 				"b2": "baz",

--- a/notifier/alertmanager_test.go
+++ b/notifier/alertmanager_test.go
@@ -14,12 +14,15 @@
 package notifier
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"log/slog"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -149,4 +152,22 @@ func TestAlertmanagerSetSync(t *testing.T) {
 
 	am3LoopAfter := ams.sendLoops["http://am3.example.com:9093/api/v2/alerts"]
 	require.Same(t, am3Loop, am3LoopAfter, "AM3 sendloop should not be recreated")
+}
+
+func TestAlertmanagerSetConfigHash(t *testing.T) {
+	cfg := &config.AlertmanagerConfig{
+		Scheme:     "http",
+		PathPrefix: "/test",
+	}
+	ams := &alertmanagerSet{cfg: cfg}
+
+	// Calculate expected hash
+	b, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	hash := sha256.Sum256(b)
+	expected := hex.EncodeToString(hash[:])
+
+	actual, err := ams.configHash()
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
 }

--- a/notifier/alertmanagerset.go
+++ b/notifier/alertmanagerset.go
@@ -14,7 +14,7 @@
 package notifier
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
@@ -127,7 +127,7 @@ func (s *alertmanagerSet) configHash() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	hash := md5.Sum(b)
+	hash := sha256.Sum256(b)
 	return hex.EncodeToString(hash[:]), nil
 }
 

--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -15,7 +15,7 @@ package remote
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
@@ -231,6 +231,6 @@ func toHash(data any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	hash := md5.Sum(bytes)
+	hash := sha256.Sum256(bytes)
 	return hex.EncodeToString(hash[:]), nil
 }

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -190,3 +190,11 @@ func TestWriteStorageApplyConfigsDuringCommit(t *testing.T) {
 	close(start)
 	wg.Wait()
 }
+
+func TestToHash(t *testing.T) {
+	data := "test-data"
+	expected := "183145e836ff4ddf03de4cc2cfc994b2ade87ca8c91e75249f6c3c9764651af9"
+	actual, err := toHash(data)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}


### PR DESCRIPTION
- Replace MD5 with SHA-256 in notifier and remote storage for FIPS compliance.
- Introduce hashmod_sha256 relabeling action.
- Add unit tests for new hashing logic.

#### Which issue(s) does the PR fix:
Fix https://github.com/prometheus/prometheus/issues/18944


#### Release notes for end users 
```release-notes
[FEATURE] Relabel: Add hashmod_sha256 action for FIPS-compliant sharding.
[CHANGE] Notifier: Use SHA-256 instead of MD5 for internal configuration hashing.
[CHANGE] Remote Storage: Use SHA-256 instead of MD5 for internal configuration hashing.
```

#### Test command and result:
```
go test -v ./model/relabel ./storage/remote ./notifier

PASS
ok      github.com/prometheus/prometheus/model/relabel  2.274s

PASS
ok      github.com/prometheus/prometheus/storage/remote 23.867s
=== RUN   TestPostPath

=== RUN   TestAlertsToOpenAPIAlertsEmptyFields
--- PASS: TestAlertsToOpenAPIAlertsEmptyFields (0.00s)
PASS
ok      github.com/prometheus/prometheus/notifier       1.296s

```

