### PR TITLE
tsdb: fail the query instead of panicking when a series exhausts the OOO chunk ID space

### DIFF
--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -77,12 +77,36 @@ func (oh *HeadAndOOOIndexReader) Series(ref storage.SeriesRef, builder *labels.S
 	*chks = (*chks)[:0]
 
 	if s.ooo != nil {
+		if err := s.checkOOOChunkIDSpace(); err != nil {
+			return err
+		}
 		oh.headChunksBuf = getOOOSeriesChunks(s, oh.head.opts.UseXOR2FloatEncoding(), oh.head.opts.EnableHistogramSTEncoding.Load(), oh.mint, oh.maxt, oh.lastGarbageCollectedMmapRef, 0, true, oh.inoMint, chks, oh.headChunksBuf)
 	} else {
 		*chks, oh.headChunksBuf = appendSeriesChunks(s, oh.inoMint, oh.maxt, *chks, oh.headChunksBuf)
 	}
 	if cap(oh.headChunksBuf) > headChunksBufMaxCap {
 		oh.headChunksBuf = nil
+	}
+	return nil
+}
+
+// checkOOOChunkIDSpace returns an error if the series has exhausted its
+// out-of-order chunk ID space, so callers can fail the query instead of
+// panicking. firstOOOChunkID grows monotonically as OOO chunks are truncated and
+// is only reset when the series' OOO data fully drains (s.ooo becomes nil). A
+// series that stays continuously out-of-order can therefore exhaust the space,
+// which is the low 23 bits of the chunk ID (bit 23 is the oooChunkIDMask "is OOO"
+// flag). Once firstOOOChunkID+pos reaches oooChunkIDMask the ID collides with that
+// flag bit, and a little further on NewHeadChunkRef panics with "chunk ID exceeds
+// 3 bytes", crashing the whole process for a single bad series. Restarting the
+// TSDB re-derives firstOOOChunkID from the current (small) set of OOO chunks.
+//
+// s must be locked and s.ooo must be non-nil.
+func (s *memSeries) checkOOOChunkIDSpace() error {
+	// The highest position getOOOSeriesChunks encodes is the OOO head chunk at
+	// len(oooMmappedChunks); bounding that bounds every ref it can build.
+	if uint64(s.ooo.firstOOOChunkID)+uint64(len(s.ooo.oooMmappedChunks)) >= oooChunkIDMask {
+		return fmt.Errorf("series %d has exhausted its out-of-order chunk ID space (firstOOOChunkID=%d, oooMmappedChunks=%d, limit=%d); restart to reclaim it", s.ref, s.ooo.firstOOOChunkID, len(s.ooo.oooMmappedChunks), oooChunkIDMask)
 	}
 	return nil
 }
@@ -525,6 +549,9 @@ func (ir *OOOCompactionHeadIndexReader) Series(ref storage.SeriesRef, builder *l
 
 	if s.ooo == nil {
 		return nil
+	}
+	if err := s.checkOOOChunkIDSpace(); err != nil {
+		return err
 	}
 
 	getOOOSeriesChunks(s, ir.ch.head.opts.UseXOR2FloatEncoding(), ir.ch.head.opts.EnableHistogramSTEncoding.Load(), ir.ch.mint, ir.ch.maxt, 0, ir.ch.lastMmapRef, false, 0, chks, nil)

--- a/tsdb/ooo_head_read_test.go
+++ b/tsdb/ooo_head_read_test.go
@@ -375,6 +375,43 @@ func TestOOOHeadIndexReader_Series(t *testing.T) {
 	}
 }
 
+// TestOOOHeadIndexReader_Series_ChunkIDSpaceExhausted verifies that a series
+// whose out-of-order chunk ID space is exhausted (firstOOOChunkID grown close to
+// oooChunkIDMask) fails its query with an error instead of panicking inside
+// NewHeadChunkRef and crashing the whole process.
+func TestOOOHeadIndexReader_Series_ChunkIDSpaceExhausted(t *testing.T) {
+	s1Lset := labels.FromStrings("foo", "bar")
+	s1ID := uint64(1)
+
+	h, _ := newTestHead(t, 1000, compression.None, true)
+	defer func() {
+		require.NoError(t, h.Close())
+	}()
+	require.NoError(t, h.Init(0))
+
+	s1, _, _ := h.getOrCreate(s1ID, s1Lset, false)
+	s1.ooo = &memSeriesOOOFields{
+		// Simulate a series that has been continuously out-of-order long enough to
+		// exhaust the OOO chunk ID space. This value is past the point where
+		// NewHeadChunkRef would panic ("chunk ID exceeds 3 bytes") without the guard.
+		firstOOOChunkID: 1 << 24,
+	}
+	s1.ooo.oooMmappedChunks = append(s1.ooo.oooMmappedChunks, &mmappedChunk{
+		minTime: 100,
+		maxTime: 200,
+	})
+
+	ir := NewHeadAndOOOIndexReader(h, 0, 0, math.MaxInt64, 0)
+
+	var chks []chunks.Meta
+	var b labels.ScratchBuilder
+	var err error
+	require.NotPanics(t, func() {
+		err = ir.Series(storage.SeriesRef(s1ID), &b, &chks)
+	})
+	require.ErrorContains(t, err, "exhausted its out-of-order chunk ID space")
+}
+
 func TestOOOHeadChunkReader_LabelValues(t *testing.T) {
 	for name, scenario := range sampleTypeScenarios {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Adds a new test in the 1st commit that fails without the fix in the 2nd commit.

#### Which issue(s) does the PR fix:

N/A

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] TSDB: Return an error instead of panicking ("chunk ID exceeds 3 bytes") when a continuously out-of-order series exhausts its out-of-order chunk ID space.
```

#### Description

<details>
<summary>Claude's summary</summary>

## Problem

A single continuously out-of-order (OOO) series can crash the whole process with
`panic: chunk ID exceeds 3 bytes`, observed on an ingester serving `QueryStream`:

```text
panic: chunk ID exceeds 3 bytes
tsdb/chunks.NewHeadChunkRef(...)
tsdb.getOOOSeriesChunks(...)              tsdb/ooo_head_read.go
tsdb.(*HeadAndOOOIndexReader).Series(...) tsdb/ooo_head_read.go
tsdb.(*blockBaseSeriesSet).Next(...)      tsdb/querier.go
...
ingester.(*Ingester).QueryStream(...)     (mimir)
```

The panic is unrecovered, so it takes down the process; with RF3 reads + querier
retries, one poisoned series can crash-loop several ingesters. Same 24-bit limit /
panic string as the compaction-path crash in
[grafana/mimir#4541](https://github.com/grafana/mimir/issues/4541); this is the
read-path sibling.

## Root cause

OOO chunk IDs are `oooHeadChunkID(pos) = (firstOOOChunkID + pos) | oooChunkIDMask`,
with `oooChunkIDMask = 1 << 23` (`tsdb/head_read.go`). Bit 23 is an "is-OOO" flag,
so the counter really only has the **low 23 bits (~8.39M)**, not the full 24.

`firstOOOChunkID` grows monotonically — `+= removedOOO` on every OOO truncation
(`tsdb/head.go`) — and only resets when the series' OOO data fully drains
(`s.ooo = nil`). The existing guard in `tsdb/head_append.go`
(`len(oooMmappedChunks) >= oooChunkIDMask-1` → "Too many OOO chunks, dropping
data") bounds only the **live count** of m-mapped chunks, not the cumulative
`firstOOOChunkID`. So a long-lived, continuously-OOO series still drives
`firstOOOChunkID` past `oooChunkIDMask`: first the ID collides with the flag bit
(bit 23), then once `firstOOOChunkID + pos` reaches `2^24` `NewHeadChunkRef`
panics.

## Fix

`getOOOSeriesChunks` (which builds the OOO refs) returns a reusable `[]*memChunk`
buffer, not an error, so the guard can't live there. Both of its callers are
`Series` methods that *do* return `error`, and both propagate it as a normal query
failure:

- `HeadAndOOOIndexReader.Series` — the read/query path (the reported panic).
- `OOOCompactionHeadIndexReader.Series` — the **compaction path** (where
  grafana/mimir#4541 originally crashed).

So the fix is a small `*memSeries` helper checking the real limit
(`oooChunkIDMask`, an in-package const, so it also prevents the bit-23 collision,
not just the panic), called from both `Series` methods before `getOOOSeriesChunks`.
One helper covers both the read and compaction paths.

</details>