### PR TITLE
tsdb: add metric for duplicate samples dropped at commit time

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -427,6 +427,7 @@ type headMetrics struct {
 	chunksRemoved             prometheus.Counter
 	gcDuration                prometheus.Summary
 	samplesAppended           *prometheus.CounterVec
+	duplicateSamplesDropped   *prometheus.CounterVec
 	outOfOrderSamplesAppended *prometheus.CounterVec
 	outOfBoundSamples         *prometheus.CounterVec
 	outOfOrderSamples         *prometheus.CounterVec
@@ -527,6 +528,10 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			Name: "prometheus_tsdb_head_samples_appended_total",
 			Help: "Total number of appended samples.",
 		}, []string{"type"}),
+		duplicateSamplesDropped: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "prometheus_tsdb_head_duplicate_samples_dropped_total",
+			Help: "Total number of samples dropped without being appended because a sample with the same timestamp (and, for in-order samples, the same value) was already appended to the same series.",
+		}, []string{"type"}),
 		outOfOrderSamplesAppended: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "prometheus_tsdb_head_out_of_order_samples_appended_total",
 			Help: "Total number of appended out of order samples.",
@@ -623,6 +628,7 @@ func newHeadMetrics(h *Head, r prometheus.Registerer) *headMetrics {
 			m.walCorruptionsTotal,
 			m.dataTotalReplayDuration,
 			m.samplesAppended,
+			m.duplicateSamplesDropped,
 			m.outOfOrderSamplesAppended,
 			m.outOfBoundSamples,
 			m.outOfOrderSamples,

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -1168,6 +1168,10 @@ type appenderCommitContext struct {
 	// Number of samples out of order but accepted: with ooo enabled and within time window.
 	oooFloatsAccepted    int
 	oooHistogramAccepted int
+	// Number of samples dropped without being appended because they were exact
+	// duplicates (same timestamp and value) of an already appended sample.
+	floatDuplicatesDropped int
+	histoDuplicatesDropped int
 	// Number of samples rejected due to: out of order but OOO support disabled.
 	floatOOORejected int
 	histoOOORejected int
@@ -1441,6 +1445,7 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 				// not with samples in already flushed OOO chunks.
 				// TODO(codesome): Add error reporting? It depends on addressing https://github.com/prometheus/prometheus/discussions/10305.
 				acc.floatsAppended--
+				acc.floatDuplicatesDropped++
 			}
 		default:
 			wasStale, wasHistogram, oldBuckets := series.sampleState()
@@ -1458,8 +1463,9 @@ func (a *headAppenderBase) commitFloats(b *appendBatch, acc *appenderCommitConte
 					a.head.updateNativeHistogramMetricsOnAppend(true, false, oldBuckets, 0)
 				}
 			} else {
-				// The sample is an exact duplicate, and should be silently dropped.
+				// The sample is an exact duplicate of the latest in-order sample, and is dropped.
 				acc.floatsAppended--
+				acc.floatDuplicatesDropped++
 			}
 		}
 
@@ -1544,6 +1550,7 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 				// not with samples in already flushed OOO chunks.
 				// TODO(codesome): Add error reporting? It depends on addressing https://github.com/prometheus/prometheus/discussions/10305.
 				acc.histogramsAppended--
+				acc.histoDuplicatesDropped++
 			}
 		default:
 			wasStale, wasHistogram, oldBuckets := series.sampleState()
@@ -1560,8 +1567,9 @@ func (a *headAppenderBase) commitHistograms(b *appendBatch, acc *appenderCommitC
 				a.head.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			} else {
+				// The sample is an exact duplicate of the latest in-order sample, and is dropped.
 				acc.histogramsAppended--
-				acc.histoOOORejected++
+				acc.histoDuplicatesDropped++
 			}
 		}
 
@@ -1646,6 +1654,7 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 				// not with samples in already flushed OOO chunks.
 				// TODO(codesome): Add error reporting? It depends on addressing https://github.com/prometheus/prometheus/discussions/10305.
 				acc.histogramsAppended--
+				acc.histoDuplicatesDropped++
 			}
 		default:
 			wasStale, wasHistogram, oldBuckets := series.sampleState()
@@ -1662,8 +1671,9 @@ func (a *headAppenderBase) commitFloatHistograms(b *appendBatch, acc *appenderCo
 				a.head.updateStaleSeriesMetricOnAppend(wasStale, isStale)
 				a.head.updateNativeHistogramMetricsOnAppend(wasHistogram, true, oldBuckets, newBuckets)
 			} else {
+				// The sample is an exact duplicate of the latest in-order sample, and is dropped.
 				acc.histogramsAppended--
-				acc.histoOOORejected++
+				acc.histoDuplicatesDropped++
 			}
 		}
 
@@ -1779,6 +1789,8 @@ func (a *headAppenderBase) Commit() (err error) {
 	h.metrics.tooOldSamples.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatTooOldRejected))
 	h.metrics.samplesAppended.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatsAppended))
 	h.metrics.samplesAppended.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histogramsAppended))
+	h.metrics.duplicateSamplesDropped.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.floatDuplicatesDropped))
+	h.metrics.duplicateSamplesDropped.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.histoDuplicatesDropped))
 	h.metrics.outOfOrderSamplesAppended.WithLabelValues(sampleMetricTypeFloat).Add(float64(acc.oooFloatsAccepted))
 	h.metrics.outOfOrderSamplesAppended.WithLabelValues(sampleMetricTypeHistogram).Add(float64(acc.oooHistogramAccepted))
 	h.updateMinMaxTime(acc.inOrderMint, acc.inOrderMaxt)

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -10436,3 +10436,71 @@ func TestHead_mmapHeadChunks(t *testing.T) {
 		requireCounterConsistent("final state")
 	})
 }
+
+func TestHeadAppender_DuplicateSamplesDroppedMetric(t *testing.T) {
+	ctx := context.Background()
+	lbls := labels.FromStrings("foo", "bar")
+
+	for name, scenario := range sampleTypeScenarios {
+		t.Run(name, func(t *testing.T) {
+			head, _ := newTestHead(t, DefaultBlockDuration, compression.None, true)
+
+			dupsDropped := func() float64 {
+				return prom_testutil.ToFloat64(head.metrics.duplicateSamplesDropped.WithLabelValues(scenario.sampleType))
+			}
+
+			app := head.Appender(ctx)
+			_, _, err := scenario.appendFunc(app, lbls, 60_000, 1)
+			require.NoError(t, err)
+			_, _, err = scenario.appendFunc(app, lbls, 120_000, 2)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+
+			// An exact duplicate of the latest in-order sample is accepted by
+			// Append but dropped at commit time and counted in the metric.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 120_000, 2)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 1.0, dupsDropped())
+
+			// The same timestamp with a different value stays an error for
+			// in-order samples and is not counted as a dropped duplicate.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 120_000, 3)
+			require.ErrorIs(t, err, storage.ErrDuplicateSampleForTimestamp)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 1.0, dupsDropped())
+			// The in-order duplicate must not be counted as an out-of-order
+			// rejection.
+			require.Equal(t, 0.0, prom_testutil.ToFloat64(head.metrics.outOfOrderSamples.WithLabelValues(scenario.sampleType)))
+
+			// The first out-of-order sample is accepted, not counted.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 30_000, 4)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 1.0, dupsDropped())
+
+			// An exact duplicate of the out-of-order sample is dropped and
+			// counted.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 30_000, 4)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 2.0, dupsDropped())
+
+			// A sample duplicating the timestamp of a sample in the OOO head
+			// chunk is dropped and counted even when its value differs.
+			app = head.Appender(ctx)
+			_, _, err = scenario.appendFunc(app, lbls, 30_000, 5)
+			require.NoError(t, err)
+			require.NoError(t, app.Commit())
+			require.Equal(t, 3.0, dupsDropped())
+
+			// The dropped duplicates must not have inflated the appended
+			// samples count: 60000, 120000 in-order plus 30000 out-of-order.
+			require.Equal(t, 3.0, prom_testutil.ToFloat64(head.metrics.samplesAppended.WithLabelValues(scenario.sampleType)))
+		})
+	}
+}


### PR DESCRIPTION
The head appender silently drops samples that duplicate already appended samples (both in-order and out-of-order). Remote-write senders that repeat writes observe their samples successfully written while they are actually discarded, with no metric to explain the discrepancy. This PR adds `prometheus_tsdb_head_duplicate_samples_dropped_total` (labeled by sample `type`, like `prometheus_tsdb_head_samples_appended_total`), incremented at commit time.

Associated Mimir issue: grafana/mimir#15552.

```release-notes
[FEATURE] TSDB: Add `prometheus_tsdb_head_duplicate_samples_dropped_total` metric counting samples silently dropped at commit time because they duplicate already appended samples.
[CHANGE] TSDB: In-order histogram samples dropped as exact duplicates are no longer counted in `prometheus_tsdb_out_of_order_samples_total`; they are counted in the new `prometheus_tsdb_head_duplicate_samples_dropped_total`.
```