### PR TITLE
fix(discovery/oci): clear targets of vanished compartments

### DIFF
--- a/discovery/oci/oci.go
+++ b/discovery/oci/oci.go
@@ -233,6 +233,14 @@ type Discovery struct {
 	tenancy             string
 	port                int
 	logger              *slog.Logger
+	// lastSources holds the live target-group sources of the previous refresh,
+	// i.e. the compartments returned by compartment listing (excluding the
+	// empty groups re-emitted for vanished sources). The discovery manager only
+	// drops a source when an empty group is sent for it, so when a compartment
+	// is no longer returned by compartment listing (deleted, or filtered out)
+	// its source must be re-emitted empty to clear its stale targets.
+	// refresh is called serially by refresh.Discovery, so no lock is needed.
+	lastSources map[string]struct{}
 }
 
 // NewDiscovery returns a new Discovery which periodically refreshes its targets.
@@ -573,6 +581,22 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 		tgs = append(tgs, tg)
 	}
+
+	// Re-emit an empty group for every source seen last refresh that is no
+	// longer present, so the discovery manager drops the stale targets of
+	// compartments that are no longer returned by compartment listing. A
+	// compartment whose instance listing fails is not cleared here: refresh
+	// returns early on that error, keeping its last known good targets.
+	current := make(map[string]struct{}, len(tgs))
+	for _, tg := range tgs {
+		current[tg.Source] = struct{}{}
+	}
+	for src := range d.lastSources {
+		if _, ok := current[src]; !ok {
+			tgs = append(tgs, &targetgroup.Group{Source: src})
+		}
+	}
+	d.lastSources = current
 
 	return tgs, nil
 }

--- a/discovery/oci/oci_test.go
+++ b/discovery/oci/oci_test.go
@@ -403,6 +403,159 @@ func TestRefresh_MultipleCompartments(t *testing.T) {
 	require.Empty(t, tgs[2].Targets)
 }
 
+func TestRefresh_DisappearingCompartmentCleared(t *testing.T) {
+	// The discovery manager only drops a source when an empty group is sent for
+	// it. When a compartment disappears between refreshes (deleted, or no longer
+	// listable) the SD must re-emit its source as an empty group so the stale
+	// targets are cleared, but only once.
+	comp1 := "ocid1.compartment.oc1..c001"
+	comp2 := "ocid1.compartment.oc1..c002"
+	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.1", "")
+
+	compartments := []string{comp1, comp2}
+
+	d := baseDiscovery()
+	d.listCompartments = func(_ context.Context) ([]string, error) { return compartments, nil }
+	d.listInstances = func(_ context.Context, compartmentID string) ([]core.Instance, error) {
+		inst := makeInstance(func(i *core.Instance) {
+			i.Id = strPtr("ocid1.instance.oc1.." + compartmentID)
+			i.CompartmentId = strPtr(compartmentID)
+		})
+		return []core.Instance{inst}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, instanceID string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{makeAttachment(instanceID, stringVal(vnic.Id))}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
+
+	// First refresh: both compartments yield a target.
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 2)
+
+	// comp2 disappears.
+	compartments = []string{comp1}
+
+	tgs, err = d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 2, "comp1 plus an empty group re-emitted for the vanished comp2")
+
+	targetsBySource := map[string]int{}
+	for _, tg := range tgs {
+		targetsBySource[tg.Source] = len(tg.Targets)
+	}
+	require.Equal(t, 1, targetsBySource["OCI_"+comp1])
+	require.Contains(t, targetsBySource, "OCI_"+comp2, "vanished compartment must be re-emitted")
+	require.Zero(t, targetsBySource["OCI_"+comp2], "vanished compartment must be re-emitted empty to clear its stale targets")
+
+	// Third refresh: comp2 was already cleared and must not be re-emitted again.
+	tgs, err = d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1, "already-cleared compartment must not be re-emitted")
+	require.Equal(t, "OCI_"+comp1, tgs[0].Source)
+}
+
+func TestRefresh_ErrorPathPreservesLastSources(t *testing.T) {
+	// A failed refresh must not mutate lastSources: it returns early and the
+	// refresh framework keeps the last known good targets. A compartment that
+	// vanishes during the outage must still be cleared on the next successful
+	// refresh, proving lastSources survived the error.
+	comp1 := "ocid1.compartment.oc1..c001"
+	comp2 := "ocid1.compartment.oc1..c002"
+	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.1", "")
+
+	compartments := []string{comp1, comp2}
+	var failInstances bool
+
+	d := baseDiscovery()
+	d.listCompartments = func(_ context.Context) ([]string, error) { return compartments, nil }
+	d.listInstances = func(_ context.Context, compartmentID string) ([]core.Instance, error) {
+		if failInstances {
+			return nil, errors.New("OCI API unavailable")
+		}
+		inst := makeInstance(func(i *core.Instance) {
+			i.Id = strPtr("ocid1.instance.oc1.." + compartmentID)
+			i.CompartmentId = strPtr(compartmentID)
+		})
+		return []core.Instance{inst}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, instanceID string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{makeAttachment(instanceID, stringVal(vnic.Id))}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
+
+	// First refresh: both compartments yield a target.
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 2)
+
+	// A transient API failure aborts the whole refresh.
+	failInstances = true
+	_, err = d.refresh(context.Background())
+	require.Error(t, err)
+
+	// The API recovers but comp2 has vanished in the meantime. comp2 must still
+	// be re-emitted empty, which is only possible if lastSources kept it across
+	// the failed refresh.
+	failInstances = false
+	compartments = []string{comp1}
+
+	tgs, err = d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 2, "comp1 plus an empty group re-emitted for the vanished comp2")
+
+	targetsBySource := map[string]int{}
+	for _, tg := range tgs {
+		targetsBySource[tg.Source] = len(tg.Targets)
+	}
+	require.Equal(t, 1, targetsBySource["OCI_"+comp1])
+	require.Contains(t, targetsBySource, "OCI_"+comp2, "vanished compartment must be re-emitted")
+	require.Zero(t, targetsBySource["OCI_"+comp2], "vanished compartment must be re-emitted empty")
+}
+
+func TestRefresh_AllCompartmentsVanish(t *testing.T) {
+	// When every compartment vanishes at once, each previously emitted source
+	// must be re-emitted as an empty group so all stale targets are cleared.
+	comp1 := "ocid1.compartment.oc1..c001"
+	comp2 := "ocid1.compartment.oc1..c002"
+	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.1", "")
+
+	compartments := []string{comp1, comp2}
+
+	d := baseDiscovery()
+	d.listCompartments = func(_ context.Context) ([]string, error) { return compartments, nil }
+	d.listInstances = func(_ context.Context, compartmentID string) ([]core.Instance, error) {
+		inst := makeInstance(func(i *core.Instance) {
+			i.Id = strPtr("ocid1.instance.oc1.." + compartmentID)
+			i.CompartmentId = strPtr(compartmentID)
+		})
+		return []core.Instance{inst}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, instanceID string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{makeAttachment(instanceID, stringVal(vnic.Id))}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
+
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 2)
+
+	// Every compartment disappears.
+	compartments = nil
+
+	tgs, err = d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 2, "an empty group must be re-emitted for each vanished compartment")
+	for _, tg := range tgs {
+		require.Empty(t, tg.Targets, "vanished compartment must be re-emitted empty")
+	}
+
+	// Once cleared, nothing is re-emitted again.
+	tgs, err = d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, tgs, "already-cleared compartments must not be re-emitted")
+}
+
 func TestRefresh_CompartmentListError_Propagates(t *testing.T) {
 	sentinel := errors.New("identity API unavailable")
 	d := baseDiscovery()


### PR DESCRIPTION
The discovery manager only drops a target group's source when an empty group is sent for it. With compartment auto-discovery the set of sources is dynamic, so a compartment that is deleted or no longer returned by compartment listing would leave its last targets behind until Prometheus restarts.

Track the sources emitted by the previous refresh and re-emit an empty group for any that are no longer present, clearing their stale targets. A compartment whose instance listing fails is not cleared: refresh returns early on that error, keeping its last known good targets.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
(part of new OCI SD)