### PR TITLE
promtool: read each unit test rule file only once

### DIFF
--- a/cmd/promtool/unittest.go
+++ b/cmd/promtool/unittest.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"math"
 	"os"
 	"path/filepath"
@@ -37,6 +38,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
@@ -118,6 +120,12 @@ func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, p parser
 		groupOrderMap[gn] = i
 	}
 
+	// Read each rule file only once and share the result across all test
+	// groups. A rule file may be a non-seekable input such as /dev/stdin, which
+	// yields EOF on its second read; re-reading it per test group would make
+	// every group after the first see an empty file.
+	groupLoader := newCachingGroupLoader(fileGroupLoader{parser: p, logger: promslog.NewNopLogger()})
+
 	// Testing.
 	var errs []error
 	for i, t := range unitTestInp.Tests {
@@ -133,6 +141,7 @@ func ruleUnitTest(filename string, queryOpts promqltest.LazyLoaderOpts, p parser
 			t.Interval = unitTestInp.EvaluationInterval
 		}
 		t.parser = p
+		t.groupLoader = groupLoader
 		ers := t.test(testname, evalInterval, groupOrderMap, queryOpts, diffFlag, debug, ignoreUnknownFields, unitTestInp.FuzzyCompare, unitTestInp.RuleFiles...)
 		if ers != nil {
 			for _, e := range ers {
@@ -189,6 +198,54 @@ func resolveAndGlobFilepaths(baseDir string, utf *unitTestFile) error {
 	return nil
 }
 
+// fileGroupLoader loads rule groups from files. It mirrors rules.FileLoader,
+// whose fields are unexported and so cannot be constructed from this package.
+type fileGroupLoader struct {
+	parser parser.Parser
+	logger *slog.Logger
+}
+
+func (l fileGroupLoader) Load(identifier string, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) (*rulefmt.RuleGroups, []error) {
+	return rulefmt.ParseFile(identifier, ignoreUnknownFields, nameValidationScheme, l.parser, l.logger)
+}
+
+func (l fileGroupLoader) Parse(query string) (parser.Expr, error) {
+	return l.parser.ParseExpr(query)
+}
+
+// cachingGroupLoader wraps a rules.GroupLoader and memoizes each identifier's
+// result, so a rule file referenced by multiple test groups is read only once.
+// This matters for non-seekable inputs such as /dev/stdin, which yield EOF on
+// their second read and would otherwise appear empty to every group after the
+// first.
+type cachingGroupLoader struct {
+	loader rules.GroupLoader
+	cache  map[string]cachedRuleGroups
+}
+
+// cachedRuleGroups is the memoized result of loading a single rule file.
+type cachedRuleGroups struct {
+	groups *rulefmt.RuleGroups
+	errs   []error
+}
+
+func newCachingGroupLoader(loader rules.GroupLoader) *cachingGroupLoader {
+	return &cachingGroupLoader{loader: loader, cache: make(map[string]cachedRuleGroups)}
+}
+
+func (c *cachingGroupLoader) Load(identifier string, ignoreUnknownFields bool, nameValidationScheme model.ValidationScheme) (*rulefmt.RuleGroups, []error) {
+	if cached, ok := c.cache[identifier]; ok {
+		return cached.groups, cached.errs
+	}
+	groups, errs := c.loader.Load(identifier, ignoreUnknownFields, nameValidationScheme)
+	c.cache[identifier] = cachedRuleGroups{groups: groups, errs: errs}
+	return groups, errs
+}
+
+func (c *cachingGroupLoader) Parse(query string) (parser.Expr, error) {
+	return c.loader.Parse(query)
+}
+
 // testStartTimestamp wraps time.Time to support custom YAML unmarshaling.
 // It can parse both RFC3339 timestamps and Unix timestamps.
 type testStartTimestamp struct {
@@ -221,7 +278,8 @@ type testGroup struct {
 	TestGroupName   string             `yaml:"name,omitempty"`
 	StartTimestamp  testStartTimestamp `yaml:"start_timestamp,omitempty"`
 
-	parser parser.Parser `yaml:"-"`
+	parser      parser.Parser     `yaml:"-"`
+	groupLoader rules.GroupLoader `yaml:"-"`
 }
 
 // test performs the unit tests.
@@ -250,12 +308,13 @@ func (tg *testGroup) test(testname string, evalInterval time.Duration, groupOrde
 
 	// Load the rule files.
 	opts := &rules.ManagerOptions{
-		QueryFunc:  rules.EngineQueryFunc(suite.QueryEngine(), suite.Storage()),
-		Appendable: suite.Storage(),
-		Context:    context.Background(),
-		NotifyFunc: func(context.Context, string, ...*rules.Alert) {},
-		Logger:     promslog.NewNopLogger(),
-		Parser:     tg.parser,
+		QueryFunc:   rules.EngineQueryFunc(suite.QueryEngine(), suite.Storage()),
+		Appendable:  suite.Storage(),
+		Context:     context.Background(),
+		NotifyFunc:  func(context.Context, string, ...*rules.Alert) {},
+		Logger:      promslog.NewNopLogger(),
+		Parser:      tg.parser,
+		GroupLoader: tg.groupLoader,
 	}
 	m := rules.NewManager(opts)
 	groupsMap, ers := m.LoadGroups(time.Duration(tg.Interval), tg.ExternalLabels, tg.ExternalURL, nil, ignoreUnknownFields, ruleFiles...)

--- a/cmd/promtool/unittest_test.go
+++ b/cmd/promtool/unittest_test.go
@@ -17,6 +17,9 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -282,4 +285,62 @@ func TestRulesUnitTestRun(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestRulesUnitTestStdinRuleFile reproduces https://github.com/prometheus/prometheus/issues/13785:
+// a rule file delivered through a non-seekable input (a pipe, as with /dev/stdin)
+// can be read only once. When it is referenced by more than one test group, every
+// group after the first used to see an empty file because the file was re-read per
+// group. The shared rule file must instead be read only once.
+func TestRulesUnitTestStdinRuleFile(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("/dev/fd is not available on Windows")
+	}
+
+	ruleContent := []byte(`groups:
+  - name: alerts
+    rules:
+      - alert: AlwaysFiring
+        expr: 1
+`)
+	// A pipe is non-seekable, so reading it a second time yields EOF. The small
+	// content fits the kernel buffer, so writing then closing before any read
+	// keeps the test deterministic without a writer goroutine.
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	_, err = w.Write(ruleContent)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	defer r.Close()
+
+	testContent := fmt.Sprintf(`rule_files:
+  - /dev/fd/%d
+evaluation_interval: 1m
+tests:
+  - name: first group
+    input_series:
+      - series: 'up{job="prometheus"}'
+        values: "1 1"
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: AlwaysFiring
+        exp_alerts:
+          - {}
+  - name: second group
+    input_series:
+      - series: 'up{job="prometheus"}'
+        values: "1 1"
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: AlwaysFiring
+        exp_alerts:
+          - {}
+`, r.Fd())
+
+	testFile := filepath.Join(t.TempDir(), "stdin-rule-test.yml")
+	require.NoError(t, os.WriteFile(testFile, []byte(testContent), 0o644))
+
+	got := RulesUnitTest(promqltest.LazyLoaderOpts{}, parser.NewParser(parser.Options{}), nil, false, false, false, testFile)
+	require.Equal(t, 0, got, "both test groups should pass: the shared rule file must be read only once")
 }

--- a/docs/configuration/unit_testing_rules.md
+++ b/docs/configuration/unit_testing_rules.md
@@ -17,6 +17,8 @@ You can use `promtool` to test your rules.
 
 ```yaml
 # This is a list of rule files to consider for testing. Globs are supported.
+# Each rule file is read only once, so a non-seekable input such as /dev/stdin
+# can be used even when it is referenced by multiple test groups.
 rule_files:
   [ - <file_name> ]
 


### PR DESCRIPTION
## What

`promtool test rules` loaded its rule files once per *test group*. When a rule
file is referenced by multiple test groups and that file is a non-seekable input
such as `/dev/stdin` (e.g. `yq .spec rules.yml | promtool test rules test.yml`),
the first test group drains the pipe and every later group reads an empty file —
its rules vanish and its alert/PromQL assertions fail.

## How

Wrap the rule `GroupLoader` in a small caching loader, created once per unit
test file and shared across all of its test groups, so each rule file is read
and parsed exactly once no matter how many groups reference it.

This follows the read-once direction maintainers preferred over the earlier
#13786 attempt (which special-cased pipes by buffering them to a temp file): it
needs no special-casing for pipes — any file referenced more than once is simply
read once.

## Tests

`TestRulesUnitTestStdinRuleFile` reproduces the bug with a real non-seekable
input: it writes the rule file into an `os.Pipe()` and references it as
`/dev/fd/N` from two test groups. The test fails on `main` (the second group
sees an empty file and returns a failure) and passes with this change. It is
skipped on Windows, where `/dev/fd` is unavailable.

Fixes #13785

```release-notes
[BUGFIX] promtool: Read each `test rules` rule file only once, so a rule file piped via /dev/stdin works when referenced by multiple test groups.
```
