### PR TITLE
ui: render delete series form on tsdb status page if `--web.enable-admin-api` flag is enabled

### DIFF
--- a/web/ui/mantine-ui/src/api/responseTypes/features.ts
+++ b/web/ui/mantine-ui/src/api/responseTypes/features.ts
@@ -1,0 +1,3 @@
+// Result type for /api/v1/features endpoint.
+// See: https://prometheus.io/docs/prometheus/latest/querying/api/#features
+export type FeaturesResult = Record<string, Record<string, boolean>>;

--- a/web/ui/mantine-ui/src/pages/TSDBStatusPage.tsx
+++ b/web/ui/mantine-ui/src/pages/TSDBStatusPage.tsx
@@ -13,6 +13,7 @@ import { IconAlertTriangle, IconCheck, IconTrash } from "@tabler/icons-react";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { useSuspenseAPIQuery, API_PATH } from "../api/api";
+import { FeaturesResult } from "../api/responseTypes/features";
 import { TSDBStatusResult } from "../api/responseTypes/tsdbStatus";
 import { formatTimestamp } from "../lib/formatTime";
 import { useSettings } from "../state/settingsSlice";
@@ -33,6 +34,14 @@ export default function TSDBStatusPage() {
       },
     },
   } = useSuspenseAPIQuery<TSDBStatusResult>({ path: `/status/tsdb` });
+
+  const {
+    data: {
+      data: { api: featureApi },
+    },
+  } = useSuspenseAPIQuery<FeaturesResult>({ path: '/features' });
+
+  const adminApiEnabled = featureApi?.admin ?? false;
 
   const { useLocalTime, pathPrefix } = useSettings();
 
@@ -251,6 +260,8 @@ export default function TSDBStatusPage() {
             label="Series selector(s)"
             description='PromQL series selectors, one per line. Example: up{job="prometheus"}'
             placeholder={'up{job="prometheus"}'}
+            disabled={!adminApiEnabled}
+            title={!adminApiEnabled ? "Requires --web.enable-admin-api flag" : ""}
             value={matchers}
             onChange={(e) => setMatchers(e.currentTarget.value)}
             autosize
@@ -264,6 +275,8 @@ export default function TSDBStatusPage() {
               description="Optional"
               placeholder="Select start time"
               valueFormat="YYYY-MM-DD HH:mm:ss"
+              disabled={!adminApiEnabled}
+              title={!adminApiEnabled ? "Requires --web.enable-admin-api flag" : ""}
               withSeconds
               value={
                 startTime !== null
@@ -290,6 +303,8 @@ export default function TSDBStatusPage() {
               description="Optional"
               placeholder="Select end time"
               valueFormat="YYYY-MM-DD HH:mm:ss"
+              disabled={!adminApiEnabled}
+              title={!adminApiEnabled ? "Requires --web.enable-admin-api flag" : ""}
               withSeconds
               value={
                 endTime !== null
@@ -319,7 +334,8 @@ export default function TSDBStatusPage() {
               leftSection={<IconTrash size={16} />}
               onClick={handleDelete}
               loading={deleting}
-              disabled={!matchers.trim()}
+              disabled={!matchers.trim() || !adminApiEnabled}
+              title={!adminApiEnabled ? "Requires --web.enable-admin-api flag" : ""}
             >
               Delete series
             </Button>
@@ -362,6 +378,8 @@ export default function TSDBStatusPage() {
               variant="outline"
               onClick={handleCleanTombstones}
               loading={cleaning}
+              disabled={!adminApiEnabled}
+              title={!adminApiEnabled ? "Requires --web.enable-admin-api flag" : ""}
             >
               Clean tombstones
             </Button>


### PR DESCRIPTION
ui: render delete series form on tsdb status page if `--web.enable-admin-api` flag is enabled


#### Which issue(s) does the PR fix:

Fixes #19019 

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->

```release-notes
[BUGFIX] UI: render delete series form on tsdb status page if `--web.enable-admin-api` flag is enabled
```


#### How to Verify

Flag is enabled:

```bash
$ ./prometheus --config.file=documentation/examples/prometheus.yml --web.enable-admin-api
$ cd web/ui
$ npm start
// go to tsdb status page
```

Flag is disabled:

```bash
$ ./prometheus --config.file=documentation/examples/prometheus.yml
$ cd web/ui
$ npm start
// go to tsdb status page
```

