### PR TITLE
tsdb: handle Close() errors in querier cleanup defers

### DIFF
--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -2577,8 +2577,9 @@ func (db *DB) Querier(mint, maxt int64) (_ storage.Querier, err error) {
 		if err != nil {
 			// If we fail, all previously opened queriers must be closed.
 			for _, q := range blockQueriers {
-				// TODO(bwplotka): Handle error.
-				_ = q.Close()
+				if closeErr := q.Close(); closeErr != nil {
+					err = errors.Join(err, fmt.Errorf("close querier during cleanup: %w", closeErr))
+				}
 			}
 		}
 	}()
@@ -2655,8 +2656,9 @@ func (db *DB) blockChunkQuerierForRange(mint, maxt int64) (_ []storage.ChunkQuer
 		if err != nil {
 			// If we fail, all previously opened queriers must be closed.
 			for _, q := range blockQueriers {
-				// TODO(bwplotka): Handle error.
-				_ = q.Close()
+				if closeErr := q.Close(); closeErr != nil {
+					err = errors.Join(err, fmt.Errorf("close querier during cleanup: %w", closeErr))
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #19114

---

### What this PR does

This PR handles the previously ignored `Close()` errors in the cleanup paths of `Querier()` and `blockChunkQuerierForRange()` in `tsdb/db.go`.

Previously, both cleanup blocks discarded errors returned from closing block queriers:

```go
for _, q := range blockQueriers {
    _ = q.Close()
}
```

These cleanup paths run while the function is already returning an error. If closing a querier also failed, that additional failure was lost.

This change uses `errors.Join()` to preserve the original error while also returning any cleanup errors:

```go
if closeErr := q.Close(); closeErr != nil {
    err = errors.Join(err, fmt.Errorf("close querier during cleanup: %w", closeErr))
}
```

This keeps the existing error behavior while providing more context when cleanup fails. The successful path remains unchanged.

---

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] TSDB: Preserve querier Close() errors during cleanup instead of silently discarding them.
```
