### PR TITLE
fix: merge adjacent literals in optimizeConcatRegex to prevent false positives

### DIFF
--- a/model/labels/regexp.go
+++ b/model/labels/regexp.go
@@ -465,10 +465,21 @@ func optimizeConcatRegex(r *syntax.Regexp) (caseInsensitivePrefix bool, prefix, 
 	}
 
 	// If contains any literal which is not a prefix/suffix, we keep track of
-	// all the ones which are case-sensitive.
+	// all the ones which are case-sensitive. Adjacent literals are merged
+	// into a single contains entry so that they are checked as a contiguous
+	// substring; separate entries would allow non-contiguous matching,
+	// producing false positives for e.g. `.*\|(foo)\|.*` against `|foo-bar|`
+	// (the three literals |, foo, | would individually match as
+	// non-contiguous parts of |foo-bar|).
 	for i := 1; i < len(sub)-1; i++ {
 		if sub[i].Op == syntax.OpLiteral && (sub[i].Flags&syntax.FoldCase) == 0 {
-			contains = append(contains, string(sub[i].Rune))
+			var sb strings.Builder
+			sb.WriteString(string(sub[i].Rune))
+			for i+1 < len(sub)-1 && sub[i+1].Op == syntax.OpLiteral && (sub[i+1].Flags&syntax.FoldCase) == 0 {
+				i++
+				sb.WriteString(string(sub[i].Rune))
+			}
+			contains = append(contains, sb.String())
 		}
 	}
 


### PR DESCRIPTION
**Fixes FastRegexMatcher false positive for patterns with capturing groups**

`FastRegexMatcher` produces a false positive for patterns like `.*\|(foo)\|.*` when matching against `|foo-bar|`. The `contains` optimization in `optimizeConcatRegex` splits adjacent `OpLiteral` entries into separate `contains` strings, and `containsInOrder` then checks them with non-contiguous matching (via `containsInOrderMulti`). This allows the three literals `|`, `foo`, `|` to individually match at non-contiguous positions in `|foo-bar|`, producing a false positive.

**Fix**: Merge consecutive `OpLiteral` entries into a single `contains` string so that they are checked as a contiguous substring. When `contains` has a single entry, `containsInOrder` uses `strings.Contains` which correctly checks for the exact substring.

**Minimal reproduction:**
```go
m, _ := labels.NewFastRegexMatcher(`.*\|(foo)\|.*`)
fmt.Println(m.MatchString("|foo-bar|")) // => true (WRONG, should be false)
```

**Before fix:** `true` (false positive)
**After fix:** `false` (correct)

The non-capturing equivalent `.*\|(?:foo)\|.*` was already correct because the group is not flattened by `clearCapture` into adjacent `OpLiteral` entries.

**Testing:** No existing tests need updating — the fix only affects the `contains` optimization which is transparent to the regex engine. The existing `FastRegexMatcher` tests cover the optimization paths and verify against the full regex engine.
