### PR TITLE
tsdb: pause on-disk block compactions when we need to write HEAD block to disk

### DIFF
--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -90,6 +90,12 @@ type LeveledCompactor struct {
 	postingsEncoder             index.PostingsEncoder
 	postingsDecoderFactory      PostingsDecoderFactory
 	enableOverlappingCompaction bool
+
+	// MaybePause tells compactor if it should pause. Compactor will
+	// call it sporadically and if merges should be pause then the call to
+	// MaybePause() will simply block until merges should resume.
+	// If MaybePause() returns an error then compaction should abort.
+	MaybePause func(ctx context.Context) error
 }
 
 type CompactorMetrics struct {
@@ -582,7 +588,7 @@ func CompactBlockMetas(uid ulid.ULID, blocks ...*BlockMeta) *BlockMeta {
 // Compact creates a new block in the compactor's directory from the blocks in the
 // provided directories.
 func (c *LeveledCompactor) Compact(dest string, dirs []string, open []*Block) ([]ulid.ULID, error) {
-	return c.CompactWithBlockPopulator(dest, dirs, open, DefaultBlockPopulator{})
+	return c.CompactWithBlockPopulator(dest, dirs, open, DefaultBlockPopulator{MaybePause: c.MaybePause})
 }
 
 func (c *LeveledCompactor) CompactWithBlockPopulator(dest string, dirs []string, open []*Block, blockPopulator BlockPopulator) ([]ulid.ULID, error) {
@@ -635,6 +641,14 @@ func (c *LeveledCompactor) CompactWithBlockPopulator(dest string, dirs []string,
 	uid := ulid.MustNew(ulid.Now(), rand.Reader)
 
 	meta := CompactBlockMetas(uid, metas...)
+	c.logger.Info(
+		"compact blocks started",
+		"count", len(blocks),
+		"mint", meta.MinTime,
+		"maxt", meta.MaxTime,
+		"ulid", meta.ULID,
+		"sources", fmt.Sprintf("%v", uids),
+	)
 	err := c.write(dest, meta, blockPopulator, blocks...)
 	if err == nil {
 		if meta.Stats.NumSamples == 0 {
@@ -659,7 +673,7 @@ func (c *LeveledCompactor) CompactWithBlockPopulator(dest string, dirs []string,
 		}
 
 		c.logger.Info(
-			"compact blocks",
+			"compact blocks completed",
 			"count", len(blocks),
 			"mint", meta.MinTime,
 			"maxt", meta.MaxTime,
@@ -887,12 +901,14 @@ func AllSortedPostings(ctx context.Context, reader IndexReader) index.Postings {
 	return reader.SortedPostings(all)
 }
 
-type DefaultBlockPopulator struct{}
+type DefaultBlockPopulator struct {
+	MaybePause func(ctx context.Context) error
+}
 
 // PopulateBlock fills the index and chunk writers with new data gathered as the union
 // of the provided blocks. It returns meta information for the new block.
 // It expects sorted blocks input by mint.
-func (DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *CompactorMetrics, logger *slog.Logger, chunkPool chunkenc.Pool, mergeFunc storage.VerticalChunkSeriesMergeFunc, blocks []BlockReader, meta *BlockMeta, indexw IndexWriter, chunkw ChunkWriter, postingsFunc IndexReaderPostingsFunc) (err error) {
+func (d DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *CompactorMetrics, logger *slog.Logger, chunkPool chunkenc.Pool, mergeFunc storage.VerticalChunkSeriesMergeFunc, blocks []BlockReader, meta *BlockMeta, indexw IndexWriter, chunkw ChunkWriter, postingsFunc IndexReaderPostingsFunc) (err error) {
 	if len(blocks) == 0 {
 		return errors.New("cannot populate block from no readers")
 	}
@@ -985,11 +1001,16 @@ func (DefaultBlockPopulator) PopulateBlock(ctx context.Context, metrics *Compact
 	}
 
 	// Iterate over all sorted chunk series.
-	for set.Next() {
+	for i := 0; set.Next(); i++ {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
+		}
+		if d.MaybePause != nil && i%10000 == 0 {
+			if err := d.MaybePause(ctx); err != nil {
+				return fmt.Errorf("maybe pause: %w", err)
+			}
 		}
 		s := set.At()
 		chksIter = s.Iterator(chksIter)

--- a/tsdb/compact_test.go
+++ b/tsdb/compact_test.go
@@ -584,6 +584,133 @@ func TestCompactionFailWillCleanUpTempDir(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "directory is not cleaned up")
 }
 
+// TestLeveledCompactorMaybePause verifies that compactor calls MaybePause
+// during compaction and that an error from MaybePause aborts the compaction.
+func TestLeveledCompactorMaybePause(t *testing.T) {
+	t.Parallel()
+
+	newSeries := func(totalSeries int, mint, maxt int64) []storage.Series {
+		return genSeriesFromSampleGenerator(totalSeries, 1, mint, maxt, 1, func(ts int64) chunks.Sample {
+			return sample{t: ts, f: float64(ts)}
+		})
+	}
+
+	cases := map[string]struct {
+		blockSeries [][]storage.Series
+		hookErr     error
+		expCalls    int
+		expErr      string
+		expStats    BlockStats
+	}{
+		"called once on a short merge and compaction completes": {
+			blockSeries: [][]storage.Series{newSeries(5, 0, 100), newSeries(5, 100, 200)},
+			expCalls:    1,
+			expStats:    BlockStats{NumSamples: 1000, NumFloatSamples: 1000, NumSeries: 5, NumChunks: 10},
+		},
+		"called twice when merge has more than 10000 series": {
+			blockSeries: [][]storage.Series{newSeries(12000, 0, 2)},
+			expCalls:    2,
+			expStats:    BlockStats{NumSamples: 24000, NumFloatSamples: 24000, NumSeries: 12000, NumChunks: 12000},
+		},
+		"error from MaybePause aborts compaction and removes the partial block": {
+			blockSeries: [][]storage.Series{newSeries(5, 0, 100), newSeries(5, 100, 200)},
+			hookErr:     errors.New("boom"),
+			expCalls:    1,
+			expErr:      "populate block: maybe pause: boom",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpdir := t.TempDir()
+			blockDirs := make([]string, 0, len(tc.blockSeries))
+			for _, series := range tc.blockSeries {
+				blockDirs = append(blockDirs, createBlock(t, tmpdir, series))
+			}
+
+			compactor, err := NewLeveledCompactor(t.Context(), nil, promslog.NewNopLogger(), []int64{200}, nil, nil)
+			require.NoError(t, err)
+
+			var calls int
+			compactor.MaybePause = func(context.Context) error {
+				calls++
+				return tc.hookErr
+			}
+
+			uids, err := compactor.Compact(tmpdir, blockDirs, nil)
+			require.Equal(t, tc.expCalls, calls)
+
+			if tc.expErr != "" {
+				require.EqualError(t, err, tc.expErr)
+				require.Nil(t, uids)
+
+				entries, err := os.ReadDir(tmpdir)
+				require.NoError(t, err)
+				require.Len(t, entries, len(tc.blockSeries), "only the source blocks may remain")
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, uids, 1)
+
+			block, err := OpenBlock(nil, filepath.Join(tmpdir, uids[0].String()), nil, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, block.Close())
+			})
+
+			meta := block.Meta()
+			require.Equal(t, 2, meta.Compaction.Level)
+			require.Len(t, meta.Compaction.Sources, len(tc.blockSeries))
+			require.Equal(t, tc.expStats, meta.Stats)
+
+			exp := map[string][]chunks.Sample{}
+			for _, series := range tc.blockSeries {
+				for _, s := range series {
+					samples, err := storage.ExpandSamples(s.Iterator(nil), newSample)
+					require.NoError(t, err)
+					exp[s.Labels().String()] = append(exp[s.Labels().String()], samples...)
+				}
+			}
+
+			q, err := NewBlockQuerier(block, block.MinTime(), block.MaxTime())
+			require.NoError(t, err)
+			require.Equal(t, exp, query(t, q, labels.MustNewMatcher(labels.MatchRegexp, defaultLabelName, ".*")))
+		})
+	}
+}
+
+// TestLeveledCompactorMaybePauseNotCalledDuringWrite verifies that Write
+// never calls MaybePause. Write already writes the head block, so there is
+// nothing to pause.
+func TestLeveledCompactorMaybePauseNotCalledDuringWrite(t *testing.T) {
+	t.Parallel()
+
+	tmpdir := t.TempDir()
+	blockDir := createBlock(t, tmpdir, genSeries(1, 1, 0, 100))
+
+	compactor, err := NewLeveledCompactor(t.Context(), nil, promslog.NewNopLogger(), []int64{200}, nil, nil)
+	require.NoError(t, err)
+
+	var calls int
+	compactor.MaybePause = func(context.Context) error {
+		calls++
+		return nil
+	}
+
+	block, err := OpenBlock(nil, blockDir, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, block.Close())
+	})
+
+	uids, err := compactor.Write(tmpdir, block, 0, 100, nil)
+	require.NoError(t, err)
+	require.Len(t, uids, 1)
+	require.Equal(t, 0, calls)
+}
+
 func metaRange(name string, mint, maxt int64, stats *BlockStats) dirMeta {
 	meta := &BlockMeta{MinTime: mint, MaxTime: maxt}
 	if stats != nil {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -378,6 +378,7 @@ type dbMetrics struct {
 	reloadsFailed                      prometheus.Counter
 	compactionsFailed                  prometheus.Counter
 	compactionsTriggered               prometheus.Counter
+	compactionsPaused                  prometheus.Counter
 	compactionsSkipped                 prometheus.Counter
 	sizeRetentionCount                 prometheus.Counter
 	timeRetentionCount                 prometheus.Counter
@@ -430,6 +431,10 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 	m.compactionsTriggered = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_compactions_triggered_total",
 		Help: "Total number of triggered compactions for the partition.",
+	})
+	m.compactionsPaused = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_compactions_paused_total",
+		Help: "Total number of times a block compaction was paused to persist the head block.",
 	})
 	m.compactionsFailed = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_compactions_failed_total",
@@ -522,6 +527,7 @@ func newDBMetrics(db *DB, r prometheus.Registerer) *dbMetrics {
 			m.reloadsFailed,
 			m.compactionsFailed,
 			m.compactionsTriggered,
+			m.compactionsPaused,
 			m.compactionsSkipped,
 			m.sizeRetentionCount,
 			m.timeRetentionCount,
@@ -1102,6 +1108,9 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 		return nil, fmt.Errorf("create compactor: %w", err)
 	}
 	db.compactCancel = cancel
+	if lc, ok := db.compactor.(*LeveledCompactor); ok {
+		lc.MaybePause = db.maybePause
+	}
 
 	if opts.BlockQuerierFunc == nil {
 		db.blockQuerierFunc = NewBlockQuerier
@@ -1579,6 +1588,41 @@ func (db *DB) Compact(ctx context.Context) (returnErr error) {
 	return db.compactBlocks()
 }
 
+// maybePause writes the head block if the head became compactable while
+// blocks are being compacted. Compact holds db.cmtx for the whole compaction,
+// so it can run while a merge is paused.
+func (db *DB) maybePause(ctx context.Context) error {
+	if !db.head.compactable() || db.waitingForCompactionDelay() {
+		return nil
+	}
+	if db.timeWhenCompactionDelayStarted.IsZero() {
+		db.timeWhenCompactionDelayStarted = time.Now()
+	}
+	if db.waitingForCompactionDelay() {
+		return nil
+	}
+	db.logger.Info("paused block compaction to persist the head block")
+	start := time.Now()
+
+	maxt, persisted, err := db.persistHead()
+	if err != nil {
+		return err
+	}
+	if !persisted {
+		return nil
+	}
+	db.metrics.compactionsPaused.Inc()
+
+	if err := db.head.truncateWAL(maxt); err != nil {
+		return fmt.Errorf("WAL truncation: %w", err)
+	}
+	if err := db.compactOOOHead(ctx); err != nil {
+		return fmt.Errorf("compact ooo head: %w", err)
+	}
+	db.logger.Info("resuming block compaction", "pause", time.Since(start).String())
+	return nil
+}
+
 // persistHead persists one chunk range of the head to disk if the head is
 // compactable and the compaction delay has passed. It returns the maxt of the
 // persisted range and whether a block was written.
@@ -2009,6 +2053,9 @@ func (db *DB) CompactSelectedSeries(seriesRefs []storage.SeriesRef) (err error) 
 	return nil
 }
 
+// Callback for testing.
+var compactBlocksTestingCallback func()
+
 // compactBlocks compacts all the eligible on-disk blocks.
 // The db.cmtx should be held before calling this method.
 func (db *DB) compactBlocks() (err error) {
@@ -2028,6 +2075,10 @@ func (db *DB) compactBlocks() (err error) {
 		}
 		if len(plan) == 0 {
 			break
+		}
+
+		if compactBlocksTestingCallback != nil {
+			compactBlocksTestingCallback()
 		}
 
 		select {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -1543,42 +1543,12 @@ func (db *DB) Compact(ctx context.Context) (returnErr error) {
 		default:
 		}
 
-		if !db.head.compactable() {
-			// Reset the counter once the head compactions are done.
-			// This would also reset it if a manual compaction was triggered while the auto compaction was in its delay period.
-			if !db.timeWhenCompactionDelayStarted.IsZero() {
-				db.timeWhenCompactionDelayStarted = time.Time{}
-			}
+		maxt, persisted, err := db.persistHead()
+		if err != nil {
+			return err
+		}
+		if !persisted {
 			break
-		}
-
-		if db.timeWhenCompactionDelayStarted.IsZero() {
-			// Start counting for the delay.
-			db.timeWhenCompactionDelayStarted = time.Now()
-		}
-		if db.waitingForCompactionDelay() {
-			break
-		}
-		mint := db.head.MinTime()
-		maxt := rangeForTimestamp(mint, db.head.chunkRange.Load())
-
-		// Wrap head into a range that bounds all reads to it.
-		// We remove 1 millisecond from maxt because block
-		// intervals are half-open: [b.MinTime, b.MaxTime). But
-		// chunk intervals are closed: [c.MinTime, c.MaxTime];
-		// so in order to make sure that overlaps are evaluated
-		// consistently, we explicitly remove the last value
-		// from the block interval here.
-		rh := NewRangeHeadWithIsolationDisabled(db.head, mint, maxt-1)
-
-		// Compaction runs with isolation disabled, because head.compactable()
-		// ensures that maxt is more than chunkRange/2 back from now, and
-		// head.appendableMinValidTime() ensures that no new appends can start within the compaction range.
-		// We do need to wait for any overlapping appenders that started previously to finish.
-		db.head.WaitForAppendersOverlapping(rh.MaxTime())
-
-		if err := db.compactHead(rh); err != nil {
-			return fmt.Errorf("compact head: %w", err)
 		}
 		// Consider only successful compactions for WAL truncation.
 		lastBlockMaxt = maxt
@@ -1607,6 +1577,56 @@ func (db *DB) Compact(ctx context.Context) (returnErr error) {
 	}
 
 	return db.compactBlocks()
+}
+
+// persistHead persists one chunk range of the head to disk if the head is
+// compactable and the compaction delay has passed. It returns the maxt of the
+// persisted range and whether a block was written.
+
+// Write HEAD block to disk, returning maxt and bool indicating if the
+// block was written or not, along with any error.
+// Callers are responsible for truncating the WAL and compacting the OOO head afterwards.
+// The db.cmtx should be held before calling this method.
+func (db *DB) persistHead() (int64, bool, error) {
+	if !db.head.compactable() {
+		// Reset the counter once the head compactions are done.
+		// This would also reset it if a manual compaction was triggered while the auto compaction was in its delay period.
+		if !db.timeWhenCompactionDelayStarted.IsZero() {
+			db.timeWhenCompactionDelayStarted = time.Time{}
+		}
+		return 0, false, nil
+	}
+
+	if db.timeWhenCompactionDelayStarted.IsZero() {
+		// Start counting for the delay.
+		db.timeWhenCompactionDelayStarted = time.Now()
+	}
+	if db.waitingForCompactionDelay() {
+		return 0, false, nil
+	}
+	mint := db.head.MinTime()
+	maxt := rangeForTimestamp(mint, db.head.chunkRange.Load())
+
+	// Wrap head into a range that bounds all reads to it.
+	// We remove 1 millisecond from maxt because block
+	// intervals are half-open: [b.MinTime, b.MaxTime). But
+	// chunk intervals are closed: [c.MinTime, c.MaxTime];
+	// so in order to make sure that overlaps are evaluated
+	// consistently, we explicitly remove the last value
+	// from the block interval here.
+	rh := NewRangeHeadWithIsolationDisabled(db.head, mint, maxt-1)
+
+	// Compaction runs with isolation disabled, because head.compactable()
+	// ensures that maxt is more than chunkRange/2 back from now, and
+	// head.appendableMinValidTime() ensures that no new appends can start within the compaction range.
+	// We do need to wait for any overlapping appenders that started previously to finish.
+	db.head.WaitForAppendersOverlapping(rh.MaxTime())
+
+	if err := db.compactHead(rh); err != nil {
+		return 0, false, fmt.Errorf("compact head: %w", err)
+	}
+
+	return maxt, true, nil
 }
 
 // CompactHead compacts the given RangeHead.

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3767,6 +3767,105 @@ func TestOneCheckpointPerCompactCall(t *testing.T) {
 	require.Equal(t, 54, cno)
 }
 
+// TestDBCompactPersistsHeadDuringBlockMerge verifies that Compact pauses a
+// running block merge to write the head block once the head becomes
+// compactable, and then finishes the merge.
+// Not parallel: it mutates compactBlocksTestingCallback.
+func TestDBCompactPersistsHeadDuringBlockMerge(t *testing.T) {
+	blockRange := int64(1000)
+	opts := &Options{
+		RetentionDuration: blockRange * 1000,
+		NoLockfile:        true,
+		MinBlockDuration:  blockRange,
+		MaxBlockDuration:  3 * blockRange,
+	}
+
+	ctx := context.Background()
+	db := newTestDB(t, withOpts(opts), withRngs(blockRange, 3*blockRange))
+	db.DisableCompactions()
+
+	newSeries := func(mint, maxt int64) []storage.Series {
+		return genSeriesFromSampleGenerator(2, 1, mint, maxt, 1, func(ts int64) chunks.Sample {
+			return sample{t: ts, f: float64(ts)}
+		})
+	}
+	// Four blocks: Plan ignores the newest one, so only the first three merge.
+	for i := range int64(4) {
+		createBlock(t, db.Dir(), newSeries(i*blockRange, (i+1)*blockRange))
+	}
+	require.NoError(t, db.reloadBlocks())
+	require.Len(t, db.Blocks(), 4)
+
+	// Append to the head when the merge starts so that the head becomes
+	// compactable mid-merge, like a merge that runs long enough would.
+	headLabels := labels.FromStrings("foo", "bar")
+	compactBlocksTestingCallback = func() {
+		app := db.Appender(ctx)
+		for ts := 4 * blockRange; ts <= 4*blockRange+1600; ts += 100 {
+			_, err := app.Append(0, headLabels, ts, float64(ts))
+			require.NoError(t, err)
+		}
+		require.NoError(t, app.Commit())
+		// Rotate the WAL so that truncation creates a checkpoint.
+		for range 3 {
+			_, err := db.head.wal.NextSegment()
+			require.NoError(t, err)
+		}
+	}
+	t.Cleanup(func() { compactBlocksTestingCallback = nil })
+
+	require.NoError(t, db.Compact(ctx))
+	require.Equal(t, 1.0, prom_testutil.ToFloat64(db.metrics.compactionsPaused))
+	require.Equal(t, 1.0, prom_testutil.ToFloat64(db.head.metrics.checkpointCreationTotal))
+	require.Equal(t, 5*blockRange, db.Head().MinTime())
+
+	blocks := db.Blocks()
+	require.Len(t, blocks, 3)
+
+	merged := blocks[0].Meta()
+	require.Equal(t, int64(0), merged.MinTime)
+	require.Equal(t, 3*blockRange, merged.MaxTime)
+	require.Equal(t, 2, merged.Compaction.Level)
+	require.Len(t, merged.Compaction.Sources, 3)
+
+	untouched := blocks[1].Meta()
+	require.Equal(t, 3*blockRange, untouched.MinTime)
+	require.Equal(t, 4*blockRange, untouched.MaxTime)
+	require.Equal(t, 1, untouched.Compaction.Level)
+
+	headBlock := blocks[2].Meta()
+	require.Equal(t, 4*blockRange, headBlock.MinTime)
+	require.Equal(t, 5*blockRange, headBlock.MaxTime)
+	require.Equal(t, 1, headBlock.Compaction.Level)
+
+	expBlocks := map[string][]chunks.Sample{}
+	for _, series := range [][]storage.Series{
+		newSeries(0, blockRange),
+		newSeries(blockRange, 2*blockRange),
+		newSeries(2*blockRange, 3*blockRange),
+		newSeries(3*blockRange, 4*blockRange),
+	} {
+		for _, s := range series {
+			samples, err := storage.ExpandSamples(s.Iterator(nil), newSample)
+			require.NoError(t, err)
+			expBlocks[s.Labels().String()] = append(expBlocks[s.Labels().String()], samples...)
+		}
+	}
+
+	q, err := db.Querier(math.MinInt64, math.MaxInt64)
+	require.NoError(t, err)
+	require.Equal(t, expBlocks, query(t, q, labels.MustNewMatcher(labels.MatchRegexp, defaultLabelName, ".+")))
+
+	expHead := map[string][]chunks.Sample{}
+	for ts := 4 * blockRange; ts <= 4*blockRange+1600; ts += 100 {
+		expHead[headLabels.String()] = append(expHead[headLabels.String()], sample{t: ts, f: float64(ts)})
+	}
+
+	q, err = db.Querier(math.MinInt64, math.MaxInt64)
+	require.NoError(t, err)
+	require.Equal(t, expHead, query(t, q, labels.MustNewMatcher(labels.MatchRegexp, "foo", "bar")))
+}
+
 func TestNoPanicOnTSDBOpenError(t *testing.T) {
 	tmpdir := t.TempDir()
 


### PR DESCRIPTION
LeveledCompactor takes 3 existing blocks and builds one large block out of them, once it has 3 bigger blocks it will also merge these together, up to 10% of configured retention.
The problem is that if original blocks are big enough, or if the retention is long enough, compactor might be building fairly large blocks, which takes time, I/O and cpu/mem.
On the other hand merging blocks is fairly important - without it each on-disk block has almost identical index (assuming no crazy churn of series), which is often very large, takes disk space (reducing effective retention) and iterating 3 * 2h block indexes is more expensive then iterating 1 * 6h block index. Simply disabling compactions will cause huge index bloat, take up a lot of disk space and also degrade query performance (more bytes to read from disk, more cpu to iterate it all).

The problem is that when we're merging big blocks, which can take an hour or more, TSDB isn't doing anything else - no HEAD block writes, no WAL checkpoints, because it's a single goroutine. If you have a big & busy Prometheus with high memory pressure already then running long compactions will increase that memory pressure even more, because more chunks will keep accumulating in memory and stale series won't be flushed to disk as quickly as it could be. In extreme cases this can lead to a death spiral:
- long and I/O heavy compaction blocks TSDB
- TSDB is forced to keep more data in memory and memory usage goes up
- There's less free memory for page cache so I/O intense compaction slows down
- This prolongs TSDB blockage even further leading to even more building up chunks in memory
- With enough memory pressure Prometheus might get OOM killed

Blocking TSDB also affects WAL - there's no WAL checkpointing so WAL files keep growing, once we finish compaction and checkpoint can run it will take a long time to finish, because there's a lot more WAL files, which will also delay next HEAD block write.

This PR tries to improve this by allowing compaction to be interrupted - while compacting we check every now and then if some other operation must run (HEAD block write or checkpoint), that's done by calling MaybePause (couldn't think of any better name, but `Interrupt`, `Yield` or `NeedsHeadWrite` could be used here maybe?). `MaybePause` might run some other operations if it needs to, like write a HEAD block, and once it's done it returns and compaction resumes.
If prometheus restarts in the middle then compaction is cancelled, just like it would be with current code.

```release-notes
[ENHANCEMENT] tsdb: pause on-disk block compactions when we need to write HEAD block to disk
```
