### PR TITLE
tsdb: fix hang in TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier

### DIFF
--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -2532,8 +2532,7 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier_AppendV
 	// lastGarbageCollectedMmapRef before creating the second querier below.
 	// Until that ref is set, the second querier would capture the stale ref (0)
 	// and permanently block the OOO reader-wait loop, which has no timeout, hanging
-	// the test on slow runners. A fixed sleep is not enough here: writing the block
-	// and reloading are disk-I/O bound and can exceed it on slow Windows CI runners.
+	// the test on slow runners.
 	require.Eventually(t, func() bool {
 		db.mtx.RLock()
 		defer db.mtx.RUnlock()

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -2533,11 +2533,19 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier_AppendV
 	// Until that ref is set, the second querier would capture the stale ref (0)
 	// and permanently block the OOO reader-wait loop, which has no timeout, hanging
 	// the test on slow runners.
+	// If compaction exits before publishing the ref, stop waiting so its error can
+	// be reported below instead of being masked by the timeout.
 	require.Eventually(t, func() bool {
+		if compactionComplete.Load() {
+			return true
+		}
 		db.mtx.RLock()
 		defer db.mtx.RUnlock()
 		return db.lastGarbageCollectedMmapRef != 0
 	}, time.Minute, 10*time.Millisecond, "CompactOOOHead did not reach the reader-wait phase")
+	if compactionComplete.Load() {
+		require.NoError(t, <-compactionErr)
+	}
 	// The compaction must still be waiting for querierCreatedBeforeCompaction to be
 	// closed. If it does not wait, then the query will return incorrect results or fail.
 	require.False(t, compactionComplete.Load(), "compaction completed before reading chunks or closing querier created before compaction")

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -2528,9 +2528,19 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier_AppendV
 		compactionErr <- db.CompactOOOHead(ctx)
 	}()
 
-	// Give CompactOOOHead time to start work.
-	// If it does not wait for querierCreatedBeforeCompaction to be closed, then the query will return incorrect results or fail.
-	time.Sleep(time.Second)
+	// Wait until CompactOOOHead has written the OOO block, reloaded, and published
+	// lastGarbageCollectedMmapRef before creating the second querier below.
+	// Until that ref is set, the second querier would capture the stale ref (0)
+	// and permanently block the OOO reader-wait loop, which has no timeout, hanging
+	// the test on slow runners. A fixed sleep is not enough here: writing the block
+	// and reloading are disk-I/O bound and can exceed it on slow Windows CI runners.
+	require.Eventually(t, func() bool {
+		db.mtx.RLock()
+		defer db.mtx.RUnlock()
+		return db.lastGarbageCollectedMmapRef != 0
+	}, time.Minute, 10*time.Millisecond, "CompactOOOHead did not reach the reader-wait phase")
+	// The compaction must still be waiting for querierCreatedBeforeCompaction to be
+	// closed. If it does not wait, then the query will return incorrect results or fail.
 	require.False(t, compactionComplete.Load(), "compaction completed before reading chunks or closing querier created before compaction")
 
 	// Get another querier. This one should only use the compacted blocks from disk and ignore the chunks that will be garbage collected.

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4125,9 +4125,19 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier(t *test
 		compactionErr <- db.CompactOOOHead(ctx)
 	}()
 
-	// Give CompactOOOHead time to start work.
-	// If it does not wait for querierCreatedBeforeCompaction to be closed, then the query will return incorrect results or fail.
-	time.Sleep(time.Second)
+	// Wait until CompactOOOHead has written the OOO block, reloaded, and published
+	// lastGarbageCollectedMmapRef before creating the second querier below.
+	// Until that ref is set, the second querier would capture the stale ref (0)
+	// and permanently block the OOO reader-wait loop, which has no timeout, hanging
+	// the test on slow runners. A fixed sleep is not enough here: writing the block
+	// and reloading are disk-I/O bound and can exceed it on slow Windows CI runners.
+	require.Eventually(t, func() bool {
+		db.mtx.RLock()
+		defer db.mtx.RUnlock()
+		return db.lastGarbageCollectedMmapRef != 0
+	}, time.Minute, 10*time.Millisecond, "CompactOOOHead did not reach the reader-wait phase")
+	// The compaction must still be waiting for querierCreatedBeforeCompaction to be
+	// closed. If it does not wait, then the query will return incorrect results or fail.
 	require.False(t, compactionComplete.Load(), "compaction completed before reading chunks or closing querier created before compaction")
 
 	// Get another querier. This one should only use the compacted blocks from disk and ignore the chunks that will be garbage collected.

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4130,11 +4130,19 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier(t *test
 	// Until that ref is set, the second querier would capture the stale ref (0)
 	// and permanently block the OOO reader-wait loop, which has no timeout, hanging
 	// the test on slow runners.
+	// If compaction exits before publishing the ref, stop waiting so its error can
+	// be reported below instead of being masked by the timeout.
 	require.Eventually(t, func() bool {
+		if compactionComplete.Load() {
+			return true
+		}
 		db.mtx.RLock()
 		defer db.mtx.RUnlock()
 		return db.lastGarbageCollectedMmapRef != 0
 	}, time.Minute, 10*time.Millisecond, "CompactOOOHead did not reach the reader-wait phase")
+	if compactionComplete.Load() {
+		require.NoError(t, <-compactionErr)
+	}
 	// The compaction must still be waiting for querierCreatedBeforeCompaction to be
 	// closed. If it does not wait, then the query will return incorrect results or fail.
 	require.False(t, compactionComplete.Load(), "compaction completed before reading chunks or closing querier created before compaction")

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -4129,8 +4129,7 @@ func TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier(t *test
 	// lastGarbageCollectedMmapRef before creating the second querier below.
 	// Until that ref is set, the second querier would capture the stale ref (0)
 	// and permanently block the OOO reader-wait loop, which has no timeout, hanging
-	// the test on slow runners. A fixed sleep is not enough here: writing the block
-	// and reloading are disk-I/O bound and can exceed it on slow Windows CI runners.
+	// the test on slow runners.
 	require.Eventually(t, func() bool {
 		db.mtx.RLock()
 		defer db.mtx.RUnlock()


### PR DESCRIPTION
## Problem

`TestQuerierShouldNotFailIfOOOCompactionOccursAfterRetrievingQuerier` (and its `_AppendV2` variant) sometimes times out on Windows CI — the failure signature is `test timed out after 10m0s` (a package-level timeout), not an assertion failure. This is one of the open items in #17941.

## Root cause

It is **not** slowness in the reader-wait poll loop (which the earlier widening of `require.Eventually` to one minute in 59c42d47 targeted). It is a genuine race that turns into a permanent hang.

The test:

1. Creates `querierCreatedBeforeCompaction` → registers an OOO-isolation reader with `minRef = 0` (the initial `db.lastGarbageCollectedMmapRef`).
2. Starts `CompactOOOHead` in a goroutine.
3. `time.Sleep(time.Second)`, then asserts compaction has not *completed*.
4. Creates `querierCreatedAfterCompaction`.

`CompactOOOHead` publishes the new GC ref (`db.lastGarbageCollectedMmapRef = minOOOMmapRef`) only **after** it writes the OOO block to disk and calls `reloadBlocks` — disk-I/O-bound work. A querier created after that point captures the new ref and does not block the reader-wait loop; a querier created before it captures the stale ref `0` and does.

The fixed one-second sleep only checks that compaction has not *completed* — never that it has *progressed* to publishing the ref. On a slow Windows runner where the block-write + reload exceeds one second, `querierCreatedAfterCompaction` captures the stale ref `0` and becomes a **permanent** blocker of `WaitForPendingReadersForOOOChunksAtOrBefore`, which has no timeout and no context cancellation. That querier is not closed until after `<-compactionErr`, which never arrives → the test hangs until the package timeout. Widening the wait cannot help, because the compaction never completes.

## Reproduction

Pure slowness does not reproduce it (verified under `qemu-aarch64-static` with `GOMAXPROCS=1` and CPU-hog background load: close→complete latency stayed at 100–433 ms, far under the wait window). Injecting a delay before the GC ref is published (simulating a slow runner) reproduces the hang deterministically: the compaction never completes and the test never finishes.

## Fix

Instead of a fixed sleep, wait until `CompactOOOHead` has published `lastGarbageCollectedMmapRef` before creating the second querier. This guarantees the second querier captures the new ref and does not block the wait loop. The subsequent `require.False(compactionComplete.Load())` still holds, since the compaction remains blocked on `querierCreatedBeforeCompaction`. The same fix is applied to the `_AppendV2` variant.

Part of #17941

```release-notes
NONE
```