### PR TITLE
promql: make mad_over_time propagate NaN and reuse its scratch slice

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1419,12 +1419,16 @@ func funcMadOverTime(_ []Vector, matrixVal Matrix, args parser.Expressions, enh 
 	return aggrOverTime(matrixVal, enh, func(s Series) float64 {
 		values := make(vectorByValueHeap, 0, len(s.Floats))
 		for _, f := range s.Floats {
+			// A NaN sample makes the median, and therefore the deviation,
+			// undefined, so propagate NaN rather than silently dropping it.
+			if math.IsNaN(f.F) {
+				return math.NaN()
+			}
 			values = append(values, Sample{F: f.F})
 		}
 		median := quantile(0.5, values)
-		values = make(vectorByValueHeap, 0, len(s.Floats))
-		for _, f := range s.Floats {
-			values = append(values, Sample{F: math.Abs(f.F - median)})
+		for i := range values {
+			values[i].F = math.Abs(values[i].F - median)
 		}
 		return quantile(0.5, values)
 	}), annos

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -1277,12 +1277,36 @@ eval instant at 55s stddev_over_time(metric[1m])
 clear
 load 10s
 	metric 4 6 2 1 999 1 2
+	metric_odd 1 2 3 4 5
+	metric_equal 7 7 7 7 7
+	metric_single 5
+	metric_nan 1 2 NaN 4
 	metric_histogram{type="only_histogram"} {{schema:1 sum:2 count:3}}x5
 	metric_histogram{type="mix"} 1 1 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}}
 
 eval instant at 70s mad_over_time(metric[70s])
 	expect no_info
 	{} 1
+
+# Odd number of samples: median is the exact middle value.
+eval instant at 40s mad_over_time(metric_odd[50s])
+	expect no_info
+	{} 1
+
+# All samples equal: deviations are all zero, so MAD is zero.
+eval instant at 40s mad_over_time(metric_equal[50s])
+	expect no_info
+	{} 0
+
+# Single sample: deviation from itself is zero.
+eval instant at 0s mad_over_time(metric_single[10s])
+	expect no_info
+	{} 0
+
+# A NaN sample makes the result NaN rather than being silently dropped.
+eval instant at 30s mad_over_time(metric_nan[40s])
+	expect no_info
+	{} NaN
 
 eval instant at 70s mad_over_time(metric_histogram{type="only_histogram"}[70s])
 	expect no_info


### PR DESCRIPTION
A NaN sample was silently swallowed to 0 because the quantile helper sorts NaN to the front, so it rarely landed on the median rank. Propagate NaN instead, matching the variance-based *_over_time functions.

While here, reuse the values slice in place when computing the absolute deviations instead of allocating a second slice per series.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] PromQL: `mad_over_time` now propagates NaN instead of silently returning 0 when the range contains a NaN sample.
```
