### PR TITLE
docs: remove unsupported http_headers from oauth2 configuration reference

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -862,18 +862,6 @@ tls_config:
 # Specifies headers to send to proxies during CONNECT requests.
 [ proxy_connect_header:
   [ <string>: [<secret>, ...] ] ]
-
-# Custom HTTP headers to be sent along with each request.
-# Headers that are set by Prometheus itself can't be overwritten.
-http_headers:
-  # Header name.
-  [ <string>:
-    # Header values.
-    [ values: [<string>, ...] ]
-    # Headers values. Hidden in configuration page.
-    [ secrets: [<secret>, ...] ]
-    # Files to read header values from.
-    [ files: [<string>, ...] ] ]
 ```
 
 ### `<aws_sd_config>`


### PR DESCRIPTION
## Description

The `<oauth2>` section of the configuration reference documents an
`http_headers` block, but the `OAuth2` type in `prometheus/common` has no
corresponding field. `OAuth2` embeds `ProxyConfig` (so the `proxy_*` options
listed above it are valid), but unlike `HTTPClientConfig` it does not have an
`HTTPHeaders` field.

Because the configuration is unmarshaled strictly, setting `http_headers`
under an `oauth2` block fails to load:

```
field http_headers not found in type config.plain
```

So the documentation currently advertises an option that cannot be used. This
removes the `http_headers` block from the `<oauth2>` reference. The `proxy_*`
options are left untouched, since `OAuth2` does embed `ProxyConfig`.

Verified against `github.com/prometheus/common@v0.69.0` (the version pinned in
`go.mod`): `OAuth2` has no `HTTPHeaders` field, while `HTTPClientConfig` does.

Fixes #19103

```release-notes
NONE
```
