### PR TITLE
discovery/aws: paginate Lightsail GetInstances so all instances are discovered

### DIFF
--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -129,7 +129,23 @@ func newLightsailClientAdapter(c *lightsail.Client) *lightsailClientAdapter {
 }
 
 func (a *lightsailClientAdapter) GetInstances(ctx context.Context, params *lightsail.GetInstancesInput, optFns ...func(*lightsail.Options)) (*lightsail.GetInstancesOutput, error) {
-	return a.getInstances(ctx, params, optFns...)
+	output, err := a.getInstances(ctx, params, optFns...)
+	if err != nil {
+		return nil, err
+	}
+
+	for output.NextPageToken != nil {
+		params.PageToken = output.NextPageToken
+		nextOutput, err := a.getInstances(ctx, params, optFns...)
+		if err != nil {
+			return nil, err
+		}
+
+		output.Instances = append(output.Instances, nextOutput.Instances...)
+		output.NextPageToken = nextOutput.NextPageToken
+	}
+
+	return output, nil
 }
 
 // LightsailDiscovery periodically performs Lightsail-SD requests. It implements
@@ -242,9 +258,7 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 		Source: d.region,
 	}
 
-	input := &lightsail.GetInstancesInput{}
-
-	output, err := lightsailClient.GetInstances(ctx, input)
+	output, err := lightsailClient.GetInstances(ctx, &lightsail.GetInstancesInput{})
 	if err != nil {
 		var awsErr smithy.APIError
 		if errors.As(err, &awsErr) && (awsErr.ErrorCode() == "AuthFailure" || awsErr.ErrorCode() == "UnauthorizedOperation") {

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
+	lightsailTypes "github.com/aws/aws-sdk-go-v2/service/lightsail/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -129,23 +130,7 @@ func newLightsailClientAdapter(c *lightsail.Client) *lightsailClientAdapter {
 }
 
 func (a *lightsailClientAdapter) GetInstances(ctx context.Context, params *lightsail.GetInstancesInput, optFns ...func(*lightsail.Options)) (*lightsail.GetInstancesOutput, error) {
-	output, err := a.getInstances(ctx, params, optFns...)
-	if err != nil {
-		return nil, err
-	}
-
-	for output.NextPageToken != nil {
-		params.PageToken = output.NextPageToken
-		nextOutput, err := a.getInstances(ctx, params, optFns...)
-		if err != nil {
-			return nil, err
-		}
-
-		output.Instances = append(output.Instances, nextOutput.Instances...)
-		output.NextPageToken = nextOutput.NextPageToken
-	}
-
-	return output, nil
+	return a.getInstances(ctx, params, optFns...)
 }
 
 // LightsailDiscovery periodically performs Lightsail-SD requests. It implements
@@ -249,7 +234,7 @@ func (d *LightsailDiscovery) lightsailClient(ctx context.Context) (*lightsailCli
 }
 
 func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
-	lightsailClient, err := d.lightsailClient(ctx)
+	_, err := d.lightsailClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +243,7 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 		Source: d.region,
 	}
 
-	output, err := lightsailClient.GetInstances(ctx, &lightsail.GetInstancesInput{})
+	instances, err := d.listInstances(ctx)
 	if err != nil {
 		var awsErr smithy.APIError
 		if errors.As(err, &awsErr) && (awsErr.ErrorCode() == "AuthFailure" || awsErr.ErrorCode() == "UnauthorizedOperation") {
@@ -267,7 +252,7 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 		return nil, fmt.Errorf("could not get instances: %w", err)
 	}
 
-	for _, inst := range output.Instances {
+	for _, inst := range instances {
 		if inst.PrivateIpAddress == nil {
 			continue
 		}
@@ -310,4 +295,26 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 		tg.Targets = append(tg.Targets, labels)
 	}
 	return []*targetgroup.Group{tg}, nil
+}
+
+// listInstances lists all Lightsail instances in the configured region.
+func (d *LightsailDiscovery) listInstances(ctx context.Context) ([]lightsailTypes.Instance, error) {
+	var (
+		instances []lightsailTypes.Instance
+		pageToken *string
+	)
+	for {
+		output, err := d.lightsail.GetInstances(ctx, &lightsail.GetInstancesInput{PageToken: pageToken})
+		if err != nil {
+			return nil, err
+		}
+
+		instances = append(instances, output.Instances...)
+		if output.NextPageToken == nil {
+			break
+		}
+		pageToken = output.NextPageToken
+	}
+
+	return instances, nil
 }

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
+	lightsailTypes "github.com/aws/aws-sdk-go-v2/service/lightsail/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -129,23 +130,7 @@ func newLightsailClientAdapter(c *lightsail.Client) *lightsailClientAdapter {
 }
 
 func (a *lightsailClientAdapter) GetInstances(ctx context.Context, params *lightsail.GetInstancesInput, optFns ...func(*lightsail.Options)) (*lightsail.GetInstancesOutput, error) {
-	output, err := a.getInstances(ctx, params, optFns...)
-	if err != nil {
-		return nil, err
-	}
-
-	for output.NextPageToken != nil {
-		params.PageToken = output.NextPageToken
-		nextOutput, err := a.getInstances(ctx, params, optFns...)
-		if err != nil {
-			return nil, err
-		}
-
-		output.Instances = append(output.Instances, nextOutput.Instances...)
-		output.NextPageToken = nextOutput.NextPageToken
-	}
-
-	return output, nil
+	return a.getInstances(ctx, params, optFns...)
 }
 
 // LightsailDiscovery periodically performs Lightsail-SD requests. It implements
@@ -249,7 +234,7 @@ func (d *LightsailDiscovery) lightsailClient(ctx context.Context) (*lightsailCli
 }
 
 func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
-	lightsailClient, err := d.lightsailClient(ctx)
+	_, err := d.lightsailClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +243,7 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 		Source: d.region,
 	}
 
-	output, err := lightsailClient.GetInstances(ctx, &lightsail.GetInstancesInput{})
+	instances, err := d.listInstances(ctx)
 	if err != nil {
 		var awsErr smithy.APIError
 		if errors.As(err, &awsErr) && (awsErr.ErrorCode() == "AuthFailure" || awsErr.ErrorCode() == "UnauthorizedOperation") {
@@ -267,7 +252,7 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 		return nil, fmt.Errorf("could not get instances: %w", err)
 	}
 
-	for _, inst := range output.Instances {
+	for _, inst := range instances {
 		if inst.PrivateIpAddress == nil {
 			continue
 		}
@@ -326,4 +311,26 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 		tg.Targets = append(tg.Targets, labels)
 	}
 	return []*targetgroup.Group{tg}, nil
+}
+
+// listInstances lists all Lightsail instances in the configured region.
+func (d *LightsailDiscovery) listInstances(ctx context.Context) ([]lightsailTypes.Instance, error) {
+	var (
+		instances []lightsailTypes.Instance
+		pageToken *string
+	)
+	for {
+		output, err := d.lightsail.GetInstances(ctx, &lightsail.GetInstancesInput{PageToken: pageToken})
+		if err != nil {
+			return nil, err
+		}
+
+		instances = append(instances, output.Instances...)
+		if output.NextPageToken == nil {
+			break
+		}
+		pageToken = output.NextPageToken
+	}
+
+	return instances, nil
 }

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -173,21 +173,21 @@ func NewLightsailDiscovery(conf *LightsailSDConfig, opts discovery.DiscovererOpt
 	return d, nil
 }
 
-func (d *LightsailDiscovery) lightsailClient(ctx context.Context) (*lightsailClientAdapter, error) {
+func (d *LightsailDiscovery) lightsailClient(ctx context.Context) error {
 	if d.lightsail != nil {
-		return d.lightsail, nil
+		return nil
 	}
 
 	// Build the HTTP client from the provided HTTPClientConfig.
 	httpClient, err := config.NewClientFromConfig(d.cfg.HTTPClientConfig, "lightsail_sd")
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Resolve the region lazily. See LightsailSDConfig.UnmarshalYAML.
 	d.region, err = loadRegion(ctx, d.cfg.Region)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Build the AWS config with the resolved region.
@@ -210,7 +210,7 @@ func (d *LightsailDiscovery) lightsailClient(ctx context.Context) (*lightsailCli
 
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, configOptions...)
 	if err != nil {
-		return nil, fmt.Errorf("could not create aws config: %w", err)
+		return fmt.Errorf("could not create aws config: %w", err)
 	}
 
 	// If the role ARN is set, assume the role to get credentials and set the credentials provider in the config.
@@ -230,11 +230,11 @@ func (d *LightsailDiscovery) lightsailClient(ctx context.Context) (*lightsailCli
 		options.HTTPClient = httpClient
 	}))
 
-	return d.lightsail, nil
+	return nil
 }
 
 func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
-	_, err := d.lightsailClient(ctx)
+	err := d.lightsailClient(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -173,21 +173,21 @@ func NewLightsailDiscovery(conf *LightsailSDConfig, opts discovery.DiscovererOpt
 	return d, nil
 }
 
-func (d *LightsailDiscovery) lightsailClient(ctx context.Context) error {
+func (d *LightsailDiscovery) lightsailClient(ctx context.Context) (*lightsailClientAdapter, error) {
 	if d.lightsail != nil {
-		return nil
+		return d.lightsail, nil
 	}
 
 	// Build the HTTP client from the provided HTTPClientConfig.
 	httpClient, err := config.NewClientFromConfig(d.cfg.HTTPClientConfig, "lightsail_sd")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Resolve the region lazily. See LightsailSDConfig.UnmarshalYAML.
 	d.region, err = loadRegion(ctx, d.cfg.Region)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Build the AWS config with the resolved region.
@@ -210,7 +210,7 @@ func (d *LightsailDiscovery) lightsailClient(ctx context.Context) error {
 
 	cfg, err := awsConfig.LoadDefaultConfig(ctx, configOptions...)
 	if err != nil {
-		return fmt.Errorf("could not create aws config: %w", err)
+		return nil, fmt.Errorf("could not create aws config: %w", err)
 	}
 
 	// If the role ARN is set, assume the role to get credentials and set the credentials provider in the config.
@@ -230,11 +230,11 @@ func (d *LightsailDiscovery) lightsailClient(ctx context.Context) error {
 		options.HTTPClient = httpClient
 	}))
 
-	return nil
+	return d.lightsail, nil
 }
 
 func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
-	err := d.lightsailClient(ctx)
+	lightsailClient, err := d.lightsailClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 		Source: d.region,
 	}
 
-	instances, err := d.listInstances(ctx)
+	instances, err := d.listInstances(ctx, lightsailClient)
 	if err != nil {
 		var awsErr smithy.APIError
 		if errors.As(err, &awsErr) && (awsErr.ErrorCode() == "AuthFailure" || awsErr.ErrorCode() == "UnauthorizedOperation") {
@@ -314,13 +314,13 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 }
 
 // listInstances lists all Lightsail instances in the configured region.
-func (d *LightsailDiscovery) listInstances(ctx context.Context) ([]lightsailTypes.Instance, error) {
+func (*LightsailDiscovery) listInstances(ctx context.Context, client *lightsailClientAdapter) ([]lightsailTypes.Instance, error) {
 	var (
 		instances []lightsailTypes.Instance
 		pageToken *string
 	)
 	for {
-		output, err := d.lightsail.GetInstances(ctx, &lightsail.GetInstancesInput{PageToken: pageToken})
+		output, err := client.GetInstances(ctx, &lightsail.GetInstancesInput{PageToken: pageToken})
 		if err != nil {
 			return nil, err
 		}

--- a/discovery/aws/lightsail_test.go
+++ b/discovery/aws/lightsail_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLightsailClientAdapterGetInstancesPaginated(t *testing.T) {
+func TestLightsailDiscoveryListInstancesPaginated(t *testing.T) {
 	ctx := context.Background()
 
 	pages := []*lightsail.GetInstancesOutput{
@@ -36,7 +36,7 @@ func TestLightsailClientAdapterGetInstancesPaginated(t *testing.T) {
 	}
 
 	var calls int
-	client := &lightsailClientAdapter{
+	discovery := &LightsailDiscovery{lightsail: &lightsailClientAdapter{
 		getInstances: func(_ context.Context, params *lightsail.GetInstancesInput, _ ...func(*lightsail.Options)) (*lightsail.GetInstancesOutput, error) {
 			if calls == 0 {
 				require.Nil(t, params.PageToken)
@@ -47,14 +47,13 @@ func TestLightsailClientAdapterGetInstancesPaginated(t *testing.T) {
 			calls++
 			return out, nil
 		},
-	}
+	}}
 
-	output, err := client.GetInstances(ctx, &lightsail.GetInstancesInput{})
+	instances, err := discovery.listInstances(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 2, calls)
 	require.Equal(t, []lightsailTypes.Instance{
 		{Name: strptr("instance-1")},
 		{Name: strptr("instance-2")},
-	}, output.Instances)
-	require.Nil(t, output.NextPageToken)
+	}, instances)
 }

--- a/discovery/aws/lightsail_test.go
+++ b/discovery/aws/lightsail_test.go
@@ -1,0 +1,60 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/lightsail"
+	lightsailTypes "github.com/aws/aws-sdk-go-v2/service/lightsail/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLightsailClientAdapterGetInstancesPaginated(t *testing.T) {
+	ctx := context.Background()
+
+	pages := []*lightsail.GetInstancesOutput{
+		{
+			Instances:     []lightsailTypes.Instance{{Name: strptr("instance-1")}},
+			NextPageToken: strptr("page-2"),
+		},
+		{
+			Instances: []lightsailTypes.Instance{{Name: strptr("instance-2")}},
+		},
+	}
+
+	var calls int
+	client := &lightsailClientAdapter{
+		getInstances: func(_ context.Context, params *lightsail.GetInstancesInput, _ ...func(*lightsail.Options)) (*lightsail.GetInstancesOutput, error) {
+			if calls == 0 {
+				require.Nil(t, params.PageToken)
+			} else {
+				require.Equal(t, "page-2", *params.PageToken)
+			}
+			out := pages[calls]
+			calls++
+			return out, nil
+		},
+	}
+
+	output, err := client.GetInstances(ctx, &lightsail.GetInstancesInput{})
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+	require.Equal(t, []lightsailTypes.Instance{
+		{Name: strptr("instance-1")},
+		{Name: strptr("instance-2")},
+	}, output.Instances)
+	require.Nil(t, output.NextPageToken)
+}

--- a/discovery/aws/lightsail_test.go
+++ b/discovery/aws/lightsail_test.go
@@ -179,3 +179,40 @@ func TestLightsailRefreshAllOptionalFieldsNil(t *testing.T) {
 		require.NotContains(t, target, absent)
 	}
 }
+
+func TestLightsailClientAdapterGetInstancesPaginated(t *testing.T) {
+	ctx := context.Background()
+
+	pages := []*lightsail.GetInstancesOutput{
+		{
+			Instances:     []types.Instance{{Name: strptr("instance-1")}},
+			NextPageToken: strptr("page-2"),
+		},
+		{
+			Instances: []types.Instance{{Name: strptr("instance-2")}},
+		},
+	}
+
+	var calls int
+	client := &lightsailClientAdapter{
+		getInstances: func(_ context.Context, params *lightsail.GetInstancesInput, _ ...func(*lightsail.Options)) (*lightsail.GetInstancesOutput, error) {
+			if calls == 0 {
+				require.Nil(t, params.PageToken)
+			} else {
+				require.Equal(t, "page-2", *params.PageToken)
+			}
+			out := pages[calls]
+			calls++
+			return out, nil
+		},
+	}
+
+	output, err := client.GetInstances(ctx, &lightsail.GetInstancesInput{})
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+	require.Equal(t, []types.Instance{
+		{Name: strptr("instance-1")},
+		{Name: strptr("instance-2")},
+	}, output.Instances)
+	require.Nil(t, output.NextPageToken)
+}

--- a/discovery/aws/lightsail_test.go
+++ b/discovery/aws/lightsail_test.go
@@ -180,7 +180,7 @@ func TestLightsailRefreshAllOptionalFieldsNil(t *testing.T) {
 	}
 }
 
-func TestLightsailClientAdapterGetInstancesPaginated(t *testing.T) {
+func TestLightsailDiscoveryListInstancesPaginated(t *testing.T) {
 	ctx := context.Background()
 
 	pages := []*lightsail.GetInstancesOutput{
@@ -194,7 +194,7 @@ func TestLightsailClientAdapterGetInstancesPaginated(t *testing.T) {
 	}
 
 	var calls int
-	client := &lightsailClientAdapter{
+	discovery := &LightsailDiscovery{lightsail: &lightsailClientAdapter{
 		getInstances: func(_ context.Context, params *lightsail.GetInstancesInput, _ ...func(*lightsail.Options)) (*lightsail.GetInstancesOutput, error) {
 			if calls == 0 {
 				require.Nil(t, params.PageToken)
@@ -205,14 +205,13 @@ func TestLightsailClientAdapterGetInstancesPaginated(t *testing.T) {
 			calls++
 			return out, nil
 		},
-	}
+	}}
 
-	output, err := client.GetInstances(ctx, &lightsail.GetInstancesInput{})
+	instances, err := discovery.listInstances(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 2, calls)
 	require.Equal(t, []types.Instance{
 		{Name: strptr("instance-1")},
 		{Name: strptr("instance-2")},
-	}, output.Instances)
-	require.Nil(t, output.NextPageToken)
+	}, instances)
 }

--- a/discovery/aws/lightsail_test.go
+++ b/discovery/aws/lightsail_test.go
@@ -207,7 +207,7 @@ func TestLightsailDiscoveryListInstancesPaginated(t *testing.T) {
 		},
 	}}
 
-	instances, err := discovery.listInstances(ctx)
+	instances, err := discovery.listInstances(ctx, discovery.lightsail)
 	require.NoError(t, err)
 	require.Equal(t, 2, calls)
 	require.Equal(t, []types.Instance{


### PR DESCRIPTION

#### Which issue(s) does the PR fix:

There is no dedicated tracking issue for this bug. (The only open Lightsail
issue, #17395, is a request to add unit tests, not this pagination bug.)

`GetInstances` is a paginated Lightsail API, but the Lightsail client adapter
called it exactly once and never followed the returned `NextPageToken`, so on
any Lightsail account whose instance list spans more than one API page, every
instance beyond the first page was silently dropped from the discovered target
set.

This change makes the client adapter request each `GetInstances` page in
sequence, advancing `PageToken` with the response `NextPageToken`, combining
the instances, and stopping when the token is `nil`.
This mirrors the manual pagination already used for the other paginated AWS SD
list operations in this package (`ecs`, `msk`, `elasticache`, `rds`); unlike
EC2, the Lightsail service package ships no `GetInstancesPaginator`, so the
caller has to request each page itself. The existing `AuthFailure` /
`UnauthorizedOperation` handling is preserved. No configuration or public API
changes.

A unit test (`discovery/aws/lightsail_test.go`) returns two pages (page one
carries a next page token, page two does not) and asserts that both requests
are made with the correct page token and that the adapter combines instances
from both pages. Without the fix the test fails because only the first page is
fetched.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] Discovery: Paginate AWS Lightsail service discovery so more than one page of instances is discovered.
```
