### PR TITLE
discovery/moby: bound Docker API requests on all host schemes

### DIFF
--- a/discovery/moby/docker.go
+++ b/discovery/moby/docker.go
@@ -166,7 +166,6 @@ func NewDockerDiscovery(conf *DockerSDConfig, opts discovery.DiscovererOptions) 
 		clientOpts = append(clientOpts,
 			client.WithHTTPClient(&http.Client{
 				Transport: rt,
-				Timeout:   time.Duration(conf.RefreshInterval),
 			}),
 			client.WithScheme(hostURL.Scheme),
 			client.WithHTTPHeaders(map[string]string{
@@ -174,6 +173,11 @@ func NewDockerDiscovery(conf *DockerSDConfig, opts discovery.DiscovererOptions) 
 			}),
 		)
 	}
+
+	// Set a deadline on whichever HTTP client is in use, so it is safe for the
+	// non-HTTP transports. It must be appended after WithHTTPClient, which
+	// replaces the client it would otherwise set that deadline on.
+	clientOpts = append(clientOpts, client.WithTimeout(time.Duration(conf.RefreshInterval)))
 
 	d.client, err = client.New(clientOpts...)
 	if err != nil {

--- a/discovery/moby/dockerswarm.go
+++ b/discovery/moby/dockerswarm.go
@@ -160,7 +160,6 @@ func NewDiscovery(conf *DockerSwarmSDConfig, opts discovery.DiscovererOptions) (
 		clientOpts = append(clientOpts,
 			client.WithHTTPClient(&http.Client{
 				Transport: rt,
-				Timeout:   time.Duration(conf.RefreshInterval),
 			}),
 			client.WithScheme(hostURL.Scheme),
 			client.WithHTTPHeaders(map[string]string{
@@ -168,6 +167,11 @@ func NewDiscovery(conf *DockerSwarmSDConfig, opts discovery.DiscovererOptions) (
 			}),
 		)
 	}
+
+	// Set a deadline on whichever HTTP client is in use, so it is safe for the
+	// non-HTTP transports. It must be appended after WithHTTPClient, which
+	// replaces the client it would otherwise set that deadline on.
+	clientOpts = append(clientOpts, client.WithTimeout(time.Duration(conf.RefreshInterval)))
 
 	d.client, err = client.New(clientOpts...)
 	if err != nil {

--- a/discovery/moby/moby_test.go
+++ b/discovery/moby/moby_test.go
@@ -1,0 +1,209 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package moby
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/promslog"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
+
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+// The refresh interval doubles as the request timeout, so it is kept well
+// below the deadlines a refresh is measured against.
+const (
+	refreshInterval    = 100 * time.Millisecond
+	maxRefreshDuration = 2 * time.Second
+	hangDeadline       = 10 * time.Second
+)
+
+// refresher is implemented by both Docker and Docker Swarm discovery.
+type refresher interface {
+	refresh(ctx context.Context) ([]*targetgroup.Group, error)
+}
+
+// TestRefreshTimesOutOnUnresponsiveDaemon asserts that a Docker daemon which
+// accepts the connection but never answers cannot block discovery forever. The
+// http case also guards the option ordering the timeout relies on.
+func TestRefreshTimesOutOnUnresponsiveDaemon(t *testing.T) {
+	for _, host := range []struct {
+		name string
+		host func(t *testing.T) string
+	}{
+		{
+			name: "unix",
+			host: func(t *testing.T) string {
+				if runtime.GOOS == "windows" {
+					t.Skip("Docker is not reached over a unix socket on Windows.")
+				}
+				// The socket path must stay under the 104 byte cap on unix
+				// addresses, so it is not derived from this test's name.
+				dir, err := os.MkdirTemp("", "moby")
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, os.RemoveAll(dir)) })
+
+				return "unix://" + unresponsiveDaemon(t, "unix", filepath.Join(dir, "d.sock"))
+			},
+		},
+		{
+			name: "http",
+			host: func(t *testing.T) string {
+				return "http://" + unresponsiveDaemon(t, "tcp", "127.0.0.1:0")
+			},
+		},
+	} {
+		for _, sd := range []struct {
+			name         string
+			newDiscovery func(t *testing.T, host string) refresher
+		}{
+			{
+				name: "docker",
+				newDiscovery: func(t *testing.T, host string) refresher {
+					var cfg DockerSDConfig
+					require.NoError(t, yaml.Unmarshal(fmt.Appendf(nil, `
+---
+host: %s
+refresh_interval: %s
+`, host, refreshInterval), &cfg))
+
+					d, err := NewDockerDiscovery(&cfg, discovery.DiscovererOptions{
+						Logger:  promslog.NewNopLogger(),
+						Metrics: newDiscovererMetrics(t, &cfg),
+					})
+					require.NoError(t, err)
+					return d
+				},
+			},
+			{
+				name: "dockerswarm",
+				newDiscovery: func(t *testing.T, host string) refresher {
+					var cfg DockerSwarmSDConfig
+					require.NoError(t, yaml.Unmarshal(fmt.Appendf(nil, `
+---
+host: %s
+role: nodes
+refresh_interval: %s
+`, host, refreshInterval), &cfg))
+
+					d, err := NewDiscovery(&cfg, discovery.DiscovererOptions{
+						Logger:  promslog.NewNopLogger(),
+						Metrics: newDiscovererMetrics(t, &cfg),
+					})
+					require.NoError(t, err)
+					return d
+				},
+			},
+		} {
+			t.Run(sd.name+"/"+host.name, func(t *testing.T) {
+				d := sd.newDiscovery(t, host.host(t))
+
+				// The context deliberately carries no deadline, so that a
+				// refresh returning at all proves the client bounded it.
+				errCh := make(chan error, 1)
+				start := time.Now()
+				go func() {
+					_, err := d.refresh(context.Background())
+					errCh <- err
+				}()
+
+				select {
+				case err := <-errCh:
+					require.Error(t, err)
+					var netErr net.Error
+					require.ErrorAs(t, err, &netErr)
+					require.True(t, netErr.Timeout(), "expected a timeout error, got: %s", err)
+					require.Less(t, time.Since(start), maxRefreshDuration,
+						"refresh returned, but too late for the timeout to still be derived from refresh_interval")
+				case <-time.After(hangDeadline):
+					t.Fatal("refresh did not return: the Docker client has no request timeout on this transport")
+				}
+			})
+		}
+	}
+}
+
+// unresponsiveDaemon accepts connections on the given address without ever
+// writing to them, simulating a wedged Docker daemon, and returns the address
+// it listens on. Connections are held open until the test ends, so that a
+// client without a request timeout blocks rather than seeing the socket close.
+func unresponsiveDaemon(t *testing.T, network, address string) string {
+	t.Helper()
+
+	l, err := net.Listen(network, address)
+	require.NoError(t, err)
+
+	var (
+		mtx    sync.Mutex
+		conns  []net.Conn
+		closed bool
+	)
+	t.Cleanup(func() {
+		require.NoError(t, l.Close())
+		mtx.Lock()
+		defer mtx.Unlock()
+		closed = true
+		for _, c := range conns {
+			c.Close()
+		}
+	})
+
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			mtx.Lock()
+			// Accepting races with the cleanup, which must not leave a
+			// connection behind.
+			if closed {
+				c.Close()
+			} else {
+				conns = append(conns, c)
+			}
+			mtx.Unlock()
+		}
+	}()
+
+	if network == "unix" {
+		return address
+	}
+	return l.Addr().String()
+}
+
+func newDiscovererMetrics(t *testing.T, cfg discovery.Config) discovery.DiscovererMetrics {
+	t.Helper()
+
+	reg := prometheus.NewRegistry()
+	refreshMetrics := discovery.NewRefreshMetrics(reg)
+	metrics := cfg.NewDiscovererMetrics(reg, refreshMetrics)
+	require.NoError(t, metrics.Register())
+	t.Cleanup(metrics.Unregister)
+	t.Cleanup(refreshMetrics.Unregister)
+
+	return metrics
+}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #19236

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] Discovery: Bound Docker API requests on `unix`, `npipe` and `tcp` hosts, so an unresponsive daemon can no longer freeze `docker_sd` and `dockerswarm_sd` indefinitely.
```

---

### Problem

`NewDockerDiscovery` and the Docker Swarm equivalent only attach an `http.Client` carrying a timeout when the configured `host` scheme is `http` or `https`:

```go
if hostURL.Scheme == "http" || hostURL.Scheme == "https" {
	...
	client.WithHTTPClient(&http.Client{Transport: rt, Timeout: time.Duration(conf.RefreshInterval)}),
```

Every other scheme — `unix`, `npipe`, and also `tcp`, which `client.ParseHostURL` explicitly supports — skips that block and falls back to the Docker client's `defaultHTTPClient`, which sets no `http.Client.Timeout` at all. The transports behind those schemes do not make up for it: `go-connections`' `configureUnixTransport` and its `default` branch each install only a **dial** timeout, and `configureNpipeTransport` installs no timeout whatsoever.

`refresh.Discovery.Run` then calls `d.refresh(ctx)` synchronously with the long-lived discoverer context and no per-call deadline. So a daemon that accepts the connection but never answers blocks the refresh loop permanently. Discovery stays pinned to its last successful snapshot: removed targets are never reaped and new ones are never picked up, until Prometheus is restarted.

The failure is silent. A hang produces no error to log, and because `refresh()` never returns, even `prometheus_sd_refresh_duration_seconds` and `prometheus_sd_refresh_failures_total` stop moving — so a stuck discovery looks identical to an idle healthy one.

### Fix

Set the timeout with `client.WithTimeout` instead. It only assigns `Timeout` on whichever HTTP client is in use rather than replacing the client, so unlike the options in the conditional it is safe for the non-HTTP transports, and one line now covers every scheme.

It must be appended **after** `WithHTTPClient`, which swaps `c.client` wholesale and would otherwise discard the deadline. That ordering is load-bearing and easy to break in a later refactor, so the `http` case of the new test pins it: reordering the two options makes that case hang and fail.

`http`/`https` behaviour is unchanged — same value, same effective deadline, just derived in one place instead of two.

### Tests

`TestRefreshTimesOutOnUnresponsiveDaemon` starts a listener that accepts connections and never writes to them, then asserts a refresh returns a timeout error rather than blocking. It runs as a table across both discoveries and both the `unix` and `http` schemes.

Verified against this branch:

| Scenario | Result |
| --- | --- |
| With the fix | all 4 cases pass in ~0.3 s each |
| With the fix reverted | both `unix` cases hang and fail on the 10 s deadline |
| With `WithTimeout` moved before `WithHTTPClient` | both `http` cases hang and fail |

Also passes under `-race -count=3`, and under a long `TMPDIR` (the unix socket path is kept short so it stays clear of the 104-byte `sockaddr_un` limit on macOS).

### Notes for reviewers

- **Timeout value.** `refresh_interval` is reused as the request budget, which is what the `http`/`https` path has always done — this makes the other schemes consistent rather than introducing a new policy. Happy to switch to a separate setting if you would rather not overload it.
- **Scope.** `refresh_interval: 0` still means "no timeout" here, as it did before for `http`/`https`. That is a pre-existing, discovery-wide gap (only `triton` and `oci` validate positivity), so it seemed better left to its own change.
- **Not proven in the field.** I have not captured a goroutine dump of a wedged `ContainerList`, so I am claiming only what the code shows: on these schemes nothing bounds the response, and nothing bounds the refresh. A downstream consumer reports a matching symptom in [grafana/alloy#3054](https://github.com/grafana/alloy/issues/3054) (open, not reproducible on demand), but I am not asserting that is the same root cause.
