### PR TITLE
tsdb: poll instead of sleeping in TestHead_FastStartupStateFile

### DIFF
--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -8993,16 +8993,21 @@ func TestHead_FastStartupStateFile(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, app.Commit())
 
-	// Wait for the ticker to update the series state file.
-	time.Sleep(1500 * time.Millisecond)
-
 	stateFilePath := filepath.Join(w.Dir(), "series_state.json")
 
-	b, err := os.ReadFile(stateFilePath)
-	require.NoError(t, err, "series_state.json should exist after ticker runs")
-
+	// Poll for the ticker (1s interval) to write the series state file rather
+	// than waiting a fixed amount of time: faster in the common case, and robust
+	// if the first tick is momentarily delayed under load.
 	var state SeriesLifecycleState
-	require.NoError(t, json.Unmarshal(b, &state), "file should be valid JSON")
+	var b []byte
+	require.Eventually(t, func() bool {
+		var err error
+		b, err = os.ReadFile(stateFilePath)
+		if err != nil {
+			return false
+		}
+		return json.Unmarshal(b, &state) == nil && state.LastSeriesID == 1
+	}, 10*time.Second, 20*time.Millisecond, "series_state.json should be written by the ticker")
 
 	// The ticker should write an unclean state.
 	require.False(t, state.CleanShutdown, "ticker should write CleanShutdown: false")


### PR DESCRIPTION
TestHead_FastStartupStateFile slept a fixed 1.5s waiting for the series-state ticker to write `series_state.json`, then read and asserted its contents:

```go
// Wait for the ticker to update the series state file.
time.Sleep(1500 * time.Millisecond)
...
b, err := os.ReadFile(stateFilePath)
require.NoError(t, err, "series_state.json should exist after ticker runs")
```

The ticker fires every **1s** (`runSeriesStateTicker`, `time.NewTicker(1 * time.Second)`), so the 1.5s wait is only just over a single tick. That is flaky: if the first tick is delayed past 1.5s on a loaded runner, the read fails with `series_state.json should exist after ticker runs` even though nothing is actually wrong.

This polls with `require.Eventually` until the ticker has written the file with our sample (`LastSeriesID == 1`), using a generous 10s ceiling, instead of a fixed sleep. The subsequent assertions are unchanged.

### Verification

`go test ./tsdb/ -run '^TestHead_FastStartupStateFile$'`:
- before: fixed 1.5s wait
- after: `--- PASS: TestHead_FastStartupStateFile (1.10s)`

`gofmt` clean; the change is confined to the test (the pre-existing `go vet` notes are in `querier.go`, unrelated). No production code touched.


```release-notes
NONE
```
