### PR TITLE
chore(tsdb): simplify cutSegmentFile by removing temp file indirection

### DIFF
--- a/tsdb/chunks/chunks.go
+++ b/tsdb/chunks/chunks.go
@@ -431,26 +431,25 @@ func (w *Writer) cut() error {
 	return nil
 }
 
+// cutSegmentFile creates the next segment file in dirFile and writes its header.
+// It does not fsync the file content, so a crash may leave the file with missing or invalid content.
+// Callers must account for this.
 func cutSegmentFile(dirFile *os.File, magicNumber uint32, chunksFormat byte, allocSize int64) (headerSize int, newFile *os.File, seq int, returnErr error) {
 	p, seq, err := nextSequenceFile(dirFile.Name())
 	if err != nil {
 		return 0, nil, 0, fmt.Errorf("next sequence file: %w", err)
 	}
-	ptmp := p + ".tmp"
-	f, err := os.OpenFile(ptmp, os.O_WRONLY|os.O_CREATE, 0o666)
+	f, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE, 0o666)
 	if err != nil {
-		return 0, nil, 0, fmt.Errorf("open temp file: %w", err)
+		return 0, nil, 0, fmt.Errorf("open segment file: %w", err)
 	}
 	defer func() {
 		if returnErr != nil {
-			errs := []error{
-				returnErr,
-			}
+			errs := []error{returnErr}
 			if f != nil {
 				errs = append(errs, f.Close())
 			}
-			// Calling RemoveAll on a non-existent file does not return error.
-			errs = append(errs, os.RemoveAll(ptmp))
+			errs = append(errs, os.RemoveAll(p))
 			returnErr = errors.Join(errs...)
 		}
 	}()
@@ -463,7 +462,7 @@ func cutSegmentFile(dirFile *os.File, magicNumber uint32, chunksFormat byte, all
 		return 0, nil, 0, fmt.Errorf("sync directory: %w", err)
 	}
 
-	// Write header metadata for new file.
+	// Write header metadata.
 	metab := make([]byte, SegmentHeaderSize)
 	binary.BigEndian.PutUint32(metab[:MagicChunksSize], magicNumber)
 	metab[4] = chunksFormat
@@ -471,24 +470,6 @@ func cutSegmentFile(dirFile *os.File, magicNumber uint32, chunksFormat byte, all
 	n, err := f.Write(metab)
 	if err != nil {
 		return 0, nil, 0, fmt.Errorf("write header: %w", err)
-	}
-	if err := f.Close(); err != nil {
-		return 0, nil, 0, fmt.Errorf("close temp file: %w", err)
-	}
-	f = nil
-
-	if err := fileutil.Rename(ptmp, p); err != nil {
-		return 0, nil, 0, fmt.Errorf("replace file: %w", err)
-	}
-
-	f, err = os.OpenFile(p, os.O_WRONLY, 0o666)
-	if err != nil {
-		return 0, nil, 0, fmt.Errorf("open final file: %w", err)
-	}
-	// Skip header for further writes.
-	offset := int64(n)
-	if _, err := f.Seek(offset, 0); err != nil {
-		return 0, nil, 0, fmt.Errorf("seek to %d in final file: %w", offset, err)
 	}
 	return n, f, seq, nil
 }

--- a/tsdb/chunks/head_chunks_test.go
+++ b/tsdb/chunks/head_chunks_test.go
@@ -446,6 +446,8 @@ func TestHeadReadWriter_TruncateAfterFailedIterateChunks(t *testing.T) {
 	require.NoError(t, hrw.Truncate(2000))
 }
 
+// TestHeadReadWriter_ReadRepairOnEmptyLastFile covers more than empty files.
+// Name kept for history context.
 func TestHeadReadWriter_ReadRepairOnEmptyLastFile(t *testing.T) {
 	t.Parallel()
 	hrw := createChunkDiskMapper(t, "")


### PR DESCRIPTION
This will allow the simplification of the directIOWriter.

PR #7573 introduced a .tmp file + rename pattern in cutSegmentFile to prevent mmap from seeing empty files after a crash. However, without an fsync on the file itself, a crash could still leave the renamed file with zero content or sth else. PR #8061 added repairLastChunkFile as the real fix, extended in PR #11338 to detect zero magic numbers.

The .tmp indirection is redundant, both callers have crash safety:

- Head chunks: repairLastChunkFile removes corrupt last files on startup. No intermediary broken file can exist (handleChunkWriteError panics, so the corrupt file is always the last one).
- Compaction: files live in a .tmp-for-creation block directory, cleaned up entirely on failure or restart.

Remove the pattern for fewer syscalls and a simpler write path.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
