### PR TITLE
scrape: synthesize start times for summary _sum and _count series

### DIFF
--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"math"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -469,9 +470,21 @@ func (sl *scrapeLoop) checkAndSynthesizeStartTime(
 			return st, val, h, fh, skipAppend, c
 		}
 
-		// TODO(bwplotka): Add support for _count and _sum summary series.
 		switch metadata.Type {
 		case model.MetricTypeCounter, model.MetricTypeHistogram:
+			// Proceed to synthesis.
+		case model.MetricTypeSummary:
+			// Summaries expose cumulative _sum and _count series (counter
+			// semantics) alongside gauge-like quantile series. Only the _sum
+			// and _count series should have start times synthesized.
+			mName := lset.Get(model.MetricNameLabel)
+			base, ok := strings.CutSuffix(mName, "_sum")
+			if !ok {
+				base, ok = strings.CutSuffix(mName, "_count")
+			}
+			if !ok || base != yoloString(lastMFName) {
+				return st, val, h, fh, skipAppend, c
+			}
 			// Proceed to synthesis.
 		default:
 			return st, val, h, fh, skipAppend, c

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -1916,6 +1916,84 @@ test_metric 32
 	requireSample(t, got[8], "test_metric", 7, timestamp.FromTime(tsF), timestamp.FromTime(tsE), false)
 }
 
+func TestScrapeLoopAppend_StartTimeSynthesis_Summary(t *testing.T) {
+	ts := time.Now()
+
+	requireSample := func(t *testing.T, s teststorage.Sample, name string, val float64, ts, st int64) {
+		t.Helper()
+		require.Equal(t, name, s.L.Get(model.MetricNameLabel))
+		require.Equal(t, ts, s.T)
+		require.Equal(t, val, s.V)
+		require.Equal(t, st, s.ST)
+	}
+
+	s := teststorage.New(t)
+
+	appTest := teststorage.NewAppendable().Then(s)
+	sl, _ := newTestScrapeLoop(t, withAppendable(appTest, true), func(sl *scrapeLoop) {
+		sl.synthesizeST = true
+		sl.parseST = true
+	})
+
+	// First Scrape: anchor the start time for _sum and _count, their append is
+	// skipped. Quantile series are gauge-like and appended as-is with no ST.
+	scrapeA := []byte(`# TYPE test_summary summary
+test_summary{quantile="0.5"} 0.3
+test_summary_sum 100
+test_summary_count 10
+# EOF
+`)
+	app := sl.appender()
+	_, _, _, err := app.append(scrapeA, "application/openmetrics-text", ts)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	got := appTest.ResultSamples()
+	require.Len(t, got, 1)
+	requireSample(t, got[0], "test_summary", 0.3, timestamp.FromTime(ts), 0)
+
+	// Second Scrape: _sum and _count yield deltas with ST = ts. The quantile
+	// series must not be synthesized (still no ST).
+	ts2 := ts.Add(time.Second)
+	scrapeB := []byte(`# TYPE test_summary summary
+test_summary{quantile="0.5"} 0.4
+test_summary_sum 130
+test_summary_count 13
+# EOF
+`)
+	app = sl.appender()
+	_, _, _, err = app.append(scrapeB, "application/openmetrics-text", ts2)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	got = appTest.ResultSamples()
+
+	require.Len(t, got, 4)
+	requireSample(t, got[1], "test_summary", 0.4, timestamp.FromTime(ts2), 0)
+	requireSample(t, got[2], "test_summary_sum", 30, timestamp.FromTime(ts2), timestamp.FromTime(ts))
+	requireSample(t, got[3], "test_summary_count", 3, timestamp.FromTime(ts2), timestamp.FromTime(ts))
+
+	// Third Scrape: simulate a reset (_count and _sum drop). ST becomes ts3-1.
+	ts3 := ts2.Add(time.Second)
+	scrapeC := []byte(`# TYPE test_summary summary
+test_summary{quantile="0.5"} 0.2
+test_summary_sum 5
+test_summary_count 1
+# EOF
+`)
+	app = sl.appender()
+	_, _, _, err = app.append(scrapeC, "application/openmetrics-text", ts3)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	got = appTest.ResultSamples()
+
+	require.Len(t, got, 7)
+	requireSample(t, got[4], "test_summary", 0.2, timestamp.FromTime(ts3), 0)
+	requireSample(t, got[5], "test_summary_sum", 5, timestamp.FromTime(ts3), timestamp.FromTime(ts3)-1)
+	requireSample(t, got[6], "test_summary_count", 1, timestamp.FromTime(ts3), timestamp.FromTime(ts3)-1)
+}
+
 func TestScrapeLoopAppend_StartTimeSynthesis_WithSTStorage(t *testing.T) {
 	ts := time.Now()
 

--- a/scrape/st_synthesis.go
+++ b/scrape/st_synthesis.go
@@ -21,7 +21,8 @@ import (
 // information needed to synthesize start times for cumulative metrics
 // (Counters, Summaries, Histograms).
 //
-// Only Counters and Histograms (Classic/Native/Float) are supported.
+// Only Counters, Histograms (Classic/Native/Float) and the _sum and _count
+// series of Summaries are supported.
 //
 // Note: The first sample observed for a series is dropped to establish the
 // start timestamp reference point. All subsequent samples are adjusted relative


### PR DESCRIPTION
Motivation:
Start-timestamp (ST) auto-synthesis was implemented for all cumulative
counter-like series on the scrape path, but summary types were left out:
their _sum and _count series (which have counter semantics) did not get a
synthesized start time. This was tracked by an in-code TODO and called out
by maintainers as the remaining gap for #14763.

Approach:
Extend checkAndSynthesizeStartTime to handle model.MetricTypeSummary. A
summary family exposes cumulative _sum and _count series alongside
gauge-like quantile series, so only the _sum and _count series may be
synthesized. The quantile series (whose metric name equals the metric
family name) are deliberately excluded so their gauge values are never
run through counter reset-detection. Suffix matching mirrors the existing
isSeriesPartOfFamily logic and is allocation-free. The stCache doc comment
is updated to reflect the newly supported series.

Validation:
  go test ./scrape/ -run 'TestScrapeLoopAppend_StartTimeSynthesis' -race -count=1
Passes, including the new TestScrapeLoopAppend_StartTimeSynthesis_Summary,
which asserts that _sum/_count get deltas with a synthesized ST (anchor and
reset paths) while the quantile series keep ST=0.

```release-notes
[ENHANCEMENT] Scrape: Synthesize start timestamps for summary `_sum` and `_count` series when start-time synthesis is enabled.
```

Fixes #14763

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
