### PR TITLE
scrape: stop manager on closed target-set channel

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -214,7 +214,7 @@ func (m *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) error {
 		select {
 		case ts, ok := <-tsets:
 			if !ok {
-				break
+				return nil
 			}
 			m.updateTsets(ts)
 

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -767,6 +767,26 @@ func TestManagerTargetsUpdates(t *testing.T) {
 	}
 }
 
+func TestManagerRunReturnsWhenTargetSetsClosed(t *testing.T) {
+	m, err := NewManager(&Options{}, nil, nil, nil, teststorage.NewAppendable(), prometheus.NewRegistry())
+	require.NoError(t, err)
+	defer m.Stop()
+
+	targetSetsCh := make(chan map[string][]*targetgroup.Group)
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- m.Run(targetSetsCh)
+	}()
+	close(targetSetsCh)
+
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("scrape manager did not stop after target sets channel was closed")
+	}
+}
+
 func TestSetOffsetSeed(t *testing.T) {
 	getConfig := func(prometheus string) *config.Config {
 		cfgText := `


### PR DESCRIPTION
﻿## Summary

`Manager.Run` used `break` when the discovery target-set channel was closed. That only exited the `select`, so the outer loop kept receiving from the closed channel and busy-spun at 100% CPU.

Return from `Run` when the channel closes. This preserves the existing shutdown path and does not change scraping behavior for valid updates.

## Testing

- `go test ./scrape -count=1`
- `go test ./scrape -run '^TestManagerRunReturnsWhenTargetSetsClosed$' -count=10`
- `go vet ./scrape`
- `go test ./promql/...`
- `go test ./...` was also attempted on Windows; unrelated integration readiness timeouts and OpenAPI golden mismatches remain.

```release-notes
[BUGFIX] scrape: stop manager when the discovery target-set channel closes
```