### PR TITLE
ovhcloud_sd(dedicated_server): add fields monitoring and iam_display_name

### DIFF
--- a/discovery/ovhcloud/dedicated_server.go
+++ b/discovery/ovhcloud/dedicated_server.go
@@ -42,6 +42,7 @@ type dedicatedServer struct {
 	CommercialRange string `json:"commercialRange"`
 	LinkSpeed       int    `json:"linkSpeed"`
 	Rack            string `json:"rack"`
+	Monitoring      bool   `json:"monitoring"`
 	NoIntervention  bool   `json:"noIntervention"`
 	Os              string `json:"os"`
 	SupportLevel    string `json:"supportLevel"`
@@ -49,6 +50,9 @@ type dedicatedServer struct {
 	Reverse         string `json:"reverse"`
 	Datacenter      string `json:"datacenter"`
 	Name            string `json:"name"`
+	Iam             struct {
+		DisplayName string `json:"displayName"`
+	} `json:"iam"`
 }
 
 type dedicatedServerDiscovery struct {
@@ -142,6 +146,7 @@ func (d *dedicatedServerDiscovery) refresh(context.Context) ([]*targetgroup.Grou
 			dedicatedServerLabelPrefix + "commercial_range": model.LabelValue(server.CommercialRange),
 			dedicatedServerLabelPrefix + "link_speed":       model.LabelValue(strconv.Itoa(server.LinkSpeed)),
 			dedicatedServerLabelPrefix + "rack":             model.LabelValue(server.Rack),
+			dedicatedServerLabelPrefix + "monitoring":       model.LabelValue(strconv.FormatBool(server.Monitoring)),
 			dedicatedServerLabelPrefix + "no_intervention":  model.LabelValue(strconv.FormatBool(server.NoIntervention)),
 			dedicatedServerLabelPrefix + "os":               model.LabelValue(server.Os),
 			dedicatedServerLabelPrefix + "support_level":    model.LabelValue(server.SupportLevel),
@@ -151,6 +156,7 @@ func (d *dedicatedServerDiscovery) refresh(context.Context) ([]*targetgroup.Grou
 			dedicatedServerLabelPrefix + "name":             model.LabelValue(server.Name),
 			dedicatedServerLabelPrefix + "ipv4":             model.LabelValue(ipv4),
 			dedicatedServerLabelPrefix + "ipv6":             model.LabelValue(ipv6),
+			dedicatedServerLabelPrefix + "iam_display_name": model.LabelValue(server.Iam.DisplayName),
 		}
 		targets = append(targets, labels)
 	}

--- a/discovery/ovhcloud/dedicated_server_test.go
+++ b/discovery/ovhcloud/dedicated_server_test.go
@@ -62,6 +62,8 @@ consumer_key: %s`, mock.URL, ovhcloudApplicationKeyTest, ovhcloudApplicationSecr
 			"__meta_ovhcloud_dedicated_server_ipv6":             "",
 			"__meta_ovhcloud_dedicated_server_link_speed":       "123",
 			"__meta_ovhcloud_dedicated_server_name":             "abcde",
+			"__meta_ovhcloud_dedicated_server_iam_display_name": "abcde",
+			"__meta_ovhcloud_dedicated_server_monitoring":       "true",
 			"__meta_ovhcloud_dedicated_server_no_intervention":  "false",
 			"__meta_ovhcloud_dedicated_server_os":               "debian11_64",
 			"__meta_ovhcloud_dedicated_server_rack":             "TESTRACK",

--- a/discovery/ovhcloud/testdata/dedicated_server/dedicated_servers_details.json
+++ b/discovery/ovhcloud/testdata/dedicated_server/dedicated_servers_details.json
@@ -16,5 +16,10 @@
   "datacenter": "gra3",
   "os": "debian11_64",
   "reverse": "abcde-rev",
-  "serverId": 1234
+  "serverId": 1234,
+  "iam": {
+    "displayName": "abcde",
+    "state": "test",
+    "urn": "urn:v1:eu:resource:dedicatedServer:abcde"
+  }
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2065,6 +2065,8 @@ For OVHcloud's [public cloud instances](https://www.ovhcloud.com/en/public-cloud
 * `__meta_ovhcloud_dedicated_server_ipv6`: the IPv6 of the server
 * `__meta_ovhcloud_dedicated_server_link_speed`: the link speed of the server
 * `__meta_ovhcloud_dedicated_server_name`: the name of the server
+* `__meta_ovhcloud_dedicated_server_iam_display_name`: the IAM display name of the server
+* `__meta_ovhcloud_dedicated_server_monitoring`: whether monitoring is enabled for the server
 * `__meta_ovhcloud_dedicated_server_no_intervention`: whether datacenter intervention is disabled for the server
 * `__meta_ovhcloud_dedicated_server_os`: the operating system of the server
 * `__meta_ovhcloud_dedicated_server_rack`: the rack of the server


### PR DESCRIPTION
#### Description

Enrich `ovhcloud_sd` with missing fields:
- `__meta_ovhcloud_dedicated_server_monitoring`: whether monitoring is enabled for the server
- `__meta_ovhcloud_dedicated_server_iam_display_name`: the IAM display name of the server

#### Which issue(s) does the PR fix:

Fixes #18782

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] OVH SD: Add dedicated_server fields `monitoring` and `iam_display_name`
```
