### PR TITLE
docs: explain how to verify node targets in getting started 

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -178,6 +178,26 @@ scrape_configs:
 Go to the expression browser and verify that Prometheus now has information
 about time series that these example endpoints expose, such as `node_cpu_seconds_total`.
 
+To check that Prometheus is scraping the new targets, go to
+[localhost:9090/targets](http://localhost:9090/targets), or open the **Status**
+menu and select **Target health**. Under the `node` job you should see the three
+endpoints, each with a state of `UP`. Following the configuration above,
+`localhost:8080` and `localhost:8081` are labeled `group="production"` and
+`localhost:8082` is labeled `group="canary"`. If an endpoint shows `DOWN`, make
+sure the corresponding Node Exporter is still running on that port.
+
+To confirm the metrics are available, enter `node_cpu_seconds_total` into the
+expression browser and click "Execute". This should return one time series per CPU
+and mode for each instance, for example:
+
+​```
+node_cpu_seconds_total{cpu="0",group="production",instance="localhost:8080",job="node",mode="idle"}
+​```
+
+To browse every metric name that is currently available, open the query options
+menu (the three-dots button to the right of the expression input) and select
+**Explore metrics**. 
+
 ## Configure rules for aggregating scraped data into new time series
 
 Though not a problem in our example, queries that aggregate over thousands of

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -186,9 +186,11 @@ endpoints, each with a state of `UP`. Following the configuration above,
 `localhost:8082` is labeled `group="canary"`. If an endpoint shows `DOWN`, make
 sure the corresponding Node Exporter is still running on that port.
 
-To confirm the metrics are available, enter `node_cpu_seconds_total` into the
-expression browser and click "Execute". This should return one time series per CPU
-and mode for each instance, for example:
+To confirm the metrics are available, first open a target's `/metrics` endpoint
+directly, for example [localhost:8080/metrics](http://localhost:8080/metrics), to
+see the raw metric names it exposes. Then enter one of them, such as 
+`node_cpu_seconds_total`, into the expression browser and click "Execute". This
+should return one time series per CPU and mode for each instance, for example:
 
 ​```
 node_cpu_seconds_total{cpu="0",group="production",instance="localhost:8080",job="node",mode="idle"}


### PR DESCRIPTION
Fixes #19091

The getting started guide says to "verify that Prometheus now has information about time series" from the node targets but doesn't explain how. This adds a short bit right after that line covering:

- checking the `node` job is `UP` under Status > Target health
- running `node_cpu_seconds_total` in the expression browser to confirm data is coming through
- using Explore metrics to see all available metrics

@metalmatze small docs change, would appreciate a review when you get a chance. Thanks!

```release-notes
NONE
```