### PR TITLE
prometheus/web: prevent test from consistently failing on windows

### DIFF
--- a/web/api/v1/openapi_golden_test.go
+++ b/web/api/v1/openapi_golden_test.go
@@ -17,6 +17,8 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -105,6 +107,11 @@ func TestOpenAPIGolden_3_2(t *testing.T) {
 	// Comparison mode: verify the spec matches the golden file.
 	goldenData, err := os.ReadFile(goldenPath)
 	require.NoError(t, err, "failed to read golden file (run with -update-openapi-spec to generate it)")
+
+	// Normalize line endings for Windows - otherwise, the comparison will fail due to CRLF vs LF differences.
+	if runtime.GOOS == "windows" {
+		goldenData = []byte(strings.ReplaceAll(string(goldenData), "\r\n", "\n"))
+	}
 
 	require.Equal(t, string(goldenData), resp.Body,
 		"OpenAPI 3.2 spec does not match golden file. Run 'go test -update-openapi-spec' to update.")


### PR DESCRIPTION
TestOpenAPIGolden_3_2 consistently fails on windows due to missing runtime guard. Simple test skip could be added on windows but at the cost of consistent coverage. 

This commit handles by replacing CRLF on windows only. 

```release-notes
NONE
```
