### PR TITLE
tsdb: don't lose samples appended to a series removed by head GC

### DIFF
--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -11082,6 +11082,122 @@ func TestCompactSelectedSeries_OpenAppenderCommittingDuringCompaction(t *testing
 		"the late sample must survive restart, proving no tombstone was written for sel")
 }
 
+// selectedSeriesTestAppender adapts the v1 and v2 appenders to a common float-append
+// signature so the selected-series eviction tests below can run against both.
+type selectedSeriesTestAppender struct {
+	storage.AppenderTransaction
+	append func(storage.SeriesRef, labels.Labels, int64, float64) (storage.SeriesRef, error)
+}
+
+// TestCompactSelectedSeries_RetriesAfterSeriesEvicted verifies that an appender
+// which resolved a series just before eviction unlinked it retries against a live
+// series instead of appending into the evicted one.
+//
+// The append-ID watermark cannot cover this case: the appender has not reached the
+// series lock yet, so it has neither an append ID nor pending state when shouldEvict
+// runs. Both appender versions are exercised.
+func TestCompactSelectedSeries_RetriesAfterSeriesEvicted(t *testing.T) {
+	for _, appender := range []struct {
+		name string
+		new  func(*testing.T, *Head) selectedSeriesTestAppender
+	}{
+		{
+			name: "v1",
+			new: func(t *testing.T, h *Head) selectedSeriesTestAppender {
+				a := h.Appender(t.Context()).(*headAppender)
+				return selectedSeriesTestAppender{
+					AppenderTransaction: a,
+					append:              a.Append,
+				}
+			},
+		},
+		{
+			name: "v2",
+			new: func(t *testing.T, h *Head) selectedSeriesTestAppender {
+				a := h.AppenderV2(t.Context()).(*headAppenderV2)
+				return selectedSeriesTestAppender{
+					AppenderTransaction: a,
+					append: func(ref storage.SeriesRef, lset labels.Labels, ts int64, v float64) (storage.SeriesRef, error) {
+						return a.Append(ref, lset, 0, ts, v, nil, nil, storage.AOptions{})
+					},
+				}
+			},
+		},
+	} {
+		t.Run(appender.name, func(t *testing.T) {
+			opts := DefaultOptions()
+			opts.MinBlockDuration = 1000
+			opts.MaxBlockDuration = 1000
+			db := newTestDB(t, withOpts(opts))
+			db.DisableCompactions()
+			h := db.Head()
+
+			lset := labels.FromStrings("series", "resolved-before-gc")
+			baseline := db.Appender(t.Context())
+			oldRef, err := baseline.Append(0, lset, 100, 1)
+			require.NoError(t, err)
+			require.NoError(t, baseline.Commit())
+			oldSeries := h.series.getByID(chunks.HeadSeriesRef(oldRef))
+			require.NotNil(t, oldSeries)
+
+			pending := appender.new(t, h)
+			lookupDone := make(chan struct{})
+			resumeAppend := make(chan struct{})
+			// Pause after the appender resolves oldSeries but before it can append,
+			// leaving it with a pointer that GC will unlink.
+			h.testAfterSeriesLookup = func(series *memSeries) {
+				if series != oldSeries {
+					return
+				}
+				close(lookupDone)
+				<-resumeAppend
+			}
+			t.Cleanup(func() { h.testAfterSeriesLookup = nil })
+
+			appendDone := make(chan error, 1)
+			go func() {
+				_, err := pending.append(oldRef, lset, 200, 2)
+				appendDone <- err
+			}()
+			select {
+			case <-lookupDone:
+			case appendErr := <-appendDone:
+				require.NoError(t, pending.Rollback())
+				t.Fatalf("append completed before reaching the series lookup hook: %v", appendErr)
+			}
+
+			compactErr := db.CompactSelectedSeries([]storage.SeriesRef{oldRef})
+			close(resumeAppend)
+			appendErr := <-appendDone
+			require.NoError(t, compactErr)
+			require.Len(t, db.Blocks(), 1, "selected-series compaction must produce a block")
+			require.NoError(t, appendErr)
+			require.NoError(t, pending.Commit())
+
+			expected := []chunks.Sample{
+				sample{t: 100, f: 1},
+				sample{t: 200, f: 2},
+			}
+			querySel := func(d *DB, stage string) {
+				t.Helper()
+				q, err := d.Querier(math.MinInt64, math.MaxInt64)
+				require.NoError(t, err)
+				result := query(t, q, labels.MustNewMatcher(labels.MatchEqual, "series", "resolved-before-gc"))
+				require.Equal(t, expected, result[lset.String()], stage)
+			}
+			querySel(db, "before WAL restart")
+
+			dir := db.Dir()
+			require.NoError(t, db.Close())
+			restarted, err := Open(dir, nil, nil, opts, nil)
+			require.NoError(t, err)
+			restarted.DisableCompactions()
+			t.Cleanup(func() { require.NoError(t, restarted.Close()) })
+			querySel(restarted, "after WAL restart")
+		})
+	}
+}
+
 // TestSelectedBlockNotMergedWithNonSelectedBlock reproduces the data-loss path
 // that occurs when a from-selected-series block is merged with a non-selected
 // block by ordinary leveled compaction.

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -156,6 +156,9 @@ type Head struct {
 
 	memTruncationInProcess atomic.Bool
 	memTruncationCallBack  func() // For testing purposes.
+	// testAfterSeriesLookup is invoked after getByID in appenders, before the
+	// series is locked. Tests use it to race GC against a resolved pointer.
+	testAfterSeriesLookup func(*memSeries)
 }
 
 type ExemplarStorage interface {

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -2375,6 +2375,7 @@ func (s *stripeSeries) gc(mint int64, minOOOMmapRef chunks.ChunkDiskMapperRef) (
 		}
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
+		series.gced = true
 		series.lset.Range(func(l labels.Label) { affected[l] = struct{}{} })
 		s.hashes[hashShard].del(hash, series.ref)
 		delete(s.series[stripe], series.ref)
@@ -2573,6 +2574,7 @@ func (s *stripeSeries) gcSeries(seriesRefs []storage.SeriesRef, maxt int64, shou
 		}
 
 		deleted[storage.SeriesRef(series.ref)] = struct{}{}
+		series.gced = true
 		stale, isHist, buckets := series.sampleState()
 		if stale {
 			staleSeriesDeleted++
@@ -2770,6 +2772,11 @@ type memSeries struct {
 	nextAt                           int64 // Timestamp at which to cut the next chunk.
 	histogramChunkHasComputedEndTime bool  // True if nextAt has been predicted for the current histograms chunk; false otherwise.
 	pendingCommit                    bool  // Whether there are samples waiting to be committed to this series.
+	// Whether garbage collection has removed this series from the head index. Such a
+	// series is unreachable, so appending to it would silently lose the samples;
+	// appenders that looked it up before it was collected have to get a fresh one
+	// instead. See headAppenderBase.lockForAppend.
+	gced bool
 	// headChunkCount tracks the number of head chunks. All mutations of the
 	// headChunks/headChunkCount pair go through pushHeadChunk and setHeadChunks.
 	// Chunk counts are bounded by the 3-byte field in HeadChunkRef, so cannot overflow uint32.

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -442,6 +442,9 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
+	if hook := a.head.testAfterSeriesLookup; hook != nil {
+		hook(s)
+	}
 	if s == nil {
 		var err error
 		s, _, err = a.getOrCreate(lset)

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -470,7 +470,10 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 		// series" and "known series with stNone".
 	}
 
-	s.Lock()
+	s, err := a.lockForAppend(s)
+	if err != nil {
+		return 0, err
+	}
 	defer s.Unlock()
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
@@ -525,7 +528,10 @@ func (a *headAppender) AppendSTZeroSample(ref storage.SeriesRef, lset labels.Lab
 	// Check if ST wouldn't be OOO vs samples we already might have for this series.
 	// NOTE(bwplotka): This will be often hit as it's expected for long living
 	// counters to share the same ST.
-	s.Lock()
+	s, err := a.lockForAppend(s)
+	if err != nil {
+		return 0, err
+	}
 	isOOO, _, err := s.appendable(st, 0, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if err == nil {
 		s.pendingCommit = true
@@ -565,6 +571,30 @@ func (a *headAppenderBase) getOrCreate(lset labels.Labels) (s *memSeries, create
 		a.series = append(a.series, s)
 	}
 	return s, created, nil
+}
+
+// lockForAppend locks s and returns it, ready to be marked as pending commit.
+//
+// Looking a series up only holds the stripe lock for the duration of the lookup, so
+// garbage collection can remove the series from the head index before the appender gets
+// to lock it and mark it as pending commit. Appending to such a series succeeds but the
+// samples are unreachable from the head, i.e. they are silently lost. When that
+// happened, a live series for the same labels is created and returned locked instead,
+// which is the same outcome as garbage collection winning the race outright.
+func (a *headAppenderBase) lockForAppend(s *memSeries) (*memSeries, error) {
+	for {
+		s.Lock()
+		if !s.gced {
+			return s, nil
+		}
+		lset := s.lset // Safe to access; the series is locked.
+		s.Unlock()
+
+		var err error
+		if s, _, err = a.getOrCreate(lset); err != nil {
+			return nil, err
+		}
+	}
 }
 
 // getCurrentBatch returns the current batch if it fits the provided sampleType
@@ -846,7 +876,10 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 
 	switch {
 	case h != nil:
-		s.Lock()
+		var lockErr error
+		if s, lockErr = a.lockForAppend(s); lockErr != nil {
+			return 0, lockErr
+		}
 		// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 		// to skip that sample from the WAL and write only in the WBL.
 		_, delta, err := s.appendableHistogram(t, h, a.headMaxt, a.minValidTime, a.oooTimeWindow)
@@ -878,7 +911,10 @@ func (a *headAppender) AppendHistogram(ref storage.SeriesRef, lset labels.Labels
 		})
 		b.histogramSeries = append(b.histogramSeries, s)
 	case fh != nil:
-		s.Lock()
+		var lockErr error
+		if s, lockErr = a.lockForAppend(s); lockErr != nil {
+			return 0, lockErr
+		}
 		// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 		// to skip that sample from the WAL and write only in the WBL.
 		_, delta, err := s.appendableFloatHistogram(t, fh, a.headMaxt, a.minValidTime, a.oooTimeWindow)
@@ -938,7 +974,10 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 			ZeroThreshold: h.ZeroThreshold,
 			CustomValues:  h.CustomValues,
 		}
-		s.Lock()
+		var lockErr error
+		if s, lockErr = a.lockForAppend(s); lockErr != nil {
+			return 0, lockErr
+		}
 		// For STZeroSamples OOO is not allowed.
 		// We set it to true to make this implementation as close as possible to the float implementation.
 		isOOO, _, err := s.appendableHistogram(st, zeroHistogram, a.headMaxt, a.minValidTime, a.oooTimeWindow)
@@ -980,7 +1019,10 @@ func (a *headAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, lset l
 			ZeroThreshold: fh.ZeroThreshold,
 			CustomValues:  fh.CustomValues,
 		}
-		s.Lock()
+		var lockErr error
+		if s, lockErr = a.lockForAppend(s); lockErr != nil {
+			return 0, lockErr
+		}
 		// We set it to true to make this implementation as close as possible to the float implementation.
 		isOOO, _, err := s.appendableFloatHistogram(st, zeroFloatHistogram, a.headMaxt, a.minValidTime, a.oooTimeWindow) // OOO is not allowed for STZeroSamples.
 		if err != nil {

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -144,16 +144,17 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	}
 
 	if a.head.opts.EnableSTAsZeroSample && st != 0 {
-		a.bestEffortAppendSTZeroSample(s, ls, st, t, h, fh)
+		s = a.bestEffortAppendSTZeroSample(s, ls, st, t, h, fh)
 	}
 
+	var appended *memSeries
 	switch {
 	case fh != nil:
 		isStale = value.IsStaleNaN(fh.Sum)
-		appErr = a.appendFloatHistogram(s, st, t, fh, opts.RejectOutOfOrder)
+		appended, appErr = a.appendFloatHistogram(s, st, t, fh, opts.RejectOutOfOrder)
 	case h != nil:
 		isStale = value.IsStaleNaN(h.Sum)
-		appErr = a.appendHistogram(s, st, t, h, opts.RejectOutOfOrder)
+		appended, appErr = a.appendHistogram(s, st, t, h, opts.RejectOutOfOrder)
 	default:
 		isStale = value.IsStaleNaN(v)
 		if isStale {
@@ -179,7 +180,7 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 			// we do not need to check for the difference between "unknown
 			// series" and "known series with stNone".
 		}
-		appErr = a.appendFloat(s, st, t, v, opts.RejectOutOfOrder)
+		appended, appErr = a.appendFloat(s, st, t, v, opts.RejectOutOfOrder)
 	}
 	// Handle append error, if any.
 	if appErr != nil {
@@ -191,6 +192,7 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 		}
 		return 0, appErr
 	}
+	s = appended
 
 	if isStale {
 		// For stale values we never attempt to process metadata/exemplars, claim the success.
@@ -220,14 +222,19 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	return storage.SeriesRef(s.ref), partialErr
 }
 
-func (a *headAppenderV2) appendFloat(s *memSeries, st, t int64, v float64, fastRejectOOO bool) error {
-	s.Lock()
+// appendFloat appends v to s, and returns the series the sample was appended to, which
+// may differ from s if s was garbage-collected in the meantime (see lockForAppend).
+func (a *headAppenderV2) appendFloat(s *memSeries, st, t int64, v float64, fastRejectOOO bool) (*memSeries, error) {
+	s, err := a.lockForAppend(s)
+	if err != nil {
+		return nil, err
+	}
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
 	isOOO, delta, err := s.appendable(t, v, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if isOOO && fastRejectOOO {
 		s.Unlock()
-		return storage.ErrOutOfOrderSample
+		return nil, storage.ErrOutOfOrderSample
 	}
 	if err == nil {
 		s.pendingCommit = true
@@ -237,23 +244,28 @@ func (a *headAppenderV2) appendFloat(s *memSeries, st, t int64, v float64, fastR
 		a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	b := a.getCurrentBatch(stFloat, s.ref)
 	b.floats = append(b.floats, record.RefSample{Ref: s.ref, ST: st, T: t, V: v})
 	b.floatSeries = append(b.floatSeries, s)
-	return nil
+	return s, nil
 }
 
-func (a *headAppenderV2) appendHistogram(s *memSeries, st, t int64, h *histogram.Histogram, fastRejectOOO bool) error {
-	s.Lock()
+// appendHistogram appends h to s, and returns the series the sample was appended to,
+// which may differ from s if s was garbage-collected in the meantime (see lockForAppend).
+func (a *headAppenderV2) appendHistogram(s *memSeries, st, t int64, h *histogram.Histogram, fastRejectOOO bool) (*memSeries, error) {
+	s, err := a.lockForAppend(s)
+	if err != nil {
+		return nil, err
+	}
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
 	isOOO, delta, err := s.appendableHistogram(t, h, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if isOOO && fastRejectOOO {
 		s.Unlock()
-		return storage.ErrOutOfOrderSample
+		return nil, storage.ErrOutOfOrderSample
 	}
 	if err == nil {
 		s.pendingCommit = true
@@ -263,7 +275,7 @@ func (a *headAppenderV2) appendHistogram(s *memSeries, st, t int64, h *histogram
 		a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	sTyp := stHistogram
 	if h.UsesCustomBuckets() {
@@ -272,17 +284,23 @@ func (a *headAppenderV2) appendHistogram(s *memSeries, st, t int64, h *histogram
 	b := a.getCurrentBatch(sTyp, s.ref)
 	b.histograms = append(b.histograms, record.RefHistogramSample{Ref: s.ref, ST: st, T: t, H: h})
 	b.histogramSeries = append(b.histogramSeries, s)
-	return nil
+	return s, nil
 }
 
-func (a *headAppenderV2) appendFloatHistogram(s *memSeries, st, t int64, fh *histogram.FloatHistogram, fastRejectOOO bool) error {
-	s.Lock()
+// appendFloatHistogram appends fh to s, and returns the series the sample was appended
+// to, which may differ from s if s was garbage-collected in the meantime (see
+// lockForAppend).
+func (a *headAppenderV2) appendFloatHistogram(s *memSeries, st, t int64, fh *histogram.FloatHistogram, fastRejectOOO bool) (*memSeries, error) {
+	s, err := a.lockForAppend(s)
+	if err != nil {
+		return nil, err
+	}
 	// TODO(codesome): If we definitely know at this point that the sample is ooo, then optimise
 	// to skip that sample from the WAL and write only in the WBL.
 	isOOO, delta, err := s.appendableFloatHistogram(t, fh, a.headMaxt, a.minValidTime, a.oooTimeWindow)
 	if isOOO && fastRejectOOO {
 		s.Unlock()
-		return storage.ErrOutOfOrderSample
+		return nil, storage.ErrOutOfOrderSample
 	}
 	if err == nil {
 		s.pendingCommit = true
@@ -292,7 +310,7 @@ func (a *headAppenderV2) appendFloatHistogram(s *memSeries, st, t int64, fh *his
 		a.head.metrics.oooHistogram.Observe(float64(delta) / 1000)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	sTyp := stFloatHistogram
 	if fh.UsesCustomBuckets() {
@@ -301,7 +319,7 @@ func (a *headAppenderV2) appendFloatHistogram(s *memSeries, st, t int64, fh *his
 	b := a.getCurrentBatch(sTyp, s.ref)
 	b.floatHistograms = append(b.floatHistograms, record.RefFloatHistogramSample{Ref: s.ref, ST: st, T: t, FH: fh})
 	b.floatHistogramSeries = append(b.floatHistogramSeries, s)
-	return nil
+	return s, nil
 }
 
 func (a *headAppenderV2) appendExemplars(s *memSeries, exemplar []exemplar.Exemplar) error {
@@ -334,18 +352,24 @@ func (a *headAppenderV2) appendExemplars(s *memSeries, exemplar []exemplar.Exemp
 // is implemented.
 //
 // ST is an experimental feature, we don't fail the append on errors, just debug log.
-func (a *headAppenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.Labels, st, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) {
+//
+// It returns the series the zero sample was appended to, which may differ from s if s was
+// garbage-collected in the meantime (see lockForAppend).
+func (a *headAppenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.Labels, st, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) *memSeries {
 	// NOTE: Use lset instead of s.lset to avoid locking memSeries. Using s.ref is acceptable without locking.
 	if st >= t {
 		a.head.logger.Debug("Error when appending ST", "series", ls.String(), "st", st, "t", t, "err", storage.ErrSTNewerThanSample)
-		return
+		return s
 	}
 	if st < a.minValidTime {
 		a.head.logger.Debug("Error when appending ST", "series", ls.String(), "st", st, "t", t, "err", storage.ErrOutOfBounds)
-		return
+		return s
 	}
 
-	var err error
+	var (
+		err      error
+		appended *memSeries
+	)
 	switch {
 	case fh != nil:
 		zeroFloatHistogram := &histogram.FloatHistogram{
@@ -356,7 +380,7 @@ func (a *headAppenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.La
 			ZeroThreshold: fh.ZeroThreshold,
 			CustomValues:  fh.CustomValues,
 		}
-		err = a.appendFloatHistogram(s, 0, st, zeroFloatHistogram, true)
+		appended, err = a.appendFloatHistogram(s, 0, st, zeroFloatHistogram, true)
 	case h != nil:
 		zeroHistogram := &histogram.Histogram{
 			// The STZeroSample represents a counter reset by definition.
@@ -366,19 +390,20 @@ func (a *headAppenderV2) bestEffortAppendSTZeroSample(s *memSeries, ls labels.La
 			ZeroThreshold: h.ZeroThreshold,
 			CustomValues:  h.CustomValues,
 		}
-		err = a.appendHistogram(s, 0, st, zeroHistogram, true)
+		appended, err = a.appendHistogram(s, 0, st, zeroHistogram, true)
 	default:
-		err = a.appendFloat(s, 0, st, 0, true)
+		appended, err = a.appendFloat(s, 0, st, 0, true)
 	}
 
 	if err != nil {
 		if errors.Is(err, storage.ErrOutOfOrderSample) {
 			// OOO errors are common and expected (cumulative). Explicitly ignored.
-			return
+			return s
 		}
 		a.head.logger.Debug("Error when appending ST", "series", s.lset.String(), "st", st, "t", t, "err", err)
-		return
+		return s
 	}
+	return appended
 }
 
 var _ storage.GetRef = &headAppenderV2{}

--- a/tsdb/head_append_v2.go
+++ b/tsdb/head_append_v2.go
@@ -135,6 +135,9 @@ func (a *headAppenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t i
 	}
 
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
+	if hook := a.head.testAfterSeriesLookup; hook != nil {
+		hook(s)
+	}
 	if s == nil {
 		var err error
 		s, _, err = a.getOrCreate(ls)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -7315,9 +7315,11 @@ func stripeSeriesWithCollidingSeries(t *testing.T) (*stripeSeries, *memSeries, *
 	lbls1, lbls2 := labelsWithHashCollision()
 	ms1 := memSeries{
 		lset: lbls1,
+		ref:  1,
 	}
 	ms2 := memSeries{
 		lset: lbls2,
+		ref:  2,
 	}
 	hash := lbls1.Hash()
 	s := newStripeSeries(1, noopSeriesLifecycleCallback{})
@@ -7356,6 +7358,12 @@ func TestStripeSeries_gc(t *testing.T) {
 	require.Nil(t, got)
 	got = s.getByHash(hash, ms2.lset)
 	require.Nil(t, got)
+	ms1.Lock()
+	require.True(t, ms1.gced)
+	ms1.Unlock()
+	ms2.Lock()
+	require.True(t, ms2.gced)
+	ms2.Unlock()
 }
 
 func TestPostingsCardinalityStats(t *testing.T) {

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -1416,6 +1416,96 @@ func TestHead_RaceBetweenSeriesCreationAndGC(t *testing.T) {
 	require.Equal(t, totalSeries, int(head.NumSeries()))
 }
 
+func TestHead_RaceBetweenExistingSeriesAppendAndGC(t *testing.T) {
+	// Unlike TestHead_RaceBetweenSeriesCreationAndGC above, this covers appends to a
+	// series that already exists in the head: Append() looks the series up, releases the
+	// stripe lock and only afterwards locks the series to mark it as pending commit. A
+	// gc() in between removes the series from the head, so the samples appended to it
+	// afterwards are lost even though Append() and Commit() report success.
+	// See https://github.com/prometheus/prometheus/issues/8365.
+	const (
+		totalSeries = 10_000
+		rounds      = 40
+		appenders   = 16
+		firstTs     = int64(1_000_000)
+		tsStep      = int64(10_000)
+	)
+
+	head, _ := newTestHead(t, 1000, compression.None, false)
+	require.NoError(t, head.Init(0))
+
+	ctx := context.Background()
+	series := make([]labels.Labels, totalSeries)
+	for i := range series {
+		series[i] = labels.FromStrings("foo", strconv.Itoa(i))
+	}
+	refs := make([]storage.SeriesRef, totalSeries)
+
+	app := head.Appender(ctx)
+	for i := range series {
+		ref, err := app.Append(0, series[i], firstTs, 1)
+		require.NoError(t, err)
+		refs[i] = ref
+	}
+	require.NoError(t, app.Commit())
+	require.Equal(t, totalSeries, int(head.NumSeries()))
+
+	for round := int64(1); round <= rounds; round++ {
+		ts := firstTs + round*tsStep
+
+		// Emulate the head truncation that makes existing series collectable in
+		// production (see Head.truncateMemory): every series only holds samples from
+		// the previous round, so gc() drops their chunks and then the series
+		// themselves - unless an appender marked them as pending commit in time.
+		head.minTime.Store(ts)
+		head.minValidTime.Store(ts)
+
+		done := atomic.NewBool(false)
+		var wg sync.WaitGroup
+		for a := range appenders {
+			wg.Add(1)
+			go func(a int) {
+				defer wg.Done()
+				app := head.Appender(ctx)
+				defer func() {
+					if err := app.Commit(); err != nil {
+						t.Errorf("Failed to commit: %v", err)
+					}
+				}()
+				for i := a; i < totalSeries; i += appenders {
+					// Append by reference, like the scrape loop does for series it has seen before.
+					ref, err := app.Append(refs[i], series[i], ts, 1)
+					if err != nil {
+						t.Errorf("Failed to append: %v", err)
+						return
+					}
+					refs[i] = ref
+				}
+			}(a)
+		}
+		go func() {
+			wg.Wait()
+			done.Store(true)
+		}()
+
+		// Don't check the atomic.Bool on all iterations in order to perform more gc iterations and make the race condition more likely.
+		for i := 1; i%4 != 0 || !done.Load(); i++ {
+			head.gc()
+		}
+
+		// Every Append() reported success, so no sample may have been dropped: each
+		// series is either the one that was looked up or the one that replaced it after
+		// being collected, but it has to be in the head, holding the sample.
+		require.Equal(t, totalSeries, int(head.NumSeries()), "round %d", round)
+	}
+
+	for _, lset := range series {
+		s := head.series.getByHash(lset.Hash(), lset)
+		require.NotNil(t, s, "series %s is not in the head", lset)
+		require.NotNil(t, s.headChunks, "series %s holds no sample", lset)
+	}
+}
+
 func TestHead_CanGarbagecollectSeriesCreatedWithoutSamples(t *testing.T) {
 	for op, finishTxn := range map[string]func(app storage.Appender) error{
 		"after commit":   func(app storage.Appender) error { return app.Commit() },


### PR DESCRIPTION
### Description

Head garbage collection can remove a series from the head index while an appender is
already holding a pointer to it. The appender then appends to a `memSeries` that is no
longer reachable from the head: `Append()` and `Commit()` both report success, but the
samples are gone. As @brian-brazil put it on the issue, "it's never okay to silently lose
a write".

Fixes #8365

### Relation to #16333

@colega fixed one half of this in #16333 (the race between series *creation* and gc), and
noted in the PR description and in
https://github.com/prometheus/prometheus/pull/16333#issuecomment-2809987012 that he was
deliberately only marking newly created series, leaving the #8365 case — a series that has
existed for a while and gets collected just as more samples arrive — unsolved.

This PR covers that remaining half, building on the same `pendingCommit`-at-creation
mechanism #16333 introduced.

grafana/mimir#10582 is a production incident report for exactly this half; the analysis by
@alexweav and @colega there is what this PR follows.

### Root cause

Looking a series up only holds the stripe lock for the duration of the lookup:

```go
s := a.head.series.getByID(chunks.HeadSeriesRef(ref))   // stripe RLock ... RUnlock
...
s.Lock()                                                // <-- gc() can run in between
...
s.pendingCommit = true                                  // too late
```

`stripeSeries.gc()` decides whether a series is still alive by looking at, among other
things, `series.pendingCommit`. In the window above that flag is still false, so gc
unlinks the series from both the by-ref and the by-hash map. The appender then carries on
with the now-orphaned `memSeries`, and `Commit()` writes the samples into a chunk nobody
can reach. Nothing reports an error.

For series that the appender created itself, #16333 closed this by setting `pendingCommit`
in the constructor, which runs under the stripe lock. That does not help when
`getByID()`/`getByHash()` return a pre-existing series, because nothing marks it before
the stripe lock is dropped.

### Fix

The locking is deliberately not widened: @codesome
[ruled out](https://github.com/prometheus/prometheus/issues/8365#issuecomment-762166723)
holding the `stripeSeries` lock for the whole append, because it depends on an external
caller invoking `Commit()`/`Rollback()` and a missing call would block gc forever.

Instead the loser of the race is made able to detect that it lost. gc already holds the
series lock while it both decides and performs the removal, so it can record that decision
on the series itself:

* `memSeries` gets a `gced` flag, set by `stripeSeries.gc()` and `stripeSeries.gcSeries()`
  when the series is unlinked from the head index. Both already hold the series lock
  there, so no new locking and no new lock ordering is introduced. The flag fits in the
  struct's existing padding — `unsafe.Sizeof(memSeries{})` is 168 bytes before and after —
  so there is no per-series memory cost.
* Appenders take the series lock through the new `headAppenderBase.lockForAppend()`, which
  checks the flag. If the series was collected in the meantime, it obtains a live series
  for the same labels through the existing `getOrCreate()` path (so the WAL series record
  and the `pendingCommit` bookkeeping from #16333 are taken care of) and returns that one,
  locked.

Because gc holds the series lock across "check `pendingCommit`" and "unlink", both
orderings are now correct:

* the appender gets the lock first: it sets `pendingCommit = true`, gc then sees it and
  keeps the series;
* gc gets the lock first: it unlinks the series and sets `gced`, the appender then sees
  the flag and appends to a fresh series instead.

The second case ends up in exactly the same state as gc winning the race outright, i.e.
`getByID()` returning nil — a case the code already handles today. Retrying rather than
returning an error matters here: the scrape loop breaks out of the sample loop on
unexpected append errors, so failing the sample would turn one racy series into a gap for
the whole target.

This is applied to every sample-appending entry point of both appenders: `Append`,
`AppendSTZeroSample`, `AppendHistogram` and `AppendHistogramSTZeroSample` on
`headAppender`, and `appendFloat`, `appendHistogram` and `appendFloatHistogram` on
`headAppenderV2` — the latter now return the series the sample landed on, so the caller
reports the right `SeriesRef`.

Deliberately left out of scope: `AppendExemplar()` and `UpdateMetadata()` also resolve a
series without marking it. Exemplars are stored keyed by labels, so they are not lost; a
metadata update can be. Both document that they assume the series already exists and
return an error otherwise, so making them create series is a behaviour change that is
better made separately.

### Tests

`TestHead_RaceBetweenExistingSeriesAppendAndGC` is the counterpart of
`TestHead_RaceBetweenSeriesCreationAndGC` that came with #16333. It appends by reference —
the way the scrape loop does for series it has seen before — while `gc()` runs, with the
head's min time moved past the previous round's samples so that the existing series really
are collectable, as they are after a head truncation in production.

Before the fix — 10 out of 10 runs failed:

```
$ go test ./tsdb/ -run 'TestHead_RaceBetweenExistingSeriesAppendAndGC$' -v
=== RUN   TestHead_RaceBetweenExistingSeriesAppendAndGC
    head_test.go:1499:
        	Error Trace:	/.../tsdb/head_test.go:1499
        	Error:      	Not equal:
        	            	expected: 10000
        	            	actual  : 9999
        	Test:       	TestHead_RaceBetweenExistingSeriesAppendAndGC
        	Messages:   	round 4
--- FAIL: TestHead_RaceBetweenExistingSeriesAppendAndGC (0.13s)
FAIL
FAIL	github.com/prometheus/prometheus/tsdb	0.912s
```

Every `Append()` in that round returned success, so the missing series is a silently
dropped sample.

After the fix — 0 out of 10 runs failed:

```
$ go test ./tsdb/ -run 'TestHead_RaceBetweenExistingSeriesAppendAndGC$' -v
=== RUN   TestHead_RaceBetweenExistingSeriesAppendAndGC
--- PASS: TestHead_RaceBetweenExistingSeriesAppendAndGC (0.71s)
PASS
```

### Benchmarks

`BenchmarkHeadAppender_AppendCommit` restricted to the cases this touches. The old (main)
and new (this PR) test binaries were built once and then run alternately, so both sides saw
the same machine conditions; 6 samples each, `-benchtime 2s -cpu 2 -benchmem`.

```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/prometheus/tsdb
cpu: Apple M4
                                                                                                       │     old      │                new                 │
                                                                                                       │    sec/op    │    sec/op     vs base              │
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=1-2                      166.0µ ± 16%   175.9µ ± 16%       ~ (p=0.937 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=100-2                    4.126m ± 11%   4.120m ± 11%       ~ (p=0.818 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=1-2                      172.3µ ± 11%   177.0µ ± 14%       ~ (p=0.937 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=100-2                    3.940m ±  9%   3.978m ±  9%       ~ (p=0.937 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=1-2   1.513m ± 17%   1.504m ± 15%       ~ (p=0.699 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=1-2   1.420m ± 16%   1.504m ± 17%       ~ (p=0.699 n=6)
geomean                                                                                                  999.8µ         1.024m        +2.43%

                                                                                                       │     old      │                new                 │
                                                                                                       │     B/op     │     B/op      vs base              │
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=1-2                      2.921Ki ± 0%   2.917Ki ± 0%       ~ (p=0.117 n=6)
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=100-2                    54.00Ki ± 6%   53.80Ki ± 5%       ~ (p=1.000 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=1-2                      2.918Ki ± 0%   2.922Ki ± 0%       ~ (p=0.985 n=6)
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=100-2                    54.75Ki ± 3%   54.51Ki ± 3%       ~ (p=0.974 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=1-2   34.39Ki ± 0%   34.39Ki ± 0%       ~ (p=0.900 n=6)
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=1-2   34.49Ki ± 0%   34.50Ki ± 0%       ~ (p=0.623 n=6)
geomean                                                                                                  17.62Ki        17.59Ki       -0.13%

                                                                                                       │    old     │                new                 │
                                                                                                       │ allocs/op  │ allocs/op   vs base                │
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=1-2                      44.00 ± 0%   44.00 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v1/case=floats/series=100/samples_per_append=100-2                    512.0 ± 0%   512.0 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=1-2                      44.00 ± 0%   44.00 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floats/series=100/samples_per_append=100-2                    512.5 ± 0%   512.0 ± 0%       ~ (p=0.545 n=6)
HeadAppender_AppendCommit/appender=v1/case=floatsHistogramsExemplars/series=100/samples_per_append=1-2   615.0 ± 0%   615.0 ± 0%       ~ (p=1.000 n=6) ¹
HeadAppender_AppendCommit/appender=v2/case=floatsHistogramsExemplars/series=100/samples_per_append=1-2   616.0 ± 0%   616.0 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                                                                  240.3        240.2       -0.02%
¹ all samples are equal
```

Nothing moves outside the noise: every case is `~` and `allocs/op` is identical. That is
what the change should do — on the hot path it only adds one bool check under a lock the
appender was already taking. The geomean `sec/op` delta sits inside the ±9-17% run-to-run
spread these benchmarks show on a laptop, and no individual case is significant (p >= 0.69).
Happy to have a maintainer trigger `/prombench` for a more representative measurement, as
was done for #16333.

### Verification

* `go test ./tsdb/ -race -run 'TestHead_RaceBetween|TestHead_CanGarbagecollect|TestHead_Truncate|TestHead_ActiveAppenders|TestHead_Append|TestHeadAppender|TestAppend|TestHead_GC|TestGCSeriesAccess|TestGCChunkAccess|TestWALReplayRaceWithStaleSeriesCompaction'` - passes, no races reported.
* `go test ./scrape/ ./storage/` - passes.
* `golangci-lint run ./tsdb/...`, `gofmt -l`, `go build -tags dedupelabels ./tsdb/...` - clean.
* The full `go test ./tsdb/...` run takes well over an hour on the machine I have here and
  I was not able to get a clean end-to-end run, so I verified the affected tests (above)
  rather than the whole package. CI will cover the rest; please tell me if anything shows
  up there.


```release-notes
[BUGFIX] TSDB: Don't silently drop samples when head garbage collection removes a series while it is being appended to
```
