### PR TITLE
PromQL: Add experimental `st_of_last_over_time()` function

### DIFF
--- a/cmd/prometheus/testdata/features.json
+++ b/cmd/prometheus/testdata/features.json
@@ -128,6 +128,7 @@
     "stddev_over_time": true,
     "stdvar_over_time": true,
     "step": false,
+    "st_of_last_over_time": false,
     "sum_over_time": true,
     "tan": true,
     "tanh": true,

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -947,6 +947,8 @@ additional functions are available:
 
 * `mad_over_time(range-vector)`: the median absolute deviation of all float
   samples in the specified interval.
+* `st_of_last_over_time(range-vector)`: the start timestamp of last sample in the
+  specified interval.
 * `ts_of_min_over_time(range-vector)`: the timestamp of the last float sample
   that has the minimum value of all float samples in the specified interval.
 * `ts_of_max_over_time(range-vector)`: the timestamp of the last float sample

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2241,9 +2241,12 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 		var chkIter chunkenc.Iterator
 
 		var startTimestamps *StartTimestamps
-		if ev.useStartTimestamps && (e.Func.Name == "rate" || e.Func.Name == "irate" || e.Func.Name == "increase" || e.Func.Name == "resets") {
-			// TODO: consider pooling this.
-			startTimestamps = &StartTimestamps{}
+		if ev.useStartTimestamps {
+			switch e.Func.Name {
+			case "rate", "irate", "increase", "resets", "st_of_last_over_time":
+				// TODO: consider pooling this.
+				startTimestamps = &StartTimestamps{}
+			}
 		}
 
 		// The last_over_time and first_over_time functions act like

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1430,6 +1430,40 @@ func funcMadOverTime(_ []Vector, matrixVal Matrix, args parser.Expressions, enh 
 	}), annos
 }
 
+// === st_of_last_over_time(Matrix parser.ValueTypeMatrix) (Vector, Notes)  ===
+func funcSTOfLastOverTime(_ []Vector, matrixVal Matrix, _ parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
+	if len(matrixVal) == 0 {
+		return enh.Out, nil
+	}
+	el := matrixVal[0]
+
+	var tf, stf int64
+	if n := len(el.Floats); n > 0 {
+		tf = el.Floats[n-1].T
+		if sts := enh.StartTimestamps; sts != nil {
+			stf = stOrDefault(sts.Floats, n-1, 0)
+		}
+	}
+
+	var th, sth int64
+	if n := len(el.Histograms); n > 0 {
+		th = el.Histograms[n-1].T
+		if sts := enh.StartTimestamps; sts != nil {
+			sth = stOrDefault(sts.Histograms, n-1, 0)
+		}
+	}
+
+	st := stf
+	if tf < th {
+		st = sth
+	}
+
+	return append(enh.Out, Sample{
+		Metric: el.Metric,
+		F:      float64(st) / 1000,
+	}), nil
+}
+
 // === ts_of_first_over_time(Matrix parser.ValueTypeMatrix) (Vector, Notes)  ===
 func funcTsOfFirstOverTime(_ []Vector, matrixVal Matrix, _ parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
 	if len(matrixVal) == 0 {
@@ -2648,6 +2682,7 @@ var FunctionCalls = map[string]FunctionCall{
 	"mad_over_time":                funcMadOverTime,
 	"max_over_time":                funcMaxOverTime,
 	"min_over_time":                funcMinOverTime,
+	"st_of_last_over_time":         funcSTOfLastOverTime,
 	"ts_of_first_over_time":        funcTsOfFirstOverTime,
 	"ts_of_last_over_time":         funcTsOfLastOverTime,
 	"ts_of_max_over_time":          funcTsOfMaxOverTime,
@@ -2828,4 +2863,11 @@ func stringSliceFromArgs(args parser.Expressions) []string {
 
 func getMetricName(metric labels.Labels) string {
 	return metric.Get(model.MetricNameLabel)
+}
+
+func stOrDefault(startTimestamps []int64, idx int, def int64) int64 {
+	if idx < len(startTimestamps) {
+		return startTimestamps[idx]
+	}
+	return def
 }

--- a/promql/parser/functions.go
+++ b/promql/parser/functions.go
@@ -311,6 +311,12 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 	},
+	"st_of_last_over_time": {
+		Name:         "st_of_last_over_time",
+		ArgTypes:     []ValueType{ValueTypeMatrix},
+		ReturnType:   ValueTypeVector,
+		Experimental: true,
+	},
 	"ts_of_first_over_time": {
 		Name:         "ts_of_first_over_time",
 		ArgTypes:     []ValueType{ValueTypeMatrix},

--- a/promql/promqltest/testdata/start_timestamps.test
+++ b/promql/promqltest/testdata/start_timestamps.test
@@ -251,7 +251,6 @@ eval range from 10m to 15m step 1m irate(delta[5m])
 
 clear
 
-
 # Tests for histogram rate where rate extrapolation is substituted with assuming 0 sample at start timestamps.
 #
 # TODO: this doesn't yet produce expected results, because tsdb doesn't yet support start timestamps
@@ -264,3 +263,16 @@ eval instant at 3m rate(series[5m])
     # No series, since single sample can only produce a rate when there's a valid and suitable ST.
 
 clear
+
+# Tests for st_of_last_over_time().
+#
+# TODO: this doesn't yet produce expected results, because tsdb doesn't yet support start timestamps
+# for histograms.
+load 10s
+    series@st  _  1ms   _   0  -1ms       -10ms       -100ms  -999ms  -1s       -10s        -20s  -30s
+    series     _   10  20  30    40  {{sum:50}}   {{sum:60}}      70   80 {{sum:90}} {{sum:100}}   110
+
+eval range from 0s to 110s step 5s st_of_last_over_time(series[20s])
+    {}  _  _  10.001  10.001  0  0  30  30  39.999  39.999  0  0  0  0  69.001 69.001 79  79  0  0  0  0  80
+    # Expected once histogram ST storage is implemented:
+    # {}  _  _  10.001  10.001  0  0  30  30  39.999  39.999  49.99  49.99  59.9  59.9  69.001 69.001 79  79  80  80  80  80  80

--- a/web/ui/mantine-ui/src/promql/functionDocs.tsx
+++ b/web/ui/mantine-ui/src/promql/functionDocs.tsx
@@ -541,6 +541,9 @@ const funcDocs: Record<string, React.ReactNode> = {
           interval.
         </li>
         <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
+        </li>
+        <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
           value of all float samples in the specified interval.
         </li>
@@ -858,6 +861,9 @@ const funcDocs: Record<string, React.ReactNode> = {
         <li>
           <code>mad_over_time(range-vector)</code>: the median absolute deviation of all float samples in the specified
           interval.
+        </li>
+        <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
         </li>
         <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
@@ -1188,6 +1194,9 @@ const funcDocs: Record<string, React.ReactNode> = {
         <li>
           <code>mad_over_time(range-vector)</code>: the median absolute deviation of all float samples in the specified
           interval.
+        </li>
+        <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
         </li>
         <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
@@ -2021,6 +2030,9 @@ const funcDocs: Record<string, React.ReactNode> = {
           interval.
         </li>
         <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
+        </li>
+        <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
           value of all float samples in the specified interval.
         </li>
@@ -2171,6 +2183,9 @@ const funcDocs: Record<string, React.ReactNode> = {
           interval.
         </li>
         <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
+        </li>
+        <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
           value of all float samples in the specified interval.
         </li>
@@ -2296,6 +2311,9 @@ const funcDocs: Record<string, React.ReactNode> = {
           interval.
         </li>
         <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
+        </li>
+        <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
           value of all float samples in the specified interval.
         </li>
@@ -2419,6 +2437,9 @@ const funcDocs: Record<string, React.ReactNode> = {
         <li>
           <code>mad_over_time(range-vector)</code>: the median absolute deviation of all float samples in the specified
           interval.
+        </li>
+        <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
         </li>
         <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
@@ -2636,6 +2657,9 @@ const funcDocs: Record<string, React.ReactNode> = {
           interval.
         </li>
         <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
+        </li>
+        <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
           value of all float samples in the specified interval.
         </li>
@@ -2743,6 +2767,9 @@ const funcDocs: Record<string, React.ReactNode> = {
         <li>
           <code>mad_over_time(range-vector)</code>: the median absolute deviation of all float samples in the specified
           interval.
+        </li>
+        <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
         </li>
         <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
@@ -3185,6 +3212,118 @@ const funcDocs: Record<string, React.ReactNode> = {
       </p>
     </>
   ),
+  st_of_last_over_time: (
+    <>
+      <p>
+        The following functions allow aggregating each series of a given range vector over time and return an instant
+        vector with per-series aggregation results:
+      </p>
+
+      <ul>
+        <li>
+          <code>avg_over_time(range-vector)</code>: the average value of all float or histogram samples in the specified
+          interval (see details below).
+        </li>
+        <li>
+          <code>min_over_time(range-vector)</code>: the minimum value of all float samples in the specified interval.
+        </li>
+        <li>
+          <code>max_over_time(range-vector)</code>: the maximum value of all float samples in the specified interval.
+        </li>
+        <li>
+          <code>sum_over_time(range-vector)</code>: the sum of all float or histogram samples in the specified interval
+          (see details below).
+        </li>
+        <li>
+          <code>count_over_time(range-vector)</code>: the count of all samples in the specified interval.
+        </li>
+        <li>
+          <code>quantile_over_time(scalar, range-vector)</code>: the φ-quantile (0 ≤ φ ≤ 1) of all float samples in the
+          specified interval.
+        </li>
+        <li>
+          <code>stddev_over_time(range-vector)</code>: the population standard deviation of all float samples in the
+          specified interval.
+        </li>
+        <li>
+          <code>stdvar_over_time(range-vector)</code>: the population variance of all float samples in the specified
+          interval.
+        </li>
+        <li>
+          <code>last_over_time(range-vector)</code>: the most recent sample in the specified interval.
+        </li>
+        <li>
+          <code>present_over_time(range-vector)</code>: the value 1 for any series in the specified interval.
+        </li>
+      </ul>
+
+      <p>
+        If the <a href="../feature_flags.md#experimental-promql-functions">feature flag</a>
+        <code>--enable-feature=promql-experimental-functions</code> is set, the following additional functions are
+        available:
+      </p>
+
+      <ul>
+        <li>
+          <code>mad_over_time(range-vector)</code>: the median absolute deviation of all float samples in the specified
+          interval.
+        </li>
+        <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
+        </li>
+        <li>
+          <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
+          value of all float samples in the specified interval.
+        </li>
+        <li>
+          <code>ts_of_max_over_time(range-vector)</code>: the timestamp of the last float sample that has the maximum
+          value of all float samples in the specified interval.
+        </li>
+        <li>
+          <code>ts_of_last_over_time(range-vector)</code>: the timestamp of last sample in the specified interval.
+        </li>
+        <li>
+          <code>first_over_time(range-vector)</code>: the oldest sample in the specified interval.
+        </li>
+        <li>
+          <code>ts_of_first_over_time(range-vector)</code>: the timestamp of earliest sample in the specified interval.
+        </li>
+      </ul>
+
+      <p>
+        Note that all values in the specified interval have the same weight in the aggregation even if the values are
+        not equally spaced throughout the interval.
+      </p>
+
+      <p>These functions act on histograms in the following way:</p>
+
+      <ul>
+        <li>
+          <code>count_over_time</code>, <code>first_over_time</code>, <code>last_over_time</code>, and
+          <code>present_over_time()</code> act on float and histogram samples in the same way.
+        </li>
+        <li>
+          <code>avg_over_time()</code> and <code>sum_over_time()</code> act on histogram samples in a way that
+          corresponds to the respective aggregation operators. If a series contains a mix of float samples and histogram
+          samples within the range, the corresponding result is removed entirely from the output vector. Such a removal
+          is flagged by a warn-level annotation.
+        </li>
+        <li>
+          All other functions ignore histogram samples in the following way: Input ranges containing only histogram
+          samples are silently removed from the output. For ranges with a mix of histogram and float samples, only the
+          float samples are processed and the omission of the histogram samples is flagged by an info-level annotation.
+        </li>
+      </ul>
+
+      <p>
+        <code>first_over_time(m[1m])</code> differs from <code>m offset 1m</code> in that the former will select the
+        first sample of <code>m</code> <em>within</em> the 1m range, where <code>m offset 1m</code> will select the most
+        recent sample within the lookback interval <em>outside and prior to</em> the 1m offset. This is particularly
+        useful with <code>first_over_time(m[step()])</code>
+        in range queries to ensure that the sample selected is within the range step.
+      </p>
+    </>
+  ),
   start: (
     <>
       <p>
@@ -3256,6 +3395,9 @@ const funcDocs: Record<string, React.ReactNode> = {
         <li>
           <code>mad_over_time(range-vector)</code>: the median absolute deviation of all float samples in the specified
           interval.
+        </li>
+        <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
         </li>
         <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
@@ -3365,6 +3507,9 @@ const funcDocs: Record<string, React.ReactNode> = {
         <li>
           <code>mad_over_time(range-vector)</code>: the median absolute deviation of all float samples in the specified
           interval.
+        </li>
+        <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
         </li>
         <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
@@ -3490,6 +3635,9 @@ const funcDocs: Record<string, React.ReactNode> = {
         <li>
           <code>mad_over_time(range-vector)</code>: the median absolute deviation of all float samples in the specified
           interval.
+        </li>
+        <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
         </li>
         <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
@@ -3757,6 +3905,9 @@ const funcDocs: Record<string, React.ReactNode> = {
           interval.
         </li>
         <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
+        </li>
+        <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
           value of all float samples in the specified interval.
         </li>
@@ -3864,6 +4015,9 @@ const funcDocs: Record<string, React.ReactNode> = {
         <li>
           <code>mad_over_time(range-vector)</code>: the median absolute deviation of all float samples in the specified
           interval.
+        </li>
+        <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
         </li>
         <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
@@ -3975,6 +4129,9 @@ const funcDocs: Record<string, React.ReactNode> = {
           interval.
         </li>
         <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
+        </li>
+        <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum
           value of all float samples in the specified interval.
         </li>
@@ -4082,6 +4239,9 @@ const funcDocs: Record<string, React.ReactNode> = {
         <li>
           <code>mad_over_time(range-vector)</code>: the median absolute deviation of all float samples in the specified
           interval.
+        </li>
+        <li>
+          <code>st_of_last_over_time(range-vector)</code>: the start timestamp of last sample in the specified interval.
         </li>
         <li>
           <code>ts_of_min_over_time(range-vector)</code>: the timestamp of the last float sample that has the minimum

--- a/web/ui/mantine-ui/src/promql/functionSignatures.ts
+++ b/web/ui/mantine-ui/src/promql/functionSignatures.ts
@@ -160,6 +160,12 @@ export const functionSignatures: Record<string, Func> = {
   },
   sort_desc: { name: "sort_desc", argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
   sqrt: { name: "sqrt", argTypes: [valueType.vector], variadic: 0, returnType: valueType.vector },
+  st_of_last_over_time: {
+    name: "st_of_last_over_time",
+    argTypes: [valueType.matrix],
+    variadic: 0,
+    returnType: valueType.vector,
+  },
   start: { name: "start", argTypes: [], variadic: 0, returnType: valueType.scalar },
   stddev_over_time: {
     name: "stddev_over_time",

--- a/web/ui/mantine-ui/src/promql/tools/gen_functions_docs/main.go
+++ b/web/ui/mantine-ui/src/promql/tools/gen_functions_docs/main.go
@@ -62,6 +62,7 @@ func main() {
 				"present_over_time",
 				"mad_over_time",
 				"first_over_time",
+				"st_of_last_over_time",
 				"ts_of_first_over_time",
 				"ts_of_last_over_time",
 				"ts_of_max_over_time",

--- a/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
+++ b/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
@@ -389,6 +389,12 @@ export const functionIdentifierTerms = [
     type: 'function',
   },
   {
+    label: 'st_of_last_over_time',
+    detail: 'function',
+    info: 'Return the start timestamp of the last value over time for input series',
+    type: 'function',
+  },
+  {
     label: 'ts_of_max_over_time',
     detail: 'function',
     info: 'Return the timestamp of the maximum value over time for input series',

--- a/web/ui/module/codemirror-promql/src/types/function.ts
+++ b/web/ui/module/codemirror-promql/src/types/function.ts
@@ -64,6 +64,7 @@ import {
   MadOverTime,
   MaxOverTime,
   MinOverTime,
+  STOfLastOverTime,
   TsOfFirstOverTime,
   TsOfMaxOverTime,
   TsOfMinOverTime,
@@ -427,6 +428,12 @@ const promqlFunctions: { [key: number]: PromQLFunction } = {
   },
   [MinOverTime]: {
     name: 'min_over_time',
+    argTypes: [ValueType.matrix],
+    variadic: 0,
+    returnType: ValueType.vector,
+  },
+  [STOfLastOverTime]: {
+    name: 'st_of_last_over_time',
     argTypes: [ValueType.matrix],
     variadic: 0,
     returnType: ValueType.vector,

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -189,6 +189,7 @@ FunctionIdentifier {
   MadOverTime |
   MaxOverTime |
   MinOverTime |
+  STOfLastOverTime |
   TsOfFirstOverTime |
   TsOfMaxOverTime |
   TsOfMinOverTime |
@@ -481,6 +482,7 @@ durationPrimary[@inline] {
   MadOverTime { condFn<"mad_over_time"> }
   MaxOverTime { condFn<"max_over_time"> }
   MinOverTime { condFn<"min_over_time"> }
+  STOfLastOverTime { condFn<"st_of_last_over_time"> }
   TsOfFirstOverTime { condFn<"ts_of_first_over_time"> }
   TsOfMaxFirstTime { condFn<"ts_of_first_over_time"> }
   TsOfMaxOverTime { condFn<"ts_of_max_over_time"> }


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Addresses https://github.com/prometheus/prometheus/issues/18533.

Add experimental `st_of_last_over_time(range-vector)` function which returns start timestamp of the last sample in the specified interval. This provides the means to inspect start timestamp values of queried samples (similarly to how `ts_of_*_over_time()` functions allow to inspect timestamp values).

The motivation for this function stems from all the other changes related to start timestamps (e.g. https://github.com/prometheus/prometheus/pull/18344, https://github.com/prometheus/prometheus/pull/18627, https://github.com/prometheus/prometheus/pull/18619, https://github.com/prometheus/prometheus/pull/18966). With these changes, we will see the output of core Prometheus functions like `rate()` being changed due to start timestamps. However, if that output is unexpected, it wouldn't be easy to understand why because there's currently no easy way to see the raw start timestamp values. Thus a function that outputs start timestamps would help with debugging. 

Besides debugging, it might be beneficial to even be able to find series with or without start timestamps, using simple query like `st_of_last_over_time(some_series[...]) != 0`.
 
#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[FEATURE] PromQL: Add experimental `st_of_last_over_time(range-vector)` function which returns start timestamp of the last sample in the specified interval.
```