### PR TITLE
histogram: fix Compact corrupting buckets on multiple span merges

### DIFF
--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -1677,6 +1677,22 @@ func TestFloatHistogramCompact(t *testing.T) {
 			},
 		},
 		{
+			"more than one span merged in the same pass",
+			&FloatHistogram{
+				PositiveSpans:   []Span{{-2, 2}, {2, 2}, {2, 2}},
+				PositiveBuckets: []float64{1, 3.3, 4.2, 0.1, 3.3, 2},
+				NegativeSpans:   []Span{{0, 1}, {1, 1}, {1, 1}},
+				NegativeBuckets: []float64{3.1, 1000, 4},
+			},
+			3,
+			&FloatHistogram{
+				PositiveSpans:   []Span{{-2, 10}},
+				PositiveBuckets: []float64{1, 3.3, 0, 0, 4.2, 0.1, 0, 0, 3.3, 2},
+				NegativeSpans:   []Span{{0, 5}},
+				NegativeBuckets: []float64{3.1, 0, 1000, 0, 4},
+			},
+		},
+		{
 			"only empty buckets and maxEmptyBuckets greater zero",
 			&FloatHistogram{
 				PositiveSpans:   []Span{{-4, 6}, {3, 3}},
@@ -1781,6 +1797,26 @@ func TestFloatHistogramCompact(t *testing.T) {
 			require.Equal(t, c.expected, c.in)
 		})
 	}
+}
+
+// TestFloatHistogramKahanCompactSpanMerge makes sure the Kahan compensation
+// terms stay aligned with the buckets they belong to when more than one span is
+// merged in the same pass.
+func TestFloatHistogramKahanCompactSpanMerge(t *testing.T) {
+	h := &FloatHistogram{
+		PositiveSpans:   []Span{{0, 1}, {1, 1}, {1, 1}},
+		PositiveBuckets: []float64{1, 2, 3},
+	}
+	c := &FloatHistogram{
+		PositiveSpans:   []Span{{0, 1}, {1, 1}, {1, 1}},
+		PositiveBuckets: []float64{0.1, 0.2, 0.3},
+	}
+
+	h, c = h.kahanCompact(3, c)
+
+	require.Equal(t, []Span{{0, 5}}, h.PositiveSpans)
+	require.Equal(t, []float64{1, 0, 2, 0, 3}, h.PositiveBuckets)
+	require.Equal(t, []float64{0.1, 0, 0.2, 0, 0.3}, c.PositiveBuckets)
 }
 
 func TestFloatHistogramAdd(t *testing.T) {

--- a/model/histogram/generic.go
+++ b/model/histogram/generic.go
@@ -476,6 +476,7 @@ func compactBuckets[IBC InternalBucketCount](
 		}
 		// Merge span with previous one and insert empty buckets.
 		offset := int(spans[iSpan].Offset)
+		l := int(spans[iSpan].Length)
 		spans[iSpan-1].Length += uint32(offset) + spans[iSpan].Length
 		spans = append(spans[:iSpan], spans[iSpan+1:]...)
 		newPrimaryBuckets := make([]IBC, len(primaryBuckets)+offset)
@@ -493,7 +494,18 @@ func compactBuckets[IBC InternalBucketCount](
 			compensationBuckets = newCompensationBuckets
 		}
 		iBucket += offset
-		currentBucketAbsolute = primaryBuckets[iBucket]
+		// The buckets of the merged span are now part of the previous span, so
+		// iBucket has to skip them as well to keep pointing at the first bucket
+		// of the span we look at next. The inserted empty buckets have reset the
+		// running absolute count to zero, so the deltas of the merged span add up
+		// to the absolute count of its last bucket.
+		if deltaBuckets {
+			currentBucketAbsolute = 0
+			for _, bucket := range primaryBuckets[iBucket : iBucket+l] {
+				currentBucketAbsolute += bucket
+			}
+		}
+		iBucket += l
 		// Note that with many merges, it would be more efficient to
 		// first record all the chunks of empty buckets to insert and
 		// then do it in one go through all the buckets.

--- a/model/histogram/histogram_test.go
+++ b/model/histogram/histogram_test.go
@@ -1259,6 +1259,24 @@ func TestHistogramCompact(t *testing.T) {
 			},
 		},
 		{
+			"more than one span merged in the same pass",
+			&Histogram{
+				Count:           30,
+				PositiveSpans:   []Span{{0, 2}, {2, 2}, {2, 2}},
+				PositiveBuckets: []int64{1, 1, 1, 1, 1, 1},
+				NegativeSpans:   []Span{{0, 1}, {1, 1}, {1, 1}},
+				NegativeBuckets: []int64{2, 1, 1},
+			},
+			3,
+			&Histogram{
+				Count:           30,
+				PositiveSpans:   []Span{{0, 10}},
+				PositiveBuckets: []int64{1, 1, -2, 0, 3, 1, -4, 0, 5, 1},
+				NegativeSpans:   []Span{{0, 5}},
+				NegativeBuckets: []int64{2, -2, 3, -3, 4},
+			},
+		},
+		{
 			"only empty buckets and maxEmptyBuckets greater zero",
 			&Histogram{
 				PositiveSpans:   []Span{{-4, 6}, {3, 3}},
@@ -1409,9 +1427,13 @@ func TestHistogramCompact(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			wasValid := c.in.Validate() == nil
 			require.Equal(t, c.expected, c.in.Compact(c.maxEmptyBuckets))
 			// Compact has happened in-place, too.
 			require.Equal(t, c.expected, c.in)
+			if wasValid {
+				require.NoError(t, c.in.Validate(), "Compact turned a valid histogram into an invalid one")
+			}
 		})
 	}
 }


### PR DESCRIPTION
@krajorama — CODEOWNERS lists you for `/model/histogram`, so tagging you as CONTRIBUTING suggests for a small fix without an existing issue.

The final loop of `compactBuckets` merges spans that are separated by no more than `maxEmptyBuckets` empty buckets. Its invariant is that `iBucket` points at the first bucket of `spans[iSpan]`, which the non-merging branch maintains with `iBucket += l`. The merging branch only did `iBucket += offset`, i.e. it advanced past the empty buckets it inserted but never past the buckets of the span it had just absorbed into the previous one. As soon as a second merge happens in the same pass, it splices its zero fill at a stale position and silently relocates real buckets to wrong indices.

For delta-encoded integer histograms the same statement also left `currentBucketAbsolute` at the *first* bucket of the merged span instead of its last, so the next merge writes `-currentBucketAbsolute` against the wrong baseline and produces negative bucket counts.

Reproduction on `main`:

```go
h := &histogram.Histogram{
	Count:           30,
	PositiveSpans:   []histogram.Span{{0, 2}, {2, 2}, {2, 2}},
	PositiveBuckets: []int64{1, 1, 1, 1, 1, 1},
	NegativeSpans:   []histogram.Span{{0, 1}, {1, 1}, {1, 1}},
	NegativeBuckets: []int64{2, 1, 1},
}
fmt.Println(h.Validate()) // <nil>
h.Compact(3)
fmt.Println(h.Validate()) // negative side: bucket number 3 has observation count of -3: ...
```

and the positive bucket iterator then reports:

```
positive bucket index 4 count 18446744073709551613
positive bucket index 5 count 18446744073709551613
```

A histogram that passes `Validate()` before `Compact` fails it afterwards, and the counts underflow through the `uint64` bucket iterator. `(*FloatHistogram).Compact` hits the same relocation (no negative counts there, since float buckets are absolute — the values simply end up under the wrong indices), and `kahanCompact` shares the `compensationBuckets` splice.

The bug needs at least two merges in one pass, which is why the existing `"everything merged into one span due to maxEmptyBuckets"` cases (two spans, one merge) never caught it.

The fix advances `iBucket` past the merged span's buckets and recomputes `currentBucketAbsolute` from them, mirroring the non-merging branch. I swept the rest of the file for the same pattern: the whole-empty-span removal at the top of the function is correct (its buckets are spliced out of `primaryBuckets` in the same step, so `iBucket` legitimately stays put), and `addBuckets`/`kahanAddBuckets` already advance by the remaining span length. This is the only site with the defect.

Tests: added a `"more than one span merged in the same pass"` case to both `TestHistogramCompact` and `TestFloatHistogramCompact`, a small test covering the Kahan compensation terms (`kahanCompact` is unexported and today only ever called with `maxEmptyBuckets == 0`, which returns before this loop — the test locks the behaviour of the code path being changed), and an assertion in the existing `TestHistogramCompact` loop that `Compact` never turns a `Validate()`-clean histogram into an invalid one. All three fail on `main` and pass with the fix. `go test ./model/... ./promql/... ./tsdb/chunkenc/... ./storage/...` is green, and `golangci-lint` (pinned v2.11.4) reports no issues on `./model/histogram/...`.

#### Which issue(s) does the PR fix:

No existing issue — I found this while reading `compactBuckets`. CONTRIBUTING allows opening a PR directly for a small fix and @-mentioning a maintainer, which I've done above. Happy to file an issue first if you'd prefer.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] histogram: Fix Compact moving buckets to wrong indices, and producing negative bucket counts for integer histograms, when more than one span is merged in the same pass.
```