### PR TITLE
cmd/prometheus: fix flaky TestRuntimeGOGCConfig

### DIFF
--- a/cmd/prometheus/features_test.go
+++ b/cmd/prometheus/features_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -53,15 +52,7 @@ func TestFeaturesAPI(t *testing.T) {
 
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 
-	// Wait for Prometheus to be ready.
-	require.Eventually(t, func() bool {
-		resp, err := http.Get(baseURL + "/-/ready")
-		if err != nil {
-			return false
-		}
-		defer resp.Body.Close()
-		return resp.StatusCode == http.StatusOK
-	}, 10*time.Second, 100*time.Millisecond, "Prometheus didn't become ready in time")
+	waitForPrometheusReady(t, port)
 
 	// Fetch features from the API.
 	resp, err := http.Get(baseURL + "/api/v1/features")

--- a/cmd/prometheus/main_test.go
+++ b/cmd/prometheus/main_test.go
@@ -178,14 +178,7 @@ storage:
 	)
 	require.NoError(t, prom.Start())
 
-	require.Eventually(t, func() bool {
-		r, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/metrics", port))
-		if err != nil {
-			return false
-		}
-		defer r.Body.Close()
-		return r.StatusCode == http.StatusOK
-	}, startupTime, 100*time.Millisecond)
+	waitForPrometheusReady(t, port)
 	require.DirExists(t, storagePath)
 }
 
@@ -902,26 +895,24 @@ global:
 				fmt.Sprintf("--storage.tsdb.path=%s", tmpDir),
 				"--web.enable-lifecycle",
 			)
-			// Inject GOGC when set.
-			prom.Env = os.Environ()
+			// Inject GOGC when set, and drop any inherited one otherwise, so
+			// that the environment the test runs in cannot influence the cases
+			// expecting the default or the configured value.
+			prom.Env = slices.DeleteFunc(os.Environ(), func(kv string) bool {
+				return strings.HasPrefix(kv, "GOGC=")
+			})
 			if tc.gogcEnvVar != "" {
 				prom.Env = append(prom.Env, fmt.Sprintf("GOGC=%s", tc.gogcEnvVar))
 			}
 			require.NoError(t, prom.Start())
 
+			// Wait for the initial configuration to be applied: /metrics is
+			// already served before that happens.
+			waitForPrometheusReady(t, port)
+
 			ensureGOGCValue := func(val float64) {
-				var (
-					r   *http.Response
-					err error
-				)
-				// Wait for the /metrics endpoint to be ready.
-				require.Eventually(t, func() bool {
-					r, err = http.Get(fmt.Sprintf("http://127.0.0.1:%d/metrics", port))
-					if err != nil {
-						return false
-					}
-					return r.StatusCode == http.StatusOK
-				}, 5*time.Second, 50*time.Millisecond)
+				r, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/metrics", port))
+				require.NoError(t, err)
 				defer r.Body.Close()
 
 				// Check the final GOGC that's set, consider go_gc_gogc_percent from /metrics as source of truth.

--- a/cmd/prometheus/reload_test.go
+++ b/cmd/prometheus/reload_test.go
@@ -123,14 +123,7 @@ func runTestSteps(t *testing.T, steps []struct {
 	require.NoError(t, prom.Start())
 
 	baseURL := "http://localhost:" + strconv.Itoa(port)
-	require.Eventually(t, func() bool {
-		resp, err := http.Get(baseURL + "/-/ready")
-		if err != nil {
-			return false
-		}
-		defer resp.Body.Close()
-		return resp.StatusCode == http.StatusOK
-	}, 5*time.Second, 100*time.Millisecond, "Prometheus didn't become ready in time")
+	waitForPrometheusReady(t, port)
 
 	for i, step := range steps {
 		t.Logf("Step %d", i)
@@ -240,4 +233,26 @@ func prometheusCommandWithLogging(t testing.TB, configFilePath string, port int,
 	}
 	args = append(args, extraArgs...)
 	return commandWithLogging(t, nil, promPath, args...)
+}
+
+// readyTimeout is how long we wait for a Prometheus process to become ready. It
+// is generous on purpose: CI runs these tests with the race detector, which
+// slows down both the test binary and the Prometheus processes it spawns in
+// parallel.
+const readyTimeout = 30 * time.Second
+
+// waitForPrometheusReady waits until the Prometheus instance listening on port
+// reports itself as ready, which means it has opened its storage and applied
+// its initial configuration.
+func waitForPrometheusReady(t testing.TB, port int) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get("http://127.0.0.1:" + strconv.Itoa(port) + "/-/ready")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, readyTimeout, 100*time.Millisecond, "Prometheus didn't become ready in time")
 }


### PR DESCRIPTION
TL;DR; I saw TestRuntimeGOGCConfig fail in a CI. At first I suspected that it cannot be run in parallel due to environment use, but it's only setting sub process env, so that wasn't it. The issue is that it's not waiting long enough for the process, which can take it's time in CI.  LLM also noticed another bug with developer settings leaking into the test. Both fixed in this PR.


LLM:

`TestRuntimeGOGCConfig` gave the spawned Prometheus 5 seconds to serve `/metrics`, the shortest deadline in the package. CI runs this package as `go test --tags=slicelabels -race ./cmd/prometheus`, so both the test binary and the Prometheus processes it spawns in parallel are race-instrumented, and 5 seconds is not always enough to get as far as creating the web listener. Seen on `main`:

```
--- FAIL: TestRuntimeGOGCConfig/empty_config_file_with_GOGC_env_var_set (5.07s)
    reload_test.go:194: ... msg="Starting Prometheus Server" ...
    reload_test.go:194: ... msg="operational information" ...
    main_test.go:918:
        	Error:      	Condition never satisfied
        	Test:       	TestRuntimeGOGCConfig/empty_config_file_with_GOGC_env_var_set
```

The captured log stops right after `operational information`, i.e. the process was alive but had not yet reached `webHandler.Listeners()`.

### Changes

**Wait for readiness through one helper.** The package had four copies of the same readiness poll with three different deadlines (5s, 5s, 10s, `startupTime`) and two different endpoints. They are replaced by a single `waitForPrometheusReady` with a more generous deadline.

`startupTime` could not simply be raised: seven of its eight uses are `case <-time.After(startupTime)` in a select meaning "if the process is still alive after this long it started successfully, now kill it", so raising it would add that time to those tests on the success path.

**Wait on `/-/ready` rather than `/metrics`.** This closes a second race in `TestRuntimeGOGCConfig` that is independent of the timeout: `/metrics` is served before the initial configuration is applied, so `go_gc_gogc_percent` could still hold the default when first scraped. `/-/ready` only flips after `<-dbOpen` and a successful `reloadConfig`.

**Drop an inherited `GOGC` from the spawned process's environment.** The test built the child environment from `os.Environ()`, so a `GOGC` set in the environment leaked into the cases that expect the default or the configured value:

```
$ GOGC=42 go test -run TestRuntimeGOGCConfig ./cmd/prometheus/
--- FAIL: TestRuntimeGOGCConfig/empty_config_file (0.54s)
        	expected: 75
        	actual  : 42
--- FAIL: TestRuntimeGOGCConfig/incomplete_runtime_block (0.58s)
        	expected: 75
        	actual  : 42
```

That passes with this change.

### Testing

`go test --tags=slicelabels -race -run 'TestRuntimeGOGCConfig|TestFeatures|TestAutoReloadConfig|TestRetentionPercentage' ./cmd/prometheus/` passes, as does the run with `GOGC=42` set in the environment.

```release-notes
NONE
```