### PR TITLE
Sync dependabot configs

### DIFF
--- a/scripts/dependabot.yml
+++ b/scripts/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      aws:
+        patterns:
+          - "github.com/aws/*"
+      go.opentelemetry.io:
+        patterns:
+          - "go.opentelemetry.io/*"
+      golang.org-x:
+        patterns:
+          - "golang.org/x/*"
+      k8s.io:
+        patterns:
+          - "k8s.io/*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      promci:
+        patterns:
+          - "prometheus/promci*"
+      codeql:
+        patterns:
+          - "github/codeql-action*"
+    # Exclude configs synced from upstream prometheus/prometheus.
+    exclude-paths:
+      - .github/workflows/container_description.yml
+      - .github/workflows/golangci-lint.yml
+      - .github/workflows/govulncheck.yml
+      - .github/workflows/scorecards.yml
+      - .github/workflows/stale.yml

--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -64,7 +64,7 @@ for org in ${orgs}; do
 done
 
 # List of files that should be synced.
-SYNC_FILES="CODE_OF_CONDUCT.md LICENSE Makefile.common SECURITY.md .dockerignore .yamllint scripts/golangci-lint.yml .github/workflows/govulncheck.yml .github/workflows/scorecards.yml .github/workflows/container_description.yml .github/workflows/stale.yml"
+SYNC_FILES="CODE_OF_CONDUCT.md LICENSE Makefile.common SECURITY.md .dockerignore .yamllint scripts/dependabot.yml scripts/golangci-lint.yml .github/workflows/govulncheck.yml .github/workflows/scorecards.yml .github/workflows/container_description.yml .github/workflows/stale.yml"
 
 # Go to the root of the repo
 cd "$(git rev-parse --show-cdup)" || exit 1
@@ -151,6 +151,10 @@ check_license() {
   echo "$1" | grep --quiet --no-messages --ignore-case 'Apache License'
 }
 
+check_no_sync() {
+  grep --quiet --no-messages 'no_prometheus_repo_sync' "${1}"
+}
+
 check_go() {
   local org_repo
   local default_branch
@@ -208,6 +212,9 @@ process_repo() {
       fi
     fi
     target_filename="${source_file}"
+    if [[ "${source_file}" == 'scripts/dependabot.yml' ]] ; then
+      target_filename=".github/dependabot.yml"
+    fi
     if [[ "${source_file}" == 'scripts/golangci-lint.yml' ]] ; then
       target_filename=".github/workflows/golangci-lint.yml"
     fi
@@ -222,12 +229,16 @@ process_repo() {
       esac
       continue
     fi
+    if check_no_sync "${target_file}" ; then
+      repo_log "${target_file} is marked as do not sync, skipping."
+      continue
+    fi
     if [[ "${source_file}" == 'LICENSE' ]] && ! check_license "${target_file}" ; then
       repo_log "LICENSE in ${org_repo} is not apache, skipping."
       continue
     fi
     target_checksum="$(echo "${target_file}" | sha256sum | cut -d' ' -f1)"
-    if [ "${source_checksum}" == "${target_checksum}" ]; then
+    if [[ "${source_checksum}" == "${target_checksum}" ]] ; then
       repo_log "${source_file} is already in sync."
       continue
     fi


### PR DESCRIPTION
Add `.github/dependabot.yml` to the repo sync script.
* Sync is optional.
* Add feature to skip files that contain the string `no_prometheus_repo_sync`.
* Add generic dependabot config for Go and GitHub Actions ecosystems.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
