### PR TITLE
tsdb: improve handling of full-range tombstones during WAL replay and checkpointing

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2355,6 +2355,15 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		h.series.hashes[hashStripe].del(hash, series.ref)
 		h.series.locks[hashStripe].Unlock()
 
+		// Keep the series record in WAL checkpoints while the WAL may still contain its samples.
+		// Without it, the next checkpoint would drop the record while its samples remain in later
+		// segments, and the following replay would discard them entirely.
+		if h.wal != nil {
+			if maxt := series.maxTime(); maxt != math.MinInt64 {
+				h.updateWALExpiry(series.ref, maxt)
+			}
+		}
+
 		if value.IsStaleNaN(series.lastValue) ||
 			(series.lastHistogramValue != nil && value.IsStaleNaN(series.lastHistogramValue.Sum)) ||
 			(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
@@ -2525,6 +2534,16 @@ func (s *stripeSeries) getByHash(hash uint64, lset labels.Labels) *memSeries {
 	s.locks[i].RUnlock()
 
 	return series
+}
+
+// unlinkHash removes the series with the given ref from the hash index, but leaves it
+// in the by-ref map so refs to it remain resolvable until it is fully deleted.
+func (s *stripeSeries) unlinkHash(hash uint64, ref chunks.HeadSeriesRef) {
+	i := hash & uint64(s.size-1)
+
+	s.locks[i].Lock()
+	defer s.locks[i].Unlock()
+	s.hashes[i].del(hash, ref)
 }
 
 func (s *stripeSeries) setUnlessAlreadySet(hash uint64, lset labels.Labels, series *memSeries) (*memSeries, bool) {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2355,9 +2355,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		h.series.hashes[hashStripe].del(hash, series.ref)
 		h.series.locks[hashStripe].Unlock()
 
-		// Keep the series record in WAL checkpoints while the WAL may still contain its samples.
-		// Without it, the next checkpoint would drop the record while its samples remain in later
-		// segments, and the following replay would discard them entirely.
+		// Keep the series record in WAL checkpoints while the WAL still contains its samples.
 		if h.wal != nil {
 			if maxt := series.maxTime(); maxt != math.MinInt64 {
 				h.updateWALExpiry(series.ref, maxt)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2355,7 +2355,8 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 		h.series.hashes[hashStripe].del(hash, series.ref)
 		h.series.locks[hashStripe].Unlock()
 
-		// Keep the series record in WAL checkpoints while the WAL still contains its samples.
+		// Keep the series record in checkpoints until its last sample time; while the
+		// WAL may still hold samples for this ref, they can't outlive maxt.
 		if h.wal != nil {
 			if maxt := series.maxTime(); maxt != math.MinInt64 {
 				h.updateWALExpiry(series.ref, maxt)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -9091,8 +9091,10 @@ func TestHead_WALCheckpoint_FullRangeTombstones(t *testing.T) {
 	walEntries := []any{
 		[]record.RefSeries{{Ref: 1, Labels: lbls1}, {Ref: 2, Labels: lbls2}},
 		[]record.RefSample{
-			{Ref: 1, T: 100, V: 1}, {Ref: 1, T: 500, V: 2},
-			{Ref: 2, T: 100, V: 3}, {Ref: 2, T: 200, V: 4},
+			{Ref: 1, T: 100, V: 1},
+			{Ref: 1, T: 500, V: 2},
+			{Ref: 2, T: 100, V: 3},
+			{Ref: 2, T: 200, V: 4},
 		},
 		[]tombstones.Stone{
 			{Ref: 1, Intervals: fullRange},

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -9147,6 +9147,13 @@ func TestHead_WALCheckpoint_FullRangeTombstones(t *testing.T) {
 	require.NoError(t, err)
 	recs := append(readTestWAL(t, cpDir), readTestWAL(t, w.Dir())...)
 	testutil.RequireEqual(t, expected, recs)
+
+	// WAL expiries are cleaned up alongside the records they retain.
+	keepUntil, ok = head.getWALExpiry(1)
+	require.True(t, ok, "ref 1 expiry must be retained (500 >= mint 250)")
+	require.Equal(t, int64(500), keepUntil)
+	_, ok = head.getWALExpiry(2)
+	require.False(t, ok, "ref 2 expiry must be cleared (200 < mint 250)")
 }
 
 func TestHead_FastStartupStateFile(t *testing.T) {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -8979,6 +8979,174 @@ func TestWALReplayRaceWithStaleSeriesCompaction(t *testing.T) {
 	require.NoError(t, head.Close())
 }
 
+// TestHead_ReadWAL_TombstonesAdvanceLastSeriesID verifies that replay advances
+// lastSeriesID past tombstone refs, regardless of whether the stone's series
+// record exists.
+func TestHead_ReadWAL_TombstonesAdvanceLastSeriesID(t *testing.T) {
+	cases := []struct {
+		name  string
+		stone tombstones.Stone
+	}{
+		{
+			name:  "interval tombstone",
+			stone: tombstones.Stone{Ref: 42, Intervals: []tombstones.Interval{{Mint: 0, Maxt: 100}}},
+		},
+		{
+			name:  "full-range tombstone",
+			stone: tombstones.Stone{Ref: 42, Intervals: []tombstones.Interval{{Mint: math.MinInt64, Maxt: math.MaxInt64}}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := []any{
+				[]record.RefSeries{
+					{Ref: 10, Labels: labels.FromStrings("a", "1")},
+				},
+				[]record.RefSample{
+					{Ref: 10, T: 100, V: 1},
+				},
+				[]tombstones.Stone{tc.stone},
+			}
+
+			head, w := newTestHead(t, 1000, compression.None, false)
+			defer func() {
+				require.NoError(t, head.Close())
+			}()
+
+			populateTestWL(t, w, entries, nil, false)
+
+			require.NoError(t, head.Init(math.MinInt64))
+
+			require.Equal(t, uint64(42), head.lastSeriesID.Load())
+		})
+	}
+}
+
+// TestStripeSeries_UnlinkHash verifies that unlinkHash removes a series from the hash
+// index while leaving it resolvable by ref. Lookups by labels no longer find it, and a
+// series with the same labels is created fresh instead of aliasing the unlinked one.
+func TestStripeSeries_UnlinkHash(t *testing.T) {
+	head, _ := newTestHead(t, 1000, compression.None, false)
+	defer func() {
+		require.NoError(t, head.Close())
+	}()
+
+	lbls := labels.FromStrings("a", "1")
+	s1, created, err := head.getOrCreateWithOptionalID(1, lbls.Hash(), lbls, false)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	head.series.unlinkHash(lbls.Hash(), s1.ref)
+
+	// Gone from the hash index, still resolvable by ref.
+	require.Nil(t, head.series.getByHash(lbls.Hash(), lbls))
+	require.Same(t, s1, head.series.getByID(s1.ref))
+
+	// A series with the same labels isn't aliased onto s1.
+	s2, created, err := head.getOrCreateWithOptionalID(2, lbls.Hash(), lbls, false)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Equal(t, chunks.HeadSeriesRef(2), s2.ref)
+}
+
+// TestHead_WALReplay_FullRangeTombstoneDeletesDuplicateRef verifies that a full-range
+// tombstone whose ref was mapped onto another series during replay deletes the series it was mapped to.
+func TestHead_WALReplay_FullRangeTombstoneDeletesDuplicateRef(t *testing.T) {
+	lbls := labels.FromStrings("a", "1")
+	entries := []any{
+		[]record.RefSeries{
+			{Ref: 1, Labels: lbls},
+			// Duplicate record for the same series under a different ref; replay
+			// maps ref 2 onto ref 1.
+			{Ref: 2, Labels: lbls},
+		},
+		[]record.RefSample{
+			{Ref: 2, T: 100, V: 1},
+		},
+		[]tombstones.Stone{
+			{Ref: 2, Intervals: tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}},
+		},
+	}
+
+	head, w := newTestHead(t, 1000, compression.None, false)
+	defer func() {
+		require.NoError(t, head.Close())
+	}()
+	populateTestWL(t, w, entries, nil, false)
+
+	require.NoError(t, head.Init(math.MinInt64))
+
+	require.Equal(t, uint64(0), head.NumSeries())
+}
+
+// TestHead_WALCheckpoint_FullRangeTombstones verifies checkpointing of a series deleted
+// during replay by a full-range tombstone. Replay sets a WAL expiry at the series' max
+// sample time, so checkpoints keep its series record and tombstone while the WAL still
+// holds samples for it and drop both once those samples age out.
+func TestHead_WALCheckpoint_FullRangeTombstones(t *testing.T) {
+	lbls1 := labels.FromStrings("a", "1")
+	lbls2 := labels.FromStrings("a", "2")
+	fullRange := tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}
+	walEntries := []any{
+		[]record.RefSeries{{Ref: 1, Labels: lbls1}, {Ref: 2, Labels: lbls2}},
+		[]record.RefSample{
+			{Ref: 1, T: 100, V: 1}, {Ref: 1, T: 500, V: 2},
+			{Ref: 2, T: 100, V: 3}, {Ref: 2, T: 200, V: 4},
+		},
+		[]tombstones.Stone{
+			{Ref: 1, Intervals: fullRange},
+			{Ref: 2, Intervals: fullRange},
+		},
+	}
+
+	head, w := newTestHead(t, 1000, compression.None, false)
+	defer func() {
+		require.NoError(t, head.Close())
+	}()
+	populateTestWL(t, w, walEntries, nil, false)
+	first, _, err := wlog.Segments(w.Dir())
+	require.NoError(t, err)
+
+	require.NoError(t, head.Init(math.MinInt64))
+
+	// Replay applied the tombstones: both series are deleted, and each ref has a WAL
+	// expiry at its max sample time.
+	require.Equal(t, uint64(0), head.NumSeries())
+	keepUntil, ok := head.getWALExpiry(1)
+	require.True(t, ok)
+	require.Equal(t, int64(500), keepUntil)
+	keepUntil, ok = head.getWALExpiry(2)
+	require.True(t, ok)
+	require.Equal(t, int64(200), keepUntil)
+
+	// Checkpoint with mint=250, between the two expiries. Each truncation creates a
+	// new segment, so attempt truncations until a checkpoint is created.
+	for {
+		head.lastWALTruncationTime.Store(0) // Reset so that it's always time to truncate the WAL.
+		require.NoError(t, head.truncateWAL(250))
+		f, _, err := wlog.Segments(w.Dir())
+		require.NoError(t, err)
+		if f > first {
+			break
+		}
+	}
+
+	// The WAL still holds a sample for ref 1 (t=500 >= mint), so its series record
+	// must be kept for the sample to resolve on replay, and its tombstone with it so
+	// the replayed series is deleted again. Ref 2's samples all age out, and its
+	// series record and tombstone are dropped with them.
+	expected := []any{
+		[]record.RefSeries{{Ref: 1, Labels: lbls1}},
+		[]record.RefSample{{Ref: 1, T: 500, V: 2}},
+		[]tombstones.Stone{{Ref: 1, Intervals: fullRange}},
+	}
+	cpDir, _, err := wlog.LastCheckpoint(w.Dir())
+	require.NoError(t, err)
+	recs := append(readTestWAL(t, cpDir), readTestWAL(t, w.Dir())...)
+	testutil.RequireEqual(t, expected, recs)
+}
+
 func TestHead_FastStartupStateFile(t *testing.T) {
 	opts := newTestHeadDefaultOptions(1000, false)
 	// Enable the fast startup feature.

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -315,15 +315,26 @@ Outer:
 			// Tombstone records will be fairly rare, so not trying to optimise the allocations here.
 			deleteSeriesShards := make([][]chunks.HeadSeriesRef, concurrency)
 			for _, s := range v {
+				// A tombstone means this ref was previously allocated, even if its series record is no
+				// longer in the WAL. Advance lastSeriesID so the ref is not reissued.
+				if h.lastSeriesID.Load() < uint64(s.Ref) {
+					h.lastSeriesID.Store(uint64(s.Ref))
+				}
 				if len(s.Intervals) == 1 && s.Intervals[0].Mint == math.MinInt64 && s.Intervals[0].Maxt == math.MaxInt64 {
 					// This series was fully deleted at this point. This record is only done for stale series at the moment.
-					mod := uint64(s.Ref) % uint64(concurrency)
-					deleteSeriesShards[mod] = append(deleteSeriesShards[mod], chunks.HeadSeriesRef(s.Ref))
-
-					// If the series is with a different reference, try deleting that.
-					if r, ok := multiRef[chunks.HeadSeriesRef(s.Ref)]; ok {
-						mod := uint64(r) % uint64(concurrency)
-						deleteSeriesShards[mod] = append(deleteSeriesShards[mod], r)
+					ref := chunks.HeadSeriesRef(s.Ref)
+					// If the series is with a different reference, delete that one.
+					if r, ok := multiRef[ref]; ok {
+						ref = r
+					}
+					if series := h.series.getByID(ref); series != nil {
+						// Remove the series from the hash index so that a later series
+						// record with the same labels creates a fresh series instead of
+						// mapping onto this one. It stays in the by-ref map so
+						// already-queued samples still resolve until the deletion applies.
+						h.series.unlinkHash(series.lset.Hash(), ref)
+						mod := uint64(ref) % uint64(concurrency)
+						deleteSeriesShards[mod] = append(deleteSeriesShards[mod], ref)
 					}
 					continue
 				}

--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -313,9 +313,13 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 			if err != nil {
 				return nil, fmt.Errorf("decode deletes: %w", err)
 			}
-			// Drop irrelevant tombstones in place.
+			// Drop irrelevant tombstones in place. A tombstone is dropped together with
+			// its series record, or once all its intervals age out of the WAL.
 			repl := tstones[:0]
 			for _, s := range tstones {
+				if !keep(chunks.HeadSeriesRef(s.Ref)) {
+					continue
+				}
 				for _, iv := range s.Intervals {
 					if iv.Maxt >= mint {
 						repl = append(repl, s)

--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -95,8 +95,15 @@ func DeleteTempCheckpoints(logger *slog.Logger, dir string) error {
 
 // Checkpoint creates a compacted checkpoint of segments in range [from, to] in the given WAL.
 // It includes the most recent checkpoint if it exists.
-// All series not satisfying keep, samples/tombstones/exemplars below mint and
-// metadata that are not the latest are dropped.
+// All series not satisfying keep, samples/exemplars below mint, tombstones not
+// satisfying keep or with all intervals below mint, and metadata that are not the
+// latest are dropped.
+//
+// keep is evaluated per record as segments are read, so its result for a given ref
+// must not change while Checkpoint runs. Otherwise records for the same ref could be
+// treated inconsistently, e.g. a series record kept but its tombstone dropped. The
+// Head satisfies this by serializing checkpointing with every series-deleting path
+// (GC and series truncation) via chunkSnapshotMtx.
 //
 // The checkpoint is stored in a directory named checkpoint.N in the same
 // segmented format as the original WAL itself.

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -16,6 +16,7 @@ package wlog
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -30,6 +31,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"github.com/prometheus/prometheus/util/compression"
 	"github.com/prometheus/prometheus/util/testutil"
 )
@@ -383,6 +385,68 @@ func TestCheckpoint(t *testing.T) {
 			})
 		}
 	}
+}
+
+// TestCheckpoint_Tombstones verifies tombstone retention. A tombstone is dropped
+// together with its series record, or once all its intervals age out of the WAL.
+func TestCheckpoint_Tombstones(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	seg, err := CreateSegment(dir, 0)
+	require.NoError(t, err)
+	require.NoError(t, seg.Close())
+
+	w, err := NewSize(nil, nil, dir, 128*1024, compression.None)
+	require.NoError(t, err)
+	var enc record.Encoder
+	fullRange := tombstones.Intervals{{Mint: math.MinInt64, Maxt: math.MaxInt64}}
+	require.NoError(t, w.Log(enc.Tombstones([]tombstones.Stone{
+		// Full-range tombstones: kept iff keep(ref).
+		{Ref: 1, Intervals: fullRange},
+		{Ref: 2, Intervals: fullRange},
+		// Finite intervals with keep(ref) = true: kept iff they extend past mint.
+		{Ref: 3, Intervals: tombstones.Intervals{{Mint: 0, Maxt: 100}}},
+		{Ref: 4, Intervals: tombstones.Intervals{{Mint: 0, Maxt: 5}}},
+		// Dropped because keep(ref) is false, even though their intervals extend past mint.
+		{Ref: 5, Intervals: tombstones.Intervals{{Mint: 1000, Maxt: math.MaxInt64}}},
+		{Ref: 6, Intervals: tombstones.Intervals{{Mint: 0, Maxt: 100}}},
+	}, nil)))
+	first, last, err := Segments(w.Dir())
+	require.NoError(t, err)
+	_, err = w.NextSegment()
+	require.NoError(t, err)
+
+	_, err = Checkpoint(promslog.NewNopLogger(), w, first, last, func(id chunks.HeadSeriesRef) bool {
+		return id == 2 || id == 3 || id == 4
+	}, 10, false)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	cpDir, _, err := LastCheckpoint(w.Dir())
+	require.NoError(t, err)
+	sr, err := NewSegmentsReader(cpDir)
+	require.NoError(t, err)
+	defer sr.Close()
+
+	dec := record.NewDecoder(labels.NewSymbolTable(), promslog.NewNopLogger())
+	r := NewReader(sr)
+	var stones []tombstones.Stone
+	for r.Next() {
+		rec := r.Record()
+		if dec.Type(rec) == record.Tombstones {
+			stones, err = dec.Tombstones(rec, stones)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, r.Err())
+
+	expected := []tombstones.Stone{
+		// Refs 1, 5, and 6 are dropped by keep(ref); ref 4 aged out.
+		{Ref: 2, Intervals: fullRange},
+		{Ref: 3, Intervals: tombstones.Intervals{{Mint: 0, Maxt: 100}}},
+	}
+	require.Equal(t, expected, stones)
 }
 
 // TestCheckpointV2HistogramsToV1 verifies that when a WAL contains V2 histogram


### PR DESCRIPTION
A full-range tombstone (a single interval covering `(MinInt64, MaxInt64)`, written when a series is fully deleted from the head, e.g. by stale-series compaction) is mishandled by WAL replay and checkpointing in three ways. These can cause `Unknown series references` during replay and missing samples:

1. **Recreated series can be deleted by the original series' tombstone.** Replay applies a full-range tombstone by queueing the series deletion onto a concurrent worker. A series record with the same labels appearing later in the WAL (a series that is deleted and comes back) is mapped onto the tombstoned ref via `multiRef`. A queued series deletion that executes **after** this mapping will delete the `multiRef` target, and drop all samples for the recreated series.

2. **Checkpoints drop deleted series still referenced later in the WAL.** Deletions applied during replay set no WAL expiry for the deleted series ref, so the next checkpoint drops the series record while later segments still hold references to it. The next replay cannot resolve those records and skips them.

3. **Full-range tombstones never leave checkpoints, and their series refs can be reissued.** Checkpoints retain any tombstone with an interval reaching past `mint`. This is always true for `Maxt = MaxInt64`, so full-range tombstones are never removed from checkpoints, even long after their series have been dropped. `lastSeriesID` is only advanced by series records, so the ref of a deleted series whose tombstone is still in the WAL can be reissued to a new, unrelated series. That tombstone could delete the new series occupying its ref on the next replay (see issue 1), and continue to do so forever.

Fixes:
- **Issue 1:** `loadWAL` synchronously removes a to-be-deleted series from the hash index before queueing the deletion. If the series re-appears later in the WAL, it will be assigned a new ID rather than aliasing the deleted one. The series stays in the by-ref map so that already-queued samples resolve until the deletion applies.
- **Issue 2:** `deleteSeriesByID` records a WAL expiry at the deleted series' max sample time, keeping its series record in checkpoints while the WAL still holds samples that reference it.
- **Issue 3:** `loadWAL` advances `lastSeriesID` past every tombstone ref, preventing new series from colliding with them
- **Issue 3:** `Checkpoint` drops tombstones whose ref fails `keep()`, the same rule used for series records. Tombstones that pass `keep()` are still subject to the existing interval-vs-`mint` check.

#### Which issue(s) does the PR fix:

None filed.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] TSDB: Improve handling of full-range tombstones during WAL replay and checkpointing.
```

Made with [Cursor](https://cursor.com)