### PR TITLE
fix(promql): never wrap step-invariant subqueries

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -4581,6 +4581,7 @@ func preprocessExprHelper(expr parser.Expr, start, end time.Time) (isStepInvaria
 		// Hence we wrap the inside of subquery irrespective of
 		// @ on subquery (given it is also step invariant) so that
 		// it is evaluated only once w.r.t. the start time of subquery.
+		// Like MatrixSelector we never wrap the subquery itself.
 		isInvariant, _ := preprocessExprHelper(n.Expr, start, end)
 		if isInvariant {
 			n.Expr = newStepInvariantExpr(n.Expr)
@@ -4591,7 +4592,7 @@ func preprocessExprHelper(expr parser.Expr, start, end time.Time) (isStepInvaria
 		case parser.END:
 			n.Timestamp = makeInt64Pointer(timestamp.FromTime(end))
 		}
-		return n.Timestamp != nil, n.Timestamp != nil
+		return n.Timestamp != nil, false
 
 	case *parser.ParenExpr:
 		return preprocessExprHelper(n.Expr, start, end)

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3327,56 +3327,52 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 		},
 		{
 			input: `foo{bar="baz"}[10m:6s] @ 10`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.SubqueryExpr{
-					Expr: &parser.VectorSelector{
-						Name: "foo",
-						LabelMatchers: []*labels.Matcher{
-							parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
-							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   14,
-						},
+			expected: &parser.SubqueryExpr{
+				Expr: &parser.VectorSelector{
+					Name: "foo",
+					LabelMatchers: []*labels.Matcher{
+						parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
+						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
 					},
-					Range:     10 * time.Minute,
-					Step:      6 * time.Second,
-					Timestamp: makeInt64Pointer(10000),
-					EndPos:    27,
+					PosRange: posrange.PositionRange{
+						Start: 0,
+						End:   14,
+					},
 				},
+				Range:     10 * time.Minute,
+				Step:      6 * time.Second,
+				Timestamp: makeInt64Pointer(10000),
+				EndPos:    27,
 			},
 		},
 		{ // Even though the subquery is step invariant, the inside is also wrapped separately.
 			input: `sum(foo{bar="baz"} @ 20)[10m:6s] @ 10`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.SubqueryExpr{
-					Expr: &parser.StepInvariantExpr{
-						Expr: &parser.AggregateExpr{
-							Op: parser.SUM,
-							Expr: &parser.VectorSelector{
-								Name: "foo",
-								LabelMatchers: []*labels.Matcher{
-									parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
-									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
-								},
-								PosRange: posrange.PositionRange{
-									Start: 4,
-									End:   23,
-								},
-								Timestamp: makeInt64Pointer(20000),
+			expected: &parser.SubqueryExpr{
+				Expr: &parser.StepInvariantExpr{
+					Expr: &parser.AggregateExpr{
+						Op: parser.SUM,
+						Expr: &parser.VectorSelector{
+							Name: "foo",
+							LabelMatchers: []*labels.Matcher{
+								parser.MustLabelMatcher(labels.MatchEqual, "bar", "baz"),
+								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
 							},
 							PosRange: posrange.PositionRange{
-								Start: 0,
-								End:   24,
+								Start: 4,
+								End:   23,
 							},
+							Timestamp: makeInt64Pointer(20000),
+						},
+						PosRange: posrange.PositionRange{
+							Start: 0,
+							End:   24,
 						},
 					},
-					Range:     10 * time.Minute,
-					Step:      6 * time.Second,
-					Timestamp: makeInt64Pointer(10000),
-					EndPos:    37,
 				},
+				Range:     10 * time.Minute,
+				Step:      6 * time.Second,
+				Timestamp: makeInt64Pointer(10000),
+				EndPos:    37,
 			},
 		},
 		{
@@ -3451,70 +3447,66 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 		},
 		{
 			input: `some_metric[10m:5s] offset 1m @ 123`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.SubqueryExpr{
-					Expr: &parser.VectorSelector{
-						Name: "some_metric",
-						LabelMatchers: []*labels.Matcher{
-							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   11,
-						},
+			expected: &parser.SubqueryExpr{
+				Expr: &parser.VectorSelector{
+					Name: "some_metric",
+					LabelMatchers: []*labels.Matcher{
+						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
 					},
-					Timestamp:      makeInt64Pointer(123000),
-					OriginalOffset: 1 * time.Minute,
-					Range:          10 * time.Minute,
-					Step:           5 * time.Second,
-					EndPos:         35,
+					PosRange: posrange.PositionRange{
+						Start: 0,
+						End:   11,
+					},
 				},
+				Timestamp:      makeInt64Pointer(123000),
+				OriginalOffset: 1 * time.Minute,
+				Range:          10 * time.Minute,
+				Step:           5 * time.Second,
+				EndPos:         35,
 			},
 		},
 		{
 			input: `(foo + bar{nm="val"} @ 1234)[5m:] @ 1603775019`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.SubqueryExpr{
-					Expr: &parser.ParenExpr{
-						Expr: &parser.BinaryExpr{
-							Op: parser.ADD,
-							VectorMatching: &parser.VectorMatching{
-								Card: parser.CardOneToOne,
+			expected: &parser.SubqueryExpr{
+				Expr: &parser.ParenExpr{
+					Expr: &parser.BinaryExpr{
+						Op: parser.ADD,
+						VectorMatching: &parser.VectorMatching{
+							Card: parser.CardOneToOne,
+						},
+						LHS: &parser.VectorSelector{
+							Name: "foo",
+							LabelMatchers: []*labels.Matcher{
+								parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
 							},
-							LHS: &parser.VectorSelector{
-								Name: "foo",
-								LabelMatchers: []*labels.Matcher{
-									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "foo"),
-								},
-								PosRange: posrange.PositionRange{
-									Start: 1,
-									End:   4,
-								},
-							},
-							RHS: &parser.StepInvariantExpr{
-								Expr: &parser.VectorSelector{
-									Name: "bar",
-									LabelMatchers: []*labels.Matcher{
-										parser.MustLabelMatcher(labels.MatchEqual, "nm", "val"),
-										parser.MustLabelMatcher(labels.MatchEqual, "__name__", "bar"),
-									},
-									Timestamp: makeInt64Pointer(1234000),
-									PosRange: posrange.PositionRange{
-										Start: 7,
-										End:   27,
-									},
-								},
+							PosRange: posrange.PositionRange{
+								Start: 1,
+								End:   4,
 							},
 						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   28,
+						RHS: &parser.StepInvariantExpr{
+							Expr: &parser.VectorSelector{
+								Name: "bar",
+								LabelMatchers: []*labels.Matcher{
+									parser.MustLabelMatcher(labels.MatchEqual, "nm", "val"),
+									parser.MustLabelMatcher(labels.MatchEqual, "__name__", "bar"),
+								},
+								Timestamp: makeInt64Pointer(1234000),
+								PosRange: posrange.PositionRange{
+									Start: 7,
+									End:   27,
+								},
+							},
 						},
 					},
-					Range:     5 * time.Minute,
-					Timestamp: makeInt64Pointer(1603775019000),
-					EndPos:    46,
+					PosRange: posrange.PositionRange{
+						Start: 0,
+						End:   28,
+					},
 				},
+				Range:     5 * time.Minute,
+				Timestamp: makeInt64Pointer(1603775019000),
+				EndPos:    46,
 			},
 		},
 		{
@@ -3693,46 +3685,42 @@ func TestPreprocessAndWrapWithStepInvariantExpr(t *testing.T) {
 		},
 		{
 			input: `some_metric[10m:5s] @ start()`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.SubqueryExpr{
-					Expr: &parser.VectorSelector{
-						Name: "some_metric",
-						LabelMatchers: []*labels.Matcher{
-							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   11,
-						},
+			expected: &parser.SubqueryExpr{
+				Expr: &parser.VectorSelector{
+					Name: "some_metric",
+					LabelMatchers: []*labels.Matcher{
+						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
 					},
-					Timestamp:  makeInt64Pointer(timestamp.FromTime(startTime)),
-					StartOrEnd: parser.START,
-					Range:      10 * time.Minute,
-					Step:       5 * time.Second,
-					EndPos:     29,
+					PosRange: posrange.PositionRange{
+						Start: 0,
+						End:   11,
+					},
 				},
+				Timestamp:  makeInt64Pointer(timestamp.FromTime(startTime)),
+				StartOrEnd: parser.START,
+				Range:      10 * time.Minute,
+				Step:       5 * time.Second,
+				EndPos:     29,
 			},
 		},
 		{
 			input: `some_metric[10m:5s] @ end()`,
-			expected: &parser.StepInvariantExpr{
-				Expr: &parser.SubqueryExpr{
-					Expr: &parser.VectorSelector{
-						Name: "some_metric",
-						LabelMatchers: []*labels.Matcher{
-							parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
-						},
-						PosRange: posrange.PositionRange{
-							Start: 0,
-							End:   11,
-						},
+			expected: &parser.SubqueryExpr{
+				Expr: &parser.VectorSelector{
+					Name: "some_metric",
+					LabelMatchers: []*labels.Matcher{
+						parser.MustLabelMatcher(labels.MatchEqual, "__name__", "some_metric"),
 					},
-					Timestamp:  makeInt64Pointer(timestamp.FromTime(endTime)),
-					StartOrEnd: parser.END,
-					Range:      10 * time.Minute,
-					Step:       5 * time.Second,
-					EndPos:     27,
+					PosRange: posrange.PositionRange{
+						Start: 0,
+						End:   11,
+					},
 				},
+				Timestamp:  makeInt64Pointer(timestamp.FromTime(endTime)),
+				StartOrEnd: parser.END,
+				Range:      10 * time.Minute,
+				Step:       5 * time.Second,
+				EndPos:     27,
 			},
 		},
 		{

--- a/promql/promqltest/testdata/at_modifier.test
+++ b/promql/promqltest/testdata/at_modifier.test
@@ -213,6 +213,34 @@ eval instant at 0s sum_over_time(timestamp(metric{job="1"} @ 10)[100s:10s] @ 300
 eval instant at 0s sum_over_time(timestamp(timestamp(metric{job="1"} @ 999))[10s:1s] @ 10)
   {job="1"} 55
 
+clear
+
+# Step-invariant matrix/subquery passed as an argument in a non-step-invariant function call.
+
+load 30s
+  arg 0 0.5 1 0.75
+  metric 1 2 3 4 5
+
+eval range from 0 to 1m30s step 30s quantile_over_time(scalar(arg), metric[2m1s] @ 2m)
+  {} 1 3 5 4
+
+eval instant at 0 quantile_over_time(scalar(arg), metric[2m1s] @ 2m)
+  {} 1
+
+eval range from 0 to 1m30s step 30s quantile_over_time(scalar(arg), metric[2m1s:30s] @ 2m)
+  {} 1 3 5 4
+
+eval instant at 0 quantile_over_time(scalar(arg), metric[2m1s:30s] @ 2m)
+  {} 1
+
+eval range from 0 to 1m30s step 30s quantile_over_time(0.5, metric[2m1s:30s] @ 2m)
+  {} 3 3 3 3
+
+eval instant at 0 quantile_over_time(0.5, metric[2m1s:30s] @ 2m)
+  {} 3
+
+eval range from 0 to 1m30s step 30s quantile_over_time(scalar(arg), metric[2m1s:30s])
+  {} 1 1.5 3 3.25
 
 clear
 
@@ -306,5 +334,3 @@ eval range from 0 to 60s step 10s timestamp(abs(metric @ 11))
 
 eval range from 0 to 60s step 10s timestamp(abs(metric_missing @ 11))
  {} 0 10 20 30 40 50 60
-
-clear


### PR DESCRIPTION
Implementation [suggested](https://github.com/prometheus/prometheus/pull/18612#discussion_r3266535528) by @vpranckaitis, who wrote:

> Subqueries should be processed in a similar way as matrix selectors: either they will be directly evaluated by functions over range selectors, or they will be used directly in instant query without enclosing functions (where there's only a single step and thus you're not optimizing anything by wrapping in `StepInvariantExpr`).

Added all the nontrivial test cases from #18610.
Several test cases in `TestPreprocessAndWrapWithStepInvariantExpr` need to be simplified.

This PR would replace #18612 which is a more complicated fix.

#### Which issue(s) does the PR fix:
Fixes #18610

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] PromQL: Fix empty results when a subquery with `@` is used as the matrix argument of a call that is not step-invariant (for example `quantile_over_time(scalar(x), metric[...:...] @ T)`).
```
