### PR TITLE
ui: fix check-package version read under pnpm

### DIFF
--- a/scripts/ui_release.sh
+++ b/scripts/ui_release.sh
@@ -47,7 +47,7 @@ function checkPackage() {
   fi
   for workspace in ${workspaces}; do
     cd "${workspace}"
-    package_version=$(pnpm run env | grep npm_package_version | cut -d= -f2-)
+    package_version=$(pnpm pkg get version | tr -d '"')
     if [ "${version}" != "${package_version}" ]; then
       echo "version of ${workspace} is not the correct one"
       echo "expected one: ${version}"


### PR DESCRIPTION
`ui_release.sh --check-package` always reports a false version mismatch under pnpm:

```
version of mantine-ui is not the correct one
expected one: 0.313.0-rc.0
current one:
please use ./ui_release --bump-version 0.313.0-rc.0
```

### Cause
`checkPackage()` read each workspace package's version with `pnpm run env | grep npm_package_version`. That is an npm idiom — `npm run env` invokes npm's built-in `env` command which prints `npm_package_version=…`. pnpm has no such built-in, so it fails with `[ERR_PNPM_NO_SCRIPT] Missing script: env` and produces no output. `package_version` is therefore empty and the comparison against the expected version always fails, even when the versions are correct.

This is a leftover from the npm-to-pnpm migration (#18797).

### Fix
Read the version with `pnpm pkg get version` (pnpm-native, reads the current package's `package.json`), stripping the surrounding quotes.

Verified: `./scripts/ui_release.sh --check-package "$(./scripts/get_module_version.sh v3.13.0-rc.0)"` now exits 0 with the workspace packages at `0.313.0-rc.0`.

```release-notes
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
