### PR TITLE
discovery/kubernetes: use cancellable context for node and namespace informers

### DIFF
--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -438,12 +438,12 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 			}
 			var nodeInf cache.SharedInformer
 			if d.attachMetadata.Node {
-				nodeInf = d.newNodeInformer(context.Background())
+				nodeInf = d.newNodeInformer(ctx)
 				go nodeInf.Run(ctx.Done())
 			}
 			var namespaceInf cache.SharedInformer
 			if d.attachMetadata.Namespace {
-				namespaceInf = d.newNamespaceInformer(context.Background())
+				namespaceInf = d.newNamespaceInformer(ctx)
 				go namespaceInf.Run(ctx.Done())
 			}
 			var replicaSetInf, jobInformer cache.SharedInformer


### PR DESCRIPTION
## Bug fix
- Fixes context.Background() being used instead of the parent context for creating Kubernetes node and namespace informers. When the parent context is cancelled, these informers now properly stop instead of leaking.

## Changes
- `discovery/kubernetes/kubernetes.go`: Use `ctx` instead of `context.Background()` when creating node and namespace informers.

## Reproduction
Currently, when Prometheus shuts down, the node and namespace informers created with context.Background() are not cancelled, causing a context leak. This is a resource leak that can accumulate on repeated restarts.

## Checklist
- [x] Code follows the project's coding style
- [x] Tests added if applicable