### PR TITLE
storage/remote/azuread: run token provider tests in parallel

### DIFF
--- a/storage/remote/azuread/azuread_test.go
+++ b/storage/remote/azuread/azuread_test.go
@@ -47,11 +47,6 @@ type AzureAdTestSuite struct {
 	mockCredential *mockCredential
 }
 
-type TokenProviderTestSuite struct {
-	suite.Suite
-	mockCredential *mockCredential
-}
-
 // mockCredential mocks azidentity TokenCredential interface.
 type mockCredential struct {
 	mock.Mock
@@ -292,21 +287,16 @@ func (m *mockCredential) GetToken(ctx context.Context, options policy.TokenReque
 	return args.Get(0).(azcore.AccessToken), nil
 }
 
-func (s *TokenProviderTestSuite) BeforeTest(_, _ string) {
-	s.mockCredential = new(mockCredential)
-}
+func TestNewTokenProvider(t *testing.T) {
+	t.Parallel()
 
-func TestTokenProvider(t *testing.T) {
-	suite.Run(t, new(TokenProviderTestSuite))
-}
-
-func (s *TokenProviderTestSuite) TestNewTokenProvider() {
 	cases := []struct {
-		cfg *AzureADConfig
-		err string
+		name string
+		cfg  *AzureADConfig
+		err  string
 	}{
-		// Invalid tokenProvider for managedidentity.
 		{
+			name: "invalid managed identity cloud",
 			cfg: &AzureADConfig{
 				Cloud: "PublicAzure",
 				ManagedIdentity: &ManagedIdentityConfig{
@@ -315,8 +305,8 @@ func (s *TokenProviderTestSuite) TestNewTokenProvider() {
 			},
 			err: "Cloud is not specified or is incorrect: ",
 		},
-		// Invalid tokenProvider for oauth.
 		{
+			name: "invalid oauth cloud",
 			cfg: &AzureADConfig{
 				Cloud: "PublicAzure",
 				OAuth: &OAuthConfig{
@@ -327,8 +317,8 @@ func (s *TokenProviderTestSuite) TestNewTokenProvider() {
 			},
 			err: "Cloud is not specified or is incorrect: ",
 		},
-		// Invalid tokenProvider for SDK.
 		{
+			name: "invalid SDK cloud",
 			cfg: &AzureADConfig{
 				Cloud: "PublicAzure",
 				SDK: &SDKConfig{
@@ -337,8 +327,8 @@ func (s *TokenProviderTestSuite) TestNewTokenProvider() {
 			},
 			err: "Cloud is not specified or is incorrect: ",
 		},
-		// Invalid tokenProvider for workload identity.
 		{
+			name: "invalid workload identity cloud",
 			cfg: &AzureADConfig{
 				Cloud: "PublicAzure",
 				WorkloadIdentity: &WorkloadIdentityConfig{
@@ -349,8 +339,8 @@ func (s *TokenProviderTestSuite) TestNewTokenProvider() {
 			},
 			err: "Cloud is not specified or is incorrect: ",
 		},
-		// Valid tokenProvider for managedidentity.
 		{
+			name: "valid managed identity",
 			cfg: &AzureADConfig{
 				Cloud: "AzurePublic",
 				ManagedIdentity: &ManagedIdentityConfig{
@@ -358,8 +348,8 @@ func (s *TokenProviderTestSuite) TestNewTokenProvider() {
 				},
 			},
 		},
-		// Valid tokenProvider for oauth.
 		{
+			name: "valid oauth",
 			cfg: &AzureADConfig{
 				Cloud: "AzurePublic",
 				OAuth: &OAuthConfig{
@@ -369,8 +359,8 @@ func (s *TokenProviderTestSuite) TestNewTokenProvider() {
 				},
 			},
 		},
-		// Valid tokenProvider for SDK.
 		{
+			name: "valid SDK",
 			cfg: &AzureADConfig{
 				Cloud: "AzurePublic",
 				SDK: &SDKConfig{
@@ -378,8 +368,8 @@ func (s *TokenProviderTestSuite) TestNewTokenProvider() {
 				},
 			},
 		},
-		// Valid tokenProvider for workload identity.
 		{
+			name: "valid workload identity",
 			cfg: &AzureADConfig{
 				Cloud: "AzurePublic",
 				WorkloadIdentity: &WorkloadIdentityConfig{
@@ -390,42 +380,55 @@ func (s *TokenProviderTestSuite) TestNewTokenProvider() {
 			},
 		},
 	}
-	mockGetTokenCallCounter := 1
-	for _, c := range cases {
-		if c.err != "" {
-			actualTokenProvider, actualErr := newTokenProvider(c.cfg, s.mockCredential)
 
-			s.Nil(actualTokenProvider)
-			s.Require().Error(actualErr)
-			s.Require().ErrorContains(actualErr, c.err)
-		} else {
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Each subtest uses its own mock so cases can run concurrently.
+			mockCred := new(mockCredential)
+
+			if c.err != "" {
+				actualTokenProvider, actualErr := newTokenProvider(c.cfg, mockCred)
+
+				require.Nil(t, actualTokenProvider)
+				require.Error(t, actualErr)
+				require.ErrorContains(t, actualErr, c.err)
+				return
+			}
+
 			testToken := &azcore.AccessToken{
 				Token:     testTokenString,
 				ExpiresOn: testTokenExpiry(),
 			}
 
-			s.mockCredential.On("GetToken", mock.Anything, mock.Anything).Return(*testToken, nil).Once().
+			mockCred.On("GetToken", mock.Anything, mock.Anything).Return(*testToken, nil).Once().
 				On("GetToken", mock.Anything, mock.Anything).Return(getToken(), nil).Once()
 
-			actualTokenProvider, actualErr := newTokenProvider(c.cfg, s.mockCredential)
+			actualTokenProvider, actualErr := newTokenProvider(c.cfg, mockCred)
 
-			s.NotNil(actualTokenProvider)
-			s.Require().NoError(actualErr)
-			s.NotNil(actualTokenProvider.getAccessToken(context.Background()))
+			require.NotNil(t, actualTokenProvider)
+			require.NoError(t, actualErr)
+			require.NotEmpty(t, mustGetAccessToken(t, actualTokenProvider))
 
 			// Token set to refresh at half of the expiry time. The test tokens are set to expiry in 5s.
 			// Hence, the 4 seconds wait to check if the token is refreshed.
 			time.Sleep(4 * time.Second)
 
-			s.NotNil(actualTokenProvider.getAccessToken(context.Background()))
+			require.NotEmpty(t, mustGetAccessToken(t, actualTokenProvider))
 
-			s.mockCredential.AssertNumberOfCalls(s.T(), "GetToken", 2*mockGetTokenCallCounter)
-			mockGetTokenCallCounter++
-			accessToken, err := actualTokenProvider.getAccessToken(context.Background())
-			s.Require().NoError(err)
-			s.NotEqual(testTokenString, accessToken)
-		}
+			mockCred.AssertNumberOfCalls(t, "GetToken", 2)
+			accessToken := mustGetAccessToken(t, actualTokenProvider)
+			require.NotEqual(t, testTokenString, accessToken)
+		})
 	}
+}
+
+func mustGetAccessToken(t *testing.T, tp *tokenProvider) string {
+	t.Helper()
+	accessToken, err := tp.getAccessToken(context.Background())
+	require.NoError(t, err)
+	return accessToken
 }
 
 func getToken() azcore.AccessToken {


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
 
`TestNewTokenProvider` had four valid auth cases that each `time.Sleep(4 * time.Second)` while waiting for token refresh, run sequentially via a testify suite (~16s total for the package).
  
Convert it to a standard table-driven test where each case:
- uses its own `mockCredential` (no shared mock / call-counter state)
- runs under `t.Parallel()`

The four refresh waits now overlap, so package time drops to a single sleep.

On my machine:

**Before:**
```
go test -count=1 ./storage/remote/azuread
ok  	github.com/prometheus/prometheus/storage/remote/azuread	16.021s
```

**After:**
```
go test -count=1 ./storage/remote/azuread
ok  	github.com/prometheus/prometheus/storage/remote/azuread	4.016s
```

Verified stable across repeated runs (`-count=3`) and with `go test -race ./storage/remote/azuread -count=2`.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #15185

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```