### PR TITLE
tsdb: gate XOR2 float encoding behind XOR2EncodingAllowed

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -281,6 +281,7 @@ func (c *flagConfig) setFeatureListOptions(logger *slog.Logger) error {
 				config.DefaultGlobalConfig.ScrapeProtocols = config.DefaultProtoFirstScrapeProtocols
 				logger.Info("Experimental start timestamp zero ingestion enabled. OpenMetrics 1.0 parsing will parse <metric>_created metrics as ST instead of normal sample. Changed default scrape_protocols to prefer PrometheusProto format.", "global.scrape_protocols", fmt.Sprintf("%v", config.DefaultGlobalConfig.ScrapeProtocols))
 			case "xor2-encoding":
+				c.tsdb.XOR2EncodingAllowed = true
 				c.tsdb.FloatChunkEncoding = chunkenc.EncXOR2
 				logger.Info("Experimental XOR2 chunk encoding enabled.")
 			case "st-synthesis":
@@ -2098,6 +2099,7 @@ type tsdbOptions struct {
 	StaleSeriesCompactionThreshold float64
 	EnableFastStartup              bool
 	FloatChunkEncoding             chunkenc.Encoding
+	XOR2EncodingAllowed            bool
 }
 
 func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
@@ -2130,6 +2132,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		StaleSeriesCompactionThreshold: opts.StaleSeriesCompactionThreshold,
 		EnableFastStartup:              opts.EnableFastStartup,
 		FloatChunkEncoding:             opts.FloatChunkEncoding,
+		XOR2EncodingAllowed:            opts.XOR2EncodingAllowed,
 	}
 }
 

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -162,6 +162,7 @@ func RunBuiltinTests(t TBRun, engine promql.QueryEngine) {
 	RunBuiltinTestsWithStorage(t, engine, func(t testing.TB) storage.Storage {
 		return teststorage.New(t, func(opt *tsdb.Options) {
 			opt.EnableSTStorage = true
+			opt.XOR2EncodingAllowed = true
 			opt.FloatChunkEncoding = chunkenc.EncXOR2
 		})
 	})

--- a/promql/promqltest/test_test.go
+++ b/promql/promqltest/test_test.go
@@ -33,6 +33,7 @@ func init() {
 	testStorageOptions = []teststorage.Option{
 		func(opts *tsdb.Options) {
 			opts.EnableSTStorage = true
+			opts.XOR2EncodingAllowed = true
 			opts.FloatChunkEncoding = chunkenc.EncXOR2
 		},
 	}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1921,6 +1921,7 @@ func TestScrapeLoopAppend_StartTimeSynthesis_WithSTStorage(t *testing.T) {
 
 	s := teststorage.New(t, func(opt *tsdb.Options) {
 		opt.EnableSTStorage = true
+		opt.XOR2EncodingAllowed = true
 		opt.FloatChunkEncoding = chunkenc.EncXOR2
 	})
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -260,11 +260,21 @@ type Options struct {
 
 	// FloatChunkEncoding is the encoding used for new float chunks when
 	// chunk_encoding.floats is absent from the configuration file.
-	// Defaults to EncXOR. Set to EncXOR2 to enable XOR2 encoding.
+	// Defaults to EncXOR. Set to EncXOR2 to default new float chunks to XOR2.
 	// Always use DefaultOptions() rather than a bare Options literal; the zero value
 	// of this field is EncNone, not EncXOR. This field is independent of EnableSTStorage:
 	// st-storage does not automatically select EncXOR2.
+	// Selecting EncXOR2 here requires XOR2EncodingAllowed to be true.
 	FloatChunkEncoding chunkenc.Encoding
+
+	// XOR2EncodingAllowed gates whether the XOR2 float chunk encoding may be used
+	// at all, either as the FloatChunkEncoding default or via chunk_encoding.floats
+	// in the configuration file. It is the enable/disable switch for the feature,
+	// kept separate from FloatChunkEncoding which selects the active default.
+	// Callers that want XOR2 available without making it the default (e.g.
+	// multi-tenant setups that opt tenants in individually) can set this to true
+	// while leaving FloatChunkEncoding at EncXOR.
+	XOR2EncodingAllowed bool
 
 	// FeatureRegistry is used to register TSDB features.
 	FeatureRegistry features.Collector
@@ -884,7 +894,7 @@ func Open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, st
 		opts.FeatureRegistry.Set(features.TSDB, "use_uncached_io", opts.UseUncachedIO)
 		opts.FeatureRegistry.Enable(features.TSDB, "native_histograms")
 		opts.FeatureRegistry.Set(features.TSDB, "st_storage", opts.EnableSTStorage)
-		opts.FeatureRegistry.Set(features.TSDB, "xor2_encoding", opts.FloatChunkEncoding == chunkenc.EncXOR2)
+		opts.FeatureRegistry.Set(features.TSDB, "xor2_encoding", opts.XOR2EncodingAllowed)
 	}
 
 	return open(dir, l, r, opts, rngs, stats)
@@ -899,6 +909,9 @@ func validateOpts(opts *Options, rngs []int64) (*Options, []int64, error) {
 	}
 	if opts.FloatChunkEncoding != chunkenc.EncXOR && opts.FloatChunkEncoding != chunkenc.EncXOR2 {
 		return nil, nil, fmt.Errorf("unsupported float chunk encoding %q; valid values are %q and %q", strings.ToLower(opts.FloatChunkEncoding.String()), config.FloatChunkEncodingXOR, config.FloatChunkEncodingXOR2)
+	}
+	if opts.FloatChunkEncoding == chunkenc.EncXOR2 && !opts.XOR2EncodingAllowed {
+		return nil, nil, fmt.Errorf("float chunk %q is not enabled", config.FloatChunkEncodingXOR2)
 	}
 	if opts.EnableSTStorage && opts.FloatChunkEncoding == chunkenc.EncXOR {
 		return nil, nil, fmt.Errorf("float chunk encoding %q is incompatible with start-timestamp storage; XOR chunks do not store start timestamps, use %q", config.FloatChunkEncodingXOR, config.FloatChunkEncodingXOR2)
@@ -1303,7 +1316,7 @@ func (db *DB) ApplyConfig(conf *config.Config) error {
 	if conf.StorageConfig.TSDBConfig != nil {
 		// Validate encoding config before updating the head encoding so that
 		// an invalid encoding in the config does not change the active encoding.
-		if conf.StorageConfig.TSDBConfig.ChunkEncoding.Floats == config.FloatChunkEncodingXOR2 && db.opts.FloatChunkEncoding != chunkenc.EncXOR2 {
+		if conf.StorageConfig.TSDBConfig.ChunkEncoding.Floats == config.FloatChunkEncodingXOR2 && !db.opts.XOR2EncodingAllowed {
 			return errors.New("'storage.tsdb.chunk_encoding.floats: xor2' requires the xor2-encoding feature flag to be enabled at startup")
 		}
 		// db.opts.EnableSTStorage is set once at startup and never mutated.

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -7510,13 +7510,14 @@ func TestCompactHeadWithSTStorage_AppendV2(t *testing.T) {
 	t.Parallel()
 
 	opts := &Options{
-		RetentionDuration:  int64(time.Hour * 24 * 15 / time.Millisecond),
-		NoLockfile:         true,
-		MinBlockDuration:   int64(time.Hour * 2 / time.Millisecond),
-		MaxBlockDuration:   int64(time.Hour * 2 / time.Millisecond),
-		WALCompression:     compression.Snappy,
-		EnableSTStorage:    true,
-		FloatChunkEncoding: chunkenc.EncXOR2,
+		RetentionDuration:   int64(time.Hour * 24 * 15 / time.Millisecond),
+		NoLockfile:          true,
+		MinBlockDuration:    int64(time.Hour * 2 / time.Millisecond),
+		MaxBlockDuration:    int64(time.Hour * 2 / time.Millisecond),
+		WALCompression:      compression.Snappy,
+		EnableSTStorage:     true,
+		XOR2EncodingAllowed: true,
+		FloatChunkEncoding:  chunkenc.EncXOR2,
 	}
 	db := newTestDB(t, withOpts(opts))
 	ctx := context.Background()
@@ -7655,6 +7656,7 @@ func TestDBAppenderV2_STStorage_OutOfOrder(t *testing.T) {
 			opts := DefaultOptions()
 			opts.OutOfOrderTimeWindow = 300 * time.Minute.Milliseconds()
 			opts.EnableSTStorage = true
+			opts.XOR2EncodingAllowed = true
 			opts.FloatChunkEncoding = chunkenc.EncXOR2
 			db := newTestDB(t, withOpts(opts))
 			db.DisableCompactions()

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -1816,8 +1816,21 @@ func TestDBApplyConfigChunkEncoding(t *testing.T) {
 			"'storage.tsdb.chunk_encoding.floats: xor2' requires the xor2-encoding feature flag")
 	})
 
+	t.Run("xor2_allowed_with_xor_default_accepts_config_xor2", func(t *testing.T) {
+		opts := DefaultOptions()
+		opts.XOR2EncodingAllowed = true
+		opts.FloatChunkEncoding = chunkenc.EncXOR
+		db := newTestDB(t, withOpts(opts))
+		// With XOR2 allowed but the default kept at XOR, an explicit xor2 in the
+		// config must be accepted because the feature is enabled. This is the
+		// multi-tenant case where the encoding is opted in per reload.
+		require.NoError(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR2)))
+		require.True(t, db.head.opts.UseXOR2FloatEncoding())
+	})
+
 	t.Run("explicit_xor_overrides_xor2_option", func(t *testing.T) {
 		opts := DefaultOptions()
+		opts.XOR2EncodingAllowed = true
 		opts.FloatChunkEncoding = chunkenc.EncXOR2
 		db := newTestDB(t, withOpts(opts))
 		require.NoError(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR)))
@@ -1827,6 +1840,7 @@ func TestDBApplyConfigChunkEncoding(t *testing.T) {
 
 	t.Run("xor2_with_option_succeeds", func(t *testing.T) {
 		opts := DefaultOptions()
+		opts.XOR2EncodingAllowed = true
 		opts.FloatChunkEncoding = chunkenc.EncXOR2
 		db := newTestDB(t, withOpts(opts))
 		require.NoError(t, db.ApplyConfig(xorCfg(config.FloatChunkEncodingXOR2)))
@@ -1837,6 +1851,7 @@ func TestDBApplyConfigChunkEncoding(t *testing.T) {
 		for _, enc := range []chunkenc.Encoding{chunkenc.EncXOR2, chunkenc.EncXOR} {
 			t.Run(enc.String(), func(t *testing.T) {
 				opts := DefaultOptions()
+				opts.XOR2EncodingAllowed = true
 				opts.FloatChunkEncoding = enc
 				db := newTestDB(t, withOpts(opts))
 				require.NoError(t, db.ApplyConfig(xorCfg("")))
@@ -1847,6 +1862,7 @@ func TestDBApplyConfigChunkEncoding(t *testing.T) {
 
 	t.Run("sequential_reload_reverts_to_startup_option", func(t *testing.T) {
 		opts := DefaultOptions()
+		opts.XOR2EncodingAllowed = true
 		opts.FloatChunkEncoding = chunkenc.EncXOR2
 		db := newTestDB(t, withOpts(opts))
 
@@ -1859,6 +1875,7 @@ func TestDBApplyConfigChunkEncoding(t *testing.T) {
 
 	t.Run("nil_TSDBConfig_resets_to_startup_option", func(t *testing.T) {
 		opts := DefaultOptions()
+		opts.XOR2EncodingAllowed = true
 		opts.FloatChunkEncoding = chunkenc.EncXOR2
 		db := newTestDB(t, withOpts(opts))
 
@@ -1871,6 +1888,7 @@ func TestDBApplyConfigChunkEncoding(t *testing.T) {
 
 	t.Run("xor_with_st_storage_returns_error", func(t *testing.T) {
 		opts := DefaultOptions()
+		opts.XOR2EncodingAllowed = true
 		opts.FloatChunkEncoding = chunkenc.EncXOR2
 		opts.EnableSTStorage = true
 		db := newTestDB(t, withOpts(opts))
@@ -1918,8 +1936,22 @@ func TestValidateOptsSTStorageRequiresXOR2(t *testing.T) {
 	_, _, err := validateOpts(opts, nil)
 	require.ErrorContains(t, err, "is incompatible with start-timestamp storage")
 
-	// EncXOR2 + st-storage must be accepted.
+	// EncXOR2 + st-storage must be accepted when XOR2 is allowed.
+	opts.XOR2EncodingAllowed = true
 	opts.FloatChunkEncoding = chunkenc.EncXOR2
+	_, _, err = validateOpts(opts, nil)
+	require.NoError(t, err)
+}
+
+func TestValidateOptsXOR2RequiresAllowed(t *testing.T) {
+	t.Parallel()
+	opts := DefaultOptions()
+	opts.FloatChunkEncoding = chunkenc.EncXOR2
+	// XOR2 as the default encoding requires the feature to be enabled.
+	_, _, err := validateOpts(opts, nil)
+	require.ErrorContains(t, err, "is not enabled")
+
+	opts.XOR2EncodingAllowed = true
 	_, _, err = validateOpts(opts, nil)
 	require.NoError(t, err)
 }

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -3991,6 +3991,7 @@ func testChunkQuerierOverlappingInOrderAndOOOChunks(t *testing.T, valType chunke
 	opts.OutOfOrderTimeWindow = 24 * time.Hour.Milliseconds()
 	opts.EnableSTStorage = storeST
 	if storeST {
+		opts.XOR2EncodingAllowed = true
 		opts.FloatChunkEncoding = chunkenc.EncXOR2
 	}
 	db := newTestDB(t, withOpts(opts))


### PR DESCRIPTION
Add an explicit XOR2EncodingAllowed option that gates whether the XOR2 float chunk encoding may be used at all, either as the FloatChunkEncoding default or via chunk_encoding.floats in the configuration file. This keeps the enable/disable switch separate from FloatChunkEncoding, which selects the active default, so callers (e.g. multi-tenant setups) can make XOR2 available without making it the default.

The xor2-encoding feature flag now sets XOR2EncodingAllowed, validateOpts rejects an EncXOR2 default when it is not allowed, and ApplyConfig checks the gate rather than the current default. This replaces the Head.SetFloatChunkEncoding setter approach.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
