### PR TITLE
model/labels: fix case-insensitive matching of long alternations

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/grafana/regexp"
 	"github.com/grafana/regexp/syntax"
-	"golang.org/x/text/unicode/norm"
 )
 
 const (
@@ -909,7 +908,7 @@ func (m *equalMultiStringSliceMatcher) Matches(s string) bool {
 // or against a set of prefix matchers.
 type equalMultiStringMapMatcher struct {
 	// values contains values to match a string against. If the matching is case insensitive,
-	// the values here must be lowercase.
+	// the values here are stored in their case folded canonical form, see toFoldedCanonical.
 	values map[string]struct{}
 	// lengthsMask is a bitmask of the lengths of the strings in values.
 	// If the bit at position i is set, it means that there's at least one string of length i in values.
@@ -918,17 +917,20 @@ type equalMultiStringMapMatcher struct {
 	// This can be used to filter case-sensitive values.
 	// Case-insensitive Unicode strings can have different lengths when case folded.
 	lengthsMask uint64
-	// prefixes maps strings, all of length minPrefixLen, to sets of matchers to check the rest of the string.
-	// If the matching is case insensitive, prefixes are all lowercase.
+	// prefixes maps prefixes of length minPrefixLen to sets of matchers to check the rest of the string.
+	// If the matching is case insensitive, prefixes are stored in their case folded canonical form,
+	// see toFoldedCanonical.
 	prefixes map[string][]StringMatcher
-	// minPrefixLen can be zero, meaning there are no prefix matchers.
+	// minPrefixLen can be zero, meaning there are no prefix matchers. It's a number of bytes if the
+	// matching is case sensitive, and a number of runes otherwise: case folding maps runes one to
+	// one, but it does not preserve their encoded length.
 	minPrefixLen  int
 	caseSensitive bool
 }
 
 func (m *equalMultiStringMapMatcher) add(s string) {
 	if !m.caseSensitive {
-		s = toNormalisedLower(s, nil) // Don't pass a stack buffer here - it will always escape to heap.
+		s = toFoldedCanonical(s, nil) // Don't pass a stack buffer here - it will always escape to heap.
 	} else {
 		m.lengthsMask |= lengthMask(s)
 	}
@@ -940,16 +942,12 @@ func (m *equalMultiStringMapMatcher) addPrefix(prefix string, prefixCaseSensitiv
 	if m.minPrefixLen == 0 {
 		panic("addPrefix called when no prefix length defined")
 	}
-	if len(prefix) < m.minPrefixLen {
+	s, ok := m.prefixKey(prefix, nil)
+	if !ok {
 		panic("addPrefix called with a too short prefix")
 	}
 	if m.caseSensitive != prefixCaseSensitive {
 		panic("addPrefix called with a prefix whose case sensitivity is different than the expected one")
-	}
-
-	s := prefix[:m.minPrefixLen]
-	if !m.caseSensitive {
-		s = strings.ToLower(s)
 	}
 
 	m.prefixes[s] = append(m.prefixes[s], matcher)
@@ -975,46 +973,63 @@ func (m *equalMultiStringMapMatcher) Matches(s string) bool {
 		sNorm := s
 		var a [32]byte
 		if !m.caseSensitive {
-			sNorm = toNormalisedLower(s, a[:])
+			sNorm = toFoldedCanonical(s, a[:])
 		}
 		if _, ok := m.values[sNorm]; ok {
 			return true
 		}
 	}
 
-	if m.minPrefixLen > 0 && len(s) >= m.minPrefixLen {
-		prefix := s[:m.minPrefixLen]
+	if m.minPrefixLen > 0 {
 		var a [32]byte
-		if !m.caseSensitive {
-			prefix = toNormalisedLower(s[:m.minPrefixLen], a[:])
-		}
-		for _, matcher := range m.prefixes[prefix] {
-			if matcher.Matches(s) {
-				return true
+		if prefix, ok := m.prefixKey(s, a[:]); ok {
+			for _, matcher := range m.prefixes[prefix] {
+				if matcher.Matches(s) {
+					return true
+				}
 			}
 		}
 	}
 	return false
 }
 
-// toNormalisedLower normalise the input string using "Unicode Normalization Form D" and then convert
-// it to lower case.
-func toNormalisedLower(s string, a []byte) string {
+// prefixKey returns the key under which the matchers whose prefix may match s
+// are stored in the prefixes map, and whether s is long enough to have one.
+// The optional buffer a is used to avoid an allocation if it's big enough.
+func (m *equalMultiStringMapMatcher) prefixKey(s string, a []byte) (string, bool) {
+	if m.caseSensitive {
+		if len(s) < m.minPrefixLen {
+			return "", false
+		}
+		return s[:m.minPrefixLen], true
+	}
+	return toFoldedCanonicalPrefix(s, m.minPrefixLen, a)
+}
+
+// toFoldedCanonical returns the canonical form of s under Unicode simple case
+// folding, which is the folding the regexp engine applies for case-insensitive
+// matching: every rune is replaced by the canonical rune of the set of runes it
+// folds with, see toFoldedCanonicalRune. Two strings have the same canonical
+// form if and only if the regexp engine considers them equal ignoring case, so
+// e.g. "ſtreet" and "STREET" both canonicalise to "street".
+// The optional buffer a is used to avoid an allocation if it's big enough.
+func toFoldedCanonical(s string, a []byte) string {
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		if c >= utf8.RuneSelf {
-			return strings.Map(unicode.ToLower, norm.NFKD.String(s))
+			return toFoldedCanonicalSlow(s, a)
 		}
 		if 'A' <= c && c <= 'Z' {
-			return toNormalisedLowerSlow(s, i, a)
+			return toFoldedCanonicalASCII(s, i, a)
 		}
 	}
 	return s
 }
 
-// toNormalisedLowerSlow is split from toNormalisedLower because having a call
-// to `copy` slows it down even when it is not called.
-func toNormalisedLowerSlow(s string, i int, a []byte) string {
+// toFoldedCanonicalASCII canonicalises s, which is ASCII up to the byte at
+// index i. It is split from toFoldedCanonical because having a call to `copy`
+// slows it down even when it is not called.
+func toFoldedCanonicalASCII(s string, i int, a []byte) string {
 	var buf []byte
 	if cap(a) > len(s) {
 		buf = a[:len(s)]
@@ -1025,13 +1040,95 @@ func toNormalisedLowerSlow(s string, i int, a []byte) string {
 	for ; i < len(s); i++ {
 		c := s[i]
 		if c >= utf8.RuneSelf {
-			return strings.Map(unicode.ToLower, norm.NFKD.String(s))
+			// Start over, runes have to be canonicalised one by one. The buffer
+			// can be reused because the slow path reads from s.
+			return toFoldedCanonicalSlow(s, a)
 		}
 		if 'A' <= c && c <= 'Z' {
 			buf[i] = c + 'a' - 'A'
 		}
 	}
 	return yoloString(buf)
+}
+
+// toFoldedCanonicalSlow canonicalises s rune by rune. It is only used when s
+// contains a non-ASCII rune, as ranging over runes is slower than scanning
+// bytes.
+func toFoldedCanonicalSlow(s string, a []byte) string {
+	buf := foldingBuffer(a, len(s))
+	for _, r := range s {
+		buf = utf8.AppendRune(buf, toFoldedCanonicalRune(r))
+	}
+	return yoloString(buf)
+}
+
+// toFoldedCanonicalPrefix returns the canonical form (see toFoldedCanonical) of
+// the first n runes of s, and whether s has at least n runes. Prefixes are
+// measured in runes because case folding maps runes one to one, while it does
+// not preserve their encoded length: 'k' folds with 'K' (Kelvin sign, U+212A),
+// which is 3 bytes long.
+func toFoldedCanonicalPrefix(s string, n int, a []byte) (string, bool) {
+	// Fast path: if the first n bytes are ASCII then they are also the first n runes.
+	if len(s) >= n {
+		i := 0
+		for ; i < n; i++ {
+			if s[i] >= utf8.RuneSelf {
+				break
+			}
+		}
+		if i == n {
+			return toFoldedCanonical(s[:n], a), true
+		}
+	}
+
+	buf := foldingBuffer(a, len(s))
+	count := 0
+	for _, r := range s {
+		if count == n {
+			break
+		}
+		buf = utf8.AppendRune(buf, toFoldedCanonicalRune(r))
+		count++
+	}
+	if count < n {
+		return "", false
+	}
+	return yoloString(buf), true
+}
+
+// toFoldedCanonicalRune returns the canonical rune of the set of runes r folds
+// with under Unicode simple case folding: the lowest of them, lower cased if it
+// is an ASCII letter. Lower casing keeps ASCII strings, which are the common
+// case, unchanged by the canonicalisation, and it is unambiguous because runes
+// folding with an ASCII letter also fold with its lower case form.
+func toFoldedCanonicalRune(r rune) rune {
+	if r < utf8.RuneSelf {
+		if 'A' <= r && r <= 'Z' {
+			return r + 'a' - 'A'
+		}
+		return r
+	}
+	// The runes folding with each other form a cycle ordered by code point,
+	// which unicode.SimpleFold walks, so the lowest one identifies the cycle.
+	c := r
+	for f := unicode.SimpleFold(r); f != r; f = unicode.SimpleFold(f) {
+		if f < c {
+			c = f
+		}
+	}
+	if 'A' <= c && c <= 'Z' {
+		c += 'a' - 'A'
+	}
+	return c
+}
+
+// foldingBuffer returns an empty buffer with room for size bytes, reusing a if
+// it is large enough.
+func foldingBuffer(a []byte, size int) []byte {
+	if cap(a) >= size {
+		return a[:0]
+	}
+	return make([]byte, 0, size)
 }
 
 // anyStringWithoutNewlineMatcher is a stringMatcher which matches any string
@@ -1130,8 +1227,14 @@ func optimizeEqualOrPrefixStringMatchers(input StringMatcher, threshold int) Str
 			caseSensitive = prefixCaseSensitive
 			caseSensitiveSet = true
 		}
-		if numPrefixes == 0 || len(prefix) < minPrefixLength {
-			minPrefixLength = len(prefix)
+		// Case-insensitive prefixes are keyed by their first minPrefixLength runes
+		// instead of bytes, see equalMultiStringMapMatcher.minPrefixLen.
+		prefixLength := len(prefix)
+		if !prefixCaseSensitive {
+			prefixLength = utf8.RuneCountInString(prefix)
+		}
+		if numPrefixes == 0 || prefixLength < minPrefixLength {
+			minPrefixLength = prefixLength
 		}
 
 		numPrefixes++

--- a/model/labels/regexp_test.go
+++ b/model/labels/regexp_test.go
@@ -115,6 +115,11 @@ var (
 		".*(?i:k)",
 		"a.*(?i:sk)",
 		"(?i:some)-pattern.*",
+		// Case-insensitive alternations long enough to be optimized into a map
+		// of values or of prefixes (see minEqualMultiStringMatcherMapThreshold).
+		"(?i:(fi|v1|v2|v3|v4|v5|v6|v7|v8|v9|v10|v11|v12|v13|v14|v15))",
+		"(?i)(ſ.*|a.*|b.*|c.*|d.*|e.*|f.*|g.*|h.*|i.*|j.*|k.*|l.*|m.*|n.*|o.*)",
+		"(?i)(µx.*|aa.*|bb.*|cc.*|dd.*|ee.*|ff.*|gg.*|hh.*|ii.*|jj.*|kk.*|ll.*|mm.*|nn.*|oo.*)",
 	}
 	values = []string{
 		"foo", " foo bar", "bar", "buzz\nbar", "bar foo", "bfoo", "\n", "\nfoo", "foo\n", "hello foo world", "hello foo\n world", "",
@@ -134,6 +139,13 @@ var (
 		// Values with runes whose case folding changes their encoded length.
 		"\u212a", "\u212aa", "\u212ab", "\u212a-a", "\u212a-abc", "\u212aelvin", "abc\u212a", "a\u212a", "axſk", "axs\u212a",
 		"ſome-pattern", "SOME-pattern", "ſk", "kſ",
+		"ſx", "ſX", "SX", "Sx",
+
+		// Values that are equal to a pattern literal under Unicode compatibility
+		// normalisation, but not under case folding.
+		"ﬁ", "ｆｉ", "ｆi", "ａ", "①",
+		// The micro sign folds with the Greek mu and its capital form.
+		"µxZ", "μxZ", "ΜxZ", "aaZ",
 
 		// Invalid utf8
 		"\xfefoo",
@@ -334,7 +346,7 @@ func BenchmarkFastRegexMatcher(b *testing.B) {
 	}
 }
 
-func BenchmarkToNormalizedLower(b *testing.B) {
+func BenchmarkToFoldedCanonical(b *testing.B) {
 	benchCase := func(l int, uppercase string, asciiOnly bool, alt int) string {
 		chars := "abcdefghijklmnopqrstuvwxyz"
 		if !asciiOnly {
@@ -371,7 +383,7 @@ func BenchmarkToNormalizedLower(b *testing.B) {
 							b.ResetTimer()
 							for n := 0; b.Loop(); n++ {
 								var a [256]byte
-								toNormalisedLower(inputs[n%len(inputs)], a[:])
+								toFoldedCanonical(inputs[n%len(inputs)], a[:])
 							}
 						})
 					}
@@ -867,6 +879,14 @@ func TestNewEqualMultiStringMatcher(t *testing.T) {
 			expectedValuesMap:   map[string]struct{}{"a": {}, "b": {}, "c": {}, "d": {}, "e": {}, "f": {}, "g": {}, "h": {}, "i": {}, "l": {}, "m": {}, "n": {}, "o": {}, "p": {}, "q": {}, "r": {}},
 			expectedPrefixesMap: map[string][]StringMatcher{},
 		},
+		"many case insensitive values with non-ASCII runes": {
+			// The long s and the Kelvin sign fold with an ASCII letter, and the
+			// micro sign folds with the Greek mu, so they share its canonical form.
+			values:              []string{"\u017f", "\u212a", "\u00b5", "\u03bc", "d", "e", "f", "g", "h", "i", "l", "m", "n", "o", "p", "q"},
+			caseSensitive:       false,
+			expectedValuesMap:   map[string]struct{}{"s": {}, "k": {}, "\u00b5": {}, "d": {}, "e": {}, "f": {}, "g": {}, "h": {}, "i": {}, "l": {}, "m": {}, "n": {}, "o": {}, "p": {}, "q": {}},
+			expectedPrefixesMap: map[string][]StringMatcher{},
+		},
 	}
 
 	for testName, testData := range tests {
@@ -971,6 +991,25 @@ func TestEqualMultiStringMatcher_Matches(t *testing.T) {
 			caseSensitive:      false,
 			expectedMatches:    []string{"a", "A", "b", "B"},
 			expectedNotMatches: []string{"x", "X"},
+		},
+		"many case insensitive values with non-ASCII runes": {
+			// Values are matched under Unicode simple case folding, the same
+			// folding the regexp engine applies: 'ſ' folds with 's' and the
+			// micro sign folds with the Greek mu, while the 'ﬁ' ligature and
+			// the fullwidth 'ａ' fold only with themselves.
+			values:             []string{"ſſs", "µx", "fi", "a", "e", "f", "g", "h", "i", "l", "m", "n", "o", "p", "q", "r"},
+			caseSensitive:      false,
+			expectedMatches:    []string{"ſſs", "sss", "SSS", "ſSs", "µx", "μX", "ΜX", "fi", "FI", "a", "A"},
+			expectedNotMatches: []string{"ﬁ", "ｆｉ", "ａ", "x", "X"},
+		},
+		"case insensitive prefixes with multi-byte runes": {
+			prefixes: []StringMatcher{
+				&literalPrefixInsensitiveStringMatcher{prefix: "ſ", right: anyStringWithoutNewlineMatcher{}},
+				&literalPrefixInsensitiveStringMatcher{prefix: "µx", right: anyStringWithoutNewlineMatcher{}},
+			},
+			caseSensitive:      false,
+			expectedMatches:    []string{"ſ", "ſx", "S", "sX", "µx", "μX", "ΜXy"},
+			expectedNotMatches: []string{"ﬁ", "x", "µy"},
 		},
 		"mixed values and prefixes": {
 			values:             []string{"a"},
@@ -1503,7 +1542,7 @@ func visitStringMatcher(matcher StringMatcher, callback func(matcher StringMatch
 	}
 }
 
-func TestToNormalisedLower(t *testing.T) {
+func TestToFoldedCanonical(t *testing.T) {
 	testCases := map[string]string{
 		"foo":                      "foo",
 		"FOO":                      "foo",
@@ -1514,9 +1553,53 @@ func TestToNormalisedLower(t *testing.T) {
 		"cccccccccccccccccccccccC": "cccccccccccccccccccccccc",
 		"ſſſſſſſſſſſſſſſſſſſſſſſſS": "sssssssssssssssssssssssss",
 		"ſſAſſa": "ssassa",
+		// Runes folding with each other have the same canonical form, even when
+		// their encoded length differs.
+		"\u212aelvin": "kelvin",
+		"\u00b5x":     "\u00b5x",
+		"\u03bcx":     "\u00b5x",
+		"\u039cX":     "\u00b5x",
+		// Runes that only compatibility normalisation would fold together keep
+		// their own canonical form, as the regexp engine tells them apart.
+		"\ufb01":  "\ufb01",
+		"\uff41":  "\uff21",
+		"\u2460":  "\u2460",
+		"e\u0301": "e\u0301",
+		"\u00e9":  "\u00c9",
 	}
 	for input, expectedOutput := range testCases {
-		require.Equal(t, expectedOutput, toNormalisedLower(input, nil))
+		require.Equal(t, expectedOutput, toFoldedCanonical(input, nil), "input: %q", input)
+	}
+}
+
+func TestToFoldedCanonicalPrefix(t *testing.T) {
+	for _, c := range []struct {
+		s              string
+		n              int
+		expectedPrefix string
+		expectedOK     bool
+	}{
+		{"marco", 3, "mar", true},
+		{"mArco", 3, "mar", true},
+		{"marco", 5, "marco", true},
+		{"marco", 6, "", false},
+		{"", 1, "", false},
+		{"marco", 0, "", true},
+		// The prefix is a number of runes, not of bytes.
+		{"\u017fx", 1, "s", true},
+		{"\u017fx", 2, "sx", true},
+		{"\u017fx", 3, "", false},
+		{"\u212aelvin", 1, "k", true},
+		{"\u00b5xy", 2, "\u00b5x", true},
+		{"\u039cxy", 2, "\u00b5x", true},
+		// Every byte of an invalid rune is decoded to U+FFFD, like the regexp
+		// engine does.
+		{"\xff\xff", 2, "\ufffd\ufffd", true},
+		{"\xff", 2, "", false},
+	} {
+		prefix, ok := toFoldedCanonicalPrefix(c.s, c.n, nil)
+		require.Equal(t, c.expectedOK, ok, "s=%q n=%d", c.s, c.n)
+		require.Equal(t, c.expectedPrefix, prefix, "s=%q n=%d", c.s, c.n)
 	}
 }
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

No open issue. Found while reading the case-folding fix in #19167; this is the same bug class in the remaining matcher, and the follow-up to #14170 / #14066 (where @bboreham already suggested `unicode.SimpleFold`).

#### What this PR does

Alternations of 16 or more values or prefixes (`minEqualMultiStringMatcherMapThreshold`) are matched by `equalMultiStringMapMatcher`, which looks the value up in a map keyed by its normalised form. For case-insensitive matching that form was `toNormalisedLower()`: NFKD compatibility normalisation followed by `unicode.ToLower()`. `FastRegexMatcher.MatchString()` returns the string matcher's answer directly, with no fallback to `m.re`, so wherever that normalisation disagrees with the regexp engine's Unicode simple case folding the matcher disagrees with its own regexp. It does so in both directions:

* **NFKD folds together runes the regexp engine keeps apart**, so the matcher returns series a query must not return. With 16 alternatives, `(?i)(fi|v1|…|v15)` matched `ﬁ` (U+FB01), `(?i)(a|…)` matched fullwidth `ａ` (U+FF41), and `(?i)(é|…)` matched the decomposed `é`. RE2 rejects all three.
* **`ToLower()` does not fold runes the regexp engine folds together**, and `addPrefix()` keyed the prefixes map with `strings.ToLower()` while `Matches()` looked it up with `toNormalisedLower()`. The two disagree for any non-ASCII prefix (`µ` U+00B5 is unchanged by `ToLower`, but NFKD+`ToLower` turns it into `μ` U+03BC), so the bucket could never be found: `(?i)(µx.*|aa.*|…)` matched neither `µxZ`, `μxZ` nor `ΜxZ`.

On top of that `Matches()` sliced the input at `minPrefixLen` **bytes** before normalising it. Case folding maps runes one to one but does not preserve their encoded length, so when the input's first rune is longer than the pattern's, the slice cut a rune in half and no bucket was found: `(?i)(ſ.*|a.*|…)` did not match `ſx`. That is exactly the defect #19167 fixed for the literal prefix/suffix fast paths; `equalMultiStringMapMatcher` was left on the old byte-slicing scheme.

In a query like `foo{bar=~"(?i)(ſ.*|a.*|…)"}` the first two silently drop matching series, and the NFKD one returns series that do not match.

The fix replaces `toNormalisedLower()` with `toFoldedCanonical()`, which maps every rune to the canonical rune of the set of runes it folds with under `unicode.SimpleFold()` — the same folding the regexp engine applies — and keys the prefixes map by the first `minPrefixLen` **runes** instead of bytes. Values differing only by case still collapse to one key, which is what #14170 wanted NFKD for (`ſ` still folds with `s`, and that case stays covered by the tests), but now for exactly the runes RE2 folds together.

The canonical rune is the lowest of the fold set, lower cased when it is an ASCII letter, so ASCII input still goes through the existing allocation-free byte fast path.

#### Tests

* New patterns and values in the shared `regexes`/`values` tables, so `TestFastRegexMatcher_MatchString` cross-checks every case above against `regexp` itself (fails on `main`, passes here).
* New cases in `TestEqualMultiStringMatcher_Matches` and `TestNewEqualMultiStringMatcher`, plus `TestToNormalisedLower` reworked into `TestToFoldedCanonical` and a new `TestToFoldedCanonicalPrefix`. The `ſ`/`s` cases from #14170 are kept unchanged.

#### Benchmarks

`go test ./model/labels/ -run XXX -bench BenchmarkToFoldedCanonical -benchmem -count=5`, medians of the `uppercase=none` cases, `main` vs this branch. The benchmark is renamed along with the function, so on `main` it is `BenchmarkToNormalizedLower`:

| case | main | this PR |
| --- | --- | --- |
| length=100 ascii=true | 46.8 ns, 0 B | 46.9 ns, 0 B |
| length=4000 ascii=true | 1785 ns, 0 B | 1806 ns, 0 B |
| length=100 ascii=false | 1826 ns, 1075 B | 1385 ns, 0 B |
| length=4000 ascii=false | 63701 ns, 17830 B | 52405 ns, 7321 B |

ASCII input is unchanged (within noise, same allocations); non-ASCII input is 6–32% faster and allocates less, since it no longer builds an intermediate NFKD string. This also drops the last use of `golang.org/x/text/unicode/norm` from the package.

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] labels: Fix case-insensitive regex matchers with 16 or more alternations dropping or over-matching series for non-ASCII label values.
```