### PR TITLE
scrape: keep staleness tracking in sync when the series ref changes

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1022,6 +1022,32 @@ func (c *scrapeCache) getDropped(met []byte) bool {
 	return ok
 }
 
+// updateRef points the cache entry at a new storage reference, e.g. because the
+// storage garbage collected the series and had to recreate it. Staleness is tracked
+// per reference, so the tracking has to follow the entry to the new reference,
+// otherwise the series looks like it stopped being exposed and gets a stale marker.
+func (c *scrapeCache) updateRef(ce *cacheEntry, ref storage.SeriesRef) {
+	if ce.ref == ref {
+		return
+	}
+	if ce.ref != 0 {
+		moveStaleness(c.seriesPrev, ce, ref)
+		moveStaleness(c.seriesCur, ce, ref)
+	}
+	ce.ref = ref
+}
+
+// moveStaleness re-keys the staleness tracking of ce from ce.ref to ref. Whether the
+// series is considered stale is left as it is, only the reference it is tracked under
+// changes. Tracking that belongs to another cache entry is left alone.
+func moveStaleness(tracked map[storage.SeriesRef]*cacheEntry, ce *cacheEntry, ref storage.SeriesRef) {
+	if tracked[ce.ref] != ce {
+		return
+	}
+	delete(tracked, ce.ref)
+	tracked[ref] = ce
+}
+
 func (c *scrapeCache) trackStaleness(ref storage.SeriesRef, ce *cacheEntry) {
 	c.seriesCur[ref] = ce
 }
@@ -1775,7 +1801,7 @@ loop:
 		if err == nil {
 			// Append may return a new ref; keep the cache in sync.
 			if ce != nil && ref != 0 {
-				ce.ref = ref
+				sl.cache.updateRef(ce, ref)
 			}
 			if (parsedTimestamp == nil || sl.trackTimestampsStaleness) && ce != nil && ce.ref != 0 {
 				sl.cache.trackStaleness(ce.ref, ce)

--- a/scrape/scrape_append_v2.go
+++ b/scrape/scrape_append_v2.go
@@ -326,7 +326,7 @@ loop:
 				// Append sample to the storage.
 				ref, err = app.Append(ref, lset, st, t, val, h, fh, appOpts)
 				if err == nil && ce != nil && ref != 0 {
-					ce.ref = ref
+					sl.cache.updateRef(ce, ref)
 				}
 			}
 		}

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2914,96 +2914,140 @@ func testScrapeLoopRunCreatesStaleMarkersOnSampleLimit(t *testing.T, appV2 bool)
 	}
 }
 
-// refChangingAppendable simulates a storage backend that returns a new SeriesRef
-// on every Append call, e.g. because the previously handed out ref was evicted
-// from storage in the meantime and the series had to be recreated.
-type refChangingAppendable struct {
-	calls int
-}
-
-func (a *refChangingAppendable) Appender(context.Context) storage.Appender {
-	return &refChangingAppender{a: a}
-}
-
-func (a *refChangingAppendable) AppenderV2(context.Context) storage.AppenderV2 {
-	return &refChangingAppenderV2{a: a}
-}
-
-func (a *refChangingAppendable) nextRef() storage.SeriesRef {
-	a.calls++
-	return storage.SeriesRef(100 * a.calls)
-}
-
-type refChangingAppender struct {
-	a *refChangingAppendable
-}
-
-func (*refChangingAppender) Commit() error                     { return nil }
-func (*refChangingAppender) Rollback() error                   { return nil }
-func (*refChangingAppender) SetOptions(*storage.AppendOptions) {}
-
-func (r *refChangingAppender) Append(storage.SeriesRef, labels.Labels, int64, float64) (storage.SeriesRef, error) {
-	return r.a.nextRef(), nil
-}
-
-func (*refChangingAppender) AppendHistogram(ref storage.SeriesRef, _ labels.Labels, _ int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
-	return ref, nil
-}
-
-func (*refChangingAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, _ labels.Labels, _, _ int64, _ *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
-	return ref, nil
-}
-
-func (*refChangingAppender) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, _ exemplar.Exemplar) (storage.SeriesRef, error) {
-	return ref, nil
-}
-
-func (*refChangingAppender) UpdateMetadata(ref storage.SeriesRef, _ labels.Labels, _ metadata.Metadata) (storage.SeriesRef, error) {
-	return ref, nil
-}
-
-func (*refChangingAppender) AppendSTZeroSample(ref storage.SeriesRef, _ labels.Labels, _, _ int64) (storage.SeriesRef, error) {
-	return ref, nil
-}
-
-type refChangingAppenderV2 struct {
-	a *refChangingAppendable
-}
-
-func (*refChangingAppenderV2) Commit() error   { return nil }
-func (*refChangingAppenderV2) Rollback() error { return nil }
-
-func (r *refChangingAppenderV2) Append(storage.SeriesRef, labels.Labels, int64, int64, float64, *histogram.Histogram, *histogram.FloatHistogram, storage.AppendV2Options) (storage.SeriesRef, error) {
-	return r.a.nextRef(), nil
-}
-
-// TestScrapeLoopCacheRefUpdatedOnChange makes sure that when the storage returns a
-// different SeriesRef than the one the scrape loop cached, the cache is updated to
-// use the new ref on the next scrape rather than keep handing storage a ref it no
-// longer recognizes.
-func TestScrapeLoopCacheRefUpdatedOnChange(t *testing.T) {
+func TestScrapeLoopSeriesRefChange(t *testing.T) {
 	foreachAppendable(t, func(t *testing.T, appV2 bool) {
-		app := &refChangingAppendable{}
-		sl, _ := newTestScrapeLoop(t, withAppendable(app, appV2))
-
-		appender := sl.appender()
-		_, _, _, err := appender.append([]byte("metric_a 1\n"), "text/plain", time.Time{})
-		require.NoError(t, err)
-		require.NoError(t, appender.Commit())
-
-		ce, ok := sl.cache.series["metric_a"]
-		require.True(t, ok)
-		require.Equal(t, storage.SeriesRef(100), ce.ref)
-
-		appender = sl.appender()
-		_, _, _, err = appender.append([]byte("metric_a 2\n"), "text/plain", time.Time{})
-		require.NoError(t, err)
-		require.NoError(t, appender.Commit())
-
-		ce, ok = sl.cache.series["metric_a"]
-		require.True(t, ok)
-		require.Equal(t, storage.SeriesRef(200), ce.ref, "cache should track the new ref returned by the second Append call")
+		testScrapeLoopSeriesRefChange(t, appV2)
 	})
+}
+
+// testScrapeLoopSeriesRefChange tests scrapes against a storage that hands out a new
+// storage.SeriesRef for a series it already gave a reference for, e.g. because the
+// series was garbage collected and had to be recreated. The scrape loop has to pick up
+// the new reference, without mistaking the series for one that stopped being exposed.
+func testScrapeLoopSeriesRefChange(t *testing.T, appV2 bool) {
+	const scrapeInterval = 15 * time.Second
+
+	firstScrape := time.Unix(1600000000, 0)
+	metricA := labels.FromStrings(model.MetricNameLabel, "metric_a")
+
+	scrapeTime := func(scrape int) time.Time {
+		return firstScrape.Add(time.Duration(scrape) * scrapeInterval)
+	}
+	sampleAtMs := func(ms int64, v float64) teststorage.Sample {
+		return teststorage.Sample{L: metricA, T: ms, V: v}
+	}
+	sampleAt := func(scrape int, v float64) teststorage.Sample {
+		return sampleAtMs(timestamp.FromTime(scrapeTime(scrape)), v)
+	}
+	staleAt := func(scrape int) teststorage.Sample {
+		return sampleAt(scrape, math.Float64frombits(value.StaleNaN))
+	}
+
+	// A timestamp the target exposes for the second scrape, one second before that
+	// scrape happens, so it is visible whether the scrape loop honoured it.
+	explicitTS := timestamp.FromTime(scrapeTime(1)) - 1000
+	explicitTSBody := fmt.Sprintf("metric_a 2 %d\n", explicitTS)
+
+	// scrape is a single scrape of the target, together with the reference the storage
+	// hands out while it is appended.
+	type scrape struct {
+		body string
+		ref  storage.SeriesRef
+	}
+
+	for _, tc := range []struct {
+		name string
+
+		scrapes []scrape
+
+		expectedSamples []teststorage.Sample
+		expectedRef     storage.SeriesRef // Reference cached once all scrapes are done.
+	}{
+		{
+			name: "reference stays the same",
+			scrapes: []scrape{
+				{body: "metric_a 1\n", ref: 100},
+				{body: "metric_a 2\n", ref: 100},
+			},
+			expectedSamples: []teststorage.Sample{sampleAt(0, 1), sampleAt(1, 2)},
+			expectedRef:     100,
+		},
+		{
+			name: "reference changes while the series is still exposed",
+			scrapes: []scrape{
+				{body: "metric_a 1\n", ref: 100},
+				{body: "metric_a 2\n", ref: 200},
+				{body: "metric_a 3\n", ref: 200},
+			},
+			expectedSamples: []teststorage.Sample{sampleAt(0, 1), sampleAt(1, 2), sampleAt(2, 3)},
+			expectedRef:     200,
+		},
+		{
+			name: "reference changes on every scrape",
+			scrapes: []scrape{
+				{body: "metric_a 1\n", ref: 100},
+				{body: "metric_a 2\n", ref: 200},
+				{body: "metric_a 3\n", ref: 300},
+			},
+			expectedSamples: []teststorage.Sample{sampleAt(0, 1), sampleAt(1, 2), sampleAt(2, 3)},
+			expectedRef:     300,
+		},
+		{
+			name: "series stops being exposed after the reference changed",
+			scrapes: []scrape{
+				{body: "metric_a 1\n", ref: 100},
+				{body: "metric_a 2\n", ref: 200},
+				{body: "", ref: 200},
+			},
+			expectedSamples: []teststorage.Sample{sampleAt(0, 1), sampleAt(1, 2), staleAt(2)},
+			expectedRef:     200,
+		},
+		// A series that starts carrying an explicit timestamp drops out of the staleness
+		// tracking and gets a stale marker, even though the target still exposes it. The
+		// next two cases pin that down, to make sure a changing reference does not make
+		// the scrape loop behave differently than an unchanged one.
+		{
+			name: "explicit timestamp appears, reference stays the same",
+			scrapes: []scrape{
+				{body: "metric_a 1\n", ref: 100},
+				{body: explicitTSBody, ref: 100},
+			},
+			expectedSamples: []teststorage.Sample{sampleAt(0, 1), sampleAtMs(explicitTS, 2), staleAt(1)},
+			expectedRef:     100,
+		},
+		{
+			name: "explicit timestamp appears and the reference changes",
+			scrapes: []scrape{
+				{body: "metric_a 1\n", ref: 100},
+				{body: explicitTSBody, ref: 200},
+			},
+			expectedSamples: []teststorage.Sample{sampleAt(0, 1), sampleAtMs(explicitTS, 2), staleAt(1)},
+			expectedRef:     200,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ref storage.SeriesRef
+			app := teststorage.NewAppendable().WithRefFn(func(labels.Labels) storage.SeriesRef {
+				return ref
+			})
+			sl, _ := newTestScrapeLoop(t, withAppendable(app, appV2))
+
+			for i, s := range tc.scrapes {
+				ref = s.ref
+
+				appender := sl.appender()
+				_, _, _, err := appender.append([]byte(s.body), "text/plain", scrapeTime(i))
+				require.NoError(t, err)
+				require.NoError(t, appender.Commit())
+			}
+
+			teststorage.RequireEqual(t, tc.expectedSamples, app.ResultSamples())
+
+			ce, ok := sl.cache.series["metric_a"]
+			require.True(t, ok)
+			require.Equal(t, tc.expectedRef, ce.ref)
+		})
+	}
 }
 
 func TestScrapeLoopCache(t *testing.T) {

--- a/util/teststorage/appender.go
+++ b/util/teststorage/appender.go
@@ -182,10 +182,11 @@ func includeStaleNaNs(s []Sample) bool {
 // It allows recording all samples that were added through the appender and injecting errors.
 // Appendable will panic if more than one Appender is open.
 type Appendable struct {
-	appendErrFn          func(ls labels.Labels) error // If non-nil, inject appender error on every Append, AppendHistogram and ST zero calls.
-	appendExemplarsError error                        // If non-nil, inject exemplar error.
-	commitErr            error                        // If non-nil, inject commit error.
-	skipRecording        bool                         // If true, Appendable won't record samples, useful for benchmarks.
+	appendErrFn          func(ls labels.Labels) error             // If non-nil, inject appender error on every Append, AppendHistogram and ST zero calls.
+	refFn                func(ls labels.Labels) storage.SeriesRef // If non-nil, decides the storage.SeriesRef returned by the appender.
+	appendExemplarsError error                                    // If non-nil, inject exemplar error.
+	commitErr            error                                    // If non-nil, inject commit error.
+	skipRecording        bool                                     // If true, Appendable won't record samples, useful for benchmarks.
 
 	mtx           sync.Mutex
 	openAppenders atomic.Int32 // Guard against multi-appender use.
@@ -220,6 +221,16 @@ func (a *Appendable) WithErrs(appendErrFn func(ls labels.Labels) error, appendEx
 	a.appendErrFn = appendErrFn
 	a.appendExemplarsError = appendExemplarsError
 	a.commitErr = commitErr
+	return a
+}
+
+// WithRefFn makes the appender return the storage.SeriesRef given by refFn instead of
+// the label hash based one. It also disables the check that the caller passes back a
+// reference matching the label set, so tests can emulate a storage that hands out a
+// new reference for a series it already handed one out for, e.g. because the series
+// was garbage collected and recreated in the meantime.
+func (a *Appendable) WithRefFn(refFn func(ls labels.Labels) storage.SeriesRef) *Appendable {
+	a.refFn = refFn
 	return a
 }
 
@@ -419,10 +430,14 @@ func (a *appender) Append(ref storage.SeriesRef, ls labels.Labels, t int64, v fl
 		return a.next.Append(ref, ls, t, v)
 	}
 
-	return computeOrCheckRef(ref, ls)
+	return a.a.computeOrCheckRef(ref, ls)
 }
 
-func computeOrCheckRef(ref storage.SeriesRef, ls labels.Labels) (storage.SeriesRef, error) {
+func (a *Appendable) computeOrCheckRef(ref storage.SeriesRef, ls labels.Labels) (storage.SeriesRef, error) {
+	if a.refFn != nil {
+		return a.refFn(ls), nil
+	}
+
 	h := ls.Hash()
 	if ref == 0 {
 		// Use labels hash as a stand-in for unique series reference, to avoid having to track all series.
@@ -457,7 +472,7 @@ func (a *appender) AppendHistogram(ref storage.SeriesRef, ls labels.Labels, t in
 		return a.next.AppendHistogram(ref, ls, t, h, fh)
 	}
 
-	return computeOrCheckRef(ref, ls)
+	return a.a.computeOrCheckRef(ref, ls)
 }
 
 func (a *appender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
@@ -492,7 +507,7 @@ func (a *appender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exem
 	if a.next != nil {
 		return a.next.AppendExemplar(ref, l, e)
 	}
-	return computeOrCheckRef(ref, l)
+	return a.a.computeOrCheckRef(ref, l)
 }
 
 func (a *appender) AppendSTZeroSample(ref storage.SeriesRef, l labels.Labels, _, st int64) (storage.SeriesRef, error) {
@@ -535,7 +550,7 @@ func (a *appender) UpdateMetadata(ref storage.SeriesRef, l labels.Labels, m meta
 	if a.next != nil {
 		return a.next.UpdateMetadata(ref, l, m)
 	}
-	return computeOrCheckRef(ref, l)
+	return a.a.computeOrCheckRef(ref, l)
 }
 
 type appenderV2 struct {
@@ -607,7 +622,7 @@ func (a *appenderV2) Append(ref storage.SeriesRef, ls labels.Labels, st, t int64
 			return 0, err
 		}
 	} else {
-		ref, err = computeOrCheckRef(ref, ls)
+		ref, err = a.a.computeOrCheckRef(ref, ls)
 		if err != nil {
 			return ref, err
 		}


### PR DESCRIPTION
Follow up on #19325.

Staleness is tracked in `scrapeCache.seriesCur`/`seriesPrev`, both keyed by
`storage.SeriesRef`. When the storage hands out a new reference for a series it
already gave one for (e.g. it was garbage collected and had to be recreated), the
scrape loop updates the cached reference and tracks the current scrape under the
new one, while the previous scrape is still tracked under the old one. The old
reference is then missing from the current scrape, so `forEachStale` reports the
series as stale even though the target still exposes it.

The stale marker is appended for `ce.ref`, i.e. for the *new*, live reference, at
the same timestamp as the sample of this scrape. `headAppender.Commit` writes the
WAL before applying samples to the head, so while the head itself drops the
marker as a duplicate, it is already persisted:

```
StaleNaN append at same t returned err=<nil>
WAL sample: ref=1 t=1000 v=1   stale=false
WAL sample: ref=1 t=1000 v=NaN stale=true
```

Remote write and agent mode read the WAL, so they ship the marker downstream and
the series ends there until the next scrape.

This affects appender v2 since the reference was first written back to the cache,
and appender v1 since #19325 made it consistent with v2. v2 is what the Prometheus
binary runs today (`cmd/prometheus/main.go` passes `nil, fanoutStorage` to
`scrape.NewManager`), so the fix is done for both loops.

`scrapeCache.updateRef` now re-keys the staleness tracking to the new reference,
and both scrape loops go through it. It deliberately *moves* the tracking instead
of dropping it: dropping it would suppress the stale marker of a series that is
still exposed but stopped being tracked for another reason in the same scrape,
which would make staleness depend on whether the reference happened to change.
The one case where that is observable is a series that starts carrying an explicit
timestamp, which the last two test cases pin down.

### Tests

`TestScrapeLoopCacheRefUpdatedOnChange` from #19325 is reworked into the table
driven `TestScrapeLoopSeriesRefChange`, which drives a sequence of scrapes and
asserts on the samples the scrape loop appends, not only on the cached reference.
It reuses the `teststorage.Appendable` mock with an injected reference rather than
a purpose built appendable, which is what makes the stale marker visible. All
cases run against both scrape loops:

| case | before | after |
| --- | --- | --- |
| reference stays the same | pass | pass |
| reference changes while the series is still exposed | stale marker | pass |
| reference changes on every scrape | stale marker per change | pass |
| series stops being exposed after the reference changed | extra stale marker | pass |
| explicit timestamp appears, reference stays the same | pass | pass |
| explicit timestamp appears and the reference changes | pass | pass |

The last two agree by construction, which is what keeps `updateRef` from turning
into a plain delete.

Commit 2 adds the test and fails on purpose, commit 3 fixes the bug.

```release-notes
[BUGFIX] Scrape: Do not append a stale marker for a series that is still exposed when the storage returns a new series reference for it.
```
