### PR TITLE
tsdb: call PostDeletion when WAL replay evicts fully-tombstoned series

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9751,6 +9751,67 @@ func TestStaleSeriesCompaction(t *testing.T) {
 	}
 }
 
+func TestLifecycleCallbackInvariantAfterWALReplayWithFullTombstones(t *testing.T) {
+	const (
+		numSeries = 6
+		deleted   = numSeries / 2
+	)
+
+	opts := DefaultOptions()
+	opts.MinBlockDuration = 1000
+	opts.MaxBlockDuration = 1000
+	opts.SeriesLifecycleCallback = &countSeriesLifecycleCallback{}
+
+	db, err := Open(t.TempDir(), nil, nil, opts, nil)
+	require.NoError(t, err)
+	db.DisableCompactions()
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	allSeries := make([]labels.Labels, 0, numSeries)
+	for i := range numSeries {
+		allSeries = append(allSeries, labels.FromStrings("name", fmt.Sprintf("series%d", i)))
+	}
+
+	app := db.Appender(context.Background())
+	for _, lset := range allSeries {
+		_, err := app.Append(0, lset, 100, 1)
+		require.NoError(t, err)
+	}
+	require.NoError(t, app.Commit())
+
+	staleV := math.Float64frombits(value.StaleNaN)
+	app = db.Appender(context.Background())
+	for i, lset := range allSeries {
+		v := float64(i)
+		if i < deleted {
+			v = staleV
+		}
+		_, err := app.Append(0, lset, 200, v)
+		require.NoError(t, err)
+	}
+	require.NoError(t, app.Commit())
+
+	require.Equal(t, uint64(numSeries), db.Head().NumSeries())
+	require.Equal(t, uint64(deleted), db.Head().NumStaleSeries())
+
+	require.NoError(t, db.CompactStaleHead())
+	require.Equal(t, uint64(numSeries-deleted), db.Head().NumSeries())
+	require.Equal(t, uint64(0), db.Head().NumStaleSeries())
+
+	dir := db.Dir()
+	require.NoError(t, db.Close())
+
+	replayCallback := &countSeriesLifecycleCallback{}
+	opts.SeriesLifecycleCallback = replayCallback
+	db, err = Open(dir, nil, nil, opts, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(db.Head().NumSeries()), replayCallback.created.Load()-replayCallback.deleted.Load())
+}
+
 // TestStaleSeriesCompactionWithZeroSeries verifies that CompactStaleHead handles
 // an empty head (0 series) gracefully without division by zero or incorrectly
 // triggering compaction. This is a regression test for issue #17949.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2255,6 +2255,7 @@ func (h *Head) gcStaleSeries(seriesRefs []storage.SeriesRef, maxt int64) map[sto
 func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 	var (
 		deleted            = map[storage.SeriesRef]struct{}{}
+		deletedForCallback = map[chunks.HeadSeriesRef]labels.Labels{}
 		affected           = map[labels.Label]struct{}{}
 		staleSeriesDeleted = 0
 		chunksRemoved      = 0
@@ -2299,6 +2300,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		series.mmappedChunks = nil
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
+		deletedForCallback[series.ref] = series.lset
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
 	}
 
@@ -2313,6 +2315,10 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 
 	// Remove tombstones referring to the deleted series.
 	h.tombstones.DeleteTombstones(deleted)
+
+	if len(deletedForCallback) > 0 {
+		h.series.seriesLifecycleCallback.PostDeletion(deletedForCallback)
+	}
 }
 
 // gcStaleSeries removes all the stale series provided that they are still stale


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
`Head.deleteSeriesByID` is the WAL-replay deletion path for series that were fully tombstoned before the previous shutdown (e.g. evicted by `CompactStaleHead`). It removes the series from the stripe maps, postings, and
tombstones, but did not invoke `SeriesLifecycleCallback.PostDeletion`. The regular eviction path (`stripeSeries.iterForDeletion`) does invoke it, so downstream consumers of the callback observed an inconsistent view after a restart: every replayed series triggered `PostCreation`, but the ones that had already been evicted never triggered `PostDeletion`, breaking the `created - deleted == NumSeries()` invariant.

This change makes `deleteSeriesByID` collect the evicted refs and labels and call `PostDeletion` once at the end, matching the contract used by `iterForDeletion`.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] TSDB: Call `SeriesLifecycleCallback.PostDeletion` when WAL replay evicts fully-tombstoned series, so the created/deleted accounting on the callback stays consistent across restarts.
```

---
