### PR TITLE
promql: make duplicate series error message deterministic

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3194,9 +3194,12 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 				oneSide = "left"
 			}
 			matchedLabels := rs.Metric.MatchLabels(matching.On, matching.MatchingLabels...)
-			// Many-to-many matching not allowed.
+			dupl1, dupl2 := rs.Metric.String(), duplSample.Metric.String()
+			if dupl1 > dupl2 {
+				dupl1, dupl2 = dupl2, dupl1
+			}
 			ev.errorf("found duplicate series for the match group %s on the %s hand-side of the operation: [%s, %s]"+
-				";many-to-many matching not allowed: matching labels must be unique on one side", matchedLabels.String(), oneSide, rs.Metric.String(), duplSample.Metric.String())
+				";many-to-many matching not allowed: matching labels must be unique on one side", matchedLabels.String(), oneSide, dupl1, dupl2)
 		}
 		rightSigs[sigOrd] = rs
 		rightSigsPresent[sigOrd] = true

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -275,6 +275,51 @@ func TestQueryError(t *testing.T) {
 	require.ErrorIs(t, res.Err, errStorage, "expected error doesn't match")
 }
 
+// TestManyToManyErrorDeterministic pins the format of the "found duplicate series"
+// error. The two label strings are sorted lexicographically before formatting so the
+// message is stable regardless of the internal iteration order, which is randomised
+// per process start.
+func TestManyToManyErrorDeterministic(t *testing.T) {
+	storage := promqltest.LoadedStorage(t, `
+		load 5m
+			dup_metric{label="alpha"} 1
+			dup_metric{label="beta"}  2
+			scalar_metric{}           3
+	`)
+	t.Cleanup(func() { storage.Close() })
+
+	engine := newTestEngine(t)
+	ctx := t.Context()
+
+	for _, tc := range []struct {
+		expr    string
+		wantErr string
+	}{
+		{
+			// CardManyToOne: duplicates are on the right-hand side.
+			expr: `scalar_metric > on() dup_metric`,
+			wantErr: `found duplicate series for the match group {} on the right hand-side of the operation: ` +
+				`[{__name__="dup_metric", label="alpha"}, {__name__="dup_metric", label="beta"}];` +
+				`many-to-many matching not allowed: matching labels must be unique on one side`,
+		},
+		{
+			// CardOneToMany: duplicates are on the left-hand side.
+			expr: `dup_metric > on() group_right() scalar_metric`,
+			wantErr: `found duplicate series for the match group {} on the left hand-side of the operation: ` +
+				`[{__name__="dup_metric", label="alpha"}, {__name__="dup_metric", label="beta"}];` +
+				`many-to-many matching not allowed: matching labels must be unique on one side`,
+		},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			q, err := engine.NewInstantQuery(ctx, storage, nil, tc.expr, time.Unix(0, 0))
+			require.NoError(t, err)
+			res := q.Exec(ctx)
+			q.Close()
+			require.EqualError(t, res.Err, tc.wantErr)
+		})
+	}
+}
+
 type noopHintRecordingQueryable struct {
 	hints []*storage.SelectHints
 }

--- a/promql/promqltest/testdata/operators.test
+++ b/promql/promqltest/testdata/operators.test
@@ -1017,3 +1017,18 @@ eval range from 0 to 20m step 10m -metric_a or -metric_b
     {} -1  -4
 
 clear
+
+# Regression: the two duplicate-series label strings in the many-to-many error must
+# be sorted so the error message is deterministic regardless of evaluation order.
+load 5m
+  dup_metric{label="alpha"} 1
+  dup_metric{label="beta"}  2
+  scalar_metric{} 3
+
+eval instant at 0m scalar_metric > on() dup_metric
+  expect fail msg: found duplicate series for the match group {} on the right hand-side of the operation: [{__name__="dup_metric", label="alpha"}, {__name__="dup_metric", label="beta"}];many-to-many matching not allowed: matching labels must be unique on one side
+
+eval instant at 0m dup_metric > on() group_right() scalar_metric
+  expect fail msg: found duplicate series for the match group {} on the left hand-side of the operation: [{__name__="dup_metric", label="alpha"}, {__name__="dup_metric", label="beta"}];many-to-many matching not allowed: matching labels must be unique on one side
+
+clear


### PR DESCRIPTION
## What

`VectorBinop` reports a \"found duplicate series for the match group\" error when the same label signature appears more than once on the \"one\" side of a many-to-one or one-to-many binary operation. The error formats two label strings inside `[X, Y]`, but the order of X and Y was determined by Go map iteration, which is randomised per process start. Two evaluations of the same query on the same data could therefore produce byte-different error messages.

## Why it matters

Non-deterministic error strings cause flaky tests in downstream projects that match against this message (e.g. via `require.EqualError` or log scraping). The issue was reported in #18809.

## Fix

Sort the two label strings lexicographically before formatting. There are always exactly two strings involved, so this is a single comparison and conditional swap — no allocation, no hot-path cost, runs only inside the error branch.

```go
dupl1, dupl2 := rs.Metric.String(), duplSample.Metric.String()
if dupl1 > dupl2 {
    dupl1, dupl2 = dupl2, dupl1
}
ev.errorf("found duplicate series for the match group %s on the %s hand-side of the operation: [%s, %s]"+
    ";many-to-many matching not allowed: matching labels must be unique on one side", matchedLabels.String(), oneSide, dupl1, dupl2)
```

## Tests

- `promql/engine_test.go` — `TestManyToManyErrorDeterministic`: table-driven, covers both `CardManyToOne` (duplicates on the right) and `CardOneToMany` (`group_right`, duplicates on the left). Pins the exact error string for each case.
- `promql/promqltest/testdata/operators.test` — two `expect fail msg:` cases exercising the same paths via the standard promqltest harness.

Fixes #18809

```release-notes
[BUGFIX] PromQL: Sort duplicate series label strings in many-to-many match error so the message is deterministic across evaluations.
```