### PR TITLE
config: add global http client config for scrape targets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -538,6 +538,21 @@ type GlobalConfig struct {
 	// When enabled, Prometheus stores samples for scrape_timeout_seconds,
 	// scrape_sample_limit, and scrape_body_size_bytes.
 	ExtraScrapeMetrics *bool `yaml:"extra_scrape_metrics,omitempty"`
+	// ScrapeHTTPClientConfig provides default HTTP client settings for all
+	// scrape jobs. Per-job settings under a scrape config take precedence over
+	// these defaults. Authentication (basic_auth, authorization, oauth2,
+	// bearer_token, bearer_token_file) and proxy options are inherited as
+	// atomic groups: a scrape config that sets any option from a group does not
+	// inherit the corresponding global settings, to avoid combining mutually
+	// exclusive options. The follow_redirects and enable_http2 options default
+	// to true, so a scrape config only overrides the global value when it sets
+	// a value that differs from that default. A nil value means no global
+	// defaults are applied. Use with caution, as it may be difficult to
+	// understand the effective configuration of a scrape job when global
+	// defaults are applied. A good example of a use case for this is to set
+	// a global HTTP header for a custom User-Agent string, while leaving
+	// all other HTTP client settings to their defaults.
+	ScrapeHTTPClientConfig *config.HTTPClientConfig `yaml:"scrape_http_client_config,omitempty"`
 }
 
 // ScrapeProtocol represents supported protocol for scraping metrics.
@@ -630,6 +645,7 @@ func validateAcceptScrapeProtocols(sps []ScrapeProtocol) error {
 func (c *GlobalConfig) SetDirectory(dir string) {
 	c.QueryLogFile = config.JoinDir(dir, c.QueryLogFile)
 	c.ScrapeFailureLogFile = config.JoinDir(dir, c.ScrapeFailureLogFile)
+	c.ScrapeHTTPClientConfig.SetDirectory(dir)
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -699,6 +715,20 @@ func (c *GlobalConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 	}
 
+	// follow_redirects and enable_http2 cannot be inherited by scrape configs
+	// because their default is true and a false value is indistinguishable from
+	// an explicitly configured false, so a scrape config could not reliably
+	// override a global value. They default to true in the global block, so
+	// reject only an explicit false to avoid silently ignoring the setting.
+	if gc.ScrapeHTTPClientConfig != nil {
+		if !gc.ScrapeHTTPClientConfig.FollowRedirects {
+			return errors.New("global scrape_http_client_config does not support follow_redirects; configure it per scrape config instead")
+		}
+		if !gc.ScrapeHTTPClientConfig.EnableHTTP2 {
+			return errors.New("global scrape_http_client_config does not support enable_http2; configure it per scrape config instead")
+		}
+	}
+
 	*c = *gc
 	return nil
 }
@@ -725,7 +755,8 @@ func (c *GlobalConfig) isZero() bool {
 		c.KeepDroppedTargets == 0 &&
 		c.MetricNameValidationScheme == model.UnsetValidation &&
 		c.MetricNameEscapingScheme == "" &&
-		c.ExtraScrapeMetrics == nil
+		c.ExtraScrapeMetrics == nil &&
+		c.ScrapeHTTPClientConfig == nil
 }
 
 const DefaultGoGCPercentage = 75
@@ -944,6 +975,15 @@ func (c *ScrapeConfig) Validate(globalConfig GlobalConfig) error {
 		c.ExtraScrapeMetrics = globalConfig.ExtraScrapeMetrics
 	}
 
+	// Fill unset HTTP client settings from the global scrape HTTP client
+	// config, then re-validate the resulting combination.
+	if globalConfig.ScrapeHTTPClientConfig != nil {
+		applyGlobalHTTPClientConfigDefaults(*globalConfig.ScrapeHTTPClientConfig, &c.HTTPClientConfig)
+		if err := c.HTTPClientConfig.Validate(); err != nil {
+			return fmt.Errorf("%w for scrape config with job name %q", err, c.JobName)
+		}
+	}
+
 	if c.ScrapeProtocols == nil {
 		switch {
 		case globalConfig.ScrapeProtocols != nil:
@@ -1055,6 +1095,114 @@ func (c *ScrapeConfig) Validate(globalConfig GlobalConfig) error {
 // MarshalYAML implements the yaml.Marshaler interface.
 func (c *ScrapeConfig) MarshalYAML() (any, error) {
 	return discovery.MarshalYAMLWithInlineConfigs(c)
+}
+
+// applyGlobalHTTPClientConfigDefaults fills unset fields of c from the global
+// scrape HTTP client config. Authentication and proxy settings are treated as
+// atomic groups: a scrape config that specifies any option from a group does
+// not inherit the corresponding global settings, to avoid combining mutually
+// exclusive options. Pointer fields carrying file paths are cloned so that a
+// later SetDirectory call on one scrape config cannot mutate the settings of
+// another scrape config that inherited the same global values.
+//
+// FollowRedirects and EnableHTTP2 are intentionally not inherited: they default
+// to true and their zero value is indistinguishable from an explicitly
+// configured false, so a scrape config could not reliably override a global
+// value. They must be configured per scrape config instead.
+//
+// TODO: Consider generalizing this HTTPClientConfig merge/inheritance logic and
+// moving it to prometheus/common alongside the config types. The atomic-group
+// and FollowRedirects/EnableHTTP2 semantics here are Prometheus-specific policy,
+// so any upstream helper would need to keep those decisions configurable.
+func applyGlobalHTTPClientConfigDefaults(global config.HTTPClientConfig, c *config.HTTPClientConfig) {
+	// Authentication group. bearer_token and bearer_token_file are folded into
+	// Authorization during validation, so an already-validated scrape config
+	// only carries auth in BasicAuth, Authorization, or OAuth2.
+	if c.BasicAuth == nil && c.Authorization == nil && c.OAuth2 == nil &&
+		c.BearerToken == "" && c.BearerTokenFile == "" {
+		c.BasicAuth = cloneBasicAuth(global.BasicAuth)
+		c.Authorization = cloneAuthorization(global.Authorization)
+		c.OAuth2 = cloneOAuth2(global.OAuth2)
+		c.BearerToken = global.BearerToken
+		c.BearerTokenFile = global.BearerTokenFile
+	}
+
+	// TLS config. TLSConfig is a value field, so a plain copy is independent.
+	if c.TLSConfig == (config.TLSConfig{}) {
+		c.TLSConfig = global.TLSConfig
+	}
+
+	// Proxy group. ProxyConfig is a value field with no file paths resolved via
+	// SetDirectory, so a plain copy is safe.
+	if c.ProxyURL.URL == nil && c.NoProxy == "" && !c.ProxyFromEnvironment && c.ProxyConnectHeader == nil {
+		c.ProxyConfig = global.ProxyConfig
+	}
+
+	// Custom headers.
+	if c.HTTPHeaders == nil {
+		c.HTTPHeaders = cloneHeaders(global.HTTPHeaders)
+	}
+}
+
+// TODO: The clone* helpers below operate only on prometheus/common/config types
+// and contain no Prometheus-specific logic. They should be upstreamed to
+// prometheus/common (ideally as Clone methods on the respective types) so they
+// stay in sync with the struct definitions: whenever a field is added to one of
+// those types, its clone must be updated in lockstep. Note that cloneOAuth2 is
+// only a shallow copy and relies on EndpointParams/Scopes/TLSConfig being
+// read-only after parsing; a general-purpose Clone in common would need to deep
+// copy those fields.
+
+// cloneBasicAuth returns an independent copy of b, or nil if b is nil.
+func cloneBasicAuth(b *config.BasicAuth) *config.BasicAuth {
+	if b == nil {
+		return nil
+	}
+	nb := *b
+	return &nb
+}
+
+// cloneAuthorization returns an independent copy of a, or nil if a is nil.
+func cloneAuthorization(a *config.Authorization) *config.Authorization {
+	if a == nil {
+		return nil
+	}
+	na := *a
+	return &na
+}
+
+// cloneOAuth2 returns a copy of o whose file-path fields are independent, or
+// nil if o is nil. The shared maps and slices are only read after parsing, so
+// a shallow struct copy is sufficient for SetDirectory safety.
+func cloneOAuth2(o *config.OAuth2) *config.OAuth2 {
+	if o == nil {
+		return nil
+	}
+	no := *o
+	return &no
+}
+
+// cloneHeaders returns a deep copy of h, or nil if h is nil. The header value
+// slices are copied because SetDirectory rewrites their file paths in place.
+func cloneHeaders(h *config.Headers) *config.Headers {
+	if h == nil {
+		return nil
+	}
+	nh := &config.Headers{Headers: make(map[string]config.Header, len(h.Headers))}
+	for name, header := range h.Headers {
+		nHeader := config.Header{}
+		if header.Values != nil {
+			nHeader.Values = append([]string(nil), header.Values...)
+		}
+		if header.Secrets != nil {
+			nHeader.Secrets = append([]config.Secret(nil), header.Secrets...)
+		}
+		if header.Files != nil {
+			nHeader.Files = append([]string(nil), header.Files...)
+		}
+		nh.Headers[name] = nHeader
+	}
+	return nh
 }
 
 // ToEscapingScheme wraps the equivalent common library function with the

--- a/config/scrape_http_client_config_test.go
+++ b/config/scrape_http_client_config_test.go
@@ -1,0 +1,233 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/promslog"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGlobalScrapeHTTPClientConfigInheritance verifies that scrape jobs inherit
+// unset HTTP client settings from the global scrape_http_client_config.
+func TestGlobalScrapeHTTPClientConfigInheritance(t *testing.T) {
+	const in = `
+global:
+  scrape_http_client_config:
+    tls_config:
+      insecure_skip_verify: true
+    basic_auth:
+      username: globaluser
+      password: globalpass
+    http_headers:
+      X-Global:
+        values: [global-value]
+scrape_configs:
+  - job_name: inherits
+    static_configs:
+      - targets: ["localhost:9090"]
+`
+	cfg, err := Load(in, promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, cfg.GlobalConfig.ScrapeHTTPClientConfig)
+
+	hc := cfg.ScrapeConfigs[0].HTTPClientConfig
+	require.True(t, hc.TLSConfig.InsecureSkipVerify, "tls_config should be inherited")
+	require.NotNil(t, hc.BasicAuth)
+	require.Equal(t, "globaluser", hc.BasicAuth.Username)
+	require.Equal(t, config.Secret("globalpass"), hc.BasicAuth.Password)
+	require.NotNil(t, hc.HTTPHeaders)
+	require.Equal(t, []string{"global-value"}, hc.HTTPHeaders.Headers["X-Global"].Values)
+	// follow_redirects and enable_http2 are not inherited and keep their
+	// per-scrape-config defaults (true).
+	require.True(t, hc.FollowRedirects)
+	require.True(t, hc.EnableHTTP2)
+}
+
+// TestGlobalScrapeHTTPClientConfigOverride verifies that per-job settings take
+// precedence over the global scrape HTTP client config and that authentication
+// is inherited as an atomic group.
+func TestGlobalScrapeHTTPClientConfigOverride(t *testing.T) {
+	const in = `
+global:
+  scrape_http_client_config:
+    basic_auth:
+      username: globaluser
+      password: globalpass
+scrape_configs:
+  - job_name: overrides-auth
+    authorization:
+      credentials: jobtoken
+    static_configs:
+      - targets: ["localhost:9090"]
+`
+	cfg, err := Load(in, promslog.NewNopLogger())
+	require.NoError(t, err)
+
+	hc := cfg.ScrapeConfigs[0].HTTPClientConfig
+	// The job configures its own authorization, so it must NOT inherit the
+	// global basic_auth, which would be mutually exclusive.
+	require.Nil(t, hc.BasicAuth)
+	require.NotNil(t, hc.Authorization)
+	require.Equal(t, config.Secret("jobtoken"), hc.Authorization.Credentials)
+}
+
+// TestGlobalScrapeHTTPClientConfigFollowRedirectsNotInherited verifies that
+// follow_redirects and enable_http2 are not inherited from the global scrape
+// HTTP client config and keep their per-scrape-config defaults.
+func TestGlobalScrapeHTTPClientConfigFollowRedirectsNotInherited(t *testing.T) {
+	const in = `
+global:
+  scrape_http_client_config:
+    tls_config:
+      insecure_skip_verify: true
+scrape_configs:
+  - job_name: default
+    static_configs:
+      - targets: ["localhost:9090"]
+`
+	cfg, err := Load(in, promslog.NewNopLogger())
+	require.NoError(t, err)
+
+	hc := cfg.ScrapeConfigs[0].HTTPClientConfig
+	require.True(t, hc.TLSConfig.InsecureSkipVerify, "tls_config should still be inherited")
+	// follow_redirects and enable_http2 keep their own defaults (true), not
+	// inherited from the global block.
+	require.Equal(t, config.DefaultHTTPClientConfig.FollowRedirects, hc.FollowRedirects)
+	require.Equal(t, config.DefaultHTTPClientConfig.EnableHTTP2, hc.EnableHTTP2)
+}
+
+// TestGlobalScrapeHTTPClientConfigRejectsUnsupportedBooleans verifies that
+// setting follow_redirects or enable_http2 to false in the global scrape HTTP
+// client config is rejected at load time, since those cannot be inherited.
+func TestGlobalScrapeHTTPClientConfigRejectsUnsupportedBooleans(t *testing.T) {
+	for _, field := range []string{"follow_redirects", "enable_http2"} {
+		in := `
+global:
+  scrape_http_client_config:
+    ` + field + `: false
+scrape_configs:
+  - job_name: default
+    static_configs:
+      - targets: ["localhost:9090"]
+`
+		_, err := Load(in, promslog.NewNopLogger())
+		require.Error(t, err, "expected error for global %s: false", field)
+		require.Contains(t, err.Error(), field)
+	}
+}
+
+// TestGlobalScrapeHTTPClientConfigProxyGroup verifies that proxy settings are
+// inherited as an atomic group.
+func TestGlobalScrapeHTTPClientConfigProxyGroup(t *testing.T) {
+	const in = `
+global:
+  scrape_http_client_config:
+    proxy_url: http://global.proxy:8080
+scrape_configs:
+  - job_name: inherits-proxy
+    static_configs:
+      - targets: ["localhost:9090"]
+  - job_name: own-proxy
+    proxy_from_environment: true
+    static_configs:
+      - targets: ["localhost:9091"]
+`
+	cfg, err := Load(in, promslog.NewNopLogger())
+	require.NoError(t, err)
+
+	inherit := cfg.ScrapeConfigs[0].HTTPClientConfig
+	require.NotNil(t, inherit.ProxyURL.URL)
+	require.Equal(t, "http://global.proxy:8080", inherit.ProxyURL.String())
+
+	own := cfg.ScrapeConfigs[1].HTTPClientConfig
+	require.True(t, own.ProxyFromEnvironment)
+	require.Nil(t, own.ProxyURL.URL, "job with its own proxy setting should not inherit global proxy_url")
+}
+
+// TestGlobalScrapeHTTPClientConfigNil verifies that scrape jobs are unaffected
+// when no global scrape HTTP client config is set.
+func TestGlobalScrapeHTTPClientConfigNil(t *testing.T) {
+	const in = `
+scrape_configs:
+  - job_name: default
+    static_configs:
+      - targets: ["localhost:9090"]
+`
+	cfg, err := Load(in, promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.Nil(t, cfg.GlobalConfig.ScrapeHTTPClientConfig)
+
+	hc := cfg.ScrapeConfigs[0].HTTPClientConfig
+	require.Equal(t, config.DefaultHTTPClientConfig.FollowRedirects, hc.FollowRedirects)
+	require.Equal(t, config.DefaultHTTPClientConfig.EnableHTTP2, hc.EnableHTTP2)
+	require.Nil(t, hc.BasicAuth)
+}
+
+// TestGlobalScrapeHTTPClientConfigSetDirectory verifies that inherited file
+// paths are resolved exactly once per scrape config, independently of the
+// global template and of other scrape jobs that inherit the same settings.
+func TestGlobalScrapeHTTPClientConfigSetDirectory(t *testing.T) {
+	const in = `
+global:
+  scrape_http_client_config:
+    basic_auth:
+      username: u
+      password_file: secrets/pw
+    http_headers:
+      X-Token:
+        files: [secrets/token]
+scrape_configs:
+  - job_name: a
+    static_configs:
+      - targets: ["localhost:1"]
+  - job_name: b
+    static_configs:
+      - targets: ["localhost:2"]
+`
+	cfg, err := Load(in, promslog.NewNopLogger())
+	require.NoError(t, err)
+
+	cfg.SetDirectory("conf")
+
+	for _, sc := range cfg.ScrapeConfigs {
+		hc := sc.HTTPClientConfig
+		require.Equal(t, "conf/secrets/pw", hc.BasicAuth.PasswordFile, "job %q", sc.JobName)
+		require.Equal(t, []string{"conf/secrets/token"}, hc.HTTPHeaders.Headers["X-Token"].Files, "job %q", sc.JobName)
+	}
+
+	// The global template is resolved once and independently.
+	require.Equal(t, "conf/secrets/pw", cfg.GlobalConfig.ScrapeHTTPClientConfig.BasicAuth.PasswordFile)
+}
+
+// TestGlobalScrapeHTTPClientConfigInvalid verifies that an invalid global scrape
+// HTTP client config is rejected at load time.
+func TestGlobalScrapeHTTPClientConfigInvalid(t *testing.T) {
+	const in = `
+global:
+  scrape_http_client_config:
+    basic_auth:
+      username: u
+      password: p
+    bearer_token: token
+scrape_configs:
+  - job_name: default
+    static_configs:
+      - targets: ["localhost:9090"]
+`
+	_, err := Load(in, promslog.NewNopLogger())
+	require.Error(t, err)
+}

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -168,7 +168,7 @@ global:
   # case, the scrape_native_histograms setting has no effect. If
   # convert_classic_histograms_to_nhcb is false, the histogram is ingested as
   # a classic histograms. If convert_classic_histograms_to_nhcb is true, the
-  # histograms is converted to an NHCB. In this case, 
+  # histograms is converted to an NHCB. In this case,
   # always_scrape_classic_histograms determines whether it is also ingested
   # as a classic histograms or not.
   #
@@ -179,7 +179,7 @@ global:
   # 1, but the resulting classic histogram or NHCB only has a sole bucket, the
   # +Inf bucket. If scrape_native_histograms is true, however, the histogram is
   # recognized as a pure native histogram and ingested as such. There will be
-  # no classic histogram ingested, no matter what 
+  # no classic histogram ingested, no matter what
   # always_scrape_classic_histograms is set to, and there will be no
   # conversion to an NHCB, no matter what convert_classic_histograms_to_nhcb
   # is set to.
@@ -200,6 +200,74 @@ global:
   # These metrics help monitor how close targets are to their configured limits.
   # This option can be overridden per scrape config.
   [ extra_scrape_metrics: <boolean> | default = false ]
+
+  # Default HTTP client settings applied to every scrape config. Any setting
+  # explicitly configured in a scrape config takes precedence over the value
+  # set here. The authentication options (basic_auth, authorization, oauth2,
+  # bearer_token, bearer_token_file) are inherited as a single group: a scrape
+  # config that configures any of them does not inherit the global
+  # authentication settings. The proxy options (proxy_url, no_proxy,
+  # proxy_from_environment, proxy_connect_header) are likewise inherited as a
+  # single group.
+  #
+  # follow_redirects and enable_http2 are NOT supported here and must be
+  # configured per scrape config. They default to true, and a false value is
+  # indistinguishable from an explicitly configured false, so a scrape config
+  # could not reliably override a global value. Setting either to false in this
+  # block is rejected at load time.
+  scrape_http_client_config:
+    # Sets the `Authorization` header on every request with the
+    # configured username and password.
+    # username and username_file are mutually exclusive.
+    # password and password_file are mutually exclusive.
+    [ basic_auth:
+      [ username: <string> ]
+      [ username_file: <string> ]
+      [ password: <secret> ]
+      [ password_file: <string> ] ]
+
+    # Sets the `Authorization` header on every request with
+    # the configured credentials.
+    [ authorization:
+      # Sets the authentication type of the request.
+      [ type: <string> | default: Bearer ]
+      # Sets the credentials of the request. It is mutually exclusive with
+      # `credentials_file`.
+      [ credentials: <secret> ]
+      # Sets the credentials of the request with the credentials read from the
+      # configured file. It is mutually exclusive with `credentials`.
+      [ credentials_file: <filename> ] ]
+
+    # Optional OAuth 2.0 configuration.
+    # Cannot be used at the same time as basic_auth or authorization.
+    [ oauth2: <oauth2> ]
+
+    # Configures the request's TLS settings.
+    [ tls_config: <tls_config> ]
+
+    # Optional proxy URL.
+    [ proxy_url: <string> ]
+    # Comma-separated string that can contain IPs, CIDR notation, domain names
+    # that should be excluded from proxying. IP and domain names can
+    # contain port numbers.
+    [ no_proxy: <string> ]
+    # Use proxy URL indicated by environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY, and their lowercase versions)
+    [ proxy_from_environment: <boolean> | default: false ]
+    # Specifies headers to send to proxies during CONNECT requests.
+    [ proxy_connect_header:
+      [ <string>: [<secret>, ...] ] ]
+
+    # Custom HTTP headers to be sent along with each request.
+    # Headers that are set by Prometheus itself can't be overwritten.
+    [ http_headers:
+      # Header name.
+      [ <string>:
+        # Header values.
+        [ values: [<string>, ...] ]
+        # Headers values. Hidden in configuration page.
+        [ secrets: [<secret>, ...] ]
+        # Files to read header values from.
+        [ files: [<string>, ...] ] ] ]
 
 runtime:
   # Configure the Go garbage collector GOGC parameter
@@ -326,7 +394,7 @@ job_name: <job_name>
 # The protocols to negotiate during a scrape with the client.
 # Supported values (case sensitive): PrometheusProto, OpenMetricsText0.0.1,
 # OpenMetricsText1.0.0, PrometheusText0.0.4, PrometheusText1.0.0.
-# If not set in the global config, the default value depends on the 
+# If not set in the global config, the default value depends on the
 # setting of scrape_native_histograms. If false, it is
 # [ OpenMetricsText1.0.0, OpenMetricsText0.0.1, PrometheusText1.0.0, PrometheusText0.0.4 ].
 # If true, it is
@@ -821,7 +889,7 @@ client_id: <string>
 # GrantType is set to "urn:ietf:params:oauth:grant-type:jwt-bearer".
 [ iss: <string> ]
 
-# Intended audience of the request. If empty, the value 
+# Intended audience of the request. If empty, the value
 # of TokenURL is used as the intended audience. Only used if
 # GrantType is set to "urn:ietf:params:oauth:grant-type:jwt-bearer".
 [ audience: <string> ]
@@ -928,7 +996,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 
 #### `ecs`
 
-The `ecs` role discovers targets from AWS ECS containers. 
+The `ecs` role discovers targets from AWS ECS containers.
 
 ECS service discovery supports all ECS networking modes:
 - **awsvpc mode** (Fargate and EC2 with ENI): Uses the task's private IP address from its elastic network interface
@@ -4001,7 +4069,7 @@ azuread:
   # Optional custom OAuth 2.0 scope to request when acquiring tokens.
   # If not specified, defaults to the appropriate monitoring scope for the cloud:
   # - AzurePublic: https://monitor.azure.com//.default
-  # - AzureGovernment: https://monitor.azure.us//.default  
+  # - AzureGovernment: https://monitor.azure.us//.default
   # - AzureChina: https://monitor.azure.cn//.default
   # Use this to authenticate against custom Azure applications or non-standard endpoints.
   [ scope: <string> ]

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -168,7 +168,7 @@ global:
   # case, the scrape_native_histograms setting has no effect. If
   # convert_classic_histograms_to_nhcb is false, the histogram is ingested as
   # a classic histograms. If convert_classic_histograms_to_nhcb is true, the
-  # histograms is converted to an NHCB. In this case, 
+  # histograms is converted to an NHCB. In this case,
   # always_scrape_classic_histograms determines whether it is also ingested
   # as a classic histograms or not.
   #
@@ -179,7 +179,7 @@ global:
   # 1, but the resulting classic histogram or NHCB only has a sole bucket, the
   # +Inf bucket. If scrape_native_histograms is true, however, the histogram is
   # recognized as a pure native histogram and ingested as such. There will be
-  # no classic histogram ingested, no matter what 
+  # no classic histogram ingested, no matter what
   # always_scrape_classic_histograms is set to, and there will be no
   # conversion to an NHCB, no matter what convert_classic_histograms_to_nhcb
   # is set to.
@@ -200,6 +200,74 @@ global:
   # These metrics help monitor how close targets are to their configured limits.
   # This option can be overridden per scrape config.
   [ extra_scrape_metrics: <boolean> | default = false ]
+
+  # Default HTTP client settings applied to every scrape config. Any setting
+  # explicitly configured in a scrape config takes precedence over the value
+  # set here. The authentication options (basic_auth, authorization, oauth2,
+  # bearer_token, bearer_token_file) are inherited as a single group: a scrape
+  # config that configures any of them does not inherit the global
+  # authentication settings. The proxy options (proxy_url, no_proxy,
+  # proxy_from_environment, proxy_connect_header) are likewise inherited as a
+  # single group.
+  #
+  # follow_redirects and enable_http2 are NOT supported here and must be
+  # configured per scrape config. They default to true, and a false value is
+  # indistinguishable from an explicitly configured false, so a scrape config
+  # could not reliably override a global value. Setting either to false in this
+  # block is rejected at load time.
+  scrape_http_client_config:
+    # Sets the `Authorization` header on every request with the
+    # configured username and password.
+    # username and username_file are mutually exclusive.
+    # password and password_file are mutually exclusive.
+    [ basic_auth:
+      [ username: <string> ]
+      [ username_file: <string> ]
+      [ password: <secret> ]
+      [ password_file: <string> ] ]
+
+    # Sets the `Authorization` header on every request with
+    # the configured credentials.
+    [ authorization:
+      # Sets the authentication type of the request.
+      [ type: <string> | default: Bearer ]
+      # Sets the credentials of the request. It is mutually exclusive with
+      # `credentials_file`.
+      [ credentials: <secret> ]
+      # Sets the credentials of the request with the credentials read from the
+      # configured file. It is mutually exclusive with `credentials`.
+      [ credentials_file: <filename> ] ]
+
+    # Optional OAuth 2.0 configuration.
+    # Cannot be used at the same time as basic_auth or authorization.
+    [ oauth2: <oauth2> ]
+
+    # Configures the request's TLS settings.
+    [ tls_config: <tls_config> ]
+
+    # Optional proxy URL.
+    [ proxy_url: <string> ]
+    # Comma-separated string that can contain IPs, CIDR notation, domain names
+    # that should be excluded from proxying. IP and domain names can
+    # contain port numbers.
+    [ no_proxy: <string> ]
+    # Use proxy URL indicated by environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY, and their lowercase versions)
+    [ proxy_from_environment: <boolean> | default: false ]
+    # Specifies headers to send to proxies during CONNECT requests.
+    [ proxy_connect_header:
+      [ <string>: [<secret>, ...] ] ]
+
+    # Custom HTTP headers to be sent along with each request.
+    # Headers that are set by Prometheus itself can't be overwritten.
+    [ http_headers:
+      # Header name.
+      [ <string>:
+        # Header values.
+        [ values: [<string>, ...] ]
+        # Headers values. Hidden in configuration page.
+        [ secrets: [<secret>, ...] ]
+        # Files to read header values from.
+        [ files: [<string>, ...] ] ] ]
 
 runtime:
   # Configure the Go garbage collector GOGC parameter
@@ -326,7 +394,7 @@ job_name: <job_name>
 # The protocols to negotiate during a scrape with the client.
 # Supported values (case sensitive): PrometheusProto, OpenMetricsText0.0.1,
 # OpenMetricsText1.0.0, PrometheusText0.0.4, PrometheusText1.0.0.
-# If not set in the global config, the default value depends on the 
+# If not set in the global config, the default value depends on the
 # setting of scrape_native_histograms. If false, it is
 # [ OpenMetricsText1.0.0, OpenMetricsText0.0.1, PrometheusText1.0.0, PrometheusText0.0.4 ].
 # If true, it is
@@ -821,7 +889,7 @@ client_id: <string>
 # GrantType is set to "urn:ietf:params:oauth:grant-type:jwt-bearer".
 [ iss: <string> ]
 
-# Intended audience of the request. If empty, the value 
+# Intended audience of the request. If empty, the value
 # of TokenURL is used as the intended audience. Only used if
 # GrantType is set to "urn:ietf:params:oauth:grant-type:jwt-bearer".
 [ audience: <string> ]
@@ -928,7 +996,7 @@ The following meta labels are available on targets during [relabeling](#relabel_
 
 #### `ecs`
 
-The `ecs` role discovers targets from AWS ECS containers. 
+The `ecs` role discovers targets from AWS ECS containers.
 
 ECS service discovery supports all ECS networking modes:
 - **awsvpc mode** (Fargate and EC2 with ENI): Uses the task's private IP address from its elastic network interface
@@ -4014,7 +4082,7 @@ azuread:
   # Optional custom OAuth 2.0 scope to request when acquiring tokens.
   # If not specified, defaults to the appropriate monitoring scope for the cloud:
   # - AzurePublic: https://monitor.azure.com//.default
-  # - AzureGovernment: https://monitor.azure.us//.default  
+  # - AzureGovernment: https://monitor.azure.us//.default
   # - AzureChina: https://monitor.azure.cn//.default
   # Use this to authenticate against custom Azure applications or non-standard endpoints.
   [ scope: <string> ]


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[ENHANCEMENT] Add config option that allows setting global defaults for a http config of scrapers, can be overwritten per job
```
