### PR TITLE
web: fix IPv6 address mangling in TLS handshake error logs

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1418,7 +1418,7 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 		}
 		bytesRead = len(b)
 	} else {
-		sl.l.Debug("Scrape failed", "err", scrapeErr)
+		sl.l.Warn("Scrape failed", "err", scrapeErr)
 		sl.scrapeFailureLoggerMtx.RLock()
 		if sl.scrapeFailureLogger != nil {
 			slog.New(sl.scrapeFailureLogger).Error(scrapeErr.Error())

--- a/web/web.go
+++ b/web/web.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"log/slog"
 	"math"
 	"net"
@@ -118,6 +119,21 @@ var (
 	fgprofHandler = fgprof.Handler()
 	fgprofMu      sync.Mutex
 )
+
+// httpErrorLogger is an io.Writer that logs HTTP server errors through the
+// provided slog.Logger. Using this instead of slog.NewLogLogger avoids issues
+// with IPv6 addresses in TLS handshake error messages being mangled.
+type httpErrorLogger struct {
+	logger *slog.Logger
+}
+
+func (l *httpErrorLogger) Write(p []byte) (int, error) {
+	msg := strings.TrimRight(string(p), "\n\r")
+	if msg != "" {
+		l.logger.Error(msg)
+	}
+	return len(p), nil
+}
 
 // withStackTracer logs the stack trace in case the request panics. The function
 // will re-raise the error which will then be handled by the net/http package.
@@ -765,7 +781,7 @@ func (h *Handler) Run(ctx context.Context, listeners []net.Listener, webConfig s
 
 	mux.Handle(apiPath+"/v1/", http.StripPrefix(apiPath+"/v1", av1))
 
-	errlog := slog.NewLogLogger(h.logger.Handler(), slog.LevelError)
+	errlog := log.New(&httpErrorLogger{h.logger}, "", 0)
 
 	spanNameFormatter := otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 		return fmt.Sprintf("%s %s", r.Method, r.URL.Path)


### PR DESCRIPTION
When a TLS handshake error occurs from an IPv6 client (e.g., `[2002:abc:4::292]:37802`), the log message was being mangled because `slog.NewLogLogger` routed the raw formatted message through the slog handler's PC-based source resolution, causing parts of the IPv6 address to leak into the `caller` field while the remainder ended up in `msg`.

Before:
caller=stdlib.go:105 level=error component=web caller="http: TLS handshake error from 2002:abc" msg=":4::292:37802: ..."

After:
level=error caller=web.go:131 msg="http: TLS handshake error from 2002:abc:4::292:37802: ..."

The fix replaces `slog.NewLogLogger` with a custom `httpErrorLogger` `io.Writer` that logs through `h.logger` directly, avoiding the PC/source resolution issue entirely.

Fixes #19197

```release-notes
[BUGFIX] web: fix IPv6 address mangling in TLS handshake error logs.