### PR TITLE
convertnhcb: reject sum-only histograms

### DIFF
--- a/model/textparse/nhcbparse_test.go
+++ b/model/textparse/nhcbparse_test.go
@@ -516,6 +516,84 @@ something_bucket{a="b",le="+Inf"} 9 # {id="something-test"} 2e100 123.000
 	requireEntries(t, exp, got)
 }
 
+func TestNHCBParserDoesNotConvertSumOnlyHistogram(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		keepClassic bool
+		expected    []parsedEntry
+	}{
+		{
+			name: "drop classic histogram",
+			input: `# TYPE sum_only histogram
+sum_only_sum 123.5
+`,
+			expected: []parsedEntry{
+				{
+					m:   "sum_only",
+					typ: model.MetricTypeHistogram,
+				},
+			},
+		},
+		{
+			name: "keep classic histogram",
+			input: `# TYPE sum_only histogram
+sum_only_sum 123.5
+`,
+			keepClassic: true,
+			expected: []parsedEntry{
+				{
+					m:   "sum_only",
+					typ: model.MetricTypeHistogram,
+				},
+				{
+					m:    "sum_only_sum",
+					v:    123.5,
+					lset: labels.FromStrings("__name__", "sum_only_sum"),
+				},
+			},
+		},
+		{
+			name: "convert histogram with count and sum",
+			input: `# TYPE bucketless histogram
+bucketless_sum 123.5
+bucketless_count 42
+`,
+			expected: []parsedEntry{
+				{
+					m:   "bucketless",
+					typ: model.MetricTypeHistogram,
+				},
+				{
+					m: "bucketless",
+					shs: &histogram.Histogram{
+						Schema:          histogram.CustomBucketsSchema,
+						Count:           42,
+						Sum:             123.5,
+						PositiveSpans:   []histogram.Span{{Length: 1}},
+						PositiveBuckets: []int64{42},
+					},
+					lset: labels.FromStrings("__name__", "bucketless"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p, err := New([]byte(test.input), "text/plain", labels.NewSymbolTable(), ParserOptions{
+				ConvertClassicHistogramsToNHCB:          true,
+				KeepClassicOnClassicAndNativeHistograms: test.keepClassic,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, p)
+
+			got := testParse(t, p)
+			requireEntries(t, test.expected, got)
+		})
+	}
+}
+
 // Verify the requirement tables from
 // https://github.com/prometheus/prometheus/issues/13532 .
 // "classic" means the option "always_scrape_classic_histograms".

--- a/util/convertnhcb/convertnhcb.go
+++ b/util/convertnhcb/convertnhcb.go
@@ -28,6 +28,7 @@ var (
 	errNegativeBucketCount = errors.New("bucket count must be non-negative")
 	errNaNBucket           = errors.New("bucket boundary must not be NaN")
 	errNegativeCount       = errors.New("count must be non-negative")
+	errMissingCount        = errors.New("count must be provided when no buckets are present")
 	errCountMismatch       = errors.New("count mismatch")
 	errCountNotCumulative  = errors.New("count is not cumulative")
 )
@@ -144,7 +145,10 @@ func (h TempHistogram) Convert() (*histogram.Histogram, *histogram.FloatHistogra
 		return nil, nil, h.err
 	}
 
-	if !h.hasCount && len(h.buckets) > 0 {
+	if !h.hasCount {
+		if len(h.buckets) == 0 {
+			return nil, nil, errMissingCount
+		}
 		// No count, so set count to the highest known bucket's count.
 		h.count = h.buckets[len(h.buckets)-1].count
 		h.hasCount = true

--- a/util/convertnhcb/convertnhcb_test.go
+++ b/util/convertnhcb/convertnhcb_test.go
@@ -34,11 +34,7 @@ func TestNHCBConvert(t *testing.T) {
 				h := NewTempHistogram()
 				return &h
 			},
-			expectedH: &histogram.Histogram{
-				Schema:          histogram.CustomBucketsSchema,
-				PositiveSpans:   []histogram.Span{},
-				PositiveBuckets: []int64{},
-			},
+			expectedErr: errMissingCount,
 		},
 		"sum only": {
 			setup: func() *TempHistogram {
@@ -46,11 +42,21 @@ func TestNHCBConvert(t *testing.T) {
 				h.SetSum(1000.25)
 				return &h
 			},
+			expectedErr: errMissingCount,
+		},
+		"count and sum without buckets": {
+			setup: func() *TempHistogram {
+				h := NewTempHistogram()
+				h.SetCount(1000)
+				h.SetSum(1000.25)
+				return &h
+			},
 			expectedH: &histogram.Histogram{
 				Schema:          histogram.CustomBucketsSchema,
+				Count:           1000,
 				Sum:             1000.25,
-				PositiveSpans:   []histogram.Span{},
-				PositiveBuckets: []int64{},
+				PositiveSpans:   []histogram.Span{{Length: 1}},
+				PositiveBuckets: []int64{1000},
 			},
 		},
 		"single integer bucket": {


### PR DESCRIPTION
A sum-only classic histogram currently converts to an NHCB with a zero count and nonzero sum.

This change requires either an explicit count or at least one bucket before conversion. Bucket-only histograms still infer their count from the highest bucket. Histograms with `_sum` and `_count` but no explicit buckets remain supported.

Tests cover the converter and text parser with classic retention enabled and disabled. This was surfaced while investigating open-telemetry/opentelemetry-collector-contrib#49892.

#### Which issue(s) does the PR fix:

None filed.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUGFIX] textparse: Reject sum-only classic histograms during NHCB conversion
```