### PR TITLE
Makefile: pin GOTOOLCHAIN in update-go-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,8 @@ update-all-go-deps: update-go-deps
 update-go-deps-in-dir:
 	@echo ">> updating Go dependencies in ./$(DIR)/"
 	@cd ./$(DIR) && for m in $$($(GO) list -mod=readonly -m -f '{{ if and (not .Indirect) (not .Main)}}{{.Path}}{{end}}' all); do \
-		$(GO) get $$m; \
+		# Prevent go get from pulling deps that require a newer Go version.
+		GOTOOLCHAIN=go$$($(GO) mod edit -json | jq -r .Go) $(GO) get $$m; \
 	done
 	@cd ./$(DIR) && $(GO) mod tidy
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -166,7 +166,8 @@ common-deps:
 update-go-deps:
 	@echo ">> updating Go dependencies"
 	@for m in $$($(GO) list -mod=readonly -m -f '{{ if and (not .Indirect) (not .Main)}}{{.Path}}{{end}}' all); do \
-		$(GO) get $$m; \
+		# Prevent go get from pulling deps that require a newer Go version.
+		GOTOOLCHAIN=go$$($(GO) mod edit -json | jq -r .Go) $(GO) get $$m; \
 	done
 	$(GO) mod tidy
 


### PR DESCRIPTION
With GOTOOLCHAIN=auto (the default), `go get` silently downloads a newer toolchain when a dependency requires a higher Go version and bumps the go directive in go.mod to match. This breaks CI's test_go_oldest and others.

Pin GOTOOLCHAIN to the version from each module's go directive so that `go get` skips incompatible deps instead of silently pulling them in.

Now getting logs like

```
go: k8s.io/api@v0.36.3 requires go >= 1.26.0 (running go 1.25.8; GOTOOLCHAIN=go1.25.8)
go: k8s.io/apimachinery@v0.36.3 requires go >= 1.26.0 (running go 1.25.8; GOTOOLCHAIN=go1.25.8)
go: k8s.io/client-go@v0.36.3 requires go >= 1.26.0 (running go 1.25.8; GOTOOLCHAIN=go1.25.8)
```
instead if Go directive being updated etc

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
