### PR TITLE
scrape: fix bucketLimitAppender doc comments

### DIFF
--- a/scrape/target.go
+++ b/scrape/target.go
@@ -413,7 +413,7 @@ func (app *timeLimitAppender) Append(ref storage.SeriesRef, lset labels.Labels, 
 	return ref, nil
 }
 
-// bucketLimitAppender limits the number of total appended samples in a batch.
+// bucketLimitAppender limits the number of buckets in appended native histograms, reducing histogram resolution or returning errBucketLimit when the limit is exceeded.
 type bucketLimitAppender struct {
 	storage.Appender
 
@@ -486,7 +486,7 @@ func (app *maxSchemaAppender) AppendHistogram(ref storage.SeriesRef, lset labels
 	return ref, nil
 }
 
-// limitAppender limits the number of total appended samples in a batch.
+// limitAppenderV2 limits the number of total appended samples in a batch.
 type limitAppenderV2 struct {
 	storage.AppenderV2
 
@@ -520,7 +520,7 @@ func (app *timeLimitAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, 
 	return app.AppenderV2.Append(ref, ls, st, t, v, h, fh, opts)
 }
 
-// bucketLimitAppender limits the number of total appended samples in a batch.
+// bucketLimitAppenderV2 limits the number of buckets in appended native histograms, reducing histogram resolution or returning errBucketLimit when the limit is exceeded.
 type bucketLimitAppenderV2 struct {
 	storage.AppenderV2
 


### PR DESCRIPTION

#### Which issue(s) does the PR fix:

None.

#### Release notes for end users (**ALL** commits must be considered).

The doc comments on `bucketLimitAppender` and `bucketLimitAppenderV2` were copied
from `limitAppender` and never updated. They claim to "limit the number of total
appended samples in a batch", but neither type counts samples: both cap the number
of buckets in native histograms, reducing the histogram resolution (via
`ReduceResolution`) or returning `errBucketLimit` when the limit is exceeded.

`bucketLimitAppender.AppendHistogram` and `bucketLimitAppenderV2.Append` have no
per-batch sample counter (only a `limit int`); they compare
`len(h.PositiveBuckets)+len(h.NegativeBuckets)` against `limit`. This is the same
copied text that was already correct on `limitAppender` (which does count samples
and returns `errSampleLimit`), so the comment reads plausibly but describes the
wrong appender.

Two of the comments also named the wrong type after the AppenderV2 additions:

- `limitAppenderV2` started `// limitAppender ...` (its behaviour text was already
  correct; only the leading identifier was wrong).
- `bucketLimitAppenderV2` started `// bucketLimitAppender ...` (wrong on both the
  identifier and the behaviour text).

This corrects all three so each doc comment starts with the type it documents and
accurately describes bucket limiting. No behaviour change.

```release-notes
NONE
```
