### PR TITLE
docs: clarify Swarm task container label source

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1690,7 +1690,7 @@ created using the `port` parameter defined in the SD configuration.
 
 Available meta labels:
 
-* `__meta_dockerswarm_container_label_<labelname>`: each label of the container, with any unsupported characters converted to an underscore
+* `__meta_dockerswarm_container_label_<labelname>`: each label from the Swarm task's container spec, with any unsupported characters converted to an underscore
 * `__meta_dockerswarm_task_id`: the id of the task
 * `__meta_dockerswarm_task_container_id`: the container id of the task
 * `__meta_dockerswarm_task_desired_state`: the desired state of the task


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Related to #12244.

This clarifies that `__meta_dockerswarm_container_label_<labelname>` for Swarm task discovery is populated from the Swarm task's container spec labels. That avoids implying that task discovery also exposes labels that are only available from inspecting the running Docker container or image.

cc @alexgreenbank

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[CHANGE] Docker Swarm SD: Clarify the documented source of task container label metadata.
```

#### Testing

- `go test ./discovery/moby -count=1`
- `go build ./cmd/prometheus/`
- `GO_ONLY=1 make test`
- `make lint`
- `make test`
