### PR TITLE
UI: Improve native histogram table formatting

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/DataTable.module.css
+++ b/web/ui/mantine-ui/src/pages/query/DataTable.module.css
@@ -8,3 +8,17 @@
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
+
+/* The count is backed by a bar proportional to the largest bucket count, so
+   that the table shows the shape of the distribution as well as exact values. */
+.bucketCountCell {
+  text-align: right;
+  min-width: 5rem;
+  background-image: linear-gradient(
+    to right,
+    light-dark(rgba(45, 180, 83, 0.25), rgba(45, 180, 83, 0.35)) 0
+      var(--bucket-count-fraction),
+    transparent var(--bucket-count-fraction) 100%
+  );
+  background-repeat: no-repeat;
+}

--- a/web/ui/mantine-ui/src/pages/query/DataTable.tsx
+++ b/web/ui/mantine-ui/src/pages/query/DataTable.tsx
@@ -4,7 +4,6 @@ import {
   Alert,
   Box,
   SegmentedControl,
-  ScrollArea,
   Group,
   Stack,
   Text,
@@ -175,37 +174,55 @@ const DataTable: FC<DataTableProps> = ({
   );
 };
 
-const histogramTable = (h: Histogram): ReactNode => (
-  <Table withTableBorder fz="xs">
-    <Table.Tbody
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "space-between",
-      }}
-    >
-      <Table.Tr
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          justifyContent: "space-between",
-        }}
+const histogramTable = (h: Histogram): ReactNode => {
+  const buckets = h.buckets || [];
+  // The bucket with the highest count sets the scale for the in-cell count bars.
+  const maxCount = buckets.reduce(
+    (max, b) => Math.max(max, parseFloat(b[3])),
+    0
+  );
+
+  return (
+    // A native scroll container (rather than Mantine's ScrollArea) is used so
+    // that the sticky header positions itself against the scrolling element.
+    <Table.ScrollContainer type="native" minWidth={200} mah={265}>
+      <Table
+        withTableBorder
+        stickyHeader
+        tabularNums
+        fz="xs"
+        ta="left"
       >
-        <Table.Th>Bucket range</Table.Th>
-        <Table.Th>Count</Table.Th>
-      </Table.Tr>
-      <ScrollArea w={"100%"} h={265}>
-        {h.buckets?.map((b, i) => (
-          <Table.Tr key={i}>
-            <Table.Td style={{ textAlign: "left" }}>
-              {bucketRangeString(b)}
-            </Table.Td>
-            <Table.Td>{b[3]}</Table.Td>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Bucket range</Table.Th>
+            <Table.Th className={classes.numberCell}>Count</Table.Th>
           </Table.Tr>
-        ))}
-      </ScrollArea>
-    </Table.Tbody>
-  </Table>
-);
+        </Table.Thead>
+        <Table.Tbody>
+          {buckets.map((b, i) => (
+            <Table.Tr key={i}>
+              <Table.Td>{bucketRangeString(b)}</Table.Td>
+              <Table.Td
+                className={classes.bucketCountCell}
+                // Set max bucket count CSS variable for background bar width calculation.
+                style={
+                  {
+                    "--bucket-count-fraction":
+                      maxCount > 0
+                        ? `${(parseFloat(b[3]) / maxCount) * 100}%`
+                        : "0%",
+                  }
+                }
+              >
+                {b[3]}
+              </Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    </Table.ScrollContainer>
+  );
+};
 
 export default DataTable;


### PR DESCRIPTION
This fixes scroll issues in the native histogram buckets table and also improves the display by aligning the values better and adding a light background bar representing the bucket count.

Before:

https://github.com/user-attachments/assets/8d9b3186-8599-422c-bf79-f668370f31ea

After:

https://github.com/user-attachments/assets/cf71aa22-8763-49d2-88f6-c8a1da257b60

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
[ENHANCEMENT]: UI: Improve native histogram table formatting and add a background bar indicating the bucket count.
```
