### PR TITLE
docs: fix proxy_from_environment environment variable list

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -722,7 +722,7 @@ tls_config:
 # that should be excluded from proxying. IP and domain names can
 # contain port numbers.
 [ no_proxy: <string> ]
-# Use proxy URL indicated by environment variables (HTTP_PROXY, https_proxy, HTTPs_PROXY, https_proxy, and no_proxy)
+# Use proxy URL indicated by environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY, and their lowercase versions)
 [ proxy_from_environment: <boolean> | default: false ]
 # Specifies headers to send to proxies during CONNECT requests.
 [ proxy_connect_header:
@@ -857,7 +857,7 @@ tls_config:
 # that should be excluded from proxying. IP and domain names can
 # contain port numbers.
 [ no_proxy: <string> ]
-# Use proxy URL indicated by environment variables (HTTP_PROXY, https_proxy, HTTPs_PROXY, https_proxy, and no_proxy)
+# Use proxy URL indicated by environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY, and their lowercase versions)
 [ proxy_from_environment: <boolean> | default: false ]
 # Specifies headers to send to proxies during CONNECT requests.
 [ proxy_connect_header:
@@ -3049,7 +3049,7 @@ region: <string>
 # that should be excluded from proxying. IP and domain names can
 # contain port numbers.
 [ no_proxy: <string> ]
-# Use proxy URL indicated by environment variables (HTTP_PROXY, https_proxy, HTTPs_PROXY, https_proxy, and no_proxy)
+# Use proxy URL indicated by environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY, and their lowercase versions)
 [ proxy_from_environment: <boolean> | default: false ]
 # Specifies headers to send to proxies during CONNECT requests.
 [ proxy_connect_header:


### PR DESCRIPTION
## Description

The `proxy_from_environment` option is documented in three places in the
configuration reference with the comment:

```
# Use proxy URL indicated by environment variables (HTTP_PROXY, https_proxy, HTTPs_PROXY, https_proxy, and no_proxy)
```

That list is malformed: `https_proxy` is repeated, `HTTPs_PROXY` uses an
inconsistent casing that is not a real variable, and the canonical
`HTTPS_PROXY` / `NO_PROXY` names are missing.

`proxy_from_environment` uses net/http's `ProxyFromEnvironment`, which honors
`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` (and their lowercase equivalents).
This updates all three occurrences to list those names consistently, so the
docs match the actual behavior.

```release-notes
NONE
```
