### PR TITLE
promql: share native-histogram bucket interpolation between trimming and histogram_fraction

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -2350,32 +2350,14 @@ func handleInfinityBuckets(isUpperTrim bool, b Bucket[float64], rhs float64) (un
 }
 
 // computeSplit calculates the portion of the bucket's count <= rhs (trim point).
-func computeSplit(b Bucket[float64], rhs float64, isPositive, isLinear bool) float64 {
+func computeSplit(b Bucket[float64], rhs float64, isLinear bool) float64 {
 	if rhs <= b.Lower {
 		return 0
 	}
 	if rhs >= b.Upper {
 		return b.Count
 	}
-
-	var fraction float64
-	switch {
-	case isLinear:
-		fraction = (rhs - b.Lower) / (b.Upper - b.Lower)
-	default:
-		// Exponential interpolation.
-		logLower := math.Log2(math.Abs(b.Lower))
-		logUpper := math.Log2(math.Abs(b.Upper))
-		logV := math.Log2(math.Abs(rhs))
-
-		if isPositive {
-			fraction = (logV - logLower) / (logUpper - logLower)
-		} else {
-			fraction = 1 - ((logV - logUpper) / (logLower - logUpper))
-		}
-	}
-
-	return b.Count * fraction
+	return b.Count * b.FractionBelow(rhs, isLinear)
 }
 
 func computeZeroBucketTrim(zeroBucket Bucket[float64], rhs float64, hasNegative, hasPositive, isUpperTrim bool) (float64, float64) {
@@ -2422,7 +2404,7 @@ func computeBucketTrim(b Bucket[float64], rhs float64, isUpperTrim, isPositive, 
 		return handleInfinityBuckets(isUpperTrim, b, rhs)
 	}
 
-	underCount := computeSplit(b, rhs, isPositive, isCustomBucket)
+	underCount := computeSplit(b, rhs, isCustomBucket)
 
 	if isUpperTrim {
 		return underCount, computeMidpoint(b.Lower, rhs, isPositive, isCustomBucket)

--- a/model/histogram/generic.go
+++ b/model/histogram/generic.go
@@ -162,6 +162,33 @@ func (b Bucket[BC]) String() string {
 	return sb.String()
 }
 
+// FractionBelow returns the fraction (between 0 and 1) of this bucket's width
+// that lies at or below the value v, assuming v is strictly inside the bucket's
+// finite bounds (b.Lower < v < b.Upper). It uses linear interpolation when
+// linear is true (as done for custom (NHCB) buckets and the zero bucket) and
+// exponential interpolation otherwise (as done for standard exponential
+// native-histogram buckets, interpolating on a logarithmic scale). Multiply the
+// result by b.Count to get the estimated number of observations at or below v.
+//
+// The caller is responsible for handling values outside the bucket bounds and
+// buckets with an infinite bound; passing those here yields a meaningless
+// result.
+func (b Bucket[BC]) FractionBelow(v float64, linear bool) float64 {
+	if linear {
+		return (v - b.Lower) / (b.Upper - b.Lower)
+	}
+	// On a logarithmic scale the exponential bucket boundaries become linear,
+	// so the fraction is computed the same way as in the linear case but over
+	// the log2 of the bounds. Negative buckets are mirrored.
+	logLower := math.Log2(math.Abs(b.Lower))
+	logUpper := math.Log2(math.Abs(b.Upper))
+	logV := math.Log2(math.Abs(v))
+	if v > 0 {
+		return (logV - logLower) / (logUpper - logLower)
+	}
+	return 1 - ((logV - logUpper) / (logLower - logUpper))
+}
+
 // BucketIterator iterates over the buckets of a Histogram, returning decoded
 // buckets.
 type BucketIterator[BC BucketCount] interface {

--- a/model/histogram/generic_test.go
+++ b/model/histogram/generic_test.go
@@ -112,6 +112,72 @@ func TestGetBoundExponential(t *testing.T) {
 	}
 }
 
+func TestBucketFractionBelow(t *testing.T) {
+	scenarios := []struct {
+		name   string
+		bucket Bucket[float64]
+		v      float64
+		linear bool
+		want   float64
+	}{
+		{
+			name:   "linear, midpoint",
+			bucket: Bucket[float64]{Lower: 0, Upper: 10, Count: 100},
+			v:      5,
+			linear: true,
+			want:   0.5,
+		},
+		{
+			name:   "linear, quarter",
+			bucket: Bucket[float64]{Lower: 2, Upper: 6, Count: 100},
+			v:      3,
+			linear: true,
+			want:   0.25,
+		},
+		{
+			name:   "linear, negative bucket",
+			bucket: Bucket[float64]{Lower: -10, Upper: -5, Count: 100},
+			v:      -6,
+			linear: true,
+			want:   0.8,
+		},
+		{
+			name:   "exponential, positive bucket at geometric midpoint",
+			bucket: Bucket[float64]{Lower: 2, Upper: 8, Count: 100},
+			v:      4,
+			linear: false,
+			want:   0.5,
+		},
+		{
+			name:   "exponential, positive bucket lower quarter of log scale",
+			bucket: Bucket[float64]{Lower: 1, Upper: 16, Count: 100},
+			v:      2,
+			linear: false,
+			want:   0.25,
+		},
+		{
+			name:   "exponential, negative bucket at geometric midpoint",
+			bucket: Bucket[float64]{Lower: -8, Upper: -2, Count: 100},
+			v:      -4,
+			linear: false,
+			want:   0.5,
+		},
+		{
+			name:   "exponential, negative bucket",
+			bucket: Bucket[float64]{Lower: -4, Upper: -2, Count: 100},
+			v:      -3,
+			linear: false,
+			want:   0.41503749927884383,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			require.InDelta(t, s.want, s.bucket.FractionBelow(s.v, s.linear), 1e-12)
+		})
+	}
+}
+
 func TestReduceResolutionHistogram(t *testing.T) {
 	cases := []struct {
 		spans           []Span

--- a/promql/quantile.go
+++ b/promql/quantile.go
@@ -426,25 +426,13 @@ func HistogramFraction(lower, upper float64, h *histogram.FloatHistogram, metric
 			if b.Lower == math.Inf(-1) {
 				return b.Count
 			}
-			return rank + b.Count*(v-b.Lower)/(b.Upper-b.Lower)
+			return rank + b.Count*b.FractionBelow(v, true)
 		}
 
-		// interpolateExponentially is using the same exponential
-		// interpolation method as above for histogramQuantile. This
-		// method is a better fit for exponential bucketing.
+		// interpolateExponentially interpolates on a logarithmic scale, which
+		// is a better fit for exponential bucketing. See Bucket.FractionBelow.
 		interpolateExponentially := func(v float64) float64 {
-			var (
-				logLower = math.Log2(math.Abs(b.Lower))
-				logUpper = math.Log2(math.Abs(b.Upper))
-				logV     = math.Log2(math.Abs(v))
-				fraction float64
-			)
-			if v > 0 {
-				fraction = (logV - logLower) / (logUpper - logLower)
-			} else {
-				fraction = 1 - ((logV - logUpper) / (logLower - logUpper))
-			}
-			return rank + b.Count*fraction
+			return rank + b.Count*b.FractionBelow(v, false)
 		}
 
 		if b.Lower <= 0 && b.Upper >= 0 {


### PR DESCRIPTION
Minor refactor to promote code reuse and ensure the logic between histogram trim operation and histogram fraction are as consistent as possible.

#### Which issue(s) does the PR fix:

Addresses part of https://github.com/prometheus/prometheus/issues/19203

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
NONE
```
