### PR TITLE
docs: fix incorrect flag name and metadata_config default

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -4062,7 +4062,7 @@ metadata_config:
   # How frequently metric metadata is sent to remote storage.
   [ send_interval: <duration> | default = 1m ]
   # Maximum number of samples per send.
-  [ max_samples_per_send: <int> | default = 500]
+  [ max_samples_per_send: <int> | default = 2000]
 
 # HTTP client settings, including authentication methods (such as basic auth and
 # authorization), proxy configurations, TLS options, custom HTTP headers, etc.

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -139,7 +139,7 @@ reason to run them sequentially.
 When the `concurrent-rule-eval` feature flag is enabled, rules without any dependency on other rules within a rule group will be evaluated concurrently.
 This has the potential to improve rule group evaluation latency and resource utilization at the expense of adding more concurrent query load.
 
-The number of concurrent rule evaluations can be configured with `--rules.max-concurrent-rule-evals`, which is set to `4` by default.
+The number of concurrent rule evaluations can be configured with `--rules.max-concurrent-evals`, which is set to `4` by default.
 
 ## Serve old Prometheus UI
 


### PR DESCRIPTION
Two documentation values did not match the code:

- `docs/feature_flags.md` referenced `--rules.max-concurrent-rule-evals`, but the flag registered in `cmd/prometheus/main.go` is `--rules.max-concurrent-evals` (no `-rule-`), so the documented command fails with `unknown flag`.
- The remote-write `metadata_config.max_samples_per_send` default was documented as 500, but `DefaultMetadataConfig` in `config/config.go` sets it to 2000. The `queue_config` default on the same page already correctly shows 2000.

Docs only.

```release-notes
NONE
```
