### PR TITLE
docs: Update AGENTS.md to test without -count=1 unless required

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,9 @@ Example:
 - Bug fixes require a test that reproduces the bug.
 - New behaviour or exported API changes require unit or e2e tests.
 - Tests should attempt to mirror realistic data and/or behaviour.
+- Run `go test` without `-count=1` by default so Go can reuse cached results.
+  Use `-count=1` only when uncached execution is specifically required, and
+  state why.
 - Use only exported APIs in tests where possible — this keeps tests closer to
   real library usage and simplifies review.
 


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Agents tend to execute `go test` with the `-count=1` flag, bypassing the Go test cache. Bypassing the test cache just wastes time, unless it's actually required. I propose we add an instruction to AGENTS.md to avoid `-count=1` by default.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
