### PR TITLE
docs: document NaN behaviour of clamp_max() and clamp_min()

### DIFF
--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -89,7 +89,8 @@ float samples in `v` to have a lower limit of `min` and an upper limit of
 Special cases:
 
 * Return an empty vector if `min > max`
-* Float samples are clamped to `NaN` if `min` or `max` is `NaN`
+* The function returns `NaN` if `min` or `max` is `NaN`
+* Float samples are unchanged if `min` is `-Inf` and `max` is `+Inf`
 
 ## `clamp_max()`
 
@@ -97,11 +98,23 @@ Special cases:
 samples in `v` to have an upper limit of `max`. Histogram samples in the input
 vector are ignored silently.
 
+Special cases:
+
+* The function returns `NaN` if the `max` argument is `NaN`
+* Float samples are unchanged if `max` is `+Inf`
+* All float samples are set to `-Inf` if `max` is `-Inf`
+
 ## `clamp_min()`
 
 `clamp_min(v instant-vector, min scalar)` clamps the values of all float
 samples in `v` to have a lower limit of `min`. Histogram samples in the input
 vector are ignored silently.
+
+Special cases:
+
+* The function returns `NaN` if the `min` argument is `NaN`
+* Float samples are unchanged if `min` is `-Inf`
+* All float samples are set to `+Inf` if `min` is `+Inf`
 
 ## `day_of_month()`
 

--- a/docs/querying/functions.md
+++ b/docs/querying/functions.md
@@ -97,11 +97,19 @@ Special cases:
 samples in `v` to have an upper limit of `max`. Histogram samples in the input
 vector are ignored silently.
 
+Special cases:
+
+* Float samples are clamped to `NaN` if `max` is `NaN`
+
 ## `clamp_min()`
 
 `clamp_min(v instant-vector, min scalar)` clamps the values of all float
 samples in `v` to have a lower limit of `min`. Histogram samples in the input
 vector are ignored silently.
+
+Special cases:
+
+* Float samples are clamped to `NaN` if `min` is `NaN`
 
 ## `day_of_month()`
 

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -649,6 +649,41 @@ eval instant at 0m clamp(test_clamp, NaN, 0)
 	{src="clamp-b"}	NaN
 	{src="clamp-c"}	NaN
 
+eval instant at 0m clamp_max(test_clamp, NaN)
+	{src="clamp-a"}	NaN
+	{src="clamp-b"}	NaN
+	{src="clamp-c"}	NaN
+
+eval instant at 0m clamp_min(test_clamp, NaN)
+	{src="clamp-a"}	NaN
+	{src="clamp-b"}	NaN
+	{src="clamp-c"}	NaN
+
+eval instant at 0m clamp_max(test_clamp, Inf)
+	{src="clamp-a"}	-50
+	{src="clamp-b"}	0
+	{src="clamp-c"}	100
+
+eval instant at 0m clamp_max(test_clamp, -Inf)
+	{src="clamp-a"}	-Inf
+	{src="clamp-b"}	-Inf
+	{src="clamp-c"}	-Inf
+
+eval instant at 0m clamp_min(test_clamp, -Inf)
+	{src="clamp-a"}	-50
+	{src="clamp-b"}	0
+	{src="clamp-c"}	100
+
+eval instant at 0m clamp_min(test_clamp, Inf)
+	{src="clamp-a"}	+Inf
+	{src="clamp-b"}	+Inf
+	{src="clamp-c"}	+Inf
+
+eval instant at 0m clamp(test_clamp, -Inf, Inf)
+	{src="clamp-a"}	-50
+	{src="clamp-b"}	0
+	{src="clamp-c"}	100
+
 eval instant at 0m clamp(test_clamp, 5, -5)
 
 clear

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -649,6 +649,16 @@ eval instant at 0m clamp(test_clamp, NaN, 0)
 	{src="clamp-b"}	NaN
 	{src="clamp-c"}	NaN
 
+eval instant at 0m clamp_max(test_clamp, NaN)
+	{src="clamp-a"}	NaN
+	{src="clamp-b"}	NaN
+	{src="clamp-c"}	NaN
+
+eval instant at 0m clamp_min(test_clamp, NaN)
+	{src="clamp-a"}	NaN
+	{src="clamp-b"}	NaN
+	{src="clamp-c"}	NaN
+
 eval instant at 0m clamp(test_clamp, 5, -5)
 
 clear

--- a/web/ui/mantine-ui/src/promql/functionDocs.tsx
+++ b/web/ui/mantine-ui/src/promql/functionDocs.tsx
@@ -642,7 +642,10 @@ const funcDocs: Record<string, React.ReactNode> = {
           Return an empty vector if <code>min &gt; max</code>
         </li>
         <li>
-          Float samples are clamped to <code>NaN</code> if <code>min</code> or <code>max</code> is <code>NaN</code>
+          The function returns <code>NaN</code> if <code>min</code> or <code>max</code> is <code>NaN</code>
+        </li>
+        <li>
+          Float samples are unchanged if <code>min</code> is <code>-Inf</code> and <code>max</code> is <code>+Inf</code>
         </li>
       </ul>
     </>
@@ -653,6 +656,20 @@ const funcDocs: Record<string, React.ReactNode> = {
         <code>clamp_max(v instant-vector, max scalar)</code> clamps the values of all float samples in <code>v</code> to
         have an upper limit of <code>max</code>. Histogram samples in the input vector are ignored silently.
       </p>
+
+      <p>Special cases:</p>
+
+      <ul>
+        <li>
+          The function returns <code>NaN</code> if the <code>max</code> argument is <code>NaN</code>
+        </li>
+        <li>
+          Float samples are unchanged if <code>max</code> is <code>+Inf</code>
+        </li>
+        <li>
+          All float samples are set to <code>-Inf</code> if <code>max</code> is <code>-Inf</code>
+        </li>
+      </ul>
     </>
   ),
   clamp_min: (
@@ -661,6 +678,20 @@ const funcDocs: Record<string, React.ReactNode> = {
         <code>clamp_min(v instant-vector, min scalar)</code> clamps the values of all float samples in <code>v</code> to
         have a lower limit of <code>min</code>. Histogram samples in the input vector are ignored silently.
       </p>
+
+      <p>Special cases:</p>
+
+      <ul>
+        <li>
+          The function returns <code>NaN</code> if the <code>min</code> argument is <code>NaN</code>
+        </li>
+        <li>
+          Float samples are unchanged if <code>min</code> is <code>-Inf</code>
+        </li>
+        <li>
+          All float samples are set to <code>+Inf</code> if <code>min</code> is <code>+Inf</code>
+        </li>
+      </ul>
     </>
   ),
   cos: (

--- a/web/ui/mantine-ui/src/promql/functionDocs.tsx
+++ b/web/ui/mantine-ui/src/promql/functionDocs.tsx
@@ -653,6 +653,14 @@ const funcDocs: Record<string, React.ReactNode> = {
         <code>clamp_max(v instant-vector, max scalar)</code> clamps the values of all float samples in <code>v</code> to
         have an upper limit of <code>max</code>. Histogram samples in the input vector are ignored silently.
       </p>
+
+      <p>Special cases:</p>
+
+      <ul>
+        <li>
+          Float samples are clamped to <code>NaN</code> if <code>max</code> is <code>NaN</code>
+        </li>
+      </ul>
     </>
   ),
   clamp_min: (
@@ -661,6 +669,14 @@ const funcDocs: Record<string, React.ReactNode> = {
         <code>clamp_min(v instant-vector, min scalar)</code> clamps the values of all float samples in <code>v</code> to
         have a lower limit of <code>min</code>. Histogram samples in the input vector are ignored silently.
       </p>
+
+      <p>Special cases:</p>
+
+      <ul>
+        <li>
+          Float samples are clamped to <code>NaN</code> if <code>min</code> is <code>NaN</code>
+        </li>
+      </ul>
     </>
   ),
   cos: (


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #19273

#### What this PR does:

`clamp()` documents that float samples come back as `NaN` when either bound is `NaN`:

> * Float samples are clamped to `NaN` if `min` or `max` is `NaN`

`clamp_max()` and `clamp_min()` route through the same `clamp()` helper in `promql/functions.go`, so they behave the same way, but neither documents it and neither has a test pinning it. `functions.test` covers `clamp(test_clamp, 0, NaN)` and `clamp(test_clamp, NaN, 0)` but not the single-bound variants.

So this is docs plus test coverage for existing behaviour, no functional change:

* add the special case to both function docs
* add the two missing cases next to the existing `clamp()` NaN coverage
* regenerate `functionDocs.tsx`, since `docs/querying/functions.md` is the source for it

The regeneration is in its own commit so the generated file is easy to skip while reviewing.

#### Test plan

```
go test ./promql/ -run TestEvaluations
ok  github.com/prometheus/prometheus/promql
```

Both new cases execute (`functions.test` lines 652 and 657). I checked they aren't passing vacuously by temporarily changing an expected value to a number, which fails as it should; worth doing here since `NaN` comparisons can pass for the wrong reason.

```release-notes
NONE
```
