### PR TITLE
tsdb: fix stale head-chunk cache after head-chunk truncation

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -493,8 +493,9 @@ type headChunkReader struct {
 	// iterating all chunks of a series oldest-to-newest.
 	cachedSeriesRef      storage.SeriesRef
 	cachedHeadChunks     []*memChunk
-	cachedHeadChunksHead *memChunk // Head pointer at collection time; detects head-chunk replacement.
-	cachedMmapLen        int       // len(s.mmappedChunks) at collection time; detects mmap events.
+	cachedHeadChunksHead *memChunk          // Head pointer at collection time; detects head-chunk replacement.
+	cachedMmapLen        int                // len(s.mmappedChunks) at collection time; detects mmap events.
+	cachedFirstChunkID   chunks.HeadChunkID // s.firstChunkID at collection time; detects truncation.
 }
 
 func (h *headChunkReader) Close() error {
@@ -504,6 +505,10 @@ func (h *headChunkReader) Close() error {
 	return nil
 }
 
+// getOrCollectHeadChunks returns the cached head-chunk slice for s, collecting
+// it first if the cache does not match the series' current chunk layout.
+// The series lock must be held; the fingerprint comparison is only consistent
+// against concurrent appends, mmapping, and truncation under that lock.
 func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 	// Skip if the cache is disabled (instant queries) or there are no head chunks or there's only one.
 	if !h.enableCache || s.headChunks == nil || s.headChunks.prev == nil {
@@ -511,7 +516,8 @@ func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 	}
 
 	ref := storage.SeriesRef(s.ref)
-	if ref == h.cachedSeriesRef && s.headChunks == h.cachedHeadChunksHead && h.cachedMmapLen == len(s.mmappedChunks) {
+	if ref == h.cachedSeriesRef && s.headChunks == h.cachedHeadChunksHead &&
+		h.cachedMmapLen == len(s.mmappedChunks) && h.cachedFirstChunkID == s.firstChunkID {
 		return h.cachedHeadChunks
 	}
 
@@ -525,6 +531,7 @@ func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 	h.cachedSeriesRef = ref
 	h.cachedHeadChunksHead = s.headChunks
 	h.cachedMmapLen = len(s.mmappedChunks)
+	h.cachedFirstChunkID = s.firstChunkID
 	return h.cachedHeadChunks
 }
 

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -621,6 +621,87 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		require.Equal(t, newestChunkMinTime, ts, "returned chunk should be the newest head chunk, not a stale cached entry")
 	})
 
+	t.Run("invalidated_after_truncation", func(t *testing.T) {
+		// Regression test: truncateChunksBefore can remove older head chunks
+		// while keeping the same head pointer and, for a series with no
+		// mmapped chunks, the same mmapped-chunk count — only firstChunkID
+		// advances. The cache must fingerprint firstChunkID as well,
+		// otherwise chunk IDs are resolved against the stale slice and the
+		// wrong chunk is returned.
+
+		opts := DefaultHeadOptions()
+		opts.ChunkRange = 100
+		opts.ChunkDirRoot = t.TempDir()
+		h, err := NewHead(nil, nil, nil, nil, opts, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, h.Close()) })
+
+		// Append enough samples to create multiple head chunks.
+		// With ChunkRange=100 and DefaultSamplesPerChunk=120, each chunk
+		// holds ~20 samples (range/step = 100/5). We want >=3 head chunks.
+		app := h.Appender(t.Context())
+		lbls := labels.FromStrings("__name__", "test")
+		for i := int64(0); i < 500; i += 5 {
+			_, err := app.Append(0, lbls, i, float64(i))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app.Commit())
+
+		s := h.series.getByID(1)
+		require.NotNil(t, s)
+		// Snapshot values under the lock and assert after unlocking: a
+		// failing require while the series lock is held would deadlock the
+		// head Close in the test cleanup.
+		s.Lock()
+		headChunksLen := s.headChunks.len()
+		mmappedLen := len(s.mmappedChunks)
+		newestChunkMinTime := s.headChunks.minTime
+		firstChunkIDBefore := s.firstChunkID
+		// Chunk IDs are stable across truncation, so this ref stays valid.
+		newestCID := firstChunkIDBefore + chunks.HeadChunkID(mmappedLen) + chunks.HeadChunkID(headChunksLen) - 1
+		newestRef := chunks.NewHeadChunkRef(s.ref, newestCID)
+		s.Unlock()
+		require.Greater(t, headChunksLen, 2, "need at least 3 head chunks for the test")
+		require.Zero(t, mmappedLen, "test requires a series with no mmapped chunks")
+
+		cr, err := h.chunksRange(0, 10000, nil)
+		require.NoError(t, err)
+		cr.enableCache = true
+
+		// First call: populates the cache.
+		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		require.NoError(t, err)
+		require.NotNil(t, cr.cachedHeadChunks)
+
+		// Truncate the oldest head chunk: the head pointer and the mmapped
+		// chunk count (0) are unchanged, but firstChunkID advances.
+		s.Lock()
+		headPtrBefore := s.headChunks
+		oldestMaxTime := s.headChunks.oldest().maxTime
+		s.truncateChunksBefore(oldestMaxTime+1, 0)
+		headPtrAfter := s.headChunks
+		mmappedLenAfter := len(s.mmappedChunks)
+		firstChunkIDAfter := s.firstChunkID
+		s.Unlock()
+
+		require.Same(t, headPtrBefore, headPtrAfter, "truncation must keep the head pointer")
+		require.Zero(t, mmappedLenAfter, "mmapped-chunk count must stay 0 so only firstChunkID distinguishes the truncated state")
+		require.Greater(t, firstChunkIDAfter, firstChunkIDBefore, "truncation should advance firstChunkID")
+
+		// Query the newest head chunk again. With a stale cache, the
+		// advanced firstChunkID indexes the old slice at the wrong position
+		// and returns an older chunk.
+		chk, _, err := cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		require.NoError(t, err)
+		require.NotNil(t, chk)
+		require.Len(t, cr.cachedHeadChunks, headChunksLen-1, "the stale cache must be re-collected after truncation")
+
+		it := chk.Iterator(nil)
+		require.Equal(t, chunkenc.ValFloat, it.Next())
+		ts, _ := it.At()
+		require.Equal(t, newestChunkMinTime, ts, "returned chunk should be the newest head chunk, not a stale cached entry")
+	})
+
 	t.Run("buffer_cap_release", func(t *testing.T) {
 		// Test that headChunksBuf is released when its capacity exceeds
 		// headChunksBufMaxCap, preventing unbounded memory retention.


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

The head-chunk cache fingerprint (series ref, head pointer, mmapped count) could not detect `truncateChunksBefore` removing older head chunks: the head pointer survives and, for a series with no mmapped chunks, the mmapped count stays 0, while `firstChunkID` advances. A cache-enabled reader (range queries through the head-and-OOO reader) then resolved chunk IDs against the stale slice and returned the wrong chunk, or failed with `ErrNotFound`.

Include `firstChunkID` in the fingerprint; it advances on every truncation and never regresses.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] TSDB: Fix the head-chunk cache returning samples from the wrong chunk, or spurious not-found errors, to range queries after head-chunk truncation
```
