### PR TITLE
ui: use react-app-rewired to dedupe codemirror packages

### DIFF
--- a/web/ui/react-app/config-overrides.js
+++ b/web/ui/react-app/config-overrides.js
@@ -1,0 +1,50 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const path = require('path');
+
+// @prometheus-io/codemirror-promql is consumed via pnpm's "link:" protocol, so
+// it is a symlink into the workspace and carries its own node_modules. Without
+// deduplication, its transitive @codemirror/* and @lezer/* imports resolve to
+// the workspace copy while react-app uses its own isolated copy. That loads two
+// instances of @codemirror/state and breaks instanceof checks at runtime
+// ("Unrecognized extension value in extension set"). Force these packages to
+// resolve to react-app's single copy.
+const singletons = [
+  '@codemirror/state',
+  '@codemirror/view',
+  '@codemirror/language',
+  '@codemirror/commands',
+  '@codemirror/search',
+  '@codemirror/autocomplete',
+  '@codemirror/lint',
+  '@lezer/common',
+  '@lezer/highlight',
+  '@lezer/lr',
+];
+
+module.exports = function override(config) {
+  config.resolve = config.resolve || {};
+  config.resolve.alias = Object.assign(
+    {},
+    config.resolve.alias,
+    Object.fromEntries(singletons.map((pkg) => [pkg, path.resolve(__dirname, 'node_modules', pkg)]))
+  );
+  // The aliases above resolve to absolute node_modules paths, which Create
+  // React App's ModuleScopePlugin rejects as imports outside src/. Drop it so
+  // the deduplicating aliases take effect.
+  config.resolve.plugins = (config.resolve.plugins || []).filter(
+    (plugin) => !(plugin.constructor && plugin.constructor.name === 'ModuleScopePlugin')
+  );
+  return config;
+};

--- a/web/ui/react-app/package.json
+++ b/web/ui/react-app/package.json
@@ -44,15 +44,15 @@
     "tempusdominus-core": "^5.19.3"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --runInBand --resetMocks=false",
-    "test:coverage": "react-scripts test --runInBand --resetMocks=false --no-watch --coverage",
-    "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test --runInBand --resetMocks=false",
+    "test:coverage": "react-app-rewired test --runInBand --resetMocks=false --no-watch --coverage",
+    "test:debug": "react-app-rewired --inspect-brk test --runInBand --no-cache",
     "eject": "react-scripts eject",
     "lint:ci": "eslint --quiet \"src/**/*.{ts,tsx}\"",
     "lint": "eslint --fix \"src/**/*.{ts,tsx}\"",
-    "snapshot": "react-scripts test --updateSnapshot"
+    "snapshot": "react-app-rewired test --updateSnapshot"
   },
   "prettier": {
     "singleQuote": true,
@@ -90,6 +90,7 @@
     "jest-fetch-mock": "^3.0.3",
     "mutationobserver-shim": "^0.3.7",
     "prettier": "^3.8.4",
+    "react-app-rewired": "^2.2.1",
     "react-scripts": "^5.0.1",
     "sinon": "^19.0.5",
     "ts-jest": "^29.4.11"

--- a/web/ui/react-app/pnpm-lock.yaml
+++ b/web/ui/react-app/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
+      react-app-rewired:
+        specifier: ^2.2.1
+        version: 2.2.1(react-scripts@5.0.1(@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7))(@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7))(@types/babel__core@7.20.5)(eslint@8.57.1)(react@17.0.2)(sass@1.101.0)(type-fest@4.41.0)(typescript@4.9.5))
       react-scripts:
         specifier: ^5.0.1
         version: 5.0.1(@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7))(@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7))(@types/babel__core@7.20.5)(eslint@8.57.1)(react@17.0.2)(sass@1.101.0)(type-fest@4.41.0)(typescript@4.9.5)
@@ -5105,6 +5108,12 @@ packages:
     resolution: {integrity: sha512-sZ41cxiU5llIB003yxxQBYrARBqe0repqPTTYBTmMqTz9szeBbE37BehCE891NZsmdZqqP+xWKdT3eo3vOzN8w==}
     engines: {node: '>=14'}
 
+  react-app-rewired@2.2.1:
+    resolution: {integrity: sha512-uFQWTErXeLDrMzOJHKp0h8P1z0LV9HzPGsJ6adOtGlA/B9WfT6Shh4j2tLTTGlXOfiVx6w6iWpp7SOC5pvk+gA==}
+    hasBin: true
+    peerDependencies:
+      react-scripts: '>=2.1.3'
+
   react-copy-to-clipboard@5.1.1:
     resolution: {integrity: sha512-s+HrzLyJBxrpGTYXF15dTgMjAJpEPZT/Yp6NytAtZMRngejxt6Pt5WrfFxLAcsqUDU6sY1Jz6tyHwIicE1U2Xg==}
     peerDependencies:
@@ -5448,6 +5457,10 @@ packages:
   selfsigned@2.4.1:
     resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
     engines: {node: '>=10'}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -12245,6 +12258,11 @@ snapshots:
       regenerator-runtime: 0.13.11
       whatwg-fetch: 3.6.20
 
+  react-app-rewired@2.2.1(react-scripts@5.0.1(@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7))(@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7))(@types/babel__core@7.20.5)(eslint@8.57.1)(react@17.0.2)(sass@1.101.0)(type-fest@4.41.0)(typescript@4.9.5)):
+    dependencies:
+      react-scripts: 5.0.1(@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7))(@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7))(@types/babel__core@7.20.5)(eslint@8.57.1)(react@17.0.2)(sass@1.101.0)(type-fest@4.41.0)(typescript@4.9.5)
+      semver: 5.7.2
+
   react-copy-to-clipboard@5.1.1(react@17.0.2):
     dependencies:
       copy-to-clipboard: 3.3.3
@@ -12743,6 +12761,8 @@ snapshots:
     dependencies:
       '@types/node-forge': 1.3.14
       node-forge: 1.4.0
+
+  semver@5.7.2: {}
 
   semver@6.3.1: {}
 


### PR DESCRIPTION
The local codemirror-promql is consumed via pnpm's link: protocol and carries its own node_modules, so its @codemirror/* and @lezer/* imports resolve to a separate copy from react-app. That loads two instances of @codemirror/state and breaks instanceof checks at runtime.

Add react-app-rewired with a config-overrides.js that aliases these packages to react-app's single copy and drops CRA's ModuleScopePlugin so the aliases take effect.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
