### PR TITLE
build: embed bundled web UI licenses instead of shipping a tarball

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -29,7 +29,6 @@ tarball:
         - documentation/examples/prometheus.yml
         - LICENSE
         - NOTICE
-        - npm_licenses.tar.bz2
 crossbuild:
     platforms:
         - aix

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ COPY .build/${OS}-${ARCH}/promtool          /bin/promtool
 COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
 COPY LICENSE                                /LICENSE
 COPY NOTICE                                 /NOTICE
-COPY npm_licenses.tar.bz2                   /npm_licenses.tar.bz2
 
 WORKDIR /prometheus
 RUN chown -R nobody:nobody /etc/prometheus /prometheus && chmod g+w /prometheus

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -18,7 +18,7 @@ LABEL org.opencontainers.image.licenses="Apache License 2.0"
 LABEL io.prometheus.image.variant="distroless"
 
 COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
-COPY LICENSE NOTICE npm_licenses.tar.bz2 /
+COPY LICENSE NOTICE /
 COPY .build/${OS}-${ARCH}/prometheus        /bin/prometheus
 COPY .build/${OS}-${ARCH}/promtool          /bin/promtool
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@
 UI_PATH = web/ui
 BUILD_UI ?= all
 UI_NODE_MODULES_PATH = $(UI_PATH)/node_modules
-REACT_APP_NPM_LICENSES_TARBALL = "npm_licenses.tar.bz2"
 
 PROMTOOL = ./promtool
 TSDB_BENCHMARK_NUM_METRICS ?= 1000
@@ -109,20 +108,9 @@ check-generated-promql-functions: generate-promql-functions
 .PHONY: assets
 ifndef SKIP_UI_BUILD
 assets: check-node-version ui-install ui-build
-
-.PHONY: npm_licenses
-npm_licenses: ui-install
-	@echo ">> bundling npm licenses"
-	rm -f $(REACT_APP_NPM_LICENSES_TARBALL) npm_licenses
-	ln -s . npm_licenses
-	find npm_licenses/$(UI_NODE_MODULES_PATH) npm_licenses/$(UI_PATH)/react-app/node_modules -iname "license*" | tar cfj $(REACT_APP_NPM_LICENSES_TARBALL) --files-from=-
-	rm -f npm_licenses
 else
 assets:
 	@echo '>> skipping assets build, pre-built assets provided'
-
-npm_licenses:
-	@echo '>> skipping assets npm licenses, pre-built assets provided'
 endif
 
 .PHONY: assets-compress
@@ -188,13 +176,13 @@ test: check-generated-parser common-test check-node-version ui-build-module ui-t
 endif
 
 .PHONY: tarball
-tarball: npm_licenses common-tarball
+tarball: common-tarball
 
 .PHONY: docker
-docker: npm_licenses common-docker
+docker: common-docker
 
 .PHONY: build
-build: assets npm_licenses assets-compress common-build
+build: assets assets-compress common-build
 
 .PHONY: bench_tsdb
 bench_tsdb: $(PROMU)

--- a/NOTICE
+++ b/NOTICE
@@ -109,5 +109,11 @@ See https://github.com/mantinedev/mantine/blob/master/LICENSE for license detail
 We also use code from a large number of npm packages. For details, see:
 - https://github.com/prometheus/prometheus/blob/main/web/ui/react-app/package.json
 - https://github.com/prometheus/prometheus/blob/main/web/ui/react-app/package-lock.json
-- The individual package licenses as copied from the node_modules directory can be found in
-  the npm_licenses.tar.bz2 archive in release tarballs and Docker images.
+- https://github.com/prometheus/prometheus/blob/main/web/ui/mantine-ui/package.json
+- https://github.com/prometheus/prometheus/blob/main/web/ui/pnpm-lock.yaml
+- The individual licenses of the packages bundled into the new (mantine) web UI
+  are collected at build time, embedded in the Prometheus binary, and served by
+  the web UI at /assets/third-party-licenses.txt.
+- The licenses of the packages bundled into the old (react-app) web UI, served
+  via --enable-feature=old-ui, are extracted at build time into a
+  *.LICENSE.txt file that is embedded alongside the old UI's JavaScript bundle.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ You can build a docker image locally with the following commands:
 ```bash
 make promu
 promu crossbuild -p linux/amd64
-make npm_licenses
 make common-docker-amd64
 ```
 

--- a/web/ui/mantine-ui/package.json
+++ b/web/ui/mantine-ui/package.json
@@ -70,6 +70,7 @@
     "postcss": "^8.5.15",
     "postcss-preset-mantine": "^1.18.0",
     "postcss-simple-vars": "^7.0.1",
+    "rollup-plugin-license": "^3.7.1",
     "vite": "^6.4.3",
     "vitest": "^3.2.6"
   }

--- a/web/ui/mantine-ui/vite.config.ts
+++ b/web/ui/mantine-ui/vite.config.ts
@@ -1,10 +1,34 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import license from "rollup-plugin-license";
+import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '',
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      plugins: [
+        // Collect the licenses of all third-party packages that end up in the
+        // bundle and write them to a single file that is embedded and shipped
+        // with Prometheus, satisfying their attribution requirements.
+        license({
+          thirdParty: {
+            includePrivate: false,
+            output: {
+              file: path.resolve(
+                __dirname,
+                "dist",
+                "assets",
+                "third-party-licenses.txt"
+              ),
+            },
+          },
+        }),
+      ],
+    },
+  },
   server: {
     proxy: {
       "/api": {

--- a/web/ui/pnpm-lock.yaml
+++ b/web/ui/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       postcss-simple-vars:
         specifier: ^7.0.1
         version: 7.0.1(postcss@8.5.15)
+      rollup-plugin-license:
+        specifier: ^3.7.1
+        version: 3.7.1(picomatch@4.0.4)(rollup@4.62.0)
       vite:
         specifier: ^6.4.3
         version: 6.4.3(@types/node@25.9.1)(sugarss@5.0.1(postcss@8.5.15))
@@ -1604,6 +1607,10 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  array-find-index@1.0.2:
+    resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==}
+    engines: {node: '>=0.10.0'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1759,6 +1766,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commenting@1.1.0:
+    resolution: {integrity: sha512-YeNK4tavZwtH7jEgK1ZINXzLKm6DZdEMfsaaieOsCAN0S8vsY7UeuO3Q7d/M018EFgE+IeUAuBOKkFccBZsUZA==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -2640,6 +2650,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2730,6 +2743,10 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-name-regex@2.0.6:
+    resolution: {integrity: sha512-gFL35q7kbE/zBaPA3UKhp2vSzcPYx2ecbYuwv1ucE9Il6IIgBDweBlH8D68UFGZic2MkllKa2KHCfC1IQBQUYA==}
+    engines: {node: '>=12'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3003,6 +3020,12 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  rollup-plugin-license@3.7.1:
+    resolution: {integrity: sha512-FcGXUbAmPvRSLxjVdjp/r/MUtKBlttVQd+ApUyvKfREnsoAfAZA6Ic2fE1Tz4RL0f9XqEQU9UIRNUMdtQtliDw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
+
   rollup@4.62.0:
     resolution: {integrity: sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3074,6 +3097,27 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  spdx-compare@1.0.0:
+    resolution: {integrity: sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-expression-validate@2.0.0:
+    resolution: {integrity: sha512-b3wydZLM+Tc6CFvaRDBOF9d76oGIHNCLYFeHbftFXUWjnfZWganmDmvtM5sm1cRwJc/VDBMLyGGrsLFd1vOxbg==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
+  spdx-ranges@2.1.1:
+    resolution: {integrity: sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==}
+
+  spdx-satisfies@5.0.1:
+    resolution: {integrity: sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -4886,6 +4930,8 @@ snapshots:
 
   aria-query@5.3.2: {}
 
+  array-find-index@1.0.2: {}
+
   assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
@@ -5054,6 +5100,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commenting@1.1.0: {}
 
   concat-map@0.0.1: {}
 
@@ -6121,6 +6169,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  moment@2.30.1: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
@@ -6193,6 +6243,8 @@ snapshots:
   p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
+
+  package-name-regex@2.0.6: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -6434,6 +6486,20 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  rollup-plugin-license@3.7.1(picomatch@4.0.4)(rollup@4.62.0):
+    dependencies:
+      commenting: 1.1.0
+      fdir: 6.5.0(picomatch@4.0.4)
+      lodash: 4.18.1
+      magic-string: 0.30.21
+      moment: 2.30.1
+      package-name-regex: 2.0.6
+      rollup: 4.62.0
+      spdx-expression-validate: 2.0.0
+      spdx-satisfies: 5.0.1
+    transitivePeerDependencies:
+      - picomatch
+
   rollup@4.62.0:
     dependencies:
       '@types/estree': 1.0.9
@@ -6517,6 +6583,33 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  spdx-compare@1.0.0:
+    dependencies:
+      array-find-index: 1.0.2
+      spdx-expression-parse: 3.0.1
+      spdx-ranges: 2.1.1
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-expression-validate@2.0.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+
+  spdx-license-ids@3.0.23: {}
+
+  spdx-ranges@2.1.1: {}
+
+  spdx-satisfies@5.0.1:
+    dependencies:
+      spdx-compare: 1.0.0
+      spdx-expression-parse: 3.0.1
+      spdx-ranges: 2.1.1
 
   sprintf-js@1.0.3: {}
 


### PR DESCRIPTION
The mantine-ui Vite build now generates a third-party-licenses.txt via rollup-plugin-license, collecting the notices of every npm package bundled into the UI. The file is embedded in the binary and served at /assets/third-party-licenses.txt.

This replaces the npm_licenses.tar.bz2 archive, which was built by sweeping node_modules for license* files and shipped as a separate file in release tarballs and Docker images.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[FEATURE] The NPM licenses are now served on `/assets/third-party-licenses.txt`, unless the `old-ui` feature is enabled.
```
