### PR TITLE
build: include react-app dependency licenses in npm_licenses tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ npm_licenses: ui-install
 	@echo ">> bundling npm licenses"
 	rm -f $(REACT_APP_NPM_LICENSES_TARBALL) npm_licenses
 	ln -s . npm_licenses
-	find npm_licenses/$(UI_NODE_MODULES_PATH) -iname "license*" | tar cfj $(REACT_APP_NPM_LICENSES_TARBALL) --files-from=-
+	find npm_licenses/$(UI_NODE_MODULES_PATH) npm_licenses/$(UI_PATH)/react-app/node_modules -iname "license*" | tar cfj $(REACT_APP_NPM_LICENSES_TARBALL) --files-from=-
 	rm -f npm_licenses
 else
 assets:


### PR DESCRIPTION
Since the npm-to-pnpm migration (#18797), the old react-app UI is a separate pnpm project with its own `web/ui/react-app/node_modules`, while the `npm_licenses` target only scanned the workspace's `web/ui/node_modules`. As a result, `npm_licenses.tar.bz2` silently lost all of react-app's dependency licenses.

The old react-app UI is still embedded in the binary (served via `--enable-feature=old-ui`), so its dependencies — bootstrap, jquery, reactstrap, moment, tempusdominus, sanitize-html, etc. — are distributed, but their license texts are no longer bundled. This is a license-compliance gap.

### Fix
Scan react-app's `node_modules` in addition to the workspace's. `npm_licenses` already depends on `ui-install`, which installs react-app's `node_modules`, so the path exists at build time.

### Verification
```
before: 626 license files (no react-app deps)
after:  1992 license files (bootstrap, jquery, reactstrap, ... now included)
```

```release-notes
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
