### PR TITLE
tsdb/wlog: document that LiveReader metrics must be non-nil

### DIFF
--- a/tsdb/wlog/live_reader.go
+++ b/tsdb/wlog/live_reader.go
@@ -60,7 +60,9 @@ func (m *LiveReaderMetrics) Unregister() {
 	m.reg.Unregister(m.readerCorruptionErrors)
 }
 
-// NewLiveReader returns a new live reader.
+// NewLiveReader returns a new live reader. The metrics must be non-nil, since
+// the reader records corruption errors through them; use
+// NewLiveReaderMetrics(nil) when there is no registerer to attach them to.
 func NewLiveReader(logger *slog.Logger, metrics *LiveReaderMetrics, r io.Reader) *LiveReader {
 	lr := &LiveReader{
 		logger:  logger,

--- a/tsdb/wlog/reader_test.go
+++ b/tsdb/wlog/reader_test.go
@@ -383,7 +383,7 @@ func TestReaderFuzz_Live(t *testing.T) {
 			require.NoError(t, err)
 			defer seg.Close()
 
-			r := NewLiveReader(logger, nil, seg)
+			r := NewLiveReader(logger, NewLiveReaderMetrics(nil), seg)
 			segmentTicker := time.NewTicker(100 * time.Millisecond)
 			readTicker := time.NewTicker(10 * time.Millisecond)
 
@@ -424,7 +424,7 @@ func TestReaderFuzz_Live(t *testing.T) {
 					seg, err = OpenReadSegment(SegmentName(dir, seg.i+1))
 					require.NoError(t, err)
 					defer seg.Close()
-					r = NewLiveReader(logger, nil, seg)
+					r = NewLiveReader(logger, NewLiveReaderMetrics(nil), seg)
 
 				case <-readTicker.C:
 					readSegment(r)
@@ -476,7 +476,7 @@ func TestLiveReaderCorrupt_ShortFile(t *testing.T) {
 	require.NoError(t, err)
 	defer seg.Close()
 
-	r := NewLiveReader(logger, nil, seg)
+	r := NewLiveReader(logger, NewLiveReaderMetrics(nil), seg)
 	require.False(t, r.Next(), "expected no records")
 	require.Equal(t, io.EOF, r.Err(), "expected error, got: %v", r.Err())
 }


### PR DESCRIPTION
NewLiveReader currently accepts nil metrics and nothing complains until a record spans a page boundary, then readRecord panics on the nil counter (live_reader.go:311). Grafana Alloy hit exactly this in production (grafana/alloy#6757, fixed on their side in grafana/alloy#6766).

Per review, this documents that metrics must be non-nil instead of coding around it. Also reader_test.go here was passing nil in three places, so those now use NewLiveReaderMetrics(nil) to match what the comment says.

#### Release notes for end users

```release-notes
NONE
```