### PR TITLE
notifier: stop targetUpdateLoop on closed target-set channel

### DIFF
--- a/notifier/manager.go
+++ b/notifier/manager.go
@@ -227,7 +227,7 @@ func (n *Manager) targetUpdateLoop(tsets <-chan map[string][]*targetgroup.Group)
 				return
 			case ts, ok := <-tsets:
 				if !ok {
-					break
+					return
 				}
 				n.reload(ts)
 			}

--- a/notifier/manager_test.go
+++ b/notifier/manager_test.go
@@ -1563,3 +1563,23 @@ func newImmediateAlertManager(done chan<- struct{}) *httptest.Server {
 		close(done)
 	}))
 }
+
+func TestRunReturnsWhenTargetSetsClosed(t *testing.T) {
+	n := NewManager(&Options{}, model.UTF8Validation, nil)
+	defer n.Stop()
+
+	tsets := make(chan map[string][]*targetgroup.Group)
+	done := make(chan struct{})
+	go func() {
+		n.Run(tsets)
+		close(done)
+	}()
+
+	close(tsets)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("notifier manager did not stop after target sets channel was closed")
+	}
+}


### PR DESCRIPTION
The `targetUpdateLoop` method uses `break` when the `tsets` channel is
closed, but `break` only exits the inner `select`, not the enclosing
`for` loop. This creates a tight CPU spin loop. Use `return` instead,
matching the fix applied to the scrape manager in #19149.

Fixes #19191

```release-notes
[BUGFIX] Notifier: Fix CPU spin when target-set channel is closed.
```

Test: `go test ./notifier/ -run TestRunReturnsWhenTargetSetsClosed -v -count=1`

This PR was developed with AI assistance.