### PR TITLE
ci: reuse pre-built UI assets in build_all crossbuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
   build:
     name: Build Prometheus for common architectures
     runs-on: ubuntu-latest
+    # Reuse the web UI built and tested by test_ui instead of rebuilding it in
+    # every crossbuild container.
+    needs: [test_ui]
     if: |
       !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
       &&
@@ -181,14 +184,28 @@ jobs:
       matrix:
         thread: [ 0, 1, 2 ]
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: prometheus/promci-artifacts/restore@f9a587dbc0b2c78a0c54f8ad1cde71ea29a4b76f # v0.1.0
+      - name: Extract pre-built UI assets
+        run: |
+          mkdir -p .prebuilt-ui
+          tar -xzvf .tarballs/prometheus-web-ui-*.tar.gz -C .prebuilt-ui
       - uses: prometheus/promci/build@c7d527128ffb38ad3d7934795da35b252c7d51dd # v0.8.3
         with:
-          promu_opts: "-p linux/amd64 -p windows/amd64 -p linux/arm64 -p darwin/amd64 -p darwin/arm64 -p linux/386"
+          checkout: false
+          # Feed the restored UI assets into the crossbuild containers so make
+          # skips the UI build (see PREBUILT_ASSETS_STATIC_DIR in the Makefile).
+          promu_opts: "-p linux/amd64 -p windows/amd64 -p linux/arm64 -p darwin/amd64 -p darwin/arm64 -p linux/386 --env PREBUILT_ASSETS_STATIC_DIR=.prebuilt-ui/static"
           parallelism: 3
           thread: ${{ matrix.thread }}
   build_all:
     name: Build Prometheus for all architectures
     runs-on: ubuntu-latest
+    # Reuse the web UI built and tested by test_ui instead of rebuilding it in
+    # every crossbuild container.
+    needs: [test_ui]
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2.'))
       ||
@@ -204,10 +221,22 @@ jobs:
     # Whenever the Go version is updated here, .promu.yml
     # should also be updated.
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: prometheus/promci-artifacts/restore@f9a587dbc0b2c78a0c54f8ad1cde71ea29a4b76f # v0.1.0
+      - name: Extract pre-built UI assets
+        run: |
+          mkdir -p .prebuilt-ui
+          tar -xzvf .tarballs/prometheus-web-ui-*.tar.gz -C .prebuilt-ui
       - uses: prometheus/promci/build@c7d527128ffb38ad3d7934795da35b252c7d51dd # v0.8.3
         with:
+          checkout: false
           parallelism: 12
           thread: ${{ matrix.thread }}
+          # Feed the restored UI assets into the crossbuild containers so make
+          # skips the UI build (see PREBUILT_ASSETS_STATIC_DIR in the Makefile).
+          promu_opts: --env PREBUILT_ASSETS_STATIC_DIR=.prebuilt-ui/static
   build_all_status:
     # This status check aggregates the individual matrix jobs of the "Build
     # Prometheus for all architectures" step into a final status. Fails if a

--- a/Makefile.common
+++ b/Makefile.common
@@ -55,7 +55,7 @@ ifneq ($(shell command -v gotestsum 2> /dev/null),)
 endif
 endif
 
-PROMU_VERSION ?= 0.18.1
+PROMU_VERSION ?= 0.20.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 SKIP_GOLANGCI_LINT :=


### PR DESCRIPTION
test_ui already builds and saves the web UI tarball. Restore it in build_all, extract it, and pass it to the crossbuild containers via promu's new --env flag (PREBUILT_ASSETS_STATIC_DIR), so make build skips rebuilding the UI in every crossbuild thread.

Bump promu to 0.20.0 for the crossbuild --env flag.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
