### PR TITLE
model/labels: preserve case-sensitive Prefix() behavior

### DIFF
--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -168,3 +168,10 @@ func (m *Matcher) IsRegexOptimized() bool {
 	}
 	return m.re.IsOptimized()
 }
+
+func (m *Matcher) HasCaseInsensitivePrefix() bool {
+	if m.re == nil {
+		return false
+	}
+	return m.re.caseInsensitivePrefix
+}

--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -168,10 +168,3 @@ func (m *Matcher) IsRegexOptimized() bool {
 	}
 	return m.re.IsOptimized()
 }
-
-func (m *Matcher) HasCaseInsensitivePrefix() bool {
-	if m.re == nil {
-		return false
-	}
-	return m.re.caseInsensitivePrefix
-}

--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -152,10 +152,10 @@ func (m *Matcher) SetMatches() []string {
 	return m.re.SetMatches()
 }
 
-// Prefix returns the required prefix of the value to match, if possible.
+// Prefix returns the required case-sensitive prefix of the value to match, if possible.
 // It will be empty if it's an equality matcher or if the prefix can't be determined.
 func (m *Matcher) Prefix() string {
-	if m.re == nil {
+	if m.re == nil || m.re.caseInsensitivePrefix {
 		return ""
 	}
 	return m.re.prefix

--- a/model/labels/matcher.go
+++ b/model/labels/matcher.go
@@ -152,7 +152,7 @@ func (m *Matcher) SetMatches() []string {
 	return m.re.SetMatches()
 }
 
-// Prefix returns the required case-sensitive prefix of the value to match, if possible.
+// Prefix returns the required prefix of the value to match byte-for-byte, if possible.
 // It will be empty if it's an equality matcher or if the prefix can't be determined.
 func (m *Matcher) Prefix() string {
 	if m.re == nil || m.re.caseInsensitivePrefix {

--- a/model/labels/matcher_test.go
+++ b/model/labels/matcher_test.go
@@ -190,7 +190,7 @@ func TestPrefix(t *testing.T) {
 		},
 		{
 			matcher:               mustNewMatcher(t, MatchNotRegexp, "(?i)abc.+"),
-			prefix:                "ABC",
+			prefix:                "",
 			caseInsensitivePrefix: true,
 		},
 	} {


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
In https://github.com/prometheus/prometheus/pull/18540, the introduction of case-insensitive prefix matching caused `Prefix()` to return case-insensitive prefixes where callers previously would have expected case-sensitive prefixes. This change returns `Prefix()` behavior to return only case-sensitive prefixes.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
