### PR TITLE
fix(notifier): stop on closed target set channel

### DIFF
--- a/notifier/manager.go
+++ b/notifier/manager.go
@@ -204,6 +204,8 @@ func (n *Manager) ApplyConfig(conf *config.Config) error {
 // Refer to https://github.com/prometheus/prometheus/issues/13676 for more details.
 func (n *Manager) Run(tsets <-chan map[string][]*targetgroup.Group) {
 	n.targetUpdateLoop(tsets)
+	// Wait for Stop even if the target update channel closes so callers control when send loops are cleaned up.
+	<-n.stopRequested
 
 	n.mtx.Lock()
 	defer n.mtx.Unlock()
@@ -227,7 +229,7 @@ func (n *Manager) targetUpdateLoop(tsets <-chan map[string][]*targetgroup.Group)
 				return
 			case ts, ok := <-tsets:
 				if !ok {
-					break
+					return
 				}
 				n.reload(ts)
 			}

--- a/notifier/manager_test.go
+++ b/notifier/manager_test.go
@@ -583,6 +583,74 @@ func (a alertmanagerMock) url() *url.URL {
 	return u
 }
 
+func TestManager_ClosedTargetSetsChannel(t *testing.T) {
+	t.Run("target update loop returns", func(t *testing.T) {
+		m := NewManager(&Options{}, model.UTF8Validation, nil)
+		defer m.Stop()
+
+		targetSetsCh := make(chan map[string][]*targetgroup.Group)
+		loopDone := make(chan struct{})
+		go func() {
+			m.targetUpdateLoop(targetSetsCh)
+			close(loopDone)
+		}()
+		close(targetSetsCh)
+
+		select {
+		case <-loopDone:
+		case <-time.After(time.Second):
+			t.Fatal("notification manager target update loop did not stop after target sets channel was closed")
+		}
+	})
+
+	t.Run("Run waits for Stop", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			m := NewManager(&Options{}, model.UTF8Validation, nil)
+			defer m.Stop()
+
+			const alertmanagerURL = "http://alertmanager:9093/api/v2/alerts"
+			amCfg := config.DefaultAlertmanagerConfig
+			ams := newTestAlertmanagerSet(&amCfg, nil, m.opts, m.metrics, alertmanagerURL)
+			m.alertmanagers = map[string]*alertmanagerSet{"test": ams}
+			ams.startSendLoops(ams.ams)
+
+			targetSetsCh := make(chan map[string][]*targetgroup.Group)
+			runDone := make(chan struct{})
+			go func() {
+				m.Run(targetSetsCh)
+				close(runDone)
+			}()
+			close(targetSetsCh)
+			synctest.Wait()
+
+			select {
+			case <-runDone:
+				t.Fatal("notification manager returned before Stop was called")
+			default:
+			}
+
+			ams.mtx.RLock()
+			sendLoopCount := len(ams.sendLoops)
+			ams.mtx.RUnlock()
+			require.Equal(t, 1, sendLoopCount, "send loop was cleaned up before Stop was called")
+
+			m.Stop()
+			synctest.Wait()
+
+			select {
+			case <-runDone:
+			default:
+				t.Fatal("notification manager did not return after Stop was called")
+			}
+
+			ams.mtx.RLock()
+			sendLoopCount = len(ams.sendLoops)
+			ams.mtx.RUnlock()
+			require.Zero(t, sendLoopCount, "send loop was not cleaned up after Stop was called")
+		})
+	})
+}
+
 func TestReload(t *testing.T) {
 	tests := []struct {
 		in  *targetgroup.Group


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
The discovery manager closes its target-set channel when it stops. The notifier's unlabeled break only exited the inner select, so the target update loop repeatedly received from the closed channel and busy-spun.

Return from the target update loop when the channel closes, but keep Run blocked until Stop is called. This preserves shutdown ordering so rule evaluation can finish before notification send loops are drained and cleaned up.

Follow-up to #19149. Fixes the same class of bug.

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] Notifier: Prevent high CPU usage when the Alertmanager service discovery channel closes
```
