### PR TITLE
docs: update contributor issue labels in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Prometheus uses GitHub to manage reviews of pull requests.
 
 Should you wish to work on an issue, please claim it first by commenting on the GitHub issue that you want to work on it. This is to prevent duplicated efforts from contributors on the same issue.
 
-Please check the [`low-hanging-fruit`](https://github.com/prometheus/prometheus/issues?q=is%3Aissue+is%3Aopen+label%3A%22low+hanging+fruit%22) label to find issues that are good for getting started. If you have questions about one of the issues, with or without the tag, please comment on them and one of the maintainers will clarify it. For a quicker response, contact us over [IRC](https://prometheus.io/community).
+Please check the [`good first issue`](https://github.com/prometheus/prometheus/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and [`help wanted`](https://github.com/prometheus/prometheus/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels to find issues that are good for getting started. If you have questions about one of the issues, with or without these labels, please comment on them and one of the maintainers will clarify it. For a quicker response, contact us over [IRC](https://prometheus.io/community).
 
 You can [spin up a prebuilt dev environment](https://gitpod.io/#https://github.com/prometheus/prometheus) using Gitpod.io.
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #19070

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```

## Summary

Update `CONTRIBUTING.md` to reference the existing `good first issue` and `help wanted` labels instead of the removed `low-hanging-fruit` label.

## Test plan

- [x] Verified `CONTRIBUTING.md` links point to issues with the correct labels.