### PR TITLE
api: deprecate unsupported values of the `stats` query parameter

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -102,7 +102,7 @@ URL query parameters:
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Doesn't affect scalars or strings but truncates the number of series for matrices and vectors. Optional. 0 means disabled.
 - `lookback_delta=<duration | float>`: Override the [lookback period](#staleness) just for this query in `duration` format or float number of seconds. Optional.
-- `stats=<string>`: Include query statistics in the response. If set to `all`, includes detailed statistics (timings and sample counts). Optional. See [Query statistics](#query-statistics).
+- `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts); any other non-empty value is rejected. Optional. See [Query statistics](#query-statistics).
 
 The current server time is used if the `time` parameter is omitted.
 
@@ -176,7 +176,7 @@ URL query parameters:
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Optional. 0 means disabled.
 - `lookback_delta=<duration | float>`: Override the [lookback period](#staleness) just for this query in `duration` format or float number of seconds. Optional.
-- `stats=<string>`: Include query statistics in the response. If set to `all`, includes detailed statistics (timings and sample counts). Optional. See [Query statistics](#query-statistics).
+- `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts); any other non-empty value is rejected. Optional. See [Query statistics](#query-statistics).
 
 You can URL-encode these parameters directly in the request body by using the `POST` method and
 `Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large

--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -102,7 +102,7 @@ URL query parameters:
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Doesn't affect scalars or strings but truncates the number of series for matrices and vectors. Optional. 0 means disabled.
 - `lookback_delta=<duration | float>`: Override the [lookback period](#staleness) just for this query in `duration` format or float number of seconds. Optional.
-- `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts); any other non-empty value is rejected. Optional. See [Query statistics](#query-statistics).
+- `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts). Any other non-empty value currently behaves like `true`, but is deprecated, adds a warning to the response, and will be rejected in the next major release. Optional. See [Query statistics](#query-statistics).
 
 The current server time is used if the `time` parameter is omitted.
 
@@ -176,7 +176,7 @@ URL query parameters:
    is capped by the value of the `-query.timeout` flag.
 - `limit=<number>`: Maximum number of returned series. Optional. 0 means disabled.
 - `lookback_delta=<duration | float>`: Override the [lookback period](#staleness) just for this query in `duration` format or float number of seconds. Optional.
-- `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts); any other non-empty value is rejected. Optional. See [Query statistics](#query-statistics).
+- `stats=<string>`: Include query statistics in the response. Supported values are `true` (basic statistics) and `all` (additionally includes detailed per-step statistics: timings and sample counts). Any other non-empty value currently behaves like `true`, but is deprecated, adds a warning to the response, and will be rejected in the next major release. Optional. See [Query statistics](#query-statistics).
 
 You can URL-encode these parameters directly in the request body by using the `POST` method and
 `Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -153,9 +153,10 @@ type StatsRenderer func(context.Context, *stats.Statistics, string) stats.QueryS
 
 // DefaultStatsRenderer is the default stats renderer for the API: any
 // non-empty `stats` value includes statistics in the response. The API
-// handlers validate the parameter against the supported values ("true",
-// "all") before rendering; custom StatsRenderer implementations are exempt
-// from that validation and may define their own values.
+// handlers attach a deprecation warning to the response for values outside
+// the supported enum ("true", "all"); those values will be rejected in the
+// next major release. Custom StatsRenderer implementations are exempt and
+// may define their own values.
 func DefaultStatsRenderer(_ context.Context, s *stats.Statistics, param string) stats.QueryStats {
 	if param != "" {
 		return stats.NewQueryStats(s)
@@ -531,9 +532,6 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 	if err != nil {
 		return invalidParamError(err, "time")
 	}
-	if err := api.validateStatsParam(r.FormValue("stats")); err != nil {
-		return invalidParamError(err, "stats")
-	}
 	ctx := r.Context()
 	if to := r.FormValue("timeout"); to != "" {
 		var cancel context.CancelFunc
@@ -579,6 +577,9 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 		if isTruncated {
 			warnings = warnings.Add(errors.New("results truncated due to limit"))
 		}
+	}
+	if warn := api.statsParamWarning(r.FormValue("stats")); warn != nil {
+		warnings = warnings.Add(warn)
 	}
 	// Optional stats field in response if parameter "stats" is not empty.
 	sr := api.statsRenderer
@@ -636,12 +637,15 @@ const (
 	statsAll  = "all"
 )
 
-// validateStatsParam rejects unsupported values of the `stats` query
-// parameter. Historically any non-empty value silently enabled basic
-// statistics; validating it as an enum matches how e.g. /api/v1/rules
-// validates `type`. Embedders that install a custom StatsRenderer define
-// their own vocabulary for the parameter, so no validation happens then.
-func (api *API) validateStatsParam(stats string) error {
+// statsParamWarning returns a deprecation warning for unsupported values of
+// the `stats` query parameter, to be attached to the response's warnings.
+// Historically any non-empty value silently enabled basic statistics; that
+// behaviour is kept for compatibility within the current major release, but
+// values outside the supported enum ("true", "all") are deprecated and will
+// be rejected in the next major release. Embedders that install a custom
+// StatsRenderer define their own vocabulary for the parameter, so no warning
+// is attached then.
+func (api *API) statsParamWarning(stats string) error {
 	if api.customStatsRenderer {
 		return nil
 	}
@@ -649,7 +653,7 @@ func (api *API) validateStatsParam(stats string) error {
 	case "", statsTrue, statsAll:
 		return nil
 	default:
-		return fmt.Errorf("not supported value %q, must be %q or %q", stats, statsTrue, statsAll)
+		return fmt.Errorf("value %q for parameter \"stats\" is deprecated and will be rejected in the next major release, use %q or %q", stats, statsTrue, statsAll)
 	}
 }
 
@@ -677,10 +681,6 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 
 	if step <= 0 {
 		return invalidParamError(errors.New("zero or negative query resolution step widths are not accepted. Try a positive integer"), "step")
-	}
-
-	if err := api.validateStatsParam(r.FormValue("stats")); err != nil {
-		return invalidParamError(err, "stats")
 	}
 
 	// For safety, limit the number of returned points per timeseries.
@@ -734,6 +734,9 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 		if isTruncated {
 			warnings = warnings.Add(errors.New("results truncated due to limit"))
 		}
+	}
+	if warn := api.statsParamWarning(r.FormValue("stats")); warn != nil {
+		warnings = warnings.Add(warn)
 	}
 
 	// Optional stats field in response if parameter "stats" is not empty.

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -151,7 +151,11 @@ type RulesRetriever interface {
 // StatsRenderer converts engine statistics into a format suitable for the API.
 type StatsRenderer func(context.Context, *stats.Statistics, string) stats.QueryStats
 
-// DefaultStatsRenderer is the default stats renderer for the API.
+// DefaultStatsRenderer is the default stats renderer for the API: any
+// non-empty `stats` value includes statistics in the response. The API
+// handlers validate the parameter against the supported values ("true",
+// "all") before rendering; custom StatsRenderer implementations are exempt
+// from that validation and may define their own values.
 func DefaultStatsRenderer(_ context.Context, s *stats.Statistics, param string) stats.QueryStats {
 	if param != "" {
 		return stats.NewQueryStats(s)
@@ -250,6 +254,7 @@ type API struct {
 	gatherer            prometheus.Gatherer
 	isAgent             bool
 	statsRenderer       StatsRenderer
+	customStatsRenderer bool // See validateStatsParam: a custom StatsRenderer's `stats` vocabulary is not validated.
 	notificationsGetter func() []notifications.Notification
 	notificationsSub    func() (<-chan notifications.Notification, func(), bool)
 	// Allows customizing the default mapping
@@ -357,6 +362,7 @@ func NewAPI(
 
 	if statsRenderer != nil {
 		a.statsRenderer = statsRenderer
+		a.customStatsRenderer = true
 	}
 
 	if (ap == nil || apV2 == nil) && (rwEnabled || otlpEnabled) {
@@ -525,6 +531,9 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 	if err != nil {
 		return invalidParamError(err, "time")
 	}
+	if err := api.validateStatsParam(r.FormValue("stats")); err != nil {
+		return invalidParamError(err, "stats")
+	}
 	ctx := r.Context()
 	if to := r.FormValue("timeout"); to != "" {
 		var cancel context.CancelFunc
@@ -614,7 +623,34 @@ func extractQueryOpts(r *http.Request) (promql.QueryOpts, error) {
 		duration = parsedDuration
 	}
 
-	return promql.NewPrometheusQueryOpts(r.FormValue("stats") == "all", duration), nil
+	return promql.NewPrometheusQueryOpts(r.FormValue("stats") == statsAll, duration), nil
+}
+
+// Accepted values of the `stats` query parameter on /query and /query_range
+// when the default stats renderer is in use: statsTrue includes basic query
+// statistics in the response, statsAll additionally includes per-step
+// statistics (with --enable-feature=promql-per-step-stats). Empty disables
+// statistics.
+const (
+	statsTrue = "true"
+	statsAll  = "all"
+)
+
+// validateStatsParam rejects unsupported values of the `stats` query
+// parameter. Historically any non-empty value silently enabled basic
+// statistics; validating it as an enum matches how e.g. /api/v1/rules
+// validates `type`. Embedders that install a custom StatsRenderer define
+// their own vocabulary for the parameter, so no validation happens then.
+func (api *API) validateStatsParam(stats string) error {
+	if api.customStatsRenderer {
+		return nil
+	}
+	switch stats {
+	case "", statsTrue, statsAll:
+		return nil
+	default:
+		return fmt.Errorf("not supported value %q, must be %q or %q", stats, statsTrue, statsAll)
+	}
 }
 
 func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
@@ -641,6 +677,10 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 
 	if step <= 0 {
 		return invalidParamError(errors.New("zero or negative query resolution step widths are not accepted. Try a positive integer"), "step")
+	}
+
+	if err := api.validateStatsParam(r.FormValue("stats")); err != nil {
+		return invalidParamError(err, "stats")
 	}
 
 	// For safety, limit the number of returned points per timeseries.

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -645,15 +645,15 @@ const (
 // be rejected in the next major release. Embedders that install a custom
 // StatsRenderer define their own vocabulary for the parameter, so no warning
 // is attached then.
-func (api *API) statsParamWarning(stats string) error {
+func (api *API) statsParamWarning(s string) error {
 	if api.customStatsRenderer {
 		return nil
 	}
-	switch stats {
+	switch s {
 	case "", statsTrue, statsAll:
 		return nil
 	default:
-		return fmt.Errorf("value %q for parameter \"stats\" is deprecated and will be rejected in the next major release, use %q or %q", stats, statsTrue, statsAll)
+		return fmt.Errorf("value %q for parameter \"stats\" is deprecated and will be rejected in the next major release, use %q or %q", s, statsTrue, statsAll)
 	}
 }
 

--- a/web/api/v1/api_scenarios_test.go
+++ b/web/api/v1/api_scenarios_test.go
@@ -14,6 +14,7 @@
 package v1
 
 import (
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -429,16 +430,19 @@ func TestAPIWithStats(t *testing.T) {
 
 	now := time.Now().Unix()
 
-	// Test combinations of methods, endpoints, and stats values.
+	// Test combinations of methods, endpoints, and stats values. Values
+	// outside the supported enum ("true", "all") are rejected with 400 —
+	// historically any non-empty value silently enabled basic statistics.
 	methods := []string{"GET", "POST"}
 	statsValues := []struct {
-		value       string
-		expectStats bool
+		value        string
+		expectStats  bool
+		expectReject bool
 	}{
-		{"true", true},
-		{"all", true},
-		{"1", true},
-		{"", false},
+		{"true", true, false},
+		{"all", true, false},
+		{"1", false, true},
+		{"", false, false},
 	}
 
 	for _, method := range methods {
@@ -456,6 +460,11 @@ func TestAPIWithStats(t *testing.T) {
 					resp = testhelpers.GET(t, api, "/api/v1/query", params...)
 				} else {
 					resp = testhelpers.POST(t, api, "/api/v1/query", params...)
+				}
+
+				if stats.expectReject {
+					resp.RequireStatusCode(http.StatusBadRequest).ValidateOpenAPI()
+					return
 				}
 
 				resp.RequireSuccess().ValidateOpenAPI()
@@ -493,6 +502,11 @@ func TestAPIWithStats(t *testing.T) {
 					resp = testhelpers.GET(t, api, "/api/v1/query_range", params...)
 				} else {
 					resp = testhelpers.POST(t, api, "/api/v1/query_range", params...)
+				}
+
+				if stats.expectReject {
+					resp.RequireStatusCode(http.StatusBadRequest).ValidateOpenAPI()
+					return
 				}
 
 				resp.RequireSuccess().ValidateOpenAPI()

--- a/web/api/v1/api_scenarios_test.go
+++ b/web/api/v1/api_scenarios_test.go
@@ -14,7 +14,6 @@
 package v1
 
 import (
-	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -431,19 +430,22 @@ func TestAPIWithStats(t *testing.T) {
 	now := time.Now().Unix()
 
 	// Test combinations of methods, endpoints, and stats values. Values
-	// outside the supported enum ("true", "all") are rejected with 400 —
-	// historically any non-empty value silently enabled basic statistics.
+	// outside the supported enum ("true", "all") keep the historical
+	// behaviour (any non-empty value enables basic statistics) but attach a
+	// deprecation warning to the response; they will be rejected in the next
+	// major release.
 	methods := []string{"GET", "POST"}
 	statsValues := []struct {
-		value        string
-		expectStats  bool
-		expectReject bool
+		value         string
+		expectStats   bool
+		expectWarning bool
 	}{
 		{"true", true, false},
 		{"all", true, false},
-		{"1", false, true},
+		{"1", true, true},
 		{"", false, false},
 	}
+	deprecationWarning := `value "1" for parameter "stats" is deprecated and will be rejected in the next major release, use "true" or "all"`
 
 	for _, method := range methods {
 		for _, stats := range statsValues {
@@ -462,12 +464,13 @@ func TestAPIWithStats(t *testing.T) {
 					resp = testhelpers.POST(t, api, "/api/v1/query", params...)
 				}
 
-				if stats.expectReject {
-					resp.RequireStatusCode(http.StatusBadRequest).ValidateOpenAPI()
-					return
-				}
-
 				resp.RequireSuccess().ValidateOpenAPI()
+
+				if stats.expectWarning {
+					resp.RequireArrayContains("$.warnings", deprecationWarning)
+				} else {
+					resp.RequireJSONPathNotExists("$.warnings")
+				}
 
 				if stats.expectStats {
 					resp.RequireJSONPathExists("$.data.stats").
@@ -504,12 +507,13 @@ func TestAPIWithStats(t *testing.T) {
 					resp = testhelpers.POST(t, api, "/api/v1/query_range", params...)
 				}
 
-				if stats.expectReject {
-					resp.RequireStatusCode(http.StatusBadRequest).ValidateOpenAPI()
-					return
-				}
-
 				resp.RequireSuccess().ValidateOpenAPI()
+
+				if stats.expectWarning {
+					resp.RequireArrayContains("$.warnings", deprecationWarning)
+				} else {
+					resp.RequireJSONPathNotExists("$.warnings")
+				}
 
 				if stats.expectStats {
 					resp.RequireJSONPathExists("$.data.stats").

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -956,11 +956,12 @@ func TestStats(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name     string
-		renderer StatsRenderer
-		param    string
-		wantErr  errorType
-		expected func(*testing.T, any)
+		name        string
+		renderer    StatsRenderer
+		param       string
+		wantErr     errorType
+		wantWarning bool
+		expected    func(*testing.T, any)
 	}{
 		{
 			name:  "stats is blank",
@@ -972,14 +973,26 @@ func TestStats(t *testing.T) {
 			},
 		},
 		{
-			name:    "stats is an unsupported value",
-			param:   "foo",
-			wantErr: errorBadData,
+			name:        "stats is an unsupported value",
+			param:       "foo",
+			wantWarning: true,
+			expected: func(t *testing.T, i any) {
+				// Deprecated values keep the historical behaviour for now:
+				// any non-empty value enables basic statistics.
+				require.IsType(t, &QueryData{}, i)
+				qd := i.(*QueryData)
+				require.NotNil(t, qd.Stats)
+			},
 		},
 		{
-			name:    "stats is an unsupported truthy value",
-			param:   "1",
-			wantErr: errorBadData,
+			name:        "stats is an unsupported truthy value",
+			param:       "1",
+			wantWarning: true,
+			expected: func(t *testing.T, i any) {
+				require.IsType(t, &QueryData{}, i)
+				qd := i.(*QueryData)
+				require.NotNil(t, qd.Stats)
+			},
 		},
 		{
 			name:  "stats is true",
@@ -1042,6 +1055,17 @@ func TestStats(t *testing.T) {
 			api.statsRenderer = tc.renderer
 			api.customStatsRenderer = tc.renderer != nil
 
+			assertWarnings := func(res apiFuncResult) {
+				if tc.wantWarning {
+					require.Len(t, res.warnings, 1)
+					for msg := range res.warnings {
+						require.Contains(t, msg, "deprecated")
+					}
+				} else {
+					require.Empty(t, res.warnings)
+				}
+			}
+
 			for _, method := range []string{http.MethodGet, http.MethodPost} {
 				ctx := context.Background()
 				req, err := request(method, tc.param)
@@ -1050,12 +1074,14 @@ func TestStats(t *testing.T) {
 				assertAPIError(t, res.err, tc.wantErr)
 				if tc.wantErr == errorNone {
 					tc.expected(t, res.data)
+					assertWarnings(res)
 				}
 
 				res = api.queryRange(req.WithContext(ctx))
 				assertAPIError(t, res.err, tc.wantErr)
 				if tc.wantErr == errorNone {
 					tc.expected(t, res.data)
+					assertWarnings(res)
 				}
 			}
 		})

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -959,6 +959,7 @@ func TestStats(t *testing.T) {
 		name     string
 		renderer StatsRenderer
 		param    string
+		wantErr  errorType
 		expected func(*testing.T, any)
 	}{
 		{
@@ -969,6 +970,16 @@ func TestStats(t *testing.T) {
 				qd := i.(*QueryData)
 				require.Nil(t, qd.Stats)
 			},
+		},
+		{
+			name:    "stats is an unsupported value",
+			param:   "foo",
+			wantErr: errorBadData,
+		},
+		{
+			name:    "stats is an unsupported truthy value",
+			param:   "1",
+			wantErr: errorBadData,
 		},
 		{
 			name:  "stats is true",
@@ -1024,21 +1035,28 @@ func TestStats(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			before := api.statsRenderer
-			defer func() { api.statsRenderer = before }()
+			before, customBefore := api.statsRenderer, api.customStatsRenderer
+			defer func() { api.statsRenderer, api.customStatsRenderer = before, customBefore }()
+			// Installing a renderer through NewAPI marks it as custom, which
+			// exempts the `stats` value from validation; mirror that here.
 			api.statsRenderer = tc.renderer
+			api.customStatsRenderer = tc.renderer != nil
 
 			for _, method := range []string{http.MethodGet, http.MethodPost} {
 				ctx := context.Background()
 				req, err := request(method, tc.param)
 				require.NoError(t, err)
 				res := api.query(req.WithContext(ctx))
-				assertAPIError(t, res.err, errorNone)
-				tc.expected(t, res.data)
+				assertAPIError(t, res.err, tc.wantErr)
+				if tc.wantErr == errorNone {
+					tc.expected(t, res.data)
+				}
 
 				res = api.queryRange(req.WithContext(ctx))
-				assertAPIError(t, res.err, errorNone)
-				tc.expected(t, res.data)
+				assertAPIError(t, res.err, tc.wantErr)
+				if tc.wantErr == errorNone {
+					tc.expected(t, res.data)
+				}
 			}
 		})
 	}

--- a/web/api/v1/openapi_paths.go
+++ b/web/api/v1/openapi_paths.go
@@ -32,7 +32,7 @@ func (*OpenAPIBuilder) queryPath() *v3.PathItem {
 		queryParamWithExample("query", "The PromQL query to execute.", true, stringSchema(), []example{{"example", "up"}}),
 		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, durationSchema(), []example{{"duration", "1m30s"}, {"number", "90"}}),
 		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, durationSchema(), []example{{"duration", "5m"}, {"number", "300"}}),
-		queryParamWithExample("stats", "Include query statistics in the response. Supported values: 'true' (basic statistics) and 'all' (basic plus per-step statistics). Other non-empty values are rejected.", false, stringSchema(), []example{{"example", "all"}}),
+		queryParamWithExample("stats", "Include query statistics in the response. Supported values: 'true' (basic statistics) and 'all' (basic plus per-step statistics). Other non-empty values are deprecated (they behave like 'true') and will be rejected in the next major release.", false, stringSchema(), []example{{"example", "all"}}),
 	}
 	return &v3.PathItem{
 		Get: &v3.Operation{
@@ -61,7 +61,7 @@ func (*OpenAPIBuilder) queryRangePath() *v3.PathItem {
 		queryParamWithExample("query", "The query to execute.", true, stringSchema(), []example{{"example", "rate(prometheus_http_requests_total{handler=\"/api/v1/query\"}[5m])"}}),
 		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, durationSchema(), []example{{"duration", "1m30s"}, {"number", "90"}}),
 		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, durationSchema(), []example{{"duration", "5m"}, {"number", "300"}}),
-		queryParamWithExample("stats", "Include query statistics in the response. Supported values: 'true' (basic statistics) and 'all' (basic plus per-step statistics). Other non-empty values are rejected.", false, stringSchema(), []example{{"example", "all"}}),
+		queryParamWithExample("stats", "Include query statistics in the response. Supported values: 'true' (basic statistics) and 'all' (basic plus per-step statistics). Other non-empty values are deprecated (they behave like 'true') and will be rejected in the next major release.", false, stringSchema(), []example{{"example", "all"}}),
 	}
 	return &v3.PathItem{
 		Get: &v3.Operation{

--- a/web/api/v1/openapi_paths.go
+++ b/web/api/v1/openapi_paths.go
@@ -32,7 +32,7 @@ func (*OpenAPIBuilder) queryPath() *v3.PathItem {
 		queryParamWithExample("query", "The PromQL query to execute.", true, stringSchema(), []example{{"example", "up"}}),
 		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, durationSchema(), []example{{"duration", "1m30s"}, {"number", "90"}}),
 		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, durationSchema(), []example{{"duration", "5m"}, {"number", "300"}}),
-		queryParamWithExample("stats", "When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.", false, stringSchema(), []example{{"example", "all"}}),
+		queryParamWithExample("stats", "Include query statistics in the response. Supported values: 'true' (basic statistics) and 'all' (basic plus per-step statistics). Other non-empty values are rejected.", false, stringSchema(), []example{{"example", "all"}}),
 	}
 	return &v3.PathItem{
 		Get: &v3.Operation{
@@ -61,7 +61,7 @@ func (*OpenAPIBuilder) queryRangePath() *v3.PathItem {
 		queryParamWithExample("query", "The query to execute.", true, stringSchema(), []example{{"example", "rate(prometheus_http_requests_total{handler=\"/api/v1/query\"}[5m])"}}),
 		queryParamWithExample("timeout", "Evaluation timeout. Optional. Defaults to and is capped by the value of the -query.timeout flag.", false, durationSchema(), []example{{"duration", "1m30s"}, {"number", "90"}}),
 		queryParamWithExample("lookback_delta", "Override the lookback period for this query. Optional.", false, durationSchema(), []example{{"duration", "5m"}, {"number", "300"}}),
-		queryParamWithExample("stats", "When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.", false, stringSchema(), []example{{"example", "all"}}),
+		queryParamWithExample("stats", "Include query statistics in the response. Supported values: 'true' (basic statistics) and 'all' (basic plus per-step statistics). Other non-empty values are rejected.", false, stringSchema(), []example{{"example", "all"}}),
 	}
 	return &v3.PathItem{
 		Get: &v3.Operation{

--- a/web/api/v1/testdata/openapi_3.1_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.1_golden.yaml
@@ -96,7 +96,7 @@ paths:
                         value: "300"
                 - name: stats
                   in: query
-                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are rejected.'
+                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are deprecated (they behave like ''true'') and will be rejected in the next major release.'
                   required: false
                   explode: false
                   schema:
@@ -329,7 +329,7 @@ paths:
                         value: "300"
                 - name: stats
                   in: query
-                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are rejected.'
+                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are deprecated (they behave like ''true'') and will be rejected in the next major release.'
                   required: false
                   explode: false
                   schema:

--- a/web/api/v1/testdata/openapi_3.1_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.1_golden.yaml
@@ -96,7 +96,7 @@ paths:
                         value: "300"
                 - name: stats
                   in: query
-                  description: When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.
+                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are rejected.'
                   required: false
                   explode: false
                   schema:
@@ -329,7 +329,7 @@ paths:
                         value: "300"
                 - name: stats
                   in: query
-                  description: When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.
+                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are rejected.'
                   required: false
                   explode: false
                   schema:

--- a/web/api/v1/testdata/openapi_3.2_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.2_golden.yaml
@@ -96,7 +96,7 @@ paths:
                         value: "300"
                 - name: stats
                   in: query
-                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are rejected.'
+                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are deprecated (they behave like ''true'') and will be rejected in the next major release.'
                   required: false
                   explode: false
                   schema:
@@ -329,7 +329,7 @@ paths:
                         value: "300"
                 - name: stats
                   in: query
-                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are rejected.'
+                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are deprecated (they behave like ''true'') and will be rejected in the next major release.'
                   required: false
                   explode: false
                   schema:

--- a/web/api/v1/testdata/openapi_3.2_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.2_golden.yaml
@@ -96,7 +96,7 @@ paths:
                         value: "300"
                 - name: stats
                   in: query
-                  description: When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.
+                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are rejected.'
                   required: false
                   explode: false
                   schema:
@@ -329,7 +329,7 @@ paths:
                         value: "300"
                 - name: stats
                   in: query
-                  description: When provided, include query statistics in the response. The special value 'all' enables more comprehensive statistics.
+                  description: 'Include query statistics in the response. Supported values: ''true'' (basic statistics) and ''all'' (basic plus per-step statistics). Other non-empty values are rejected.'
                   required: false
                   explode: false
                   schema:


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Related to #10953 (design as proposed [in the issue](https://github.com/prometheus/prometheus/issues/10953#issuecomment-4902792910); beorn7 had asked for suggestions, roidelapluie confirmed the change is acceptable). Per the bug-scrub feedback below, the hard rejection is deferred to the next major release; this PR ships the deprecation phase.

#### What this PR does:

Historically any non-empty `stats` value on `/api/v1/query` and `/api/v1/query_range` silently enabled basic statistics (`stats=foo` worked), and only the magic string `all` additionally enabled per-step statistics.

This PR keeps that behaviour fully backwards-compatible but attaches a **deprecation warning** to the response for values outside the supported enum (`true`, `all`):

```json
{"status":"success","warnings":["value \"foo\" for parameter \"stats\" is deprecated and will be rejected in the next major release, use \"true\" or \"all\""], ...}
```

- empty — no statistics (unchanged),
- `true` — basic statistics (what the built-in UI sends),
- `all` — basic plus per-step statistics,
- anything else — still enables basic statistics, plus the warning above; to be rejected with 400 `bad_data` in the next major release.

Embedders that install a custom `StatsRenderer` via `NewAPI` define their own vocabulary for the parameter, so no warning is attached for them — downstream projects are unaffected.

Notes for review:

- The first commit implemented the original strict 400; the second commit relaxes it to the deprecation warning per the bug-scrub feedback (breaking → v4) while still letting users know ahead of time. Happy to squash if preferred.
- Docs (`docs/querying/api.md`) and the OpenAPI parameter descriptions are updated; the OpenAPI golden files were regenerated with `go test -update-openapi-spec`.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[CHANGE] API: The `stats` query parameter of `/api/v1/query` and `/api/v1/query_range` is deprecated for values other than `true` and `all`. Such values still enable basic statistics but now add a deprecation warning to the response; they will be rejected in the next major release.
```
