### PR TITLE
scrape: enable start time synthesis for summary _count and _sum metrics

### DIFF
--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"math"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -469,9 +470,14 @@ func (sl *scrapeLoop) checkAndSynthesizeStartTime(
 			return st, val, h, fh, skipAppend, c
 		}
 
-		// TODO(bwplotka): Add support for _count and _sum summary series.
 		switch metadata.Type {
 		case model.MetricTypeCounter, model.MetricTypeHistogram:
+			// Proceed to synthesis.
+		case model.MetricTypeSummary:
+			mName := lset.Get(model.MetricNameLabel)
+			if !strings.HasSuffix(mName, "_count") && !strings.HasSuffix(mName, "_sum") {
+				return st, val, h, fh, skipAppend, c
+			}
 			// Proceed to synthesis.
 		default:
 			return st, val, h, fh, skipAppend, c

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2117,6 +2117,67 @@ test_metric 25
 	require.Empty(t, got, "Expected no samples because the state was cleared and the sample was used to re-anchor")
 }
 
+func TestScrapeLoopAppend_StartTimeSynthesis_Summary(t *testing.T) {
+	ts := time.Now()
+
+	requireSample := func(t *testing.T, s teststorage.Sample, name string, val float64, ts, st int64, isNaN bool) {
+		t.Helper()
+		require.Equal(t, name, s.L.Get(model.MetricNameLabel))
+		require.Equal(t, ts, s.T)
+		if isNaN {
+			require.True(t, value.IsStaleNaN(s.V))
+		} else {
+			require.Equal(t, val, s.V)
+		}
+		require.Equal(t, st, s.ST)
+	}
+
+	s := teststorage.New(t)
+
+	appTest := teststorage.NewAppendable().Then(s)
+	sl, _ := newTestScrapeLoop(t, withAppendable(appTest, true), func(sl *scrapeLoop) {
+		sl.synthesizeST = true
+		sl.parseST = true
+	})
+
+	// First Scrape: Anchor start time for _sum and _count. Quantiles are not cumulative, so quantile is appended directly without anchoring.
+	scrapeA := []byte(`# TYPE test_summary summary
+test_summary{quantile="0.5"} 10
+test_summary_sum 100
+test_summary_count 10
+# EOF
+`)
+	app := sl.appender()
+	_, _, _, err := app.append(scrapeA, "application/openmetrics-text", ts)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	// Quantile should be appended (1 point), _sum and _count should be skipped (anchored).
+	got := appTest.ResultSamples()
+	require.Len(t, got, 1)
+	requireSample(t, got[0], "test_summary", 10, timestamp.FromTime(ts), 0, false)
+
+	// Second Scrape: _sum and _count should yield points with delta values and synthesized ST = ts.
+	ts2 := ts.Add(time.Second)
+	scrapeB := []byte(`# TYPE test_summary summary
+test_summary{quantile="0.5"} 12
+test_summary_sum 150
+test_summary_count 15
+# EOF
+`)
+	app = sl.appender()
+	_, _, _, err = app.append(scrapeB, "application/openmetrics-text", ts2)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	got = appTest.ResultSamples()
+	require.Len(t, got, 4)
+	requireSample(t, got[0], "test_summary", 10, timestamp.FromTime(ts), 0, false)
+	requireSample(t, got[1], "test_summary", 12, timestamp.FromTime(ts2), 0, false)
+	requireSample(t, got[2], "test_summary_sum", 50, timestamp.FromTime(ts2), timestamp.FromTime(ts), false)
+	requireSample(t, got[3], "test_summary_count", 5, timestamp.FromTime(ts2), timestamp.FromTime(ts), false)
+}
+
 func requireSampleHist(t *testing.T, s teststorage.Sample, name, expectedHist string, ts, st int64, isNaN bool) {
 	t.Helper()
 	require.Equal(t, name, s.L.Get(model.MetricNameLabel))


### PR DESCRIPTION
Fixes https://github.com/prometheus/prometheus/issues/14763

This PR enables Start Time (ST) synthesis for Summary metrics (`_count` and `_sum` series) in `scrape_append_v2.go`.

Summary metrics contain cumulative float counters (`_count` and `_sum`) alongside non-cumulative quantile series. This change ensures that when ST synthesis is enabled, `_count` and `_sum` series undergo ST synthesis while quantile series continue to be appended without synthesis.

Added unit test `TestScrapeLoopAppend_StartTimeSynthesis_Summary` to verify this behavior.

## Release notes for end users (ALL commits must be considered).

```release-notes
[ENHANCEMENT] scrape: Enable start time synthesis for summary `_count` and `_sum` series in scrape appender v2.
```