### PR TITLE
notifier: fix targetUpdateLoop spinning on closed target-set channel

### DIFF
--- a/notifier/manager.go
+++ b/notifier/manager.go
@@ -227,7 +227,8 @@ func (n *Manager) targetUpdateLoop(tsets <-chan map[string][]*targetgroup.Group)
 				return
 			case ts, ok := <-tsets:
 				if !ok {
-					break
+					// The channel has been closed; exit the loop cleanly.
+					return
 				}
 				n.reload(ts)
 			}

--- a/notifier/manager_test.go
+++ b/notifier/manager_test.go
@@ -835,6 +835,32 @@ func TestHangingNotifier(t *testing.T) {
 	})
 }
 
+// TestTargetUpdateLoopExitsOnClosedChannel verifies that targetUpdateLoop returns
+// cleanly when the target-set channel is closed, rather than spinning indefinitely.
+// Regression test for https://github.com/prometheus/prometheus/issues/19234.
+func TestTargetUpdateLoopExitsOnClosedChannel(t *testing.T) {
+	m := NewManager(&Options{QueueCapacity: 10}, model.UTF8Validation, nil)
+	m.alertmanagers = make(map[string]*alertmanagerSet)
+
+	tsets := make(chan map[string][]*targetgroup.Group)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.targetUpdateLoop(tsets)
+	}()
+
+	// Closing the channel should cause targetUpdateLoop to return, not spin.
+	close(tsets)
+
+	select {
+	case <-done:
+		// targetUpdateLoop exited cleanly as expected.
+	case <-time.After(5 * time.Second):
+		t.Fatal("targetUpdateLoop did not exit after tsets channel was closed — possible infinite spin")
+	}
+}
+
 func TestStop_DrainingDisabled(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		const alertmanagerURL = "http://alertmanager:9093/api/v2/alerts"


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #19234

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] notifier: fix targetUpdateLoop spinning at 100% CPU when the target-set channel is closed.
```

When the `tsets` channel passed to `targetUpdateLoop` is closed, the inner
`select` receives `ok = false` and hits `break`. In Go, `break` inside a
`select` exits the `select` statement only, not the enclosing `for` loop.
The loop immediately re-enters the `default` branch and reads from the closed
channel again indefinitely, spinning at 100% CPU with no error logged.

Replace `break` with `return` so a closed channel causes the goroutine to
exit cleanly, consistent with how the `stopRequested` path already behaves.

A new test `TestTargetUpdateLoopExitsOnClosedChannel` closes the channel and
asserts the goroutine terminates within a deadline, failing before this fix.