### PR TITLE
storage/remote: migrate Remote Write 1.0 receiver to AppenderV2

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1950,6 +1950,15 @@ type notReadyAppenderV2 struct{}
 func (notReadyAppenderV2) Append(storage.SeriesRef, labels.Labels, int64, int64, float64, *histogram.Histogram, *histogram.FloatHistogram, storage.AOptions) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
+
+func (notReadyAppenderV2) AppendExemplar(storage.SeriesRef, labels.Labels, exemplar.Exemplar) (storage.SeriesRef, error) {
+	return 0, tsdb.ErrNotReady
+}
+
+func (notReadyAppenderV2) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+	return 0, tsdb.ErrNotReady
+}
+
 func (notReadyAppenderV2) Commit() error { return tsdb.ErrNotReady }
 
 func (notReadyAppenderV2) Rollback() error { return tsdb.ErrNotReady }

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1960,6 +1960,15 @@ type notReadyAppenderV2 struct{}
 func (notReadyAppenderV2) Append(storage.SeriesRef, labels.Labels, int64, int64, float64, *histogram.Histogram, *histogram.FloatHistogram, storage.AOptions) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
+
+func (notReadyAppenderV2) AppendExemplar(storage.SeriesRef, labels.Labels, exemplar.Exemplar) (storage.SeriesRef, error) {
+	return 0, tsdb.ErrNotReady
+}
+
+func (notReadyAppenderV2) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+	return 0, tsdb.ErrNotReady
+}
+
 func (notReadyAppenderV2) Commit() error { return tsdb.ErrNotReady }
 
 func (notReadyAppenderV2) Rollback() error { return tsdb.ErrNotReady }

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -318,6 +318,52 @@ func (f *fanoutAppenderV2) Append(ref SeriesRef, l labels.Labels, st, t int64, v
 	return ref, partialErr.ToError()
 }
 
+// AppendExemplar implements the optional storage.ExemplarAppenderV2 capability.
+// It delegates only to those appenders that also implement it.
+func (f *fanoutAppenderV2) AppendExemplar(ref SeriesRef, l labels.Labels, e exemplar.Exemplar) (SeriesRef, error) {
+	if pa, ok := f.primary.(ExemplarAppenderV2); ok {
+		var err error
+		ref, err = pa.AppendExemplar(ref, l, e)
+		if err != nil {
+			return ref, err
+		}
+	}
+
+	for _, appender := range f.secondaries {
+		sa, ok := appender.(ExemplarAppenderV2)
+		if !ok {
+			continue
+		}
+		if _, err := sa.AppendExemplar(ref, l, e); err != nil {
+			return 0, err
+		}
+	}
+	return ref, nil
+}
+
+// UpdateMetadata implements the optional storage.MetadataUpdaterV2 capability.
+// It delegates only to those appenders that also implement it.
+func (f *fanoutAppenderV2) UpdateMetadata(ref SeriesRef, l labels.Labels, m metadata.Metadata) (SeriesRef, error) {
+	if pu, ok := f.primary.(MetadataUpdaterV2); ok {
+		var err error
+		ref, err = pu.UpdateMetadata(ref, l, m)
+		if err != nil {
+			return ref, err
+		}
+	}
+
+	for _, appender := range f.secondaries {
+		su, ok := appender.(MetadataUpdaterV2)
+		if !ok {
+			continue
+		}
+		if _, err := su.UpdateMetadata(ref, l, m); err != nil {
+			return 0, err
+		}
+	}
+	return ref, nil
+}
+
 func (f *fanoutAppenderV2) Commit() (err error) {
 	err = f.primary.Commit()
 

--- a/storage/interface_append.go
+++ b/storage/interface_append.go
@@ -189,6 +189,56 @@ type AppenderV2 interface {
 	Append(ref SeriesRef, ls labels.Labels, st, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, opts AppendV2Options) (SeriesRef, error)
 }
 
+// ExemplarAppenderV2 is an optional capability that an AppenderV2 implementation
+// MAY also implement to accept exemplars through a standalone call rather than
+// via AppendV2Options.Exemplars. Callers discover it via a type assertion on the
+// AppenderV2, similar to GetRef.
+//
+// It exists to let callers structured around standalone exemplar appends (e.g.
+// the remote-write receiver) reuse that shape. It is intentionally NOT embedded
+// into AppenderV2 so that downstream AppenderV2 implementations are not forced
+// to implement it.
+//
+// As with the V1 ExemplarAppender, AppendExemplar must be called after the
+// corresponding sample Append for the same series.
+type ExemplarAppenderV2 interface {
+	// AppendExemplar adds an exemplar for the given series labels.
+	// An optional reference number can be provided to accelerate calls.
+	// A reference number is returned which can be used to add further
+	// exemplars in the same or later transactions.
+	// Returned reference numbers are ephemeral and may be rejected in calls
+	// to Append() at any point. Adding the sample via Append() returns a new
+	// reference number.
+	// If the reference is 0 it must not be used for caching.
+	// Note that in our current implementation of Prometheus' exemplar storage
+	// calls to Append should generate the reference numbers, AppendExemplar
+	// generating a new reference number should be considered possible erroneous behaviour and be logged.
+	AppendExemplar(ref SeriesRef, l labels.Labels, e exemplar.Exemplar) (SeriesRef, error)
+}
+
+// MetadataUpdaterV2 is an optional capability that an AppenderV2 implementation
+// MAY also implement to accept series metadata through a standalone call rather
+// than via AppendV2Options.Metadata. Callers discover it via a type assertion on
+// the AppenderV2, similar to GetRef.
+//
+// It exists to let callers structured around standalone metadata updates (e.g.
+// the remote-write receiver) reuse that shape. It is intentionally NOT embedded
+// into AppenderV2 so that downstream AppenderV2 implementations are not forced
+// to implement it.
+//
+// As with the V1 MetadataUpdater, UpdateMetadata must be called after the
+// corresponding sample Append for the same series.
+type MetadataUpdaterV2 interface {
+	// UpdateMetadata updates a metadata entry for the given series and labels.
+	// A series reference number is returned which can be used to modify the
+	// metadata of the given series in the same or later transactions.
+	// Returned reference numbers are ephemeral and may be rejected in calls
+	// to UpdateMetadata() at any point. If the series does not exist,
+	// UpdateMetadata returns an error.
+	// If the reference is 0 it must not be used for caching.
+	UpdateMetadata(ref SeriesRef, l labels.Labels, m metadata.Metadata) (SeriesRef, error)
+}
+
 // AppenderTransaction allows transactional appends.
 type AppenderTransaction interface {
 	// Commit submits the collected samples and purges the batch. If Commit

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -401,3 +401,14 @@ func (t *timestampTrackerV2) Append(ref storage.SeriesRef, _ labels.Labels, _, t
 	t.exemplars += int64(len(opts.Exemplars))
 	return ref, nil
 }
+
+func (t *timestampTrackerV2) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, _ exemplar.Exemplar) (storage.SeriesRef, error) {
+	t.exemplars++
+	return ref, nil
+}
+
+func (*timestampTrackerV2) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+	// TODO: Add and increment a `metadata` field when we get around to wiring metadata in remote_write.
+	// UpdateMetadata is no-op for remote write (where timestampTrackerV2 is being used) for now.
+	return 0, nil
+}

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -403,3 +403,14 @@ func (t *timestampTrackerV2) Append(ref storage.SeriesRef, _ labels.Labels, _, t
 	t.exemplars += int64(len(opts.Exemplars))
 	return ref, nil
 }
+
+func (t *timestampTrackerV2) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, _ exemplar.Exemplar) (storage.SeriesRef, error) {
+	t.exemplars++
+	return ref, nil
+}
+
+func (*timestampTrackerV2) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+	// TODO: Add and increment a `metadata` field when we get around to wiring metadata in remote_write.
+	// UpdateMetadata is no-op for remote write (where timestampTrackerV2 is being used) for now.
+	return 0, nil
+}

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -39,8 +39,12 @@ import (
 )
 
 type writeHandler struct {
-	logger     *slog.Logger
-	appendable storage.Appendable
+	logger *slog.Logger
+	// appendable is used by the Remote Write 2.x path (writeV2). The Remote
+	// Write 1.0 path (write) uses appendableV2 as part of the migration to
+	// AppenderV2 (https://github.com/prometheus/prometheus/issues/17632).
+	appendable   storage.Appendable
+	appendableV2 storage.AppendableV2
 
 	samplesWithInvalidLabelsTotal  prometheus.Counter
 	samplesAppendedWithoutMetadata prometheus.Counter
@@ -50,17 +54,31 @@ type writeHandler struct {
 	appendMetadata          bool
 }
 
+// receiverAppenderV2 is the AppenderV2 capability the Remote Write receiver
+// requires: standalone exemplar and metadata appends on top of AppenderV2.
+// Prometheus' own appenders (TSDB head, agent, fanout, remote write) implement
+// it. It is defined here, rather than embedded into storage.AppenderV2, so that
+// downstream AppenderV2 implementations are not forced to implement it.
+type receiverAppenderV2 interface {
+	storage.AppenderV2
+	storage.ExemplarAppenderV2
+	storage.MetadataUpdaterV2
+}
+
 const maxAheadTime = 10 * time.Minute
 
 // NewWriteHandler creates a http.Handler that accepts remote write requests with
-// the given message in acceptedMsgs and writes them to the provided appendable.
+// the given message in acceptedMsgs and writes them to the provided appendables.
+// The Remote Write 1.0 path uses appendableV2 (storage.AppenderV2); the Remote
+// Write 2.x path still uses appendable (storage.Appender) until it is migrated.
 //
 // NOTE(bwplotka): When accepting v2 proto and spec, partial writes are possible
 // as per https://prometheus.io/docs/specs/remote_write_spec_2_0/#partial-write.
-func NewWriteHandler(logger *slog.Logger, reg prometheus.Registerer, appendable storage.Appendable, acceptedMsgs remoteapi.MessageTypes, ingestSTZeroSample, enableTypeAndUnitLabels, appendMetadata bool) http.Handler {
+func NewWriteHandler(logger *slog.Logger, reg prometheus.Registerer, appendable storage.Appendable, appendableV2 storage.AppendableV2, acceptedMsgs remoteapi.MessageTypes, ingestSTZeroSample, enableTypeAndUnitLabels, appendMetadata bool) http.Handler {
 	h := &writeHandler{
-		logger:     logger,
-		appendable: appendable,
+		logger:       logger,
+		appendable:   appendable,
+		appendableV2: appendableV2,
 		samplesWithInvalidLabelsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Namespace: "prometheus",
 			Subsystem: "api",
@@ -151,9 +169,14 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 	samplesWithInvalidLabels := 0
 	samplesAppended := 0
 
-	app := &remoteWriteAppender{
-		Appender: h.appendable.Appender(ctx),
-		maxTime:  timestamp.FromTime(time.Now().Add(maxAheadTime)),
+	appV2 := h.appendableV2.AppenderV2(ctx)
+	recv, ok := appV2.(receiverAppenderV2)
+	if !ok {
+		return fmt.Errorf("remote write 1.0 receiver requires a storage.AppenderV2 that also implements storage.ExemplarAppenderV2 and storage.MetadataUpdaterV2, got %T", appV2)
+	}
+	app := &remoteWriteAppenderV2{
+		AppenderV2: recv,
+		maxTime:    timestamp.FromTime(time.Now().Add(maxAheadTime)),
 	}
 
 	defer func() {
@@ -217,11 +240,11 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 	return nil
 }
 
-func (h *writeHandler) appendV1Samples(app storage.Appender, ss []prompb.Sample, labels labels.Labels) error {
+func (h *writeHandler) appendV1Samples(app storage.AppenderV2, ss []prompb.Sample, labels labels.Labels) error {
 	var ref storage.SeriesRef
 	var err error
 	for _, s := range ss {
-		ref, err = app.Append(ref, labels, s.GetTimestamp(), s.GetValue())
+		ref, err = app.Append(ref, labels, 0, s.GetTimestamp(), s.GetValue(), nil, nil, storage.AppendV2Options{})
 		if err != nil {
 			if errors.Is(err, storage.ErrOutOfOrderSample) ||
 				errors.Is(err, storage.ErrOutOfBounds) ||
@@ -235,13 +258,14 @@ func (h *writeHandler) appendV1Samples(app storage.Appender, ss []prompb.Sample,
 	return nil
 }
 
-func (h *writeHandler) appendV1Histograms(app storage.Appender, hh []prompb.Histogram, labels labels.Labels) error {
+func (h *writeHandler) appendV1Histograms(app storage.AppenderV2, hh []prompb.Histogram, labels labels.Labels) error {
+	var ref storage.SeriesRef
 	var err error
 	for _, hp := range hh {
 		if hp.IsFloatHistogram() {
-			_, err = app.AppendHistogram(0, labels, hp.Timestamp, nil, hp.ToFloatHistogram())
+			ref, err = app.Append(ref, labels, 0, hp.Timestamp, 0, nil, hp.ToFloatHistogram(), storage.AppendV2Options{})
 		} else {
-			_, err = app.AppendHistogram(0, labels, hp.Timestamp, hp.ToIntHistogram(), nil)
+			ref, err = app.Append(ref, labels, 0, hp.Timestamp, 0, hp.ToIntHistogram(), nil, storage.AppendV2Options{})
 		}
 		if err != nil {
 			// Although AppendHistogram does not currently return ErrDuplicateSampleForTimestamp there is
@@ -567,4 +591,17 @@ func (app *remoteWriteAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels
 		}
 	}
 	return app.AppenderV2.Append(ref, ls, st, t, v, h, fh, opts)
+}
+
+// AppendExemplar delegates to the wrapped appender's optional
+// storage.ExemplarAppenderV2 capability, enforcing max ahead time.
+func (app *remoteWriteAppenderV2) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	if e.Ts > app.maxTime {
+		return 0, fmt.Errorf("%w: timestamp is too far in the future", storage.ErrOutOfBounds)
+	}
+	ea, ok := app.AppenderV2.(storage.ExemplarAppenderV2)
+	if !ok {
+		return 0, fmt.Errorf("appender %T does not support exemplars", app.AppenderV2)
+	}
+	return ea.AppendExemplar(ref, l, e)
 }

--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -55,14 +55,13 @@ type writeHandler struct {
 }
 
 // receiverAppenderV2 is the AppenderV2 capability the Remote Write receiver
-// requires: standalone exemplar and metadata appends on top of AppenderV2.
-// Prometheus' own appenders (TSDB head, agent, fanout, remote write) implement
-// it. It is defined here, rather than embedded into storage.AppenderV2, so that
+// requires: standalone exemplar appends on top of AppenderV2. Prometheus' own
+// appenders (TSDB head, agent, fanout, remote write) implement it. It is
+// defined here, rather than embedded into storage.AppenderV2, so that
 // downstream AppenderV2 implementations are not forced to implement it.
 type receiverAppenderV2 interface {
 	storage.AppenderV2
 	storage.ExemplarAppenderV2
-	storage.MetadataUpdaterV2
 }
 
 const maxAheadTime = 10 * time.Minute
@@ -172,7 +171,7 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 	appV2 := h.appendableV2.AppenderV2(ctx)
 	recv, ok := appV2.(receiverAppenderV2)
 	if !ok {
-		return fmt.Errorf("remote write 1.0 receiver requires a storage.AppenderV2 that also implements storage.ExemplarAppenderV2 and storage.MetadataUpdaterV2, got %T", appV2)
+		return fmt.Errorf("remote write 1.0 receiver requires a storage.AppenderV2 that also implements storage.ExemplarAppenderV2, got %T", appV2)
 	}
 	app := &remoteWriteAppenderV2{
 		AppenderV2: recv,

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -130,7 +130,7 @@ func TestRemoteWriteHandlerHeadersHandling_V1Message(t *testing.T) {
 			}
 
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -237,7 +237,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 			}
 
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -272,7 +272,7 @@ func TestRemoteWriteHandlerHeadersHandling_V2Message(t *testing.T) {
 		}
 
 		appendable := &mockAppendable{}
-		handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
+		handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
 
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, req)
@@ -301,7 +301,7 @@ func TestRemoteWriteHandler_V1Message(t *testing.T) {
 	// in Prometheus, so keeping like this to not break existing 1.0 clients.
 
 	appendable := &mockAppendable{}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -736,7 +736,7 @@ func TestRemoteWriteHandler_V2Message(t *testing.T) {
 				appendExemplarErr:     tc.appendExemplarErr,
 				updateMetadataErr:     tc.updateMetadataErr,
 			}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, tc.ingestSTZeroSample, tc.enableTypeAndUnitLabels, tc.appendMetadata)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, tc.ingestSTZeroSample, tc.enableTypeAndUnitLabels, tc.appendMetadata)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -911,7 +911,7 @@ func TestRemoteWriteHandler_V2Message_NoDuplicateTypeAndUnitLabels(t *testing.T)
 			req.Header.Set(RemoteWriteVersionHeader, RemoteWriteVersion20HeaderValue)
 
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, true, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, true, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -960,7 +960,7 @@ func TestOutOfOrderSample_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -1002,7 +1002,7 @@ func TestOutOfOrderExemplar_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -1040,7 +1040,7 @@ func TestOutOfOrderHistogram_V1Message(t *testing.T) {
 			require.NoError(t, err)
 
 			appendable := &mockAppendable{latestSample: map[uint64]int64{labels.FromStrings("__name__", "test_metric").Hash(): 100}}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, req)
@@ -1090,7 +1090,7 @@ func BenchmarkRemoteWriteHandler(b *testing.B) {
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{tc.protoFormat}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{tc.protoFormat}, false, false, false)
 			b.ResetTimer()
 			for b.Loop() {
 				b.StopTimer()
@@ -1115,7 +1115,7 @@ func TestCommitErr_V1Message(t *testing.T) {
 	require.NoError(t, err)
 
 	appendable := &mockAppendable{commitErr: errors.New("commit error")}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -1181,7 +1181,7 @@ func TestHistogramValidationErrorHandling(t *testing.T) {
 				require.NoError(t, err)
 				t.Cleanup(func() { require.NoError(t, db.Close()) })
 
-				handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []remoteapi.WriteMessageType{protoMsg}, false, false, false)
+				handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), db.Head(), []remoteapi.WriteMessageType{protoMsg}, false, false, false)
 				recorder := httptest.NewRecorder()
 
 				var buf []byte
@@ -1226,7 +1226,7 @@ func TestCommitErr_V2Message(t *testing.T) {
 	req.Header.Set(RemoteWriteVersionHeader, RemoteWriteVersion20HeaderValue)
 
 	appendable := &mockAppendable{commitErr: errors.New("commit error")}
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{remoteapi.WriteV2MessageType}, false, false, false)
 
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
@@ -1253,7 +1253,7 @@ func BenchmarkRemoteWriteOOOSamples(b *testing.B) {
 		require.NoError(b, db.Close())
 	})
 	// TODO: test with other proto format(s)
-	handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
+	handler := NewWriteHandler(promslog.NewNopLogger(), nil, db.Head(), db.Head(), []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType}, false, false, false)
 
 	buf, _, _, err := buildWriteRequest(nil, genSeriesWithSample(1000, 200*time.Minute.Milliseconds()), nil, nil, nil, nil, "snappy")
 	require.NoError(b, err)
@@ -1366,6 +1366,37 @@ func (m *mockAppendable) Appender(context.Context) storage.Appender {
 		m.latestExemplar = map[uint64]int64{}
 	}
 	return m
+}
+
+func (m *mockAppendable) AppenderV2(context.Context) storage.AppenderV2 {
+	if m.latestSample == nil {
+		m.latestSample = map[uint64]int64{}
+	}
+	if m.latestHistogram == nil {
+		m.latestHistogram = map[uint64]int64{}
+	}
+	if m.latestFloatHist == nil {
+		m.latestFloatHist = map[uint64]int64{}
+	}
+	if m.latestExemplar == nil {
+		m.latestExemplar = map[uint64]int64{}
+	}
+	return mockAppenderV2{m}
+}
+
+// mockAppenderV2 adapts mockAppendable to storage.AppenderV2, recording into the
+// same slices as the V1 appender. It reuses the V1 AppendExemplar, UpdateMetadata,
+// Commit and Rollback methods, whose signatures match the V2 capabilities.
+type mockAppenderV2 struct {
+	*mockAppendable
+}
+
+func (m mockAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, _, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, _ storage.AOptions) (storage.SeriesRef, error) {
+	if h != nil || fh != nil {
+		return m.AppendHistogram(ref, ls, t, h, fh)
+	}
+	// Qualified to call the V1 Append and not recurse into this method.
+	return m.mockAppendable.Append(ref, ls, t, v)
 }
 
 func (*mockAppendable) SetOptions(*storage.AppendOptions) {
@@ -1585,7 +1616,7 @@ func TestHistogramsReduction(t *testing.T) {
 	for _, protoMsg := range []remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType} {
 		t.Run(string(protoMsg), func(t *testing.T) {
 			appendable := &mockAppendable{}
-			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, []remoteapi.WriteMessageType{protoMsg}, false, false, false)
+			handler := NewWriteHandler(promslog.NewNopLogger(), nil, appendable, appendable, []remoteapi.WriteMessageType{protoMsg}, false, false, false)
 
 			var (
 				err     error
@@ -1676,6 +1707,7 @@ func TestRemoteWriteHandler_ResponseStats(t *testing.T) {
 			handler := NewWriteHandler(
 				promslog.NewNopLogger(),
 				nil,
+				appendable,
 				appendable,
 				[]remoteapi.WriteMessageType{remoteapi.WriteV1MessageType, remoteapi.WriteV2MessageType},
 				false,

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -983,7 +983,7 @@ func (a *appenderBase) getOrCreate(ref chunks.HeadSeriesRef, l labels.Labels) (s
 	return series, nil
 }
 
-func (a *appender) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+func (a *appenderBase) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
 	// Series references and chunk references are identical for agent mode.
 	headRef := chunks.HeadSeriesRef(ref)
 
@@ -1091,7 +1091,7 @@ func (a *appender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int
 	return storage.SeriesRef(series.ref), nil
 }
 
-func (*appender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+func (*appenderBase) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
 	// TODO: Wire metadata in the Agent's appender.
 	return 0, nil
 }

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -777,9 +777,9 @@ func (s *memSeries) appendableFloatHistogram(t int64, fh *histogram.FloatHistogr
 	return false, headMaxt - t, storage.ErrOutOfOrderSample
 }
 
-// AppendExemplar for headAppender assumes the series ref already exists, and so it doesn't
+// AppendExemplar for the head appender assumes the series ref already exists, and so it doesn't
 // use getOrCreate or make any of the lset validity checks that Append does.
-func (a *headAppender) AppendExemplar(ref storage.SeriesRef, lset labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+func (a *headAppenderBase) AppendExemplar(ref storage.SeriesRef, lset labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
 	// Check if exemplar storage is enabled.
 	if !a.head.opts.EnableExemplarStorage || a.head.opts.MaxExemplars.Load() <= 0 {
 		return 0, nil
@@ -1019,7 +1019,7 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 
 // UpdateMetadata for headAppender assumes the series ref already exists, and so it doesn't
 // use getOrCreate or make any of the lset sanity checks that Append does.
-func (a *headAppender) UpdateMetadata(ref storage.SeriesRef, lset labels.Labels, meta metadata.Metadata) (storage.SeriesRef, error) {
+func (a *headAppenderBase) UpdateMetadata(ref storage.SeriesRef, lset labels.Labels, meta metadata.Metadata) (storage.SeriesRef, error) {
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
 	if s == nil {
 		s = a.head.series.getByHash(lset.Hash(), lset)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -778,9 +778,9 @@ func (s *memSeries) appendableFloatHistogram(t int64, fh *histogram.FloatHistogr
 	return false, headMaxt - t, storage.ErrOutOfOrderSample
 }
 
-// AppendExemplar for headAppender assumes the series ref already exists, and so it doesn't
+// AppendExemplar for the head appender assumes the series ref already exists, and so it doesn't
 // use getOrCreate or make any of the lset validity checks that Append does.
-func (a *headAppender) AppendExemplar(ref storage.SeriesRef, lset labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+func (a *headAppenderBase) AppendExemplar(ref storage.SeriesRef, lset labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
 	// Check if exemplar storage is enabled.
 	if !a.head.opts.EnableExemplarStorage || a.head.opts.MaxExemplars.Load() <= 0 {
 		return 0, nil
@@ -1020,7 +1020,7 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 
 // UpdateMetadata for headAppender assumes the series ref already exists, and so it doesn't
 // use getOrCreate or make any of the lset sanity checks that Append does.
-func (a *headAppender) UpdateMetadata(ref storage.SeriesRef, lset labels.Labels, meta metadata.Metadata) (storage.SeriesRef, error) {
+func (a *headAppenderBase) UpdateMetadata(ref storage.SeriesRef, lset labels.Labels, meta metadata.Metadata) (storage.SeriesRef, error) {
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
 	if s == nil {
 		s = a.head.series.getByHash(lset.Hash(), lset)

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -30,7 +31,7 @@ import (
 // initAppenderV2 is a helper to initialize the time bounds of the head
 // upon the first sample it receives.
 type initAppenderV2 struct {
-	app  storage.AppenderV2
+	app  *headAppenderV2
 	head *Head
 }
 
@@ -44,9 +45,35 @@ func (a *initAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	return a.app.Append(ref, ls, st, t, v, h, fh, opts)
 }
 
+func (a *initAppenderV2) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	// Check if exemplar storage is enabled.
+	if !a.head.opts.EnableExemplarStorage || a.head.opts.MaxExemplars.Load() <= 0 {
+		return 0, nil
+	}
+
+	if a.app != nil {
+		return a.app.AppendExemplar(ref, l, e)
+	}
+	// We should never reach here given we would call Append before AppendExemplar
+	// and we probably want to always base head/WAL min time on sample times.
+	a.head.initTime(e.Ts)
+	a.app = a.head.appenderV2()
+
+	return a.app.AppendExemplar(ref, l, e)
+}
+
+func (a *initAppenderV2) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	if a.app != nil {
+		return a.app.UpdateMetadata(ref, l, m)
+	}
+
+	a.app = a.head.appenderV2()
+	return a.app.UpdateMetadata(ref, l, m)
+}
+
 func (a *initAppenderV2) GetRef(lset labels.Labels, hash uint64) (storage.SeriesRef, labels.Labels) {
-	if g, ok := a.app.(storage.GetRef); ok {
-		return g.GetRef(lset, hash)
+	if a.app != nil {
+		return a.app.GetRef(lset, hash)
 	}
 	return 0, labels.EmptyLabels()
 }

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -1349,6 +1350,50 @@ func TestHeadAppenderV2_AppendExemplars(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, app.Commit())
 	require.NoError(t, head.Close())
+}
+
+// TestHeadAppenderV2_AppendExemplarAndUpdateMetadata verifies that the head
+// AppenderV2 implements the optional storage.ExemplarAppenderV2 and
+// storage.MetadataUpdaterV2 capabilities and stores the exemplar and metadata
+// against the appended series.
+func TestHeadAppenderV2_AppendExemplarAndUpdateMetadata(t *testing.T) {
+	head, _ := newTestHead(t, 1000, compression.None, false)
+	defer func() { require.NoError(t, head.Close()) }()
+
+	app := head.AppenderV2(context.Background())
+	exApp, ok := app.(storage.ExemplarAppenderV2)
+	require.True(t, ok, "head AppenderV2 must implement storage.ExemplarAppenderV2")
+	mdApp, ok := app.(storage.MetadataUpdaterV2)
+	require.True(t, ok, "head AppenderV2 must implement storage.MetadataUpdaterV2")
+
+	ls := labels.FromStrings("a", "b")
+	ref, err := app.Append(0, ls, 0, 100, 1, nil, nil, storage.AOptions{})
+	require.NoError(t, err)
+
+	e := exemplar.Exemplar{Labels: labels.FromStrings("trace_id", "abc"), HasTs: true, Ts: 100, Value: 1}
+	_, err = exApp.AppendExemplar(ref, ls, e)
+	require.NoError(t, err)
+
+	m := metadata.Metadata{Type: "counter", Unit: "seconds", Help: "help text"}
+	_, err = mdApp.UpdateMetadata(ref, ls, m)
+	require.NoError(t, err)
+
+	require.NoError(t, app.Commit())
+
+	// Verify the exemplar was stored.
+	q, err := head.ExemplarQuerier(context.Background())
+	require.NoError(t, err)
+	res, err := q.Select(0, 1000, []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "a", "b")})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Len(t, res[0].Exemplars, 1)
+	require.True(t, e.Equals(res[0].Exemplars[0]))
+
+	// Verify the metadata was stored against the series.
+	s := head.series.getByID(chunks.HeadSeriesRef(ref))
+	require.NotNil(t, s)
+	require.NotNil(t, s.meta)
+	require.Equal(t, m, *s.meta)
 }
 
 // Tests https://github.com/prometheus/prometheus/issues/9079.

--- a/tsdb/head_append_v2_test.go
+++ b/tsdb/head_append_v2_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -1354,6 +1355,50 @@ func TestHeadAppenderV2_AppendExemplars(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, app.Commit())
 	require.NoError(t, head.Close())
+}
+
+// TestHeadAppenderV2_AppendExemplarAndUpdateMetadata verifies that the head
+// AppenderV2 implements the optional storage.ExemplarAppenderV2 and
+// storage.MetadataUpdaterV2 capabilities and stores the exemplar and metadata
+// against the appended series.
+func TestHeadAppenderV2_AppendExemplarAndUpdateMetadata(t *testing.T) {
+	head, _ := newTestHead(t, 1000, compression.None, false)
+	defer func() { require.NoError(t, head.Close()) }()
+
+	app := head.AppenderV2(context.Background())
+	exApp, ok := app.(storage.ExemplarAppenderV2)
+	require.True(t, ok, "head AppenderV2 must implement storage.ExemplarAppenderV2")
+	mdApp, ok := app.(storage.MetadataUpdaterV2)
+	require.True(t, ok, "head AppenderV2 must implement storage.MetadataUpdaterV2")
+
+	ls := labels.FromStrings("a", "b")
+	ref, err := app.Append(0, ls, 0, 100, 1, nil, nil, storage.AOptions{})
+	require.NoError(t, err)
+
+	e := exemplar.Exemplar{Labels: labels.FromStrings("trace_id", "abc"), HasTs: true, Ts: 100, Value: 1}
+	_, err = exApp.AppendExemplar(ref, ls, e)
+	require.NoError(t, err)
+
+	m := metadata.Metadata{Type: "counter", Unit: "seconds", Help: "help text"}
+	_, err = mdApp.UpdateMetadata(ref, ls, m)
+	require.NoError(t, err)
+
+	require.NoError(t, app.Commit())
+
+	// Verify the exemplar was stored.
+	q, err := head.ExemplarQuerier(context.Background())
+	require.NoError(t, err)
+	res, err := q.Select(0, 1000, []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "a", "b")})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Len(t, res[0].Exemplars, 1)
+	require.True(t, e.Equals(res[0].Exemplars[0]))
+
+	// Verify the metadata was stored against the series.
+	s := head.series.getByID(chunks.HeadSeriesRef(ref))
+	require.NotNil(t, s)
+	require.NotNil(t, s.meta)
+	require.Equal(t, m, *s.meta)
 }
 
 // Tests https://github.com/prometheus/prometheus/issues/9079.

--- a/util/teststorage/appender.go
+++ b/util/teststorage/appender.go
@@ -614,3 +614,70 @@ func (a *appenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t int64
 	}
 	return ref, partialErr
 }
+
+func (a *appenderV2) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	if err := a.checkErr(); err != nil {
+		return 0, err
+	}
+	if a.a.appendExemplarsError != nil {
+		return 0, a.a.appendExemplarsError
+	}
+
+	if !a.a.skipRecording {
+		var appended bool
+
+		a.a.mtx.Lock()
+		// NOTE(bwplotka): Eventually exemplar has to be attached to a series and soon
+		// the AppenderV2 will guarantee that for TSDB. Assume this from the mock perspective
+		// with the naive attaching. See: https://github.com/prometheus/prometheus/issues/17632
+		i := len(a.a.pendingSamples) - 1
+		for ; i >= 0; i-- { // Attach exemplars to the last matching sample.
+			if labels.Equal(l, a.a.pendingSamples[i].L) {
+				a.a.pendingSamples[i].ES = append(a.a.pendingSamples[i].ES, e)
+				appended = true
+				break
+			}
+		}
+		a.a.mtx.Unlock()
+		if !appended {
+			return 0, fmt.Errorf("teststorage.appenderV2: exemplar appender without series; ref %v; l %v; exemplar: %v", ref, l, e)
+		}
+	}
+
+	if ea, ok := a.next.(storage.ExemplarAppenderV2); ok {
+		return ea.AppendExemplar(ref, l, e)
+	}
+	return computeOrCheckRef(ref, l)
+}
+
+func (a *appenderV2) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	if err := a.checkErr(); err != nil {
+		return 0, err
+	}
+
+	if !a.a.skipRecording {
+		var updated bool
+
+		a.a.mtx.Lock()
+		// NOTE(bwplotka): Eventually metadata has to be attached to a series and soon
+		// the AppenderV2 will guarantee that for TSDB. Assume this from the mock perspective
+		// with the naive attaching. See: https://github.com/prometheus/prometheus/issues/17632
+		i := len(a.a.pendingSamples) - 1
+		for ; i >= 0; i-- { // Attach metadata to the last matching sample.
+			if labels.Equal(l, a.a.pendingSamples[i].L) {
+				a.a.pendingSamples[i].M = m
+				updated = true
+				break
+			}
+		}
+		a.a.mtx.Unlock()
+		if !updated {
+			return 0, fmt.Errorf("teststorage.appenderV2: metadata update without series; ref %v; l %v; m: %v", ref, l, m)
+		}
+	}
+
+	if mu, ok := a.next.(storage.MetadataUpdaterV2); ok {
+		return mu.UpdateMetadata(ref, l, m)
+	}
+	return computeOrCheckRef(ref, l)
+}

--- a/util/teststorage/appender.go
+++ b/util/teststorage/appender.go
@@ -629,3 +629,70 @@ func (a *appenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t int64
 	}
 	return ref, partialErr
 }
+
+func (a *appenderV2) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	if err := a.checkErr(); err != nil {
+		return 0, err
+	}
+	if a.a.appendExemplarsError != nil {
+		return 0, a.a.appendExemplarsError
+	}
+
+	if !a.a.skipRecording {
+		var appended bool
+
+		a.a.mtx.Lock()
+		// NOTE(bwplotka): Eventually exemplar has to be attached to a series and soon
+		// the AppenderV2 will guarantee that for TSDB. Assume this from the mock perspective
+		// with the naive attaching. See: https://github.com/prometheus/prometheus/issues/17632
+		i := len(a.a.pendingSamples) - 1
+		for ; i >= 0; i-- { // Attach exemplars to the last matching sample.
+			if labels.Equal(l, a.a.pendingSamples[i].L) {
+				a.a.pendingSamples[i].ES = append(a.a.pendingSamples[i].ES, e)
+				appended = true
+				break
+			}
+		}
+		a.a.mtx.Unlock()
+		if !appended {
+			return 0, fmt.Errorf("teststorage.appenderV2: exemplar appender without series; ref %v; l %v; exemplar: %v", ref, l, e)
+		}
+	}
+
+	if ea, ok := a.next.(storage.ExemplarAppenderV2); ok {
+		return ea.AppendExemplar(ref, l, e)
+	}
+	return computeOrCheckRef(ref, l)
+}
+
+func (a *appenderV2) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	if err := a.checkErr(); err != nil {
+		return 0, err
+	}
+
+	if !a.a.skipRecording {
+		var updated bool
+
+		a.a.mtx.Lock()
+		// NOTE(bwplotka): Eventually metadata has to be attached to a series and soon
+		// the AppenderV2 will guarantee that for TSDB. Assume this from the mock perspective
+		// with the naive attaching. See: https://github.com/prometheus/prometheus/issues/17632
+		i := len(a.a.pendingSamples) - 1
+		for ; i >= 0; i-- { // Attach metadata to the last matching sample.
+			if labels.Equal(l, a.a.pendingSamples[i].L) {
+				a.a.pendingSamples[i].M = m
+				updated = true
+				break
+			}
+		}
+		a.a.mtx.Unlock()
+		if !updated {
+			return 0, fmt.Errorf("teststorage.appenderV2: metadata update without series; ref %v; l %v; m: %v", ref, l, m)
+		}
+	}
+
+	if mu, ok := a.next.(storage.MetadataUpdaterV2); ok {
+		return mu.UpdateMetadata(ref, l, m)
+	}
+	return computeOrCheckRef(ref, l)
+}

--- a/util/teststorage/appender.go
+++ b/util/teststorage/appender.go
@@ -662,7 +662,7 @@ func (a *appenderV2) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e ex
 	if ea, ok := a.next.(storage.ExemplarAppenderV2); ok {
 		return ea.AppendExemplar(ref, l, e)
 	}
-	return computeOrCheckRef(ref, l)
+	return a.a.computeOrCheckRef(ref, l)
 }
 
 func (a *appenderV2) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
@@ -694,5 +694,5 @@ func (a *appenderV2) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m me
 	if mu, ok := a.next.(storage.MetadataUpdaterV2); ok {
 		return mu.UpdateMetadata(ref, l, m)
 	}
-	return computeOrCheckRef(ref, l)
+	return a.a.computeOrCheckRef(ref, l)
 }

--- a/util/teststorage/appender_test.go
+++ b/util/teststorage/appender_test.go
@@ -104,10 +104,24 @@ func testAppendableV2(t *testing.T, appTest *Appendable, a storage.AppendableV2)
 		_, err = app.Append(0, labels.FromStrings(model.MetricNameLabel, "test_metric3", "app", "v2"), -3, 3, 0, nil, fh, storage.AOptions{})
 		require.NoError(t, err)
 
+		// Fourth series is appended without opts, then gets metadata and an
+		// exemplar attached via the optional standalone AppenderV2 capabilities.
+		ref4, err := app.Append(0, labels.FromStrings(model.MetricNameLabel, "test_metric4", "app", "v2"), -4, 4, 2, nil, nil, storage.AOptions{})
+		require.NoError(t, err)
+
+		m4 := metadata.Metadata{Type: "counter", Unit: "seconds", Help: "help text"}
+		_, err = app.(storage.MetadataUpdaterV2).UpdateMetadata(ref4, labels.FromStrings(model.MetricNameLabel, "test_metric4", "app", "v2"), m4)
+		require.NoError(t, err)
+
+		e4 := exemplar.Exemplar{Labels: labels.FromStrings(model.MetricNameLabel, "trace"), HasTs: true, Ts: 4}
+		_, err = app.(storage.ExemplarAppenderV2).AppendExemplar(ref4, labels.FromStrings(model.MetricNameLabel, "test_metric4", "app", "v2"), e4)
+		require.NoError(t, err)
+
 		exp := []Sample{
 			{L: labels.FromStrings(model.MetricNameLabel, "test_metric1", "app", "v2"), MF: "test_metric1", M: m1, ST: -1, T: 1, V: 2, ES: []exemplar.Exemplar{e1}},
 			{L: labels.FromStrings(model.MetricNameLabel, "test_metric2", "app", "v2"), ST: -2, T: 2, H: h},
 			{L: labels.FromStrings(model.MetricNameLabel, "test_metric3", "app", "v2"), ST: -3, T: 3, FH: fh},
+			{L: labels.FromStrings(model.MetricNameLabel, "test_metric4", "app", "v2"), M: m4, ST: -4, T: 4, V: 2, ES: []exemplar.Exemplar{e4}},
 		}
 		testutil.RequireEqual(t, exp, appTest.PendingSamples())
 		require.Nil(t, appTest.ResultSamples())

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -364,7 +364,7 @@ func NewAPI(
 	}
 
 	if rwEnabled {
-		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, acceptRemoteWriteProtoMsgs, stZeroIngestionEnabled, enableTypeAndUnitLabels, appendMetadata)
+		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, apV2, acceptRemoteWriteProtoMsgs, stZeroIngestionEnabled, enableTypeAndUnitLabels, appendMetadata)
 	}
 	if otlpEnabled {
 		a.otlpWriteHandler = remote.NewOTLPWriteHandler(logger, registerer, apV2, configFunc, remote.OTLPOptions{

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -375,7 +375,7 @@ func NewAPI(
 	}
 
 	if rwEnabled {
-		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, acceptRemoteWriteProtoMsgs, stZeroIngestionEnabled, enableTypeAndUnitLabels, appendMetadata)
+		a.remoteWriteHandler = remote.NewWriteHandler(logger, registerer, ap, apV2, acceptRemoteWriteProtoMsgs, stZeroIngestionEnabled, enableTypeAndUnitLabels, appendMetadata)
 	}
 	if otlpEnabled {
 		a.otlpWriteHandler = remote.NewOTLPWriteHandler(logger, registerer, apV2, configFunc, remote.OTLPOptions{


### PR DESCRIPTION
Part of #17632.

Alternative to #19248. Same goal (migrate the Remote Write 1.0 receiver to `AppenderV2`) but **without modifying the exported `storage.AppenderV2` interface**, so downstream `AppenderV2` implementations are not forced to change.

## What

The RW 1.0 receiver path (`writeHandler.write`) is ported from V1 `storage.Appender` to `storage.AppenderV2`. RW 1.0 carries exemplars as a per-series list appended through a standalone `AppendExemplar` call, which `AppenderV2` (exemplars via `AppendV2Options`) does not offer.

Instead of adding methods to `storage.AppenderV2`, this introduces two **optional capability interfaces**, `storage.ExemplarAppenderV2` and `storage.MetadataUpdaterV2`, discovered via a type assertion — the same idiom as `storage.GetRef`. The remote-write package composes them into the capability its receiver requires (`receiverAppenderV2`). Only Prometheus' own appenders on the RW path implement them:

- **tsdb head**: `AppendExemplar`/`UpdateMetadata` moved to the shared `headAppenderBase` so both V1 and V2 appenders share one implementation; `initAppenderV2` delegates.
- **tsdb agent**: the two methods moved to the shared `appenderBase`.
- **fanoutAppenderV2**: delegates only to appenders that also implement the optional capability.
- **remote-write `timestampTrackerV2`**: counts exemplars, metadata no-op.
- **notReadyAppenderV2**: returns `ErrNotReady`.
- **teststorage**: records via the optional capabilities.

The Remote Write 2.x path (`writeV2`) still uses the V1 appendable and will be migrated separately. `NewWriteHandler` now takes both `appendable` and `appendableV2`; `web/api/v1` passes both.

## Why this shape

`storage.AppenderV2` is implemented by downstream projects (e.g. Cortex/Mimir). Adding methods to it is a breaking change for them. Keeping exemplar/metadata as optional, assertion-discovered capabilities avoids that while still letting the receiver reuse the standalone-append shape.

## Tests

- RW 1.0 handler tests now exercise the `AppenderV2` path (the mock appendable gained a V2 appender recording into the same slices, so existing assertions hold).
- `TestHeadAppenderV2_AppendExemplarAndUpdateMetadata` verifies the head implements the optional capabilities and stores the exemplar (via `ExemplarQuerier`) and metadata.
- teststorage's shared V2 appender test covers the optional methods (incl. `.Then` chaining).

```release-notes
NONE
```