### PR TITLE
ci: don't delete repo-sync branch when force-updating open PR

### DIFF
--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -109,17 +109,28 @@ fork_repo() {
 push_branch() {
   local git_url
   local safe_url
+  local force_push
   git_url="https://${git_user}:${GITHUB_TOKEN}@github.com/${1}"
   safe_url="https://${git_user}:***@github.com/${1}"
+  # When set, force-update the existing PR branch in place instead of
+  # deleting it first.
+  force_push="${2:-}"
   # stdout and stderr are redirected to /dev/null otherwise git-push could leak
   # the token in the logs.
-  # Delete the remote branch in case it was merged but not deleted.
-  git push --quiet "${git_url}" ":${branch}" 1>/dev/null 2>&1
+  local push_args=(--set-upstream)
+  if [[ -n "${force_push}" ]]; then
+    # An open PR points at this branch. Deleting it would close the PR, so
+    # force-push over it instead.
+    push_args+=(--force)
+  else
+    # Delete the remote branch in case it was merged but not deleted.
+    git push --quiet "${git_url}" ":${branch}" 1>/dev/null 2>&1
+  fi
   # Forking is asynchronous; retry for up to 5 minutes until the git objects
   # are available before giving up.
   local deadline=$(( $(date +%s) + 300 ))
   local push_output
-  until push_output="$(git push "${git_url}" --set-upstream "${branch}" 2>&1)"; do
+  until push_output="$(git push "${git_url}" "${push_args[@]}" "${branch}" 2>&1)"; do
     if [[ $(date +%s) -ge ${deadline} ]]; then
       repo_log_red "push to ${safe_url} failed: $(echo "${push_output}" | sed "s|${GITHUB_TOKEN}|***|g")"
       return 1
@@ -311,7 +322,7 @@ process_repo() {
     else
       fork_org_repo="$(fork_repo "${org_repo}")" || { repo_log_red "Forking ${org_repo} failed"; return 1; }
     fi
-    if push_branch "${fork_org_repo}"; then
+    if push_branch "${fork_org_repo}" "${force_fork}"; then
       if [[ -n "${force_fork}" ]]; then
         repo_log_green "Force-updated existing PR branch on ${fork_org_repo}"
       elif ! post_pull_request "${org_repo}" "${default_branch}" "${git_user}" "${fork_org_repo}" "${pr_token}"; then


### PR DESCRIPTION
push_branch unconditionally deleted the remote branch before pushing. On the force-update path for an existing bot-only PR, deleting the branch closes the PR on GitHub, so the PR was lost instead of updated. Force-push in place on that path and keep the delete only for the fresh-PR path.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
