### PR TITLE
test(cmd): handle multiple LTS versions in fetchLTSPrefix

### DIFF
--- a/cmd/prometheus/main_upgrade_test.go
+++ b/cmd/prometheus/main_upgrade_test.go
@@ -40,7 +40,8 @@ import (
 
 const prometheusDocsLTSConfigURL = "https://raw.githubusercontent.com/prometheus/docs/main/docs-config.ts"
 
-// fetchLTSPrefix fetches the single LTS version prefix (e.g. "3.5") from the docs config.
+// fetchLTSPrefix fetches the oldest LTS version prefix (e.g. "3.5") from the docs config.
+// The config may list several LTS versions; the first entry is the oldest released LTS.
 func fetchLTSPrefix(t *testing.T) string {
 	t.Helper()
 
@@ -52,11 +53,12 @@ func fetchLTSPrefix(t *testing.T) string {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	// Extracts "X.Y" from the ltsVersions block:
+	// Extracts the first "X.Y" from the ltsVersions block, which may list
+	// several LTS versions (the first entry being the oldest released LTS):
 	//   ltsVersions: {
-	//     prometheus: ["X.Y"],
+	//     prometheus: ["X.Y", "X.Z"],
 	//   },
-	matches := regexp.MustCompile(`ltsVersions:\s*{\s*prometheus:\s*\["(\d+\.\d+)"]`).FindSubmatch(body)
+	matches := regexp.MustCompile(`ltsVersions:\s*{\s*prometheus:\s*\["(\d+\.\d+)"`).FindSubmatch(body)
 	require.NotEmpty(t, matches)
 	return string(matches[1])
 }


### PR DESCRIPTION
The upstream docs-config.ts now lists more than one LTS version (e.g. ["3.5", "3.13"]). The regex anchored on the closing bracket right after the first version, so it no longer matched, breaking TestVersionUpgrade_fetchLTSPrefix and TestVersionUpgrade_UpgradeDowngradeLatestLTS.

Match only the first (oldest released) LTS entry regardless of how many follow, and update the comments accordingly.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
