### PR TITLE
docs: clarify that compaction can temporarily exceed retention.size

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -82,7 +82,9 @@ For further details on file format, see [TSDB format](/tsdb/docs/format/README.m
 The initial two-hour blocks are eventually compacted into longer blocks in the background.
 
 Compaction will create larger blocks containing data spanning up to 10% of the retention time,
-or 31 days, whichever is smaller.
+or 31 days, whichever is smaller. Because both the source blocks and the new compacted block
+must coexist on disk, on-disk size can briefly exceed `storage.tsdb.retention.size`; the
+excess is released when the next retention cleanup removes the source blocks.
 
 ### Operational aspects
 
@@ -145,8 +147,10 @@ a buffer, ensuring that older entries will be removed before the allocated stora
 for Prometheus becomes full.
 
 At present, we recommend setting the retention size to, at most, 80-85% of your
-allocated Prometheus disk space. This increases the likelihood that older entries
-will be removed prior to hitting any disk limitations.
+allocated Prometheus disk space. The remaining 15-20% buffer covers the temporary
+extra space required by in-progress compactions (see [Compaction](#compaction)),
+which keep both the source blocks and the newly compacted block on disk at the
+same time before the old blocks are removed.
 
 ## Remote storage integrations
 


### PR DESCRIPTION
Documents the fact that `storage.tsdb.retention.size` can be temporarily exceeded while a compaction is in progress, and ties the existing 80-85% right-sizing recommendation to that mechanism.

## Why

Per #11112, the current docs describe `storage.tsdb.retention.size` as a hard limit but do not explain that compactions keep both the source and the new block on disk at the same time. The mitigation path suggested in the issue (@beorn7, @machine424) was a docs clarification.

## Changes

* `docs/storage.md` Compaction section: note that on-disk size can briefly exceed `storage.tsdb.retention.size`; the excess is released when the next retention cleanup removes the source blocks.
* `docs/storage.md` Right-Sizing Retention Size section: replace the vague "increases the likelihood" sentence with a concrete reason that links to the Compaction section.

No code, no behavior change.

## Verification

The mechanism was verified by reading `tsdb/compact.go` (`write()` creates the new block in a tmp directory and atomically renames it to the final location; source blocks are marked `Deletable=true` rather than deleted by compaction) and `tsdb/db.go` (`BeyondSizeRetention` sums `Head().Size()` plus `block.Size()` for every persistent block, so the new compacted block does count toward the size limit; the actual deletion of the source blocks happens in the next retention cleanup cycle).

```release-notes
NONE
```

Mitigates #11112

Assisted-by: Claude Code
