### PR TITLE
feat(discovery/kubernetes): add gateway and httproute roles for Gateway API

### DIFF
--- a/discovery/kubernetes/gateway.go
+++ b/discovery/kubernetes/gateway.go
@@ -1,0 +1,225 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+// Gateway implements discovery of Gateway API Gateways.
+type Gateway struct {
+	logger                *slog.Logger
+	informer              cache.SharedIndexInformer
+	store                 cache.Store
+	queue                 *workqueue.Typed[string]
+	namespaceInf          cache.SharedInformer
+	withNamespaceMetadata bool
+}
+
+// NewGateway returns a new Gateway discovery.
+func NewGateway(l *slog.Logger, inf cache.SharedIndexInformer, namespace cache.SharedInformer, eventCount *prometheus.CounterVec) *Gateway {
+	gatewayAddCount := eventCount.WithLabelValues(RoleGateway.String(), MetricLabelRoleAdd)
+	gatewayUpdateCount := eventCount.WithLabelValues(RoleGateway.String(), MetricLabelRoleUpdate)
+	gatewayDeleteCount := eventCount.WithLabelValues(RoleGateway.String(), MetricLabelRoleDelete)
+
+	s := &Gateway{
+		logger:   l,
+		informer: inf,
+		store:    inf.GetStore(),
+		queue: workqueue.NewTypedWithConfig(workqueue.TypedQueueConfig[string]{
+			Name: RoleGateway.String(),
+		}),
+		namespaceInf:          namespace,
+		withNamespaceMetadata: namespace != nil,
+	}
+
+	_, err := s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(o any) {
+			gatewayAddCount.Inc()
+			s.enqueue(o)
+		},
+		DeleteFunc: func(o any) {
+			gatewayDeleteCount.Inc()
+			s.enqueue(o)
+		},
+		UpdateFunc: func(_, o any) {
+			gatewayUpdateCount.Inc()
+			s.enqueue(o)
+		},
+	})
+	if err != nil {
+		l.Error("Error adding gateways event handler.", "err", err)
+	}
+
+	if s.withNamespaceMetadata {
+		_, err = s.namespaceInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(_, o any) {
+				namespace := o.(*apiv1.Namespace)
+				s.enqueueNamespace(namespace.Name)
+			},
+			// Creation and deletion will trigger events for the change handlers of the resources within the namespace.
+			// No need to have additional handlers for them here.
+		})
+		if err != nil {
+			l.Error("Error adding namespaces event handler.", "err", err)
+		}
+	}
+
+	return s
+}
+
+func (g *Gateway) enqueue(obj any) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	g.queue.Add(key)
+}
+
+func (g *Gateway) enqueueNamespace(namespace string) {
+	gateways, err := g.informer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
+	if err != nil {
+		g.logger.Error("Error getting gateways in namespace", "namespace", namespace, "err", err)
+		return
+	}
+
+	for _, gtw := range gateways {
+		g.enqueue(gtw)
+	}
+}
+
+// Run implements the Discoverer interface.
+func (g *Gateway) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+	defer g.queue.ShutDown()
+
+	cacheSyncs := []cache.InformerSynced{g.informer.HasSynced}
+	if g.withNamespaceMetadata {
+		cacheSyncs = append(cacheSyncs, g.namespaceInf.HasSynced)
+	}
+
+	if !cache.WaitForCacheSync(ctx.Done(), cacheSyncs...) {
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			g.logger.Error("gateway informer unable to sync cache")
+		}
+		return
+	}
+
+	go func() {
+		for g.process(ctx, ch) {
+		}
+	}()
+
+	// Block until the target provider is explicitly canceled.
+	<-ctx.Done()
+}
+
+func (g *Gateway) process(ctx context.Context, ch chan<- []*targetgroup.Group) bool {
+	key, quit := g.queue.Get()
+	if quit {
+		return false
+	}
+	defer g.queue.Done(key)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return true
+	}
+
+	o, exists, err := g.store.GetByKey(key)
+	if err != nil {
+		return true
+	}
+	if !exists {
+		send(ctx, ch, &targetgroup.Group{Source: gatewaySourceFromNamespaceAndName(namespace, name)})
+		return true
+	}
+
+	gtw, ok := o.(*gatewayv1.Gateway)
+	if !ok {
+		g.logger.Error("converting to Gateway object failed", "err",
+			fmt.Errorf("received unexpected object: %v", o))
+		return true
+	}
+	send(ctx, ch, g.buildGateway(*gtw))
+	return true
+}
+
+func gatewaySource(s gatewayv1.Gateway) string {
+	return gatewaySourceFromNamespaceAndName(s.Namespace, s.Name)
+}
+
+func gatewaySourceFromNamespaceAndName(namespace, name string) string {
+	return "gateway/" + namespace + "/" + name
+}
+
+const (
+	gatewayClassNameLabel        = metaLabelPrefix + "gateway_class_name"
+	gatewayListenerNameLabel     = metaLabelPrefix + "gateway_listener_name"
+	gatewayListenerHostnameLabel = metaLabelPrefix + "gateway_listener_hostname"
+	gatewayListenerPortLabel     = metaLabelPrefix + "gateway_listener_port"
+	gatewayListenerProtocolLabel = metaLabelPrefix + "gateway_listener_protocol"
+)
+
+func gatewayLabels(gtw gatewayv1.Gateway) model.LabelSet {
+	ls := make(model.LabelSet)
+	ls[namespaceLabel] = lv(gtw.Namespace)
+	ls[gatewayClassNameLabel] = lv(string(gtw.Spec.GatewayClassName))
+
+	addObjectMetaLabels(ls, gtw.ObjectMeta, RoleGateway)
+
+	return ls
+}
+
+func (g *Gateway) buildGateway(gtw gatewayv1.Gateway) *targetgroup.Group {
+	tg := &targetgroup.Group{
+		Source: gatewaySource(gtw),
+	}
+	tg.Labels = gatewayLabels(gtw)
+
+	if g.withNamespaceMetadata {
+		tg.Labels = addNamespaceLabels(tg.Labels, g.namespaceInf, g.logger, gtw.Namespace)
+	}
+
+	for _, listener := range gtw.Spec.Listeners {
+		hostname := ""
+		if listener.Hostname != nil {
+			hostname = string(*listener.Hostname)
+		}
+
+		port := strconv.Itoa(int(listener.Port))
+		tg.Targets = append(tg.Targets, model.LabelSet{
+			model.AddressLabel:           lv(hostname + ":" + port),
+			gatewayListenerNameLabel:     lv(string(listener.Name)),
+			gatewayListenerHostnameLabel: lv(hostname),
+			gatewayListenerPortLabel:     lv(port),
+			gatewayListenerProtocolLabel: lv(string(listener.Protocol)),
+		})
+	}
+
+	return tg
+}

--- a/discovery/kubernetes/gateway_test.go
+++ b/discovery/kubernetes/gateway_test.go
@@ -1,0 +1,196 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"maps"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapi "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
+
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+// makeGatewayDiscovery creates a kubernetes.Discovery instance wired to a fake
+// Gateway API clientset for testing. coreObjects seeds the regular Kubernetes
+// fake clientset (used for namespace metadata), gatewayObjects seeds the fake
+// Gateway API clientset.
+func makeGatewayDiscovery(nsDiscovery NamespaceDiscovery, attachMetadata AttachMetadataConfig, coreObjects, gatewayObjects []runtime.Object) (*Discovery, gatewayapi.Interface) {
+	clientset := fake.NewClientset(coreObjects...)
+	gwClientset := gatewayfake.NewSimpleClientset(gatewayObjects...)
+
+	reg := prometheus.NewRegistry()
+	refreshMetrics := discovery.NewRefreshMetrics(reg)
+	metrics := newDiscovererMetrics(reg, refreshMetrics)
+	err := metrics.Register()
+	if err != nil {
+		panic(err)
+	}
+
+	kubeMetrics, ok := metrics.(*kubernetesMetrics)
+	if !ok {
+		panic("invalid discovery metrics type")
+	}
+
+	d := &Discovery{
+		client:             clientset,
+		gatewayClient:      gwClientset,
+		logger:             promslog.NewNopLogger(),
+		role:               RoleGateway,
+		namespaceDiscovery: &nsDiscovery,
+		ownNamespace:       "own-ns",
+		attachMetadata:     attachMetadata,
+		metrics:            kubeMetrics,
+	}
+
+	return d, gwClientset
+}
+
+func makeGateway(namespace string) *gatewayv1.Gateway {
+	hostname := gatewayv1.Hostname("example.com")
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "testgateway",
+			Namespace:   namespace,
+			Labels:      map[string]string{"test/label": "testvalue"},
+			Annotations: map[string]string{"test/annotation": "testannotationvalue"},
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "testclass",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Hostname: &hostname,
+					Port:     80,
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+				{
+					Name:     "https",
+					Hostname: &hostname,
+					Port:     443,
+					Protocol: gatewayv1.HTTPSProtocolType,
+				},
+			},
+		},
+	}
+}
+
+func expectedGatewayTargetGroups(ns string) map[string]*targetgroup.Group {
+	key := fmt.Sprintf("gateway/%s/testgateway", ns)
+	return map[string]*targetgroup.Group{
+		key: {
+			Targets: []model.LabelSet{
+				{
+					"__address__": "example.com:80",
+					"__meta_kubernetes_gateway_listener_name":     "http",
+					"__meta_kubernetes_gateway_listener_hostname": "example.com",
+					"__meta_kubernetes_gateway_listener_port":     "80",
+					"__meta_kubernetes_gateway_listener_protocol": "HTTP",
+				},
+				{
+					"__address__": "example.com:443",
+					"__meta_kubernetes_gateway_listener_name":     "https",
+					"__meta_kubernetes_gateway_listener_hostname": "example.com",
+					"__meta_kubernetes_gateway_listener_port":     "443",
+					"__meta_kubernetes_gateway_listener_protocol": "HTTPS",
+				},
+			},
+			Labels: model.LabelSet{
+				"__meta_kubernetes_gateway_name":                              "testgateway",
+				"__meta_kubernetes_namespace":                                 lv(ns),
+				"__meta_kubernetes_gateway_label_test_label":                  "testvalue",
+				"__meta_kubernetes_gateway_labelpresent_test_label":           "true",
+				"__meta_kubernetes_gateway_annotation_test_annotation":        "testannotationvalue",
+				"__meta_kubernetes_gateway_annotationpresent_test_annotation": "true",
+				"__meta_kubernetes_gateway_class_name":                        "testclass",
+			},
+			Source: key,
+		},
+	}
+}
+
+func TestGatewayDiscoveryAdd(t *testing.T) {
+	t.Parallel()
+	n, c := makeGatewayDiscovery(NamespaceDiscovery{Names: []string{"default"}}, AttachMetadataConfig{}, nil, nil)
+
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := makeGateway("default")
+			c.GatewayV1().Gateways("default").Create(t.Context(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes:      expectedGatewayTargetGroups("default"),
+	}.Run(t)
+}
+
+func TestGatewayDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
+	n, c := makeGatewayDiscovery(NamespaceDiscovery{Names: []string{"ns1", "ns2"}}, AttachMetadataConfig{}, nil, nil)
+
+	expected := expectedGatewayTargetGroups("ns1")
+	maps.Copy(expected, expectedGatewayTargetGroups("ns2"))
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			for _, ns := range []string{"ns1", "ns2"} {
+				obj := makeGateway(ns)
+				c.GatewayV1().Gateways(obj.Namespace).Create(t.Context(), obj, metav1.CreateOptions{})
+			}
+		},
+		expectedMaxItems: 2,
+		expectedRes:      expected,
+	}.Run(t)
+}
+
+func TestGatewayDiscoveryWithNamespaceMetadata(t *testing.T) {
+	t.Parallel()
+
+	ns := "test-ns"
+	nsLabels := map[string]string{"service": "web", "layer": "frontend"}
+	nsAnnotations := map[string]string{"contact": "platform", "release": "v5.6.7"}
+
+	namespace := makeNamespace(ns, nsLabels, nsAnnotations)
+	n, c := makeGatewayDiscovery(NamespaceDiscovery{}, AttachMetadataConfig{Namespace: true}, []runtime.Object{namespace}, nil)
+
+	expected := expectedGatewayTargetGroups(ns)
+	expected[fmt.Sprintf("gateway/%s/testgateway", ns)].Labels["__meta_kubernetes_namespace_label_service"] = "web"
+	expected[fmt.Sprintf("gateway/%s/testgateway", ns)].Labels["__meta_kubernetes_namespace_labelpresent_service"] = "true"
+	expected[fmt.Sprintf("gateway/%s/testgateway", ns)].Labels["__meta_kubernetes_namespace_label_layer"] = "frontend"
+	expected[fmt.Sprintf("gateway/%s/testgateway", ns)].Labels["__meta_kubernetes_namespace_labelpresent_layer"] = "true"
+	expected[fmt.Sprintf("gateway/%s/testgateway", ns)].Labels["__meta_kubernetes_namespace_annotation_contact"] = "platform"
+	expected[fmt.Sprintf("gateway/%s/testgateway", ns)].Labels["__meta_kubernetes_namespace_annotationpresent_contact"] = "true"
+	expected[fmt.Sprintf("gateway/%s/testgateway", ns)].Labels["__meta_kubernetes_namespace_annotation_release"] = "v5.6.7"
+	expected[fmt.Sprintf("gateway/%s/testgateway", ns)].Labels["__meta_kubernetes_namespace_annotationpresent_release"] = "true"
+
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := makeGateway(ns)
+			c.GatewayV1().Gateways(ns).Create(t.Context(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes:      expected,
+	}.Run(t)
+}

--- a/discovery/kubernetes/httproute.go
+++ b/discovery/kubernetes/httproute.go
@@ -1,0 +1,249 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+// HTTPRoute implements discovery of Gateway API HTTPRoutes.
+type HTTPRoute struct {
+	logger                *slog.Logger
+	informer              cache.SharedIndexInformer
+	store                 cache.Store
+	queue                 *workqueue.Typed[string]
+	namespaceInf          cache.SharedInformer
+	withNamespaceMetadata bool
+}
+
+// NewHTTPRoute returns a new HTTPRoute discovery.
+func NewHTTPRoute(l *slog.Logger, inf cache.SharedIndexInformer, namespace cache.SharedInformer, eventCount *prometheus.CounterVec) *HTTPRoute {
+	httpRouteAddCount := eventCount.WithLabelValues(RoleHTTPRoute.String(), MetricLabelRoleAdd)
+	httpRouteUpdateCount := eventCount.WithLabelValues(RoleHTTPRoute.String(), MetricLabelRoleUpdate)
+	httpRouteDeleteCount := eventCount.WithLabelValues(RoleHTTPRoute.String(), MetricLabelRoleDelete)
+
+	s := &HTTPRoute{
+		logger:   l,
+		informer: inf,
+		store:    inf.GetStore(),
+		queue: workqueue.NewTypedWithConfig(workqueue.TypedQueueConfig[string]{
+			Name: RoleHTTPRoute.String(),
+		}),
+		namespaceInf:          namespace,
+		withNamespaceMetadata: namespace != nil,
+	}
+
+	_, err := s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(o any) {
+			httpRouteAddCount.Inc()
+			s.enqueue(o)
+		},
+		DeleteFunc: func(o any) {
+			httpRouteDeleteCount.Inc()
+			s.enqueue(o)
+		},
+		UpdateFunc: func(_, o any) {
+			httpRouteUpdateCount.Inc()
+			s.enqueue(o)
+		},
+	})
+	if err != nil {
+		l.Error("Error adding httproutes event handler.", "err", err)
+	}
+
+	if s.withNamespaceMetadata {
+		_, err = s.namespaceInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(_, o any) {
+				namespace := o.(*apiv1.Namespace)
+				s.enqueueNamespace(namespace.Name)
+			},
+			// Creation and deletion will trigger events for the change handlers of the resources within the namespace.
+			// No need to have additional handlers for them here.
+		})
+		if err != nil {
+			l.Error("Error adding namespaces event handler.", "err", err)
+		}
+	}
+
+	return s
+}
+
+func (r *HTTPRoute) enqueue(obj any) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	r.queue.Add(key)
+}
+
+func (r *HTTPRoute) enqueueNamespace(namespace string) {
+	httpRoutes, err := r.informer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
+	if err != nil {
+		r.logger.Error("Error getting httproutes in namespace", "namespace", namespace, "err", err)
+		return
+	}
+
+	for _, hr := range httpRoutes {
+		r.enqueue(hr)
+	}
+}
+
+// Run implements the Discoverer interface.
+func (r *HTTPRoute) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
+	defer r.queue.ShutDown()
+
+	cacheSyncs := []cache.InformerSynced{r.informer.HasSynced}
+	if r.withNamespaceMetadata {
+		cacheSyncs = append(cacheSyncs, r.namespaceInf.HasSynced)
+	}
+
+	if !cache.WaitForCacheSync(ctx.Done(), cacheSyncs...) {
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			r.logger.Error("httproute informer unable to sync cache")
+		}
+		return
+	}
+
+	go func() {
+		for r.process(ctx, ch) {
+		}
+	}()
+
+	// Block until the target provider is explicitly canceled.
+	<-ctx.Done()
+}
+
+func (r *HTTPRoute) process(ctx context.Context, ch chan<- []*targetgroup.Group) bool {
+	key, quit := r.queue.Get()
+	if quit {
+		return false
+	}
+	defer r.queue.Done(key)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return true
+	}
+
+	o, exists, err := r.store.GetByKey(key)
+	if err != nil {
+		return true
+	}
+	if !exists {
+		send(ctx, ch, &targetgroup.Group{Source: httpRouteSourceFromNamespaceAndName(namespace, name)})
+		return true
+	}
+
+	hr, ok := o.(*gatewayv1.HTTPRoute)
+	if !ok {
+		r.logger.Error("converting to HTTPRoute object failed", "err",
+			fmt.Errorf("received unexpected object: %v", o))
+		return true
+	}
+	send(ctx, ch, r.buildHTTPRoute(*hr))
+	return true
+}
+
+func httpRouteSource(s gatewayv1.HTTPRoute) string {
+	return httpRouteSourceFromNamespaceAndName(s.Namespace, s.Name)
+}
+
+func httpRouteSourceFromNamespaceAndName(namespace, name string) string {
+	return "httproute/" + namespace + "/" + name
+}
+
+const (
+	httpRouteHostnameLabel  = metaLabelPrefix + "httproute_hostname"
+	httpRoutePathLabel      = metaLabelPrefix + "httproute_path"
+	httpRouteParentRefLabel = metaLabelPrefix + "httproute_parent_ref_name"
+)
+
+func httpRouteLabels(hr gatewayv1.HTTPRoute) model.LabelSet {
+	ls := make(model.LabelSet)
+	ls[namespaceLabel] = lv(hr.Namespace)
+
+	if len(hr.Spec.ParentRefs) > 0 {
+		ls[httpRouteParentRefLabel] = lv(string(hr.Spec.ParentRefs[0].Name))
+	}
+
+	addObjectMetaLabels(ls, hr.ObjectMeta, RoleHTTPRoute)
+
+	return ls
+}
+
+// httpRoutePaths returns the path matches configured for a rule, defaulting
+// to "/" the same way Ingress paths do, since an HTTPRoute rule with no
+// matches at all still applies to all paths.
+func httpRoutePaths(rule gatewayv1.HTTPRouteRule) []string {
+	if len(rule.Matches) == 0 {
+		return []string{"/"}
+	}
+	paths := make([]string, 0, len(rule.Matches))
+	for _, m := range rule.Matches {
+		if m.Path == nil || m.Path.Value == nil || *m.Path.Value == "" {
+			paths = append(paths, "/")
+			continue
+		}
+		paths = append(paths, *m.Path.Value)
+	}
+	return paths
+}
+
+func (r *HTTPRoute) buildHTTPRoute(hr gatewayv1.HTTPRoute) *targetgroup.Group {
+	tg := &targetgroup.Group{
+		Source: httpRouteSource(hr),
+	}
+	tg.Labels = httpRouteLabels(hr)
+
+	if r.withNamespaceMetadata {
+		tg.Labels = addNamespaceLabels(tg.Labels, r.namespaceInf, r.logger, hr.Namespace)
+	}
+
+	hostnames := hr.Spec.Hostnames
+	if len(hostnames) == 0 {
+		// No hostnames means the route matches any hostname allowed by the
+		// Gateways it's attached to. We can't resolve that here without
+		// cross-referencing the parent Gateway, so we still emit one target
+		// per rule/path with an empty hostname, same as Ingress does for an
+		// unset rule.Host.
+		hostnames = []gatewayv1.Hostname{""}
+	}
+
+	for _, hostname := range hostnames {
+		for _, rule := range hr.Spec.Rules {
+			for _, path := range httpRoutePaths(rule) {
+				tg.Targets = append(tg.Targets, model.LabelSet{
+					model.AddressLabel:     lv(string(hostname)),
+					httpRouteHostnameLabel: lv(string(hostname)),
+					httpRoutePathLabel:     lv(path),
+				})
+			}
+		}
+	}
+
+	return tg
+}

--- a/discovery/kubernetes/httproute_test.go
+++ b/discovery/kubernetes/httproute_test.go
@@ -1,0 +1,131 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"maps"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+func pathMatch(v string) *gatewayv1.HTTPPathMatch {
+	return &gatewayv1.HTTPPathMatch{Value: &v}
+}
+
+func makeHTTPRoute(namespace string) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "testhttproute",
+			Namespace:   namespace,
+			Labels:      map[string]string{"test/label": "testvalue"},
+			Annotations: map[string]string{"test/annotation": "testannotationvalue"},
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: "testgateway"},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{Path: pathMatch("/")},
+						{Path: pathMatch("/foo")},
+					},
+				},
+				{
+					// No matches, defaults to "/".
+				},
+			},
+		},
+	}
+}
+
+func expectedHTTPRouteTargetGroups(ns string) map[string]*targetgroup.Group {
+	key := fmt.Sprintf("httproute/%s/testhttproute", ns)
+	return map[string]*targetgroup.Group{
+		key: {
+			Targets: []model.LabelSet{
+				{
+					"__address__":                          "example.com",
+					"__meta_kubernetes_httproute_hostname": "example.com",
+					"__meta_kubernetes_httproute_path":     "/",
+				},
+				{
+					"__address__":                          "example.com",
+					"__meta_kubernetes_httproute_hostname": "example.com",
+					"__meta_kubernetes_httproute_path":     "/foo",
+				},
+				{
+					"__address__":                          "example.com",
+					"__meta_kubernetes_httproute_hostname": "example.com",
+					"__meta_kubernetes_httproute_path":     "/",
+				},
+			},
+			Labels: model.LabelSet{
+				"__meta_kubernetes_httproute_name":                              "testhttproute",
+				"__meta_kubernetes_namespace":                                   lv(ns),
+				"__meta_kubernetes_httproute_label_test_label":                  "testvalue",
+				"__meta_kubernetes_httproute_labelpresent_test_label":           "true",
+				"__meta_kubernetes_httproute_annotation_test_annotation":        "testannotationvalue",
+				"__meta_kubernetes_httproute_annotationpresent_test_annotation": "true",
+				"__meta_kubernetes_httproute_parent_ref_name":                   "testgateway",
+			},
+			Source: key,
+		},
+	}
+}
+
+func TestHTTPRouteDiscoveryAdd(t *testing.T) {
+	t.Parallel()
+	n, c := makeGatewayDiscovery(NamespaceDiscovery{Names: []string{"default"}}, AttachMetadataConfig{}, nil, nil)
+	n.role = RoleHTTPRoute
+
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			obj := makeHTTPRoute("default")
+			c.GatewayV1().HTTPRoutes("default").Create(t.Context(), obj, metav1.CreateOptions{})
+		},
+		expectedMaxItems: 1,
+		expectedRes:      expectedHTTPRouteTargetGroups("default"),
+	}.Run(t)
+}
+
+func TestHTTPRouteDiscoveryNamespaces(t *testing.T) {
+	t.Parallel()
+	n, c := makeGatewayDiscovery(NamespaceDiscovery{Names: []string{"ns1", "ns2"}}, AttachMetadataConfig{}, nil, nil)
+	n.role = RoleHTTPRoute
+
+	expected := expectedHTTPRouteTargetGroups("ns1")
+	maps.Copy(expected, expectedHTTPRouteTargetGroups("ns2"))
+	k8sDiscoveryTest{
+		discovery: n,
+		afterStart: func() {
+			for _, ns := range []string{"ns1", "ns2"} {
+				obj := makeHTTPRoute(ns)
+				c.GatewayV1().HTTPRoutes(obj.Namespace).Create(t.Context(), obj, metav1.CreateOptions{})
+			}
+		},
+		expectedMaxItems: 2,
+		expectedRes:      expected,
+	}.Run(t)
+}

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -82,6 +82,7 @@ const (
 	RoleEndpointSlice Role = "endpointslice"
 	RoleIngress       Role = "ingress"
 	RoleGateway       Role = "gateway"
+	RoleHTTPRoute     Role = "httproute"
 )
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -90,7 +91,7 @@ func (c *Role) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 	switch *c {
-	case RoleNode, RolePod, RoleService, RoleEndpoint, RoleEndpointSlice, RoleIngress, RoleGateway:
+	case RoleNode, RolePod, RoleService, RoleEndpoint, RoleEndpointSlice, RoleIngress, RoleGateway, RoleHTTPRoute:
 		return nil
 	default:
 		return fmt.Errorf("unknown Kubernetes SD role %q", *c)
@@ -145,6 +146,7 @@ type roleSelector struct {
 	endpointslice resourceSelector
 	ingress       resourceSelector
 	gateway       resourceSelector
+	httpRoute     resourceSelector
 }
 
 type SelectorConfig struct {
@@ -215,6 +217,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		RoleNode:          {string(RoleNode)},
 		RoleIngress:       {string(RoleIngress)},
 		RoleGateway:       {string(RoleGateway)},
+		RoleHTTPRoute:     {string(RoleHTTPRoute)},
 	}
 
 	for _, selector := range c.Selectors {
@@ -387,6 +390,9 @@ func mapSelector(rawSelector []SelectorConfig) roleSelector {
 		case RoleGateway:
 			rs.gateway.field = resourceSelectorRaw.Field
 			rs.gateway.label = resourceSelectorRaw.Label
+		case RoleHTTPRoute:
+			rs.httpRoute.field = resourceSelectorRaw.Field
+			rs.httpRoute.label = resourceSelectorRaw.Label
 		case RoleNode:
 			rs.node.field = resourceSelectorRaw.Field
 			rs.node.label = resourceSelectorRaw.Label
@@ -714,6 +720,36 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 			d.discoverers = append(d.discoverers, gtw)
 			go gtw.informer.Run(ctx.Done())
 		}
+	case RoleHTTPRoute:
+		var namespaceInformer cache.SharedInformer
+		if d.attachMetadata.Namespace {
+			namespaceInformer = d.newNamespaceInformer(ctx)
+			go namespaceInformer.Run(ctx.Done())
+		}
+
+		for _, namespace := range namespaces {
+			hrc := d.gatewayClient.GatewayV1().HTTPRoutes(namespace)
+			hlw := &cache.ListWatch{
+				ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = d.selectors.httpRoute.field
+					options.LabelSelector = d.selectors.httpRoute.label
+					return hrc.List(ctx, options)
+				},
+				WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = d.selectors.httpRoute.field
+					options.LabelSelector = d.selectors.httpRoute.label
+					return hrc.Watch(ctx, options)
+				},
+			}
+			hr := NewHTTPRoute(
+				d.logger.With("role", "httproute"),
+				d.newIndexedHTTPRoutesInformer(hlw),
+				namespaceInformer,
+				d.metrics.eventCount,
+			)
+			d.discoverers = append(d.discoverers, hr)
+			go hr.informer.Run(ctx.Done())
+		}
 	case RoleNode:
 		nodeInformer := d.newNodeInformer(ctx)
 		node := NewNode(d.logger.With("role", "node"), nodeInformer, d.metrics.eventCount)
@@ -996,6 +1032,16 @@ func (d *Discovery) newIndexedGatewaysInformer(glw *cache.ListWatch) cache.Share
 	}
 
 	return d.mustNewSharedIndexInformer(glw, &gatewayv1.Gateway{}, resyncDisabled, indexers)
+}
+
+func (d *Discovery) newIndexedHTTPRoutesInformer(hlw *cache.ListWatch) cache.SharedIndexInformer {
+	indexers := make(map[string]cache.IndexFunc)
+
+	if d.attachMetadata.Namespace {
+		indexers[cache.NamespaceIndex] = cache.MetaNamespaceIndexFunc
+	}
+
+	return d.mustNewSharedIndexInformer(hlw, &gatewayv1.HTTPRoute{}, resyncDisabled, indexers)
 }
 
 func (d *Discovery) informerWatchErrorHandler(ctx context.Context, r *cache.Reflector, err error) {

--- a/discovery/kubernetes/kubernetes.go
+++ b/discovery/kubernetes/kubernetes.go
@@ -45,6 +45,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapi "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -79,6 +81,7 @@ const (
 	RoleEndpoint      Role = "endpoints"
 	RoleEndpointSlice Role = "endpointslice"
 	RoleIngress       Role = "ingress"
+	RoleGateway       Role = "gateway"
 )
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -87,7 +90,7 @@ func (c *Role) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 	switch *c {
-	case RoleNode, RolePod, RoleService, RoleEndpoint, RoleEndpointSlice, RoleIngress:
+	case RoleNode, RolePod, RoleService, RoleEndpoint, RoleEndpointSlice, RoleIngress, RoleGateway:
 		return nil
 	default:
 		return fmt.Errorf("unknown Kubernetes SD role %q", *c)
@@ -141,6 +144,7 @@ type roleSelector struct {
 	endpoints     resourceSelector
 	endpointslice resourceSelector
 	ingress       resourceSelector
+	gateway       resourceSelector
 }
 
 type SelectorConfig struct {
@@ -210,6 +214,7 @@ func (c *SDConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		RoleEndpoint:      {string(RolePod), string(RoleService), string(RoleEndpoint)},
 		RoleNode:          {string(RoleNode)},
 		RoleIngress:       {string(RoleIngress)},
+		RoleGateway:       {string(RoleGateway)},
 	}
 
 	for _, selector := range c.Selectors {
@@ -255,6 +260,7 @@ func (c *NamespaceDiscovery) UnmarshalYAML(unmarshal func(any) error) error {
 type Discovery struct {
 	sync.RWMutex
 	client             k8sClient
+	gatewayClient      gatewayapi.Interface
 	role               Role
 	logger             *slog.Logger
 	namespaceDiscovery *NamespaceDiscovery
@@ -333,6 +339,15 @@ func New(l *slog.Logger, metrics discovery.DiscovererMetrics, conf *SDConfig) (*
 	}
 
 	kcfg.UserAgent = version.PrometheusUserAgent()
+
+	// The Gateway API clientset talks to a CRD, which the API server only ever
+	// serves as JSON, so build it before switching the shared config over to
+	// protobuf for the core client below.
+	gwc, err := gatewayapi.NewForConfig(kcfg)
+	if err != nil {
+		return nil, err
+	}
+
 	kcfg.ContentType = "application/vnd.kubernetes.protobuf"
 
 	c, err := kubernetes.NewForConfig(kcfg)
@@ -342,6 +357,7 @@ func New(l *slog.Logger, metrics discovery.DiscovererMetrics, conf *SDConfig) (*
 
 	d := &Discovery{
 		client:             newClientAdapter(c),
+		gatewayClient:      gwc,
 		logger:             l,
 		role:               conf.Role,
 		namespaceDiscovery: &conf.NamespaceDiscovery,
@@ -368,6 +384,9 @@ func mapSelector(rawSelector []SelectorConfig) roleSelector {
 		case RoleIngress:
 			rs.ingress.field = resourceSelectorRaw.Field
 			rs.ingress.label = resourceSelectorRaw.Label
+		case RoleGateway:
+			rs.gateway.field = resourceSelectorRaw.Field
+			rs.gateway.label = resourceSelectorRaw.Label
 		case RoleNode:
 			rs.node.field = resourceSelectorRaw.Field
 			rs.node.label = resourceSelectorRaw.Label
@@ -665,6 +684,36 @@ func (d *Discovery) Run(ctx context.Context, ch chan<- []*targetgroup.Group) {
 			d.discoverers = append(d.discoverers, ingress)
 			go ingress.informer.Run(ctx.Done())
 		}
+	case RoleGateway:
+		var namespaceInformer cache.SharedInformer
+		if d.attachMetadata.Namespace {
+			namespaceInformer = d.newNamespaceInformer(ctx)
+			go namespaceInformer.Run(ctx.Done())
+		}
+
+		for _, namespace := range namespaces {
+			gwc := d.gatewayClient.GatewayV1().Gateways(namespace)
+			glw := &cache.ListWatch{
+				ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+					options.FieldSelector = d.selectors.gateway.field
+					options.LabelSelector = d.selectors.gateway.label
+					return gwc.List(ctx, options)
+				},
+				WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+					options.FieldSelector = d.selectors.gateway.field
+					options.LabelSelector = d.selectors.gateway.label
+					return gwc.Watch(ctx, options)
+				},
+			}
+			gtw := NewGateway(
+				d.logger.With("role", "gateway"),
+				d.newIndexedGatewaysInformer(glw),
+				namespaceInformer,
+				d.metrics.eventCount,
+			)
+			d.discoverers = append(d.discoverers, gtw)
+			go gtw.informer.Run(ctx.Done())
+		}
 	case RoleNode:
 		nodeInformer := d.newNodeInformer(ctx)
 		node := NewNode(d.logger.With("role", "node"), nodeInformer, d.metrics.eventCount)
@@ -937,6 +986,16 @@ func (d *Discovery) newIndexedIngressesInformer(ilw *cache.ListWatch) cache.Shar
 	}
 
 	return d.mustNewSharedIndexInformer(ilw, &networkv1.Ingress{}, resyncDisabled, indexers)
+}
+
+func (d *Discovery) newIndexedGatewaysInformer(glw *cache.ListWatch) cache.SharedIndexInformer {
+	indexers := make(map[string]cache.IndexFunc)
+
+	if d.attachMetadata.Namespace {
+		indexers[cache.NamespaceIndex] = cache.MetaNamespaceIndexFunc
+	}
+
+	return d.mustNewSharedIndexInformer(glw, &gatewayv1.Gateway{}, resyncDisabled, indexers)
 }
 
 func (d *Discovery) informerWatchErrorHandler(ctx context.Context, r *cache.Reflector, err error) {

--- a/discovery/kubernetes/metrics.go
+++ b/discovery/kubernetes/metrics.go
@@ -61,6 +61,7 @@ func newDiscovererMetrics(reg prometheus.Registerer, _ discovery.RefreshMetricsI
 		RoleService.String(),
 		RoleIngress.String(),
 		RoleGateway.String(),
+		RoleHTTPRoute.String(),
 	} {
 		for _, evt := range []string{
 			MetricLabelRoleAdd,

--- a/discovery/kubernetes/metrics.go
+++ b/discovery/kubernetes/metrics.go
@@ -60,6 +60,7 @@ func newDiscovererMetrics(reg prometheus.Registerer, _ discovery.RefreshMetricsI
 		RolePod.String(),
 		RoleService.String(),
 		RoleIngress.String(),
+		RoleGateway.String(),
 	} {
 		for _, evt := range []string{
 			MetricLabelRoleAdd,

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2598,6 +2598,54 @@ Available meta labels:
   config is set. Defaults to `http`.
 * `__meta_kubernetes_ingress_path`: Path from ingress spec. Defaults to `/`.
 
+#### `gateway`
+
+The `gateway` role discovers a target for each listener of each
+[Gateway API](https://gateway-api.sigs.k8s.io/) `Gateway`. This is generally
+useful for blackbox monitoring of a gateway's exposed listeners.
+The address is set to the listener's hostname and port.
+
+This role requires the `sigs.k8s.io/gateway-api` CRDs to be installed in the
+cluster.
+
+Available meta labels:
+
+* `__meta_kubernetes_namespace`: The namespace of the gateway object.
+* `__meta_kubernetes_gateway_name`: The name of the gateway object.
+* `__meta_kubernetes_gateway_label_<labelname>`: Each label from the gateway object, with any unsupported characters converted to an underscore.
+* `__meta_kubernetes_gateway_labelpresent_<labelname>`: `true` for each label from the gateway object, with any unsupported characters converted to an underscore.
+* `__meta_kubernetes_gateway_annotation_<annotationname>`: Each annotation from the gateway object.
+* `__meta_kubernetes_gateway_annotationpresent_<annotationname>`: `true` for each annotation from the gateway object.
+* `__meta_kubernetes_gateway_class_name`: The `gatewayClassName` from the gateway spec.
+* `__meta_kubernetes_gateway_listener_name`: The name of the listener.
+* `__meta_kubernetes_gateway_listener_hostname`: The hostname of the listener, if set.
+* `__meta_kubernetes_gateway_listener_port`: The port of the listener.
+* `__meta_kubernetes_gateway_listener_protocol`: The protocol of the listener.
+
+#### `httproute`
+
+The `httproute` role discovers a target for each hostname/path combination of
+each [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. This is
+generally useful for blackbox monitoring of an HTTPRoute's matched paths.
+The address is set to the route's hostname; since an HTTPRoute doesn't carry
+its own network address, resolving it depends on the `Gateway` it's attached
+to actually serving that hostname.
+
+This role requires the `sigs.k8s.io/gateway-api` CRDs to be installed in the
+cluster.
+
+Available meta labels:
+
+* `__meta_kubernetes_namespace`: The namespace of the HTTPRoute object.
+* `__meta_kubernetes_httproute_name`: The name of the HTTPRoute object.
+* `__meta_kubernetes_httproute_label_<labelname>`: Each label from the HTTPRoute object, with any unsupported characters converted to an underscore.
+* `__meta_kubernetes_httproute_labelpresent_<labelname>`: `true` for each label from the HTTPRoute object, with any unsupported characters converted to an underscore.
+* `__meta_kubernetes_httproute_annotation_<annotationname>`: Each annotation from the HTTPRoute object.
+* `__meta_kubernetes_httproute_annotationpresent_<annotationname>`: `true` for each annotation from the HTTPRoute object.
+* `__meta_kubernetes_httproute_parent_ref_name`: The name of the first `parentRef` (the Gateway this route is attached to).
+* `__meta_kubernetes_httproute_hostname`: Hostname matched by this target, if set on the route.
+* `__meta_kubernetes_httproute_path`: Path matched by this target. Defaults to `/`.
+
 See below for the configuration options for Kubernetes discovery:
 
 ```yaml
@@ -2609,7 +2657,7 @@ See below for the configuration options for Kubernetes discovery:
 [ api_server: <host> ]
 
 # The Kubernetes role of entities that should be discovered.
-# One of endpoints, endpointslice, service, pod, node, or ingress.
+# One of endpoints, endpointslice, service, pod, node, ingress, gateway, or httproute.
 role: <string>
 
 # Optional path to a kubeconfig file.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -2605,6 +2605,54 @@ Available meta labels:
   config is set. Defaults to `http`.
 * `__meta_kubernetes_ingress_path`: Path from ingress spec. Defaults to `/`.
 
+#### `gateway`
+
+The `gateway` role discovers a target for each listener of each
+[Gateway API](https://gateway-api.sigs.k8s.io/) `Gateway`. This is generally
+useful for blackbox monitoring of a gateway's exposed listeners.
+The address is set to the listener's hostname and port.
+
+This role requires the `sigs.k8s.io/gateway-api` CRDs to be installed in the
+cluster.
+
+Available meta labels:
+
+* `__meta_kubernetes_namespace`: The namespace of the gateway object.
+* `__meta_kubernetes_gateway_name`: The name of the gateway object.
+* `__meta_kubernetes_gateway_label_<labelname>`: Each label from the gateway object, with any unsupported characters converted to an underscore.
+* `__meta_kubernetes_gateway_labelpresent_<labelname>`: `true` for each label from the gateway object, with any unsupported characters converted to an underscore.
+* `__meta_kubernetes_gateway_annotation_<annotationname>`: Each annotation from the gateway object.
+* `__meta_kubernetes_gateway_annotationpresent_<annotationname>`: `true` for each annotation from the gateway object.
+* `__meta_kubernetes_gateway_class_name`: The `gatewayClassName` from the gateway spec.
+* `__meta_kubernetes_gateway_listener_name`: The name of the listener.
+* `__meta_kubernetes_gateway_listener_hostname`: The hostname of the listener, if set.
+* `__meta_kubernetes_gateway_listener_port`: The port of the listener.
+* `__meta_kubernetes_gateway_listener_protocol`: The protocol of the listener.
+
+#### `httproute`
+
+The `httproute` role discovers a target for each hostname/path combination of
+each [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. This is
+generally useful for blackbox monitoring of an HTTPRoute's matched paths.
+The address is set to the route's hostname; since an HTTPRoute doesn't carry
+its own network address, resolving it depends on the `Gateway` it's attached
+to actually serving that hostname.
+
+This role requires the `sigs.k8s.io/gateway-api` CRDs to be installed in the
+cluster.
+
+Available meta labels:
+
+* `__meta_kubernetes_namespace`: The namespace of the HTTPRoute object.
+* `__meta_kubernetes_httproute_name`: The name of the HTTPRoute object.
+* `__meta_kubernetes_httproute_label_<labelname>`: Each label from the HTTPRoute object, with any unsupported characters converted to an underscore.
+* `__meta_kubernetes_httproute_labelpresent_<labelname>`: `true` for each label from the HTTPRoute object, with any unsupported characters converted to an underscore.
+* `__meta_kubernetes_httproute_annotation_<annotationname>`: Each annotation from the HTTPRoute object.
+* `__meta_kubernetes_httproute_annotationpresent_<annotationname>`: `true` for each annotation from the HTTPRoute object.
+* `__meta_kubernetes_httproute_parent_ref_name`: The name of the first `parentRef` (the Gateway this route is attached to).
+* `__meta_kubernetes_httproute_hostname`: Hostname matched by this target, if set on the route.
+* `__meta_kubernetes_httproute_path`: Path matched by this target. Defaults to `/`.
+
 See below for the configuration options for Kubernetes discovery:
 
 ```yaml
@@ -2616,7 +2664,7 @@ See below for the configuration options for Kubernetes discovery:
 [ api_server: <host> ]
 
 # The Kubernetes role of entities that should be discovered.
-# One of endpoints, endpointslice, service, pod, node, or ingress.
+# One of endpoints, endpointslice, service, pod, node, ingress, gateway, or httproute.
 role: <string>
 
 # Optional path to a kubeconfig file.

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	k8s.io/client-go v0.35.3
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.140.0
+	sigs.k8s.io/gateway-api v1.4.1
 )
 
 require (
@@ -114,7 +115,6 @@ require (
 	github.com/hashicorp/go-metrics v0.6.0 // indirect
 	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
-	sigs.k8s.io/gateway-api v1.4.1 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 	github.com/hashicorp/go-metrics v0.6.0 // indirect
 	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	sigs.k8s.io/gateway-api v1.4.1 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	k8s.io/client-go v0.36.4
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.140.0
+	sigs.k8s.io/gateway-api v1.4.1
 )
 
 require (
@@ -114,7 +115,6 @@ require (
 	github.com/hashicorp/go-metrics v0.6.0 // indirect
 	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
-	sigs.k8s.io/gateway-api v1.4.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -770,6 +770,8 @@ k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0x
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
 pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
+sigs.k8s.io/gateway-api v1.4.1 h1:NPxFutNkKNa8UfLd2CMlEuhIPMQgDQ6DXNKG9sHbJU8=
+sigs.k8s.io/gateway-api v1.4.1/go.mod h1:AR5RSqciWP98OPckEjOjh2XJhAe2Na4LHyXD2FUY7Qk=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/go.sum
+++ b/go.sum
@@ -768,6 +768,8 @@ k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0x
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
 pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
+sigs.k8s.io/gateway-api v1.4.1 h1:NPxFutNkKNa8UfLd2CMlEuhIPMQgDQ6DXNKG9sHbJU8=
+sigs.k8s.io/gateway-api v1.4.1/go.mod h1:AR5RSqciWP98OPckEjOjh2XJhAe2Na4LHyXD2FUY7Qk=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=


### PR DESCRIPTION
## What's this?

Proof of concept for the scope proposed on #15863: discover Gateway API `Gateway` and `HTTPRoute` objects via `kubernetes_sd_config`, the same way `role: ingress` already discovers Ingress objects.

Opening as a draft because the scope itself (which Gateway API kinds to support, how to answer the "opens the door to any CRD" concern raised on the issue) hasn't been agreed yet. Posted a proposal comment on the issue with the reasoning; this PR is meant to make that discussion concrete rather than to be merged as-is.

## How it works

- `role: gateway`: one target per Gateway listener, address is `hostname:port`.
- `role: httproute`: one target per hostname/path match, following the same simplification Ingress already uses (the route's own hostname becomes the address, no live resolution of the parent Gateway).
- Both are opt-in and follow the exact same pattern as `discovery/kubernetes/ingress.go`: a `cache.SharedIndexInformer` + workqueue per role, wired into the existing `Role` enum, selectors, and metrics.
- Uses `sigs.k8s.io/gateway-api`'s generated clientset, built from a copy of the REST config before the core client switches to protobuf, since the CRD only serves JSON.

Split into 3 commits (gateway, httproute, docs), each builds and passes tests on its own.

## Not yet in scope

- No GRPCRoute/TCPRoute/TLSRoute, matching the narrower scope proposed on the issue.
- HTTPRoute doesn't resolve its parent Gateway's actual address; it's documented as a known simplification, same as Ingress already has.

## Checklist

- [x] Tests were added.
- [ ] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added.

```release-notes
[FEATURE] discovery/kubernetes: add `gateway` and `httproute` roles to discover Gateway API resources.
```

### AI Disclosure

Investigation, implementation and tests were done with Claude Code, with direction and review from me.