### PR TITLE
web/api: fix TestStats failing on Windows (timer granularity)

### DIFF
--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -979,7 +979,11 @@ func TestStats(t *testing.T) {
 				require.NotNil(t, qd.Stats)
 				qs := qd.Stats.Builtin()
 				require.NotNil(t, qs.Timings)
-				require.Greater(t, qs.Timings.EvalTotalTime, float64(0))
+				// GreaterOrEqual, not Greater: on Windows the monotonic clock has
+				// millisecond-scale granularity, so evaluating this trivial query
+				// legitimately measures 0. Non-nil Timings already proves the
+				// timings were populated.
+				require.GreaterOrEqual(t, qs.Timings.EvalTotalTime, float64(0))
 				require.NotNil(t, qs.Samples)
 				require.NotNil(t, qs.Samples.TotalQueryableSamples)
 				require.Nil(t, qs.Samples.TotalQueryableSamplesPerStep)
@@ -995,7 +999,11 @@ func TestStats(t *testing.T) {
 				require.NotNil(t, qd.Stats)
 				qs := qd.Stats.Builtin()
 				require.NotNil(t, qs.Timings)
-				require.Greater(t, qs.Timings.EvalTotalTime, float64(0))
+				// GreaterOrEqual, not Greater: on Windows the monotonic clock has
+				// millisecond-scale granularity, so evaluating this trivial query
+				// legitimately measures 0. Non-nil Timings already proves the
+				// timings were populated.
+				require.GreaterOrEqual(t, qs.Timings.EvalTotalTime, float64(0))
 				require.NotNil(t, qs.Samples)
 				require.NotNil(t, qs.Samples.TotalQueryableSamples)
 				require.NotNil(t, qs.Samples.TotalQueryableSamplesPerStep)


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None filed — found while developing on Windows.

#### What this PR does:

`TestStats/stats_is_true` and `TestStats/stats_is_all` fail on every run on Windows:

```
--- FAIL: TestStats/stats_is_true (0.00s)
        Error:      "0" is not greater than "0"
```

The assertions require `EvalTotalTime > 0`, but Windows' monotonic clock has millisecond-scale granularity, so evaluating the trivial test query legitimately measures `0`. CI never sees this because the `test_windows` job excludes the `web` packages (`ci.yml` filters out `github.com/prometheus/prometheus/web`); it bites anyone developing on Windows with a plain `go test ./...`.

The fix relaxes the two assertions to `GreaterOrEqual`, matching the style of the `SamplesRead` assertion directly below them — the `require.NotNil(t, qs.Timings)` check already proves the timings were populated. Verified on Windows: `go test ./web/api/v1/ -run TestStats -count=3` now passes.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```
