### PR TITLE
web/api: support POST for label values endpoint

### DIFF
--- a/docs/querying/api.md
+++ b/docs/querying/api.md
@@ -478,6 +478,7 @@ The following endpoint returns a list of label values for a provided label name:
 
 ```
 GET /api/v1/label/<label_name>/values
+POST /api/v1/label/<label_name>/values
 ```
 
 URL query parameters:
@@ -487,6 +488,10 @@ URL query parameters:
 - `match[]=<series_selector>`: Repeated series selector argument that selects the
   series from which to read the label values. Optional.
 - `limit=<number>`: Maximum number of returned series. Optional. 0 means disabled.
+
+You can URL-encode these parameters directly in the request body by using the `POST` method and
+`Content-Type: application/x-www-form-urlencoded` header. This is useful when specifying a large
+or dynamic number of series selectors that may breach server-side URL character limits.
 
 The `data` section of the JSON response is a list of string label values. Note
 that the `start` and `end` times are approximate and the result may contain

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -456,6 +456,7 @@ func (api *API) Register(r *route.Router) {
 	r.Get("/labels", wrapAgent(api.labelNames))
 	r.Post("/labels", wrapAgent(api.labelNames))
 	r.Get("/label/:name/values", wrapAgent(api.labelValues))
+	r.Post("/label/:name/values", wrapAgent(api.labelValues))
 
 	r.Get("/series", wrapAgent(api.series))
 	r.Post("/series", wrapAgent(api.series))
@@ -895,6 +896,9 @@ func (api *API) labelNames(r *http.Request) apiFuncResult {
 func (api *API) labelValues(r *http.Request) (result apiFuncResult) {
 	ctx := r.Context()
 	name := route.Param(ctx, "name")
+	if err := r.ParseForm(); err != nil {
+		return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("error parsing form values: %w", err)}, nil, nil}
+	}
 
 	if strings.HasPrefix(name, "U__") {
 		name = model.UnescapeName(name, model.ValueEncodingEscaping)

--- a/web/api/v1/api_scenarios_test.go
+++ b/web/api/v1/api_scenarios_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/web/api/testhelpers"
 )
@@ -139,6 +140,26 @@ func TestAPIEmpty(t *testing.T) {
 			ValidateOpenAPI().
 			RequireEquals("$.data.resultType", "vector")
 	})
+}
+
+func TestLabelValuesPOST(t *testing.T) {
+	store := promqltest.LoadedStorage(t, `
+		load 1m
+			up{job="prometheus"} 1
+			up{job="node"} 1
+	`)
+	t.Cleanup(func() { _ = store.Close() })
+
+	api := newTestAPI(t, testhelpers.APIConfig{
+		Queryable: testhelpers.NewLazyLoader(func() storage.SampleAndChunkQueryable {
+			return store
+		}),
+	})
+
+	testhelpers.POST(t, api, "/api/v1/label/job/values", "match[]", `{job="prometheus"}`).
+		RequireSuccess().
+		ValidateOpenAPI().
+		RequireEquals("$.data", []any{"prometheus"})
 }
 
 // TestAPIWithSeries tests the API with metrics/series data.

--- a/web/api/v1/openapi_examples.go
+++ b/web/api/v1/openapi_examples.go
@@ -163,6 +163,28 @@ func labelsPostExamples() *orderedmap.Map[string, *base.Example] {
 	return examples
 }
 
+// labelValuesPostExamples returns examples for POST /label/{name}/values endpoint.
+func labelValuesPostExamples() *orderedmap.Map[string, *base.Example] {
+	examples := orderedmap.New[string, *base.Example]()
+
+	examples.Set("valuesWithMatch", &base.Example{
+		Summary: "Get label values matching series selectors",
+		Value: createYAMLNode(map[string]any{
+			"match[]": []string{"up", "process_start_time_seconds{job=\"prometheus\"}"},
+		}),
+	})
+
+	examples.Set("valuesWithTimeRange", &base.Example{
+		Summary: "Get label values within time range",
+		Value: createYAMLNode(map[string]any{
+			"start": "2026-01-02T12:37:00.000Z",
+			"end":   "2026-01-02T13:37:00.000Z",
+		}),
+	})
+
+	return examples
+}
+
 // searchMetricNamesPostExamples returns examples for POST /search/metric_names endpoint.
 func searchMetricNamesPostExamples() *orderedmap.Map[string, *base.Example] {
 	examples := orderedmap.New[string, *base.Example]()

--- a/web/api/v1/openapi_paths.go
+++ b/web/api/v1/openapi_paths.go
@@ -196,6 +196,14 @@ func (*OpenAPIBuilder) labelValuesPath() *v3.PathItem {
 			Parameters:  params,
 			Responses:   responsesWithErrorExamples("LabelValuesOutputBody", labelValuesResponseExamples(), errorResponseExamples(), "Label values retrieved successfully.", "Error retrieving label values."),
 		},
+		Post: &v3.Operation{
+			OperationId: "label-values-post",
+			Summary:     "Get label values",
+			Tags:        []string{"labels"},
+			Parameters:  []*v3.Parameter{pathParam("name", "Label name.", stringSchema())},
+			RequestBody: formRequestBodyWithExamples("LabelValuesPostInputBody", labelValuesPostExamples(), "Submit a label values query. This endpoint accepts the same parameters as the GET version."),
+			Responses:   responsesWithErrorExamples("LabelValuesOutputBody", labelValuesResponseExamples(), errorResponseExamples(), "Label values retrieved successfully via POST.", "Error retrieving label values via POST."),
+		},
 	}
 }
 

--- a/web/api/v1/openapi_schemas.go
+++ b/web/api/v1/openapi_schemas.go
@@ -54,6 +54,7 @@ func (b *OpenAPIBuilder) buildComponents() *v3.Components {
 	schemas.Set("LabelsOutputBody", b.stringArrayResponseBodySchema())
 	schemas.Set("LabelsPostInputBody", b.labelsPostInputBodySchema())
 	schemas.Set("LabelValuesOutputBody", b.stringArrayResponseBodySchema())
+	schemas.Set("LabelValuesPostInputBody", b.labelValuesPostInputBodySchema())
 	schemas.Set("SearchMetricNamesPostInputBody", b.searchMetricNamesPostInputBodySchema())
 	schemas.Set("SearchLabelNamesPostInputBody", b.searchLabelNamesPostInputBodySchema())
 	schemas.Set("SearchLabelValuesPostInputBody", b.searchLabelValuesPostInputBodySchema())
@@ -732,6 +733,21 @@ func (*OpenAPIBuilder) labelsPostInputBodySchema() *base.SchemaProxy {
 	return base.CreateSchemaProxy(&base.Schema{
 		Type:                 []string{"object"},
 		Description:          "POST request body for labels query.",
+		AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{N: 1, B: false},
+		Properties:           props,
+	})
+}
+
+func (*OpenAPIBuilder) labelValuesPostInputBodySchema() *base.SchemaProxy {
+	props := orderedmap.New[string, *base.SchemaProxy]()
+	props.Set("start", stringSchemaWithDescriptionAndExample("Form field: The start time of the query.", "2023-07-21T20:00:00.000Z"))
+	props.Set("end", stringSchemaWithDescriptionAndExample("Form field: The end time of the query.", "2023-07-21T21:00:00.000Z"))
+	props.Set("match[]", stringArraySchemaWithDescriptionAndExample("Form field: Series selector argument that selects the series from which to read the label values.", []string{"{job=\"prometheus\"}"}))
+	props.Set("limit", integerSchemaWithDescriptionAndExample("Form field: The maximum number of label values to return.", 1000))
+
+	return base.CreateSchemaProxy(&base.Schema{
+		Type:                 []string{"object"},
+		Description:          "POST request body for label values query.",
 		AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{N: 1, B: false},
 		Properties:           props,
 	})

--- a/web/api/v1/testdata/openapi_3.1_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.1_golden.yaml
@@ -1044,6 +1044,71 @@ paths:
                                         error: TSDB not ready
                                         errorType: internal
                                         status: error
+        post:
+            tags:
+                - labels
+            summary: Get label values
+            operationId: label-values-post
+            parameters:
+                - name: name
+                  in: path
+                  description: Label name.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                description: Submit a label values query. This endpoint accepts the same parameters as the GET version.
+                content:
+                    application/x-www-form-urlencoded:
+                        schema:
+                            $ref: '#/components/schemas/LabelValuesPostInputBody'
+                        examples:
+                            valuesWithMatch:
+                                summary: Get label values matching series selectors
+                                value:
+                                    match[]:
+                                        - up
+                                        - process_start_time_seconds{job="prometheus"}
+                            valuesWithTimeRange:
+                                summary: Get label values within time range
+                                value:
+                                    end: "2026-01-02T13:37:00.000Z"
+                                    start: "2026-01-02T12:37:00.000Z"
+                required: true
+            responses:
+                "200":
+                    description: Label values retrieved successfully via POST.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LabelValuesOutputBody'
+                            examples:
+                                labelValues:
+                                    summary: List of values for a label
+                                    value:
+                                        data:
+                                            - alertmanager
+                                            - blackbox
+                                            - caddy
+                                            - cadvisor
+                                            - grafana
+                                            - node
+                                            - prometheus
+                                            - random
+                                        status: success
+                default:
+                    description: Error retrieving label values via POST.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                            examples:
+                                tsdbNotReady:
+                                    summary: TSDB not ready
+                                    value:
+                                        error: TSDB not ready
+                                        errorType: internal
+                                        status: error
     /search/metric_names:
         get:
             tags:
@@ -3993,6 +4058,31 @@ components:
                 - data
             additionalProperties: false
             description: Response body with an array of strings.
+        LabelValuesPostInputBody:
+            type: object
+            properties:
+                start:
+                    type: string
+                    description: 'Form field: The start time of the query.'
+                    example: "2023-07-21T20:00:00.000Z"
+                end:
+                    type: string
+                    description: 'Form field: The end time of the query.'
+                    example: "2023-07-21T21:00:00.000Z"
+                match[]:
+                    type: array
+                    items:
+                        type: string
+                    description: 'Form field: Series selector argument that selects the series from which to read the label values.'
+                    example:
+                        - '{job="prometheus"}'
+                limit:
+                    type: integer
+                    format: int64
+                    description: 'Form field: The maximum number of label values to return.'
+                    example: 1000
+            additionalProperties: false
+            description: POST request body for label values query.
         SearchMetricNamesPostInputBody:
             type: object
             properties:

--- a/web/api/v1/testdata/openapi_3.2_golden.yaml
+++ b/web/api/v1/testdata/openapi_3.2_golden.yaml
@@ -1044,6 +1044,71 @@ paths:
                                         error: TSDB not ready
                                         errorType: internal
                                         status: error
+        post:
+            tags:
+                - labels
+            summary: Get label values
+            operationId: label-values-post
+            parameters:
+                - name: name
+                  in: path
+                  description: Label name.
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                description: Submit a label values query. This endpoint accepts the same parameters as the GET version.
+                content:
+                    application/x-www-form-urlencoded:
+                        schema:
+                            $ref: '#/components/schemas/LabelValuesPostInputBody'
+                        examples:
+                            valuesWithMatch:
+                                summary: Get label values matching series selectors
+                                value:
+                                    match[]:
+                                        - up
+                                        - process_start_time_seconds{job="prometheus"}
+                            valuesWithTimeRange:
+                                summary: Get label values within time range
+                                value:
+                                    end: "2026-01-02T13:37:00.000Z"
+                                    start: "2026-01-02T12:37:00.000Z"
+                required: true
+            responses:
+                "200":
+                    description: Label values retrieved successfully via POST.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LabelValuesOutputBody'
+                            examples:
+                                labelValues:
+                                    summary: List of values for a label
+                                    value:
+                                        data:
+                                            - alertmanager
+                                            - blackbox
+                                            - caddy
+                                            - cadvisor
+                                            - grafana
+                                            - node
+                                            - prometheus
+                                            - random
+                                        status: success
+                default:
+                    description: Error retrieving label values via POST.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                            examples:
+                                tsdbNotReady:
+                                    summary: TSDB not ready
+                                    value:
+                                        error: TSDB not ready
+                                        errorType: internal
+                                        status: error
     /search/metric_names:
         get:
             tags:
@@ -4031,6 +4096,31 @@ components:
                 - data
             additionalProperties: false
             description: Response body with an array of strings.
+        LabelValuesPostInputBody:
+            type: object
+            properties:
+                start:
+                    type: string
+                    description: 'Form field: The start time of the query.'
+                    example: "2023-07-21T20:00:00.000Z"
+                end:
+                    type: string
+                    description: 'Form field: The end time of the query.'
+                    example: "2023-07-21T21:00:00.000Z"
+                match[]:
+                    type: array
+                    items:
+                        type: string
+                    description: 'Form field: Series selector argument that selects the series from which to read the label values.'
+                    example:
+                        - '{job="prometheus"}'
+                limit:
+                    type: integer
+                    format: int64
+                    description: 'Form field: The maximum number of label values to return.'
+                    example: 1000
+            additionalProperties: false
+            description: POST request body for label values query.
         SearchMetricNamesPostInputBody:
             type: object
             properties:


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #19172

#### What does this PR do?

Adds POST support to `/api/v1/label/<label_name>/values`.

POST requests accept `start`, `end`, `match[]`, and `limit` as `application/x-www-form-urlencoded` form data. This allows clients to submit large or numerous series selectors without exceeding URL length limits.

The change also updates the OpenAPI specification and API documentation.

#### Tests

- `go test ./web/api/... -count=1`
- `go test ./web/... -count=1`
- `git diff --check`

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[ENHANCEMENT] API: Support POST requests for the label values endpoint.