### PR TITLE
docs: fix Dependabot config link in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -62,7 +62,7 @@ Maintaining the release branches for older minor releases happens on a best effo
 
 A few days before a major or minor release, consider updating the dependencies.
 
-Note that we use [Dependabot](.github/dependabot.yml) to continuously update most things automatically. Therefore, most dependencies should be up to date.
+Note that we use [Dependabot](scripts/dependabot.yml) to continuously update most things automatically. Therefore, most dependencies should be up to date.
 Check the [dependencies GitHub label](https://github.com/prometheus/prometheus/labels/dependencies) to see if there are any pending updates.
 
 This bot currently does not manage `+incompatible` and `v0.0.0` in the version specifier for Go modules.


### PR DESCRIPTION
`RELEASE.md` links to `[Dependabot](.github/dependabot.yml)`, but there is no `.github/dependabot.yml` in the repository — the Dependabot configuration lives at `scripts/dependabot.yml`. Updated the link to point there.

Docs-only change; commit is DCO signed-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


```release-notes
NONE
```
