### PR TITLE
promql: fix round() producing NaN for to_nearest=0 and wrong results for negative to_nearest

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1163,6 +1163,18 @@ func funcRound(vectorVals []Vector, _ Matrix, args parser.Expressions, enh *Eval
 	if len(args) >= 2 {
 		toNearest = vectorVals[1][0].F
 	}
+	// Use the absolute value of toNearest. The set of multiples of a negative
+	// number is the same as the set of multiples of its absolute value, so the
+	// sign should not affect the result.
+	toNearest = math.Abs(toNearest)
+	// If toNearest is zero, return the original values unchanged. Rounding to
+	// the nearest multiple of zero is undefined; returning the input is the
+	// least surprising behaviour and avoids producing NaN.
+	if toNearest == 0 {
+		return simpleFloatFunc(vectorVals, enh, func(f float64) float64 {
+			return f
+		}), nil
+	}
 	// Invert as it seems to cause fewer floating point accuracy issues.
 	toNearestInverse := 1.0 / toNearest
 	return simpleFloatFunc(vectorVals, enh, func(f float64) float64 {

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -1718,6 +1718,30 @@ eval instant at 0m round(data)
 	{type="ninf"} -Inf
 	{type="nan"} NaN
 
+# round with toNearest of 0 should return the original values unchanged.
+eval instant at 0m round(data, 0)
+	{type="positive"} 2.5
+	{type="whole"} 2
+	{type="negative"} -2.5
+	{type="nwhole"} -2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} -Inf
+	{type="nan"} NaN
+
+# round with negative toNearest should behave the same as with positive.
+eval instant at 0m round(data, -2)
+	{type="positive"} 2
+	{type="whole"} 2
+	{type="negative"} -2
+	{type="nwhole"} -2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} -Inf
+	{type="nan"} NaN
+
 clear
 
 # Test for absent().


### PR DESCRIPTION
## Description

The `round()` PromQL function did not validate the `to_nearest` scalar argument, leading to two bugs:

1. **`round(v, 0)` returns NaN** — `1.0 / 0` produces `+Inf`, causing all sample values to become `NaN`.
2. **`round(v, -2)` returns wrong results** — a negative `toNearest` makes `toNearestInverse` negative, which flips the direction of `math.Floor`. For example, `round(5, -2)` returns `4` instead of `6`.

The fix takes the absolute value of `toNearest` before computing the inverse (since the set of multiples of `-N` is the same as for `N`), and returns the original values unchanged when `toNearest` is zero (since rounding to the nearest multiple of zero is undefined).

## Test cases added

Added test cases in `promql/promqltest/testdata/functions.test`:
- `round(data, 0)` — verifies original values are returned unchanged
- `round(data, -2)` — verifies behavior matches `round(data, 2)`

Both test cases use the existing `data` fixture that includes positive, negative, zero, Inf, and NaN values.

Fixes #19198

```release-notes
[BUGFIX] PromQL: Fix `round()` producing NaN when `to_nearest` is 0 and incorrect results when `to_nearest` is negative.
```
