### PR TITLE
textparse: fix recursion in ProtobufParser.Next

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -84,8 +84,9 @@ const (
 	globLabelNameLengthLimit  = 200
 	globLabelValueLengthLimit = 200
 	globalGoGC                = 42
-	globScrapeFailureLogFile  = "testdata/fail.log"
 )
+
+var globScrapeFailureLogFile  = filepath.FromSlash("testdata/fail.log")
 
 var expectedConf = &Config{
 	loaded: true,
@@ -93,7 +94,7 @@ var expectedConf = &Config{
 		ScrapeInterval:       model.Duration(15 * time.Second),
 		ScrapeTimeout:        DefaultGlobalConfig.ScrapeTimeout,
 		EvaluationInterval:   model.Duration(30 * time.Second),
-		QueryLogFile:         "testdata/query.log",
+		QueryLogFile:         filepath.FromSlash("testdata/query.log"),
 		ScrapeFailureLogFile: globScrapeFailureLogFile,
 
 		ExternalLabels: labels.FromStrings("foo", "bar", "monitor", "codelab"),
@@ -229,7 +230,7 @@ var expectedConf = &Config{
 			LabelValueLengthLimit:          globLabelValueLengthLimit,
 			ScrapeProtocols:                DefaultScrapeProtocols,
 			ScrapeFallbackProtocol:         PrometheusText0_0_4,
-			ScrapeFailureLogFile:           "testdata/fail_prom.log",
+			ScrapeFailureLogFile:           filepath.FromSlash("testdata/fail_prom.log"),
 			MetricNameValidationScheme:     DefaultGlobalConfig.MetricNameValidationScheme,
 			MetricNameEscapingScheme:       DefaultGlobalConfig.MetricNameEscapingScheme,
 			ScrapeNativeHistograms:         boolPtr(false),
@@ -263,11 +264,11 @@ var expectedConf = &Config{
 
 			ServiceDiscoveryConfigs: discovery.Configs{
 				&file.SDConfig{
-					Files:           []string{"testdata/foo/*.slow.json", "testdata/foo/*.slow.yml", "testdata/single/file.yml"},
+					Files:           []string{filepath.FromSlash("testdata/foo/*.slow.json"), filepath.FromSlash("testdata/foo/*.slow.yml"), filepath.FromSlash("testdata/single/file.yml")},
 					RefreshInterval: model.Duration(10 * time.Minute),
 				},
 				&file.SDConfig{
-					Files:           []string{"testdata/bar/*.yaml"},
+					Files:           []string{filepath.FromSlash("testdata/bar/*.yaml")},
 					RefreshInterval: model.Duration(5 * time.Minute),
 				},
 				discovery.StaticConfig{
@@ -1110,8 +1111,8 @@ var expectedConf = &Config{
 					RefreshInterval: model.Duration(60 * time.Second),
 					Version:         1,
 					TLSConfig: config.TLSConfig{
-						CertFile: "testdata/valid_cert_file",
-						KeyFile:  "testdata/valid_key_file",
+						CertFile: filepath.FromSlash("testdata/valid_cert_file"),
+						KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 					},
 				},
 			},
@@ -1266,7 +1267,7 @@ var expectedConf = &Config{
 					Tenancy:          "ocid1.tenancy.oc1..tenancy001",
 					User:             "ocid1.user.oc1..user001",
 					Fingerprint:      "aa:bb:cc:dd:ee:ff",
-					KeyFile:          "testdata/valid_key_file",
+					KeyFile:          filepath.FromSlash("testdata/valid_key_file"),
 					KeyPassphrase:    "mysecret",
 					Compartments:     []string{"ocid1.compartment.oc1..comp001"},
 					Port:             9100,
@@ -1309,9 +1310,9 @@ var expectedConf = &Config{
 					Availability:    "public",
 					RefreshInterval: model.Duration(60 * time.Second),
 					TLSConfig: config.TLSConfig{
-						CAFile:   "testdata/valid_ca_file",
-						CertFile: "testdata/valid_cert_file",
-						KeyFile:  "testdata/valid_key_file",
+						CAFile:   filepath.FromSlash("testdata/valid_ca_file"),
+						CertFile: filepath.FromSlash("testdata/valid_cert_file"),
+						KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 					},
 				},
 			},
@@ -1353,9 +1354,9 @@ var expectedConf = &Config{
 						FollowRedirects: true,
 						EnableHTTP2:     true,
 						TLSConfig: config.TLSConfig{
-							CAFile:   "testdata/valid_ca_file",
-							CertFile: "testdata/valid_cert_file",
-							KeyFile:  "testdata/valid_key_file",
+							CAFile:   filepath.FromSlash("testdata/valid_ca_file"),
+							CertFile: filepath.FromSlash("testdata/valid_cert_file"),
+							KeyFile:  filepath.FromSlash("testdata/valid_key_file"),
 						},
 					},
 				},
@@ -1837,8 +1838,8 @@ var expectedConf = &Config{
 		Timeout:     model.Duration(5 * time.Second),
 		Headers:     map[string]string{"foo": "bar"},
 		TLSConfig: config.TLSConfig{
-			CertFile:           "testdata/valid_cert_file",
-			KeyFile:            "testdata/valid_key_file",
+			CertFile:           filepath.FromSlash("testdata/valid_cert_file"),
+			KeyFile:            filepath.FromSlash("testdata/valid_key_file"),
 			InsecureSkipVerify: true,
 		},
 	},

--- a/config/config_windows_test.go
+++ b/config/config_windows_test.go
@@ -20,6 +20,7 @@ var ruleFilesExpectedConf = &Config{
 
 	GlobalConfig:  DefaultGlobalConfig,
 	Runtime:       DefaultRuntimeConfig,
+	OTLPConfig:    DefaultOTLPConfig,
 	StorageConfig: StorageConfig{TSDBConfig: &TSDBConfig{Retention: &TSDBRetentionConfig{}}},
 	RuleFiles: []string{
 		"testdata\\first.rules",

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -426,178 +426,181 @@ func (p *ProtobufParser) Next() (Entry, error) {
 	p.exemplarReturned = false
 	p.nhcbH = nil
 	p.nhcbFH = nil
-	switch p.state {
-	// Invalid state occurs on:
-	// * First Next() call.
-	// * Recursive call that tells Next to move to the next metric family.
-	case EntryInvalid:
-		p.exemplarPos = 0
-		p.fieldPos = -2
-
-		if err := p.dec.NextMetricFamily(); err != nil {
-			return p.state, err
-		}
-		if err := p.dec.NextMetric(); err != nil {
-			// Skip empty metric families.
-			if errors.Is(err, io.EOF) {
-				return p.Next()
-			}
-			return EntryInvalid, err
-		}
-
-		// We are at the beginning of a metric family. Put only the name
-		// into entryBytes and validate only name, help, and type for now.
-		name := p.dec.GetName()
-		if !model.UTF8Validation.IsValidMetricName(name) {
-			return EntryInvalid, fmt.Errorf("invalid metric name: %s", name)
-		}
-		if help := p.dec.GetHelp(); !utf8.ValidString(help) {
-			return EntryInvalid, fmt.Errorf("invalid help for metric %q: %s", name, help)
-		}
-		switch p.dec.GetType() {
-		case dto.MetricType_COUNTER,
-			dto.MetricType_GAUGE,
-			dto.MetricType_HISTOGRAM,
-			dto.MetricType_GAUGE_HISTOGRAM,
-			dto.MetricType_SUMMARY,
-			dto.MetricType_UNTYPED:
-			// All good.
-		default:
-			return EntryInvalid, fmt.Errorf("unknown metric type for metric %q: %s", name, p.dec.GetType())
-		}
-		p.entryBytes.Reset()
-		p.entryBytes.WriteString(name)
-		p.state = EntryHelp
-	case EntryHelp:
-		if p.dec.Unit != "" {
-			p.state = EntryUnit
-		} else {
-			p.state = EntryType
-		}
-	case EntryUnit:
-		p.state = EntryType
-	case EntryType:
-		t := p.dec.GetType()
-		if t == dto.MetricType_HISTOGRAM || t == dto.MetricType_GAUGE_HISTOGRAM {
-			if p.ignoreNativeHistograms || !isNativeHistogram(p.dec.GetHistogram()) {
-				p.state = EntrySeries
-				p.fieldPos = -3 // We have not returned anything, let p.Next() increment it to -2.
-				return p.Next()
-			}
-			if err := checkNativeHistogramConsistency(p.dec.GetHistogram()); err != nil {
-				return EntryInvalid, fmt.Errorf("histogram %q: %w", p.dec.GetName(), err)
-			}
-			p.state = EntryHistogram
-		} else {
-			p.state = EntrySeries
-		}
-		if err := p.onSeriesOrHistogramUpdate(); err != nil {
-			return EntryInvalid, err
-		}
-	case EntrySeries:
-		// Potentially a second series in the metric family.
-		t := p.dec.GetType()
-		decodeNext := true
-		if t == dto.MetricType_SUMMARY ||
-			t == dto.MetricType_HISTOGRAM ||
-			t == dto.MetricType_GAUGE_HISTOGRAM {
-			// Non-trivial series (complex metrics, with magic suffixes).
-
-			isClassicHistogram := (t == dto.MetricType_HISTOGRAM || t == dto.MetricType_GAUGE_HISTOGRAM) &&
-				(p.ignoreNativeHistograms || !isNativeHistogram(p.dec.GetHistogram()))
-			skipSeries := p.convertClassicHistogramsToNHCB && isClassicHistogram && !p.parseClassicHistograms
-
-			// Did we iterate over all the classic representations fields?
-			// NOTE: p.fieldsDone is updated on p.onSeriesOrHistogramUpdate.
-			if !p.fieldsDone && !skipSeries {
-				// Still some fields to iterate over.
-				p.fieldPos++
-				if err := p.onSeriesOrHistogramUpdate(); err != nil {
-					return EntryInvalid, err
-				}
-				return p.state, nil
-			}
-
-			// Reset histogram fields.
-			p.fieldPos = -2
-			p.fieldsDone = false
+	for {
+		switch p.state {
+		// Invalid state occurs on:
+		// * First Next() call.
+		// * Loop iteration that tells Next to move to the next metric family.
+		case EntryInvalid:
 			p.exemplarPos = 0
+			p.fieldPos = -2
 
-			// If this is a metric family containing native
-			// histograms, it means we are here thanks to redoClassic state.
-			// Return to native histograms for the consistent flow.
-			// If this is a metric family containing classic histograms,
-			// it means we might need to do NHCB conversion.
-			if t == dto.MetricType_HISTOGRAM || t == dto.MetricType_GAUGE_HISTOGRAM {
-				if !isClassicHistogram {
-					if err := checkNativeHistogramConsistency(p.dec.GetHistogram()); err != nil {
-						return EntryInvalid, fmt.Errorf("histogram %q: %w", p.dec.GetName(), err)
-					}
-					p.state = EntryHistogram
-				} else if p.convertClassicHistogramsToNHCB {
-					// We still need to spit out the NHCB.
-					var err error
-					p.nhcbH, p.nhcbFH, err = p.convertToNHCB(t)
-					if err != nil {
-						return EntryInvalid, err
-					}
-					p.state = EntryHistogram
-					// We have an NHCB to emit, no need to decode the next series.
-					decodeNext = false
-				}
+			if err := p.dec.NextMetricFamily(); err != nil {
+				return p.state, err
 			}
-		}
-		// Is there another series?
-		if decodeNext {
 			if err := p.dec.NextMetric(); err != nil {
+				// Skip empty metric families.
 				if errors.Is(err, io.EOF) {
-					p.state = EntryInvalid
-					return p.Next()
+					continue
 				}
 				return EntryInvalid, err
 			}
-		}
-		if err := p.onSeriesOrHistogramUpdate(); err != nil {
-			return EntryInvalid, err
-		}
-	case EntryHistogram:
-		switchToClassic := func() (Entry, error) {
-			p.redoClassic = false
-			p.fieldPos = -3
-			p.fieldsDone = false
-			p.state = EntrySeries
-			return p.Next() // Switch to classic histogram.
-		}
 
-		// Was Histogram() called and parseClassicHistograms is true?
-		if p.redoClassic {
-			return switchToClassic()
-		}
-
-		// Is there another series?
-		if err := p.dec.NextMetric(); err != nil {
-			if errors.Is(err, io.EOF) {
-				p.state = EntryInvalid
-				return p.Next()
+			// We are at the beginning of a metric family. Put only the name
+			// into entryBytes and validate only name, help, and type for now.
+			name := p.dec.GetName()
+			if !model.UTF8Validation.IsValidMetricName(name) {
+				return EntryInvalid, fmt.Errorf("invalid metric name: %s", name)
 			}
-			return EntryInvalid, err
-		}
+			if help := p.dec.GetHelp(); !utf8.ValidString(help) {
+				return EntryInvalid, fmt.Errorf("invalid help for metric %q: %s", name, help)
+			}
+			switch p.dec.GetType() {
+			case dto.MetricType_COUNTER,
+				dto.MetricType_GAUGE,
+				dto.MetricType_HISTOGRAM,
+				dto.MetricType_GAUGE_HISTOGRAM,
+				dto.MetricType_SUMMARY,
+				dto.MetricType_UNTYPED:
+				// All good.
+			default:
+				return EntryInvalid, fmt.Errorf("unknown metric type for metric %q: %s", name, p.dec.GetType())
+			}
+			p.entryBytes.Reset()
+			p.entryBytes.WriteString(name)
+			p.state = EntryHelp
+		case EntryHelp:
+			if p.dec.Unit != "" {
+				p.state = EntryUnit
+			} else {
+				p.state = EntryType
+			}
+		case EntryUnit:
+			p.state = EntryType
+		case EntryType:
+			t := p.dec.GetType()
+			if t == dto.MetricType_HISTOGRAM || t == dto.MetricType_GAUGE_HISTOGRAM {
+				if p.ignoreNativeHistograms || !isNativeHistogram(p.dec.GetHistogram()) {
+					p.state = EntrySeries
+					p.fieldPos = -3 // We have not returned anything, let p.Next() increment it to -2.
+					continue
+				}
+				if err := checkNativeHistogramConsistency(p.dec.GetHistogram()); err != nil {
+					return EntryInvalid, fmt.Errorf("histogram %q: %w", p.dec.GetName(), err)
+				}
+				p.state = EntryHistogram
+			} else {
+				p.state = EntrySeries
+			}
+			if err := p.onSeriesOrHistogramUpdate(); err != nil {
+				return EntryInvalid, err
+			}
+		case EntrySeries:
+			// Potentially a second series in the metric family.
+			t := p.dec.GetType()
+			decodeNext := true
+			if t == dto.MetricType_SUMMARY ||
+				t == dto.MetricType_HISTOGRAM ||
+				t == dto.MetricType_GAUGE_HISTOGRAM {
+				// Non-trivial series (complex metrics, with magic suffixes).
 
-		// If this metric is not a native histograms or we are ignoring
-		// native histograms, it means we are here thanks to NHCB
-		// conversion. Return to classic histograms for the consistent
-		// flow.
-		if p.ignoreNativeHistograms || !isNativeHistogram(p.dec.GetHistogram()) {
-			return switchToClassic()
-		}
+				isClassicHistogram := (t == dto.MetricType_HISTOGRAM || t == dto.MetricType_GAUGE_HISTOGRAM) &&
+					(p.ignoreNativeHistograms || !isNativeHistogram(p.dec.GetHistogram()))
+				skipSeries := p.convertClassicHistogramsToNHCB && isClassicHistogram && !p.parseClassicHistograms
 
-		if err := p.onSeriesOrHistogramUpdate(); err != nil {
-			return EntryInvalid, err
+				// Did we iterate over all the classic representations fields?
+				// NOTE: p.fieldsDone is updated on p.onSeriesOrHistogramUpdate.
+				if !p.fieldsDone && !skipSeries {
+					// Still some fields to iterate over.
+					p.fieldPos++
+					if err := p.onSeriesOrHistogramUpdate(); err != nil {
+						return EntryInvalid, err
+					}
+					return p.state, nil
+				}
+
+				// Reset histogram fields.
+				p.fieldPos = -2
+				p.fieldsDone = false
+				p.exemplarPos = 0
+
+				// If this is a metric family containing native
+				// histograms, it means we are here thanks to redoClassic state.
+				// Return to native histograms for the consistent flow.
+				// If this is a metric family containing classic histograms,
+				// it means we might need to do NHCB conversion.
+				if t == dto.MetricType_HISTOGRAM || t == dto.MetricType_GAUGE_HISTOGRAM {
+					if !isClassicHistogram {
+						if err := checkNativeHistogramConsistency(p.dec.GetHistogram()); err != nil {
+							return EntryInvalid, fmt.Errorf("histogram %q: %w", p.dec.GetName(), err)
+						}
+						p.state = EntryHistogram
+					} else if p.convertClassicHistogramsToNHCB {
+						// We still need to spit out the NHCB.
+						var err error
+						p.nhcbH, p.nhcbFH, err = p.convertToNHCB(t)
+						if err != nil {
+							return EntryInvalid, err
+						}
+						p.state = EntryHistogram
+						// We have an NHCB to emit, no need to decode the next series.
+						decodeNext = false
+					}
+				}
+			}
+			// Is there another series?
+			if decodeNext {
+				if err := p.dec.NextMetric(); err != nil {
+					if errors.Is(err, io.EOF) {
+						p.state = EntryInvalid
+						continue
+					}
+					return EntryInvalid, err
+				}
+			}
+			if err := p.onSeriesOrHistogramUpdate(); err != nil {
+				return EntryInvalid, err
+			}
+		case EntryHistogram:
+			switchToClassic := func() {
+				p.redoClassic = false
+				p.fieldPos = -3
+				p.fieldsDone = false
+				p.state = EntrySeries
+			}
+
+			// Was Histogram() called and parseClassicHistograms is true?
+			if p.redoClassic {
+				switchToClassic()
+				continue
+			}
+
+			// Is there another series?
+			if err := p.dec.NextMetric(); err != nil {
+				if errors.Is(err, io.EOF) {
+					p.state = EntryInvalid
+					continue
+				}
+				return EntryInvalid, err
+			}
+
+			// If this metric is not a native histograms or we are ignoring
+			// native histograms, it means we are here thanks to NHCB
+			// conversion. Return to classic histograms for the consistent
+			// flow.
+			if p.ignoreNativeHistograms || !isNativeHistogram(p.dec.GetHistogram()) {
+				switchToClassic()
+				continue
+			}
+
+			if err := p.onSeriesOrHistogramUpdate(); err != nil {
+				return EntryInvalid, err
+			}
+		default:
+			return EntryInvalid, fmt.Errorf("invalid protobuf parsing state: %d", p.state)
 		}
-	default:
-		return EntryInvalid, fmt.Errorf("invalid protobuf parsing state: %d", p.state)
+		return p.state, nil
 	}
-	return p.state, nil
 }
 
 // onSeriesOrHistogramUpdate updates internal state before returning

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -426,7 +426,7 @@ func (p *ProtobufParser) Next() (Entry, error) {
 	p.exemplarReturned = false
 	p.nhcbH = nil
 	p.nhcbFH = nil
-	for {
+	for { // Note there is a return at end of this loop; we only come back here on explicit continue.
 		switch p.state {
 		// Invalid state occurs on:
 		// * First Next() call.

--- a/model/textparse/protobufparse.go
+++ b/model/textparse/protobufparse.go
@@ -430,7 +430,7 @@ func (p *ProtobufParser) Next() (Entry, error) {
 		switch p.state {
 		// Invalid state occurs on:
 		// * First Next() call.
-		// * Loop iteration that tells Next to move to the next metric family.
+		// * Loop continue that tells Next to move to the next metric family.
 		case EntryInvalid:
 			p.exemplarPos = 0
 			p.fieldPos = -2

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -6016,6 +6016,28 @@ metric: <
 	}
 }
 
+func TestProtobufParseRecursionStackOverflow(t *testing.T) {
+	// Generate 500,000 empty metric families in binary format.
+	// Serialized dto.MetricFamily{Name: "a"} is []byte{10, 1, 'a'}. Length-prefixed with varint 3: []byte{3, 10, 1, 'a'}
+	b := []byte{3, 10, 1, 'a'}
+	var buf bytes.Buffer
+	for range 500000 {
+		buf.Write(b)
+	}
+
+	p := NewProtobufParser(buf.Bytes(), false, false, false, false, labels.NewSymbolTable())
+
+	// This would trigger a stack overflow previously, but should now pass successfully and iteratively.
+	require.NotPanics(t, func() {
+		for {
+			_, err := p.Next()
+			if errors.Is(err, io.EOF) || err != nil {
+				break
+			}
+		}
+	})
+}
+
 func generateString(r *rand.Rand, firstRunes, restRunes []rune) string {
 	result := make([]rune, 1+r.Intn(20))
 	for i := range result {

--- a/model/textparse/protobufparse_test.go
+++ b/model/textparse/protobufparse_test.go
@@ -114,6 +114,10 @@ metric: <
 >
 
 `,
+		`name: "empty_metric_family"
+help: "No samples, only metadata."
+type: GAUGE
+`,
 		`name: "test_histogram"
 help: "Test histogram with many buckets removed to keep it manageable in size."
 type: HISTOGRAM
@@ -6014,28 +6018,6 @@ metric: <
 			require.ErrorContains(t, gotErr, "positive side")
 		})
 	}
-}
-
-func TestProtobufParseRecursionStackOverflow(t *testing.T) {
-	// Generate 500,000 empty metric families in binary format.
-	// Serialized dto.MetricFamily{Name: "a"} is []byte{10, 1, 'a'}. Length-prefixed with varint 3: []byte{3, 10, 1, 'a'}
-	b := []byte{3, 10, 1, 'a'}
-	var buf bytes.Buffer
-	for range 500000 {
-		buf.Write(b)
-	}
-
-	p := NewProtobufParser(buf.Bytes(), false, false, false, false, labels.NewSymbolTable())
-
-	// This would trigger a stack overflow previously, but should now pass successfully and iteratively.
-	require.NotPanics(t, func() {
-		for {
-			_, err := p.Next()
-			if errors.Is(err, io.EOF) || err != nil {
-				break
-			}
-		}
-	})
 }
 
 func generateString(r *rand.Rand, firstRunes, restRunes []rune) string {


### PR DESCRIPTION

 **Context**: `ProtobufParser.Next()` used recursive self-calls when skipping empty metric families or fallback states. Under deeply nested or high-volume streams, this recursion could exhaust system stack memory, leading to a stack overflow crash. This issue mirrors a recursion bug class previously fixed in text and OpenMetrics parsers under #19160, but the protobuf parser was left unpatched.

**Changes**: Refactored `ProtobufParser.Next()` to loop iteratively using `for` and `continue` instead of recursive calls. Inlined the local helper closure `switchToClassic` to safely update state and transition iteratively.

**Verification**: Added `TestProtobufParseRecursionStackOverflow` to `protobufparse_test.go` verifying that parsing 500,000 empty metric families completes iteratively and successfully without hitting the stack limit.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
Fixes #19184

#### Release notes 
<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] textparse: Parse metrics in ProtobufParser.Next without recursion to prevent stack overflows
```

