### PR TITLE
Fix/remote write metadata interval

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1540,6 +1540,9 @@ func (c *RemoteWriteConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := c.QueueConfig.Validate(); err != nil {
 		return err
 	}
+	if c.ProtobufMessage == remoteapi.WriteV1MessageType && c.MetadataConfig.Send && c.MetadataConfig.SendInterval <= 0 {
+		return errors.New("remote write metadata send_interval must be positive")
+	}
 
 	return validateAuthConfigs(c)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2526,6 +2526,14 @@ var expectedErrors = []struct {
 		errMsg:   `remote write queue max_backoff must not be less than min_backoff`,
 	},
 	{
+		filename: "remote_write_metadata_send_interval_zero.bad.yml",
+		errMsg:   `remote write metadata send_interval must be positive`,
+	},
+	{
+		filename: "remote_write_metadata_send_interval_negative.bad.yml",
+		errMsg:   `remote write metadata send_interval must be positive`,
+	},
+	{
 		filename: "remote_read_dup.bad.yml",
 		errMsg:   `found multiple remote read configs with job name "queue1"`,
 	},
@@ -2792,6 +2800,37 @@ func TestBadConfigs(t *testing.T) {
 		_, err := LoadFile("testdata/"+ee.filename, false, promslog.NewNopLogger())
 		require.ErrorContains(t, err, ee.errMsg,
 			"Expected error for %s to contain %q but got: %s", ee.filename, ee.errMsg, err)
+	}
+}
+
+func TestRemoteWriteMetadataSendIntervalUnused(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config string
+	}{
+		{
+			name: "remote write 1 with metadata sending disabled",
+			config: `remote_write:
+  - url: http://localhost:9090/api/v1/write
+    metadata_config:
+      send: false
+      send_interval: 0s
+`,
+		},
+		{
+			name: "remote write 2",
+			config: `remote_write:
+  - url: http://localhost:9090/api/v1/write
+    protobuf_message: io.prometheus.write.v2.Request
+    metadata_config:
+      send_interval: 0s
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load(tc.config, promslog.NewNopLogger())
+			require.NoError(t, err)
+		})
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2531,7 +2531,7 @@ var expectedErrors = []struct {
 	},
 	{
 		filename: "remote_write_metadata_send_interval_negative.bad.yml",
-		errMsg:   `remote write metadata send_interval must be positive`,
+		errMsg:   `not a valid duration string: "-1s"`,
 	},
 	{
 		filename: "remote_read_dup.bad.yml",

--- a/config/testdata/remote_write_metadata_send_interval_negative.bad.yml
+++ b/config/testdata/remote_write_metadata_send_interval_negative.bad.yml
@@ -1,0 +1,5 @@
+remote_write:
+  - url: http://localhost:9090/api/v1/write
+    metadata_config:
+      send: true
+      send_interval: -1s

--- a/config/testdata/remote_write_metadata_send_interval_zero.bad.yml
+++ b/config/testdata/remote_write_metadata_send_interval_zero.bad.yml
@@ -1,0 +1,5 @@
+remote_write:
+  - url: http://localhost:9090/api/v1/write
+    metadata_config:
+      send: true
+      send_interval: 0s

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -662,6 +662,9 @@ func (s *chunkedSeriesSet) Next() bool {
 	res := &prompb.ChunkedReadResponse{}
 
 	err := s.chunkedReader.NextProto(res)
+	if err == nil && len(res.ChunkedSeries) == 0 {
+		err = errors.New("remote read response contains no series")
+	}
 	if err != nil {
 		if !errors.Is(err, io.EOF) {
 			s.err = err

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -1140,6 +1140,26 @@ func TestChunkedSeriesSet(t *testing.T) {
 		require.False(t, res)
 		require.ErrorContains(t, ss.Err(), "proto: illegal wireType 7")
 	})
+
+	t.Run("empty response", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		flusher := &mockFlusher{}
+
+		w := NewChunkedWriter(buf, flusher)
+		respBody := io.NopCloser(buf)
+		r := NewChunkedReader(respBody, config.DefaultChunkedReadLimit, nil)
+
+		b, err := proto.Marshal(&prompb.ChunkedReadResponse{})
+		require.NoError(t, err)
+
+		_, err = w.Write(b)
+		require.NoError(t, err)
+
+		ss := NewChunkedSeriesSet(r, respBody, 0, 14000, func(error) {})
+		require.False(t, ss.Next())
+		require.EqualError(t, ss.Err(), "remote read response contains no series")
+		require.False(t, ss.Next())
+	})
 }
 
 // mockFlusher implements http.Flusher.

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -1141,7 +1141,7 @@ func TestChunkedSeriesSet(t *testing.T) {
 		require.ErrorContains(t, ss.Err(), "proto: illegal wireType 7")
 	})
 
-	t.Run("empty response", func(t *testing.T) {
+	t.Run("response without series", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		flusher := &mockFlusher{}
 
@@ -1149,7 +1149,8 @@ func TestChunkedSeriesSet(t *testing.T) {
 		respBody := io.NopCloser(buf)
 		r := NewChunkedReader(respBody, config.DefaultChunkedReadLimit, nil)
 
-		b, err := proto.Marshal(&prompb.ChunkedReadResponse{})
+		// QueryIndex ensures the marshaled response has a non-empty payload.
+		b, err := proto.Marshal(&prompb.ChunkedReadResponse{QueryIndex: 1})
 		require.NoError(t, err)
 
 		_, err = w.Write(b)


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes #19310 
https://github.com/prometheus/prometheus/issues/19310


#### Why is this needed?

Before this change, a configuration such as:

```yaml
remote_write:
  - url: http://localhost:9090/api/v1/write
    metadata_config:
      send: true
      send_interval: 0s
```

was accepted. When the queue manager started the metadata watcher, the watcher
called `time.NewTicker(0)`, which panicked with `non-positive interval for
NewTicker`. Configuration validation should return an actionable error before
the runtime watcher starts.

#### Release notes for end users

```release-notes
[BUGFIX] Config: Reject non-positive Remote Write metadata intervals before they can panic the metadata watcher.
```