### PR TITLE
promql: handle negative and zero to_nearest in round()

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1163,6 +1163,15 @@ func funcRound(vectorVals []Vector, _ Matrix, args parser.Expressions, enh *Eval
 	if len(args) >= 2 {
 		toNearest = vectorVals[1][0].F
 	}
+	// A negative to_nearest should not change the result: the set of multiples
+	// of -N is the same as the set of multiples of N. Taking the absolute value
+	// avoids math.Floor flipping its rounding direction for negative inputs.
+	// A zero to_nearest is undefined; returning the input unchanged is the least
+	// surprising behaviour (and avoids producing NaN via 1/0).
+	toNearest = math.Abs(toNearest)
+	if toNearest == 0 {
+		return vectorVals[0], nil
+	}
 	// Invert as it seems to cause fewer floating point accuracy issues.
 	toNearestInverse := 1.0 / toNearest
 	return simpleFloatFunc(vectorVals, enh, func(f float64) float64 {

--- a/promql/functions_test.go
+++ b/promql/functions_test.go
@@ -148,3 +148,46 @@ func TestStartTimestampOutputWhenUseStartTimestampIsDisabled(t *testing.T) {
 		})
 	}
 }
+
+func TestRound(t *testing.T) {
+	// Reproduces the bugs reported in https://github.com/prometheus/prometheus/issues/19198:
+	//   1. round(v, 0) used to return NaN for all samples (division by zero).
+	//   2. round(v, -N) used to produce wrong results because the negative
+	//      inverse flipped math.Floor's rounding direction.
+	tests := []struct {
+		expr     string
+		expected float64
+	}{
+		{expr: "round(foo)", expected: 6},         // default to_nearest=1, 5.5 rounds up
+		{expr: "round(foo, 2)", expected: 6},      // 5.5 rounded to nearest multiple of 2
+		{expr: "round(foo, -2)", expected: 6},     // negative to_nearest must match positive
+		{expr: "round(foo, 0)", expected: 5.5},    // zero to_nearest returns input unchanged
+		{expr: "round(neg_foo, 2)", expected: -4}, // -3.7 rounded to nearest multiple of 2
+		{expr: "round(neg_foo, -2)", expected: -4},
+	}
+	storage := teststorage.New(t)
+	a := storage.Appender(context.Background())
+	metric := labels.FromStrings("__name__", "foo")
+	negMetric := labels.FromStrings("__name__", "neg_foo")
+	a.Append(0, metric, 0, 5.5)
+	a.Append(0, negMetric, 0, -3.7)
+	require.NoError(t, a.Commit())
+
+	engine := promqltest.NewTestEngineWithOpts(t, promql.EngineOpts{
+		MaxSamples: 10000,
+		Timeout:    10 * time.Second,
+	})
+	ctx := context.Background()
+
+	for _, tc := range tests {
+		t.Run(tc.expr, func(t *testing.T) {
+			query, err := engine.NewInstantQuery(ctx, storage, nil, tc.expr, timestamp.Time(0))
+			require.NoError(t, err)
+			result := query.Exec(ctx)
+			require.NoError(t, result.Err)
+			vec, _ := result.Vector()
+			require.Len(t, vec, 1)
+			require.Equal(t, tc.expected, vec[0].F, "query: %s", tc.expr)
+		})
+	}
+}


### PR DESCRIPTION
round(v, 0) returned NaN for every sample because the 1/toNearest inverse became +Inf, and round(v, -N) returned wrong values because the negative inverse flipped math.Floor's rounding direction (e.g. round(5, -2) gave 4 instead of 6). The set of multiples of -N is identical to that of N, so the sign should not matter.

This takes the absolute value of toNearest before computing the inverse, which makes negative inputs behave like their positive counterparts. When toNearest is zero the operation is undefined, so the input is returned unchanged rather than producing NaN. Added a TestRound case covering the default, positive, negative, and zero to_nearest values.

Fixes #19198

```release-notes
[BUGFIX] PromQL: `round()` now returns correct results for a negative `to_nearest` argument and returns the input unchanged for `to_nearest = 0` instead of `NaN`.
```
