### PR TITLE
promtool: support custom headers for series and labels queries

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -179,17 +179,16 @@ func main() {
 	queryCmd := app.Command("query", "Run query against a Prometheus server.")
 	queryCmdFmt := queryCmd.Flag("format", "Output format of the query.").Short('o').Default("promql").Enum("promql", "json")
 	queryCmd.Flag("http.config.file", httpConfigFileDescription).PlaceHolder("<filename>").ExistingFileVar(&httpConfigFilePath)
+	queryHeaders := queryCmd.Flag("header", "Extra headers to send to server.").StringMap()
 
 	queryInstantCmd := queryCmd.Command("instant", "Run instant query.")
 	queryInstantCmd.Arg("server", "Prometheus server to query.").Required().URLVar(&serverURL)
 	queryInstantExpr := queryInstantCmd.Arg("expr", "PromQL query expression.").Required().String()
 	queryInstantTime := queryInstantCmd.Flag("time", "Query evaluation time (RFC3339 or Unix timestamp).").String()
-	queryInstantHeaders := queryInstantCmd.Flag("header", "Extra headers to send to server.").StringMap()
 
 	queryRangeCmd := queryCmd.Command("range", "Run range query.")
 	queryRangeCmd.Arg("server", "Prometheus server to query.").Required().URLVar(&serverURL)
 	queryRangeExpr := queryRangeCmd.Arg("expr", "PromQL query expression.").Required().String()
-	queryRangeHeaders := queryRangeCmd.Flag("header", "Extra headers to send to server.").StringMap()
 	queryRangeBegin := queryRangeCmd.Flag("start", "Query range start time (RFC3339 or Unix timestamp).").String()
 	queryRangeEnd := queryRangeCmd.Flag("end", "Query range end time (RFC3339 or Unix timestamp).").String()
 	queryRangeStep := queryRangeCmd.Flag("step", "Query step size (duration).").Duration()
@@ -199,7 +198,6 @@ func main() {
 	querySeriesMatch := querySeriesCmd.Flag("match", "Series selector. Can be specified multiple times.").Required().Strings()
 	querySeriesBegin := querySeriesCmd.Flag("start", "Start time (RFC3339 or Unix timestamp).").String()
 	querySeriesEnd := querySeriesCmd.Flag("end", "End time (RFC3339 or Unix timestamp).").String()
-	querySeriesHeaders := querySeriesCmd.Flag("header", "Extra headers to send to server.").StringMap()
 
 	debugCmd := app.Command("debug", "Fetch debug information.")
 	debugPprofCmd := debugCmd.Command("pprof", "Fetch profiling debug information.")
@@ -215,7 +213,6 @@ func main() {
 	queryLabelsBegin := queryLabelsCmd.Flag("start", "Start time (RFC3339 or Unix timestamp).").String()
 	queryLabelsEnd := queryLabelsCmd.Flag("end", "End time (RFC3339 or Unix timestamp).").String()
 	queryLabelsMatch := queryLabelsCmd.Flag("match", "Series selector. Can be specified multiple times.").Strings()
-	queryLabelsHeaders := queryLabelsCmd.Flag("header", "Extra headers to send to server.").StringMap()
 
 	queryAnalyzeCfg := &QueryAnalyzeConfig{}
 	queryAnalyzeCmd := queryCmd.Command("analyze", "Run queries against your Prometheus to analyze the usage pattern of certain metrics.")
@@ -403,13 +400,13 @@ func main() {
 		os.Exit(PushMetrics(remoteWriteURL, httpRoundTripper, *pushMetricsHeaders, *pushMetricsTimeout, *pushMetricsProtoMsg, *pushMetricsAPIPath, *pushMetricsLabels, *metricFiles...))
 
 	case queryInstantCmd.FullCommand():
-		os.Exit(QueryInstant(serverURL, httpRoundTripper, *queryInstantHeaders, *queryInstantExpr, *queryInstantTime, p))
+		os.Exit(QueryInstant(serverURL, httpRoundTripper, *queryHeaders, *queryInstantExpr, *queryInstantTime, p))
 
 	case queryRangeCmd.FullCommand():
-		os.Exit(QueryRange(serverURL, httpRoundTripper, *queryRangeHeaders, *queryRangeExpr, *queryRangeBegin, *queryRangeEnd, *queryRangeStep, p))
+		os.Exit(QueryRange(serverURL, httpRoundTripper, *queryHeaders, *queryRangeExpr, *queryRangeBegin, *queryRangeEnd, *queryRangeStep, p))
 
 	case querySeriesCmd.FullCommand():
-		os.Exit(QuerySeries(serverURL, httpRoundTripper, *querySeriesHeaders, *querySeriesMatch, *querySeriesBegin, *querySeriesEnd, p))
+		os.Exit(QuerySeries(serverURL, httpRoundTripper, *queryHeaders, *querySeriesMatch, *querySeriesBegin, *querySeriesEnd, p))
 
 	case debugPprofCmd.FullCommand():
 		os.Exit(debugPprof(*debugPprofServer))
@@ -421,7 +418,7 @@ func main() {
 		os.Exit(debugAll(*debugAllServer))
 
 	case queryLabelsCmd.FullCommand():
-		os.Exit(QueryLabels(serverURL, httpRoundTripper, *queryLabelsHeaders, *queryLabelsMatch, *queryLabelsName, *queryLabelsBegin, *queryLabelsEnd, p))
+		os.Exit(QueryLabels(serverURL, httpRoundTripper, *queryHeaders, *queryLabelsMatch, *queryLabelsName, *queryLabelsBegin, *queryLabelsEnd, p))
 
 	case testRulesCmd.FullCommand():
 		results := io.Discard

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -199,6 +199,7 @@ func main() {
 	querySeriesMatch := querySeriesCmd.Flag("match", "Series selector. Can be specified multiple times.").Required().Strings()
 	querySeriesBegin := querySeriesCmd.Flag("start", "Start time (RFC3339 or Unix timestamp).").String()
 	querySeriesEnd := querySeriesCmd.Flag("end", "End time (RFC3339 or Unix timestamp).").String()
+	querySeriesHeaders := querySeriesCmd.Flag("header", "Extra headers to send to server.").StringMap()
 
 	debugCmd := app.Command("debug", "Fetch debug information.")
 	debugPprofCmd := debugCmd.Command("pprof", "Fetch profiling debug information.")
@@ -214,6 +215,7 @@ func main() {
 	queryLabelsBegin := queryLabelsCmd.Flag("start", "Start time (RFC3339 or Unix timestamp).").String()
 	queryLabelsEnd := queryLabelsCmd.Flag("end", "End time (RFC3339 or Unix timestamp).").String()
 	queryLabelsMatch := queryLabelsCmd.Flag("match", "Series selector. Can be specified multiple times.").Strings()
+	queryLabelsHeaders := queryLabelsCmd.Flag("header", "Extra headers to send to server.").StringMap()
 
 	queryAnalyzeCfg := &QueryAnalyzeConfig{}
 	queryAnalyzeCmd := queryCmd.Command("analyze", "Run queries against your Prometheus to analyze the usage pattern of certain metrics.")
@@ -407,7 +409,7 @@ func main() {
 		os.Exit(QueryRange(serverURL, httpRoundTripper, *queryRangeHeaders, *queryRangeExpr, *queryRangeBegin, *queryRangeEnd, *queryRangeStep, p))
 
 	case querySeriesCmd.FullCommand():
-		os.Exit(QuerySeries(serverURL, httpRoundTripper, *querySeriesMatch, *querySeriesBegin, *querySeriesEnd, p))
+		os.Exit(QuerySeries(serverURL, httpRoundTripper, *querySeriesHeaders, *querySeriesMatch, *querySeriesBegin, *querySeriesEnd, p))
 
 	case debugPprofCmd.FullCommand():
 		os.Exit(debugPprof(*debugPprofServer))
@@ -419,7 +421,7 @@ func main() {
 		os.Exit(debugAll(*debugAllServer))
 
 	case queryLabelsCmd.FullCommand():
-		os.Exit(QueryLabels(serverURL, httpRoundTripper, *queryLabelsMatch, *queryLabelsName, *queryLabelsBegin, *queryLabelsEnd, p))
+		os.Exit(QueryLabels(serverURL, httpRoundTripper, *queryLabelsHeaders, *queryLabelsMatch, *queryLabelsName, *queryLabelsBegin, *queryLabelsEnd, p))
 
 	case testRulesCmd.FullCommand():
 		results := io.Discard

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -120,6 +120,38 @@ func TestQueryInstantHeaders(t *testing.T) {
 	require.Equal(t, "value", getRequest().Header.Get("X-Custom"))
 }
 
+func TestQuerySeriesHeaders(t *testing.T) {
+	t.Parallel()
+	s, getRequest := mockServer(200, `{"status": "success", "data": []}`)
+	defer s.Close()
+
+	urlObject, err := url.Parse(s.URL)
+	require.NoError(t, err)
+
+	p := &promqlPrinter{}
+	headers := map[string]string{"X-Scope-OrgID": "prom", "X-Custom": "value"}
+	exitCode := QuerySeries(urlObject, http.DefaultTransport, headers, []string{"up"}, "", "", p)
+	require.Equal(t, 0, exitCode)
+	require.Equal(t, "prom", getRequest().Header.Get("X-Scope-OrgID"))
+	require.Equal(t, "value", getRequest().Header.Get("X-Custom"))
+}
+
+func TestQueryLabelsHeaders(t *testing.T) {
+	t.Parallel()
+	s, getRequest := mockServer(200, `{"status": "success", "data": []}`)
+	defer s.Close()
+
+	urlObject, err := url.Parse(s.URL)
+	require.NoError(t, err)
+
+	p := &promqlPrinter{}
+	headers := map[string]string{"X-Scope-OrgID": "prom", "X-Custom": "value"}
+	exitCode := QueryLabels(urlObject, http.DefaultTransport, headers, []string{"up"}, "job", "", "", p)
+	require.Equal(t, 0, exitCode)
+	require.Equal(t, "prom", getRequest().Header.Get("X-Scope-OrgID"))
+	require.Equal(t, "value", getRequest().Header.Get("X-Custom"))
+}
+
 func TestCheckServerStatus(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/promtool/query.go
+++ b/cmd/promtool/query.go
@@ -146,8 +146,8 @@ func QueryRange(url *url.URL, roundTripper http.RoundTripper, headers map[string
 }
 
 // QuerySeries queries for a series against a Prometheus server.
-func QuerySeries(url *url.URL, roundTripper http.RoundTripper, matchers []string, start, end string, p printer) int {
-	api, err := newAPI(url, roundTripper, nil)
+func QuerySeries(url *url.URL, roundTripper http.RoundTripper, headers map[string]string, matchers []string, start, end string, p printer) int {
+	api, err := newAPI(url, roundTripper, headers)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating API client:", err)
 		return failureExitCode
@@ -173,8 +173,8 @@ func QuerySeries(url *url.URL, roundTripper http.RoundTripper, matchers []string
 }
 
 // QueryLabels queries for label values against a Prometheus server.
-func QueryLabels(url *url.URL, roundTripper http.RoundTripper, matchers []string, name, start, end string, p printer) int {
-	api, err := newAPI(url, roundTripper, nil)
+func QueryLabels(url *url.URL, roundTripper http.RoundTripper, headers map[string]string, matchers []string, name, start, end string, p printer) int {
+	api, err := newAPI(url, roundTripper, headers)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating API client:", err)
 		return failureExitCode

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -296,6 +296,7 @@ Run series query.
 | <code class="text-nowrap">--match</code> <code class="text-nowrap">...</code> | Series selector. Can be specified multiple times. |
 | <code class="text-nowrap">--start</code> | Start time (RFC3339 or Unix timestamp). |
 | <code class="text-nowrap">--end</code> | End time (RFC3339 or Unix timestamp). |
+| <code class="text-nowrap">--header</code> | Extra headers to send to server. |
 
 
 
@@ -322,6 +323,7 @@ Run labels query.
 | <code class="text-nowrap">--start</code> | Start time (RFC3339 or Unix timestamp). |
 | <code class="text-nowrap">--end</code> | End time (RFC3339 or Unix timestamp). |
 | <code class="text-nowrap">--match</code> <code class="text-nowrap">...</code> | Series selector. Can be specified multiple times. |
+| <code class="text-nowrap">--header</code> | Extra headers to send to server. |
 
 
 

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -225,6 +225,7 @@ Run query against a Prometheus server.
 | --- | --- | --- |
 | <code class="text-nowrap">-o</code>, <code class="text-nowrap">--format</code> | Output format of the query. | `promql` |
 | <code class="text-nowrap">--http.config.file</code> | HTTP client configuration file, see details at https://prometheus.io/docs/prometheus/latest/configuration/promtool |  |
+| <code class="text-nowrap">--header</code> | Extra headers to send to server. |  |
 
 
 
@@ -240,7 +241,6 @@ Run instant query.
 | Flag | Description |
 | --- | --- |
 | <code class="text-nowrap">--time</code> | Query evaluation time (RFC3339 or Unix timestamp). |
-| <code class="text-nowrap">--header</code> | Extra headers to send to server. |
 
 
 
@@ -265,7 +265,6 @@ Run range query.
 
 | Flag | Description |
 | --- | --- |
-| <code class="text-nowrap">--header</code> | Extra headers to send to server. |
 | <code class="text-nowrap">--start</code> | Query range start time (RFC3339 or Unix timestamp). |
 | <code class="text-nowrap">--end</code> | Query range end time (RFC3339 or Unix timestamp). |
 | <code class="text-nowrap">--step</code> | Query step size (duration). |
@@ -296,7 +295,6 @@ Run series query.
 | <code class="text-nowrap">--match</code> <code class="text-nowrap">...</code> | Series selector. Can be specified multiple times. |
 | <code class="text-nowrap">--start</code> | Start time (RFC3339 or Unix timestamp). |
 | <code class="text-nowrap">--end</code> | End time (RFC3339 or Unix timestamp). |
-| <code class="text-nowrap">--header</code> | Extra headers to send to server. |
 
 
 
@@ -323,7 +321,6 @@ Run labels query.
 | <code class="text-nowrap">--start</code> | Start time (RFC3339 or Unix timestamp). |
 | <code class="text-nowrap">--end</code> | End time (RFC3339 or Unix timestamp). |
 | <code class="text-nowrap">--match</code> <code class="text-nowrap">...</code> | Series selector. Can be specified multiple times. |
-| <code class="text-nowrap">--header</code> | Extra headers to send to server. |
 
 
 


### PR DESCRIPTION
## Summary

`promtool query instant` and `promtool query range` already support `--header`, but `query series` and `query labels` did not pass custom headers to the API client.

This prevents metadata queries from working with header-based multi-tenancy, such as `X-Scope-OrgID`.

## What changed

- Added `--header` to `promtool query series` and `promtool query labels`.
- Passed the existing header map through `QuerySeries` and `QueryLabels`.
- Added request-header tests for both commands.
- Regenerated the promtool command-line documentation.

## Tests

- `go test ./cmd/promtool -run '^(TestQueryInstantHeaders|TestQuerySeriesHeaders|TestQueryLabelsHeaders|TestDocumentation)$' -count=1`
- `make lint`

```release-notes
[ENHANCEMENT] promtool: Support custom headers for series and labels queries.
```