### PR TITLE
web: set Allow header on lifecycle method validation

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -594,10 +594,12 @@ func New(logger *slog.Logger, o *Options) *Handler {
 		router.Put("/-/reload", forbiddenAPINotEnabled)
 	}
 	router.Get("/-/quit", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Allow", "POST, PUT")
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		w.Write([]byte("Only POST or PUT requests allowed"))
 	})
 	router.Get("/-/reload", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Allow", "POST, PUT")
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		w.Write([]byte("Only POST or PUT requests allowed"))
 	})

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -207,6 +207,55 @@ func TestReadyAndHealthy(t *testing.T) {
 	cleanupTestResponse(t, resp)
 }
 
+func TestLifecycleMethodNotAllowedSetsAllowHeader(t *testing.T) {
+	t.Parallel()
+
+	port := fmt.Sprintf(":%d", testutil.RandomUnprivilegedPort(t))
+
+	opts := &Options{
+		ListenAddresses: []string{port},
+		MaxConnections:  512,
+		EnableLifecycle: true,
+		RoutePrefix:     "/",
+		ExternalURL: &url.URL{
+			Scheme: "http",
+			Host:   "localhost" + port,
+			Path:   "/",
+		},
+	}
+
+	webHandler := New(nil, opts)
+	webHandler.config = &config.Config{}
+	webHandler.notifier = &notifier.Manager{}
+	l, err := webHandler.Listeners()
+	if err != nil {
+		panic(fmt.Sprintf("Unable to start web listeners: %s", err))
+	}
+
+	ctx := t.Context()
+	go func() {
+		err := webHandler.Run(ctx, l, "")
+		if err != nil {
+			panic(fmt.Sprintf("Can't start web handler:%s", err))
+		}
+	}()
+
+	baseURL := "http://localhost" + port
+
+	waitForServerReady(t, baseURL, 5*time.Second)
+
+	for _, path := range []string{"/-/quit", "/-/reload"} {
+		resp, err := http.Get(baseURL + path)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+		require.Equal(t, "POST, PUT", resp.Header.Get("Allow"))
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "Only POST or PUT requests allowed", strings.TrimSpace(string(body)))
+		cleanupTestResponse(t, resp)
+	}
+}
+
 func TestRoutePrefix(t *testing.T) {
 	t.Parallel()
 	dbDir := t.TempDir()


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
N/A — no existing issue tracked this; found during review of `web/web.go` lifecycle endpoint handling.

#### Release notes for end users (**ALL** commits must be considered).
```release-notes
[ENHANCEMENT] Web: Add `Allow` header to `405 Method Not Allowed` responses on `/-/quit` and `/-/reload`.
```

## Summary

`GET` requests to `/-/quit` and `/-/reload` return `405 Method Not Allowed`, but the response does not include an `Allow` header indicating which methods are accepted. Per HTTP semantics (RFC 9110 §15.5.6), a 405 response should include an `Allow` header listing the supported methods.

## Changes

- Added `Allow: POST, PUT` to the `405` responses for `GET /-/quit` and `GET /-/reload`.
- Added `TestLifecycleMethodNotAllowedSetsAllowHeader`, verifying status code, `Allow` header, and unchanged response body for both endpoints.