### PR TITLE
tsdb/wlog: fix shadowed metadata slice decoding in Checkpoint.

### DIFF
--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -358,7 +358,7 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 			stats.TotalExemplars += len(exemplars)
 			stats.DroppedExemplars += len(exemplars) - len(repl)
 		case record.Metadata:
-			metadata, err := dec.Metadata(rec, metadata)
+			metadata, err = dec.Metadata(rec, metadata)
 			if err != nil {
 				return nil, fmt.Errorf("decode metadata: %w", err)
 			}

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -387,6 +387,43 @@ func TestCheckpoint(t *testing.T) {
 	}
 }
 
+func TestCheckpoint_Metadata(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	w, err := NewSize(nil, nil, dir, 128*1024, compression.None)
+	require.NoError(t, err)
+
+	enc := record.Encoder{EnableSTStorage: false}
+
+	require.NoError(t, w.Log(enc.Metadata([]record.RefMetadata{
+		{Ref: 1, Unit: "u1", Help: "h1"},
+		{Ref: 2, Unit: "u2", Help: "h2"},
+		{Ref: 3, Unit: "u3", Help: "h3"},
+	}, nil)))
+
+	require.NoError(t, w.Log(enc.Metadata([]record.RefMetadata{
+		{Ref: 1, Unit: "u1-updated", Help: "h1-updated"},
+	}, nil)))
+
+	require.NoError(t, w.Close())
+
+	w, err = NewSize(nil, nil, dir, 128*1024, compression.None)
+	require.NoError(t, err)
+	t.Cleanup(func() { w.Close() })
+
+	first, last, err := Segments(w.Dir())
+	require.NoError(t, err)
+
+	stats, err := Checkpoint(promslog.NewNopLogger(), w, first, last, func(id chunks.HeadSeriesRef) bool {
+		return id == 1 || id == 2
+	}, 0, false)
+	require.NoError(t, err)
+
+	require.Equal(t, 4, stats.TotalMetadata)
+	require.Equal(t, 2, stats.DroppedMetadata)
+}
+
 // TestCheckpoint_Tombstones verifies tombstone retention. A tombstone is dropped
 // together with its series record, or once all its intervals age out of the WAL.
 func TestCheckpoint_Tombstones(t *testing.T) {

--- a/tsdb/wlog/checkpoint_test.go
+++ b/tsdb/wlog/checkpoint_test.go
@@ -387,43 +387,6 @@ func TestCheckpoint(t *testing.T) {
 	}
 }
 
-func TestCheckpoint_Metadata(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-
-	w, err := NewSize(nil, nil, dir, 128*1024, compression.None)
-	require.NoError(t, err)
-
-	enc := record.Encoder{EnableSTStorage: false}
-
-	require.NoError(t, w.Log(enc.Metadata([]record.RefMetadata{
-		{Ref: 1, Unit: "u1", Help: "h1"},
-		{Ref: 2, Unit: "u2", Help: "h2"},
-		{Ref: 3, Unit: "u3", Help: "h3"},
-	}, nil)))
-
-	require.NoError(t, w.Log(enc.Metadata([]record.RefMetadata{
-		{Ref: 1, Unit: "u1-updated", Help: "h1-updated"},
-	}, nil)))
-
-	require.NoError(t, w.Close())
-
-	w, err = NewSize(nil, nil, dir, 128*1024, compression.None)
-	require.NoError(t, err)
-	t.Cleanup(func() { w.Close() })
-
-	first, last, err := Segments(w.Dir())
-	require.NoError(t, err)
-
-	stats, err := Checkpoint(promslog.NewNopLogger(), w, first, last, func(id chunks.HeadSeriesRef) bool {
-		return id == 1 || id == 2
-	}, 0, false)
-	require.NoError(t, err)
-
-	require.Equal(t, 4, stats.TotalMetadata)
-	require.Equal(t, 2, stats.DroppedMetadata)
-}
-
 // TestCheckpoint_Tombstones verifies tombstone retention. A tombstone is dropped
 // together with its series record, or once all its intervals age out of the WAL.
 func TestCheckpoint_Tombstones(t *testing.T) {


### PR DESCRIPTION
### PR Context


Fixes #19173

#### Context & Changes
During WAL checkpointing, the `Checkpoint` function in `tsdb/wlog/checkpoint.go` sequentially decodes segments from the WAL. Slices are pre-allocated outside the read loop and reset to `[:0]` on each iteration to optimize memory allocation.

However, the handler for `Metadata` records was written using short variable declaration `:=` instead of normal assignment `=`:
```go
metadata, err := dec.Metadata(rec, metadata)
```
This shadows the outer `metadata` variable inside the `case record.Metadata` block. Because of this shadowing, the outer `metadata` slice is never updated or reused across iterations, resulting in:
1. A fresh memory allocation for every metadata record decoded during WAL checkpointing.
2. Inaccurate stats calculation for `DroppedMetadata` under duplicate metadata updates.

This PR fixes the bug by replacing the `:=` declaration with `=` assignment. We also added `TestCheckpoint_Metadata` in `tsdb/wlog/checkpoint_test.go` to verify correctness of the stats.

#### Verification
- Ran unit tests `go test -v ./tsdb/wlog -run "TestCheckpoint|TestCheckpoint_Metadata"` which pass successfully.
- Ran `go vet ./tsdb/wlog/...` with no errors.

#### Release notes for end users
```release-notes
[BUGFIX] tsdb/wlog: Fix shadowed metadata slice decoding in checkpoint.
```
