### PR TITLE
storage/remote: reject unsorted remote-write labels

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -87,6 +87,27 @@ func isHistogramValidationError(err error) bool {
 	return errors.As(err, &e)
 }
 
+func labelProtosOutOfOrder(lbls []prompb.Label) (current, previous string, ok bool) {
+	for i, l := range lbls {
+		if i > 0 && l.Name < previous {
+			return l.Name, previous, true
+		}
+		previous = l.Name
+	}
+	return "", "", false
+}
+
+func labelRefsOutOfOrder(labelRefs []uint32, symbols []string) (current, previous string, ok bool) {
+	for i := 0; i < len(labelRefs); i += 2 {
+		name := symbols[labelRefs[i]]
+		if i > 0 && name < previous {
+			return name, previous, true
+		}
+		previous = name
+	}
+	return "", "", false
+}
+
 // Store implements remoteapi.writeStorage interface.
 // TODO(bwplotka): Improve remoteapi.Store API. Right now it's confusing if PRWv1 flows should use WriteResponse or not.
 // If it's not filled, it will be "confirmed zero" which caused partial error reporting on client side in the past.
@@ -169,6 +190,11 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 
 	b := labels.NewScratchBuilder(0)
 	for _, ts := range req.Timeseries {
+		if current, previous, ok := labelProtosOutOfOrder(ts.Labels); ok {
+			h.logger.Warn("Invalid labels for series.", "labels", ts.Labels, "label", current, "previous_label", previous)
+			samplesWithInvalidLabels++
+			continue
+		}
 		ls := ts.ToLabels(&b, nil)
 
 		// TODO(bwplotka): Even as per 1.0 spec, this should be a 400 error, while other samples are
@@ -315,6 +341,11 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 		ls, err := ts.ToLabels(&b, req.Symbols)
 		if err != nil {
 			badRequestErrs = append(badRequestErrs, fmt.Errorf("parsing labels for series %v: %w", ts.LabelsRefs, err))
+			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)
+			continue
+		}
+		if current, previous, ok := labelRefsOutOfOrder(ts.LabelsRefs, req.Symbols); ok {
+			badRequestErrs = append(badRequestErrs, fmt.Errorf(`invalid labels for series, labels %v, label name %q is out of order after %q`, ls.String(), current, previous))
 			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)
 			continue
 		}

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -338,6 +338,31 @@ func TestRemoteWriteHandler_V1Message(t *testing.T) {
 	}
 }
 
+func TestRemoteWriteHandler_V1Message_DropsUnsortedLabels(t *testing.T) {
+	payload, _, _, err := buildWriteRequest(nil, []prompb.TimeSeries{{
+		Labels: []prompb.Label{
+			{Name: "__name__", Value: "test_metric"},
+			{Name: "z", Value: "1"},
+			{Name: "a", Value: "2"},
+		},
+		Samples: []prompb.Sample{{Value: 1, Timestamp: 1}},
+	}}, nil, nil, nil, nil, "snappy")
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(payload))
+	require.NoError(t, err)
+
+	appendable := &mockAppendable{}
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	resp := recorder.Result()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Empty(t, appendable.samples)
+}
+
 func expectHeaderValue(t testing.TB, expected int, got string) {
 	t.Helper()
 
@@ -405,6 +430,14 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 				writeV2RequestFixture.Timeseries...),
 			expectedCode:     http.StatusBadRequest,
 			expectedRespBody: "invalid labels for series, labels {__name__=\"test_metric1\", test_metric1=\"test_metric1\", test_metric1=\"test_metric1\"}, duplicated label test_metric1\n",
+		},
+		{
+			desc: "Partial write; first series with unsorted labels",
+			input: append(
+				[]writev2.TimeSeries{{LabelsRefs: []uint32{1, 2, 9, 10, 5, 6}, Samples: []writev2.Sample{{Value: 1, Timestamp: 1}}}},
+				writeV2RequestFixture.Timeseries...),
+			expectedCode:     http.StatusBadRequest,
+			expectedRespBody: "invalid labels for series, labels {__name__=\"test_metric1\", baz=\"qux\", foo=\"bar\"}, label name \"baz\" is out of order after \"foo\"\n",
 		},
 		{
 			desc: "Partial write; first series with odd number of label refs",


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #11505.

#### What this changes

This adds explicit remote-write label-order validation before samples are appended.

- Remote write v1 now treats a series with out-of-order label names as invalid and skips it through the existing invalid-label path.
- Remote write v2 now reports out-of-order label names through the existing partial-write bad-request path.
- Regression coverage was added for both v1 and v2 remote-write requests.

#### Validation

Validated in a Linux arm64 container with Go 1.26.4, Node v24.16.0, and pnpm 10.33.0:

- `make test`
- `make lint`

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] Remote write: Reject samples with unsorted label names before appending.
```