### PR TITLE
relabel: fix Regexp JSON marshaling of the nil/zero value

### DIFF
--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -234,7 +234,14 @@ func (re Regexp) MarshalYAML() (any, error) {
 	return re.String(), nil
 }
 
-// UnmarshalJSON implements the json.Unmarshaler interface.
+// UnmarshalJSON implements the json.Unmarshaler interface. The explicit null
+// handling below mirrors UnmarshalYAML's behaviour, where the yaml library
+// never invokes the Unmarshaler on a null node and leaves *re at its zero
+// value; encoding/json has no such built-in skip, so it is done here. This
+// only matters to external Go callers marshaling Regexp/relabel.Config
+// values directly: Prometheus's own YAML-loaded scrape configs always seed a
+// non-nil default regex before unmarshaling and never round-trip through
+// JSON in that path.
 func (re *Regexp) UnmarshalJSON(b []byte) error {
 	if string(b) == "null" {
 		*re = Regexp{}

--- a/model/relabel/relabel.go
+++ b/model/relabel/relabel.go
@@ -236,6 +236,10 @@ func (re Regexp) MarshalYAML() (any, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (re *Regexp) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		*re = Regexp{}
+		return nil
+	}
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
@@ -250,6 +254,9 @@ func (re *Regexp) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (re Regexp) MarshalJSON() ([]byte, error) {
+	if re.Regexp == nil {
+		return []byte("null"), nil
+	}
 	return json.Marshal(re.String())
 }
 

--- a/model/relabel/relabel_test.go
+++ b/model/relabel/relabel_test.go
@@ -1150,6 +1150,19 @@ func TestRegexp_ShouldMarshalAndUnmarshalZeroValue(t *testing.T) {
 	require.Nil(t, unmarshalled.Regexp)
 }
 
+func TestRegexp_ShouldJSONMarshalAndUnmarshalZeroValue(t *testing.T) {
+	var zero Regexp
+
+	marshalled, err := json.Marshal(&zero)
+	require.NoError(t, err)
+	require.Equal(t, "null", string(marshalled))
+
+	var unmarshalled Regexp
+	err = json.Unmarshal(marshalled, &unmarshalled)
+	require.NoError(t, err)
+	require.Nil(t, unmarshalled.Regexp)
+}
+
 func TestRegexp_JSONUnmarshalThenMarshal(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

None filed. Found while checking for the JSON sibling of #18653, which fixed the same nil/zero
value asymmetry for `Regexp.MarshalYAML`/`UnmarshalYAML` two weeks ago.

`Regexp.MarshalJSON`/`UnmarshalJSON` did not distinguish an unset (nil) regexp from one
explicitly compiled from the empty string: both marshal to the JSON string `""`, and
unmarshaling that (or JSON `null`) back produces a non-nil, compiled empty-pattern regexp
instead of nil. This affects external Go consumers building `relabel.Config{}`/`Regexp{}`
values directly and round-tripping them through JSON; Prometheus's own YAML-loaded scrape
configs always go through `Config.UnmarshalYAML`, which seeds a non-nil default regex, so this
does not affect the server's own JSON API responses in practice.

New test `TestRegexp_ShouldJSONMarshalAndUnmarshalZeroValue` mirrors the existing YAML test.
Fails on unmodified code (`expected: "null", actual: "\"\""`), passes with this change.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] Relabel: Fix Regexp JSON marshaling of the nil/zero value to match the existing YAML behavior.
```
