### PR TITLE
chore: remove Beorn from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@
 /Makefile                       @prometheus/default-maintainers @simonpasquier @SuperQ
 /cmd/promtool                   @prometheus/default-maintainers @dgl
 /documentation/prometheus-mixin @prometheus/default-maintainers @metalmatze
-/model/histogram                @prometheus/default-maintainers @beorn7 @krajorama
+/model/histogram                @prometheus/default-maintainers @krajorama
 /web/ui                         @prometheus/default-maintainers @juliusv
 /web/ui/module                  @prometheus/default-maintainers @juliusv @nexucis
 /promql                         @prometheus/default-maintainers @roidelapluie @vpranckaitis


### PR DESCRIPTION
CODEOWNERS has an error, because Beorn no longer has write access after retiring from the project.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
