### PR TITLE
remote_write: skip updateMetrics on cancelled requests

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1697,7 +1697,9 @@ func populateTimeSeries(batch []timeSeries, pendingData []prompb.TimeSeries, sen
 func (s *shards) sendSamples(ctx context.Context, samples []prompb.TimeSeries, sampleCount, exemplarCount, histogramCount int, pBuf *proto.Buffer, buf compression.EncodeBuffer, compr compression.Type) error {
 	begin := time.Now()
 	rs, err := s.sendSamplesWithBackoff(ctx, samples, sampleCount, exemplarCount, histogramCount, 0, pBuf, buf, compr)
-	s.updateMetrics(ctx, err, sampleCount, exemplarCount, histogramCount, 0, rs, time.Since(begin))
+	if !errors.Is(err, context.Canceled) {
+		s.updateMetrics(ctx, err, sampleCount, exemplarCount, histogramCount, 0, rs, time.Since(begin))
+	}
 	return err
 }
 
@@ -1706,7 +1708,9 @@ func (s *shards) sendSamples(ctx context.Context, samples []prompb.TimeSeries, s
 func (s *shards) sendV2Samples(ctx context.Context, samples []writev2.TimeSeries, labels []string, sampleCount, exemplarCount, histogramCount, metadataCount int, pBuf *[]byte, buf compression.EncodeBuffer, compr compression.Type) error {
 	begin := time.Now()
 	rs, err := s.sendV2SamplesWithBackoff(ctx, samples, labels, sampleCount, exemplarCount, histogramCount, metadataCount, pBuf, buf, compr)
-	s.updateMetrics(ctx, err, sampleCount, exemplarCount, histogramCount, metadataCount, rs, time.Since(begin))
+	if !errors.Is(err, context.Canceled) {
+		s.updateMetrics(ctx, err, sampleCount, exemplarCount, histogramCount, metadataCount, rs, time.Since(begin))
+	}
 	return err
 }
 

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -825,6 +825,62 @@ func TestDisableReshardOnRetry(t *testing.T) {
 	}, time.Minute, retryAfter, "shouldReshard should have been re-enabled")
 }
 
+// TestLastSendTimestampNotUpdatedOnContextCancellation verifies that cancelled
+// sends do not count as successful send activity.
+func TestLastSendTimestampNotUpdatedOnContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	// staleTimestamp is older than shardUpdateDuration.
+	staleTimestamp := time.Now().Add(-2 * shardUpdateDuration).Unix()
+
+	sendAttempted := make(chan struct{})
+	var once sync.Once
+	client := &MockWriteClient{
+		StoreFunc: func(ctx context.Context, _ []byte, _ int) (WriteResponseStats, error) {
+			once.Do(func() { close(sendAttempted) })
+			<-ctx.Done()
+			return WriteResponseStats{}, ctx.Err()
+		},
+		NameFunc:     func() string { return "mock" },
+		EndpointFunc: func() string { return "http://fake:9090/api/v1/write" },
+	}
+
+	recs := testwal.GenerateRecords(recCase{
+		Series:           1,
+		SamplesPerSeries: 1,
+	})
+
+	cfg := config.DefaultQueueConfig
+	cfg.MaxShards = 1
+	cfg.MaxSamplesPerSend = 1
+	mcfg := config.DefaultMetadataConfig
+
+	m := newTestQueueManager(
+		t, cfg, mcfg, time.Second, client, remoteapi.WriteV1MessageType,
+	)
+	m.StoreSeries(recs.Series, 0)
+	m.lastSendTimestamp.Store(staleTimestamp)
+	m.Start()
+
+	m.Append(recs.Samples)
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-sendAttempted:
+			return true
+		default:
+			return false
+		}
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Stop cancels the shard context while Store is blocked.
+	m.Stop()
+
+	currentLastSend := m.lastSendTimestamp.Load()
+	require.Equal(t, staleTimestamp, currentLastSend)
+	require.False(t, m.shouldReshard(m.numShards+1))
+}
+
 func createProtoTimeseriesWithOld(numSamples, baseTs int64) []prompb.TimeSeries {
 	samples := make([]prompb.TimeSeries, numSamples)
 	// use a fixed rand source so tests are consistent


### PR DESCRIPTION
Do not update send metrics when a remote write request is cancelled.
Cancelled requests are not successful, so updating lastSendTimestamp can allow resharding based on bogus send state.
This seems to happen during re-sharding since it triggers shutdown of some shards, which causes context to be cancelled, and that is handled as if succeed, at least for part of the logic (lastSendTimestamp). If I understand the logic correctly this causes some samples to be silently dropped during re-sharding, because queue manager thinks they've been successfully sent (because of the updateMetrics() call), when they should have been cancelled and re-queued without calling updateMetrics().

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] remote_write: correctly handle cancelled requests in remote_write queue logic
```
