### PR TITLE
tsdb: restore memSeries state from mmapped chunks

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1081,7 +1081,52 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 		// secondLastRef because the lastRef caused an error.
 		return nil, nil, secondLastRef, fmt.Errorf("iterate on-disk chunks: %w", err)
 	}
+	for _, ms := range refSeries {
+		// A snapshot may contain an in-memory head chunk newer than the chunks
+		// loaded above. In that case its cached state is still authoritative.
+		if ms.headChunks == nil && len(ms.mmappedChunks) > 0 {
+			if err := h.restoreSeriesStateFromMmappedChunks(ms); err != nil {
+				return nil, nil, secondLastRef, err
+			}
+		}
+	}
 	return mmappedChunks, oooMmappedChunks, lastRef, nil
+}
+
+// restoreSeriesStateFromMmappedChunks restores the cached state that is not
+// persisted in the WAL when samples are already covered by an m-mapped chunk.
+func (h *Head) restoreSeriesStateFromMmappedChunks(s *memSeries) error {
+	wasStale, wasHistogram, oldBuckets := s.sampleState()
+	s.lastValue = 0
+	s.lastHistogramValue = nil
+	s.lastFloatHistogramValue = nil
+
+	if len(s.mmappedChunks) > 0 {
+		lastChunk := s.mmappedChunks[len(s.mmappedChunks)-1]
+		chunk, err := h.chunkDiskMapper.Chunk(lastChunk.ref)
+		if err != nil {
+			return fmt.Errorf("load last m-mapped chunk for series ref %d: %w", s.ref, err)
+		}
+		it := chunk.Iterator(nil)
+		switch typ := it.Seek(lastChunk.maxTime); typ {
+		case chunkenc.ValFloat:
+			_, s.lastValue = it.At()
+		case chunkenc.ValHistogram:
+			_, s.lastHistogramValue = it.AtHistogram(nil)
+		case chunkenc.ValFloatHistogram:
+			_, s.lastFloatHistogramValue = it.AtFloatHistogram(nil)
+		default:
+			if err := it.Err(); err != nil {
+				return fmt.Errorf("iterate last m-mapped chunk for series ref %d: %w", s.ref, err)
+			}
+			return fmt.Errorf("last m-mapped chunk for series ref %d has no sample at %d", s.ref, lastChunk.maxTime)
+		}
+	}
+
+	isStale, isHistogram, newBuckets := s.sampleState()
+	h.updateStaleSeriesMetricOnAppend(wasStale, isStale)
+	h.updateNativeHistogramMetricsOnAppend(wasHistogram, isHistogram, oldBuckets, newBuckets)
+	return nil
 }
 
 // removeCorruptedMmappedChunks attempts to delete the corrupted mmapped chunks and if it fails, it clears all the previously

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1086,7 +1086,7 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 		// restored after mmap replay attaches the on-disk chunks.
 		if ms.headChunks == nil && len(ms.mmappedChunks) > 0 {
 			if err := h.restoreSeriesStateFromMmappedChunks(ms); err != nil {
-				h.logger.Warn("Failed to restore series state from m-mapped chunks", "seriesRef", ms.ref, "err", err)
+				return nil, nil, secondLastRef, err
 			}
 		}
 	}
@@ -1130,6 +1130,18 @@ func (h *Head) restoreSeriesStateFromMmappedChunks(s *memSeries) error {
 	h.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 	h.updateNativeHistogramMetricsOnAppend(wasHistogram, isHistogram, oldBuckets, newBuckets)
 	return restoreErr
+}
+
+// discardMmappedChunks removes chunks that cannot be decoded from the series
+// so WAL replay can append their samples instead of skipping them via mmMaxTime.
+func (h *Head) discardMmappedChunks(s *memSeries) {
+	if len(s.mmappedChunks) == 0 {
+		return
+	}
+	h.metrics.chunksRemoved.Add(float64(len(s.mmappedChunks)))
+	h.metrics.chunks.Sub(float64(len(s.mmappedChunks)))
+	s.mmappedChunks = nil
+	s.mmMaxTime = math.MinInt64
 }
 
 // removeCorruptedMmappedChunks attempts to delete the corrupted mmapped chunks and if it fails, it clears all the previously

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -1082,11 +1082,11 @@ func (h *Head) loadMmappedChunks(refSeries map[chunks.HeadSeriesRef]*memSeries) 
 		return nil, nil, secondLastRef, fmt.Errorf("iterate on-disk chunks: %w", err)
 	}
 	for _, ms := range refSeries {
-		// A snapshot may contain an in-memory head chunk newer than the chunks
-		// loaded above. In that case its cached state is still authoritative.
+		// Snapshot records without an in-memory head chunk need their cached state
+		// restored after mmap replay attaches the on-disk chunks.
 		if ms.headChunks == nil && len(ms.mmappedChunks) > 0 {
 			if err := h.restoreSeriesStateFromMmappedChunks(ms); err != nil {
-				return nil, nil, secondLastRef, err
+				h.logger.Warn("Failed to restore series state from m-mapped chunks", "seriesRef", ms.ref, "err", err)
 			}
 		}
 	}
@@ -1100,33 +1100,36 @@ func (h *Head) restoreSeriesStateFromMmappedChunks(s *memSeries) error {
 	s.lastValue = 0
 	s.lastHistogramValue = nil
 	s.lastFloatHistogramValue = nil
+	var restoreErr error
 
 	if len(s.mmappedChunks) > 0 {
 		lastChunk := s.mmappedChunks[len(s.mmappedChunks)-1]
 		chunk, err := h.chunkDiskMapper.Chunk(lastChunk.ref)
 		if err != nil {
-			return fmt.Errorf("load last m-mapped chunk for series ref %d: %w", s.ref, err)
-		}
-		it := chunk.Iterator(nil)
-		switch typ := it.Seek(lastChunk.maxTime); typ {
-		case chunkenc.ValFloat:
-			_, s.lastValue = it.At()
-		case chunkenc.ValHistogram:
-			_, s.lastHistogramValue = it.AtHistogram(nil)
-		case chunkenc.ValFloatHistogram:
-			_, s.lastFloatHistogramValue = it.AtFloatHistogram(nil)
-		default:
-			if err := it.Err(); err != nil {
-				return fmt.Errorf("iterate last m-mapped chunk for series ref %d: %w", s.ref, err)
+			restoreErr = fmt.Errorf("load last m-mapped chunk for series ref %d: %w", s.ref, err)
+		} else {
+			it := chunk.Iterator(nil)
+			switch typ := it.Seek(lastChunk.maxTime); typ {
+			case chunkenc.ValFloat:
+				_, s.lastValue = it.At()
+			case chunkenc.ValHistogram:
+				_, s.lastHistogramValue = it.AtHistogram(nil)
+			case chunkenc.ValFloatHistogram:
+				_, s.lastFloatHistogramValue = it.AtFloatHistogram(nil)
+			default:
+				if err := it.Err(); err != nil {
+					restoreErr = fmt.Errorf("iterate last m-mapped chunk for series ref %d: %w", s.ref, err)
+				} else {
+					restoreErr = fmt.Errorf("last m-mapped chunk for series ref %d has no sample at %d", s.ref, lastChunk.maxTime)
+				}
 			}
-			return fmt.Errorf("last m-mapped chunk for series ref %d has no sample at %d", s.ref, lastChunk.maxTime)
 		}
 	}
 
 	isStale, isHistogram, newBuckets := s.sampleState()
 	h.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 	h.updateNativeHistogramMetricsOnAppend(wasHistogram, isHistogram, oldBuckets, newBuckets)
-	return nil
+	return restoreErr
 }
 
 // removeCorruptedMmappedChunks attempts to delete the corrupted mmapped chunks and if it fails, it clears all the previously

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -8260,6 +8260,79 @@ func TestHead_WALReplayStaleMarkerTypeConsistency(t *testing.T) {
 	}
 }
 
+func TestHead_MmappedChunkRestoresSeriesState(t *testing.T) {
+	tests := map[string]struct {
+		appendSamples func(*Head, labels.Labels)
+		wantStale     uint64
+		wantHist      uint64
+		wantBuckets   uint64
+	}{
+		"stale float": {
+			appendSamples: func(head *Head, lbls labels.Labels) {
+				app := head.Appender(context.Background())
+				_, err := app.Append(0, lbls, 100, 1)
+				require.NoError(t, err)
+				require.NoError(t, app.Commit())
+
+				app = head.Appender(context.Background())
+				_, err = app.Append(0, lbls, 200, math.Float64frombits(value.StaleNaN))
+				require.NoError(t, err)
+				require.NoError(t, app.Commit())
+			},
+			wantStale: 1,
+		},
+		"integer histogram": {
+			appendSamples: func(head *Head, lbls labels.Labels) {
+				app := head.Appender(context.Background())
+				_, err := app.AppendHistogram(0, lbls, 100, tsdbutil.GenerateTestHistogram(1), nil)
+				require.NoError(t, err)
+				require.NoError(t, app.Commit())
+			},
+			wantHist:    1,
+			wantBuckets: 8,
+		},
+		"float histogram": {
+			appendSamples: func(head *Head, lbls labels.Labels) {
+				app := head.Appender(context.Background())
+				_, err := app.AppendHistogram(0, lbls, 100, nil, tsdbutil.GenerateTestFloatHistogram(1))
+				require.NoError(t, err)
+				require.NoError(t, app.Commit())
+			},
+			wantHist:    1,
+			wantBuckets: 8,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := newTestHeadDefaultOptions(1000, false)
+			head, _ := newTestHeadWithOptions(t, compression.None, opts)
+			t.Cleanup(func() { _ = head.Close() })
+			require.NoError(t, head.Init(0))
+
+			lbls := labels.FromStrings("name", name)
+			tc.appendSamples(head, lbls)
+			require.Equal(t, tc.wantStale, head.NumStaleSeries())
+			require.Equal(t, tc.wantHist, head.NumNativeHistogramSeries())
+			require.Equal(t, tc.wantBuckets, head.NumNativeHistogramBuckets())
+
+			// Force the latest sample into an m-mapped chunk. WAL replay skips
+			// samples covered by this chunk, so startup must restore its state.
+			require.NoError(t, head.truncateMemory(300))
+			require.NoError(t, head.Close())
+
+			wal, err := wlog.NewSize(nil, nil, filepath.Join(opts.ChunkDirRoot, "wal"), 32768, compression.None)
+			require.NoError(t, err)
+			head, err = NewHead(nil, nil, wal, nil, opts, nil)
+			require.NoError(t, err)
+			require.NoError(t, head.Init(0))
+			require.Equal(t, tc.wantStale, head.NumStaleSeries())
+			require.Equal(t, tc.wantHist, head.NumNativeHistogramSeries())
+			require.Equal(t, tc.wantBuckets, head.NumNativeHistogramBuckets())
+		})
+	}
+}
+
 func TestHead_NumNativeHistogramSeriesAndBuckets(t *testing.T) {
 	head, _ := newTestHead(t, 1000, compression.None, false)
 	t.Cleanup(func() {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -8263,6 +8263,7 @@ func TestHead_WALReplayStaleMarkerTypeConsistency(t *testing.T) {
 func TestHead_MmappedChunkRestoresSeriesState(t *testing.T) {
 	tests := map[string]struct {
 		appendSamples func(*Head, labels.Labels)
+		snapshot      bool
 		wantStale     uint64
 		wantHist      uint64
 		wantBuckets   uint64
@@ -8301,6 +8302,16 @@ func TestHead_MmappedChunkRestoresSeriesState(t *testing.T) {
 			wantHist:    1,
 			wantBuckets: 8,
 		},
+		"stale float from snapshot": {
+			appendSamples: func(head *Head, lbls labels.Labels) {
+				app := head.Appender(context.Background())
+				_, err := app.Append(0, lbls, 100, math.Float64frombits(value.StaleNaN))
+				require.NoError(t, err)
+				require.NoError(t, app.Commit())
+			},
+			snapshot:  true,
+			wantStale: 1,
+		},
 	}
 
 	for name, tc := range tests {
@@ -8309,6 +8320,7 @@ func TestHead_MmappedChunkRestoresSeriesState(t *testing.T) {
 			head, _ := newTestHeadWithOptions(t, compression.None, opts)
 			t.Cleanup(func() { _ = head.Close() })
 			require.NoError(t, head.Init(0))
+			head.opts.EnableMemorySnapshotOnShutdown = tc.snapshot
 
 			lbls := labels.FromStrings("name", name)
 			tc.appendSamples(head, lbls)
@@ -8316,9 +8328,26 @@ func TestHead_MmappedChunkRestoresSeriesState(t *testing.T) {
 			require.Equal(t, tc.wantHist, head.NumNativeHistogramSeries())
 			require.Equal(t, tc.wantBuckets, head.NumNativeHistogramBuckets())
 
-			// Force the latest sample into an m-mapped chunk. WAL replay skips
-			// samples covered by this chunk, so startup must restore its state.
-			require.NoError(t, head.truncateMemory(300))
+			// Put the only chunk on disk and remove the in-memory copy. This models
+			// a head whose latest sample is covered by an m-mapped chunk, so WAL
+			// replay skips it and startup must restore its cached state.
+			series, created, err := head.getOrCreate(lbls.Hash(), lbls, false)
+			require.NoError(t, err)
+			require.False(t, created)
+			series.Lock()
+			require.NotNil(t, series.headChunks)
+			chunk := series.headChunks
+			chunkRef := head.chunkDiskMapper.WriteChunk(series.ref, chunk.minTime, chunk.maxTime, chunk.chunk, false, handleChunkWriteError)
+			series.mmappedChunks = append(series.mmappedChunks, &mmappedChunk{
+				ref:        chunkRef,
+				minTime:    chunk.minTime,
+				maxTime:    chunk.maxTime,
+				numSamples: uint16(chunk.chunk.NumSamples()),
+				encoding:   chunk.chunk.Encoding(),
+			})
+			series.setHeadChunks(nil, 0)
+			series.app = nil
+			series.Unlock()
 			require.NoError(t, head.Close())
 
 			wal, err := wlog.NewSize(nil, nil, filepath.Join(opts.ChunkDirRoot, "wal"), 32768, compression.None)
@@ -8331,6 +8360,42 @@ func TestHead_MmappedChunkRestoresSeriesState(t *testing.T) {
 			require.Equal(t, tc.wantBuckets, head.NumNativeHistogramBuckets())
 		})
 	}
+}
+
+func TestHead_MmappedChunkRestoreFailureReplaysWALSamples(t *testing.T) {
+	head, _ := newTestHead(t, 1000, compression.None, false)
+	require.NoError(t, head.Init(0))
+
+	lset := labels.FromStrings("name", "corrupt-mmap")
+	series, created, err := head.getOrCreate(lset.Hash(), lset, false)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	// Use a reference to a chunk file that does not exist. The restore path must
+	// discard it so replay does not treat its header's max time as authoritative.
+	mmapped := map[chunks.HeadSeriesRef][]*mmappedChunk{
+		series.ref: {{
+			ref:      chunks.ChunkDiskMapperRef(1 << 32),
+			minTime:  100,
+			maxTime:  100,
+			encoding: chunkenc.EncXOR,
+		}},
+	}
+	processor := walSubsetProcessor{}
+	processor.setup()
+	processor.input <- walSubsetProcessorInputItem{existingSeries: series, walSeriesRef: series.ref}
+	processor.input <- walSubsetProcessorInputItem{samples: []record.RefSample{{Ref: series.ref, T: 100, V: 42}}}
+	close(processor.input)
+
+	missing, unknownSamples, unknownHistograms, overlapping := processor.processWALSamples(head, mmapped, nil)
+	require.Empty(t, missing)
+	require.Zero(t, unknownSamples)
+	require.Zero(t, unknownHistograms)
+	require.Zero(t, overlapping)
+	require.Empty(t, series.mmappedChunks)
+	require.Equal(t, int64(math.MinInt64), series.mmMaxTime)
+	require.Equal(t, uint32(1), series.headChunkCount.Load())
+	require.Equal(t, float64(42), series.lastValue)
 }
 
 func TestHead_NumNativeHistogramSeriesAndBuckets(t *testing.T) {

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -101,6 +101,7 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		histogramShards = make([][]histogramRecord, concurrency)
 
 		decoded                      = make(chan any, 10)
+		processErrChan               = make(chan error, concurrency)
 		decodeErr, seriesCreationErr error
 	)
 
@@ -121,11 +122,14 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		processors[i].setup()
 
 		go func(wp *walSubsetProcessor) {
-			missingSeries, unknownSamples, unknownHistograms, overlapping := wp.processWALSamples(h, mmappedChunks, oooMmappedChunks)
+			missingSeries, unknownSamples, unknownHistograms, overlapping, processErr := wp.processWALSamples(h, mmappedChunks, oooMmappedChunks)
 			unknownSeriesRefs.merge(missingSeries)
 			unknownSampleRefs.Add(unknownSamples)
 			mmapOverlappingChunks.Add(overlapping)
 			unknownHistogramRefs.Add(unknownHistograms)
+			if processErr != nil {
+				processErrChan <- processErr
+			}
 			wg.Done()
 		}(&processors[i])
 	}
@@ -494,6 +498,11 @@ Outer:
 	}
 	close(exemplarsInput)
 	wg.Wait()
+	select {
+	case err := <-processErrChan:
+		return err
+	default:
+	}
 
 	if err := r.Err(); err != nil {
 		return fmt.Errorf("read records: %w", err)
@@ -524,7 +533,7 @@ Outer:
 }
 
 // resetSeriesWithMMappedChunks is only used during the WAL replay.
-func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*mmappedChunk, walSeriesRef chunks.HeadSeriesRef) (overlapped bool) {
+func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*mmappedChunk, walSeriesRef chunks.HeadSeriesRef) (overlapped bool, err error) {
 	if mSeries.ref != walSeriesRef {
 		// Checking if the new m-mapped chunks overlap with the already existing ones.
 		if len(mSeries.mmappedChunks) > 0 && len(mmc) > 0 {
@@ -595,7 +604,7 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 	}
 	mSeries.setHeadChunks(nil, 0)
 	mSeries.app = nil
-	return overlapped
+	return overlapped, h.restoreSeriesStateFromMmappedChunks(mSeries)
 }
 
 type walSubsetProcessor struct {
@@ -771,7 +780,7 @@ func (h *Head) appendWALHistogram(ms *memSeries, st, t int64, hist *histogram.Hi
 // processWALSamples adds the samples it receives to the head and passes
 // the buffer received to an output channel for reuse.
 // Samples before the minValidTime timestamp are discarded.
-func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmappedChunks map[chunks.HeadSeriesRef][]*mmappedChunk) (map[chunks.HeadSeriesRef]struct{}, uint64, uint64, uint64) {
+func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmappedChunks map[chunks.HeadSeriesRef][]*mmappedChunk) (map[chunks.HeadSeriesRef]struct{}, uint64, uint64, uint64, error) {
 	defer close(wp.output)
 	defer close(wp.histogramsOutput)
 
@@ -797,7 +806,11 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 		if in.existingSeries != nil {
 			mmc := mmappedChunks[in.walSeriesRef]
 			oooMmc := oooMmappedChunks[in.walSeriesRef]
-			if h.resetSeriesWithMMappedChunks(in.existingSeries, mmc, oooMmc, in.walSeriesRef) {
+			overlapped, err := h.resetSeriesWithMMappedChunks(in.existingSeries, mmc, oooMmc, in.walSeriesRef)
+			if err != nil {
+				return missingSeries, unknownSampleRefs, unknownHistogramRefs, mmapOverlappingChunks, err
+			}
+			if overlapped {
 				mmapOverlappingChunks++
 			}
 			continue
@@ -864,7 +877,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 	}
 	h.updateMinMaxTime(mint, maxt)
 
-	return missingSeries, unknownSampleRefs, unknownHistogramRefs, mmapOverlappingChunks
+	return missingSeries, unknownSampleRefs, unknownHistogramRefs, mmapOverlappingChunks, nil
 }
 
 func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, lastMmapRef chunks.ChunkDiskMapperRef) (err error) {

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -598,6 +598,7 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 	// the mmap chunk payload is unreadable.
 	if err := h.restoreSeriesStateFromMmappedChunks(mSeries); err != nil {
 		h.logger.Warn("Failed to restore series state from m-mapped chunks", "seriesRef", mSeries.ref, "err", err)
+		h.discardMmappedChunks(mSeries)
 	}
 	return overlapped
 }

--- a/tsdb/head_wal.go
+++ b/tsdb/head_wal.go
@@ -101,7 +101,6 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		histogramShards = make([][]histogramRecord, concurrency)
 
 		decoded                      = make(chan any, 10)
-		processErrChan               = make(chan error, concurrency)
 		decodeErr, seriesCreationErr error
 	)
 
@@ -122,14 +121,11 @@ func (h *Head) loadWAL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[ch
 		processors[i].setup()
 
 		go func(wp *walSubsetProcessor) {
-			missingSeries, unknownSamples, unknownHistograms, overlapping, processErr := wp.processWALSamples(h, mmappedChunks, oooMmappedChunks)
+			missingSeries, unknownSamples, unknownHistograms, overlapping := wp.processWALSamples(h, mmappedChunks, oooMmappedChunks)
 			unknownSeriesRefs.merge(missingSeries)
 			unknownSampleRefs.Add(unknownSamples)
 			mmapOverlappingChunks.Add(overlapping)
 			unknownHistogramRefs.Add(unknownHistograms)
-			if processErr != nil {
-				processErrChan <- processErr
-			}
 			wg.Done()
 		}(&processors[i])
 	}
@@ -498,12 +494,6 @@ Outer:
 	}
 	close(exemplarsInput)
 	wg.Wait()
-	select {
-	case err := <-processErrChan:
-		return err
-	default:
-	}
-
 	if err := r.Err(); err != nil {
 		return fmt.Errorf("read records: %w", err)
 	}
@@ -533,7 +523,7 @@ Outer:
 }
 
 // resetSeriesWithMMappedChunks is only used during the WAL replay.
-func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*mmappedChunk, walSeriesRef chunks.HeadSeriesRef) (overlapped bool, err error) {
+func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*mmappedChunk, walSeriesRef chunks.HeadSeriesRef) (overlapped bool) {
 	if mSeries.ref != walSeriesRef {
 		// Checking if the new m-mapped chunks overlap with the already existing ones.
 		if len(mSeries.mmappedChunks) > 0 && len(mmc) > 0 {
@@ -604,7 +594,12 @@ func (h *Head) resetSeriesWithMMappedChunks(mSeries *memSeries, mmc, oooMmc []*m
 	}
 	mSeries.setHeadChunks(nil, 0)
 	mSeries.app = nil
-	return overlapped, h.restoreSeriesStateFromMmappedChunks(mSeries)
+	// State restoration is best-effort because WAL replay can recover samples if
+	// the mmap chunk payload is unreadable.
+	if err := h.restoreSeriesStateFromMmappedChunks(mSeries); err != nil {
+		h.logger.Warn("Failed to restore series state from m-mapped chunks", "seriesRef", mSeries.ref, "err", err)
+	}
+	return overlapped
 }
 
 type walSubsetProcessor struct {
@@ -780,7 +775,7 @@ func (h *Head) appendWALHistogram(ms *memSeries, st, t int64, hist *histogram.Hi
 // processWALSamples adds the samples it receives to the head and passes
 // the buffer received to an output channel for reuse.
 // Samples before the minValidTime timestamp are discarded.
-func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmappedChunks map[chunks.HeadSeriesRef][]*mmappedChunk) (map[chunks.HeadSeriesRef]struct{}, uint64, uint64, uint64, error) {
+func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmappedChunks map[chunks.HeadSeriesRef][]*mmappedChunk) (map[chunks.HeadSeriesRef]struct{}, uint64, uint64, uint64) {
 	defer close(wp.output)
 	defer close(wp.histogramsOutput)
 
@@ -806,10 +801,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 		if in.existingSeries != nil {
 			mmc := mmappedChunks[in.walSeriesRef]
 			oooMmc := oooMmappedChunks[in.walSeriesRef]
-			overlapped, err := h.resetSeriesWithMMappedChunks(in.existingSeries, mmc, oooMmc, in.walSeriesRef)
-			if err != nil {
-				return missingSeries, unknownSampleRefs, unknownHistogramRefs, mmapOverlappingChunks, err
-			}
+			overlapped := h.resetSeriesWithMMappedChunks(in.existingSeries, mmc, oooMmc, in.walSeriesRef)
 			if overlapped {
 				mmapOverlappingChunks++
 			}
@@ -877,7 +869,7 @@ func (wp *walSubsetProcessor) processWALSamples(h *Head, mmappedChunks, oooMmapp
 	}
 	h.updateMinMaxTime(mint, maxt)
 
-	return missingSeries, unknownSampleRefs, unknownHistogramRefs, mmapOverlappingChunks, nil
+	return missingSeries, unknownSampleRefs, unknownHistogramRefs, mmapOverlappingChunks
 }
 
 func (h *Head) loadWBL(r *wlog.Reader, syms *labels.SymbolTable, multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef, lastMmapRef chunks.ChunkDiskMapperRef) (err error) {


### PR DESCRIPTION
## What does this PR do?

Restores the cached last-value state for series whose newest in-order samples are already in memory-mapped head chunks. WAL replay intentionally skips those samples, so startup previously lost stale-series and native-histogram state.

The startup path now decodes the final sample of the newest memory-mapped chunk and updates the stale and native-histogram counters. The regression tests cover stale floats and integer/float histograms through WAL replay, plus a snapshot-loaded series with no in-memory head chunk.

Mmap state restoration is best-effort during WAL replay. If a chunk payload cannot be decoded, the affected mmap chunks are removed from the in-memory series and `mmMaxTime` is reset so WAL replay can recover their samples instead of skipping them. If restoration fails for a loaded memory snapshot, the error goes through the existing mmap-corruption recovery path, which discards the snapshot/chunks and replays the WAL. This also avoids stopping a WAL worker before it drains its input channel.

The additional startup work is one chunk read and a seek through the newest mmap chunk for each affected series. It is limited to startup and is required to recover the sample type and staleness state when WAL replay skips those samples.

## Testing

- `go test ./tsdb -run '^TestHead_(MmappedChunkRestoresSeriesState|MmappedChunkRestoreFailureReplaysWALSamples|NumStaleSeries|NumNativeHistogramSeriesAndBuckets)$' -count=1`
- `go test ./tsdb -count=1`
- `git diff --check`

```release-notes
[BUGFIX] TSDB: Restore cached series state from memory-mapped head chunks after restart.
```

Fixes #19239
