### PR TITLE
promtool: add promql-binop-fill-modifiers to --enable-feature handling

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -364,6 +364,8 @@ func main() {
 				// This feature is now permanently enabled and therefore a no-op.
 			case "promql-extended-range-selectors":
 				promtoolParserOpts.EnableExtendedRangeSelectors = true
+			case "promql-binop-fill-modifiers":
+				promtoolParserOpts.EnableBinopFillModifiers = true
 			case "":
 				continue
 			default:

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -702,7 +702,7 @@ func TestCheckRulesWithFeatureFlag(t *testing.T) {
 	// As opposed to TestCheckRules calling CheckRules directly we run promtool
 	// so the feature flag parsing can be tested.
 
-	args := []string{"-test.main", "--enable-feature=promql-experimental-functions", "--enable-feature=promql-extended-range-selectors", "check", "rules", "testdata/features.yml"}
+	args := []string{"-test.main", "--enable-feature=promql-experimental-functions", "--enable-feature=promql-extended-range-selectors", "--enable-feature=promql-binop-fill-modifiers", "check", "rules", "testdata/features.yml"}
 	tool := exec.Command(promtoolPath, args...)
 	err := tool.Run()
 	require.NoError(t, err)

--- a/cmd/promtool/testdata/features.yml
+++ b/cmd/promtool/testdata/features.yml
@@ -8,3 +8,5 @@ groups:
         expr: rate(up[1m * 2])
       - record: promql-extended-range-selectors
         expr: rate(up[1m] anchored)
+      - record: promql-binop-fill-modifiers
+        expr: rate(up[5m]) + fill(0) rate(down[5m])


### PR DESCRIPTION
### Fix #19152

## Context

`promtool check rules --enable-feature=promql-binop-fill-modifiers` was silently
ignoring the flag and failing to parse any `fill()` / `fill_left()` / `fill_right()`
expression with _"binop fill modifiers are experimental and not enabled"_.

### Verification

```bash
go test ./cmd/promtool/... -run TestCheckRulesWithFeatureFlag -v
go test ./cmd/promtool/...
```

```release-notes
[BUGFIX] promtool: `--enable-feature=promql-binop-fill-modifiers` is now recognised, allowing `check rules` to validate `fill()`/`fill_left()`/`fill_right()` binary-operator expressions.
```

