### PR TITLE
tsdb/index: fix data race in memposting

### DIFF
--- a/tsdb/index/postings.go
+++ b/tsdb/index/postings.go
@@ -28,6 +28,8 @@ import (
 	"time"
 
 	"github.com/bboreham/go-loser"
+	"github.com/cespare/xxhash/v2"
+	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -53,6 +55,21 @@ var ensureOrderBatchPool = sync.Pool{
 	},
 }
 
+// readEpochShards is the number of shards that label names are hashed onto to track which postings lists have been handed out to readers.
+const readEpochShards = 512
+
+// trackedListMinLen is the postings list length from which we track how much of the list readers may have observed, shorter ones are just copied.
+const trackedListMinLen = 1024
+
+// listMeta records how much of a postings list may already have been observed by a reader, so that addFor knows which refs it must not modify in place.
+type listMeta struct {
+	// safeLen is the number of leading refs that may already have been handed out to a reader, refs below it must not be modified.
+	safeLen int
+
+	// epoch is the label name's read epoch when safeLen was last computed, and safeLen must be recomputed once it has moved on.
+	epoch uint64
+}
+
 // MemPostings holds postings list for series ID per label pair. They may be written
 // to out of order.
 // EnsureOrder() must be called once before any reads are done. This allows for quick
@@ -63,10 +80,7 @@ type MemPostings struct {
 	// m holds the postings lists for each label-value pair, indexed first by label name, and then by label value.
 	//
 	// mtx must be held when interacting with m (the appropriate one for reading or writing).
-	// It is safe to retain a reference to a postings list after releasing the lock.
-	//
-	// BUG: There's currently a data race in addFor, which might modify the tail of the postings list:
-	// https://github.com/prometheus/prometheus/issues/15317
+	// It is safe to retain a reference to a postings list after releasing the lock, as refs a reader can see are never modified in place, see addFor.
 	m map[string]map[string][]storage.SeriesRef
 
 	// lvs holds the label values for each label name.
@@ -75,7 +89,30 @@ type MemPostings struct {
 	// Since it's append-only, it is safe to read the label values slice after releasing the lock.
 	lvs map[string][]string
 
+	// readEpochs[i] is incremented by readers holding mtx for reading when they take a postings list of a label name on shard i, so that the increment happens-before the next writer sees it.
+	readEpochs [readEpochShards]atomic.Uint64
+
+	// listMeta tracks reader exposure for postings lists of at least trackedListMinLen refs, mtx must be held for writing when interacting with it.
+	listMeta map[labels.Label]listMeta
+
 	ordered bool
+}
+
+// readEpochShard returns the read epoch shard a label name is tracked on.
+func readEpochShard(name string) uint64 {
+	return xxhash.Sum64String(name) % readEpochShards
+}
+
+// markRead records that the caller is taking a reference to postings lists of the given label name, and must be called while still holding mtx.
+func (p *MemPostings) markRead(name string) {
+	p.readEpochs[readEpochShard(name)].Add(1)
+}
+
+// markAllRead is markRead for callers that take references to the postings lists of every label name.
+func (p *MemPostings) markAllRead() {
+	for i := range p.readEpochs {
+		p.readEpochs[i].Add(1)
+	}
 }
 
 const defaultLabelNamesMapSize = 512
@@ -83,9 +120,10 @@ const defaultLabelNamesMapSize = 512
 // NewMemPostings returns a memPostings that's ready for reads and writes.
 func NewMemPostings() *MemPostings {
 	return &MemPostings{
-		m:       make(map[string]map[string][]storage.SeriesRef, defaultLabelNamesMapSize),
-		lvs:     make(map[string][]string, defaultLabelNamesMapSize),
-		ordered: true,
+		m:        make(map[string]map[string][]storage.SeriesRef, defaultLabelNamesMapSize),
+		lvs:      make(map[string][]string, defaultLabelNamesMapSize),
+		listMeta: map[labels.Label]listMeta{},
+		ordered:  true,
 	}
 }
 
@@ -93,9 +131,10 @@ func NewMemPostings() *MemPostings {
 // until EnsureOrder() was called once.
 func NewUnorderedMemPostings() *MemPostings {
 	return &MemPostings{
-		m:       make(map[string]map[string][]storage.SeriesRef, defaultLabelNamesMapSize),
-		lvs:     make(map[string][]string, defaultLabelNamesMapSize),
-		ordered: false,
+		m:        make(map[string]map[string][]storage.SeriesRef, defaultLabelNamesMapSize),
+		lvs:      make(map[string][]string, defaultLabelNamesMapSize),
+		listMeta: map[labels.Label]listMeta{},
+		ordered:  false,
 	}
 }
 
@@ -318,8 +357,11 @@ func (p *MemPostings) Delete(deleted map[storage.SeriesRef]struct{}, affected ma
 				repl = append(repl, id)
 			}
 		}
+		// repl is a fresh slice that no reader can have a reference to, so what we recorded about the old one no longer applies.
+		delete(p.listMeta, l)
 		if len(repl) > 0 {
 			p.m[l.Name][l.Value] = repl
+			p.resetSafeLen(l, len(repl))
 		} else {
 			delete(p.m[l.Name], l.Value)
 			affectedLabelNames[l.Name] = struct{}{}
@@ -388,6 +430,7 @@ func (p *MemPostings) unlockWaitAndLockAgain() {
 func (p *MemPostings) Iter(f func(labels.Label, Postings) error) error {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
+	p.markAllRead()
 
 	for n, e := range p.m {
 		for v, p := range e {
@@ -430,22 +473,73 @@ func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
 	if !ok {
 		p.lvs[l.Name] = appendWithExponentialGrowth(p.lvs[l.Name], l.Value)
 	}
+	// appendWithExponentialGrowth reallocates when the list is full, and no reader can have a reference to the resulting backing array.
+	copied := cap(vm) < len(vm)+1
 	list := appendWithExponentialGrowth(vm, id)
 	nm[l.Value] = list
 
-	if !p.ordered {
+	// Appending never modifies a ref that a reader can already see, so a list that is still ordered needs no repair, which is by far the common case.
+	if !p.ordered || len(list) == 1 || list[len(list)-1] >= list[len(list)-2] {
+		if copied {
+			// The append reallocated, so nothing in the new backing array has been handed out to a reader yet.
+			p.resetSafeLen(l, len(list))
+		}
 		return
 	}
+
 	// There is no guarantee that no higher ID was inserted before as they may
 	// be generated independently before adding them to postings.
 	// We repair order violations on insert. The invariant is that the first n-1
 	// items in the list are already sorted.
-	for i := len(list) - 1; i >= 1; i-- {
-		if list[i] >= list[i-1] {
-			break
-		}
-		list[i], list[i-1] = list[i-1], list[i]
+	// Repairing the order moves refs that are already in the list, which must not be done to refs a reader may hold, see https://github.com/prometheus/prometheus/issues/15317.
+	at := len(list) - 1
+	for at > 0 && list[at-1] > id {
+		at--
 	}
+
+	if !copied && at < p.safeLen(l, len(list)-1) {
+		// The new ref belongs among refs a reader may already be reading, so insert it into a copy of the list and publish that instead.
+		repl := make([]storage.SeriesRef, len(list), cap(list))
+		copy(repl, list[:at])
+		repl[at] = id
+		copy(repl[at+1:], list[at:len(list)-1])
+		nm[l.Value] = repl
+		p.resetSafeLen(l, len(repl))
+		return
+	}
+
+	// Everything from at onwards is ours to move.
+	copy(list[at+1:], list[at:len(list)-1])
+	list[at] = id
+	if copied {
+		p.resetSafeLen(l, len(list))
+	}
+}
+
+// safeLen returns how many leading refs of l's postings list must not be modified in place, where n is the list length before the append. mtx must be held for writing.
+func (p *MemPostings) safeLen(l labels.Label, n int) int {
+	if n < trackedListMinLen {
+		// Not worth tracking: copying a list this short is cheap, so treat all of it as potentially observed by a reader.
+		return n
+	}
+
+	epoch := p.readEpochs[readEpochShard(l.Name)].Load()
+	meta, ok := p.listMeta[l]
+	if !ok || meta.epoch != epoch {
+		// A reader has taken a postings list of this label name since we last looked, so assume it took this one at its current length.
+		meta = listMeta{safeLen: n, epoch: epoch}
+		p.listMeta[l] = meta
+	}
+	return meta.safeLen
+}
+
+// resetSafeLen records that l's postings list lives in a backing array no reader has a reference to, so all of it may be modified until the next read. mtx must be held for writing.
+func (p *MemPostings) resetSafeLen(l labels.Label, n int) {
+	if n < trackedListMinLen {
+		// Short lists are never tracked and safeLen doesn't consult listMeta for them, so there is nothing to reset, and Delete cleans up any leftover entry.
+		return
+	}
+	p.listMeta[l] = listMeta{safeLen: 0, epoch: p.readEpochs[readEpochShard(l.Name)].Load()}
 }
 
 func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string, match func(string) bool) Postings {
@@ -481,6 +575,7 @@ func (p *MemPostings) PostingsForLabelMatching(ctx context.Context, name string,
 	its := make([]*listPostings, 0, len(vals))
 	lps := make([]listPostings, len(vals))
 	p.mtx.RLock()
+	p.markRead(name)
 	e := p.m[name]
 	for i, v := range vals {
 		if refs, ok := e[v]; ok {
@@ -503,6 +598,7 @@ func (p *MemPostings) Postings(ctx context.Context, name string, values ...strin
 	res := make([]*listPostings, 0, len(values))
 	lps := make([]listPostings, len(values))
 	p.mtx.RLock()
+	p.markRead(name)
 	postingsMapForName := p.m[name]
 	for i, value := range values {
 		if lp := postingsMapForName[value]; lp != nil {
@@ -516,6 +612,7 @@ func (p *MemPostings) Postings(ctx context.Context, name string, values ...strin
 
 func (p *MemPostings) PostingsForAllLabelValues(ctx context.Context, name string) Postings {
 	p.mtx.RLock()
+	p.markRead(name)
 
 	e := p.m[name]
 	its := make([]*listPostings, 0, len(e))

--- a/tsdb/index/postings_test.go
+++ b/tsdb/index/postings_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -1518,4 +1520,186 @@ func TestMemPostings_PostingsForLabelMatchingHonorsContextCancel(t *testing.T) {
 	})
 	require.Error(t, p.Err())
 	require.Equal(t, failAfter+1, ctx.Count()) // Plus one for the Err() call that puts the error in the result.
+}
+
+func TestMemPostings_Unordered_Add_Get(t *testing.T) {
+	mp := NewMemPostings()
+	for ref := storage.SeriesRef(1); ref < 8; ref += 2 {
+		// First, add next series.
+		next := ref + 1
+		mp.Add(next, labels.FromStrings(labels.MetricName, "test", "series", strconv.Itoa(int(next))))
+		nextPostings := mp.Postings(context.Background(), labels.MetricName, "test")
+
+		// Now add current ref.
+		mp.Add(ref, labels.FromStrings(labels.MetricName, "test", "series", strconv.Itoa(int(ref))))
+
+		// Next postings should still reference the next series.
+		nextExpanded, err := ExpandPostings(nextPostings)
+		require.NoError(t, err)
+		require.Len(t, nextExpanded, int(ref))
+		require.Equal(t, next, nextExpanded[len(nextExpanded)-1])
+	}
+}
+
+func TestMemPostings_Concurrent_Add_Get(t *testing.T) {
+	refs := make(chan storage.SeriesRef)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	t.Cleanup(wg.Wait)
+	t.Cleanup(func() { close(refs) })
+
+	mp := NewMemPostings()
+	go func() {
+		defer wg.Done()
+		for ref := range refs {
+			mp.Add(ref, labels.FromStrings(labels.MetricName, "test", "series", strconv.Itoa(int(ref))))
+			p := mp.Postings(context.Background(), labels.MetricName, "test")
+
+			_, err := ExpandPostings(p)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+		}
+	}()
+
+	for ref := storage.SeriesRef(1); ref < 8; ref += 2 {
+		// Add next ref in another goroutine so they would race.
+		refs <- ref + 1
+		// Add current ref here.
+		mp.Add(ref, labels.FromStrings(labels.MetricName, "test", "series", strconv.Itoa(int(ref))))
+
+		// This test only checks that there's no data race, the values are checked in TestMemPostings_Unordered_Add_Get where determinism is easier.
+		p := mp.Postings(context.Background(), labels.MetricName, "test")
+		_, err := ExpandPostings(p)
+		require.NoError(t, err)
+	}
+}
+
+// TestMemPostings_ConcurrentAddGet_LargeList exercises the path where lists are long enough that addFor repairs order violations in place.
+func TestMemPostings_ConcurrentAddGet_LargeList(t *testing.T) {
+	const (
+		readers    = 2
+		writers    = 4
+		perWriter  = 400
+		labelValue = "big"
+	)
+
+	mp := NewMemPostings()
+	// Seed the list well past trackedListMinLen, which is what makes addFor track reader exposure rather than copying on every repair.
+	seeded := storage.SeriesRef(trackedListMinLen * 2)
+	for i := range seeded {
+		mp.Add(i*2, labels.FromStrings("name", labelValue))
+	}
+
+	var (
+		wg      sync.WaitGroup
+		stop    = make(chan struct{})
+		next    atomic.Uint64
+		readIts atomic.Int64
+	)
+	next.Store(uint64(seeded * 2))
+
+	for range writers {
+		wg.Go(func() {
+			for range perWriter {
+				// Grab a ref, then yield before adding it, so writers interleave and produce out-of-order inserts just like the head does.
+				ref := storage.SeriesRef(next.Add(2))
+				runtime.Gosched()
+				mp.Add(ref, labels.FromStrings("name", labelValue))
+			}
+		})
+	}
+
+	var readWG sync.WaitGroup
+	for range readers {
+		readWG.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Expand the postings outside of any lock like a query does, the result must always be sorted and duplicate-free.
+				refs, err := ExpandPostings(mp.Postings(context.Background(), "name", labelValue))
+				if err != nil {
+					t.Errorf("unexpected error: %s", err)
+					return
+				}
+				for i := 1; i < len(refs); i++ {
+					if refs[i] <= refs[i-1] {
+						t.Errorf("postings not strictly sorted at %d: %d then %d", i, refs[i-1], refs[i])
+						return
+					}
+				}
+				readIts.Add(1)
+				// Let the writers get the lock, otherwise they starve and the interesting interleavings never happen.
+				runtime.Gosched()
+			}
+		})
+	}
+
+	wg.Wait()
+	close(stop)
+	readWG.Wait()
+	require.Positive(t, readIts.Load(), "readers never got to read")
+
+	// Every ref that was added must be present exactly once, and in order.
+	refs, err := ExpandPostings(mp.Postings(context.Background(), "name", labelValue))
+	require.NoError(t, err)
+	require.Len(t, refs, int(seeded)+writers*perWriter)
+	require.IsIncreasing(t, refs)
+}
+
+// BenchmarkMemPostings_Add benchmarks adding series to already large postings lists, where repairing an order violation is expensive, see https://github.com/prometheus/prometheus/issues/15317.
+func BenchmarkMemPostings_Add(b *testing.B) {
+	const (
+		seeded = 200000
+		// Out of order refs go back this far at most, the order of magnitude observed for concurrent series creation in the head.
+		maxShift = 256
+	)
+
+	for _, bc := range []struct {
+		name string
+		// outOfOrderEvery is how often an added ref is lower than the previous one.
+		outOfOrderEvery int
+		// readEvery is how often a reader takes a reference to the postings list.
+		readEvery int
+	}{
+		{name: "ordered", outOfOrderEvery: 0, readEvery: 0},
+		{name: "ordered_with_reads", outOfOrderEvery: 0, readEvery: 100},
+		{name: "out_of_order", outOfOrderEvery: 30, readEvery: 0},
+		{name: "out_of_order_with_reads", outOfOrderEvery: 30, readEvery: 100},
+		{name: "out_of_order_read_every_add", outOfOrderEvery: 30, readEvery: 1},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			mp := NewMemPostings()
+			lbls := labels.FromStrings("job", "bench")
+			// Refs go up in steps of maxShift*2 so that out of order refs never collide with one that was already added.
+			next := storage.SeriesRef(0)
+			step := storage.SeriesRef(maxShift * 2)
+			for range seeded {
+				next += step
+				mp.Add(next, lbls)
+			}
+
+			rnd := rand.New(rand.NewSource(1))
+			i := 0
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				i++
+				next += step
+				ref := next
+				if bc.outOfOrderEvery > 0 && i%bc.outOfOrderEvery == 0 {
+					// Go back a random number of positions, subtracting one to stay unique since every in-order ref is a multiple of step.
+					ref = next - storage.SeriesRef(rnd.Intn(maxShift)+1)*step - 1
+				}
+				mp.Add(ref, lbls)
+				if bc.readEvery > 0 && i%bc.readEvery == 0 {
+					// A query taking a reference to the postings list, which is what makes it unsafe to repair order violations in place afterwards.
+					mp.Postings(context.Background(), "job", "bench")
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes: #15317

## What

This refactors `MemPostings` to safely handle concurrent readers and out-of-order insertions by tracking which portion of each postings list may already be visible to readers. Instead of always copying an entire postings list when repairing an ordering violation, the implementation now performs in-place repairs whenever it is safe, falling back to copying only when readers could observe the modified region. The change also introduces sharded read tracking, preserves the fast path for in-order appends, restores regression tests, and fixes the race condition that could cause queries to return incorrect series.

## Why

Previously, `MemPostings` repaired ordering violations by modifying postings lists in place after readers had already obtained references to them, introducing a data race and allowing readers to observe incorrectly ordered postings. An earlier fix resolved the race by copying the entire postings list on every repair, but this caused excessive memory allocations and was reverted due to poor performance. By tracking the portion of each list that may be visible to readers, this implementation copies only when necessary, eliminating the race while avoiding the significant memory and performance overhead of unconditional whole-list copies.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
