### PR TITLE
tests: speed up TestHeadCompactionWhileScraping

### DIFF
--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -953,6 +953,9 @@ runtime:
 // concurrently with a scrape does not trigger the data race described in
 // https://github.com/prometheus/prometheus/issues/16490.
 func TestHeadCompactionWhileScraping(t *testing.T) {
+	if runtime.GOOS == "windows" { // No race detector on Windows.
+		t.SkipNow()
+	}
 	t.Parallel()
 
 	// To increase the chance of reproducing the data race
@@ -983,6 +986,7 @@ scrape_configs:
 				port,
 				fmt.Sprintf("--storage.tsdb.path=%s", tmpDir),
 				"--storage.tsdb.min-block-duration=100ms",
+				"--scrape.discovery-reload-interval=100ms", // Reduce initial wait time from default of 5 seconds.
 			)
 			require.NoError(t, prom.Start())
 
@@ -1020,6 +1024,7 @@ scrape_configs:
 				require.Zero(t, failures)
 				return true
 			}, 15*time.Second, 500*time.Millisecond)
+			prom.Process.Signal(os.Interrupt)
 		})
 	}
 }


### PR DESCRIPTION
This test runs a Prometheus test binary in a subprocess five times, doing three compactions each time with ~60ms between each, intending that the race detector will be checking for errors.

Everything must finish within 15 seconds, which seems to be tight on GitHub Actions runners.

This PR:
* Reduces a 5-second delay before anything happens to 100ms.
* Terminates each Prometheus subprocess via SIGINT as soon as it completes three compactions. ~Absent this, each of the five Prometheus continues running and compacting until the whole test finishes.~ This analysis is wrong.
* Skips the test on Windows, where SIGINT is not implemented. The race detector requires a special C compiler on Windows.

#### Which issue(s) does the PR fix:
Fixes #17956

On my home machine the wall-clock time under `-race` goes from 8s to 3s.

#### Release notes for end users
```release-notes
NONE
```
