### PR TITLE
tsdb(wal): Update st-in-wal tests for tsdb impl

### DIFF
--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -7528,6 +7528,8 @@ func TestCompactHeadWithSTStorage_AppendV2(t *testing.T) {
 		name             string
 		lbls             labels.Labels
 		expectedEncoding chunkenc.Encoding
+		// append wraps the Append() calls so they are uniform, and returns the
+		// appended sample so it can be used to initialize the expectation slice.
 		append           func(storage.AppenderV2, labels.Labels, int64) (chunks.Sample, error)
 	}
 

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -7530,7 +7530,7 @@ func TestCompactHeadWithSTStorage_AppendV2(t *testing.T) {
 		expectedEncoding chunkenc.Encoding
 		// append wraps the Append() calls so they are uniform, and returns the
 		// appended sample so it can be used to initialize the expectation slice.
-		append           func(storage.AppenderV2, labels.Labels, int64) (chunks.Sample, error)
+		append func(storage.AppenderV2, labels.Labels, int64) (chunks.Sample, error)
 	}
 
 	cases := []sampleCase{

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -7520,9 +7520,53 @@ func TestAbortBlockCompactions_AppendV2(t *testing.T) {
 }
 
 // TestCompactHeadWithSTStorage_AppendV2 ensures that when EnableSTStorage is true,
-// compacted blocks contain chunks with EncXOR2 encoding for float samples.
+// compacted blocks contain ST-capable chunks that preserve start timestamps.
 func TestCompactHeadWithSTStorage_AppendV2(t *testing.T) {
 	t.Parallel()
+
+	type sampleCase struct {
+		name             string
+		lbls             labels.Labels
+		expectedEncoding chunkenc.Encoding
+		append           func(storage.AppenderV2, labels.Labels, int64) (chunks.Sample, error)
+	}
+
+	cases := []sampleCase{
+		{
+			name:             "float",
+			lbls:             labels.FromStrings("a", "b", "type", "float"),
+			expectedEncoding: chunkenc.EncXOR2,
+			append: func(app storage.AppenderV2, lbls labels.Labels, ts int64) (chunks.Sample, error) {
+				st := ts - 50
+				_, err := app.Append(0, lbls, st, ts, float64(ts), nil, nil, storage.AOptions{})
+				return newSample(st, ts, float64(ts), nil, nil), err
+			},
+		},
+		{
+			name:             "histogram",
+			lbls:             labels.FromStrings("a", "b", "type", "histogram"),
+			expectedEncoding: chunkenc.EncHistogramST,
+			append: func(app storage.AppenderV2, lbls labels.Labels, ts int64) (chunks.Sample, error) {
+				st := ts - 60
+				h := tsdbutil.GenerateTestHistogram(ts)
+				h.CounterResetHint = histogram.NotCounterReset
+				_, err := app.Append(0, lbls, st, ts, 0, h, nil, storage.AOptions{})
+				return newSample(st, ts, 0, h, nil), err
+			},
+		},
+		{
+			name:             "float histogram",
+			lbls:             labels.FromStrings("a", "b", "type", "float_histogram"),
+			expectedEncoding: chunkenc.EncFloatHistogramST,
+			append: func(app storage.AppenderV2, lbls labels.Labels, ts int64) (chunks.Sample, error) {
+				st := ts - 70
+				fh := tsdbutil.GenerateTestFloatHistogram(ts)
+				fh.CounterResetHint = histogram.NotCounterReset
+				_, err := app.Append(0, lbls, st, ts, 0, nil, fh, storage.AOptions{})
+				return newSample(st, ts, 0, nil, fh), err
+			},
+		},
+	}
 
 	opts := &Options{
 		RetentionDuration:         int64(time.Hour * 24 * 15 / time.Millisecond),
@@ -7541,9 +7585,13 @@ func TestCompactHeadWithSTStorage_AppendV2(t *testing.T) {
 
 	mint := 100
 	maxt := 200
+	expectedSamples := make(map[string][]chunks.Sample, len(cases))
 	for i := mint; i < maxt; i++ {
-		_, err := app.Append(0, labels.FromStrings("a", "b"), 50, int64(i), float64(i), nil, nil, storage.AOptions{})
-		require.NoError(t, err)
+		for _, c := range cases {
+			s, err := c.append(app, c.lbls, int64(i))
+			require.NoError(t, err)
+			expectedSamples[c.name] = append(expectedSamples[c.name], s)
+		}
 	}
 	require.NoError(t, app.Commit())
 
@@ -7559,24 +7607,35 @@ func TestCompactHeadWithSTStorage_AppendV2(t *testing.T) {
 	require.NoError(t, err)
 	defer indexr.Close()
 
-	p, err := indexr.Postings(ctx, "a", "b")
-	require.NoError(t, err)
-
 	chunkCount := 0
-	for p.Next() {
-		var builder labels.ScratchBuilder
-		var chks []chunks.Meta
-		require.NoError(t, indexr.Series(p.At(), &builder, &chks))
-
-		for _, chk := range chks {
-			c, _, err := chunkr.ChunkOrIterable(chk)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p, err := indexr.Postings(ctx, "type", c.lbls.Get("type"))
 			require.NoError(t, err)
-			require.Equal(t, chunkenc.EncXOR2, c.Encoding(),
-				"unexpected chunk encoding, got %s", c.Encoding())
-			chunkCount++
-		}
+
+			var actualSamples []chunks.Sample
+			for p.Next() {
+				var builder labels.ScratchBuilder
+				var chks []chunks.Meta
+				require.NoError(t, indexr.Series(p.At(), &builder, &chks))
+
+				for _, chk := range chks {
+					chunk, _, err := chunkr.ChunkOrIterable(chk)
+					require.NoError(t, err)
+					require.Equal(t, c.expectedEncoding, chunk.Encoding(),
+						"unexpected chunk encoding, got %s", chunk.Encoding())
+
+					samples, err := storage.ExpandSamples(chunk.Iterator(nil), newSample)
+					require.NoError(t, err)
+					actualSamples = append(actualSamples, samples...)
+					chunkCount++
+				}
+			}
+			require.NoError(t, p.Err())
+			requireEqualSamples(t, c.name, expectedSamples[c.name], actualSamples, requireEqualSamplesIgnoreCounterResets)
+		})
 	}
-	require.NoError(t, p.Err())
+
 	require.Positive(t, chunkCount, "expected at least one chunk")
 }
 

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
@@ -5058,48 +5057,11 @@ func TestHeadAppenderV2_STStorage(t *testing.T) {
 	}
 }
 
-// readWALHistogramSamples reads the WAL at dir and returns the decoded
-// integer-histogram samples, float-histogram samples, and the record types
-// observed for each.
-func readWALHistogramSamples(t testing.TB, dir string) (intSamples []record.RefHistogramSample, intTypes []record.Type, floatSamples []record.RefFloatHistogramSample, floatTypes []record.Type) {
-	sr, err := wlog.NewSegmentsReader(dir)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, sr.Close())
-	}()
-
-	dec := record.NewDecoder(labels.NewSymbolTable(), promslog.NewNopLogger())
-	r := wlog.NewReader(sr)
-	for r.Next() {
-		rec := r.Record()
-		switch typ := dec.Type(rec); typ {
-		case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
-			samples, err := dec.HistogramSamples(rec, nil)
-			require.NoError(t, err)
-			intSamples = append(intSamples, samples...)
-			for range samples {
-				intTypes = append(intTypes, typ)
-			}
-		case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
-			samples, err := dec.FloatHistogramSamples(rec, nil)
-			require.NoError(t, err)
-			floatSamples = append(floatSamples, samples...)
-			for range samples {
-				floatTypes = append(floatTypes, typ)
-			}
-		}
-	}
-	require.NoError(t, r.Err())
-	return intSamples, intTypes, floatSamples, floatTypes
-}
-
-// TestHeadAppenderV2_Histogram_STInWAL verifies that start timestamps supplied
-// via AppenderV2.Append are written into the WAL for histogram and
-// float-histogram samples. The chunk encoder still drops histogram ST until
-// #18609 lands, so this test asserts at the WAL record layer.
-// TODO(krajorama,ywwg): Once histogram chunks preserve ST, simplify this test
-// to assert histogram ST through chunks or queries instead of WAL records.
-func TestHeadAppenderV2_Histogram_STInWAL(t *testing.T) {
+// TestHeadAppenderV2_Histogram_STStorage verifies that start timestamps supplied
+// via AppenderV2.Append round-trip through histogram and float-histogram chunks
+// and are returned by both the chunk iterator and the querier. When ST encoding
+// is disabled the histograms fall back to V1 chunks and report ST=0.
+func TestHeadAppenderV2_Histogram_STStorage(t *testing.T) {
 	type histSample struct {
 		st int64
 		ts int64
@@ -5119,42 +5081,37 @@ func TestHeadAppenderV2_Histogram_STInWAL(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name               string
-		enableSTStorage    bool
-		samples            []histSample
-		expectedSTs        []int64
-		expectedRecordType record.Type
-		isFloatHistogram   bool
+		name             string
+		enableSTStorage  bool
+		samples          []histSample
+		expectedSTs      []int64
+		isFloatHistogram bool
 	}{
 		{
-			name:               "Integer histograms with ST enabled",
-			enableSTStorage:    true,
-			samples:            []histSample{{st: 10, ts: 100, h: intHist(1)}, {st: 100, ts: 200, h: intHist(2)}, {st: 200, ts: 300, h: intHist(3)}},
-			expectedSTs:        []int64{10, 100, 200},
-			expectedRecordType: record.HistogramSamplesV2,
+			name:            "Integer histograms with ST enabled",
+			enableSTStorage: true,
+			samples:         []histSample{{st: 10, ts: 100, h: intHist(1)}, {st: 100, ts: 200, h: intHist(2)}, {st: 200, ts: 300, h: intHist(3)}},
+			expectedSTs:     []int64{10, 100, 200},
 		},
 		{
-			name:               "Float histograms with ST enabled",
-			enableSTStorage:    true,
-			samples:            []histSample{{st: 11, ts: 101, fh: floatHist(1)}, {st: 101, ts: 202, fh: floatHist(2)}, {st: 202, ts: 303, fh: floatHist(3)}},
-			expectedSTs:        []int64{11, 101, 202},
-			expectedRecordType: record.FloatHistogramSamplesV2,
-			isFloatHistogram:   true,
+			name:             "Float histograms with ST enabled",
+			enableSTStorage:  true,
+			samples:          []histSample{{st: 11, ts: 101, fh: floatHist(1)}, {st: 101, ts: 202, fh: floatHist(2)}, {st: 202, ts: 303, fh: floatHist(3)}},
+			expectedSTs:      []int64{11, 101, 202},
+			isFloatHistogram: true,
 		},
 		{
-			name:               "Integer histograms with ST disabled emit V1 records and ST=0",
-			enableSTStorage:    false,
-			samples:            []histSample{{st: 10, ts: 100, h: intHist(1)}, {st: 100, ts: 200, h: intHist(2)}},
-			expectedSTs:        []int64{0, 0},
-			expectedRecordType: record.HistogramSamples,
+			name:            "Integer histograms with ST disabled report ST=0",
+			enableSTStorage: false,
+			samples:         []histSample{{st: 10, ts: 100, h: intHist(1)}, {st: 100, ts: 200, h: intHist(2)}},
+			expectedSTs:     []int64{0, 0},
 		},
 		{
-			name:               "Float histograms with ST disabled emit V1 records and ST=0",
-			enableSTStorage:    false,
-			samples:            []histSample{{st: 11, ts: 101, fh: floatHist(1)}, {st: 101, ts: 202, fh: floatHist(2)}},
-			expectedSTs:        []int64{0, 0},
-			expectedRecordType: record.FloatHistogramSamples,
-			isFloatHistogram:   true,
+			name:             "Float histograms with ST disabled report ST=0",
+			enableSTStorage:  false,
+			samples:          []histSample{{st: 11, ts: 101, fh: floatHist(1)}, {st: 101, ts: 202, fh: floatHist(2)}},
+			expectedSTs:      []int64{0, 0},
+			isFloatHistogram: true,
 		},
 	}
 
@@ -5163,7 +5120,8 @@ func TestHeadAppenderV2_Histogram_STInWAL(t *testing.T) {
 			opts := newTestHeadDefaultOptions(DefaultBlockDuration, false)
 			opts.EnableSTStorage.Store(tc.enableSTStorage)
 			opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
-			h, w := newTestHeadWithOptions(t, compression.None, opts)
+			opts.EnableHistogramSTEncoding.Store(tc.enableSTStorage)
+			h, _ := newTestHeadWithOptions(t, compression.None, opts)
 
 			lbls := labels.FromStrings("foo", "bar")
 
@@ -5173,29 +5131,59 @@ func TestHeadAppenderV2_Histogram_STInWAL(t *testing.T) {
 				require.NoError(t, err)
 			}
 			require.NoError(t, a.Commit())
-			require.NoError(t, h.Close())
 
-			intSamples, intTypes, floatSamples, floatTypes := readWALHistogramSamples(t, w.Dir())
+			ctx := context.Background()
 
-			if tc.isFloatHistogram {
-				require.Empty(t, intSamples, "no integer-histogram records expected")
-				require.Len(t, floatSamples, len(tc.samples))
-				var gotSTs []int64
-				for i, s := range floatSamples {
-					gotSTs = append(gotSTs, s.ST)
-					require.Equal(t, tc.expectedRecordType, floatTypes[i], "unexpected float-histogram record type")
+			// Verify ST values round-trip through the chunks.
+			idxReader, err := h.Index()
+			require.NoError(t, err)
+			defer idxReader.Close()
+
+			chkReader, err := h.Chunks()
+			require.NoError(t, err)
+			defer chkReader.Close()
+
+			p, err := idxReader.Postings(ctx, "foo", "bar")
+			require.NoError(t, err)
+
+			var lblBuilder labels.ScratchBuilder
+			require.True(t, p.Next())
+			sRef := p.At()
+
+			var chkMetas []chunks.Meta
+			require.NoError(t, idxReader.Series(sRef, &lblBuilder, &chkMetas))
+
+			var chunkSTs []int64
+			for _, meta := range chkMetas {
+				chk, iterable, err := chkReader.ChunkOrIterable(meta)
+				require.NoError(t, err)
+				require.Nil(t, iterable)
+
+				it := chk.Iterator(nil)
+				for it.Next() != chunkenc.ValNone {
+					chunkSTs = append(chunkSTs, it.AtST())
 				}
-				require.Equal(t, tc.expectedSTs, gotSTs)
-			} else {
-				require.Empty(t, floatSamples, "no float-histogram records expected")
-				require.Len(t, intSamples, len(tc.samples))
-				var gotSTs []int64
-				for i, s := range intSamples {
-					gotSTs = append(gotSTs, s.ST)
-					require.Equal(t, tc.expectedRecordType, intTypes[i], "unexpected integer-histogram record type")
-				}
-				require.Equal(t, tc.expectedSTs, gotSTs)
+				require.NoError(t, it.Err())
 			}
+			require.Equal(t, tc.expectedSTs, chunkSTs, "ST values should round-trip through chunks")
+
+			// Verify the querier returns the same ST values.
+			q, err := NewBlockQuerier(h, math.MinInt64, math.MaxInt64)
+			require.NoError(t, err)
+			defer q.Close()
+
+			ss := q.Select(ctx, false, nil, labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"))
+			require.True(t, ss.Next())
+			series := ss.At()
+			require.NoError(t, ss.Err())
+
+			seriesIt := series.Iterator(nil)
+			var queriedSTs []int64
+			for seriesIt.Next() != chunkenc.ValNone {
+				queriedSTs = append(queriedSTs, seriesIt.AtST())
+			}
+			require.NoError(t, seriesIt.Err())
+			require.Equal(t, tc.expectedSTs, queriedSTs, "querier should return same ST values as chunk iterator")
 		})
 	}
 }

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -859,7 +859,7 @@ func (p *populateWithDelSeriesIterator) AtT() int64 {
 	return p.curr.AtT()
 }
 
-// AtST TODO(krajorama,ywwg): test AtST() when chunks support it.
+// AtST returns the start timestamp of the current sample.
 func (p *populateWithDelSeriesIterator) AtST() int64 {
 	return p.curr.AtST()
 }
@@ -1293,7 +1293,7 @@ func (it *DeletedIterator) AtT() int64 {
 	return it.Iter.AtT()
 }
 
-// AtST TODO(krajorama,ywwg): test AtST() when chunks support it.
+// AtST returns the start timestamp of the current sample.
 func (it *DeletedIterator) AtST() int64 {
 	return it.Iter.AtST()
 }

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2328,16 +2328,13 @@ func (mockChunkReader) Close() error {
 }
 
 func TestDeletedIterator(t *testing.T) {
-	chk := chunkenc.NewXORChunk()
-	app, err := chk.Appender()
-	require.NoError(t, err)
 	// Insert random stuff from (0, 1000).
-	act := make([]sample, 1000)
+	act := make([]chunks.Sample, 1000)
 	for i := range 1000 {
-		act[i].t = int64(i)
-		act[i].f = rand.Float64()
-		app.Append(0, act[i].t, act[i].f)
+		act[i] = sample{st: int64(i / 2), t: int64(i), f: rand.Float64()}
 	}
+	meta, err := chunks.ChunkFromSamples(act)
+	require.NoError(t, err)
 
 	cases := []struct {
 		r tombstones.Intervals
@@ -2356,7 +2353,7 @@ func TestDeletedIterator(t *testing.T) {
 
 	for _, c := range cases {
 		i := int64(-1)
-		it := &DeletedIterator{Iter: chk.Iterator(nil), Intervals: c.r[:]}
+		it := &DeletedIterator{Iter: meta.Chunk.Iterator(nil), Intervals: c.r[:]}
 		ranges := c.r[:]
 		for it.Next() == chunkenc.ValFloat {
 			i++
@@ -2370,8 +2367,9 @@ func TestDeletedIterator(t *testing.T) {
 			require.Less(t, i, int64(1000))
 
 			ts, v := it.At()
-			require.Equal(t, act[i].t, ts)
-			require.Equal(t, act[i].f, v)
+			require.Equal(t, act[i].T(), ts)
+			require.Equal(t, act[i].F(), v)
+			require.Equal(t, act[i].ST(), it.AtST())
 		}
 		// There has been an extra call to Next().
 		i++
@@ -2425,64 +2423,6 @@ func TestDeletedIterator_WithSeek(t *testing.T) {
 			ts := it.AtT()
 			require.Equal(t, c.seekedTs, ts)
 		}
-	}
-}
-
-// TestDeletedIterator_WithST verifies that DeletedIterator forwards start
-// timestamps from the underlying iterator for the samples that survive deletion.
-func TestDeletedIterator_WithST(t *testing.T) {
-	samples := []chunks.Sample{
-		sample{st: 100, t: 1000, f: 1.0},
-		sample{st: 200, t: 2000, f: 2.0},
-		sample{st: 300, t: 3000, f: 3.0},
-		sample{st: 400, t: 4000, f: 4.0},
-		sample{st: 500, t: 5000, f: 5.0},
-	}
-	meta, err := chunks.ChunkFromSamples(samples)
-	require.NoError(t, err)
-
-	cases := []struct {
-		name      string
-		intervals tombstones.Intervals
-		expected  []chunks.Sample
-	}{
-		{
-			name:     "no deletions - ST preserved",
-			expected: samples,
-		},
-		{
-			name:      "delete middle samples - ST preserved",
-			intervals: tombstones.Intervals{{Mint: 2000, Maxt: 2000}, {Mint: 4000, Maxt: 4000}},
-			expected: []chunks.Sample{
-				sample{st: 100, t: 1000, f: 1.0},
-				sample{st: 300, t: 3000, f: 3.0},
-				sample{st: 500, t: 5000, f: 5.0},
-			},
-		},
-		{
-			name:      "delete first sample - ST preserved",
-			intervals: tombstones.Intervals{{Mint: 1000, Maxt: 1000}},
-			expected: []chunks.Sample{
-				sample{st: 200, t: 2000, f: 2.0},
-				sample{st: 300, t: 3000, f: 3.0},
-				sample{st: 400, t: 4000, f: 4.0},
-				sample{st: 500, t: 5000, f: 5.0},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			it := &DeletedIterator{Iter: meta.Chunk.Iterator(nil), Intervals: c.intervals}
-
-			var result []chunks.Sample
-			for it.Next() != chunkenc.ValNone {
-				ts, v := it.At()
-				result = append(result, sample{st: it.AtST(), t: ts, f: v})
-			}
-			require.NoError(t, it.Err())
-			require.Equal(t, c.expected, result)
-		})
 	}
 }
 

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2428,6 +2428,64 @@ func TestDeletedIterator_WithSeek(t *testing.T) {
 	}
 }
 
+// TestDeletedIterator_WithST verifies that DeletedIterator forwards start
+// timestamps from the underlying iterator for the samples that survive deletion.
+func TestDeletedIterator_WithST(t *testing.T) {
+	samples := []chunks.Sample{
+		sample{st: 100, t: 1000, f: 1.0},
+		sample{st: 200, t: 2000, f: 2.0},
+		sample{st: 300, t: 3000, f: 3.0},
+		sample{st: 400, t: 4000, f: 4.0},
+		sample{st: 500, t: 5000, f: 5.0},
+	}
+	meta, err := chunks.ChunkFromSamples(samples)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name      string
+		intervals tombstones.Intervals
+		expected  []chunks.Sample
+	}{
+		{
+			name:     "no deletions - ST preserved",
+			expected: samples,
+		},
+		{
+			name:      "delete middle samples - ST preserved",
+			intervals: tombstones.Intervals{{Mint: 2000, Maxt: 2000}, {Mint: 4000, Maxt: 4000}},
+			expected: []chunks.Sample{
+				sample{st: 100, t: 1000, f: 1.0},
+				sample{st: 300, t: 3000, f: 3.0},
+				sample{st: 500, t: 5000, f: 5.0},
+			},
+		},
+		{
+			name:      "delete first sample - ST preserved",
+			intervals: tombstones.Intervals{{Mint: 1000, Maxt: 1000}},
+			expected: []chunks.Sample{
+				sample{st: 200, t: 2000, f: 2.0},
+				sample{st: 300, t: 3000, f: 3.0},
+				sample{st: 400, t: 4000, f: 4.0},
+				sample{st: 500, t: 5000, f: 5.0},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			it := &DeletedIterator{Iter: meta.Chunk.Iterator(nil), Intervals: c.intervals}
+
+			var result []chunks.Sample
+			for it.Next() != chunkenc.ValNone {
+				ts, v := it.At()
+				result = append(result, sample{st: it.AtST(), t: ts, f: v})
+			}
+			require.NoError(t, it.Err())
+			require.Equal(t, c.expected, result)
+		})
+	}
+}
+
 type series struct {
 	l      labels.Labels
 	chunks []chunks.Meta

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -178,24 +178,18 @@ func TestCheckpoint(t *testing.T) {
 
 				enc := record.Encoder{EnableSTStorage: enableSTStorage}
 				setSampleSTs := func(samples []record.RefSample) {
-					if enableSTStorage {
-						for i := range samples {
-							samples[i].ST = samples[i].T - 1
-						}
+					for i := range samples {
+						samples[i].ST = samples[i].T - 1
 					}
 				}
 				setHistogramSTs := func(samples []record.RefHistogramSample) {
-					if enableSTStorage {
-						for i := range samples {
-							samples[i].ST = samples[i].T - 1
-						}
+					for i := range samples {
+						samples[i].ST = samples[i].T - 1
 					}
 				}
 				setFloatHistogramSTs := func(samples []record.RefFloatHistogramSample) {
-					if enableSTStorage {
-						for i := range samples {
-							samples[i].ST = samples[i].T - 1
-						}
+					for i := range samples {
+						samples[i].ST = samples[i].T - 1
 					}
 				}
 				// Create a dummy segment to bump the initial number.
@@ -256,7 +250,9 @@ func TestCheckpoint(t *testing.T) {
 						{Ref: 2, T: last + 20000, V: float64(i)},
 						{Ref: 3, T: last + 30000, V: float64(i)},
 					}
-					setSampleSTs(samples)
+					if enableSTStorage {
+						setSampleSTs(samples)
+					}
 					b := enc.Samples(samples, nil)
 					require.NoError(t, w.Log(b))
 					samplesInWAL += 4
@@ -267,7 +263,9 @@ func TestCheckpoint(t *testing.T) {
 						{Ref: 2, T: last + 20000, H: h},
 						{Ref: 3, T: last + 30000, H: h},
 					}
-					setHistogramSTs(histograms)
+					if enableSTStorage {
+						setHistogramSTs(histograms)
+					}
 					b, _ = enc.HistogramSamples(histograms, nil)
 					require.NoError(t, w.Log(b))
 					histogramsInWAL += 4
@@ -278,7 +276,9 @@ func TestCheckpoint(t *testing.T) {
 						{Ref: 2, T: last + 20000, H: cbh},
 						{Ref: 3, T: last + 30000, H: cbh},
 					}
-					setHistogramSTs(customBucketHistograms)
+					if enableSTStorage {
+						setHistogramSTs(customBucketHistograms)
+					}
 					b = enc.CustomBucketsHistogramSamples(customBucketHistograms, nil)
 					require.NoError(t, w.Log(b))
 					histogramsInWAL += 4

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -177,6 +177,27 @@ func TestCheckpoint(t *testing.T) {
 				dir := t.TempDir()
 
 				enc := record.Encoder{EnableSTStorage: enableSTStorage}
+				setSampleSTs := func(samples []record.RefSample) {
+					if enableSTStorage {
+						for i := range samples {
+							samples[i].ST = samples[i].T - 1
+						}
+					}
+				}
+				setHistogramSTs := func(samples []record.RefHistogramSample) {
+					if enableSTStorage {
+						for i := range samples {
+							samples[i].ST = samples[i].T - 1
+						}
+					}
+				}
+				setFloatHistogramSTs := func(samples []record.RefFloatHistogramSample) {
+					if enableSTStorage {
+						for i := range samples {
+							samples[i].ST = samples[i].T - 1
+						}
+					}
+				}
 				// Create a dummy segment to bump the initial number.
 				seg, err := CreateSegment(dir, 100)
 				require.NoError(t, err)
@@ -229,48 +250,58 @@ func TestCheckpoint(t *testing.T) {
 					// Write samples until the WAL has enough segments.
 					// Make them have drifting timestamps within a record to see that they
 					// get filtered properly.
-					b := enc.Samples([]record.RefSample{
+					samples := []record.RefSample{
 						{Ref: 0, T: last, V: float64(i)},
 						{Ref: 1, T: last + 10000, V: float64(i)},
 						{Ref: 2, T: last + 20000, V: float64(i)},
 						{Ref: 3, T: last + 30000, V: float64(i)},
-					}, nil)
+					}
+					setSampleSTs(samples)
+					b := enc.Samples(samples, nil)
 					require.NoError(t, w.Log(b))
 					samplesInWAL += 4
 					h := makeHistogram(i)
-					b, _ = enc.HistogramSamples([]record.RefHistogramSample{
+					histograms := []record.RefHistogramSample{
 						{Ref: 0, T: last, H: h},
 						{Ref: 1, T: last + 10000, H: h},
 						{Ref: 2, T: last + 20000, H: h},
 						{Ref: 3, T: last + 30000, H: h},
-					}, nil)
+					}
+					setHistogramSTs(histograms)
+					b, _ = enc.HistogramSamples(histograms, nil)
 					require.NoError(t, w.Log(b))
 					histogramsInWAL += 4
 					cbh := makeCustomBucketHistogram(i)
-					b = enc.CustomBucketsHistogramSamples([]record.RefHistogramSample{
+					customBucketHistograms := []record.RefHistogramSample{
 						{Ref: 0, T: last, H: cbh},
 						{Ref: 1, T: last + 10000, H: cbh},
 						{Ref: 2, T: last + 20000, H: cbh},
 						{Ref: 3, T: last + 30000, H: cbh},
-					}, nil)
+					}
+					setHistogramSTs(customBucketHistograms)
+					b = enc.CustomBucketsHistogramSamples(customBucketHistograms, nil)
 					require.NoError(t, w.Log(b))
 					histogramsInWAL += 4
 					fh := makeFloatHistogram(i)
-					b, _ = enc.FloatHistogramSamples([]record.RefFloatHistogramSample{
+					floatHistograms := []record.RefFloatHistogramSample{
 						{Ref: 0, T: last, FH: fh},
 						{Ref: 1, T: last + 10000, FH: fh},
 						{Ref: 2, T: last + 20000, FH: fh},
 						{Ref: 3, T: last + 30000, FH: fh},
-					}, nil)
+					}
+					setFloatHistogramSTs(floatHistograms)
+					b, _ = enc.FloatHistogramSamples(floatHistograms, nil)
 					require.NoError(t, w.Log(b))
 					floatHistogramsInWAL += 4
 					cbfh := makeCustomBucketFloatHistogram(i)
-					b = enc.CustomBucketsFloatHistogramSamples([]record.RefFloatHistogramSample{
+					customBucketFloatHistograms := []record.RefFloatHistogramSample{
 						{Ref: 0, T: last, FH: cbfh},
 						{Ref: 1, T: last + 10000, FH: cbfh},
 						{Ref: 2, T: last + 20000, FH: cbfh},
 						{Ref: 3, T: last + 30000, FH: cbfh},
-					}, nil)
+					}
+					setFloatHistogramSTs(customBucketFloatHistograms)
+					b = enc.CustomBucketsFloatHistogramSamples(customBucketFloatHistograms, nil)
 					require.NoError(t, w.Log(b))
 					floatHistogramsInWAL += 4
 
@@ -330,6 +361,11 @@ func TestCheckpoint(t *testing.T) {
 						require.NoError(t, err)
 						for _, s := range samples {
 							require.GreaterOrEqual(t, s.T, last/2, "sample with wrong timestamp")
+							if enableSTStorage {
+								require.Equal(t, s.T-1, s.ST, "sample with wrong start timestamp")
+							} else {
+								require.Zero(t, s.ST, "sample should not have start timestamp")
+							}
 						}
 						samplesInCheckpoint += len(samples)
 					case record.HistogramSamples, record.CustomBucketsHistogramSamples, record.HistogramSamplesV2:
@@ -337,6 +373,11 @@ func TestCheckpoint(t *testing.T) {
 						require.NoError(t, err)
 						for _, h := range histograms {
 							require.GreaterOrEqual(t, h.T, last/2, "histogram with wrong timestamp")
+							if enableSTStorage {
+								require.Equal(t, h.T-1, h.ST, "histogram with wrong start timestamp")
+							} else {
+								require.Zero(t, h.ST, "histogram should not have start timestamp")
+							}
 						}
 						histogramsInCheckpoint += len(histograms)
 					case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples, record.FloatHistogramSamplesV2:
@@ -344,6 +385,11 @@ func TestCheckpoint(t *testing.T) {
 						require.NoError(t, err)
 						for _, h := range floatHistograms {
 							require.GreaterOrEqual(t, h.T, last/2, "float histogram with wrong timestamp")
+							if enableSTStorage {
+								require.Equal(t, h.T-1, h.ST, "float histogram with wrong start timestamp")
+							} else {
+								require.Zero(t, h.ST, "float histogram should not have start timestamp")
+							}
 						}
 						floatHistogramsInCheckpoint += len(floatHistograms)
 					case record.Exemplars:

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -177,21 +177,6 @@ func TestCheckpoint(t *testing.T) {
 				dir := t.TempDir()
 
 				enc := record.Encoder{EnableSTStorage: enableSTStorage}
-				setSampleSTs := func(samples []record.RefSample) {
-					for i := range samples {
-						samples[i].ST = samples[i].T - 1
-					}
-				}
-				setHistogramSTs := func(samples []record.RefHistogramSample) {
-					for i := range samples {
-						samples[i].ST = samples[i].T - 1
-					}
-				}
-				setFloatHistogramSTs := func(samples []record.RefFloatHistogramSample) {
-					for i := range samples {
-						samples[i].ST = samples[i].T - 1
-					}
-				}
 				// Create a dummy segment to bump the initial number.
 				seg, err := CreateSegment(dir, 100)
 				require.NoError(t, err)
@@ -244,63 +229,54 @@ func TestCheckpoint(t *testing.T) {
 					// Write samples until the WAL has enough segments.
 					// Make them have drifting timestamps within a record to see that they
 					// get filtered properly.
+					// Start times are ignored at encoding time if start time storage is
+					// disabled.
 					samples := []record.RefSample{
-						{Ref: 0, T: last, V: float64(i)},
-						{Ref: 1, T: last + 10000, V: float64(i)},
-						{Ref: 2, T: last + 20000, V: float64(i)},
-						{Ref: 3, T: last + 30000, V: float64(i)},
-					}
-					if enableSTStorage {
-						setSampleSTs(samples)
+						{Ref: 0, ST: last - 1, T: last, V: float64(i)},
+						{Ref: 1, ST: last + 9999, T: last + 10000, V: float64(i)},
+						{Ref: 2, ST: last + 19999, T: last + 20000, V: float64(i)},
+						{Ref: 3, ST: last + 29999, T: last + 30000, V: float64(i)},
 					}
 					b := enc.Samples(samples, nil)
 					require.NoError(t, w.Log(b))
 					samplesInWAL += 4
 					h := makeHistogram(i)
 					histograms := []record.RefHistogramSample{
-						{Ref: 0, T: last, H: h},
-						{Ref: 1, T: last + 10000, H: h},
-						{Ref: 2, T: last + 20000, H: h},
-						{Ref: 3, T: last + 30000, H: h},
-					}
-					if enableSTStorage {
-						setHistogramSTs(histograms)
+						{Ref: 0, ST: last - 1, T: last, H: h},
+						{Ref: 1, ST: last + 9999, T: last + 10000, H: h},
+						{Ref: 2, ST: last + 19999, T: last + 20000, H: h},
+						{Ref: 3, ST: last + 29999, T: last + 30000, H: h},
 					}
 					b, _ = enc.HistogramSamples(histograms, nil)
 					require.NoError(t, w.Log(b))
 					histogramsInWAL += 4
 					cbh := makeCustomBucketHistogram(i)
 					customBucketHistograms := []record.RefHistogramSample{
-						{Ref: 0, T: last, H: cbh},
-						{Ref: 1, T: last + 10000, H: cbh},
-						{Ref: 2, T: last + 20000, H: cbh},
-						{Ref: 3, T: last + 30000, H: cbh},
-					}
-					if enableSTStorage {
-						setHistogramSTs(customBucketHistograms)
+						{Ref: 0, ST: last - 1, T: last, H: cbh},
+						{Ref: 1, ST: last + 9999, T: last + 10000, H: cbh},
+						{Ref: 2, ST: last + 19999, T: last + 20000, H: cbh},
+						{Ref: 3, ST: last + 29999, T: last + 30000, H: cbh},
 					}
 					b = enc.CustomBucketsHistogramSamples(customBucketHistograms, nil)
 					require.NoError(t, w.Log(b))
 					histogramsInWAL += 4
 					fh := makeFloatHistogram(i)
 					floatHistograms := []record.RefFloatHistogramSample{
-						{Ref: 0, T: last, FH: fh},
-						{Ref: 1, T: last + 10000, FH: fh},
-						{Ref: 2, T: last + 20000, FH: fh},
-						{Ref: 3, T: last + 30000, FH: fh},
+						{Ref: 0, ST: last - 1, T: last, FH: fh},
+						{Ref: 1, ST: last + 9999, T: last + 10000, FH: fh},
+						{Ref: 2, ST: last + 19999, T: last + 20000, FH: fh},
+						{Ref: 3, ST: last + 29999, T: last + 30000, FH: fh},
 					}
-					setFloatHistogramSTs(floatHistograms)
 					b, _ = enc.FloatHistogramSamples(floatHistograms, nil)
 					require.NoError(t, w.Log(b))
 					floatHistogramsInWAL += 4
 					cbfh := makeCustomBucketFloatHistogram(i)
 					customBucketFloatHistograms := []record.RefFloatHistogramSample{
-						{Ref: 0, T: last, FH: cbfh},
-						{Ref: 1, T: last + 10000, FH: cbfh},
-						{Ref: 2, T: last + 20000, FH: cbfh},
-						{Ref: 3, T: last + 30000, FH: cbfh},
+						{Ref: 0, ST: last - 1, T: last, FH: cbfh},
+						{Ref: 1, ST: last + 9999, T: last + 10000, FH: cbfh},
+						{Ref: 2, ST: last + 19999, T: last + 20000, FH: cbfh},
+						{Ref: 3, ST: last + 29999, T: last + 30000, FH: cbfh},
 					}
-					setFloatHistogramSTs(customBucketFloatHistograms)
 					b = enc.CustomBucketsFloatHistogramSamples(customBucketFloatHistograms, nil)
 					require.NoError(t, w.Log(b))
 					floatHistogramsInWAL += 4
@@ -364,6 +340,7 @@ func TestCheckpoint(t *testing.T) {
 							if enableSTStorage {
 								require.Equal(t, s.T-1, s.ST, "sample with wrong start timestamp")
 							} else {
+								// Start times should have not survived the round trip.
 								require.Zero(t, s.ST, "sample should not have start timestamp")
 							}
 						}


### PR DESCRIPTION
Now that tsdb supports start times, we can clean up the tests written for the original st-in-wal implementation.

Signed-off-by: Owen Williams <owen.williams@grafana.com>

```release-notes
NONE
```
