### PR TITLE
scrape: stop scrape pools in parallel

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -323,9 +324,19 @@ func (m *Manager) Stop() {
 	m.mtxScrape.Lock()
 	defer m.mtxScrape.Unlock()
 
+	// Stop pools in parallel as each stop() blocks until all its scrape
+	// loops have exited, which can take a long time if there'a a lot of
+	// pools with high number of targets.
+	// Limit the number of pools stopping at once to avoid unbounded goroutines.
+	g := new(errgroup.Group)
+	g.SetLimit(runtime.GOMAXPROCS(0))
 	for _, sp := range m.scrapePools {
-		sp.stop()
+		g.Go(func() error {
+			sp.stop()
+			return nil
+		})
 	}
+	_ = g.Wait()
 	close(m.graceShut)
 }
 


### PR DESCRIPTION
Some big instances we run take 10+ minutes to stop, which seems to be down to the fact that manager loops over scrape pools and stops them one at a time. Since that requires waiting for in-flight scrapes to finish it can take a while if there's a lot of scrape pools, especially ones where scrapes take a while to complete. Stop all pools in parallel to speed shutdown.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[ENHANCEMENT] scrape: stop all pools in parallel for faster shutdowns
```
