### PR TITLE
scrape: allow embedders to supply a FailureLogger

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -365,6 +365,20 @@ func parseCompressionType(compress bool, compressType compression.Type) compress
 	return compression.None
 }
 
+// newScrapeFailureLogger adapts logging.NewJSONFileLogger to scrape.FailureLogger.
+// NewJSONFileLogger returns a nil *JSONFileLogger when no file is configured, which
+// would become a non-nil interface holding a nil pointer, so map it to an untyped nil.
+func newScrapeFailureLogger(filename string) (scrape.FailureLogger, error) {
+	l, err := logging.NewJSONFileLogger(filename)
+	if err != nil {
+		return nil, err
+	}
+	if l == nil {
+		return nil, nil
+	}
+	return l, nil
+}
+
 func main() {
 	if os.Getenv("DEBUG") != "" {
 		runtime.SetBlockProfileRate(20)
@@ -968,7 +982,7 @@ func main() {
 	scrapeManager, err := scrape.NewManager(
 		&cfg.scrape,
 		logger.With("component", "scrape manager"),
-		logging.NewJSONFileLogger,
+		newScrapeFailureLogger,
 		nil, fanoutStorage,
 		prometheus.DefaultRegisterer,
 	)

--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -34,7 +34,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/features"
-	"github.com/prometheus/prometheus/util/logging"
 	"github.com/prometheus/prometheus/util/osutil"
 	"github.com/prometheus/prometheus/util/pool"
 )
@@ -46,12 +45,17 @@ import (
 //
 // NewManager returns error if both appendable and appendableV2 are specified.
 //
+// newScrapeFailureLogger builds the scrape failure log destination for a given
+// scrape_failure_log_file. It may be nil to disable scrape failure logging.
+// Implementations must return an untyped nil rather than a nil pointer in a
+// non-nil interface. The Manager closes the returned loggers on reload and shutdown.
+//
 // Switch to AppendableV2 is in progress (https://github.com/prometheus/prometheus/issues/17632).
 // storage.Appendable will be removed soon (ETA: Q2 2026).
 func NewManager(
 	o *Options,
 	logger *slog.Logger,
-	newScrapeFailureLogger func(string) (*logging.JSONFileLogger, error),
+	newScrapeFailureLogger func(string) (FailureLogger, error),
 	appendable storage.Appendable,
 	appendableV2 storage.AppendableV2,
 	registerer prometheus.Registerer,
@@ -196,7 +200,7 @@ type Manager struct {
 	mtxScrape              sync.Mutex // Guards the fields below.
 	scrapeConfigs          map[string]*config.ScrapeConfig
 	scrapePools            map[string]*scrapePool
-	newScrapeFailureLogger func(string) (*logging.JSONFileLogger, error)
+	newScrapeFailureLogger func(string) (FailureLogger, error)
 	scrapeFailureLoggers   map[string]FailureLogger
 	targetSets             map[string][]*targetgroup.Group
 	buffers                *pool.Pool

--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -2037,6 +2038,141 @@ func TestManagerReloader(t *testing.T) {
 
 				require.Len(t, findSamplesForMetric(app.ResultSamples(), "expected_metric"), tcase.expectedSamplesTotal)
 			})
+		})
+	}
+}
+
+// recordingFailureLogger is a caller-supplied FailureLogger used to assert that
+// scrape failures reach a destination other than a JSON file.
+type recordingFailureLogger struct {
+	mtx      sync.Mutex
+	messages []string
+	closed   bool
+}
+
+func (*recordingFailureLogger) Enabled(context.Context, slog.Level) bool { return true }
+
+func (l *recordingFailureLogger) Handle(_ context.Context, r slog.Record) error {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	l.messages = append(l.messages, r.Message)
+	return nil
+}
+
+func (l *recordingFailureLogger) WithAttrs([]slog.Attr) slog.Handler { return l }
+
+func (l *recordingFailureLogger) WithGroup(string) slog.Handler { return l }
+
+func (l *recordingFailureLogger) Close() error {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	l.closed = true
+	return nil
+}
+
+func (l *recordingFailureLogger) recorded() []string {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	return slices.Clone(l.messages)
+}
+
+// TestManagerScrapeFailureLoggerFactory verifies that a FailureLogger built by the
+// factory passed to NewManager receives scrape failures.
+func TestManagerScrapeFailureLoggerFactory(t *testing.T) {
+	for _, tcase := range []struct {
+		name         string
+		logFile      string
+		expectCalled bool
+	}{
+		{
+			name:         "failure logger configured",
+			logFile:      "scrape-failures.log",
+			expectCalled: true,
+		},
+		{
+			name:         "no failure logger configured",
+			logFile:      "",
+			expectCalled: false,
+		},
+	} {
+		t.Run(tcase.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			t.Cleanup(srv.Close)
+
+			srvURL, err := url.Parse(srv.URL)
+			require.NoError(t, err)
+
+			recorder := &recordingFailureLogger{}
+			var (
+				keyMtx sync.Mutex
+				keys   []string
+			)
+			newFailureLogger := func(key string) (FailureLogger, error) {
+				keyMtx.Lock()
+				defer keyMtx.Unlock()
+				keys = append(keys, key)
+				return recorder, nil
+			}
+
+			mgr, err := NewManager(
+				&Options{DiscoveryReloadInterval: model.Duration(10 * time.Millisecond)},
+				promslog.NewNopLogger(),
+				newFailureLogger,
+				teststorage.NewAppendable(),
+				nil,
+				prometheus.NewRegistry(),
+			)
+			require.NoError(t, err)
+
+			failureLogLine := ""
+			if tcase.logFile != "" {
+				failureLogLine = "  scrape_failure_log_file: " + tcase.logFile + "\n"
+			}
+			cfg := loadConfiguration(t, fmt.Sprintf(`
+global:
+  scrape_interval: 100ms
+  scrape_timeout: 100ms
+scrape_configs:
+- job_name: failing
+%s`, failureLogLine))
+			require.NoError(t, mgr.ApplyConfig(cfg))
+
+			tsets := make(chan map[string][]*targetgroup.Group)
+			go func() {
+				require.NoError(t, mgr.Run(tsets))
+			}()
+			t.Cleanup(mgr.Stop)
+
+			tsets <- map[string][]*targetgroup.Group{
+				"failing": {{
+					Targets: []model.LabelSet{{model.AddressLabel: model.LabelValue(srvURL.Host)}},
+				}},
+			}
+
+			if !tcase.expectCalled {
+				// The factory must not be consulted when no file is configured,
+				// because the empty key is pre-seeded with a nil logger.
+				require.Eventually(t, func() bool {
+					return len(mgr.TargetsActive()["failing"]) > 0
+				}, 10*time.Second, 50*time.Millisecond, "target was never scraped")
+				keyMtx.Lock()
+				defer keyMtx.Unlock()
+				require.Empty(t, keys)
+				require.Empty(t, recorder.recorded())
+				return
+			}
+
+			require.Eventually(t, func() bool {
+				return len(recorder.recorded()) > 0
+			}, 10*time.Second, 50*time.Millisecond, "scrape failure never reached the supplied FailureLogger")
+
+			require.Contains(t, recorder.recorded()[0], "server returned HTTP status 500")
+
+			keyMtx.Lock()
+			defer keyMtx.Unlock()
+			require.Equal(t, []string{tcase.logFile}, keys)
 		})
 	}
 }


### PR DESCRIPTION
`scrape.NewManager` accepts a factory that must return `*logging.JSONFileLogger`, so the only possible destination for scrape failure logs is a JSON file on disk. Embedders that vendor the scrape package, such as the OpenTelemetry Collector's `prometheusreceiver`, cannot route scrape failures into their own logging stack.

The `scrape.FailureLogger` interface already exists and `*logging.JSONFileLogger` already satisfies it. This widens the factory signature to return that interface instead of the concrete type.

`cmd/prometheus` gains a small adapter around `logging.NewJSONFileLogger`. The adapter matters because `NewJSONFileLogger("")` returns a nil `*JSONFileLogger`, which would otherwise become a non-nil interface holding a nil pointer. It is mapped to an untyped nil, and the contract is documented on `NewManager`.

No behaviour change for Prometheus itself.

## Testing

Added `TestManagerScrapeFailureLoggerFactory`, a table-driven test that supplies a `FailureLogger` through the factory and asserts it receives scrape failures, and that the factory is not consulted when no `scrape_failure_log_file` is set.

All existing `./scrape/...` tests pass. The 12 existing `NewManager` callers pass `nil` for this parameter and are unaffected.

```release-notes
NONE
```
