### PR TITLE
tsdb: add Head.SetFloatChunkEncoding setter

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1126,6 +1126,11 @@ func (h *Head) SetOutOfOrderTimeWindow(oooTimeWindow int64, wbl *wlog.WL) {
 	h.opts.OutOfOrderTimeWindow.Store(oooTimeWindow)
 }
 
+// SetFloatChunkEncoding updates the encoding applied to new float chunks.
+func (h *Head) SetFloatChunkEncoding(enc chunkenc.Encoding) {
+	h.opts.FloatChunkEncoding.Store(uint32(enc))
+}
+
 // PostingsCardinalityStats returns highest cardinality stats by label and value names.
 func (h *Head) PostingsCardinalityStats(statsByLabelName string, limit int) *index.PostingsStats {
 	cacheKey := statsByLabelName + ";" + strconv.Itoa(limit)


### PR DESCRIPTION
Allow updating the float chunk encoding for new chunks on a running Head without a restart. The encoding is stored as an atomic in HeadOptions, so this mirrors SetOutOfOrderTimeWindow and lets callers (e.g. multi-tenant setups switching a tenant between xor and xor2) change the encoding at runtime rather than only at startup or via ApplyConfig.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
