### PR TITLE
discovery/aws: extract RDS label building out of the refresh loop

### DIFF
--- a/discovery/aws/aws.go
+++ b/discovery/aws/aws.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
@@ -124,30 +125,14 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		c.EC2SDConfig.HTTPClientConfig = c.HTTPClientConfig
 		c.EC2SDConfig.Region = c.Region
-		if c.Endpoint != "" {
-			c.EC2SDConfig.Endpoint = c.Endpoint
-		}
-		if c.AccessKey != "" {
-			c.EC2SDConfig.AccessKey = c.AccessKey
-		}
-		if c.SecretKey != "" {
-			c.EC2SDConfig.SecretKey = c.SecretKey
-		}
-		if c.Profile != "" {
-			c.EC2SDConfig.Profile = c.Profile
-		}
-		if c.RoleARN != "" {
-			c.EC2SDConfig.RoleARN = c.RoleARN
-		}
-		if c.ExternalID != "" {
-			c.EC2SDConfig.ExternalID = c.ExternalID
-		}
-		if c.Port != 0 {
-			c.EC2SDConfig.Port = c.Port
-		}
-		if c.RefreshInterval != 0 {
-			c.EC2SDConfig.RefreshInterval = c.RefreshInterval
-		}
+		setIfNonZero(&c.EC2SDConfig.Endpoint, c.Endpoint)
+		setIfNonZero(&c.EC2SDConfig.AccessKey, c.AccessKey)
+		setIfNonZero(&c.EC2SDConfig.SecretKey, c.SecretKey)
+		setIfNonZero(&c.EC2SDConfig.Profile, c.Profile)
+		setIfNonZero(&c.EC2SDConfig.RoleARN, c.RoleARN)
+		setIfNonZero(&c.EC2SDConfig.ExternalID, c.ExternalID)
+		setIfNonZero(&c.EC2SDConfig.Port, c.Port)
+		setIfNonZero(&c.EC2SDConfig.RefreshInterval, c.RefreshInterval)
 		if c.Filters != nil {
 			c.EC2SDConfig.Filters = c.Filters
 		}
@@ -158,30 +143,14 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		c.ECSSDConfig.HTTPClientConfig = c.HTTPClientConfig
 		c.ECSSDConfig.Region = c.Region
-		if c.Endpoint != "" {
-			c.ECSSDConfig.Endpoint = c.Endpoint
-		}
-		if c.AccessKey != "" {
-			c.ECSSDConfig.AccessKey = c.AccessKey
-		}
-		if c.SecretKey != "" {
-			c.ECSSDConfig.SecretKey = c.SecretKey
-		}
-		if c.Profile != "" {
-			c.ECSSDConfig.Profile = c.Profile
-		}
-		if c.RoleARN != "" {
-			c.ECSSDConfig.RoleARN = c.RoleARN
-		}
-		if c.ExternalID != "" {
-			c.ECSSDConfig.ExternalID = c.ExternalID
-		}
-		if c.Port != 0 {
-			c.ECSSDConfig.Port = c.Port
-		}
-		if c.RefreshInterval != 0 {
-			c.ECSSDConfig.RefreshInterval = c.RefreshInterval
-		}
+		setIfNonZero(&c.ECSSDConfig.Endpoint, c.Endpoint)
+		setIfNonZero(&c.ECSSDConfig.AccessKey, c.AccessKey)
+		setIfNonZero(&c.ECSSDConfig.SecretKey, c.SecretKey)
+		setIfNonZero(&c.ECSSDConfig.Profile, c.Profile)
+		setIfNonZero(&c.ECSSDConfig.RoleARN, c.RoleARN)
+		setIfNonZero(&c.ECSSDConfig.ExternalID, c.ExternalID)
+		setIfNonZero(&c.ECSSDConfig.Port, c.Port)
+		setIfNonZero(&c.ECSSDConfig.RefreshInterval, c.RefreshInterval)
 		if c.Clusters != nil {
 			c.ECSSDConfig.Clusters = c.Clusters
 		}
@@ -192,30 +161,14 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		c.ElasticacheSDConfig.HTTPClientConfig = c.HTTPClientConfig
 		c.ElasticacheSDConfig.Region = c.Region
-		if c.Endpoint != "" {
-			c.ElasticacheSDConfig.Endpoint = c.Endpoint
-		}
-		if c.AccessKey != "" {
-			c.ElasticacheSDConfig.AccessKey = c.AccessKey
-		}
-		if c.SecretKey != "" {
-			c.ElasticacheSDConfig.SecretKey = c.SecretKey
-		}
-		if c.Profile != "" {
-			c.ElasticacheSDConfig.Profile = c.Profile
-		}
-		if c.RoleARN != "" {
-			c.ElasticacheSDConfig.RoleARN = c.RoleARN
-		}
-		if c.ExternalID != "" {
-			c.ElasticacheSDConfig.ExternalID = c.ExternalID
-		}
-		if c.Port != 0 {
-			c.ElasticacheSDConfig.Port = c.Port
-		}
-		if c.RefreshInterval != 0 {
-			c.ElasticacheSDConfig.RefreshInterval = c.RefreshInterval
-		}
+		setIfNonZero(&c.ElasticacheSDConfig.Endpoint, c.Endpoint)
+		setIfNonZero(&c.ElasticacheSDConfig.AccessKey, c.AccessKey)
+		setIfNonZero(&c.ElasticacheSDConfig.SecretKey, c.SecretKey)
+		setIfNonZero(&c.ElasticacheSDConfig.Profile, c.Profile)
+		setIfNonZero(&c.ElasticacheSDConfig.RoleARN, c.RoleARN)
+		setIfNonZero(&c.ElasticacheSDConfig.ExternalID, c.ExternalID)
+		setIfNonZero(&c.ElasticacheSDConfig.Port, c.Port)
+		setIfNonZero(&c.ElasticacheSDConfig.RefreshInterval, c.RefreshInterval)
 		if c.Clusters != nil {
 			c.ElasticacheSDConfig.Clusters = c.Clusters
 		}
@@ -226,30 +179,14 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		c.LightsailSDConfig.HTTPClientConfig = c.HTTPClientConfig
 		c.LightsailSDConfig.Region = c.Region
-		if c.Endpoint != "" {
-			c.LightsailSDConfig.Endpoint = c.Endpoint
-		}
-		if c.AccessKey != "" {
-			c.LightsailSDConfig.AccessKey = c.AccessKey
-		}
-		if c.SecretKey != "" {
-			c.LightsailSDConfig.SecretKey = c.SecretKey
-		}
-		if c.Profile != "" {
-			c.LightsailSDConfig.Profile = c.Profile
-		}
-		if c.RoleARN != "" {
-			c.LightsailSDConfig.RoleARN = c.RoleARN
-		}
-		if c.ExternalID != "" {
-			c.LightsailSDConfig.ExternalID = c.ExternalID
-		}
-		if c.Port != 0 {
-			c.LightsailSDConfig.Port = c.Port
-		}
-		if c.RefreshInterval != 0 {
-			c.LightsailSDConfig.RefreshInterval = c.RefreshInterval
-		}
+		setIfNonZero(&c.LightsailSDConfig.Endpoint, c.Endpoint)
+		setIfNonZero(&c.LightsailSDConfig.AccessKey, c.AccessKey)
+		setIfNonZero(&c.LightsailSDConfig.SecretKey, c.SecretKey)
+		setIfNonZero(&c.LightsailSDConfig.Profile, c.Profile)
+		setIfNonZero(&c.LightsailSDConfig.RoleARN, c.RoleARN)
+		setIfNonZero(&c.LightsailSDConfig.ExternalID, c.ExternalID)
+		setIfNonZero(&c.LightsailSDConfig.Port, c.Port)
+		setIfNonZero(&c.LightsailSDConfig.RefreshInterval, c.RefreshInterval)
 	case RoleMSK:
 		if c.MSKSDConfig == nil {
 			mskConfig := DefaultMSKSDConfig
@@ -257,30 +194,14 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		c.MSKSDConfig.HTTPClientConfig = c.HTTPClientConfig
 		c.MSKSDConfig.Region = c.Region
-		if c.Endpoint != "" {
-			c.MSKSDConfig.Endpoint = c.Endpoint
-		}
-		if c.AccessKey != "" {
-			c.MSKSDConfig.AccessKey = c.AccessKey
-		}
-		if c.SecretKey != "" {
-			c.MSKSDConfig.SecretKey = c.SecretKey
-		}
-		if c.Profile != "" {
-			c.MSKSDConfig.Profile = c.Profile
-		}
-		if c.RoleARN != "" {
-			c.MSKSDConfig.RoleARN = c.RoleARN
-		}
-		if c.ExternalID != "" {
-			c.MSKSDConfig.ExternalID = c.ExternalID
-		}
-		if c.Port != 0 {
-			c.MSKSDConfig.Port = c.Port
-		}
-		if c.RefreshInterval != 0 {
-			c.MSKSDConfig.RefreshInterval = c.RefreshInterval
-		}
+		setIfNonZero(&c.MSKSDConfig.Endpoint, c.Endpoint)
+		setIfNonZero(&c.MSKSDConfig.AccessKey, c.AccessKey)
+		setIfNonZero(&c.MSKSDConfig.SecretKey, c.SecretKey)
+		setIfNonZero(&c.MSKSDConfig.Profile, c.Profile)
+		setIfNonZero(&c.MSKSDConfig.RoleARN, c.RoleARN)
+		setIfNonZero(&c.MSKSDConfig.ExternalID, c.ExternalID)
+		setIfNonZero(&c.MSKSDConfig.Port, c.Port)
+		setIfNonZero(&c.MSKSDConfig.RefreshInterval, c.RefreshInterval)
 		if c.Clusters != nil {
 			c.MSKSDConfig.Clusters = c.Clusters
 		}
@@ -291,30 +212,14 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		c.RDSSDConfig.HTTPClientConfig = c.HTTPClientConfig
 		c.RDSSDConfig.Region = c.Region
-		if c.Endpoint != "" {
-			c.RDSSDConfig.Endpoint = c.Endpoint
-		}
-		if c.AccessKey != "" {
-			c.RDSSDConfig.AccessKey = c.AccessKey
-		}
-		if c.SecretKey != "" {
-			c.RDSSDConfig.SecretKey = c.SecretKey
-		}
-		if c.Profile != "" {
-			c.RDSSDConfig.Profile = c.Profile
-		}
-		if c.RoleARN != "" {
-			c.RDSSDConfig.RoleARN = c.RoleARN
-		}
-		if c.ExternalID != "" {
-			c.RDSSDConfig.ExternalID = c.ExternalID
-		}
-		if c.Port != 0 {
-			c.RDSSDConfig.Port = c.Port
-		}
-		if c.RefreshInterval != 0 {
-			c.RDSSDConfig.RefreshInterval = c.RefreshInterval
-		}
+		setIfNonZero(&c.RDSSDConfig.Endpoint, c.Endpoint)
+		setIfNonZero(&c.RDSSDConfig.AccessKey, c.AccessKey)
+		setIfNonZero(&c.RDSSDConfig.SecretKey, c.SecretKey)
+		setIfNonZero(&c.RDSSDConfig.Profile, c.Profile)
+		setIfNonZero(&c.RDSSDConfig.RoleARN, c.RoleARN)
+		setIfNonZero(&c.RDSSDConfig.ExternalID, c.ExternalID)
+		setIfNonZero(&c.RDSSDConfig.Port, c.Port)
+		setIfNonZero(&c.RDSSDConfig.RefreshInterval, c.RefreshInterval)
 		if c.Filters != nil {
 			c.RDSSDConfig.Filters = c.Filters
 		}
@@ -370,29 +275,30 @@ func (c *SDConfig) NewDiscoverer(opts discovery.DiscovererOptions) (discovery.Di
 func (c *SDConfig) SetDirectory(dir string) {
 	switch c.Role {
 	case RoleEC2:
-		if c.EC2SDConfig != nil {
-			c.EC2SDConfig.SetDirectory(dir)
-		}
+		setDirectory(c.EC2SDConfig, dir)
 	case RoleECS:
-		if c.ECSSDConfig != nil {
-			c.ECSSDConfig.SetDirectory(dir)
-		}
+		setDirectory(c.ECSSDConfig, dir)
 	case RoleElasticache:
-		if c.ElasticacheSDConfig != nil {
-			c.ElasticacheSDConfig.SetDirectory(dir)
-		}
+		setDirectory(c.ElasticacheSDConfig, dir)
 	case RoleLightsail:
-		if c.LightsailSDConfig != nil {
-			c.LightsailSDConfig.SetDirectory(dir)
-		}
+		setDirectory(c.LightsailSDConfig, dir)
 	case RoleMSK:
-		if c.MSKSDConfig != nil {
-			c.MSKSDConfig.SetDirectory(dir)
-		}
+		setDirectory(c.MSKSDConfig, dir)
 	case RoleRDS:
-		if c.RDSSDConfig != nil {
-			c.RDSSDConfig.SetDirectory(dir)
-		}
+		setDirectory(c.RDSSDConfig, dir)
+	}
+}
+
+// setDirectory calls cfg.SetDirectory, unless cfg is nil. It replaces the nil
+// check every role repeats in SDConfig.SetDirectory, since the role-specific
+// config for the role that is not active is left nil.
+func setDirectory[T interface {
+	comparable
+	SetDirectory(string)
+}](cfg T, dir string) {
+	var zero T
+	if cfg != zero {
+		cfg.SetDirectory(dir)
 	}
 }
 
@@ -432,4 +338,73 @@ func loadRegion(ctx context.Context, specifiedRegion string) (region string, err
 	}
 
 	return imdsRegion.Region, nil
+}
+
+// setIfNonZero assigns *dst = src, unless src is the zero value of T. It
+// replaces the repeated "if the parent config set this field, copy it into
+// the role-specific config" checks in SDConfig.UnmarshalYAML.
+func setIfNonZero[T comparable](dst *T, src T) {
+	var zero T
+	if src != zero {
+		*dst = src
+	}
+}
+
+// setIfNotNil assigns *dst = *v, unless v is nil. It replaces the nil checks
+// AWS discoveries repeat when copying an optional AWS SDK pointer field into
+// a plain struct field.
+func setIfNotNil[T any](dst, v *T) {
+	if v != nil {
+		*dst = *v
+	}
+}
+
+// setNonEmptyField assigns *dst = string(v), unless v is empty. It is meant
+// for the AWS SDK enumeration types, which are string types without a nil
+// value, when the destination is a plain struct field rather than a label.
+func setNonEmptyField[T ~string](dst *string, v T) {
+	if v != "" {
+		*dst = string(v)
+	}
+}
+
+// The setXLabel helpers below replace the nil and empty value checks that every
+// AWS discovery repeats for each meta label it builds. They leave labels
+// untouched for values AWS did not report, so a target never carries a label
+// with a placeholder value.
+
+// setStringLabel sets name in labels to the value of v, unless v is nil.
+func setStringLabel(labels model.LabelSet, name model.LabelName, v *string) {
+	if v != nil {
+		labels[name] = model.LabelValue(*v)
+	}
+}
+
+// setNonEmptyLabel sets name in labels to v, unless v is empty. It is meant for
+// the AWS SDK enumeration types, which are string types without a nil value.
+func setNonEmptyLabel[T ~string](labels model.LabelSet, name model.LabelName, v T) {
+	if v != "" {
+		labels[name] = model.LabelValue(v)
+	}
+}
+
+// setBoolLabel sets name in labels to "true" or "false", unless v is nil.
+func setBoolLabel(labels model.LabelSet, name model.LabelName, v *bool) {
+	if v != nil {
+		labels[name] = model.LabelValue(strconv.FormatBool(*v))
+	}
+}
+
+// setIntLabel sets name in labels to the decimal representation of v, unless v is nil.
+func setIntLabel[T ~int32 | ~int64](labels model.LabelSet, name model.LabelName, v *T) {
+	if v != nil {
+		labels[name] = model.LabelValue(strconv.FormatInt(int64(*v), 10))
+	}
+}
+
+// setTimeLabel sets name in labels to v formatted as RFC 3339, unless v is nil.
+func setTimeLabel(labels model.LabelSet, name model.LabelName, v *time.Time) {
+	if v != nil {
+		labels[name] = model.LabelValue(v.Format(time.RFC3339))
+	}
 }

--- a/discovery/aws/aws_test.go
+++ b/discovery/aws/aws_test.go
@@ -16,6 +16,7 @@ package aws
 import (
 	"context"
 	"errors"
+	"math"
 	"math/rand/v2"
 	"net/http"
 	"net/http/httptest"
@@ -24,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
@@ -628,4 +630,138 @@ region: us-west-1
 			cfg.SetDirectory(tmpDir)
 		})
 	})
+}
+
+func TestSetLabelHelpers(t *testing.T) {
+	t.Parallel()
+
+	// enum stands in for the AWS SDK enumeration types, which are string types
+	// without a nil value.
+	type enum string
+
+	const name = model.LabelName("test_label")
+
+	testTime := time.Date(2024, 1, 1, 12, 30, 0, 0, time.UTC)
+	cet := time.FixedZone("CET", 3600)
+
+	tests := []struct {
+		name     string
+		set      func(model.LabelSet)
+		expected model.LabelSet
+	}{
+		// setStringLabel.
+		{
+			name:     "string pointer is set",
+			set:      func(ls model.LabelSet) { setStringLabel(ls, name, aws.String("db.example.com")) },
+			expected: model.LabelSet{name: "db.example.com"},
+		},
+		{
+			name:     "nil string pointer is skipped",
+			set:      func(ls model.LabelSet) { setStringLabel(ls, name, nil) },
+			expected: model.LabelSet{},
+		},
+		{
+			name:     "pointer to empty string is set",
+			set:      func(ls model.LabelSet) { setStringLabel(ls, name, aws.String("")) },
+			expected: model.LabelSet{name: ""},
+		},
+
+		// setNonEmptyLabel.
+		{
+			name:     "enum is set",
+			set:      func(ls model.LabelSet) { setNonEmptyLabel(ls, name, enum("async")) },
+			expected: model.LabelSet{name: "async"},
+		},
+		{
+			name:     "empty enum is skipped",
+			set:      func(ls model.LabelSet) { setNonEmptyLabel(ls, name, enum("")) },
+			expected: model.LabelSet{},
+		},
+		{
+			name:     "string is set",
+			set:      func(ls model.LabelSet) { setNonEmptyLabel(ls, name, "subnet-01234567") },
+			expected: model.LabelSet{name: "subnet-01234567"},
+		},
+		{
+			name:     "empty string is skipped",
+			set:      func(ls model.LabelSet) { setNonEmptyLabel(ls, name, "") },
+			expected: model.LabelSet{},
+		},
+
+		// setBoolLabel.
+		{
+			name:     "true bool is set",
+			set:      func(ls model.LabelSet) { setBoolLabel(ls, name, aws.Bool(true)) },
+			expected: model.LabelSet{name: "true"},
+		},
+		{
+			name:     "false bool is set",
+			set:      func(ls model.LabelSet) { setBoolLabel(ls, name, aws.Bool(false)) },
+			expected: model.LabelSet{name: "false"},
+		},
+		{
+			name:     "nil bool is skipped",
+			set:      func(ls model.LabelSet) { setBoolLabel(ls, name, nil) },
+			expected: model.LabelSet{},
+		},
+
+		// setIntLabel.
+		{
+			name:     "int32 is set",
+			set:      func(ls model.LabelSet) { setIntLabel(ls, name, aws.Int32(100)) },
+			expected: model.LabelSet{name: "100"},
+		},
+		{
+			name:     "zero int32 is set",
+			set:      func(ls model.LabelSet) { setIntLabel(ls, name, aws.Int32(0)) },
+			expected: model.LabelSet{name: "0"},
+		},
+		{
+			name:     "nil int32 is skipped",
+			set:      func(ls model.LabelSet) { setIntLabel(ls, name, (*int32)(nil)) },
+			expected: model.LabelSet{},
+		},
+		{
+			name:     "int64 is set",
+			set:      func(ls model.LabelSet) { setIntLabel(ls, name, aws.Int64(4294967296)) },
+			expected: model.LabelSet{name: "4294967296"},
+		},
+		{
+			name:     "int64 max is not truncated",
+			set:      func(ls model.LabelSet) { setIntLabel(ls, name, aws.Int64(math.MaxInt64)) },
+			expected: model.LabelSet{name: "9223372036854775807"},
+		},
+		{
+			name:     "nil int64 is skipped",
+			set:      func(ls model.LabelSet) { setIntLabel(ls, name, (*int64)(nil)) },
+			expected: model.LabelSet{},
+		},
+
+		// setTimeLabel.
+		{
+			name:     "UTC time is set",
+			set:      func(ls model.LabelSet) { setTimeLabel(ls, name, &testTime) },
+			expected: model.LabelSet{name: "2024-01-01T12:30:00Z"},
+		},
+		{
+			name:     "time keeps its offset",
+			set:      func(ls model.LabelSet) { ts := testTime.In(cet); setTimeLabel(ls, name, &ts) },
+			expected: model.LabelSet{name: "2024-01-01T13:30:00+01:00"},
+		},
+		{
+			name:     "nil time is skipped",
+			set:      func(ls model.LabelSet) { setTimeLabel(ls, name, nil) },
+			expected: model.LabelSet{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			labels := model.LabelSet{}
+			tt.set(labels)
+			require.Equal(t, tt.expected, labels)
+		})
+	}
 }

--- a/discovery/aws/ec2.go
+++ b/discovery/aws/ec2.go
@@ -358,33 +358,22 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 					ec2LabelRegion:     model.LabelValue(d.region),
 				}
 
-				if r.OwnerId != nil {
-					labels[ec2LabelOwnerID] = model.LabelValue(*r.OwnerId)
-				}
+				setStringLabel(labels, ec2LabelOwnerID, r.OwnerId)
 
-				if defaultIPv6Addr != nil {
-					labels[ec2LabelDefaultIPv6Address] = model.LabelValue(*defaultIPv6Addr)
-				}
+				setStringLabel(labels, ec2LabelDefaultIPv6Address, defaultIPv6Addr)
 
+				setStringLabel(labels, ec2LabelPrivateIP, inst.PrivateIpAddress)
 				if inst.PrivateIpAddress != nil {
-					labels[ec2LabelPrivateIP] = model.LabelValue(*inst.PrivateIpAddress)
 					labels[model.AddressLabel] = model.LabelValue(net.JoinHostPort(*inst.PrivateIpAddress, strconv.Itoa(d.cfg.Port)))
 				} else {
 					labels[model.AddressLabel] = model.LabelValue(net.JoinHostPort(*defaultIPv6Addr, strconv.Itoa(d.cfg.Port)))
 				}
 
-				if inst.PrivateDnsName != nil {
-					labels[ec2LabelPrivateDNS] = model.LabelValue(*inst.PrivateDnsName)
-				}
+				setStringLabel(labels, ec2LabelPrivateDNS, inst.PrivateDnsName)
+				setNonEmptyLabel(labels, ec2LabelPlatform, inst.Platform)
 
-				if inst.Platform != "" {
-					labels[ec2LabelPlatform] = model.LabelValue(inst.Platform)
-				}
-
-				if inst.PublicIpAddress != nil {
-					labels[ec2LabelPublicIP] = model.LabelValue(*inst.PublicIpAddress)
-					labels[ec2LabelPublicDNS] = model.LabelValue(*inst.PublicDnsName)
-				}
+				setStringLabel(labels, ec2LabelPublicIP, inst.PublicIpAddress)
+				setStringLabel(labels, ec2LabelPublicDNS, inst.PublicDnsName)
 
 				if primaryIPv6Addrs != nil {
 					labels[ec2LabelPrimaryIPv6Addresses] = model.LabelValue(
@@ -412,17 +401,12 @@ func (d *EC2Discovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 				labels[ec2LabelInstanceState] = model.LabelValue(inst.State.Name)
 				labels[ec2LabelInstanceType] = model.LabelValue(inst.InstanceType)
 
-				if inst.InstanceLifecycle != "" {
-					labels[ec2LabelInstanceLifecycle] = model.LabelValue(inst.InstanceLifecycle)
-				}
-
-				if inst.Architecture != "" {
-					labels[ec2LabelArch] = model.LabelValue(inst.Architecture)
-				}
+				setNonEmptyLabel(labels, ec2LabelInstanceLifecycle, inst.InstanceLifecycle)
+				setNonEmptyLabel(labels, ec2LabelArch, inst.Architecture)
 
 				if inst.VpcId != nil {
-					labels[ec2LabelVPCID] = model.LabelValue(*inst.VpcId)
-					labels[ec2LabelPrimarySubnetID] = model.LabelValue(*inst.SubnetId)
+					setStringLabel(labels, ec2LabelVPCID, inst.VpcId)
+					setStringLabel(labels, ec2LabelPrimarySubnetID, inst.SubnetId)
 
 					var subnets []string
 					subnetsMap := make(map[string]struct{})

--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -618,15 +618,9 @@ func (d *ECSDiscovery) describeEC2Instances(ctx context.Context, instanceIDs []s
 					privateIP: *instance.PrivateIpAddress,
 					tags:      make(map[string]string),
 				}
-				if instance.PublicIpAddress != nil {
-					info.publicIP = *instance.PublicIpAddress
-				}
-				if instance.SubnetId != nil {
-					info.subnetID = *instance.SubnetId
-				}
-				if instance.InstanceType != "" {
-					info.instanceType = string(instance.InstanceType)
-				}
+				setIfNotNil(&info.publicIP, instance.PublicIpAddress)
+				setIfNotNil(&info.subnetID, instance.SubnetId)
+				setNonEmptyField(&info.instanceType, instance.InstanceType)
 				// Collect EC2 instance tags
 				for _, tag := range instance.Tags {
 					if tag.Key != nil && tag.Value != nil {
@@ -949,36 +943,17 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 					}
 
 					// Add subnet ID when available (awsvpc mode from ENI, bridge/host from EC2 instance)
-					if subnetID != "" {
-						labels[ecsLabelSubnetID] = model.LabelValue(subnetID)
-					}
+					setNonEmptyLabel(labels, ecsLabelSubnetID, subnetID)
 
 					// Add container instance and EC2 instance info for EC2 launch type
-					if task.ContainerInstanceArn != nil {
-						labels[ecsLabelContainerInstanceARN] = model.LabelValue(*task.ContainerInstanceArn)
-					}
-					if ec2InstanceID != "" {
-						labels[ecsLabelEC2InstanceID] = model.LabelValue(ec2InstanceID)
-					}
-					if ec2InstanceType != "" {
-						labels[ecsLabelEC2InstanceType] = model.LabelValue(ec2InstanceType)
-					}
-					if ec2InstancePrivateIP != "" {
-						labels[ecsLabelEC2InstancePrivateIP] = model.LabelValue(ec2InstancePrivateIP)
-					}
-					if ec2InstancePublicIP != "" {
-						labels[ecsLabelEC2InstancePublicIP] = model.LabelValue(ec2InstancePublicIP)
-					}
-					if publicIP != "" {
-						labels[ecsLabelPublicIP] = model.LabelValue(publicIP)
-					}
-
-					if task.PlatformFamily != nil {
-						labels[ecsLabelPlatformFamily] = model.LabelValue(*task.PlatformFamily)
-					}
-					if task.PlatformVersion != nil {
-						labels[ecsLabelPlatformVersion] = model.LabelValue(*task.PlatformVersion)
-					}
+					setStringLabel(labels, ecsLabelContainerInstanceARN, task.ContainerInstanceArn)
+					setNonEmptyLabel(labels, ecsLabelEC2InstanceID, ec2InstanceID)
+					setNonEmptyLabel(labels, ecsLabelEC2InstanceType, ec2InstanceType)
+					setNonEmptyLabel(labels, ecsLabelEC2InstancePrivateIP, ec2InstancePrivateIP)
+					setNonEmptyLabel(labels, ecsLabelEC2InstancePublicIP, ec2InstancePublicIP)
+					setNonEmptyLabel(labels, ecsLabelPublicIP, publicIP)
+					setStringLabel(labels, ecsLabelPlatformFamily, task.PlatformFamily)
+					setStringLabel(labels, ecsLabelPlatformVersion, task.PlatformVersion)
 
 					labels[model.AddressLabel] = model.LabelValue(net.JoinHostPort(ipAddress, strconv.Itoa(d.cfg.Port)))
 
@@ -995,15 +970,9 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 						if !ok {
 							d.logger.Debug("Service not found for task", "task", *task.TaskArn, "service", getServiceNameFromTaskGroup(task))
 						}
-						if service.ServiceName != nil {
-							labels[ecsLabelService] = model.LabelValue(*service.ServiceName)
-						}
-						if service.ServiceArn != nil {
-							labels[ecsLabelServiceARN] = model.LabelValue(*service.ServiceArn)
-						}
-						if service.Status != nil {
-							labels[ecsLabelServiceStatus] = model.LabelValue(*service.Status)
-						}
+						setStringLabel(labels, ecsLabelService, service.ServiceName)
+						setStringLabel(labels, ecsLabelServiceARN, service.ServiceArn)
+						setStringLabel(labels, ecsLabelServiceStatus, service.Status)
 
 						// Add service tags
 						for _, serviceTag := range service.Tags {

--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -629,46 +629,21 @@ func addServerlessCacheTargets(tg *targetgroup.Group, cache *types.ServerlessCac
 		elasticacheLabelServerlessCacheMajorEngineVersion: model.LabelValue(*cache.MajorEngineVersion),
 	}
 
-	if cache.Description != nil {
-		labels[elasticacheLabelServerlessCacheDescription] = model.LabelValue(*cache.Description)
-	}
-
-	if cache.CreateTime != nil {
-		labels[elasticacheLabelServerlessCacheCreateTime] = model.LabelValue(cache.CreateTime.Format(time.RFC3339))
-	}
-
-	if cache.KmsKeyId != nil {
-		labels[elasticacheLabelServerlessCacheKmsKeyID] = model.LabelValue(*cache.KmsKeyId)
-	}
-
-	if cache.UserGroupId != nil {
-		labels[elasticacheLabelServerlessCacheUserGroupID] = model.LabelValue(*cache.UserGroupId)
-	}
-
-	if cache.DailySnapshotTime != nil {
-		labels[elasticacheLabelServerlessCacheDailySnapshotTime] = model.LabelValue(*cache.DailySnapshotTime)
-	}
-
-	if cache.SnapshotRetentionLimit != nil {
-		labels[elasticacheLabelServerlessCacheSnapshotRetentionLimit] = model.LabelValue(strconv.Itoa(int(*cache.SnapshotRetentionLimit)))
-	}
+	setStringLabel(labels, elasticacheLabelServerlessCacheDescription, cache.Description)
+	setTimeLabel(labels, elasticacheLabelServerlessCacheCreateTime, cache.CreateTime)
+	setStringLabel(labels, elasticacheLabelServerlessCacheKmsKeyID, cache.KmsKeyId)
+	setStringLabel(labels, elasticacheLabelServerlessCacheUserGroupID, cache.UserGroupId)
+	setStringLabel(labels, elasticacheLabelServerlessCacheDailySnapshotTime, cache.DailySnapshotTime)
+	setIntLabel(labels, elasticacheLabelServerlessCacheSnapshotRetentionLimit, cache.SnapshotRetentionLimit)
 
 	if cache.Endpoint != nil {
-		if cache.Endpoint.Address != nil {
-			labels[elasticacheLabelServerlessCacheEndpointAddress] = model.LabelValue(*cache.Endpoint.Address)
-		}
-		if cache.Endpoint.Port != nil {
-			labels[elasticacheLabelServerlessCacheEndpointPort] = model.LabelValue(strconv.Itoa(int(*cache.Endpoint.Port)))
-		}
+		setStringLabel(labels, elasticacheLabelServerlessCacheEndpointAddress, cache.Endpoint.Address)
+		setIntLabel(labels, elasticacheLabelServerlessCacheEndpointPort, cache.Endpoint.Port)
 	}
 
 	if cache.ReaderEndpoint != nil {
-		if cache.ReaderEndpoint.Address != nil {
-			labels[elasticacheLabelServerlessCacheReaderEndpointAddress] = model.LabelValue(*cache.ReaderEndpoint.Address)
-		}
-		if cache.ReaderEndpoint.Port != nil {
-			labels[elasticacheLabelServerlessCacheReaderEndpointPort] = model.LabelValue(strconv.Itoa(int(*cache.ReaderEndpoint.Port)))
-		}
+		setStringLabel(labels, elasticacheLabelServerlessCacheReaderEndpointAddress, cache.ReaderEndpoint.Address)
+		setIntLabel(labels, elasticacheLabelServerlessCacheReaderEndpointPort, cache.ReaderEndpoint.Port)
 	}
 
 	for i, sgID := range cache.SecurityGroupIds {
@@ -681,21 +656,13 @@ func addServerlessCacheTargets(tg *targetgroup.Group, cache *types.ServerlessCac
 
 	if cache.CacheUsageLimits != nil {
 		if cache.CacheUsageLimits.DataStorage != nil {
-			if cache.CacheUsageLimits.DataStorage.Maximum != nil {
-				labels[elasticacheLabelServerlessCacheCacheUsageLimitCacheDataStorageMaximum] = model.LabelValue(strconv.Itoa(int(*cache.CacheUsageLimits.DataStorage.Maximum)))
-			}
-			if cache.CacheUsageLimits.DataStorage.Minimum != nil {
-				labels[elasticacheLabelServerlessCacheCacheUsageLimitCacheDataStorageMinimum] = model.LabelValue(strconv.Itoa(int(*cache.CacheUsageLimits.DataStorage.Minimum)))
-			}
+			setIntLabel(labels, elasticacheLabelServerlessCacheCacheUsageLimitCacheDataStorageMaximum, cache.CacheUsageLimits.DataStorage.Maximum)
+			setIntLabel(labels, elasticacheLabelServerlessCacheCacheUsageLimitCacheDataStorageMinimum, cache.CacheUsageLimits.DataStorage.Minimum)
 			labels[elasticacheLabelServerlessCacheCacheUsageLimitCacheDataStorageUnit] = model.LabelValue(cache.CacheUsageLimits.DataStorage.Unit)
 		}
 		if cache.CacheUsageLimits.ECPUPerSecond != nil {
-			if cache.CacheUsageLimits.ECPUPerSecond.Maximum != nil {
-				labels[elasticacheLabelServerlessCacheCacheUsageLimitECPUPerSecondMaximum] = model.LabelValue(strconv.Itoa(int(*cache.CacheUsageLimits.ECPUPerSecond.Maximum)))
-			}
-			if cache.CacheUsageLimits.ECPUPerSecond.Minimum != nil {
-				labels[elasticacheLabelServerlessCacheCacheUsageLimitECPUPerSecondMinimum] = model.LabelValue(strconv.Itoa(int(*cache.CacheUsageLimits.ECPUPerSecond.Minimum)))
-			}
+			setIntLabel(labels, elasticacheLabelServerlessCacheCacheUsageLimitECPUPerSecondMaximum, cache.CacheUsageLimits.ECPUPerSecond.Maximum)
+			setIntLabel(labels, elasticacheLabelServerlessCacheCacheUsageLimitECPUPerSecondMinimum, cache.CacheUsageLimits.ECPUPerSecond.Minimum)
 		}
 	}
 
@@ -724,163 +691,71 @@ func addCacheClusterTargets(tg *targetgroup.Group, cluster *types.CacheCluster, 
 		elasticacheLabelCacheClusterStatus: model.LabelValue(*cluster.CacheClusterStatus),
 	}
 
-	if cluster.AtRestEncryptionEnabled != nil {
-		commonLabels[elasticacheLabelCacheClusterAtRestEncryptionEnabled] = model.LabelValue(strconv.FormatBool(*cluster.AtRestEncryptionEnabled))
+	setBoolLabel(commonLabels, elasticacheLabelCacheClusterAtRestEncryptionEnabled, cluster.AtRestEncryptionEnabled)
+	setBoolLabel(commonLabels, elasticacheLabelCacheClusterAuthTokenEnabled, cluster.AuthTokenEnabled)
+	setTimeLabel(commonLabels, elasticacheLabelCacheClusterAuthTokenLastModified, cluster.AuthTokenLastModifiedDate)
+	setBoolLabel(commonLabels, elasticacheLabelCacheClusterAutoMinorVersionUpgrade, cluster.AutoMinorVersionUpgrade)
+	setTimeLabel(commonLabels, elasticacheLabelCacheClusterCreateTime, cluster.CacheClusterCreateTime)
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterNodeType, cluster.CacheNodeType)
+
+	if cluster.CacheParameterGroup != nil {
+		setStringLabel(commonLabels, elasticacheLabelCacheClusterParameterGroup, cluster.CacheParameterGroup.CacheParameterGroupName)
 	}
 
-	if cluster.AuthTokenEnabled != nil {
-		commonLabels[elasticacheLabelCacheClusterAuthTokenEnabled] = model.LabelValue(strconv.FormatBool(*cluster.AuthTokenEnabled))
-	}
-
-	if cluster.AuthTokenLastModifiedDate != nil {
-		commonLabels[elasticacheLabelCacheClusterAuthTokenLastModified] = model.LabelValue(cluster.AuthTokenLastModifiedDate.Format(time.RFC3339))
-	}
-
-	if cluster.AutoMinorVersionUpgrade != nil {
-		commonLabels[elasticacheLabelCacheClusterAutoMinorVersionUpgrade] = model.LabelValue(strconv.FormatBool(*cluster.AutoMinorVersionUpgrade))
-	}
-
-	if cluster.CacheClusterCreateTime != nil {
-		commonLabels[elasticacheLabelCacheClusterCreateTime] = model.LabelValue(cluster.CacheClusterCreateTime.Format(time.RFC3339))
-	}
-
-	if cluster.CacheNodeType != nil {
-		commonLabels[elasticacheLabelCacheClusterNodeType] = model.LabelValue(*cluster.CacheNodeType)
-	}
-
-	if cluster.CacheParameterGroup != nil && cluster.CacheParameterGroup.CacheParameterGroupName != nil {
-		commonLabels[elasticacheLabelCacheClusterParameterGroup] = model.LabelValue(*cluster.CacheParameterGroup.CacheParameterGroupName)
-	}
-
-	if cluster.CacheSubnetGroupName != nil {
-		commonLabels[elasticacheLabelCacheClusterSubnetGroupName] = model.LabelValue(*cluster.CacheSubnetGroupName)
-	}
-
-	if cluster.ClientDownloadLandingPage != nil {
-		commonLabels[elasticacheLabelCacheClusterClientDownloadLandingPage] = model.LabelValue(*cluster.ClientDownloadLandingPage)
-	}
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterSubnetGroupName, cluster.CacheSubnetGroupName)
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterClientDownloadLandingPage, cluster.ClientDownloadLandingPage)
 
 	if cluster.ConfigurationEndpoint != nil {
-		if cluster.ConfigurationEndpoint.Address != nil {
-			commonLabels[elasticacheLabelCacheClusterConfigurationEndpointAddress] = model.LabelValue(*cluster.ConfigurationEndpoint.Address)
-		}
-		if cluster.ConfigurationEndpoint.Port != nil {
-			commonLabels[elasticacheLabelCacheClusterConfigurationEndpointPort] = model.LabelValue(strconv.Itoa(int(*cluster.ConfigurationEndpoint.Port)))
-		}
+		setStringLabel(commonLabels, elasticacheLabelCacheClusterConfigurationEndpointAddress, cluster.ConfigurationEndpoint.Address)
+		setIntLabel(commonLabels, elasticacheLabelCacheClusterConfigurationEndpointPort, cluster.ConfigurationEndpoint.Port)
 	}
 
-	if cluster.Engine != nil {
-		commonLabels[elasticacheLabelCacheClusterEngine] = model.LabelValue(*cluster.Engine)
-	}
-
-	if cluster.EngineVersion != nil {
-		commonLabels[elasticacheLabelCacheClusterEngineVersion] = model.LabelValue(*cluster.EngineVersion)
-	}
-
-	if len(cluster.IpDiscovery) > 0 {
-		commonLabels[elasticacheLabelCacheClusterIPDiscovery] = model.LabelValue(cluster.IpDiscovery)
-	}
-
-	if len(cluster.NetworkType) > 0 {
-		commonLabels[elasticacheLabelCacheClusterNetworkType] = model.LabelValue(cluster.NetworkType)
-	}
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterEngine, cluster.Engine)
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterEngineVersion, cluster.EngineVersion)
+	setNonEmptyLabel(commonLabels, elasticacheLabelCacheClusterIPDiscovery, cluster.IpDiscovery)
+	setNonEmptyLabel(commonLabels, elasticacheLabelCacheClusterNetworkType, cluster.NetworkType)
 
 	if cluster.NotificationConfiguration != nil {
-		if cluster.NotificationConfiguration.TopicArn != nil {
-			commonLabels[elasticacheLabelCacheClusterNotificationTopicARN] = model.LabelValue(*cluster.NotificationConfiguration.TopicArn)
-		}
-		if cluster.NotificationConfiguration.TopicStatus != nil {
-			commonLabels[elasticacheLabelCacheClusterNotificationTopicStatus] = model.LabelValue(*cluster.NotificationConfiguration.TopicStatus)
-		}
+		setStringLabel(commonLabels, elasticacheLabelCacheClusterNotificationTopicARN, cluster.NotificationConfiguration.TopicArn)
+		setStringLabel(commonLabels, elasticacheLabelCacheClusterNotificationTopicStatus, cluster.NotificationConfiguration.TopicStatus)
 	}
 
-	if cluster.NumCacheNodes != nil {
-		commonLabels[elasticacheLabelCacheClusterNumCacheNodes] = model.LabelValue(strconv.Itoa(int(*cluster.NumCacheNodes)))
-	}
-
-	if cluster.PreferredAvailabilityZone != nil {
-		commonLabels[elasticacheLabelCacheClusterPreferredAvailabilityZone] = model.LabelValue(*cluster.PreferredAvailabilityZone)
-	}
-
-	if cluster.PreferredMaintenanceWindow != nil {
-		commonLabels[elasticacheLabelCacheClusterPreferredMaintenanceWindow] = model.LabelValue(*cluster.PreferredMaintenanceWindow)
-	}
-
-	if cluster.PreferredOutpostArn != nil {
-		commonLabels[elasticacheLabelCacheClusterPreferredOutpostARN] = model.LabelValue(*cluster.PreferredOutpostArn)
-	}
-
-	if cluster.ReplicationGroupId != nil {
-		commonLabels[elasticacheLabelCacheClusterReplicationGroupID] = model.LabelValue(*cluster.ReplicationGroupId)
-	}
-
-	if cluster.ReplicationGroupLogDeliveryEnabled != nil {
-		commonLabels[elasticacheLabelCacheClusterReplicationGroupLogDeliveryEnabled] = model.LabelValue(strconv.FormatBool(*cluster.ReplicationGroupLogDeliveryEnabled))
-	}
-
-	if cluster.SnapshotRetentionLimit != nil {
-		commonLabels[elasticacheLabelCacheClusterSnapshotRetentionLimit] = model.LabelValue(strconv.Itoa(int(*cluster.SnapshotRetentionLimit)))
-	}
-
-	if cluster.SnapshotWindow != nil {
-		commonLabels[elasticacheLabelCacheClusterSnapshotWindow] = model.LabelValue(*cluster.SnapshotWindow)
-	}
-
-	if cluster.TransitEncryptionEnabled != nil {
-		commonLabels[elasticacheLabelCacheClusterTransitEncryptionEnabled] = model.LabelValue(strconv.FormatBool(*cluster.TransitEncryptionEnabled))
-	}
-
-	if len(cluster.TransitEncryptionMode) > 0 {
-		commonLabels[elasticacheLabelCacheClusterTransitEncryptionMode] = model.LabelValue(cluster.TransitEncryptionMode)
-	}
+	setIntLabel(commonLabels, elasticacheLabelCacheClusterNumCacheNodes, cluster.NumCacheNodes)
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterPreferredAvailabilityZone, cluster.PreferredAvailabilityZone)
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterPreferredMaintenanceWindow, cluster.PreferredMaintenanceWindow)
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterPreferredOutpostARN, cluster.PreferredOutpostArn)
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterReplicationGroupID, cluster.ReplicationGroupId)
+	setBoolLabel(commonLabels, elasticacheLabelCacheClusterReplicationGroupLogDeliveryEnabled, cluster.ReplicationGroupLogDeliveryEnabled)
+	setIntLabel(commonLabels, elasticacheLabelCacheClusterSnapshotRetentionLimit, cluster.SnapshotRetentionLimit)
+	setStringLabel(commonLabels, elasticacheLabelCacheClusterSnapshotWindow, cluster.SnapshotWindow)
+	setBoolLabel(commonLabels, elasticacheLabelCacheClusterTransitEncryptionEnabled, cluster.TransitEncryptionEnabled)
+	setNonEmptyLabel(commonLabels, elasticacheLabelCacheClusterTransitEncryptionMode, cluster.TransitEncryptionMode)
 
 	// Log delivery configurations (slice)
 	for i, logDelivery := range cluster.LogDeliveryConfigurations {
-		if len(logDelivery.DestinationType) > 0 {
-			commonLabels[model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationDestinationType, i))] = model.LabelValue(logDelivery.DestinationType)
-		}
-		if len(logDelivery.LogFormat) > 0 {
-			commonLabels[model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationLogFormat, i))] = model.LabelValue(logDelivery.LogFormat)
-		}
-		if len(logDelivery.LogType) > 0 {
-			commonLabels[model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationLogType, i))] = model.LabelValue(logDelivery.LogType)
-		}
-		if len(logDelivery.Status) > 0 {
-			commonLabels[model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationStatus, i))] = model.LabelValue(logDelivery.Status)
-		}
-		if logDelivery.Message != nil {
-			commonLabels[model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationMessage, i))] = model.LabelValue(*logDelivery.Message)
-		}
+		setNonEmptyLabel(commonLabels, model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationDestinationType, i)), logDelivery.DestinationType)
+		setNonEmptyLabel(commonLabels, model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationLogFormat, i)), logDelivery.LogFormat)
+		setNonEmptyLabel(commonLabels, model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationLogType, i)), logDelivery.LogType)
+		setNonEmptyLabel(commonLabels, model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationStatus, i)), logDelivery.Status)
+		setStringLabel(commonLabels, model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationMessage, i)), logDelivery.Message)
 		if logDelivery.DestinationDetails != nil {
-			if logDelivery.DestinationDetails.CloudWatchLogsDetails != nil && logDelivery.DestinationDetails.CloudWatchLogsDetails.LogGroup != nil {
-				commonLabels[model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationLogGroup, i))] = model.LabelValue(*logDelivery.DestinationDetails.CloudWatchLogsDetails.LogGroup)
+			if logDelivery.DestinationDetails.CloudWatchLogsDetails != nil {
+				setStringLabel(commonLabels, model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationLogGroup, i)), logDelivery.DestinationDetails.CloudWatchLogsDetails.LogGroup)
 			}
-			if logDelivery.DestinationDetails.KinesisFirehoseDetails != nil && logDelivery.DestinationDetails.KinesisFirehoseDetails.DeliveryStream != nil {
-				commonLabels[model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationDeliveryStream, i))] = model.LabelValue(*logDelivery.DestinationDetails.KinesisFirehoseDetails.DeliveryStream)
+			if logDelivery.DestinationDetails.KinesisFirehoseDetails != nil {
+				setStringLabel(commonLabels, model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterLogDeliveryConfigurationDeliveryStream, i)), logDelivery.DestinationDetails.KinesisFirehoseDetails.DeliveryStream)
 			}
 		}
 	}
 
 	// Pending modified values
 	if cluster.PendingModifiedValues != nil {
-		if len(cluster.PendingModifiedValues.AuthTokenStatus) > 0 {
-			commonLabels[elasticacheLabelCacheClusterPendingModifiedValuesAuthTokenStatus] = model.LabelValue(cluster.PendingModifiedValues.AuthTokenStatus)
-		}
-		if cluster.PendingModifiedValues.CacheNodeType != nil {
-			commonLabels[elasticacheLabelCacheClusterPendingModifiedValuesCacheNodeType] = model.LabelValue(*cluster.PendingModifiedValues.CacheNodeType)
-		}
-		if cluster.PendingModifiedValues.EngineVersion != nil {
-			commonLabels[elasticacheLabelCacheClusterPendingModifiedValuesEngineVersion] = model.LabelValue(*cluster.PendingModifiedValues.EngineVersion)
-		}
-		if cluster.PendingModifiedValues.NumCacheNodes != nil {
-			commonLabels[elasticacheLabelCacheClusterPendingModifiedValuesNumCacheNodes] = model.LabelValue(strconv.Itoa(int(*cluster.PendingModifiedValues.NumCacheNodes)))
-		}
-		if cluster.PendingModifiedValues.TransitEncryptionEnabled != nil {
-			commonLabels[elasticacheLabelCacheClusterPendingModifiedValuesTransitEncryptionEnabled] = model.LabelValue(strconv.FormatBool(*cluster.PendingModifiedValues.TransitEncryptionEnabled))
-		}
-		if len(cluster.PendingModifiedValues.TransitEncryptionMode) > 0 {
-			commonLabels[elasticacheLabelCacheClusterPendingModifiedValuesTransitEncryptionMode] = model.LabelValue(cluster.PendingModifiedValues.TransitEncryptionMode)
-		}
+		setNonEmptyLabel(commonLabels, elasticacheLabelCacheClusterPendingModifiedValuesAuthTokenStatus, cluster.PendingModifiedValues.AuthTokenStatus)
+		setStringLabel(commonLabels, elasticacheLabelCacheClusterPendingModifiedValuesCacheNodeType, cluster.PendingModifiedValues.CacheNodeType)
+		setStringLabel(commonLabels, elasticacheLabelCacheClusterPendingModifiedValuesEngineVersion, cluster.PendingModifiedValues.EngineVersion)
+		setIntLabel(commonLabels, elasticacheLabelCacheClusterPendingModifiedValuesNumCacheNodes, cluster.PendingModifiedValues.NumCacheNodes)
+		setBoolLabel(commonLabels, elasticacheLabelCacheClusterPendingModifiedValuesTransitEncryptionEnabled, cluster.PendingModifiedValues.TransitEncryptionEnabled)
+		setNonEmptyLabel(commonLabels, elasticacheLabelCacheClusterPendingModifiedValuesTransitEncryptionMode, cluster.PendingModifiedValues.TransitEncryptionMode)
 		if len(cluster.PendingModifiedValues.CacheNodeIdsToRemove) > 0 {
 			commonLabels[elasticacheLabelCacheClusterPendingModifiedValuesCacheNodeIDsToRemove] = model.LabelValue(strings.Join(cluster.PendingModifiedValues.CacheNodeIdsToRemove, ","))
 		}
@@ -888,12 +763,8 @@ func addCacheClusterTargets(tg *targetgroup.Group, cluster *types.CacheCluster, 
 
 	// Security group membership (slice)
 	for i, sg := range cluster.SecurityGroups {
-		if sg.SecurityGroupId != nil {
-			commonLabels[model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterSecurityGroupMembershipID, i))] = model.LabelValue(*sg.SecurityGroupId)
-		}
-		if sg.Status != nil {
-			commonLabels[model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterSecurityGroupMembershipStatus, i))] = model.LabelValue(*sg.Status)
-		}
+		setStringLabel(commonLabels, model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterSecurityGroupMembershipID, i)), sg.SecurityGroupId)
+		setStringLabel(commonLabels, model.LabelName(fmt.Sprintf("%s_%d", elasticacheLabelCacheClusterSecurityGroupMembershipStatus, i)), sg.Status)
 	}
 
 	// Tags
@@ -910,34 +781,17 @@ func addCacheClusterTargets(tg *targetgroup.Group, cluster *types.CacheCluster, 
 		maps.Copy(labels, commonLabels)
 
 		// Add node-specific labels
-		if node.CacheNodeId != nil {
-			labels[elasticacheLabelCacheClusterNodeID] = model.LabelValue(*node.CacheNodeId)
-		}
-		if node.CacheNodeStatus != nil {
-			labels[elasticacheLabelCacheClusterNodeStatus] = model.LabelValue(*node.CacheNodeStatus)
-		}
-		if node.CacheNodeCreateTime != nil {
-			labels[elasticacheLabelCacheClusterNodeCreateTime] = model.LabelValue(node.CacheNodeCreateTime.Format(time.RFC3339))
-		}
-		if node.CustomerAvailabilityZone != nil {
-			labels[elasticacheLabelCacheClusterNodeAZ] = model.LabelValue(*node.CustomerAvailabilityZone)
-		}
-		if node.CustomerOutpostArn != nil {
-			labels[elasticacheLabelCacheClusterNodeCustomerOutpostARN] = model.LabelValue(*node.CustomerOutpostArn)
-		}
-		if node.SourceCacheNodeId != nil {
-			labels[elasticacheLabelCacheClusterNodeSourceCacheNodeID] = model.LabelValue(*node.SourceCacheNodeId)
-		}
-		if node.ParameterGroupStatus != nil {
-			labels[elasticacheLabelCacheClusterNodeParameterGroupStatus] = model.LabelValue(*node.ParameterGroupStatus)
-		}
+		setStringLabel(labels, elasticacheLabelCacheClusterNodeID, node.CacheNodeId)
+		setStringLabel(labels, elasticacheLabelCacheClusterNodeStatus, node.CacheNodeStatus)
+		setTimeLabel(labels, elasticacheLabelCacheClusterNodeCreateTime, node.CacheNodeCreateTime)
+		setStringLabel(labels, elasticacheLabelCacheClusterNodeAZ, node.CustomerAvailabilityZone)
+		setStringLabel(labels, elasticacheLabelCacheClusterNodeCustomerOutpostARN, node.CustomerOutpostArn)
+		setStringLabel(labels, elasticacheLabelCacheClusterNodeSourceCacheNodeID, node.SourceCacheNodeId)
+		setStringLabel(labels, elasticacheLabelCacheClusterNodeParameterGroupStatus, node.ParameterGroupStatus)
+
 		if node.Endpoint != nil {
-			if node.Endpoint.Address != nil {
-				labels[elasticacheLabelCacheClusterNodeEndpointAddress] = model.LabelValue(*node.Endpoint.Address)
-			}
-			if node.Endpoint.Port != nil {
-				labels[elasticacheLabelCacheClusterNodeEndpointPort] = model.LabelValue(strconv.Itoa(int(*node.Endpoint.Port)))
-			}
+			setStringLabel(labels, elasticacheLabelCacheClusterNodeEndpointAddress, node.Endpoint.Address)
+			setIntLabel(labels, elasticacheLabelCacheClusterNodeEndpointPort, node.Endpoint.Port)
 
 			// Set the address label to this node's endpoint
 			if node.Endpoint.Address != nil && node.Endpoint.Port != nil {

--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -272,9 +272,7 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 		addr := net.JoinHostPort(*inst.PrivateIpAddress, strconv.Itoa(d.cfg.Port))
 		labels[model.AddressLabel] = model.LabelValue(addr)
 
-		if inst.PublicIpAddress != nil {
-			labels[lightsailLabelPublicIP] = model.LabelValue(*inst.PublicIpAddress)
-		}
+		setStringLabel(labels, lightsailLabelPublicIP, inst.PublicIpAddress)
 
 		if len(inst.Ipv6Addresses) > 0 {
 			var ipv6addrs []string

--- a/discovery/aws/rds.go
+++ b/discovery/aws/rds.go
@@ -507,6 +507,206 @@ func (d *RDSDiscovery) describeDBInstances(ctx context.Context, dbClusterARN str
 	return dbInstances, nil
 }
 
+// rdsClusterWriters maps the instance identifier of every cluster member to its
+// IsClusterWriter status.
+func rdsClusterWriters(cluster types.DBCluster) map[string]bool {
+	writers := make(map[string]bool, len(cluster.DBClusterMembers))
+	for _, member := range cluster.DBClusterMembers {
+		if member.DBInstanceIdentifier != nil && member.IsClusterWriter != nil {
+			writers[*member.DBInstanceIdentifier] = *member.IsClusterWriter
+		}
+	}
+	return writers
+}
+
+// rdsClusterLabels returns the labels describing the DB cluster. The same set
+// applies to every instance of the cluster, so callers must copy it before
+// adding instance specific labels to it.
+func rdsClusterLabels(cluster types.DBCluster) model.LabelSet {
+	labels := model.LabelSet{}
+
+	setStringLabel(labels, rdsLabelClusterDBClusterArn, cluster.DBClusterArn)
+	setStringLabel(labels, rdsLabelClusterDBClusterIdentifier, cluster.DBClusterIdentifier)
+	setStringLabel(labels, rdsLabelClusterActivityStreamKinesisStreamName, cluster.ActivityStreamKinesisStreamName)
+	setStringLabel(labels, rdsLabelClusterActivityStreamKMSKeyID, cluster.ActivityStreamKmsKeyId)
+	setNonEmptyLabel(labels, rdsLabelClusterActivityStreamMode, cluster.ActivityStreamMode)
+	setNonEmptyLabel(labels, rdsLabelClusterActivityStreamStatus, cluster.ActivityStreamStatus)
+	setIntLabel(labels, rdsLabelClusterAllocatedStorage, cluster.AllocatedStorage)
+	setBoolLabel(labels, rdsLabelClusterAutoMinorVersionUpgrade, cluster.AutoMinorVersionUpgrade)
+	setTimeLabel(labels, rdsLabelClusterAutomaticRestartTime, cluster.AutomaticRestartTime)
+	setStringLabel(labels, rdsLabelClusterAwsBackupRecoveryPointArn, cluster.AwsBackupRecoveryPointArn)
+	setIntLabel(labels, rdsLabelClusterBacktrackConsumedChangeRecords, cluster.BacktrackConsumedChangeRecords)
+	setIntLabel(labels, rdsLabelClusterBacktrackWindow, cluster.BacktrackWindow)
+	setIntLabel(labels, rdsLabelClusterBackupRetentionPeriod, cluster.BackupRetentionPeriod)
+	setIntLabel(labels, rdsLabelClusterCapacity, cluster.Capacity)
+	setStringLabel(labels, rdsLabelClusterCharacterSetName, cluster.CharacterSetName)
+	setStringLabel(labels, rdsLabelClusterCloneGroupID, cluster.CloneGroupId)
+	setTimeLabel(labels, rdsLabelClusterClusterCreateTime, cluster.ClusterCreateTime)
+	setNonEmptyLabel(labels, rdsLabelClusterClusterScalabilityType, cluster.ClusterScalabilityType)
+	setBoolLabel(labels, rdsLabelClusterCopyTagsToSnapshot, cluster.CopyTagsToSnapshot)
+	setBoolLabel(labels, rdsLabelClusterCrossAccountClone, cluster.CrossAccountClone)
+	setStringLabel(labels, rdsLabelClusterDBClusterInstanceClass, cluster.DBClusterInstanceClass)
+	setStringLabel(labels, rdsLabelClusterDBClusterParameterGroup, cluster.DBClusterParameterGroup)
+	setStringLabel(labels, rdsLabelClusterDBSubnetGroup, cluster.DBSubnetGroup)
+	setStringLabel(labels, rdsLabelClusterDBSystemID, cluster.DBSystemId)
+	setNonEmptyLabel(labels, rdsLabelClusterDatabaseInsightsMode, cluster.DatabaseInsightsMode)
+	setStringLabel(labels, rdsLabelClusterDatabaseName, cluster.DatabaseName)
+	setStringLabel(labels, rdsLabelClusterDBClusterResourceID, cluster.DbClusterResourceId)
+	setBoolLabel(labels, rdsLabelClusterDeletionProtection, cluster.DeletionProtection)
+	setTimeLabel(labels, rdsLabelClusterEarliestBacktrackTime, cluster.EarliestBacktrackTime)
+	setTimeLabel(labels, rdsLabelClusterEarliestRestorableTime, cluster.EarliestRestorableTime)
+	setStringLabel(labels, rdsLabelClusterEndpoint, cluster.Endpoint)
+	setStringLabel(labels, rdsLabelClusterEngine, cluster.Engine)
+	setStringLabel(labels, rdsLabelClusterEngineLifecycleSupport, cluster.EngineLifecycleSupport)
+	setStringLabel(labels, rdsLabelClusterEngineMode, cluster.EngineMode)
+	setStringLabel(labels, rdsLabelClusterEngineVersion, cluster.EngineVersion)
+	setStringLabel(labels, rdsLabelClusterGlobalClusterIdentifier, cluster.GlobalClusterIdentifier)
+	setBoolLabel(labels, rdsLabelClusterGlobalWriteForwardingRequested, cluster.GlobalWriteForwardingRequested)
+	setNonEmptyLabel(labels, rdsLabelClusterGlobalWriteForwardingStatus, cluster.GlobalWriteForwardingStatus)
+	setStringLabel(labels, rdsLabelClusterHostedZoneID, cluster.HostedZoneId)
+	setBoolLabel(labels, rdsLabelClusterHTTPEndpointEnabled, cluster.HttpEndpointEnabled)
+	setBoolLabel(labels, rdsLabelClusterIAMDatabaseAuthenticationEnabled, cluster.IAMDatabaseAuthenticationEnabled)
+	setTimeLabel(labels, rdsLabelClusterIOOptimizedNextAllowedModificationTime, cluster.IOOptimizedNextAllowedModificationTime)
+	setIntLabel(labels, rdsLabelClusterIops, cluster.Iops)
+	setStringLabel(labels, rdsLabelClusterKMSKeyID, cluster.KmsKeyId)
+	setTimeLabel(labels, rdsLabelClusterLatestRestorableTime, cluster.LatestRestorableTime)
+	setNonEmptyLabel(labels, rdsLabelClusterLocalWriteForwardingStatus, cluster.LocalWriteForwardingStatus)
+	setStringLabel(labels, rdsLabelClusterMasterUsername, cluster.MasterUsername)
+	setIntLabel(labels, rdsLabelClusterMonitoringInterval, cluster.MonitoringInterval)
+	setStringLabel(labels, rdsLabelClusterMonitoringRoleArn, cluster.MonitoringRoleArn)
+	setBoolLabel(labels, rdsLabelClusterMultiAZ, cluster.MultiAZ)
+	setStringLabel(labels, rdsLabelClusterNetworkType, cluster.NetworkType)
+	setStringLabel(labels, rdsLabelClusterPercentProgress, cluster.PercentProgress)
+	setBoolLabel(labels, rdsLabelClusterPerformanceInsightsEnabled, cluster.PerformanceInsightsEnabled)
+	setStringLabel(labels, rdsLabelClusterPerformanceInsightsKMSKeyID, cluster.PerformanceInsightsKMSKeyId)
+	setIntLabel(labels, rdsLabelClusterPerformanceInsightsRetentionPeriod, cluster.PerformanceInsightsRetentionPeriod)
+	setIntLabel(labels, rdsLabelClusterPort, cluster.Port)
+	setStringLabel(labels, rdsLabelClusterPreferredBackupWindow, cluster.PreferredBackupWindow)
+	setStringLabel(labels, rdsLabelClusterPreferredMaintenanceWindow, cluster.PreferredMaintenanceWindow)
+	setBoolLabel(labels, rdsLabelClusterPubliclyAccessible, cluster.PubliclyAccessible)
+	setStringLabel(labels, rdsLabelClusterReaderEndpoint, cluster.ReaderEndpoint)
+	setStringLabel(labels, rdsLabelClusterReplicationSourceIdentifier, cluster.ReplicationSourceIdentifier)
+	setStringLabel(labels, rdsLabelClusterServerlessV2PlatformVersion, cluster.ServerlessV2PlatformVersion)
+	setStringLabel(labels, rdsLabelClusterStatus, cluster.Status)
+	setBoolLabel(labels, rdsLabelClusterStorageEncrypted, cluster.StorageEncrypted)
+	setNonEmptyLabel(labels, rdsLabelClusterStorageEncryptionType, cluster.StorageEncryptionType)
+	setIntLabel(labels, rdsLabelClusterStorageThroughput, cluster.StorageThroughput)
+	setStringLabel(labels, rdsLabelClusterStorageType, cluster.StorageType)
+	setNonEmptyLabel(labels, rdsLabelClusterUpgradeRolloutOrder, cluster.UpgradeRolloutOrder)
+
+	// Cluster tags.
+	for _, tag := range cluster.TagList {
+		if tag.Key != nil && tag.Value != nil {
+			labels[model.LabelName(rdsLabelClusterTag+strutil.SanitizeLabelName(*tag.Key))] = model.LabelValue(*tag.Value)
+		}
+	}
+
+	return labels
+}
+
+// addRDSInstanceLabels adds the labels describing the DB instance to labels.
+// writers maps instance identifiers to their IsClusterWriter status, as
+// returned by rdsClusterWriters.
+func addRDSInstanceLabels(labels model.LabelSet, instance types.DBInstance, writers map[string]bool) {
+	setStringLabel(labels, rdsLabelInstanceDBInstanceArn, instance.DBInstanceArn)
+	if instance.DBInstanceIdentifier != nil {
+		labels[rdsLabelInstanceDBInstanceIdentifier] = model.LabelValue(*instance.DBInstanceIdentifier)
+		// Set IsClusterWriter based on cluster membership information.
+		if isWriter, found := writers[*instance.DBInstanceIdentifier]; found {
+			labels[rdsLabelInstanceIsClusterWriter] = model.LabelValue(strconv.FormatBool(isWriter))
+		}
+	}
+	setBoolLabel(labels, rdsLabelInstanceActivityStreamEngineNativeAuditFieldsIncluded, instance.ActivityStreamEngineNativeAuditFieldsIncluded)
+	setStringLabel(labels, rdsLabelInstanceActivityStreamKinesisStreamName, instance.ActivityStreamKinesisStreamName)
+	setStringLabel(labels, rdsLabelInstanceActivityStreamKmsKeyID, instance.ActivityStreamKmsKeyId)
+	setNonEmptyLabel(labels, rdsLabelInstanceActivityStreamMode, instance.ActivityStreamMode)
+	setNonEmptyLabel(labels, rdsLabelInstanceActivityStreamPolicyStatus, instance.ActivityStreamPolicyStatus)
+	setNonEmptyLabel(labels, rdsLabelInstanceActivityStreamStatus, instance.ActivityStreamStatus)
+	setIntLabel(labels, rdsLabelInstanceAllocatedStorage, instance.AllocatedStorage)
+	setBoolLabel(labels, rdsLabelInstanceAutoMinorVersionUpgrade, instance.AutoMinorVersionUpgrade)
+	setTimeLabel(labels, rdsLabelInstanceAutomaticRestartTime, instance.AutomaticRestartTime)
+	setNonEmptyLabel(labels, rdsLabelInstanceAutomationMode, instance.AutomationMode)
+	setStringLabel(labels, rdsLabelInstanceAvailabilityZone, instance.AvailabilityZone)
+	setStringLabel(labels, rdsLabelInstanceAwsBackupRecoveryPointArn, instance.AwsBackupRecoveryPointArn)
+	setIntLabel(labels, rdsLabelInstanceBackupRetentionPeriod, instance.BackupRetentionPeriod)
+	setStringLabel(labels, rdsLabelInstanceBackupTarget, instance.BackupTarget)
+	setStringLabel(labels, rdsLabelInstanceCACertificateIdentifier, instance.CACertificateIdentifier)
+	setStringLabel(labels, rdsLabelInstanceCharacterSetName, instance.CharacterSetName)
+	setBoolLabel(labels, rdsLabelInstanceCopyTagsToSnapshot, instance.CopyTagsToSnapshot)
+	setStringLabel(labels, rdsLabelInstanceCustomIamInstanceProfile, instance.CustomIamInstanceProfile)
+	setBoolLabel(labels, rdsLabelInstanceCustomerOwnedIPEnabled, instance.CustomerOwnedIpEnabled)
+	setStringLabel(labels, rdsLabelInstanceDBClusterIdentifier, instance.DBClusterIdentifier)
+	setStringLabel(labels, rdsLabelInstanceDBInstanceClass, instance.DBInstanceClass)
+	setStringLabel(labels, rdsLabelInstanceDBInstanceStatus, instance.DBInstanceStatus)
+	setStringLabel(labels, rdsLabelInstanceDBName, instance.DBName)
+	setIntLabel(labels, rdsLabelInstanceDBInstancePort, instance.DbInstancePort)
+	setStringLabel(labels, rdsLabelInstanceDBResourceID, instance.DbiResourceId)
+	setBoolLabel(labels, rdsLabelInstanceDedicatedLogVolume, instance.DedicatedLogVolume)
+	setBoolLabel(labels, rdsLabelInstanceDeletionProtection, instance.DeletionProtection)
+	if instance.Endpoint != nil {
+		setStringLabel(labels, rdsLabelInstanceEndpointAddress, instance.Endpoint.Address)
+		setStringLabel(labels, rdsLabelInstanceEndpointHostedZoneID, instance.Endpoint.HostedZoneId)
+		setIntLabel(labels, rdsLabelInstanceEndpointPort, instance.Endpoint.Port)
+	}
+	setStringLabel(labels, rdsLabelInstanceEngine, instance.Engine)
+	setStringLabel(labels, rdsLabelInstanceEngineLifecycleSupport, instance.EngineLifecycleSupport)
+	setStringLabel(labels, rdsLabelInstanceEngineVersion, instance.EngineVersion)
+	setStringLabel(labels, rdsLabelInstanceEnhancedMonitoringResourceArn, instance.EnhancedMonitoringResourceArn)
+	setBoolLabel(labels, rdsLabelInstanceIAMDatabaseAuthenticationEnabled, instance.IAMDatabaseAuthenticationEnabled)
+	setTimeLabel(labels, rdsLabelInstanceInstanceCreateTime, instance.InstanceCreateTime)
+	setIntLabel(labels, rdsLabelInstanceIops, instance.Iops)
+	setBoolLabel(labels, rdsLabelInstanceIsStorageConfigUpgradeAvailable, instance.IsStorageConfigUpgradeAvailable)
+	setStringLabel(labels, rdsLabelInstanceKMSKeyID, instance.KmsKeyId)
+	setTimeLabel(labels, rdsLabelInstanceLatestRestorableTime, instance.LatestRestorableTime)
+	setStringLabel(labels, rdsLabelInstanceLicenseModel, instance.LicenseModel)
+	if instance.ListenerEndpoint != nil {
+		setStringLabel(labels, rdsLabelInstanceListenerEndpointAddress, instance.ListenerEndpoint.Address)
+		setStringLabel(labels, rdsLabelInstanceListenerEndpointHostedZoneID, instance.ListenerEndpoint.HostedZoneId)
+		setIntLabel(labels, rdsLabelInstanceListenerEndpointPort, instance.ListenerEndpoint.Port)
+	}
+	setStringLabel(labels, rdsLabelInstanceMasterUsername, instance.MasterUsername)
+	setIntLabel(labels, rdsLabelInstanceMaxAllocatedStorage, instance.MaxAllocatedStorage)
+	setIntLabel(labels, rdsLabelInstanceMonitoringInterval, instance.MonitoringInterval)
+	setStringLabel(labels, rdsLabelInstanceMonitoringRoleArn, instance.MonitoringRoleArn)
+	setBoolLabel(labels, rdsLabelInstanceMultiAZ, instance.MultiAZ)
+	setBoolLabel(labels, rdsLabelInstanceMultiTenant, instance.MultiTenant)
+	setStringLabel(labels, rdsLabelInstanceNcharCharacterSetName, instance.NcharCharacterSetName)
+	setStringLabel(labels, rdsLabelInstanceNetworkType, instance.NetworkType)
+	setStringLabel(labels, rdsLabelInstancePercentProgress, instance.PercentProgress)
+	setBoolLabel(labels, rdsLabelInstancePerformanceInsightsEnabled, instance.PerformanceInsightsEnabled)
+	setStringLabel(labels, rdsLabelInstancePerformanceInsightsKMSKeyID, instance.PerformanceInsightsKMSKeyId)
+	setIntLabel(labels, rdsLabelInstancePerformanceInsightsRetentionPeriod, instance.PerformanceInsightsRetentionPeriod)
+	setStringLabel(labels, rdsLabelInstancePreferredBackupWindow, instance.PreferredBackupWindow)
+	setStringLabel(labels, rdsLabelInstancePreferredMaintenanceWindow, instance.PreferredMaintenanceWindow)
+	setIntLabel(labels, rdsLabelInstancePromotionTier, instance.PromotionTier)
+	setBoolLabel(labels, rdsLabelInstancePubliclyAccessible, instance.PubliclyAccessible)
+	setStringLabel(labels, rdsLabelInstanceReadReplicaSourceDBClusterIdentifier, instance.ReadReplicaSourceDBClusterIdentifier)
+	setStringLabel(labels, rdsLabelInstanceReadReplicaSourceDBInstanceIdentifier, instance.ReadReplicaSourceDBInstanceIdentifier)
+	setNonEmptyLabel(labels, rdsLabelInstanceReplicaMode, instance.ReplicaMode)
+	setTimeLabel(labels, rdsLabelInstanceResumeFullAutomationModeTime, instance.ResumeFullAutomationModeTime)
+	setStringLabel(labels, rdsLabelInstanceSecondaryAvailabilityZone, instance.SecondaryAvailabilityZone)
+	setBoolLabel(labels, rdsLabelInstanceStorageEncrypted, instance.StorageEncrypted)
+	setNonEmptyLabel(labels, rdsLabelInstanceStorageEncryptionType, instance.StorageEncryptionType)
+	setIntLabel(labels, rdsLabelInstanceStorageThroughput, instance.StorageThroughput)
+	setStringLabel(labels, rdsLabelInstanceStorageType, instance.StorageType)
+	setStringLabel(labels, rdsLabelInstanceStorageVolumeStatus, instance.StorageVolumeStatus)
+	setStringLabel(labels, rdsLabelInstanceTdeCredentialArn, instance.TdeCredentialArn)
+	setStringLabel(labels, rdsLabelInstanceTimezone, instance.Timezone)
+	setNonEmptyLabel(labels, rdsLabelInstanceUpgradeRolloutOrder, instance.UpgradeRolloutOrder)
+	if instance.DBSubnetGroup != nil {
+		setStringLabel(labels, rdsLabelInstanceDBSubnetGroup, instance.DBSubnetGroup.DBSubnetGroupName)
+	}
+	setStringLabel(labels, rdsLabelInstanceDBSystemID, instance.DBSystemId)
+	setNonEmptyLabel(labels, rdsLabelInstanceDatabaseInsightsMode, instance.DatabaseInsightsMode)
+
+	// Instance tags.
+	for _, tag := range instance.TagList {
+		if tag.Key != nil && tag.Value != nil {
+			labels[model.LabelName(rdsLabelInstanceTag+strutil.SanitizeLabelName(*tag.Key))] = model.LabelValue(*tag.Value)
+		}
+	}
+}
+
 func (d *RDSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error) {
 	err := d.initRdsClient(ctx)
 	if err != nil {
@@ -545,480 +745,14 @@ func (d *RDSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 		go func(cluster types.DBCluster, instances []types.DBInstance) {
 			defer wg.Done()
 
-			// Build a map of instance identifiers to their IsClusterWriter status
-			writerMap := make(map[string]bool)
-			for _, member := range cluster.DBClusterMembers {
-				if member.DBInstanceIdentifier != nil && member.IsClusterWriter != nil {
-					writerMap[*member.DBInstanceIdentifier] = *member.IsClusterWriter
-				}
-			}
+			// The cluster labels and the writer status of its members are the
+			// same for every instance of the cluster, so compute them once.
+			clusterLabels := rdsClusterLabels(cluster)
+			writers := rdsClusterWriters(cluster)
 
 			for _, instance := range instances {
-				labels := model.LabelSet{}
-
-				// Cluster labels
-				if cluster.DBClusterArn != nil {
-					labels[rdsLabelClusterDBClusterArn] = model.LabelValue(*cluster.DBClusterArn)
-				}
-				if cluster.DBClusterIdentifier != nil {
-					labels[rdsLabelClusterDBClusterIdentifier] = model.LabelValue(*cluster.DBClusterIdentifier)
-				}
-				if cluster.ActivityStreamKinesisStreamName != nil {
-					labels[rdsLabelClusterActivityStreamKinesisStreamName] = model.LabelValue(*cluster.ActivityStreamKinesisStreamName)
-				}
-				if cluster.ActivityStreamKmsKeyId != nil {
-					labels[rdsLabelClusterActivityStreamKMSKeyID] = model.LabelValue(*cluster.ActivityStreamKmsKeyId)
-				}
-				if cluster.ActivityStreamMode != "" {
-					labels[rdsLabelClusterActivityStreamMode] = model.LabelValue(cluster.ActivityStreamMode)
-				}
-				if cluster.ActivityStreamStatus != "" {
-					labels[rdsLabelClusterActivityStreamStatus] = model.LabelValue(cluster.ActivityStreamStatus)
-				}
-				if cluster.AllocatedStorage != nil {
-					labels[rdsLabelClusterAllocatedStorage] = model.LabelValue(strconv.Itoa(int(*cluster.AllocatedStorage)))
-				}
-				if cluster.AutoMinorVersionUpgrade != nil {
-					labels[rdsLabelClusterAutoMinorVersionUpgrade] = model.LabelValue(strconv.FormatBool(*cluster.AutoMinorVersionUpgrade))
-				}
-				if cluster.AutomaticRestartTime != nil {
-					labels[rdsLabelClusterAutomaticRestartTime] = model.LabelValue(cluster.AutomaticRestartTime.Format(time.RFC3339))
-				}
-				if cluster.AwsBackupRecoveryPointArn != nil {
-					labels[rdsLabelClusterAwsBackupRecoveryPointArn] = model.LabelValue(*cluster.AwsBackupRecoveryPointArn)
-				}
-				if cluster.BacktrackConsumedChangeRecords != nil {
-					labels[rdsLabelClusterBacktrackConsumedChangeRecords] = model.LabelValue(strconv.FormatInt(*cluster.BacktrackConsumedChangeRecords, 10))
-				}
-				if cluster.BacktrackWindow != nil {
-					labels[rdsLabelClusterBacktrackWindow] = model.LabelValue(strconv.FormatInt(*cluster.BacktrackWindow, 10))
-				}
-				if cluster.BackupRetentionPeriod != nil {
-					labels[rdsLabelClusterBackupRetentionPeriod] = model.LabelValue(strconv.Itoa(int(*cluster.BackupRetentionPeriod)))
-				}
-				if cluster.Capacity != nil {
-					labels[rdsLabelClusterCapacity] = model.LabelValue(strconv.Itoa(int(*cluster.Capacity)))
-				}
-				if cluster.CharacterSetName != nil {
-					labels[rdsLabelClusterCharacterSetName] = model.LabelValue(*cluster.CharacterSetName)
-				}
-				if cluster.CloneGroupId != nil {
-					labels[rdsLabelClusterCloneGroupID] = model.LabelValue(*cluster.CloneGroupId)
-				}
-				if cluster.ClusterCreateTime != nil {
-					labels[rdsLabelClusterClusterCreateTime] = model.LabelValue(cluster.ClusterCreateTime.Format(time.RFC3339))
-				}
-				if cluster.ClusterScalabilityType != "" {
-					labels[rdsLabelClusterClusterScalabilityType] = model.LabelValue(cluster.ClusterScalabilityType)
-				}
-				if cluster.CopyTagsToSnapshot != nil {
-					labels[rdsLabelClusterCopyTagsToSnapshot] = model.LabelValue(strconv.FormatBool(*cluster.CopyTagsToSnapshot))
-				}
-				if cluster.CrossAccountClone != nil {
-					labels[rdsLabelClusterCrossAccountClone] = model.LabelValue(strconv.FormatBool(*cluster.CrossAccountClone))
-				}
-				if cluster.DBClusterInstanceClass != nil {
-					labels[rdsLabelClusterDBClusterInstanceClass] = model.LabelValue(*cluster.DBClusterInstanceClass)
-				}
-				if cluster.DBClusterParameterGroup != nil {
-					labels[rdsLabelClusterDBClusterParameterGroup] = model.LabelValue(*cluster.DBClusterParameterGroup)
-				}
-				if cluster.DBSubnetGroup != nil {
-					labels[rdsLabelClusterDBSubnetGroup] = model.LabelValue(*cluster.DBSubnetGroup)
-				}
-				if cluster.DBSystemId != nil {
-					labels[rdsLabelClusterDBSystemID] = model.LabelValue(*cluster.DBSystemId)
-				}
-				if cluster.DatabaseInsightsMode != "" {
-					labels[rdsLabelClusterDatabaseInsightsMode] = model.LabelValue(cluster.DatabaseInsightsMode)
-				}
-				if cluster.DatabaseName != nil {
-					labels[rdsLabelClusterDatabaseName] = model.LabelValue(*cluster.DatabaseName)
-				}
-				if cluster.DbClusterResourceId != nil {
-					labels[rdsLabelClusterDBClusterResourceID] = model.LabelValue(*cluster.DbClusterResourceId)
-				}
-				if cluster.DeletionProtection != nil {
-					labels[rdsLabelClusterDeletionProtection] = model.LabelValue(strconv.FormatBool(*cluster.DeletionProtection))
-				}
-				if cluster.EarliestBacktrackTime != nil {
-					labels[rdsLabelClusterEarliestBacktrackTime] = model.LabelValue(cluster.EarliestBacktrackTime.Format(time.RFC3339))
-				}
-				if cluster.EarliestRestorableTime != nil {
-					labels[rdsLabelClusterEarliestRestorableTime] = model.LabelValue(cluster.EarliestRestorableTime.Format(time.RFC3339))
-				}
-				if cluster.Endpoint != nil {
-					labels[rdsLabelClusterEndpoint] = model.LabelValue(*cluster.Endpoint)
-				}
-				if cluster.Engine != nil {
-					labels[rdsLabelClusterEngine] = model.LabelValue(*cluster.Engine)
-				}
-				if cluster.EngineLifecycleSupport != nil {
-					labels[rdsLabelClusterEngineLifecycleSupport] = model.LabelValue(*cluster.EngineLifecycleSupport)
-				}
-				if cluster.EngineMode != nil {
-					labels[rdsLabelClusterEngineMode] = model.LabelValue(*cluster.EngineMode)
-				}
-				if cluster.EngineVersion != nil {
-					labels[rdsLabelClusterEngineVersion] = model.LabelValue(*cluster.EngineVersion)
-				}
-				if cluster.GlobalClusterIdentifier != nil {
-					labels[rdsLabelClusterGlobalClusterIdentifier] = model.LabelValue(*cluster.GlobalClusterIdentifier)
-				}
-				if cluster.GlobalWriteForwardingRequested != nil {
-					labels[rdsLabelClusterGlobalWriteForwardingRequested] = model.LabelValue(strconv.FormatBool(*cluster.GlobalWriteForwardingRequested))
-				}
-				if cluster.GlobalWriteForwardingStatus != "" {
-					labels[rdsLabelClusterGlobalWriteForwardingStatus] = model.LabelValue(cluster.GlobalWriteForwardingStatus)
-				}
-				if cluster.HostedZoneId != nil {
-					labels[rdsLabelClusterHostedZoneID] = model.LabelValue(*cluster.HostedZoneId)
-				}
-				if cluster.HttpEndpointEnabled != nil {
-					labels[rdsLabelClusterHTTPEndpointEnabled] = model.LabelValue(strconv.FormatBool(*cluster.HttpEndpointEnabled))
-				}
-				if cluster.IAMDatabaseAuthenticationEnabled != nil {
-					labels[rdsLabelClusterIAMDatabaseAuthenticationEnabled] = model.LabelValue(strconv.FormatBool(*cluster.IAMDatabaseAuthenticationEnabled))
-				}
-				if cluster.IOOptimizedNextAllowedModificationTime != nil {
-					labels[rdsLabelClusterIOOptimizedNextAllowedModificationTime] = model.LabelValue(cluster.IOOptimizedNextAllowedModificationTime.Format(time.RFC3339))
-				}
-				if cluster.Iops != nil {
-					labels[rdsLabelClusterIops] = model.LabelValue(strconv.Itoa(int(*cluster.Iops)))
-				}
-				if cluster.KmsKeyId != nil {
-					labels[rdsLabelClusterKMSKeyID] = model.LabelValue(*cluster.KmsKeyId)
-				}
-				if cluster.LatestRestorableTime != nil {
-					labels[rdsLabelClusterLatestRestorableTime] = model.LabelValue(cluster.LatestRestorableTime.Format(time.RFC3339))
-				}
-				if cluster.LocalWriteForwardingStatus != "" {
-					labels[rdsLabelClusterLocalWriteForwardingStatus] = model.LabelValue(cluster.LocalWriteForwardingStatus)
-				}
-				if cluster.MasterUsername != nil {
-					labels[rdsLabelClusterMasterUsername] = model.LabelValue(*cluster.MasterUsername)
-				}
-				if cluster.MonitoringInterval != nil {
-					labels[rdsLabelClusterMonitoringInterval] = model.LabelValue(strconv.Itoa(int(*cluster.MonitoringInterval)))
-				}
-				if cluster.MonitoringRoleArn != nil {
-					labels[rdsLabelClusterMonitoringRoleArn] = model.LabelValue(*cluster.MonitoringRoleArn)
-				}
-				if cluster.MultiAZ != nil {
-					labels[rdsLabelClusterMultiAZ] = model.LabelValue(strconv.FormatBool(*cluster.MultiAZ))
-				}
-				if cluster.NetworkType != nil {
-					labels[rdsLabelClusterNetworkType] = model.LabelValue(*cluster.NetworkType)
-				}
-				if cluster.PercentProgress != nil {
-					labels[rdsLabelClusterPercentProgress] = model.LabelValue(*cluster.PercentProgress)
-				}
-				if cluster.PerformanceInsightsEnabled != nil {
-					labels[rdsLabelClusterPerformanceInsightsEnabled] = model.LabelValue(strconv.FormatBool(*cluster.PerformanceInsightsEnabled))
-				}
-				if cluster.PerformanceInsightsKMSKeyId != nil {
-					labels[rdsLabelClusterPerformanceInsightsKMSKeyID] = model.LabelValue(*cluster.PerformanceInsightsKMSKeyId)
-				}
-				if cluster.PerformanceInsightsRetentionPeriod != nil {
-					labels[rdsLabelClusterPerformanceInsightsRetentionPeriod] = model.LabelValue(strconv.Itoa(int(*cluster.PerformanceInsightsRetentionPeriod)))
-				}
-				if cluster.Port != nil {
-					labels[rdsLabelClusterPort] = model.LabelValue(strconv.Itoa(int(*cluster.Port)))
-				}
-				if cluster.PreferredBackupWindow != nil {
-					labels[rdsLabelClusterPreferredBackupWindow] = model.LabelValue(*cluster.PreferredBackupWindow)
-				}
-				if cluster.PreferredMaintenanceWindow != nil {
-					labels[rdsLabelClusterPreferredMaintenanceWindow] = model.LabelValue(*cluster.PreferredMaintenanceWindow)
-				}
-				if cluster.PubliclyAccessible != nil {
-					labels[rdsLabelClusterPubliclyAccessible] = model.LabelValue(strconv.FormatBool(*cluster.PubliclyAccessible))
-				}
-				if cluster.ReaderEndpoint != nil {
-					labels[rdsLabelClusterReaderEndpoint] = model.LabelValue(*cluster.ReaderEndpoint)
-				}
-				if cluster.ReplicationSourceIdentifier != nil {
-					labels[rdsLabelClusterReplicationSourceIdentifier] = model.LabelValue(*cluster.ReplicationSourceIdentifier)
-				}
-				if cluster.ServerlessV2PlatformVersion != nil {
-					labels[rdsLabelClusterServerlessV2PlatformVersion] = model.LabelValue(*cluster.ServerlessV2PlatformVersion)
-				}
-				if cluster.Status != nil {
-					labels[rdsLabelClusterStatus] = model.LabelValue(*cluster.Status)
-				}
-				if cluster.StorageEncrypted != nil {
-					labels[rdsLabelClusterStorageEncrypted] = model.LabelValue(strconv.FormatBool(*cluster.StorageEncrypted))
-				}
-				if cluster.StorageEncryptionType != "" {
-					labels[rdsLabelClusterStorageEncryptionType] = model.LabelValue(cluster.StorageEncryptionType)
-				}
-				if cluster.StorageThroughput != nil {
-					labels[rdsLabelClusterStorageThroughput] = model.LabelValue(strconv.Itoa(int(*cluster.StorageThroughput)))
-				}
-				if cluster.StorageType != nil {
-					labels[rdsLabelClusterStorageType] = model.LabelValue(*cluster.StorageType)
-				}
-				if cluster.UpgradeRolloutOrder != "" {
-					labels[rdsLabelClusterUpgradeRolloutOrder] = model.LabelValue(cluster.UpgradeRolloutOrder)
-				}
-
-				// Cluster tags
-				for _, tag := range cluster.TagList {
-					if tag.Key != nil && tag.Value != nil {
-						labels[model.LabelName(rdsLabelClusterTag+strutil.SanitizeLabelName(*tag.Key))] = model.LabelValue(*tag.Value)
-					}
-				}
-
-				// Instance labels
-				if instance.DBInstanceArn != nil {
-					labels[rdsLabelInstanceDBInstanceArn] = model.LabelValue(*instance.DBInstanceArn)
-				}
-				if instance.DBInstanceIdentifier != nil {
-					labels[rdsLabelInstanceDBInstanceIdentifier] = model.LabelValue(*instance.DBInstanceIdentifier)
-					// Set IsClusterWriter based on cluster membership information
-					if isWriter, found := writerMap[*instance.DBInstanceIdentifier]; found {
-						labels[rdsLabelInstanceIsClusterWriter] = model.LabelValue(strconv.FormatBool(isWriter))
-					}
-				}
-				if instance.ActivityStreamEngineNativeAuditFieldsIncluded != nil {
-					labels[rdsLabelInstanceActivityStreamEngineNativeAuditFieldsIncluded] = model.LabelValue(strconv.FormatBool(*instance.ActivityStreamEngineNativeAuditFieldsIncluded))
-				}
-				if instance.ActivityStreamKinesisStreamName != nil {
-					labels[rdsLabelInstanceActivityStreamKinesisStreamName] = model.LabelValue(*instance.ActivityStreamKinesisStreamName)
-				}
-				if instance.ActivityStreamKmsKeyId != nil {
-					labels[rdsLabelInstanceActivityStreamKmsKeyID] = model.LabelValue(*instance.ActivityStreamKmsKeyId)
-				}
-				if instance.ActivityStreamMode != "" {
-					labels[rdsLabelInstanceActivityStreamMode] = model.LabelValue(instance.ActivityStreamMode)
-				}
-				if instance.ActivityStreamPolicyStatus != "" {
-					labels[rdsLabelInstanceActivityStreamPolicyStatus] = model.LabelValue(instance.ActivityStreamPolicyStatus)
-				}
-				if instance.ActivityStreamStatus != "" {
-					labels[rdsLabelInstanceActivityStreamStatus] = model.LabelValue(instance.ActivityStreamStatus)
-				}
-				if instance.AllocatedStorage != nil {
-					labels[rdsLabelInstanceAllocatedStorage] = model.LabelValue(strconv.Itoa(int(*instance.AllocatedStorage)))
-				}
-				if instance.AutoMinorVersionUpgrade != nil {
-					labels[rdsLabelInstanceAutoMinorVersionUpgrade] = model.LabelValue(strconv.FormatBool(*instance.AutoMinorVersionUpgrade))
-				}
-				if instance.AutomaticRestartTime != nil {
-					labels[rdsLabelInstanceAutomaticRestartTime] = model.LabelValue(instance.AutomaticRestartTime.Format(time.RFC3339))
-				}
-				if instance.AutomationMode != "" {
-					labels[rdsLabelInstanceAutomationMode] = model.LabelValue(instance.AutomationMode)
-				}
-				if instance.AvailabilityZone != nil {
-					labels[rdsLabelInstanceAvailabilityZone] = model.LabelValue(*instance.AvailabilityZone)
-				}
-				if instance.AwsBackupRecoveryPointArn != nil {
-					labels[rdsLabelInstanceAwsBackupRecoveryPointArn] = model.LabelValue(*instance.AwsBackupRecoveryPointArn)
-				}
-				if instance.BackupRetentionPeriod != nil {
-					labels[rdsLabelInstanceBackupRetentionPeriod] = model.LabelValue(strconv.Itoa(int(*instance.BackupRetentionPeriod)))
-				}
-				if instance.BackupTarget != nil {
-					labels[rdsLabelInstanceBackupTarget] = model.LabelValue(*instance.BackupTarget)
-				}
-				if instance.CACertificateIdentifier != nil {
-					labels[rdsLabelInstanceCACertificateIdentifier] = model.LabelValue(*instance.CACertificateIdentifier)
-				}
-				if instance.CharacterSetName != nil {
-					labels[rdsLabelInstanceCharacterSetName] = model.LabelValue(*instance.CharacterSetName)
-				}
-				if instance.CopyTagsToSnapshot != nil {
-					labels[rdsLabelInstanceCopyTagsToSnapshot] = model.LabelValue(strconv.FormatBool(*instance.CopyTagsToSnapshot))
-				}
-				if instance.CustomIamInstanceProfile != nil {
-					labels[rdsLabelInstanceCustomIamInstanceProfile] = model.LabelValue(*instance.CustomIamInstanceProfile)
-				}
-				if instance.CustomerOwnedIpEnabled != nil {
-					labels[rdsLabelInstanceCustomerOwnedIPEnabled] = model.LabelValue(strconv.FormatBool(*instance.CustomerOwnedIpEnabled))
-				}
-				if instance.DBClusterIdentifier != nil {
-					labels[rdsLabelInstanceDBClusterIdentifier] = model.LabelValue(*instance.DBClusterIdentifier)
-				}
-				if instance.DBInstanceClass != nil {
-					labels[rdsLabelInstanceDBInstanceClass] = model.LabelValue(*instance.DBInstanceClass)
-				}
-				if instance.DBInstanceStatus != nil {
-					labels[rdsLabelInstanceDBInstanceStatus] = model.LabelValue(*instance.DBInstanceStatus)
-				}
-				if instance.DBName != nil {
-					labels[rdsLabelInstanceDBName] = model.LabelValue(*instance.DBName)
-				}
-				if instance.DbInstancePort != nil {
-					labels[rdsLabelInstanceDBInstancePort] = model.LabelValue(strconv.Itoa(int(*instance.DbInstancePort)))
-				}
-				if instance.DbiResourceId != nil {
-					labels[rdsLabelInstanceDBResourceID] = model.LabelValue(*instance.DbiResourceId)
-				}
-				if instance.DedicatedLogVolume != nil {
-					labels[rdsLabelInstanceDedicatedLogVolume] = model.LabelValue(strconv.FormatBool(*instance.DedicatedLogVolume))
-				}
-				if instance.DeletionProtection != nil {
-					labels[rdsLabelInstanceDeletionProtection] = model.LabelValue(strconv.FormatBool(*instance.DeletionProtection))
-				}
-				if instance.Endpoint != nil {
-					if instance.Endpoint.Address != nil {
-						labels[rdsLabelInstanceEndpointAddress] = model.LabelValue(*instance.Endpoint.Address)
-					}
-					if instance.Endpoint.HostedZoneId != nil {
-						labels[rdsLabelInstanceEndpointHostedZoneID] = model.LabelValue(*instance.Endpoint.HostedZoneId)
-					}
-					if instance.Endpoint.Port != nil {
-						labels[rdsLabelInstanceEndpointPort] = model.LabelValue(strconv.Itoa(int(*instance.Endpoint.Port)))
-					}
-				}
-				if instance.Engine != nil {
-					labels[rdsLabelInstanceEngine] = model.LabelValue(*instance.Engine)
-				}
-				if instance.EngineLifecycleSupport != nil {
-					labels[rdsLabelInstanceEngineLifecycleSupport] = model.LabelValue(*instance.EngineLifecycleSupport)
-				}
-				if instance.EngineVersion != nil {
-					labels[rdsLabelInstanceEngineVersion] = model.LabelValue(*instance.EngineVersion)
-				}
-				if instance.EnhancedMonitoringResourceArn != nil {
-					labels[rdsLabelInstanceEnhancedMonitoringResourceArn] = model.LabelValue(*instance.EnhancedMonitoringResourceArn)
-				}
-				if instance.IAMDatabaseAuthenticationEnabled != nil {
-					labels[rdsLabelInstanceIAMDatabaseAuthenticationEnabled] = model.LabelValue(strconv.FormatBool(*instance.IAMDatabaseAuthenticationEnabled))
-				}
-				if instance.InstanceCreateTime != nil {
-					labels[rdsLabelInstanceInstanceCreateTime] = model.LabelValue(instance.InstanceCreateTime.Format(time.RFC3339))
-				}
-				if instance.Iops != nil {
-					labels[rdsLabelInstanceIops] = model.LabelValue(strconv.Itoa(int(*instance.Iops)))
-				}
-				if instance.IsStorageConfigUpgradeAvailable != nil {
-					labels[rdsLabelInstanceIsStorageConfigUpgradeAvailable] = model.LabelValue(strconv.FormatBool(*instance.IsStorageConfigUpgradeAvailable))
-				}
-				if instance.KmsKeyId != nil {
-					labels[rdsLabelInstanceKMSKeyID] = model.LabelValue(*instance.KmsKeyId)
-				}
-				if instance.LatestRestorableTime != nil {
-					labels[rdsLabelInstanceLatestRestorableTime] = model.LabelValue(instance.LatestRestorableTime.Format(time.RFC3339))
-				}
-				if instance.LicenseModel != nil {
-					labels[rdsLabelInstanceLicenseModel] = model.LabelValue(*instance.LicenseModel)
-				}
-				if instance.ListenerEndpoint != nil {
-					if instance.ListenerEndpoint.Address != nil {
-						labels[rdsLabelInstanceListenerEndpointAddress] = model.LabelValue(*instance.ListenerEndpoint.Address)
-					}
-					if instance.ListenerEndpoint.HostedZoneId != nil {
-						labels[rdsLabelInstanceListenerEndpointHostedZoneID] = model.LabelValue(*instance.ListenerEndpoint.HostedZoneId)
-					}
-					if instance.ListenerEndpoint.Port != nil {
-						labels[rdsLabelInstanceListenerEndpointPort] = model.LabelValue(strconv.Itoa(int(*instance.ListenerEndpoint.Port)))
-					}
-				}
-				if instance.MasterUsername != nil {
-					labels[rdsLabelInstanceMasterUsername] = model.LabelValue(*instance.MasterUsername)
-				}
-				if instance.MaxAllocatedStorage != nil {
-					labels[rdsLabelInstanceMaxAllocatedStorage] = model.LabelValue(strconv.Itoa(int(*instance.MaxAllocatedStorage)))
-				}
-				if instance.MonitoringInterval != nil {
-					labels[rdsLabelInstanceMonitoringInterval] = model.LabelValue(strconv.Itoa(int(*instance.MonitoringInterval)))
-				}
-				if instance.MonitoringRoleArn != nil {
-					labels[rdsLabelInstanceMonitoringRoleArn] = model.LabelValue(*instance.MonitoringRoleArn)
-				}
-				if instance.MultiAZ != nil {
-					labels[rdsLabelInstanceMultiAZ] = model.LabelValue(strconv.FormatBool(*instance.MultiAZ))
-				}
-				if instance.MultiTenant != nil {
-					labels[rdsLabelInstanceMultiTenant] = model.LabelValue(strconv.FormatBool(*instance.MultiTenant))
-				}
-				if instance.NcharCharacterSetName != nil {
-					labels[rdsLabelInstanceNcharCharacterSetName] = model.LabelValue(*instance.NcharCharacterSetName)
-				}
-				if instance.NetworkType != nil {
-					labels[rdsLabelInstanceNetworkType] = model.LabelValue(*instance.NetworkType)
-				}
-				if instance.PercentProgress != nil {
-					labels[rdsLabelInstancePercentProgress] = model.LabelValue(*instance.PercentProgress)
-				}
-				if instance.PerformanceInsightsEnabled != nil {
-					labels[rdsLabelInstancePerformanceInsightsEnabled] = model.LabelValue(strconv.FormatBool(*instance.PerformanceInsightsEnabled))
-				}
-				if instance.PerformanceInsightsKMSKeyId != nil {
-					labels[rdsLabelInstancePerformanceInsightsKMSKeyID] = model.LabelValue(*instance.PerformanceInsightsKMSKeyId)
-				}
-				if instance.PerformanceInsightsRetentionPeriod != nil {
-					labels[rdsLabelInstancePerformanceInsightsRetentionPeriod] = model.LabelValue(strconv.Itoa(int(*instance.PerformanceInsightsRetentionPeriod)))
-				}
-				if instance.PreferredBackupWindow != nil {
-					labels[rdsLabelInstancePreferredBackupWindow] = model.LabelValue(*instance.PreferredBackupWindow)
-				}
-				if instance.PreferredMaintenanceWindow != nil {
-					labels[rdsLabelInstancePreferredMaintenanceWindow] = model.LabelValue(*instance.PreferredMaintenanceWindow)
-				}
-				if instance.PromotionTier != nil {
-					labels[rdsLabelInstancePromotionTier] = model.LabelValue(strconv.Itoa(int(*instance.PromotionTier)))
-				}
-				if instance.PubliclyAccessible != nil {
-					labels[rdsLabelInstancePubliclyAccessible] = model.LabelValue(strconv.FormatBool(*instance.PubliclyAccessible))
-				}
-				if instance.ReadReplicaSourceDBClusterIdentifier != nil {
-					labels[rdsLabelInstanceReadReplicaSourceDBClusterIdentifier] = model.LabelValue(*instance.ReadReplicaSourceDBClusterIdentifier)
-				}
-				if instance.ReadReplicaSourceDBInstanceIdentifier != nil {
-					labels[rdsLabelInstanceReadReplicaSourceDBInstanceIdentifier] = model.LabelValue(*instance.ReadReplicaSourceDBInstanceIdentifier)
-				}
-				if instance.ReplicaMode != "" {
-					labels[rdsLabelInstanceReplicaMode] = model.LabelValue(instance.ReplicaMode)
-				}
-				if instance.ResumeFullAutomationModeTime != nil {
-					labels[rdsLabelInstanceResumeFullAutomationModeTime] = model.LabelValue(instance.ResumeFullAutomationModeTime.Format(time.RFC3339))
-				}
-				if instance.SecondaryAvailabilityZone != nil {
-					labels[rdsLabelInstanceSecondaryAvailabilityZone] = model.LabelValue(*instance.SecondaryAvailabilityZone)
-				}
-				if instance.StorageEncrypted != nil {
-					labels[rdsLabelInstanceStorageEncrypted] = model.LabelValue(strconv.FormatBool(*instance.StorageEncrypted))
-				}
-				if instance.StorageEncryptionType != "" {
-					labels[rdsLabelInstanceStorageEncryptionType] = model.LabelValue(instance.StorageEncryptionType)
-				}
-				if instance.StorageThroughput != nil {
-					labels[rdsLabelInstanceStorageThroughput] = model.LabelValue(strconv.Itoa(int(*instance.StorageThroughput)))
-				}
-				if instance.StorageType != nil {
-					labels[rdsLabelInstanceStorageType] = model.LabelValue(*instance.StorageType)
-				}
-				if instance.StorageVolumeStatus != nil {
-					labels[rdsLabelInstanceStorageVolumeStatus] = model.LabelValue(*instance.StorageVolumeStatus)
-				}
-				if instance.TdeCredentialArn != nil {
-					labels[rdsLabelInstanceTdeCredentialArn] = model.LabelValue(*instance.TdeCredentialArn)
-				}
-				if instance.Timezone != nil {
-					labels[rdsLabelInstanceTimezone] = model.LabelValue(*instance.Timezone)
-				}
-				if instance.UpgradeRolloutOrder != "" {
-					labels[rdsLabelInstanceUpgradeRolloutOrder] = model.LabelValue(instance.UpgradeRolloutOrder)
-				}
-				if instance.DBSubnetGroup != nil && instance.DBSubnetGroup.DBSubnetGroupName != nil {
-					labels[rdsLabelInstanceDBSubnetGroup] = model.LabelValue(*instance.DBSubnetGroup.DBSubnetGroupName)
-				}
-				if instance.DBSystemId != nil {
-					labels[rdsLabelInstanceDBSystemID] = model.LabelValue(*instance.DBSystemId)
-				}
-				if instance.DatabaseInsightsMode != "" {
-					labels[rdsLabelInstanceDatabaseInsightsMode] = model.LabelValue(instance.DatabaseInsightsMode)
-				}
-
-				// Instance tags
-				for _, tag := range instance.TagList {
-					if tag.Key != nil && tag.Value != nil {
-						labels[model.LabelName(rdsLabelInstanceTag+strutil.SanitizeLabelName(*tag.Key))] = model.LabelValue(*tag.Value)
-					}
-				}
+				labels := clusterLabels.Clone()
+				addRDSInstanceLabels(labels, instance, writers)
 
 				// Set the address label
 				if instance.Endpoint != nil && instance.Endpoint.Address != nil && instance.Endpoint.Port != nil {


### PR DESCRIPTION
Refactor only, no functional change.

`RDSDiscovery.refresh()` built the complete meta label set for every discovered
DB instance inline, which made it a 528 line function with a cyclomatic
complexity of 170, as reported in #19261.

The label constants and the label building move to a new `rds_labels.go`:

- `rdsClusterWriters()` maps the cluster members to their `IsClusterWriter`
  status.
- `rdsClusterLabels()` returns the labels of a DB cluster. `refresh()` now
  computes them once per cluster and clones them per instance, instead of
  rebuilding the same set for every cluster member.
- `addRDSInstanceLabels()` adds the labels of a DB instance.
- `setStringLabel`, `setEnumLabel`, `setBoolLabel`, `setIntLabel` and
  `setTimeLabel` replace the repeated nil and empty string checks.

`refresh()` is left with the discovery flow only.

The emitted label set is unchanged. The replaced `strconv.Itoa(int(*v))`
conversions were all on `int32` fields, so no narrowing was possible on any
platform, and the `int64` fields already used `strconv.FormatInt`.

`TestRDSDiscoveryRefresh` no longer reimplements a subset of the label logic and
now exercises the same helpers as the production code. `TestRDSSetLabelHelpers`
covers the setters, including nil, empty and boundary values.

Fixes #19261

```release-notes
NONE
```


**open for feedback :)**