### PR TITLE
ui: do not tag pre-release npm packages as latest

### DIFF
--- a/scripts/ui_release.sh
+++ b/scripts/ui_release.sh
@@ -8,6 +8,10 @@ set -e
 current=$(pwd)
 root_ui_folder=${current}/web/ui
 
+# Source of truth for which release is the latest and which are LTS.
+# Overridable for testing.
+DOWNLOAD_JSON_URL="${DOWNLOAD_JSON_URL:-https://prometheus.io/download.json}"
+
 cd "${root_ui_folder}"
 
 files=("../../LICENSE" "../../CHANGELOG.md")
@@ -23,12 +27,93 @@ function copy() {
   done
 }
 
+# distTag prints the npm dist-tag to publish under, given the Prometheus
+# version (e.g. 3.13.0-rc.1, as found in the VERSION file). It consults
+# download.json to tell apart the latest, LTS and older stable releases so
+# that pre-releases and old patches never move the "latest" tag.
+function distTag() {
+  local version="${1#v}"
+  local offline="${2:-}"
+
+  # Pre-release versions (semver pre-release, contains "-") must never move
+  # the "latest" tag. Derive the channel from the pre-release identifier.
+  if [[ "${version}" == *-* ]]; then
+    case "${version#*-}" in
+      rc*)    echo "rc" ;;
+      beta*)  echo "beta" ;;
+      alpha*) echo "alpha" ;;
+      *)      echo "next" ;;
+    esac
+    return
+  fi
+
+  # Stable release. Dry-runs do not need the network: keep the historical
+  # behaviour of publishing to "latest".
+  if [[ "${offline}" == "offline" ]]; then
+    echo "latest"
+    return
+  fi
+
+  # download.json keys releases with a leading "v".
+  local ref="v${version}"
+
+  local json
+  json=$(curl -sSL "${DOWNLOAD_JSON_URL}" || true)
+  if [[ -z "${json}" ]]; then
+    echo "ERROR: failed to fetch ${DOWNLOAD_JSON_URL}; cannot determine npm dist-tag" >&2
+    exit 1
+  fi
+
+  local entry
+  entry=$(echo "${json}" | jq -r --arg v "${ref}" \
+    '[.prometheus[]? | select(.version==$v)] | if length>0 then "\(.[0].latest) \(.[0].lts)" else "missing" end')
+
+  # Version not yet listed in download.json: fall back to "latest".
+  if [[ "${entry}" == "missing" ]]; then
+    echo "latest"
+    return
+  fi
+
+  local is_latest is_lts
+  read -r is_latest is_lts <<< "${entry}"
+
+  if [[ "${is_latest}" == "true" ]]; then
+    echo "latest"
+    return
+  fi
+
+  if [[ "${is_lts}" == "true" ]]; then
+    # The shared "lts" tag tracks the newest LTS line only; older LTS patch
+    # releases are published as "oldstable".
+    local newest_lts
+    newest_lts=$(echo "${json}" | jq -r '.prometheus[]? | select(.lts==true) | .version' | sort -V | tail -1)
+    if [[ "${ref}" == "${newest_lts}" ]]; then
+      echo "lts"
+    else
+      echo "oldstable"
+    fi
+    return
+  fi
+
+  # Stable, but neither the latest nor an LTS release (e.g. an old patch).
+  echo "oldstable"
+}
+
 function publish() {
   dry_run="${1}"
-  cmd="pnpm publish --access public --no-git-checks"
+  # The VERSION file holds the Prometheus version and is keyed the same way as
+  # download.json; it drives both the pre-release channel and the lookup.
+  version="$(< "${current}/VERSION")"
+  offline=""
+  if [[ "${dry_run}" == "dry-run" ]]; then
+    offline="offline"
+  fi
+  tag=$(distTag "${version}" "${offline}")
+  cmd="pnpm publish --access public --no-git-checks --tag ${tag}"
   if [[ "${dry_run}" == "dry-run" ]]; then
     cmd+=" --dry-run"
   fi
+  echo "Publishing ${version} under npm dist-tag '${tag}'"
   for workspace in ${workspaces}; do
     # package "mantine-ui" is private so we shouldn't try to publish it.
     if [[ "${workspace}" != "mantine-ui" ]]; then


### PR DESCRIPTION
Derive the npm dist-tag from the Prometheus version (VERSION file) and download.json so pre-releases and old patches never move the "latest" tag: pre-releases publish under their channel (rc/beta/alpha/next), the latest stable under "latest", the newest LTS under "lts", and older stable or LTS patches under "oldstable". Fail the publish if download.json cannot be fetched.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
