### PR TITLE
storage/remote: Intern metadata in queue manager

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"unique"
 
 	"github.com/gogo/protobuf/proto"
 	remoteapi "github.com/prometheus/client_golang/exp/api/remote"
@@ -443,7 +444,7 @@ type QueueManager struct {
 
 	seriesMtx      sync.Mutex // Covers seriesLabels, seriesMetadata, droppedSeries and builder.
 	seriesLabels   map[chunks.HeadSeriesRef]labels.Labels
-	seriesMetadata map[chunks.HeadSeriesRef]*metadata.Metadata
+	seriesMetadata map[chunks.HeadSeriesRef]unique.Handle[metadata.Metadata]
 	droppedSeries  map[chunks.HeadSeriesRef]struct{}
 	builder        *labels.Builder
 
@@ -514,7 +515,7 @@ func NewQueueManager(
 		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
 
 		seriesLabels:         make(map[chunks.HeadSeriesRef]labels.Labels),
-		seriesMetadata:       make(map[chunks.HeadSeriesRef]*metadata.Metadata),
+		seriesMetadata:       make(map[chunks.HeadSeriesRef]unique.Handle[metadata.Metadata]),
 		seriesSegmentIndexes: make(map[chunks.HeadSeriesRef]int),
 		droppedSeries:        make(map[chunks.HeadSeriesRef]struct{}),
 		builder:              labels.NewBuilder(labels.EmptyLabels()),
@@ -1037,11 +1038,11 @@ func (t *QueueManager) StoreMetadata(meta []record.RefMetadata) {
 	t.seriesMtx.Lock()
 	defer t.seriesMtx.Unlock()
 	for _, m := range meta {
-		t.seriesMetadata[m.Ref] = &metadata.Metadata{
+		t.seriesMetadata[m.Ref] = unique.Make(metadata.Metadata{
 			Type: record.ToMetricType(m.Type),
 			Unit: m.Unit,
 			Help: m.Help,
-		}
+		})
 	}
 }
 
@@ -1399,12 +1400,15 @@ type queue struct {
 	batchPool [][]timeSeries
 }
 
+// Used for identifying a seriesMetadata map miss.
+var emptyMetadataHandle unique.Handle[metadata.Metadata]
+
 type timeSeries struct {
 	seriesLabels              labels.Labels
 	value                     float64
 	histogram                 *histogram.Histogram
 	floatHistogram            *histogram.FloatHistogram
-	metadata                  *metadata.Metadata
+	metadata                  unique.Handle[metadata.Metadata]
 	startTimestamp, timestamp int64
 	exemplarLabels            labels.Labels
 	// The type of series: sample, exemplar, or histogram.
@@ -1966,14 +1970,15 @@ func populateV2TimeSeries(symbolTable *writev2.SymbolsTable, batch []timeSeries,
 			pendingData[nPending].Metadata.UnitRef = symbolTable.Symbolize(m.Unit)
 			pendingData[nPending].Metadata.HelpRef = 0 // Type and unit does not give us help.
 			// Use Help from d.metadata if available.
-			if d.metadata != nil {
-				pendingData[nPending].Metadata.HelpRef = symbolTable.Symbolize(d.metadata.Help)
+			if d.metadata != emptyMetadataHandle {
+				pendingData[nPending].Metadata.HelpRef = symbolTable.Symbolize(d.metadata.Value().Help)
 				nPendingMetadata++
 			}
-		case d.metadata != nil:
-			pendingData[nPending].Metadata.Type = writev2.FromMetadataType(d.metadata.Type)
-			pendingData[nPending].Metadata.HelpRef = symbolTable.Symbolize(d.metadata.Help)
-			pendingData[nPending].Metadata.UnitRef = symbolTable.Symbolize(d.metadata.Unit)
+		case d.metadata != emptyMetadataHandle:
+			md := d.metadata.Value()
+			pendingData[nPending].Metadata.Type = writev2.FromMetadataType(md.Type)
+			pendingData[nPending].Metadata.HelpRef = symbolTable.Symbolize(md.Help)
+			pendingData[nPending].Metadata.UnitRef = symbolTable.Symbolize(md.Unit)
 			nPendingMetadata++
 		default:
 			// Safeguard against sending garbage in case of not having metadata

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"testing/synctest"
 	"time"
+	"unique"
 
 	"github.com/gogo/protobuf/proto"
 	remoteapi "github.com/prometheus/client_golang/exp/api/remote"
@@ -344,6 +345,41 @@ func TestMetadataDelivery(t *testing.T) {
 	require.Equal(t, numMetadata/config.DefaultMetadataConfig.MaxSamplesPerSend+1, c.writesReceived)
 	// Make sure the last samples were sent.
 	require.Equal(t, c.receivedMetadata[metadata[len(metadata)-1].MetricFamily][0].MetricFamilyName, metadata[len(metadata)-1].MetricFamily)
+}
+
+func TestStoreMetadataInterns(t *testing.T) {
+	_, m := newTestClientAndQueueManager(t, defaultFlushDeadline, remoteapi.WriteV2MessageType)
+
+	// Refs 1-3 share an identical {Type, Unit, Help} triple; ref 4 differs.
+	meta := []record.RefMetadata{
+		{Ref: 1, Type: uint8(record.Counter), Unit: "bytes", Help: "a shared help string"},
+		{Ref: 2, Type: uint8(record.Counter), Unit: "bytes", Help: "a shared help string"},
+		{Ref: 3, Type: uint8(record.Counter), Unit: "bytes", Help: "a shared help string"},
+		{Ref: 4, Type: uint8(record.Gauge), Unit: "seconds", Help: "a different help string"},
+	}
+	m.StoreMetadata(meta)
+
+	m.seriesMtx.Lock()
+	defer m.seriesMtx.Unlock()
+
+	// Series with an identical metadata triple must resolve to the same interned
+	// handle, so it is allocated only once regardless of series count.
+	require.Equal(t, m.seriesMetadata[1], m.seriesMetadata[2], "identical metadata should share one handle")
+	require.Equal(t, m.seriesMetadata[1], m.seriesMetadata[3], "identical metadata should share one handle")
+	require.NotEqual(t, m.seriesMetadata[1], m.seriesMetadata[4], "different metadata must not share a handle")
+
+	// The handle must round-trip the original values.
+	got := m.seriesMetadata[1].Value()
+	require.Equal(t, model.MetricTypeCounter, got.Type)
+	require.Equal(t, "bytes", got.Unit)
+	require.Equal(t, "a shared help string", got.Help)
+
+	// Remote-write v1 must not store metadata at all.
+	_, mv1 := newTestClientAndQueueManager(t, defaultFlushDeadline, remoteapi.WriteV1MessageType)
+	mv1.StoreMetadata(meta)
+	mv1.seriesMtx.Lock()
+	require.Empty(t, mv1.seriesMetadata)
+	mv1.seriesMtx.Unlock()
 }
 
 func TestWALMetadataDelivery(t *testing.T) {
@@ -1425,29 +1461,27 @@ func BenchmarkSeriesMetadataMemory(b *testing.B) {
 
 	for _, seriesPerFamily := range []int{1, 5, 10, 100} {
 		b.Run(fmt.Sprintf("seriesPerFamily=%d", seriesPerFamily), func(b *testing.B) {
-	var retained uint64
-	for b.Loop() {
-		_, m := newTestClientAndQueueManager(b, defaultFlushDeadline, remoteapi.WriteV2MessageType)
+			var retained uint64
+			for b.Loop() {
+				_, m := newTestClientAndQueueManager(b, defaultFlushDeadline, remoteapi.WriteV2MessageType)
 
-		// Snapshot the empty manager so the delta isolates seriesMetadata. Two GCs:
-		// one runs the unique package's cleanup, the second frees what it released.
-		runtime.GC()
-		runtime.GC()
-		var before, after runtime.MemStats
-		runtime.ReadMemStats(&before)
+				// Snapshot the empty manager so the delta isolates seriesMetadata. Two GCs:
+				// one runs the unique package's cleanup, the second frees what it released.
+				runtime.GC()
+				runtime.GC()
+				var before, after runtime.MemStats
+				runtime.ReadMemStats(&before)
 
-				recs := genRecords(seriesPerFamily)
-		m.StoreMetadata(recs)
-		recs = nil // Drop sources so only the map's retention is measured.
+				m.StoreMetadata(genRecords(seriesPerFamily))
 
-		runtime.GC()
-		runtime.GC()
-		runtime.ReadMemStats(&after)
-		runtime.KeepAlive(m)
-		retained = after.HeapAlloc - before.HeapAlloc
-	}
-	b.ReportMetric(float64(retained), "retainedBytes")
-	b.ReportMetric(float64(retained)/numSeries, "retainedBytes/series")
+				runtime.GC()
+				runtime.GC()
+				runtime.ReadMemStats(&after)
+				runtime.KeepAlive(m)
+				retained = after.HeapAlloc - before.HeapAlloc
+			}
+			b.ReportMetric(float64(retained), "retainedBytes")
+			b.ReportMetric(float64(retained)/numSeries, "retainedBytes/series")
 		})
 	}
 }
@@ -2560,7 +2594,9 @@ func TestPopulateV2TimeSeries_MetadataAndTypeAndUnit(t *testing.T) {
 				value:        123.45,
 				timestamp:    time.Now().UnixMilli(),
 				sType:        tSample,
-				metadata:     tc.metadata,
+			}
+			if tc.metadata != nil {
+				batch[0].metadata = unique.Make(*tc.metadata)
 			}
 
 			pendingData := make([]writev2.TimeSeries, 1)

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"runtime"
 	"runtime/pprof"
 	"strconv"
 	"strings"
@@ -1398,6 +1399,55 @@ func BenchmarkStoreSeries(b *testing.B) {
 
 				m.StoreSeries(recs.Series, 0)
 			}
+		})
+	}
+}
+
+// BenchmarkSeriesMetadataMemory measures the heap retained by a QueueManager's
+// seriesMetadata map for many series sharing metadata per family.
+func BenchmarkSeriesMetadataMemory(b *testing.B) {
+	const numSeries = 1_000_000
+
+	// Each record gets fresh Help/Unit strings, as decoding WAL records would.
+	genRecords := func(seriesPerFamily int) []record.RefMetadata {
+		recs := make([]record.RefMetadata, numSeries)
+		for i := range recs {
+			family := i / seriesPerFamily
+			recs[i] = record.RefMetadata{
+				Ref:  chunks.HeadSeriesRef(i),
+				Type: uint8(record.Gauge),
+				Unit: fmt.Sprintf("unit_for_family_%d", family),
+				Help: fmt.Sprintf("Help text describing metric family number %d, generated for the remote write metadata interning benchmark.", family),
+			}
+		}
+		return recs
+	}
+
+	for _, seriesPerFamily := range []int{1, 5, 10, 100} {
+		b.Run(fmt.Sprintf("seriesPerFamily=%d", seriesPerFamily), func(b *testing.B) {
+	var retained uint64
+	for b.Loop() {
+		_, m := newTestClientAndQueueManager(b, defaultFlushDeadline, remoteapi.WriteV2MessageType)
+
+		// Snapshot the empty manager so the delta isolates seriesMetadata. Two GCs:
+		// one runs the unique package's cleanup, the second frees what it released.
+		runtime.GC()
+		runtime.GC()
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+				recs := genRecords(seriesPerFamily)
+		m.StoreMetadata(recs)
+		recs = nil // Drop sources so only the map's retention is measured.
+
+		runtime.GC()
+		runtime.GC()
+		runtime.ReadMemStats(&after)
+		runtime.KeepAlive(m)
+		retained = after.HeapAlloc - before.HeapAlloc
+	}
+	b.ReportMetric(float64(retained), "retainedBytes")
+	b.ReportMetric(float64(retained)/numSeries, "retainedBytes/series")
 		})
 	}
 }


### PR DESCRIPTION
I've been looking for ways to reduce memory consumption when metadata is enabled. This seems like a low hanging fruit.

#### Testing

How should I test this? I added benchmarks, but should I also do end to end testing?

I tried end-to-end testing using the config below together with a `--enable-feature=metadata-wal-records` cmd arg, but I didn't see any metadata-related profiles. I expected to see `StoreMetadata`, but it's not in the `inuse_memory` profile.

<details>

<summary>Prometheus config</summary>

```yaml
global:
  scrape_interval: 15s

scrape_configs:
  - job_name: demo
    honor_timestamps: true
    static_configs:
      - targets:
          - "127.0.0.1:9001"

remote_write:
  - url: "http://localhost:9999/api/v1/metrics/write"
    protobuf_message: io.prometheus.write.v2.Request
```

</details>

I used this avalanche config:
```
avalanche   --gauge-metric-count=200000   --counter-metric-count=0   --histogram-metric-count=0   --native-histogram-metric-count=0   --summary-metric-count=0   --series-count=5   --label-count=0
```

What sort of use case are we optimising for? Is there an "average user" that we usually try to optimise for? E.g. a certain amount of churn, series per family, metric types? Optimisations will often make the code a bit less readable, and they will often only optimise some use cases. So I'm not sure what to aim for. Is there a standard Avalanche config that people tend to use when benchmarking?

#### Which issue(s) does the PR fix:

Related to #17619

#### Release notes for end users (**ALL** commits must be considered).

Is this change worth flagging to end users? Memory and CPU savings would depend on their use case. In fact, if all their metric families have only one series then the CPU and memory performance would get worse:

| series/family | before (pointer) | after (interned) | result |
|---:|---|---|---|
| 1 | 221.8 B/series | 328.5 B/series | 0.68× — interning ~1.5× **worse** (+107 B/series) |
| 5 | 221.8 B/series | 113.9 B/series | 1.95× — saves ~49% |
| 10 | 221.8 B/series | 76.0 B/series | 2.92× — saves ~66% |
| 100 | 221.8 B/series | 41.6 B/series | 5.33× — saves ~81% |

