### PR TITLE
discovery/moby: enrich task labels via container inspect (#12244)

### DIFF
--- a/discovery/moby/tasks.go
+++ b/discovery/moby/tasks.go
@@ -81,9 +81,7 @@ func (d *Discovery) refreshTasks(ctx context.Context) ([]*targetgroup.Group, err
 
 		if s.Spec.ContainerSpec != nil {
 			if s.Status.ContainerStatus != nil {
-				for k, v := range containerLabels[s.Status.ContainerStatus.ContainerID] {
-					commonLabels[k] = v
-				}
+				maps.Copy(commonLabels, containerLabels[s.Status.ContainerStatus.ContainerID])
 			}
 			// Then apply container spec labels (higher priority, may override image labels).
 			for k, v := range s.Spec.ContainerSpec.Labels {

--- a/discovery/moby/tasks.go
+++ b/discovery/moby/tasks.go
@@ -186,13 +186,13 @@ func (d *Discovery) getContainerLabels(ctx context.Context, tasks []mobyswarm.Ta
 			continue
 		}
 
-		c, err := d.client.ContainerInspect(ctx, containerID)
-		if err != nil || c.Config == nil {
+		c, err := d.client.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+		if err != nil || c.Container.Config == nil {
 			continue
 		}
 
-		containerLabels := make(map[string]string, len(c.Config.Labels))
-		for k, v := range c.Config.Labels {
+		containerLabels := make(map[string]string, len(c.Container.Config.Labels))
+		for k, v := range c.Container.Config.Labels {
 			ln := strutil.SanitizeLabelName(k)
 			containerLabels[swarmLabelContainerLabelPrefix+ln] = v
 		}

--- a/discovery/moby/tasks.go
+++ b/discovery/moby/tasks.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	mobynetwork "github.com/moby/moby/api/types/network"
+	mobyswarm "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/prometheus/common/model"
 
@@ -64,6 +65,8 @@ func (d *Discovery) refreshTasks(ctx context.Context) ([]*targetgroup.Group, err
 		return nil, fmt.Errorf("error while computing swarm network labels: %w", err)
 	}
 
+	containerLabels := d.getContainerLabels(ctx, tasks.Items)
+
 	for _, s := range tasks.Items {
 		commonLabels := map[string]string{
 			swarmLabelTaskID:           s.ID,
@@ -77,6 +80,12 @@ func (d *Discovery) refreshTasks(ctx context.Context) ([]*targetgroup.Group, err
 		}
 
 		if s.Spec.ContainerSpec != nil {
+			if s.Status.ContainerStatus != nil {
+				for k, v := range containerLabels[s.Status.ContainerStatus.ContainerID] {
+					commonLabels[k] = v
+				}
+			}
+			// Then apply container spec labels (higher priority, may override image labels).
 			for k, v := range s.Spec.ContainerSpec.Labels {
 				ln := strutil.SanitizeLabelName(k)
 				commonLabels[swarmLabelContainerLabelPrefix+ln] = v
@@ -156,4 +165,39 @@ func (d *Discovery) refreshTasks(ctx context.Context) ([]*targetgroup.Group, err
 		}
 	}
 	return []*targetgroup.Group{tg}, nil
+}
+
+// getContainerLabels fetches labels by inspecting the task container IDs.
+// Errors fetching individual containers are skipped so transient state does not
+// abort the full discovery cycle.
+func (d *Discovery) getContainerLabels(ctx context.Context, tasks []mobyswarm.Task) map[string]map[string]string {
+	labelsByContainerID := make(map[string]map[string]string)
+
+	for _, t := range tasks {
+		if t.Status.ContainerStatus == nil {
+			continue
+		}
+
+		containerID := t.Status.ContainerStatus.ContainerID
+		if containerID == "" {
+			continue
+		}
+		if _, alreadyLoaded := labelsByContainerID[containerID]; alreadyLoaded {
+			continue
+		}
+
+		c, err := d.client.ContainerInspect(ctx, containerID)
+		if err != nil || c.Config == nil {
+			continue
+		}
+
+		containerLabels := make(map[string]string, len(c.Config.Labels))
+		for k, v := range c.Config.Labels {
+			ln := strutil.SanitizeLabelName(k)
+			containerLabels[swarmLabelContainerLabelPrefix+ln] = v
+		}
+		labelsByContainerID[containerID] = containerLabels
+	}
+
+	return labelsByContainerID
 }

--- a/discovery/moby/tasks_test.go
+++ b/discovery/moby/tasks_test.go
@@ -828,6 +828,10 @@ host: %s
 		},
 	} {
 		t.Run(fmt.Sprintf("item %d", i), func(t *testing.T) {
+			if lbls["__meta_dockerswarm_task_container_id"] != "" {
+				lbls["__meta_dockerswarm_container_label_org_opencontainers_image_version"] = model.LabelValue("v-from-image")
+				lbls["__meta_dockerswarm_container_label_org_opencontainers_image_created"] = model.LabelValue("2026-01-01T00:00:00Z")
+			}
 			require.Equal(t, lbls, tg.Targets[i])
 		})
 	}

--- a/discovery/moby/testdata/swarmprom/containers/json.json
+++ b/discovery/moby/testdata/swarmprom/containers/json.json
@@ -1,0 +1,10 @@
+{
+  "Id": "dummy",
+  "Config": {
+    "Labels": {
+      "org.opencontainers.image.version": "v-from-image",
+      "org.opencontainers.image.created": "2026-01-01T00:00:00Z",
+      "com.docker.stack.namespace": "from-container-inspect"
+    }
+  }
+}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #12244

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*
```release-notes
[BUGFIX] Docker Swarm SD: Populate container labels via container inspect, since the tasks API does not return them.
```

---

**Additional context (paste below the template, not inside it):**

The Docker Swarm `tasks` API doesn't return container-level labels — the `Labels` field on task responses is consistently empty, even though the same container's inspect endpoint does return labels (including OCI image labels like `org.opencontainers.image.version`). This means `__meta_dockerswarm_container_label_<labelname>` never populates for any task, despite being documented as available.

This PR adds a container inspect call per discovered task to fill in those labels, since inspect is the only endpoint that actually returns them.

**Open questions for maintainers:**
- This adds one extra Docker API call per task per refresh cycle — is that an acceptable cost, or should this be opt-in behind a config flag?
- Environments using `docker-socket-proxy` will need inspect permissions granted on top of existing task-list