### PR TITLE
tsdb/wlog: avoid shadowing checkpoint metadata

### DIFF
--- a/tsdb/wlog/checkpoint.go
+++ b/tsdb/wlog/checkpoint.go
@@ -358,7 +358,7 @@ func Checkpoint(logger *slog.Logger, w *WL, from, to int, keep func(id chunks.He
 			stats.TotalExemplars += len(exemplars)
 			stats.DroppedExemplars += len(exemplars) - len(repl)
 		case record.Metadata:
-			metadata, err := dec.Metadata(rec, metadata)
+			metadata, err = dec.Metadata(rec, metadata)
 			if err != nil {
 				return nil, fmt.Errorf("decode metadata: %w", err)
 			}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #19173

#### Summary

Use normal assignment when decoding checkpoint metadata so the outer slice is updated and reused consistently with the other record paths.

This is the minimal code-only change requested in the review of #19174. The earlier proposed test passed before the fix, so it is intentionally not repeated here.

#### Testing

- `go test ./tsdb/wlog`

cc @krajorama

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
NONE
```