### PR TITLE
ci: publish UI packages with npm to fix OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,10 @@ jobs:
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
+      # npm OIDC trusted publishing requires npm >= 11.5.1, newer than the npm
+      # bundled with Node 22.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install --global npm@latest
       - name: Check libraries version
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))

--- a/scripts/ui_release.sh
+++ b/scripts/ui_release.sh
@@ -25,19 +25,24 @@ function copy() {
 
 function publish() {
   dry_run="${1}"
-  cmd="pnpm publish --access public --no-git-checks"
-  if [[ "${dry_run}" == "dry-run" ]]; then
-    cmd+=" --dry-run"
-  fi
   for workspace in ${workspaces}; do
     # package "mantine-ui" is private so we shouldn't try to publish it.
     if [[ "${workspace}" != "mantine-ui" ]]; then
       cd "${workspace}"
-      eval "${cmd}"
+      # Build the tarball with pnpm so the "workspace:" protocol dependencies are
+      # rewritten to real versions, then publish it with npm. npm supports OIDC
+      # trusted publishing while pnpm's own publish does not yet
+      # (https://github.com/pnpm/pnpm/issues/11513).
+      tarball="$(pnpm pack | tail -n 1)"
+      if [[ "${dry_run}" == "dry-run" ]]; then
+        npm publish "${tarball}" --access public --dry-run
+      else
+        npm publish "${tarball}" --access public
+      fi
+      rm -f "${tarball}"
       cd "${root_ui_folder}"
     fi
   done
-
 }
 
 function checkPackage() {


### PR DESCRIPTION
NOTE: This might be AI slop, we haven't seen the failure yet. So keeping draft for now.


The `publish_ui_release` job (added in #18959) uses npm OIDC trusted publishing — it requests `id-token: write` and provides no npm token — but the actual publish ran via `pnpm publish` (`scripts/ui_release.sh --publish`).

Since pnpm 11, `pnpm publish` is implemented natively and **does not support OIDC trusted publishing**: it fails with a 404 ([pnpm#11513](https://github.com/pnpm/pnpm/issues/11513), tracked by [pnpm#9812](https://github.com/pnpm/pnpm/issues/9812)). The job sets up pnpm `version: 11`, so the `Publish libraries` step would fail on a release tag. This is untested today — the dry-run runs on non-tags and doesn't exercise the real OIDC upload, and 3.13.0-rc.0 is the first tag since #18959.

### Fix
Publish with **npm**, which supports OIDC trusted publishing. Because the packages use the `workspace:` protocol (e.g. `@prometheus-io/codemirror-promql` depends on `@prometheus-io/lezer-promql`), which npm doesn't understand, build the tarball with `pnpm pack` first — it rewrites `workspace:` deps to real versions — then `npm publish` the resulting tarball.

npm OIDC trusted publishing also requires **npm >= 11.5.1**, newer than the npm bundled with Node 22 (10.9.x), so the job upgrades npm.

### Verification
`pnpm pack` correctly rewrites the workspace dependency in the tarball's `package.json`:
```
@prometheus-io/lezer-promql:  workspace:*  →  0.313.0-rc.0
```

```release-notes
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
