### PR TITLE
Fix outdated contributor label docs and improve rule group heading contrast

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Prometheus uses GitHub to manage reviews of pull requests.
 
 Should you wish to work on an issue, please claim it first by commenting on the GitHub issue that you want to work on it. This is to prevent duplicated efforts from contributors on the same issue.
 
-Please check the [`low-hanging-fruit`](https://github.com/prometheus/prometheus/issues?q=is%3Aissue+is%3Aopen+label%3A%22low+hanging+fruit%22) label to find issues that are good for getting started. If you have questions about one of the issues, with or without the tag, please comment on them and one of the maintainers will clarify it. For a quicker response, contact us over [IRC](https://prometheus.io/community).
+Please check the [`good first issue`](https://github.com/prometheus/prometheus/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and [`help wanted`](https://github.com/prometheus/prometheus/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels to find issues that are good for getting started. If you have questions about one of the issues, with or without these labels, please comment on them and one of the maintainers will clarify it. For a quicker response, contact us over [IRC](https://prometheus.io/community).
 
 You can [spin up a prebuilt dev environment](https://gitpod.io/#https://github.com/prometheus/prometheus) using Gitpod.io.
 

--- a/web/ui/mantine-ui/src/GroupName.module.css
+++ b/web/ui/mantine-ui/src/GroupName.module.css
@@ -1,0 +1,4 @@
+.groupName {
+  /* Use lighter blue in dark mode to meet WCAG 2.1 AA contrast (4.5:1) on dark backgrounds. */
+  color: light-dark(var(--mantine-color-blue-8), var(--mantine-color-blue-3));
+}

--- a/web/ui/mantine-ui/src/pages/AlertsPage.tsx
+++ b/web/ui/mantine-ui/src/pages/AlertsPage.tsx
@@ -41,6 +41,7 @@ import { KVSearch } from "@nexucis/kvsearch";
 import { inputIconStyle } from "../styles";
 import CustomInfiniteScroll from "../components/CustomInfiniteScroll";
 import classes from "./AlertsPage.module.css";
+import groupNameClasses from "../GroupName.module.css";
 
 type AlertsPageData = {
   // How many rules are in each state across all groups.
@@ -232,7 +233,7 @@ export default function AlertsPage() {
         <Card shadow="xs" withBorder p="md" key={`${g.file}-${g.name}`}>
           <Group mb="sm" justify="space-between">
             <Group align="baseline">
-              <Text fz="xl" fw={600} c="var(--mantine-primary-color-filled)">
+              <Text fz="xl" fw={600} className={groupNameClasses.groupName}>
                 {g.name}
               </Text>
               <Text fz="sm" c="gray.6">

--- a/web/ui/mantine-ui/src/pages/RulesPage.tsx
+++ b/web/ui/mantine-ui/src/pages/RulesPage.tsx
@@ -34,6 +34,7 @@ import {
 import { useSuspenseAPIQuery } from "../api/api";
 import { Rule, RuleGroup, RulesResult } from "../api/responseTypes/rules";
 import badgeClasses from "../Badge.module.css";
+import groupNameClasses from "../GroupName.module.css";
 import RuleDefinition from "../components/RuleDefinition";
 import { badgeIconStyle, inputIconStyle } from "../styles";
 import {
@@ -168,7 +169,7 @@ export default function RulesPage() {
         <Card shadow="xs" withBorder p="md" key={`${g.file}-${g.name}`}>
           <Group mb="sm" justify="space-between">
             <Group align="baseline">
-              <Text fz="xl" fw={600} c="var(--mantine-primary-color-filled)">
+              <Text fz="xl" fw={600} className={groupNameClasses.groupName}>
                 {g.name}
               </Text>
               <Text fz="sm" c="gray.6">


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #19070
Fixes #18776

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] UI: Improve rule group heading contrast in dark mode on Alerts and Rules pages.
```

## Summary

- Update `CONTRIBUTING.md` to reference the existing `good first issue` and `help wanted` labels instead of the removed `low-hanging-fruit` label (#19070).
- Improve WCAG 2.1 AA contrast for rule group headings on the Alerts and Rules pages by using a lighter blue in dark mode (#18776).

## Test plan

- [x] Verified `CONTRIBUTING.md` links point to issues with the correct labels.
- [ ] Manually checked Alerts and Rules pages in dark mode to confirm rule group headings have sufficient contrast.
- [ ] Manually checked Alerts and Rules pages in light mode to confirm headings still look correct.