### PR TITLE
discovery/ovhcloud: bracket IPv6 target addresses

### DIFF
--- a/discovery/ovhcloud/dedicated_server.go
+++ b/discovery/ovhcloud/dedicated_server.go
@@ -131,10 +131,7 @@ func (d *dedicatedServerDiscovery) refresh(context.Context) ([]*targetgroup.Grou
 				ipv6 = ip.String()
 			}
 		}
-		defaultIP := ipv4
-		if defaultIP == "" {
-			defaultIP = ipv6
-		}
+		defaultIP := formatTargetAddress(ipv4, ipv6)
 		labels := model.LabelSet{
 			model.AddressLabel:                              model.LabelValue(defaultIP),
 			model.InstanceLabel:                             model.LabelValue(server.Name),

--- a/discovery/ovhcloud/ovhcloud.go
+++ b/discovery/ovhcloud/ovhcloud.go
@@ -137,6 +137,16 @@ func parseIPList(ipList []string) ([]netip.Addr, error) {
 	return ipAddresses, nil
 }
 
+func formatTargetAddress(ipv4, ipv6 string) string {
+	if ipv4 != "" {
+		return ipv4
+	}
+	if ipv6 != "" {
+		return "[" + ipv6 + "]"
+	}
+	return ""
+}
+
 func newRefresher(conf *SDConfig, logger *slog.Logger) (refresher, error) {
 	switch conf.Service {
 	case "vps":

--- a/discovery/ovhcloud/ovhcloud_test.go
+++ b/discovery/ovhcloud/ovhcloud_test.go
@@ -119,6 +119,41 @@ func TestParseIPs(t *testing.T) {
 	}
 }
 
+func TestFormatTargetAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		ipv4 string
+		ipv6 string
+		want string
+	}{
+		{
+			name: "IPv4Only",
+			ipv4: "192.0.2.1",
+			want: "192.0.2.1",
+		},
+		{
+			name: "IPv6Only",
+			ipv6: "2001:db8::1",
+			want: "[2001:db8::1]",
+		},
+		{
+			name: "IPv4Preferred",
+			ipv4: "192.0.2.1",
+			ipv6: "2001:db8::1",
+			want: "192.0.2.1",
+		},
+		{
+			name: "NoAddress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, formatTargetAddress(tt.ipv4, tt.ipv6))
+		})
+	}
+}
+
 func TestDiscoverer(t *testing.T) {
 	conf, _ := getMockConf("vps")
 	logger := promslog.NewNopLogger()

--- a/discovery/ovhcloud/vps.go
+++ b/discovery/ovhcloud/vps.go
@@ -149,10 +149,7 @@ func (d *vpsDiscovery) refresh(context.Context) ([]*targetgroup.Group, error) {
 				ipv6 = ip.String()
 			}
 		}
-		defaultIP := ipv4
-		if defaultIP == "" {
-			defaultIP = ipv6
-		}
+		defaultIP := formatTargetAddress(ipv4, ipv6)
 		labels := model.LabelSet{
 			model.AddressLabel:                       model.LabelValue(defaultIP),
 			model.InstanceLabel:                      model.LabelValue(server.Name),


### PR DESCRIPTION
## Summary

OVHcloud discovery prefers IPv4 and falls back to IPv6. In the IPv6-only case, it emitted the raw IPv6 literal in `__address__`, but target addresses are later used as URL hosts and IPv6 literals need brackets.

This affected both VPS and dedicated-server discovery, so an IPv6-only target could not be scraped correctly.

## What changed

- Added a shared target-address formatter for both OVHcloud discovery paths.
- Kept IPv4 preference unchanged.
- Bracketed only the IPv6 fallback.
- Left the raw IPv6 metadata labels unchanged.
- Added coverage for IPv4-only, IPv6-only, dual-stack, and empty inputs.

## Tests

- `go test ./discovery/ovhcloud -run '^(TestFormatTargetAddress|TestOvhCloudVpsRefresh|TestOvhcloudDedicatedServerRefresh)$' -count=20`
- `go test ./discovery/ovhcloud`
- `go test ./scrape -run 'TestTargetURL|TestPopulateLabels'`
- `make lint`

```release-notes
[BUGFIX] discovery/ovhcloud: Bracket IPv6-only target addresses.
```