### PR TITLE
mixin: add alert for scrape pool creation failures

### DIFF
--- a/documentation/prometheus-mixin/alerts.libsonnet
+++ b/documentation/prometheus-mixin/alerts.libsonnet
@@ -346,6 +346,20 @@
             },
           },
           {
+            alert: 'PrometheusScrapePoolCreationFailure',
+            expr: |||
+              increase(prometheus_target_scrape_pools_failed_total{%(prometheusSelector)s}[1h]) > 0
+            ||| % $._config,
+            'for': '0s',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Prometheus has failed to create scrape pools.',
+              description: 'Prometheus %(prometheusName)s has failed to create {{ printf "%%.0f" $value }} scrape pools in the last 1h, so their targets are not scraped.' % $._config,
+            },
+          },
+          {
             alert: 'PrometheusHighQueryLoad',
             expr: |||
               avg_over_time(prometheus_engine_queries{%(prometheusSelector)s}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{%(prometheusSelector)s}[5m]) > 0.8


### PR DESCRIPTION
When Prometheus cannot create a scrape pool, the failure is silent. The job stays in the running configuration, `prometheus_config_last_reload_successful` stays at 1, and the targets of that pool appear in neither the active nor the dropped target list, so from the outside it looks as if the job had never been configured at all. The only trace is one log line per reload, `msg="error creating new scrape pool"`, and `prometheus_target_scrape_pools_failed_total` going up.

None of the existing alerts in this mixin catch it. `PrometheusBadConfig` watches the reload flag, which stays successful because the configuration itself is valid. `PrometheusTargetSyncFailure` watches `prometheus_target_sync_failed_total`, which this failure never increments, because service discovery is not the part that breaks. Every other alert is about scrapes that did happen, and here no scrape is ever attempted.

I ran into this in a scenario where the client certificate of an etcd scrape config was incomplete - only part of it had been copied into the secret - so there was no PEM data to parse, the HTTP client for that pool could not be built and the pool was skipped. The configuration was reported as healthy, every other job kept working, and the etcd metrics were simply absent for two days. What makes it hard to notice is that a missing pool leaves nothing to look at - `up` has no series for the job and the targets page shows neither a healthy nor a failing target, so the job looks as if nobody had ever configured it.

The new alert fires on `increase(prometheus_target_scrape_pools_failed_total[5m]) > 0` with `severity: warning` and `for: 15m`, matching the shape of the neighbouring scrape alerts in this file, so a pool that fails briefly during a reload or a restart stays quiet while a persistently broken one surfaces.

`make -C documentation/prometheus-mixin` passes locally: `jsonnetfmt` reports no diff and `promtool check rules` accepts the generated `prometheus_alerts.yaml`.

/cc @metalmatze

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

None.

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[ENHANCEMENT] Mixin: Add PrometheusScrapePoolCreationFailure alert.
```
