### PR TITLE
docs: document request_concurrency for AWS service discovery

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1350,6 +1350,11 @@ filters:
 # This can significantly improve performance when you only need to monitor specific clusters/caches.
 [ clusters: [<string>, ...] ]
 
+# Maximum number of AWS API requests issued concurrently while discovering
+# targets (ecs, elasticache, msk, and rds roles only). The defaults are aligned
+# with the sustained request rate limits of the respective AWS APIs.
+[ request_concurrency: <int> | default = 20 for the ecs role, 10 for the elasticache, msk and rds roles ]
+
 # HTTP client settings, including authentication methods (such as basic auth and
 # authorization), proxy configurations, TLS options, custom HTTP headers, etc.
 [ <http_config> ]


### PR DESCRIPTION
The `ecs`, `elasticache`, `msk` and `rds` roles of `aws_sd_config` accept a `request_concurrency` field:

- `discovery/aws/ecs.go`
- `discovery/aws/elasticache.go`
- `discovery/aws/msk.go`
- `discovery/aws/rds.go`

It does not appear anywhere under `docs/`, so there is currently no way for a user to discover it other than by reading the source. This adds it to the `<aws_sd_config>` reference next to the other role-specific options, following the same style used for `filters` and `clusters`.

The defaults are taken from the code and differ per role: `20` for `ecs`, `10` for `elasticache`, `msk` and `rds`. The code comment in `ecs.go` explains why, so the rationale is summarised in one line rather than repeated in full.

No behaviour change, documentation only.

```release-notes
NONE
```