### PR TITLE
ci: skip broken pnpm 11.12.0 in Publish UI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11
+          # Exclude the broken pnpm 11.12.0 (self-installer crash, see
+          # https://github.com/pnpm/action-setup/issues/276) while still
+          # picking up future 11.x releases that fix it.
+          version: ">=11.0.0 <11.12.0 || >11.12.0 <12.0.0"
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.local/share/pnpm/store


### PR DESCRIPTION
## Problem

The Publish UI on npm Registry job in `ci.yml` pins the pnpm major version with `version: 11`, which floats to the latest 11.x release. Since pnpm v11.12.0 was published (currently `latest-11`), the action's self-installer crashes on every run:

```
Switching pnpm from v11.7.0 to v11.12.0...
[ERROR] Cannot use 'in' operator to search for 'integrity' in undefined
    at createFullPkgId (.../pnpm.mjs)
    at lockfileToDepGraph (...)
##[error]Something went wrong, self-installer exits with code 1
```

This is an upstream pnpm regression, tracked in pnpm/action-setup#276.

## Fix

Rather than pinning to a stale exact version, use a semver range that excludes **only** the broken `11.12.0` while staying on 11.x:

```yaml
version: ">=11.0.0 <11.12.0 || >11.12.0 <12.0.0"
```

This resolves to `11.11.0` today and will automatically pick up future 11.x releases that fix the issue, so we don't have to bump the workflow again once upstream ships a fix.

```release-notes
NONE
```