### PR TITLE
web/api/v1: parallelize TestApiStatusCodes subtests

### DIFF
--- a/web/api/v1/errors_test.go
+++ b/web/api/v1/errors_test.go
@@ -43,6 +43,7 @@ import (
 )
 
 func TestApiStatusCodes(t *testing.T) {
+	t.Parallel()
 	for name, tc := range map[string]struct {
 		err               error
 		expectedString    string
@@ -107,6 +108,7 @@ func TestApiStatusCodes(t *testing.T) {
 			"error from seriesset": errorTestQueryable{q: errorTestQuerier{s: errorTestSeriesSet{err: tc.err}}},
 		} {
 			t.Run(fmt.Sprintf("%s/%s", name, k), func(t *testing.T) {
+				t.Parallel()
 				r := createPrometheusAPI(t, q, tc.overrideErrorCode)
 				rec := httptest.NewRecorder()
 


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
`TestApiStatusCodes` runs 21 independent subtests (7 error cases × 3 queryable variants). Each subtest builds its own API instance and HTTP request via `createPrometheusAPI`, with no shared mutable state between them, so they're safe to run with `t.Parallel()`

On my machine, with the race detector:

**Before:**
```
go test -race -count=1 -run TestApiStatusCodes ./web/api/v1/...
ok      github.com/prometheus/prometheus/web/api/v1     18.780s
```

**After:**
```
go test -race -count=1 -run TestApiStatusCodes ./web/api/v1/...
ok      github.com/prometheus/prometheus/web/api/v1     4.133s
```

Verified stable across repeated runs (`-count=3`) and with `go test -race ./web/api/v1/...` for the whole package.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Part of #15185

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
