### PR TITLE
util/netconnlimit: run listener concurrency subtests in parallel

### DIFF
--- a/util/netconnlimit/netconnlimit_test.go
+++ b/util/netconnlimit/netconnlimit_test.go
@@ -51,6 +51,8 @@ func TestSharedLimitListenerConcurrency(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			sem := NewSharedSemaphore(tc.semCapacity)
 			listener, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err, "failed to create listener")


### PR DESCRIPTION
## Summary

Part of #15185.

This adds `t.Parallel()` to the independent subtests in `util/netconnlimit`'s `TestSharedLimitListenerConcurrency`.


## Testing

Observed locally while preparing this PR.

Before this change:

```text
go test -count=10 ./util/netconnlimit
ok  	github.com/prometheus/prometheus/util/netconnlimit	6.511s
```

After this change:

```text
go test -count=10 ./util/netconnlimit
ok  	github.com/prometheus/prometheus/util/netconnlimit	3.313s

go test -race -count=5 ./util/netconnlimit
ok  	github.com/prometheus/prometheus/util/netconnlimit	3.277s

go test -count=5 ./util/...
ok  	github.com/prometheus/prometheus/util/netconnlimit	3.792s
```

```release-notes
NONE
```