### PR TITLE
tsdb: fix flaky TestQuerierShouldNotFailIfOOOCompactionOccurs* tests

### DIFF
--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -2521,11 +2521,11 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier_AppendV
 
 	// Start OOO head compaction.
 	compactionComplete := atomic.NewBool(false)
+	compactionErr := make(chan error, 1)
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx))
-		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
+		compactionErr <- db.CompactOOOHead(ctx)
 	}()
 
 	// Give CompactOOOHead time to start work.
@@ -2565,7 +2565,12 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier_AppendV
 
 	require.False(t, compactionComplete.Load(), "compaction completed before closing querier created before compaction")
 	require.NoError(t, querierCreatedBeforeCompaction.Close())
-	require.Eventually(t, compactionComplete.Load, time.Second, 10*time.Millisecond, "compaction should complete after querier created before compaction was closed, and not wait for querier created after compaction")
+	// CompactOOOHead only re-checks for pending readers every 500ms and still has
+	// to garbage collect chunks and truncate the WBL after it notices the close,
+	// so give slow runners plenty of time beyond the poll interval.
+	require.Eventually(t, compactionComplete.Load, time.Minute, 10*time.Millisecond, "compaction should complete after querier created before compaction was closed, and not wait for querier created after compaction")
+	require.NoError(t, <-compactionErr)
+	require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 
 	// Use the querier created after compaction and confirm it returns the expected results (ie. from the disk block created from OOO head and in-order head) without error.
 	testQuerier(querierCreatedAfterCompaction)
@@ -2616,11 +2621,11 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterSelecting_AppendV2(t *tes
 
 	// Start OOO head compaction.
 	compactionComplete := atomic.NewBool(false)
+	compactionErr := make(chan error, 1)
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx))
-		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
+		compactionErr <- db.CompactOOOHead(ctx)
 	}()
 
 	// Give CompactOOOHead time to start work.
@@ -2648,7 +2653,12 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterSelecting_AppendV2(t *tes
 
 	require.False(t, compactionComplete.Load(), "compaction completed before closing querier")
 	require.NoError(t, querier.Close())
-	require.Eventually(t, compactionComplete.Load, time.Second, 10*time.Millisecond, "compaction should complete after querier was closed")
+	// CompactOOOHead only re-checks for pending readers every 500ms and still has
+	// to garbage collect chunks and truncate the WBL after it notices the close,
+	// so give slow runners plenty of time beyond the poll interval.
+	require.Eventually(t, compactionComplete.Load, time.Minute, 10*time.Millisecond, "compaction should complete after querier was closed")
+	require.NoError(t, <-compactionErr)
+	require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 }
 
 func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingIterators_AppendV2(t *testing.T) {
@@ -2704,11 +2714,11 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingIterators_Appen
 
 	// Start OOO head compaction.
 	compactionComplete := atomic.NewBool(false)
+	compactionErr := make(chan error, 1)
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx))
-		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
+		compactionErr <- db.CompactOOOHead(ctx)
 	}()
 
 	// Give CompactOOOHead time to start work.
@@ -2727,7 +2737,12 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingIterators_Appen
 
 	require.False(t, compactionComplete.Load(), "compaction completed before closing querier")
 	require.NoError(t, querier.Close())
-	require.Eventually(t, compactionComplete.Load, time.Second, 10*time.Millisecond, "compaction should complete after querier was closed")
+	// CompactOOOHead only re-checks for pending readers every 500ms and still has
+	// to garbage collect chunks and truncate the WBL after it notices the close,
+	// so give slow runners plenty of time beyond the poll interval.
+	require.Eventually(t, compactionComplete.Load, time.Minute, 10*time.Millisecond, "compaction should complete after querier was closed")
+	require.NoError(t, <-compactionErr)
+	require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 }
 
 func TestOOOWALWrite_AppendV2(t *testing.T) {

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3958,11 +3958,11 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier(t *test
 
 	// Start OOO head compaction.
 	compactionComplete := atomic.NewBool(false)
+	compactionErr := make(chan error, 1)
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx))
-		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
+		compactionErr <- db.CompactOOOHead(ctx)
 	}()
 
 	// Give CompactOOOHead time to start work.
@@ -4002,7 +4002,12 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier(t *test
 
 	require.False(t, compactionComplete.Load(), "compaction completed before closing querier created before compaction")
 	require.NoError(t, querierCreatedBeforeCompaction.Close())
-	require.Eventually(t, compactionComplete.Load, time.Second, 10*time.Millisecond, "compaction should complete after querier created before compaction was closed, and not wait for querier created after compaction")
+	// CompactOOOHead only re-checks for pending readers every 500ms and still has
+	// to garbage collect chunks and truncate the WBL after it notices the close,
+	// so give slow runners plenty of time beyond the poll interval.
+	require.Eventually(t, compactionComplete.Load, time.Minute, 10*time.Millisecond, "compaction should complete after querier created before compaction was closed, and not wait for querier created after compaction")
+	require.NoError(t, <-compactionErr)
+	require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 
 	// Use the querier created after compaction and confirm it returns the expected results (ie. from the disk block created from OOO head and in-order head) without error.
 	testQuerier(querierCreatedAfterCompaction)
@@ -4053,11 +4058,11 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterSelecting(t *testing.T) {
 
 	// Start OOO head compaction.
 	compactionComplete := atomic.NewBool(false)
+	compactionErr := make(chan error, 1)
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx))
-		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
+		compactionErr <- db.CompactOOOHead(ctx)
 	}()
 
 	// Give CompactOOOHead time to start work.
@@ -4085,7 +4090,12 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterSelecting(t *testing.T) {
 
 	require.False(t, compactionComplete.Load(), "compaction completed before closing querier")
 	require.NoError(t, querier.Close())
-	require.Eventually(t, compactionComplete.Load, time.Second, 10*time.Millisecond, "compaction should complete after querier was closed")
+	// CompactOOOHead only re-checks for pending readers every 500ms and still has
+	// to garbage collect chunks and truncate the WBL after it notices the close,
+	// so give slow runners plenty of time beyond the poll interval.
+	require.Eventually(t, compactionComplete.Load, time.Minute, 10*time.Millisecond, "compaction should complete after querier was closed")
+	require.NoError(t, <-compactionErr)
+	require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 }
 
 func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingIterators(t *testing.T) {
@@ -4141,11 +4151,11 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingIterators(t *te
 
 	// Start OOO head compaction.
 	compactionComplete := atomic.NewBool(false)
+	compactionErr := make(chan error, 1)
 	go func() {
 		defer compactionComplete.Store(true)
 
-		require.NoError(t, db.CompactOOOHead(ctx))
-		require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
+		compactionErr <- db.CompactOOOHead(ctx)
 	}()
 
 	// Give CompactOOOHead time to start work.
@@ -4164,7 +4174,12 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingIterators(t *te
 
 	require.False(t, compactionComplete.Load(), "compaction completed before closing querier")
 	require.NoError(t, querier.Close())
-	require.Eventually(t, compactionComplete.Load, time.Second, 10*time.Millisecond, "compaction should complete after querier was closed")
+	// CompactOOOHead only re-checks for pending readers every 500ms and still has
+	// to garbage collect chunks and truncate the WBL after it notices the close,
+	// so give slow runners plenty of time beyond the poll interval.
+	require.Eventually(t, compactionComplete.Load, time.Minute, 10*time.Millisecond, "compaction should complete after querier was closed")
+	require.NoError(t, <-compactionErr)
+	require.Equal(t, float64(1), prom_testutil.ToFloat64(db.Head().metrics.chunksRemoved))
 }
 
 func TestOOOWALWrite(t *testing.T) {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Part of #17941 (the remaining `TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier_AppendV2` / `_Iterators_AppendV2` Windows item; intentionally not `Fixes` so the meta issue stays open).

#### What this PR does:

All six `TestQuerierShouldNotFailIfOOOCompactionOccurs*` tests (three in `db_test.go`, three `_AppendV2` variants) wait at most **one second** for `CompactOOOHead` to complete after closing the blocking querier:

```go
require.Eventually(t, compactionComplete.Load, time.Second, 10*time.Millisecond, ...)
```

That window sits right at the failure boundary by construction: the compaction goroutine only notices the querier close by **polling in 500ms intervals** (`WaitForPendingReadersForOOOChunksAtOrBefore`, [head.go#L1393-L1397](https://github.com/prometheus/prometheus/blob/main/tsdb/head.go#L1393-L1397)), and after it notices it still has to garbage collect chunks and truncate the WBL. On slow Windows CI runners that regularly exceeds one second, producing the failures posted in #17941.

Two changes, test-only:

1. **Widen the `require.Eventually` window from 1s to 1min.** `Eventually` returns as soon as the condition holds, so fast runners lose nothing; slow runners stop flaking.
2. **Move the `require` calls out of the compaction goroutine.** `require` must not be called from non-test goroutines (`t.FailNow` only works on the test goroutine). This is also what produced the confusing secondary `compact ooo head: populate block: context canceled` failures in the CI logs: after the `Eventually` timeout failed the test, cleanup closed the DB, and the still-running goroutine's `require.NoError` fired with the cancellation error. The goroutine now reports its error through a channel and all assertions (including the `chunksRemoved` metric check) happen on the test goroutine after completion.

The initial `time.Sleep(time.Second)` + `require.False` (asserting compaction blocks while the querier is open) is left untouched — its semantics are unaffected.

#### Verification

Ran natively on **Windows** (the platform where the flake reproduces): all six tests, three runs each, green (`go test ./tsdb/ -run "TestQuerierShouldNotFailIfOOOCompactionOccurs" -count=3`).

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```
