### PR TITLE
ui: link react-app to local codemirror-promql instead of an npm version

### DIFF
--- a/scripts/ui_release.sh
+++ b/scripts/ui_release.sh
@@ -77,14 +77,11 @@ function bumpVersion() {
   fi
   # increase the version on all packages in the pnpm workspace
   pnpm -r --include-workspace-root version "${version}" --no-git-tag-version --git-checks=false
-  # bump react-app version and update pinned @prometheus-io/* dependencies
+  # bump the react-app version. its @prometheus-io/* dependencies use the
+  # "link:" protocol to consume the locally built workspace packages, so they
+  # carry no version to rewrite and must be left untouched.
   cd react-app
   pnpm version "${version}" --no-git-tag-version --git-checks=false
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -E -i "" "s|(\"@prometheus-io/.+\": )\".+\"|\1\"${version}\"|" package.json
-  else
-    sed -E -i "s|(\"@prometheus-io/.+\": )\".+\"|\1\"${version}\"|" package.json
-  fi
   cd "${root_ui_folder}"
 }
 

--- a/web/ui/react-app/package.json
+++ b/web/ui/react-app/package.json
@@ -20,7 +20,7 @@
     "@lezer/lr": "^1.4.10",
     "@nexucis/fuzzy": "^0.5.1",
     "@nexucis/kvsearch": "^0.9.1",
-    "@prometheus-io/codemirror-promql": "0.311.3",
+    "@prometheus-io/codemirror-promql": "link:../module/codemirror-promql",
     "bootstrap": "^4.6.2",
     "css.escape": "^1.5.1",
     "downshift": "^9.3.6",

--- a/web/ui/react-app/pnpm-lock.yaml
+++ b/web/ui/react-app/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       '@prometheus-io/codemirror-promql':
-        specifier: 0.311.3
-        version: 0.311.3(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)
+        specifier: link:../module/codemirror-promql
+        version: link:../module/codemirror-promql
       bootstrap:
         specifier: ^4.6.2
         version: 4.6.2(jquery@3.7.1)(popper.js@1.16.1)
@@ -1375,23 +1375,6 @@ packages:
         optional: true
       webpack-plugin-serve:
         optional: true
-
-  '@prometheus-io/codemirror-promql@0.311.3':
-    resolution: {integrity: sha512-WgfC910pn/EHcwC9zRPwO8hGbT0G2eS5uvGi4GCAtKLY68SqfjIXaewvOMyR3avnIjoL7c45WpxkD5++df8omQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@codemirror/autocomplete': ^6.4.0
-      '@codemirror/language': ^6.3.0
-      '@codemirror/lint': ^6.0.0
-      '@codemirror/state': ^6.1.1
-      '@codemirror/view': ^6.4.0
-      '@lezer/common': ^1.0.1
-
-  '@prometheus-io/lezer-promql@0.311.3':
-    resolution: {integrity: sha512-2MmOiYa4DNAkav12w8g5hSCZgGDEKFoT2Y6kqmhdhlXvP8zyACv3mx+wOqmJdkX0zLP0KZyjrQIOZtAXIHlnsA==}
-    peerDependencies:
-      '@lezer/highlight': ^1.1.2
-      '@lezer/lr': ^1.2.3
 
   '@rollup/plugin-babel@5.3.1':
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
@@ -4167,10 +4150,6 @@ packages:
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
-
-  lru-cache@11.5.0:
-    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
-    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -7848,25 +7827,6 @@ snapshots:
       type-fest: 4.41.0
       webpack-dev-server: 4.15.2(webpack@5.107.1(postcss@8.5.15))
 
-  '@prometheus-io/codemirror-promql@0.311.3(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)':
-    dependencies:
-      '@codemirror/autocomplete': 6.20.3
-      '@codemirror/language': 6.12.3
-      '@codemirror/lint': 6.9.7
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
-      '@lezer/common': 1.5.2
-      '@prometheus-io/lezer-promql': 0.311.3(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)
-      lru-cache: 11.5.0
-    transitivePeerDependencies:
-      - '@lezer/highlight'
-      - '@lezer/lr'
-
-  '@prometheus-io/lezer-promql@0.311.3(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)':
-    dependencies:
-      '@lezer/highlight': 1.2.3
-      '@lezer/lr': 1.4.10
-
   '@rollup/plugin-babel@5.3.1(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@2.80.0)':
     dependencies:
       '@babel/core': 7.29.7
@@ -11360,8 +11320,6 @@ snapshots:
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
-
-  lru-cache@11.5.0: {}
 
   lru-cache@5.1.1:
     dependencies:


### PR DESCRIPTION
react-app is not part of the pnpm workspace, so it pulled @prometheus-io/codemirror-promql from the npm registry by exact version. During a release, `make ui-bump-version` rewrote that pin to the new, not-yet-published version, so the subsequent `pnpm install` failed with ERR_PNPM_NO_MATCHING_VERSION.

Use pnpm's "link:" protocol to consume the locally built workspace package instead. There is no version to publish or rewrite, react-app always builds against the in-tree codemirror-promql, and its lockfile stays isolated (which is why react-app was separated from the workspace in the first place).

build_ui.sh --all already builds the modules before react-app, so dist/ is present at build time; `make ui-build` passes. Drop the dependency-rewriting sed from ui_release.sh's bumpVersion accordingly.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
