### PR TITLE
scrape: fix data race in TargetsDroppedCounts

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -498,7 +498,7 @@ func (m *Manager) TargetsDroppedCounts() map[string]int {
 
 	counts := make(map[string]int, len(m.scrapePools))
 	for tset, sp := range m.scrapePools {
-		counts[tset] = sp.droppedTargetsCount
+		counts[tset] = sp.DroppedTargetsCount()
 	}
 	return counts
 }


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

N/A (discovered via code audit)

#### What does this PR do:

`Manager.TargetsDroppedCounts()` reads `scrapePool.droppedTargetsCount` directly without holding `sp.targetMtx`, while `Sync()` writes to it under `sp.targetMtx`. This is a data race detectable by the Go race detector.

The race occurs when `TargetsDroppedCounts()` is called concurrently with `Sync()` — for example, when the HTTP API endpoint `/api/v1/targets` is queried while target discovery updates are running.

```
WARNING: DATA RACE
Write at scrape/scrape.go:397 (Sync)
Previous read at scrape/manager.go:501 (TargetsDroppedCounts)
```

After the fix, the test passes cleanly.

```release-notes
[BUGFIX] scrape: fix data race in Manager.TargetsDroppedCounts when called concurrently with Sync.
```