### PR TITLE
tsdb: call .String() on time.Duration values in structured log fields

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -924,7 +924,7 @@ func (h *Head) Init(minValidTime int64) error {
 		if err != nil {
 			return err
 		}
-		h.logger.Info("WAL segment loaded", "segment", i, "maxSegment", endAt, "duration", time.Since(walSegmentStart))
+		h.logger.Info("WAL segment loaded", "segment", i, "maxSegment", endAt, "duration", time.Since(walSegmentStart).String())
 		h.updateWALReplayStatusRead(i)
 	}
 	walReplayDuration := time.Since(walReplayStart)
@@ -1586,7 +1586,7 @@ func (h *Head) truncateWAL(mint int64) error {
 	h.metrics.walTruncateDuration.Observe(time.Since(start).Seconds())
 
 	h.logger.Info("WAL checkpoint complete",
-		"first", first, "last", last, "duration", time.Since(start))
+		"first", first, "last", last, "duration", time.Since(start).String())
 
 	return nil
 }
@@ -1624,7 +1624,7 @@ func (h *Head) truncateSeriesAndChunkDiskMapper(caller string) error {
 	start := time.Now()
 	headMaxt := h.MaxTime()
 	actualMint, minOOOTime, minMmapFile := h.gc()
-	h.logger.Info("Head GC completed", "caller", caller, "duration", time.Since(start))
+	h.logger.Info("Head GC completed", "caller", caller, "duration", time.Since(start).String())
 	h.metrics.gcDuration.Observe(time.Since(start).Seconds())
 
 	if actualMint > h.minTime.Load() {


### PR DESCRIPTION
Three `logger.Info` calls in `head.go` pass `time.Since(...)` (a
`time.Duration`) directly as a log value. In JSON structured logging, Go's
`log/slog` renders a bare `time.Duration` as its nanosecond integer (e.g.
`1918514118`) rather than a human-readable string like `"1.918s"`. All other
duration fields in `head.go` and `head_wal.go` consistently call `.String()`.

**Affected calls:**
- `"WAL segment loaded"` — `time.Since(walSegmentStart)` (line 927)
- `"WAL checkpoint complete"` — `time.Since(start)` (line 1589)
- `"Head GC completed"` — `time.Since(start)` (line 1627)

Fixes #16766

```release-notes
[BUGFIX] tsdb: Fix WAL and GC log messages to emit human-readable duration strings instead of nanosecond integers.
```