### PR TITLE
notifier: add test coverage for sendLoop error paths and drainQueue

### DIFF
--- a/notifier/sendloop_test.go
+++ b/notifier/sendloop_test.go
@@ -19,8 +19,10 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
@@ -184,4 +186,170 @@ func TestMetrics(t *testing.T) {
 	// Verify metrics are re-initialized correctly
 	require.Equal(t, 0.0, prom_testutil.ToFloat64(metrics.dropped.WithLabelValues(alertmanagerURL)))
 	require.Equal(t, 0.0, prom_testutil.ToFloat64(metrics.sent.WithLabelValues(alertmanagerURL)))
+}
+
+func TestSendAllInvalidAPIVersion(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	metrics := newAlertMetrics(reg, nil)
+	cfg := &config.AlertmanagerConfig{
+		APIVersion: "v3-invalid",
+	}
+	s := newSendLoop("http://mock", nil, cfg, &Options{QueueCapacity: 10}, slog.New(slog.DiscardHandler), metrics)
+	defer s.stop()
+
+	alerts := []*Alert{
+		{Labels: labels.FromStrings("alertname", "test")},
+	}
+	require.False(t, s.sendAll(alerts))
+}
+
+func TestSendAllHTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	reg := prometheus.NewRegistry()
+	metrics := newAlertMetrics(reg, nil)
+	cfg := config.DefaultAlertmanagerConfig
+	cfg.APIVersion = config.AlertmanagerAPIVersionV2
+
+	s := newSendLoop(ts.URL, ts.Client(), &cfg, &Options{
+		QueueCapacity: 10,
+		Do:            do,
+	}, slog.New(slog.DiscardHandler), metrics)
+	defer s.stop()
+
+	alerts := []*Alert{
+		{Labels: labels.FromStrings("alertname", "test")},
+	}
+	require.False(t, s.sendAll(alerts))
+	require.Equal(t, 1.0, prom_testutil.ToFloat64(metrics.errors.WithLabelValues(ts.URL)))
+}
+
+func TestDrainQueue(t *testing.T) {
+	var count int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	reg := prometheus.NewRegistry()
+	metrics := newAlertMetrics(reg, nil)
+	cfg := config.DefaultAlertmanagerConfig
+	cfg.APIVersion = config.AlertmanagerAPIVersionV2
+
+	s := newSendLoop(ts.URL, ts.Client(), &cfg, &Options{
+		QueueCapacity: 10,
+		MaxBatchSize:  2,
+		Do:            do,
+	}, slog.New(slog.DiscardHandler), metrics)
+
+	alerts := []*Alert{
+		{Labels: labels.FromStrings("alertname", "a1")},
+		{Labels: labels.FromStrings("alertname", "a2")},
+		{Labels: labels.FromStrings("alertname", "a3")},
+	}
+	s.add(alerts...)
+
+	require.Equal(t, 3, s.queueLen())
+
+	s.drainQueue()
+
+	require.Equal(t, 2, count)
+	require.Equal(t, 0, s.queueLen())
+	require.Equal(t, 3.0, prom_testutil.ToFloat64(metrics.sent.WithLabelValues(ts.URL)))
+}
+
+type logRecord struct {
+	Msg  string
+	Attr map[string]any
+}
+
+type recordHandler struct {
+	logs *[]logRecord
+}
+
+func (recordHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h recordHandler) Handle(_ context.Context, r slog.Record) error {
+	attr := make(map[string]any)
+	r.Attrs(func(a slog.Attr) bool {
+		attr[a.Key] = a.Value.Any()
+		return true
+	})
+	*h.logs = append(*h.logs, logRecord{Msg: r.Message, Attr: attr})
+	return nil
+}
+func (h recordHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h recordHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func TestStopWithoutDrain(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	metrics := newAlertMetrics(reg, nil)
+	cfg := config.DefaultAlertmanagerConfig
+
+	var logs []logRecord
+	logger := slog.New(recordHandler{logs: &logs})
+
+	s := newSendLoop("http://mock", nil, &cfg, &Options{
+		QueueCapacity:   10,
+		DrainOnShutdown: false,
+		Do:              do,
+	}, logger, metrics)
+
+	alerts := []*Alert{
+		{Labels: labels.FromStrings("alertname", "a1")},
+		{Labels: labels.FromStrings("alertname", "a2")},
+	}
+	s.add(alerts...)
+
+	s.stop()
+
+	// Verify that the correct warning log was recorded
+	var found bool
+	for _, l := range logs {
+		if l.Msg == "Alert notification queue not drained on shutdown, dropping alerts" {
+			found = true
+			require.Equal(t, int64(2), l.Attr["count"])
+		}
+	}
+	require.True(t, found, "warning log not found")
+}
+
+func TestSendLoopShutdown(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	reg := prometheus.NewRegistry()
+	metrics := newAlertMetrics(reg, nil)
+	cfg := config.DefaultAlertmanagerConfig
+	cfg.APIVersion = config.AlertmanagerAPIVersionV2
+
+	s := newSendLoop(ts.URL, ts.Client(), &cfg, &Options{
+		QueueCapacity:   10,
+		DrainOnShutdown: true,
+		MaxBatchSize:    10,
+		Do:              do,
+	}, slog.New(slog.DiscardHandler), metrics)
+
+	done := make(chan struct{})
+	go func() {
+		s.loop()
+		close(done)
+	}()
+
+	s.add(&Alert{Labels: labels.FromStrings("alertname", "a1")})
+
+	time.Sleep(100 * time.Millisecond)
+
+	s.stop()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not shut down on stop")
+	}
 }


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
-->
N/A (test coverage expansion; no functional change)

#### What This Does
Adds test coverage for untested error, drain, and shutdown paths in notifier/sendloop.go:

Unsupported API versions in sendAll().
Handling of non-2xx HTTP error status codes in sendAll() and ensuring error metrics are incremented.
Batching and sending validation inside drainQueue().
Dropped metrics verification when stopping a loop with DrainOnShutdown=false (using a custom recording slog.Handler to capture warnings).
Clean loop goroutine shutdown verification.

#### Release notes for end users .
```release-notes
NONE
