### PR TITLE
scrape: detect duplicate series after metric relabeling

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -912,9 +912,12 @@ type scrapeCache struct {
 	seriesCur  map[storage.SeriesRef]*cacheEntry
 	seriesPrev map[storage.SeriesRef]*cacheEntry
 
-	// Cache of post-relabeling hashes seen in the current scrape iteration.
-	// Used to detect duplicate labels after relabeling.
-	seriesHashes map[uint64]struct{}
+	// Cache of post-relabeling label sets seen in the current scrape iteration,
+	// keyed by label-set hash. Used to detect duplicate labels after relabeling.
+	// A separate conflict map handles the rare case of hash collisions, following
+	// the same approach as TSDB's seriesHashmap.
+	seriesHashes        map[uint64]labels.Labels
+	seriesHashConflicts map[uint64][]labels.Labels
 
 	// TODO(bwplotka): Consider moving metadata caching to head. See
 	// https://github.com/prometheus/prometheus/issues/17619.
@@ -943,7 +946,7 @@ func newScrapeCache(metrics *scrapeMetrics) *scrapeCache {
 		droppedSeries: map[string]*uint64{},
 		seriesCur:     map[storage.SeriesRef]*cacheEntry{},
 		seriesPrev:    map[storage.SeriesRef]*cacheEntry{},
-		seriesHashes:  map[uint64]struct{}{},
+		seriesHashes:  map[uint64]labels.Labels{},
 		metadata:      map[string]*metaEntry{},
 		metrics:       metrics,
 	}
@@ -995,8 +998,35 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 	c.seriesPrev, c.seriesCur = c.seriesCur, c.seriesPrev
 	clear(c.seriesCur)
 	clear(c.seriesHashes)
+	clear(c.seriesHashConflicts)
 
 	c.iter++
+}
+
+// isSeriesHashDuplicate reports whether lset was already seen in the current
+// scrape iteration. It follows the same approach as TSDB's seriesHashmap:
+// a primary map holds the first label set per hash, and a lazily-allocated
+// conflict map handles the rare case of different label sets sharing a hash.
+func (c *scrapeCache) isSeriesHashDuplicate(hash uint64, lset labels.Labels) bool {
+	if existing, ok := c.seriesHashes[hash]; ok {
+		if labels.Equal(existing, lset) {
+			return true
+		}
+		// Hash collision — check the conflict bucket.
+		for _, l := range c.seriesHashConflicts[hash] {
+			if labels.Equal(l, lset) {
+				return true
+			}
+		}
+		// New series with a colliding hash.
+		if c.seriesHashConflicts == nil {
+			c.seriesHashConflicts = make(map[uint64][]labels.Labels)
+		}
+		c.seriesHashConflicts[hash] = append(c.seriesHashConflicts[hash], lset)
+		return false
+	}
+	c.seriesHashes[hash] = lset
+	return false
 }
 
 func (c *scrapeCache) get(met []byte) (*cacheEntry, bool, bool) {
@@ -1747,11 +1777,7 @@ loop:
 
 		var isDuplicate bool
 		if parsedTimestamp == nil {
-			if _, ok := sl.cache.seriesHashes[hash]; ok {
-				isDuplicate = true
-			} else {
-				sl.cache.seriesHashes[hash] = struct{}{}
-			}
+			isDuplicate = sl.cache.isSeriesHashDuplicate(hash, lset)
 		}
 
 		if isDuplicate {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -895,7 +895,8 @@ type scrapeLoop struct {
 // scrapes.
 // Cache is meant to be used per a single target.
 type scrapeCache struct {
-	iter uint64 // Current scrape iteration.
+	iter     uint64 // Current scrape iteration.
+	scrapeID uint64 // Scrape attempt ID, incremented on every append attempt.
 
 	// How many series and metadata entries there were at the last success.
 	successfulCount int
@@ -916,8 +917,9 @@ type scrapeCache struct {
 	// keyed by label-set hash. Used to detect duplicate labels after relabeling.
 	// A separate conflict map handles the rare case of hash collisions, following
 	// the same approach as TSDB's seriesHashmap.
-	seriesHashes        map[uint64]labels.Labels
-	seriesHashConflicts map[uint64][]labels.Labels
+	// Both use generational versioning (iter) to avoid map clearing per scrape.
+	seriesHashes        map[uint64]hashEntry
+	seriesHashConflicts map[uint64][]hashEntry
 
 	// TODO(bwplotka): Consider moving metadata caching to head. See
 	// https://github.com/prometheus/prometheus/issues/17619.
@@ -925,6 +927,13 @@ type scrapeCache struct {
 	metadata map[string]*metaEntry // metadata by metric family name.
 
 	metrics *scrapeMetrics
+}
+
+// hashEntry is used for generation-based duplicate hash detection without
+// needing to clear maps per scrape.
+type hashEntry struct {
+	lset     labels.Labels
+	scrapeID uint64
 }
 
 // metaEntry holds meta information about a metric.
@@ -946,7 +955,7 @@ func newScrapeCache(metrics *scrapeMetrics) *scrapeCache {
 		droppedSeries: map[string]*uint64{},
 		seriesCur:     map[storage.SeriesRef]*cacheEntry{},
 		seriesPrev:    map[storage.SeriesRef]*cacheEntry{},
-		seriesHashes:  map[uint64]labels.Labels{},
+		seriesHashes:  map[uint64]hashEntry{},
 		metadata:      map[string]*metaEntry{},
 		metrics:       metrics,
 	}
@@ -979,6 +988,11 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 				delete(c.series, s)
 			}
 		}
+		// Clean up hashes that haven't been seen in the current success iteration
+		// to prevent unbounded growth across label/hash changes.
+		// We'll just clear the hashes map fully on cache flush.
+		// It's rare enough (forced flush) that clearing it is fine.
+		clear(c.seriesHashes)
 		for s, iter := range c.droppedSeries {
 			if c.iter != *iter {
 				delete(c.droppedSeries, s)
@@ -992,13 +1006,14 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 			}
 		}
 		c.metaMtx.Unlock()
+
+		// Clear hash conflicts fully on cache flush since they are rare.
+		c.seriesHashConflicts = nil
 	}
 
 	// Swap current and previous series then clear the new current, to save allocations.
 	c.seriesPrev, c.seriesCur = c.seriesCur, c.seriesPrev
 	clear(c.seriesCur)
-	clear(c.seriesHashes)
-	clear(c.seriesHashConflicts)
 
 	c.iter++
 }
@@ -1007,26 +1022,35 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 // scrape iteration. It follows the same approach as TSDB's seriesHashmap:
 // a primary map holds the first label set per hash, and a lazily-allocated
 // conflict map handles the rare case of different label sets sharing a hash.
+// It uses generational versioning (scrapeID) so maps don't need clearing per scrape.
 func (c *scrapeCache) isSeriesHashDuplicate(hash uint64, lset labels.Labels) bool {
-	if existing, ok := c.seriesHashes[hash]; ok {
-		if labels.Equal(existing, lset) {
+	if existing, ok := c.seriesHashes[hash]; ok && existing.scrapeID == c.scrapeID {
+		if labels.Equal(existing.lset, lset) {
 			return true
 		}
 		// Hash collision — check the conflict bucket.
-		for _, l := range c.seriesHashConflicts[hash] {
-			if labels.Equal(l, lset) {
+		for _, conflict := range c.seriesHashConflicts[hash] {
+			if conflict.scrapeID == c.scrapeID && labels.Equal(conflict.lset, lset) {
 				return true
 			}
 		}
-		// New series with a colliding hash.
+		// New series with a colliding hash in this iteration.
 		if c.seriesHashConflicts == nil {
-			c.seriesHashConflicts = make(map[uint64][]labels.Labels)
+			c.seriesHashConflicts = make(map[uint64][]hashEntry)
 		}
-		c.seriesHashConflicts[hash] = append(c.seriesHashConflicts[hash], lset)
+		c.seriesHashConflicts[hash] = append(c.seriesHashConflicts[hash], hashEntry{lset: lset, scrapeID: c.scrapeID})
 		return false
 	}
-	c.seriesHashes[hash] = lset
+	c.seriesHashes[hash] = hashEntry{lset: lset, scrapeID: c.scrapeID}
 	return false
+}
+
+// trackHashScrapeAttempt bumps the scrape attempt ID to ensure previous scrape hash state
+// doesn't leak into the next scrape if the previous scrape failed (iterDone skipped).
+func (c *scrapeCache) trackHashScrapeAttempt() {
+	c.scrapeID++
+	// Note: We don't clear seriesHashConflicts map here because it's rarely used.
+	// It's cleared entirely on flushCache.
 }
 
 func (c *scrapeCache) get(met []byte) (*cacheEntry, bool, bool) {
@@ -1671,6 +1695,8 @@ func (sl *scrapeLoopAppender) append(b []byte, contentType string, ts time.Time)
 
 	// Take an appender with limits.
 	app := appenderWithLimits(sl.Appender, sl.sampleLimit, sl.bucketLimit, sl.maxSchema)
+
+	sl.cache.trackHashScrapeAttempt()
 
 	defer func() {
 		if err != nil {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -912,6 +912,10 @@ type scrapeCache struct {
 	seriesCur  map[storage.SeriesRef]*cacheEntry
 	seriesPrev map[storage.SeriesRef]*cacheEntry
 
+	// Cache of post-relabeling hashes seen in the current scrape iteration.
+	// Used to detect duplicate labels after relabeling.
+	seriesHashes map[uint64]struct{}
+
 	// TODO(bwplotka): Consider moving metadata caching to head. See
 	// https://github.com/prometheus/prometheus/issues/17619.
 	metaMtx  sync.Mutex            // Mutex is needed due to api touching it when metadata is queried.
@@ -939,6 +943,7 @@ func newScrapeCache(metrics *scrapeMetrics) *scrapeCache {
 		droppedSeries: map[string]*uint64{},
 		seriesCur:     map[storage.SeriesRef]*cacheEntry{},
 		seriesPrev:    map[storage.SeriesRef]*cacheEntry{},
+		seriesHashes:  map[uint64]struct{}{},
 		metadata:      map[string]*metaEntry{},
 		metrics:       metrics,
 	}
@@ -989,6 +994,7 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 	// Swap current and previous series then clear the new current, to save allocations.
 	c.seriesPrev, c.seriesCur = c.seriesCur, c.seriesPrev
 	clear(c.seriesCur)
+	clear(c.seriesHashes)
 
 	c.iter++
 }
@@ -1699,7 +1705,7 @@ loop:
 		if sl.cache.getDropped(met) {
 			continue
 		}
-		ce, seriesCached, seriesAlreadyScraped := sl.cache.get(met)
+		ce, seriesCached, _ := sl.cache.get(met)
 		var (
 			ref  storage.SeriesRef
 			hash uint64
@@ -1711,10 +1717,8 @@ loop:
 			hash = ce.hash
 		} else {
 			p.Labels(&lset)
-			hash = lset.Hash()
 
-			// Hash label set as it is seen local to the target. Then add target labels
-			// and relabeling and store the final label set.
+			// Add target labels and relabeling and store the final label set.
 			lset = sl.sampleMutator(lset)
 
 			// The label set may be set to empty to indicate dropping.
@@ -1737,9 +1741,20 @@ loop:
 				sl.metrics.targetScrapePoolExceededLabelLimits.Inc()
 				break loop
 			}
+
+			hash = lset.Hash()
 		}
 
-		if seriesAlreadyScraped && parsedTimestamp == nil {
+		var isDuplicate bool
+		if parsedTimestamp == nil {
+			if _, ok := sl.cache.seriesHashes[hash]; ok {
+				isDuplicate = true
+			} else {
+				sl.cache.seriesHashes[hash] = struct{}{}
+			}
+		}
+
+		if isDuplicate {
 			err = storage.ErrDuplicateSampleForTimestamp
 		} else {
 			if sl.enableSTZeroIngestion {

--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -203,7 +203,7 @@ loop:
 		if sl.cache.getDropped(met) {
 			continue
 		}
-		ce, seriesCached, seriesAlreadyScraped := sl.cache.get(met)
+		ce, seriesCached, _ := sl.cache.get(met)
 		var (
 			ref  storage.SeriesRef
 			hash uint64
@@ -215,10 +215,8 @@ loop:
 			hash = ce.hash
 		} else {
 			p.Labels(&lset)
-			hash = lset.Hash()
 
-			// Hash label set as it is seen local to the target. Then add target labels
-			// and relabeling and store the final label set.
+			// Add target labels and relabeling and store the final label set.
 			lset = sl.sampleMutator(lset)
 
 			// The label set may be set to empty to indicate dropping.
@@ -241,11 +239,22 @@ loop:
 				sl.metrics.targetScrapePoolExceededLabelLimits.Inc()
 				break loop
 			}
+
+			hash = lset.Hash()
 		}
 
 		exemplars = exemplars[:0] // Reset and reuse the exemplar slice.
 
-		if seriesAlreadyScraped && parsedTimestamp == nil {
+		var isDuplicate bool
+		if parsedTimestamp == nil {
+			if _, ok := sl.cache.seriesHashes[hash]; ok {
+				isDuplicate = true
+			} else {
+				sl.cache.seriesHashes[hash] = struct{}{}
+			}
+		}
+
+		if isDuplicate {
 			err = storage.ErrDuplicateSampleForTimestamp
 		} else {
 			// Double check we don't append float 0 for

--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -247,11 +247,7 @@ loop:
 
 		var isDuplicate bool
 		if parsedTimestamp == nil {
-			if _, ok := sl.cache.seriesHashes[hash]; ok {
-				isDuplicate = true
-			} else {
-				sl.cache.seriesHashes[hash] = struct{}{}
-			}
+			isDuplicate = sl.cache.isSeriesHashDuplicate(hash, lset)
 		}
 
 		if isDuplicate {

--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -137,6 +137,8 @@ func (sl *scrapeLoopAppenderV2) append(b []byte, contentType string, ts time.Tim
 	// Take an appender with limits.
 	app := appenderV2WithLimits(sl.AppenderV2, sl.sampleLimit, sl.bucketLimit, sl.maxSchema)
 
+	sl.cache.trackHashScrapeAttempt()
+
 	defer func() {
 		if err != nil {
 			return

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -6742,7 +6742,7 @@ func testScrapeLoopSeriesAddedDuplicatesHashCollision(t *testing.T, appV2 bool) 
 	var buf strings.Builder
 	buf.WriteString(ls1.Get(model.MetricNameLabel))
 	buf.WriteString("{")
-	var first = true
+	first := true
 	ls1.Range(func(l labels.Label) {
 		if l.Name == model.MetricNameLabel {
 			return

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -3250,7 +3250,7 @@ func testScrapeLoopAppendSampleLimit(t *testing.T, appV2 bool) {
 	require.NoError(t, app.Rollback())
 	require.Equal(t, 9, total)
 	require.Equal(t, 6, added)
-	require.Equal(t, 1, seriesAdded)
+	require.Equal(t, 0, seriesAdded)
 }
 
 func TestScrapeLoop_HistogramBucketLimit(t *testing.T) {
@@ -6725,6 +6725,46 @@ func labelsWithHashCollision() (labels.Labels, labels.Labels) {
 	}
 
 	return ls1, ls2
+}
+
+// TestScrapeLoopHashStateCleanupOnError tests that post-relabel hash state from a
+// failed scrape does not leak into the next scrape and cause false duplicate
+// detection for a different raw metric that relabels to the same label set.
+// Regression test for https://github.com/prometheus/prometheus/issues/12255
+func TestScrapeLoopHashStateCleanupOnError(t *testing.T) {
+	foreachAppendable(t, func(t *testing.T, appV2 bool) {
+		testScrapeLoopHashStateCleanupOnError(t, appV2)
+	})
+}
+
+func testScrapeLoopHashStateCleanupOnError(t *testing.T, appV2 bool) {
+	sl, _ := newTestScrapeLoop(t, withAppendable(teststorage.NewAppendable(), appV2), func(sl *scrapeLoop) {
+		sl.sampleMutator = func(l labels.Labels) labels.Labels {
+			b := labels.NewBuilder(l)
+			b.Del("drop")
+			return b.Labels()
+		}
+	})
+
+	// First scrape: record a post-relabel hash for metric{}, then fail due to sample_limit
+	// on a metric with a different post-relabel label set.
+	sl.sampleLimit = 1
+	app := sl.appender()
+	_, _, _, err := app.append([]byte("metric{drop=\"a\"} 1\nmetric{keep=\"x\"} 1\n"), "text/plain", time.Time{})
+	require.ErrorIs(t, err, errSampleLimit)
+	require.NoError(t, app.Rollback())
+
+	// Second scrape: a different raw metric relabels to the same label set as scrape 1.
+	// It must not be treated as a duplicate because of stale hash state.
+	sl.sampleLimit = 0
+	app = sl.appender()
+	total, added, seriesAdded, err := app.append([]byte("metric{drop=\"b\"} 1\n"), "text/plain", time.Time{})
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+	require.Equal(t, 1, total)
+	require.Equal(t, 1, added)
+	require.Equal(t, 1, seriesAdded)
+	require.Equal(t, 0.0, prom_testutil.ToFloat64(sl.metrics.targetScrapeSampleDuplicate))
 }
 
 func TestScrapeLoopSeriesAddedDuplicates_HashCollision(t *testing.T) {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -6681,6 +6681,34 @@ func testScrapeLoopSeriesAddedDuplicates(t *testing.T, appV2 bool) {
 	require.Equal(t, 4.0, prom_testutil.ToFloat64(sl.metrics.targetScrapeSampleDuplicate))
 }
 
+func TestScrapeLoopSeriesAddedDuplicates_MetricRelabeling(t *testing.T) {
+	foreachAppendable(t, func(t *testing.T, appV2 bool) {
+		testScrapeLoopSeriesAddedDuplicates_MetricRelabeling(t, appV2)
+	})
+}
+
+func testScrapeLoopSeriesAddedDuplicates_MetricRelabeling(t *testing.T, appV2 bool) {
+	sl, _ := newTestScrapeLoop(t, withAppendable(teststorage.NewAppendable(), appV2), func(sl *scrapeLoop) {
+		// Mutator drops the "drop" label.
+		sl.sampleMutator = func(l labels.Labels) labels.Labels {
+			b := labels.NewBuilder(l)
+			b.Del("drop")
+			return b.Labels()
+		}
+	})
+
+	// test_metric{drop="a"} and test_metric{drop="b"} both become test_metric{}
+	// Since they map to the same post-relabeling labelset, it should be treated as a duplicate.
+	app := sl.appender()
+	total, added, seriesAdded, err := app.append([]byte("test_metric{drop=\"a\"} 1\ntest_metric{drop=\"b\"} 2\n"), "text/plain", time.Time{})
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+	require.Equal(t, 2, total)
+	require.Equal(t, 2, added)
+	require.Equal(t, 1, seriesAdded) // Only one series should be added.
+	require.Equal(t, 1.0, prom_testutil.ToFloat64(sl.metrics.targetScrapeSampleDuplicate))
+}
+
 // This tests running a full scrape loop and checking that the scrape option
 // `native_histogram_min_bucket_factor` is used correctly.
 func TestNativeHistogramMaxSchemaSet(t *testing.T) {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -6683,11 +6683,11 @@ func testScrapeLoopSeriesAddedDuplicates(t *testing.T, appV2 bool) {
 
 func TestScrapeLoopSeriesAddedDuplicates_MetricRelabeling(t *testing.T) {
 	foreachAppendable(t, func(t *testing.T, appV2 bool) {
-		testScrapeLoopSeriesAddedDuplicates_MetricRelabeling(t, appV2)
+		testScrapeLoopSeriesAddedDuplicatesMetricRelabeling(t, appV2)
 	})
 }
 
-func testScrapeLoopSeriesAddedDuplicates_MetricRelabeling(t *testing.T, appV2 bool) {
+func testScrapeLoopSeriesAddedDuplicatesMetricRelabeling(t *testing.T, appV2 bool) {
 	sl, _ := newTestScrapeLoop(t, withAppendable(teststorage.NewAppendable(), appV2), func(sl *scrapeLoop) {
 		// Mutator drops the "drop" label.
 		sl.sampleMutator = func(l labels.Labels) labels.Labels {

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -6709,6 +6709,82 @@ func testScrapeLoopSeriesAddedDuplicatesMetricRelabeling(t *testing.T, appV2 boo
 	require.Equal(t, 1.0, prom_testutil.ToFloat64(sl.metrics.targetScrapeSampleDuplicate))
 }
 
+func labelsWithHashCollision() (labels.Labels, labels.Labels) {
+	// These two series have the same XXHash; thanks to https://github.com/pstibrany/labels_hash_collisions
+	ls1 := labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
+	ls2 := labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
+
+	if ls1.Hash() != ls2.Hash() {
+		// These ones are the same when using -tags slicelabels
+		ls1 = labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "l6CQ5y")
+		ls2 = labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
+	}
+
+	if ls1.Hash() != ls2.Hash() {
+		panic("This code needs to be updated: find new labels with colliding hash values.")
+	}
+
+	return ls1, ls2
+}
+
+func TestScrapeLoopSeriesAddedDuplicates_HashCollision(t *testing.T) {
+	foreachAppendable(t, func(t *testing.T, appV2 bool) {
+		testScrapeLoopSeriesAddedDuplicatesHashCollision(t, appV2)
+	})
+}
+
+func testScrapeLoopSeriesAddedDuplicatesHashCollision(t *testing.T, appV2 bool) {
+	sl, _ := newTestScrapeLoop(t, withAppendable(teststorage.NewAppendable(), appV2))
+	app := sl.appender()
+
+	ls1, ls2 := labelsWithHashCollision()
+
+	var buf strings.Builder
+	buf.WriteString(ls1.Get(model.MetricNameLabel))
+	buf.WriteString("{")
+	var first = true
+	ls1.Range(func(l labels.Label) {
+		if l.Name == model.MetricNameLabel {
+			return
+		}
+		if !first {
+			buf.WriteString(",")
+		}
+		buf.WriteString(l.Name)
+		buf.WriteString(`="`)
+		buf.WriteString(l.Value)
+		buf.WriteString(`"`)
+		first = false
+	})
+	buf.WriteString("} 1\n")
+
+	buf.WriteString(ls2.Get(model.MetricNameLabel))
+	buf.WriteString("{")
+	first = true
+	ls2.Range(func(l labels.Label) {
+		if l.Name == model.MetricNameLabel {
+			return
+		}
+		if !first {
+			buf.WriteString(",")
+		}
+		buf.WriteString(l.Name)
+		buf.WriteString(`="`)
+		buf.WriteString(l.Value)
+		buf.WriteString(`"`)
+		first = false
+	})
+	buf.WriteString("} 2\n")
+
+	total, added, seriesAdded, err := app.append([]byte(buf.String()), "text/plain", time.Time{})
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+	require.Equal(t, 2, total)
+	require.Equal(t, 2, added)
+	require.Equal(t, 2, seriesAdded) // Both series should be added despite hash collision.
+	require.Equal(t, 0.0, prom_testutil.ToFloat64(sl.metrics.targetScrapeSampleDuplicate))
+}
+
 // This tests running a full scrape loop and checking that the scrape option
 // `native_histogram_min_bucket_factor` is used correctly.
 func TestNativeHistogramMaxSchemaSet(t *testing.T) {


### PR DESCRIPTION
Fixes #12255

## Summary

This change moves duplicate series detection to occur after metric relabeling.

Previously, duplicate detection in the scrape loop was based on the parsed metric before metric relabeling. If metric relabeling transformed multiple scraped metrics into the same final label set, duplicate detection did not occur until the samples reached the TSDB appender.

This change performs duplicate detection using the post-relabel label set by tracking label-set hashes during each scrape iteration, allowing duplicates introduced by metric relabeling to be detected before appending samples to TSDB.

## Changes

- Track post-relabel label-set hashes during each scrape iteration.
- Perform duplicate detection after metric relabeling in both V1 and V2 scrape appenders.
- Clear the per-scrape hash tracker at the end of each scrape iteration.
- Add a regression test covering duplicate label sets introduced by metric relabeling.

#### Release notes for end users

```release-notes
[BUGFIX] Scrape: Detect duplicate series after metric relabeling before appending samples.
```