### PR TITLE
tsdb: add conflicting-samples counter for commit-time series collisions

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -416,6 +416,7 @@ type headMetrics struct {
 	outOfBoundSamples         *prometheus.CounterVec
 	outOfOrderSamples         *prometheus.CounterVec
 	tooOldSamples             *prometheus.CounterVec
+	conflictingSamples        *prometheus.CounterVec
 	walTruncateDuration       prometheus.Summary
 	walCorruptionsTotal       prometheus.Counter
 	dataTotalReplayDuration   prometheus.Gauge
@@ -516,6 +517,10 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Name: "prometheus_tsdb_too_old_samples_total",
 			Help: "Total number of out of order samples ingestion failed attempts with out of support enabled, but sample outside of time window.",
 		}, []string{"type"}),
+		conflictingSamples: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "prometheus_tsdb_conflicting_samples_total",
+			Help: "Total number of samples rejected at commit because another sample with the same timestamp but a different value already existed for the series (series collision, e.g. from metric relabeling).",
+		}, []string{"type"}),
 		headTruncateFail: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_head_truncations_failed_total",
 			Help: "Total number of head truncations that failed.",
@@ -598,6 +603,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.outOfBoundSamples,
 			m.outOfOrderSamples,
 			m.tooOldSamples,
+			m.conflictingSamples,
 			m.headTruncateFail,
 			m.headTruncateTotal,
 			m.checkpointDeleteFail,

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -432,6 +432,7 @@ type headMetrics struct {
 	outOfBoundSamples         *prometheus.CounterVec
 	outOfOrderSamples         *prometheus.CounterVec
 	tooOldSamples             *prometheus.CounterVec
+	conflictingSamples        *prometheus.CounterVec
 	walTruncateDuration       prometheus.Summary
 	walCorruptionsTotal       prometheus.Counter
 	dataTotalReplayDuration   prometheus.Gauge
@@ -548,6 +549,10 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Name: "prometheus_tsdb_too_old_samples_total",
 			Help: "Total number of out of order samples ingestion failed attempts with out of support enabled, but sample outside of time window.",
 		}, []string{"type"}),
+		conflictingSamples: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "prometheus_tsdb_conflicting_samples_total",
+			Help: "Total number of samples rejected at commit because another sample with the same timestamp but a different value already existed for the series (series collision, e.g. from metric relabeling).",
+		}, []string{"type"}),
 		headTruncateFail: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_head_truncations_failed_total",
 			Help: "Total number of head truncations that failed.",
@@ -633,6 +638,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.outOfBoundSamples,
 			m.outOfOrderSamples,
 			m.tooOldSamples,
+			m.conflictingSamples,
 			m.headTruncateFail,
 			m.headTruncateTotal,
 			m.checkpointDeleteFail,

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1172,6 +1172,9 @@ type appenderCommitContext struct {
 	// Number of samples rejected due to: out of order but too old (OOO support enabled, but outside time window).
 	floatTooOldRejected int
 	histoTooOldRejected int
+	// Number of samples rejected at commit due to: a sample with the same timestamp but a different value already exists for the series (series collision, e.g. from metric relabeling).
+	floatConflictRejected int
+	histoConflictRejected int
 	// Number of samples rejected due to: out of bounds: with t < minValidTime (OOO support disabled).
 	floatOOBRejected    int
 	histoOOBRejected    int
@@ -1272,6 +1275,11 @@ func (acc *appenderCommitContext) collectOOORecords(a *headAppenderBase) {
 	acc.oooMmapMarkers = nil
 }
 
+// errConflictingSample is storage.ErrDuplicateSampleForTimestamp boxed once into an error
+// interface. That sentinel is a value-typed struct, so passing it directly to errors.Is in the
+// per-sample commit path would box it onto the heap on every call; the pre-boxed copy avoids that.
+var errConflictingSample error = storage.ErrDuplicateSampleForTimestamp
+
 // handleAppendableError processes errors encountered during sample appending and updates
 // the provided counters accordingly.
 //
@@ -1281,7 +1289,8 @@ func (acc *appenderCommitContext) collectOOORecords(a *headAppenderBase) {
 // - oooRejected: Pointer to the counter tracking the number of out-of-order samples rejected.
 // - oobRejected: Pointer to the counter tracking the number of out-of-bounds samples rejected.
 // - tooOldRejected: Pointer to the counter tracking the number of too-old samples rejected.
-func handleAppendableError(err error, appended, oooRejected, oobRejected, tooOldRejected *int) {
+// - conflictRejected: Pointer to the counter tracking the number of same-timestamp different-value samples rejected.
+func handleAppendableError(err error, appended, oooRejected, oobRejected, tooOldRejected, conflictRejected *int) {
 	switch {
 	case errors.Is(err, storage.ErrOutOfOrderSample):
 		*appended--
@@ -1292,6 +1301,9 @@ func handleAppendableError(err error, appended, oooRejected, oobRejected, tooOld
 	case errors.Is(err, storage.ErrTooOldSample):
 		*appended--
 		*tooOldRejected++
+	case errors.Is(err, errConflictingSample):
+		*appended--
+		*conflictRejected++
 	default:
 		*appended--
 	}
@@ -1386,7 +1398,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		}
 		oooSample, _, err := series.appendable(s.T, s.V, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
-			handleAppendableError(err, &acc.floatsAppended, &acc.floatOOORejected, &acc.floatOOBRejected, &acc.floatTooOldRejected)
+			handleAppendableError(err, &acc.floatsAppended, &acc.floatOOORejected, &acc.floatOOBRejected, &acc.floatTooOldRejected, &acc.floatConflictRejected)
 		}
 
 		prevHeadChunkCount := series.headChunkCount.Load()
@@ -1491,7 +1503,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 
 		oooSample, _, err := series.appendableHistogram(s.T, s.H, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
-			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
+			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected, &acc.histoConflictRejected)
 		}
 
 		prevHeadChunkCount := series.headChunkCount.Load()
@@ -1600,7 +1612,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 
 		oooSample, _, err := series.appendableFloatHistogram(s.T, s.FH, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
-			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
+			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected, &acc.histoConflictRejected)
 		}
 
 		prevHeadChunkCount := series.headChunkCount.Load()
@@ -1789,6 +1801,8 @@ func (a *headAppenderBase) Commit() (err error) {
 	h.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histoOOORejected))
 	h.metrics.outOfBoundSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatOOBRejected))
 	h.metrics.tooOldSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatTooOldRejected))
+	h.metrics.conflictingSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatConflictRejected))
+	h.metrics.conflictingSamples.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histoConflictRejected))
 	h.metrics.samplesAppended.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatsAppended))
 	h.metrics.samplesAppended.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histogramsAppended))
 	h.metrics.outOfOrderSamplesAppended.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.oooFloatsAccepted))

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1175,6 +1175,9 @@ type appenderCommitContext struct {
 	// Number of samples rejected due to: out of order but too old (OOO support enabled, but outside time window).
 	floatTooOldRejected int
 	histoTooOldRejected int
+	// Number of samples rejected at commit due to: a sample with the same timestamp but a different value already exists for the series (series collision, e.g. from metric relabeling).
+	floatConflictRejected int
+	histoConflictRejected int
 	// Number of samples rejected due to: out of bounds: with t < minValidTime (OOO support disabled).
 	floatOOBRejected    int
 	histoOOBRejected    int
@@ -1275,6 +1278,11 @@ func (acc *appenderCommitContext) collectOOORecords(a *headAppenderBase) {
 	acc.oooMmapMarkers = nil
 }
 
+// errConflictingSample is storage.ErrDuplicateSampleForTimestamp boxed once into an error
+// interface. That sentinel is a value-typed struct, so passing it directly to errors.Is in the
+// per-sample commit path would box it onto the heap on every call; the pre-boxed copy avoids that.
+var errConflictingSample error = storage.ErrDuplicateSampleForTimestamp
+
 // handleAppendableError processes errors encountered during sample appending and updates
 // the provided counters accordingly.
 //
@@ -1284,7 +1292,8 @@ func (acc *appenderCommitContext) collectOOORecords(a *headAppenderBase) {
 // - oooRejected: Pointer to the counter tracking the number of out-of-order samples rejected.
 // - oobRejected: Pointer to the counter tracking the number of out-of-bounds samples rejected.
 // - tooOldRejected: Pointer to the counter tracking the number of too-old samples rejected.
-func handleAppendableError(err error, appended, oooRejected, oobRejected, tooOldRejected *int) {
+// - conflictRejected: Pointer to the counter tracking the number of same-timestamp different-value samples rejected.
+func handleAppendableError(err error, appended, oooRejected, oobRejected, tooOldRejected, conflictRejected *int) {
 	switch {
 	case errors.Is(err, storage.ErrOutOfOrderSample):
 		*appended--
@@ -1295,6 +1304,9 @@ func handleAppendableError(err error, appended, oooRejected, oobRejected, tooOld
 	case errors.Is(err, storage.ErrTooOldSample):
 		*appended--
 		*tooOldRejected++
+	case errors.Is(err, errConflictingSample):
+		*appended--
+		*conflictRejected++
 	default:
 		*appended--
 	}
@@ -1391,7 +1403,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		}
 		oooSample, _, err := series.appendable(s.T, s.V, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
-			handleAppendableError(err, &acc.floatsAppended, &acc.floatOOORejected, &acc.floatOOBRejected, &acc.floatTooOldRejected)
+			handleAppendableError(err, &acc.floatsAppended, &acc.floatOOORejected, &acc.floatOOBRejected, &acc.floatTooOldRejected, &acc.floatConflictRejected)
 		}
 
 		prevHeadChunkCount := series.headChunkCount.Load()
@@ -1494,7 +1506,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 
 		oooSample, _, err := series.appendableHistogram(s.T, s.H, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
-			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
+			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected, &acc.histoConflictRejected)
 		}
 
 		prevHeadChunkCount := series.headChunkCount.Load()
@@ -1596,7 +1608,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 
 		oooSample, _, err := series.appendableFloatHistogram(s.T, s.FH, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 		if err != nil {
-			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected)
+			handleAppendableError(err, &acc.histogramsAppended, &acc.histoOOORejected, &acc.histoOOBRejected, &acc.histoTooOldRejected, &acc.histoConflictRejected)
 		}
 
 		prevHeadChunkCount := series.headChunkCount.Load()
@@ -1778,6 +1790,8 @@ func (a *headAppenderBase) Commit() (err error) {
 	h.metrics.outOfOrderSamples.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histoOOORejected))
 	h.metrics.outOfBoundSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatOOBRejected))
 	h.metrics.tooOldSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatTooOldRejected))
+	h.metrics.conflictingSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatConflictRejected))
+	h.metrics.conflictingSamples.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histoConflictRejected))
 	h.metrics.samplesAppended.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatsAppended))
 	h.metrics.samplesAppended.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histogramsAppended))
 	h.metrics.outOfOrderSamplesAppended.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.oooFloatsAccepted))

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -9406,3 +9406,33 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		requireCounterConsistent("final state")
 	})
 }
+
+// TestHeadAppenderV2_ConflictingSampleCounted verifies that when two samples for
+// the same series carry the same timestamp but different values within one
+// AppenderV2 batch, the second is rejected at commit and counted by the
+// conflicting-samples metric rather than dropped silently. This is the
+// observability gap reported in https://github.com/prometheus/prometheus/issues/11725
+// (a relabel collision collapses two series onto one and the loser vanished
+// without any counter or log).
+func TestHeadAppenderV2_ConflictingSampleCounted(t *testing.T) {
+	head, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
+	defer func() { require.NoError(t, head.Close()) }()
+	require.NoError(t, head.Init(0))
+
+	conflicting := head.metrics.conflictingSamples.WithLabelValues(sampleMetricTypeFloat)
+	require.Equal(t, 0.0, prom_testutil.ToFloat64(conflicting))
+
+	lbls := labels.FromStrings("foo", "bar")
+	app := head.AppenderV2(t.Context())
+	// Both appends pass: within one uncommitted batch the series maxTime is
+	// stale, so the conflict is only detected when commit re-runs appendable.
+	_, err := app.Append(0, lbls, 0, 100, 1.0, nil, nil, storage.AOptions{})
+	require.NoError(t, err)
+	_, err = app.Append(0, lbls, 0, 100, 2.0, nil, nil, storage.AOptions{})
+	require.NoError(t, err)
+	// Commit does not surface the conflict as an error (the loser is dropped),
+	// so the counter is the only signal that a sample was lost.
+	require.NoError(t, app.Commit())
+
+	require.Equal(t, 1.0, prom_testutil.ToFloat64(conflicting))
+}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -10671,3 +10671,33 @@ func testOOORestartResetsFirstOOOChunkID(t *testing.T, scenario sampleTypeScenar
 
 	require.NoError(t, h.Close())
 }
+
+// TestHeadAppenderV2_ConflictingSampleCounted verifies that when two samples for
+// the same series carry the same timestamp but different values within one
+// AppenderV2 batch, the second is rejected at commit and counted by the
+// conflicting-samples metric rather than dropped silently. This is the
+// observability gap reported in https://github.com/prometheus/prometheus/issues/11725
+// (a relabel collision collapses two series onto one and the loser vanished
+// without any counter or log).
+func TestHeadAppenderV2_ConflictingSampleCounted(t *testing.T) {
+	head, _ := newTestHead(t, DefaultBlockDuration, compression.None, false)
+	defer func() { require.NoError(t, head.Close()) }()
+	require.NoError(t, head.Init(0))
+
+	conflicting := head.metrics.conflictingSamples.WithLabelValues(sampleMetricTypeFloat)
+	require.Equal(t, 0.0, prom_testutil.ToFloat64(conflicting))
+
+	lbls := labels.FromStrings("foo", "bar")
+	app := head.AppenderV2(t.Context())
+	// Both appends pass: within one uncommitted batch the series maxTime is
+	// stale, so the conflict is only detected when commit re-runs appendable.
+	_, err := app.Append(0, lbls, 0, 100, 1.0, nil, nil, storage.AOptions{})
+	require.NoError(t, err)
+	_, err = app.Append(0, lbls, 0, 100, 2.0, nil, nil, storage.AOptions{})
+	require.NoError(t, err)
+	// Commit does not surface the conflict as an error (the loser is dropped),
+	// so the counter is the only signal that a sample was lost.
+	require.NoError(t, app.Commit())
+
+	require.Equal(t, 1.0, prom_testutil.ToFloat64(conflicting))
+}


### PR DESCRIPTION
Fixes #11725.

## Problem

When metric relabeling collapses two distinct series onto one, both samples pass `Append` (the batch `maxTime` is still stale because the batch is uncommitted). The conflict is only detected at `Commit`, where `series.appendable` returns an `ErrDuplicateSampleForTimestamp`-family error. That error fell into the bare `default` branch of `handleAppendableError`, which decremented the appended count with no counter and no log, so the losing sample vanished with no signal at all (the scrape-level duplicate warning only fires for `Append`-time errors, never for this commit-only path).

## Fix

Add `prometheus_tsdb_conflicting_samples_total{type=...}`, incremented per `ErrDuplicateSampleForTimestamp` rejection in `handleAppendableError`, flushed once per `Commit` via the same accumulate-int-then-`Add` pattern the existing out-of-order / out-of-bound / too-old reject counters already use. New `head_test.go` unit test on `AppenderV2` asserts the counter increments when two same-timestamp different-value samples for one series are committed together.

## Notes for review

- **V2 + performance.** Per the discussion (V2 is enough, perf is critical) the change is in the commit path that `AppenderV2` uses. There is no separate v2 `Commit`: both appenders embed `headAppenderBase`, so the counter also covers v1. That is purely additive observability with no behavior change (v1 already dropped these samples), but flagging it since the diff is not in a v2-only file.
- **Allocation-proven.** `storage.ErrDuplicateSampleForTimestamp` is a value-typed sentinel, so passing it straight to `errors.Is` in the per-sample path heap-boxes it on every call. It is pre-boxed once into an `error` interface (`errConflictingSample`) to avoid that. `benchstat` over `BenchmarkHeadAppender_AppendCommit/appender=v2` (`-count 10`) shows **zero allocs/op delta** across the matrix after this; the naive version regressed the histogram+exemplar cases by ~6-8% allocs/op, which the pre-boxing removes.
- **Counter-only, by design.** No per-sample log: under this exact failure mode a log would reintroduce unbounded hot-path cost. The counter is the observability the issue asks for.
- **Metric name.** I used `prometheus_tsdb_conflicting_samples_total` to match the existing reject-counter family (`prometheus_tsdb_out_of_order_samples_total`, etc.). The issue thread also floated `prometheus_tsdb_conflicting_samples_for_timestamp_total`; happy to rename if you prefer that spelling.

Signed-off-by present (DCO).

```release-notes
[ENHANCEMENT] TSDB: Add `prometheus_tsdb_conflicting_samples_total` metric counting samples rejected at commit because another sample with the same timestamp but a different value already existed for the series.
```
