### PR TITLE
tsdb: shard MemPostings writes safely

### DIFF
--- a/tsdb/head_postings_concurrency_test.go
+++ b/tsdb/head_postings_concurrency_test.go
@@ -120,7 +120,7 @@ func BenchmarkHeadInitialScrapeWithQueries(b *testing.B) {
 	const seriesPerScrape = 200
 
 	for _, queryers := range []int{0, 4} {
-		b.Run("queryers="+strconv.Itoa(queryers), func(b *testing.B) {
+		b.Run("queryers=" + strconv.Itoa(queryers), func(b *testing.B) {
 			opts := DefaultHeadOptions()
 			opts.ChunkRange = 1000
 			opts.ChunkDirRoot = b.TempDir()

--- a/tsdb/head_postings_concurrency_test.go
+++ b/tsdb/head_postings_concurrency_test.go
@@ -61,7 +61,7 @@ func TestHeadConcurrentSeriesCreationDoesNotExposePartialPostings(t *testing.T) 
 				default:
 				}
 
-				p, err := PostingsForMatchers(context.Background(), ir, early, lateMissing)
+				p, err := PostingsForMatchers(t.Context(), ir, early, lateMissing)
 				if err != nil {
 					reportPostingsLoadError(readerErr, err)
 					return
@@ -88,7 +88,7 @@ func TestHeadConcurrentSeriesCreationDoesNotExposePartialPostings(t *testing.T) 
 	for writer := range writerCount {
 		writers.Go(func() {
 			for scrape := range scrapesPerWriter {
-				app := h.Appender(context.Background())
+				app := h.Appender(t.Context())
 				for series := range seriesPerScrape {
 					lset := postingsLoadLabels(writer, scrape, series)
 					if _, err := app.Append(0, lset, int64(scrape), float64(series)); err != nil {
@@ -116,14 +116,11 @@ func TestHeadConcurrentSeriesCreationDoesNotExposePartialPostings(t *testing.T) 
 	}
 }
 
-// Run with a fixed iteration count when comparing branches, for example:
-//
-// go test ./tsdb -run '^$' -bench '^BenchmarkHeadInitialScrapeWithQueries$' -benchmem -benchtime=20x -count=6
 func BenchmarkHeadInitialScrapeWithQueries(b *testing.B) {
 	const seriesPerScrape = 200
 
 	for _, queryers := range []int{0, 4} {
-		b.Run(fmt.Sprintf("queryers=%d", queryers), func(b *testing.B) {
+		b.Run("queryers="+strconv.Itoa(queryers), func(b *testing.B) {
 			opts := DefaultHeadOptions()
 			opts.ChunkRange = 1000
 			opts.ChunkDirRoot = b.TempDir()
@@ -163,7 +160,7 @@ func BenchmarkHeadInitialScrapeWithQueries(b *testing.B) {
 							}
 							return
 						}
-						for p.Next() {
+						if p.Next() {
 							reportPostingsLoadError(queryErr, fmt.Errorf("series %d was visible before all of its postings were added", p.At()))
 							return
 						}

--- a/tsdb/head_postings_concurrency_test.go
+++ b/tsdb/head_postings_concurrency_test.go
@@ -216,14 +216,14 @@ func BenchmarkHeadInitialScrapeWithQueries(b *testing.B) {
 
 func postingsLoadLabels(writer, scrape, series int) labels.Labels {
 	return labels.FromStrings(
-		labels.MetricName, "postings_load_metric_"+strconv.Itoa(series%50),
+		labels.MetricName, "postings_load_metric_" + strconv.Itoa(series%50),
 		"cluster", "test",
 		"early", "present",
-		"instance", "target-"+strconv.Itoa(writer),
+		"instance", "target-" + strconv.Itoa(writer),
 		"job", "postings-load",
 		"late", "present",
-		"namespace", "namespace-"+strconv.Itoa(series%20),
-		"pod", "pod-"+strconv.Itoa(scrape)+"-"+strconv.Itoa(series),
+		"namespace", "namespace-" + strconv.Itoa(series%20),
+		"pod", "pod-" + strconv.Itoa(scrape) + "-" + strconv.Itoa(series),
 		"scrape", strconv.Itoa(scrape),
 		"series", strconv.Itoa(series),
 	)

--- a/tsdb/head_postings_concurrency_test.go
+++ b/tsdb/head_postings_concurrency_test.go
@@ -79,9 +79,9 @@ func TestHeadConcurrentSeriesCreationDoesNotExposePartialPostings(t *testing.T) 
 	}
 
 	const (
-		writerCount      = 8
-		scrapesPerWriter = 20
-		seriesPerScrape  = 200
+		writerCount      = 4
+		scrapesPerWriter = 10
+		seriesPerScrape  = 100
 	)
 
 	var writers sync.WaitGroup
@@ -137,6 +137,7 @@ func BenchmarkHeadInitialScrapeWithQueries(b *testing.B) {
 			ctx, cancel := context.WithCancel(b.Context())
 			defer cancel()
 
+			startQueries := make(chan struct{})
 			var queryCount atomic.Uint64
 			queryErr := make(chan error, 1)
 			var readers sync.WaitGroup
@@ -153,6 +154,7 @@ func BenchmarkHeadInitialScrapeWithQueries(b *testing.B) {
 						}
 					}()
 
+					<-startQueries
 					for ctx.Err() == nil {
 						p, err := PostingsForMatchers(ctx, ir, early, lateMissing)
 						if err != nil {
@@ -177,6 +179,7 @@ func BenchmarkHeadInitialScrapeWithQueries(b *testing.B) {
 			var nextScrape atomic.Uint64
 			b.ReportAllocs()
 			b.ResetTimer()
+			close(startQueries)
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					scrape := nextScrape.Inc()

--- a/tsdb/head_postings_concurrency_test.go
+++ b/tsdb/head_postings_concurrency_test.go
@@ -1,0 +1,237 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestHeadConcurrentSeriesCreationDoesNotExposePartialPostings(t *testing.T) {
+	opts := DefaultHeadOptions()
+	opts.ChunkRange = 1000
+	opts.ChunkDirRoot = t.TempDir()
+
+	h, err := NewHead(nil, nil, nil, nil, opts, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, h.Close()) })
+
+	early := labels.MustNewMatcher(labels.MatchEqual, "early", "present")
+	lateMissing := labels.MustNewMatcher(labels.MatchNotEqual, "late", "present")
+
+	stopReaders := make(chan struct{})
+	readerErr := make(chan error, 1)
+	var readers sync.WaitGroup
+	for range 4 {
+		readers.Go(func() {
+			ir, err := h.Index()
+			if err != nil {
+				reportPostingsLoadError(readerErr, err)
+				return
+			}
+			defer func() {
+				if err := ir.Close(); err != nil {
+					reportPostingsLoadError(readerErr, err)
+				}
+			}()
+
+			for {
+				select {
+				case <-stopReaders:
+					return
+				default:
+				}
+
+				p, err := PostingsForMatchers(context.Background(), ir, early, lateMissing)
+				if err != nil {
+					reportPostingsLoadError(readerErr, err)
+					return
+				}
+				if p.Next() {
+					reportPostingsLoadError(readerErr, fmt.Errorf("series %d was visible before all of its postings were added", p.At()))
+					return
+				}
+				if err := p.Err(); err != nil {
+					reportPostingsLoadError(readerErr, err)
+					return
+				}
+			}
+		})
+	}
+
+	const (
+		writerCount      = 8
+		scrapesPerWriter = 20
+		seriesPerScrape  = 200
+	)
+
+	var writers sync.WaitGroup
+	for writer := range writerCount {
+		writers.Go(func() {
+			for scrape := range scrapesPerWriter {
+				app := h.Appender(context.Background())
+				for series := range seriesPerScrape {
+					lset := postingsLoadLabels(writer, scrape, series)
+					if _, err := app.Append(0, lset, int64(scrape), float64(series)); err != nil {
+						reportPostingsLoadError(readerErr, err)
+						_ = app.Rollback()
+						return
+					}
+				}
+				if err := app.Commit(); err != nil {
+					reportPostingsLoadError(readerErr, err)
+					return
+				}
+			}
+		})
+	}
+
+	writers.Wait()
+	close(stopReaders)
+	readers.Wait()
+
+	select {
+	case err := <-readerErr:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+// Run with a fixed iteration count when comparing branches, for example:
+//
+// go test ./tsdb -run '^$' -bench '^BenchmarkHeadInitialScrapeWithQueries$' -benchmem -benchtime=20x -count=6
+func BenchmarkHeadInitialScrapeWithQueries(b *testing.B) {
+	const seriesPerScrape = 200
+
+	for _, queryers := range []int{0, 4} {
+		b.Run(fmt.Sprintf("queryers=%d", queryers), func(b *testing.B) {
+			opts := DefaultHeadOptions()
+			opts.ChunkRange = 1000
+			opts.ChunkDirRoot = b.TempDir()
+
+			h, err := NewHead(nil, nil, nil, nil, opts, nil)
+			require.NoError(b, err)
+			defer func() { require.NoError(b, h.Close()) }()
+
+			early := labels.MustNewMatcher(labels.MatchEqual, "early", "present")
+			lateMissing := labels.MustNewMatcher(labels.MatchNotEqual, "late", "present")
+			ctx, cancel := context.WithCancel(b.Context())
+			defer cancel()
+
+			var queryCount atomic.Uint64
+			queryErr := make(chan error, 1)
+			var readers sync.WaitGroup
+			for range queryers {
+				readers.Go(func() {
+					ir, err := h.Index()
+					if err != nil {
+						reportPostingsLoadError(queryErr, err)
+						return
+					}
+					defer func() {
+						if err := ir.Close(); err != nil {
+							reportPostingsLoadError(queryErr, err)
+						}
+					}()
+
+					for ctx.Err() == nil {
+						p, err := PostingsForMatchers(ctx, ir, early, lateMissing)
+						if err != nil {
+							if ctx.Err() == nil {
+								reportPostingsLoadError(queryErr, err)
+							}
+							return
+						}
+						for p.Next() {
+							reportPostingsLoadError(queryErr, fmt.Errorf("series %d was visible before all of its postings were added", p.At()))
+							return
+						}
+						if err := p.Err(); err != nil {
+							reportPostingsLoadError(queryErr, err)
+							return
+						}
+						queryCount.Inc()
+					}
+				})
+			}
+
+			var nextScrape atomic.Uint64
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					scrape := nextScrape.Inc()
+					app := h.Appender(ctx)
+					for series := range seriesPerScrape {
+						lset := postingsLoadLabels(int(scrape%100), int(scrape), series)
+						if _, err := app.Append(0, lset, int64(scrape), float64(series)); err != nil {
+							b.Errorf("append: %v", err)
+							_ = app.Rollback()
+							return
+						}
+					}
+					if err := app.Commit(); err != nil {
+						b.Errorf("commit: %v", err)
+						return
+					}
+				}
+			})
+			b.StopTimer()
+
+			cancel()
+			readers.Wait()
+			select {
+			case err := <-queryErr:
+				require.NoError(b, err)
+			default:
+			}
+
+			seconds := b.Elapsed().Seconds()
+			if seconds > 0 {
+				b.ReportMetric(float64(b.N*seriesPerScrape)/seconds, "series/s")
+				b.ReportMetric(float64(queryCount.Load())/seconds, "queries/s")
+			}
+		})
+	}
+}
+
+func postingsLoadLabels(writer, scrape, series int) labels.Labels {
+	return labels.FromStrings(
+		labels.MetricName, "postings_load_metric_"+strconv.Itoa(series%50),
+		"cluster", "test",
+		"early", "present",
+		"instance", "target-"+strconv.Itoa(writer),
+		"job", "postings-load",
+		"late", "present",
+		"namespace", "namespace-"+strconv.Itoa(series%20),
+		"pod", "pod-"+strconv.Itoa(scrape)+"-"+strconv.Itoa(series),
+		"scrape", strconv.Itoa(scrape),
+		"series", strconv.Itoa(series),
+	)
+}
+
+func reportPostingsLoadError(ch chan<- error, err error) {
+	select {
+	case ch <- err:
+	default:
+	}
+}

--- a/tsdb/head_postings_concurrency_test.go
+++ b/tsdb/head_postings_concurrency_test.go
@@ -120,7 +120,7 @@ func BenchmarkHeadInitialScrapeWithQueries(b *testing.B) {
 	const seriesPerScrape = 200
 
 	for _, queryers := range []int{0, 4} {
-		b.Run("queryers=" + strconv.Itoa(queryers), func(b *testing.B) {
+		b.Run("queryers="+strconv.Itoa(queryers), func(b *testing.B) {
 			opts := DefaultHeadOptions()
 			opts.ChunkRange = 1000
 			opts.ChunkDirRoot = b.TempDir()
@@ -216,14 +216,14 @@ func BenchmarkHeadInitialScrapeWithQueries(b *testing.B) {
 
 func postingsLoadLabels(writer, scrape, series int) labels.Labels {
 	return labels.FromStrings(
-		labels.MetricName, "postings_load_metric_" + strconv.Itoa(series%50),
+		labels.MetricName, "postings_load_metric_"+strconv.Itoa(series%50),
 		"cluster", "test",
 		"early", "present",
-		"instance", "target-" + strconv.Itoa(writer),
+		"instance", "target-"+strconv.Itoa(writer),
 		"job", "postings-load",
 		"late", "present",
-		"namespace", "namespace-" + strconv.Itoa(series%20),
-		"pod", "pod-" + strconv.Itoa(scrape) + "-" + strconv.Itoa(series),
+		"namespace", "namespace-"+strconv.Itoa(series%20),
+		"pod", "pod-"+strconv.Itoa(scrape)+"-"+strconv.Itoa(series),
 		"scrape", strconv.Itoa(scrape),
 		"series", strconv.Itoa(series),
 	)

--- a/tsdb/head_postings_concurrency_test.go
+++ b/tsdb/head_postings_concurrency_test.go
@@ -34,6 +34,7 @@ func TestHeadConcurrentSeriesCreationDoesNotExposePartialPostings(t *testing.T) 
 	h, err := NewHead(nil, nil, nil, nil, opts, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, h.Close()) })
+	require.NoError(t, h.Init(0))
 
 	early := labels.MustNewMatcher(labels.MatchEqual, "early", "present")
 	lateMissing := labels.MustNewMatcher(labels.MatchNotEqual, "late", "present")
@@ -128,6 +129,7 @@ func BenchmarkHeadInitialScrapeWithQueries(b *testing.B) {
 			h, err := NewHead(nil, nil, nil, nil, opts, nil)
 			require.NoError(b, err)
 			defer func() { require.NoError(b, h.Close()) }()
+			require.NoError(b, h.Init(0))
 
 			early := labels.MustNewMatcher(labels.MatchEqual, "early", "present")
 			lateMissing := labels.MustNewMatcher(labels.MatchNotEqual, "late", "present")

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/bboreham/go-loser"
 	"github.com/cespare/xxhash/v2"
@@ -53,106 +52,6 @@ var ensureOrderBatchPool = sync.Pool{
 	},
 }
 
-// postingsPhaseGate separates MemPostings operations into add, read, and
-// exclusive phases. A phase is the part of an operation that observes or
-// publishes postings state across shards. The gate does not replace shard
-// locks; shard locks still protect shard-local maps and slices.
-//
-// The gate keeps read snapshots out of the middle of a multi-label Add. A
-// reader may see the postings before an Add or after it, but not after only
-// some label pairs for that series have been published. Waiting readers block
-// new adders so an active Add phase can drain. Exclusive waiters block new
-// readers and adders so Delete and EnsureOrder do not starve.
-type postingsPhaseGate struct {
-	mtx              sync.Mutex
-	cond             *sync.Cond
-	activeAdds       int
-	activeReads      int
-	readWaiters      int
-	exclusiveActive  bool
-	exclusiveWaiters int
-}
-
-func (g *postingsPhaseGate) init() {
-	g.cond = sync.NewCond(&g.mtx)
-}
-
-// beginAdd waits until there are no active reads or exclusive operations. It
-// also waits behind pending readers and exclusive operations so the current
-// phase can drain.
-func (g *postingsPhaseGate) beginAdd() {
-	g.mtx.Lock()
-	defer g.mtx.Unlock()
-	for g.activeReads > 0 || g.readWaiters > 0 || g.exclusiveActive || g.exclusiveWaiters > 0 {
-		g.cond.Wait()
-	}
-	g.activeAdds++
-}
-
-func (g *postingsPhaseGate) endAdd() {
-	g.mtx.Lock()
-	g.activeAdds--
-	if g.activeAdds == 0 {
-		g.cond.Broadcast()
-	}
-	g.mtx.Unlock()
-}
-
-// beginRead waits for active Adds because a read can snapshot multiple shards
-// and label-value metadata. It registers as a waiter before blocking so later
-// Adds cannot keep extending the active Add phase. Pending exclusive operations
-// retain priority over waiting readers.
-func (g *postingsPhaseGate) beginRead() {
-	g.mtx.Lock()
-	defer g.mtx.Unlock()
-	g.readWaiters++
-	defer func() { g.readWaiters-- }()
-	for g.activeAdds > 0 || g.exclusiveActive || g.exclusiveWaiters > 0 {
-		g.cond.Wait()
-	}
-	g.activeReads++
-}
-
-func (g *postingsPhaseGate) endRead() {
-	g.mtx.Lock()
-	g.activeReads--
-	if g.activeReads == 0 {
-		g.cond.Broadcast()
-	}
-	g.mtx.Unlock()
-}
-
-// beginExclusive is used by Delete and EnsureOrder. It marks an exclusive
-// waiter before waiting so new Adds and reads do not enter, then waits for
-// current Adds, reads, and any active exclusive operation to finish.
-func (g *postingsPhaseGate) beginExclusive() {
-	g.mtx.Lock()
-	defer g.mtx.Unlock()
-	g.exclusiveWaiters++
-	defer func() { g.exclusiveWaiters-- }()
-	for g.activeAdds > 0 || g.activeReads > 0 || g.exclusiveActive {
-		g.cond.Wait()
-	}
-	g.exclusiveActive = true
-}
-
-func (g *postingsPhaseGate) endExclusive() {
-	g.mtx.Lock()
-	g.exclusiveActive = false
-	g.cond.Broadcast()
-	g.mtx.Unlock()
-}
-
-// yieldExclusive briefly drops the exclusive phase during long Delete work.
-// Readers and adders that are blocked on the gate can run between batches.
-// beginExclusive is called again afterwards, so later readers and adders queue
-// behind the Delete instead of starving it.
-func (g *postingsPhaseGate) yieldExclusive() {
-	g.endExclusive()
-	time.Sleep(time.Millisecond)
-	g.beginExclusive()
-}
-
 const memPostingsShardCount = 256
 
 type memPostingsShard struct {
@@ -167,14 +66,11 @@ type memPostingsShard struct {
 // EnsureOrder() must be called once before any reads are done. This allows for quick
 // unordered batch fills on startup.
 type MemPostings struct {
-	gate postingsPhaseGate
+	gate postingsGate
 
-	// shards holds the postings lists for each label-value pair.
 	shards [memPostingsShardCount]memPostingsShard
 
-	// lvs holds all known values for each label name. It lets label-value
-	// queries avoid scanning every shard to discover values. Add updates lvs
-	// while readers are excluded by the phase gate.
+	// lvs indexes known values by label name.
 	lvsMtx sync.RWMutex
 	lvs    map[string][]string
 
@@ -225,8 +121,8 @@ func (p *MemPostings) shard(name, value string) *memPostingsShard {
 
 // Symbols returns an iterator over all unique name and value strings, in order.
 func (p *MemPostings) Symbols() StringIter {
-	p.gate.beginRead()
-	defer p.gate.endRead()
+	p.gate.enterRead()
+	defer p.gate.leaveRead()
 
 	// Add all the strings to a map to de-duplicate.
 	symbols := make(map[string]struct{}, defaultLabelNamesMapSize)
@@ -250,8 +146,8 @@ func (p *MemPostings) Symbols() StringIter {
 
 // SortedKeys returns a list of sorted label keys of the postings.
 func (p *MemPostings) SortedKeys() []labels.Label {
-	p.gate.beginRead()
-	defer p.gate.endRead()
+	p.gate.enterRead()
+	defer p.gate.leaveRead()
 
 	keys := make([]labels.Label, 0, defaultLabelNamesMapSize)
 	for i := range p.shards {
@@ -279,8 +175,8 @@ func (p *MemPostings) SortedKeys() []labels.Label {
 
 // LabelNames returns all the unique label names.
 func (p *MemPostings) LabelNames() []string {
-	p.gate.beginRead()
-	defer p.gate.endRead()
+	p.gate.enterRead()
+	defer p.gate.leaveRead()
 
 	p.lvsMtx.RLock()
 	defer p.lvsMtx.RUnlock()
@@ -296,8 +192,8 @@ func (p *MemPostings) LabelNames() []string {
 
 // LabelValues returns label values for the given name.
 func (p *MemPostings) LabelValues(_ context.Context, name string, hints *storage.LabelHints) []string {
-	p.gate.beginRead()
-	defer p.gate.endRead()
+	p.gate.enterRead()
+	defer p.gate.leaveRead()
 
 	p.lvsMtx.RLock()
 	values := p.lvs[name]
@@ -321,8 +217,8 @@ type PostingsStats struct {
 // Stats calculates the cardinality statistics from postings.
 // Caller can pass in a function which computes the space required for n series with a given label.
 func (p *MemPostings) Stats(label string, limit int, labelSizeFunc func(string, string, uint64) uint64) *PostingsStats {
-	p.gate.beginRead()
-	defer p.gate.endRead()
+	p.gate.enterRead()
+	defer p.gate.leaveRead()
 
 	metrics := &maxHeap{}
 	labelStats := &maxHeap{}
@@ -385,8 +281,8 @@ func (p *MemPostings) All() Postings {
 // CPU cores used for this operation. If it is <= 0, GOMAXPROCS is used.
 // GOMAXPROCS was the default before introducing this parameter.
 func (p *MemPostings) EnsureOrder(numberOfConcurrentProcesses int) {
-	p.gate.beginExclusive()
-	defer p.gate.endExclusive()
+	p.gate.enterExclusive()
+	defer p.gate.leaveExclusive()
 
 	if p.ordered {
 		return
@@ -444,8 +340,7 @@ func (p *MemPostings) EnsureOrder(numberOfConcurrentProcesses int) {
 	p.ordered = true
 }
 
-// enableSharding moves replay-built postings into the live shards without
-// copying the postings lists. The caller must hold the exclusive phase.
+// enableSharding moves replay-built postings into the live shards.
 func (p *MemPostings) enableSharding() {
 	if p.sharded {
 		return
@@ -479,8 +374,8 @@ func (p *MemPostings) enableSharding() {
 // Delete removes all ids in the given map from the postings lists.
 // affectedLabels contains all the labels that are affected by the deletion, there's no need to check other labels.
 func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected map[labels.Label]struct{}) {
-	p.gate.beginExclusive()
-	defer p.gate.endExclusive()
+	p.gate.enterExclusive()
+	defer p.gate.leaveExclusive()
 
 	affectedLabelNames := map[string]struct{}{}
 	process := func(l labels.Label) {
@@ -512,7 +407,7 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 		i++
 		process(l)
 
-		// From time to time we want some readers to go through and read their postings.
+		// Let blocked operations run between batches.
 		if i%512 == 0 {
 			p.gate.yieldExclusive()
 		}
@@ -549,8 +444,8 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 
 // Iter calls f for each postings list. It aborts if f returns an error and returns it.
 func (p *MemPostings) Iter(f func(labels.Label, Postings) error) error {
-	p.gate.beginRead()
-	defer p.gate.endRead()
+	p.gate.enterRead()
+	defer p.gate.leaveRead()
 
 	for i := range p.shards {
 		shard := &p.shards[i]
@@ -568,13 +463,10 @@ func (p *MemPostings) Iter(f func(labels.Label, Postings) error) error {
 	return nil
 }
 
-// Add a label set to the postings index. The whole label set, including the
-// all-postings entry, is published in one Add phase. This keeps readers from
-// observing a series through one label matcher but not another matcher from the
-// same label set.
+// Add inserts a series into every postings list before allowing reads to continue.
 func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
-	p.gate.beginAdd()
-	defer p.gate.endAdd()
+	p.gate.enterAdd()
+	defer p.gate.leaveAdd()
 
 	lset.Range(func(l labels.Label) {
 		p.addFor(id, l)
@@ -626,7 +518,7 @@ func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
 	nm[l.Value] = list
 }
 
-func sameStringSliceData(a, b []string) bool {
+func sameStringSliceBackingArray(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -655,9 +547,6 @@ func (p *MemPostings) valueIndexesByShard(name string, values []string) ([]int, 
 	return valueIndexes, offsets
 }
 
-// postingsForLabelValues assumes the caller is in a read phase. Shard locks
-// protect shard-local postings, and the read phase protects the cross-shard
-// snapshot from overlapping a multi-label Add.
 func (p *MemPostings) postingsForLabelValues(name string, values []string) []*listPostings {
 	if len(values) == 0 {
 		return nil
@@ -687,9 +576,6 @@ func (p *MemPostings) postingsForLabelValues(name string, values []string) []*li
 	return its
 }
 
-// postingsForAllLabelValues assumes the caller is in a read phase. Shard locks
-// protect shard-local postings, and the read phase protects the cross-shard
-// snapshot from overlapping a multi-label Add.
 func (p *MemPostings) postingsForAllLabelValues(name string, valueCount int) []*listPostings {
 	its := make([]*listPostings, 0, valueCount)
 	lps := make([]listPostings, valueCount)
@@ -709,22 +595,19 @@ func (p *MemPostings) postingsForAllLabelValues(name string, valueCount int) []*
 	return its
 }
 
-// postingsForAllLabelValuesIfUnchanged enters a read phase and verifies that
-// the label-value slice captured before matching is still current before reading
-// postings for all values.
 func (p *MemPostings) postingsForAllLabelValuesIfUnchanged(ctx context.Context, name string, labelValues []string) (Postings, bool) {
-	p.gate.beginRead()
+	p.gate.enterRead()
 	p.lvsMtx.RLock()
 	currentLabelValues := p.lvs[name]
-	unchanged := sameStringSliceData(labelValues, currentLabelValues)
+	unchanged := sameStringSliceBackingArray(labelValues, currentLabelValues)
 	p.lvsMtx.RUnlock()
 	if !unchanged {
-		p.gate.endRead()
+		p.gate.leaveRead()
 		return nil, false
 	}
 
 	its := p.postingsForAllLabelValues(name, len(currentLabelValues))
-	p.gate.endRead()
+	p.gate.leaveRead()
 	return Merge(ctx, its...), true
 }
 
@@ -737,11 +620,11 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	//
 	// We just need to make sure we don't modify the slice we took,
 	// so we'll append matching values to a different one.
-	p.gate.beginRead()
+	p.gate.enterRead()
 	p.lvsMtx.RLock()
 	readOnlyLabelValues := p.lvs[name]
 	p.lvsMtx.RUnlock()
-	p.gate.endRead()
+	p.gate.leaveRead()
 
 	if len(readOnlyLabelValues) == 0 {
 		return EmptyPostings()
@@ -775,7 +658,7 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 		return EmptyPostings()
 	}
 
-	if sameStringSliceData(vals, readOnlyLabelValues) {
+	if sameStringSliceBackingArray(vals, readOnlyLabelValues) {
 		postings, ok := p.postingsForAllLabelValuesIfUnchanged(ctx, name, readOnlyLabelValues)
 		if ok {
 			return postings
@@ -783,10 +666,9 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	}
 
 	// Now `vals` only contains the values that matched, get their postings.
-	p.gate.beginRead()
+	p.gate.enterRead()
 	its := p.postingsForLabelValues(name, vals)
-	// Let the mutex go before merging.
-	p.gate.endRead()
+	p.gate.leaveRead()
 
 	return Merge(ctx, its...)
 }
@@ -797,7 +679,7 @@ func (p *MemPostings) Postings(ctx context.Context, name string, values ...strin
 	lps := make([]listPostings, len(values))
 	valueIndexes, shardOffsets := p.valueIndexesByShard(name, values)
 
-	p.gate.beginRead()
+	p.gate.enterRead()
 	for shardIndex := range p.shards {
 		start, end := shardOffsets[shardIndex], shardOffsets[shardIndex+1]
 		if start == end {
@@ -815,12 +697,12 @@ func (p *MemPostings) Postings(ctx context.Context, name string, values ...strin
 		}
 		shard.mtx.RUnlock()
 	}
-	p.gate.endRead()
+	p.gate.leaveRead()
 	return Merge(ctx, res...)
 }
 
 func (p *MemPostings) PostingsForAllLabelValues(ctx context.Context, name string) Postings {
-	p.gate.beginRead()
+	p.gate.enterRead()
 
 	var its []*listPostings
 	var lps []listPostings
@@ -841,8 +723,7 @@ func (p *MemPostings) PostingsForAllLabelValues(ctx context.Context, name string
 		shard.mtx.RUnlock()
 	}
 
-	// Let the mutex go before merging.
-	p.gate.endRead()
+	p.gate.leaveRead()
 	return Merge(ctx, its...)
 }
 

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -53,76 +53,93 @@ var ensureOrderBatchPool = sync.Pool{
 	},
 }
 
-// postingsPhaseGate lets MemPostings shard writes without exposing partially added
-// label sets to readers. Multiple Add calls may run concurrently, and multiple
-// reads may run concurrently, but the two phases do not overlap.
+// postingsPhaseGate separates MemPostings operations into add, read, and
+// exclusive phases. A phase is the part of an operation that observes or
+// publishes postings state across shards. The gate does not replace shard
+// locks; shard locks still protect shard-local maps and slices.
+//
+// The gate keeps read snapshots out of the middle of a multi-label Add. A
+// reader may see the postings before an Add or after it, but not after only
+// some label pairs for that series have been published. Exclusive waiters block
+// new readers and adders so Delete and EnsureOrder do not starve.
 type postingsPhaseGate struct {
 	mtx              sync.Mutex
 	cond             *sync.Cond
-	adds             int
-	reads            int
-	exclusive        bool
-	exclusiveWaiting int
+	activeAdds       int
+	activeReads      int
+	exclusiveActive  bool
+	exclusiveWaiters int
 }
 
 func (g *postingsPhaseGate) init() {
 	g.cond = sync.NewCond(&g.mtx)
 }
 
+// beginAdd waits until there are no active reads or exclusive operations. It
+// also waits behind pending exclusive operations so they can drain current work.
 func (g *postingsPhaseGate) beginAdd() {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
-	for g.reads > 0 || g.exclusive || g.exclusiveWaiting > 0 {
+	for g.activeReads > 0 || g.exclusiveActive || g.exclusiveWaiters > 0 {
 		g.cond.Wait()
 	}
-	g.adds++
+	g.activeAdds++
 }
 
 func (g *postingsPhaseGate) endAdd() {
 	g.mtx.Lock()
-	g.adds--
-	if g.adds == 0 {
+	g.activeAdds--
+	if g.activeAdds == 0 {
 		g.cond.Broadcast()
 	}
 	g.mtx.Unlock()
 }
 
+// beginRead waits for active Adds because a read can snapshot multiple shards
+// and label-value metadata. It also waits behind pending exclusive operations.
 func (g *postingsPhaseGate) beginRead() {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
-	for g.adds > 0 || g.exclusive || g.exclusiveWaiting > 0 {
+	for g.activeAdds > 0 || g.exclusiveActive || g.exclusiveWaiters > 0 {
 		g.cond.Wait()
 	}
-	g.reads++
+	g.activeReads++
 }
 
 func (g *postingsPhaseGate) endRead() {
 	g.mtx.Lock()
-	g.reads--
-	if g.reads == 0 {
+	g.activeReads--
+	if g.activeReads == 0 {
 		g.cond.Broadcast()
 	}
 	g.mtx.Unlock()
 }
 
+// beginExclusive is used by Delete and EnsureOrder. It marks an exclusive
+// waiter before waiting so new Adds and reads do not enter, then waits for
+// current Adds, reads, and any active exclusive operation to finish.
 func (g *postingsPhaseGate) beginExclusive() {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
-	g.exclusiveWaiting++
-	defer func() { g.exclusiveWaiting-- }()
-	for g.adds > 0 || g.reads > 0 || g.exclusive {
+	g.exclusiveWaiters++
+	defer func() { g.exclusiveWaiters-- }()
+	for g.activeAdds > 0 || g.activeReads > 0 || g.exclusiveActive {
 		g.cond.Wait()
 	}
-	g.exclusive = true
+	g.exclusiveActive = true
 }
 
 func (g *postingsPhaseGate) endExclusive() {
 	g.mtx.Lock()
-	g.exclusive = false
+	g.exclusiveActive = false
 	g.cond.Broadcast()
 	g.mtx.Unlock()
 }
 
+// yieldExclusive briefly drops the exclusive phase during long Delete work.
+// Readers and adders that are blocked on the gate can run between batches.
+// beginExclusive is called again afterwards, so later readers and adders queue
+// behind the Delete instead of starving it.
 func (g *postingsPhaseGate) yieldExclusive() {
 	g.endExclusive()
 	time.Sleep(time.Millisecond)
@@ -148,8 +165,9 @@ type MemPostings struct {
 	// shards holds the postings lists for each label-value pair.
 	shards [memPostingsShardCount]memPostingsShard
 
-	// lvs holds the label values for each label name.
-	// The phase gate prevents readers from observing lvs while Adds are active.
+	// lvs holds all known values for each label name. It lets label-value
+	// queries avoid scanning every shard to discover values. Add updates lvs
+	// while readers are excluded by the phase gate.
 	lvsMtx sync.RWMutex
 	lvs    map[string][]string
 
@@ -510,7 +528,10 @@ func (p *MemPostings) Iter(f func(labels.Label, Postings) error) error {
 	return nil
 }
 
-// Add a label set to the postings index.
+// Add a label set to the postings index. The whole label set, including the
+// all-postings entry, is published in one Add phase. This keeps readers from
+// observing a series through one label matcher but not another matcher from the
+// same label set.
 func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
 	p.gate.beginAdd()
 	defer p.gate.endAdd()
@@ -593,6 +614,9 @@ func (p *MemPostings) valueIndexesByShard(name string, values []string) ([]int, 
 	return valueIndexes, offsets
 }
 
+// postingsForLabelValues assumes the caller is in a read phase. Shard locks
+// protect shard-local postings, and the read phase protects the cross-shard
+// snapshot from overlapping a multi-label Add.
 func (p *MemPostings) postingsForLabelValues(name string, values []string) []*listPostings {
 	if len(values) == 0 {
 		return nil
@@ -622,6 +646,9 @@ func (p *MemPostings) postingsForLabelValues(name string, values []string) []*li
 	return its
 }
 
+// postingsForAllLabelValues assumes the caller is in a read phase. Shard locks
+// protect shard-local postings, and the read phase protects the cross-shard
+// snapshot from overlapping a multi-label Add.
 func (p *MemPostings) postingsForAllLabelValues(name string, valueCount int) []*listPostings {
 	its := make([]*listPostings, 0, valueCount)
 	lps := make([]listPostings, valueCount)
@@ -641,6 +668,9 @@ func (p *MemPostings) postingsForAllLabelValues(name string, valueCount int) []*
 	return its
 }
 
+// postingsForAllLabelValuesIfUnchanged enters a read phase and verifies that
+// the label-value slice captured before matching is still current before reading
+// postings for all values.
 func (p *MemPostings) postingsForAllLabelValuesIfUnchanged(ctx context.Context, name string, labelValues []string) (Postings, bool) {
 	p.gate.beginRead()
 	p.lvsMtx.RLock()

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -440,7 +440,40 @@ func (p *MemPostings) EnsureOrder(numberOfConcurrentProcesses int) {
 	close(workc)
 	wg.Wait()
 
+	p.enableSharding()
 	p.ordered = true
+}
+
+// enableSharding moves replay-built postings into the live shards without
+// copying the postings lists. The caller must hold the exclusive phase.
+func (p *MemPostings) enableSharding() {
+	if p.sharded {
+		return
+	}
+
+	var sharded [memPostingsShardCount]map[string]map[string][]storage.SeriesRef
+	for i := range sharded {
+		sharded[i] = make(map[string]map[string][]storage.SeriesRef, defaultLabelNamesMapSize/memPostingsShardCount+1)
+	}
+
+	for i := range p.shards {
+		for name, values := range p.shards[i].m {
+			for value, refs := range values {
+				shardIndex := memPostingsShardIndex(name, value)
+				byName := sharded[shardIndex][name]
+				if byName == nil {
+					byName = map[string][]storage.SeriesRef{}
+					sharded[shardIndex][name] = byName
+				}
+				byName[value] = refs
+			}
+		}
+	}
+
+	for i := range p.shards {
+		p.shards[i].m = sharded[i]
+	}
+	p.sharded = true
 }
 
 // Delete removes all ids in the given map from the postings lists.
@@ -574,22 +607,23 @@ func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
 		p.lvs[l.Name] = appendWithExponentialGrowth(p.lvs[l.Name], l.Value)
 		p.lvsMtx.Unlock()
 	}
-	list := appendWithExponentialGrowth(vm, id)
-	nm[l.Value] = list
-
-	if !p.ordered {
+	if !p.ordered || len(vm) == 0 || vm[len(vm)-1] <= id {
+		nm[l.Value] = appendWithExponentialGrowth(vm, id)
 		return
 	}
-	// There is no guarantee that no higher ID was inserted before as they may
-	// be generated independently before adding them to postings.
-	// We repair order violations on insert. The invariant is that the first n-1
-	// items in the list are already sorted.
+
+	// Existing iterators retain the old slice after the shard lock is released.
+	// Copy before moving IDs so a later out-of-order insert cannot change them.
+	list := make([]storage.SeriesRef, len(vm)+1, len(vm)*exponentialSliceGrowthFactor+1)
+	copy(list, vm)
+	list[len(vm)] = id
 	for i := len(list) - 1; i >= 1; i-- {
 		if list[i] >= list[i-1] {
 			break
 		}
 		list[i], list[i-1] = list[i-1], list[i]
 	}
+	nm[l.Value] = list
 }
 
 func sameStringSliceData(a, b []string) bool {

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"maps"
 	"math"
 	"runtime"
 	"slices"
@@ -28,6 +27,7 @@ import (
 	"time"
 
 	"github.com/bboreham/go-loser"
+	"github.com/cespare/xxhash/v2"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -53,68 +53,166 @@ var ensureOrderBatchPool = sync.Pool{
 	},
 }
 
+// postingsPhaseGate lets MemPostings shard writes without exposing partially added
+// label sets to readers. Multiple Add calls may run concurrently, and multiple
+// reads may run concurrently, but the two phases do not overlap.
+type postingsPhaseGate struct {
+	mtx              sync.Mutex
+	cond             *sync.Cond
+	adds             int
+	reads            int
+	exclusive        bool
+	exclusiveWaiting int
+}
+
+func (g *postingsPhaseGate) init() {
+	g.cond = sync.NewCond(&g.mtx)
+}
+
+func (g *postingsPhaseGate) beginAdd() {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+	for g.reads > 0 || g.exclusive || g.exclusiveWaiting > 0 {
+		g.cond.Wait()
+	}
+	g.adds++
+}
+
+func (g *postingsPhaseGate) endAdd() {
+	g.mtx.Lock()
+	g.adds--
+	if g.adds == 0 {
+		g.cond.Broadcast()
+	}
+	g.mtx.Unlock()
+}
+
+func (g *postingsPhaseGate) beginRead() {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+	for g.adds > 0 || g.exclusive || g.exclusiveWaiting > 0 {
+		g.cond.Wait()
+	}
+	g.reads++
+}
+
+func (g *postingsPhaseGate) endRead() {
+	g.mtx.Lock()
+	g.reads--
+	if g.reads == 0 {
+		g.cond.Broadcast()
+	}
+	g.mtx.Unlock()
+}
+
+func (g *postingsPhaseGate) beginExclusive() {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+	g.exclusiveWaiting++
+	defer func() { g.exclusiveWaiting-- }()
+	for g.adds > 0 || g.reads > 0 || g.exclusive {
+		g.cond.Wait()
+	}
+	g.exclusive = true
+}
+
+func (g *postingsPhaseGate) endExclusive() {
+	g.mtx.Lock()
+	g.exclusive = false
+	g.cond.Broadcast()
+	g.mtx.Unlock()
+}
+
+func (g *postingsPhaseGate) yieldExclusive() {
+	g.endExclusive()
+	time.Sleep(time.Millisecond)
+	g.beginExclusive()
+}
+
+const memPostingsShardCount = 256
+
+type memPostingsShard struct {
+	mtx sync.RWMutex
+
+	// m holds postings lists for label pairs in this shard.
+	m map[string]map[string][]storage.SeriesRef
+}
+
 // MemPostings holds postings list for series ID per label pair. They may be written
 // to out of order.
 // EnsureOrder() must be called once before any reads are done. This allows for quick
 // unordered batch fills on startup.
 type MemPostings struct {
-	mtx sync.RWMutex
+	gate postingsPhaseGate
 
-	// m holds the postings lists for each label-value pair, indexed first by label name, and then by label value.
-	//
-	// mtx must be held when interacting with m (the appropriate one for reading or writing).
-	// It is safe to retain a reference to a postings list after releasing the lock.
-	//
-	// BUG: There's currently a data race in addFor, which might modify the tail of the postings list:
-	// https://github.com/prometheus/prometheus/issues/15317
-	m map[string]map[string][]storage.SeriesRef
+	// shards holds the postings lists for each label-value pair.
+	shards [memPostingsShardCount]memPostingsShard
 
 	// lvs holds the label values for each label name.
-	// lvs[name] is essentially an unsorted append-only list of all keys in m[name]
-	// mtx must be held when interacting with lvs.
-	// Since it's append-only, it is safe to read the label values slice after releasing the lock.
-	lvs map[string][]string
+	// The phase gate prevents readers from observing lvs while Adds are active.
+	lvsMtx sync.RWMutex
+	lvs    map[string][]string
 
+	sharded bool
 	ordered bool
 }
 
 const defaultLabelNamesMapSize = 512
 
+func newMemPostings(ordered, sharded bool) *MemPostings {
+	p := &MemPostings{
+		lvs:     make(map[string][]string, defaultLabelNamesMapSize),
+		sharded: sharded,
+		ordered: ordered,
+	}
+	p.gate.init()
+	for i := range p.shards {
+		p.shards[i].m = make(map[string]map[string][]storage.SeriesRef, defaultLabelNamesMapSize/memPostingsShardCount+1)
+	}
+	return p
+}
+
 // NewMemPostings returns a memPostings that's ready for reads and writes.
 func NewMemPostings() *MemPostings {
-	return &MemPostings{
-		m:       make(map[string]map[string][]storage.SeriesRef, defaultLabelNamesMapSize),
-		lvs:     make(map[string][]string, defaultLabelNamesMapSize),
-		ordered: true,
-	}
+	return newMemPostings(true, true)
 }
 
 // NewUnorderedMemPostings returns a memPostings that is not safe to be read from
 // until EnsureOrder() was called once.
 func NewUnorderedMemPostings() *MemPostings {
-	return &MemPostings{
-		m:       make(map[string]map[string][]storage.SeriesRef, defaultLabelNamesMapSize),
-		lvs:     make(map[string][]string, defaultLabelNamesMapSize),
-		ordered: false,
+	return newMemPostings(false, false)
+}
+
+func memPostingsShardIndex(name, value string) uint64 {
+	return xxhash.Sum64String(name+"\xff"+value) % memPostingsShardCount
+}
+
+func (p *MemPostings) shardIndex(name, value string) uint64 {
+	if !p.sharded {
+		return 0
 	}
+	return memPostingsShardIndex(name, value)
+}
+
+func (p *MemPostings) shard(name, value string) *memPostingsShard {
+	return &p.shards[p.shardIndex(name, value)]
 }
 
 // Symbols returns an iterator over all unique name and value strings, in order.
 func (p *MemPostings) Symbols() StringIter {
-	p.mtx.RLock()
-	// Make a quick clone of the map to avoid holding the lock while iterating.
-	// It's safe to use the values of the map after releasing the lock, as they're append-only slices.
-	lvs := maps.Clone(p.lvs)
-	p.mtx.RUnlock()
+	p.gate.beginRead()
+	defer p.gate.endRead()
 
 	// Add all the strings to a map to de-duplicate.
 	symbols := make(map[string]struct{}, defaultLabelNamesMapSize)
-	for n, labelValues := range lvs {
+	p.lvsMtx.RLock()
+	for n, labelValues := range p.lvs {
 		symbols[n] = struct{}{}
 		for _, v := range labelValues {
 			symbols[v] = struct{}{}
 		}
 	}
+	p.lvsMtx.RUnlock()
 
 	res := make([]string, 0, len(symbols))
 	for k := range symbols {
@@ -127,15 +225,20 @@ func (p *MemPostings) Symbols() StringIter {
 
 // SortedKeys returns a list of sorted label keys of the postings.
 func (p *MemPostings) SortedKeys() []labels.Label {
-	p.mtx.RLock()
-	keys := make([]labels.Label, 0, len(p.m))
+	p.gate.beginRead()
+	defer p.gate.endRead()
 
-	for n, e := range p.m {
-		for v := range e {
-			keys = append(keys, labels.Label{Name: n, Value: v})
+	keys := make([]labels.Label, 0, defaultLabelNamesMapSize)
+	for i := range p.shards {
+		shard := &p.shards[i]
+		shard.mtx.RLock()
+		for n, e := range shard.m {
+			for v := range e {
+				keys = append(keys, labels.Label{Name: n, Value: v})
+			}
 		}
+		shard.mtx.RUnlock()
 	}
-	p.mtx.RUnlock()
 
 	slices.SortFunc(keys, func(a, b labels.Label) int {
 		nameCompare := strings.Compare(a.Name, b.Name)
@@ -151,15 +254,14 @@ func (p *MemPostings) SortedKeys() []labels.Label {
 
 // LabelNames returns all the unique label names.
 func (p *MemPostings) LabelNames() []string {
-	p.mtx.RLock()
-	defer p.mtx.RUnlock()
-	n := len(p.m)
-	if n == 0 {
-		return nil
-	}
+	p.gate.beginRead()
+	defer p.gate.endRead()
 
-	names := make([]string, 0, n-1)
-	for name := range p.m {
+	p.lvsMtx.RLock()
+	defer p.lvsMtx.RUnlock()
+
+	names := make([]string, 0, len(p.lvs))
+	for name := range p.lvs {
 		if name != allPostingsKey.Name {
 			names = append(names, name)
 		}
@@ -169,19 +271,17 @@ func (p *MemPostings) LabelNames() []string {
 
 // LabelValues returns label values for the given name.
 func (p *MemPostings) LabelValues(_ context.Context, name string, hints *storage.LabelHints) []string {
-	p.mtx.RLock()
-	values := p.lvs[name]
-	p.mtx.RUnlock()
+	p.gate.beginRead()
+	defer p.gate.endRead()
 
+	p.lvsMtx.RLock()
+	values := p.lvs[name]
 	if hints != nil && hints.Limit > 0 && len(values) > hints.Limit {
 		values = values[:hints.Limit]
 	}
-
-	// The slice from p.lvs[name] is shared between all readers, and it is append-only.
-	// Since it's shared, we need to make a copy of it before returning it to make
-	// sure that no caller modifies the original one by sorting it or filtering it.
-	// Since it's append-only, we can do this while not holding the mutex anymore.
-	return slices.Clone(values)
+	res := slices.Clone(values)
+	p.lvsMtx.RUnlock()
+	return res
 }
 
 // PostingsStats contains cardinality based statistics for postings.
@@ -196,46 +296,56 @@ type PostingsStats struct {
 // Stats calculates the cardinality statistics from postings.
 // Caller can pass in a function which computes the space required for n series with a given label.
 func (p *MemPostings) Stats(label string, limit int, labelSizeFunc func(string, string, uint64) uint64) *PostingsStats {
-	var size uint64
-	p.mtx.RLock()
+	p.gate.beginRead()
+	defer p.gate.endRead()
 
 	metrics := &maxHeap{}
-	labels := &maxHeap{}
+	labelStats := &maxHeap{}
 	labelValueLength := &maxHeap{}
 	labelValuePairs := &maxHeap{}
-	numLabelPairs := 0
 
 	metrics.init(limit)
-	labels.init(limit)
+	labelStats.init(limit)
 	labelValueLength.init(limit)
 	labelValuePairs.init(limit)
 
-	for n, e := range p.m {
-		if n == "" {
-			continue
-		}
-		labels.push(Stat{Name: n, Count: uint64(len(e))})
-		numLabelPairs += len(e)
-		size = 0
-		for name, values := range e {
-			if n == label {
-				metrics.push(Stat{Name: name, Count: uint64(len(values))})
+	labelValueCounts := make(map[labels.Label]uint64, defaultLabelNamesMapSize)
+	for i := range p.shards {
+		shard := &p.shards[i]
+		shard.mtx.RLock()
+		for name, values := range shard.m {
+			if name == "" {
+				continue
 			}
-			seriesCnt := uint64(len(values))
-			labelValuePairs.push(Stat{Name: n + "=" + name, Count: seriesCnt})
-			size += labelSizeFunc(n, name, seriesCnt)
+			for value, refs := range values {
+				labelValueCounts[labels.Label{Name: name, Value: value}] += uint64(len(refs))
+			}
 		}
-		labelValueLength.push(Stat{Name: n, Count: size})
+		shard.mtx.RUnlock()
 	}
 
-	p.mtx.RUnlock()
+	labelValueCountsByName := make(map[string]uint64, defaultLabelNamesMapSize)
+	labelValueSizeByName := make(map[string]uint64, defaultLabelNamesMapSize)
+	for labelValue, seriesCnt := range labelValueCounts {
+		if labelValue.Name == label {
+			metrics.push(Stat{Name: labelValue.Value, Count: seriesCnt})
+		}
+		labelValuePairs.push(Stat{Name: labelValue.Name + "=" + labelValue.Value, Count: seriesCnt})
+		labelValueCountsByName[labelValue.Name]++
+		labelValueSizeByName[labelValue.Name] += labelSizeFunc(labelValue.Name, labelValue.Value, seriesCnt)
+	}
+
+	for name, count := range labelValueCountsByName {
+		labelStats.push(Stat{Name: name, Count: count})
+		labelValueLength.push(Stat{Name: name, Count: labelValueSizeByName[name]})
+	}
 
 	return &PostingsStats{
 		CardinalityMetricsStats: metrics.get(),
-		CardinalityLabelStats:   labels.get(),
+		CardinalityLabelStats:   labelStats.get(),
 		LabelValueStats:         labelValueLength.get(),
 		LabelValuePairsStats:    labelValuePairs.get(),
-		NumLabelPairs:           numLabelPairs,
+		NumLabelPairs:           len(labelValueCounts),
 	}
 }
 
@@ -250,8 +360,8 @@ func (p *MemPostings) All() Postings {
 // CPU cores used for this operation. If it is <= 0, GOMAXPROCS is used.
 // GOMAXPROCS was the default before introducing this parameter.
 func (p *MemPostings) EnsureOrder(numberOfConcurrentProcesses int) {
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
+	p.gate.beginExclusive()
+	defer p.gate.endExclusive()
 
 	if p.ordered {
 		return
@@ -281,15 +391,20 @@ func (p *MemPostings) EnsureOrder(numberOfConcurrentProcesses int) {
 	}
 
 	nextJob := ensureOrderBatchPool.Get().(*[][]storage.SeriesRef)
-	for _, e := range p.m {
-		for _, l := range e {
-			*nextJob = append(*nextJob, l)
+	for i := range p.shards {
+		shard := &p.shards[i]
+		shard.mtx.Lock()
+		for _, e := range shard.m {
+			for _, l := range e {
+				*nextJob = append(*nextJob, l)
 
-			if len(*nextJob) >= ensureOrderBatchSize {
-				workc <- nextJob
-				nextJob = ensureOrderBatchPool.Get().(*[][]storage.SeriesRef)
+				if len(*nextJob) >= ensureOrderBatchSize {
+					workc <- nextJob
+					nextJob = ensureOrderBatchPool.Get().(*[][]storage.SeriesRef)
+				}
 			}
 		}
+		shard.mtx.Unlock()
 	}
 
 	// If the last job was partially filled, we need to push it to workers too.
@@ -306,12 +421,20 @@ func (p *MemPostings) EnsureOrder(numberOfConcurrentProcesses int) {
 // Delete removes all ids in the given map from the postings lists.
 // affectedLabels contains all the labels that are affected by the deletion, there's no need to check other labels.
 func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected map[labels.Label]struct{}) {
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
+	p.gate.beginExclusive()
+	defer p.gate.endExclusive()
 
 	affectedLabelNames := map[string]struct{}{}
 	process := func(l labels.Label) {
-		orig := p.m[l.Name][l.Value]
+		shard := p.shard(l.Name, l.Value)
+		shard.mtx.Lock()
+		defer shard.mtx.Unlock()
+
+		values := shard.m[l.Name]
+		if values == nil {
+			return
+		}
+		orig := values[l.Value]
 		repl := make([]storage.SeriesRef, 0, len(orig))
 		for _, id := range orig {
 			if _, ok := deleted[id]; !ok {
@@ -319,9 +442,9 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 			}
 		}
 		if len(repl) > 0 {
-			p.m[l.Name][l.Value] = repl
+			values[l.Value] = repl
 		} else {
-			delete(p.m[l.Name], l.Value)
+			delete(values, l.Value)
 			affectedLabelNames[l.Name] = struct{}{}
 		}
 	}
@@ -332,11 +455,8 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 		process(l)
 
 		// From time to time we want some readers to go through and read their postings.
-		// It takes around 50ms to process a 1K series batch, and 120ms to process a 10K series batch (local benchmarks on an M3).
-		// Note that a read query will most likely want to read multiple postings lists, say 5, 10 or 20 (depending on the number of matchers)
-		// And that read query will most likely evaluate only one of those matchers before we unpause here, so we want to pause often.
 		if i%512 == 0 {
-			p.unlockWaitAndLockAgain()
+			p.gate.yieldExclusive()
 		}
 	}
 	process(allPostingsKey)
@@ -345,70 +465,60 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 	i = 0
 	for name := range affectedLabelNames {
 		i++
-		// From time to time we want some readers to go through and read their postings.
 		if i%512 == 0 {
-			p.unlockWaitAndLockAgain()
+			p.gate.yieldExclusive()
 		}
 
-		if len(p.m[name]) == 0 {
-			// Delete the label name key if we deleted all values.
-			delete(p.m, name)
+		lvs := make([]string, 0, len(p.lvs[name]))
+		for shardIndex := range p.shards {
+			shard := &p.shards[shardIndex]
+			shard.mtx.RLock()
+			for v := range shard.m[name] {
+				lvs = append(lvs, v)
+			}
+			shard.mtx.RUnlock()
+		}
+
+		p.lvsMtx.Lock()
+		if len(lvs) == 0 {
 			delete(p.lvs, name)
-			continue
+		} else {
+			p.lvs[name] = lvs
 		}
-
-		// Create the new slice with enough room to grow without reallocating.
-		// We have deleted values here, so there's definitely some churn, so be prepared for it.
-		lvs := make([]string, 0, exponentialSliceGrowthFactor*len(p.m[name]))
-		for v := range p.m[name] {
-			lvs = append(lvs, v)
-		}
-		p.lvs[name] = lvs
+		p.lvsMtx.Unlock()
 	}
-}
-
-// unlockWaitAndLockAgain will unlock an already locked p.mtx.Lock() and then wait a little bit before locking it again,
-// letting the RLock()-waiting goroutines to get the lock.
-func (p *MemPostings) unlockWaitAndLockAgain() {
-	p.mtx.Unlock()
-	// While it's tempting to just do a `time.Sleep(time.Millisecond)` here,
-	// it wouldn't ensure use that readers actually were able to get the read lock,
-	// because if there are writes waiting on same mutex, readers won't be able to get it.
-	// So we just grab one RLock ourselves.
-	p.mtx.RLock()
-	// We shouldn't wait here, because we would be blocking a potential write for no reason.
-	// Note that if there's a writer waiting for us to unlock, no reader will be able to get the read lock.
-	p.mtx.RUnlock() //nolint:staticcheck // SA2001: this is an intentionally empty critical section.
-	// Now we can wait a little bit just to increase the chance of a reader getting the lock.
-	time.Sleep(time.Millisecond)
-	p.mtx.Lock()
 }
 
 // Iter calls f for each postings list. It aborts if f returns an error and returns it.
 func (p *MemPostings) Iter(f func(labels.Label, Postings) error) error {
-	p.mtx.RLock()
-	defer p.mtx.RUnlock()
+	p.gate.beginRead()
+	defer p.gate.endRead()
 
-	for n, e := range p.m {
-		for v, p := range e {
-			if err := f(labels.Label{Name: n, Value: v}, NewListPostings(p)); err != nil {
-				return err
+	for i := range p.shards {
+		shard := &p.shards[i]
+		shard.mtx.RLock()
+		for n, e := range shard.m {
+			for v, p := range e {
+				if err := f(labels.Label{Name: n, Value: v}, NewListPostings(p)); err != nil {
+					shard.mtx.RUnlock()
+					return err
+				}
 			}
 		}
+		shard.mtx.RUnlock()
 	}
 	return nil
 }
 
 // Add a label set to the postings index.
 func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
-	p.mtx.Lock()
+	p.gate.beginAdd()
+	defer p.gate.endAdd()
 
 	lset.Range(func(l labels.Label) {
 		p.addFor(id, l)
 	})
 	p.addFor(id, allPostingsKey)
-
-	p.mtx.Unlock()
 }
 
 func appendWithExponentialGrowth[T any](a []T, v T) []T {
@@ -421,14 +531,20 @@ func appendWithExponentialGrowth[T any](a []T, v T) []T {
 }
 
 func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
-	nm, ok := p.m[l.Name]
+	shard := p.shard(l.Name, l.Value)
+	shard.mtx.Lock()
+	defer shard.mtx.Unlock()
+
+	nm, ok := shard.m[l.Name]
 	if !ok {
 		nm = map[string][]storage.SeriesRef{}
-		p.m[l.Name] = nm
+		shard.m[l.Name] = nm
 	}
 	vm, ok := nm[l.Value]
 	if !ok {
+		p.lvsMtx.Lock()
 		p.lvs[l.Name] = appendWithExponentialGrowth(p.lvs[l.Name], l.Value)
+		p.lvsMtx.Unlock()
 	}
 	list := appendWithExponentialGrowth(vm, id)
 	nm[l.Value] = list
@@ -448,6 +564,99 @@ func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
 	}
 }
 
+func sameStringSliceData(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return len(a) == 0 || &a[0] == &b[0]
+}
+
+func (p *MemPostings) valueIndexesByShard(name string, values []string) ([]int, [memPostingsShardCount + 1]int) {
+	var counts [memPostingsShardCount]int
+	for _, value := range values {
+		counts[p.shardIndex(name, value)]++
+	}
+
+	var offsets [memPostingsShardCount + 1]int
+	for shardIndex := range &counts {
+		offsets[shardIndex+1] = offsets[shardIndex] + counts[shardIndex]
+	}
+
+	valueIndexes := make([]int, len(values))
+	next := offsets
+	for valueIndex, value := range values {
+		shardIndex := p.shardIndex(name, value)
+		valueIndexes[next[shardIndex]] = valueIndex
+		next[shardIndex]++
+	}
+
+	return valueIndexes, offsets
+}
+
+func (p *MemPostings) postingsForLabelValues(name string, values []string) []*listPostings {
+	if len(values) == 0 {
+		return nil
+	}
+
+	its := make([]*listPostings, 0, len(values))
+	lps := make([]listPostings, len(values))
+	valueIndexes, shardOffsets := p.valueIndexesByShard(name, values)
+
+	for shardIndex := range p.shards {
+		start, end := shardOffsets[shardIndex], shardOffsets[shardIndex+1]
+		if start == end {
+			continue
+		}
+		shard := &p.shards[shardIndex]
+		shard.mtx.RLock()
+		postingsMapForName := shard.m[name]
+		for _, i := range valueIndexes[start:end] {
+			value := values[i]
+			if refs := postingsMapForName[value]; refs != nil {
+				lps[i] = listPostings{list: refs}
+				its = append(its, &lps[i])
+			}
+		}
+		shard.mtx.RUnlock()
+	}
+	return its
+}
+
+func (p *MemPostings) postingsForAllLabelValues(name string, valueCount int) []*listPostings {
+	its := make([]*listPostings, 0, valueCount)
+	lps := make([]listPostings, valueCount)
+	valueIndex := 0
+	for shardIndex := range p.shards {
+		shard := &p.shards[shardIndex]
+		shard.mtx.RLock()
+		for _, refs := range shard.m[name] {
+			if len(refs) > 0 {
+				lps[valueIndex] = listPostings{list: refs}
+				its = append(its, &lps[valueIndex])
+				valueIndex++
+			}
+		}
+		shard.mtx.RUnlock()
+	}
+	return its
+}
+
+func (p *MemPostings) postingsForAllLabelValuesIfUnchanged(ctx context.Context, name string, labelValues []string) (Postings, bool) {
+	p.gate.beginRead()
+	p.lvsMtx.RLock()
+	currentLabelValues := p.lvs[name]
+	unchanged := sameStringSliceData(labelValues, currentLabelValues)
+	p.lvsMtx.RUnlock()
+	if !unchanged {
+		p.gate.endRead()
+		return nil, false
+	}
+
+	its := p.postingsForAllLabelValues(name, len(currentLabelValues))
+	p.gate.endRead()
+	return Merge(ctx, its...), true
+}
+
 func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string, match func(string) bool) Postings {
 	// We'll take the label values slice and then match over that,
 	// this way we don't need to hold the mutex while we're matching,
@@ -457,19 +666,37 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	//
 	// We just need to make sure we don't modify the slice we took,
 	// so we'll append matching values to a different one.
-	p.mtx.RLock()
+	p.gate.beginRead()
+	p.lvsMtx.RLock()
 	readOnlyLabelValues := p.lvs[name]
-	p.mtx.RUnlock()
+	p.lvsMtx.RUnlock()
+	p.gate.endRead()
 
-	vals := make([]string, 0, len(readOnlyLabelValues))
+	if len(readOnlyLabelValues) == 0 {
+		return EmptyPostings()
+	}
+
+	vals := readOnlyLabelValues
 	for i, v := range readOnlyLabelValues {
 		if i%checkContextEveryNIterations == 0 && ctx.Err() != nil {
 			return ErrPostings(ctx.Err())
 		}
 
 		if match(v) {
-			vals = append(vals, v)
+			continue
 		}
+
+		vals = append(make([]string, 0, len(readOnlyLabelValues)), readOnlyLabelValues[:i]...)
+		for j := i + 1; j < len(readOnlyLabelValues); j++ {
+			if j%checkContextEveryNIterations == 0 && ctx.Err() != nil {
+				return ErrPostings(ctx.Err())
+			}
+
+			if match(readOnlyLabelValues[j]) {
+				vals = append(vals, readOnlyLabelValues[j])
+			}
+		}
+		break
 	}
 
 	// If none matched (or this label had no values), no need to grab the lock again.
@@ -477,23 +704,18 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 		return EmptyPostings()
 	}
 
-	// Now `vals` only contains the values that matched, get their postings.
-	its := make([]*listPostings, 0, len(vals))
-	lps := make([]listPostings, len(vals))
-	p.mtx.RLock()
-	e := p.m[name]
-	for i, v := range vals {
-		if refs, ok := e[v]; ok {
-			// Some of the values may have been garbage-collected in the meantime this is fine, we'll just skip them.
-			// If we didn't let the mutex go, we'd have these postings here, but they would be pointing nowhere
-			// because there would be a `MemPostings.Delete()` call waiting for the lock to delete these labels,
-			// because the series were deleted already.
-			lps[i] = listPostings{list: refs}
-			its = append(its, &lps[i])
+	if sameStringSliceData(vals, readOnlyLabelValues) {
+		postings, ok := p.postingsForAllLabelValuesIfUnchanged(ctx, name, readOnlyLabelValues)
+		if ok {
+			return postings
 		}
 	}
+
+	// Now `vals` only contains the values that matched, get their postings.
+	p.gate.beginRead()
+	its := p.postingsForLabelValues(name, vals)
 	// Let the mutex go before merging.
-	p.mtx.RUnlock()
+	p.gate.endRead()
 
 	return Merge(ctx, its...)
 }
@@ -502,35 +724,54 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 func (p *MemPostings) Postings(ctx context.Context, name string, values ...string) Postings {
 	res := make([]*listPostings, 0, len(values))
 	lps := make([]listPostings, len(values))
-	p.mtx.RLock()
-	postingsMapForName := p.m[name]
-	for i, value := range values {
-		if lp := postingsMapForName[value]; lp != nil {
-			lps[i] = listPostings{list: lp}
-			res = append(res, &lps[i])
+	valueIndexes, shardOffsets := p.valueIndexesByShard(name, values)
+
+	p.gate.beginRead()
+	for shardIndex := range p.shards {
+		start, end := shardOffsets[shardIndex], shardOffsets[shardIndex+1]
+		if start == end {
+			continue
 		}
+		shard := &p.shards[shardIndex]
+		shard.mtx.RLock()
+		postingsMapForName := shard.m[name]
+		for _, i := range valueIndexes[start:end] {
+			value := values[i]
+			if lp := postingsMapForName[value]; lp != nil {
+				lps[i] = listPostings{list: lp}
+				res = append(res, &lps[i])
+			}
+		}
+		shard.mtx.RUnlock()
 	}
-	p.mtx.RUnlock()
+	p.gate.endRead()
 	return Merge(ctx, res...)
 }
 
 func (p *MemPostings) PostingsForAllLabelValues(ctx context.Context, name string) Postings {
-	p.mtx.RLock()
+	p.gate.beginRead()
 
-	e := p.m[name]
-	its := make([]*listPostings, 0, len(e))
-	lps := make([]listPostings, len(e))
-	i := 0
-	for _, refs := range e {
-		if len(refs) > 0 {
-			lps[i] = listPostings{list: refs}
-			its = append(its, &lps[i])
+	var its []*listPostings
+	var lps []listPostings
+	for i := range p.shards {
+		shard := &p.shards[i]
+		shard.mtx.RLock()
+		e := shard.m[name]
+		base := len(lps)
+		lps = append(lps, make([]listPostings, len(e))...)
+		j := 0
+		for _, refs := range e {
+			if len(refs) > 0 {
+				lps[base+j] = listPostings{list: refs}
+				its = append(its, &lps[base+j])
+			}
+			j++
 		}
-		i++
+		shard.mtx.RUnlock()
 	}
 
 	// Let the mutex go before merging.
-	p.mtx.RUnlock()
+	p.gate.endRead()
 	return Merge(ctx, its...)
 }
 

--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -60,13 +60,15 @@ var ensureOrderBatchPool = sync.Pool{
 //
 // The gate keeps read snapshots out of the middle of a multi-label Add. A
 // reader may see the postings before an Add or after it, but not after only
-// some label pairs for that series have been published. Exclusive waiters block
-// new readers and adders so Delete and EnsureOrder do not starve.
+// some label pairs for that series have been published. Waiting readers block
+// new adders so an active Add phase can drain. Exclusive waiters block new
+// readers and adders so Delete and EnsureOrder do not starve.
 type postingsPhaseGate struct {
 	mtx              sync.Mutex
 	cond             *sync.Cond
 	activeAdds       int
 	activeReads      int
+	readWaiters      int
 	exclusiveActive  bool
 	exclusiveWaiters int
 }
@@ -76,11 +78,12 @@ func (g *postingsPhaseGate) init() {
 }
 
 // beginAdd waits until there are no active reads or exclusive operations. It
-// also waits behind pending exclusive operations so they can drain current work.
+// also waits behind pending readers and exclusive operations so the current
+// phase can drain.
 func (g *postingsPhaseGate) beginAdd() {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
-	for g.activeReads > 0 || g.exclusiveActive || g.exclusiveWaiters > 0 {
+	for g.activeReads > 0 || g.readWaiters > 0 || g.exclusiveActive || g.exclusiveWaiters > 0 {
 		g.cond.Wait()
 	}
 	g.activeAdds++
@@ -96,10 +99,14 @@ func (g *postingsPhaseGate) endAdd() {
 }
 
 // beginRead waits for active Adds because a read can snapshot multiple shards
-// and label-value metadata. It also waits behind pending exclusive operations.
+// and label-value metadata. It registers as a waiter before blocking so later
+// Adds cannot keep extending the active Add phase. Pending exclusive operations
+// retain priority over waiting readers.
 func (g *postingsPhaseGate) beginRead() {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
+	g.readWaiters++
+	defer func() { g.readWaiters-- }()
 	for g.activeAdds > 0 || g.exclusiveActive || g.exclusiveWaiters > 0 {
 		g.cond.Wait()
 	}

--- a/tsdb/index/postings_gate.go
+++ b/tsdb/index/postings_gate.go
@@ -1,0 +1,110 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"sync"
+	"time"
+)
+
+type postingsGateMode uint8
+
+const (
+	postingsIdle postingsGateMode = iota
+	postingsAdding
+	postingsReading
+	postingsExclusive
+)
+
+// postingsGate allows concurrent adds or concurrent reads, but never both.
+// Delete and EnsureOrder run alone. Waiting readers stop new adds, and a
+// waiting exclusive operation stops both.
+type postingsGate struct {
+	mu               sync.Mutex
+	cond             *sync.Cond
+	mode             postingsGateMode
+	activeCount      int // adds or reads in the current mode
+	waitingReaders   int
+	waitingExclusive int
+}
+
+func (g *postingsGate) init() {
+	g.cond = sync.NewCond(&g.mu)
+}
+
+func (g *postingsGate) enterAdd() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for g.mode == postingsReading || g.mode == postingsExclusive || g.waitingReaders > 0 || g.waitingExclusive > 0 {
+		g.cond.Wait()
+	}
+	g.mode = postingsAdding
+	g.activeCount++
+}
+
+func (g *postingsGate) leaveAdd() {
+	g.mu.Lock()
+	g.activeCount--
+	if g.activeCount == 0 {
+		g.mode = postingsIdle
+		g.cond.Broadcast()
+	}
+	g.mu.Unlock()
+}
+
+func (g *postingsGate) enterRead() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.waitingReaders++
+	defer func() { g.waitingReaders-- }()
+	for g.mode == postingsAdding || g.mode == postingsExclusive || g.waitingExclusive > 0 {
+		g.cond.Wait()
+	}
+	g.mode = postingsReading
+	g.activeCount++
+}
+
+func (g *postingsGate) leaveRead() {
+	g.mu.Lock()
+	g.activeCount--
+	if g.activeCount == 0 {
+		g.mode = postingsIdle
+		g.cond.Broadcast()
+	}
+	g.mu.Unlock()
+}
+
+func (g *postingsGate) enterExclusive() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.waitingExclusive++
+	defer func() { g.waitingExclusive-- }()
+	for g.mode != postingsIdle {
+		g.cond.Wait()
+	}
+	g.mode = postingsExclusive
+}
+
+func (g *postingsGate) leaveExclusive() {
+	g.mu.Lock()
+	g.mode = postingsIdle
+	g.cond.Broadcast()
+	g.mu.Unlock()
+}
+
+func (g *postingsGate) yieldExclusive() {
+	g.leaveExclusive()
+	time.Sleep(time.Millisecond)
+	g.enterExclusive()
+}

--- a/tsdb/index/postings_gate_test.go
+++ b/tsdb/index/postings_gate_test.go
@@ -21,12 +21,12 @@ import (
 )
 
 func TestMemPostingsReadWaiterBlocksNewAdds(t *testing.T) {
-	var gate postingsPhaseGate
+	var gate postingsGate
 	gate.init()
 
-	gate.beginAdd()
+	gate.enterAdd()
 	var endFirstAdd sync.Once
-	endFirst := func() { endFirstAdd.Do(gate.endAdd) }
+	endFirst := func() { endFirstAdd.Do(gate.leaveAdd) }
 	t.Cleanup(endFirst)
 
 	readerEntered := make(chan struct{})
@@ -37,28 +37,27 @@ func TestMemPostingsReadWaiterBlocksNewAdds(t *testing.T) {
 	t.Cleanup(release)
 
 	go func() {
-		gate.beginRead()
+		gate.enterRead()
 		close(readerEntered)
 		<-releaseReader
-		gate.endRead()
+		gate.leaveRead()
 		close(readerDone)
 	}()
 
-	waitForGateState(t, &gate, func(g *postingsPhaseGate) bool {
-		return g.readWaiters == 1
+	waitForGateState(t, &gate, func(g *postingsGate) bool {
+		return g.waitingReaders == 1
 	}, "reader did not register as waiting")
 
 	secondAddStarted := make(chan struct{})
 	secondAddEntered := make(chan struct{})
 	secondAddDone := make(chan struct{})
 
-	// Start the second Add before releasing the first one.
-	gate.mtx.Lock()
+	gate.mu.Lock()
 	go func() {
 		close(secondAddStarted)
-		gate.beginAdd()
+		gate.enterAdd()
 		close(secondAddEntered)
-		gate.endAdd()
+		gate.leaveAdd()
 		close(secondAddDone)
 	}()
 	<-secondAddStarted
@@ -69,7 +68,7 @@ func TestMemPostingsReadWaiterBlocksNewAdds(t *testing.T) {
 		endFirst()
 	}()
 	<-firstAddExitStarted
-	gate.mtx.Unlock()
+	gate.mu.Unlock()
 
 	select {
 	case <-readerEntered:
@@ -105,15 +104,15 @@ func TestMemPostingsReadWaiterBlocksNewAdds(t *testing.T) {
 	}
 }
 
-func waitForGateState(t *testing.T, gate *postingsPhaseGate, condition func(*postingsPhaseGate) bool, failure string) {
+func waitForGateState(t *testing.T, gate *postingsGate, condition func(*postingsGate) bool, failure string) {
 	t.Helper()
 
 	timer := time.NewTimer(time.Second)
 	defer timer.Stop()
 	for {
-		gate.mtx.Lock()
+		gate.mu.Lock()
 		ok := condition(gate)
-		gate.mtx.Unlock()
+		gate.mu.Unlock()
 		if ok {
 			return
 		}

--- a/tsdb/index/postings_iterator_test.go
+++ b/tsdb/index/postings_iterator_test.go
@@ -1,0 +1,41 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+)
+
+func TestMemPostingsOutOfOrderAddDoesNotChangeExistingIterator(t *testing.T) {
+	p := NewMemPostings()
+	lset := labels.FromStrings("a", "x")
+	p.Add(2, lset)
+	p.Add(3, lset)
+
+	before := p.Postings(t.Context(), "a", "x")
+	p.Add(1, lset)
+
+	beforeRefs, err := ExpandPostings(before)
+	require.NoError(t, err)
+	require.Equal(t, []storage.SeriesRef{2, 3}, beforeRefs)
+
+	afterRefs, err := ExpandPostings(p.Postings(t.Context(), "a", "x"))
+	require.NoError(t, err)
+	require.Equal(t, []storage.SeriesRef{1, 2, 3}, afterRefs)
+}

--- a/tsdb/index/postings_phase_gate_test.go
+++ b/tsdb/index/postings_phase_gate_test.go
@@ -52,9 +52,7 @@ func TestMemPostingsReadWaiterBlocksNewAdds(t *testing.T) {
 	secondAddEntered := make(chan struct{})
 	secondAddDone := make(chan struct{})
 
-	// Hold the gate mutex while both the later Add and the first Add's exit are
-	// started. This ensures the later Add has attempted to enter before the
-	// active Add phase is allowed to drain.
+	// Start the second Add before releasing the first one.
 	gate.mtx.Lock()
 	go func() {
 		close(secondAddStarted)

--- a/tsdb/index/postings_phase_gate_test.go
+++ b/tsdb/index/postings_phase_gate_test.go
@@ -1,0 +1,130 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMemPostingsReadWaiterBlocksNewAdds(t *testing.T) {
+	var gate postingsPhaseGate
+	gate.init()
+
+	gate.beginAdd()
+	var endFirstAdd sync.Once
+	endFirst := func() { endFirstAdd.Do(gate.endAdd) }
+	t.Cleanup(endFirst)
+
+	readerEntered := make(chan struct{})
+	releaseReader := make(chan struct{})
+	readerDone := make(chan struct{})
+	var releaseReaderOnce sync.Once
+	release := func() { releaseReaderOnce.Do(func() { close(releaseReader) }) }
+	t.Cleanup(release)
+
+	go func() {
+		gate.beginRead()
+		close(readerEntered)
+		<-releaseReader
+		gate.endRead()
+		close(readerDone)
+	}()
+
+	waitForGateState(t, &gate, func(g *postingsPhaseGate) bool {
+		return g.readWaiters == 1
+	}, "reader did not register as waiting")
+
+	secondAddStarted := make(chan struct{})
+	secondAddEntered := make(chan struct{})
+	secondAddDone := make(chan struct{})
+
+	// Hold the gate mutex while both the later Add and the first Add's exit are
+	// started. This ensures the later Add has attempted to enter before the
+	// active Add phase is allowed to drain.
+	gate.mtx.Lock()
+	go func() {
+		close(secondAddStarted)
+		gate.beginAdd()
+		close(secondAddEntered)
+		gate.endAdd()
+		close(secondAddDone)
+	}()
+	<-secondAddStarted
+
+	firstAddExitStarted := make(chan struct{})
+	go func() {
+		close(firstAddExitStarted)
+		endFirst()
+	}()
+	<-firstAddExitStarted
+	gate.mtx.Unlock()
+
+	select {
+	case <-readerEntered:
+	case <-secondAddEntered:
+		t.Fatal("later Add entered before the waiting reader")
+	case <-time.After(time.Second):
+		t.Fatal("waiting reader did not enter")
+	}
+
+	select {
+	case <-secondAddEntered:
+		t.Fatal("later Add entered while the reader was active")
+	default:
+	}
+
+	release()
+	select {
+	case <-readerDone:
+	case <-time.After(time.Second):
+		t.Fatal("reader did not exit")
+	}
+
+	select {
+	case <-secondAddEntered:
+	case <-time.After(time.Second):
+		t.Fatal("later Add did not enter after the reader exited")
+	}
+
+	select {
+	case <-secondAddDone:
+	case <-time.After(time.Second):
+		t.Fatal("later Add did not exit")
+	}
+}
+
+func waitForGateState(t *testing.T, gate *postingsPhaseGate, condition func(*postingsPhaseGate) bool, failure string) {
+	t.Helper()
+
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	for {
+		gate.mtx.Lock()
+		ok := condition(gate)
+		gate.mtx.Unlock()
+		if ok {
+			return
+		}
+
+		select {
+		case <-timer.C:
+			t.Fatal(failure)
+		default:
+			runtime.Gosched()
+		}
+	}
+}

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -37,36 +38,38 @@ import (
 
 func TestMemPostings_addFor(t *testing.T) {
 	p := NewMemPostings()
-	p.m[allPostingsKey.Name] = map[string][]storage.SeriesRef{}
-	p.m[allPostingsKey.Name][allPostingsKey.Value] = []storage.SeriesRef{1, 2, 3, 4, 6, 7, 8}
+	shard := p.shard(allPostingsKey.Name, allPostingsKey.Value)
+	shard.m[allPostingsKey.Name] = map[string][]storage.SeriesRef{}
+	shard.m[allPostingsKey.Name][allPostingsKey.Value] = []storage.SeriesRef{1, 2, 3, 4, 6, 7, 8}
 
 	p.addFor(5, allPostingsKey)
 
-	require.Equal(t, []storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8}, p.m[allPostingsKey.Name][allPostingsKey.Value])
+	require.Equal(t, []storage.SeriesRef{1, 2, 3, 4, 5, 6, 7, 8}, shard.m[allPostingsKey.Name][allPostingsKey.Value])
 }
 
 func TestMemPostings_ensureOrder(t *testing.T) {
 	p := NewUnorderedMemPostings()
-	p.m["a"] = map[string][]storage.SeriesRef{}
-
 	for i := range 100 {
 		l := make([]storage.SeriesRef, 100)
 		for j := range l {
 			l[j] = storage.SeriesRef(rand.Uint64())
 		}
 		v := strconv.Itoa(i)
-
-		p.m["a"][v] = l
+		shard := p.shard("a", v)
+		if shard.m["a"] == nil {
+			shard.m["a"] = map[string][]storage.SeriesRef{}
+		}
+		shard.m["a"][v] = l
 	}
 
 	p.EnsureOrder(0)
 
-	for _, e := range p.m {
-		for _, l := range e {
-			ok := slices.IsSorted(l)
-			require.True(t, ok, "postings list %v is not sorted", l)
-		}
-	}
+	require.NoError(t, p.Iter(func(_ labels.Label, postings Postings) error {
+		refs, err := ExpandPostings(postings)
+		require.NoError(t, err)
+		require.True(t, slices.IsSorted(refs), "postings list %v is not sorted", refs)
+		return nil
+	}))
 }
 
 func BenchmarkMemPostings_ensureOrder(b *testing.B) {
@@ -99,7 +102,6 @@ func BenchmarkMemPostings_ensureOrder(b *testing.B) {
 			// Generate postings.
 			for l := 0; l < testData.numLabels; l++ {
 				labelName := strconv.Itoa(l)
-				p.m[labelName] = map[string][]storage.SeriesRef{}
 
 				for v := 0; v < testData.numValuesPerLabel; v++ {
 					refs := make([]storage.SeriesRef, testData.numRefsPerValue)
@@ -108,7 +110,11 @@ func BenchmarkMemPostings_ensureOrder(b *testing.B) {
 					}
 
 					labelValue := strconv.Itoa(v)
-					p.m[labelName][labelValue] = refs
+					shard := p.shard(labelName, labelValue)
+					if shard.m[labelName] == nil {
+						shard.m[labelName] = map[string][]storage.SeriesRef{}
+					}
+					shard.m[labelName][labelValue] = refs
 				}
 			}
 
@@ -1463,6 +1469,45 @@ func BenchmarkMemPostings_PostingsForLabelMatching(b *testing.B) {
 					}
 				}
 			})
+		})
+	}
+}
+
+func BenchmarkMemPostings_Add(b *testing.B) {
+	const labelSetCount = 100_000
+	labelSets := make([]labels.Labels, labelSetCount)
+	for i := range labelSets {
+		labelSets[i] = labels.FromStrings(
+			labels.MetricName, "metric_"+strconv.Itoa(i%1000),
+			"job", "large-scrape",
+			"namespace", "namespace_"+strconv.Itoa(i%100),
+			"pod", "pod_"+strconv.Itoa(i),
+			"instance", "instance_"+strconv.Itoa(i%10_000),
+			"common", "same",
+		)
+	}
+
+	for _, workers := range []int{1, 10, 20} {
+		b.Run(fmt.Sprintf("workers=%d", workers), func(b *testing.B) {
+			p := NewMemPostings()
+			var next atomic.Uint64
+			var wg sync.WaitGroup
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for range workers {
+				wg.Go(func() {
+					for {
+						n := next.Inc()
+						if n > uint64(b.N) {
+							return
+						}
+						p.Add(storage.SeriesRef(n), labelSets[n%labelSetCount])
+					}
+				})
+			}
+			wg.Wait()
 		})
 	}
 }

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1512,6 +1512,85 @@ func BenchmarkMemPostings_Add(b *testing.B) {
 	}
 }
 
+func TestMemPostingsConcurrentReadDoesNotObservePartialAdd(t *testing.T) {
+	mp := NewMemPostings()
+	ctx := context.Background()
+
+	const seriesCount = 512
+	start := make(chan struct{})
+	done := make(chan struct{})
+	errCh := make(chan error, 1)
+	var writers sync.WaitGroup
+	writers.Add(seriesCount)
+	for i := 1; i <= seriesCount; i++ {
+		id := storage.SeriesRef(i)
+		value := strconv.Itoa(i)
+		go func() {
+			defer writers.Done()
+			<-start
+			mp.Add(id, labels.FromStrings("a", value, "b", value))
+		}()
+	}
+
+	checkSnapshot := func() error {
+		mp.gate.beginRead()
+		defer mp.gate.endRead()
+		for i := 1; i <= seriesCount; i++ {
+			value := strconv.Itoa(i)
+			aRefs, err := ExpandPostings(Merge(ctx, mp.postingsForLabelValues("a", []string{value})...))
+			if err != nil {
+				return err
+			}
+			bRefs, err := ExpandPostings(Merge(ctx, mp.postingsForLabelValues("b", []string{value})...))
+			if err != nil {
+				return err
+			}
+
+			aVisible := slices.Contains(aRefs, storage.SeriesRef(i))
+			bVisible := slices.Contains(bRefs, storage.SeriesRef(i))
+			if aVisible != bVisible {
+				return fmt.Errorf("series %d visible through only one label", i)
+			}
+		}
+		return nil
+	}
+
+	var readers sync.WaitGroup
+	for range 4 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			<-start
+			for range 16 {
+				select {
+				case <-done:
+					return
+				default:
+				}
+
+				if err := checkSnapshot(); err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	writers.Wait()
+	close(done)
+	readers.Wait()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	default:
+	}
+}
+
 func TestMemPostings_PostingsForLabelMatching(t *testing.T) {
 	mp := NewMemPostings()
 	mp.Add(1, labels.FromStrings("foo", "1"))

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1518,7 +1518,6 @@ func TestMemPostingsConcurrentReadDoesNotObservePartialAdd(t *testing.T) {
 
 	const seriesCount = 512
 	start := make(chan struct{})
-	done := make(chan struct{})
 	errCh := make(chan error, 1)
 	var writers sync.WaitGroup
 	writers.Add(seriesCount)
@@ -1562,12 +1561,6 @@ func TestMemPostingsConcurrentReadDoesNotObservePartialAdd(t *testing.T) {
 			defer readers.Done()
 			<-start
 			for range 16 {
-				select {
-				case <-done:
-					return
-				default:
-				}
-
 				if err := checkSnapshot(); err != nil {
 					select {
 					case errCh <- err:
@@ -1581,7 +1574,6 @@ func TestMemPostingsConcurrentReadDoesNotObservePartialAdd(t *testing.T) {
 
 	close(start)
 	writers.Wait()
-	close(done)
 	readers.Wait()
 
 	select {

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1539,8 +1539,8 @@ func TestMemPostingsConcurrentReadDoesNotObservePartialAdd(t *testing.T) {
 	}
 
 	checkSnapshot := func() error {
-		mp.gate.beginRead()
-		defer mp.gate.endRead()
+		mp.gate.enterRead()
+		defer mp.gate.leaveRead()
 		for i := 1; i <= seriesCount; i++ {
 			value := strconv.Itoa(i)
 			aRefs, err := ExpandPostings(Merge(ctx, mp.postingsForLabelValues("a", []string{value})...))

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -64,6 +64,15 @@ func TestMemPostings_ensureOrder(t *testing.T) {
 
 	p.EnsureOrder(0)
 
+	require.True(t, p.sharded)
+	nonEmptyShards := 0
+	for i := range p.shards {
+		if len(p.shards[i].m) > 0 {
+			nonEmptyShards++
+		}
+	}
+	require.Greater(t, nonEmptyShards, 1)
+
 	require.NoError(t, p.Iter(func(_ labels.Label, postings Postings) error {
 		refs, err := ExpandPostings(postings)
 		require.NoError(t, err)

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -1520,15 +1520,13 @@ func TestMemPostingsConcurrentReadDoesNotObservePartialAdd(t *testing.T) {
 	start := make(chan struct{})
 	errCh := make(chan error, 1)
 	var writers sync.WaitGroup
-	writers.Add(seriesCount)
 	for i := 1; i <= seriesCount; i++ {
 		id := storage.SeriesRef(i)
 		value := strconv.Itoa(i)
-		go func() {
-			defer writers.Done()
+		writers.Go(func() {
 			<-start
 			mp.Add(id, labels.FromStrings("a", value, "b", value))
-		}()
+		})
 	}
 
 	checkSnapshot := func() error {
@@ -1556,9 +1554,7 @@ func TestMemPostingsConcurrentReadDoesNotObservePartialAdd(t *testing.T) {
 
 	var readers sync.WaitGroup
 	for range 4 {
-		readers.Add(1)
-		go func() {
-			defer readers.Done()
+		readers.Go(func() {
 			<-start
 			for range 16 {
 				if err := checkSnapshot(); err != nil {
@@ -1569,7 +1565,7 @@ func TestMemPostingsConcurrentReadDoesNotObservePartialAdd(t *testing.T) {
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	close(start)


### PR DESCRIPTION
#### Which issue(s) this PR fixes

Part of #16902.

#### What this PR does

This is a transaction-safe MemPostings sharding implementation for the live ordered postings path.

The previous sharding attempt in #13642 showed the write-side upside, but it could expose partially inserted label sets to readers. That breaks negative matcher correctness: one matcher can observe a new series while another matcher does not.

This PR avoids that by adding a small phase gate around MemPostings:

- multiple `Add()` calls can run concurrently;
- multiple read snapshots can run concurrently;
- reads and adds do not overlap while postings slices are captured;
- `Delete()` and `EnsureOrder()` run as exclusive phases;
- exclusive waiters block new readers/adders so long delete/order phases do not starve.

Ordered/live MemPostings now shard postings by label pair. Unordered MemPostings, used for WAL replay, keep the single-shard layout so the existing `EnsureOrder()` profile does not pay the label-pair sharding overhead during replay.

Label-value metadata (`lvs`) stays global so matcher scans do not need to touch every shard.

#### Benchmark notes

Focused concurrent Add benchmark added in this PR:

```text
BenchmarkMemPostings_Add/workers=1     main 1199 ns/op    this PR 1869 ns/op   +55.9%
BenchmarkMemPostings_Add/workers=10    main 1458 ns/op    this PR 1023 ns/op   -29.8%
BenchmarkMemPostings_Add/workers=20    main 1659 ns/op    this PR  978 ns/op   -41.1%
```

The tradeoff is intentional and should be reviewed: the uncontended single-writer path is slower, while the contended multi-writer path improves substantially, which is the workload described in #16902.

Broad 1x benchmark smoke checks showed mixed but bounded results:

- `MemPostings_Delete` improved for several no-reader / low-reader cases and substantially reduced memory/allocations in the `refs=10000/readers=10` case.
- `PostingsForLabelMatching` is mostly close to main after keeping label-value metadata global, with some small-regex cases still mixed.
- `EnsureOrder` is kept close to main by leaving unordered postings single-shard.

I am including these notes so the performance tradeoffs are explicit rather than hidden.

#### Validation

```text
git diff --check
go test ./tsdb/index
go test ./tsdb -run TestQuerierIndexQueriesRace -count=3
go test ./tsdb/...
go test ./tsdb/index -run '^$' -bench '^BenchmarkMemPostings_Add$' -benchmem -benchtime=1s -count=3
```

```release-notes
[ENHANCEMENT] TSDB: Improve concurrent in-memory postings insertion throughput while preserving atomic label-set visibility.
```
