### PR TITLE
tsdb: fix stale head-chunk cache after head-chunk truncation (#19134)

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -477,8 +477,9 @@ type headChunkReader struct {
 	// iterating all chunks of a series oldest-to-newest.
 	cachedSeriesRef      storage.SeriesRef
 	cachedHeadChunks     []*memChunk
-	cachedHeadChunksHead *memChunk // Head pointer at collection time; detects head-chunk replacement.
-	cachedMmapLen        int       // len(s.mmappedChunks) at collection time; detects mmap events.
+	cachedHeadChunksHead *memChunk          // Head pointer at collection time; detects head-chunk replacement.
+	cachedMmapLen        int                // len(s.mmappedChunks) at collection time; detects mmap events.
+	cachedFirstChunkID   chunks.HeadChunkID // s.firstChunkID at collection time; detects truncation.
 }
 
 func (h *headChunkReader) Close() error {
@@ -488,6 +489,10 @@ func (h *headChunkReader) Close() error {
 	return nil
 }
 
+// getOrCollectHeadChunks returns the cached head-chunk slice for s, collecting
+// it first if the cache does not match the series' current chunk layout.
+// The series lock must be held; the fingerprint comparison is only consistent
+// against concurrent appends, mmapping, and truncation under that lock.
 func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 	// Skip if the cache is disabled (instant queries) or there are no head chunks or there's only one.
 	if !h.enableCache || s.headChunks == nil || s.headChunks.prev == nil {
@@ -495,7 +500,8 @@ func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 	}
 
 	ref := storage.SeriesRef(s.ref)
-	if ref == h.cachedSeriesRef && s.headChunks == h.cachedHeadChunksHead && h.cachedMmapLen == len(s.mmappedChunks) {
+	if ref == h.cachedSeriesRef && s.headChunks == h.cachedHeadChunksHead &&
+		h.cachedMmapLen == len(s.mmappedChunks) && h.cachedFirstChunkID == s.firstChunkID {
 		return h.cachedHeadChunks
 	}
 
@@ -509,6 +515,7 @@ func (h *headChunkReader) getOrCollectHeadChunks(s *memSeries) []*memChunk {
 	h.cachedSeriesRef = ref
 	h.cachedHeadChunksHead = s.headChunks
 	h.cachedMmapLen = len(s.mmappedChunks)
+	h.cachedFirstChunkID = s.firstChunkID
 	return h.cachedHeadChunks
 }
 

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -621,6 +621,87 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		require.Equal(t, newestChunkMinTime, ts, "returned chunk should be the newest head chunk, not a stale cached entry")
 	})
 
+	t.Run("invalidated_after_truncation", func(t *testing.T) {
+		// Regression test: truncateChunksBefore can remove older head chunks
+		// while keeping the same head pointer and, for a series with no
+		// mmapped chunks, the same mmapped-chunk count — only firstChunkID
+		// advances. The cache must fingerprint firstChunkID as well,
+		// otherwise chunk IDs are resolved against the stale slice and the
+		// wrong chunk is returned.
+
+		opts := DefaultHeadOptions()
+		opts.ChunkRange = 100
+		opts.ChunkDirRoot = t.TempDir()
+		h, err := NewHead(nil, nil, nil, nil, opts, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, h.Close()) })
+
+		// Append enough samples to create multiple head chunks.
+		// With ChunkRange=100 and DefaultSamplesPerChunk=120, each chunk
+		// holds ~20 samples (range/step = 100/5). We want >=3 head chunks.
+		app := h.Appender(t.Context())
+		lbls := labels.FromStrings("__name__", "test")
+		for i := int64(0); i < 500; i += 5 {
+			_, err := app.Append(0, lbls, i, float64(i))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app.Commit())
+
+		s := h.series.getByID(1)
+		require.NotNil(t, s)
+		// Snapshot values under the lock and assert after unlocking: a
+		// failing require while the series lock is held would deadlock the
+		// head Close in the test cleanup.
+		s.Lock()
+		headChunksLen := s.headChunks.len()
+		mmappedLen := len(s.mmappedChunks)
+		newestChunkMinTime := s.headChunks.minTime
+		firstChunkIDBefore := s.firstChunkID
+		// Chunk IDs are stable across truncation, so this ref stays valid.
+		newestCID := firstChunkIDBefore + chunks.HeadChunkID(mmappedLen) + chunks.HeadChunkID(headChunksLen) - 1
+		newestRef := chunks.NewHeadChunkRef(s.ref, newestCID)
+		s.Unlock()
+		require.Greater(t, headChunksLen, 2, "need at least 3 head chunks for the test")
+		require.Zero(t, mmappedLen, "test requires a series with no mmapped chunks")
+
+		cr, err := h.chunksRange(0, 10000, nil)
+		require.NoError(t, err)
+		cr.enableCache = true
+
+		// First call: populates the cache.
+		_, _, err = cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		require.NoError(t, err)
+		require.NotNil(t, cr.cachedHeadChunks)
+
+		// Truncate the oldest head chunk: the head pointer and the mmapped
+		// chunk count (0) are unchanged, but firstChunkID advances.
+		s.Lock()
+		headPtrBefore := s.headChunks
+		oldestMaxTime := s.headChunks.oldest().maxTime
+		s.truncateChunksBefore(oldestMaxTime+1, 0)
+		headPtrAfter := s.headChunks
+		mmappedLenAfter := len(s.mmappedChunks)
+		firstChunkIDAfter := s.firstChunkID
+		s.Unlock()
+
+		require.Same(t, headPtrBefore, headPtrAfter, "truncation must keep the head pointer")
+		require.Zero(t, mmappedLenAfter, "mmapped-chunk count must stay 0 so only firstChunkID distinguishes the truncated state")
+		require.Greater(t, firstChunkIDAfter, firstChunkIDBefore, "truncation should advance firstChunkID")
+
+		// Query the newest head chunk again. With a stale cache, the
+		// advanced firstChunkID indexes the old slice at the wrong position
+		// and returns an older chunk.
+		chk, _, err := cr.chunk(chunks.Meta{Ref: chunks.ChunkRef(newestRef)}, false)
+		require.NoError(t, err)
+		require.NotNil(t, chk)
+		require.Len(t, cr.cachedHeadChunks, headChunksLen-1, "the stale cache must be re-collected after truncation")
+
+		it := chk.Iterator(nil)
+		require.Equal(t, chunkenc.ValFloat, it.Next())
+		ts, _ := it.At()
+		require.Equal(t, newestChunkMinTime, ts, "returned chunk should be the newest head chunk, not a stale cached entry")
+	})
+
 	t.Run("buffer_cap_release", func(t *testing.T) {
 		// Test that headChunksBuf is released when its capacity exceeds
 		// headChunksBufMaxCap, preventing unbounded memory retention.


### PR DESCRIPTION
Backport of #19134 to `release-3.13`.

The head-chunk cache fingerprint (series ref, head pointer, mmapped count) could not detect `truncateChunksBefore` removing older head chunks: the head pointer survives and, for a series with no mmapped chunks, the mmapped count stays 0, while `firstChunkID` advances. A cache-enabled reader (range queries through the head-and-OOO reader) then resolved chunk IDs against the stale slice and returned the wrong chunk, or failed with `ErrNotFound`.

Include `firstChunkID` in the fingerprint; it advances on every truncation and never regresses.

The head-chunk cache (#18302) that introduced the bug is present in `release-3.13`, so the fix applies. Cherry-picked cleanly from commit 39359eb784397136c1aa91046915ca6c2ec93b42; the `headChunkReader` struct and `getOrCollectHeadChunks` are byte-identical between `main` and `release-3.13`.

```release-notes
[BUGFIX] TSDB: Fix the head-chunk cache returning samples from the wrong chunk, or spurious not-found errors, to range queries after head-chunk truncation
```
