### PR TITLE
docs(textparse): fix OpenMetricsParser.StartTimestamp comment sentinel

### DIFF
--- a/model/textparse/openmetricsparse.go
+++ b/model/textparse/openmetricsparse.go
@@ -285,7 +285,7 @@ func (p *OpenMetricsParser) Exemplar(e *exemplar.Exemplar) bool {
 	return true
 }
 
-// StartTimestamp returns the start timestamp for a current Metric if exists or nil.
+// StartTimestamp returns the start timestamp for a current Metric, or 0 if it does not exist.
 // NOTE(Maniktherana): Might use additional CPU/mem resources due to deep copy of parser required for peeking given 1.0 OM specification on _created series.
 func (p *OpenMetricsParser) StartTimestamp() int64 {
 	if !typeRequiresST(p.mtype) {


### PR DESCRIPTION

<!-- The repo PR template has two sections: the linked-issue line and the
     release-notes block. There is no issue to link (self-contained doc fix), so
     the issue section is left as-is / not applicable. -->

#### Which issue(s) does the PR fix:

N/A. Self-contained doc-comment correctness fix (no tracking issue).

The `OpenMetricsParser.StartTimestamp` doc comment says the method returns the
start timestamp "if exists or nil":

```go
// StartTimestamp returns the start timestamp for a current Metric if exists or nil.
func (p *OpenMetricsParser) StartTimestamp() int64 {
```

The method returns `int64`, which is a non-nilable value type, so it can never
return `nil`. When the start timestamp is unknown the method returns the sentinel
`0`. That matches:

- the `Parser.StartTimestamp` interface contract in `model/textparse/interface.go`
  ("It returns 0 if it is unknown ..."), and
- the sibling parser doc comments in `model/textparse/protobufparse.go`
  ("returns ST or 0 if ST is not present") and `model/textparse/promparse.go`
  ("returns 0 as it's not implemented yet").

`OpenMetricsParser` was the only implementation documenting `nil`. This corrects
the wording to `0` so the comment agrees with the `int64` signature and the
`return 0` sentinel path. No behaviour change.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```
