### PR TITLE
RemoteReadConfig: Do not omit filter_external_labels in yaml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1691,7 +1691,7 @@ type RemoteReadConfig struct {
 	RequiredMatchers model.LabelSet `yaml:"required_matchers,omitempty"`
 
 	// Whether to use the external labels as selectors for the remote read endpoint.
-	FilterExternalLabels bool `yaml:"filter_external_labels,omitempty"`
+	FilterExternalLabels bool `yaml:"filter_external_labels"`
 }
 
 // SetDirectory joins any relative file paths with dir.


### PR DESCRIPTION
Do not omit filter_external_labels in yaml to allow generate config with `filter_external_labels:false`

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Prometheus allows runtime configuration reloads. When `prometheus.yaml` is modified and a reload is invoked, Prometheus applies the new settings. The Prometheus Operator utilizes a `config-reloader` sidecar to manage this process.

### Real usecase
Custom `config-reloader` works by unmarshaling the default `prometheus.yaml` into a `Config` struct, appending `RemoteReadConfig`, and marshaling it back into YAML.

However, if a user sets `filter_external_labels: false`, Prometheus never receives this value. This happens because `DefaultRemoteReadConfig.FilterExternalLabels` defaults to `true`, and the struct field uses the `,omitempty` YAML tag. As a result, the `false` value is dropped during marshaling, causing Prometheus to fall back to the `true` default.

### Proposed Solution
This PR removes the `,omitempty` tag from the `FilterExternalLabels` field.
* **Safe:** This is a non-breaking change.
* **Isolated:** The field will only explicitly appear in configurations that actively use `RemoteReadConfig`.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] RemoteReadConfig: Do not omit filter_external_labels in yaml to allow generate config with `filter_external_labels:false`
```
