### PR TITLE
ci: run version upgrade test as a per-LTS matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,28 @@ jobs:
       # Alternatively we could adjust each relevant test to have 386 aware parallelization setting.
       - run: GOARCH=386 go test -parallel=1 ./...
 
+  list_lts_releases:
+    name: List active LTS releases
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.lts.outputs.versions }}
+    steps:
+      - id: lts
+        # Emit the active LTS versions as a JSON array consumed by the matrix below.
+        run: |
+          versions=$(curl -sSf https://prometheus.io/download.json \
+            | jq -c '[.prometheus[] | select(.lts == true) | (.version | ltrimstr("v"))]')
+          echo "versions=$versions" >> "$GITHUB_OUTPUT"
+
   test_version_upgrade:
     name: Go tests for Prometheus upgrades and downgrades
+    needs: list_lts_releases
     runs-on: ubuntu-latest
+    strategy:
+      # Run every LTS release even if one fails.
+      fail-fast: false
+      matrix:
+        lts_version: ${{ fromJSON(needs.list_lts_releases.outputs.versions) }}
     container:
       image: quay.io/prometheus/golang-builder:1.26-base
     steps:
@@ -71,7 +90,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
-      - run: go test -v --race ./cmd/prometheus/ --test.version-upgrade=true -run TestVersionUpgrade
+      - run: go test -v --race ./cmd/prometheus/ --test.version-upgrade=true --test.lts-version=${{ matrix.lts_version }} -run TestVersionUpgrade
 
   test_go_oldest:
     name: Go tests with previous Go version

--- a/cmd/prometheus/main_upgrade_test.go
+++ b/cmd/prometheus/main_upgrade_test.go
@@ -298,7 +298,10 @@ func ensureHealthyLogs(t *testing.T, r io.Reader) {
 	require.NoError(t, scanner.Err())
 }
 
-var testVersionUpgrade = flag.Bool("test.version-upgrade", false, "run resource-intensive and probably slow version upgrade tests")
+var (
+	testVersionUpgrade = flag.Bool("test.version-upgrade", false, "run resource-intensive and probably slow version upgrade tests")
+	testLTSVersion     = flag.String("test.lts-version", "", "restrict the version upgrade test to a single LTS version (e.g. 3.5.0); if empty, all active LTS releases are tested")
+)
 
 // TestVersionUpgrade_UpgradeDowngradeLatestLTS verifies that Prometheus can
 // upgrade from each current LTS release to the current build and then downgrade
@@ -315,6 +318,18 @@ func TestVersionUpgrade_UpgradeDowngradeLatestLTS(t *testing.T) {
 
 	ltsReleases := fetchLTSReleases(t)
 	t.Logf("[%s] found %d LTS release(s) from %s", time.Since(start), len(ltsReleases), prometheusDownloadManifestURL)
+
+	if *testLTSVersion != "" {
+		want := strings.TrimPrefix(*testLTSVersion, "v")
+		filtered := ltsReleases[:0]
+		for _, lts := range ltsReleases {
+			if lts.version == want {
+				filtered = append(filtered, lts)
+			}
+		}
+		require.NotEmpty(t, filtered, "LTS version %q not found among active LTS releases in %s", want, prometheusDownloadManifestURL)
+		ltsReleases = filtered
+	}
 
 	for _, lts := range ltsReleases {
 		t.Run(lts.version, func(t *testing.T) {


### PR DESCRIPTION
Backport of commit 827d0f9ad ("ci: run version upgrade test as a per-LTS matrix") to `release-3.13`.

On `release-3.13`, `TestVersionUpgrade_UpgradeDowngradeLatestLTS` runs every active LTS release sequentially within a single CI job. The download manifest currently returns two active LTS releases (`v3.13.0` and `v3.5.4`), so the job serially downloads, runs, upgrades and downgrades each — slow, and one release failing masks the others.

This fans the upgrade/downgrade test out over each active LTS release so the matrix jobs run in parallel and a single release failure does not mask the others:

- A new `list_lts_releases` job reads the active LTS versions from `prometheus.io/download.json` and feeds them to the matrix.
- Adds a `--test.lts-version` flag so `TestVersionUpgrade` can be restricted to a single LTS release; when empty, all active LTS releases are tested (behaviour unchanged for local runs).

Cherry-picked with `-x`. The Go change applied cleanly. The `ci.yml` step block was adapted to keep `release-3.13`'s existing `promci-setup@v0.1.0` (the `cache_key_suffix` input introduced on `main` belongs to a newer promci-setup version and is not part of this speedup); only the `go test` invocation gained the `--test.lts-version=${{ matrix.lts_version }}` argument.

```release-notes
NONE
```
