### PR TITLE
storage/remote: send metadata when MetadataWatcher starts

### DIFF
--- a/storage/remote/metadata_watcher.go
+++ b/storage/remote/metadata_watcher.go
@@ -115,6 +115,10 @@ func (mw *MetadataWatcher) loop() {
 	defer ticker.Stop()
 	defer close(mw.done)
 
+	// Collect once at start so remote storage gets metadata without waiting
+	// a full send_interval after the watcher begins.
+	mw.collect()
+
 	for {
 		select {
 		case <-mw.softShutdownCtx.Done():

--- a/storage/remote/metadata_watcher_test.go
+++ b/storage/remote/metadata_watcher_test.go
@@ -16,6 +16,7 @@ package remote
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -54,11 +55,20 @@ func (*TestMetaStore) SizeMetadata() int   { return 0 }
 func (*TestMetaStore) LengthMetadata() int { return 0 }
 
 type writeMetadataToMock struct {
+	mu               sync.Mutex
 	metadataAppended int
 }
 
 func (mwtm *writeMetadataToMock) AppendWatcherMetadata(_ context.Context, m []scrape.MetricMetadata) {
+	mwtm.mu.Lock()
+	defer mwtm.mu.Unlock()
 	mwtm.metadataAppended += len(m)
+}
+
+func (mwtm *writeMetadataToMock) appended() int {
+	mwtm.mu.Lock()
+	defer mwtm.mu.Unlock()
+	return mwtm.metadataAppended
 }
 
 func newMetadataWriteToMock() *writeMetadataToMock {
@@ -97,7 +107,7 @@ func TestWatchScrapeManager_NotReady(t *testing.T) {
 
 	mw.collect()
 
-	require.Equal(t, 0, wt.metadataAppended)
+	require.Equal(t, 0, wt.appended())
 }
 
 func TestWatchScrapeManager_ReadyForCollection(t *testing.T) {
@@ -151,5 +161,45 @@ func TestWatchScrapeManager_ReadyForCollection(t *testing.T) {
 
 	mw.collect()
 
-	require.Equal(t, 2, wt.metadataAppended)
+	require.Equal(t, 2, wt.appended())
+}
+
+func TestMetadataWatcher_CollectsOnStart(t *testing.T) {
+	wt := newMetadataWriteToMock()
+
+	metadata := &TestMetaStore{
+		Metadata: []scrape.MetricMetadata{
+			{
+				MetricFamily: "prometheus_tsdb_head_chunks_created",
+				Type:         model.MetricTypeCounter,
+				Help:         "Total number",
+				Unit:         "",
+			},
+			{
+				MetricFamily: "prometheus_remote_storage_retried_samples",
+				Type:         model.MetricTypeCounter,
+				Help:         "Total number",
+				Unit:         "",
+			},
+		},
+	}
+
+	target := &scrape.Target{}
+	target.SetMetadataStore(metadata)
+
+	manager := &fakeManager{
+		activeTargets: map[string][]*scrape.Target{
+			"job": {target},
+		},
+	}
+
+	// Interval is deliberately long so a pass cannot come from the ticker.
+	mw := NewMetadataWatcher(nil, &scrapeManagerMock{ready: true}, "", wt, model.Duration(time.Hour), time.Second)
+	mw.manager = manager
+	mw.Start()
+	t.Cleanup(mw.Stop)
+
+	require.Eventually(t, func() bool {
+		return wt.appended() == 2
+	}, time.Second, 10*time.Millisecond)
 }


### PR DESCRIPTION
## What

When `metadata_config.send` is enabled for remote write v1, `MetadataWatcher` waited for the first `send_interval` before collecting any scraped metadata. Receivers could get samples without type/help/unit for that whole first interval.

Collect once when the watcher starts. Keep the existing interval for later sends.

## Changes

- `MetadataWatcher.loop` calls `collect()` before waiting on the ticker
- Test covers the startup send with a long interval so a pass cannot come from the ticker
- Small lock on the test mock so concurrent appends from the watcher are safe to read

## Test plan

- [x] `go test ./storage/remote/ -run 'TestWatchScrapeManager|TestMetadataWatcher'`
- [ ] CI

Fixes #19222

```release-notes
[ENHANCEMENT] Remote Write: Send scraped metadata when the metadata watcher starts instead of waiting for the first send_interval.
```