### PR TITLE
discovery/aws: don't panic on Lightsail instances with absent optional fields

### DIFF
--- a/discovery/aws/lightsail.go
+++ b/discovery/aws/lightsail.go
@@ -258,15 +258,31 @@ func (d *LightsailDiscovery) refresh(ctx context.Context) ([]*targetgroup.Group,
 			continue
 		}
 
+		// Every field below is optional in the Lightsail API. Omit the label
+		// when the field is absent rather than dereferencing a nil pointer,
+		// which would panic and take down the whole Prometheus process.
 		labels := model.LabelSet{
-			lightsailLabelAZ:                  model.LabelValue(*inst.Location.AvailabilityZone),
-			lightsailLabelBlueprintID:         model.LabelValue(*inst.BlueprintId),
-			lightsailLabelBundleID:            model.LabelValue(*inst.BundleId),
-			lightsailLabelInstanceName:        model.LabelValue(*inst.Name),
-			lightsailLabelInstanceState:       model.LabelValue(*inst.State.Name),
-			lightsailLabelInstanceSupportCode: model.LabelValue(*inst.SupportCode),
-			lightsailLabelPrivateIP:           model.LabelValue(*inst.PrivateIpAddress),
-			lightsailLabelRegion:              model.LabelValue(d.region),
+			lightsailLabelPrivateIP: model.LabelValue(*inst.PrivateIpAddress),
+			lightsailLabelRegion:    model.LabelValue(d.region),
+		}
+
+		if inst.Location != nil && inst.Location.AvailabilityZone != nil {
+			labels[lightsailLabelAZ] = model.LabelValue(*inst.Location.AvailabilityZone)
+		}
+		if inst.BlueprintId != nil {
+			labels[lightsailLabelBlueprintID] = model.LabelValue(*inst.BlueprintId)
+		}
+		if inst.BundleId != nil {
+			labels[lightsailLabelBundleID] = model.LabelValue(*inst.BundleId)
+		}
+		if inst.Name != nil {
+			labels[lightsailLabelInstanceName] = model.LabelValue(*inst.Name)
+		}
+		if inst.State != nil && inst.State.Name != nil {
+			labels[lightsailLabelInstanceState] = model.LabelValue(*inst.State.Name)
+		}
+		if inst.SupportCode != nil {
+			labels[lightsailLabelInstanceSupportCode] = model.LabelValue(*inst.SupportCode)
 		}
 
 		addr := net.JoinHostPort(*inst.PrivateIpAddress, strconv.Itoa(d.cfg.Port))

--- a/discovery/aws/lightsail_test.go
+++ b/discovery/aws/lightsail_test.go
@@ -1,0 +1,181 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/lightsail"
+	"github.com/aws/aws-sdk-go-v2/service/lightsail/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+// newMockLightsailClient returns an adapter whose GetInstances answers with the
+// supplied instances, so refresh() can be exercised without reaching AWS.
+func newMockLightsailClient(instances []types.Instance) *lightsailClientAdapter {
+	return &lightsailClientAdapter{
+		getInstances: func(_ context.Context, _ *lightsail.GetInstancesInput, _ ...func(*lightsail.Options)) (*lightsail.GetInstancesOutput, error) {
+			return &lightsail.GetInstancesOutput{Instances: instances}, nil
+		},
+	}
+}
+
+func lightsailTestDiscovery(instances []types.Instance) *LightsailDiscovery {
+	return &LightsailDiscovery{
+		lightsail: newMockLightsailClient(instances),
+		cfg:       &LightsailSDConfig{Port: 8080},
+		region:    "us-east-1",
+	}
+}
+
+// fullyPopulatedLightsailInstance is the shape the AWS API returns when every
+// optional field happens to be set. Each subtest below blanks exactly one of
+// them.
+func fullyPopulatedLightsailInstance() types.Instance {
+	return types.Instance{
+		PrivateIpAddress: strptr("10.0.0.1"),
+		BlueprintId:      strptr("ubuntu_22_04"),
+		BundleId:         strptr("nano_2_0"),
+		Name:             strptr("instance-1"),
+		SupportCode:      strptr("support-code-1"),
+		Location:         &types.ResourceLocation{AvailabilityZone: strptr("us-east-1a")},
+		State:            &types.InstanceState{Name: strptr("running")},
+	}
+}
+
+// TestLightsailRefreshFullyPopulated pins the happy path so the nil-handling
+// added for the cases below cannot silently drop labels that used to be set.
+func TestLightsailRefreshFullyPopulated(t *testing.T) {
+	t.Parallel()
+
+	tgs, err := lightsailTestDiscovery([]types.Instance{fullyPopulatedLightsailInstance()}).refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Len(t, tgs[0].Targets, 1)
+
+	target := tgs[0].Targets[0]
+	require.Equal(t, model.LabelValue("10.0.0.1:8080"), target[model.AddressLabel])
+	require.Equal(t, model.LabelValue("us-east-1a"), target[lightsailLabelAZ])
+	require.Equal(t, model.LabelValue("ubuntu_22_04"), target[lightsailLabelBlueprintID])
+	require.Equal(t, model.LabelValue("nano_2_0"), target[lightsailLabelBundleID])
+	require.Equal(t, model.LabelValue("instance-1"), target[lightsailLabelInstanceName])
+	require.Equal(t, model.LabelValue("running"), target[lightsailLabelInstanceState])
+	require.Equal(t, model.LabelValue("support-code-1"), target[lightsailLabelInstanceSupportCode])
+}
+
+// TestLightsailRefreshNilOptionalFields covers instances where the AWS API
+// omitted an optional field. Every field blanked here is a pointer in the SDK
+// (Location and State are pointers to structs whose members are themselves
+// pointers), and refresh() dereferenced all of them without a nil check, so a
+// single missing field panicked the whole Prometheus process during service
+// discovery rather than degrading the target.
+func TestLightsailRefreshNilOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*types.Instance)
+		absent  model.LabelName
+		present map[model.LabelName]model.LabelValue
+	}{
+		{
+			name:   "NilLocation",
+			mutate: func(i *types.Instance) { i.Location = nil },
+			absent: lightsailLabelAZ,
+		},
+		{
+			name:   "NilLocationAvailabilityZone",
+			mutate: func(i *types.Instance) { i.Location = &types.ResourceLocation{} },
+			absent: lightsailLabelAZ,
+		},
+		{
+			name:   "NilState",
+			mutate: func(i *types.Instance) { i.State = nil },
+			absent: lightsailLabelInstanceState,
+		},
+		{
+			name:   "NilStateName",
+			mutate: func(i *types.Instance) { i.State = &types.InstanceState{} },
+			absent: lightsailLabelInstanceState,
+		},
+		{
+			name:   "NilBlueprintId",
+			mutate: func(i *types.Instance) { i.BlueprintId = nil },
+			absent: lightsailLabelBlueprintID,
+		},
+		{
+			name:   "NilBundleId",
+			mutate: func(i *types.Instance) { i.BundleId = nil },
+			absent: lightsailLabelBundleID,
+		},
+		{
+			name:   "NilName",
+			mutate: func(i *types.Instance) { i.Name = nil },
+			absent: lightsailLabelInstanceName,
+		},
+		{
+			name:   "NilSupportCode",
+			mutate: func(i *types.Instance) { i.SupportCode = nil },
+			absent: lightsailLabelInstanceSupportCode,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			inst := fullyPopulatedLightsailInstance()
+			tc.mutate(&inst)
+
+			tgs, err := lightsailTestDiscovery([]types.Instance{inst}).refresh(context.Background())
+			require.NoError(t, err)
+			require.Len(t, tgs, 1)
+			require.Len(t, tgs[0].Targets, 1,
+				"instance must still be discovered when an optional field is absent")
+
+			target := tgs[0].Targets[0]
+			require.NotContains(t, target, tc.absent,
+				"label sourced from the absent field should be omitted")
+			// The instance is still usable: the address is what makes it a target.
+			require.Equal(t, model.LabelValue("10.0.0.1:8080"), target[model.AddressLabel])
+		})
+	}
+}
+
+// TestLightsailRefreshAllOptionalFieldsNil is the serverless-ish worst case:
+// only the private IP is present. It must still yield a scrapeable target.
+func TestLightsailRefreshAllOptionalFieldsNil(t *testing.T) {
+	t.Parallel()
+
+	tgs, err := lightsailTestDiscovery([]types.Instance{
+		{PrivateIpAddress: strptr("10.0.0.9")},
+	}).refresh(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tgs, 1)
+	require.Len(t, tgs[0].Targets, 1)
+
+	target := tgs[0].Targets[0]
+	require.Equal(t, model.LabelValue("10.0.0.9:8080"), target[model.AddressLabel])
+	require.Equal(t, model.LabelValue("us-east-1"), target[lightsailLabelRegion])
+	for _, absent := range []model.LabelName{
+		lightsailLabelAZ,
+		lightsailLabelBlueprintID,
+		lightsailLabelBundleID,
+		lightsailLabelInstanceName,
+		lightsailLabelInstanceState,
+		lightsailLabelInstanceSupportCode,
+	} {
+		require.NotContains(t, target, absent)
+	}
+}


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

There is no dedicated tracking issue for this bug. (The only open Lightsail issue,
#17395, is a request for unit tests, not this panic.)

#### Problem

Lightsail service discovery dereferences seven optional pointer fields when building
the label set for each instance, but guards only one of them. If the Lightsail API
omits any of the other six, `refresh()` panics with a nil pointer dereference.

This is not a degraded-target failure. The panic happens on the discovery manager's
refresh goroutine, so an unrecovered nil deref takes down the entire Prometheus
process — every scrape job, not just Lightsail SD.

#### Root cause

`discovery/aws/lightsail.go` guards `PrivateIpAddress` and then unconditionally
dereferences everything else (line numbers from `main` at b9fdfc32):

```go
256	for _, inst := range output.Instances {
257		if inst.PrivateIpAddress == nil {
258			continue
259		}
260
261		labels := model.LabelSet{
262			lightsailLabelAZ:                  model.LabelValue(*inst.Location.AvailabilityZone),
263			lightsailLabelBlueprintID:         model.LabelValue(*inst.BlueprintId),
264			lightsailLabelBundleID:            model.LabelValue(*inst.BundleId),
265			lightsailLabelInstanceName:        model.LabelValue(*inst.Name),
266			lightsailLabelInstanceState:       model.LabelValue(*inst.State.Name),
267			lightsailLabelInstanceSupportCode: model.LabelValue(*inst.SupportCode),
```

All six are optional in the Lightsail API. Two of them chain through a second
pointer: `Location` is a `*ResourceLocation` and `State` an `*InstanceState`, so
`*inst.Location.AvailabilityZone` panics if either `Location` **or**
`AvailabilityZone` is absent. That is eight distinct nil paths, none checked.

#### Fix

Emit each label only when its source field is present, leaving `PrivateIpAddress`
and `region` — the two fields that are genuinely required to produce a target — in
the literal.

This is the guarding style the same function already uses a few lines further down
for `PublicIpAddress`, `Ipv6Addresses` and tags, so the fix makes the loop
self-consistent rather than introducing a new convention. An instance carrying
nothing but a private IP still yields a scrapeable target instead of killing the
process.

Behavioural delta: labels whose source field is absent are now omitted from the
target rather than being unreachable behind a panic. No label that was previously
populated changes value.

#### Scope — what I deliberately left out

- **`elasticache.go` and `ecs.go` have the same pattern.** `addServerlessCacheTargets`
  (`*cache.ARN`, `*cache.ServerlessCacheName`, `*cache.Status`, `*cache.Engine`, …),
  `addCacheClusterTargets` (`*cluster.ARN`, `*cluster.CacheClusterId`, …) and the ECS
  label literal (`*cluster.ClusterArn`, `*task.Group`, `*task.AvailabilityZone`, …)
  all dereference optional fields in the initial map literal without a guard. I have
  not touched them here, per the scope-discipline guidance in `AGENTS.md` — they are
  separate discovery mechanisms and deserve their own PR with their own tests. Happy
  to follow up if you want them fixed the same way.
- Lightsail `GetInstances` pagination — that is #19180's subject, not this PR's.

#### Relationship to the other open Lightsail PRs

Flagging this up front, since both also create `discovery/aws/lightsail_test.go`:

- **#17529** (add lightsail unit tests, `Fixes #17395`) — tests only, no behaviour
  change, and it adds a `lightsailClient` interface to make the package testable.
  That is no longer necessary: `lightsailClientAdapter` landed in #18818 and already
  makes `refresh()` mockable, which is why this PR needs no production change purely
  for testability.
- **#19180** (paginate `GetInstances`) — touches the client adapter and the
  `refresh()` prologue. It does not touch the label-building loop, so this change is
  orthogonal to it; I confirmed the two diffs do not overlap in `lightsail.go`.

The only real collision is the new test file. I am happy to rebase onto whichever of
those lands first and fold my cases into theirs, or to reshape this as a
behaviour-only diff if you would rather take the tests from #17529.

#### Tests

Adds `discovery/aws/lightsail_test.go` — the package had no Lightsail coverage at
all, which is why this went unnoticed. It follows the existing `ec2_test.go`
convention of driving `d.refresh(ctx)` against a mocked adapter.

- `TestLightsailRefreshFullyPopulated` pins the happy path so the new nil handling
  cannot silently drop labels that used to be set.
- `TestLightsailRefreshNilOptionalFields` is table-driven over all eight nil paths,
  including `Location`/`State` being nil and being present-but-empty.
- `TestLightsailRefreshAllOptionalFieldsNil` is the worst case: only a private IP.

On `main`, with the test file applied but the fix reverted, the suite does not merely
fail — it crashes the test binary:

```
--- FAIL: TestLightsailRefreshAllOptionalFieldsNil (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10487f9c0]

github.com/prometheus/prometheus/discovery/aws.(*LightsailDiscovery).refresh(...)
	discovery/aws/lightsail.go:262 +0x2b0
github.com/prometheus/prometheus/discovery/aws.TestLightsailRefreshAllOptionalFieldsNil(...)
	discovery/aws/lightsail_test.go:163 +0x138
FAIL	github.com/prometheus/prometheus/discovery/aws	0.601s
```

`lightsail.go:262` is the `*inst.Location.AvailabilityZone` line quoted above.

#### Verification

- Baseline on clean `main` (b9fdfc32): `go test ./discovery/...` → **30 packages ok,
  0 failures**.
- With this change: `go test ./discovery/...` → **30 packages ok, 0 failures**.
  Identical; no pre-existing failures in this tree to disambiguate.
- `go test ./discovery/aws/ -run TestLightsail -v` → 10/10 pass.
- `gofmt -l discovery/aws/` clean, `go vet ./discovery/aws/` clean,
  `golangci-lint run discovery/aws/...` (v2.12.2, the pinned version) clean.
- Go 1.26.0, darwin/arm64.

To reproduce the failure yourself:

```bash
git checkout <this-branch>
git checkout main -- discovery/aws/lightsail.go   # revert the fix, keep the tests
go test ./discovery/aws/ -run TestLightsail       # panics at lightsail.go:262
```

#### Release notes for end users (**ALL** commits must be considered).

```release-notes
[BUGFIX] Discovery: Do not panic in AWS Lightsail service discovery when an instance is missing optional fields such as availability zone, blueprint, bundle, name, state or support code.
```
