### PR TITLE
discovery/aws: fix MSK panic on clusters without provisioned config

### DIFF
--- a/discovery/aws/msk.go
+++ b/discovery/aws/msk.go
@@ -423,18 +423,28 @@ func (d *MSKDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 			defer wg.Done()
 			for _, node := range nodes {
 				labels := model.LabelSet{
-					mskLabelClusterName:                  model.LabelValue(aws.ToString(cluster.ClusterName)),
-					mskLabelClusterARN:                   model.LabelValue(aws.ToString(cluster.ClusterArn)),
-					mskLabelClusterState:                 model.LabelValue(string(cluster.State)),
-					mskLabelClusterType:                  model.LabelValue(string(cluster.ClusterType)),
-					mskLabelClusterVersion:               model.LabelValue(aws.ToString(cluster.CurrentVersion)),
-					mskLabelNodeARN:                      model.LabelValue(aws.ToString(node.NodeARN)),
-					mskLabelNodeAddedTime:                model.LabelValue(aws.ToString(node.AddedToClusterTime)),
-					mskLabelNodeInstanceType:             model.LabelValue(aws.ToString(node.InstanceType)),
-					mskLabelClusterJmxExporterEnabled:    model.LabelValue(strconv.FormatBool(*cluster.Provisioned.OpenMonitoring.Prometheus.JmxExporter.EnabledInBroker)),
-					mskLabelClusterConfigurationARN:      model.LabelValue(aws.ToString(cluster.Provisioned.CurrentBrokerSoftwareInfo.ConfigurationArn)),
-					mskLabelClusterConfigurationRevision: model.LabelValue(strconv.FormatInt(*cluster.Provisioned.CurrentBrokerSoftwareInfo.ConfigurationRevision, 10)),
-					mskLabelClusterKafkaVersion:          model.LabelValue(aws.ToString(cluster.Provisioned.CurrentBrokerSoftwareInfo.KafkaVersion)),
+					mskLabelClusterName:      model.LabelValue(aws.ToString(cluster.ClusterName)),
+					mskLabelClusterARN:       model.LabelValue(aws.ToString(cluster.ClusterArn)),
+					mskLabelClusterState:     model.LabelValue(string(cluster.State)),
+					mskLabelClusterType:      model.LabelValue(string(cluster.ClusterType)),
+					mskLabelClusterVersion:   model.LabelValue(aws.ToString(cluster.CurrentVersion)),
+					mskLabelNodeARN:          model.LabelValue(aws.ToString(node.NodeARN)),
+					mskLabelNodeAddedTime:    model.LabelValue(aws.ToString(node.AddedToClusterTime)),
+					mskLabelNodeInstanceType: model.LabelValue(aws.ToString(node.InstanceType)),
+				}
+
+				// Serverless clusters have no Provisioned configuration, and
+				// clusters without Open Monitoring have a nil OpenMonitoring,
+				// so the corresponding labels are omitted.
+				if provisioned := cluster.Provisioned; provisioned != nil {
+					if info := provisioned.CurrentBrokerSoftwareInfo; info != nil {
+						labels[mskLabelClusterConfigurationARN] = model.LabelValue(aws.ToString(info.ConfigurationArn))
+						labels[mskLabelClusterConfigurationRevision] = model.LabelValue(strconv.FormatInt(aws.ToInt64(info.ConfigurationRevision), 10))
+						labels[mskLabelClusterKafkaVersion] = model.LabelValue(aws.ToString(info.KafkaVersion))
+					}
+					if om := provisioned.OpenMonitoring; om != nil && om.Prometheus != nil && om.Prometheus.JmxExporter != nil {
+						labels[mskLabelClusterJmxExporterEnabled] = model.LabelValue(strconv.FormatBool(aws.ToBool(om.Prometheus.JmxExporter.EnabledInBroker)))
+					}
 				}
 
 				for key, value := range cluster.Tags {
@@ -448,7 +458,12 @@ func (d *MSKDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 					labels[mskLabelBrokerID] = model.LabelValue(fmt.Sprintf("%.0f", aws.ToFloat64(node.BrokerNodeInfo.BrokerId)))
 					labels[mskLabelBrokerClientSubnet] = model.LabelValue(aws.ToString(node.BrokerNodeInfo.ClientSubnet))
 					labels[mskLabelBrokerClientVPCIP] = model.LabelValue(aws.ToString(node.BrokerNodeInfo.ClientVpcIpAddress))
-					labels[mskLabelBrokerNodeExporterEnabled] = model.LabelValue(strconv.FormatBool(*cluster.Provisioned.OpenMonitoring.Prometheus.NodeExporter.EnabledInBroker))
+					if provisioned := cluster.Provisioned; provisioned != nil &&
+						provisioned.OpenMonitoring != nil &&
+						provisioned.OpenMonitoring.Prometheus != nil &&
+						provisioned.OpenMonitoring.Prometheus.NodeExporter != nil {
+						labels[mskLabelBrokerNodeExporterEnabled] = model.LabelValue(strconv.FormatBool(aws.ToBool(provisioned.OpenMonitoring.Prometheus.NodeExporter.EnabledInBroker)))
+					}
 
 					for idx, endpoint := range node.BrokerNodeInfo.Endpoints {
 						endpointLabels := labels.Clone()

--- a/discovery/aws/msk.go
+++ b/discovery/aws/msk.go
@@ -429,28 +429,23 @@ func (d *MSKDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 			defer wg.Done()
 			for _, node := range nodes {
 				labels := model.LabelSet{
-					mskLabelClusterName:      model.LabelValue(aws.ToString(cluster.ClusterName)),
-					mskLabelClusterARN:       model.LabelValue(aws.ToString(cluster.ClusterArn)),
-					mskLabelClusterState:     model.LabelValue(string(cluster.State)),
-					mskLabelClusterType:      model.LabelValue(string(cluster.ClusterType)),
-					mskLabelClusterVersion:   model.LabelValue(aws.ToString(cluster.CurrentVersion)),
-					mskLabelNodeARN:          model.LabelValue(aws.ToString(node.NodeARN)),
-					mskLabelNodeAddedTime:    model.LabelValue(aws.ToString(node.AddedToClusterTime)),
-					mskLabelNodeInstanceType: model.LabelValue(aws.ToString(node.InstanceType)),
+					mskLabelClusterName:                  model.LabelValue(aws.ToString(cluster.ClusterName)),
+					mskLabelClusterARN:                   model.LabelValue(aws.ToString(cluster.ClusterArn)),
+					mskLabelClusterState:                 model.LabelValue(string(cluster.State)),
+					mskLabelClusterType:                  model.LabelValue(string(cluster.ClusterType)),
+					mskLabelClusterVersion:               model.LabelValue(aws.ToString(cluster.CurrentVersion)),
+					mskLabelNodeARN:                      model.LabelValue(aws.ToString(node.NodeARN)),
+					mskLabelNodeAddedTime:                model.LabelValue(aws.ToString(node.AddedToClusterTime)),
+					mskLabelNodeInstanceType:             model.LabelValue(aws.ToString(node.InstanceType)),
+					mskLabelClusterConfigurationARN:      model.LabelValue(aws.ToString(cluster.Provisioned.CurrentBrokerSoftwareInfo.ConfigurationArn)),
+					mskLabelClusterConfigurationRevision: model.LabelValue(strconv.FormatInt(aws.ToInt64(cluster.Provisioned.CurrentBrokerSoftwareInfo.ConfigurationRevision), 10)),
+					mskLabelClusterKafkaVersion:          model.LabelValue(aws.ToString(cluster.Provisioned.CurrentBrokerSoftwareInfo.KafkaVersion)),
 				}
 
-				// Serverless clusters have no Provisioned configuration, and
-				// clusters without Open Monitoring have a nil OpenMonitoring,
-				// so the corresponding labels are omitted.
-				if provisioned := cluster.Provisioned; provisioned != nil {
-					if info := provisioned.CurrentBrokerSoftwareInfo; info != nil {
-						labels[mskLabelClusterConfigurationARN] = model.LabelValue(aws.ToString(info.ConfigurationArn))
-						labels[mskLabelClusterConfigurationRevision] = model.LabelValue(strconv.FormatInt(aws.ToInt64(info.ConfigurationRevision), 10))
-						labels[mskLabelClusterKafkaVersion] = model.LabelValue(aws.ToString(info.KafkaVersion))
-					}
-					if om := provisioned.OpenMonitoring; om != nil && om.Prometheus != nil && om.Prometheus.JmxExporter != nil {
-						labels[mskLabelClusterJmxExporterEnabled] = model.LabelValue(strconv.FormatBool(aws.ToBool(om.Prometheus.JmxExporter.EnabledInBroker)))
-					}
+				// The JMX exporter label is omitted when Open Monitoring is
+				// not enabled on the cluster.
+				if om := cluster.Provisioned.OpenMonitoring; om != nil && om.Prometheus != nil && om.Prometheus.JmxExporter != nil {
+					labels[mskLabelClusterJmxExporterEnabled] = model.LabelValue(strconv.FormatBool(aws.ToBool(om.Prometheus.JmxExporter.EnabledInBroker)))
 				}
 
 				for key, value := range cluster.Tags {
@@ -464,11 +459,10 @@ func (d *MSKDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 					labels[mskLabelBrokerID] = model.LabelValue(fmt.Sprintf("%.0f", aws.ToFloat64(node.BrokerNodeInfo.BrokerId)))
 					labels[mskLabelBrokerClientSubnet] = model.LabelValue(aws.ToString(node.BrokerNodeInfo.ClientSubnet))
 					labels[mskLabelBrokerClientVPCIP] = model.LabelValue(aws.ToString(node.BrokerNodeInfo.ClientVpcIpAddress))
-					if provisioned := cluster.Provisioned; provisioned != nil &&
-						provisioned.OpenMonitoring != nil &&
-						provisioned.OpenMonitoring.Prometheus != nil &&
-						provisioned.OpenMonitoring.Prometheus.NodeExporter != nil {
-						labels[mskLabelBrokerNodeExporterEnabled] = model.LabelValue(strconv.FormatBool(aws.ToBool(provisioned.OpenMonitoring.Prometheus.NodeExporter.EnabledInBroker)))
+					// The node exporter label is omitted when Open Monitoring
+					// is not enabled on the cluster.
+					if om := cluster.Provisioned.OpenMonitoring; om != nil && om.Prometheus != nil && om.Prometheus.NodeExporter != nil {
+						labels[mskLabelBrokerNodeExporterEnabled] = model.LabelValue(strconv.FormatBool(aws.ToBool(om.Prometheus.NodeExporter.EnabledInBroker)))
 					}
 
 					for idx, endpoint := range node.BrokerNodeInfo.Endpoints {

--- a/discovery/aws/msk.go
+++ b/discovery/aws/msk.go
@@ -308,6 +308,12 @@ func (d *MSKDiscovery) describeClusters(ctx context.Context, clusterARNs []strin
 			if err != nil {
 				return fmt.Errorf("could not describe cluster %v: %w", clusterARN, err)
 			}
+			// Only provisioned clusters expose broker nodes; skip anything
+			// else (e.g. serverless clusters) that was explicitly configured.
+			if cluster.ClusterInfo.ClusterType != types.ClusterTypeProvisioned {
+				d.logger.Warn("Skipping non-provisioned MSK cluster, only provisioned clusters are supported", "cluster", clusterARN, "type", string(cluster.ClusterInfo.ClusterType))
+				return nil
+			}
 			mu.Lock()
 			clusters = append(clusters, *cluster.ClusterInfo)
 			mu.Unlock()

--- a/discovery/aws/msk_test.go
+++ b/discovery/aws/msk_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
 	"github.com/aws/aws-sdk-go-v2/service/kafka/types"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -137,6 +138,41 @@ func TestMSKDiscoveryDescribeClusters(t *testing.T) {
 		expected    []types.Cluster
 	}{
 		{
+			name: "ServerlessClusterIsSkipped",
+			mskData: &mskDataStore{
+				region: "us-west-2",
+				clusters: []types.Cluster{
+					{
+						ClusterName:    strptr("provisioned-cluster"),
+						ClusterArn:     strptr("arn:aws:kafka:us-west-2:123456789012:cluster/provisioned-cluster/abc-123"),
+						State:          types.ClusterStateActive,
+						ClusterType:    types.ClusterTypeProvisioned,
+						CurrentVersion: strptr("1.2.3"),
+					},
+					{
+						ClusterName:    strptr("serverless-cluster"),
+						ClusterArn:     strptr("arn:aws:kafka:us-west-2:123456789012:cluster/serverless-cluster/def-456"),
+						State:          types.ClusterStateActive,
+						ClusterType:    types.ClusterTypeServerless,
+						CurrentVersion: strptr("1.0.0"),
+					},
+				},
+			},
+			clusterARNs: []string{
+				"arn:aws:kafka:us-west-2:123456789012:cluster/provisioned-cluster/abc-123",
+				"arn:aws:kafka:us-west-2:123456789012:cluster/serverless-cluster/def-456",
+			},
+			expected: []types.Cluster{
+				{
+					ClusterName:    strptr("provisioned-cluster"),
+					ClusterArn:     strptr("arn:aws:kafka:us-west-2:123456789012:cluster/provisioned-cluster/abc-123"),
+					State:          types.ClusterStateActive,
+					ClusterType:    types.ClusterTypeProvisioned,
+					CurrentVersion: strptr("1.2.3"),
+				},
+			},
+		},
+		{
 			name: "SingleCluster",
 			mskData: &mskDataStore{
 				region: "us-west-2",
@@ -218,7 +254,8 @@ func TestMSKDiscoveryDescribeClusters(t *testing.T) {
 			client := newMockMSKClient(tt.mskData)
 
 			d := &MSKDiscovery{
-				msk: client,
+				msk:    client,
+				logger: promslog.NewNopLogger(),
 				cfg: &MSKSDConfig{
 					Region:             tt.mskData.region,
 					RequestConcurrency: 10,
@@ -508,7 +545,7 @@ func TestMSKDiscoveryRefresh(t *testing.T) {
 			},
 		},
 		{
-			name: "ServerlessClusterWithoutProvisionedConfig",
+			name: "ServerlessClusterProducesNoTargets",
 			mskData: &mskDataStore{
 				region: "us-west-2",
 				clusters: []types.Cluster{
@@ -544,28 +581,11 @@ func TestMSKDiscoveryRefresh(t *testing.T) {
 				RequestConcurrency: 10,
 				Clusters:           []string{"arn:aws:kafka:us-west-2:123456789012:cluster/serverless-cluster/def-456"},
 			},
+			// Serverless clusters are skipped by describeClusters, so no
+			// targets are produced even though the cluster has nodes.
 			expected: []*targetgroup.Group{
 				{
 					Source: "us-west-2",
-					Targets: []model.LabelSet{
-						{
-							model.AddressLabel:                 model.LabelValue("b-2.serverless-cluster.def456.kafka.us-west-2.amazonaws.com:80"),
-							"__meta_msk_cluster_name":          model.LabelValue("serverless-cluster"),
-							"__meta_msk_cluster_arn":           model.LabelValue("arn:aws:kafka:us-west-2:123456789012:cluster/serverless-cluster/def-456"),
-							"__meta_msk_cluster_state":         model.LabelValue("ACTIVE"),
-							"__meta_msk_cluster_type":          model.LabelValue("SERVERLESS"),
-							"__meta_msk_cluster_version":       model.LabelValue("1.0.0"),
-							"__meta_msk_node_type":             model.LabelValue("BROKER"),
-							"__meta_msk_node_arn":              model.LabelValue("arn:aws:kafka:us-west-2:123456789012:node/broker-2"),
-							"__meta_msk_node_added_time":       model.LabelValue("2023-01-01T00:00:00Z"),
-							"__meta_msk_node_instance_type":    model.LabelValue("kafka.m5.xlarge"),
-							"__meta_msk_node_attached_eni":     model.LabelValue("eni-67890"),
-							"__meta_msk_broker_id":             model.LabelValue("2"),
-							"__meta_msk_broker_client_subnet":  model.LabelValue("subnet-67890"),
-							"__meta_msk_broker_client_vpc_ip":  model.LabelValue("10.0.2.100"),
-							"__meta_msk_broker_endpoint_index": model.LabelValue("0"),
-						},
-					},
 				},
 			},
 		},
@@ -1141,6 +1161,7 @@ func TestMSKDiscoveryRefresh(t *testing.T) {
 
 			d := &MSKDiscovery{
 				msk:    client,
+				logger: promslog.NewNopLogger(),
 				cfg:    config,
 				region: tt.mskData.region,
 			}

--- a/discovery/aws/msk_test.go
+++ b/discovery/aws/msk_test.go
@@ -508,6 +508,140 @@ func TestMSKDiscoveryRefresh(t *testing.T) {
 			},
 		},
 		{
+			name: "ServerlessClusterWithoutProvisionedConfig",
+			mskData: &mskDataStore{
+				region: "us-west-2",
+				clusters: []types.Cluster{
+					{
+						ClusterName:    strptr("serverless-cluster"),
+						ClusterArn:     strptr("arn:aws:kafka:us-west-2:123456789012:cluster/serverless-cluster/def-456"),
+						State:          types.ClusterStateActive,
+						ClusterType:    types.ClusterTypeServerless,
+						CurrentVersion: strptr("1.0.0"),
+						// Serverless clusters have no Provisioned configuration.
+					},
+				},
+				nodes: map[string][]types.NodeInfo{
+					"arn:aws:kafka:us-west-2:123456789012:cluster/serverless-cluster/def-456": {
+						{
+							NodeARN:            strptr("arn:aws:kafka:us-west-2:123456789012:node/broker-2"),
+							AddedToClusterTime: strptr("2023-01-01T00:00:00Z"),
+							InstanceType:       strptr("kafka.m5.xlarge"),
+							BrokerNodeInfo: &types.BrokerNodeInfo{
+								BrokerId:           aws.Float64(2),
+								ClientSubnet:       strptr("subnet-67890"),
+								ClientVpcIpAddress: strptr("10.0.2.100"),
+								Endpoints:          []string{"b-2.serverless-cluster.def456.kafka.us-west-2.amazonaws.com"},
+								AttachedENIId:      strptr("eni-67890"),
+							},
+						},
+					},
+				},
+			},
+			config: &MSKSDConfig{
+				Region:             "us-west-2",
+				Port:               80,
+				RequestConcurrency: 10,
+				Clusters:           []string{"arn:aws:kafka:us-west-2:123456789012:cluster/serverless-cluster/def-456"},
+			},
+			expected: []*targetgroup.Group{
+				{
+					Source: "us-west-2",
+					Targets: []model.LabelSet{
+						{
+							model.AddressLabel:                 model.LabelValue("b-2.serverless-cluster.def456.kafka.us-west-2.amazonaws.com:80"),
+							"__meta_msk_cluster_name":          model.LabelValue("serverless-cluster"),
+							"__meta_msk_cluster_arn":           model.LabelValue("arn:aws:kafka:us-west-2:123456789012:cluster/serverless-cluster/def-456"),
+							"__meta_msk_cluster_state":         model.LabelValue("ACTIVE"),
+							"__meta_msk_cluster_type":          model.LabelValue("SERVERLESS"),
+							"__meta_msk_cluster_version":       model.LabelValue("1.0.0"),
+							"__meta_msk_node_type":             model.LabelValue("BROKER"),
+							"__meta_msk_node_arn":              model.LabelValue("arn:aws:kafka:us-west-2:123456789012:node/broker-2"),
+							"__meta_msk_node_added_time":       model.LabelValue("2023-01-01T00:00:00Z"),
+							"__meta_msk_node_instance_type":    model.LabelValue("kafka.m5.xlarge"),
+							"__meta_msk_node_attached_eni":     model.LabelValue("eni-67890"),
+							"__meta_msk_broker_id":             model.LabelValue("2"),
+							"__meta_msk_broker_client_subnet":  model.LabelValue("subnet-67890"),
+							"__meta_msk_broker_client_vpc_ip":  model.LabelValue("10.0.2.100"),
+							"__meta_msk_broker_endpoint_index": model.LabelValue("0"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ProvisionedClusterWithoutOpenMonitoring",
+			mskData: &mskDataStore{
+				region: "us-west-2",
+				clusters: []types.Cluster{
+					{
+						ClusterName:    strptr("no-monitoring-cluster"),
+						ClusterArn:     strptr("arn:aws:kafka:us-west-2:123456789012:cluster/no-monitoring-cluster/ghi-789"),
+						State:          types.ClusterStateActive,
+						ClusterType:    types.ClusterTypeProvisioned,
+						CurrentVersion: strptr("1.2.3"),
+						Provisioned: &types.Provisioned{
+							CurrentBrokerSoftwareInfo: &types.BrokerSoftwareInfo{
+								ConfigurationArn:      strptr("arn:aws:kafka:us-west-2:123456789012:configuration/my-config/ghi-789"),
+								ConfigurationRevision: aws.Int64(2),
+								KafkaVersion:          strptr("2.8.1"),
+							},
+							// Open Monitoring is not enabled on this cluster.
+						},
+					},
+				},
+				nodes: map[string][]types.NodeInfo{
+					"arn:aws:kafka:us-west-2:123456789012:cluster/no-monitoring-cluster/ghi-789": {
+						{
+							NodeARN:            strptr("arn:aws:kafka:us-west-2:123456789012:node/broker-3"),
+							AddedToClusterTime: strptr("2023-01-01T00:00:00Z"),
+							InstanceType:       strptr("kafka.m5.large"),
+							BrokerNodeInfo: &types.BrokerNodeInfo{
+								BrokerId:           aws.Float64(3),
+								ClientSubnet:       strptr("subnet-12345"),
+								ClientVpcIpAddress: strptr("10.0.3.100"),
+								Endpoints:          []string{"b-3.no-monitoring-cluster.ghi789.kafka.us-west-2.amazonaws.com"},
+								AttachedENIId:      strptr("eni-12345"),
+							},
+						},
+					},
+				},
+			},
+			config: &MSKSDConfig{
+				Region:             "us-west-2",
+				Port:               80,
+				RequestConcurrency: 10,
+				Clusters:           []string{"arn:aws:kafka:us-west-2:123456789012:cluster/no-monitoring-cluster/ghi-789"},
+			},
+			expected: []*targetgroup.Group{
+				{
+					Source: "us-west-2",
+					Targets: []model.LabelSet{
+						{
+							model.AddressLabel:                          model.LabelValue("b-3.no-monitoring-cluster.ghi789.kafka.us-west-2.amazonaws.com:80"),
+							"__meta_msk_cluster_name":                   model.LabelValue("no-monitoring-cluster"),
+							"__meta_msk_cluster_arn":                    model.LabelValue("arn:aws:kafka:us-west-2:123456789012:cluster/no-monitoring-cluster/ghi-789"),
+							"__meta_msk_cluster_state":                  model.LabelValue("ACTIVE"),
+							"__meta_msk_cluster_type":                   model.LabelValue("PROVISIONED"),
+							"__meta_msk_cluster_version":                model.LabelValue("1.2.3"),
+							"__meta_msk_cluster_configuration_arn":      model.LabelValue("arn:aws:kafka:us-west-2:123456789012:configuration/my-config/ghi-789"),
+							"__meta_msk_cluster_configuration_revision": model.LabelValue("2"),
+							"__meta_msk_cluster_kafka_version":          model.LabelValue("2.8.1"),
+							"__meta_msk_node_type":                      model.LabelValue("BROKER"),
+							"__meta_msk_node_arn":                       model.LabelValue("arn:aws:kafka:us-west-2:123456789012:node/broker-3"),
+							"__meta_msk_node_added_time":                model.LabelValue("2023-01-01T00:00:00Z"),
+							"__meta_msk_node_instance_type":             model.LabelValue("kafka.m5.large"),
+							"__meta_msk_node_attached_eni":              model.LabelValue("eni-12345"),
+							"__meta_msk_broker_id":                      model.LabelValue("3"),
+							"__meta_msk_broker_client_subnet":           model.LabelValue("subnet-12345"),
+							"__meta_msk_broker_client_vpc_ip":           model.LabelValue("10.0.3.100"),
+							"__meta_msk_broker_endpoint_index":          model.LabelValue("0"),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "NoClustersWithEmptyClustersConfig",
 			mskData: &mskDataStore{
 				region:   "us-east-1",

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1007,10 +1007,10 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_msk_cluster_name`: the name of the MSK cluster
 * `__meta_msk_cluster_arn`: the ARN of the MSK cluster
 * `__meta_msk_cluster_state`: the state of the MSK cluster (e.g., ACTIVE, CREATING, DELETING)
-* `__meta_msk_cluster_type`: the type of the MSK cluster (e.g., PROVISIONED, SERVERLESS)
+* `__meta_msk_cluster_type`: the type of the MSK cluster (always PROVISIONED, as serverless clusters are skipped)
 * `__meta_msk_cluster_version`: the current version of the MSK cluster
 * `__meta_msk_cluster_kafka_version`: the Kafka version running on the cluster
-* `__meta_msk_cluster_jmx_exporter_enabled`: whether JMX exporter is enabled on the cluster
+* `__meta_msk_cluster_jmx_exporter_enabled`: whether JMX exporter is enabled on the cluster; this label is absent (not `false`) when Open Monitoring is not enabled on the cluster
 * `__meta_msk_cluster_configuration_arn`: the ARN of the MSK configuration
 * `__meta_msk_cluster_configuration_revision`: the revision of the MSK configuration
 * `__meta_msk_cluster_tag_<tagkey>`: each cluster tag value, keyed by tag name
@@ -1023,7 +1023,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 * `__meta_msk_broker_endpoint_index`: the index of the broker endpoint (broker nodes only)
 * `__meta_msk_broker_client_subnet`: the client subnet of the broker (broker nodes only)
 * `__meta_msk_broker_client_vpc_ip`: the VPC IP address of the broker (broker nodes only)
-* `__meta_msk_broker_node_exporter_enabled`: whether node exporter is enabled on brokers (broker nodes only)
+* `__meta_msk_broker_node_exporter_enabled`: whether node exporter is enabled on brokers (broker nodes only); this label is absent (not `false`) when Open Monitoring is not enabled on the cluster
 * `__meta_msk_controller_endpoint_index`: the index of the controller endpoint (controller nodes only)
 
 #### `elasticache`


### PR DESCRIPTION
Serverless MSK clusters return a nil `Provisioned` field, and provisioned clusters without Open Monitoring return a nil `OpenMonitoring` field. The MSK discovery dereferenced both unconditionally while building target labels, crashing the whole Prometheus process during service discovery.

This guards the dereferences and omits the affected labels when the configuration is absent:

* `__meta_msk_cluster_configuration_arn`, `__meta_msk_cluster_configuration_revision`, and `__meta_msk_cluster_kafka_version` are only set when `Provisioned.CurrentBrokerSoftwareInfo` is present.
* `__meta_msk_cluster_jmx_exporter_enabled` and `__meta_msk_broker_node_exporter_enabled` are only set when Open Monitoring is configured.

The first commit adds a regression test reproducing the reported panic
(nil pointer dereference at `msk.go:434` with a serverless cluster and a provisioned cluster without Open Monitoring); the second commit fixes it.

Fixes #19184

```release-notes
[BUGFIX] AWS SD: Do not crash on serverless MSK clusters or MSK clusters without Open Monitoring.
```