### PR TITLE
discovery/file: reject file_sd wildcard in non-final path segment on Windows

### DIFF
--- a/discovery/file/file.go
+++ b/discovery/file/file.go
@@ -40,7 +40,8 @@ import (
 )
 
 var (
-	patFileSDName = regexp.MustCompile(`^[^*]*(\*[^/]*)?\.(json|yml|yaml|JSON|YML|YAML)$`)
+	patFileSDName        = regexp.MustCompile(`^[^*]*(\*[^/]*)?\.(json|yml|yaml|JSON|YML|YAML)$`)
+	patFileSDNameWindows = regexp.MustCompile(`^[^*]*(\*[^/\\]*)?\.(json|yml|yaml|JSON|YML|YAML)$`)
 
 	// DefaultSDConfig is the default file SD configuration.
 	DefaultSDConfig = SDConfig{
@@ -89,8 +90,12 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if len(c.Files) == 0 {
 		return errors.New("file service discovery config must contain at least one path name")
 	}
+	pathPattern := patFileSDName
+	if filepath.Separator == '\\' {
+		pathPattern = patFileSDNameWindows
+	}
 	for _, name := range c.Files {
-		if !patFileSDName.MatchString(name) {
+		if !pathPattern.MatchString(name) {
 			return fmt.Errorf("path name %q is not valid for file discovery", name)
 		}
 	}

--- a/discovery/file/file_test.go
+++ b/discovery/file/file_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -328,6 +329,54 @@ func valid2Tg(file string) []*targetgroup.Group {
 			},
 			Source: fileSource(file, 2),
 		},
+	}
+}
+
+func TestSDConfigUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name:    "wildcard in final segment (slash)",
+			yaml:    "files:\n  - targets/*.json",
+			wantErr: false,
+		},
+		{
+			name:    "wildcard in final segment (backslash)",
+			yaml:    "files:\n  - targets\\*.json",
+			wantErr: false,
+		},
+		{
+			name:    "no wildcard",
+			yaml:    "files:\n  - /etc/prometheus/targets.yml",
+			wantErr: false,
+		},
+		{
+			name:    "wildcard in non-final segment (slash) is rejected",
+			yaml:    "files:\n  - /etc/prometheus/*/targets.json",
+			wantErr: true,
+		},
+		{
+			name:    "wildcard in non-final segment (backslash)",
+			yaml:    "files:\n  - C:\\prometheus\\*\\targets.json",
+			wantErr: filepath.Separator == '\\',
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var cfg SDConfig
+			err := yaml.Unmarshal([]byte(tt.yaml), &cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

No open issue tracks this; it is a self-contained behavioural bug found by code inspection.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] discovery/file: reject a file_sd `files` glob whose `*` is in a non-final path segment on Windows.
```

The `file_sd` validator ensures that `*` only appears in the final path segment, which lets `watchFiles` derive a static directory to watch. It previously recognized only `/` as a separator, so Windows paths such as `C:\prometheus\*\targets.json` passed validation and produced an invalid watch directory.

This adds a Windows-specific validation pattern that also treats `\` as a separator. Unix keeps the existing pattern because backslash is a legal filename character there.

The tests use `go.yaml.in/yaml/v3` and verify both separators, including the platform-specific behavior for backslash.