### PR TITLE
discovery/hetzner: run tests in parallel

### DIFF
--- a/discovery/hetzner/hcloud_test.go
+++ b/discovery/hetzner/hcloud_test.go
@@ -36,6 +36,7 @@ func (s *hcloudSDTestSuite) SetupTest(t *testing.T) {
 }
 
 func TestHCloudSDRefresh(t *testing.T) {
+	t.Parallel()
 	suite := &hcloudSDTestSuite{}
 	suite.SetupTest(t)
 
@@ -130,6 +131,7 @@ func TestHCloudSDRefresh(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, labelSet, targetGroup.Targets[i])
 		})
 	}

--- a/discovery/hetzner/robot_test.go
+++ b/discovery/hetzner/robot_test.go
@@ -36,6 +36,7 @@ func (s *robotSDTestSuite) SetupTest(t *testing.T) {
 }
 
 func TestRobotSDRefresh(t *testing.T) {
+	t.Parallel()
 	suite := &robotSDTestSuite{}
 	suite.SetupTest(t)
 	cfg := DefaultSDConfig
@@ -82,12 +83,14 @@ func TestRobotSDRefresh(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, labelSet, targetGroup.Targets[i])
 		})
 	}
 }
 
 func TestRobotSDRefreshHandleError(t *testing.T) {
+	t.Parallel()
 	suite := &robotSDTestSuite{}
 	suite.SetupTest(t)
 	cfg := DefaultSDConfig


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Part of #15185

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```

Adds `t.Parallel()` to the three top-level tests in `discovery/hetzner`
(`TestHCloudSDRefresh`, `TestRobotSDRefresh`, `TestRobotSDRefreshHandleError`)
and to their two table-driven `t.Run` subtests. Each top-level test builds its
own `SDMock`/`httptest.Server` via `NewSDMock(t)` with `t.Cleanup`, so there is
no shared mutable state and the tests are safe to run concurrently. Test-only,
no production code or dependency changes. Part of the #15185 effort.
