### PR TITLE
fix(model/histogram): do not miss counter resets behind empty buckets in DetectReset

### DIFF
--- a/model/histogram/float_histogram.go
+++ b/model/histogram/float_histogram.go
@@ -822,6 +822,7 @@ func detectReset(currIt, prevIt *floatBucketIterator) bool {
 			if !prevIt.Next() {
 				return false
 			}
+			prevBucket = prevIt.strippedAt()
 		}
 	}
 	currBucket := currIt.strippedAt()
@@ -841,6 +842,7 @@ func detectReset(currIt, prevIt *floatBucketIterator) bool {
 					if !prevIt.Next() {
 						return false
 					}
+					prevBucket = prevIt.strippedAt()
 				}
 			}
 			currBucket = currIt.strippedAt()

--- a/model/histogram/float_histogram_test.go
+++ b/model/histogram/float_histogram_test.go
@@ -1415,6 +1415,47 @@ func TestFloatHistogramDetectReset(t *testing.T) {
 			},
 			false, // No reset: all mapped buckets increase
 		},
+		{
+			// The previous histogram's first negative bucket is empty and a
+			// later one is populated. The current histogram has no negative
+			// buckets at all, so the populated previous bucket disappeared,
+			// which is a reset.
+			"reset when a populated bucket following an empty one disappears",
+			&FloatHistogram{
+				ZeroThreshold:   0.001,
+				Count:           10,
+				PositiveSpans:   []Span{{0, 1}},
+				PositiveBuckets: []float64{5},
+				NegativeSpans:   []Span{{1, 2}},
+				NegativeBuckets: []float64{0, 5},
+			},
+			&FloatHistogram{
+				ZeroThreshold:   0.001,
+				Count:           20,
+				PositiveSpans:   []Span{{0, 1}},
+				PositiveBuckets: []float64{20},
+			},
+			true,
+		},
+		{
+			// The current histogram runs out of buckets before a later
+			// populated bucket of the previous histogram, which sits behind an
+			// empty one. That populated bucket disappeared, so it is a reset.
+			"reset when current ends before a later populated previous bucket",
+			&FloatHistogram{
+				ZeroThreshold:   0.001,
+				Count:           7,
+				PositiveSpans:   []Span{{0, 3}},
+				PositiveBuckets: []float64{2, 0, 5},
+			},
+			&FloatHistogram{
+				ZeroThreshold:   0.001,
+				Count:           100,
+				PositiveSpans:   []Span{{0, 1}},
+				PositiveBuckets: []float64{100},
+			},
+			true,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
`FloatHistogram.DetectReset` walks the previous histogram's buckets through the `detectReset` helper. Two of its inner loops advance the previous iterator with `prevIt.Next()` but never reassign `prevBucket = prevIt.strippedAt()`, so they keep inspecting the first previous bucket instead of moving on. One loop handles the case where the current histogram has no buckets at all; the other handles the current iterator running out before the previous one.

When the first previous bucket is empty and a later one is populated, and the current histogram no longer has that later bucket, the loops reach the end without ever seeing the populated bucket and return false, so a real counter reset is missed. The main loop further down already reassigns `prevBucket` after advancing; the integer `DetectReset` proposed in #18313 handles the same loops correctly, so these two float loops were the exception.

`DetectReset` drives counter-reset detection for native-histogram `rate()`, `increase()` and related functions (through `promql/histogram_stats_iterator.go` and `promql/functions.go`) and for scrape-time synthesis in `scrape/st_synthesis.go`, so a missed reset makes those results undercount.

I added two cases to the existing `TestFloatHistogramDetectReset` table, one for each loop. Both fail on current main and pass with this change.

```release-notes
[BUGFIX] Native histograms: `DetectReset` no longer misses a counter reset when a populated bucket behind an empty one disappears, which could make histogram `rate()`/`increase()` undercount.
```
