### PR TITLE
Notifier: migrate internal config hashing to SHA-256

### DIFF
--- a/notifier/alertmanager_test.go
+++ b/notifier/alertmanager_test.go
@@ -14,12 +14,15 @@
 package notifier
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"log/slog"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -149,4 +152,22 @@ func TestAlertmanagerSetSync(t *testing.T) {
 
 	am3LoopAfter := ams.sendLoops["http://am3.example.com:9093/api/v2/alerts"]
 	require.Same(t, am3Loop, am3LoopAfter, "AM3 sendloop should not be recreated")
+}
+
+func TestAlertmanagerSetConfigHash(t *testing.T) {
+	cfg := &config.AlertmanagerConfig{
+		Scheme:     "http",
+		PathPrefix: "/test",
+	}
+	ams := &alertmanagerSet{cfg: cfg}
+
+	// Calculate expected hash
+	b, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	hash := sha256.Sum256(b)
+	expected := hex.EncodeToString(hash[:])
+
+	actual, err := ams.configHash()
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
 }

--- a/notifier/alertmanagerset.go
+++ b/notifier/alertmanagerset.go
@@ -14,7 +14,7 @@
 package notifier
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
@@ -127,7 +127,7 @@ func (s *alertmanagerSet) configHash() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	hash := md5.Sum(b)
+	hash := sha256.Sum256(b)
 	return hex.EncodeToString(hash[:]), nil
 }
 


### PR DESCRIPTION
This PR is part of the effort to transition from MD5 to SHA-256 for FIPS compliance, as outlined in #18944.

Specifically, it migrates the internal configuration hashing in the `notifier` package to use SHA-256. This hash is used to detect configuration changes during reloads and does not change any external API or behavior.

- Replace MD5 with SHA-256 in notifier for FIPS compliance.
- Add unit tests to verify the new hashing logic.

#### Which issue(s) does the PR fix:
Part of https://github.com/prometheus/prometheus/issues/18944

#### Release notes for end users 
```release-notes
[CHANGE] Notifier: Use SHA-256 instead of MD5 for internal configuration hashing.
```

#### Test command and result:
```
go test -v  ./notifier

PASS
ok      github.com/prometheus/prometheus/notifier       1.296s
```
