### PR TITLE
fix(discovery/oci): clear targets of vanished compartments

### DIFF
--- a/discovery/oci/oci.go
+++ b/discovery/oci/oci.go
@@ -533,16 +533,16 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 		return nil, fmt.Errorf("oci_sd: failed to list compartments: %w", err)
 	}
 
-	var tgs []*targetgroup.Group
+	// Merge all compartments into a single target group so the manager
+	// replaces the whole target set every refresh.
+	tg := &targetgroup.Group{Source: "OCI"}
 
 	for _, compartmentID := range compartments {
-		tg := &targetgroup.Group{Source: "OCI_" + compartmentID}
-
 		instances, err := d.listInstances(ctx, compartmentID)
 		if err != nil {
-			// Return the error rather than emitting an empty group: the
-			// refresh framework will keep the last known good targets for
-			// this source, avoiding a flap on a transient OCI API failure.
+			// Return the error rather than emitting a partial group, so the
+			// refresh framework keeps the last known good targets on a
+			// transient OCI API failure.
 			return nil, fmt.Errorf("listing OCI instances in compartment %s: %w", compartmentID, err)
 		}
 
@@ -570,11 +570,9 @@ func (d *Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 
 			tg.Targets = append(tg.Targets, instanceLabels(inst, vnics, d.tenancy, d.port))
 		}
-
-		tgs = append(tgs, tg)
 	}
 
-	return tgs, nil
+	return []*targetgroup.Group{tg}, nil
 }
 
 // vnicInfo is the subset of a single OCI VNIC that the SD exposes through

--- a/discovery/oci/oci_test.go
+++ b/discovery/oci/oci_test.go
@@ -289,7 +289,7 @@ func TestRefresh_SingleInstance(t *testing.T) {
 	tgs, err := d.refresh(context.Background())
 	require.NoError(t, err)
 	require.Len(t, tgs, 1)
-	require.Equal(t, "OCI_"+testCompartment, tgs[0].Source)
+	require.Equal(t, "OCI", tgs[0].Source)
 	require.Len(t, tgs[0].Targets, 1)
 
 	labels := tgs[0].Targets[0]
@@ -393,14 +393,69 @@ func TestRefresh_MultipleCompartments(t *testing.T) {
 
 	tgs, err := d.refresh(context.Background())
 	require.NoError(t, err)
-	// One group per compartment, including the empty one.
-	require.Len(t, tgs, 3)
-	require.Equal(t, "OCI_"+comp1, tgs[0].Source)
+	// All compartments are merged into a single group; the empty comp3
+	// contributes no targets.
+	require.Len(t, tgs, 1)
+	require.Equal(t, "OCI", tgs[0].Source)
+	require.Len(t, tgs[0].Targets, 2)
+
+	compartments := map[model.LabelValue]struct{}{}
+	for _, target := range tgs[0].Targets {
+		compartments[target[ociLabelCompartmentID]] = struct{}{}
+	}
+	require.Equal(t, map[model.LabelValue]struct{}{
+		model.LabelValue(comp1): {},
+		model.LabelValue(comp2): {},
+	}, compartments)
+}
+
+func TestRefresh_DisappearingCompartmentCleared(t *testing.T) {
+	comp1 := "ocid1.compartment.oc1..c001"
+	comp2 := "ocid1.compartment.oc1..c002"
+	vnic := makeVnic("ocid1.vnic.oc1..v001", "10.0.0.1", "")
+
+	compartments := []string{comp1, comp2}
+
+	d := baseDiscovery()
+	d.listCompartments = func(_ context.Context) ([]string, error) { return compartments, nil }
+	d.listInstances = func(_ context.Context, compartmentID string) ([]core.Instance, error) {
+		inst := makeInstance(func(i *core.Instance) {
+			i.Id = strPtr("ocid1.instance.oc1.." + compartmentID)
+			i.CompartmentId = strPtr(compartmentID)
+		})
+		return []core.Instance{inst}, nil
+	}
+	d.listVnicAttachments = func(_ context.Context, _, instanceID string) ([]core.VnicAttachment, error) {
+		return []core.VnicAttachment{makeAttachment(instanceID, stringVal(vnic.Id))}, nil
+	}
+	d.getVnic = func(_ context.Context, _ string) (*core.Vnic, error) { return vnic, nil }
+
+	// First refresh: both compartments yield a target in the single group.
+	tgs, err := d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Equal(t, "OCI", tgs[0].Source)
+	require.Len(t, tgs[0].Targets, 2)
+
+	// comp2 disappears: only comp1's target remains, comp2's is gone.
+	compartments = []string{comp1}
+
+	tgs, err = d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Equal(t, "OCI", tgs[0].Source)
 	require.Len(t, tgs[0].Targets, 1)
-	require.Equal(t, "OCI_"+comp2, tgs[1].Source)
-	require.Len(t, tgs[1].Targets, 1)
-	require.Equal(t, "OCI_"+comp3, tgs[2].Source)
-	require.Empty(t, tgs[2].Targets)
+	require.Equal(t, model.LabelValue(comp1), tgs[0].Targets[0][ociLabelCompartmentID])
+
+	// Every compartment disappears: the group is emitted empty so the manager
+	// clears the remaining targets.
+	compartments = nil
+
+	tgs, err = d.refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Equal(t, "OCI", tgs[0].Source)
+	require.Empty(t, tgs[0].Targets)
 }
 
 func TestRefresh_CompartmentListError_Propagates(t *testing.T) {


### PR DESCRIPTION
The SD emitted one target group per compartment, keyed by compartment OCID. The discovery manager only drops a target group's source when an empty group is sent for it, so with compartment auto-discovery a compartment that was deleted or is no longer returned by compartment listing left its last targets behind until Prometheus restarted.

Merge all compartments into a single target group instead. Emitting one static source per refresh lets the manager replace the whole target set every cycle, so vanished instances simply disappear with no per-compartment bookkeeping. The owning compartment stays available on each target via the __meta_oci_compartment_id label.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```

(part of new OCI SD)