### PR TITLE
docs: prefer extending table-driven tests in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,10 @@ Example:
 - Tests should attempt to mirror realistic data and/or behaviour.
 - Use only exported APIs in tests where possible — this keeps tests closer to
   real library usage and simplifies review.
+- Prefer adding cases to existing table-driven tests over writing new test
+  functions, even if the existing test needs minor adjustments to fit the new
+  case. Where it helps, convert an existing test into a table-driven test
+  rather than duplicating it.
 
 ---
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None. This documents a testing preference in the contributor guide.

#### Changes

Adds a bullet to the Tests section of `AGENTS.md`: prefer adding cases to
existing table-driven tests over writing new test functions, even when the
existing test needs minor adjustments to fit the new case, and convert an
existing test into a table-driven form where that helps.

This reduces the size of PRs and the amount of test code, and keeps related
scenarios in one place, which simplifies review.

#### Does this PR introduce a user-facing change?
```release-notes
NONE
```