### PR TITLE
ci: fix no_prometheus_repo_sync opt-out in repo sync

### DIFF
--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -147,12 +147,12 @@ post_pull_request() {
 }
 
 check_license() {
-  # Check to see if the input is an Apache license of some kind
-  echo "$1" | grep --quiet --no-messages --ignore-case 'Apache License'
+  # Check to see if the input is an Apache license of some kind.
+  grep --quiet --no-messages --ignore-case 'Apache License' <<<"$1"
 }
 
 check_no_sync() {
-  grep --quiet --no-messages 'no_prometheus_repo_sync' "${1}"
+  grep --quiet --no-messages 'no_prometheus_repo_sync' <<<"$1"
 }
 
 check_go() {
@@ -230,7 +230,7 @@ process_repo() {
       continue
     fi
     if check_no_sync "${target_file}" ; then
-      repo_log "${target_file} is marked as do not sync, skipping."
+      repo_log "${target_filename} is marked as do not sync, skipping."
       continue
     fi
     if [[ "${source_file}" == 'LICENSE' ]] && ! check_license "${target_file}" ; then


### PR DESCRIPTION
check_no_sync received the fetched file contents but grepped them as a filename, so the marker was never detected and repos opting out via no_prometheus_repo_sync were synced anyway. Feed the contents on stdin with a here-string, matching check_license, and log the filename instead of the whole file body.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
