### PR TITLE
perf(tsdb): reuse scratch buffer in mmapChunks

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2065,6 +2065,7 @@ func (h *Head) onChunkCreated(series *memSeries, prevHeadChunkCount uint32) {
 // since holding the lock during an append could delay the next scrape or cause query timeouts.
 func (h *Head) mmapHeadChunks() {
 	var count int
+	var buf []*memChunk // Reusable scratch buffer for mmapChunks.
 	for i := range h.series.size {
 		if h.series.mmapReady[i].Load() == 0 {
 			continue // No series in this stripe need mmapping.
@@ -2077,7 +2078,8 @@ func (h *Head) mmapHeadChunks() {
 			}
 
 			series.Lock()
-			n := series.mmapChunks(h.chunkDiskMapper)
+			var n int
+			n, buf = series.mmapChunks(h.chunkDiskMapper, buf)
 			series.Unlock()
 			if n > 0 {
 				count += n
@@ -2838,6 +2840,26 @@ func (mc *memChunk) len() (count int) {
 		elem = elem.prev
 	}
 	return count
+}
+
+// prepareHeadChunksBuf returns an empty reusable buffer sized for expectedLen.
+func prepareHeadChunksBuf(buf []*memChunk, expectedLen int) []*memChunk {
+	if expectedLen < 0 {
+		expectedLen = 0
+	}
+	if cap(buf) > headChunksBufMaxCap || cap(buf) < expectedLen {
+		return make([]*memChunk, 0, expectedLen)
+	}
+	return buf[:0]
+}
+
+// releaseHeadChunksBuf returns an empty reusable buffer, or nil if it is oversized.
+func releaseHeadChunksBuf(buf []*memChunk) []*memChunk {
+	if cap(buf) > headChunksBufMaxCap {
+		return nil
+	}
+	clear(buf[:cap(buf)])
+	return buf[:0]
 }
 
 // collectHeadChunks walks the headChunks linked list once and returns a slice

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2144,9 +2144,14 @@ func (h *Head) onChunkCreated(series *memSeries, prevHeadChunkCount uint32) {
 // since holding the lock during an append could delay the next scrape or cause query timeouts.
 func (h *Head) mmapHeadChunks() {
 	var count int
+	var mmapScratch headChunksScratch
 	for i := range h.series.size {
-		count += h.mmapHeadChunksInStripe(i)
+		if h.series.mmapReady[i].Load() == 0 {
+			continue // No series in this stripe need mmapping.
+		}
+		count += h.mmapHeadChunksInStripe(i, &mmapScratch)
 	}
+	mmapScratch.release()
 	h.metrics.mmapChunksTotal.Add(float64(count))
 }
 
@@ -2154,11 +2159,7 @@ func (h *Head) mmapHeadChunks() {
 // need it. It uses deferred unlocking so that locks are released even if
 // mmapChunks panics (e.g. via handleChunkWriteError), preventing deadlocks
 // during cleanup.
-func (h *Head) mmapHeadChunksInStripe(i int) (count int) {
-	if h.series.mmapReady[i].Load() == 0 {
-		return 0 // No series in this stripe need mmapping.
-	}
-
+func (h *Head) mmapHeadChunksInStripe(i int, mmapScratch *headChunksScratch) (count int) {
 	h.series.locks[i].RLock()
 	defer h.series.locks[i].RUnlock()
 
@@ -2166,7 +2167,7 @@ func (h *Head) mmapHeadChunksInStripe(i int) (count int) {
 		if series.headChunkCount.Load() < 2 { // < 2 means 0 or 1 head chunks, nothing to mmap.
 			continue
 		}
-		n := h.mmapSeriesChunks(series)
+		n := h.mmapSeriesChunks(series, mmapScratch)
 		if n > 0 {
 			count += n
 			h.series.decMmapReady(series.ref)
@@ -2175,10 +2176,10 @@ func (h *Head) mmapHeadChunksInStripe(i int) (count int) {
 	return count
 }
 
-func (h *Head) mmapSeriesChunks(s *memSeries) int {
+func (h *Head) mmapSeriesChunks(s *memSeries, mmapScratch *headChunksScratch) int {
 	s.Lock()
 	defer s.Unlock()
-	return s.mmapChunks(h.chunkDiskMapper)
+	return s.mmapChunks(h.chunkDiskMapper, mmapScratch)
 }
 
 // seriesHashmap lets TSDB find a memSeries by its label set, via a 64-bit hash.
@@ -3036,6 +3037,40 @@ func (mc *memChunk) len() (count int) {
 		elem = elem.prev
 	}
 	return count
+}
+
+type headChunksScratch struct {
+	buf     []*memChunk
+	storage [1]*memChunk
+}
+
+func (b *headChunksScratch) prepare(expectedLen int) []*memChunk {
+	if cap(b.buf) == 0 && expectedLen <= len(b.storage) {
+		b.buf = b.storage[:0]
+	}
+	if cap(b.buf) > headChunksBufMaxCap || cap(b.buf) < expectedLen {
+		b.buf = make([]*memChunk, expectedLen)
+	} else {
+		b.buf = b.buf[:expectedLen]
+	}
+	return b.buf
+}
+
+func (b *headChunksScratch) reuse(buf []*memChunk) {
+	if cap(buf) > headChunksBufMaxCap {
+		b.buf = nil
+		return
+	}
+	b.buf = buf[:0]
+}
+
+func (b *headChunksScratch) release() {
+	if cap(b.buf) > headChunksBufMaxCap {
+		b.buf = nil
+		return
+	}
+	clear(b.buf[:cap(b.buf)])
+	b.buf = b.buf[:0]
 }
 
 // collectHeadChunks walks the headChunks linked list once and returns a slice

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -2193,15 +2193,20 @@ func (s *memSeries) mmapCurrentOOOHeadChunk(o chunkOpts, logger *slog.Logger) []
 }
 
 // mmapChunks will m-map all but first chunk on s.headChunks list and update headChunkCount.
-func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count int) {
+// buf is a reusable scratch buffer; the (possibly grown) buffer is returned
+// empty so callers can pass it back on the next call to avoid per-series
+// allocations.
+func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper, buf []*memChunk) (count int, _ []*memChunk) {
 	if s.headChunks == nil || s.headChunks.prev == nil {
 		// There is none or only one head chunk, so nothing to m-map here.
-		return count
+		return count, releaseHeadChunksBuf(buf)
 	}
 
-	// Collect head chunks in oldest-first order, then write all except the newest.
-	hc := collectHeadChunks(s.headChunks, make([]*memChunk, 0, s.headChunkCount.Load()))
-	for _, chk := range hc[:len(hc)-1] {
+	// Collect the completed head chunks (all but the newest) in oldest-first
+	// order, then write them out.
+	buf = prepareHeadChunksBuf(buf, int(s.headChunkCount.Load())-1)
+	buf = collectHeadChunks(s.headChunks.prev, buf)
+	for _, chk := range buf {
 		chunkRef := chunkDiskMapper.WriteChunk(s.ref, chk.minTime, chk.maxTime, chk.chunk, false, handleChunkWriteError)
 		s.mmappedChunks = append(s.mmappedChunks, &mmappedChunk{
 			ref:        chunkRef,
@@ -2217,7 +2222,7 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 	s.headChunks.prev = nil
 	s.setHeadChunks(s.headChunks, 1)
 
-	return count
+	return count, releaseHeadChunksBuf(buf)
 }
 
 // TODO(bwplotka): Propagate errors correctly, even when they are async. Panicking here do occurs from time to time

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -2260,15 +2260,26 @@ func (s *memSeries) mmapCurrentOOOHeadChunk(o chunkOpts, logger *slog.Logger) []
 }
 
 // mmapChunks will m-map all but first chunk on s.headChunks list and update headChunkCount.
-func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count int) {
+// scratch is reused across calls; nil uses call-local storage.
+func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper, scratch *headChunksScratch) (count int) {
+	if scratch == nil {
+		scratch = new(headChunksScratch)
+	}
 	if s.headChunks == nil || s.headChunks.prev == nil {
 		// There is none or only one head chunk, so nothing to m-map here.
 		return count
 	}
 
-	// Collect head chunks in oldest-first order, then write all except the newest.
-	hc := collectHeadChunks(s.headChunks, make([]*memChunk, 0, s.headChunkCount.Load()))
-	for _, chk := range hc[:len(hc)-1] {
+	// Collect the completed head chunks (all but the newest) in oldest-first
+	// order, then write them out.
+	expectedLen := int(s.headChunkCount.Load()) - 1
+	buf := scratch.prepare(expectedLen)
+	i := len(buf)
+	for chk := s.headChunks.prev; chk != nil; chk = chk.prev {
+		i--
+		buf[i] = chk
+	}
+	for _, chk := range buf {
 		chunkRef := chunkDiskMapper.WriteChunk(s.ref, chk.minTime, chk.maxTime, chk.chunk, false, handleChunkWriteError)
 		s.mmappedChunks = append(s.mmappedChunks, &mmappedChunk{
 			ref:        chunkRef,
@@ -2284,6 +2295,7 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 	s.headChunks.prev = nil
 	s.setHeadChunks(s.headChunks, 1)
 
+	scratch.reuse(buf)
 	return count
 }
 

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -2565,7 +2565,7 @@ func TestHeadAppenderV2_Append_CounterResetHeader(t *testing.T) {
 
 				ms, _, err := head.getOrCreate(l.Hash(), l, false)
 				require.NoError(t, err)
-				ms.mmapChunks(head.chunkDiskMapper)
+				ms.mmapChunks(head.chunkDiskMapper, nil)
 				require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
 
 				for i, mmapChunk := range ms.mmappedChunks {
@@ -3219,7 +3219,7 @@ func TestHead_Init_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
 
-	series.mmapChunks(h.chunkDiskMapper)
+	series.mmapChunks(h.chunkDiskMapper, nil)
 	expChunks := make([]*mmappedChunk, len(series.mmappedChunks))
 	copy(expChunks, series.mmappedChunks)
 

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -2571,7 +2571,7 @@ func TestHeadAppenderV2_Append_CounterResetHeader(t *testing.T) {
 
 				ms, _, err := head.getOrCreate(l.Hash(), l, false)
 				require.NoError(t, err)
-				ms.mmapChunks(head.chunkDiskMapper)
+				ms.mmapChunks(head.chunkDiskMapper, nil)
 				require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
 
 				for i, mmapChunk := range ms.mmappedChunks {
@@ -3225,7 +3225,7 @@ func TestHead_Init_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
 
-	series.mmapChunks(h.chunkDiskMapper)
+	series.mmapChunks(h.chunkDiskMapper, nil)
 	expChunks := make([]*mmappedChunk, len(series.mmappedChunks))
 	copy(expChunks, series.mmappedChunks)
 

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -125,7 +125,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -138,7 +138,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=1 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -151,7 +151,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -164,7 +164,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -178,7 +178,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=2 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -192,7 +192,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -206,7 +206,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=1 on memSeries with 3 mmapped chunks and closed ChunkDiskMapper",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -220,7 +220,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks and closed ChunkDiskMapper",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -270,7 +270,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -287,7 +287,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=2 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -304,7 +304,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -321,7 +321,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=5 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -338,7 +338,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=6 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -356,7 +356,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=10 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -462,7 +462,7 @@ func TestMemSeries_chunk_FastPath(t *testing.T) {
 
 	// Build 3 mmapped + 3 head chunks.
 	appendSamples(t, series, 0, chunkRange*4, chunkDiskMapper)
-	series.mmapChunks(chunkDiskMapper)
+	series.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, series.mmappedChunks, 3)
 	require.Equal(t, 1, series.headChunks.len())
 	appendSamples(t, series, chunkRange*4, chunkRange*6, chunkDiskMapper)
@@ -619,7 +619,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		// require under the series lock would deadlock the cleanup's Close).
 		s.Lock()
 		headPtrBefore := s.headChunks
-		s.mmapChunks(h.chunkDiskMapper)
+		s.mmapChunks(h.chunkDiskMapper, nil)
 		headChunksLenAfter := s.headChunks.len()
 		headPtrAfter := s.headChunks
 		newestMinTimeAfter := s.headChunks.minTime
@@ -837,6 +837,37 @@ func TestHeadChunkReaderCache(t *testing.T) {
 
 		// Buffer should have been released because cap exceeded threshold.
 		require.Nil(t, ir.headChunksBuf, "headChunksBuf should be released when cap > headChunksBufMaxCap")
+	})
+}
+
+func TestHeadChunksBufReusePolicy(t *testing.T) {
+	t.Run("small buffer retained and cleared", func(t *testing.T) {
+		buf := make([]*memChunk, 2, headChunksBufMaxCap)
+		buf[0] = &memChunk{}
+		buf[1] = &memChunk{}
+
+		released := releaseHeadChunksBuf(buf)
+		require.NotNil(t, released)
+		require.Empty(t, released)
+		require.Equal(t, headChunksBufMaxCap, cap(released))
+		for _, chk := range buf[:cap(buf)] {
+			require.Nil(t, chk)
+		}
+	})
+
+	t.Run("oversized buffer released", func(t *testing.T) {
+		buf := make([]*memChunk, 1, headChunksBufMaxCap+1)
+		buf[0] = &memChunk{}
+
+		require.Nil(t, releaseHeadChunksBuf(buf))
+	})
+
+	t.Run("oversized buffer dropped before reuse", func(t *testing.T) {
+		buf := make([]*memChunk, 0, headChunksBufMaxCap+1)
+
+		prepared := prepareHeadChunksBuf(buf, 4)
+		require.Empty(t, prepared)
+		require.Equal(t, 4, cap(prepared))
 	})
 }
 

--- a/tsdb/head_read_test.go
+++ b/tsdb/head_read_test.go
@@ -125,7 +125,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -138,7 +138,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=1 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -151,7 +151,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -164,7 +164,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -178,7 +178,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=2 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -192,7 +192,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks and no headChunk",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -206,7 +206,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=1 on memSeries with 3 mmapped chunks and closed ChunkDiskMapper",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -220,7 +220,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 mmapped chunks and closed ChunkDiskMapper",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 				require.Equal(t, chunkRange*3, s.headChunks.oldest().minTime, "wrong minTime on last headChunks element")
@@ -270,7 +270,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=0 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -287,7 +287,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=2 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -304,7 +304,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=3 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -321,7 +321,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=5 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -338,7 +338,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=6 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -356,7 +356,7 @@ func TestMemSeries_chunk(t *testing.T) {
 			name: "call ix=10 on memSeries with 3 head chunks and 3 mmapped chunks",
 			setup: func(t *testing.T, s *memSeries, cdm *chunks.ChunkDiskMapper) {
 				appendSamples(t, s, 0, chunkRange*4, cdm)
-				s.mmapChunks(cdm)
+				s.mmapChunks(cdm, nil)
 				require.Len(t, s.mmappedChunks, 3, "wrong number of mmappedChunks")
 				require.Equal(t, 1, s.headChunks.len(), "wrong number of headChunks")
 
@@ -462,7 +462,7 @@ func TestMemSeries_chunk_FastPath(t *testing.T) {
 
 	// Build 3 mmapped + 3 head chunks.
 	appendSamples(t, series, 0, chunkRange*4, chunkDiskMapper)
-	series.mmapChunks(chunkDiskMapper)
+	series.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, series.mmappedChunks, 3)
 	require.Equal(t, 1, series.headChunks.len())
 	appendSamples(t, series, chunkRange*4, chunkRange*6, chunkDiskMapper)
@@ -527,7 +527,7 @@ func TestMemSeries_chunk_ResolveAfterWrap(t *testing.T) {
 		})
 		require.True(t, ok, "sample append failed")
 	}
-	series.mmapChunks(chunkDiskMapper)
+	series.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, series.mmappedChunks, numChunks-1, "wrong number of mmapped chunks")
 	require.Equal(t, 1, series.headChunks.len(), "wrong number of head chunks")
 
@@ -688,7 +688,7 @@ func TestHeadChunkReaderCache(t *testing.T) {
 		// require under the series lock would deadlock the cleanup's Close).
 		s.Lock()
 		headPtrBefore := s.headChunks
-		s.mmapChunks(h.chunkDiskMapper)
+		s.mmapChunks(h.chunkDiskMapper, nil)
 		headChunksLenAfter := s.headChunks.len()
 		headPtrAfter := s.headChunks
 		newestMinTimeAfter := s.headChunks.minTime

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -438,7 +438,7 @@ func BenchmarkLoadWLs(b *testing.B) {
 									// ignores the latest chunk, so we need to cut a new head chunk to guarantee the chunk with
 									// the sample at c.mmappedChunkT is mmapped.
 									s.cutNewHeadChunk(c.mmappedChunkT, chunkenc.EncXOR, c.mmappedChunkT)
-									s.mmapChunks(chunkDiskMapper)
+									s.mmapChunks(chunkDiskMapper, nil)
 								}
 								require.NoError(b, chunkDiskMapper.Close())
 							}
@@ -1647,7 +1647,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 		ok, _ := s.append(0, int64(i), float64(i), 0, cOpts)
 		require.True(t, ok, "sample append failed")
 	}
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	// Check that truncate removes half of the chunks and afterwards
 	// that the ID of the last chunk still gives us the same chunk afterwards.
@@ -1797,7 +1797,7 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 					ok, _ := series.append(0, int64(i), float64(i), 0, cOpts)
 					require.True(t, ok, "sample append failed")
 				}
-				series.mmapChunks(chunkDiskMapper)
+				series.mmapChunks(chunkDiskMapper, nil)
 			}
 
 			if tc.headChunks == 0 {
@@ -2422,7 +2422,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 	ok, chunkCreated = s.append(stFunc(999), 999, 2, 0, cOpts)
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	ok, chunkCreated = s.append(stFunc(1000), 1000, 3, 0, cOpts)
 	require.True(t, ok, "append failed")
@@ -2432,7 +2432,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -2446,7 +2446,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 		ok, _ := s.append(stFunc(ts), ts, float64(i), 0, cOpts)
 		require.True(t, ok, "append failed")
 	}
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	require.Greater(t, len(s.mmappedChunks)+1, 7, "expected intermediate chunks")
 
@@ -2541,7 +2541,7 @@ func testMemSeriesAppendHistogram(t *testing.T, useXOR2 bool, stFunc func(ts int
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -2552,7 +2552,7 @@ func testMemSeriesAppendHistogram(t *testing.T, useXOR2 bool, stFunc func(ts int
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "third sample should trigger a re-encoded chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -2601,7 +2601,7 @@ func TestMemSeries_append_atVariableRate(t *testing.T) {
 	require.True(t, ok, "new chunk sample was not appended")
 	require.True(t, chunkCreated, "sample at block duration timestamp should create a new chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	var totalSamplesInChunks int
 	for i, c := range s.mmappedChunks {
 		totalSamplesInChunks += int(c.numSamples)
@@ -3037,7 +3037,7 @@ func TestHeadReadWriterRepair(t *testing.T) {
 			require.True(t, ok, "series append failed")
 			require.False(t, chunkCreated, "chunk was created")
 			h.chunkDiskMapper.CutNewFile()
-			s.mmapChunks(h.chunkDiskMapper)
+			s.mmapChunks(h.chunkDiskMapper, nil)
 		}
 		require.NoError(t, h.Close())
 
@@ -5457,7 +5457,7 @@ func TestHistogramCounterResetHeader(t *testing.T) {
 
 				ms, _, err := head.getOrCreate(l.Hash(), l, false)
 				require.NoError(t, err)
-				ms.mmapChunks(head.chunkDiskMapper)
+				ms.mmapChunks(head.chunkDiskMapper, nil)
 				require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
 
 				for i, mmapChunk := range ms.mmappedChunks {
@@ -6368,7 +6368,7 @@ func TestHeadInit_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
 
-	series.mmapChunks(h.chunkDiskMapper)
+	series.mmapChunks(h.chunkDiskMapper, nil)
 	expChunks := make([]*mmappedChunk, len(series.mmappedChunks))
 	copy(expChunks, series.mmappedChunks)
 
@@ -9938,7 +9938,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 				// Invoke the WAL-replay-style helper with a sample timestamped
 				// past the next chunk boundary to force a chunk cut.
 				s.Lock()
-				_, chunkCreated := h.appendChunkAndMmap(s, func() (bool, bool) {
+				_, chunkCreated, _ := h.appendChunkAndMmap(s, nil, func() (bool, bool) {
 					return tc.appendInternal(s, ts+h.chunkRange.Load(), chunkOpts{
 						chunkDiskMapper: h.chunkDiskMapper,
 						chunkRange:      h.chunkRange.Load(),

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -438,7 +438,7 @@ func BenchmarkLoadWLs(b *testing.B) {
 									// ignores the latest chunk, so we need to cut a new head chunk to guarantee the chunk with
 									// the sample at c.mmappedChunkT is mmapped.
 									s.cutNewHeadChunk(c.mmappedChunkT, chunkenc.EncXOR, c.mmappedChunkT)
-									s.mmapChunks(chunkDiskMapper)
+									s.mmapChunks(chunkDiskMapper, nil)
 								}
 								require.NoError(b, chunkDiskMapper.Close())
 							}
@@ -1743,7 +1743,7 @@ func TestMemSeries_truncateChunks(t *testing.T) {
 		ok, _ := s.append(0, int64(i), float64(i), 0, cOpts)
 		require.True(t, ok, "sample append failed")
 	}
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	// Check that truncate removes half of the chunks and afterwards
 	// that the ID of the last chunk still gives us the same chunk afterwards.
@@ -1893,7 +1893,7 @@ func TestMemSeries_truncateChunks_scenarios(t *testing.T) {
 					ok, _ := series.append(0, int64(i), float64(i), 0, cOpts)
 					require.True(t, ok, "sample append failed")
 				}
-				series.mmapChunks(chunkDiskMapper)
+				series.mmapChunks(chunkDiskMapper, nil)
 			}
 
 			if tc.headChunks == 0 {
@@ -2634,7 +2634,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 	ok, chunkCreated = s.append(stFunc(999), 999, 2, 0, cOpts)
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	ok, chunkCreated = s.append(stFunc(1000), 1000, 3, 0, cOpts)
 	require.True(t, ok, "append failed")
@@ -2644,7 +2644,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -2658,7 +2658,7 @@ func testMemSeriesAppend(t *testing.T, useXOR2 bool, stFunc func(ts int64) int64
 		ok, _ := s.append(stFunc(ts), ts, float64(i), 0, cOpts)
 		require.True(t, ok, "append failed")
 	}
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 
 	require.Greater(t, len(s.mmappedChunks)+1, 7, "expected intermediate chunks")
 
@@ -2753,7 +2753,7 @@ func testMemSeriesAppendHistogram(t *testing.T, useXOR2 bool, stFunc func(ts int
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "second sample should use same chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -2764,7 +2764,7 @@ func testMemSeriesAppendHistogram(t *testing.T, useXOR2 bool, stFunc func(ts int
 	require.True(t, ok, "append failed")
 	require.False(t, chunkCreated, "third sample should trigger a re-encoded chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	require.Len(t, s.mmappedChunks, 1, "there should be only 1 mmapped chunk")
 	require.Equal(t, int64(998), s.mmappedChunks[0].minTime, "wrong chunk range")
 	require.Equal(t, int64(999), s.mmappedChunks[0].maxTime, "wrong chunk range")
@@ -2813,7 +2813,7 @@ func TestMemSeries_append_atVariableRate(t *testing.T) {
 	require.True(t, ok, "new chunk sample was not appended")
 	require.True(t, chunkCreated, "sample at block duration timestamp should create a new chunk")
 
-	s.mmapChunks(chunkDiskMapper)
+	s.mmapChunks(chunkDiskMapper, nil)
 	var totalSamplesInChunks int
 	for i, c := range s.mmappedChunks {
 		totalSamplesInChunks += int(c.numSamples)
@@ -3249,7 +3249,7 @@ func TestHeadReadWriterRepair(t *testing.T) {
 			require.True(t, ok, "series append failed")
 			require.False(t, chunkCreated, "chunk was created")
 			h.chunkDiskMapper.CutNewFile()
-			s.mmapChunks(h.chunkDiskMapper)
+			s.mmapChunks(h.chunkDiskMapper, nil)
 		}
 		require.NoError(t, h.Close())
 
@@ -5669,7 +5669,7 @@ func TestHistogramCounterResetHeader(t *testing.T) {
 
 				ms, _, err := head.getOrCreate(l.Hash(), l, false)
 				require.NoError(t, err)
-				ms.mmapChunks(head.chunkDiskMapper)
+				ms.mmapChunks(head.chunkDiskMapper, nil)
 				require.Len(t, ms.mmappedChunks, len(expHeaders)-1) // One is the head chunk.
 
 				for i, mmapChunk := range ms.mmappedChunks {
@@ -6580,7 +6580,7 @@ func TestHeadInit_DiscardChunksWithUnsupportedEncoding(t *testing.T) {
 	require.False(t, created, "should already exist")
 	require.NotNil(t, series, "should return the series we created above")
 
-	series.mmapChunks(h.chunkDiskMapper)
+	series.mmapChunks(h.chunkDiskMapper, nil)
 	expChunks := make([]*mmappedChunk, len(series.mmappedChunks))
 	copy(expChunks, series.mmappedChunks)
 
@@ -10315,6 +10315,53 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		require.Equal(t, uint32(1), getCount(lblsB), "series B headChunkCount should be 1 after mmap")
 	})
 
+	t.Run("scratch buffer reuse policy", func(t *testing.T) {
+		t.Run("small buffer retained and cleared", func(t *testing.T) {
+			buf := make([]*memChunk, 2, headChunksBufMaxCap)
+			buf[0] = &memChunk{}
+			buf[1] = &memChunk{}
+
+			var scratch headChunksScratch
+			scratch.reuse(buf)
+			require.NotNil(t, scratch.buf)
+			require.Empty(t, scratch.buf)
+			require.Equal(t, headChunksBufMaxCap, cap(scratch.buf))
+			require.NotNil(t, buf[0])
+			require.NotNil(t, buf[1])
+
+			scratch.release()
+			require.NotNil(t, scratch.buf)
+			require.Empty(t, scratch.buf)
+			require.Equal(t, headChunksBufMaxCap, cap(scratch.buf))
+			for _, chk := range buf[:cap(buf)] {
+				require.Nil(t, chk)
+			}
+		})
+
+		t.Run("oversized buffer released", func(t *testing.T) {
+			buf := make([]*memChunk, 1, headChunksBufMaxCap+1)
+			buf[0] = &memChunk{}
+
+			scratch := headChunksScratch{buf: buf}
+			scratch.release()
+			require.Nil(t, scratch.buf)
+		})
+
+		t.Run("oversized buffer replaced during prepare", func(t *testing.T) {
+			scratch := headChunksScratch{buf: make([]*memChunk, 0, headChunksBufMaxCap+1)}
+
+			prepared := scratch.prepare(4)
+			require.Len(t, prepared, 4)
+			require.Equal(t, 4, cap(prepared))
+		})
+
+		t.Run("oversized buffer dropped during reuse", func(t *testing.T) {
+			var scratch headChunksScratch
+			scratch.reuse(make([]*memChunk, 0, headChunksBufMaxCap+1))
+			require.Nil(t, scratch.buf)
+		})
+	})
+
 	// Regression test for https://github.com/prometheus/prometheus/issues/17941:
 	// if mmapChunks panics (via handleChunkWriteError) while mmapHeadChunks holds
 	// the stripe and series locks, those locks must still be released. A leaked
@@ -10546,7 +10593,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 				// Invoke the WAL-replay-style helper with a sample timestamped
 				// past the next chunk boundary to force a chunk cut.
 				s.Lock()
-				_, chunkCreated := h.appendChunkAndMmap(s, func() (bool, bool) {
+				_, chunkCreated := h.appendChunkAndMmap(s, nil, func() (bool, bool) {
 					return tc.appendInternal(s, ts+h.chunkRange.Load(), chunkOpts{
 						chunkDiskMapper: h.chunkDiskMapper,
 						chunkRange:      h.chunkRange.Load(),

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -658,18 +658,21 @@ func (wp *walSubsetProcessor) reuseHistogramBuf() []histogramRecord {
 // happens whenever prev >= 2, since mmapChunks always sets the count to 1
 // when it does work), the per-stripe mmap-ready counter is decremented to
 // maintain its invariant.
-func (h *Head) appendChunkAndMmap(ms *memSeries, appendFn func() (sampleInOrder, chunkCreated bool)) (sampleInOrder, chunkCreated bool) {
+//
+// buf is a reusable scratch buffer for mmapChunks; the (possibly grown)
+// buffer is returned so callers can pass it back on the next call.
+func (h *Head) appendChunkAndMmap(ms *memSeries, buf []*memChunk, appendFn func() (sampleInOrder, chunkCreated bool)) (sampleInOrder, chunkCreated bool, mmapBuf []*memChunk) {
 	prev := ms.headChunkCount.Load()
 	sampleInOrder, chunkCreated = appendFn()
 	if chunkCreated {
 		h.metrics.chunksCreated.Inc()
 		h.metrics.chunks.Inc()
-		_ = ms.mmapChunks(h.chunkDiskMapper)
+		_, buf = ms.mmapChunks(h.chunkDiskMapper, buf)
 		if prev >= 2 {
 			h.series.decMmapReady(ms.ref)
 		}
 	}
-	return sampleInOrder, chunkCreated
+	return sampleInOrder, chunkCreated, buf
 }
 
 // valueTypeForChunkEncoding maps a chunk encoding to the sample value type it holds.
@@ -713,7 +716,8 @@ func (s *memSeries) latestInOrderValueType() chunkenc.ValueType {
 // in-order sample is a native histogram is converted to a (float) histogram
 // staleness marker, matching the live commitFloats path, so replay reproduces
 // the same chunk types instead of appending a float to a histogram series.
-func (h *Head) appendWALFloat(ms *memSeries, s record.RefSample, opts chunkOpts) {
+// mmapBuf is returned for reuse by subsequent WAL samples.
+func (h *Head) appendWALFloat(ms *memSeries, s record.RefSample, opts chunkOpts, mmapBuf []*memChunk) []*memChunk {
 	isStale := value.IsStaleNaN(s.V)
 	if isStale {
 		// Mirror commitFloats: decide the marker type from the series' most recent
@@ -722,43 +726,44 @@ func (h *Head) appendWALFloat(ms *memSeries, s record.RefSample, opts chunkOpts)
 		// still recognised.
 		switch ms.latestInOrderValueType() {
 		case chunkenc.ValHistogram:
-			h.appendWALHistogram(ms, s.ST, s.T, &histogram.Histogram{Sum: s.V}, nil, opts)
-			return
+			return h.appendWALHistogram(ms, s.ST, s.T, &histogram.Histogram{Sum: s.V}, nil, opts, mmapBuf)
 		case chunkenc.ValFloatHistogram:
-			h.appendWALHistogram(ms, s.ST, s.T, nil, &histogram.FloatHistogram{Sum: s.V}, opts)
-			return
+			return h.appendWALHistogram(ms, s.ST, s.T, nil, &histogram.FloatHistogram{Sum: s.V}, opts, mmapBuf)
 		}
 	}
 
 	wasStale := isStaleSeries(ms)
-	sampleInOrder, _ := h.appendChunkAndMmap(ms, func() (bool, bool) {
+	sampleInOrder, _, mmapBuf := h.appendChunkAndMmap(ms, mmapBuf, func() (bool, bool) {
 		return ms.append(s.ST, s.T, s.V, 0, opts)
 	})
 	if sampleInOrder {
 		h.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 	}
+	return mmapBuf
 }
 
 // appendWALHistogram replays an integer or float histogram sample (exactly one of
 // hist/floatHist must be non-nil) and updates the stale-series gauge if the
 // sample is accepted in-order.
-func (h *Head) appendWALHistogram(ms *memSeries, st, t int64, hist *histogram.Histogram, floatHist *histogram.FloatHistogram, opts chunkOpts) {
+// mmapBuf is returned for reuse by subsequent WAL samples.
+func (h *Head) appendWALHistogram(ms *memSeries, st, t int64, hist *histogram.Histogram, floatHist *histogram.FloatHistogram, opts chunkOpts, mmapBuf []*memChunk) []*memChunk {
 	wasStale := isStaleSeries(ms)
 	var isStale, sampleInOrder bool
 	if hist != nil {
 		isStale = value.IsStaleNaN(hist.Sum)
-		sampleInOrder, _ = h.appendChunkAndMmap(ms, func() (bool, bool) {
+		sampleInOrder, _, mmapBuf = h.appendChunkAndMmap(ms, mmapBuf, func() (bool, bool) {
 			return ms.appendHistogram(st, t, hist, 0, opts)
 		})
 	} else {
 		isStale = value.IsStaleNaN(floatHist.Sum)
-		sampleInOrder, _ = h.appendChunkAndMmap(ms, func() (bool, bool) {
+		sampleInOrder, _, mmapBuf = h.appendChunkAndMmap(ms, mmapBuf, func() (bool, bool) {
 			return ms.appendFloatHistogram(st, t, floatHist, 0, opts)
 		})
 	}
 	if sampleInOrder {
 		h.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 	}
+	return mmapBuf
 }
 
 // processWALSamples adds the samples it receives to the head and passes
@@ -773,6 +778,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 
 	minValidTime := h.minValidTime.Load()
 	mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)
+	var mmapBuf []*memChunk // Reusable scratch buffer for mmapChunks.
 	// storeST must be passed here so that appendPreprocessor cuts an in-progress
 	// XOR chunk immediately when replaying into a head with ST storage enabled.
 	// XOR chunks cannot store start timestamps and must not be continued with
@@ -807,7 +813,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				continue
 			}
 
-			h.appendWALFloat(ms, s, appendChunkOpts)
+			mmapBuf = h.appendWALFloat(ms, s, appendChunkOpts, mmapBuf)
 			if s.T > maxt {
 				maxt = s.T
 			}
@@ -834,9 +840,9 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				continue
 			}
 			if s.h != nil {
-				h.appendWALHistogram(ms, s.st, s.t, s.h, nil, appendChunkOpts)
+				mmapBuf = h.appendWALHistogram(ms, s.st, s.t, s.h, nil, appendChunkOpts, mmapBuf)
 			} else {
-				h.appendWALHistogram(ms, s.st, s.t, nil, s.fh, appendChunkOpts)
+				mmapBuf = h.appendWALHistogram(ms, s.st, s.t, nil, s.fh, appendChunkOpts, mmapBuf)
 			}
 			if s.t > maxt {
 				maxt = s.t

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -659,13 +659,15 @@ func (wp *walSubsetProcessor) reuseHistogramBuf() []histogramRecord {
 // happens whenever prev >= 2, since mmapChunks always sets the count to 1
 // when it does work), the per-stripe mmap-ready counter is decremented to
 // maintain its invariant.
-func (h *Head) appendChunkAndMmap(ms *memSeries, appendFn func() (sampleInOrder, chunkCreated bool)) (sampleInOrder, chunkCreated bool) {
+//
+// mmapScratch is reused across calls to avoid per-series allocations.
+func (h *Head) appendChunkAndMmap(ms *memSeries, mmapScratch *headChunksScratch, appendFn func() (sampleInOrder, chunkCreated bool)) (sampleInOrder, chunkCreated bool) {
 	prev := ms.headChunkCount.Load()
 	sampleInOrder, chunkCreated = appendFn()
 	if chunkCreated {
 		h.metrics.chunksCreated.Inc()
 		h.metrics.chunks.Inc()
-		_ = ms.mmapChunks(h.chunkDiskMapper)
+		_ = ms.mmapChunks(h.chunkDiskMapper, mmapScratch)
 		if prev >= 2 {
 			h.series.decMmapReady(ms.ref)
 		}
@@ -714,7 +716,7 @@ func (s *memSeries) latestInOrderValueType() chunkenc.ValueType {
 // in-order sample is a native histogram is converted to a (float) histogram
 // staleness marker, matching the live commitFloats path, so replay reproduces
 // the same chunk types instead of appending a float to a histogram series.
-func (h *Head) appendWALFloat(ms *memSeries, s record.RefSample, opts chunkOpts) {
+func (h *Head) appendWALFloat(ms *memSeries, s record.RefSample, opts chunkOpts, mmapScratch *headChunksScratch) {
 	isStale := value.IsStaleNaN(s.V)
 	if isStale {
 		// Mirror commitFloats: decide the marker type from the series' most recent
@@ -723,16 +725,16 @@ func (h *Head) appendWALFloat(ms *memSeries, s record.RefSample, opts chunkOpts)
 		// still recognised.
 		switch ms.latestInOrderValueType() {
 		case chunkenc.ValHistogram:
-			h.appendWALHistogram(ms, s.ST, s.T, &histogram.Histogram{Sum: s.V}, nil, opts)
+			h.appendWALHistogram(ms, s.ST, s.T, &histogram.Histogram{Sum: s.V}, nil, opts, mmapScratch)
 			return
 		case chunkenc.ValFloatHistogram:
-			h.appendWALHistogram(ms, s.ST, s.T, nil, &histogram.FloatHistogram{Sum: s.V}, opts)
+			h.appendWALHistogram(ms, s.ST, s.T, nil, &histogram.FloatHistogram{Sum: s.V}, opts, mmapScratch)
 			return
 		}
 	}
 
 	wasStale, wasHistogram, oldBuckets := ms.sampleState()
-	sampleInOrder, _ := h.appendChunkAndMmap(ms, func() (bool, bool) {
+	sampleInOrder, _ := h.appendChunkAndMmap(ms, mmapScratch, func() (bool, bool) {
 		return ms.append(s.ST, s.T, s.V, 0, opts)
 	})
 	if sampleInOrder {
@@ -746,20 +748,20 @@ func (h *Head) appendWALFloat(ms *memSeries, s record.RefSample, opts chunkOpts)
 // appendWALHistogram replays an integer or float histogram sample (exactly one of
 // hist/floatHist must be non-nil) and updates the stale-series gauge if the
 // sample is accepted in-order.
-func (h *Head) appendWALHistogram(ms *memSeries, st, t int64, hist *histogram.Histogram, floatHist *histogram.FloatHistogram, opts chunkOpts) {
+func (h *Head) appendWALHistogram(ms *memSeries, st, t int64, hist *histogram.Histogram, floatHist *histogram.FloatHistogram, opts chunkOpts, mmapScratch *headChunksScratch) {
 	wasStale, wasHistogram, oldBuckets := ms.sampleState()
 	var isStale, sampleInOrder bool
 	var newBuckets int
 	if hist != nil {
 		isStale = value.IsStaleNaN(hist.Sum)
 		newBuckets = len(hist.PositiveBuckets) + len(hist.NegativeBuckets)
-		sampleInOrder, _ = h.appendChunkAndMmap(ms, func() (bool, bool) {
+		sampleInOrder, _ = h.appendChunkAndMmap(ms, mmapScratch, func() (bool, bool) {
 			return ms.appendHistogram(st, t, hist, 0, opts)
 		})
 	} else {
 		isStale = value.IsStaleNaN(floatHist.Sum)
 		newBuckets = len(floatHist.PositiveBuckets) + len(floatHist.NegativeBuckets)
-		sampleInOrder, _ = h.appendChunkAndMmap(ms, func() (bool, bool) {
+		sampleInOrder, _ = h.appendChunkAndMmap(ms, mmapScratch, func() (bool, bool) {
 			return ms.appendFloatHistogram(st, t, floatHist, 0, opts)
 		})
 	}
@@ -781,6 +783,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 
 	minValidTime := h.minValidTime.Load()
 	mint, maxt := int64(math.MaxInt64), int64(math.MinInt64)
+	var mmapScratch headChunksScratch
 	// storeST must be passed here so that appendPreprocessor cuts an in-progress
 	// XOR chunk immediately when replaying into a head with ST storage enabled.
 	// XOR chunks cannot store start timestamps and must not be continued with
@@ -815,7 +818,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				continue
 			}
 
-			h.appendWALFloat(ms, s, appendChunkOpts)
+			h.appendWALFloat(ms, s, appendChunkOpts, &mmapScratch)
 			if s.T > maxt {
 				maxt = s.T
 			}
@@ -842,9 +845,9 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				continue
 			}
 			if s.h != nil {
-				h.appendWALHistogram(ms, s.st, s.t, s.h, nil, appendChunkOpts)
+				h.appendWALHistogram(ms, s.st, s.t, s.h, nil, appendChunkOpts, &mmapScratch)
 			} else {
-				h.appendWALHistogram(ms, s.st, s.t, nil, s.fh, appendChunkOpts)
+				h.appendWALHistogram(ms, s.st, s.t, nil, s.fh, appendChunkOpts, &mmapScratch)
 			}
 			if s.t > maxt {
 				maxt = s.t
@@ -863,6 +866,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			h.deleteSeriesByID(in.deletedSeriesRefs)
 		}
 	}
+	mmapScratch.release()
 	h.updateMinMaxTime(mint, maxt)
 
 	return missingSeries, unknownSampleRefs, unknownHistogramRefs, mmapOverlappingChunks


### PR DESCRIPTION

Reduce the overhead of memory-mapping completed head chunks by:
- Avoiding the stripe helper for stripes with no mmap-ready series
- Filling completed chunks directly in oldest-first order
- Reusing one pass-scoped scratch buffer across series in both periodic mmap and WAL replay.

The newest head chunk remains in memory as before. Scratch storage is cleared after each pass and oversized buffers are dropped, preventing chunk references from being retained between passes.

### Benchmarks

Benchmarks were run six times with Go 1.26.0 on darwin/arm64 using an Apple M4 Pro:

```console
go test -run '^$' -count=6 -benchmem -bench '^BenchmarkMmapHeadChunks$' ./tsdb
```

- Time/op geomean improved by 14.02%.
- Five of nine workloads improved significantly by 5.63–48.51%; the other four had no significant difference.
- No workload had a significant B/op change; the geomean was +0.20%.
- Allocs/op geomean increased by 1.05%, reflecting one fixed allocation per mmap pass in smaller cases rather than a cost that scales with ready series.

These measurements were collected before the final rebase and source-level scratch-helper cleanup: the baseline was `c93268ce4`, and the benchmarked implementation was subsequently published as `4027058c1`. Go 1.26 already inlined all three removed helpers and the lifecycle methods that called them at the production call sites; the benchmark was not rerun after this source-only cleanup.

<details>
<summary>Raw benchstat output</summary>

```text
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Apple M4 Pro
                                             │     base     │                head                │
                                             │    sec/op    │   sec/op     vs base               │
MmapHeadChunks/series=1000/ready=10-14         29.45µ ±  2%   15.16µ ± 3%  -48.51% (p=0.002 n=6)
MmapHeadChunks/series=1000/ready=100-14        51.91µ ±  5%   40.62µ ± 6%  -21.74% (p=0.002 n=6)
MmapHeadChunks/series=1000/ready=1000-14       238.9µ ± 11%   225.5µ ± 3%        ~ (p=0.240 n=6)
MmapHeadChunks/series=10000/ready=100-14       55.29µ ±  3%   42.65µ ± 2%  -22.86% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=1000-14      256.7µ ±  6%   242.2µ ± 8%   -5.63% (p=0.041 n=6)
MmapHeadChunks/series=10000/ready=10000-14     2.635m ± 14%   2.556m ± 5%        ~ (p=0.485 n=6)
MmapHeadChunks/series=100000/ready=1000-14     282.3µ ± 15%   303.0µ ± 6%        ~ (p=0.180 n=6)
MmapHeadChunks/series=100000/ready=10000-14    4.312m ± 10%   3.786m ± 9%  -12.20% (p=0.009 n=6)
MmapHeadChunks/series=100000/ready=100000-14   46.02m ±  4%   46.69m ± 4%        ~ (p=0.180 n=6)
geomean                                        450.6µ         387.4µ       -14.02%

                                             │     base     │                head                │
                                             │     B/op     │     B/op      vs base              │
MmapHeadChunks/series=1000/ready=10-14         1.953Ki ± 2%   1.969Ki ± 1%       ~ (p=0.180 n=6)
MmapHeadChunks/series=1000/ready=100-14        15.40Ki ± 1%   15.81Ki ± 3%       ~ (p=0.102 n=6)
MmapHeadChunks/series=1000/ready=1000-14       142.4Ki ± 2%   143.7Ki ± 2%       ~ (p=0.310 n=6)
MmapHeadChunks/series=10000/ready=100-14       15.61Ki ± 1%   15.53Ki ± 0%       ~ (p=0.093 n=6)
MmapHeadChunks/series=10000/ready=1000-14      148.4Ki ± 2%   145.7Ki ± 4%       ~ (p=0.132 n=6)
MmapHeadChunks/series=10000/ready=10000-14     1.282Mi ± 3%   1.277Mi ± 2%       ~ (p=0.394 n=6)
MmapHeadChunks/series=100000/ready=1000-14     149.7Ki ± 3%   145.6Ki ± 2%       ~ (p=0.065 n=6)
MmapHeadChunks/series=100000/ready=10000-14    1.325Mi ± 5%   1.362Mi ± 2%       ~ (p=0.937 n=6)
MmapHeadChunks/series=100000/ready=100000-14   13.60Mi ± 8%   13.61Mi ± 8%       ~ (p=0.818 n=6)
geomean                                        149.3Ki        149.6Ki       +0.20%

                                             │    base     │               head                │
                                             │  allocs/op  │  allocs/op   vs base              │
MmapHeadChunks/series=1000/ready=10-14          13.00 ± 0%    14.00 ± 0%  +7.69% (p=0.002 n=6)
MmapHeadChunks/series=1000/ready=100-14         108.0 ± 0%    109.0 ± 0%  +0.93% (p=0.002 n=6)
MmapHeadChunks/series=1000/ready=1000-14       1.032k ± 0%   1.033k ± 0%  +0.10% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=100-14        108.0 ± 0%    109.0 ± 0%  +0.93% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=1000-14      1.032k ± 0%   1.033k ± 0%  +0.10% (p=0.002 n=6)
MmapHeadChunks/series=10000/ready=10000-14     10.43k ± 1%   10.42k ± 0%       ~ (p=0.121 n=6)
MmapHeadChunks/series=100000/ready=1000-14     1.032k ± 0%   1.032k ± 0%       ~ (p=0.273 n=6)
MmapHeadChunks/series=100000/ready=10000-14    10.59k ± 0%   10.54k ± 0%  -0.44% (p=0.013 n=6)
MmapHeadChunks/series=100000/ready=100000-14   120.8k ± 2%   121.3k ± 1%       ~ (p=0.552 n=6)
geomean                                        1.093k        1.104k       +1.05%
```

</details>

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[PERF] TSDB: Reduce CPU usage when memory-mapping head chunks
```
