### PR TITLE
tsdb: add EnabledFloatChunkEncodings to gate selectable float encodings

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -282,6 +282,7 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 				logger.Info("Experimental start timestamp zero ingestion enabled. OpenMetrics 1.0 parsing will parse <metric>_created metrics as ST instead of normal sample. Changed default scrape_protocols to prefer PrometheusProto format.", "global.scrape_protocols", fmt.Sprintf("%v", config.DefaultGlobalConfig.ScrapeProtocols))
 			case "xor2-encoding":
 				c.tsdb.FloatChunkEncoding = chunkenc.EncXOR2
+				c.tsdb.EnabledFloatChunkEncodings = append(c.tsdb.EnabledFloatChunkEncodings, chunkenc.EncXOR2)
 				logger.Info("Experimental XOR2 chunk encoding enabled.")
 			case "st-synthesis":
 				// TODO(ridwanmsharif): Move this to scrape configuration once stable.
@@ -396,7 +397,8 @@ func main() {
 		},
 		tsdb: tsdbOptions{
 			// Default to XOR encoding; xor2-encoding feature flag overrides this to EncXOR2.
-			FloatChunkEncoding: chunkenc.EncXOR,
+			FloatChunkEncoding:         chunkenc.EncXOR,
+			EnabledFloatChunkEncodings: []chunkenc.Encoding{chunkenc.EncXOR},
 		},
 	}
 
@@ -2098,6 +2100,7 @@ type tsdbOptions struct {
 	StaleSeriesCompactionThreshold float64
 	EnableFastStartup              bool
 	FloatChunkEncoding             chunkenc.Encoding
+	EnabledFloatChunkEncodings     []chunkenc.Encoding
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -2130,6 +2133,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		StaleSeriesCompactionThreshold: opts.StaleSeriesCompactionThreshold,
 		EnableFastStartup:              opts.EnableFastStartup,
 		FloatChunkEncoding:             opts.FloatChunkEncoding,
+		EnabledFloatChunkEncodings:     opts.EnabledFloatChunkEncodings,
 	}
 }
 

--- a/cmd/promtool/tsdb.go
+++ b/cmd/promtool/tsdb.go
@@ -89,8 +89,10 @@ func benchmarkWrite(outPath, samplesFile string, numMetrics, numScrapes int) err
 	dir := filepath.Join(b.outPath, "storage")
 
 	st, err := tsdb.Open(dir, b.logger, nil, &tsdb.Options{
-		RetentionDuration: int64(15 * 24 * time.Hour / time.Millisecond),
-		MinBlockDuration:  int64(2 * time.Hour / time.Millisecond),
+		RetentionDuration:          int64(15 * 24 * time.Hour / time.Millisecond),
+		MinBlockDuration:           int64(2 * time.Hour / time.Millisecond),
+		FloatChunkEncoding:         chunkenc.EncXOR,
+		EnabledFloatChunkEncodings: []chunkenc.Encoding{chunkenc.EncXOR},
 	}, tsdb.NewDBStats())
 	if err != nil {
 		return err

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -163,6 +163,7 @@ func RunBuiltinTests(t TBRun, engine promql.QueryEngine) {
 		return teststorage.New(t, func(opt *tsdb.Options) {
 			opt.EnableSTStorage = true
 			opt.FloatChunkEncoding = chunkenc.EncXOR2
+			opt.EnabledFloatChunkEncodings = []chunkenc.Encoding{chunkenc.EncXOR2}
 		})
 	})
 }

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -92,6 +92,7 @@ func DefaultOptions() *Options {
 		EnableSharding:              false,
 		EnableDelayedCompaction:     false,
 		FloatChunkEncoding:          chunkenc.EncXOR,
+		EnabledFloatChunkEncodings:  []chunkenc.Encoding{chunkenc.EncXOR},
 		CompactionDelayMaxPercent:   DefaultCompactionDelayMaxPercent,
 		CompactionDelay:             time.Duration(0),
 		PostingsDecoderFactory:      DefaultPostingsDecoderFactory,
@@ -258,13 +259,15 @@ type Options struct {
 	// BlockReloadInterval is the interval at which blocks are reloaded.
 	BlockReloadInterval time.Duration
 
-	// FloatChunkEncoding is the encoding used for new float chunks when
-	// chunk_encoding.floats is absent from the configuration file.
-	// Defaults to EncXOR. Set to EncXOR2 to enable XOR2 encoding.
-	// Always use DefaultOptions() rather than a bare Options literal; the zero value
-	// of this field is EncNone, not EncXOR. This field is independent of EnableSTStorage:
-	// st-storage does not automatically select EncXOR2.
+	// FloatChunkEncoding is the encoding the head emits at open, until ApplyConfig
+	// selects one from chunk_encoding.floats. Defaults to EncXOR (the zero value
+	// EncNone is treated as EncXOR); st-storage seeds it to EncXOR2.
 	FloatChunkEncoding chunkenc.Encoding
+
+	// EnabledFloatChunkEncodings is the set of encodings chunk_encoding.floats may
+	// select. EncXOR is auto-added unless st-storage is enabled; EncXOR2 must be
+	// listed (the xor2-encoding flag adds it). Must contain FloatChunkEncoding.
+	EnabledFloatChunkEncodings []chunkenc.Encoding
 
 	// FeatureRegistry is used to register TSDB features.
 	FeatureRegistry features.Collector
@@ -884,7 +887,7 @@ func Open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, st
 		opts.FeatureRegistry.Set(features.TSDB, "use_uncached_io", opts.UseUncachedIO)
 		opts.FeatureRegistry.Enable(features.TSDB, "native_histograms")
 		opts.FeatureRegistry.Set(features.TSDB, "st_storage", opts.EnableSTStorage)
-		opts.FeatureRegistry.Set(features.TSDB, "xor2_encoding", opts.FloatChunkEncoding == chunkenc.EncXOR2)
+		opts.FeatureRegistry.Set(features.TSDB, "xor2_encoding", slices.Contains(opts.EnabledFloatChunkEncodings, chunkenc.EncXOR2))
 	}
 
 	return open(dir, l, r, opts, rngs, stats)
@@ -900,8 +903,24 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64, error) {
 	if opts.FloatChunkEncoding != chunkenc.EncXOR && opts.FloatChunkEncoding != chunkenc.EncXOR2 {
 		return nil, nil, fmt.Errorf("unsupported float chunk encoding %q; valid values are %q and %q", strings.ToLower(opts.FloatChunkEncoding.String()), config.FloatChunkEncodingXOR, config.FloatChunkEncodingXOR2)
 	}
-	if opts.EnableSTStorage && opts.FloatChunkEncoding == chunkenc.EncXOR {
-		return nil, nil, fmt.Errorf("float chunk encoding %q is incompatible with start-timestamp storage; XOR chunks do not store start timestamps, use %q", config.FloatChunkEncodingXOR, config.FloatChunkEncodingXOR2)
+	for _, enc := range opts.EnabledFloatChunkEncodings {
+		if enc != chunkenc.EncXOR && enc != chunkenc.EncXOR2 {
+			return nil, nil, fmt.Errorf("unsupported enabled float chunk encoding %q; valid values are %q and %q", strings.ToLower(enc.String()), config.FloatChunkEncodingXOR, config.FloatChunkEncodingXOR2)
+		}
+	}
+	// When unspecified, only the active encoding is selectable.
+	if len(opts.EnabledFloatChunkEncodings) == 0 {
+		opts.EnabledFloatChunkEncodings = []chunkenc.Encoding{opts.FloatChunkEncoding}
+	}
+	if opts.EnableSTStorage {
+		// st-storage requires XOR2, which the xor2-encoding feature flag unlocks.
+		if !slices.Contains(opts.EnabledFloatChunkEncodings, chunkenc.EncXOR2) {
+			return nil, nil, fmt.Errorf("start-timestamp storage requires the xor2-encoding feature flag; XOR chunks do not store start timestamps, use %q", config.FloatChunkEncodingXOR2)
+		}
+		opts.FloatChunkEncoding = chunkenc.EncXOR2
+	}
+	if !slices.Contains(opts.EnabledFloatChunkEncodings, opts.FloatChunkEncoding) {
+		return nil, nil, fmt.Errorf("active float chunk encoding %q is not in the set of enabled encodings", strings.ToLower(opts.FloatChunkEncoding.String()))
 	}
 	if opts.StripeSize <= 0 {
 		opts.StripeSize = DefaultStripeSize
@@ -1301,14 +1320,21 @@ func (db *DB) AppenderV2(ctx context.Context) storage.AppenderV2 {
 func (db *DB) ApplyConfig(conf *config.Config) error {
 	oooTimeWindow := int64(0)
 	if conf.StorageConfig.TSDBConfig != nil {
-		// Validate encoding config before updating the head encoding so that
-		// an invalid encoding in the config does not change the active encoding.
-		if conf.StorageConfig.TSDBConfig.ChunkEncoding.Floats == config.FloatChunkEncodingXOR2 && db.opts.FloatChunkEncoding != chunkenc.EncXOR2 {
-			return errors.New("'storage.tsdb.chunk_encoding.floats: xor2' requires the xor2-encoding feature flag to be enabled at startup")
+		// Resolve and validate the encoding before mutating any state, defaulting
+		// to the startup encoding when chunk_encoding.floats is absent.
+		effectiveEncoding := db.opts.FloatChunkEncoding
+		switch conf.StorageConfig.TSDBConfig.ChunkEncoding.Floats {
+		case config.FloatChunkEncodingXOR:
+			effectiveEncoding = chunkenc.EncXOR
+		case config.FloatChunkEncodingXOR2:
+			effectiveEncoding = chunkenc.EncXOR2
 		}
 		// db.opts.EnableSTStorage is set once at startup and never mutated.
-		if conf.StorageConfig.TSDBConfig.ChunkEncoding.Floats == config.FloatChunkEncodingXOR && db.opts.EnableSTStorage {
-			return errors.New("'storage.tsdb.chunk_encoding.floats: xor' is incompatible with st-storage; XOR chunks do not store start timestamps")
+		if effectiveEncoding == chunkenc.EncXOR && db.opts.EnableSTStorage {
+			return errors.New("float chunk encoding \"xor\" is incompatible with st-storage; XOR chunks do not store start timestamps")
+		}
+		if !slices.Contains(db.opts.EnabledFloatChunkEncodings, effectiveEncoding) {
+			return fmt.Errorf("float chunk encoding %q is not enabled", strings.ToLower(effectiveEncoding.String()))
 		}
 		oooTimeWindow = conf.StorageConfig.TSDBConfig.OutOfOrderTimeWindow
 		db.opts.staleSeriesCompactionThreshold.Store(conf.StorageConfig.TSDBConfig.StaleSeriesCompactionThreshold)
@@ -1322,14 +1348,6 @@ func (db *DB) ApplyConfig(conf *config.Config) error {
 			db.opts.MaxPercentage = conf.StorageConfig.TSDBConfig.Retention.Percentage
 			db.metrics.maxPercentage.Set(db.opts.MaxPercentage)
 			db.retentionMtx.Unlock()
-		}
-		// Default to the startup encoding; overridden by an explicit value below.
-		effectiveEncoding := db.opts.FloatChunkEncoding
-		switch conf.StorageConfig.TSDBConfig.ChunkEncoding.Floats {
-		case config.FloatChunkEncodingXOR:
-			effectiveEncoding = chunkenc.EncXOR
-		case config.FloatChunkEncodingXOR2:
-			effectiveEncoding = chunkenc.EncXOR2
 		}
 		db.head.opts.FloatChunkEncoding.Store(uint32(effectiveEncoding))
 	} else {

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -7510,13 +7510,14 @@ func TestCompactHeadWithSTStorage_AppendV2(t *testing.T) {
 	t.Parallel()
 
 	opts := &Options{
-		RetentionDuration:  int64(time.Hour * 24 * 15 / time.Millisecond),
-		NoLockfile:         true,
-		MinBlockDuration:   int64(time.Hour * 2 / time.Millisecond),
-		MaxBlockDuration:   int64(time.Hour * 2 / time.Millisecond),
-		WALCompression:     compression.Snappy,
-		EnableSTStorage:    true,
-		FloatChunkEncoding: chunkenc.EncXOR2,
+		RetentionDuration:          int64(time.Hour * 24 * 15 / time.Millisecond),
+		NoLockfile:                 true,
+		MinBlockDuration:           int64(time.Hour * 2 / time.Millisecond),
+		MaxBlockDuration:           int64(time.Hour * 2 / time.Millisecond),
+		WALCompression:             compression.Snappy,
+		EnableSTStorage:            true,
+		FloatChunkEncoding:         chunkenc.EncXOR2,
+		EnabledFloatChunkEncodings: []chunkenc.Encoding{chunkenc.EncXOR2},
 	}
 	db := newTestDB(t, withOpts(opts))
 	ctx := context.Background()
@@ -7656,6 +7657,7 @@ func TestDBAppenderV2_STStorage_OutOfOrder(t *testing.T) {
 			opts.OutOfOrderTimeWindow = 300 * time.Minute.Milliseconds()
 			opts.EnableSTStorage = true
 			opts.FloatChunkEncoding = chunkenc.EncXOR2
+			opts.EnabledFloatChunkEncodings = []chunkenc.Encoding{chunkenc.EncXOR2}
 			db := newTestDB(t, withOpts(opts))
 			db.DisableCompactions()
 

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1813,22 +1813,27 @@ func TestDBApplyConfigChunkEncoding(t *testing.T) {
 		opts.FloatChunkEncoding = chunkenc.EncXOR
 		db := newTestDB(t, withOpts(opts))
 		require.ErrorContains(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR2)),
-			"'storage.tsdb.chunk_encoding.floats: xor2' requires the xor2-encoding feature flag")
+			`float chunk encoding "xor2" is not enabled`)
 	})
 
-	t.Run("explicit_xor_overrides_xor2_option", func(t *testing.T) {
+	// xor2Opts models a startup with the xor2-encoding feature flag: XOR2 is the
+	// active encoding and XOR2 is in the enabled set.
+	xor2Opts := func() *Options {
 		opts := DefaultOptions()
 		opts.FloatChunkEncoding = chunkenc.EncXOR2
-		db := newTestDB(t, withOpts(opts))
+		opts.EnabledFloatChunkEncodings = []chunkenc.Encoding{chunkenc.EncXOR, chunkenc.EncXOR2}
+		return opts
+	}
+
+	t.Run("explicit_xor_overrides_xor2_option", func(t *testing.T) {
+		db := newTestDB(t, withOpts(xor2Opts()))
 		require.NoError(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR)))
 		require.False(t, db.head.opts.UseXOR2FloatEncoding())
 		require.Equal(t, chunkenc.EncXOR2, db.opts.FloatChunkEncoding, "startup option must not be mutated")
 	})
 
 	t.Run("xor2_with_option_succeeds", func(t *testing.T) {
-		opts := DefaultOptions()
-		opts.FloatChunkEncoding = chunkenc.EncXOR2
-		db := newTestDB(t, withOpts(opts))
+		db := newTestDB(t, withOpts(xor2Opts()))
 		require.NoError(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR2)))
 		require.True(t, db.head.opts.UseXOR2FloatEncoding())
 	})
@@ -1838,6 +1843,7 @@ func TestDBApplyConfigChunkEncoding(t *testing.T) {
 			t.Run(enc.String(), func(t *testing.T) {
 				opts := DefaultOptions()
 				opts.FloatChunkEncoding = enc
+				opts.EnabledFloatChunkEncodings = []chunkenc.Encoding{enc}
 				db := newTestDB(t, withOpts(opts))
 				require.NoError(t, db.ApplyConfig(xorCfg("")))
 				require.Equal(t, enc == chunkenc.EncXOR2, db.head.opts.UseXOR2FloatEncoding())
@@ -1846,9 +1852,7 @@ func TestDBApplyConfigChunkEncoding(t *testing.T) {
 	})
 
 	t.Run("sequential_reload_reverts_to_startup_option", func(t *testing.T) {
-		opts := DefaultOptions()
-		opts.FloatChunkEncoding = chunkenc.EncXOR2
-		db := newTestDB(t, withOpts(opts))
+		db := newTestDB(t, withOpts(xor2Opts()))
 
 		require.NoError(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR)))
 		require.False(t, db.head.opts.UseXOR2FloatEncoding())
@@ -1858,9 +1862,7 @@ func TestDBApplyConfigChunkEncoding(t *testing.T) {
 	})
 
 	t.Run("nil_TSDBConfig_resets_to_startup_option", func(t *testing.T) {
-		opts := DefaultOptions()
-		opts.FloatChunkEncoding = chunkenc.EncXOR2
-		db := newTestDB(t, withOpts(opts))
+		db := newTestDB(t, withOpts(xor2Opts()))
 
 		require.NoError(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR)))
 		require.False(t, db.head.opts.UseXOR2FloatEncoding())
@@ -1870,8 +1872,7 @@ func TestDBApplyConfigChunkEncoding(t *testing.T) {
 	})
 
 	t.Run("xor_with_st_storage_returns_error", func(t *testing.T) {
-		opts := DefaultOptions()
-		opts.FloatChunkEncoding = chunkenc.EncXOR2
+		opts := xor2Opts()
 		opts.EnableSTStorage = true
 		db := newTestDB(t, withOpts(opts))
 		require.ErrorContains(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR)),
@@ -1914,14 +1915,15 @@ func TestValidateOptsSTStorageRequiresXOR2(t *testing.T) {
 	t.Parallel()
 	opts := DefaultOptions()
 	opts.EnableSTStorage = true
-	// Default encoding is EncXOR; combining it with EnableSTStorage must be rejected.
+	// st-storage requires XOR2 to be enabled; without it, startup must be rejected.
 	_, _, err := validateOpts(opts, nil)
-	require.ErrorContains(t, err, "is incompatible with start-timestamp storage")
+	require.ErrorContains(t, err, "requires the xor2-encoding feature flag")
 
-	// EncXOR2 + st-storage must be accepted.
-	opts.FloatChunkEncoding = chunkenc.EncXOR2
-	_, _, err = validateOpts(opts, nil)
+	// With XOR2 enabled, st-storage is accepted and seeds the active encoding.
+	opts.EnabledFloatChunkEncodings = []chunkenc.Encoding{chunkenc.EncXOR2}
+	got, _, err := validateOpts(opts, nil)
 	require.NoError(t, err)
+	require.Equal(t, chunkenc.EncXOR2, got.FloatChunkEncoding, "st-storage must seed the active encoding to XOR2")
 }
 
 func TestNotMatcherSelectsLabelsUnsetSeries(t *testing.T) {

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3992,6 +3992,7 @@ func testChunkQuerierOverlappingInOrderAndOOOChunks(t *testing.T, valType chunke
 	opts.EnableSTStorage = storeST
 	if storeST {
 		opts.FloatChunkEncoding = chunkenc.EncXOR2
+		opts.EnabledFloatChunkEncodings = []chunkenc.Encoding{chunkenc.EncXOR2}
 	}
 	db := newTestDB(t, withOpts(opts))
 	db.DisableCompactions()


### PR DESCRIPTION
Introduce an explicit set of float chunk encodings that chunk_encoding.floats may select, instead of inferring it from the single active FloatChunkEncoding. EncXOR is enabled by default and the xor2-encoding feature flag adds EncXOR2. st-storage now requires XOR2 to be in the enabled set and seeds the active encoding to XOR2.

ApplyConfig resolves and validates the requested encoding against the enabled set before mutating any state, and the xor2_encoding feature is reported based on the enabled set.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes

```
