### PR TITLE
promql: honour @ modifier when evaluating info series

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1843,7 +1843,10 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration,
 // For every storage.Series iterator in series, the method iterates in ev.interval sized steps from ev.startTimestamp until and including ev.endTimestamp,
 // collecting every corresponding sample (obtained via ev.vectorSelectorSingle) into a Series.
 // All of the generated Series are collected into a Matrix, that gets returned.
-func (ev *evaluator) evalSeries(ctx context.Context, series []storage.Series, offset time.Duration, recordOrigT bool) Matrix {
+// If atTimestamp is non-nil, every step is evaluated as of that fixed timestamp instead of the
+// step timestamp (the sample is still emitted at the step timestamp); this is used by info() so
+// that an @ modifier on its first argument pins the info-series lookup to that timestamp.
+func (ev *evaluator) evalSeries(ctx context.Context, series []storage.Series, offset time.Duration, recordOrigT bool, atTimestamp *int64) Matrix {
 	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
 
 	mat := make(Matrix, 0, len(series))
@@ -1863,7 +1866,11 @@ func (ev *evaluator) evalSeries(ctx context.Context, series []storage.Series, of
 
 		for ts, step := ev.startTimestamp, -1; ts <= ev.endTimestamp; ts += ev.interval {
 			step++
-			_, origT, f, h, ok := ev.vectorSelectorSingle(it, offset, ts)
+			lookupTS := ts
+			if atTimestamp != nil {
+				lookupTS = *atTimestamp
+			}
+			_, origT, f, h, ok := ev.vectorSelectorSingle(it, offset, lookupTS)
 			if !ok {
 				continue
 			}
@@ -2542,7 +2549,7 @@ func (ev *evaluator) eval(ctx context.Context, expr parser.Expr) (parser.Value, 
 			ws.Merge(smoothAnnos)
 			return mat, ws
 		}
-		mat := ev.evalSeries(ctx, e.Series, e.Offset, false)
+		mat := ev.evalSeries(ctx, e.Series, e.Offset, false, nil)
 		return mat, ws
 
 	case *parser.MatrixSelector:

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1844,8 +1844,7 @@ func (ev *evaluator) smoothSeries(series []storage.Series, offset time.Duration,
 // collecting every corresponding sample (obtained via ev.vectorSelectorSingle) into a Series.
 // All of the generated Series are collected into a Matrix, that gets returned.
 // If atTimestamp is non-nil, every step is evaluated as of that fixed timestamp instead of the
-// step timestamp (the sample is still emitted at the step timestamp); this is used by info() so
-// that an @ modifier on its first argument pins the info-series lookup to that timestamp.
+// step timestamp; the sample is still emitted at the step timestamp.
 func (ev *evaluator) evalSeries(ctx context.Context, series []storage.Series, offset time.Duration, recordOrigT bool, atTimestamp *int64) Matrix {
 	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
 

--- a/promql/info.go
+++ b/promql/info.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/grafana/regexp"
 	"github.com/prometheus/common/model"
@@ -72,8 +73,12 @@ func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (par
 		}
 	}
 
+	// The @ timestamp and offset on the first argument must also govern at which time the info
+	// series are evaluated and matched (not just which series are selected), so that info(v @ T)
+	// enriches with the info series as of T at every step, independent of the evaluation time.
+	nodeTimestamp, offset := infoSelectTimestampAndOffset(args[0])
 	selectHints := ev.infoSelectHints(args[0])
-	infoSeries, ws, err := ev.fetchInfoSeries(ctx, mat, ignoreSeries, dataLabelMatchers, selectHints)
+	infoSeries, ws, err := ev.fetchInfoSeries(ctx, mat, ignoreSeries, dataLabelMatchers, selectHints, nodeTimestamp, offset)
 	if err != nil {
 		ev.error(err)
 	}
@@ -104,22 +109,26 @@ func effectiveInfoNameMatchers(matchers []*labels.Matcher) []*labels.Matcher {
 	return []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, targetInfo)}
 }
 
+// infoSelectTimestampAndOffset returns the @ timestamp (nil if unset) and offset that govern
+// selection and evaluation of the info series, given expr (the first argument to an info call).
+// They are taken from the first vector selector found in expr, mirroring the way infoSelectHints
+// and Prometheus's step-invariance handling treat the modifiers on the first argument.
+func infoSelectTimestampAndOffset(expr parser.Expr) (nodeTimestamp *int64, offset time.Duration) {
+	parser.Inspect(expr, func(node parser.Node, _ []parser.Node) error {
+		if n, ok := node.(*parser.VectorSelector); ok {
+			nodeTimestamp = n.Timestamp
+			offset = n.OriginalOffset
+			return errors.New("end traversal")
+		}
+		return nil
+	})
+	return nodeTimestamp, offset
+}
+
 // infoSelectHints calculates the storage.SelectHints for selecting info series, given expr (first argument to info call).
 func (ev *evaluator) infoSelectHints(expr parser.Expr) storage.SelectHints {
-	var nodeTimestamp *int64
-	var offset int64
-	parser.Inspect(expr, func(node parser.Node, _ []parser.Node) error {
-		switch n := node.(type) {
-		case *parser.VectorSelector:
-			if n.Timestamp != nil {
-				nodeTimestamp = n.Timestamp
-			}
-			offset = durationMilliseconds(n.OriginalOffset)
-			return errors.New("end traversal")
-		default:
-			return nil
-		}
-	})
+	nodeTimestamp, offset := infoSelectTimestampAndOffset(expr)
+	offsetMs := durationMilliseconds(offset)
 
 	start := ev.startTimestamp
 	end := ev.endTimestamp
@@ -132,8 +141,8 @@ func (ev *evaluator) infoSelectHints(expr parser.Expr) storage.SelectHints {
 	// because wo want to exclude samples that are precisely the
 	// lookback delta before the eval time.
 	start -= durationMilliseconds(ev.lookbackDelta) - 1
-	start -= offset
-	end -= offset
+	start -= offsetMs
+	end -= offsetMs
 
 	return storage.SelectHints{
 		Start: start,
@@ -146,7 +155,7 @@ func (ev *evaluator) infoSelectHints(expr parser.Expr) storage.SelectHints {
 // fetchInfoSeries fetches info series given matching identifying labels in mat.
 // Series in ignoreSeries are not fetched.
 // dataLabelMatchers may be mutated.
-func (ev *evaluator) fetchInfoSeries(ctx context.Context, mat Matrix, ignoreSeries map[uint64]struct{}, dataLabelMatchers map[string][]*labels.Matcher, selectHints storage.SelectHints) (Matrix, annotations.Annotations, error) {
+func (ev *evaluator) fetchInfoSeries(ctx context.Context, mat Matrix, ignoreSeries map[uint64]struct{}, dataLabelMatchers map[string][]*labels.Matcher, selectHints storage.SelectHints, atTimestamp *int64, offset time.Duration) (Matrix, annotations.Annotations, error) {
 	removeNameFromDataLabelMatchers := func() {
 		for name, ms := range dataLabelMatchers {
 			ms = slices.DeleteFunc(ms, func(m *labels.Matcher) bool {
@@ -228,7 +237,10 @@ func (ev *evaluator) fetchInfoSeries(ctx context.Context, mat Matrix, ignoreSeri
 		return nil, ws, err
 	}
 
-	infoMat := ev.evalSeries(ctx, infoSeries, 0, true)
+	// Evaluate the info series at the @-pinned timestamp (when set) and shifted by the offset,
+	// so enrichment reflects the info series as of the time selected by the first argument's
+	// modifiers, consistently at every step, rather than the raw evaluation timestamp.
+	infoMat := ev.evalSeries(ctx, infoSeries, offset, true, atTimestamp)
 	return infoMat, ws, nil
 }
 

--- a/promql/info.go
+++ b/promql/info.go
@@ -38,6 +38,14 @@ var identifyingLabels = []string{"instance", "job"}
 
 // evalInfo implements the info PromQL function.
 func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (parser.Value, annotations.Annotations) {
+	// The @ timestamp and offset on the first argument also govern at which time the info
+	// series are evaluated and matched (not just which series are selected), so that info(v @ T)
+	// enriches with the info series as of T at every step, independent of the evaluation time.
+	// They must be extracted before evaluating the first argument: evaluating a subquery
+	// replaces it in the expression with a materialized matrix selector that no longer carries
+	// the modifiers of the selectors inside the subquery.
+	nodeTimestamp, offset := infoSelectTimestampAndOffset(args[0])
+
 	val, annots := ev.eval(ctx, args[0])
 	mat := val.(Matrix)
 	// Map from data label name to matchers.
@@ -73,10 +81,6 @@ func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (par
 		}
 	}
 
-	// The @ timestamp and offset on the first argument must also govern at which time the info
-	// series are evaluated and matched (not just which series are selected), so that info(v @ T)
-	// enriches with the info series as of T at every step, independent of the evaluation time.
-	nodeTimestamp, offset := infoSelectTimestampAndOffset(args[0])
 	selectHints := ev.infoSelectHints(nodeTimestamp, offset)
 	infoSeries, ws, err := ev.fetchInfoSeries(ctx, mat, ignoreSeries, dataLabelMatchers, selectHints, nodeTimestamp, offset)
 	if err != nil {
@@ -111,16 +115,27 @@ func effectiveInfoNameMatchers(matchers []*labels.Matcher) []*labels.Matcher {
 
 // infoSelectTimestampAndOffset returns the @ timestamp (nil if unset) and offset that govern
 // selection and evaluation of the info series, given expr (the first argument to an info call).
-// They are taken from the first vector selector found in expr, mirroring the way Prometheus's
-// step-invariance handling treats the modifiers on the first argument.
+// The reference time is derived from the first vector selector found in expr: the innermost @
+// timestamp among the selector and its enclosing subqueries anchors it (the evaluation time if
+// none is set), shifted by the offsets accumulated from the selector up to and including the
+// anchoring node.
 func infoSelectTimestampAndOffset(expr parser.Expr) (nodeTimestamp *int64, offset time.Duration) {
-	parser.Inspect(expr, func(node parser.Node, _ []parser.Node) error {
-		if n, ok := node.(*parser.VectorSelector); ok {
-			nodeTimestamp = n.Timestamp
-			offset = n.OriginalOffset
-			return errors.New("end traversal")
+	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
+		n, ok := node.(*parser.VectorSelector)
+		if !ok {
+			return nil
 		}
-		return nil
+		nodeTimestamp = n.Timestamp
+		offset = n.OriginalOffset
+		// Enclosing subqueries shift the selector's reference time: their offsets add up until
+		// an @ timestamp anchors it, making any modifiers further out irrelevant.
+		for i := len(path) - 1; nodeTimestamp == nil && i >= 0; i-- {
+			if sq, ok := path[i].(*parser.SubqueryExpr); ok {
+				offset += sq.OriginalOffset
+				nodeTimestamp = sq.Timestamp
+			}
+		}
+		return errors.New("end traversal")
 	})
 	return nodeTimestamp, offset
 }

--- a/promql/info.go
+++ b/promql/info.go
@@ -77,7 +77,7 @@ func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (par
 	// series are evaluated and matched (not just which series are selected), so that info(v @ T)
 	// enriches with the info series as of T at every step, independent of the evaluation time.
 	nodeTimestamp, offset := infoSelectTimestampAndOffset(args[0])
-	selectHints := ev.infoSelectHints(args[0])
+	selectHints := ev.infoSelectHints(nodeTimestamp, offset)
 	infoSeries, ws, err := ev.fetchInfoSeries(ctx, mat, ignoreSeries, dataLabelMatchers, selectHints, nodeTimestamp, offset)
 	if err != nil {
 		ev.error(err)
@@ -111,8 +111,8 @@ func effectiveInfoNameMatchers(matchers []*labels.Matcher) []*labels.Matcher {
 
 // infoSelectTimestampAndOffset returns the @ timestamp (nil if unset) and offset that govern
 // selection and evaluation of the info series, given expr (the first argument to an info call).
-// They are taken from the first vector selector found in expr, mirroring the way infoSelectHints
-// and Prometheus's step-invariance handling treat the modifiers on the first argument.
+// They are taken from the first vector selector found in expr, mirroring the way Prometheus's
+// step-invariance handling treats the modifiers on the first argument.
 func infoSelectTimestampAndOffset(expr parser.Expr) (nodeTimestamp *int64, offset time.Duration) {
 	parser.Inspect(expr, func(node parser.Node, _ []parser.Node) error {
 		if n, ok := node.(*parser.VectorSelector); ok {
@@ -125,9 +125,9 @@ func infoSelectTimestampAndOffset(expr parser.Expr) (nodeTimestamp *int64, offse
 	return nodeTimestamp, offset
 }
 
-// infoSelectHints calculates the storage.SelectHints for selecting info series, given expr (first argument to info call).
-func (ev *evaluator) infoSelectHints(expr parser.Expr) storage.SelectHints {
-	nodeTimestamp, offset := infoSelectTimestampAndOffset(expr)
+// infoSelectHints calculates the storage.SelectHints for selecting info series, given the
+// @ timestamp (nil if unset) and offset that govern the first argument to the info call.
+func (ev *evaluator) infoSelectHints(nodeTimestamp *int64, offset time.Duration) storage.SelectHints {
 	offsetMs := durationMilliseconds(offset)
 
 	start := ev.startTimestamp

--- a/promql/promqltest/testdata/info.test
+++ b/promql/promqltest/testdata/info.test
@@ -211,6 +211,33 @@ eval range from 1m to 4m step 1m info(metric @ 60)
 eval range from 1m to 4m step 1m info(metric offset 1m)
     metric{data="info", instance="a", job="1", label="value"} 0 0 2 3
 
+# @ operator works also with info in an instant query.
+# Because info() evaluates the info series as of the @ timestamp, info(metric @ 60) is step
+# invariant: it returns the same result at any evaluation time, so the instant-query test
+# harness's @-invariance checks (which re-evaluate at other eval times) hold.
+eval instant at 4m info(metric @ 60)
+    metric{data="info", instance="a", job="1", label="value"} 0
+
+clear
+
+# info() honours the @ modifier when evaluating the info series, not just when selecting it.
+load 1m
+    metric{instance="a", job="1"} 1 2 3 4 5 6 7 8
+    target_info{instance="a", job="1", version="v1"} 1
+
+# The enrichment is evaluated as of t=0 (the @ timestamp) at every step, independent of the
+# query range start: the two queries below agree on the shared timestamps 6m and 7m.
+eval range from 4m to 7m step 1m info(metric @ 0)
+    metric{instance="a", job="1", version="v1"} 1 1 1 1
+
+eval range from 6m to 7m step 1m info(metric @ 0)
+    metric{instance="a", job="1", version="v1"} 1 1
+
+# The same holds for an instant query far past the @ timestamp: enrichment is pinned to t=0
+# rather than being looked up (and lost) at the evaluation time.
+eval instant at 40m info(metric @ 0)
+    metric{instance="a", job="1", version="v1"} 1
+
 clear
 
 # info_metric churn:

--- a/promql/promqltest/testdata/info.test
+++ b/promql/promqltest/testdata/info.test
@@ -240,6 +240,40 @@ eval instant at 40m info(metric @ 0)
 
 clear
 
+# Churning target_info series: @ and offset pin which info series enriches, not just whether
+# one is found.
+load 1m
+    metric{instance="a", job="1"} 0 1 2 3 4 5 6 7 8
+    target_info{instance="a", job="1", version="old"} 1 1 1 stale
+    target_info{instance="a", job="1", version="new"} _ _ _ 1 1 1 1 1 1
+
+# The info series is matched as of ts-2m, like the base samples, so enrichment reflects the
+# version current at the offset-shifted time and switches when that time crosses the flip at 3m.
+eval range from 4m to 8m step 1m info(metric offset 2m)
+    metric{instance="a", job="1", version="old"} 2 _ _ _ _
+    metric{instance="a", job="1", version="new"} _ 3 4 5 6
+
+# The @ timestamp selects the version current at 2m, even at evaluation times where "new" is
+# current and "old" has gone stale.
+eval range from 8m to 9m step 1m info(metric @ 120)
+    metric{instance="a", job="1", version="old"} 2 2
+
+# @ on a subquery argument is honoured too: enrichment is as of the subquery's @ timestamp.
+eval instant at 40m info(last_over_time(metric[10m:1m] @ 420))
+    metric{instance="a", job="1", version="new"} 7
+
+# An offset inside a pinned subquery shifts the info series reference time as well: samples
+# are read as of 2m (@ 3m minus the 1m offset), when "old" was still current.
+eval instant at 40m info(last_over_time((metric offset 1m)[10m:1m] @ 180))
+    metric{instance="a", job="1", version="old"} 2
+
+# Without @, a subquery offset shifts the info series reference time per step.
+eval range from 8m to 9m step 1m info(last_over_time(metric[5m:1m] offset 6m))
+    metric{instance="a", job="1", version="old"} 2 _
+    metric{instance="a", job="1", version="new"} _ 3
+
+clear
+
 # info_metric churn:
 
 load 1m


### PR DESCRIPTION
This PR makes `info()` actually honor the `@`/offset when evaluating and matching the info series, not just when selecting them. This mirrors what `infoSelectHints` already does for the fetch window, so fetch and eval are now consistent.

`info(metric @ 0)` now enriches with the info series as of t=0 at every step and eval time so it's genuinely step-invariant, fixing the problems described below without adding info() to @ modifier unsafe functions list (which would modify current behaviour though it doesn't break existing tests in Prometheus).

The test cases with expected behaviour are added in the first commit and fail, then the second commit with the fix makes them pass.

The issue I had which led to this was that test cases for @ wouldn't work with instant queries.

<details>
  <summary>Claude's summary of the current problem</summary>
  
# `info()` and the `@` modifier: the problem

## What `info()` does

`info(metric)` enriches each sample of `metric` with labels pulled from a matching
`target_info` series (matched on identifying labels like `instance`/`job`). So
`info(http_requests @ 8:00)` should return `http_requests` evaluated at 8:00, tagged with the
`target_info` labels that applied at 8:00.

## The `@` modifier's job

`@ <ts>` pins evaluation to timestamp `<ts>` regardless of query eval time. `metric @ 8:00`
always means "metric as of 8:00." An expression where every selector is `@`-pinned is
**step-invariant**: it should return the same value at every step of a range query and at any
instant eval time.

## Bug part 1 — `info()` only half-applies the `@`

Look at how enrichment is fetched vs. matched (`promql/info.go`):

- `infoSelectHints(args[0])` reads the `@`/offset off the first selector and pins the
  **storage fetch window** for `target_info` to that timestamp. ✅ honors `@`.
- But `fetchInfoSeries` → `evalSeries(..., 0, true)` then evaluates those fetched `target_info`
  series at the **query's own step timestamps** (`ev.startTimestamp..ev.endTimestamp`), and
  `combineWithInfoSeries` matches them to base samples **at each eval step** — not at the `@`
  timestamp. ❌ ignores `@`.

Concrete consequence: `info(metric @ 0)` with a single `target_info` sample at t=0.

- Eval at t=4m: lookback window `[4m-5m, 4m]` includes t=0 → `target_info` found → enriched.
- Eval at t=40m: lookback window `[40m-5m, 40m]` excludes t=0 → `target_info` not found →
  **not enriched**.

Same `@ 0`, different result depending on eval time. That violates what `@` guarantees.

## Bug part 2 — the engine assumes `info()` is step-invariant when it isn't

`preprocessExprHelper` (`promql/engine.go`) decides whether to wrap a call in a
`StepInvariantExpr`. It treats a function as step-invariant unless the name is in
`AtModifierUnsafeFunctions` (`promql/functions.go`). `info` is **not** in that set, so
`info(metric @ 0)` gets wrapped as step-invariant.

A `StepInvariantExpr` is evaluated **once**, at the query's **start timestamp**, and the result
is replicated to every step. But from Bug part 1 we know `info()`'s result actually depends on
the eval timestamp. So the replicated value is "whatever enrichment happened at the query
start," stamped onto every step.

Concrete consequence — same data (one `target_info` sample at t=0), same timestamps queried,
different query ranges:

```
eval range from 4m to 7m step 1m info(metric @ 0)
    metric{... version="v1"} 1 1 1 1        # enrichment computed at start=4m; 4m sees t=0 within lookback

eval range from 6m to 7m step 1m info(metric @ 0)
    metric{...}              1 1            # enrichment computed at start=6m; 6m does NOT see t=0; no label
```

The value at t=6m and t=7m is enriched in the first query and unenriched in the second — purely
because the query **started** at a different time. That's the clearest "this is a bug" symptom.

There's also a corollary for instant queries: the test harness's `atModifierTestCases` re-runs a
fully-`@`-pinned instant query at several eval times and expects identical results. Because of
Bug part 1, `info(metric @ 60)` fails that check today — which is why existing `info.test` only
covers `@` with range queries.

## The fix

Make `info()` actually match `target_info` at the `@`-pinned timestamp, not the eval-step timestamp.
Then `info(metric @ 0)` genuinely returns the t=0 enrichment at every step/eval time — truly
step-invariant, and consistent with the fetch window `infoSelectHints` already pins.

</details>

#### Which issue(s) does the PR fix:

N/A

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] PromQL: info() now applies the @ modifier/offset when evaluating the info series, so info(v @ T) enriches as of T consistently instead of depending on the query start/eval time
```
