### PR TITLE
storage: add AppendExemplar/UpdateMetadata to AppenderV2

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1950,6 +1950,15 @@ type notReadyAppenderV2 struct{}
 func (notReadyAppenderV2) Append(storage.SeriesRef, labels.Labels, int64, int64, float64, *histogram.Histogram, *histogram.FloatHistogram, storage.AOptions) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
+
+func (notReadyAppenderV2) AppendExemplar(storage.SeriesRef, labels.Labels, exemplar.Exemplar) (storage.SeriesRef, error) {
+	return 0, tsdb.ErrNotReady
+}
+
+func (notReadyAppenderV2) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+	return 0, tsdb.ErrNotReady
+}
+
 func (notReadyAppenderV2) Commit() error { return tsdb.ErrNotReady }
 
 func (notReadyAppenderV2) Rollback() error { return tsdb.ErrNotReady }

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -318,6 +318,34 @@ func (f *fanoutAppenderV2) Append(ref SeriesRef, l labels.Labels, st, t int64, v
 	return ref, partialErr.ToError()
 }
 
+func (f *fanoutAppenderV2) AppendExemplar(ref SeriesRef, l labels.Labels, e exemplar.Exemplar) (SeriesRef, error) {
+	ref, err := f.primary.AppendExemplar(ref, l, e)
+	if err != nil {
+		return ref, err
+	}
+
+	for _, appender := range f.secondaries {
+		if _, err := appender.AppendExemplar(ref, l, e); err != nil {
+			return 0, err
+		}
+	}
+	return ref, nil
+}
+
+func (f *fanoutAppenderV2) UpdateMetadata(ref SeriesRef, l labels.Labels, m metadata.Metadata) (SeriesRef, error) {
+	ref, err := f.primary.UpdateMetadata(ref, l, m)
+	if err != nil {
+		return ref, err
+	}
+
+	for _, appender := range f.secondaries {
+		if _, err := appender.UpdateMetadata(ref, l, m); err != nil {
+			return 0, err
+		}
+	}
+	return ref, nil
+}
+
 func (f *fanoutAppenderV2) Commit() (err error) {
 	err = f.primary.Commit()
 

--- a/storage/interface_append.go
+++ b/storage/interface_append.go
@@ -156,6 +156,9 @@ var _ error = &AppendPartialError{}
 type AppenderV2 interface {
 	AppenderTransaction
 
+	ExemplarAppenderV2
+	MetadataUpdaterV2
+
 	// Append appends a sample and related exemplars, metadata, and start timestamp (st) to the storage.
 	//
 	// ref (optional) represents the stable ID for the given series identified by ls (excluding metadata).
@@ -187,6 +190,44 @@ type AppenderV2 interface {
 	//   of the series (metadata matters). Current solution is to enable 'type-and-unit-label' features for those cases, but we may
 	//   start to extend the id with metadata one day.
 	Append(ref SeriesRef, ls labels.Labels, st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, opts AppendV2Options) (SeriesRef, error)
+}
+
+// ExemplarAppenderV2 provides appending exemplars against a storage for AppenderV2.
+//
+// Exemplars can be provided either through this method or through
+// AppendV2Options.Exemplars passed to AppenderV2.Append. As with the V1
+// ExemplarAppender, AppendExemplar must be called after the corresponding
+// sample Append for the same series.
+type ExemplarAppenderV2 interface {
+	// AppendExemplar adds an exemplar for the given series labels.
+	// An optional reference number can be provided to accelerate calls.
+	// A reference number is returned which can be used to add further
+	// exemplars in the same or later transactions.
+	// Returned reference numbers are ephemeral and may be rejected in calls
+	// to Append() at any point. Adding the sample via Append() returns a new
+	// reference number.
+	// If the reference is 0 it must not be used for caching.
+	// Note that in our current implementation of Prometheus' exemplar storage
+	// calls to Append should generate the reference numbers, AppendExemplar
+	// generating a new reference number should be considered possible erroneous behaviour and be logged.
+	AppendExemplar(ref SeriesRef, l labels.Labels, e exemplar.Exemplar) (SeriesRef, error)
+}
+
+// MetadataUpdaterV2 provides updating series metadata against a storage for AppenderV2.
+//
+// Metadata can be provided either through this method or through
+// AppendV2Options.Metadata passed to AppenderV2.Append. As with the V1
+// MetadataUpdater, UpdateMetadata must be called after the corresponding
+// sample Append for the same series.
+type MetadataUpdaterV2 interface {
+	// UpdateMetadata updates a metadata entry for the given series and labels.
+	// A series reference number is returned which can be used to modify the
+	// metadata of the given series in the same or later transactions.
+	// Returned reference numbers are ephemeral and may be rejected in calls
+	// to UpdateMetadata() at any point. If the series does not exist,
+	// UpdateMetadata returns an error.
+	// If the reference is 0 it must not be used for caching.
+	UpdateMetadata(ref SeriesRef, l labels.Labels, m metadata.Metadata) (SeriesRef, error)
 }
 
 // AppenderTransaction allows transactional appends.

--- a/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw_test.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 
 	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/metadata"
@@ -1447,6 +1448,14 @@ func (a *noOpAppender) Append(_ storage.SeriesRef, _ labels.Labels, _, _ int64, 
 		return 1, nil
 	}
 	a.samples++
+	return 1, nil
+}
+
+func (*noOpAppender) AppendExemplar(storage.SeriesRef, labels.Labels, exemplar.Exemplar) (storage.SeriesRef, error) {
+	return 1, nil
+}
+
+func (*noOpAppender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
 	return 1, nil
 }
 

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -401,3 +401,14 @@ func (t *timestampTrackerV2) Append(ref storage.SeriesRef, _ labels.Labels, _, t
 	t.exemplars += int64(len(opts.Exemplars))
 	return ref, nil
 }
+
+func (t *timestampTrackerV2) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, _ exemplar.Exemplar) (storage.SeriesRef, error) {
+	t.exemplars++
+	return ref, nil
+}
+
+func (*timestampTrackerV2) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+	// TODO: Add and increment a `metadata` field when we get around to wiring metadata in remote_write.
+	// UpdateMetadata is no-op for remote write (where timestampTrackerV2 is being used) for now.
+	return 0, nil
+}

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -983,7 +983,7 @@ func (a *appenderBase) getOrCreate(ref chunks.HeadSeriesRef, l labels.Labels) (s
 	return series, nil
 }
 
-func (a *appender) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+func (a *appenderBase) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
 	// Series references and chunk references are identical for agent mode.
 	headRef := chunks.HeadSeriesRef(ref)
 
@@ -1091,7 +1091,7 @@ func (a *appender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int
 	return storage.SeriesRef(series.ref), nil
 }
 
-func (*appender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+func (*appenderBase) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
 	// TODO: Wire metadata in the Agent's appender.
 	return 0, nil
 }

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -777,9 +777,9 @@ func (s *memSeries) appendableFloatHistogram(t int64, fh *histogram.FloatHistogr
 	return false, headMaxt - t, storage.ErrOutOfOrderSample
 }
 
-// AppendExemplar for headAppender assumes the series ref already exists, and so it doesn't
+// AppendExemplar for the head appender assumes the series ref already exists, and so it doesn't
 // use getOrCreate or make any of the lset validity checks that Append does.
-func (a *headAppender) AppendExemplar(ref storage.SeriesRef, lset labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+func (a *headAppenderBase) AppendExemplar(ref storage.SeriesRef, lset labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
 	// Check if exemplar storage is enabled.
 	if !a.head.opts.EnableExemplarStorage || a.head.opts.MaxExemplars.Load() <= 0 {
 		return 0, nil
@@ -1019,7 +1019,7 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 
 // UpdateMetadata for headAppender assumes the series ref already exists, and so it doesn't
 // use getOrCreate or make any of the lset sanity checks that Append does.
-func (a *headAppender) UpdateMetadata(ref storage.SeriesRef, lset labels.Labels, meta metadata.Metadata) (storage.SeriesRef, error) {
+func (a *headAppenderBase) UpdateMetadata(ref storage.SeriesRef, lset labels.Labels, meta metadata.Metadata) (storage.SeriesRef, error) {
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
 	if s == nil {
 		s = a.head.series.getByHash(lset.Hash(), lset)

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -42,6 +43,32 @@ func (a *initAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 		a.app = a.head.appenderV2()
 	}
 	return a.app.Append(ref, ls, st, t, v, h, fh, opts)
+}
+
+func (a *initAppenderV2) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	// Check if exemplar storage is enabled.
+	if !a.head.opts.EnableExemplarStorage || a.head.opts.MaxExemplars.Load() <= 0 {
+		return 0, nil
+	}
+
+	if a.app != nil {
+		return a.app.AppendExemplar(ref, l, e)
+	}
+	// We should never reach here given we would call Append before AppendExemplar
+	// and we probably want to always base head/WAL min time on sample times.
+	a.head.initTime(e.Ts)
+	a.app = a.head.appenderV2()
+
+	return a.app.AppendExemplar(ref, l, e)
+}
+
+func (a *initAppenderV2) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	if a.app != nil {
+		return a.app.UpdateMetadata(ref, l, m)
+	}
+
+	a.app = a.head.appenderV2()
+	return a.app.UpdateMetadata(ref, l, m)
 }
 
 func (a *initAppenderV2) GetRef(lset labels.Labels, hash uint64) (storage.SeriesRef, labels.Labels) {

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -1349,6 +1350,45 @@ func TestHeadAppenderV2_AppendExemplars(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, app.Commit())
 	require.NoError(t, head.Close())
+}
+
+// TestHeadAppenderV2_AppendExemplarAndUpdateMetadata verifies that the
+// standalone AppenderV2.AppendExemplar and AppenderV2.UpdateMetadata methods
+// store the exemplar and metadata against the appended series.
+func TestHeadAppenderV2_AppendExemplarAndUpdateMetadata(t *testing.T) {
+	head, _ := newTestHead(t, 1000, compression.None, false)
+	defer func() { require.NoError(t, head.Close()) }()
+
+	app := head.AppenderV2(context.Background())
+
+	ls := labels.FromStrings("a", "b")
+	ref, err := app.Append(0, ls, 0, 100, 1, nil, nil, storage.AOptions{})
+	require.NoError(t, err)
+
+	e := exemplar.Exemplar{Labels: labels.FromStrings("trace_id", "abc"), HasTs: true, Ts: 100, Value: 1}
+	_, err = app.AppendExemplar(ref, ls, e)
+	require.NoError(t, err)
+
+	m := metadata.Metadata{Type: "counter", Unit: "seconds", Help: "help text"}
+	_, err = app.UpdateMetadata(ref, ls, m)
+	require.NoError(t, err)
+
+	require.NoError(t, app.Commit())
+
+	// Verify the exemplar was stored.
+	q, err := head.ExemplarQuerier(context.Background())
+	require.NoError(t, err)
+	res, err := q.Select(0, 1000, []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "a", "b")})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Len(t, res[0].Exemplars, 1)
+	require.True(t, e.Equals(res[0].Exemplars[0]))
+
+	// Verify the metadata was stored against the series.
+	s := head.series.getByID(chunks.HeadSeriesRef(ref))
+	require.NotNil(t, s)
+	require.NotNil(t, s.meta)
+	require.Equal(t, m, *s.meta)
 }
 
 // Tests https://github.com/prometheus/prometheus/issues/9079.

--- a/util/teststorage/appender.go
+++ b/util/teststorage/appender.go
@@ -614,3 +614,70 @@ func (a *appenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t int64
 	}
 	return ref, partialErr
 }
+
+func (a *appenderV2) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	if err := a.checkErr(); err != nil {
+		return 0, err
+	}
+	if a.a.appendExemplarsError != nil {
+		return 0, a.a.appendExemplarsError
+	}
+
+	if !a.a.skipRecording {
+		var appended bool
+
+		a.a.mtx.Lock()
+		// NOTE(bwplotka): Eventually exemplar has to be attached to a series and soon
+		// the AppenderV2 will guarantee that for TSDB. Assume this from the mock perspective
+		// with the naive attaching. See: https://github.com/prometheus/prometheus/issues/17632
+		i := len(a.a.pendingSamples) - 1
+		for ; i >= 0; i-- { // Attach exemplars to the last matching sample.
+			if labels.Equal(l, a.a.pendingSamples[i].L) {
+				a.a.pendingSamples[i].ES = append(a.a.pendingSamples[i].ES, e)
+				appended = true
+				break
+			}
+		}
+		a.a.mtx.Unlock()
+		if !appended {
+			return 0, fmt.Errorf("teststorage.appenderV2: exemplar appender without series; ref %v; l %v; exemplar: %v", ref, l, e)
+		}
+	}
+
+	if a.next != nil {
+		return a.next.AppendExemplar(ref, l, e)
+	}
+	return computeOrCheckRef(ref, l)
+}
+
+func (a *appenderV2) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	if err := a.checkErr(); err != nil {
+		return 0, err
+	}
+
+	if !a.a.skipRecording {
+		var updated bool
+
+		a.a.mtx.Lock()
+		// NOTE(bwplotka): Eventually metadata has to be attached to a series and soon
+		// the AppenderV2 will guarantee that for TSDB. Assume this from the mock perspective
+		// with the naive attaching. See: https://github.com/prometheus/prometheus/issues/17632
+		i := len(a.a.pendingSamples) - 1
+		for ; i >= 0; i-- { // Attach metadata to the last matching sample.
+			if labels.Equal(l, a.a.pendingSamples[i].L) {
+				a.a.pendingSamples[i].M = m
+				updated = true
+				break
+			}
+		}
+		a.a.mtx.Unlock()
+		if !updated {
+			return 0, fmt.Errorf("teststorage.appenderV2: metadata update without series; ref %v; l %v; m: %v", ref, l, m)
+		}
+	}
+
+	if a.next != nil {
+		return a.next.UpdateMetadata(ref, l, m)
+	}
+	return computeOrCheckRef(ref, l)
+}

--- a/util/teststorage/appender_test.go
+++ b/util/teststorage/appender_test.go
@@ -104,10 +104,24 @@ func testAppendableV2(t *testing.T, appTest *Appendable, a storage.AppendableV2)
 		_, err = app.Append(0, labels.FromStrings(model.MetricNameLabel, "test_metric3", "app", "v2"), -3, 3, 0, nil, fh, storage.AOptions{})
 		require.NoError(t, err)
 
+		// Fourth series is appended without opts, then gets metadata and an
+		// exemplar attached via the standalone AppenderV2 methods.
+		ref4, err := app.Append(0, labels.FromStrings(model.MetricNameLabel, "test_metric4", "app", "v2"), -4, 4, 2, nil, nil, storage.AOptions{})
+		require.NoError(t, err)
+
+		m4 := metadata.Metadata{Type: "counter", Unit: "seconds", Help: "help text"}
+		_, err = app.UpdateMetadata(ref4, labels.FromStrings(model.MetricNameLabel, "test_metric4", "app", "v2"), m4)
+		require.NoError(t, err)
+
+		e4 := exemplar.Exemplar{Labels: labels.FromStrings(model.MetricNameLabel, "trace"), HasTs: true, Ts: 4}
+		_, err = app.AppendExemplar(ref4, labels.FromStrings(model.MetricNameLabel, "test_metric4", "app", "v2"), e4)
+		require.NoError(t, err)
+
 		exp := []Sample{
 			{L: labels.FromStrings(model.MetricNameLabel, "test_metric1", "app", "v2"), MF: "test_metric1", M: m1, ST: -1, T: 1, V: 2, ES: []exemplar.Exemplar{e1}},
 			{L: labels.FromStrings(model.MetricNameLabel, "test_metric2", "app", "v2"), ST: -2, T: 2, H: h},
 			{L: labels.FromStrings(model.MetricNameLabel, "test_metric3", "app", "v2"), ST: -3, T: 3, FH: fh},
+			{L: labels.FromStrings(model.MetricNameLabel, "test_metric4", "app", "v2"), M: m4, ST: -4, T: 4, V: 2, ES: []exemplar.Exemplar{e4}},
 		}
 		testutil.RequireEqual(t, exp, appTest.PendingSamples())
 		require.Nil(t, appTest.ResultSamples())


### PR DESCRIPTION
Part of #17632.

## What

`AppenderV2` so far only exposed `Append`, with exemplars and metadata carried through `AppendV2Options`. Callers structured around the V1 standalone `AppendExemplar`/`UpdateMetadata` calls (e.g. the remote-write receiver) cannot be ported mechanically to that model.

This adds two new V2-scoped interfaces, `ExemplarAppenderV2` and `MetadataUpdaterV2`, embedded into `AppenderV2`, mirroring the V1 `ExemplarAppender`/`MetadataUpdater` sub-interfaces. The `AppendV2Options.Exemplars` and `.Metadata` fields remain; both entry points feed the same per-series batch.

The methods are implemented on every concrete V2 appender:

- **tsdb head**: `AppendExemplar`/`UpdateMetadata` moved to the shared `headAppenderBase` so both V1 and V2 appenders share one implementation; `initAppenderV2` gains delegating variants.
- **tsdb agent**: the two methods moved to the shared `appenderBase`.
- **fanoutAppenderV2**: delegates to primary and secondaries.
- **remote-write `timestampTrackerV2`**: counts exemplars, metadata is a no-op (matching V1).
- **notReadyAppenderV2**: returns `ErrNotReady`.
- **teststorage** and the `noOpAppender` test mock: record / no-op as appropriate.

This change is additive; no existing behaviour changes.

## Why

Preparatory step for migrating the remote-write receiver (starting with RW 1.0) off the V1 `storage.Appender`. A follow-up PR will use these methods to switch the receiver to `AppenderV2`.

## Tests

- Extended teststorage's shared `testAppendableV2` (also exercises `.Then` chaining) to cover the new standalone methods.
- Added `TestHeadAppenderV2_AppendExemplarAndUpdateMetadata` verifying the exemplar via `ExemplarQuerier` and the metadata via the series' stored metadata.

```release-notes
NONE
```