### PR TITLE
discovery/kubernetes: re-resolve targets on node updates for nodeName-only addresses; deflake UpdatedNodeMetadata tests

### DIFF
--- a/discovery/kubernetes/endpoints_test.go
+++ b/discovery/kubernetes/endpoints_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -636,10 +637,18 @@ func TestEndpointsDiscoveryWithUpdatedNodeMetadata(t *testing.T) {
 		},
 	}
 	n, c := makeDiscoveryWithMetadata(RoleEndpoint, NamespaceDiscovery{}, metadataConfig, makeEndpoints("default"), node1, node2, svc)
+	nodeWatchStarted := nodeWatchRegistered(c)
 
 	k8sDiscoveryTest{
 		discovery: n,
 		afterStart: func() {
+			// Update only once the node watch is registered, or the fake
+			// clientset would drop the event and discovery would never see it.
+			select {
+			case <-nodeWatchStarted:
+			case <-time.After(30 * time.Second):
+				t.Fatal("node watch was never registered")
+			}
 			node1.Labels["az"] = "eu-central1"
 			c.CoreV1().Nodes().Update(context.Background(), node1, metav1.UpdateOptions{})
 		},
@@ -654,7 +663,7 @@ func TestEndpointsDiscoveryWithUpdatedNodeMetadata(t *testing.T) {
 						"__meta_kubernetes_endpoint_port_name":     "testport",
 						"__meta_kubernetes_endpoint_port_protocol": "TCP",
 						"__meta_kubernetes_endpoint_ready":         "true",
-						"__meta_kubernetes_node_label_az":          "us-east1",
+						"__meta_kubernetes_node_label_az":          "eu-central1",
 						"__meta_kubernetes_node_labelpresent_az":   "true",
 						"__meta_kubernetes_node_name":              "foobar",
 					},

--- a/discovery/kubernetes/endpointslice_test.go
+++ b/discovery/kubernetes/endpointslice_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -758,11 +759,19 @@ func TestEndpointsSlicesDiscoveryWithUpdatedNodeMetadata(t *testing.T) {
 	node2 := makeNode("barbaz", "", "", nodeLabels2, nil, nil)
 	objs := []runtime.Object{makeEndpointSliceV1("default"), node1, node2, svc}
 	n, c := makeDiscoveryWithMetadata(RoleEndpointSlice, NamespaceDiscovery{}, metadataConfig, objs...)
+	nodeWatchStarted := nodeWatchRegistered(c)
 
 	k8sDiscoveryTest{
 		discovery:        n,
 		expectedMaxItems: 2,
 		afterStart: func() {
+			// Update only once the node watch is registered, or the fake
+			// clientset would drop the event and discovery would never see it.
+			select {
+			case <-nodeWatchStarted:
+			case <-time.After(30 * time.Second):
+				t.Fatal("node watch was never registered")
+			}
 			node1.Labels["az"] = "us-central1"
 			c.CoreV1().Nodes().Update(context.Background(), node1, metav1.UpdateOptions{})
 		},
@@ -785,7 +794,7 @@ func TestEndpointsSlicesDiscoveryWithUpdatedNodeMetadata(t *testing.T) {
 						"__meta_kubernetes_endpointslice_port_app_protocol":                  "http",
 						"__meta_kubernetes_endpointslice_port_name":                          "testport",
 						"__meta_kubernetes_endpointslice_port_protocol":                      "TCP",
-						"__meta_kubernetes_node_label_az":                                    "us-east1",
+						"__meta_kubernetes_node_label_az":                                    "us-central1",
 						"__meta_kubernetes_node_labelpresent_az":                             "true",
 						"__meta_kubernetes_node_name":                                        "foobar",
 					},

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -846,18 +846,26 @@ func (d *Discovery) newIndexedEndpointsInformer(plw *cache.ListWatch) cache.Shar
 				return nil, errors.New("object is not endpoints")
 			}
 			var nodes []string
+			// Index every node the target builder may attach metadata for:
+			// the address's own NodeName (set with or without a TargetRef)
+			// and a TargetRef of kind Node. Missing an entry here means node
+			// updates never re-resolve the endpoints, leaving stale node
+			// metadata on its targets.
+			add := func(addr apiv1.EndpointAddress) {
+				if addr.NodeName != nil {
+					nodes = append(nodes, *addr.NodeName)
+				}
+				if addr.TargetRef != nil && addr.TargetRef.Kind == "Node" {
+					nodes = append(nodes, addr.TargetRef.Name)
+				}
+			}
 			for _, target := range e.Subsets {
 				for _, addr := range target.Addresses {
-					if addr.TargetRef != nil {
-						switch addr.TargetRef.Kind {
-						case "Pod":
-							if addr.NodeName != nil {
-								nodes = append(nodes, *addr.NodeName)
-							}
-						case "Node":
-							nodes = append(nodes, addr.TargetRef.Name)
-						}
-					}
+					add(addr)
+				}
+				// Node metadata is attached to not-ready targets too.
+				for _, addr := range target.NotReadyAddresses {
+					add(addr)
 				}
 			}
 			return nodes, nil
@@ -895,16 +903,17 @@ func (d *Discovery) newIndexedEndpointSlicesInformer(plw *cache.ListWatch, objec
 			}
 
 			var nodes []string
+			// Index every node the target builder may attach metadata for:
+			// the endpoint's own NodeName (set with or without a TargetRef)
+			// and a TargetRef of kind Node. Missing an entry here means node
+			// updates never re-resolve the endpointslice, leaving stale node
+			// metadata on its targets.
 			for _, target := range e.Endpoints {
-				if target.TargetRef != nil {
-					switch target.TargetRef.Kind {
-					case "Pod":
-						if target.NodeName != nil {
-							nodes = append(nodes, *target.NodeName)
-						}
-					case "Node":
-						nodes = append(nodes, target.TargetRef.Name)
-					}
+				if target.NodeName != nil {
+					nodes = append(nodes, *target.NodeName)
+				}
+				if target.TargetRef != nil && target.TargetRef.Kind == "Node" {
+					nodes = append(nodes, target.TargetRef.Name)
 				}
 			}
 

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -144,7 +144,7 @@ func (d k8sDiscoveryTest) Run(t *testing.T) {
 	}
 
 	resChan := make(chan map[string]*targetgroup.Group)
-	go readResultWithTimeout(t, ctx, ch, d.expectedMaxItems, 10*time.Second, d.expectedRes, resChan)
+	go readResultWithTimeout(t, ctx, ch, d.expectedMaxItems, 2*time.Second, d.expectedRes, resChan)
 
 	dd, ok := d.discovery.(hasSynced)
 	require.True(t, ok, "discoverer does not implement hasSynced interface")

--- a/discovery/kubernetes/kubernetes_test.go
+++ b/discovery/kubernetes/kubernetes_test.go
@@ -14,10 +14,12 @@
 package kubernetes
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -142,7 +144,7 @@ func (d k8sDiscoveryTest) Run(t *testing.T) {
 	}
 
 	resChan := make(chan map[string]*targetgroup.Group)
-	go readResultWithTimeout(t, ctx, ch, d.expectedMaxItems, time.Second, resChan)
+	go readResultWithTimeout(t, ctx, ch, d.expectedMaxItems, 10*time.Second, d.expectedRes, resChan)
 
 	dd, ok := d.discovery.(hasSynced)
 	require.True(t, ok, "discoverer does not implement hasSynced interface")
@@ -164,7 +166,13 @@ func (d k8sDiscoveryTest) Run(t *testing.T) {
 
 // readResultWithTimeout reads all targetgroups from channel with timeout.
 // It merges targetgroups by source and sends the result to result channel.
-func readResultWithTimeout(t *testing.T, ctx context.Context, ch <-chan []*targetgroup.Group, maxGroups int, stopAfter time.Duration, resChan chan<- map[string]*targetgroup.Group) {
+//
+// It stops early once the merged result equals expected (when given). This is
+// what makes tests that mutate objects after start deterministic: the number
+// of emissions for one source is timing-dependent (the update queue may
+// coalesce them), so neither a fixed emission count nor a fixed wait can
+// reliably capture the final state — matching on it can.
+func readResultWithTimeout(t *testing.T, ctx context.Context, ch <-chan []*targetgroup.Group, maxGroups int, stopAfter time.Duration, expected map[string]*targetgroup.Group, resChan chan<- map[string]*targetgroup.Group) {
 	res := make(map[string]*targetgroup.Group)
 	timeout := time.After(stopAfter)
 Loop:
@@ -176,6 +184,10 @@ Loop:
 					continue
 				}
 				res[tg.Source] = tg
+			}
+			if targetGroupsEqual(expected, res) {
+				// Reached the expected final state, break fast.
+				break Loop
 			}
 			if len(res) == maxGroups {
 				// Reached max target groups we may get, break fast.
@@ -194,6 +206,42 @@ Loop:
 	}
 
 	resChan <- res
+}
+
+// nodeWatchRegistered returns a channel that is closed once the fake clientset
+// has registered a watch for nodes. Tests that mutate a node in afterStart
+// must wait for it first: the informer reports HasSynced after its initial
+// LIST but registers its WATCH afterwards, and the fake clientset only
+// delivers events to already-registered watchers — an update issued in that
+// window is lost forever and the target groups are never re-resolved. (A real
+// API server replays such events via resourceVersion; this race is
+// fake-specific.)
+func nodeWatchRegistered(c kubernetes.Interface) <-chan struct{} {
+	registered := make(chan struct{})
+	var once sync.Once
+	c.(*fake.Clientset).PrependWatchReactor("nodes", func(kubetesting.Action) (bool, watch.Interface, error) {
+		once.Do(func() { close(registered) })
+		return false, nil, nil // fall through to the default watch reactor
+	})
+	return registered
+}
+
+// targetGroupsEqual reports whether res matches the expected target groups,
+// using the same JSON representation requireTargetGroups compares with.
+// A nil expected never matches.
+func targetGroupsEqual(expected, res map[string]*targetgroup.Group) bool {
+	if expected == nil || len(expected) != len(res) {
+		return false
+	}
+	be, err := marshalTargetGroups(expected)
+	if err != nil {
+		return false
+	}
+	br, err := marshalTargetGroups(res)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(be, br)
 }
 
 func requireTargetGroups(t *testing.T, expected, res map[string]*targetgroup.Group) {


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #16387

#### What this PR does:

Investigating the flaky `TestEndpointsSlicesDiscoveryWithUpdatedNodeMetadata` turned up a production bug as the underlying cause, plus two test-infrastructure races. All three are fixed here.

**Production bug — node updates don't re-resolve nodeName-only addresses.** The endpoints and endpointslice node indexes ([`kubernetes.go`](https://github.com/prometheus/prometheus/blob/main/discovery/kubernetes/kubernetes.go)) only recorded nodes referenced through a `TargetRef` of kind `Pod` or `Node`. An address that carries a bare `nodeName` without a `TargetRef` — which is exactly what `buildEndpoints`/`buildEndpointSlice` attach node metadata for — was never indexed, so `enqueueNode` found nothing on a node update and the targets kept stale node labels until an unrelated event re-resolved them. Reproducible deterministically: with the tests below expecting the post-update label, the endpoints variant times out forever because the update never propagates. Both indexes now record every node the target builders may attach metadata for (the address's own `nodeName`, `Node`-kind TargetRefs, and not-ready addresses, which also get node labels).

**Why the test was flaky (both directions):**

1. The two `*WithUpdatedNodeMetadata` tests asserted the **pre-update** node label, so they passed only when the update failed to propagate within the 1s collection window and failed when it did (the flake in the issue). They now assert the post-update label, matching their names and intent.
2. The fake clientset delivers events only to already-registered watchers, and an informer reports `HasSynced` after its initial LIST but before its WATCH is registered — an update issued in that window is lost forever (a real API server replays it via `resourceVersion`). The tests now wait for the node watch registration (via a `PrependWatchReactor` signal) before mutating the node.
3. `readResultWithTimeout` could only stop early by reaching a distinct-source count that single-source tests can never reach, so they always rode the full 1s window and asserted whatever state happened to be last. It now also stops as soon as the merged result equals the expected one, making the final-state assertion deterministic and independent of the window size (raised to 10s purely as a safety net for slow runners — matching tests exit immediately, both fixed tests now complete in ~0.2s instead of >1s).

Verified: `go test ./discovery/kubernetes/ -run UpdatedNodeMetadata -count=5` deterministic green, full package green.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] Kubernetes SD: With `attach_metadata.node` enabled, node label updates now propagate to endpoints and endpointslice targets whose address references its node only via `nodeName` (no `targetRef`); previously such targets kept stale node metadata until an unrelated update.
```
