### PR TITLE
discovery/aws: avoid panic on custom ECS task groups

### DIFF
--- a/discovery/aws/ecs.go
+++ b/discovery/aws/ecs.go
@@ -989,11 +989,11 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 						}
 					}
 
-					// If this is not a standalone task, add service information and tags
-					if !isStandaloneTask(task) {
-						service, ok := services[getServiceNameFromTaskGroup(task)]
+					// If this task belongs to a service, add service information and tags.
+					if serviceName, isServiceTask := strings.CutPrefix(*task.Group, "service:"); isServiceTask {
+						service, ok := services[serviceName]
 						if !ok {
-							d.logger.Debug("Service not found for task", "task", *task.TaskArn, "service", getServiceNameFromTaskGroup(task))
+							d.logger.Debug("Service not found for task", "task", *task.TaskArn, "service", serviceName)
 						}
 						if service.ServiceName != nil {
 							labels[ecsLabelService] = model.LabelValue(*service.ServiceName)
@@ -1050,13 +1050,4 @@ func (d *ECSDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group, error
 	tg.Targets = clusterTargets
 
 	return []*targetgroup.Group{tg}, nil
-}
-
-func isStandaloneTask(task types.Task) bool {
-	// A standalone task will have a group of "family:task-def-name"
-	return task.Group != nil && strings.HasPrefix(*task.Group, "family:")
-}
-
-func getServiceNameFromTaskGroup(task types.Task) string {
-	return strings.Split(*task.Group, ":")[1]
 }

--- a/discovery/aws/ecs_test.go
+++ b/discovery/aws/ecs_test.go
@@ -1100,7 +1100,7 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 			},
 		},
 		{
-			name: "StandaloneTaskNoService",
+			name: "StandaloneTaskWithCustomGroup",
 			ecsData: &ecsDataStore{
 				region: "us-west-2",
 				clusters: []ecsTypes.Cluster{
@@ -1116,7 +1116,7 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 						TaskArn:           strptr("arn:aws:ecs:us-west-2:123456789012:task/standalone-cluster/task-standalone"),
 						ClusterArn:        strptr("arn:aws:ecs:us-west-2:123456789012:cluster/standalone-cluster"),
 						TaskDefinitionArn: strptr("arn:aws:ecs:us-west-2:123456789012:task-definition/standalone-task:1"),
-						Group:             strptr("family:standalone-task"),
+						Group:             strptr("batch-jobs"),
 						LaunchType:        ecsTypes.LaunchTypeFargate,
 						LastStatus:        strptr("RUNNING"),
 						DesiredStatus:     strptr("RUNNING"),
@@ -1149,7 +1149,7 @@ func TestECSDiscoveryRefresh(t *testing.T) {
 							model.AddressLabel:             model.LabelValue("10.0.4.10:80"),
 							"__meta_ecs_cluster":           model.LabelValue("standalone-cluster"),
 							"__meta_ecs_cluster_arn":       model.LabelValue("arn:aws:ecs:us-west-2:123456789012:cluster/standalone-cluster"),
-							"__meta_ecs_task_group":        model.LabelValue("family:standalone-task"),
+							"__meta_ecs_task_group":        model.LabelValue("batch-jobs"),
 							"__meta_ecs_task_arn":          model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task/standalone-cluster/task-standalone"),
 							"__meta_ecs_task_definition":   model.LabelValue("arn:aws:ecs:us-west-2:123456789012:task-definition/standalone-task:1"),
 							"__meta_ecs_region":            model.LabelValue("us-west-2"),
@@ -1722,101 +1722,4 @@ func (m *mockECSEC2Client) DescribeNetworkInterfaces(_ context.Context, input *e
 	return &ec2.DescribeNetworkInterfacesOutput{
 		NetworkInterfaces: networkInterfaces,
 	}, nil
-}
-
-func TestIsStandaloneTask(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name     string
-		task     ecsTypes.Task
-		expected bool
-	}{
-		{
-			name: "StandaloneTask",
-			task: ecsTypes.Task{
-				Group: strptr("family:my-task-definition"),
-			},
-			expected: true,
-		},
-		{
-			name: "ServiceTask",
-			task: ecsTypes.Task{
-				Group: strptr("service:my-service"),
-			},
-			expected: false,
-		},
-		{
-			name: "ServiceTaskWithColon",
-			task: ecsTypes.Task{
-				Group: strptr("service:my:service:name"),
-			},
-			expected: false,
-		},
-		{
-			name: "NilGroup",
-			task: ecsTypes.Task{
-				Group: nil,
-			},
-			expected: false,
-		},
-		{
-			name: "EmptyGroup",
-			task: ecsTypes.Task{
-				Group: strptr(""),
-			},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isStandaloneTask(tt.task)
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestGetServiceNameFromTaskGroup(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name     string
-		task     ecsTypes.Task
-		expected string
-	}{
-		{
-			name: "SimpleServiceName",
-			task: ecsTypes.Task{
-				Group: strptr("service:my-service"),
-			},
-			expected: "my-service",
-		},
-		{
-			name: "ServiceNameWithHyphens",
-			task: ecsTypes.Task{
-				Group: strptr("service:web-api-service"),
-			},
-			expected: "web-api-service",
-		},
-		{
-			name: "ServiceNameWithColons",
-			task: ecsTypes.Task{
-				Group: strptr("service:my:service:name"),
-			},
-			expected: "my",
-		},
-		{
-			name: "FamilyGroup",
-			task: ecsTypes.Task{
-				Group: strptr("family:my-task-def"),
-			},
-			expected: "my-task-def",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := getServiceNameFromTaskGroup(tt.task)
-			require.Equal(t, tt.expected, result)
-		})
-	}
 }


### PR DESCRIPTION
AWS allows standalone ECS tasks to use a custom task group instead of the default `family:` group. ECS discovery assumed every group without the `family:` prefix belonged to a service and indexed the result of splitting it on `:`. A valid custom group such as `batch-jobs` therefore caused the discovery refresh to panic.

Standalone task discovery was added in #18029 using the default `family:` group format; custom standalone groups were not covered.

This change recognizes service tasks by the `service:` prefix. Tasks with custom groups remain discoverable without service metadata, matching other standalone tasks. The refresh test uses a custom group and fails with an index-out-of-range panic before the fix.

AWS documentation: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-groups.html

#### Which issue(s) does the PR fix:

None.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] Discovery/AWS: Avoid a panic when discovering standalone ECS tasks with custom task groups.
```