### PR TITLE
remote/azuread: respect AZURE_FEDERATED_TOKEN_FILE for workload identity

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -3841,6 +3841,10 @@ azuread:
   [ workload_identity:
      client_id: <string>
      tenant_id: <string>
+     # Path to the projected service account token file. If unset, Prometheus
+     # uses the AZURE_FEDERATED_TOKEN_FILE environment variable (set by the
+     # Azure Workload Identity webhook); if that is also unset, it falls back
+     # to the default below.
      [ token_file_path: <string> | default = "/var/run/secrets/azure/tokens/azure-identity-token" ] ]
 
   # Azure OAuth.

--- a/storage/remote/azuread/azuread.go
+++ b/storage/remote/azuread/azuread.go
@@ -48,7 +48,15 @@ const (
 const (
 	// DefaultWorkloadIdentityTokenPath is the default path where the Azure Workload Identity
 	// webhook puts the service account token on Azure environments. See <azure docs link>.
+	// It is only used as a fallback when the AzureFederatedTokenFileEnvVar environment
+	// variable is unset, since the webhook may project the token to a different path.
 	DefaultWorkloadIdentityTokenPath = "/var/run/secrets/azure/tokens/azure-identity-token"
+
+	// AzureFederatedTokenFileEnvVar is the environment variable the Azure Workload Identity
+	// webhook sets to the path of the projected service account token. The path moved
+	// between webhook releases, so this variable is the authoritative source of the token
+	// location and takes precedence over DefaultWorkloadIdentityTokenPath.
+	AzureFederatedTokenFileEnvVar = "AZURE_FEDERATED_TOKEN_FILE"
 )
 
 // ManagedIdentityConfig is used to store managed identity config values.
@@ -67,7 +75,8 @@ type WorkloadIdentityConfig struct {
 	TenantID string `yaml:"tenant_id,omitempty"`
 
 	// TokenFilePath is the path to the token file provided by the Kubernetes service account projected volume.
-	// If not specified, it defaults to DefaultWorkloadIdentityTokenPath.
+	// If not specified, it defaults to the AzureFederatedTokenFileEnvVar environment variable when set,
+	// otherwise to DefaultWorkloadIdentityTokenPath.
 	TokenFilePath string `yaml:"token_file_path,omitempty"`
 }
 
@@ -215,7 +224,14 @@ func (c *AzureADConfig) Validate() error {
 		}
 
 		if c.WorkloadIdentity.TokenFilePath == "" {
-			c.WorkloadIdentity.TokenFilePath = DefaultWorkloadIdentityTokenPath
+			// Prefer the path advertised by the Azure Workload Identity webhook via the
+			// environment variable, since the projected token location can change between
+			// webhook releases. Fall back to the historical default only when it is unset.
+			if tokenFilePath := os.Getenv(AzureFederatedTokenFileEnvVar); tokenFilePath != "" {
+				c.WorkloadIdentity.TokenFilePath = tokenFilePath
+			} else {
+				c.WorkloadIdentity.TokenFilePath = DefaultWorkloadIdentityTokenPath
+			}
 		}
 	}
 

--- a/storage/remote/azuread/azuread_test.go
+++ b/storage/remote/azuread/azuread_test.go
@@ -518,3 +518,57 @@ func TestCustomScopeSupport(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkloadIdentityTokenFilePath(t *testing.T) {
+	const envTokenPath = "/var/run/secrets/azure/wi/token/azure-identity-token"
+
+	cases := []struct {
+		name              string
+		envValue          string
+		envSet            bool
+		configTokenPath   string
+		expectedTokenPath string
+	}{
+		{
+			name:              "AZURE_FEDERATED_TOKEN_FILE is honored when token_file_path is unset",
+			envValue:          envTokenPath,
+			envSet:            true,
+			expectedTokenPath: envTokenPath,
+		},
+		{
+			name:              "falls back to the default path when the environment variable is unset",
+			envSet:            false,
+			expectedTokenPath: DefaultWorkloadIdentityTokenPath,
+		},
+		{
+			name:              "an explicit token_file_path takes precedence over the environment variable",
+			envValue:          envTokenPath,
+			envSet:            true,
+			configTokenPath:   "/custom/token/path",
+			expectedTokenPath: "/custom/token/path",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.envSet {
+				t.Setenv(AzureFederatedTokenFileEnvVar, c.envValue)
+			} else {
+				// t.Setenv with an empty value still sets the variable, so unset it explicitly.
+				require.NoError(t, os.Unsetenv(AzureFederatedTokenFileEnvVar))
+			}
+
+			cfg := &AzureADConfig{
+				Cloud: "AzurePublic",
+				WorkloadIdentity: &WorkloadIdentityConfig{
+					ClientID:      dummyClientID,
+					TenantID:      dummyTenantID,
+					TokenFilePath: c.configTokenPath,
+				},
+			}
+
+			require.NoError(t, cfg.Validate())
+			require.Equal(t, c.expectedTokenPath, cfg.WorkloadIdentity.TokenFilePath)
+		})
+	}
+}


### PR DESCRIPTION
## What this does

`remote_write` with `azuread.workload_identity` ignored the `AZURE_FEDERATED_TOKEN_FILE` environment variable. When `token_file_path` was not configured, `Validate()` unconditionally set it to the hardcoded `DefaultWorkloadIdentityTokenPath` (`/var/run/secrets/azure/tokens/azure-identity-token`).

After the [azure-workload-identity webhook](https://github.com/Azure/azure-workload-identity) v1.6.0 relocated the projected service account token to `/var/run/secrets/azure/wi/token/azure-identity-token` (and updated `AZURE_FEDERATED_TOKEN_FILE` accordingly), authentication broke and required a manual `token_file_path` override.

This makes `Validate()` prefer the path advertised by the webhook via `AZURE_FEDERATED_TOKEN_FILE`, falling back to the historical default only when the variable is unset — so existing deployments keep working.

## Testing

Added `TestWorkloadIdentityTokenFilePath`, which covers:
- the env var is honored when `token_file_path` is unset,
- it falls back to `DefaultWorkloadIdentityTokenPath` when the env var is unset,
- an explicit `token_file_path` still takes precedence over the env var.

Fixes #18972

```release-notes
[BUGFIX] remote/azuread: respect the AZURE_FEDERATED_TOKEN_FILE environment variable for workload identity authentication instead of hardcoding the token file path.
```
