### PR TITLE
UI: Remove extraneous tick mark in native histogram chart

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/HistogramHelpers.test.ts
+++ b/web/ui/mantine-ui/src/pages/query/HistogramHelpers.test.ts
@@ -1,0 +1,102 @@
+import { findZeroAxisLeft } from "./HistogramHelpers";
+
+describe("findZeroAxisLeft", () => {
+  describe("linear scale", () => {
+    const cases: {
+      name: string;
+      rangeMin: number;
+      rangeMax: number;
+      expected: string;
+    }[] = [
+      {
+        name: "positions the zero axis proportionally when zero is in range",
+        rangeMin: -10,
+        rangeMax: 30,
+        expected: "25%",
+      },
+      {
+        name: "clamps to the left edge for all-positive buckets",
+        rangeMin: 0.001,
+        rangeMax: 1024,
+        expected: "0%",
+      },
+      {
+        name: "clamps to the right edge for all-negative buckets",
+        rangeMin: -1024,
+        rangeMax: -0.001,
+        expected: "100%",
+      },
+      {
+        name: "keeps the left edge when the range starts at zero",
+        rangeMin: 0,
+        rangeMax: 1024,
+        expected: "0%",
+      },
+      {
+        name: "keeps the right edge when the range ends at zero",
+        rangeMin: -1024,
+        rangeMax: 0,
+        expected: "100%",
+      },
+    ];
+
+    for (const c of cases) {
+      test(c.name, () => {
+        expect(
+          findZeroAxisLeft(
+            "linear",
+            c.rangeMin,
+            c.rangeMax,
+            // The remaining arguments are only used by the exponential scale.
+            0,
+            0,
+            -1,
+            0,
+            0,
+            0,
+          ),
+        ).toBe(c.expected);
+      });
+    }
+  });
+
+  describe("exponential scale", () => {
+    test("clamps to the left edge for all-positive buckets", () => {
+      expect(
+        findZeroAxisLeft("exponential", 0.001, 1024, 0.001, 0, -1, 0, 10, 1),
+      ).toBe("0%");
+    });
+
+    test("clamps to the right edge for all-negative buckets", () => {
+      expect(
+        findZeroAxisLeft(
+          "exponential",
+          -1024,
+          -0.001,
+          0,
+          -0.001,
+          -1,
+          10,
+          10,
+          1,
+        ),
+      ).toBe("100%");
+    });
+
+    test("positions the zero axis between the buckets around zero", () => {
+      expect(
+        findZeroAxisLeft(
+          "exponential",
+          -1024,
+          1024,
+          0.001,
+          -0.001,
+          -1,
+          5,
+          20,
+          1,
+        ),
+      ).toBe("25%");
+    });
+  });
+});

--- a/web/ui/mantine-ui/src/pages/query/HistogramHelpers.ts
+++ b/web/ui/mantine-ui/src/pages/query/HistogramHelpers.ts
@@ -86,6 +86,14 @@ export function findZeroAxisLeft(
   expBucketWidth: number
 ): string {
   if (scale === "linear") {
+    // Clamp the zero axis to the chart bounds, otherwise it is rendered
+    // outside of the chart for all-positive or all-negative histograms.
+    if (rangeMin > 0) {
+      return "0%";
+    }
+    if (rangeMax < 0) {
+      return "100%";
+    }
     return ((0 - rangeMin) / (rangeMax - rangeMin)) * 100 + "%";
   } else {
     if (maxNegative === 0) {


### PR DESCRIPTION
For the "linear" display mode, the native histogram chart display code didn't calculate / clamp the minimum X-axis tick mark correctly to 0 (for positive-only histograms), so an additional tick mark was shown outside of the chart to the left.

This makes sure that the range is clamped appropriately.

Old:

<img width="1873" height="875" alt="image" src="https://github.com/user-attachments/assets/e53d884e-d2ef-4e71-a93f-c3cadc3872e3" />

New:

<img width="1875" height="877" alt="image" src="https://github.com/user-attachments/assets/a8d7be45-82e7-44e4-bb9d-4ae06e0ad6d9" />

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[BUGFIX] UI: Remove an extraneous X-axis tick mark in the native histogram chart when using the "linear" display mode.
```
