### PR TITLE
discovery: delete last_update_timestamp metric on config reload

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -265,6 +265,7 @@ func (m *Manager) ApplyConfig(cfg map[string]Configs) error {
 				// Also clean up discovered targets metric. targetsMtx lock needed for safe access to m.targets.
 				delete(m.targets, poolKey{s, prov.name})
 				m.metrics.DiscoveredTargets.DeleteLabelValues(s)
+				m.metrics.LastUpdated.DeleteLabelValues(s)
 
 				if cfg, ok := prov.config.(Config); ok {
 					m.sdMetrics.RefreshManager.DeleteLabelValues(cfg.Name(), s)
@@ -287,6 +288,7 @@ func (m *Manager) ApplyConfig(cfg map[string]Configs) error {
 			if _, ok := prov.newSubs[s]; !ok {
 				delete(m.targets, poolKey{s, prov.name})
 				m.metrics.DiscoveredTargets.DeleteLabelValues(s)
+				m.metrics.LastUpdated.DeleteLabelValues(s)
 
 				// Also clean up refresh metrics for subs that are being removed from a provider that is still running.
 				cfg, ok := prov.config.(Config)

--- a/discovery/manager_test.go
+++ b/discovery/manager_test.go
@@ -1686,6 +1686,10 @@ func TestMetricsCleanupAfterConfigReload(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, count)
 
+	count, err = client_testutil.GatherAndCount(reg, "prometheus_sd_last_update_timestamp_seconds")
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+
 	// Simulate a config refresh.
 	delete(c, "prometheus")
 	discoveryManager.ApplyConfig(c)
@@ -1697,6 +1701,10 @@ func TestMetricsCleanupAfterConfigReload(t *testing.T) {
 	require.Equal(t, 1, count)
 
 	count, err = client_testutil.GatherAndCount(reg, "prometheus_sd_refresh_failures_total")
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	count, err = client_testutil.GatherAndCount(reg, "prometheus_sd_last_update_timestamp_seconds")
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 }


### PR DESCRIPTION
`prometheus_sd_last_update_timestamp_seconds` is a `GaugeVec` labelled by the SD config set name, set together with `prometheus_sd_discovered_targets` in `allGroups()`. But on the two config-removal paths in `ApplyConfig` (a provider that is fully cancelled, and a sub removed from a still-running provider) only `discovered_targets` is deleted, so the `last_update_timestamp` series for a removed config sticks around until the process restarts. It's the same shape as the `prometheus_sd_refresh_failures_total` cleanup that's already there next to it.

This just deletes the `last_update_timestamp` series alongside `discovered_targets` at both sites. I also extended `TestMetricsCleanupAfterConfigReload`, which already checks the sibling metrics go 2 -> 1 on reload, to assert the same for `last_update_timestamp` (it fails before the fix, stays at 2).

```release-notes
[BUGFIX] Discovery: delete the stale `prometheus_sd_last_update_timestamp_seconds` series for a config that is removed on reload.
```
