### PR TITLE
rules: fix state restoration for firing alerts with short hold durations

### DIFF
--- a/rules/group.go
+++ b/rules/group.go
@@ -763,15 +763,7 @@ func (g *Group) RestoreForState(ts time.Time) {
 		if !ok {
 			continue
 		}
-
 		alertHoldDuration := alertRule.HoldDuration()
-		if alertHoldDuration < g.opts.ForGracePeriod {
-			// If alertHoldDuration is already less than grace period, we would not
-			// like to make it wait for `g.opts.ForGracePeriod` time before firing.
-			// Hence we skip restoration, which will make it wait for alertHoldDuration.
-			alertRule.SetRestored(true)
-			continue
-		}
 
 		sset, err := alertRule.QueryForStateSeries(g.opts.Context, q)
 		if err != nil {
@@ -855,11 +847,12 @@ func (g *Group) RestoreForState(ts time.Time) {
 				downDuration := ts.Sub(downAt)
 				restoredActiveAt = restoredActiveAt.Add(downDuration)
 			}
-
-			a.ActiveAt = restoredActiveAt
-			g.logger.Debug("'for' state restored",
-				labels.AlertName, alertRule.Name(), "restored_time", a.ActiveAt.Format(time.RFC850),
-				"labels", a.Labels.String())
+			if !restoredActiveAt.After(ts) {
+				a.ActiveAt = restoredActiveAt
+				g.logger.Debug("'for' state restored",
+					labels.AlertName, alertRule.Name(), "restored_time", a.ActiveAt.Format(time.RFC850),
+					"labels", a.Labels.String())
+			}
 		})
 
 		alertRule.SetRestored(true)

--- a/rules/manager_test.go
+++ b/rules/manager_test.go
@@ -534,6 +534,94 @@ func TestForStateRestore(t *testing.T) {
 	}
 }
 
+func TestForStateRestoreAlreadyFiringShortHold(t *testing.T) {
+	storage := promqltest.LoadedStorage(t, `
+		load 5m
+		http_requests{job="app-server", instance="0", group="canary"}	75  85 50 0 0 25 0 0 40 0 120
+	`)
+
+	expr, err := testParser.ParseExpr(`http_requests{group="canary", job="app-server"} < 100`)
+	require.NoError(t, err)
+
+	ng := testEngine(t)
+	opts := &ManagerOptions{
+		QueryFunc:       EngineQueryFunc(ng, storage),
+		Appendable:      storage,
+		Queryable:       storage,
+		Context:         context.Background(),
+		Logger:          promslog.NewNopLogger(),
+		NotifyFunc:      func(context.Context, string, ...*Alert) {},
+		OutageTolerance: 30 * time.Minute,
+		ForGracePeriod:  10 * time.Minute,
+	}
+
+	alertForDuration := 5 * time.Minute // Shorter than ForGracePeriod of 10m
+	rule := NewAlertingRule(
+		"HTTPRequestRateLow",
+		expr,
+		alertForDuration,
+		0,
+		labels.FromStrings("severity", "critical"),
+		labels.EmptyLabels(), labels.EmptyLabels(), "", true, nil,
+	)
+
+	group := NewGroup(GroupOptions{
+		Name:          "default",
+		Interval:      time.Second,
+		Rules:         []Rule{rule},
+		ShouldRestore: true,
+		Opts:          opts,
+	})
+
+	baseTime := time.Unix(0, 0).UTC()
+	// Run at 0m and 5m.
+	// At 0m, alert goes to StatePending.
+	// At 5m, alert goes to StateFiring (since 5m >= alertForDuration).
+	group.Eval(context.TODO(), baseTime)
+	group.Eval(context.TODO(), baseTime.Add(5*time.Minute))
+
+	// Verify it is firing before restart.
+	require.Len(t, rule.ActiveAlerts(), 1)
+	require.Equal(t, StateFiring, rule.ActiveAlerts()[0].State)
+
+	// Now simulate Prometheus restart.
+	newRule := NewAlertingRule(
+		"HTTPRequestRateLow",
+		expr,
+		alertForDuration,
+		0,
+		labels.FromStrings("severity", "critical"),
+		labels.EmptyLabels(), labels.EmptyLabels(), "", false, nil,
+	)
+	newGroup := NewGroup(GroupOptions{
+		Name:          "default",
+		Interval:      time.Second,
+		Rules:         []Rule{newRule},
+		ShouldRestore: true,
+		Opts:          opts,
+	})
+
+	restoreTime := baseTime.Add(15 * time.Minute)
+	// First eval before restoration to create the alert instances.
+	newGroup.Eval(context.TODO(), restoreTime)
+
+	// Verify the alert is newly created in StatePending state.
+	require.Len(t, newRule.ActiveAlerts(), 1)
+	require.Equal(t, StatePending, newRule.ActiveAlerts()[0].State)
+	require.Equal(t, restoreTime, newRule.ActiveAlerts()[0].ActiveAt)
+
+	// Perform state restoration.
+	newGroup.RestoreForState(restoreTime)
+
+	// Verify that restored ActiveAt is correct (original ActiveAt was baseTime, i.e., 0).
+	require.Len(t, newRule.ActiveAlerts(), 1)
+	require.Equal(t, baseTime, newRule.ActiveAlerts()[0].ActiveAt)
+
+	// Evaluate again, this should transition the alert to StateFiring immediately.
+	newGroup.Eval(context.TODO(), restoreTime.Add(time.Second))
+	require.Equal(t, StateFiring, newRule.ActiveAlerts()[0].State)
+}
+
 func TestStaleness(t *testing.T) {
 	for _, queryOffset := range []time.Duration{0, time.Minute} {
 		st := teststorage.New(t)


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #15175

#### Description of changes:
Currently, when Prometheus starts up, it attempts to restore the `for` state of active alerts from storage. However, it completely skips restoration for any alerting rule whose hold duration (`for` time) is shorter than the configured grace period (default `10m`). 

This creates a bug where if an alert has a short `for` duration (e.g. `5m`) and was already `firing` when Prometheus went down, it gets reset back to the `pending` state and has to wait the full `5m` from scratch before firing again. 

To fix this, this PR:
1. Removes the pre-query check that skips rules with short hold durations.
2. Applies the restored state conditionally: we only update the active time `ActiveAt` if the restored active time is not in the future (relative to the startup evaluation time). 

This guarantees that:
- Firing alerts (whose restored times are in the past) are successfully restored and fire immediately in the next evaluation.
- Pending alerts (whose grace-period shifted times would be in the future) are not restored, allowing them to fire sooner by starting from scratch.

I have also added a unit test `TestForStateRestoreAlreadyFiringShortHold` in `rules/manager_test.go` to verify this fix.

#### Release notes for end users:
```release-notes
[BUGFIX] Rules: Fix state restoration on restart for firing alerts with 'for' durations shorter than the grace period.