### PR TITLE
storage/remote: add failed_request_logging config for remote write v2

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1491,6 +1491,8 @@ type RemoteWriteConfig struct {
 	// ProtobufMessage specifies the protobuf message to use against the remote
 	// receiver as specified in https://prometheus.io/docs/specs/remote_write_spec_2_0/
 	ProtobufMessage remoteapi.WriteMessageType `yaml:"protobuf_message,omitempty"`
+	// FailedRequestLogging enables debug logging of remote write V2 request on sent error.
+	FailedRequestLogging bool `yaml:"failed_request_logging,omitempty"`
 
 	// We cannot do proper Go type embedding below as the parser will then parse
 	// values arbitrarily into the overflow maps of further-down types.

--- a/config/config.go
+++ b/config/config.go
@@ -1491,7 +1491,7 @@ type RemoteWriteConfig struct {
 	// ProtobufMessage specifies the protobuf message to use against the remote
 	// receiver as specified in https://prometheus.io/docs/specs/remote_write_spec_2_0/
 	ProtobufMessage remoteapi.WriteMessageType `yaml:"protobuf_message,omitempty"`
-	// FailedRequestLogging enables debug logging of remote write V2 request on sent error.
+	// FailedRequestLogging enables debug logging of remote write V2 request on send error.
 	FailedRequestLogging bool `yaml:"failed_request_logging,omitempty"`
 
 	// We cannot do proper Go type embedding below as the parser will then parse

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1876,6 +1876,20 @@ func TestRemoteWriteRetryOnRateLimit(t *testing.T) {
 	require.False(t, got.RemoteWriteConfigs[1].QueueConfig.RetryOnRateLimit)
 }
 
+func TestRemoteWriteFailedRequestLogging(t *testing.T) {
+	cfgYAML := `
+remote_write:
+  - url: http://remote1/api/v1/write
+    failed_request_logging: true
+  - url: http://remote2/api/v1/write
+`
+	cfg, err := Load(cfgYAML, promslog.NewNopLogger())
+	require.NoError(t, err)
+	require.Len(t, cfg.RemoteWriteConfigs, 2)
+	require.True(t, cfg.RemoteWriteConfigs[0].FailedRequestLogging)
+	require.False(t, cfg.RemoteWriteConfigs[1].FailedRequestLogging)
+}
+
 func TestOTLPSanitizeResourceAttributes(t *testing.T) {
 	t.Run("good config - default resource attributes", func(t *testing.T) {
 		want, err := LoadFile(filepath.Join("testdata", "otlp_sanitize_default_resource_attributes.good.yml"), false, promslog.NewNopLogger())

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -786,7 +786,7 @@ func TestDecodeWriteRequest(t *testing.T) {
 }
 
 func TestDecodeWriteV2Request(t *testing.T) {
-	buf, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), writeV2RequestFixture.Timeseries, writeV2RequestFixture.Symbols, nil, nil, nil, "snappy")
+	buf, _, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), writeV2RequestFixture.Timeseries, writeV2RequestFixture.Symbols, nil, nil, nil, "snappy")
 	require.NoError(t, err)
 
 	actual, err := DecodeWriteV2Request(bytes.NewReader(buf))

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -433,6 +433,7 @@ type QueueManager struct {
 	sendExemplars           bool
 	sendNativeHistograms    bool
 	enableTypeAndUnitLabels bool
+	failedRequestLogging    bool
 	watcher                 *wlog.Watcher
 	metadataWatcher         *MetadataWatcher
 
@@ -489,6 +490,7 @@ func NewQueueManager(
 	enableTypeAndUnitLabels bool,
 	protoMsg remoteapi.WriteMessageType,
 	recordBuf *record.BuffersPool,
+	failedRequestLogging bool,
 ) *QueueManager {
 	if logger == nil {
 		logger = promslog.NewNopLogger()
@@ -512,6 +514,7 @@ func NewQueueManager(
 		sendExemplars:           enableExemplarRemoteWrite,
 		sendNativeHistograms:    enableNativeHistogramRemoteWrite,
 		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
+		failedRequestLogging:    failedRequestLogging,
 
 		seriesLabels:         make(map[chunks.HeadSeriesRef]labels.Labels),
 		seriesMetadata:       make(map[chunks.HeadSeriesRef]*metadata.Metadata),
@@ -1854,11 +1857,14 @@ func (s *shards) sendSamplesWithBackoff(ctx context.Context, samples []prompb.Ti
 // sendV2SamplesWithBackoff to the remote storage with backoff for recoverable errors.
 func (s *shards) sendV2SamplesWithBackoff(ctx context.Context, samples []writev2.TimeSeries, labels []string, sampleCount, exemplarCount, histogramCount, metadataCount int, pBuf *[]byte, buf compression.EncodeBuffer, compr compression.Type) (WriteResponseStats, error) {
 	// Build the WriteRequest with no metadata.
-	req, highest, lowest, err := buildV2WriteRequest(s.qm.logger, samples, labels, pBuf, nil, buf, compr)
+	req, v2Req, highest, lowest, err := buildV2WriteRequest(s.qm.logger, samples, labels, pBuf, nil, buf, compr)
 	s.qm.buildRequestLimitTimestamp.Store(lowest)
 	if err != nil {
 		// Failing to build the write request is non-recoverable, since it will
 		// only error if marshaling the proto to bytes fails.
+		if s.qm.failedRequestLogging {
+			s.qm.logger.Debug("Failed to send remote write v2 request", "req", v2Req, "err", err)
+		}
 		return WriteResponseStats{}, err
 	}
 
@@ -1894,7 +1900,7 @@ func (s *shards) sendV2SamplesWithBackoff(ctx context.Context, samples []writev2
 		lowest := s.qm.buildRequestLimitTimestamp.Load()
 		if isSampleOld(currentTime, time.Duration(s.qm.cfg.SampleAgeLimit), lowest) {
 			// This will filter out old samples during retries.
-			req2, _, lowest, err := buildV2WriteRequest(
+			req2, v2Req2, _, lowest, err := buildV2WriteRequest(
 				s.qm.logger,
 				samples,
 				labels,
@@ -1905,9 +1911,13 @@ func (s *shards) sendV2SamplesWithBackoff(ctx context.Context, samples []writev2
 			)
 			s.qm.buildRequestLimitTimestamp.Store(lowest)
 			if err != nil {
+				if s.qm.failedRequestLogging {
+					s.qm.logger.Debug("Failed to send remote write v2 request", "req", v2Req2, "err", err)
+				}
 				return err
 			}
 			req = req2
+			v2Req = v2Req2
 		}
 
 		ctx, span := createBatchSpan(sc.ctx, sc, s.qm.storeClient.Name(), s.qm.storeClient.Endpoint(), try)
@@ -1931,11 +1941,17 @@ func (s *shards) sendV2SamplesWithBackoff(ctx context.Context, samples []writev2
 					rs.Samples, rs.Histograms, rs.Exemplars,
 				)
 				span.RecordError(err)
+				if s.qm.failedRequestLogging {
+					s.qm.logger.Debug("Failed to send remote write v2 request", "req", v2Req, "err", err)
+				}
 				return err
 			}
 			return nil
 		}
 		span.RecordError(err)
+		if s.qm.failedRequestLogging {
+			s.qm.logger.Debug("Failed to send remote write v2 request", "req", v2Req, "err", err)
+		}
 		return err
 	}
 
@@ -2160,14 +2176,14 @@ func buildWriteRequest(logger *slog.Logger, timeSeries []prompb.TimeSeries, meta
 	return compressed, stats.highest, stats.lowest, nil
 }
 
-func buildV2WriteRequest(logger *slog.Logger, samples []writev2.TimeSeries, labels []string, pBuf *[]byte, filter func(writev2.TimeSeries) bool, buf compression.EncodeBuffer, compr compression.Type) (compressed []byte, highest, lowest int64, _ error) {
+func buildV2WriteRequest(logger *slog.Logger, samples []writev2.TimeSeries, labels []string, pBuf *[]byte, filter func(writev2.TimeSeries) bool, buf compression.EncodeBuffer, compr compression.Type) (compressed []byte, req *writev2.Request, highest, lowest int64, _ error) {
 	timeSeries, stats := buildV2TimeSeries(samples, filter)
 
 	if stats.droppedSamples > 0 || stats.droppedExemplars > 0 || stats.droppedHistograms > 0 {
 		logger.Debug("dropped data due to their age", "droppedSamples", stats.droppedSamples, "droppedExemplars", stats.droppedExemplars, "droppedHistograms", stats.droppedHistograms)
 	}
 
-	req := &writev2.Request{
+	req = &writev2.Request{
 		Symbols:    labels,
 		Timeseries: timeSeries,
 	}
@@ -2178,15 +2194,15 @@ func buildV2WriteRequest(logger *slog.Logger, samples []writev2.TimeSeries, labe
 
 	data, err := req.OptimizedMarshal(*pBuf)
 	if err != nil {
-		return nil, stats.highest, stats.lowest, err
+		return nil, req, stats.highest, stats.lowest, err
 	}
 	*pBuf = data
 
 	compressed, err = compression.Encode(compr, *pBuf, buf)
 	if err != nil {
-		return nil, stats.highest, stats.lowest, err
+		return nil, req, stats.highest, stats.lowest, err
 	}
-	return compressed, stats.highest, stats.lowest, nil
+	return compressed, req, stats.highest, stats.lowest, nil
 }
 
 func buildV2TimeSeries(timeSeries []writev2.TimeSeries, filter func(writev2.TimeSeries) bool) ([]writev2.TimeSeries, *timeSeriesStats) {

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1862,9 +1862,6 @@ func (s *shards) sendV2SamplesWithBackoff(ctx context.Context, samples []writev2
 	if err != nil {
 		// Failing to build the write request is non-recoverable, since it will
 		// only error if marshaling the proto to bytes fails.
-		if s.qm.failedRequestLogging {
-			s.qm.logger.Debug("Failed to send remote write v2 request", "req", v2Req, "err", err)
-		}
 		return WriteResponseStats{}, err
 	}
 
@@ -1911,9 +1908,6 @@ func (s *shards) sendV2SamplesWithBackoff(ctx context.Context, samples []writev2
 			)
 			s.qm.buildRequestLimitTimestamp.Store(lowest)
 			if err != nil {
-				if s.qm.failedRequestLogging {
-					s.qm.logger.Debug("Failed to send remote write v2 request", "req", v2Req2, "err", err)
-				}
 				return err
 			}
 			req = req2

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2806,6 +2806,23 @@ func TestAppendHistogramsWithStartTimestamp(t *testing.T) {
 	c.waitForExpectedData(t, 30*time.Second)
 }
 
+type safeBuffer struct {
+	mtx sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *safeBuffer) Write(p []byte) (int, error) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *safeBuffer) String() string {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return s.buf.String()
+}
+
 func TestQueueManager_FailedRequestLogging(t *testing.T) {
 	for _, tc := range []struct {
 		name                 string
@@ -2832,8 +2849,8 @@ func TestQueueManager_FailedRequestLogging(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			var buf bytes.Buffer
-			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			buf := &safeBuffer{}
+			logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 			client := &MockWriteClient{
 				StoreFunc: func(context.Context, []byte, int) (WriteResponseStats, error) {
@@ -2864,8 +2881,9 @@ func TestQueueManager_FailedRequestLogging(t *testing.T) {
 
 			if tc.expectLog {
 				require.Eventually(t, func() bool {
-					return strings.Contains(buf.String(), "Failed to send remote write v2 request") &&
-						strings.Contains(buf.String(), "req=")
+					s := buf.String()
+					return strings.Contains(s, "Failed to send remote write v2 request") &&
+						strings.Contains(s, "req=")
 				}, 5*time.Second, 10*time.Millisecond)
 			} else {
 				time.Sleep(100 * time.Millisecond)

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -2852,8 +2852,10 @@ func TestQueueManager_FailedRequestLogging(t *testing.T) {
 			buf := &safeBuffer{}
 			logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
+			var storeCalled atomic.Int64
 			client := &MockWriteClient{
 				StoreFunc: func(context.Context, []byte, int) (WriteResponseStats, error) {
+					storeCalled.Add(1)
 					if tc.noDataWritten {
 						return WriteResponseStats{}, nil
 					}
@@ -2886,7 +2888,9 @@ func TestQueueManager_FailedRequestLogging(t *testing.T) {
 						strings.Contains(s, "req=")
 				}, 5*time.Second, 10*time.Millisecond)
 			} else {
-				time.Sleep(100 * time.Millisecond)
+				require.Eventually(t, func() bool {
+					return storeCalled.Load() > 0
+				}, 5*time.Second, 10*time.Millisecond)
 				require.NotContains(t, buf.String(), "Failed to send remote write v2 request")
 			}
 		})

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -14,9 +14,11 @@
 package remote
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"os"
 	"runtime/pprof"
@@ -306,7 +308,7 @@ func newTestClientAndQueueManager(t testing.TB, flushDeadline time.Duration, pro
 func newTestQueueManager(t testing.TB, cfg config.QueueConfig, mcfg config.MetadataConfig, deadline time.Duration, c WriteClient, protoMsg remoteapi.WriteMessageType) *QueueManager {
 	dir := t.TempDir()
 	metrics := newQueueManagerMetrics(nil, "", "")
-	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, protoMsg, record.NewBuffersPool())
+	m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, deadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, protoMsg, record.NewBuffersPool(), false)
 
 	return m
 }
@@ -791,7 +793,7 @@ func TestDisableReshardOnRetry(t *testing.T) {
 		}
 	)
 
-	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, nil)
+	m := NewQueueManager(metrics, nil, nil, nil, "", newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, 0, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, nil, false)
 	m.StoreSeries(recs.Series, 0)
 
 	// Attempt to samples while the manager is running. We immediately stop the
@@ -1399,7 +1401,7 @@ func BenchmarkStoreSeries(b *testing.B) {
 				mcfg := config.DefaultMetadataConfig
 				metrics := newQueueManagerMetrics(nil, "", "")
 
-				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, record.NewBuffersPool())
+				m := NewQueueManager(metrics, nil, nil, nil, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, c, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV1MessageType, record.NewBuffersPool(), false)
 				m.externalLabels = tc.externalLabels
 				m.relabelConfigs = tc.relabelConfigs
 
@@ -1893,7 +1895,7 @@ func BenchmarkBuildV2WriteRequest(b *testing.B) {
 		totalSize := 0
 		for b.Loop() {
 			populateV2TimeSeries(&symbolTable, batch, seriesBuff, true, true, false)
-			req, _, _, err := buildV2WriteRequest(noopLogger, seriesBuff, symbolTable.Symbols(), &pBuf, nil, cEnc, "snappy")
+			req, _, _, _, err := buildV2WriteRequest(noopLogger, seriesBuff, symbolTable.Symbols(), &pBuf, nil, cEnc, "snappy")
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -2802,4 +2804,73 @@ func TestAppendHistogramsWithStartTimestamp(t *testing.T) {
 	require.True(t, m.AppendFloatHistograms(floatHistograms))
 
 	c.waitForExpectedData(t, 30*time.Second)
+}
+
+func TestQueueManager_FailedRequestLogging(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		failedRequestLogging bool
+		expectLog            bool
+		noDataWritten        bool
+	}{
+		{
+			name:                 "failed request logging enabled",
+			failedRequestLogging: true,
+			expectLog:            true,
+		},
+		{
+			name:                 "failed request logging enabled - 2xx but no data written error",
+			failedRequestLogging: true,
+			expectLog:            true,
+			noDataWritten:        true,
+		},
+		{
+			name:                 "failed request logging disabled",
+			failedRequestLogging: false,
+			expectLog:            false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			client := &MockWriteClient{
+				StoreFunc: func(context.Context, []byte, int) (WriteResponseStats, error) {
+					if tc.noDataWritten {
+						return WriteResponseStats{}, nil
+					}
+					return WriteResponseStats{}, errors.New("remote store error")
+				},
+				NameFunc:     func() string { return "mock" },
+				EndpointFunc: func() string { return "http://fake:9090/api/v1/write" },
+			}
+
+			cfg := testDefaultQueueConfig()
+			cfg.MaxBackoff = model.Duration(10 * time.Millisecond)
+			cfg.MinBackoff = model.Duration(10 * time.Millisecond)
+			cfg.BatchSendDeadline = model.Duration(10 * time.Millisecond)
+			mcfg := config.DefaultMetadataConfig
+
+			metrics := newQueueManagerMetrics(nil, "", "")
+			qm := NewQueueManager(metrics, nil, nil, logger, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV2MessageType, record.NewBuffersPool(), tc.failedRequestLogging)
+
+			qm.Start()
+			defer qm.Stop()
+
+			recs := testwal.GenerateRecords(recCase{Series: 1, SamplesPerSeries: 1})
+			qm.StoreSeries(recs.Series, 0)
+			qm.Append(recs.Samples)
+
+			if tc.expectLog {
+				require.Eventually(t, func() bool {
+					return strings.Contains(buf.String(), "Failed to send remote write v2 request") &&
+						strings.Contains(buf.String(), "req=")
+				}, 5*time.Second, 10*time.Millisecond)
+			} else {
+				time.Sleep(100 * time.Millisecond)
+				require.NotContains(t, buf.String(), "Failed to send remote write v2 request")
+			}
+		})
+	}
 }

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -14,11 +14,9 @@
 package remote
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"math/rand"
 	"os"
 	"runtime/pprof"
@@ -2804,95 +2802,4 @@ func TestAppendHistogramsWithStartTimestamp(t *testing.T) {
 	require.True(t, m.AppendFloatHistograms(floatHistograms))
 
 	c.waitForExpectedData(t, 30*time.Second)
-}
-
-type safeBuffer struct {
-	mtx sync.Mutex
-	buf bytes.Buffer
-}
-
-func (s *safeBuffer) Write(p []byte) (int, error) {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-	return s.buf.Write(p)
-}
-
-func (s *safeBuffer) String() string {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-	return s.buf.String()
-}
-
-func TestQueueManager_FailedRequestLogging(t *testing.T) {
-	for _, tc := range []struct {
-		name                 string
-		failedRequestLogging bool
-		expectLog            bool
-		noDataWritten        bool
-	}{
-		{
-			name:                 "failed request logging enabled",
-			failedRequestLogging: true,
-			expectLog:            true,
-		},
-		{
-			name:                 "failed request logging enabled - 2xx but no data written error",
-			failedRequestLogging: true,
-			expectLog:            true,
-			noDataWritten:        true,
-		},
-		{
-			name:                 "failed request logging disabled",
-			failedRequestLogging: false,
-			expectLog:            false,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			buf := &safeBuffer{}
-			logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-
-			var storeCalled atomic.Int64
-			client := &MockWriteClient{
-				StoreFunc: func(context.Context, []byte, int) (WriteResponseStats, error) {
-					storeCalled.Add(1)
-					if tc.noDataWritten {
-						return WriteResponseStats{}, nil
-					}
-					return WriteResponseStats{}, errors.New("remote store error")
-				},
-				NameFunc:     func() string { return "mock" },
-				EndpointFunc: func() string { return "http://fake:9090/api/v1/write" },
-			}
-
-			cfg := testDefaultQueueConfig()
-			cfg.MaxBackoff = model.Duration(10 * time.Millisecond)
-			cfg.MinBackoff = model.Duration(10 * time.Millisecond)
-			cfg.BatchSendDeadline = model.Duration(10 * time.Millisecond)
-			mcfg := config.DefaultMetadataConfig
-
-			metrics := newQueueManagerMetrics(nil, "", "")
-			qm := NewQueueManager(metrics, nil, nil, logger, dir, newEWMARate(ewmaWeight, shardUpdateDuration), cfg, mcfg, labels.EmptyLabels(), nil, client, defaultFlushDeadline, newPool(), newHighestTimestampMetric(), nil, false, false, false, remoteapi.WriteV2MessageType, record.NewBuffersPool(), tc.failedRequestLogging)
-
-			qm.Start()
-			defer qm.Stop()
-
-			recs := testwal.GenerateRecords(recCase{Series: 1, SamplesPerSeries: 1})
-			qm.StoreSeries(recs.Series, 0)
-			qm.Append(recs.Samples)
-
-			if tc.expectLog {
-				require.Eventually(t, func() bool {
-					s := buf.String()
-					return strings.Contains(s, "Failed to send remote write v2 request") &&
-						strings.Contains(s, "req=")
-				}, 5*time.Second, 10*time.Millisecond)
-			} else {
-				require.Eventually(t, func() bool {
-					return storeCalled.Load() > 0
-				}, 5*time.Second, 10*time.Millisecond)
-				require.NotContains(t, buf.String(), "Failed to send remote write v2 request")
-			}
-		})
-	}
 }

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -220,6 +220,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			rws.enableTypeAndUnitLabels,
 			rwConf.ProtobufMessage,
 			rws.recordBuf,
+			rwConf.FailedRequestLogging,
 		)
 		// Keep track of which queues are new so we know which to start.
 		newHashes = append(newHashes, hash)

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -145,7 +145,7 @@ func TestRemoteWriteHandlerHeadersHandling_V1Message(t *testing.T) {
 }
 
 func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
-	payload, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), writeV2RequestFixture.Timeseries, writeV2RequestFixture.Symbols, nil, nil, nil, "snappy")
+	payload, _, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), writeV2RequestFixture.Timeseries, writeV2RequestFixture.Symbols, nil, nil, nil, "snappy")
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -718,7 +718,7 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 			if tc.symbols != nil {
 				symbols = tc.symbols
 			}
-			payload, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), tc.input, symbols, nil, nil, nil, "snappy")
+			payload, _, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), tc.input, symbols, nil, nil, nil, "snappy")
 			require.NoError(t, err)
 
 			req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(payload))
@@ -900,7 +900,7 @@ func TestRemoteWriteHandler_V2Message_NoDuplicateTypeAndUnitLabels(t *testing.T)
 				},
 			}
 
-			payload, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), ts, symbolTable.Symbols(), nil, nil, nil, "snappy")
+			payload, _, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), ts, symbolTable.Symbols(), nil, nil, nil, "snappy")
 			require.NoError(t, err)
 
 			req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(payload))
@@ -1077,7 +1077,7 @@ func BenchmarkRemoteWriteHandler(b *testing.B) {
 		{
 			name: "V2 Write",
 			payloadFunc: func() ([]byte, error) {
-				buf, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), []writev2.TimeSeries{{
+				buf, _, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), []writev2.TimeSeries{{
 					LabelsRefs: []uint32{0, 1, 2, 3},
 					Histograms: []writev2.Histogram{writev2.FromIntHistogram(0, 0, &testHistogram)},
 				}}, labelStrings,
@@ -1197,7 +1197,7 @@ func TestHistogramValidationErrorHandling(t *testing.T) {
 						LabelsRefs: st.SymbolizeLabels(labels.FromStrings("__name__", "test"), nil),
 						Histograms: []writev2.Histogram{writev2.FromIntHistogram(0, 1, &tc.hist)},
 					}}
-					buf, _, _, err = buildV2WriteRequest(promslog.NewNopLogger(), ts, st.Symbols(), nil, nil, nil, "snappy")
+					buf, _, _, _, err = buildV2WriteRequest(promslog.NewNopLogger(), ts, st.Symbols(), nil, nil, nil, "snappy")
 				}
 				require.NoError(t, err)
 
@@ -1215,7 +1215,7 @@ func TestHistogramValidationErrorHandling(t *testing.T) {
 }
 
 func TestCommitErr_V2Message(t *testing.T) {
-	payload, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), writeV2RequestFixture.Timeseries, writeV2RequestFixture.Symbols, nil, nil, nil, "snappy")
+	payload, _, _, _, err := buildV2WriteRequest(promslog.NewNopLogger(), writeV2RequestFixture.Timeseries, writeV2RequestFixture.Symbols, nil, nil, nil, "snappy")
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(payload))
@@ -1604,7 +1604,7 @@ func TestHistogramsReduction(t *testing.T) {
 					},
 				}, nil, nil, nil, nil, "snappy")
 			} else {
-				payload, _, _, err = buildV2WriteRequest(promslog.NewNopLogger(), []writev2.TimeSeries{
+				payload, _, _, _, err = buildV2WriteRequest(promslog.NewNopLogger(), []writev2.TimeSeries{
 					{
 						LabelsRefs: []uint32{0, 1},
 						Histograms: []writev2.Histogram{writev2.FromIntHistogram(0, 1, highSchemaHistogram)},
@@ -1645,7 +1645,7 @@ func TestHistogramsReduction(t *testing.T) {
 func TestRemoteWriteHandler_ResponseStats(t *testing.T) {
 	payloadV1, _, _, err := buildWriteRequest(nil, writeRequestFixture.Timeseries, nil, nil, nil, nil, "snappy")
 	require.NoError(t, err)
-	payloadV2, _, _, err := buildV2WriteRequest(nil, writeV2RequestFixture.Timeseries, writeV2RequestFixture.Symbols, nil, nil, nil, "snappy")
+	payloadV2, _, _, _, err := buildV2WriteRequest(nil, writeV2RequestFixture.Timeseries, writeV2RequestFixture.Symbols, nil, nil, nil, "snappy")
 	require.NoError(t, err)
 
 	for _, tt := range []struct {


### PR DESCRIPTION
Ensure we have a way to quickly debug what we send to a backend for the requests that fails.

> [!NOTE] 
> This is quite spammy, so we could also consider per metric filtering for those.

This PR adds an undocumented configuration field `failed_request_logging` to remote write configuration.

When `failed_request_logging` is enabled, Prometheus logs Remote Write 2.0 requests along with the error at DEBUG level upon send errors.

```release-notes
[ENHANCEMENT] storage/remote: Add undocumented failed_request_logging config field to debug log remote write V2 requests on send errors.
```

TAG=agy
CONV=cb66295a-2e69-4736-970c-31160e8fe0c6