### PR TITLE
docs: document chunked_read_limit for remote read

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -4087,6 +4087,10 @@ required_matchers:
 # Timeout for requests to the remote read endpoint.
 [ remote_timeout: <duration> | default = 1m ]
 
+# Maximum size, in bytes, of a protobuf frame that Prometheus accepts when
+# reading a streamed (chunked) response from the remote read endpoint.
+[ chunked_read_limit: <int> | default = 5e+7 ]
+
 # Custom HTTP headers to be sent along with each remote read request.
 # Be aware that headers that are set by Prometheus itself can't be overwritten.
 headers:


### PR DESCRIPTION
`RemoteReadConfig` has a `chunked_read_limit` field:

https://github.com/prometheus/prometheus/blob/main/config/config.go#L1680

It has a default of `5e+7` (50MB, described in the code as roughly 100k full XOR chunks and an average labelset), and it is part of `DefaultRemoteReadConfig`. The `<remote_read>` section of the configuration reference documents `url`, `name`, `required_matchers`, `remote_timeout`, `headers`, `read_recent` and `filter_external_labels`, but not this one, so the only way to find it is to read the source.

Added after `remote_timeout`, in the same style as the surrounding entries.

No behaviour change, documentation only.

```release-notes
NONE
```