### PR TITLE
fix(labels): case-insensitive regex prefix/suffix matching breaks on length-changing case folds

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -775,12 +775,13 @@ type literalPrefixInsensitiveStringMatcher struct {
 }
 
 func (m *literalPrefixInsensitiveStringMatcher) Matches(s string) bool {
-	if !hasPrefixCaseInsensitive(s, m.prefix) {
+	prefixLen, ok := prefixCaseInsensitiveMatchLen(s, m.prefix)
+	if !ok {
 		return false
 	}
 
 	// Ensure the right side matches.
-	return m.right.Matches(s[len(m.prefix):])
+	return m.right.Matches(s[prefixLen:])
 }
 
 // literalSuffixStringMatcher matches a string with the given literal suffix and left side matcher.
@@ -794,15 +795,22 @@ type literalSuffixStringMatcher struct {
 
 func (m *literalSuffixStringMatcher) Matches(s string) bool {
 	// Ensure the suffix matches.
-	if m.suffixCaseSensitive && !strings.HasSuffix(s, m.suffix) {
-		return false
+	if m.suffixCaseSensitive {
+		if !strings.HasSuffix(s, m.suffix) {
+			return false
+		}
+
+		// Ensure the left side matches.
+		return m.left.Matches(s[:len(s)-len(m.suffix)])
 	}
-	if !m.suffixCaseSensitive && !hasSuffixCaseInsensitive(s, m.suffix) {
+
+	suffixLen, ok := suffixCaseInsensitiveMatchLen(s, m.suffix)
+	if !ok {
 		return false
 	}
 
 	// Ensure the left side matches.
-	return m.left.Matches(s[:len(s)-len(m.suffix)])
+	return m.left.Matches(s[:len(s)-suffixLen])
 }
 
 // emptyStringMatcher matches an empty string.
@@ -1201,11 +1209,111 @@ func findEqualOrPrefixStringMatchers(input StringMatcher, equalMatcherCallback f
 }
 
 func hasPrefixCaseInsensitive(s, prefix string) bool {
-	return len(s) >= len(prefix) && strings.EqualFold(s[0:len(prefix)], prefix)
+	_, ok := prefixCaseInsensitiveMatchLen(s, prefix)
+	return ok
 }
 
-func hasSuffixCaseInsensitive(s, suffix string) bool {
-	return len(s) >= len(suffix) && strings.EqualFold(s[len(s)-len(suffix):], suffix)
+// prefixCaseInsensitiveMatchLen checks whether s begins with a prefix that is
+// equal to prefix under Unicode simple case folding (the same folding the
+// regexp engine applies for case-insensitive matching). It returns the length
+// in bytes of that prefix in s, and whether such a prefix exists.
+//
+// The returned length can differ from len(prefix) because simple case folding
+// does not preserve the encoded length of a rune, e.g. 'K' (the Kelvin sign,
+// U+212A, 3 bytes) folds with 'k' (1 byte). For this reason a simple
+// strings.EqualFold(s[:len(prefix)], prefix) check is not equivalent: it would
+// slice s in the middle of a rune and fail to match.
+func prefixCaseInsensitiveMatchLen(s, prefix string) (int, bool) {
+	// Fast path: process ASCII characters in lockstep while we can.
+	i := 0
+	for ; i < len(prefix) && i < len(s); i++ {
+		pc, sc := prefix[i], s[i]
+		if pc >= utf8.RuneSelf || sc >= utf8.RuneSelf {
+			break
+		}
+		if pc != sc && lowerASCII(pc) != lowerASCII(sc) {
+			return 0, false
+		}
+	}
+	if i == len(prefix) {
+		return i, true
+	}
+
+	// Slow path: at least one of the next characters is non-ASCII, so runes
+	// must be compared one by one under simple case folding. Both prefix[i:]
+	// and s[i:] start at a rune boundary because the fast path above only
+	// consumed ASCII bytes from both.
+	n := i
+	for _, pr := range prefix[i:] {
+		if n >= len(s) {
+			return 0, false
+		}
+		sr, size := utf8.DecodeRuneInString(s[n:])
+		if sr != pr && !runeFoldEqual(sr, pr) {
+			return 0, false
+		}
+		n += size
+	}
+	return n, true
+}
+
+// suffixCaseInsensitiveMatchLen is the equivalent of
+// prefixCaseInsensitiveMatchLen for suffixes: it checks whether s ends with a
+// suffix that is equal to suffix under Unicode simple case folding, and
+// returns the length in bytes of that suffix in s.
+func suffixCaseInsensitiveMatchLen(s, suffix string) (int, bool) {
+	// Fast path: process ASCII characters in lockstep while we can. Bytes of
+	// multi-byte runes are >= utf8.RuneSelf, so this cannot stop in the middle
+	// of a rune.
+	i, j := len(suffix), len(s)
+	for i > 0 && j > 0 {
+		pc, sc := suffix[i-1], s[j-1]
+		if pc >= utf8.RuneSelf || sc >= utf8.RuneSelf {
+			break
+		}
+		if pc != sc && lowerASCII(pc) != lowerASCII(sc) {
+			return 0, false
+		}
+		i--
+		j--
+	}
+	if i == 0 {
+		return len(s) - j, true
+	}
+
+	// Slow path: compare the remaining runes one by one, from the end, under
+	// simple case folding.
+	for i > 0 {
+		if j == 0 {
+			return 0, false
+		}
+		pr, prSize := utf8.DecodeLastRuneInString(suffix[:i])
+		sr, srSize := utf8.DecodeLastRuneInString(s[:j])
+		if sr != pr && !runeFoldEqual(sr, pr) {
+			return 0, false
+		}
+		i -= prSize
+		j -= srSize
+	}
+	return len(s) - j, true
+}
+
+func lowerASCII(c byte) byte {
+	if 'A' <= c && c <= 'Z' {
+		return c + 'a' - 'A'
+	}
+	return c
+}
+
+// runeFoldEqual tells whether two distinct runes are equal under Unicode
+// simple case folding.
+func runeFoldEqual(a, b rune) bool {
+	for r := unicode.SimpleFold(a); r != a; r = unicode.SimpleFold(r) {
+		if r == b {
+			return true
+		}
+	}
+	return false
 }
 
 func containsInOrder(s string, contains []string) bool {

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -106,6 +106,15 @@ var (
 		"((.*))(?i:f)((.*))o((.*))o((.*))",
 		"((.*))f((.*))(?i:o)((.*))o((.*))",
 		"(.*0.*)",
+		// Case-insensitive literal prefixes and suffixes containing runes
+		// whose case folding changes their encoded length: 'k' folds with
+		// 'K' (Kelvin sign, U+212A) and 's' folds with 'ſ' (long s, U+017F).
+		"(?i)k.*",
+		"(?i)k-(a|b)",
+		"(?i)(ka.+|kb.+)",
+		".*(?i:k)",
+		"a.*(?i:sk)",
+		"(?i:some)-pattern.*",
 	}
 	values = []string{
 		"foo", " foo bar", "bar", "buzz\nbar", "bar foo", "bfoo", "\n", "\nfoo", "foo\n", "hello foo world", "hello foo\n world", "",
@@ -121,6 +130,10 @@ var (
 
 		// Values matching / not matching the test regexps on long alternations.
 		"zQPbMkNO", "zQPbMkNo", "jyyfj00j0061", "jyyfj00j006", "jyyfj00j00612", "NNSPdvMi", "NNSPdvMiXXX", "NNSPdvMixxx", "nnSPdvMi", "nnSPdvMiXXX",
+
+		// Values with runes whose case folding changes their encoded length.
+		"\u212a", "\u212aa", "\u212ab", "\u212a-a", "\u212a-abc", "\u212aelvin", "abc\u212a", "a\u212a", "axſk", "axs\u212a",
+		"ſome-pattern", "SOME-pattern", "ſk", "kſ",
 
 		// Invalid utf8
 		"\xfefoo",
@@ -1280,6 +1293,16 @@ func TestLiteralPrefixInsensitiveStringMatcher(t *testing.T) {
 	require.False(t, m.Matches("marco"))
 	require.False(t, m.Matches("ma"))
 	require.True(t, m.Matches("mAr"))
+
+	// The prefix of the matched string can have a different length than the
+	// literal prefix due to Unicode simple case folding ('k' folds with the
+	// Kelvin sign 'K', U+212A).
+	m = &literalPrefixInsensitiveStringMatcher{prefix: "kar", right: &equalStringMatcher{s: "co", caseSensitive: false}}
+	require.True(t, m.Matches("karco"))
+	require.True(t, m.Matches("\u212aarco"))
+	require.True(t, m.Matches("\u212aarCO"))
+	require.False(t, m.Matches("\u212aar"))
+	require.False(t, m.Matches("\u212aarcopracucci"))
 }
 
 func TestLiteralSuffixStringMatcher(t *testing.T) {
@@ -1308,6 +1331,16 @@ func TestLiteralSuffixStringMatcher(t *testing.T) {
 	require.True(t, m.Matches("marCO"))
 	require.False(t, m.Matches("mar"))
 	require.False(t, m.Matches("marcopracucci"))
+
+	// The suffix of the matched string can have a different length than the
+	// literal suffix due to Unicode simple case folding ('k' folds with the
+	// Kelvin sign 'K', U+212A).
+	m = &literalSuffixStringMatcher{left: &equalStringMatcher{s: "mar", caseSensitive: false}, suffix: "ck", suffixCaseSensitive: false}
+	require.True(t, m.Matches("marck"))
+	require.True(t, m.Matches("marc\u212a"))
+	require.True(t, m.Matches("MARc\u212a"))
+	require.False(t, m.Matches("marc"))
+	require.False(t, m.Matches("c\u212a"))
 }
 
 func TestHasPrefixCaseInsensitive(t *testing.T) {
@@ -1319,6 +1352,14 @@ func TestHasPrefixCaseInsensitive(t *testing.T) {
 
 	require.False(t, hasPrefixCaseInsensitive("marco", "a"))
 	require.False(t, hasPrefixCaseInsensitive("marco", "abcdefghi"))
+
+	// Case folding can change the encoded length of a rune, e.g. 'k' folds
+	// with 'K' (Kelvin sign, U+212A) and 's' folds with 'ſ' (long s, U+017F).
+	require.True(t, hasPrefixCaseInsensitive("\u212aelvin", "k"))
+	require.True(t, hasPrefixCaseInsensitive("\u212aelvin", "kel"))
+	require.True(t, hasPrefixCaseInsensitive("kelvin", "\u212a"))
+	require.True(t, hasPrefixCaseInsensitive("ſtreet", "st"))
+	require.False(t, hasPrefixCaseInsensitive("\u212aelvin", "s"))
 }
 
 func TestHasSuffixCaseInsensitive(t *testing.T) {

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -1362,12 +1362,72 @@ func TestHasPrefixCaseInsensitive(t *testing.T) {
 	require.False(t, hasPrefixCaseInsensitive("\u212aelvin", "s"))
 }
 
-func TestHasSuffixCaseInsensitive(t *testing.T) {
-	require.True(t, hasSuffixCaseInsensitive("marco", "rco"))
-	require.True(t, hasSuffixCaseInsensitive("marco", "RcO"))
-	require.True(t, hasSuffixCaseInsensitive("marco", "marco"))
-	require.False(t, hasSuffixCaseInsensitive("marco", "a"))
-	require.False(t, hasSuffixCaseInsensitive("marco", "abcdefghi"))
+func TestPrefixCaseInsensitiveMatchLen(t *testing.T) {
+	for _, c := range []struct {
+		s, prefix   string
+		expectedLen int
+		expectedOK  bool
+	}{
+		{"marco", "mar", 3, true},
+		{"mArco", "MaR", 3, true},
+		{"marco", "marco", 5, true},
+		{"mar", "marco", 0, false},
+		{"marco", "x", 0, false},
+		{"", "", 0, true},
+		{"marco", "", 0, true},
+		// The matched prefix of s can have a different length than the
+		// searched prefix due to Unicode simple case folding.
+		{"\u212aelvin", "k", 3, true},
+		{"\u212aelvin", "kel", 5, true},
+		{"kelvin", "\u212a", 1, true},
+		{"ſtreet", "st", 3, true},
+		{"streets", "ſt", 2, true},
+		{"ſſs", "sss", 5, true},
+		{"ſtreet", "str", 4, true},
+		{"\u212aelvin", "s", 0, false},
+		{"ſtreet", "sx", 0, false},
+		// Invalid UTF-8 is decoded to U+FFFD, which folds only with itself.
+		{"\xff", "\xff", 1, true},
+		{"\xffabc", "\xffab", 3, true},
+		{"\u212aelvin", "\xff", 0, false},
+	} {
+		n, ok := prefixCaseInsensitiveMatchLen(c.s, c.prefix)
+		require.Equal(t, c.expectedOK, ok, "s=%q prefix=%q", c.s, c.prefix)
+		require.Equal(t, c.expectedLen, n, "s=%q prefix=%q", c.s, c.prefix)
+	}
+}
+
+func TestSuffixCaseInsensitiveMatchLen(t *testing.T) {
+	for _, c := range []struct {
+		s, suffix   string
+		expectedLen int
+		expectedOK  bool
+	}{
+		{"marco", "rco", 3, true},
+		{"marco", "RcO", 3, true},
+		{"marco", "marco", 5, true},
+		{"rco", "marco", 0, false},
+		{"marco", "x", 0, false},
+		{"", "", 0, true},
+		{"marco", "", 0, true},
+		// The matched suffix of s can have a different length than the
+		// searched suffix due to Unicode simple case folding.
+		{"a\u212a", "k", 3, true},
+		{"drin\u212a", "ink", 5, true},
+		{"drink", "in\u212a", 3, true},
+		{"streetſ", "ts", 3, true},
+		{"ſſs", "sss", 5, true},
+		{"a\u212a", "s", 0, false},
+		{"streetſ", "tſt", 0, false},
+		// Invalid UTF-8 is decoded to U+FFFD, which folds only with itself.
+		{"\xff", "\xff", 1, true},
+		{"abc\xff", "bc\xff", 3, true},
+		{"a\u212a", "\xff", 0, false},
+	} {
+		n, ok := suffixCaseInsensitiveMatchLen(c.s, c.suffix)
+		require.Equal(t, c.expectedOK, ok, "s=%q suffix=%q", c.s, c.suffix)
+		require.Equal(t, c.expectedLen, n, "s=%q suffix=%q", c.s, c.suffix)
+	}
 }
 
 func TestContainsInOrder(t *testing.T) {


### PR DESCRIPTION
`FastRegexMatcher`'s case-insensitive literal prefix/suffix fast paths slice the input at `len(prefix)`/`len(suffix)` bytes before comparing with `strings.EqualFold`. Unicode simple case folding — which the regexp engine applies for `(?i)` matching — does not preserve encoded rune length: `k` folds with `K` (Kelvin sign, U+212A, 3 bytes) and `s` folds with `ſ` (long s, U+017F, 2 bytes). The slice cuts such runes in the middle, so the optimized matcher wrongly rejects values that its own fallback regexp matches:

- `(?i)k.*` does not match `"Kelvin"` (the prefilter path added in #18540),
- `(?i)(ka.+|kb.+)` does not match `"Ka"`, and
- `.*(?i:k)` does not match `"abcK"` (the `literalPrefixInsensitiveStringMatcher` / `literalSuffixStringMatcher` paths from #13843, present in stable releases).

In a query like `foo{bar=~"(?i)k.*"}` this silently drops matching series.

This PR replaces the byte-slicing checks with fold-aware prefix/suffix comparisons that walk runes under `unicode.SimpleFold` (with an ASCII lockstep fast path, like `EqualFold`) and return the number of input bytes actually consumed, so the right/left sub-matchers receive the correctly sliced remainder. The first commit adds tests exposing the bug (they fail on `main`); the second commit fixes it. The invariant asserted is the one the package's own oracle test already defines — `FastRegexMatcher.MatchString(v)` must agree with `regexp.MustCompile("^(?s:" + pattern + ")$").MatchString(v)`.

**Not addressed here** (pre-existing, separate component, happy to follow up): `equalMultiStringMapMatcher` (≥16 case-insensitive alternates) compares values via NFKD normalization (#14170), which both over- and under-matches relative to the regexp engine's simple folding, and its prefix-bucket keys are also byte-sliced.

Micro-benchmark of the changed helper (ASCII inputs): 30.7ns → 36.5ns per 4 calls; since the pre-filter gates a full `re.MatchString`, end-to-end impact is negligible.

> Disclosure: this bug was found and the fix authored with the assistance of an AI tool (Claude, Anthropic); all changes were human-reviewed and verified against the regexp-engine oracle.

```release-notes
[BUGFIX] PromQL: Fix case-insensitive regex label matchers dropping values whose case folding changes the encoded rune length (e.g. `(?i)k.*` not matching values starting with the Kelvin sign `K`).
```
