### PR TITLE
discovery/aws: avoid panic on truncated ElastiCache ARNs

### DIFF
--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -600,7 +600,7 @@ func splitCacheDeploymentOptions(caches []string) (serverlessCacheIDs, cacheClus
 			continue
 		}
 		parts := strings.Split(cacheARN, ":")
-		if len(parts) < 6 {
+		if len(parts) < 7 {
 			continue
 		}
 		resourceType := parts[5]

--- a/discovery/aws/elasticache.go
+++ b/discovery/aws/elasticache.go
@@ -519,7 +519,7 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 
 	var clusters []string
 	clustersMu := sync.Mutex{}
-	serverlessCacheIDs, cacheClusterIDs := splitCacheDeploymentOptions(d.cfg.Clusters)
+	serverlessCacheIDs, cacheClusterIDs := splitCacheDeploymentOptions(d.cfg.Clusters, d.logger)
 
 	clusterErrg, clusterCtx := errgroup.WithContext(ctx)
 	clusterErrg.Go(func() error {
@@ -594,13 +594,14 @@ func (d *ElasticacheDiscovery) refresh(ctx context.Context) ([]*targetgroup.Grou
 // splitCacheTypes takes a list of cache ARNs and splits them into serverless cache IDs and cache cluster IDs based on their format.
 // Serverless caches are in the format arn:aws:elasticache:<REGION>:<ACCOUNT_ID>:serverlesscache:<CACHE_NAME>
 // Cache clusters are in the format arn:aws:elasticache:<REGION>:<ACCOUNT_ID>:replicationgroup:<CACHE_CLUSTER_ID>.
-func splitCacheDeploymentOptions(caches []string) (serverlessCacheIDs, cacheClusterIDs []string) {
+func splitCacheDeploymentOptions(caches []string, logger *slog.Logger) (serverlessCacheIDs, cacheClusterIDs []string) {
 	for _, cacheARN := range caches {
 		if cacheARN == "" {
 			continue
 		}
 		parts := strings.Split(cacheARN, ":")
 		if len(parts) < 7 {
+			logger.Warn("Skipping invalid ElastiCache ARN", "arn", cacheARN)
 			continue
 		}
 		resourceType := parts[5]

--- a/discovery/aws/elasticache_test.go
+++ b/discovery/aws/elasticache_test.go
@@ -582,6 +582,7 @@ func TestSplitCacheDeploymentOptions(t *testing.T) {
 			caches: []string{
 				"not-an-arn",
 				"arn:aws:elasticache:us-east-1",
+				"arn:aws:elasticache:us-east-1:123456789012:serverlesscache",
 				"",
 			},
 			expectedServerlessCacheIDs: nil,

--- a/discovery/aws/elasticache_test.go
+++ b/discovery/aws/elasticache_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -612,7 +613,7 @@ func TestSplitCacheDeploymentOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			serverlessCacheIDs, cacheClusterIDs := splitCacheDeploymentOptions(tt.caches)
+			serverlessCacheIDs, cacheClusterIDs := splitCacheDeploymentOptions(tt.caches, promslog.NewNopLogger())
 
 			require.Equal(t, tt.expectedServerlessCacheIDs, serverlessCacheIDs, "serverless cache IDs mismatch")
 			require.Equal(t, tt.expectedCacheClusterIDs, cacheClusterIDs, "cache cluster IDs mismatch")


### PR DESCRIPTION
## Summary

A malformed ElastiCache ARN with no resource ID has six colon-separated components. `splitCacheDeploymentOptions` checked `len(parts) < 6` and then read `parts[6]`, causing an index-out-of-range panic during discovery refresh.

This changes the guard to require all seven components before reading the resource ID. Valid serverless-cache and replication-group ARNs are unchanged.

## Tests

- `go test ./discovery/aws -run '^TestSplitCacheDeploymentOptions$' -count=20`
- `go test ./discovery/aws`

```release-notes
[BUGFIX] discovery/aws: Avoid a panic when an ElastiCache ARN is missing its resource ID.
```