### PR TITLE
tsdb: use bytes.Clone instead of make and copy

### DIFF
--- a/tsdb/chunks/head_chunks.go
+++ b/tsdb/chunks/head_chunks.go
@@ -15,6 +15,7 @@ package chunks
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -818,8 +819,7 @@ func (cdm *ChunkDiskMapper) Chunk(ref ChunkDiskMapperRef) (chunkenc.Chunk, error
 	// Make a copy of the chunk data to prevent a panic occurring because the returned
 	// chunk data slice references an mmap-ed file which could be closed after the
 	// function returns but while the chunk is still in use.
-	chkDataCopy := make([]byte, len(chkData))
-	copy(chkDataCopy, chkData)
+	chkDataCopy := bytes.Clone(chkData)
 
 	chk, err := cdm.pool.Get(chunkenc.Encoding(chkEnc), chkDataCopy)
 	if err != nil {

--- a/tsdb/db_append_v2_test.go
+++ b/tsdb/db_append_v2_test.go
@@ -15,6 +15,7 @@ package tsdb
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -7470,8 +7471,7 @@ func TestChunkQuerierReadWriteRace_AppendV2(t *testing.T) {
 			for it.Next() {
 				m := it.At()
 				b := m.Chunk.Bytes()
-				bb := make([]byte, len(b))
-				copy(bb, b) // This copying of chunk bytes detects any race.
+				_ = bytes.Clone(b) // This copying of chunk bytes detects any race.
 			}
 		}
 		require.NoError(t, ss.Err())

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -9377,8 +9377,7 @@ func TestChunkQuerierReadWriteRace(t *testing.T) {
 			for it.Next() {
 				m := it.At()
 				b := m.Chunk.Bytes()
-				bb := make([]byte, len(b))
-				copy(bb, b) // This copying of chunk bytes detects any race.
+				_ = bytes.Clone(b) // This copying of chunk bytes detects any race.
 			}
 		}
 		require.NoError(t, ss.Err())

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -14,6 +14,7 @@
 package tsdb
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1368,8 +1369,7 @@ func decodeSeriesFromChunkSnapshot(d *record.Decoder, b []byte) (csr chunkSnapsh
 
 	// The underlying bytes gets re-used later, so make a copy.
 	chunkBytes := dec.UvarintBytes()
-	chunkBytesCopy := make([]byte, len(chunkBytes))
-	copy(chunkBytesCopy, chunkBytes)
+	chunkBytesCopy := bytes.Clone(chunkBytes)
 
 	chk, err := chunkenc.FromData(enc, chunkBytesCopy)
 	if err != nil {


### PR DESCRIPTION
This PR replaces occurrences of `make` and `copy` with `bytes.Clone()` in the `tsdb` package for cleaner and more idiomatic code.

#### Which issue(s) does the PR fix:
<!-- No issue was created for this trivial cleanup -->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```