### PR TITLE
rule: add alerting rule backtesting and promtool query backtest

### DIFF
--- a/cmd/promtool/backtest.go
+++ b/cmd/promtool/backtest.go
@@ -1,0 +1,256 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/rules"
+)
+
+// backtestConfig holds the flags of the "query backtest" command.
+type backtestConfig struct {
+	name          string
+	expr          string
+	forDuration   time.Duration
+	keepFiringFor time.Duration
+	ruleLabels    map[string]string
+	start, end    string
+	interval      time.Duration
+	headers       map[string]string
+}
+
+// alertPeriod is a contiguous run of evaluations during which one alert
+// instance stayed in the same state.
+type alertPeriod struct {
+	Labels map[string]string `json:"labels"`
+	State  string            `json:"state"`
+	Start  time.Time         `json:"start"`
+	End    time.Time         `json:"end"`
+}
+
+// BacktestAlert replays an alerting rule over historical data on a Prometheus
+// server and reports when it would have been pending and firing.
+func BacktestAlert(serverURL *url.URL, roundTripper http.RoundTripper, cfg backtestConfig, exprParser parser.Parser, p printer) int {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	periods, err := backtestAlert(ctx, serverURL, roundTripper, cfg, exprParser)
+	if err != nil {
+		return handleAPIError(err)
+	}
+
+	printAlertPeriods(periods, p)
+	return successExitCode
+}
+
+func backtestAlert(ctx context.Context, serverURL *url.URL, roundTripper http.RoundTripper, cfg backtestConfig, exprParser parser.Parser) ([]alertPeriod, error) {
+	opts, err := cfg.backtestOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	rule, err := cfg.rule(exprParser)
+	if err != nil {
+		return nil, err
+	}
+
+	api, err := newAPI(serverURL, roundTripper, cfg.headers)
+	if err != nil {
+		return nil, fmt.Errorf("creating API client: %w", err)
+	}
+
+	// A single range query at the evaluation interval yields the same samples as
+	// one instant query per step, at a fraction of the cost.
+	val, _, err := api.QueryRange(ctx, cfg.expr, v1.Range{Start: opts.Start, End: opts.End, Step: opts.Interval})
+	if err != nil {
+		return nil, err
+	}
+	m, ok := val.(model.Matrix)
+	if !ok {
+		return nil, fmt.Errorf("expected a range vector result, got %s", val.Type())
+	}
+	samples, err := convertMatrix(m)
+	if err != nil {
+		return nil, err
+	}
+
+	alerts, err := rules.BacktestMatrix(ctx, rule, samples, apiQueryFunc(api), opts)
+	if err != nil {
+		return nil, err
+	}
+	return alertPeriods(alerts, opts.Interval), nil
+}
+
+func (cfg backtestConfig) rule(exprParser parser.Parser) (*rules.AlertingRule, error) {
+	expr, err := exprParser.ParseExpr(cfg.expr)
+	if err != nil {
+		return nil, err
+	}
+	return rules.NewAlertingRule(
+		cfg.name, expr, cfg.forDuration, cfg.keepFiringFor,
+		labels.FromMap(cfg.ruleLabels), labels.EmptyLabels(), labels.EmptyLabels(),
+		"", false, nil,
+	), nil
+}
+
+func (cfg backtestConfig) backtestOptions() (rules.BacktestOptions, error) {
+	opts := rules.BacktestOptions{Interval: cfg.interval}
+
+	var err error
+	opts.End = time.Now()
+	if cfg.end != "" {
+		if opts.End, err = parseTime(cfg.end); err != nil {
+			return opts, fmt.Errorf("end time: %w", err)
+		}
+	}
+
+	opts.Start = opts.End.Add(-time.Hour)
+	if cfg.start != "" {
+		if opts.Start, err = parseTime(cfg.start); err != nil {
+			return opts, fmt.Errorf("start time: %w", err)
+		}
+	}
+	return opts, nil
+}
+
+// apiQueryFunc adapts a Prometheus API client to the query function used for
+// expanding alert templates.
+func apiQueryFunc(api v1.API) rules.QueryFunc {
+	return func(ctx context.Context, q string, t time.Time) (promql.Vector, error) {
+		val, _, err := api.Query(ctx, q, t)
+		if err != nil {
+			return nil, err
+		}
+		vec, ok := val.(model.Vector)
+		if !ok {
+			return nil, fmt.Errorf("expected an instant vector result, got %s", val.Type())
+		}
+		out := make(promql.Vector, 0, len(vec))
+		for _, s := range vec {
+			out = append(out, promql.Sample{
+				Metric: convertMetric(s.Metric),
+				T:      int64(s.Timestamp),
+				F:      float64(s.Value),
+			})
+		}
+		return out, nil
+	}
+}
+
+func convertMatrix(m model.Matrix) (promql.Matrix, error) {
+	out := make(promql.Matrix, 0, len(m))
+	for _, ss := range m {
+		if len(ss.Histograms) > 0 {
+			return nil, errors.New("backtesting expressions that return native histograms is not supported")
+		}
+		s := promql.Series{
+			Metric: convertMetric(ss.Metric),
+			Floats: make([]promql.FPoint, 0, len(ss.Values)),
+		}
+		for _, p := range ss.Values {
+			s.Floats = append(s.Floats, promql.FPoint{T: int64(p.Timestamp), F: float64(p.Value)})
+		}
+		out = append(out, s)
+	}
+	sort.Sort(out)
+	return out, nil
+}
+
+func convertMetric(m model.Metric) labels.Labels {
+	b := labels.NewScratchBuilder(len(m))
+	for n, v := range m {
+		b.Add(string(n), string(v))
+	}
+	b.Sort()
+	return b.Labels()
+}
+
+// alertPeriods collapses the ALERTS series of a backtest into one entry per
+// uninterrupted run of the same state. A gap wider than the evaluation interval
+// ends the current period.
+func alertPeriods(m promql.Matrix, interval time.Duration) []alertPeriod {
+	var out []alertPeriod
+	for _, s := range m {
+		if s.Metric.Get(labels.MetricName) != "ALERTS" {
+			continue
+		}
+
+		lset := s.Metric.Map()
+		delete(lset, labels.MetricName)
+		state := lset["alertstate"]
+		delete(lset, "alertstate")
+
+		var cur *alertPeriod
+		for _, p := range s.Floats {
+			ts := timestamp.Time(p.T)
+			if cur != nil && ts.Sub(cur.End) <= interval {
+				cur.End = ts
+				continue
+			}
+			if cur != nil {
+				out = append(out, *cur)
+			}
+			cur = &alertPeriod{Labels: lset, State: state, Start: ts, End: ts}
+		}
+		if cur != nil {
+			out = append(out, *cur)
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].Start.Equal(out[j].Start) {
+			return out[i].Start.Before(out[j].Start)
+		}
+		return out[i].State < out[j].State
+	})
+	return out
+}
+
+func printAlertPeriods(periods []alertPeriod, p printer) {
+	if _, ok := p.(*jsonPrinter); ok {
+		//nolint:errcheck
+		json.NewEncoder(os.Stdout).Encode(periods)
+		return
+	}
+
+	if len(periods) == 0 {
+		fmt.Println("The alert would never have been active over this range.")
+		return
+	}
+	for _, period := range periods {
+		fmt.Printf("%-7s %s -> %s (%s) %s\n",
+			period.State,
+			period.Start.UTC().Format(time.RFC3339),
+			period.End.UTC().Format(time.RFC3339),
+			period.End.Sub(period.Start),
+			labels.FromMap(period.Labels).String(),
+		)
+	}
+}

--- a/cmd/promtool/backtest_test.go
+++ b/cmd/promtool/backtest_test.go
@@ -1,0 +1,177 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// backtestServer serves a fixed range query result, standing in for a Prometheus
+// server holding the historical data.
+func backtestServer(t *testing.T, body string) *url.URL {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/query_range", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(body))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	return u
+}
+
+func TestBacktestAlert(t *testing.T) {
+	t.Parallel()
+
+	// The result of `http_requests < 100` at a 1m step: below the threshold from
+	// 1m to 4m, back above it at 5m, below again at 6m and 7m.
+	const result = `{"status":"success","data":{"resultType":"matrix","result":[
+		{"metric":{"__name__":"http_requests","instance":"0"},
+		 "values":[[60,"90"],[120,"90"],[180,"90"],[240,"90"],[360,"90"],[420,"90"]]}
+	]}}`
+
+	at := func(sec int64) time.Time { return time.Unix(sec, 0).UTC() }
+	instance := map[string]string{"alertname": "Backtest", "instance": "0"}
+
+	for _, tc := range []struct {
+		name          string
+		forDuration   time.Duration
+		keepFiringFor time.Duration
+		want          []alertPeriod
+	}{
+		{
+			name: "no for",
+			want: []alertPeriod{
+				{Labels: instance, State: "firing", Start: at(60), End: at(240)},
+				{Labels: instance, State: "firing", Start: at(360), End: at(420)},
+			},
+		},
+		{
+			name:        "for 2m",
+			forDuration: 2 * time.Minute,
+			want: []alertPeriod{
+				{Labels: instance, State: "pending", Start: at(60), End: at(120)},
+				{Labels: instance, State: "firing", Start: at(180), End: at(240)},
+				{Labels: instance, State: "pending", Start: at(360), End: at(420)},
+			},
+		},
+		{
+			name:        "for 5m never fires",
+			forDuration: 5 * time.Minute,
+			want: []alertPeriod{
+				{Labels: instance, State: "pending", Start: at(60), End: at(240)},
+				{Labels: instance, State: "pending", Start: at(360), End: at(420)},
+			},
+		},
+		{
+			name:          "keep_firing_for bridges the gap",
+			keepFiringFor: 2 * time.Minute,
+			want: []alertPeriod{
+				{Labels: instance, State: "firing", Start: at(60), End: at(480)},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := backtestConfig{
+				name:          "Backtest",
+				expr:          "http_requests < 100",
+				forDuration:   tc.forDuration,
+				keepFiringFor: tc.keepFiringFor,
+				start:         "0",
+				end:           "480",
+				interval:      time.Minute,
+			}
+
+			got, err := backtestAlert(context.Background(), backtestServer(t, result), http.DefaultTransport, cfg, parser.NewParser(parser.Options{}))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestBacktestAlertCommand exercises the command through the real CLI, which is
+// the only way to cover the kingpin flag wiring.
+func TestBacktestAlertCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	const result = `{"status":"success","data":{"resultType":"matrix","result":[
+		{"metric":{"__name__":"http_requests","instance":"0"},
+		 "values":[[60,"90"],[120,"90"],[180,"90"],[240,"90"]]}
+	]}}`
+
+	out, err := exec.Command(promtoolPath, "-test.main", "query", "backtest",
+		backtestServer(t, result).String(), "http_requests < 100",
+		"--for=2m", "--start=0", "--end=480", "--interval=1m",
+		"--label=severity=page", "--header=X-Test=1",
+	).CombinedOutput()
+	require.NoError(t, err, "promtool output: %s", out)
+
+	require.Contains(t, string(out), "pending")
+	require.Contains(t, string(out), "firing")
+	require.Contains(t, string(out), `severity="page"`)
+}
+
+func TestBacktestAlertErrors(t *testing.T) {
+	t.Parallel()
+
+	const empty = `{"status":"success","data":{"resultType":"matrix","result":[]}}`
+
+	for _, tc := range []struct {
+		name string
+		cfg  backtestConfig
+		err  string
+	}{
+		{
+			name: "invalid expression",
+			cfg:  backtestConfig{expr: "http_requests <", interval: time.Minute},
+			err:  "unexpected end of input",
+		},
+		{
+			name: "invalid start time",
+			cfg:  backtestConfig{expr: "up", start: "yesterday", interval: time.Minute},
+			err:  `start time: cannot parse "yesterday"`,
+		},
+		{
+			name: "range too long for the interval",
+			cfg:  backtestConfig{expr: "up", start: "0", end: "660000", interval: time.Second},
+			err:  "exceeded maximum of 11000 evaluations",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := backtestAlert(context.Background(), backtestServer(t, empty), http.DefaultTransport, tc.cfg, parser.NewParser(parser.Options{}))
+			require.ErrorContains(t, err, tc.err)
+		})
+	}
+}

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -194,6 +194,20 @@ func main() {
 	queryRangeEnd := queryRangeCmd.Flag("end", "Query range end time (RFC3339 or Unix timestamp).").String()
 	queryRangeStep := queryRangeCmd.Flag("step", "Query step size (duration).").Duration()
 
+	// The maps must be non-nil: kingpin assigns into them without allocating.
+	backtestCfg := backtestConfig{ruleLabels: map[string]string{}, headers: map[string]string{}}
+	queryBacktestCmd := queryCmd.Command("backtest", "Replay an alerting rule over historical data and report when it would have been pending and firing.")
+	queryBacktestCmd.Arg("server", "Prometheus server to query.").Required().URLVar(&serverURL)
+	queryBacktestCmd.Arg("expr", "PromQL alerting rule expression.").Required().StringVar(&backtestCfg.expr)
+	queryBacktestCmd.Flag("name", "Name of the simulated alert.").Default("Backtest").StringVar(&backtestCfg.name)
+	queryBacktestCmd.Flag("for", "The 'for' duration to simulate.").DurationVar(&backtestCfg.forDuration)
+	queryBacktestCmd.Flag("keep-firing-for", "The 'keep_firing_for' duration to simulate.").DurationVar(&backtestCfg.keepFiringFor)
+	queryBacktestCmd.Flag("label", "Label to attach to the simulated alert. Can be specified multiple times.").StringMapVar(&backtestCfg.ruleLabels)
+	queryBacktestCmd.Flag("start", "Backtest range start time (RFC3339 or Unix timestamp), defaults to one hour before the end.").StringVar(&backtestCfg.start)
+	queryBacktestCmd.Flag("end", "Backtest range end time (RFC3339 or Unix timestamp), defaults to now.").StringVar(&backtestCfg.end)
+	queryBacktestCmd.Flag("interval", "Evaluation interval to simulate. Determines the resolution of the 'for' duration.").Default("1m").DurationVar(&backtestCfg.interval)
+	queryBacktestCmd.Flag("header", "Extra headers to send to server.").StringMapVar(&backtestCfg.headers)
+
 	querySeriesCmd := queryCmd.Command("series", "Run series query.")
 	querySeriesCmd.Arg("server", "Prometheus server to query.").Required().URLVar(&serverURL)
 	querySeriesMatch := querySeriesCmd.Flag("match", "Series selector. Can be specified multiple times.").Required().Strings()
@@ -405,6 +419,9 @@ func main() {
 
 	case queryRangeCmd.FullCommand():
 		os.Exit(QueryRange(serverURL, httpRoundTripper, *queryRangeHeaders, *queryRangeExpr, *queryRangeBegin, *queryRangeEnd, *queryRangeStep, p))
+
+	case queryBacktestCmd.FullCommand():
+		os.Exit(BacktestAlert(serverURL, httpRoundTripper, backtestCfg, promtoolParser, p))
 
 	case querySeriesCmd.FullCommand():
 		os.Exit(QuerySeries(serverURL, httpRoundTripper, *querySeriesMatch, *querySeriesBegin, *querySeriesEnd, p))

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -283,6 +283,38 @@ Run range query.
 
 
 
+##### `promtool query backtest`
+
+Replay an alerting rule over historical data and report when it would have been pending and firing.
+
+
+
+###### Flags
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| <code class="text-nowrap">--name</code> | Name of the simulated alert. | `Backtest` |
+| <code class="text-nowrap">--for</code> | The 'for' duration to simulate. |  |
+| <code class="text-nowrap">--keep-firing-for</code> | The 'keep_firing_for' duration to simulate. |  |
+| <code class="text-nowrap">--label</code> | Label to attach to the simulated alert. Can be specified multiple times. |  |
+| <code class="text-nowrap">--start</code> | Backtest range start time (RFC3339 or Unix timestamp), defaults to one hour before the end. |  |
+| <code class="text-nowrap">--end</code> | Backtest range end time (RFC3339 or Unix timestamp), defaults to now. |  |
+| <code class="text-nowrap">--interval</code> | Evaluation interval to simulate. Determines the resolution of the 'for' duration. | `1m` |
+| <code class="text-nowrap">--header</code> | Extra headers to send to server. |  |
+
+
+
+
+###### Arguments
+
+| Argument | Description | Required |
+| --- | --- | --- |
+| server | Prometheus server to query. | Yes |
+| expr | PromQL alerting rule expression. | Yes |
+
+
+
+
 ##### `promtool query series`
 
 Run series query.

--- a/rules/alerting.go
+++ b/rules/alerting.go
@@ -390,7 +390,12 @@ func (r *AlertingRule) Eval(ctx context.Context, queryOffset time.Duration, ts t
 	if err != nil {
 		return nil, err
 	}
+	return r.eval(ctx, queryOffset, ts, res, query, externalURL, limit)
+}
 
+// eval advances the alert state machine by one step, using res as the result of
+// the rule expression at ts. query is only used to expand templates.
+func (r *AlertingRule) eval(ctx context.Context, queryOffset time.Duration, ts time.Time, res promql.Vector, query QueryFunc, externalURL *url.URL, limit int) (promql.Vector, error) {
 	// Create pending alerts for any new vector elements in the alert expression
 	// or update the expression value for existing elements.
 	resultFPs := map[uint64]struct{}{}

--- a/rules/backtest.go
+++ b/rules/backtest.go
@@ -1,0 +1,206 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+// MaxBacktestSteps caps the number of simulated evaluations of a single backtest.
+// It matches the range query point limit of the HTTP API.
+const MaxBacktestSteps = 11000
+
+// BacktestOptions configures a backtest run.
+type BacktestOptions struct {
+	// Start and End bound the simulated evaluations, both inclusive.
+	Start, End time.Time
+	// Interval is the simulated group evaluation interval. It determines the
+	// resolution at which the alert expression is sampled, so a coarse interval
+	// makes the "for" duration coarse too.
+	Interval time.Duration
+	// Limit is the per-evaluation alert limit, as configured on the rule group.
+	Limit int
+	// ExternalURL is used to expand the $externalURL template variable.
+	ExternalURL *url.URL
+}
+
+func (o BacktestOptions) validate() error {
+	switch {
+	case o.Interval <= 0:
+		return errors.New("interval must be positive")
+	case o.End.Before(o.Start):
+		return errors.New("end timestamp must not be before start timestamp")
+	case o.steps() > MaxBacktestSteps:
+		return fmt.Errorf("exceeded maximum of %d evaluations, try a larger interval or a shorter range", MaxBacktestSteps)
+	}
+	return nil
+}
+
+func (o BacktestOptions) steps() int {
+	return int(o.End.Sub(o.Start)/o.Interval) + 1
+}
+
+// Backtest replays rule over the range described by opts using data already in
+// storage, and returns the ALERTS and ALERTS_FOR_STATE series the rule would
+// have produced. The rule expression is evaluated as a single range query, which
+// is equivalent to, but much cheaper than, one instant query per step.
+//
+// rule is left untouched; the replay runs against a copy of it.
+func Backtest(ctx context.Context, rule *AlertingRule, engine promql.QueryEngine, queryable storage.Queryable, opts BacktestOptions) (promql.Matrix, annotations.Annotations, error) {
+	if err := opts.validate(); err != nil {
+		return nil, nil, err
+	}
+
+	qry, err := engine.NewRangeQuery(ctx, queryable, nil, rule.vector.String(), opts.Start, opts.End, opts.Interval)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer qry.Close()
+
+	res := qry.Exec(ctx)
+	if res.Err != nil {
+		return nil, res.Warnings, res.Err
+	}
+	m, err := res.Matrix()
+	if err != nil {
+		return nil, res.Warnings, err
+	}
+
+	out, err := BacktestMatrix(ctx, rule, m, EngineQueryFunc(engine, queryable), opts)
+	return out, res.Warnings, err
+}
+
+// BacktestMatrix replays rule over m, which must be the result of range querying
+// the rule expression over the same range and at the same interval as opts
+// describes. query is only used to expand templates and may be nil if the rule
+// has no templated labels or annotations.
+//
+// It is the transport-independent half of Backtest, for callers that obtain the
+// matrix from somewhere other than a local query engine.
+func BacktestMatrix(ctx context.Context, rule *AlertingRule, m promql.Matrix, query QueryFunc, opts BacktestOptions) (promql.Matrix, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+	if query == nil {
+		query = noopQueryFunc
+	}
+
+	// A copy keeps the live state of rule intact, and restored=true makes eval
+	// emit the alert series we are after.
+	replay := rule.clone(true)
+	out := seriesBuilder{}
+	it := newMatrixIterator(m)
+
+	for i := range opts.steps() {
+		ts := opts.Start.Add(time.Duration(i) * opts.Interval)
+		vec, err := replay.eval(ctx, 0, ts, it.at(ts), query, opts.ExternalURL, opts.Limit)
+		if err != nil {
+			return nil, fmt.Errorf("evaluating at %s: %w", ts, err)
+		}
+		out.add(vec)
+	}
+	return out.matrix(), nil
+}
+
+func noopQueryFunc(context.Context, string, time.Time) (promql.Vector, error) {
+	return nil, nil
+}
+
+// seriesBuilder accumulates the vectors of successive evaluations into a matrix.
+type seriesBuilder map[uint64]*promql.Series
+
+func (b seriesBuilder) add(vec promql.Vector) {
+	for _, s := range vec {
+		h := s.Metric.Hash()
+		if _, ok := b[h]; !ok {
+			b[h] = &promql.Series{Metric: s.Metric}
+		}
+		b[h].Floats = append(b[h].Floats, promql.FPoint{T: s.T, F: s.F})
+	}
+}
+
+func (b seriesBuilder) matrix() promql.Matrix {
+	m := make(promql.Matrix, 0, len(b))
+	for _, s := range b {
+		m = append(m, *s)
+	}
+	sort.Sort(m)
+	return m
+}
+
+// clone returns a copy of r with no active alerts, so that it can be evaluated
+// independently of the original.
+func (r *AlertingRule) clone(restored bool) *AlertingRule {
+	return NewAlertingRule(
+		r.name, r.vector, r.holdDuration, r.keepFiringFor,
+		r.labels, r.annotations, labels.FromMap(r.externalLabels), r.externalURL,
+		restored, r.logger,
+	)
+}
+
+// matrixIterator walks a matrix timestamp by timestamp, turning it back into the
+// vectors an instant query would have returned at each step.
+type matrixIterator struct {
+	m    promql.Matrix
+	fPos []int
+	hPos []int
+	vec  promql.Vector
+}
+
+func newMatrixIterator(m promql.Matrix) *matrixIterator {
+	return &matrixIterator{
+		m:    m,
+		fPos: make([]int, len(m)),
+		hPos: make([]int, len(m)),
+		vec:  make(promql.Vector, 0, len(m)),
+	}
+}
+
+// at returns the samples at ts. The returned vector is only valid until the next
+// call, and callers must not retain it.
+func (it *matrixIterator) at(ts time.Time) promql.Vector {
+	t := timestamp.FromTime(ts)
+	it.vec = it.vec[:0]
+
+	for i, s := range it.m {
+		for it.fPos[i] < len(s.Floats) && s.Floats[it.fPos[i]].T < t {
+			it.fPos[i]++
+		}
+		if it.fPos[i] < len(s.Floats) && s.Floats[it.fPos[i]].T == t {
+			p := s.Floats[it.fPos[i]]
+			it.vec = append(it.vec, promql.Sample{Metric: s.Metric, T: p.T, F: p.F})
+			continue
+		}
+
+		for it.hPos[i] < len(s.Histograms) && s.Histograms[it.hPos[i]].T < t {
+			it.hPos[i]++
+		}
+		if it.hPos[i] < len(s.Histograms) && s.Histograms[it.hPos[i]].T == t {
+			p := s.Histograms[it.hPos[i]]
+			it.vec = append(it.vec, promql.Sample{Metric: s.Metric, T: p.T, H: p.H})
+		}
+	}
+	return it.vec
+}

--- a/rules/backtest_test.go
+++ b/rules/backtest_test.go
@@ -1,0 +1,188 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/promqltest"
+)
+
+// alertStateTimeline renders the ALERTS series of a backtest as one state per
+// evaluation step, using "-" where no alert was active.
+func alertStateTimeline(t *testing.T, m promql.Matrix, opts BacktestOptions) []string {
+	t.Helper()
+
+	out := make([]string, opts.steps())
+	for i := range out {
+		out[i] = "-"
+	}
+	for _, s := range m {
+		if s.Metric.Get(labels.MetricName) != alertMetricName {
+			continue
+		}
+		state := s.Metric.Get(alertStateLabel)
+		for _, p := range s.Floats {
+			i := int(timestamp.Time(p.T).Sub(opts.Start) / opts.Interval)
+			require.Equalf(t, "-", out[i], "more than one alert state at step %d", i)
+			out[i] = state
+		}
+	}
+	return out
+}
+
+func TestBacktest(t *testing.T) {
+	st := promqltest.LoadedStorage(t, `
+		load 1m
+			http_requests{job="app-server", instance="0"} 120 90 90 90 90 120 90 90 120
+	`)
+	t.Cleanup(func() { require.NoError(t, st.Close()) })
+
+	expr, err := testParser.ParseExpr(`http_requests < 100`)
+	require.NoError(t, err)
+
+	engine := testEngine(t)
+	baseTime := time.Unix(0, 0).UTC()
+
+	for _, tc := range []struct {
+		name          string
+		holdDuration  time.Duration
+		keepFiringFor time.Duration
+		want          []string
+	}{
+		{
+			name: "no for",
+			want: []string{"-", "firing", "firing", "firing", "firing", "-", "firing", "firing", "-"},
+		},
+		{
+			name:         "for shorter than the outage",
+			holdDuration: 2 * time.Minute,
+			want:         []string{"-", "pending", "pending", "firing", "firing", "-", "pending", "pending", "-"},
+		},
+		{
+			name:         "for longer than the outage never fires",
+			holdDuration: 5 * time.Minute,
+			want:         []string{"-", "pending", "pending", "pending", "pending", "-", "pending", "pending", "-"},
+		},
+		{
+			name:          "keep_firing_for bridges the gap",
+			keepFiringFor: 2 * time.Minute,
+			want:          []string{"-", "firing", "firing", "firing", "firing", "firing", "firing", "firing", "firing"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rule := NewAlertingRule(
+				"HTTPRequestRateLow", expr, tc.holdDuration, tc.keepFiringFor,
+				labels.EmptyLabels(), labels.EmptyLabels(), labels.EmptyLabels(), "", false, nil,
+			)
+			opts := BacktestOptions{
+				Start:    baseTime,
+				End:      baseTime.Add(8 * time.Minute),
+				Interval: time.Minute,
+			}
+
+			m, _, err := Backtest(context.Background(), rule, engine, st, opts)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, alertStateTimeline(t, m, opts))
+
+			// Backtesting must not disturb the state of the rule it was given.
+			require.Empty(t, rule.ActiveAlerts())
+			require.False(t, rule.Restored())
+		})
+	}
+}
+
+// TestBacktestMatchesEval guards the range query shortcut: replaying a matrix
+// must produce exactly what stepping the rule with instant queries produces.
+func TestBacktestMatchesEval(t *testing.T) {
+	st := promqltest.LoadedStorage(t, `
+		load 30s
+			http_requests{job="app-server", instance="0"} 120 90 90 _ 90 120 90 90 120 90 90 90
+			http_requests{job="app-server", instance="1"} 90 90 120 120 90 90 90 120 90 90 120 90
+	`)
+	t.Cleanup(func() { require.NoError(t, st.Close()) })
+
+	expr, err := testParser.ParseExpr(`http_requests < 100`)
+	require.NoError(t, err)
+
+	engine := testEngine(t)
+	baseTime := time.Unix(0, 0).UTC()
+	opts := BacktestOptions{
+		Start:    baseTime,
+		End:      baseTime.Add(6 * time.Minute),
+		Interval: 30 * time.Second,
+	}
+
+	newRule := func(restored bool) *AlertingRule {
+		return NewAlertingRule(
+			"HTTPRequestRateLow", expr, time.Minute, 30*time.Second,
+			labels.FromStrings("severity", "page"),
+			labels.FromStrings("summary", "{{$labels.instance}} is at {{$value}}"),
+			labels.EmptyLabels(), "", restored, nil,
+		)
+	}
+
+	got, _, err := Backtest(context.Background(), newRule(false), engine, st, opts)
+	require.NoError(t, err)
+
+	query := EngineQueryFunc(engine, st)
+	reference := seriesBuilder{}
+	stepped := newRule(true)
+	for i := range opts.steps() {
+		ts := opts.Start.Add(time.Duration(i) * opts.Interval)
+		vec, err := stepped.Eval(context.Background(), 0, ts, query, nil, 0)
+		require.NoError(t, err)
+		reference.add(vec)
+	}
+
+	require.Equal(t, reference.matrix(), got)
+}
+
+func TestBacktestOptionsValidation(t *testing.T) {
+	baseTime := time.Unix(0, 0).UTC()
+
+	for _, tc := range []struct {
+		name string
+		opts BacktestOptions
+		err  string
+	}{
+		{
+			name: "zero interval",
+			opts: BacktestOptions{Start: baseTime, End: baseTime.Add(time.Hour)},
+			err:  "interval must be positive",
+		},
+		{
+			name: "end before start",
+			opts: BacktestOptions{Start: baseTime.Add(time.Hour), End: baseTime, Interval: time.Minute},
+			err:  "end timestamp must not be before start timestamp",
+		},
+		{
+			name: "too many steps",
+			opts: BacktestOptions{Start: baseTime, End: baseTime.Add(MaxBacktestSteps * time.Minute), Interval: time.Minute},
+			err:  "exceeded maximum of 11000 evaluations",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := BacktestMatrix(context.Background(), nil, nil, nil, tc.opts)
+			require.ErrorContains(t, err, tc.err)
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #15545

## What

Adds `promtool query backtest`, which replays an alerting rule over historical data and reports when it would have been pending and firing. This provides a native way to test alert conditions against historical data without rewriting
them into equivalent PromQL.

## Why

Today, users who want to understand how an alert would have behaved over historical data must approximate the alert state machine manually by wrapping their expression with PromQL such as:

```promql
clamp_max(count_over_time((<expr>)[<for>:30s]) >= <for/30s>, 1)
```

This is cumbersome and only approximates the alert lifecycle. Reusing Prometheus' existing alert state machine ensures `for`, `keep_firing_for`, alert identity, and templated labels behave exactly as they do during normal rule evaluation, while making historical alert validation much
easier.
<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!--
Write NONE only if there is no user-facing change.

Otherwise use one of: [FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Following the pattern `[TYPE] Component: description.`

Example: [FEATURE] API: Add `/api/v1/features` endpoint.

Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/
prometheus/blob/main/CHANGELOG.md
-->
```release-notes
NONE
```
