### PR TITLE
remote_write: fix orphaned exemplars when native histograms are disabled

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -64,6 +64,7 @@ const (
 	reasonDroppedSeries              = "dropped_series"
 	reasonUnintentionalDroppedSeries = "unintentionally_dropped_series"
 	reasonNHCBNotSupported           = "nhcb_in_rw1_not_supported"
+	reasonNativeHistogramNotSent     = "native_histogram_not_sent"
 )
 
 type queueManagerMetrics struct {
@@ -441,11 +442,12 @@ type QueueManager struct {
 	protoMsg    remoteapi.WriteMessageType
 	compr       compression.Type
 
-	seriesMtx      sync.Mutex // Covers seriesLabels, seriesMetadata, droppedSeries and builder.
-	seriesLabels   map[chunks.HeadSeriesRef]labels.Labels
-	seriesMetadata map[chunks.HeadSeriesRef]*metadata.Metadata
-	droppedSeries  map[chunks.HeadSeriesRef]struct{}
-	builder        *labels.Builder
+	seriesMtx         sync.Mutex // Covers seriesLabels, seriesMetadata, seriesIsHistogram, droppedSeries and builder.
+	seriesLabels      map[chunks.HeadSeriesRef]labels.Labels
+	seriesMetadata    map[chunks.HeadSeriesRef]*metadata.Metadata
+	seriesIsHistogram map[chunks.HeadSeriesRef]struct{}
+	droppedSeries     map[chunks.HeadSeriesRef]struct{}
+	builder           *labels.Builder
 
 	seriesSegmentMtx     sync.Mutex // Covers seriesSegmentIndexes - if you also lock seriesMtx, take seriesMtx first.
 	seriesSegmentIndexes map[chunks.HeadSeriesRef]int
@@ -515,6 +517,7 @@ func NewQueueManager(
 
 		seriesLabels:         make(map[chunks.HeadSeriesRef]labels.Labels),
 		seriesMetadata:       make(map[chunks.HeadSeriesRef]*metadata.Metadata),
+		seriesIsHistogram:    make(map[chunks.HeadSeriesRef]struct{}),
 		seriesSegmentIndexes: make(map[chunks.HeadSeriesRef]int),
 		droppedSeries:        make(map[chunks.HeadSeriesRef]struct{}),
 		builder:              labels.NewBuilder(labels.EmptyLabels()),
@@ -745,6 +748,10 @@ outer:
 			t.seriesMtx.Unlock()
 			continue
 		}
+		if !t.sendNativeHistograms {
+			// Series is receiving float samples now, so stop treating it as a histogram series.
+			delete(t.seriesIsHistogram, s.Ref)
+		}
 		// TODO(cstyan): Handle or at least log an error if no metadata is found.
 		// See https://github.com/prometheus/prometheus/issues/14405
 		meta := t.seriesMetadata[s.Ref]
@@ -809,6 +816,14 @@ outer:
 			t.seriesMtx.Unlock()
 			continue
 		}
+		if !t.sendNativeHistograms {
+			if _, ok := t.seriesIsHistogram[e.Ref]; ok {
+				// Drop exemplars for native histogram series we're not sending.
+				t.metrics.droppedExemplarsTotal.WithLabelValues(reasonNativeHistogramNotSent).Inc()
+				t.seriesMtx.Unlock()
+				continue
+			}
+		}
 		meta := t.seriesMetadata[e.Ref]
 		t.seriesMtx.Unlock()
 		// This will only loop if the queues are being resharded.
@@ -843,6 +858,14 @@ outer:
 
 func (t *QueueManager) AppendHistograms(histograms []record.RefHistogramSample) bool {
 	if !t.sendNativeHistograms {
+		if t.sendExemplars {
+			// Mark these as histogram series so AppendExemplars can drop their exemplars.
+			t.seriesMtx.Lock()
+			for _, h := range histograms {
+				t.seriesIsHistogram[h.Ref] = struct{}{}
+			}
+			t.seriesMtx.Unlock()
+		}
 		return true
 	}
 	currentTime := time.Now()
@@ -905,6 +928,14 @@ outer:
 
 func (t *QueueManager) AppendFloatHistograms(floatHistograms []record.RefFloatHistogramSample) bool {
 	if !t.sendNativeHistograms {
+		if t.sendExemplars {
+			// Mark these as histogram series so AppendExemplars can drop their exemplars.
+			t.seriesMtx.Lock()
+			for _, h := range floatHistograms {
+				t.seriesIsHistogram[h.Ref] = struct{}{}
+			}
+			t.seriesMtx.Unlock()
+		}
 		return true
 	}
 	currentTime := time.Now()
@@ -1066,12 +1097,14 @@ func (t *QueueManager) SeriesReset(index int) {
 	// Check for series that are in segments older than the checkpoint
 	// that were not also present in the checkpoint.
 	for k, v := range t.seriesSegmentIndexes {
-		if v < index {
-			delete(t.seriesSegmentIndexes, k)
-			delete(t.seriesLabels, k)
-			delete(t.seriesMetadata, k)
-			delete(t.droppedSeries, k)
+		if v >= index {
+			continue
 		}
+		delete(t.seriesSegmentIndexes, k)
+		delete(t.seriesLabels, k)
+		delete(t.seriesMetadata, k)
+		delete(t.seriesIsHistogram, k)
+		delete(t.droppedSeries, k)
 	}
 }
 

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -64,6 +64,7 @@ const (
 	reasonDroppedSeries              = "dropped_series"
 	reasonUnintentionalDroppedSeries = "unintentionally_dropped_series"
 	reasonNHCBNotSupported           = "nhcb_in_rw1_not_supported"
+	reasonNativeHistogramNotSent     = "native_histogram_not_sent"
 )
 
 type queueManagerMetrics struct {
@@ -441,11 +442,12 @@ type QueueManager struct {
 	protoMsg    remoteapi.WriteMessageType
 	compr       compression.Type
 
-	seriesMtx      sync.Mutex // Covers seriesLabels, seriesMetadata, droppedSeries and builder.
-	seriesLabels   map[chunks.HeadSeriesRef]labels.Labels
-	seriesMetadata map[chunks.HeadSeriesRef]*metadata.Metadata
-	droppedSeries  map[chunks.HeadSeriesRef]struct{}
-	builder        *labels.Builder
+	seriesMtx             sync.Mutex // Covers seriesLabels, seriesMetadata, unsentHistogramSeries, droppedSeries and builder.
+	seriesLabels          map[chunks.HeadSeriesRef]labels.Labels
+	seriesMetadata        map[chunks.HeadSeriesRef]*metadata.Metadata
+	unsentHistogramSeries map[chunks.HeadSeriesRef]struct{}
+	droppedSeries         map[chunks.HeadSeriesRef]struct{}
+	builder               *labels.Builder
 
 	seriesSegmentMtx     sync.Mutex // Covers seriesSegmentIndexes - if you also lock seriesMtx, take seriesMtx first.
 	seriesSegmentIndexes map[chunks.HeadSeriesRef]int
@@ -513,11 +515,12 @@ func NewQueueManager(
 		sendNativeHistograms:    enableNativeHistogramRemoteWrite,
 		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
 
-		seriesLabels:         make(map[chunks.HeadSeriesRef]labels.Labels),
-		seriesMetadata:       make(map[chunks.HeadSeriesRef]*metadata.Metadata),
-		seriesSegmentIndexes: make(map[chunks.HeadSeriesRef]int),
-		droppedSeries:        make(map[chunks.HeadSeriesRef]struct{}),
-		builder:              labels.NewBuilder(labels.EmptyLabels()),
+		seriesLabels:          make(map[chunks.HeadSeriesRef]labels.Labels),
+		seriesMetadata:        make(map[chunks.HeadSeriesRef]*metadata.Metadata),
+		unsentHistogramSeries: make(map[chunks.HeadSeriesRef]struct{}),
+		seriesSegmentIndexes:  make(map[chunks.HeadSeriesRef]int),
+		droppedSeries:         make(map[chunks.HeadSeriesRef]struct{}),
+		builder:               labels.NewBuilder(labels.EmptyLabels()),
 
 		numShards:   cfg.MinShards,
 		reshardChan: make(chan int),
@@ -745,6 +748,11 @@ outer:
 			t.seriesMtx.Unlock()
 			continue
 		}
+		if len(t.unsentHistogramSeries) > 0 {
+			// This sample of the series is sent, so its exemplars have something
+			// to attach to again.
+			delete(t.unsentHistogramSeries, s.Ref)
+		}
 		// TODO(cstyan): Handle or at least log an error if no metadata is found.
 		// See https://github.com/prometheus/prometheus/issues/14405
 		meta := t.seriesMetadata[s.Ref]
@@ -809,6 +817,15 @@ outer:
 			t.seriesMtx.Unlock()
 			continue
 		}
+		if len(t.unsentHistogramSeries) > 0 {
+			if _, ok := t.unsentHistogramSeries[e.Ref]; ok {
+				// The native histogram samples of this series are not sent, so the
+				// remote endpoint has no series to attach this exemplar to.
+				t.metrics.droppedExemplarsTotal.WithLabelValues(reasonNativeHistogramNotSent).Inc()
+				t.seriesMtx.Unlock()
+				continue
+			}
+		}
 		meta := t.seriesMetadata[e.Ref]
 		t.seriesMtx.Unlock()
 		// This will only loop if the queues are being resharded.
@@ -841,8 +858,29 @@ outer:
 	return true
 }
 
+// markUnsentHistogramSeries records that a native histogram sample of the given
+// series is not sent to the remote endpoint, so that AppendExemplars drops the
+// exemplars of that series as well.
+func (t *QueueManager) markUnsentHistogramSeries(ref chunks.HeadSeriesRef) {
+	if !t.sendExemplars {
+		return
+	}
+	t.seriesMtx.Lock()
+	t.unsentHistogramSeries[ref] = struct{}{}
+	t.seriesMtx.Unlock()
+}
+
 func (t *QueueManager) AppendHistograms(histograms []record.RefHistogramSample) bool {
 	if !t.sendNativeHistograms {
+		if t.sendExemplars {
+			// None of these histograms are sent, so their exemplars must be
+			// dropped too, see markUnsentHistogramSeries.
+			t.seriesMtx.Lock()
+			for _, h := range histograms {
+				t.unsentHistogramSeries[h.Ref] = struct{}{}
+			}
+			t.seriesMtx.Unlock()
+		}
 		return true
 	}
 	currentTime := time.Now()
@@ -856,6 +894,7 @@ outer:
 			// We cannot send native histograms with custom buckets (NHCB) via remote write v1.
 			t.metrics.droppedHistogramsTotal.WithLabelValues(reasonNHCBNotSupported).Inc()
 			t.logger.Warn("Dropped native histogram with custom buckets (NHCB) as remote write v1 does not support itB", "ref", h.Ref)
+			t.markUnsentHistogramSeries(h.Ref)
 			continue
 		}
 		t.seriesMtx.Lock()
@@ -870,6 +909,9 @@ outer:
 			}
 			t.seriesMtx.Unlock()
 			continue
+		}
+		if len(t.unsentHistogramSeries) > 0 {
+			delete(t.unsentHistogramSeries, h.Ref)
 		}
 		meta := t.seriesMetadata[h.Ref]
 		t.seriesMtx.Unlock()
@@ -905,6 +947,15 @@ outer:
 
 func (t *QueueManager) AppendFloatHistograms(floatHistograms []record.RefFloatHistogramSample) bool {
 	if !t.sendNativeHistograms {
+		if t.sendExemplars {
+			// None of these histograms are sent, so their exemplars must be
+			// dropped too, see markUnsentHistogramSeries.
+			t.seriesMtx.Lock()
+			for _, h := range floatHistograms {
+				t.unsentHistogramSeries[h.Ref] = struct{}{}
+			}
+			t.seriesMtx.Unlock()
+		}
 		return true
 	}
 	currentTime := time.Now()
@@ -918,6 +969,7 @@ outer:
 			// We cannot send native histograms with custom buckets (NHCB) via remote write v1.
 			t.metrics.droppedHistogramsTotal.WithLabelValues(reasonNHCBNotSupported).Inc()
 			t.logger.Warn("Dropped float native histogram with custom buckets (NHCB) as remote write v1 does not support itB", "ref", h.Ref)
+			t.markUnsentHistogramSeries(h.Ref)
 			continue
 		}
 		t.seriesMtx.Lock()
@@ -932,6 +984,11 @@ outer:
 			}
 			t.seriesMtx.Unlock()
 			continue
+		}
+		if len(t.unsentHistogramSeries) > 0 {
+			// This sample of the series is sent, so its exemplars have something
+			// to attach to again.
+			delete(t.unsentHistogramSeries, h.Ref)
 		}
 		meta := t.seriesMetadata[h.Ref]
 		t.seriesMtx.Unlock()
@@ -1066,12 +1123,14 @@ func (t *QueueManager) SeriesReset(index int) {
 	// Check for series that are in segments older than the checkpoint
 	// that were not also present in the checkpoint.
 	for k, v := range t.seriesSegmentIndexes {
-		if v < index {
-			delete(t.seriesSegmentIndexes, k)
-			delete(t.seriesLabels, k)
-			delete(t.seriesMetadata, k)
-			delete(t.droppedSeries, k)
+		if v >= index {
+			continue
 		}
+		delete(t.seriesSegmentIndexes, k)
+		delete(t.seriesLabels, k)
+		delete(t.seriesMetadata, k)
+		delete(t.unsentHistogramSeries, k)
+		delete(t.droppedSeries, k)
 	}
 }
 

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2735,6 +2735,76 @@ func TestAppendHistogramSchemaValidation(t *testing.T) {
 	}
 }
 
+// TestQueueManager_DropsExemplarsForUnsentNativeHistogram is a regression test for
+// https://github.com/prometheus/prometheus/issues/13552: when send_native_histograms
+// is disabled, exemplars attached to a native histogram series must be dropped too,
+// since the histogram sample itself is never sent and the remote endpoint would
+// otherwise reject the exemplar as belonging to a series it never received.
+func TestQueueManager_DropsExemplarsForUnsentNativeHistogram(t *testing.T) {
+	for _, protoMsg := range []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType} {
+		t.Run(string(protoMsg), func(t *testing.T) {
+			c := NewTestWriteClient(protoMsg)
+			cfg := testDefaultQueueConfig()
+			mcfg := config.DefaultMetadataConfig
+			cfg.MaxShards = 1
+
+			m := newTestQueueManager(t, cfg, mcfg, defaultFlushDeadline, c, protoMsg)
+			m.sendExemplars = true
+			// m.sendNativeHistograms stays false, as set by newTestQueueManager.
+
+			histogramSeriesRef := chunks.HeadSeriesRef(0)
+			floatSeriesRef := chunks.HeadSeriesRef(1)
+			series := []record.RefSeries{
+				{Ref: histogramSeriesRef, Labels: labels.FromStrings("__name__", "test_histogram")},
+				{Ref: floatSeriesRef, Labels: labels.FromStrings("__name__", "test_float")},
+			}
+			m.StoreSeries(series, 0)
+
+			histograms := []record.RefHistogramSample{
+				{
+					Ref: histogramSeriesRef,
+					T:   1234567890,
+					H: &histogram.Histogram{
+						Schema:          0,
+						ZeroThreshold:   1e-128,
+						Count:           2,
+						Sum:             5.0,
+						PositiveSpans:   []histogram.Span{{Offset: 0, Length: 1}},
+						PositiveBuckets: []int64{2},
+					},
+				},
+			}
+			floatSamples := []record.RefSample{
+				{Ref: floatSeriesRef, T: 1234567890, V: 1},
+			}
+			exemplars := []record.RefExemplar{
+				{Ref: histogramSeriesRef, T: 1234567891, V: 1, Labels: labels.FromStrings("traceID", "histogram-exemplar")},
+				{Ref: floatSeriesRef, T: 1234567891, V: 1, Labels: labels.FromStrings("traceID", "float-exemplar")},
+			}
+
+			c.expectSamples(floatSamples, series)
+			c.expectExemplars(exemplars[1:], series) // Only the float series' exemplar should be sent.
+
+			m.Start()
+			defer m.Stop()
+
+			// Append the histogram before its exemplar, so the queue manager has
+			// already learned that histogramSeriesRef is a native histogram series.
+			require.True(t, m.AppendHistograms(histograms))
+			require.True(t, m.Append(floatSamples))
+			require.True(t, m.AppendExemplars(exemplars))
+
+			c.waitForExpectedData(t, 30*time.Second)
+
+			require.Equal(t, 1.0, client_testutil.ToFloat64(m.metrics.droppedExemplarsTotal.WithLabelValues(reasonNativeHistogramNotSent)))
+
+			c.mtx.Lock()
+			defer c.mtx.Unlock()
+			require.Empty(t, c.receivedExemplars[getSeriesIDFromRef(series[histogramSeriesRef])], "exemplar for unsent native histogram series must not be sent")
+		})
+	}
+}
+
 // TestAppendHistogramsWithStartTimestamp verifies that AppendHistograms and
 // AppendFloatHistograms propagate the per-sample start timestamp end-to-end
 // through the queue manager into a Remote Write 2.0 request. ST is only

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2735,6 +2735,197 @@ func TestAppendHistogramSchemaValidation(t *testing.T) {
 	}
 }
 
+// TestExemplarsDroppedForUnsentHistograms is a regression test for
+// https://github.com/prometheus/prometheus/issues/13552: an exemplar must only
+// be sent if the sample it belongs to is sent as well, otherwise the remote
+// endpoint rejects it as it has no series to attach it to. A native histogram
+// sample is not sent if native histograms are disabled for the queue, or if it
+// has custom buckets (NHCB), which remote write 1.0 cannot represent.
+func TestExemplarsDroppedForUnsentHistograms(t *testing.T) {
+	const (
+		histogramSeriesRef = chunks.HeadSeriesRef(0)
+		floatSeriesRef     = chunks.HeadSeriesRef(1)
+		ts                 = int64(1234567890)
+	)
+	series := []record.RefSeries{
+		{Ref: histogramSeriesRef, Labels: labels.FromStrings("__name__", "test_histogram")},
+		{Ref: floatSeriesRef, Labels: labels.FromStrings("__name__", "test_float")},
+	}
+
+	for _, tc := range []struct {
+		name                 string
+		protoMsg             remoteapi.WriteMessageType
+		sendNativeHistograms bool
+		// schemas are the schemas of the native histogram samples appended for
+		// the histogram series, in order.
+		schemas []int32
+		// floatHistograms appends float native histograms instead of integer ones.
+		floatHistograms bool
+		// sentIdxs indexes the appended native histogram samples that are
+		// expected to reach the remote endpoint.
+		sentIdxs []int
+		// recycleRef appends a float sample for the histogram series, as happens
+		// once its series ref is reused for another series.
+		recycleRef bool
+		// wantExemplarSent is whether the exemplar of the histogram series is
+		// expected to reach the remote endpoint.
+		wantExemplarSent bool
+	}{
+		{
+			name:     "native histograms disabled, remote write 1.0",
+			protoMsg: remoteapi.WriteV1MessageType,
+			schemas:  []int32{0},
+		},
+		{
+			name:     "native histograms disabled, remote write 2.0",
+			protoMsg: remoteapi.WriteV2MessageType,
+			schemas:  []int32{0},
+		},
+		{
+			name:            "float native histograms disabled",
+			protoMsg:        remoteapi.WriteV2MessageType,
+			schemas:         []int32{0},
+			floatHistograms: true,
+		},
+		{
+			name:                 "NHCB unsupported by remote write 1.0",
+			protoMsg:             remoteapi.WriteV1MessageType,
+			sendNativeHistograms: true,
+			schemas:              []int32{histogram.CustomBucketsSchema},
+		},
+		{
+			name:                 "float NHCB unsupported by remote write 1.0",
+			protoMsg:             remoteapi.WriteV1MessageType,
+			sendNativeHistograms: true,
+			schemas:              []int32{histogram.CustomBucketsSchema},
+			floatHistograms:      true,
+		},
+		{
+			name:                 "NHCB sent via remote write 2.0",
+			protoMsg:             remoteapi.WriteV2MessageType,
+			sendNativeHistograms: true,
+			schemas:              []int32{histogram.CustomBucketsSchema},
+			sentIdxs:             []int{0},
+			wantExemplarSent:     true,
+		},
+		{
+			name:                 "series stops using custom buckets",
+			protoMsg:             remoteapi.WriteV1MessageType,
+			sendNativeHistograms: true,
+			schemas:              []int32{histogram.CustomBucketsSchema, 0},
+			sentIdxs:             []int{1},
+			wantExemplarSent:     true,
+		},
+		{
+			name:             "series ref recycled for float samples",
+			protoMsg:         remoteapi.WriteV1MessageType,
+			schemas:          []int32{0},
+			recycleRef:       true,
+			wantExemplarSent: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewTestWriteClient(tc.protoMsg)
+			cfg := testDefaultQueueConfig()
+			cfg.MaxShards = 1
+			m := newTestQueueManager(t, cfg, config.DefaultMetadataConfig, defaultFlushDeadline, c, tc.protoMsg)
+			m.sendExemplars = true
+			m.sendNativeHistograms = tc.sendNativeHistograms
+			m.StoreSeries(series, 0)
+
+			var (
+				histograms      []record.RefHistogramSample
+				floatHistograms []record.RefFloatHistogramSample
+			)
+			for i, schema := range tc.schemas {
+				// NHCBs need custom bucket boundaries, other schemas must not have any.
+				var customValues []float64
+				if schema == histogram.CustomBucketsSchema {
+					customValues = []float64{2.0}
+				}
+				if tc.floatHistograms {
+					floatHistograms = append(floatHistograms, record.RefFloatHistogramSample{
+						Ref: histogramSeriesRef,
+						T:   ts + int64(i),
+						FH: &histogram.FloatHistogram{
+							Schema:          schema,
+							Count:           2,
+							Sum:             5.0,
+							PositiveSpans:   []histogram.Span{{Offset: 0, Length: 1}},
+							PositiveBuckets: []float64{2},
+							CustomValues:    customValues,
+						},
+					})
+					continue
+				}
+				histograms = append(histograms, record.RefHistogramSample{
+					Ref: histogramSeriesRef,
+					T:   ts + int64(i),
+					H: &histogram.Histogram{
+						Schema:          schema,
+						Count:           2,
+						Sum:             5.0,
+						PositiveSpans:   []histogram.Span{{Offset: 0, Length: 1}},
+						PositiveBuckets: []int64{2},
+						CustomValues:    customValues,
+					},
+				})
+			}
+			floatSamples := []record.RefSample{{Ref: floatSeriesRef, T: ts, V: 1}}
+			if tc.recycleRef {
+				floatSamples = append(floatSamples, record.RefSample{Ref: histogramSeriesRef, T: ts, V: 2})
+			}
+			exemplars := []record.RefExemplar{
+				{Ref: histogramSeriesRef, T: ts, V: 1, Labels: labels.FromStrings("traceID", "histogram-exemplar")},
+				{Ref: floatSeriesRef, T: ts, V: 1, Labels: labels.FromStrings("traceID", "float-exemplar")},
+			}
+
+			var (
+				sentHistograms      []record.RefHistogramSample
+				sentFloatHistograms []record.RefFloatHistogramSample
+			)
+			for _, i := range tc.sentIdxs {
+				if tc.floatHistograms {
+					sentFloatHistograms = append(sentFloatHistograms, floatHistograms[i])
+					continue
+				}
+				sentHistograms = append(sentHistograms, histograms[i])
+			}
+			expectedExemplars := exemplars[1:] // Only the float series' exemplar.
+			if tc.wantExemplarSent {
+				expectedExemplars = exemplars
+			}
+			c.expectSamples(floatSamples, series)
+			c.expectExemplars(expectedExemplars, series)
+			c.expectHistograms(sentHistograms, series)
+			c.expectFloatHistograms(sentFloatHistograms, series)
+
+			m.Start()
+			defer m.Stop()
+
+			// Append the histograms first, as the WAL also records the exemplars of
+			// a series after its samples.
+			require.True(t, m.AppendHistograms(histograms))
+			require.True(t, m.AppendFloatHistograms(floatHistograms))
+			require.True(t, m.Append(floatSamples))
+			require.True(t, m.AppendExemplars(exemplars))
+
+			c.waitForExpectedData(t, 30*time.Second)
+
+			wantDropped := 1.0
+			if tc.wantExemplarSent {
+				wantDropped = 0.0
+			}
+			require.Equal(t, wantDropped, client_testutil.ToFloat64(m.metrics.droppedExemplarsTotal.WithLabelValues(reasonNativeHistogramNotSent)))
+
+			c.mtx.Lock()
+			defer c.mtx.Unlock()
+			require.Len(t, c.receivedExemplars[getSeriesIDFromRef(series[histogramSeriesRef])], len(expectedExemplars)-1,
+				"an exemplar must only be sent if the sample it belongs to is sent")
+		})
+	}
+}
+
 // TestAppendHistogramsWithStartTimestamp verifies that AppendHistograms and
 // AppendFloatHistograms propagate the per-sample start timestamp end-to-end
 // through the queue manager into a Remote Write 2.0 request. ST is only


### PR DESCRIPTION
Fixes: #13552

### What

This ensures that exemplars are only sent when their corresponding histogram data is also being sent. If a histogram is skipped, its related exemplars are skipped as well. It also adds a metric to track these dropped exemplars and includes a regression test to cover the issue.

### Why

Previously, it was possible for exemplars to be sent without their corresponding histogram data. This created orphaned exemplars that remote storage systems, such as Mimir, rejected because they had no matching series to attach them to. By keeping histogram data and exemplars in sync, this change prevents those errors and ensures only valid data is sent.




<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
