### PR TITLE
remote: evaluate external labels before remote read

### DIFF
--- a/storage/remote/read_handler.go
+++ b/storage/remote/read_handler.go
@@ -128,9 +128,13 @@ func (h *readHandler) remoteReadSamples(
 	}
 	for i, query := range req.Queries {
 		if err := func() error {
-			filteredMatchers, err := filterExtLabelsFromMatchers(query.Matchers, externalLabels)
+			filteredMatchers, matches, err := filterExtLabelsFromMatchers(query.Matchers, externalLabels)
 			if err != nil {
 				return err
+			}
+			if !matches {
+				resp.Results[i] = &prompb.QueryResult{}
+				return nil
 			}
 
 			querier, err := h.queryable.Querier(query.StartTimestampMs, query.EndTimestampMs)
@@ -199,9 +203,12 @@ func (h *readHandler) remoteReadStreamedXORChunks(ctx context.Context, w http.Re
 
 	for i, query := range req.Queries {
 		if err := func() error {
-			filteredMatchers, err := filterExtLabelsFromMatchers(query.Matchers, externalLabels)
+			filteredMatchers, matches, err := filterExtLabelsFromMatchers(query.Matchers, externalLabels)
 			if err != nil {
 				return err
+			}
+			if !matches {
+				return nil
 			}
 
 			querier, err := h.queryable.ChunkQuerier(query.StartTimestampMs, query.EndTimestampMs)
@@ -256,28 +263,30 @@ func (h *readHandler) remoteReadStreamedXORChunks(ctx context.Context, w http.Re
 	}
 }
 
-// filterExtLabelsFromMatchers change equality matchers which match external labels
-// to a matcher that looks for an empty label,
-// as that label should not be present in the storage.
-func filterExtLabelsFromMatchers(pbMatchers []*prompb.LabelMatcher, externalLabels map[string]string) ([]*labels.Matcher, error) {
+// filterExtLabelsFromMatchers evaluates matchers for external labels before
+// querying storage, where those labels are absent.
+func filterExtLabelsFromMatchers(pbMatchers []*prompb.LabelMatcher, externalLabels map[string]string) ([]*labels.Matcher, bool, error) {
 	matchers, err := FromLabelMatchers(pbMatchers)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	filteredMatchers := make([]*labels.Matcher, 0, len(matchers))
 	for _, m := range matchers {
-		value := externalLabels[m.Name]
-		if m.Type == labels.MatchEqual && value == m.Value {
-			matcher, err := labels.NewMatcher(labels.MatchEqual, m.Name, "")
-			if err != nil {
-				return nil, err
-			}
-			filteredMatchers = append(filteredMatchers, matcher)
-		} else {
+		value, ok := externalLabels[m.Name]
+		if !ok {
 			filteredMatchers = append(filteredMatchers, m)
+			continue
 		}
+		if !m.Matches(value) {
+			return nil, false, nil
+		}
+		matcher, err := labels.NewMatcher(labels.MatchEqual, m.Name, "")
+		if err != nil {
+			return nil, false, err
+		}
+		filteredMatchers = append(filteredMatchers, matcher)
 	}
 
-	return filteredMatchers, nil
+	return filteredMatchers, true, nil
 }

--- a/storage/remote/read_handler_test.go
+++ b/storage/remote/read_handler_test.go
@@ -164,6 +164,122 @@ func TestSampledReadEndpoint(t *testing.T) {
 	}, resp.Results[2])
 }
 
+func TestSampledReadEndpointExternalLabelMatchers(t *testing.T) {
+	store := promqltest.LoadedStorage(t, `
+		load 1m
+			test_metric{job="api"} 1
+	`)
+	defer store.Close()
+
+	h := NewReadHandler(nil, nil, store, func() config.Config {
+		return config.Config{
+			GlobalConfig: config.GlobalConfig{
+				ExternalLabels: labels.FromStrings("cluster", "prod"),
+			},
+		}
+	}, 1e6, 1, 0)
+
+	tests := []struct {
+		name      string
+		matchType labels.MatchType
+		value     string
+		series    int
+	}{
+		{name: "matching regex", matchType: labels.MatchRegexp, value: "prod", series: 1},
+		{name: "non-matching regex", matchType: labels.MatchRegexp, value: "staging", series: 0},
+		{name: "negative equality", matchType: labels.MatchNotEqual, value: "prod", series: 0},
+		{name: "negative regex", matchType: labels.MatchNotRegexp, value: "prod", series: 0},
+		{name: "matching negative regex", matchType: labels.MatchNotRegexp, value: "staging", series: 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nameMatcher := labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "test_metric")
+			externalMatcher := labels.MustNewMatcher(tc.matchType, "cluster", tc.value)
+			query, err := ToQuery(0, 1, []*labels.Matcher{nameMatcher, externalMatcher}, nil)
+			require.NoError(t, err)
+
+			req, err := proto.Marshal(&prompb.ReadRequest{Queries: []*prompb.Query{query}})
+			require.NoError(t, err)
+
+			request, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(snappy.Encode(nil, req)))
+			require.NoError(t, err)
+			recorder := httptest.NewRecorder()
+			h.ServeHTTP(recorder, request)
+			require.Equal(t, http.StatusOK, recorder.Code)
+
+			compressed, err := io.ReadAll(recorder.Result().Body)
+			require.NoError(t, err)
+			decoded, err := snappy.Decode(nil, compressed)
+			require.NoError(t, err)
+			var resp prompb.ReadResponse
+			require.NoError(t, proto.Unmarshal(decoded, &resp))
+			require.Len(t, resp.Results, 1)
+			require.Len(t, resp.Results[0].Timeseries, tc.series)
+		})
+	}
+}
+
+func TestStreamReadEndpointExternalLabelMatchers(t *testing.T) {
+	store := promqltest.LoadedStorage(t, `
+		load 1m
+			test_metric{job="api"} 1
+	`)
+	defer store.Close()
+
+	h := NewReadHandler(nil, nil, store, func() config.Config {
+		return config.Config{
+			GlobalConfig: config.GlobalConfig{
+				ExternalLabels: labels.FromStrings("cluster", "prod"),
+			},
+		}
+	}, 1e6, 1, 0)
+
+	tests := []struct {
+		name      string
+		matchType labels.MatchType
+		value     string
+		frames    int
+	}{
+		{name: "matching regex", matchType: labels.MatchRegexp, value: "prod", frames: 1},
+		{name: "negative equality", matchType: labels.MatchNotEqual, value: "prod", frames: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nameMatcher := labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "test_metric")
+			externalMatcher := labels.MustNewMatcher(tc.matchType, "cluster", tc.value)
+			query, err := ToQuery(0, 1, []*labels.Matcher{nameMatcher, externalMatcher}, nil)
+			require.NoError(t, err)
+
+			req, err := proto.Marshal(&prompb.ReadRequest{
+				Queries:               []*prompb.Query{query},
+				AcceptedResponseTypes: []prompb.ReadRequest_ResponseType{prompb.ReadRequest_STREAMED_XOR_CHUNKS},
+			})
+			require.NoError(t, err)
+
+			request, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(snappy.Encode(nil, req)))
+			require.NoError(t, err)
+			recorder := httptest.NewRecorder()
+			h.ServeHTTP(recorder, request)
+			require.Equal(t, http.StatusOK, recorder.Code)
+
+			var frames []*prompb.ChunkedReadResponse
+			stream := NewChunkedReader(recorder.Result().Body, config.DefaultChunkedReadLimit, nil)
+			for {
+				frame := &prompb.ChunkedReadResponse{}
+				err := stream.NextProto(frame)
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				require.NoError(t, err)
+				frames = append(frames, frame)
+			}
+			require.Len(t, frames, tc.frames)
+		})
+	}
+}
+
 func BenchmarkStreamReadEndpoint(b *testing.B) {
 	store := promqltest.LoadedStorage(b, `
 	load 1m


### PR DESCRIPTION
Fixes #11663

Remote-read handlers select local series before adding configured external labels to the response. Exact equality matchers are rewritten for local storage, but regex and negative matchers are evaluated against the missing local label.

Evaluate matchers for configured external labels before selecting local storage. Queries that cannot match return an empty result. Matchers satisfied by an external label are rewritten to match the absent local label. The sampled and streamed remote-read paths are covered.

Tests:
- `go test ./storage/remote -count=1`
- `go build ./cmd/prometheus/`

`go vet ./storage/remote` is blocked by pre-existing Go 1.25.8 diagnostics in unchanged `storage/remote/codec.go`.

@cstyan

```release-notes
[BUGFIX] Remote read: Evaluate regex and negative external-label matchers before querying local storage.
```