### PR TITLE
web/api: reject NaN, Inf and out-of-range floats in time params

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -2264,9 +2264,12 @@ func parseTimeParam(r *http.Request, paramName string, defaultValue time.Time) (
 
 func parseTime(s string) (time.Time, error) {
 	if t, err := strconv.ParseFloat(s, 64); err == nil {
-		s, ns := math.Modf(t)
-		ns = math.Round(ns*1000) / 1000
-		return time.Unix(int64(s), int64(ns*float64(time.Second))).UTC(), nil
+		if math.IsNaN(t) || t < float64(MinTime.Unix()) || t > float64(MaxTime.Unix()) {
+			return time.Time{}, fmt.Errorf("cannot parse %q to a valid timestamp", s)
+		}
+		sec, frac := math.Modf(t)
+		frac = math.Round(frac*1000) / 1000
+		return time.Unix(int64(sec), int64(frac*float64(time.Second))).UTC(), nil
 	}
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return t, nil

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -4403,6 +4403,27 @@ func TestParseTime(t *testing.T) {
 			fail:  true,
 		},
 		{
+			input: "NaN",
+			fail:  true,
+		},
+		{
+			input: "Inf",
+			fail:  true,
+		},
+		{
+			input: "+Inf",
+			fail:  true,
+		},
+		{
+			input: "-Inf",
+			fail:  true,
+		},
+		{
+			// Finite float that is out of the supported time range.
+			input: "9e18",
+			fail:  true,
+		},
+		{
 			input:  "123",
 			result: time.Unix(123, 0),
 		},


### PR DESCRIPTION

#### Which issue(s) does the PR fix:
<!-- No existing issue; this PR documents and fixes the bug directly. -->
None. This fixes an input-validation bug in the HTTP query API that has no
existing tracking issue.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] API: Reject NaN, Inf and out-of-range float values in the query time/start/end parameters instead of returning a bogus timestamp.
```

`parseTime` (used by the `time`, `start` and `end` parameters of `/api/v1/query`,
`/api/v1/query_range`, `/api/v1/series`, the label and metadata endpoints, etc.)
fed the result of `strconv.ParseFloat` straight into
`time.Unix(int64(s), ...)` without validating it. `strconv.ParseFloat` succeeds
for `"NaN"`, `"Inf"`, `"+Inf"`, `"-Inf"` and for finite-but-huge magnitudes such
as `"9e18"` or `"1e100"`, so those values entered the float branch and, via an
implementation-defined `float64 -> int64` conversion, produced a nonsensical
instant with **no error**:

- `NaN` -> `1970-01-01T00:00:00Z` (the epoch)
- `Inf` / `+Inf` -> year ~292277026596 (far future)
- `-Inf` -> the far past
- `9e18` / `1e100` -> far future

All of the non-NaN cases land outside the deliberate `[MinTime, MaxTime]` bounds
(`web/api/v1/api.go`), whose historical-note comments say the clamps exist
specifically to avoid the `time.Unix(math.MaxInt64, ...)` overflow, and those
far-future seconds subsequently overflow int64 milliseconds in
`timestamp.FromTime` (`UnixMilli`), corrupting the query bounds. The fix guards
the float branch the same way the sibling `parseDuration` (int64-overflow guard)
and `template.floatToTime` (NaN/Inf reject) already do, so these inputs now
return a 400 instead of silently querying a wrong or empty time range. A
reproducing set of rows was added to `TestParseTime`.
