### PR TITLE
BUGFIX: Allow DNS changes for FQDN scrape targets to be picked up

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptrace"
+	"net/netip"
 	"reflect"
 	"slices"
 	"strconv"
@@ -741,6 +742,9 @@ func (s *targetScraper) scrape(ctx context.Context) (*http.Response, error) {
 		req.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", strconv.FormatFloat(s.timeout.Seconds(), 'f', -1, 64))
 
 		s.req = req
+	if _, err := netip.ParseAddr(s.req.URL.Hostname()); err != nil {
+		s.req.Close = true
+	}
 	}
 	ctx, span := otel.Tracer("").Start(ctx, "Scrape", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -742,9 +742,9 @@ func (s *targetScraper) scrape(ctx context.Context) (*http.Response, error) {
 		req.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", strconv.FormatFloat(s.timeout.Seconds(), 'f', -1, 64))
 
 		s.req = req
-	if _, err := netip.ParseAddr(s.req.URL.Hostname()); err != nil {
-		s.req.Close = true
-	}
+		if _, err := netip.ParseAddr(s.req.URL.Hostname()); err != nil {
+			s.req.Close = true
+		}
 	}
 	ctx, span := otel.Tracer("").Start(ctx, "Scrape", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()


### PR DESCRIPTION
## What changed

For scrape targets whose request URL host is not an IP literal, Prometheus now marks the scrape request as non-reusable (`req.Close = true`). This prevents the Go HTTP transport from keeping a long-lived connection to a stale address behind a hostname.

IP literal targets keep the existing keep-alive behavior unchanged.

## Why

When a target is discovered as an FQDN and the address behind that FQDN changes, the Go HTTP transport may keep using an existing idle/persistent connection. In that case DNS is not consulted again until a new connection is opened, so the target can remain DOWN even though the hostname now resolves to a healthy backend.

## Notes

- For HTTP/1.1 this is expressed as `Connection: close`.
- For HTTP/2, Go's transport treats `req.Close` as a single-use connection and does not send a forbidden connection-specific header.
- IPv4, IPv6, and IPv6 zone literal hosts are treated as IP literals and keep connection reuse.
- `localhost` is treated as a hostname (not IP literal), so it will also get fresh connections.
- When a proxy is configured, DNS/address refresh semantics may depend on the proxy. This change primarily targets direct scrape connections.
- Multi-IP hostname selection remains resolver/dialer dependent.

```release-notes
[BUGFIX] Allow DNS changes for FQDN scrape targets to be picked up by avoiding persistent connection reuse for non-IP target addresses.
```

Fixes https://github.com/prometheus/prometheus/issues/18387