### PR TITLE
OTLP: surface attribute-name collision warnings and add a translation-warnings metric

### DIFF
--- a/storage/remote/otlptranslator/prometheusremotewrite/annotations.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/annotations.go
@@ -1,0 +1,83 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusremotewrite
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+// WarningCategory is a stable, machine-readable classification of an OTLP
+// translation warning. It is a closed enum so that callers can use it as a
+// metric label without risking unbounded cardinality.
+type WarningCategory string
+
+const (
+	// WarningCategoryLabelNameCollision is set when two or more OTLP attribute
+	// names map to the same label name after sanitization and their values are
+	// concatenated.
+	WarningCategoryLabelNameCollision WarningCategory = "label_name_collision"
+	// WarningCategoryHistogramZeroCountNonZeroSum is set when a histogram data
+	// point has a zero count but a non-zero sum, for both exponential and
+	// classic (NHCB) histograms.
+	WarningCategoryHistogramZeroCountNonZeroSum WarningCategory = "histogram_zero_count_non_zero_sum"
+	// WarningCategoryOther is the fallback for any warning that has not been
+	// assigned a category. It keeps the label space bounded.
+	WarningCategoryOther WarningCategory = "other"
+)
+
+// categorizedWarning is an annotation error that carries a machine-readable
+// category. Its Error() returns the human-readable message unchanged, so
+// annotation deduplication (which keys on the message), logging, and
+// Annotations.AsStrings all behave exactly as they did for a bare error.
+type categorizedWarning struct {
+	category WarningCategory
+	msg      string
+}
+
+func (w *categorizedWarning) Error() string { return w.msg }
+
+// newCategorizedWarningf builds a categorized warning whose message is formatted
+// from format and args, identically to fmt.Errorf.
+func newCategorizedWarningf(category WarningCategory, format string, args ...any) *categorizedWarning {
+	return &categorizedWarning{category: category, msg: fmt.Sprintf(format, args...)}
+}
+
+// WarningCategoryOf returns the category of an annotation error, or
+// WarningCategoryOther if it carries none.
+func WarningCategoryOf(err error) WarningCategory {
+	var cw *categorizedWarning
+	if errors.As(err, &cw) {
+		return cw.category
+	}
+	return WarningCategoryOther
+}
+
+// CountWarningsByCategory buckets the warnings in annots by category, skipping
+// info-level annotations.
+func CountWarningsByCategory(annots annotations.Annotations) map[WarningCategory]int {
+	if len(annots) == 0 {
+		return nil
+	}
+	counts := make(map[WarningCategory]int, len(annots))
+	for _, err := range annots {
+		if errors.Is(err, annotations.PromQLInfo) {
+			continue
+		}
+		counts[WarningCategoryOf(err)]++
+	}
+	return counts
+}

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper.go
@@ -119,6 +119,7 @@ func (c *PrometheusConverter) createAttributes(
 				return
 			}
 			if existingValue := c.builder.Get(finalKey); existingValue != "" {
+				c.recordLabelCollision(sortedLabels, finalKey)
 				c.builder.Set(finalKey, existingValue+";"+l.Value)
 			} else {
 				c.builder.Set(finalKey, l.Value)
@@ -192,6 +193,40 @@ func (c *PrometheusConverter) createAttributes(
 	}
 
 	return c.builder.Labels(), nil
+}
+
+// recordLabelCollision adds a warning annotation naming the original attribute
+// keys that map to the same label name finalKey after sanitization, so that
+// callers of FromMetrics can surface which attributes produced a concatenated
+// label value. Name lookups hit the sanitizedLabels cache.
+//
+// Each finalKey is recorded at most once per FromMetrics call.
+// Accepted limitation: if different attribute sets
+// collide as the same finalKey within one call, only the first set is recorded.
+func (c *PrometheusConverter) recordLabelCollision(sortedLabels labels.Labels, finalKey string) {
+	if _, ok := c.recordedCollisions[finalKey]; ok {
+		return
+	}
+
+	var keys strings.Builder
+	sortedLabels.Range(func(l labels.Label) {
+		// No need to handle errors here.
+		if name, err := c.buildLabelName(l.Name); err != nil || name != finalKey {
+			return
+		}
+		if keys.Len() > 0 {
+			keys.WriteString(", ")
+		}
+		fmt.Fprintf(&keys, "%q", l.Name)
+	})
+	c.collisionAnnots.Add(newCategorizedWarningf(WarningCategoryLabelNameCollision,
+		"OTLP %s attributes %s collide as label %q after name sanitization, values are concatenated with ';'",
+		c.collisionSource.String(), keys.String(), finalKey))
+
+	if c.recordedCollisions == nil {
+		c.recordedCollisions = make(map[string]struct{}, 4)
+	}
+	c.recordedCollisions[finalKey] = struct{}{}
 }
 
 func aggregationTemporality(metric pmetric.Metric) (pmetric.AggregationTemporality, bool, error) {
@@ -540,7 +575,9 @@ func (c *PrometheusConverter) addResourceTargetInfo(resource pcommon.Resource, s
 	// Temporarily clear scope labels for this call.
 	savedScopeLabels := c.scopeLabels
 	c.scopeLabels = nil
+	c.collisionSource = collisionFromResource
 	lbls, err := c.createAttributes(attributes, settings, identifyingAttrs, false, metadata.Metadata{}, model.MetricNameLabel, name)
+	c.collisionSource = collisionFromDataPoint
 	c.scopeLabels = savedScopeLabels
 	if err != nil {
 		return err

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
@@ -89,6 +89,15 @@ func TestPrometheusConverter_createAttributes(t *testing.T) {
 	attrsWithUnderscores.PutStr("_metric_private", "private metric")
 	attrsWithUnderscores.PutStr("metric___multi", "multi metric")
 
+	// Attribute names that collide after sanitization (`.` and `-` both map to `_`).
+	collidingAttrs := pcommon.NewMap()
+	collidingAttrs.PutStr("a.b", "1")
+	collidingAttrs.PutStr("a_b", "2")
+	tripleCollidingAttrs := pcommon.NewMap()
+	tripleCollidingAttrs.PutStr("a-b", "1")
+	tripleCollidingAttrs.PutStr("a.b", "2")
+	tripleCollidingAttrs.PutStr("a_b", "3")
+
 	testCases := []struct {
 		name                                 string
 		resource                             pcommon.Resource
@@ -102,6 +111,7 @@ func TestPrometheusConverter_createAttributes(t *testing.T) {
 		labelNameUnderscoreSanitization      bool
 		labelNamePreserveMultipleUnderscores bool
 		expectedLabels                       labels.Labels
+		expectedCollisionWarnings            []string
 	}{
 		{
 			name:                      "Successful conversion without resource attribute promotion and without scope promotion",
@@ -404,6 +414,32 @@ func TestPrometheusConverter_createAttributes(t *testing.T) {
 				"metric_attr_other", "metric value other",
 			),
 		},
+		{
+			name:  "Attributes colliding after sanitization are concatenated and recorded as a warning",
+			attrs: collidingAttrs,
+			expectedLabels: labels.FromStrings(
+				"__name__", "test_metric",
+				"a_b", "1;2",
+				"instance", "service ID",
+				"job", "service name",
+			),
+			expectedCollisionWarnings: []string{
+				`OTLP data point attributes "a.b", "a_b" collide as label "a_b" after name sanitization, values are concatenated with ';'`,
+			},
+		},
+		{
+			name:  "Three colliding attributes report all names in concatenation order",
+			attrs: tripleCollidingAttrs,
+			expectedLabels: labels.FromStrings(
+				"__name__", "test_metric",
+				"a_b", "1;2;3",
+				"instance", "service ID",
+				"job", "service name",
+			),
+			expectedCollisionWarnings: []string{
+				`OTLP data point attributes "a-b", "a.b", "a_b" collide as label "a_b" after name sanitization, values are concatenated with ';'`,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -439,6 +475,7 @@ func TestPrometheusConverter_createAttributes(t *testing.T) {
 			require.NoError(t, err)
 
 			testutil.RequireEqual(t, tc.expectedLabels, lbls)
+			require.ElementsMatch(t, tc.expectedCollisionWarnings, c.CollisionWarnings())
 		})
 	}
 

--- a/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/helper_test.go
@@ -97,6 +97,17 @@ func TestPrometheusConverter_createAttributes(t *testing.T) {
 	tripleCollidingAttrs.PutStr("a-b", "1")
 	tripleCollidingAttrs.PutStr("a.b", "2")
 	tripleCollidingAttrs.PutStr("a_b", "3")
+	// Two independent collision groups in one attribute set.
+	multiGroupCollidingAttrs := pcommon.NewMap()
+	multiGroupCollidingAttrs.PutStr("a.b", "1")
+	multiGroupCollidingAttrs.PutStr("a_b", "2")
+	multiGroupCollidingAttrs.PutStr("c.d", "3")
+	multiGroupCollidingAttrs.PutStr("c_d", "4")
+	// A colliding group plus an attribute that does not participate in it.
+	collisionWithExtraAttrs := pcommon.NewMap()
+	collisionWithExtraAttrs.PutStr("a.b", "1")
+	collisionWithExtraAttrs.PutStr("a_b", "2")
+	collisionWithExtraAttrs.PutStr("unrelated", "9")
 
 	testCases := []struct {
 		name                                 string
@@ -440,6 +451,35 @@ func TestPrometheusConverter_createAttributes(t *testing.T) {
 				`OTLP data point attributes "a-b", "a.b", "a_b" collide as label "a_b" after name sanitization, values are concatenated with ';'`,
 			},
 		},
+		{
+			name:  "Multiple independent collision groups each produce a distinct warning",
+			attrs: multiGroupCollidingAttrs,
+			expectedLabels: labels.FromStrings(
+				"__name__", "test_metric",
+				"a_b", "1;2",
+				"c_d", "3;4",
+				"instance", "service ID",
+				"job", "service name",
+			),
+			expectedCollisionWarnings: []string{
+				`OTLP data point attributes "a.b", "a_b" collide as label "a_b" after name sanitization, values are concatenated with ';'`,
+				`OTLP data point attributes "c.d", "c_d" collide as label "c_d" after name sanitization, values are concatenated with ';'`,
+			},
+		},
+		{
+			name:  "Attributes not participating in a collision are excluded from the warning",
+			attrs: collisionWithExtraAttrs,
+			expectedLabels: labels.FromStrings(
+				"__name__", "test_metric",
+				"a_b", "1;2",
+				"instance", "service ID",
+				"job", "service name",
+				"unrelated", "9",
+			),
+			expectedCollisionWarnings: []string{
+				`OTLP data point attributes "a.b", "a_b" collide as label "a_b" after name sanitization, values are concatenated with ';'`,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -475,7 +515,7 @@ func TestPrometheusConverter_createAttributes(t *testing.T) {
 			require.NoError(t, err)
 
 			testutil.RequireEqual(t, tc.expectedLabels, lbls)
-			require.ElementsMatch(t, tc.expectedCollisionWarnings, c.CollisionWarnings())
+			require.ElementsMatch(t, tc.expectedCollisionWarnings, collisionWarnings(c.collisionAnnots))
 		})
 	}
 

--- a/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/histograms.go
@@ -144,7 +144,7 @@ func exponentialToNativeHistogram(p pmetric.ExponentialHistogramDataPoint, tempo
 		}
 		h.Count = p.Count()
 		if p.Count() == 0 && h.Sum != 0 {
-			annots.Add(fmt.Errorf("exponential histogram data point has zero count, but non-zero sum: %f", h.Sum))
+			annots.Add(newCategorizedWarningf(WarningCategoryHistogramZeroCountNonZeroSum, "exponential histogram data point has zero count, but non-zero sum: %f", h.Sum))
 		}
 	}
 	return h, annots, nil
@@ -356,7 +356,7 @@ func explicitHistogramToCustomBucketsHistogram(p pmetric.HistogramDataPoint, tem
 		}
 		h.Count = p.Count()
 		if p.Count() == 0 && h.Sum != 0 {
-			annots.Add(fmt.Errorf("histogram data point has zero count, but non-zero sum: %f", h.Sum))
+			annots.Add(newCategorizedWarningf(WarningCategoryHistogramZeroCountNonZeroSum, "histogram data point has zero count, but non-zero sum: %f", h.Sum))
 		}
 	}
 	return h, annots, nil

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -146,18 +146,6 @@ func NewPrometheusConverter(appender storage.AppenderV2) *PrometheusConverter {
 	}
 }
 
-// CollisionWarnings returns the label name collision warnings recorded during
-// the last FromMetrics call, as strings. The same warnings are merged into the
-// annotations returned by FromMetrics; this accessor lets embedders treat them
-// separately from other translation annotations.
-func (c *PrometheusConverter) CollisionWarnings() []string {
-	if len(c.collisionAnnots) == 0 {
-		return nil
-	}
-	warnings, _ := c.collisionAnnots.AsStrings("", 0, 0)
-	return warnings
-}
-
 // buildLabelName returns a sanitized label name, using the cache to avoid repeated allocations.
 func (c *PrometheusConverter) buildLabelName(label string) (string, error) {
 	if sanitized, ok := c.sanitizedLabels[label]; ok {
@@ -226,6 +214,7 @@ func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metric
 	c.seenTargetInfo = make(map[targetInfoKey]struct{})
 	c.collisionAnnots = nil
 	c.recordedCollisions = nil
+	c.collisionSource = collisionFromDataPoint
 	defer func() { annots.Merge(c.collisionAnnots) }()
 	resourceMetricsSlice := md.ResourceMetrics()
 

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -98,6 +98,37 @@ type PrometheusConverter struct {
 	// sanitizedLabels caches the results of label name sanitization within a request.
 	// This avoids repeated string allocations for the same label names.
 	sanitizedLabels map[string]string
+
+	// collisionAnnots collects warning annotations about attribute names that
+	// collide after label name sanitization, causing their values to be
+	// concatenated. Reset on every FromMetrics call.
+	collisionAnnots annotations.Annotations
+	// recordedCollisions tracks the sanitized label names whose collision has
+	// already been recorded during the current FromMetrics call, so that a
+	// collision repeated across data points is recorded once instead of
+	// rebuilding the annotation per data point. Reset on
+	// every FromMetrics call.
+	recordedCollisions map[string]struct{}
+	// collisionSource records whether the attributes currently being converted are
+	// data point or resource attributes, so collision warnings can name the source.
+	collisionSource collisionAttrSource
+}
+
+// collisionAttrSource identifies which OTLP attribute source is being converted,
+// so label-name collision warnings can name it. The zero value is data point,
+// which covers every path except target_info (resource attributes).
+type collisionAttrSource int
+
+const (
+	collisionFromDataPoint collisionAttrSource = iota
+	collisionFromResource
+)
+
+func (s collisionAttrSource) String() string {
+	if s == collisionFromResource {
+		return "resource"
+	}
+	return "data point"
 }
 
 // targetInfoKey uniquely identifies a target_info sample by its labelset and timestamp.
@@ -113,6 +144,18 @@ func NewPrometheusConverter(appender storage.AppenderV2) *PrometheusConverter {
 		appender:        appender,
 		sanitizedLabels: make(map[string]string, 64), // Pre-size for typical label count.
 	}
+}
+
+// CollisionWarnings returns the label name collision warnings recorded during
+// the last FromMetrics call, as strings. The same warnings are merged into the
+// annotations returned by FromMetrics; this accessor lets embedders treat them
+// separately from other translation annotations.
+func (c *PrometheusConverter) CollisionWarnings() []string {
+	if len(c.collisionAnnots) == 0 {
+		return nil
+	}
+	warnings, _ := c.collisionAnnots.AsStrings("", 0, 0)
+	return warnings
 }
 
 // buildLabelName returns a sanitized label name, using the cache to avoid repeated allocations.
@@ -181,6 +224,9 @@ func (c *PrometheusConverter) FromMetrics(ctx context.Context, md pmetric.Metric
 	unitNamer := otlptranslator.UnitNamer{}
 	c.everyN = everyNTimes{n: 128}
 	c.seenTargetInfo = make(map[targetInfoKey]struct{})
+	c.collisionAnnots = nil
+	c.recordedCollisions = nil
+	defer func() { annots.Merge(c.collisionAnnots) }()
 	resourceMetricsSlice := md.ResourceMetrics()
 
 	for i := range resourceMetricsSlice.Len() {

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -308,6 +308,93 @@ func TestFromMetrics(t *testing.T) {
 		}, ws)
 	})
 
+	t.Run("attribute collision is surfaced as a warning and via CollisionWarnings", func(t *testing.T) {
+		request := pmetricotlp.NewExportRequest()
+		rm := request.Metrics().ResourceMetrics().AppendEmpty()
+		m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		m.SetName("test_gauge")
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		dp.SetIntValue(1)
+		dp.Attributes().PutStr("a.b", "x")
+		dp.Attributes().PutStr("a_b", "y")
+
+		converter := NewPrometheusConverter(teststorage.NewAppendable().AppenderV2(t.Context()))
+		annots, err := converter.FromMetrics(t.Context(), request.Metrics(), Settings{})
+		require.NoError(t, err)
+
+		want := []string{
+			`OTLP data point attributes "a.b", "a_b" collide as label "a_b" after name sanitization, values are concatenated with ';'`,
+		}
+		ws, infos := annots.AsStrings("", 0, 0)
+		require.Empty(t, infos)
+		require.Equal(t, want, ws)
+		require.Equal(t, want, converter.CollisionWarnings())
+	})
+
+	t.Run("resource attribute collision is surfaced as a warning", func(t *testing.T) {
+		request := pmetricotlp.NewExportRequest()
+		rm := request.Metrics().ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("k8s.pod.name", "foo")
+		rm.Resource().Attributes().PutStr("k8s_pod_name", "bar")
+		m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		m.SetName("test_gauge")
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		dp.SetIntValue(1)
+
+		converter := NewPrometheusConverter(teststorage.NewAppendable().AppenderV2(t.Context()))
+		annots, err := converter.FromMetrics(t.Context(), request.Metrics(), Settings{})
+		require.NoError(t, err)
+		ws, _ := annots.AsStrings("", 0, 0)
+		require.Contains(t, ws, `OTLP resource attributes "k8s.pod.name", "k8s_pod_name" collide as label "k8s_pod_name" after name sanitization, values are concatenated with ';'`)
+	})
+
+	t.Run("repeated collision across data points is recorded once", func(t *testing.T) {
+		request := pmetricotlp.NewExportRequest()
+		rm := request.Metrics().ResourceMetrics().AppendEmpty()
+		m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		m.SetName("test_gauge")
+		g := m.SetEmptyGauge()
+		ts := pcommon.NewTimestampFromTime(time.Now())
+		// Two distinct series sharing the same colliding attribute names.
+		for i, v := range []string{"y", "z"} {
+			dp := g.DataPoints().AppendEmpty()
+			dp.SetTimestamp(ts)
+			dp.SetIntValue(int64(i))
+			dp.Attributes().PutStr("a.b", "x")
+			dp.Attributes().PutStr("a_b", v)
+		}
+
+		converter := NewPrometheusConverter(teststorage.NewAppendable().AppenderV2(t.Context()))
+		annots, err := converter.FromMetrics(t.Context(), request.Metrics(), Settings{})
+		require.NoError(t, err)
+
+		ws, _ := annots.AsStrings("", 0, 0)
+		require.Equal(t, []string{
+			`OTLP data point attributes "a.b", "a_b" collide as label "a_b" after name sanitization, values are concatenated with ';'`,
+		}, ws)
+	})
+
+	t.Run("no collision warning when UTF-8 is allowed", func(t *testing.T) {
+		request := pmetricotlp.NewExportRequest()
+		rm := request.Metrics().ResourceMetrics().AppendEmpty()
+		m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		m.SetName("test_gauge")
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		dp.SetIntValue(1)
+		dp.Attributes().PutStr("a.b", "x")
+		dp.Attributes().PutStr("a_b", "y")
+
+		converter := NewPrometheusConverter(teststorage.NewAppendable().AppenderV2(t.Context()))
+		annots, err := converter.FromMetrics(t.Context(), request.Metrics(), Settings{AllowUTF8: true})
+		require.NoError(t, err)
+		require.Empty(t, converter.CollisionWarnings())
+		ws, _ := annots.AsStrings("", 0, 0)
+		require.Empty(t, ws)
+	})
+
 	t.Run("target_info's samples starts at the earliest metric sample timestamp and ends at the latest sample timestamp of the corresponding resource, with one sample every lookback delta/2 timestamps between", func(t *testing.T) {
 		request := pmetricotlp.NewExportRequest()
 		rm := request.Metrics().ResourceMetrics().AppendEmpty()

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -308,7 +308,7 @@ func TestFromMetrics(t *testing.T) {
 		}, ws)
 	})
 
-	t.Run("attribute collision is surfaced as a warning and via CollisionWarnings", func(t *testing.T) {
+	t.Run("attribute collision is surfaced as a warning", func(t *testing.T) {
 		request := pmetricotlp.NewExportRequest()
 		rm := request.Metrics().ResourceMetrics().AppendEmpty()
 		m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
@@ -329,7 +329,7 @@ func TestFromMetrics(t *testing.T) {
 		ws, infos := annots.AsStrings("", 0, 0)
 		require.Empty(t, infos)
 		require.Equal(t, want, ws)
-		require.Equal(t, want, converter.CollisionWarnings())
+		require.Equal(t, want, collisionWarnings(annots))
 	})
 
 	t.Run("resource attribute collision is surfaced as a warning", func(t *testing.T) {
@@ -390,7 +390,7 @@ func TestFromMetrics(t *testing.T) {
 		converter := NewPrometheusConverter(teststorage.NewAppendable().AppenderV2(t.Context()))
 		annots, err := converter.FromMetrics(t.Context(), request.Metrics(), Settings{AllowUTF8: true})
 		require.NoError(t, err)
-		require.Empty(t, converter.CollisionWarnings())
+		require.Empty(t, collisionWarnings(annots))
 		ws, _ := annots.AsStrings("", 0, 0)
 		require.Empty(t, ws)
 	})

--- a/storage/remote/otlptranslator/prometheusremotewrite/testutil_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/testutil_test.go
@@ -21,7 +21,21 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/prometheus/prometheus/util/annotations"
 )
+
+// collisionWarnings returns the label-name collision warning messages in annots,
+// the way an embedder extracts them via the public warning-category API.
+func collisionWarnings(annots annotations.Annotations) []string {
+	var ws []string
+	for _, err := range annots {
+		if WarningCategoryOf(err) == WarningCategoryLabelNameCollision {
+			ws = append(ws, err.Error())
+		}
+	}
+	return ws
+}
 
 func getIntGaugeMetric(name string, attributes pcommon.Map, value int64, ts uint64) pmetric.Metric {
 	metric := pmetric.NewMetric()

--- a/storage/remote/write_otlp_handler.go
+++ b/storage/remote/write_otlp_handler.go
@@ -67,6 +67,12 @@ func NewOTLPWriteHandler(logger *slog.Logger, reg prometheus.Registerer, appenda
 		allowDeltaTemporality:   opts.NativeDelta,
 		lookbackDelta:           opts.LookbackDelta,
 		enableTypeAndUnitLabels: opts.EnableTypeAndUnitLabels,
+		translationWarnings: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "prometheus",
+			Subsystem: "api",
+			Name:      "otlp_translation_warnings_total",
+			Help:      "The total number of warnings produced while translating OTLP metrics to the Prometheus model, by category.",
+		}, []string{"category"}),
 	}
 
 	wh := &otlpWriteHandler{logger: logger, defaultConsumer: ex}
@@ -106,6 +112,7 @@ type rwExporter struct {
 	allowDeltaTemporality   bool
 	lookbackDelta           time.Duration
 	enableTypeAndUnitLabels bool
+	translationWarnings     *prometheus.CounterVec
 }
 
 func (rw *rwExporter) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
@@ -138,6 +145,9 @@ func (rw *rwExporter) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) er
 	}()
 	ws, _ := annots.AsStrings("", 0, 0)
 	if len(ws) > 0 {
+		for category, count := range otlptranslator.CountWarningsByCategory(annots) {
+			rw.translationWarnings.WithLabelValues(string(category)).Add(float64(count))
+		}
 		rw.logger.Warn("Warnings translating OTLP metrics to Prometheus write request", "warnings", ws)
 	}
 	return err

--- a/storage/remote/write_otlp_handler_test.go
+++ b/storage/remote/write_otlp_handler_test.go
@@ -256,6 +256,53 @@ func TestOTLPWriteHandler(t *testing.T) {
 			teststorage.RequireEqual(t, expectedSamples, appendable.ResultSamples())
 		})
 	}
+
+	t.Run("translation warnings metric", func(t *testing.T) {
+		newExporter := func() *rwExporter {
+			log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+			handler := NewOTLPWriteHandler(log, prometheus.NewRegistry(), teststorage.NewAppendable(), func() config.Config {
+				return config.Config{OTLPConfig: config.OTLPConfig{TranslationStrategy: otlptranslator.UnderscoreEscapingWithSuffixes}}
+			}, OTLPOptions{})
+			return handler.(*otlpWriteHandler).defaultConsumer.(*rwExporter)
+		}
+
+		t.Run("label name collision", func(t *testing.T) {
+			// Two attributes that collide after sanitization (`a.b` and `a_b` both
+			// map to `a_b`) produce one collision warning. Escaping must be enabled
+			// for the collision to occur, hence UnderscoreEscapingWithSuffixes.
+			request := pmetricotlp.NewExportRequest()
+			m := request.Metrics().ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+			m.SetName("test_gauge")
+			dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+			dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			dp.SetIntValue(1)
+			dp.Attributes().PutStr("a.b", "x")
+			dp.Attributes().PutStr("a_b", "y")
+
+			ex := newExporter()
+			require.Equal(t, 0.0, testutil.ToFloat64(ex.translationWarnings.WithLabelValues("label_name_collision")))
+			require.NoError(t, ex.ConsumeMetrics(t.Context(), request.Metrics()))
+			require.Equal(t, 1.0, testutil.ToFloat64(ex.translationWarnings.WithLabelValues("label_name_collision")))
+		})
+
+		t.Run("histogram zero count non-zero sum", func(t *testing.T) {
+			// An exponential histogram data point with zero count but a non-zero sum
+			// produces one warning in the histogram_zero_count_non_zero_sum category.
+			request := pmetricotlp.NewExportRequest()
+			m := request.Metrics().ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+			m.SetName("test_exponential_histogram")
+			m.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+			h := m.ExponentialHistogram().DataPoints().AppendEmpty()
+			h.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			h.SetCount(0)
+			h.SetSum(155)
+
+			ex := newExporter()
+			require.Equal(t, 0.0, testutil.ToFloat64(ex.translationWarnings.WithLabelValues("histogram_zero_count_non_zero_sum")))
+			require.NoError(t, ex.ConsumeMetrics(t.Context(), request.Metrics()))
+			require.Equal(t, 1.0, testutil.ToFloat64(ex.translationWarnings.WithLabelValues("histogram_zero_count_non_zero_sum")))
+		})
+	})
 }
 
 func handleOTLP(t *testing.T, exportRequest pmetricotlp.ExportRequest, otlpCfg config.OTLPConfig, otlpOpts OTLPOptions) *teststorage.Appendable {


### PR DESCRIPTION
When OTLP attributes are translated to Prometheus labels, two attribute names that translate to the same label name have their values silently concatenated with `;` (e.g. `k8s.pod.name` and `k8s_pod_name` both become label `k8s_pod_name` -> `foo;bar`). Today this happens with no signal, so operators can't tell that distinct attributes were merged. Histogram "zero count, but non-zero sum" data points already emit warning annotations, but there's no way to alert on any translation warning.

This PR makes OTLP translation warnings observable, without changing translation output.

As well, the OTLP write handler exposes `prometheus_api_otlp_translation_warnings_total`, a counter labelled by `category`, incremented per warning produced during a translation.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[ENHANCEMENT] OTLP: Warn when OTLP attribute names collide as the same label after sanitization (values are concatenated), and add the `prometheus_api_otlp_translation_warnings_total` counter, labelled by `category`, to track translation warnings
```
