### PR TITLE
storage: add OriginalLabelsHash() method to SeriesSet

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -4436,6 +4436,10 @@ type mockSeries struct {
 	labelSet []string
 }
 
+func (s mockSeries) OriginalLabelsHash() uint64 {
+	return s.Labels().Hash()
+}
+
 func (s mockSeries) Labels() labels.Labels {
 	return labels.FromStrings(s.labelSet...)
 }

--- a/promql/value.go
+++ b/promql/value.go
@@ -447,6 +447,10 @@ func NewStorageSeries(series Series) *StorageSeries {
 	}
 }
 
+func (ss *StorageSeries) OriginalLabelsHash() uint64 {
+	return ss.series.Metric.Hash()
+}
+
 func (ss *StorageSeries) Labels() labels.Labels {
 	return ss.series.Metric
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -241,8 +241,9 @@ type SelectHints struct {
 	// even if we only fetch the `label` label. For some storage implementations this is beneficial.
 
 	// ProjectionLabels are the minimum amount of labels required to be fetched for this Select call
-	// When honored it is required to add an __series_hash__ label containing the hash of all labels
-	// of a particular series so that the engine can still perform horizontal joins.
+	// When honored you can add an __series_hash__ label containing the hash of all labels
+	// of a particular series so that the engine can still perform horizontal joins. However, adding it as a label
+	// is wasteful and slower than exposing it through OriginalLabelsHash() so prefer that if possible.
 	ProjectionLabels []string
 
 	// ProjectionInclude defines if we have to include or exclude the labels from the ProjectLabels field.
@@ -601,6 +602,20 @@ func ErrChunkSeriesSet(err error) ChunkSeriesSet {
 type Series interface {
 	Labels
 	SampleIterable
+
+	// Returns the hash of the original labels. If projections are enabled
+	// (returns a subset of labels of each series for example in case of
+	// sum by (...) as an optimization to reduce I/O needed. Not supported right now in
+	// Prometheus itself!) then this returns the hash of the original labels
+	// before trimming.
+	// For now, implementers can just call Labels.Hash() Not used by
+	// Prometheus itself.
+	// Not using the labels to pass around the hash because:
+	// - Storing a hash (8 bytes binary data) in a string takes more space
+	// compared to uint64
+	// - It is slower and wasteful to compare strings and/or convert the hash into a
+	// uint64 before comparison
+	OriginalLabelsHash() uint64
 }
 
 type mockSeries struct {
@@ -612,6 +627,10 @@ type mockSeries struct {
 
 func (s mockSeries) Labels() labels.Labels {
 	return labels.FromStrings(s.labelSet...)
+}
+
+func (s mockSeries) OriginalLabelsHash() uint64 {
+	return labels.FromStrings(s.labelSet...).Hash()
 }
 
 func (s mockSeries) Iterator(chunkenc.Iterator) chunkenc.Iterator {

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -382,6 +382,10 @@ func (c *concreteSeries) Labels() labels.Labels {
 	return c.labels.Copy()
 }
 
+func (c *concreteSeries) OriginalLabelsHash() uint64 {
+	return c.labels.Hash()
+}
+
 func (c *concreteSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
 	if csi, ok := it.(*concreteSeriesIterator); ok {
 		csi.reset(c)
@@ -709,6 +713,10 @@ var _ storage.Series = &chunkedSeries{}
 func (s *chunkedSeries) Labels() labels.Labels {
 	b := labels.NewScratchBuilder(0)
 	return s.ToLabels(&b, nil)
+}
+
+func (s *chunkedSeries) OriginalLabelsHash() uint64 {
+	return s.Labels().Hash()
 }
 
 func (s *chunkedSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {

--- a/storage/series.go
+++ b/storage/series.go
@@ -30,6 +30,7 @@ type SeriesEntry struct {
 }
 
 func (s *SeriesEntry) Labels() labels.Labels                           { return s.Lset }
+func (s *SeriesEntry) OriginalLabelsHash() uint64                      { return s.Lset.Hash() }
 func (s *SeriesEntry) Iterator(it chunkenc.Iterator) chunkenc.Iterator { return s.SampleIteratorFn(it) }
 
 type ChunkSeriesEntry struct {

--- a/tsdb/querier.go
+++ b/tsdb/querier.go
@@ -550,7 +550,8 @@ type seriesData struct {
 }
 
 // Labels implements part of storage.Series and storage.ChunkSeries.
-func (s *seriesData) Labels() labels.Labels { return s.labels }
+func (s *seriesData) Labels() labels.Labels      { return s.labels }
+func (s *seriesData) OriginalLabelsHash() uint64 { return s.labels.Hash() }
 
 // blockBaseSeriesSet allows to iterate over all series in the single block.
 // Iterated series are trimmed with given min and max time as well as tombstones.

--- a/web/api/testhelpers/mocks.go
+++ b/web/api/testhelpers/mocks.go
@@ -231,6 +231,10 @@ type FakeSeries struct {
 	samples []promql.FPoint
 }
 
+func (f *FakeSeries) OriginalLabelsHash() uint64 {
+	return f.Labels().Hash()
+}
+
 func (f *FakeSeries) Labels() labels.Labels {
 	return f.labels
 }
@@ -292,6 +296,10 @@ func (*FakeSeriesIterator) Err() error {
 type FakeHistogramSeries struct {
 	labels     labels.Labels
 	histograms []promql.HPoint
+}
+
+func (f *FakeHistogramSeries) OriginalLabelsHash() uint64 {
+	return f.Labels().Hash()
 }
 
 func (f *FakeHistogramSeries) Labels() labels.Labels {


### PR DESCRIPTION
Add a way to capture the original hash of labels that is "out of bound" of the labels model. This is because even with the best encoding schemes like base 91 storing a hash is wasteful. Also, comparing strings is much slower than comparing uint64s.

#### Which issue(s) does the PR fix:

NA

#### Release notes for end users (**ALL** commits must be considered).

*Reviewers should verify clarity and quality.*

```release-notes
[CHANGE] Add OriginalLabelsHash() uint64 method to storage.SeriesSet interface
```
