### PR TITLE
promql: count subquery samples in total sample stats

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1924,10 +1924,7 @@ func (ev *evaluator) numSteps() int {
 
 // runSubquery evaluates the given SubqueryExpr in a fresh child evaluator
 // aligned to the subquery's own step grid and returns the result along with
-// the child's samples stats. The caller decides how to merge the child stats
-// into the parent: peak and samples-read are always safe to absorb, while
-// TotalSamples should only be absorbed when the caller does not later
-// re-count the materialized matrix (e.g. evalSubquery does not absorb it).
+// the child's samples stats.
 func (ev *evaluator) runSubquery(ctx context.Context, e *parser.SubqueryExpr) (parser.Value, *stats.QuerySamples, annotations.Annotations) {
 	offsetMillis := durationMilliseconds(e.Offset)
 	rangeMillis := durationMilliseconds(e.Range)
@@ -1953,11 +1950,10 @@ func (ev *evaluator) runSubquery(ctx context.Context, e *parser.SubqueryExpr) (p
 		subqStart += subqInterval
 	}
 
-	// Subquery children always track per-step samples-read (independent of
-	// the parent's per-step setting) so MergeSamplesReadFromSubquery can
-	// attribute each subquery iteration to a parent step and drop iterations
-	// that fall in gaps between parent windows. The arrays don't escape this
-	// call.
+	// Subquery children always track per-step samples (independent of the
+	// parent's per-step setting) so subquery stats can attribute each subquery
+	// iteration to a parent step and drop iterations that fall in gaps between
+	// parent windows. The arrays don't escape this call.
 	childStats := stats.NewChildWithStepTracking(subqStart, subqEnd, subqInterval)
 	newEv := &evaluator{
 		startTimestamp:           subqStart,
@@ -1989,10 +1985,6 @@ func (ev *evaluator) runSubquery(ctx context.Context, e *parser.SubqueryExpr) (p
 
 // evalSubquery evaluates given SubqueryExpr and returns an equivalent
 // evaluated MatrixSelector in its place. Note that the Name and LabelMatchers are not set.
-// Only PeakSamples and SamplesRead from the subquery are merged into the
-// parent; TotalSamples is intentionally not merged because the call/range-vector
-// caller will count samples again from the materialized matrix.
-//
 // outerOffset is durationMilliseconds(subq.OriginalOffset) so the merge can
 // shift child timestamps to match the parent step that consumes them.
 // outerRange is the outer call's selRange so the merge can drop subquery
@@ -2001,6 +1993,7 @@ func (ev *evaluator) runSubquery(ctx context.Context, e *parser.SubqueryExpr) (p
 func (ev *evaluator) evalSubquery(ctx context.Context, subq *parser.SubqueryExpr, outerOffset, outerRange int64) (*parser.MatrixSelector, int, annotations.Annotations) {
 	val, childStats, ws := ev.runSubquery(ctx, subq)
 	ev.samplesStats.UpdatePeakFromSubquery(childStats)
+	ev.samplesStats.MergeTotalSamplesFromSubquery(childStats, ev.startTimestamp, ev.interval, ev.numSteps(), outerOffset, outerRange, subq.Timestamp != nil)
 	ev.samplesStats.MergeSamplesReadFromSubquery(childStats, ev.startTimestamp, ev.interval, ev.numSteps(), outerOffset, outerRange)
 	mat := val.(Matrix)
 	vs := &parser.VectorSelector{

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -1152,7 +1152,7 @@ load 10s
 			Query:        "metricWith1SampleEvery10Seconds[60s:5s]",
 			Start:        time.Unix(201, 0),
 			PeakSamples:  12,
-			TotalSamples: 12, // 1 sample per query * 12 queries (60/5)
+			TotalSamples: 12, // 1 sample per query * 12 queries (60/5).
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
 			},
@@ -1165,7 +1165,7 @@ load 10s
 			Query:        "metricWith1SampleEvery10Seconds[60s:5s] offset 10s",
 			Start:        time.Unix(201, 0),
 			PeakSamples:  12,
-			TotalSamples: 12, // 1 sample per query * 12 queries (60/5)
+			TotalSamples: 12, // 1 sample per query * 12 queries (60/5).
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
 				201000: 12,
 			},
@@ -1178,9 +1178,9 @@ load 10s
 			Query:        "max_over_time(metricWith3SampleEvery10Seconds[60s:5s])",
 			Start:        time.Unix(201, 0),
 			PeakSamples:  51,
-			TotalSamples: 36, // 3 sample per query * 12 queries (60/5)
+			TotalSamples: 72, // 36 subquery input samples + 36 materialized samples.
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 36,
+				201000: 72,
 			},
 			SamplesRead: 36,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1191,9 +1191,9 @@ load 10s
 			Query:        "sum(max_over_time(metricWith3SampleEvery10Seconds[60s:5s])) + sum(max_over_time(metricWith3SampleEvery10Seconds[60s:5s]))",
 			Start:        time.Unix(201, 0),
 			PeakSamples:  52,
-			TotalSamples: 72, // 2 * (3 sample per query * 12 queries (60/5))
+			TotalSamples: 144, // 2 * (36 subquery input samples + 36 materialized samples).
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 72,
+				201000: 144,
 			},
 			SamplesRead: 72,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1413,17 +1413,59 @@ load 10s
 			},
 		},
 		{
+			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[60s])",
+			Start:        time.Unix(201, 0),
+			End:          time.Unix(231, 0),
+			Interval:     10 * time.Second,
+			PeakSamples:  10,
+			TotalSamples: 24, // 6 samples in each 60s aggregation window * 4 steps.
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+				211000: 6,
+				221000: 6,
+				231000: 6,
+			},
+			SamplesRead: 9,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+				211000: 1,
+				221000: 1,
+				231000: 1,
+			},
+		},
+		{
+			Query:        "last_over_time(sum_over_time(metricWith1SampleEvery10Seconds[60s])[10s:10s])",
+			Start:        time.Unix(201, 0),
+			End:          time.Unix(231, 0),
+			Interval:     10 * time.Second,
+			PeakSamples:  10,
+			TotalSamples: 28, // 1 subquery result point + 6 underlying input points per step.
+			TotalSamplesPerStep: stats.TotalSamplesPerStep{
+				201000: 7,
+				211000: 7,
+				221000: 7,
+				231000: 7,
+			},
+			SamplesRead: 9,
+			SamplesReadPerStep: stats.TotalSamplesPerStep{
+				201000: 6,
+				211000: 1,
+				221000: 1,
+				231000: 1,
+			},
+		},
+		{
 			Query:        "max_over_time(metricWith3SampleEvery10Seconds[60s:5s])",
 			Start:        time.Unix(201, 0),
 			End:          time.Unix(220, 0),
 			Interval:     5 * time.Second,
 			PeakSamples:  69,
-			TotalSamples: 144, // 3 sample per query * 12 queries (60/5) * 4 steps
+			TotalSamples: 288, // 144 materialized samples + 144 subquery input samples.
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 36,
-				206000: 36,
-				211000: 36,
-				216000: 36,
+				201000: 72,
+				206000: 72,
+				211000: 72,
+				216000: 72,
 			},
 			SamplesRead: 45,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1439,12 +1481,12 @@ load 10s
 			End:          time.Unix(220, 0),
 			Interval:     5 * time.Second,
 			PeakSamples:  31,
-			TotalSamples: 48, // 1 sample per query * 12 queries (60/5) * 4 steps
+			TotalSamples: 96, // 48 materialized samples + 48 subquery input samples.
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 12,
-				206000: 12,
-				211000: 12,
-				216000: 12,
+				201000: 24,
+				206000: 24,
+				211000: 24,
+				216000: 24,
 			},
 			SamplesRead: 15,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1460,12 +1502,12 @@ load 10s
 			End:          time.Unix(220, 0),
 			Interval:     5 * time.Second,
 			PeakSamples:  31,
-			TotalSamples: 48, // 1 sample per query * 12 queries (60/5) * 4 steps
+			TotalSamples: 96, // 48 materialized samples + 48 subquery input samples.
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 12,
-				206000: 12,
-				211000: 12,
-				216000: 12,
+				201000: 24,
+				206000: 24,
+				211000: 24,
+				216000: 24,
 			},
 			SamplesRead: 15,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1481,12 +1523,12 @@ load 10s
 			End:          time.Unix(220, 0),
 			Interval:     5 * time.Second,
 			PeakSamples:  73,
-			TotalSamples: 288, // 2 * (3 sample per query * 12 queries (60/5) * 4 steps)
+			TotalSamples: 576, // 288 materialized samples + 288 subquery input samples.
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 72,
-				206000: 72,
-				211000: 72,
-				216000: 72,
+				201000: 144,
+				206000: 144,
+				211000: 144,
+				216000: 144,
 			},
 			SamplesRead: 90,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1502,12 +1544,12 @@ load 10s
 			End:          time.Unix(220, 0),
 			Interval:     5 * time.Second,
 			PeakSamples:  69,
-			TotalSamples: 192, // (1 sample per query * 12 queries (60/5) + 3 sample per query * 12 queries (60/5)) * 4 steps
+			TotalSamples: 384, // 192 materialized samples + 192 subquery input samples.
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 48,
-				206000: 48,
-				211000: 48,
-				216000: 48,
+				201000: 96,
+				206000: 96,
+				211000: 96,
+				216000: 96,
 			},
 			SamplesRead: 60,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1523,9 +1565,9 @@ load 10s
 			Query:        "max_over_time(metricWith1SampleEvery10Seconds[20s:10s])",
 			Start:        time.Unix(201, 0),
 			PeakSamples:  5,
-			TotalSamples: 2,
+			TotalSamples: 4,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 2,
+				201000: 4,
 			},
 			SamplesRead: 2,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1538,9 +1580,9 @@ load 10s
 			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[30s:30s])",
 			Start:        time.Unix(90, 0),
 			PeakSamples:  3,
-			TotalSamples: 1,
+			TotalSamples: 2,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				90000: 1,
+				90000: 2,
 			},
 			SamplesRead: 1,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1553,9 +1595,9 @@ load 10s
 			Query:        "max_over_time(metricWith1SampleEvery10Seconds[30s:2m])",
 			Start:        time.Unix(240, 0),
 			PeakSamples:  3,
-			TotalSamples: 1,
+			TotalSamples: 2,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 1,
+				240000: 2,
 			},
 			SamplesRead: 1,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1570,10 +1612,10 @@ load 10s
 			End:          time.Unix(231, 0),
 			Interval:     30 * time.Second,
 			PeakSamples:  11,
-			TotalSamples: 6,
+			TotalSamples: 12,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 3,
-				231000: 3,
+				201000: 6,
+				231000: 6,
 			},
 			SamplesRead: 6,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1590,15 +1632,15 @@ load 10s
 			End:          time.Unix(261, 0),
 			Interval:     10 * time.Second,
 			PeakSamples:  17,
-			TotalSamples: 14,
+			TotalSamples: 28,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 2,
-				211000: 2,
-				221000: 2,
-				231000: 2,
-				241000: 2,
-				251000: 2,
-				261000: 2,
+				201000: 4,
+				211000: 4,
+				221000: 4,
+				231000: 4,
+				241000: 4,
+				251000: 4,
+				261000: 4,
 			},
 			SamplesRead: 8,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1623,10 +1665,10 @@ load 10s
 			End:          time.Unix(261, 0),
 			Interval:     1 * time.Minute,
 			PeakSamples:  14,
-			TotalSamples: 6,
+			TotalSamples: 12,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 3,
-				261000: 3,
+				201000: 6,
+				261000: 6,
 			},
 			SamplesRead: 6,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1640,9 +1682,9 @@ load 10s
 			Query:        "histogram_count(max_over_time(metricWith1HistogramEvery10Seconds[20s:10s]))",
 			Start:        time.Unix(201, 0),
 			PeakSamples:  52,
-			TotalSamples: 26,
+			TotalSamples: 52,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				201000: 26,
+				201000: 52,
 			},
 			SamplesRead: 26,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1657,11 +1699,11 @@ load 10s
 			End:          time.Unix(240, 0),
 			Interval:     60 * time.Second,
 			PeakSamples:  117,
-			TotalSamples: 78,
+			TotalSamples: 156,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				120000: 26,
-				180000: 26,
-				240000: 26,
+				120000: 52,
+				180000: 52,
+				240000: 52,
 			},
 			SamplesRead: 52,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1678,15 +1720,15 @@ load 10s
 			End:          time.Unix(400, 0),
 			Interval:     30 * time.Second,
 			PeakSamples:  99,
-			TotalSamples: 126,
+			TotalSamples: 252,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				200000: 18,
-				230000: 18,
-				260000: 18,
-				290000: 18,
-				320000: 18,
-				350000: 18,
-				380000: 18,
+				200000: 36,
+				230000: 36,
+				260000: 36,
+				290000: 36,
+				320000: 36,
+				350000: 36,
+				380000: 36,
 			},
 			SamplesRead: 72,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1731,9 +1773,9 @@ load 10s
 			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[20s:10s] @ 200)",
 			Start:        time.Unix(250, 0),
 			PeakSamples:  11,
-			TotalSamples: 6,
+			TotalSamples: 12,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				250000: 6,
+				250000: 12,
 			},
 			SamplesRead: 6,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1746,9 +1788,9 @@ load 10s
 			Query:        "sum_over_time(metricWith1SampleEvery10Seconds[20s:10s] offset 1m)",
 			Start:        time.Unix(240, 0),
 			PeakSamples:  5,
-			TotalSamples: 2,
+			TotalSamples: 4,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 2,
+				240000: 4,
 			},
 			SamplesRead: 2,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1761,9 +1803,9 @@ load 10s
 			Query:        "sum_over_time(metricWith3SampleEvery10Seconds[1m:10s] @ 200 offset 1m)",
 			Start:        time.Unix(300, 0),
 			PeakSamples:  27,
-			TotalSamples: 18,
+			TotalSamples: 36,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				300000: 18,
+				300000: 36,
 			},
 			SamplesRead: 18,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1776,9 +1818,9 @@ load 10s
 			Query:        "sum_over_time(max_over_time(metricWith3SampleEvery10Seconds[60s] @ 300)[5m:1m] @ 600)[10m:2m]",
 			Start:        time.Unix(800, 0),
 			PeakSamples:  23,
-			TotalSamples: 75,
+			TotalSamples: 525,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				800000: 75,
+				800000: 525,
 			},
 			SamplesRead: 18,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{
@@ -1787,14 +1829,14 @@ load 10s
 		},
 
 		// Outer subquery wrapping inner range-vector (evalSubquery path):
-		// SamplesRead > TotalSamples because inner subquery reads more data than it surfaces.
+		// TotalSamples includes the inner range-vector windows and the outer materialized samples.
 		{
 			Query:        "rate(sum_over_time(metricWith1SampleEvery10Seconds[30s])[1m:30s])",
 			Start:        time.Unix(240, 0),
 			PeakSamples:  5,
-			TotalSamples: 2,
+			TotalSamples: 8,
 			TotalSamplesPerStep: stats.TotalSamplesPerStep{
-				240000: 2,
+				240000: 8,
 			},
 			SamplesRead: 6,
 			SamplesReadPerStep: stats.TotalSamplesPerStep{

--- a/util/stats/query_stats.go
+++ b/util/stats/query_stats.go
@@ -414,10 +414,53 @@ func NewChildWithStepTracking(start, end, interval int64) *QuerySamples {
 	return qs
 }
 
-// MergeSamplesReadFromSubquery merges only SamplesRead and SamplesReadPerStep from
-// the child (subquery) into the parent. TotalSamples and TotalSamplesPerStep are
-// not merged, because the outer range-eval loop already counts those when it
-// iterates over the pre-computed matrix. The child must have per-step tracking
+// MergeTotalSamplesFromSubquery merges TotalSamples and TotalSamplesPerStep from
+// the child (subquery) into the parent. For range-vector functions, each parent
+// step counts the full subquery window it consumes. The child must have per-step
+// tracking enabled (callers should construct it via NewChildWithStepTracking).
+func (qs *QuerySamples) MergeTotalSamplesFromSubquery(child *QuerySamples, parentStart, parentInterval int64, parentNumSteps int, outerOffset, outerRange int64, reusedByParentSteps bool) {
+	if qs == nil || child == nil {
+		return
+	}
+	if parentNumSteps <= 1 || outerRange <= 0 {
+		qs.TotalSamples += child.TotalSamples
+		if qs.TotalSamplesPerStep != nil {
+			qs.TotalSamplesPerStep[0] += child.TotalSamples
+		}
+		return
+	}
+
+	if reusedByParentSteps {
+		for parentStep := range parentNumSteps {
+			qs.TotalSamples += child.TotalSamples
+			if qs.TotalSamplesPerStep != nil {
+				qs.TotalSamplesPerStep[parentStep] += child.TotalSamples
+			}
+		}
+		return
+	}
+
+	for parentStep := range parentNumSteps {
+		parentTs := parentStart + int64(parentStep)*parentInterval
+		for k, n := range child.TotalSamplesPerStep {
+			if n == 0 {
+				continue
+			}
+			tk := child.StartTimestamp + int64(k)*child.Interval + outerOffset
+			if tk <= parentTs-outerRange || tk > parentTs {
+				continue
+			}
+
+			qs.TotalSamples += n
+			if qs.TotalSamplesPerStep != nil {
+				qs.TotalSamplesPerStep[parentStep] += n
+			}
+		}
+	}
+}
+
+// MergeSamplesReadFromSubquery merges SamplesRead and SamplesReadPerStep from
+// the child (subquery) into the parent. The child must have per-step tracking
 // enabled (callers should construct it via NewChildWithStepTracking).
 //
 // parentStart, parentInterval and parentNumSteps describe the parent's step
@@ -459,21 +502,9 @@ func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples, parent
 		if n == 0 {
 			continue
 		}
-		tk := child.StartTimestamp + int64(k)*child.Interval + outerOffset
-
-		outerStep := 0
-		if tk > parentStart {
-			outerStep = int((tk - parentStart + parentInterval - 1) / parentInterval)
-		}
-		if outerStep >= parentNumSteps {
-			outerStep = parentNumSteps - 1
-		}
-
-		if outerRange > 0 {
-			parentTs := parentStart + int64(outerStep)*parentInterval
-			if tk <= parentTs-outerRange {
-				continue
-			}
+		outerStep, ok := subqueryStep(child.StartTimestamp+int64(k)*child.Interval, parentStart, parentInterval, parentNumSteps, outerOffset, outerRange)
+		if !ok {
+			continue
 		}
 
 		qs.SamplesRead += n
@@ -481,6 +512,27 @@ func (qs *QuerySamples) MergeSamplesReadFromSubquery(child *QuerySamples, parent
 			qs.SamplesReadPerStep[outerStep] += n
 		}
 	}
+}
+
+func subqueryStep(childTs, parentStart, parentInterval int64, parentNumSteps int, outerOffset, outerRange int64) (int, bool) {
+	tk := childTs + outerOffset
+
+	outerStep := 0
+	if tk > parentStart {
+		outerStep = int((tk - parentStart + parentInterval - 1) / parentInterval)
+	}
+	if outerStep >= parentNumSteps {
+		outerStep = parentNumSteps - 1
+	}
+
+	if outerRange > 0 {
+		parentTs := parentStart + int64(outerStep)*parentInterval
+		if tk <= parentTs-outerRange {
+			return 0, false
+		}
+	}
+
+	return outerStep, true
 }
 
 func (qs *QueryTimers) GetSpanTimer(ctx context.Context, qt QueryTiming, observers ...prometheus.Observer) (*SpanTimer, context.Context) {


### PR DESCRIPTION
## Summary

Count the samples processed by a subquery's inner evaluation in the parent query's `TotalSamples` / `TotalSamplesPerStep` statistics.

- **`evalSubquery`** now merges the child's total-sample stats into the parent via a new `MergeTotalSamplesFromSubquery`, in addition to the peak and samples-read stats it already absorbed.
- **`MergeTotalSamplesFromSubquery`** attributes each subquery window to the parent step that consumes it, mirroring the existing samples-read attribution. The per-step attribution logic is factored into a shared `subqueryStep` helper used by both merges.

## Problem

`evalSubquery` previously merged only `PeakSamples` and `SamplesRead` from a subquery child into the parent. `TotalSamples` was intentionally skipped on the assumption that the outer range-vector caller re-counts the materialized matrix. As a result the work done inside the subquery -- the samples its inner query processes to produce each step -- was never reflected in `TotalSamples`, so subquery-backed range evaluations under-reported the samples they consumed.

The undercounting grows with nesting. Two new test cases in `promql/engine_test.go` show the effect:

- `sum_over_time(metricWith1SampleEvery10Seconds[60s])` on its own reports `TotalSamples: 24` (6 samples per 60s window * 4 steps).
- Wrapping that exact expression in a `[10s:10s]` subquery, `last_over_time(sum_over_time(metricWith1SampleEvery10Seconds[60s])[10s:10s])`, used to report only the 4 materialized points and drop the 24 samples of real work the inner query still performs. With the fix it reports `TotalSamples: 28` (24 inner input samples + 4 materialized points).

The doubly-nested case `sum_over_time(max_over_time(metricWith3SampleEvery10Seconds[60s] @ 300)[5m:1m] @ 600)[10m:2m]` is more extreme: `TotalSamples` goes from `75` to `525`, a 7x correction, because each layer's inner work was previously discarded.

## Solution

Merge the subquery child's `TotalSamples` / `TotalSamplesPerStep` into the parent. Each parent step is charged for the subquery window it consumes:

- Single-step / instant queries (`parentNumSteps <= 1` or `outerRange <= 0`) fold the child total into step 0.
- When the subquery matrix is reused across parent steps (`subq.Timestamp != nil`, e.g. the `@` modifier), every parent step is charged the full child total.
- Otherwise each child per-step bucket is attributed to the parent step whose window `(parentTs - outerRange, parentTs]` contains it.

`TotalSamples` now reflects both the subquery's inner input samples and the outer function's materialized samples, consistent with how a non-subquery range-vector counts the samples it processes.

## Test plan

- [x] `promql/engine_test.go` `TotalSamples` / `TotalSamplesPerStep` expectations updated across the subquery cases; added coverage for a bare `sum_over_time([60s])` baseline and a `last_over_time(...[10s:10s])` nested subquery.
- [x] `go test ./promql/... ./util/stats/...`

```release-notes
[CHANGE] PromQL: Subquery samples are now included in the query TotalSamples and TotalSamplesPerStep statistics.
```
