### PR TITLE
PromQL: use start timestamps with float extended range selectors

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1230,6 +1230,8 @@ type EvalNodeHelper struct {
 	Ts int64
 	// Vector that can be used for output.
 	Out Vector
+	// Lookback delta for this query.
+	LookbackDelta time.Duration
 
 	// Caches.
 	// funcHistogramQuantile and funcHistogramFraction for classic histograms.
@@ -1440,7 +1442,7 @@ func (ev *evaluator) rangeEval(ctx context.Context, matching *parser.VectorMatch
 			biggestLen = len(matrixes[i])
 		}
 	}
-	enh := &EvalNodeHelper{Out: make(Vector, 0, biggestLen), enableDelayedNameRemoval: ev.enableDelayedNameRemoval}
+	enh := &EvalNodeHelper{Out: make(Vector, 0, biggestLen), LookbackDelta: ev.lookbackDelta, enableDelayedNameRemoval: ev.enableDelayedNameRemoval}
 	type seriesAndTimestamp struct {
 		Series
 		ts int64
@@ -1598,7 +1600,7 @@ func (ev *evaluator) rangeEvalAgg(ctx context.Context, aggExpr *parser.Aggregate
 
 	var annos annotations.Annotations
 
-	enh := &EvalNodeHelper{enableDelayedNameRemoval: ev.enableDelayedNameRemoval}
+	enh := &EvalNodeHelper{LookbackDelta: ev.lookbackDelta, enableDelayedNameRemoval: ev.enableDelayedNameRemoval}
 	tempNumSamples := ev.currentSamples
 
 	// Create a mapping from input series to output groups.
@@ -2224,7 +2226,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		var histograms []HPoint
 		var prevSS *Series
 		inMatrix := make(Matrix, 1)
-		enh := &EvalNodeHelper{Out: make(Vector, 0, 1), enableDelayedNameRemoval: ev.enableDelayedNameRemoval}
+		enh := &EvalNodeHelper{Out: make(Vector, 0, 1), LookbackDelta: ev.lookbackDelta, enableDelayedNameRemoval: ev.enableDelayedNameRemoval}
 		// Process all the calls for one time series at a time.
 		// For anchored and smoothed selectors, we need to iterate over a
 		// larger range than the query range to account for the lookback delta.
@@ -2816,15 +2818,19 @@ func (ev *evaluator) matrixSelector(ctx context.Context, node *parser.MatrixSele
 		matrixMaxt  = maxt
 		matrix      = make(Matrix, 0, len(vs.Series))
 		bufferRange = durationMilliseconds(node.Range)
+
+		retrieveStartTimestamps = false
 	)
 	switch {
 	case vs.Anchored:
 		bufferRange += durationMilliseconds(ev.lookbackDelta)
 		mint -= durationMilliseconds(ev.lookbackDelta)
+		retrieveStartTimestamps = true
 	case vs.Smoothed:
 		bufferRange += 2 * durationMilliseconds(ev.lookbackDelta)
 		mint -= durationMilliseconds(ev.lookbackDelta)
 		maxt += durationMilliseconds(ev.lookbackDelta)
+		retrieveStartTimestamps = true
 	}
 	it := storage.NewBuffer(bufferRange)
 	ws, err := checkAndExpandSeriesSet(ctx, node)
@@ -2844,18 +2850,30 @@ func (ev *evaluator) matrixSelector(ctx context.Context, node *parser.MatrixSele
 			Metric: series[i].Labels(),
 		}
 
-		ss.Floats, ss.Histograms, _ = ev.matrixIterSlice(it, mint, maxt, nil, nil, nil)
+		var startTimestamps *StartTimestamps
+		if ev.useStartTimestamps && retrieveStartTimestamps {
+			startTimestamps = &StartTimestamps{}
+		}
+		ss.Floats, ss.Histograms, startTimestamps = ev.matrixIterSlice(it, mint, maxt, nil, nil, startTimestamps)
 		switch {
 		case vs.Anchored:
 			if ss.Histograms != nil {
 				ev.errorf("anchored modifier is not supported with histograms")
 			}
-			ss.Floats = extendFloats(ss.Floats, matrixMint, matrixMaxt, false)
+			var sts []int64
+			if startTimestamps != nil {
+				sts = startTimestamps.Floats
+			}
+			ss.Floats = extendFloats(ss.Floats, sts, matrixMint, matrixMaxt, mint, false)
 		case vs.Smoothed:
 			if ss.Histograms != nil {
 				ev.errorf("smoothed modifier is not supported with histograms")
 			}
-			ss.Floats = extendFloats(ss.Floats, matrixMint, matrixMaxt, true)
+			var sts []int64
+			if startTimestamps != nil {
+				sts = startTimestamps.Floats
+			}
+			ss.Floats = extendFloats(ss.Floats, sts, matrixMint, matrixMaxt, mint, true)
 		}
 		totalSize := int64(len(ss.Floats)) + int64(totalHPointSize(ss.Histograms))
 		ev.samplesStats.IncrementSamplesAtTimestamp(ev.startTimestamp, totalSize)
@@ -4840,7 +4858,13 @@ func (ev *evaluator) gatherVector(ts int64, input Matrix, output Vector, bufHelp
 
 // extendFloats extends the floats to the given mint and maxt.
 // This function is used with matrix selectors that are smoothed or anchored.
-func extendFloats(floats []FPoint, mint, maxt int64, smoothed bool) []FPoint {
+func extendFloats(
+	floats []FPoint,
+	startTimestamps []int64,
+	mint, maxt int64,
+	lookbackStart int64,
+	smoothed bool,
+) []FPoint {
 	lastSampleIndex := len(floats) - 1
 
 	firstSampleIndex := max(0, sort.Search(lastSampleIndex, func(i int) bool { return floats[i].T > mint })-1)
@@ -4853,8 +4877,8 @@ func extendFloats(floats []FPoint, mint, maxt int64, smoothed bool) []FPoint {
 	}
 
 	// TODO: detect if the sample is a counter, based on __type__ or metadata.
-	left := pickOrInterpolateLeft(floats, firstSampleIndex, mint, smoothed, false)
-	right := pickOrInterpolateRight(floats, lastSampleIndex, maxt, smoothed, false)
+	left, _ := pickOrInterpolateLeft(floats, startTimestamps, firstSampleIndex, mint, lookbackStart, smoothed, false)
+	right, _ := pickOrInterpolateRight(floats, startTimestamps, lastSampleIndex, maxt, lookbackStart, smoothed, false)
 
 	// Filter out samples at boundaries or outside the range.
 	if floats[firstSampleIndex].T <= mint {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1809,6 +1809,8 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration,
 				// Binary search for the first index with T >= dataTS.
 				i := sort.Search(len(floats), func(i int) bool { return floats[i].T >= dataTS })
 
+				// TODO: for counters, detect start timestamp resets and adjust interpolation accordingly.
+
 				switch {
 				case i < len(floats) && floats[i].T == dataTS:
 					// Exact match.

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -123,7 +123,9 @@ func pickOrInterpolateLeft(
 		nextST = stOrDefault(startTimestamps, first+1, 0)
 	)
 
-	if isStartTimestampResetAfter(rangeStart, nextST, nextDP.T) {
+	if !isCounter {
+		// No adjustments due to ST.
+	} else if isStartTimestampResetAfter(rangeStart, nextST, nextDP.T) {
 		// If there is a ST reset with 'nextST' > 'rangeStart', we adjust nextDP.
 		nextDP = FPoint{
 			T: nextST,
@@ -198,7 +200,9 @@ func pickOrInterpolateRight(
 		prevST = stOrDefault(startTimestamps, last-1, 0)
 	)
 
-	if isStartTimestampResetAfter(rangeEnd, lastST, lastDP.T) {
+	if !isCounter {
+		// No adjustments due to ST.
+	} else if isStartTimestampResetAfter(rangeEnd, lastST, lastDP.T) {
 		// If there is a ST reset with 'lastST' > 'rangeEnd', we adjust lastDP.
 		lastDP = FPoint{
 			T: lastST,

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -123,15 +123,16 @@ func pickOrInterpolateLeft(
 		nextST = stOrDefault(startTimestamps, first+1, 0)
 	)
 
-	if !isCounter {
-		// No adjustments due to ST.
-	} else if isStartTimestampResetAfter(rangeStart, nextST, nextDP.T) {
+	switch {
+	case !isCounter:
+		// No adjustments.
+	case isStartTimestampResetAfter(rangeStart, nextST, nextDP.T):
 		// If there is a ST reset with 'nextST' > 'rangeStart', we adjust nextDP.
 		nextDP = FPoint{
 			T: nextST,
 			F: 0,
 		}
-	} else if isStartTimestampReset(firstST, firstDP.T, nextST, nextDP.T) {
+	case isStartTimestampReset(firstST, firstDP.T, nextST, nextDP.T):
 		// Otherwise if there is ST reset between '(firstDP.T, rangeStart]', we adjust firstDP.
 		firstDP = FPoint{
 			T: nextST,
@@ -200,16 +201,17 @@ func pickOrInterpolateRight(
 		prevST = stOrDefault(startTimestamps, last-1, 0)
 	)
 
-	if !isCounter {
-		// No adjustments due to ST.
-	} else if isStartTimestampResetAfter(rangeEnd, lastST, lastDP.T) {
+	switch {
+	case !isCounter:
+		// No adjustments.
+	case isStartTimestampResetAfter(rangeEnd, lastST, lastDP.T):
 		// If there is a ST reset with 'lastST' > 'rangeEnd', we adjust lastDP.
 		lastDP = FPoint{
 			T: lastST,
 			F: 0,
 		}
 		returnedST = prevST
-	} else if isStartTimestampReset(prevST, prevDP.T, lastST, lastDP.T) {
+	case isStartTimestampReset(prevST, prevDP.T, lastST, lastDP.T):
 		// Otherwise if there is ST reset between '(prevDP.T, rangeEnd]', we adjust prevDP.
 		prevDP = FPoint{
 			T: lastST,

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -69,21 +69,155 @@ func funcTime(_ []Vector, _ Matrix, _ parser.Expressions, enh *EvalNodeHelper) (
 // pickOrInterpolateLeft returns the value at the left boundary of the range.
 // If interpolation is needed (when smoothed is true and the first sample is before the range start),
 // it returns the interpolated value at the left boundary; otherwise, it returns the first sample's value.
-func pickOrInterpolateLeft(floats []FPoint, first int, rangeStart int64, smoothed, isCounter bool) float64 {
-	if smoothed && floats[first].T < rangeStart {
-		return interpolate(floats[first], floats[first+1], rangeStart, isCounter)
+// 'first' is expected to point to a most recent sample which is before or at 'rangeStart', or if no samples
+// satisfy this condition – first sample in the slice.
+func pickOrInterpolateLeft(
+	floats []FPoint,
+	startTimestamps []int64,
+	first int,
+	rangeStart int64,
+	lookbackStart int64,
+	smoothed, isCounter bool,
+) (float64, int64) {
+	var (
+		firstDP = floats[first]
+		firstST = stOrDefault(startTimestamps, first, 0)
+
+		returnedST = firstST
+	)
+	if returnedST > rangeStart {
+		returnedST = 0
 	}
-	return floats[first].F
+
+	if firstDP.T == rangeStart {
+		return firstDP.F, firstST
+	}
+
+	if firstDP.T > rangeStart {
+		// 'first' is meant to be the index of the most recent sample with T <= rangeStart.
+		// If the latter is not true, then there are no other samples before it.
+
+		if !isCounter {
+			return firstDP.F, returnedST
+		}
+
+		if !isStartTimestampResetAfter(lookbackStart, firstST, firstDP.T) {
+			// Check if there's a ST reset in the visible lookback.
+			return firstDP.F, returnedST
+		}
+
+		if isStartTimestampResetAfter(rangeStart, firstST, firstDP.T) {
+			// Check if there's a ST reset since the range start.
+			return 0, returnedST
+		}
+
+		if smoothed {
+			return interpolate(FPoint{T: firstST, F: 0}, firstDP, rangeStart, isCounter), returnedST
+		}
+
+		return 0, returnedST
+	}
+
+	var (
+		nextDP = floats[first+1]
+		nextST = stOrDefault(startTimestamps, first+1, 0)
+	)
+
+	if isStartTimestampResetAfter(rangeStart, nextST, nextDP.T) {
+		// If there is a ST reset with 'nextST' > 'rangeStart', we adjust nextDP.
+		nextDP = FPoint{
+			T: nextST,
+			F: 0,
+		}
+	} else if isStartTimestampReset(firstST, firstDP.T, nextST, nextDP.T) {
+		// Otherwise if there is ST reset between '(firstDP.T, rangeStart]', we adjust firstDP.
+		firstDP = FPoint{
+			T: nextST,
+			F: 0,
+		}
+		returnedST = nextST
+	}
+
+	if smoothed {
+		return interpolate(firstDP, nextDP, rangeStart, isCounter), returnedST
+	}
+
+	return firstDP.F, returnedST
 }
 
 // pickOrInterpolateRight returns the value at the right boundary of the range.
 // If interpolation is needed (when smoothed is true and the last sample is after the range end),
 // it returns the interpolated value at the right boundary; otherwise, it returns the last sample's value.
-func pickOrInterpolateRight(floats []FPoint, last int, rangeEnd int64, smoothed, isCounter bool) float64 {
-	if smoothed && last > 0 && floats[last].T > rangeEnd {
-		return interpolate(floats[last-1], floats[last], rangeEnd, isCounter)
+func pickOrInterpolateRight(
+	floats []FPoint,
+	startTimestamps []int64,
+	last int,
+	rangeEnd int64,
+	lookbackStart int64,
+	smoothed, isCounter bool,
+) (float64, int64) {
+	var (
+		lastDP = floats[last]
+		lastST = stOrDefault(startTimestamps, last, 0)
+
+		returnedST = lastST
+	)
+	if returnedST > rangeEnd {
+		returnedST = 0
 	}
-	return floats[last].F
+
+	if lastDP.T <= rangeEnd {
+		return lastDP.F, returnedST
+	}
+
+	if last == 0 {
+		if !isCounter {
+			return lastDP.F, returnedST
+		}
+
+		if !isStartTimestampResetAfter(lookbackStart, lastST, lastDP.T) {
+			// Check if there's a ST reset in the visible lookback
+			return lastDP.F, returnedST
+		}
+
+		if isStartTimestampResetAfter(rangeEnd, lastST, lastDP.T) {
+			// Check if there's a ST reset since the range end.
+			return 0, returnedST
+		}
+
+		if smoothed {
+			v := interpolate(FPoint{T: lastST, F: 0}, lastDP, rangeEnd, isCounter)
+			return v, returnedST
+		}
+
+		return 0, returnedST
+	}
+
+	var (
+		prevDP = floats[last-1]
+		prevST = stOrDefault(startTimestamps, last-1, 0)
+	)
+
+	if isStartTimestampResetAfter(rangeEnd, lastST, lastDP.T) {
+		// If there is a ST reset with 'lastST' > 'rangeEnd', we adjust lastDP.
+		lastDP = FPoint{
+			T: lastST,
+			F: 0,
+		}
+		returnedST = prevST
+	} else if isStartTimestampReset(prevST, prevDP.T, lastST, lastDP.T) {
+		// Otherwise if there is ST reset between '(prevDP.T, rangeEnd]', we adjust prevDP.
+		prevDP = FPoint{
+			T: lastST,
+			F: 0,
+		}
+	}
+
+	if smoothed {
+		return interpolate(prevDP, lastDP, rangeEnd, isCounter), returnedST
+	}
+
+	return prevDP.F, returnedST
 }
 
 // interpolate performs linear interpolation between two points.
@@ -162,16 +296,29 @@ func pickOrInterpolateRightHistogram(hists []HPoint, last int, rangeEnd int64, s
 
 // correctForCounterResets calculates the correction for counter resets.
 // This function is only used for extendedRate functions with smoothed or anchored rates.
-func correctForCounterResets(left, right float64, points []FPoint) float64 {
+func correctForCounterResets(
+	left, right float64,
+	leftT, rightT int64,
+	leftST, rightST int64,
+	points []FPoint,
+	startTimestamps []int64,
+) float64 {
 	var correction float64
-	prev := left
-	for _, p := range points {
-		if p.F < prev {
+	var (
+		prev   = left
+		prevT  = leftT
+		prevST = leftST
+	)
+	for i, p := range points {
+		st := stOrDefault(startTimestamps, i, 0)
+		if p.F < prev || isStartTimestampReset(prevST, prevT, st, p.T) {
 			correction += prev
 		}
 		prev = p.F
+		prevT = p.T
+		prevST = st
 	}
-	if right < prev {
+	if right < prev || isStartTimestampReset(prevST, prevT, rightST, rightT) {
 		correction += prev
 	}
 	return correction
@@ -315,9 +462,15 @@ func extendedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper, isC
 		lastSampleIndex = len(f) - 1
 		rangeStart      = enh.Ts - durationMilliseconds(ms.Range+vs.Offset)
 		rangeEnd        = enh.Ts - durationMilliseconds(vs.Offset)
+		lookbackStart   = rangeStart - durationMilliseconds(enh.LookbackDelta)
 		annos           annotations.Annotations
 		smoothed        = vs.Smoothed
+		startTimestamps []int64
 	)
+
+	if sts := enh.StartTimestamps; sts != nil {
+		startTimestamps = sts.Floats
+	}
 
 	firstSampleIndex := max(0, sort.Search(lastSampleIndex, func(i int) bool { return f[i].T > rangeStart })-1)
 	if smoothed {
@@ -327,12 +480,17 @@ func extendedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper, isC
 	if f[lastSampleIndex].T <= rangeStart {
 		return enh.Out, annos
 	}
-	if smoothed && f[firstSampleIndex].T > rangeEnd {
-		return enh.Out, annos
+	if firstT := f[firstSampleIndex].T; smoothed && firstT > rangeEnd {
+		firstST := stOrDefault(startTimestamps, firstSampleIndex, 0)
+		if !isCounter || !isStartTimestampReset(lookbackStart, lookbackStart, firstST, firstT) || isStartTimestampReset(rangeEnd, rangeEnd, firstST, firstT) {
+			// We cannot calculate a rate if there's no ST reset in inside lookback range, or if the reset is after
+			// range end.
+			return enh.Out, annos
+		}
 	}
 
-	left := pickOrInterpolateLeft(f, firstSampleIndex, rangeStart, smoothed, isCounter)
-	right := pickOrInterpolateRight(f, lastSampleIndex, rangeEnd, smoothed, isCounter)
+	left, leftST := pickOrInterpolateLeft(f, startTimestamps, firstSampleIndex, rangeStart, lookbackStart, smoothed, isCounter)
+	right, rightST := pickOrInterpolateRight(f, startTimestamps, lastSampleIndex, rangeEnd, lookbackStart, smoothed, isCounter)
 
 	resultFloat := right - left
 
@@ -347,7 +505,9 @@ func extendedRate(vals Matrix, args parser.Expressions, enh *EvalNodeHelper, isC
 			lastSampleIndex--
 		}
 
-		resultFloat += correctForCounterResets(left, right, f[firstSampleIndex:lastSampleIndex+1])
+		stLen := len(startTimestamps)
+		sts := startTimestamps[min(stLen, firstSampleIndex):min(stLen, lastSampleIndex+1)]
+		resultFloat += correctForCounterResets(left, right, rangeStart, rangeEnd, leftST, rightST, f[firstSampleIndex:lastSampleIndex+1], sts)
 	}
 	if isRate {
 		resultFloat /= ms.Range.Seconds()
@@ -702,8 +862,9 @@ func histogramRate(
 
 // isStartTimestampReset tells whether there was a counter reset by checking the start timestamp value.
 func isStartTimestampReset(prevStartTimestamp, prevTimestamp, currStartTimestamp, currTimestamp int64) bool {
-	if currStartTimestamp == 0 || currStartTimestamp > currTimestamp {
-		// No reset if start timestamp is not set (value is 0), or if it is clearly invalid.
+	if currStartTimestamp == 0 || currStartTimestamp >= currTimestamp {
+		// No reset if start timestamp is not set (value is 0), if it is clearly invalid
+		// (ST > T), or if it is OTel's unknown start time (ST == T).
 		return false
 	}
 
@@ -729,7 +890,18 @@ func isStartTimestampReset(prevStartTimestamp, prevTimestamp, currStartTimestamp
 	if prevStartTimestamp > prevTimestamp {
 		return false
 	}
-	return prevStartTimestamp != 0
+	return prevStartTimestamp != 0 && prevStartTimestamp != prevTimestamp
+}
+
+func isStartTimestampResetAfter(t, startTimestamps, timestamp int64) bool {
+	if startTimestamps <= t || timestamp <= t {
+		return false
+	}
+	// To check whether there is a start timestamps reset after a time t, we use the same function
+	// which checks for resets between two datapoints. However, for previous datapoint we pass an imaginary
+	// datapoints with T=t and ST=t. This creates and unknown start timestamp datapoint (ST==T),
+	// which only allows resets if following datapoint ST is after it.
+	return isStartTimestampReset(t, t, startTimestamps, timestamp)
 }
 
 // === delta(Matrix parser.ValueTypeMatrix) (Vector, Annotations) ===
@@ -2789,4 +2961,11 @@ func stringSliceFromArgs(args parser.Expressions) []string {
 
 func getMetricName(metric labels.Labels) string {
 	return metric.Get(model.MetricNameLabel)
+}
+
+func stOrDefault(startTimestamps []int64, idx int, def int64) int64 {
+	if idx < len(startTimestamps) {
+		return startTimestamps[idx]
+	}
+	return def
 }

--- a/promql/info.go
+++ b/promql/info.go
@@ -275,7 +275,8 @@ func (ev *evaluator) combineWithInfoSeries(ctx context.Context, mat, infoMat Mat
 	baseVector := make(Vector, 0, len(mat))
 	infoVector := make(Vector, 0, len(infoMat))
 	enh := &EvalNodeHelper{
-		Out: make(Vector, 0, biggestLen),
+		Out:           make(Vector, 0, biggestLen),
+		LookbackDelta: ev.lookbackDelta,
 	}
 	type seriesAndTimestamp struct {
 		Series

--- a/promql/promqltest/testdata/start_timestamps.test
+++ b/promql/promqltest/testdata/start_timestamps.test
@@ -26,11 +26,16 @@ eval range from 7m to 15m step 1m round(increase(cumulative[5m1ms]))
     {type="st_resets"}          420 720 720 600 1080 1080 780 1440 1440
     {type="normalized_resets"}  420 720 720 600 1080 1080 780 1440 1440
 
-# TODO actual anchored
-# eval range from 7m to 15m step 1m increase(cumulative[5m] anchored)
-#    {type="no_st"}              300 300 300 300  300  300 300  300  300
-#    {type="st_resets"}          420 720 720 600 1080 1080 780 1440 1440
-#    {type="normalized_resets"}  420 720 720 600 1080 1080 780 1440 1440
+eval range from 7m to 15m step 1m increase(cumulative[5m] anchored)
+    {type="no_st"}              300 300 300 300  300  300 300  300  300
+    {type="st_resets"}          420 720 720 600 1080 1080 780 1440 1440
+    {type="normalized_resets"}  420 720 720 600 1080 1080 780 1440 1440
+
+eval range from 7m to 15m step 1m increase(cumulative[5m] smoothed)
+    {type="no_st"}              300 300 300 300  300  300 300  300  300
+    {type="st_resets"}          420 720 720 600 1080 1080 780 1440 1440
+    {type="normalized_resets"}  420 720 720 600 1080 1080 780 1440 1440
+
 
 # Subqueries cut the propagation of start timestamps.
 eval range from 7m to 15m step 1m increase(cumulative[5m:1m])
@@ -68,7 +73,7 @@ eval range from 10m to 15m step 1m increase(delta[5m])
     {type="otel"}               300x5
     {type="gcp"}                300x5
     {type="minimal_range"}      300x5
-    {type="empty_range"}        300x5
+    {type="empty_range"}          0x5
     {type="normalized_resets"}  300x5
 
 eval range from 10m to 15m step 1m rate(delta[5m])
@@ -76,7 +81,7 @@ eval range from 10m to 15m step 1m rate(delta[5m])
     {type="otel"}               1x5
     {type="gcp"}                1x5
     {type="minimal_range"}      1x5
-    {type="empty_range"}        1x5
+    {type="empty_range"}        0x5
     {type="normalized_resets"}  1x5
 
 eval range from 10m to 15m step 1m irate(delta[5m])
@@ -84,7 +89,7 @@ eval range from 10m to 15m step 1m irate(delta[5m])
     {type="otel"}               1x5
     {type="gcp"}                1x5
     {type="minimal_range"}      1x5
-    {type="empty_range"}        1x5
+    {type="empty_range"}        0x5
     {type="normalized_resets"}  1x5
 
 # Subqueries cuts the propagation of start timestamps
@@ -115,6 +120,200 @@ eval instant at 3m round(increase(series[1m1ms]))
     {type="otel_cumulative_unknown_start"}  0
     {type="otel_delta"}                     1
     {type="invalid_prev_st"}                0
+
+clear
+
+# Tests for extended range selectors (`anchored`, `smoothed`).
+load 1m
+    series{type="1_dp_before/st_outside_lookback"}@st                 _x100 -10m    _    _    _
+    series{type="1_dp_before/st_outside_lookback"}                    _x100   60    _    _    _
+    series{type="1_dp_before/st_outside_range"}@st                    _x100  -3m    _    _    _
+    series{type="1_dp_before/st_outside_range"}                       _x100   60    _    _    _
+    series{type="1_dp_before/st_at_range_edge"}@st                    _x100  -1m    _    _    _
+    series{type="1_dp_before/st_at_range_edge"}                       _x100   60    _    _    _
+    series{type="1_dp_before/st_inside"}@st                           _x100 -30s    _    _    _
+    series{type="1_dp_before/st_inside"}                              _x100   60    _    _    _
+    series{type="1_dp_at/st_outside_range"}@st                        _x100    _ -10m    _    _
+    series{type="1_dp_at/st_outside_range"}                           _x100    _   60    _    _
+    series{type="1_dp_at/st_outside_range"}@st                        _x100    _  -3m    _    _
+    series{type="1_dp_at/st_outside_range"}                           _x100    _   60    _    _
+    series{type="1_dp_at/st_at_range_edge"}@st                        _x100    _  -2m    _    _
+    series{type="1_dp_at/st_at_range_edge"}                           _x100    _   60    _    _
+    series{type="1_dp_at/st_inside_range"}@st                         _x100    _  -1m    _    _
+    series{type="1_dp_at/st_inside_range"}                            _x100    _   60    _    _
+    series{type="1_dp_after/st_outside_lookback"}@st                  _x100    _    _ -10m    _
+    series{type="1_dp_after/st_outside_lookback"}                     _x100    _    _   60    _
+    series{type="1_dp_after/st_outside_range"}@st                     _x100    _    _  -5m    _
+    series{type="1_dp_after/st_outside_range"}                        _x100    _    _   60    _
+    series{type="1_dp_after/st_at_range_edge"}@st                     _x100    _    _  -3m    _
+    series{type="1_dp_after/st_at_range_edge"}                        _x100    _    _   60    _
+    series{type="1_dp_after/st_close"}@st                             _x100    _    _  -2m    _
+    series{type="1_dp_after/st_close"}                                _x100    _    _   60    _
+    series{type="1_dp_after/st_closer"}@st                            _x100    _    _  -1m    _
+    series{type="1_dp_after/st_closer"}                               _x100    _    _   60    _
+    series{type="1_dp_after/st_closest"}@st                           _x100    _    _ -30s    _
+    series{type="1_dp_after/st_closest"}                              _x100    _    _   60    _
+    series{type="2_dp_before/st_no_reset"}@st                         _x100  -1m  -2m    _    _
+    series{type="2_dp_before/st_no_reset"}                            _x100   60  120    _    _
+    series{type="2_dp_before/st_delta_reset"}@st                      _x100  -1m  -1m    _    _
+    series{type="2_dp_before/st_delta_reset"}                         _x100   60   60    _    _
+    series{type="2_dp_before/st_reset_inside"}@st                     _x100  -1m -30s    _    _
+    series{type="2_dp_before/st_reset_inside"}                        _x100   60   60    _    _
+    series{type="2_dp_before/st_unknown"}@st                          _x100    0  -1m    _    _
+    series{type="2_dp_before/st_unknown"}                             _x100   60  120    _    _
+    series{type="2_dp_straddle/st_no_reset"}@st                       _x100  -1m    _  -3m    _
+    series{type="2_dp_straddle/st_no_reset"}                          _x100   60    _  120    _
+    series{type="2_dp_straddle/st_delta_reset"}@st                    _x100  -1m    _  -2m    _
+    series{type="2_dp_straddle/st_delta_reset"}                       _x100   60    _   60    _
+    series{type="2_dp_straddle/st_reset_inside"}@st                   _x100  -1m    _ -90s    _
+    series{type="2_dp_straddle/st_reset_inside"}                      _x100   60    _   60    _
+    series{type="2_dp_straddle/st_reset_inside_closer"}@st            _x100  -1m    _ -30s    _
+    series{type="2_dp_straddle/st_reset_inside_closer"}               _x100   60    _   60    _
+    series{type="2_dp_straddle/st_unknown"}@st                        _x100    0    _  -2m    _
+    series{type="2_dp_straddle/st_unknown"}                           _x100   60    _  120    _
+    series{type="2_dp_after/st_no_reset"}@st                          _x100    _  -1m  -2m    _
+    series{type="2_dp_after/st_no_reset"}                             _x100    _   60  120    _
+    series{type="2_dp_after/st_delta_reset"}@st                       _x100    _  -1m  -1m    _
+    series{type="2_dp_after/st_delta_reset"}                          _x100    _   60   60    _
+    series{type="2_dp_after/st_reset_inside"}@st                      _x100    _  -1m -30s    _
+    series{type="2_dp_after/st_reset_inside"}                         _x100    _   60   60    _
+    series{type="2_dp_after/st_unknown"}@st                           _x100    _    0  -1m    _
+    series{type="2_dp_after/st_unknown"}                              _x100    _   60  120    _
+
+eval instant at 101m increase(series[2m] anchored)
+    {type="1_dp_before/st_outside_lookback"}               0
+    {type="1_dp_before/st_outside_range"}                 60
+    {type="1_dp_before/st_at_range_edge"}                 60
+    {type="1_dp_before/st_inside"}                        60
+    {type="1_dp_at/st_outside_range"}                     60
+    {type="1_dp_at/st_outside_range"}                     60
+    {type="1_dp_at/st_at_range_edge"}                     60
+    {type="1_dp_at/st_inside_range"}                      60
+    {type="2_dp_before/st_no_reset"}                     120
+    {type="2_dp_before/st_delta_reset"}                  120
+    {type="2_dp_before/st_reset_inside"}                 120
+    {type="2_dp_before/st_unknown"}                       60
+    {type="2_dp_straddle/st_no_reset"}                    60
+    {type="2_dp_straddle/st_delta_reset"}                 60
+    {type="2_dp_straddle/st_reset_inside"}                60
+    {type="2_dp_straddle/st_reset_inside_closer"}         60
+    {type="2_dp_straddle/st_unknown"}                      0
+    {type="2_dp_after/st_no_reset"}                       60
+    {type="2_dp_after/st_delta_reset"}                    60
+    {type="2_dp_after/st_reset_inside"}                   60
+    {type="2_dp_after/st_unknown"}                         0
+
+eval instant at 103m increase(series[2m] anchored)
+    {type="1_dp_after/st_outside_lookback"}                0
+    {type="1_dp_after/st_outside_range"}                  60
+    {type="1_dp_after/st_at_range_edge"}                  60
+    {type="1_dp_after/st_close"}                          60
+    {type="1_dp_after/st_closer"}                         60
+    {type="1_dp_after/st_closest"}                        60
+    {type="2_dp_straddle/st_no_reset"}                    60
+    {type="2_dp_straddle/st_delta_reset"}                 60
+    {type="2_dp_straddle/st_reset_inside"}                60
+    {type="2_dp_straddle/st_reset_inside_closer"}         60
+    {type="2_dp_straddle/st_unknown"}                     60
+    {type="2_dp_after/st_no_reset"}                       60
+    {type="2_dp_after/st_delta_reset"}                    60
+    {type="2_dp_after/st_reset_inside"}                   60
+    {type="2_dp_after/st_unknown"}                        60
+
+eval instant at 101m rate(series[2m] smoothed)
+    {type="1_dp_before/st_outside_lookback"}              0
+    {type="1_dp_before/st_outside_range"}                 0.1666666666666667
+    {type="1_dp_before/st_at_range_edge"}                 0.5
+    {type="1_dp_before/st_inside"}                        0.5
+    {type="1_dp_at/st_outside_range"}                     0.3333333333333333
+    {type="1_dp_at/st_at_range_edge"}                     0.5
+    {type="1_dp_at/st_inside_range"}                      0.5
+    {type="1_dp_after/st_outside_range"}                  0.2
+    {type="1_dp_after/st_at_range_edge"}                  0.3333333333333333
+    {type="1_dp_after/st_close"}                          0.25
+    {type="1_dp_after/st_closer"}                         0
+    {type="2_dp_before/st_no_reset"}                      1
+    {type="2_dp_before/st_delta_reset"}                   1
+    {type="2_dp_before/st_reset_inside"}                  1
+    {type="2_dp_before/st_unknown"}                       0.5
+    {type="2_dp_straddle/st_no_reset"}                    0.75
+    {type="2_dp_straddle/st_delta_reset"}                 0.75
+    {type="2_dp_straddle/st_reset_inside"}                0.6666666666666667
+    {type="2_dp_straddle/st_reset_inside_closer"}         0.5
+    {type="2_dp_straddle/st_unknown"}                     0.25
+    {type="2_dp_after/st_no_reset"}                       0.5
+    {type="2_dp_after/st_delta_reset"}                    0.5
+    {type="2_dp_after/st_reset_inside"}                   0.5
+    {type="2_dp_after/st_unknown"}                        0
+
+eval instant at 103m rate(series[2m] smoothed)
+    {type="1_dp_after/st_outside_lookback"}               0
+    {type="1_dp_after/st_outside_range"}                  0.1
+    {type="1_dp_after/st_at_range_edge"}                  0.16666666666666667
+    {type="1_dp_after/st_close"}                          0.25
+    {type="1_dp_after/st_closer"}                         0.5
+    {type="1_dp_after/st_closest"}                        0.5
+    {type="2_dp_straddle/st_no_reset"}                    0.25
+    {type="2_dp_straddle/st_delta_reset"}                 0.25
+    {type="2_dp_straddle/st_reset_inside"}                0.3333333333333333
+    {type="2_dp_straddle/st_reset_inside_closer"}         0.5
+    {type="2_dp_straddle/st_unknown"}                     0.25
+    {type="2_dp_after/st_no_reset"}                       0.5
+    {type="2_dp_after/st_delta_reset"}                    0.5
+    {type="2_dp_after/st_reset_inside"}                   0.5
+    {type="2_dp_after/st_unknown"}                        0.5
+
+clear
+
+
+load 1m
+    series{type="st_no_reset"}@st                       _x100  -1m    _  -3m    _
+    series{type="st_no_reset"}                          _x100   60    _  120    _
+    series{type="st_delta_reset"}@st                    _x100  -1m    _  -2m    _
+    series{type="st_delta_reset"}                       _x100   60    _   60    _
+    series{type="st_reset_inside"}@st                   _x100  -1m    _ -90s    _
+    series{type="st_reset_inside"}                      _x100   60    _   60    _
+    series{type="st_reset_inside_closer"}@st            _x100  -1m    _ -30s    _
+    series{type="st_reset_inside_closer"}               _x100   60    _   60    _
+    series{type="st_unknown"}@st                        _x100    0    _  -2m    _
+    series{type="st_unknown"}                           _x100   60    _  120    _
+
+# A few tests with selected timeseries to validate that delta() function ignores start timestamps.
+eval instant at 101m delta(series[2m] smoothed)
+    {type="st_no_reset"}             30
+    {type="st_delta_reset"}           0
+    {type="st_reset_inside"}          0
+    {type="st_reset_inside_closer"}   0
+    {type="st_unknown"}              30
+
+eval instant at 103m delta(series[2m] anchored)
+    {type="st_no_reset"}             60
+    {type="st_delta_reset"}           0
+    {type="st_reset_inside"}          0
+    {type="st_reset_inside_closer"}   0
+    {type="st_unknown"}              60
+
+clear
+
+
+# Special case for to check that counter resets don't get lost when `pickOrInterpolate*()` functions
+# project/interpolate samples at range start. This might happen if there was a sample the ST of which
+# was pointing to range start. If there were no samples at range start, then this means a counter reset.
+# However, once we project/interpolate a sample at range start, with particular ST values this might
+# become unknown ST, losing the reset.
+load 1m
+    series{type="potentially_unknown_ST=0"}@st     _x100    _    _  -1m    _
+    series{type="potentially_unknown_ST=0"}        _x100   60    _   60    _
+    series{type="potentially_unknown_ST=T"}@st     _x100   1m    _  -1m    _
+    series{type="potentially_unknown_ST=T"}        _x100   60    _   60    _
+
+eval instant at 103m increase(series[2m] anchored)
+    {type="potentially_unknown_ST=0"}       60
+    {type="potentially_unknown_ST=T"}       60
+
+eval instant at 103m rate(series[2m] smoothed)
+    {type="potentially_unknown_ST=0"}       0.5
+    {type="potentially_unknown_ST=T"}       0.5
 
 clear
 

--- a/promql/promqltest/testdata/start_timestamps.test
+++ b/promql/promqltest/testdata/start_timestamps.test
@@ -267,16 +267,16 @@ clear
 
 
 load 1m
-    series{type="st_no_reset"}@st                       _x100  -1m    _  -3m    _
-    series{type="st_no_reset"}                          _x100   60    _  120    _
-    series{type="st_delta_reset"}@st                    _x100  -1m    _  -2m    _
-    series{type="st_delta_reset"}                       _x100   60    _   60    _
-    series{type="st_reset_inside"}@st                   _x100  -1m    _ -90s    _
-    series{type="st_reset_inside"}                      _x100   60    _   60    _
-    series{type="st_reset_inside_closer"}@st            _x100  -1m    _ -30s    _
-    series{type="st_reset_inside_closer"}               _x100   60    _   60    _
-    series{type="st_unknown"}@st                        _x100    0    _  -2m    _
-    series{type="st_unknown"}                           _x100   60    _  120    _
+    series{type="st_no_reset"}@st                       _x100  -1m    _  -3m    _  -5m
+    series{type="st_no_reset"}                          _x100   60    _  120    _  180
+    series{type="st_delta_reset"}@st                    _x100  -1m    _  -2m    _  -2m
+    series{type="st_delta_reset"}                       _x100   60    _   60    _   60
+    series{type="st_reset_inside"}@st                   _x100  -1m    _ -90s    _ -90s
+    series{type="st_reset_inside"}                      _x100   60    _   60    _   60
+    series{type="st_reset_inside_closer"}@st            _x100  -1m    _ -30s    _ -30s
+    series{type="st_reset_inside_closer"}               _x100   60    _   60    _   60
+    series{type="st_unknown"}@st                        _x100    0    _  -2m    _  -5m
+    series{type="st_unknown"}                           _x100   60    _  120    _  180
 
 # A few tests with selected timeseries to validate that delta() function ignores start timestamps.
 eval instant at 101m delta(series[2m] smoothed)
@@ -292,6 +292,38 @@ eval instant at 103m delta(series[2m] anchored)
     {type="st_reset_inside"}          0
     {type="st_reset_inside_closer"}   0
     {type="st_unknown"}              60
+
+# A few tests for raw sample anchoring / smoothing.
+# TODO: the code currently treats these series not as counters, so STs are ignored.
+eval instant at 101m series smoothed
+    series{type="st_no_reset"}             90
+    series{type="st_delta_reset"}          60
+    series{type="st_reset_inside"}         60
+    series{type="st_reset_inside_closer"}  60
+    series{type="st_unknown"}              90
+
+eval instant at 101m series anchored
+    series{type="st_no_reset"}             60
+    series{type="st_delta_reset"}          60
+    series{type="st_reset_inside"}         60
+    series{type="st_reset_inside_closer"}  60
+    series{type="st_unknown"}              60
+
+eval instant at 103m series[2m] smoothed
+    expect range vector from 101m to 103m step 1m
+    series{type="st_no_reset"}             90 120 150
+    series{type="st_delta_reset"}          60  60  60
+    series{type="st_reset_inside"}         60  60  60
+    series{type="st_reset_inside_closer"}  60  60  60
+    series{type="st_unknown"}              90 120 150
+
+eval instant at 103m series[2m] anchored
+    expect range vector from 101m to 103m step 1m
+    series{type="st_no_reset"}             60 120 120
+    series{type="st_delta_reset"}          60  60  60
+    series{type="st_reset_inside"}         60  60  60
+    series{type="st_reset_inside_closer"}  60  60  60
+    series{type="st_unknown"}              60 120 120
 
 clear
 


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Updating extended range selector (`anochored`, `smoothed`) code to detect float counter resets using start timestamps. This PR implements logic which is described in [this section of PROM-77 proposal](https://github.com/vpranckaitis/prometheus-proposals/blob/71746e2ac9d5f254e04c6efc63ec5bab3c68ded2/proposals/0077-use-start-timestamp-in-rate-like-functions.md#extended-range-selectors-anchored-and-smoothed-modifiers).

When considering `rate()`-like functions with extended rate selectors, there are two parts affected by start timestamp inclusion:
* Detecting counter resets between samples inside the range, and also projected / interpolated samples at range start / end. This is similar to how we detect counter resets between samples in original `rate()`.
* Taking into account start timestamps when projecting / interpolating samples at the range start and end. There are many different configurations of how samples and start timestamps could be situated around projection / interpolation point, thus this constitute the bulk of the logic changes. See the [PROM-77 proposal](https://github.com/vpranckaitis/prometheus-proposals/blob/71746e2ac9d5f254e04c6efc63ec5bab3c68ded2/proposals/0077-use-start-timestamp-in-rate-like-functions.md#extended-range-selectors-anchored-and-smoothed-modifiers) for illustrated description of different configurations.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
–

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[FEATURE] PromQL: Use start timestamps to detect counter resets when float timeseries are queried using extended range selector modifiers (`anchored`, `smoothed`). This feature is hidden behind `use-start-timestamps` feature flag. 
```