### PR TITLE
tsdb: use bytes.Clone instead of make and copy

### DIFF
--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -634,8 +635,7 @@ func (h *Head) chunkFromSeries(s *memSeries, cid chunks.HeadChunkID, isOOO bool,
 		// The caller may ask to copy the head chunk in order to take the
 		// bytes of the chunk without causing the race between read and append.
 		b := s.headChunks.chunk.Bytes()
-		newB := make([]byte, len(b))
-		copy(newB, b) // TODO(codesome): Use bytes.Clone() when we upgrade to Go 1.20.
+		newB := bytes.Clone(b)
 		// TODO(codesome): Put back in the pool (non-trivial).
 		chk, err = h.opts.ChunkPool.Get(s.headChunks.chunk.Encoding(), newB)
 		if err != nil {


### PR DESCRIPTION
This PR resolves a small technical debt in `tsdb/head_read.go` by upgrading the slice copying mechanism. As noted by a `TODO` in the codebase, we can now use the `bytes.Clone()` method from the standard library since Prometheus has been upgraded to Go >= 1.20.

cc @codesome 

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
None

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration: https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
### Performance

Ran `BenchmarkSeriesChunk` to verify there are no performance regressions from `bytes.Clone()` (addressing golang/go#55905). The results show no statistically significant difference in performance or allocations.

<details>
<summary><code>benchstat</code> Output</summary>

```text
goarch: amd64
pkg: github.com/prometheus/prometheus/tsdb
cpu: AMD Ryzen 5 5500U with Radeon Graphics         
                          │   old.txt    │             new.txt               │
                          │    sec/op    │   sec/op     vs base              │
SeriesChunk/1/oldest-12     4.994n ±  3%   5.018n ± 3%       ~ (p=0.485 n=6)
SeriesChunk/4/oldest-12     6.543n ±  4%   6.502n ± 3%       ~ (p=0.937 n=6)
SeriesChunk/4/middle-12     5.362n ±  9%   5.383n ± 4%       ~ (p=0.818 n=6)
SeriesChunk/16/oldest-12    13.88n ±  4%   14.04n ± 6%       ~ (p=0.485 n=6)
SeriesChunk/16/middle-12    8.793n ±  2%   8.719n ± 3%       ~ (p=0.394 n=6)
SeriesChunk/64/oldest-12    62.95n ±  8%   61.04n ± 4%       ~ (p=0.093 n=6)
SeriesChunk/64/middle-12    27.56n ±  7%   27.49n ± 2%       ~ (p=0.937 n=6)
SeriesChunk/256/oldest-12   326.4n ± 10%   325.9n ± 7%       ~ (p=0.937 n=6)
SeriesChunk/256/middle-12   149.3n ±  4%   147.5n ± 2%       ~ (p=0.394 n=6)
geomean                     23.01n         22.90n       -0.46%
