### PR TITLE
scrape: log failed scrapes at warn level

### DIFF
--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -2039,4 +2040,100 @@ func TestManagerReloader(t *testing.T) {
 			})
 		})
 	}
+}
+
+// levelRecordingHandler captures records emitted through the scrape manager's
+// logger so tests can assert on their severity.
+type levelRecordingHandler struct {
+	mtx     sync.Mutex
+	records []slog.Record
+}
+
+func (*levelRecordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *levelRecordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mtx.Lock()
+	defer h.mtx.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *levelRecordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *levelRecordingHandler) WithGroup(string) slog.Handler { return h }
+
+// find returns the first record with the given message.
+func (h *levelRecordingHandler) find(msg string) (slog.Record, bool) {
+	h.mtx.Lock()
+	defer h.mtx.Unlock()
+	for _, r := range h.records {
+		if r.Message == msg {
+			return r, true
+		}
+	}
+	return slog.Record{}, false
+}
+
+// TestScrapeFailedLogSeverity asserts that a failing scrape is logged at warn level
+// with the underlying error attached.
+func TestScrapeFailedLogSeverity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	srvURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	handler := &levelRecordingHandler{}
+	mgr, err := NewManager(
+		&Options{DiscoveryReloadInterval: model.Duration(10 * time.Millisecond)},
+		slog.New(handler),
+		nil,
+		teststorage.NewAppendable(),
+		nil,
+		prometheus.NewRegistry(),
+	)
+	require.NoError(t, err)
+
+	cfg := loadConfiguration(t, `
+global:
+  scrape_interval: 100ms
+  scrape_timeout: 100ms
+scrape_configs:
+- job_name: failing
+`)
+	require.NoError(t, mgr.ApplyConfig(cfg))
+
+	tsets := make(chan map[string][]*targetgroup.Group)
+	go func() {
+		require.NoError(t, mgr.Run(tsets))
+	}()
+	t.Cleanup(mgr.Stop)
+
+	tsets <- map[string][]*targetgroup.Group{
+		"failing": {{
+			Targets: []model.LabelSet{{model.AddressLabel: model.LabelValue(srvURL.Host)}},
+		}},
+	}
+
+	var rec slog.Record
+	require.Eventually(t, func() bool {
+		var ok bool
+		rec, ok = handler.find("Scrape failed")
+		return ok
+	}, 10*time.Second, 50*time.Millisecond, `no "Scrape failed" record was emitted`)
+
+	require.Equal(t, slog.LevelWarn, rec.Level,
+		"scrape failures must be visible without enabling debug logging")
+
+	var gotErr string
+	rec.Attrs(func(a slog.Attr) bool {
+		if a.Key == "err" {
+			gotErr = a.Value.String()
+			return false
+		}
+		return true
+	})
+	require.Contains(t, gotErr, "401", "the scrape failure reason must be attached to the record")
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1418,7 +1418,9 @@ func (sl *scrapeLoop) scrapeAndReport(last, appendTime time.Time, errc chan<- er
 		}
 		bytesRead = len(b)
 	} else {
-		sl.l.Debug("Scrape failed", "err", scrapeErr)
+		// Warn, not debug: a failing target is an operational problem and its cause
+		// should be visible without enabling debug logging for the whole process.
+		sl.l.Warn("Scrape failed", "err", scrapeErr)
 		sl.scrapeFailureLoggerMtx.RLock()
 		if sl.scrapeFailureLogger != nil {
 			slog.New(sl.scrapeFailureLogger).Error(scrapeErr.Error())


### PR DESCRIPTION
Fixes #19195

A failing scrape is logged at debug level in `scrapeAndReport`:

```go
sl.l.Debug("Scrape failed", "err", scrapeErr)
```

This is the only place the scrape error is reported unless `scrape_failure_log_file` is configured. Enabling debug logging just to learn why a target is down is not practical in production, because it turns on debug output for the entire process.

The effect is worse for embedders. The OpenTelemetry Collector's `prometheusreceiver` runs the scrape manager over a zap core that is usually at warn or info, so the record is dropped and operators see a target go down with no reason attached.

This changes the log to warn level. The error is already attached to the record, so the reason becomes visible at default verbosity.

Note: `scrape_failure_log_file` is unaffected, and targets that fail every interval will now log every interval at warn. If maintainers prefer info here, I am happy to change it.

## Testing

Added `TestScrapeFailedLogSeverity`, which points the manager at a server returning 401, captures records with a `slog.Handler`, and asserts the `Scrape failed` record is at warn level and carries the 401 in its `err` attribute.

Verified the test fails if the level is reverted to debug. All existing `./scrape/...` tests pass.

```release-notes
[ENHANCEMENT] Scrape: log failed scrapes at warn level instead of debug so the failure reason is visible at default verbosity.
```
