### PR TITLE
Remote: migrate internal config hashing to SHA-256

### DIFF
--- a/storage/remote/storage.go
+++ b/storage/remote/storage.go
@@ -15,7 +15,7 @@ package remote
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
@@ -231,6 +231,6 @@ func toHash(data any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	hash := md5.Sum(bytes)
+	hash := sha256.Sum256(bytes)
 	return hex.EncodeToString(hash[:]), nil
 }

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -190,3 +190,11 @@ func TestWriteStorageApplyConfigsDuringCommit(t *testing.T) {
 	close(start)
 	wg.Wait()
 }
+
+func TestToHash(t *testing.T) {
+	data := "test-data"
+	expected := "183145e836ff4ddf03de4cc2cfc994b2ade87ca8c91e75249f6c3c9764651af9"
+	actual, err := toHash(data)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}


### PR DESCRIPTION
This PR is part of the effort to transition from MD5 to SHA-256 for FIPS compliance, as outlined in #18944.

Specifically, it migrates the internal configuration hashing in the `remote` storage package to use SHA-256. This hash is used to identify unique remote read/write configurations and does not change any external API or behavior.

- Replace MD5 with SHA-256 in remote storage for FIPS compliance.
- Add unit tests to verify the new hashing logic.

#### Which issue(s) does the PR fix:
Part of https://github.com/prometheus/prometheus/issues/18944

#### Release notes for end users 
```release-notes
[CHANGE] Remote Storage: Use SHA-256 instead of MD5 for internal configuration hashing.
```

#### Test command and result:
```
go test -v  ./storage/remote 

PASS
ok      github.com/prometheus/prometheus/storage/remote 23.867s
```

