### PR TITLE
RFC: cmd/promtool: add tsdb export/import to/from protobuf

### DIFF
--- a/cmd/promtool/backfill.go
+++ b/cmd/promtool/backfill.go
@@ -84,7 +84,17 @@ func getCompatibleBlockDuration(maxBlockDuration int64) int64 {
 	return blockDuration
 }
 
-func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesInAppender int, outputDir string, humanReadable, quiet bool, customLabels map[string]string) (returnErr error) {
+type parserBuilder func(input []byte, st *labels.SymbolTable) textparse.Parser
+
+func protobufParserBuilder(input []byte, _ *labels.SymbolTable) textparse.Parser {
+	return textparse.NewProtobufSeriesParser(input)
+}
+
+func openMetricsParserBuilder(input []byte, st *labels.SymbolTable) textparse.Parser {
+	return textparse.NewOpenMetricsParser(input, st)
+}
+
+func createBlocks(input []byte, parserBuilder parserBuilder, mint, maxt, maxBlockDuration int64, maxSamplesInAppender int, outputDir string, humanReadable, quiet bool, customLabels map[string]string) (returnErr error) {
 	blockDuration := getCompatibleBlockDuration(maxBlockDuration)
 	mint = blockDuration * (mint / blockDuration)
 
@@ -130,7 +140,7 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 			ctx := context.Background()
 			app := w.Appender(ctx)
 			symbolTable := labels.NewSymbolTable() // One table per block means it won't grow too large.
-			p := textparse.NewOpenMetricsParser(input, symbolTable)
+			p := parserBuilder(input, symbolTable)
 			samplesCount := 0
 			for {
 				e, err := p.Next()
@@ -228,13 +238,13 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 	return nil
 }
 
-func backfill(maxSamplesInAppender int, input []byte, outputDir string, humanReadable, quiet bool, maxBlockDuration time.Duration, customLabels map[string]string) (err error) {
-	p := textparse.NewOpenMetricsParser(input, nil) // Don't need a SymbolTable to get max and min timestamps.
+func backfill(maxSamplesInAppender int, input []byte, outputDir string, parserBuilder parserBuilder, humanReadable, quiet bool, maxBlockDuration time.Duration, customLabels map[string]string) (err error) {
+	p := parserBuilder(input, nil) // Don't need a SymbolTable to get max and min timestamps.
 	maxt, mint, err := getMinAndMaxTimestamps(p)
 	if err != nil {
 		return fmt.Errorf("getting min and max timestamp: %w", err)
 	}
-	if err = createBlocks(input, mint, maxt, int64(maxBlockDuration/time.Millisecond), maxSamplesInAppender, outputDir, humanReadable, quiet, customLabels); err != nil {
+	if err = createBlocks(input, parserBuilder, mint, maxt, int64(maxBlockDuration/time.Millisecond), maxSamplesInAppender, outputDir, humanReadable, quiet, customLabels); err != nil {
 		return fmt.Errorf("block creation: %w", err)
 	}
 	return nil

--- a/cmd/promtool/backfill_test.go
+++ b/cmd/promtool/backfill_test.go
@@ -735,7 +735,7 @@ after_eof 1 2
 
 			outputDir := t.TempDir()
 
-			err := backfill(test.MaxSamplesInAppender, []byte(test.ToParse), outputDir, false, false, test.MaxBlockDuration, test.Labels)
+			err := backfill(test.MaxSamplesInAppender, []byte(test.ToParse), outputDir, openMetricsParserBuilder, false, false, test.MaxBlockDuration, test.Labels)
 
 			if !test.IsOk {
 				require.Error(t, err, test.Description)

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -273,7 +273,7 @@ func main() {
 	dumpMinTime := tsdbDumpCmd.Flag("min-time", "Minimum timestamp to dump, in milliseconds since the Unix epoch.").Default(strconv.FormatInt(math.MinInt64, 10)).Int64()
 	dumpMaxTime := tsdbDumpCmd.Flag("max-time", "Maximum timestamp to dump, in milliseconds since the Unix epoch.").Default(strconv.FormatInt(math.MaxInt64, 10)).Int64()
 	dumpMatch := tsdbDumpCmd.Flag("match", "Series selector. Can be specified multiple times.").Default("{__name__=~'(?s:.*)'}").Strings()
-	dumpFormat := tsdbDumpCmd.Flag("format", "Output format of the dump (prom (default) or seriesjson).").Default("prom").Enum("prom", "seriesjson")
+	dumpFormat := tsdbDumpCmd.Flag("format", "Output format of the dump (prom (default), seriesjson or protobuf).").Default("prom").Enum("prom", "seriesjson", "protobuf")
 
 	tsdbDumpOpenMetricsCmd := tsdbCmd.Command("dump-openmetrics", "[Experimental] Dump samples from a TSDB into OpenMetrics text format, excluding native histograms and staleness markers, which are not representable in OpenMetrics.")
 	dumpOpenMetricsPath := tsdbDumpOpenMetricsCmd.Arg("db path", "Database path (default is "+defaultDBPath+").").Default(defaultDBPath).String()
@@ -290,6 +290,10 @@ func main() {
 	openMetricsLabels := openMetricsImportCmd.Flag("label", "Label to attach to metrics. Can be specified multiple times. Example --label=label_name=label_value").StringMap()
 	importFilePath := openMetricsImportCmd.Arg("input file", "OpenMetrics file to read samples from.").Required().String()
 	importDBPath := openMetricsImportCmd.Arg("output directory", "Output directory for generated blocks.").Default(defaultDBPath).String()
+	importProtobufCmd := importCmd.Command("protobuf", "Import samples from Protobuf input and produce TSDB blocks. Please refer to the storage docs for more details.")
+	importProtobufLabels := importProtobufCmd.Flag("label", "Label to attach to metrics. Can be specified multiple times. Example --label=label_name=label_value").StringMap()
+	importProtobufFilePath := importProtobufCmd.Arg("input file", "OpenMetrics file to read samples from.").Required().String()
+	importProtobufDBPath := importProtobufCmd.Arg("output directory", "Output directory for generated blocks.").Default(defaultDBPath).String()
 	importRulesCmd := importCmd.Command("rules", "Create blocks of data for new recording rules.")
 	importRulesCmd.Flag("http.config.file", httpConfigFileDescription).PlaceHolder("<filename>").ExistingFileVar(&httpConfigFilePath)
 	importRulesCmd.Flag("url", "The URL for the Prometheus API with the data where the rule will be backfilled from.").Default("http://localhost:9090").URLVar(&serverURL)
@@ -446,8 +450,11 @@ func main() {
 
 	case tsdbDumpCmd.FullCommand():
 		format := formatSeriesSet
-		if *dumpFormat == "seriesjson" {
+		switch *dumpFormat {
+		case "seriesjson":
 			format = formatSeriesSetLabelsToJSON
+		case "protobuf":
+			format = formatSeriesSetProtobuf
 		}
 		os.Exit(checkErr(dumpTSDBData(ctx, *dumpPath, *dumpSandboxDirRoot, *dumpMinTime, *dumpMaxTime, *dumpMatch, format, promtoolParser)))
 
@@ -455,7 +462,9 @@ func main() {
 		os.Exit(checkErr(dumpTSDBData(ctx, *dumpOpenMetricsPath, *dumpOpenMetricsSandboxDirRoot, *dumpOpenMetricsMinTime, *dumpOpenMetricsMaxTime, *dumpOpenMetricsMatch, formatSeriesSetOpenMetrics, promtoolParser)))
 	// TODO(aSquare14): Work on adding support for custom block size.
 	case openMetricsImportCmd.FullCommand():
-		os.Exit(backfillOpenMetrics(*importFilePath, *importDBPath, *importHumanReadable, *importQuiet, *maxBlockDuration, *openMetricsLabels))
+		os.Exit(backfillFromFile(*importFilePath, *importDBPath, openMetricsParserBuilder, *importHumanReadable, *importQuiet, *maxBlockDuration, *openMetricsLabels))
+	case importProtobufCmd.FullCommand():
+		os.Exit(backfillFromFile(*importProtobufFilePath, *importProtobufDBPath, protobufParserBuilder, *importHumanReadable, *importQuiet, *maxBlockDuration, *importProtobufLabels))
 
 	case importRulesCmd.FullCommand():
 		os.Exit(checkErr(importRules(serverURL, httpRoundTripper, *importRulesStart, *importRulesEnd, *importRulesOutputDir, *importRulesEvalInterval, *maxBlockDuration, model.UTF8Validation, *importRulesFiles...)))

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -34,12 +34,14 @@ import (
 	"time"
 
 	"github.com/alecthomas/units"
+	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/common/promslog"
 	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -815,6 +817,22 @@ func formatSeriesSetLabelsToJSON(ss storage.SeriesSet) error {
 	return nil
 }
 
+func formatSeriesSetProtobuf(ss storage.SeriesSet) error {
+	result, _, err := remote.ToQueryResult(ss, -1)
+	if err != nil {
+		return err
+	}
+	buf, err := proto.Marshal(result)
+	if err != nil {
+		return err
+	}
+	_, err = os.Stdout.Write(buf)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func formatSeriesSetOpenMetrics(ss storage.SeriesSet) error {
 	for ss.Next() {
 		series := ss.At()
@@ -842,7 +860,7 @@ func checkErr(err error) int {
 	return 0
 }
 
-func backfillOpenMetrics(path, outputDir string, humanReadable, quiet bool, maxBlockDuration time.Duration, customLabels map[string]string) int {
+func backfillFromFile(path, outputDir string, parserBuilder parserBuilder, humanReadable, quiet bool, maxBlockDuration time.Duration, customLabels map[string]string) int {
 	var buf []byte
 	info, err := os.Stat(path)
 	if err != nil {
@@ -867,7 +885,7 @@ func backfillOpenMetrics(path, outputDir string, humanReadable, quiet bool, maxB
 		return checkErr(fmt.Errorf("create output dir: %w", err))
 	}
 
-	return checkErr(backfill(5000, buf, outputDir, humanReadable, quiet, maxBlockDuration, customLabels))
+	return checkErr(backfill(5000, buf, outputDir, parserBuilder, humanReadable, quiet, maxBlockDuration, customLabels))
 }
 
 func displayHistogram(dataType string, datas []int, total int) {

--- a/cmd/promtool/tsdb_posix_test.go
+++ b/cmd/promtool/tsdb_posix_test.go
@@ -53,7 +53,7 @@ func TestTSDBDumpOpenMetricsRoundTripPipe(t *testing.T) {
 	}()
 
 	// Import samples from OM format
-	code := backfillOpenMetrics(pipe, dbDir, false, false, 2*time.Hour, map[string]string{})
+	code := backfillFromFile(pipe, dbDir, openMetricsParserBuilder, false, false, 2*time.Hour, map[string]string{})
 	require.Equal(t, 0, code)
 	db, err := tsdb.Open(dbDir, nil, nil, tsdb.DefaultOptions(), nil)
 	require.NoError(t, err)

--- a/cmd/promtool/tsdb_test.go
+++ b/cmd/promtool/tsdb_test.go
@@ -228,7 +228,7 @@ func TestTSDBDumpOpenMetricsRoundTrip(t *testing.T) {
 
 	dbDir := t.TempDir()
 	// Import samples from OM format
-	err = backfill(5000, initialMetrics, dbDir, false, false, 2*time.Hour, map[string]string{})
+	err = backfill(5000, initialMetrics, dbDir, openMetricsParserBuilder, false, false, 2*time.Hour, map[string]string{})
 	require.NoError(t, err)
 	db, err := tsdb.Open(dbDir, nil, nil, tsdb.DefaultOptions(), nil)
 	require.NoError(t, err)

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -594,7 +594,7 @@ Dump data (series+samples or optionally just series) from a TSDB.
 | <code class="text-nowrap">--min-time</code> | Minimum timestamp to dump, in milliseconds since the Unix epoch. | `-9223372036854775808` |
 | <code class="text-nowrap">--max-time</code> | Maximum timestamp to dump, in milliseconds since the Unix epoch. | `9223372036854775807` |
 | <code class="text-nowrap">--match</code> <code class="text-nowrap">...</code> | Series selector. Can be specified multiple times. | `{__name__=~'(?s:.*)'}` |
-| <code class="text-nowrap">--format</code> | Output format of the dump (prom (default) or seriesjson). | `prom` |
+| <code class="text-nowrap">--format</code> | Output format of the dump (prom (default), seriesjson or protobuf). | `prom` |
 
 
 
@@ -654,6 +654,31 @@ Dump data (series+samples or optionally just series) from a TSDB.
 ##### `promtool tsdb create-blocks-from openmetrics`
 
 Import samples from OpenMetrics input and produce TSDB blocks. Please refer to the storage docs for more details.
+
+
+
+###### Flags
+
+| Flag | Description |
+| --- | --- |
+| <code class="text-nowrap">--label</code> | Label to attach to metrics. Can be specified multiple times. Example --label=label_name=label_value |
+
+
+
+
+###### Arguments
+
+| Argument | Description | Default | Required |
+| --- | --- | --- | --- |
+| input file | OpenMetrics file to read samples from. |  | Yes |
+| output directory | Output directory for generated blocks. | `data/` |  |
+
+
+
+
+##### `promtool tsdb create-blocks-from protobuf`
+
+Import samples from Protobuf input and produce TSDB blocks. Please refer to the storage docs for more details.
 
 
 

--- a/model/textparse/protobufseriesparse.go
+++ b/model/textparse/protobufseriesparse.go
@@ -1,0 +1,132 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textparse
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
+)
+
+// ProtobufSeriesParser is a Protobuf parser of Timeseries set encoded as
+// [prompb.QueryResult] that implements the [Parser] interface. It currently
+// only supports parsing Sample values, not Histograms.
+type ProtobufSeriesParser struct {
+	b  []byte
+	ts []*prompb.TimeSeries
+
+	// state is marked by the entry we are processing. EntryInvalid implies
+	// that we have to decode the next MetricDescriptor.
+	state          Entry
+	currTsIndex    int
+	currTs         *prompb.TimeSeries
+	currEntryIndex int
+}
+
+func NewProtobufSeriesParser(b []byte) Parser {
+	return &ProtobufSeriesParser{b: b, state: EntryInvalid}
+}
+
+// Series implements [Parser.Series].
+func (p *ProtobufSeriesParser) Series() ([]byte, *int64, float64) {
+	switch p.state {
+	case EntrySeries:
+		v := p.currTs.Samples[p.currEntryIndex]
+		return nil, &v.Timestamp, v.Value
+	}
+	panic("invalid state")
+}
+
+// Histogram implements [Parser.Histogram] (currently not implemented).
+func (*ProtobufSeriesParser) Histogram() ([]byte, *int64, *histogram.Histogram, *histogram.FloatHistogram) {
+	panic("not implemented")
+}
+
+// Help implements [Parser.Help] (currently not implemented).
+func (*ProtobufSeriesParser) Help() ([]byte, []byte) {
+	panic("not implemented")
+}
+
+// Type implements [Parser.Type] (currently not implemented).
+func (*ProtobufSeriesParser) Type() ([]byte, model.MetricType) {
+	panic("not implemented")
+}
+
+// Unit implements [Parser.Unit] (currently not implemented).
+func (*ProtobufSeriesParser) Unit() ([]byte, []byte) {
+	panic("not implemented")
+}
+
+// Comment implements [Parser.Comment] (currently not implemented).
+func (*ProtobufSeriesParser) Comment() []byte {
+	panic("not implemented")
+}
+
+// Labels implements [Parser.Labels].
+func (p *ProtobufSeriesParser) Labels(l *labels.Labels) {
+	builder := labels.NewScratchBuilder(len(p.currTs.Labels))
+	*l = p.currTs.ToLabels(&builder, nil)
+}
+
+// Exemplar implements [Parser.Exemplar] (currently not implemented).
+func (*ProtobufSeriesParser) Exemplar(_ *exemplar.Exemplar) bool {
+	panic("not implemented")
+}
+
+// StartTimestamp implements [Parser.StartTimestamp].
+func (*ProtobufSeriesParser) StartTimestamp() int64 {
+	return 0
+}
+
+// Next implements [Parser.Next].
+func (p *ProtobufSeriesParser) Next() (Entry, error) {
+	switch p.state {
+	case EntryInvalid:
+		if p.ts == nil {
+			var result prompb.QueryResult
+			err := proto.Unmarshal(p.b, &result)
+			if err != nil {
+				return p.state, err
+			}
+			p.ts = result.Timeseries
+		} else {
+			p.currTsIndex++
+			p.currEntryIndex = 0
+		}
+		if len(p.ts) <= p.currTsIndex {
+			return p.state, io.EOF
+		}
+		p.currTs = p.ts[p.currTsIndex]
+		p.state = EntrySeries
+		p.currEntryIndex = -1
+		return p.Next()
+	case EntrySeries:
+		p.currEntryIndex++
+		if len(p.currTs.Samples) <= p.currEntryIndex {
+			p.state = EntryInvalid
+			p.currEntryIndex = -1
+			return p.Next()
+		}
+	default:
+		return EntryInvalid, fmt.Errorf("invalid protobuf parsing state: %d", p.state)
+	}
+	return p.state, nil
+}


### PR DESCRIPTION
This is more of a prototype than a finished implementation. The idea is to add a Protobuf import/export feature of the tsdb in addition to the text ones, to save space and improve cpu usage while encoding/decoding.

The protobuf message used is `prompb.QueryResult` as it is a much more compact message for series set than the `promdb/io/prometheus/client` list of metrics. The encoding and decoding code was already present in the `storage/remote` package, but the decoder did not implement the needed `parser.Parser` interface. To fix this I introduced a very basic `Parser` implementation for this `prompb.QueryResult` message. It is only capable of returning Samples, not Histograms, as these are not supported by the rest of the tsdb import code anyway.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
None
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[FEATURE]: promtool/tsdb: ad import/export from/to protobuf
```

Here are quick benchmarks of the improvements:

```console
$ benchcmd -n 20 Export promtool tsdb dump-openmetrics | grep -aEo "Benchmark.*$" >> openmetrics.txt
$ benchcmd -n 20 Export promtool tsdb dump --format protobuf | grep -aEo "Benchmark.*$" >> protobuf.txt
$ benchcmd -n 20 Import promtool tsdb create-blocks-from openmetrics test.om /tmp/data | grep -E "^Benchmark" >> openmetrics.txt
$ benchcmd -n 20 Import promtool tsdb create-blocks-from protobuf test.protobuf /tmp/data | grep -E "^Benchmark" >> protobuf.txt
$ benchstat openmetrics.txt protobuf.txt 
        │ openmetrics.txt │            protobuf.txt             │
        │     sec/op      │   sec/op     vs base                │
Export       1516.6m ± 2%   231.1m ± 5%  -84.76% (p=0.000 n=20)
Import         2.507 ± 1%    1.203 ± 3%  -52.00% (p=0.000 n=20)
geomean        1.950        527.3m       -72.95%

        │ openmetrics.txt │            protobuf.txt             │
        │   user-sec/op   │ user-sec/op  vs base                │
Export       1107.1m ± 2%   311.7m ± 6%  -71.85% (p=0.000 n=20)
Import         2.431 ± 1%    1.494 ± 3%  -38.53% (p=0.000 n=20)
geomean        1.640        682.4m       -58.40%

        │ openmetrics.txt │             protobuf.txt              │
        │   sys-sec/op    │  sys-sec/op    vs base                │
Export      560.97m ±  6%    61.66m ± 17%  -89.01% (p=0.000 n=20)
Import       99.56m ± 19%   169.76m ± 10%  +70.51% (p=0.000 n=20)
geomean      236.3m          102.3m        -56.71%

        │ openmetrics.txt │              protobuf.txt               │
        │ peak-RSS-bytes  │ peak-RSS-bytes  vs base                 │
Export       81.17Mi ± 1%    228.25Mi ± 3%  +181.20% (p=0.000 n=20)
Import       370.2Mi ± 2%     397.9Mi ± 4%    +7.48% (p=0.000 n=20)
geomean      173.3Mi          301.3Mi        +73.85%
```

Here is an idea of the size differences:

```console
$ du -h test.*
157M	test.om
22M	test.protobuf
$ time xz test.om 
real	0m17,220s
user	0m17,167s
sys	0m0,052s
$ time xz test.protobuf 
real	0m2,758s
user	0m2,725s
sys	0m0,033s
$ du -h test.*
2,4M	test.om.xz
996K	test.protobuf.xz
$ unxz test.*
$ promtool tsdb create-blocks-from openmetrics test.om data-om
BLOCK ULID                  MIN TIME       MAX TIME       DURATION     NUM SAMPLES  NUM CHUNKS   NUM SERIES   SIZE
01KVWYMTW4E7WJER57N1PJSV09  1781625086201  1781625599941  8m33.74s     1309427      12686        12464        2954356
01KVWYMVJ42N3E0RFEX10FQTWY  1781625600011  1781625686420  1m26.409s    227906       12536        12536        1387766
$ promtool tsdb create-blocks-from protobuf test.protobuf data-protobuf
BLOCK ULID                  MIN TIME       MAX TIME       DURATION     NUM SAMPLES  NUM CHUNKS   NUM SERIES   SIZE
01KVWYM8K14G45NEE93D62TXVQ  1781625086201  1781625599941  8m33.74s     1309427      12686        12464        2954356
01KVWYM8W4R2RJQ2TJEWP7D4DJ  1781625600011  1781625686420  1m26.409s    227906       12536        12536        1387766
```