### PR TITLE
model/histogram: trim native histogram buckets in place

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -2119,14 +2119,17 @@ func (h *FloatHistogram) HasOverflow() bool {
 	return false
 }
 
-// TrimBuckets trims native histogram buckets.
+// TrimBuckets trims native histogram buckets in place, modifying the receiver
+// and returning it (to allow call chaining). Because it mutates the receiver
+// (and compacts its bucket and span slices), callers that must preserve the
+// original histogram have to pass a copy, e.g.
+// h.Copy().TrimBuckets(rhs, isUpperTrim). This matches the in-place convention
+// of the other FloatHistogram arithmetic methods (Add, Sub, Mul, Div).
 func (h *FloatHistogram) TrimBuckets(rhs float64, isUpperTrim bool) *FloatHistogram {
 	var (
-		trimmedHist = h.Copy()
-
 		updatedCount, updatedSum float64
 		trimmedBuckets           bool
-		isCustomBucket           = trimmedHist.UsesCustomBuckets()
+		isCustomBucket           = h.UsesCustomBuckets()
 		hasPositive, hasNegative bool
 	)
 
@@ -2134,7 +2137,7 @@ func (h *FloatHistogram) TrimBuckets(rhs float64, isUpperTrim bool) *FloatHistog
 		// Calculate the fraction to keep for buckets that contain the trim value.
 		// For TRIM_UPPER, we keep observations below the trim point (rhs).
 		// Example: histogram </ float.
-		for i, iter := 0, trimmedHist.PositiveBucketIterator(); iter.Next(); i++ {
+		for i, iter := 0, h.PositiveBucketIterator(); iter.Next(); i++ {
 			bucket := iter.At()
 			if bucket.Count == 0 {
 				continue
@@ -2154,19 +2157,19 @@ func (h *FloatHistogram) TrimBuckets(rhs float64, isUpperTrim bool) *FloatHistog
 
 				updatedCount += keepCount
 				updatedSum += bucketMidpoint * keepCount
-				if trimmedHist.PositiveBuckets[i] != keepCount {
-					trimmedHist.PositiveBuckets[i] = keepCount
+				if h.PositiveBuckets[i] != keepCount {
+					h.PositiveBuckets[i] = keepCount
 					trimmedBuckets = true
 				}
 
 			default:
 				// Bucket is entirely above the trim point - discard.
-				trimmedHist.PositiveBuckets[i] = 0
+				h.PositiveBuckets[i] = 0
 				trimmedBuckets = true
 			}
 		}
 
-		for i, iter := 0, trimmedHist.NegativeBucketIterator(); iter.Next(); i++ {
+		for i, iter := 0, h.NegativeBucketIterator(); iter.Next(); i++ {
 			bucket := iter.At()
 			if bucket.Count == 0 {
 				continue
@@ -2186,20 +2189,20 @@ func (h *FloatHistogram) TrimBuckets(rhs float64, isUpperTrim bool) *FloatHistog
 
 				updatedCount += keepCount
 				updatedSum += bucketMidpoint * keepCount
-				if trimmedHist.NegativeBuckets[i] != keepCount {
-					trimmedHist.NegativeBuckets[i] = keepCount
+				if h.NegativeBuckets[i] != keepCount {
+					h.NegativeBuckets[i] = keepCount
 					trimmedBuckets = true
 				}
 
 			default:
-				trimmedHist.NegativeBuckets[i] = 0
+				h.NegativeBuckets[i] = 0
 				trimmedBuckets = true
 			}
 		}
 	} else { // !isUpperTrim
 		// For TRIM_LOWER, we keep observations above the trim point (rhs).
 		// Example: histogram >/ float.
-		for i, iter := 0, trimmedHist.PositiveBucketIterator(); iter.Next(); i++ {
+		for i, iter := 0, h.PositiveBucketIterator(); iter.Next(); i++ {
 			bucket := iter.At()
 			if bucket.Count == 0 {
 				continue
@@ -2219,18 +2222,18 @@ func (h *FloatHistogram) TrimBuckets(rhs float64, isUpperTrim bool) *FloatHistog
 
 				updatedCount += keepCount
 				updatedSum += bucketMidpoint * keepCount
-				if trimmedHist.PositiveBuckets[i] != keepCount {
-					trimmedHist.PositiveBuckets[i] = keepCount
+				if h.PositiveBuckets[i] != keepCount {
+					h.PositiveBuckets[i] = keepCount
 					trimmedBuckets = true
 				}
 
 			default:
-				trimmedHist.PositiveBuckets[i] = 0
+				h.PositiveBuckets[i] = 0
 				trimmedBuckets = true
 			}
 		}
 
-		for i, iter := 0, trimmedHist.NegativeBucketIterator(); iter.Next(); i++ {
+		for i, iter := 0, h.NegativeBucketIterator(); iter.Next(); i++ {
 			bucket := iter.At()
 			if bucket.Count == 0 {
 				continue
@@ -2250,24 +2253,24 @@ func (h *FloatHistogram) TrimBuckets(rhs float64, isUpperTrim bool) *FloatHistog
 
 				updatedCount += keepCount
 				updatedSum += bucketMidpoint * keepCount
-				if trimmedHist.NegativeBuckets[i] != keepCount {
-					trimmedHist.NegativeBuckets[i] = keepCount
+				if h.NegativeBuckets[i] != keepCount {
+					h.NegativeBuckets[i] = keepCount
 					trimmedBuckets = true
 				}
 
 			default:
-				trimmedHist.NegativeBuckets[i] = 0
+				h.NegativeBuckets[i] = 0
 				trimmedBuckets = true
 			}
 		}
 	}
 
 	// Handle the zero count bucket.
-	if trimmedHist.ZeroCount > 0 {
-		keepCount, bucketMidpoint := computeZeroBucketTrim(trimmedHist.ZeroBucket(), rhs, hasNegative, hasPositive, isUpperTrim)
+	if h.ZeroCount > 0 {
+		keepCount, bucketMidpoint := computeZeroBucketTrim(h.ZeroBucket(), rhs, hasNegative, hasPositive, isUpperTrim)
 
-		if trimmedHist.ZeroCount != keepCount {
-			trimmedHist.ZeroCount = keepCount
+		if h.ZeroCount != keepCount {
+			h.ZeroCount = keepCount
 			trimmedBuckets = true
 		}
 		updatedSum += bucketMidpoint * keepCount
@@ -2276,13 +2279,13 @@ func (h *FloatHistogram) TrimBuckets(rhs float64, isUpperTrim bool) *FloatHistog
 
 	if trimmedBuckets {
 		// Only update the totals in case some bucket(s) were fully (or partially) trimmed.
-		trimmedHist.Count = updatedCount
-		trimmedHist.Sum = updatedSum
+		h.Count = updatedCount
+		h.Sum = updatedSum
 
-		trimmedHist.Compact(0)
+		h.Compact(0)
 	}
 
-	return trimmedHist
+	return h
 }
 
 func handleInfinityBuckets(isUpperTrim bool, b Bucket[float64], rhs float64) (underCount, bucketMidpoint float64) {

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -4608,3 +4608,34 @@ func TestFloatHistogramReduceResolution(t *testing.T) {
 		})
 	}
 }
+
+func TestFloatHistogramTrimBucketsInPlace(t *testing.T) {
+	// Schema 0 native histogram with buckets straddling a trim point of 4.
+	newHist := func() *FloatHistogram {
+		return &FloatHistogram{
+			Schema:          0,
+			Count:           30,
+			Sum:             100,
+			PositiveSpans:   []Span{{Offset: 0, Length: 4}},
+			PositiveBuckets: []float64{5, 5, 10, 10}, // Bucket upper bounds: 1, 2, 4, 8.
+		}
+	}
+
+	t.Run("mutates the receiver and returns it", func(t *testing.T) {
+		h := newHist()
+		got := h.TrimBuckets(4, true)
+		// The returned histogram is the receiver, not a copy.
+		require.Same(t, h, got)
+		// The bucket entirely above the trim point (upper bound 8) is dropped.
+		require.NotEqual(t, newHist(), h)
+	})
+
+	t.Run("Copy preserves the original", func(t *testing.T) {
+		h := newHist()
+		trimmed := h.Copy().TrimBuckets(4, true)
+		// The original is untouched.
+		require.Equal(t, newHist(), h)
+		// The copy was actually trimmed.
+		require.NotEqual(t, h, trimmed)
+	})
+}

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -4460,6 +4460,41 @@ func BenchmarkFloatHistogramAdd(b *testing.B) {
 	})
 }
 
+func BenchmarkFloatHistogramTrimBuckets(b *testing.B) {
+	var (
+		rng           = rand.New(rand.NewSource(0))
+		numHistograms = 120
+		fhs           = make([]*FloatHistogram, 0, numHistograms)
+	)
+
+	for range numHistograms {
+		fhs = append(fhs, createRandomFloatHistogram(rng, 5))
+	}
+
+	// In place: the caller owns the histogram and lets TrimBuckets mutate it.
+	b.Run("InPlace", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			for _, hist := range fhs {
+				hist.TrimBuckets(3, true)
+			}
+		}
+	})
+
+	// Copy: the caller must preserve the input, so it copies first (the old
+	// behaviour, now expressed explicitly at the call site).
+	b.Run("Copy", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			for _, hist := range fhs {
+				hist.Copy().TrimBuckets(3, true)
+			}
+		}
+	})
+}
+
 func createRandomFloatHistogram(rng *rand.Rand, spanNum int32) *FloatHistogram {
 	f := &FloatHistogram{}
 	f.PositiveSpans, f.PositiveBuckets = createRandomSpans(rng, spanNum)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -3505,10 +3505,12 @@ func vectorElemBinop(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram
 				return 0, hlhs.Copy().Mul(rhs).Compact(0), true, nil, nil
 			case parser.DIV:
 				return 0, hlhs.Copy().Div(rhs).Compact(0), true, nil, nil
+			// TrimBuckets mutates its receiver in place, and hlhs may be shared
+			// with other samples/series, so trim a copy rather than hlhs itself.
 			case parser.TRIM_UPPER:
-				return 0, hlhs.TrimBuckets(rhs, true), true, nil, nil
+				return 0, hlhs.Copy().TrimBuckets(rhs, true), true, nil, nil
 			case parser.TRIM_LOWER:
-				return 0, hlhs.TrimBuckets(rhs, false), true, nil, nil
+				return 0, hlhs.Copy().TrimBuckets(rhs, false), true, nil, nil
 			case parser.ADD, parser.SUB, parser.POW, parser.MOD, parser.EQLC, parser.NEQ, parser.GTR, parser.LSS, parser.GTE, parser.LTE, parser.ATAN2:
 				return 0, nil, false, nil, annotations.NewIncompatibleTypesInBinOpInfo("histogram", parser.ItemTypeStr[op], "float", pos)
 			}


### PR DESCRIPTION
`FloatHistogram.TrimBuckets` now mutates the receiver and returns it instead of copying internally, so callers that need to preserve the original pass a copy, matching the in-place convention of the other arithmetic methods.

Query results and Prometheus performance are unchanged since it still copies before trimming, just that the copy is now done at the call site. This would achieve consistency with other methods like `Add` and `Sub`, and also allow downstream callers that can safely mutate their histogram skip the copy to avoid unnecessary allocations. `BenchmarkFloatHistogramTrimBuckets` shows the in-place path at 0 allocs vs ~450 allocs for the copy path.

<details>
  <summary>Benchmark results</summary>

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/prometheus/model/histogram
cpu: Intel(R) Core(TM) Ultra 7 258V
                                    │ BenchmarkFloatHistogramTrimBuckets_before.txt │ BenchmarkFloatHistogramTrimBuckets_after.txt │
                                    │                    sec/op                     │        sec/op          vs base               │
FloatHistogramTrimBuckets/InPlace-8                                    333.67µ ± 4%             98.32µ ± 3%  -70.53% (p=0.002 n=6)
FloatHistogramTrimBuckets/Copy-8                                        397.7µ ± 6%             190.3µ ± 7%  -52.15% (p=0.002 n=6)
geomean                                                                 364.3µ                  136.8µ       -62.45%

                                    │ BenchmarkFloatHistogramTrimBuckets_before.txt │ BenchmarkFloatHistogramTrimBuckets_after.txt │
                                    │                     B/op                      │       B/op        vs base                    │
FloatHistogramTrimBuckets/InPlace-8                                    58.68Ki ± 0%        0.00Ki ±  ?  -100.00% (p=0.002 n=6)
FloatHistogramTrimBuckets/Copy-8                                      117.35Ki ± 0%       39.63Ki ± 0%   -66.22% (p=0.002 n=6)
geomean                                                                82.98Ki                          ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                                    │ BenchmarkFloatHistogramTrimBuckets_before.txt │ BenchmarkFloatHistogramTrimBuckets_after.txt │
                                    │                   allocs/op                   │    allocs/op      vs base                    │
FloatHistogramTrimBuckets/InPlace-8                                      600.0 ± 0%           0.0 ± 0%  -100.00% (p=0.002 n=6)
FloatHistogramTrimBuckets/Copy-8                                        1200.0 ± 0%         450.0 ± 0%   -62.50% (p=0.002 n=6)
geomean                                                                  848.5                          ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```

</details>

This does change the contract of an exported API as the method previously left the receiver untouched. Since `TrimBuckets` is new, it's better to make such changes earlier while no known external callers are adversely affected.

#### Which issue(s) does the PR fix:

N/A

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```