### PR TITLE
promql: fail gracefully when active query log cannot be created

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -985,12 +985,18 @@ func main() {
 	)
 
 	if !agentMode {
+		activeQueryTracker, err := promql.NewActiveQueryTracker(localStoragePath, cfg.queryConcurrency, logger.With("component", "activeQueryTracker"))
+		if err != nil {
+			logger.Error("failed to create active query tracker", "err", err)
+			os.Exit(1)
+		}
+
 		opts := promql.EngineOpts{
 			Logger:                   logger.With("component", "query engine"),
 			Reg:                      prometheus.DefaultRegisterer,
 			MaxSamples:               cfg.queryMaxSamples,
 			Timeout:                  time.Duration(cfg.queryTimeout),
-			ActiveQueryTracker:       promql.NewActiveQueryTracker(localStoragePath, cfg.queryConcurrency, logger.With("component", "activeQueryTracker")),
+			ActiveQueryTracker:       activeQueryTracker,
 			LookbackDelta:            time.Duration(cfg.lookbackDelta),
 			NoStepSubqueryIntervalFn: noStepSubqueryInterval.Get,
 			// EnableAtModifier and EnableNegativeOffset have to be

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -57,7 +57,8 @@ func TestMain(m *testing.M) {
 func TestQueryConcurrency(t *testing.T) {
 	maxConcurrency := 10
 
-	queryTracker := promql.NewActiveQueryTracker(t.TempDir(), maxConcurrency, nil)
+	queryTracker, err := promql.NewActiveQueryTracker(t.TempDir(), maxConcurrency, nil)
+	require.NoError(t, err)
 	opts := promql.EngineOpts{
 		Logger:             nil,
 		Reg:                nil,

--- a/promql/query_logger.go
+++ b/promql/query_logger.go
@@ -114,10 +114,18 @@ func getMMappedFile(filename string, filesize int, logger *slog.Logger) ([]byte,
 		return nil, nil, err
 	}
 
-	err = file.Truncate(int64(filesize))
-	if err != nil {
+	// Write zeroes instead of calling Truncate to reserve the space on disk.
+	// On filesystems supporting sparse files, Truncate would only update the
+	// file size without allocating blocks, and writes through the memory map
+	// would crash the process with SIGBUS once the disk is full.
+	if _, err := file.Write(make([]byte, filesize)); err != nil {
 		file.Close()
-		logger.Error("Error setting filesize.", "filesize", filesize, "err", err)
+		logger.Error("Error allocating disk space for query log file", "filesize", filesize, "err", err)
+		return nil, nil, err
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		logger.Error("Error syncing query log file to disk", "err", err)
 		return nil, nil, err
 	}
 
@@ -131,7 +139,7 @@ func getMMappedFile(filename string, filesize int, logger *slog.Logger) ([]byte,
 	return fileAsBytes, &mmappedFile{f: file, m: fileAsBytes}, err
 }
 
-func NewActiveQueryTracker(localStoragePath string, maxConcurrent int, logger *slog.Logger) *ActiveQueryTracker {
+func NewActiveQueryTracker(localStoragePath string, maxConcurrent int, logger *slog.Logger) (*ActiveQueryTracker, error) {
 	err := os.MkdirAll(localStoragePath, 0o777)
 	if err != nil {
 		logger.Error("Failed to create directory for logging active queries")
@@ -142,7 +150,7 @@ func NewActiveQueryTracker(localStoragePath string, maxConcurrent int, logger *s
 
 	fileAsBytes, closer, err := getMMappedFile(filename, filesize, logger)
 	if err != nil {
-		panic("Unable to create mmap-ed active query log")
+		return nil, fmt.Errorf("create mmapped active query log: %w", err)
 	}
 
 	copy(fileAsBytes, "[")
@@ -156,7 +164,7 @@ func NewActiveQueryTracker(localStoragePath string, maxConcurrent int, logger *s
 
 	activeQueryTracker.generateIndices(maxConcurrent)
 
-	return &activeQueryTracker
+	return &activeQueryTracker, nil
 }
 
 func trimStringByBytes(str string, size int) string {

--- a/promql/query_logger_test.go
+++ b/promql/query_logger_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/grafana/regexp"
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -125,6 +126,25 @@ func TestMMapFile(t *testing.T) {
 	require.NoError(t, err, "Unexpected error while reading file.")
 	require.Equal(t, 2, n)
 	require.Equal(t, []byte(data), bytes[:2], "Mmap failed")
+}
+
+func TestNewActiveQueryTracker(t *testing.T) {
+	tracker, err := NewActiveQueryTracker(t.TempDir(), 5, promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, tracker.Close())
+}
+
+func TestNewActiveQueryTrackerError(t *testing.T) {
+	// Pass a file as the localStoragePath so creating the query log
+	// file inside it fails: the error must be returned, not panic.
+	notADir := filepath.Join(t.TempDir(), "file")
+	require.NoError(t, os.WriteFile(notADir, nil, 0o666))
+
+	require.NotPanics(t, func() {
+		tracker, err := NewActiveQueryTracker(notADir, 5, promslog.NewNopLogger())
+		require.Error(t, err)
+		require.Nil(t, tracker)
+	})
 }
 
 func TestTrimStringByBytes(t *testing.T) {


### PR DESCRIPTION
`NewActiveQueryTracker` panics in a crash loop when the `queries.active` file cannot be created or mmapped — and on filesystems supporting sparse files, `Truncate` reserved no real space, so a full disk only surfaced once a query wrote through the memory map and killed the process with SIGBUS (#9923).

This picks up where #14494 left off, following the approach approved in that review:

- Reserve the file's space with an explicit zero write + `Sync()` instead of `Truncate`, so ENOSPC is reported at startup rather than as a SIGBUS mid-query.
- `NewActiveQueryTracker` returns an error instead of panicking; `cmd/prometheus/main.go` logs it and exits cleanly like other startup failures.
- Deliberately omits #14494's per-insert `mmap.Flush()` calls — they're unrelated to the reported crash and were the prime suspect in that PR's Windows CI failures.

Tested on Windows natively (the platform where #14494's CI kept failing): full `./promql/` query-logger test battery passes, including two new tests covering the error path (which panics on `main`, verified).

Fixes #9923