### PR TITLE
promql: add positioned annotations in promqltest

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -4531,26 +4531,26 @@ load 1m
 	nonmonotonic_bucket{le="+Inf"}  				0+8x10
 
 eval instant at 1m histogram_quantile(0.5, classic_histogram_invalid)
-	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of ""
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" (1:25)
 
 eval instant at 1m histogram_fraction(0.5, 1, conflicting_histogram)
-	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms (1:28)
 
 eval instant at 1m histogram_quantile(0.5, nonmonotonic_bucket)
-	expect info msg: PromQL info: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile)
+	expect info regex: PromQL info: input to histogram_quantile needed to be fixed for monotonicity .* \(1:25\)
 	{} 8.5
 
 eval instant at 1m histogram_quantile(1, histogram_nan)
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN (1:20)
     {case="100% NaNs"} NaN
     {case="20% NaNs"} NaN
 
 eval instant at 1m histogram_quantile(0.8, histogram_nan{case="20% NaNs"})
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher (1:20)
     {case="20% NaNs"} 1
 
 eval instant at 1m histogram_fraction(-Inf, 0.7071067811865475, histogram_nan)
-    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions
+    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions (1:20)
     {case="100% NaNs"} 0.0
     {case="20% NaNs"} 0.4
 

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -1189,19 +1189,41 @@ func validateExpectedAnnotationsOfType(expr string, expectedAnnotationsOfType []
 		return fmt.Errorf("expected %s annotations but none were found for query %q (line %d)", annotationType, expr, line)
 	}
 
+	var actualAnnotationsOfTypeWithPositions []string
+	actualWithPositions := func() []string {
+		if actualAnnotationsOfTypeWithPositions != nil {
+			return actualAnnotationsOfTypeWithPositions
+		}
+		warnings, infos := allAnnos.AsStrings(expr, 0, 0)
+		if annotationType == "warn" {
+			actualAnnotationsOfTypeWithPositions = warnings
+		} else {
+			actualAnnotationsOfTypeWithPositions = infos
+		}
+		return actualAnnotationsOfTypeWithPositions
+	}
+
 	// Check if all expected annotations are found in actual.
 	for _, e := range expectedAnnotationsOfType {
-		matchFound := slices.ContainsFunc(actualAnnotationsOfType, e.CheckMatch)
+		matchFound := slices.ContainsFunc(actualAnnotationsOfType, e.CheckMatch) || slices.ContainsFunc(actualWithPositions(), e.CheckMatch)
 		if !matchFound {
-			return fmt.Errorf(`expected %s annotation matching %s %q but no matching annotation was found for query %q (line %d), found: %v`, annotationType, e.Type(), e.String(), expr, line, allAnnos.AsErrors())
+			return fmt.Errorf(`expected %s annotation matching %s %q but no matching annotation was found for query %q (line %d), found: %v`, annotationType, e.Type(), e.String(), expr, line, actualAnnotationsOfType)
 		}
 	}
 
 	// Check if all actual annotations have a corresponding expected annotation.
-	for _, anno := range actualAnnotationsOfType {
+	for i, anno := range actualAnnotationsOfType {
 		matchFound := slices.ContainsFunc(expectedAnnotationsOfType, func(e expectCmd) bool {
 			return e.CheckMatch(anno)
 		})
+		if !matchFound {
+			actualAnnotationsOfTypeWithPositions := actualWithPositions()
+			if i < len(actualAnnotationsOfTypeWithPositions) {
+				matchFound = slices.ContainsFunc(expectedAnnotationsOfType, func(e expectCmd) bool {
+					return e.CheckMatch(actualAnnotationsOfTypeWithPositions[i])
+				})
+			}
+		}
 		if !matchFound {
 			return fmt.Errorf("unexpected %s annotation %q found for query %s (line %d)", annotationType, anno, expr, line)
 		}

--- a/promql/promqltest/test.go
+++ b/promql/promqltest/test.go
@@ -1180,7 +1180,7 @@ func (ev *evalCmd) expectMetric(pos int, m labels.Labels, vals ...parser.Sequenc
 }
 
 // validateExpectedAnnotationsOfType validates expected messages and regex match actual annotations.
-func validateExpectedAnnotationsOfType(expr string, expectedAnnotationsOfType []expectCmd, actualAnnotationsOfType []string, line int, annotationType string, allAnnos annotations.Annotations) error {
+func validateExpectedAnnotationsOfType(expr string, expectedAnnotationsOfType []expectCmd, actualAnnotationsOfType []string, line int, annotationType string) error {
 	if len(expectedAnnotationsOfType) == 0 {
 		return nil
 	}
@@ -1189,41 +1189,19 @@ func validateExpectedAnnotationsOfType(expr string, expectedAnnotationsOfType []
 		return fmt.Errorf("expected %s annotations but none were found for query %q (line %d)", annotationType, expr, line)
 	}
 
-	var actualAnnotationsOfTypeWithPositions []string
-	actualWithPositions := func() []string {
-		if actualAnnotationsOfTypeWithPositions != nil {
-			return actualAnnotationsOfTypeWithPositions
-		}
-		warnings, infos := allAnnos.AsStrings(expr, 0, 0)
-		if annotationType == "warn" {
-			actualAnnotationsOfTypeWithPositions = warnings
-		} else {
-			actualAnnotationsOfTypeWithPositions = infos
-		}
-		return actualAnnotationsOfTypeWithPositions
-	}
-
 	// Check if all expected annotations are found in actual.
 	for _, e := range expectedAnnotationsOfType {
-		matchFound := slices.ContainsFunc(actualAnnotationsOfType, e.CheckMatch) || slices.ContainsFunc(actualWithPositions(), e.CheckMatch)
+		matchFound := slices.ContainsFunc(actualAnnotationsOfType, e.CheckMatch)
 		if !matchFound {
 			return fmt.Errorf(`expected %s annotation matching %s %q but no matching annotation was found for query %q (line %d), found: %v`, annotationType, e.Type(), e.String(), expr, line, actualAnnotationsOfType)
 		}
 	}
 
 	// Check if all actual annotations have a corresponding expected annotation.
-	for i, anno := range actualAnnotationsOfType {
+	for _, anno := range actualAnnotationsOfType {
 		matchFound := slices.ContainsFunc(expectedAnnotationsOfType, func(e expectCmd) bool {
 			return e.CheckMatch(anno)
 		})
-		if !matchFound {
-			actualAnnotationsOfTypeWithPositions := actualWithPositions()
-			if i < len(actualAnnotationsOfTypeWithPositions) {
-				matchFound = slices.ContainsFunc(expectedAnnotationsOfType, func(e expectCmd) bool {
-					return e.CheckMatch(actualAnnotationsOfTypeWithPositions[i])
-				})
-			}
-		}
 		if !matchFound {
 			return fmt.Errorf("unexpected %s annotation %q found for query %s (line %d)", annotationType, anno, expr, line)
 		}
@@ -1242,22 +1220,16 @@ func (ev *evalCmd) checkAnnotations(expr string, annos annotations.Annotations) 
 		return fmt.Errorf("expected info annotations evaluating query %q (line %d) but got none", expr, ev.line)
 	}
 
-	var warnings, infos []string
-
 	for _, err := range annos {
-		switch {
-		case errors.Is(err, annotations.PromQLWarning):
-			warnings = append(warnings, err.Error())
-		case errors.Is(err, annotations.PromQLInfo):
-			infos = append(infos, err.Error())
-		default:
+		if !errors.Is(err, annotations.PromQLWarning) && !errors.Is(err, annotations.PromQLInfo) {
 			return fmt.Errorf("unexpected annotation type, must be either info or warn but got: %w", err)
 		}
 	}
-	if err := validateExpectedAnnotationsOfType(expr, ev.expectedCmds[Warn], warnings, ev.line, "warn", annos); err != nil {
+	warnings, infos := annos.AsStrings(expr, 0, 0)
+	if err := validateExpectedAnnotationsOfType(expr, ev.expectedCmds[Warn], warnings, ev.line, "warn"); err != nil {
 		return err
 	}
-	if err := validateExpectedAnnotationsOfType(expr, ev.expectedCmds[Info], infos, ev.line, "info", annos); err != nil {
+	if err := validateExpectedAnnotationsOfType(expr, ev.expectedCmds[Info], infos, ev.line, "info"); err != nil {
 		return err
 	}
 	if ev.expectedCmds[NoWarn] != nil && len(warnings) > 0 {

--- a/promql/promqltest/test_test.go
+++ b/promql/promqltest/test_test.go
@@ -395,7 +395,7 @@ eval instant at 50m sort(rate(http_requests[10m]))
 	{group="canary", instance="0", job="api-server"} 0.1
 	{group="canary", instance="1", job="api-server"} 0.13333333333333333
 `,
-			expectedError: `unexpected info annotations evaluating query "sort(rate(http_requests[10m]))" (line 10): [PromQL info: metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "http_requests"]`,
+			expectedError: `unexpected info annotations evaluating query "sort(rate(http_requests[10m]))" (line 10): [PromQL info: metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "http_requests" (1:11)]`,
 		},
 		"instant query with unexpectedly missing warn annotation": {
 			input: testData + `
@@ -742,7 +742,7 @@ load 5m
 	metric{src="b"} 1
 
 eval_warn instant at 0m sum(metric)
-	expect warn msg: PromQL warning: encountered a mix of histograms and floats for aggregation
+	expect warn msg: PromQL warning: encountered a mix of histograms and floats for aggregation (1:5)
 `,
 		},
 		"instant query expected to have warn but not with the specific message (with new eval syntax)": {
@@ -754,7 +754,7 @@ load 5m
 eval_warn instant at 0m sum(metric)
 	expect warn msg: PromQL warning: encountered a mix
 `,
-			expectedError: `expected warn annotation matching message "PromQL warning: encountered a mix" but no matching annotation was found for query "sum(metric)" (line 6), found: [PromQL warning: encountered a mix of histograms and floats for aggregation]`,
+			expectedError: `expected warn annotation matching message "PromQL warning: encountered a mix" but no matching annotation was found for query "sum(metric)" (line 6), found: [PromQL warning: encountered a mix of histograms and floats for aggregation (1:5)]`,
 		},
 		"instant query expected to have warn annotation with specific regex (with new eval syntax)": {
 			input: `
@@ -775,7 +775,7 @@ load 5m
 eval_warn instant at 0m sum(metric)
 	expect warn regex: PromQL warning: something went (wrong|boom)
 `,
-			expectedError: `expected warn annotation matching pattern "PromQL warning: something went (wrong|boom)" but no matching annotation was found for query "sum(metric)" (line 6), found: [PromQL warning: encountered a mix of histograms and floats for aggregation]`,
+			expectedError: `expected warn annotation matching pattern "PromQL warning: something went (wrong|boom)" but no matching annotation was found for query "sum(metric)" (line 6), found: [PromQL warning: encountered a mix of histograms and floats for aggregation (1:5)]`,
 		},
 		"instant query expected to have warn annotation and no info annotation (with new eval syntax)": {
 			input: `
@@ -809,7 +809,7 @@ load 5m
 eval_warn instant at 0m sum(metric)
 	expect no_warn
 `,
-			expectedError: `unexpected warning annotations evaluating query "sum(metric)" (line 6): [PromQL warning: encountered a mix of histograms and floats for aggregation]`,
+			expectedError: `unexpected warning annotations evaluating query "sum(metric)" (line 6): [PromQL warning: encountered a mix of histograms and floats for aggregation (1:5)]`,
 		},
 		"instant query expected to only have info annotation (with new eval syntax)": {
 			input: `
@@ -829,7 +829,7 @@ load 5m
 	metric{src="b"} 1
 
 eval_info instant at 0m min(metric)
-	expect info msg: PromQL info: ignored histogram in min aggregation
+	expect info msg: PromQL info: ignored histogram in min aggregation (1:5)
 	{} 1
 `,
 		},
@@ -843,7 +843,7 @@ eval_info instant at 0m min(metric)
 	expect info msg: something went wrong
 	{} 1
 `,
-			expectedError: `expected info annotation matching message "something went wrong" but no matching annotation was found for query "min(metric)" (line 6), found: [PromQL info: ignored histogram in min aggregation]`,
+			expectedError: `expected info annotation matching message "something went wrong" but no matching annotation was found for query "min(metric)" (line 6), found: [PromQL info: ignored histogram in min aggregation (1:5)]`,
 		},
 		"instant query expected to have info annotation with specific regex (with new eval syntax)": {
 			input: `
@@ -866,7 +866,7 @@ eval_info instant at 0m min(metric)
 	expect info regex: something went (wrong|boom)
 	{} 1
 `,
-			expectedError: `expected info annotation matching pattern "something went (wrong|boom)" but no matching annotation was found for query "min(metric)" (line 6), found: [PromQL info: ignored histogram in min aggregation]`,
+			expectedError: `expected info annotation matching pattern "something went (wrong|boom)" but no matching annotation was found for query "min(metric)" (line 6), found: [PromQL info: ignored histogram in min aggregation (1:5)]`,
 		},
 		"instant query expected to have info annotation and no warn annotation (with new eval syntax)": {
 			input: `
@@ -903,7 +903,7 @@ eval_info instant at 0m min(metric)
 	expect no_info
 	{} 1
 `,
-			expectedError: `unexpected info annotations evaluating query "min(metric)" (line 6): [PromQL info: ignored histogram in min aggregation]`,
+			expectedError: `unexpected info annotations evaluating query "min(metric)" (line 6): [PromQL info: ignored histogram in min aggregation (1:5)]`,
 		},
 		"instant query with results expected to match provided order, and result is in expected order (with new eval syntax)": {
 			input: testData + `

--- a/promql/promqltest/testdata/aggregators.test
+++ b/promql/promqltest/testdata/aggregators.test
@@ -542,7 +542,7 @@ eval instant at 1m quantile without(point)((scalar(foo)), data)
 	{test="NaN sample"} 0.6
 
 eval instant at 1m quantile without(point)(NaN, data)
-	expect warn msg: PromQL warning: quantile value should be between 0 and 1, got NaN
+	expect warn regex: PromQL warning: quantile value should be between 0 and 1, got NaN \([0-9]+:[0-9]+\)
 	{test="two samples"} NaN
 	{test="three samples"} NaN
 	{test="uneven samples"} NaN

--- a/promql/promqltest/testdata/extended_vectors.test
+++ b/promql/promqltest/testdata/extended_vectors.test
@@ -508,7 +508,7 @@ eval instant at 5s histogram_sum(increase(hist_counter[1m] anchored))
 # for a monotonic series (no counter reset correction needed).
 # hist_counter samples have no GaugeType hint so a not-a-gauge warning is emitted.
 eval instant at 50s histogram_count(delta(hist_counter[1m] smoothed))
-    expect warn msg: PromQL warning: this native histogram metric is not a gauge: "hist_counter"
+    expect warn msg: PromQL warning: this native histogram metric is not a gauge: "hist_counter" (1:23)
     {} 3.333333333333333
 
 # Anchored rate at 50s: left=count:1 (t=0), right=count:4 (t=45), rate=3/60.
@@ -518,7 +518,7 @@ eval instant at 50s histogram_count(rate(hist_counter[1m] anchored))
 # Anchored delta (non-counter) at 50s: same result as anchored increase but
 # hist_counter samples have no GaugeType hint so a not-a-gauge warning is emitted.
 eval instant at 50s histogram_count(delta(hist_counter[1m] anchored))
-    expect warn msg: PromQL warning: this native histogram metric is not a gauge: "hist_counter"
+    expect warn msg: PromQL warning: this native histogram metric is not a gauge: "hist_counter" (1:23)
     {} 3
 
 # Smoothed vector selector interpolation for native histograms.
@@ -553,13 +553,13 @@ load 30s
 # Anchored rate should warn and return no result when the range mixes exponential
 # and custom buckets at the boundaries.
 eval instant at 1m rate(mixed_hist[1m] anchored)
-    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "mixed_hist"
+    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "mixed_hist" (1:6)
     # Should produce no results.
 
 # Smoothed rate should warn and return no result when interpolation would cross
 # exponential and custom buckets.
 eval instant at 45s rate(mixed_hist[1m] smoothed)
-    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "mixed_hist"
+    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "mixed_hist" (1:6)
     # Should produce no results.
 
 # Anchored increase should still account for resets for custom-bucket histograms.
@@ -586,17 +586,17 @@ load 30s
   mid_gauge_hist {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:0 sum:2 count:2 buckets:[2] counter_reset_hint:gauge}} {{schema:0 sum:3 count:3 buckets:[3]}}
 
 eval instant at 90s histogram_count(rate(mid_gauge_hist[90s] anchored))
-    expect warn msg: PromQL warning: this native histogram metric is not a counter: "mid_gauge_hist"
+    expect warn msg: PromQL warning: this native histogram metric is not a counter: "mid_gauge_hist" (1:22)
     {} 0.022222222222222223
 
 eval instant at 90s histogram_count(increase(mid_gauge_hist[90s] smoothed))
-    expect warn msg: PromQL warning: this native histogram metric is not a counter: "mid_gauge_hist"
+    expect warn msg: PromQL warning: this native histogram metric is not a counter: "mid_gauge_hist" (1:26)
     {} 2
 
 # Gauge op on a counter-typed series must warn when a boundary sample lacks the
 # gauge hint.
 eval instant at 90s histogram_count(delta(mid_gauge_hist[90s] anchored))
-    expect warn msg: PromQL warning: this native histogram metric is not a gauge: "mid_gauge_hist"
+    expect warn msg: PromQL warning: this native histogram metric is not a gauge: "mid_gauge_hist" (1:23)
     {} 2
 
 # Smoothed rate on a custom-bucket-only series interpolates cleanly.
@@ -684,7 +684,7 @@ load 30s
   smoothed_mix {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1]}}
 
 eval instant at 45s histogram_count(smoothed_mix smoothed)
-    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "smoothed_mix"
+    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "smoothed_mix" (1:17)
 
 # Smoothed vector selector must emit a warning and produce no result when the
 # lookback window mixes floats and histograms.
@@ -693,10 +693,10 @@ load 30s
   mixed_types 1 2 {{schema:0 sum:3 count:3 buckets:[3]}} {{schema:0 sum:4 count:4 buckets:[4]}}
 
 eval instant at 45s mixed_types smoothed
-    expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "mixed_types"
+    expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "mixed_types" (1:1)
 
 eval instant at 45s sort(mixed_types smoothed)
-    expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "mixed_types"
+    expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "mixed_types" (1:6)
 
 # Smoothed rate where the RIGHT boundary interpolation crosses a counter reset.
 # Samples: t=0 count:5, t=10 count:10, t=20 count:3 (reset).

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -254,15 +254,15 @@ eval instant at 20m irate(http_requests_histogram{path="/b"}[6m])
   	expect no_warn
 
 eval instant at 20m irate(http_requests_histogram{path="/c"}[20m])
-	expect warn msg: PromQL warning: this native histogram metric is not a counter: "http_requests_histogram"
+	expect warn msg: PromQL warning: this native histogram metric is not a counter: "http_requests_histogram" (1:7)
 	{path="/c"} {{sum:0.01 count:0.01 counter_reset_hint:gauge}}
 
 eval instant at 20m irate(http_requests_histogram{path="/d"}[20m])
-	expect warn msg: PromQL warning: this native histogram metric is not a counter: "http_requests_histogram"
+	expect warn msg: PromQL warning: this native histogram metric is not a counter: "http_requests_histogram" (1:7)
 	{path="/d"} {{sum:0.01 count:0.01 counter_reset_hint:gauge}}
 
 eval instant at 20m irate(http_requests_histogram{path="/e"}[20m])
-  expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "http_requests_histogram"
+  expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "http_requests_histogram" (1:7)
 
 eval instant at 20m irate(http_requests_histogram{path="/f"}[20m])
   	expect no_warn
@@ -293,12 +293,12 @@ eval instant at 20m delta(http_requests_gauge[20m])
 
 # delta emits warn annotation for non-gauge histogram types.
 eval instant at 20m delta(http_requests_counter[20m])
-	expect warn msg: PromQL warning: this native histogram metric is not a gauge: "http_requests_counter"
+	expect warn msg: PromQL warning: this native histogram metric is not a gauge: "http_requests_counter" (1:7)
 	{path="/foo"} {{schema:0 sum:4 count:8 buckets:[4 4 4]}}
 
 # delta emits warn annotation for mix of histogram and floats.
 eval instant at 20m delta(http_requests_mix[20m])
-	expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "http_requests_mix"
+	expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "http_requests_mix" (1:7)
 	#empty
 
 clear
@@ -337,22 +337,22 @@ eval instant at 20m idelta(http_requests_histogram{path="/b"}[6m])
 	expect no_warn
 
 eval instant at 20m idelta(http_requests_histogram{path="/c"}[20m])
-	expect warn msg: PromQL warning: this native histogram metric is not a gauge: "http_requests_histogram"
+	expect warn msg: PromQL warning: this native histogram metric is not a gauge: "http_requests_histogram" (1:8)
 	{path="/c"} {{sum:1 count:1 counter_reset_hint:gauge}}
 
 eval instant at 20m idelta(http_requests_histogram{path="/d"}[20m])
-	expect warn msg: PromQL warning: this native histogram metric is not a gauge: "http_requests_histogram"
+	expect warn msg: PromQL warning: this native histogram metric is not a gauge: "http_requests_histogram" (1:8)
 	{path="/d"} {{sum:1 count:1 counter_reset_hint:gauge}}
 
 eval instant at 20m idelta(http_requests_histogram{path="/e"}[20m])
-  expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "http_requests_histogram"
+  expect warn msg: PromQL warning: encountered a mix of histograms and floats for metric name "http_requests_histogram" (1:8)
 
 eval instant at 20m idelta(http_requests_histogram{path="/f"}[20m])
-  expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "http_requests_histogram"
+  expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "http_requests_histogram" (1:8)
 
 eval instant at 20m idelta(http_requests_histogram{path="/g"}[20m])
 	expect no_warn
-	expect info msg: PromQL info: mismatched custom buckets were reconciled during subtraction
+	expect info msg: PromQL info: mismatched custom buckets were reconciled during subtraction (1:8)
 	{path="/g"} {{schema:-53 custom_values:[1] counter_reset_hint:gauge buckets:[-1]}}
 
 clear

--- a/promql/promqltest/testdata/histograms.test
+++ b/promql/promqltest/testdata/histograms.test
@@ -1035,7 +1035,7 @@ eval instant at 50m histogram_quantile(0.99, nonmonotonic_bucket)
     {} 979.75
 
 eval instant at 50m histogram_quantiles(nonmonotonic_bucket, "q", 0.01, 0.5, 0.99)
-    expect info
+    expect info regex: PromQL info: input to histogram_quantile needed to be fixed for monotonicity .* \(1:21\)
     {q="0.01"} 0.0045
     {q="0.5"} 8.5
     {q="0.99"} 979.75

--- a/promql/promqltest/testdata/histograms.test
+++ b/promql/promqltest/testdata/histograms.test
@@ -699,10 +699,10 @@ eval instant at 50m histogram_quantiles(testhistogram_bucket, "q", NaN)
 	{q="NaN", start="negative"} NaN
 
 eval instant at 50m histogram_quantile(NaN, non_existent)
-  expect warn msg: PromQL warning: quantile value should be between 0 and 1, got NaN
+  expect warn regex: PromQL warning: quantile value should be between 0 and 1, got NaN \([0-9]+:[0-9]+\)
 
 eval instant at 50m histogram_quantiles(non_existent, "q", NaN)
-  expect warn msg: PromQL warning: quantile value should be between 0 and 1, got NaN
+  expect warn regex: PromQL warning: quantile value should be between 0 and 1, got NaN \([0-9]+:[0-9]+\)
 
 # Quantile value in lowest bucket.
 
@@ -1157,17 +1157,17 @@ load 1m
 
 eval instant at 0 histogram_quantile(0.8, series)
   expect no_info
-  expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+  expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series" (1:25)
   # Should return no results.
 
 eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
   expect no_info
-  expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+  expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series" (1:21)
   # Should return no results.
 
 eval instant at 0 histogram_fraction(-Inf, 1, series)
   expect no_info
-  expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+  expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series" (1:29)
   # Should return no results.
 
 clear
@@ -1178,17 +1178,17 @@ load 1m
 
 eval instant at 0 histogram_quantile(0.8, series)
 	expect no_info
-	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series" (1:25)
 	# Should return no results.
 
 eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
 	expect no_info
-	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series" (1:21)
 	# Should return no results.
 
 eval instant at 0 histogram_fraction(-Inf, 1, series)
 	expect no_info
-	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series" (1:29)
 	# Should return no results.
 
 clear
@@ -1199,17 +1199,17 @@ load 1m
 
 eval instant at 0 histogram_quantile(0.8, series)
 	expect no_info
-	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series" (1:25)
 	# Should return no results.
 
 eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
 	expect no_info
-	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series" (1:21)
 	# Should return no results.
 
 eval instant at 0 histogram_fraction(-Inf, 1, series)
 	expect no_info
-	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series" (1:29)
 	# Should return no results.
 
 clear
@@ -1222,15 +1222,15 @@ load 1m
 
 eval instant at 0 histogram_quantile(0.8, series)
 	expect no_info
-	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series" (1:25)
 	# Should return no results.
 
 eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
 	expect no_info
-	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series" (1:21)
 	# Should return no results.
 
 eval instant at 0 histogram_fraction(-Inf, 1, series)
 	expect no_info
-	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series" (1:29)
 	# Should return no results.

--- a/promql/promqltest/testdata/limit.test
+++ b/promql/promqltest/testdata/limit.test
@@ -116,12 +116,12 @@ eval range from 0 to 50m step 5m count(limit_ratio(-1.0, http_requests) and http
 
 # Capped to 1.0 -> all samples.
 eval range from 0 to 50m step 5m count(limit_ratio(1.1, http_requests) and http_requests)
-	expect warn msg: PromQL warning: ratio value should be between -1 and 1, got 1.1, capping to 1
+	expect warn msg: PromQL warning: ratio value should be between -1 and 1, got 1.1, capping to 1 (1:19)
     {} 8+0x10
 
 # Capped to -1.0 -> all samples.
 eval range from 0 to 50m step 5m count(limit_ratio(-1.1, http_requests) and http_requests)
-	expect warn msg: PromQL warning: ratio value should be between -1 and 1, got -1.1, capping to -1
+	expect warn msg: PromQL warning: ratio value should be between -1 and 1, got -1.1, capping to -1 (1:19)
     {} 8+0x10
 
 # Verify that limit_ratio(value) and limit_ratio(1.0-value) return the "complement" of each other.

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1094,12 +1094,12 @@ load 30s
 
 # Test the case where we only have two points for rate
 eval instant at 30s rate(some_metric[1m])
-    expect warn msg: PromQL warning: this native histogram metric is not a counter: "some_metric"
+    expect warn msg: PromQL warning: this native histogram metric is not a counter: "some_metric" (1:6)
     {} {{count:0.03333333333333333 sum:0.03333333333333333 buckets:[0.03333333333333333]}}
 
 # Test the case where we have more than two points for rate
 eval instant at 1m rate(some_metric[1m30s])
-    expect warn msg: PromQL warning: this native histogram metric is not a counter: "some_metric"
+    expect warn msg: PromQL warning: this native histogram metric is not a counter: "some_metric" (1:6)
     {} {{count:0.03333333333333333 sum:0.03333333333333333 buckets:[0.03333333333333333]}}
 
 clear
@@ -1110,19 +1110,19 @@ load 30s
 
 # Start and end with exponential, with custom in the middle.
 eval instant at 1m rate(some_metric[1m30s])
-    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "some_metric"
+    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "some_metric" (1:6)
     # Should produce no results.
 
 # Start and end with custom, with exponential in the middle.
 eval instant at 1m30s rate(some_metric[1m30s])
-    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "some_metric"
+    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "some_metric" (1:6)
     # Should produce no results.
 
 # histogram_count(rate()) must also warn when the schema mix falls inside the stats-only
 # path (HistogramStatsIterator). Without Schema being set in that iterator, all histograms
 # appear as Schema=0 and the custom-bucket mismatch is silently missed.
 eval instant at 1m histogram_count(rate(some_metric[1m30s]))
-    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "some_metric"
+    expect warn msg: PromQL warning: vector contains a mix of histograms with exponential and custom buckets schemas for metric name "some_metric" (1:22)
     # Should produce no results.
 
 # Start with custom, end with exponential. Return the exponential histogram divided by 48.
@@ -1260,11 +1260,11 @@ eval range from 0 to 12m step 6m metric{series="1"} or ignoring(series) metric{s
 
 # Test mismatched boundaries with arithmetic binary operators
 eval range from 0 to 12m step 6m metric{series="2"} + ignoring (series) metric{series="3"}
-  expect info msg:PromQL info: mismatched custom buckets were reconciled during addition
+  expect info msg: PromQL info: mismatched custom buckets were reconciled during addition (1:1)
   {} {{schema:-53 count:2 sum:2 custom_values:[10] buckets:[2]}} _ {{schema:-53 count:2 sum:2 custom_values:[5] buckets:[2]}}
 
 eval range from 0 to 12m step 6m metric{series="2"} - ignoring (series) metric{series="3"}
-  expect info msg:PromQL info: mismatched custom buckets were reconciled during subtraction
+  expect info msg: PromQL info: mismatched custom buckets were reconciled during subtraction (1:1)
   {} {{schema:-53 custom_values:[10] counter_reset_hint:gauge}} _ {{schema:-53 custom_values:[5] counter_reset_hint:gauge}}
 
 clear
@@ -1295,12 +1295,12 @@ load 6m
 
 eval instant at 12m sum_over_time(nhcb_metric[13m])
   expect no_warn
-  expect info msg: PromQL info: mismatched custom buckets were reconciled during aggregation
+  expect info msg: PromQL info: mismatched custom buckets were reconciled during aggregation (1:15)
   {} {{schema:-53 count:3 sum:3 custom_values:[5] buckets:[3]}}
 
 eval instant at 12m avg_over_time(nhcb_metric[13m])
   expect no_warn
-  expect info msg: PromQL info: mismatched custom buckets were reconciled during aggregation
+  expect info msg: PromQL info: mismatched custom buckets were reconciled during aggregation (1:15)
   {} {{schema:-53 count:1 sum:1 custom_values:[5] buckets:[1]}}
 
 eval instant at 12m last_over_time(nhcb_metric[13m])
@@ -1320,7 +1320,7 @@ eval instant at 12m changes(nhcb_metric[13m])
   {} 1
 
 eval instant at 12m delta(nhcb_metric[13m])
-  expect warn msg: PromQL warning: this native histogram metric is not a gauge: "nhcb_metric"
+  expect warn msg: PromQL warning: this native histogram metric is not a gauge: "nhcb_metric" (1:7)
   {} {{schema:-53 custom_values:[5]}}
 
 eval instant at 12m increase(nhcb_metric[13m])
@@ -1363,8 +1363,8 @@ eval instant at 18m changes(nhcb_metric[13m])
   {} 1
 
 eval instant at 18m delta(nhcb_metric[13m])
-  expect warn msg: PromQL warning: this native histogram metric is not a gauge: "nhcb_metric"
-  expect info msg: PromQL info: mismatched custom buckets were reconciled during subtraction
+  expect warn msg: PromQL warning: this native histogram metric is not a gauge: "nhcb_metric" (1:7)
+  expect info msg: PromQL info: mismatched custom buckets were reconciled during subtraction (1:7)
   {} {{schema:-53 custom_values:[5]}}
 
 eval instant at 18m increase(nhcb_metric[13m])
@@ -1614,44 +1614,44 @@ load 1m
     histogram_nan{case="20% NaNs"} {{schema:0 count:0 sum:0}} {{schema:0 count:15 sum:NaN buckets:[12]}}
 
 eval instant at 1m histogram_quantile(1, histogram_nan)
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan"
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:20)
     {case="100% NaNs"} NaN
     {case="20% NaNs"} NaN
 
 eval instant at 1m histogram_quantile(0.81, histogram_nan)
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan"
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:20)
     {case="100% NaNs"} NaN
     {case="20% NaNs"} NaN
 
 eval instant at 1m histogram_quantiles(histogram_nan, "q", 0.81)
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan"
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:21)
     {case="100% NaNs", q="0.81"} NaN
     {case="20% NaNs", q="0.81"} NaN
 
 eval instant at 1m histogram_quantile(0.8, histogram_nan{case="100% NaNs"})
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan"
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:20)
     {case="100% NaNs"} NaN
 
 eval instant at 1m histogram_quantile(0.8, histogram_nan{case="20% NaNs"})
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher for metric name "histogram_nan"
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher for metric name "histogram_nan" (1:20)
     {case="20% NaNs"} 1
 
 eval instant at 1m histogram_quantile(0.4, histogram_nan{case="100% NaNs"})
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan"
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:20)
     {case="100% NaNs"} NaN
 
 # histogram_quantile and histogram_fraction equivalence if quantile is not NaN
 eval instant at 1m histogram_quantile(0.4, histogram_nan{case="20% NaNs"})
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher for metric name "histogram_nan"
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher for metric name "histogram_nan" (1:20)
     {case="20% NaNs"} 0.7071067811865475
 
 eval instant at 1m histogram_fraction(-Inf, 0.7071067811865475, histogram_nan)
-    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions for metric name "histogram_nan"
+    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions for metric name "histogram_nan" (1:20)
     {case="100% NaNs"} 0.0
     {case="20% NaNs"} 0.4
 
 eval instant at 1m histogram_fraction(-Inf, +Inf, histogram_nan)
-    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions for metric name "histogram_nan"
+    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions for metric name "histogram_nan" (1:20)
     {case="100% NaNs"} 0.0
     {case="20% NaNs"} 0.8
 
@@ -1855,22 +1855,22 @@ eval instant at 15m avg_over_time(mixed[10m])
 # is able to create the counter reset hint "reset", which we can then mix
 # with the "not_reset" hint in the test and provoke the warning.
 eval instant at 6m histogram_count(sum(metric))
-  expect warn msg:PromQL warning: conflicting counter resets during histogram aggregation
+  expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation (1:21)
   expect no_info
   {} 49
 
 eval instant at 6m histogram_count(avg(metric))
-  expect warn msg:PromQL warning: conflicting counter resets during histogram aggregation
+  expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation (1:21)
   expect no_info
   {} 16.333333333333332
 
 eval instant at 14m histogram_count(sum_over_time(mixed[10m]))
-  expect warn msg:PromQL warning: conflicting counter resets during histogram aggregation
+  expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation (1:31)
   expect no_info
   {} 93
 
 eval instant at 14m histogram_count(avg_over_time(mixed[10m]))
-  expect warn msg:PromQL warning: conflicting counter resets during histogram aggregation
+  expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation (1:31)
   expect no_info
   {} 9.3
 
@@ -1878,12 +1878,12 @@ eval instant at 14m histogram_count(avg_over_time(mixed[10m]))
 # and the second has "reset". This tests if the conflict is detected
 # between the first two samples, too.
 eval instant at 11m histogram_count(sum_over_time(mixed[2m]))
-  expect warn msg:PromQL warning: conflicting counter resets during histogram aggregation
+  expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation (1:31)
   expect no_info
   {} 21
 
 eval instant at 11m histogram_count(avg_over_time(mixed[2m]))
-  expect warn msg:PromQL warning: conflicting counter resets during histogram aggregation
+  expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation (1:31)
   expect no_info
   {} 10.5
 
@@ -1902,20 +1902,20 @@ load 1m
 	mixedHistogram{}           {{schema:0 count:10 sum:50 buckets:[1 2 3]}}
 
 eval instant at 1m histogram_quantile(0.5, nonmonotonic_bucket)
-	expect info msg: PromQL info: input to histogram_quantile needed to be fixed for monotonicity (see https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) for metric name "nonmonotonic_bucket"
+	expect info regex: PromQL info: input to histogram_quantile needed to be fixed for monotonicity .* \(1:25\)
 	{} 8.5
 
 eval instant at 1m histogram_quantile(0.5, myHistogram1)
-	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "myHistogram1"
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "myHistogram1" (1:25)
 
 eval instant at 1m histogram_quantile(0.5, myHistogram2)
-	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "myHistogram2"
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "myHistogram2" (1:25)
 
 eval instant at 1m histogram_quantile(0.5, mixedHistogram)
-	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "mixedHistogram"
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "mixedHistogram" (1:25)
 
 eval instant at 1m histogram_quantiles(mixedHistogram, "q", 0.5)
-	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "mixedHistogram"
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "mixedHistogram" (1:21)
 
 clear
 
@@ -1945,15 +1945,15 @@ load 1m
 # Trigger an annotation about conflicting counter resets by going through the
 # HistogramStatsIterator, which creates counter reset hints on the fly.
 eval instant at 5m histogram_count(sum_over_time(reset{timing="late"}[5m]))
-    expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation
+    expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation (1:31)
     {timing="late"} 7
 
 eval instant at 5m histogram_count(sum(reset))
-    expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation
+    expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation (1:21)
     {} 5
 
 eval instant at 5m histogram_count(avg(reset))
-    expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation
+    expect warn msg: PromQL warning: conflicting counter resets during histogram aggregation (1:21)
     {} 2.5
 
 # No annotation with the right timing.
@@ -2013,7 +2013,7 @@ load 1m
 
 eval instant at 1m irate(nhcb_add_buckets[2m]) * 60
     expect no_warn
-    expect info msg: PromQL info: mismatched custom buckets were reconciled during subtraction
+    expect info msg: PromQL info: mismatched custom buckets were reconciled during subtraction (1:7)
     {} {{schema:-53 sum:500 count:435 custom_values:[2 4 6] buckets:[29 68 105 233]}}
 
 load 1m
@@ -2021,7 +2021,7 @@ load 1m
 
 eval instant at 1m irate(nhcb_remove_buckets[2m]) * 60
     expect no_warn
-    expect info msg: PromQL info: mismatched custom buckets were reconciled during subtraction
+    expect info msg: PromQL info: mismatched custom buckets were reconciled during subtraction (1:7)
     {} {{schema:-53 sum:5505 count:955 custom_values:[3 5 7] buckets:[94 191 287 383]}}
 
 clear

--- a/promql/promqltest/testdata/range_queries.test
+++ b/promql/promqltest/testdata/range_queries.test
@@ -107,16 +107,16 @@ eval instant at 10m some_metric[1m]
     expect range vector from 9m10s to 10m step 1m
 
 eval range from 1m to 2m step 1m sort(series)
-  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels
+  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels (1:1)
 
 eval range from 1m to 2m step 1m sort_desc(series)
-  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels
+  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels (1:1)
 
 eval range from 1m to 2m step 1m sort_by_label(series)
-  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels
+  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels (1:1)
 
 eval range from 1m to 2m step 1m sort_by_label_desc(series)
-  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels
+  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels (1:1)
 
 eval range from 1m to 2m step 1m sum(sort(series))
-  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels
+  expect warn msg: PromQL warning: sort is ineffective for range queries since results are always ordered by labels (1:5)

--- a/promql/promqltest/testdata/start_timestamps.test
+++ b/promql/promqltest/testdata/start_timestamps.test
@@ -283,7 +283,7 @@ eval instant at 4m rate(counter_total{type!="overlap"}[3m])
 # Test overlapping start timestamps - warning expected
 eval instant at 4m rate(counter_total{type="overlap"}[3m])
     {type="overlap"} 1
-    expect warn msg: PromQL warning: sample has start time that overlaps with previous sample timestamp for metric "counter_total"
+    expect warn msg: PromQL warning: sample has start time that overlaps with previous sample timestamp for metric "counter_total" (1:6)
 
 # Test querying all series - should only warn for overlap case
 eval instant at 4m rate(counter_total[3m])
@@ -291,6 +291,6 @@ eval instant at 4m rate(counter_total[3m])
     {type="cumulative"} 1
     {type="no_st"} 1
     {type="overlap"} 1
-    expect warn msg: PromQL warning: sample has start time that overlaps with previous sample timestamp for metric "counter_total"
+    expect warn msg: PromQL warning: sample has start time that overlaps with previous sample timestamp for metric "counter_total" (1:6)
 
 clear


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
 
This adds regression coverage for the `histogram_quantiles` forced-monotonicity annotation position.

The bug this protects against is `histogram_quantiles(...)` attaching the annotation to the quantile label argument (`"q"`) instead of the histogram vector argument. The new promqltest case checks that the annotation points at the histogram input.

While adding that coverage, `promqltest` now matches expected warning/info annotations against the positioned annotation strings consistently. The existing exact-match expectations were updated to include their positions.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #19162

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```