### PR TITLE
Add automation to let triagers approve PR workflows

### DIFF
--- a/.github/workflows/approve-workflows.yml
+++ b/.github/workflows/approve-workflows.yml
@@ -1,0 +1,24 @@
+---
+name: Approve pending workflows
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: read-all
+
+jobs:
+  approve:
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/workflow-approve' &&
+      github.repository_owner == 'prometheus'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: prometheus/promci/approve_workflows@370e8c15dcec50043cbe66f2f34633d9efc0a190
+        with:
+          github_token: ${{ github.token }}

--- a/scripts/dependabot.yml
+++ b/scripts/dependabot.yml
@@ -30,6 +30,7 @@ updates:
           - "github/codeql-action*"
     # Exclude configs synced from upstream prometheus/prometheus.
     exclude-paths:
+      - .github/workflows/approve-workflows.yml
       - .github/workflows/container_description.yml
       - .github/workflows/golangci-lint.yml
       - .github/workflows/govulncheck.yml

--- a/scripts/sync_repo_files.sh
+++ b/scripts/sync_repo_files.sh
@@ -64,7 +64,7 @@ for org in ${orgs}; do
 done
 
 # List of files that should be synced.
-SYNC_FILES="CODE_OF_CONDUCT.md LICENSE Makefile.common SECURITY.md .dockerignore .yamllint scripts/dependabot.yml scripts/golangci-lint.yml .github/workflows/govulncheck.yml .github/workflows/scorecards.yml .github/workflows/container_description.yml .github/workflows/stale.yml"
+SYNC_FILES="CODE_OF_CONDUCT.md LICENSE Makefile.common SECURITY.md .dockerignore .yamllint scripts/dependabot.yml scripts/golangci-lint.yml .github/workflows/approve-workflows.yml .github/workflows/govulncheck.yml .github/workflows/scorecards.yml .github/workflows/container_description.yml .github/workflows/stale.yml"
 
 # Go to the root of the repo
 cd "$(git rev-parse --show-cdup)" || exit 1
@@ -238,7 +238,7 @@ process_repo() {
     if [[ -z "${target_file}" ]]; then
       repo_log "${target_filename} doesn't exist in ${org_repo}"
       case "${source_file}" in
-        CODE_OF_CONDUCT.md | SECURITY.md | .dockerignore | .github/workflows/container_description.yml | .github/workflows/govulncheck.yml)
+        CODE_OF_CONDUCT.md | SECURITY.md | .dockerignore | .github/workflows/approve-workflows.yml | .github/workflows/container_description.yml | .github/workflows/govulncheck.yml)
           repo_log_yellow "${source_file} missing in ${org_repo}, force updating."
           needs_update+=("${source_file}")
           ;;


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Adds automation to enable triagers to approve CI workflows across our orgs, bypassing GitHub's default behavior, which requires `write` permissions.

It won't have much effect here at the Prometheus main repository, but we've introduced the triagers group for the exporters already, and we're looking at how to roll this out for other groups.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
