### PR TITLE
remote: skip resharding after non-recoverable send failures

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1734,7 +1734,9 @@ func (s *shards) updateMetrics(_ context.Context, err error, sampleCount, exempl
 	// should be maintained irrespective of success or failure.
 	s.qm.dataOut.incr(int64(sampleCount + exemplarCount + histogramCount + metadataCount))
 	s.qm.dataOutDuration.incr(int64(duration))
-	s.qm.lastSendTimestamp.Store(time.Now().Unix())
+	if err == nil {
+		s.qm.lastSendTimestamp.Store(time.Now().Unix())
+	}
 
 	// Pending samples/exemplars/histograms also should be subtracted, as an error means
 	// they will not be retried.

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -761,6 +761,45 @@ func TestShouldReshard(t *testing.T) {
 	}
 }
 
+func TestFailedSendDoesNotAllowReshard(t *testing.T) {
+	writeAttempted := make(chan struct{})
+	client := &MockWriteClient{
+		StoreFunc: func(context.Context, []byte, int) (WriteResponseStats, error) {
+			close(writeAttempted)
+			return WriteResponseStats{}, errors.New("remote endpoint unavailable")
+		},
+		NameFunc:     func() string { return "mock" },
+		EndpointFunc: func() string { return "http://fake:9090/api/v1/write" },
+	}
+
+	cfg := testDefaultQueueConfig()
+	cfg.MinShards = 1
+	cfg.MaxShards = 2
+	cfg.MaxSamplesPerSend = 1
+	cfg.Capacity = 1
+
+	recs := testwal.GenerateRecords(recCase{Series: 1, SamplesPerSeries: 1})
+	m := newTestQueueManager(t, cfg, config.DefaultMetadataConfig, defaultFlushDeadline, client, remoteapi.WriteV1MessageType)
+	m.StoreSeries(recs.Series, 0)
+	m.Start()
+	defer m.Stop()
+
+	require.True(t, m.Append(recs.Samples))
+	select {
+	case <-writeAttempted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for a remote write attempt")
+	}
+	require.Eventually(t, func() bool {
+		return client_testutil.ToFloat64(m.metrics.failedSamplesTotal) == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return client_testutil.ToFloat64(m.metrics.pendingSamples) == 0
+	}, time.Second, 10*time.Millisecond)
+
+	require.False(t, m.shouldReshard(m.numShards+1))
+}
+
 // TestDisableReshardOnRetry asserts that resharding should be disabled when a
 // recoverable error is returned from remote_write.
 func TestDisableReshardOnRetry(t *testing.T) {


### PR DESCRIPTION
## Summary

- Update the remote-write resharding timestamp only after a batch completes successfully.
- Add a regression test covering a non-recoverable remote-write failure.

## Root cause

`updateMetrics` refreshed `lastSendTimestamp` even when a batch failed with a non-recoverable error. The resharding guard therefore treated that failed batch as a successful send and could permit a reshard. Keeping the timestamp unchanged until a successful batch makes the guard reflect its intended condition.

## Verification

- `go test ./storage/remote -count=1`
- `go build ./cmd/prometheus`
- A local Prometheus process was run against an unavailable remote-write endpoint; it retried writes without recording a successful send or resharding.

```release-notes
[BUGFIX] Remote-write: Avoid resharding after non-recoverable send failures.
```
