### PR TITLE
docs: align range vector link style in querying examples

### DIFF
--- a/docs/querying/examples.md
+++ b/docs/querying/examples.md
@@ -16,7 +16,7 @@ Return all time series with the metric `http_requests_total` and the given
     http_requests_total{job="apiserver", handler="/api/comments"}
 
 Return a whole range of time (in this case 5 minutes up to the query time)
-for the same vector, making it a [range vector](../basics/#range-vector-selectors):
+for the same vector, making it a [range vector](./basics.md#range-vector-selectors):
 
     http_requests_total{job="apiserver", handler="/api/comments"}[5m]
 


### PR DESCRIPTION
In docs/querying/examples.md the "range vector" link points to `../basics/#range-vector-selectors`, which resolves to a non-existent `docs/basics` path. The target section is in the sibling `basics.md`. Fixed to `./basics.md#range-vector-selectors`, matching the two other sibling links in the same file (lines 26 and 37).

```release-notes
NONE
```