### PR TITLE
promql: handle to_nearest=0 and negative values in round()

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1163,6 +1163,19 @@ func funcRound(vectorVals []Vector, _ Matrix, args parser.Expressions, enh *Eval
 	if len(args) >= 2 {
 		toNearest = vectorVals[1][0].F
 	}
+	// The set of multiples of N equals the set of multiples of -N, so a negative
+	// toNearest must not change the result. Use the absolute value to keep the
+	// floor direction consistent.
+	toNearest = math.Abs(toNearest)
+	// round to 0 is undefined and previously produced NaN for every sample
+	// (division by zero); return the input unchanged in that case. Route through
+	// simpleFloatFunc with an identity function so label/metric handling matches
+	// the normal path.
+	if toNearest == 0 {
+		return simpleFloatFunc(vectorVals, enh, func(f float64) float64 {
+			return f
+		}), nil
+	}
 	// Invert as it seems to cause fewer floating point accuracy issues.
 	toNearestInverse := 1.0 / toNearest
 	return simpleFloatFunc(vectorVals, enh, func(f float64) float64 {

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -1718,6 +1718,43 @@ eval instant at 0m round(data)
 	{type="ninf"} -Inf
 	{type="nan"} NaN
 
+# Test for round() with to_nearest values of 0 and negative numbers.
+# round(v, 0) should return the input unchanged (was producing NaN for all samples).
+# round(v, -2) should match round(v, 2) since the set of multiples is identical.
+
+eval instant at 0m round(data, 0)
+	{type="positive"} 2.5
+	{type="whole"} 2
+	{type="negative"} -2.5
+	{type="nwhole"} -2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} -Inf
+	{type="nan"} NaN
+
+eval instant at 0m round(data, 2)
+	{type="positive"} 2
+	{type="whole"} 2
+	{type="negative"} -2
+	{type="nwhole"} -2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} -Inf
+	{type="nan"} NaN
+
+eval instant at 0m round(data, -2)
+	{type="positive"} 2
+	{type="whole"} 2
+	{type="negative"} -2
+	{type="nwhole"} -2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} -Inf
+	{type="nan"} NaN
+
 clear
 
 # Test for absent().


### PR DESCRIPTION
round(v, 0) returned NaN for every sample because 1.0/0 yields +Inf, and round(v, -N) gave wrong results since a negative toNearest inverts the floor direction even though the set of multiples of N and -N is identical.

I take math.Abs(toNearest) up front so the sign no longer matters, and when toNearest is 0 I return the input unchanged (rounding to a multiple of 0 is undefined). The zero case is routed through simpleFloatFunc with an identity function so label and metric-name handling matches the normal path rather than short-circuiting on the raw input vector.

Added cases to the existing round() block in functions.test covering to_nearest=0, to_nearest=2, and to_nearest=-2 to lock in both fixes.

Fixes #19198

```release-notes
[BUGFIX] PromQL: round() no longer returns NaN for to_nearest=0 and produces correct results for negative to_nearest values.
```