### PR TITLE
remote: update last send time only on success

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1737,7 +1737,9 @@ func (s *shards) updateMetrics(_ context.Context, err error, sampleCount, exempl
 	// should be maintained irrespective of success or failure.
 	s.qm.dataOut.incr(int64(sampleCount + exemplarCount + histogramCount + metadataCount))
 	s.qm.dataOutDuration.incr(int64(duration))
-	s.qm.lastSendTimestamp.Store(time.Now().Unix())
+	if err == nil {
+		s.qm.lastSendTimestamp.Store(time.Now().Unix())
+	}
 
 	// Pending samples/exemplars/histograms also should be subtracted, as an error means
 	// they will not be retried.

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -761,6 +761,17 @@ func TestShouldReshard(t *testing.T) {
 	}
 }
 
+func TestUpdateMetricsRecordsLastSuccessfulSend(t *testing.T) {
+	_, m := newTestClientAndQueueManager(t, defaultFlushDeadline, remoteapi.WriteV1MessageType)
+	s := m.newShards()
+
+	s.updateMetrics(context.Background(), errors.New("failed send"), 0, 0, 0, 0, WriteResponseStats{}, 0)
+	require.Zero(t, m.lastSendTimestamp.Load())
+
+	s.updateMetrics(context.Background(), nil, 0, 0, 0, 0, WriteResponseStats{}, 0)
+	require.NotZero(t, m.lastSendTimestamp.Load())
+}
+
 // TestDisableReshardOnRetry asserts that resharding should be disabled when a
 // recoverable error is returned from remote_write.
 func TestDisableReshardOnRetry(t *testing.T) {


### PR DESCRIPTION
Fixes #12559

Failed remote-write attempts were updating the timestamp used to decide whether resharding is safe. During an endpoint outage, this could make Prometheus treat failed sends as successful and reshard while the queue is unable to drain.

This change updates the timestamp only after a send completes without an error. The existing throughput and error accounting remains unchanged.

Added a regression test covering failed and successful sends.

```release-notes
[BUGFIX] Remote write: Track only successful sends when deciding whether to reshard.
```