### PR TITLE
promql: fix annotation position of native histogram NaN annotations

### DIFF
--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -4543,16 +4543,16 @@ eval instant at 1m histogram_quantile(0.5, nonmonotonic_bucket)
 	{} 8.5
 
 eval instant at 1m histogram_quantile(1, histogram_nan)
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN (1:20)
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN (1:23)
     {case="100% NaNs"} NaN
     {case="20% NaNs"} NaN
 
 eval instant at 1m histogram_quantile(0.8, histogram_nan{case="20% NaNs"})
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher (1:20)
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher (1:25)
     {case="20% NaNs"} 1
 
 eval instant at 1m histogram_fraction(-Inf, 0.7071067811865475, histogram_nan)
-    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions (1:20)
+    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions (1:46)
     {case="100% NaNs"} 0.0
     {case="20% NaNs"} 0.4
 

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -2145,7 +2145,7 @@ func funcHistogramFraction(vectorVals []Vector, _ Matrix, args parser.Expression
 		if !enh.enableDelayedNameRemoval {
 			sample.Metric = sample.Metric.DropReserved(schema.IsMetadataLabel)
 		}
-		hf, hfAnnos := HistogramFraction(lower, upper, sample.H, getMetricName(sample.Metric), args[0].PositionRange())
+		hf, hfAnnos := HistogramFraction(lower, upper, sample.H, getMetricName(sample.Metric), args[2].PositionRange())
 		annos.Merge(hfAnnos)
 		enh.Out = append(enh.Out, Sample{
 			Metric:   sample.Metric,
@@ -2196,7 +2196,7 @@ func funcHistogramQuantile(vectorVals []Vector, _ Matrix, args parser.Expression
 		if !enh.enableDelayedNameRemoval {
 			sample.Metric = sample.Metric.DropReserved(schema.IsMetadataLabel)
 		}
-		hq, hqAnnos := HistogramQuantile(q, sample.H, getMetricName(sample.Metric), args[0].PositionRange())
+		hq, hqAnnos := HistogramQuantile(q, sample.H, getMetricName(sample.Metric), args[1].PositionRange())
 		annos.Merge(hqAnnos)
 		enh.Out = append(enh.Out, Sample{
 			Metric:   sample.Metric,

--- a/promql/promqltest/README.md
+++ b/promql/promqltest/README.md
@@ -172,7 +172,7 @@ expect <type> <match_type>: <string>
     * `msg` for exact string match.
     * `regex` for regular expression match.
     * **Not applicable** for `ordered`, `no_info`, and `no_warn`.
-* `<string>` is the expected annotation message.
+* `<string>` is the expected annotation message, or for `fail` the expected error message. `warn` and `info` annotation strings end with a position, which an exact `msg` match must include, see [Annotation Positions](#annotation-positions).
 
 For example:
 
@@ -184,8 +184,8 @@ eval instant at 1m sum by (env) (my_metric)
     {env="test"} 20
     
 eval range from 0 to 3m step 1m sum by (env) (my_metric)
-    expect warn msg: something went wrong
-    expect info regex: something went (wrong|boom)
+    expect warn msg: PromQL warning: something went wrong (1:15)
+    expect info regex: PromQL info: something went (wrong|boom) \(1:15\)
     {env="prod"} 2 5 10 20
     {env="test"} 10 20 30 45
 
@@ -209,6 +209,44 @@ There can be multiple `<expect>` lines for a given `<type>`. Each `<type>` valid
 Every `<expect>` line must match at least one corresponding annotation or error.
 
 If at least one `<expect>` line of type `warn` or `info` is present, then all corresponding annotations must have a matching `expect` line.
+
+#### Annotation Positions
+
+`warn` and `info` expectations are matched against the annotation as the API
+renders it, which ends with the position of the expression that triggered it:
+
+```
+eval instant at 0m sum(metric)
+    expect warn msg: PromQL warning: encountered a mix of histograms and floats for aggregation (1:5)
+```
+
+Here `1:5` is the line and column of `metric`, the expression the annotation is
+about. Asserting it keeps an annotation pointing at the right part of the query.
+`fail` expectations are matched against the query error, which carries no
+position.
+
+Two things make an exact position impractical, and `regex` is the way out of
+both.
+
+Some annotations reveal further detail once the position is attached, and that
+detail may depend on the evaluation time:
+
+```
+eval instant at 50m histogram_quantiles(nonmonotonic_bucket, "q", 0.01, 0.5, 0.99)
+    expect info regex: PromQL info: input to histogram_quantile needed to be fixed for monotonicity .* \(1:21\)
+```
+
+Instant queries are also re-run with an `@` modifier appended to every selector,
+to check that the result is step invariant. Re-serializing the expression can
+normalize spacing and always lengthens each selector, which shifts the column of
+everything after the first one. An exact position therefore only holds when the
+annotated expression starts no later than the first selector, which is the case
+in both examples above. Otherwise match the position loosely:
+
+```
+eval instant at 50m histogram_quantiles(non_existent, "q", NaN)
+    expect warn regex: PromQL warning: quantile value should be between 0 and 1, got NaN \([0-9]+:[0-9]+\)
+```
 
 #### Migrating Test Files to the New Syntax
 

--- a/promql/promqltest/testdata/native_histograms.test
+++ b/promql/promqltest/testdata/native_histograms.test
@@ -1614,12 +1614,12 @@ load 1m
     histogram_nan{case="20% NaNs"} {{schema:0 count:0 sum:0}} {{schema:0 count:15 sum:NaN buckets:[12]}}
 
 eval instant at 1m histogram_quantile(1, histogram_nan)
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:20)
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:23)
     {case="100% NaNs"} NaN
     {case="20% NaNs"} NaN
 
 eval instant at 1m histogram_quantile(0.81, histogram_nan)
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:20)
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:26)
     {case="100% NaNs"} NaN
     {case="20% NaNs"} NaN
 
@@ -1629,29 +1629,29 @@ eval instant at 1m histogram_quantiles(histogram_nan, "q", 0.81)
     {case="20% NaNs", q="0.81"} NaN
 
 eval instant at 1m histogram_quantile(0.8, histogram_nan{case="100% NaNs"})
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:20)
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:25)
     {case="100% NaNs"} NaN
 
 eval instant at 1m histogram_quantile(0.8, histogram_nan{case="20% NaNs"})
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher for metric name "histogram_nan" (1:20)
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher for metric name "histogram_nan" (1:25)
     {case="20% NaNs"} 1
 
 eval instant at 1m histogram_quantile(0.4, histogram_nan{case="100% NaNs"})
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:20)
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is NaN for metric name "histogram_nan" (1:25)
     {case="100% NaNs"} NaN
 
 # histogram_quantile and histogram_fraction equivalence if quantile is not NaN
 eval instant at 1m histogram_quantile(0.4, histogram_nan{case="20% NaNs"})
-    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher for metric name "histogram_nan" (1:20)
+    expect info msg: PromQL info: input to histogram_quantile has NaN observations, result is skewed higher for metric name "histogram_nan" (1:25)
     {case="20% NaNs"} 0.7071067811865475
 
 eval instant at 1m histogram_fraction(-Inf, 0.7071067811865475, histogram_nan)
-    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions for metric name "histogram_nan" (1:20)
+    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions for metric name "histogram_nan" (1:46)
     {case="100% NaNs"} 0.0
     {case="20% NaNs"} 0.4
 
 eval instant at 1m histogram_fraction(-Inf, +Inf, histogram_nan)
-    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions for metric name "histogram_nan" (1:20)
+    expect info msg: PromQL info: input to histogram_fraction has NaN observations, which are excluded from all fractions for metric name "histogram_nan" (1:32)
     {case="100% NaNs"} 0.0
     {case="20% NaNs"} 0.8
 

--- a/promql/quantile.go
+++ b/promql/quantile.go
@@ -217,6 +217,9 @@ func BucketQuantile(q float64, buckets Buckets) (
 // HistogramQuantile is for calculating the histogram_quantile() of native
 // histograms. See also: BucketQuantile for classic histograms.
 //
+// The returned annotations are all about the histogram h, so pos must be the
+// position of the expression that h was derived from, not the position of q.
+//
 // HistogramQuantile is exported as it may be used by other PromQL engine
 // implementations.
 func HistogramQuantile(q float64, h *histogram.FloatHistogram, metricName string, pos posrange.PositionRange) (float64, annotations.Annotations) {
@@ -388,6 +391,9 @@ func HistogramQuantile(q float64, h *histogram.FloatHistogram, metricName string
 // If the histogram has NaN observations, these are not considered in any bucket
 // thus histogram_fraction(-Inf, +Inf, v) might be less than 1.0. The function
 // returns an info level annotation in this case.
+//
+// The returned annotation is about the histogram h, so pos must be the position
+// of the expression that h was derived from, not the position of lower or upper.
 //
 // HistogramFraction is exported as it may be used by other PromQL engine
 // implementations.


### PR DESCRIPTION
#19164 made annotation positions visible to `promqltest`, and necessarily transcribed the positions the engine currently reports. Three of those are wrong. Now that it is merged, this PR fixes the engine and corrects the expectations. I found this when trying to apply #19164 to Grafana Mimir and found that the PromQL engine there disagreed with the Prometheus engine.

### The bug

The three info annotations about NaN observations in a native histogram input are anchored to `args[0]` of the calling function:

- `NativeHistogramQuantileNaNResultInfo`
- `NativeHistogramQuantileNaNSkewInfo`
- `NativeHistogramFractionNaNsInfo`

For `histogram_quantile(q, v)` that is the quantile, and for `histogram_fraction(lower, upper, v)` that is the lower bound. So the position reported to the user points at a scalar argument instead of at the histogram the annotation is about:

```
histogram_quantile(1, histogram_nan)                         -> (1:20)  "1"
histogram_quantile(0.81, histogram_nan)                      -> (1:20)  "0.81"
histogram_fraction(-Inf, 0.7071067811865475, histogram_nan)  -> (1:20)  "-Inf"
histogram_fraction(-Inf, +Inf, histogram_nan)                -> (1:20)  "-Inf"
histogram_quantiles(histogram_nan, "q", 0.81)                -> (1:21)  the vector
```

Four differently shaped queries all reporting column 20 is the `args[0]` fingerprint. `histogram_quantiles` is unaffected because there the histogram *is* `args[0]`, which left the two spellings of the same annotation text disagreeing about where to point.

After the fix they agree, and each points at the histogram:

```
histogram_quantile(1, histogram_nan)                         -> (1:23)
histogram_quantile(0.81, histogram_nan)                      -> (1:26)
histogram_fraction(-Inf, 0.7071067811865475, histogram_nan)  -> (1:46)
histogram_fraction(-Inf, +Inf, histogram_nan)                -> (1:32)
histogram_quantiles(histogram_nan, "q", 0.81)                -> (1:21)  unchanged
```

The neighbouring call sites were already correct and are untouched: `validateQuantile(q, args[0])` keeps the invalid-quantile warning on the quantile, while `resetHistograms(inVec, args[1])` and the forced-monotonicity annotation already used the vector. `pos` is used for nothing but these three annotations inside `HistogramQuantile`/`HistogramFraction`, so the change is contained. Both functions are fixed-arity (`ArgTypes` in `promql/parser/functions.go`), so `args[1]`/`args[2]` are always present.

Same bug class as #18852, in the sibling annotations that fix did not cover.


```release-notes
[BUGFIX] PromQL: Report the position of the histogram argument rather than of a scalar argument in the native histogram NaN observation annotations of `histogram_quantile` and `histogram_fraction`.
```

