### PR TITLE
discovery/aws: defer region resolution from YAML parsing to SD init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [BUGFIX] Discovery/AWS: Defer region resolution in EC2, ECS, RDS, MSK, ElastiCache, and Lightsail service discovery configs from YAML unmarshaling to SD init time. `promtool check config` and other config-only operations no longer make network calls to the EC2 instance metadata service (IMDS) when the region is omitted, which is supported by the documented configuration. Region resolution errors now surface at the discovery's first refresh instead of failing config validation. #19037
+
 ## 3.13.0 / 2026-07-01
 
 - [SECURITY] UI: Bump `sanitize-html` to fix a cross-site scripting vulnerability (CVE-2026-44990). #18697

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -558,6 +558,11 @@ func TestExitCodes(t *testing.T) {
 			file: "prometheus-config.good.yml",
 		},
 		{
+			// Regression test for https://github.com/prometheus/prometheus/issues/6092:
+			// AWS SDs with empty region must parse without IMDS calls.
+			file: "prometheus-aws-sd-empty-region.good.yml",
+		},
+		{
 			file:     "prometheus-config.bad.yml",
 			exitCode: 1,
 		},

--- a/cmd/promtool/testdata/prometheus-aws-sd-empty-region.good.yml
+++ b/cmd/promtool/testdata/prometheus-aws-sd-empty-region.good.yml
@@ -1,0 +1,24 @@
+# Regression test for https://github.com/prometheus/prometheus/issues/6092.
+# Before the fix, the AWS SDs called IMDS during YAML parsing, so
+# `promtool check config` failed with a network error when the region
+# was omitted (which the docs say is valid).
+
+scrape_configs:
+  - job_name: 'ec2'
+    ec2_sd_configs:
+      - port: 9090
+  - job_name: 'ecs'
+    ecs_sd_configs:
+      - port: 9090
+  - job_name: 'rds'
+    rds_sd_configs:
+      - port: 9090
+  - job_name: 'msk'
+    msk_sd_configs:
+      - port: 9090
+  - job_name: 'elasticache'
+    elasticache_sd_configs:
+      - port: 9090
+  - job_name: 'lightsail'
+    lightsail_sd_configs:
+      - port: 9090

--- a/discovery/aws/aws.go
+++ b/discovery/aws/aws.go
@@ -104,6 +104,8 @@ type SDConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for SDConfig.
+// Region resolution is deferred to each concrete discovery's xxxClient
+// method; see loadRegion.
 func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	// Alias to avoid recursion
 	type plain SDConfig
@@ -113,12 +115,6 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 	*c = SDConfig(aux)
-
-	var err error
-	c.Region, err = loadRegion(context.Background(), c.Region)
-	if err != nil {
-		return fmt.Errorf("could not determine AWS region: %w", err)
-	}
 
 	switch c.Role {
 	case RoleEC2:
@@ -400,8 +396,17 @@ func (c *SDConfig) SetDirectory(dir string) {
 	}
 }
 
-// loadRegion finds the region in order: AWS config/env vars ->IMDS.
-func loadRegion(ctx context.Context, specifiedRegion string) (string, error) {
+// loadRegion finds the region in order: configured region -> AWS config/env vars -> IMDS.
+// Region resolution is intentionally deferred to SD init so config-only operations
+// (e.g. `promtool check config`) stay free of network I/O. See the UnmarshalYAML
+// docstrings in this package.
+func loadRegion(ctx context.Context, specifiedRegion string) (region string, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("could not determine AWS region: %w", err)
+		}
+	}()
+
 	if specifiedRegion != "" {
 		return specifiedRegion, nil
 	}
@@ -417,14 +422,14 @@ func loadRegion(ctx context.Context, specifiedRegion string) (string, error) {
 
 	// Fallback (may fail in non-AWS environments)
 	imdsClient := imds.NewFromConfig(cfg)
-	region, err := imdsClient.GetRegion(ctx, &imds.GetRegionInput{})
+	imdsRegion, err := imdsClient.GetRegion(ctx, &imds.GetRegionInput{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get region from IMDS: %w", err)
 	}
 
-	if region.Region == "" {
+	if imdsRegion.Region == "" {
 		return "", errors.New("region not found in AWS config or IMDS")
 	}
 
-	return region.Region, nil
+	return imdsRegion.Region, nil
 }

--- a/discovery/aws/aws_test.go
+++ b/discovery/aws/aws_test.go
@@ -512,6 +512,37 @@ region = ` + randomRegion + `
 	})
 }
 
+// Regression test for issue #6092: parsing an AWS SD config must not call
+// IMDS even when the region is omitted.
+func TestAWSSDConfigUnmarshalYAML_NoRegionResolution(t *testing.T) {
+	// Point IMDS at a black hole and wipe every other region source so any
+	// accidental loadRegion call fails fast instead of waiting on IMDS.
+	t.Setenv("AWS_EC2_METADATA_SERVICE_ENDPOINT", "http://127.0.0.1:1")
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_CONFIG_FILE", "")
+	t.Setenv("AWS_PROFILE", "")
+
+	yamls := map[string]string{
+		"ec2":         `region: ""`,
+		"ecs":         `region: ""`,
+		"rds":         `region: ""`,
+		"msk":         `region: ""`,
+		"elasticache": `region: ""`,
+		"lightsail":   `region: ""`,
+	}
+
+	for role, body := range yamls {
+		t.Run(role, func(t *testing.T) {
+			yamlStr := "role: " + role + "\n" + body + "\n"
+			cfg := SDConfig{}
+			err := yaml.Unmarshal([]byte(yamlStr), &cfg)
+			require.NoError(t, err, "config parsing must not make network calls")
+			require.Empty(t, cfg.Region, "region must remain empty after parse; resolution is deferred to SD init")
+		})
+	}
+}
+
 func TestSDConfigSetDirectory(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -117,18 +117,13 @@ func (c *EC2SDConfig) SetDirectory(dir string) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the EC2 Config.
+// Region resolution is deferred to ec2Client; see loadRegion.
 func (c *EC2SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultEC2SDConfig
 	type plain EC2SDConfig
 	err := unmarshal((*plain)(c))
 	if err != nil {
 		return err
-	}
-
-	// Check if the region is set, if not attempt to load it from the AWS SDK.
-	c.Region, err = loadRegion(context.Background(), c.Region)
-	if err != nil {
-		return fmt.Errorf("could not determine AWS region: %w", err)
 	}
 
 	for _, f := range c.Filters {
@@ -193,6 +188,10 @@ type EC2Discovery struct {
 	cfg    *EC2SDConfig
 	ec2    ec2Client
 
+	// region is the resolved region used for the AWS client and for the
+	// Source / __meta_ec2_region labels. Lazily populated by ec2Client.
+	region string
+
 	// azToAZID maps this account's availability zones to their underlying AZ
 	// ID, e.g. eu-west-2a -> euw2-az2. Refreshes are performed sequentially, so
 	// no locking is required.
@@ -237,9 +236,15 @@ func (d *EC2Discovery) ec2Client(ctx context.Context) (ec2Client, error) {
 		return nil, err
 	}
 
-	// Build the AWS config with the provided region.
+	// Resolve the region lazily. See EC2SDConfig.UnmarshalYAML.
+	d.region, err = loadRegion(ctx, d.cfg.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the AWS config with the resolved region.
 	configOptions := []func(*awsConfig.LoadOptions) error{
-		awsConfig.WithRegion(d.cfg.Region),
+		awsConfig.WithRegion(d.region),
 		awsConfig.WithHTTPClient(httpClient),
 	}
 
@@ -306,7 +311,7 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 	}
 
 	tg := &targetgroup.Group{
-		Source: d.cfg.Region,
+		Source: d.region,
 	}
 
 	var filters []ec2Types.Filter
@@ -350,7 +355,7 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 
 				labels := model.LabelSet{
 					ec2LabelInstanceID: model.LabelValue(*inst.InstanceId),
-					ec2LabelRegion:     model.LabelValue(d.cfg.Region),
+					ec2LabelRegion:     model.LabelValue(d.region),
 				}
 
 				if r.OwnerId != nil {

--- a/discovery/aws/ec2_test.go
+++ b/discovery/aws/ec2_test.go
@@ -516,6 +516,7 @@ func TestEC2DiscoveryRefresh(t *testing.T) {
 					Region:  client.ec2Data.region,
 					Filters: tt.filters,
 				},
+				region: client.ec2Data.region,
 			}
 
 			g, err := d.refresh(ctx)

--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -136,17 +136,13 @@ func (c *ECSSDConfig) SetDirectory(dir string) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the ECS Config.
+// Region resolution is deferred to initEcsClient; see loadRegion.
 func (c *ECSSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultECSSDConfig
 	type plain ECSSDConfig
 	err := unmarshal((*plain)(c))
 	if err != nil {
 		return err
-	}
-
-	c.Region, err = loadRegion(context.Background(), c.Region)
-	if err != nil {
-		return fmt.Errorf("could not determine AWS region: %w", err)
 	}
 
 	return c.HTTPClientConfig.Validate()
@@ -229,6 +225,10 @@ type ECSDiscovery struct {
 	cfg    *ECSSDConfig
 	ecs    ecsClient
 	ec2    ecsEC2Client
+
+	// region is the resolved region used for the AWS client and for the
+	// Source / __meta_ecs_region labels. Lazily populated by initEcsClient.
+	region string
 }
 
 // NewECSDiscovery returns a new ECSDiscovery which periodically refreshes its targets.
@@ -262,19 +262,21 @@ func (d *ECSDiscovery) initEcsClient(ctx context.Context) error {
 		return nil
 	}
 
-	if d.cfg.Region == "" {
-		return errors.New("region must be set for ECS service discovery")
-	}
-
 	// Build the HTTP client from the provided HTTPClientConfig.
 	client, err := config.NewClientFromConfig(d.cfg.HTTPClientConfig, "ecs_sd")
 	if err != nil {
 		return err
 	}
 
-	// Build the AWS config with the provided region.
+	// Resolve the region lazily. See ECSSDConfig.UnmarshalYAML.
+	d.region, err = loadRegion(ctx, d.cfg.Region)
+	if err != nil {
+		return err
+	}
+
+	// Build the AWS config with the resolved region.
 	var configOptions []func(*awsConfig.LoadOptions) error
-	configOptions = append(configOptions, awsConfig.WithRegion(d.cfg.Region))
+	configOptions = append(configOptions, awsConfig.WithRegion(d.region))
 	configOptions = append(configOptions, awsConfig.WithHTTPClient(client))
 
 	// Only set static credentials if both access key and secret key are provided
@@ -713,13 +715,13 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 	if len(clusters) == 0 {
 		return []*targetgroup.Group{
 			{
-				Source: d.cfg.Region,
+				Source: d.region,
 			},
 		}, nil
 	}
 
 	tg := &targetgroup.Group{
-		Source: d.cfg.Region,
+		Source: d.region,
 	}
 
 	// Fetch cluster details, service ARNs, and task ARNs in parallel
@@ -936,7 +938,7 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 						ecsLabelTaskARN:          model.LabelValue(*task.TaskArn),
 						ecsLabelTaskDefinition:   model.LabelValue(*task.TaskDefinitionArn),
 						ecsLabelIPAddress:        model.LabelValue(ipAddress),
-						ecsLabelRegion:           model.LabelValue(d.cfg.Region),
+						ecsLabelRegion:           model.LabelValue(d.region),
 						ecsLabelLaunchType:       model.LabelValue(task.LaunchType),
 						ecsLabelAvailabilityZone: model.LabelValue(*task.AvailabilityZone),
 						ecsLabelDesiredStatus:    model.LabelValue(*task.DesiredStatus),

--- a/discovery/aws/ecs_test.go
+++ b/discovery/aws/ecs_test.go
@@ -1512,6 +1512,7 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 					Port:               80,
 					RequestConcurrency: 1,
 				},
+				region: tt.ecsData.region,
 			}
 
 			groups, err := d.refresh(ctx)

--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -224,17 +224,13 @@ func (c *ElasticacheSDConfig) SetDirectory(dir string) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the Elasticache Config.
+// Region resolution is deferred to initElasticacheClient; see loadRegion.
 func (c *ElasticacheSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultElasticacheSDConfig
 	type plain ElasticacheSDConfig
 	err := unmarshal((*plain)(c))
 	if err != nil {
 		return err
-	}
-
-	c.Region, err = loadRegion(context.Background(), c.Region)
-	if err != nil {
-		return fmt.Errorf("could not determine AWS region: %w", err)
 	}
 
 	return c.HTTPClientConfig.Validate()
@@ -284,6 +280,10 @@ type ElasticacheDiscovery struct {
 	logger            *slog.Logger
 	cfg               *ElasticacheSDConfig
 	elasticacheClient elasticacheClient
+
+	// region is the resolved region used for the AWS client and for the
+	// Source label. Lazily populated by initElasticacheClient.
+	region string
 }
 
 // NewElasticacheDiscovery returns a new ElasticacheDiscovery which periodically refreshes its targets.
@@ -317,19 +317,21 @@ func (d *ElasticacheDiscovery) initElasticacheClient(ctx context.Context) error 
 		return nil
 	}
 
-	if d.cfg.Region == "" {
-		return errors.New("region must be set for Elasticache service discovery")
-	}
-
 	// Build the HTTP client from the provided HTTPClientConfig.
 	client, err := config.NewClientFromConfig(d.cfg.HTTPClientConfig, "elasticache_sd")
 	if err != nil {
 		return err
 	}
 
-	// Build the AWS config with the provided region.
+	// Resolve the region lazily. See ElasticacheSDConfig.UnmarshalYAML.
+	d.region, err = loadRegion(ctx, d.cfg.Region)
+	if err != nil {
+		return err
+	}
+
+	// Build the AWS config with the resolved region.
 	var configOptions []func(*awsConfig.LoadOptions) error
-	configOptions = append(configOptions, awsConfig.WithRegion(d.cfg.Region))
+	configOptions = append(configOptions, awsConfig.WithRegion(d.region))
 	configOptions = append(configOptions, awsConfig.WithHTTPClient(client))
 
 	// Only set static credentials if both access key and secret key are provided
@@ -556,7 +558,7 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 	}
 
 	tg := &targetgroup.Group{
-		Source: d.cfg.Region,
+		Source: d.region,
 	}
 
 	errg, ectx := errgroup.WithContext(ctx)

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -103,17 +103,13 @@ func (c *LightsailSDConfig) SetDirectory(dir string) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the Lightsail Config.
+// Region resolution is deferred to lightsailClient; see loadRegion.
 func (c *LightsailSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultLightsailSDConfig
 	type plain LightsailSDConfig
 	err := unmarshal((*plain)(c))
 	if err != nil {
 		return err
-	}
-
-	c.Region, err = loadRegion(context.Background(), c.Region)
-	if err != nil {
-		return fmt.Errorf("could not determine AWS region: %w", err)
 	}
 
 	return c.HTTPClientConfig.Validate()
@@ -142,6 +138,11 @@ type LightsailDiscovery struct {
 	*refresh.Discovery
 	cfg       *LightsailSDConfig
 	lightsail *lightsailClientAdapter
+
+	// region is the resolved region used for the AWS client and for the
+	// Source / __meta_lightsail_region labels. Lazily populated by
+	// lightsailClient.
+	region string
 }
 
 // NewLightsailDiscovery returns a new LightsailDiscovery which periodically refreshes its targets.
@@ -182,9 +183,15 @@ func (d *LightsailDiscovery) lightsailClient(ctx context.Context) (*lightsailCli
 		return nil, err
 	}
 
-	// Build the AWS config with the provided region.
+	// Resolve the region lazily. See LightsailSDConfig.UnmarshalYAML.
+	d.region, err = loadRegion(ctx, d.cfg.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the AWS config with the resolved region.
 	configOptions := []func(*awsConfig.LoadOptions) error{
-		awsConfig.WithRegion(d.cfg.Region),
+		awsConfig.WithRegion(d.region),
 		awsConfig.WithHTTPClient(httpClient),
 	}
 
@@ -232,7 +239,7 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 	}
 
 	tg := &targetgroup.Group{
-		Source: d.cfg.Region,
+		Source: d.region,
 	}
 
 	input := &lightsail.GetInstancesInput{}
@@ -259,7 +266,7 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 			lightsailLabelInstanceState:       model.LabelValue(*inst.State.Name),
 			lightsailLabelInstanceSupportCode: model.LabelValue(*inst.SupportCode),
 			lightsailLabelPrivateIP:           model.LabelValue(*inst.PrivateIpAddress),
-			lightsailLabelRegion:              model.LabelValue(d.cfg.Region),
+			lightsailLabelRegion:              model.LabelValue(d.region),
 		}
 
 		addr := net.JoinHostPort(*inst.PrivateIpAddress, strconv.Itoa(d.cfg.Port))

--- a/discovery/aws/msk.go
+++ b/discovery/aws/msk.go
@@ -136,17 +136,13 @@ func (c *MSKSDConfig) SetDirectory(dir string) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the MSK Config.
+// Region resolution is deferred to initMskClient; see loadRegion.
 func (c *MSKSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultMSKSDConfig
 	type plain MSKSDConfig
 	err := unmarshal((*plain)(c))
 	if err != nil {
 		return err
-	}
-
-	c.Region, err = loadRegion(context.Background(), c.Region)
-	if err != nil {
-		return fmt.Errorf("could not determine AWS region: %w", err)
 	}
 
 	return c.HTTPClientConfig.Validate()
@@ -195,6 +191,10 @@ type MSKDiscovery struct {
 	logger *slog.Logger
 	cfg    *MSKSDConfig
 	msk    mskClient
+
+	// region is the resolved region used for the AWS client and for the
+	// Source label. Lazily populated by initMskClient.
+	region string
 }
 
 // NewMSKDiscovery returns a new MSKDiscovery which periodically refreshes its targets.
@@ -228,19 +228,21 @@ func (d *MSKDiscovery) initMskClient(ctx context.Context) error {
 		return nil
 	}
 
-	if d.cfg.Region == "" {
-		return errors.New("region must be set for MSK service discovery")
-	}
-
 	// Build the HTTP client from the provided HTTPClientConfig.
 	client, err := config.NewClientFromConfig(d.cfg.HTTPClientConfig, "msk_sd")
 	if err != nil {
 		return err
 	}
 
-	// Build the AWS config with the provided region.
+	// Resolve the region lazily. See MSKSDConfig.UnmarshalYAML.
+	d.region, err = loadRegion(ctx, d.cfg.Region)
+	if err != nil {
+		return err
+	}
+
+	// Build the AWS config with the resolved region.
 	var configOptions []func(*awsConfig.LoadOptions) error
-	configOptions = append(configOptions, awsConfig.WithRegion(d.cfg.Region))
+	configOptions = append(configOptions, awsConfig.WithRegion(d.region))
 	configOptions = append(configOptions, awsConfig.WithHTTPClient(client))
 
 	// Only set static credentials if both access key and secret key are provided
@@ -389,7 +391,7 @@ func (d *MSKDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 	}
 
 	tg := &targetgroup.Group{
-		Source: d.cfg.Region,
+		Source: d.region,
 	}
 
 	var clusters []types.Cluster

--- a/discovery/aws/msk_test.go
+++ b/discovery/aws/msk_test.go
@@ -1006,8 +1006,9 @@ func TestMSKDiscoveryRefresh(t *testing.T) {
 			}
 
 			d := &MSKDiscovery{
-				msk: client,
-				cfg: config,
+				msk:    client,
+				cfg:    config,
+				region: tt.mskData.region,
 			}
 
 			groups, err := d.refresh(ctx)

--- a/discovery/aws/rds.go
+++ b/discovery/aws/rds.go
@@ -256,17 +256,13 @@ func (c *RDSSDConfig) SetDirectory(dir string) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for the RDS Config.
+// Region resolution is deferred to initRdsClient; see loadRegion.
 func (c *RDSSDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultRDSSDConfig
 	type plain RDSSDConfig
 	err := unmarshal((*plain)(c))
 	if err != nil {
 		return err
-	}
-
-	c.Region, err = loadRegion(context.Background(), c.Region)
-	if err != nil {
-		return fmt.Errorf("could not determine AWS region: %w", err)
 	}
 
 	return c.HTTPClientConfig.Validate()
@@ -308,6 +304,10 @@ type RDSDiscovery struct {
 	logger *slog.Logger
 	cfg    *RDSSDConfig
 	rds    rdsClient
+
+	// region is the resolved region used for the AWS client and for the
+	// Source label. Lazily populated by initRdsClient.
+	region string
 }
 
 // NewRDSDiscovery returns a new RDSDiscovery which periodically refreshes its targets.
@@ -341,19 +341,21 @@ func (d *RDSDiscovery) initRdsClient(ctx context.Context) error {
 		return nil
 	}
 
-	if d.cfg.Region == "" {
-		return errors.New("region must be set for RDS service discovery")
-	}
-
 	// Build the HTTP client from the provided HTTPClientConfig.
 	client, err := config.NewClientFromConfig(d.cfg.HTTPClientConfig, "rds_sd")
 	if err != nil {
 		return err
 	}
 
-	// Build the AWS config with the provided region.
+	// Resolve the region lazily. See RDSSDConfig.UnmarshalYAML.
+	d.region, err = loadRegion(ctx, d.cfg.Region)
+	if err != nil {
+		return err
+	}
+
+	// Build the AWS config with the resolved region.
 	var configOptions []func(*awsConfig.LoadOptions) error
-	configOptions = append(configOptions, awsConfig.WithRegion(d.cfg.Region))
+	configOptions = append(configOptions, awsConfig.WithRegion(d.region))
 	configOptions = append(configOptions, awsConfig.WithHTTPClient(client))
 
 	// Only set static credentials if both access key and secret key are provided
@@ -512,7 +514,7 @@ func (d *RDSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 	}
 
 	tg := &targetgroup.Group{
-		Source: d.cfg.Region,
+		Source: d.region,
 	}
 
 	var clusters map[string]types.DBCluster


### PR DESCRIPTION
## Summary

`promtool check config` and other config-only operations no longer make network calls to the EC2 Instance Metadata Service (IMDS) when the AWS service discovery region is omitted. Region resolution is now deferred from YAML unmarshaling to each discovery's init path, so an empty `region` (which the docs explicitly support) is accepted at config-validation time. The error now surfaces at the discovery's first refresh — same error, different (and correct) timing.

Closes #6092

## Reproduction

```bash
$ promtool check config prometheus-aws-all.yml
  FAILED: parsing YAML file prometheus-aws-all.yml: could not determine AWS region: failed to get region from IMDS: ... dial tcp 169.254.169.254:80: connect: operation not supported
```

Same root cause existed in `ec2`, `ecs`, `rds`, `msk`, `elasticache`, `lightsail`, and the legacy `role: ec2` wrapper. All seven sites are fixed in this PR.

## Test Results

<details>
<summary>Before the change (issue reproduced)</summary>

```
$ promtool check config prometheus-aws-all.yml
  FAILED: parsing YAML file prometheus-aws-all.yml: could not determine AWS region: failed to get region from IMDS: operation error ec2imds: GetRegion, exceeded maximum number of attempts, 3, request send failed, Get "http://169.254.169.254/latest/dynamic/instance-identity/document": dial tcp 169.254.169.254:80: connect: operation not supported
```

Reproduction covered all 6 AWS SDs (ec2/ecs/rds/msk/elasticache/lightsail) and the legacy `SDConfig` wrapper. Each `UnmarshalYAML` invoked `loadRegion`, which made the IMDS call.

</details>

<details>
<summary>After the change (fix verified)</summary>

```
$ promtool check config prometheus-aws-all.yml
 SUCCESS: prometheus-aws-all.yml is valid prometheus config file syntax
```

Runtime behavior preserved — when region can't be resolved in the runtime environment, the SD fails at first refresh with the same `could not determine AWS region: ...` error:

```
level=ERROR source=refresh.go:72 msg="Unable to refresh target groups" component="discovery manager scrape" discovery=ec2 config=ec2 err="could not determine AWS region: failed to get region from IMDS: ..."
```

| Check | Result |
|---|---|
| `go build ./...` | clean |
| `go test -short -race ./discovery/aws/ ./config/ ./cmd/promtool/` | all pass |
| `golangci-lint run` (changed files) | zero issues |
| `gofmt -l` | clean |
| `go vet` | clean |

</details>

## Edge cases considered

<table>
  <colgroup>
    <col style="width: 35%;">
    <col style="width: 50%;">
    <col style="width: 15%;">
  </colgroup>
  <thead>
    <tr>
      <th>Case</th>
      <th>Expected</th>
      <th align="center">Verified</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Empty region, no env vars, no IMDS</td>
      <td><code>promtool check config</code> succeeds; SD fails at first refresh.</td>
      <td align="center">✅ Yes</td>
    </tr>
    <tr>
      <td>Explicit region, IMDS unreachable</td>
      <td>Region is used as-is; no IMDS call.</td>
      <td align="center">✅ Yes</td>
    </tr>
    <tr>
      <td><code>AWS_REGION</code> env var set, config region empty</td>
      <td>Environment variable is picked up at refresh time.</td>
      <td align="center">✅ Yes</td>
    </tr>
    <tr>
      <td>Explicit config region + <code>AWS_REGION</code></td>
      <td>Configured region takes precedence.</td>
      <td align="center">✅ Yes</td>
    </tr>
    <tr>
      <td>Explicit empty <code>region: ""</code></td>
      <td>Behaves the same as an omitted region.</td>
      <td align="center">✅ Yes</td>
    </tr>
    <tr>
      <td>Mixed explicit + empty regions across six SDs</td>
      <td>All configurations parse successfully; regions resolve independently.</td>
      <td align="center">✅ Yes</td>
    </tr>
    <tr>
      <td><code>Source</code> target-group label and <code>__meta_*_region</code></td>
      <td>Match the region the AWS client was built with (resolved region stored in <code>d.region</code>).</td>
      <td align="center">✅ Yes</td>
    </tr>
    <tr>
      <td>Concurrency</td>
      <td>Safe — <code>if d.ec2 != nil</code> memoizes the client; mutation occurs only from a single refresh goroutine.</td>
      <td align="center">✅ Yes</td>
    </tr>
    <tr>
      <td>Legacy <code>role: ec2</code> syntax</td>
      <td>Uses the same fix path; no separate regression (<code>TestAWSSDConfigUnmarshalYAML_NoRegionResolution</code>).</td>
      <td align="center">✅ Yes</td>
    </tr>
  </tbody>
</table>

## Tests added

- `TestAWSSDConfigUnmarshalYAML_NoRegionResolution` (`discovery/aws/aws_test.go`) — unit-level regression test. Points IMDS at a black hole, unsets every other region source, and asserts that `UnmarshalYAML` succeeds for all 6 AWS roles (parallel subtests). Would have failed before the fix.
- `prometheus-aws-sd-empty-region.good.yml` (`cmd/promtool/testdata/`) — end-to-end regression fixture: all 6 AWS SDs with empty regions. Registered in `TestExitCodes` so `promtool check config` against this fixture is locked as a passing test.

## Release notes

```release-notes
[BUGFIX] Discovery/AWS: Defer region resolution in EC2, ECS, RDS, MSK, ElastiCache, and Lightsail service discovery configs from YAML unmarshaling to SD init time. `promtool check config` and other config-only operations no longer make network calls to the EC2 instance metadata service (IMDS) when the region is omitted. #6092
```

## AI use

This PR was implemented with AI assistance.