### PR TITLE
tsdb: fix native histogram head metric tracking

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2331,9 +2331,9 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 			(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
 			staleSeriesDeleted++
 		}
-		if series.isNativeHistogramSeries() {
+		if isHist, buckets := series.nativeHistogramState(); isHist {
 			histogramSeriesDeleted++
-			histogramBucketsDeleted += series.nativeHistogramBucketCount()
+			histogramBucketsDeleted += buckets
 		}
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
@@ -2441,9 +2441,9 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 			(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
 			staleSeriesDeleted++
 		}
-		if series.isNativeHistogramSeries() {
+		if isHist, buckets := series.nativeHistogramState(); isHist {
 			histogramSeriesDeleted++
-			histogramBucketsDeleted += series.nativeHistogramBucketCount()
+			histogramBucketsDeleted += buckets
 		}
 
 		chunksRemoved += len(series.mmappedChunks)
@@ -2541,9 +2541,9 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 		if isStaleSeries(series) {
 			staleSeriesDeleted++
 		}
-		if series.isNativeHistogramSeries() {
+		if isHist, buckets := series.nativeHistogramState(); isHist {
 			histogramSeriesDeleted++
-			histogramBucketsDeleted += series.nativeHistogramBucketCount()
+			histogramBucketsDeleted += buckets
 		}
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
 		s.hashes[hashShard].del(hash, series.ref)
@@ -2757,24 +2757,20 @@ type memSeries struct {
 	txs *txRing
 }
 
-// isNativeHistogramSeries reports whether the series' most recent in-order
-// sample is a native histogram (integer or float).
-func (s *memSeries) isNativeHistogramSeries() bool {
-	return s.lastHistogramValue != nil || s.lastFloatHistogramValue != nil
-}
-
-// nativeHistogramBucketCount returns the number of stored buckets in the
-// series' most recent in-order native histogram sample, or 0 if the series is
-// not currently a native histogram series (e.g. a float series or a staleness
-// marker, which carries no buckets).
-func (s *memSeries) nativeHistogramBucketCount() int {
+// nativeHistogramState reports whether the series' most recent in-order sample
+// is a native histogram (integer or float) and the number of stored buckets in
+// that sample. The buckets count is 0 when the series is not a native histogram
+// series or when its last sample is a staleness marker, which carries no
+// buckets. It reads the last-value fields only once, for use on the append hot
+// path.
+func (s *memSeries) nativeHistogramState() (isHistogram bool, buckets int) {
 	switch {
 	case s.lastHistogramValue != nil:
-		return len(s.lastHistogramValue.PositiveBuckets) + len(s.lastHistogramValue.NegativeBuckets)
+		return true, len(s.lastHistogramValue.PositiveBuckets) + len(s.lastHistogramValue.NegativeBuckets)
 	case s.lastFloatHistogramValue != nil:
-		return len(s.lastFloatHistogramValue.PositiveBuckets) + len(s.lastFloatHistogramValue.NegativeBuckets)
+		return true, len(s.lastFloatHistogramValue.PositiveBuckets) + len(s.lastFloatHistogramValue.NegativeBuckets)
 	}
-	return 0
+	return false, 0
 }
 
 // memSeriesOOOFields contains the fields required by memSeries

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -473,13 +473,13 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 		}),
 		nativeHistogramSeries: prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 			Name: "prometheus_tsdb_head_native_histogram_series",
-			Help: "Total number of native histogram series in the head block.",
+			Help: "Number of series whose most recent in-order sample is a native histogram.",
 		}, func() float64 {
 			return float64(h.NumNativeHistogramSeries())
 		}),
 		nativeHistogramBuckets: prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 			Name: "prometheus_tsdb_head_native_histogram_buckets",
-			Help: "Total number of native histogram buckets across all series in the head block.",
+			Help: "Number of positive and negative bucket entries in the most recent in-order native histogram sample of each series; stale histograms contribute zero.",
 		}, func() float64 {
 			return float64(h.NumNativeHistogramBuckets())
 		}),
@@ -1006,6 +1006,7 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 					minTime:    mint,
 					maxTime:    maxt,
 					numSamples: numSamples,
+					encoding:   encoding,
 				})
 				return nil
 			}
@@ -1022,6 +1023,7 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 				minTime:    mint,
 				maxTime:    maxt,
 				numSamples: numSamples,
+				encoding:   encoding,
 			})
 
 			h.updateMinOOOMaxOOOTime(mint, maxt)
@@ -1040,6 +1042,7 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 				minTime:    mint,
 				maxTime:    maxt,
 				numSamples: numSamples,
+				encoding:   encoding,
 			})
 			mmappedChunks[seriesRef] = slice
 			return nil
@@ -1059,6 +1062,7 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 			minTime:    mint,
 			maxTime:    maxt,
 			numSamples: numSamples,
+			encoding:   encoding,
 		})
 		h.updateMinMaxTime(mint, maxt)
 		if ms.headChunks != nil && maxt >= ms.headChunks.minTime {
@@ -1302,9 +1306,14 @@ func isSeriesWithoutOOO(s *memSeries) bool {
 
 // isStaleSeries reports whether s's most recent in-order sample is a stale-NaN marker.
 func isStaleSeries(s *memSeries) bool {
-	return value.IsStaleNaN(s.lastValue) ||
-		(s.lastHistogramValue != nil && value.IsStaleNaN(s.lastHistogramValue.Sum)) ||
-		(s.lastFloatHistogramValue != nil && value.IsStaleNaN(s.lastFloatHistogramValue.Sum))
+	switch {
+	case s.lastHistogramValue != nil:
+		return value.IsStaleNaN(s.lastHistogramValue.Sum)
+	case s.lastFloatHistogramValue != nil:
+		return value.IsStaleNaN(s.lastFloatHistogramValue.Sum)
+	default:
+		return value.IsStaleNaN(s.lastValue)
+	}
 }
 
 // truncateStaleSeries removes the provided series as long as they are still stale and
@@ -1908,27 +1917,38 @@ func (h *Head) NumStaleSeries() uint64 {
 	return h.numStaleSeries.Load()
 }
 
+// updateStaleSeriesMetricOnAppend updates the stale-series gauge after an in-order append.
+func (h *Head) updateStaleSeriesMetricOnAppend(wasStale, isStale bool) {
+	switch {
+	case !wasStale && isStale:
+		h.numStaleSeries.Inc()
+	case wasStale && !isStale:
+		h.numStaleSeries.Dec()
+	}
+}
+
 // NumNativeHistogramSeries returns the number of series in the head whose most
 // recent in-order sample is a native histogram.
 func (h *Head) NumNativeHistogramSeries() uint64 {
 	return h.numNativeHistogramSeries.Load()
 }
 
-// NumNativeHistogramBuckets returns the total number of native histogram
-// buckets across all series in the head, counting the buckets of each series'
-// most recent in-order native histogram sample.
+// NumNativeHistogramBuckets returns the total positive and negative bucket
+// entries in each series' most recent in-order native histogram. Stale
+// histograms contribute zero buckets.
 func (h *Head) NumNativeHistogramBuckets() uint64 {
 	return h.numNativeHistogramBuckets.Load()
 }
 
-// addNativeHistogramBuckets adjusts the native histogram bucket gauge by delta,
-// which may be negative.
+// addNativeHistogramBuckets adjusts the bucket gauge by a signed delta.
 func (h *Head) addNativeHistogramBuckets(delta int) {
-	if delta >= 0 {
+	if delta > 0 {
 		h.numNativeHistogramBuckets.Add(uint64(delta))
 		return
 	}
-	h.numNativeHistogramBuckets.Sub(uint64(-delta))
+	if delta < 0 {
+		h.numNativeHistogramBuckets.Sub(uint64(-delta))
+	}
 }
 
 // updateNativeHistogramMetricsOnAppend updates the native histogram series and
@@ -2326,9 +2346,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 			defer s.locks[stripe].Unlock()
 		}
 
-		if value.IsStaleNaN(series.lastValue) ||
-			(series.lastHistogramValue != nil && value.IsStaleNaN(series.lastHistogramValue.Sum)) ||
-			(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
+		if isStaleSeries(series) {
 			staleSeriesDeleted++
 		}
 		if isHist, buckets := series.nativeHistogramState(); isHist {
@@ -2436,9 +2454,7 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 			}
 		}
 
-		if value.IsStaleNaN(series.lastValue) ||
-			(series.lastHistogramValue != nil && value.IsStaleNaN(series.lastHistogramValue.Sum)) ||
-			(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
+		if isStaleSeries(series) {
 			staleSeriesDeleted++
 		}
 		if isHist, buckets := series.nativeHistogramState(); isHist {
@@ -2757,18 +2773,30 @@ type memSeries struct {
 	txs *txRing
 }
 
-// nativeHistogramState reports whether the series' most recent in-order sample
-// is a native histogram (integer or float) and the number of stored buckets in
-// that sample. The buckets count is 0 when the series is not a native histogram
-// series or when its last sample is a staleness marker, which carries no
-// buckets. It reads the last-value fields only once, for use on the append hot
-// path.
+// nativeHistogramBucketCount returns zero for a staleness marker.
+func nativeHistogramBucketCount(sum float64, positiveBuckets, negativeBuckets int) int {
+	if value.IsStaleNaN(sum) {
+		return 0
+	}
+	return positiveBuckets + negativeBuckets
+}
+
+// nativeHistogramState reports whether the most recent in-order sample is a
+// native histogram and its bucket-entry count. Stale histograms have no buckets.
 func (s *memSeries) nativeHistogramState() (isHistogram bool, buckets int) {
 	switch {
 	case s.lastHistogramValue != nil:
-		return true, len(s.lastHistogramValue.PositiveBuckets) + len(s.lastHistogramValue.NegativeBuckets)
+		return true, nativeHistogramBucketCount(
+			s.lastHistogramValue.Sum,
+			len(s.lastHistogramValue.PositiveBuckets),
+			len(s.lastHistogramValue.NegativeBuckets),
+		)
 	case s.lastFloatHistogramValue != nil:
-		return true, len(s.lastFloatHistogramValue.PositiveBuckets) + len(s.lastFloatHistogramValue.NegativeBuckets)
+		return true, nativeHistogramBucketCount(
+			s.lastFloatHistogramValue.Sum,
+			len(s.lastFloatHistogramValue.PositiveBuckets),
+			len(s.lastFloatHistogramValue.NegativeBuckets),
+		)
 	}
 	return false, 0
 }
@@ -3003,6 +3031,7 @@ func overlapsClosedInterval(mint1, maxt1, mint2, maxt2 int64) bool {
 type mmappedChunk struct {
 	ref              chunks.ChunkDiskMapperRef
 	numSamples       uint16
+	encoding         chunkenc.Encoding
 	minTime, maxTime int64
 }
 

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -69,9 +69,15 @@ var (
 
 // Head handles reads and writes of time series data within a time window.
 type Head struct {
-	chunkRange               atomic.Int64
-	numSeries                atomic.Uint64
-	numStaleSeries           atomic.Uint64
+	chunkRange     atomic.Int64
+	numSeries      atomic.Uint64
+	numStaleSeries atomic.Uint64
+	// Native histogram counters, tracking the number of series whose most recent
+	// in-order sample is a native histogram and the total number of buckets across
+	// those series.
+	numNativeHistogramSeries  atomic.Uint64
+	numNativeHistogramBuckets atomic.Uint64
+
 	minOOOTime, maxOOOTime   atomic.Int64 // TODO(jesusvazquez) These should be updated after garbage collection.
 	minTime, maxTime         atomic.Int64 // Current min and max of the samples included in the head. minTime != math.MaxInt64 is used to determine whether the head has been initialized, so care must be taken that the initialized state only changes after maxTime is already updated.
 	minValidTime             atomic.Int64 // Mint allowed to be added to the head. It shouldn't be lower than the maxt of the last persisted block.
@@ -379,6 +385,8 @@ func (h *Head) resetInMemoryState() error {
 	h.iso = newIsolation(h.opts.IsolationDisabled)
 	h.oooIso = newOOOIsolation()
 	h.numSeries.Store(0)
+	h.numNativeHistogramSeries.Store(0)
+	h.numNativeHistogramBuckets.Store(0)
 	h.exemplarMetrics = em
 	h.exemplars = es
 	h.postings = index.NewUnorderedMemPostings()
@@ -409,6 +417,8 @@ type headMetrics struct {
 	activeAppenders           prometheus.Gauge
 	series                    prometheus.GaugeFunc
 	staleSeries               prometheus.GaugeFunc
+	nativeHistogramSeries     prometheus.GaugeFunc
+	nativeHistogramBuckets    prometheus.GaugeFunc
 	seriesCreated             prometheus.Counter
 	seriesRemoved             prometheus.Counter
 	seriesNotFound            prometheus.Counter
@@ -460,6 +470,18 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Help: "Total number of stale series in the head block.",
 		}, func() float64 {
 			return float64(h.NumStaleSeries())
+		}),
+		nativeHistogramSeries: prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "prometheus_tsdb_head_native_histogram_series",
+			Help: "Total number of native histogram series in the head block.",
+		}, func() float64 {
+			return float64(h.NumNativeHistogramSeries())
+		}),
+		nativeHistogramBuckets: prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "prometheus_tsdb_head_native_histogram_buckets",
+			Help: "Total number of native histogram buckets across all series in the head block.",
+		}, func() float64 {
+			return float64(h.NumNativeHistogramBuckets())
 		}),
 		seriesCreated: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_head_series_created_total",
@@ -588,6 +610,8 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.activeAppenders,
 			m.series,
 			m.staleSeries,
+			m.nativeHistogramSeries,
+			m.nativeHistogramBuckets,
 			m.chunks,
 			m.chunksCreated,
 			m.chunksRemoved,
@@ -1836,7 +1860,7 @@ func (h *Head) gc() (actualInOrderMint, minOOOTime int64, minMmapFile int) {
 
 	// Drop old chunks and remember series IDs and hashes if they can be
 	// deleted entirely.
-	deleted, affected, chunksRemoved, staleSeriesDeleted, actualInOrderMint, minOOOTime, minMmapFile := h.series.gc(mint, minOOOMmapRef)
+	deleted, affected, chunksRemoved, staleSeriesDeleted, histogramSeriesDeleted, histogramBucketsDeleted, actualInOrderMint, minOOOTime, minMmapFile := h.series.gc(mint, minOOOMmapRef)
 	seriesRemoved := len(deleted)
 
 	h.metrics.seriesRemoved.Add(float64(seriesRemoved))
@@ -1844,6 +1868,8 @@ func (h *Head) gc() (actualInOrderMint, minOOOTime int64, minMmapFile int) {
 	h.metrics.chunks.Sub(float64(chunksRemoved))
 	h.numSeries.Sub(uint64(seriesRemoved))
 	h.numStaleSeries.Sub(uint64(staleSeriesDeleted))
+	h.numNativeHistogramSeries.Sub(uint64(histogramSeriesDeleted))
+	h.numNativeHistogramBuckets.Sub(uint64(histogramBucketsDeleted))
 
 	// Remove deleted series IDs from the postings lists.
 	h.postings.Delete(deleted, affected)
@@ -1880,6 +1906,44 @@ func (h *Head) NumSeries() uint64 {
 // NumStaleSeries returns the number of stale series in the head.
 func (h *Head) NumStaleSeries() uint64 {
 	return h.numStaleSeries.Load()
+}
+
+// NumNativeHistogramSeries returns the number of series in the head whose most
+// recent in-order sample is a native histogram.
+func (h *Head) NumNativeHistogramSeries() uint64 {
+	return h.numNativeHistogramSeries.Load()
+}
+
+// NumNativeHistogramBuckets returns the total number of native histogram
+// buckets across all series in the head, counting the buckets of each series'
+// most recent in-order native histogram sample.
+func (h *Head) NumNativeHistogramBuckets() uint64 {
+	return h.numNativeHistogramBuckets.Load()
+}
+
+// addNativeHistogramBuckets adjusts the native histogram bucket gauge by delta,
+// which may be negative.
+func (h *Head) addNativeHistogramBuckets(delta int) {
+	if delta >= 0 {
+		h.numNativeHistogramBuckets.Add(uint64(delta))
+		return
+	}
+	h.numNativeHistogramBuckets.Sub(uint64(-delta))
+}
+
+// updateNativeHistogramMetricsOnAppend updates the native histogram series and
+// bucket gauges after an in-order sample was appended to a series. wasHistogram
+// and oldBuckets must be captured before the append overwrote the series' last
+// values. isHistogram reports whether the just-appended sample is a native
+// histogram and newBuckets is its bucket count (both zero for a float sample).
+func (h *Head) updateNativeHistogramMetricsOnAppend(wasHistogram, isHistogram bool, oldBuckets, newBuckets int) {
+	switch {
+	case !wasHistogram && isHistogram:
+		h.numNativeHistogramSeries.Inc()
+	case wasHistogram && !isHistogram:
+		h.numNativeHistogramSeries.Dec()
+	}
+	h.addNativeHistogramBuckets(newBuckets - oldBuckets)
 }
 
 var headULID = ulid.MustParse("0000000000XXXXXXXXXXXXHEAD")
@@ -2197,14 +2261,16 @@ func newStripeSeries(stripeSize int, seriesCallback SeriesLifecycleCallback) *st
 // but the returned map goes into postings.Delete() which expects a map[storage.SeriesRef]struct
 // and there's no easy way to cast maps.
 // minMmapFile is the min mmap file number seen in the series (in-order and out-of-order) after gc'ing the series.
-func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (_ map[storage.SeriesRef]struct{}, _ map[labels.Label]struct{}, _, _ int, _, _ int64, minMmapFile int) {
+func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (_ map[storage.SeriesRef]struct{}, _ map[labels.Label]struct{}, _, _, _, _ int, _, _ int64, minMmapFile int) {
 	var (
-		deleted                  = map[storage.SeriesRef]struct{}{}
-		affected                 = map[labels.Label]struct{}{}
-		rmChunks                 = 0
-		staleSeriesDeleted       = 0
-		actualMint         int64 = math.MaxInt64
-		minOOOTime         int64 = math.MaxInt64
+		deleted                       = map[storage.SeriesRef]struct{}{}
+		affected                      = map[labels.Label]struct{}{}
+		rmChunks                      = 0
+		staleSeriesDeleted            = 0
+		histogramSeriesDeleted        = 0
+		histogramBucketsDeleted       = 0
+		actualMint              int64 = math.MaxInt64
+		minOOOTime              int64 = math.MaxInt64
 	)
 	minMmapFile = math.MaxInt32
 
@@ -2265,6 +2331,10 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 			(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
 			staleSeriesDeleted++
 		}
+		if series.isNativeHistogramSeries() {
+			histogramSeriesDeleted++
+			histogramBucketsDeleted += series.nativeHistogramBucketCount()
+		}
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
@@ -2279,7 +2349,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		actualMint = mint
 	}
 
-	return deleted, affected, rmChunks, staleSeriesDeleted, actualMint, minOOOTime, minMmapFile
+	return deleted, affected, rmChunks, staleSeriesDeleted, histogramSeriesDeleted, histogramBucketsDeleted, actualMint, minOOOTime, minMmapFile
 }
 
 // gcSeries removes the provided series from the head index and updates head metrics,
@@ -2291,7 +2361,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 func (h *Head) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict func(*memSeries) bool) map[storage.SeriesRef]struct{} {
 	// Drop old chunks and remember series IDs and hashes if they can be
 	// deleted entirely.
-	deleted, affected, chunksRemoved, staleSeriesDeleted := h.series.gcSeries(seriesRefs, maxt, shouldEvict)
+	deleted, affected, chunksRemoved, staleSeriesDeleted, histogramSeriesDeleted, histogramBucketsDeleted := h.series.gcSeries(seriesRefs, maxt, shouldEvict)
 	seriesRemoved := len(deleted)
 
 	h.metrics.seriesRemoved.Add(float64(seriesRemoved))
@@ -2299,6 +2369,8 @@ func (h *Head) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict 
 	h.metrics.chunks.Sub(float64(chunksRemoved))
 	h.numSeries.Sub(uint64(seriesRemoved))
 	h.numStaleSeries.Sub(uint64(staleSeriesDeleted))
+	h.numNativeHistogramSeries.Sub(uint64(histogramSeriesDeleted))
+	h.numNativeHistogramBuckets.Sub(uint64(histogramBucketsDeleted))
 
 	// Remove deleted series IDs from the postings lists.
 	h.postings.Delete(deleted, affected)
@@ -2327,11 +2399,13 @@ func (h *Head) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict 
 // Only used for WAL replay.
 func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 	var (
-		deleted            = map[storage.SeriesRef]struct{}{}
-		deletedForCallback = map[chunks.HeadSeriesRef]labels.Labels{}
-		affected           = map[labels.Label]struct{}{}
-		staleSeriesDeleted = 0
-		chunksRemoved      = 0
+		deleted                 = map[storage.SeriesRef]struct{}{}
+		deletedForCallback      = map[chunks.HeadSeriesRef]labels.Labels{}
+		affected                = map[labels.Label]struct{}{}
+		staleSeriesDeleted      = 0
+		histogramSeriesDeleted  = 0
+		histogramBucketsDeleted = 0
+		chunksRemoved           = 0
 	)
 
 	for _, ref := range refs {
@@ -2367,6 +2441,10 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 			(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
 			staleSeriesDeleted++
 		}
+		if series.isNativeHistogramSeries() {
+			histogramSeriesDeleted++
+			histogramBucketsDeleted += series.nativeHistogramBucketCount()
+		}
 
 		chunksRemoved += len(series.mmappedChunks)
 		if series.headChunks != nil {
@@ -2390,6 +2468,8 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 	h.metrics.chunks.Sub(float64(chunksRemoved))
 	h.numSeries.Sub(uint64(len(deleted)))
 	h.numStaleSeries.Sub(uint64(staleSeriesDeleted))
+	h.numNativeHistogramSeries.Sub(uint64(histogramSeriesDeleted))
+	h.numNativeHistogramBuckets.Sub(uint64(histogramBucketsDeleted))
 
 	// Remove deleted series IDs from the postings lists.
 	h.postings.Delete(deleted, affected)
@@ -2406,12 +2486,14 @@ func (h *Head) deleteSeriesByID(refs []chunks.HeadSeriesRef) {
 // <= maxt, and for which shouldEvict returns true. Returns the set of deleted refs, the set
 // of label-name/value pairs whose postings are affected, the count of removed chunks, and
 // the number of deleted series that carried a stale-NaN last value.
-func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict func(*memSeries) bool) (_ map[storage.SeriesRef]struct{}, _ map[labels.Label]struct{}, _, _ int) {
+func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shouldEvict func(*memSeries) bool) (_ map[storage.SeriesRef]struct{}, _ map[labels.Label]struct{}, _, _, _, _ int) {
 	var (
-		deleted            = map[storage.SeriesRef]struct{}{}
-		affected           = map[labels.Label]struct{}{}
-		rmChunks           = 0
-		staleSeriesDeleted = 0
+		deleted                 = map[storage.SeriesRef]struct{}{}
+		affected                = map[labels.Label]struct{}{}
+		rmChunks                = 0
+		staleSeriesDeleted      = 0
+		histogramSeriesDeleted  = 0
+		histogramBucketsDeleted = 0
 	)
 
 	refsSet := map[storage.SeriesRef]struct{}{}
@@ -2459,6 +2541,10 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 		if isStaleSeries(series) {
 			staleSeriesDeleted++
 		}
+		if series.isNativeHistogramSeries() {
+			histogramSeriesDeleted++
+			histogramBucketsDeleted += series.nativeHistogramBucketCount()
+		}
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
 		s.hashes[hashShard].del(hash, series.ref)
 		delete(s.series[stripe], series.ref)
@@ -2467,7 +2553,7 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 
 	s.iterForDeletion(check)
 
-	return deleted, affected, rmChunks, staleSeriesDeleted
+	return deleted, affected, rmChunks, staleSeriesDeleted, histogramSeriesDeleted, histogramBucketsDeleted
 }
 
 // The iterForDeletion function iterates through all series, invoking the checkDeletedFunc for each.
@@ -2669,6 +2755,26 @@ type memSeries struct {
 
 	// txs is nil if isolation is disabled.
 	txs *txRing
+}
+
+// isNativeHistogramSeries reports whether the series' most recent in-order
+// sample is a native histogram (integer or float).
+func (s *memSeries) isNativeHistogramSeries() bool {
+	return s.lastHistogramValue != nil || s.lastFloatHistogramValue != nil
+}
+
+// nativeHistogramBucketCount returns the number of stored buckets in the
+// series' most recent in-order native histogram sample, or 0 if the series is
+// not currently a native histogram series (e.g. a float series or a staleness
+// marker, which carries no buckets).
+func (s *memSeries) nativeHistogramBucketCount() int {
+	switch {
+	case s.lastHistogramValue != nil:
+		return len(s.lastHistogramValue.PositiveBuckets) + len(s.lastHistogramValue.NegativeBuckets)
+	case s.lastFloatHistogramValue != nil:
+		return len(s.lastFloatHistogramValue.PositiveBuckets) + len(s.lastFloatHistogramValue.NegativeBuckets)
+	}
+	return 0
 }
 
 // memSeriesOOOFields contains the fields required by memSeries

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1363,6 +1363,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			case series.lastHistogramValue != nil:
 				b.histograms = append(b.histograms, record.RefHistogramSample{
 					Ref: series.ref,
+					ST:  s.ST,
 					T:   s.T,
 					H:   &histogram.Histogram{Sum: s.V},
 				})
@@ -1375,6 +1376,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 			case series.lastFloatHistogramValue != nil:
 				b.floatHistograms = append(b.floatHistograms, record.RefFloatHistogramSample{
 					Ref: series.ref,
+					ST:  s.ST,
 					T:   s.T,
 					FH:  &histogram.FloatHistogram{Sum: s.V},
 				})
@@ -1441,8 +1443,8 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 				acc.floatsAppended--
 			}
 		default:
-			newlyStale := !value.IsStaleNaN(series.lastValue) && value.IsStaleNaN(s.V)
-			staleToNonStale := value.IsStaleNaN(series.lastValue) && !value.IsStaleNaN(s.V)
+			wasStale := isStaleSeries(series)
+			isStale := value.IsStaleNaN(s.V)
 			wasHistogram, oldBuckets := series.nativeHistogramState()
 			ok, chunkCreated = series.append(s.ST, s.T, s.V, a.appendID, acc.appendChunkOpts)
 			if ok {
@@ -1452,12 +1454,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 				if s.T > acc.inOrderMaxt {
 					acc.inOrderMaxt = s.T
 				}
-				if newlyStale {
-					a.head.numStaleSeries.Inc()
-				}
-				if staleToNonStale {
-					a.head.numStaleSeries.Dec()
-				}
+				a.head.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, false, oldBuckets, 0)
 			} else {
 				// The sample is an exact duplicate, and should be silently dropped.
@@ -1548,14 +1545,10 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 				acc.histogramsAppended--
 			}
 		default:
-			newlyStale := value.IsStaleNaN(s.H.Sum)
-			staleToNonStale := false
-			if series.lastHistogramValue != nil {
-				newlyStale = newlyStale && !value.IsStaleNaN(series.lastHistogramValue.Sum)
-				staleToNonStale = value.IsStaleNaN(series.lastHistogramValue.Sum) && !value.IsStaleNaN(s.H.Sum)
-			}
+			wasStale := isStaleSeries(series)
+			isStale := value.IsStaleNaN(s.H.Sum)
 			wasHistogram, oldBuckets := series.nativeHistogramState()
-			newBuckets := len(s.H.PositiveBuckets) + len(s.H.NegativeBuckets)
+			newBuckets := nativeHistogramBucketCount(s.H.Sum, len(s.H.PositiveBuckets), len(s.H.NegativeBuckets))
 			ok, chunkCreated = series.appendHistogram(s.ST, s.T, s.H, a.appendID, acc.appendChunkOpts)
 			if ok {
 				if s.T < acc.inOrderMint {
@@ -1564,12 +1557,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 				if s.T > acc.inOrderMaxt {
 					acc.inOrderMaxt = s.T
 				}
-				if newlyStale {
-					a.head.numStaleSeries.Inc()
-				}
-				if staleToNonStale {
-					a.head.numStaleSeries.Dec()
-				}
+				a.head.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			} else {
 				acc.histogramsAppended--
@@ -1660,14 +1648,10 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 				acc.histogramsAppended--
 			}
 		default:
-			newlyStale := value.IsStaleNaN(s.FH.Sum)
-			staleToNonStale := false
-			if series.lastFloatHistogramValue != nil {
-				newlyStale = newlyStale && !value.IsStaleNaN(series.lastFloatHistogramValue.Sum)
-				staleToNonStale = value.IsStaleNaN(series.lastFloatHistogramValue.Sum) && !value.IsStaleNaN(s.FH.Sum)
-			}
+			wasStale := isStaleSeries(series)
+			isStale := value.IsStaleNaN(s.FH.Sum)
 			wasHistogram, oldBuckets := series.nativeHistogramState()
-			newBuckets := len(s.FH.PositiveBuckets) + len(s.FH.NegativeBuckets)
+			newBuckets := nativeHistogramBucketCount(s.FH.Sum, len(s.FH.PositiveBuckets), len(s.FH.NegativeBuckets))
 			ok, chunkCreated = series.appendFloatHistogram(s.ST, s.T, s.FH, a.appendID, acc.appendChunkOpts)
 			if ok {
 				if s.T < acc.inOrderMint {
@@ -1676,12 +1660,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 				if s.T > acc.inOrderMaxt {
 					acc.inOrderMaxt = s.T
 				}
-				if newlyStale {
-					a.head.numStaleSeries.Inc()
-				}
-				if staleToNonStale {
-					a.head.numStaleSeries.Dec()
-				}
+				a.head.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			} else {
 				acc.histogramsAppended--
@@ -2213,6 +2192,7 @@ func (s *memSeries) mmapCurrentOOOHeadChunk(o chunkOpts, logger *slog.Logger) []
 		s.ooo.oooMmappedChunks = append(s.ooo.oooMmappedChunks, &mmappedChunk{
 			ref:        chunkRef,
 			numSamples: uint16(memchunk.chunk.NumSamples()),
+			encoding:   memchunk.chunk.Encoding(),
 			minTime:    memchunk.minTime,
 			maxTime:    memchunk.maxTime,
 		})
@@ -2237,6 +2217,7 @@ func (s *memSeries) mmapChunks(chunkDiskMapper *chunks.ChunkDiskMapper) (count i
 		s.mmappedChunks = append(s.mmappedChunks, &mmappedChunk{
 			ref:        chunkRef,
 			numSamples: uint16(chk.chunk.NumSamples()),
+			encoding:   chk.chunk.Encoding(),
 			minTime:    chk.minTime,
 			maxTime:    chk.maxTime,
 		})

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1443,6 +1443,8 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		default:
 			newlyStale := !value.IsStaleNaN(series.lastValue) && value.IsStaleNaN(s.V)
 			staleToNonStale := value.IsStaleNaN(series.lastValue) && !value.IsStaleNaN(s.V)
+			wasHistogram := series.isNativeHistogramSeries()
+			oldBuckets := series.nativeHistogramBucketCount()
 			ok, chunkCreated = series.append(s.ST, s.T, s.V, a.appendID, acc.appendChunkOpts)
 			if ok {
 				if s.T < acc.inOrderMint {
@@ -1457,6 +1459,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 				if staleToNonStale {
 					a.head.numStaleSeries.Dec()
 				}
+				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, false, oldBuckets, 0)
 			} else {
 				// The sample is an exact duplicate, and should be silently dropped.
 				acc.floatsAppended--
@@ -1552,6 +1555,9 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 				newlyStale = newlyStale && !value.IsStaleNaN(series.lastHistogramValue.Sum)
 				staleToNonStale = value.IsStaleNaN(series.lastHistogramValue.Sum) && !value.IsStaleNaN(s.H.Sum)
 			}
+			wasHistogram := series.isNativeHistogramSeries()
+			oldBuckets := series.nativeHistogramBucketCount()
+			newBuckets := len(s.H.PositiveBuckets) + len(s.H.NegativeBuckets)
 			ok, chunkCreated = series.appendHistogram(s.ST, s.T, s.H, a.appendID, acc.appendChunkOpts)
 			if ok {
 				if s.T < acc.inOrderMint {
@@ -1566,6 +1572,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 				if staleToNonStale {
 					a.head.numStaleSeries.Dec()
 				}
+				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			} else {
 				acc.histogramsAppended--
 				acc.histoOOORejected++
@@ -1661,6 +1668,9 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 				newlyStale = newlyStale && !value.IsStaleNaN(series.lastFloatHistogramValue.Sum)
 				staleToNonStale = value.IsStaleNaN(series.lastFloatHistogramValue.Sum) && !value.IsStaleNaN(s.FH.Sum)
 			}
+			wasHistogram := series.isNativeHistogramSeries()
+			oldBuckets := series.nativeHistogramBucketCount()
+			newBuckets := len(s.FH.PositiveBuckets) + len(s.FH.NegativeBuckets)
 			ok, chunkCreated = series.appendFloatHistogram(s.ST, s.T, s.FH, a.appendID, acc.appendChunkOpts)
 			if ok {
 				if s.T < acc.inOrderMint {
@@ -1675,6 +1685,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 				if staleToNonStale {
 					a.head.numStaleSeries.Dec()
 				}
+				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			} else {
 				acc.histogramsAppended--
 				acc.histoOOORejected++

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1443,8 +1443,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 		default:
 			newlyStale := !value.IsStaleNaN(series.lastValue) && value.IsStaleNaN(s.V)
 			staleToNonStale := value.IsStaleNaN(series.lastValue) && !value.IsStaleNaN(s.V)
-			wasHistogram := series.isNativeHistogramSeries()
-			oldBuckets := series.nativeHistogramBucketCount()
+			wasHistogram, oldBuckets := series.nativeHistogramState()
 			ok, chunkCreated = series.append(s.ST, s.T, s.V, a.appendID, acc.appendChunkOpts)
 			if ok {
 				if s.T < acc.inOrderMint {
@@ -1555,8 +1554,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 				newlyStale = newlyStale && !value.IsStaleNaN(series.lastHistogramValue.Sum)
 				staleToNonStale = value.IsStaleNaN(series.lastHistogramValue.Sum) && !value.IsStaleNaN(s.H.Sum)
 			}
-			wasHistogram := series.isNativeHistogramSeries()
-			oldBuckets := series.nativeHistogramBucketCount()
+			wasHistogram, oldBuckets := series.nativeHistogramState()
 			newBuckets := len(s.H.PositiveBuckets) + len(s.H.NegativeBuckets)
 			ok, chunkCreated = series.appendHistogram(s.ST, s.T, s.H, a.appendID, acc.appendChunkOpts)
 			if ok {
@@ -1668,8 +1666,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 				newlyStale = newlyStale && !value.IsStaleNaN(series.lastFloatHistogramValue.Sum)
 				staleToNonStale = value.IsStaleNaN(series.lastFloatHistogramValue.Sum) && !value.IsStaleNaN(s.FH.Sum)
 			}
-			wasHistogram := series.isNativeHistogramSeries()
-			oldBuckets := series.nativeHistogramBucketCount()
+			wasHistogram, oldBuckets := series.nativeHistogramState()
 			newBuckets := len(s.FH.PositiveBuckets) + len(s.FH.NegativeBuckets)
 			ok, chunkCreated = series.appendFloatHistogram(s.ST, s.T, s.FH, a.appendID, acc.appendChunkOpts)
 			if ok {

--- a/tsdb/head_bench_test.go
+++ b/tsdb/head_bench_test.go
@@ -252,6 +252,31 @@ func BenchmarkHeadAppender_AppendCommit(b *testing.B) {
 	}
 }
 
+func BenchmarkHeadUpdateNativeHistogramMetricsOnAppend(b *testing.B) {
+	testCases := []struct {
+		name                      string
+		wasHistogram, isHistogram bool
+		oldBuckets, newBuckets    int
+	}{
+		{name: "unchanged_float"},
+		{name: "unchanged_histogram", wasHistogram: true, isHistogram: true, oldBuckets: 8, newBuckets: 8},
+		{name: "bucket_growth", wasHistogram: true, isHistogram: true, oldBuckets: 8, newBuckets: 9},
+		{name: "float_to_histogram", isHistogram: true, newBuckets: 8},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			h := &Head{}
+			b.ReportAllocs()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					h.updateNativeHistogramMetricsOnAppend(tc.wasHistogram, tc.isHistogram, tc.oldBuckets, tc.newBuckets)
+				}
+			})
+		})
+	}
+}
+
 func BenchmarkHeadStripeSeriesCreate(b *testing.B) {
 	chunkDir := b.TempDir()
 	// Put a series, select it. GC it and then access it.

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -7899,6 +7899,629 @@ func TestHead_NumStaleSeries(t *testing.T) {
 	verifySeriesCounts(4, 5)
 }
 
+type nativeHistogramTestSample struct {
+	labels labels.Labels
+	st, t  int64
+	v      float64
+	h      *histogram.Histogram
+	fh     *histogram.FloatHistogram
+}
+
+func openTestHeadWithWALAndWBL(t testing.TB, dir string, opts *HeadOptions) *Head {
+	t.Helper()
+	wal, err := wlog.NewSize(nil, nil, filepath.Join(dir, "wal"), 32768, compression.None)
+	require.NoError(t, err)
+	wbl, err := wlog.NewSize(nil, nil, filepath.Join(dir, wlog.WblDirName), 32768, compression.None)
+	require.NoError(t, err)
+	head, err := NewHead(nil, nil, wal, wbl, opts, nil)
+	require.NoError(t, err)
+	require.NoError(t, head.Init(0))
+	return head
+}
+
+func appendNativeHistogramTestSamples(t testing.TB, head *Head, appenderV2 bool, samples ...nativeHistogramTestSample) {
+	t.Helper()
+	if appenderV2 {
+		app := head.AppenderV2(t.Context())
+		for _, s := range samples {
+			_, err := app.Append(0, s.labels, s.st, s.t, s.v, s.h, s.fh, storage.AOptions{})
+			require.NoError(t, err)
+		}
+		require.NoError(t, app.Commit())
+		return
+	}
+
+	app := head.Appender(t.Context())
+	for _, s := range samples {
+		var err error
+		if s.h != nil || s.fh != nil {
+			_, err = app.AppendHistogram(0, s.labels, s.t, s.h, s.fh)
+		} else {
+			_, err = app.Append(0, s.labels, s.t, s.v)
+		}
+		require.NoError(t, err)
+	}
+	require.NoError(t, app.Commit())
+}
+
+func requireHeadSampleTypeAndST(t testing.TB, head *Head, lbls labels.Labels, ts int64, wantType chunkenc.ValueType, wantST int64) {
+	t.Helper()
+	q, err := NewBlockQuerier(head, math.MinInt64, math.MaxInt64)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, q.Close()) }()
+
+	ss := q.Select(t.Context(), false, nil, labels.MustNewMatcher(labels.MatchEqual, "name", lbls.Get("name")))
+	require.True(t, ss.Next())
+	it := ss.At().Iterator(nil)
+	found := false
+	for typ := it.Next(); typ != chunkenc.ValNone; typ = it.Next() {
+		var gotT int64
+		switch typ {
+		case chunkenc.ValFloat:
+			gotT, _ = it.At()
+		case chunkenc.ValHistogram:
+			gotT, _ = it.AtHistogram(nil)
+		case chunkenc.ValFloatHistogram:
+			gotT, _ = it.AtFloatHistogram(nil)
+		}
+		if gotT != ts {
+			continue
+		}
+		require.Equal(t, wantType, typ)
+		require.Equal(t, wantST, it.AtST())
+		found = true
+	}
+	require.NoError(t, it.Err())
+	require.NoError(t, ss.Err())
+	require.True(t, found, "sample at timestamp %d not found", ts)
+}
+
+func requireOOOHeadSampleTypeAndST(t testing.TB, head *Head, lbls labels.Labels, ts int64, wantType chunkenc.ValueType, wantST int64) {
+	t.Helper()
+	series := head.series.getByHash(lbls.Hash(), lbls)
+	require.NotNil(t, series)
+	require.NotNil(t, series.ooo)
+	require.NotNil(t, series.ooo.oooHeadChunk)
+	encoded, err := series.ooo.oooHeadChunk.chunk.ToEncodedChunks(
+		math.MinInt64,
+		math.MaxInt64,
+		head.opts.UseXOR2FloatEncoding(),
+		head.opts.EnableHistogramSTEncoding.Load(),
+	)
+	require.NoError(t, err)
+	found := false
+	for _, chk := range encoded {
+		it := chk.chunk.Iterator(nil)
+		for typ := it.Next(); typ != chunkenc.ValNone; typ = it.Next() {
+			var gotT int64
+			switch typ {
+			case chunkenc.ValFloat:
+				gotT, _ = it.At()
+			case chunkenc.ValHistogram:
+				gotT, _ = it.AtHistogram(nil)
+			case chunkenc.ValFloatHistogram:
+				gotT, _ = it.AtFloatHistogram(nil)
+			}
+			if gotT != ts {
+				continue
+			}
+			require.Equal(t, wantType, typ)
+			require.Equal(t, wantST, it.AtST())
+			found = true
+		}
+		require.NoError(t, it.Err())
+	}
+	require.True(t, found, "OOO sample at timestamp %d not found", ts)
+}
+
+func TestHead_NativeHistogramMetrics_WALReplayStaleMarkerConversion(t *testing.T) {
+	for _, appenderV2 := range []bool{false, true} {
+		for _, floatHistogram := range []bool{false, true} {
+			name := fmt.Sprintf("appender_v2=%t/float_histogram=%t", appenderV2, floatHistogram)
+			t.Run(name, func(t *testing.T) {
+				dir := t.TempDir()
+				opts := DefaultHeadOptions()
+				opts.ChunkDirRoot = dir
+				opts.ChunkRange = 1000
+				if appenderV2 {
+					opts.EnableSTStorage.Store(true)
+					opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+					opts.EnableHistogramSTEncoding.Store(true)
+				}
+
+				head := openTestHeadWithWALAndWBL(t, dir, opts)
+				lbls := labels.FromStrings("name", name)
+				first := nativeHistogramTestSample{labels: lbls, st: 900, t: 1000}
+				if floatHistogram {
+					first.fh = tsdbutil.GenerateTestFloatHistograms(1)[0]
+				} else {
+					first.h = tsdbutil.GenerateTestHistograms(1)[0]
+				}
+				appendNativeHistogramTestSamples(t, head, appenderV2, first)
+				appendNativeHistogramTestSamples(t, head, appenderV2, nativeHistogramTestSample{
+					labels: lbls,
+					st:     1900,
+					t:      2000,
+					v:      math.Float64frombits(value.StaleNaN),
+				})
+
+				require.Equal(t, uint64(1), head.NumNativeHistogramSeries())
+				require.Equal(t, uint64(0), head.NumNativeHistogramBuckets())
+				require.Equal(t, uint64(1), head.NumStaleSeries())
+				wantType := chunkenc.ValHistogram
+				if floatHistogram {
+					wantType = chunkenc.ValFloatHistogram
+				}
+				wantST := int64(0)
+				if appenderV2 {
+					wantST = 1900
+				}
+				requireHeadSampleTypeAndST(t, head, lbls, 2000, wantType, wantST)
+
+				head.mmapHeadChunks()
+				series := head.series.getByHash(lbls.Hash(), lbls)
+				require.NotNil(t, series)
+				series.Lock()
+				require.NotEmpty(t, series.mmappedChunks, "the predecessor must be mmaped for this regression test")
+				require.Equal(t, wantType, valueTypeForChunkEncoding(series.mmappedChunks[len(series.mmappedChunks)-1].encoding))
+				series.Unlock()
+
+				require.NoError(t, head.Close())
+				head = openTestHeadWithWALAndWBL(t, dir, opts)
+				t.Cleanup(func() { _ = head.Close() })
+
+				require.Equal(t, uint64(1), head.NumNativeHistogramSeries())
+				require.Equal(t, uint64(0), head.NumNativeHistogramBuckets())
+				require.Equal(t, uint64(1), head.NumStaleSeries())
+				requireHeadSampleTypeAndST(t, head, lbls, 2000, wantType, wantST)
+			})
+		}
+	}
+
+	for _, appenderV2 := range []bool{false, true} {
+		for _, floatHistogram := range []bool{false, true} {
+			name := fmt.Sprintf("newer_mmap_than_snapshot/appender_v2=%t/float_histogram=%t", appenderV2, floatHistogram)
+			t.Run(name, func(t *testing.T) {
+				dir := t.TempDir()
+				opts := DefaultHeadOptions()
+				opts.ChunkDirRoot = dir
+				opts.ChunkRange = 1000
+				opts.EnableMemorySnapshotOnShutdown = true
+				if appenderV2 {
+					opts.EnableSTStorage.Store(true)
+					opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+					opts.EnableHistogramSTEncoding.Store(true)
+				}
+
+				head := openTestHeadWithWALAndWBL(t, dir, opts)
+				lbls := labels.FromStrings("name", name)
+				first := nativeHistogramTestSample{labels: lbls, st: 900, t: 1000}
+				if floatHistogram {
+					first.fh = tsdbutil.GenerateTestFloatHistograms(1)[0]
+				} else {
+					first.h = tsdbutil.GenerateTestHistograms(1)[0]
+				}
+				appendNativeHistogramTestSamples(t, head, appenderV2, first)
+				require.NoError(t, head.Close())
+
+				snapshotDir, snapshotIdx, snapshotOffset, err := LastChunkSnapshot(dir)
+				require.NoError(t, err)
+
+				head = openTestHeadWithWALAndWBL(t, dir, opts)
+				appendNativeHistogramTestSamples(t, head, appenderV2,
+					nativeHistogramTestSample{labels: lbls, st: 1900, t: 2000, v: 1},
+					nativeHistogramTestSample{labels: lbls, st: 2900, t: 3000, v: math.Float64frombits(value.StaleNaN)},
+				)
+				head.mmapHeadChunks()
+				series := head.series.getByHash(lbls.Hash(), lbls)
+				require.NotNil(t, series)
+				func() {
+					series.Lock()
+					defer series.Unlock()
+					require.NotEmpty(t, series.mmappedChunks, "a newer float predecessor must be mmaped")
+					require.Equal(t, chunkenc.ValFloat, valueTypeForChunkEncoding(series.mmappedChunks[len(series.mmappedChunks)-1].encoding))
+				}()
+
+				head.opts.EnableMemorySnapshotOnShutdown = false
+				require.NoError(t, head.Close())
+				gotSnapshotDir, gotSnapshotIdx, gotSnapshotOffset, err := LastChunkSnapshot(dir)
+				require.NoError(t, err)
+				require.Equal(t, snapshotDir, gotSnapshotDir)
+				require.Equal(t, snapshotIdx, gotSnapshotIdx)
+				require.Equal(t, snapshotOffset, gotSnapshotOffset)
+
+				opts.EnableMemorySnapshotOnShutdown = true
+				head = openTestHeadWithWALAndWBL(t, dir, opts)
+				t.Cleanup(func() { _ = head.Close() })
+
+				require.Equal(t, uint64(0), head.NumNativeHistogramSeries())
+				require.Equal(t, uint64(0), head.NumNativeHistogramBuckets())
+				require.Equal(t, uint64(1), head.NumStaleSeries())
+				wantST := int64(0)
+				if appenderV2 {
+					wantST = 2900
+				}
+				requireHeadSampleTypeAndST(t, head, lbls, 3000, chunkenc.ValFloat, wantST)
+			})
+		}
+	}
+
+	for _, appenderV2 := range []bool{false, true} {
+		for _, floatHistogram := range []bool{false, true} {
+			name := fmt.Sprintf("stale_snapshot_with_newer_histogram_mmap/appender_v2=%t/float_histogram=%t", appenderV2, floatHistogram)
+			t.Run(name, func(t *testing.T) {
+				dir := t.TempDir()
+				opts := DefaultHeadOptions()
+				opts.ChunkDirRoot = dir
+				opts.ChunkRange = 1000
+				opts.EnableMemorySnapshotOnShutdown = true
+				if appenderV2 {
+					opts.EnableSTStorage.Store(true)
+					opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+					opts.EnableHistogramSTEncoding.Store(true)
+				}
+
+				head := openTestHeadWithWALAndWBL(t, dir, opts)
+				lbls := labels.FromStrings("name", name)
+				appendNativeHistogramTestSamples(t, head, appenderV2, nativeHistogramTestSample{
+					labels: lbls,
+					st:     900,
+					t:      1000,
+					v:      math.Float64frombits(value.StaleNaN),
+				})
+				require.NoError(t, head.Close())
+
+				snapshotDir, snapshotIdx, snapshotOffset, err := LastChunkSnapshot(dir)
+				require.NoError(t, err)
+
+				head = openTestHeadWithWALAndWBL(t, dir, opts)
+				histogramSample := nativeHistogramTestSample{labels: lbls, st: 1900, t: 2000}
+				wantType := chunkenc.ValHistogram
+				if floatHistogram {
+					histogramSample.fh = tsdbutil.GenerateTestFloatHistograms(1)[0]
+					wantType = chunkenc.ValFloatHistogram
+				} else {
+					histogramSample.h = tsdbutil.GenerateTestHistograms(1)[0]
+				}
+				appendNativeHistogramTestSamples(t, head, appenderV2, histogramSample)
+				appendNativeHistogramTestSamples(t, head, appenderV2, nativeHistogramTestSample{
+					labels: lbls,
+					st:     2900,
+					t:      3000,
+					v:      math.Float64frombits(value.StaleNaN),
+				})
+				head.mmapHeadChunks()
+				series := head.series.getByHash(lbls.Hash(), lbls)
+				require.NotNil(t, series)
+				func() {
+					series.Lock()
+					defer series.Unlock()
+					require.NotEmpty(t, series.mmappedChunks, "a newer histogram predecessor must be mmaped")
+					require.Equal(t, wantType, valueTypeForChunkEncoding(series.mmappedChunks[len(series.mmappedChunks)-1].encoding))
+				}()
+
+				head.opts.EnableMemorySnapshotOnShutdown = false
+				require.NoError(t, head.Close())
+				gotSnapshotDir, gotSnapshotIdx, gotSnapshotOffset, err := LastChunkSnapshot(dir)
+				require.NoError(t, err)
+				require.Equal(t, snapshotDir, gotSnapshotDir)
+				require.Equal(t, snapshotIdx, gotSnapshotIdx)
+				require.Equal(t, snapshotOffset, gotSnapshotOffset)
+
+				opts.EnableMemorySnapshotOnShutdown = true
+				head = openTestHeadWithWALAndWBL(t, dir, opts)
+				t.Cleanup(func() { _ = head.Close() })
+
+				require.Equal(t, uint64(1), head.NumNativeHistogramSeries())
+				require.Equal(t, uint64(0), head.NumNativeHistogramBuckets())
+				require.Equal(t, uint64(1), head.NumStaleSeries())
+				wantST := int64(0)
+				if appenderV2 {
+					wantST = 2900
+				}
+				requireHeadSampleTypeAndST(t, head, lbls, 3000, wantType, wantST)
+			})
+		}
+	}
+}
+
+func TestHead_NativeHistogramMetrics_WALReplaySelectedSeriesDeletion(t *testing.T) {
+	for _, appenderV2 := range []bool{false, true} {
+		for _, floatHistogram := range []bool{false, true} {
+			name := fmt.Sprintf("appender_v2=%t/float_histogram=%t", appenderV2, floatHistogram)
+			t.Run(name, func(t *testing.T) {
+				dir := t.TempDir()
+				opts := DefaultHeadOptions()
+				opts.ChunkDirRoot = dir
+				if appenderV2 {
+					opts.EnableSTStorage.Store(true)
+					opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+					opts.EnableHistogramSTEncoding.Store(true)
+				}
+
+				head := openTestHeadWithWALAndWBL(t, dir, opts)
+				lbls := labels.FromStrings("name", name)
+				appendNativeHistogramTestSamples(t, head, appenderV2, nativeHistogramTestSample{
+					labels: lbls,
+					st:     900,
+					t:      1000,
+					v:      math.Float64frombits(value.StaleNaN),
+				})
+
+				histogramSample := nativeHistogramTestSample{labels: lbls, st: 1900, t: 2000}
+				if floatHistogram {
+					histogramSample.fh = tsdbutil.GenerateTestFloatHistograms(1)[0]
+				} else {
+					histogramSample.h = tsdbutil.GenerateTestHistograms(1)[0]
+				}
+				appendNativeHistogramTestSamples(t, head, appenderV2, histogramSample)
+
+				series := head.series.getByHash(lbls.Hash(), lbls)
+				require.NotNil(t, series)
+				require.NoError(t, head.truncateSelectedSeries(
+					[]storage.SeriesRef{storage.SeriesRef(series.ref)},
+					2000,
+					math.MaxUint64,
+				))
+				require.Zero(t, head.NumSeries())
+				require.NoError(t, head.Close())
+
+				head = openTestHeadWithWALAndWBL(t, dir, opts)
+				t.Cleanup(func() { _ = head.Close() })
+				require.Zero(t, head.NumSeries())
+				require.Zero(t, head.NumStaleSeries())
+				require.Zero(t, head.NumNativeHistogramSeries())
+				require.Zero(t, head.NumNativeHistogramBuckets())
+			})
+		}
+	}
+}
+
+func TestHead_NativeHistogramMetrics_MixedTypeStalenessRecoveryAndGC(t *testing.T) {
+	testTypes := []struct {
+		name   string
+		sample func(labels.Labels, int64, int64, bool) nativeHistogramTestSample
+	}{
+		{
+			name: "float",
+			sample: func(lbls labels.Labels, st, ts int64, stale bool) nativeHistogramTestSample {
+				v := float64(1)
+				if stale {
+					v = math.Float64frombits(value.StaleNaN)
+				}
+				return nativeHistogramTestSample{labels: lbls, st: st, t: ts, v: v}
+			},
+		},
+		{
+			name: "histogram",
+			sample: func(lbls labels.Labels, st, ts int64, stale bool) nativeHistogramTestSample {
+				h := tsdbutil.GenerateTestHistograms(1)[0]
+				if stale {
+					h.Sum = math.Float64frombits(value.StaleNaN)
+				}
+				return nativeHistogramTestSample{labels: lbls, st: st, t: ts, h: h}
+			},
+		},
+		{
+			name: "float_histogram",
+			sample: func(lbls labels.Labels, st, ts int64, stale bool) nativeHistogramTestSample {
+				fh := tsdbutil.GenerateTestFloatHistograms(1)[0]
+				if stale {
+					fh.Sum = math.Float64frombits(value.StaleNaN)
+				}
+				return nativeHistogramTestSample{labels: lbls, st: st, t: ts, fh: fh}
+			},
+		},
+	}
+
+	for _, appenderV2 := range []bool{false, true} {
+		for _, from := range testTypes {
+			for _, to := range testTypes {
+				if from.name == to.name {
+					continue
+				}
+				name := fmt.Sprintf("appender_v2=%t/from=%s/to=%s", appenderV2, from.name, to.name)
+				t.Run(name, func(t *testing.T) {
+					dir := t.TempDir()
+					opts := DefaultHeadOptions()
+					opts.ChunkDirRoot = dir
+					opts.ChunkRange = 1000
+					if appenderV2 {
+						opts.EnableSTStorage.Store(true)
+						opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+						opts.EnableHistogramSTEncoding.Store(true)
+					}
+
+					head := openTestHeadWithWALAndWBL(t, dir, opts)
+					lbls := labels.FromStrings("name", name)
+					appendNativeHistogramTestSamples(t, head, appenderV2, from.sample(lbls, 900, 1000, true))
+					require.Equal(t, uint64(1), head.NumStaleSeries())
+					appendNativeHistogramTestSamples(t, head, appenderV2, to.sample(lbls, 1900, 2000, false))
+					require.Zero(t, head.NumStaleSeries())
+
+					// Simulate an unclean shutdown before the stale predecessor is mmaped.
+					require.NoError(t, head.chunkDiskMapper.Close())
+					require.NoError(t, head.wal.Close())
+					require.NoError(t, head.wbl.Close())
+
+					head = openTestHeadWithWALAndWBL(t, dir, opts)
+					t.Cleanup(func() { _ = head.Close() })
+					require.Zero(t, head.NumStaleSeries())
+
+					appendNativeHistogramTestSamples(t, head, appenderV2, nativeHistogramTestSample{
+						labels: labels.FromStrings("name", "keep"),
+						st:     3900,
+						t:      4000,
+						v:      1,
+					})
+					require.NoError(t, head.Truncate(3000))
+					head.gc()
+					require.Equal(t, uint64(1), head.NumSeries())
+					require.Zero(t, head.NumStaleSeries())
+					require.Zero(t, head.NumNativeHistogramSeries())
+					require.Zero(t, head.NumNativeHistogramBuckets())
+				})
+			}
+		}
+	}
+}
+
+func TestHead_NativeHistogramMetrics_WALReplayRejectedSamples(t *testing.T) {
+	for _, appenderV2 := range []bool{false, true} {
+		t.Run(fmt.Sprintf("appender_v2=%t", appenderV2), func(t *testing.T) {
+			dir := t.TempDir()
+			opts := DefaultHeadOptions()
+			opts.ChunkDirRoot = dir
+			opts.ChunkRange = DefaultBlockDuration
+			opts.OutOfOrderTimeWindow.Store(5000)
+			if appenderV2 {
+				opts.EnableSTStorage.Store(true)
+				opts.FloatChunkEncoding.Store(uint32(chunkenc.EncXOR2))
+				opts.EnableHistogramSTEncoding.Store(true)
+			}
+			head := openTestHeadWithWALAndWBL(t, dir, opts)
+
+			histograms := tsdbutil.GenerateTestHistograms(5)
+			threeBucketHistogram := &histogram.Histogram{
+				Count:           9,
+				ZeroThreshold:   0.001,
+				Schema:          1,
+				Sum:             10,
+				PositiveSpans:   []histogram.Span{{Offset: 0, Length: 3}},
+				PositiveBuckets: []int64{2, 1, 1},
+			}
+			histogramSeries := labels.FromStrings("name", "histogram_then_ooo_floats")
+			floatSeries := labels.FromStrings("name", "float_then_ooo_histograms")
+			staleSeries := labels.FromStrings("name", "histogram_then_ooo_stale")
+			conflictSeries := labels.FromStrings("name", "conflicting_histograms")
+
+			appendNativeHistogramTestSamples(t, head, appenderV2, nativeHistogramTestSample{labels: histogramSeries, st: 1900, t: 2000, h: histograms[0]})
+			appendNativeHistogramTestSamples(t, head, appenderV2,
+				nativeHistogramTestSample{labels: histogramSeries, st: 900, t: 1000, v: 1},
+				nativeHistogramTestSample{labels: histogramSeries, st: 1000, t: 1100, v: 2},
+			)
+			appendNativeHistogramTestSamples(t, head, appenderV2, nativeHistogramTestSample{labels: floatSeries, st: 1900, t: 2000, v: 1})
+			appendNativeHistogramTestSamples(t, head, appenderV2,
+				nativeHistogramTestSample{labels: floatSeries, st: 900, t: 1000, h: histograms[1]},
+				nativeHistogramTestSample{labels: floatSeries, st: 1000, t: 1100, h: histograms[2]},
+			)
+			appendNativeHistogramTestSamples(t, head, appenderV2, nativeHistogramTestSample{labels: staleSeries, st: 1900, t: 2000, h: histograms[3]})
+			appendNativeHistogramTestSamples(t, head, appenderV2, nativeHistogramTestSample{
+				labels: staleSeries,
+				st:     900,
+				t:      1000,
+				v:      math.Float64frombits(value.StaleNaN),
+			})
+			appendNativeHistogramTestSamples(t, head, appenderV2,
+				nativeHistogramTestSample{labels: conflictSeries, st: 2900, t: 3000, h: histograms[4]},
+				nativeHistogramTestSample{labels: conflictSeries, st: 2900, t: 3000, h: threeBucketHistogram},
+			)
+
+			require.Equal(t, uint64(3), head.NumNativeHistogramSeries())
+			require.Equal(t, uint64(24), head.NumNativeHistogramBuckets())
+			require.Equal(t, uint64(0), head.NumStaleSeries())
+			require.NoError(t, head.Close())
+
+			head = openTestHeadWithWALAndWBL(t, dir, opts)
+			t.Cleanup(func() { _ = head.Close() })
+			require.Equal(t, uint64(3), head.NumNativeHistogramSeries())
+			require.Equal(t, uint64(24), head.NumNativeHistogramBuckets())
+			require.Equal(t, uint64(0), head.NumStaleSeries())
+
+			wantOOOST := int64(0)
+			wantInOrderST := int64(0)
+			if appenderV2 {
+				wantOOOST = 900
+				wantInOrderST = 1900
+			}
+			requireOOOHeadSampleTypeAndST(t, head, histogramSeries, 1000, chunkenc.ValFloat, wantOOOST)
+			requireHeadSampleTypeAndST(t, head, histogramSeries, 2000, chunkenc.ValHistogram, wantInOrderST)
+			requireOOOHeadSampleTypeAndST(t, head, floatSeries, 1000, chunkenc.ValHistogram, wantOOOST)
+			requireHeadSampleTypeAndST(t, head, floatSeries, 2000, chunkenc.ValFloat, wantInOrderST)
+			requireOOOHeadSampleTypeAndST(t, head, staleSeries, 1000, chunkenc.ValHistogram, wantOOOST)
+
+			series := head.series.getByHash(conflictSeries.Hash(), conflictSeries)
+			require.NotNil(t, series)
+			series.Lock()
+			require.NotNil(t, series.lastHistogramValue)
+			require.Equal(t, 8, len(series.lastHistogramValue.PositiveBuckets)+len(series.lastHistogramValue.NegativeBuckets))
+			series.Unlock()
+		})
+	}
+}
+
+func TestHead_NativeHistogramMetrics_StalePayloadRecoveryAndGC(t *testing.T) {
+	for _, snapshot := range []bool{false, true} {
+		for _, floatHistogram := range []bool{false, true} {
+			name := fmt.Sprintf("snapshot=%t/float_histogram=%t", snapshot, floatHistogram)
+			t.Run(name, func(t *testing.T) {
+				dir := t.TempDir()
+				opts := DefaultHeadOptions()
+				opts.ChunkDirRoot = dir
+				opts.ChunkRange = 1000
+				opts.EnableMemorySnapshotOnShutdown = snapshot
+				head := openTestHeadWithWALAndWBL(t, dir, opts)
+
+				lbls := labels.FromStrings("name", "stale_histogram")
+				first := nativeHistogramTestSample{labels: lbls, t: 100}
+				stale := nativeHistogramTestSample{labels: lbls, t: 200}
+				wantType := chunkenc.ValHistogram
+				if floatHistogram {
+					first.fh = tsdbutil.GenerateTestFloatHistograms(1)[0]
+					stale.fh = first.fh.Copy()
+					stale.fh.Sum = math.Float64frombits(value.StaleNaN)
+					wantType = chunkenc.ValFloatHistogram
+				} else {
+					first.h = tsdbutil.GenerateTestHistograms(1)[0]
+					stale.h = first.h.Copy()
+					stale.h.Sum = math.Float64frombits(value.StaleNaN)
+				}
+				appendNativeHistogramTestSamples(t, head, false, first)
+				appendNativeHistogramTestSamples(t, head, false, stale)
+				require.Equal(t, uint64(1), head.NumNativeHistogramSeries())
+				require.Equal(t, uint64(0), head.NumNativeHistogramBuckets())
+				require.Equal(t, uint64(1), head.NumStaleSeries())
+				require.NoError(t, head.Close())
+				if snapshot {
+					_, _, _, err := LastChunkSnapshot(dir)
+					require.NoError(t, err)
+				}
+
+				head = openTestHeadWithWALAndWBL(t, dir, opts)
+				t.Cleanup(func() { _ = head.Close() })
+				require.Equal(t, uint64(1), head.NumNativeHistogramSeries())
+				require.Equal(t, uint64(0), head.NumNativeHistogramBuckets())
+				require.Equal(t, uint64(1), head.NumStaleSeries())
+				requireHeadSampleTypeAndST(t, head, lbls, 200, wantType, 0)
+
+				series := head.series.getByHash(lbls.Hash(), lbls)
+				require.NotNil(t, series)
+				series.Lock()
+				isHistogram, buckets := series.nativeHistogramState()
+				require.True(t, isHistogram)
+				require.Zero(t, buckets)
+				if floatHistogram {
+					require.NotEmpty(t, series.lastFloatHistogramValue.PositiveBuckets)
+				} else {
+					require.NotEmpty(t, series.lastHistogramValue.PositiveBuckets)
+				}
+				series.Unlock()
+
+				appendNativeHistogramTestSamples(t, head, false, nativeHistogramTestSample{
+					labels: labels.FromStrings("name", "keep"),
+					t:      2000,
+					v:      1,
+				})
+				require.NoError(t, head.Truncate(1000))
+				head.gc()
+				require.Equal(t, uint64(1), head.NumSeries())
+				require.Equal(t, uint64(0), head.NumNativeHistogramSeries())
+				require.Equal(t, uint64(0), head.NumNativeHistogramBuckets())
+			})
+		}
+	}
+}
+
 func TestHead_NumNativeHistogramSeriesAndBuckets(t *testing.T) {
 	head, _ := newTestHead(t, 1000, compression.None, false)
 	t.Cleanup(func() {
@@ -9647,7 +10270,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 
 		type testCase struct {
 			appendOnce     func(app storage.Appender, lbls labels.Labels, ts int64, i int) error
-			appendInternal func(ms *memSeries, t int64, opts chunkOpts) bool
+			appendInternal func(ms *memSeries, t int64, opts chunkOpts) (bool, bool)
 		}
 		testCases := map[string]testCase{
 			"floats": {
@@ -9655,9 +10278,8 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 					_, err := app.Append(0, lbls, ts, float64(ts))
 					return err
 				},
-				appendInternal: func(ms *memSeries, t int64, opts chunkOpts) bool {
-					_, chunkCreated := ms.append(0, t, 0, 0, opts)
-					return chunkCreated
+				appendInternal: func(ms *memSeries, t int64, opts chunkOpts) (bool, bool) {
+					return ms.append(0, t, 0, 0, opts)
 				},
 			},
 			"histograms": {
@@ -9665,9 +10287,8 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 					_, err := app.AppendHistogram(0, lbls, ts, histograms[i], nil)
 					return err
 				},
-				appendInternal: func(ms *memSeries, t int64, opts chunkOpts) bool {
-					_, chunkCreated := ms.appendHistogram(0, t, histograms[0], 0, opts)
-					return chunkCreated
+				appendInternal: func(ms *memSeries, t int64, opts chunkOpts) (bool, bool) {
+					return ms.appendHistogram(0, t, histograms[0], 0, opts)
 				},
 			},
 			"float histograms": {
@@ -9675,9 +10296,8 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 					_, err := app.AppendHistogram(0, lbls, ts, nil, floatHistograms[i])
 					return err
 				},
-				appendInternal: func(ms *memSeries, t int64, opts chunkOpts) bool {
-					_, chunkCreated := ms.appendFloatHistogram(0, t, floatHistograms[0], 0, opts)
-					return chunkCreated
+				appendInternal: func(ms *memSeries, t int64, opts chunkOpts) (bool, bool) {
+					return ms.appendFloatHistogram(0, t, floatHistograms[0], 0, opts)
 				},
 			},
 		}
@@ -9713,7 +10333,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 				// Invoke the WAL-replay-style helper with a sample timestamped
 				// past the next chunk boundary to force a chunk cut.
 				s.Lock()
-				chunkCreated := h.appendChunkAndMmap(s, func() bool {
+				sampleInOrder, chunkCreated := h.appendChunkAndMmap(s, func() (bool, bool) {
 					return tc.appendInternal(s, ts+h.chunkRange.Load(), chunkOpts{
 						chunkDiskMapper: h.chunkDiskMapper,
 						chunkRange:      h.chunkRange.Load(),
@@ -9721,6 +10341,7 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 					})
 				})
 				s.Unlock()
+				require.True(t, sampleInOrder, "test sample must be accepted")
 				require.True(t, chunkCreated, "test needs a chunk cut to be meaningful")
 
 				// After the chunk cut + mmap, headChunkCount == 1 (mmapChunks

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -7899,6 +7899,144 @@ func TestHead_NumStaleSeries(t *testing.T) {
 	verifySeriesCounts(4, 5)
 }
 
+func TestHead_NumNativeHistogramSeriesAndBuckets(t *testing.T) {
+	head, _ := newTestHead(t, 1000, compression.None, false)
+	t.Cleanup(func() {
+		// Captures head by reference, so it closes the final head after restarts.
+		_ = head.Close()
+	})
+	require.NoError(t, head.Init(0))
+
+	// Initially, there are no native histogram series or buckets.
+	require.Equal(t, uint64(0), head.NumNativeHistogramSeries())
+	require.Equal(t, uint64(0), head.NumNativeHistogramBuckets())
+
+	appendSample := func(lbls labels.Labels, ts int64, val float64) {
+		app := head.Appender(context.Background())
+		_, err := app.Append(0, lbls, ts, val)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+	}
+	appendHistogram := func(lbls labels.Labels, ts int64, val *histogram.Histogram) {
+		app := head.Appender(context.Background())
+		_, err := app.AppendHistogram(0, lbls, ts, val, nil)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+	}
+	appendFloatHistogram := func(lbls labels.Labels, ts int64, val *histogram.FloatHistogram) {
+		app := head.Appender(context.Background())
+		_, err := app.AppendHistogram(0, lbls, ts, nil, val)
+		require.NoError(t, err)
+		require.NoError(t, app.Commit())
+	}
+
+	verifyCounts := func(numHistogramSeries, numHistogramBuckets, numSeries int) {
+		t.Helper()
+		require.Equal(t, uint64(numHistogramSeries), head.NumNativeHistogramSeries())
+		require.Equal(t, uint64(numHistogramBuckets), head.NumNativeHistogramBuckets())
+		require.Equal(t, uint64(numSeries), head.NumSeries())
+	}
+
+	restartHeadAndVerifyCounts := func(numHistogramSeries, numHistogramBuckets, numSeries int) {
+		t.Helper()
+		verifyCounts(numHistogramSeries, numHistogramBuckets, numSeries)
+
+		require.NoError(t, head.Close())
+
+		wal, err := wlog.NewSize(nil, nil, filepath.Join(head.opts.ChunkDirRoot, "wal"), 32768, compression.None)
+		require.NoError(t, err)
+		head, err = NewHead(nil, nil, wal, nil, head.opts, nil)
+		require.NoError(t, err)
+		require.NoError(t, head.Init(0))
+
+		verifyCounts(numHistogramSeries, numHistogramBuckets, numSeries)
+	}
+
+	// The standard test histograms carry 4 positive and 4 negative buckets each.
+	stdHist := tsdbutil.GenerateTestHistograms(3)
+	require.Equal(t, 8, len(stdHist[0].PositiveBuckets)+len(stdHist[0].NegativeBuckets))
+	stdFloatHist := tsdbutil.GenerateTestFloatHistograms(3)
+	require.Equal(t, 8, len(stdFloatHist[0].PositiveBuckets)+len(stdFloatHist[0].NegativeBuckets))
+	// A histogram with a different (3) bucket count, to exercise bucket deltas.
+	threeBucketHist := &histogram.Histogram{
+		// Buckets accumulate to 2, 3, 4, so the observation count is 9.
+		Count:           9,
+		ZeroThreshold:   0.001,
+		Schema:          1,
+		Sum:             10,
+		PositiveSpans:   []histogram.Span{{Offset: 0, Length: 3}},
+		PositiveBuckets: []int64{2, 1, 1},
+	}
+
+	series1 := labels.FromStrings("name", "series1")
+	series2 := labels.FromStrings("name", "series2")
+
+	// Plain float series never count as native histogram series.
+	appendSample(series1, 100, 1)
+	verifyCounts(0, 0, 1)
+
+	// A float series turning into a native histogram series is counted, and its
+	// buckets are added.
+	appendHistogram(series1, 110, stdHist[0])
+	verifyCounts(1, 8, 1)
+
+	// Another native histogram sample with the same bucket count keeps the counts.
+	appendHistogram(series1, 120, stdHist[1])
+	verifyCounts(1, 8, 1)
+
+	// A new series that starts directly as a float histogram is counted.
+	appendFloatHistogram(series2, 100, stdFloatHist[0])
+	verifyCounts(2, 16, 2)
+
+	restartHeadAndVerifyCounts(2, 16, 2)
+
+	// A native histogram sample with fewer buckets adjusts the bucket gauge by
+	// the delta (8 -> 3).
+	appendHistogram(series1, 130, threeBucketHist)
+	verifyCounts(2, 11, 2)
+
+	// A float sample on a native histogram series removes it from both gauges.
+	appendSample(series1, 140, 5)
+	verifyCounts(1, 8, 2)
+
+	restartHeadAndVerifyCounts(1, 8, 2)
+
+	// A proper staleness marker (an empty histogram) keeps the series counted as
+	// a native histogram series but drops its buckets to zero.
+	staleFloatHist := &histogram.FloatHistogram{Sum: math.Float64frombits(value.StaleNaN)}
+	appendFloatHistogram(series2, 110, staleFloatHist)
+	verifyCounts(1, 0, 2)
+
+	// A subsequent non-stale float histogram restores the bucket count.
+	appendFloatHistogram(series2, 120, stdFloatHist[1])
+	verifyCounts(1, 8, 2)
+
+	// This will test restarting with snapshot.
+	head.opts.EnableMemorySnapshotOnShutdown = true
+	restartHeadAndVerifyCounts(1, 8, 2)
+
+	// Garbage collection: a removed native histogram series decrements both gauges.
+	// Keep series2 alive with a fresh sample, then truncate away the older series1.
+	appendFloatHistogram(series2, 400, stdFloatHist[2])
+	require.NoError(t, head.Truncate(300))
+	head.gc()
+	// series1 (float, last sample at ts 140) is gone; series2 remains as a native
+	// histogram series with 8 buckets.
+	verifyCounts(1, 8, 1)
+
+	// A brand new series starting directly as a native histogram is counted.
+	series3 := labels.FromStrings("name", "series3")
+	appendHistogram(series3, 400, stdHist[2])
+	verifyCounts(2, 16, 2)
+
+	// GC of that native histogram series decrements the gauges again.
+	appendFloatHistogram(series2, 500, stdFloatHist[0])
+	require.NoError(t, head.Truncate(450))
+	head.gc()
+	// series3 (last sample at ts 400) is removed, series2 remains.
+	verifyCounts(1, 8, 1)
+}
+
 // TestHead_FilterSelectedSeriesAndSortPostings exercises the helper directly, covering the
 // three outcomes for a given ref: kept (clean series), skipped (series carries OOO data), and
 // silently dropped (ref does not resolve to any series in the head).

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -722,8 +722,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				h.numStaleSeries.Dec()
 			}
 
-			wasHistogram := ms.isNativeHistogramSeries()
-			oldBuckets := ms.nativeHistogramBucketCount()
+			wasHistogram, oldBuckets := ms.nativeHistogramState()
 			h.appendChunkAndMmap(ms, func() bool {
 				_, chunkCreated := ms.append(s.ST, s.T, s.V, 0, appendChunkOpts)
 				return chunkCreated
@@ -755,8 +754,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				continue
 			}
 			var newlyStale, staleToNonStale bool
-			wasHistogram := ms.isNativeHistogramSeries()
-			oldBuckets := ms.nativeHistogramBucketCount()
+			wasHistogram, oldBuckets := ms.nativeHistogramState()
 			var newBuckets int
 			if s.h != nil {
 				newlyStale = value.IsStaleNaN(s.h.Sum)
@@ -1732,9 +1730,9 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 					(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
 					h.numStaleSeries.Inc()
 				}
-				if series.isNativeHistogramSeries() {
+				if isHist, buckets := series.nativeHistogramState(); isHist {
 					h.numNativeHistogramSeries.Inc()
-					h.addNativeHistogramBuckets(series.nativeHistogramBucketCount())
+					h.addNativeHistogramBuckets(buckets)
 				}
 
 				app, err := series.headChunks.chunk.Appender()

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -722,10 +722,13 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				h.numStaleSeries.Dec()
 			}
 
+			wasHistogram := ms.isNativeHistogramSeries()
+			oldBuckets := ms.nativeHistogramBucketCount()
 			h.appendChunkAndMmap(ms, func() bool {
 				_, chunkCreated := ms.append(s.ST, s.T, s.V, 0, appendChunkOpts)
 				return chunkCreated
 			})
+			h.updateNativeHistogramMetricsOnAppend(wasHistogram, false, oldBuckets, 0)
 			if s.T > maxt {
 				maxt = s.T
 			}
@@ -752,12 +755,16 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				continue
 			}
 			var newlyStale, staleToNonStale bool
+			wasHistogram := ms.isNativeHistogramSeries()
+			oldBuckets := ms.nativeHistogramBucketCount()
+			var newBuckets int
 			if s.h != nil {
 				newlyStale = value.IsStaleNaN(s.h.Sum)
 				if ms.lastHistogramValue != nil {
 					newlyStale = newlyStale && !value.IsStaleNaN(ms.lastHistogramValue.Sum)
 					staleToNonStale = value.IsStaleNaN(ms.lastHistogramValue.Sum) && !value.IsStaleNaN(s.h.Sum)
 				}
+				newBuckets = len(s.h.PositiveBuckets) + len(s.h.NegativeBuckets)
 				h.appendChunkAndMmap(ms, func() bool {
 					_, chunkCreated := ms.appendHistogram(s.st, s.t, s.h, 0, appendChunkOpts)
 					return chunkCreated
@@ -768,6 +775,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 					newlyStale = newlyStale && !value.IsStaleNaN(ms.lastFloatHistogramValue.Sum)
 					staleToNonStale = value.IsStaleNaN(ms.lastFloatHistogramValue.Sum) && !value.IsStaleNaN(s.fh.Sum)
 				}
+				newBuckets = len(s.fh.PositiveBuckets) + len(s.fh.NegativeBuckets)
 				h.appendChunkAndMmap(ms, func() bool {
 					_, chunkCreated := ms.appendFloatHistogram(s.st, s.t, s.fh, 0, appendChunkOpts)
 					return chunkCreated
@@ -779,6 +787,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if staleToNonStale {
 				h.numStaleSeries.Dec()
 			}
+			h.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			if s.t > maxt {
 				maxt = s.t
 			}
@@ -1722,6 +1731,10 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 					(series.lastHistogramValue != nil && value.IsStaleNaN(series.lastHistogramValue.Sum)) ||
 					(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
 					h.numStaleSeries.Inc()
+				}
+				if series.isNativeHistogramSeries() {
+					h.numNativeHistogramSeries.Inc()
+					h.addNativeHistogramBuckets(series.nativeHistogramBucketCount())
 				}
 
 				app, err := series.headChunks.chunk.Appender()

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -646,27 +646,103 @@ func (wp *walSubsetProcessor) reuseHistogramBuf() []histogramRecord {
 	return nil
 }
 
-// appendChunkAndMmap appends a sample to ms via appendFn and, if a new head
-// chunk was created, immediately mmaps the now-completed predecessors. Used
-// by WAL replay paths to keep memory bounded by mmapping eagerly rather than
-// waiting for the periodic mmapHeadChunks pass.
-//
-// If the chunk cut + mmap reduces headChunkCount from >= 2 to < 2 (which
-// happens whenever prev >= 2, since mmapChunks always sets the count to 1
-// when it does work), the per-stripe mmap-ready counter is decremented to
-// maintain its invariant.
-func (h *Head) appendChunkAndMmap(ms *memSeries, appendFn func() bool) bool {
+// appendChunkAndMmap appends during WAL replay and eagerly mmaps completed
+// predecessors. It returns whether the sample was accepted and cut a chunk.
+func (h *Head) appendChunkAndMmap(ms *memSeries, appendFn func() (bool, bool)) (sampleInOrder, chunkCreated bool) {
 	prev := ms.headChunkCount.Load()
-	chunkCreated := appendFn()
+	sampleInOrder, chunkCreated = appendFn()
 	if chunkCreated {
 		h.metrics.chunksCreated.Inc()
 		h.metrics.chunks.Inc()
 		_ = ms.mmapChunks(h.chunkDiskMapper)
+		// mmapChunks leaves one head chunk, so the series is no longer ready.
 		if prev >= 2 {
 			h.series.decMmapReady(ms.ref)
 		}
 	}
-	return chunkCreated
+	return sampleInOrder, chunkCreated
+}
+
+func valueTypeForChunkEncoding(enc chunkenc.Encoding) chunkenc.ValueType {
+	switch enc {
+	case chunkenc.EncXOR, chunkenc.EncXOR2:
+		return chunkenc.ValFloat
+	case chunkenc.EncHistogram, chunkenc.EncHistogramST:
+		return chunkenc.ValHistogram
+	case chunkenc.EncFloatHistogram, chunkenc.EncFloatHistogramST:
+		return chunkenc.ValFloatHistogram
+	default:
+		return chunkenc.ValNone
+	}
+}
+
+// latestInOrderValueType reports the newest materialized chunk's type, falling
+// back to snapshot last-value state when no chunk remains.
+func (s *memSeries) latestInOrderValueType() chunkenc.ValueType {
+	switch {
+	case s.headChunks != nil:
+		return valueTypeForChunkEncoding(s.headChunks.chunk.Encoding())
+	case len(s.mmappedChunks) > 0:
+		return valueTypeForChunkEncoding(s.mmappedChunks[len(s.mmappedChunks)-1].encoding)
+	case s.lastHistogramValue != nil:
+		return chunkenc.ValHistogram
+	case s.lastFloatHistogramValue != nil:
+		return chunkenc.ValFloatHistogram
+	default:
+		return chunkenc.ValNone
+	}
+}
+
+func (h *Head) appendWALFloat(ms *memSeries, s record.RefSample, opts chunkOpts) bool {
+	if value.IsStaleNaN(s.V) {
+		switch ms.latestInOrderValueType() {
+		case chunkenc.ValHistogram:
+			return h.appendWALHistogram(ms, s.ST, s.T, &histogram.Histogram{Sum: s.V}, nil, opts)
+		case chunkenc.ValFloatHistogram:
+			return h.appendWALHistogram(ms, s.ST, s.T, nil, &histogram.FloatHistogram{Sum: s.V}, opts)
+		}
+	}
+
+	wasStale := isStaleSeries(ms)
+	isStale := value.IsStaleNaN(s.V)
+	wasHistogram, oldBuckets := ms.nativeHistogramState()
+	sampleInOrder, _ := h.appendChunkAndMmap(ms, func() (bool, bool) {
+		return ms.append(s.ST, s.T, s.V, 0, opts)
+	})
+	if !sampleInOrder {
+		return false
+	}
+	h.updateStaleSeriesMetricOnAppend(wasStale, isStale)
+	h.updateNativeHistogramMetricsOnAppend(wasHistogram, false, oldBuckets, 0)
+	return true
+}
+
+func (h *Head) appendWALHistogram(ms *memSeries, st, t int64, hist *histogram.Histogram, floatHist *histogram.FloatHistogram, opts chunkOpts) bool {
+	wasStale := isStaleSeries(ms)
+	wasHistogram, oldBuckets := ms.nativeHistogramState()
+	var isStale bool
+	var newBuckets int
+	var sampleInOrder bool
+
+	if hist != nil {
+		isStale = value.IsStaleNaN(hist.Sum)
+		newBuckets = nativeHistogramBucketCount(hist.Sum, len(hist.PositiveBuckets), len(hist.NegativeBuckets))
+		sampleInOrder, _ = h.appendChunkAndMmap(ms, func() (bool, bool) {
+			return ms.appendHistogram(st, t, hist, 0, opts)
+		})
+	} else {
+		isStale = value.IsStaleNaN(floatHist.Sum)
+		newBuckets = nativeHistogramBucketCount(floatHist.Sum, len(floatHist.PositiveBuckets), len(floatHist.NegativeBuckets))
+		sampleInOrder, _ = h.appendChunkAndMmap(ms, func() (bool, bool) {
+			return ms.appendFloatHistogram(st, t, floatHist, 0, opts)
+		})
+	}
+	if !sampleInOrder {
+		return false
+	}
+	h.updateStaleSeriesMetricOnAppend(wasStale, isStale)
+	h.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
+	return true
 }
 
 // processWALSamples adds the samples it receives to the head and passes
@@ -715,19 +791,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 				continue
 			}
 
-			if !value.IsStaleNaN(ms.lastValue) && value.IsStaleNaN(s.V) {
-				h.numStaleSeries.Inc()
-			}
-			if value.IsStaleNaN(ms.lastValue) && !value.IsStaleNaN(s.V) {
-				h.numStaleSeries.Dec()
-			}
-
-			wasHistogram, oldBuckets := ms.nativeHistogramState()
-			h.appendChunkAndMmap(ms, func() bool {
-				_, chunkCreated := ms.append(s.ST, s.T, s.V, 0, appendChunkOpts)
-				return chunkCreated
-			})
-			h.updateNativeHistogramMetricsOnAppend(wasHistogram, false, oldBuckets, 0)
+			h.appendWALFloat(ms, s, appendChunkOpts)
 			if s.T > maxt {
 				maxt = s.T
 			}
@@ -753,39 +817,11 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 			if s.t <= ms.mmMaxTime {
 				continue
 			}
-			var newlyStale, staleToNonStale bool
-			wasHistogram, oldBuckets := ms.nativeHistogramState()
-			var newBuckets int
 			if s.h != nil {
-				newlyStale = value.IsStaleNaN(s.h.Sum)
-				if ms.lastHistogramValue != nil {
-					newlyStale = newlyStale && !value.IsStaleNaN(ms.lastHistogramValue.Sum)
-					staleToNonStale = value.IsStaleNaN(ms.lastHistogramValue.Sum) && !value.IsStaleNaN(s.h.Sum)
-				}
-				newBuckets = len(s.h.PositiveBuckets) + len(s.h.NegativeBuckets)
-				h.appendChunkAndMmap(ms, func() bool {
-					_, chunkCreated := ms.appendHistogram(s.st, s.t, s.h, 0, appendChunkOpts)
-					return chunkCreated
-				})
+				h.appendWALHistogram(ms, s.st, s.t, s.h, nil, appendChunkOpts)
 			} else {
-				newlyStale = value.IsStaleNaN(s.fh.Sum)
-				if ms.lastFloatHistogramValue != nil {
-					newlyStale = newlyStale && !value.IsStaleNaN(ms.lastFloatHistogramValue.Sum)
-					staleToNonStale = value.IsStaleNaN(ms.lastFloatHistogramValue.Sum) && !value.IsStaleNaN(s.fh.Sum)
-				}
-				newBuckets = len(s.fh.PositiveBuckets) + len(s.fh.NegativeBuckets)
-				h.appendChunkAndMmap(ms, func() bool {
-					_, chunkCreated := ms.appendFloatHistogram(s.st, s.t, s.fh, 0, appendChunkOpts)
-					return chunkCreated
-				})
+				h.appendWALHistogram(ms, s.st, s.t, nil, s.fh, appendChunkOpts)
 			}
-			if newlyStale {
-				h.numStaleSeries.Inc()
-			}
-			if staleToNonStale {
-				h.numStaleSeries.Dec()
-			}
-			h.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			if s.t > maxt {
 				maxt = s.t
 			}
@@ -1725,9 +1761,7 @@ func (h *Head) loadChunkSnapshot() (int, int, map[chunks.HeadSeriesRef]*memSerie
 				series.lastHistogramValue = csr.lastHistogramValue
 				series.lastFloatHistogramValue = csr.lastFloatHistogramValue
 
-				if value.IsStaleNaN(series.lastValue) ||
-					(series.lastHistogramValue != nil && value.IsStaleNaN(series.lastHistogramValue.Sum)) ||
-					(series.lastFloatHistogramValue != nil && value.IsStaleNaN(series.lastFloatHistogramValue.Sum)) {
+				if isStaleSeries(series) {
 					h.numStaleSeries.Inc()
 				}
 				if isHist, buckets := series.nativeHistogramState(); isHist {


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

Supposed fixes made by Codex to #19170. PTAL @krajorama and let me know whether they make sense.

## What

Fixes native histogram Head metric and stale-series accounting during ingestion, WAL replay, recovery, and series removal.

## Changes

- Update metrics only after WAL samples are accepted as in-order, preventing rejected or conflicting samples from corrupting the gauges.
- Track staleness according to the series’ current sample type across float, integer histogram, and float histogram transitions.
- Preserve histogram stale-marker types and start timestamps during ingestion and replay.
- Recover the current sample type from newer memory-mapped chunks when snapshot state is outdated.
- Count stale native histograms as zero buckets, including stale samples that retain bucket payloads.
- Clarify the metric help text to document latest-sample and stale-histogram semantics.

## Tests

Adds regression coverage for both appender versions, integer and float histograms, mixed-type transitions, rejected WAL samples, stale-marker conversion, outdated snapshots, unclean restarts, garbage collection, and selected-series deletion.

Also adds a benchmark for the native histogram metric update path.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes

```
