### PR TITLE
promtool: skip and count duplicate samples during backfill

### DIFF
--- a/cmd/promtool/backfill.go
+++ b/cmd/promtool/backfill.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/textparse"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
 )
 
@@ -97,8 +99,9 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 	}()
 
 	var (
-		wroteHeader  bool
-		nextSampleTs int64 = math.MaxInt64
+		wroteHeader       bool
+		nextSampleTs      int64 = math.MaxInt64
+		duplicatesSkipped int
 	)
 
 	lb := labels.NewBuilder(labels.EmptyLabels())
@@ -170,6 +173,16 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 				lbls := lb.Labels()
 
 				if _, err := app.Append(0, lbls, *ts, v); err != nil {
+					// Within a single appender batch, TSDB silently drops duplicate
+					// samples (same series + timestamp, different value) at Commit().
+					// Across batch boundaries the first sample has already been
+					// committed, so Append returns ErrDuplicateSampleForTimestamp.
+					// Skip those samples so behaviour is consistent regardless of
+					// where the duplicate falls relative to maxSamplesInAppender.
+					if errors.Is(err, storage.ErrDuplicateSampleForTimestamp) {
+						duplicatesSkipped++
+						continue
+					}
 					return fmt.Errorf("add sample: %w", err)
 				}
 
@@ -224,6 +237,10 @@ func createBlocks(input []byte, mint, maxt, maxBlockDuration int64, maxSamplesIn
 		if err != nil {
 			return fmt.Errorf("process blocks: %w", err)
 		}
+	}
+
+	if !quiet && duplicatesSkipped > 0 {
+		fmt.Fprintf(os.Stderr, "skipped %d duplicate sample(s)\n", duplicatesSkipped)
 	}
 	return nil
 }

--- a/cmd/promtool/backfill_test.go
+++ b/cmd/promtool/backfill_test.go
@@ -682,6 +682,115 @@ http_requests_total{code="200"} 3 1629863088.000
 			},
 		},
 		{
+			// Regression test for https://github.com/prometheus/prometheus/issues/12531.
+			// Duplicate samples (same series + timestamp, different value) that cross an
+			// appender batch boundary must be skipped (first value wins), matching the
+			// within-batch behaviour where the TSDB commit already drops them without error.
+			ToParse: `# HELP http_requests_total The total number of HTTP requests.
+# TYPE http_requests_total counter
+http_requests_total{code="200"} 1 1565133713.989
+http_requests_total{code="200"} 2 1565133713.989
+http_requests_total{code="200"} 3 1565133714.989
+# EOF
+`,
+			IsOk:                 true,
+			Description:          "Duplicate samples across appender batch boundary are skipped, not fatal.",
+			MaxSamplesInAppender: 1,
+			Expected: struct {
+				MinTime       int64
+				MaxTime       int64
+				NumBlocks     int
+				BlockDuration int64
+				Samples       []backfillSample
+			}{
+				MinTime:       1565133713989,
+				MaxTime:       1565133714989,
+				NumBlocks:     1,
+				BlockDuration: tsdb.DefaultBlockDuration,
+				Samples: []backfillSample{
+					{
+						Timestamp: 1565133713989,
+						Value:     1,
+						Labels:    labels.FromStrings("__name__", "http_requests_total", "code", "200"),
+					},
+					{
+						Timestamp: 1565133714989,
+						Value:     3,
+						Labels:    labels.FromStrings("__name__", "http_requests_total", "code", "200"),
+					},
+				},
+			},
+		},
+		{
+			// Issue #12531 reproducer: multiple conflicting values for the same
+			// series+timestamp. With MaxSamplesInAppender=1 every append commits
+			// immediately so every duplicate takes the cross-batch path.
+			ToParse: `# HELP camel_route_exchange Camel route exchange count.
+# TYPE camel_route_exchange gauge
+camel_route_exchange{host="XXX"} 12 1686096035.177
+camel_route_exchange{host="XXX"} 11 1686096035.177
+camel_route_exchange{host="XXX"} 13 1686096035.177
+camel_route_exchange{host="XXX"} 10 1686096035.177
+# EOF
+`,
+			IsOk:                 true,
+			Description:          "Issue #12531 repro: multiple duplicates for one series+timestamp are skipped.",
+			MaxSamplesInAppender: 1,
+			Expected: struct {
+				MinTime       int64
+				MaxTime       int64
+				NumBlocks     int
+				BlockDuration int64
+				Samples       []backfillSample
+			}{
+				MinTime:       1686096035177,
+				MaxTime:       1686096035177,
+				NumBlocks:     1,
+				BlockDuration: tsdb.DefaultBlockDuration,
+				Samples: []backfillSample{
+					{
+						Timestamp: 1686096035177,
+						Value:     12,
+						Labels:    labels.FromStrings("__name__", "camel_route_exchange", "host", "XXX"),
+					},
+				},
+			},
+		},
+		{
+			// Same four conflicting samples as above, but all inside one appender
+			// batch. Must also succeed (TSDB drops duplicates at Commit).
+			ToParse: `# HELP camel_route_exchange Camel route exchange count.
+# TYPE camel_route_exchange gauge
+camel_route_exchange{host="XXX"} 14 1686096035.177
+camel_route_exchange{host="XXX"} 2 1686096035.177
+camel_route_exchange{host="XXX"} 40 1686096035.177
+camel_route_exchange{host="XXX"} 1 1686096035.177
+# EOF
+`,
+			IsOk:                 true,
+			Description:          "Within-batch duplicate samples are silently dropped at commit.",
+			MaxSamplesInAppender: 5000,
+			Expected: struct {
+				MinTime       int64
+				MaxTime       int64
+				NumBlocks     int
+				BlockDuration int64
+				Samples       []backfillSample
+			}{
+				MinTime:       1686096035177,
+				MaxTime:       1686096035177,
+				NumBlocks:     1,
+				BlockDuration: tsdb.DefaultBlockDuration,
+				Samples: []backfillSample{
+					{
+						Timestamp: 1686096035177,
+						Value:     14,
+						Labels:    labels.FromStrings("__name__", "camel_route_exchange", "host", "XXX"),
+					},
+				},
+			},
+		},
+		{
 			ToParse: `# HELP rpc_duration_seconds A summary of the RPC duration in seconds.
 # TYPE rpc_duration_seconds summary
 rpc_duration_seconds{quantile="0.01"} 3102


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #12531

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] promtool: Fix backfill aborting on duplicate samples that straddle appender batch boundaries; skip and report them instead.
```

## Summary

`promtool tsdb create-blocks-from openmetrics` handled duplicate samples inconsistently:

- **Within one appender batch** (`maxSamplesInAppender`, default 5000): TSDB drops the duplicate at `Commit()` with no error.
- **Across batch boundaries**: the first sample is already committed, so `Append()` returns `storage.ErrDuplicateSampleForTimestamp` and backfill aborted with `add sample: duplicate sample for timestamp`.

The same input could therefore succeed or fail depending only on file size / where the duplicate fell relative to the batch boundary (as reported in #12531 and confirmed in the issue discussion).

## Fix

On `app.Append()`:

1. If the error is `storage.ErrDuplicateSampleForTimestamp`, **skip** the sample (first value wins) and continue.
2. **Count** skipped duplicates.
3. When not `--quiet`, print `skipped N duplicate sample(s)` to stderr after the run.

Other append errors remain fatal.

## Relation to closed PR #18808

#18808 proposed the same core skip of `ErrDuplicateSampleForTimestamp` but was closed unmerged. This PR differs by:

- Counting skipped duplicates and logging a summary (unless `--quiet`), so large noisy imports are observable rather than silently truncated only on the cross-batch path.
- Adding the original issue reproducer (`camel_route_exchange` multi-value same-timestamp lines) as tests for both cross-batch (`MaxSamplesInAppender=1`) and within-batch paths, not only a synthetic two-sample case.

## Tests

- Cross-batch regression with `MaxSamplesInAppender: 1` (every sample flushes).
- Issue #12531 repro (four conflicting values, cross-batch) — first value kept, import succeeds.
- Within-batch control (same shape, default batch size) — still succeeds; first value kept.

```text
go test ./cmd/promtool/ -run TestBackfill -count=1
```