### PR TITLE
rules: delete remaining rule_group metrics on group removal

### DIFF
--- a/rules/manager.go
+++ b/rules/manager.go
@@ -311,6 +311,8 @@ func (m *Manager) Update(interval time.Duration, files []string, externalLabels 
 				m.GroupLastDuration.DeleteLabelValues(n)
 				m.GroupRules.DeleteLabelValues(n)
 				m.GroupSamples.DeleteLabelValues((n))
+				m.GroupLastRuleDurationSum.DeleteLabelValues(n)
+				m.GroupLastRestoreDuration.DeleteLabelValues(n)
 			}
 			wg.Done()
 		}(n, oldg)

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -978,6 +978,7 @@ func TestMetricsUpdate(t *testing.T) {
 		"prometheus_rule_evaluation_failures_total",
 		"prometheus_rule_group_interval_seconds",
 		"prometheus_rule_group_last_duration_seconds",
+		"prometheus_rule_group_last_rule_duration_sum_seconds",
 		"prometheus_rule_group_last_evaluation_timestamp_seconds",
 		"prometheus_rule_group_rules",
 	}
@@ -1022,11 +1023,11 @@ func TestMetricsUpdate(t *testing.T) {
 	}{
 		{
 			files:   files,
-			metrics: 12,
+			metrics: 14,
 		},
 		{
 			files:   files[:1],
-			metrics: 6,
+			metrics: 7,
 		},
 		{
 			files:   files[:0],
@@ -1034,7 +1035,7 @@ func TestMetricsUpdate(t *testing.T) {
 		},
 		{
 			files:   files[1:],
-			metrics: 6,
+			metrics: 7,
 		},
 	}
 


### PR DESCRIPTION
#### Description

When a rule group is removed or renamed on config reload, `Manager.Update` deletes the `rule_group`-labeled series for the group metrics, but two metrics carrying the same `rule_group` label were missed:

- `GroupLastRuleDurationSum` (`rule_group_last_rule_duration_sum_seconds`)
- `GroupLastRestoreDuration` (`rule_group_last_restore_duration_seconds`)

Both are `GaugeVec`s labeled by `rule_group` and set per group (on every evaluation and on restore respectively), so their series were never cleaned up. Every reload that dropped or renamed a group leaked two stale series per group, growing memory and `/metrics` cardinality over time.

This adds the two missing `DeleteLabelValues` calls next to the existing cleanup, and extends `TestMetricsUpdate` to include `rule_group_last_rule_duration_sum_seconds`. The test fails without the fix (the dropped group's series remain) and passes with it.

#### Testing

`go test ./rules/ -run TestMetricsUpdate` passes with the fix and fails without it.

```release-notes
[BUGFIX] Rules: Delete the `rule_group_last_rule_duration_sum_seconds` and `rule_group_last_restore_duration_seconds` series when a rule group is removed or renamed on reload.
```
