### PR TITLE
promql: avoid SIGBUS by explicitly allocating active query log file

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -963,12 +963,18 @@ func main() {
 	)
 
 	if !agentMode {
+		activeQueryTracker, err := promql.NewActiveQueryTracker(localStoragePath, cfg.queryConcurrency, logger.With("component", "activeQueryTracker"))
+		if err != nil {
+			logger.Error("failed to initialize active query tracker", "err", err)
+			os.Exit(1)
+		}
+
 		opts := promql.EngineOpts{
 			Logger:                   logger.With("component", "query engine"),
 			Reg:                      prometheus.DefaultRegisterer,
 			MaxSamples:               cfg.queryMaxSamples,
 			Timeout:                  time.Duration(cfg.queryTimeout),
-			ActiveQueryTracker:       promql.NewActiveQueryTracker(localStoragePath, cfg.queryConcurrency, logger.With("component", "activeQueryTracker")),
+			ActiveQueryTracker:       activeQueryTracker,
 			LookbackDelta:            time.Duration(cfg.lookbackDelta),
 			NoStepSubqueryIntervalFn: noStepSubqueryInterval.Get,
 			// EnableAtModifier and EnableNegativeOffset have to be

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -58,7 +58,8 @@ func TestMain(m *testing.M) {
 func TestQueryConcurrency(t *testing.T) {
 	maxConcurrency := 10
 
-	queryTracker := promql.NewActiveQueryTracker(t.TempDir(), maxConcurrency, nil)
+	queryTracker, err := promql.NewActiveQueryTracker(t.TempDir(), maxConcurrency, nil)
+	require.NoError(t, err)
 	opts := promql.EngineOpts{
 		Logger:             nil,
 		Reg:                nil,

--- a/promql/query_logger.go
+++ b/promql/query_logger.go
@@ -62,6 +62,31 @@ func parseBrokenJSON(brokenJSON []byte) (string, bool) {
 	return queries, true
 }
 
+type syncWriter interface {
+	io.Writer
+	Sync() error
+}
+
+func allocateQueryLogFile(file syncWriter, filesize int) error {
+	zeroes := make([]byte, min(filesize, 32*1024))
+	remaining := filesize
+	for remaining > 0 {
+		writeBytes := zeroes
+		if remaining < len(writeBytes) {
+			writeBytes = writeBytes[:remaining]
+		}
+		n, err := file.Write(writeBytes)
+		if err != nil {
+			return err
+		}
+		if n != len(writeBytes) {
+			return io.ErrShortWrite
+		}
+		remaining -= n
+	}
+	return file.Sync()
+}
+
 func logUnfinishedQueries(filename string, filesize int, logger *slog.Logger) {
 	if _, err := os.Stat(filename); err == nil {
 		fd, err := os.Open(filename)
@@ -114,10 +139,9 @@ func getMMappedFile(filename string, filesize int, logger *slog.Logger) ([]byte,
 		return nil, nil, err
 	}
 
-	err = file.Truncate(int64(filesize))
-	if err != nil {
+	if err := allocateQueryLogFile(file, filesize); err != nil {
 		file.Close()
-		logger.Error("Error setting filesize.", "filesize", filesize, "err", err)
+		logger.Error("Error allocating query log file.", "filesize", filesize, "err", err)
 		return nil, nil, err
 	}
 
@@ -131,10 +155,11 @@ func getMMappedFile(filename string, filesize int, logger *slog.Logger) ([]byte,
 	return fileAsBytes, &mmappedFile{f: file, m: fileAsBytes}, err
 }
 
-func NewActiveQueryTracker(localStoragePath string, maxConcurrent int, logger *slog.Logger) *ActiveQueryTracker {
+func NewActiveQueryTracker(localStoragePath string, maxConcurrent int, logger *slog.Logger) (*ActiveQueryTracker, error) {
 	err := os.MkdirAll(localStoragePath, 0o777)
 	if err != nil {
 		logger.Error("Failed to create directory for logging active queries")
+		return nil, fmt.Errorf("create active query log directory: %w", err)
 	}
 
 	filename, filesize := filepath.Join(localStoragePath, "queries.active"), 1+maxConcurrent*entrySize
@@ -142,7 +167,7 @@ func NewActiveQueryTracker(localStoragePath string, maxConcurrent int, logger *s
 
 	fileAsBytes, closer, err := getMMappedFile(filename, filesize, logger)
 	if err != nil {
-		panic("Unable to create mmap-ed active query log")
+		return nil, fmt.Errorf("create mmap-ed active query log: %w", err)
 	}
 
 	copy(fileAsBytes, "[")
@@ -156,7 +181,7 @@ func NewActiveQueryTracker(localStoragePath string, maxConcurrent int, logger *s
 
 	activeQueryTracker.generateIndices(maxConcurrent)
 
-	return &activeQueryTracker
+	return &activeQueryTracker, nil
 }
 
 func trimStringByBytes(str string, size int) string {

--- a/promql/query_logger.go
+++ b/promql/query_logger.go
@@ -158,7 +158,7 @@ func getMMappedFile(filename string, filesize int, logger *slog.Logger) ([]byte,
 func NewActiveQueryTracker(localStoragePath string, maxConcurrent int, logger *slog.Logger) (*ActiveQueryTracker, error) {
 	err := os.MkdirAll(localStoragePath, 0o777)
 	if err != nil {
-		logger.Error("Failed to create directory for logging active queries")
+		logger.Error("Failed to create directory for logging active queries", "err", err)
 		return nil, fmt.Errorf("create active query log directory: %w", err)
 	}
 

--- a/promql/query_logger_test.go
+++ b/promql/query_logger_test.go
@@ -184,7 +184,7 @@ func TestNewActiveQueryTrackerReturnsError(t *testing.T) {
 	localStoragePath := filepath.Join(t.TempDir(), "not-a-directory")
 	require.NoError(t, os.WriteFile(localStoragePath, nil, 0o666))
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	queryLogger, err := NewActiveQueryTracker(localStoragePath, 1, logger)
 	require.Error(t, err)
 	require.Nil(t, queryLogger)

--- a/promql/query_logger_test.go
+++ b/promql/query_logger_test.go
@@ -15,6 +15,8 @@ package promql
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,6 +24,42 @@ import (
 	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 )
+
+type queryLogWriter struct {
+	written int
+	err     error
+}
+
+func (w *queryLogWriter) Write(p []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	w.written += len(p)
+	return len(p), nil
+}
+
+func (*queryLogWriter) Sync() error {
+	return nil
+}
+
+type shortQueryLogWriter struct{}
+
+func (*shortQueryLogWriter) Write(p []byte) (int, error) {
+	return len(p) - 1, nil
+}
+
+func (*shortQueryLogWriter) Sync() error {
+	return nil
+}
+
+type syncErrorQueryLogWriter struct {
+	queryLogWriter
+	err error
+}
+
+func (w *syncErrorQueryLogWriter) Sync() error {
+	return w.err
+}
 
 func TestQueryLogging(t *testing.T) {
 	fileAsBytes := make([]byte, 4096)
@@ -125,6 +163,31 @@ func TestMMapFile(t *testing.T) {
 	require.NoError(t, err, "Unexpected error while reading file.")
 	require.Equal(t, 2, n)
 	require.Equal(t, []byte(data), bytes[:2], "Mmap failed")
+}
+
+func TestAllocateQueryLogFile(t *testing.T) {
+	writer := &queryLogWriter{}
+	require.NoError(t, allocateQueryLogFile(writer, 100_000))
+	require.Equal(t, 100_000, writer.written)
+}
+
+func TestAllocateQueryLogFileReturnsWriteErrors(t *testing.T) {
+	require.ErrorIs(t, allocateQueryLogFile(&queryLogWriter{err: os.ErrPermission}, 1), os.ErrPermission)
+	require.ErrorIs(t, allocateQueryLogFile(&shortQueryLogWriter{}, 1), io.ErrShortWrite)
+}
+
+func TestAllocateQueryLogFileReturnsSyncError(t *testing.T) {
+	require.ErrorIs(t, allocateQueryLogFile(&syncErrorQueryLogWriter{err: os.ErrPermission}, 1), os.ErrPermission)
+}
+
+func TestNewActiveQueryTrackerReturnsError(t *testing.T) {
+	localStoragePath := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(localStoragePath, nil, 0o666))
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	queryLogger, err := NewActiveQueryTracker(localStoragePath, 1, logger)
+	require.Error(t, err)
+	require.Nil(t, queryLogger)
 }
 
 func TestTrimStringByBytes(t *testing.T) {

--- a/promql/query_logger_test.go
+++ b/promql/query_logger_test.go
@@ -54,11 +54,11 @@ func (*shortQueryLogWriter) Sync() error {
 
 type syncErrorQueryLogWriter struct {
 	queryLogWriter
-	err error
+	syncErr error
 }
 
 func (w *syncErrorQueryLogWriter) Sync() error {
-	return w.err
+	return w.syncErr
 }
 
 func TestQueryLogging(t *testing.T) {
@@ -177,7 +177,7 @@ func TestAllocateQueryLogFileReturnsWriteErrors(t *testing.T) {
 }
 
 func TestAllocateQueryLogFileReturnsSyncError(t *testing.T) {
-	require.ErrorIs(t, allocateQueryLogFile(&syncErrorQueryLogWriter{err: os.ErrPermission}, 1), os.ErrPermission)
+	require.ErrorIs(t, allocateQueryLogFile(&syncErrorQueryLogWriter{syncErr: os.ErrPermission}, 1), os.ErrPermission)
 }
 
 func TestNewActiveQueryTrackerReturnsError(t *testing.T) {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #19017

#### What does this PR do?

This PR fixes a potential `SIGBUS` crash in the PromQL active query tracker when Prometheus is running on a full disk and follows the same approach as in #18633

The active query tracker uses a memory-mapped `queries.active` file. Previously, the file was sized with `file.Truncate`, which can create a sparse file on some filesystems. In that case, the operating system may accept the file size change without physically allocating the required disk space. If the disk later becomes full and Prometheus tries to write to it, the write can fail with `SIGBUS`.

This change, preallocates the active query tracker file by writing zeroes to it and syncing it before the file is memory-mapped. This makes the failure mode explicit and recoverable during startup or initialization : 

If the filesystem cannot provide the required space, Prometheus receives a normal error instead of later crashing with `SIGBUS` :
```
time=2026-06-30T14:29:20.396Z level=ERROR source=query_logger.go:144 msg="Error allocating query log file." component=activeQueryTracker filesize=20001 err="write /tmp/prom-data/queries.active: no space left on device"
time=2026-06-30T14:29:20.396Z level=ERROR source=main.go:968 msg="failed to initialize active query tracker" err="create mmap-ed active query log: write /tmp/prom-data/queries.active: no space left on device"
```
### Manual testing : 
Start prometheus -> It allocates the space using zeros -> fill the disk -> excecute 3-5 queries
Earlier it would result in SIGBUS after 2 queries :
```
[signal SIGBUS: bus error code=0x2 addr=0x79cb0d001388 pc=0x496906]
goroutine 700 gp=0x2d81b60c8960 m=5 mp=0x2d81b5600808 [running]:
runtime.throw({0x690e9a5?, 0x2d81b5acdb8c?})
        /usr/lib/go-1.26/src/runtime/panic.go:1229 +0x48 fp=0x2d81b64d27f8 sp=0x2d81b64d27c8 pc=0x48e288
```
after the fix it did not crash as the space was allocated for it before the disk was filled.

#### Release notes for end users (**ALL** commits must be considered).

*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] PromQL: Preallocate the active query tracker file to avoid SIGBUS crashes when the data disk is full.
```
