### PR TITLE
fix: "Compaction failed" errors in Windows container when TSDB (Data direc...

### DIFF
--- a/tsdb/fileutil/fileutil.go
+++ b/tsdb/fileutil/fileutil.go
@@ -20,6 +20,7 @@ package fileutil
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -124,5 +125,76 @@ func Replace(from, to string) error {
 		}
 	}
 
-	return Rename(from, to)
+	if err := Rename(from, to); err != nil {
+		// On Windows, renaming a directory can fail when the data directory
+		// lives on a bind-mounted volume (for example a Docker volume), in
+		// which case MoveFileEx returns "The system cannot find the path
+		// specified.". Fall back to copying the directory and removing the
+		// source. See https://github.com/prometheus/prometheus/issues/18308.
+		if runtime.GOOS != "windows" {
+			return err
+		}
+		if fi, statErr := os.Stat(from); statErr != nil || !fi.IsDir() {
+			return err
+		}
+		return replaceDirByCopy(from, to)
+	}
+	return nil
+}
+
+// replaceDirByCopy moves the directory at from to to by copying it and then
+// removing the source. It is used as a fallback when Rename fails.
+func replaceDirByCopy(from, to string) error {
+	if err := os.RemoveAll(to); err != nil {
+		return err
+	}
+	if err := CopyDirs(from, to); err != nil {
+		return err
+	}
+	if err := syncTree(to); err != nil {
+		return err
+	}
+	return os.RemoveAll(from)
+}
+
+// syncTree fsyncs every file and directory under dir as well as dir's parent,
+// so the copied data and the new directory entry are persisted to disk.
+func syncTree(dir string) error {
+	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			d, err := OpenDir(path)
+			if err != nil {
+				return err
+			}
+			if err := d.Sync(); err != nil {
+				d.Close()
+				return err
+			}
+			return d.Close()
+		}
+		f, err := os.OpenFile(path, os.O_RDWR, 0)
+		if err != nil {
+			return err
+		}
+		if err := Fdatasync(f); err != nil {
+			f.Close()
+			return err
+		}
+		return f.Close()
+	}); err != nil {
+		return err
+	}
+
+	pdir, err := OpenDir(filepath.Dir(dir))
+	if err != nil {
+		return err
+	}
+	if err := pdir.Sync(); err != nil {
+		pdir.Close()
+		return err
+	}
+	return pdir.Close()
 }

--- a/tsdb/fileutil/fileutil_test.go
+++ b/tsdb/fileutil/fileutil_test.go
@@ -1,0 +1,69 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceDirByCopy(t *testing.T) {
+	base := t.TempDir()
+
+	from := filepath.Join(base, "block.tmp-for-creation")
+	require.NoError(t, os.MkdirAll(filepath.Join(from, "chunks"), 0o777))
+	require.NoError(t, os.WriteFile(filepath.Join(from, "meta.json"), []byte(`{"version":1}`), 0o666))
+	require.NoError(t, os.WriteFile(filepath.Join(from, "chunks", "000001"), []byte("data"), 0o666))
+
+	to := filepath.Join(base, "block")
+
+	require.NoError(t, replaceDirByCopy(from, to))
+
+	// Source is gone.
+	_, err := os.Stat(from)
+	require.True(t, os.IsNotExist(err))
+
+	// Destination has the copied content.
+	got, err := os.ReadFile(filepath.Join(to, "meta.json"))
+	require.NoError(t, err)
+	require.Equal(t, `{"version":1}`, string(got))
+
+	got, err = os.ReadFile(filepath.Join(to, "chunks", "000001"))
+	require.NoError(t, err)
+	require.Equal(t, "data", string(got))
+}
+
+func TestReplaceDirByCopyOverwritesDestination(t *testing.T) {
+	base := t.TempDir()
+
+	from := filepath.Join(base, "src")
+	require.NoError(t, os.MkdirAll(from, 0o777))
+	require.NoError(t, os.WriteFile(filepath.Join(from, "new.txt"), []byte("new"), 0o666))
+
+	to := filepath.Join(base, "dst")
+	require.NoError(t, os.MkdirAll(to, 0o777))
+	require.NoError(t, os.WriteFile(filepath.Join(to, "stale.txt"), []byte("stale"), 0o666))
+
+	require.NoError(t, replaceDirByCopy(from, to))
+
+	_, err := os.Stat(filepath.Join(to, "stale.txt"))
+	require.True(t, os.IsNotExist(err))
+
+	got, err := os.ReadFile(filepath.Join(to, "new.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "new", string(got))
+}


### PR DESCRIPTION
## Summary

When the TSDB data directory lives on a bind-mounted Docker volume inside a Windows container (process isolation), renaming a directory fails. During head compaction, `LeveledCompactor.write` builds the block in a temporary directory named `<ulid>.tmp-for-creation` and then makes it visible by calling...


## Root cause

When the TSDB data directory lives on a bind-mounted Docker volume inside a
Windows container (process isolation), renaming a directory fails. During head
compaction, `LeveledCompactor.write` builds the block in a temporary directory
named `<ulid>.tmp-for-creation` and then makes it visible by calling
`fileutil.Replace(tmp, dir)`, which ends up calling `os.Rename`.

On Windows `os.Rename` maps to `MoveFileEx`. On a bind-mounted volume that call
returns "The system cannot find the path specified." (ERROR_PATH_NOT_FOUND), so
the rename never succeeds. The block can never be promoted out of the temp
directory, compaction keeps failing, and the TSDB stays uncompacted forever:

```
msg="compaction failed" err="compact head: persist head block: rename block dir:
rename data\\01KKVCWYJVA6GQK2FVTE7X2YBZ.tmp-for-creation data\\01KKVCWYJVA6GQK2FVTE7X2YBZ:
The system cannot find the path specified."
```

The error message format (`rename <from> <to>: <err>`) confirms the failure is
the `os.Rename` call itself, not a later parent-directory sync.


## What changed

`tsdb/fileutil/fileutil.go`

- `Replace` now has a fallback path. If `Rename` fails and we are on Windows and
 the source is a directory, it falls back to copying the directory to the
 destination and then removing the source. This mirrors the well known
 copy-and-delete workaround used by other Go projects for directory renames
 that the OS refuses on Windows bind mounts. The fallback is gated to Windows
 so behavior on Linux/macOS is unchanged.
- Added `replaceDirByCopy`, which removes any existing destination, copies the
 tree with the existing `CopyDirs`, fsyncs it, and removes the source.
- Added `syncTree`, which fsyncs every file and directory under the destination
 plus the parent directory, so the copied block is durably persisted. This
 keeps the same durability intent as the original `Rename` path (which syncs
 the parent dir). Files are reopened with `O_RDWR` so the fsync also works on
 Windows.
- `Replace` is documented as non-atomic, so the copy-based fallback does not
 change its contract.

`tsdb/fileutil/fileutil_test.go` (new)

- `TestReplaceDirByCopy` verifies the fallback copies nested files and removes
 the source.
- `TestReplaceDirByCopyOverwritesDestination` verifies a pre-existing
 destination directory is replaced rather than merged.

These tests exercise the fallback logic directly so it is covered on all
platforms, even though the fallback only triggers on Windows.


## Issue

Fixes #18308

Issue: https://github.com/prometheus/prometheus/issues/18308


## Diffstat

```
tsdb/fileutil/fileutil.go | 74 +++++++++++++++++++++++++++++++++++++++++-
 tsdb/fileutil/fileutil_test.go | 69 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 142 insertions(+), 1 deletion(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.