### PR TITLE
ci: run version upgrade test as a per-LTS matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,28 @@ jobs:
       # Alternatively we could adjust each relevant test to have 386 aware parallelization setting.
       - run: GOARCH=386 go test -parallel=1 ./...
 
+  list_lts_releases:
+    name: List active LTS releases
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.lts.outputs.versions }}
+    steps:
+      - id: lts
+        # Emit the active LTS versions as a JSON array consumed by the matrix below.
+        run: |
+          versions=$(curl -sSf https://prometheus.io/download.json \
+            | jq -c '[.prometheus[] | select(.lts == true) | (.version | ltrimstr("v"))]')
+          echo "versions=$versions" >> "$GITHUB_OUTPUT"
+
   test_version_upgrade:
     name: Go tests for Prometheus upgrades and downgrades
+    needs: list_lts_releases
     runs-on: ubuntu-latest
+    strategy:
+      # Run every LTS release even if one fails.
+      fail-fast: false
+      matrix:
+        lts_version: ${{ fromJSON(needs.list_lts_releases.outputs.versions) }}
     container:
       image: quay.io/prometheus/golang-builder:1.26-base
     steps:
@@ -78,7 +97,7 @@ jobs:
       - uses: prometheus/promci-setup@b7975feb8bd443f6da85911ca32b93c7701b81cf # v0.2.0
         with:
           cache_key_suffix: upgrade
-      - run: go test -v --race ./cmd/prometheus/ --test.version-upgrade=true -run TestVersionUpgrade
+      - run: go test -v --race ./cmd/prometheus/ --test.version-upgrade=true --test.lts-version=${{ matrix.lts_version }} -run TestVersionUpgrade
 
   test_go_oldest:
     name: Go tests with previous Go version

--- a/cmd/prometheus/main_upgrade_test.go
+++ b/cmd/prometheus/main_upgrade_test.go
@@ -298,7 +298,10 @@ func ensureHealthyLogs(t *testing.T, r io.Reader) {
 	require.NoError(t, scanner.Err())
 }
 
-var testVersionUpgrade = flag.Bool("test.version-upgrade", false, "run resource-intensive and probably slow version upgrade tests")
+var (
+	testVersionUpgrade = flag.Bool("test.version-upgrade", false, "run resource-intensive and probably slow version upgrade tests")
+	testLTSVersion     = flag.String("test.lts-version", "", "restrict the version upgrade test to a single LTS version (e.g. 3.5.0); if empty, all active LTS releases are tested")
+)
 
 // TestVersionUpgrade_UpgradeDowngradeLatestLTS verifies that Prometheus can
 // upgrade from each current LTS release to the current build and then downgrade
@@ -315,6 +318,18 @@ func TestVersionUpgrade_UpgradeDowngradeLatestLTS(t *testing.T) {
 
 	ltsReleases := fetchLTSReleases(t)
 	t.Logf("[%s] found %d LTS release(s) from %s", time.Since(start), len(ltsReleases), prometheusDownloadManifestURL)
+
+	if *testLTSVersion != "" {
+		want := strings.TrimPrefix(*testLTSVersion, "v")
+		filtered := ltsReleases[:0]
+		for _, lts := range ltsReleases {
+			if lts.version == want {
+				filtered = append(filtered, lts)
+			}
+		}
+		require.NotEmpty(t, filtered, "LTS version %q not found among active LTS releases in %s", want, prometheusDownloadManifestURL)
+		ltsReleases = filtered
+	}
 
 	for _, lts := range ltsReleases {
 		t.Run(lts.version, func(t *testing.T) {


### PR DESCRIPTION
Fan out the upgrade/downgrade test over each active LTS release so the matrix jobs run in parallel and a single release failure does not mask the others. A new list_lts_releases job reads the active LTS versions from prometheus.io/download.json and feeds them to the matrix.

Add a --test.lts-version flag so TestVersionUpgrade can be restricted to a single LTS release; when empty, all active LTS releases are tested.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
