### PR TITLE
scrape: raise 'Scrape failed' log level from debug to warn

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1418,7 +1418,7 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 		}
 		bytesRead = len(b)
 	} else {
-		sl.l.Debug("Scrape failed", "err", scrapeErr)
+		sl.l.Warn("Scrape failed", "err", scrapeErr)
 		sl.scrapeFailureLoggerMtx.RLock()
 		if sl.scrapeFailureLogger != nil {
 			slog.New(sl.scrapeFailureLogger).Error(scrapeErr.Error())


### PR DESCRIPTION
When a scrape fails (e.g., body size limit exceeded, network error, timeout), the message was logged at `debug` level, making it easy to miss even though it indicates a target is not producing metrics.

Raising this to `warn` so operators see it without enabling debug logging, while the `up` metric remains the primary monitoring signal.

#### Which issue(s) does the PR fix:

Fixes #19195

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[ENHANCEMENT] scrape: raise 'Scrape failed' log level from debug to warn.